### PR TITLE
Implement Pay Day and Make it Rain

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -10,7 +10,7 @@ import { initCommonAnims, initMoveAnim, loadCommonAnimAssets, loadMoveAnimAssets
 import { Phase } from './phase';
 import { initGameSpeed } from './system/game-speed';
 import { Biome } from "./data/enums/biome";
-import { Arena, ArenaBase, getBiomeHasProps, getBiomeKey } from './field/arena';
+import { Arena, ArenaBase } from './field/arena';
 import { GameData, PlayerGender } from './system/game-data';
 import StarterSelectUiHandler from './ui/starter-select-ui-handler';
 import { TextStyle, addTextObject } from './ui/text';
@@ -26,7 +26,6 @@ import FieldSpritePipeline from './pipelines/field-sprite';
 import SpritePipeline from './pipelines/sprite';
 import PartyExpBar from './ui/party-exp-bar';
 import { TrainerSlot, trainerConfigs } from './data/trainer-config';
-import { TrainerType } from "./data/enums/trainer-type";
 import Trainer, { TrainerVariant } from './field/trainer';
 import TrainerData from './system/trainer-data';
 import SoundFade from 'phaser3-rex-plugins/plugins/soundfade';
@@ -38,11 +37,10 @@ import MessageUiHandler from './ui/message-ui-handler';
 import { Species } from './data/enums/species';
 import InvertPostFX from './pipelines/invert';
 import { Achv, ModifierAchv, achvs } from './system/achv';
-import { GachaType } from './data/egg';
 import { Voucher, vouchers } from './system/voucher';
 import { Gender } from './data/gender';
 import UIPlugin from 'phaser3-rex-plugins/templates/ui/ui-plugin';
-import { WindowVariant, addUiThemeOverrides, getWindowVariantSuffix } from './ui/ui-theme';
+import { addUiThemeOverrides } from './ui/ui-theme';
 import PokemonData from './system/pokemon-data';
 import { Nature } from './data/nature';
 import { SpeciesFormChangeTimeOfDayTrigger, SpeciesFormChangeTrigger, pokemonFormChanges } from './data/pokemon-forms';
@@ -888,26 +886,22 @@ export default class BattleScene extends SceneBase {
 	trySpreadPokerus(): void {
 		const party = this.getParty();
 		const infectedIndexes: integer[] = [];
+		const spread = (index: number, spreadTo: number) => {
+			const partyMember = party[index + spreadTo];
+			if (!partyMember.pokerus && !Utils.randSeedInt(10)) {
+				partyMember.pokerus = true;
+				infectedIndexes.push(index + spreadTo);
+			}
+		};
 		party.forEach((pokemon, p) => {
 			if (!pokemon.pokerus || infectedIndexes.indexOf(p) > -1)
 				return;
 			
 			this.executeWithSeedOffset(() => {
-				if (p) {
-					const partyMember = party[p - 1];
-					if (!partyMember.pokerus && !Utils.randSeedInt(10)) {
-						partyMember.pokerus = true;
-						infectedIndexes.push(p - 1);
-					}
-				}
-
-				if (p < party.length - 1) {
-					const partyMember = party[p + 1];
-					if (!partyMember.pokerus && !Utils.randSeedInt(10)) {
-						partyMember.pokerus = true;
-						infectedIndexes.push(p + 1);
-					}
-				}
+				if (p)
+					spread(p, -1);
+				if (p < party.length - 1)
+					spread(p, 1);
 			}, this.currentBattle.waveIndex + (p << 8));
 		});
 	}

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -9,7 +9,8 @@ import { TrainerType } from "./data/enums/trainer-type";
 import { GameMode } from "./game-mode";
 import { BattleSpec } from "./enums/battle-spec";
 import { PlayerGender } from "./system/game-data";
-import { PokemonHeldItemModifier } from "./modifier/modifier";
+import { MoneyMultiplierModifier, PokemonHeldItemModifier } from "./modifier/modifier";
+import { MoneyAchv } from "./system/achv";
 
 export enum BattleType {
     WILD,
@@ -58,6 +59,7 @@ export default class Battle {
     public lastMove: Moves;
     public battleSeed: string;
     private battleSeedState: string;
+    public moneyScattered: number;
 
     private rngCounter: integer = 0;
 
@@ -81,6 +83,7 @@ export default class Battle {
         this.started = false;
         this.battleSeed = Utils.randomString(16, true);
         this.battleSeedState = null;
+        this.moneyScattered = 0;
     }
 
     private initBattleSpec(): void {
@@ -146,6 +149,19 @@ export default class Battle {
             ret.pokemonId = null;
             return ret;
         }));
+    }
+
+    pickUpScatteredMoney(scene: BattleScene): void {
+        const moneyAmount = new Utils.IntegerHolder(scene.currentBattle.moneyScattered);
+        scene.applyModifiers(MoneyMultiplierModifier, true, moneyAmount);
+
+        scene.money += moneyAmount.value;
+        scene.updateMoneyText();
+    
+        scene.validateAchvs(MoneyAchv);
+        scene.queueMessage(`You picked up ₽${moneyAmount.value.toLocaleString('en-US')}!`, null, true);
+
+        scene.currentBattle.moneyScattered = 0;
     }
 
     addBattleScore(scene: BattleScene): void {

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2392,7 +2392,7 @@ export class FirstMoveTypeAttr extends MoveEffectAttr {
       return false;
 
     const firstMoveType = target.getMoveset()[0].getMove().type
-   
+  
     user.summonData.types = [ firstMoveType ];
 
     user.scene.queueMessage(getPokemonMessage(user, ` transformed\ninto to the ${Utils.toReadableString(Type[firstMoveType])} type!`));
@@ -2687,6 +2687,18 @@ export class DiscourageFrequentUseAttr extends MoveAttr {
   }
 }
 
+export class MoneyAttr extends MoveEffectAttr {
+  constructor() {
+    super(true, MoveEffectTrigger.HIT);
+  }
+
+  apply(user: Pokemon, target: Pokemon, move: Move): boolean {
+    user.scene.currentBattle.moneyScattered += user.scene.getWaveMoneyAmount(0.2);
+    user.scene.queueMessage("Coins were scattered everywhere!")
+    return true;
+  }
+}
+
 const failOnGravityCondition: MoveConditionFunc = (user, target, move) => !user.scene.arena.getTag(ArenaTagType.GRAVITY);
 
 const failOnBossCondition: MoveConditionFunc = (user, target, move) => !target.isBossImmune();
@@ -2811,7 +2823,8 @@ export function initMoves() {
       .punchingMove(),
     new AttackMove(Moves.MEGA_PUNCH, "Mega Punch", Type.NORMAL, MoveCategory.PHYSICAL, 80, 85, 20, "The target is slugged by a punch thrown with muscle-packed power.", -1, 0, 1)
       .punchingMove(),
-    new AttackMove(Moves.PAY_DAY, "Pay Day (P)", Type.NORMAL, MoveCategory.PHYSICAL, 40, 100, 20, "Numerous coins are hurled at the target to inflict damage. Money is earned after the battle.", -1, 0, 1)
+    new AttackMove(Moves.PAY_DAY, "Pay Day", Type.NORMAL, MoveCategory.PHYSICAL, 40, 100, 20, "Numerous coins are hurled at the target to inflict damage. Money is earned after the battle.", -1, 0, 1)
+      .attr(MoneyAttr)
       .makesContact(false),
     new AttackMove(Moves.FIRE_PUNCH, "Fire Punch", Type.FIRE, MoveCategory.PHYSICAL, 75, 100, 15, "The target is punched with a fiery fist. This may also leave the target with a burn.", 10, 0, 1)
       .attr(StatusEffectAttr, StatusEffect.BURN)
@@ -4893,7 +4906,8 @@ export function initMoves() {
       .attr(StatChangeAttr, BattleStat.SPD, 1, true)
       .danceMove(),
     new AttackMove(Moves.RAGING_BULL, "Raging Bull (P)", Type.NORMAL, MoveCategory.PHYSICAL, 90, 100, 10, "The user performs a tackle like a raging bull. This move's type depends on the user's form. It can also break barriers, such as Light Screen and Reflect.", -1, 0, 9),
-    new AttackMove(Moves.MAKE_IT_RAIN, "Make It Rain (P)", Type.STEEL, MoveCategory.SPECIAL, 120, 100, 5, "The user attacks by throwing out a mass of coins. This also lowers the user's Sp. Atk stat. Money is earned after the battle.", -1, 0, 9)
+    new AttackMove(Moves.MAKE_IT_RAIN, "Make It Rain", Type.STEEL, MoveCategory.SPECIAL, 120, 100, 5, "The user attacks by throwing out a mass of coins. This also lowers the user's Sp. Atk stat. Money is earned after the battle.", -1, 0, 9)
+      .attr(MoneyAttr)
       .attr(StatChangeAttr, BattleStat.SPATK, -1, true, null, true, true)
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new AttackMove(Moves.PSYBLADE, "Psyblade (P)", Type.PSYCHIC, MoveCategory.PHYSICAL, 80, 100, 15, "The user rends the target with an ethereal blade. This move's power is boosted by 50 percent if the user is on Electric Terrain.", -1, 0, 9)

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1874,6 +1874,8 @@ export class BattleEndPhase extends BattlePhase {
     super.start();
 
     this.scene.currentBattle.addBattleScore(this.scene);
+    if (this.scene.currentBattle.moneyScattered)
+      this.scene.currentBattle.pickUpScatteredMoney(this.scene);
 
     this.scene.gameData.gameStats.battles++;
     if (this.scene.currentBattle.trainer)


### PR DESCRIPTION
the battle-scene change was just refactoring duplicate code I saw and removing stale imports

the way money scattered is being calculated is based on the base price for the shop to keep it balanced. 1/5 base cost is essentially enough to buy a potion. 

Pay Day: https://bulbapedia.bulbagarden.net/wiki/Pay_Day_(move)
Make it Rain: https://bulbapedia.bulbagarden.net/wiki/Make_It_Rain_(move)