### PR TITLE
Fix Flail and Reversal damage

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1540,20 +1540,20 @@ export class LowHpPowerAttr extends VariablePowerAttr {
     const hpRatio = user.getHpRatio();
 
     switch (true) {
-      case (hpRatio < 0.6875):
-        power.value = 40;
-        break;
-      case (hpRatio < 0.3542):
-        power.value = 80;
-        break;
-      case (hpRatio < 0.2083):
-        power.value = 100;
+      case (hpRatio < 0.0417):
+        power.value = 200;
         break;
       case (hpRatio < 0.1042):
         power.value = 150;
         break;
-      case (hpRatio < 0.0417):
-        power.value = 200;
+      case (hpRatio < 0.2083):
+        power.value = 100;
+        break;
+      case (hpRatio < 0.3542):
+        power.value = 80;
+        break;
+      case (hpRatio < 0.6875):
+        power.value = 40;
         break;
       default:
         power.value = 20;


### PR DESCRIPTION
Flail and Reversal were capped to 40bp due to the easiest to pass case being at the top.