### PR TITLE
Toxic Spikes - Properly removed by statused Poison types

### DIFF
--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -17,7 +17,21 @@ export enum ArenaTagSide {
   ENEMY
 }
 
-export abstract class ArenaTag {
+export abstract class ArenaTag {activateTrap(pokemon: Pokemon): boolean {
+    if (pokemon.isOfType(Type.POISON) && pokemon.isGrounded()) {
+      this.neutralized = true;
+      if (pokemon.scene.arena.removeTag(this.tagType)) {
+        pokemon.scene.queueMessage(getPokemonMessage(pokemon, ` absorbed the ${this.getMoveName()}!`));
+        return true;
+      }
+    }
+    else if (!pokemon.status && pokemon.isGrounded()) {
+      const toxic = this.layers > 1;
+      if (pokemon.trySetStatus(!toxic ? StatusEffect.POISON : StatusEffect.TOXIC, true, null, `the ${this.getMoveName()}`))
+        return true;      
+    }
+    return false;
+  }
   public tagType: ArenaTagType;
   public turnCount: integer;
   public sourceMove: Moves;
@@ -211,18 +225,20 @@ class ToxicSpikesTag extends ArenaTrapTag {
   }
 
   activateTrap(pokemon: Pokemon): boolean {
-    if (!pokemon.status && pokemon.isGrounded()) {
-      const toxic = this.layers > 1;
-      if (pokemon.trySetStatus(!toxic ? StatusEffect.POISON : StatusEffect.TOXIC, true, null, `the ${this.getMoveName()}`))
+    if (pokemon.isOfType(Type.POISON) && pokemon.isGrounded()) {
+      this.neutralized = true;
+      if (pokemon.scene.arena.removeTag(this.tagType)) {
+        pokemon.scene.queueMessage(getPokemonMessage(pokemon, ` absorbed the ${this.getMoveName()}!`));
         return true;
-      else if (pokemon.isOfType(Type.POISON)) {
-        this.neutralized = true;
-        if (pokemon.scene.arena.removeTag(this.tagType)) {
-          pokemon.scene.queueMessage(getPokemonMessage(pokemon, ` absorbed the ${this.getMoveName()}!`));
-          return true;
-        }
       }
     }
+    else if (!pokemon.status && pokemon.isGrounded()) {
+      const toxic = this.layers > 1;
+      if (pokemon.trySetStatus(!toxic ? StatusEffect.POISON : StatusEffect.TOXIC, true, null, `the ${this.getMoveName()}`))
+        return true;      
+    }
+    return false;
+  }
 
     return false;
   }

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -17,21 +17,7 @@ export enum ArenaTagSide {
   ENEMY
 }
 
-export abstract class ArenaTag {activateTrap(pokemon: Pokemon): boolean {
-    if (pokemon.isOfType(Type.POISON) && pokemon.isGrounded()) {
-      this.neutralized = true;
-      if (pokemon.scene.arena.removeTag(this.tagType)) {
-        pokemon.scene.queueMessage(getPokemonMessage(pokemon, ` absorbed the ${this.getMoveName()}!`));
-        return true;
-      }
-    }
-    else if (!pokemon.status && pokemon.isGrounded()) {
-      const toxic = this.layers > 1;
-      if (pokemon.trySetStatus(!toxic ? StatusEffect.POISON : StatusEffect.TOXIC, true, null, `the ${this.getMoveName()}`))
-        return true;      
-    }
-    return false;
-  }
+export abstract class ArenaTag {
   public tagType: ArenaTagType;
   public turnCount: integer;
   public sourceMove: Moves;


### PR DESCRIPTION
Toxic spikes should now be removed by poison types who are statused before they are switched to, instead of ignoring their entry