### PR TITLE
Small fix for Reflect/Light Screen/Aurora Veil

### DIFF
--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -78,7 +78,7 @@ export class MistTag extends ArenaTag {
 
 export class WeakenMoveScreenTag extends ArenaTag {
   constructor(tagType: ArenaTagType, turnCount: integer, sourceMove: Moves, sourceId: integer, side: ArenaTagSide) {
-    super(tagType, turnCount, sourceMove, sourceId);
+    super(tagType, turnCount, sourceMove, sourceId, side);
   }
 
   apply(arena: Arena, args: any[]): boolean {


### PR DESCRIPTION
Had to add "side" in there too, otherwise the Screens were being set for ArenaTagSide.BOTH and not working (since now they are set in the right side).