### PR TITLE
Fixing Confusion triggering after Sleep, Paralysis, and Recharging

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -17,6 +17,7 @@ import { BattleStat } from "./battle-stat";
 export enum BattlerTagLapseType {
   FAINT,
   MOVE,
+  PRE_MOVE,
   AFTER_MOVE,
   MOVE_EFFECT,
   TURN_END,
@@ -77,7 +78,7 @@ export interface TerrainBattlerTag {
 
 export class RechargingTag extends BattlerTag {
   constructor(sourceMove: Moves) {
-    super(BattlerTagType.RECHARGING, BattlerTagLapseType.MOVE, 1, sourceMove);
+    super(BattlerTagType.RECHARGING, BattlerTagLapseType.PRE_MOVE, 1, sourceMove);
   }
 
   onAdd(pokemon: Pokemon): void {
@@ -90,7 +91,9 @@ export class RechargingTag extends BattlerTag {
     super.lapse(pokemon, lapseType);
 
     pokemon.scene.queueMessage(getPokemonMessage(pokemon, ' must\nrecharge!'));
-
+    (pokemon.scene.getCurrentPhase() as MovePhase).cancel();
+    pokemon.getMoveQueue().shift();
+    
     return true;
   }
 }

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2023,12 +2023,13 @@ export class MovePhase extends BattlePhase {
     });
 
     const doMove = () => {
-      if (!this.followUp && this.canMove()) {
-        this.pokemon.lapseTags(BattlerTagLapseType.MOVE);
-        if (this.cancelled) {
-          this.pokemon.pushMoveHistory({ move: Moves.NONE, result: MoveResult.FAIL });
-          return this.end();
-        }
+      this.pokemon.lapseTags(BattlerTagLapseType.PRE_MOVE);
+      if (!this.followUp && this.canMove() && !this.cancelled) {
+            this.pokemon.lapseTags(BattlerTagLapseType.MOVE);
+      }
+      if (this.cancelled) {
+        this.pokemon.pushMoveHistory({ move: Moves.NONE, result: MoveResult.FAIL });
+        return this.end();
       }
 
       const moveQueue = this.pokemon.getMoveQueue();

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2024,8 +2024,9 @@ export class MovePhase extends BattlePhase {
 
     const doMove = () => {
       this.pokemon.lapseTags(BattlerTagLapseType.PRE_MOVE);
+	    
       if (!this.followUp && this.canMove() && !this.cancelled) {
-            this.pokemon.lapseTags(BattlerTagLapseType.MOVE);
+        this.pokemon.lapseTags(BattlerTagLapseType.MOVE);
       }
       if (this.cancelled) {
         this.pokemon.pushMoveHistory({ move: Moves.NONE, result: MoveResult.FAIL });


### PR DESCRIPTION
Made Recharge its own BattlerTagLapseType called PRE_MOVE that triggers before MOVE, cancelling the move phase.  doMove now checks for this.cancelled before calling on the MOVE lapse tag, which should prevent confusion or infatuation from triggering after the pokemon has already had its move cancelled by the other statuses.  I wasn't able to find any issues with moving the if (this.cancelled) check to end the turn outside of if(!this.followUp && this.canMove()) check, but if need be I can edit those into the if statement, just didn't want to add bloat.