### PR TITLE
Fix: Guts ability now ignores burn damage debuff

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1179,7 +1179,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
             damage.value = Math.ceil(((((2 * source.level / 5 + 2) * power.value * sourceAtk.value / targetDef.value) / 50) + 2) * stabMultiplier.value * typeMultiplier.value * arenaAttackTypeMultiplier * screenMultiplier.value * ((this.scene.randBattleSeedInt(15) + 85) / 100) * criticalMultiplier);
             if (isPhysical && source.status && source.status.effect === StatusEffect.BURN) {
               const burnDamageReductionCancelled = new Utils.BooleanHolder(false);
-              applyAbAttrs(BypassBurnDamageReductionAbAttr, this, burnDamageReductionCancelled);
+              applyAbAttrs(BypassBurnDamageReductionAbAttr, source, burnDamageReductionCancelled);
               if (!burnDamageReductionCancelled.value)
                 damage.value = Math.floor(damage.value / 2);
             }


### PR DESCRIPTION
Trello Card: https://trello.com/c/Tmhsfkff
Discord Bug Report: https://discord.com/channels/1125469663833370665/1226068395917705216

Guts has an effect that prevents an pokemon w/ the ability from losing Attack when burned. The attribute for this ability was being mistakenly applied to the pokemon being attacked, rather than the pokemon attacking.