### PR TITLE
Add basic PWA support

### DIFF
--- a/index.css
+++ b/index.css
@@ -41,6 +41,12 @@ body {
   z-index: 3;
 }
 
+@media (orientation: portrait) {
+  #dpad, #apad {
+    bottom: calc(1rem + env(safe-area-inset-bottom));
+  }
+}
+
 #dpad {
   left: 1rem;
 }

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 	<meta property="og:description" content="A Pokémon fangame heavily inspired by the roguelite genre. Battle endlessly while gathering stacking items, exploring many different biomes, and reaching Pokémon stats you never thought possible." />
 	<meta property="og:image" content="https://pokerogue.net/logo.png" />
 	<meta charset="UTF-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 	<style type="text/css">
 		@font-face {
 			font-family: 'emerald';
@@ -23,6 +23,21 @@
 		}
 	</style>
 	<link rel="stylesheet" type="text/css" href="index.css" />
+  <link rel="manifest" href="manifest.json" />
+  <script>
+    if ("serviceWorker" in navigator) {
+      window.addEventListener("load", function () {
+        navigator.serviceWorker.register("/service-worker.js").then(
+          function (registration) {
+            console.log("ServiceWorker registration successful");
+          },
+          function (err) {
+            console.log("ServiceWorker registration failed: ", err);
+          },
+        );
+      });
+    }
+  </script>
 </head>
 
 <body>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "PokéRogue",
+  "short_name": "PokéRogue",
+  "description": "A Pokémon fangame heavily inspired by the roguelite genre. Battle endlessly while gathering stacking items, exploring many different biomes, and reaching Pokémon stats you never thought possible.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#8c8c8c",
+  "theme_color": "#8c8c8c",
+  "icons": [
+    {
+      "src": "../logo.png",
+      "sizes": "128x128",
+      "type": "image/png"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,3 @@
+self.addEventListener('install', function () {
+  console.log('Service worker installing...');
+});


### PR DESCRIPTION
This PR adds basic PWA support for mobile devices, allowing users to "install" the web app onto their device. It also adjusts the controller padding to account for the safe area on iOS when necessary.

If someone is able to confirm that this works on Android before merging, that would be much appreciated as I only have an iPhone. You can test it by opening one of the network hosts that Vite sets up when running `npm run start:dev`, then just open the share sheet and press "Add to Home Screen".

In the future, once there are less frequent changes, this could be adjusted to cache static assets as well.

Here's what it looks like on a iPhone 14 Pro Max:

![pr-pwa-portrait](https://github.com/pagefaultgames/pokerogue/assets/47071224/14094030-c6f2-4b46-b984-043cca2409f2)
![pr-pwa-landscape](https://github.com/pagefaultgames/pokerogue/assets/47071224/ac57ec40-d9f4-4b39-a755-f96729a5fd1c)

And the home screen icon:
![pr-pwa-icon](https://github.com/pagefaultgames/pokerogue/assets/47071224/2cc10208-95d3-4837-bd54-fadb3440a663)
