### PR TITLE
Implement Aura Wheel and Raging Bull types

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -18,6 +18,7 @@ import { BattlerIndex } from "../battle";
 import { Stat } from "./pokemon-stat";
 import { TerrainType } from "./terrain";
 import { SpeciesFormChangeActiveTrigger } from "./pokemon-forms";
+import { Species } from "./enums/species";
 
 export enum MoveCategory {
   PHYSICAL,
@@ -1844,7 +1845,6 @@ export class ToxicAccuracyAttr extends VariableAccuracyAttr {
   }
 }
 
-
 export class BlizzardAccuracyAttr extends VariableAccuracyAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     if (!user.scene.arena.weather?.isEffectSuppressed(user.scene)) {
@@ -1854,6 +1854,53 @@ export class BlizzardAccuracyAttr extends VariableAccuracyAttr {
         accuracy.value = -1;
         return true;
       }
+    }
+
+    return false;
+  }
+}
+
+export class VariableMoveTypeAttr extends MoveAttr {
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    return false;
+  }
+}
+
+export class AuraWheelTypeAttr extends VariableMoveTypeAttr {
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    if (user.getSpeciesForm().speciesId === Species.MORPEKO) {
+      const type = (args[0] as Utils.IntegerHolder);
+      switch (user.formIndex) {
+        case 1: // Hangry Mode
+          type.value = Type.DARK;
+          break;
+        default: // Full Belly Mode
+          type.value = Type.ELECTRIC;
+          break;
+      }
+      return true;
+    }
+
+    return false;
+  }
+}
+
+export class RagingBullTypeAttr extends VariableMoveTypeAttr {
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    if (user.getSpeciesForm().speciesId === Species.PALDEA_TAUROS) {
+      const type = (args[0] as Utils.IntegerHolder);
+      switch (user.formIndex) {
+        case 1: // Blaze breed
+          type.value = Type.FIRE;
+          break;
+        case 2: // Aqua breed
+          type.value = Type.WATER;
+          break;
+        default:
+          type.value = Type.FIGHTING;
+          break;
+      }
+      return true;
     }
 
     return false;
@@ -4681,9 +4728,11 @@ export function initMoves() {
     new AttackMove(Moves.BEHEMOTH_BLADE, "Behemoth Blade", Type.STEEL, MoveCategory.PHYSICAL, 100, 100, 5, "The user wields a large, powerful sword using its whole body and cuts the target in a vigorous attack.", -1, 0, 8)
       .slicingMove(),
     new AttackMove(Moves.BEHEMOTH_BASH, "Behemoth Bash", Type.STEEL, MoveCategory.PHYSICAL, 100, 100, 5, "The user's body becomes a firm shield and slams into the target fiercely.", -1, 0, 8),
-    new AttackMove(Moves.AURA_WHEEL, "Aura Wheel (P)", Type.ELECTRIC, MoveCategory.PHYSICAL, 110, 100, 10, "Morpeko attacks and raises its Speed with the energy stored in its cheeks. This move's type changes depending on the user's form.", 100, 0, 8)
+    new AttackMove(Moves.AURA_WHEEL, "Aura Wheel", Type.ELECTRIC, MoveCategory.PHYSICAL, 110, 100, 10, "Morpeko attacks and raises its Speed with the energy stored in its cheeks. This move's type changes depending on the user's form.", 100, 0, 8)
       .attr(StatChangeAttr, BattleStat.SPD, 1, true)
-      .makesContact(false),
+      .makesContact(false)
+      .attr(AuraWheelTypeAttr)
+      .condition((user, target, move) => user.species.speciesId === Species.MORPEKO), // Missing custom fail message
     new AttackMove(Moves.BREAKING_SWIPE, "Breaking Swipe", Type.DRAGON, MoveCategory.PHYSICAL, 60, 100, 15, "The user swings its tough tail wildly and attacks opposing Pokémon. This also lowers their Attack stats.", 100, 0, 8)
       .target(MoveTarget.ALL_NEAR_ENEMIES)
       .attr(StatChangeAttr, BattleStat.ATK, -1),
@@ -4976,7 +5025,8 @@ export function initMoves() {
     new AttackMove(Moves.AQUA_STEP, "Aqua Step", Type.WATER, MoveCategory.PHYSICAL, 80, 100, 10, "The user toys with the target and attacks it using light and fluid dance steps. This also boosts the user's Speed stat.", 100, 0, 9)
       .attr(StatChangeAttr, BattleStat.SPD, 1, true)
       .danceMove(),
-    new AttackMove(Moves.RAGING_BULL, "Raging Bull (P)", Type.NORMAL, MoveCategory.PHYSICAL, 90, 100, 10, "The user performs a tackle like a raging bull. This move's type depends on the user's form. It can also break barriers, such as Light Screen and Reflect.", -1, 0, 9),
+    new AttackMove(Moves.RAGING_BULL, "Raging Bull (P)", Type.NORMAL, MoveCategory.PHYSICAL, 90, 100, 10, "The user performs a tackle like a raging bull. This move's type depends on the user's form. It can also break barriers, such as Light Screen and Reflect.", -1, 0, 9)
+      .attr(RagingBullTypeAttr),
     new AttackMove(Moves.MAKE_IT_RAIN, "Make It Rain", Type.STEEL, MoveCategory.SPECIAL, 120, 100, 5, "The user attacks by throwing out a mass of coins. This also lowers the user's Sp. Atk stat. Money is earned after the battle.", -1, 0, 9)
       .attr(MoneyAttr)
       .attr(StatChangeAttr, BattleStat.SPATK, -1, true, null, true, true)

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1868,9 +1868,11 @@ export class VariableMoveTypeAttr extends MoveAttr {
 
 export class AuraWheelTypeAttr extends VariableMoveTypeAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    if (user.getSpeciesForm().speciesId === Species.MORPEKO) {
+    if ([user.species.speciesId, user.fusionSpecies?.speciesId].includes(Species.MORPEKO)) {
+      const form = user.species.speciesId === Species.MORPEKO ? user.formIndex : user.fusionSpecies.formIndex;
       const type = (args[0] as Utils.IntegerHolder);
-      switch (user.formIndex) {
+
+      switch (form) {
         case 1: // Hangry Mode
           type.value = Type.DARK;
           break;
@@ -1887,9 +1889,11 @@ export class AuraWheelTypeAttr extends VariableMoveTypeAttr {
 
 export class RagingBullTypeAttr extends VariableMoveTypeAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    if (user.getSpeciesForm().speciesId === Species.PALDEA_TAUROS) {
+    if ([user.species.speciesId, user.fusionSpecies?.speciesId].includes(Species.PALDEA_TAUROS)) {
+      const form = user.species.speciesId === Species.PALDEA_TAUROS ? user.formIndex : user.fusionSpecies.formIndex;
       const type = (args[0] as Utils.IntegerHolder);
-      switch (user.formIndex) {
+
+      switch (form) {
         case 1: // Blaze breed
           type.value = Type.FIRE;
           break;
@@ -4732,7 +4736,7 @@ export function initMoves() {
       .attr(StatChangeAttr, BattleStat.SPD, 1, true)
       .makesContact(false)
       .attr(AuraWheelTypeAttr)
-      .condition((user, target, move) => user.species.speciesId === Species.MORPEKO), // Missing custom fail message
+      .condition((user, target, move) => [user.species.speciesId, user.fusionSpecies?.speciesId].includes(Species.MORPEKO)), // Missing custom fail message
     new AttackMove(Moves.BREAKING_SWIPE, "Breaking Swipe", Type.DRAGON, MoveCategory.PHYSICAL, 60, 100, 15, "The user swings its tough tail wildly and attacks opposing Pokémon. This also lowers their Attack stats.", 100, 0, 8)
       .target(MoveTarget.ALL_NEAR_ENEMIES)
       .attr(StatChangeAttr, BattleStat.ATK, -1),

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2,7 +2,7 @@ import Phaser from 'phaser';
 import BattleScene, { ABILITY_OVERRIDE, AnySound, MOVE_OVERRIDE, OPP_ABILITY_OVERRIDE, OPP_MOVE_OVERRIDE } from '../battle-scene';
 import BattleInfo, { PlayerBattleInfo, EnemyBattleInfo } from '../ui/battle-info';
 import { Moves } from "../data/enums/moves";
-import Move, { HighCritAttr, HitsTagAttr, applyMoveAttrs, FixedDamageAttr, VariableAtkAttr, VariablePowerAttr, allMoves, MoveCategory, TypelessAttr, CritOnlyAttr, getMoveTargets, OneHitKOAttr, MultiHitAttr, StatusMoveTypeImmunityAttr, MoveTarget, VariableDefAttr, AttackMove, ModifiedDamageAttr, VariableMoveTypeMultiplierAttr, IgnoreOpponentStatChangesAttr, SacrificialAttr } from "../data/move";
+import Move, { HighCritAttr, HitsTagAttr, applyMoveAttrs, FixedDamageAttr, VariableAtkAttr, VariablePowerAttr, allMoves, MoveCategory, TypelessAttr, CritOnlyAttr, getMoveTargets, OneHitKOAttr, MultiHitAttr, StatusMoveTypeImmunityAttr, MoveTarget, VariableDefAttr, AttackMove, ModifiedDamageAttr, VariableMoveTypeMultiplierAttr, IgnoreOpponentStatChangesAttr, SacrificialAttr, VariableMoveTypeAttr } from "../data/move";
 import { default as PokemonSpecies, PokemonSpeciesForm, SpeciesFormKey, getFusedSpeciesName, getPokemonSpecies, getPokemonSpeciesForm } from '../data/pokemon-species';
 import * as Utils from '../utils';
 import { Type, TypeDamageMultiplier, getTypeDamageMultiplier, getTypeRgb } from '../data/type';
@@ -1088,6 +1088,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
     const variableType = new Utils.IntegerHolder(move.type);
     const typeChangeMovePowerMultiplier = new Utils.NumberHolder(1);
+    applyMoveAttrs(VariableMoveTypeAttr, source, this, move, variableType);
     // 2nd argument is for MoveTypeChangePowerMultiplierAbAttr
     applyAbAttrs(VariableMoveTypeAbAttr, source, null, variableType, typeChangeMovePowerMultiplier);
     const type = variableType.value as Type;


### PR DESCRIPTION
Aura wheel and Raging bull now switch typing depending on user form. Made Aura wheel fail if used by anything else than Morpeko. (There was no pokemon with Aura Wheel as egg move).
Raging bull is still marked as (P) as it doesn't break screens yet.