### PR TITLE
Fix protect having a chance to fail twice in a row

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2293,10 +2293,15 @@ export class ProtectAttr extends AddBattlerTagAttr {
       let timesUsed = 0;
       const moveHistory = user.getLastXMoves();
       let turnMove: TurnMove;
-      while (moveHistory.length && allMoves[(turnMove = moveHistory.shift()).move].getAttrs(ProtectAttr).find(pa => (pa as ProtectAttr).tagType === this.tagType))
+
+      while (moveHistory.length) {
+        turnMove = moveHistory.shift();
+        if(!allMoves[turnMove.move].getAttrs(ProtectAttr).length || turnMove.result !== MoveResult.SUCCESS)
+          break;
         timesUsed++;
+      }
       if (timesUsed)
-        return !user.randSeedInt(Math.pow(2, timesUsed));
+        return !user.randSeedInt(Math.pow(3, timesUsed));
       return true;
     });
   }


### PR DESCRIPTION
Protection moves did not check if the previous uses were successful.