### PR TITLE
Implement Shed Skin (and Hydration!)

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2391,7 +2391,7 @@ export function initAbilities() {
       .passive()
       .ignorable(),
     new Ability(Abilities.SHED_SKIN, "Shed Skin", "The Pokémon may heal its own status conditions by shedding its skin.", 3)
-	  .conditionalAttr(pokemon => !!Utils.randSeedInt(3) == 0, PostTurnResetStatusAbAttr),
+	  .conditionalAttr(pokemon => !Utils.randSeedInt(3), PostTurnResetStatusAbAttr),
     new Ability(Abilities.GUTS, "Guts", "It's so gutsy that having a status condition boosts the Pokémon's Attack stat.", 3)
       .attr(BypassBurnDamageReductionAbAttr)
       .conditionalAttr(pokemon => !!pokemon.status, BattleStatMultiplierAbAttr, BattleStat.ATK, 1.5),

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -7,7 +7,7 @@ import { getPokemonMessage } from "../messages";
 import { Weather, WeatherType } from "./weather";
 import { BattlerTag } from "./battler-tags";
 import { BattlerTagType } from "./enums/battler-tag-type";
-import { StatusEffect, getStatusEffectDescriptor, getStatusEffectHealText} from "./status-effect";
+import { StatusEffect, getStatusEffectDescriptor, getStatusEffectHealText } from "./status-effect";
 import Move, { AttackMove, MoveCategory, MoveFlags, MoveTarget, RecoilAttr, StatusMoveTypeImmunityAttr, allMoves } from "./move";
 import { ArenaTagType } from "./enums/arena-tag-type";
 import { Stat } from "./pokemon-stat";
@@ -1367,14 +1367,14 @@ export class PostTurnAbAttr extends AbAttr {
 }
 
 export class PostTurnResetStatusAbAttr extends PostTurnAbAttr {
-  applyPostTurn(pokemon: Pokemon, args: any[]): boolean | Promise<boolean> {
+  applyPostTurn(pokemon: Pokemon, args: any[]): boolean {
     if (pokemon.status) {
 	
-	  pokemon.scene.queueMessage(getPokemonMessage(pokemon, getStatusEffectHealText(pokemon.status?.effect)));
-	  pokemon.resetStatus();
-	  pokemon.updateInfo();
-	  return true;
-	}
+      pokemon.scene.queueMessage(getPokemonMessage(pokemon, getStatusEffectHealText(pokemon.status?.effect)));
+      pokemon.resetStatus();
+      pokemon.updateInfo();
+      return true;
+    }
 	
     return false;
   }
@@ -2391,7 +2391,7 @@ export function initAbilities() {
       .passive()
       .ignorable(),
     new Ability(Abilities.SHED_SKIN, "Shed Skin", "The Pokémon may heal its own status conditions by shedding its skin.", 3)
-	  .conditionalAttr(pokemon=> !!Math.floor(Math.random() * 2) == 0, PostTurnResetStatusAbAttr),
+	  .conditionalAttr(pokemon => !!Utils.randSeedInt(3) == 0, PostTurnResetStatusAbAttr),
     new Ability(Abilities.GUTS, "Guts", "It's so gutsy that having a status condition boosts the Pokémon's Attack stat.", 3)
       .attr(BypassBurnDamageReductionAbAttr)
       .conditionalAttr(pokemon => !!pokemon.status, BattleStatMultiplierAbAttr, BattleStat.ATK, 1.5),
@@ -2467,8 +2467,8 @@ export function initAbilities() {
     new Ability(Abilities.SKILL_LINK, "Skill Link", "Maximizes the number of times multistrike moves hit.", 4)
       .attr(MaxMultiHitAbAttr),
     new Ability(Abilities.HYDRATION, "Hydration", "Heals status conditions if it's raining.", 4)
-	  .attr(PostTurnResetStatusAbAttr)
-	  .condition(getWeatherCondition(WeatherType.RAIN, WeatherType.HEAVY_RAIN)),
+      .attr(PostTurnResetStatusAbAttr)
+      .condition(getWeatherCondition(WeatherType.RAIN, WeatherType.HEAVY_RAIN)),
     new Ability(Abilities.SOLAR_POWER, "Solar Power", "Boosts the Sp. Atk stat in harsh sunlight, but HP decreases every turn.", 4)
       .attr(PostWeatherLapseDamageAbAttr, 2, WeatherType.SUNNY, WeatherType.HARSH_SUN)
       .attr(BattleStatMultiplierAbAttr, BattleStat.SPATK, 1.5)


### PR DESCRIPTION
Implemented Shed Skin, with a 1/3 chance to remove a non-volatile status condition if inflicted with it at the end of each turn. While doing this I noticed Hydration is the same effect but in Rain/Heavy Rain, so I implemented that too.

Tested on all of the statuses - burn, freeze, both forms of poison, sleep, paralysis. Tested non-volatile and it shouldn't work on those. Tested that it only applies to the person with the ability and doesn't somehow do anything wacky there, and that seems to be in order.

Hydration was implemented through the same mechanisms, just a check for rain or heavy rain before it does the clearing, rather than a chance roll. Figured since these are the same ability just with different conditionals it wouldn't be right not to.