### PR TITLE
Rapid Spin and similar moves implemented fully, logic fix for Stealth Rocks/Other traps

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -3648,7 +3648,7 @@ export function initMoves() {
       .attr(AddBattlerTagAttr, BattlerTagType.ENCORE, false, true)
       .condition((user, target, move) => new EncoreTag(user.id).canAdd(target)),
     new AttackMove(Moves.PURSUIT, "Pursuit (P)", Type.DARK, MoveCategory.PHYSICAL, 40, 100, 20, "The power of this attack move is doubled if it's used on a target that's switching out of battle.", -1, 0, 2),
-    new AttackMove(Moves.RAPID_SPIN, "Rapid Spin (P)", Type.NORMAL, MoveCategory.PHYSICAL, 50, 100, 40, "A spin attack that can also eliminate such moves as Bind, Wrap, and Leech Seed. This also raises the user's Speed stat.", 100, 0, 2)
+    new AttackMove(Moves.RAPID_SPIN, "Rapid Spin", Type.NORMAL, MoveCategory.PHYSICAL, 50, 100, 40, "A spin attack that can also eliminate such moves as Bind, Wrap, and Leech Seed. This also raises the user's Speed stat.", 100, 0, 2)
       .attr(StatChangeAttr, BattleStat.SPD, 1, true)
       .attr(RemoveBattlerTagAttr, [ BattlerTagType.BIND, BattlerTagType.WRAP, BattlerTagType.FIRE_SPIN, BattlerTagType.WHIRLPOOL, BattlerTagType.CLAMP, BattlerTagType.SAND_TOMB, BattlerTagType.MAGMA_STORM, BattlerTagType.THUNDER_CAGE, BattlerTagType.SEEDED ], true)
       .attr(RemoveArenaTagAttr, [ArenaTagType.SPIKES, ArenaTagType.STEALTH_ROCK, ArenaTagType.STICKY_WEB, ArenaTagType.TOXIC_SPIKES], true, ArenaTagSide.PLAYER),

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -479,7 +479,7 @@ export class Arena {
 	}
 
   addTag(tagType: ArenaTagType, turnCount: integer, sourceMove: Moves, sourceId: integer, side: ArenaTagSide = ArenaTagSide.BOTH, targetIndex?: BattlerIndex): boolean {
-    const existingTag = this.getTag(tagType);
+    const existingTag = this.getTag(tagType,side);
     if (existingTag) {
       existingTag.onOverlap(this);
       return false;
@@ -492,8 +492,8 @@ export class Arena {
     return true;
   }
 
-  getTag(tagType: ArenaTagType | { new(...args: any[]): ArenaTag }): ArenaTag {
-    return this.getTagOnSide(tagType, ArenaTagSide.BOTH);
+  getTag(tagType: ArenaTagType | { new(...args: any[]): ArenaTag }, side: ArenaTagSide = ArenaTagSide.BOTH): ArenaTag {
+    return this.getTagOnSide(tagType, side);
   }
 
   getTagOnSide(tagType: ArenaTagType | { new(...args: any[]): ArenaTag }, side: ArenaTagSide): ArenaTag {
@@ -517,9 +517,9 @@ export class Arena {
     });
   }
 
-  removeTag(tagType: ArenaTagType): boolean {
+  removeTag(tagType: ArenaTagType, side: ArenaTagSide = ArenaTagSide.BOTH): boolean {
     const tags = this.tags;
-    const tag = tags.find(t => t.tagType === tagType);
+    const tag = tags.find(t => t.tagType === tagType && t.side === side);
     if (tag) {
       tag.onRemove(this);
       tags.splice(tags.indexOf(tag), 1);


### PR DESCRIPTION
Added a method to remove arena tags via move, Rapid Spin, Mortal Spin, Tidy Up, and Defog now remove the proper side(s) traps.  Fixed an issue with trap logic where if Stealth Rocks or another trap was set on one side, it wouldn't allow it to be set on the other since it wasn't checking for side. Removed (P) from rapid spin but kept on Tidy Up as a reminder for future substitute interaction.