### PR TITLE
fix for Psychic Terrain blocking Protect Moves

### DIFF
--- a/src/data/terrain.ts
+++ b/src/data/terrain.ts
@@ -3,6 +3,7 @@ import Move from "./move";
 import { Type } from "./type";
 import * as Utils from "../utils";
 import { IncrementMovePriorityAbAttr, applyAbAttrs } from "./ability";
+import { ProtectAttr } from "./move";
 
 export enum TerrainType {
   NONE,
@@ -50,9 +51,12 @@ export class Terrain {
   isMoveTerrainCancelled(user: Pokemon, move: Move): boolean {
     switch (this.terrainType) {
       case TerrainType.PSYCHIC:
-        const priority = new Utils.IntegerHolder(move.priority);
-        applyAbAttrs(IncrementMovePriorityAbAttr, user, null, move, priority);
-        return priority.value > 0;
+        if (!move.getAttrs(ProtectAttr).length )
+        {
+          const priority = new Utils.IntegerHolder(move.priority);
+          applyAbAttrs(IncrementMovePriorityAbAttr, user, null, move, priority);
+          return priority.value > 0;
+        }
     }
 
     return false;

--- a/src/data/terrain.ts
+++ b/src/data/terrain.ts
@@ -51,8 +51,7 @@ export class Terrain {
   isMoveTerrainCancelled(user: Pokemon, move: Move): boolean {
     switch (this.terrainType) {
       case TerrainType.PSYCHIC:
-        if (!move.getAttrs(ProtectAttr).length )
-        {
+        if (!move.getAttrs(ProtectAttr).length){
           const priority = new Utils.IntegerHolder(move.priority);
           applyAbAttrs(IncrementMovePriorityAbAttr, user, null, move, priority);
           return priority.value > 0;


### PR DESCRIPTION
There was a bug where Psychic Terrain would block protecting moves.

Added an if guard to check for Protected Attribute on the current move that's being used, so Protect, King's Shield, etc. that have increased priority brackets can work as expected. (they are not supposed to be blocked in Psychic Terrain)