### PR TITLE
Fix the logo not appearing when installed as a PWA

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
   "theme_color": "#8c8c8c",
   "icons": [
     {
-      "src": "../logo.png",
+      "src": "./logo.png",
       "sizes": "128x128",
       "type": "image/png"
     }


### PR DESCRIPTION
I think I initially had manifest.json in `src/`, but moved it to the root dir and forgot to update the src property... oops..