### PR TITLE
Prevent install as an app prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,11 @@
         );
       });
     }
+
+    window.addEventListener('beforeinstallprompt', e => {
+      // Prevent invasive install prompt (users are still able to install as an app)
+      e.preventDefault();
+    });
   </script>
 </head>
 


### PR DESCRIPTION
Prevents browsers from firing a PWA install prompt that was causing confusion to some users.

Users can still install as an app from the browsers' menu/nav button.