### PR TITLE
Fix: stop escaping interpolation values in i18next

### DIFF
--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -20,6 +20,9 @@ i18next.init({
   lng: DEFAULT_LANGUAGE_OVERRIDE ? DEFAULT_LANGUAGE_OVERRIDE : 'en',
   fallbackLng: 'en',
   debug: true,
+  interpolation: {
+    escapeValue: false,
+  },
   resources: {
     en: {
       menu: enMenu,


### PR DESCRIPTION
By default, i18next interpolation escapes input values so as to avoid XSS attacks. This turned characters like `&` into `&amp;`, which then got displayed as is in-game.

The text being displayed in this game is code-input only, so we get little value out of XSS protection. Disabling escapes fixes the issue:

![image](https://github.com/pagefaultgames/pokerogue/assets/9257920/47c1029f-c36d-4d3f-b056-c0748585fcbe)
