### PR TITLE
Fix bug in legendary gacha that reduced epic egg rates

### DIFF
--- a/src/ui/egg-gacha-ui-handler.ts
+++ b/src/ui/egg-gacha-ui-handler.ts
@@ -339,7 +339,7 @@ export default class EggGachaUiHandler extends MessageUiHandler {
       const tierValueOffset = this.gachaCursor === GachaType.LEGENDARY ? 1 : 0;
       const tiers = new Array(pullCount).fill(null).map(() => {
         const tierValue = Utils.randInt(256);
-        return tierValue >= 52 + tierValueOffset ? EggTier.COMMON : tierValue + tierValueOffset >= 8 ? EggTier.GREAT : tierValue >= 1 + tierValueOffset ? EggTier.ULTRA : EggTier.MASTER;
+        return tierValue >= 52 + tierValueOffset ? EggTier.COMMON : tierValue >= 8 + tierValueOffset ? EggTier.GREAT : tierValue >= 1 + tierValueOffset ? EggTier.ULTRA : EggTier.MASTER;
       });
       if (pullCount >= 25 && !tiers.filter(t => t >= EggTier.ULTRA).length)
         tiers[Utils.randInt(tiers.length)] = EggTier.ULTRA;


### PR DESCRIPTION
The legendary egg gacha currently removes 1/255 value from common and epic, putting them into rare and legendary. 

This change now properly only removes 1/255 values from common and moves it into legendary as intended.