### PR TITLE
Implement sucker punch

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -4165,7 +4165,8 @@ export function initMoves() {
       }),
     new StatusMove(Moves.WORRY_SEED, "Worry Seed", Type.GRASS, 100, 10, "A seed that causes worry is planted on the target. It prevents sleep by making the target's Ability Insomnia.", -1, 0, 4)
       .attr(AbilityChangeAttr, Abilities.INSOMNIA),
-    new AttackMove(Moves.SUCKER_PUNCH, "Sucker Punch (P)", Type.DARK, MoveCategory.PHYSICAL, 70, 100, 5, "This move enables the user to attack first. This move fails if the target is not readying an attack.", -1, 1, 4),
+    new AttackMove(Moves.SUCKER_PUNCH, "Sucker Punch", Type.DARK, MoveCategory.PHYSICAL, 70, 100, 5, "This move enables the user to attack first. This move fails if the target is not readying an attack.", -1, 1, 4)
+      .condition((user, target, move) => !target.turnData.acted && allMoves[user.scene.currentBattle.turnCommands[target.getBattlerIndex()].move.move].category !== MoveCategory.STATUS),
     new StatusMove(Moves.TOXIC_SPIKES, "Toxic Spikes", Type.POISON, -1, 20, "The user lays a trap of poison spikes at the feet of the opposing team. The spikes will poison opposing Pokémon that switch into battle.", -1, 0, 4)
       .attr(AddArenaTrapTagAttr, ArenaTagType.TOXIC_SPIKES)
       .target(MoveTarget.ENEMY_SIDE),

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2822,6 +2822,7 @@ export class PokemonTurnData {
   public hitsLeft: integer;
   public damageDealt: integer = 0;
   public attacksReceived: AttackMoveResult[] = [];
+  public successfullyActed: boolean;
 }
 
 export enum AiType {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2818,11 +2818,11 @@ export class PokemonBattleSummonData {
 
 export class PokemonTurnData {
   public flinched: boolean;
+  public acted: boolean;
   public hitCount: integer;
   public hitsLeft: integer;
   public damageDealt: integer = 0;
   public attacksReceived: AttackMoveResult[] = [];
-  public successfullyActed: boolean;
 }
 
 export enum AiType {

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2155,6 +2155,8 @@ export class MovePhase extends BattlePhase {
     });
 
     const doMove = () => {
+      this.pokemon.turnData.acted = true; // Record that the move was attempted, even if it fails
+      
       this.pokemon.lapseTags(BattlerTagLapseType.PRE_MOVE);
 	    
       if (!this.followUp && this.canMove() && !this.cancelled) {


### PR DESCRIPTION
Now fails if the target has already acted or has selected a status move

I've tested this a bit and it seems to work, I also confirmed you can sucker punch a sleeping target that has selected an attacking move so the move doesn't have to be possible as intended.