### PR TITLE
Updated Hydro Steam to function correctly

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5351,7 +5351,8 @@ export function initMoves() {
     new AttackMove(Moves.PSYBLADE, "Psyblade", Type.PSYCHIC, MoveCategory.PHYSICAL, 80, 100, 15, "The user rends the target with an ethereal blade. This move's power is boosted by 50 percent if the user is on Electric Terrain.", -1, 0, 9)
       .attr(MovePowerMultiplierAttr, (user, target, move) => user.scene.arena.getTerrainType() === TerrainType.ELECTRIC && user.isGrounded() ? 1.5 : 1)  
       .slicingMove(),
-    new AttackMove(Moves.HYDRO_STEAM, "Hydro Steam (P)", Type.WATER, MoveCategory.SPECIAL, 80, 100, 15, "The user blasts the target with boiling-hot water. This move's power is not lowered in harsh sunlight but rather boosted by 50 percent.", -1, 0, 9),
+    new AttackMove(Moves.HYDRO_STEAM, "Hydro Steam", Type.WATER, MoveCategory.SPECIAL, 80, 100, 15, "The user blasts the target with boiling-hot water. This move's power is not lowered in harsh sunlight but rather boosted by 50 percent.", -1, 0, 9)
+      .attr(MovePowerMultiplierAttr, (user, target, move) => user.scene.arena.getWeatherType() === WeatherType.SUNNY ? 3 : 1),
     new AttackMove(Moves.RUINATION, "Ruination", Type.DARK, MoveCategory.SPECIAL, 1, 90, 10, "The user summons a ruinous disaster. This cuts the target's HP in half.", -1, 0, 9)
       .attr(TargetHalfHpDamageAttr),
     new AttackMove(Moves.COLLISION_COURSE, "Collision Course (P)", Type.FIGHTING, MoveCategory.PHYSICAL, 100, 100, 5, "The user transforms and crashes to the ground, causing a massive prehistoric explosion. This move's power is boosted more than usual if it's a supereffective hit.", -1, 0, 9),

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -331,6 +331,10 @@ export class Arena {
     return this.terrain?.terrainType || TerrainType.NONE;
   }
 
+  getWeatherType() : WeatherType {
+    return this.weather?.weatherType || WeatherType.NONE;
+  }
+
   getAttackTypeMultiplier(attackType: Type, grounded: boolean): number {
     let weatherMultiplier = 1;
     if (this.weather && !this.weather.isEffectSuppressed(this.scene))


### PR DESCRIPTION
Added a new function to the Arena check (getWeatherType) so now moves can check for weather conditions independently for power boosts such as Hydro Steam