### PR TITLE
Copies the moveset of the evolving Nincada to the newly generated pokemon for Shedinja

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2260,6 +2260,7 @@ export class PlayerPokemon extends Pokemon {
       if (newEvolution.condition.predicate(this)) {
         const newPokemon = this.scene.addPlayerPokemon(this.species, this.level, this.abilityIndex, this.formIndex, this.gender, this.shiny, this.ivs, this.nature);
         newPokemon.natureOverride = this.natureOverride;
+        newPokemon.moveset = this.moveset.slice();
         newPokemon.fusionSpecies = this.fusionSpecies;
         newPokemon.fusionFormIndex = this.fusionFormIndex;
         newPokemon.fusionAbilityIndex = this.fusionAbilityIndex;


### PR DESCRIPTION
I was excited to use Shedinja with some of Nincada's egg moves but found that it did not inherit the moveset from Nincada during evolution and instead had it's default level-up moves.

I'm _think_ the expected behavior is that Shedinja inherits the moveset from the Nincada, but let me know if that is incorrect. Thanks for the fun game!