### PR TITLE
Resolves issue with defend abilities not triggering if the target fainted 

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2343,7 +2343,7 @@ export class MoveEffectPhase extends PokemonPhase {
                       }
                       Utils.executeIf(!isProtected && !chargeEffect, () => applyFilteredMoveAttrs((attr: MoveAttr) => attr instanceof MoveEffectAttr && (attr as MoveEffectAttr).trigger === MoveEffectTrigger.HIT && (!attr.firstHitOnly || firstHit),
                         user, target, this.move.getMove()).then(() => {
-                          return Utils.executeIf(!target.isFainted(), () => applyPostDefendAbAttrs(PostDefendAbAttr, target, user, this.move, hitResult).then(() => {
+                          return Utils.executeIf(!target.isFainted() || target.canApplyAbility(), () => applyPostDefendAbAttrs(PostDefendAbAttr, target, user, this.move, hitResult).then(() => {
                             if (!user.isPlayer() && this.move.getMove() instanceof AttackMove)
                               user.scene.applyModifiers(EnemyAttackStatusEffectChanceModifier, false, target);
                           })).then(() => {


### PR DESCRIPTION
Previously if a move KO'd the target then post defend abilities like rough skin and mummy were not triggered. I tested that this is resolved, and also that a run ends as expected if the player's last pokemon is KO'd by rough skin after KOing the target. 


Uploading 2024-04-14 19-29-07.mp4…

