### PR TITLE
Fakeout-bug

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2640,6 +2640,8 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
 	  	// Switch out logic for the battle type
 	  	switchOutTarget.resetTurnData();
 	  	switchOutTarget.resetSummonData();
+      // Decrement turns in play by one to account for the turns being incremented at the end of the current turn
+      switchOutTarget.battleSummonData.turnCount --;
 	  	switchOutTarget.hideInfo();
 	  	switchOutTarget.setVisible(false);
 	  	switchOutTarget.scene.field.remove(switchOutTarget);

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2641,7 +2641,7 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
 	  	switchOutTarget.resetTurnData();
 	  	switchOutTarget.resetSummonData();
       // Decrement turns in play by one to account for the turns being incremented at the end of the current turn
-      switchOutTarget.battleSummonData.turnCount --;
+      switchOutTarget.battleSummonData.turnCount--;
 	  	switchOutTarget.hideInfo();
 	  	switchOutTarget.setVisible(false);
 	  	switchOutTarget.scene.field.remove(switchOutTarget);


### PR DESCRIPTION
Updated data/move.ts to decrement the turns in play when a forced switch out happens during a battle, so the turns will be 1 and not 2 the following turn, allowing fakeout to work.