### PR TITLE
Place 'summary' option at front

### DIFF
--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -550,6 +550,8 @@ export default class PartyUiHandler extends MessageUiHandler {
     let formChangeItemModifiers: PokemonFormChangeItemModifier[];
 
     if (this.partyUiMode !== PartyUiMode.MOVE_MODIFIER && this.partyUiMode !== PartyUiMode.REMEMBER_MOVE_MODIFIER && (this.transferMode || this.partyUiMode !== PartyUiMode.MODIFIER_TRANSFER)) {
+      this.options.push(PartyOption.SUMMARY); // Unconsequential option first
+      
       switch (this.partyUiMode) {
         case PartyUiMode.SWITCH:
         case PartyUiMode.FAINT_SWITCH:
@@ -589,8 +591,6 @@ export default class PartyUiHandler extends MessageUiHandler {
           this.options.push(PartyOption.RELEASE);
           break;
       }
-
-      this.options.push(PartyOption.SUMMARY);
 
       if (pokemon.pauseEvolutions && pokemonEvolutions.hasOwnProperty(pokemon.species.speciesId))
         this.options.push(PartyOption.UNPAUSE_EVOLUTION);


### PR DESCRIPTION
Prevents selecting wrong option out of habit.

---

I moved the 'summary' option to the front. Because in most cases, the summary option is first, players may rely on this behaviour eventually. This commit ensures that this player expectation is met.

I don't know how the code works so kindly verify changes.

# Assumptions

- the push order determines the order of appearance in-game menu
- options can be pushed in any order, independent of other options
- the first option implicitly serves as "pre-selected" option