### PR TITLE
add unit test for util function padInt

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it } from "vitest";
-import { randomString } from "./utils";
+import { randomString, padInt } from "./utils";
 
 import Phaser from "phaser";
 
@@ -18,5 +18,27 @@ describe("utils", () => {
 
       expect(str1).toBe(str2);
     });
+  });
+
+  describe("padInt", () => {
+    it("should return a string", () => {
+      const result = padInt(1, 10);
+      expect(typeof result).toBe('string');
+    });
+
+    it("should return a padded result with default padWith", () => {
+      const result = padInt(1, 3);
+      expect(result).toBe('001');
+    });
+
+    it("should return a padded result using a custom padWith", () => {
+      const result = padInt(1, 10, 'yes')
+      expect(result).toBe('yesyesyes1');
+    });
+
+    it("should return inputted value when zero length is entered", () => {
+      const result = padInt(1, 0);
+      expect(result).toBe('1')
+    })
   });
 });


### PR DESCRIPTION
Added Unit test for `padInt` function

<img width="647" alt="Screenshot 2024-04-17 at 9 16 31 PM" src="https://github.com/pagefaultgames/pokerogue/assets/6759804/53fb3d2b-b460-4ef3-a370-a232a5f515c6">

How to Test:
- In root, run `npm run test`