### PR TITLE
Fix cloud nine, strong winds and stellar effectiveness

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2352,7 +2352,7 @@ export function initAbilities() {
       .attr(BattlerTagImmunityAbAttr, BattlerTagType.INFATUATED)
       .ignorable(),
     new Ability(Abilities.CLOUD_NINE, "Cloud Nine", "Eliminates the effects of weather.", 3)
-      .attr(SuppressWeatherEffectAbAttr),
+      .attr(SuppressWeatherEffectAbAttr, true),
     new Ability(Abilities.COMPOUND_EYES, "Compound Eyes", "The Pokémon's compound eyes boost its accuracy.", 3)
       .attr(BattleStatMultiplierAbAttr, BattleStat.ACC, 1.3),
     new Ability(Abilities.INSOMNIA, "Insomnia", "The Pokémon is suffering from insomnia and cannot fall asleep.", 3)

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1221,7 +1221,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     const cancelled = new Utils.BooleanHolder(false);
     const typeless = !!move.getAttrs(TypelessAttr).length;
     const typeMultiplier = new Utils.NumberHolder(!typeless && (moveCategory !== MoveCategory.STATUS || move.getAttrs(StatusMoveTypeImmunityAttr).find(attr => types.includes((attr as StatusMoveTypeImmunityAttr).immuneType)))
-      ? getTypeDamageMultiplier(type, types[0]) * (types.length > 1 ? getTypeDamageMultiplier(type, types[1]) : 1)
+      ? this.getAttackTypeEffectiveness(type)
       : 1);
     applyMoveAttrs(VariableMoveTypeMultiplierAttr, source, this, move, typeMultiplier);
     if (typeless)


### PR DESCRIPTION
The `getAttackTypeEffectiveness` was only being used by the AI for decision making but was never being applied. This means that stellar attacks were not doing double damage against tera'd Pokemon. This also meant that the strong winds damage reduction effect was not being applied. Cloud nine should function identically to air lock.