### PR TITLE
Add option for rival gender

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -8,7 +8,7 @@ import { Moves } from "./data/enums/moves";
 import { TrainerType } from "./data/enums/trainer-type";
 import { GameMode } from "./game-mode";
 import { BattleSpec } from "./enums/battle-spec";
-import { PlayerGender } from "./system/game-data";
+import { PlayerGender, RivalGender } from "./system/game-data";
 import { MoneyMultiplierModifier, PokemonHeldItemModifier } from "./modifier/modifier";
 import { MoneyAchv } from "./system/achv";
 
@@ -301,15 +301,15 @@ export const fixedBattles: FixedBattleConfigs = {
     [5]: new FixedBattleConfig().setBattleType(BattleType.TRAINER)
         .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.YOUNGSTER, Utils.randSeedInt(2) ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT)),
     [8]: new FixedBattleConfig().setBattleType(BattleType.TRAINER)
-        .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL, scene.gameData.gender === PlayerGender.MALE ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT)),
+        .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL, scene.gameData.rivalGender === RivalGender.FEMALE ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT)),
     [25]: new FixedBattleConfig().setBattleType(BattleType.TRAINER)
-        .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL_2, scene.gameData.gender === PlayerGender.MALE ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT)),
+        .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL_2, scene.gameData.rivalGender === RivalGender.FEMALE ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT)),
     [55]: new FixedBattleConfig().setBattleType(BattleType.TRAINER)
-        .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL_3, scene.gameData.gender === PlayerGender.MALE ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT)),
+        .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL_3, scene.gameData.rivalGender === RivalGender.FEMALE ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT)),
     [95]: new FixedBattleConfig().setBattleType(BattleType.TRAINER)
-        .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL_4, scene.gameData.gender === PlayerGender.MALE ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT)),
+        .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL_4, scene.gameData.rivalGender === RivalGender.FEMALE ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT)),
     [145]: new FixedBattleConfig().setBattleType(BattleType.TRAINER)
-        .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL_5, scene.gameData.gender === PlayerGender.MALE ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT)),
+        .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL_5, scene.gameData.rivalGender === RivalGender.FEMALE ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT)),
     [182]: new FixedBattleConfig().setBattleType(BattleType.TRAINER)
         .setGetTrainerFunc(getRandomTrainerFunc([ TrainerType.LORELEI, TrainerType.WILL, TrainerType.SIDNEY, TrainerType.AARON, TrainerType.SHAUNTAL, TrainerType.MALVA, [ TrainerType.HALA, TrainerType.MOLAYNE ], TrainerType.RIKA, TrainerType.CRISPIN ])),
     [184]: new FixedBattleConfig().setBattleType(BattleType.TRAINER).setSeedOffsetWave(182)
@@ -321,5 +321,5 @@ export const fixedBattles: FixedBattleConfigs = {
     [190]: new FixedBattleConfig().setBattleType(BattleType.TRAINER).setSeedOffsetWave(182)
         .setGetTrainerFunc(getRandomTrainerFunc([ TrainerType.BLUE, [ TrainerType.RED, TrainerType.LANCE_CHAMPION ], [ TrainerType.STEVEN, TrainerType.WALLACE ], TrainerType.CYNTHIA, [ TrainerType.ALDER, TrainerType.IRIS ], TrainerType.DIANTHA, TrainerType.HAU, [ TrainerType.GEETA, TrainerType.NEMONA ], TrainerType.KIERAN, TrainerType.LEON ])),
     [195]: new FixedBattleConfig().setBattleType(BattleType.TRAINER)
-        .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL_6, scene.gameData.gender === PlayerGender.MALE ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT))
+        .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL_6, scene.gameData.rivalGender === RivalGender.FEMALE ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT))
 };

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -45,6 +45,12 @@ export enum PlayerGender {
   FEMALE
 }
 
+export enum RivalGender {
+  UNSET,
+  MALE,
+  FEMALE
+}
+
 export enum Passive {
   UNLOCKED = 1,
   ENABLED = 2
@@ -70,6 +76,7 @@ interface SystemSaveData {
   trainerId: integer;
   secretId: integer;
   gender: PlayerGender;
+  rivalGender: RivalGender;
   dexData: DexData;
   starterData: StarterData;
   gameStats: GameStats;
@@ -203,6 +210,7 @@ export class GameData {
   public secretId: integer;
 
   public gender: PlayerGender;
+  public rivalGender: RivalGender;
   
   public dexData: DexData;
   private defaultDexData: DexData;
@@ -256,6 +264,7 @@ export class GameData {
           trainerId: this.trainerId,
           secretId: this.secretId,
           gender: this.gender,
+          rivalGender: this.rivalGender,
           dexData: this.dexData,
           starterData: this.starterData,
           gameStats: this.gameStats,
@@ -320,8 +329,10 @@ export class GameData {
           this.secretId = systemData.secretId;
 
           this.gender = systemData.gender;
+          this.rivalGender = systemData.rivalGender;
 
           this.saveSetting(Setting.Player_Gender, systemData.gender === PlayerGender.FEMALE ? 1 : 0);
+          this.saveSetting(Setting.Rival_Gender, systemData.rivalGender === RivalGender.FEMALE ? 1 : 0);
 
           const initStarterData = !systemData.starterData;
 

--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -1,7 +1,7 @@
 import BattleScene from "../battle-scene";
 import { hasTouchscreen } from "../touch-controls";
 import { updateWindowType } from "../ui/ui-theme";
-import { PlayerGender } from "./game-data";
+import { PlayerGender, RivalGender } from "./game-data";
 
 export enum Setting {
   Game_Speed = "GAME_SPEED",
@@ -20,6 +20,7 @@ export enum Setting {
   HP_Bar_Speed = "HP_BAR_SPEED",
   Fusion_Palette_Swaps = "FUSION_PALETTE_SWAPS",
   Player_Gender = "PLAYER_GENDER",
+  Rival_Gender = "RIVAL_GENDER",
   Gamepad_Support = "GAMEPAD_SUPPORT",
   Touch_Controls = "TOUCH_CONTROLS",
   Vibration = "VIBRATION"
@@ -50,6 +51,7 @@ export const settingOptions: SettingOptions = {
   [Setting.HP_Bar_Speed]: [ 'Normal', 'Fast', 'Faster', 'Instant' ],
   [Setting.Fusion_Palette_Swaps]: [ 'Off', 'On' ],
   [Setting.Player_Gender]: [ 'Boy', 'Girl' ],
+  [Setting.Rival_Gender]: ['Boy', 'Girl' ],
   [Setting.Gamepad_Support]: [ 'Auto', 'Disabled' ],
   [Setting.Touch_Controls]: [ 'Auto', 'Disabled' ],
   [Setting.Vibration]: [ 'Auto', 'Disabled' ]
@@ -72,6 +74,7 @@ export const settingDefaults: SettingDefaults = {
   [Setting.HP_Bar_Speed]: 0,
   [Setting.Fusion_Palette_Swaps]: 1,
   [Setting.Player_Gender]: 0,
+  [Setting.Rival_Gender]: 1,
   [Setting.Gamepad_Support]: 0,
   [Setting.Touch_Controls]: 0,
   [Setting.Vibration]: 0
@@ -136,6 +139,13 @@ export function setSetting(scene: BattleScene, setting: Setting, value: integer)
         const female = settingOptions[setting][value] === 'Girl';
         scene.gameData.gender = female ? PlayerGender.FEMALE : PlayerGender.MALE;
         scene.trainer.setTexture(scene.trainer.texture.key.replace(female ? 'm' : 'f', female ? 'f' : 'm'));
+      } else
+        return false;
+      break;
+    case Setting.Rival_Gender:
+      if (scene.gameData) {
+        const female = settingOptions[setting][value] === 'Girl';
+        scene.gameData.rivalGender = female ? RivalGender.FEMALE : RivalGender.MALE;
       } else
         return false;
       break;


### PR DESCRIPTION
Seems to be a popular request. Allow option for setting the gender of the rival. Created a new enum for it in case in the future we want it renamed to Rival Finn/Ivy instead of also being boy/girl. 

Testing: [Female player vs Ivy](https://cdn.discordapp.com/attachments/1206721468160024597/1231313427826475028/image.png?ex=663680fd&is=66240bfd&hm=0c2c5f31bb8074612cbfc6a804c1251b2c5428b52a8540e730f16feff70dc5d7&) and [male player vs Finn](https://cdn.discordapp.com/attachments/1206721468160024597/1231314353308041226/image.png?ex=66255e5a&is=66240cda&hm=a758884bf138f636738b110b5c7113cca5a976876881f193ccba8ac71767bea4&)

Rival gender can be changed at any time but needs to be done before the rival spawns in.