### PR TITLE
Fixed bug where Solar Beam wouldn't display if it was sunny

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2295,6 +2295,7 @@ export class MovePhase extends BattlePhase {
           this.cancelled = activated;
           break;
       }
+      
       if (activated) {
         this.scene.queueMessage(getPokemonMessage(this.pokemon, getStatusEffectActivationText(this.pokemon.status.effect)));
         this.scene.unshiftPhase(new CommonAnimPhase(this.scene, this.pokemon.getBattlerIndex(), undefined, CommonAnim.POISON + (this.pokemon.status.effect - 1)));
@@ -2317,6 +2318,7 @@ export class MovePhase extends BattlePhase {
 
   showMoveText(): void {
     if (this.move.getMove().getAttrs(ChargeAttr).length) {
+      this.scene.queueMessage(getPokemonMessage(this.pokemon, ` used\n${this.move.getName()}!`), 500);
       const lastMove = this.pokemon.getLastXMoves() as TurnMove[];
       if (!lastMove.length || lastMove[0].move !== this.move.getMove().id || lastMove[0].result !== MoveResult.OTHER)
         return;


### PR DESCRIPTION
The bug that we fixed with this commit revolved around using charged moves in optimal weather and the text not displaying. For example, if a player used the move Solar Beam when it was Sunny or Harshly Sunny, the Pokemon would bypass the charging turn and use the move immediately. However, when they used this move, there would be no text displayed (i.e. "Bulbasaur used Solar Beam" would not be shown). 

To fix this bug we looked into the ShowMoveText() function in the src/phases.ts file and added logic so that the text would display in the first if statement. This would allow the text box to display moves when the weather is optimal to bypass charging.

QA tests:
OPP_ABILITY_OVERRIDE: Abilities.DROUGHT
MOVE_OVERRIDE: Moves.SOLAR_BEAM

OPP_ABILITY_OVERRIDE: Abilities.DRIZZLE
MOVE_OVERRIDE: Moves.ELECTRO_SHOT
