### PR TITLE
Fix OHKO accuracy formula

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2304,7 +2304,10 @@ export class WaterSuperEffectTypeMultiplierAttr extends VariableMoveTypeMultipli
 export class OneHitKOAccuracyAttr extends VariableAccuracyAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const accuracy = args[0] as Utils.NumberHolder;
-    accuracy.value = 30 + 70 * Math.min(target.level / user.level, 0.5) * 2;
+    if (user.level < target.level)
+      accuracy.value = 0;
+    else
+      accuracy.value = Math.min(Math.max(30 + 100 * (1 - target.level / user.level), 0), 100);
     return true;
   }
 }


### PR DESCRIPTION
Scales from 30% at equal level up to 100% at 0.3x level, similar to the games at level 100. This is linear scaling though as consistent with the previous because we scale way past level 100. Also makes it no longer work on higher leveled targets, same as the games.

Should work.