### PR TITLE
Fixed type immunity abilities not working against status moves

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -312,7 +312,7 @@ export class TypeImmunityAbAttr extends PreDefendAbAttr {
     const target = move.getMove().moveTarget;
     const targetsField = target === MoveTarget.ENEMY_SIDE || target === MoveTarget.USER_SIDE || target === MoveTarget.BOTH_SIDES; // should not activate on moves like spikes or grassy terrain
 
-    if (((move.getMove() instanceof Move && !targetsField) || move.getMove().getAttrs(StatusMoveTypeImmunityAttr).find(attr => (attr as StatusMoveTypeImmunityAttr).immuneType === this.immuneType)) && move.getMove().type === this.immuneType) {
+    if ((!targetsField || move.getMove().getAttrs(StatusMoveTypeImmunityAttr).find(attr => (attr as StatusMoveTypeImmunityAttr).immuneType === this.immuneType)) && move.getMove().type === this.immuneType) {
       (args[0] as Utils.NumberHolder).value = 0;
       return true;
     }

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -296,6 +296,13 @@ export class PreDefendMovePowerToOneAbAttr extends ReceivedMoveDamageMultiplierA
   }
 }
 
+/**
+ * Makes the user immune to moves of a specific type. Works regardless
+ * of move category. Does not affect moves that target the field (ex. spikes)
+ * @param immuneType The {@link Type} that the user is immune to
+ * @param condition N/A
+ * @returns if the ability successfully activates
+ */
 export class TypeImmunityAbAttr extends PreDefendAbAttr {
   private immuneType: Type;
   private condition: AbAttrCondition;

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -308,7 +308,11 @@ export class TypeImmunityAbAttr extends PreDefendAbAttr {
   }
 
   applyPreDefend(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: PokemonMove, cancelled: Utils.BooleanHolder, args: any[]): boolean {
-    if ((move.getMove() instanceof AttackMove || move.getMove().getAttrs(StatusMoveTypeImmunityAttr).find(attr => (attr as StatusMoveTypeImmunityAttr).immuneType === this.immuneType)) && move.getMove().type === this.immuneType) {
+
+    const target = move.getMove().moveTarget;
+    const targetsField = target === MoveTarget.ENEMY_SIDE || target === MoveTarget.USER_SIDE || target === MoveTarget.BOTH_SIDES; // should not activate on moves like spikes or grassy terrain
+
+    if (((move.getMove() instanceof Move && !targetsField) || move.getMove().getAttrs(StatusMoveTypeImmunityAttr).find(attr => (attr as StatusMoveTypeImmunityAttr).immuneType === this.immuneType)) && move.getMove().type === this.immuneType) {
       (args[0] as Utils.NumberHolder).value = 0;
       return true;
     }


### PR DESCRIPTION
Currently type immunity abilities only work against instances of `AttackMove`, leading to unintentional behaviour such as moves like Leech Seed or Sleep Powder working against Pokemon with Sap Sipper.
- `TypeImmunityAbAttr` has been changed to work against all move categories (instances of `Move`)
- Added additional logic to prevent ability activation against moves that target the field (preventing Earth Eater from blocking spikes, Sap Sipper from blocking Grassy Terrain, etc)