### PR TITLE
add hazard removal for Rapid Spin, Defog, Tidy Up, Mortal Spin

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2765,29 +2765,37 @@ export class AddArenaTrapTagAttr extends AddArenaTagAttr {
 }
 
 export class RemoveArenaTrapAttr extends MoveEffectAttr {
-  private arenaTarget : ArenaTagSide;  
 
-  constructor(arenaTarget: ArenaTagSide = ArenaTagSide.PLAYER) {
+  private targetBothSides: boolean;
+
+  constructor(targetBothSides: boolean = false) {
     super(true, MoveEffectTrigger.PRE_APPLY);
-    this.arenaTarget = arenaTarget;
+    this.targetBothSides = targetBothSides;
   }
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+
     if (!super.apply(user, target, move, args))
       return false;
 
-    if((target.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY ==  this.arenaTarget) || this.arenaTarget == ArenaTagSide.BOTH){
+    if(this.targetBothSides){
       user.scene.arena.removeTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.PLAYER);
       user.scene.arena.removeTagOnSide(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.PLAYER);
       user.scene.arena.removeTagOnSide(ArenaTagType.STEALTH_ROCK, ArenaTagSide.PLAYER);
       user.scene.arena.removeTagOnSide(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER);
-    }
-    if(((!target.isPlayer()) ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY ==  this.arenaTarget) || this.arenaTarget == ArenaTagSide.BOTH){
+
       user.scene.arena.removeTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.ENEMY);
       user.scene.arena.removeTagOnSide(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY);
       user.scene.arena.removeTagOnSide(ArenaTagType.STEALTH_ROCK, ArenaTagSide.ENEMY);
       user.scene.arena.removeTagOnSide(ArenaTagType.STICKY_WEB, ArenaTagSide.ENEMY);
     }
+    else {
+      user.scene.arena.removeTagOnSide(ArenaTagType.SPIKES, target.isPlayer() ? ArenaTagSide.ENEMY : ArenaTagSide.PLAYER);
+      user.scene.arena.removeTagOnSide(ArenaTagType.TOXIC_SPIKES, target.isPlayer() ? ArenaTagSide.ENEMY : ArenaTagSide.PLAYER);
+      user.scene.arena.removeTagOnSide(ArenaTagType.STEALTH_ROCK, target.isPlayer() ? ArenaTagSide.ENEMY : ArenaTagSide.PLAYER);
+      user.scene.arena.removeTagOnSide(ArenaTagType.STICKY_WEB, target.isPlayer() ? ArenaTagSide.ENEMY : ArenaTagSide.PLAYER);
+    }
+
     return true;
   }
 }
@@ -4338,8 +4346,7 @@ export function initMoves() {
         BattlerTagType.SEEDED,
         BattlerTagType.INFESTATION
       ], true)
-      .attr(RemoveArenaTrapAttr)
-      .partial(),
+      .attr(RemoveArenaTrapAttr),
     new StatusMove(Moves.SWEET_SCENT, Type.NORMAL, 100, 20, -1, 0, 2)
       .attr(StatChangeAttr, BattleStat.EVA, -1)
       .target(MoveTarget.ALL_NEAR_ENEMIES),
@@ -4886,7 +4893,7 @@ export function initMoves() {
       .attr(ClearWeatherAttr, WeatherType.FOG)
       .attr(ClearTerrainAttr)
       .attr(RemoveScreensAttr, false)
-      .attr(RemoveArenaTrapAttr, ArenaTagSide.BOTH),
+      .attr(RemoveArenaTrapAttr, true),
     new StatusMove(Moves.TRICK_ROOM, Type.PSYCHIC, -1, 5, -1, -7, 4)
       .attr(AddArenaTagAttr, ArenaTagType.TRICK_ROOM, 5)
       .ignoresProtect()
@@ -6216,8 +6223,7 @@ export function initMoves() {
       .target(MoveTarget.BOTH_SIDES),
     new SelfStatusMove(Moves.TIDY_UP, Type.NORMAL, -1, 10, 100, 0, 9)
       .attr(StatChangeAttr, [ BattleStat.ATK, BattleStat.SPD ], 1, true)
-      .attr(RemoveArenaTrapAttr)
-      .partial(),
+      .attr(RemoveArenaTrapAttr),
     new StatusMove(Moves.SNOWSCAPE, Type.ICE, -1, 10, -1, 0, 9)
       .attr(WeatherChangeAttr, WeatherType.SNOW)
       .target(MoveTarget.BOTH_SIDES),

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2765,37 +2765,29 @@ export class AddArenaTrapTagAttr extends AddArenaTagAttr {
 }
 
 export class RemoveArenaTrapAttr extends MoveEffectAttr {
+  private arenaTarget : ArenaTagSide;  
 
-  private targetBothSides: boolean;
-
-  constructor(targetBothSides: boolean = false) {
+  constructor(arenaTarget: ArenaTagSide = ArenaTagSide.PLAYER) {
     super(true, MoveEffectTrigger.PRE_APPLY);
-    this.targetBothSides = targetBothSides;
+    this.arenaTarget = arenaTarget;
   }
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-
     if (!super.apply(user, target, move, args))
       return false;
 
-    if(this.targetBothSides){
+    if((target.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY ==  this.arenaTarget) || this.arenaTarget == ArenaTagSide.BOTH){
       user.scene.arena.removeTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.PLAYER);
       user.scene.arena.removeTagOnSide(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.PLAYER);
       user.scene.arena.removeTagOnSide(ArenaTagType.STEALTH_ROCK, ArenaTagSide.PLAYER);
       user.scene.arena.removeTagOnSide(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER);
-
+    }
+    if(((!target.isPlayer()) ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY ==  this.arenaTarget) || this.arenaTarget == ArenaTagSide.BOTH){
       user.scene.arena.removeTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.ENEMY);
       user.scene.arena.removeTagOnSide(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY);
       user.scene.arena.removeTagOnSide(ArenaTagType.STEALTH_ROCK, ArenaTagSide.ENEMY);
       user.scene.arena.removeTagOnSide(ArenaTagType.STICKY_WEB, ArenaTagSide.ENEMY);
     }
-    else {
-      user.scene.arena.removeTagOnSide(ArenaTagType.SPIKES, target.isPlayer() ? ArenaTagSide.ENEMY : ArenaTagSide.PLAYER);
-      user.scene.arena.removeTagOnSide(ArenaTagType.TOXIC_SPIKES, target.isPlayer() ? ArenaTagSide.ENEMY : ArenaTagSide.PLAYER);
-      user.scene.arena.removeTagOnSide(ArenaTagType.STEALTH_ROCK, target.isPlayer() ? ArenaTagSide.ENEMY : ArenaTagSide.PLAYER);
-      user.scene.arena.removeTagOnSide(ArenaTagType.STICKY_WEB, target.isPlayer() ? ArenaTagSide.ENEMY : ArenaTagSide.PLAYER);
-    }
-
     return true;
   }
 }
@@ -4893,8 +4885,8 @@ export function initMoves() {
       .attr(StatChangeAttr, BattleStat.EVA, -1)
       .attr(ClearWeatherAttr, WeatherType.FOG)
       .attr(ClearTerrainAttr)
-      .attr(RemoveScreensAttr, true)
-      .attr(RemoveArenaTrapAttr, true),
+      .attr(RemoveScreensAttr, false)
+      .attr(RemoveArenaTrapAttr, ArenaTagSide.BOTH),
     new StatusMove(Moves.TRICK_ROOM, Type.PSYCHIC, -1, 5, -1, -7, 4)
       .attr(AddArenaTagAttr, ArenaTagType.TRICK_ROOM, 5)
       .ignoresProtect()

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2764,6 +2764,42 @@ export class AddArenaTrapTagAttr extends AddArenaTagAttr {
   }
 }
 
+export class RemoveArenaTrapAttr extends MoveEffectAttr {
+
+  private targetBothSides: boolean;
+
+  constructor(targetBothSides: boolean = false) {
+    super(true, MoveEffectTrigger.PRE_APPLY);
+    this.targetBothSides = targetBothSides;
+  }
+
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+
+    if (!super.apply(user, target, move, args))
+      return false;
+
+    if(this.targetBothSides){
+      user.scene.arena.removeTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.PLAYER);
+      user.scene.arena.removeTagOnSide(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.PLAYER);
+      user.scene.arena.removeTagOnSide(ArenaTagType.STEALTH_ROCK, ArenaTagSide.PLAYER);
+      user.scene.arena.removeTagOnSide(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER);
+
+      user.scene.arena.removeTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.ENEMY);
+      user.scene.arena.removeTagOnSide(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY);
+      user.scene.arena.removeTagOnSide(ArenaTagType.STEALTH_ROCK, ArenaTagSide.ENEMY);
+      user.scene.arena.removeTagOnSide(ArenaTagType.STICKY_WEB, ArenaTagSide.ENEMY);
+    }
+    else {
+      user.scene.arena.removeTagOnSide(ArenaTagType.SPIKES, target.isPlayer() ? ArenaTagSide.ENEMY : ArenaTagSide.PLAYER);
+      user.scene.arena.removeTagOnSide(ArenaTagType.TOXIC_SPIKES, target.isPlayer() ? ArenaTagSide.ENEMY : ArenaTagSide.PLAYER);
+      user.scene.arena.removeTagOnSide(ArenaTagType.STEALTH_ROCK, target.isPlayer() ? ArenaTagSide.ENEMY : ArenaTagSide.PLAYER);
+      user.scene.arena.removeTagOnSide(ArenaTagType.STICKY_WEB, target.isPlayer() ? ArenaTagSide.ENEMY : ArenaTagSide.PLAYER);
+    }
+
+    return true;
+  }
+}
+
 export class RemoveScreensAttr extends MoveEffectAttr {
 
   private targetBothSides: boolean;
@@ -4310,6 +4346,7 @@ export function initMoves() {
         BattlerTagType.SEEDED,
         BattlerTagType.INFESTATION
       ], true)
+      .attr(RemoveArenaTrapAttr)
       .partial(),
     new StatusMove(Moves.SWEET_SCENT, Type.NORMAL, 100, 20, -1, 0, 2)
       .attr(StatChangeAttr, BattleStat.EVA, -1)
@@ -4856,7 +4893,8 @@ export function initMoves() {
       .attr(StatChangeAttr, BattleStat.EVA, -1)
       .attr(ClearWeatherAttr, WeatherType.FOG)
       .attr(ClearTerrainAttr)
-      .attr(RemoveScreensAttr, true),
+      .attr(RemoveScreensAttr, true)
+      .attr(RemoveArenaTrapAttr, true),
     new StatusMove(Moves.TRICK_ROOM, Type.PSYCHIC, -1, 5, -1, -7, 4)
       .attr(AddArenaTagAttr, ArenaTagType.TRICK_ROOM, 5)
       .ignoresProtect()
@@ -6142,6 +6180,7 @@ export function initMoves() {
         BattlerTagType.INFESTATION
       ], true)
       .attr(StatusEffectAttr, StatusEffect.POISON)
+      .attr(RemoveArenaTrapAttr)
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new StatusMove(Moves.DOODLE, Type.NORMAL, 100, 10, -1, 0, 9)
       .attr(AbilityCopyAttr, true),
@@ -6185,6 +6224,7 @@ export function initMoves() {
       .target(MoveTarget.BOTH_SIDES),
     new SelfStatusMove(Moves.TIDY_UP, Type.NORMAL, -1, 10, 100, 0, 9)
       .attr(StatChangeAttr, [ BattleStat.ATK, BattleStat.SPD ], 1, true)
+      .attr(RemoveArenaTrapAttr)
       .partial(),
     new StatusMove(Moves.SNOWSCAPE, Type.ICE, -1, 10, -1, 0, 9)
       .attr(WeatherChangeAttr, WeatherType.SNOW)


### PR DESCRIPTION
This PR implements hazard removal via Rapid Spin, Defog, Tidy Up, and Mortal Spin. Logic is mostly copied over from screens removal logic. PR does not address Court Change.

I'm having a hard time building this, so if someone could test it out that would be great, but the logic seems to check out.