### PR TITLE
Forecast and Flower Gift Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist-ssr
 .vscode/*
 !.vscode/extensions.json
 !.vscode/settings.json
+.vs/*
 .idea
 .DS_Store
 *.suo

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2544,7 +2544,8 @@ export function initAbilities() {
       .attr(PostDefendContactApplyTagChanceAbAttr, 30, BattlerTagType.INFATUATED),
     new Ability(Abilities.PLUS, "Plus (N)", "Boosts the Sp. Atk stat of the Pokémon if an ally with the Plus or Minus Ability is also in battle.", 3),
     new Ability(Abilities.MINUS, "Minus (N)", "Boosts the Sp. Atk stat of the Pokémon if an ally with the Plus or Minus Ability is also in battle.", 3),
-    new Ability(Abilities.FORECAST, "Forecast (N)", "The Pokémon transforms with the weather to change its type to Water, Fire, or Ice.", 3)
+    new Ability(Abilities.FORECAST, "Forecast (P)", "The Pokémon transforms with the weather to change its type to Water, Fire, or Ice.", 3)
+      .attr(PostWeatherChangeAbAttr)
       .attr(UncopiableAbilityAbAttr)
       .attr(NoFusionAbilityAbAttr),
     new Ability(Abilities.STICKY_HOLD, "Sticky Hold", "Items held by the Pokémon are stuck fast and cannot be removed by other Pokémon.", 3)
@@ -2706,6 +2707,7 @@ export function initAbilities() {
     new Ability(Abilities.FLOWER_GIFT, "Flower Gift (P)", "Boosts the Attack and Sp. Def stats of itself and allies in harsh sunlight.", 4)
       .conditionalAttr(getWeatherCondition(WeatherType.SUNNY || WeatherType.HARSH_SUN), BattleStatMultiplierAbAttr, BattleStat.ATK, 1.5)
       .conditionalAttr(getWeatherCondition(WeatherType.SUNNY || WeatherType.HARSH_SUN), BattleStatMultiplierAbAttr, BattleStat.SPDEF, 1.5)
+      .attr(PostWeatherChangeAbAttr)
       .attr(UncopiableAbilityAbAttr)
       .attr(NoFusionAbilityAbAttr)
       .ignorable(),
@@ -3137,6 +3139,7 @@ export function initAbilities() {
     new Ability(Abilities.PROTOSYNTHESIS, "Protosynthesis", "Boosts the Pokémon's most proficient stat in harsh sunlight or if the Pokémon is holding Booster Energy.", 9)
       .conditionalAttr(getWeatherCondition(WeatherType.SUNNY, WeatherType.HARSH_SUN), PostSummonAddBattlerTagAbAttr, BattlerTagType.PROTOSYNTHESIS, 0, true)
       .attr(PostWeatherChangeAddBattlerTagAttr, BattlerTagType.PROTOSYNTHESIS, 0, WeatherType.SUNNY, WeatherType.HARSH_SUN)
+      .attr(UnsuppressableAbilityAbAttr)
       .attr(UncopiableAbilityAbAttr)
       .attr(UnswappableAbilityAbAttr)
       .attr(NoTransformAbilityAbAttr),

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -14,6 +14,7 @@ import { ArenaTagType } from "../data/enums/arena-tag-type";
 import { TrainerType } from "../data/enums/trainer-type";
 import { BattlerIndex } from "../battle";
 import { Moves } from "../data/enums/moves";
+import { SpeciesFormChangeWeatherTrigger } from "../data/pokemon-forms";
 import { TimeOfDay } from "../data/enums/time-of-day";
 import { Terrain, TerrainType } from "../data/terrain";
 import { PostTerrainChangeAbAttr, PostWeatherChangeAbAttr, applyPostTerrainChangeAbAttrs, applyPostWeatherChangeAbAttrs } from "../data/ability";
@@ -303,8 +304,16 @@ export class Arena {
     }
 
     this.scene.getField(true).filter(p => p.isOnField()).map(pokemon => {
-      pokemon.findAndRemoveTags(t => 'weatherTypes' in t && !(t.weatherTypes as WeatherType[]).find(t => t === weather));
+      pokemon.findAndRemoveTags(t => 'weatherTypes' in t && !(t.weatherTypes as WeatherType[]).find(t => t === weather));      
       applyPostWeatherChangeAbAttrs(PostWeatherChangeAbAttr, pokemon, weather);
+
+      if(this.weather){
+        this.scene.triggerPokemonFormChange(pokemon, SpeciesFormChangeWeatherTrigger, false );
+      }
+      else{
+        this.scene.triggerPokemonFormChange(pokemon, SpeciesFormChangeWeatherTrigger, true );
+      }
+      //
     });
     
     return true;

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -45,7 +45,7 @@ import { vouchers } from "./system/voucher";
 import { loggedInUser, updateUserInfo } from "./account";
 import { PlayerGender, SessionSaveData } from "./system/game-data";
 import { addPokeballCaptureStars, addPokeballOpenParticles } from "./field/anims";
-import { SpeciesFormChangeActiveTrigger, SpeciesFormChangeManualTrigger, SpeciesFormChangeMoveLearnedTrigger, SpeciesFormChangePostMoveTrigger, SpeciesFormChangePreMoveTrigger } from "./data/pokemon-forms";
+import { SpeciesFormChangeActiveTrigger, SpeciesFormChangeManualTrigger, SpeciesFormChangeMoveLearnedTrigger, SpeciesFormChangePostMoveTrigger, SpeciesFormChangePreMoveTrigger, SpeciesFormChangeWeatherTrigger} from "./data/pokemon-forms";
 import { battleSpecDialogue, getCharVariantFromDialogue } from "./data/dialogue";
 import ModifierSelectUiHandler, { SHOP_OPTIONS_ROW_LIMIT } from "./ui/modifier-select-ui-handler";
 import { Setting } from "./system/settings";
@@ -1292,7 +1292,7 @@ export class SummonPhase extends PartyMemberPokemonPhase {
 
     if (!this.loaded || this.scene.currentBattle.battleType === BattleType.TRAINER || (this.scene.currentBattle.waveIndex % 10) === 1) {
       this.scene.triggerPokemonFormChange(pokemon, SpeciesFormChangeActiveTrigger, true);
-
+      this.scene.triggerPokemonFormChange(pokemon, SpeciesFormChangeWeatherTrigger, false);
       this.queuePostSummon();
     }
   }
@@ -2796,8 +2796,7 @@ export class WeatherEffectPhase extends CommonAnimPhase {
     }
 
     this.scene.ui.showText(getWeatherLapseMessage(this.weather.weatherType), null, () => {
-      this.executeForAll((pokemon: Pokemon) => applyPostWeatherLapseAbAttrs(PostWeatherLapseAbAttr, pokemon, this.weather));
-
+      this.executeForAll((pokemon: Pokemon) => applyPostWeatherLapseAbAttrs(PostWeatherLapseAbAttr, pokemon, this.weather));      
       super.start();
     });
   }


### PR DESCRIPTION
- Added SpeciesFormChangeWeatherTrigger to allow for forms to change when weather does.
- Changed TrySetWeather and SummonPhases to trigger weather setting form Changes
- Preliminary support for ability suppression form triggers in SpeciesFormChangeAbilitySuppressionTrigger


Implemented:

- Forecast: Castform transforms with the weather.
- Flower Gift: Cherrim Transforms in the weather.

Not yet implemented:

- Both effects need further ability suppression triggers to reach full intended behavior.
- Currently they mirror generation 4 functionality
- SpeciesFormChangeAbilitySuppressionTrigger doesn't have a home yet