### PR TITLE
Fix password input types for languages other than english

### DIFF
--- a/src/ui/form-modal-ui-handler.ts
+++ b/src/ui/form-modal-ui-handler.ts
@@ -5,6 +5,7 @@ import { TextStyle, addTextInputObject, addTextObject } from "./text";
 import { WindowVariant, addWindow } from "./ui-theme";
 import InputText from "phaser3-rex-plugins/plugins/inputtext";
 import * as Utils from "../utils";
+import i18next from '../plugins/i18n';
 
 export interface FormModalConfig extends ModalConfig {
   errorMessage?: string;
@@ -55,7 +56,7 @@ export abstract class FormModalUiHandler extends ModalUiHandler {
 
       const inputBg = addWindow(this.scene, 0, 0, 80, 16, false, false, 0, 0, WindowVariant.XTHIN);
 
-      const isPassword = field.includes('Password');
+      const isPassword = field.includes(i18next.t("menu:password")) || field.includes(i18next.t("menu:confirmPassword"));
       const input = addTextInputObject(this.scene, 4, -2, 440, 116, TextStyle.TOOLTIP_CONTENT, { type: isPassword ? 'password' : 'text', maxLength: isPassword ? 64 : 16 });
       input.setOrigin(0, 0);
 


### PR DESCRIPTION
This is a fix for an issue introduced by my last PR : https://github.com/pagefaultgames/pokerogue/pull/244

What happened is that input fields are given a type by their label, either "text" or "password".
That type is given after a check using string.includes and the label of the input.
The difference between those is that "password" type input accepts 64 characters vs 16 for the "text" one.

With my last change introducing localisation in both login and register form, I didn't see that the password input was different because it only checked against the hard coded "Password" string, making inputs impossible to be "password" type in locales where the password input label was changed.

That introduced a breaking change for any non-english locale user with passwords longer than 16 since they can't login anymore.

I only noticed since I couldn't login anymore because of that issue, I apologize for not noticing that big breaking change during my last PR.

To fix this quickly, I check the label based on the locale but also add a check for the "confirm password" input label, present in the register form, since it can be different than the first one (it currently is for the french locale).