### PR TITLE
Implement localisation for pokemon stats & add french locale

### DIFF
--- a/src/data/pokemon-stat.ts
+++ b/src/data/pokemon-stat.ts
@@ -1,3 +1,5 @@
+import i18next from '../plugins/i18n';
+
 export enum Stat {
   HP = 0,
   ATK,
@@ -11,22 +13,22 @@ export function getStatName(stat: Stat, shorten: boolean = false) {
   let ret: string;
   switch (stat) {
     case Stat.HP:
-      ret = !shorten ? 'Max. HP' : 'MaxHP';
+      ret = !shorten ? i18next.t('pokemonStat:HP') : i18next.t('pokemonStat:HPshortened');
       break;
     case Stat.ATK:
-      ret = !shorten ? 'Attack' : 'Atk';
+      ret = !shorten ? i18next.t('pokemonStat:ATK') : i18next.t('pokemonStat:ATKshortened');
       break;
     case Stat.DEF:
-      ret = !shorten ? 'Defense' : 'Def';
+      ret = !shorten ? i18next.t('pokemonStat:DEF') : i18next.t('pokemonStat:DEFshortened');
       break;
     case Stat.SPATK:
-      ret = !shorten ? 'Sp. Atk' : 'SpAtk';
+      ret = !shorten ? i18next.t('pokemonStat:SPATK') : i18next.t('pokemonStat:SPATKshortened');
       break;
     case Stat.SPDEF:
-      ret = !shorten ? 'Sp. Def' : 'SpDef';
+      ret = !shorten ? i18next.t('pokemonStat:SPDEF') : i18next.t('pokemonStat:SPDEFshortened');
       break;
     case Stat.SPD:
-      ret = !shorten ? 'Speed' : 'Spd';
+      ret = !shorten ? i18next.t('pokemonStat:SPD') : i18next.t('pokemonStat:SPDshortened');
       break;
   }
   return ret;

--- a/src/locales/en/pokemon-stat.ts
+++ b/src/locales/en/pokemon-stat.ts
@@ -1,0 +1,16 @@
+import { SimpleTranslationEntries } from "#app/plugins/i18n";
+
+export const pokemonStat: SimpleTranslationEntries = {
+    "HP": "Max. HP",
+    "HPshortened": "MaxHP",
+    "ATK": "Attack",
+    "ATKshortened": "Atk",
+    "DEF": "Defense",
+    "DEFshortened": "Def",
+    "SPATK": "Sp. Atk",
+    "SPATKshortened": "SpAtk",
+    "SPDEF": "Sp. Def",
+    "SPDEFshortened": "SpDef",
+    "SPD": "Speed",
+    "SPDshortened": "Spd"
+} as const;

--- a/src/locales/es/pokemon-stat.ts
+++ b/src/locales/es/pokemon-stat.ts
@@ -1,0 +1,16 @@
+import { SimpleTranslationEntries } from "#app/plugins/i18n";
+
+export const pokemonStat: SimpleTranslationEntries = {
+    "HP": "Max. HP",
+    "HPshortened": "MaxHP",
+    "ATK": "Attack",
+    "ATKshortened": "Atk",
+    "DEF": "Defense",
+    "DEFshortened": "Def",
+    "SPATK": "Sp. Atk",
+    "SPATKshortened": "SpAtk",
+    "SPDEF": "Sp. Def",
+    "SPDEFshortened": "SpDef",
+    "SPD": "Speed",
+    "SPDshortened": "Spd"
+} as const;

--- a/src/locales/fr/pokemon-stat.ts
+++ b/src/locales/fr/pokemon-stat.ts
@@ -1,0 +1,16 @@
+import { SimpleTranslationEntries } from "#app/plugins/i18n";
+
+export const pokemonStat: SimpleTranslationEntries = {
+    "HP": "PV",
+    "HPshortened": "PV",
+    "ATK": "Attaque",
+    "ATKshortened": "Atq",
+    "DEF": "Défense",
+    "DEFshortened": "Déf",
+    "SPATK": "Atq. Spé",
+    "SPATKshortened": "AtqSp",
+    "SPDEF": "Déf. Spé",
+    "SPDEFshortened": "DéfSp",
+    "SPD": "Vitesse",
+    "SPDshortened": "Vit"
+} as const;

--- a/src/locales/it/pokemon-stat.ts
+++ b/src/locales/it/pokemon-stat.ts
@@ -1,0 +1,16 @@
+import { SimpleTranslationEntries } from "#app/plugins/i18n";
+
+export const pokemonStat: SimpleTranslationEntries = {
+    "HP": "Max. HP",
+    "HPshortened": "MaxHP",
+    "ATK": "Attack",
+    "ATKshortened": "Atk",
+    "DEF": "Defense",
+    "DEFshortened": "Def",
+    "SPATK": "Sp. Atk",
+    "SPATKshortened": "SpAtk",
+    "SPDEF": "Sp. Def",
+    "SPDEFshortened": "SpDef",
+    "SPD": "Speed",
+    "SPDshortened": "Spd"
+} as const;

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -16,6 +16,11 @@ import { pokemon as enPokemon } from '../locales/en/pokemon';
 import { pokemon as esPokemon } from '../locales/es/pokemon';
 import { pokemon as frPokemon } from '../locales/fr/pokemon';
 
+import { pokemonStat as enPokemonStat } from '../locales/en/pokemon-stat';
+import { pokemonStat as esPokemonStat } from '../locales/es/pokemon-stat';
+import { pokemonStat as frPokemonStat } from '../locales/fr/pokemon-stat';
+import { pokemonStat as itPokemonStat } from '../locales/it/pokemon-stat';
+
 import { commandUiHandler as enCommandUiHandler } from '../locales/en/command-ui-handler';
 import { commandUiHandler as esCommandUiHandler } from '../locales/es/command-ui-handler';
 import { commandUiHandler as frCommandUiHandler } from '../locales/fr/command-ui-handler';
@@ -71,6 +76,7 @@ export function initI18n(): void {
         move: enMove,
         pokeball: enPokeball,
         pokemon: enPokemon,
+        pokemonStat: enPokemonStat,
         commandUiHandler: enCommandUiHandler,
       },
       es: {
@@ -78,6 +84,7 @@ export function initI18n(): void {
         move: esMove,
         pokeball: esPokeball,
         pokemon: esPokemon,
+        pokemonStat: esPokemonStat,
         commandUiHandler: esCommandUiHandler,
       },
       fr: {
@@ -85,10 +92,12 @@ export function initI18n(): void {
         move: frMove,
         pokeball: frPokeball,
         pokemon: frPokemon,
+        pokemonStat: frPokemonStat,
         commandUiHandler: frCommandUiHandler,
       },
       it: {
         menu: itMenu,
+        pokemonStat: itPokemonStat,
       },
     },
   });
@@ -102,6 +111,7 @@ declare module 'i18next' {
       move: typeof enMove;
       pokeball: typeof enPokeball;
       pokemon: typeof enPokemon;
+      pokemonStat: typeof enPokemonStat;
       commandUiHandler: typeof enCommandUiHandler;
     };
   }


### PR DESCRIPTION
I also created files for pokemon stats in other languages using the english stats by default.

For future reference, i've used what we had on gen 1-2-3 for the french shortened stat names, and the last gen for the full ones.

![vivaldi_2024-04-24_22-14-52](https://github.com/pagefaultgames/pokerogue/assets/1712845/22eaeb5c-b280-4c2a-b2c9-0864d6482201)
![vivaldi_2024-04-24_22-16-32](https://github.com/pagefaultgames/pokerogue/assets/1712845/8bafa37c-f39a-4637-856a-cda175646a42)
![vivaldi_2024-04-24_22-16-50](https://github.com/pagefaultgames/pokerogue/assets/1712845/0ae9cb38-e2d8-4bd4-8d22-f621e1c3685b)
