### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Utiliser l'image officielle Node.js avec la version spécifique 18.3.0
+FROM node:18.3.0
+
+# Définir le répertoire de travail dans le conteneur
+WORKDIR /app
+
+# Copier les fichiers de gestion des paquets. Utilisez le wildcard pour inclure à la fois package.json et package-lock.json
+COPY package*.json ./
+
+# Installer les dépendances. Notez que cela n'impactera pas les fichiers sur le host mais uniquement dans l'image.
+RUN npm install
+
+# Copier tout le contenu du dossier actuel dans le répertoire de travail du conteneur
+COPY . .
+
+# Définir le port que l'application va utiliser
+EXPOSE 8000
+
+# Définir la commande par défaut pour exécuter l'application
+CMD ["npm", "run", "start:dev"]


### PR DESCRIPTION
Dockerfile functional and tested in order to build a Docker image. The container's internal port remains 8000. You can add a Github action to build a Docker image and pull it onto DockerHub automatically.

![pokerogue_container](https://github.com/pagefaultgames/pokerogue/assets/94562942/5730eea3-1c2c-4ddf-a5ba-467cdc84975a)
![pokerogue_log](https://github.com/pagefaultgames/pokerogue/assets/94562942/2acbebb9-243d-4d59-bef9-ac3e9e20209b)
![pokerogue_screen](https://github.com/pagefaultgames/pokerogue/assets/94562942/6a92b23f-aa1e-400f-8b5b-0b149c3ea24c)
