### PR TITLE
Fix Moody and Quark Drive

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2832,10 +2832,11 @@ export function initAbilities() {
       .attr(MovePowerBoostAbAttr, (user, target, move) => move.category === MoveCategory.PHYSICAL && (user.status?.effect === StatusEffect.POISON || user.status?.effect === StatusEffect.TOXIC), 1.5),
     new Ability(Abilities.FLARE_BOOST, 5)
       .attr(MovePowerBoostAbAttr, (user, target, move) => move.category === MoveCategory.SPECIAL && user.status?.effect === StatusEffect.BURN, 1.5),
-    new Ability(Abilities.HARVEST, 5),
+    new Ability(Abilities.HARVEST, 5)
+      .unimplemented(),
     new Ability(Abilities.TELEPATHY, 5)
-      .unimplemented()
-      .ignorable(),
+      .ignorable()
+      .unimplemented(),
     new Ability(Abilities.MOODY, 5)
       .attr(MoodyAbAttr),
     new Ability(Abilities.OVERCOAT, 5)

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -1773,7 +1773,7 @@ export class PostTerrainChangeAddBattlerTagAttr extends PostTerrainChangeAbAttr 
   }
 
   applyPostTerrainChange(pokemon: Pokemon, passive: boolean, terrain: TerrainType, args: any[]): boolean {
-    if (!this.terrainTypes.find(t => terrain === terrain))
+    if (!this.terrainTypes.find(t => t === terrain))
       return false;
 
     return pokemon.addTag(this.tagType, this.turnCount);
@@ -1804,6 +1804,23 @@ export class PostTurnResetStatusAbAttr extends PostTurnAbAttr {
     }
 	
     return false;
+  }
+}
+
+export class MoodyAbAttr extends PostTurnAbAttr {
+  constructor() {
+    super(true);
+  }
+
+  applyPostTurn(pokemon: Pokemon, passive: boolean, args: any[]): boolean {
+    // TODO: Edge case of not choosing to buff or debuff a stat that's already maxed
+    let selectableStats = [BattleStat.ATK, BattleStat.DEF, BattleStat.SPATK, BattleStat.SPDEF, BattleStat.SPD];
+    let increaseStat = selectableStats[Utils.randInt(selectableStats.length)];
+    selectableStats = selectableStats.filter(s => s !== increaseStat);
+    let decreaseStat = selectableStats[Utils.randInt(selectableStats.length)];
+    pokemon.scene.unshiftPhase(new StatChangePhase(pokemon.scene, pokemon.getBattlerIndex(), true, [increaseStat], 2));
+    pokemon.scene.unshiftPhase(new StatChangePhase(pokemon.scene, pokemon.getBattlerIndex(), true, [decreaseStat], -1));
+    return true;
   }
 }
 
@@ -2771,8 +2788,7 @@ export function initAbilities() {
     new Ability(Abilities.TELEPATHY, "Telepathy (N)", "Anticipates an ally's attack and dodges it.", 5)
       .ignorable(),
     new Ability(Abilities.MOODY, "Moody", "Raises one stat sharply and lowers another every turn.", 5)
-      .attr(PostTurnStatChangeAbAttr, BattleStat.RAND, 2)
-      .attr(PostTurnStatChangeAbAttr, BattleStat.RAND, -1),
+      .attr(MoodyAbAttr),
     new Ability(Abilities.OVERCOAT, "Overcoat", "Protects the Pokémon from things like sand, hail, and powder.", 5)
       .attr(BlockWeatherDamageAttr)
       .attr(MoveImmunityAbAttr, (pokemon, attacker, move) => pokemon !== attacker && move.getMove().hasFlag(MoveFlags.POWDER_MOVE))

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2834,6 +2834,7 @@ export function initAbilities() {
       .attr(MovePowerBoostAbAttr, (user, target, move) => move.category === MoveCategory.SPECIAL && user.status?.effect === StatusEffect.BURN, 1.5),
     new Ability(Abilities.HARVEST, 5),
     new Ability(Abilities.TELEPATHY, 5)
+      .unimplemented()
       .ignorable(),
     new Ability(Abilities.MOODY, 5)
       .attr(MoodyAbAttr),


### PR DESCRIPTION
* Quark Drive was triggering on all terrain instead of just electric terrain
* Moody was not picking random stats every turn. Right now it chooses a pair of stats and those are the only stats it will buff/debuff
* Moody could pick the same stat for buffing and debuffing
* Minor edge case in Moody for when stats are near the cap but I need to do more research and testing it will be easier with the stat change UI update