### PR TITLE
Change Unnerve to on-summon message

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2802,7 +2802,8 @@ export function initAbilities() {
       .attr(StatChangeMultiplierAbAttr, -1)
       .ignorable(),
     new Ability(Abilities.UNNERVE, 5)
-      .attr(PreventBerryUseAbAttr),
+      .attr(PreventBerryUseAbAttr)
+      .attr(PostSummonMessageAbAttr, (pokemon: Pokemon) => getPokemonMessage(pokemon, ' prevents eating berries!')),
     new Ability(Abilities.DEFIANT, 5)
       .attr(PostStatChangeStatChangeAbAttr, (target, statsChanged, levels) => levels < 0, [BattleStat.ATK], 2),
     new Ability(Abilities.DEFEATIST, 5)

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -878,7 +878,6 @@ export class BerryModifier extends PokemonHeldItemModifier {
     pokemon.getOpponents().map(opp => applyAbAttrs(PreventBerryUseAbAttr, opp, cancelled));
 
     if (cancelled.value) {
-      pokemon.scene.queueMessage(getPokemonMessage(pokemon, ' is too\nnervous to eat berries!'));
       return false;
     }
 

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -3813,8 +3813,8 @@ export class BerryPhase extends CommonAnimPhase {
             berryModifier.consumed = false;
           this.scene.updateModifiers(this.player);
         }
+        return super.start();
       }
-      return super.start();
     }
 
     this.end();


### PR DESCRIPTION
Quick and simple change because I got sick of the spam in my Endless run.

Also moved the `super.start()` call in `BerryPhase` so that the animation (and sound) is properly skipped when all berries are being skipped.