### PR TITLE
Implement localisation for main menu options (menu-ui-handler file) & add french locale

### DIFF
--- a/src/locales/en/menu-ui-handler.ts
+++ b/src/locales/en/menu-ui-handler.ts
@@ -1,0 +1,23 @@
+import { SimpleTranslationEntries } from "#app/plugins/i18n";
+
+export const menuUiHandler: SimpleTranslationEntries = {
+    "GAME_SETTINGS": 'Game Settings',
+    "ACHIEVEMENTS": "Achievements",
+    "STATS": "Stats",
+    "VOUCHERS": "Vouchers",
+    "EGG_LIST": "Egg List",
+    "EGG_GACHA": "Egg Gacha",
+    "MANAGE_DATA": "Manage Data",
+    "COMMUNITY": "Community",
+    "RETURN_TO_TITLE": "Return To Title",
+    "LOG_OUT": "Log Out",
+    "slot": "Slot {{slotNumber}}",
+    "importSession": "Import Session",
+    "importSlotSelect": "Select a slot to import to.",
+    "exportSession": "Export Session",
+    "exportSlotSelect": "Select a slot to export from.",
+    "importData": "Import Data",
+    "exportData": "Export Data",
+    "cancel": "Cancel",
+    "losingProgressionWarning": "You will lose any progress since the beginning of the battle. Proceed?"
+} as const;

--- a/src/locales/es/menu-ui-handler.ts
+++ b/src/locales/es/menu-ui-handler.ts
@@ -1,0 +1,23 @@
+import { SimpleTranslationEntries } from "#app/plugins/i18n";
+
+export const menuUiHandler: SimpleTranslationEntries = {
+    "GAME_SETTINGS": 'Game Settings',
+    "ACHIEVEMENTS": "Achievements",
+    "STATS": "Stats",
+    "VOUCHERS": "Vouchers",
+    "EGG_LIST": "Egg List",
+    "EGG_GACHA": "Egg Gacha",
+    "MANAGE_DATA": "Manage Data",
+    "COMMUNITY": "Community",
+    "RETURN_TO_TITLE": "Return To Title",
+    "LOG_OUT": "Log Out",
+    "slot": "Slot {{slotNumber}}",
+    "importSession": "Import Session",
+    "importSlotSelect": "Select a slot to import to.",
+    "exportSession": "Export Session",
+    "exportSlotSelect": "Select a slot to export from.",
+    "importData": "Import Data",
+    "exportData": "Export Data",
+    "cancel": "Cancel",
+    "losingProgressionWarning": "You will lose any progress since the beginning of the battle. Proceed?"
+} as const;

--- a/src/locales/fr/menu-ui-handler.ts
+++ b/src/locales/fr/menu-ui-handler.ts
@@ -1,0 +1,23 @@
+import { SimpleTranslationEntries } from "#app/plugins/i18n";
+
+export const menuUiHandler: SimpleTranslationEntries = {
+    "GAME_SETTINGS": 'Options',
+    "ACHIEVEMENTS": "Succès",
+    "STATS": "Statistiques",
+    "VOUCHERS": "Coupons",
+    "EGG_LIST": "Liste des œufs",
+    "EGG_GACHA": "Gacha-œufs",
+    "MANAGE_DATA": "Gestion données",
+    "COMMUNITY": "Communauté",
+    "RETURN_TO_TITLE": "Écran titre",
+    "LOG_OUT": "Se déconnecter",
+    "slot": "Emplacement {{slotNumber}}",
+    "importSession": "Importer session",
+    "importSlotSelect": "Sélectionnez l'emplacement depuis lequel importer.",
+    "exportSession": "Exporter session",
+    "exportSlotSelect": "Sélectionnez l'emplacement vers lequel exporter.",
+    "importData": "Importer données",
+    "exportData": "Exporter données",
+    "cancel": "Retour",
+    "losingProgressionWarning": "Vous allez perdre votre progression depuis le début du combat. Continuer?"
+} as const;

--- a/src/locales/it/menu-ui-handler.ts
+++ b/src/locales/it/menu-ui-handler.ts
@@ -1,0 +1,23 @@
+import { SimpleTranslationEntries } from "#app/plugins/i18n";
+
+export const menuUiHandler: SimpleTranslationEntries = {
+    "GAME_SETTINGS": 'Game Settings',
+    "ACHIEVEMENTS": "Achievements",
+    "STATS": "Stats",
+    "VOUCHERS": "Vouchers",
+    "EGG_LIST": "Egg List",
+    "EGG_GACHA": "Egg Gacha",
+    "MANAGE_DATA": "Manage Data",
+    "COMMUNITY": "Community",
+    "RETURN_TO_TITLE": "Return To Title",
+    "LOG_OUT": "Log Out",
+    "slot": "Slot {{slotNumber}}",
+    "importSession": "Import Session",
+    "importSlotSelect": "Select a slot to import to.",
+    "exportSession": "Export Session",
+    "exportSlotSelect": "Select a slot to export from.",
+    "importData": "Import Data",
+    "exportData": "Export Data",
+    "cancel": "Cancel",
+    "losingProgressionWarning": "You will lose any progress since the beginning of the battle. Proceed?"
+} as const;

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -4,6 +4,11 @@ import { menu as esMenu } from '../locales/es/menu';
 import { menu as itMenu } from '../locales/it/menu';
 import { menu as frMenu } from '../locales/fr/menu';
 
+import { menuUiHandler as enMenuUiHandler } from '../locales/en/menu-ui-handler.js';
+import { menuUiHandler as esMenuUiHandler } from '../locales/es/menu-ui-handler.js';
+import { menuUiHandler as frMenuUiHandler } from '../locales/fr/menu-ui-handler.js';
+import { menuUiHandler as itMenuUiHandler } from '../locales/it/menu-ui-handler.js';
+
 import { move as enMove } from '../locales/en/move';
 import { move as esMove } from '../locales/es/move';
 import { move as frMove } from '../locales/fr/move';
@@ -86,6 +91,7 @@ export function initI18n(): void {
     resources: {
       en: {
         menu: enMenu,
+        menuUiHandler: enMenuUiHandler,
         move: enMove,
         ability: enAbility,
         pokeball: enPokeball,
@@ -95,6 +101,7 @@ export function initI18n(): void {
       },
       es: {
         menu: esMenu,
+        menuUiHandler: esMenuUiHandler,
         move: esMove,
         ability: esAbility,
         pokeball: esPokeball,
@@ -104,6 +111,7 @@ export function initI18n(): void {
       },
       fr: {
         menu: frMenu,
+        menuUiHandler: frMenuUiHandler,
         move: frMove,
         ability: frAbility,
         pokeball: frPokeball,
@@ -113,6 +121,7 @@ export function initI18n(): void {
       },
       it: {
         menu: itMenu,
+        menuUiHandler: itMenuUiHandler,
         pokemonStat: itPokemonStat,
       },
     },
@@ -124,6 +133,7 @@ declare module 'i18next' {
   interface CustomTypeOptions {
     resources: {
       menu: typeof enMenu;
+      menuUiHandler: typeof enMenuUiHandler;
       move: typeof enMove;
       ability: typeof enAbility;
       pokeball: typeof enPokeball;

--- a/src/ui/menu-ui-handler.ts
+++ b/src/ui/menu-ui-handler.ts
@@ -8,6 +8,7 @@ import { GameDataType } from "../system/game-data";
 import { OptionSelectConfig, OptionSelectItem } from "./abstact-option-select-ui-handler";
 import { Tutorial, handleTutorial } from "../tutorial";
 import { updateUserInfo } from "../account";
+import i18next from '../plugins/i18n';
 
 export enum MenuOptions {
   GAME_SETTINGS,
@@ -62,7 +63,7 @@ export default class MenuUiHandler extends MessageUiHandler {
 
     this.menuContainer.add(this.menuBg);
 
-    this.optionSelectText = addTextObject(this.scene, 0, 0, this.menuOptions.map(o => Utils.toReadableString(MenuOptions[o])).join('\n'), TextStyle.WINDOW, { maxLines: this.menuOptions.length });
+    this.optionSelectText = addTextObject(this.scene, 0, 0, this.menuOptions.map(o => `${i18next.t(`menuUiHandler:${MenuOptions[o]}`)}`).join('\n'), TextStyle.WINDOW, { maxLines: this.menuOptions.length });
     this.optionSelectText.setPositionRelative(this.menuBg, 14, 6);
     this.optionSelectText.setLineSpacing(12);
     this.menuContainer.add(this.optionSelectText);
@@ -94,7 +95,7 @@ export default class MenuUiHandler extends MessageUiHandler {
         const config: OptionSelectConfig = {
           options: new Array(3).fill(null).map((_, i) => i).filter(slotFilter).map(i => {
             return {
-              label: `Slot ${i + 1}`,
+              label: i18next.t('menuUiHandler:slot', {slotNumber: i+1}),
               handler: () => {
                 callback(i);
                 ui.revertMode();
@@ -103,7 +104,7 @@ export default class MenuUiHandler extends MessageUiHandler {
               }
             };
           }).concat([{
-            label: 'Cancel',
+            label: i18next.t('menuUiHandler:cancel'),
             handler: () => {
               ui.revertMode();
               ui.showText(null, 0);
@@ -118,16 +119,16 @@ export default class MenuUiHandler extends MessageUiHandler {
 
     if (Utils.isLocal) {
       manageDataOptions.push({
-        label: 'Import Session',
+        label: i18next.t("menuUiHandler:importSession"),
         handler: () => {
-          confirmSlot('Select a slot to import to.', () => true, slotId => this.scene.gameData.importData(GameDataType.SESSION, slotId));
+          confirmSlot(i18next.t("menuUiHandler:importSlotSelect"), () => true, slotId => this.scene.gameData.importData(GameDataType.SESSION, slotId));
           return true;
         },
         keepOpen: true
       });
     }
     manageDataOptions.push({
-      label: 'Export Session',
+      label: i18next.t("menuUiHandler:exportSession"),
       handler: () => {
         const dataSlots: integer[] = [];
         Promise.all(
@@ -138,7 +139,7 @@ export default class MenuUiHandler extends MessageUiHandler {
                 dataSlots.push(slotId);
             })
           })).then(() => {
-            confirmSlot('Select a slot to export from.',
+            confirmSlot(i18next.t("menuUiHandler:exportSlotSelect"),
               i => dataSlots.indexOf(i) > -1,
               slotId => this.scene.gameData.tryExportData(GameDataType.SESSION, slotId));
           });
@@ -148,7 +149,7 @@ export default class MenuUiHandler extends MessageUiHandler {
     });
     if (Utils.isLocal) {
       manageDataOptions.push({
-        label: 'Import Data',
+        label: i18next.t("menuUiHandler:importData"),
         handler: () => {
           this.scene.gameData.importData(GameDataType.SYSTEM);
           return true;
@@ -158,7 +159,7 @@ export default class MenuUiHandler extends MessageUiHandler {
     }
     manageDataOptions.push(
       {
-        label: 'Export Data',
+        label: i18next.t("menuUiHandler:exportData"),
         handler: () => {
           this.scene.gameData.tryExportData(GameDataType.SYSTEM);
           return true;
@@ -166,7 +167,7 @@ export default class MenuUiHandler extends MessageUiHandler {
         keepOpen: true
       },
       {
-        label: 'Cancel',
+        label: i18next.t('menuUiHandler:cancel'),
         handler: () => {
           this.scene.ui.revertMode();
           return true;
@@ -205,7 +206,7 @@ export default class MenuUiHandler extends MessageUiHandler {
         keepOpen: true
       },
       {
-        label: 'Cancel',
+        label: i18next.t('menuUiHandler:cancel'),
         handler: () => {
           this.scene.ui.revertMode();
           return true;
@@ -295,7 +296,7 @@ export default class MenuUiHandler extends MessageUiHandler {
         case MenuOptions.RETURN_TO_TITLE:
           if (this.scene.currentBattle) {
             success = true;
-            ui.showText('You will lose any progress since the beginning of the battle. Proceed?', null, () => {
+            ui.showText(i18next.t("menuUiHandler:losingProgressionWarning"), null, () => {
               ui.setOverlayMode(Mode.CONFIRM, () => this.scene.reset(true), () => {
                 ui.revertMode();
                 ui.showText(null, 0);
@@ -315,7 +316,7 @@ export default class MenuUiHandler extends MessageUiHandler {
             });
           };
           if (this.scene.currentBattle) {
-            ui.showText('You will lose any progress since the beginning of the battle. Proceed?', null, () => {
+            ui.showText(i18next.t("menuUiHandler:losingProgressionWarning"), null, () => {
               ui.setOverlayMode(Mode.CONFIRM, doLogout, () => {
                 ui.revertMode();
                 ui.showText(null, 0);


### PR DESCRIPTION
- Implements i18n localisation on "menu-ui-handler" file that handles the main menu options.
- Adds "menu-ui-handler" locale files for all supported languages using the english locale as a base.
- Modifies the newly created french "menu-ui-handler" locale file to add a 1st french translation.