### PR TITLE
Modification of the fr translation for menu-ui-handler

### DIFF
--- a/src/locales/fr/menu-ui-handler.ts
+++ b/src/locales/fr/menu-ui-handler.ts
@@ -7,17 +7,17 @@ export const menuUiHandler: SimpleTranslationEntries = {
     "VOUCHERS": "Coupons",
     "EGG_LIST": "Liste des œufs",
     "EGG_GACHA": "Gacha-œufs",
-    "MANAGE_DATA": "Gestion données",
+    "MANAGE_DATA": "Mes données",
     "COMMUNITY": "Communauté",
     "RETURN_TO_TITLE": "Écran titre",
-    "LOG_OUT": "Se déconnecter",
+    "LOG_OUT": "Déconnexion",
     "slot": "Emplacement {{slotNumber}}",
     "importSession": "Importer session",
-    "importSlotSelect": "Sélectionnez l'emplacement depuis lequel importer.",
+    "importSlotSelect": "Sélectionnez l'emplacement vers lequel importer les données.",
     "exportSession": "Exporter session",
-    "exportSlotSelect": "Sélectionnez l'emplacement vers lequel exporter.",
+    "exportSlotSelect": "Sélectionnez l'emplacement depuis lequel exporter les données.",
     "importData": "Importer données",
     "exportData": "Exporter données",
     "cancel": "Retour",
-    "losingProgressionWarning": "Vous allez perdre votre progression depuis le début du combat. Continuer?"
+    "losingProgressionWarning": "Vous allez perdre votre progression depuis le début du combat. Continuer ?"
 } as const;


### PR DESCRIPTION
## Changes
- Modification of the fr translation for menu-ui-handler in `src/locales/fr/menu-ui-handler.ts`
  - Reduction of `MANAGE_DATA` and `LOG_OUT` strings to avoid overflowing the window border
    > Before
![2024-04-25_21-01](https://github.com/pagefaultgames/pokerogue/assets/8146474/dccc1a7c-8825-4924-a121-dc032815d456)
    > After
![2024-04-25_21-04](https://github.com/pagefaultgames/pokerogue/assets/8146474/48cad75d-587e-4110-aed5-f11ae6995619)
  - Added missing space for `losingProgressionWarning`.
  - Inversion of words in `importSlotSelect` and `exportSlotSelect` strings + sentence completion to make it clearer
    > Before
![2024-04-25_21-08](https://github.com/pagefaultgames/pokerogue/assets/8146474/896e4dbf-401a-4923-ba1c-ca0a6c282dee)
    > After
![2024-04-25_21-10](https://github.com/pagefaultgames/pokerogue/assets/8146474/863029d4-45b7-43e4-8eb2-b042f6a51587)