### PR TITLE
Assurance effect implementation

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -430,6 +430,7 @@ export class PostDefendDisguiseAbAttr extends PostDefendAbAttr {
       if (!recoilDamage)
         return false;
       pokemon.damageAndUpdate(recoilDamage, HitResult.OTHER);
+      pokemon.turnData.damageTaken += recoilDamage;
       pokemon.scene.queueMessage(getPokemonMessage(pokemon, '\'s disguise was busted!'));
       return true;
     }
@@ -710,6 +711,7 @@ export class PostDefendContactDamageAbAttr extends PostDefendAbAttr {
   applyPostDefend(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: PokemonMove, hitResult: HitResult, args: any[]): boolean {
     if (move.getMove().checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)) {
       attacker.damageAndUpdate(Math.ceil(attacker.getMaxHp() * (1 / this.damageRatio)), HitResult.OTHER);
+      attacker.turnData.damageTaken += Math.ceil(attacker.getMaxHp() * (1 / this.damageRatio));
       return true;
     }
     
@@ -2018,6 +2020,7 @@ export class PostFaintContactDamageAbAttr extends PostFaintAbAttr {
   applyPostFaint(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: PokemonMove, hitResult: HitResult, args: any[]): boolean {
     if (move.getMove().checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)) {
       attacker.damageAndUpdate(Math.ceil(attacker.getMaxHp() * (1 / this.damageRatio)), HitResult.OTHER);
+      attacker.turnData.damageTaken += Math.ceil(attacker.getMaxHp() * (1 / this.damageRatio));
       return true;
     }
 

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -252,6 +252,7 @@ class SpikesTag extends ArenaTrapTag {
 
         pokemon.scene.queueMessage(getPokemonMessage(pokemon, ' is hurt\nby the spikes!'));
         pokemon.damageAndUpdate(damage, HitResult.OTHER);
+        pokemon.turnData.damageTaken += damage;
         return true;
       }
     }
@@ -382,6 +383,7 @@ class StealthRockTag extends ArenaTrapTag {
       const damage = Math.ceil(pokemon.getMaxHp() * damageHpRatio);
       pokemon.scene.queueMessage(`Pointed stones dug into\n${pokemon.name}!`);
       pokemon.damageAndUpdate(damage, HitResult.OTHER);
+      pokemon.turnData.damageTaken += damage;
     }
 
     return false;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -695,6 +695,7 @@ export class RecoilAttr extends MoveEffectAttr {
       
     user.damageAndUpdate(recoilDamage, HitResult.OTHER, false, true, true);
     user.scene.queueMessage(getPokemonMessage(user, ' is hit\nwith recoil!'));
+	user.turnData.damageTaken += recoilDamage;
 
     return true;
   }
@@ -714,6 +715,7 @@ export class SacrificialAttr extends MoveEffectAttr {
       return false;
 
     user.damageAndUpdate(user.hp, HitResult.OTHER, false, true, true);
+	user.turnData.damageTaken += user.hp;
 
     return true;
   }
@@ -850,6 +852,7 @@ export class HitHealAttr extends MoveEffectAttr {
       !reverseDrain ? healAmount : healAmount * -1,
       !reverseDrain ? getPokemonMessage(target, ` had its\nenergy drained!`) : undefined,
       false, true));
+    if (reverseDrain) user.turnData.damageTaken += healAmount;
     return true;
   }
 
@@ -2350,6 +2353,7 @@ const crashDamageFunc = (user: Pokemon, move: Move) => {
   
   user.damageAndUpdate(Math.floor(user.getMaxHp() / 2), HitResult.OTHER, false, true);
   user.scene.queueMessage(getPokemonMessage(user, ' kept going\nand crashed!'));
+  user.turnData.damageTaken += Math.floor(user.getMaxHp() / 2);
   
   return true;
 };
@@ -4699,7 +4703,7 @@ export function initMoves() {
     new AttackMove(Moves.PAYBACK, Type.DARK, MoveCategory.PHYSICAL, 50, 100, 10, -1, 0, 4)
     .attr(MovePowerMultiplierAttr, (user, target, move) => target.getLastXMoves(1).find(m => m.turn === target.scene.currentBattle.turn) || user.scene.currentBattle.turnCommands[target.getBattlerIndex()].command === Command.BALL ? 2 : 1),  
     new AttackMove(Moves.ASSURANCE, Type.DARK, MoveCategory.PHYSICAL, 60, 100, 10, -1, 0, 4)
-      .partial(),
+      .attr(MovePowerMultiplierAttr, (user, target, move) => target.turnData.damageTaken > 0 ? 2 : 1),
     new StatusMove(Moves.EMBARGO, Type.DARK, 100, 15, -1, 0, 4)
       .unimplemented(),
     new AttackMove(Moves.FLING, Type.DARK, MoveCategory.PHYSICAL, -1, 100, 10, -1, 0, 4)

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1389,6 +1389,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
             const oneHitKo = result === HitResult.ONE_HIT_KO;
             damage.value = this.damageAndUpdate(damage.value, result as DamageResult, isCritical, oneHitKo, oneHitKo);
+            this.turnData.damageTaken += damage.value;
             if (isCritical)
               this.scene.queueMessage('A critical hit!');
             this.scene.setPhaseQueueSplice();
@@ -2974,6 +2975,7 @@ export class PokemonTurnData {
   public hitCount: integer;
   public hitsLeft: integer;
   public damageDealt: integer = 0;
+  public damageTaken: integer = 0;
   public attacksReceived: AttackMoveResult[] = [];
 }
 


### PR DESCRIPTION
Tested and functional in the following scenarios:
- Regular damage
- Recoil damage
- Crash damage (i.e. Hi Jump Kick)
- Contact damage (i.e. Rough Skin)
- Entry Hazards
- Aftermath
- Disguise 1/8 recoil damage

It should not work, and does not, in the following scenarios:
- Belly Drum
- Pain Split
- Clangorous Soul/Fillet Away
- Confusion self-damage

It is impossible to trigger in the following scenarios, and so is unimplemented there:
- Burn/Poison
- Other end-of-turn damage (Solar Power, Sandstorm)

It should work for Liquid Ooze damage, but it is impossible to verify this as Liquid Ooze does not currently work.

It is also theoretically implemented for Explosion, but it is currently impossible to survive Explosion even with Reviver Seeds.  If such becomes possible, this should likely work for that too.

I am not aware of any other use cases in PokeRogue, to implement or rule out, but cannot be fully certain.