### PR TITLE
Fixed entry hazard crash

### DIFF
--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -252,7 +252,7 @@ class SpikesTag extends ArenaTrapTag {
 
         pokemon.scene.queueMessage(getPokemonMessage(pokemon, ' is hurt\nby the spikes!'));
         pokemon.damageAndUpdate(damage, HitResult.OTHER);
-        pokemon.turnData.damageTaken += damage;
+        if (pokemon.turnData) pokemon.turnData.damageTaken += damage;
         return true;
       }
     }
@@ -383,7 +383,7 @@ class StealthRockTag extends ArenaTrapTag {
       const damage = Math.ceil(pokemon.getMaxHp() * damageHpRatio);
       pokemon.scene.queueMessage(`Pointed stones dug into\n${pokemon.name}!`);
       pokemon.damageAndUpdate(damage, HitResult.OTHER);
-      pokemon.turnData.damageTaken += damage;
+      if (pokemon.turnData) pokemon.turnData.damageTaken += damage;
     }
 
     return false;


### PR DESCRIPTION
Having Spikes or Stealth Rock on the field when a new wild battle starts no longer crashes the game.