### PR TITLE
Make grass types unable to be seeded

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -276,6 +276,10 @@ export class SeedTag extends BattlerTag {
     super(BattlerTagType.SEEDED, BattlerTagLapseType.TURN_END, 1, Moves.LEECH_SEED, sourceId);
   }
 
+  canAdd(pokemon: Pokemon): boolean {
+    return !pokemon.isOfType(Type.GRASS);
+  }
+
   onAdd(pokemon: Pokemon): void {
     super.onAdd(pokemon);
     


### PR DESCRIPTION
Leech seed was checking specifically, but sappy seed was not.