### PR TITLE
Implements telepathy

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2851,8 +2851,8 @@ export function initAbilities() {
     new Ability(Abilities.HARVEST, 5)
       .unimplemented(),
     new Ability(Abilities.TELEPATHY, 5)
-      .ignorable()
-      .unimplemented(),
+      .attr(MoveImmunityAbAttr, (pokemon, attacker, move) => pokemon.getAlly() === attacker && move.getMove() instanceof AttackMove)
+      .ignorable(),
     new Ability(Abilities.MOODY, 5)
       .attr(MoodyAbAttr),
     new Ability(Abilities.OVERCOAT, 5)


### PR DESCRIPTION
Went off of the showdown description of "This Pokemon does not take damage from attacks made by its allies."
Wasn't sure if this meant that they were completely immune to the damaging moves, or if they just hit them with 0 damage. Anyone know which it is? This currently just makes them immune to the move as it stands.

Tested and verified to work for both the player side and enemy side with this setup.
![image](https://github.com/pagefaultgames/pokerogue/assets/16782886/e058b728-f8c6-41e7-a477-4938b4f2f100)
