### PR TITLE
Bug Fix: Stopped blackscreens and softlocks during learn move cancel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pokemon-rogue-battle",
-	"version": "1.0.1",
+	"version": "1.0.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pokemon-rogue-battle",
-			"version": "1.0.1",
+			"version": "1.0.3",
 			"dependencies": {
 				"@material/material-color-utilities": "^0.2.7",
 				"crypto-js": "^4.2.0",

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -376,8 +376,13 @@ export default class SummaryUiHandler extends UiHandler {
           success = true;
         }
       } else if (button === Button.CANCEL) {
-        ui.setMode(Mode.PARTY);
-        success = true;
+        if (this.summaryUiMode === SummaryUiMode.LEARN_MOVE){
+          this.hideMoveSelect();
+          success = true;
+        } else {
+          ui.setMode(Mode.PARTY);
+          success = true;
+        }
       } else {
         const pages = Utils.getEnumValues(Page);
         switch (button) {


### PR DESCRIPTION
Added a conditional if statement for checking if the user is in SummaryUIMode.LEARN_MOVE when pressing the exit/back button whilst viewing the stats of a pokemon during the LearnMovePhase. 
It wasn't checking for this before, so if a user pressed Button.CANCEL it would assume the user was exiting from the party menu stats screen of a pokemon rather than the LEARN_MOVE UI, which caused a softlock/blackscreen for users. 
Saw quite a few bug reports of this.