### PR TITLE
Auto select language implementation

### DIFF
--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -75,7 +75,7 @@ export interface Localizable {
 const DEFAULT_LANGUAGE_OVERRIDE = '';
 
 export function initI18n(): void {
-  let lang = 'en';
+  let lang = navigator.language;
 
   if (localStorage.getItem('prLang'))
     lang = localStorage.getItem('prLang');


### PR DESCRIPTION
Selects the display language according to the browser language. If this language is not supported, english will be used instead.