### PR TITLE
Implementing Gen 6 Toxic Changes

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2760,7 +2760,6 @@ export class HitsTagAttr extends MoveAttr {
 export class ToxicHitAttr extends HitsTagAttr {
     apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
       if (user.isOfType(Type.POISON)) {
-        this.getTargetBenefitScore(user, target, move)
         return true;
       }
       return false;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2757,6 +2757,16 @@ export class HitsTagAttr extends MoveAttr {
   }
 }
 
+export class ToxicHitAttr extends HitsTagAttr {
+    apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+      if (user.isOfType(Type.POISON)) {
+        this.getTargetBenefitScore(user, target, move)
+        return true;
+      }
+      return false;
+    }
+}
+
 export class AddArenaTagAttr extends MoveEffectAttr {
   public tagType: ArenaTagType;
   public turnCount: integer;
@@ -3969,7 +3979,11 @@ export function initMoves() {
       .ignoresVirtual(),
     new StatusMove(Moves.TOXIC, Type.POISON, 90, 10, -1, 0, 1)
       .attr(StatusEffectAttr, StatusEffect.TOXIC)
-      .attr(ToxicAccuracyAttr),
+      .attr(ToxicAccuracyAttr)
+      .attr(ToxicHitAttr, BattlerTagType.FLYING)
+      .attr(ToxicHitAttr, BattlerTagType.UNDERGROUND)
+      .attr(ToxicHitAttr, BattlerTagType.UNDERWATER)
+      .attr(ToxicHitAttr, BattlerTagType.HIDDEN),
     new AttackMove(Moves.CONFUSION, Type.PSYCHIC, MoveCategory.SPECIAL, 50, 100, 25, 10, 0, 1)
       .attr(ConfuseAttr),
     new AttackMove(Moves.PSYCHIC, Type.PSYCHIC, MoveCategory.SPECIAL, 90, 100, 10, 10, 0, 1)


### PR DESCRIPTION
Toxic, until raids/Z crystals are added, is completely implemented. 

I added a HitAttr that allows Poison type Pokemon to hit semi invulnerable state Pokemon. It accounts for Flying, Underground, Underwater, as well as Hidden Pokemon. 

From the Bulbapedia page: _If Toxic is used by a Poison-type Pokémon, that move will never miss, even if the target is in the semi-invulnerable turn of a move such as Fly or Dig._
 