### PR TITLE
Fix frenzy moves like Outrage lasting 4 turns sometimes

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2466,7 +2466,7 @@ export class FrenzyAttr extends MoveEffectAttr {
 
     if (!user.getMoveQueue().length) {
       if (!user.getTag(BattlerTagType.FRENZY)) {
-        const turnCount = user.randSeedIntRange(2, 3);
+        const turnCount = user.randSeedIntRange(1, 2);
         new Array(turnCount).fill(null).map(() => user.getMoveQueue().push({ move: move.id, targets: [ target.getBattlerIndex() ], ignorePP: true }));
         user.addTag(BattlerTagType.FRENZY, 1, move.id, user.id);
       } else {


### PR DESCRIPTION
Currently, the game generates a random number from 2 to 3, and pushes the frenzy move to the attacker's move queue _after_ the first hit, meaning these moves actually hit 3-4 times in total. I changed the random number range to 1 to 2, as the first hit should count as one of the 2-3 hits.