### PR TITLE
Fixed Fake Out + Pivot move interaction

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1420,10 +1420,9 @@ export class SwitchSummonPhase extends SummonPhase {
     super.onEnd();
 
     const pokemon = this.getPokemon();
-  
-    const moveId = pokemon.scene.currentBattle.turnCommands[this.fieldIndex]?.move?.move
+    const moveId = pokemon.scene.currentBattle.turnCommands[this.fieldIndex]?.move?.move;
     const lastUsedMove = moveId ? allMoves[moveId] : undefined;
-    
+
     // Compensate for turn spent summoning
     if (pokemon.scene.currentBattle.turnCommands[this.fieldIndex]?.command === Command.POKEMON || !!lastUsedMove?.findAttr(attr => attr instanceof ForceSwitchOutAttr)) //check if hard switch OR pivot move was used
       pokemon.battleSummonData.turnCount--;

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2,7 +2,7 @@ import BattleScene, { STARTER_FORM_OVERRIDE, STARTER_SPECIES_OVERRIDE, bypassLog
 import { default as Pokemon, PlayerPokemon, EnemyPokemon, PokemonMove, MoveResult, DamageResult, FieldPosition, HitResult, TurnMove } from "./field/pokemon";
 import * as Utils from './utils';
 import { Moves } from "./data/enums/moves";
-import { allMoves, applyMoveAttrs, BypassSleepAttr, ChargeAttr, applyFilteredMoveAttrs, HitsTagAttr, MissEffectAttr, MoveAttr, MoveEffectAttr, MoveFlags, MultiHitAttr, OverrideMoveEffectAttr, VariableAccuracyAttr, MoveTarget, OneHitKOAttr, getMoveTargets, MoveTargetSet, MoveEffectTrigger, CopyMoveAttr, AttackMove, SelfStatusMove, DelayedAttackAttr, RechargeAttr, PreMoveMessageAttr, HealStatusEffectAttr, IgnoreOpponentStatChangesAttr, NoEffectAttr, FixedDamageAttr, OneHitKOAccuracyAttr } from "./data/move";
+import { allMoves, applyMoveAttrs, BypassSleepAttr, ChargeAttr, applyFilteredMoveAttrs, HitsTagAttr, MissEffectAttr, MoveAttr, MoveEffectAttr, MoveFlags, MultiHitAttr, OverrideMoveEffectAttr, VariableAccuracyAttr, MoveTarget, OneHitKOAttr, getMoveTargets, MoveTargetSet, MoveEffectTrigger, CopyMoveAttr, AttackMove, SelfStatusMove, DelayedAttackAttr, RechargeAttr, PreMoveMessageAttr, HealStatusEffectAttr, IgnoreOpponentStatChangesAttr, NoEffectAttr, FixedDamageAttr, OneHitKOAccuracyAttr, ForceSwitchOutAttr } from "./data/move";
 import { Mode } from './ui/ui';
 import { Command } from "./ui/command-ui-handler";
 import { Stat } from "./data/pokemon-stat";
@@ -1420,9 +1420,12 @@ export class SwitchSummonPhase extends SummonPhase {
     super.onEnd();
 
     const pokemon = this.getPokemon();
-
+  
+    const moveId = pokemon.scene.currentBattle.turnCommands[this.fieldIndex]?.move?.move
+    const lastUsedMove = moveId ? allMoves[moveId] : undefined;
+    
     // Compensate for turn spent summoning
-    if (pokemon.scene.currentBattle.turnCommands[this.fieldIndex]?.command === Command.POKEMON)
+    if (pokemon.scene.currentBattle.turnCommands[this.fieldIndex]?.command === Command.POKEMON || !!lastUsedMove?.findAttr(attr => attr instanceof ForceSwitchOutAttr)) //check if hard switch OR pivot move was used
       pokemon.battleSummonData.turnCount--;
 
     if (this.batonPass && pokemon)


### PR DESCRIPTION
Currently Fake Out will fail after switching out with a move such as U-Turn, Volt Switch or Baton Pass as they enter the field with a turnCount == 1. As Pokemon cannot act on the same turn they are switched in by this method, they are unable to act until their turnCount == 2, meaning Fake Out will always fail. 

This is not the case for hard switches however, as the incoming Pokemon's turnCount is decremented to compensate for this when the switch was caused by `Command.POKEMON`.  This PR extends this to Pokemon switched in with pivoting moves by checking to see if a move with `ForceSwitchOutAttr` was used from the Pokemon's field index on the turn of the switch. 

Additionally, this will greatly simplify the implementation of some other moves and abilities, namely Stakeout and Analytic, which currently suffer from having no clean way of checking to see if a Pokemon switched in with a pivot move.

I think this is a relatively clean and elegant solution but please let me know if you can think of any potential edge cases or side effects that this may cause.