### PR TITLE
Implented Gen VII Sheer Cold Changes

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2333,7 +2333,7 @@ export class IceNoEffectTypeMultiplierAttr extends VariableMoveTypeMultiplierAtt
    apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const multiplier = args[0] as Utils.NumberHolder;
     if (target.isOfType(Type.ICE)) {
-      multiplier.value *= 0; // Increased twice because initial reduction against water
+      multiplier.value = 0;
       return true;
     }
     return false;
@@ -4653,7 +4653,8 @@ export function initMoves() {
     new AttackMove(Moves.SAND_TOMB, Type.GROUND, MoveCategory.PHYSICAL, 35, 85, 15, 100, 0, 3)
       .attr(TrapAttr, BattlerTagType.SAND_TOMB)
       .makesContact(false),
-      new AttackMove(Moves.SHEER_COLD, Type.ICE, MoveCategory.SPECIAL, 200, 20, 5, -1, 0, 3)
+    new AttackMove(Moves.SHEER_COLD, Type.ICE, MoveCategory.SPECIAL, 200, 20, 5, -1, 0, 3)
+      .attr(OneHitKOAttr)
       .attr(IceNoEffectTypeMultiplierAttr)
       .attr(SheerColdAttr),
     new AttackMove(Moves.MUDDY_WATER, Type.WATER, MoveCategory.SPECIAL, 90, 85, 10, 30, 0, 3)

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2349,17 +2349,21 @@ export class OneHitKOAccuracyAttr extends VariableAccuracyAttr {
 }
 
 export class SheerColdAttr extends OneHitKOAccuracyAttr {
-    apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-        const accuracy = args[0] as Utils.NumberHolder;
-        if (!target.isOfType(Type.ICE)) {
-            if (user.level < target.level)
-                accuracy.value = 0;
-            else
-                accuracy.value = Math.min(Math.max(30 + 100 * (1 - target.level / user.level), 0), 100);
-            return true;
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    const accuracy = args[0] as Utils.NumberHolder;
+    if (!target.isOfType(Type.ICE)) {
+      if (user.level < target.level)
+        accuracy.value = 0;
+      else {
+        if (user.isOfType(Type.ICE))
+          accuracy.value = Math.min(Math.max(30 + 100 * (1 - target.level / user.level), 0), 100);
+        else
+          accuracy.value = Math.min(Math.max(20 + 100 * (1 - target.level / user.level), 0), 100);
         }
-        return false;
+    return true;
     }
+  return false;
+  }
 }
 
 export class MissEffectAttr extends MoveAttr {

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2329,6 +2329,17 @@ export class WaterSuperEffectTypeMultiplierAttr extends VariableMoveTypeMultipli
   }
 }
 
+export class IceNoEffectTypeMultiplierAttr extends VariableMoveTypeMultiplierAttr {
+   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    const multiplier = args[0] as Utils.NumberHolder;
+    if (target.isOfType(Type.ICE)) {
+      multiplier.value *= 0; // Increased twice because initial reduction against water
+      return true;
+    }
+    return false;
+  }
+}
+
 export class FlyingTypeMultiplierAttr extends VariableMoveTypeMultiplierAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const multiplier = args[0] as Utils.NumberHolder;
@@ -2351,18 +2362,17 @@ export class OneHitKOAccuracyAttr extends VariableAccuracyAttr {
 export class SheerColdAttr extends OneHitKOAccuracyAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const accuracy = args[0] as Utils.NumberHolder;
-    if (!target.isOfType(Type.ICE)) {
-      if (user.level < target.level)
-        accuracy.value = 0;
-      else {
-        if (user.isOfType(Type.ICE))
-          accuracy.value = Math.min(Math.max(30 + 100 * (1 - target.level / user.level), 0), 100);
-        else
-          accuracy.value = Math.min(Math.max(20 + 100 * (1 - target.level / user.level), 0), 100);
-        }
+      if (user.level < target.level) {
+          accuracy.value = 0;
+      } else { 
+          if (user.isOfType(Type.ICE)) {
+              accuracy.value = Math.min(Math.max(30 + 100 * (1 - target.level / user.level), 0), 100);
+          }
+          else {
+              accuracy.value = Math.min(Math.max(20 + 100 * (1 - target.level / user.level), 0), 100);
+          }
+      }
     return true;
-    }
-  return false;
   }
 }
 
@@ -4643,7 +4653,8 @@ export function initMoves() {
     new AttackMove(Moves.SAND_TOMB, Type.GROUND, MoveCategory.PHYSICAL, 35, 85, 15, 100, 0, 3)
       .attr(TrapAttr, BattlerTagType.SAND_TOMB)
       .makesContact(false),
-    new AttackMove(Moves.SHEER_COLD, Type.ICE, MoveCategory.SPECIAL, 200, 30, 5, -1, 0, 3)
+      new AttackMove(Moves.SHEER_COLD, Type.ICE, MoveCategory.SPECIAL, 200, 20, 5, -1, 0, 3)
+      .attr(IceNoEffectTypeMultiplierAttr)
       .attr(SheerColdAttr),
     new AttackMove(Moves.MUDDY_WATER, Type.WATER, MoveCategory.SPECIAL, 90, 85, 10, 30, 0, 3)
       .attr(StatChangeAttr, BattleStat.ACC, -1)

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2374,7 +2374,7 @@ export class SheerColdAccuracyAttr extends OneHitKOAccuracyAttr {
    * @param {Pokemon} target Pokemon that is receiving the move; checks the Pokemon's level.
    * @param {Move} move N/A 
    * @param {any[]} args Uses the accuracy argument, allowing to change it from either 0 if it doesn't pass
-   * the first if/else, and either the first value if the user is Ice-Type, or the second if not.
+   * the first if/else, or 30/20 depending on the type of the user Pokemon.
    * @returns Returns true if move is successful, false if misses.
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -2382,12 +2382,8 @@ export class SheerColdAccuracyAttr extends OneHitKOAccuracyAttr {
       if (user.level < target.level) {
           accuracy.value = 0;
       } else { 
-          if (user.isOfType(Type.ICE)) {
-              accuracy.value = Math.min(Math.max(30 + 100 * (1 - target.level / user.level), 0), 100);
-          }
-          else {
-              accuracy.value = Math.min(Math.max(20 + 100 * (1 - target.level / user.level), 0), 100);
-          }
+         const baseAccuracy = user.isOfType(Type.ICE) ? 30 : 20;
+         accuracy.value = Math.min(Math.max(baseAccuracy + 100 * (1 - target.level / user.level), 0), 100);
       }
     return true;
   }

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2348,6 +2348,20 @@ export class OneHitKOAccuracyAttr extends VariableAccuracyAttr {
   }
 }
 
+export class SheerColdAttr extends OneHitKOAccuracyAttr {
+    apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+        const accuracy = args[0] as Utils.NumberHolder;
+        if (!target.isOfType(Type.ICE)) {
+            if (user.level < target.level)
+                accuracy.value = 0;
+            else
+                accuracy.value = Math.min(Math.max(30 + 100 * (1 - target.level / user.level), 0), 100);
+            return true;
+        }
+        return false;
+    }
+}
+
 export class MissEffectAttr extends MoveAttr {
   private missEffectFunc: UserMoveConditionFunc;
 
@@ -4626,8 +4640,7 @@ export function initMoves() {
       .attr(TrapAttr, BattlerTagType.SAND_TOMB)
       .makesContact(false),
     new AttackMove(Moves.SHEER_COLD, Type.ICE, MoveCategory.SPECIAL, 200, 30, 5, -1, 0, 3)
-      .attr(OneHitKOAttr)
-      .attr(OneHitKOAccuracyAttr),
+      .attr(SheerColdAttr),
     new AttackMove(Moves.MUDDY_WATER, Type.WATER, MoveCategory.SPECIAL, 90, 85, 10, 30, 0, 3)
       .attr(StatChangeAttr, BattleStat.ACC, -1)
       .target(MoveTarget.ALL_NEAR_ENEMIES),

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2329,14 +2329,13 @@ export class WaterSuperEffectTypeMultiplierAttr extends VariableMoveTypeMultipli
   }
 }
 
-export class IceNoEffectTypeMultiplierAttr extends VariableMoveTypeMultiplierAttr {
+export class IceNoEffectTypeAttr extends VariableMoveTypeMultiplierAttr {
    apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const multiplier = args[0] as Utils.NumberHolder;
     if (target.isOfType(Type.ICE)) {
-      multiplier.value = 0;
-      return true;
+      (args[0] as Utils.BooleanHolder).value = false;
+      return false;
     }
-    return false;
+    return true;
   }
 }
 
@@ -2359,7 +2358,7 @@ export class OneHitKOAccuracyAttr extends VariableAccuracyAttr {
   }
 }
 
-export class SheerColdAttr extends OneHitKOAccuracyAttr {
+export class SheerColdAccuracyAttr extends OneHitKOAccuracyAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const accuracy = args[0] as Utils.NumberHolder;
       if (user.level < target.level) {
@@ -4654,9 +4653,9 @@ export function initMoves() {
       .attr(TrapAttr, BattlerTagType.SAND_TOMB)
       .makesContact(false),
     new AttackMove(Moves.SHEER_COLD, Type.ICE, MoveCategory.SPECIAL, 200, 20, 5, -1, 0, 3)
+      .attr(IceNoEffectTypeAttr)
       .attr(OneHitKOAttr)
-      .attr(IceNoEffectTypeMultiplierAttr)
-      .attr(SheerColdAttr),
+      .attr(SheerColdAccuracyAttr),
     new AttackMove(Moves.MUDDY_WATER, Type.WATER, MoveCategory.SPECIAL, 90, 85, 10, 30, 0, 3)
       .attr(StatChangeAttr, BattleStat.ACC, -1)
       .target(MoveTarget.ALL_NEAR_ENEMIES),

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2330,6 +2330,14 @@ export class WaterSuperEffectTypeMultiplierAttr extends VariableMoveTypeMultipli
 }
 
 export class IceNoEffectTypeAttr extends VariableMoveTypeMultiplierAttr {
+  /**
+   * Checks to see if the Target is Ice-Type or not. If so, the move will have no effect.
+   * @param {Pokemon} user N/A
+   * @param {Pokemon} target Pokemon that is being checked whether Ice-Type or not.
+   * @param {Move} move N/A
+   * @param {any[]} args Sets to false if the target is Ice-Type, so it should do no damage/no effect.
+   * @returns {boolean} Returns true if move is successful, false if Ice-Type.
+   */
    apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     if (target.isOfType(Type.ICE)) {
       (args[0] as Utils.BooleanHolder).value = false;
@@ -2359,6 +2367,16 @@ export class OneHitKOAccuracyAttr extends VariableAccuracyAttr {
 }
 
 export class SheerColdAccuracyAttr extends OneHitKOAccuracyAttr {
+  /**
+   * Changes the normal One Hit KO Accuracy Attr to implement the Gen VII changes, 
+   * where if the user is Ice-Type, it has more accuracy.
+   * @param {Pokemon} user Pokemon that is using the move; checks the Pokemon's level.
+   * @param {Pokemon} target Pokemon that is receiving the move; checks the Pokemon's level.
+   * @param {Move} move N/A 
+   * @param {any[]} args Uses the accuracy argument, allowing to change it from either 0 if it doesn't pass
+   * the first if/else, and either the first value if the user is Ice-Type, or the second if not.
+   * @returns Returns true if move is successful, false if misses.
+   */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const accuracy = args[0] as Utils.NumberHolder;
       if (user.level < target.level) {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1366,7 +1366,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
           
           if (!result) {
             if (!typeMultiplier.value)
-              result = move.id == Moves.SHEER_COLD ? HitResult.FAIL : HitResult.NO_EFFECT;
+              result = move.id == Moves.SHEER_COLD ? HitResult.IMMUNE : HitResult.NO_EFFECT;
             else {
               const oneHitKo = new Utils.BooleanHolder(false);
               applyMoveAttrs(OneHitKOAttr, source, this, move, oneHitKo);
@@ -1434,7 +1434,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
               case HitResult.NO_EFFECT:
                 this.scene.queueMessage(`It doesn\'t affect ${this.name}!`);
                 break;
-              case HitResult.FAIL:
+              case HitResult.IMMUNE:
                 this.scene.queueMessage(`${this.name} is unaffected!`);
                 break;
               case HitResult.ONE_HIT_KO:  
@@ -3027,7 +3027,8 @@ export enum HitResult {
   HEAL,
   FAIL,
   MISS,
-  OTHER
+  OTHER,
+  IMMUNE
 }
 
 export type DamageResult = HitResult.EFFECTIVE | HitResult.SUPER_EFFECTIVE | HitResult.NOT_VERY_EFFECTIVE | HitResult.ONE_HIT_KO | HitResult.OTHER;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1366,7 +1366,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
           
           if (!result) {
             if (!typeMultiplier.value)
-              result = HitResult.NO_EFFECT;
+              result = move.id == Moves.SHEER_COLD ? HitResult.FAIL : HitResult.NO_EFFECT;
             else {
               const oneHitKo = new Utils.BooleanHolder(false);
               applyMoveAttrs(OneHitKOAttr, source, this, move, oneHitKo);
@@ -1433,6 +1433,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
                 break;
               case HitResult.NO_EFFECT:
                 this.scene.queueMessage(`It doesn\'t affect ${this.name}!`);
+                break;
+              case HitResult.FAIL:
+                this.scene.queueMessage(`${this.name} is unaffected!`);
                 break;
               case HitResult.ONE_HIT_KO:  
                 this.scene.queueMessage('It\'s a one-hit KO!');


### PR DESCRIPTION
Gen VII added two things to sheer cold:
- _Ice-type Pokémon are now immune to Sheer Cold._
- _Additionally, the move's base chance of hitting is only 20% if the user is not an Ice-type Pokémon._

I tested it with increased accuracy for the ice immunity. 
I also split the attributes into two, one for accuracy and one for Ice immunity.

https://bulbapedia.bulbagarden.net/wiki/Sheer_Cold_(move)