### PR TITLE
Catch global errors and rejected promises and display them in an alert box.

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -889,8 +889,6 @@ export default class BattleScene extends SceneBase {
 
 		let battleConfig: FixedBattleConfig = null;
 
-		throw new Error('JLIN not implemented.');
-
 		this.resetSeed(newWaveIndex);
 
 		const playerField = this.getPlayerField();

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -889,6 +889,8 @@ export default class BattleScene extends SceneBase {
 
 		let battleConfig: FixedBattleConfig = null;
 
+		throw new Error('JLIN not implemented.');
+
 		this.resetSeed(newWaveIndex);
 
 		const playerField = this.getPlayerField();

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ window.onerror = function (message, source, lineno, colno, error) {
 	return true;
 };
 
+// Catch global promise rejections and display them in an alert so users can report the issue.
 window.addEventListener('unhandledrejection', (event) => {	
 	let errorString = `Received unhandled promise rejection. Open browser console and click OK to see details.\nReason: ${event.reason}`;
 	alert(errorString);

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,21 @@ import BBCodeText from 'phaser3-rex-plugins/plugins/bbcodetext';
 import TransitionImagePackPlugin from 'phaser3-rex-plugins/templates/transitionimagepack/transitionimagepack-plugin.js';
 import { LoadingScene } from './loading-scene';
 
+
+// Catch global errors and display them in an alert so users can report the issue.
+window.onerror = function (message, source, lineno, colno, error) {
+	console.error(error);
+	let errorString = `Received unhandled error. Open browser console and click OK to see details.\nError: ${message}\nSource: ${source}\nLine: ${lineno}\nColumn: ${colno}\nStack: ${error.stack}`;
+	alert(errorString);
+	// Avoids logging the error a second time.
+	return true;
+};
+
+window.addEventListener('unhandledrejection', (event) => {	
+	let errorString = `Received unhandled promise rejection. Open browser console and click OK to see details.\nReason: ${event.reason}`;
+	alert(errorString);
+  });
+
 const config: Phaser.Types.Core.GameConfig = {
 	type: Phaser.WEBGL,
 	parent: 'app',

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -330,6 +330,8 @@ export class TitlePhase extends Phase {
           this.scene.sessionPlayTime = 0;
           this.end();
         });
+      }).catch(err => {
+        console.error("Failed to load daily run:\n", err);
       });
     });
   }

--- a/src/ui/daily-run-scoreboard.ts
+++ b/src/ui/daily-run-scoreboard.ts
@@ -165,7 +165,7 @@ export class DailyRunScoreboard extends Phaser.GameObjects.Container {
           } else
             this.loadingLabel.setText('No Rankings');
         });
-    });
+    }).catch(err => { console.error("Failed to load daily rankings:\n", err) });
   }
 }
 

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -64,6 +64,9 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
         this.playerCountLabel.setText(`${stats.playerCount} Players Online`);
         if (this.splashMessage === battleCountSplashMessage)
           this.splashMessageText.setText(battleCountSplashMessage.replace('{COUNT}', stats.battleCount.toLocaleString('en-US')));
+      })
+      .catch(err => {
+        console.error("Failed to fetch title stats:\n", err);
       });
   }
 


### PR DESCRIPTION
DO NOT MERGE WITHOUT READING DOWNSIDES


### Before

Casual users lacked the data to catch severe bugs in the moment (ex. black screen crashes), and by the time they reported the issue they had already refreshed or left the page. This leads to low signal for difficult to reproduce issues.

### After

Globally uncaught errors or rejected promises (i.e. anything that is not explicitly handled) results in an alert popping up on the user's screen, notifying them of the error and requesting that they open the console to see details. The hope is that this will motivate users to share the error w/ developers so that further debugging is possible.

Also explicitly catches a few places that rely on uncaught API calls to avoid errors propagating.

![image](https://github.com/pagefaultgames/pokerogue/assets/9257920/e683d4d4-813e-4747-a6e0-d0b5b3bb4749)
![image](https://github.com/pagefaultgames/pokerogue/assets/9257920/7f25856b-e829-4704-a941-b924fa5f962d)

Ideally, these alerts would trigger a crash report to be sent directly back to the servers and stored in a DB for future reference.

### Downsides / Risks

This solution is fully contingent on globally uncaught errors/promise rejections being a rare, game-breaking event. If there is a lot of noise that don't actually correspond w/ broken gameplay, the alerts popping up will hurt the player experience.

### Testing

I played through a run to confirm that no spurious errors/alerts showed up.