### PR TITLE
Implement Terrain Pulse

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2278,7 +2278,7 @@ export class WeatherBallTypeAttr extends VariableMoveTypeAttr {
 export class TerrainPulseTypeAttr extends VariableMoveTypeAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const type = (args[0] as Utils.IntegerHolder);
-    switch (user.scene.arena.terrain.terrainType) {
+    switch (user.scene.arena.terrain?.terrainType) {
       case TerrainType.MISTY:
         type.value = Type.FAIRY
         break;
@@ -5929,7 +5929,7 @@ export function initMoves() {
       .attr(MovePowerMultiplierAttr, (user, target, move) => user.scene.arena.getTerrainType() === TerrainType.ELECTRIC && target.isGrounded() ? 2 : 1),
     new AttackMove(Moves.TERRAIN_PULSE, Type.NORMAL, MoveCategory.SPECIAL, 50, 100, 10, -1, 0, 8)
       .attr(TerrainPulseTypeAttr)
-      .attr(MovePowerMultiplierAttr, (user, target, move) => (user.scene.arena.terrain.terrainType != TerrainType.NONE)  ? 2 : 1)
+      .attr(MovePowerMultiplierAttr, (user, target, move) => ([TerrainType.ELECTRIC, TerrainType.GRASSY, TerrainType.MISTY, TerrainType.PSYCHIC].includes(user.scene.arena.terrain?.terrainType)  ? 2 : 1))
       .pulseMove(),
     new AttackMove(Moves.SKITTER_SMACK, Type.BUG, MoveCategory.PHYSICAL, 70, 90, 10, 100, 0, 8)
       .attr(StatChangeAttr, BattleStat.SPATK, -1),

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2275,6 +2275,29 @@ export class WeatherBallTypeAttr extends VariableMoveTypeAttr {
   }
 }
 
+export class TerrainPulseTypeAttr extends VariableMoveTypeAttr {
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    const type = (args[0] as Utils.IntegerHolder);
+    switch (user.scene.arena.terrain.terrainType) {
+      case TerrainType.MISTY:
+        type.value = Type.FAIRY
+        break;
+      case TerrainType.ELECTRIC:
+        type.value = Type.ELECTRIC;
+        break;
+      case TerrainType.GRASSY:
+        type.value = Type.GRASS
+        break;
+      case TerrainType.PSYCHIC:
+        type.value = Type.PSYCHIC
+        break;
+      default:
+        return false;
+    }
+    return true;
+  }
+}
+
 export class HiddenPowerTypeAttr extends VariableMoveTypeAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const type = (args[0] as Utils.IntegerHolder);
@@ -5905,8 +5928,9 @@ export function initMoves() {
     new AttackMove(Moves.RISING_VOLTAGE, Type.ELECTRIC, MoveCategory.SPECIAL, 70, 100, 20, -1, 0, 8)
       .attr(MovePowerMultiplierAttr, (user, target, move) => user.scene.arena.getTerrainType() === TerrainType.ELECTRIC && target.isGrounded() ? 2 : 1),
     new AttackMove(Moves.TERRAIN_PULSE, Type.NORMAL, MoveCategory.SPECIAL, 50, 100, 10, -1, 0, 8)
-      .pulseMove()
-      .partial(),
+      .attr(TerrainPulseTypeAttr)
+      .attr(MovePowerMultiplierAttr, (user, target, move) => (user.scene.arena.terrain.terrainType != TerrainType.NONE)  ? 2 : 1)
+      .pulseMove(),
     new AttackMove(Moves.SKITTER_SMACK, Type.BUG, MoveCategory.PHYSICAL, 70, 90, 10, 100, 0, 8)
       .attr(StatChangeAttr, BattleStat.SPATK, -1),
     new AttackMove(Moves.BURNING_JEALOUSY, Type.FIRE, MoveCategory.SPECIAL, 70, 100, 5, 100, 0, 8)


### PR DESCRIPTION
Similar to https://github.com/pagefaultgames/pokerogue/pull/73 implement missing effects of Terrain Pulse.

- Type should change depending on the current field terrain. 
- Increase base power from 50 to 100 if the is a terrain.