### PR TITLE
feat: added french translation for new entries in menu.ts

### DIFF
--- a/src/locales/fr/menu.ts
+++ b/src/locales/fr/menu.ts
@@ -73,9 +73,9 @@ export const menu: SimpleTranslationEntries = {
   "skipItemQuestion": "Êtes-vous sûr·e de ne pas vouloir prendre d’objet ?",
   "eggHatching": "Oh ?",
   "ivScannerUseQuestion": "Utiliser le Scanner d’IV sur {{pokemonName}} ?",
-  "rankings": "Rankings",
-  "dailyRankings": "Daily Rankings",
-  "noRankings": "No Rankings",
-  "loading": "Loading…",
-  "playersOnline": "Players Online"
+  "rankings": "Classement",
+  "dailyRankings": "Classement du Jour",
+  "noRankings": "Pas de Classement",
+  "loading": "Chargement…",
+  "playersOnline": "Joueurs Connectés"
 } as const;


### PR DESCRIPTION
Updated french translation for new entries in `menu.ts`
Tested locally, works as expected, here is a screenshot :
![image](https://github.com/pagefaultgames/pokerogue/assets/6080933/983e7a3f-9b3f-4748-9ecf-0300cb893f73)

Regarding "Rankings" translation, it can either be "Classement" or "Classements" (plural). I find singular more accurate, but I'm opened to switch it to plural if you prefer 👍 