### PR TITLE
fix: reworked daily and weekly rankings translations workflow

### DIFF
--- a/src/locales/de/menu.ts
+++ b/src/locales/de/menu.ts
@@ -59,8 +59,8 @@ export const menu: SimpleTranslationEntries = {
     "escapeVerbSwitch": "auswechseln",
     "escapeVerbFlee": "flucht",
     "notDisabled": "{{moveName}} ist\nnicht mehr deaktiviert!",
-    "rankings": "Rankings",
     "dailyRankings": "Daily Rankings",
+    "weeklyRankings": "Weekly Rankings",
     "noRankings": "No Rankings",
     "loading": "Loading…",
     "playersOnline": "Players Online"

--- a/src/locales/en/menu.ts
+++ b/src/locales/en/menu.ts
@@ -78,8 +78,8 @@ export const menu: SimpleTranslationEntries = {
     "skipItemQuestion": "Are you sure you want to skip taking an item?",
     "eggHatching": "Oh?",
     "ivScannerUseQuestion": "Use IV Scanner on {{pokemonName}}?",
-    "rankings": "Rankings",
     "dailyRankings": "Daily Rankings",
+    "weeklyRankings": "Weekly Rankings",
     "noRankings": "No Rankings",
     "loading": "Loading…",
     "playersOnline": "Players Online"

--- a/src/locales/es/menu.ts
+++ b/src/locales/es/menu.ts
@@ -62,8 +62,8 @@ export const menu: SimpleTranslationEntries = {
     "skipItemQuestion": "¿Estás seguro de que no quieres coger un objeto?",
     "eggHatching": "¿Y esto?",
     "ivScannerUseQuestion": "¿Quieres usar el Escáner de IVs en {{pokemonName}}?",
-    "rankings": "Rankings",
     "dailyRankings": "Daily Rankings",
+    "weeklyRankings": "Weekly Rankings",
     "noRankings": "No Rankings",
     "loading": "Loading…",
     "playersOnline": "Players Online"

--- a/src/locales/fr/menu.ts
+++ b/src/locales/fr/menu.ts
@@ -73,8 +73,8 @@ export const menu: SimpleTranslationEntries = {
   "skipItemQuestion": "Êtes-vous sûr·e de ne pas vouloir prendre d’objet ?",
   "eggHatching": "Oh ?",
   "ivScannerUseQuestion": "Utiliser le Scanner d’IV sur {{pokemonName}} ?",
-  "rankings": "Classement",
   "dailyRankings": "Classement du Jour",
+  "weeklyRankings": "Classement de la Semaine",
   "noRankings": "Pas de Classement",
   "loading": "Chargement…",
   "playersOnline": "Joueurs Connectés"

--- a/src/locales/it/menu.ts
+++ b/src/locales/it/menu.ts
@@ -7,8 +7,8 @@ export const menu: SimpleTranslationEntries = {
     "loadGame": "Carica Partita",
     "dailyRun": "Corsa Giornaliera (Beta)",
     "selectGameMode": "Seleziona una modalità di gioco.",
-    "rankings": "Rankings",
     "dailyRankings": "Daily Rankings",
+    "weeklyRankings": "Weekly Rankings",
     "noRankings": "No Rankings",
     "loading": "Loading…",
     "playersOnline": "Players Online"

--- a/src/ui/daily-run-scoreboard.ts
+++ b/src/ui/daily-run-scoreboard.ts
@@ -11,6 +11,7 @@ interface RankingEntry {
   wave: integer
 }
 
+// Don't forget to update translations when adding a new category
 enum ScoreboardCategory {
   DAILY,
   WEEKLY
@@ -40,7 +41,7 @@ export class DailyRunScoreboard extends Phaser.GameObjects.Container {
     const titleWindow = addWindow(this.scene, 0, 0, 114, 18, false, false, null, null, WindowVariant.THIN);
     this.add(titleWindow);
 
-    this.titleLabel = addTextObject(this.scene, titleWindow.displayWidth / 2, titleWindow.displayHeight / 2, i18next.t('menu:dailyRankings'), TextStyle.WINDOW, { fontSize: '64px' });
+    this.titleLabel = addTextObject(this.scene, titleWindow.displayWidth / 2, titleWindow.displayHeight / 2, i18next.t('menu:loading'), TextStyle.WINDOW, { fontSize: '64px' });
     this.titleLabel.setOrigin(0.5, 0.5);
     this.add(this.titleLabel);
 
@@ -156,7 +157,7 @@ export class DailyRunScoreboard extends Phaser.GameObjects.Container {
         .then(jsonResponse => {
           this.page = page;
           this.category = category;
-          this.titleLabel.setText(`${Utils.toReadableString(ScoreboardCategory[category])} ${i18next.t("menu:rankings")}`);
+          this.titleLabel.setText(`${i18next.t(`menu:${ScoreboardCategory[category].toLowerCase()}Rankings`)}`);
           this.prevPageButton.setAlpha(page > 1 ? 1 : 0.5);
           this.nextPageButton.setAlpha(page < this.pageCount ? 1 : 0.5);
           this.pageNumberLabel.setText(page.toString());


### PR DESCRIPTION
After checking the last changes from #360  were deployed, I noticed an issue with the wording : we had "Daily Classement" instead of "Classement du Jour". 

I digged a bit in the code and found out the translation for `menu:dailyRankings` I put was only used as a placeholder while loading the data. As I couldn't test locally with an API to simulate, I didn't notice the issue until it was on prod, mb.

I changed the logic to make it more accurate : 
- Put `menu:loading` instead of `menu:dailyRankings` as placeholder while loading data from API
- Removed obsolete `menu:rankings` translation
- Added dedicated `menu:weeklyRankings` translation

Tested in all 5 languages to make sure there is no regression. Here are screenshots of the 3 possible states in french (I tested by manually set `DAILY` or `WEEKLY` and see if the updated code worked) : 
![image](https://github.com/pagefaultgames/pokerogue/assets/6080933/9fc522f6-3a84-43f0-9ff5-342374f2f7ab)
![image](https://github.com/pagefaultgames/pokerogue/assets/6080933/349e5a39-f973-4d5f-bc88-d509ec178e8a)
![image](https://github.com/pagefaultgames/pokerogue/assets/6080933/fa783eec-8338-4241-a12f-c94cc640d3d3)

