### PR TITLE
Fixed Dire Claw & Tri-Attack status chances

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1011,20 +1011,14 @@ export class StatusEffectAttr extends MoveEffectAttr {
 
 export class MultiStatusEffectAttr extends StatusEffectAttr {
   public effects: StatusEffect[];
-  public cureTurn: integer;
-  public overrideStatus: boolean;
 
   constructor(effects: StatusEffect[], selfTarget?: boolean, cureTurn?: integer, overrideStatus?: boolean) {
     super(effects[0], selfTarget, cureTurn, overrideStatus);
-
     this.effects = effects;
-    this.cureTurn = cureTurn;
-    this.overrideStatus = !!overrideStatus;
   }
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const statusIndex = Math.floor((Utils.randSeedInt(100)*this.effects.length-1)/100)
-    this.effect = this.effects[statusIndex] as StatusEffect;
+    this.effect = Utils.randSeedItem(this.effects);
     const result = super.apply(user, target, move, args);
     return result;
   }

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5520,9 +5520,6 @@ export function initMoves() {
     /* End Unused */
     new SelfStatusMove(Moves.SHORE_UP, Type.GROUND, -1, 5, -1, 0, 7)
       .attr(SandHealAttr)
-      .attr(HealStatusEffectAttr, true, StatusEffect.POISON)
-      .attr(HealStatusEffectAttr, true, StatusEffect.PARALYSIS)
-      .attr(HealStatusEffectAttr, true, StatusEffect.SLEEP)
       .triageMove(),
     new AttackMove(Moves.FIRST_IMPRESSION, Type.BUG, MoveCategory.PHYSICAL, 90, 100, 10, -1, 2, 7)
       .condition(new FirstMoveCondition()),

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1009,6 +1009,31 @@ export class StatusEffectAttr extends MoveEffectAttr {
   }
 }
 
+export class MultiStatusEffectAttr extends StatusEffectAttr {
+  public effects: StatusEffect[];
+  public cureTurn: integer;
+  public overrideStatus: boolean;
+
+  constructor(effects: StatusEffect[], selfTarget?: boolean, cureTurn?: integer, overrideStatus?: boolean) {
+    super(effects[0], selfTarget, cureTurn, overrideStatus);
+
+    this.effects = effects;
+    this.cureTurn = cureTurn;
+    this.overrideStatus = !!overrideStatus;
+  }
+
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    const statusIndex = Math.floor((Utils.randSeedInt(100)*this.effects.length-1)/100)
+    this.effect = this.effects[statusIndex] as StatusEffect;
+    const result = super.apply(user, target, move, args);
+    return result;
+  }
+
+  getTargetBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
+    return !(this.selfTarget ? user : target).status && (this.selfTarget ? user : target).canSetStatus(this.effect, true) ? Math.floor(move.chance * -0.1) : 0;
+  }
+}
+
 export class PsychoShiftEffectAttr extends MoveEffectAttr {
   constructor() {
     super(false, MoveEffectTrigger.HIT);
@@ -4152,9 +4177,7 @@ export function initMoves() {
     new SelfStatusMove(Moves.CONVERSION, Type.NORMAL, -1, 30, -1, 0, 1)
       .attr(FirstMoveTypeAttr),
     new AttackMove(Moves.TRI_ATTACK, Type.NORMAL, MoveCategory.SPECIAL, 80, 100, 10, 20, 0, 1)
-      .attr(StatusEffectAttr, StatusEffect.PARALYSIS)
-      .attr(StatusEffectAttr, StatusEffect.BURN)
-      .attr(StatusEffectAttr, StatusEffect.FREEZE),
+    .attr(MultiStatusEffectAttr, [StatusEffect.BURN, StatusEffect.FREEZE, StatusEffect.PARALYSIS]),
     new AttackMove(Moves.SUPER_FANG, Type.NORMAL, MoveCategory.PHYSICAL, -1, 90, 10, -1, 0, 1)
       .attr(TargetHalfHpDamageAttr),
     new AttackMove(Moves.SLASH, Type.NORMAL, MoveCategory.PHYSICAL, 70, 100, 20, -1, 0, 1)
@@ -5497,6 +5520,9 @@ export function initMoves() {
     /* End Unused */
     new SelfStatusMove(Moves.SHORE_UP, Type.GROUND, -1, 5, -1, 0, 7)
       .attr(SandHealAttr)
+      .attr(HealStatusEffectAttr, true, StatusEffect.POISON)
+      .attr(HealStatusEffectAttr, true, StatusEffect.PARALYSIS)
+      .attr(HealStatusEffectAttr, true, StatusEffect.SLEEP)
       .triageMove(),
     new AttackMove(Moves.FIRST_IMPRESSION, Type.BUG, MoveCategory.PHYSICAL, 90, 100, 10, -1, 2, 7)
       .condition(new FirstMoveCondition()),
@@ -5968,9 +5994,7 @@ export function initMoves() {
       .soundBased()
       .partial(),
     new AttackMove(Moves.DIRE_CLAW, Type.POISON, MoveCategory.PHYSICAL, 80, 100, 15, 50, 0, 8)
-      .attr(StatusEffectAttr, StatusEffect.POISON)
-      .attr(StatusEffectAttr, StatusEffect.PARALYSIS)
-      .attr(StatusEffectAttr, StatusEffect.SLEEP),
+      .attr(MultiStatusEffectAttr, [StatusEffect.POISON, StatusEffect.PARALYSIS, StatusEffect.SLEEP]),
     new AttackMove(Moves.PSYSHIELD_BASH, Type.PSYCHIC, MoveCategory.PHYSICAL, 70, 90, 10, 100, 0, 8)
       .attr(StatChangeAttr, BattleStat.DEF, 1, true),
     new SelfStatusMove(Moves.POWER_SHIFT, Type.NORMAL, -1, 10, 100, 0, 8)


### PR DESCRIPTION
The math on Dire Claw and Tri-Attack is currently incorrect, resulting in vastly higher rates of status effects. These moves make three independent attempts to apply a status effect (each at 50%/20% respectively), leading to Dire Claw having an 87.5% chance to apply a status effect of any kind and Tri-Attack having a 48.8% chance. 

This PR addresses this with a new move attribute `MultiStatusEffectAttr`, which extends `StatusEffectAttr`. The primary difference is that it takes an array of `StatusEffect` and chooses a random one to use for the apply method of `StatusEffectAttr`. 