### PR TITLE
Added StatusHealAttr for both Lunar Blessing and Jungle Healing

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -788,10 +788,6 @@ export class HealAttr extends MoveEffectAttr {
 
 
 export class StatusHealAttr extends HealAttr {
-    constructor() {
-        super();
-    }
-
     apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
         user.resetStatus();
         return true;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -786,6 +786,18 @@ export class HealAttr extends MoveEffectAttr {
   }
 }
 
+
+export class StatusHealAttr extends HealAttr {
+    constructor() {
+        super();
+    }
+
+    apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+        user.resetStatus();
+        return true;
+    }
+}
+
 export class SacrificialFullRestoreAttr extends SacrificialAttr {
   constructor() {
     super();
@@ -5939,8 +5951,8 @@ export function initMoves() {
       .attr(StatusEffectAttr, StatusEffect.BURN),
     new StatusMove(Moves.JUNGLE_HEALING, Type.GRASS, -1, 10, -1, 0, 8)
       .attr(HealAttr, 0.25, true, false)
-      .target(MoveTarget.USER_AND_ALLIES)
-      .partial(),
+      .attr(StatusHealAttr)
+      .target(MoveTarget.USER_AND_ALLIES),
     new AttackMove(Moves.WICKED_BLOW, Type.DARK, MoveCategory.PHYSICAL, 75, 100, 5, -1, 0, 8)
       .attr(CritOnlyAttr)
       .punchingMove(),
@@ -6038,9 +6050,9 @@ export function initMoves() {
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new StatusMove(Moves.LUNAR_BLESSING, Type.PSYCHIC, -1, 5, -1, 0, 8)
       .attr(HealAttr, 0.25)
+      .attr(StatusHealAttr)
       .target(MoveTarget.USER_AND_ALLIES)
-      .triageMove()
-      .partial(),
+      .triageMove(),
     new SelfStatusMove(Moves.TAKE_HEART, Type.PSYCHIC, -1, 10, -1, 0, 8)
       .attr(StatChangeAttr, [ BattleStat.SPATK, BattleStat.SPDEF ], 1, true)
       .partial(),


### PR DESCRIPTION
Both moves have essentially the same function:

- _Jungle Healing restores the HP of the user and its allies by 25% of their maximum HP, and heals any non-volatile status conditions they may have._
- _Lunar Blessing's PP was reduced to 5. Lunar Blessing restores the HP of the user and its allies by 25% of their maximum HP, and heals any non-volatile status conditions they may have._

Both heal status conditions as I tested, and should be fully implemented.

https://bulbapedia.bulbagarden.net/wiki/Jungle_Healing_(move)
https://bulbapedia.bulbagarden.net/wiki/Lunar_Blessing_(move)