### PR TITLE
Retry api post request on timeout

### DIFF
--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -275,17 +275,22 @@ export class GameData {
           Utils.apiPost(`savedata/update?datatype=${GameDataType.SYSTEM}`, systemData, undefined, true)
             .then(response => response.text())
             .then(error => {
-              this.scene.ui.savingIcon.hide();
               if (error) {
+                console.error(error);
                 if (error.startsWith('client version out of date')) {
+                  this.scene.ui.savingIcon.hide();
                   this.scene.clearPhaseQueue();
                   this.scene.unshiftPhase(new OutdatedPhase(this.scene));
+                  return resolve(false);
                 } else if (error.startsWith('session out of date')) {
+                  this.scene.ui.savingIcon.hide();
                   this.scene.clearPhaseQueue();
                   this.scene.unshiftPhase(new ReloadSessionPhase(this.scene));
+                  return resolve(false);
                 }
-                console.error(error);
-                return resolve(false);
+                console.log(`Retrying...`);
+                this.scene.ui.savingIcon.retry();
+                return this.saveSystem().then(resolve);
               }
               resolve(true);
             });
@@ -558,12 +563,14 @@ export class GameData {
             .then(response => response.text())
             .then(error => {
               if (error) {
+                console.error(error);
                 if (error.startsWith('session out of date')) {
                   this.scene.clearPhaseQueue();
                   this.scene.unshiftPhase(new ReloadSessionPhase(this.scene));
+                  return resolve(false);
                 }
-                console.error(error);
-                return resolve(false);
+                console.log(`Retrying...`);
+                return this.saveSession(this.scene, skipVerification).then(resolve);
               }
               console.debug('Session data saved');
               resolve(true);

--- a/src/ui/saving-icon-handler.ts
+++ b/src/ui/saving-icon-handler.ts
@@ -13,7 +13,7 @@ export default class SavingIconHandler extends Phaser.GameObjects.Container {
 
   setup(): void {
     this.icon = this.scene.add.sprite(0, 0, 'saving_icon');
-    this.icon.setOrigin(1, 1);
+    this.icon.setOrigin(0.5, 0.5);
 
     this.add(this.icon);
 
@@ -48,6 +48,24 @@ export default class SavingIconHandler extends Phaser.GameObjects.Container {
   
     this.setVisible(true);
     this.shown = true;
+  }
+
+  retry(): void {
+    this.setAlpha(1);
+    this.setVisible(true);
+    this.shown = true;
+
+    this.animActive = true;
+
+    this.scene.tweens.add({
+      targets: this,
+      rotation: 360,
+      repeat: Infinity,
+      duration: Utils.fixedInt(60000),
+      ease: 'Linear'
+    });
+  
+    this.setVisible(true);
   }
 
   hide(): void {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -258,9 +258,24 @@ export function apiPost(path: string, data?: any, contentType: string = 'applica
       if (sId)
         headers['Authorization'] = sId;
     }
-    fetch(`${apiUrl}/${path}`, { method: 'POST', headers: headers, body: data })
-      .then(response => resolve(response))
-      .catch(err => reject(err));
+
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    const timeoutId = setTimeout(() => {
+      controller.abort();
+      reject(new Error('Request timed out'));
+    }, 8000);
+
+    fetch(`${apiUrl}/${path}`, { method: 'POST', headers: headers, body: data, signal })
+      .then(response => {
+        clearTimeout(timeoutId);
+        resolve(response);
+      })
+      .catch(err => {
+        clearTimeout(timeoutId);
+        reject(err);
+      });
   });
 }
 


### PR DESCRIPTION
This PR add a timeout on the apiPost request after 8000ms. This timeout trigger an error and the caller as the choice to retry the request.

It was only added to saveGame and saveSession as it seems to be the ones that trigger the more often. I also think these one are the least at risk for save corruption.

For the context, I have a lot of short disconnection while traveling in train and I think this could be a handy solution. The current state of the game is to block indefinitely and need a full restart.

I'm not an expert in typescript, feel free to challenge and edit this feature.

Also, I don't know how to test this feature in local. If you have any ideas or advices on that, please comment and I will try.