### PR TITLE
Fixed Rounding Error For TargetHalfHpDamageAttr

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -557,7 +557,7 @@ export class TargetHalfHpDamageAttr extends FixedDamageAttr {
   }
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    (args[0] as Utils.IntegerHolder).value = Math.floor(target.hp / 2);
+    (args[0] as Utils.IntegerHolder).value = Math.max(Math.floor(target.hp / 2), 1);
 
     return true;
   }


### PR DESCRIPTION
Moves that deal half of a target's HP were not able to deal damage if the target had 1 HP. Used Math.max to ensure 1 is the lowest this value ever evaluates to.

Fixes this issue: https://discord.com/channels/1125469663833370665/1235351188455555092