### PR TITLE
Fix Pokemon stuck in semi-vulnerable state after Yawn

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1893,6 +1893,21 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       applyAbAttrs(ReduceStatusEffectDurationAbAttr, this, null, effect, statusCureTurn);
 
       this.setFrameRate(4);
+
+      // If the user is invulnerable, lets remove their invulnerability when they fall asleep
+      const invulnerableTags = [
+        BattlerTagType.UNDERGROUND,
+        BattlerTagType.UNDERWATER,
+        BattlerTagType.HIDDEN,
+        BattlerTagType.FLYING
+      ];
+
+      const tag = invulnerableTags.find((t) => this.getTag(t));
+
+      if (tag) {
+        this.removeTag(tag);
+        this.getMoveQueue().pop();
+      }
     }
 
     this.status = new Status(effect, 0, statusCureTurn?.value);


### PR DESCRIPTION
Fixed a bug where a Pokemon would be stuck in a semi-vulnerable state when falling asleep in that state.

Trello: https://trello.com/c/8Lkse4ot
Video: https://capture.dropbox.com/fGtfs63XNvQvoBaX

This is my first time contributing to any open source project so please look it over and let me know if there's anything I missed or anything you want changed.