### PR TITLE
Implemented Zero to Hero

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -1950,19 +1950,20 @@ export class PostTurnFormChangeAbAttr extends PostTurnAbAttr {
   }
 }
 
-export class ZeroToHeroAbAttr extends PreSwitchOutAbAttr {
-     // .attr(PostBattleInitFormChangeAbAttr, p => p.getHpRatio() <= 0.9 ? 1 : 0)
-      //.attr(PostSummonFormChangeAbAttr, p => p.getHpRatio() <= 0.9 ? 1 : 0)
-      //.attr(PostTurnFormChangeAbAttr, p => p.getHpRatio() <= 0.9 ? 1 : 0)
+export class PreSwitchOutFormChangeAbAttr extends PreSwitchOutAbAttr {
+  private formFunc: (p: Pokemon) => integer;
+
       constructor(formFunc: ((p: Pokemon) => integer)) {
         super();
     
-        //this.formFunc = formFunc;
+        this.formFunc = formFunc;
       }
 
   applyPreSwitchOut(pokemon: Pokemon, passive: boolean, args: any[]): boolean | Promise<boolean> {
+    console.log(pokemon.getFormKey())
 
-    if (1 !== pokemon.formIndex && pokemon.species.name == "Palafin") {
+    const formIndex = this.formFunc(pokemon);
+    if (formIndex !== pokemon.formIndex) {
       pokemon.scene.triggerPokemonFormChange(pokemon, SpeciesFormChangeManualTrigger, false);
       return true;
     }
@@ -3354,7 +3355,9 @@ export function initAbilities() {
       .attr(UnsuppressableAbilityAbAttr)
       .attr(NoTransformAbilityAbAttr)
       .attr(NoFusionAbilityAbAttr)
-      .attr(ZeroToHeroAbAttr, p => true ? 1 : 0),
+      .attr(PreSwitchOutFormChangeAbAttr, p => p.getFormKey() ? 1 : 0)
+      .attr(PostBattleInitFormChangeAbAttr, p => p.battleData.switchesMade === 0 ? 0 : 1)
+      .attr(PostSummonFormChangeAbAttr,p => p.battleData.switchesMade === 0 ? 0 : 1),
     new Ability(Abilities.COMMANDER, 9)
       .attr(UncopiableAbilityAbAttr)
       .attr(UnswappableAbilityAbAttr)

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -20,6 +20,7 @@ import { SpeciesFormChangeManualTrigger } from "./pokemon-forms";
 import { Abilities } from "./enums/abilities";
 import i18next, { Localizable } from "#app/plugins/i18n.js";
 import { Command } from "../ui/command-ui-handler";
+import PokemonSpecies from "./pokemon-species";
 
 export class Ability implements Localizable {
   public id: Abilities;
@@ -1949,6 +1950,27 @@ export class PostTurnFormChangeAbAttr extends PostTurnAbAttr {
   }
 }
 
+export class ZeroToHeroAbAttr extends PreSwitchOutAbAttr {
+     // .attr(PostBattleInitFormChangeAbAttr, p => p.getHpRatio() <= 0.9 ? 1 : 0)
+      //.attr(PostSummonFormChangeAbAttr, p => p.getHpRatio() <= 0.9 ? 1 : 0)
+      //.attr(PostTurnFormChangeAbAttr, p => p.getHpRatio() <= 0.9 ? 1 : 0)
+      constructor(formFunc: ((p: Pokemon) => integer)) {
+        super();
+    
+        //this.formFunc = formFunc;
+      }
+
+  applyPreSwitchOut(pokemon: Pokemon, passive: boolean, args: any[]): boolean | Promise<boolean> {
+
+    if (1 !== pokemon.formIndex && pokemon.species.name == "Palafin") {
+      pokemon.scene.triggerPokemonFormChange(pokemon, SpeciesFormChangeManualTrigger, false);
+      return true;
+    }
+
+    return false;
+  }
+}
+
 export class PostBiomeChangeAbAttr extends AbAttr { }
 
 export class PostBiomeChangeWeatherChangeAbAttr extends PostBiomeChangeAbAttr {
@@ -3332,7 +3354,7 @@ export function initAbilities() {
       .attr(UnsuppressableAbilityAbAttr)
       .attr(NoTransformAbilityAbAttr)
       .attr(NoFusionAbilityAbAttr)
-      .unimplemented(),
+      .attr(ZeroToHeroAbAttr, p => true ? 1 : 0),
     new Ability(Abilities.COMMANDER, 9)
       .attr(UncopiableAbilityAbAttr)
       .attr(UnswappableAbilityAbAttr)

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -21,6 +21,7 @@ import { Abilities } from "./enums/abilities";
 import i18next, { Localizable } from "#app/plugins/i18n.js";
 import { Command } from "../ui/command-ui-handler";
 import PokemonSpecies from "./pokemon-species";
+import { BattleType } from "#app/battle.js";
 
 export class Ability implements Localizable {
   public id: Abilities;
@@ -3356,8 +3357,8 @@ export function initAbilities() {
       .attr(NoTransformAbilityAbAttr)
       .attr(NoFusionAbilityAbAttr)
       .attr(PreSwitchOutFormChangeAbAttr, p => p.getFormKey() ? 1 : 0)
-      .attr(PostBattleInitFormChangeAbAttr, p => p.battleData.switchesMade === 0 ? 0 : 1)
-      .attr(PostSummonFormChangeAbAttr,p => p.battleData.switchesMade === 0 ? 0 : 1),
+      .attr(PostBattleInitFormChangeAbAttr, p => p.battleData.switchesMade === 0 && p.scene.currentBattle.battleType === BattleType.TRAINER ? 0 : 1)
+      .attr(PostSummonFormChangeAbAttr,p => p.battleData.switchesMade === 0 && p.scene.currentBattle.battleType === BattleType.TRAINER? 0 : 1),
     new Ability(Abilities.COMMANDER, 9)
       .attr(UncopiableAbilityAbAttr)
       .attr(UnswappableAbilityAbAttr)

--- a/src/data/pokemon-forms.ts
+++ b/src/data/pokemon-forms.ts
@@ -681,6 +681,9 @@ export const pokemonFormChanges: PokemonFormChanges = {
   [Species.ENAMORUS]: [
     new SpeciesFormChange(Species.ENAMORUS, SpeciesFormKey.INCARNATE, SpeciesFormKey.THERIAN, new SpeciesFormChangeItemTrigger(FormChangeItem.REVEAL_GLASS))
   ],
+  [Species.PALAFIN]: [
+    new SpeciesFormChange(Species.PALAFIN, 'zero', 'hero', new SpeciesFormChangeManualTrigger(), true),
+  ],
   [Species.OGERPON]: [
     new SpeciesFormChange(Species.OGERPON, 'teal-mask', 'wellspring-mask', new SpeciesFormChangeItemTrigger(FormChangeItem.WELLSPRING_MASK)),
     new SpeciesFormChange(Species.OGERPON, 'teal-mask', 'hearthflame-mask', new SpeciesFormChangeItemTrigger(FormChangeItem.HEARTHFLAME_MASK)),

--- a/src/data/pokemon-forms.ts
+++ b/src/data/pokemon-forms.ts
@@ -683,6 +683,7 @@ export const pokemonFormChanges: PokemonFormChanges = {
   ],
   [Species.PALAFIN]: [
     new SpeciesFormChange(Species.PALAFIN, 'zero', 'hero', new SpeciesFormChangeManualTrigger(), true),
+    new SpeciesFormChange(Species.PALAFIN, 'hero', 'zero', new SpeciesFormChangeManualTrigger(), true),
   ],
   [Species.OGERPON]: [
     new SpeciesFormChange(Species.OGERPON, 'teal-mask', 'wellspring-mask', new SpeciesFormChangeItemTrigger(FormChangeItem.WELLSPRING_MASK)),

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3036,6 +3036,7 @@ export class PokemonBattleData {
   public hitCount: integer = 0;
   public endured: boolean = false;
   public berriesEaten: BerryType[] = [];
+  public switchesMade: integer = 0;
 }
 
 export class PokemonBattleSummonData {

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1433,6 +1433,7 @@ export class SwitchSummonPhase extends SummonPhase {
     if (this.batonPass && pokemon)
       pokemon.transferSummon(this.lastPokemon);
 
+    this.lastPokemon.battleData.switchesMade++;
     this.lastPokemon?.resetSummonData();
 
     this.scene.triggerPokemonFormChange(pokemon, SpeciesFormChangeActiveTrigger, true);


### PR DESCRIPTION
Implemented Zero to Hero using a new ability attribute `PreSwitchOutFormChangeAbAttr`. Added variable `switchesMade` to `PokemonBattleData`, which is incremented when the pokemon is switched out by any means. This variable, if implemented, could also be used for abilities that only trigger on the first switch-in, such as Intrepid Sword and Dauntless Shield.

