### PR TITLE
Fix Shedinja PPused Share

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2473,7 +2473,7 @@ export class PlayerPokemon extends Pokemon {
       if (newEvolution.condition.predicate(this)) {
         const newPokemon = this.scene.addPlayerPokemon(this.species, this.level, this.abilityIndex, this.formIndex, undefined, this.shiny, this.variant, this.ivs, this.nature);
         newPokemon.natureOverride = this.natureOverride;
-        newPokemon.moveset = this.moveset.slice();
+        newPokemon.moveset = this.copyMoveset();
         newPokemon.luck = this.luck;
 
         newPokemon.fusionSpecies = this.fusionSpecies;
@@ -2582,6 +2582,15 @@ export class PlayerPokemon extends Pokemon {
       this.updateInfo(true).then(() => resolve());
       this.updateFusionPalette();
     });
+  }
+
+  /** Returns a deep copy of this Pokemon's moveset array */
+  copyMoveset(): PokemonMove[] {
+    let newMoveset = [];
+    this.moveset.forEach(move => 
+      newMoveset.push(new PokemonMove(move.moveId, 0, move.ppUp, move.virtual)));
+
+    return newMoveset;
   }
 }
 


### PR DESCRIPTION
Fixed having Shedinja share PP usage with the Ninjask it evolved from and vice versa.

The solution was to make a deep copy of each move in the moveset array rather than copying the array itself.

https://github.com/pagefaultgames/pokerogue/assets/13838608/6310de7b-5ca3-44e2-9b9f-ecdf1ad65203