### PR TITLE
Fix Gyro Ball only checking base stat

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1770,13 +1770,13 @@ export class BattleStatRatioPowerAttr extends VariablePowerAttr {
 
     if (this.invert) {
       // Gyro ball uses a specific formula
-      let userSpeed = user.getStat(this.stat);
+      let userSpeed = user.getBattleStat(this.stat);
       if (userSpeed < 1) {
         // Gen 6+ always have 1 base power
         power.value = 1;
         return true;
       } 
-      let bp = Math.floor(Math.min(150, 25 * target.getStat(this.stat) / userSpeed + 1));
+      let bp = Math.floor(Math.min(150, 25 * target.getBattleStat(this.stat) / userSpeed + 1));
       power.value = bp;
       return true;
     }


### PR DESCRIPTION
Gyro Ball was getting Speed values with getStat instead of getBattleStat, making it so it didn't take enemy speed increases into account, or having a worse synergy with Curse.

Simply changing the called method seems to have fixed it. Tested with two Steelix, one of them having Speed Boost as ability. Before the change, damage never changed over turns, now it does.