### PR TITLE
Add variable power attribute for knock off 

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2022,10 +2022,9 @@ export class KnockOffPowerAttr extends VariablePowerAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     if(target.getHeldItems().length > 0){
       (args[0] as Utils.NumberHolder).value *= 1.5;
-      console.log(args[0])
       return true; 
     }
-    console.log(args[0])
+    
     return false;
   }
 }

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2018,6 +2018,18 @@ export class PresentPowerAttr extends VariablePowerAttr {
   }
 }
 
+export class KnockOffPowerAttr extends VariablePowerAttr {
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    if(target.getHeldItems().length > 0){
+      (args[0] as Utils.NumberHolder).value *= 1.5;
+      console.log(args[0])
+      return true; 
+    }
+    console.log(args[0])
+    return false;
+  }
+}
+
 export class VariableAtkAttr extends MoveAttr {
   constructor() {
     super();
@@ -4580,6 +4592,7 @@ export function initMoves() {
       .attr(AddBattlerTagAttr, BattlerTagType.DROWSY, false, true)
       .condition((user, target, move) => !target.status),
     new AttackMove(Moves.KNOCK_OFF, Type.DARK, MoveCategory.PHYSICAL, 65, 100, 20, -1, 0, 3)
+      .attr(KnockOffPowerAttr)
       .partial(),
     new AttackMove(Moves.ENDEAVOR, Type.NORMAL, MoveCategory.PHYSICAL, -1, 100, 5, -1, 0, 3)
       .attr(MatchHpAttr)


### PR DESCRIPTION
Adds 1.5x power attribute when hitting a target with items. https://pokemondb.net/move/knock-off

Testing: 

Base power is 65 when hitting target with no item 
![image](https://github.com/pagefaultgames/pokerogue/assets/13306707/a9a21f33-d0a3-4991-8431-7aab6ee7f589)


Base power is 97.5 when hitting target with item 
![image](https://github.com/pagefaultgames/pokerogue/assets/13306707/557da534-dfa4-4456-9a5c-2212cb6b9f49)


*I did not add the item removal effect yet