### PR TITLE
Implements upper hand (mostly) 

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6429,7 +6429,10 @@ export function initMoves() {
     new AttackMove(Moves.PSYCHIC_NOISE, Type.PSYCHIC, MoveCategory.SPECIAL, 75, 100, 10, -1, 0, 9)
       .soundBased()
       .partial(),
-    new AttackMove(Moves.UPPER_HAND, Type.FIGHTING, MoveCategory.PHYSICAL, 65, 100, 15, -1, 3, 9)
+    new AttackMove(Moves.UPPER_HAND, Type.FIGHTING, MoveCategory.PHYSICAL, 65, 100, 15, 100, 3, 9)
+      .attr(FlinchAttr)
+      .condition((user, target, move) => user.scene.currentBattle.turnCommands[target.getBattlerIndex()].command === Command.FIGHT && !target.turnData.acted && allMoves[user.scene.currentBattle.turnCommands[target.getBattlerIndex()].move.move].category !== MoveCategory.STATUS && allMoves[user.scene.currentBattle.turnCommands[target.getBattlerIndex()].move.move].priority > 0 )
+      //TODO: Should also apply when target move priority increased by ability ex. gale wings
       .partial(),
     new AttackMove(Moves.MALIGNANT_CHAIN, Type.POISON, MoveCategory.SPECIAL, 100, 100, 5, 50, 0, 9)
       .attr(StatusEffectAttr, StatusEffect.TOXIC)


### PR DESCRIPTION
LMK if you want me to move this condition to its own function since it's not super readable but it's like this for sucker punch so I figured it's probably fine. 

https://pokemon.fandom.com/wiki/Upper_Hand

Testing: 
- Attacks & flinches if target chose a priority attacking move and hasn't moved yet  
- Fails if target chose a non-priority attacking move 
- Fails if target chose a priority status move

*Known issue- Upper hand currently fails if the target is using a non-priority move but the priority is increased due to an ability. I didn't see a good way to fix that so added a TODO for now. 