### PR TITLE
Add Form Text to Starter UI

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -128,6 +128,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
   private starterSelectMessageBox: Phaser.GameObjects.NineSlice;
   private starterSelectMessageBoxContainer: Phaser.GameObjects.Container;
   private statsContainer: StatsContainer;
+  private pokemonFormText: Phaser.GameObjects.Text;
 
   private genMode: boolean;
   private statsMode: boolean;
@@ -433,6 +434,10 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.pokemonCandyIcon.setScale(0.5);
     this.pokemonCandyIcon.setOrigin(0, 0);
     this.starterSelectContainer.add(this.pokemonCandyIcon);
+
+    this.pokemonFormText = addTextObject(this.scene, 6, 42, 'Form', TextStyle.WINDOW_ALT, { fontSize: '42px' });
+    this.pokemonFormText.setOrigin(0, 0);
+    this.starterSelectContainer.add(this.pokemonFormText);
 
     this.pokemonCandyOverlayIcon = this.scene.add.sprite(1, 12, 'items', 'candy_overlay');
     this.pokemonCandyOverlayIcon.setScale(0.5);
@@ -1288,6 +1293,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
           this.pokemonCandyOverlayIcon.setVisible(true);
           this.pokemonCandyCountText.setText(`x${this.scene.gameData.starterData[species.speciesId].candyCount}`);
           this.pokemonCandyCountText.setVisible(true);
+          this.pokemonFormText.setVisible(true);
         }
         this.iconAnimHandler.addOrUpdate(this.starterSelectGenIconContainers[species.generation - 1].getAt(this.genSpecies[species.generation - 1].indexOf(species)) as Phaser.GameObjects.Sprite, PokemonIconAnimMode.PASSIVE);
 
@@ -1337,6 +1343,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         this.pokemonCandyIcon.setVisible(false);
         this.pokemonCandyOverlayIcon.setVisible(false);
         this.pokemonCandyCountText.setVisible(false);
+        this.pokemonFormText.setVisible(false);
 
         const defaultDexAttr = this.scene.gameData.getSpeciesDefaultDexAttr(species, true, true);
         const defaultAbilityIndex = this.scene.gameData.getStarterSpeciesDefaultAbilityIndex(species);
@@ -1363,6 +1370,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       this.pokemonCandyIcon.setVisible(false);
       this.pokemonCandyOverlayIcon.setVisible(false);
       this.pokemonCandyCountText.setVisible(false);
+      this.pokemonFormText.setVisible(false);
 
       this.setSpeciesDetails(species, false, 0, false, 0, 0, 0);
       this.pokemonSprite.clearTint();
@@ -1522,6 +1530,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
           this.starterMoveset.push(...availableStarterMoves.filter(sm => this.starterMoveset.indexOf(sm) === -1).slice(0, 4 - this.starterMoveset.length));
 
         const speciesForm = getPokemonSpeciesForm(species.speciesId, formIndex);
+        this.pokemonFormText.setText(species?.forms[formIndex]?.formKey.toLocaleUpperCase());
         this.setTypeIcons(speciesForm.type1, speciesForm.type2);
       } else {
         this.pokemonAbilityText.setText('');

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1530,7 +1530,13 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
           this.starterMoveset.push(...availableStarterMoves.filter(sm => this.starterMoveset.indexOf(sm) === -1).slice(0, 4 - this.starterMoveset.length));
 
         const speciesForm = getPokemonSpeciesForm(species.speciesId, formIndex);
-        this.pokemonFormText.setText(species?.forms[formIndex]?.formKey.toLocaleUpperCase());
+        
+        const formText = species?.forms[formIndex]?.formKey.split('-');
+        for (let i = 0; i < formText?.length; i++)
+          formText[i] = formText[i].charAt(0).toUpperCase() + formText[i].substring(1);
+
+        this.pokemonFormText.setText(formText?.join(' '));
+
         this.setTypeIcons(speciesForm.type1, speciesForm.type2);
       } else {
         this.pokemonAbilityText.setText('');


### PR DESCRIPTION
Adds text to the starter screen UI which indicates which Form you are currently selecting. This helps with Pokémon who don't have a sprite change for their form because it doesn't affect them until later.

https://github.com/pagefaultgames/pokerogue/assets/13838608/6c87c9dd-6ef5-4e60-bfe6-18d88f68c685

