### PR TITLE
have arena tags check their sides.

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2817,7 +2817,7 @@ export class AddArenaTagAttr extends MoveEffectAttr {
   public tagType: ArenaTagType;
   public turnCount: integer;
   private failOnOverlap: boolean;
-  private selfSideTarget: boolean;
+  public selfSideTarget: boolean;
 
   constructor(tagType: ArenaTagType, turnCount?: integer, failOnOverlap: boolean = false, selfSideTarget: boolean = false) {
     super(true, MoveEffectTrigger.POST_APPLY, true);
@@ -2850,7 +2850,7 @@ export class AddArenaTagAttr extends MoveEffectAttr {
 export class AddArenaTrapTagAttr extends AddArenaTagAttr {
   getCondition(): MoveConditionFunc {
     return (user, target, move) => {
-      if (move.category !== MoveCategory.STATUS || !user.scene.arena.getTag(this.tagType))
+      if (move.category !== MoveCategory.STATUS || !user.scene.arena.getTagOnSide(this.tagType, (this.selfSideTarget ? user : target).isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY))
         return true;
       const tag = user.scene.arena.getTag(this.tagType) as ArenaTrapTag;
       return tag.layers < tag.maxLayers;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2850,9 +2850,10 @@ export class AddArenaTagAttr extends MoveEffectAttr {
 export class AddArenaTrapTagAttr extends AddArenaTagAttr {
   getCondition(): MoveConditionFunc {
     return (user, target, move) => {
-      if (move.category !== MoveCategory.STATUS || !user.scene.arena.getTagOnSide(this.tagType, (this.selfSideTarget ? user : target).isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY))
+      const side = (this.selfSideTarget ? user : target).isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY;
+      if (move.category !== MoveCategory.STATUS || !user.scene.arena.getTagOnSide(this.tagType, side))
         return true;
-      const tag = user.scene.arena.getTag(this.tagType) as ArenaTrapTag;
+      const tag = user.scene.arena.getTagOnSide(this.tagType, side) as ArenaTrapTag;
       return tag.layers < tag.maxLayers;
     };
   }

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -492,7 +492,7 @@ export class Arena {
 	}
 
   addTag(tagType: ArenaTagType, turnCount: integer, sourceMove: Moves, sourceId: integer, side: ArenaTagSide = ArenaTagSide.BOTH, targetIndex?: BattlerIndex): boolean {
-    const existingTag = this.getTag(tagType);
+    const existingTag = this.getTagOnSide(tagType, side);
     if (existingTag) {
       existingTag.onOverlap(this);
       return false;


### PR DESCRIPTION



Right now arena trap tags are not having their sides checked for application and overlapping. This makes it impossible to have stealth rocks or another arena trap on both sides.  

This change just looks at their side when considering overlapping and applications.

Let me know if I am misunderstanding something!