### PR TITLE
Minor Update to French battle.ts

### DIFF
--- a/src/locales/fr/battle.ts
+++ b/src/locales/fr/battle.ts
@@ -12,7 +12,7 @@ export const battle: SimpleTranslationEntries = {
   "switchQuestion": "Voulez-vous changer\n{{pokemonName}} ?",
   "trainerDefeated": `Vous avez battu\n{{trainerName}} !`,
   "pokemonCaught": "Vous avez attrapé {{pokemonName}} !",
-  "pokemon": "Pokémon",
+  "pokemon": "de Pokémon",
   "sendOutPokemon": "{{pokemonName}} ! Go !",
   "hitResultCriticalHit": "Coup critique !",
   "hitResultSuperEffective": "C’est super efficace !",


### PR DESCRIPTION
Added "de" to "Pokémon" to make this sentence grammatically correct

![Capture d’écran 2024-05-04 163313](https://github.com/pagefaultgames/pokerogue/assets/2070109/4bc714ee-4d79-4fd5-ae17-5d23ad76a4c7)
