### PR TITLE
Function to check status which heals mid-turn when appropriate

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1187,7 +1187,7 @@ export class HealStatusEffectAttr extends MoveEffectAttr {
 
 export class BypassSleepAttr extends MoveAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    if (user.status?.effect === StatusEffect.SLEEP) {
+    if (user.getStatusEffect() === StatusEffect.SLEEP) {
       user.addTag(BattlerTagType.BYPASS_SLEEP, 1, move.id, user.id);
       return true;
     }
@@ -4214,7 +4214,7 @@ export function initMoves() {
       .attr(StatusEffectAttr, StatusEffect.PARALYSIS),
     new AttackMove(Moves.DREAM_EATER, Type.PSYCHIC, MoveCategory.SPECIAL, 100, 100, 15, -1, 0, 1)
       .attr(HitHealAttr)
-      .condition((user, target, move) => target.status?.effect === StatusEffect.SLEEP)
+      .condition((user, target, move) => target.getStatusEffect() === StatusEffect.SLEEP)
       .triageMove(),
     new StatusMove(Moves.POISON_GAS, Type.POISON, 90, 40, -1, 0, 1)
       .attr(StatusEffectAttr, StatusEffect.POISON)
@@ -4315,14 +4315,14 @@ export function initMoves() {
       .attr(IgnoreAccuracyAttr),
     new StatusMove(Moves.NIGHTMARE, Type.GHOST, 100, 15, -1, 0, 2)
       .attr(AddBattlerTagAttr, BattlerTagType.NIGHTMARE)
-      .condition((user, target, move) => target.status?.effect === StatusEffect.SLEEP),
+      .condition((user, target, move) => target.getStatusEffect() === StatusEffect.SLEEP),
     new AttackMove(Moves.FLAME_WHEEL, Type.FIRE, MoveCategory.PHYSICAL, 60, 100, 25, 10, 0, 2)
       .attr(HealStatusEffectAttr, true, StatusEffect.FREEZE)
       .attr(StatusEffectAttr, StatusEffect.BURN),
     new AttackMove(Moves.SNORE, Type.NORMAL, MoveCategory.SPECIAL, 50, 100, 15, 30, 0, 2)
       .attr(BypassSleepAttr)
       .attr(FlinchAttr)
-      .condition((user, target, move) => user.status?.effect === StatusEffect.SLEEP)
+      .condition((user, target, move) => user.getStatusEffect() === StatusEffect.SLEEP)
       .soundBased(),
     new StatusMove(Moves.CURSE, Type.GHOST, -1, 10, -1, 0, 2)
       .attr(StatChangeAttr, BattleStat.SPD, -1, true)
@@ -4433,7 +4433,7 @@ export function initMoves() {
     new SelfStatusMove(Moves.SLEEP_TALK, Type.NORMAL, -1, 10, -1, 0, 2)
       .attr(BypassSleepAttr)
       .attr(RandomMovesetMoveAttr)
-      .condition((user, target, move) => user.status?.effect === StatusEffect.SLEEP)
+      .condition((user, target, move) => user.getStatusEffect() === StatusEffect.SLEEP)
       .ignoresVirtual(),
     new StatusMove(Moves.HEAL_BELL, Type.NORMAL, -1, 5, -1, 0, 2)
       .soundBased()
@@ -4582,14 +4582,13 @@ export function initMoves() {
       .attr(SacrificialAttr)
       .attr(StatChangeAttr, [ BattleStat.ATK, BattleStat.SPATK ], -2),
     new AttackMove(Moves.FACADE, Type.NORMAL, MoveCategory.PHYSICAL, 70, 100, 20, -1, 0, 3)
-      .attr(MovePowerMultiplierAttr, (user, target, move) => user.status
-        && (user.status.effect === StatusEffect.BURN || user.status.effect === StatusEffect.POISON || user.status.effect === StatusEffect.TOXIC || user.status.effect === StatusEffect.PARALYSIS) ? 2 : 1),
+      .attr(MovePowerMultiplierAttr, (user, target, move) => [StatusEffect.BURN, StatusEffect.PARALYSIS, StatusEffect.POISON, StatusEffect.TOXIC].includes(user.getStatusEffect())) ? 2 : 1),
     new AttackMove(Moves.FOCUS_PUNCH, Type.FIGHTING, MoveCategory.PHYSICAL, 150, 100, 20, -1, -3, 3)
       .punchingMove()
       .ignoresVirtual()
       .condition((user, target, move) => !user.turnData.attacksReceived.find(r => r.damage)),
     new AttackMove(Moves.SMELLING_SALTS, Type.NORMAL, MoveCategory.PHYSICAL, 70, 100, 10, -1, 0, 3)
-      .attr(MovePowerMultiplierAttr, (user, target, move) => target.status?.effect === StatusEffect.PARALYSIS ? 2 : 1)
+      .attr(MovePowerMultiplierAttr, (user, target, move) => target.getStatusEffect() === StatusEffect.PARALYSIS ? 2 : 1)
       .attr(HealStatusEffectAttr, true, StatusEffect.PARALYSIS),
     new SelfStatusMove(Moves.FOLLOW_ME, Type.NORMAL, -1, 20, -1, 2, 3)
       .unimplemented(),
@@ -4832,7 +4831,7 @@ export function initMoves() {
     new StatusMove(Moves.MIRACLE_EYE, Type.PSYCHIC, -1, 40, -1, 0, 4)
       .unimplemented(),
     new AttackMove(Moves.WAKE_UP_SLAP, Type.FIGHTING, MoveCategory.PHYSICAL, 70, 100, 10, -1, 0, 4)
-      .attr(MovePowerMultiplierAttr, (user, target, move) => target.status?.effect === StatusEffect.SLEEP ? 2 : 1)
+      .attr(MovePowerMultiplierAttr, (user, target, move) => target.getStatusEffect() === StatusEffect.SLEEP ? 2 : 1)
       .attr(HealStatusEffectAttr, false, StatusEffect.SLEEP),
     new AttackMove(Moves.HAMMER_ARM, Type.FIGHTING, MoveCategory.PHYSICAL, 100, 90, 10, 100, 0, 4)
       .attr(StatChangeAttr, BattleStat.SPD, -1, true)
@@ -4880,11 +4879,7 @@ export function initMoves() {
       .unimplemented(),
     new StatusMove(Moves.PSYCHO_SHIFT, Type.PSYCHIC, 100, 10, -1, 0, 4)
       .attr(PsychoShiftEffectAttr)
-      .condition((user, target, move) => (user.status?.effect === StatusEffect.BURN
-        || user.status?.effect === StatusEffect.POISON
-        || user.status?.effect === StatusEffect.TOXIC
-        || user.status?.effect === StatusEffect.PARALYSIS
-        || user.status?.effect === StatusEffect.SLEEP)
+      .condition((user, target, move) => [StatusEffect.POISON, StatusEffect.TOXIC,StatusEffect.PARALYSIS,StatusEffect.SLEEP].includes(user.getStatusEffect())
         && target.canSetStatus(user.status?.effect)
         ),
     new AttackMove(Moves.TRUMP_CARD, Type.NORMAL, MoveCategory.SPECIAL, -1, -1, 5, -1, 0, 4)
@@ -5145,7 +5140,7 @@ export function initMoves() {
     new AttackMove(Moves.PSYSHOCK, Type.PSYCHIC, MoveCategory.SPECIAL, 80, 100, 10, -1, 0, 5)
       .attr(DefDefAttr),
     new AttackMove(Moves.VENOSHOCK, Type.POISON, MoveCategory.SPECIAL, 65, 100, 10, -1, 0, 5)
-      .attr(MovePowerMultiplierAttr, (user, target, move) => target.status && (target.status.effect === StatusEffect.POISON || target.status.effect === StatusEffect.TOXIC) ? 2 : 1),
+      .attr(MovePowerMultiplierAttr, (user, target, move) => [StatusEffect.POISON, StatusEffect.TOXIC].includes(target.getStatusEffect()) ? 2 : 1),
     new SelfStatusMove(Moves.AUTOTOMIZE, Type.STEEL, -1, 15, -1, 0, 5)
       .attr(StatChangeAttr, BattleStat.SPD, 2, true)
       .partial(),
@@ -5484,7 +5479,7 @@ export function initMoves() {
     new StatusMove(Moves.EERIE_IMPULSE, Type.ELECTRIC, 100, 15, -1, 0, 6)
       .attr(StatChangeAttr, BattleStat.SPATK, -2),
     new StatusMove(Moves.VENOM_DRENCH, Type.POISON, 100, 20, 100, 0, 6)
-      .attr(StatChangeAttr, [ BattleStat.ATK, BattleStat.SPATK, BattleStat.SPD ], -1, false, (user, target, move) => target.status?.effect === StatusEffect.POISON || target.status?.effect === StatusEffect.TOXIC)
+      .attr(StatChangeAttr, [ BattleStat.ATK, BattleStat.SPATK, BattleStat.SPD ], -1, false, (user, target, move) => [StatusEffect.POISON || StatusEffect.TOXIC].includes(target.getStatusEffect()))
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new StatusMove(Moves.POWDER, Type.BUG, 100, 20, -1, 1, 6)
       .powderMove()
@@ -6131,7 +6126,7 @@ export function initMoves() {
       .attr(StatChangeAttr, [ BattleStat.DEF, BattleStat.SPDEF ], -1, true)
       .punchingMove(),
     new AttackMove(Moves.BARB_BARRAGE, Type.POISON, MoveCategory.PHYSICAL, 60, 100, 10, 50, 0, 8)
-      .attr(MovePowerMultiplierAttr, (user, target, move) => target.status && (target.status.effect === StatusEffect.POISON || target.status.effect === StatusEffect.TOXIC) ? 2 : 1)
+      .attr(MovePowerMultiplierAttr, (user, target, move) => [StatusEffect.POISON, StatusEffect.TOXIC].includes(target.getStatusEffect()) ? 2 : 1)
       .attr(StatusEffectAttr, StatusEffect.POISON),
     new AttackMove(Moves.ESPER_WING, Type.PSYCHIC, MoveCategory.SPECIAL, 80, 100, 10, 100, 0, 8)
       .attr(HighCritAttr)

--- a/src/data/pokemon-forms.ts
+++ b/src/data/pokemon-forms.ts
@@ -244,7 +244,7 @@ export class SpeciesFormChangeStatusEffectTrigger extends SpeciesFormChangeTrigg
   }
 
   canChange(pokemon: Pokemon): boolean {
-    return (this.statusEffects.indexOf(pokemon.status?.effect || StatusEffect.NONE) > -1) !== this.invert;
+    return (this.statusEffects.indexOf(pokemon.getStatusEffect() || StatusEffect.NONE) > -1) !== this.invert;
   }
 }
 

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2283,7 +2283,7 @@ export class MovePhase extends BattlePhase {
       this.end();
     };
 
-    if (!this.followUp && this.pokemon.status && !this.pokemon.status.isPostTurn()) {
+    if (!this.followUp && this.pokemon.status && !this.pokemon.status.isPostTurn() && this.pokemon.getStatusEffect()) {
       this.pokemon.status.incrementTurn();
       let activated = false;
       let healed = false;
@@ -2906,7 +2906,7 @@ export class ObtainStatusEffectPhase extends PokemonPhase {
         });
         return;
       }
-    } else if (pokemon.status.effect === this.statusEffect)
+    } else if (pokemon.getStatusEffect() === this.statusEffect)
       this.scene.queueMessage(getPokemonMessage(pokemon, getStatusEffectOverlapText(this.statusEffect)));
     this.end();
   }


### PR DESCRIPTION
In most places where status condition is checked, a function will instead be called to check the mon's status and apply Lum Berry, ability etc. when necessary. This makes it a little more clean with abilities that cure you when they're gained/unsuppressed, and also fixes an issue I ran into where you'd lose a turn from sleep/freeze even with Lum Berry. This PR should also be compatible with Pastel Veil when it's added, assuming it's implemented as an arena tag. I also added a function to check which side a mon is on.

Basically:
- Lum Berry activates (if it can) basically whenever a mon's status is checked
- Insomnia, Immunity et al heal their respective status if a mon gains it, or if they're statused while the ability is suppressed

There might be a better way to do this by just having more triggers, such as:
- After a mon gets statused
- After arena tags change
- After an ability is gained or unsuppressed
- After a mon is summoned

This is still a draft while I clean up and test, this is a bigger change so it would be better to get more eyes on it/sanity checks before it's "ready".