### PR TITLE
Prevent Fusing Status Errors

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -3,7 +3,7 @@
   "short_name": "PokéRogue",
   "description": "A Pokémon fangame heavily inspired by the roguelite genre. Battle endlessly while gathering stacking items, exploring many different biomes, and reaching Pokémon stats you never thought possible.",
   "scope": "/",
-  "start_url": "https://pokerogue.net",
+  "start_url": "/",
   "display": "fullscreen",
   "background_color": "#8c8c8c",
   "theme_color": "#8c8c8c",

--- a/src/data/status-effect.ts
+++ b/src/data/status-effect.ts
@@ -135,3 +135,43 @@ export function getStatusEffectCatchRateMultiplier(statusEffect: StatusEffect): 
 
   return 1;
 }
+
+/**
+* Returns a random non-volatile StatusEffect
+*/
+export function generateRandomStatusEffect(): StatusEffect {
+  return Utils.randIntRange(1, 6);
+}
+
+/**
+* Returns a random non-volatile StatusEffect between the two provided
+* @param statusEffectA The first StatusEffect
+* @param statusEffectA The second StatusEffect
+*/
+export function getRandomStatusEffect(statusEffectA: StatusEffect, statusEffectB: StatusEffect): StatusEffect {
+  if (statusEffectA === StatusEffect.NONE || statusEffectA === StatusEffect.FAINT) {
+    return statusEffectB;
+  }
+  if (statusEffectB === StatusEffect.NONE || statusEffectB === StatusEffect.FAINT) {
+    return statusEffectA;
+  }
+
+  return Utils.randIntRange(0, 2) ? statusEffectA : statusEffectB;
+}
+
+/**
+* Returns a random non-volatile StatusEffect between the two provided
+* @param statusA The first Status
+* @param statusB The second Status
+*/
+export function getRandomStatus(statusA: Status, statusB: Status): Status {  
+  if (statusA === undefined || statusA.effect === StatusEffect.NONE || statusA.effect === StatusEffect.FAINT) {
+    return statusB;
+  }
+  if (statusB === undefined || statusB.effect === StatusEffect.NONE || statusB.effect === StatusEffect.FAINT) {
+    return statusA;
+  }
+  
+
+  return Utils.randIntRange(0, 2) ? statusA : statusB;
+}

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -14,7 +14,7 @@ import { AttackTypeBoosterModifier, DamageMoneyRewardModifier, EnemyDamageBooste
 import { PokeballType } from '../data/pokeball';
 import { Gender } from '../data/gender';
 import { initMoveAnim, loadMoveAnimAssets } from '../data/battle-anims';
-import { Status, StatusEffect } from '../data/status-effect';
+import { Status, StatusEffect, getRandomStatus } from '../data/status-effect';
 import { pokemonEvolutions, pokemonPrevolutions, SpeciesFormEvolution, SpeciesEvolutionCondition, FusionSpeciesFormEvolution } from '../data/pokemon-evolutions';
 import { reverseCompatibleTms, tmSpecies } from '../data/tms';
 import { DamagePhase, FaintPhase, LearnMovePhase, ObtainStatusEffectPhase, StatChangePhase, SwitchSummonPhase } from '../phases';
@@ -2542,6 +2542,10 @@ export class PlayerPokemon extends Pokemon {
     this.generateCompatibleTms();
   }
 
+  /**
+  * Returns a Promise to fuse two PlayerPokemon together
+  * @param pokemon The PlayerPokemon to fuse to this one
+  */
   fuse(pokemon: PlayerPokemon): Promise<void> {
     return new Promise(resolve => {
       this.fusionSpecies = pokemon.species;
@@ -2555,8 +2559,25 @@ export class PlayerPokemon extends Pokemon {
       this.scene.validateAchv(achvs.SPLICE);
       this.scene.gameData.gameStats.pokemonFused++;
 
+      // Store the average HP% that each Pokemon has
+      const newHpPercent = ((pokemon.hp / pokemon.stats[Stat.HP]) + (this.hp / this.stats[Stat.HP])) / 2;
+
       this.generateName();
       this.calculateStats();
+      
+      // Set this Pokemon's HP to the average % of both fusion components
+      this.hp = Math.round(this.stats[Stat.HP] * newHpPercent);
+      if (!this.isFainted()) {
+        // If this Pokemon hasn't fainted, make sure the HP wasn't set over the new maximum
+        this.hp = Math.min(this.hp, this.stats[Stat.HP]);
+        this.status = getRandomStatus(this.status, pokemon.status); // Get a random valid status between the two
+      }
+      else if (!pokemon.isFainted()) {
+        // If this Pokemon fainted but the other hasn't, make sure the HP wasn't set to zero
+        this.hp = Math.max(this.hp, 1);
+        this.status = pokemon.status; // Inherit the other Pokemon's status
+      }
+
       this.generateCompatibleTms();
       this.updateInfo(true);
       const fusedPartyMemberIndex = this.scene.getParty().indexOf(pokemon);

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1179,14 +1179,25 @@ export class SummonPhase extends PartyMemberPokemonPhase {
     this.preSummon();
   }
 
+  /**
+  * Sends out a Pokemon before the battle begins and shows the appropriate messages
+  */
   preSummon(): void {
     const partyMember = this.getPokemon();
+    // If the Pokemon about to be sent out is fainted, switch to the first non-fainted Pokemon
     if (partyMember.isFainted()) {
+      console.warn("The Pokemon about to be sent out is fainted. Attempting to resolve...");
       const party = this.getParty();
-      const nonFaintedIndex = party.slice(this.partyMemberIndex).findIndex(p => !p.isFainted()) + this.partyMemberIndex;
-      const nonFaintedPartyMember = party[nonFaintedIndex];
-      party[nonFaintedIndex] = partyMember;
-      party[this.partyMemberIndex] = nonFaintedPartyMember;
+      
+      const nonFaintedIndex = party.findIndex(x => !x.isFainted()); // Find the first non-fainted Pokemon index
+      if (nonFaintedIndex === -1) {
+        console.error("Party Details:\n", party);
+        throw new Error("All available Pokemon were fainted!");
+      }
+
+      // Swaps the fainted Pokemon and the first non-fainted Pokemon in the party
+      [party[this.partyMemberIndex], party[nonFaintedIndex]] = [party[nonFaintedIndex], party[this.partyMemberIndex]]; 
+      console.warn("Swapped %s %O with %s %O", partyMember?.name, partyMember, party[0]?.name, party[0]);
     }
 
     if (this.player) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,6 +62,11 @@ export function padInt(value: integer, length: integer, padWith?: string): strin
   return valueStr;
 }
 
+/**
+* Returns a random integer between min and min + range
+* @param range The amount of possible numbers
+* @param min The starting number
+*/
 export function randInt(range: integer, min: integer = 0): integer {
   if (range === 1)
     return min;
@@ -74,6 +79,11 @@ export function randSeedInt(range: integer, min: integer = 0): integer {
   return Phaser.Math.RND.integerInRange(min, (range - 1) + min);
 }
 
+/**
+* Returns a random integer between min and max (non-inclusive)
+* @param min The lowest number
+* @param max The highest number
+*/
 export function randIntRange(min: integer, max: integer): integer {
   return randInt(max - min, min);
 }


### PR DESCRIPTION
Currently, if a fainted Pokemon gets fused with a non-fainted one then the Pokemon becomes fainted. This can cause tons of issues since it reduces your party size and faints that slot. 

This will balance fusions a bit. The resulting HP is now based on the average percentage each Pokemon was at. So a fainted and non-fainted results in a non-fainted pokemon with 50% HP. Two fainted Pokemon still becomes one fainted. Status effects are also inherited. So if one Pokemon was healthy but the other was Burned, the resulting Pokemon is burned. If both have a status, it chooses randomly between them.

Finally, this also adds some extra error messages in the case that a fainted Pokemon gets sent out at the start of a battle. This isn't intended to be able to happen, so the console now better states what happens if it does. The logic which swaps to the next available pokemon is unchanged, but now throws an explicit error if your entire party is fainted (which should **really** never happen).


https://github.com/pagefaultgames/pokerogue/assets/13838608/588b5cc1-f76f-45ec-81eb-63267311e403


https://github.com/pagefaultgames/pokerogue/assets/13838608/acaf2c36-412e-48ac-8dea-7af975877b71


https://github.com/pagefaultgames/pokerogue/assets/13838608/0a90df1e-48df-4eab-a086-379d218c5dd9


https://github.com/pagefaultgames/pokerogue/assets/13838608/adc75433-a197-4f10-a9f0-4eea0b633b77


https://github.com/pagefaultgames/pokerogue/assets/13838608/6b8a1750-8094-4dbd-9e2b-9e0c79f196c1


https://github.com/pagefaultgames/pokerogue/assets/13838608/b9aea5cf-a22c-4313-a249-8244243a77ed



https://github.com/pagefaultgames/pokerogue/assets/13838608/b0301ecc-d0cb-4791-8f95-741f8f3ce39e


https://github.com/pagefaultgames/pokerogue/assets/13838608/27fecdac-0bef-4f03-b61f-8393863c2584