### PR TITLE
Implement Water Shuriken Battle Bond condition

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -3217,8 +3217,7 @@ export function initAbilities() {
       .attr(UncopiableAbilityAbAttr)
       .attr(UnswappableAbilityAbAttr)
       .attr(UnsuppressableAbilityAbAttr)
-      .attr(NoFusionAbilityAbAttr)
-      .partial(),
+      .attr(NoFusionAbilityAbAttr),
     new Ability(Abilities.POWER_CONSTRUCT, 7) // TODO: 10% Power Construct Zygarde isn't accounted for yet. If changed, update Zygarde's getSpeciesFormIndex entry accordingly
       .attr(PostBattleInitFormChangeAbAttr, p => p.getHpRatio() <= 0.5 ? 4 : 2)
       .attr(PostSummonFormChangeAbAttr, p => p.getHpRatio() <= 0.5 ? 4 : 2)

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -986,13 +986,11 @@ export class ChangeMultiHitTypeAttr extends MoveAttr {
 
 export class WaterShurikenMultiHitTypeAttr extends ChangeMultiHitTypeAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    if ([user.species.speciesId, user.fusionSpecies?.speciesId].includes(Species.GRENINJA) && user.hasAbility(Abilities.BATTLE_BOND)) {
-      if ((user.species.speciesId === Species.GRENINJA ? user.formIndex : user.fusionSpecies.formIndex) == 2) {
-        (args[0] as Utils.IntegerHolder).value = MultiHitType._3
-        return true;
-      }
-      return false;
+    if (user.species.speciesId == Species.GRENINJA && user.hasAbility(Abilities.BATTLE_BOND) && user.formIndex == 2) {
+      (args[0] as Utils.IntegerHolder).value = MultiHitType._3
+      return true;
     }
+    return false;
   }
 }
 
@@ -2072,13 +2070,11 @@ export class KnockOffPowerAttr extends VariablePowerAttr {
 
 export class WaterShurikenPowerAttr extends VariablePowerAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    if ([user.species.speciesId, user.fusionSpecies?.speciesId].includes(Species.GRENINJA) && user.hasAbility(Abilities.BATTLE_BOND)) {
-      if ((user.species.speciesId === Species.GRENINJA ? user.formIndex : user.fusionSpecies.formIndex) == 2) {
-        (args[0] as Utils.IntegerHolder).value = 20
-        return true;
-      }
-      return false;
+    if (user.species.speciesId == Species.GRENINJA && user.hasAbility(Abilities.BATTLE_BOND) && user.formIndex == 2) {
+      (args[0] as Utils.IntegerHolder).value = 20
+      return true;
     }
+    return false;
   }
 }
 

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -756,7 +756,7 @@ export enum MultiHitType {
   _2_TO_5,
   _3,
   _3_INCR,
-  _1_TO_10
+  _1_TO_10,
 }
 
 export class HealAttr extends MoveEffectAttr {
@@ -912,7 +912,9 @@ export class MultiHitAttr extends MoveAttr {
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     let hitTimes: integer;
-    switch (this.multiHitType) {
+    const hitType = new Utils.IntegerHolder(this.multiHitType)
+    applyMoveAttrs(ChangeMultiHitTypeAttr, user, target, move, hitType)
+    switch (hitType.value) {
       case MultiHitType._2_TO_5:
         {
           const rand = user.randSeedInt(16);
@@ -972,6 +974,25 @@ export class MultiHitAttr extends MoveAttr {
 
   getTargetBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
     return -5;
+  }
+}
+
+export class ChangeMultiHitTypeAttr extends MoveAttr {
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    //const hitType = args[0] as Utils.NumberHolder;
+    return false;
+  }
+}
+
+export class WaterShurikenMultiHitTypeAttr extends ChangeMultiHitTypeAttr {
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    if ([user.species.speciesId, user.fusionSpecies?.speciesId].includes(Species.GRENINJA) && user.hasAbility(Abilities.BATTLE_BOND)) {
+      if ((user.species.speciesId === Species.GRENINJA ? user.formIndex : user.fusionSpecies.formIndex) == 2) {
+        (args[0] as Utils.IntegerHolder).value = MultiHitType._3
+        return true;
+      }
+      return false;
+    }
   }
 }
 
@@ -2046,6 +2067,18 @@ export class KnockOffPowerAttr extends VariablePowerAttr {
     }
     
     return false;
+  }
+}
+
+export class WaterShurikenPowerAttr extends VariablePowerAttr {
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    if ([user.species.speciesId, user.fusionSpecies?.speciesId].includes(Species.GRENINJA) && user.hasAbility(Abilities.BATTLE_BOND)) {
+      if ((user.species.speciesId === Species.GRENINJA ? user.formIndex : user.fusionSpecies.formIndex) == 2) {
+        (args[0] as Utils.IntegerHolder).value = 20
+        return true;
+      }
+      return false;
+    }
   }
 }
 
@@ -5473,7 +5506,9 @@ export function initMoves() {
     new AttackMove(Moves.HYPERSPACE_HOLE, Type.PSYCHIC, MoveCategory.SPECIAL, 80, -1, 5, -1, 0, 6)
       .ignoresProtect(),
     new AttackMove(Moves.WATER_SHURIKEN, Type.WATER, MoveCategory.SPECIAL, 15, 100, 20, -1, 1, 6)
-      .attr(MultiHitAttr),
+      .attr(MultiHitAttr)
+      .attr(WaterShurikenPowerAttr)
+      .attr(WaterShurikenMultiHitTypeAttr),
     new AttackMove(Moves.MYSTICAL_FIRE, Type.FIRE, MoveCategory.SPECIAL, 75, 100, 10, 100, 0, 6)
       .attr(StatChangeAttr, BattleStat.SPATK, -1),
     new SelfStatusMove(Moves.SPIKY_SHIELD, Type.GRASS, -1, 10, -1, 4, 6)


### PR DESCRIPTION
Add a new (potential) general-purpose attribute, and 2 move-specific ones for Water Shuriken. 

- `ChangeMultiHitTypeAttr` can be extended to be checked before a multi-hit move is processed, if you want its multi-hit type to be conditional. 
- `WaterShurikenMultiHitTypeAttr` checks if you're a Greninja in Ash-Greninja form with the ability Battle Bond (for good measure...), and changes the move's `MultiHitType` to 3 if you are. 
- `WaterShurikenPowerAttr` does the exact same check, and changes the move's power to 20 if you are. 

All of this should make Battle Bond fully implemented, so its `.partial()` tag is removed as part of this as well.