### PR TITLE
Psychic Terrain no longer blocks priority moves targeted at the user's side

### DIFF
--- a/src/data/terrain.ts
+++ b/src/data/terrain.ts
@@ -4,6 +4,7 @@ import { Type } from "./type";
 import * as Utils from "../utils";
 import { IncrementMovePriorityAbAttr, applyAbAttrs } from "./ability";
 import { ProtectAttr } from "./move";
+import { BattlerIndex } from "#app/battle.js";
 
 export enum TerrainType {
   NONE,
@@ -48,13 +49,13 @@ export class Terrain {
     return 1;
   }
 
-  isMoveTerrainCancelled(user: Pokemon, move: Move): boolean {
+  isMoveTerrainCancelled(user: Pokemon, targets: BattlerIndex[], move: Move): boolean {
     switch (this.terrainType) {
       case TerrainType.PSYCHIC:
-        if (!move.getAttrs(ProtectAttr).length){
+        if (!move.getAttrs(ProtectAttr).length) {
           const priority = new Utils.IntegerHolder(move.priority);
           applyAbAttrs(IncrementMovePriorityAbAttr, user, null, move, priority);
-          return priority.value > 0;
+          return priority.value > 0 && user.getOpponents().filter(o => targets.includes(o.getBattlerIndex())).length > 0;
         }
     }
 

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -336,8 +336,8 @@ export class Arena {
     return this.weather && !this.weather.isEffectSuppressed(this.scene) && this.weather.isMoveWeatherCancelled(move);
   }
 
-  isMoveTerrainCancelled(user: Pokemon, move: Move) {
-    return this.terrain && this.terrain.isMoveTerrainCancelled(user, move);
+  isMoveTerrainCancelled(user: Pokemon, targets: BattlerIndex[], move: Move) {
+    return this.terrain && this.terrain.isMoveTerrainCancelled(user, targets, move);
   }
 
   getTerrainType() : TerrainType {

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2269,7 +2269,7 @@ export class MovePhase extends BattlePhase {
       let failedText = null;
       if (success && this.scene.arena.isMoveWeatherCancelled(this.move.getMove()))
         success = false;
-      else if (success && this.scene.arena.isMoveTerrainCancelled(this.pokemon, this.move.getMove())) {
+      else if (success && this.scene.arena.isMoveTerrainCancelled(this.pokemon, this.targets, this.move.getMove())) {
         success = false;
         failedText = getTerrainBlockMessage(targets[0], this.scene.arena.terrain.terrainType);
       }


### PR DESCRIPTION
Examples, side Aqua Jet, Prankster Bulk Up will now properly work in Psychic Terrain. This is done by making `isMoveTerrainCancelled` take in the target list and checking if any opponents are being targeted. Fixes https://discord.com/channels/1125469663833370665/1236464078898069504