### PR TITLE
Add Setting to Swap A and B on Gamepad 

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -235,6 +235,10 @@ export default class BattleScene extends SceneBase {
 		this.nextCommandPhaseQueue = [];
 	}
 
+	/**
+	 * Conditionally swaps the ACTION and CANCEL button
+	 * @param standard When true, uses the default values
+	 */
 	setGamepadConfirm(standard: boolean) {
 		this.gamepadKeyConfig[Button.ACTION] = standard ? 0 : 1;
 		this.gamepadKeyConfig[Button.CANCEL] = standard ? 1 : 0;

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -235,6 +235,11 @@ export default class BattleScene extends SceneBase {
 		this.nextCommandPhaseQueue = [];
 	}
 
+	setGamepadConfirm(standard: boolean) {
+		this.gamepadKeyConfig[Button.ACTION] = standard ? 0 : 1;
+		this.gamepadKeyConfig[Button.CANCEL] = standard ? 1 : 0;
+	}
+
 	loadPokemonAtlas(key: string, atlasPath: string, experimental?: boolean) {
 		if (experimental === undefined)
 			experimental = this.experimentalSprites;

--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -25,6 +25,7 @@ export enum Setting {
   Fusion_Palette_Swaps = "FUSION_PALETTE_SWAPS",
   Player_Gender = "PLAYER_GENDER",
   Gamepad_Support = "GAMEPAD_SUPPORT",
+  Swap_A_and_B = "SWAP_A_B",
   Touch_Controls = "TOUCH_CONTROLS",
   Vibration = "VIBRATION"
 }
@@ -56,6 +57,7 @@ export const settingOptions: SettingOptions = {
   [Setting.Fusion_Palette_Swaps]: [ 'Off', 'On' ],
   [Setting.Player_Gender]: [ 'Boy', 'Girl' ],
   [Setting.Gamepad_Support]: [ 'Auto', 'Disabled' ],
+  [Setting.Swap_A_and_B]: [ 'Enabled', 'Disabled' ],
   [Setting.Touch_Controls]: [ 'Auto', 'Disabled' ],
   [Setting.Vibration]: [ 'Auto', 'Disabled' ]
 };
@@ -79,6 +81,7 @@ export const settingDefaults: SettingDefaults = {
   [Setting.Fusion_Palette_Swaps]: 1,
   [Setting.Player_Gender]: 0,
   [Setting.Gamepad_Support]: 0,
+  [Setting.Swap_A_and_B]: 1,
   [Setting.Touch_Controls]: 0,
   [Setting.Vibration]: 0
 };
@@ -147,6 +150,9 @@ export function setSetting(scene: BattleScene, setting: Setting, value: integer)
       break;
     case Setting.Gamepad_Support:
       scene.gamepadSupport = settingOptions[setting][value] !== 'Disabled';
+      break;
+    case Setting.Swap_A_and_B:debugger;
+      scene.setGamepadConfirm(settingOptions[setting][value] !== 'Enabled');
       break;
     case Setting.Touch_Controls:
       scene.enableTouchControls = settingOptions[setting][value] !== 'Disabled' && hasTouchscreen();

--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -25,7 +25,7 @@ export enum Setting {
   Fusion_Palette_Swaps = "FUSION_PALETTE_SWAPS",
   Player_Gender = "PLAYER_GENDER",
   Gamepad_Support = "GAMEPAD_SUPPORT",
-  Swap_A_and_B = "SWAP_A_B",
+  Swap_A_and_B = "SWAP_A_B", // Swaps which gamepad button handles ACTION and CANCEL
   Touch_Controls = "TOUCH_CONTROLS",
   Vibration = "VIBRATION"
 }
@@ -81,7 +81,7 @@ export const settingDefaults: SettingDefaults = {
   [Setting.Fusion_Palette_Swaps]: 1,
   [Setting.Player_Gender]: 0,
   [Setting.Gamepad_Support]: 0,
-  [Setting.Swap_A_and_B]: 1,
+  [Setting.Swap_A_and_B]: 1, // Set to 'Disabled' by default
   [Setting.Touch_Controls]: 0,
   [Setting.Vibration]: 0
 };


### PR DESCRIPTION
Added a new setting to swap the A and B button on controller. Defaults to off which retains the current behavior on live.