### PR TITLE
Small Typo when Learning a TM

### DIFF
--- a/src/locales/es/battle.ts
+++ b/src/locales/es/battle.ts
@@ -24,7 +24,7 @@ export const battle: SimpleTranslationEntries = {
   "expGain": "{{pokemonName}} ha ganado\n{{exp}} puntos de experiencia.",
   "levelUp": "¡{{pokemonName}} ha subido al \nNv. {{level}}!",
   "learnMove": "¡{{pokemonName}} ha aprendido {{moveName}}!",
-  "learnMovePrompt": "{{pokemonName}} quiere aprender {{moveName}}.",
+  "learnMovePrompt": "{{pokemonName}} quiere aprender\n{{moveName}}.",
   "learnMoveLimitReached": "Pero, {{pokemonName}} ya conoce\ncuatro movimientos.",
   "learnMoveReplaceQuestion": "¿Quieres sustituir uno de sus movimientos por {{moveName}}?",
   "learnMoveStopTeaching": "¿Prefieres que no aprenda\n{{moveName}}?",

--- a/src/locales/it/battle.ts
+++ b/src/locales/it/battle.ts
@@ -24,7 +24,7 @@ export const battle: SimpleTranslationEntries = {
   "expGain": "{{pokemonName}} ha guadagnato\n{{exp}} Punti Esperienza!",
   "levelUp": "{{pokemonName}} è salito al \nLivello {{level}}!",
   "learnMove": "{{pokemonName}} impara \n{{moveName}}!",
-  "learnMovePrompt": "{{pokemonName}} vorrebbe imparare \l{{moveName}}.",
+  "learnMovePrompt": "{{pokemonName}} vorrebbe imparare\n{{moveName}}.",
   "learnMoveLimitReached": "Tuttavia, {{pokemonName}} \nconosce già quattro mosse.",
   "learnMoveReplaceQuestion": "Vuoi che ne dimentichi una e al suo \nposto la sostituisca con {{moveName}}?",
   "learnMoveStopTeaching": "Vuoi smettere di fargli imparare \n{{moveName}}?",


### PR DESCRIPTION
Fixes a small typo when learning a tm. The incorrect escape character was being used and no escape character was being used for Spanish.