### PR TITLE
Stat change comma fix

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2839,7 +2839,7 @@ export class StatChangePhase extends PokemonPhase {
       if (relLevelStats.length > 1) {
         statsFragment = relLevelStats.length >= 5
           ? 'stats'
-          : `${relLevelStats.slice(0, -1).map(s => getBattleStatName(s)).join(', ')}, and ${getBattleStatName(relLevelStats[relLevelStats.length - 1])}`;
+          : `${relLevelStats.slice(0, -1).map(s => getBattleStatName(s)).join(', ')}${relLevelStats.length > 2 ? ',' : ''} and ${getBattleStatName(relLevelStats[relLevelStats.length - 1])}`;
       } else
         statsFragment = getBattleStatName(relLevelStats[0]);
       messages.push(getPokemonMessage(this.getPokemon(), `'s ${statsFragment} ${getBattleStatLevelChangeDescription(Math.abs(parseInt(rl)), levels >= 1)}!`));


### PR DESCRIPTION
Previously, changing 2 stats would display as "Sprigatito's Attack, and Sp. Atk rose!". This isn't proper grammar, as there shouldn't be a comma if there's only 2 subjects. This adds a check so the comma won't show up if there's only 2 stats; so it'll write "Sprigatito's Attack and Sp. Atk rose!", but also "Sprigatito's Attack, Sp. Atk, and Speed rose!"