### PR TITLE
Fix - Black screen on input for some players

### DIFF
--- a/src/inputs-controller.ts
+++ b/src/inputs-controller.ts
@@ -110,6 +110,7 @@ export class InputsController {
 
     getActionGamepadMapping(): ActionGamepadMapping {
         const gamepadMapping = {};
+        if (!this.player?.mapping) return gamepadMapping;
         gamepadMapping[this.player.mapping.LC_N] = Button.UP;
         gamepadMapping[this.player.mapping.LC_S] = Button.DOWN;
         gamepadMapping[this.player.mapping.LC_W] = Button.LEFT;


### PR DESCRIPTION
Fix for:
https://discord.com/channels/1125469663833370665/1236692838973181992/1236692838973181992

the player.mapping variable should be initialized when a controller is connected or when a controller is already connected.
and then, inputs from gamepad and keyboard are listened and use this variable (this.player.mapping) to know which action need to be done.

For some reason, for some players, the gamepad and keyboard is listened before this variable is initialized.
So i set a condition to check if this variable is initialized before trying to know which action need to be done.