### PR TITLE
Fix ability Liquid Ooze

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -549,8 +549,9 @@ export class MoveImmunityStatChangeAbAttr extends MoveImmunityAbAttr {
 
 export class ReverseDrainAbAttr extends PostDefendAbAttr {
   applyPostDefend(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: PokemonMove, hitResult: HitResult, args: any[]): boolean {
-    if (!!move.getMove().getAttrs(HitHealAttr).length || !!move.getMove().getAttrs(StrengthSapHealAttr).length ) {
-      pokemon.scene.queueMessage(getPokemonMessage(attacker, ` sucked up the liquid ooze!`));
+    const isDrain = args.some(arg => typeof arg === 'object' && 'seedDrain' in arg && !!arg['seedDrain']);
+    if (!!move.getMove().getAttrs(HitHealAttr).length || !!move.getMove().getAttrs(StrengthSapHealAttr).length || isDrain) {
+      pokemon.scene.queueMessage(getPokemonMessage(attacker, ' sucked up the liquid ooze!'));
       return true;
     }
     return false;
@@ -2870,7 +2871,8 @@ export function initAbilities() {
       .conditionalAttr(pokemon => !!pokemon.status, BattleStatMultiplierAbAttr, BattleStat.DEF, 1.5)
       .ignorable(),
     new Ability(Abilities.LIQUID_OOZE, 3)
-      .attr(ReverseDrainAbAttr),
+      .attr(ReverseDrainAbAttr)
+      .bypassFaint(),
     new Ability(Abilities.OVERGROW, 3)
       .attr(LowHpMoveTypePowerBoostAbAttr, Type.GRASS),
     new Ability(Abilities.BLAZE, 3)

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -900,12 +900,7 @@ export class HitHealAttr extends MoveEffectAttr {
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const healAmount = Math.max(Math.floor(user.turnData.damageDealt * this.healRatio), 1);
-    const reverseDrain = user.hasAbilityWithAttr(ReverseDrainAbAttr);
-    user.scene.unshiftPhase(new PokemonHealPhase(user.scene, user.getBattlerIndex(),
-      !reverseDrain ? healAmount : healAmount * -1,
-      !reverseDrain ? getPokemonMessage(target, ` had its\nenergy drained!`) : undefined,
-      false, true));
-    if (reverseDrain) user.turnData.damageTaken += healAmount;
+    target.drain(user, healAmount,  getPokemonMessage(target, ' had its\nenergy drained!'));
     return true;
   }
 
@@ -921,11 +916,7 @@ export class StrengthSapHealAttr extends MoveEffectAttr {
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const healAmount = target.stats[Stat.ATK] * (Math.max(2, 2 + target.summonData.battleStats[BattleStat.ATK]) / Math.max(2, 2 - target.summonData.battleStats[BattleStat.ATK]));
-    const reverseDrain = user.hasAbilityWithAttr(ReverseDrainAbAttr);
-    user.scene.unshiftPhase(new PokemonHealPhase(user.scene, user.getBattlerIndex(),
-      !reverseDrain ? healAmount : healAmount * -1,
-      !reverseDrain ? getPokemonMessage(user, ` regained\nhealth!`) : undefined,
-      false, true));
+    target.drain(user, healAmount,  getPokemonMessage(target, ' regained\nhealth!'));
     return true;
   }
 }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -17,7 +17,7 @@ import { initMoveAnim, loadMoveAnimAssets } from '../data/battle-anims';
 import { Status, StatusEffect, getRandomStatus } from '../data/status-effect';
 import { pokemonEvolutions, pokemonPrevolutions, SpeciesFormEvolution, SpeciesEvolutionCondition, FusionSpeciesFormEvolution } from '../data/pokemon-evolutions';
 import { reverseCompatibleTms, tmSpecies } from '../data/tms';
-import { DamagePhase, FaintPhase, LearnMovePhase, ObtainStatusEffectPhase, StatChangePhase, SwitchSummonPhase } from '../phases';
+import { DamagePhase, FaintPhase, LearnMovePhase, ObtainStatusEffectPhase, PokemonHealPhase, StatChangePhase, SwitchSummonPhase } from '../phases';
 import { BattleStat } from '../data/battle-stat';
 import { BattlerTag, BattlerTagLapseType, EncoreTag, HelpingHandTag, HighestStatBoostTag, TypeBoostTag, getBattlerTag } from '../data/battler-tags';
 import { BattlerTagType } from "../data/enums/battler-tag-type";
@@ -27,7 +27,7 @@ import { TempBattleStat } from '../data/temp-battle-stat';
 import { ArenaTagSide, WeakenMoveScreenTag, WeakenMoveTypeTag } from '../data/arena-tag';
 import { ArenaTagType } from "../data/enums/arena-tag-type";
 import { Biome } from "../data/enums/biome";
-import { Ability, AbAttr, BattleStatMultiplierAbAttr, BlockCritAbAttr, BonusCritAbAttr, BypassBurnDamageReductionAbAttr, FieldPriorityMoveImmunityAbAttr, FieldVariableMovePowerAbAttr, IgnoreOpponentStatChangesAbAttr, MoveImmunityAbAttr, MoveTypeChangeAttr, NonSuperEffectiveImmunityAbAttr, PreApplyBattlerTagAbAttr, PreDefendFullHpEndureAbAttr, ReceivedMoveDamageMultiplierAbAttr, ReduceStatusEffectDurationAbAttr, StabBoostAbAttr, StatusEffectImmunityAbAttr, TypeImmunityAbAttr, VariableMovePowerAbAttr, VariableMoveTypeAbAttr, WeightMultiplierAbAttr, allAbilities, applyAbAttrs, applyBattleStatMultiplierAbAttrs, applyPostDefendAbAttrs, applyPreApplyBattlerTagAbAttrs, applyPreAttackAbAttrs, applyPreDefendAbAttrs, applyPreSetStatusAbAttrs, UnsuppressableAbilityAbAttr, SuppressFieldAbilitiesAbAttr, NoFusionAbilityAbAttr, MultCritAbAttr, IgnoreTypeImmunityAbAttr } from '../data/ability';
+import { Ability, AbAttr, BattleStatMultiplierAbAttr, BlockCritAbAttr, BonusCritAbAttr, BypassBurnDamageReductionAbAttr, FieldPriorityMoveImmunityAbAttr, FieldVariableMovePowerAbAttr, IgnoreOpponentStatChangesAbAttr, MoveImmunityAbAttr, MoveTypeChangeAttr, NonSuperEffectiveImmunityAbAttr, PreApplyBattlerTagAbAttr, PreDefendFullHpEndureAbAttr, ReceivedMoveDamageMultiplierAbAttr, ReduceStatusEffectDurationAbAttr, StabBoostAbAttr, StatusEffectImmunityAbAttr, TypeImmunityAbAttr, VariableMovePowerAbAttr, VariableMoveTypeAbAttr, WeightMultiplierAbAttr, allAbilities, applyAbAttrs, applyBattleStatMultiplierAbAttrs, applyPostDefendAbAttrs, applyPreApplyBattlerTagAbAttrs, applyPreAttackAbAttrs, applyPreDefendAbAttrs, applyPreSetStatusAbAttrs, UnsuppressableAbilityAbAttr, SuppressFieldAbilitiesAbAttr, NoFusionAbilityAbAttr, MultCritAbAttr, IgnoreTypeImmunityAbAttr, ReverseDrainAbAttr } from '../data/ability';
 import { Abilities } from "#app/data/enums/abilities";
 import PokemonData from '../system/pokemon-data';
 import Battle, { BattlerIndex } from '../battle';
@@ -2311,6 +2311,17 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   destroy(): void {
     this.battleInfo?.destroy();
     super.destroy();
+  }
+
+  /** Heals the source Pokemon of the given amount, or damages it if this Pokemon has a ReverseDrainAbAttr ability. */
+  drain(source: Pokemon, amount: number, healMessage: string): void {
+    const reverseDrain = this.hasAbilityWithAttr(ReverseDrainAbAttr);
+    if (reverseDrain) {
+      source.damageAndUpdate(amount);
+      source.turnData.damageTaken += amount;
+    }
+    else
+      source.scene.unshiftPhase(new PokemonHealPhase(source.scene, source.getBattlerIndex(), amount, healMessage, false, true));
   }
 }
 

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -3901,15 +3901,11 @@ export class PokemonHealPhase extends CommonAnimPhase {
     const hasMessage = !!this.message;
     let lastStatusEffect = StatusEffect.NONE;
 
-    if (!fullHp || this.hpHealed < 0) {
+    if (!fullHp) {
       const hpRestoreMultiplier = new Utils.IntegerHolder(1);
       if (!this.revive)
         this.scene.applyModifiers(HealingBoosterModifier, this.player, hpRestoreMultiplier);
       const healAmount = new Utils.NumberHolder(Math.floor(this.hpHealed * hpRestoreMultiplier.value));
-      if (healAmount.value < 0) {
-        pokemon.damageAndUpdate(healAmount.value * -1, HitResult.HEAL);
-        healAmount.value = 0;
-      }
       // Prevent healing to full if specified (in case of healing tokens so Sturdy doesn't cause a softlock)
       if (this.preventFullHeal && pokemon.hp + healAmount.value >= pokemon.getMaxHp())
         healAmount.value = (pokemon.getMaxHp() - pokemon.hp) - 1;


### PR DESCRIPTION
Pokemons attacking a target with Liquid Ooze should take damage instead of healing with draining moves (Leech Seed, Strength Sap, all moves like Mega Drain).
Instead, it currently applies when the Pokemon with Liquid Ooze uses a draining move.

The PR also refactors how the damage from Liquid Ooze is applied, to use a proper DamagePhase instead of a PokemonHealPhase with negative healing amount. This fixes the animation and number display, to use damage animation instead of healing animation

Also Liquid Ooze now applies even if the target dies from the draining hit


https://github.com/pagefaultgames/pokerogue/assets/71925152/e62a1e9e-b284-48a9-9f1e-770a94abc142

