### PR TITLE
Implement curse

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2716,8 +2716,8 @@ export class CurseAttr extends MoveEffectAttr {
       target.addTag(BattlerTagType.CURSED, 0, move.id, user.id);
       return true;
     } else {
-      user.scene.unshiftPhase(new StatChangePhase(user.scene, user.getBattlerIndex(), this.selfTarget, [BattleStat.ATK, BattleStat.DEF], 1));
-      user.scene.unshiftPhase(new StatChangePhase(user.scene, user.getBattlerIndex(), this.selfTarget, [BattleStat.SPD], -1));
+      user.scene.unshiftPhase(new StatChangePhase(user.scene, user.getBattlerIndex(), true, [BattleStat.ATK, BattleStat.DEF], 1));
+      user.scene.unshiftPhase(new StatChangePhase(user.scene, user.getBattlerIndex(), true, [BattleStat.SPD], -1));
       return true;
     }
   }


### PR DESCRIPTION
* Gen 8 curse is always a random opponent target
* Curse recoil damage will always be at least 1 as Shedinja will faint upon using it
* Curse ignores substitute and protect like moves *except* crafty shield but substitute and crafty shield are still (N) right now