### PR TITLE
Make curse target

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -4418,7 +4418,6 @@ export function initMoves() {
       .soundBased(),
     new StatusMove(Moves.CURSE, Type.GHOST, -1, 10, -1, 0, 2)
       .attr(CurseAttr)
-      .target(MoveTarget.RANDOM_NEAR_ENEMY)
       .ignoresProtect(true),
     new AttackMove(Moves.FLAIL, Type.NORMAL, MoveCategory.PHYSICAL, -1, 100, 15, -1, 0, 2)
       .attr(LowHpPowerAttr),


### PR DESCRIPTION
Curse currently uses the gen 7 implementation that always selects a random target. This change adds targeting back to curse as of gen 9. Downside is that non ghost type users have to do another input with the way targeting works right now.

Also ignoring the edge case of using curse on an ally targeting a random enemy because that is utterly incomprehensible and instead uses the older generation version where you can still curse allies.