### PR TITLE
Save battler tags

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -69,6 +69,11 @@ export class BattlerTag {
       : null;
   }
 
+  /**
+  * When given a battler tag or json representing one, load the data for it.
+  * This is meant to be inherited from by any battler tag with custom attributes
+  * @param {BattlerTag | any} source A battler tag
+  */
   loadTag(source: BattlerTag | any): void {
     this.turnCount = source.turnCount;
     this.sourceMove = source.sourceMove;
@@ -305,6 +310,10 @@ export class SeedTag extends BattlerTag {
     super(BattlerTagType.SEEDED, BattlerTagLapseType.TURN_END, 1, Moves.LEECH_SEED, sourceId);
   }
 
+  /**
+  * When given a battler tag or json representing one, load the data for it.
+  * @param {BattlerTag | any} source A battler tag
+  */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
     this.sourceIndex = source.sourceIndex;
@@ -415,6 +424,10 @@ export class EncoreTag extends BattlerTag {
     super(BattlerTagType.ENCORE, BattlerTagLapseType.AFTER_MOVE, 3, Moves.ENCORE, sourceId);
   }
 
+  /**
+  * When given a battler tag or json representing one, load the data for it.
+  * @param {BattlerTag | any} source A battler tag
+  */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
     this.moveId = source.moveId as Moves;
@@ -569,6 +582,10 @@ export abstract class DamagingTrapTag extends TrappedTag {
     this.commonAnim = commonAnim;
   }
 
+  /**
+  * When given a battler tag or json representing one, load the data for it.
+  * @param {BattlerTag | any} source A battler tag
+  */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
     this.commonAnim = source.commonAnim as CommonAnim;
@@ -730,6 +747,10 @@ export class ContactDamageProtectedTag extends ProtectedTag {
     this.damageRatio = damageRatio;
   }
 
+  /**
+  * When given a battler tag or json representing one, load the data for it.
+  * @param {BattlerTag | any} source A battler tag
+  */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
     this.damageRatio = source.damageRatio;
@@ -761,6 +782,10 @@ export class ContactStatChangeProtectedTag extends ProtectedTag {
     this.levels = levels;
   }
 
+  /**
+  * When given a battler tag or json representing one, load the data for it.
+  * @param {BattlerTag | any} source A battler tag
+  */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
     this.stat = source.stat as BattleStat;
@@ -888,6 +913,10 @@ export class AbilityBattlerTag extends BattlerTag {
     this.ability = ability;
   }
 
+  /**
+  * When given a battler tag or json representing one, load the data for it.
+  * @param {BattlerTag | any} source A battler tag
+  */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
     this.ability = source.ability as Abilities;
@@ -949,6 +978,10 @@ export class HighestStatBoostTag extends AbilityBattlerTag {
     super(tagType, ability, BattlerTagLapseType.CUSTOM, 1);
   }
 
+  /**
+  * When given a battler tag or json representing one, load the data for it.
+  * @param {BattlerTag | any} source A battler tag
+  */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
     this.stat = source.stat as Stat;
@@ -997,6 +1030,10 @@ export class WeatherHighestStatBoostTag extends HighestStatBoostTag implements W
     this.weatherTypes = weatherTypes;
   }
 
+  /**
+  * When given a battler tag or json representing one, load the data for it.
+  * @param {BattlerTag | any} source A battler tag
+  */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
     this.weatherTypes = source.weatherTypes.map(w => w as WeatherType);
@@ -1011,6 +1048,10 @@ export class TerrainHighestStatBoostTag extends HighestStatBoostTag implements T
     this.terrainTypes = terrainTypes;
   }
 
+  /**
+  * When given a battler tag or json representing one, load the data for it.
+  * @param {BattlerTag | any} source A battler tag
+  */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
     this.terrainTypes = source.terrainTypes.map(w => w as TerrainType);
@@ -1043,6 +1084,10 @@ export class TypeImmuneTag extends BattlerTag {
     super(tagType, BattlerTagLapseType.TURN_END, 1, sourceMove);
   }
 
+  /**
+  * When given a battler tag or json representing one, load the data for it.
+  * @param {BattlerTag | any} source A battler tag
+  */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
     this.immuneType = source.immuneType as Type;
@@ -1068,6 +1113,10 @@ export class TypeBoostTag extends BattlerTag {
     this.oneUse = oneUse;
   }
 
+  /**
+  * When given a battler tag or json representing one, load the data for it.
+  * @param {BattlerTag | any} source A battler tag
+  */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
     this.boostedType = source.boostedType as Type;
@@ -1121,6 +1170,10 @@ export class SaltCuredTag extends BattlerTag {
     super(BattlerTagType.SALT_CURED, BattlerTagLapseType.TURN_END, 1, Moves.SALT_CURE, sourceId);
   }
 
+  /**
+  * When given a battler tag or json representing one, load the data for it.
+  * @param {BattlerTag | any} source A battler tag
+  */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
     this.sourceIndex = source.sourceIndex;
@@ -1161,6 +1214,10 @@ export class CursedTag extends BattlerTag {
     super(BattlerTagType.CURSED, BattlerTagLapseType.TURN_END, 1, Moves.CURSE, sourceId);
   }
 
+  /**
+  * When given a battler tag or json representing one, load the data for it.
+  * @param {BattlerTag | any} source A battler tag
+  */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
     this.sourceIndex = source.sourceIndex;
@@ -1307,6 +1364,11 @@ export function getBattlerTag(tagType: BattlerTagType, turnCount: integer, sourc
   }
 }
 
+/**
+* When given a battler tag or json representing one, creates an actual BattlerTag object with the same data.
+* @param {BattlerTag | any} source A battler tag
+* @return {BattlerTag} The valid battler tag
+*/
 export function loadBattlerTag(source: BattlerTag | any): BattlerTag {
   const tag = getBattlerTag(source.tagType, source.turnCount, source.sourceMove, source.sourceId);
   tag.loadTag(source);

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -68,6 +68,12 @@ export class BattlerTag {
       ? allMoves[this.sourceMove].name
       : null;
   }
+
+  loadTag(source: BattlerTag | any): void {
+    this.turnCount = source.turnCount;
+    this.sourceMove = source.sourceMove;
+    this.sourceId = source.sourceId;
+  }
 }
 
 export interface WeatherBattlerTag {
@@ -299,6 +305,11 @@ export class SeedTag extends BattlerTag {
     super(BattlerTagType.SEEDED, BattlerTagLapseType.TURN_END, 1, Moves.LEECH_SEED, sourceId);
   }
 
+  loadTag(source: BattlerTag | any): void {
+    super.loadTag(source);
+    this.sourceIndex = source.sourceIndex;
+  }
+
   canAdd(pokemon: Pokemon): boolean {
     return !pokemon.isOfType(Type.GRASS);
   }
@@ -402,6 +413,11 @@ export class EncoreTag extends BattlerTag {
 
   constructor(sourceId: integer) {
     super(BattlerTagType.ENCORE, BattlerTagLapseType.AFTER_MOVE, 3, Moves.ENCORE, sourceId);
+  }
+
+  loadTag(source: BattlerTag | any): void {
+    super.loadTag(source);
+    this.moveId = source.moveId as Moves;
   }
 
   canAdd(pokemon: Pokemon): boolean {
@@ -551,6 +567,11 @@ export abstract class DamagingTrapTag extends TrappedTag {
     super(tagType, BattlerTagLapseType.TURN_END, turnCount, sourceMove, sourceId);
 
     this.commonAnim = commonAnim;
+  }
+
+  loadTag(source: BattlerTag | any): void {
+    super.loadTag(source);
+    this.commonAnim = source.commonAnim as CommonAnim;
   }
 
   canAdd(pokemon: Pokemon): boolean {
@@ -709,6 +730,11 @@ export class ContactDamageProtectedTag extends ProtectedTag {
     this.damageRatio = damageRatio;
   }
 
+  loadTag(source: BattlerTag | any): void {
+    super.loadTag(source);
+    this.damageRatio = source.damageRatio;
+  }
+
   lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
     const ret = super.lapse(pokemon, lapseType);
 
@@ -733,6 +759,12 @@ export class ContactStatChangeProtectedTag extends ProtectedTag {
 
     this.stat = stat;
     this.levels = levels;
+  }
+
+  loadTag(source: BattlerTag | any): void {
+    super.loadTag(source);
+    this.stat = source.stat as BattleStat;
+    this.levels = source.levels;
   }
 
   lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
@@ -855,6 +887,11 @@ export class AbilityBattlerTag extends BattlerTag {
 
     this.ability = ability;
   }
+
+  loadTag(source: BattlerTag | any): void {
+    super.loadTag(source);
+    this.ability = source.ability as Abilities;
+  }
 }
 
 export class TruantTag extends AbilityBattlerTag {
@@ -912,6 +949,12 @@ export class HighestStatBoostTag extends AbilityBattlerTag {
     super(tagType, ability, BattlerTagLapseType.CUSTOM, 1);
   }
 
+  loadTag(source: BattlerTag | any): void {
+    super.loadTag(source);
+    this.stat = source.stat as Stat;
+    this.multiplier = this.multiplier;
+  }
+
   onAdd(pokemon: Pokemon): void {
     super.onAdd(pokemon);
 
@@ -953,6 +996,11 @@ export class WeatherHighestStatBoostTag extends HighestStatBoostTag implements W
     super(tagType, ability);
     this.weatherTypes = weatherTypes;
   }
+
+  loadTag(source: BattlerTag | any): void {
+    super.loadTag(source);
+    this.weatherTypes = source.weatherTypes.map(w => w as WeatherType);
+  }
 }
 
 export class TerrainHighestStatBoostTag extends HighestStatBoostTag implements TerrainBattlerTag {
@@ -961,6 +1009,11 @@ export class TerrainHighestStatBoostTag extends HighestStatBoostTag implements T
   constructor(tagType: BattlerTagType, ability: Abilities, ...terrainTypes: TerrainType[]) {
     super(tagType, ability);
     this.terrainTypes = terrainTypes;
+  }
+
+  loadTag(source: BattlerTag | any): void {
+    super.loadTag(source);
+    this.terrainTypes = source.terrainTypes.map(w => w as TerrainType);
   }
 }
 
@@ -989,6 +1042,11 @@ export class TypeImmuneTag extends BattlerTag {
   constructor(tagType: BattlerTagType, sourceMove: Moves, immuneType: Type, length: number) {
     super(tagType, BattlerTagLapseType.TURN_END, 1, sourceMove);
   }
+
+  loadTag(source: BattlerTag | any): void {
+    super.loadTag(source);
+    this.immuneType = source.immuneType as Type;
+  }
 }
 
 export class MagnetRisenTag extends TypeImmuneTag {
@@ -1008,6 +1066,11 @@ export class TypeBoostTag extends BattlerTag {
     this.boostedType = boostedType;
     this.boostValue = boostValue;
     this.oneUse = oneUse;
+  }
+
+  loadTag(source: BattlerTag | any): void {
+    super.loadTag(source);
+    this.boostedType = source.boostedType as Type;
   }
 
   lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
@@ -1056,6 +1119,11 @@ export class SaltCuredTag extends BattlerTag {
     super(BattlerTagType.SALT_CURED, BattlerTagLapseType.TURN_END, 1, Moves.SALT_CURE, sourceId);
   }
 
+  loadTag(source: BattlerTag | any): void {
+    super.loadTag(source);
+    this.sourceIndex = source.sourceIndex;
+  }
+
   onAdd(pokemon: Pokemon): void {
     super.onAdd(pokemon);
     
@@ -1089,6 +1157,11 @@ export class CursedTag extends BattlerTag {
 
   constructor(sourceId: integer) {
     super(BattlerTagType.CURSED, BattlerTagLapseType.TURN_END, 1, Moves.CURSE, sourceId);
+  }
+
+  loadTag(source: BattlerTag | any): void {
+    super.loadTag(source);
+    this.sourceIndex = source.sourceIndex;
   }
 
   onAdd(pokemon: Pokemon): void {
@@ -1231,4 +1304,10 @@ export function getBattlerTag(tagType: BattlerTagType, turnCount: integer, sourc
         return new BattlerTag(tagType, BattlerTagLapseType.CUSTOM, turnCount, sourceMove, sourceId);
   }
 }
- 
+
+export function loadBattlerTag(source: BattlerTag | any): BattlerTag {
+  const tag = getBattlerTag(source.tagType, source.turnCount, source.sourceMove, source.sourceId);
+  tag.loadTag(source);
+  return tag;
+}
+

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -1071,6 +1071,8 @@ export class TypeBoostTag extends BattlerTag {
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
     this.boostedType = source.boostedType as Type;
+    this.boostValue = source.boostValue;
+    this.oneUse = source.oneUse;
   }
 
   lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3187,6 +3187,11 @@ export class PokemonMove {
     return this.getMove().name;
   }
 
+  /**
+  * Copies an existing move or creates a valid PokemonMove object from json representing one
+  * @param {PokemonMove | any} source The data for the move to copy
+  * @return {PokemonMove} A valid pokemonmove object
+  */
   static loadMove(source: PokemonMove | any): PokemonMove {
     return new PokemonMove(source.moveId, source.ppUsed, source.ppUp, source.virtual);
   }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3186,4 +3186,8 @@ export class PokemonMove {
   getName(): string {
     return this.getMove().name;
   }
+
+  static loadMove(source: PokemonMove | any): PokemonMove {
+    return new PokemonMove(source.moveId, source.ppUsed, source.ppUp, source.virtual);
+  }
 }

--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -11,6 +11,7 @@ import Pokemon, { EnemyPokemon, PokemonMove, PokemonSummonData } from "../field/
 import { TrainerSlot } from "../data/trainer-config";
 import { Moves } from "../data/enums/moves";
 import { Variant } from "#app/data/variant";
+import { loadBattlerTag } from '../data/battler-tags';
 
 export default class PokemonData {
   public id: integer;
@@ -112,9 +113,18 @@ export default class PokemonData {
       if (!forHistory && source.summonData) {
         this.summonData.battleStats = source.summonData.battleStats;
         this.summonData.moveQueue = source.summonData.moveQueue;
-        this.summonData.tags = []; // TODO
-        this.summonData.moveset = source.summonData.moveset;
+        this.summonData.disabledMove = source.summonData.disabledMove;
+        this.summonData.disabledTurns = source.summonData.disabledTurns;
+        this.summonData.abilitySuppressed = source.summonData.abilitySuppressed;
+
+        this.summonData.ability = source.summonData.ability;
+        this.summonData.moveset = source.summonData.moveset?.map(m => PokemonMove.loadMove(m));
         this.summonData.types = source.summonData.types;
+        
+        if (source.summonData.tags)
+          this.summonData.tags = source.summonData.tags?.map(t => loadBattlerTag(t));
+        else
+          this.summonData.tags = [];
       }
     }
   }


### PR DESCRIPTION
Also saves the rest of the summonData except for transform specific things.

Since this modifies how saving and loading data works someone other than just me should really make sure to test this before it's merged, we 100% do not want this to break in prod. My tests all seemed to work fine, but just to be sure.