### PR TITLE
Lum berry should cure status and confusion if possible

### DIFF
--- a/src/data/berry.ts
+++ b/src/data/berry.ts
@@ -114,7 +114,8 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
           pokemon.scene.queueMessage(getPokemonMessage(pokemon, getStatusEffectHealText(pokemon.status.effect)));
           pokemon.resetStatus();
           pokemon.updateInfo();
-        } else if (pokemon.getTag(BattlerTagType.CONFUSED))
+        } 
+        if (pokemon.getTag(BattlerTagType.CONFUSED))
           pokemon.lapseTag(BattlerTagType.CONFUSED);
       };
     case BerryType.LIECHI:


### PR DESCRIPTION
If a pokemon has a status effect and is confused, when it consumes a lum berry it should cure the status effect and confusion. 

https://github.com/pagefaultgames/pokerogue/assets/13306707/ca3c205b-c523-483d-8830-a785e211e6d2

Reported here and I checked on showdown that this is correct: 
https://discord.com/channels/1125469663833370665/1236613326599884820