### PR TITLE
Fix some move type-sensitive abilities not respecting variable-type moves

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2977,9 +2977,17 @@ export function initAbilities() {
       .attr(IgnoreOpponentStatChangesAbAttr)
       .ignorable(),
     new Ability(Abilities.TINTED_LENS, 4)
-      .attr(MovePowerBoostAbAttr, (user, target, move) => target.getAttackTypeEffectiveness(move.type) <= 0.5, 2),
+      .attr(MovePowerBoostAbAttr, (user, target, move) => {
+        const variableType = new Utils.IntegerHolder(move.type);
+        applyMoveAttrs(VariableMoveTypeAttr, user, target, move, variableType);
+        return target.getAttackTypeEffectiveness(variableType.value) <= 0.5;
+      }, 2),
     new Ability(Abilities.FILTER, 4)
-      .attr(ReceivedMoveDamageMultiplierAbAttr,(target, user, move) => target.getAttackTypeEffectiveness(move.type) >= 2, 0.75)
+      .attr(ReceivedMoveDamageMultiplierAbAttr, (target, user, move) => {
+        const variableType = new Utils.IntegerHolder(move.type);
+        applyMoveAttrs(VariableMoveTypeAttr, user, target, move, variableType);
+        return target.getAttackTypeEffectiveness(move.type) >= 2;
+      }, 0.75)
       .ignorable(),
     new Ability(Abilities.SLOW_START, 4)
       .attr(PostSummonAddBattlerTagAbAttr, BattlerTagType.SLOW_START, 5),
@@ -2994,7 +3002,11 @@ export function initAbilities() {
       .attr(BlockWeatherDamageAttr, WeatherType.HAIL)
       .attr(PostWeatherLapseHealAbAttr, 1, WeatherType.HAIL, WeatherType.SNOW),
     new Ability(Abilities.SOLID_ROCK, 4)
-      .attr(ReceivedMoveDamageMultiplierAbAttr,(target, user, move) => target.getAttackTypeEffectiveness(move.type) >= 2, 0.75)
+      .attr(ReceivedMoveDamageMultiplierAbAttr, (target, user, move) => {
+        const variableType = new Utils.IntegerHolder(move.type);
+        applyMoveAttrs(VariableMoveTypeAttr, user, target, move, variableType);
+        return target.getAttackTypeEffectiveness(move.type) >= 2;
+      }, 0.75)
       .ignorable(),
     new Ability(Abilities.SNOW_WARNING, 4)
       .attr(PostSummonWeatherChangeAbAttr, WeatherType.SNOW)

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -9,7 +9,7 @@ import { BattlerTag } from "./battler-tags";
 import { BattlerTagType } from "./enums/battler-tag-type";
 import { StatusEffect, getStatusEffectDescriptor, getStatusEffectHealText } from "./status-effect";
 import { Gender } from "./gender";
-import Move, { AttackMove, MoveCategory, MoveFlags, MoveTarget, RecoilAttr, StatusMoveTypeImmunityAttr, FlinchAttr, OneHitKOAttr, HitHealAttr, StrengthSapHealAttr, allMoves, StatusMove } from "./move";
+import Move, { AttackMove, MoveCategory, MoveFlags, MoveTarget, RecoilAttr, StatusMoveTypeImmunityAttr, FlinchAttr, OneHitKOAttr, HitHealAttr, StrengthSapHealAttr, allMoves, StatusMove, VariablePowerAttr, applyMoveAttrs, VariableMoveTypeAttr } from "./move";
 import { ArenaTagSide, ArenaTrapTag } from "./arena-tag";
 import { ArenaTagType } from "./enums/arena-tag-type";
 import { Stat } from "./pokemon-stat";
@@ -333,11 +333,15 @@ export class TypeImmunityAbAttr extends PreDefendAbAttr {
   }
 
   applyPreDefend(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: PokemonMove, cancelled: Utils.BooleanHolder, args: any[]): boolean {
-    if ((move.getMove() instanceof AttackMove || move.getMove().getAttrs(StatusMoveTypeImmunityAttr).find(attr => (attr as StatusMoveTypeImmunityAttr).immuneType === this.immuneType)) && move.getMove().type === this.immuneType) {
+    const variableType = new Utils.IntegerHolder(move.getMove().type);
+    applyMoveAttrs(VariableMoveTypeAttr, attacker, pokemon, move.getMove(), variableType);
+    if ((
+      (move.getMove() instanceof AttackMove) || 
+      (!!move.getMove().getAttrs(StatusMoveTypeImmunityAttr).find(attr => (attr as StatusMoveTypeImmunityAttr).immuneType === this.immuneType))
+    ) && (variableType.value === this.immuneType)) {
       (args[0] as Utils.NumberHolder).value = 0;
       return true;
     }
-
     return false;
   }
 

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -12,7 +12,7 @@ import * as Utils from "../utils";
 import { WeatherType } from "./weather";
 import { ArenaTagSide, ArenaTrapTag } from "./arena-tag";
 import { ArenaTagType } from "./enums/arena-tag-type";
-import { UnswappableAbilityAbAttr, UncopiableAbilityAbAttr, UnsuppressableAbilityAbAttr, NoTransformAbilityAbAttr, BlockRecoilDamageAttr, BlockOneHitKOAbAttr, IgnoreContactAbAttr, MaxMultiHitAbAttr, applyAbAttrs, BlockNonDirectDamageAbAttr, applyPreSwitchOutAbAttrs, PreSwitchOutAbAttr, applyPostDefendAbAttrs, PostDefendContactApplyStatusEffectAbAttr, MoveAbilityBypassAbAttr, ReverseDrainAbAttr, FieldPreventExplosiveMovesAbAttr, ForceSwitchOutImmunityAbAttr } from "./ability";
+import { UnswappableAbilityAbAttr, UncopiableAbilityAbAttr, UnsuppressableAbilityAbAttr, NoTransformAbilityAbAttr, BlockRecoilDamageAttr, BlockOneHitKOAbAttr, IgnoreContactAbAttr, MaxMultiHitAbAttr, applyAbAttrs, BlockNonDirectDamageAbAttr, applyPreSwitchOutAbAttrs, PreSwitchOutAbAttr, applyPostDefendAbAttrs, PostDefendContactApplyStatusEffectAbAttr, MoveAbilityBypassAbAttr, ReverseDrainAbAttr, FieldPreventExplosiveMovesAbAttr, ForceSwitchOutImmunityAbAttr, MoveTypeChangeAttr, applyPreAttackAbAttrs } from "./ability";
 import { Abilities } from "./enums/abilities";
 import { allAbilities } from './ability';
 import { PokemonHeldItemModifier } from "../modifier/modifier";
@@ -297,6 +297,12 @@ export default class Move implements Localizable {
   ignoresAbilities(ignoresAbilities?: boolean): this {
     this.setFlag(MoveFlags.IGNORE_ABILITIES, ignoresAbilities);
     return this;
+  }
+
+  getType(user: Pokemon, target: Pokemon): Type {
+    const variableType = new Utils.IntegerHolder(this.type);
+    applyMoveAttrs(VariableMoveTypeAttr, user, target, this, variableType);
+    return variableType.value;
   }
 
   checkFlag(flag: MoveFlags, user: Pokemon, target: Pokemon): boolean {
@@ -2357,7 +2363,7 @@ export class IvyCudgelTypeAttr extends VariableMoveTypeAttr {
 
       switch (form) {
         case 1: // Wellspring Mask
-          type.value = Type.WATER;
+          type.value = Type.FIRE;
           break;
         case 2: // Hearthflame Mask
           type.value = Type.FIRE;


### PR DESCRIPTION
Some of these fixes are very un-ideal and I can tell there's a few more effects that won't work still, namely Storm Drain (I think). However, for now this fixes the issues listed in #527.