### PR TITLE
Hunger switch shouldn't trigger if terastallized

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -3434,7 +3434,8 @@ export function initAbilities() {
       .attr(UncopiableAbilityAbAttr)
       .attr(UnswappableAbilityAbAttr)
       .attr(NoTransformAbilityAbAttr)
-      .attr(NoFusionAbilityAbAttr),
+      .attr(NoFusionAbilityAbAttr)
+      .condition((pokemon) => !pokemon.isTerastallized()),
     new Ability(Abilities.QUICK_DRAW, 8)
       .unimplemented(),
     new Ability(Abilities.UNSEEN_FIST, 8)


### PR DESCRIPTION
Resolves this issue: https://github.com/pagefaultgames/pokerogue/issues/535

I tested that hunger switch doesn't activate while terastallized and that when the tera shard wears off it starts working again. I also checked the showdown abilities and didn't see any other ones that are fully disabled when you tera. 