### PR TITLE
Repels Implementation

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -4,7 +4,7 @@ import { NextEncounterPhase, NewBiomeEncounterPhase, SelectBiomePhase, MessagePh
 import Pokemon, { PlayerPokemon, EnemyPokemon } from './field/pokemon';
 import PokemonSpecies, { PokemonSpeciesFilter, allSpecies, getPokemonSpecies, initSpecies, speciesStarters } from './data/pokemon-species';
 import * as Utils from './utils';
-import { Modifier, ModifierBar, ConsumablePokemonModifier, ConsumableModifier, PokemonHpRestoreModifier, HealingBoosterModifier, PersistentModifier, PokemonHeldItemModifier, ModifierPredicate, DoubleBattleChanceBoosterModifier, FusePokemonModifier, PokemonFormChangeItemModifier, TerastallizeModifier, overrideModifiers, overrideHeldItems } from './modifier/modifier';
+import { Modifier, ModifierBar, ConsumablePokemonModifier, ConsumableModifier, PokemonHpRestoreModifier, HealingBoosterModifier, PersistentModifier, PokemonHeldItemModifier, ModifierPredicate, DoubleBattleChanceBoosterModifier, DoubleBattleChancePreventerModifier, FusePokemonModifier, PokemonFormChangeItemModifier, TerastallizeModifier, overrideModifiers, overrideHeldItems } from './modifier/modifier';
 import { PokeballType } from './data/pokeball';
 import { initCommonAnims, initMoveAnim, loadCommonAnimAssets, loadMoveAnimAssets, populateAnims } from './data/battle-anims';
 import { Phase } from './phase';
@@ -861,6 +861,8 @@ export default class BattleScene extends SceneBase {
 					this.applyModifiers(DoubleBattleChanceBoosterModifier, true, doubleChance);
 					playerField.forEach(p => applyAbAttrs(DoubleBattleChanceAbAttr, p, null, doubleChance));
 					doubleTrainer = !Utils.randSeedInt(doubleChance.value);
+					if (this.getModifiers(DoubleBattleChancePreventerModifier).length != 0)
+						doubleTrainer = false;
 				}
 				newTrainer = trainerData !== undefined ? trainerData.toTrainer(this) : new Trainer(this, trainerType, doubleTrainer ? TrainerVariant.DOUBLE : Utils.randSeedInt(2) ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT);
 				this.field.add(newTrainer);
@@ -880,6 +882,9 @@ export default class BattleScene extends SceneBase {
 
 		if (Overrides.DOUBLE_BATTLE_OVERRIDE)
 			newDouble = true;
+
+		if (this.getModifiers(DoubleBattleChancePreventerModifier).length != 0)
+			newDouble = false;
 
 		const lastBattle = this.currentBattle;
 

--- a/src/locales/en/modifier-type.ts
+++ b/src/locales/en/modifier-type.ts
@@ -51,6 +51,9 @@ export const modifierType: ModifierTypeTranslationEntries = {
     "DoubleBattleChanceBoosterModifierType": {
       description: "Doubles the chance of an encounter being a double battle for {{battleCount}} battles",
     },
+    "DoubleBattleChancePreventerModifierType": {
+      description: "Prevents double battles for {{battleCount}} battles",
+    },
     "TempBattleStatBoosterModifierType": {
       description: "Increases the {{tempBattleStatName}} of all party members by 1 stage for 5 battles",
     },
@@ -157,6 +160,10 @@ export const modifierType: ModifierTypeTranslationEntries = {
 
     "PP_UP": { name: "PP Up" },
     "PP_MAX": { name: "PP Max" },
+
+    "REPEL": { name: "Repel" },
+    "SUPER_REPEL": { name: "Super Repel" },
+    "MAX_REPEL": { name: "Max Repel" },
 
     "LURE": { name: "Lure" },
     "SUPER_LURE": { name: "Super Lure" },

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -407,11 +407,21 @@ export class DoubleBattleChanceBoosterModifierType extends ModifierType {
   }
 }
 
+/**
+ * Class representing a ModifierType for a Modifier that prevents Double Battles from occurring.
+ * @extends ModifierType
+ */
 export class DoubleBattleChancePreventerModifierType extends ModifierType {
   public battleCount: integer;
 
+  /**
+     * Instantiates the ModifierType
+     * @param {string} localeKey - Used to grab the appropriate language texts
+     * @param {string} iconImage - Used to grab the appropriate icon
+     * @param {integer} battleCount - Represents how long the modifier should exist for
+     */
   constructor(localeKey: string, iconImage: string, battleCount: integer) {
-    super(localeKey, iconImage, (_type, _args) => new Modifiers.DoubleBattleChancePreventerModifier(this, this.battleCount), 'lure');
+    super(localeKey, iconImage, (_type, _args) => new Modifiers.DoubleBattleChancePreventerModifier(this, this.battleCount), 'repel');
 
     this.battleCount = battleCount;
   }

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -407,6 +407,20 @@ export class DoubleBattleChanceBoosterModifierType extends ModifierType {
   }
 }
 
+export class DoubleBattleChancePreventerModifierType extends ModifierType {
+  public battleCount: integer;
+
+  constructor(localeKey: string, iconImage: string, battleCount: integer) {
+    super(localeKey, iconImage, (_type, _args) => new Modifiers.DoubleBattleChancePreventerModifier(this, this.battleCount), 'lure');
+
+    this.battleCount = battleCount;
+  }
+
+  getDescription(scene: BattleScene): string {
+    return i18next.t(`modifierType:ModifierType.DoubleBattleChancePreventerModifierType.description`, { battleCount: this.battleCount });
+  }
+}
+
 export class TempBattleStatBoosterModifierType extends ModifierType implements GeneratedPersistentModifierType {
   public tempBattleStat: TempBattleStat;
 
@@ -1031,9 +1045,9 @@ export const modifierTypes = {
   PP_UP: () => new PokemonPpUpModifierType(`modifierType:ModifierType.PP_UP`, 'pp_up', 1),
   PP_MAX: () => new PokemonPpUpModifierType(`modifierType:ModifierType.PP_MAX`, 'pp_max', 3),
 
-  /*REPEL: () => new DoubleBattleChanceBoosterModifierType('Repel', 5),
-  SUPER_REPEL: () => new DoubleBattleChanceBoosterModifierType('Super Repel', 10),
-  MAX_REPEL: () => new DoubleBattleChanceBoosterModifierType('Max Repel', 25),*/
+  REPEL: () => new DoubleBattleChancePreventerModifierType(`modifierType:ModifierType.REPEL`, 'repel', 5),
+  SUPER_REPEL: () => new DoubleBattleChancePreventerModifierType(`modifierType:ModifierType.SUPER_REPEL`, 'super_repel', 10),
+  MAX_REPEL: () => new DoubleBattleChancePreventerModifierType(`modifierType:ModifierType.MAX_REPEL`, 'max_repel', 25),
 
   LURE: () => new DoubleBattleChanceBoosterModifierType(`modifierType:ModifierType.LURE`, 'lure', 5),
   SUPER_LURE: () => new DoubleBattleChanceBoosterModifierType(`modifierType:ModifierType.SUPER_LURE`, 'super_lure', 10),
@@ -1201,7 +1215,8 @@ const modifierPool: ModifierPool = {
       const thresholdPartyMemberCount = Math.min(party.filter(p => p.hp && p.getMoveset().filter(m => (m.getMovePp() - m.ppUsed) <= 5).length).length, 3);
       return thresholdPartyMemberCount;
     }, 3),
-    new WeightedModifierType(modifierTypes.LURE, 2),
+    new WeightedModifierType(modifierTypes.REPEL, (party: Pokemon[]) => party[0].scene.findModifier(m => m.type instanceof DoubleBattleChancePreventerModifierType || m.type instanceof DoubleBattleChanceBoosterModifierType) ? 0 : 2),
+    new WeightedModifierType(modifierTypes.LURE, (party: Pokemon[]) => party[0].scene.findModifier(m => m.type instanceof DoubleBattleChancePreventerModifierType || m.type instanceof DoubleBattleChanceBoosterModifierType) ? 0 : 2),
     new WeightedModifierType(modifierTypes.TEMP_STAT_BOOSTER, 4),
     new WeightedModifierType(modifierTypes.BERRY, 2),
     new WeightedModifierType(modifierTypes.TM_COMMON, 1),
@@ -1245,7 +1260,8 @@ const modifierPool: ModifierPool = {
       return thresholdPartyMemberCount;
     }, 3),
     new WeightedModifierType(modifierTypes.DIRE_HIT, 4),
-    new WeightedModifierType(modifierTypes.SUPER_LURE, 4),
+    new WeightedModifierType(modifierTypes.SUPER_REPEL, (party: Pokemon[]) => party[0].scene.findModifier(m => m.type instanceof DoubleBattleChancePreventerModifierType || m.type instanceof DoubleBattleChanceBoosterModifierType) ? 0 : 4),
+    new WeightedModifierType(modifierTypes.SUPER_LURE, (party: Pokemon[]) => party[0].scene.findModifier(m => m.type instanceof DoubleBattleChancePreventerModifierType || m.type instanceof DoubleBattleChanceBoosterModifierType) ? 0 : 4),
     new WeightedModifierType(modifierTypes.NUGGET, 5),
     new WeightedModifierType(modifierTypes.EVOLUTION_ITEM, (party: Pokemon[]) => {
       return Math.min(Math.ceil(party[0].scene.currentBattle.waveIndex / 15), 8);
@@ -1264,7 +1280,8 @@ const modifierPool: ModifierPool = {
   ].map(m => { m.setTier(ModifierTier.GREAT); return m; }),
   [ModifierTier.ULTRA]: [
     new WeightedModifierType(modifierTypes.ULTRA_BALL, 24),
-    new WeightedModifierType(modifierTypes.MAX_LURE, 4),
+    new WeightedModifierType(modifierTypes.MAX_REPEL, (party: Pokemon[]) => party[0].scene.findModifier(m => m.type instanceof DoubleBattleChancePreventerModifierType || m.type instanceof DoubleBattleChanceBoosterModifierType) ? 0 : 4),
+    new WeightedModifierType(modifierTypes.MAX_LURE, (party: Pokemon[]) => party[0].scene.findModifier(m => m.type instanceof DoubleBattleChancePreventerModifierType || m.type instanceof DoubleBattleChanceBoosterModifierType) ? 0 : 4),
     new WeightedModifierType(modifierTypes.BIG_NUGGET, 12),
     new WeightedModifierType(modifierTypes.PP_UP, 9),
     new WeightedModifierType(modifierTypes.PP_MAX, 3),

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -310,6 +310,30 @@ export class DoubleBattleChanceBoosterModifier extends LapsingPersistentModifier
   }
 }
 
+export class DoubleBattleChancePreventerModifier extends LapsingPersistentModifier {
+  constructor(type: ModifierTypes.DoubleBattleChancePreventerModifierType, battlesLeft: integer, stackCount?: integer) {
+    super(type, battlesLeft, stackCount);
+  }
+
+  match(modifier: Modifier): boolean {
+    if (modifier instanceof DoubleBattleChancePreventerModifier)
+      return (modifier as DoubleBattleChancePreventerModifier).battlesLeft === this.battlesLeft;
+    return false;
+  }
+
+  clone(): DoubleBattleChancePreventerModifier {
+    return new DoubleBattleChancePreventerModifier(this.type as ModifierTypes.DoubleBattleChancePreventerModifierType, this.battlesLeft, this.stackCount);
+  }
+
+  getArgs(): any[] {
+    return [ this.battlesLeft ];
+  }
+
+  apply(args: any[]): boolean {
+    return true;
+  }
+}
+
 export class TempBattleStatBoosterModifier extends LapsingPersistentModifier {
   private tempBattleStat: TempBattleStat;
 


### PR DESCRIPTION
Implements all types of Repels (Regular, Super, and Max) with functionality as described on the [Trello Board](https://trello.com/c/1TSW0HSz/29-add-repels). Repels last for (5/10/25) waves and prevent double battles from occurring (including trainer doubles) by checking if the player has the modifier active during `newBattle()`, and overriding the double parameter to be false.

Also modifies the weightings of both repels and lures so that they do not show up in the shop if the player already has one of either.