### PR TITLE
Added Pokemon renaming hook to the Summary

### DIFF
--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -29,7 +29,8 @@ enum Page {
 
 export enum SummaryUiMode {
   DEFAULT,
-  LEARN_MOVE
+  LEARN_MOVE,
+  RENAME,
 }
 
 export default class SummaryUiHandler extends UiHandler {
@@ -79,6 +80,10 @@ export default class SummaryUiHandler extends UiHandler {
   private moveCursor: integer;
   private selectedMoveIndex: integer;
 
+  private renamePokemon: boolean;
+  private newName: string;
+  private isCapitalized: boolean;
+  
   constructor(scene: BattleScene) {
     super(scene, Mode.SUMMARY);
   }
@@ -265,6 +270,7 @@ export default class SummaryUiHandler extends UiHandler {
     this.pokemon.cry();
 
     this.nameText.setText(this.pokemon.name);
+    this.newName = this.pokemon.name;
 
     const isFusion = this.pokemon.isFusion();
 
@@ -415,17 +421,31 @@ export default class SummaryUiHandler extends UiHandler {
             }
         }
       }
+    } else if (this.renamePokemon) {
+      if (button === Button.SUBMIT) {
+        this.pokemon.name = this.newName;
+        this.hideRenamePokemon();
+      } else if (button === Button.CANCEL) {
+        this.newName = this.pokemon.name;
+        this.hideRenamePokemon();
+      }
     } else {
       if (button === Button.ACTION) {
         if (this.cursor === Page.MOVES) {
           this.showMoveSelect();
           success = true;
+        } else if (this.cursor === Page.STATUS) {
+          this.showRenamePokemon();
+          success = true;
         }
       } else if (button === Button.CANCEL) {
-        if (this.summaryUiMode === SummaryUiMode.LEARN_MOVE)
+        if (this.summaryUiMode === SummaryUiMode.LEARN_MOVE) {
           this.hideMoveSelect();
-        else
+        } else if (this.summaryUiMode === SummaryUiMode.RENAME) {
+          this.hideRenamePokemon();
+        } else {
           ui.setMode(Mode.PARTY);
+        }
         success = true;
       } else {
         const pages = Utils.getEnumValues(Page);
@@ -902,6 +922,13 @@ export default class SummaryUiHandler extends UiHandler {
     return null;
   }
 
+  showRenamePokemon() {
+    this.renamePokemon = true;
+  }
+  hideRenamePokemon() {
+    this.renamePokemon = false;
+  }
+  
   showMoveSelect() {
     this.moveSelect = true;
     this.extraMoveRowContainer.setVisible(true);

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -270,7 +270,6 @@ export default class SummaryUiHandler extends UiHandler {
     this.pokemon.cry();
 
     this.nameText.setText(this.pokemon.name);
-    this.newName = this.pokemon.name;
 
     const isFusion = this.pokemon.isFusion();
 
@@ -345,7 +344,7 @@ export default class SummaryUiHandler extends UiHandler {
       this.status.setFrame(this.pokemon.status ? StatusEffect[this.pokemon.status.effect].toLowerCase() : 'pokerus');
     } else
       this.hideStatus(!fromSummary);
-
+    
     return true;
   }
 
@@ -425,9 +424,10 @@ export default class SummaryUiHandler extends UiHandler {
       if (button === Button.SUBMIT) {
         this.pokemon.name = this.newName;
         this.hideRenamePokemon();
+        success = true;
       } else if (button === Button.CANCEL) {
-        this.newName = this.pokemon.name;
         this.hideRenamePokemon();
+        success = true;
       }
     } else {
       if (button === Button.ACTION) {
@@ -924,9 +924,13 @@ export default class SummaryUiHandler extends UiHandler {
 
   showRenamePokemon() {
     this.renamePokemon = true;
+    this.newName = this.pokemon.name;
+    this.isCapitalized = true;
   }
   hideRenamePokemon() {
     this.renamePokemon = false;
+    this.newName = this.pokemon.name;
+    this.isCapitalized = true;
   }
   
   showMoveSelect() {
@@ -1012,6 +1016,11 @@ export default class SummaryUiHandler extends UiHandler {
         this.selectedMoveCursorObj = null;
       }
       this.hideMoveEffect(true);
+    }
+    if (this.renamePokemon) {
+      this.renamePokemon = false;
+      this.newName = this.pokemon.name;
+      this.isCapitalized = true;
     }
     this.summaryContainer.setVisible(false);
     this.summaryPageContainer.setVisible(false);


### PR DESCRIPTION
The hook is done. On Submit it should be able to set the Pokemon's name to its new name saved in variable newName, and on Cancel is sets newName back to the Pokemon's current name. It also saves capitalization state in variable isCapitalized, and will automatically capitalizes the first letter.

But, the text input UI itself is still mising and there's still no actual way to input the text. Ideally it'd be a cursor input system like traditional handheld Pokemon games so controller player's could also rename their Pokemon, but to make it there needs to be a UI first so moving the cursor variable is consistent to moving the cursor UI.

If anyone wants to, feel free to take over adding the feature since making good UI is not my cup of tea.