### PR TITLE
Implement innards out

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2281,7 +2281,6 @@ export class PostFaintHPDamageAbAttr extends PostFaintAbAttr {
   }
 
   applyPostFaint(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: PokemonMove, hitResult: HitResult, args: any[]): boolean {
-    console.log(args);
     let damage = args[0];
     attacker.damageAndUpdate((damage), HitResult.OTHER);
     attacker.turnData.damageTaken += damage;

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2275,6 +2275,9 @@ export class PostFaintContactDamageAbAttr extends PostFaintAbAttr {
   }
 }
 
+/** 
+ * Attribute used for abilities (Innards Out) that damage the opponent based on how much HP the last attack used to knock out the owner of the ability.
+ */
 export class PostFaintHPDamageAbAttr extends PostFaintAbAttr {
   constructor() {
     super ();

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2275,6 +2275,24 @@ export class PostFaintContactDamageAbAttr extends PostFaintAbAttr {
   }
 }
 
+export class PostFaintHPDamageAbAttr extends PostFaintAbAttr {
+  constructor() {
+    super ();
+  }
+
+  applyPostFaint(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: PokemonMove, hitResult: HitResult, args: any[]): boolean {
+    console.log(args);
+    let damage = args[0];
+    attacker.damageAndUpdate((damage), HitResult.OTHER);
+    attacker.turnData.damageTaken += damage;
+    return true;
+  } 
+
+  getTriggerMessage(pokemon: Pokemon, abilityName: string, ...args: any[]): string {
+    return getPokemonMessage(pokemon, `'s ${abilityName} hurt\nits attacker!`);
+  }
+}
+
 export class RedirectMoveAbAttr extends AbAttr {
   apply(pokemon: Pokemon, passive: boolean, cancelled: Utils.BooleanHolder, args: any[]): boolean {
     if (this.canRedirect(args[0] as Moves)) {
@@ -3316,7 +3334,8 @@ export function initAbilities() {
       .attr(FieldPriorityMoveImmunityAbAttr)
       .ignorable(),
     new Ability(Abilities.INNARDS_OUT, 7)
-      .unimplemented(),
+      .attr(PostFaintHPDamageAbAttr)
+      .bypassFaint(),
     new Ability(Abilities.DANCER, 7)
       .unimplemented(),
     new Ability(Abilities.BATTERY, 7)

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2281,7 +2281,7 @@ export class PostFaintHPDamageAbAttr extends PostFaintAbAttr {
   }
 
   applyPostFaint(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: PokemonMove, hitResult: HitResult, args: any[]): boolean {
-    let damage = args[0];
+    const damage = pokemon.turnData.attacksReceived[0].damage;
     attacker.damageAndUpdate((damage), HitResult.OTHER);
     attacker.turnData.damageTaken += damage;
     return true;

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -3135,7 +3135,7 @@ export class FaintPhase extends PokemonPhase {
 
     if (pokemon.turnData?.attacksReceived?.length) {
       const lastAttack = pokemon.turnData.attacksReceived[0];
-      applyPostFaintAbAttrs(PostFaintAbAttr, pokemon, this.scene.getPokemonById(lastAttack.sourceId), new PokemonMove(lastAttack.move), lastAttack.result, lastAttack.damage);
+      applyPostFaintAbAttrs(PostFaintAbAttr, pokemon, this.scene.getPokemonById(lastAttack.sourceId), new PokemonMove(lastAttack.move), lastAttack.result);
     }
 
     const alivePlayField = this.scene.getField(true);

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -3135,7 +3135,7 @@ export class FaintPhase extends PokemonPhase {
 
     if (pokemon.turnData?.attacksReceived?.length) {
       const lastAttack = pokemon.turnData.attacksReceived[0];
-      applyPostFaintAbAttrs(PostFaintAbAttr, pokemon, this.scene.getPokemonById(lastAttack.sourceId), new PokemonMove(lastAttack.move), lastAttack.result);
+      applyPostFaintAbAttrs(PostFaintAbAttr, pokemon, this.scene.getPokemonById(lastAttack.sourceId), new PokemonMove(lastAttack.move), lastAttack.result, lastAttack.damage);
     }
 
     const alivePlayField = this.scene.getField(true);


### PR DESCRIPTION
Reusing a lot of code from Aftermath and `PostFaintContactDamageAbAttr`. Passing in lastAttack.damage into the unused `args[]` of `applyPostFaintAbAttrs` since that value is capped by the HP of the fainted Pokemon at the time.

Not sure about the message, but the for aftermath is pretty descriptive so I also reused that.