### PR TITLE
Show number of Pokeballs in inventory when selecting a pokeball in the reward phase

### DIFF
--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -144,13 +144,14 @@ class AddPokeballModifierType extends ModifierType implements Localizable {
   }
 
   localize(): void {
+    // TODO: Actually use i18n to localize this description.
     this.name = `${this.count}x ${getPokeballName(this.pokeballType)}`;
     this.description = `Receive ${getPokeballName(this.pokeballType)} x${this.count} (Inventory: {AMOUNT}) \nCatch Rate: ${getPokeballCatchMultiplier(this.pokeballType) > -1 ? `${getPokeballCatchMultiplier(this.pokeballType)}x` : 'Certain'}`;
   }
   
   getDescription(scene: BattleScene): string {
     this.localize();
-    return this.description.replace('{AMOUNT}', scene.pokeballCounts[this.pokeballType].toLocaleString('en-US'));
+    return this.description.replace('{AMOUNT}', scene.pokeballCounts[this.pokeballType].toString());
   }
 
 }

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -145,8 +145,14 @@ class AddPokeballModifierType extends ModifierType implements Localizable {
 
   localize(): void {
     this.name = `${this.count}x ${getPokeballName(this.pokeballType)}`;
-    this.description = `Receive ${getPokeballName(this.pokeballType)} x${this.count}\nCatch Rate: ${getPokeballCatchMultiplier(this.pokeballType) > -1 ? `${getPokeballCatchMultiplier(this.pokeballType)}x` : 'Certain'}`;
+    this.description = `Receive ${getPokeballName(this.pokeballType)} x${this.count} (Inventory: {AMOUNT}) \nCatch Rate: ${getPokeballCatchMultiplier(this.pokeballType) > -1 ? `${getPokeballCatchMultiplier(this.pokeballType)}x` : 'Certain'}`;
   }
+  
+  getDescription(scene: BattleScene): string {
+    this.localize();
+    return this.description.replace('{AMOUNT}', scene.pokeballCounts[this.pokeballType].toLocaleString('en-US'));
+  }
+
 }
 
 class AddVoucherModifierType extends ModifierType {


### PR DESCRIPTION
QOL enhancement to show the user how many of the selected Pokeball they have while in the rewards phase.

<img width="1500" alt="image" src="https://github.com/pagefaultgames/pokerogue/assets/59787978/2b07a328-f93e-42f5-a50a-924ec1b4244f">
