### PR TITLE
Implement once per battle restriction on abilities

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -1826,6 +1826,19 @@ function getAnticipationCondition(): AbAttrCondition {
   };
 }
 
+/**
+ * Creates an ability condition that causes the ability to fail if that ability
+ * has already been used by that pokemon that battle. It requires an ability to
+ * be specified due to current limitations in how conditions on abilities work.
+ * @param {Abilities} ability The ability to check if it's already been applied
+ * @returns {AbAttrCondition} The condition
+ */
+function getOncePerBattleCondition(ability: Abilities): AbAttrCondition {
+  return (pokemon: Pokemon) => {
+    return !pokemon.battleData?.abilitiesApplied.includes(ability);
+  }
+}
+
 export class ForewarnAbAttr extends PostSummonAbAttr {
   constructor() {
     super(true);
@@ -2522,6 +2535,9 @@ function applyAbAttrsInternal<TAttr extends AbAttr>(attrType: { new(...args: any
         return applyNextAbAttr();
       pokemon.scene.setPhaseQueueSplice();
       const onApplySuccess = () => {
+        if (pokemon.battleData && !pokemon.battleData.abilitiesApplied.includes(ability.id)) {
+          pokemon.battleData.abilitiesApplied.push(ability.id);
+        }
         if (attr.showAbility && !quiet) {
           if (showAbilityInstant)
             pokemon.scene.abilityBar.showAbility(pokemon, passive);
@@ -3379,9 +3395,11 @@ export function initAbilities() {
     new Ability(Abilities.NEUROFORCE, 7)
       .attr(MovePowerBoostAbAttr, (user, target, move) => target.getAttackTypeEffectiveness(move.type, user) >= 2, 1.25),
     new Ability(Abilities.INTREPID_SWORD, 8)
-      .attr(PostSummonStatChangeAbAttr, BattleStat.ATK, 1, true),
+      .attr(PostSummonStatChangeAbAttr, BattleStat.ATK, 1, true)
+      .condition(getOncePerBattleCondition(Abilities.INTREPID_SWORD)),
     new Ability(Abilities.DAUNTLESS_SHIELD, 8)
-      .attr(PostSummonStatChangeAbAttr, BattleStat.DEF, 1, true),
+      .attr(PostSummonStatChangeAbAttr, BattleStat.DEF, 1, true)
+      .condition(getOncePerBattleCondition(Abilities.DAUNTLESS_SHIELD)),
     new Ability(Abilities.LIBERO, 8)
       .unimplemented(),
     new Ability(Abilities.BALL_FETCH, 8)

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3133,6 +3133,7 @@ export class PokemonBattleData {
   public hitCount: integer = 0;
   public endured: boolean = false;
   public berriesEaten: BerryType[] = [];
+  public abilitiesApplied: Abilities[] = [];
 }
 
 export class PokemonBattleSummonData {


### PR DESCRIPTION
Currently just Intrepid Sword and Dauntless Shield, but this supports easily adding the condition to additional abilities in the future that might warrant it such as disguise.