### PR TITLE
Fix charge

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -4745,7 +4745,7 @@ export function initMoves() {
       .ignoresVirtual(),
     new SelfStatusMove(Moves.CHARGE, Type.ELECTRIC, -1, 20, -1, 0, 3)
       .attr(StatChangeAttr, BattleStat.SPDEF, 1, true)
-      .attr(AddBattlerTagAttr, BattlerTagType.CHARGED, true, true),
+      .attr(AddBattlerTagAttr, BattlerTagType.CHARGED, true, false),
     new StatusMove(Moves.TAUNT, Type.DARK, 100, 20, -1, 0, 3)
       .unimplemented(),
     new StatusMove(Moves.HELPING_HAND, Type.NORMAL, -1, 20, -1, 5, 3)

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1320,9 +1320,12 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         else {
           let typeBoost = source.findTag(t => t instanceof TypeBoostTag && (t as TypeBoostTag).boostedType === type) as TypeBoostTag;
           if (typeBoost) {
+            console.log("AAAAAAAAA");
             power.value *= typeBoost.boostValue;
             if (typeBoost.oneUse) {
-              this.removeTag(typeBoost.tagType);
+              console.log(typeBoost.tagType);
+              console.log(source);
+              source.removeTag(typeBoost.tagType);
             }
           }
           const arenaAttackTypeMultiplier = this.scene.arena.getAttackTypeMultiplier(type, source.isGrounded());

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1320,11 +1320,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         else {
           let typeBoost = source.findTag(t => t instanceof TypeBoostTag && (t as TypeBoostTag).boostedType === type) as TypeBoostTag;
           if (typeBoost) {
-            console.log("AAAAAAAAA");
             power.value *= typeBoost.boostValue;
             if (typeBoost.oneUse) {
-              console.log(typeBoost.tagType);
-              console.log(source);
               source.removeTag(typeBoost.tagType);
             }
           }


### PR DESCRIPTION
1. Charge accidentally had the `failOnOverlap` field as true instead of false which meant you would not gain the special defense boost if you were already charged
2. The charged status was incorrectly trying to be removed on the attacked Pokemon instead of the attacker