### PR TITLE
Fix cry when pokemon is fused with its own species and form

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1712,7 +1712,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     const scene = sceneOverride || this.scene;
     const cry = this.getSpeciesForm().cry(scene, soundConfig);
     let duration = cry.totalDuration * 1000;
-    if (this.fusionSpecies) {
+    if (this.fusionSpecies && this.getSpeciesForm() != this.getFusionSpeciesForm()) {
       let fusionCry = this.getFusionSpeciesForm().cry(scene, soundConfig, true);
       duration = Math.min(duration, fusionCry.totalDuration * 1000);
       fusionCry.destroy();
@@ -1731,7 +1731,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   faintCry(callback: Function): void {
-    if (this.fusionSpecies)
+    if (this.fusionSpecies && this.getSpeciesForm() != this.getFusionSpeciesForm())
       return this.fusionFaintCry(callback);
 
     const key = this.getSpeciesForm().getCryKey(this.formIndex);


### PR DESCRIPTION
If the pokemon species and form is the same as the second fusion component, then skip the logic to make a fused cry and just use the cry of the primary component. Previously a pokemon spliced with another of the same species and form would not have a cry and would log an error to the console.

Tested with various combinations of pokemon and their mega/gigantamax forms, but _not_ tested with other kinds of forms, like rotom or alcremie.