### PR TITLE
Fix opponent sprite disappearing when using Roar

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -4167,8 +4167,7 @@ export function initMoves() {
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new StatusMove(Moves.ROAR, Type.NORMAL, -1, 20, -1, -6, 1)
       .attr(ForceSwitchOutAttr)
-      .soundBased()
-      .hidesTarget(),
+      .soundBased(),
     new StatusMove(Moves.SING, Type.NORMAL, 55, 15, -1, 0, 1)
       .attr(StatusEffectAttr, StatusEffect.SLEEP)
       .soundBased(),


### PR DESCRIPTION
This PR addresses the issue raised here: https://github.com/pagefaultgames/pokerogue/issues/481

https://github.com/pagefaultgames/pokerogue/assets/59787978/8f899953-d9c2-4fa7-93dc-376e0ee3f615

Verified that this is also working correctly when the player pokemon uses roar