### PR TITLE
Fixed Failed Moves Not Using PP

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3206,6 +3206,14 @@ export class PokemonMove {
     return allMoves[this.moveId];
   }
 
+  /**
+   * Sets {@link ppUsed} for this move and ensures the value does not exceed {@link getMovePp}
+   * @param {number} count Amount of PP to use
+   */
+  usePp(count: number = 1) {
+    this.ppUsed = Math.min(this.ppUsed + count, this.getMovePp());
+  }
+
   getMovePp(): integer {
     return this.getMove().pp + this.ppUp * Math.max(Math.floor(this.getMove().pp / 5), 1);
   }

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2158,6 +2158,7 @@ export class MovePhase extends BattlePhase {
   public targets: BattlerIndex[];
   protected followUp: boolean;
   protected ignorePp: boolean;
+  protected failed: boolean;
   protected cancelled: boolean;
 
   constructor(scene: BattleScene, pokemon: Pokemon, targets: BattlerIndex[], move: PokemonMove, followUp?: boolean, ignorePp?: boolean) {
@@ -2168,6 +2169,7 @@ export class MovePhase extends BattlePhase {
     this.move = move;
     this.followUp = !!followUp;
     this.ignorePp = !!ignorePp;
+    this.failed = false;
     this.cancelled = false;
   }
 
@@ -2175,6 +2177,12 @@ export class MovePhase extends BattlePhase {
     return this.pokemon.isActive(true) && this.move.isUsable(this.pokemon, this.ignorePp) && !!this.targets.length;
   }
 
+  /**Signifies the current move should fail but still use PP */
+  fail(): void {
+    this.failed = true;
+  }
+
+  /**Signifies the current move should cancel and retain PP */
   cancel(): void {
     this.cancelled = true;
   }
@@ -2214,7 +2222,7 @@ export class MovePhase extends BattlePhase {
           this.targets[0] = attacker.getBattlerIndex();
       }
       if (this.targets[0] === BattlerIndex.ATTACKER) {
-        this.cancel();
+        this.fail(); // Marks the move as failed for later in doMove
         this.showMoveText();
         this.showFailedText();
       }
@@ -2234,11 +2242,24 @@ export class MovePhase extends BattlePhase {
       this.pokemon.turnData.acted = true; // Record that the move was attempted, even if it fails
       
       this.pokemon.lapseTags(BattlerTagLapseType.PRE_MOVE);
+      
+      let ppUsed = 1;
+      // Filter all opponents to include only those this move is targeting
+      const targetedOpponents = this.pokemon.getOpponents().filter(o => this.targets.includes(o.getBattlerIndex()));
+      for (let opponent of targetedOpponents) {
+        if (this.move.ppUsed + ppUsed >= this.move.getMovePp()) // If we're already at max PP usage, stop checking
+          break;
+        if (opponent.hasAbilityWithAttr(IncreasePpAbAttr)) // Accounting for abilities like Pressure
+          ppUsed++;
+      }
 	    
       if (!this.followUp && this.canMove() && !this.cancelled) {
         this.pokemon.lapseTags(BattlerTagLapseType.MOVE);
       }
-      if (this.cancelled) {
+      if (this.cancelled || this.failed) {
+        if (this.failed)
+          this.move.usePp(ppUsed); // Only use PP if the move failed
+
         this.pokemon.pushMoveHistory({ move: Moves.NONE, result: MoveResult.FAIL });
         return this.end();
       }
@@ -2253,23 +2274,12 @@ export class MovePhase extends BattlePhase {
       if ((moveQueue.length && moveQueue[0].move === Moves.NONE) || !targets.length) {
         moveQueue.shift();
         this.cancel();
-      }
-
-      if (this.cancelled) {
         this.pokemon.pushMoveHistory({ move: Moves.NONE, result: MoveResult.FAIL });
         return this.end();
       }
 
-      if (!moveQueue.length || !moveQueue.shift().ignorePP) {
-        this.move.ppUsed++;
-        const targetedOpponents = this.pokemon.getOpponents().filter(o => this.targets.includes(o.getBattlerIndex()));
-        for (let opponent of targetedOpponents) {
-          if (this.move.ppUsed === this.move.getMove().pp)
-            break;
-          if (opponent.hasAbilityWithAttr(IncreasePpAbAttr))
-            this.move.ppUsed = Math.min(this.move.ppUsed + 1, this.move.getMovePp());
-        }
-      }
+      if (!moveQueue.length || !moveQueue.shift().ignorePP) // using .shift here clears out two turn moves once they've been used
+        this.move.usePp(ppUsed);
 
       if (!allMoves[this.move.moveId].getAttrs(CopyMoveAttr).length)
         this.scene.currentBattle.lastMove = this.move.moveId;


### PR DESCRIPTION
Fixed an issue where if a move failed, it would not use Power Points. This caused soft locks in Endless for some pokemon that could only use moves on the user that failed.

Taking a look at the code, there was no solution I could find that didn't involve adding in some way to differentiate a canceled move from a failed one. Canceled moves don't use PP and there were a lot of reasons why this may happen. Most of them I could account for. That is, except for Truant. There was no simple way to determine if the cause for canceling the move was Truant. At that point it was less destructive to simply add a way to mark a move as failed.

With that said, I added the appropriate property and method to match the 'cancel' method though it isn't used outside of this instance at the moment. Move which fail still consume Power Points. Moves which are canceled do not.  

https://github.com/pagefaultgames/pokerogue/assets/13838608/9e6afa35-f0e1-4b67-aa4a-4a5de64db092

https://github.com/pagefaultgames/pokerogue/assets/13838608/395a45ed-ac1d-4343-8765-ac3ec068475c

https://github.com/pagefaultgames/pokerogue/assets/13838608/db605da6-9833-4c07-81aa-f09eca40dbe1

https://github.com/pagefaultgames/pokerogue/assets/13838608/ab2e8bea-438b-4de2-a5d7-c9232d05ab0b

https://github.com/pagefaultgames/pokerogue/assets/13838608/b97dc687-dc10-44f5-90cd-a9f07a89da6b

