### PR TITLE
Names of the languages in their respectives languages

### DIFF
--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -195,7 +195,7 @@ export function setSetting(scene: BattleScene, setting: Setting, value: integer)
                 handler: () => changeLocaleHandler('fr')
               },
               {
-                label: 'Deutsche',
+                label: 'Deutsch',
                 handler: () => changeLocaleHandler('de')
               },
               {

--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -183,19 +183,19 @@ export function setSetting(scene: BattleScene, setting: Setting, value: integer)
                 handler: () => changeLocaleHandler('en')
               },
               {
-                label: 'Spanish',
+                label: 'Español',
                 handler: () => changeLocaleHandler('es')
               },
               {
-                label: 'Italian',
+                label: 'Italiano',
                 handler: () => changeLocaleHandler('it')
               },
               {
-                label: 'French',
+                label: 'Français',
                 handler: () => changeLocaleHandler('fr')
               },
               {
-                label: 'German',
+                label: 'Deutsche',
                 handler: () => changeLocaleHandler('de')
               },
               {


### PR DESCRIPTION
In Game Settings, proposal to give languages the names they have in their respective languages, as it is in recent games :
![language select sv](https://github.com/pagefaultgames/pokerogue/assets/2070109/5266857c-e91a-4a9f-a85b-85b1a6eeee2b)
(screenshot from Scarlet and Violet)
