### PR TITLE
Added repels :

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -4,7 +4,7 @@ import { NextEncounterPhase, NewBiomeEncounterPhase, SelectBiomePhase, MessagePh
 import Pokemon, { PlayerPokemon, EnemyPokemon } from './field/pokemon';
 import PokemonSpecies, { PokemonSpeciesFilter, allSpecies, getPokemonSpecies, initSpecies, speciesStarters } from './data/pokemon-species';
 import * as Utils from './utils';
-import { Modifier, ModifierBar, ConsumablePokemonModifier, ConsumableModifier, PokemonHpRestoreModifier, HealingBoosterModifier, PersistentModifier, PokemonHeldItemModifier, ModifierPredicate, DoubleBattleChanceBoosterModifier, FusePokemonModifier, PokemonFormChangeItemModifier, TerastallizeModifier } from './modifier/modifier';
+import { Modifier, ModifierBar, ConsumablePokemonModifier, ConsumableModifier, PokemonHpRestoreModifier, HealingBoosterModifier, PersistentModifier, PokemonHeldItemModifier, ModifierPredicate, DoubleBattleChanceModifier, FusePokemonModifier, PokemonFormChangeItemModifier, TerastallizeModifier } from './modifier/modifier';
 import { PokeballType } from './data/pokeball';
 import { initCommonAnims, initMoveAnim, loadCommonAnimAssets, loadMoveAnimAssets, populateAnims } from './data/battle-anims';
 import { Phase } from './phase';
@@ -822,7 +822,7 @@ export default class BattleScene extends SceneBase {
 					doubleTrainer = true;
 				else if (trainerConfigs[trainerType].hasDouble) {
 					const doubleChance = new Utils.IntegerHolder(newWaveIndex % 10 === 0 ? 32 : 8);
-					this.applyModifiers(DoubleBattleChanceBoosterModifier, true, doubleChance);
+					this.applyModifiers(DoubleBattleChanceModifier, true, doubleChance);
 					playerField.forEach(p => applyAbAttrs(DoubleBattleChanceAbAttr, p, null, doubleChance));
 					doubleTrainer = !Utils.randSeedInt(doubleChance.value);
 				}
@@ -834,7 +834,7 @@ export default class BattleScene extends SceneBase {
 		if (double === undefined && newWaveIndex > 1) {
 			if (newBattleType === BattleType.WILD && !this.gameMode.isWaveFinal(newWaveIndex)) {
 				const doubleChance = new Utils.IntegerHolder(newWaveIndex % 10 === 0 ? 32 : 8);
-				this.applyModifiers(DoubleBattleChanceBoosterModifier, true, doubleChance);
+				this.applyModifiers(DoubleBattleChanceModifier, true, doubleChance);
 				playerField.forEach(p => applyAbAttrs(DoubleBattleChanceAbAttr, p, null, doubleChance));
 				newDouble = !Utils.randSeedInt(doubleChance.value);
 			} else if (newBattleType === BattleType.TRAINER)

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -328,13 +328,17 @@ export class RememberMoveModifierType extends PokemonModifierType {
   }
 }
 
-export class DoubleBattleChanceBoosterModifierType extends ModifierType {
+export class DoubleBattleChanceModifierType extends ModifierType {
   public battleCount: integer;
 
-  constructor(name: string, battleCount: integer) {
-    super(name, `Doubles the chance of an encounter being a double battle for ${battleCount} battles`, (_type, _args) => new Modifiers.DoubleBattleChanceBoosterModifier(this, this.battleCount),
+  constructor(name: string, battleCount: integer, modifier: integer) {
+    if (modifier < 0) {
+      super(name, `Avoid encounter being a double battle for ${battleCount} battles`, (_type, _args) => new Modifiers.DoubleBattleChanceModifier(this, this.battleCount, modifier),
+      null, 'repel');
+    } else {
+      super(name, `Doubles the chance of an encounter being a double battle for ${battleCount} battles`, (_type, _args) => new Modifiers.DoubleBattleChanceModifier(this, this.battleCount, modifier),
       null, 'lure');
-
+    }
     this.battleCount = battleCount;
   }
 }
@@ -811,13 +815,13 @@ export const modifierTypes = {
   PP_UP: () => new PokemonPpUpModifierType('PP Up', 1),
   PP_MAX: () => new PokemonPpUpModifierType('PP Max', 3),
 
-  /*REPEL: () => new DoubleBattleChanceBoosterModifierType('Repel', 5),
-  SUPER_REPEL: () => new DoubleBattleChanceBoosterModifierType('Super Repel', 10),
-  MAX_REPEL: () => new DoubleBattleChanceBoosterModifierType('Max Repel', 25),*/
+  REPEL: () => new DoubleBattleChanceModifierType('Repel', 5, -1),
+  SUPER_REPEL: () => new DoubleBattleChanceModifierType('Super Repel', 10, -1),
+  MAX_REPEL: () => new DoubleBattleChanceModifierType('Max Repel', 25, -1),
 
-  LURE: () => new DoubleBattleChanceBoosterModifierType('Lure', 5),
-  SUPER_LURE: () => new DoubleBattleChanceBoosterModifierType('Super Lure', 10),
-  MAX_LURE: () => new DoubleBattleChanceBoosterModifierType('Max Lure', 25),
+  LURE: () => new DoubleBattleChanceModifierType('Lure', 5, 1),
+  SUPER_LURE: () => new DoubleBattleChanceModifierType('Super Lure', 10, 1),
+  MAX_LURE: () => new DoubleBattleChanceModifierType('Max Lure', 25, 1),
 
   TEMP_STAT_BOOSTER: () => new ModifierTypeGenerator((party: Pokemon[], pregenArgs?: any[]) => {
     if (pregenArgs)
@@ -991,6 +995,7 @@ const modifierPool: ModifierPool = {
       return thresholdPartyMemberCount;
     }, 3),
     new WeightedModifierType(modifierTypes.LURE, 2),
+    new WeightedModifierType(modifierTypes.REPEL, 2),
     new WeightedModifierType(modifierTypes.TEMP_STAT_BOOSTER, 4),
     new WeightedModifierType(modifierTypes.BERRY, 2),
     new WeightedModifierType(modifierTypes.TM_COMMON, 1),
@@ -1035,6 +1040,7 @@ const modifierPool: ModifierPool = {
     }, 3),
     new WeightedModifierType(modifierTypes.DIRE_HIT, 4),
     new WeightedModifierType(modifierTypes.SUPER_LURE, 4),
+    new WeightedModifierType(modifierTypes.SUPER_REPEL, 4),
     new WeightedModifierType(modifierTypes.NUGGET, 5),
     new WeightedModifierType(modifierTypes.EVOLUTION_ITEM, (party: Pokemon[]) => {
       return Math.min(Math.ceil(party[0].scene.currentBattle.waveIndex / 15), 8);
@@ -1054,6 +1060,7 @@ const modifierPool: ModifierPool = {
   [ModifierTier.ULTRA]: [
     new WeightedModifierType(modifierTypes.ULTRA_BALL, 24),
     new WeightedModifierType(modifierTypes.MAX_LURE, 4),
+    new WeightedModifierType(modifierTypes.MAX_REPEL, 4),
     new WeightedModifierType(modifierTypes.BIG_NUGGET, 12),
     new WeightedModifierType(modifierTypes.PP_UP, 9),
     new WeightedModifierType(modifierTypes.PP_MAX, 3),

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -282,19 +282,21 @@ export abstract class LapsingPersistentModifier extends PersistentModifier {
   }
 }
 
-export class DoubleBattleChanceBoosterModifier extends LapsingPersistentModifier {
-  constructor(type: ModifierTypes.DoubleBattleChanceBoosterModifierType, battlesLeft: integer, stackCount?: integer) {
+export class DoubleBattleChanceModifier extends LapsingPersistentModifier {
+  private modifier;
+  constructor(type: ModifierTypes.DoubleBattleChanceModifierType, battlesLeft: integer, modifier: integer, stackCount?: integer) {
     super(type, battlesLeft, stackCount);
+    this.modifier = modifier;
   }
 
   match(modifier: Modifier): boolean {
-    if (modifier instanceof DoubleBattleChanceBoosterModifier)
-      return (modifier as DoubleBattleChanceBoosterModifier).battlesLeft === this.battlesLeft;
+    if (modifier instanceof DoubleBattleChanceModifier)
+      return (modifier as DoubleBattleChanceModifier).battlesLeft === this.battlesLeft;
     return false;
   }
 
-  clone(): DoubleBattleChanceBoosterModifier {
-    return new DoubleBattleChanceBoosterModifier(this.type as ModifierTypes.DoubleBattleChanceBoosterModifierType, this.battlesLeft, this.stackCount);
+  clone(): DoubleBattleChanceModifier {
+    return new DoubleBattleChanceModifier(this.type as ModifierTypes.DoubleBattleChanceModifierType, this.battlesLeft, this.stackCount);
   }
 
   getArgs(): any[] {
@@ -303,8 +305,11 @@ export class DoubleBattleChanceBoosterModifier extends LapsingPersistentModifier
 
   apply(args: any[]): boolean {
     const doubleBattleChance = args[0] as Utils.NumberHolder;
-    doubleBattleChance.value = Math.ceil(doubleBattleChance.value / 2);
-
+    if (this.modifier < 0){
+      doubleBattleChance.value = Number.MAX_SAFE_INTEGER;
+    } else {
+      doubleBattleChance.value = Math.ceil(doubleBattleChance.value / 2);
+    }
     return true;
   }
 }


### PR DESCRIPTION
* Prevents double battle from happening by setting the maximum range of the random  managing the double battle chances at Number.MAX_SAFE_INTEGER.
* Does not prevents lure appearance as I think it allows more play options
* Renamed the Modifier class DoubleBattleChanceBoosterModifier into DoubleBattleChanceModifier using refactor
* Added an integer argument to DoubleBattleChanceModifier class called 'modifier' (maybe change the name), that indicates to apply the repel effects if negative, or the lure effect if positive. It allows to possibly use it at a multiplicative modifier if you do not want repels to make the chances fall to 0 but instead diminish the chances by 2 or 3 depending on repel type. Same goes for the lures.