### PR TITLE
Fix offline mode imports in the app

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -220,7 +220,7 @@ export function executeIf<T>(condition: boolean, promiseFunc: () => Promise<T>):
 }
 
 export const sessionIdKey = 'pokerogue_sessionId';
-export const isLocal = window.location.hostname === 'localhost';
+export const isLocal = window.location.hostname === 'localhost' || window.location.hostname === '';
 export const serverUrl = isLocal ? 'http://localhost:8001' : '';
 export const apiUrl = isLocal ? serverUrl : 'https://api.pokerogue.net';
 export const fallbackApiUrl = isLocal ? serverUrl : 'api';


### PR DESCRIPTION
Apparently when you're loading files from the filesystem, window.location.hostname is an empty string rather than localhost. This PR changes it to also check for empty strings so that offline features like importing properly work in my app.