### PR TITLE
Implement Snipe Shot, and Propeller Tail/Stalwart

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2321,6 +2321,8 @@ export class RedirectTypeMoveAbAttr extends RedirectMoveAbAttr {
   }
 }
 
+export class BlockRedirectAbAttr extends AbAttr { }
+
 export class ReduceStatusEffectDurationAbAttr extends AbAttr {
   private statusEffect: StatusEffect;
 
@@ -3407,7 +3409,7 @@ export function initAbilities() {
     new Ability(Abilities.COTTON_DOWN, 8)
       .unimplemented(),
     new Ability(Abilities.PROPELLER_TAIL, 8)
-      .unimplemented(),
+      .attr(BlockRedirectAbAttr),
     new Ability(Abilities.MIRROR_ARMOR, 8)
       .ignorable()
       .unimplemented(),
@@ -3417,7 +3419,7 @@ export function initAbilities() {
       .attr(NoFusionAbilityAbAttr)
       .unimplemented(),
     new Ability(Abilities.STALWART, 8)
-      .unimplemented(),
+      .attr(BlockRedirectAbAttr),
     new Ability(Abilities.STEAM_ENGINE, 8)
       .attr(PostDefendStatChangeAbAttr, (target, user, move) => (move.type === Type.FIRE || move.type === Type.WATER) && move.category !== MoveCategory.STATUS, BattleStat.SPD, 6),
     new Ability(Abilities.PUNK_ROCK, 8)

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6064,6 +6064,7 @@ export function initMoves() {
       .attr(DiscourageFrequentUseAttr)
       .ignoresVirtual(),
     new AttackMove(Moves.SNIPE_SHOT, Type.WATER, MoveCategory.SPECIAL, 80, 100, 15, -1, 0, 8)
+      .attr(HighCritAttr)  
       .attr(BypassRedirectAttr),
     new AttackMove(Moves.JAW_LOCK, Type.DARK, MoveCategory.PHYSICAL, 80, 100, 10, -1, 0, 8)
       .attr(AddBattlerTagAttr, BattlerTagType.TRAPPED, false, false, 1)

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2598,6 +2598,9 @@ const crashDamageFunc = (user: Pokemon, move: Move) => {
 
 export class TypelessAttr extends MoveAttr { }
 
+export class BypassRedirectAttr extends MoveAttr { }
+
+
 export class DisableMoveAttr extends MoveEffectAttr {
   constructor() {
     super(false);
@@ -6061,7 +6064,7 @@ export function initMoves() {
       .attr(DiscourageFrequentUseAttr)
       .ignoresVirtual(),
     new AttackMove(Moves.SNIPE_SHOT, Type.WATER, MoveCategory.SPECIAL, 80, 100, 15, -1, 0, 8)
-      .partial(),
+      .attr(BypassRedirectAttr),
     new AttackMove(Moves.JAW_LOCK, Type.DARK, MoveCategory.PHYSICAL, 80, 100, 10, -1, 0, 8)
       .attr(AddBattlerTagAttr, BattlerTagType.TRAPPED, false, false, 1)
       .attr(AddBattlerTagAttr, BattlerTagType.TRAPPED, true, false, 1)

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2597,9 +2597,11 @@ const crashDamageFunc = (user: Pokemon, move: Move) => {
 };
 
 export class TypelessAttr extends MoveAttr { }
-
+/**
+* Attribute used for moves which ignore redirection effects, and always target their original target, i.e. Snipe Shot
+* Bypasses Storm Drain, Follow Me, Ally Switch, and the like.
+*/ 
 export class BypassRedirectAttr extends MoveAttr { }
-
 
 export class DisableMoveAttr extends MoveEffectAttr {
   constructor() {

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -5,19 +5,19 @@ import { Moves } from "./data/enums/moves";
 import { WeatherType } from "./data/weather";
 
 export const SEED_OVERRIDE = '';
-export const STARTER_SPECIES_OVERRIDE = 0;
+export const STARTER_SPECIES_OVERRIDE = 847;
 export const STARTER_FORM_OVERRIDE = 0;
-export const STARTING_LEVEL_OVERRIDE = 0;
+export const STARTING_LEVEL_OVERRIDE = 50;
 export const STARTING_WAVE_OVERRIDE = 0;
-export const STARTING_BIOME_OVERRIDE = Biome.TOWN;
-export const STARTING_MONEY_OVERRIDE = 0;
+export const STARTING_BIOME_OVERRIDE = Biome.SWAMP;
+export const STARTING_MONEY_OVERRIDE = 10000;
 export const WEATHER_OVERRIDE = WeatherType.NONE;
-export const DOUBLE_BATTLE_OVERRIDE = false;
+export const DOUBLE_BATTLE_OVERRIDE = true;
 
 export const ABILITY_OVERRIDE = Abilities.NONE;
 export const PASSIVE_ABILITY_OVERRIDE = Abilities.NONE;
 export const MOVE_OVERRIDE = Moves.NONE;
-export const MOVE_OVERRIDE_2 = Moves.NONE;
+export const MOVE_OVERRIDE_2 = Moves.SNIPE_SHOT;
 export const OPP_SPECIES_OVERRIDE = 0;
 export const OPP_ABILITY_OVERRIDE = Abilities.NONE;
 export const OPP_PASSIVE_ABILITY_OVERRIDE = Abilities.NONE;

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -5,19 +5,19 @@ import { Moves } from "./data/enums/moves";
 import { WeatherType } from "./data/weather";
 
 export const SEED_OVERRIDE = '';
-export const STARTER_SPECIES_OVERRIDE = 847;
+export const STARTER_SPECIES_OVERRIDE = 0;
 export const STARTER_FORM_OVERRIDE = 0;
-export const STARTING_LEVEL_OVERRIDE = 50;
+export const STARTING_LEVEL_OVERRIDE = 0;
 export const STARTING_WAVE_OVERRIDE = 0;
-export const STARTING_BIOME_OVERRIDE = Biome.SWAMP;
-export const STARTING_MONEY_OVERRIDE = 10000;
+export const STARTING_BIOME_OVERRIDE = Biome.TOWN;
+export const STARTING_MONEY_OVERRIDE = 0;
 export const WEATHER_OVERRIDE = WeatherType.NONE;
-export const DOUBLE_BATTLE_OVERRIDE = true;
+export const DOUBLE_BATTLE_OVERRIDE = false;
 
 export const ABILITY_OVERRIDE = Abilities.NONE;
 export const PASSIVE_ABILITY_OVERRIDE = Abilities.NONE;
 export const MOVE_OVERRIDE = Moves.NONE;
-export const MOVE_OVERRIDE_2 = Moves.SNIPE_SHOT;
+export const MOVE_OVERRIDE_2 = Moves.NONE;
 export const OPP_SPECIES_OVERRIDE = 0;
 export const OPP_ABILITY_OVERRIDE = Abilities.NONE;
 export const OPP_PASSIVE_ABILITY_OVERRIDE = Abilities.NONE;

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2211,6 +2211,7 @@ export class MovePhase extends BattlePhase {
       ? new Utils.IntegerHolder(this.targets[0])
       : null;
       if (moveTarget) {
+	  //If user has an ability preventing moves from being redirected, or is using a move that can not be redirected (i.e. Snipe Shot), don't redirect it.
           if (!(this.pokemon.hasAbilityWithAttr(BlockRedirectAbAttr) || this.move.getMove().getAttrs(BypassRedirectAttr).length) )
           {
             this.scene.getField(true).filter(p => p !== this.pokemon).forEach(p => applyAbAttrs(RedirectMoveAbAttr, p, null, this.move.moveId, moveTarget));

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2207,23 +2207,22 @@ export class MovePhase extends BattlePhase {
     }
 
     // Move redirection abilities (ie. Storm Drain) only support single target moves
-      const moveTarget = this.targets.length === 1
-          ? new Utils.IntegerHolder(this.targets[0])
-          : null;
-      if (moveTarget) {
-          var oldTarget = moveTarget.value;
-          this.scene.getField(true).filter(p => p !== this.pokemon).forEach(p => applyAbAttrs(RedirectMoveAbAttr, p, null, this.move.moveId, moveTarget));
-          //Check if this move is immune to being redirected, and restore its target to the intended target if it is.
-          if ((this.pokemon.hasAbilityWithAttr(BlockRedirectAbAttr) || this.move.getMove().getAttrs(BypassRedirectAttr).length)) {
-              //If an ability prevented this move from being redirected, display its ability pop up.
-              if ((this.pokemon.hasAbilityWithAttr(BlockRedirectAbAttr) && !this.move.getMove().getAttrs(BypassRedirectAttr).length) && oldTarget != moveTarget.value) {
-                  this.scene.unshiftPhase(new ShowAbilityPhase(this.scene, this.pokemon.getBattlerIndex(), this.pokemon.getPassiveAbility().hasAttr(BlockRedirectAbAttr)));
-              }
-              moveTarget.value = oldTarget;
-          }
-          this.targets[0] = moveTarget.value;
-      }
-
+const moveTarget = this.targets.length === 1
+        ? new Utils.IntegerHolder(this.targets[0])
+         : null;
+ if (moveTarget) {
+        var oldTarget = moveTarget.value;
+        this.scene.getField(true).filter(p => p !== this.pokemon).forEach(p => applyAbAttrs(RedirectMoveAbAttr, p, null, this.move.moveId, moveTarget));
+  //Check if this move is immune to being redirected, and restore its target to the intended target if it is.
+        if ((this.pokemon.hasAbilityWithAttr(BlockRedirectAbAttr) || this.move.getMove().getAttrs(BypassRedirectAttr).length)) {
+         //If an ability prevented this move from being redirected, display its ability pop up.
+         if ((this.pokemon.hasAbilityWithAttr(BlockRedirectAbAttr) && !this.move.getMove().getAttrs(BypassRedirectAttr).length) && oldTarget != moveTarget.value) {
+                this.scene.unshiftPhase(new ShowAbilityPhase(this.scene, this.pokemon.getBattlerIndex(), this.pokemon.getPassiveAbility().hasAttr(BlockRedirectAbAttr)));
+         }
+        moveTarget.value = oldTarget;
+	}
+ this.targets[0] = moveTarget.value;
+}
 
     if (this.targets.length === 1 && this.targets[0] === BattlerIndex.ATTACKER) {
       if (this.pokemon.turnData.attacksReceived.length) {

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2207,17 +2207,23 @@ export class MovePhase extends BattlePhase {
     }
 
     // Move redirection abilities (ie. Storm Drain) only support single target moves
-    const moveTarget = this.targets.length === 1
-      ? new Utils.IntegerHolder(this.targets[0])
-      : null;
+      const moveTarget = this.targets.length === 1
+          ? new Utils.IntegerHolder(this.targets[0])
+          : null;
       if (moveTarget) {
-	  //If user has an ability preventing moves from being redirected, or is using a move that can not be redirected (i.e. Snipe Shot), don't redirect it.
-          if (!(this.pokemon.hasAbilityWithAttr(BlockRedirectAbAttr) || this.move.getMove().getAttrs(BypassRedirectAttr).length) )
-          {
-            this.scene.getField(true).filter(p => p !== this.pokemon).forEach(p => applyAbAttrs(RedirectMoveAbAttr, p, null, this.move.moveId, moveTarget));
+          var oldTarget = moveTarget.value;
+          this.scene.getField(true).filter(p => p !== this.pokemon).forEach(p => applyAbAttrs(RedirectMoveAbAttr, p, null, this.move.moveId, moveTarget));
+          //Check if this move is immune to being redirected, and restore its target to the intended target if it is.
+          if ((this.pokemon.hasAbilityWithAttr(BlockRedirectAbAttr) || this.move.getMove().getAttrs(BypassRedirectAttr).length)) {
+              //If an ability prevented this move from being redirected, display its ability pop up.
+              if ((this.pokemon.hasAbilityWithAttr(BlockRedirectAbAttr) && !this.move.getMove().getAttrs(BypassRedirectAttr).length) && oldTarget != moveTarget.value) {
+                  this.scene.unshiftPhase(new ShowAbilityPhase(this.scene, this.pokemon.getBattlerIndex(), this.pokemon.getPassiveAbility().hasAttr(BlockRedirectAbAttr)));
+              }
+              moveTarget.value = oldTarget;
           }
-      this.targets[0] = moveTarget.value;
-    }
+          this.targets[0] = moveTarget.value;
+      }
+
 
     if (this.targets.length === 1 && this.targets[0] === BattlerIndex.ATTACKER) {
       if (this.pokemon.turnData.attacksReceived.length) {

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2,7 +2,7 @@ import BattleScene, { AnySound, bypassLogin, startingWave } from "./battle-scene
 import { default as Pokemon, PlayerPokemon, EnemyPokemon, PokemonMove, MoveResult, DamageResult, FieldPosition, HitResult, TurnMove } from "./field/pokemon";
 import * as Utils from './utils';
 import { Moves } from "./data/enums/moves";
-import { allMoves, applyMoveAttrs, BypassSleepAttr, ChargeAttr, applyFilteredMoveAttrs, HitsTagAttr, MissEffectAttr, MoveAttr, MoveEffectAttr, MoveFlags, MultiHitAttr, OverrideMoveEffectAttr, VariableAccuracyAttr, MoveTarget, OneHitKOAttr, getMoveTargets, MoveTargetSet, MoveEffectTrigger, CopyMoveAttr, AttackMove, SelfStatusMove, DelayedAttackAttr, RechargeAttr, PreMoveMessageAttr, HealStatusEffectAttr, IgnoreOpponentStatChangesAttr, NoEffectAttr, FixedDamageAttr, PostVictoryStatChangeAttr, OneHitKOAccuracyAttr, ForceSwitchOutAttr, VariableTargetAttr } from "./data/move";
+import { allMoves, applyMoveAttrs, BypassSleepAttr, ChargeAttr, applyFilteredMoveAttrs, HitsTagAttr, MissEffectAttr, MoveAttr, MoveEffectAttr, MoveFlags, MultiHitAttr, OverrideMoveEffectAttr, VariableAccuracyAttr, MoveTarget, OneHitKOAttr, getMoveTargets, MoveTargetSet, MoveEffectTrigger, CopyMoveAttr, AttackMove, SelfStatusMove, DelayedAttackAttr, RechargeAttr, PreMoveMessageAttr, HealStatusEffectAttr, IgnoreOpponentStatChangesAttr, NoEffectAttr, BypassRedirectAttr ,FixedDamageAttr, PostVictoryStatChangeAttr, OneHitKOAccuracyAttr, ForceSwitchOutAttr, VariableTargetAttr } from "./data/move";
 import { Mode } from './ui/ui';
 import { Command } from "./ui/command-ui-handler";
 import { Stat } from "./data/pokemon-stat";
@@ -30,7 +30,7 @@ import { Weather, WeatherType, getRandomWeatherType, getTerrainBlockMessage, get
 import { TempBattleStat } from "./data/temp-battle-stat";
 import { ArenaTagSide, ArenaTrapTag, MistTag, TrickRoomTag } from "./data/arena-tag";
 import { ArenaTagType } from "./data/enums/arena-tag-type";
-import { CheckTrappedAbAttr, IgnoreOpponentStatChangesAbAttr, PostAttackAbAttr, PostBattleAbAttr, PostDefendAbAttr, PostSummonAbAttr, PostTurnAbAttr, PostWeatherLapseAbAttr, PreSwitchOutAbAttr, PreWeatherDamageAbAttr, ProtectStatAbAttr, RedirectMoveAbAttr, RunSuccessAbAttr, StatChangeMultiplierAbAttr, SuppressWeatherEffectAbAttr, SyncEncounterNatureAbAttr, applyAbAttrs, applyCheckTrappedAbAttrs, applyPostAttackAbAttrs, applyPostBattleAbAttrs, applyPostDefendAbAttrs, applyPostSummonAbAttrs, applyPostTurnAbAttrs, applyPostWeatherLapseAbAttrs, applyPreStatChangeAbAttrs, applyPreSwitchOutAbAttrs, applyPreWeatherEffectAbAttrs, BattleStatMultiplierAbAttr, applyBattleStatMultiplierAbAttrs, IncrementMovePriorityAbAttr, applyPostVictoryAbAttrs, PostVictoryAbAttr, applyPostBattleInitAbAttrs, PostBattleInitAbAttr, BlockNonDirectDamageAbAttr as BlockNonDirectDamageAbAttr, applyPostKnockOutAbAttrs, PostKnockOutAbAttr, PostBiomeChangeAbAttr, applyPostFaintAbAttrs, PostFaintAbAttr, IncreasePpAbAttr, PostStatChangeAbAttr, applyPostStatChangeAbAttrs, AlwaysHitAbAttr, PreventBerryUseAbAttr, StatChangeCopyAbAttr } from "./data/ability";
+import { CheckTrappedAbAttr, IgnoreOpponentStatChangesAbAttr, PostAttackAbAttr, PostBattleAbAttr, PostDefendAbAttr, PostSummonAbAttr, PostTurnAbAttr, PostWeatherLapseAbAttr, PreSwitchOutAbAttr, PreWeatherDamageAbAttr, ProtectStatAbAttr, RedirectMoveAbAttr, BlockRedirectAbAttr, RunSuccessAbAttr, StatChangeMultiplierAbAttr, SuppressWeatherEffectAbAttr, SyncEncounterNatureAbAttr, applyAbAttrs, applyCheckTrappedAbAttrs, applyPostAttackAbAttrs, applyPostBattleAbAttrs, applyPostDefendAbAttrs, applyPostSummonAbAttrs, applyPostTurnAbAttrs, applyPostWeatherLapseAbAttrs, applyPreStatChangeAbAttrs, applyPreSwitchOutAbAttrs, applyPreWeatherEffectAbAttrs, BattleStatMultiplierAbAttr, applyBattleStatMultiplierAbAttrs, IncrementMovePriorityAbAttr, applyPostVictoryAbAttrs, PostVictoryAbAttr, applyPostBattleInitAbAttrs, PostBattleInitAbAttr, BlockNonDirectDamageAbAttr as BlockNonDirectDamageAbAttr, applyPostKnockOutAbAttrs, PostKnockOutAbAttr, PostBiomeChangeAbAttr, applyPostFaintAbAttrs, PostFaintAbAttr, IncreasePpAbAttr, PostStatChangeAbAttr, applyPostStatChangeAbAttrs, AlwaysHitAbAttr, PreventBerryUseAbAttr, StatChangeCopyAbAttr } from "./data/ability";
 import { Unlockables, getUnlockableName } from "./system/unlockables";
 import { getBiomeKey } from "./field/arena";
 import { BattleType, BattlerIndex, TurnCommand } from "./battle";
@@ -2210,8 +2210,11 @@ export class MovePhase extends BattlePhase {
     const moveTarget = this.targets.length === 1
       ? new Utils.IntegerHolder(this.targets[0])
       : null;
-    if (moveTarget) {
-      this.scene.getField(true).filter(p => p !== this.pokemon).forEach(p => applyAbAttrs(RedirectMoveAbAttr, p, null, this.move.moveId, moveTarget));
+      if (moveTarget) {
+          if (!(this.pokemon.hasAbilityWithAttr(BlockRedirectAbAttr) || this.move.getMove().getAttrs(BypassRedirectAttr).length) )
+          {
+            this.scene.getField(true).filter(p => p !== this.pokemon).forEach(p => applyAbAttrs(RedirectMoveAbAttr, p, null, this.move.moveId, moveTarget));
+          }
       this.targets[0] = moveTarget.value;
     }
 

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2213,7 +2213,7 @@ const moveTarget = this.targets.length === 1
  if (moveTarget) {
         var oldTarget = moveTarget.value;
         this.scene.getField(true).filter(p => p !== this.pokemon).forEach(p => applyAbAttrs(RedirectMoveAbAttr, p, null, this.move.moveId, moveTarget));
-  //Check if this move is immune to being redirected, and restore its target to the intended target if it is.
+	//Check if this move is immune to being redirected, and restore its target to the intended target if it is.
         if ((this.pokemon.hasAbilityWithAttr(BlockRedirectAbAttr) || this.move.getMove().getAttrs(BypassRedirectAttr).length)) {
          //If an ability prevented this move from being redirected, display its ability pop up.
          if ((this.pokemon.hasAbilityWithAttr(BlockRedirectAbAttr) && !this.move.getMove().getAttrs(BypassRedirectAttr).length) && oldTarget != moveTarget.value) {


### PR DESCRIPTION
This pull request adds the functionality of ignoring redirects to the move Snipe Shot, and the abilities Propeller Tail and Stalwart. Currently, the only things that can redirect a move, are the abilities Storm Drain and Lightning Rod. If more ways to do so get implemented in the future, these moves and abilities may need to be tweaked further.