### PR TITLE
Fix Water Compaction Triggering on Status Moves

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -3305,7 +3305,7 @@ export function initAbilities() {
     new Ability(Abilities.EMERGENCY_EXIT, 7)
       .unimplemented(),
     new Ability(Abilities.WATER_COMPACTION, 7)
-      .attr(PostDefendStatChangeAbAttr, (target, user, move) => move.type === Type.WATER, BattleStat.DEF, 2),
+      .attr(PostDefendStatChangeAbAttr, (target, user, move) => move.type === Type.WATER && move.category !== MoveCategory.STATUS, BattleStat.DEF, 2),
     new Ability(Abilities.MERCILESS, 7)
       .unimplemented(),
     new Ability(Abilities.SHIELDS_DOWN, 7)


### PR DESCRIPTION
Tested behavior in Showdown. Water Compaction is not intended to work on any water-type status moves (i.e. Soak, Life Dew, etc.)