### PR TITLE
Added local system save to reduce requests made

### DIFF
--- a/src/ui/menu-ui-handler.ts
+++ b/src/ui/menu-ui-handler.ts
@@ -310,6 +310,10 @@ export default class MenuUiHandler extends MessageUiHandler {
             error = true;
           break;
         case MenuOptions.LOG_OUT:
+          // Syncing system to the server before logout
+          // this way we can safely overwrite local save later
+          this.scene.gameData.saveSystem().then(() => console.log("System data synced."));
+
           success = true;
           const doLogout = () => {
             Utils.apiFetch('account/logout', true).then(res => {


### PR DESCRIPTION
Base implementation of what has been discussed in the [discord thead](https://discord.com/channels/1125469663833370665/1237843658628141256).  
TLDR: Make the system save less often to reduce the amount of requests to the server by saving the system data locally, and syncing with the server every 5 waves / on logout (no impact on session requests for now)

Currently, it's only the base implementation, **no encryption** is made to the local save, this needs to be tested more to identify edge cases before adding encryption on top, since encryption will need more code changes.
I don't think it should be merged to main right now, maybe in a separate branch so we can work on it more. (because right now no encryption = easily modifiable)

## What I have tested
✅ Normal game 
✅ Reload mid wave (= local data will be fetched)
✅ Reload after sync (= remote data will be fetched)
✅ Logout (= local data is synced)
✅ New login (=local data is overwrote with the new system data)
✅ Login on previous account (= remote data is synced)