### PR TITLE
Adds simulated tag support to all abilities

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -823,7 +823,7 @@ export default class BattleScene extends SceneBase {
 				else if (trainerConfigs[trainerType].hasDouble) {
 					const doubleChance = new Utils.IntegerHolder(newWaveIndex % 10 === 0 ? 32 : 8);
 					this.applyModifiers(DoubleBattleChanceBoosterModifier, true, doubleChance);
-					playerField.forEach(p => applyAbAttrs(DoubleBattleChanceAbAttr, p, null, doubleChance));
+					playerField.forEach(p => applyAbAttrs(DoubleBattleChanceAbAttr, p, null, false, doubleChance));
 					doubleTrainer = !Utils.randSeedInt(doubleChance.value);
 				}
 				newTrainer = trainerData !== undefined ? trainerData.toTrainer(this) : new Trainer(this, trainerType, doubleTrainer ? TrainerVariant.DOUBLE : Utils.randSeedInt(2) ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT);
@@ -835,7 +835,7 @@ export default class BattleScene extends SceneBase {
 			if (newBattleType === BattleType.WILD && !this.gameMode.isWaveFinal(newWaveIndex)) {
 				const doubleChance = new Utils.IntegerHolder(newWaveIndex % 10 === 0 ? 32 : 8);
 				this.applyModifiers(DoubleBattleChanceBoosterModifier, true, doubleChance);
-				playerField.forEach(p => applyAbAttrs(DoubleBattleChanceAbAttr, p, null, doubleChance));
+				playerField.forEach(p => applyAbAttrs(DoubleBattleChanceAbAttr, p, null, false, doubleChance));
 				newDouble = !Utils.randSeedInt(doubleChance.value);
 			} else if (newBattleType === BattleType.TRAINER)
 				newDouble = newTrainer.variant === TrainerVariant.DOUBLE;
@@ -1542,7 +1542,7 @@ export default class BattleScene extends SceneBase {
 
 	pushMovePhase(movePhase: MovePhase, priorityOverride?: integer): void {
 		const movePriority = new Utils.IntegerHolder(priorityOverride !== undefined ? priorityOverride : movePhase.move.getMove().priority);
-		applyAbAttrs(IncrementMovePriorityAbAttr, movePhase.pokemon, null, movePhase.move.getMove(), movePriority);
+		applyAbAttrs(IncrementMovePriorityAbAttr, movePhase.pokemon, null, false, movePhase.move.getMove(), movePriority);
 		const lowerPriorityPhase = this.phaseQueue.find(p => p instanceof MovePhase && p.move.getMove().priority < movePriority.value);
 		if (lowerPriorityPhase)
 			this.phaseQueue.splice(this.phaseQueue.indexOf(lowerPriorityPhase), 0, movePhase);

--- a/src/data/berry.ts
+++ b/src/data/berry.ts
@@ -68,25 +68,25 @@ export function getBerryPredicate(berryType: BerryType): BerryPredicate {
       return (pokemon: Pokemon) => {
         const threshold = new Utils.NumberHolder(0.25);
         const battleStat = (berryType - BerryType.LIECHI) as BattleStat;
-        applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, null, threshold);
+        applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, null, false, threshold);
         return pokemon.getHpRatio() < threshold.value && pokemon.summonData.battleStats[battleStat] < 6;
       };
     case BerryType.LANSAT:
       return (pokemon: Pokemon) => {
         const threshold = new Utils.NumberHolder(0.25);
-        applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, null, threshold);
+        applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, null, false, threshold);
         return pokemon.getHpRatio() < 0.25 && !pokemon.getTag(BattlerTagType.CRIT_BOOST);
       };
     case BerryType.STARF:
       return (pokemon: Pokemon) => {
         const threshold = new Utils.NumberHolder(0.25);
-        applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, null, threshold);
+        applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, null, false, threshold);
         return pokemon.getHpRatio() < 0.25;
       };
     case BerryType.LEPPA:
       return (pokemon: Pokemon) => {
         const threshold = new Utils.NumberHolder(0.25);
-        applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, null, threshold);
+        applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, null, false, threshold);
         return !!pokemon.getMoveset().find(m => !m.getPpRatio());
       };
   }
@@ -102,7 +102,7 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
         if (pokemon.battleData)
           pokemon.battleData.berriesEaten.push(berryType);
         const hpHealed = new Utils.NumberHolder(Math.floor(pokemon.getMaxHp() / 4));
-        applyAbAttrs(DoubleBerryEffectAbAttr, pokemon, null, hpHealed);
+        applyAbAttrs(DoubleBerryEffectAbAttr, pokemon, null, false, hpHealed);
         pokemon.scene.unshiftPhase(new PokemonHealPhase(pokemon.scene, pokemon.getBattlerIndex(),
           hpHealed.value, getPokemonMessage(pokemon, `'s ${getBerryName(berryType)}\nrestored its HP!`), true));
       };
@@ -128,7 +128,7 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
           pokemon.battleData.berriesEaten.push(berryType);
         const battleStat = (berryType - BerryType.LIECHI) as BattleStat;
         const statLevels = new Utils.NumberHolder(1);
-        applyAbAttrs(DoubleBerryEffectAbAttr, pokemon, null, statLevels);
+        applyAbAttrs(DoubleBerryEffectAbAttr, pokemon, null, false, statLevels);
         pokemon.scene.unshiftPhase(new StatChangePhase(pokemon.scene, pokemon.getBattlerIndex(), true, [ battleStat ], statLevels.value));
       };
     case BerryType.LANSAT:
@@ -142,7 +142,7 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
         if (pokemon.battleData)
           pokemon.battleData.berriesEaten.push(berryType);
         const statLevels = new Utils.NumberHolder(2);
-        applyAbAttrs(DoubleBerryEffectAbAttr, pokemon, null, statLevels);
+        applyAbAttrs(DoubleBerryEffectAbAttr, pokemon, null, false, statLevels);
         pokemon.scene.unshiftPhase(new StatChangePhase(pokemon.scene, pokemon.getBattlerIndex(), true, [ BattleStat.RAND ], statLevels.value));
       };
     case BerryType.LEPPA:

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -325,7 +325,7 @@ export default class Move implements Localizable {
       case MoveFlags.IGNORE_ABILITIES:
         if (user.hasAbilityWithAttr(MoveAbilityBypassAbAttr)) {
           const abilityEffectsIgnored = new Utils.BooleanHolder(false);
-          applyAbAttrs(MoveAbilityBypassAbAttr, user, abilityEffectsIgnored, this);
+          applyAbAttrs(MoveAbilityBypassAbAttr, user, abilityEffectsIgnored, false, this);
           if (abilityEffectsIgnored.value)
             return true;
         }
@@ -965,7 +965,7 @@ export class MultiHitAttr extends MoveAttr {
         {
           const rand = user.randSeedInt(16);
           const hitValue = new Utils.IntegerHolder(rand);
-          applyAbAttrs(MaxMultiHitAbAttr, user, null, hitValue);
+          applyAbAttrs(MaxMultiHitAbAttr, user, null, false, hitValue);
           if (hitValue.value >= 10)
             hitTimes = 2;
           else if (hitValue.value >= 4)
@@ -990,7 +990,7 @@ export class MultiHitAttr extends MoveAttr {
         {
           const rand = user.randSeedInt(90);
           const hitValue = new Utils.IntegerHolder(rand);
-          applyAbAttrs(MaxMultiHitAbAttr, user, null, hitValue);
+          applyAbAttrs(MaxMultiHitAbAttr, user, null, false, hitValue);
           if (hitValue.value >= 81)
             hitTimes = 1;
           else if (hitValue.value >= 73)

--- a/src/data/terrain.ts
+++ b/src/data/terrain.ts
@@ -54,7 +54,7 @@ export class Terrain {
       case TerrainType.PSYCHIC:
         if (!move.getAttrs(ProtectAttr).length) {
           const priority = new Utils.IntegerHolder(move.priority);
-          applyAbAttrs(IncrementMovePriorityAbAttr, user, null, move, priority);
+          applyAbAttrs(IncrementMovePriorityAbAttr, user, null, false, move, priority);
           return priority.value > 0 && user.getOpponents().filter(o => targets.includes(o.getBattlerIndex())).length > 0;
         }
     }

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -696,7 +696,7 @@ export class EncounterPhase extends BattlePhase {
           if (this.scene.currentBattle.battleSpec === BattleSpec.FINAL_BOSS)
             battle.enemyParty[e].ivs = new Array(6).fill(31);
           this.scene.getParty().slice(0, !battle.double ? 1 : 2).reverse().forEach(playerPokemon => {
-            applyAbAttrs(SyncEncounterNatureAbAttr, playerPokemon, null, battle.enemyParty[e]);
+            applyAbAttrs(SyncEncounterNatureAbAttr, playerPokemon, null, false, battle.enemyParty[e]);
           });
         }
       }
@@ -1967,8 +1967,8 @@ export class TurnStartPhase extends FieldPhase {
         const aPriority = new Utils.IntegerHolder(aMove.priority);
         const bPriority = new Utils.IntegerHolder(bMove.priority);
 
-		    applyAbAttrs(IncrementMovePriorityAbAttr, this.scene.getField().find(p => p?.isActive() && p.getBattlerIndex() === a), null, aMove, aPriority);
-        applyAbAttrs(IncrementMovePriorityAbAttr, this.scene.getField().find(p => p?.isActive() && p.getBattlerIndex() === b), null, bMove, bPriority);
+		    applyAbAttrs(IncrementMovePriorityAbAttr, this.scene.getField().find(p => p?.isActive() && p.getBattlerIndex() === a), null, false, aMove, aPriority);
+        applyAbAttrs(IncrementMovePriorityAbAttr, this.scene.getField().find(p => p?.isActive() && p.getBattlerIndex() === b), null, false, bMove, bPriority);
         
         if (aPriority.value !== bPriority.value)
           return aPriority.value < bPriority.value ? 1 : -1;
@@ -2211,7 +2211,7 @@ export class MovePhase extends BattlePhase {
       ? new Utils.IntegerHolder(this.targets[0])
       : null;
     if (moveTarget) {
-      this.scene.getField(true).filter(p => p !== this.pokemon).forEach(p => applyAbAttrs(RedirectMoveAbAttr, p, null, this.move.moveId, moveTarget));
+      this.scene.getField(true).filter(p => p !== this.pokemon).forEach(p => applyAbAttrs(RedirectMoveAbAttr, p, null, false, this.move.moveId, moveTarget));
       this.targets[0] = moveTarget.value;
     }
 
@@ -2566,8 +2566,8 @@ export class MoveEffectPhase extends PokemonPhase {
       
     const userAccuracyLevel = new Utils.IntegerHolder(user.summonData.battleStats[BattleStat.ACC]);
     const targetEvasionLevel = new Utils.IntegerHolder(target.summonData.battleStats[BattleStat.EVA]);
-    applyAbAttrs(IgnoreOpponentStatChangesAbAttr, target, null, userAccuracyLevel);
-    applyAbAttrs(IgnoreOpponentStatChangesAbAttr, user, null, targetEvasionLevel);
+    applyAbAttrs(IgnoreOpponentStatChangesAbAttr, target, null, false, userAccuracyLevel);
+    applyAbAttrs(IgnoreOpponentStatChangesAbAttr, user, null, false, targetEvasionLevel);
     applyMoveAttrs(IgnoreOpponentStatChangesAttr, user, target, this.move.getMove(), targetEvasionLevel);
     this.scene.applyModifiers(TempBattleStatBoosterModifier, this.player, TempBattleStat.ACC, userAccuracyLevel);
 
@@ -2580,7 +2580,7 @@ export class MoveEffectPhase extends PokemonPhase {
         : 3 / (3 + Math.min(targetEvasionLevel.value - userAccuracyLevel.value, 6));
     }
 
-    applyBattleStatMultiplierAbAttrs(BattleStatMultiplierAbAttr, user, BattleStat.ACC, accuracyMultiplier, this.move.getMove());
+    applyBattleStatMultiplierAbAttrs(BattleStatMultiplierAbAttr, user, BattleStat.ACC, accuracyMultiplier, false, this.move.getMove());
 
     const evasionMultiplier = new Utils.NumberHolder(1);
     applyBattleStatMultiplierAbAttrs(BattleStatMultiplierAbAttr, this.getTarget(), BattleStat.EVA, evasionMultiplier);
@@ -2730,7 +2730,7 @@ export class StatChangePhase extends PokemonPhase {
     const levels = new Utils.IntegerHolder(this.levels);
 
     if (!this.ignoreAbilities)
-      applyAbAttrs(StatChangeMultiplierAbAttr, pokemon, null, levels);
+      applyAbAttrs(StatChangeMultiplierAbAttr, pokemon, null, false, levels);
 
     const battleStats = this.getPokemon().summonData.battleStats;
     const relLevels = filteredStats.map(stat => (levels.value >= 1 ? Math.min(battleStats[stat] + levels.value, 6) : Math.max(battleStats[stat] + levels.value, -6)) - battleStats[stat]);
@@ -2747,7 +2747,7 @@ export class StatChangePhase extends PokemonPhase {
       
       if (levels.value > 0 && this.canBeCopied)
         for (let opponent of pokemon.getOpponents())
-          applyAbAttrs(StatChangeCopyAbAttr, opponent, null, this.stats, levels.value);
+          applyAbAttrs(StatChangeCopyAbAttr, opponent, null, false, this.stats, levels.value);
       
       applyPostStatChangeAbAttrs(PostStatChangeAbAttr, pokemon, filteredStats, this.levels, this.selfTarget);
       
@@ -4278,7 +4278,7 @@ export class AttemptRunPhase extends PokemonPhase {
     const enemySpeed = enemyField.reduce((total: integer, enemyPokemon: Pokemon) => total + enemyPokemon.getStat(Stat.SPD), 0) / enemyField.length;
 
     const escapeChance = new Utils.IntegerHolder((((playerPokemon.getStat(Stat.SPD) * 128) / enemySpeed) + (30 * this.scene.currentBattle.escapeAttempts++)) % 256);
-    applyAbAttrs(RunSuccessAbAttr, playerPokemon, null, escapeChance);
+    applyAbAttrs(RunSuccessAbAttr, playerPokemon, null, false, escapeChance);
 
     if (playerPokemon.randSeedInt(256) < escapeChance.value) {
       this.scene.playSound('flee');


### PR DESCRIPTION
This PR works to add support for simulated/quiet ability application to all abilities, not just presetstatus and predefend. This helps set up support for future developments of the AI be allowing them to simulate abilities being applied which isn't currently possible to do for most abilities. Particularly useful as setup for simulating damage rolls which should be invaluable for the AI and basically requires a change like this to perform safely.