### PR TITLE
Fix loading protosynthesis/quark drive boosts

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -985,7 +985,7 @@ export class HighestStatBoostTag extends AbilityBattlerTag {
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
     this.stat = source.stat as Stat;
-    this.multiplier = this.multiplier;
+    this.multiplier = source.multiplier;
   }
 
   onAdd(pokemon: Pokemon): void {


### PR DESCRIPTION
Weren't loading the multiplier causing weird behavior with them.