### PR TITLE
Fixed flying type being removed in type effectiveness calculation under gravity

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -772,12 +772,6 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       }
     }
 
-    if (forDefend && (this.getTag(BattlerTagType.IGNORE_FLYING) || this.scene.arena.getTag(ArenaTagType.GRAVITY) || this.getTag(BattlerTagType.GROUNDED))) {
-      const flyingIndex = types.indexOf(Type.FLYING);
-      if (flyingIndex > -1)
-        types.splice(flyingIndex, 1);
-    }
-
     if (!types.length) // become UNKNOWN if no types are present
       types.push(Type.UNKNOWN);
 
@@ -907,6 +901,12 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     if (moveType === Type.STELLAR)
       return this.isTerastallized() ? 2 : 1;
     const types = this.getTypes(true, true);
+
+    if (moveType === Type.GROUND && (this.getTag(BattlerTagType.IGNORE_FLYING) || this.scene.arena.getTag(ArenaTagType.GRAVITY) || this.getTag(BattlerTagType.GROUNDED))) {
+      const flyingIndex = types.indexOf(Type.FLYING);
+      if (flyingIndex > -1)
+        types.splice(flyingIndex, 1);
+    }
 
     const ignorableImmunities = source?.getAbility()?.getAttrs(IgnoreTypeImmunityAbAttr) || [];
     const cancelled = new Utils.BooleanHolder(false);


### PR DESCRIPTION
### Issue https://github.com/pagefaultgames/pokerogue/issues/524
When Gravity is in effect, moves that would usually be super effective / not very effective against Flying pokemon, are neutral.

--- 

### Testing the issue
--- 
**Under Gravity** 
**SUPER EFFECTIVE MOVES**
Dusclops ice punch into Pidgey     = Neutral Effective
Dusclops thunder punch into Pidgey = Neutral Effective
Dusclops rock slide into Pidgey    = Neutral Effective

**NOT VERY EFFECTIVE MOVES**
Dusclops bug bite into Pidgey      = Neutral Effective
Dusclops grass knot into Pidgey    = Neutral Effective
Dusclops low kick into Pidgey      = Super Effective

**NEUTRAL MOVES**
Dusclops earthquake into Pidgey    = Neutral Effective
Dusclops fire spin into Pidgey     = Neutral Effective

--- 

### Cause 
Flying type is removed from the damage calculation in Pokemon::getTypes() whenever gravity is in effect.
 
--- 
### Fix 
The only time Flying type should be removed from the calculation would be when a Ground move is being used. I moved the the Gravity check into Pokemon::getAttackTypeEffectiveness to have access to the attacking moves type. 

