### PR TITLE
Implement Tera Shell

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -27,7 +27,7 @@ import { TempBattleStat } from "../data/temp-battle-stat";
 import { ArenaTagSide, WeakenMoveScreenTag, WeakenMoveTypeTag } from "../data/arena-tag";
 import { ArenaTagType } from "../data/enums/arena-tag-type";
 import { Biome } from "../data/enums/biome";
-import { Ability, AbAttr, BattleStatMultiplierAbAttr, BlockCritAbAttr, BonusCritAbAttr, BypassBurnDamageReductionAbAttr, FieldPriorityMoveImmunityAbAttr, FieldVariableMovePowerAbAttr, IgnoreOpponentStatChangesAbAttr, MoveImmunityAbAttr, MoveTypeChangeAttr, PreApplyBattlerTagAbAttr, PreDefendFullHpEndureAbAttr, ReceivedMoveDamageMultiplierAbAttr, ReduceStatusEffectDurationAbAttr, StabBoostAbAttr, StatusEffectImmunityAbAttr, TypeImmunityAbAttr, VariableMovePowerAbAttr, VariableMoveTypeAbAttr, WeightMultiplierAbAttr, allAbilities, applyAbAttrs, applyBattleStatMultiplierAbAttrs, applyPreApplyBattlerTagAbAttrs, applyPreAttackAbAttrs, applyPreDefendAbAttrs, applyPreSetStatusAbAttrs, UnsuppressableAbilityAbAttr, SuppressFieldAbilitiesAbAttr, NoFusionAbilityAbAttr, MultCritAbAttr, IgnoreTypeImmunityAbAttr, DamageBoostAbAttr, IgnoreTypeStatusEffectImmunityAbAttr, ConditionalCritAbAttr } from "../data/ability";
+import { Ability, AbAttr, BattleStatMultiplierAbAttr, BlockCritAbAttr, BonusCritAbAttr, BypassBurnDamageReductionAbAttr, FieldPriorityMoveImmunityAbAttr, FieldVariableMovePowerAbAttr, IgnoreOpponentStatChangesAbAttr, MoveImmunityAbAttr, MoveTypeChangeAttr, PreApplyBattlerTagAbAttr, PreDefendFullHpEndureAbAttr, ReceivedMoveDamageMultiplierAbAttr, ReduceStatusEffectDurationAbAttr, StabBoostAbAttr, StatusEffectImmunityAbAttr, TypeImmunityAbAttr, VariableMovePowerAbAttr, VariableMoveTypeAbAttr, WeightMultiplierAbAttr, allAbilities, applyAbAttrs, applyBattleStatMultiplierAbAttrs, applyPreApplyBattlerTagAbAttrs, applyPreAttackAbAttrs, applyPreDefendAbAttrs, applyPreSetStatusAbAttrs, UnsuppressableAbilityAbAttr, SuppressFieldAbilitiesAbAttr, NoFusionAbilityAbAttr, MultCritAbAttr, IgnoreTypeImmunityAbAttr, DamageBoostAbAttr, IgnoreTypeStatusEffectImmunityAbAttr, ConditionalCritAbAttr, ReceivedMoveEffectivenessAbAttr } from "../data/ability";
 import { Abilities } from "#app/data/enums/abilities";
 import PokemonData from "../system/pokemon-data";
 import { BattlerIndex } from "../battle";
@@ -1675,6 +1675,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       if (cancelled.value) {
         result = HitResult.NO_EFFECT;
       } else {
+        applyPreDefendAbAttrs(ReceivedMoveEffectivenessAbAttr, this, source, battlerMove, null, typeMultiplier);
         const typeBoost = source.findTag(t => t instanceof TypeBoostTag && (t as TypeBoostTag).boostedType === type) as TypeBoostTag;
         if (typeBoost) {
           power.value *= typeBoost.boostValue;
@@ -3738,6 +3739,7 @@ export class PokemonTurnData {
   public currDamageDealt: integer = 0;
   public damageTaken: integer = 0;
   public attacksReceived: AttackMoveResult[] = [];
+  public hpPreDefend: number;
 }
 
 export enum AiType {

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2710,6 +2710,11 @@ export class MoveEffectPhase extends PokemonPhase {
           this.scene.applyModifiers(PokemonMultiHitModifier, user.isPlayer(), user, hitCount, new Utils.IntegerHolder(0));
         }
         user.turnData.hitsLeft = user.turnData.hitCount = hitCount.value;
+
+        // Store the hp of the targets before any hits of the attack
+        targets.map((t) => {
+          t.turnData.hpPreDefend = t.hp;
+        });
       }
 
       const moveHistoryEntry = { move: this.move.moveId, targets: this.targets, result: MoveResult.PENDING, virtual: this.move.virtual };


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Implemented the ability [Tera Shell](https://www.smogon.com/dex/sv/abilities/tera-shell/), that makes any attacks received while at full HP not very effective (including all hits of multi hit moves).

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
The ability was still not implemented, and I believe I have found a good way to do so.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- A new ability attribute `ReceivedMoveEffectivenessAbAttr` has been created, that can be used by abilities to override the effectiveness of upcoming attacks based on a condition. This attribute should never be used to force an effectiveness of 0, as there's other attributes for immunities, and this attribute is checked after immunties are. This, together with a check to make sure that the upcoming effectiveness isn't already the same as the forced one, ensures that the ability doesn't show in the screen even if it didn't change anything.
- Added documentation for said attribute, warning about the situation mentioned above, and suggesting to use `MoveImmunityAbAttr` instead
- The ability Tera Shell has been implemented using this new attribute, with 0.5 as the forced effectivenes (not very effective) and the condition that the target was full HP at the start of the attack, before all hits from multi-hit moves. `.attr(ReceivedMoveEffectivenessAbAttr, (target, user, move) => target.turnData.hpPreDefend >= target.getMaxHp(), 0.5)`
- A numerical attribute `hpPreDefend` has been created in the `PokemonTurnData` that stores the hp of the Pokémon, but the value is only updated before any hits of an attack. This allows moves to check the hp of the target during multi-hit moves, and potentially obtain other stats such as total damage dealt by a multi-hit attack.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
The next video showcases how the ability works as expected with multi-hit moves (first attack), is indeed applied after all other type effectiveness modifiers such as Freeze Dry (second attack), and the effectiveness modifier is applied correctly (damage of first attack is roughly 8 times lower than the third one, as expected):


https://github.com/pagefaultgames/pokerogue/assets/22176793/e48e0a2f-7e4c-44de-a0c0-9165eac9f893


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
I used the overrides.ts to test interactions such as the ones shown in the video above.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?