### PR TITLE
Bouncy bubble description update + DeepL translations

### DIFF
--- a/src/locales/de/move.ts
+++ b/src/locales/de/move.ts
@@ -2931,7 +2931,7 @@ export const move: MoveTranslationEntries = {
   },
   "bouncyBubble": {
     name: "Blubbsauger",
-    effect: "Evoli greift mit Wasserblasen an. Evolis KP werden um die Hälfte des vom Wasser angerichteten Schadens geheilt."
+    effect: "Der Anwender greift an, indem er Wasserblasen auf sein Ziel schießt. Er absorbiert dann Wasser und stellt seine HP um 100% des vom Ziel erlittenen Schadens wieder her."
   },
   "buzzyBuzz": {
     name: "Knisterladung",

--- a/src/locales/de/move.ts
+++ b/src/locales/de/move.ts
@@ -2931,7 +2931,7 @@ export const move: MoveTranslationEntries = {
   },
   "bouncyBubble": {
     name: "Blubbsauger",
-    effect: "Der Anwender greift an, indem er Wasserblasen auf sein Ziel schießt. Er absorbiert dann Wasser und stellt seine HP um 100% des vom Ziel erlittenen Schadens wieder her."
+    effect: "Der Anwender greift mit Wasserblasen an. Seine KP werden in Höhe des vom Wasser angerichteten Schadens geheilt."
   },
   "buzzyBuzz": {
     name: "Knisterladung",

--- a/src/locales/en/move.ts
+++ b/src/locales/en/move.ts
@@ -2931,7 +2931,7 @@ export const move: MoveTranslationEntries = {
   },
   "bouncyBubble": {
     name: "Bouncy Bubble",
-    effect: "The user attacks by shooting water bubbles at the target. It then absorbs water and restores its HP by half the damage taken by the target."
+    effect: "The user attacks by shooting water bubbles at the target. It then absorbs water and restores its HP by 100% of the damage taken by the target."
   },
   "buzzyBuzz": {
     name: "Buzzy Buzz",

--- a/src/locales/es/move.ts
+++ b/src/locales/es/move.ts
@@ -2931,7 +2931,7 @@ export const move: MoveTranslationEntries = {
   },
   bouncyBubble: {
     name: "Vapodrenaje",
-    effect: "Ataca lanzando proyectiles de agua y recupera una cantidad de PS equivalente a la mitad del daño causado.",
+    effect: "El usuario ataca disparando burbujas de agua al objetivo. A continuación, absorbe agua y restaura sus PS en un 100% del daño recibido por el objetivo.",
   },
   buzzyBuzz: {
     name: "Joltioparálisis",

--- a/src/locales/fr/move.ts
+++ b/src/locales/fr/move.ts
@@ -2931,7 +2931,7 @@ export const move: MoveTranslationEntries = {
   },
   "bouncyBubble": {
     name: "Évo-Thalasso",
-    effect: "Évoli frappe l’adversaire avec des bulles d’eau qu’il absorbe ensuite pour récupérer un nombre de PV égal à la moitié des dégâts infligés à l’ennemi."
+    effect: "L'utilisateur attaque en projetant des bulles d'eau sur la cible. Il absorbe alors l'eau et restaure ses PV à hauteur de 100% des dégâts subis par la cible."
   },
   "buzzyBuzz": {
     name: "Évo-Dynamo",

--- a/src/locales/it/move.ts
+++ b/src/locales/it/move.ts
@@ -2931,7 +2931,7 @@ export const move: MoveTranslationEntries = {
   },
   bouncyBubble: {
     name: "Bollaslurp",
-    effect: "Chi la usa colpisce il bersaglio con una raffica di bolle, per poi assorbirle e recuperare una quantità di PS pari alla metà del danno inferto.",
+    effect: "L'utente attacca sparando bolle d'acqua contro il bersaglio. Assorbe quindi l'acqua e ripristina i suoi HP del 100% dei danni subiti dal bersaglio.",
   },
   buzzyBuzz: {
     name: "Elettrozap",

--- a/src/locales/zh_CN/move.ts
+++ b/src/locales/zh_CN/move.ts
@@ -2931,7 +2931,7 @@ export const move: MoveTranslationEntries = {
   },
   "bouncyBubble": {
     name: "活活气泡",
-    effect: "投掷水球进行攻击。吸水后能回复等同于造成的伤害一半的HP。"
+    effect: "使用者向目标发射水泡进行攻击。然后它就会吸收水分，并恢复其 HP，恢复量为目标所受伤害的 100%。"
   },
   "buzzyBuzz": {
     name: "麻麻电击",


### PR DESCRIPTION
Updated Bouncy Bubble description (and added DeepL translations) to reflect the move changes.
~~50%~~ -> **100%**

@Flashfyre Closed the previous PR as it accidentally took commits from others into it.
DeepL used the en version as the base description. Might need it to be looked over by the translators. 
 