### PR TITLE
Add Nuzlocke Mode's rich presence support to live

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -53,7 +53,7 @@ import PokemonSpriteSparkleHandler from './field/pokemon-sprite-sparkle-handler'
 import CharSprite from './ui/char-sprite';
 import DamageNumberHandler from './field/damage-number-handler';
 import PokemonInfoContainer from './ui/pokemon-info-container';
-import { biomeDepths } from './data/biomes';
+import { biomeDepths, getBiomeName } from './data/biomes';
 import { UiTheme } from './enums/ui-theme';
 import { SceneBase } from './scene-base';
 import CandyBar from './ui/candy-bar';
@@ -188,6 +188,7 @@ export default class BattleScene extends SceneBase {
 		this.phaseQueuePrepend = [];
 		this.phaseQueuePrependSpliceIndex = -1;
 		this.nextCommandPhaseQueue = [];
+		this.updateGameInfo();
 	}
 
 	loadPokemonAtlas(key: string, atlasPath: string, experimental?: boolean) {
@@ -757,6 +758,8 @@ export default class BattleScene extends SceneBase {
 		this.trainer.setTexture(`trainer_${this.gameData.gender === PlayerGender.FEMALE ? 'f' : 'm'}_back`);
 		this.trainer.setPosition(406, 186);
 		this.trainer.setVisible(true);
+		
+		this.updateGameInfo();
 
 		if (reloadI18n) {
 			const localizable: Localizable[] = [
@@ -1950,5 +1953,17 @@ export default class BattleScene extends SceneBase {
 		}
 
 		return false;
+	}
+	
+	updateGameInfo(): void {
+		const gameInfo = {
+			gameMode: this.currentBattle ? this.gameMode.getName() : 'Title',
+			biome: this.currentBattle ? getBiomeName(this.arena.biomeType) : '',
+			wave: this.currentBattle?.waveIndex || 0,
+			party: this.party ? this.party.map(p => {
+				return { name: p.name, level: p.level };
+			}) : []
+		};
+		(window as any).gameInfo = gameInfo;
 	}
 }

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -680,6 +680,8 @@ export class EncounterPhase extends BattlePhase {
   start() {
     super.start();
 
+    this.scene.updateGameInfo();
+
     this.scene.initSession();
 
     const loadEnemyAssets = [];


### PR DESCRIPTION
Sam accidentally added the rich presence support into his main Nuzlocke mode commit so it couldn't easily be cherry-picked over to the main branch. This PR is just those changes and nothing more.

Presumably merging this would mean having to go delete those changes from the Nuzlocke branch, so if this too troublesome or something feel free to close the request; it might be useful for Sam anyways seeing everywhere the code is used.

![image](https://github.com/pagefaultgames/pokerogue/assets/72857839/1753a5e8-2d3f-4915-83b3-58031d4800d9)
