### PR TITLE
Adds 'accuracy' to the move information in the fight ui

### DIFF
--- a/src/locales/de/fight-ui-handler.ts
+++ b/src/locales/de/fight-ui-handler.ts
@@ -2,5 +2,6 @@ import { SimpleTranslationEntries } from "#app/plugins/i18n";
 
 export const fightUiHandler: SimpleTranslationEntries = {
     "pp": "PP",
-    "power": "POWER",
+    "power": "Power",
+    "accuracy": "Accuracy",
 } as const;

--- a/src/locales/en/fight-ui-handler.ts
+++ b/src/locales/en/fight-ui-handler.ts
@@ -2,5 +2,6 @@ import { SimpleTranslationEntries } from "#app/plugins/i18n";
 
 export const fightUiHandler: SimpleTranslationEntries = {
     "pp": "PP",
-    "power": "POWER",
+    "power": "Power",
+    "accuracy": "Accuracy",
 } as const;

--- a/src/locales/es/fight-ui-handler.ts
+++ b/src/locales/es/fight-ui-handler.ts
@@ -2,5 +2,6 @@ import { SimpleTranslationEntries } from "#app/plugins/i18n";
 
 export const fightUiHandler: SimpleTranslationEntries = {
     "pp": "PP",
-    "power": "POTENCIA",
+    "power": "Power",
+    "accuracy": "Accuracy",
 } as const;

--- a/src/locales/fr/fight-ui-handler.ts
+++ b/src/locales/fr/fight-ui-handler.ts
@@ -2,5 +2,6 @@ import { SimpleTranslationEntries } from "#app/plugins/i18n";
 
 export const fightUiHandler: SimpleTranslationEntries = {
     "pp": "PP",
-    "power": "PUISSANCE",
+    "power": "Puissance",
+    "accuracy": "Précision",
 } as const;

--- a/src/locales/it/fight-ui-handler.ts
+++ b/src/locales/it/fight-ui-handler.ts
@@ -2,5 +2,6 @@ import { SimpleTranslationEntries } from "#app/plugins/i18n";
 
 export const fightUiHandler: SimpleTranslationEntries = {
     "pp": "PP",
-    "power": "POTENZA",
+    "power": "Power",
+    "accuracy": "Accuracy",
 } as const;

--- a/src/locales/zh_CN/fight-ui-handler.ts
+++ b/src/locales/zh_CN/fight-ui-handler.ts
@@ -2,5 +2,6 @@ import { SimpleTranslationEntries } from "#app/plugins/i18n";
 
 export const fightUiHandler: SimpleTranslationEntries = {
     "pp": "PP",
-    "power": "POWER",
+    "power": "Power",
+    "accuracy": "Accuracy",
 } as const;

--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -17,6 +17,8 @@ export default class FightUiHandler extends UiHandler {
   private ppText: Phaser.GameObjects.Text;
   private powerLabel: Phaser.GameObjects.Text;
   private powerText: Phaser.GameObjects.Text;
+  private accuracyLabel: Phaser.GameObjects.Text;
+  private accuracyText: Phaser.GameObjects.Text;
   private cursorObj: Phaser.GameObjects.Image;
   private moveCategoryIcon: Phaser.GameObjects.Sprite;
 
@@ -33,35 +35,46 @@ export default class FightUiHandler extends UiHandler {
     this.movesContainer = this.scene.add.container(18, -38.7);
     ui.add(this.movesContainer);
 
-    this.typeIcon = this.scene.add.sprite((this.scene.game.canvas.width / 6) - 57, -34, 'types', 'unknown');
+    this.typeIcon = this.scene.add.sprite((this.scene.game.canvas.width / 6) - 57, -36, 'types', 'unknown');
     this.typeIcon.setVisible(false);
     ui.add(this.typeIcon);
 
-    this.moveCategoryIcon = this.scene.add.sprite((this.scene.game.canvas.width / 6) - 25, -34, 'categories', 'physical');
+    this.moveCategoryIcon = this.scene.add.sprite((this.scene.game.canvas.width / 6) - 25, -36, 'categories', 'physical');
     this.moveCategoryIcon.setVisible(false);
     ui.add(this.moveCategoryIcon);
 
-    this.ppLabel = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 70, -22, 'PP', TextStyle.TOOLTIP_CONTENT);
+    this.ppLabel = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 70, -26, 'PP', TextStyle.MOVE_INFO_CONTENT);
     this.ppLabel.setOrigin(0.0, 0.5);
     this.ppLabel.setVisible(false);
     this.ppLabel.setText(i18next.t('fightUiHandler:pp'));
     ui.add(this.ppLabel);
 
-    this.ppText = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 12, -22, '--/--', TextStyle.TOOLTIP_CONTENT);
+    this.ppText = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 12, -26, '--/--', TextStyle.MOVE_INFO_CONTENT);
     this.ppText.setOrigin(1, 0.5);
     this.ppText.setVisible(false);
     ui.add(this.ppText);
 
-    this.powerLabel = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 70, -12, 'POWER', TextStyle.TOOLTIP_CONTENT);
+    this.powerLabel = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 70, -18, 'POWER', TextStyle.MOVE_INFO_CONTENT);
     this.powerLabel.setOrigin(0.0, 0.5);
     this.powerLabel.setVisible(false);
     this.powerLabel.setText(i18next.t('fightUiHandler:power'));
     ui.add(this.powerLabel);
 
-    this.powerText = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 12, -12, '---', TextStyle.TOOLTIP_CONTENT);
+    this.powerText = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 12, -18, '---', TextStyle.MOVE_INFO_CONTENT);
     this.powerText.setOrigin(1, 0.5);
     this.powerText.setVisible(false);
     ui.add(this.powerText);
+
+    this.accuracyLabel = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 70, -10, 'ACC', TextStyle.MOVE_INFO_CONTENT);
+    this.accuracyLabel.setOrigin(0.0, 0.5);
+    this.accuracyLabel.setVisible(false);
+    this.accuracyLabel.setText(i18next.t('fightUiHandler:accuracy'))
+    ui.add(this.accuracyLabel);
+
+    this.accuracyText = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 12, -10, '---', TextStyle.MOVE_INFO_CONTENT);
+    this.accuracyText.setOrigin(1, 0.5);
+    this.accuracyText.setVisible(false);
+    ui.add(this.accuracyText);
   }
 
   show(args: any[]): boolean {
@@ -152,11 +165,13 @@ export default class FightUiHandler extends UiHandler {
       this.moveCategoryIcon.setTexture('categories', MoveCategory[pokemonMove.getMove().category].toLowerCase()).setScale(1.0);
 
       const power = pokemonMove.getMove().power;
+      const accuracy = pokemonMove.getMove().accuracy;
       const maxPP = pokemonMove.getMovePp();
       const pp = maxPP - pokemonMove.ppUsed;
 
       this.ppText.setText(`${Utils.padInt(pp, 2, '  ')}/${Utils.padInt(maxPP, 2, '  ')}`);
       this.powerText.setText(`${power >= 0 ? power : '---'}`);
+      this.accuracyText.setText(`${accuracy >= 0 ? accuracy : '---'}`);
     }
 
     this.typeIcon.setVisible(hasMove);
@@ -164,6 +179,8 @@ export default class FightUiHandler extends UiHandler {
     this.ppText.setVisible(hasMove);
     this.powerLabel.setVisible(hasMove);
     this.powerText.setVisible(hasMove);
+    this.accuracyLabel.setVisible(hasMove);
+    this.accuracyText.setVisible(hasMove);
     this.moveCategoryIcon.setVisible(hasMove);
 
     this.cursorObj.setPosition(13 + (cursor % 2 === 1 ? 100 : 0), -31 + (cursor >= 2 ? 15 : 0));
@@ -189,6 +206,8 @@ export default class FightUiHandler extends UiHandler {
     this.ppText.setVisible(false);
     this.powerLabel.setVisible(false);
     this.powerText.setVisible(false);
+    this.accuracyLabel.setVisible(false);
+    this.accuracyText.setVisible(false);
     this.moveCategoryIcon.setVisible(false);
     this.eraseCursor();
   }

--- a/src/ui/text.ts
+++ b/src/ui/text.ts
@@ -24,7 +24,8 @@ export enum TextStyle {
   SETTINGS_LABEL,
   SETTINGS_SELECTED,
   TOOLTIP_TITLE,
-  TOOLTIP_CONTENT
+  TOOLTIP_CONTENT,
+  MOVE_INFO_CONTENT
 };
 
 export function addTextObject(scene: Phaser.Scene, x: number, y: number, content: string, style: TextStyle, extraStyleOptions?: Phaser.Types.GameObjects.Text.TextStyle): Phaser.GameObjects.Text {
@@ -106,6 +107,10 @@ function getTextStyleOptions(style: TextStyle, uiTheme: UiTheme, extraStyleOptio
       styleOptions.fontSize = '64px';
       shadowSize = 4;
       break;
+    case TextStyle.MOVE_INFO_CONTENT:
+      styleOptions.fontSize = '56px';
+      shadowSize = 3;
+      break;
   }
 
   shadowColor = getTextColor(style, true, uiTheme);
@@ -130,6 +135,7 @@ export function getTextColor(textStyle: TextStyle, shadow?: boolean, uiTheme: Ui
     case TextStyle.MESSAGE:
       return !shadow ? '#f8f8f8' : '#6b5a73';
     case TextStyle.WINDOW:
+      case TextStyle.MOVE_INFO_CONTENT:
     case TextStyle.TOOLTIP_CONTENT:
       if (uiTheme)
         return !shadow ? '#484848' : '#d0d0c8';


### PR DESCRIPTION
## Changes
- Adds `accuracy` to the move information in the fight ui
> In a safer way for translations, compared to what was proposed in #702
![image](https://github.com/pagefaultgames/pokerogue/assets/8146474/afb96833-1397-416e-88e5-a34858572569)
- Add new locales field `accuracy` in fight-ui-handler with default english value for translation
- Capitalize `accuracy` & `power` fields