### PR TITLE
Bugfix: Tidy Up removes hazards from both sides now

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6709,8 +6709,9 @@ export function initMoves() {
       .attr(ForceSwitchOutAttr, true, false)
       .target(MoveTarget.BOTH_SIDES),
     new SelfStatusMove(Moves.TIDY_UP, Type.NORMAL, -1, 10, 100, 0, 9)
-      .attr(StatChangeAttr, [ BattleStat.ATK, BattleStat.SPD ], 1, true)
-      .attr(RemoveArenaTrapAttr),
+      .attr(StatChangeAttr, [ BattleStat.ATK, BattleStat.SPD ], 1, true, null, true, true)
+      .attr(RemoveArenaTrapAttr)
+      .target(MoveTarget.BOTH_SIDES),
     new StatusMove(Moves.SNOWSCAPE, Type.ICE, -1, 10, -1, 0, 9)
       .attr(WeatherChangeAttr, WeatherType.SNOW)
       .target(MoveTarget.BOTH_SIDES),


### PR DESCRIPTION
Based on #705 , Tidy Up was only cleaning up hazards on opponents side of the field. This change makes it so hazards are removed on both sides of the field now.

https://github.com/pagefaultgames/pokerogue/assets/85713900/bff81162-40c6-41b2-945a-2fea5e0188d3