### PR TITLE
[FIX] Give functionality to the RETURN TO TITLE button before a new run

### DIFF
--- a/src/ui/menu-ui-handler.ts
+++ b/src/ui/menu-ui-handler.ts
@@ -298,6 +298,11 @@ export default class MenuUiHandler extends MessageUiHandler {
           success = true;
           break;
         case MenuOptions.RETURN_TO_TITLE:
+          if (this.scene.getParty().length === 0) {
+            success = true;
+            this.scene.reset(true);
+          }
+
           if (this.scene.currentBattle) {
             success = true;
             ui.showText(i18next.t("menuUiHandler:losingProgressionWarning"), null, () => {


### PR DESCRIPTION
This pr is to bring functionality to the Return to Title menu button before starting a new run. (Such as the Starter Select Screen)

Steps to reproduce the bug: 
1. Launch the game. 
2. Select the New Game button. 
3. Press Esc to enter the Menu. 
4. Navigate to the Return to Title button. 
5. Select the button. 
6. Observe the screen. 

Result: 
The user remains at the Starter Select screen. 

Expected Results: 
I expected to be taken back to the Title Menu. 

<img width="1012" alt="return_to_tilte_button_issue" src="https://github.com/pagefaultgames/pokerogue/assets/7002124/f1b98c2c-c48d-466b-9f48-f4d0d3946df3">
