### PR TITLE
Bugfix - Ghost types are no longer trapped by abilities like Shadow Tag or moves like Fire Spin

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2259,13 +2259,17 @@ export class CheckTrappedAbAttr extends AbAttr {
     super(false);
   }
   
-  applyCheckTrapped(pokemon: Pokemon, passive: boolean, trapped: Utils.BooleanHolder, args: any[]): boolean | Promise<boolean> {
+  applyCheckTrapped(pokemon: Pokemon, passive: boolean, trapped: Utils.BooleanHolder, otherPokemon: Pokemon[], args: any[]): boolean | Promise<boolean> {
     return false;
   }
 }
 
 export class ArenaTrapAbAttr extends CheckTrappedAbAttr {
-  applyCheckTrapped(pokemon: Pokemon, passive: boolean, trapped: Utils.BooleanHolder, args: any[]): boolean {
+  applyCheckTrapped(pokemon: Pokemon, passive: boolean, trapped: Utils.BooleanHolder, otherPokemon: Pokemon[], args: any[]): boolean {
+    if (otherPokemon[0].getTypes().includes(Type.GHOST)){
+      trapped.value = false;
+      return false;
+    }
     trapped.value = true;
     return true;
   }

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2263,20 +2263,11 @@ export class CheckTrappedAbAttr extends AbAttr {
   constructor() {
     super(false);
   }
-  /**
-   * Checks if enemy Pokemon is trapped by an Arena Trap-esque ability
-   * @param pokemon N/A
-   * @param passive N/A
-   * @param trapped N/A
-   * @param otherPokemon N/A
-   * @param args N/A
-   * @returns if enemy Pokemon is trapped or not
-   */
+
   applyCheckTrapped(pokemon: Pokemon, passive: boolean, trapped: Utils.BooleanHolder, otherPokemon: Pokemon, args: any[]): boolean | Promise<boolean> {
     return false;
   }
 }
-
 
 /**
  * Determines whether a Pokemon is blocked from switching/running away

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2254,19 +2254,48 @@ export class RunSuccessAbAttr extends AbAttr {
   }
 }
 
+/**
+ * Base class for checking if a Pokemon is trapped by arena trap
+ * @extends AbAttr
+ * @see {@linkcode applyCheckTrapped}
+ */
 export class CheckTrappedAbAttr extends AbAttr {
   constructor() {
     super(false);
   }
-  
-  applyCheckTrapped(pokemon: Pokemon, passive: boolean, trapped: Utils.BooleanHolder, otherPokemon: Pokemon[], args: any[]): boolean | Promise<boolean> {
+  /**
+   * Checks if enemy Pokemon is trapped by an Arena Trap-esque ability
+   * @param pokemon N/A
+   * @param passive N/A
+   * @param trapped N/A
+   * @param otherPokemon N/A
+   * @param args N/A
+   * @returns if enemy Pokemon is trapped or not
+   */
+  applyCheckTrapped(pokemon: Pokemon, passive: boolean, trapped: Utils.BooleanHolder, otherPokemon: Pokemon, args: any[]): boolean | Promise<boolean> {
     return false;
   }
 }
 
+
+/**
+ * Determines whether a Pokemon is blocked from switching/running away
+ * because of a trapping ability or move.
+ * @extends CheckTrappedAbAttr
+ * @see {@linkcode applyCheckTrapped}
+ */
 export class ArenaTrapAbAttr extends CheckTrappedAbAttr {
-  applyCheckTrapped(pokemon: Pokemon, passive: boolean, trapped: Utils.BooleanHolder, otherPokemon: Pokemon[], args: any[]): boolean {
-    if (otherPokemon[0].getTypes().includes(Type.GHOST)){
+  /**
+   * Checks if enemy Pokemon is trapped by an Arena Trap-esque ability
+   * @param pokemon The {@link Pokemon} with this {@link AbAttr}
+   * @param passive N/A
+   * @param trapped {@link Utils.BooleanHolder} indicating whether the other Pokemon is trapped or not
+   * @param otherPokemon The {@link Pokemon} that is affected by an Arena Trap ability
+   * @param args N/A
+   * @returns if enemy Pokemon is trapped or not
+   */
+  applyCheckTrapped(pokemon: Pokemon, passive: boolean, trapped: Utils.BooleanHolder, otherPokemon: Pokemon, args: any[]): boolean {
+    if (otherPokemon.getTypes().includes(Type.GHOST)){
       trapped.value = false;
       return false;
     }
@@ -2735,8 +2764,8 @@ export function applyPostTerrainChangeAbAttrs(attrType: { new(...args: any[]): P
 }
 
 export function applyCheckTrappedAbAttrs(attrType: { new(...args: any[]): CheckTrappedAbAttr },
-  pokemon: Pokemon, trapped: Utils.BooleanHolder, ...args: any[]): Promise<void> {
-  return applyAbAttrsInternal<CheckTrappedAbAttr>(attrType, pokemon, (attr, passive) => attr.applyCheckTrapped(pokemon, passive, trapped, args), args, true);
+  pokemon: Pokemon, trapped: Utils.BooleanHolder, otherPokemon: Pokemon, ...args: any[]): Promise<void> {
+  return applyAbAttrsInternal<CheckTrappedAbAttr>(attrType, pokemon, (attr, passive) => attr.applyCheckTrapped(pokemon, passive, trapped, otherPokemon, args), args, true);
 }
 
 export function applyPostBattleAbAttrs(attrType: { new(...args: any[]): PostBattleAbAttr },

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1783,7 +1783,7 @@ export class CommandPhase extends FieldPhase {
           const trapped = new Utils.BooleanHolder(false);
           const batonPass = isSwitch && args[0] as boolean;
           if (!batonPass)
-            enemyField.forEach(enemyPokemon => applyCheckTrappedAbAttrs(CheckTrappedAbAttr, enemyPokemon, trapped));
+            enemyField.forEach(enemyPokemon => applyCheckTrappedAbAttrs(CheckTrappedAbAttr, enemyPokemon, trapped, playerPokemon));
           if (batonPass || (!trapTag && !trapped.value)) {
             this.scene.currentBattle.turnCommands[this.fieldIndex] = isSwitch
               ? { command: Command.POKEMON, cursor: cursor, args: args }
@@ -1881,7 +1881,7 @@ export class EnemyCommandPhase extends FieldPhase {
 
       const trapTag = enemyPokemon.findTag(t => t instanceof TrappedTag) as TrappedTag;
       const trapped = new Utils.BooleanHolder(false);
-      opponents.forEach(playerPokemon => applyCheckTrappedAbAttrs(CheckTrappedAbAttr, playerPokemon, trapped));
+      opponents.forEach(playerPokemon => applyCheckTrappedAbAttrs(CheckTrappedAbAttr, playerPokemon, trapped, enemyPokemon));
       if (!trapTag && !trapped.value) {
         const partyMemberScores = trainer.getPartyMemberMatchupScores(enemyPokemon.trainerSlot, true);
 


### PR DESCRIPTION
@Piefrenzy in Discord

Originally reported in Discord Bug Reports channel, Ghost type Pokemon were being trapped by Shadow Tag as well as moves like Fire Spin/Whirlpool/etc. despite documentation saying [trapping abilities](https://bulbapedia.bulbagarden.net/wiki/Ghost_(type)#Interacting_with_the_Ghost_type) shouldn't work and [trapping moves](https://bulbapedia.bulbagarden.net/wiki/Fire_Spin_(move)#Generation_VI_onwards) shouldn't work.

The function didn't even take in the Pokemon trying to switch/run in the first place, so it now gets passed in and checked to see if it's a Ghost type.

Here is a Ghost type swapping through Shadow Tag and a non-Ghost type getting stuck:

https://github.com/pagefaultgames/pokerogue/assets/85713900/d017534b-fd46-45f5-ae0c-d3d5ca22e414

Ghost type successfully swapping through Fire Spin and a non-Ghost type getting stuck:

https://github.com/pagefaultgames/pokerogue/assets/85713900/5897b8d0-a9af-4a85-9270-4e6d3de6794a

Working on right side:

https://github.com/pagefaultgames/pokerogue/assets/85713900/2f39ad3a-4c85-4e6b-9d2d-32f2af60c0de