### PR TITLE
Lowers xp curve for fluctuating slightly

### DIFF
--- a/src/data/exp.ts
+++ b/src/data/exp.ts
@@ -43,7 +43,7 @@ export function getLevelTotalExp(level: integer, growthRate: GrowthRate): intege
       ret = Math.pow(level, 3) * 5 / 4;
       break;
     case GrowthRate.FLUCTUATING:
-      ret = (Math.pow(level, 3) * ((level / 2) + 32)) * 4 / (100 + level);
+      ret = (Math.pow(level, 3) * ((level / 2) + 8)) * 4 / (100 + level);
       break;
   }
 


### PR DESCRIPTION
People were complaining the new formula where it actually has its own curve was too high. You'd need about 25% more exp than medium-fast by level 200. This lowers that to about 14%.