### PR TITLE
Add capability to view Pokemon Status screen when learning moves

### DIFF
--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -464,20 +464,16 @@ export default class SummaryUiHandler extends UiHandler {
             }
             break;
           case Button.LEFT:
-            if (this.summaryUiMode === SummaryUiMode.LEARN_MOVE)
-              break;
             if (this.cursor)
               success = this.setCursor(this.cursor - 1);
             break;
           case Button.RIGHT:
-            if (this.summaryUiMode === SummaryUiMode.LEARN_MOVE) {
-              this.setCursor(Page.MOVES); 
-              this.moveSelect = true;
-              success = true;
-              break;
-            }
-            if (this.cursor < pages.length - 1)
+            if (this.cursor < pages.length - 1) {
               success = this.setCursor(this.cursor + 1);
+              if (this.summaryUiMode === SummaryUiMode.LEARN_MOVE && this.cursor === Page.MOVES) {
+                this.moveSelect = true;
+              }
+            }
             break;
         }
       }
@@ -584,13 +580,7 @@ export default class SummaryUiHandler extends UiHandler {
             onComplete: () => {
               if (forward){
                 this.populatePageContainer(this.summaryPageContainer); 
-                if (this.summaryUiMode === SummaryUiMode.LEARN_MOVE) {
-                  this.moveCursorObj = null; 
-                  this.extraMoveRowContainer.setVisible(true);
-                  this.setCursor(0, true);
-                  this.showMoveEffect();
-                }
-                else if (this.cursor===Page.MOVES) {
+                if (this.cursor===Page.MOVES) {
                   this.moveCursorObj = null; 
                   this.showMoveSelect();
                   this.showMoveEffect();


### PR DESCRIPTION
This PR resolves https://github.com/pagefaultgames/pokerogue/issues/548, and introduces the ability to view the Pokemon Status screen when learning moves. Previously, the user could only view the stats and moves screens when learning moves. 

**When learning a new move via leveling up:**

https://github.com/pagefaultgames/pokerogue/assets/59787978/b8c07d9c-f209-43bd-ba24-5304da1e3bb4

**When learning a new move via TM:**

https://github.com/pagefaultgames/pokerogue/assets/59787978/5c91ea90-7f67-423a-86c0-cf5dc8aa0561

