### PR TITLE
Add ignoresProtect to Life Dew

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6362,7 +6362,8 @@ export function initMoves() {
       .attr(ConfuseAttr),
     new StatusMove(Moves.LIFE_DEW, Type.WATER, -1, 10, -1, 0, 8)
       .attr(HealAttr, 0.25, true, false)
-      .target(MoveTarget.USER_AND_ALLIES),
+      .target(MoveTarget.USER_AND_ALLIES)
+      .ignoresProtect(),
     new SelfStatusMove(Moves.OBSTRUCT, Type.DARK, 100, 10, -1, 4, 8)
       .attr(ProtectAttr, BattlerTagType.OBSTRUCT),
     new AttackMove(Moves.FALSE_SURRENDER, Type.DARK, MoveCategory.PHYSICAL, 80, -1, 10, -1, 0, 8),


### PR DESCRIPTION
When using Life Dew, pokemons that use Protect should still be healed from Life Dew coming from an ally.

As per https://bulbapedia.bulbagarden.net/wiki/Life_Dew_(move)