### PR TITLE
Fixes some variable damage moves not working with tinted lens

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -988,6 +988,12 @@ export class MoveTypeChangeAttr extends PreAttackAbAttr {
   }
 }
 
+/**
+ * Class for abilities that boost the damage of moves
+ * For abilities that boost the base power of moves, see VariableMovePowerAbAttr
+ * @param damageMultiplier the amount to multiply the damage by 
+ * @param condition the condition for this ability to be applied 
+ */
 export class DamageBoostAbAttr extends PreAttackAbAttr {
   private damageMultiplier: number;
   private condition: PokemonAttackCondition;
@@ -998,9 +1004,18 @@ export class DamageBoostAbAttr extends PreAttackAbAttr {
     this.condition = condition;
   }
 
-    applyPreAttack(pokemon: Pokemon, passive: boolean, target: Pokemon, move: PokemonMove, args: any[]): boolean {
-      if (this.condition(pokemon, target, move.getMove())) {
-        (args[0] as Utils.NumberHolder).value *= this.damageMultiplier;
+  /**
+   * 
+   * @param pokemon the attacker pokemon
+   * @param passive N/A
+   * @param defender the target pokemon
+   * @param move the move used by the attacker pokemon
+   * @param args Utils.NumberHolder as damage
+   * @returns true if the function succeeds
+   */
+  applyPreAttack(pokemon: Pokemon, passive: boolean, defender: Pokemon, move: PokemonMove, args: any[]): boolean {
+    if (this.condition(pokemon, defender, move.getMove())) {
+      (args[0] as Utils.NumberHolder).value *= this.damageMultiplier;
         return true;
       }
 

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -990,8 +990,7 @@ export class MoveTypeChangeAttr extends PreAttackAbAttr {
 
 export class DamageBoostAbAttr extends PreAttackAbAttr {
   private damageMultiplier: number;
-  private condition: PokemonAttackCondition
-
+  private condition: PokemonAttackCondition;
 
   constructor(damageMultiplier: number, condition: PokemonAttackCondition){
     super(true);

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -988,6 +988,31 @@ export class MoveTypeChangeAttr extends PreAttackAbAttr {
   }
 }
 
+export class DamageBoostAbAttr extends PreAttackAbAttr {
+  private damageMultiplier: number;
+  private condition: PokemonAttackCondition
+
+
+  constructor(damageMultiplier: number, condition: PokemonAttackCondition){
+    super(true);
+    this.damageMultiplier = damageMultiplier
+    this.condition = condition
+  }
+
+    applyPreAttack(pokemon: Pokemon, passive: boolean, target: Pokemon, move: PokemonMove, args: any[]): boolean {
+      console.log('trying to apply')
+      console.log(args[0].value)
+      if (this.condition(pokemon, target, move.getMove())) {
+        (args[0] as Utils.NumberHolder).value *= this.damageMultiplier;
+        console.log('did apply')
+        console.log(args[0].value)
+        return true;
+      }
+
+      return false
+  }
+}
+
 export class MovePowerBoostAbAttr extends VariableMovePowerAbAttr {
   private condition: PokemonAttackCondition;
   private powerMultiplier: number;
@@ -3066,7 +3091,7 @@ export function initAbilities() {
       .attr(IgnoreOpponentStatChangesAbAttr)
       .ignorable(),
     new Ability(Abilities.TINTED_LENS, 4)
-      .attr(MovePowerBoostAbAttr, (user, target, move) => target.getAttackTypeEffectiveness(move.type, user) <= 0.5, 2),
+      .attr(DamageBoostAbAttr, 2, (user, target, move) => target.getAttackTypeEffectiveness(move.type, user) <= 0.5),
     new Ability(Abilities.FILTER, 4)
       .attr(ReceivedMoveDamageMultiplierAbAttr,(target, user, move) => target.getAttackTypeEffectiveness(move.type, user) >= 2, 0.75)
       .ignorable(),

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -1015,7 +1015,8 @@ export class DamageBoostAbAttr extends PreAttackAbAttr {
    */
   applyPreAttack(pokemon: Pokemon, passive: boolean, defender: Pokemon, move: PokemonMove, args: any[]): boolean {
     if (this.condition(pokemon, defender, move.getMove())) {
-      (args[0] as Utils.NumberHolder).value *= this.damageMultiplier;
+      const power = args[0] as Utils.NumberHolder;
+      power.value = Math.floor(power.value * this.damageMultiplier);
         return true;
       }
 

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -994,21 +994,17 @@ export class DamageBoostAbAttr extends PreAttackAbAttr {
 
   constructor(damageMultiplier: number, condition: PokemonAttackCondition){
     super(true);
-    this.damageMultiplier = damageMultiplier
-    this.condition = condition
+    this.damageMultiplier = damageMultiplier;
+    this.condition = condition;
   }
 
     applyPreAttack(pokemon: Pokemon, passive: boolean, target: Pokemon, move: PokemonMove, args: any[]): boolean {
-      console.log('trying to apply')
-      console.log(args[0].value)
       if (this.condition(pokemon, target, move.getMove())) {
         (args[0] as Utils.NumberHolder).value *= this.damageMultiplier;
-        console.log('did apply')
-        console.log(args[0].value)
         return true;
       }
 
-      return false
+      return false;
   }
 }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -27,7 +27,7 @@ import { TempBattleStat } from '../data/temp-battle-stat';
 import { ArenaTagSide, WeakenMoveScreenTag, WeakenMoveTypeTag } from '../data/arena-tag';
 import { ArenaTagType } from "../data/enums/arena-tag-type";
 import { Biome } from "../data/enums/biome";
-import { Ability, AbAttr, BattleStatMultiplierAbAttr, BlockCritAbAttr, BonusCritAbAttr, BypassBurnDamageReductionAbAttr, FieldPriorityMoveImmunityAbAttr, FieldVariableMovePowerAbAttr, IgnoreOpponentStatChangesAbAttr, MoveImmunityAbAttr, MoveTypeChangeAttr, NonSuperEffectiveImmunityAbAttr, PreApplyBattlerTagAbAttr, PreDefendFullHpEndureAbAttr, ReceivedMoveDamageMultiplierAbAttr, ReduceStatusEffectDurationAbAttr, StabBoostAbAttr, StatusEffectImmunityAbAttr, TypeImmunityAbAttr, VariableMovePowerAbAttr, VariableMoveTypeAbAttr, WeightMultiplierAbAttr, allAbilities, applyAbAttrs, applyBattleStatMultiplierAbAttrs, applyPostDefendAbAttrs, applyPreApplyBattlerTagAbAttrs, applyPreAttackAbAttrs, applyPreDefendAbAttrs, applyPreSetStatusAbAttrs, UnsuppressableAbilityAbAttr, SuppressFieldAbilitiesAbAttr, NoFusionAbilityAbAttr, MultCritAbAttr, IgnoreTypeImmunityAbAttr } from '../data/ability';
+import { Ability, AbAttr, BattleStatMultiplierAbAttr, BlockCritAbAttr, BonusCritAbAttr, BypassBurnDamageReductionAbAttr, FieldPriorityMoveImmunityAbAttr, FieldVariableMovePowerAbAttr, IgnoreOpponentStatChangesAbAttr, MoveImmunityAbAttr, MoveTypeChangeAttr, NonSuperEffectiveImmunityAbAttr, PreApplyBattlerTagAbAttr, PreDefendFullHpEndureAbAttr, ReceivedMoveDamageMultiplierAbAttr, ReduceStatusEffectDurationAbAttr, StabBoostAbAttr, StatusEffectImmunityAbAttr, TypeImmunityAbAttr, VariableMovePowerAbAttr, VariableMoveTypeAbAttr, WeightMultiplierAbAttr, allAbilities, applyAbAttrs, applyBattleStatMultiplierAbAttrs, applyPostDefendAbAttrs, applyPreApplyBattlerTagAbAttrs, applyPreAttackAbAttrs, applyPreDefendAbAttrs, applyPreSetStatusAbAttrs, UnsuppressableAbilityAbAttr, SuppressFieldAbilitiesAbAttr, NoFusionAbilityAbAttr, MultCritAbAttr, IgnoreTypeImmunityAbAttr, DamageBoostAbAttr } from '../data/ability';
 import { Abilities } from "#app/data/enums/abilities";
 import PokemonData from '../system/pokemon-data';
 import Battle, { BattlerIndex } from '../battle';
@@ -1409,6 +1409,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
               if (!burnDamageReductionCancelled.value)
                 damage.value = Math.floor(damage.value / 2);
             }
+            
+            applyPreAttackAbAttrs(DamageBoostAbAttr, source, this, battlerMove, damage)
+
             move.getAttrs(HitsTagAttr).map(hta => hta as HitsTagAttr).filter(hta => hta.doubleDamage).forEach(hta => {
               if (this.getTag(hta.tagType))
                 damage.value *= 2;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1410,7 +1410,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
                 damage.value = Math.floor(damage.value / 2);
             }
 
-            applyPreAttackAbAttrs(DamageBoostAbAttr, source, this, battlerMove, damage)
+            applyPreAttackAbAttrs(DamageBoostAbAttr, source, this, battlerMove, damage);
 
             move.getAttrs(HitsTagAttr).map(hta => hta as HitsTagAttr).filter(hta => hta.doubleDamage).forEach(hta => {
               if (this.getTag(hta.tagType))

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1314,6 +1314,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         const sourceTeraType = source.getTeraType();
         if (sourceTeraType !== Type.UNKNOWN && sourceTeraType === type && power.value < 60 && move.priority <= 0 && !move.getAttrs(MultiHitAttr).length && !this.scene.findModifier(m => m instanceof PokemonMultiHitModifier && m.pokemonId === source.id))
           power.value = 60;
+        applyMoveAttrs(VariablePowerAttr, source, this, move, power);
         applyPreAttackAbAttrs(VariableMovePowerAbAttr, source, this, battlerMove, power);
         this.scene.getField(true).map(p => applyPreAttackAbAttrs(FieldVariableMovePowerAbAttr, this, source, battlerMove, power));
 
@@ -1342,7 +1343,6 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
           applyMoveAttrs(IgnoreWeatherTypeDebuffAttr, source, this, move, arenaAttackTypeMultiplier);
           if (this.scene.arena.getTerrainType() === TerrainType.GRASSY && this.isGrounded() && type === Type.GROUND && move.moveTarget === MoveTarget.ALL_NEAR_OTHERS)
             power.value /= 2;
-          applyMoveAttrs(VariablePowerAttr, source, this, move, power);
           this.scene.applyModifiers(PokemonMultiHitModifier, source.isPlayer(), source, new Utils.IntegerHolder(0), power);
           if (!typeless) {
             this.scene.arena.applyTags(WeakenMoveTypeTag, type, power);

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1314,7 +1314,6 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         const sourceTeraType = source.getTeraType();
         if (sourceTeraType !== Type.UNKNOWN && sourceTeraType === type && power.value < 60 && move.priority <= 0 && !move.getAttrs(MultiHitAttr).length && !this.scene.findModifier(m => m instanceof PokemonMultiHitModifier && m.pokemonId === source.id))
           power.value = 60;
-        applyMoveAttrs(VariablePowerAttr, source, this, move, power);
         applyPreAttackAbAttrs(VariableMovePowerAbAttr, source, this, battlerMove, power);
         this.scene.getField(true).map(p => applyPreAttackAbAttrs(FieldVariableMovePowerAbAttr, this, source, battlerMove, power));
 
@@ -1343,6 +1342,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
           applyMoveAttrs(IgnoreWeatherTypeDebuffAttr, source, this, move, arenaAttackTypeMultiplier);
           if (this.scene.arena.getTerrainType() === TerrainType.GRASSY && this.isGrounded() && type === Type.GROUND && move.moveTarget === MoveTarget.ALL_NEAR_OTHERS)
             power.value /= 2;
+          applyMoveAttrs(VariablePowerAttr, source, this, move, power);
           this.scene.applyModifiers(PokemonMultiHitModifier, source.isPlayer(), source, new Utils.IntegerHolder(0), power);
           if (!typeless) {
             this.scene.arena.applyTags(WeakenMoveTypeTag, type, power);
@@ -1409,7 +1409,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
               if (!burnDamageReductionCancelled.value)
                 damage.value = Math.floor(damage.value / 2);
             }
-            
+
             applyPreAttackAbAttrs(DamageBoostAbAttr, source, this, battlerMove, damage)
 
             move.getAttrs(HitsTagAttr).map(hta => hta as HitsTagAttr).filter(hta => hta.doubleDamage).forEach(hta => {


### PR DESCRIPTION
Updated Description: Some variable power moves like magnitude and dragon energy were not getting boosted by tinted lens. This PR adds a new class for abilities that boost the damage of moves rather than the base power (currently this appears to just be tinted lens). 

Testing: 
- Magnitude does double damage on a not very effective target when attacker has tinted lens 
- Magnitude does normal damage on a not very effective target when attacker does not have tinted lens 
- Neutral damage move does same damage with/without tinted lens 
 
