### PR TITLE
Implement Parental Bond

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -913,6 +913,34 @@ export class PostStatChangeStatChangeAbAttr extends PostStatChangeAbAttr {
   }
 }
 
+export class PreHitAbAttr extends AbAttr {
+  apply(pokemon: Pokemon, passive: boolean, cancelled: Utils.BooleanHolder, args: any[]): boolean {
+    return false; 
+  }
+}
+
+export class ExtraHitMoveAbAttr extends PreHitAbAttr {
+  private extraHits: integer;
+  private powerMultiplier: number;
+
+  constructor(extraHits: integer, powerMultiplier: number){
+    super(true);
+    this.extraHits = extraHits;
+    this.powerMultiplier = powerMultiplier;
+  }
+
+  apply(pokemon: Pokemon, passive: boolean, cancelled: Utils.BooleanHolder, args: any[]): boolean {
+    const hits = (args[0] as number[]);
+    if (this.extraHits > 0) {
+      for (let i = 0; i < this.extraHits; i++)
+        hits.push(this.powerMultiplier);
+      return true;
+    }
+    
+    return false;
+  }
+}
+
 export class PreAttackAbAttr extends AbAttr {
   applyPreAttack(pokemon: Pokemon, passive: boolean, defender: Pokemon, move: PokemonMove, args: any[]): boolean | Promise<boolean> {
     return false;
@@ -3285,7 +3313,7 @@ export function initAbilities() {
     new Ability(Abilities.AERILATE, 6)
       .attr(MoveTypeChangePowerMultiplierAbAttr, Type.NORMAL, Type.FLYING, 1.2),
     new Ability(Abilities.PARENTAL_BOND, 6)
-      .unimplemented(),
+      .attr(ExtraHitMoveAbAttr, 1, 0.25),
     new Ability(Abilities.DARK_AURA, 6)
       .attr(PostSummonMessageAbAttr, (pokemon: Pokemon) => getPokemonMessage(pokemon, ' is radiating a Dark Aura!'))
       .attr(FieldMoveTypePowerBoostAbAttr, Type.DARK, 4 / 3),

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1415,7 +1415,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     return (this.isPlayer() ? this.scene.getPlayerField() : this.scene.getEnemyField())[this.getFieldIndex() ? 0 : 1];
   }
 
-  apply(source: Pokemon, battlerMove: PokemonMove): HitResult {
+  apply(source: Pokemon, battlerMove: PokemonMove, extraHitModifier: number = 1): HitResult {
     let result: HitResult;
     const move = battlerMove.getMove();
     let damage = new Utils.NumberHolder(0);
@@ -1541,7 +1541,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
           applyMoveAttrs(VariableDefAttr, source, this, move, targetDef);
 
           if (!isTypeImmune) {
-            damage.value = Math.ceil(((((2 * source.level / 5 + 2) * power.value * sourceAtk.value / targetDef.value) / 50) + 2) * stabMultiplier.value * typeMultiplier.value * arenaAttackTypeMultiplier.value * screenMultiplier.value * ((this.scene.randBattleSeedInt(15) + 85) / 100) * criticalMultiplier.value);
+            damage.value = Math.ceil(((((2 * source.level / 5 + 2) * power.value * sourceAtk.value / targetDef.value) / 50) + 2) * stabMultiplier.value * typeMultiplier.value * arenaAttackTypeMultiplier.value * screenMultiplier.value * extraHitModifier * ((this.scene.randBattleSeedInt(15) + 85) / 100) * criticalMultiplier.value);
             if (isPhysical && source.status && source.status.effect === StatusEffect.BURN) {
               const burnDamageReductionCancelled = new Utils.BooleanHolder(false);
               applyAbAttrs(BypassBurnDamageReductionAbAttr, source, burnDamageReductionCancelled);
@@ -3310,6 +3310,7 @@ export class PokemonTurnData {
   public damageDealt: integer = 0;
   public damageTaken: integer = 0;
   public attacksReceived: AttackMoveResult[] = [];
+  public multipliersExtraHits: number[] = [];
 }
 
 export enum AiType {


### PR DESCRIPTION
Implemented the ability Parental Bond, with a new ExtraHitMoveAbAttr that takes two values, the amount of extra hits and the damage modifier for them (in this case 1 and 0.25).

From my testing it seems to work like original Pokemon, with the exception that I intentionally allowed it to activate with Multi-Hit moves, so that it doesn't become redundant with Multi Lens and so that Maushold makes sense with Parental Bond as passive (otherwise it would be a useless passive). This can be changed easily if needed.

Tested that non-attacking moves don't activate it, misses also stop the second hit, and it procs secondary effects as expected.