### PR TITLE
Fix Curse targeting for non ghost types

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -51,7 +51,8 @@ export enum MoveTarget {
   USER_SIDE,
   ENEMY_SIDE,
   BOTH_SIDES,
-  PARTY
+  PARTY,
+  CURSE
 }
 
 export enum MoveFlags {
@@ -4096,7 +4097,7 @@ export function getMoveTargets(user: Pokemon, move: Moves): MoveTargetSet {
   switch (moveTarget) {
     case MoveTarget.USER:
     case MoveTarget.PARTY:
-      set = [ user];
+      set = [ user ];
       break;
     case MoveTarget.NEAR_OTHER:
     case MoveTarget.OTHER:
@@ -4131,6 +4132,9 @@ export function getMoveTargets(user: Pokemon, move: Moves): MoveTargetSet {
     case MoveTarget.BOTH_SIDES:
       set = [ user, user.getAlly() ].concat(opponents);
       multiple = true;
+      break;
+    case MoveTarget.CURSE:
+      set = user.getTypes(true).includes(Type.GHOST) ? (opponents.concat([ user.getAlly() ])) : [ user ];
       break;
   }
 
@@ -4613,7 +4617,8 @@ export function initMoves() {
       .soundBased(),
     new StatusMove(Moves.CURSE, Type.GHOST, -1, 10, -1, 0, 2)
       .attr(CurseAttr)
-      .ignoresProtect(true),
+      .ignoresProtect(true)
+      .target(MoveTarget.CURSE),
     new AttackMove(Moves.FLAIL, Type.NORMAL, MoveCategory.PHYSICAL, -1, 100, 15, -1, 0, 2)
       .attr(LowHpPowerAttr),
     new StatusMove(Moves.CONVERSION_2, Type.NORMAL, -1, 30, -1, 0, 2)


### PR DESCRIPTION
Added a new MoveTarget type, MoveTarget.CURSE especifically for the move, so that it only makes you choose target if you are a ghost type (or tera into ghost). I don't believe many moves with variable targeting will be added so I think it's okay to fix it like this.

This should fix the bugs related to this move, such as the ones mentioned in issues https://github.com/pagefaultgames/pokerogue/issues/537 and https://github.com/pagefaultgames/pokerogue/issues/779