### PR TITLE
Update Frisk description in most languages

### DIFF
--- a/src/locales/de/ability.ts
+++ b/src/locales/de/ability.ts
@@ -475,7 +475,7 @@ export const ability: AbilityTranslationEntries = {
   },
   frisk: {
     name: "Frisk",
-    description: "When it enters a battle, the Pokémon can check an opposing Pokémon's held item.",
+    description: "When it enters a battle, the Pokémon can check an opposing Pokémon's ability.",
   },
   reckless: {
     name: "Reckless",

--- a/src/locales/en/ability.ts
+++ b/src/locales/en/ability.ts
@@ -475,7 +475,7 @@ export const ability: AbilityTranslationEntries = {
   },
   frisk: {
     name: "Frisk",
-    description: "When it enters a battle, the Pokémon can check an opposing Pokémon's held item.",
+    description: "When it enters a battle, the Pokémon can check an opposing Pokémon's ability.",
   },
   reckless: {
     name: "Reckless",

--- a/src/locales/es/ability.ts
+++ b/src/locales/es/ability.ts
@@ -475,7 +475,7 @@ export const ability: AbilityTranslationEntries = {
   },
   "frisk": {
     name: "Cacheo",
-    description: "Puede ver el objeto que lleva el rival al entrar en combate."
+    description: "Puede ver la habilidad del rival al entrar en combate."
   },
   "reckless": {
     name: "Audaz",

--- a/src/locales/fr/ability.ts
+++ b/src/locales/fr/ability.ts
@@ -475,7 +475,7 @@ export const ability: AbilityTranslationEntries = {
   },
   frisk: {
     name: "Fouille",
-    description: "Permet de connaitre l’objet tenu par l’adversaire quand le combat commence.",
+    description: "Permet de connaitre le talent de l’adversaire quand le combat commence.",
   },
   reckless: {
     name: "Téméraire",

--- a/src/locales/it/ability.ts
+++ b/src/locales/it/ability.ts
@@ -475,7 +475,7 @@ export const ability: AbilityTranslationEntries = {
   },
   frisk: {
     name: "Indagine",
-    description: "Quando il Pokémon entra in campo, rivela lo strumento del nemico.",
+    description: "Quando il Pokémon entra in campo, rivela l'abilità del nemico.",
   },
   reckless: {
     name: "Temerarietà",


### PR DESCRIPTION
Changed the description of Frisk ability to reflect its new effect for Pokerogue, as mentioned by the issue https://github.com/pagefaultgames/pokerogue/issues/778

I changed all languages except Chinese since I don't really know it well, so if anyone can give me the translation I'll gladly add it to the PR.

I also kept the german one in english as the other abilities also seem to be in english.