### PR TITLE
[CONCEPT] Conditional boss ur

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2281,7 +2281,6 @@ export class PostFaintHPDamageAbAttr extends PostFaintAbAttr {
   }
 
   applyPostFaint(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: PokemonMove, hitResult: HitResult, args: any[]): boolean {
-    console.log(args);
     let damage = args[0];
     attacker.damageAndUpdate((damage), HitResult.OTHER);
     attacker.turnData.damageTaken += damage;

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2275,6 +2275,9 @@ export class PostFaintContactDamageAbAttr extends PostFaintAbAttr {
   }
 }
 
+/** 
+ * Attribute used for abilities (Innards Out) that damage the opponent based on how much HP the last attack used to knock out the owner of the ability.
+ */
 export class PostFaintHPDamageAbAttr extends PostFaintAbAttr {
   constructor() {
     super ();

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2275,6 +2275,24 @@ export class PostFaintContactDamageAbAttr extends PostFaintAbAttr {
   }
 }
 
+export class PostFaintHPDamageAbAttr extends PostFaintAbAttr {
+  constructor() {
+    super ();
+  }
+
+  applyPostFaint(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: PokemonMove, hitResult: HitResult, args: any[]): boolean {
+    console.log(args);
+    let damage = args[0];
+    attacker.damageAndUpdate((damage), HitResult.OTHER);
+    attacker.turnData.damageTaken += damage;
+    return true;
+  } 
+
+  getTriggerMessage(pokemon: Pokemon, abilityName: string, ...args: any[]): string {
+    return getPokemonMessage(pokemon, `'s ${abilityName} hurt\nits attacker!`);
+  }
+}
+
 export class RedirectMoveAbAttr extends AbAttr {
   apply(pokemon: Pokemon, passive: boolean, cancelled: Utils.BooleanHolder, args: any[]): boolean {
     if (this.canRedirect(args[0] as Moves)) {
@@ -3316,7 +3334,8 @@ export function initAbilities() {
       .attr(FieldPriorityMoveImmunityAbAttr)
       .ignorable(),
     new Ability(Abilities.INNARDS_OUT, 7)
-      .unimplemented(),
+      .attr(PostFaintHPDamageAbAttr)
+      .bypassFaint(),
     new Ability(Abilities.DANCER, 7)
       .unimplemented(),
     new Ability(Abilities.BATTERY, 7)

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2281,7 +2281,7 @@ export class PostFaintHPDamageAbAttr extends PostFaintAbAttr {
   }
 
   applyPostFaint(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: PokemonMove, hitResult: HitResult, args: any[]): boolean {
-    let damage = args[0];
+    const damage = pokemon.turnData.attacksReceived[0].damage;
     attacker.damageAndUpdate((damage), HitResult.OTHER);
     attacker.turnData.damageTaken += damage;
     return true;

--- a/src/data/biomes.ts
+++ b/src/data/biomes.ts
@@ -34,6 +34,15 @@ interface BiomeDepths {
   [key: integer]: [integer, integer]
 }
 
+interface BiomeConditions {
+  [key: integer]: (p: any) => boolean;
+}
+
+export const biomeConditions: BiomeConditions = {
+  [Biome.TOWN]: (p) => !!p.scene.getParty().find(p => p.species.speciesId === Species.MEWTWO),
+  [Biome.PLAINS]: () => {return false},
+}
+
 export const biomeLinks: BiomeLinks = {
   [Biome.TOWN]: Biome.PLAINS,
   [Biome.PLAINS]: [ Biome.GRASS, Biome.METROPOLIS, Biome.LAKE ],
@@ -82,7 +91,8 @@ export enum BiomePoolTier {
   BOSS,
   BOSS_RARE,
   BOSS_SUPER_RARE,
-  BOSS_ULTRA_RARE
+  BOSS_ULTRA_RARE,
+  BOSS_CONDITIONAL_ULTRA_RARE
 };
 
 export const uncatchableSpecies: Species[] = [];
@@ -157,7 +167,8 @@ export const biomePokemonPools: BiomePokemonPools = {
     [BiomePoolTier.BOSS]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [] },
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [] },
     [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [] },
-    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [] }
+    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [Species.ZEKROM] },
+    [BiomePoolTier.BOSS_CONDITIONAL_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [Species.RESHIRAM]},
   },
   [Biome.PLAINS]: {
     [BiomePoolTier.COMMON]: {
@@ -5126,11 +5137,13 @@ export const biomeTrainerPools: BiomeTrainerPools = {
       ]
     ],
     [ Species.RESHIRAM, Type.DRAGON, Type.FIRE, [
-        [ Biome.VOLCANO, BiomePoolTier.BOSS_ULTRA_RARE ]
+        [ Biome.VOLCANO, BiomePoolTier.BOSS_ULTRA_RARE ],
+        [ Biome.TOWN, BiomePoolTier.BOSS_CONDITIONAL_ULTRA_RARE ]
       ]
     ],
     [ Species.ZEKROM, Type.DRAGON, Type.ELECTRIC, [
-        [ Biome.POWER_PLANT, BiomePoolTier.BOSS_ULTRA_RARE ]
+        [ Biome.POWER_PLANT, BiomePoolTier.BOSS_ULTRA_RARE ],
+        [ Biome.TOWN, BiomePoolTier.BOSS_ULTRA_RARE ]
       ]
     ],
     [ Species.LANDORUS, Type.GROUND, Type.FLYING, [

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -1,5 +1,5 @@
 import BattleScene from "../battle-scene";
-import { BiomePoolTier, PokemonPools, BiomeTierTrainerPools, biomePokemonPools, biomeTrainerPools } from "../data/biomes";
+import { BiomePoolTier, PokemonPools, BiomeTierTrainerPools, biomePokemonPools, biomeTrainerPools, biomeConditions } from "../data/biomes";
 import { Biome } from "../data/enums/biome";
 import * as Utils from "../utils";
 import PokemonSpecies, { getPokemonSpecies } from "../data/pokemon-species";
@@ -68,13 +68,24 @@ export class Arena {
     const overrideSpecies = this.scene.gameMode.getOverrideSpecies(waveIndex);
     if (overrideSpecies)
       return overrideSpecies;
-    const isBoss = !!this.scene.getEncounterBossSegments(waveIndex, level) && !!this.pokemonPool[BiomePoolTier.BOSS].length
-      && (this.biomeType !== Biome.END || this.scene.gameMode.isClassic || this.scene.gameMode.isWaveFinal(waveIndex));
-    const tierValue = Utils.randSeedInt(!isBoss ? 512 : 64);
+    // const isBoss = !!this.scene.getEncounterBossSegments(waveIndex, level) && !!this.pokemonPool[BiomePoolTier.BOSS].length
+    //   && (this.biomeType !== Biome.END || this.scene.gameMode.isClassic || this.scene.gameMode.isWaveFinal(waveIndex));
+    const isBoss = true; // OVERIDE
+    // const tierValue = Utils.randSeedInt(!isBoss ? 512 : 64);
+    // let tier = !isBoss
+    //   ? tierValue >= 156 ? BiomePoolTier.COMMON : tierValue >= 32 ? BiomePoolTier.UNCOMMON : tierValue >= 6 ? BiomePoolTier.RARE : tierValue >= 1 ? BiomePoolTier.SUPER_RARE : BiomePoolTier.ULTRA_RARE
+    //   : tierValue >= 20 ? BiomePoolTier.BOSS : tierValue >= 6 ? BiomePoolTier.BOSS_RARE : tierValue >= 1 ? BiomePoolTier.BOSS_SUPER_RARE : BiomePoolTier.BOSS_ULTRA_RARE;
+    const tierValue = 0; // Utils.randSeedInt(!isBoss ? 512 : 128); OVERRIDE
     let tier = !isBoss
       ? tierValue >= 156 ? BiomePoolTier.COMMON : tierValue >= 32 ? BiomePoolTier.UNCOMMON : tierValue >= 6 ? BiomePoolTier.RARE : tierValue >= 1 ? BiomePoolTier.SUPER_RARE : BiomePoolTier.ULTRA_RARE
-      : tierValue >= 20 ? BiomePoolTier.BOSS : tierValue >= 6 ? BiomePoolTier.BOSS_RARE : tierValue >= 1 ? BiomePoolTier.BOSS_SUPER_RARE : BiomePoolTier.BOSS_ULTRA_RARE;
+      : tierValue >= 40 ? BiomePoolTier.BOSS : tierValue >= 12 ? BiomePoolTier.BOSS_RARE : tierValue >= 2 ? BiomePoolTier.BOSS_SUPER_RARE : tierValue >= 1 ? BiomePoolTier.BOSS_ULTRA_RARE : 
+        biomeConditions[this.biomeType](this) ? BiomePoolTier.BOSS_CONDITIONAL_ULTRA_RARE : BiomePoolTier.BOSS_ULTRA_RARE;
+    console.log("this.scene: " + this.scene);
+    console.log("this.scene get party " + this.scene.getParty());
+    console.log("biome condition: " + biomeConditions[this.biomeType](this));
     console.log(BiomePoolTier[tier]);
+    console.log(this.pokemonPool);
+    console.log(this.pokemonPool[tier]);
     while (!this.pokemonPool[tier].length) {
       console.log(`Downgraded rarity tier from ${BiomePoolTier[tier]} to ${BiomePoolTier[tier - 1]}`);
       tier--;

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -3135,7 +3135,7 @@ export class FaintPhase extends PokemonPhase {
 
     if (pokemon.turnData?.attacksReceived?.length) {
       const lastAttack = pokemon.turnData.attacksReceived[0];
-      applyPostFaintAbAttrs(PostFaintAbAttr, pokemon, this.scene.getPokemonById(lastAttack.sourceId), new PokemonMove(lastAttack.move), lastAttack.result, lastAttack.damage);
+      applyPostFaintAbAttrs(PostFaintAbAttr, pokemon, this.scene.getPokemonById(lastAttack.sourceId), new PokemonMove(lastAttack.move), lastAttack.result);
     }
 
     const alivePlayField = this.scene.getField(true);

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -3135,7 +3135,7 @@ export class FaintPhase extends PokemonPhase {
 
     if (pokemon.turnData?.attacksReceived?.length) {
       const lastAttack = pokemon.turnData.attacksReceived[0];
-      applyPostFaintAbAttrs(PostFaintAbAttr, pokemon, this.scene.getPokemonById(lastAttack.sourceId), new PokemonMove(lastAttack.move), lastAttack.result);
+      applyPostFaintAbAttrs(PostFaintAbAttr, pokemon, this.scene.getPokemonById(lastAttack.sourceId), new PokemonMove(lastAttack.move), lastAttack.result, lastAttack.damage);
     }
 
     const alivePlayField = this.scene.getField(true);


### PR DESCRIPTION
Proof of concept for conditional biome spawns.
* Create a new rarity in a tier BOSS_CONDITIONAL_ULTRA_RARE (but this can be extended to other tiers as well)
* So right now the logic for generating a boss is 0 = UR, 1-5 = SR, 6-19 R, 20-63 C
* With  BOSS_CONDITIONAL_ULTRA_RARE generate a number from 0-128 where 0 = CUR, 1 = UR, 2-11 = SR, 12 - 39 = R, 40+ C
* If the condition fails then it defaults to BOSS_ULTRA_RARE
* Allows for more puzzle concepts (ie needing relicanth+wailord in the party to unlock something) and new encounters
* An extra biome tier allows weighting in tiers. For example, by setting the volcano condition to always be true and have the volcano conditional_ur tier have [reshiram, arceus-fire] for example, then the URs in volcano would be weighted 2:1 reshiram to arceus-fire

## Testing
* Set Zekrom as a ur boss and Reshiram as a conditional ur boss in town
* The condition in town is having a mewtwo in the party
* Override to generate a boss with random number 0
* [no mewtwo in party leads to zekrom](https://cdn.discordapp.com/attachments/1176874654015684739/1239273739028267098/image.png?ex=6642531b&is=6641019b&hm=aaa0b38d5d0ebaadb60d44295b8aa7a77c17b67d57705050d2b41e48f7f2a903&)
* [mewtwo in party leads to reshiram](https://cdn.discordapp.com/attachments/1176874654015684739/1239273739225665686/image.png?ex=6642531c&is=6641019c&hm=ef4800241f8bed29e26862f5be6351178dc8e72df915e6897721853da5ebe977&)

Ignore the innards out commits in here, that's some git confusion on my end.