### PR TITLE
Prevent applying item boosts when power is <1

### DIFF
--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -635,6 +635,9 @@ export class PokemonBaseStatModifier extends PokemonHeldItemModifier {
   }
 }
 
+  /**
+ * Applies Specific Type item boosts (e.g., Magnet)
+ */
 export class AttackTypeBoosterModifier extends PokemonHeldItemModifier {
   private moveType: Type;
   private boostMultiplier: number;
@@ -667,6 +670,13 @@ export class AttackTypeBoosterModifier extends PokemonHeldItemModifier {
     return super.shouldApply(args) && args.length === 3 && typeof args[1] === 'number' && args[2] instanceof Utils.NumberHolder;
   }
 
+  /**
+ * @param {Array<any>} args Array 
+ *                          - Index 0: {Pokemon} Pokemon
+ *                          - Index 1: {number} Move type
+ *                          - Index 2: {Utils.NumberHolder} Move power
+ * @returns {boolean} Returns true if boosts have been applied to the move.
+ */
   apply(args: any[]): boolean {
     if (args[1] === this.moveType && (args[2] as Utils.NumberHolder).value >= 1) {
       (args[2] as Utils.NumberHolder).value = Math.floor((args[2] as Utils.NumberHolder).value * (1 + (this.getStackCount() * this.boostMultiplier)));

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -668,7 +668,7 @@ export class AttackTypeBoosterModifier extends PokemonHeldItemModifier {
   }
 
   apply(args: any[]): boolean {
-    if (args[1] === this.moveType) {
+    if (args[1] === this.moveType && (args[2] as Utils.NumberHolder).value >= 1) {
       (args[2] as Utils.NumberHolder).value = Math.floor((args[2] as Utils.NumberHolder).value * (1 + (this.getStackCount() * this.boostMultiplier)));
       return true;
     }


### PR DESCRIPTION
This PR prevents item type power boosts from being applied, if base power is less than 1. (For example, when you hit a disguise with multi-lens).
Because the value is Math.floored, applying the boost will cause the move to do no damage at all.

This is Disguise not breaking against Magnet + Multi-Lens Thunderbolt before the fix

https://github.com/pagefaultgames/pokerogue/assets/73663099/986e12d7-2cfe-4f7e-bd1a-ef71b2e8d5c2

The Disguise not breaking bug does not happen with Multi-Lens and no Magnet before the fix

https://github.com/pagefaultgames/pokerogue/assets/73663099/38b63bb9-048e-473b-b339-2794fba9df05

The Disguise breaks properly with Magnets equipped after the fix

https://github.com/pagefaultgames/pokerogue/assets/73663099/9fcdd8cc-85bc-4723-9525-af491a61b0b2

