### PR TITLE
Fixed clear freeze in offline mode

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -3611,9 +3611,13 @@ export class GameOverPhase extends BattlePhase {
       });
     };
     if (this.victory) {
-      Utils.apiFetch(`savedata/newclear?slot=${this.scene.sessionSlotId}`, true)
+      if (Utils.isLocal) {
+        doGameOver(true);
+      } else {
+        Utils.apiFetch(`savedata/newclear?slot=${this.scene.sessionSlotId}`, true)
         .then(response => response.json())
         .then(newClear => doGameOver(newClear));
+      }
     } else
       doGameOver(false);
   }


### PR DESCRIPTION
Currently when in offline mode, api "savedata/newclear" gets called to check dailyRun seed every handleGameOver().
Added a simple isLocal check to prevent that since it was causing freezes when playing classic offline.