### PR TITLE
Stench should not trigger on status moves

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2760,7 +2760,7 @@ export const allAbilities = [ new Ability(Abilities.NONE, 3) ];
 export function initAbilities() {
   allAbilities.push(
     new Ability(Abilities.STENCH, 3)
-      .attr(PostAttackApplyBattlerTagAbAttr, false, (user, target, move) => !move.getMove().findAttr(attr => attr instanceof FlinchAttr) ? 10 : 0, BattlerTagType.FLINCHED),
+      .attr(PostAttackApplyBattlerTagAbAttr, false, (user, target, move) => (move.getMove().category !== MoveCategory.STATUS && !move.getMove().findAttr(attr => attr instanceof FlinchAttr)) ? 10 : 0, BattlerTagType.FLINCHED),
     new Ability(Abilities.DRIZZLE, 3)
       .attr(PostSummonWeatherChangeAbAttr, WeatherType.RAIN)
       .attr(PostBiomeChangeWeatherChangeAbAttr, WeatherType.RAIN),


### PR DESCRIPTION
## Testing
* Set flinch chance to 100%
* Verified status moves (smokescreen) would trigger flinch
* Verified damage moves (tackle) would trigger flinch
* Made code change
* Verified status moves no longer trigger flinch while damage moves still do
* Set flinch chance back to 10%