### PR TITLE
Feature: Adds the ability for users to spend candy to max a random IV

### DIFF
--- a/src/locales/de/starter-select-ui-handler.ts
+++ b/src/locales/de/starter-select-ui-handler.ts
@@ -28,5 +28,6 @@ export const starterSelectUiHandler: SimpleTranslationEntries = {
     "cycleNature": "N: Wesen Ändern",
     "cycleVariant": "V: Seltenheit ändern",
     "enablePassive": "Passiv-Skill aktivieren",
-    "disablePassive": "Passiv-Skill deaktivieren"
+    "disablePassive": "Passiv-Skill deaktivieren",
+    "maxIV": "Max a Random IV"
 }

--- a/src/locales/en/starter-select-ui-handler.ts
+++ b/src/locales/en/starter-select-ui-handler.ts
@@ -28,5 +28,6 @@ export const starterSelectUiHandler: SimpleTranslationEntries = {
     "cycleNature": 'N: Cycle Nature',
     "cycleVariant": 'V: Cycle Variant',
     "enablePassive": "Enable Passive",
-    "disablePassive": "Disable Passive"
+    "disablePassive": "Disable Passive",
+    "maxIV": "Max a Random IV"
 }

--- a/src/locales/es/starter-select-ui-handler.ts
+++ b/src/locales/es/starter-select-ui-handler.ts
@@ -28,5 +28,6 @@ export const starterSelectUiHandler: SimpleTranslationEntries = {
     "cycleNature": 'N: Cambiar Naturaleza',
     "cycleVariant": 'V: Cambiar Variante',
     "enablePassive": "Activar Pasiva",
-    "disablePassive": "Desactivar Pasiva"
+    "disablePassive": "Desactivar Pasiva",
+    "maxIV": "Max a Random IV"
 }

--- a/src/locales/fr/starter-select-ui-handler.ts
+++ b/src/locales/fr/starter-select-ui-handler.ts
@@ -28,5 +28,6 @@ export const starterSelectUiHandler: SimpleTranslationEntries = {
     "cycleNature": "N: » Natures",
     "cycleVariant": "V: » Variants",
     "enablePassive": "Activer Passif",
-    "disablePassive": "Désactiver Passif"
+    "disablePassive": "Désactiver Passif",
+    "maxIV": "Max a Random IV"
 }

--- a/src/locales/it/starter-select-ui-handler.ts
+++ b/src/locales/it/starter-select-ui-handler.ts
@@ -28,5 +28,6 @@ export const starterSelectUiHandler: SimpleTranslationEntries = {
     "cycleNature": 'N: Alterna Natura',
     "cycleVariant": 'V: Alterna Variante',
     "enablePassive": "Attiva Passiva",
-    "disablePassive": "Disattiva Passiva"
+    "disablePassive": "Disattiva Passiva",
+    "maxIV": "Max a Random IV"
 }

--- a/src/locales/zh_CN/starter-select-ui-handler.ts
+++ b/src/locales/zh_CN/starter-select-ui-handler.ts
@@ -28,5 +28,6 @@ export const starterSelectUiHandler: SimpleTranslationEntries = {
     "cycleNature": 'N: 切换性格',
     "cycleVariant": 'V: 切换变种',
     "enablePassive": "启用被动",
-    "disablePassive": "禁用被动"
+    "disablePassive": "禁用被动",
+    "maxIV": "Max a Random IV"
 }


### PR DESCRIPTION
@Piefrenzy on Discord

Right now, once you've reduced cost twice and unlocked the passive there is nothing to do with your candy on a particular Pokemon. For a 3 cost, that's 110 candy which can be done in under 10 runs of classic (personally got there in about 8).

The goal of this PR is to provide something else to spend candy on - upgrading IVs. Still keeps eggs valuable seeing as that's how you get egg moves + shinies, but makes it so it's slightly easier to use different Pokemon on endless because it'll increase the max stack of a specific vitamin they can use.

I made the cost identical to first cost reduction, but numbers are not necessarily set in stone if they're too low/high. Alternatively, it could be a random amount (like 5-15 for an avg of 10?) for a lower cost.

The text is the same across all the languages. I don't speak any other language but didn't want to not include it in those respective files. Hope that's okay until someone that speaks those languages can provide a translation.

Also pulls up/refreshes the IV page whenever you max an IV so you can see what IV you rolled to max.

https://github.com/pagefaultgames/pokerogue/assets/85713900/1cdff3c2-b4fb-4d48-99a5-95c1bc39d273
