### PR TITLE
Draft: Feature for Hidden Ability Gacha machine

### DIFF
--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -10,7 +10,8 @@ export const EGG_SEED = 1073741824;
 export enum GachaType {
   MOVE,
   LEGENDARY,
-  SHINY
+  SHINY,
+  ABILITY
 }
 
 export class Egg {

--- a/src/egg-hatch-phase.ts
+++ b/src/egg-hatch-phase.ts
@@ -12,6 +12,7 @@ import { achvs } from "./system/achv";
 import { pokemonPrevolutions } from "./data/pokemon-evolutions";
 import { EggTier } from "./data/enums/egg-type";
 import PokemonInfoContainer from "./ui/pokemon-info-container";
+import { Abilities } from "./data/enums/abilities";
 
 export class EggHatchPhase extends Phase {
   private egg: Egg;
@@ -413,10 +414,10 @@ export class EggHatchPhase extends Phase {
         }
 
         const pokemonSpecies = getPokemonSpecies(species);
-
         ret = this.scene.addPlayerPokemon(pokemonSpecies, 1, undefined, undefined, undefined, false);
       }
 
+      ret.abilityIndex = this.egg.gachaType == GachaType.ABILITY ? ret.abilityIndex : ret.calculateHiddenAbilityIndex(128);
       ret.trySetShiny(this.egg.gachaType === GachaType.SHINY ? 1024 : 512);
       ret.variant = ret.shiny ? ret.generateVariant() : 0;
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -111,20 +111,10 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
     if (!species.isObtainable() && this.isPlayer())
       throw `Cannot create a player Pokemon for species '${species.getName(formIndex)}'`;
-
-    const hiddenAbilityChance = new Utils.IntegerHolder(256);
-    if (!this.hasTrainer())
-      this.scene.applyModifiers(HiddenAbilityRateBoosterModifier, true, hiddenAbilityChance);
-
-    const hasHiddenAbility = !Utils.randSeedInt(hiddenAbilityChance.value);
-    const randAbilityIndex = Utils.randSeedInt(2);
-
     this.species = species;
     this.pokeball = dataSource?.pokeball || PokeballType.POKEBALL;
     this.level = level;
-    this.abilityIndex = abilityIndex !== undefined
-      ? abilityIndex
-      : (species.abilityHidden && hasHiddenAbility ? species.ability2 ? 2 : 1 : species.ability2 ? randAbilityIndex : 0);
+    this.abilityIndex = abilityIndex != undefined ? abilityIndex : this.calculateHiddenAbilityIndex();
     if (formIndex !== undefined)
       this.formIndex = formIndex;
     if (gender !== undefined)
@@ -348,6 +338,18 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
             this.scene.load.start();
         });
     });
+  }
+
+  calculateHiddenAbilityIndex(chanceOverride: number=256): number {
+    const hiddenAbilityChance = new Utils.IntegerHolder(chanceOverride);
+    if (!this.hasTrainer())
+      this.scene.applyModifiers(HiddenAbilityRateBoosterModifier, true, hiddenAbilityChance);
+
+    const hasHiddenAbility = !Utils.randSeedInt(hiddenAbilityChance.value);
+    const randAbilityIndex = Utils.randSeedInt(2);
+
+    const abilityIndex = this.species.abilityHidden && hasHiddenAbility ? this.species.ability2 ? 2 : 1 : this.species.ability2 ? randAbilityIndex : 0;
+    return abilityIndex;
   }
 
   getFormKey(): string {


### PR DESCRIPTION
@Piefrenzy on Discord

Quick draft for a gacha machine that has a higher chance of giving hidden abilities.

Doesn't exclude Pokemon that don't have hidden abilities - just raises it from a 1/256 to 1/128 that it is generated with a Hidden Ability.

There seems to be some level of interest for something like this, but wanted to check if something like this would be approved before doing all of it + testing.