### PR TITLE
Limit rare eggs to e4+

### DIFF
--- a/src/data/trainer-config.ts
+++ b/src/data/trainer-config.ts
@@ -855,14 +855,20 @@ export const trainerConfigs: TrainerConfigs = {
     }),
   [TrainerType.RIVAL_6]: new TrainerConfig(++t).setName('Finn').setHasGenders('Ivy').setHasCharSprite().setTitle('Rival').setBoss().setStaticParty().setMoneyMultiplier(3).setEncounterBgm('final').setBattleBgm('battle_rival_3').setPartyTemplates(trainerPartyTemplates.RIVAL_6)
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([ Species.VENUSAUR, Species.CHARIZARD, Species.BLASTOISE, Species.MEGANIUM, Species.TYPHLOSION, Species.FERALIGATR, Species.SCEPTILE, Species.BLAZIKEN, Species.SWAMPERT, Species.TORTERRA, Species.INFERNAPE, Species.EMPOLEON, Species.SERPERIOR, Species.EMBOAR, Species.SAMUROTT, Species.CHESNAUGHT, Species.DELPHOX, Species.GRENINJA, Species.DECIDUEYE, Species.INCINEROAR, Species.PRIMARINA, Species.RILLABOOM, Species.CINDERACE, Species.INTELEON, Species.MEOWSCARADA, Species.SKELEDIRGE, Species.QUAQUAVAL ], TrainerSlot.TRAINER, true,
-      p => p.setBoss(true, 3))
-    )
+      p => {
+        p.setBoss(true, 3);
+        p.generateAndPopulateMoveset();
+      }))
     .setPartyMemberFunc(1, getRandomPartyMemberFunc([ Species.PIDGEOT, Species.NOCTOWL, Species.SWELLOW, Species.STARAPTOR, Species.UNFEZANT, Species.TALONFLAME, Species.TOUCANNON, Species.CORVIKNIGHT, Species.KILOWATTREL ], TrainerSlot.TRAINER, true,
-      p => p.setBoss(true, 2)))
+      p => {
+        p.setBoss(true, 2);
+        p.generateAndPopulateMoveset();
+      }))
     .setPartyMemberFunc(2, getSpeciesFilterRandomPartyMemberFunc((species: PokemonSpecies) => !pokemonEvolutions.hasOwnProperty(species.speciesId) && !pokemonPrevolutions.hasOwnProperty(species.speciesId) && species.baseTotal >= 450))
     .setSpeciesFilter(species => species.baseTotal >= 540)
     .setPartyMemberFunc(5, getRandomPartyMemberFunc([ Species.RAYQUAZA ], TrainerSlot.TRAINER, true, p => {
       p.setBoss();
+      p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.MASTER_BALL;
       p.shiny = true;
       p.variant = 1;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1229,14 +1229,20 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         for (let i = 0; i < 3; i++) {
           const moveId = speciesEggMoves[this.species.getRootSpeciesId()][i];
           if (!movePool.some(m => m[0] === moveId) && !allMoves[moveId].name.endsWith(' (N)'))
-            movePool.push([moveId, Math.min(this.level * 0.5, 40)]);
+            movePool.push([moveId, 40]);
         }
+        const moveId = speciesEggMoves[this.species.getRootSpeciesId()][3];
+        if (this.level >= 170 && !movePool.some(m => m[0] === moveId) && !allMoves[moveId].name.endsWith(' (N)') && !this.isBoss()) // No rare egg moves before e4
+          movePool.push([moveId, 30]);
         if (this.fusionSpecies) {
           for (let i = 0; i < 3; i++) {
             const moveId = speciesEggMoves[this.fusionSpecies.getRootSpeciesId()][i];
             if (!movePool.some(m => m[0] === moveId) && !allMoves[moveId].name.endsWith(' (N)'))
-              movePool.push([moveId, Math.min(this.level * 0.5, 30)]);
+              movePool.push([moveId, 40]);
           }
+          const moveId = speciesEggMoves[this.fusionSpecies.getRootSpeciesId()][3];
+          if (this.level >= 170 && !movePool.some(m => m[0] === moveId) && !allMoves[moveId].name.endsWith(' (N)') && !this.isBoss()) // No rare egg moves before e4
+            movePool.push([moveId, 30]);
         }
       }
     }


### PR DESCRIPTION
This also fixes the weighting to account for the adjusted level ranges because that was mostly destroyed by the level changes.

This also allows the moveset code to know when it's generating for a boss, and prevents rare eggs on bosses. This is done by just regenerating the moveset for a boss after it's marked as a boss.