### PR TITLE
Partially implemented mimicry.

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2126,10 +2126,21 @@ export class PostTerrainChangeAddBattlerTagAttr extends PostTerrainChangeAbAttr 
   }
 }
 
+/**
+ * When the terrain changes or the pokemon is summoned, change its type according to
+ * a Record passed into the constructor.
+ * @
+ * @extends PostTerrainChangeAbAttr
+ * @see {@link applyPostTerrainChange}
+ */
 export class PostTerrainChangeTypeAttr extends PostTerrainChangeAbAttr {
-  private oldType: Type[];
   private terrainToTypeMap: Record<TerrainType, Type>;
 
+  /**
+   * @param {Record<TerrainType, Type>} terrainToTypeMap a map from terrain types to pokemon 
+   *                types containing information about what type to change to. 
+   *                Type.UNKOWN reverts to original typing.
+   */
   constructor(terrainToTypeMap: Record<TerrainType, Type>) {
     super();
     this.terrainToTypeMap = terrainToTypeMap;

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2148,16 +2148,16 @@ export class PostTerrainChangeTypeAttr extends PostTerrainChangeAbAttr {
 
   applyPostTerrainChange(pokemon: Pokemon, passive: boolean, terrain: TerrainType, args: any[]): boolean {
 
-    if (this.terrainToTypeMap[terrain] == Type.UNKNOWN) {
-      if (pokemon.summonData.types == null) return false;
-      pokemon.summonData.types = null;
-      pokemon.updateInfo();
+    if (this.terrainToTypeMap[terrain] == Type.UNKNOWN) { //If no type is given, transform back to original type
+      if (pokemon.summonData.types == null) return false; //If already original type, ability did not activate
+      pokemon.summonData.types = null;                    //Clear any changed type
+      pokemon.updateInfo();                               //Update info to apply change
       pokemon.scene.queueMessage(getPokemonMessage(pokemon, ` transformed\nback into its original type!`));
       return true;
     }
 
-    pokemon.summonData.types = [this.terrainToTypeMap[terrain]]
-    pokemon.updateInfo();
+    pokemon.summonData.types = [this.terrainToTypeMap[terrain]] //Changes type to the specified type based on the record
+    pokemon.updateInfo();                                       //Apply changes
     pokemon.scene.queueMessage(getPokemonMessage(pokemon, ` transformed\ninto the ${Utils.toReadableString(Type[pokemon.getTypes()[0]])} type!`));
     return true;
   }

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -348,6 +348,10 @@ export class Arena {
     return this.terrain?.terrainType || TerrainType.NONE;
   }
 
+  getWeatherType(): WeatherType {
+    return this.weather?.weatherType || WeatherType.NONE;
+  }
+
   getAttackTypeMultiplier(attackType: Type, grounded: boolean): number {
     let weatherMultiplier = 1;
     if (this.weather && !this.weather.isEffectSuppressed(this.scene))

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -30,7 +30,7 @@ import { Weather, WeatherType, getRandomWeatherType, getTerrainBlockMessage, get
 import { TempBattleStat } from "./data/temp-battle-stat";
 import { ArenaTagSide, ArenaTrapTag, MistTag, TrickRoomTag } from "./data/arena-tag";
 import { ArenaTagType } from "./data/enums/arena-tag-type";
-import { CheckTrappedAbAttr, IgnoreOpponentStatChangesAbAttr, PostAttackAbAttr, PostBattleAbAttr, PostDefendAbAttr, PostSummonAbAttr, PostTurnAbAttr, PostWeatherLapseAbAttr, PreSwitchOutAbAttr, PreWeatherDamageAbAttr, ProtectStatAbAttr, RedirectMoveAbAttr, BlockRedirectAbAttr, RunSuccessAbAttr, StatChangeMultiplierAbAttr, SuppressWeatherEffectAbAttr, SyncEncounterNatureAbAttr, applyAbAttrs, applyCheckTrappedAbAttrs, applyPostAttackAbAttrs, applyPostBattleAbAttrs, applyPostDefendAbAttrs, applyPostSummonAbAttrs, applyPostTurnAbAttrs, applyPostWeatherLapseAbAttrs, applyPreStatChangeAbAttrs, applyPreSwitchOutAbAttrs, applyPreWeatherEffectAbAttrs, BattleStatMultiplierAbAttr, applyBattleStatMultiplierAbAttrs, IncrementMovePriorityAbAttr, applyPostVictoryAbAttrs, PostVictoryAbAttr, applyPostBattleInitAbAttrs, PostBattleInitAbAttr, BlockNonDirectDamageAbAttr as BlockNonDirectDamageAbAttr, applyPostKnockOutAbAttrs, PostKnockOutAbAttr, PostBiomeChangeAbAttr, applyPostFaintAbAttrs, PostFaintAbAttr, IncreasePpAbAttr, PostStatChangeAbAttr, applyPostStatChangeAbAttrs, AlwaysHitAbAttr, PreventBerryUseAbAttr, StatChangeCopyAbAttr } from "./data/ability";
+import { CheckTrappedAbAttr, IgnoreOpponentStatChangesAbAttr, PostAttackAbAttr, PostBattleAbAttr, PostDefendAbAttr, PostSummonAbAttr, PostTurnAbAttr, PostWeatherLapseAbAttr, PreSwitchOutAbAttr, PreWeatherDamageAbAttr, ProtectStatAbAttr, RedirectMoveAbAttr, BlockRedirectAbAttr, RunSuccessAbAttr, StatChangeMultiplierAbAttr, SuppressWeatherEffectAbAttr, SyncEncounterNatureAbAttr, applyAbAttrs, applyCheckTrappedAbAttrs, applyPostAttackAbAttrs, applyPostBattleAbAttrs, applyPostDefendAbAttrs, applyPostSummonAbAttrs, applyPostTurnAbAttrs, applyPostWeatherLapseAbAttrs, applyPreStatChangeAbAttrs, applyPreSwitchOutAbAttrs, applyPreWeatherEffectAbAttrs, BattleStatMultiplierAbAttr, applyBattleStatMultiplierAbAttrs, IncrementMovePriorityAbAttr, applyPostVictoryAbAttrs, PostVictoryAbAttr, applyPostBattleInitAbAttrs, PostBattleInitAbAttr, BlockNonDirectDamageAbAttr as BlockNonDirectDamageAbAttr, applyPostKnockOutAbAttrs, PostKnockOutAbAttr, PostBiomeChangeAbAttr, applyPostFaintAbAttrs, PostFaintAbAttr, IncreasePpAbAttr, PostStatChangeAbAttr, applyPostStatChangeAbAttrs, AlwaysHitAbAttr, PreventBerryUseAbAttr, StatChangeCopyAbAttr, PostTerrainChangeAbAttr, applyPostTerrainChangeAbAttrs, applyPostWeatherChangeAbAttrs, PostWeatherChangeAbAttr } from "./data/ability";
 import { Unlockables, getUnlockableName } from "./system/unlockables";
 import { getBiomeKey } from "./field/arena";
 import { BattleType, BattlerIndex, TurnCommand } from "./battle";
@@ -1051,6 +1051,9 @@ export class PostSummonPhase extends PokemonPhase {
     const pokemon = this.getPokemon();
 
     this.scene.arena.applyTags(ArenaTrapTag, pokemon);
+
+    applyPostWeatherChangeAbAttrs(PostWeatherChangeAbAttr, pokemon, this.scene.arena.getWeatherType());
+    applyPostTerrainChangeAbAttrs(PostTerrainChangeAbAttr, pokemon, this.scene.arena.getTerrainType());
     applyPostSummonAbAttrs(PostSummonAbAttr, pokemon).then(() => this.end());
   }
 }


### PR DESCRIPTION
Edge cases where other effects also change type may exhibit some unintended behavior (soak, forest's curse).

Streamlined on summon weather/terrain effects by adding an onTerrainChange and onWeatherChange call when switching in and removing the relevant onSummonEffect so that when coding an ability that activates on specific terrain or weather, you only need to implement the onTerrainChange or onWeatherChange attribute. Added a getWeather() function to arena.ts to simplify it (identical to the preceding getTerrain() function).