### PR TITLE
Evolution item check for g-max form instead of alternate forms (allows sinistea antique form to evolve)

### DIFF
--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -554,10 +554,10 @@ export class EvolutionItemModifierType extends PokemonModifierType implements Ge
     super(Utils.toReadableString(EvolutionItem[evolutionItem]), `Causes certain Pokémon to evolve`, (_type, args) => new Modifiers.EvolutionItemModifier(this, (args[0] as PlayerPokemon).id),
     (pokemon: PlayerPokemon) => {
       if (pokemonEvolutions.hasOwnProperty(pokemon.species.speciesId) && pokemonEvolutions[pokemon.species.speciesId].filter(e => e.item === this.evolutionItem
-          && (!e.condition || e.condition.predicate(pokemon))).length && (pokemon.formIndex == 0))
+          && (!e.condition || e.condition.predicate(pokemon))).length && (pokemon.getFormKey() !== SpeciesFormKey.GIGANTAMAX))
         return null;
       else if (pokemon.isFusion() && pokemonEvolutions.hasOwnProperty(pokemon.fusionSpecies.speciesId) && pokemonEvolutions[pokemon.fusionSpecies.speciesId].filter(e => e.item === this.evolutionItem
-        && (!e.condition || e.condition.predicate(pokemon))).length && (pokemon.fusionFormIndex == 0))
+        && (!e.condition || e.condition.predicate(pokemon))).length && (pokemon.getFusionFormKey() !== SpeciesFormKey.GIGANTAMAX))
         return null;
 
       return PartyUiHandler.NoEffectMessage;


### PR DESCRIPTION
Modifies changes from #636 for compatibility with pokemon with alternate forms that also use evolution items. E.g. sinistea, poltchageist. The alternate forms are treated as formIndex 1 so getFormKey() and comparing against GIGANTAMAX seems more appropriate, see #839.
Since there are no other cases i.e. megas are always final form, eternamax, primal, origin, gignatamax single/rapid all are very limited and only apply to legendaries / one pokemon that don't use evo items I think it's safe to only check GIGANTAMAX (I double checked).
See #839 for main behaviour (antique form can't evolve with chipped pot it just says it will have no effect).

Previous pull changes still working i.e. thunder stone won't apply for g-max pikachu and g-max pikachu fused with other pokemon.

![ScreenRecording2024-05-14at11 41 15-ezgif com-video-to-gif-converter](https://github.com/pagefaultgames/pokerogue/assets/105332964/2fcadace-8446-4655-9aba-954c8f1f4063)
![ScreenRecording2024-05-14at11 47 34-ezgif com-video-to-gif-converter](https://github.com/pagefaultgames/pokerogue/assets/105332964/4b5e8306-eb33-4348-916e-46229917a9b8)

Thunder stone will work on normal evolution item pokemon fused with a g-max pokemon (e.g. normal pikachu x g-max pikachu):


![ScreenRecording2024-05-14at11 52 17-ezgif com-video-to-gif-converter](https://github.com/pagefaultgames/pokerogue/assets/105332964/7bdfe876-1bcf-4137-8d70-215f1425c8ee)

Also testing some other g-max interactions

Polteagist evolution via chipped pot working as intended
![ScreenRecording2024-05-14at12 13 45-ezgif com-video-to-gif-converter](https://github.com/pagefaultgames/pokerogue/assets/105332964/37b81604-a771-42c1-81aa-c9f1e3fa9147)

