### PR TITLE
Fix the error sound effect when changing language

### DIFF
--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -178,11 +178,17 @@ export function setSetting(scene: BattleScene, setting: Setting, value: integer)
             scene.ui.revertMode();
             (scene.ui.getHandler() as SettingsUiHandler).setOptionCursor(Object.values(Setting).indexOf(Setting.Language), 0, true);
           };
-          const changeLocaleHandler = (locale: string) => {
-            i18next.changeLanguage(locale);
-            localStorage.setItem('prLang', locale);
-            cancelHandler();
-            scene.reset(true, false, true);
+          const changeLocaleHandler = (locale: string): boolean => {
+            try {
+              i18next.changeLanguage(locale);
+              localStorage.setItem('prLang', locale);
+              cancelHandler();
+              scene.reset(true, false, true);
+              return true;
+            } catch (error) {
+              console.error('Error changing locale:', error);
+              return false;
+            }
           };
           scene.ui.setOverlayMode(Mode.OPTION_SELECT, {
             options: [


### PR DESCRIPTION
Fixes #832 

The check for the sound effect can be found in _src/ui/abstact-option-select-ui-handler.ts_:
```
      if (option.handler()) {
        if (!option.keepOpen)
          this.clear();
        playSound = !option.overrideSound;
      } else
        ui.playError();
```
Since `changeLocaleHandler()` does not return anything (undefined), it will always resolve to the else statement.

Fix:
- Add boolean return value from changing locale handler