### PR TITLE
Automatically center window vertically when playing on landscape

### DIFF
--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -2,7 +2,7 @@ import SettingsUiHandler from "#app/ui/settings-ui-handler";
 import { Mode } from "#app/ui/ui";
 import i18next from "i18next";
 import BattleScene from "../battle-scene";
-import { hasTouchscreen } from "../touch-controls";
+import { hasTouchscreen, isMobile } from "../touch-controls";
 import { updateWindowType } from "../ui/ui-theme";
 import { PlayerGender } from "./game-data";
 
@@ -167,6 +167,14 @@ export function setSetting(scene: BattleScene, setting: Setting, value: integer)
       const touchControls = document.getElementById('touchControls');
       if (touchControls)
         touchControls.classList.toggle('visible', scene.enableTouchControls);
+      
+      const isLandscape = window.matchMedia("(orientation: landscape)").matches;
+      const appContainer = document.getElementById('app');
+
+      if (!isMobile() && isLandscape && !scene.enableTouchControls) 
+        appContainer.style.alignItems = 'center';
+      else 
+        appContainer.style.alignItems = 'start';
       break;
     case Setting.Vibration:
       scene.enableVibration = settingOptions[setting][value] !== 'Disabled' && hasTouchscreen();


### PR DESCRIPTION
Resolves enhancement #810 

EDIT:

If device is not a mobile device and you'd disable the touch controls, it will center the game window.
- this will be ideal for those playing with tablets along with external controller, and handheld devices like steam deck and the likes
- this will technically not matter on large screen devices like laptops and pc, since height of the game window will fill the screen as much as possible keeping the aspect ratio
- we only want this to happen on landscape orientation

If device is mobile device, this will retain the existing behavior- the window should be at the top of the screen.

**MOBILE DEVICES**
- PORTRAIT
<img width="435" alt="Screenshot 2024-05-15 at 11 08 39 PM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/56605573-9c13-46b7-9d95-fa4dc911c1df">

- LANDSCAPE
<img width="881" alt="Screenshot 2024-05-15 at 11 09 40 PM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/1185f127-0acf-4d55-8fe7-5ca75b3fee7a">

**NON-MOBILE DEVICES**
- With touchscreen capability (please note in screenrecording, it is set to Desktop (touch) to simulate tablet or other handheld devices like steam deck)

https://github.com/pagefaultgames/pokerogue/assets/68144167/bf3294db-f0ad-46d3-a2c6-805b5e78628b

- Without touchscreen capability like pc, this will always center the window
