### PR TITLE
Modify legend gacha to be even split

### DIFF
--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -95,9 +95,14 @@ export function getLegendaryGachaSpeciesForTimestamp(scene: BattleScene, timesta
 
   let ret: Species;
 
+  // 604800000 is the number of miliseconds in one week
+  const weekOffset = Utils.getSunday(new Date(timestamp)).getTime(); // Timestamp of current week
+  const offset = Math.floor(Math.floor(weekOffset / 604800000)/legendarySpecies.length); // Cycle number
+  const index = Math.floor(weekOffset / 604800000)%legendarySpecies.length // Index within cycle
+
   scene.executeWithSeedOffset(() => {
-    ret = Utils.randSeedItem(legendarySpecies);
-  }, Utils.getSunday(new Date(timestamp)).getTime(), EGG_SEED.toString());
+    ret = Phaser.Math.RND.shuffle(legendarySpecies)[index];
+  }, offset, EGG_SEED.toString());
 
   return ret;
 }

--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -95,10 +95,12 @@ export function getLegendaryGachaSpeciesForTimestamp(scene: BattleScene, timesta
 
   let ret: Species;
 
-  // 604800000 is the number of miliseconds in one week
-  const weekOffset = Utils.getSunday(new Date(timestamp)).getTime(); // Timestamp of current week
-  const offset = Math.floor(Math.floor(weekOffset / 604800000)/legendarySpecies.length); // Cycle number
-  const index = Math.floor(weekOffset / 604800000)%legendarySpecies.length // Index within cycle
+  // 86400000 is the number of miliseconds in one day
+  const timeDate = new Date(timestamp);
+  const dayDate = new Date(Date.UTC(timeDate.getUTCFullYear(), timeDate.getUTCMonth(), timeDate.getUTCDate()));
+  const dayTimestamp = timeDate.getTime(); // Timestamp of current week
+  const offset = Math.floor(Math.floor(dayTimestamp / 86400000)/legendarySpecies.length); // Cycle number
+  const index = Math.floor(dayTimestamp / 86400000)%legendarySpecies.length // Index within cycle
 
   scene.executeWithSeedOffset(() => {
     ret = Phaser.Math.RND.shuffle(legendarySpecies)[index];

--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -99,8 +99,8 @@ export function getLegendaryGachaSpeciesForTimestamp(scene: BattleScene, timesta
   const timeDate = new Date(timestamp);
   const dayDate = new Date(Date.UTC(timeDate.getUTCFullYear(), timeDate.getUTCMonth(), timeDate.getUTCDate()));
   const dayTimestamp = timeDate.getTime(); // Timestamp of current week
-  const offset = Math.floor(Math.floor(dayTimestamp / 86400000)/legendarySpecies.length); // Cycle number
-  const index = Math.floor(dayTimestamp / 86400000)%legendarySpecies.length // Index within cycle
+  const offset = Math.floor(Math.floor(dayTimestamp / 86400000) / legendarySpecies.length); // Cycle number
+  const index = Math.floor(dayTimestamp / 86400000) % legendarySpecies.length // Index within cycle
 
   scene.executeWithSeedOffset(() => {
     ret = Phaser.Math.RND.shuffle(legendarySpecies)[index];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -116,13 +116,6 @@ export function randSeedEasedWeightedItem<T>(items: T[], easingFunction: string 
   return items[Math.floor(easedValue * items.length)];
 }
 
-export function getSunday(date: Date): Date {
-  const day = date.getUTCDay();
-  const diff = date.getUTCDate() - day;
-  const newDate = new Date(date.setUTCDate(diff));
-  return new Date(Date.UTC(newDate.getUTCFullYear(), newDate.getUTCMonth(), newDate.getUTCDate()));
-}
-
 export function getFrameMs(frameCount: integer): integer {
   return Math.floor((1 / 60) * 1000 * frameCount);
 }


### PR DESCRIPTION
Modifies the functionality of the legendary gacha banner to be evenly split between all possible legends, as opposed to a 64 length cycle. This works by creating super cycles where it goes through a shuffled list exactly once before reshuffling and restarting, so it is still random, but each 25 week cycle will always contain every legend exactly once.

Due to the limited seed space this is still technically going to loop, but instead of looping every 64 banners it will loop every 1638400 banners, or specifically every 65536 super cycles which seems more than sufficient.

This is probably retroactive to any eggs anyone currently has but hasn't hatched, but so was the change earlier today to the banner so I'm not sure that's a high concern.