### PR TITLE
Minor Adjustment to French pokemon-stat.ts

### DIFF
--- a/src/locales/fr/pokemon-stat.ts
+++ b/src/locales/fr/pokemon-stat.ts
@@ -7,9 +7,9 @@ export const pokemonStat: SimpleTranslationEntries = {
     "ATKshortened": "Atq",
     "DEF": "Défense",
     "DEFshortened": "Déf",
-    "SPATK": "Atq. Spé",
+    "SPATK": "Atq. Spé.",
     "SPATKshortened": "AtqSp",
-    "SPDEF": "Déf. Spé",
+    "SPDEF": "Déf. Spé.",
     "SPDEFshortened": "DéfSp",
     "SPD": "Vitesse",
     "SPDshortened": "Vit"


### PR DESCRIPTION
Added dots after "Atq. Spé." and "Déf. Spé." , as it is in Scarlet and Violet
![image](https://github.com/pagefaultgames/pokerogue/assets/2070109/4313c272-e524-4312-9bd2-2eafc4d899ed) 
![image](https://github.com/pagefaultgames/pokerogue/assets/2070109/3a3e8263-1a6f-4d18-9562-b0318d9124de)
