### PR TITLE
meta charset should be ordered before any elements containing text

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+	<meta charset="UTF-8" />
 	<title>PokéRogue</title>
 	<meta name="description" content="A Pokémon fangame heavily inspired by the roguelite genre. Battle endlessly while gathering stacking items, exploring many different biomes, and reaching Pokémon stats you never thought possible." />
 	<meta name="theme-color" content="#da3838" />
@@ -12,7 +13,6 @@
 	<link rel="apple-touch-icon" href="./logo512.png" />
 	<link rel="shortcut icon" type="image/png" href="./logo512.png" />
 	<link rel="canonical" href="https://pokerogue.net" />
-	<meta charset="UTF-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 	<style type="text/css">
 		@font-face {


### PR DESCRIPTION
Very minor ordering change - just to prevent "é" not being shown correctly for some people