### PR TITLE
Fixes status immunity abilities not showing on UI

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -1755,7 +1755,7 @@ export class StatusEffectImmunityAbAttr extends PreSetStatusAbAttr {
   }
 
   getTriggerMessage(pokemon: Pokemon, abilityName: string, ...args: any[]): string {
-    return getPokemonMessage(pokemon, `'s ${abilityName}\nprevents ${this.immuneEffects.length ? getStatusEffectDescriptor(args[0] as StatusEffect) : 'status problems'}!`);
+    return getPokemonMessage(pokemon, `'s ${abilityName}\nprevents ${this.immuneEffects.length ? getStatusEffectDescriptor(this.immuneEffects[0]) : 'status problems'}!`);
   }
 }
 
@@ -2825,7 +2825,7 @@ export function applyPostStatChangeAbAttrs(attrType: { new(...args: any[]): Post
 export function applyPreSetStatusAbAttrs(attrType: { new(...args: any[]): PreSetStatusAbAttr },
   pokemon: Pokemon, effect: StatusEffect, cancelled: Utils.BooleanHolder, ...args: any[]): Promise<void> {
   const simulated = args.length > 1 && args[1];
-  return applyAbAttrsInternal<PreSetStatusAbAttr>(attrType, pokemon, (attr, passive) => attr.applyPreSetStatus(pokemon, passive, effect, cancelled, args), args, false, false, !simulated);
+  return applyAbAttrsInternal<PreSetStatusAbAttr>(attrType, pokemon, (attr, passive) => attr.applyPreSetStatus(pokemon, passive, effect, cancelled, args), args, false, false, simulated);
 }
 
 export function applyPreApplyBattlerTagAbAttrs(attrType: { new(...args: any[]): PreApplyBattlerTagAbAttr },


### PR DESCRIPTION
Accidentally discarded my [previous commit](https://github.com/pagefaultgames/pokerogue/pull/818), reopening with Xavion's changes.

Status abilities ( Limber, Insomnia, Immunity, Magma Armour, Water Veil, Vital Spirit, Leaf Guard, Sweet Veil, Water Bubble, Pastel Veil, Thermal Exchange, Purifying Salt ) will now show on the left ability/passive pane when they successfully immune a status, and correctly send their chat box message. [Example](https://imgur.com/aJ5aMSj)

The change in the applyPreSetStatusAbAttrs removes the !simulated arg so that the message doesn't get suppressed by .attr.
The change in getTriggerMessage is because after getting the trigger message to actually show, turns out it never worked and just produced undefined. Instead it accesses the immuneEffects array.

One bug still remains in the sleep prevention abilities, as yawn is handled by BattlerTagImmunityAbAttr which would need another fix to properly send a chat message.