### PR TITLE
Cave's Beach link changed to Lake

### DIFF
--- a/src/data/biomes.ts
+++ b/src/data/biomes.ts
@@ -48,7 +48,7 @@ export const biomeLinks: BiomeLinks = {
   [Biome.SEABED]: [ Biome.CAVE, [ Biome.VOLCANO, 4 ] ],
   [Biome.MOUNTAIN]: [ Biome.VOLCANO, [ Biome.WASTELAND, 3 ] ],
   [Biome.BADLANDS]: [ Biome.DESERT, Biome.MOUNTAIN ],
-  [Biome.CAVE]: [ Biome.BADLANDS, Biome.BEACH ],
+  [Biome.CAVE]: [ Biome.BADLANDS, Biome.LAKE ],
   [Biome.DESERT]: Biome.RUINS,
   [Biome.ICE_CAVE]: Biome.SNOWY_FOREST,
   [Biome.MEADOW]: [ Biome.PLAINS, [ Biome.FAIRY_CAVE, 2 ] ],


### PR DESCRIPTION
Replacing Cave's Beach link with Lake would weaken the "water loop", a situation where players get continually routed back to Beach, leading to frustration. Lake is a crossroads biome that connects to much of the rest of the game, while still connecting to Beach, making it not a drastic detour.

Infernal Vulpix simulated a hypothetical 10k wave endless run for me to see the difference this change would have on biome frequencies. Odds is old odds, Alt is odds with the link changed to Lake:

```
                   Odds      Alt
Abyss              1.98%     2.40%
Badlands           3.57%     3.46%
Beach              6.30%     4.06%
Cave               5.87%     5.91%
Construction Site  3.90%     4.83%
Desert             1.70%     1.70%
Dojo               2.05%     2.58%
Factory            2.03%     2.57%
Fairy Cave         0.86%     0.59%
Forest             5.79%     5.64%
Grass              2.12%     2.48%
Graveyard          2.03%     2.39%
Ice Cave           4.00%     2.68%
Island             0.79%     0.53%
Jungle             2.80%     2.72%
Laboratory         0.13%     0.13%
Lake               3.37%     6.26%
Meadow             2.93%     2.74%
Metropolis         2.33%     2.55%
Mountain           2.86%     2.40%
Plains             5.96%     6.94%
Power Plant        2.06%     2.63%
Ruins              2.51%     2.59%
Sea                6.16%     4.07%
Seabed             2.90%     2.04%
Slum               2.58%     2.67%
Snowy Forest       3.79%     2.60%
Space              0.37%     0.41%
Swamp              3.79%     4.64%
Tall Grass         4.18%     4.73%
Temple             2.98%     3.06%
Town               0.00%     0.00%
Volcano            2.58%     2.29%
Wasteland          0.72%     0.72%
End                2.00%     2.00%
```