### PR TITLE
Fix tinted caught icon false positive

### DIFF
--- a/src/ui/battle-info.ts
+++ b/src/ui/battle-info.ts
@@ -268,8 +268,8 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
       // If the opposing Pokemon only has 1 ability and is using the hidden ability, it should have the same
       // behavior if it had 2 abilities so it is set to 2 so it lines up with the math checking the proper
       // hidden ability abilityAttr which is 4
-      const opponentPokemonOneAbility = (pokemon.species.getAbilityCount() == 2);
-      const opponentPokemonAbilityIndex = (pokemon.abilityIndex === 1 && opponentPokemonOneAbility) ? 2 : pokemon.abilityIndex;
+      const opponentPokemonOneNormalAbility = (pokemon.species.getAbilityCount() == 2);
+      const opponentPokemonAbilityIndex = (opponentPokemonOneNormalAbility && pokemon.abilityIndex === 1) ? 2 : pokemon.abilityIndex;
       const opponentPokemonAbilityAttr = Math.pow(2, opponentPokemonAbilityIndex);
 
       const rootFormHasHiddenAbility = pokemon.scene.gameData.starterData[pokemon.species.getRootSpeciesId()].abilityAttr & opponentPokemonAbilityAttr;

--- a/src/ui/battle-info.ts
+++ b/src/ui/battle-info.ts
@@ -265,9 +265,11 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
       // Check if Player owns all genders and forms of the Pokemon
       const missingDexAttrs = ((dexEntry.caughtAttr & opponentPokemonDexAttr) < opponentPokemonDexAttr); 
 
-      // If the opposing Pokemon only has 1 ability and is using the hidden ability, it should have the same
-      // behavior if it had 2 abilities so it is set to 2 so it lines up with the math checking the proper
-      // hidden ability abilityAttr which is 4
+      /**
+       * If the opposing Pokemon only has 1 normal ability and is using the hidden ability it should have the same behavior
+       * if it had 2 normal abilities. This code checks if that is the case and uses the correct opponent Pokemon abilityIndex (2)
+       * for calculations so it aligns with where the hidden ability is stored in the starter data's abilityAttr (4)
+       */
       const opponentPokemonOneNormalAbility = (pokemon.species.getAbilityCount() == 2);
       const opponentPokemonAbilityIndex = (opponentPokemonOneNormalAbility && pokemon.abilityIndex === 1) ? 2 : pokemon.abilityIndex;
       const opponentPokemonAbilityAttr = Math.pow(2, opponentPokemonAbilityIndex);

--- a/src/ui/battle-info.ts
+++ b/src/ui/battle-info.ts
@@ -8,7 +8,6 @@ import BattleScene from '../battle-scene';
 import { Type, getTypeRgb } from '../data/type';
 import { getVariantTint } from '#app/data/variant';
 import { BattleStat } from '#app/data/battle-stat';
-import { DexAttr } from '#app/system/game-data.js';
 
 const battleStatOrder = [ BattleStat.ATK, BattleStat.DEF, BattleStat.SPATK, BattleStat.SPDEF, BattleStat.ACC, BattleStat.EVA, BattleStat.SPD ];
 

--- a/src/ui/battle-info.ts
+++ b/src/ui/battle-info.ts
@@ -270,7 +270,7 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
        * if it had 2 normal abilities. This code checks if that is the case and uses the correct opponent Pokemon abilityIndex (2)
        * for calculations so it aligns with where the hidden ability is stored in the starter data's abilityAttr (4)
        */
-      const opponentPokemonOneNormalAbility = (pokemon.species.getAbilityCount() == 2);
+      const opponentPokemonOneNormalAbility = (pokemon.species.getAbilityCount() === 2);
       const opponentPokemonAbilityIndex = (opponentPokemonOneNormalAbility && pokemon.abilityIndex === 1) ? 2 : pokemon.abilityIndex;
       const opponentPokemonAbilityAttr = Math.pow(2, opponentPokemonAbilityIndex);
 


### PR DESCRIPTION
Issue [here](https://github.com/pagefaultgames/pokerogue/issues/883)

Normally a Pokemon has their hidden ability as abilityIndex 2. However Pokemon with only 1 ability have their hidden ability with abilityIndex 1 instead of 2. This causes a problem when trying to compare the Pokemon's abilityIndex with the starter's abilityAttr where the hidden ability is stored as 4, causing a dark tinted Pokeball to appear even if the player owns the hidden ability.

I added a check so that if a Pokemon only has 1 ability has a hidden ability then it will be treated as being 2 instead of 1. I also went through and renamed some variables to hopefully make the logic a lot more clear and readable.

[Before fix](https://cdn.discordapp.com/attachments/1240069508127789117/1240070681236865155/image.png?ex=66453951&is=6643e7d1&hm=837211f91a5ed1b9d3ee1ee742156a0be6ff38c8ab56db64780081613dc3497f&)

[After fix](https://cdn.discordapp.com/attachments/1240069508127789117/1240108420825354281/image.png?ex=66455c77&is=66440af7&hm=bf4914e8d3c972ab41f279de6aeb30cb57f229bfb5617ac33f3be14ac9510865&)