### PR TITLE
Fixes toxic spikes poison damage turn 0

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2054,8 +2054,7 @@ export class TurnStartPhase extends FieldPhase {
       this.scene.pushPhase(new WeatherEffectPhase(this.scene, this.scene.arena.weather));
 
     for (let o of order) {
-      if (field[o].status && field[o].status.isPostTurn())
-        this.scene.pushPhase(new PostTurnStatusEffectPhase(this.scene, o));
+      this.scene.pushPhase(new PostTurnStatusEffectPhase(this.scene, o));
     }
 
     this.scene.pushPhase(new TurnEndPhase(this.scene));
@@ -2985,8 +2984,6 @@ export class ObtainStatusEffectPhase extends PokemonPhase {
         pokemon.updateInfo(true);
         new CommonBattleAnim(CommonAnim.POISON + (this.statusEffect - 1), pokemon).play(this.scene, () => {
           this.scene.queueMessage(getPokemonMessage(pokemon, getStatusEffectObtainText(this.statusEffect, this.sourceText)));
-          if (pokemon.status.isPostTurn())
-            this.scene.pushPhase(new PostTurnStatusEffectPhase(this.scene, this.battlerIndex));
           this.end();
         });
         return;


### PR DESCRIPTION
Very simple fix for toxic spikes turn 0 damage bug. Fixes #830 
Bug description: If toxic spikes were out and a new pokemon encounter happened, they would take poison damage before battle start.
Fix: Instead of adding the post-turn status phase when adding status, just check for it at the end of each turn so there are no situations where it gets added at the wrong time, or added multiple times (e.g. toxic -> heal bell -> toxic causing 2 procs)

https://github.com/pagefaultgames/pokerogue/assets/107140457/faeef013-eedf-4d9d-890f-bbf5e1ba4665

