### PR TITLE
DE Correct a translation due to misleading token and source string

### DIFF
--- a/src/locales/de/battle.ts
+++ b/src/locales/de/battle.ts
@@ -43,7 +43,7 @@ export const battle: SimpleTranslationEntries = {
   "noEscapeTrainer": "Du kannst nicht\naus einem Trainerkampf fliehen!",
   "noEscapePokemon": "{{pokemonName}}'s {{moveName}}\nverhindert {{escapeVerb}}!",
   "runAwaySuccess": "Du bist entkommen!",
-  "runAwayCannotEscape": 'Flucht unmöglich!',
+  "runAwayCannotEscape": 'Flucht gescheitert!',
   "escapeVerbSwitch": "auswechseln",
   "escapeVerbFlee": "flucht",
   "skipItemQuestion": "Bist du sicher, dass du kein Item nehmen willst?",


### PR DESCRIPTION
I started to notice that, you can escape from some Pokemon Battles. Therefore saying that it is impossible _(which it currently does)_ is wrong.


The reason why I translated it like so, is because the original string says, that you _can't_ escape. Which is wrong.

The original Pokemon game says, ``BTL_STRID_STD_EscapeFail``

> You couldn’t get away!

And the corresponding German Translation to it is.

> Flucht gescheitert!

&nbsp;

**The current English one is from** ``BTL_STRID_STD_EscapeProhibit``, but since you **can** escape. "Prohibit" is wrong.

&nbsp;

I could put the Localization Dump from Pokemon Scarlet and Violet on a GitHub repository, it's just the question whether Pokemon and affiliated companies care whether that data is on a GitHub repository or not.

&nbsp;

I do **suggest** changing the English string for it as well. Or switch the tokens. I am not sure how hard it is to set-up the repository locally to test changes.

I also do not know how I would "summon" this String in a local test. Other than using ``this.scene``.

&nbsp;

I'd also like to ask, if it is intentional that there's barely any comments around the TypeScript files.

&nbsp;

Further feedback about the translations. Mainly, translation is only important for anything inherited from the Pokemon games. Meaning, Pokemon Names, their Description, Moves and etc.

The _**reason**_ for that is because of memory. Those who played and watched Pokemon in one language, have all the Names memorized for one language. If that language doesn't exist, it's a very crucial experience. I believe Pokemon translated Moves and Names, because it's more than just a translation, the translation fits the language's environment giving the translation way more sense.

&nbsp;

If adding support for more translation strings, I'd only prioritize things inherited from Pokemon games, over the customizable things, or adding separate settings. One where you can pick a language for the "Core" (Pokemon related strings), and one for the Custom stuff _(Modifiers Reroll stuff, Tutorial, etc.)_

The _**reason**_ for that is... wrong translations. The original language has their meanings wrapped around. If those are not translated right, it will appear wrong, and that's bad for quality.