### PR TITLE
Fix False Trigger of Corrosion

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2824,7 +2824,7 @@ export function applyPostStatChangeAbAttrs(attrType: { new(...args: any[]): Post
 
 export function applyPreSetStatusAbAttrs(attrType: { new(...args: any[]): PreSetStatusAbAttr },
   pokemon: Pokemon, effect: StatusEffect, cancelled: Utils.BooleanHolder, ...args: any[]): Promise<void> {
-  const simulated = args[0];
+  const simulated = args[0]; // Used to mark the call as simulated or not
   return applyAbAttrsInternal<PreSetStatusAbAttr>(attrType, pokemon, (attr, passive) => attr.applyPreSetStatus(pokemon, passive, effect, cancelled, args), args, false, false, simulated);
 }
 

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -1736,6 +1736,30 @@ export class PreSetStatusAbAttr extends AbAttr {
   }
 }
 
+/**
+ * Ignores the type immunity to Status Effects of the defender if the defender is of a certain type
+ */
+export class IgnoreTypeStatusEffectImmunityAbAttr extends PreSetStatusAbAttr {
+  private statusEffect: StatusEffect[];
+  private defenderType: Type[];
+
+  constructor(statusEffect: StatusEffect[], defenderType: Type[]) {
+    super(true);
+
+    this.statusEffect = statusEffect;
+    this.defenderType = defenderType;
+  }
+
+  applyPreSetStatus(pokemon: Pokemon, passive: boolean, effect: StatusEffect,cancelled: Utils.BooleanHolder, args: any[]): boolean {
+    if (this.statusEffect.includes(effect) && this.defenderType.includes(args[1] as Type)) {
+      cancelled.value = true;
+      return true;
+    }
+
+    return false;
+  }
+}
+
 export class StatusEffectImmunityAbAttr extends PreSetStatusAbAttr {
   private immuneEffects: StatusEffect[];
 
@@ -2666,30 +2690,6 @@ export class IgnoreTypeImmunityAbAttr extends AbAttr {
   }
 }
 
-/**
- * Ignores the type immunity to Status Effects of the defender if the defender is of a certain type
- */
-export class IgnoreTypeStatusEffectImmunityAbAttr extends AbAttr {
-  private statusEffect: StatusEffect[];
-  private defenderType: Type[];
-
-  constructor(statusEffect: StatusEffect[], defenderType: Type[]) {
-    super(true);
-
-    this.statusEffect = statusEffect;
-    this.defenderType = defenderType;
-  }
-
-  apply(pokemon: Pokemon, passive: boolean, cancelled: Utils.BooleanHolder, args: any[]): boolean {
-    if (this.statusEffect.includes(args[0] as StatusEffect) && this.defenderType.includes(args[1] as Type)) {
-      cancelled.value = true;
-      return true;
-    }
-
-    return false;
-  }
-}
-
 function applyAbAttrsInternal<TAttr extends AbAttr>(attrType: { new(...args: any[]): TAttr },
   pokemon: Pokemon, applyFunc: AbAttrApplyFunc<TAttr>, args: any[], isAsync: boolean = false, showAbilityInstant: boolean = false, quiet: boolean = false, passive: boolean = false): Promise<void> {
   return new Promise(resolve => {
@@ -2824,8 +2824,8 @@ export function applyPostStatChangeAbAttrs(attrType: { new(...args: any[]): Post
 
 export function applyPreSetStatusAbAttrs(attrType: { new(...args: any[]): PreSetStatusAbAttr },
   pokemon: Pokemon, effect: StatusEffect, cancelled: Utils.BooleanHolder, ...args: any[]): Promise<void> {
-  const simulated = args.length > 1 && args[1];
-  return applyAbAttrsInternal<PreSetStatusAbAttr>(attrType, pokemon, (attr, passive) => attr.applyPreSetStatus(pokemon, passive, effect, cancelled, args), args, false, false, !simulated);
+  const simulated = args[0];
+  return applyAbAttrsInternal<PreSetStatusAbAttr>(attrType, pokemon, (attr, passive) => attr.applyPreSetStatus(pokemon, passive, effect, cancelled, args), args, false, false, simulated);
 }
 
 export function applyPreApplyBattlerTagAbAttrs(attrType: { new(...args: any[]): PreApplyBattlerTagAbAttr },

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2052,6 +2052,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     switch (effect) {
       case StatusEffect.POISON:
       case StatusEffect.TOXIC:
+        console.log('checking poison immunity', this.name, types, sourcePokemon?.name, sourcePokemon?.id)
         // Check if the Pokemon is immune to Poison/Toxic or if the source pokemon is canceling the immunity
         let poisonImmunity = types.map(defType => {
           // Check if the Pokemon is not immune to Poison/Toxic
@@ -2061,7 +2062,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
           // Check if the source Pokemon has an ability that cancels the Poison/Toxic immunity
           const cancelImmunity = new Utils.BooleanHolder(false);
           if (sourcePokemon) {
-            applyAbAttrs(IgnoreTypeStatusEffectImmunityAbAttr, sourcePokemon, cancelImmunity, effect, defType);
+            applyPreSetStatusAbAttrs(IgnoreTypeStatusEffectImmunityAbAttr, sourcePokemon, effect, cancelImmunity, quiet, defType);
             if (cancelImmunity.value)
               return false;
           }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2052,7 +2052,6 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     switch (effect) {
       case StatusEffect.POISON:
       case StatusEffect.TOXIC:
-        console.log('checking poison immunity', this.name, types, sourcePokemon?.name, sourcePokemon?.id)
         // Check if the Pokemon is immune to Poison/Toxic or if the source pokemon is canceling the immunity
         let poisonImmunity = types.map(defType => {
           // Check if the Pokemon is not immune to Poison/Toxic


### PR DESCRIPTION
Issue: Corrosion triggers when moves use getTargetBenefitScore even if the move is not actually used by the opponent.

Fix:
Moved IgnoreTypeStatusEffectImunity to extend from PreSetStatusAbAttr instead of AbAttr so I can use the existing implemented quiet arg.

Extras:
I changed simulated to just use the first arg which is how the current checks pass the quiet arg.

I was able to remove effect from args and have it as a set parameter being passed


https://github.com/pagefaultgames/pokerogue/assets/9848614/0bfc926d-9ddb-4915-ae05-e78a9e989a5d

