### PR TITLE
Change seed flare stat drop to 2 stages

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5650,7 +5650,7 @@ export function initMoves() {
       .attr(StatusEffectAttr, StatusEffect.SLEEP)
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new AttackMove(Moves.SEED_FLARE, Type.GRASS, MoveCategory.SPECIAL, 120, 85, 5, 40, 0, 4)
-      .attr(StatChangeAttr, BattleStat.SPDEF, -1),
+      .attr(StatChangeAttr, BattleStat.SPDEF, -2),
     new AttackMove(Moves.OMINOUS_WIND, Type.GHOST, MoveCategory.SPECIAL, 60, 100, 5, 10, 0, 4)
       .attr(StatChangeAttr, [ BattleStat.ATK, BattleStat.DEF, BattleStat.SPATK, BattleStat.SPDEF, BattleStat.SPD ], 1, true)
       .windMove(),


### PR DESCRIPTION
Seed flare is supposed to lower the target's Special Defense stat by two stages, but only lowers by one right now. 
https://bulbapedia.bulbagarden.net/wiki/Seed_Flare_(move)