### PR TITLE
Fix Entry Hazard Miss

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -55,6 +55,7 @@ export enum MoveTarget {
   /** {@link https://bulbapedia.bulbagarden.net/wiki/Category:Moves_that_target_all_Pok%C3%A9mon Moves that target all Pokemon} */
   ALL,
   USER_SIDE,
+  /** {@link https://bulbapedia.bulbagarden.net/wiki/Category:Entry_hazard-creating_moves Entry hazard-creating moves} */
   ENEMY_SIDE,
   BOTH_SIDES,
   PARTY

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2588,7 +2588,8 @@ export class MoveEffectPhase extends PokemonPhase {
   }
 
   hitCheck(target: Pokemon): boolean {
-    if (this.move.getMove().moveTarget === MoveTarget.USER)
+    // Moves targeting the user and entry hazards can't miss
+    if ([MoveTarget.USER, MoveTarget.ENEMY_SIDE].includes(this.move.getMove().moveTarget))
       return true;
 
     const user = this.getUserPokemon();


### PR DESCRIPTION
Made Entry Hazards bypass the accuracy check as they cannot miss a target. There's still one more bug to fix with this but it requires way more code changes. This change needed to be done anyway, so I'm getting it out first.

https://github.com/pagefaultgames/pokerogue/assets/13838608/96c02cf7-fd6f-4066-9a45-1397469d9d8d

## These are really just sanity checks, nothing in the code affected this anyway

https://github.com/pagefaultgames/pokerogue/assets/13838608/b4109773-d443-4def-b743-0e8af4aa4f69

https://github.com/pagefaultgames/pokerogue/assets/13838608/e441dc1b-4a24-4023-8c36-2f29b5bf1358