### PR TITLE
Move Ingrain Fix For All Ghosts

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -15,7 +15,6 @@ import { TerrainType } from "./terrain";
 import { WeatherType } from "./weather";
 import { BattleStat } from "./battle-stat";
 import { allAbilities } from "./ability";
-import { Species } from "./enums/species";
 
 export enum BattlerTagLapseType {
   FAINT,
@@ -120,9 +119,8 @@ export class TrappedTag extends BattlerTag {
   canAdd(pokemon: Pokemon): boolean {
     const isGhost = pokemon.isOfType(Type.GHOST);
     const isTrapped = pokemon.getTag(BattlerTagType.TRAPPED);
-    const isAllowedGhostType = pokemon.species.speciesId === Species.PHANTUMP || pokemon.species.speciesId === Species.TREVENANT;
 
-    return !isTrapped && (!isGhost || isAllowedGhostType);
+    return !isTrapped && !isGhost;
   }
 
   onAdd(pokemon: Pokemon): void {
@@ -503,9 +501,24 @@ export class HelpingHandTag extends BattlerTag {
   }
 }
 
+/**
+ * Applies the Ingrain tag to a pokemon
+ * @extends TrappedTag
+ */
 export class IngrainTag extends TrappedTag {
   constructor(sourceId: integer) {
     super(BattlerTagType.INGRAIN, BattlerTagLapseType.TURN_END, 1, Moves.INGRAIN, sourceId);
+  }
+
+  /**
+   * Check if the Ingrain tag can be added to the pokemon
+   * @param pokemon {@linkcode Pokemon} The pokemon to check if the tag can be added to
+   * @returns boolean True if the tag can be added, false otherwise
+   */
+  canAdd(pokemon: Pokemon): boolean {
+    const isTrapped = pokemon.getTag(BattlerTagType.TRAPPED);
+
+    return !isTrapped;
   }
 
   lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {


### PR DESCRIPTION
### Issue
Ingrain can only be used by Trevenant and Phantump because they are hardcoded. This move should be useable by all Ghost types.
Since we have Splicing, technically any pokemon can learn any move.

### What this fix does
Sets Class TrappedTag, method canAdd back to the original of checking if pokemon is not trapped and not ghost instead of having an override for two specific pokemon
Adds method override canAdd to the IngrainTag and it just checks if the pokemon is already trapped since it should be applicable to any pokemon regardless of type.

### What this fix does not do
This does not trap ghost types when they use ingrain. 
PR #998 already added a check to switching pokemon if the trapped tag is applied by move Ingrain and the pokemon switching is ghost.