### PR TITLE
Make the settings display the current set language for the Language Setting

### DIFF
--- a/src/ui/settings-ui-handler.ts
+++ b/src/ui/settings-ui-handler.ts
@@ -6,6 +6,7 @@ import { Mode } from "./ui";
 import UiHandler from "./ui-handler";
 import { addWindow } from "./ui-theme";
 import {Button} from "../enums/buttons";
+import i18next from "i18next";
 
 export default class SettingsUiHandler extends UiHandler {
   private settingsContainer: Phaser.GameObjects.Container;
@@ -67,6 +68,26 @@ export default class SettingsUiHandler extends UiHandler {
       this.optionValueLabels.push(settingOptions[Setting[setting]].map((option, o) => {
         const valueLabel = addTextObject(this.scene, 0, 0, option, settingDefaults[Setting[setting]] === o ? TextStyle.SETTINGS_SELECTED : TextStyle.WINDOW);
         valueLabel.setOrigin(0, 0);
+
+        // Current the game reloads
+        // this is ideal to show the current set Language, right here
+        if ((Setting[setting] == Setting.Language) && (valueLabel.text == "English")) {
+          var tempLang = i18next.language;
+
+          const displayNames = (() => {
+            try {
+              return new Intl.DisplayNames([tempLang], { type: 'language' });
+            } catch(err) {
+              console.warn(err);
+              // Fallback to English.
+              tempLang = "en";
+              return new Intl.DisplayNames([tempLang], { type: 'language' });
+            }})();
+
+          // Display current set language, translated in the current language.
+          // Except zH, that one mismatches with DisplayNames.
+          valueLabel.text = displayNames.of(tempLang);
+        }
 
         this.optionsContainer.add(valueLabel);
 


### PR DESCRIPTION
![image](https://github.com/pagefaultgames/pokerogue/assets/12023782/f93f82b9-5c37-4a22-84dc-87884b184366)

This is what the change looks like. If I set my game to German, it shows it as German in German.


**Currently**, it just shows English. And to be honest, while I was exploring the source code for the best location to change it... well, it's a bit of a unorganized setup for this specific setting.


I implemented this inside the ``setup()``, since the game reloads anyways, making it ideal to add this in. For some reason I decided to put ``i18next.language || "en"`` incase someone manually changes ``i18next.language`` and messes up, but whatever, to a regular user, this would never happen.

Then it converts ``"en"`` or whatever to the set language, hopefully.

But then I ended up changing this with **try**, **catch**, because when I tested languages such as ``zH_CN``, these somehow have like something after it, and whatever ``Init.DisplayNames`` does, has it different.

But since there are some other issues, with that in pokemon species...

![image](https://github.com/pagefaultgames/pokerogue/assets/12023782/d49aaf93-db03-4cb4-b98f-094a4092841a)


And now it will just show the current set language, except for one. Because there's more languages that have that issue where the locale IDs aren't the same. I don't know if i18next has a implementation of DisplayNames as well.


**If it errors**, it will just use "en" and show "English".