### PR TITLE
Fix Move Sparkly Swirl Cure Status

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6483,7 +6483,8 @@ export function initMoves() {
     new AttackMove(Moves.FREEZY_FROST, Type.ICE, MoveCategory.SPECIAL, 100, 90, 10, -1, 0, 7)
       .attr(ResetStatsAttr),
     new AttackMove(Moves.SPARKLY_SWIRL, Type.FAIRY, MoveCategory.SPECIAL, 120, 85, 5, -1, 0, 7)
-      .attr(PartyStatusCureAttr, null, Abilities.NONE),
+      .attr(PartyStatusCureAttr, null, Abilities.NONE)
+      .target(MoveTarget.PARTY),
     new AttackMove(Moves.VEEVEE_VOLLEY, Type.NORMAL, MoveCategory.PHYSICAL, -1, -1, 20, -1, 0, 7)
       .attr(FriendshipPowerAttr),
     new AttackMove(Moves.DOUBLE_IRON_BASH, Type.STEEL, MoveCategory.PHYSICAL, 60, 100, 5, 30, 0, 7)


### PR DESCRIPTION
### Description
This PR fixes sparkly swirl not curing the status of the party discovered in [#bug-report-chat](https://discord.com/channels/1125469663833370665/1125894949020381285/1241099819078914180)

per [Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Sparkly_Swirl_(move))
> Sparkly Swirl deals damage and cures the user, all Pokémon in the user's party, and the user's allies, of all non-volatile status conditions (sleep, poison, paralysis, freeze, and burn). 

Using #238  as a reference, it seems the move is just missing the `.target(MoveTarget.PARTY),` line

### Before Fix
Notice that after using Sparkly Swirl, Eevee is still paralyzed.

https://github.com/pagefaultgames/pokerogue/assets/146129103/7cc1083f-3f8c-4f6c-a9b7-7c163c6c77a3

### After Fix
After using Sparkly Swirl, Eevee and her party are no longer paralyzed.

https://github.com/pagefaultgames/pokerogue/assets/146129103/7e2ab457-2a5c-4063-ae35-fa171e10336a

