### PR TITLE
Calculate recoil damage correctly

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -779,8 +779,8 @@ export class RecoilAttr extends MoveEffectAttr {
     if (cancelled.value)
       return false;
 
-    const recoilDamage = Math.max(Math.floor((!this.useHp ? user.turnData.damageDealt : user.getMaxHp()) * this.damageRatio),
-      user.turnData.damageDealt ? 1 : 0);
+    const recoilDamage = Math.max(Math.floor((!this.useHp ? user.turnData.currDamageDealt : user.getMaxHp()) * this.damageRatio),
+      user.turnData.currDamageDealt ? 1 : 0);
     if (!recoilDamage)
       return false;
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1625,6 +1625,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
                 this.scene.gameData.gameStats.highestDamage = damage.value;
             }
             source.turnData.damageDealt += damage.value;
+            source.turnData.currDamageDealt = damage.value;
             this.battleData.hitCount++;
             const attackResult = { move: move.id, result: result as DamageResult, damage: damage.value, critical: isCritical, sourceId: source.id };
             this.turnData.attacksReceived.unshift(attackResult);
@@ -3347,6 +3348,7 @@ export class PokemonTurnData {
   public hitCount: integer;
   public hitsLeft: integer;
   public damageDealt: integer = 0;
+  public currDamageDealt: integer = 0;
   public damageTaken: integer = 0;
   public attacksReceived: AttackMoveResult[] = [];
 }


### PR DESCRIPTION
As #1048 highlighted recoil damage isn't calculated correctly. Currently the recoil damage is a certain % of the total damage the user has dealt during the entire turn, so when recoil is activated within the same turn in which damage was already dealt then recoil damage is higher than expected. This change makes it so that recoil damage takes only into account the damage dealt by the recoil move.