### PR TITLE
[QoL] Make IV-Scanner less annoying, by giving it a toggle and the ability to scan stuff at any time by clicking on the icon

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -4828,6 +4828,12 @@ export class ScanIvsPhase extends PokemonPhase {
 
     const pokemon = this.getPokemon();
 
+    const ivScannerModifier = this.scene.findModifier(m => m instanceof IvScannerModifier) as IvScannerModifier;
+
+    // Only show if auto-prompt is enabled.
+    if (!ivScannerModifier.shouldAutoPrompt)
+      return this.end()
+
     this.scene.ui.showText(i18next.t('battle:ivScannerUseQuestion', { pokemonName: pokemon.name }), null, () => {
       this.scene.ui.setMode(Mode.CONFIRM, () => {
         this.scene.ui.setMode(Mode.MESSAGE);


### PR DESCRIPTION
**Edit:** scroll down, I fixed some stuff

I was trying to figure out how to do this for like way too long. I am not happy with the end result.

The freaking code base has a bunch of lines but **lack comments above them**, that explain what is what. So, when I was trying to figure out what the hell ``Mode.MESSAGE`` and the rest is for, I had a mental breakdown.

And the result, is buggy. Except the Toggle button, that one works... So I expect someone to like tell me how to fix, yes?? :) :) :)

&nbsp;

Anyways, let me explain the change.

FIRST, I tried to push back **CommandPhase** dynamically. But that thing would break, here's my freak out post about it: https://github.com/pagefaultgames/pokerogue/issues/1062

So, then I decided to do this more stupid. But eventually, it's not really that bad actually.

&nbsp;

Currently, nobody will freaking choose the IV-Scanner if they've chosen it once, pretty sure. That freaking thing prompts a player if you want to scan a Pokemon every encounter, everytime.

So, I added a Toggle.

<img src="https://github.com/pagefaultgames/pokerogue/assets/12023782/69c340b3-2c1b-48d6-a8c8-320fff66fe5d" width=50%/>

You **click** on the Modifier. And yes, I tried to listen to the SOLID Principle and OOP. There's a ``onClick`` method that gets now called onto all the Modifiers in that Modifiers bar, but it doesn't do anything unless you assign it something.

This should even function on mobile.

Eitherways.

&nbsp;
<img src="https://github.com/pagefaultgames/pokerogue/assets/12023782/4067ca66-8176-4e80-aa2c-bf911e9b0714" width=50%/>

This UI Container will open. It opens like that, because I copy pasted the other existing code and I think the offset is alright too.

The Toggle button is amazing and it toggles stuff.

<img src="https://github.com/pagefaultgames/pokerogue/assets/12023782/63a92025-8567-4501-8ec9-7366c0b8b034" width=30%/>

<img src="https://github.com/pagefaultgames/pokerogue/assets/12023782/1b784b88-1ef4-4466-810e-10a5ab16032e" width=30%/>

&nbsp;

&nbsp;

**Then!**, the other option is that you can scan anything anywhere. Ofc only if it's a wild encounter and bla bla bla.

You simply click on it.


Draw back is, you'll be stuck with this box until the end of the turn.

<img src="https://github.com/pagefaultgames/pokerogue/assets/12023782/5313735c-f5a6-4142-a7b8-d781612ee77d" width=50%/>



This is where I need help with. And yep. Okay thanks.




