### PR TITLE
Update confuse chance to modern value (1/3 instead of 1/2)

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -235,7 +235,7 @@ export class ConfusedTag extends BattlerTag {
       pokemon.scene.queueMessage(getPokemonMessage(pokemon, ' is\nconfused!'));
       pokemon.scene.unshiftPhase(new CommonAnimPhase(pokemon.scene, pokemon.getBattlerIndex(), undefined, CommonAnim.CONFUSION));
 
-      if (pokemon.randSeedInt(2)) {
+      if (pokemon.randSeedInt(3)) {
         const atk = pokemon.getBattleStat(Stat.ATK);
         const def = pokemon.getBattleStat(Stat.DEF);
         const damage = Math.ceil(((((2 * pokemon.level / 5 + 2) * 40 * atk / def) / 50) + 2) * (pokemon.randSeedInt(15, 85) / 100));


### PR DESCRIPTION
Changed from 1/2 to 1/3, as games after gen 5 use this value

https://bulbapedia.bulbagarden.net/wiki/Confusion_(status_condition)
![image](https://github.com/pagefaultgames/pokerogue/assets/19582161/660de982-ed99-4ea7-a6cd-a9019bc3486a)
