### PR TITLE
Fix README to match current state of Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PokéRogue is a browser based Pokémon fangame heavily inspired by the roguelite
 
 # Contributing
 ## 🛠️ Development
-If you have the motivation and experience with Typescript/Javascript (or are willing to learn) please feel free to fork the repository and make pull requests with contributions. If you don't know what to work on but want to help, reference the below **To-Do** section or the **#feature-vote** channel in the discord. 
+If you have the motivation and experience with Typescript/Javascript (or are willing to learn) please feel free to fork the repository and make pull requests with contributions. ~~If you don't know what to work on but want to help, reference the below **To-Do** section or the **#feature-vote** channel in the discord.~~
 
 ### 💻 Environment Setup
 #### Prerequisites


### PR DESCRIPTION
I was not able to type in ``#dev-corner`` 😔, after asking one Staff. My hopes are shattered. I will still have to explore the source code all by myself and go through pain. And what's the point typing in dev-corner if not all Contributors are Contributors on the Discord. Who will reply back, a ghost? The answer is nobody.

&nbsp;

To avoid anyone else from experiencing this, I simply stroke through the motivating text to join the Discord. Since this so called "lockdown" is prolly gonna stay up for long, and yes.