### PR TITLE
Font resize for French in starterInfoTextSize

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -271,6 +271,9 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     // The font size should be set per language
     // currentLanguage is already defined
     switch (currentLanguage) {
+      case 'fr':
+        starterInfoTextSize = '54px';
+        break;
       case 'pt_BR':
         starterInfoTextSize = '47px';
         break;


### PR DESCRIPTION
Font resize for French in starterInfoTextSize
- To restore an acceptable space between "Nature :" and the name of the nature
- Avoid the closing parenthesis of Nature effects being a bit off borders in some cases

**Before :**
![image](https://github.com/pagefaultgames/pokerogue/assets/2070109/54100110-f9e9-4117-adcf-ee9c59dcb922)

**After :**
![image](https://github.com/pagefaultgames/pokerogue/assets/2070109/ae72caeb-c209-4cbf-bda4-ee87a7e86126)

