### PR TITLE
[QoL] Automatically center window vertically when playing on landscape 

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -27,12 +27,6 @@ window.addEventListener("unhandledrejection", (event) => {
   //alert(errorString);
 });
 
-// Reinitialize game with the updated config.scale.autoCenter when 'touchControlsChange' event is dispatched
-window.addEventListener("touchControlsChange", () => {
-  config.scale.autoCenter = shouldCenterWindow() ? Phaser.Scale.CENTER_VERTICALLY : Phaser.Scale.NO_CENTER;
-  reinitializeGame();
-});
-
 /**
  * Determines if the game window should be centered based on the current device and settings.
  *
@@ -46,7 +40,7 @@ window.addEventListener("touchControlsChange", () => {
  */
 const shouldCenterWindow = (): boolean => {
   const touchControlsOptions = Setting.find(s => s.key === SettingKeys.Touch_Controls).options;
-  console.log(touchControlsOptions)
+  console.log(touchControlsOptions);
   const settings = localStorage.hasOwnProperty("settings") ? JSON.parse(localStorage.getItem("settings")) : null;
 
   const isLandscape = window.matchMedia("(orientation: landscape)").matches;
@@ -190,18 +184,6 @@ let game: Phaser.Game;
 const startGame = () => {
   game = new Phaser.Game(config);
   game.sound.pauseOnBlur = false;
-};
-
-/**
- * Reinitializes the game by destroying the current instance and starting a new one.
- * @function reinitializeGame
- * @returns {void}
- */
-const reinitializeGame = (): void => {
-  if (game) {
-    game.destroy(true, false);
-    startGame();
-  }
 };
 
 fetch("/manifest.json")

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,7 @@ window.addEventListener("unhandledrejection", (event) => {
 
 // Reinitialize game with the updated config.scale.autoCenter when 'touchControlsChange' event is dispatched
 window.addEventListener("touchControlsChange", () => {
-  config.scale.autoCenter = shouldCenterWindow() ? Phaser.Scale.CENTER_BOTH : Phaser.Scale.NO_CENTER;
+  config.scale.autoCenter = shouldCenterWindow() ? Phaser.Scale.CENTER_VERTICALLY : Phaser.Scale.NO_CENTER;
   reinitializeGame();
 });
 
@@ -65,7 +65,7 @@ const config: Phaser.Types.Core.GameConfig = {
     width: 1920,
     height: 1080,
     mode: Phaser.Scale.FIT,
-    autoCenter: shouldCenterWindow() ? Phaser.Scale.CENTER_BOTH : Phaser.Scale.NO_CENTER
+    autoCenter: shouldCenterWindow() ? Phaser.Scale.CENTER_VERTICALLY : Phaser.Scale.NO_CENTER
   },
   plugins: {
     global: [{

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,7 +40,6 @@ window.addEventListener("unhandledrejection", (event) => {
  */
 const shouldCenterWindow = (): boolean => {
   const touchControlsOptions = Setting.find(s => s.key === SettingKeys.Touch_Controls).options;
-  console.log(touchControlsOptions);
   const settings = localStorage.hasOwnProperty("settings") ? JSON.parse(localStorage.getItem("settings")) : null;
 
   const isLandscape = window.matchMedia("(orientation: landscape)").matches;

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,8 +37,8 @@ window.addEventListener("touchControlsChange", () => {
  * Determines if the game window should be centered based on the current device and settings.
  *
  * This function checks several conditions to decide whether the game window should be centered:
- * 1. Checks if the device is not a mobile device.
- * 2. Checks if the device is in landscape orientation.
+ * 1. Checks if the device is in landscape orientation.
+ * 2. Checks if the device is not a mobile device.
  * 3. Checks if the device has a touchscreen.
  * 4. Checks if touch controls is explicitly enabled in the settings.
  *

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -244,7 +244,8 @@ export const Setting: Array<Setting> = [
     label: "Touch Controls",
     options: AUTO_DISABLED,
     default: 0,
-    type: SettingType.GENERAL
+    type: SettingType.GENERAL,
+    requireReload: true
   },
   {
     key: SettingKeys.Vibration,

--- a/src/ui/settings/abstract-settings-ui-handler.ts
+++ b/src/ui/settings/abstract-settings-ui-handler.ts
@@ -386,8 +386,8 @@ export default class AbstractSettingsUiHandler extends UiHandler {
     this.eraseCursor();
     if (this.reloadRequired) {
       if (setting.key === SettingKeys.Touch_Controls) {
-        const event = new CustomEvent("touchControlsChange");
-        return window.dispatchEvent(event);
+        window.location.reload();
+        return;
       }
       this.reloadRequired = false;
       this.scene.reset(true, false, true);


### PR DESCRIPTION
### PLEASE REFER [HERE](https://github.com/pagefaultgames/pokerogue/pull/1114#issuecomment-2128087672) FOR UPDATED DESCRIPTION

--------

This PR includes changes from [851](https://github.com/pagefaultgames/pokerogue/pull/851)

Only added the check if window width < 1920 - this should prevent applying the `align-items: center` property when the game window is scaled up.

There is another cleaner approach to achieving this through phaser but this would _require a reload_. If forcing a reload is okay, then that approach is better, otherwise this is.

- width < 1920
<img width="1299" alt="Screenshot 2024-05-19 at 5 46 38 AM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/e9ad0304-28c7-449c-b691-c45e186f6ce1">

- width >= 1920
<img width="1406" alt="Screenshot 2024-05-19 at 5 49 38 AM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/2359470d-2155-4f35-8c4e-c3a3c823e0f4">
