### PR TITLE
Repel Implementation - Trainer battle chance

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -4,7 +4,7 @@ import { NextEncounterPhase, NewBiomeEncounterPhase, SelectBiomePhase, MessagePh
 import Pokemon, { PlayerPokemon, EnemyPokemon } from './field/pokemon';
 import PokemonSpecies, { PokemonSpeciesFilter, allSpecies, getPokemonSpecies, initSpecies, speciesStarters } from './data/pokemon-species';
 import * as Utils from './utils';
-import { Modifier, ModifierBar, ConsumablePokemonModifier, ConsumableModifier, PokemonHpRestoreModifier, HealingBoosterModifier, PersistentModifier, PokemonHeldItemModifier, ModifierPredicate, DoubleBattleChanceBoosterModifier, FusePokemonModifier, PokemonFormChangeItemModifier, TerastallizeModifier, overrideModifiers, overrideHeldItems } from './modifier/modifier';
+import { Modifier, ModifierBar, ConsumablePokemonModifier, ConsumableModifier, PokemonHpRestoreModifier, HealingBoosterModifier, PersistentModifier, PokemonHeldItemModifier, ModifierPredicate, DoubleBattleChanceBoosterModifier, FusePokemonModifier, PokemonFormChangeItemModifier, TerastallizeModifier, overrideModifiers, overrideHeldItems, TrainerBattleChanceBoosterModifier } from './modifier/modifier';
 import { PokeballType } from './data/pokeball';
 import { initCommonAnims, initMoveAnim, loadCommonAnimAssets, loadMoveAnimAssets, populateAnims } from './data/battle-anims';
 import { Phase } from './phase';
@@ -846,9 +846,11 @@ export default class BattleScene extends SceneBase {
 		} else {
 			if (!this.gameMode.hasTrainers)
 				newBattleType = BattleType.WILD;
-			else if (battleType === undefined)
-				newBattleType = this.gameMode.isWaveTrainer(newWaveIndex, this.arena) ? BattleType.TRAINER : BattleType.WILD;
-			else
+			else if (battleType === undefined) {
+				const trainerChanceMod = new Utils.IntegerHolder(this.arena.getTrainerChance());
+				this.applyModifiers(TrainerBattleChanceBoosterModifier, true, trainerChanceMod);
+				newBattleType = this.gameMode.isWaveTrainer(newWaveIndex, this.arena, trainerChanceMod.value) ? BattleType.TRAINER : BattleType.WILD;
+			} else
 				newBattleType = battleType;
 
 			if (newBattleType === BattleType.TRAINER) {

--- a/src/game-mode.ts
+++ b/src/game-mode.ts
@@ -96,13 +96,13 @@ export class GameMode implements GameModeConfig {
     }
   }
 
-  isWaveTrainer(waveIndex: integer, arena: Arena): boolean {
+  isWaveTrainer(waveIndex: integer, arena: Arena, trainerChanceMod: integer): boolean {
     if (this.isDaily)
       return waveIndex % 10 === 5 || (!(waveIndex % 10) && waveIndex > 10 && !this.isWaveFinal(waveIndex));
     if ((waveIndex % 30) === (arena.scene.offsetGym ? 0 : 20) && !this.isWaveFinal(waveIndex))
       return true;
     else if (waveIndex % 10 !== 1 && waveIndex % 10) {
-      const trainerChance = arena.getTrainerChance();
+      const trainerChance = trainerChanceMod;
       let allowTrainerBattle = true;
       if (trainerChance) {
         const waveBase = Math.floor(waveIndex / 10) * 10;
@@ -114,7 +114,7 @@ export class GameMode implements GameModeConfig {
             break;
           } else if (w < waveIndex) {
             arena.scene.executeWithSeedOffset(() => {
-              const waveTrainerChance = arena.getTrainerChance();
+              const waveTrainerChance = trainerChanceMod;
               if (!Utils.randSeedInt(waveTrainerChance))
                 allowTrainerBattle = false;
             }, w);
@@ -123,7 +123,7 @@ export class GameMode implements GameModeConfig {
           }
         }
       }
-      return allowTrainerBattle && trainerChance && !Utils.randSeedInt(trainerChance);
+      return allowTrainerBattle && trainerChance && !Utils.randSeedInt(trainerChanceMod);
     }
     return false;
   }

--- a/src/locales/de/modifier-type.ts
+++ b/src/locales/de/modifier-type.ts
@@ -51,6 +51,9 @@ export const modifierType: ModifierTypeTranslationEntries = {
     "DoubleBattleChanceBoosterModifierType": {
       description: "Verdoppelt die Wahrscheinlichkeit, dass die nächsten {{battleCount}} Begegnungen mit wilden Pokémon ein Doppelkampf sind.",
     },
+    "TrainerBattleChanceBoosterModifierType": {
+      description: "Verdoppelt für {{battleCount}} Kämpfe die Chance auf einen Trainerkampf",
+    },
     "TempBattleStatBoosterModifierType": {
       description: "Erhöht die {{tempBattleStatName}} aller Teammitglieder für 5 Kämpfe um eine Stufe",
     },
@@ -161,6 +164,10 @@ export const modifierType: ModifierTypeTranslationEntries = {
     "LURE": { name: "Lockparfüm" },
     "SUPER_LURE": { name: "Super-Lockparfüm" },
     "MAX_LURE": { name: "Top-Lockparfüm" },
+
+    "REPEL": { name: "Schutz" },
+    "SUPER_REPEL": { name: "Superschutz" },
+    "MAX_REPEL": { name: "Top-Schutz" },
 
     "MEMORY_MUSHROOM": { name: "Erinnerungspilz", description: "Lässt ein Pokémon eine vergessene Attacke wiedererlernen" },
 

--- a/src/locales/en/modifier-type.ts
+++ b/src/locales/en/modifier-type.ts
@@ -51,6 +51,9 @@ export const modifierType: ModifierTypeTranslationEntries = {
     "DoubleBattleChanceBoosterModifierType": {
       description: "Doubles the chance of an encounter being a double battle for {{battleCount}} battles",
     },
+    "TrainerBattleChanceBoosterModifierType": {
+      description: "Doubles the chance of an encounter being a trainer battle for {{battleCount}} battles",
+    },
     "TempBattleStatBoosterModifierType": {
       description: "Increases the {{tempBattleStatName}} of all party members by 1 stage for 5 battles",
     },
@@ -161,6 +164,10 @@ export const modifierType: ModifierTypeTranslationEntries = {
     "LURE": { name: "Lure" },
     "SUPER_LURE": { name: "Super Lure" },
     "MAX_LURE": { name: "Max Lure" },
+
+    "REPEL": { name: "Repel" },
+    "SUPER_REPEL": { name: "Super Repel" },
+    "MAX_REPEL": { name: "Max Repel" },
 
     "MEMORY_MUSHROOM": { name: "Memory Mushroom", description: "Recall one Pokémon's forgotten move" },
 

--- a/src/locales/fr/modifier-type.ts
+++ b/src/locales/fr/modifier-type.ts
@@ -51,6 +51,9 @@ export const modifierType: ModifierTypeTranslationEntries = {
     "DoubleBattleChanceBoosterModifierType": {
 	  description: "Double les chances de tomber sur un combat double pendant {{battleCount}} combats",
     },
+    "TrainerBattleChanceBoosterModifierType": {
+      description: "Double les chances de rencontrer un dresseur pendant {{battleCount}} combats",
+    },
     "TempBattleStatBoosterModifierType": {
 	  description: "Augmente d’1 cran {{tempBattleStatName}} pour toute l’équipe pendant 5 combats",
     },
@@ -161,6 +164,10 @@ export const modifierType: ModifierTypeTranslationEntries = {
     "LURE": { name: "Parfum" },
     "SUPER_LURE": { name: "Super Parfum" },
     "MAX_LURE": { name: "Parfum Max" },
+
+    "REPEL": { name: "Repousse" },
+    "SUPER_REPEL": { name: "Super Repousse" },
+    "MAX_REPEL": { name: "Repousse Max" },
 
     "MEMORY_MUSHROOM": { name: "Champi Mémoriel", description: "Remémore une capacité à un Pokémon" },
 

--- a/src/locales/it/modifier-type.ts
+++ b/src/locales/it/modifier-type.ts
@@ -51,6 +51,9 @@ export const modifierType: ModifierTypeTranslationEntries = {
     "DoubleBattleChanceBoosterModifierType": {
       description: "Raddoppia la possibilità di imbattersi in doppie battaglie per {{battleCount}} battaglie",
     },
+    "TrainerBattleChanceBoosterModifierType": {
+      description: "Raddoppia la possibilità di imbattersi in battaglie con allenatori per {{battleCount}} battaglie",
+    },
     "TempBattleStatBoosterModifierType": {
       description: "Aumenta {{tempBattleStatName}} di un livello a tutti i Pokémon nel gruppo per 5 battaglie",
     },
@@ -161,6 +164,10 @@ export const modifierType: ModifierTypeTranslationEntries = {
     "LURE": { name: "Profumo Invito" },
     "SUPER_LURE": { name: "Profumo Invito Super" },
     "MAX_LURE": { name: "Profumo Invito Max" },
+
+    "REPEL": { name: "Repellente" },
+    "SUPER_REPEL": { name: "Superrepellente" },
+    "MAX_REPEL": { name: "Repellente max" },
 
     "MEMORY_MUSHROOM": { name: "Fungo della Memoria", description: "Ricorda la mossa dimenticata di un Pokémon" },
 

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -407,6 +407,20 @@ export class DoubleBattleChanceBoosterModifierType extends ModifierType {
   }
 }
 
+export class TrainerBattleChanceBoosterModifierType extends ModifierType {
+  public battleCount: integer;
+
+  constructor(localeKey: string, iconImage: string, battleCount: integer) {
+    super(localeKey, iconImage, (_type, _args) => new Modifiers.TrainerBattleChanceBoosterModifier(this, this.battleCount), 'repel');
+
+    this.battleCount = battleCount;
+  }
+
+  getDescription(scene: BattleScene): string {
+    return i18next.t(`modifierType:ModifierType.DoubleBattleChanceBoosterModifierType.description`, { battleCount: this.battleCount });
+  }
+}
+
 export class TempBattleStatBoosterModifierType extends ModifierType implements GeneratedPersistentModifierType {
   public tempBattleStat: TempBattleStat;
 
@@ -1031,9 +1045,9 @@ export const modifierTypes = {
   PP_UP: () => new PokemonPpUpModifierType(`modifierType:ModifierType.PP_UP`, 'pp_up', 1),
   PP_MAX: () => new PokemonPpUpModifierType(`modifierType:ModifierType.PP_MAX`, 'pp_max', 3),
 
-  /*REPEL: () => new DoubleBattleChanceBoosterModifierType('Repel', 5),
-  SUPER_REPEL: () => new DoubleBattleChanceBoosterModifierType('Super Repel', 10),
-  MAX_REPEL: () => new DoubleBattleChanceBoosterModifierType('Max Repel', 25),*/
+  REPEL: () => new TrainerBattleChanceBoosterModifierType(`modifierType:ModifierType.REPEL`, 'repel', 5),
+  SUPER_REPEL: () => new DoubleBattleChanceBoosterModifierType(`modifierType:ModifierType.SUPER_REPEL`, 'super_repel', 10),
+  MAX_REPEL: () => new DoubleBattleChanceBoosterModifierType(`modifierType:ModifierType.MAX_REPEL`, 'max_repel', 25),
 
   LURE: () => new DoubleBattleChanceBoosterModifierType(`modifierType:ModifierType.LURE`, 'lure', 5),
   SUPER_LURE: () => new DoubleBattleChanceBoosterModifierType(`modifierType:ModifierType.SUPER_LURE`, 'super_lure', 10),
@@ -1202,6 +1216,7 @@ const modifierPool: ModifierPool = {
       return thresholdPartyMemberCount;
     }, 3),
     new WeightedModifierType(modifierTypes.LURE, 2),
+    new WeightedModifierType(modifierTypes.REPEL, 2),
     new WeightedModifierType(modifierTypes.TEMP_STAT_BOOSTER, 4),
     new WeightedModifierType(modifierTypes.BERRY, 2),
     new WeightedModifierType(modifierTypes.TM_COMMON, 1),
@@ -1246,6 +1261,7 @@ const modifierPool: ModifierPool = {
     }, 3),
     new WeightedModifierType(modifierTypes.DIRE_HIT, 4),
     new WeightedModifierType(modifierTypes.SUPER_LURE, 4),
+    new WeightedModifierType(modifierTypes.SUPER_REPEL, 4),
     new WeightedModifierType(modifierTypes.NUGGET, 5),
     new WeightedModifierType(modifierTypes.EVOLUTION_ITEM, (party: Pokemon[]) => {
       return Math.min(Math.ceil(party[0].scene.currentBattle.waveIndex / 15), 8);
@@ -1265,6 +1281,7 @@ const modifierPool: ModifierPool = {
   [ModifierTier.ULTRA]: [
     new WeightedModifierType(modifierTypes.ULTRA_BALL, 24),
     new WeightedModifierType(modifierTypes.MAX_LURE, 4),
+    new WeightedModifierType(modifierTypes.MAX_REPEL, 4),
     new WeightedModifierType(modifierTypes.BIG_NUGGET, 12),
     new WeightedModifierType(modifierTypes.PP_UP, 9),
     new WeightedModifierType(modifierTypes.PP_MAX, 3),

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -310,6 +310,33 @@ export class DoubleBattleChanceBoosterModifier extends LapsingPersistentModifier
   }
 }
 
+export class TrainerBattleChanceBoosterModifier extends LapsingPersistentModifier {
+  constructor(type: ModifierTypes.TrainerBattleChanceBoosterModifierType, battlesLeft: integer, stackCount?: integer) {
+    super(type, battlesLeft, stackCount);
+  }
+
+  match(modifier: Modifier): boolean {
+    if (modifier instanceof TrainerBattleChanceBoosterModifier)
+      return (modifier as TrainerBattleChanceBoosterModifier).battlesLeft === this.battlesLeft;
+    return false;
+  }
+
+  clone(): TrainerBattleChanceBoosterModifier {
+    return new TrainerBattleChanceBoosterModifier(this.type as ModifierTypes.TrainerBattleChanceBoosterModifierType, this.battlesLeft, this.stackCount);
+  }
+
+  getArgs(): any[] {
+    return [ this.battlesLeft ];
+  }
+
+  apply(args: any[]): boolean {
+    const trainerChance = args[0] as Utils.NumberHolder;
+    trainerChance.value = Math.ceil(trainerChance.value / 2);
+
+    return true;
+  }
+}
+
 export class TempBattleStatBoosterModifier extends LapsingPersistentModifier {
   private tempBattleStat: TempBattleStat;
 


### PR DESCRIPTION
Added repels for increased trainer battle chance


I had to delete the previous fork so also the previous pull request.
In the previous pull request I prevented double battles, now I changed the implementation thanks to a comment in the previous pull request saying something along the lines of 'Adding repels preventing double battle would be bloat (it will make lures and repels go in conflict)'.

ps. Still need these translations: de, es, fr, pt_BR, zh_CN