### PR TITLE
Reduce EXP Balance

### DIFF
--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1280,7 +1280,6 @@ const modifierPool: ModifierPool = {
     new WeightedModifierType(modifierTypes.IV_SCANNER, 4),
     new WeightedModifierType(modifierTypes.EXP_CHARM, 8),
     new WeightedModifierType(modifierTypes.EXP_SHARE, 12),
-    new WeightedModifierType(modifierTypes.EXP_BALANCE, 4),
     new WeightedModifierType(modifierTypes.TERA_ORB, (party: Pokemon[]) => Math.min(Math.max(Math.floor(party[0].scene.currentBattle.waveIndex / 50) * 2, 1), 4), 4),
     new WeightedModifierType(modifierTypes.VOUCHER, (party: Pokemon[], rerollCount: integer) => !party[0].scene.gameMode.isDaily ? Math.max(3 - rerollCount, 0) : 0, 3),
   ].map(m => { m.setTier(ModifierTier.ULTRA); return m; }),

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1280,6 +1280,7 @@ const modifierPool: ModifierPool = {
     new WeightedModifierType(modifierTypes.IV_SCANNER, 4),
     new WeightedModifierType(modifierTypes.EXP_CHARM, 8),
     new WeightedModifierType(modifierTypes.EXP_SHARE, 12),
+    new WeightedModifierType(modifierTypes.EXP_BALANCE, 4),
     new WeightedModifierType(modifierTypes.TERA_ORB, (party: Pokemon[]) => Math.min(Math.max(Math.floor(party[0].scene.currentBattle.waveIndex / 50) * 2, 1), 4), 4),
     new WeightedModifierType(modifierTypes.VOUCHER, (party: Pokemon[], rerollCount: integer) => !party[0].scene.gameMode.isDaily ? Math.max(3 - rerollCount, 0) : 0, 3),
   ].map(m => { m.setTier(ModifierTier.ULTRA); return m; }),

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -1423,7 +1423,7 @@ export class ExpBalanceModifier extends PersistentModifier {
   }
 
   getMaxStackCount(scene: BattleScene): integer {
-    return 5;
+    return 2;
   }
 }
 

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -1423,7 +1423,7 @@ export class ExpBalanceModifier extends PersistentModifier {
   }
 
   getMaxStackCount(scene: BattleScene): integer {
-    return 2;
+    return 4;
   }
 }
 

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -867,8 +867,10 @@ export class GameData {
         const ret: PersistentModifierData[] = [];
         if (v === null)
           v = [];
-        for (let md of v)
-          ret.push(new PersistentModifierData(md, player));
+        for (let md of v) {
+          if(md?.className !== 'ExpBalanceModifier') // Temporarily disable EXP Balance until it gets reworked
+            ret.push(new PersistentModifierData(md, player));
+        }
         return ret;
       }
 

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -868,8 +868,9 @@ export class GameData {
         if (v === null)
           v = [];
         for (let md of v) {
-          if(md?.className !== 'ExpBalanceModifier') // Temporarily disable EXP Balance until it gets reworked
-            ret.push(new PersistentModifierData(md, player));
+          if(md?.className === 'ExpBalanceModifier') // Temporarily limit EXP Balance until it gets reworked
+            md.stackCount = Math.min(md.stackCount, 2);
+          ret.push(new PersistentModifierData(md, player));
         }
         return ret;
       }

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -869,7 +869,7 @@ export class GameData {
           v = [];
         for (let md of v) {
           if(md?.className === 'ExpBalanceModifier') // Temporarily limit EXP Balance until it gets reworked
-            md.stackCount = Math.min(md.stackCount, 2);
+            md.stackCount = Math.min(md.stackCount, 4);
           ret.push(new PersistentModifierData(md, player));
         }
         return ret;


### PR DESCRIPTION
The EXP Balance item is not currently functioning as a useful item. This reduces the item's Max Stack Count temporarily until a better solution can be found. Saves with this item will have them reduces to a max of 2 and shops will no longer carry them once you reach this value.

### With EXP Balance

https://github.com/pagefaultgames/pokerogue/assets/13838608/af4b8ffe-1477-432e-8087-71cfc423e18e

### Without EXP Balance

https://github.com/pagefaultgames/pokerogue/assets/13838608/116b0094-d7ee-43dd-b410-0cacd4df0ead

