### PR TITLE
Add support for a simple menu message

### DIFF
--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -12,10 +12,13 @@ import { Stat } from './data/pokemon-stat';
 import { PokeballCounts } from './battle-scene';
 import { PokeballType } from './data/pokeball';
 
+export const MENU_MESSAGE: { active: boolean, text: string, textColor: string, backgroundColor: string } = {
+    active: true,
+    text: "Shiny event active!",
+    textColor: "#FFD700",
+    backgroundColor: "#FAFAD2"
+}
 
-export const MENU_MESSAGE: string = "";
-export const MENU_MESSAGE_TEXT_COLOR: string = "";
-export const MENU_MESSAGE_BACKGROUND_COLOR: string = "";
 /**
  * Overrides for testing different in game situations
  * if an override name starts with "STARTING", it will apply when a new run begins

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -12,6 +12,10 @@ import { Stat } from './data/pokemon-stat';
 import { PokeballCounts } from './battle-scene';
 import { PokeballType } from './data/pokeball';
 
+
+export const MENU_MESSAGE: string = "";
+export const MENU_MESSAGE_TEXT_COLOR: string = "";
+export const MENU_MESSAGE_BACKGROUND_COLOR: string = "";
 /**
  * Overrides for testing different in game situations
  * if an override name starts with "STARTING", it will apply when a new run begins

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -12,13 +12,6 @@ import { Stat } from './data/pokemon-stat';
 import { PokeballCounts } from './battle-scene';
 import { PokeballType } from './data/pokeball';
 
-export const MENU_MESSAGE: { active: boolean, text: string, textColor: string, backgroundColor: string } = {
-    active: true,
-    text: "Shiny event active!",
-    textColor: "#FFD700",
-    backgroundColor: "#FAFAD2"
-}
-
 /**
  * Overrides for testing different in game situations
  * if an override name starts with "STARTING", it will apply when a new run begins

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -6,6 +6,7 @@ import * as Utils from "../utils";
 import { TextStyle, addTextObject } from "./text";
 import { getBattleCountSplashMessage, getSplashMessages } from "../data/splash-messages";
 import i18next from "i18next";
+import { MENU_MESSAGE, MENU_MESSAGE_TEXT_COLOR, MENU_MESSAGE_BACKGROUND_COLOR } from "../overrides";
 
 export default class TitleUiHandler extends OptionSelectUiHandler {
   private titleContainer: Phaser.GameObjects.Container;
@@ -41,6 +42,16 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
     this.playerCountLabel = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 2, (this.scene.game.canvas.height / 6) - 90, `? ${i18next.t("menu:playersOnline")}`, TextStyle.MESSAGE, { fontSize: '54px' });
     this.playerCountLabel.setOrigin(1, 0);
     this.titleContainer.add(this.playerCountLabel);
+	
+    if (MENU_MESSAGE !== "") {
+        this.menuMessage = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 2, (this.scene.game.canvas.height / 6) - 100, MENU_MESSAGE, TextStyle.MESSAGE, {
+            fontSize: '54px',
+            backgroundColor: MENU_MESSAGE_BACKGROUND_COLOR,
+            color: MENU_MESSAGE_TEXT_COLOR !== "" ? MENU_MESSAGE_TEXT_COLOR : "#FFFFFF"
+        });
+        this.menuMessage.setOrigin(1, 0);
+        this.titleContainer.add(this.menuMessage);
+    }
 
     this.splashMessageText = addTextObject(this.scene, logo.x + 64, logo.y + logo.displayHeight - 8, '', TextStyle.MONEY, { fontSize: '54px' });
     this.splashMessageText.setOrigin(0.5, 0.5);

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -6,7 +6,7 @@ import * as Utils from "../utils";
 import { TextStyle, addTextObject } from "./text";
 import { getBattleCountSplashMessage, getSplashMessages } from "../data/splash-messages";
 import i18next from "i18next";
-import { MENU_MESSAGE, MENU_MESSAGE_TEXT_COLOR, MENU_MESSAGE_BACKGROUND_COLOR } from "../overrides";
+import * as Overrides from '../overrides';
 
 export default class TitleUiHandler extends OptionSelectUiHandler {
   private titleContainer: Phaser.GameObjects.Container;
@@ -43,11 +43,11 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
     this.playerCountLabel.setOrigin(1, 0);
     this.titleContainer.add(this.playerCountLabel);
 	
-    if (MENU_MESSAGE !== "") {
-        this.menuMessage = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 2, (this.scene.game.canvas.height / 6) - 100, MENU_MESSAGE, TextStyle.MESSAGE, {
+    if (Overrides.MENU_MESSAGE.active) {
+        this.menuMessage = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 2, (this.scene.game.canvas.height / 6) - 100, Overrides.MENU_MESSAGE.text, TextStyle.MESSAGE, {
             fontSize: '54px',
-            backgroundColor: MENU_MESSAGE_BACKGROUND_COLOR,
-            color: MENU_MESSAGE_TEXT_COLOR !== "" ? MENU_MESSAGE_TEXT_COLOR : "#FFFFFF"
+            backgroundColor: Overrides.MENU_MESSAGE.backgroundColor,
+            color: Overrides.MENU_MESSAGE.textColor !== "" ? Overrides.MENU_MESSAGE.textColor : "#FFFFFF"
         });
         this.menuMessage.setOrigin(1, 0);
         this.titleContainer.add(this.menuMessage);

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -6,7 +6,6 @@ import * as Utils from "../utils";
 import { TextStyle, addTextObject } from "./text";
 import { getBattleCountSplashMessage, getSplashMessages } from "../data/splash-messages";
 import i18next from "i18next";
-import * as Overrides from '../overrides';
 
 export default class TitleUiHandler extends OptionSelectUiHandler {
   private titleContainer: Phaser.GameObjects.Container;
@@ -14,6 +13,12 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
   private playerCountLabel: Phaser.GameObjects.Text;
   private splashMessage: string;
   private splashMessageText: Phaser.GameObjects.Text;
+  private MENU_MESSAGE: { active: boolean, text: string, textColor: string, backgroundColor: string } = {
+    active: true,
+    text: "Shiny event active!",
+    textColor: "#FFD700",
+    backgroundColor: "#FAFAD2"
+  }
 
   private titleStatsTimer: number;
 
@@ -43,11 +48,11 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
     this.playerCountLabel.setOrigin(1, 0);
     this.titleContainer.add(this.playerCountLabel);
 	
-    if (Overrides.MENU_MESSAGE.active) {
-        this.menuMessage = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 2, (this.scene.game.canvas.height / 6) - 100, Overrides.MENU_MESSAGE.text, TextStyle.MESSAGE, {
+    if (this.MENU_MESSAGE.active) {
+        this.menuMessage = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 2, (this.scene.game.canvas.height / 6) - 100, this.MENU_MESSAGE.text, TextStyle.MESSAGE, {
             fontSize: '54px',
-            backgroundColor: Overrides.MENU_MESSAGE.backgroundColor,
-            color: Overrides.MENU_MESSAGE.textColor !== "" ? Overrides.MENU_MESSAGE.textColor : "#FFFFFF"
+            backgroundColor: this.MENU_MESSAGE.backgroundColor,
+            color: this.MENU_MESSAGE.textColor !== "" ? this.MENU_MESSAGE.textColor : "#FFFFFF"
         });
         this.menuMessage.setOrigin(1, 0);
         this.titleContainer.add(this.menuMessage);


### PR DESCRIPTION
As the title implies, this adds support for a basic menu message that can be used to alert players of shiny events, special updates, giveaways, etc.

If the message is an empty string, it just won't show up at all. If the background color is blank, there will be no background color. if the text color is blank, it'll default to white.

For example this is the result of this code:

```typescript
export const MENU_MESSAGE: string = "Admiral Billy cool mode active!";
export const MENU_MESSAGE_TEXT_COLOR: string = "#FFD700";
export const MENU_MESSAGE_BACKGROUND_COLOR: string = "#FF69B4";
```

![image](https://github.com/pagefaultgames/pokerogue/assets/72857839/1466d2a1-a31e-4066-9a29-5134bfb1c2e9)

Feel free to move the variables wherever seems most appropriate; currently they're just at the top of overrides.