### PR TITLE
[QOL] Allow starters to relearn egg moves

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -743,6 +743,10 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     return this.getLevelMoves(1, true).map(lm => lm[1]).filter(lm => !this.moveset.filter(m => m.moveId === lm).length).filter((move: Moves, i: integer, array: Moves[]) => array.indexOf(move) === i);
   }
 
+  getLearnableEggMoves(): Moves[] {
+    return this.metBiome < 0 ? this.scene.gameData.getUnlockedEggMoves(this.species).filter(lm => !this.moveset.filter(m => m.moveId === lm).length).filter((move: Moves, i: integer, array: Moves[]) => array.indexOf(move) === i) : [];
+  }
+
   getTypes(includeTeraType = false, forDefend: boolean = false, ignoreOverride?: boolean): Type[] {
     const types = [];
 

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -21,6 +21,7 @@ import { ModifierTier } from './modifier-tier';
 import { Nature, getNatureName, getNatureStatMultiplier } from '#app/data/nature';
 import i18next from '#app/plugins/i18n';
 import { getModifierTierTextTint } from '#app/ui/text';
+import { Biome } from '#app/data/enums/biome.js';
 
 const outputModifierData = false;
 const useMaxWeightForOutput = false;
@@ -386,7 +387,7 @@ export class RememberMoveModifierType extends PokemonModifierType {
   constructor(localeKey: string, iconImage: string, group?: string) {
     super(localeKey, iconImage, (type, args) => new Modifiers.RememberMoveModifier(type, (args[0] as PlayerPokemon).id, (args[1] as integer)),
       (pokemon: PlayerPokemon) => {
-        if (!pokemon.getLearnableLevelMoves().length)
+        if (!pokemon.getLearnableLevelMoves().length && !pokemon.getLearnableEggMoves().length)
           return PartyUiHandler.NoEffectMessage;
         return null;
       }, group);

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -1195,8 +1195,10 @@ export class RememberMoveModifier extends ConsumablePokemonModifier {
 
   apply(args: any[]): boolean {
     const pokemon = args[0] as PlayerPokemon;
+    const moves = pokemon.getLearnableLevelMoves();
+    moves.push(...pokemon.getLearnableEggMoves());
 
-    pokemon.scene.unshiftPhase(new LearnMovePhase(pokemon.scene, pokemon.scene.getParty().indexOf(pokemon), pokemon.getLearnableLevelMoves()[this.levelMoveIndex]));
+    pokemon.scene.unshiftPhase(new LearnMovePhase(pokemon.scene, pokemon.scene.getParty().indexOf(pokemon), moves[this.levelMoveIndex]));
 
     return true;
   }

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1253,7 +1253,7 @@ export class GameData {
       if (!this.starterData[speciesId].eggMoves)
         this.starterData[speciesId].eggMoves = 0;
 
-      const value = Math.pow(2, eggMoveIndex);
+      const value = Math.pow(2, eggMoveIndex); 
 
       if (this.starterData[speciesId].eggMoves & value) {
         resolve(false);
@@ -1265,6 +1265,23 @@ export class GameData {
       this.scene.playSound('level_up_fanfare');
       this.scene.ui.showText(`${eggMoveIndex === 3 ? 'Rare ' : ''}Egg Move unlocked: ${allMoves[speciesEggMoves[speciesId][eggMoveIndex]].name}`, null, () => resolve(true), null, true);
     });
+  }
+
+  /**
+   * @returns {Moves}[] An array of every egg move the player has unlocked for a given species
+   * @param species {PokemonSpecies} species to get the egg moves of
+   */
+  getUnlockedEggMoves(species: PokemonSpecies): Moves[] {
+    const unlockedEggMoves=[];
+    const speciesId = species.getRootSpeciesId(true);
+    if (speciesEggMoves.hasOwnProperty(speciesId) && this.starterData[speciesId].eggMoves){
+      for (let eggMoveIndex = 0; eggMoveIndex < speciesEggMoves[speciesId].length; eggMoveIndex++){
+        const value = Math.pow(2, eggMoveIndex);
+        if (this.starterData[speciesId].eggMoves & value)
+          unlockedEggMoves.push(speciesEggMoves[speciesId][eggMoveIndex]);
+      }
+    }
+    return unlockedEggMoves;
   }
 
   updateSpeciesDexIvs(speciesId: Species, ivs: integer[]): void {

--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -17,6 +17,7 @@ import { addWindow } from "./ui-theme";
 import { SpeciesFormChangeItemTrigger } from "../data/pokemon-forms";
 import { getVariantTint } from "#app/data/variant";
 import {Button} from "../enums/buttons";
+import { speciesEggMoves } from "#app/data/egg-moves.js";
 
 const defaultMessage = 'Choose a Pokémon.';
 
@@ -546,6 +547,8 @@ export default class PartyUiHandler extends MessageUiHandler {
     const learnableLevelMoves = this.partyUiMode === PartyUiMode.REMEMBER_MOVE_MODIFIER
         ? pokemon.getLearnableLevelMoves()
         : null;
+    if (this.partyUiMode === PartyUiMode.REMEMBER_MOVE_MODIFIER) // Append egg moves to relearn options on starters
+      learnableLevelMoves.push(...pokemon.getLearnableEggMoves());
 
     const itemModifiers = this.partyUiMode === PartyUiMode.MODIFIER_TRANSFER
       ? this.scene.findModifiers(m => m instanceof PokemonHeldItemModifier
@@ -617,6 +620,7 @@ export default class PartyUiHandler extends MessageUiHandler {
         this.options.push(PartyOption.MOVE_1 + m);
     } else if (this.partyUiMode === PartyUiMode.REMEMBER_MOVE_MODIFIER) {
       const learnableMoves = pokemon.getLearnableLevelMoves();
+      learnableMoves.push(...pokemon.getLearnableEggMoves())
       for (let m = 0; m < learnableMoves.length; m++)
         this.options.push(m);
     } else {


### PR DESCRIPTION
Somewhat simple fix for a QOL issue.

Currently egg moves are mostly balanced around the last stage of a mon's line, including Megas. So occasionally you'll have to bring in an egg move that's dead weight until you reach the stage it's intended for. You might also accidentally delete egg moves during move learning.

This PR allows you to relearn an unlocked egg move with the Memory Mushroom _only if you brought that mon into the run as a starter_. It also adds a function, "getUnlockedEggMoves", which may be useful in the future.