### PR TITLE
Prevent Pokemon Info screen from being covered up

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -4322,6 +4322,7 @@ export class AttemptCapturePhase extends PokemonPhase {
         if (this.scene.getParty().length === 6) {
           const promptRelease = () => {
             this.scene.ui.showText(`Your party is full.\nRelease a Pokémon to make room for ${pokemon.name}?`, null, () => {
+              this.scene.pokemonInfoContainer.makeRoomForConfirmUi();
               this.scene.ui.setMode(Mode.CONFIRM, () => {
                 this.scene.ui.setMode(Mode.PARTY, PartyUiMode.RELEASE, this.fieldIndex, (slotIndex: integer, _option: PartyOption) => {
                   this.scene.ui.setMode(Mode.MESSAGE).then(() => {

--- a/src/ui/confirm-ui-handler.ts
+++ b/src/ui/confirm-ui-handler.ts
@@ -5,6 +5,9 @@ import i18next from "i18next";
 import {Button} from "../enums/buttons";
 
 export default class ConfirmUiHandler extends AbstractOptionSelectUiHandler {
+
+  public static readonly windowWidth: integer = 48;
+
   private switchCheck: boolean;
   private switchCheckCursor: integer;
 
@@ -13,7 +16,7 @@ export default class ConfirmUiHandler extends AbstractOptionSelectUiHandler {
   }
 
   getWindowWidth(): integer {
-    return 48;
+    return ConfirmUiHandler.windowWidth;
   }
 
   show(args: any[]): boolean {

--- a/src/ui/pokemon-info-container.ts
+++ b/src/ui/pokemon-info-container.ts
@@ -9,8 +9,11 @@ import { getNatureName } from "../data/nature";
 import * as Utils from "../utils";
 import { Type } from "../data/type";
 import { getVariantTint } from "#app/data/variant";
+import ConfirmUiHandler from "./confirm-ui-handler";
 
 export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
+  private readonly infoWindowWidth = 104;
+  
   private pokemonGenderLabelText: Phaser.GameObjects.Text;
   private pokemonGenderText: Phaser.GameObjects.Text;
   private pokemonAbilityLabelText: Phaser.GameObjects.Text;
@@ -37,7 +40,7 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
   }
 
   setup(): void {
-    const infoBg = addWindow(this.scene, 0, 0, 104, 132);
+    const infoBg = addWindow(this.scene, 0, 0, this.infoWindowWidth, 132);
     infoBg.setOrigin(0.5, 0.5);
 
     this.pokemonMovesContainer = this.scene.add.container(6, 14);
@@ -172,7 +175,7 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
         targets: this,
         duration: Utils.fixedInt(Math.floor(750 / speedMultiplier)),
         ease: 'Cubic.easeInOut',
-        x: this.initialX - 104,
+        x: this.initialX - this.infoWindowWidth,
         onComplete: () => {
           resolve();
         }
@@ -198,6 +201,20 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
 
       this.setVisible(true);
       this.shown = true;
+    });
+  }
+
+  makeRoomForConfirmUi(speedMultiplier: number = 1): Promise<void> {
+    return new Promise<void>(resolve => {
+      this.scene.tweens.add({
+        targets: this,
+        duration: Utils.fixedInt(Math.floor(750 / speedMultiplier)),
+        ease: 'Cubic.easeInOut',
+        x: this.initialX - this.infoWindowWidth - ConfirmUiHandler.windowWidth,
+        onComplete: () => {
+          resolve();
+        }
+      });
     });
   }
 

--- a/src/ui/pokemon-info-container.ts
+++ b/src/ui/pokemon-info-container.ts
@@ -208,7 +208,7 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
     return new Promise<void>(resolve => {
       this.scene.tweens.add({
         targets: this,
-        duration: Utils.fixedInt(Math.floor(750 / speedMultiplier)),
+        duration: Utils.fixedInt(Math.floor(150 / speedMultiplier)),
         ease: 'Cubic.easeInOut',
         x: this.initialX - this.infoWindowWidth - ConfirmUiHandler.windowWidth,
         onComplete: () => {


### PR DESCRIPTION
Prevents the yes/no confirm menu from getting in the way when the Pokemon Info screen is open when catching a new Pokemon with a full party. Maybe subjective whether or not this is improved but I think it's nicer this way since you can actually read the ability and nature completely.

Before:

https://github.com/pagefaultgames/pokerogue/assets/9343160/97e62850-970f-4a99-8a40-c73ce9439bbf


After:

https://github.com/pagefaultgames/pokerogue/assets/9343160/3ae328a4-5286-4afd-ae1b-0fab0e99e1fc

