### PR TITLE
made enigma berries and lum berries able to proc more than once per turn

### DIFF
--- a/src/data/berry.ts
+++ b/src/data/berry.ts
@@ -1,4 +1,4 @@
-import { PokemonHealPhase, StatChangePhase } from "../phases";
+import { PokemonHealPhase, StatChangePhase, TurnEndPhase } from "../phases";
 import { getPokemonMessage } from "../messages";
 import Pokemon, { HitResult } from "../field/pokemon";
 import { getBattleStatName } from "./battle-stat";
@@ -36,7 +36,7 @@ export type BerryPredicate = (pokemon: Pokemon) => boolean;
 export function getBerryPredicate(berryType: BerryType): BerryPredicate {
   switch (berryType) {
     case BerryType.SITRUS:
-      return (pokemon: Pokemon) => pokemon.getHpRatio() < 0.5;
+      return (pokemon: Pokemon) => pokemon.getHpRatio() < 0.5 && pokemon.scene.getCurrentPhase() instanceof TurnEndPhase;
     case BerryType.LUM:
       return (pokemon: Pokemon) => !!pokemon.status || !!pokemon.getTag(BattlerTagType.CONFUSED);
     case BerryType.ENIGMA:
@@ -50,19 +50,19 @@ export function getBerryPredicate(berryType: BerryType): BerryPredicate {
         const threshold = new Utils.NumberHolder(0.25);
         const battleStat = (berryType - BerryType.LIECHI) as BattleStat;
         applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, null, threshold);
-        return pokemon.getHpRatio() < threshold.value && pokemon.summonData.battleStats[battleStat] < 6;
+        return pokemon.getHpRatio() < threshold.value && pokemon.summonData.battleStats[battleStat] < 6 && pokemon.scene.getCurrentPhase() instanceof TurnEndPhase;
       };
     case BerryType.LANSAT:
       return (pokemon: Pokemon) => {
         const threshold = new Utils.NumberHolder(0.25);
         applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, null, threshold);
-        return pokemon.getHpRatio() < 0.25 && !pokemon.getTag(BattlerTagType.CRIT_BOOST);
+        return pokemon.getHpRatio() < 0.25 && !pokemon.getTag(BattlerTagType.CRIT_BOOST) && pokemon.scene.getCurrentPhase() instanceof TurnEndPhase;
       };
     case BerryType.STARF:
       return (pokemon: Pokemon) => {
         const threshold = new Utils.NumberHolder(0.25);
         applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, null, threshold);
-        return pokemon.getHpRatio() < 0.25;
+        return pokemon.getHpRatio() < 0.25 && pokemon.scene.getCurrentPhase() instanceof TurnEndPhase;
       };
     case BerryType.LEPPA:
       return (pokemon: Pokemon) => {

--- a/src/data/berry.ts
+++ b/src/data/berry.ts
@@ -40,7 +40,7 @@ export function getBerryPredicate(berryType: BerryType): BerryPredicate {
     case BerryType.LUM:
       return (pokemon: Pokemon) => !!pokemon.status || !!pokemon.getTag(BattlerTagType.CONFUSED);
     case BerryType.ENIGMA:
-      return (pokemon: Pokemon) => !!pokemon.turnData.attacksReceived.filter(a => a.result === HitResult.SUPER_EFFECTIVE).length;
+      return (pokemon: Pokemon) => !!pokemon.turnData.attacksReceived.filter(a => a.result === HitResult.SUPER_EFFECTIVE).length && !(pokemon.scene.getCurrentPhase() instanceof TurnEndPhase);
     case BerryType.LIECHI:
     case BerryType.GANLON:
     case BerryType.PETAYA:

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2584,8 +2584,20 @@ export class MoveEffectPhase extends PokemonPhase {
   }
 
   end() {
+
+    
+    if (this.getTarget()?.isActive()) {
+      const target = this.getTarget()
+      const hasUsableBerry = !!this.scene.findModifier(m => m instanceof BerryModifier && m.shouldApply([ target ]), target.isPlayer());
+      if (hasUsableBerry)
+        this.scene.unshiftPhase(new BerryPhase(this.scene, target.getBattlerIndex()));
+      }
+    
     const user = this.getUserPokemon();
     if (user) {
+      const hasUsableBerry = !!this.scene.findModifier(m => m instanceof BerryModifier && m.shouldApply([ user ]), user.isPlayer());
+      if (hasUsableBerry)
+        this.scene.unshiftPhase(new BerryPhase(this.scene, user.getBattlerIndex()));
       if (--user.turnData.hitsLeft >= 1 && this.getTarget()?.isActive())
         this.scene.unshiftPhase(this.getNewHitPhase());
       else {


### PR DESCRIPTION
fixes issue #1169
I think this issue is actually a bit up to interpretation, because in mainline pokemon games you cannot have more than 1 berry at once. 
Normally, if you are below 50% hp for example and obtain a Sitrus berry, you will heal immediately.
However I'm not sure if Sitrus berries and stat raising berries proccing multiple times per turn is desirable, so I have added the requirement to them that they can only be procced during the TurnEndPhase.
However, I made Enigma and Lum berries able to proc multiple times per turn, this is currently checked for both the user and the opponent after using a move or being targeted by a move.
Note: This means that (as in cart) if you select a move and are afflicted by an status that would prevent you from using that move, but have a Lum berry, it will clear the status immediately and you will be able to use the move.
There might be edge cases.