### PR TITLE
Correction to French ability-trigger.ts

### DIFF
--- a/src/locales/fr/ability-trigger.ts
+++ b/src/locales/fr/ability-trigger.ts
@@ -2,5 +2,5 @@ import { SimpleTranslationEntries } from "#app/plugins/i18n";
 
 export const abilityTriggers: SimpleTranslationEntries = {
     'blockRecoilDamage' : `{{abilityName}}\nde {{pokemonName}} le protège du contrecoup !`,
-    'badDreams': `{{pokemonName}} est tourmenté!`
+    'badDreams': `{{pokemonName}} a le sommeil agité !`
 } as const;


### PR DESCRIPTION
Proper French translation to Bad Dreams trigger

![Mauvais_Rêve_USUL](https://github.com/pagefaultgames/pokerogue/assets/2070109/dbce37c1-e3f5-4723-8be2-dd883edd5876)
Image from SM, still up to date in SV