### PR TITLE
Tie event end date to UTC

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1127,7 +1127,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     let shinyThreshold = new Utils.IntegerHolder(32);
     if (thresholdOverride === undefined) {
       if (!this.hasTrainer()) {
-        if (new Date() < new Date(2024, 4, 21, 20))
+        if (new Date() < new Date(Date.UTC(2024, 4, 22, 0)))
           shinyThreshold.value *= 3;
         this.scene.applyModifiers(ShinyRateBoosterModifier, true, shinyThreshold);
       }


### PR DESCRIPTION
Corrects the Event ending time to be same for everyone by using UTC.