### PR TITLE
Allow opening menu in item reroll.

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -3454,7 +3454,7 @@ export class TrainerVictoryPhase extends BattlePhase {
   }
 
   start() {
-    this.scene.disableMenu = true;
+    this.scene.disableMenu = false;
 
     this.scene.playBgm(this.scene.currentBattle.trainer.config.victoryBgm);
 

--- a/src/ui-inputs.ts
+++ b/src/ui-inputs.ts
@@ -110,6 +110,7 @@ export class UiInputs {
             case Mode.FIGHT:
             case Mode.BALL:
             case Mode.TARGET_SELECT:
+            case Mode.MODIFIER_SELECT:
             case Mode.SAVE_SLOT:
             case Mode.PARTY:
             case Mode.SUMMARY:


### PR DESCRIPTION
Allows you to enter the menu screen from the item selection screen after battle. Don't know why it's not allowed to begin with, if you go in to the transfer screen, then open the menu up -- it works.