### PR TITLE
Scrafty line does not have Trailblaze in their TM learnset

### DIFF
--- a/src/data/tms.ts
+++ b/src/data/tms.ts
@@ -63413,6 +63413,8 @@ export const tmSpecies: TmSpecies = {
     Species.LEAVANNY,
     Species.PETILIL,
     Species.LILLIGANT,
+    Species.SCRAGGY,
+    Species.SCRAFTY,
     Species.DUCKLETT,
     Species.SWANNA,
     Species.DEERLING,


### PR DESCRIPTION
# Fixes Issue #1225

Really easy fix; just added Scrafty and Scraggy to the TM list for Trailblaze.

Testing for it:

[Video](https://github.com/pagefaultgames/pokerogue/assets/71776311/ab97fe05-7b28-405a-9c65-c4a7e4299371)




