### PR TITLE
Get the correct faction's party size for Last Respects

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -7270,7 +7270,8 @@ export function initMoves() {
       .recklessMove(),
     new AttackMove(Moves.LAST_RESPECTS, Type.GHOST, MoveCategory.PHYSICAL, 50, 100, 10, -1, 0, 9)
       .attr(MovePowerMultiplierAttr, (user, target, move) => {
-          return user.scene.getParty().reduce((acc, pokemonInParty) => acc + (pokemonInParty.status?.effect == StatusEffect.FAINT ? 1 : 0),
+          const party = user.isPlayer() ? user.scene.getParty() : user.scene.getEnemyParty();
+          return party.reduce((acc, pokemonInParty) => acc + (pokemonInParty.status?.effect == StatusEffect.FAINT ? 1 : 0),
           1,)
         })
       .makesContact(false),


### PR DESCRIPTION
This is for resolving: 
https://github.com/pagefaultgames/pokerogue/issues/1208

Code change checks for if you're the player or not and gets the appropriate party accordingly. 

Of note is currently for wild battles, the 2 wild ones on the field are part of the same 'party' even though wild pokemon do not normally have a party. In my opinion, this should just count anyways since you figure they're fighting together against the player and don't attack each other, alleging at least a loose comradery. Were horde battles, the 5 v 1 battles seen in the official games, added, I would argue the same for those as well.

If the above note isn't desirable, it should be as simple as checking if the enemy is wild and then setting party count to 1 if it is, though I feel that'd also just be less interesting for gameplay.