### PR TITLE
Remove TODO from Blizzard (This was a glitched feature)

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -4892,7 +4892,7 @@ export function initMoves() {
       .attr(StatusEffectAttr, StatusEffect.FREEZE),
     new AttackMove(Moves.BLIZZARD, Type.ICE, MoveCategory.SPECIAL, 110, 70, 5, 10, 0, 1)
       .attr(BlizzardAccuracyAttr)
-      .attr(StatusEffectAttr, StatusEffect.FREEZE) // TODO: 30% chance to hit protect/detect in hail
+      .attr(StatusEffectAttr, StatusEffect.FREEZE)
       .windMove()
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new AttackMove(Moves.PSYBEAM, Type.PSYCHIC, MoveCategory.SPECIAL, 65, 100, 20, 10, 0, 1)


### PR DESCRIPTION
# Fixes #805 

I just removed a comment, nothing else. The TODO refers to the below, but you can also see it was patched the next game. 

> When used during [hail](https://bulbapedia.bulbagarden.net/wiki/Hail_(weather_condition)), Blizzard bypasses [accuracy](https://bulbapedia.bulbagarden.net/wiki/Stat#Accuracy) checks to always hit, unless the target is in the [semi-invulnerable turn](https://bulbapedia.bulbagarden.net/wiki/Semi-invulnerable_turn) of a move such as [Dig](https://bulbapedia.bulbagarden.net/wiki/Dig_(move)) or [Fly](https://bulbapedia.bulbagarden.net/wiki/Fly_(move)). In [Pokémon Diamond and Pearl](https://bulbapedia.bulbagarden.net/wiki/Pok%C3%A9mon_Diamond_and_Pearl_Versions), due to a glitch, when used in hail, it has a 30% chance to hit a target that has used [Protect](https://bulbapedia.bulbagarden.net/wiki/Protect_(move)) or [Detect](https://bulbapedia.bulbagarden.net/wiki/Detect_(move)); this was fixed in [Pokémon Platinum](https://bulbapedia.bulbagarden.net/wiki/Pok%C3%A9mon_Platinum_Version) onward.