### PR TITLE
Allow BattleInfo to slightly move when Pokemon is targeted in double battles 

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2765,6 +2765,10 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     this.battleInfo?.destroy();
     super.destroy();
   }
+
+  getBattleInfo(): BattleInfo {
+    return this.battleInfo;
+  }
 }
 
 export default interface Pokemon {

--- a/src/ui/battle-info.ts
+++ b/src/ui/battle-info.ts
@@ -12,6 +12,8 @@ import { BattleStat } from "#app/data/battle-stat";
 const battleStatOrder = [ BattleStat.ATK, BattleStat.DEF, BattleStat.SPATK, BattleStat.SPDEF, BattleStat.ACC, BattleStat.EVA, BattleStat.SPD ];
 
 export default class BattleInfo extends Phaser.GameObjects.Container {
+  private baseY: number;
+
   private player: boolean;
   private mini: boolean;
   private boss: boolean;
@@ -57,6 +59,7 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
 
   constructor(scene: Phaser.Scene, x: number, y: number, player: boolean) {
     super(scene, x, y);
+    this.baseY = y;
     this.player = player;
     this.mini = !player;
     this.boss = false;
@@ -417,6 +420,7 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
 
     this.x += 10 * (offset === this.player ? 1 : -1);
     this.y += 27 * (offset ? 1 : -1);
+    this.baseY = this.y;
   }
 
   updateInfo(pokemon: Pokemon, instant?: boolean): Promise<void> {
@@ -654,6 +658,14 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
     battleStatOrder.map((s, i) => {
       this.statNumbers[i].setFrame(battleStats[s].toString());
     });
+  }
+
+  getBaseY(): number {
+    return this.baseY;
+  }
+
+  resetY(): void {
+    this.y = this.baseY;
   }
 }
 

--- a/src/ui/target-select-ui-handler.ts
+++ b/src/ui/target-select-ui-handler.ts
@@ -16,6 +16,7 @@ export default class TargetSelectUiHandler extends UiHandler {
 
   private targets: BattlerIndex[];
   private targetFlashTween: Phaser.Tweens.Tween;
+  private targetBattleInfoMoveTween: Phaser.Tweens.Tween;
 
   constructor(scene: BattleScene) {
     super(scene, Mode.TARGET_SELECT);
@@ -116,6 +117,25 @@ export default class TargetSelectUiHandler extends UiHandler {
       }
     });
 
+    if (this.targetBattleInfoMoveTween) {
+      this.targetBattleInfoMoveTween.stop();
+      const lastTarget = this.scene.getField()[lastCursor];
+      if (lastTarget) {
+        lastTarget.getBattleInfo().resetY();
+      }
+    }
+
+    const targetBattleInfo = target.getBattleInfo();
+
+    this.targetBattleInfoMoveTween = this.scene.tweens.add({
+      targets: [ targetBattleInfo ],
+      y: { start: targetBattleInfo.getBaseY(), to: targetBattleInfo.getBaseY() + 1 },
+      loop: -1,
+      duration: Utils.fixedInt(250),
+      ease: "Linear",
+      yoyo: true
+    });
+
     return ret;
   }
 
@@ -127,6 +147,15 @@ export default class TargetSelectUiHandler extends UiHandler {
     }
     if (target) {
       target.setAlpha(1);
+    }
+
+    const targetBattleInfo = target.getBattleInfo();
+    if (this.targetBattleInfoMoveTween) {
+      this.targetBattleInfoMoveTween.stop();
+      this.targetBattleInfoMoveTween = null;
+    }
+    if (targetBattleInfo) {
+      targetBattleInfo.resetY();
     }
   }
 


### PR DESCRIPTION
## What are the changes?

This PR aims at allowing the battle info of the targeted enemy Pokemon to move during double battles. Currently, only the Pokemon itself allows to know the targeted enemy Pokemon, by continuously modifying the opacity. This PR aims at allowing the battle info to move as well.

For the context, I'm referencing this as a `BattleInfo`:
![image](https://github.com/pagefaultgames/pokerogue/assets/57403591/076bc03d-70e2-4e84-83b9-7f998cf95d60)


I was inspired by _Pokemon Emerald_ UI on this, where the battle info of the targeted enemy Pokemon moves as well (I actually took inspiration from this video on [Youtube](https://www.youtube.com/watch?v=DIu0hFzxzxQ)).

https://github.com/pagefaultgames/pokerogue/assets/57403591/c8cbb868-026a-41cc-abc2-426c6ef60d46

## Why am I doing these changes?
I'm a big fan of the Pokemon license, but I need to say I wasn't following all the new generations (I probably kinda stopped around gen 5 or 6). Because of that, during double battles, I was struggling a bit to understand which "battle info" I was targeting, and it happened more than once that I actually chose the wrong Pokemon because of my lack of Pokemon knowledge.

I believe that this change will help players like me to better understand which Pokemon they are targeting during double battles.

## What did change?

Before, the battle info of the targeted enemy Pokemon was never moving. The only way to know which Pokemon was targeted was by looking at the Pokemon itself, which was changing its opacity.

Now, the battle info moves as well when the enemy Pokemon is targeted. It will move up and down by a bit in a linear way to make it clear that the player is targeting this Pokemon (and the related battle info).

### Videos

Before:

https://github.com/pagefaultgames/pokerogue/assets/57403591/b5f2d885-abfd-4620-b337-2eefbabda5e7

After:

https://github.com/pagefaultgames/pokerogue/assets/57403591/9395cd52-2f85-4919-8d22-143a8cfe11e2

## How to test the changes?
I currently tested the changes manually, as I currently don't know how easy it would be to write actual tests for this. I'm open to any feedback on how to improve the testing process.

I've been using the [`src/overrides.ts`](https://github.com/pagefaultgames/pokerogue/blob/6952fe065b44c0c6371f0a575b8cf5fb8e97dbe3/src/overrides.ts) file to test the changes.

To do so, I just enabled double battles, and ensured to have an attacking move, an all-enemy focuses move, and a move affecting every other Pokemon on the field. I've been using `TACKLE`, `RAZOR_LEAF` and `SURF` for this purpose.
was changed to
```typescript
// ...
export const DOUBLE_BATTLE_OVERRIDE: boolean = true;
// ...
export const MOVESET_OVERRIDE: Array<Moves> = [Moves.TACKLE, Moves.RAZOR_LEAF, Moves.SURF];
// ...
```

Since this is just UI changes, I believe I'm not introducing any new bugs.

## Alternatives
<details>
  <summary>Before edit</summary>
  Currently, I'm making the box move in a fluent way. We can make it move in a more "jumpy" way, like in _Pokemon Emerald_, but I'm not sure it would fit the current UX/UI of the game, as the Pokemon itself is changing its opacity in a fluent way as well (as opposed to the "jumpy" way in Pokemon Emerald). I'm open to any feedback on this.
</details>

I currently make the box move up and down in a linear way. Does that look good from a UX perspective?

Of course, I'm open to any suggestion regarding this change, or about a way to make the double battles more user-friendly.
