### PR TITLE
Fix Run Away to bypass trapping

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1815,8 +1815,14 @@ export class CommandPhase extends FieldPhase {
           const trapTag = playerPokemon.findTag(t => t instanceof TrappedTag) as TrappedTag;
           const trapped = new Utils.BooleanHolder(false);
           const batonPass = isSwitch && args[0] as boolean;
-          if (!batonPass)
+          const runAway = playerPokemon.hasAbility(Abilities.RUN_AWAY) as boolean;
+          if (!batonPass) 
             enemyField.forEach(enemyPokemon => applyCheckTrappedAbAttrs(CheckTrappedAbAttr, enemyPokemon, trapped, playerPokemon));
+          if(!isSwitch && runAway) {
+            success = true;
+            this.scene.currentBattle.turnCommands[this.fieldIndex] = { command: Command.RUN };
+            break;
+          }
           if (batonPass || (!trapTag && !trapped.value)) {
             this.scene.currentBattle.turnCommands[this.fieldIndex] = isSwitch
               ? { command: Command.POKEMON, cursor: cursor, args: args }


### PR DESCRIPTION
Currently the logic for checking trapping does not account for the ability Run Away. Run Away is supposed to bypass trapping for running specifically, but not allow switching. In order to accomplish this, we need to add the specific case that ignores trapping if the run command is used and the player Pokemon has the ability run away. 

Test for Run Away facing Arena Trap:
https://github.com/pagefaultgames/pokerogue/assets/132619649/1d404c3c-3f7a-4782-99c8-4c521bbf4662

Test for Flash Fire facing Arena Trap:
https://github.com/pagefaultgames/pokerogue/assets/132619649/dd57338f-9645-4eb6-814b-bc4cb5839b9f

Test for Flash Fire facing Sand Veil:
https://github.com/pagefaultgames/pokerogue/assets/132619649/5bab8350-2d26-4cd0-902a-9d8b76ba3aa7

