### PR TITLE
TM Shop Step 1: Add flags in save data to track TMs unlocked by player

### DIFF
--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -1204,7 +1204,7 @@ export class TmModifier extends ConsumablePokemonModifier {
   apply(args: any[]): boolean {
     const pokemon = args[0] as PlayerPokemon;
 
-    pokemon.scene.unshiftPhase(new LearnMovePhase(pokemon.scene, pokemon.scene.getParty().indexOf(pokemon), (this.type as ModifierTypes.TmModifierType).moveId));
+    pokemon.scene.unshiftPhase(new LearnMovePhase(pokemon.scene, pokemon.scene.getParty().indexOf(pokemon), (this.type as ModifierTypes.TmModifierType).moveId, true));
 
     return true;
   }

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -4292,7 +4292,9 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
               this.scene.playSound("level_up_fanfare");
               this.scene.ui.showText(i18next.t("battle:learnMove", { pokemonName: pokemon.name, moveName: move.name }), null, () => {
                 this.scene.triggerPokemonFormChange(pokemon, SpeciesFormChangeMoveLearnedTrigger, true);
-                if (this.isFromTMDrop) this.scene.gameData.setTMMoveUnlocked(this.moveId);
+                if (this.isFromTMDrop) {
+                  this.scene.gameData.setTMMoveUnlocked(this.moveId);
+                }
                 this.end();
               }, messageMode === Mode.EVOLUTION_SCENE ? 1000 : null, true);
             });

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -4254,11 +4254,13 @@ export class LevelUpPhase extends PlayerPartyMemberPokemonPhase {
 
 export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
   private moveId: Moves;
+  private isFromTMDrop: boolean;
 
-  constructor(scene: BattleScene, partyMemberIndex: integer, moveId: Moves) {
+  constructor(scene: BattleScene, partyMemberIndex: integer, moveId: Moves, isFromTMDrop?: boolean) {
     super(scene, partyMemberIndex);
 
     this.moveId = moveId;
+    this.isFromTMDrop=isFromTMDrop;
   }
 
   start() {
@@ -4290,6 +4292,7 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
               this.scene.playSound("level_up_fanfare");
               this.scene.ui.showText(i18next.t("battle:learnMove", { pokemonName: pokemon.name, moveName: move.name }), null, () => {
                 this.scene.triggerPokemonFormChange(pokemon, SpeciesFormChangeMoveLearnedTrigger, true);
+                if (this.isFromTMDrop) this.scene.gameData.setTMMoveUnlocked(this.moveId);
                 this.end();
               }, messageMode === Mode.EVOLUTION_SCENE ? 1000 : null, true);
             });

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1220,8 +1220,9 @@ export class GameData {
   }
 
   setTMNoUnlocked(tmNo: integer): void {
-    if(!this.isTmNoUnlocked(tmNo))
+    if(!this.isTmNoUnlocked(tmNo)) {
       this.tmFlags[tmNo/32] |= Math.pow(2,tmNo%32);
+    }
   }
 
   setTMMoveUnlocked(moveId: integer): void {


### PR DESCRIPTION
Just a draft for now. This PR will make the game start to track which TMs players have "unlocked". This is represented by an array of 10 32 bit integers in the save data. Each bit represents a TM that's been unlocked. I also made functions to convert from TM number to Move number and vice versa. The way I implemented it, a TM will be permanently "unlocked" for the account when the player teaches their mon a move using that TM.

Obviously this doesn't implement a TM shop, but I believe this is a good first step, as I think at the very least keeping track of this will be relevant for our implementation.

Personally, I think the TM shop should have a pool of 5 random TMs available as well as any TM the player has unlocked. TMs probably shouldn't be unlocked by buying in the shop. I also think some TMs could be unlocked in other ways, for example by defeating Gym Leaders, or unlocking the "ultimate" moves like Hydro Cannon or Hyper Beam by beating Classic Mode the first time. This can be discussed on the discord.