### PR TITLE
Add Memory Mushroom to the Shop on Floors 141+

### DIFF
--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1671,7 +1671,8 @@ export function getPlayerShopModifierTypeOptionsForWave(waveIndex: integer, base
       new ModifierTypeOption(modifierTypes.MAX_ELIXIR(), 0, baseCost * 2.5)
     ],
     [
-      new ModifierTypeOption(modifierTypes.FULL_RESTORE(), 0, baseCost * 2.25)
+      new ModifierTypeOption(modifierTypes.FULL_RESTORE(), 0, baseCost * 2.25),
+      new ModifierTypeOption(modifierTypes.MEMORY_MUSHROOM(), 0, baseCost * 1.5)
     ],
     [
       new ModifierTypeOption(modifierTypes.SACRED_ASH(), 0, baseCost * 10)


### PR DESCRIPTION
## Summary
Adds Memory Mushroom to the shop beginning at Floor 141+ to Classic and Endless modes. 
The starting price is 1.5x base price, equal to a Max Potion.

## Test Case
Using local dev server:
Begin run at 139 -> check shop
Continue to 141 -> check shop (140 has no shop)

https://github.com/pagefaultgames/pokerogue/assets/43153371/1e6c3a33-aca6-4617-bf13-0aa96891a31c

