### PR TITLE
add generics to number holder utils

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -298,22 +298,22 @@ export class BooleanHolder {
   }
 }
 
-export class NumberHolder {
-  public value: number;
+export class NumberHolder<T = number> {
+  public value: T;
 
-  constructor(value: number) {
+  constructor(value: T) {
     this.value = value;
   }
 }
 
-export class IntegerHolder extends NumberHolder {
-  constructor(value: integer) {
+export class IntegerHolder<T = integer> extends NumberHolder<T> {
+  constructor(value: T) {
     super(value);
   }
 }
 
-export class FixedInt extends IntegerHolder {
-  constructor(value: integer) {
+export class FixedInt<T = integer> extends IntegerHolder<T> {
+  constructor(value: T) {
     super(value);
   }
 }


### PR DESCRIPTION
This is a separate PR for what I had written inside of #1309 

We currently do a lot of manual type casting in certain places because using these NumberHolder classes drops the type annotations on init
```ts
// typeof move.category -> MoveCategory
const variableCategory = new Utils.IntegerHolder(move.category);

// Mutate the holder's data
...

// typeof variableCategory.value -> number
// Because we want the variable to be of type MoveCategory we manually typecast it (which is dangerous)
const moveCategory = variableCategory.value as MoveCategory;
// typeof moveCategory -> MoveCategory
```

By using generics typescript will infer the type based on the type of what is passed to the constructor.
```ts
// typeof move.category -> MoveCategory
const variableCategory = new Utils.IntegerHolder(move.category);

// Mutate the holder's data
... 

// typeof variableCategory.value -> MoveCategory
 // Typescript is able to infer the type so a manual typecast isn't necessary
const moveCategory = variableCategory.value;
// typeof moveCategory -> MoveCategory
```