### PR TITLE
Show type of Hidden Power or other variable type moves in battle and summary

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -340,7 +340,7 @@ export class TypeImmunityAbAttr extends PreDefendAbAttr {
   }
 
   applyPreDefend(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: PokemonMove, cancelled: Utils.BooleanHolder, args: any[]): boolean {
-    if ((move.getMove() instanceof AttackMove || move.getMove().getAttrs(StatusMoveTypeImmunityAttr).find(attr => (attr as StatusMoveTypeImmunityAttr).immuneType === this.immuneType)) && move.getMove().type === this.immuneType) {
+    if ((move.getMove() instanceof AttackMove || move.getMove().getAttrs(StatusMoveTypeImmunityAttr).find(attr => (attr as StatusMoveTypeImmunityAttr).immuneType === this.immuneType)) && pokemon.getRealMoveType(move) === this.immuneType) {
       (args[0] as Utils.NumberHolder).value = 0;
       return true;
     }
@@ -435,7 +435,7 @@ export class NonSuperEffectiveImmunityAbAttr extends TypeImmunityAbAttr {
   }
 
   applyPreDefend(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: PokemonMove, cancelled: Utils.BooleanHolder, args: any[]): boolean {
-    if (move.getMove() instanceof AttackMove && pokemon.getAttackTypeEffectiveness(move.getMove().type, attacker) < 2) {
+    if (move.getMove() instanceof AttackMove && pokemon.getAttackTypeEffectiveness(pokemon.getRealMoveType(move), attacker) < 2) {
       cancelled.value = true;
       (args[0] as Utils.NumberHolder).value = 0;
       return true;
@@ -680,7 +680,7 @@ export class PostDefendApplyBattlerTagAbAttr extends PostDefendAbAttr {
 export class PostDefendTypeChangeAbAttr extends PostDefendAbAttr {
   applyPostDefend(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: PokemonMove, hitResult: HitResult, args: any[]): boolean {
     if (hitResult < HitResult.NO_EFFECT) {
-      const type = move.getMove().type;
+      const type = pokemon.getRealMoveType(move);
       const pokemonTypes = pokemon.getTypes(true);
       if (pokemonTypes.length !== 1 || pokemonTypes[0] !== type) {
         pokemon.summonData.types = [ type ];
@@ -1999,7 +1999,7 @@ function getAnticipationCondition(): AbAttrCondition {
     for (const opponent of pokemon.getOpponents()) {
       for (const move of opponent.moveset) {
         // move is super effective
-        if (move.getMove() instanceof AttackMove && pokemon.getAttackTypeEffectiveness(move.getMove().type, opponent) >= 2) {
+        if (move.getMove() instanceof AttackMove && pokemon.getAttackTypeEffectiveness(pokemon.getRealMoveType(move, true), opponent) >= 2) {
           return true;
         }
         // move is a OHKO

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1597,7 +1597,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     // 2nd argument is for MoveTypeChangePowerMultiplierAbAttr
     applyAbAttrs(VariableMoveTypeAbAttr, source, null, variableType, typeChangeMovePowerMultiplier);
     applyPreAttackAbAttrs(MoveTypeChangeAttr, source, this, battlerMove, variableType, typeChangeMovePowerMultiplier);
+
     const type = variableType.value as Type;
+    battlerMove.finalType = type;
     const types = this.getTypes(true, true);
 
     const cancelled = new Utils.BooleanHolder(false);

--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -162,13 +162,14 @@ export default class FightUiHandler extends UiHandler {
       ui.add(this.cursorObj);
     }
 
-    const moveset = (this.scene.getCurrentPhase() as CommandPhase).getPokemon().getMoveset();
+    const pokemon = (this.scene.getCurrentPhase() as CommandPhase).getPokemon();
+    const moveset = pokemon.getMoveset();
 
     const hasMove = cursor < moveset.length;
 
     if (hasMove) {
       const pokemonMove = moveset[cursor];
-      this.typeIcon.setTexture("types", Type[pokemonMove.getMove().type].toLowerCase()).setScale(0.8);
+      this.typeIcon.setTexture("types", Type[pokemon.getRealMoveType(pokemonMove)].toLowerCase()).setScale(0.8);
       this.moveCategoryIcon.setTexture("categories", MoveCategory[pokemonMove.getMove().category].toLowerCase()).setScale(1.0);
 
       const power = pokemonMove.getMove().power;

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -2,7 +2,7 @@ import BattleScene, { starterColors } from "../battle-scene";
 import { Mode } from "./ui";
 import UiHandler from "./ui-handler";
 import * as Utils from "../utils";
-import { PlayerPokemon } from "../field/pokemon";
+import { PlayerPokemon, PokemonMove } from "../field/pokemon";
 import { getStarterValueFriendshipCap, speciesStarters } from "../data/pokemon-species";
 import { argbFromRgba } from "@material/material-color-utilities";
 import { Type, getTypeRgb } from "../data/type";
@@ -897,7 +897,7 @@ export default class SummaryUiHandler extends UiHandler {
 
       if (this.summaryUiMode === SummaryUiMode.LEARN_MOVE) {
         this.extraMoveRowContainer.setVisible(true);
-        const newMoveTypeIcon = this.scene.add.sprite(0, 0, "types", Type[this.newMove.type].toLowerCase());
+        const newMoveTypeIcon = this.scene.add.sprite(0, 0, "types", Type[this.pokemon.getRealMoveType(new PokemonMove(this.newMove.id))].toLowerCase());
         newMoveTypeIcon.setOrigin(0, 1);
         this.extraMoveRowContainer.add(newMoveTypeIcon);
 
@@ -920,7 +920,7 @@ export default class SummaryUiHandler extends UiHandler {
         this.moveRowsContainer.add(moveRowContainer);
 
         if (move) {
-          const typeIcon = this.scene.add.sprite(0, 0, "types", Type[move.getMove().type].toLowerCase());
+          const typeIcon = this.scene.add.sprite(0, 0, "types", Type[this.pokemon.getRealMoveType(move)].toLowerCase());
           typeIcon.setOrigin(0, 1);
           moveRowContainer.add(typeIcon);
         }


### PR DESCRIPTION
This change makes it so that you can see the type of your Hidden Power, or any other move that can have its type changed (like Revelation Dance, Weather Ball, etc...). It even shows type changes from abilities such as Pixilate or Liquid Voice, as it does the same checks that are done in battle in the same order.

Here's some proof:


https://github.com/pagefaultgames/pokerogue/assets/22176793/823eba04-8334-4436-a051-7e2e9a1ac4ef


It also works with stuff like setting Sunny Day, it updates dynamically, first turn shows Normal then shows Fire next turn:


https://github.com/pagefaultgames/pokerogue/assets/22176793/951f2fe9-9e50-40a7-9d6e-5b017523c703


EDIT: This also fixes abilities that change move immunities/resistances, such as Flash Fire no longer being immune to Liquid Voice+Torch Song, or Tinted Lens actually doubling resisted Hidden Power in damage.
