### PR TITLE
Fix incorrectly unselectable starter formes

### DIFF
--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -794,7 +794,7 @@ export class PokemonForm extends PokemonSpeciesForm {
   public formSpriteKey: string;
 
   // This is a collection of form keys that have in-run form changes, but should still be separately selectable from the start screen
-  private starterSelectableKeys: string[] = ["10", "50", "10-pc", "50-pc", "battle-bond", "red", "orange", "yellow", "green", "blue", "indigo", "violet"];
+  private starterSelectableKeys: string[] = ["10", "50", "10-pc", "50-pc", "red", "orange", "yellow", "green", "blue", "indigo", "violet"];
 
   constructor(formName: string, formKey: string, type1: Type, type2: Type, height: number, weight: number, ability1: Abilities, ability2: Abilities, abilityHidden: Abilities,
     baseTotal: integer, baseHp: integer, baseAtk: integer, baseDef: integer, baseSpatk: integer, baseSpdef: integer, baseSpd: integer,

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -793,6 +793,9 @@ export class PokemonForm extends PokemonSpeciesForm {
   public formKey: string;
   public formSpriteKey: string;
 
+  // This is a collection of form keys that have in-run form changes, but should still be separately selectable from the start screen
+  private starterSelectableKeys: string[] = ["10", "50", "10-pc", "50-pc", "battle-bond", "red", "orange", "yellow", "green", "blue", "indigo", "violet"];
+
   constructor(formName: string, formKey: string, type1: Type, type2: Type, height: number, weight: number, ability1: Abilities, ability2: Abilities, abilityHidden: Abilities,
     baseTotal: integer, baseHp: integer, baseAtk: integer, baseDef: integer, baseSpatk: integer, baseSpdef: integer, baseSpd: integer,
     catchRate: integer, baseFriendship: integer, baseExp: integer, genderDiffs?: boolean, formSpriteKey?: string) {
@@ -805,6 +808,10 @@ export class PokemonForm extends PokemonSpeciesForm {
 
   getFormSpriteKey(_formIndex?: integer) {
     return this.formSpriteKey !== null ? this.formSpriteKey : this.formKey;
+  }
+
+  isStarterSelectable() {
+    return !this.formKey || this.starterSelectableKeys.indexOf[this.formKey] !== -1;
   }
 }
 

--- a/src/ui/battle-info.ts
+++ b/src/ui/battle-info.ts
@@ -274,7 +274,7 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
       this.ownedIcon.setVisible(!!dexEntry.caughtAttr);
       const opponentPokemonDexAttr = pokemon.getDexAttr();
       if (pokemon.scene.gameMode.isClassic) {
-        if(pokemon.scene.gameData.starterData[pokemon.species.getRootSpeciesId()].classicWinCount > 0 && pokemon.scene.gameData.starterData[pokemon.species.getRootSpeciesId(true)].classicWinCount > 0) {
+        if (pokemon.scene.gameData.starterData[pokemon.species.getRootSpeciesId()].classicWinCount > 0 && pokemon.scene.gameData.starterData[pokemon.species.getRootSpeciesId(true)].classicWinCount > 0) {
           this.championRibbon.setVisible(true);
         }
       }

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1627,7 +1627,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         this.canCycleShiny = !!(dexEntry.caughtAttr & DexAttr.NON_SHINY && dexEntry.caughtAttr & DexAttr.SHINY);
         this.canCycleGender = !!(dexEntry.caughtAttr & DexAttr.MALE && dexEntry.caughtAttr & DexAttr.FEMALE);
         this.canCycleAbility = [ abilityAttr & AbilityAttr.ABILITY_1, (abilityAttr & AbilityAttr.ABILITY_2) && species.ability2, abilityAttr & AbilityAttr.ABILITY_HIDDEN ].filter(a => a).length > 1;
-        this.canCycleForm = species.forms.filter(f => !f.formKey || !pokemonFormChanges[species.speciesId]?.find(fc => fc.formKey))
+        this.canCycleForm = species.forms.filter(f => f.isStarterSelectable || !pokemonFormChanges[species.speciesId]?.find(fc => fc.formKey))
           .map((_, f) => dexEntry.caughtAttr & this.scene.gameData.getFormAttr(f)).filter(f => f).length > 1;
         this.canCycleNature = this.scene.gameData.getNaturesForAttr(dexEntry.natureAttr).length > 1;
         this.canCycleVariant = shiny && [ dexEntry.caughtAttr & DexAttr.DEFAULT_VARIANT, dexEntry.caughtAttr & DexAttr.VARIANT_2, dexEntry.caughtAttr & DexAttr.VARIANT_3].filter(v => v).length > 1;


### PR DESCRIPTION
This PR enables selection of starter Formes that both should be selectable as starters, but that also have in-battle Forme changes, which the current starter selection logic filters out (presumably to prevent users from selecting in-battle Formes as their starter base, like having a Mega-Evo starter).

This currently appears to affect 3 Pokemon: Minior (color selection unavailable), Froakie (Battle Bond selection unavailable), and Zygarde (10%/50% Formes and Ability split selection unavailable).

This change only includes override form keys, rather than modifying the PokemonForm constructor, which would require a significantly larger code change, but this does centralize the logic in the PokemonForm class, rather than on the forme initializations, which is maybe less than ideal. Happy to make the larger code change if moving where the logic is defined is preferred.

Existing behavior for Minior / Froakie / Zygarde
[screen-capture-old.webm](https://github.com/pagefaultgames/pokerogue/assets/1302975/49dc4672-e722-4f9f-bf37-3924385483c9)

New behavior for Minio / Froakie / Zygarde
[screen-capture-new.webm](https://github.com/pagefaultgames/pokerogue/assets/1302975/6500a55e-a4ef-4bca-9616-4892b086530b)