### PR TITLE
Changing Biome Text Colour

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1249,8 +1249,8 @@ export default class BattleScene extends SceneBase {
     const isBoss = !(this.currentBattle.waveIndex % 10);
     const biomeString: string = getBiomeName(this.arena.biomeType);
     this.biomeWaveText.setText( biomeString + " - " + this.currentBattle.waveIndex.toString());
-    this.biomeWaveText.setColor(!isBoss ? "#404040" : "#f89890");
-    this.biomeWaveText.setShadowColor(!isBoss ? "#ded6b5" : "#984038");
+    this.biomeWaveText.setColor(!isBoss ? "#ffffff" : "#f89890");
+    this.biomeWaveText.setShadowColor(!isBoss ? "#636363" : "#984038");
     this.biomeWaveText.setVisible(true);
   }
 


### PR DESCRIPTION
- On light coloured biomes this change should be similar readability
- In darker biomes it's has much easier readability
- Now becomes more consistent colour with the rest of the game text which just looks better imo
old text is the grey with yellow drop shadow
![biometext](https://github.com/pagefaultgames/pokerogue/assets/17427370/3175e3dc-a8b1-4430-a711-060359c98e06)
![biometext2](https://github.com/pagefaultgames/pokerogue/assets/17427370/5968c71f-8c07-4432-94bc-9eb316100b9e)
![biometextmobile](https://github.com/pagefaultgames/pokerogue/assets/17427370/27486099-ce8a-4262-8991-ab7f4cfc447b)
