### PR TITLE
Players win if classic and past floor 200

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -3855,7 +3855,6 @@ export class GameOverPhase extends BattlePhase {
     // Failsafe if players somehow skip floor 200 in classic mode
     if (this.scene.gameMode.isClassic && this.scene.currentBattle.waveIndex > 200) {
       this.victory = true;
-      this.handleGameOver();
     }
 
     if (this.victory || !this.scene.enableRetries) {

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -730,7 +730,7 @@ export class EncounterPhase extends BattlePhase {
     this.scene.initSession();
 
     // Failsafe if players somehow skip floor 200 in classic mode
-    if (this.scene.gameMode.modeId === GameModes.CLASSIC && this.scene.currentBattle.waveIndex > 200) {
+    if (this.scene.gameMode.isClassic && this.scene.currentBattle.waveIndex > 200) {
       this.scene.unshiftPhase(new GameOverPhase(this.scene));
     }
 
@@ -3853,7 +3853,7 @@ export class GameOverPhase extends BattlePhase {
     super.start();
 
     // Failsafe if players somehow skip floor 200 in classic mode
-    if (this.scene.gameMode.modeId === GameModes.CLASSIC && this.scene.currentBattle.waveIndex > 200) {
+    if (this.scene.gameMode.isClassic && this.scene.currentBattle.waveIndex > 200) {
       this.victory = true;
       this.handleGameOver();
     }

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -729,6 +729,11 @@ export class EncounterPhase extends BattlePhase {
 
     this.scene.initSession();
 
+    // Failsafe if players somehow skip floor 200 in classic mode
+    if (this.scene.gameMode.modeId === GameModes.CLASSIC && this.scene.currentBattle.waveIndex > 200) {
+      this.scene.unshiftPhase(new GameOverPhase(this.scene));
+    }
+
     const loadEnemyAssets = [];
 
     const battle = this.scene.currentBattle;
@@ -3846,6 +3851,12 @@ export class GameOverPhase extends BattlePhase {
 
   start() {
     super.start();
+
+    // Failsafe if players somehow skip floor 200 in classic mode
+    if (this.scene.gameMode.modeId === GameModes.CLASSIC && this.scene.currentBattle.waveIndex > 200) {
+      this.victory = true;
+      this.handleGameOver();
+    }
 
     if (this.victory || !this.scene.enableRetries) {
       this.handleGameOver();


### PR DESCRIPTION
Added a check in `EncounterPhase` where if the player is in classic mode and they are past floor 200 it automatically goes to the `GameOverPhase` where the run is treated as a victory and rewards are given. 

## Testing
![](https://cdn.discordapp.com/attachments/1241164581997510656/1243731119195553894/image.png?ex=66528a5e&is=665138de&hm=df189df288d39384e1a8706d2c962827d0e4e12123f7252882ef5a518ac10ca0&)