### PR TITLE
Update zh_CN ability.ts and move.ts

### DIFF
--- a/src/locales/zh_CN/ability.ts
+++ b/src/locales/zh_CN/ability.ts
@@ -475,7 +475,7 @@ export const ability: AbilityTranslationEntries = {
   },
   frisk: {
     name: "察觉",
-    description: "出场时，可以察觉对手的持有物。",
+    description: "出场时，可以察觉对手的特性。",
   },
   reckless: {
     name: "舍身",

--- a/src/locales/zh_CN/ability.ts
+++ b/src/locales/zh_CN/ability.ts
@@ -475,7 +475,7 @@ export const ability: AbilityTranslationEntries = {
   },
   frisk: {
     name: "察觉",
-    description: "进入战斗时，神奇宝贝可以检查对方神奇宝贝的能力。",
+    description: "出场时，可以察觉对手的持有物。",
   },
   reckless: {
     name: "舍身",
@@ -1063,7 +1063,7 @@ export const ability: AbilityTranslationEntries = {
   },
   asOneGlastrier: {
     name: "人马一体",
-    description: "兼备蕾冠王的紧张感和灵幽\n马的漆黑嘶鸣这两种特性。",
+    description: "兼备蕾冠王的紧张感和雪暴\n马的苍白嘶鸣这两种特性。",
   },
   asOneSpectrier: {
     name: "人马一体",
@@ -1211,11 +1211,11 @@ export const ability: AbilityTranslationEntries = {
   },
   embodyAspectTeal: {
     name: "面影辉映",
-    description: "将回忆映于心中，让水井面\n具发出光辉，提高自己的特\n防。",
+    description: "将回忆映于心中，让碧草面\n具发出光辉，提高自己的速\n度。",
   },
   embodyAspectWellspring: {
     name: "面影辉映",
-    description: "将回忆映于心中，让碧草面\n具发出光辉，提高自己的速\n度。",
+    description: "将回忆映于心中，让水井面\n具发出光辉，提高自己的特\n防。",
   },
   embodyAspectHearthflame: {
     name: "面影辉映",

--- a/src/locales/zh_CN/move.ts
+++ b/src/locales/zh_CN/move.ts
@@ -2915,7 +2915,7 @@ export const move: MoveTranslationEntries = {
   },
   "zippyZap": {
     name: "电电加速",
-    effect: "迅猛无比的电击。必定能够\n先制攻击，击中对方的要害。",
+    effect: "迅猛无比的电击。必定能够\n先制攻击，并且提高自己的\n闪避率。",
   },
   "splishySplash": {
     name: "滔滔冲浪",

--- a/src/locales/zh_CN/move.ts
+++ b/src/locales/zh_CN/move.ts
@@ -2915,7 +2915,7 @@ export const move: MoveTranslationEntries = {
   },
   "zippyZap": {
     name: "电电加速",
-    effect: "The user attacks the target with bursts of electricity at high speed. This move always goes first and raises the user's evasiveness.",
+    effect: "迅猛无比的电击。必定能够\n先制攻击，击中对方的要害。",
   },
   "splishySplash": {
     name: "滔滔冲浪",


### PR DESCRIPTION
## What are the changes:

- fixed an error in the translation of the _Frisk_ ability.
- fixed an error in the translation of the _As One_ ability for Glastrier.
- swapped the translated description of the _Embody Aspect_ ability when carrying _Teal Mask_ and _Wellspring Mask_.