### PR TITLE
Fix first player Pokemon info being wrongly placed when targeted

### DIFF
--- a/src/ui/battle-info.ts
+++ b/src/ui/battle-info.ts
@@ -358,6 +358,7 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
 
     if (this.player) {
       this.y -= 12 * (mini ? 1 : -1);
+      this.baseY = this.y;
     }
 
     const offsetElements = [ this.nameText, this.genderText, this.teraIcon, this.splicedIcon, this.shinyIcon, this.statusIndicator, this.levelContainer ];


### PR DESCRIPTION
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This PR aims at fixing the position of the first Pokemon battle info when targeted by an ally.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
This has been reported by some players on the [Discord](https://discord.com/channels/1125469663833370665/1243457704861896786/1243457704861896786), and by @bennybroseph on the related PR https://github.com/pagefaultgames/pokerogue/pull/1255#issuecomment-2130317297.

Of course, this was not the intended behavior.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Before, we were offsetting the battle info position if it was the first player Pokemon, while the base position, being used for the UI for the `SelectTargetPhase`, was not.

Now, we make sure to also offset the base position in this case.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
Before:

https://github.com/pagefaultgames/pokerogue/assets/57403591/d1c9779c-e6cf-4c59-9112-b85294942931

After:

https://github.com/pagefaultgames/pokerogue/assets/57403591/ba1559db-efaa-441f-b440-120e5fbb40fd

## How to test the changes?
<!-- How can a reviewer test your changes once he checks out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
I currently tested the changes manually, as I currently don't know how easy it would be to write actual tests for this. I'm open to any feedback on how to improve the testing process.

I've been using the [`src/overrides.ts`](https://github.com/pagefaultgames/pokerogue/blob/6952fe065b44c0c6371f0a575b8cf5fb8e97dbe3/src/overrides.ts) file to test the changes.

To do so, I just enabled double battles, and ensured to have an attacking move. I've been using `TACKLE` for this purpose.
The [`src/overrides.ts`](https://github.com/pagefaultgames/pokerogue/blob/4277439a2d110cfc933954019592cdfd271fdfb3/src/overrides.ts) was changed to
```typescript
// ...
export const DOUBLE_BATTLE_OVERRIDE: boolean = true;
// ...
export const MOVESET_OVERRIDE: Array<Moves> = [Moves.TACKLE];
// ...
```

Then, I checked that:
- When targeting with my first Pokemon the 2 enemy Pokemon, or my ally, it behaves as expected
- When targeting with my second Pokemon the 2 enemy Pokemon, or my ally, it behaves as expected

## Checklist
- [x] Have I checked that there is no overlap with another PR?
- [x] Have I made sure the PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?