### PR TITLE
Implement Spectral Thief

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2924,7 +2924,7 @@ export class StealStatBoostsAttr extends PreAttackStatChangeAttr {
       // For each battle stat, check if any boosts were stolen and apply them to the user
       targetBoosts.forEach((boost, index) => {
         if (boost > 0) {
-          user.scene.unshiftPhase(new StatChangePhase(user.scene, user.getBattlerIndex(), true, [index], boost));
+          user.scene.overridePhase(new StatChangePhase(user.scene, user.getBattlerIndex(), true, [index], boost));
         }
       });
 

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2890,6 +2890,51 @@ export class DefDefAttr extends VariableDefAttr {
   }
 }
 
+/**
+ * Attribute used for moves that change the stats of the user before dealing damage
+ * @extends MoveAttr
+ */
+export class PreAttackStatChangeAttr extends MoveAttr {
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    return false;
+  }
+}
+
+/**
+ * Attribute used for moves that steal the enemy's positive stat boosts before dealing damage
+ * @extends PreAttackStatChangeAttr
+ */
+export class StealStatBoostsAttr extends PreAttackStatChangeAttr {
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    // Can't steal if the move doesn't land
+    const canHit = args[0] as boolean;
+    if (!user || !target || !canHit) {
+      return false;
+    }
+
+    // If the target has any stat boost (at least +1 in any stat)
+    if (target.summonData.battleStats.find((stat) => stat > 0)) {
+      const targetBoosts = target.summonData.battleStats.map((stat) => stat > 0 ? stat : 0);
+
+      // Reset the target's positive boosts back to 0
+      target.summonData.battleStats = target.summonData.battleStats.map(stat => Math.min(0, stat));
+      target.updateInfo();
+      user.scene.queueMessage(getPokemonMessage(user, " stole the target's boosted stats!"));
+
+      // For each battle stat, check if any boosts were stolen and apply them to the user
+      targetBoosts.forEach((boost, index) => {
+        if (boost > 0) {
+          user.scene.unshiftPhase(new StatChangePhase(user.scene, user.getBattlerIndex(), true, [index], boost));
+        }
+      });
+
+      return true;
+    }
+
+    return false;
+  }
+}
+
 export class VariableAccuracyAttr extends MoveAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     //const accuracy = args[0] as Utils.NumberHolder;
@@ -7034,7 +7079,7 @@ export function initMoves() {
     new AttackMove(Moves.PRISMATIC_LASER, Type.PSYCHIC, MoveCategory.SPECIAL, 160, 100, 10, -1, 0, 7)
       .attr(RechargeAttr),
     new AttackMove(Moves.SPECTRAL_THIEF, Type.GHOST, MoveCategory.PHYSICAL, 90, 100, 10, -1, 0, 7)
-      .partial(),
+      .attr(StealStatBoostsAttr),
     new AttackMove(Moves.SUNSTEEL_STRIKE, Type.STEEL, MoveCategory.PHYSICAL, 100, 100, 5, -1, 0, 7)
       .ignoresAbilities()
       .partial(),

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4,7 +4,7 @@ import { Variant, VariantSet, variantColorCache } from "#app/data/variant";
 import { variantData } from "#app/data/variant";
 import BattleInfo, { PlayerBattleInfo, EnemyBattleInfo } from "../ui/battle-info";
 import { Moves } from "../data/enums/moves";
-import Move, { HighCritAttr, HitsTagAttr, applyMoveAttrs, FixedDamageAttr, VariableAtkAttr, VariablePowerAttr, allMoves, MoveCategory, TypelessAttr, CritOnlyAttr, getMoveTargets, OneHitKOAttr, MultiHitAttr, StatusMoveTypeImmunityAttr, MoveTarget, VariableDefAttr, AttackMove, ModifiedDamageAttr, VariableMoveTypeMultiplierAttr, IgnoreOpponentStatChangesAttr, SacrificialAttr, VariableMoveTypeAttr, VariableMoveCategoryAttr, CounterDamageAttr, StatChangeAttr, RechargeAttr, ChargeAttr, IgnoreWeatherTypeDebuffAttr, BypassBurnDamageReductionAttr, SacrificialAttrOnHit, MoveFlags } from "../data/move";
+import Move, { HighCritAttr, HitsTagAttr, applyMoveAttrs, FixedDamageAttr, VariableAtkAttr, VariablePowerAttr, allMoves, MoveCategory, TypelessAttr, CritOnlyAttr, getMoveTargets, OneHitKOAttr, MultiHitAttr, StatusMoveTypeImmunityAttr, MoveTarget, VariableDefAttr, AttackMove, ModifiedDamageAttr, VariableMoveTypeMultiplierAttr, IgnoreOpponentStatChangesAttr, SacrificialAttr, VariableMoveTypeAttr, VariableMoveCategoryAttr, CounterDamageAttr, StatChangeAttr, RechargeAttr, ChargeAttr, IgnoreWeatherTypeDebuffAttr, BypassBurnDamageReductionAttr, SacrificialAttrOnHit, MoveFlags, PreAttackStatChangeAttr } from "../data/move";
 import { default as PokemonSpecies, PokemonSpeciesForm, SpeciesFormKey, getFusedSpeciesName, getPokemonSpecies, getPokemonSpeciesForm, getStarterValueFriendshipCap, speciesStarters, starterPassiveAbilities } from "../data/pokemon-species";
 import * as Utils from "../utils";
 import { Type, TypeDamageMultiplier, getTypeDamageMultiplier, getTypeRgb } from "../data/type";
@@ -1687,6 +1687,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         if (this.scene.arena.getTerrainType() === TerrainType.GRASSY && this.isGrounded() && type === Type.GROUND && move.moveTarget === MoveTarget.ALL_NEAR_OTHERS) {
           power.value /= 2;
         }
+        const isTypeImmune = (typeMultiplier.value * arenaAttackTypeMultiplier.value) === 0;
+        applyMoveAttrs(PreAttackStatChangeAttr, source, this, move, !isTypeImmune);
         applyMoveAttrs(VariablePowerAttr, source, this, move, power);
         this.scene.applyModifiers(PokemonMultiHitModifier, source.isPlayer(), source, new Utils.IntegerHolder(0), power);
         if (!typeless) {
@@ -1734,7 +1736,6 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         if (!isCritical) {
           this.scene.arena.applyTagsForSide(WeakenMoveScreenTag, this.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY, move.category, this.scene.currentBattle.double, screenMultiplier);
         }
-        const isTypeImmune = (typeMultiplier.value * arenaAttackTypeMultiplier.value) === 0;
         const sourceTypes = source.getTypes();
         const matchesSourceType = sourceTypes[0] === type || (sourceTypes.length > 1 && sourceTypes[1] === type);
         const stabMultiplier = new Utils.NumberHolder(1);

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -3067,28 +3067,28 @@ export class StatChangePhase extends PokemonPhase {
     const battleStats = this.getPokemon().summonData.battleStats;
     const relLevels = filteredStats.map(stat => (levels.value >= 1 ? Math.min(battleStats[stat] + levels.value, 6) : Math.max(battleStats[stat] + levels.value, -6)) - battleStats[stat]);
 
+    if (this.showMessage) {
+      const messages = this.getStatChangeMessages(filteredStats, levels.value, relLevels);
+      for (const message of messages) {
+        this.scene.queueMessage(message);
+      }
+    }
+
+    for (const stat of filteredStats) {
+      pokemon.summonData.battleStats[stat] = Math.max(Math.min(pokemon.summonData.battleStats[stat] + levels.value, 6), -6);
+    }
+
+    if (levels.value > 0 && this.canBeCopied) {
+      for (const opponent of pokemon.getOpponents()) {
+        applyAbAttrs(StatChangeCopyAbAttr, opponent, null, this.stats, levels.value);
+      }
+    }
+
+    applyPostStatChangeAbAttrs(PostStatChangeAbAttr, pokemon, filteredStats, this.levels, this.selfTarget);
+
+    pokemon.updateInfo();
+
     const end = () => {
-      if (this.showMessage) {
-        const messages = this.getStatChangeMessages(filteredStats, levels.value, relLevels);
-        for (const message of messages) {
-          this.scene.queueMessage(message);
-        }
-      }
-
-      for (const stat of filteredStats) {
-        pokemon.summonData.battleStats[stat] = Math.max(Math.min(pokemon.summonData.battleStats[stat] + levels.value, 6), -6);
-      }
-
-      if (levels.value > 0 && this.canBeCopied) {
-        for (const opponent of pokemon.getOpponents()) {
-          applyAbAttrs(StatChangeCopyAbAttr, opponent, null, this.stats, levels.value);
-        }
-      }
-
-      applyPostStatChangeAbAttrs(PostStatChangeAbAttr, pokemon, filteredStats, this.levels, this.selfTarget);
-
-      pokemon.updateInfo();
-
       handleTutorial(this.scene, Tutorial.Stat_Change).then(() => super.end());
     };
 


### PR DESCRIPTION
Implemented the move Spectral Thief.

It steals positive stat boosts from the target before hitting them, as described [here](https://bulbapedia.bulbagarden.net/wiki/Spectral_Thief_(move)#Effect). Abilities that protect or alter stat changes only work on the attacker, not on the defender, even abilities that can't be ignored like Full Metal Body don't stop it, as described in its own [page](https://bulbapedia.bulbagarden.net/wiki/Full_Metal_Body_(Ability)#Effect)

Here's an example:


https://github.com/pagefaultgames/pokerogue/assets/22176793/f3685d48-7948-42c3-9427-a4d0674fbfe4


If the move fails, like the target being immune, stats are not stolen, as expected:


https://github.com/pagefaultgames/pokerogue/assets/22176793/341a728a-1f3b-4e5b-83be-18cbad6f53d9


And as mentioned above, abilities are still applied for the attacker, in this case we have both Simple and Contrary:

https://github.com/pagefaultgames/pokerogue/assets/22176793/e5449ba0-0c0e-4f48-874b-c95c2149282f

