### PR TITLE
Bugfix: Right Pokemon no longer hits self when left dies with no replacement when using spread move

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2629,8 +2629,14 @@ export class MoveEffectPhase extends PokemonPhase {
 
   constructor(scene: BattleScene, battlerIndex: BattlerIndex, targets: BattlerIndex[], move: PokemonMove) {
     super(scene, battlerIndex);
-
     this.move = move;
+    // In double battles, if the right Pokemon selects a spread move and the left Pokemon dies
+    // with no party members available to switch in, then the right Pokemon takes the index
+    // of the left Pokemon and gets hit unless this is checked.
+    if (targets.includes(battlerIndex) && this.move.getMove().moveTarget === MoveTarget.ALL_NEAR_OTHERS) {
+      const i = targets.indexOf(battlerIndex);
+      targets.splice(i,i+1);
+    }
     this.targets = targets;
   }
 


### PR DESCRIPTION
## What are the changes?
Adds a clause in `MoveEffectPhase` that skips user being its own target if the move selected is `MoveTarget.ALL_NEAR_OTHERS`. This encompasses moves like `Discharge`, `Earthquake`, etc. Tried to limit it to the main problem moves being reported in Discord to minimize impact just in case.

## Why am I doing these changes?
It's a bug - unintended behavior. At a bad time too because it means the user only has one Pokemon left 😬 

## What did change?
Right Pokemon no longer hits itself with spread move if it becomes the only Pokemon after left dies before spread move goes off. 

## Videos
Before change (includes left dying w/ right using spread move which is the problem and right dying w/ left using the spread move which works properly rn)

https://github.com/pagefaultgames/pokerogue/assets/85713900/073d0eb9-46c2-467c-aa80-d4d9d1cf6ac6

After change

https://github.com/pagefaultgames/pokerogue/assets/85713900/212e6345-0917-4e7b-9969-567d461b4b1d
