### PR TITLE
Fixed German localization for Starf Berry description and localized zippyZap effect

### DIFF
--- a/src/locales/de/berry.ts
+++ b/src/locales/de/berry.ts
@@ -39,7 +39,7 @@ export const berry: BerryTranslationEntries = {
   },
   "STARF": {
     name: "Krambobeere",
-    effect: "Erhöht eine Statuswert stark, wenn die KP unter 25% sind"
+    effect: "Erhöht einen zufälligen Statuswert stark, wenn die KP unter 25% sind"
   },
   "LEPPA": {
     name: "Jonagobeere",

--- a/src/locales/de/move.ts
+++ b/src/locales/de/move.ts
@@ -2915,7 +2915,7 @@ export const move: MoveTranslationEntries = {
   },
   "zippyZap": {
     name: "Britzelturbo",
-    effect: "The user attacks the target with bursts of electricity at high speed. This move always goes first and raises the user's evasiveness."
+    effect: "Ein stürmischer Blitz-Angriff mit hoher Erstschlag- und Volltrefferquote."
   },
   "splishySplash": {
     name: "Plätschersurfer",


### PR DESCRIPTION
In the German localization I fixed an mistake in the Starf Berry description and localized the effect description of the zippyZap move