### PR TITLE
Classic Turbo game mode

### DIFF
--- a/public/battle-anims/psychic.json
+++ b/public/battle-anims/psychic.json
@@ -1,6 +1,6 @@
 {
   "id": 94,
-  "graphic": "PRAS- PsychicBG",
+  "graphic": "PRAS- Psychic BG",
   "frames": [
     [
       {

--- a/public/battle-anims/psychic.json
+++ b/public/battle-anims/psychic.json
@@ -1,6 +1,6 @@
 {
   "id": 94,
-  "graphic": "PRAS- Psychic BG",
+  "graphic": "PRAS- PsychicBG",
   "frames": [
     [
       {

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -863,16 +863,18 @@ export default class BattleScene extends SceneBase {
     if (newWaveIndex === undefined) {
       if (this.currentBattle?.waveIndex === undefined) {
         newWaveIndex = startingWave;
-      } else if (this.gameMode.isTurbo) {
+      } else {
         newWaveIndex = this.currentBattle?.waveIndex + 1;
-        if (!fixedBattles[newWaveIndex]) {
+
+        // Turbo mode: If we don't have a fixed battle next, skip a wave
+        if (this.gameMode.isTurbo && !fixedBattles[newWaveIndex]) {
           newWaveIndex++;
+          // If we're on an odd wave (because we just started the game or left a fixed battle), skip back to even
+          // Effectively, Turbo spends all its time on even-numbered waves except to hit fixed battles
           if (newWaveIndex % 2 && !fixedBattles[newWaveIndex]) {
             newWaveIndex++;
           }
         }
-      } else {
-        newWaveIndex = this.currentBattle?.waveIndex + 1;
       }
     }
     let newDouble: boolean;

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -859,7 +859,22 @@ export default class BattleScene extends SceneBase {
   }
 
   newBattle(waveIndex?: integer, battleType?: BattleType, trainerData?: TrainerData, double?: boolean): Battle {
-    const newWaveIndex = waveIndex || ((this.currentBattle?.waveIndex || (startingWave - 1)) + 1);
+    let newWaveIndex = waveIndex;
+    if (newWaveIndex === undefined) {
+      if (this.currentBattle?.waveIndex === undefined) {
+        newWaveIndex = startingWave;
+      } else if (this.gameMode.isTurbo) {
+        newWaveIndex = this.currentBattle?.waveIndex + 1;
+        if (!fixedBattles[newWaveIndex]) {
+          newWaveIndex++;
+          if (newWaveIndex % 2 && !fixedBattles[newWaveIndex]) {
+            newWaveIndex++;
+          }
+        }
+      } else {
+        newWaveIndex = this.currentBattle?.waveIndex + 1;
+      }
+    }
     let newDouble: boolean;
     let newBattleType: BattleType;
     let newTrainer: Trainer;
@@ -2129,3 +2144,4 @@ export default class BattleScene extends SceneBase {
     (window as any).gameInfo = gameInfo;
   }
 }
+

--- a/src/game-mode.ts
+++ b/src/game-mode.ts
@@ -11,7 +11,8 @@ export enum GameModes {
   CLASSIC,
   ENDLESS,
   SPLICED_ENDLESS,
-  DAILY
+  DAILY,
+  TURBO,
 }
 
 interface GameModeConfig {
@@ -25,6 +26,7 @@ interface GameModeConfig {
   hasRandomBiomes?: boolean;
   hasRandomBosses?: boolean;
   isSplicedOnly?: boolean;
+  isTurbo?: boolean;
 }
 
 export class GameMode implements GameModeConfig {
@@ -39,6 +41,7 @@ export class GameMode implements GameModeConfig {
   public hasRandomBiomes: boolean;
   public hasRandomBosses: boolean;
   public isSplicedOnly: boolean;
+  public isTurbo: boolean;
 
   constructor(modeId: GameModes, config: GameModeConfig) {
     this.modeId = modeId;
@@ -162,6 +165,8 @@ export class GameMode implements GameModeConfig {
     switch (modeId) {
     case GameModes.CLASSIC:
       return waveIndex === 200;
+    case GameModes.TURBO:
+      return waveIndex >= 200;
     case GameModes.ENDLESS:
     case GameModes.SPLICED_ENDLESS:
       return !(waveIndex % 250);
@@ -233,6 +238,8 @@ export class GameMode implements GameModeConfig {
     switch (this.modeId) {
     case GameModes.CLASSIC:
       return "Classic";
+    case GameModes.TURBO:
+      return "Classic (Turbo)";
     case GameModes.ENDLESS:
       return "Endless";
     case GameModes.SPLICED_ENDLESS:
@@ -245,7 +252,9 @@ export class GameMode implements GameModeConfig {
 
 export const gameModes = Object.freeze({
   [GameModes.CLASSIC]: new GameMode(GameModes.CLASSIC, { isClassic: true, hasTrainers: true, hasFixedBattles: true }),
+  [GameModes.TURBO]: new GameMode(GameModes.TURBO, { isClassic: true, hasTrainers: true, hasFixedBattles: true, isTurbo: true }),
   [GameModes.ENDLESS]: new GameMode(GameModes.ENDLESS, { isEndless: true, hasShortBiomes: true, hasRandomBosses: true }),
   [GameModes.SPLICED_ENDLESS]: new GameMode(GameModes.SPLICED_ENDLESS, { isEndless: true, hasShortBiomes: true, hasRandomBosses: true, isSplicedOnly: true }),
   [GameModes.DAILY]: new GameMode(GameModes.DAILY, { isDaily: true, hasTrainers: true, hasNoShop: true })
 });
+


### PR DESCRIPTION
This adds a shorter version of Classic that skips half of the levels but never any fixed fights or bosses.

While you now heal every five fights instead of ten, the game ends up more difficult, largely because you receive 44% of the usual number of shops (4 out of every 5 instead of 9 of 10). To counterbalance this, rerolls have been made much less expensive. You end up with much less money than usual, so that change isn't nearly enough to bring it to parity. Still, it's probably best that this game mode errs on the side of too difficult rather than too easy.

There is a single known issue with the game mode: trainers fought immediately after a biome change do not appear on screen. This is guaranteed to happen at wave 182. It is a cosmetic bug that has no gameplay effects.