### PR TITLE
Fix: display every hit result of multi-hit moves

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
 				"vitest-canvas-mock": "^0.3.3"
 			},
 			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
 				"vitest-canvas-mock": "^0.3.3"
 			},
 			"engines": {
-				"node": ">=20.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@ampproject/remapping": {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1839,24 +1839,22 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
           }
         }
 
-        if (source.turnData.hitsLeft === 1) {
-          switch (result) {
-          case HitResult.SUPER_EFFECTIVE:
-            this.scene.queueMessage(i18next.t("battle:hitResultSuperEffective"));
-            break;
-          case HitResult.NOT_VERY_EFFECTIVE:
-            this.scene.queueMessage(i18next.t("battle:hitResultNotVeryEffective"));
-            break;
-          case HitResult.NO_EFFECT:
-            this.scene.queueMessage(i18next.t("battle:hitResultNoEffect", { pokemonName: this.name }));
-            break;
-          case HitResult.IMMUNE:
-            this.scene.queueMessage(`${this.name} is unaffected!`);
-            break;
-          case HitResult.ONE_HIT_KO:
-            this.scene.queueMessage(i18next.t("battle:hitResultOneHitKO"));
-            break;
-          }
+        switch (result) {
+        case HitResult.SUPER_EFFECTIVE:
+          this.scene.queueMessage(i18next.t("battle:hitResultSuperEffective"));
+          break;
+        case HitResult.NOT_VERY_EFFECTIVE:
+          this.scene.queueMessage(i18next.t("battle:hitResultNotVeryEffective"));
+          break;
+        case HitResult.NO_EFFECT:
+          this.scene.queueMessage(i18next.t("battle:hitResultNoEffect", { pokemonName: this.name }));
+          break;
+        case HitResult.IMMUNE:
+          this.scene.queueMessage(`${this.name} is unaffected!`);
+          break;
+        case HitResult.ONE_HIT_KO:
+          this.scene.queueMessage(i18next.t("battle:hitResultOneHitKO"));
+          break;
         }
 
         if (this.isFainted()) {


### PR DESCRIPTION
## What are the changes:

- Remove the condition that judges whether to display _HitResult_ information.

## Why am I making these changes:

- This PR aims to address #1287. After changing, the hit result will be shown even if the opponent's Pokemon faints before the final hit of the multi-hit move.
- Follow the official versions, every hit result for multi-hit moves needs to be displayed correctly and respectively.
