### PR TITLE
zhTW Type Images are now correctly loaded.

### DIFF
--- a/public/images/types_zh_TW.json
+++ b/public/images/types_zh_TW.json
@@ -1,7 +1,7 @@
 {
 	"textures": [
 		{
-			"image": "types_zh_CN.png",
+			"image": "types_zh_TW.png",
 			"format": "RGBA8888",
 			"size": {
 				"w": 32,

--- a/src/loading-scene.ts
+++ b/src/loading-scene.ts
@@ -216,6 +216,10 @@ export class LoadingScene extends SceneBase {
         break;
       }
       if (Utils.verifyLang(lang)) {
+        if (lang === "zh_CN") {
+          // Load also the traditional Chinese since it doesn't have a separate language code in supportedLngs
+          this.loadAtlas("types_zh_TW", "");
+        }
         this.loadAtlas(`types_${lang}`, "");
       }
     });


### PR DESCRIPTION
Test with giving it the german images (for the test) to make sure it doesnt load the zn_CN images instead.

![image](https://github.com/pagefaultgames/pokerogue/assets/38758606/e343b5b3-4b4a-402d-aafa-3abe5c5b8526)

Of course it uses the english images for now