### PR TITLE
When the language is changed the game will complety reload (same as F5).

### DIFF
--- a/src/loading-scene.ts
+++ b/src/loading-scene.ts
@@ -206,23 +206,19 @@ export class LoadingScene extends SceneBase {
     this.loadAtlas("items", "");
     this.loadAtlas("types", "");
 
-    (i18next.options.supportedLngs as Array<any>).forEach(lang => {
-      switch (lang) {
-      case "pt":
-        lang = "pt_BR";
-        break;
-      case "zh":
-        lang = "zh_CN";
-        break;
-      }
+    // Get current lang and load the types atlas for it. English will only load types while all other languages will load types and types_<lang>
+    const lang = i18next.language;
+    if (lang !== "en") {
       if (Utils.verifyLang(lang)) {
-        if (lang === "zh_CN") {
-          // Load also the traditional Chinese since it doesn't have a separate language code in supportedLngs
-          this.loadAtlas("types_zh_TW", "");
-        }
         this.loadAtlas(`types_${lang}`, "");
+      } else {
+        // Fallback to English
+        this.loadAtlas("types", "");
       }
-    });
+    } else {
+      this.loadAtlas("types", "");
+    }
+
 
     this.loadAtlas("statuses", "");
     this.loadAtlas("categories", "");

--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -186,7 +186,8 @@ export function setSetting(scene: BattleScene, setting: Setting, value: integer)
             i18next.changeLanguage(locale);
             localStorage.setItem("prLang", locale);
             cancelHandler();
-            scene.reset(true, false, true);
+            // Reload the whole game to apply the new locale since also some constants are translated
+            window.location.reload();
             return true;
           } catch (error) {
             console.error("Error changing locale:", error);


### PR DESCRIPTION
Also now only the current language type image is loaded. If it doesnt exist for a language it will load the english one as a fallback

Tested with all lanugages

Before: (Does not reload titles, trainer classes and names correctly. Loads all type images always)

https://github.com/pagefaultgames/pokerogue/assets/38758606/e17cb595-ad45-4e8a-8088-d5cc22ac72cb

After: (Reloads the whole game so titles, trainer classes and names are correctly localized. Only loads the current type image. (If it doesnt exist it loads the english one)


https://github.com/pagefaultgames/pokerogue/assets/38758606/41bd542b-5137-4216-94ed-65dc1111595b

