### PR TITLE
Implemented "After You"

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1652,6 +1652,10 @@ export default class BattleScene extends SceneBase {
     return this.phaseQueue.find(phaseFilter);
   }
 
+  getPhaseIndex(phaseFilter: (phase: Phase) => boolean): int {
+    return this.phaseQueue.indexOf(this.phaseQueue.find(phaseFilter));
+  }
+
   tryReplacePhase(phaseFilter: (phase: Phase) => boolean, phase: Phase): boolean {
     const phaseIndex = this.phaseQueue.findIndex(phaseFilter);
     if (phaseIndex > -1) {


### PR DESCRIPTION
Implemented "After You" move, which causes the target to move immediately after the user, unless it already acted this turn.

Using on slower ally:
https://github.com/pagefaultgames/pokerogue/assets/14551750/0cf36a33-4924-4d4e-a3db-990cb2bd7319

Using on faster ally:
https://github.com/pagefaultgames/pokerogue/assets/14551750/71a2fba9-5884-41d1-8acb-2c93d01d80c5

Both ally pokemon using on each other:
https://github.com/pagefaultgames/pokerogue/assets/14551750/a41d704e-244e-4111-8de6-76a2c10460bc

Using on slower enemy:
https://github.com/pagefaultgames/pokerogue/assets/14551750/9493b474-29d5-4b33-8503-6b37bbd8e572

Both player pokemon using on the same enemy pokemon:
https://github.com/pagefaultgames/pokerogue/assets/14551750/b0db5aa4-a813-4329-9377-214aed4f72c7
