### PR TITLE
update viewport settings to disable zoom on iOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 	<link rel="apple-touch-icon" href="./logo512.png" />
 	<link rel="shortcut icon" type="image/png" href="./logo512.png" />
 	<link rel="canonical" href="https://pokerogue.net" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, viewport-fit=cover" />
 	<style type="text/css">
 		@font-face {
 			font-family: 'emerald';


### PR DESCRIPTION
Fixes bug from this post: https://discord.com/channels/1125469663833370665/1243536779919884328

Before the fix there was an issue where double-tapping the screen outside of the D-pad controls would zoom in and user would be unable to zoom back out. 

https://streamable.com/wldifp

This updates viewport settings to disable all zoom features