### PR TITLE
Update Phione and Manaphy levelup learnset

### DIFF
--- a/src/data/pokemon-level-moves.ts
+++ b/src/data/pokemon-level-moves.ts
@@ -8448,8 +8448,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
     [ 72, Moves.LUNAR_BLESSING ],
   ],
   [Species.PHIONE]: [
-    [ 1, Moves.BUBBLE ],
-    [ 1, Moves.WATER_SPORT ],
+    [ 1, Moves.WATER_GUN ],
     [ 9, Moves.CHARM ],
     [ 16, Moves.SUPERSONIC ],
     [ 24, Moves.BUBBLE_BEAM ],
@@ -8459,11 +8458,12 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
     [ 54, Moves.AQUA_RING ],
     [ 61, Moves.DIVE ],
     [ 69, Moves.RAIN_DANCE ],
+    [ 75, Moves.TAKE_HEART ],
   ],
   [Species.MANAPHY]: [
-    [ 1, Moves.BUBBLE ],
+    [ 1, Moves.HEART_SWAP ],
     [ 1, Moves.TAIL_GLOW ],
-    [ 1, Moves.WATER_SPORT ],
+    [ 1, Moves.WATER_GUN ],
     [ 9, Moves.CHARM ],
     [ 16, Moves.SUPERSONIC ],
     [ 24, Moves.BUBBLE_BEAM ],
@@ -8473,7 +8473,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
     [ 54, Moves.AQUA_RING ],
     [ 61, Moves.DIVE ],
     [ 69, Moves.RAIN_DANCE ],
-    [ 76, Moves.HEART_SWAP ],
+    [ 76, Moves.TAKE_HEART ],
   ],
   [Species.DARKRAI]: [
     [ 1, Moves.DISABLE ],


### PR DESCRIPTION
https://github.com/pagefaultgames/pokerogue/issues/1460

* Phione and Manaphy now both learn Take Heart
* Updated Phione's level 1 learnset [bubble, water sport] -> water gun
* Updated Manaphy's level 1 learnset [bubble, water sport] -> [water gun, heart swap]

References used: [Bulbapedia Phione](https://bulbapedia.bulbagarden.net/wiki/Phione_(Pok%C3%A9mon)#Learnset) [Bulbapedia Manaphy](https://bulbapedia.bulbagarden.net/wiki/Manaphy_(Pok%C3%A9mon)#Learnset)