### PR TITLE
Implemented Triple Kick and Triple Axel properly

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2356,6 +2356,19 @@ export class BeatUpAttr extends VariablePowerAttr {
   }
 }
 
+export class MultiHitIncrementerThree extends VariablePowerAttr {
+
+  /**
+  * Gets the current number of hits left and doubles or triples the power for the 2nd and 3rd hits respectively
+  */
+
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    const power = args[0] as Utils.NumberHolder;
+    power.value = move.power * (1+((3-(user.turnData.hitsLeft%3))%3));
+    return true;
+  }
+}
+
 const doublePowerChanceMessageFunc = (user: Pokemon, target: Pokemon, move: Move) => {
   let message: string = null;
   user.scene.executeWithSeedOffset(() => {
@@ -5409,6 +5422,7 @@ export function initMoves() {
       .ignoresVirtual(),
     new AttackMove(Moves.TRIPLE_KICK, Type.FIGHTING, MoveCategory.PHYSICAL, 10, 90, 10, -1, 0, 2)
       .attr(MultiHitAttr, MultiHitType._3_INCR)
+      .attr(MultiHitIncrementerThree)
       .attr(MissEffectAttr, (user: Pokemon, move: Move) => {
         user.turnData.hitsLeft = 1;
         return true;
@@ -7266,6 +7280,7 @@ export function initMoves() {
       .attr(ForceSwitchOutAttr, true, false),
     new AttackMove(Moves.TRIPLE_AXEL, Type.ICE, MoveCategory.PHYSICAL, 20, 90, 10, -1, 0, 8)
       .attr(MultiHitAttr, MultiHitType._3_INCR)
+      .attr(MultiHitIncrementerThree)
       .attr(MissEffectAttr, (user: Pokemon, move: Move) => {
         user.turnData.hitsLeft = 1;
         return true;


### PR DESCRIPTION
Added a proposed implementation for cyclically incrementing power in the moves Triple Kick and Triple Axel.

This implementation is based on MultiHitIncrementerThree which extends VariablePowerAttr.

This should cause each hit of these abilities to do 1, 2, or 3 times its base power on each hit.

This is repeated for each multi lens the Pokémon is holding as well.

For example, a Pokémon holding 1 multi lens using Triple Axel would have each hit of Triple Axel have a power, respectively, of: 20, 40, 60, 20, 40 60.

This seems like the natural follow-up to https://github.com/pagefaultgames/pokerogue/pull/1341 which, to be honest, I am not sure that was not followed through on.

However, since this has nothing to do with the accuracy component of these moves and only their power, Population Bomb is not associated with this update at all despite its inclusion in 1341 (which **does** address accuracy).

Edit: Small adjustments for clarity about accuracy component's exclusion.