### PR TITLE
Starter select - Implement up and down offset navigation

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1115,11 +1115,23 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         case Button.UP:
           if (row) {
             success = this.setCursor(this.cursor - 9);
+          } else {
+            if (this.cursor + (rows - 1) * 9 > genStarters - 1) {
+              success = this.setCursor(this.cursor + (rows - 2) * 9);
+            } else {
+              success = this.setCursor(this.cursor + (rows - 1) * 9);
+            }
           }
           break;
         case Button.DOWN:
           if (row < rows - 2 || (row < rows - 1 && this.cursor % 9 <= (genStarters - 1) % 9)) {
             success = this.setCursor(this.cursor + 9);
+          } else {
+            if (row === rows - 2 && this.cursor + 9 > genStarters - 1) {
+              success = this.setCursor(this.cursor - (rows - 2) * 9);
+            } else {
+              success = this.setCursor(this.cursor - (rows - 1) * 9);
+            }
           }
           break;
         case Button.LEFT:

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1116,6 +1116,8 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
           if (row) {
             success = this.setCursor(this.cursor - 9);
           } else {
+            // when strictly opposite starter based on rows length
+            // does not exits, set cursor on the second to last row
             if (this.cursor + (rows - 1) * 9 > genStarters - 1) {
               success = this.setCursor(this.cursor + (rows - 2) * 9);
             } else {
@@ -1127,6 +1129,8 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
           if (row < rows - 2 || (row < rows - 1 && this.cursor % 9 <= (genStarters - 1) % 9)) {
             success = this.setCursor(this.cursor + 9);
           } else {
+            // if there is no starter below while being on the second to
+            // last row, adjust cursor position with one line less
             if (row === rows - 2 && this.cursor + 9 > genStarters - 1) {
               success = this.setCursor(this.cursor - (rows - 2) * 9);
             } else {


### PR DESCRIPTION
#### Changes

- Add conditions when moving up or down at the edges of the select starter ui

#### Purpose

- Make it easier to navigate in the select starter ui by moving the cursor to the opposing edge

#### Demo

https://github.com/pagefaultgames/pokerogue/assets/12510911/06b218b0-8028-431b-85cf-93d2780d642e