### PR TITLE
Fix - Removes useless '/' make it them doubles in somes URLs

### DIFF
--- a/src/scene-base.ts
+++ b/src/scene-base.ts
@@ -47,11 +47,11 @@ export class SceneBase extends Phaser.Scene {
     if (folder) {
       folder += "/";
     }
-    this.load.atlas(key, this.getCachedUrl(`images/${folder}${filenameRoot}.png`), this.getCachedUrl(`images/${folder}/${filenameRoot}.json`));
+    this.load.atlas(key, this.getCachedUrl(`images/${folder}${filenameRoot}.png`), this.getCachedUrl(`images/${folder}${filenameRoot}.json`));
     if (folder.startsWith("ui")) {
       legacyCompatibleImages.push(key);
       folder = folder.replace("ui", "ui/legacy");
-      this.load.atlas(`${key}_legacy`, this.getCachedUrl(`images/${folder}${filenameRoot}.png`), this.getCachedUrl(`images/${folder}/${filenameRoot}.json`));
+      this.load.atlas(`${key}_legacy`, this.getCachedUrl(`images/${folder}${filenameRoot}.png`), this.getCachedUrl(`images/${folder}${filenameRoot}.json`));
     }
   }
 


### PR DESCRIPTION
I was tired of seeing malformed URLs in my Nginx logs 🤣

> Before
![image](https://github.com/pagefaultgames/pokerogue/assets/8146474/29b263e6-1b8b-4108-9722-ee7659adad5e)
![image](https://github.com/pagefaultgames/pokerogue/assets/8146474/56860e56-b211-470b-938b-7bfa64d9dff9)
![image](https://github.com/pagefaultgames/pokerogue/assets/8146474/e1e7ecd3-1322-4daf-ac74-fcda6b5c8fce)

> After
![image](https://github.com/pagefaultgames/pokerogue/assets/8146474/26bdfff6-2b70-41bb-8b25-c0d4bff1a102)
![image](https://github.com/pagefaultgames/pokerogue/assets/8146474/671eb53d-b2e2-44fb-b367-37e9b6f883b2)
![image](https://github.com/pagefaultgames/pokerogue/assets/8146474/289cffa5-365d-4b59-b7a1-8ae787ff1ada)
