### PR TITLE
[Bug] Added check for expGainsSpeed to updatePokemonExp to disable XP Bar animation on Skip setting

### DIFF
--- a/src/ui/battle-info.ts
+++ b/src/ui/battle-info.ts
@@ -616,6 +616,23 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
       const relLevelExp = getLevelRelExp(this.lastLevel + 1, pokemon.species.growthRate);
       const levelExp = levelUp ? relLevelExp : pokemon.levelExp;
       let ratio = relLevelExp ? levelExp / relLevelExp : 0;
+
+      if (instant || this.scene.expGainsSpeed >= 3) {
+        if (levelUp) {
+          this.lastLevelExp = 0;
+          this.lastLevel++;
+        } else {
+          this.lastExp = pokemon.exp;
+          this.lastLevelExp = pokemon.levelExp;
+        }
+        this.expMaskRect.x = ratio * 510;
+        if (levelUp) {
+          this.setLevel(this.lastLevel);
+        }
+        this.updateInfo(pokemon, true).then(() => resolve());
+        return;
+      }
+      
       if (this.lastLevel >= (this.scene as BattleScene).getMaxExpLevel(true)) {
         if (levelUp) {
           ratio = 1;


### PR DESCRIPTION
As of now updatePokemonExp() does not respect the expGainsSpeed setting "Skip". This means that the exp bar animation still plays. This added check aims to fix that.

All necessary checks and status updates are performed before returning and the exp bar is instantly set to the appropriate value.

How to test: The xp bar animation will no longer trigger with setting "Exp Gains Speed" to "Skip".

## Checklist
- [X ] There is no overlap with another PR?
- [X ] The PR is self-contained and cannot be split into smaller PRs?
- [X ] Have I provided a clear explanation of the changes?
- [X ] Have I tested the changes (manually)?
    - [X ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?