### PR TITLE
Implement starters overrides

### DIFF
--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -105,3 +105,19 @@ export const OPP_MODIFIER_OVERRIDE: Array<ModifierOverride> = [];
 
 export const STARTING_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [];
 export const OPP_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [];
+
+/**
+ * STARTERS OVERRIDE
+ * Unlock all starters
+ */
+export const STARTERS_OVERRIDE: boolean = false;
+/**
+ * STARTERS FORMS OVERRIDE
+ * Unlock all forms for starters
+ */
+export const STARTERS_FORMS_OVERRIDE: boolean = false;
+/**
+ * STARTERS OVERRIDE
+ * Unlock all form even those not usually available for starters
+ */
+export const STARTERS_ALL_FORMS_OVERRIDE: boolean = false;

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -29,7 +29,7 @@ import { StatsContainer } from "./stats-container";
 import { TextStyle, addBBCodeTextObject, addTextObject } from "./text";
 import { Mode } from "./ui";
 import { addWindow } from "./ui-theme";
-import * as Overrides from '../overrides';
+import * as Overrides from "../overrides";
 
 export type StarterSelectCallback = (starters: Starter[]) => void;
 
@@ -1626,9 +1626,9 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         this.canCycleShiny = !!(dexEntry.caughtAttr & DexAttr.NON_SHINY && dexEntry.caughtAttr & DexAttr.SHINY);
         this.canCycleGender = !!(dexEntry.caughtAttr & DexAttr.MALE && dexEntry.caughtAttr & DexAttr.FEMALE);
         this.canCycleAbility = [ abilityAttr & AbilityAttr.ABILITY_1, (abilityAttr & AbilityAttr.ABILITY_2) && species.ability2, abilityAttr & AbilityAttr.ABILITY_HIDDEN ].filter(a => a).length > 1;
-        this.canCycleForm = Overrides.STARTERS_ALL_FORMS_OVERRIDE ? species.forms.filter(f => f.formKey || pokemonFormChanges[species.speciesId]?.find(fc => fc.formKey)).length > 1 : 
-        Overrides.STARTERS_FORMS_OVERRIDE ? species.forms.filter(f => f.isStarterSelectable || !pokemonFormChanges[species.speciesId]?.find(fc => fc.formKey)).length > 1 : species.forms.filter(f => f.isStarterSelectable || !pokemonFormChanges[species.speciesId]?.find(fc => fc.formKey))
-          .map((_, f) => dexEntry.caughtAttr & this.scene.gameData.getFormAttr(f)).filter(f => f).length > 1;
+        this.canCycleForm = Overrides.STARTERS_ALL_FORMS_OVERRIDE ? species.forms.filter(f => f.formKey || pokemonFormChanges[species.speciesId]?.find(fc => fc.formKey)).length > 1 :
+          Overrides.STARTERS_FORMS_OVERRIDE ? species.forms.filter(f => f.isStarterSelectable || !pokemonFormChanges[species.speciesId]?.find(fc => fc.formKey)).length > 1 : species.forms.filter(f => f.isStarterSelectable || !pokemonFormChanges[species.speciesId]?.find(fc => fc.formKey))
+            .map((_, f) => dexEntry.caughtAttr & this.scene.gameData.getFormAttr(f)).filter(f => f).length > 1;
         this.canCycleNature = this.scene.gameData.getNaturesForAttr(dexEntry.natureAttr).length > 1;
         this.canCycleVariant = shiny && [ dexEntry.caughtAttr & DexAttr.DEFAULT_VARIANT, dexEntry.caughtAttr & DexAttr.VARIANT_2, dexEntry.caughtAttr & DexAttr.VARIANT_3].filter(v => v).length > 1;
       }

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1,3 +1,4 @@
+import { BattleSceneEventType, CandyUpgradeNotificationChangedEvent } from "#app/battle-scene-events.js";
 import { pokemonPrevolutions } from "#app/data/pokemon-evolutions";
 import { Variant, getVariantTint } from "#app/data/variant";
 import { argbFromRgba } from "@material/material-color-utilities";
@@ -104,6 +105,29 @@ function getValueReductionCandyCounts(baseValue: integer): [integer, integer] {
   return starterCandyCosts[baseValue - 1].costReduction;
 }
 
+/**
+ * Calculates the icon position for a Pokemon of a given UI index
+ * @param index UI index to calculate the icon position of
+ * @returns An interface with an x and y property
+ */
+function calcIconPosition(index: number): {x: number, y: number} {
+  const x = (index % 9) * 18;
+  const y = Math.floor(index / 9) * 18;
+
+  return {x: x, y: y};
+}
+
+/**
+ * Calculates the {@linkcode Phaser.GameObjects.Sprite} position for a Pokemon of a given UI index
+ * @param index UI index to calculate the icon position of
+ * @returns An interface with an x and y property
+ */
+function calcSpritePosition(index: number): {x: number, y: number} {
+  const position = calcIconPosition(index);
+
+  return {x: position.x - 2, y: position.y + 2};
+}
+
 const gens = [
   i18next.t("starterSelectUiHandler:gen1"),
   i18next.t("starterSelectUiHandler:gen2"),
@@ -203,6 +227,8 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
   private shinyIcons: Phaser.GameObjects.Image[][];
   private hiddenAbilityIcons: Phaser.GameObjects.Image[];
   private classicWinIcons: Phaser.GameObjects.Image[];
+  private candyUpgradeIcon: Phaser.GameObjects.Image[];
+  private candyUpgradeOverlayIcon: Phaser.GameObjects.Image[];
 
   private iconAnimHandler: PokemonIconAnimHandler;
 
@@ -393,9 +419,8 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         this.genSpecies[g].push(species);
         const defaultDexAttr = this.scene.gameData.getSpeciesDefaultDexAttr(species, false, true);
         const defaultProps = this.scene.gameData.getSpeciesDexAttrProps(species, defaultDexAttr);
-        const x = (s % 9) * 18;
-        const y = Math.floor(s / 9) * 18;
-        const icon = this.scene.add.sprite(x - 2, y + 2, species.getIconAtlasKey(defaultProps.formIndex, defaultProps.shiny, defaultProps.variant));
+        const position = calcIconPosition(s);
+        const icon = this.scene.add.sprite(position.x - 2, position.y + 2, species.getIconAtlasKey(defaultProps.formIndex, defaultProps.shiny, defaultProps.variant));
         icon.setScale(0.5);
         icon.setOrigin(0, 0);
         icon.setFrame(species.getIconId(defaultProps.female, defaultProps.formIndex, defaultProps.shiny, defaultProps.variant));
@@ -418,9 +443,8 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     });
 
     this.starterValueLabels = new Array(81).fill(null).map((_, i) => {
-      const x = (i % 9) * 18;
-      const y = Math.floor(i / 9) * 18;
-      const ret = addTextObject(this.scene, x + 152, y + 11, "0", TextStyle.WINDOW, { fontSize: "32px" });
+      const position = calcIconPosition(i);
+      const ret = addTextObject(this.scene, position.x + 152, position.y + 11, "0", TextStyle.WINDOW, { fontSize: "32px" });
       ret.setShadowOffset(2, 2);
       ret.setOrigin(0, 0);
       ret.setVisible(false);
@@ -429,9 +453,8 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     });
 
     const getShinyStar = (i: integer, v: integer): Phaser.GameObjects.Image => {
-      const x = (i % 9) * 18 - v * 3;
-      const y = Math.floor(i / 9) * 18;
-      const ret = this.scene.add.image(x + 163, y + 11, "shiny_star_small");
+      const position = calcIconPosition(i);
+      const ret = this.scene.add.image((position.x - v * 3) + 163, position.y + 11, "shiny_star_small");
       ret.setOrigin(0, 0);
       ret.setScale(0.5);
       ret.setVisible(false);
@@ -444,9 +467,8 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     });
 
     this.hiddenAbilityIcons = new Array(81).fill(null).map((_, i) => {
-      const x = (i % 9) * 18;
-      const y = Math.floor(i / 9) * 18;
-      const ret = this.scene.add.image(x + 163, y + 16, "ha_capsule");
+      const position = calcIconPosition(i);
+      const ret = this.scene.add.image(position.x + 163, position.y + 16, "ha_capsule");
       ret.setOrigin(0, 0);
       ret.setScale(0.5);
       ret.setVisible(false);
@@ -455,11 +477,30 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     });
 
     this.classicWinIcons = new Array(81).fill(null).map((_, i) => {
-      const x = (i % 9) * 18;
-      const y = Math.floor(i / 9) * 18;
-      const ret = this.scene.add.image(x + 153, y + 21, "champion_ribbon");
+      const position = calcIconPosition(i);
+      const ret = this.scene.add.image(position.x + 153, position.y + 21, "champion_ribbon");
       ret.setOrigin(0, 0);
       ret.setScale(0.5);
+      ret.setVisible(false);
+      this.starterSelectContainer.add(ret);
+      return ret;
+    });
+
+    this.candyUpgradeIcon = new Array(81).fill(null).map((_, i) => {
+      const position = calcIconPosition(i);
+      const ret = this.scene.add.image(position.x + 163, position.y + 21, "candy");
+      ret.setOrigin(0, 0);
+      ret.setScale(0.25);
+      ret.setVisible(false);
+      this.starterSelectContainer.add(ret);
+      return ret;
+    });
+
+    this.candyUpgradeOverlayIcon = new Array(81).fill(null).map((_, i) => {
+      const position = calcIconPosition(i);
+      const ret = this.scene.add.image(position.x + 163, position.y + 21, "candy_overlay");
+      ret.setOrigin(0, 0);
+      ret.setScale(0.25);
       ret.setVisible(false);
       this.starterSelectContainer.add(ret);
       return ret;
@@ -654,25 +695,14 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
     this.starterSelectContainer.add(this.statsContainer);
 
+    this.scene.eventTarget.addEventListener(BattleSceneEventType.CANDY_UPGRADE_NOTIFICATION_CHANGED, (e) => this.onCandyUpgradeDisplayChanged(e));
+
     this.updateInstructions();
   }
 
   show(args: any[]): boolean {
     if (args.length >= 2 && args[0] instanceof Function && typeof args[1] === "number") {
       super.show(args);
-
-      for (let g = 0; g < this.genSpecies.length; g++) {
-        this.genSpecies[g].forEach((species, s) => {
-          const dexEntry = this.scene.gameData.dexData[species.speciesId];
-          const icon = this.starterSelectGenIconContainers[g].getAt(s) as Phaser.GameObjects.Sprite;
-          if (dexEntry.caughtAttr || Overrides.STARTERS_OVERRIDE) {
-            icon.clearTint();
-          } else if (dexEntry.seenAttr) {
-            icon.setTint(0x808080);
-          }
-        });
-      }
-
       this.starterSelectCallback = args[0] as StarterSelectCallback;
 
       this.starterSelectContainer.setVisible(true);
@@ -684,6 +714,21 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       this.setGenMode(true);
       this.setCursor(0);
       this.tryUpdateValue(0);
+
+      for (let g = 0; g < this.genSpecies.length; g++) {
+        this.genSpecies[g].forEach((species, s) => {
+          const icon = this.starterSelectGenIconContainers[g].getAt(s) as Phaser.GameObjects.Sprite;
+          const dexEntry = this.scene.gameData.dexData[species.speciesId];
+
+          if (dexEntry.caughtAttr|| Overrides.STARTERS_OVERRIDE) {
+            icon.clearTint();
+          } else if (dexEntry.seenAttr) {
+            icon.setTint(0x808080);
+          }
+
+          this.setUpgradeAnimation(icon, species);
+        });
+      }
 
       handleTutorial(this.scene, Tutorial.Starter_Select);
 
@@ -705,6 +750,161 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     }
 
     this.starterSelectMessageBoxContainer.setVisible(!!text?.length);
+  }
+
+  /**
+   * Determines if 'Icon' based upgrade notifications should be shown
+   * @returns true if upgrade notifications are enabled and set to display an 'Icon'
+   */
+  isUpgradeIconEnabled(): boolean {
+    return this.scene.candyUpgradeNotification !== 0 && this.scene.candyUpgradeDisplay === 0;
+  }
+  /**
+   * Determines if 'Animation' based upgrade notifications should be shown
+   * @returns true if upgrade notifications are enabled and set to display an 'Animation'
+   */
+  isUpgradeAnimationEnabled(): boolean {
+    return this.scene.candyUpgradeNotification !== 0 && this.scene.candyUpgradeDisplay === 1;
+  }
+
+  /**
+   * Determines if a passive upgrade is available for the given species ID
+   * @param speciesId The ID of the species to check the passive of
+   * @returns true if the user has enough candies and a passive has not been unlocked already
+   */
+  isPassiveAvailable(speciesId: number): boolean {
+    // Get this species ID's starter data
+    const starterData = this.scene.gameData.starterData[speciesId];
+
+    return starterData.candyCount >= getPassiveCandyCount(speciesStarters[speciesId])
+      && !(starterData.passiveAttr & PassiveAttr.UNLOCKED);
+  }
+
+  /**
+   * Determines if a value reduction upgrade is available for the given species ID
+   * @param speciesId The ID of the species to check the value reduction of
+   * @returns true if the user has enough candies and all value reductions have not been unlocked already
+   */
+  isValueReductionAvailable(speciesId: number): boolean {
+    // Get this species ID's starter data
+    const starterData = this.scene.gameData.starterData[speciesId];
+
+    return starterData.candyCount >= getValueReductionCandyCounts(speciesStarters[speciesId])[starterData.valueReduction]
+        && starterData.valueReduction < 2;
+  }
+
+  /**
+   * Sets a bounce animation if enabled and the Pokemon has an upgrade
+   * @param icon {@linkcode Phaser.GameObjects.GameObject} to animate
+   * @param species {@linkcode PokemonSpecies} of the icon used to check for upgrades
+   * @param startPaused Should this animation be paused after it is added?
+   */
+  setUpgradeAnimation(icon: Phaser.GameObjects.Sprite, species: PokemonSpecies, startPaused: boolean = false): void {
+    this.scene.tweens.killTweensOf(icon);
+    // Skip animations if they are disabled
+    if (this.scene.candyUpgradeDisplay === 0 || species.speciesId !== species.getRootSpeciesId(false)) {
+      return;
+    }
+
+    const position = calcSpritePosition(this.genSpecies[species.generation - 1].indexOf(species));
+    icon.y = position.y;
+
+    const tweenChain: Phaser.Types.Tweens.TweenChainBuilderConfig = {
+      targets: icon,
+      loop: -1,
+      // Make the initial bounce a little randomly delayed
+      delay: Utils.randIntRange(0, 50) * 5,
+      loopDelay: 1000,
+      tweens: [
+        {
+          targets: icon,
+          y: position.y - 5,
+          duration: Utils.fixedInt(125),
+          ease: "Cubic.easeOut",
+          yoyo: true
+        },
+        {
+          targets: icon,
+          y: position.y - 3,
+          duration: Utils.fixedInt(150),
+          ease: "Cubic.easeOut",
+          yoyo: true
+        }
+      ],};
+
+    const passiveAvailable = this.isPassiveAvailable(species.speciesId);
+    // 'Only Passives' mode
+    if (this.scene.candyUpgradeNotification === 1) {
+      if (passiveAvailable) {
+        this.scene.tweens.chain(tweenChain).paused = startPaused;
+      }
+    // 'On' mode
+    } else if (this.scene.candyUpgradeNotification === 2) {
+      if (passiveAvailable || this.isValueReductionAvailable(species.speciesId)) {
+        this.scene.tweens.chain(tweenChain).paused = startPaused;
+      }
+    }
+  }
+
+  /**
+   * Sets the visibility of a Candy Upgrade Icon given an index
+   * @param index The UI index of the icon within this generation container
+   */
+  setUpgradeIcon(index: number): void {
+    const species = this.genSpecies[this.getGenCursorWithScroll()][index];
+    const slotVisible = !!species?.speciesId;
+
+    if (!species // No Pokemon exists at that UI index
+      || this.scene.candyUpgradeNotification === 0 // Notification setting is 'Off'
+      || species.speciesId !== species.getRootSpeciesId(false)) { // Pokemon is not the base evolution and can't use candy
+      // Set all icons as hidden and exit early
+      this.candyUpgradeIcon[index].setVisible(false);
+      this.candyUpgradeOverlayIcon[index].setVisible(false);
+
+      return;
+    }
+
+    const passiveAvailable = this.isPassiveAvailable(species.speciesId);
+    // 'Only Passive Unlocks' mode
+    if (this.scene.candyUpgradeNotification === 1) {
+      this.candyUpgradeIcon[index].setVisible(slotVisible && passiveAvailable);
+      this.candyUpgradeOverlayIcon[index].setVisible(slotVisible && this.candyUpgradeIcon[index].visible);
+
+      // 'On' mode
+    } else if (this.scene.candyUpgradeNotification === 2) {
+      this.candyUpgradeIcon[index].setVisible(
+        slotVisible && ( passiveAvailable || this.isValueReductionAvailable(species.speciesId)));
+      this.candyUpgradeOverlayIcon[index].setVisible(slotVisible && this.candyUpgradeIcon[index].visible);
+    }
+  }
+
+  /**
+   * Processes an {@linkcode CandyUpgradeNotificationChangedEvent} sent when the corresponding setting changes
+   * @param event {@linkcode Event} sent by the callback
+   */
+  onCandyUpgradeDisplayChanged(event: Event): void {
+    const candyUpgradeDisplayEvent = event as CandyUpgradeNotificationChangedEvent;
+    if (!candyUpgradeDisplayEvent) {
+      return;
+    }
+
+    // Loop through all visible candy icons when set to 'Icon' mode
+    if (this.scene.candyUpgradeDisplay === 0) {
+      this.genSpecies[this.getGenCursorWithScroll()].forEach((_species, s) => {
+        this.setUpgradeIcon(s);
+      });
+
+      return;
+    }
+
+    // Loop through all animations when set to 'Animation' mode
+    for (let g = 0; g < this.genSpecies.length; g++) {
+      this.genSpecies[g].forEach((species, s) => {
+        const icon = this.starterSelectGenIconContainers[g].getAt(s) as Phaser.GameObjects.Sprite;
+
+        this.setUpgradeAnimation(icon, species);
+      });
+    }
   }
 
   processInput(button: Button): boolean {
@@ -949,6 +1149,16 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
                     });
                     ui.setMode(Mode.STARTER_SELECT);
                     this.setSpeciesDetails(this.lastSpecies, undefined, undefined, undefined, undefined, undefined, undefined);
+
+                    // Update the candy upgrade display
+                    if (this.isUpgradeIconEnabled() ) {
+                      this.setUpgradeIcon(this.cursor);
+                    }
+                    if (this.isUpgradeAnimationEnabled()) {
+                      const genSpecies = this.genSpecies[this.lastSpecies.generation - 1];
+                      this.setUpgradeAnimation(this.starterSelectGenIconContainers[this.lastSpecies.generation - 1].getAt(genSpecies.indexOf(this.lastSpecies)), this.lastSpecies, true);
+                    }
+
                     return true;
                   }
                   return false;
@@ -976,6 +1186,18 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
                     this.tryUpdateValue(0);
                     ui.setMode(Mode.STARTER_SELECT);
                     this.scene.playSound("buy");
+
+                    // If the notification setting is set to 'On', update the candy upgrade display
+                    if (this.scene.candyUpgradeNotification === 2) {
+                      if (this.isUpgradeIconEnabled() ) {
+                        this.setUpgradeIcon(this.cursor);
+                      }
+                      if (this.isUpgradeAnimationEnabled()) {
+                        const genSpecies = this.genSpecies[this.lastSpecies.generation - 1];
+                        this.setUpgradeAnimation(this.starterSelectGenIconContainers[this.lastSpecies.generation - 1].getAt(genSpecies.indexOf(this.lastSpecies)), this.lastSpecies, true);
+                      }
+                    }
+
                     return true;
                   }
                   return false;
@@ -1294,6 +1516,24 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         }
         this.hiddenAbilityIcons[s].setVisible(slotVisible && !!this.scene.gameData.dexData[speciesId].caughtAttr && !!(this.scene.gameData.starterData[speciesId].abilityAttr & 4));
         this.classicWinIcons[s].setVisible(slotVisible && this.scene.gameData.starterData[speciesId].classicWinCount > 0);
+
+        // 'Candy Icon' mode
+        if (this.scene.candyUpgradeDisplay === 0) {
+
+          if (!starterColors[speciesId]) {
+            // Default to white if no colors are found
+            starterColors[speciesId] = [ "ffffff", "ffffff" ];
+          }
+
+          // Set the candy colors
+          this.candyUpgradeIcon[s].setTint(argbFromRgba(Utils.rgbHexToRgba(starterColors[speciesId][0])));
+          this.candyUpgradeOverlayIcon[s].setTint(argbFromRgba(Utils.rgbHexToRgba(starterColors[speciesId][1])));
+
+          this.setUpgradeIcon(s);
+        } else if (this.scene.candyUpgradeDisplay === 1) {
+          this.candyUpgradeIcon[s].setVisible(false);
+          this.candyUpgradeOverlayIcon[s].setVisible(false);
+        }
       }
     } else {
       changed = super.setCursor(cursor);
@@ -1371,6 +1611,11 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       lastSpeciesIcon.setTexture(this.lastSpecies.getIconAtlasKey(props.formIndex, props.shiny, props.variant), this.lastSpecies.getIconId(props.female, props.formIndex, props.shiny, props.variant));
       this.checkIconId(lastSpeciesIcon, this.lastSpecies, props.female, props.formIndex, props.shiny, props.variant);
       this.iconAnimHandler.addOrUpdate(lastSpeciesIcon, PokemonIconAnimMode.NONE);
+
+      // Resume the animation for the previously selected species
+      const speciesIndex = this.genSpecies[this.lastSpecies.generation - 1].indexOf(this.lastSpecies);
+      const icon = this.starterSelectGenIconContainers[this.lastSpecies.generation - 1].getAt(speciesIndex) as Phaser.GameObjects.Sprite;
+      this.scene.tweens.getTweensOf(icon).forEach(tween => tween.resume());
     }
 
     this.lastSpecies = species;
@@ -1435,7 +1680,22 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
           this.pokemonCandyDarknessOverlay.setCrop(0,0,16, candyCropY);
         }
-        this.iconAnimHandler.addOrUpdate(this.starterSelectGenIconContainers[species.generation - 1].getAt(this.genSpecies[species.generation - 1].indexOf(species)) as Phaser.GameObjects.Sprite, PokemonIconAnimMode.PASSIVE);
+
+
+        // Pause the animation when the species is selected
+        const speciesIndex = this.genSpecies[species.generation - 1].indexOf(species);
+        const icon = this.starterSelectGenIconContainers[species.generation - 1].getAt(speciesIndex) as Phaser.GameObjects.Sprite;
+
+        if (this.isUpgradeAnimationEnabled()) {
+          this.scene.tweens.getTweensOf(icon).forEach(tween => tween.pause());
+          // Reset the position of the icon
+          const position = calcSpritePosition(speciesIndex);
+          icon.x = position.x;
+          icon.y = position.y;
+        }
+
+        // Initiates the small up and down idle animation
+        this.iconAnimHandler.addOrUpdate(icon, PokemonIconAnimMode.PASSIVE);
 
         let starterIndex = -1;
 


### PR DESCRIPTION
## What are the changes?
Addition of 3 new overrides to manage available starters

## Why am I doing these changes?
I'm currently working on the localization of pokemon forms, so I've added these overrides to make it easier to check that the form name is displayed in the starters menu.

## How to test the changes?
Go to `src/overrides.ts` and change `STARTERS_OVERRIDE` or `STARTERS_FORMS_OVERRIDE` or `STARTERS_ALL_FORMS_OVERRIDE` to `true`.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)