### PR TITLE
Candy Icon Display Bugfix

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -855,7 +855,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
     if (!species // No Pokemon exists at that UI index
       || this.scene.candyUpgradeNotification === 0 // Notification setting is 'Off'
-      || species?.getRootSpeciesId(false) !== species?.speciesId) { // Pokemon is not the base evolution and can't use candy
+      || species.speciesId !== species.getRootSpeciesId(false)) { // Pokemon is not the base evolution and can't use candy
       // Set all icons as hidden and exit early
       this.candyUpgradeIcon[index].setVisible(false);
       this.candyUpgradeOverlayIcon[index].setVisible(false);
@@ -1516,9 +1516,8 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         this.hiddenAbilityIcons[s].setVisible(slotVisible && !!this.scene.gameData.dexData[speciesId].caughtAttr && !!(this.scene.gameData.starterData[speciesId].abilityAttr & 4));
         this.classicWinIcons[s].setVisible(slotVisible && this.scene.gameData.starterData[speciesId].classicWinCount > 0);
 
-        const species = this.genSpecies[genCursorWithScroll][s];
         // 'Candy Icon' mode
-        if (this.scene.candyUpgradeDisplay === 0 && species?.getRootSpeciesId(false) === species?.speciesId) {
+        if (this.scene.candyUpgradeDisplay === 0) {
 
           if (!starterColors[speciesId]) {
             // Default to white if no colors are found


### PR DESCRIPTION
Fixes a small visual issue where scrolling through a list of Pokémon would not hide a candy if all the following was true:

1. The new Pokémon was not the root species.
2. The previous Pokémon in the same row/column had an upgrade available. 
3. The previous Pokémon in the same row/column *was* the root species.