### PR TITLE
Remove Trello Link from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,6 @@ If you have the motivation and experience with Typescript/Javascript (or are wil
 **How do I test a new _______?**
 - In the `src/overrides.ts` file there are overrides for most values you'll need to change for testing
 
-
-## 🪧 To Do
-Check out our [Trello Board](https://trello.com/b/z10B703R/pokerogue-board) to see what we're working on
-
 # 📝 Credits
 > If this project contains assets you have produced and you do not see your name here, **please** reach out.
 


### PR DESCRIPTION
# Removes the Trello Link from the README.

I find that it just confuses newcomers that want to help and code, and it's been explained that it is no longer kept up with. 

Before
![image](https://github.com/pagefaultgames/pokerogue/assets/71776311/415d03a5-b9a0-4d51-8ee5-db3264618b7c)

After
![image](https://github.com/pagefaultgames/pokerogue/assets/71776311/0bd2da87-e7a8-4fb5-9f65-7432dab2abc5)
