### PR TITLE
Update starter-select-ui-handler.ts

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -453,7 +453,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
     const getShinyStar = (i: integer, v: integer): Phaser.GameObjects.Image => {
       const position = calcIconPosition(i);
-      const ret = this.scene.add.image(position.x + 163, position.y + 11, "shiny_star_small");
+      const ret = this.scene.add.image((position.x - v * 3) + 163, position.y + 11, "shiny_star_small");
       ret.setOrigin(0, 0);
       ret.setScale(0.5);
       ret.setVisible(false);


### PR DESCRIPTION
Fixes an error with shiny star placement

### Before

![image](https://github.com/pagefaultgames/pokerogue/assets/13838608/34d75f56-9783-4419-acaa-6c48c04116f7)

### After

![image](https://github.com/pagefaultgames/pokerogue/assets/13838608/417efc07-8c3e-4853-bf8e-3cde0ea77c2e)
