### PR TITLE
Fixing Global Scope Issues: Encapsulating preventElementZoom to Prevent Test Crashes

### DIFF
--- a/src/touch-controls.js
+++ b/src/touch-controls.js
@@ -3,6 +3,8 @@ export const keysDown = new Map();
 let lastTouchedId;
 
 export function initTouchControls(buttonMap) {
+  const dpadDiv = document.querySelector("#dpad");
+  preventElementZoom(dpadDiv);
   for (const button of document.querySelectorAll("[data-key]")) {
     // @ts-ignore
     bindKey(button, button.dataset.key, buttonMap);
@@ -138,6 +140,3 @@ function preventElementZoom(element) {
     event.target.click();
   });
 }
-
-const dpadDiv = document.querySelector("#dpad");
-preventElementZoom(dpadDiv);


### PR DESCRIPTION
## Overview

To avoid crashes when the DOM is not yet created, especially during tests, we encapsulate the `preventElementZoom` call into a method that can be imported and called as needed.

## Conclusion

Stop putting code in the global scope. It's bad practice and can lead to crashes. Instead, encapsulate your code in a method that can be imported and called as needed.
