### PR TITLE
[QoL] [Localization] Make achv-bar ui resize dynamically based on content

### DIFF
--- a/src/ui/achv-bar.ts
+++ b/src/ui/achv-bar.ts
@@ -72,20 +72,15 @@ export default class AchvBar extends Phaser.GameObjects.Container {
       this.scoreText.setText(`+${(achv as Achv).score}pt`);
     }
 
-    this.bg.width = this.icon.displayWidth + this.titleText.displayWidth + this.scoreText.displayWidth + 16;
-    if (this.bg.width < this.defaultWidth) {
-      this.bg.width = this.defaultWidth;
-    }
+    // Take the width of the default interface or the title if longest
+    this.bg.width = Math.max(this.defaultWidth, this.icon.displayWidth + this.titleText.displayWidth + this.scoreText.displayWidth + 16);
 
     this.scoreText.x = this.bg.width - 2;
     this.descriptionText.width = this.bg.width - this.icon.displayWidth - 16;
     this.descriptionText.setWordWrapWidth(this.descriptionText.width * 6);
 
-    this.bg.height = this.titleText.displayHeight + this.descriptionText.displayHeight + 8;
-    if (this.bg.height < this.defaultHeight) {
-      this.bg.height = this.defaultHeight;
-    }
-
+    // Take the height of the default interface or the description if longest
+    this.bg.height = Math.max(this.defaultHeight, this.titleText.displayHeight + this.descriptionText.displayHeight + 8);
     this.icon.y = (this.bg.height / 2) - (this.icon.height / 2);
 
     (this.scene as BattleScene).playSound("achv");

--- a/src/ui/achv-bar.ts
+++ b/src/ui/achv-bar.ts
@@ -4,6 +4,9 @@ import { Voucher } from "../system/voucher";
 import { TextStyle, addTextObject } from "./text";
 
 export default class AchvBar extends Phaser.GameObjects.Container {
+  private defaultWidth: number;
+  private defaultHeight: number;
+
   private bg: Phaser.GameObjects.NineSlice;
   private icon: Phaser.GameObjects.Sprite;
   private titleText: Phaser.GameObjects.Text;
@@ -19,7 +22,10 @@ export default class AchvBar extends Phaser.GameObjects.Container {
   }
 
   setup(): void {
-    this.bg = this.scene.add.nineslice(0, 0, "achv_bar", null, 160, 40, 41, 6, 16, 4);
+    this.defaultWidth = 160;
+    this.defaultHeight = 40;
+
+    this.bg = this.scene.add.nineslice(0, 0, "achv_bar", null, this.defaultWidth, this.defaultHeight, 41, 6, 16, 4);
     this.bg.setOrigin(0, 0);
 
     this.add(this.bg);
@@ -66,11 +72,27 @@ export default class AchvBar extends Phaser.GameObjects.Container {
       this.scoreText.setText(`+${(achv as Achv).score}pt`);
     }
 
+    this.bg.width = this.icon.displayWidth + this.titleText.displayWidth + this.scoreText.displayWidth + 16;
+    if (this.bg.width < this.defaultWidth) {
+      this.bg.width = this.defaultWidth;
+    }
+
+    this.scoreText.x = this.bg.width - 2;
+    this.descriptionText.width = this.bg.width - this.icon.displayWidth - 16;
+    this.descriptionText.setWordWrapWidth(this.descriptionText.width * 6);
+
+    this.bg.height = this.titleText.displayHeight + this.descriptionText.displayHeight + 8;
+    if (this.bg.height < this.defaultHeight) {
+      this.bg.height = this.defaultHeight;
+    }
+
+    this.icon.y = (this.bg.height / 2) - (this.icon.height / 2);
+
     (this.scene as BattleScene).playSound("achv");
 
     this.scene.tweens.add({
       targets: this,
-      x: (this.scene.game.canvas.width / 6) - 76,
+      x: (this.scene.game.canvas.width / 6) - (this.bg.width / 2),
       duration: 500,
       ease: "Sine.easeOut"
     });


### PR DESCRIPTION
## What are the changes?
Make achv-bar ui "responsive"

The interface size remains the same as by default.
However: 
- If the title is longer, the width of the interface is increased.
- If the description is longer, the height is increased.
- And of course, if the 2 cases are combined, the interface is enlarged in both height and width.

## Why am I doing these changes?
To facilitate translation and fix problems with some English achievements that were also having trouble displaying correctly

## What did change?
> Before
![image](https://github.com/pagefaultgames/pokerogue/assets/8146474/59e3e39a-0976-4222-942c-6d1c03eee922)

> After
![image](https://github.com/pagefaultgames/pokerogue/assets/8146474/de3be44c-65cc-4a93-90c3-6cae8b7cfa52)

### Screenshots/Videos
https://github.com/pagefaultgames/pokerogue/assets/8146474/31af3068-9644-4a08-95d5-2edf2484bae6

## How to test the changes?
I placed achievements directly in the show() method of the `src/ui/menu-ui-handler`
```typescript
  ...
  this.getUi().achvBar.showAchv(achvs._10K_MONEY);
  this.getUi().achvBar.showAchv(achvs._100K_MONEY);
  ...
```

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?