### PR TITLE
[Localization] French typos in dialogue.ts

### DIFF
--- a/src/locales/fr/dialogue.ts
+++ b/src/locales/fr/dialogue.ts
@@ -4564,7 +4564,7 @@ export const PGMbattleSpecDialogue: SimpleTranslationEntries = {
 			   $Tu es la seule présence ici, bien que j’ai le sentiment d’en ressentir… une autre.
 			   $Vas-tu enfin me livrer un affrontement digne de ce nom ?\nCe challenge dont je rêve depuis un millénaire ?
                $Commençons.`,
-  "firstStageWin": `Je vois. Cette précence était bien réelle.\nJe n’ai donc plus besoin de retenir mes coups.
+  "firstStageWin": `Je vois. Cette présence était bien réelle.\nJe n’ai donc plus besoin de retenir mes coups.
                     $Ne me déçoit pas.`,
   "secondStageWin": "… Magnifique."
 };
@@ -4579,7 +4579,7 @@ export const PGFbattleSpecDialogue: SimpleTranslationEntries = {
 			   $Tu es la seule présence ici, bien que j’ai le sentiment d’en ressentir… une autre.
 			   $Vas-tu enfin me livrer un affrontement digne de ce nom ?\nCe challenge dont je rêve depuis un millénaire ?
                $Commençons.`,
-  "firstStageWin": `Je vois. Cette précence était bien réelle.\nJe n’ai donc plus besoin de retenir mes coups.
+  "firstStageWin": `Je vois. Cette présence était bien réelle.\nJe n’ai donc plus besoin de retenir mes coups.
                     $Ne me déçoit pas.`,
   "secondStageWin": "… Magnifique."
 };


### PR DESCRIPTION
## What are the changes?
Typo in French typos in dialogue.ts

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?