### PR TITLE
[Bug] Adjusts bug bite/pluck functionality with three berry pouches

### DIFF
--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -60,11 +60,11 @@ export const STARTING_LEVEL_OVERRIDE: integer = 0;
  * default is 0 to not override
  * @example SPECIES_OVERRIDE = Species.Bulbasaur;
  */
-export const STARTER_SPECIES_OVERRIDE: Species | integer = 0;
+export const STARTER_SPECIES_OVERRIDE: Species | integer = 12;
 export const ABILITY_OVERRIDE: Abilities = Abilities.NONE;
 export const PASSIVE_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
 export const GENDER_OVERRIDE: Gender = null;
-export const MOVESET_OVERRIDE: Array<Moves> = [];
+export const MOVESET_OVERRIDE: Array<Moves> = [Moves.BUG_BITE];
 export const SHINY_OVERRIDE: boolean = false;
 export const VARIANT_OVERRIDE: Variant = 0;
 
@@ -103,5 +103,5 @@ interface ModifierOverride {
 export const STARTING_MODIFIER_OVERRIDE: Array<ModifierOverride> = [];
 export const OPP_MODIFIER_OVERRIDE: Array<ModifierOverride> = [];
 
-export const STARTING_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [];
-export const OPP_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [];
+export const STARTING_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [{name: "BERRY_POUCH", count: 3}];
+export const OPP_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [{name: "BERRY", count: 4, type: BerryType.SITRUS}];

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -60,11 +60,11 @@ export const STARTING_LEVEL_OVERRIDE: integer = 0;
  * default is 0 to not override
  * @example SPECIES_OVERRIDE = Species.Bulbasaur;
  */
-export const STARTER_SPECIES_OVERRIDE: Species | integer = 12;
+export const STARTER_SPECIES_OVERRIDE: Species | integer = 0;
 export const ABILITY_OVERRIDE: Abilities = Abilities.NONE;
 export const PASSIVE_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
 export const GENDER_OVERRIDE: Gender = null;
-export const MOVESET_OVERRIDE: Array<Moves> = [Moves.BUG_BITE];
+export const MOVESET_OVERRIDE: Array<Moves> = [];
 export const SHINY_OVERRIDE: boolean = false;
 export const VARIANT_OVERRIDE: Variant = 0;
 
@@ -103,5 +103,5 @@ interface ModifierOverride {
 export const STARTING_MODIFIER_OVERRIDE: Array<ModifierOverride> = [];
 export const OPP_MODIFIER_OVERRIDE: Array<ModifierOverride> = [];
 
-export const STARTING_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [{name: "BERRY_POUCH", count: 3}];
-export const OPP_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [{name: "BERRY", count: 4, type: BerryType.SITRUS}];
+export const STARTING_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [];
+export const OPP_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [];


### PR DESCRIPTION
#1315 

## What are the changes?
Changes to the StealEatBerryAttr class to account for the user having three berry pouches (100% chance to keep berry after using it).  
The berry is first transferred to the user's held items before being selected to eat using the super class (EatBerryAttr). 

## Why am I doing these changes?
To fix the possibility of having an infinite berry supply from the opposing pokemon, as previously the berry would be kept on the opposing pokemon's held items.

<!-- Explain why you believe this can enhance user experience -->
Preventing an infinite berry farming glitch.

## What did change?
Removes previous logic from #232 which would simply set this.chosenBerry to a berry from the opposing pokemon's held items before eating it.
With the new logic, the berry is transferred into the user's pokemon's held items before being eaten.
I use the tryTransferHeldItemModifier to transfer into the user's pokemon's held items. I had to provide Promise<boolean> as a return option for this to work in both the StealEatBerryAttr class and the EatBerryAttr class.
I then grab the latest berry from the user's berries (length - 1). 

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
Tested using the `src/overrides.ts` file. 
Recommend testing with no berry pouches vs. three berry pouches to see the effect.
No automated tests were used.