### PR TITLE
[Feature] Add prestige system mode foundations

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -158,6 +158,7 @@ export default class BattleScene extends SceneBase {
   public arenaNextEnemy: ArenaBase;
   public arena: Arena;
   public gameMode: GameMode;
+  public prestigeLevel: integer;
   public score: integer;
   public lockModifierTiers: boolean;
   public trainer: Phaser.GameObjects.Sprite;

--- a/src/feature-flags.ts
+++ b/src/feature-flags.ts
@@ -1,0 +1,7 @@
+export enum FeatureFlag {
+  PRESTIGE_MODE
+}
+
+export const FEATURE_FLAGS: Record<FeatureFlag, boolean> = {
+  [FeatureFlag.PRESTIGE_MODE]: false
+};

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -62,6 +62,8 @@ import * as Overrides from "./overrides";
 import { TextStyle, addTextObject } from "./ui/text";
 import { Type } from "./data/type";
 import { MoveUsedEvent, TurnEndEvent, TurnInitEvent } from "./battle-scene-events";
+import { Prestige } from "./system/prestige";
+import { FEATURE_FLAGS, FeatureFlag } from "./feature-flags";
 
 
 export class LoginPhase extends Phase {
@@ -4026,13 +4028,16 @@ export class GameOverPhase extends BattlePhase {
   handleUnlocks(): void {
     if (this.victory && this.scene.gameMode.isClassic) {
       if (!this.scene.gameData.unlocks[Unlockables.ENDLESS_MODE]) {
-        this.scene.unshiftPhase(new UnlockPhase(this.scene, Unlockables.ENDLESS_MODE));
+        this.scene.unshiftPhase(UnlockPhaseFactory.get(this.scene, Unlockables.ENDLESS_MODE));
       }
       if (this.scene.getParty().filter(p => p.fusionSpecies).length && !this.scene.gameData.unlocks[Unlockables.SPLICED_ENDLESS_MODE]) {
-        this.scene.unshiftPhase(new UnlockPhase(this.scene, Unlockables.SPLICED_ENDLESS_MODE));
+        this.scene.unshiftPhase(UnlockPhaseFactory.get(this.scene, Unlockables.SPLICED_ENDLESS_MODE));
       }
       if (!this.scene.gameData.unlocks[Unlockables.MINI_BLACK_HOLE]) {
-        this.scene.unshiftPhase(new UnlockPhase(this.scene, Unlockables.MINI_BLACK_HOLE));
+        this.scene.unshiftPhase(UnlockPhaseFactory.get(this.scene, Unlockables.MINI_BLACK_HOLE));
+      }
+      if (this.scene.gameData.prestigeLevel < Prestige.MAX_LEVEL && FEATURE_FLAGS[FeatureFlag.PRESTIGE_MODE]) {
+        this.scene.unshiftPhase(UnlockPhaseFactory.get(this.scene, Unlockables.PRESTIGE_MODE));
       }
     }
   }
@@ -4082,6 +4087,24 @@ export class EndCardPhase extends Phase {
   }
 }
 
+export abstract class UnlockPhaseFactory {
+  /**
+   * Get the unlock phase for the specified unlockable
+   *
+   * @param scene
+   * @param unlockable
+   * @returns the unlock phase
+   */
+  public static get(scene: BattleScene, unlockable: Unlockables): UnlockPhase {
+    switch (unlockable) {
+    case Unlockables.PRESTIGE_MODE:
+      return new UnlockPrestigePhase(scene, unlockable);
+    default:
+      return new UnlockPhase(scene, unlockable);
+    }
+  }
+}
+
 export class UnlockPhase extends Phase {
   private unlockable: Unlockables;
 
@@ -4101,6 +4124,35 @@ export class UnlockPhase extends Phase {
         this.end();
       }, null, true, 1500);
     });
+  }
+}
+
+export class UnlockPrestigePhase extends UnlockPhase {
+  /**
+   * Start the unlock phase for PRESTIGE_MODE
+   */
+  start(): void {
+    if (this.scene.gameData.prestigeLevel === Prestige.MAX_LEVEL) {
+      return;
+    }
+    const prestigeAlreadyUnlocked = this.scene.gameData.unlocks[Unlockables.PRESTIGE_MODE];
+    const isLastPrestigeLevelSelected = this.scene.prestigeLevel === this.scene.gameData.prestigeLevel;
+    if (prestigeAlreadyUnlocked) {
+      if (isLastPrestigeLevelSelected) {
+        this.scene.time.delayedCall(2000, () => {
+          this.scene.gameData.increasePrestigeLevel();
+          this.scene.playSound("level_up_fanfare");
+          this.scene.ui.setMode(Mode.MESSAGE);
+          this.scene.ui.showText(`Prestige ${this.scene.gameData.prestigeLevel} has been unlocked.`, null, () => {
+            this.scene.time.delayedCall(1500, () => this.scene.arenaBg.setVisible(true));
+            this.end();
+          }, null, true, 1500);
+        });
+      }
+    } else {
+      this.scene.gameData.increasePrestigeLevel();
+      super.start();
+    }
   }
 }
 

--- a/src/system/game-stats.ts
+++ b/src/system/game-stats.ts
@@ -4,6 +4,7 @@
 export class GameStats {
   public playTime: integer;
   public battles: integer;
+  public prestigeLevel: integer;
   public classicSessionsPlayed: integer;
   public sessionsWon: integer;
   public ribbonsOwned: integer;
@@ -42,6 +43,7 @@ export class GameStats {
   constructor(source?: any) {
     this.playTime = source?.playTime || 0;
     this.battles = source?.battles || 0;
+    this.prestigeLevel = source?.prestigeLevel || 0;
     this.classicSessionsPlayed = source?.classicSessionsPlayed || 0;
     this.sessionsWon = source?.sessionsWon || 0;
     this.ribbonsOwned = source?.ribbonsOwned || 0;

--- a/src/system/prestige.ts
+++ b/src/system/prestige.ts
@@ -1,0 +1,81 @@
+export enum PrestigeModifierAttribute {}
+
+enum PrestigeModifierOperation {
+  ADD,
+  MULTIPLY
+}
+
+class PrestigeModifier {
+  attribute: PrestigeModifierAttribute;
+  value: number;
+  operation: PrestigeModifierOperation;
+
+  constructor(attribute: PrestigeModifierAttribute, operation: PrestigeModifierOperation, value: number) {
+    this.attribute = attribute;
+    this.operation = operation;
+    this.value = value;
+  }
+}
+
+const PRESTIGE_MODIFIERS: PrestigeModifier[][] = [
+  // Level 0 - Should be empty
+  [],
+  // Level 1
+  [],
+  // Level 2
+  [],
+  // Level 3
+  [],
+  // Level 4
+  [],
+  // Level 5
+  [],
+  // Level 6
+  [],
+  // Level 7
+  [],
+  // Level 8
+  [],
+  // Level 9
+  [],
+  // Level 10
+  []
+];
+
+export abstract class Prestige {
+  public static readonly MAX_LEVEL = PRESTIGE_MODIFIERS.length - 1;
+
+  /**
+   * Get the modified value for the given attribute knowing the prestige level
+   *
+   * @param prestigeLevel
+   * @param attribute
+   * @param value
+   * @returns the modified value
+   */
+  public static getModifiedValue(prestigeLevel: integer, attribute: PrestigeModifierAttribute, value: number): number {
+    if (prestigeLevel === 0) {
+      return value;
+    }
+    return this.getModifiersUntil(prestigeLevel)
+      .filter(modifier => modifier.attribute === attribute)
+      .reduce((acc, modifier) => {
+        switch (modifier.operation) {
+        case PrestigeModifierOperation.ADD:
+          return acc + modifier.value;
+        case PrestigeModifierOperation.MULTIPLY:
+          return acc * modifier.value;
+        }
+      }, value);
+  }
+
+  /**
+   * Get the modifiers until the given prestige level
+   *
+   * @param prestigeLevel
+   * @returns the modifiers
+   */
+  private static getModifiersUntil(prestigeLevel: integer): PrestigeModifier[] {
+    return PRESTIGE_MODIFIERS.slice(0, Math.min(prestigeLevel + 1, this.MAX_LEVEL + 1)).flat();
+  }
+}

--- a/src/system/unlockables.ts
+++ b/src/system/unlockables.ts
@@ -3,7 +3,8 @@ import { GameModes, gameModes } from "../game-mode";
 export enum Unlockables {
   ENDLESS_MODE,
   MINI_BLACK_HOLE,
-  SPLICED_ENDLESS_MODE
+  SPLICED_ENDLESS_MODE,
+  PRESTIGE_MODE
 }
 
 export function getUnlockableName(unlockable: Unlockables) {
@@ -14,5 +15,7 @@ export function getUnlockableName(unlockable: Unlockables) {
     return "Mini Black Hole";
   case Unlockables.SPLICED_ENDLESS_MODE:
     return `${gameModes[GameModes.SPLICED_ENDLESS].getName()} Mode`;
+  case Unlockables.PRESTIGE_MODE:
+    return "Prestige Mode";
   }
 }


### PR DESCRIPTION
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

> [!NOTE]
> This PR is part of the `Prestiges` project. You can find more information in https://github.com/pagefaultgames/pokerogue/issues/1545
>
> This aims to merge into https://github.com/pagefaultgames/pokerogue/pull/1533
>
> Because of how forks are working, I cannot base my PR on one of my branch and have the pull request pointing to the main repository. So, I decided to create 2 PRs: one in the base repository that will point to main (this one), and one in my repository that will point to the correct branch (see [francktrouillez/pokerogue#2](https://github.com/francktrouillez/pokerogue/pull/2)), so that we can see the relevant changes.

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This allows to add the foundations for the `Prestige` project. The goal of this PR is to allow anyone to start working on the `Prestige` project.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
This is part of the `Prestiges` project.

I believe this allows people to actually start contributing to the `Prestige` project.

See https://github.com/pagefaultgames/pokerogue/issues/1545 for more information.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- Added `prestigeLevel` to the `GameData` and `BattleScene`.
- Allows to unlock the `Prestige` once we finish the _Classic_ mode.
- Allows to unlock the next `Prestige` once we finish the current one.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
(I've sped up the videos because they were quite long)

Don't unlock the `Prestige` once we finish the _Classic_ mode if the feature flag is disabled:

https://github.com/pagefaultgames/pokerogue/assets/57403591/114e37be-9514-4cc5-b9d5-c4ecf235c678

Allows to unlock the `Prestige` once we finish the _Classic_ mode:

https://github.com/pagefaultgames/pokerogue/assets/57403591/017e4f88-7ee9-4442-aae1-78202508af19

Allows to unlock the next `Prestige` once we finish the current one (in this case, the run was done in Prestige 1):

https://github.com/pagefaultgames/pokerogue/assets/57403591/6ecb51ed-f4b9-4811-949d-93014b1a6fb4


## How to test the changes?
<!-- How can a reviewer test your changes once he checks out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
To make sure that you start from a clean base, you can firstly reset your local storage to start from a blank state.

You can set the `FEATURE_FLAG` for `PRESTIGE_MODE` to `true` locally in the `src/feature_flags.ts` file.

```typescript
export const FEATURE_FLAGS: Record<FeatureFlag, boolean> = {
  [FeatureFlag.PRESTIGE_MODE]: true
};
```

Then, what you can do is to start a new game, and you will see that you can unlock the `Prestige` once you finish the _Classic_ mode. To quickly do so, what I suggest is to change in the `src/overrides.ts` file like so:
```typescript
// ...
export const STARTING_WAVE_OVERRIDE: integer = 199;
// ...
export const POKEBALL_OVERRIDE: { active: boolean, pokeballs: PokeballCounts } = {
  active: true,
  pokeballs: {
    [PokeballType.POKEBALL]: 5,
    [PokeballType.GREAT_BALL]: 0,
    [PokeballType.ULTRA_BALL]: 0,
    [PokeballType.ROGUE_BALL]: 0,
    [PokeballType.MASTER_BALL]: 1, // To catch the pokemon at wave 199
  }
};
// ...
export const MOVESET_OVERRIDE: Array<Moves> = [Moves.WILL_O_WISP, Moves.LEECH_SEED, Moves.SUPER_FANG];
// ...
export const OPP_SPECIES_OVERRIDE: Species | integer = Species.ETERNATUS;
// ...
export const OPP_MOVESET_OVERRIDE: Array<Moves> = [Moves.SPLASH, Moves.SPLASH, Moves.SPLASH, Moves.SPLASH];
```

This allows to first catch the pokemon at wave 199, and then to finish the _Classic_ mode by using `WILL_O_WISP`, `LEECH_SEED`, and `SUPER_FANG` against the last `ETERNATUS` that only knows the moveset `SPLASH`.

Then, you will be able to unlock the `Prestige` once you finish the _Classic_ mode and then unlock the next `Prestige` once you finish the current one when the feature flag is enabled.

To test the next `Prestige` unlocking, you can actually set the prestige level artificially in your Battle Scene to `1` in `src/battle-scene.ts`:
```typescript
public prestigeLevel: integer = 1;
```

## Checklist
- [ ] Have I checked that there is no overlap with another PR?
- [x] Have I made sure the PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
