### PR TITLE
[Feature] Decrease EXP gain depending on Prestige

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -158,6 +158,7 @@ export default class BattleScene extends SceneBase {
   public arenaNextEnemy: ArenaBase;
   public arena: Arena;
   public gameMode: GameMode;
+  public prestigeLevel: integer;
   public score: integer;
   public lockModifierTiers: boolean;
   public trainer: Phaser.GameObjects.Sprite;

--- a/src/feature-flags.ts
+++ b/src/feature-flags.ts
@@ -1,0 +1,7 @@
+export enum FeatureFlag {
+  PRESTIGE_MODE
+}
+
+export const FEATURE_FLAGS: Record<FeatureFlag, boolean> = {
+  [FeatureFlag.PRESTIGE_MODE]: false
+};

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -62,7 +62,7 @@ import * as Overrides from "./overrides";
 import { TextStyle, addTextObject } from "./ui/text";
 import { Type } from "./data/type";
 import { MoveUsedEvent, TurnEndEvent, TurnInitEvent } from "./battle-scene-events";
-import { Prestige } from "./system/prestige";
+import { Prestige, PrestigeModifierAttribute } from "./system/prestige";
 import { FEATURE_FLAGS, FeatureFlag } from "./feature-flags";
 
 
@@ -4249,7 +4249,8 @@ export class ExpPhase extends PlayerPartyMemberPokemonPhase {
     super.start();
 
     const pokemon = this.getPokemon();
-    const exp = new Utils.NumberHolder(this.expValue);
+    const rawExp = FEATURE_FLAGS[FeatureFlag.PRESTIGE_MODE] ? Prestige.getModifiedValue(this.scene.prestigeLevel, PrestigeModifierAttribute.POKEMON_EXP_GAIN, this.expValue) : this.expValue;
+    const exp = new Utils.NumberHolder(rawExp);
     this.scene.applyModifiers(ExpBoosterModifier, true, exp);
     exp.value = Math.floor(exp.value);
     this.scene.ui.showText(i18next.t("battle:expGain", { pokemonName: pokemon.name, exp: exp.value }), null, () => {

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -62,6 +62,8 @@ import * as Overrides from "./overrides";
 import { TextStyle, addTextObject } from "./ui/text";
 import { Type } from "./data/type";
 import { MoveUsedEvent, TurnEndEvent, TurnInitEvent } from "./battle-scene-events";
+import { Prestige } from "./system/prestige";
+import { FEATURE_FLAGS, FeatureFlag } from "./feature-flags";
 
 
 export class LoginPhase extends Phase {
@@ -4026,13 +4028,16 @@ export class GameOverPhase extends BattlePhase {
   handleUnlocks(): void {
     if (this.victory && this.scene.gameMode.isClassic) {
       if (!this.scene.gameData.unlocks[Unlockables.ENDLESS_MODE]) {
-        this.scene.unshiftPhase(new UnlockPhase(this.scene, Unlockables.ENDLESS_MODE));
+        this.scene.unshiftPhase(UnlockPhaseFactory.get(this.scene, Unlockables.ENDLESS_MODE));
       }
       if (this.scene.getParty().filter(p => p.fusionSpecies).length && !this.scene.gameData.unlocks[Unlockables.SPLICED_ENDLESS_MODE]) {
-        this.scene.unshiftPhase(new UnlockPhase(this.scene, Unlockables.SPLICED_ENDLESS_MODE));
+        this.scene.unshiftPhase(UnlockPhaseFactory.get(this.scene, Unlockables.SPLICED_ENDLESS_MODE));
       }
       if (!this.scene.gameData.unlocks[Unlockables.MINI_BLACK_HOLE]) {
-        this.scene.unshiftPhase(new UnlockPhase(this.scene, Unlockables.MINI_BLACK_HOLE));
+        this.scene.unshiftPhase(UnlockPhaseFactory.get(this.scene, Unlockables.MINI_BLACK_HOLE));
+      }
+      if (this.scene.gameData.prestigeLevel < Prestige.MAX_LEVEL && FEATURE_FLAGS[FeatureFlag.PRESTIGE_MODE]) {
+        this.scene.unshiftPhase(UnlockPhaseFactory.get(this.scene, Unlockables.PRESTIGE_MODE));
       }
     }
   }
@@ -4082,6 +4087,24 @@ export class EndCardPhase extends Phase {
   }
 }
 
+export abstract class UnlockPhaseFactory {
+  /**
+   * Get the unlock phase for the specified unlockable
+   *
+   * @param scene
+   * @param unlockable
+   * @returns the unlock phase
+   */
+  public static get(scene: BattleScene, unlockable: Unlockables): UnlockPhase {
+    switch (unlockable) {
+    case Unlockables.PRESTIGE_MODE:
+      return new UnlockPrestigePhase(scene, unlockable);
+    default:
+      return new UnlockPhase(scene, unlockable);
+    }
+  }
+}
+
 export class UnlockPhase extends Phase {
   private unlockable: Unlockables;
 
@@ -4101,6 +4124,35 @@ export class UnlockPhase extends Phase {
         this.end();
       }, null, true, 1500);
     });
+  }
+}
+
+export class UnlockPrestigePhase extends UnlockPhase {
+  /**
+   * Start the unlock phase for PRESTIGE_MODE
+   */
+  start(): void {
+    if (this.scene.gameData.prestigeLevel === Prestige.MAX_LEVEL) {
+      return;
+    }
+    const prestigeAlreadyUnlocked = this.scene.gameData.unlocks[Unlockables.PRESTIGE_MODE];
+    const isLastPrestigeLevelSelected = this.scene.prestigeLevel === this.scene.gameData.prestigeLevel;
+    if (prestigeAlreadyUnlocked) {
+      if (isLastPrestigeLevelSelected) {
+        this.scene.time.delayedCall(2000, () => {
+          this.scene.gameData.increasePrestigeLevel();
+          this.scene.playSound("level_up_fanfare");
+          this.scene.ui.setMode(Mode.MESSAGE);
+          this.scene.ui.showText(`Prestige ${this.scene.gameData.prestigeLevel} has been unlocked.`, null, () => {
+            this.scene.time.delayedCall(1500, () => this.scene.arenaBg.setVisible(true));
+            this.end();
+          }, null, true, 1500);
+        });
+      }
+    } else {
+      this.scene.gameData.increasePrestigeLevel();
+      super.start();
+    }
   }
 }
 

--- a/src/system/game-stats.ts
+++ b/src/system/game-stats.ts
@@ -4,6 +4,7 @@
 export class GameStats {
   public playTime: integer;
   public battles: integer;
+  public prestigeLevel: integer;
   public classicSessionsPlayed: integer;
   public sessionsWon: integer;
   public ribbonsOwned: integer;
@@ -42,6 +43,7 @@ export class GameStats {
   constructor(source?: any) {
     this.playTime = source?.playTime || 0;
     this.battles = source?.battles || 0;
+    this.prestigeLevel = source?.prestigeLevel || 0;
     this.classicSessionsPlayed = source?.classicSessionsPlayed || 0;
     this.sessionsWon = source?.sessionsWon || 0;
     this.ribbonsOwned = source?.ribbonsOwned || 0;

--- a/src/system/prestige.ts
+++ b/src/system/prestige.ts
@@ -1,4 +1,6 @@
-export enum PrestigeModifierAttribute {}
+export enum PrestigeModifierAttribute {
+  POKEMON_EXP_GAIN
+}
 
 enum PrestigeModifierOperation {
   ADD,
@@ -25,13 +27,17 @@ const PRESTIGE_MODIFIERS: PrestigeModifier[][] = [
   // Level 2
   [],
   // Level 3
-  [],
+  [
+    new PrestigeModifier(PrestigeModifierAttribute.POKEMON_EXP_GAIN, PrestigeModifierOperation.MULTIPLY, 0.9)
+  ],
   // Level 4
   [],
   // Level 5
   [],
   // Level 6
-  [],
+  [
+    new PrestigeModifier(PrestigeModifierAttribute.POKEMON_EXP_GAIN, PrestigeModifierOperation.MULTIPLY, 0.85)
+  ],
   // Level 7
   [],
   // Level 8
@@ -39,7 +45,9 @@ const PRESTIGE_MODIFIERS: PrestigeModifier[][] = [
   // Level 9
   [],
   // Level 10
-  []
+  [
+    new PrestigeModifier(PrestigeModifierAttribute.POKEMON_EXP_GAIN, PrestigeModifierOperation.MULTIPLY, 0.8)
+  ]
 ];
 
 export abstract class Prestige {

--- a/src/system/prestige.ts
+++ b/src/system/prestige.ts
@@ -1,0 +1,81 @@
+export enum PrestigeModifierAttribute {}
+
+enum PrestigeModifierOperation {
+  ADD,
+  MULTIPLY
+}
+
+class PrestigeModifier {
+  attribute: PrestigeModifierAttribute;
+  value: number;
+  operation: PrestigeModifierOperation;
+
+  constructor(attribute: PrestigeModifierAttribute, operation: PrestigeModifierOperation, value: number) {
+    this.attribute = attribute;
+    this.operation = operation;
+    this.value = value;
+  }
+}
+
+const PRESTIGE_MODIFIERS: PrestigeModifier[][] = [
+  // Level 0 - Should be empty
+  [],
+  // Level 1
+  [],
+  // Level 2
+  [],
+  // Level 3
+  [],
+  // Level 4
+  [],
+  // Level 5
+  [],
+  // Level 6
+  [],
+  // Level 7
+  [],
+  // Level 8
+  [],
+  // Level 9
+  [],
+  // Level 10
+  []
+];
+
+export abstract class Prestige {
+  public static readonly MAX_LEVEL = PRESTIGE_MODIFIERS.length - 1;
+
+  /**
+   * Get the modified value for the given attribute knowing the prestige level
+   *
+   * @param prestigeLevel
+   * @param attribute
+   * @param value
+   * @returns the modified value
+   */
+  public static getModifiedValue(prestigeLevel: integer, attribute: PrestigeModifierAttribute, value: number): number {
+    if (prestigeLevel === 0) {
+      return value;
+    }
+    return this.getModifiersUntil(prestigeLevel)
+      .filter(modifier => modifier.attribute === attribute)
+      .reduce((acc, modifier) => {
+        switch (modifier.operation) {
+        case PrestigeModifierOperation.ADD:
+          return acc + modifier.value;
+        case PrestigeModifierOperation.MULTIPLY:
+          return acc * modifier.value;
+        }
+      }, value);
+  }
+
+  /**
+   * Get the modifiers until the given prestige level
+   *
+   * @param prestigeLevel
+   * @returns the modifiers
+   */
+  private static getModifiersUntil(prestigeLevel: integer): PrestigeModifier[] {
+    return PRESTIGE_MODIFIERS.slice(0, Math.min(prestigeLevel + 1, this.MAX_LEVEL + 1)).flat();
+  }
+}

--- a/src/system/unlockables.ts
+++ b/src/system/unlockables.ts
@@ -3,7 +3,8 @@ import { GameModes, gameModes } from "../game-mode";
 export enum Unlockables {
   ENDLESS_MODE,
   MINI_BLACK_HOLE,
-  SPLICED_ENDLESS_MODE
+  SPLICED_ENDLESS_MODE,
+  PRESTIGE_MODE
 }
 
 export function getUnlockableName(unlockable: Unlockables) {
@@ -14,5 +15,7 @@ export function getUnlockableName(unlockable: Unlockables) {
     return "Mini Black Hole";
   case Unlockables.SPLICED_ENDLESS_MODE:
     return `${gameModes[GameModes.SPLICED_ENDLESS].getName()} Mode`;
+  case Unlockables.PRESTIGE_MODE:
+    return "Prestige Mode";
   }
 }


### PR DESCRIPTION
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

> [!NOTE]
> This PR is part of the `Prestiges` project. You can find more information in https://github.com/pagefaultgames/pokerogue/issues/1545
>
> This PR aims to merge into https://github.com/pagefaultgames/pokerogue/pull/1534
>
> Because of how forks are working, I cannot base my PR on one of my branch and have the pull request pointing to the main repository. So, I decided to create 2 PRs: one in the base repository that will point to main (this one), and one in my repository that will point to the correct branch (see [francktrouillez/pokerogue#8](https://github.com/francktrouillez/pokerogue/pull/8)), so that we can see the relevant changes.

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This allows to decrease the EXP gain depending on the Prestige level chosen.

I didn't dive into level design, so we might want to tweak the values of the modifiers.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
This is part of the `Prestiges` project.

I believe this increases the difficulty of the game, as the player will have to choose a Prestige level, which will decrease the EXP gain, leading to a lower rate at which pokemon can level up.

This is based on the Prestige level chosen.

See https://github.com/pagefaultgames/pokerogue/issues/1545 for more information.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- Decrease the EXP gain depending on the Prestige level.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

When no Prestige level is chosen, the EXP gain is the same as usual (prestige level stays at 0):

https://github.com/pagefaultgames/pokerogue/assets/57403591/562411b7-0be2-45d8-98b7-f88a49b4dc31

When a Prestige level that contains a decrease of the EXP gain is chosen, the EXP gain will be decreased:

https://github.com/pagefaultgames/pokerogue/assets/57403591/d4d01543-2254-4f3b-808e-1fb745b7390d

When the feature flag is disabled, the EXP gain is the same as usual:

https://github.com/pagefaultgames/pokerogue/assets/57403591/ef0cba89-4942-4c81-b31c-79e1beb866d1

## How to test the changes?
<!-- How can a reviewer test your changes once he checks out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
You can set the `FEATURE_FLAG` for `PRESTIGE_MODE` to `true` locally in the `src/feature_flags.ts` file.

```typescript
export const FEATURE_FLAGS: Record<FeatureFlag, boolean> = {
  [FeatureFlag.PRESTIGE_MODE]: true
};
```

You can then set the default value of the `prestigeLevel` of your Battle Scene to `10` for instance in `src/battle-scene.ts`:
```typescript
public prestigeLevel: integer = 10;
```

You can also set a given pokemon to encounter in the `src/overrides.ts` file to make sure you have a fair comparison:
```typescript
export const OPP_SPECIES_OVERRIDE: Species | integer = Species.SQUIRTLE;
```

Then, running the game in Classic mode, starting a game, beating one pokemon will allow you to see the difference in the EXP gained when enabling and disabling the feature flag.

## Checklist
- [ ] Have I checked that there is no overlap with another PR?
- [x] Have I made sure the PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
