### PR TITLE
[Feature] Add OptionSelect for Prestige level when in Classic mode

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -158,6 +158,7 @@ export default class BattleScene extends SceneBase {
   public arenaNextEnemy: ArenaBase;
   public arena: Arena;
   public gameMode: GameMode;
+  public prestigeLevel: integer;
   public score: integer;
   public lockModifierTiers: boolean;
   public trainer: Phaser.GameObjects.Sprite;

--- a/src/feature-flags.ts
+++ b/src/feature-flags.ts
@@ -1,0 +1,7 @@
+export enum FeatureFlag {
+  PRESTIGE_MODE
+}
+
+export const FEATURE_FLAGS: Record<FeatureFlag, boolean> = {
+  [FeatureFlag.PRESTIGE_MODE]: false
+};

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -62,6 +62,8 @@ import * as Overrides from "./overrides";
 import { TextStyle, addTextObject } from "./ui/text";
 import { Type } from "./data/type";
 import { MoveUsedEvent, TurnEndEvent, TurnInitEvent } from "./battle-scene-events";
+import { Prestige } from "./system/prestige";
+import { FEATURE_FLAGS, FeatureFlag } from "./feature-flags";
 
 
 export class LoginPhase extends Phase {
@@ -4026,13 +4028,16 @@ export class GameOverPhase extends BattlePhase {
   handleUnlocks(): void {
     if (this.victory && this.scene.gameMode.isClassic) {
       if (!this.scene.gameData.unlocks[Unlockables.ENDLESS_MODE]) {
-        this.scene.unshiftPhase(new UnlockPhase(this.scene, Unlockables.ENDLESS_MODE));
+        this.scene.unshiftPhase(UnlockPhaseFactory.get(this.scene, Unlockables.ENDLESS_MODE));
       }
       if (this.scene.getParty().filter(p => p.fusionSpecies).length && !this.scene.gameData.unlocks[Unlockables.SPLICED_ENDLESS_MODE]) {
-        this.scene.unshiftPhase(new UnlockPhase(this.scene, Unlockables.SPLICED_ENDLESS_MODE));
+        this.scene.unshiftPhase(UnlockPhaseFactory.get(this.scene, Unlockables.SPLICED_ENDLESS_MODE));
       }
       if (!this.scene.gameData.unlocks[Unlockables.MINI_BLACK_HOLE]) {
-        this.scene.unshiftPhase(new UnlockPhase(this.scene, Unlockables.MINI_BLACK_HOLE));
+        this.scene.unshiftPhase(UnlockPhaseFactory.get(this.scene, Unlockables.MINI_BLACK_HOLE));
+      }
+      if (this.scene.gameData.prestigeLevel < Prestige.MAX_LEVEL && FEATURE_FLAGS[FeatureFlag.PRESTIGE_MODE]) {
+        this.scene.unshiftPhase(UnlockPhaseFactory.get(this.scene, Unlockables.PRESTIGE_MODE));
       }
     }
   }
@@ -4082,6 +4087,24 @@ export class EndCardPhase extends Phase {
   }
 }
 
+export abstract class UnlockPhaseFactory {
+  /**
+   * Get the unlock phase for the specified unlockable
+   *
+   * @param scene
+   * @param unlockable
+   * @returns the unlock phase
+   */
+  public static get(scene: BattleScene, unlockable: Unlockables): UnlockPhase {
+    switch (unlockable) {
+    case Unlockables.PRESTIGE_MODE:
+      return new UnlockPrestigePhase(scene, unlockable);
+    default:
+      return new UnlockPhase(scene, unlockable);
+    }
+  }
+}
+
 export class UnlockPhase extends Phase {
   private unlockable: Unlockables;
 
@@ -4101,6 +4124,35 @@ export class UnlockPhase extends Phase {
         this.end();
       }, null, true, 1500);
     });
+  }
+}
+
+export class UnlockPrestigePhase extends UnlockPhase {
+  /**
+   * Start the unlock phase for PRESTIGE_MODE
+   */
+  start(): void {
+    if (this.scene.gameData.prestigeLevel === Prestige.MAX_LEVEL) {
+      return;
+    }
+    const prestigeAlreadyUnlocked = this.scene.gameData.unlocks[Unlockables.PRESTIGE_MODE];
+    const isLastPrestigeLevelSelected = this.scene.prestigeLevel === this.scene.gameData.prestigeLevel;
+    if (prestigeAlreadyUnlocked) {
+      if (isLastPrestigeLevelSelected) {
+        this.scene.time.delayedCall(2000, () => {
+          this.scene.gameData.increasePrestigeLevel();
+          this.scene.playSound("level_up_fanfare");
+          this.scene.ui.setMode(Mode.MESSAGE);
+          this.scene.ui.showText(`Prestige ${this.scene.gameData.prestigeLevel} has been unlocked.`, null, () => {
+            this.scene.time.delayedCall(1500, () => this.scene.arenaBg.setVisible(true));
+            this.end();
+          }, null, true, 1500);
+        });
+      }
+    } else {
+      this.scene.gameData.increasePrestigeLevel();
+      super.start();
+    }
   }
 }
 

--- a/src/system/game-stats.ts
+++ b/src/system/game-stats.ts
@@ -4,6 +4,7 @@
 export class GameStats {
   public playTime: integer;
   public battles: integer;
+  public prestigeLevel: integer;
   public classicSessionsPlayed: integer;
   public sessionsWon: integer;
   public ribbonsOwned: integer;
@@ -42,6 +43,7 @@ export class GameStats {
   constructor(source?: any) {
     this.playTime = source?.playTime || 0;
     this.battles = source?.battles || 0;
+    this.prestigeLevel = source?.prestigeLevel || 0;
     this.classicSessionsPlayed = source?.classicSessionsPlayed || 0;
     this.sessionsWon = source?.sessionsWon || 0;
     this.ribbonsOwned = source?.ribbonsOwned || 0;

--- a/src/system/prestige.ts
+++ b/src/system/prestige.ts
@@ -1,0 +1,81 @@
+export enum PrestigeModifierAttribute {}
+
+enum PrestigeModifierOperation {
+  ADD,
+  MULTIPLY
+}
+
+class PrestigeModifier {
+  attribute: PrestigeModifierAttribute;
+  value: number;
+  operation: PrestigeModifierOperation;
+
+  constructor(attribute: PrestigeModifierAttribute, operation: PrestigeModifierOperation, value: number) {
+    this.attribute = attribute;
+    this.operation = operation;
+    this.value = value;
+  }
+}
+
+const PRESTIGE_MODIFIERS: PrestigeModifier[][] = [
+  // Level 0 - Should be empty
+  [],
+  // Level 1
+  [],
+  // Level 2
+  [],
+  // Level 3
+  [],
+  // Level 4
+  [],
+  // Level 5
+  [],
+  // Level 6
+  [],
+  // Level 7
+  [],
+  // Level 8
+  [],
+  // Level 9
+  [],
+  // Level 10
+  []
+];
+
+export abstract class Prestige {
+  public static readonly MAX_LEVEL = PRESTIGE_MODIFIERS.length - 1;
+
+  /**
+   * Get the modified value for the given attribute knowing the prestige level
+   *
+   * @param prestigeLevel
+   * @param attribute
+   * @param value
+   * @returns the modified value
+   */
+  public static getModifiedValue(prestigeLevel: integer, attribute: PrestigeModifierAttribute, value: number): number {
+    if (prestigeLevel === 0) {
+      return value;
+    }
+    return this.getModifiersUntil(prestigeLevel)
+      .filter(modifier => modifier.attribute === attribute)
+      .reduce((acc, modifier) => {
+        switch (modifier.operation) {
+        case PrestigeModifierOperation.ADD:
+          return acc + modifier.value;
+        case PrestigeModifierOperation.MULTIPLY:
+          return acc * modifier.value;
+        }
+      }, value);
+  }
+
+  /**
+   * Get the modifiers until the given prestige level
+   *
+   * @param prestigeLevel
+   * @returns the modifiers
+   */
+  private static getModifiersUntil(prestigeLevel: integer): PrestigeModifier[] {
+    return PRESTIGE_MODIFIERS.slice(0, Math.min(prestigeLevel + 1, this.MAX_LEVEL + 1)).flat();
+  }
+}

--- a/src/system/unlockables.ts
+++ b/src/system/unlockables.ts
@@ -3,7 +3,8 @@ import { GameModes, gameModes } from "../game-mode";
 export enum Unlockables {
   ENDLESS_MODE,
   MINI_BLACK_HOLE,
-  SPLICED_ENDLESS_MODE
+  SPLICED_ENDLESS_MODE,
+  PRESTIGE_MODE
 }
 
 export function getUnlockableName(unlockable: Unlockables) {
@@ -14,5 +15,7 @@ export function getUnlockableName(unlockable: Unlockables) {
     return "Mini Black Hole";
   case Unlockables.SPLICED_ENDLESS_MODE:
     return `${gameModes[GameModes.SPLICED_ENDLESS].getName()} Mode`;
+  case Unlockables.PRESTIGE_MODE:
+    return "Prestige Mode";
   }
 }

--- a/src/ui/abstact-option-select-ui-handler.ts
+++ b/src/ui/abstact-option-select-ui-handler.ts
@@ -23,6 +23,7 @@ export interface OptionSelectItem {
   overrideSound?: boolean;
   item?: string;
   itemArgs?: any[]
+  value?: any;
 }
 
 const scrollUpLabel = "↑";
@@ -171,7 +172,7 @@ export default abstract class AbstractOptionSelectUiHandler extends UiHandler {
           return false;
         }
       }
-      const option = this.config?.options[this.cursor + (this.scrollCursor - (this.scrollCursor ? 1 : 0))];
+      const option = this.getCurrentSelectedOption();
       if (option?.handler()) {
         if (!option.keepOpen) {
           this.clear();
@@ -302,5 +303,9 @@ export default abstract class AbstractOptionSelectUiHandler extends UiHandler {
       this.cursorObj.destroy();
     }
     this.cursorObj = null;
+  }
+
+  protected getCurrentSelectedOption(): OptionSelectItem {
+    return this.config?.options[this.cursor + (this.scrollCursor - (this.scrollCursor ? 1 : 0))];
   }
 }

--- a/src/ui/prestige-level-select-ui-handler.ts
+++ b/src/ui/prestige-level-select-ui-handler.ts
@@ -1,0 +1,55 @@
+import BattleScene from "../battle-scene";
+import OptionSelectUiHandler from "./option-select-ui-handler";
+import { PrestigeModifiersDescription } from "./prestige-modifiers-description";
+import { Mode } from "./ui";
+
+export default class PrestigeLevelSelectUiHandler extends OptionSelectUiHandler {
+  private prestigeModifiersDescription: PrestigeModifiersDescription;
+  private descriptionContainer: Phaser.GameObjects.Container;
+
+  constructor(scene: BattleScene, mode: Mode = Mode.PRESTIGE_LEVEL_SELECT) {
+    super(scene, mode);
+  }
+
+  setup() {
+    super.setup();
+
+    const ui = this.getUi();
+
+    this.descriptionContainer = this.scene.add.container(0, -(this.scene.game.canvas.height / 6));
+    this.descriptionContainer.setVisible(false);
+    ui.add(this.descriptionContainer);
+
+    this.prestigeModifiersDescription = new PrestigeModifiersDescription(this.scene, 0, 0);
+    this.prestigeModifiersDescription.setup();
+
+    this.descriptionContainer.add(this.prestigeModifiersDescription);
+  }
+
+  show(args: any[]): boolean {
+    const result = super.show(args);
+    if (result) {
+      this.descriptionContainer.setVisible(true);
+      this.prestigeModifiersDescription.setVisible(true);
+    }
+    return result;
+  }
+
+  clear(): void {
+    super.clear();
+    this.descriptionContainer.setVisible(false);
+    this.prestigeModifiersDescription.setVisible(false);
+  }
+
+  setCursor(cursor: number): boolean {
+    const result = super.setCursor(cursor);
+    const selectedOption = this.getCurrentSelectedOption();
+    if (selectedOption !== undefined) {
+      const value = selectedOption.value;
+      if (value !== undefined) {
+        this.prestigeModifiersDescription.updateContent(value as integer);
+      }
+    }
+    return result;
+  }
+}

--- a/src/ui/prestige-modifiers-description.ts
+++ b/src/ui/prestige-modifiers-description.ts
@@ -1,0 +1,50 @@
+import BattleScene from "../battle-scene";
+import { TextStyle, addTextObject } from "./text";
+import { WindowVariant, addWindow } from "./ui-theme";
+import { Prestige } from "#app/system/prestige";
+
+
+export class PrestigeModifiersDescription extends Phaser.GameObjects.Container {
+  private descriptionContainer: Phaser.GameObjects.Container;
+  private prestigeLevel: number;
+
+  constructor(scene: BattleScene, x: number, y: number) {
+    super(scene, x, y);
+
+    this.setup();
+  }
+
+  setup() {
+    const window = addWindow(this.scene, 5, 5, 200, 118, false, false, null, null, WindowVariant.THIN);
+    this.add(window);
+
+    this.descriptionContainer = this.scene.add.container(15, 15);
+    this.add(this.descriptionContainer);
+  }
+
+  updateContent(prestigeLevel: number): void {
+    if (prestigeLevel === undefined) {
+      return;
+    }
+    this.prestigeLevel = prestigeLevel;
+    if (this.prestigeLevel === 0) {
+      this.descriptionContainer.removeAll(true);
+      this.descriptionContainer.add(addTextObject(this.scene, 0, 0, "No modifiers", TextStyle.WINDOW, { fontSize: "74px" }));
+      return;
+    }
+    const descriptions = Prestige.getLevelDescriptionsUntil(prestigeLevel);
+    this.descriptionContainer.removeAll(true);
+    if (descriptions.length === 0) {
+      this.descriptionContainer.add(addTextObject(this.scene, 0, 0, "No modifiers", TextStyle.WINDOW, { fontSize: "74px" }));
+      return;
+    }
+    descriptions.forEach((d: string, i: integer) => {
+      const text = addTextObject(this.scene, 0, i * 9, d, TextStyle.WINDOW, { fontSize: "74px" });
+      this.descriptionContainer.add(text);
+    });
+  }
+}
+
+export interface PrestigeModifiersDescription {
+  scene: BattleScene
+}

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -38,6 +38,7 @@ import SessionReloadModalUiHandler from "./session-reload-modal-ui-handler";
 import {Button} from "../enums/buttons";
 import i18next, {ParseKeys} from "i18next";
 import {PlayerGender} from "#app/system/game-data";
+import PrestigeLevelSelectUiHandler from "./prestige-level-select-ui-handler";
 
 export enum Mode {
   MESSAGE,
@@ -55,6 +56,7 @@ export enum Mode {
   EGG_HATCH_SCENE,
   CONFIRM,
   OPTION_SELECT,
+  PRESTIGE_LEVEL_SELECT,
   MENU,
   MENU_OPTION_SELECT,
   SETTINGS,
@@ -86,6 +88,7 @@ const noTransitionModes = [
   Mode.TITLE,
   Mode.CONFIRM,
   Mode.OPTION_SELECT,
+  Mode.PRESTIGE_LEVEL_SELECT,
   Mode.MENU,
   Mode.MENU_OPTION_SELECT,
   Mode.SETTINGS,
@@ -136,6 +139,7 @@ export default class UI extends Phaser.GameObjects.Container {
       new EggHatchSceneHandler(scene),
       new ConfirmUiHandler(scene),
       new OptionSelectUiHandler(scene),
+      new PrestigeLevelSelectUiHandler(scene),
       new MenuUiHandler(scene),
       new OptionSelectUiHandler(scene, Mode.MENU_OPTION_SELECT),
       new SettingsUiHandler(scene),


### PR DESCRIPTION
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

> [!NOTE]
> This PR is part of the `Prestiges` project. You can find more information in https://github.com/pagefaultgames/pokerogue/issues/1545
>
> This PR aims to merge into https://github.com/pagefaultgames/pokerogue/pull/1534
>
> Because of how forks are working, I cannot base my PR on one of my branch and have the pull request pointing to the main repository. So, I decided to create 2 PRs: one in the base repository that will point to main (this one), and one in my repository that will point to the correct branch (see [francktrouillez/pokerogue#9](https://github.com/francktrouillez/pokerogue/pull/9)), so that we can see the relevant changes.

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This allows the user to select a Prestige level whenever he chooses to start a new _Classic_ game.

The cumulated modifiers for each prestige is also shown to the user.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
This is part of the `Prestiges` project.

I believe this is a good way and intuitive way to introduce the Prestige levels selection to the user.

It also allows the user to see the different modifiers that will be applied to the game depending on the Prestige level chosen.

These modifiers are stackables, which means that we show the combined modifiers for each Prestige level.

See https://github.com/pagefaultgames/pokerogue/issues/1545 for more information.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- Add a new `PrestigeLevelSelectUiHandler` that will handle the UI for the Prestige level selection.
- Add a new `PrestigeModifierDescription` that will handle the description of the modifiers for each Prestige level.
- Add the new selector whenever the user chooses to start a new _Classic_ game once he has unlocked prestiges.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

When the Prestiges are not unlocked yet:

https://github.com/pagefaultgames/pokerogue/assets/57403591/22246a41-e27e-4451-9e8c-187967fde847

When the Prestiges are unlocked (here until prestige 5 using dummy modifiers):

https://github.com/pagefaultgames/pokerogue/assets/57403591/1a01407a-f224-4e8d-9965-9399541ac64e

When the feature flag is disabled:

https://github.com/pagefaultgames/pokerogue/assets/57403591/4b7d9847-1cfe-44f3-9e32-985a42373cf5

## How to test the changes?
<!-- How can a reviewer test your changes once he checks out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
You can first reset your local storage to start from scratch.

You can set the `FEATURE_FLAG` for `PRESTIGE_MODE` to `true` locally in the `src/feature_flags.ts` file.

```typescript
export const FEATURE_FLAGS: Record<FeatureFlag, boolean> = {
  [FeatureFlag.PRESTIGE_MODE]: true
};
```

Then, you need to beat the game at least once to unlock the Prestiges. If your local storage already contains the Prestiges unlocked, you can directly test the new selector. Otherwise, you'll need to beat the game at least once.

You can do that by hijacking the load of the game in the `src/system/game-data.ts` file in the `#initSystem` method by adding right after the unlocks an explicit unlock of the Prestiges:

```typescript
// ...
if (systemData.unlocks) {
  for (const key of Object.keys(systemData.unlocks)) {
    if (this.unlocks.hasOwnProperty(key)) {
      this.unlocks[key] = systemData.unlocks[key];
    }
  }
}

if (systemData.prestigeLevel) {
  this.prestigeLevel = systemData.prestigeLevel;
}

this.unlocks[Unlockables.PRESTIGE_MODE] = true;
this.prestigeLevel = 5; // Unlock all Prestiges until the 5th one
// ...
```

Then, trying to start the game in Classic mode will actually show you the selector when enabling the feature flag.

To show some modifiers, you can define some dummy attributes in `src/system/prestige.src` like:

```typescript
export enum PrestigeModifierAttribute {
  MODIFIER_FOR_POKEMONS,
  MODIFIER_FOR_MONEY
}
// ...
const PRESTIGE_MODIFIERS: PrestigeModifier[][] = [
  // Level 0 - Should be empty
  [],
  // Level 1
  [
    new PrestigeModifier(PrestigeModifierAttribute.MODIFIER_FOR_POKEMONS, PrestigeModifierOperation.ADD, 5)
  ],
  // Level 2
  [
    new PrestigeModifier(PrestigeModifierAttribute.MODIFIER_FOR_POKEMONS, PrestigeModifierOperation.ADD, 5),
    new PrestigeModifier(PrestigeModifierAttribute.MODIFIER_FOR_MONEY, PrestigeModifierOperation.MULTIPLY, 2)
  ],
  // Level 3
  [
    new PrestigeModifier(PrestigeModifierAttribute.MODIFIER_FOR_MONEY, PrestigeModifierOperation.MULTIPLY, 2)
  ],
  // Level 4
  [],
  // Level 5
  [],
  // Level 6
  [],
  // Level 7
  [],
  // Level 8
  [],
  // Level 9
  [],
  // Level 10
  []
];
// ...
private static getModifierAttributeName(attribute: PrestigeModifierAttribute): string {
  switch (attribute) {
  case PrestigeModifierAttribute.MODIFIER_FOR_POKEMONS:
    return "Pokemons";
  case PrestigeModifierAttribute.MODIFIER_FOR_MONEY:
    return "Money";
  default:
    throw new PrestigeModifierNameNotImplementedError(attribute);
  }
}
```

This will allow you to see the different modifiers for each Prestige level in the selector.

Once this is done, you can also try to check when the Prestiges are not unlocked yet, and see that the selector is not shown (unless other modes are unlocked).

## Checklist
- [ ] Have I checked that there is no overlap with another PR?
- [x] Have I made sure the PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
