### PR TITLE
[zh_CN localization] fixing text size of zh_CN Update text.ts

### DIFF
--- a/src/ui/text.ts
+++ b/src/ui/text.ts
@@ -46,7 +46,13 @@ const languageSettings: { [key: string]: LanguageSetting } = {
   "es":{},
   "it":{},
   "fr":{},
-  "zh_CN":{},
+  "zh_CN":{
+          summaryFontSize:"70px",
+          battleInfoFontSize:"65px",
+	        partyFontSize:"50px",
+	        tooltipContentFontSize:"50px",
+	        moveInfoFontSize:"50px"
+  },
   "pt_BR":{},
 };
 

--- a/src/ui/text.ts
+++ b/src/ui/text.ts
@@ -47,11 +47,11 @@ const languageSettings: { [key: string]: LanguageSetting } = {
   "it":{},
   "fr":{},
   "zh_CN":{
-          summaryFontSize:"70px",
-          battleInfoFontSize:"65px",
-	        partyFontSize:"50px",
-	        tooltipContentFontSize:"50px",
-	        moveInfoFontSize:"50px"
+    summaryFontSize:"70px",
+    battleInfoFontSize:"65px",
+    partyFontSize:"50px",
+    tooltipContentFontSize:"50px",
+    moveInfoFontSize:"50px"
   },
   "pt_BR":{},
 };


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
some fontsize has been fixed so that dialogues can be showed correctly. Chinese characters in some interface also looks better


### Screenshots/Videos
**before**
![image](https://github.com/pagefaultgames/pokerogue/assets/47717431/03b7f261-8683-430c-bc4c-737e4000f3c8)
![image](https://github.com/pagefaultgames/pokerogue/assets/47717431/53dd341b-9283-492b-86c6-45238917c64e)
![image](https://github.com/pagefaultgames/pokerogue/assets/47717431/8a64f610-7b7a-4063-9b16-b9a1f5f009f4)
![image](https://github.com/pagefaultgames/pokerogue/assets/47717431/17cac10b-1dc3-4536-b16a-36b1fd59e40f)

**after**
![image](https://github.com/pagefaultgames/pokerogue/assets/47717431/b3e111cb-cc3a-4300-a63b-b158832c4838)
![image](https://github.com/pagefaultgames/pokerogue/assets/47717431/c1915bb6-cb41-43ca-9286-6c75623f60af)
![image](https://github.com/pagefaultgames/pokerogue/assets/47717431/76e48b46-0c30-487e-84d3-2acefc316757)
![image](https://github.com/pagefaultgames/pokerogue/assets/47717431/440663f6-c99b-42fb-b3c4-02fa02ba06a0)
![image](https://github.com/pagefaultgames/pokerogue/assets/47717431/53287e54-610d-4586-a462-0a00dc02fbba)

