### PR TITLE
[Enhancement] Preserve move PP when fusing

### DIFF
--- a/src/data/enums/moves.ts
+++ b/src/data/enums/moves.ts
@@ -1,5 +1,5 @@
 export enum Moves {
-  /**{@link https://bulbapedia.bulbagarden.net/wiki/None_(move) | Source} */
+  /** Represents an empty slot in the moveset */
   NONE,
   /**{@link https://bulbapedia.bulbagarden.net/wiki/Pound_(move) | Source} */
   POUND,

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1214,8 +1214,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     return ret;
   }
 
-  setMove(moveIndex: integer, moveId: Moves): void {
-    const move = moveId ? new PokemonMove(moveId) : null;
+  setMove(moveIndex: integer, moveId: Moves, ppUp?: integer): void {
+    const move = moveId ? new PokemonMove(moveId, undefined, ppUp) : null;
     this.moveset[moveIndex] = move;
     if (this.summonData?.moveset) {
       this.summonData.moveset[moveIndex] = move;
@@ -3166,7 +3166,7 @@ export class PlayerPokemon extends Pokemon {
           this.scene.removePartyMemberModifiers(fusedPartyMemberIndex);
           this.scene.getParty().splice(fusedPartyMemberIndex, 1)[0];
           const newPartyMemberIndex = this.scene.getParty().indexOf(this);
-          pokemon.getMoveset(true).map(m => this.scene.unshiftPhase(new LearnMovePhase(this.scene, newPartyMemberIndex, m.getMove().id)));
+          pokemon.getMoveset(true).map(m => this.scene.unshiftPhase(new LearnMovePhase(this.scene, newPartyMemberIndex, m.getMove().id, m.ppUp)));
           pokemon.destroy();
           this.updateFusionPalette();
           resolve();
@@ -3769,7 +3769,7 @@ export class PokemonMove {
   }
 
   getMovePp(): integer {
-    return this.getMove().pp + this.ppUp * Math.max(Math.floor(this.getMove().pp / 5), 1);
+    return PokemonMove.getMovePp(this.getMove(), this.ppUp);
   }
 
   getPpRatio(): number {
@@ -3778,6 +3778,10 @@ export class PokemonMove {
 
   getName(): string {
     return this.getMove().name;
+  }
+
+  static getMovePp(move: Move, ppUp?: integer): integer {
+    return move.pp + (ppUp ?? 0) * Math.max(Math.floor(move.pp / 5), 1)
   }
 
   /**

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3781,7 +3781,7 @@ export class PokemonMove {
   }
 
   static getMovePp(move: Move, ppUp?: integer): integer {
-    return move.pp + (ppUp ?? 0) * Math.max(Math.floor(move.pp / 5), 1)
+    return move.pp + (ppUp ?? 0) * Math.max(Math.floor(move.pp / 5), 1);
   }
 
   /**

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -92,6 +92,7 @@ export default class SummaryUiHandler extends UiHandler {
 
   private pokemon: PlayerPokemon;
   private newMove: Move;
+  private newMovePpOverride: integer;
   private moveSelectFunction: Function;
   private transitioning: boolean;
   private statusVisible: boolean;
@@ -370,6 +371,9 @@ export default class SummaryUiHandler extends UiHandler {
     case SummaryUiMode.LEARN_MOVE:
       this.newMove = args[2] as Move;
       this.moveSelectFunction = args[3] as Function;
+      if (args.length > 4) {
+        this.newMovePpOverride = args[4];
+      }
 
       this.showMoveEffect(true);
       this.setCursor(Page.MOVES);
@@ -905,8 +909,9 @@ export default class SummaryUiHandler extends UiHandler {
         ppOverlay.setOrigin(0, 1);
         this.extraMoveRowContainer.add(ppOverlay);
 
-        const pp = Utils.padInt(this.newMove.pp, 2, "  ");
-        const ppText = addTextObject(this.scene, 173, 1, `${pp}/${pp}`, TextStyle.WINDOW);
+        const ppNum = this.newMovePpOverride ?? this.newMove.pp;
+        const ppPadded = Utils.padInt(ppNum, 2, "  ");
+        const ppText = addTextObject(this.scene, 173, 1, `${ppPadded}/${ppPadded}`, TextStyle.WINDOW);
         ppText.setOrigin(0, 1);
         this.extraMoveRowContainer.add(ppText);
       }
@@ -1067,6 +1072,7 @@ export default class SummaryUiHandler extends UiHandler {
     this.pokemon = null;
     this.cursor = -1;
     this.newMove = null;
+    this.newMovePpOverride = null;
     if (this.moveSelect) {
       this.moveSelect = false;
       this.moveSelectFunction = null;


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Move PP is now preserved when learning any moves that come from fusion. This is reflected on the move summary UI. Additionally, for the edge case when both members of the fusion have the same move known, the higher PP is used.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Issue: https://github.com/pagefaultgames/pokerogue/issues/1284
I thought this issue was a good idea -- fusion order and what is retained is already confusing, I think it's best to limit that confusion where possible. It's also just nice for the player not to lose PP for "no reason".

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Added a PPUp override value that can be passed through into `LearnMovePhase` as well as `Pokemon.setMove()` that allows for moves to begin with non-zero values for `ppUp`. Provided this override value to the fusion move learning phase in `pokemon.ts`. I also moved PP calculation into a static method so PP could be calculated with PP Ups taken into account when a move hasn't been learned yet.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

https://github.com/pagefaultgames/pokerogue/assets/9343160/d20ccfcb-bfca-4654-abf0-a7d259a8fba6

Note: to clarify the video above, Sand Attack has had a PP Max used on it, and that carries over during fusion.


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Increase the drop rate of PP Up, PP Max, and DNA Splicer. Try different combinations -- there's a particular edge case when both know the same move with different PP.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?