### PR TITLE
[Feature] Add possibility to override foe level

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -670,11 +670,10 @@ export default class BattleScene extends SceneBase {
       species = getPokemonSpecies(Overrides.OPP_SPECIES_OVERRIDE);
     }
     const pokemon = new EnemyPokemon(this, species, level, trainerSlot, boss, dataSource);
-    
     if (Overrides.OPP_LEVEL_OVERRIDE !== null) {
       pokemon.level = Overrides.OPP_LEVEL_OVERRIDE;
     }
-    
+
     if (Overrides.OPP_GENDER_OVERRIDE !== null) {
       pokemon.gender = Overrides.OPP_GENDER_OVERRIDE;
     }

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -670,7 +670,7 @@ export default class BattleScene extends SceneBase {
       species = getPokemonSpecies(Overrides.OPP_SPECIES_OVERRIDE);
     }
     const pokemon = new EnemyPokemon(this, species, level, trainerSlot, boss, dataSource);
-    if (Overrides.OPP_LEVEL_OVERRIDE !== null) {
+    if (Overrides.OPP_LEVEL_OVERRIDE !== 0) {
       pokemon.level = Overrides.OPP_LEVEL_OVERRIDE;
     }
 

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -670,6 +670,11 @@ export default class BattleScene extends SceneBase {
       species = getPokemonSpecies(Overrides.OPP_SPECIES_OVERRIDE);
     }
     const pokemon = new EnemyPokemon(this, species, level, trainerSlot, boss, dataSource);
+    
+    if (Overrides.OPP_LEVEL_OVERRIDE !== null) {
+      pokemon.level = Overrides.OPP_LEVEL_OVERRIDE;
+    }
+    
     if (Overrides.OPP_GENDER_OVERRIDE !== null) {
       pokemon.gender = Overrides.OPP_GENDER_OVERRIDE;
     }

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -79,6 +79,7 @@ export const OPP_GENDER_OVERRIDE: Gender = null;
 export const OPP_MOVESET_OVERRIDE: Array<Moves> = [];
 export const OPP_SHINY_OVERRIDE: boolean = false;
 export const OPP_VARIANT_OVERRIDE: Variant = 0;
+export const OPP_LEVEL_OVERRIDE: number | null = null;
 
 /**
  * MODIFIER / ITEM OVERRIDES

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -79,7 +79,7 @@ export const OPP_GENDER_OVERRIDE: Gender = null;
 export const OPP_MOVESET_OVERRIDE: Array<Moves> = [];
 export const OPP_SHINY_OVERRIDE: boolean = false;
 export const OPP_VARIANT_OVERRIDE: Variant = 0;
-export const OPP_LEVEL_OVERRIDE: number | null = null;
+export const OPP_LEVEL_OVERRIDE: number = 0;
 
 /**
  * MODIFIER / ITEM OVERRIDES

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -73,13 +73,13 @@ export const VARIANT_OVERRIDE: Variant = 0;
  */
 
 export const OPP_SPECIES_OVERRIDE: Species | integer = 0;
+export const OPP_LEVEL_OVERRIDE: number = 0;
 export const OPP_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
 export const OPP_PASSIVE_ABILITY_OVERRIDE = Abilities.NONE;
 export const OPP_GENDER_OVERRIDE: Gender = null;
 export const OPP_MOVESET_OVERRIDE: Array<Moves> = [];
 export const OPP_SHINY_OVERRIDE: boolean = false;
 export const OPP_VARIANT_OVERRIDE: Variant = 0;
-export const OPP_LEVEL_OVERRIDE: number = 0;
 
 /**
  * MODIFIER / ITEM OVERRIDES


### PR DESCRIPTION
## What are the changes?
Add more flexibility in pokemon overrides

## Why am I doing these changes?
Adding possibility to override foe level to have more flexibility in testing different things

## What did change?
Added new option in Overrides to hardcoded foe level

### Screenshots/Videos
<img width="1033" alt="Screenshot 2024-05-29 at 15 41 38" src="https://github.com/pagefaultgames/pokerogue/assets/19636010/73d922fb-57c1-4ab8-ae55-da5e91bbd073">

High wave, low levels
<img width="1670" alt="Screenshot 2024-05-29 at 18 27 31" src="https://github.com/pagefaultgames/pokerogue/assets/19636010/cf18ca30-464f-49fb-9ef5-139c109e8680">


## How to test the changes?
You can just set number for variable OPP_LEVEL_OVERRIDE
`export const OPP_LEVEL_OVERRIDE: number | null = 100;`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?