### PR TITLE
[Localization] Improve French Locales

### DIFF
--- a/src/egg-hatch-phase.ts
+++ b/src/egg-hatch-phase.ts
@@ -12,6 +12,7 @@ import { achvs } from "./system/achv";
 import { pokemonPrevolutions } from "./data/pokemon-evolutions";
 import { EggTier } from "./data/enums/egg-type";
 import PokemonInfoContainer from "./ui/pokemon-info-container";
+import i18next from "i18next";
 
 export class EggHatchPhase extends Phase {
   private egg: Egg;
@@ -292,7 +293,7 @@ export class EggHatchPhase extends Phase {
 
         this.scene.playSoundWithoutBgm("evolution_fanfare");
 
-        this.scene.ui.showText(`${this.pokemon.name} hatched from the egg!`, null, () => {
+        this.scene.ui.showText(i18next.t("egg:eggHatched", {pokemonName: this.pokemon.name}), null, () => {
           this.scene.gameData.updateSpeciesDexIvs(this.pokemon.species.speciesId, this.pokemon.ivs);
           this.scene.gameData.setPokemonCaught(this.pokemon, true, true).then(() => {
             this.scene.gameData.setEggMoveUnlocked(this.pokemon.species, this.eggMoveIndex).then(() => {

--- a/src/locales/de/config.ts
+++ b/src/locales/de/config.ts
@@ -10,6 +10,7 @@ import { menuUiHandler } from "./menu-ui-handler";
 import { modifierType } from "./modifier-type";
 import { move } from "./move";
 import { nature } from "./nature";
+import { phases } from "./phases";
 import { pokeball } from "./pokeball";
 import { pokemon } from "./pokemon";
 import { pokemonInfo } from "./pokemon-info";
@@ -46,6 +47,7 @@ export const deConfig = {
   modifierType: modifierType,
   move: move,
   nature: nature,
+  phases: phases,
   pokeball: pokeball,
   pokemon: pokemon,
   pokemonInfo: pokemonInfo,

--- a/src/locales/de/egg.ts
+++ b/src/locales/de/egg.ts
@@ -17,5 +17,6 @@ export const egg: SimpleTranslationEntries = {
   "notEnoughVouchers": "Du hast nicht genug Ei-Gutscheine!",
   "tooManyEggs": "Du hast schon zu viele Eier!",
   "pull": "Pull",
-  "pulls": "Pulls"
+  "pulls": "Pulls",
+  "eggHatched": "{{pokemonName}} hatched from the egg!"
 } as const;

--- a/src/locales/de/phases.ts
+++ b/src/locales/de/phases.ts
@@ -1,0 +1,15 @@
+import { SimpleTranslationEntries } from "#app/plugins/i18n";
+
+export const phases: SimpleTranslationEntries = {
+  "berryNervous": "{{pokemonName}} ist zu\nnervös um Beeren zu essen!",
+  "restoredHp": "Die KP von{{pokemonName}}\n wurden wiederhergestellt",
+  "moveDisabled": "{{moveName}} ist blockiert!",
+  "moveUsed": "{{pokemonName}} setzt\n{{moveName}} ein!",
+  "attackMissed": "Die Attacke von {{pokemonName}}\n hat verfehlt!",
+  "fainted": "{{pokemonName}} wurde besiegt!",
+  "rewards": "Du erhältst\n{{rewardsName}}!",
+  "gamemodeReward": "{{name}} beendete {{gamemodeName}}-Modus zum ersten Mal!\nDu erhältst {{rewardsName}}!",
+  "retry": "Willst du diesen Kampf wiederholen?",
+  "unlocked": "{{unlockableName}}\nwurde freigeschaltet.",
+  "fullHp": "Die KP von {{pokemonName}}\n sind voll!",
+} as const;

--- a/src/locales/de/pokemon-info.ts
+++ b/src/locales/de/pokemon-info.ts
@@ -38,4 +38,9 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "Fee",
     "STELLAR": "Stellar",
   },
+  Prefix: {
+    "Foe": "Foe ",
+    "Wild": "Wild ",
+    "Default": "",
+  },
 } as const;

--- a/src/locales/en/config.ts
+++ b/src/locales/en/config.ts
@@ -10,6 +10,7 @@ import { menuUiHandler } from "./menu-ui-handler";
 import { modifierType } from "./modifier-type";
 import { move } from "./move";
 import { nature } from "./nature";
+import { phases } from "./phases";
 import { pokeball } from "./pokeball";
 import { pokemon } from "./pokemon";
 import { pokemonInfo } from "./pokemon-info";
@@ -46,6 +47,7 @@ export const enConfig = {
   modifierType: modifierType,
   move: move,
   nature: nature,
+  phases: phases,
   pokeball: pokeball,
   pokemon: pokemon,
   pokemonInfo: pokemonInfo,

--- a/src/locales/en/egg.ts
+++ b/src/locales/en/egg.ts
@@ -17,5 +17,6 @@ export const egg: SimpleTranslationEntries = {
   "notEnoughVouchers": "You don't have enough vouchers!",
   "tooManyEggs": "You have too many eggs!",
   "pull": "Pull",
-  "pulls": "Pulls"
+  "pulls": "Pulls",
+  "eggHatched": "{{pokemonName}} hatched from the egg!"
 } as const;

--- a/src/locales/en/phases.ts
+++ b/src/locales/en/phases.ts
@@ -1,0 +1,15 @@
+import { SimpleTranslationEntries } from "#app/plugins/i18n";
+
+export const phases: SimpleTranslationEntries = {
+  "berryNervous": "{{pokemonName}} is too\nnervous to eat berries!",
+  "restoredHp": "{{pokemonName}}'s\nHP was restored.",
+  "moveDisabled": "{{moveName}} is disabled!",
+  "moveUsed": "{{pokemonName}} used\n{{moveName}}!",
+  "attackMissed": "{{pokemonName}}'s\nattack missed!",
+  "fainted": "{{pokemonName}} fainted!",
+  "rewards": "You received\n{{rewardsName}}!",
+  "gamemodeReward": "{{name}} beat {{gamemodeName}} Mode for the first time!\nYou received {{rewardsName}}!",
+  "retry": "Would you like to retry from the start of the battle?",
+  "unlocked": "{{unlockableName}}\nhas been unlocked.",
+  "fullHp": "{{pokemonName}}'s\nHP is full!",
+} as const;

--- a/src/locales/en/pokemon-info.ts
+++ b/src/locales/en/pokemon-info.ts
@@ -38,4 +38,9 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "Fairy",
     "STELLAR": "Stellar",
   },
+  Prefix: {
+    "Foe": "Foe ",
+    "Wild": "Wild ",
+    "Default": "",
+  },
 } as const;

--- a/src/locales/es/config.ts
+++ b/src/locales/es/config.ts
@@ -10,6 +10,7 @@ import { menuUiHandler } from "./menu-ui-handler";
 import { modifierType } from "./modifier-type";
 import { move } from "./move";
 import { nature } from "./nature";
+import { phases } from "./phases";
 import { pokeball } from "./pokeball";
 import { pokemon } from "./pokemon";
 import { pokemonInfo } from "./pokemon-info";
@@ -46,6 +47,7 @@ export const esConfig = {
   modifierType: modifierType,
   move: move,
   nature: nature,
+  phases: phases,
   pokeball: pokeball,
   pokemon: pokemon,
   pokemonInfo: pokemonInfo,

--- a/src/locales/es/egg.ts
+++ b/src/locales/es/egg.ts
@@ -17,5 +17,6 @@ export const egg: SimpleTranslationEntries = {
   "notEnoughVouchers": "You don't have enough vouchers!",
   "tooManyEggs": "You have too many eggs!",
   "pull": "Pull",
-  "pulls": "Pulls"
+  "pulls": "Pulls",
+  "eggHatched": "{{pokemonName}} hatched from the egg!"
 } as const;

--- a/src/locales/es/phases.ts
+++ b/src/locales/es/phases.ts
@@ -1,0 +1,15 @@
+import { SimpleTranslationEntries } from "#app/plugins/i18n";
+
+export const phases: SimpleTranslationEntries = {
+  "berryNervous": "{{pokemonName}} is too\nnervous to eat berries!",
+  "restoredHp": "{{pokemonName}}'s\nHP was restored.",
+  "moveDisabled": "{{moveName}} is disabled!",
+  "moveUsed": "{{pokemonName}} used\n{{moveName}}!",
+  "attackMissed": "{{pokemonName}}'s\nattack missed!",
+  "fainted": "{{pokemonName}} fainted!",
+  "rewards": "You received\n{{rewardsName}}!",
+  "gamemodeReward": "{{name}} beat {{gamemodeName}} Mode for the first time!\nYou received {{rewardsName}}!",
+  "retry": "Would you like to retry from the start of the battle?",
+  "unlocked": "{{unlockableName}}\nhas been unlocked.",
+  "fullHp": "{{pokemonName}}'s\nHP is full!",
+} as const;

--- a/src/locales/es/pokemon-info.ts
+++ b/src/locales/es/pokemon-info.ts
@@ -38,4 +38,9 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "Hada",
     "STELLAR": "Astral",
   },
+  Prefix: {
+    "Foe": "Foe ",
+    "Wild": "Wild ",
+    "Default": "",
+  },
 } as const;

--- a/src/locales/fr/config.ts
+++ b/src/locales/fr/config.ts
@@ -10,6 +10,7 @@ import { menuUiHandler } from "./menu-ui-handler";
 import { modifierType } from "./modifier-type";
 import { move } from "./move";
 import { nature } from "./nature";
+import { phases } from "./phases";
 import { pokeball } from "./pokeball";
 import { pokemon } from "./pokemon";
 import { pokemonInfo } from "./pokemon-info";
@@ -46,6 +47,7 @@ export const frConfig = {
   modifierType: modifierType,
   move: move,
   nature: nature,
+  phases: phases,
   pokeball: pokeball,
   pokemon: pokemon,
   pokemonInfo: pokemonInfo,

--- a/src/locales/fr/egg.ts
+++ b/src/locales/fr/egg.ts
@@ -17,5 +17,6 @@ export const egg: SimpleTranslationEntries = {
   "notEnoughVouchers": "Vous n’avez pas assez de coupons !",
   "tooManyEggs": "Vous avez trop d’Œufs !",
   "pull": "Tirage",
-  "pulls": "Tirages"
+  "pulls": "Tirages",
+  "eggHatched": "Un {{pokemonName}} vient de sortir de l’Œuf !"
 } as const;

--- a/src/locales/fr/phases.ts
+++ b/src/locales/fr/phases.ts
@@ -1,0 +1,15 @@
+import { SimpleTranslationEntries } from "#app/plugins/i18n";
+
+export const phases: SimpleTranslationEntries = {
+  "berryNervous": "{{pokemonName}} est trop\nnerveux pour manger des baies !",
+  "restoredHp": "Les PV de {{pokemonName}} ont été restaurés.",
+  "moveDisabled": "{{moveName}} est désactivé !",
+  "moveUsed": "{{pokemonName}} utilise\n{{moveName}} !",
+  "attackMissed": "L'attaque de {{pokemonName}}\na raté !",
+  "fainted": "{{pokemonName}} est K.O. !",
+  "rewards": "Vous avez reçu\n{{rewardsName}} !",
+  "gamemodeReward": "{{name}} a battu le mode {{gamemodeName}} pour la première fois !\nVous avez reçu {{rewardsName}} !",
+  "retry": "Voulez-vous recommencer depuis le début du combat ?",
+  "unlocked": "{{unlockableName}}\na été débloqué.",
+  "fullHp": "Les PV de {{pokemonName}} sont au maximum !",
+} as const;

--- a/src/locales/fr/pokemon-info.ts
+++ b/src/locales/fr/pokemon-info.ts
@@ -38,4 +38,9 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "Fée",
     "STELLAR": "Stellaire",
   },
+  Prefix: {
+    "Foe": "Adversaire ",
+    "Wild": "Sauvage ",
+    "Default": "",
+  },
 } as const;

--- a/src/locales/it/config.ts
+++ b/src/locales/it/config.ts
@@ -10,6 +10,7 @@ import { menuUiHandler } from "./menu-ui-handler";
 import { modifierType } from "./modifier-type";
 import { move } from "./move";
 import { nature } from "./nature";
+import { phases } from "./phases";
 import { pokeball } from "./pokeball";
 import { pokemon } from "./pokemon";
 import { pokemonInfo } from "./pokemon-info";
@@ -46,6 +47,7 @@ export const itConfig = {
   modifierType: modifierType,
   move: move,
   nature: nature,
+  phases: phases,
   pokeball: pokeball,
   pokemon: pokemon,
   pokemonInfo: pokemonInfo,

--- a/src/locales/it/egg.ts
+++ b/src/locales/it/egg.ts
@@ -17,5 +17,6 @@ export const egg: SimpleTranslationEntries = {
   "notEnoughVouchers": "Non hai abbastanza Biglietti!",
   "tooManyEggs": "Hai troppe Uova!",
   "pull": "Tiro",
-  "pulls": "Tiri"
+  "pulls": "Tiri",
+  "eggHatched": "{{pokemonName}} hatched from the egg!"
 } as const;

--- a/src/locales/it/phases.ts
+++ b/src/locales/it/phases.ts
@@ -1,0 +1,15 @@
+import { SimpleTranslationEntries } from "#app/plugins/i18n";
+
+export const phases: SimpleTranslationEntries = {
+  "berryNervous": "{{pokemonName}} is too\nnervous to eat berries!",
+  "restoredHp": "{{pokemonName}}'s\nHP was restored.",
+  "moveDisabled": "{{moveName}} is disabled!",
+  "moveUsed": "{{pokemonName}} used\n{{moveName}}!",
+  "attackMissed": "{{pokemonName}}'s\nattack missed!",
+  "fainted": "{{pokemonName}} fainted!",
+  "rewards": "You received\n{{rewardsName}}!",
+  "gamemodeReward": "{{name}} beat {{gamemodeName}} Mode for the first time!\nYou received {{rewardsName}}!",
+  "retry": "Would you like to retry from the start of the battle?",
+  "unlocked": "{{unlockableName}}\nhas been unlocked.",
+  "fullHp": "{{pokemonName}}'s\nHP is full!",
+} as const;

--- a/src/locales/it/pokemon-info.ts
+++ b/src/locales/it/pokemon-info.ts
@@ -38,4 +38,9 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "Folletto",
     "STELLAR": "Astrale",
   },
+  Prefix: {
+    "Foe": "Foe ",
+    "Wild": "Wild ",
+    "Default": "",
+  },
 } as const;

--- a/src/locales/pt_BR/config.ts
+++ b/src/locales/pt_BR/config.ts
@@ -10,6 +10,7 @@ import { menuUiHandler } from "./menu-ui-handler";
 import { modifierType } from "./modifier-type";
 import { move } from "./move";
 import { nature } from "./nature";
+import { phases } from "./phases";
 import { pokeball } from "./pokeball";
 import { pokemon } from "./pokemon";
 import { pokemonInfo } from "./pokemon-info";
@@ -46,6 +47,7 @@ export const ptBrConfig = {
   modifierType: modifierType,
   move: move,
   nature: nature,
+  phases: phases,
   pokeball: pokeball,
   pokemon: pokemon,
   pokemonInfo: pokemonInfo,

--- a/src/locales/pt_BR/egg.ts
+++ b/src/locales/pt_BR/egg.ts
@@ -17,5 +17,6 @@ export const egg: SimpleTranslationEntries = {
   "notEnoughVouchers": "Você não tem vouchers suficientes!",
   "tooManyEggs": "Você já tem muitos ovos!",
   "pull": "Prêmio",
-  "pulls": "Prêmios"
+  "pulls": "Prêmios",
+  "eggHatched": "{{pokemonName}} hatched from the egg!"
 } as const;

--- a/src/locales/pt_BR/phases.ts
+++ b/src/locales/pt_BR/phases.ts
@@ -1,0 +1,15 @@
+import { SimpleTranslationEntries } from "#app/plugins/i18n";
+
+export const phases: SimpleTranslationEntries = {
+  "berryNervous": "{{pokemonName}} is too\nnervous to eat berries!",
+  "restoredHp": "{{pokemonName}}'s\nHP was restored.",
+  "moveDisabled": "{{moveName}} is disabled!",
+  "moveUsed": "{{pokemonName}} used\n{{moveName}}!",
+  "attackMissed": "{{pokemonName}}'s\nattack missed!",
+  "fainted": "{{pokemonName}} fainted!",
+  "rewards": "You received\n{{rewardsName}}!",
+  "gamemodeReward": "{{name}} beat {{gamemodeName}} Mode for the first time!\nYou received {{rewardsName}}!",
+  "retry": "Would you like to retry from the start of the battle?",
+  "unlocked": "{{unlockableName}}\nhas been unlocked.",
+  "fullHp": "{{pokemonName}}'s\nHP is full!",
+} as const;

--- a/src/locales/pt_BR/pokemon-info.ts
+++ b/src/locales/pt_BR/pokemon-info.ts
@@ -38,4 +38,9 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "Fada",
     "STELLAR": "Estelar"
   },
+  Prefix: {
+    "Foe": "Foe ",
+    "Wild": "Wild ",
+    "Default": "",
+  },
 } as const;

--- a/src/locales/zh_CN/config.ts
+++ b/src/locales/zh_CN/config.ts
@@ -10,6 +10,7 @@ import { menuUiHandler } from "./menu-ui-handler";
 import { modifierType } from "./modifier-type";
 import { move } from "./move";
 import { nature } from "./nature";
+import { phases } from "./phases";
 import { pokeball } from "./pokeball";
 import { pokemon } from "./pokemon";
 import { pokemonInfo } from "./pokemon-info";
@@ -46,6 +47,7 @@ export const zhCnConfig = {
   modifierType: modifierType,
   move: move,
   nature: nature,
+  phases: phases,
   pokeball: pokeball,
   pokemon: pokemon,
   pokemonInfo: pokemonInfo,

--- a/src/locales/zh_CN/egg.ts
+++ b/src/locales/zh_CN/egg.ts
@@ -17,5 +17,6 @@ export const egg: SimpleTranslationEntries = {
   "notEnoughVouchers": "你没有足够的兑换券！",
   "tooManyEggs": "你的蛋太多啦！",
   "pull": "次",
-  "pulls": "次"
+  "pulls": "次",
+  "eggHatched": "{{pokemonName}} hatched from the egg!"
 } as const;

--- a/src/locales/zh_CN/phases.ts
+++ b/src/locales/zh_CN/phases.ts
@@ -1,0 +1,15 @@
+import { SimpleTranslationEntries } from "#app/plugins/i18n";
+
+export const phases: SimpleTranslationEntries = {
+  "berryNervous": "{{pokemonName}} is too\nnervous to eat berries!",
+  "restoredHp": "{{pokemonName}}'s\nHP was restored.",
+  "moveDisabled": "{{moveName}} is disabled!",
+  "moveUsed": "{{pokemonName}} used\n{{moveName}}!",
+  "attackMissed": "{{pokemonName}}'s\nattack missed!",
+  "fainted": "{{pokemonName}} fainted!",
+  "rewards": "You received\n{{rewardsName}}!",
+  "gamemodeReward": "{{name}} beat {{gamemodeName}} Mode for the first time!\nYou received {{rewardsName}}!",
+  "retry": "Would you like to retry from the start of the battle?",
+  "unlocked": "{{unlockableName}}\nhas been unlocked.",
+  "fullHp": "{{pokemonName}}'s\nHP is full!",
+} as const;

--- a/src/locales/zh_CN/pokemon-info.ts
+++ b/src/locales/zh_CN/pokemon-info.ts
@@ -38,4 +38,9 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "妖精",
     "STELLAR": "星晶",
   },
+  Prefix: {
+    "Foe": "Foe ",
+    "Wild": "Wild ",
+    "Default": "",
+  },
 } as const;

--- a/src/locales/zh_TW/config.ts
+++ b/src/locales/zh_TW/config.ts
@@ -10,6 +10,7 @@ import { menuUiHandler } from "./menu-ui-handler";
 import { modifierType } from "./modifier-type";
 import { move } from "./move";
 import { nature } from "./nature";
+import { phases } from "./phases";
 import { pokeball } from "./pokeball";
 import { pokemon } from "./pokemon";
 import { pokemonInfo } from "./pokemon-info";
@@ -45,6 +46,7 @@ export const zhTWConfig = {
   modifierType: modifierType,
   move: move,
   nature: nature,
+  phases: phases,
   pokeball: pokeball,
   pokemon: pokemon,
   pokemonInfo: pokemonInfo,

--- a/src/locales/zh_TW/egg.ts
+++ b/src/locales/zh_TW/egg.ts
@@ -17,5 +17,6 @@ export const egg: SimpleTranslationEntries = {
   "notEnoughVouchers": "你沒有足夠的兌換券！",
   "tooManyEggs": "你的蛋太多啦！",
   "pull": "抽",
-  "pulls": "抽"
+  "pulls": "抽",
+  "eggHatched": "{{pokemonName}} hatched from the egg!"
 } as const;

--- a/src/locales/zh_TW/phases.ts
+++ b/src/locales/zh_TW/phases.ts
@@ -1,0 +1,15 @@
+import { SimpleTranslationEntries } from "#app/plugins/i18n";
+
+export const phases: SimpleTranslationEntries = {
+  "berryNervous": "{{pokemonName}} is too\nnervous to eat berries!",
+  "restoredHp": "{{pokemonName}}'s\nHP was restored.",
+  "moveDisabled": "{{moveName}} is disabled!",
+  "moveUsed": "{{pokemonName}} used\n{{moveName}}!",
+  "attackMissed": "{{pokemonName}}'s\nattack missed!",
+  "fainted": "{{pokemonName}} fainted!",
+  "rewards": "You received\n{{rewardsName}}!",
+  "gamemodeReward": "{{name}} beat {{gamemodeName}} Mode for the first time!\nYou received {{rewardsName}}!",
+  "retry": "Would you like to retry from the start of the battle?",
+  "unlocked": "{{unlockableName}}\nhas been unlocked.",
+  "fullHp": "{{pokemonName}}'s\nHP is full!",
+} as const;

--- a/src/locales/zh_TW/pokemon-info.ts
+++ b/src/locales/zh_TW/pokemon-info.ts
@@ -38,4 +38,9 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "妖精",
     "STELLAR": "星晶"
   },
+  Prefix: {
+    "Foe": "Foe ",
+    "Wild": "Wild ",
+    "Default": "",
+  },
 } as const;

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,5 +1,6 @@
 import { BattleSpec } from "./enums/battle-spec";
 import Pokemon from "./field/pokemon";
+import i18next from "./plugins/i18n";
 
 export function getPokemonMessage(pokemon: Pokemon, content: string): string {
   return `${getPokemonPrefix(pokemon)}${pokemon.name}${content}`;
@@ -9,10 +10,10 @@ export function getPokemonPrefix(pokemon: Pokemon): string {
   let prefix: string;
   switch (pokemon.scene.currentBattle.battleSpec) {
   case BattleSpec.DEFAULT:
-    prefix = !pokemon.isPlayer() ? pokemon.hasTrainer() ? "Foe " : "Wild " : "";
+    prefix = !pokemon.isPlayer() ? pokemon.hasTrainer() ? i18next.t("pokemonInfo:Prefix.Foe") : i18next.t("pokemonInfo:Prefix.Wild") : i18next.t("pokemonInfo:Prefix.Default");
     break;
   case BattleSpec.FINAL_BOSS:
-    prefix = !pokemon.isPlayer() ? "Foe " : "";
+    prefix = !pokemon.isPlayer() ? i18next.t("pokemonInfo:Prefix.Foe") : i18next.t("pokemonInfo:Prefix.Default");
     break;
   }
   return prefix;

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2226,7 +2226,7 @@ export class BerryPhase extends FieldPhase {
         pokemon.getOpponents().map((opp) => applyAbAttrs(PreventBerryUseAbAttr, opp, cancelled));
 
         if (cancelled.value) {
-          pokemon.scene.queueMessage(getPokemonMessage(pokemon, " is too\nnervous to eat berries!"));
+          pokemon.scene.queueMessage(i18next.t("phases:berryNervous", { pokemonName: `${getPokemonPrefix(pokemon)}${pokemon.name}` }));
         } else {
           this.scene.unshiftPhase(
             new CommonAnimPhase(this.scene, pokemon.getBattlerIndex(), pokemon.getBattlerIndex(), CommonAnim.USE_ITEM)
@@ -2276,7 +2276,7 @@ export class TurnEndPhase extends FieldPhase {
 
       if (this.scene.arena.terrain?.terrainType === TerrainType.GRASSY && pokemon.isGrounded()) {
         this.scene.unshiftPhase(new PokemonHealPhase(this.scene, pokemon.getBattlerIndex(),
-          Math.max(pokemon.getMaxHp() >> 4, 1), getPokemonMessage(pokemon, "'s HP was restored."), true));
+          Math.max(pokemon.getMaxHp() >> 4, 1), i18next.t("phases:restoredHp", {pokemonName: `${getPokemonPrefix(pokemon)}${pokemon.name}` }), true));
       }
 
       if (!pokemon.isPlayer()) {
@@ -2428,7 +2428,7 @@ export class MovePhase extends BattlePhase {
 
     if (!this.canMove()) {
       if (this.move.moveId && this.pokemon.summonData?.disabledMove === this.move.moveId) {
-        this.scene.queueMessage(`${this.move.getName()} is disabled!`);
+        this.scene.queueMessage(i18next.t("phases:moveDisabled", { moveName: this.move.getName() }));
       }
       return this.end();
     }
@@ -2629,7 +2629,7 @@ export class MovePhase extends BattlePhase {
     if (this.move.getMove().getAttrs(ChargeAttr).length) {
       const lastMove = this.pokemon.getLastXMoves() as TurnMove[];
       if (!lastMove.length || lastMove[0].move !== this.move.getMove().id || lastMove[0].result !== MoveResult.OTHER) {
-        this.scene.queueMessage(getPokemonMessage(this.pokemon, ` used\n${this.move.getName()}!`), 500);
+        this.scene.queueMessage(i18next.t("phases:moveUsed", {pokemonName: getPokemonMessage(this.pokemon,""), moveName: this.move.getName()}), 500);
         return;
       }
     }
@@ -2638,7 +2638,7 @@ export class MovePhase extends BattlePhase {
       return;
     }
 
-    this.scene.queueMessage(getPokemonMessage(this.pokemon, ` used\n${this.move.getName()}!`), 500);
+    this.scene.queueMessage(i18next.t("phases:moveUsed", {pokemonName: getPokemonMessage(this.pokemon,""), moveName: this.move.getName()}), 500);
     applyMoveAttrs(PreMoveMessageAttr, this.pokemon, this.pokemon.getOpponents().find(() => true), this.move.getMove());
   }
 
@@ -3498,7 +3498,7 @@ export class FaintPhase extends PokemonPhase {
       this.scene.currentBattle.enemyFaints += 1;
     }
 
-    this.scene.queueMessage(getPokemonMessage(pokemon, " fainted!"), null, true);
+    this.scene.queueMessage(i18next.t("phases:fainted", { pokemonName: getPokemonMessage(pokemon,"") }), null, true);
 
     if (pokemon.turnData?.attacksReceived?.length) {
       const lastAttack = pokemon.turnData.attacksReceived[0];
@@ -3841,7 +3841,7 @@ export class ModifierRewardPhase extends BattlePhase {
       const newModifier = this.modifierType.newModifier();
       this.scene.addModifier(newModifier).then(() => {
         this.scene.playSound("item_fanfare");
-        this.scene.ui.showText(`You received\n${newModifier.type.name}!`, null, () => resolve(), null, true);
+        this.scene.ui.showText(i18next.t("phases:rewards", {rewardsName: newModifier.type.name}), null, () => resolve(), null, true);
       });
     });
   }
@@ -3859,7 +3859,7 @@ export class GameOverModifierRewardPhase extends ModifierRewardPhase {
         this.scene.playSound("level_up_fanfare");
         this.scene.ui.setMode(Mode.MESSAGE);
         this.scene.ui.fadeIn(250).then(() => {
-          this.scene.ui.showText(`You received\n${newModifier.type.name}!`, null, () => {
+          this.scene.ui.showText(i18next.t("phases:rewards", {rewardsName: newModifier.type.name}), null, () => {
             this.scene.time.delayedCall(1500, () => this.scene.arenaBg.setVisible(true));
             resolve();
           }, null, true, 1500);
@@ -3884,7 +3884,7 @@ export class RibbonModifierRewardPhase extends ModifierRewardPhase {
       this.scene.addModifier(newModifier).then(() => {
         this.scene.playSound("level_up_fanfare");
         this.scene.ui.setMode(Mode.MESSAGE);
-        this.scene.ui.showText(`${this.species.name} beat ${this.scene.gameMode.getName()} Mode for the first time!\nYou received ${newModifier.type.name}!`, null, () => {
+        this.scene.ui.showText(i18next.t("phases:gamemodeReward", { name: this.species.name, gamemodeName: this.scene.gameMode.getName(), rewardsName: newModifier.type.name}), null, () => {
           resolve();
         }, null, true, 1500);
       });
@@ -3915,7 +3915,7 @@ export class GameOverPhase extends BattlePhase {
     } else if (this.victory || !this.scene.enableRetries) {
       this.handleGameOver();
     } else {
-      this.scene.ui.showText("Would you like to retry from the start of the battle?", null, () => {
+      this.scene.ui.showText(i18next.t("phases:retry"), null, () => {
         this.scene.ui.setMode(Mode.CONFIRM, () => {
           this.scene.ui.fadeOut(1250).then(() => {
             this.scene.reset();
@@ -4103,7 +4103,7 @@ export class UnlockPhase extends Phase {
       this.scene.gameData.unlocks[this.unlockable] = true;
       this.scene.playSound("level_up_fanfare");
       this.scene.ui.setMode(Mode.MESSAGE);
-      this.scene.ui.showText(`${getUnlockableName(this.unlockable)}\nhas been unlocked.`, null, () => {
+      this.scene.ui.showText(i18next.t("phases:unlocked", { unlockableName: getUnlockableName(this.unlockable) }), null, () => {
         this.scene.time.delayedCall(1500, () => this.scene.arenaBg.setVisible(true));
         this.end();
       }, null, true, 1500);
@@ -4497,7 +4497,7 @@ export class PokemonHealPhase extends CommonAnimPhase {
       pokemon.resetStatus();
       pokemon.updateInfo().then(() => super.end());
     } else if (this.showFullHpMessage) {
-      this.message = getPokemonMessage(pokemon, "'s\nHP is full!");
+      this.message = i18next.t( "phases:fullHp", {pokemonName: getPokemonMessage(pokemon,"")});
     }
 
     if (this.message) {

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -49,6 +49,7 @@ export interface ModifierTypeTranslationEntries {
 export interface PokemonInfoTranslationEntries {
   Stat: SimpleTranslationEntries,
   Type: SimpleTranslationEntries,
+  Prefix: SimpleTranslationEntries,
 }
 
 export interface BerryTranslationEntry {

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -167,6 +167,7 @@ declare module "i18next" {
       starterSelectUiHandler: SimpleTranslationEntries;
       splashMessages: SimpleTranslationEntries;
       nature: SimpleTranslationEntries;
+      phases: SimpleTranslationEntries;
       growth: SimpleTranslationEntries;
       egg: SimpleTranslationEntries;
       weather: SimpleTranslationEntries;


### PR DESCRIPTION
## What are the changes?
This add French Locales for the different combat phases and egg hatch.
I also put the German translation that you gave me in my previous PR (battle phase only)

## Why am I doing these changes?
To have more of the game translated into French for French players.
I had already made a PR ( #1344 ) but it was closed due to my many errors.
I still continue to translate into French what remains to be translated in the rest of the game

## What did change?
I changed different texts in the battle phase (not all)

### Screenshots/Videos
![image](https://github.com/pagefaultgames/pokerogue/assets/101729154/101a31c9-cbeb-4a7b-88f0-8f0a4476dc27)
![image](https://github.com/pagefaultgames/pokerogue/assets/101729154/aae67f1e-52e4-4499-a0b9-e08bb8a4fe8d)
![image](https://github.com/pagefaultgames/pokerogue/assets/101729154/f83e3998-7351-4e5f-930d-4b3487478cd6)

## How to test the changes?
You just have to set the French language

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?