### PR TITLE
[Localization] German translations added for 'thunderclap', 'wicked/blazing/noxious/combat/magical torque' and fixed a typo

### DIFF
--- a/src/locales/de/move.ts
+++ b/src/locales/de/move.ts
@@ -3715,23 +3715,23 @@ export const move: MoveTranslationEntries = {
   },
   "blazingTorque": {
     name: "Hitzeturbo",
-    effect: "The user revs their blazing engine into the target. This may also leave the target with a burn."
+    effect: "Der Anwender rammt seinen glühend heißen Motor in das Ziel. Dieses erleidet eventuell Verbrennungen."
   },
   "wickedTorque": {
     name: "Finsterturbo",
-    effect: "The user revs their engine into the target with malicious intent. This may put the target to sleep."
+    effect: "Der Anwender rammt seinen Motor mit böswilliger Absicht in das Ziel. Dieses schläft eventuell ein."
   },
   "noxiousTorque": {
     name: "Toxiturbo",
-    effect: "The user revs their poisonous engine into the target. This may also poison the target."
+    effect: "Der Anwender rammt seinen giftigen Motor in das Ziel. Dieses wird eventuell vergiftet."
   },
   "combatTorque": {
     name: "Raufturbo",
-    effect: "The user revs their engine forcefully into the target. This may also leave the target with paralysis."
+    effect: "Der Anwender rammt seinen Motor gewaltvoll in das Ziel. Dieses wird eventuell paralysiert."
   },
   "magicalTorque": {
     name: "Zauberturbo",
-    effect: "The user revs their fae-like engine into the target. This may also confuse the target."
+    effect: "Der Anwender rammt seinen feenartigen Motor in das Ziel. Dieses wird eventuell verwirrt."
   },
   "bloodMoon": {
     name: "Blutmond",
@@ -3767,7 +3767,7 @@ export const move: MoveTranslationEntries = {
   },
   "thunderclap": {
     name: "Sturmblitz",
-    effect: "This move enables the user to attack first with a jolt of electricity. This move fails if the target is not readying an attack."
+    effect: "Der Anwender trifft das Ziel mit einem schnellen Stromschlag. Erstschlaggarantie."
   },
   "mightyCleave": {
     name: "Wuchtklinge",

--- a/src/locales/de/splash-messages.ts
+++ b/src/locales/de/splash-messages.ts
@@ -26,7 +26,7 @@ export const splashMessages: SimpleTranslationEntries = {
   "basedOnAnUnfinishedFlashGame": "Basierend auf einem unfertigen Flash-Spiel!",
   "moreAddictiveThanIntended": "Süchtig machender als beabsichtigt!",
   "mostlyConsistentSeeds": "Meistens konsistente Seeds!",
-  "achievementPointsDontDoAnything": "Erungenschaftspunkte tun nichts!",
+  "achievementPointsDontDoAnything": "Errungenschaftspunkte tun nichts!",
   "youDoNotStartAtLevel": "Du startest nicht auf Level 2000!",
   "dontTalkAboutTheManaphyEggIncident": "Wir reden nicht über den Manaphy-Ei-Vorfall!",
   "alsoTryPokengine": "Versuche auch Pokéngine!",


### PR DESCRIPTION
## What are the changes?
- Added translations for the moves 'thunderclap', 'wicked/blazing/noxious/combat/magical torque'
- Fixed a typo in the splash message 'achievementPointsDontDoAnything'

## Why am I doing these changes?
Because the translations were missing.

## How to test the changes?
No real need for testing. But if you want to look at the move descriptions and splash message ingame
## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?