### PR TITLE
[QoL] Keyboard Shortcut to Toggle IVs during Starter Select 

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -3100,6 +3100,68 @@ export class MoneyAbAttr extends PostBattleAbAttr {
   }
 }
 
+/*
+Attribute for Abilities like Parental Bond
+*
+*@extends AbAttr
+*/
+export class PreHitAbAttr extends AbAttr {
+  apply(pokemon: Pokemon, passive: boolean, cancelled: Utils.BooleanHolder, args: any[]): boolean {
+    return false;
+  }
+}
+
+/**
+   * Checks if Pokemon has extra hits
+   *
+   * @extneds PreHitAbAttr
+   *
+   * @param extraHits : number of extra hits allowed for by the ability
+   * @param powerMultiplier : reduced power of the extra hit
+   * @returns if the ability provides an extra hit
+*/
+export class ExtraHitMoveAbAttr extends PreHitAbAttr {
+  private extraHits: integer;
+  private powerMultiplier: number;
+
+  constructor(extraHits: integer, powerMultiplier: number) {
+    super(true);
+    this.extraHits = extraHits;
+    this.powerMultiplier = powerMultiplier;
+  }
+
+  apply(pokemon: Pokemon, passive: boolean, cancelled: Utils.BooleanHolder, args: any[]): boolean {
+    const currentMove = pokemon.move.getMove();
+    const targets = pokemon.getOpponents().length;
+    const hits = (args[0] as number[]);
+    if (targets > 1) {
+      /*If a move could hit multiple targets (including allies), such as Earthquake and Rock Slide, it will not strike twice;
+      *however, if it can only hit a single Pokémon, such as in a Single Battle or if using a move that can hit multiple targets
+      *when only one target is in range, it will strike twice.
+      *If a move could hit multiple Pokémon but only hits one due to missing the other Pokémon, it will only strike once.*/
+      return false;
+    }
+    if (currentMove.MoveTarget === MoveTarget.USER) {
+      /*If Present heals the target it will only strike once,
+       *but if it damages the target it will strike twice (the second strike will always damage the target).*/
+      return false;
+    }
+    if (currentMove.FixedDamageAttr) {
+      /*Fixed-damage moves (such as Seismic Toss and Dragon Rage) deal the full amount of damage for both strikes.*/
+      this.powerMultiplier = 1;
+    }
+
+    if (this.extraHits > 0) {
+      for (let i = 0; i < this.extraHits; i++) {
+        hits.push(this.powerMultiplier);
+      }
+      return true;
+    }
+    return false;
+  }
+}
+
+
 function applyAbAttrsInternal<TAttr extends AbAttr>(attrType: { new(...args: any[]): TAttr },
   pokemon: Pokemon, applyFunc: AbAttrApplyFunc<TAttr>, args: any[], isAsync: boolean = false, showAbilityInstant: boolean = false, quiet: boolean = false, passive: boolean = false): Promise<void> {
   return new Promise(resolve => {
@@ -3851,7 +3913,7 @@ export function initAbilities() {
     new Ability(Abilities.AERILATE, 6)
       .attr(MoveTypeChangePowerMultiplierAbAttr, Type.NORMAL, Type.FLYING, 1.2),
     new Ability(Abilities.PARENTAL_BOND, 6)
-      .unimplemented(),
+      .attr(ExtraHitMoveAbAttr, 1, 0.25),
     new Ability(Abilities.DARK_AURA, 6)
       .attr(PostSummonMessageAbAttr, (pokemon: Pokemon) => getPokemonMessage(pokemon, " is radiating a Dark Aura!"))
       .attr(FieldMoveTypePowerBoostAbAttr, Type.DARK, 4 / 3),

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -3100,68 +3100,6 @@ export class MoneyAbAttr extends PostBattleAbAttr {
   }
 }
 
-/*
-Attribute for Abilities like Parental Bond
-*
-*@extends AbAttr
-*/
-export class PreHitAbAttr extends AbAttr {
-  apply(pokemon: Pokemon, passive: boolean, cancelled: Utils.BooleanHolder, args: any[]): boolean {
-    return false;
-  }
-}
-
-/**
-   * Checks if Pokemon has extra hits
-   *
-   * @extneds PreHitAbAttr
-   *
-   * @param extraHits : number of extra hits allowed for by the ability
-   * @param powerMultiplier : reduced power of the extra hit
-   * @returns if the ability provides an extra hit
-*/
-export class ExtraHitMoveAbAttr extends PreHitAbAttr {
-  private extraHits: integer;
-  private powerMultiplier: number;
-
-  constructor(extraHits: integer, powerMultiplier: number) {
-    super(true);
-    this.extraHits = extraHits;
-    this.powerMultiplier = powerMultiplier;
-  }
-
-  apply(pokemon: Pokemon, passive: boolean, cancelled: Utils.BooleanHolder, args: any[]): boolean {
-    const currentMove = pokemon.move.getMove();
-    const targets = pokemon.getOpponents().length;
-    const hits = (args[0] as number[]);
-    if (targets > 1) {
-      /*If a move could hit multiple targets (including allies), such as Earthquake and Rock Slide, it will not strike twice;
-      *however, if it can only hit a single Pokémon, such as in a Single Battle or if using a move that can hit multiple targets
-      *when only one target is in range, it will strike twice.
-      *If a move could hit multiple Pokémon but only hits one due to missing the other Pokémon, it will only strike once.*/
-      return false;
-    }
-    if (currentMove.MoveTarget === MoveTarget.USER) {
-      /*If Present heals the target it will only strike once,
-       *but if it damages the target it will strike twice (the second strike will always damage the target).*/
-      return false;
-    }
-    if (currentMove.FixedDamageAttr) {
-      /*Fixed-damage moves (such as Seismic Toss and Dragon Rage) deal the full amount of damage for both strikes.*/
-      this.powerMultiplier = 1;
-    }
-
-    if (this.extraHits > 0) {
-      for (let i = 0; i < this.extraHits; i++) {
-        hits.push(this.powerMultiplier);
-      }
-      return true;
-    }
-    return false;
-  }
-}
-
-
 function applyAbAttrsInternal<TAttr extends AbAttr>(attrType: { new(...args: any[]): TAttr },
   pokemon: Pokemon, applyFunc: AbAttrApplyFunc<TAttr>, args: any[], isAsync: boolean = false, showAbilityInstant: boolean = false, quiet: boolean = false, passive: boolean = false): Promise<void> {
   return new Promise(resolve => {
@@ -3913,7 +3851,7 @@ export function initAbilities() {
     new Ability(Abilities.AERILATE, 6)
       .attr(MoveTypeChangePowerMultiplierAbAttr, Type.NORMAL, Type.FLYING, 1.2),
     new Ability(Abilities.PARENTAL_BOND, 6)
-      .attr(ExtraHitMoveAbAttr, 1, 0.25),
+      .unimplemented(),
     new Ability(Abilities.DARK_AURA, 6)
       .attr(PostSummonMessageAbAttr, (pokemon: Pokemon) => getPokemonMessage(pokemon, " is radiating a Dark Aura!"))
       .attr(FieldMoveTypePowerBoostAbAttr, Type.DARK, 4 / 3),

--- a/src/locales/en/starter-select-ui-handler.ts
+++ b/src/locales/en/starter-select-ui-handler.ts
@@ -30,6 +30,7 @@ export const starterSelectUiHandler: SimpleTranslationEntries = {
   "selectMoveSwapWith": "Select a move to swap with",
   "unlockPassive": "Unlock Passive",
   "reduceCost": "Reduce Cost",
+  "shortcutIVs": "Shift: Toggle IVs",
   "cycleShiny": "R: Cycle Shiny",
   "cycleForm": "F: Cycle Form",
   "cycleGender": "G: Cycle Gender",

--- a/src/ui-inputs.ts
+++ b/src/ui-inputs.ts
@@ -94,7 +94,9 @@ export class UiInputs {
   }
 
   buttonStats(pressed: boolean = true): void {
-    if (pressed) {
+    if (pressed && this.scene.ui?.getMode()===Mode.STARTER_SELECT) {
+      this.scene.ui.processInput(Button.STATS);
+    } else if (pressed) {
       for (const p of this.scene.getField().filter(p => p?.isActive(true))) {
         p.toggleStats(true);
       }

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -963,6 +963,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         success = true;
         break;
       }
+      this.toggleStatsMode(false);
     } else if (this.genMode) {
       switch (button) {
       case Button.UP:
@@ -986,6 +987,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       case Button.RIGHT:
         success = this.setGenMode(false);
         break;
+        this.toggleStatsMode(false);
       }
     } else {
       if (button === Button.ACTION) {
@@ -1245,6 +1247,13 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         const row = Math.floor(this.cursor / 9);
         const props = this.scene.gameData.getSpeciesDexAttrProps(this.lastSpecies, this.dexAttrCursor);
         switch (button) {
+        case Button.STATS:
+          if (!this.statsMode) {
+            this.toggleStatsMode(true);
+          } else {
+            this.toggleStatsMode(false);
+          }
+          break;
         case Button.CYCLE_SHINY:
           if (this.canCycleShiny) {
             this.setSpeciesDetails(this.lastSpecies, !props.shiny, undefined, undefined, props.shiny ? 0 : undefined, undefined, undefined);
@@ -1336,11 +1345,13 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
           if (row) {
             success = this.setCursor(this.cursor - 9);
           }
+          this.toggleStatsMode(false);
           break;
         case Button.DOWN:
           if (row < rows - 2 || (row < rows - 1 && this.cursor % 9 <= (genStarters - 1) % 9)) {
             success = this.setCursor(this.cursor + 9);
           }
+          this.toggleStatsMode(false);
           break;
         case Button.LEFT:
           if (this.cursor % 9) {
@@ -1351,6 +1362,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
             }
             success = this.setGenMode(true);
           }
+          this.toggleStatsMode(false);
           break;
         case Button.RIGHT:
           if (this.cursor % 9 < (row < rows - 1 ? 8 : (genStarters - 1) % 9)) {
@@ -1361,6 +1373,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
             }
             success = this.setGenMode(true);
           }
+          this.toggleStatsMode(false);
           break;
         }
       }
@@ -1431,6 +1444,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       if (this.canCycleVariant) {
         cycleInstructionLines.push(i18next.t("starterSelectUiHandler:cycleVariant"));
       }
+      cycleInstructionLines.push(i18next.t("starterSelectUiHandler:shortcutIVs"));
     }
 
     if (cycleInstructionLines.length > 2) {


### PR DESCRIPTION
## What are the changes?
The user can now use the Shift or C key to view a starter's IV without having to do so through the starter's menu options. The IV view automatically turns off after the cursor moves to a new Pokemon/generation/etc. 

## Why am I doing these changes?
Right now, players have to go to a starter's menu options and toggle a specific option to see their starter's IVs. Oftentimes, the IV view blocks the starter's moves and other details so the player has to go to the menu options again to turn off the IVs. I feel like this is a minor drag on the player's experience. By adding a shortcut to view a starter's IVs, players can enjoy the game experience more. In addition, because IVs are more accessible with this shortcut, limited space in the UI can be allocated for other things.

## What did change?
modified:   src/locales/en/starter-select-ui-handler.ts
modified:   src/ui-inputs.ts
modified:   src/ui/starter-select-ui-handler.ts

src/locales/en/starter-select-ui-handler.ts was modified to include the English text for the option. 
src/ui-inputs.ts and src/ui/starter-select-ui-handler.ts was modified to allow functionality with Buttons.STATS on Mode.Starter_Select

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
I believe you can just run the application and test it as is. It does not have multi-language support though. 

## Checklist
- [ x] There is no overlap with another PR?
- [ x] The PR is self-contained and cannot be split into smaller PRs?
- [ x] Have I provided a clear explanation of the changes?
- [ x] Have I tested the changes (manually)?
    - [ x] Are all unit tests still passing? (`npm run test`)
- [ x] Are the changes visual?
  - [ x] Have I provided screenshots/videos of the changes?

Video Attached on Discord: https://discord.com/channels/1125469663833370665/1176874654015684739/1245614853876486185 
Apologies, video is too big for Github. 