### PR TITLE
[Localization] updated german translation for thunderclap

### DIFF
--- a/src/locales/de/move.ts
+++ b/src/locales/de/move.ts
@@ -3767,7 +3767,7 @@ export const move: MoveTranslationEntries = {
   },
   "thunderclap": {
     name: "Sturmblitz",
-    effect: "Der Anwender trifft das Ziel mit einem schnellen Stromschlag. Erstschlaggarantie."
+    effect: "Diese Attacke ermöglicht es dem Anwender, zuerst mit einem Stromstoß anzugreifen. Die Attacke schlägt fehl, wenn das Ziel keinen Angriff vorbereitet."
   },
   "mightyCleave": {
     name: "Wuchtklinge",

--- a/src/locales/de/move.ts
+++ b/src/locales/de/move.ts
@@ -3767,7 +3767,7 @@ export const move: MoveTranslationEntries = {
   },
   "thunderclap": {
     name: "Sturmblitz",
-    effect: "Diese Attacke ermöglicht es dem Anwender, zuerst mit einem Stromstoß anzugreifen. Die Attacke schlägt fehl, wenn das Ziel keinen Angriff vorbereitet."
+    effect: "Der Anwender trifft das Ziel mit einem schnellen Stromschlag mit Erstschlaggarantie. Schlägt fehl, wenn der Gegner keine Attacke vorbereitet."
   },
   "mightyCleave": {
     name: "Wuchtklinge",

--- a/src/locales/de/move.ts
+++ b/src/locales/de/move.ts
@@ -3767,7 +3767,7 @@ export const move: MoveTranslationEntries = {
   },
   "thunderclap": {
     name: "Sturmblitz",
-    effect: "Der Anwender trifft das Ziel mit einem schnellen Stromschlag mit Erstschlaggarantie. Schlägt fehl, wenn der Gegner keine Attacke vorbereitet."
+    effect: "Der Angriff erlaubt es dem Nutzer zuerst mit einem Stromstoß anzugreifen. Sie schlägt fehl, wenn das Ziel keine Attacke vorbereitet."
   },
   "mightyCleave": {
     name: "Wuchtklinge",

--- a/src/locales/de/move.ts
+++ b/src/locales/de/move.ts
@@ -3767,7 +3767,7 @@ export const move: MoveTranslationEntries = {
   },
   "thunderclap": {
     name: "Sturmblitz",
-    effect: "Der Angriff erlaubt es dem Nutzer zuerst mit einem Stromstoß anzugreifen. Sie schlägt fehl, wenn das Ziel keine Attacke vorbereitet."
+    effect: "Bei dieser Erstschlag-Attacke lässt der Anwender einen Blitz auf das Ziel einschlagen. Sie gelingt nur, wenn dieses gerade eine Angriffsattacke vorbereitet."
   },
   "mightyCleave": {
     name: "Wuchtklinge",


### PR DESCRIPTION
Fixed thunderclap translation for a more literal translation and without leaving out the "attack misses" part.