### PR TITLE
[QoL] Better support for OLED screens in PWA application mode

### DIFF
--- a/index.css
+++ b/index.css
@@ -25,6 +25,12 @@ body {
   background: #484050;
 }
 
+@media (display-mode: fullscreen) {
+  body {
+    background: #000000;
+  }
+}
+
 #links {
   width: 90%;
   text-align: center;


### PR DESCRIPTION
## What are the changes?
Change background-color to black if display-mode is fullscreen, fullscreen which is the mode defined in `manifest.webmanifest`.

## Why am I doing these changes?
Small modification to ensure a totally black background for fullscreen display, allowing the application installed in PWA mode to benefit from all the advantages of an OLED screen when so equipped.

## What did change?
Adds CSS rule to `index.css`.
```css
@media (display-mode: fullscreen) {
  body {
    background: #000000;
  }
}
```

### Screenshots/Videos
> Before
![Screenshot_20240530_192214_Firefox](https://github.com/pagefaultgames/pokerogue/assets/8146474/df478a70-7247-4326-a7e6-e3a70d5b37a2)

> After
![Screenshot_20240530_192251_Firefox](https://github.com/pagefaultgames/pokerogue/assets/8146474/1c336dae-c026-486f-b7df-3683e311ea5f)

## How to test the changes?
It is possible to switch to “adaptive view” on the browser, then switch to fullscreen, the background should change from its normal color to black.
![better_pwa](https://github.com/pagefaultgames/pokerogue/assets/8146474/09bd0bd3-3a4b-4ab0-8bbf-2daf5a4d5cfe)

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?