### PR TITLE
Override to Provide Near-Infinite HP for Pokémon During Testing

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -733,8 +733,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       this.stats[s] = value;
     }
     if (Overrides.INFINITE_HP) {
-      this.stats[Stat.HP] = 1e250;
-      this.hp = 1e250;
+      this.stats[Stat.HP] = 1e+250;
+      this.hp = 1e+250;
     }
   }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -732,6 +732,10 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       }
       this.stats[s] = value;
     }
+    if (Overrides.INFINITE_HP) {
+      this.stats[Stat.HP] = 1e250;
+      this.hp = 1e250;
+    }
   }
 
   getNature(): Nature {

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -69,6 +69,7 @@ export const GENDER_OVERRIDE: Gender = null;
 export const MOVESET_OVERRIDE: Array<Moves> = [];
 export const SHINY_OVERRIDE: boolean = false;
 export const VARIANT_OVERRIDE: Variant = 0;
+export const INFINITE_HP: boolean = false;
 
 /**
  * OPPONENT / ENEMY OVERRIDES


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
I added an override that almost gives infinite HP to a Pokémon. This change allows for better control during my tests.

## Why am I doing these changes?
The purpose of this change is to enhance the testing process by providing more control over the Pokémon's HP during tests. This improvement comes from the need to have a stable and predictable environment for testing various scenarios without the interference of HP limitations.

## What did change?
The override added to the codebase modifies the HP values of a Pokémon, making it almost infinite. Before this change, Pokémon had their standard HP values which could lead to inconsistent test results. After the change, the Pokémon's HP is set to a very high value, ensuring consistent test conditions.

### Screenshots/Videos
the HP bar is stuck like that, no matter the opponent attacks.
![chrome_V2UAQqrMJI](https://github.com/pagefaultgames/pokerogue/assets/44787002/bed4fbe5-04a9-4db9-b3cd-f4ebcf77528f)


## How to test the changes?
1. Check out the branch with the override.
2. Run the application and verify that the Pokémon's HP behaves as expected.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
