### PR TITLE
[Ability] Added Partial and TODO to Compound Eyes and Super Luck

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -3500,7 +3500,8 @@ export function initAbilities() {
     new Ability(Abilities.CLOUD_NINE, 3)
       .attr(SuppressWeatherEffectAbAttr, true),
     new Ability(Abilities.COMPOUND_EYES, 3)
-      .attr(BattleStatMultiplierAbAttr, BattleStat.ACC, 1.3), // TODO: Generation III Item Implementation https://bulbapedia.bulbagarden.net/wiki/Compound_Eyes_(Ability)
+      .attr(BattleStatMultiplierAbAttr, BattleStat.ACC, 1.3)
+      .partial(), // TODO: Generation III Item Implementation https://bulbapedia.bulbagarden.net/wiki/Compound_Eyes_(Ability)
     new Ability(Abilities.INSOMNIA, 3)
       .attr(StatusEffectImmunityAbAttr, StatusEffect.SLEEP)
       .attr(BattlerTagImmunityAbAttr, BattlerTagType.DROWSY)
@@ -3775,7 +3776,8 @@ export function initAbilities() {
       .attr(PostSummonMessageAbAttr, (pokemon: Pokemon) => getPokemonMessage(pokemon, " breaks the mold!"))
       .attr(MoveAbilityBypassAbAttr),
     new Ability(Abilities.SUPER_LUCK, 4)
-      .attr(BonusCritAbAttr), // TODO: Generation VIII Item Implementation https://bulbapedia.bulbagarden.net/wiki/Super_Luck_(Ability)
+      .attr(BonusCritAbAttr)
+      .partial(), // TODO: Generation VIII Item Implementation https://bulbapedia.bulbagarden.net/wiki/Super_Luck_(Ability)
     new Ability(Abilities.AFTERMATH, 4)
       .attr(PostFaintContactDamageAbAttr,4)
       .bypassFaint(),

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -3500,7 +3500,7 @@ export function initAbilities() {
     new Ability(Abilities.CLOUD_NINE, 3)
       .attr(SuppressWeatherEffectAbAttr, true),
     new Ability(Abilities.COMPOUND_EYES, 3)
-      .attr(BattleStatMultiplierAbAttr, BattleStat.ACC, 1.3), // TODO - Generation III Item Implementation https://bulbapedia.bulbagarden.net/wiki/Compound_Eyes_(Ability)
+      .attr(BattleStatMultiplierAbAttr, BattleStat.ACC, 1.3), // TODO: Generation III Item Implementation https://bulbapedia.bulbagarden.net/wiki/Compound_Eyes_(Ability)
     new Ability(Abilities.INSOMNIA, 3)
       .attr(StatusEffectImmunityAbAttr, StatusEffect.SLEEP)
       .attr(BattlerTagImmunityAbAttr, BattlerTagType.DROWSY)
@@ -3775,7 +3775,7 @@ export function initAbilities() {
       .attr(PostSummonMessageAbAttr, (pokemon: Pokemon) => getPokemonMessage(pokemon, " breaks the mold!"))
       .attr(MoveAbilityBypassAbAttr),
     new Ability(Abilities.SUPER_LUCK, 4)
-      .attr(BonusCritAbAttr), // TODO - Generation VIII Item Implementation https://bulbapedia.bulbagarden.net/wiki/Super_Luck_(Ability)
+      .attr(BonusCritAbAttr), // TODO: Generation VIII Item Implementation https://bulbapedia.bulbagarden.net/wiki/Super_Luck_(Ability)
     new Ability(Abilities.AFTERMATH, 4)
       .attr(PostFaintContactDamageAbAttr,4)
       .bypassFaint(),

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -3500,7 +3500,7 @@ export function initAbilities() {
     new Ability(Abilities.CLOUD_NINE, 3)
       .attr(SuppressWeatherEffectAbAttr, true),
     new Ability(Abilities.COMPOUND_EYES, 3)
-      .attr(BattleStatMultiplierAbAttr, BattleStat.ACC, 1.3),
+      .attr(BattleStatMultiplierAbAttr, BattleStat.ACC, 1.3), // TODO - Generation III Item Implementation https://bulbapedia.bulbagarden.net/wiki/Compound_Eyes_(Ability)
     new Ability(Abilities.INSOMNIA, 3)
       .attr(StatusEffectImmunityAbAttr, StatusEffect.SLEEP)
       .attr(BattlerTagImmunityAbAttr, BattlerTagType.DROWSY)
@@ -3775,8 +3775,7 @@ export function initAbilities() {
       .attr(PostSummonMessageAbAttr, (pokemon: Pokemon) => getPokemonMessage(pokemon, " breaks the mold!"))
       .attr(MoveAbilityBypassAbAttr),
     new Ability(Abilities.SUPER_LUCK, 4)
-      .attr(BonusCritAbAttr)
-      .partial(),
+      .attr(BonusCritAbAttr), // TODO - Generation VIII Item Implementation https://bulbapedia.bulbagarden.net/wiki/Super_Luck_(Ability)
     new Ability(Abilities.AFTERMATH, 4)
       .attr(PostFaintContactDamageAbAttr,4)
       .bypassFaint(),


### PR DESCRIPTION
Just removed partial from Super Luck. It makes the ability look better, and the actual in battle ability does work as intended. Compound eyes is the exact same situation but does not have .partial(). 

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
  - (it just removes (P))