### PR TITLE
[Ability] Add and consume bonus luck attributes

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2010,6 +2010,16 @@ export class BonusCritAbAttr extends AbAttr {
   }
 }
 
+/** Attribute that adds luck when the pokemon with this ability is in the party */
+export class BonusLuckAbAttr extends AbAttr {
+  constructor(
+    /** By how much luck will increase */
+    public bonusLuck: number
+  ) {
+    super(false);
+  }
+}
+
 export class MultCritAbAttr extends AbAttr {
   public multAmount: number;
 
@@ -3566,7 +3576,8 @@ export function initAbilities() {
     new Ability(Abilities.CLOUD_NINE, 3)
       .attr(SuppressWeatherEffectAbAttr, true),
     new Ability(Abilities.COMPOUND_EYES, 3)
-      .attr(BattleStatMultiplierAbAttr, BattleStat.ACC, 1.3),
+      .attr(BattleStatMultiplierAbAttr, BattleStat.ACC, 1.3)
+      .attr(BonusLuckAbAttr, 1),
     new Ability(Abilities.INSOMNIA, 3)
       .attr(StatusEffectImmunityAbAttr, StatusEffect.SLEEP)
       .attr(BattlerTagImmunityAbAttr, BattlerTagType.DROWSY)
@@ -3843,7 +3854,7 @@ export function initAbilities() {
       .attr(MoveAbilityBypassAbAttr),
     new Ability(Abilities.SUPER_LUCK, 4)
       .attr(BonusCritAbAttr)
-      .partial(),
+      .attr(BonusLuckAbAttr, 1),
     new Ability(Abilities.AFTERMATH, 4)
       .attr(PostFaintContactDamageAbAttr,4)
       .bypassFaint(),

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2004,6 +2004,10 @@ export class BlockCritAbAttr extends AbAttr {
 }
 
 export class BonusCritAbAttr extends AbAttr {
+  constructor() {
+    super(false);
+  }
+
   apply(pokemon: Pokemon, passive: boolean, cancelled: Utils.BooleanHolder, args: any[]): boolean {
     (args[0] as Utils.BooleanHolder).value = true;
     return true;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -27,7 +27,7 @@ import { TempBattleStat } from "../data/temp-battle-stat";
 import { ArenaTagSide, WeakenMoveScreenTag, WeakenMoveTypeTag } from "../data/arena-tag";
 import { ArenaTagType } from "../data/enums/arena-tag-type";
 import { Biome } from "../data/enums/biome";
-import { Ability, AbAttr, BattleStatMultiplierAbAttr, BlockCritAbAttr, BonusCritAbAttr, BypassBurnDamageReductionAbAttr, FieldPriorityMoveImmunityAbAttr, FieldVariableMovePowerAbAttr, IgnoreOpponentStatChangesAbAttr, MoveImmunityAbAttr, MoveTypeChangeAttr, PreApplyBattlerTagAbAttr, PreDefendFullHpEndureAbAttr, ReceivedMoveDamageMultiplierAbAttr, ReduceStatusEffectDurationAbAttr, StabBoostAbAttr, StatusEffectImmunityAbAttr, TypeImmunityAbAttr, VariableMovePowerAbAttr, VariableMoveTypeAbAttr, WeightMultiplierAbAttr, allAbilities, applyAbAttrs, applyBattleStatMultiplierAbAttrs, applyPreApplyBattlerTagAbAttrs, applyPreAttackAbAttrs, applyPreDefendAbAttrs, applyPreSetStatusAbAttrs, UnsuppressableAbilityAbAttr, SuppressFieldAbilitiesAbAttr, NoFusionAbilityAbAttr, MultCritAbAttr, IgnoreTypeImmunityAbAttr, DamageBoostAbAttr, IgnoreTypeStatusEffectImmunityAbAttr, ConditionalCritAbAttr } from "../data/ability";
+import { Ability, AbAttr, BattleStatMultiplierAbAttr, BlockCritAbAttr, BonusCritAbAttr, BypassBurnDamageReductionAbAttr, FieldPriorityMoveImmunityAbAttr, FieldVariableMovePowerAbAttr, IgnoreOpponentStatChangesAbAttr, MoveImmunityAbAttr, MoveTypeChangeAttr, PreApplyBattlerTagAbAttr, PreDefendFullHpEndureAbAttr, ReceivedMoveDamageMultiplierAbAttr, ReduceStatusEffectDurationAbAttr, StabBoostAbAttr, StatusEffectImmunityAbAttr, TypeImmunityAbAttr, VariableMovePowerAbAttr, VariableMoveTypeAbAttr, WeightMultiplierAbAttr, allAbilities, applyAbAttrs, applyBattleStatMultiplierAbAttrs, applyPreApplyBattlerTagAbAttrs, applyPreAttackAbAttrs, applyPreDefendAbAttrs, applyPreSetStatusAbAttrs, UnsuppressableAbilityAbAttr, SuppressFieldAbilitiesAbAttr, NoFusionAbilityAbAttr, MultCritAbAttr, IgnoreTypeImmunityAbAttr, DamageBoostAbAttr, IgnoreTypeStatusEffectImmunityAbAttr, ConditionalCritAbAttr, BonusLuckAbAttr } from "../data/ability";
 import { Abilities } from "#app/data/enums/abilities";
 import PokemonData from "../system/pokemon-data";
 import { BattlerIndex } from "../battle";
@@ -801,7 +801,18 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   getLuck(): integer {
-    return this.luck + (this.isFusion() ? this.fusionLuck : 0);
+    let luck = this.luck + (this.isFusion() ? this.fusionLuck : 0);
+
+    if (!this.isFainted() && this.hasAbilityWithAttr(BonusLuckAbAttr)) {
+      this.getAbility()
+        .getAttrs(BonusLuckAbAttr)
+        .map(({ bonusLuck }: BonusLuckAbAttr) => (luck += bonusLuck));
+      this.getPassiveAbility()
+        .getAttrs(BonusLuckAbAttr)
+        .map(({ bonusLuck }: BonusLuckAbAttr) => (luck += bonusLuck));
+    }
+
+    return luck;
   }
 
   isFusion(): boolean {


### PR DESCRIPTION
## What are the changes?
Super Luck and Compound Eyes now give +1 Luck out of combat
This is loosely related to this PR #1624 

## Why am I doing these changes?
As discussed in [this thread](https://discord.com/channels/1125469663833370665/1245888749678755841) instead of doing something complicated to implement Super Luck's out of combat ability simply add +1 Luck when relevant

## What did change?
Add attribute to Super Luck and Compound Eyes. Consume attribute in `pokemon.getLuck()`

### Screenshots/Videos
https://github.com/pagefaultgames/pokerogue/assets/5421700/477e042e-6c70-415c-879d-3360c92a0288

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?