### PR TITLE
Queenly Majesty/Dazzling/Armor Tail Fix

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -501,7 +501,7 @@ export class FieldPriorityMoveImmunityAbAttr extends PreDefendAbAttr {
     applyMoveAttrs(IncrementMovePriorityAttr,attacker,null,move.getMove(),attackPriority);
     applyAbAttrs(IncrementMovePriorityAbAttr, attacker, null, move.getMove(), attackPriority);
 
-    if (move.getMove().moveTarget===MoveTarget.USER) {
+    if (move.getMove().moveTarget===MoveTarget.USER || move.getMove().moveTarget===MoveTarget.NEAR_ALLY) {
       return false;
     }
 


### PR DESCRIPTION
## What are the changes?
Fixes previously broken priority stopping abilities. Before they would stop moves that target your allies when they should not.

## Why am I doing these changes?
The previous implementation was broken. this simply fixes that.

### Screenshots/Videos

Broken Implementation
https://github.com/pagefaultgames/pokerogue/assets/114428473/a04c1e5d-028c-4443-b5b3-aa0899b12a03

Fixed Implementation
https://github.com/pagefaultgames/pokerogue/assets/114428473/d7e508b9-5af9-4d03-8ffb-0da32bd65008

## How to test the changes?
Just take a Pokemon with a priority move that targets your ally, such as helping hand, into a double battle

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?