### PR TITLE
[Bug] Fix status abilities not considering Comatose (fixes #1639)

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -3716,9 +3716,9 @@ export function initAbilities() {
       .conditionalAttr(pokemon => !Utils.randSeedInt(3), PostTurnResetStatusAbAttr),
     new Ability(Abilities.GUTS, 3)
       .attr(BypassBurnDamageReductionAbAttr)
-      .conditionalAttr(pokemon => !!pokemon.status, BattleStatMultiplierAbAttr, BattleStat.ATK, 1.5),
+      .conditionalAttr(pokemon => !!pokemon.status || pokemon.hasAbility(Abilities.COMATOSE), BattleStatMultiplierAbAttr, BattleStat.ATK, 1.5),
     new Ability(Abilities.MARVEL_SCALE, 3)
-      .conditionalAttr(pokemon => !!pokemon.status, BattleStatMultiplierAbAttr, BattleStat.DEF, 1.5)
+      .conditionalAttr(pokemon => !!pokemon.status || pokemon.hasAbility(Abilities.COMATOSE), BattleStatMultiplierAbAttr, BattleStat.DEF, 1.5)
       .ignorable(),
     new Ability(Abilities.LIQUID_OOZE, 3)
       .attr(ReverseDrainAbAttr),
@@ -3813,7 +3813,7 @@ export function initAbilities() {
       .condition(getWeatherCondition(WeatherType.SUNNY, WeatherType.HARSH_SUN)),
     new Ability(Abilities.QUICK_FEET, 4)
       .conditionalAttr(pokemon => pokemon.status ? pokemon.status.effect === StatusEffect.PARALYSIS : false, BattleStatMultiplierAbAttr, BattleStat.SPD, 2)
-      .conditionalAttr(pokemon => !!pokemon.status, BattleStatMultiplierAbAttr, BattleStat.SPD, 1.5),
+      .conditionalAttr(pokemon => !!pokemon.status || pokemon.hasAbility(Abilities.COMATOSE), BattleStatMultiplierAbAttr, BattleStat.SPD, 1.5),
     new Ability(Abilities.NORMALIZE, 4)
       .attr(MoveTypeChangeAttr, Type.NORMAL, 1.2, (user, target, move) => move.id !== Moves.HIDDEN_POWER && move.id !== Moves.WEATHER_BALL &&
             move.id !== Moves.NATURAL_GIFT && move.id !== Moves.JUDGMENT && move.id !== Moves.TECHNO_BLAST),


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
The abilities Guts, Marvel Scale and Quick Feet now properly boost the user's stats if it also has the ability Comatose.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
The issue https://github.com/pagefaultgames/pokerogue/issues/1639 showed that the interaction between Comatose and other status abilities wasn't working, probably due to the fact that it's not a thing present in main series games, as you can't have more than 1 ability there. The solution seemed pretty easy and straight forward, so I did it.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Simply added an extra condition for the 3 mentioned abilities, instead of checking if `!!pokemon.status` is true, it now checks if `!!pokemon.status` OR `pokemon.hasAbility(Abilities.COMATOSE)` are true. This is the same logic the ability already uses in the [code](https://github.com/pagefaultgames/pokerogue/commit/bfe018ef65aaeb4621661eb35930d9ae1ebc6c21), so it is consistent.

I don't believe a tag or custom status is needed for now, as Comatose is the only existing ability with such functionality. But if more abilities like this were introduced in the future, it would be an idea to consider then.

## Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
Tested it using Gastro Acid on the enemy, to cancel Guts mid battle and see the difference. Since Gastro Acid is currently coded to only remove main Ability (and not passive) I had to put Guts as ability and Comatose as passive.

Before: (Hit with Guts does 23, hit without Guts deals 22, showing no real difference)

https://github.com/pagefaultgames/pokerogue/assets/22176793/dc2973d4-617d-43a5-9506-922e01970849



After: (Hit with Guts does 33, hit without Guts deals 22, the 50% boost to Attack is working now!)

https://github.com/pagefaultgames/pokerogue/assets/22176793/6a1abb8e-26e1-4dc8-82ff-5a81d8886f26



## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
I simply used the overrides.ts file, gave the enemy a moveset of 4 Gastro Acid (to guarantee it doesn't use anything else) and I gave my pokemon the Guts ability and Comatose passive (the passive must be Comatose and not vice versa for us to see the difference with the Gastro Acid method). Of course, choose a tanky and slow enemy pokemon for easier testing, so that you can attack once before the ability is removed.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?