### PR TITLE
[Qol]? Disables all double battles but tate and Liza. And those two will now…

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -314,8 +314,8 @@ function getRandomTrainerFunc(trainerPool: (TrainerType | TrainerType[])[]): Get
         : trainerPoolEntry;
       trainerTypes.push(trainerType);
     }
-    // If the trainer type has a double variant, there's a 33% chance of it being a double battle
-    if (trainerConfigs[trainerTypes[rand]].trainerTypeDouble) {
+    // If the trainer type has a double variant, there's a 33% chance of it being a double battle (for now we only allow tate&liza to be double)
+    if (trainerConfigs[trainerTypes[rand]].trainerTypeDouble && (trainerTypes[rand] === TrainerType.TATE || trainerTypes[rand] === TrainerType.LIZA)) {
       return new Trainer(scene, trainerTypes[rand], Utils.randSeedInt(3) ? TrainerVariant.DOUBLE : TrainerVariant.DEFAULT);
     }
     return new Trainer(scene, trainerTypes[rand], TrainerVariant.DEFAULT);

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -20,6 +20,7 @@ import {trainerNamePools} from "../data/trainer-names";
 import {ArenaTagSide, ArenaTrapTag} from "#app/data/arena-tag";
 import {getIsInitialized, initI18n} from "#app/plugins/i18n";
 import i18next from "i18next";
+import {Species} from "#app/data/enums/species";
 
 export enum TrainerVariant {
     DEFAULT,
@@ -314,12 +315,25 @@ export default class Trainer extends Phaser.GameObjects.Container {
 
         // If the index is even, use the species pool for the main trainer (that way he only uses his own pokemon in battle)
         if (!(index % 2)) {
-          newSpeciesPool = speciesPoolFiltered;
+          // Since the only currently allowed double battle with named trainers is Tate & Liza, we need to make sure that Solrock is the first pokemon in the party for Tate and Lunatone for Liza
+          if (index === 0 && (TrainerType[this.config.trainerType] === TrainerType[TrainerType.TATE])) {
+            newSpeciesPool = [Species.SOLROCK];
+          } else if (index === 0 && (TrainerType[this.config.trainerType] === TrainerType[TrainerType.LIZA])) {
+            newSpeciesPool = [Species.LUNATONE];
+          } else {
+            newSpeciesPool = speciesPoolFiltered;
+          }
         } else {
           // If the index is odd, use the species pool for the partner trainer (that way he only uses his own pokemon in battle)
-          newSpeciesPool = speciesPoolPartnerFiltered;
+          // Since the only currently allowed double battle with named trainers is Tate & Liza, we need to make sure that Solrock is the first pokemon in the party for Tate and Lunatone for Liza
+          if (index === 1 && (TrainerType[this.config.trainerTypeDouble] === TrainerType[TrainerType.TATE])) {
+            newSpeciesPool = [Species.SOLROCK];
+          } else if (index === 1 && (TrainerType[this.config.trainerTypeDouble] === TrainerType[TrainerType.LIZA])) {
+            newSpeciesPool = [Species.LUNATONE];
+          } else {
+            newSpeciesPool = speciesPoolPartnerFiltered;
+          }
         }
-
         // Fallback for when the species pool is empty
         if (newSpeciesPool.length === 0) {
           // If all pokemon from this pool are already in the party, generate a random species


### PR DESCRIPTION
… always have lunatone and the other one (solrock?) as their first pokemon

<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
We discussed in contribuer chat about it. The double battles destroy the balance. We want to keep them for a possible future mode. 
Only tate&liza should have a chance to appear at a 1/3 chance. 

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Because we came to a conclusion to do so. And i was the person who introduced the double battle thing in the first place

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
The champs and piers/marnie can not longer appear in the double battles. 
And Tate&Liza now always have a solrock and lunatone as their first pokemon.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
https://github.com/pagefaultgames/pokerogue/assets/38758606/c1bd6479-cc4f-4b54-848c-3adf28604771

(Not quite sure how i would show the removal of the other double battles)

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Made Blue spawn as the champion (forced) for wave 190 several times. He didnt appear as a double even once.
Made Tate&Liza forced spawn as a double at wave 5 to see if the their first pokemon are always the ones we want

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?