### PR TITLE
[Bug] Fix Gracidea

### DIFF
--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -756,14 +756,23 @@ export class EvolutionItemModifierType extends PokemonModifierType implements Ge
   }
 }
 
+/**
+ * Class that represents form changing items
+ */
 export class FormChangeItemModifierType extends PokemonModifierType implements GeneratedPersistentModifierType {
   public formChangeItem: FormChangeItem;
 
   constructor(formChangeItem: FormChangeItem) {
     super("", FormChangeItem[formChangeItem].toLowerCase(), (_type, args) => new Modifiers.PokemonFormChangeItemModifier(this, (args[0] as PlayerPokemon).id, formChangeItem, true),
       (pokemon: PlayerPokemon) => {
-        if (pokemonFormChanges.hasOwnProperty(pokemon.species.speciesId) && !!pokemonFormChanges[pokemon.species.speciesId].find(fc => fc.trigger.hasTriggerType(SpeciesFormChangeItemTrigger)
-        && (fc.trigger as SpeciesFormChangeItemTrigger).item === this.formChangeItem)) {
+        // Make sure the Pokemon has alternate forms
+        if (pokemonFormChanges.hasOwnProperty(pokemon.species.speciesId)
+          // Get all form changes for this species with an item trigger, including any compound triggers
+          && pokemonFormChanges[pokemon.species.speciesId].filter(fc => fc.trigger.hasTriggerType(SpeciesFormChangeItemTrigger))
+          // Returns true if any form changes match this item
+            .map(fc => fc.findTrigger(SpeciesFormChangeItemTrigger) as SpeciesFormChangeItemTrigger)
+            .flat().flatMap(fc => fc.item).includes(this.formChangeItem)
+        ) {
           return null;
         }
 


### PR DESCRIPTION
## What are the changes?
Updated form change logic. Code lifted from https://github.com/pagefaultgames/pokerogue/pull/826 but added comments

> It uses similar logic to the shop when it chooses if an evolution item should spawn or not.
The shop checks if any current species in party has SpeciesFormEvolution with an evolution item requirement.
This fix checks if the Pokemon you are applying to has a SpeciesFormEvolution with an item or items and maps it to an Array, then checks if the applied item is in that array.
The old process was trying to do this shorthand, but for some reason on Shaymin it was not detecting an evolution item, so I just changed it to use a deeper check.

## Why am I doing these changes?
Fixes Gracidea bug on Shaymin

## What did change?
> This allows an item to be given to valid Species that can use the given item even if not immediately.

> Ex: Shaymin cannot be given Gracidea unless it is Daytime, this allows you to give it to Shaymin even at night, then when day time comes around Shaymin will change form

> Just like Rayquaza and a mega stone which currently works. You can give a mega stone even if they do not know Dragon Ascent. This fix should apply this same logic to all Pokemon that use Evolution items. (Currently Shaymin is the only known Pokemon that this does not work for, and is the only one with an Item & Time of day requirement)

### Screenshots/Videos
![](https://cdn.discordapp.com/attachments/1241164581997510656/1246150402915700838/image.png?ex=665b5780&is=665a0600&hm=f356fa1f5c755a3eef107342397f873d2fb465c1366b1d6544a6c40421995786&)
![](https://cdn.discordapp.com/attachments/1241164581997510656/1246150581895303178/image.png?ex=665b57ab&is=665a062b&hm=baaf0d4413817bd9a43bfa2da150555d6f023efffdabf55af41a17fb4a88576c&)

## How to test the changes?
Edited [this line](https://github.com/pagefaultgames/pokerogue/blob/main/src/modifier/modifier-type.ts#L1758) so only rogue items would drop and brought Shaymin as a starter

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?