### PR TITLE
[QoL] Neutralizing Gas no longer suppresses the source's abilities

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -978,7 +978,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     }
     if (this.isOnField() && !ability.hasAttr(SuppressFieldAbilitiesAbAttr)) {
       const suppressed = new Utils.BooleanHolder(false);
-      this.scene.getField(true).map(p => {
+      this.scene.getField(true).filter(p => p !== this).map(p => {
         if (p.getAbility().hasAttr(SuppressFieldAbilitiesAbAttr) && p.canApplyAbility()) {
           p.getAbility().getAttrs(SuppressFieldAbilitiesAbAttr).map(a => a.apply(this, false, suppressed, [ability]));
         }


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
A Pokemon with the ability Neutralizing Gas no longer suppresses their passive ability (and vice versa).

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
In its current implementation, Neutralizing Gas suppresses all abilities on the playfield, including the source Pokemon's passive ability (if it has one). However, based on the description for Neutralizing Gas in Gen IX, the source Pokemon's other abilities should not be suppressed.
![image](https://github.com/pagefaultgames/pokerogue/assets/168692175/77d40853-f593-4cb8-b7fe-754f3ae49ea2)

From a balance perspective, this allows Pokemon like Weezing to have a much larger pool of passive abilities to choose from without the fear of them being suppressed. It also facilitates Neutralizing Gas as a passive ability option for Pokemon with valuable primary Abilities that would otherwise be suppressed.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- `data/pokemon`: `Pokemon.canApplyAbility()` is changed so that when it checks the Pokemon on the playfield for suppression ability attributes, the check does not include `this`.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
Video Test:
- The player's Bulbasaur was given Neutralizing Gas with Intimidate as a passive via `src/overrides`
- All enemies were given Intimidate via `src/overrides`
- At the start of battle, Bulbasaur's Neutralizing Gas ability is shown, then Bulbasaur's Intimidate activates. The opposing Pidgey's Intimidate is suppressed by Neutralizing Gas and does not activate.

https://github.com/pagefaultgames/pokerogue/assets/168692175/7d24cb6e-9dc6-4c08-912d-fa841b587ebe

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
See the use of `src/overrides` in the test above. You can test with Neutralizing Gas as the passive ability instead, or switch Intimidate with any suppressable ability.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?