### PR TITLE
[Localization] Add localization for battle phase

### DIFF
--- a/src/locales/de/battle.ts
+++ b/src/locales/de/battle.ts
@@ -55,5 +55,9 @@ export const battle: SimpleTranslationEntries = {
   "skipItemQuestion": "Bist du sicher, dass du kein Item nehmen willst?",
   "notDisabled": "{{pokemonName}}'s {{moveName}} ist\nnicht mehr deaktiviert!",
   "eggHatching": "Oh?",
-  "ivScannerUseQuestion": "IV-Scanner auf {{pokemonName}} benutzen?"
+  "ivScannerUseQuestion": "IV-Scanner auf {{pokemonName}} benutzen?",
+  // "useMove": " used\n{{moveName}}!",
+  // "fainted": " fainted!",
+  // "foe": "Foe",
+  // "wild": "Wild",
 } as const;

--- a/src/locales/en/battle.ts
+++ b/src/locales/en/battle.ts
@@ -55,5 +55,9 @@ export const battle: SimpleTranslationEntries = {
   "notDisabled": "{{pokemonName}}'s {{moveName}} is disabled\nno more!",
   "skipItemQuestion": "Are you sure you want to skip taking an item?",
   "eggHatching": "Oh?",
-  "ivScannerUseQuestion": "Use IV Scanner on {{pokemonName}}?"
+  "ivScannerUseQuestion": "Use IV Scanner on {{pokemonName}}?",
+  "useMove": " used\n{{moveName}}!",
+  "fainted": " fainted!",
+  "foe": "Foe",
+  "wild": "Wild",
 } as const;

--- a/src/locales/es/battle.ts
+++ b/src/locales/es/battle.ts
@@ -55,5 +55,9 @@ export const battle: SimpleTranslationEntries = {
   "notDisabled": "¡El movimiento {{moveName}} de {{pokemonName}}\nya no está anulado!",
   "skipItemQuestion": "¿Estás seguro de que no quieres coger un objeto?",
   "eggHatching": "¿Y esto?",
-  "ivScannerUseQuestion": "¿Quieres usar el Escáner de IVs en {{pokemonName}}?"
+  "ivScannerUseQuestion": "¿Quieres usar el Escáner de IVs en {{pokemonName}}?",
+  // "useMove": " used\n{{moveName}}!",
+  // "fainted": " fainted!",
+  // "foe": "Foe",
+  // "wild": "Wild",
 } as const;

--- a/src/locales/fr/battle.ts
+++ b/src/locales/fr/battle.ts
@@ -55,5 +55,9 @@ export const battle: SimpleTranslationEntries = {
   "notDisabled": "La capacité {{moveName}}\nde {{pokemonName}} n’est plus sous entrave !",
   "skipItemQuestion": "Êtes-vous sûr·e de ne pas vouloir prendre d’objet ?",
   "eggHatching": "Oh ?",
-  "ivScannerUseQuestion": "Utiliser le Scanner d’IV sur {{pokemonName}} ?"
+  "ivScannerUseQuestion": "Utiliser le Scanner d’IV sur {{pokemonName}} ?",
+  // "useMove": " used\n{{moveName}}!",
+  // "fainted": " fainted!",
+  // "foe": "Foe",
+  // "wild": "Wild",
 } as const;

--- a/src/locales/it/battle.ts
+++ b/src/locales/it/battle.ts
@@ -55,5 +55,9 @@ export const battle: SimpleTranslationEntries = {
   "notDisabled": "{{pokemonName}}'s {{moveName}} non è più\ndisabilitata!",
   "skipItemQuestion": "Sei sicuro di non voler prendere nessun oggetto?",
   "eggHatching": "Oh!",
-  "ivScannerUseQuestion": "Vuoi usare lo scanner di IV su {{pokemonName}}?"
+  "ivScannerUseQuestion": "Vuoi usare lo scanner di IV su {{pokemonName}}?",
+  // "useMove": " used\n{{moveName}}!",
+  // "fainted": " fainted!",
+  // "foe": "Foe",
+  // "wild": "Wild",
 } as const;

--- a/src/locales/ko/battle.ts
+++ b/src/locales/ko/battle.ts
@@ -55,5 +55,9 @@ export const battle: SimpleTranslationEntries = {
   "notDisabled": "{{pokemonName}}의\n{{moveName}} 사슬묶기가 풀렸다!",
   "skipItemQuestion": "아이템을 받지 않고 넘어가시겠습니까?",
   "eggHatching": "어라…?",
-  "ivScannerUseQuestion": "{{pokemonName}}에게 개체값탐지기를 사용하시겠습니까?"
+  "ivScannerUseQuestion": "{{pokemonName}}에게 개체값탐지기를 사용하시겠습니까?",
+  "useMove": "의\n{{moveName}}!",
+  "fainted": "(은)는 쓰러졌다!",
+  "foe": "적",
+  "wild": "야생",
 } as const;

--- a/src/locales/pt_BR/battle.ts
+++ b/src/locales/pt_BR/battle.ts
@@ -55,5 +55,9 @@ export const battle: SimpleTranslationEntries = {
   "notDisabled": "O movimento {{moveName}}\nnão está mais desabilitado!",
   "skipItemQuestion": "Tem certeza de que não quer escolher um item?",
   "eggHatching": "Opa?",
-  "ivScannerUseQuestion": "Quer usar o Scanner de IVs em {{pokemonName}}?"
+  "ivScannerUseQuestion": "Quer usar o Scanner de IVs em {{pokemonName}}?",
+  // "useMove": " used\n{{moveName}}!",
+  // "fainted": " fainted!",
+  // "foe": "Foe",
+  // "wild": "Wild",
 } as const;

--- a/src/locales/zh_CN/battle.ts
+++ b/src/locales/zh_CN/battle.ts
@@ -55,5 +55,9 @@ export const battle: SimpleTranslationEntries = {
   "notDisabled": "{{moveName}} 不再被禁用！",
   "skipItemQuestion": "你确定要跳过拾取道具吗？",
   "eggHatching": "咦？",
-  "ivScannerUseQuestion": "对 {{pokemonName}} 使用个体值扫描仪？"
+  "ivScannerUseQuestion": "对 {{pokemonName}} 使用个体值扫描仪？",
+  // "useMove": " used\n{{moveName}}!",
+  // "fainted": " fainted!",
+  // "foe": "Foe",
+  // "wild": "Wild",
 } as const;

--- a/src/locales/zh_TW/battle.ts
+++ b/src/locales/zh_TW/battle.ts
@@ -52,5 +52,9 @@ export const battle: SimpleTranslationEntries = {
   "notDisabled": "{{moveName}} 不再被禁用!",
   "skipItemQuestion": "你要跳過拾取道具嗎?",
   "eggHatching": "咦?",
-  "ivScannerUseQuestion": "對 {{pokemonName}} 使用個體值掃描?"
+  "ivScannerUseQuestion": "對 {{pokemonName}} 使用個體值掃描?",
+  // "useMove": " used\n{{moveName}}!",
+  // "fainted": " fainted!",
+  // "foe": "Foe",
+  // "wild": "Wild",
 } as const;

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,3 +1,4 @@
+import i18next from "i18next";
 import { BattleSpec } from "./enums/battle-spec";
 import Pokemon from "./field/pokemon";
 
@@ -9,7 +10,13 @@ export function getPokemonPrefix(pokemon: Pokemon): string {
   let prefix: string;
   switch (pokemon.scene.currentBattle.battleSpec) {
   case BattleSpec.DEFAULT:
-    prefix = !pokemon.isPlayer() ? pokemon.hasTrainer() ? "Foe " : "Wild " : "";
+    if (pokemon.isPlayer()) {
+      prefix = "";
+    } else if (pokemon.hasTrainer()) {
+      prefix = `${i18next.t("battle:foe")} `;
+    } else {
+      prefix = `${i18next.t("battle:wild")} `;
+    }
     break;
   case BattleSpec.FINAL_BOSS:
     prefix = !pokemon.isPlayer() ? "Foe " : "";

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2,7 +2,7 @@ import BattleScene, { bypassLogin } from "./battle-scene";
 import { default as Pokemon, PlayerPokemon, EnemyPokemon, PokemonMove, MoveResult, DamageResult, FieldPosition, HitResult, TurnMove } from "./field/pokemon";
 import * as Utils from "./utils";
 import { Moves } from "./data/enums/moves";
-import { allMoves, applyMoveAttrs, BypassSleepAttr, ChargeAttr, applyFilteredMoveAttrs, HitsTagAttr, MissEffectAttr, MoveAttr, MoveEffectAttr, MoveFlags, MultiHitAttr, OverrideMoveEffectAttr, VariableAccuracyAttr, MoveTarget, getMoveTargets, MoveTargetSet, MoveEffectTrigger, CopyMoveAttr, AttackMove, SelfStatusMove, PreMoveMessageAttr, HealStatusEffectAttr, IgnoreOpponentStatChangesAttr, NoEffectAttr, BypassRedirectAttr, FixedDamageAttr, PostVictoryStatChangeAttr, OneHitKOAccuracyAttr, ForceSwitchOutAttr, VariableTargetAttr, IncrementMovePriorityAttr  } from "./data/move";
+import { allMoves, applyMoveAttrs, BypassSleepAttr, ChargeAttr, applyFilteredMoveAttrs, HitsTagAttr, MissEffectAttr, MoveAttr, MoveEffectAttr, MoveFlags, MultiHitAttr, OverrideMoveEffectAttr, VariableAccuracyAttr, MoveTarget, getMoveTargets, MoveTargetSet, MoveEffectTrigger, CopyMoveAttr, AttackMove, SelfStatusMove, PreMoveMessageAttr, HealStatusEffectAttr, IgnoreOpponentStatChangesAttr, NoEffectAttr, BypassRedirectAttr, FixedDamageAttr, PostVictoryStatChangeAttr, OneHitKOAccuracyAttr, ForceSwitchOutAttr, VariableTargetAttr, IncrementMovePriorityAttr, StatusMove  } from "./data/move";
 import { Mode } from "./ui/ui";
 import { Command } from "./ui/command-ui-handler";
 import { Stat } from "./data/pokemon-stat";
@@ -2647,6 +2647,11 @@ export class MovePhase extends BattlePhase {
       return;
     }
 
+    if (this.move.getMove() instanceof AttackMove || this.move.getMove() instanceof StatusMove) {
+      this.scene.queueMessage(getPokemonMessage(this.pokemon, i18next.t("battle:useMove", { moveName: this.move.getName() })), 500);
+      return;
+    }
+
     this.scene.queueMessage(getPokemonMessage(this.pokemon, ` used\n${this.move.getName()}!`), 500);
     applyMoveAttrs(PreMoveMessageAttr, this.pokemon, this.pokemon.getOpponents().find(() => true), this.move.getMove());
   }
@@ -3520,7 +3525,7 @@ export class FaintPhase extends PokemonPhase {
       this.scene.currentBattle.enemyFaints += 1;
     }
 
-    this.scene.queueMessage(getPokemonMessage(pokemon, " fainted!"), null, true);
+    this.scene.queueMessage(getPokemonMessage(pokemon, i18next.t("battle:fainted")), null, true);
 
     if (pokemon.turnData?.attacksReceived?.length) {
       const lastAttack = pokemon.turnData.attacksReceived[0];


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Add localization for battle phase

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
It needs to be localized

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- Add localization "battle:useMove" when pokemon use AttackMove or StatusMove.
- Add localization "battle:fainted" when pokemon fainted.
- Add "battle:foe" and "battle:wild" for local translation, these use in message.ts
- Add localization in all each localization folders. but these are commented out. I think this work will be helpful to translators.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

#### Foe
![image](https://github.com/pagefaultgames/pokerogue/assets/13056250/8b300b4d-a70a-4a46-8c3c-b1ff3199b2f7)
![image](https://github.com/pagefaultgames/pokerogue/assets/13056250/c4a9c662-011f-47c5-92f9-47cc05bc6f5c)

#### Wild
![image](https://github.com/pagefaultgames/pokerogue/assets/13056250/3a2d4d11-a654-4087-844a-bb4ecab14028)
![image](https://github.com/pagefaultgames/pokerogue/assets/13056250/a9452e1d-2c77-4ad3-9ec4-f003976cfba6)

#### useMove (AttackMove or StatusMove)
![image](https://github.com/pagefaultgames/pokerogue/assets/13056250/3a2d4d11-a654-4087-844a-bb4ecab14028)
![image](https://github.com/pagefaultgames/pokerogue/assets/13056250/a9452e1d-2c77-4ad3-9ec4-f003976cfba6)

#### fainted
![image](https://github.com/pagefaultgames/pokerogue/assets/13056250/cf76102f-b1d5-4490-a54e-7f9b97819eb2)
![image](https://github.com/pagefaultgames/pokerogue/assets/13056250/2666792a-70bb-4648-9cf3-38602880ac66)


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
- Checkout this PR
- Change language to Korean
> Other languages show in english

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?