### PR TITLE
[Encounters] Added Mew to Jungle Biome

### DIFF
--- a/src/data/biomes.ts
+++ b/src/data/biomes.ts
@@ -1371,10 +1371,10 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.DAY]: [ Species.AMOONGUSS ],
       [TimeOfDay.DUSK]: [],
       [TimeOfDay.NIGHT]: [],
-      [TimeOfDay.ALL]: [ Species.KANGASKHAN, Species.SCIZOR, Species.SLAKING, Species.LEAFEON, Species.SERPERIOR, Species.RILLABOOM ]
+      [TimeOfDay.ALL]: [ Species.KANGASKHAN, Species.SCIZOR, Species.SLAKING, Species.LEAFEON, Species.SERPERIOR, Species.RILLABOOM, Species.KLEAVOR ]
     },
     [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.TAPU_LELE, Species.BUZZWOLE, Species.ZARUDE, Species.MUNKIDORI ] },
-    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.KLEAVOR ] }
+    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MEW ] }
   },
   [Biome.FAIRY_CAVE]: {
     [BiomePoolTier.COMMON]: {
@@ -2778,6 +2778,7 @@ export function initBiomes() {
     ]
     ],
     [ Species.MEW, Type.PSYCHIC, -1, [ ]
+      [ Biome.JUNGLE, BiomePoolTier.BOSS_ULTRA_RARE ]
     ],
     [ Species.CHIKORITA, Type.GRASS, -1, [
       [ Biome.TALL_GRASS, BiomePoolTier.RARE ]
@@ -6301,7 +6302,7 @@ export function initBiomes() {
     ],
     [ Species.KLEAVOR, Type.BUG, Type.ROCK, [
       [ Biome.JUNGLE, BiomePoolTier.SUPER_RARE ],
-      [ Biome.JUNGLE, BiomePoolTier.BOSS_ULTRA_RARE ]
+      [ Biome.JUNGLE, BiomePoolTier.BOSS_RARE ]
     ]
     ],
     [ Species.URSALUNA, Type.GROUND, Type.NORMAL, [

--- a/src/data/biomes.ts
+++ b/src/data/biomes.ts
@@ -2777,8 +2777,9 @@ export function initBiomes() {
       [ Biome.LABORATORY, BiomePoolTier.BOSS_ULTRA_RARE ]
     ]
     ],
-    [ Species.MEW, Type.PSYCHIC, -1, [ ]
+    [ Species.MEW, Type.PSYCHIC, -1, [
       [ Biome.JUNGLE, BiomePoolTier.BOSS_ULTRA_RARE ]
+    ]
     ],
     [ Species.CHIKORITA, Type.GRASS, -1, [
       [ Biome.TALL_GRASS, BiomePoolTier.RARE ]

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -75,10 +75,16 @@ export class Arena {
     }
     const isBoss = !!this.scene.getEncounterBossSegments(waveIndex, level) && !!this.pokemonPool[BiomePoolTier.BOSS].length
       && (this.biomeType !== Biome.END || this.scene.gameMode.isClassic || this.scene.gameMode.isWaveFinal(waveIndex));
+    // const isBoss = true;
+    // USED FOR TESTING
     const tierValue = Utils.randSeedInt(!isBoss ? 512 : 64);
     let tier = !isBoss
       ? tierValue >= 156 ? BiomePoolTier.COMMON : tierValue >= 32 ? BiomePoolTier.UNCOMMON : tierValue >= 6 ? BiomePoolTier.RARE : tierValue >= 1 ? BiomePoolTier.SUPER_RARE : BiomePoolTier.ULTRA_RARE
       : tierValue >= 20 ? BiomePoolTier.BOSS : tierValue >= 6 ? BiomePoolTier.BOSS_RARE : tierValue >= 1 ? BiomePoolTier.BOSS_SUPER_RARE : BiomePoolTier.BOSS_ULTRA_RARE;
+    // let tier = !isBoss
+    //   ? tierValue >= 156 ? BiomePoolTier.BOSS_ULTRA_RARE : tierValue >= 32 ? BiomePoolTier.BOSS_ULTRA_RARE : tierValue >= 6 ? BiomePoolTier.BOSS_ULTRA_RARE : tierValue >= 1 ? BiomePoolTier.BOSS_ULTRA_RARE : BiomePoolTier.BOSS_ULTRA_RARE
+    //   : tierValue >= 20 ? BiomePoolTier.BOSS_ULTRA_RARE : tierValue >= 6 ? BiomePoolTier.BOSS_ULTRA_RARE : tierValue >= 1 ? BiomePoolTier.BOSS_ULTRA_RARE : BiomePoolTier.BOSS_ULTRA_RARE;
+    // USED FOR TESTING
     console.log(BiomePoolTier[tier]);
     while (!this.pokemonPool[tier].length) {
       console.log(`Downgraded rarity tier from ${BiomePoolTier[tier]} to ${BiomePoolTier[tier - 1]}`);

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -31,6 +31,8 @@ export const WEATHER_OVERRIDE: WeatherType = WeatherType.NONE;
 export const DOUBLE_BATTLE_OVERRIDE: boolean = false;
 export const STARTING_WAVE_OVERRIDE: integer = 0;
 export const STARTING_BIOME_OVERRIDE: Biome = Biome.TOWN;
+// export const STARTING_BIOME_OVERRIDE: Biome = Biome.TOWN;
+// USED FOR TESTING
 export const ARENA_TINT_OVERRIDE: TimeOfDay = null;
 // Multiplies XP gained by this value including 0. Set to null to ignore the override
 export const XP_MULTIPLIER_OVERRIDE: number = null;


### PR DESCRIPTION
## What are the changes?
Mew is added as an Ultra Rare Boss encounter in the Jungle Biome.

## Why am I doing these changes?
There was a post in #feature-vote that aimed to reduce the amount of egg-exclusive pokemon by adding Mew to the regular encounter table.

Currently, Jungle's Ultra Rare Boss is Kleavor. This does not coincide well with the rarity of other Hisuian pokemon like Sneasler or Wyrdeer, that are found as Rare Bosses in other biomes. 

Scizor is also already a Rare Boss in Jungle Biome, so it makes more sense for Kleavor to move to the rare boss section and Mew to move to the ultra rare boss section for the Jungle biome.

Mew is said to come from the Jungle in the game's lore, as cited in Bulbapedia:
[ According to journals found in Kanto's Pokémon Mansion, Dr. Fuji is the one who discovered Mew deep in the jungle and coined its name. ] , as a result this change makes sense. 

This improves the user experience as it creates more opportunities to add Mew as a starter other than relying on eggs. This change allows players to hunt Mew in the Jungle biome with the Map, for example.

## What did change?
+ Correctly added Mew to the encounter table for the Jungle Biome as an Ultra Rare Boss.

- Removed Kleavor as an Ultra Rare Boss

+ Added Kleavor as a Rare Boss

+ Added commented code for testing in overrides.ts and arena.ts that set the starting biome as jungle and forces an ultra rare boss encounter

### Screenshots/Videos
![](https://i.imgur.com/FjK35js.png)

## How to test the changes?
Uncomment the code in arena.ts and overrides.ts, comment the line that currently exists for that code.

E.g. 

export const STARTING_BIOME_OVERRIDE: Biome = Biome.TOWN;
// export const STARTING_BIOME_OVERRIDE: Biome = Biome.TOWN;

Uncomment bottom line, comment top line.