### PR TITLE
French corrections to Toxic Orb and Flame Orb descriptions

### DIFF
--- a/src/locales/fr/modifier-type.ts
+++ b/src/locales/fr/modifier-type.ts
@@ -209,8 +209,8 @@ export const modifierType: ModifierTypeTranslationEntries = {
     "LEFTOVERS": { name: "Restes", description: "Soigne à chaque tour 1/16 des PV max d’un Pokémon" },
     "SHELL_BELL": { name: "Grelot Coque", description: "Soigne 1/8 des dégâts infligés par un Pokémon" },
 
-    "TOXIC_ORB": { name: "Orbe Toxique", description: "Empoisonne gravement son porteur à la fin du tour s’il na pas déjà de problème de statut." },
-    "FLAME_ORB": { name: "Orbe Flamme", description: "Brule son porteur à la fin du tour s’il na pas déjà de problème de statut." },
+    "TOXIC_ORB": { name: "Orbe Toxique", description: "Empoisonne gravement son porteur à la fin du tour s’il n’a pas déjà de problème de statut." },
+    "FLAME_ORB": { name: "Orbe Flamme", description: "Brule son porteur à la fin du tour s’il n’a pas déjà de problème de statut." },
 
     "BATON": { name: "Bâton", description: "Permet de transmettre les effets en cas de changement de Pokémon. Ignore les pièges." },
 

--- a/src/locales/fr/modifier-type.ts
+++ b/src/locales/fr/modifier-type.ts
@@ -209,8 +209,8 @@ export const modifierType: ModifierTypeTranslationEntries = {
     "LEFTOVERS": { name: "Restes", description: "Soigne à chaque tour 1/16 des PV max d’un Pokémon" },
     "SHELL_BELL": { name: "Grelot Coque", description: "Soigne 1/8 des dégâts infligés par un Pokémon" },
 
-    "TOXIC_ORB": { name: "Orbe Toxique", description: "Un orbe bizarre qui empoisonne gravement son porteur durant le combat" },
-    "FLAME_ORB": { name: "Orbe Flamme", description: "Un orbe bizarre qui brûle son porteur durant le combat" },
+    "TOXIC_ORB": { name: "Orbe Toxique", description: "Empoisonne gravement son porteur à la fin du tour s’il na pas déjà de problème de statut." },
+    "FLAME_ORB": { name: "Orbe Flamme", description: "Brule son porteur à la fin du tour s’il na pas déjà de problème de statut." },
 
     "BATON": { name: "Bâton", description: "Permet de transmettre les effets en cas de changement de Pokémon. Ignore les pièges." },
 


### PR DESCRIPTION
## What are the changes?
Change French translation of Toxic Orb and Flame Orb.

## Why am I doing these changes?
The French description was too generic and did not provided the same amount of informations as the original custom English description made for Rogue.

## What did change?
French Toxic Orb and Flame Orb French descriptions

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)