### PR TITLE
[Feature] Add buying specific species Egg with candy

### DIFF
--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -6,6 +6,11 @@ import i18next from "../plugins/i18n";
 
 export const EGG_SEED = 1073741824;
 
+export enum EggSource {
+  GACHA,
+  CANDY
+}
+
 export enum GachaType {
   MOVE,
   LEGENDARY,
@@ -15,20 +20,25 @@ export enum GachaType {
 export class Egg {
   public id: integer;
   public tier: EggTier;
-  public gachaType: GachaType;
   public hatchWaves: integer;
   public timestamp: integer;
+  public source: EggSource;
+  public gachaType: GachaType;
+  public species: Species;
 
-  constructor(id: integer, gachaType: GachaType, hatchWaves: integer, timestamp: integer) {
+
+  constructor(id: integer, hatchWaves: integer, timestamp: integer, source: EggSource, gachaType: GachaType = null, species: Species = null) {
     this.id = id;
-    this.tier = Math.floor(id / EGG_SEED);
-    this.gachaType = gachaType;
-    this.hatchWaves = hatchWaves;
+    this.tier = species === null ? Math.floor(id / EGG_SEED) : getSpeciesTier(species);
+    this.hatchWaves = hatchWaves ?? getEggTierDefaultHatchWaves(this.tier);
     this.timestamp = timestamp;
+    this.source = source;
+    this.gachaType = gachaType;
+    this.species = species;
   }
 
   isManaphyEgg(): boolean {
-    return this.tier === EggTier.COMMON && !(this.id % 255);
+    return (this.tier === EggTier.COMMON && !(this.id % 255)) || this.species	=== Species.PHIONE || this.species === Species.MANAPHY;
   }
 
   getKey(): string {
@@ -80,14 +90,22 @@ export function getEggHatchWavesMessage(hatchWaves: integer): string {
   return i18next.t("egg:hatchWavesMessageLongTime");
 }
 
-export function getEggGachaTypeDescriptor(scene: BattleScene, egg: Egg): string {
-  switch (egg.gachaType) {
-  case GachaType.LEGENDARY:
-    return `${i18next.t("egg:gachaTypeLegendary")} (${getPokemonSpecies(getLegendaryGachaSpeciesForTimestamp(scene, egg.timestamp)).getName()})`;
-  case GachaType.MOVE:
-    return i18next.t("egg:gachaTypeMove");
-  case GachaType.SHINY:
-    return i18next.t("egg:gachaTypeShiny");
+export function getEggSourceDescriptor(scene: BattleScene, egg: Egg): string {
+  switch (egg.source) {
+  case EggSource.GACHA:
+    if (egg.gachaType === null) {
+      break;
+    }
+    switch (egg.gachaType) {
+    case GachaType.LEGENDARY:
+      return `${i18next.t("egg:gachaTypeLegendary")} (${getPokemonSpecies(getLegendaryGachaSpeciesForTimestamp(scene, egg.timestamp)).getName()})`;
+    case GachaType.MOVE:
+      return i18next.t("egg:gachaTypeMove");
+    case GachaType.SHINY:
+      return i18next.t("egg:gachaTypeShiny");
+    }
+  case EggSource.CANDY:
+    return `${i18next.t("egg:sourceCandyExchange")} (${getPokemonSpecies(egg.species).getName()})`;
   }
 }
 
@@ -110,4 +128,27 @@ export function getLegendaryGachaSpeciesForTimestamp(scene: BattleScene, timesta
   }, offset, EGG_SEED.toString());
 
   return ret;
+}
+
+/**
+ * Obtains the egg tier of a starter species, using its starter value
+ * @param species The {@linkcode Species} of which we are trying to obtain the egg tier
+ * @returns the {@linkcode EggTier} from which this species usually hatches from, or {@linkcode EggTier.COMMON} if not a starter species
+ */
+export function getSpeciesTier(species: Species): EggTier {
+  if (species === Species.PHIONE || species === Species.MANAPHY) {
+    return EggTier.COMMON;
+  }
+
+  const starterValue = speciesStarters[species] ?? 1;
+  if (starterValue >= 8) {
+    return EggTier.MASTER;
+  }
+  if (starterValue >= 6) {
+    return EggTier.ULTRA;
+  }
+  if (starterValue >= 4) {
+    return EggTier.GREAT;
+  }
+  return EggTier.COMMON;
 }

--- a/src/egg-hatch-phase.ts
+++ b/src/egg-hatch-phase.ts
@@ -3,7 +3,7 @@ import { Phase } from "./phase";
 import BattleScene, { AnySound } from "./battle-scene";
 import * as Utils from "./utils";
 import { Mode } from "./ui/ui";
-import { EGG_SEED, Egg, GachaType, getLegendaryGachaSpeciesForTimestamp } from "./data/egg";
+import { EGG_SEED, Egg, EggSource, GachaType, getLegendaryGachaSpeciesForTimestamp } from "./data/egg";
 import EggHatchSceneHandler from "./ui/egg-hatch-scene-handler";
 import { Species } from "./data/enums/species";
 import { PlayerPokemon } from "./field/pokemon";
@@ -458,7 +458,9 @@ export class EggHatchPhase extends Phase {
        * Legendary eggs pulled from the legendary gacha have a 50% of being converted into
        * the species that was the legendary focus at the time
        */
-      if (this.egg.isManaphyEgg()) {
+      if (this.egg.source === EggSource.CANDY && this.egg.species) {
+        speciesOverride = this.egg.species;
+      } else if (this.egg.isManaphyEgg()) {
         const rand = Utils.randSeedInt(8);
 
         speciesOverride = rand ? Species.PHIONE : Species.MANAPHY;

--- a/src/egg-hatch-phase.ts
+++ b/src/egg-hatch-phase.ts
@@ -458,8 +458,8 @@ export class EggHatchPhase extends Phase {
        * Legendary eggs pulled from the legendary gacha have a 50% of being converted into
        * the species that was the legendary focus at the time
        */
-      if (this.egg.source === EggSource.CANDY && this.egg.species) {
-        speciesOverride = this.egg.species;
+      if (this.egg.source === EggSource.CANDY && this.egg.forcedSpecies) {
+        speciesOverride = this.egg.forcedSpecies;
       } else if (this.egg.isManaphyEgg()) {
         const rand = Utils.randSeedInt(8);
 

--- a/src/locales/de/egg.ts
+++ b/src/locales/de/egg.ts
@@ -13,6 +13,7 @@ export const egg: SimpleTranslationEntries = {
   "gachaTypeLegendary": "Erhöhte Chance auf legendäre Eier",
   "gachaTypeMove": "Erhöhte Chance auf Eier mit seltenen Attacken",
   "gachaTypeShiny": "Erhöhte Chance auf schillernde Eier",
+  "sourceCandyExchange": "Candy Exchange",
   "selectMachine": "Wähle eine Maschine",
   "notEnoughVouchers": "Du hast nicht genug Ei-Gutscheine!",
   "tooManyEggs": "Du hast schon zu viele Eier!",

--- a/src/locales/de/starter-select-ui-handler.ts
+++ b/src/locales/de/starter-select-ui-handler.ts
@@ -30,6 +30,7 @@ export const starterSelectUiHandler: SimpleTranslationEntries = {
   "selectMoveSwapWith": "Wähle die gewünschte Attacke.",
   "unlockPassive": "Passiv-Skill freischalten",
   "reduceCost": "Preis reduzieren",
+  "buyEgg": "Buy Egg",
   "cycleShiny": "R: Schillernd Ja/Nein",
   "cycleForm": "F: Form ändern",
   "cycleGender": "G: Geschlecht ändern",

--- a/src/locales/en/egg.ts
+++ b/src/locales/en/egg.ts
@@ -13,6 +13,7 @@ export const egg: SimpleTranslationEntries = {
   "gachaTypeLegendary": "Legendary Rate Up",
   "gachaTypeMove": "Rare Egg Move Rate Up",
   "gachaTypeShiny": "Shiny Rate Up",
+  "sourceCandyExchange": "Candy Exchange",
   "selectMachine": "Select a machine.",
   "notEnoughVouchers": "You don't have enough vouchers!",
   "tooManyEggs": "You have too many eggs!",

--- a/src/locales/en/starter-select-ui-handler.ts
+++ b/src/locales/en/starter-select-ui-handler.ts
@@ -30,6 +30,7 @@ export const starterSelectUiHandler: SimpleTranslationEntries = {
   "selectMoveSwapWith": "Select a move to swap with",
   "unlockPassive": "Unlock Passive",
   "reduceCost": "Reduce Cost",
+  "buyEgg": "Buy Egg",
   "cycleShiny": "R: Cycle Shiny",
   "cycleForm": "F: Cycle Form",
   "cycleGender": "G: Cycle Gender",

--- a/src/locales/es/egg.ts
+++ b/src/locales/es/egg.ts
@@ -13,6 +13,7 @@ export const egg: SimpleTranslationEntries = {
   "gachaTypeLegendary": "Mayor tasa de Legendario",
   "gachaTypeMove": "Mayor tasa de Movimiento Huevo Raro",
   "gachaTypeShiny": "Mayor tasa de Shiny",
+  "sourceCandyExchange": "Candy Exchange",
   "selectMachine": "Seleccione una máquina.",
   "notEnoughVouchers": "¡No tienes suficientes vales!",
   "tooManyEggs": "¡No tienes suficiente espacio!",

--- a/src/locales/es/starter-select-ui-handler.ts
+++ b/src/locales/es/starter-select-ui-handler.ts
@@ -30,6 +30,7 @@ export const starterSelectUiHandler: SimpleTranslationEntries = {
   "selectMoveSwapWith": "Elige el movimiento que sustituirá a",
   "unlockPassive": "Añadir Pasiva",
   "reduceCost": "Reducir Coste",
+  "buyEgg": "Comprar Huevo",
   "cycleShiny": "R: Cambiar Shiny",
   "cycleForm": "F: Cambiar Forma",
   "cycleGender": "G: Cambiar Género",

--- a/src/locales/fr/egg.ts
+++ b/src/locales/fr/egg.ts
@@ -13,6 +13,7 @@ export const egg: SimpleTranslationEntries = {
   "gachaTypeLegendary": "Taux de Légendaires élevé",
   "gachaTypeMove": "Taux de Capacité Œuf Rare élevé",
   "gachaTypeShiny": "Taux de Chromatiques élevé",
+  "sourceCandyExchange": "Candy Exchange",
   "selectMachine": "Sélectionnez une machine.",
   "notEnoughVouchers": "Vous n’avez pas assez de coupons !",
   "tooManyEggs": "Vous avez trop d’Œufs !",

--- a/src/locales/fr/starter-select-ui-handler.ts
+++ b/src/locales/fr/starter-select-ui-handler.ts
@@ -30,6 +30,7 @@ export const starterSelectUiHandler: SimpleTranslationEntries = {
   "selectMoveSwapWith": "Sélectionnez laquelle échanger avec",
   "unlockPassive": "Débloquer Passif",
   "reduceCost": "Diminuer le cout",
+  "buyEgg": "Buy Egg",
   "cycleShiny": "R: » Chromatiques",
   "cycleForm": "F: » Formes",
   "cycleGender": "G: » Sexes",

--- a/src/locales/it/egg.ts
+++ b/src/locales/it/egg.ts
@@ -13,6 +13,7 @@ export const egg: SimpleTranslationEntries = {
   "gachaTypeLegendary": "Tasso dei Leggendari Aumentato",
   "gachaTypeMove": "Tasso delle Mosse Rare delle Uova Aumentato",
   "gachaTypeShiny": "Tasso degli Shiny Aumentato",
+  "sourceCandyExchange": "Candy Exchange",
   "selectMachine": "Seleziona un distributore.",
   "notEnoughVouchers": "Non hai abbastanza Biglietti!",
   "tooManyEggs": "Hai troppe Uova!",

--- a/src/locales/it/starter-select-ui-handler.ts
+++ b/src/locales/it/starter-select-ui-handler.ts
@@ -30,6 +30,7 @@ export const starterSelectUiHandler: SimpleTranslationEntries = {
   "selectMoveSwapWith": "Seleziona una mossa da scambiare con",
   "unlockPassive": "Sblocca Passiva",
   "reduceCost": "Riduci Costo",
+  "buyEgg": "Buy Egg",
   "cycleShiny": "R: Alterna Shiny",
   "cycleForm": "F: Alterna Forma",
   "cycleGender": "G: Alterna Sesso",

--- a/src/locales/ko/egg.ts
+++ b/src/locales/ko/egg.ts
@@ -13,6 +13,7 @@ export const egg: SimpleTranslationEntries = {
   "gachaTypeLegendary": "레전더리 확률 업",
   "gachaTypeMove": "희귀 알 기술 확률 업",
   "gachaTypeShiny": "색이 다른 포켓몬 확률 업",
+  "sourceCandyExchange": "Candy Exchange",
   "selectMachine": "사용할 뽑기 기계를 골라주세요.",
   "notEnoughVouchers": "바우처가 충분하지 않습니다!",
   "tooManyEggs": "알을 너무 많이 갖고 있습니다!",

--- a/src/locales/pt_BR/egg.ts
+++ b/src/locales/pt_BR/egg.ts
@@ -13,6 +13,7 @@ export const egg: SimpleTranslationEntries = {
   "gachaTypeLegendary": "Chance de Lendário Aumentada",
   "gachaTypeMove": "Chance de Movimento de Ovo Raro Aumentada",
   "gachaTypeShiny": "Chance de Shiny Aumentada",
+  "sourceCandyExchange": "Candy Exchange",
   "selectMachine": "Escolha uma máquina.",
   "notEnoughVouchers": "Você não tem vouchers suficientes!",
   "tooManyEggs": "Você já tem muitos ovos!",

--- a/src/locales/pt_BR/starter-select-ui-handler.ts
+++ b/src/locales/pt_BR/starter-select-ui-handler.ts
@@ -30,6 +30,7 @@ export const starterSelectUiHandler: SimpleTranslationEntries = {
   "selectMoveSwapWith": "Escolha o movimento que substituirá",
   "unlockPassive": "Aprender Passiva",
   "reduceCost": "Reduzir Custo",
+  "buyEgg": "Buy Egg",
   "cycleShiny": "R: » Shiny",
   "cycleForm": "F: » Forma",
   "cycleGender": "G: » Gênero",

--- a/src/locales/zh_CN/egg.ts
+++ b/src/locales/zh_CN/egg.ts
@@ -13,6 +13,7 @@ export const egg: SimpleTranslationEntries = {
   "gachaTypeLegendary": "传说概率上升",
   "gachaTypeMove": "稀有概率上升",
   "gachaTypeShiny": "闪光概率上升",
+  "sourceCandyExchange": "Candy Exchange",
   "selectMachine": "选择一个机器。",
   "notEnoughVouchers": "你没有足够的兑换券！",
   "tooManyEggs": "你的蛋太多啦！",

--- a/src/locales/zh_CN/starter-select-ui-handler.ts
+++ b/src/locales/zh_CN/starter-select-ui-handler.ts
@@ -30,6 +30,7 @@ export const starterSelectUiHandler: SimpleTranslationEntries = {
   "selectMoveSwapWith": "选择要替换成的招式",
   "unlockPassive": "解锁被动",
   "reduceCost": "降低花费",
+  "buyEgg": "Buy Egg",
   "cycleShiny": "R: 切换闪光",
   "cycleForm": "F: 切换形态",
   "cycleGender": "G: 切换性别",

--- a/src/locales/zh_TW/egg.ts
+++ b/src/locales/zh_TW/egg.ts
@@ -13,6 +13,7 @@ export const egg: SimpleTranslationEntries = {
   "gachaTypeLegendary": "傳說概率上升",
   "gachaTypeMove": "稀有概率上升",
   "gachaTypeShiny": "閃光概率上升",
+  "sourceCandyExchange": "Candy Exchange",
   "selectMachine": "選擇一個機器。",
   "notEnoughVouchers": "你沒有足夠的兌換券！",
   "tooManyEggs": "你的蛋太多啦！",

--- a/src/locales/zh_TW/starter-select-ui-handler.ts
+++ b/src/locales/zh_TW/starter-select-ui-handler.ts
@@ -30,6 +30,7 @@ export const starterSelectUiHandler: SimpleTranslationEntries = {
   "selectMoveSwapWith": "選擇想要替換成的招式",
   "unlockPassive": "解鎖被動",
   "reduceCost": "降低花費",
+  "buyEgg": "Buy Egg",
   "cycleShiny": "R: 切換閃光",
   "cycleForm": "F: 切換形態",
   "cycleGender": "G: 切換性別",

--- a/src/system/egg-data.ts
+++ b/src/system/egg-data.ts
@@ -7,7 +7,7 @@ export default class EggData {
   public timestamp: integer;
   public source: EggSource;
   public gachaType: GachaType;
-  public species: Species;
+  public forcedSpecies: Species;
 
   constructor(source: Egg | any) {
     const sourceEgg = source instanceof Egg ? source as Egg : null;
@@ -16,10 +16,10 @@ export default class EggData {
     this.timestamp = sourceEgg ? sourceEgg.timestamp : source.timestamp;
     this.source = sourceEgg ? sourceEgg.source : source.source;
     this.gachaType = sourceEgg ? sourceEgg.gachaType : source.gachaType;
-    this.species = sourceEgg ? sourceEgg.species : source.species;
+    this.forcedSpecies = sourceEgg ? sourceEgg.forcedSpecies : source.forcedSpecies;
   }
 
   toEgg(): Egg {
-    return new Egg(this.id, this.hatchWaves, this.timestamp, this.source, this.gachaType, this.species);
+    return new Egg(this.id, this.hatchWaves, this.timestamp, this.source, this.gachaType, this.forcedSpecies);
   }
 }

--- a/src/system/egg-data.ts
+++ b/src/system/egg-data.ts
@@ -1,20 +1,25 @@
-import { Egg, GachaType } from "../data/egg";
+import { Species } from "#app/data/enums/species.js";
+import { Egg, EggSource, GachaType } from "../data/egg";
 
 export default class EggData {
   public id: integer;
-  public gachaType: GachaType;
   public hatchWaves: integer;
   public timestamp: integer;
+  public source: EggSource;
+  public gachaType: GachaType;
+  public species: Species;
 
   constructor(source: Egg | any) {
     const sourceEgg = source instanceof Egg ? source as Egg : null;
     this.id = sourceEgg ? sourceEgg.id : source.id;
-    this.gachaType = sourceEgg ? sourceEgg.gachaType : source.gachaType;
     this.hatchWaves = sourceEgg ? sourceEgg.hatchWaves : source.hatchWaves;
     this.timestamp = sourceEgg ? sourceEgg.timestamp : source.timestamp;
+    this.source = sourceEgg ? sourceEgg.source : source.source;
+    this.gachaType = sourceEgg ? sourceEgg.gachaType : source.gachaType;
+    this.species = sourceEgg ? sourceEgg.species : source.species;
   }
 
   toEgg(): Egg {
-    return new Egg(this.id, this.gachaType, this.hatchWaves, this.timestamp);
+    return new Egg(this.id, this.hatchWaves, this.timestamp, this.source, this.gachaType, this.species);
   }
 }

--- a/src/ui/egg-gacha-ui-handler.ts
+++ b/src/ui/egg-gacha-ui-handler.ts
@@ -3,7 +3,7 @@ import { Mode } from "./ui";
 import { TextStyle, addTextObject, getEggTierTextTint } from "./text";
 import MessageUiHandler from "./message-ui-handler";
 import * as Utils from "../utils";
-import { EGG_SEED, Egg, GachaType, getEggTierDefaultHatchWaves, getEggDescriptor, getLegendaryGachaSpeciesForTimestamp } from "../data/egg";
+import { EGG_SEED, Egg, GachaType, getEggTierDefaultHatchWaves, getEggDescriptor, getLegendaryGachaSpeciesForTimestamp, EggSource } from "../data/egg";
 import { VoucherType, getVoucherTypeIcon } from "../system/voucher";
 import { getPokemonSpecies } from "../data/pokemon-species";
 import { addWindow } from "./ui-theme";
@@ -382,7 +382,7 @@ export default class EggGachaUiHandler extends MessageUiHandler {
       const timestamp = new Date().getTime();
 
       for (const tier of tiers) {
-        const egg = new Egg(Utils.randInt(EGG_SEED, EGG_SEED * tier), this.gachaCursor, getEggTierDefaultHatchWaves(tier), timestamp);
+        const egg = new Egg(Utils.randInt(EGG_SEED, EGG_SEED * tier), getEggTierDefaultHatchWaves(tier), timestamp, EggSource.GACHA, this.gachaCursor);
         if (egg.isManaphyEgg()) {
           this.scene.gameData.gameStats.manaphyEggsPulled++;
           egg.hatchWaves = getEggTierDefaultHatchWaves(EggTier.ULTRA);

--- a/src/ui/egg-list-ui-handler.ts
+++ b/src/ui/egg-list-ui-handler.ts
@@ -3,7 +3,7 @@ import { Mode } from "./ui";
 import PokemonIconAnimHandler, { PokemonIconAnimMode } from "./pokemon-icon-anim-handler";
 import { TextStyle, addTextObject } from "./text";
 import MessageUiHandler from "./message-ui-handler";
-import { Egg, getEggGachaTypeDescriptor, getEggHatchWavesMessage, getEggDescriptor } from "../data/egg";
+import { Egg, getEggSourceDescriptor, getEggHatchWavesMessage, getEggDescriptor } from "../data/egg";
 import { addWindow } from "./ui-theme";
 import {Button} from "../enums/buttons";
 import i18next from "../plugins/i18n";
@@ -180,7 +180,7 @@ export default class EggListUiHandler extends MessageUiHandler {
       })
     );
     this.eggHatchWavesText.setText(getEggHatchWavesMessage(egg.hatchWaves));
-    this.eggGachaInfoText.setText(getEggGachaTypeDescriptor(this.scene, egg));
+    this.eggGachaInfoText.setText(getEggSourceDescriptor(this.scene, egg));
   }
 
   setCursor(cursor: integer): boolean {

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1215,7 +1215,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
               });
             }
             const eggCost = getEggCandyCount(speciesStarters[this.lastSpecies.speciesId]);
-            if (eggCost > 0) {
+            if ((passiveAttr & PassiveAttr.UNLOCKED) && valueReduction >= 2 && eggCost > 0) {
               options.push({
                 label: `x${eggCost} ${i18next.t("starterSelectUiHandler:buyEgg")}`,
                 handler: () => {


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Added a new third way to spend starter candy, "Buy Egg", that can be used infinitely to exchange some candy for eggs that will always hatch that species. This gives players a use for their candies after unlocking passive and the 2 cost reductions, that isn't unbalanced since nothing is guaranteed: you may improve the IVs... or not, you may unlock an Egg Move... or not, etc.

![Captura de pantalla 2024-06-01 204612](https://github.com/pagefaultgames/pokerogue/assets/22176793/eb06588a-acbf-45c0-8816-182b969b42ea)

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
I am aware that implementing a feature doesn't mean it will be added. However I wanted to test myself and I believe this is a nice and interactive way to propose an idea to the community. I don't mind it being rejected, but I would love if it is considered a bit after seeing this example implementation and my arguments in favour of it, as it would really improve the game.

Candy progression is fun, as it allows players to have things to be excited for and to upgrade their favourites. However, once the passive and the two cost reductions are unlocked, continuing to use that Pokémon starts feeling like a waste. I am aware that the devs mentioned having plans to add more uses for candy.

However I still believe an option to buy eggs is good, as it feels like a natural way to progress with your starter. It preserves the randomness that roguelites are known for, keeping the players excited, which is better than other ideas that just allow you to straight up max an IV. This will make it balanced as it should not be strictly better than the other 2 ways of spending candy, while still allowing you to unlock many things like hidden ability, shinies, egg moves... if you are lucky, of course. And as a bonus, it also works as some sort of replacement for "breeding" for the time being.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- Added a new option in the candy exchange menu to spend candy to buy an egg, that will always hatch that starter
- I set the costs to 30 for 1-3 value starters, 20 for 4-5 value starters, 15 for 6-7 value and 10 for 8-9. No eggs for 10 cost Eternatus. These numbers are of course mostly for testing, and can easily be changed
- These eggs do not benefit from any extra rates, since they don't come from any gacha
- They have the same tier (and therefore, same waves to hatch) as if they came from gacha
- Eggs now have an EggSource attribute, currently only GACHA or CANDY
- Since the constructor and some functions in egg.ts have been changed, I have updated everywhere in the code where those are referenced accordingly, including EggData, to make sure nothing breaks
- The egg information menu will show if an egg was obtained through candy exchange and for what starter it is

## Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
Here is a video that shows the process of buying the eggs, viewing the egg information, and hatching them:

https://github.com/pagefaultgames/pokerogue/assets/22176793/0a3d7ee9-4969-437b-93bd-e350960fc91d


https://github.com/pagefaultgames/pokerogue/assets/22176793/7e4d25a9-4deb-4d4b-bf68-a7c983e028a4

(had to split them in two because of the 10MB limit)

Also here's a quick test that gacha eggs are still working fine:


https://github.com/pagefaultgames/pokerogue/assets/22176793/77b4572d-1a6c-4c9c-bd2f-c1e7aaad182f


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Set the `export const IMMEDIATE_HATCH_EGGS_OVERRIDE: boolean = true;` to true in the overrides.ts file so that you just need to clear one wave to test the eggs. You will also probably need to go into Manage Data > Import Data in the game itself to import a data file with a bunch of candies so you can actually test it. I found my file in one of the pinned messages of the offiline-and-modding channel in the discord server.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?