### PR TITLE
[Localization] Korean rival dialogue very small fix

### DIFF
--- a/src/locales/ko/dialogue.ts
+++ b/src/locales/ko/dialogue.ts
@@ -2321,7 +2321,7 @@ export const PGMmiscDialogue: SimpleTranslationEntries = {
         $@c{smile_eclosed}물론… 언제나 느껴왔지.\n@c{smile}끝난 거, 맞지? 이 굴레를 말이야.
         $@c{smile_ehalf}네 꿈도 이뤘고 말이야.\n어떻게 한번도 안 졌대?
         $네가 한 일은 나만 기억하게 될 모양이지만.\n@c{angry_mopen}나, 안 까먹어볼 테니까!
-        $@c{smile_wave_wink}농담이야!@d{64} @c{smile}절대로 안 잊어버릴 거야.@d{32}\n오늘 일은 우리의 마음 속에서 살아갈 야.
+        $@c{smile_wave_wink}농담이야!@d{64} @c{smile}절대 안 잊어버릴 거야.@d{32}\n마음 속엔 쭉 남아있을 수 있게.
         $@c{smile_wave}어쨌든,@d{64} 시간이 좀 늦었어…@d{96}\n이런 곳에서 할 말은 아닌가?
         $집에 가자. @c{smile_wave_wink}아마 내일은,\n추억을 되짚어보기 위한 배틀을 해볼 수 있을 거야.`,
   "ending_endless": "끝에 도달하신 것을 축하드립니다!\n더 많은 컨텐츠를 기다려주세요.",


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
Fix Wrong Sentence.
<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I doing these changes?
1 letter is missing.
오늘 일은 우리의 마음 속에서 살아갈 `거`야.
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What did change?
Not only add 1 letter, make sentence more-talking-style.
Still awkward, but better than before.

Remove `로` in `절대로` (talking style reducing unnessary postposition)
Convert `살아가다` to `남아있다` (from misunderstanding living-like-a-creature to remaining-like-the-memory)

<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos
![image](https://github.com/pagefaultgames/pokerogue/assets/87186129/1d953f61-3cc8-4c09-82c0-b4c12ed6488b)
Old one.
농담이야! 절대로 안 잊어버릴 거야.
오늘 일은 우리의 마음 속에서 살아갈 `거`야.

![image](https://github.com/pagefaultgames/pokerogue/assets/87186129/12d82a28-537f-4d2b-bdc1-6c4975c6bdb3)
New one.
농담이야! 절대 안 잊어버릴 거야.
마음 속엔 쭉 남아있을 수 있게. 

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Beat classic mode.
Unfortunately, screenshots are tested using "rival_female" instead of "ending_female".

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?

ps. 대사 쓰기 정말 어렵습니다 누가 싹 다듬어줬으면 좋겠습니다..
ps2. Multiple one-line-PR is.. right way? "cannot be split into smaller" is too difficult for me.