### PR TITLE
[Bug] Fix for Dancer activating when enemy in not on field / using a 2 steps charging move

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -23,6 +23,7 @@ import { Command } from "../ui/command-ui-handler";
 import { BerryModifierType } from "#app/modifier/modifier-type";
 import { getPokeballName } from "./pokeball";
 import { Species } from "./enums/species";
+import { BattlerIndex } from "#app/battle";
 
 export class Ability implements Localizable {
   public id: Abilities;

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -1,49 +1,28 @@
-import Pokemon, {HitResult, PokemonMove} from "../field/pokemon";
-import {Type} from "./type";
+import Pokemon, { HitResult, PokemonMove } from "../field/pokemon";
+import { Type } from "./type";
 import * as Utils from "../utils";
-import {BattleStat, getBattleStatName} from "./battle-stat";
-import {MovePhase, PokemonHealPhase, ShowAbilityPhase, StatChangePhase} from "../phases";
-import {getPokemonMessage, getPokemonPrefix} from "../messages";
-import {Weather, WeatherType} from "./weather";
-import {BattlerTag} from "./battler-tags";
-import {BattlerTagType} from "./enums/battler-tag-type";
-import {
-  getNonVolatileStatusEffects,
-  getStatusEffectDescriptor,
-  getStatusEffectHealText,
-  StatusEffect
-} from "./status-effect";
-import {Gender} from "./gender";
-import Move, {
-  allMoves,
-  applyMoveAttrs,
-  AttackMove,
-  FlinchAttr,
-  HitHealAttr,
-  IncrementMovePriorityAttr,
-  MoveCategory,
-  MoveFlags,
-  MoveTarget,
-  OneHitKOAttr,
-  SelfStatusMove,
-  StatusMove,
-  StatusMoveTypeImmunityAttr,
-  VariablePowerAttr
-} from "./move";
-import {ArenaTagSide, ArenaTrapTag} from "./arena-tag";
-import {ArenaTagType} from "./enums/arena-tag-type";
-import {Stat} from "./pokemon-stat";
-import {BerryModifier, PokemonHeldItemModifier} from "../modifier/modifier";
-import {Moves} from "./enums/moves";
-import {TerrainType} from "./terrain";
-import {SpeciesFormChangeManualTrigger} from "./pokemon-forms";
-import {Abilities} from "./enums/abilities";
-import i18next, {Localizable} from "#app/plugins/i18n.js";
-import {Command} from "../ui/command-ui-handler";
-import {BerryModifierType} from "#app/modifier/modifier-type";
-import {getPokeballName} from "./pokeball";
-import {Species} from "./enums/species";
-import {BattlerIndex} from "#app/battle";
+import { BattleStat, getBattleStatName } from "./battle-stat";
+import { MovePhase, PokemonHealPhase, ShowAbilityPhase, StatChangePhase } from "../phases";
+import { getPokemonMessage, getPokemonPrefix } from "../messages";
+import { Weather, WeatherType } from "./weather";
+import { BattlerTag } from "./battler-tags";
+import { BattlerTagType } from "./enums/battler-tag-type";
+import { StatusEffect, getNonVolatileStatusEffects, getStatusEffectDescriptor, getStatusEffectHealText } from "./status-effect";
+import { Gender } from "./gender";
+import Move, { AttackMove, MoveCategory, MoveFlags, MoveTarget, StatusMoveTypeImmunityAttr, FlinchAttr, OneHitKOAttr, HitHealAttr, allMoves, StatusMove, SelfStatusMove, VariablePowerAttr, applyMoveAttrs, IncrementMovePriorityAttr  } from "./move";
+import { ArenaTagSide, ArenaTrapTag } from "./arena-tag";
+import { ArenaTagType } from "./enums/arena-tag-type";
+import { Stat } from "./pokemon-stat";
+import { BerryModifier, PokemonHeldItemModifier } from "../modifier/modifier";
+import { Moves } from "./enums/moves";
+import { TerrainType } from "./terrain";
+import { SpeciesFormChangeManualTrigger } from "./pokemon-forms";
+import { Abilities } from "./enums/abilities";
+import i18next, { Localizable } from "#app/plugins/i18n.js";
+import { Command } from "../ui/command-ui-handler";
+import { BerryModifierType } from "#app/modifier/modifier-type";
+import { getPokeballName } from "./pokeball";
+import { Species } from "./enums/species";
 
 export class Ability implements Localizable {
   public id: Abilities;

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -1,28 +1,48 @@
-import Pokemon, { HitResult, PokemonMove } from "../field/pokemon";
-import { Type } from "./type";
+import Pokemon, {HitResult, PokemonMove} from "../field/pokemon";
+import {Type} from "./type";
 import * as Utils from "../utils";
-import { BattleStat, getBattleStatName } from "./battle-stat";
-import { MovePhase, PokemonHealPhase, ShowAbilityPhase, StatChangePhase } from "../phases";
-import { getPokemonMessage, getPokemonPrefix } from "../messages";
-import { Weather, WeatherType } from "./weather";
-import { BattlerTag } from "./battler-tags";
-import { BattlerTagType } from "./enums/battler-tag-type";
-import { StatusEffect, getNonVolatileStatusEffects, getStatusEffectDescriptor, getStatusEffectHealText } from "./status-effect";
-import { Gender } from "./gender";
-import Move, { AttackMove, MoveCategory, MoveFlags, MoveTarget, StatusMoveTypeImmunityAttr, FlinchAttr, OneHitKOAttr, HitHealAttr, allMoves, StatusMove, SelfStatusMove, VariablePowerAttr, applyMoveAttrs, IncrementMovePriorityAttr  } from "./move";
-import { ArenaTagSide, ArenaTrapTag } from "./arena-tag";
-import { ArenaTagType } from "./enums/arena-tag-type";
-import { Stat } from "./pokemon-stat";
-import { BerryModifier, PokemonHeldItemModifier } from "../modifier/modifier";
-import { Moves } from "./enums/moves";
-import { TerrainType } from "./terrain";
-import { SpeciesFormChangeManualTrigger } from "./pokemon-forms";
-import { Abilities } from "./enums/abilities";
-import i18next, { Localizable } from "#app/plugins/i18n.js";
-import { Command } from "../ui/command-ui-handler";
-import { BerryModifierType } from "#app/modifier/modifier-type";
-import { getPokeballName } from "./pokeball";
-import { Species } from "./enums/species";
+import {BattleStat, getBattleStatName} from "./battle-stat";
+import {MovePhase, PokemonHealPhase, ShowAbilityPhase, StatChangePhase} from "../phases";
+import {getPokemonMessage, getPokemonPrefix} from "../messages";
+import {Weather, WeatherType} from "./weather";
+import {BattlerTag} from "./battler-tags";
+import {BattlerTagType} from "./enums/battler-tag-type";
+import {
+  getNonVolatileStatusEffects,
+  getStatusEffectDescriptor,
+  getStatusEffectHealText,
+  StatusEffect
+} from "./status-effect";
+import {Gender} from "./gender";
+import Move, {
+  allMoves,
+  applyMoveAttrs,
+  AttackMove,
+  FlinchAttr,
+  HitHealAttr,
+  IncrementMovePriorityAttr,
+  MoveCategory,
+  MoveFlags,
+  MoveTarget,
+  OneHitKOAttr,
+  SelfStatusMove,
+  StatusMove,
+  StatusMoveTypeImmunityAttr,
+  VariablePowerAttr
+} from "./move";
+import {ArenaTagSide, ArenaTrapTag} from "./arena-tag";
+import {ArenaTagType} from "./enums/arena-tag-type";
+import {Stat} from "./pokemon-stat";
+import {BerryModifier, PokemonHeldItemModifier} from "../modifier/modifier";
+import {Moves} from "./enums/moves";
+import {TerrainType} from "./terrain";
+import {SpeciesFormChangeManualTrigger} from "./pokemon-forms";
+import {Abilities} from "./enums/abilities";
+import i18next, {Localizable} from "#app/plugins/i18n.js";
+import {Command} from "../ui/command-ui-handler";
+import {BerryModifierType} from "#app/modifier/modifier-type";
+import {getPokeballName} from "./pokeball";
+import {Species} from "./enums/species";
 import {BattlerIndex} from "#app/battle";
 
 export class Ability implements Localizable {
@@ -2764,8 +2784,12 @@ export class PostDancingMoveAbAttr extends PostMoveUsedAbAttr {
    * @return true if the Dancer ability was resolved
    */
   applyPostMoveUsed(dancer: Pokemon, move: PokemonMove, source: Pokemon, targets: BattlerIndex[], args: any[]): boolean | Promise<boolean> {
+    // List of tags that prevent the Dancer from replicating the move
+    const forbiddenTags = [BattlerTagType.FLYING, BattlerTagType.UNDERWATER,
+      BattlerTagType.UNDERGROUND, BattlerTagType.HIDDEN];
     // The move to replicate cannot come from the Dancer
-    if (source.getBattlerIndex() !== dancer.getBattlerIndex()) {
+    if (source.getBattlerIndex() !== dancer.getBattlerIndex()
+        && !dancer.summonData.tags.some(tag => forbiddenTags.includes(tag.tagType))) {
       // If the move is an AttackMove or a StatusMove the Dancer must replicate the move on the source of the Dance
       if (move.getMove() instanceof AttackMove || move.getMove() instanceof StatusMove) {
         const target = this.getTarget(dancer, source, targets);
@@ -2774,8 +2798,9 @@ export class PostDancingMoveAbAttr extends PostMoveUsedAbAttr {
         // If the move is a SelfStatusMove (ie. Swords Dance) the Dancer should replicate it on itself
         dancer.scene.unshiftPhase(new MovePhase(dancer.scene, dancer, [dancer.getBattlerIndex()], move, true));
       }
+      return true;
     }
-    return true;
+    return false;
   }
 
   /**

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2581,7 +2581,7 @@ export class MovePhase extends BattlePhase {
         this.scene.getPlayerField().forEach(pokemon => {
           applyPostMoveUsedAbAttrs(PostMoveUsedAbAttr, pokemon, this.move, this.pokemon, this.targets);
         });
-        this.scene.getEnemyParty().forEach(pokemon => {
+        this.scene.getEnemyField().forEach(pokemon => {
           applyPostMoveUsedAbAttrs(PostMoveUsedAbAttr, pokemon, this.move, this.pokemon, this.targets);
         });
       }


### PR DESCRIPTION
## What are the changes?
Fix for #1686 and #1450

## What did change?
Fixed a bug where Dancer activates while a Pokemon with Dancer Ability is charging a 2 turns move. 
Fixed a bug where Dancer activates while a Pokemon with Dancer Ability is on the opponent team but not on the field.

### Screenshots/Videos
#### Before
https://github.com/pagefaultgames/pokerogue/assets/11600168/14737303-f159-45ba-ab28-02fb4583245a

#### After
https://github.com/pagefaultgames/pokerogue/assets/11600168/209c3a54-93c5-4ce0-9222-ef829216bf3d

## How to test the changes?
Have a pokemon having the Dancer abilty use fly and use a dancing move afterwards.
Have a pokemon having the Dancer abilty on the opponent team but not in the field and use a dancing move.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?