### PR TITLE
[Move] Implement poltergeist

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -4917,6 +4917,23 @@ export class LastResortAttr extends MoveAttr {
   }
 }
 
+export class AttackedByItemAttr extends MoveAttr {
+  getCondition(): MoveConditionFunc {
+    return (user: Pokemon, target: Pokemon, move: Move) => {
+      const heldItems = target.getHeldItems().filter(i => i.getTransferrable(true));
+      if (heldItems.length === 0) {
+        return false;
+      }
+
+      const itemName = heldItems[0]?.type?.name ?? "item";
+      const attackedByItemString = " is about to be attacked by its " + itemName + "!";
+      target.scene.queueMessage(getPokemonMessage(target, attackedByItemString));
+
+      return true;
+    };
+  }
+}
+
 export class VariableTargetAttr extends MoveAttr {
   private targetChangeFunc: (user: Pokemon, target: Pokemon, move: Move) => number;
 
@@ -7379,8 +7396,8 @@ export function initMoves() {
     new AttackMove(Moves.LASH_OUT, Type.DARK, MoveCategory.PHYSICAL, 75, 100, 5, -1, 0, 8)
       .partial(),
     new AttackMove(Moves.POLTERGEIST, Type.GHOST, MoveCategory.PHYSICAL, 110, 90, 5, -1, 0, 8)
-      .makesContact(false)
-      .partial(),
+      .attr(AttackedByItemAttr)
+      .makesContact(false),
     new StatusMove(Moves.CORROSIVE_GAS, Type.POISON, 100, 40, -1, 0, 8)
       .target(MoveTarget.ALL_NEAR_OTHERS)
       .unimplemented(),

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -4935,7 +4935,7 @@ export class AttackedByItemAttr extends MoveAttr {
       }
 
       const itemName = heldItems[0]?.type?.name ?? "item";
-      const attackedByItemString = " is about to be attacked by its " + itemName + "!";
+      const attackedByItemString = ` is about to be attacked by its ${itemName}!`;
       target.scene.queueMessage(getPokemonMessage(target, attackedByItemString));
 
       return true;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -4917,7 +4917,16 @@ export class LastResortAttr extends MoveAttr {
   }
 }
 
+
+/**
+ * The move only works if the target has a transferable held item
+ * @extends MoveAttr
+ * @see {@linkcode getCondition}
+ */
 export class AttackedByItemAttr extends MoveAttr {
+  /**
+   * @returns the {@linkcode MoveConditionFunc} for this {@linkcode Move}
+   */
   getCondition(): MoveConditionFunc {
     return (user: Pokemon, target: Pokemon, move: Move) => {
       const heldItems = target.getHeldItems().filter(i => i.getTransferrable(true));


### PR DESCRIPTION
## What are the changes?
Implementing the move poltergeist. This was already coded in [this PR](https://github.com/pagefaultgames/pokerogue/pull/281) but was closed du to inactivity

## Why am I doing these changes?
Unimplemented move

## What did change?
Added AttackedByItemAttr for moves that used opponent's transferable held item (ie not vitamins) to work and added this attribute to poltergeist

### Screenshots/Videos
The move fails if the opponent has no transferable held item
https://github.com/pagefaultgames/pokerogue/assets/56865723/d8f20516-0fba-470b-8486-ee0cac6d8596

The move works if the opponent has an held item
https://github.com/pagefaultgames/pokerogue/assets/56865723/83fb6d9b-9122-49d0-8e92-adcf2d7f2ab2

## How to test the changes?
You can modify src/overrides.ts to test the move on an opponent with or without item

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?