### PR TITLE
[Move] Implement pollen puff

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1202,6 +1202,29 @@ export class BoostHealAttr extends HealAttr {
 }
 
 /**
+ * Heals the target only if it is the ally
+ * @extends HealAttr
+ * @see {@linkcode apply}
+ */
+export class HealOnAllyAttr extends HealAttr {
+  /**
+   * @param user {@linkcode Pokemon} using the move
+   * @param target {@linkcode Pokemon} target of the move
+   * @param move {@linkcode Move} with this attribute
+   * @param args N/A
+   * @returns true if the function succeeds
+   */
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    if (user.getAlly() === target) {
+      super.apply(user, target, move, args);
+      return true;
+    }
+
+    return false;
+  }
+}
+
+/**
  * Heals user as a side effect of a move that hits a target.
  * Healing is based on {@linkcode healRatio} * the amount of damage dealt or a stat of the target.
  * @extends MoveEffectAttr
@@ -3036,6 +3059,31 @@ export class TeraBlastCategoryAttr extends VariableMoveCategoryAttr {
 
     if (user.isTerastallized() && user.getBattleStat(Stat.ATK, target, move) > user.getBattleStat(Stat.SPATK, target, move)) {
       category.value = MoveCategory.PHYSICAL;
+      return true;
+    }
+
+    return false;
+  }
+}
+
+/**
+ * Change the move category to status when used on the ally
+ * @extends VariableMoveCategoryAttr
+ * @see {@linkcode apply}
+ */
+export class StatusCategoryOnAllyAttr extends VariableMoveCategoryAttr {
+  /**
+   * @param user {@linkcode Pokemon} using the move
+   * @param target {@linkcode Pokemon} target of the move
+   * @param move {@linkcode Move} with this attribute
+   * @param args [0] {@linkcode Utils.IntegerHolder} The category of the move
+   * @returns true if the function succeeds
+   */
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    const category = (args[0] as Utils.IntegerHolder);
+
+    if (user.getAlly() === target) {
+      category.value = MoveCategory.STATUS;
       return true;
     }
 
@@ -6966,8 +7014,9 @@ export function initMoves() {
     new AttackMove(Moves.THROAT_CHOP, Type.DARK, MoveCategory.PHYSICAL, 80, 100, 15, 100, 0, 7)
       .partial(),
     new AttackMove(Moves.POLLEN_PUFF, Type.BUG, MoveCategory.SPECIAL, 90, 100, 15, -1, 0, 7)
-      .ballBombMove()
-      .partial(),
+      .attr(StatusCategoryOnAllyAttr)
+      .attr(HealOnAllyAttr, 0.5, true, false)
+      .ballBombMove(),
     new AttackMove(Moves.ANCHOR_SHOT, Type.STEEL, MoveCategory.PHYSICAL, 80, 100, 20, -1, 0, 7)
       .attr(AddBattlerTagAttr, BattlerTagType.TRAPPED, false, false, 1),
     new StatusMove(Moves.PSYCHIC_TERRAIN, Type.PSYCHIC, -1, 10, -1, 0, 7)


### PR DESCRIPTION
## What are the changes?
Implementing the move Pollen Puff. There was already this PR on this subject but it was incomplete and closed due to inactivity.

## Why am I doing these changes?
Unimplemented move

## What did change?
Pollen puff effect change when used on ally : the ally is now restored 50% of max health instead of taking damage.
Pokemon with Bulletproof or Telepathy are not affected by the heal effect.
As Heal Block is unimplemented, the interraction of pollen puff with heal block isn't implemented.

### Screenshots/Videos
Pollen puff damaging opponent and healing ally
https://github.com/pagefaultgames/pokerogue/assets/56865723/0f31df5d-44c2-4595-b80a-7b08590f3c73

Pollen puff is innefective on pokemon with Bulletproof
https://github.com/pagefaultgames/pokerogue/assets/56865723/4e8478fe-56e9-41d4-90df-fbed62b45239

Pollen puff is innefective on ally with Telepathy
https://github.com/pagefaultgames/pokerogue/assets/56865723/645436d8-f455-4a96-af15-35f2891dfed7

## How to test the changes?
You can modify src/overrides.ts to test the move in a double battle with the different abilities

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?