### PR TITLE
[Move] Partial implement Jungle Healing

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -7402,7 +7402,9 @@ export function initMoves() {
     new StatusMove(Moves.JUNGLE_HEALING, Type.GRASS, -1, 10, -1, 0, 8)
       .attr(HealAttr, 0.25, true, false)
       .attr(HealStatusEffectAttr, true, ...getNonVolatileStatusEffects())
-      .target(MoveTarget.USER_AND_ALLIES),
+      .target(MoveTarget.USER_AND_ALLIES)
+      // JUNGLE_HEALING should heal both user and allies on double battle
+      .partial(),
     new AttackMove(Moves.WICKED_BLOW, Type.DARK, MoveCategory.PHYSICAL, 75, 100, 5, -1, 0, 8)
       .attr(CritOnlyAttr)
       .punchingMove(),

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -7401,8 +7401,8 @@ export function initMoves() {
       .attr(StatusEffectAttr, StatusEffect.BURN),
     new StatusMove(Moves.JUNGLE_HEALING, Type.GRASS, -1, 10, -1, 0, 8)
       .attr(HealAttr, 0.25, true, false)
-      .target(MoveTarget.USER_AND_ALLIES)
-      .partial(),
+      .attr(HealStatusEffectAttr, true, ...getNonVolatileStatusEffects())
+      .target(MoveTarget.USER_AND_ALLIES),
     new AttackMove(Moves.WICKED_BLOW, Type.DARK, MoveCategory.PHYSICAL, 75, 100, 5, -1, 0, 8)
       .attr(CritOnlyAttr)
       .punchingMove(),


### PR DESCRIPTION
## What are the changes?
Jungle Healing already heals, 25% of users health. 
This commit just adds the healing of all non volatile status effects

- [x] User heals 25% of their health
- [x] User heals non-volatile status effects

### To do:
- [ ] Allies heal 25% 
- [ ] Allies heal non-volatile status effects

### Screenshots/Videos

https://github.com/pagefaultgames/pokerogue/assets/31145813/8dedeaf0-e7af-49f3-88f7-68ee64d31777


