### PR TITLE
[Bug] Primal weather interaction fix

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -1702,7 +1702,9 @@ export class PostSummonWeatherChangeAbAttr extends PostSummonAbAttr {
   }
 
   applyPostSummon(pokemon: Pokemon, passive: boolean, args: any[]): boolean {
-    if (!pokemon.scene.arena.weather?.isImmutable()) {
+    if ((this.weatherType as WeatherType === WeatherType.HEAVY_RAIN || 
+      this.weatherType as WeatherType === WeatherType.HARSH_SUN || 
+      this.weatherType === WeatherType.STRONG_WINDS) || !pokemon.scene.arena.weather?.isImmutable()) {
       return pokemon.scene.arena.trySetWeather(this.weatherType, true);
     }
 
@@ -1827,6 +1829,16 @@ export class PreSwitchOutResetStatusAbAttr extends PreSwitchOutAbAttr {
     }
 
     return false;
+  }
+}
+
+/**
+ * Clears weather upon Primal Groudon/Kyogre/Rayquaza switch out
+ */
+export class PreSwitchOutClearWeatherAttr extends PreSwitchOutAbAttr {
+  applyPreSwitchOut(pokemon: Pokemon, passive: boolean, args: any[]): boolean | Promise<boolean> {
+    pokemon.scene.arena.trySetWeather(WeatherType.NONE, false);
+    return true;
   }
 }
 
@@ -2953,6 +2965,20 @@ export class PostBattleLootAbAttr extends PostBattleAbAttr {
 export class PostFaintAbAttr extends AbAttr {
   applyPostFaint(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: PokemonMove, hitResult: HitResult, args: any[]): boolean {
     return false;
+  }
+}
+
+/**
+ * Clears weather upon Primal Groudon/Kyogre/Rayquaza fainting
+ */
+export class PostFaintClearWeatherAbAttr extends PostFaintAbAttr {
+  constructor() {
+    super ();
+  }
+
+  applyPostFaint(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: PokemonMove, hitResult: HitResult, args: any[]): boolean {
+    pokemon.scene.arena.trySetWeather(WeatherType.NONE, false);
+    return true;
   }
 }
 
@@ -4090,13 +4116,22 @@ export function initAbilities() {
       .unimplemented(),
     new Ability(Abilities.PRIMORDIAL_SEA, 6)
       .attr(PostSummonWeatherChangeAbAttr, WeatherType.HEAVY_RAIN)
-      .attr(PostBiomeChangeWeatherChangeAbAttr, WeatherType.HEAVY_RAIN),
+      .attr(PostBiomeChangeWeatherChangeAbAttr, WeatherType.HEAVY_RAIN)
+      .attr(PreSwitchOutClearWeatherAttr)
+      .attr(PostFaintClearWeatherAbAttr)
+      .bypassFaint(),
     new Ability(Abilities.DESOLATE_LAND, 6)
       .attr(PostSummonWeatherChangeAbAttr, WeatherType.HARSH_SUN)
-      .attr(PostBiomeChangeWeatherChangeAbAttr, WeatherType.HARSH_SUN),
+      .attr(PostBiomeChangeWeatherChangeAbAttr, WeatherType.HARSH_SUN)
+      .attr(PreSwitchOutClearWeatherAttr)
+      .attr(PostFaintClearWeatherAbAttr)
+      .bypassFaint(),
     new Ability(Abilities.DELTA_STREAM, 6)
       .attr(PostSummonWeatherChangeAbAttr, WeatherType.STRONG_WINDS)
-      .attr(PostBiomeChangeWeatherChangeAbAttr, WeatherType.STRONG_WINDS),
+      .attr(PostBiomeChangeWeatherChangeAbAttr, WeatherType.STRONG_WINDS)
+      .attr(PreSwitchOutClearWeatherAttr)
+      .attr(PostFaintClearWeatherAbAttr)
+      .bypassFaint(),
     new Ability(Abilities.STAMINA, 7)
       .attr(PostDefendStatChangeAbAttr, (target, user, move) => move.category !== MoveCategory.STATUS, BattleStat.DEF, 1),
     new Ability(Abilities.WIMP_OUT, 7)

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1486,16 +1486,18 @@ export class StealHeldItemChanceAttr extends MoveEffectAttr {
  * "If Knock Off causes a Pokémon with the Sticky Hold Ability to faint, it can now remove that Pokémon's held item."
  */
 export class RemoveHeldItemAttr extends MoveEffectAttr {
+
+  /** Optional restriction for item pool to berries only i.e. Differentiating Incinerate and Knock Off */
   private berriesOnly: boolean; 
 
-  constructor(berriesOnly: boolean) { // Optional restriction for item pool to berries only i.e. Differentiating Incinerate and Knock Off
+  constructor(berriesOnly: boolean) { 
     super(false, MoveEffectTrigger.HIT);
     this.berriesOnly = berriesOnly;
   }
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean { 
 
-      if (!this.berriesOnly && target.isPlayer()) { // Wild Pokemon cannot knock off Player Pokemon's held items.
+      if (!this.berriesOnly && target.isPlayer()) { // "Wild Pokemon cannot knock off Player Pokemon's held items" (See Bulbapedia)
         return true;
       }
       
@@ -1506,8 +1508,10 @@ export class RemoveHeldItemAttr extends MoveEffectAttr {
         return false;
 
       // Considers entire transferrable item pool by default (Knock Off). Otherwise berries only if specified (Incinerate).
-      const heldItems = this.berriesOnly ? target.scene.findModifiers(m => m instanceof BerryModifier
-        && (m as BerryModifier).pokemonId === target.id, target.isPlayer()) as BerryModifier[] : this.getTargetHeldItems(target).filter(i => i.getTransferrable(false));
+      let heldItems = this.getTargetHeldItems(target).filter(i => i.getTransferrable(false));
+      if (this.berriesOnly) {
+        heldItems = heldItems.filter(m => m instanceof BerryModifier && (m as BerryModifier).pokemonId === target.id, target.isPlayer());
+      }
 
       if (heldItems.length) {
         const removedItem = heldItems[user.randSeedInt(heldItems.length)];

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1424,7 +1424,11 @@ export class PsychoShiftEffectAttr extends MoveEffectAttr {
     return !(this.selfTarget ? user : target).status && (this.selfTarget ? user : target).canSetStatus(user.status?.effect, true, false, user) ? Math.floor(move.chance * -0.1) : 0;
   }
 }
-
+/**
+ * The following needs to be implemented for Thief
+ * "If the user faints due to the target's Ability (Rough Skin or Iron Barbs) or held Rocky Helmet, it cannot remove the target's held item."
+ * "If Knock Off causes a Pokémon with the Sticky Hold Ability to faint, it can now remove that Pokémon's held item."
+ */
 export class StealHeldItemChanceAttr extends MoveEffectAttr {
   private chance: number;
 
@@ -1474,37 +1478,53 @@ export class StealHeldItemChanceAttr extends MoveEffectAttr {
   }
 }
 
+/**
+ * Removes a random held item (or berry) from target. 
+ * Used for Incinerate and Knock Off.
+ * Not Implemented Cases: (Same applies for Thief)
+ * "If the user faints due to the target's Ability (Rough Skin or Iron Barbs) or held Rocky Helmet, it cannot remove the target's held item."
+ * "If Knock Off causes a Pokémon with the Sticky Hold Ability to faint, it can now remove that Pokémon's held item."
+ */
 export class RemoveHeldItemAttr extends MoveEffectAttr {
-  private chance: number;
+  private berriesOnly: boolean; 
 
-  constructor(chance: number) {
+  constructor(berriesOnly: boolean) { // Optional restriction for item pool to berries only i.e. Differentiating Incinerate and Knock Off
     super(false, MoveEffectTrigger.HIT);
-    this.chance = chance;
+    this.berriesOnly = berriesOnly;
   }
 
-  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): Promise<boolean> {
-    return new Promise<boolean>(resolve => {
-      const rand = Phaser.Math.RND.realInRange(0, 1);
-      if (rand >= this.chance) {
-        return resolve(false);
-      }
-      const heldItems = this.getTargetHeldItems(target).filter(i => i.getTransferrable(false));
-      if (heldItems.length) {
-        const poolType = target.isPlayer() ? ModifierPoolType.PLAYER : target.hasTrainer() ? ModifierPoolType.TRAINER : ModifierPoolType.WILD;
-        const highestItemTier = heldItems.map(m => m.type.getOrInferTier(poolType)).reduce((highestTier, tier) => Math.max(tier, highestTier), 0);
-        const tierHeldItems = heldItems.filter(m => m.type.getOrInferTier(poolType) === highestItemTier);
-        const stolenItem = tierHeldItems[user.randSeedInt(tierHeldItems.length)];
-        user.scene.tryTransferHeldItemModifier(stolenItem, user, false).then(success => {
-          if (success) {
-            user.scene.queueMessage(getPokemonMessage(user, ` knocked off\n${target.name}'s ${stolenItem.type.name}!`));
-          }
-          resolve(success);
-        });
-        return;
-      }
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean { 
 
-      resolve(false);
-    });
+      if (!this.berriesOnly && target.isPlayer()) { // Wild Pokemon cannot knock off Player Pokemon's held items.
+        return true;
+      }
+      
+      const cancelled = new Utils.BooleanHolder(false);
+      applyAbAttrs(BlockItemTheftAbAttr, target, cancelled); // Check for abilities that block item theft
+
+      if(cancelled.value == true)
+        return false;
+
+      // Considers entire transferrable item pool by default (Knock Off). Otherwise berries only if specified (Incinerate).
+      const heldItems = this.berriesOnly ? target.scene.findModifiers(m => m instanceof BerryModifier
+        && (m as BerryModifier).pokemonId === target.id, target.isPlayer()) as BerryModifier[] : this.getTargetHeldItems(target).filter(i => i.getTransferrable(false));
+
+      if (heldItems.length) {
+        const removedItem = heldItems[user.randSeedInt(heldItems.length)];
+
+        // Decrease item amount and update icon
+        if (!--removedItem.stackCount) {
+          target.scene.removeModifier(removedItem, !target.isPlayer());
+        }
+        target.scene.updateModifiers(target.isPlayer());
+        
+        if (this.berriesOnly) {
+          user.scene.queueMessage(getPokemonMessage(user, ` incinerated\n${target.name}'s ${removedItem.type.name}!`));
+        } else {
+          user.scene.queueMessage(getPokemonMessage(user, ` knocked off\n${target.name}'s ${removedItem.type.name}!`));
+        }
+      }
+      return true;
   }
 
   getTargetHeldItems(target: Pokemon): PokemonHeldItemModifier[] {
@@ -2775,17 +2795,6 @@ export class PresentPowerAttr extends VariablePowerAttr {
     }
 
     return true;
-  }
-}
-
-export class KnockOffPowerAttr extends VariablePowerAttr {
-  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    if (target.getHeldItems().length > 0) {
-      (args[0] as Utils.NumberHolder).value *= 1.5;
-      return true;
-    }
-
-    return false;
   }
 }
 
@@ -5822,8 +5831,8 @@ export function initMoves() {
       .attr(AddBattlerTagAttr, BattlerTagType.DROWSY, false, true)
       .condition((user, target, move) => !target.status),
     new AttackMove(Moves.KNOCK_OFF, Type.DARK, MoveCategory.PHYSICAL, 65, 100, 20, -1, 0, 3)
-      .attr(KnockOffPowerAttr)
-      .partial(),
+      .attr(MovePowerMultiplierAttr, (user, target, move) => target.getHeldItems().filter(i => i.getTransferrable(false)).length > 0 ? 1.5 : 1)
+      .attr(RemoveHeldItemAttr, false),
     new AttackMove(Moves.ENDEAVOR, Type.NORMAL, MoveCategory.PHYSICAL, -1, 100, 5, -1, 0, 3)
       .attr(MatchHpAttr)
       .condition(failOnBossCondition),
@@ -6452,7 +6461,7 @@ export function initMoves() {
       .attr(ForceSwitchOutAttr),
     new AttackMove(Moves.INCINERATE, Type.FIRE, MoveCategory.SPECIAL, 60, 100, 15, -1, 0, 5)
       .target(MoveTarget.ALL_NEAR_ENEMIES)
-      .partial(),
+      .attr(RemoveHeldItemAttr, true),
     new StatusMove(Moves.QUASH, Type.DARK, 100, 15, -1, 0, 5)
       .unimplemented(),
     new AttackMove(Moves.ACROBATICS, Type.FLYING, MoveCategory.PHYSICAL, 55, 100, 15, -1, 0, 5)


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Closes #1715
* Primal weather can overwrite each other
* Primal weather ends upon switching out or fainting

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
They weren't working correctly before.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
If a primal weather was already in effect, it could not be overriden by another -> now it can
Primal weather would not revert upon Pokemon switching out or fainting -> now it does

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

https://github.com/pagefaultgames/pokerogue/assets/63990624/89cd747b-101d-4498-9263-75155b6cac7a


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Override abilities as Desolate Land, Primordial Sea, or Delta Stream.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?