### PR TITLE
[Bug] Curse should do at least 1 damage

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -1341,7 +1341,7 @@ export class CursedTag extends BattlerTag {
       applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, cancelled);
 
       if (!cancelled.value) {
-        pokemon.damageAndUpdate(Math.min(Math.floor(pokemon.getMaxHp() / 4), 1));
+        pokemon.damageAndUpdate(Math.max(Math.floor(pokemon.getMaxHp() / 4), 1));
         pokemon.scene.queueMessage(getPokemonMessage(pokemon, ` is hurt by the ${this.getMoveName()}!`));
       }
     }

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -1341,7 +1341,7 @@ export class CursedTag extends BattlerTag {
       applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, cancelled);
 
       if (!cancelled.value) {
-        pokemon.damageAndUpdate(Math.floor(pokemon.getMaxHp() / 4));
+        pokemon.damageAndUpdate(Math.min(Math.floor(pokemon.getMaxHp() / 4), 1));
         pokemon.scene.queueMessage(getPokemonMessage(pokemon, ` is hurt by the ${this.getMoveName()}!`));
       }
     }


### PR DESCRIPTION
## What are the changes?
Make curse do at least 1 damage

## Why am I doing these changes?
Shedinja takes no damage from curse currently

## What did change?
Added a Math.max

### Screenshots/Videos
Before
![](https://cdn.discordapp.com/attachments/1246595595758600242/1246595596001874021/Screenshot_2024-06-01_at_6.30.19_PM.png?ex=665d9ede&is=665c4d5e&hm=36b7fde33bd5b151a975eb0195b22f64a4674620256c15703b21ed5c502f06ee&)
After
![](https://cdn.discordapp.com/attachments/1176874654015684739/1246956357547069582/image.png?ex=665e461a&is=665cf49a&hm=886de7c61e935d4194d645db329daf429071a9a6b11a9bcfea308661a3eadec2&)

## How to test the changes?
Override a Shedinja for player Pokemon and give the Opponent curse and a ghost type

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?