### PR TITLE
[QoL] [duplicate] Dont roll pokeballs when you already have 99

### DIFF
--- a/src/data/pokeball.ts
+++ b/src/data/pokeball.ts
@@ -10,6 +10,8 @@ export enum PokeballType {
   LUXURY_BALL
 }
 
+export const MAX_PER_TYPE_POKEBALL_COUNT = 99;
+
 export function getPokeballAtlasKey(type: PokeballType): string {
   switch (type) {
   case PokeballType.POKEBALL:

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1233,7 +1233,7 @@ interface ModifierPool {
 const modifierPool: ModifierPool = {
   [ModifierTier.COMMON]: [
     new WeightedModifierType(modifierTypes.POKEBALL, (party: Pokemon[]) => {
-      return party[0].scene.pokeballCounts[PokeballType.POKEBALL] < MAX_PER_TYPE_POKEBALL_COUNT ? 6 : 0
+      return party[0].scene.pokeballCounts[PokeballType.POKEBALL] < MAX_PER_TYPE_POKEBALL_COUNT ? 6 : 0;
     }, 6),
     new WeightedModifierType(modifierTypes.RARE_CANDY, 2),
     new WeightedModifierType(modifierTypes.POTION, (party: Pokemon[]) => {
@@ -1261,8 +1261,8 @@ const modifierPool: ModifierPool = {
   }),
   [ModifierTier.GREAT]: [
     new WeightedModifierType(modifierTypes.GREAT_BALL, (party: Pokemon[]) => {
-      return party[0].scene.pokeballCounts[PokeballType.GREAT_BALL] < MAX_PER_TYPE_POKEBALL_COUNT ? 6 : 0
-    }),
+      return party[0].scene.pokeballCounts[PokeballType.GREAT_BALL] < MAX_PER_TYPE_POKEBALL_COUNT ? 6 : 0;
+    }, 6),
     new WeightedModifierType(modifierTypes.FULL_HEAL, (party: Pokemon[]) => {
       const statusEffectPartyMemberCount = Math.min(party.filter(p => p.hp && !!p.status && !p.getHeldItems().some(i => {
         if (i instanceof Modifiers.TurnStatusEffectModifier) {
@@ -1332,7 +1332,7 @@ const modifierPool: ModifierPool = {
   }),
   [ModifierTier.ULTRA]: [
     new WeightedModifierType(modifierTypes.ULTRA_BALL, (party: Pokemon[]) => {
-      return party[0].scene.pokeballCounts[PokeballType.ULTRA_BALL] < MAX_PER_TYPE_POKEBALL_COUNT ? 24 : 0
+      return party[0].scene.pokeballCounts[PokeballType.ULTRA_BALL] < MAX_PER_TYPE_POKEBALL_COUNT ? 24 : 0;
     }, 24),
     new WeightedModifierType(modifierTypes.MAX_LURE, 4),
     new WeightedModifierType(modifierTypes.BIG_NUGGET, 12),
@@ -1371,7 +1371,7 @@ const modifierPool: ModifierPool = {
   }),
   [ModifierTier.ROGUE]: [
     new WeightedModifierType(modifierTypes.ROGUE_BALL, (party: Pokemon[]) => {
-      return party[0].scene.pokeballCounts[PokeballType.ROGUE_BALL] < MAX_PER_TYPE_POKEBALL_COUNT ? 24 : 0
+      return party[0].scene.pokeballCounts[PokeballType.ROGUE_BALL] < MAX_PER_TYPE_POKEBALL_COUNT ? 24 : 0;
     }, 24),
     new WeightedModifierType(modifierTypes.RELIC_GOLD, 2),
     new WeightedModifierType(modifierTypes.LEFTOVERS, 3),
@@ -1396,7 +1396,7 @@ const modifierPool: ModifierPool = {
   }),
   [ModifierTier.MASTER]: [
     new WeightedModifierType(modifierTypes.MASTER_BALL, (party: Pokemon[]) => {
-      return party[0].scene.pokeballCounts[PokeballType.MASTER_BALL] < MAX_PER_TYPE_POKEBALL_COUNT ? 24 : 0
+      return party[0].scene.pokeballCounts[PokeballType.MASTER_BALL] < MAX_PER_TYPE_POKEBALL_COUNT ? 24 : 0;
     }, 24),
     new WeightedModifierType(modifierTypes.SHINY_CHARM, 14),
     new WeightedModifierType(modifierTypes.HEALING_CHARM, 18),

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -2,7 +2,7 @@ import * as Modifiers from "./modifier";
 import { AttackMove, allMoves } from "../data/move";
 import { Moves } from "../data/enums/moves";
 import { Abilities } from "../data/enums/abilities";
-import { PokeballType, getPokeballCatchMultiplier, getPokeballName } from "../data/pokeball";
+import { MAX_PER_TYPE_POKEBALL_COUNT, PokeballType, getPokeballCatchMultiplier, getPokeballName } from "../data/pokeball";
 import Pokemon, { EnemyPokemon, PlayerPokemon, PokemonMove } from "../field/pokemon";
 import { EvolutionItem, pokemonEvolutions } from "../data/pokemon-evolutions";
 import { Stat, getStatName } from "../data/pokemon-stat";
@@ -1232,7 +1232,9 @@ interface ModifierPool {
 
 const modifierPool: ModifierPool = {
   [ModifierTier.COMMON]: [
-    new WeightedModifierType(modifierTypes.POKEBALL, 6),
+    new WeightedModifierType(modifierTypes.POKEBALL, (party: Pokemon[]) => {
+      return party[0].scene.pokeballCounts[PokeballType.POKEBALL] < MAX_PER_TYPE_POKEBALL_COUNT ? 6 : 0
+    }, 6),
     new WeightedModifierType(modifierTypes.RARE_CANDY, 2),
     new WeightedModifierType(modifierTypes.POTION, (party: Pokemon[]) => {
       const thresholdPartyMemberCount = Math.min(party.filter(p => (p.getInverseHp() >= 10 || p.getHpRatio() <= 0.875) && !p.isFainted()).length, 3);
@@ -1258,7 +1260,9 @@ const modifierPool: ModifierPool = {
     m.setTier(ModifierTier.COMMON); return m;
   }),
   [ModifierTier.GREAT]: [
-    new WeightedModifierType(modifierTypes.GREAT_BALL, 6),
+    new WeightedModifierType(modifierTypes.GREAT_BALL, (party: Pokemon[]) => {
+      return party[0].scene.pokeballCounts[PokeballType.GREAT_BALL] < MAX_PER_TYPE_POKEBALL_COUNT ? 6 : 0
+    }),
     new WeightedModifierType(modifierTypes.FULL_HEAL, (party: Pokemon[]) => {
       const statusEffectPartyMemberCount = Math.min(party.filter(p => p.hp && !!p.status && !p.getHeldItems().some(i => {
         if (i instanceof Modifiers.TurnStatusEffectModifier) {
@@ -1327,7 +1331,9 @@ const modifierPool: ModifierPool = {
     m.setTier(ModifierTier.GREAT); return m;
   }),
   [ModifierTier.ULTRA]: [
-    new WeightedModifierType(modifierTypes.ULTRA_BALL, 24),
+    new WeightedModifierType(modifierTypes.ULTRA_BALL, (party: Pokemon[]) => {
+      return party[0].scene.pokeballCounts[PokeballType.ULTRA_BALL] < MAX_PER_TYPE_POKEBALL_COUNT ? 24 : 0
+    }, 24),
     new WeightedModifierType(modifierTypes.MAX_LURE, 4),
     new WeightedModifierType(modifierTypes.BIG_NUGGET, 12),
     new WeightedModifierType(modifierTypes.PP_UP, 9),
@@ -1364,7 +1370,9 @@ const modifierPool: ModifierPool = {
     m.setTier(ModifierTier.ULTRA); return m;
   }),
   [ModifierTier.ROGUE]: [
-    new WeightedModifierType(modifierTypes.ROGUE_BALL, 24),
+    new WeightedModifierType(modifierTypes.ROGUE_BALL, (party: Pokemon[]) => {
+      return party[0].scene.pokeballCounts[PokeballType.ROGUE_BALL] < MAX_PER_TYPE_POKEBALL_COUNT ? 24 : 0
+    }, 24),
     new WeightedModifierType(modifierTypes.RELIC_GOLD, 2),
     new WeightedModifierType(modifierTypes.LEFTOVERS, 3),
     new WeightedModifierType(modifierTypes.SHELL_BELL, 3),
@@ -1387,7 +1395,9 @@ const modifierPool: ModifierPool = {
     m.setTier(ModifierTier.ROGUE); return m;
   }),
   [ModifierTier.MASTER]: [
-    new WeightedModifierType(modifierTypes.MASTER_BALL, 24),
+    new WeightedModifierType(modifierTypes.MASTER_BALL, (party: Pokemon[]) => {
+      return party[0].scene.pokeballCounts[PokeballType.MASTER_BALL] < MAX_PER_TYPE_POKEBALL_COUNT ? 24 : 0
+    }, 24),
     new WeightedModifierType(modifierTypes.SHINY_CHARM, 14),
     new WeightedModifierType(modifierTypes.HEALING_CHARM, 18),
     new WeightedModifierType(modifierTypes.MULTI_LENS, 18),

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -2,7 +2,7 @@ import * as ModifierTypes from "./modifier-type";
 import { LearnMovePhase, LevelUpPhase, PokemonHealPhase } from "../phases";
 import BattleScene from "../battle-scene";
 import { getLevelTotalExp } from "../data/exp";
-import { PokeballType } from "../data/pokeball";
+import { MAX_PER_TYPE_POKEBALL_COUNT, PokeballType } from "../data/pokeball";
 import Pokemon, { PlayerPokemon } from "../field/pokemon";
 import { Stat } from "../data/pokemon-stat";
 import { addTextObject, TextStyle } from "../ui/text";
@@ -235,7 +235,7 @@ export class AddPokeballModifier extends ConsumableModifier {
 
   apply(args: any[]): boolean {
     const pokeballCounts = (args[0] as BattleScene).pokeballCounts;
-    pokeballCounts[this.pokeballType] = Math.min(pokeballCounts[this.pokeballType] + this.count, 99);
+    pokeballCounts[this.pokeballType] = Math.min(pokeballCounts[this.pokeballType] + this.count, MAX_PER_TYPE_POKEBALL_COUNT);
 
     return true;
   }


### PR DESCRIPTION
I didn't notice there was a PR doing something similar at https://github.com/pagefaultgames/pokerogue/pull/1677
My PR is the duplicate, but I am leaving it just in case the team prefers to go for this implementation
I will close the PR if https://github.com/pagefaultgames/pokerogue/pull/1677 is merged.

## What are the changes?

Inspired by https://github.com/pagefaultgames/pokerogue/pull/1474, prevent giving the player useless picks. 
Whenever the player has 99 pokeballs. The item reward may roll more pokeballs eventhough the player can not hold more of them. This change aims to avoid giving the player useless items

## Why am I doing these changes?
QoL change, if a player is rerolling items to find a specific one they shouldnt be suggested useless picks.

## Testes scenarios
- [x] Player with less than 99 pokeballs can roll the item
- [x] Player with mote than 99 pokeballs cannot roll the item

## What did change?
Modified the weight function for all Pokeball types.

### Screenshots/Videos

**Before**
If player had 99 pokeballs and they roll the item, they continue with 99 pokeballs.

https://github.com/pagefaultgames/pokerogue/assets/31145813/4195934f-f153-4101-bae2-f4f41666ade1

**After**
Player with <=98 pokeballs can roll the item

https://github.com/pagefaultgames/pokerogue/assets/31145813/4139451c-0644-44b6-a0da-8b0c1bb036a0

Player with 99 pokeball cannot roll the item

https://github.com/pagefaultgames/pokerogue/assets/31145813/a87c1a72-e98c-47bb-b5c4-fada8560c36c

## How to test the changes?
```ts overrides.ts
export const STARTING_MONEY_OVERRIDE: integer = 1_000_000_000_00;
export const POKEBALL_OVERRIDE: { active: boolean, pokeballs: PokeballCounts } = {
  active: true,
  pokeballs: {
    [PokeballType.POKEBALL]: 99,
    [PokeballType.GREAT_BALL]: 0,
    [PokeballType.ULTRA_BALL]: 0,
    [PokeballType.ROGUE_BALL]: 0,
    [PokeballType.MASTER_BALL]: 0,
  }
};

```
## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?