### PR TITLE
Feature: Add Ability Capsule Item

### DIFF
--- a/src/locales/de/modifier-type.ts
+++ b/src/locales/de/modifier-type.ts
@@ -48,6 +48,10 @@ export const modifierType: ModifierTypeTranslationEntries = {
       name: "{{natureName}} Minze",
       description: "Ändert das Wesen zu {{natureName}}. Schaltet dieses Wesen permanent für diesen Starter frei.",
     },
+    "PokemonAbilityChangeModifierType": {
+      "name": "Ability Capsule",
+      "description": "A capsule that allows a Pokémon to switch its current Ability to the other Ability its species can have."
+    },
     "DoubleBattleChanceBoosterModifierType": {
       description: "Verdoppelt die Wahrscheinlichkeit, dass die nächsten {{battleCount}} Begegnungen mit wilden Pokémon ein Doppelkampf sind.",
     },

--- a/src/locales/en/modifier-type.ts
+++ b/src/locales/en/modifier-type.ts
@@ -48,6 +48,10 @@ export const modifierType: ModifierTypeTranslationEntries = {
       name: "{{natureName}} Mint",
       description: "Changes a Pokémon's nature to {{natureName}} and permanently unlocks the nature for the starter.",
     },
+    "PokemonAbilityChangeModifierType": {
+      "name": "Ability Capsule",
+      "description": "A capsule that allows a Pokémon to switch its current Ability to the other Ability its species can have."
+    },
     "DoubleBattleChanceBoosterModifierType": {
       description: "Doubles the chance of an encounter being a double battle for {{battleCount}} battles",
     },

--- a/src/locales/es/modifier-type.ts
+++ b/src/locales/es/modifier-type.ts
@@ -48,6 +48,10 @@ export const modifierType: ModifierTypeTranslationEntries = {
       name: "Menta {{natureName}}",
       description: "Cambia la naturaleza de un Pokémon a {{natureName}} y desbloquea permanentemente dicha naturaleza para el inicial",
     },
+    "PokemonAbilityChangeModifierType": {
+      "name": "Ability Capsule",
+      "description": "A capsule that allows a Pokémon to switch its current Ability to the other Ability its species can have."
+    },
     "DoubleBattleChanceBoosterModifierType": {
       description: "Duplica la posibilidad de que un encuentro sea una combate doble durante {{battleCount}} combates",
     },

--- a/src/locales/fr/modifier-type.ts
+++ b/src/locales/fr/modifier-type.ts
@@ -48,6 +48,10 @@ export const modifierType: ModifierTypeTranslationEntries = {
       name: "Aromate {{natureName}}",
 	  description: "Donne la nature {{natureName}} à un Pokémon et la débloque pour le starter lui étant lié.",
     },
+    "PokemonAbilityChangeModifierType": {
+      "name": "Ability Capsule",
+      "description": "A capsule that allows a Pokémon to switch its current Ability to the other Ability its species can have."
+    },
     "DoubleBattleChanceBoosterModifierType": {
 	  description: "Double les chances de tomber sur un combat double pendant {{battleCount}} combats",
     },

--- a/src/locales/it/modifier-type.ts
+++ b/src/locales/it/modifier-type.ts
@@ -48,6 +48,10 @@ export const modifierType: ModifierTypeTranslationEntries = {
       name: "Menta {{natureName}}",
       description: "Cambia la natura del Pokémon in {{natureName}} e sblocca la natura per il Pokémon iniziale",
     },
+    "PokemonAbilityChangeModifierType": {
+      "name": "Ability Capsule",
+      "description": "A capsule that allows a Pokémon to switch its current Ability to the other Ability its species can have."
+    },
     "DoubleBattleChanceBoosterModifierType": {
       description: "Raddoppia la possibilità di imbattersi in doppie battaglie per {{battleCount}} battaglie",
     },

--- a/src/locales/ko/modifier-type.ts
+++ b/src/locales/ko/modifier-type.ts
@@ -48,6 +48,10 @@ export const modifierType: ModifierTypeTranslationEntries = {
       name: "{{natureName}}민트",
       description: "포켓몬의 성격을 {{natureName}}(으)로 바꾸고 스타팅에도 등록한다.",
     },
+    "PokemonAbilityChangeModifierType": {
+      "name": "Ability Capsule",
+      "description": "A capsule that allows a Pokémon to switch its current Ability to the other Ability its species can have."
+    },
     "DoubleBattleChanceBoosterModifierType": {
       description: "{{battleCount}}번의 배틀 동안 더블 배틀이 등장할 확률 두 배",
     },

--- a/src/locales/pt_BR/modifier-type.ts
+++ b/src/locales/pt_BR/modifier-type.ts
@@ -48,6 +48,10 @@ export const modifierType: ModifierTypeTranslationEntries = {
       name: "Hortelã {{natureName}}",
       description: "Muda a natureza de um Pokémon para {{natureName}} e a desbloqueia permanentemente para seu inicial",
     },
+    "PokemonAbilityChangeModifierType": {
+      "name": "Ability Capsule",
+      "description": "A capsule that allows a Pokémon to switch its current Ability to the other Ability its species can have."
+    },
     "DoubleBattleChanceBoosterModifierType": {
       description: "Dobra as chances de encontrar uma batalha em dupla por {{battleCount}} batalhas",
     },

--- a/src/locales/zh_CN/modifier-type.ts
+++ b/src/locales/zh_CN/modifier-type.ts
@@ -48,6 +48,10 @@ export const modifierType: ModifierTypeTranslationEntries = {
       name: "{{natureName}}薄荷",
       description: "将一只宝可梦的性格改为{{natureName}}并为该宝可\n梦永久解锁该性格.",
     },
+    "PokemonAbilityChangeModifierType": {
+      "name": "Ability Capsule",
+      "description": "A capsule that allows a Pokémon to switch its current Ability to the other Ability its species can have."
+    },
     "DoubleBattleChanceBoosterModifierType": {
       description: "接下来的{{battleCount}}场战斗是双打的概率翻倍",
     },

--- a/src/locales/zh_TW/modifier-type.ts
+++ b/src/locales/zh_TW/modifier-type.ts
@@ -48,6 +48,10 @@ export const modifierType: ModifierTypeTranslationEntries = {
       description:
                 "將一隻寶可夢的性格改爲{{natureName}}併爲該寶可\n夢永久解鎖該性格.",
     },
+    PokemonAbilityChangeModifierType: {
+      "name": "Ability Capsule",
+      "description": "A capsule that allows a Pokémon to switch its current Ability to the other Ability its species can have."
+    },
     DoubleBattleChanceBoosterModifierType: {
       description: "接下來的{{battleCount}}場戰鬥是雙打的概率翻倍",
     },

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -397,6 +397,26 @@ export class PokemonNatureChangeModifierType extends PokemonModifierType {
   }
 }
 
+export class PokemonAbilityChangeModifierType extends PokemonModifierType {
+  constructor() {
+    super("", "ability_capsule", ((_type, args) => new Modifiers.PokemonAbilityChangeModifier(this, (args[0] as PlayerPokemon).id)),
+      ((pokemon: PlayerPokemon) => {
+        if (pokemon.abilityIndex === 0 && pokemon.species.ability2 === Abilities.NONE) {
+          return PartyUiHandler.NoEffectMessage;
+        }
+        return null;
+      }), "ability");
+  }
+
+  get name(): string {
+    return i18next.t("modifierType:ModifierType.PokemonAbilityChangeModifierType.name");
+  }
+
+  getDescription(scene: BattleScene): string {
+    return i18next.t("modifierType:ModifierType.PokemonAbilityChangeModifierType.description");
+  }
+}
+
 export class RememberMoveModifierType extends PokemonModifierType {
   constructor(localeKey: string, iconImage: string, group?: string) {
     super(localeKey, iconImage, (type, args) => new Modifiers.RememberMoveModifier(type, (args[0] as PlayerPokemon).id, (args[1] as integer)),
@@ -1105,6 +1125,10 @@ export const modifierTypes = {
     return new PokemonNatureChangeModifierType(Utils.randSeedInt(Utils.getEnumValues(Nature).length) as Nature);
   }),
 
+  ABILITY_CAPSULE: () => new ModifierTypeGenerator((party: Pokemon[], pregenArgs?: any[]) => {
+    return new PokemonAbilityChangeModifierType();
+  }),
+
   TERA_SHARD: () => new ModifierTypeGenerator((party: Pokemon[], pregenArgs?: any[]) => {
     if (pregenArgs) {
       return new TerastallizeModifierType(pregenArgs[0] as Type);
@@ -1373,6 +1397,12 @@ const modifierPool: ModifierPool = {
     new WeightedModifierType(modifierTypes.BATON, 2),
     new WeightedModifierType(modifierTypes.SOUL_DEW, 8),
     //new WeightedModifierType(modifierTypes.OVAL_CHARM, 6),
+    new WeightedModifierType(modifierTypes.ABILITY_CAPSULE, (party: Pokemon[]) => {
+      // Capsule is not useable if you are on ability1 with no ability2
+      const usable = party.some(pokemon => !(pokemon.abilityIndex === 0 && pokemon.species.ability2 === Abilities.NONE));
+      console.log(usable);
+      return usable ? 4 : 0;
+    }),
     new WeightedModifierType(modifierTypes.SOOTHE_BELL, 4),
     new WeightedModifierType(modifierTypes.ABILITY_CHARM, 6),
     new WeightedModifierType(modifierTypes.FOCUS_BAND, 5),

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -21,6 +21,7 @@ import { Nature } from "#app/data/nature";
 import { BattlerTagType } from "#app/data/enums/battler-tag-type";
 import * as Overrides from "../overrides";
 import { ModifierType, modifierTypes } from "./modifier-type";
+import { Abilities } from "#app/data/enums/abilities.js";
 
 export type ModifierPredicate = (modifier: Modifier) => boolean;
 
@@ -1229,6 +1230,41 @@ export class PokemonNatureChangeModifier extends ConsumablePokemonModifier {
     while (pokemonPrevolutions.hasOwnProperty(speciesId)) {
       speciesId = pokemonPrevolutions[speciesId];
       pokemon.scene.gameData.dexData[speciesId].natureAttr |= Math.pow(2, this.nature + 1);
+    }
+
+    return true;
+  }
+}
+
+export class PokemonAbilityChangeModifier extends ConsumablePokemonModifier {
+
+  constructor(type: ModifierType, pokemonId: integer) {
+    super(type, pokemonId);
+  }
+
+  apply(args: any[]): boolean {
+    const pokemon = args[0] as Pokemon;
+    let newAbilityIndex = 0;
+    if (pokemon.abilityIndex === 2) {
+      const maxAbilityIndex = pokemon.species.ability2 !== Abilities.NONE ? 2 : 1;
+      newAbilityIndex = Utils.randIntRange(0, maxAbilityIndex);
+    } else if (pokemon.abilityIndex === 0) {
+      newAbilityIndex = 1;
+    } else {
+      newAbilityIndex = 0;
+    }
+    pokemon.abilityIndex = newAbilityIndex;
+    let speciesId = pokemon.species.speciesId;
+
+    if (pokemon.scene.gameData.starterData[speciesId]?.abilityAttr) {
+      pokemon.scene.gameData.starterData[speciesId].abilityAttr |= Math.pow(2, newAbilityIndex);
+    }
+
+    while (pokemonPrevolutions.hasOwnProperty(speciesId)) {
+      speciesId = pokemonPrevolutions[speciesId];
+      if (pokemon.scene.gameData.starterData[speciesId]?.abilityAttr) {
+        pokemon.scene.gameData.starterData[speciesId].abilityAttr |= Math.pow(2, newAbilityIndex);
+      }
     }
 
     return true;


### PR DESCRIPTION
## What are the changes?
Ability Capsule - an item that allows you to swap basic abilities of a Pokemon. If you have a Pokemon's first ability, you'll get its second. If you have its second, you get its first. If you have a Pokemon's hidden ability, you randomly get either their first or second ability. If a Pokemon has their first ability and does not have their second ability, it won't work.

## Why am I doing these changes?
Ability Capsule has been an item in mainline games for awhile and it's missing in PokeRogue so I figured I would add it. Also, it's pretty nice to be able to unlock/swap abilities similar to how mints actively work right now.

## What did change?
New item added to `modifier-type.ts` in the Rogue section called Ability Capsule as well as a new function in `modifier.ts` which swaps your ability to the other basic ability index if possible, and unlocks it for starters of that Pokemon's species.

### Screenshots/Videos
Different language works correctly (obviously text is different in this PR but was to show it is working)

https://github.com/pagefaultgames/pokerogue/assets/85713900/530b2db3-d069-41e9-8b04-dec66f2cf2ea

Ability changing on a 2 stage evo and being saved to starter

https://github.com/pagefaultgames/pokerogue/assets/85713900/68a72e4c-904e-43f7-8271-51aa3419b943

Ability changing on a Gmax Pokemon and being saved as starter data

https://github.com/pagefaultgames/pokerogue/assets/85713900/dbcf33b5-45b8-44da-8331-6cccc60734dd

Hidden Ability swapping to Ability 1 and being saved

https://github.com/pagefaultgames/pokerogue/assets/85713900/cb3e3488-f344-42ab-ac80-8a26a907581d

Hidden Ability swapping to Ability 1 while in Mega and Mega ability being the same

https://github.com/pagefaultgames/pokerogue/assets/85713900/9bf19221-95c5-4573-b092-b2f79999eb6c

Hidden Ability swapping to Ability 2 while in Mega and Mega ability being the same

https://github.com/pagefaultgames/pokerogue/assets/85713900/4d1594a5-7d64-4c3d-bbb4-0929e8227a03

Updates multiple starters ability just in case that is applicable (Pikachu/Pichu, Hitmonchan/Hitmontop, etc.)

https://github.com/pagefaultgames/pokerogue/assets/85713900/10f5ddad-cc48-410f-9631-cbf71f8395a6

Doesn't work when you only have one ability

https://github.com/pagefaultgames/pokerogue/assets/85713900/2db65aa4-4663-413c-b8ba-c1b37c249fcf

Can't roll it when no one in your party meets the criteria (or I am the luckiest human alive)

https://github.com/pagefaultgames/pokerogue/assets/85713900/6e98c18a-0755-4ffd-b4a7-9dedf39f1166

Swapping between Ability 1 and Ability 2

https://github.com/pagefaultgames/pokerogue/assets/85713900/973124da-4c0d-4ee5-93f0-a24420dcf68f


## How to test the changes?
Pull this branch and add it ability capsule as a common tier item to `modifier-type.ts` or to `overrides.ts` if you know how.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?