### PR TITLE
[Bug] Fixed primal weather interaction.

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -1870,22 +1870,35 @@ export class PreSwitchOutClearWeatherAbAttr extends PreSwitchOutAbAttr {
    * @returns {boolean} Returns true if the weather clears, otherwise false.
    */
   applyPreSwitchOut(pokemon: Pokemon, passive: boolean, args: any[]): boolean | Promise<boolean> {
-    const abilities: Abilities[] = [pokemon.getAbility().id, pokemon.getPassiveAbility().id];
     const weatherType = pokemon.scene.arena.weather.weatherType;
+    let turnOffWeather = false;
 
-    // Clear weather if ability matches weather and if no one else has the ability
-    abilities.forEach((ab) => {
-      if ((ab === Abilities.DESOLATE_LAND && weatherType === WeatherType.HARSH_SUN) ||
-      (ab === Abilities.PRIMORDIAL_SEA && weatherType === WeatherType.HEAVY_RAIN) ||
-      (ab === Abilities.DELTA_STREAM && weatherType === WeatherType.STRONG_WINDS)) {
-
-        // Besides the user, check if another has the ability on the field.
-        if (pokemon.scene.getField(true).filter(p => p !== pokemon).filter(p => p.hasAbility(ab)).length === 0) {
-          pokemon.scene.arena.trySetWeather(WeatherType.NONE, false);
-          return true;
-        }
+    // Clear weather only if user's ability matches the weather and no other pokemon has the ability.
+    switch (weatherType) {
+    case (WeatherType.HARSH_SUN):
+      if (pokemon.hasAbility(Abilities.DESOLATE_LAND)
+          && pokemon.scene.getField(true).filter(p => p !== pokemon).filter(p => p.hasAbility(Abilities.DESOLATE_LAND)).length === 0) {
+        turnOffWeather = true;
       }
-    });
+      break;
+    case (WeatherType.HEAVY_RAIN):
+      if (pokemon.hasAbility(Abilities.PRIMORDIAL_SEA)
+          && pokemon.scene.getField(true).filter(p => p !== pokemon).filter(p => p.hasAbility(Abilities.PRIMORDIAL_SEA)).length === 0) {
+        turnOffWeather = true;
+      }
+      break;
+    case (WeatherType.STRONG_WINDS):
+      if (pokemon.hasAbility(Abilities.DELTA_STREAM)
+          && pokemon.scene.getField(true).filter(p => p !== pokemon).filter(p => p.hasAbility(Abilities.DELTA_STREAM)).length === 0) {
+        turnOffWeather = true;
+      }
+      break;
+    }
+
+    if (turnOffWeather) {
+      pokemon.scene.arena.trySetWeather(WeatherType.NONE, false);
+      return true;
+    }
 
     return false;
   }
@@ -3032,22 +3045,35 @@ export class PostFaintClearWeatherAbAttr extends PostFaintAbAttr {
    * @returns {boolean} Returns true if the weather clears, otherwise false.
    */
   applyPostFaint(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: PokemonMove, hitResult: HitResult, args: any[]): boolean {
-    const abilities: Abilities[] = [pokemon.getAbility().id, pokemon.getPassiveAbility().id];
     const weatherType = pokemon.scene.arena.weather.weatherType;
+    let turnOffWeather = false;
 
-    // Clear weather if ability matches weather and if no one else has the ability
-    abilities.forEach((ab) => {
-      if ((ab === Abilities.DESOLATE_LAND && weatherType === WeatherType.HARSH_SUN) ||
-      (ab === Abilities.PRIMORDIAL_SEA && weatherType === WeatherType.HEAVY_RAIN) ||
-      (ab === Abilities.DELTA_STREAM && weatherType === WeatherType.STRONG_WINDS)) {
-
-        // Besides the user, check if another has the ability on the field.
-        if (pokemon.scene.getField(true).filter(p => p.hasAbility(ab)).length === 0) {
-          pokemon.scene.arena.trySetWeather(WeatherType.NONE, false);
-          return true;
-        }
+    // Clear weather only if user's ability matches the weather and no other pokemon has the ability.
+    switch (weatherType) {
+    case (WeatherType.HARSH_SUN):
+      if (pokemon.hasAbility(Abilities.DESOLATE_LAND)
+          && pokemon.scene.getField(true).filter(p => p.hasAbility(Abilities.DESOLATE_LAND)).length === 0) {
+        turnOffWeather = true;
       }
-    });
+      break;
+    case (WeatherType.HEAVY_RAIN):
+      if (pokemon.hasAbility(Abilities.PRIMORDIAL_SEA)
+          && pokemon.scene.getField(true).filter(p => p.hasAbility(Abilities.PRIMORDIAL_SEA)).length === 0) {
+        turnOffWeather = true;
+      }
+      break;
+    case (WeatherType.STRONG_WINDS):
+      if (pokemon.hasAbility(Abilities.DELTA_STREAM)
+          && pokemon.scene.getField(true).filter(p => p.hasAbility(Abilities.DELTA_STREAM)).length === 0) {
+        turnOffWeather = true;
+      }
+      break;
+    }
+
+    if (turnOffWeather) {
+      pokemon.scene.arena.trySetWeather(WeatherType.NONE, false);
+      return true;
+    }
 
     return false;
   }

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -1728,8 +1728,8 @@ export class PostSummonWeatherChangeAbAttr extends PostSummonAbAttr {
   }
 
   applyPostSummon(pokemon: Pokemon, passive: boolean, args: any[]): boolean {
-    if ((this.weatherType as WeatherType === WeatherType.HEAVY_RAIN ||
-      this.weatherType as WeatherType === WeatherType.HARSH_SUN ||
+    if ((this.weatherType === WeatherType.HEAVY_RAIN ||
+      this.weatherType === WeatherType.HARSH_SUN ||
       this.weatherType === WeatherType.STRONG_WINDS) || !pokemon.scene.arena.weather?.isImmutable()) {
       return pokemon.scene.arena.trySetWeather(this.weatherType, true);
     }
@@ -1862,21 +1862,31 @@ export class PreSwitchOutResetStatusAbAttr extends PreSwitchOutAbAttr {
  * Clears Desolate Land/Primordial Sea/Delta Stream upon the Pokemon switching out.
  */
 export class PreSwitchOutClearWeatherAbAttr extends PreSwitchOutAbAttr {
+
+  /**
+   * @param pokemon The {@linkcode Pokemon} with the ability
+   * @param passive N/A
+   * @param args N/A
+   * @returns {boolean} Returns true if the weather clears, otherwise false.
+   */
   applyPreSwitchOut(pokemon: Pokemon, passive: boolean, args: any[]): boolean | Promise<boolean> {
-    const currentAbility = pokemon.getAbility().id;
+    const abilities: Abilities[] = [pokemon.getAbility().id, pokemon.getPassiveAbility().id];
     const weatherType = pokemon.scene.arena.weather.weatherType;
 
     // Clear weather if ability matches weather and if no one else has the ability
-    if ((currentAbility === Abilities.DESOLATE_LAND && weatherType === WeatherType.HARSH_SUN) ||
-    (currentAbility === Abilities.PRIMORDIAL_SEA && weatherType === WeatherType.HEAVY_RAIN) ||
-    (currentAbility === Abilities.DESOLATE_LAND && weatherType === WeatherType.HARSH_SUN)) {
+    abilities.forEach((ab) => {
+      if ((ab === Abilities.DESOLATE_LAND && weatherType === WeatherType.HARSH_SUN) ||
+      (ab === Abilities.PRIMORDIAL_SEA && weatherType === WeatherType.HEAVY_RAIN) ||
+      (ab === Abilities.DELTA_STREAM && weatherType === WeatherType.STRONG_WINDS)) {
 
-      // Besides the user, check if another has the ability on the field.
-      if (pokemon.scene.getField(true).filter(p => p !== pokemon).filter(p => p.hasAbility(currentAbility)).length === 0) {
-        pokemon.scene.arena.trySetWeather(WeatherType.NONE, false);
-        return true;
+        // Besides the user, check if another has the ability on the field.
+        if (pokemon.scene.getField(true).filter(p => p !== pokemon).filter(p => p.hasAbility(ab)).length === 0) {
+          pokemon.scene.arena.trySetWeather(WeatherType.NONE, false);
+          return true;
+        }
       }
-    }
+    });
+
     return false;
   }
 }
@@ -3011,21 +3021,34 @@ export class PostFaintAbAttr extends AbAttr {
  * Clears Desolate Land/Primordial Sea/Delta Stream upon the Pokemon fainting
  */
 export class PostFaintClearWeatherAbAttr extends PostFaintAbAttr {
+
+  /**
+   * @param pokemon The {@linkcode Pokemon} with the ability
+   * @param passive N/A
+   * @param attacker N/A
+   * @param move N/A
+   * @param hitResult N/A
+   * @param args N/A
+   * @returns {boolean} Returns true if the weather clears, otherwise false.
+   */
   applyPostFaint(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: PokemonMove, hitResult: HitResult, args: any[]): boolean {
-    const currentAbility = pokemon.getAbility().id;
+    const abilities: Abilities[] = [pokemon.getAbility().id, pokemon.getPassiveAbility().id];
     const weatherType = pokemon.scene.arena.weather.weatherType;
 
     // Clear weather if ability matches weather and if no one else has the ability
-    if ((currentAbility === Abilities.DESOLATE_LAND && weatherType === WeatherType.HARSH_SUN) ||
-    (currentAbility === Abilities.PRIMORDIAL_SEA && weatherType === WeatherType.HEAVY_RAIN) ||
-    (currentAbility === Abilities.DESOLATE_LAND && weatherType === WeatherType.HARSH_SUN)) {
+    abilities.forEach((ab) => {
+      if ((ab === Abilities.DESOLATE_LAND && weatherType === WeatherType.HARSH_SUN) ||
+      (ab === Abilities.PRIMORDIAL_SEA && weatherType === WeatherType.HEAVY_RAIN) ||
+      (ab === Abilities.DELTA_STREAM && weatherType === WeatherType.STRONG_WINDS)) {
 
-      // Besides the user, check if another has the ability on the field.
-      if (pokemon.scene.getField(true).filter(p => p.hasAbility(currentAbility)).length === 0) {
-        pokemon.scene.arena.trySetWeather(WeatherType.NONE, false);
-        return true;
+        // Besides the user, check if another has the ability on the field.
+        if (pokemon.scene.getField(true).filter(p => p.hasAbility(ab)).length === 0) {
+          pokemon.scene.arena.trySetWeather(WeatherType.NONE, false);
+          return true;
+        }
       }
-    }
+    });
+
     return false;
   }
 }


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Closes #1715
* Primal weather can overwrite each other
* Primal weather ends upon switching out or fainting

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Interactions weren't working before.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
If a primal weather was already in effect, it could not be overriden by another -> now it can
Primal weather would not revert upon Pokemon switching out or fainting -> now it does

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

https://github.com/pagefaultgames/pokerogue/assets/63990624/68eb7021-59a7-48ea-802a-5692f72bb95c


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Override ability to Desolate Land, Primordial Sea, or Delta Stream.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?