### PR TITLE
Implement Pity System

### DIFF
--- a/src/egg-hatch-phase.ts
+++ b/src/egg-hatch-phase.ts
@@ -497,10 +497,17 @@ export class EggHatchPhase extends Phase {
 
         const ignoredSpecies = [ Species.PHIONE, Species.MANAPHY, Species.ETERNATUS ];
 
-        const speciesPool = Object.keys(speciesStarters)
+        let speciesPool = Object.keys(speciesStarters)
           .filter(s => speciesStarters[s] >= minStarterValue && speciesStarters[s] <= maxStarterValue)
           .map(s => parseInt(s) as Species)
           .filter(s => !pokemonPrevolutions.hasOwnProperty(s) && getPokemonSpecies(s).isObtainable() && ignoredSpecies.indexOf(s) === -1);
+
+        if (this.scene.gameData.unlockPity[this.egg.tier] >= 9) {
+          const lockedPool = speciesPool.filter(s => !this.scene.gameData.dexData[s].caughtAttr);
+          if (lockedPool.length) { // Skip this if everything is unlocked
+            speciesPool = lockedPool;
+          }
+        }
 
         /**
          * Pokemon that are cheaper in their tier get a weight boost. Regionals get a weight penalty
@@ -534,6 +541,12 @@ export class EggHatchPhase extends Phase {
             species = speciesPool[s];
             break;
           }
+        }
+
+        if (!!this.scene.gameData.dexData[species].caughtAttr) {
+          this.scene.gameData.unlockPity[this.egg.tier] += 1;
+        } else {
+          this.scene.gameData.unlockPity[this.egg.tier] = 0;
         }
 
         const pokemonSpecies = getPokemonSpecies(species);

--- a/src/egg-hatch-phase.ts
+++ b/src/egg-hatch-phase.ts
@@ -502,6 +502,7 @@ export class EggHatchPhase extends Phase {
           .map(s => parseInt(s) as Species)
           .filter(s => !pokemonPrevolutions.hasOwnProperty(s) && getPokemonSpecies(s).isObtainable() && ignoredSpecies.indexOf(s) === -1);
 
+        // If this is the 10th egg without unlocking something new, attempt to force it.
         if (this.scene.gameData.unlockPity[this.egg.tier] >= 9) {
           const lockedPool = speciesPool.filter(s => !this.scene.gameData.dexData[s].caughtAttr);
           if (lockedPool.length) { // Skip this if everything is unlocked
@@ -544,7 +545,7 @@ export class EggHatchPhase extends Phase {
         }
 
         if (!!this.scene.gameData.dexData[species].caughtAttr) {
-          this.scene.gameData.unlockPity[this.egg.tier] += 1;
+          this.scene.gameData.unlockPity[this.egg.tier] = Math.min(this.scene.gameData.unlockPity[this.egg.tier] + 1, 10);
         } else {
           this.scene.gameData.unlockPity[this.egg.tier] = 0;
         }

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -97,6 +97,8 @@ interface SystemSaveData {
   eggs: EggData[];
   gameVersion: string;
   timestamp: integer;
+  eggPity: integer[];
+  unlockPity: integer[];
 }
 
 export interface SessionSaveData {
@@ -241,6 +243,8 @@ export class GameData {
   public voucherUnlocks: VoucherUnlocks;
   public voucherCounts: VoucherCounts;
   public eggs: Egg[];
+  public eggPity: integer[];
+  public unlockPity: integer[];
 
   constructor(scene: BattleScene) {
     this.scene = scene;
@@ -265,6 +269,8 @@ export class GameData {
       [VoucherType.GOLDEN]: 0
     };
     this.eggs = [];
+    this.eggPity = [0, 0, 0, 0];
+    this.unlockPity = [0, 0, 0, 0];
     this.initDexData();
     this.initStarterData();
   }
@@ -283,7 +289,9 @@ export class GameData {
       voucherCounts: this.voucherCounts,
       eggs: this.eggs.map(e => new EggData(e)),
       gameVersion: this.scene.game.config.gameVersion,
-      timestamp: new Date().getTime()
+      timestamp: new Date().getTime(),
+      eggPity: this.eggPity.slice(0),
+      unlockPity: this.unlockPity.slice(0)
     };
   }
 
@@ -465,6 +473,9 @@ export class GameData {
         this.eggs = systemData.eggs
           ? systemData.eggs.map(e => e.toEgg())
           : [];
+
+        this.eggPity = systemData.eggPity ? systemData.eggPity.slice(0) : [0, 0, 0, 0];
+        this.unlockPity = systemData.unlockPity ? systemData.unlockPity.slice(0) : [0, 0, 0, 0];
 
         this.dexData = Object.assign(this.dexData, systemData.dexData);
         this.consolidateDexData(this.dexData);

--- a/src/ui/egg-gacha-ui-handler.ts
+++ b/src/ui/egg-gacha-ui-handler.ts
@@ -378,6 +378,19 @@ export default class EggGachaUiHandler extends MessageUiHandler {
       } else if (pullCount >= 10 && !tiers.filter(t => t >= EggTier.GREAT).length) {
         tiers[Utils.randInt(tiers.length)] = EggTier.GREAT;
       }
+      for (let i = 0; i < pullCount; i++) {
+        this.scene.gameData.eggPity[EggTier.GREAT] += 1;
+        this.scene.gameData.eggPity[EggTier.ULTRA] += 1;
+        this.scene.gameData.eggPity[EggTier.MASTER] += 1 + tierValueOffset;
+        if (this.scene.gameData.eggPity[EggTier.MASTER] >= 412 && tiers[i] === EggTier.COMMON) {
+          tiers[i] = EggTier.MASTER;
+        } else if (this.scene.gameData.eggPity[EggTier.ULTRA] >= 59 && tiers[i] === EggTier.COMMON) {
+          tiers[i] = EggTier.ULTRA;
+        } else if (this.scene.gameData.eggPity[EggTier.GREAT] >= 9 && tiers[i] === EggTier.COMMON) {
+          tiers[i] = EggTier.GREAT;
+        }
+        this.scene.gameData.eggPity[tiers[i]] = 0;
+      }
 
       const timestamp = new Date().getTime();
 

--- a/src/ui/egg-gacha-ui-handler.ts
+++ b/src/ui/egg-gacha-ui-handler.ts
@@ -382,6 +382,7 @@ export default class EggGachaUiHandler extends MessageUiHandler {
         this.scene.gameData.eggPity[EggTier.GREAT] += 1;
         this.scene.gameData.eggPity[EggTier.ULTRA] += 1;
         this.scene.gameData.eggPity[EggTier.MASTER] += 1 + tierValueOffset;
+        // These numbers are roughly the 80% mark. That is, 80% of the time you'll get an egg before this gets triggered.
         if (this.scene.gameData.eggPity[EggTier.MASTER] >= 412 && tiers[i] === EggTier.COMMON) {
           tiers[i] = EggTier.MASTER;
         } else if (this.scene.gameData.eggPity[EggTier.ULTRA] >= 59 && tiers[i] === EggTier.COMMON) {


### PR DESCRIPTION
## What are the changes?
Implements a pity system for eggs.

## Why am I doing these changes?
It's on the roadmap.

## What did change?
You are guaranteed at least one legendary egg every ~412 eggs, one epic every ~59 eggs, and one rare every ~9 eggs. You are guaranteed at least one new species unlocked every 10 eggs of a given tier.

### Screenshots/Videos
N/A - Not really visible.

## How to test the changes?
Give yourself vouchers, then hatch eggs. It should also track across saving and loading.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [N] Are the changes visual?
  - [N] Have I provided screenshots/videos of the changes?