### PR TITLE
[Move] Implement Fusion Flare and Fusion Bolt

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -3404,6 +3404,72 @@ export class MultiHitPowerIncrementAttr extends VariablePowerAttr {
   }
 }
 
+/**
+ * Attribute used for moves that double in power if the given move immediately
+ * preceded the move applying the attribute, namely Fusion Flare and
+ * Fusion Bolt.
+ * @extends VariablePowerAttr
+ * @see {@linkcode apply}
+ */
+export class LastMoveDoublePowerAttr extends VariablePowerAttr {
+  /** The move that must precede the current move */
+  private move: Moves;
+
+  constructor(move: Moves) {
+    super();
+
+    this.move = move;
+  }
+
+  /**
+   * Doubles power of move if the given move is found to precede the current
+   * move with no other moves being executed in between, only ignoring failed
+   * moves if any.
+   * @param user {@linkcode Pokemon} that used the move
+   * @param target N/A
+   * @param move N/A
+   * @param args [0] {@linkcode Utils.NumberHolder} that holds the resulting power of the move
+   * @returns true if attribute application succeeds, false otherwise
+   */
+  apply(user: Pokemon, _target: Pokemon, _move: Move, args: any[]): boolean {
+    const power = args[0] as Utils.NumberHolder;
+    const enemy = user.getOpponent(0);
+    const pokemonActed: Pokemon[] = [];
+
+    if (enemy.turnData.acted) {
+      pokemonActed.push(enemy);
+    }
+
+    if (user.scene.currentBattle.double) {
+      const userAlly = user.getAlly();
+      const enemyAlly = enemy.getAlly();
+
+      if (userAlly && userAlly.turnData.acted) {
+        pokemonActed.push(userAlly);
+      }
+      if (enemyAlly && enemyAlly.turnData.acted) {
+        pokemonActed.push(enemyAlly);
+      }
+    }
+
+    pokemonActed.sort((a, b) => b.turnData.order - a.turnData.order);
+
+    for (const p of pokemonActed) {
+      const [ lastMove ] = p.getLastXMoves(1);
+      if (lastMove.result !== MoveResult.FAIL) {
+        if ((lastMove.result === MoveResult.SUCCESS) && (lastMove.move === this.move)) {
+          power.value *= 2;
+          return true;
+        } else {
+          break;
+        }
+      }
+    }
+
+    return false;
+  }
+}
+
 export class VariableAtkAttr extends MoveAttr {
   constructor() {
     super();
@@ -7445,10 +7511,10 @@ export function initMoves() {
       .attr(StatChangeAttr, [ BattleStat.DEF, BattleStat.SPDEF, BattleStat.SPD ], -1, true),
     new AttackMove(Moves.FUSION_FLARE, Type.FIRE, MoveCategory.SPECIAL, 100, 100, 5, -1, 0, 5)
       .attr(HealStatusEffectAttr, true, StatusEffect.FREEZE)
-      .partial(),
+      .attr(LastMoveDoublePowerAttr, Moves.FUSION_BOLT),
     new AttackMove(Moves.FUSION_BOLT, Type.ELECTRIC, MoveCategory.PHYSICAL, 100, 100, 5, -1, 0, 5)
-      .makesContact(false)
-      .partial(),
+      .attr(LastMoveDoublePowerAttr, Moves.FUSION_FLARE)
+      .makesContact(false),
     new AttackMove(Moves.FLYING_PRESS, Type.FIGHTING, MoveCategory.PHYSICAL, 100, 95, 10, -1, 0, 6)
       .attr(MinimizeAccuracyAttr)
       .attr(FlyingTypeMultiplierAttr)

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4062,6 +4062,7 @@ export class PokemonTurnData {
   public currDamageDealt: integer = 0;
   public damageTaken: integer = 0;
   public attacksReceived: AttackMoveResult[] = [];
+  public order: number;
 }
 
 export enum AiType {

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2314,6 +2314,8 @@ export class TurnStartPhase extends FieldPhase {
       return aIndex < bIndex ? -1 : aIndex > bIndex ? 1 : 0;
     });
 
+    let orderIndex = 0;
+
     for (const o of moveOrder) {
 
       const pokemon = field[o];
@@ -2326,6 +2328,7 @@ export class TurnStartPhase extends FieldPhase {
       switch (turnCommand.command) {
       case Command.FIGHT:
         const queuedMove = turnCommand.move;
+        pokemon.turnData.order = orderIndex++;
         if (!queuedMove) {
           continue;
         }

--- a/src/test/moves/fusion_bolt.test.ts
+++ b/src/test/moves/fusion_bolt.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import Phaser from "phaser";
+import GameManager from "#app/test/utils/gameManager";
+import overrides from "#app/overrides";
+import { getMovePosition } from "#app/test/utils/gameManagerUtils";
+import { Species } from "#enums/species";
+import { Moves } from "#enums/moves";
+import { Abilities } from "#enums/abilities";
+
+describe("Moves - Fusion Bolt", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  const fusionBolt = Moves.FUSION_BOLT;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([ fusionBolt ]);
+    vi.spyOn(overrides, "STARTING_LEVEL_OVERRIDE", "get").mockReturnValue(1);
+
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.RESHIRAM);
+    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.ROUGH_SKIN);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([ Moves.SPLASH, Moves.SPLASH, Moves.SPLASH, Moves.SPLASH ]);
+
+    vi.spyOn(overrides, "BATTLE_TYPE_OVERRIDE", "get").mockReturnValue("single");
+    vi.spyOn(overrides, "STARTING_WAVE_OVERRIDE", "get").mockReturnValue(97);
+    vi.spyOn(overrides, "NEVER_CRIT_OVERRIDE", "get").mockReturnValue(true);
+  });
+
+  it("should not make contact", async() => {
+    await game.startBattle([
+      Species.ZEKROM,
+    ]);
+
+    const partyMember = game.scene.getPlayerPokemon();
+    const initialHp = partyMember.hp;
+
+    game.doAttack(getMovePosition(game.scene, 0, fusionBolt));
+
+    await game.toNextTurn();
+
+    expect(initialHp - partyMember.hp).toBe(0);
+  }, 20000);
+});

--- a/src/test/moves/fusion_flare.test.ts
+++ b/src/test/moves/fusion_flare.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import Phaser from "phaser";
+import GameManager from "#app/test/utils/gameManager";
+import overrides from "#app/overrides";
+import { TurnStartPhase } from "#app/phases";
+import { getMovePosition } from "#app/test/utils/gameManagerUtils";
+import { StatusEffect } from "#app/data/status-effect";
+import { Species } from "#enums/species";
+import { Moves } from "#enums/moves";
+
+describe("Moves - Fusion Flare", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  const fusionFlare = Moves.FUSION_FLARE;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([ fusionFlare ]);
+    vi.spyOn(overrides, "STARTING_LEVEL_OVERRIDE", "get").mockReturnValue(1);
+
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.RESHIRAM);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([ Moves.REST, Moves.REST, Moves.REST, Moves.REST ]);
+
+    vi.spyOn(overrides, "BATTLE_TYPE_OVERRIDE", "get").mockReturnValue("single");
+    vi.spyOn(overrides, "STARTING_WAVE_OVERRIDE", "get").mockReturnValue(97);
+    vi.spyOn(overrides, "NEVER_CRIT_OVERRIDE", "get").mockReturnValue(true);
+  });
+
+  it("should thaw freeze status condition", async() => {
+    await game.startBattle([
+      Species.RESHIRAM,
+    ]);
+
+    const partyMember = game.scene.getPlayerPokemon();
+
+    game.doAttack(getMovePosition(game.scene, 0, fusionFlare));
+
+    await game.phaseInterceptor.to(TurnStartPhase, false);
+
+    // Inflict freeze quietly and check if it was properly inflicted
+    partyMember.trySetStatus(StatusEffect.FREEZE, false);
+    expect(partyMember.status.effect).toBe(StatusEffect.FREEZE);
+
+    await game.toNextTurn();
+
+    // Check if FUSION_FLARE thawed freeze
+    expect(partyMember.status?.effect).toBeUndefined();
+  });
+});

--- a/src/test/moves/fusion_flare_bolt.test.ts
+++ b/src/test/moves/fusion_flare_bolt.test.ts
@@ -1,0 +1,323 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import Phaser from "phaser";
+import GameManager from "#app/test/utils/gameManager";
+import overrides from "#app/overrides";
+import { MoveEffectPhase, MovePhase, MoveEndPhase, TurnStartPhase, DamagePhase } from "#app/phases";
+import { getMovePosition } from "#app/test/utils/gameManagerUtils";
+import { Stat } from "#app/data/pokemon-stat";
+import { allMoves } from "#app/data/move";
+import { BattlerIndex } from "#app/battle";
+import { Species } from "#enums/species";
+import { Moves } from "#enums/moves";
+
+describe("Moves - Fusion Flare and Fusion Bolt", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  const fusionFlare = allMoves[Moves.FUSION_FLARE];
+  const fusionBolt = allMoves[Moves.FUSION_BOLT];
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([ fusionFlare.id, fusionBolt.id ]);
+    vi.spyOn(overrides, "STARTING_LEVEL_OVERRIDE", "get").mockReturnValue(1);
+
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.RESHIRAM);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([ Moves.REST, Moves.REST, Moves.REST, Moves.REST ]);
+
+    vi.spyOn(overrides, "BATTLE_TYPE_OVERRIDE", "get").mockReturnValue("double");
+    vi.spyOn(overrides, "STARTING_WAVE_OVERRIDE", "get").mockReturnValue(97);
+    vi.spyOn(overrides, "NEVER_CRIT_OVERRIDE", "get").mockReturnValue(true);
+
+    vi.spyOn(fusionFlare, "calculateBattlePower");
+    vi.spyOn(fusionBolt, "calculateBattlePower");
+  });
+
+  it("FUSION_FLARE should double power of subsequent FUSION_BOLT", async() => {
+    await game.startBattle([
+      Species.ZEKROM,
+      Species.ZEKROM
+    ]);
+
+    game.doAttack(getMovePosition(game.scene, 0, fusionFlare.id));
+    game.doSelectTarget(BattlerIndex.ENEMY);
+
+    game.doAttack(getMovePosition(game.scene, 0, fusionBolt.id));
+    game.doSelectTarget(BattlerIndex.ENEMY);
+
+    await game.phaseInterceptor.to(TurnStartPhase, false);
+
+    // Force user party to act before enemy party
+    vi.spyOn(game.scene.getCurrentPhase() as TurnStartPhase, "getOrder").mockReturnValue([ BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2 ]);
+
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    expect((game.scene.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionFlare.id);
+    await game.phaseInterceptor.to(DamagePhase, false);
+    expect(fusionFlare.calculateBattlePower).toHaveLastReturnedWith(100);
+
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    expect((game.scene.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionBolt.id);
+    await game.phaseInterceptor.to(DamagePhase, false);
+    expect(fusionBolt.calculateBattlePower).toHaveLastReturnedWith(200);
+  }, 20000);
+
+  it("FUSION_BOLT should double power of subsequent FUSION_FLARE", async() => {
+    await game.startBattle([
+      Species.ZEKROM,
+      Species.ZEKROM
+    ]);
+
+    game.doAttack(getMovePosition(game.scene, 0, fusionBolt.id));
+    game.doSelectTarget(BattlerIndex.ENEMY);
+
+    game.doAttack(getMovePosition(game.scene, 0, fusionFlare.id));
+    game.doSelectTarget(BattlerIndex.ENEMY);
+
+    await game.phaseInterceptor.to(TurnStartPhase, false);
+
+    // Force user party to act before enemy party
+    vi.spyOn(game.scene.getCurrentPhase() as TurnStartPhase, "getOrder").mockReturnValue([ BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2 ]);
+
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    expect((game.scene.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionBolt.id);
+    await game.phaseInterceptor.to(DamagePhase, false);
+    expect(fusionBolt.calculateBattlePower).toHaveLastReturnedWith(100);
+
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    expect((game.scene.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionFlare.id);
+    await game.phaseInterceptor.to(DamagePhase, false);
+    expect(fusionFlare.calculateBattlePower).toHaveLastReturnedWith(200);
+  }, 20000);
+
+  it("FUSION_FLARE should double power of subsequent FUSION_BOLT if a move failed in between", async() => {
+    await game.startBattle([
+      Species.ZEKROM,
+      Species.ZEKROM
+    ]);
+
+    game.doAttack(getMovePosition(game.scene, 0, fusionFlare.id));
+    game.doSelectTarget(0);
+
+    game.doAttack(getMovePosition(game.scene, 0, fusionBolt.id));
+    game.doSelectTarget(0);
+
+    await game.phaseInterceptor.to(TurnStartPhase, false);
+
+    // Force first enemy to act (and fail) in between party
+    vi.spyOn(game.scene.getCurrentPhase() as TurnStartPhase, "getOrder").mockReturnValue([ BattlerIndex.PLAYER, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY ]);
+
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    expect((game.scene.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionFlare.id);
+    await game.phaseInterceptor.to(DamagePhase, false);
+    expect(fusionFlare.calculateBattlePower).toHaveLastReturnedWith(100);
+
+    await game.phaseInterceptor.to(MoveEndPhase);
+
+    // Skip enemy move; because the enemy is at full HP, Rest should fail
+    await game.phaseInterceptor.runFrom(MovePhase).to(MoveEndPhase);
+
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    expect((game.scene.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionBolt.id);
+    await game.phaseInterceptor.to(DamagePhase, false);
+    expect(fusionBolt.calculateBattlePower).toHaveLastReturnedWith(200);
+  }, 20000);
+
+  it("FUSION_FLARE should not double power of subsequent FUSION_BOLT if a move succeeded in between", async() => {
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([ Moves.SPLASH, Moves.SPLASH, Moves.SPLASH, Moves.SPLASH ]);
+    await game.startBattle([
+      Species.ZEKROM,
+      Species.ZEKROM
+    ]);
+
+    game.doAttack(getMovePosition(game.scene, 0, fusionFlare.id));
+    game.doSelectTarget(BattlerIndex.ENEMY);
+
+    game.doAttack(getMovePosition(game.scene, 0, fusionBolt.id));
+    game.doSelectTarget(BattlerIndex.ENEMY);
+
+    await game.phaseInterceptor.to(TurnStartPhase, false);
+
+    // Force first enemy to act in between party
+    vi.spyOn(game.scene.getCurrentPhase() as TurnStartPhase, "getOrder").mockReturnValue([ BattlerIndex.PLAYER, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY ]);
+
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    expect((game.scene.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionFlare.id);
+    await game.phaseInterceptor.to(DamagePhase, false);
+    expect(fusionFlare.calculateBattlePower).toHaveLastReturnedWith(100);
+
+    await game.phaseInterceptor.to(MoveEndPhase);
+    // Skip enemy move
+    await game.phaseInterceptor.runFrom(MovePhase).to(MoveEndPhase);
+
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    expect((game.scene.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionBolt.id);
+    await game.phaseInterceptor.to(DamagePhase, false);
+    expect(fusionBolt.calculateBattlePower).toHaveLastReturnedWith(100);
+  }, 20000);
+
+  it("FUSION_FLARE should double power of subsequent FUSION_BOLT if moves are aimed at allies", async() => {
+    await game.startBattle([
+      Species.ZEKROM,
+      Species.RESHIRAM
+    ]);
+
+    game.doAttack(getMovePosition(game.scene, 0, fusionBolt.id));
+    game.doSelectTarget(BattlerIndex.PLAYER_2);
+
+    game.doAttack(getMovePosition(game.scene, 0, fusionFlare.id));
+    game.doSelectTarget(BattlerIndex.PLAYER);
+
+    await game.phaseInterceptor.to(TurnStartPhase, false);
+
+    // Force user party to act before enemy party
+    vi.spyOn(game.scene.getCurrentPhase() as TurnStartPhase, "getOrder").mockReturnValue([ BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2 ]);
+
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    expect((game.scene.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionBolt.id);
+    await game.phaseInterceptor.to(DamagePhase, false);
+    expect(fusionBolt.calculateBattlePower).toHaveLastReturnedWith(100);
+
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    expect((game.scene.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionFlare.id);
+    await game.phaseInterceptor.to(DamagePhase, false);
+    expect(fusionFlare.calculateBattlePower).toHaveLastReturnedWith(200);
+  }, 20000);
+
+  it("FUSION_FLARE and FUSION_BOLT alternating throughout turn should double power of subsequent moves", async() => {
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([ fusionFlare.id, fusionFlare.id, fusionFlare.id, fusionFlare.id ]);
+    await game.startBattle([
+      Species.ZEKROM,
+      Species.ZEKROM
+    ]);
+
+    const party = game.scene.getParty();
+    const enemyParty = game.scene.getEnemyParty();
+
+    // Get rid of any modifiers that may alter power
+    game.scene.clearEnemyHeldItemModifiers();
+    game.scene.clearEnemyModifiers();
+
+    // Mock stats by replacing entries in copy with desired values for specific stats
+    const stats = {
+      enemy: [
+        [...enemyParty[0].stats],
+        [...enemyParty[1].stats],
+      ],
+      player: [
+        [...party[0].stats],
+        [...party[1].stats],
+      ]
+    };
+
+    // Ensure survival by reducing enemy Sp. Atk and boosting party Sp. Def
+    vi.spyOn(enemyParty[0], "stats", "get").mockReturnValue(stats.enemy[0].map((val, i) => (i === Stat.SPATK ? 1 : val)));
+    vi.spyOn(enemyParty[1], "stats", "get").mockReturnValue(stats.enemy[1].map((val, i) => (i === Stat.SPATK ? 1 : val)));
+    vi.spyOn(party[1], "stats", "get").mockReturnValue(stats.player[0].map((val, i) => (i === Stat.SPDEF ? 250 : val)));
+    vi.spyOn(party[1], "stats", "get").mockReturnValue(stats.player[1].map((val, i) => (i === Stat.SPDEF ? 250 : val)));
+
+    game.doAttack(getMovePosition(game.scene, 0, fusionBolt.id));
+    game.doSelectTarget(BattlerIndex.ENEMY);
+
+    game.doAttack(getMovePosition(game.scene, 0, fusionBolt.id));
+    game.doSelectTarget(BattlerIndex.ENEMY);
+
+    await game.phaseInterceptor.to(TurnStartPhase, false);
+
+    // Force first enemy to act in between party
+    vi.spyOn(game.scene.getCurrentPhase() as TurnStartPhase, "getOrder").mockReturnValue([ BattlerIndex.PLAYER, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY ]);
+
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    expect((game.scene.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionBolt.id);
+    await game.phaseInterceptor.to(DamagePhase, false);
+    expect(fusionBolt.calculateBattlePower).toHaveLastReturnedWith(100);
+
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    expect((game.scene.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionFlare.id);
+    await game.phaseInterceptor.to(DamagePhase, false);
+    expect(fusionFlare.calculateBattlePower).toHaveLastReturnedWith(200);
+
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    expect((game.scene.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionBolt.id);
+    await game.phaseInterceptor.to(DamagePhase, false);
+    expect(fusionBolt.calculateBattlePower).toHaveLastReturnedWith(200);
+
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    expect((game.scene.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionFlare.id);
+    await game.phaseInterceptor.to(DamagePhase, false);
+    expect(fusionFlare.calculateBattlePower).toHaveLastReturnedWith(200);
+  }, 20000);
+
+  it("FUSION_FLARE and FUSION_BOLT alternating throughout turn should double power of subsequent moves if moves are aimed at allies", async() => {
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([ fusionFlare.id, fusionFlare.id, fusionFlare.id, fusionFlare.id ]);
+    await game.startBattle([
+      Species.ZEKROM,
+      Species.ZEKROM
+    ]);
+
+    const party = game.scene.getParty();
+    const enemyParty = game.scene.getEnemyParty();
+
+    // Get rid of any modifiers that may alter power
+    game.scene.clearEnemyHeldItemModifiers();
+    game.scene.clearEnemyModifiers();
+
+    // Mock stats by replacing entries in copy with desired values for specific stats
+    const stats = {
+      enemy: [
+        [...enemyParty[0].stats],
+        [...enemyParty[1].stats],
+      ],
+      player: [
+        [...party[0].stats],
+        [...party[1].stats],
+      ]
+    };
+
+    // Ensure survival by reducing enemy Sp. Atk and boosting party Sp. Def
+    vi.spyOn(enemyParty[0], "stats", "get").mockReturnValue(stats.enemy[0].map((val, i) => (i === Stat.SPATK ? 1 : val)));
+    vi.spyOn(enemyParty[1], "stats", "get").mockReturnValue(stats.enemy[1].map((val, i) => (i === Stat.SPATK ? 1 : val)));
+    vi.spyOn(party[1], "stats", "get").mockReturnValue(stats.player[0].map((val, i) => (i === Stat.SPDEF ? 250 : val)));
+    vi.spyOn(party[1], "stats", "get").mockReturnValue(stats.player[1].map((val, i) => (i === Stat.SPDEF ? 250 : val)));
+
+    game.doAttack(getMovePosition(game.scene, 0, fusionBolt.id));
+    game.doSelectTarget(BattlerIndex.PLAYER_2);
+
+    game.doAttack(getMovePosition(game.scene, 0, fusionBolt.id));
+    game.doSelectTarget(BattlerIndex.PLAYER);
+
+    await game.phaseInterceptor.to(TurnStartPhase, false);
+
+    // Force first enemy to act in between party
+    vi.spyOn(game.scene.getCurrentPhase() as TurnStartPhase, "getOrder").mockReturnValue([ BattlerIndex.PLAYER, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY ]);
+
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    expect((game.scene.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionBolt.id);
+    await game.phaseInterceptor.to(DamagePhase, false);
+    expect(fusionBolt.calculateBattlePower).toHaveLastReturnedWith(100);
+
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    expect((game.scene.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionFlare.id);
+    await game.phaseInterceptor.to(DamagePhase, false);
+    expect(fusionFlare.calculateBattlePower).toHaveLastReturnedWith(200);
+
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    expect((game.scene.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionBolt.id);
+    await game.phaseInterceptor.to(DamagePhase, false);
+    expect(fusionBolt.calculateBattlePower).toHaveLastReturnedWith(200);
+
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    expect((game.scene.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionFlare.id);
+    await game.phaseInterceptor.to(DamagePhase, false);
+    expect(fusionFlare.calculateBattlePower).toHaveLastReturnedWith(200);
+  }, 20000);
+});


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Implemented the power boosting effects to the following moves: [``Fusion Flare``](https://bulbapedia.bulbagarden.net/wiki/Fusion_Flare_(move)) and [``Fusion Bolt``](https://bulbapedia.bulbagarden.net/wiki/Fusion_Bolt_(move)).

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
The two moves, prior to this PR, were left partially implemented and did not include their secondary effect, doubling their base power if the opposite move was used immediately before the other without any other moves in between. This PR aims to achieve this effect. Note that, on the moves' Bulbapedia pages, the phrase "except perhaps for failed moves" is taken to mean that all failed moves, if any have occurred that turn, are ignored when checking if the opposing move has happened "immediately" before.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
For some preliminary context, move order within a turn is determined in `TurnStartPhase`. However, move order is not stored anywhere (as far as I could tell); individual move histories are stored in `Pokemon` with appropriate getters like `getMoveHistory()` and `getLastXMoves()`, but the context for when those moves happen relative to other `Pokemon` is not stored. In a single battle, it's easy to check if one acted before the other, but this becomes an issue in double battles and trying to determine the moves that have occurred in the turn so far in addition to the order they occurred. To work around this, a new `order` field was added to `PokemonTurnData` and set, starting from a `0` index, during `TurnStartPhase` when `MovePhase`s are being provided to each `Pokemon` in the order they occur.

To achieve the effect of both moves, `LastMoveDoublePowerAttr`, extending `VariablePowerAttr`, was written such that its `apply` function would get the `Pokemon` that have already acted during the turn, sort them in descending order by the new `order` field, and check in order if the last move they used had failed (moving on to the next acting `Pokemon`), was a successful use of the specified move (doubling the power of the move), or was not (doing nothing).

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

#### Move Behavior - Before

<img width="530" alt="flareToBoltBefore" src="https://github.com/pagefaultgames/pokerogue/assets/109637146/9b0ba2e2-cfd1-4e07-b5ad-69b199ee6d69">

Note that the value to the right of the move name is the base power and that it doesn't change even if the opposing move is used.

#### Move Behavior - After

<img width="509" alt="flareToBolt" src="https://github.com/pagefaultgames/pokerogue/assets/109637146/9d7dcd08-d3b0-482c-8a29-271d593b29ae">

<img width="510" alt="boltToFlare" src="https://github.com/pagefaultgames/pokerogue/assets/109637146/bf7cf2a5-a304-4ec4-a96c-7ea664a3b385">

In the two scenarios where either opposing move is used one after another, the second move used always has its base power doubled.

<img width="514" alt="flareToFlare" src="https://github.com/pagefaultgames/pokerogue/assets/109637146/3fd131d9-79e5-46fb-aacd-5eaa0e1db4ff">

In the case that the same move is used by two different `Pokemon`, the second move does not have its base power doubled.

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

For general testing of the moves functionality, the `src/overrides.ts` file was modified such that the `MOVESET_OVERRIDE` array included both `Moves.FUSION_FLARE` and `Moves.FUSION_BOLT`. `DOUBLE_BATTLE_OVERRIDE` was also set to test the moves in a double battle context since that was the most rigorous scenario for determining whether the moves' effect worked. 

~~Note that, due to the limits of the given overrides and the sparse scenarios for moves failing while also having opponents interleave the moves in a given turn, the case in which, for example, `Fusion Bolt` was used, moves failed in between, and `Fusion Flare` was used was not directly tested.~~ 

For further stress testing, unit tests are included to check both the individual properties of the moves alone and check the interactions between the usage of both in mock battles.

## Comments

A couple things worth noting:
- The Bulbapedia description of these moves mention an interaction with `Instruct`, where if one of the moves is used that turn and the target then uses the opposing move right after, the power doubling effect comes into play. So far, this isn't addressed since `Instruct` is not implemented yet; however, I have thought about how to account for this if needed now for future-proofing the PR.
- The current implementation, by checking who acted so far in that turn, guarantees that the last move used will be one that happened that turn; that is, it should be impossible for any empty move histories to appear to necessitate move history length checking. However, specifically related to expanding the implementation for `Instruct`, it does not take into account multiple moves from the same user in the same turn. This is fine for `Multi Lens`-modified moves since the same move can only be used multiple times, but this becomes an issue if different moves can happen from the same user in the same turn, as in the case with `Instruct`. Noting this down for the sake of discussion and bookkeeping later.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?