### PR TITLE
[Ability] Implement Unseen Fist

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -3393,6 +3393,9 @@ export class SuppressFieldAbilitiesAbAttr extends AbAttr {
 
 export class AlwaysHitAbAttr extends AbAttr { }
 
+/** Attribute for abilities that allow moves that make contact to ignore protection (i.e. Unseen Fist) */
+export class IgnoreProtectOnContactAbAttr extends AbAttr { }
+
 export class UncopiableAbilityAbAttr extends AbAttr {
   constructor() {
     super(false);
@@ -4641,7 +4644,7 @@ export function initAbilities() {
     new Ability(Abilities.QUICK_DRAW, 8)
       .unimplemented(),
     new Ability(Abilities.UNSEEN_FIST, 8)
-      .unimplemented(),
+      .attr(IgnoreProtectOnContactAbAttr),
     new Ability(Abilities.CURIOUS_MEDICINE, 8)
       .attr(PostSummonClearAllyStatsAbAttr),
     new Ability(Abilities.TRANSISTOR, 8)

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -9,7 +9,7 @@ import { Type } from "./type";
 import * as Utils from "../utils";
 import { WeatherType } from "./weather";
 import { ArenaTagSide, ArenaTrapTag } from "./arena-tag";
-import { UnswappableAbilityAbAttr, UncopiableAbilityAbAttr, UnsuppressableAbilityAbAttr, BlockRecoilDamageAttr, BlockOneHitKOAbAttr, IgnoreContactAbAttr, MaxMultiHitAbAttr, applyAbAttrs, BlockNonDirectDamageAbAttr, applyPreSwitchOutAbAttrs, PreSwitchOutAbAttr, applyPostDefendAbAttrs, PostDefendContactApplyStatusEffectAbAttr, MoveAbilityBypassAbAttr, ReverseDrainAbAttr, FieldPreventExplosiveMovesAbAttr, ForceSwitchOutImmunityAbAttr, BlockItemTheftAbAttr, applyPostAttackAbAttrs, ConfusionOnStatusEffectAbAttr, HealFromBerryUseAbAttr } from "./ability";
+import { UnswappableAbilityAbAttr, UncopiableAbilityAbAttr, UnsuppressableAbilityAbAttr, BlockRecoilDamageAttr, BlockOneHitKOAbAttr, IgnoreContactAbAttr, MaxMultiHitAbAttr, applyAbAttrs, BlockNonDirectDamageAbAttr, applyPreSwitchOutAbAttrs, PreSwitchOutAbAttr, applyPostDefendAbAttrs, PostDefendContactApplyStatusEffectAbAttr, MoveAbilityBypassAbAttr, ReverseDrainAbAttr, FieldPreventExplosiveMovesAbAttr, ForceSwitchOutImmunityAbAttr, BlockItemTheftAbAttr, applyPostAttackAbAttrs, ConfusionOnStatusEffectAbAttr, HealFromBerryUseAbAttr, IgnoreProtectOnContactAbAttr } from "./ability";
 import { allAbilities } from "./ability";
 import { PokemonHeldItemModifier, BerryModifier, PreserveBerryModifier } from "../modifier/modifier";
 import { BattlerIndex } from "../battle";
@@ -559,6 +559,11 @@ export default class Move implements Localizable {
           return true;
         }
       }
+    case MoveFlags.IGNORE_PROTECT:
+      if (user.hasAbilityWithAttr(IgnoreProtectOnContactAbAttr) &&
+          this.checkFlag(MoveFlags.MAKES_CONTACT, user, target)) {
+        return true;
+      }
     }
 
     return !!(this.flags & flag);
@@ -811,7 +816,8 @@ export class MoveEffectAttr extends MoveAttr {
    */
   canApply(user: Pokemon, target: Pokemon, move: Move, args: any[]) {
     return !! (this.selfTarget ? user.hp && !user.getTag(BattlerTagType.FRENZY) : target.hp)
-           && (this.selfTarget || !target.getTag(BattlerTagType.PROTECTED) || move.hasFlag(MoveFlags.IGNORE_PROTECT));
+           && (this.selfTarget || !target.getTag(BattlerTagType.PROTECTED) ||
+                move.checkFlag(MoveFlags.IGNORE_PROTECT, user, target));
   }
 
   /** Applies move effects so long as they are able based on {@linkcode canApply} */

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1726,7 +1726,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     }
 
     // Apply arena tags for conditional protection
-    if (!move.hasFlag(MoveFlags.IGNORE_PROTECT) && !move.isAllyTarget()) {
+    if (!move.checkFlag(MoveFlags.IGNORE_PROTECT, source, this) && !move.isAllyTarget()) {
       const defendingSide = this.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY;
       this.scene.arena.applyTagsForSide(ArenaTagType.QUICK_GUARD, defendingSide, cancelled, this, move.priority);
       this.scene.arena.applyTagsForSide(ArenaTagType.WIDE_GUARD, defendingSide, cancelled, this, move.moveTarget);

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2889,7 +2889,7 @@ export class MoveEffectPhase extends PokemonPhase {
             continue;
           }
 
-          const isProtected = !move.hasFlag(MoveFlags.IGNORE_PROTECT) && target.findTags(t => t instanceof ProtectedTag).find(t => target.lapseTag(t.tagType));
+          const isProtected = !this.move.getMove().checkFlag(MoveFlags.IGNORE_PROTECT, user, target) && target.findTags(t => t instanceof ProtectedTag).find(t => target.lapseTag(t.tagType));
 
           const firstHit = moveHistoryEntry.result !== MoveResult.SUCCESS;
 

--- a/src/test/abilities/unseen_fist.test.ts
+++ b/src/test/abilities/unseen_fist.test.ts
@@ -1,0 +1,91 @@
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import GameManager from "../utils/gameManager";
+import * as Overrides from "#app/overrides";
+import { Species } from "#app/data/enums/species.js";
+import { Abilities } from "#app/data/enums/abilities.js";
+import { Moves } from "#app/data/enums/moves.js";
+import { getMovePosition } from "../utils/gameManagerUtils";
+import { TurnEndPhase } from "#app/phases.js";
+
+const TIMEOUT = 20 * 1000;
+
+describe("Abilities - Unseen Fist", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    vi.spyOn(Overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(Overrides, "STARTER_SPECIES_OVERRIDE", "get").mockReturnValue(Species.URSHIFU);
+    vi.spyOn(Overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.SNORLAX);
+    vi.spyOn(Overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.PROTECT, Moves.PROTECT, Moves.PROTECT, Moves.PROTECT]);
+    vi.spyOn(Overrides, "STARTING_LEVEL_OVERRIDE", "get").mockReturnValue(100);
+  });
+
+  test(
+    "ability causes a contact move to ignore Protect",
+    () => testUnseenFistHitResult(game, Moves.QUICK_ATTACK, Moves.PROTECT, true),
+    TIMEOUT
+  );
+
+  test(
+    "ability does not cause a non-contact move to ignore Protect",
+    () => testUnseenFistHitResult(game, Moves.ABSORB, Moves.PROTECT, false),
+    TIMEOUT
+  );
+
+  test(
+    "ability does not apply if the source has Long Reach",
+    () => {
+      vi.spyOn(Overrides, "PASSIVE_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.LONG_REACH);
+      testUnseenFistHitResult(game, Moves.QUICK_ATTACK, Moves.PROTECT, false);
+    }, TIMEOUT
+  );
+
+  test(
+    "ability causes a contact move to ignore Wide Guard",
+    () => testUnseenFistHitResult(game, Moves.BREAKING_SWIPE, Moves.WIDE_GUARD, true),
+    TIMEOUT
+  );
+
+  test(
+    "ability does not cause a non-contact move to ignore Wide Guard",
+    () => testUnseenFistHitResult(game, Moves.BULLDOZE, Moves.WIDE_GUARD, false),
+    TIMEOUT
+  );
+});
+
+async function testUnseenFistHitResult(game: GameManager, attackMove: Moves, protectMove: Moves, shouldSucceed: boolean = true): Promise<void> {
+  vi.spyOn(Overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([attackMove]);
+  vi.spyOn(Overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([protectMove, protectMove, protectMove, protectMove]);
+
+  await game.startBattle();
+
+  const leadPokemon = game.scene.getPlayerPokemon();
+  expect(leadPokemon).not.toBe(undefined);
+
+  const enemyPokemon = game.scene.getEnemyPokemon();
+  expect(enemyPokemon).not.toBe(undefined);
+
+  const enemyStartingHp = enemyPokemon.hp;
+
+  game.doAttack(getMovePosition(game.scene, 0, attackMove));
+  await game.phaseInterceptor.to(TurnEndPhase);
+
+  if (shouldSucceed) {
+    expect(enemyPokemon.hp).toBeLessThan(enemyStartingHp);
+  } else {
+    expect(enemyPokemon.hp).toBe(enemyStartingHp);
+  }
+}

--- a/src/test/abilities/unseen_fist.test.ts
+++ b/src/test/abilities/unseen_fist.test.ts
@@ -2,9 +2,9 @@ import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import GameManager from "../utils/gameManager";
 import * as Overrides from "#app/overrides";
-import { Species } from "#app/data/enums/species.js";
-import { Abilities } from "#app/data/enums/abilities.js";
-import { Moves } from "#app/data/enums/moves.js";
+import { Species } from "#enums/species";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
 import { getMovePosition } from "../utils/gameManagerUtils";
 import { TurnEndPhase } from "#app/phases.js";
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This implements the effects of the ability [Unseen Fist](https://bulbapedia.bulbagarden.net/wiki/Unseen_Fist_(Ability)).

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Unseen Fist isn't currently implemented, and with most (if not all) protection moves now implemented, it's possible to cover all edge cases and fully implement this ability.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- `data/ability`: A new attribute `IgnoreProtectOnContactAbAttr` is added, along with a global (`export`) function that checks if the attribute can be applied. Unseen Fist is now given this attribute.
- `field/pokemon`, `data/move`, and `phases`: All protection checks account for Unseen Fist using the function `data/ability#canApplyIgnoreProtectOnContact()`.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

For both test videos below, Pokemon and moves are preset using `src/overrides.ts`

- All battles are forced to be double battles.
- The player's Pokemon are Urshifu (with Unseen Fist) and Charmander (without Unseen Fist). Both Pokemon are given Breaking Swipe (a move that targets all nearby foes **and makes contact**) and Rock Slide (a move that targets all nearby foes **and does not make contact**).
- The enemy Pokemon are Ninjasks with Protect and Wide Guard.

#### Test 1: Unseen Fist vs. Protect

- Both opposing Ninjasks use Protect.
- Urshifu uses Breaking Swipe. Because of Unseen Fist, this bypasses Protect and hits both Ninjasks, causing one to faint.
- Charmander also uses Breaking Swipe on the surviving Ninjask, which is blocked by Protect.

https://github.com/pagefaultgames/pokerogue/assets/168692175/89aa8e2a-8f5c-4424-ad9f-0eed9a26bcd8

#### Test 2: Unseen Fist vs. Wide Guard

- Both opposing Ninjasks use Wide Guard
- Urshifu uses Breaking Swipe. Because of Unseen Fist, this bypasses Wide Guard and hits both Ninjasks.
- Charmander also uses Breaking Swipe, which is blocked by Wide Guard.
- The next turn, the surviving Ninjask uses Wide Guard again, and both Urshifu and Charmander use Rock Slide
- Since Rock Slide doesn't make contact, Urshifu and Charmander's attacks are both blocked by Ninjask's Wide Guard.

https://github.com/pagefaultgames/pokerogue/assets/168692175/2c1f48bc-013f-4000-87dd-4348c59a097e

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

In `src/overrides.ts`:
- Set `DOUBLE_BATTLE_OVERRIDE` to `true`.
- Set `STARTER_SPECIES_OVERRIDE` to `Species.URSHIFU`.
- For `MOVESET_OVERRIDE`, include moves that make/do not make contact, and if testing conditional protect moves e.g. Quick Guard, include moves that would activate protection.
- Set `OPP_MOVESET_OVERRIDE`, fill the array with 4 copies of the protect move you want to test against. The opponent AI gives the conditional protect moves low priority, so it's important to overwrite their other moves.
- `npm run start:dev`, then test the effects of Unseen Fist as shown in the videos above

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?