### PR TITLE
[Bug] Fix generateVariant to account for forms

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1273,7 +1273,15 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * @returns the shiny variant
    */
   generateVariant(): Variant {
-    if (!this.shiny || !variantData.hasOwnProperty(this.species.speciesId)) {
+    const formIndex = this.formIndex;
+    let variantDataIndex = this.species.speciesId;
+    if (this.species.forms.length > 0) {
+      const formKey = this.species.forms[formIndex]?.formKey;
+      if (formKey) {
+        variantDataIndex = `${variantDataIndex}-${formKey}`;
+      }
+    }
+    if (!this.shiny || !variantData.hasOwnProperty(variantDataIndex)) {
       return 0;
     }
     const rand = Utils.randSeedInt(10);

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1281,7 +1281,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         variantDataIndex = `${variantDataIndex}-${formKey}`;
       }
     }
-    if (!this.shiny || !variantData.hasOwnProperty(variantDataIndex)) {
+    // Checks if there is no variant data for both the index or index with form
+    if (!this.shiny || (!variantData.hasOwnProperty(variantDataIndex) && !variantData.hasOwnProperty(this.species.speciesId))) {
       return 0;
     }
     const rand = Utils.randSeedInt(10);

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1273,8 +1273,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * @returns the shiny variant
    */
   generateVariant(): Variant {
-    const formIndex = this.formIndex;
-    let variantDataIndex = this.species.speciesId;
+    const formIndex: number = this.formIndex;
+    let variantDataIndex: string | number = this.species.speciesId;
     if (this.species.forms.length > 0) {
       const formKey = this.species.forms[formIndex]?.formKey;
       if (formKey) {


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Currently Pokemon with forms (with the exception of forms that had a formKey of "", an empty string) that have shiny variants cannot spawn as Rare or Epic shinies. This change will allow them to properly generate. 

Hoopa and Castform both have a base form that has a key of an empty string, which allowed the old code to evaluate correctly without a formKey and only their species ID, ex: 720 for Hoopa.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Because blue and red shiny good.

[Issue](https://github.com/pagefaultgames/pokerogue/issues/1745)

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Adds formKey to the check to see if variantData has a variant for the given Pokemon and its given form.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
I just recorded about 12 different tests and all of the files are corrupted so I'm uploading this now and will add them in the morning.

<img width="834" alt="image" src="https://github.com/pagefaultgames/pokerogue/assets/132619649/b011ecc0-6114-48c6-8590-9e4f9e2294a1">

Tested so far:
- Burmy
- Wormadam
- Shellos
- Gastrodon
- Vivillion
- Meloetta
- Shaymin
- Hoopa


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
To test, you can set the OPP_SHINY_OVERRIDE to true as that will always cause the opposing Pokemon to be shiny but not guarantee its variant. Before the changes it will always pass just the species index in, and you can see that it will return that there is no data for Pokemon like Gastrodon or Wormdam. After the changes proposed you will variants for both of those examples.

This logging in the generate variant function might also prove useful to test:
```
console.log("old check");
console.log(this.species.speciesId);
console.log(variantData.hasOwnProperty(this.species.speciesId));
console.log("new check");
console.log(variantDataIndex);
console.log(variantData.hasOwnProperty(variantDataIndex));
```

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
  
  
<img width="567" alt="image" src="https://github.com/pagefaultgames/pokerogue/assets/132619649/533a42d3-2a39-4d2d-b39c-f5d6ee35eedc">
