### PR TITLE
[BUG] fix language auto detect

### DIFF
--- a/src/locales/zh_CN/tutorial.ts
+++ b/src/locales/zh_CN/tutorial.ts
@@ -1,7 +1,7 @@
 import { SimpleTranslationEntries } from "#app/plugins/i18n";
 
 export const tutorial: SimpleTranslationEntries = {
-  "intro": `欢迎来到PokéRogue！这是一款以战斗为核心的融合了roguelite元素的宝可梦同人游戏。
+  "intro": `欢迎来到PokéRogue！这是一款以战斗为核心的\n融合了roguelite元素的宝可梦同人游戏。
     $本游戏未进行商业化，我们没有\nPokémon或Pokémon使用的版
     $权资产的所有权。
     $游戏仍在开发中，但已可完整游玩。如需报\n告错误，请通过 Discord 社区。

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -174,13 +174,13 @@ export function initI18n(): void {
       de: {
         ...deConfig
       },
-      pt_BR: {
+      "pt-BR": {
         ...ptBrConfig
       },
-      zh_CN: {
+      "zh-CN": {
         ...zhCnConfig
       },
-      zh_TW: {
+      "zh-TW": {
         ...zhTwConfig
       },
       ko: {

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -433,15 +433,15 @@ export function setSetting(scene: BattleScene, setting: string, value: integer):
             },
             {
               label: "Português (BR)",
-              handler: () => changeLocaleHandler("pt_BR")
+              handler: () => changeLocaleHandler("pt-BR")
             },
             {
               label: "简体中文",
-              handler: () => changeLocaleHandler("zh_CN")
+              handler: () => changeLocaleHandler("zh-CN")
             },
             {
               label: "繁體中文",
-              handler: () => changeLocaleHandler("zh_TW")
+              handler: () => changeLocaleHandler("zh-TW")
             },
             {
               label: "한국어",


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
currently language auto detection is broken,
fixed according to [i18next documentation](https://www.i18next.com/how-to/faq#how-should-the-language-codes-be-formatted)

## Why am I doing these changes?
currently language auto detection is broken for **Simplified Chinese, Traditional Chinese, Portugese Brazilian**

## What did change?
i18next config resource key

### Screenshots/Videos
#### BEFORE FIX
<img width="1273" alt="image" src="https://github.com/pagefaultgames/pokerogue/assets/17879773/39236803-d8f6-4051-9506-e7c44be34cbd">

----

#### AFTER FIX
<img width="1318" alt="image" src="https://github.com/pagefaultgames/pokerogue/assets/17879773/ebeb6303-c087-4258-93bd-53731ca9da14">

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?