### PR TITLE
[Enhancement] Fetch and use server time for legendary gacha

### DIFF
--- a/src/ui/egg-gacha-ui-handler.ts
+++ b/src/ui/egg-gacha-ui-handler.ts
@@ -11,6 +11,7 @@ import { Tutorial, handleTutorial } from "../tutorial";
 import { EggTier } from "../data/enums/egg-type";
 import {Button} from "../enums/buttons";
 import i18next from "../plugins/i18n";
+import { fetchServerTime } from "../utils";
 
 export default class EggGachaUiHandler extends MessageUiHandler {
   private eggGachaContainer: Phaser.GameObjects.Container;
@@ -499,12 +500,15 @@ export default class EggGachaUiHandler extends MessageUiHandler {
 
   updateGachaInfo(gachaType: GachaType): void {
     const infoContainer = this.gachaInfoContainers[gachaType];
-    switch (gachaType as GachaType) {
-    case GachaType.LEGENDARY:
-      const species = getPokemonSpecies(getLegendaryGachaSpeciesForTimestamp(this.scene, new Date().getTime()));
-      const pokemonIcon = infoContainer.getAt(1) as Phaser.GameObjects.Sprite;
-      pokemonIcon.setTexture(species.getIconAtlasKey(), species.getIconId(false));
-      break;
+
+    if (gachaType === GachaType.LEGENDARY) {
+      fetchServerTime().then(res => {
+        const species = getPokemonSpecies(getLegendaryGachaSpeciesForTimestamp(this.scene, res));
+        const pokemonIcon = infoContainer.getAt(1) as Phaser.GameObjects.Sprite;
+        pokemonIcon.setTexture(species.getIconAtlasKey(), species.getIconId(false));
+      }).catch(error => {
+        console.error(error);
+      });
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -468,4 +468,22 @@ export function reverseValueToKeySetting(input) {
   return capitalizedWords.join("_");
 }
 
+/**
+ * Attempts to fetch the server time asynchronously
+ * @returns {Promise<integer>} A promise that resolves to the time in milliseconds
+ */
+export async function fetchServerTime(): Promise<integer> {
+  try {
+    // Fetch the server time data from the API
+    const response = await fetch("http://worldtimeapi.org/api/ip");
+    const data = await response.json();
 
+    // Return the server time in milliseconds
+    return new Date(data.utc_datetime).getTime();
+  } catch (error) {
+    console.warn("Error fetching server time, using system time instead.", error.message);
+
+    // Fallback to local time if server time is not available
+    return Date.now();
+  }
+}


### PR DESCRIPTION
## What are the changes?
- use server time instead of system time in gacha

## Why am I doing these changes?
- prevent time travelers from the game

## What did change?
- added `fetchServerTime()` for gacha usage

### Screenshots/Videos

## How to test the changes?
- add `console.log(species.name)` after this line https://github.com/pagefaultgames/pokerogue/blob/7ac7c2b63b5eaebcb4b663bc3a96553e2ef3be5e/src/ui/egg-gacha-ui-handler.ts#L504 to check the legendary it serves based on time
- set your system date forwards or backwards to check if server time is being used instead of system time
- to simulate an error from the API, add random character/s on the API endpoint, this should return and use the system data

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
- [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
- [ ] Have I provided screenshots/videos of the changes?