### PR TITLE
[Bug] Handle if the browser gives a long form of a language (like "de-DE") …

### DIFF
--- a/src/loading-scene.ts
+++ b/src/loading-scene.ts
@@ -29,6 +29,28 @@ export class LoadingScene extends SceneBase {
   }
 
   preload() {
+
+    let languageToSet = "en";
+    // Check if the language is valid, if not, try to load the language without the region and if that fails, fall back to English
+    if (!Utils.verifyLang(i18next.language) && i18next.language.includes("-")) {
+      // Try without the region
+      const lang = i18next.language.split("-")[0];
+      if (Utils.verifyLang(lang)) {
+        languageToSet = lang;
+      }
+    } else if (!Utils.verifyLang(i18next.language)) {
+      // Fallback to English
+      languageToSet = "en";
+    } else {
+      languageToSet = i18next.language;
+    }
+    // Reset the language if it's not the same as the one we're trying to set
+    if (languageToSet !== i18next.language) {
+      i18next.changeLanguage(languageToSet);
+    }
+
+
+
     this.load["manifest"] = this.game["manifest"];
 
     if (!isMobile()) {

--- a/src/loading-scene.ts
+++ b/src/loading-scene.ts
@@ -29,28 +29,6 @@ export class LoadingScene extends SceneBase {
   }
 
   preload() {
-
-    let languageToSet = "en";
-    // Check if the language is valid, if not, try to load the language without the region and if that fails, fall back to English
-    if (!Utils.verifyLang(i18next.language) && i18next.language.includes("-")) {
-      // Try without the region
-      const lang = i18next.language.split("-")[0];
-      if (Utils.verifyLang(lang)) {
-        languageToSet = lang;
-      }
-    } else if (!Utils.verifyLang(i18next.language)) {
-      // Fallback to English
-      languageToSet = "en";
-    } else {
-      languageToSet = i18next.language;
-    }
-    // Reset the language if it's not the same as the one we're trying to set
-    if (languageToSet !== i18next.language) {
-      i18next.changeLanguage(languageToSet);
-    }
-
-
-
     this.load["manifest"] = this.game["manifest"];
 
     if (!isMobile()) {
@@ -235,7 +213,7 @@ export class LoadingScene extends SceneBase {
     this.loadAtlas("types", "");
 
     // Get current lang and load the types atlas for it. English will only load types while all other languages will load types and types_<lang>
-    const lang = i18next.language;
+    const lang = i18next.resolvedLanguage;
     if (lang !== "en") {
       if (Utils.verifyLang(lang)) {
         this.loadAtlas(`types_${lang}`, "");

--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -35,7 +35,7 @@ export default class FightUiHandler extends UiHandler {
     this.movesContainer = this.scene.add.container(18, -38.7);
     ui.add(this.movesContainer);
 
-    this.typeIcon = this.scene.add.sprite((this.scene.game.canvas.width / 6) - 57, -36,`types${Utils.verifyLang(i18next.language) ? `_${i18next.language}` : ""}` , "unknown");
+    this.typeIcon = this.scene.add.sprite((this.scene.game.canvas.width / 6) - 57, -36,`types${Utils.verifyLang(i18next.resolvedLanguage) ? `_${i18next.resolvedLanguage}` : ""}` , "unknown");
     this.typeIcon.setVisible(false);
     ui.add(this.typeIcon);
 
@@ -168,7 +168,7 @@ export default class FightUiHandler extends UiHandler {
 
     if (hasMove) {
       const pokemonMove = moveset[cursor];
-      this.typeIcon.setTexture(`types${Utils.verifyLang(i18next.language) ? `_${i18next.language}` : ""}`, Type[pokemonMove.getMove().type].toLowerCase()).setScale(0.8);
+      this.typeIcon.setTexture(`types${Utils.verifyLang(i18next.resolvedLanguage) ? `_${i18next.resolvedLanguage}` : ""}`, Type[pokemonMove.getMove().type].toLowerCase()).setScale(0.8);
       this.moveCategoryIcon.setTexture("categories", MoveCategory[pokemonMove.getMove().category].toLowerCase()).setScale(1.0);
 
       const power = pokemonMove.getMove().power;

--- a/src/ui/pokemon-info-container.ts
+++ b/src/ui/pokemon-info-container.ts
@@ -73,7 +73,7 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
   }
 
   setup(): void {
-    const currentLanguage = i18next.language;
+    const currentLanguage = i18next.resolvedLanguage;
     const langSettingKey = Object.keys(languageSettings).find(lang => currentLanguage.includes(lang));
     const textSettings = languageSettings[langSettingKey];
     const infoBg = addWindow(this.scene, 0, 0, this.infoWindowWidth, 132);

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -251,7 +251,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
   setup() {
     const ui = this.getUi();
-    const currentLanguage = i18next.language;
+    const currentLanguage = i18next.resolvedLanguage;
     const langSettingKey = Object.keys(languageSettings).find(lang => currentLanguage.includes(lang));
     const textSettings = languageSettings[langSettingKey];
 
@@ -518,11 +518,11 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.pokemonSprite.setPipeline(this.scene.spritePipeline, { tone: [ 0.0, 0.0, 0.0, 0.0 ], ignoreTimeTint: true });
     this.starterSelectContainer.add(this.pokemonSprite);
 
-    this.type1Icon = this.scene.add.sprite(8, 98, `types${Utils.verifyLang(i18next.language) ? `_${i18next.language}` : ""}`);    this.type1Icon.setScale(0.5);
+    this.type1Icon = this.scene.add.sprite(8, 98, `types${Utils.verifyLang(i18next.resolvedLanguage) ? `_${i18next.resolvedLanguage}` : ""}`);    this.type1Icon.setScale(0.5);
     this.type1Icon.setOrigin(0, 0);
     this.starterSelectContainer.add(this.type1Icon);
 
-    this.type2Icon = this.scene.add.sprite(26, 98, `types${Utils.verifyLang(i18next.language) ? `_${i18next.language}` : ""}`);    this.type2Icon.setScale(0.5);
+    this.type2Icon = this.scene.add.sprite(26, 98, `types${Utils.verifyLang(i18next.resolvedLanguage) ? `_${i18next.resolvedLanguage}` : ""}`);    this.type2Icon.setScale(0.5);
     this.type2Icon.setOrigin(0, 0);
     this.starterSelectContainer.add(this.type2Icon);
 

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -695,7 +695,7 @@ export default class SummaryUiHandler extends UiHandler {
       const getTypeIcon = (index: integer, type: Type, tera: boolean = false) => {
         const xCoord = 39 + 34 * index;
         const typeIcon = !tera
-          ? this.scene.add.sprite(xCoord, 42, `types${Utils.verifyLang(i18next.language) ? `_${i18next.language}` : ""}`, Type[type].toLowerCase())          : this.scene.add.sprite(xCoord, 42, "type_tera");
+          ? this.scene.add.sprite(xCoord, 42, `types${Utils.verifyLang(i18next.resolvedLanguage) ? `_${i18next.resolvedLanguage}` : ""}`, Type[type].toLowerCase())          : this.scene.add.sprite(xCoord, 42, "type_tera");
         if (tera) {
           typeIcon.setScale(0.5);
           const typeRgb = getTypeRgb(type);
@@ -897,7 +897,7 @@ export default class SummaryUiHandler extends UiHandler {
 
       if (this.summaryUiMode === SummaryUiMode.LEARN_MOVE) {
         this.extraMoveRowContainer.setVisible(true);
-        const newMoveTypeIcon = this.scene.add.sprite(0, 0, `types${Utils.verifyLang(i18next.language) ? `_${i18next.language}` : ""}`, Type[this.newMove.type].toLowerCase());
+        const newMoveTypeIcon = this.scene.add.sprite(0, 0, `types${Utils.verifyLang(i18next.resolvedLanguage) ? `_${i18next.resolvedLanguage}` : ""}`, Type[this.newMove.type].toLowerCase());
         newMoveTypeIcon.setOrigin(0, 1);
         this.extraMoveRowContainer.add(newMoveTypeIcon);
 
@@ -920,7 +920,7 @@ export default class SummaryUiHandler extends UiHandler {
         this.moveRowsContainer.add(moveRowContainer);
 
         if (move) {
-          const typeIcon = this.scene.add.sprite(0, 0, `types${Utils.verifyLang(i18next.language) ? `_${i18next.language}` : ""}`, Type[move.getMove().type].toLowerCase());          typeIcon.setOrigin(0, 1);
+          const typeIcon = this.scene.add.sprite(0, 0, `types${Utils.verifyLang(i18next.resolvedLanguage) ? `_${i18next.resolvedLanguage}` : ""}`, Type[move.getMove().type].toLowerCase());          typeIcon.setOrigin(0, 1);
           moveRowContainer.add(typeIcon);
         }
 

--- a/src/ui/text.ts
+++ b/src/ui/text.ts
@@ -98,7 +98,7 @@ export function addTextInputObject(scene: Phaser.Scene, x: number, y: number, wi
 }
 
 function getTextStyleOptions(style: TextStyle, uiTheme: UiTheme, extraStyleOptions?: Phaser.Types.GameObjects.Text.TextStyle): [ Phaser.Types.GameObjects.Text.TextStyle | InputText.IConfig, string, number, number ] {
-  const lang = i18next.language;
+  const lang = i18next.resolvedLanguage;
   let shadowXpos = 4;
   let shadowYpos = 5;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -396,7 +396,7 @@ English itself counts as not available
 export function verifyLang(lang?: string): boolean {
   //IMPORTANT - ONLY ADD YOUR LANG HERE IF YOU'VE ALREADY ADDED ALL THE NECESSARY IMAGES
   if (!lang) {
-    lang = i18next.language;
+    lang = i18next.resolvedLanguage;
   }
 
   switch (lang) {


### PR DESCRIPTION
…for cases where we only have the short form "de".

<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Used https://www.i18next.com/overview/api#resolvedlanguage instead of language

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
While testing my browser autodetected the language to "de-DE" (German - Germany). So the type icons were not loaded correctly in german but in the fallback english. Same would happen for "fr-FR" (French - France) and others.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Changes i18next.language to i18next.resolvedLanugage everywhere

So for example if the browser says "de-DE". It will search that, not find it. Then try "de" find that and set it as a language.

This doesnt break the fallback to english at all that we have for completly unsupported languages (like currently for example CZ or something)

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

None

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

Set your browser to "de-DE" or "fr-FR". It should still load the type images in the correct languages

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?