### PR TITLE
[Move] Implemented Court Change

### DIFF
--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -28,23 +28,25 @@ export abstract class ArenaTag {
   public sourceMove: Moves;
   public sourceId: integer;
   public side: ArenaTagSide;
+  public quiet: boolean;
 
-  constructor(tagType: ArenaTagType, turnCount: integer, sourceMove: Moves, sourceId?: integer, side: ArenaTagSide = ArenaTagSide.BOTH) {
+  constructor(tagType: ArenaTagType, turnCount: integer, sourceMove: Moves, sourceId?: integer, side: ArenaTagSide = ArenaTagSide.BOTH, quiet: boolean = false) {
     this.tagType = tagType;
     this.turnCount = turnCount;
     this.sourceMove = sourceMove;
     this.sourceId = sourceId;
     this.side = side;
+    this.quiet = quiet;
   }
 
   apply(arena: Arena, args: any[]): boolean {
     return true;
   }
 
-  onAdd(arena: Arena, quiet: boolean = false): void { }
+  onAdd(arena: Arena): void { }
 
-  onRemove(arena: Arena, quiet: boolean = false): void {
-    if (quiet === false) {
+  onRemove(arena: Arena): void {
+    if (!this.quiet) {
       arena.scene.queueMessage(`${this.getMoveName()}\'s effect wore off${this.side === ArenaTagSide.PLAYER ? "\non your side" : this.side === ArenaTagSide.ENEMY ? "\non the foe's side" : ""}.`);
     }
   }
@@ -67,11 +69,11 @@ export class MistTag extends ArenaTag {
     super(ArenaTagType.MIST, turnCount, Moves.MIST, sourceId, side);
   }
 
-  onAdd(arena: Arena, quiet: boolean): void {
-    super.onAdd(arena, quiet);
+  onAdd(arena: Arena): void {
+    super.onAdd(arena);
 
     const source = arena.scene.getPokemonById(this.sourceId);
-    if (quiet === false) {
+    if (!this.quiet) {
       arena.scene.queueMessage(getPokemonMessage(source, "'s team became\nshrouded in mist!"));
     }
   }
@@ -117,8 +119,8 @@ class ReflectTag extends WeakenMoveScreenTag {
     return false;
   }
 
-  onAdd(arena: Arena, quiet: boolean): void {
-    if (quiet === false) {
+  onAdd(arena: Arena): void {
+    if (!this.quiet) {
       arena.scene.queueMessage(`Reflect reduced the damage of physical moves${this.side === ArenaTagSide.PLAYER ? "\non your side" : this.side === ArenaTagSide.ENEMY ? "\non the foe's side" : ""}.`);
     }
   }
@@ -141,8 +143,8 @@ class LightScreenTag extends WeakenMoveScreenTag {
     return false;
   }
 
-  onAdd(arena: Arena, quiet: boolean): void {
-    if (quiet === false) {
+  onAdd(arena: Arena): void {
+    if (!this.quiet) {
       arena.scene.queueMessage(`Light Screen reduced the damage of special moves${this.side === ArenaTagSide.PLAYER ? "\non your side" : this.side === ArenaTagSide.ENEMY ? "\non the foe's side" : ""}.`);
     }
   }
@@ -153,8 +155,8 @@ class AuroraVeilTag extends WeakenMoveScreenTag {
     super(ArenaTagType.AURORA_VEIL, turnCount, Moves.AURORA_VEIL, sourceId, side);
   }
 
-  onAdd(arena: Arena, quiet: boolean): void {
-    if (quiet === false) {
+  onAdd(arena: Arena): void {
+    if (!this.quiet) {
       arena.scene.queueMessage(`Aurora Veil reduced the damage of moves${this.side === ArenaTagSide.PLAYER ? "\non your side" : this.side === ArenaTagSide.ENEMY ? "\non the foe's side" : ""}.`);
     }
   }
@@ -396,11 +398,11 @@ class SpikesTag extends ArenaTrapTag {
     super(ArenaTagType.SPIKES, Moves.SPIKES, sourceId, side, 3);
   }
 
-  onAdd(arena: Arena, quiet: boolean): void {
-    super.onAdd(arena, quiet);
+  onAdd(arena: Arena): void {
+    super.onAdd(arena);
 
     const source = arena.scene.getPokemonById(this.sourceId);
-    if (quiet === false) {
+    if (!this.quiet) {
       arena.scene.queueMessage(`${this.getMoveName()} were scattered\nall around ${source.getOpponentDescriptor()}'s feet!`);
     }
   }
@@ -435,18 +437,18 @@ class ToxicSpikesTag extends ArenaTrapTag {
     this.neutralized = false;
   }
 
-  onAdd(arena: Arena, quiet: boolean): void {
-    super.onAdd(arena, quiet);
+  onAdd(arena: Arena): void {
+    super.onAdd(arena);
 
     const source = arena.scene.getPokemonById(this.sourceId);
-    if (quiet === false) {
+    if (!this.quiet) {
       arena.scene.queueMessage(`${this.getMoveName()} were scattered\nall around ${source.getOpponentDescriptor()}'s feet!`);
     }
   }
 
-  onRemove(arena: Arena, quiet: boolean): void {
+  onRemove(arena: Arena): void {
     if (!this.neutralized) {
-      super.onRemove(arena, quiet);
+      super.onRemove(arena);
     }
   }
 
@@ -507,11 +509,11 @@ class StealthRockTag extends ArenaTrapTag {
     super(ArenaTagType.STEALTH_ROCK, Moves.STEALTH_ROCK, sourceId, side, 1);
   }
 
-  onAdd(arena: Arena, quiet: boolean): void {
-    super.onAdd(arena, quiet);
+  onAdd(arena: Arena): void {
+    super.onAdd(arena);
 
     const source = arena.scene.getPokemonById(this.sourceId);
-    if (quiet === false) {
+    if (!this.quiet) {
       arena.scene.queueMessage(`Pointed stones float in the air\naround ${source.getOpponentDescriptor()}!`);
     }
   }
@@ -578,13 +580,13 @@ class StickyWebTag extends ArenaTrapTag {
     super(ArenaTagType.STICKY_WEB, Moves.STICKY_WEB, sourceId, side, 1);
   }
 
-  onAdd(arena: Arena, quiet: boolean): void {
-    super.onAdd(arena, quiet);
+  onAdd(arena: Arena): void {
+    super.onAdd(arena);
 
     // does not seem to be used anywhere
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const source = arena.scene.getPokemonById(this.sourceId);
-    if (quiet === false) {
+    if (!this.quiet) {
       arena.scene.queueMessage(`A ${this.getMoveName()} has been laid out on the ground around the opposing team!`);
     }
   }
@@ -644,8 +646,8 @@ class TailwindTag extends ArenaTag {
     super(ArenaTagType.TAILWIND, turnCount, Moves.TAILWIND, sourceId, side);
   }
 
-  onAdd(arena: Arena, quiet: boolean): void {
-    if (quiet === false) {
+  onAdd(arena: Arena): void {
+    if (!this.quiet) {
       arena.scene.queueMessage(`The Tailwind blew from behind${this.side === ArenaTagSide.PLAYER ? "\nyour" : this.side === ArenaTagSide.ENEMY ? "\nthe opposing" : ""} team!`);
     }
 
@@ -666,8 +668,8 @@ class TailwindTag extends ArenaTag {
     }
   }
 
-  onRemove(arena: Arena, quiet: boolean): void {
-    if (quiet === false) {
+  onRemove(arena: Arena): void {
+    if (!this.quiet) {
       arena.scene.queueMessage(`${this.side === ArenaTagSide.PLAYER ? "Your" : this.side === ArenaTagSide.ENEMY ? "The opposing" : ""} team's Tailwind petered out!`);
     }
   }

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -28,25 +28,24 @@ export abstract class ArenaTag {
   public sourceMove: Moves;
   public sourceId: integer;
   public side: ArenaTagSide;
-  public quiet: boolean;
 
-  constructor(tagType: ArenaTagType, turnCount: integer, sourceMove: Moves, sourceId?: integer, side: ArenaTagSide = ArenaTagSide.BOTH, quiet: boolean = false) {
+
+  constructor(tagType: ArenaTagType, turnCount: integer, sourceMove: Moves, sourceId?: integer, side: ArenaTagSide = ArenaTagSide.BOTH) {
     this.tagType = tagType;
     this.turnCount = turnCount;
     this.sourceMove = sourceMove;
     this.sourceId = sourceId;
     this.side = side;
-    this.quiet = quiet;
   }
 
   apply(arena: Arena, args: any[]): boolean {
     return true;
   }
 
-  onAdd(arena: Arena): void { }
+  onAdd(arena: Arena, quiet: boolean = false): void { }
 
-  onRemove(arena: Arena): void {
-    if (!this.quiet) {
+  onRemove(arena: Arena, quiet: boolean = false): void {
+    if (!quiet) {
       arena.scene.queueMessage(`${this.getMoveName()}\'s effect wore off${this.side === ArenaTagSide.PLAYER ? "\non your side" : this.side === ArenaTagSide.ENEMY ? "\non the foe's side" : ""}.`);
     }
   }
@@ -69,11 +68,11 @@ export class MistTag extends ArenaTag {
     super(ArenaTagType.MIST, turnCount, Moves.MIST, sourceId, side);
   }
 
-  onAdd(arena: Arena): void {
+  onAdd(arena: Arena, quiet: boolean = false): void {
     super.onAdd(arena);
 
     const source = arena.scene.getPokemonById(this.sourceId);
-    if (!this.quiet) {
+    if (!quiet) {
       arena.scene.queueMessage(getPokemonMessage(source, "'s team became\nshrouded in mist!"));
     }
   }
@@ -119,8 +118,8 @@ class ReflectTag extends WeakenMoveScreenTag {
     return false;
   }
 
-  onAdd(arena: Arena): void {
-    if (!this.quiet) {
+  onAdd(arena: Arena, quiet: boolean = false): void {
+    if (!quiet) {
       arena.scene.queueMessage(`Reflect reduced the damage of physical moves${this.side === ArenaTagSide.PLAYER ? "\non your side" : this.side === ArenaTagSide.ENEMY ? "\non the foe's side" : ""}.`);
     }
   }
@@ -143,8 +142,8 @@ class LightScreenTag extends WeakenMoveScreenTag {
     return false;
   }
 
-  onAdd(arena: Arena): void {
-    if (!this.quiet) {
+  onAdd(arena: Arena, quiet: boolean = false): void {
+    if (!quiet) {
       arena.scene.queueMessage(`Light Screen reduced the damage of special moves${this.side === ArenaTagSide.PLAYER ? "\non your side" : this.side === ArenaTagSide.ENEMY ? "\non the foe's side" : ""}.`);
     }
   }
@@ -155,8 +154,8 @@ class AuroraVeilTag extends WeakenMoveScreenTag {
     super(ArenaTagType.AURORA_VEIL, turnCount, Moves.AURORA_VEIL, sourceId, side);
   }
 
-  onAdd(arena: Arena): void {
-    if (!this.quiet) {
+  onAdd(arena: Arena, quiet: boolean = false): void {
+    if (!quiet) {
       arena.scene.queueMessage(`Aurora Veil reduced the damage of moves${this.side === ArenaTagSide.PLAYER ? "\non your side" : this.side === ArenaTagSide.ENEMY ? "\non the foe's side" : ""}.`);
     }
   }
@@ -398,11 +397,11 @@ class SpikesTag extends ArenaTrapTag {
     super(ArenaTagType.SPIKES, Moves.SPIKES, sourceId, side, 3);
   }
 
-  onAdd(arena: Arena): void {
+  onAdd(arena: Arena, quiet: boolean = false): void {
     super.onAdd(arena);
 
     const source = arena.scene.getPokemonById(this.sourceId);
-    if (!this.quiet) {
+    if (!quiet) {
       arena.scene.queueMessage(`${this.getMoveName()} were scattered\nall around ${source.getOpponentDescriptor()}'s feet!`);
     }
   }
@@ -437,11 +436,11 @@ class ToxicSpikesTag extends ArenaTrapTag {
     this.neutralized = false;
   }
 
-  onAdd(arena: Arena): void {
+  onAdd(arena: Arena, quiet: boolean = false): void {
     super.onAdd(arena);
 
     const source = arena.scene.getPokemonById(this.sourceId);
-    if (!this.quiet) {
+    if (!quiet) {
       arena.scene.queueMessage(`${this.getMoveName()} were scattered\nall around ${source.getOpponentDescriptor()}'s feet!`);
     }
   }
@@ -509,11 +508,11 @@ class StealthRockTag extends ArenaTrapTag {
     super(ArenaTagType.STEALTH_ROCK, Moves.STEALTH_ROCK, sourceId, side, 1);
   }
 
-  onAdd(arena: Arena): void {
+  onAdd(arena: Arena, quiet: boolean = false): void {
     super.onAdd(arena);
 
     const source = arena.scene.getPokemonById(this.sourceId);
-    if (!this.quiet) {
+    if (!quiet) {
       arena.scene.queueMessage(`Pointed stones float in the air\naround ${source.getOpponentDescriptor()}!`);
     }
   }
@@ -580,13 +579,13 @@ class StickyWebTag extends ArenaTrapTag {
     super(ArenaTagType.STICKY_WEB, Moves.STICKY_WEB, sourceId, side, 1);
   }
 
-  onAdd(arena: Arena): void {
+  onAdd(arena: Arena, quiet: boolean = false): void {
     super.onAdd(arena);
 
     // does not seem to be used anywhere
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const source = arena.scene.getPokemonById(this.sourceId);
-    if (!this.quiet) {
+    if (!quiet) {
       arena.scene.queueMessage(`A ${this.getMoveName()} has been laid out on the ground around the opposing team!`);
     }
   }
@@ -646,8 +645,8 @@ class TailwindTag extends ArenaTag {
     super(ArenaTagType.TAILWIND, turnCount, Moves.TAILWIND, sourceId, side);
   }
 
-  onAdd(arena: Arena): void {
-    if (!this.quiet) {
+  onAdd(arena: Arena, quiet: boolean = false): void {
+    if (!quiet) {
       arena.scene.queueMessage(`The Tailwind blew from behind${this.side === ArenaTagSide.PLAYER ? "\nyour" : this.side === ArenaTagSide.ENEMY ? "\nthe opposing" : ""} team!`);
     }
 
@@ -668,8 +667,8 @@ class TailwindTag extends ArenaTag {
     }
   }
 
-  onRemove(arena: Arena): void {
-    if (!this.quiet) {
+  onRemove(arena: Arena, quiet: boolean = false): void {
+    if (!quiet) {
       arena.scene.queueMessage(`${this.side === ArenaTagSide.PLAYER ? "Your" : this.side === ArenaTagSide.ENEMY ? "The opposing" : ""} team's Tailwind petered out!`);
     }
   }

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -41,10 +41,12 @@ export abstract class ArenaTag {
     return true;
   }
 
-  onAdd(arena: Arena): void { }
+  onAdd(arena: Arena, quiet: boolean = false): void { }
 
-  onRemove(arena: Arena): void {
-    arena.scene.queueMessage(`${this.getMoveName()}\'s effect wore off${this.side === ArenaTagSide.PLAYER ? "\non your side" : this.side === ArenaTagSide.ENEMY ? "\non the foe's side" : ""}.`);
+  onRemove(arena: Arena, quiet: boolean = false): void {
+    if (quiet === false) {
+      arena.scene.queueMessage(`${this.getMoveName()}\'s effect wore off${this.side === ArenaTagSide.PLAYER ? "\non your side" : this.side === ArenaTagSide.ENEMY ? "\non the foe's side" : ""}.`);
+    }
   }
 
   onOverlap(arena: Arena): void { }
@@ -65,11 +67,13 @@ export class MistTag extends ArenaTag {
     super(ArenaTagType.MIST, turnCount, Moves.MIST, sourceId, side);
   }
 
-  onAdd(arena: Arena): void {
-    super.onAdd(arena);
+  onAdd(arena: Arena, quiet: boolean): void {
+    super.onAdd(arena, quiet);
 
     const source = arena.scene.getPokemonById(this.sourceId);
-    arena.scene.queueMessage(getPokemonMessage(source, "'s team became\nshrouded in mist!"));
+    if (quiet === false) {
+      arena.scene.queueMessage(getPokemonMessage(source, "'s team became\nshrouded in mist!"));
+    }
   }
 
   apply(arena: Arena, args: any[]): boolean {
@@ -113,8 +117,10 @@ class ReflectTag extends WeakenMoveScreenTag {
     return false;
   }
 
-  onAdd(arena: Arena): void {
-    arena.scene.queueMessage(`Reflect reduced the damage of physical moves${this.side === ArenaTagSide.PLAYER ? "\non your side" : this.side === ArenaTagSide.ENEMY ? "\non the foe's side" : ""}.`);
+  onAdd(arena: Arena, quiet: boolean): void {
+    if (quiet === false) {
+      arena.scene.queueMessage(`Reflect reduced the damage of physical moves${this.side === ArenaTagSide.PLAYER ? "\non your side" : this.side === ArenaTagSide.ENEMY ? "\non the foe's side" : ""}.`);
+    }
   }
 }
 
@@ -135,8 +141,10 @@ class LightScreenTag extends WeakenMoveScreenTag {
     return false;
   }
 
-  onAdd(arena: Arena): void {
-    arena.scene.queueMessage(`Light Screen reduced the damage of special moves${this.side === ArenaTagSide.PLAYER ? "\non your side" : this.side === ArenaTagSide.ENEMY ? "\non the foe's side" : ""}.`);
+  onAdd(arena: Arena, quiet: boolean): void {
+    if (quiet === false) {
+      arena.scene.queueMessage(`Light Screen reduced the damage of special moves${this.side === ArenaTagSide.PLAYER ? "\non your side" : this.side === ArenaTagSide.ENEMY ? "\non the foe's side" : ""}.`);
+    }
   }
 }
 
@@ -145,8 +153,10 @@ class AuroraVeilTag extends WeakenMoveScreenTag {
     super(ArenaTagType.AURORA_VEIL, turnCount, Moves.AURORA_VEIL, sourceId, side);
   }
 
-  onAdd(arena: Arena): void {
-    arena.scene.queueMessage(`Aurora Veil reduced the damage of moves${this.side === ArenaTagSide.PLAYER ? "\non your side" : this.side === ArenaTagSide.ENEMY ? "\non the foe's side" : ""}.`);
+  onAdd(arena: Arena, quiet: boolean): void {
+    if (quiet === false) {
+      arena.scene.queueMessage(`Aurora Veil reduced the damage of moves${this.side === ArenaTagSide.PLAYER ? "\non your side" : this.side === ArenaTagSide.ENEMY ? "\non the foe's side" : ""}.`);
+    }
   }
 }
 
@@ -386,11 +396,13 @@ class SpikesTag extends ArenaTrapTag {
     super(ArenaTagType.SPIKES, Moves.SPIKES, sourceId, side, 3);
   }
 
-  onAdd(arena: Arena): void {
-    super.onAdd(arena);
+  onAdd(arena: Arena, quiet: boolean): void {
+    super.onAdd(arena, quiet);
 
     const source = arena.scene.getPokemonById(this.sourceId);
-    arena.scene.queueMessage(`${this.getMoveName()} were scattered\nall around ${source.getOpponentDescriptor()}'s feet!`);
+    if (quiet === false) {
+      arena.scene.queueMessage(`${this.getMoveName()} were scattered\nall around ${source.getOpponentDescriptor()}'s feet!`);
+    }
   }
 
   activateTrap(pokemon: Pokemon): boolean {
@@ -423,16 +435,18 @@ class ToxicSpikesTag extends ArenaTrapTag {
     this.neutralized = false;
   }
 
-  onAdd(arena: Arena): void {
-    super.onAdd(arena);
+  onAdd(arena: Arena, quiet: boolean): void {
+    super.onAdd(arena, quiet);
 
     const source = arena.scene.getPokemonById(this.sourceId);
-    arena.scene.queueMessage(`${this.getMoveName()} were scattered\nall around ${source.getOpponentDescriptor()}'s feet!`);
+    if (quiet === false) {
+      arena.scene.queueMessage(`${this.getMoveName()} were scattered\nall around ${source.getOpponentDescriptor()}'s feet!`);
+    }
   }
 
-  onRemove(arena: Arena): void {
+  onRemove(arena: Arena, quiet: boolean): void {
     if (!this.neutralized) {
-      super.onRemove(arena);
+      super.onRemove(arena, quiet);
     }
   }
 
@@ -493,11 +507,13 @@ class StealthRockTag extends ArenaTrapTag {
     super(ArenaTagType.STEALTH_ROCK, Moves.STEALTH_ROCK, sourceId, side, 1);
   }
 
-  onAdd(arena: Arena): void {
-    super.onAdd(arena);
+  onAdd(arena: Arena, quiet: boolean): void {
+    super.onAdd(arena, quiet);
 
     const source = arena.scene.getPokemonById(this.sourceId);
-    arena.scene.queueMessage(`Pointed stones float in the air\naround ${source.getOpponentDescriptor()}!`);
+    if (quiet === false) {
+      arena.scene.queueMessage(`Pointed stones float in the air\naround ${source.getOpponentDescriptor()}!`);
+    }
   }
 
   getDamageHpRatio(pokemon: Pokemon): number {
@@ -562,13 +578,15 @@ class StickyWebTag extends ArenaTrapTag {
     super(ArenaTagType.STICKY_WEB, Moves.STICKY_WEB, sourceId, side, 1);
   }
 
-  onAdd(arena: Arena): void {
-    super.onAdd(arena);
+  onAdd(arena: Arena, quiet: boolean): void {
+    super.onAdd(arena, quiet);
 
     // does not seem to be used anywhere
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const source = arena.scene.getPokemonById(this.sourceId);
-    arena.scene.queueMessage(`A ${this.getMoveName()} has been laid out on the ground around the opposing team!`);
+    if (quiet === false) {
+      arena.scene.queueMessage(`A ${this.getMoveName()} has been laid out on the ground around the opposing team!`);
+    }
   }
 
   activateTrap(pokemon: Pokemon): boolean {
@@ -626,8 +644,10 @@ class TailwindTag extends ArenaTag {
     super(ArenaTagType.TAILWIND, turnCount, Moves.TAILWIND, sourceId, side);
   }
 
-  onAdd(arena: Arena): void {
-    arena.scene.queueMessage(`The Tailwind blew from behind${this.side === ArenaTagSide.PLAYER ? "\nyour" : this.side === ArenaTagSide.ENEMY ? "\nthe opposing" : ""} team!`);
+  onAdd(arena: Arena, quiet: boolean): void {
+    if (quiet === false) {
+      arena.scene.queueMessage(`The Tailwind blew from behind${this.side === ArenaTagSide.PLAYER ? "\nyour" : this.side === ArenaTagSide.ENEMY ? "\nthe opposing" : ""} team!`);
+    }
 
     const source = arena.scene.getPokemonById(this.sourceId);
     const party = source.isPlayer() ? source.scene.getPlayerField() : source.scene.getEnemyField();
@@ -646,8 +666,10 @@ class TailwindTag extends ArenaTag {
     }
   }
 
-  onRemove(arena: Arena): void {
-    arena.scene.queueMessage(`${this.side === ArenaTagSide.PLAYER ? "Your" : this.side === ArenaTagSide.ENEMY ? "The opposing" : ""} team's Tailwind petered out!`);
+  onRemove(arena: Arena, quiet: boolean): void {
+    if (quiet === false) {
+      arena.scene.queueMessage(`${this.side === ArenaTagSide.PLAYER ? "Your" : this.side === ArenaTagSide.ENEMY ? "The opposing" : ""} team's Tailwind petered out!`);
+    }
   }
 }
 

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -4040,30 +4040,35 @@ export class SwapArenaTagsAttr extends MoveEffectAttr {
     }
     const swapTags = [ArenaTagType.AURORA_VEIL, ArenaTagType.LIGHT_SCREEN, ArenaTagType.MIST, ArenaTagType.REFLECT, ArenaTagType.SPIKES, ArenaTagType.STEALTH_ROCK, ArenaTagType.STICKY_WEB, ArenaTagType.TAILWIND, ArenaTagType.TOXIC_SPIKES];
 
-    for (const swapTagType of swapTags) {
+    const tagPlayerTemp = user.scene.arena.findTagsOnSide((t => swapTags.includes(t.tagType)), ArenaTagSide.PLAYER);
+    const tagEnemyTemp = user.scene.arena.findTagsOnSide((t => swapTags.includes(t.tagType)), ArenaTagSide.ENEMY);
 
-      const tagPlayerTemp = user.scene.arena.getTagOnSide(swapTagType, ArenaTagSide.PLAYER);
-      const tagEnemyTemp = user.scene.arena.getTagOnSide(swapTagType, ArenaTagSide.ENEMY);
 
-      if (tagPlayerTemp) {
-        user.scene.arena.removeTagOnSide(swapTagType, ArenaTagSide.PLAYER, true);
-        user.scene.arena.addTag(tagPlayerTemp.tagType, tagPlayerTemp.turnCount, tagPlayerTemp.sourceMove, tagPlayerTemp.sourceId, ArenaTagSide.ENEMY, true);
+    if (tagPlayerTemp) {
+      for (const swapTagsType of tagPlayerTemp) {
+        user.scene.arena.removeTagOnSide(swapTagsType.tagType, ArenaTagSide.PLAYER, true);
+        user.scene.arena.addTag(swapTagsType.tagType, swapTagsType.turnCount, swapTagsType.sourceMove, swapTagsType.sourceId, ArenaTagSide.ENEMY, true);
       }
-      if (tagEnemyTemp) {
-        user.scene.arena.removeTagOnSide(swapTagType, ArenaTagSide.ENEMY, true);
-        user.scene.arena.addTag(tagEnemyTemp.tagType, tagEnemyTemp.turnCount, tagEnemyTemp.sourceMove, tagEnemyTemp.sourceId, ArenaTagSide.PLAYER, true);
-      }
-
-      if (tagEnemyTemp && tagPlayerTemp) {
-
-        user.scene.arena.removeTagOnSide(swapTagType, ArenaTagSide.PLAYER, true);
-        user.scene.arena.addTag(tagPlayerTemp.tagType, tagPlayerTemp.turnCount, tagPlayerTemp.sourceMove, tagPlayerTemp.sourceId, ArenaTagSide.ENEMY, true);
-
-        user.scene.arena.removeTagOnSide(swapTagType, ArenaTagSide.ENEMY, true);
-        user.scene.arena.addTag(tagEnemyTemp.tagType, tagEnemyTemp.turnCount, tagEnemyTemp.sourceMove, tagEnemyTemp.sourceId, ArenaTagSide.PLAYER, true);
-      }
-
     }
+    if (tagEnemyTemp) {
+      for (const swapTagsType of tagEnemyTemp) {
+        user.scene.arena.removeTagOnSide(swapTagsType.tagType, ArenaTagSide.ENEMY, true);
+        user.scene.arena.addTag(swapTagsType.tagType, swapTagsType.turnCount, swapTagsType.sourceMove, swapTagsType.sourceId, ArenaTagSide.PLAYER, true);
+      }
+    }
+
+    if (tagEnemyTemp && tagPlayerTemp) {
+      for (const swapTagsType of tagPlayerTemp) {
+        user.scene.arena.removeTagOnSide(swapTagsType.tagType, ArenaTagSide.PLAYER, true);
+        user.scene.arena.addTag(swapTagsType.tagType, swapTagsType.turnCount, swapTagsType.sourceMove, swapTagsType.sourceId, ArenaTagSide.ENEMY, true);
+      }
+      for (const swapTagsType of tagEnemyTemp) {
+        user.scene.arena.removeTagOnSide(swapTagsType.tagType, ArenaTagSide.ENEMY, true);
+        user.scene.arena.addTag(swapTagsType.tagType, swapTagsType.turnCount, swapTagsType.sourceMove, swapTagsType.sourceId, ArenaTagSide.PLAYER, true);
+      }
+    }
+
+
 
     user.scene.queueMessage( `${user.name} swapped the battle effects affecting each side of the field!`);
     return true;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -4027,21 +4027,21 @@ export class RemoveScreensAttr extends MoveEffectAttr {
   * @see {@linkcode apply}
 */
 export class SwapArenaTagsAttr extends MoveEffectAttr {
-  public ArenaTags: ArenaTagType[];
+  public SwapTags: ArenaTagType[];
 
 
-  constructor() {
+  constructor(SwapTags: ArenaTagType[]) {
     super(true, MoveEffectTrigger.POST_APPLY);
+    this.SwapTags = SwapTags;
   }
 
   apply(user:Pokemon, target:Pokemon, move:Move, args: any[]): boolean {
     if (!super.apply(user, target, move, args)) {
       return false;
     }
-    const swapTags = [ArenaTagType.AURORA_VEIL, ArenaTagType.LIGHT_SCREEN, ArenaTagType.MIST, ArenaTagType.REFLECT, ArenaTagType.SPIKES, ArenaTagType.STEALTH_ROCK, ArenaTagType.STICKY_WEB, ArenaTagType.TAILWIND, ArenaTagType.TOXIC_SPIKES];
 
-    const tagPlayerTemp = user.scene.arena.findTagsOnSide((t => swapTags.includes(t.tagType)), ArenaTagSide.PLAYER);
-    const tagEnemyTemp = user.scene.arena.findTagsOnSide((t => swapTags.includes(t.tagType)), ArenaTagSide.ENEMY);
+    const tagPlayerTemp = user.scene.arena.findTagsOnSide((t => this.SwapTags.includes(t.tagType)), ArenaTagSide.PLAYER);
+    const tagEnemyTemp = user.scene.arena.findTagsOnSide((t => this.SwapTags.includes(t.tagType)), ArenaTagSide.ENEMY);
 
 
     if (tagPlayerTemp) {
@@ -7295,7 +7295,7 @@ export function initMoves() {
       .attr(FirstAttackDoublePowerAttr)
       .bitingMove(),
     new StatusMove(Moves.COURT_CHANGE, Type.NORMAL, 100, 10, -1, 0, 8)
-      .attr(SwapArenaTagsAttr),
+      .attr(SwapArenaTagsAttr, [ArenaTagType.AURORA_VEIL, ArenaTagType.LIGHT_SCREEN, ArenaTagType.MIST, ArenaTagType.REFLECT, ArenaTagType.SPIKES, ArenaTagType.STEALTH_ROCK, ArenaTagType.STICKY_WEB, ArenaTagType.TAILWIND, ArenaTagType.TOXIC_SPIKES]),
     new AttackMove(Moves.MAX_FLARE, Type.FIRE, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .target(MoveTarget.NEAR_ENEMY)
       .unimplemented()

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -4057,18 +4057,6 @@ export class SwapArenaTagsAttr extends MoveEffectAttr {
       }
     }
 
-    if (tagEnemyTemp && tagPlayerTemp) {
-      for (const swapTagsType of tagPlayerTemp) {
-        user.scene.arena.removeTagOnSide(swapTagsType.tagType, ArenaTagSide.PLAYER, true);
-        user.scene.arena.addTag(swapTagsType.tagType, swapTagsType.turnCount, swapTagsType.sourceMove, swapTagsType.sourceId, ArenaTagSide.ENEMY, true);
-      }
-      for (const swapTagsType of tagEnemyTemp) {
-        user.scene.arena.removeTagOnSide(swapTagsType.tagType, ArenaTagSide.ENEMY, true);
-        user.scene.arena.addTag(swapTagsType.tagType, swapTagsType.turnCount, swapTagsType.sourceMove, swapTagsType.sourceId, ArenaTagSide.PLAYER, true);
-      }
-    }
-
-
 
     user.scene.queueMessage( `${user.name} swapped the battle effects affecting each side of the field!`);
     return true;

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -547,8 +547,9 @@ export class Arena {
     }
 
     const newTag = getArenaTag(tagType, turnCount || 0, sourceMove, sourceId, targetIndex, side);
+    newTag.quiet = quiet;
     this.tags.push(newTag);
-    newTag.onAdd(this, quiet);
+    newTag.onAdd(this);
 
     this.eventTarget.dispatchEvent(new TagAddedEvent(newTag.tagType, newTag.side, newTag.turnCount));
 
@@ -597,7 +598,8 @@ export class Arena {
   removeTagOnSide(tagType: ArenaTagType, side: ArenaTagSide, quiet: boolean = false): boolean {
     const tag = this.getTagOnSide(tagType, side);
     if (tag) {
-      tag.onRemove(this, quiet);
+      tag.quiet = quiet;
+      tag.onRemove(this);
       this.tags.splice(this.tags.indexOf(tag), 1);
 
       this.eventTarget.dispatchEvent(new TagRemovedEvent(tag.tagType, tag.side, tag.turnCount));

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -547,9 +547,8 @@ export class Arena {
     }
 
     const newTag = getArenaTag(tagType, turnCount || 0, sourceMove, sourceId, targetIndex, side);
-    newTag.quiet = quiet;
     this.tags.push(newTag);
-    newTag.onAdd(this);
+    newTag.onAdd(this, quiet);
 
     this.eventTarget.dispatchEvent(new TagAddedEvent(newTag.tagType, newTag.side, newTag.turnCount));
 
@@ -598,8 +597,7 @@ export class Arena {
   removeTagOnSide(tagType: ArenaTagType, side: ArenaTagSide, quiet: boolean = false): boolean {
     const tag = this.getTagOnSide(tagType, side);
     if (tag) {
-      tag.quiet = quiet;
-      tag.onRemove(this);
+      tag.onRemove(this, quiet);
       this.tags.splice(this.tags.indexOf(tag), 1);
 
       this.eventTarget.dispatchEvent(new TagRemovedEvent(tag.tagType, tag.side, tag.turnCount));

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -539,7 +539,7 @@ export class Arena {
     this.applyTagsForSide(tagType, ArenaTagSide.BOTH, ...args);
   }
 
-  addTag(tagType: ArenaTagType, turnCount: integer, sourceMove: Moves, sourceId: integer, side: ArenaTagSide = ArenaTagSide.BOTH, targetIndex?: BattlerIndex): boolean {
+  addTag(tagType: ArenaTagType, turnCount: integer, sourceMove: Moves, sourceId: integer, side: ArenaTagSide = ArenaTagSide.BOTH, quiet: boolean = false, targetIndex?: BattlerIndex): boolean {
     const existingTag = this.getTagOnSide(tagType, side);
     if (existingTag) {
       existingTag.onOverlap(this);
@@ -548,7 +548,7 @@ export class Arena {
 
     const newTag = getArenaTag(tagType, turnCount || 0, sourceMove, sourceId, targetIndex, side);
     this.tags.push(newTag);
-    newTag.onAdd(this);
+    newTag.onAdd(this, quiet);
 
     this.eventTarget.dispatchEvent(new TagAddedEvent(newTag.tagType, newTag.side, newTag.turnCount));
 
@@ -594,10 +594,10 @@ export class Arena {
     return !!tag;
   }
 
-  removeTagOnSide(tagType: ArenaTagType, side: ArenaTagSide): boolean {
+  removeTagOnSide(tagType: ArenaTagType, side: ArenaTagSide, quiet: boolean = false): boolean {
     const tag = this.getTagOnSide(tagType, side);
     if (tag) {
-      tag.onRemove(this);
+      tag.onRemove(this, quiet);
       this.tags.splice(this.tags.indexOf(tag), 1);
 
       this.eventTarget.dispatchEvent(new TagRemovedEvent(tag.tagType, tag.side, tag.turnCount));

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -67,7 +67,7 @@ export const ABILITY_OVERRIDE: Abilities = Abilities.NONE;
 export const PASSIVE_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
 export const STATUS_OVERRIDE: StatusEffect = StatusEffect.NONE;
 export const GENDER_OVERRIDE: Gender = null;
-export const MOVESET_OVERRIDE: Array<Moves> = [Moves.COURT_CHANGE];
+export const MOVESET_OVERRIDE: Array<Moves> = [];
 export const SHINY_OVERRIDE: boolean = false;
 export const VARIANT_OVERRIDE: Variant = 0;
 
@@ -81,7 +81,7 @@ export const OPP_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
 export const OPP_PASSIVE_ABILITY_OVERRIDE = Abilities.NONE;
 export const OPP_STATUS_OVERRIDE: StatusEffect = StatusEffect.NONE;
 export const OPP_GENDER_OVERRIDE: Gender = null;
-export const OPP_MOVESET_OVERRIDE: Array<Moves> = [Moves.SPIKES];
+export const OPP_MOVESET_OVERRIDE: Array<Moves> = [];
 export const OPP_SHINY_OVERRIDE: boolean = false;
 export const OPP_VARIANT_OVERRIDE: Variant = 0;
 

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -67,7 +67,7 @@ export const ABILITY_OVERRIDE: Abilities = Abilities.NONE;
 export const PASSIVE_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
 export const STATUS_OVERRIDE: StatusEffect = StatusEffect.NONE;
 export const GENDER_OVERRIDE: Gender = null;
-export const MOVESET_OVERRIDE: Array<Moves> = [];
+export const MOVESET_OVERRIDE: Array<Moves> = [Moves.COURT_CHANGE];
 export const SHINY_OVERRIDE: boolean = false;
 export const VARIANT_OVERRIDE: Variant = 0;
 
@@ -81,7 +81,7 @@ export const OPP_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
 export const OPP_PASSIVE_ABILITY_OVERRIDE = Abilities.NONE;
 export const OPP_STATUS_OVERRIDE: StatusEffect = StatusEffect.NONE;
 export const OPP_GENDER_OVERRIDE: Gender = null;
-export const OPP_MOVESET_OVERRIDE: Array<Moves> = [];
+export const OPP_MOVESET_OVERRIDE: Array<Moves> = [Moves.SPIKES];
 export const OPP_SHINY_OVERRIDE: boolean = false;
 export const OPP_VARIANT_OVERRIDE: Variant = 0;
 


### PR DESCRIPTION

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Added Court Change into the game. 
## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
The move was unimplemented
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
 Added a swaptagsattr to move.ts. Also added a boolean value named quiet to ignore onAdd and onRemove tags when the move is used in arena-tag and arena.ts
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
I tested the move through override and the enemy would use on field effects, move works with spikes, toxic spikes, stealth rock,
sticky web, tailwind, light screen, reflect, and mist
<!-- Did you just make use of the `src/overrides.ts` file? -->
I did.
<!-- Did you introduce any automated tests? -->
No
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?

Sticky Web:
https://github.com/pagefaultgames/pokerogue/assets/171395666/488d7831-cd10-4c2c-b327-8fab43232ebc
Mist: 
https://github.com/pagefaultgames/pokerogue/assets/171395666/b1a5fce9-d4e9-4156-b066-a026a4e4fd09
Light Screen:
https://github.com/pagefaultgames/pokerogue/assets/171395666/2d027324-7749-446f-9bff-0c898770c8bf
Toxic Spikes:
https://github.com/pagefaultgames/pokerogue/assets/171395666/0b9eb43e-012d-46a9-9e2a-d919ae2b3ced
Spikes:
https://github.com/pagefaultgames/pokerogue/assets/171395666/4081f822-707e-47a4-9c84-d453a2d0519a

