### PR TITLE
feat:  attack move locales into pokemon information, add luck localiz…

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -52,7 +52,7 @@ import { UiTheme } from "./enums/ui-theme";
 import { SceneBase } from "./scene-base";
 import CandyBar from "./ui/candy-bar";
 import { Variant, variantData } from "./data/variant";
-import { Localizable } from "./plugins/i18n";
+import i18next, { Localizable } from "./plugins/i18n";
 import * as Overrides from "./overrides";
 import {InputsController} from "./inputs-controller";
 import {UiInputs} from "./ui-inputs";
@@ -409,7 +409,7 @@ export default class BattleScene extends SceneBase {
     this.luckText.setVisible(false);
     this.fieldUI.add(this.luckText);
 
-    this.luckLabelText = addTextObject(this, (this.game.canvas.width / 6) - 2, 0, "Luck:", TextStyle.PARTY, { fontSize: "54px" });
+    this.luckLabelText = addTextObject(this, (this.game.canvas.width / 6) - 2, 0, `${i18next.t("pokemonInfo:Stat.LUCK")}:`, TextStyle.PARTY, { fontSize: "54px" });
     this.luckLabelText.setName("text-luck-label");
     this.luckLabelText.setOrigin(1, 0);
     this.luckLabelText.setVisible(false);

--- a/src/locales/de/config.ts
+++ b/src/locales/de/config.ts
@@ -17,7 +17,7 @@ import {
   PGMmiscDialogue
 } from "./dialogue";
 import { egg } from "./egg";
-import { fightUiHandler } from "./fight-ui-handler";
+
 import { gameStatsUiHandler } from "./game-stats-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
@@ -54,7 +54,6 @@ export const deConfig = {
   PGMdoubleBattleDialogue: PGMdoubleBattleDialogue,
   PGFdoubleBattleDialogue: PGFdoubleBattleDialogue,
   egg: egg,
-  fightUiHandler: fightUiHandler,
   gameStatsUiHandler: gameStatsUiHandler,
   growth: growth,
   menu: menu,

--- a/src/locales/de/fight-ui-handler.ts
+++ b/src/locales/de/fight-ui-handler.ts
@@ -1,7 +1,0 @@
-import { SimpleTranslationEntries } from "#app/plugins/i18n";
-
-export const fightUiHandler: SimpleTranslationEntries = {
-  "pp": "AP",
-  "power": "Stärke",
-  "accuracy": "Genauigkeit",
-} as const;

--- a/src/locales/de/pokemon-info.ts
+++ b/src/locales/de/pokemon-info.ts
@@ -41,9 +41,9 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
   },
 
   Move: {
-    "EFFECT_POWER": "Stärke",
-    "EFFECT_ACCURACY": "Genauigkeit",
-    "EFFECT_CATEGORY": "Kategorie",
-    "EFFECT_PP": "AP"
+    "POWER": "Stärke",
+    "ACCURACY": "Genauigkeit",
+    "CATEGORY": "Kategorie",
+    "PP": "AP"
   }
 } as const;

--- a/src/locales/de/pokemon-info.ts
+++ b/src/locales/de/pokemon-info.ts
@@ -14,6 +14,7 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "SPDEFshortened": "SpVert",
     "SPD": "Initiative",
     "SPDshortened": "Init",
+    "LUCK": "Glück"
   },
 
   Type: {
@@ -38,4 +39,11 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "Fee",
     "STELLAR": "Stellar",
   },
+
+  Move: {
+    "EFFECT_POWER": "Stärke",
+    "EFFECT_ACCURACY": "Genauigkeit",
+    "EFFECT_CATEGORY": "Kategorie",
+    "EFFECT_PP": "AP"
+  }
 } as const;

--- a/src/locales/en/config.ts
+++ b/src/locales/en/config.ts
@@ -17,7 +17,7 @@ import {
   PGMmiscDialogue
 } from "./dialogue";
 import { egg } from "./egg";
-import { fightUiHandler } from "./fight-ui-handler";
+
 import { gameStatsUiHandler } from "./game-stats-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
@@ -54,7 +54,6 @@ export const enConfig = {
   PGMdoubleBattleDialogue: PGMdoubleBattleDialogue,
   PGFdoubleBattleDialogue: PGFdoubleBattleDialogue,
   egg: egg,
-  fightUiHandler: fightUiHandler,
   gameStatsUiHandler: gameStatsUiHandler,
   growth: growth,
   menu: menu,

--- a/src/locales/en/fight-ui-handler.ts
+++ b/src/locales/en/fight-ui-handler.ts
@@ -1,7 +1,0 @@
-import { SimpleTranslationEntries } from "#app/plugins/i18n";
-
-export const fightUiHandler: SimpleTranslationEntries = {
-  "pp": "PP",
-  "power": "Power",
-  "accuracy": "Accuracy",
-} as const;

--- a/src/locales/en/pokemon-info.ts
+++ b/src/locales/en/pokemon-info.ts
@@ -13,7 +13,8 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "SPDEF": "Sp. Def",
     "SPDEFshortened": "SpDef",
     "SPD": "Speed",
-    "SPDshortened": "Spd"
+    "SPDshortened": "Spd",
+    "LUCK": "Luck"
   },
 
   Type: {
@@ -38,4 +39,10 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "Fairy",
     "STELLAR": "Stellar",
   },
+  Move: {
+    "EFFECT_POWER": "Power",
+    "EFFECT_ACCURACY": "Accuracy",
+    "EFFECT_CATEGORY": "Category",
+    "EFFECT_PP": "PP"
+  }
 } as const;

--- a/src/locales/en/pokemon-info.ts
+++ b/src/locales/en/pokemon-info.ts
@@ -40,9 +40,9 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "STELLAR": "Stellar",
   },
   Move: {
-    "EFFECT_POWER": "Power",
-    "EFFECT_ACCURACY": "Accuracy",
-    "EFFECT_CATEGORY": "Category",
-    "EFFECT_PP": "PP"
+    "POWER": "Power",
+    "ACCURACY": "Accuracy",
+    "CATEGORY": "Category",
+    "PP": "PP"
   }
 } as const;

--- a/src/locales/es/config.ts
+++ b/src/locales/es/config.ts
@@ -17,7 +17,7 @@ import {
   PGMmiscDialogue
 } from "./dialogue";
 import { egg } from "./egg";
-import { fightUiHandler } from "./fight-ui-handler";
+
 import { gameStatsUiHandler } from "./game-stats-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
@@ -54,7 +54,6 @@ export const esConfig = {
   PGMdoubleBattleDialogue: PGMdoubleBattleDialogue,
   PGFdoubleBattleDialogue: PGFdoubleBattleDialogue,
   egg: egg,
-  fightUiHandler: fightUiHandler,
   gameStatsUiHandler: gameStatsUiHandler,
   growth: growth,
   menu: menu,

--- a/src/locales/es/fight-ui-handler.ts
+++ b/src/locales/es/fight-ui-handler.ts
@@ -1,7 +1,0 @@
-import { SimpleTranslationEntries } from "#app/plugins/i18n";
-
-export const fightUiHandler: SimpleTranslationEntries = {
-  "pp": "PP",
-  "power": "Potencia",
-  "accuracy": "Precisión",
-} as const;

--- a/src/locales/es/pokemon-info.ts
+++ b/src/locales/es/pokemon-info.ts
@@ -39,8 +39,8 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "STELLAR": "Astral",
   },
   Move: {
-    "EFFECT_POWER": "Potencia",
-    "EFFECT_ACCURACY": "Precisión",
-    "EFFECT_PP": "PP"
+    "POWER": "Potencia",
+    "ACCURACY": "Precisión",
+    "PP": "PP"
   }
 } as const;

--- a/src/locales/es/pokemon-info.ts
+++ b/src/locales/es/pokemon-info.ts
@@ -38,4 +38,9 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "Hada",
     "STELLAR": "Astral",
   },
+  Move: {
+    "EFFECT_POWER": "Potencia",
+    "EFFECT_ACCURACY": "Precisión",
+    "EFFECT_PP": "PP"
+  }
 } as const;

--- a/src/locales/fr/config.ts
+++ b/src/locales/fr/config.ts
@@ -17,7 +17,7 @@ import {
   PGMmiscDialogue
 } from "./dialogue";
 import { egg } from "./egg";
-import { fightUiHandler } from "./fight-ui-handler";
+
 import { gameStatsUiHandler } from "./game-stats-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
@@ -54,7 +54,6 @@ export const frConfig = {
   PGMdoubleBattleDialogue: PGMdoubleBattleDialogue,
   PGFdoubleBattleDialogue: PGFdoubleBattleDialogue,
   egg: egg,
-  fightUiHandler: fightUiHandler,
   gameStatsUiHandler: gameStatsUiHandler,
   growth: growth,
   menu: menu,

--- a/src/locales/fr/fight-ui-handler.ts
+++ b/src/locales/fr/fight-ui-handler.ts
@@ -1,7 +1,0 @@
-import { SimpleTranslationEntries } from "#app/plugins/i18n";
-
-export const fightUiHandler: SimpleTranslationEntries = {
-  "pp": "PP",
-  "power": "Puissance",
-  "accuracy": "Précision",
-} as const;

--- a/src/locales/fr/pokemon-info.ts
+++ b/src/locales/fr/pokemon-info.ts
@@ -38,4 +38,10 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "Fée",
     "STELLAR": "Stellaire",
   },
+
+  Move: {
+    "EFFECT_POWER": "Puissance",
+    "EFFECT_ACCURACY": "Précision",
+    "EFFECT_PP": "PP"
+  }
 } as const;

--- a/src/locales/fr/pokemon-info.ts
+++ b/src/locales/fr/pokemon-info.ts
@@ -40,8 +40,8 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
   },
 
   Move: {
-    "EFFECT_POWER": "Puissance",
-    "EFFECT_ACCURACY": "Précision",
-    "EFFECT_PP": "PP"
+    "POWER": "Puissance",
+    "ACCURACY": "Précision",
+    "PP": "PP"
   }
 } as const;

--- a/src/locales/it/config.ts
+++ b/src/locales/it/config.ts
@@ -17,7 +17,7 @@ import {
   PGMmiscDialogue
 } from "./dialogue";
 import { egg } from "./egg";
-import { fightUiHandler } from "./fight-ui-handler";
+
 import { gameStatsUiHandler } from "./game-stats-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
@@ -54,7 +54,6 @@ export const itConfig = {
   PGMdoubleBattleDialogue: PGMdoubleBattleDialogue,
   PGFdoubleBattleDialogue: PGFdoubleBattleDialogue,
   egg: egg,
-  fightUiHandler: fightUiHandler,
   gameStatsUiHandler: gameStatsUiHandler,
   growth: growth,
   menu: menu,

--- a/src/locales/it/fight-ui-handler.ts
+++ b/src/locales/it/fight-ui-handler.ts
@@ -1,7 +1,0 @@
-import { SimpleTranslationEntries } from "#app/plugins/i18n";
-
-export const fightUiHandler: SimpleTranslationEntries = {
-  "pp": "PP",
-  "power": "Potenza",
-  "accuracy": "Precisione",
-} as const;

--- a/src/locales/it/pokemon-info.ts
+++ b/src/locales/it/pokemon-info.ts
@@ -38,4 +38,10 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "Folletto",
     "STELLAR": "Astrale",
   },
+
+  Move: {
+    "EFFECT_POWER": "Potenza",
+    "EFFECT_ACCURACY": "Precisione",
+    "EFFECT_PP": "PP"
+  }
 } as const;

--- a/src/locales/it/pokemon-info.ts
+++ b/src/locales/it/pokemon-info.ts
@@ -40,8 +40,8 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
   },
 
   Move: {
-    "EFFECT_POWER": "Potenza",
-    "EFFECT_ACCURACY": "Precisione",
-    "EFFECT_PP": "PP"
+    "POWER": "Potenza",
+    "ACCURACY": "Precisione",
+    "PP": "PP"
   }
 } as const;

--- a/src/locales/ko/config.ts
+++ b/src/locales/ko/config.ts
@@ -17,7 +17,7 @@ import {
   PGMmiscDialogue
 } from "./dialogue";
 import { egg } from "./egg";
-import { fightUiHandler } from "./fight-ui-handler";
+
 import { gameStatsUiHandler } from "./game-stats-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
@@ -54,7 +54,6 @@ export const koConfig = {
   PGMdoubleBattleDialogue: PGMdoubleBattleDialogue,
   PGFdoubleBattleDialogue: PGFdoubleBattleDialogue,
   egg: egg,
-  fightUiHandler: fightUiHandler,
   gameStatsUiHandler: gameStatsUiHandler,
   growth: growth,
   menu: menu,

--- a/src/locales/ko/fight-ui-handler.ts
+++ b/src/locales/ko/fight-ui-handler.ts
@@ -1,7 +1,0 @@
-import { SimpleTranslationEntries } from "#app/plugins/i18n";
-
-export const fightUiHandler: SimpleTranslationEntries = {
-  "pp": "PP",
-  "power": "위력",
-  "accuracy": "명중률",
-} as const;

--- a/src/locales/ko/pokemon-info.ts
+++ b/src/locales/ko/pokemon-info.ts
@@ -40,8 +40,8 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
   },
 
   Move: {
-    "EFFECT_POWER": "위력",
-    "EFFECT_ACCURACY": "명중률",
-    "EFFECT_PP": "PP"
+    "POWER": "위력",
+    "ACCURACY": "명중률",
+    "PP": "PP"
   }
 } as const;

--- a/src/locales/ko/pokemon-info.ts
+++ b/src/locales/ko/pokemon-info.ts
@@ -38,4 +38,10 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "페어리",
     "STELLAR": "스텔라",
   },
+
+  Move: {
+    "EFFECT_POWER": "위력",
+    "EFFECT_ACCURACY": "명중률",
+    "EFFECT_PP": "PP"
+  }
 } as const;

--- a/src/locales/pt_BR/config.ts
+++ b/src/locales/pt_BR/config.ts
@@ -17,7 +17,7 @@ import {
   PGMmiscDialogue
 } from "./dialogue";
 import { egg } from "./egg";
-import { fightUiHandler } from "./fight-ui-handler";
+
 import { gameStatsUiHandler } from "./game-stats-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
@@ -54,7 +54,6 @@ export const ptBrConfig = {
   PGMdoubleBattleDialogue: PGMdoubleBattleDialogue,
   PGFdoubleBattleDialogue: PGFdoubleBattleDialogue,
   egg: egg,
-  fightUiHandler: fightUiHandler,
   gameStatsUiHandler: gameStatsUiHandler,
   growth: growth,
   menu: menu,

--- a/src/locales/pt_BR/fight-ui-handler.ts
+++ b/src/locales/pt_BR/fight-ui-handler.ts
@@ -1,7 +1,0 @@
-import { SimpleTranslationEntries } from "#app/plugins/i18n";
-
-export const fightUiHandler: SimpleTranslationEntries = {
-  "pp": "PP",
-  "power": "Poder",
-  "accuracy": "Precisão",
-} as const;

--- a/src/locales/pt_BR/pokemon-info.ts
+++ b/src/locales/pt_BR/pokemon-info.ts
@@ -38,4 +38,10 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "Fada",
     "STELLAR": "Estelar"
   },
+
+  Move: {
+    "EFFECT_POWER": "Poder",
+    "EFFECT_ACCURACY": "Precisão",
+    "EFFECT_PP": "PP"
+  }
 } as const;

--- a/src/locales/pt_BR/pokemon-info.ts
+++ b/src/locales/pt_BR/pokemon-info.ts
@@ -40,8 +40,8 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
   },
 
   Move: {
-    "EFFECT_POWER": "Poder",
-    "EFFECT_ACCURACY": "Precisão",
-    "EFFECT_PP": "PP"
+    "POWER": "Poder",
+    "ACCURACY": "Precisão",
+    "PP": "PP"
   }
 } as const;

--- a/src/locales/zh_CN/config.ts
+++ b/src/locales/zh_CN/config.ts
@@ -17,7 +17,7 @@ import {
   PGMmiscDialogue
 } from "./dialogue";
 import { egg } from "./egg";
-import { fightUiHandler } from "./fight-ui-handler";
+
 import { gameStatsUiHandler } from "./game-stats-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
@@ -54,7 +54,6 @@ export const zhCnConfig = {
   PGMdoubleBattleDialogue: PGMdoubleBattleDialogue,
   PGFdoubleBattleDialogue: PGFdoubleBattleDialogue,
   egg: egg,
-  fightUiHandler: fightUiHandler,
   gameStatsUiHandler: gameStatsUiHandler,
   growth: growth,
   menu: menu,

--- a/src/locales/zh_CN/fight-ui-handler.ts
+++ b/src/locales/zh_CN/fight-ui-handler.ts
@@ -1,7 +1,0 @@
-import { SimpleTranslationEntries } from "#app/plugins/i18n";
-
-export const fightUiHandler: SimpleTranslationEntries = {
-  "pp": "PP",
-  "power": "威力",
-  "accuracy": "命中",
-} as const;

--- a/src/locales/zh_CN/pokemon-info.ts
+++ b/src/locales/zh_CN/pokemon-info.ts
@@ -38,4 +38,10 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "妖精",
     "STELLAR": "星晶",
   },
+
+  Move: {
+    "EFFECT_POWER": "威力",
+    "EFFECT_ACCURACY": "命中",
+    "EFFECT_PP": "PP"
+  }
 } as const;

--- a/src/locales/zh_CN/pokemon-info.ts
+++ b/src/locales/zh_CN/pokemon-info.ts
@@ -40,8 +40,8 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
   },
 
   Move: {
-    "EFFECT_POWER": "威力",
-    "EFFECT_ACCURACY": "命中",
-    "EFFECT_PP": "PP"
+    "POWER": "威力",
+    "ACCURACY": "命中",
+    "PP": "PP"
   }
 } as const;

--- a/src/locales/zh_TW/config.ts
+++ b/src/locales/zh_TW/config.ts
@@ -17,7 +17,7 @@ import {
   PGMmiscDialogue
 } from "./dialogue";
 import { egg } from "./egg";
-import { fightUiHandler } from "./fight-ui-handler";
+
 import { gameStatsUiHandler } from "./game-stats-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
@@ -54,7 +54,6 @@ export const zhTwConfig = {
   PGMdoubleBattleDialogue: PGMdoubleBattleDialogue,
   PGFdoubleBattleDialogue: PGFdoubleBattleDialogue,
   egg: egg,
-  fightUiHandler: fightUiHandler,
   gameStatsUiHandler: gameStatsUiHandler,
   growth: growth,
   menu: menu,

--- a/src/locales/zh_TW/fight-ui-handler.ts
+++ b/src/locales/zh_TW/fight-ui-handler.ts
@@ -1,7 +1,0 @@
-import { SimpleTranslationEntries } from "#app/plugins/i18n";
-
-export const fightUiHandler: SimpleTranslationEntries = {
-  "pp": "PP",
-  "power": "威力",
-  "accuracy": "命中率",
-} as const;

--- a/src/locales/zh_TW/pokemon-info.ts
+++ b/src/locales/zh_TW/pokemon-info.ts
@@ -38,4 +38,9 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "FAIRY": "妖精",
     "STELLAR": "星晶"
   },
+  Move: {
+    "EFFECT_POWER": "威力",
+    "EFFECT_ACCURACY": "命中率",
+    "EFFECT_PP": "PP"
+  }
 } as const;

--- a/src/locales/zh_TW/pokemon-info.ts
+++ b/src/locales/zh_TW/pokemon-info.ts
@@ -39,8 +39,8 @@ export const pokemonInfo: PokemonInfoTranslationEntries = {
     "STELLAR": "星晶"
   },
   Move: {
-    "EFFECT_POWER": "威力",
-    "EFFECT_ACCURACY": "命中率",
-    "EFFECT_PP": "PP"
+    "POWER": "威力",
+    "ACCURACY": "命中率",
+    "PP": "PP"
   }
 } as const;

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -51,6 +51,7 @@ export interface ModifierTypeTranslationEntries {
 export interface PokemonInfoTranslationEntries {
   Stat: SimpleTranslationEntries,
   Type: SimpleTranslationEntries,
+  Move: SimpleTranslationEntries
 }
 
 export interface BerryTranslationEntry {
@@ -206,7 +207,6 @@ declare module "i18next" {
       pokemon: SimpleTranslationEntries;
       pokemonInfo: PokemonInfoTranslationEntries;
       commandUiHandler: SimpleTranslationEntries;
-      fightUiHandler: SimpleTranslationEntries;
       titles: SimpleTranslationEntries;
       trainerClasses: SimpleTranslationEntries;
       trainerNames: SimpleTranslationEntries;

--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -46,7 +46,7 @@ export default class FightUiHandler extends UiHandler {
     this.ppLabel = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 70, -26, "PP", TextStyle.MOVE_INFO_CONTENT);
     this.ppLabel.setOrigin(0.0, 0.5);
     this.ppLabel.setVisible(false);
-    this.ppLabel.setText(i18next.t("pokemonInfo:Move.EFFECT_PP"));
+    this.ppLabel.setText(i18next.t("pokemonInfo:Move.PP"));
     ui.add(this.ppLabel);
 
     this.ppText = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 12, -26, "--/--", TextStyle.MOVE_INFO_CONTENT);
@@ -57,7 +57,7 @@ export default class FightUiHandler extends UiHandler {
     this.powerLabel = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 70, -18, "POWER", TextStyle.MOVE_INFO_CONTENT);
     this.powerLabel.setOrigin(0.0, 0.5);
     this.powerLabel.setVisible(false);
-    this.powerLabel.setText(i18next.t("pokemonInfo:Move.EFFECT_POWER"));
+    this.powerLabel.setText(i18next.t("pokemonInfo:Move.POWER"));
     ui.add(this.powerLabel);
 
     this.powerText = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 12, -18, "---", TextStyle.MOVE_INFO_CONTENT);
@@ -68,7 +68,7 @@ export default class FightUiHandler extends UiHandler {
     this.accuracyLabel = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 70, -10, "ACC", TextStyle.MOVE_INFO_CONTENT);
     this.accuracyLabel.setOrigin(0.0, 0.5);
     this.accuracyLabel.setVisible(false);
-    this.accuracyLabel.setText(i18next.t("pokemonInfo:Move.EFFECT_ACCURACY"));
+    this.accuracyLabel.setText(i18next.t("pokemonInfo:Move.ACCURACY"));
     ui.add(this.accuracyLabel);
 
     this.accuracyText = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 12, -10, "---", TextStyle.MOVE_INFO_CONTENT);

--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -46,7 +46,7 @@ export default class FightUiHandler extends UiHandler {
     this.ppLabel = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 70, -26, "PP", TextStyle.MOVE_INFO_CONTENT);
     this.ppLabel.setOrigin(0.0, 0.5);
     this.ppLabel.setVisible(false);
-    this.ppLabel.setText(i18next.t("fightUiHandler:pp"));
+    this.ppLabel.setText(i18next.t("pokemonInfo:Move.EFFECT_PP"));
     ui.add(this.ppLabel);
 
     this.ppText = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 12, -26, "--/--", TextStyle.MOVE_INFO_CONTENT);
@@ -57,7 +57,7 @@ export default class FightUiHandler extends UiHandler {
     this.powerLabel = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 70, -18, "POWER", TextStyle.MOVE_INFO_CONTENT);
     this.powerLabel.setOrigin(0.0, 0.5);
     this.powerLabel.setVisible(false);
-    this.powerLabel.setText(i18next.t("fightUiHandler:power"));
+    this.powerLabel.setText(i18next.t("pokemonInfo:Move.EFFECT_POWER"));
     ui.add(this.powerLabel);
 
     this.powerText = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 12, -18, "---", TextStyle.MOVE_INFO_CONTENT);
@@ -68,7 +68,7 @@ export default class FightUiHandler extends UiHandler {
     this.accuracyLabel = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 70, -10, "ACC", TextStyle.MOVE_INFO_CONTENT);
     this.accuracyLabel.setOrigin(0.0, 0.5);
     this.accuracyLabel.setVisible(false);
-    this.accuracyLabel.setText(i18next.t("fightUiHandler:accuracy"));
+    this.accuracyLabel.setText(i18next.t("pokemonInfo:Move.EFFECT_ACCURACY"));
     ui.add(this.accuracyLabel);
 
     this.accuracyText = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 12, -10, "---", TextStyle.MOVE_INFO_CONTENT);

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -526,7 +526,8 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.type2Icon.setOrigin(0, 0);
     this.starterSelectContainer.add(this.type2Icon);
 
-    this.pokemonLuckLabelText = addTextObject(this.scene, 8, 89, "Luck:", TextStyle.WINDOW_ALT, { fontSize: "56px" });
+    this.pokemonLuckLabelText = addTextObject(this.scene, 8, 89, `${i18next.t("pokemonInfo:Stat.LUCK")}:`, TextStyle.WINDOW_ALT, { fontSize: "56px" });
+    this.pokemonLuckLabelText.setOrigin(0, 0);
     this.pokemonLuckLabelText.setOrigin(0, 0);
     this.starterSelectContainer.add(this.pokemonLuckLabelText);
 

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -225,7 +225,7 @@ export default class SummaryUiHandler extends UiHandler {
     moveEffectBg.setOrigin(0, 0);
     this.moveEffectContainer.add(moveEffectBg);
 
-    const moveEffectLabels = addTextObject(this.scene, 8, 12, "Power\nAccuracy\nCategory", TextStyle.SUMMARY);
+    const moveEffectLabels = addTextObject(this.scene, 8, 12, `${i18next.t("pokemonInfo:Move.EFFECT_POWER")}\n${i18next.t("pokemonInfo:Move.EFFECT_ACCURACY")}\n${i18next.t("pokemonInfo:Move.EFFECT_CATEGORY")}`, TextStyle.SUMMARY);
     moveEffectLabels.setLineSpacing(9);
     moveEffectLabels.setOrigin(0, 0);
 

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -225,7 +225,7 @@ export default class SummaryUiHandler extends UiHandler {
     moveEffectBg.setOrigin(0, 0);
     this.moveEffectContainer.add(moveEffectBg);
 
-    const moveEffectLabels = addTextObject(this.scene, 8, 12, `${i18next.t("pokemonInfo:Move.EFFECT_POWER")}\n${i18next.t("pokemonInfo:Move.EFFECT_ACCURACY")}\n${i18next.t("pokemonInfo:Move.EFFECT_CATEGORY")}`, TextStyle.SUMMARY);
+    const moveEffectLabels = addTextObject(this.scene, 8, 12, `${i18next.t("pokemonInfo:Move.POWER")}\n${i18next.t("pokemonInfo:Move.ACCURACY")}\n${i18next.t("pokemonInfo:Move.CATEGORY")}`, TextStyle.SUMMARY);
     moveEffectLabels.setLineSpacing(9);
     moveEffectLabels.setOrigin(0, 0);
 

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -225,7 +225,7 @@ export default class SummaryUiHandler extends UiHandler {
     moveEffectBg.setOrigin(0, 0);
     this.moveEffectContainer.add(moveEffectBg);
 
-    const moveEffectLabels = addTextObject(this.scene, 8, 12, `${i18next.t("pokemonInfo:Move.POWER")}\n${i18next.t("pokemonInfo:Move.ACCURACY")}\n${i18next.t("pokemonInfo:Move.CATEGORY")}`, TextStyle.SUMMARY);
+    const moveEffectLabels = addTextObject(this.scene, 4, 12, `${i18next.t("pokemonInfo:Move.POWER")}\n${i18next.t("pokemonInfo:Move.ACCURACY")}\n${i18next.t("pokemonInfo:Move.CATEGORY")}`, TextStyle.SUMMARY);
     moveEffectLabels.setLineSpacing(9);
     moveEffectLabels.setOrigin(0, 0);
 


### PR DESCRIPTION
## What are the changes?
The word "Luck" will be properly translated in german.
The pokemon move information will be properly translated in german.
The logic for other languages is implemented, but the translations need to be added to the respective `pokemon-info.ts` translation files.

## Why am I doing these changes?
Bit by bit I want to fully localize all text in pokerogue.

## What did change?
- `locales/**/fighter-handler-ui.ts` has been removed and its translations are moved into `locales/**/pokemon-info.ts`
- `Luck` has been added as a new key to `pokemon-info.ts`
- `Move.Category` has been added to `pokemon-info.ts`

### Screenshots/Videos
![grafik](https://github.com/pagefaultgames/pokerogue/assets/58704291/b2652f71-3da6-437e-80b0-22995512c706)
![grafik](https://github.com/pagefaultgames/pokerogue/assets/58704291/73ab1114-605e-4ce4-8d02-da2127353f80)
![grafik](https://github.com/pagefaultgames/pokerogue/assets/58704291/53216949-f5d7-4f50-b6f4-7b31af3c3f3a)

## How to test the changes?
- Set the language to german and ...
  - visit a shop and look at the Luck Parameter
  - Open the summary on any pokemon and view the move information

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?