### PR TITLE
[Bug] Fix Leppa Berries not Updating Flyout PP

### DIFF
--- a/src/battle-scene-events.ts
+++ b/src/battle-scene-events.ts
@@ -1,4 +1,5 @@
 import Move from "./data/move";
+import { BerryModifier } from "./modifier/modifier";
 
 /** Alias for all {@linkcode BattleScene} events */
 export enum BattleSceneEventType {
@@ -14,6 +15,12 @@ export enum BattleSceneEventType {
    */
   MOVE_USED = "onMoveUsed",
   /**
+   * Triggers when a berry gets successfully used
+   * @see {@linkcode BerryUsedEvent}
+   */
+  BERRY_USED = "onBerryUsed",
+
+  /**
    * Triggers on the first turn of a new battle
    * @see {@linkcode TurnInitEvent}
    */
@@ -23,6 +30,7 @@ export enum BattleSceneEventType {
    * @see {@linkcode TurnEndEvent}
    */
   TURN_END  = "onTurnEnd",
+
   /**
    * Triggers when a new {@linkcode Arena} is created during initialization
    * @see {@linkcode NewArenaEvent}
@@ -63,6 +71,20 @@ export class MoveUsedEvent extends Event {
     this.ppUsed = ppUsed;
   }
 }
+/**
+ * Container class for {@linkcode BattleSceneEventType.BERRY_USED} events
+ * @extends Event
+*/
+export class BerryUsedEvent extends Event {
+  /** The {@linkcode BerryModifier} being used */
+  public berryModifier: BerryModifier;
+  constructor(berry: BerryModifier) {
+    super(BattleSceneEventType.BERRY_USED);
+
+    this.berryModifier = berry;
+  }
+}
+
 /**
  * Container class for {@linkcode BattleSceneEventType.TURN_INIT} events
  * @extends Event

--- a/src/battle-scene-events.ts
+++ b/src/battle-scene-events.ts
@@ -58,7 +58,7 @@ export class CandyUpgradeNotificationChangedEvent extends Event {
 */
 export class MoveUsedEvent extends Event {
   /** The ID of the {@linkcode Pokemon} that used the {@linkcode Move} */
-  public userId: number;
+  public pokemonId: number;
   /** The {@linkcode Move} used */
   public move: Move;
   /** The amount of PP used on the {@linkcode Move} this turn */
@@ -66,7 +66,7 @@ export class MoveUsedEvent extends Event {
   constructor(userId: number, move: Move, ppUsed: number) {
     super(BattleSceneEventType.MOVE_USED);
 
-    this.userId = userId;
+    this.pokemonId = userId;
     this.move = move;
     this.ppUsed = ppUsed;
   }

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -61,7 +61,7 @@ import { Abilities } from "./data/enums/abilities";
 import * as Overrides from "./overrides";
 import { TextStyle, addTextObject } from "./ui/text";
 import { Type } from "./data/type";
-import { MoveUsedEvent, TurnEndEvent, TurnInitEvent } from "./battle-scene-events";
+import { BerryUsedEvent, MoveUsedEvent, TurnEndEvent, TurnInitEvent } from "./battle-scene-events";
 
 
 export class LoginPhase extends Phase {
@@ -2244,6 +2244,7 @@ export class BerryPhase extends FieldPhase {
                 berryModifier.consumed = false;
               }
             }
+            this.scene.eventTarget.dispatchEvent(new BerryUsedEvent(berryModifier)); // Announce a berry was used
           }
 
           this.scene.updateModifiers(pokemon.isPlayer());

--- a/src/ui/arena-flyout.ts
+++ b/src/ui/arena-flyout.ts
@@ -81,11 +81,11 @@ export default class ArenaFlyout extends Phaser.GameObjects.Container {
   private readonly fieldEffectInfo: ArenaEffectInfo[] = [];
 
   // Stores callbacks in a variable so they can be unsubscribed from when destroyed
-  private onNewArenaEvent =  (event: Event) => this.onNewArena(event);
-  private onTurnInitEvent =  (event: Event) => this.onTurnInit(event);
-  private onTurnEndEvent =   (event: Event) => this.onTurnEnd(event);
+  private readonly onNewArenaEvent =  (event: Event) => this.onNewArena(event);
+  private readonly onTurnInitEvent =  (event: Event) => this.onTurnInit(event);
+  private readonly onTurnEndEvent =   (event: Event) => this.onTurnEnd(event);
 
-  private onFieldEffectChangedEvent = (event: Event) => this.onFieldEffectChanged(event);
+  private readonly onFieldEffectChangedEvent = (event: Event) => this.onFieldEffectChanged(event);
 
   constructor(scene: Phaser.Scene) {
     super(scene, 0, 0);
@@ -379,6 +379,6 @@ export default class ArenaFlyout extends Phaser.GameObjects.Container {
     this.battleScene.arena.eventTarget.removeEventListener(ArenaEventType.TAG_ADDED,       this.onFieldEffectChangedEvent);
     this.battleScene.arena.eventTarget.removeEventListener(ArenaEventType.TAG_REMOVED,     this.onFieldEffectChangedEvent);
 
-    super.destroy();
+    super.destroy(fromScene);
   }
 }

--- a/src/ui/battle-flyout.ts
+++ b/src/ui/battle-flyout.ts
@@ -154,8 +154,8 @@ export default class BattleFlyout extends Phaser.GameObjects.Container {
   private onBerryUsed(event: Event) {
     const berryUsedEvent = event as BerryUsedEvent;
     if (!berryUsedEvent
-      || berryUsedEvent.berryModifier.berryType !== BerryType.LEPPA // We only care about Leppa berries
-      || berryUsedEvent.berryModifier.pokemonId !== this.pokemon?.id) {
+      || berryUsedEvent.berryModifier.pokemonId !== this.pokemon?.id
+      || berryUsedEvent.berryModifier.berryType !== BerryType.LEPPA) { // We only care about Leppa berries
       return;
     }
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Fixes an issue where Leppa Berries were not reflected in the Moveset Flyout. Also skips tracking for Struggle

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
This was a bug since the user is notified when an enemy eats a berry and could easily track how much PP was restored.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
A new event was added when a berry is used and the BerryModifier is sent along to the listener. 

The flyout finds the first move that has no PP left and restores 10 PP to the tracked version of the move. This mirrors the code of the berry.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
https://github.com/pagefaultgames/pokerogue/assets/13838608/b5ede988-4ad7-4314-8547-dec6dc5bae4f

https://github.com/pagefaultgames/pokerogue/assets/13838608/857832e5-0dae-42c9-9d45-12f8e36e6f31

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Set overrides to have a pokemon with a shallow move pool and low PP. Add a leppa berry as well. Use moves until the pokemon runs out of moves and must eat a berry.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?