### PR TITLE
[Bug] Fix quick claw message showing up if command is not fight

### DIFF
--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -22,6 +22,7 @@ import { Nature } from "#app/data/nature";
 import { BattlerTagType } from "#app/data/enums/battler-tag-type";
 import * as Overrides from "../overrides";
 import { ModifierType, modifierTypes } from "./modifier-type";
+import { Command } from "#app/ui/command-ui-handler.js";
 
 export type ModifierPredicate = (modifier: Modifier) => boolean;
 
@@ -776,7 +777,10 @@ export class BypassSpeedChanceModifier extends PokemonHeldItemModifier {
 
     if (!bypassSpeed.value && pokemon.randSeedInt(10) < this.getStackCount()) {
       bypassSpeed.value = true;
-      if (this.type instanceof ModifierTypes.PokemonHeldItemModifierType && this.type.id === "QUICK_CLAW") {
+      const isCommandFight = pokemon.scene.currentBattle.turnCommands[pokemon.getBattlerIndex()]?.command === Command.FIGHT;
+      const hasQuickClaw = this.type instanceof ModifierTypes.PokemonHeldItemModifierType && this.type.id === "QUICK_CLAW";
+
+      if (isCommandFight && hasQuickClaw) {
         pokemon.scene.queueMessage(getPokemonMessage(pokemon, " used its quick claw to move faster!"));
       }
       return true;


### PR DESCRIPTION
## What are the changes?
- prevent quick claw message from showing up when using ball/run/switching pokemon

## Why am I doing these changes?
- quick claw is showing message on ball/run/switch when activated- its because the modifier class is called on TurnStartPhase

## What did change?
- added additional check if command is fight

### Screenshots/Videos
I added a `console.log('BYPASSED SPEED')` here:
<img width="721" alt="Screenshot 2024-06-05 at 4 23 29 PM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/0f05b06f-f897-42cc-9bdf-546a16b869e8">


Note that _BYPASSED SPEED_ and _Applied Quick Claw_ were logged but the message no longer appears

https://github.com/pagefaultgames/pokerogue/assets/68144167/cd4d1e21-a706-46b6-9b7c-824389d85e37




Message now only shows when Command is FIGHT


https://github.com/pagefaultgames/pokerogue/assets/68144167/2f89696c-f7af-407b-a8c4-cbd886cd3f85




## How to test the changes?
set your pokemon to a slower pokemon, use ball/run/switch
```
export const STARTER_SPECIES_OVERRIDE: Species | integer = Species.SHUCKLE;
export const OPP_SPECIES_OVERRIDE: Species | integer = Species.HITMONLEE;
```

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
- [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
- [x] Have I provided screenshots/videos of the changes?