### PR TITLE
[Localization] Phrase fix in weather.ts and pokemon-info-container.ts Spanish translation

### DIFF
--- a/src/locales/es/pokemon-info-container.ts
+++ b/src/locales/es/pokemon-info-container.ts
@@ -1,11 +1,11 @@
 import { SimpleTranslationEntries } from "#app/plugins/i18n";
 
 export const pokemonInfoContainer: SimpleTranslationEntries = {
-  "moveset": "Moveset",
-  "gender": "Gender:",
-  "ability": "Ability:",
-  "nature": "Nature:",
-  "epic": "Epic",
-  "rare": "Rare",
-  "common": "Common"
+  "moveset": "Movimientos",
+  "gender": "Género:",
+  "ability": "Habilid:",
+  "nature": "Natur:",
+  "epic": "Épico",
+  "rare": "Raro",
+  "common": "Común"
 } as const;

--- a/src/locales/es/weather.ts
+++ b/src/locales/es/weather.ts
@@ -15,12 +15,12 @@ export const weather: SimpleTranslationEntries = {
   "sandstormStartMessage": "¡Se ha desatado una tormenta de arena!",
   "sandstormLapseMessage": "La tormenta de arena arrecia...",
   "sandstormClearMessage": "La tormenta de arena termino.",
-  "sandstormDamageMessage": "¡La tormenta de arena zarandea al\n{{pokemonName}}{{pokemonPrefix}}!",
+  "sandstormDamageMessage": "¡La tormenta de arena zarandea al\n{{pokemonName}} {{pokemonPrefix}}!",
 
   "hailStartMessage": "¡Ha empezado a granizar!",
   "hailLapseMessage": "Sigue granizando...",
   "hailClearMessage": "Had dejado de granizar.",
-  "hailDamageMessage": "El granizo golpea al\n{{pokemonName}}{{pokemonPrefix}}!",
+  "hailDamageMessage": "El granizo golpea al\n{{pokemonName}} {{pokemonPrefix}}!",
 
   "snowStartMessage": "¡Ha empezado a nevar!",
   "snowLapseMessage": "Sigue nevando...",


### PR DESCRIPTION
## What are the changes?
- Updated weather.ts
- Updated pokemon-info-container.ts

## Why am I doing these changes?
I decided to introduce these changes to improve the overall user experience, particularly for Spanish-speaking players who may not understand English well.


## What did change?
In weather.ts, the phrases were missing spaces between some words.
Translated pokemon info container.

### Screenshots/Videos
**Before changes**
![Antes](https://github.com/pagefaultgames/pokerogue/assets/162721984/28d3c370-ffa5-42bc-a2b9-71286c659d50)
**After changes**
![Despues](https://github.com/pagefaultgames/pokerogue/assets/162721984/e8d3ea99-61f4-4cf9-b8df-7459878c3228)



## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?