### PR TITLE
[Bug] Change confuse chance from 2/3 to 1/3

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -200,6 +200,9 @@ export class InterruptedTag extends BattlerTag {
   }
 }
 
+/**
+ * BattlerTag that represents the {@link https://bulbapedia.bulbagarden.net/wiki/Confusion_(status_condition)}
+ */
 export class ConfusedTag extends BattlerTag {
   constructor(turnCount: integer, sourceMove: Moves) {
     super(BattlerTagType.CONFUSED, BattlerTagLapseType.MOVE, turnCount, sourceMove);
@@ -235,7 +238,8 @@ export class ConfusedTag extends BattlerTag {
       pokemon.scene.queueMessage(getPokemonMessage(pokemon, " is\nconfused!"));
       pokemon.scene.unshiftPhase(new CommonAnimPhase(pokemon.scene, pokemon.getBattlerIndex(), undefined, CommonAnim.CONFUSION));
 
-      if (pokemon.randSeedInt(3)) {
+      // 1/3 chance of hitting self with a 40 base power move
+      if (pokemon.randSeedInt(3) === 0) {
         const atk = pokemon.getBattleStat(Stat.ATK);
         const def = pokemon.getBattleStat(Stat.DEF);
         const damage = Math.ceil(((((2 * pokemon.level / 5 + 2) * 40 * atk / def) / 50) + 2) * (pokemon.randSeedInt(15, 85) / 100));


### PR DESCRIPTION
## What are the changes?
Fixes a typo in https://github.com/pagefaultgames/pokerogue/pull/1085

## Why am I doing these changes?
Changes confusion chance from 2/3 to the correct 1/3

## What did change?
Used `if(pokemon.randSeedInt(3) === 0)` instead of `if(pokemon.randSeedInt(3))`

### Screenshots/Videos
n/a

## How to test the changes?
`console.log` the `pokemon.randSeedInt` and see if a Pokemon hits itself

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?