### PR TITLE
Hotfix for NaN luck

### DIFF
--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1875,8 +1875,9 @@ export class ModifierTypeOption {
 }
 
 export function getPartyLuckValue(party: Pokemon[]): integer {
-  return Phaser.Math.Clamp(party.map(p => p.isFainted() ? 0 : p.getLuck())
+  const luck = Phaser.Math.Clamp(party.map(p => p.isFainted() ? 0 : p.getLuck())
     .reduce((total: integer, value: integer) => total += value, 0), 0, 14);
+  return luck || 0;
 }
 
 export function getLuckString(luckValue: integer): string {


### PR DESCRIPTION
## What are the changes?
Makes luck default to 0 if false-y. This works for NaN, null and undefined.

## Why am I doing these changes?
NaN luck bricks the logic

## What did change?
Add an || 0 to the getPartyLuck function.

### Screenshots/Videos
N/A

## How to test the changes?
Do anything involving luck.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)