### PR TITLE
[Bug] Fix toxic damage increment not resetting upon switching

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1128,7 +1128,7 @@ export class PostSummonPhase extends PokemonPhase {
     const pokemon = this.getPokemon();
 
     if (pokemon.status?.effect === StatusEffect.TOXIC) {
-        pokemon.status.turnCount = 0;
+      pokemon.status.turnCount = 0;
     }
     this.scene.arena.applyTags(ArenaTrapTag, pokemon);
     applyPostSummonAbAttrs(PostSummonAbAttr, pokemon).then(() => this.end());

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1127,6 +1127,9 @@ export class PostSummonPhase extends PokemonPhase {
 
     const pokemon = this.getPokemon();
 
+    if (pokemon.status?.effect === StatusEffect.TOXIC) {
+        pokemon.status.turnCount = 0;
+    }
     this.scene.arena.applyTags(ArenaTrapTag, pokemon);
     applyPostSummonAbAttrs(PostSummonAbAttr, pokemon).then(() => this.end());
   }


### PR DESCRIPTION
I'm not sure if this is the best way to solve this since I'm a programming noob (specially when it comes to OOP), but I just figured that if an experienced developer looks at this PR and does it the proper way then that's a win for everyone, so why not give it a go?

<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Toxic damage increment now resets when you switch out and then back in, as it's intended.
Note that this doesn't address the issue with poison damage being applied twice in some instances: #830 

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
I ran into the issue myself and lost my daily run to Pecharunt 😢
There's also an open issue about this: #1723 

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Added a simple check in the PostSummonPhase: if the pokémon has Toxic status it resets turnCount to 0.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
Before:

https://github.com/pagefaultgames/pokerogue/assets/18709552/ad06d1e8-09dd-4431-ba7c-1e99d09ec5cb

After:

https://github.com/pagefaultgames/pokerogue/assets/18709552/64758ddf-8029-4a7a-9d16-458de9b892e9

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
There's many ways, but a simple one is just to use this override and then switch out and back in after taking at least one tick of toxic damage.
`export const STATUS_OVERRIDE: StatusEffect = StatusEffect.TOXIC;`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?