### PR TITLE
[Localization] Pokemon affix + useMove and modifier-type.ts Spanish Translations

### DIFF
--- a/src/locales/es/battle.ts
+++ b/src/locales/es/battle.ts
@@ -56,9 +56,9 @@ export const battle: SimpleTranslationEntries = {
   "skipItemQuestion": "¿Estás seguro de que no quieres coger un objeto?",
   "eggHatching": "¿Y esto?",
   "ivScannerUseQuestion": "¿Quieres usar el Escáner de IVs en {{pokemonName}}?",
-  "wildPokemonWithAffix": "Wild {{pokemonName}}",
-  "foePokemonWithAffix": "Foe {{pokemonName}}",
-  "useMove": "{{pokemonNameWithAffix}} used {{moveName}}!",
-  "drainMessage": "{{pokemonName}} had its\nenergy drained!",
-  "regainHealth": "{{pokemonName}} regained\nhealth!"
+  "wildPokemonWithAffix": "{{pokemonName}} salvaje",
+  "foePokemonWithAffix": "{{pokemonName}} enemigo",
+  "useMove": "¡{{pokemonNameWithAffix}} usó {{moveName}}!",
+  "drainMessage": "¡{{pokemonName}} ha perdido energía!",
+  "regainHealth": "¡{{pokemonName}} recuperó\nsalud!"
 } as const;

--- a/src/locales/es/modifier-type.ts
+++ b/src/locales/es/modifier-type.ts
@@ -101,7 +101,7 @@ export const modifierType: ModifierTypeTranslationEntries = {
     },
     "TmModifierTypeWithInfo": {
       name: "MT{{moveId}} - {{moveName}}",
-      description: "Enseña {{moveName}} a un Pokémon\n(Hold C or Shift for more info)",
+      description: "Enseña {{moveName}} a un Pokémon\n(Presiona C o Shift para más información)",
     },
     "EvolutionItemModifierType": {
       description: "Hace que ciertos Pokémon evolucionen",


### PR DESCRIPTION
## What are the changes?
- Updated battle.ts
- Updated modifier-type.ts

## Why am I doing these changes?
I decided to introduce these changes to improve the overall user experience, particularly for Spanish-speaking players who may not understand English well.
Added Spanish translations based on PR #1276 and #1585

## What did change?
Translated affix of pokemon and used move.
Translated Move Info Overlay.

### Screenshots/Videos
https://github.com/pagefaultgames/pokerogue/assets/162721984/b1e52c85-69cb-4b36-a179-eff2e49f9831


https://github.com/pagefaultgames/pokerogue/assets/162721984/9f23f373-3998-480a-9775-082c1a83d116

![Captura](https://github.com/pagefaultgames/pokerogue/assets/162721984/eb35855c-a22e-4841-84fe-1d0e84a0d810)
![Captura2](https://github.com/pagefaultgames/pokerogue/assets/162721984/cb61c155-2dc4-43fe-a3af-b238a8f6926f)


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?