### PR TITLE
[Feature] Added Battle Style setting

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -145,6 +145,12 @@ export default class BattleScene extends SceneBase {
   public fusionPaletteSwaps: boolean = true;
   public enableTouchControls: boolean = false;
   public enableVibration: boolean = false;
+  /**
+   * Determines the selected battle style.
+   * - 0 = 'Shift'
+   * - 1 = 'Set' - The option to switch the active pokemon at the start of a battle will not display.
+   */
+  public battleStyle: integer = 0;
 
   public disableMenu: boolean = false;
 

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1667,6 +1667,11 @@ export class CheckSwitchPhase extends BattlePhase {
 
     const pokemon = this.scene.getPlayerField()[this.fieldIndex];
 
+    if (this.scene.battleStyle === 1) {
+      super.end();
+      return;
+    }
+
     if (this.scene.field.getAll().indexOf(pokemon) === -1) {
       this.scene.unshiftPhase(new SummonMissingPhase(this.scene, this.fieldIndex));
       super.end();

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -111,7 +111,7 @@ export const Setting: Array<Setting> = [
   {
     key: SettingKeys.Battle_Style,
     label: "Battle Style",
-    options: ["Shift", "Set"],
+    options: ["Switch", "Set"],
     default: 0,
     type: SettingType.GENERAL
   },

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -42,6 +42,7 @@ export const SettingKeys = {
   EXP_Gains_Speed: "EXP_GAINS_SPEED",
   EXP_Party_Display: "EXP_PARTY_DISPLAY",
   Skip_Seen_Dialogues: "SKIP_SEEN_DIALOGUES",
+  Battle_Style: "BATTLE_STYLE",
   Enable_Retries: "ENABLE_RETRIES",
   Tutorials: "TUTORIALS",
   Touch_Controls: "TOUCH_CONTROLS",
@@ -104,6 +105,13 @@ export const Setting: Array<Setting> = [
     key: SettingKeys.Skip_Seen_Dialogues,
     label: "Skip Seen Dialogues",
     options: OFF_ON,
+    default: 0,
+    type: SettingType.GENERAL
+  },
+  {
+    key: SettingKeys.Battle_Style,
+    label: "Battle Style",
+    options: ["Shift", "Set"],
     default: 0,
     type: SettingType.GENERAL
   },
@@ -347,6 +355,9 @@ export function setSetting(scene: BattleScene, setting: string, value: integer):
     break;
   case SettingKeys.Skip_Seen_Dialogues:
     scene.skipSeenDialogues = Setting[index].options[value] === "On";
+    break;
+  case SettingKeys.Battle_Style:
+    scene.battleStyle = value;
     break;
   case SettingKeys.Candy_Upgrade_Notification:
     if (scene.candyUpgradeNotification === value) {


### PR DESCRIPTION
## What are the changes?
Added a Battle Style setting that allows you to stop the "Will you switch Pokemon?" menu from appearing at the start of a battle.

## Why am I doing these changes?
The Switch vs Set Battle Style setting is available in all mainline Pokemon games, and adds QoL enhancement for the Endless game modes.

## What did change?
The `battleStyle` property was added to `battle-scene.ts`.
`phases.ts` was modified to end the `CheckSwitchPhase` if the battle style is Set.

In `settings.ts` `Battle_Style` became a GENERAL setting

### Screenshots/Videos
https://github.com/pagefaultgames/pokerogue/assets/167576411/3ab42504-a300-4323-b6a6-703d695da6b3

## How to test the changes?
The new Battle_Style setting can be tested by selecting either "Switch" or "Set" in the settings, and then entering a battle and observing one of the following:
- If "Switch" has been selected you should see the "Will you switch Pokemon?" menu appear at the start of the battle.
- If "Set" has been selected you should NOT see the "Will you switch Pokemon?" menu appear at the start of the battle.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?