### PR TITLE
[Localization] Fix typo in healing charm for Chinese localization

### DIFF
--- a/src/locales/zh_CN/modifier-type.ts
+++ b/src/locales/zh_CN/modifier-type.ts
@@ -199,7 +199,7 @@ export const modifierType: ModifierTypeTranslationEntries = {
 
     "MULTI_LENS": { name: "多重镜" },
 
-    "HEALING_CHARM": { name: "治愈护符", description: "HP回复量增加10% (含复活)" },
+    "HEALING_CHARM": { name: "治愈护符", description: "HP回复量增加10% (不含复活)" },
     "CANDY_JAR": { name: "糖果罐", description: "神奇糖果提供的升级额外增加1级" },
 
     "BERRY_POUCH": { name: "树果袋", description: "使用树果时有30%的几率不会消耗树果" },

--- a/src/locales/zh_TW/modifier-type.ts
+++ b/src/locales/zh_TW/modifier-type.ts
@@ -212,7 +212,7 @@ export const modifierType: ModifierTypeTranslationEntries = {
     MULTI_LENS: { name: "多重鏡" },
     HEALING_CHARM: {
       name: "治癒護符",
-      description: "HP恢復量增加10% (含復活)",
+      description: "HP恢復量增加10% (不含復活)",
     },
     CANDY_JAR: { name: "糖果罐", description: "神奇糖果提供的升級提升1級" },
     BERRY_POUCH: {


### PR DESCRIPTION
## What are the changes?
Fixed a mistranslation in healing charm for Chinese

## Why am I doing these changes?
Description was wrong

## What did change?
Changed "includes" to "excludes"

### Screenshots/Videos
n/a

## How to test the changes?
Pull the changes and change locale to Chinese and spawn in a healing charm

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?