### PR TITLE
[Bug] Thunderclap should not let the AI read your inputs

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3396,7 +3396,7 @@ export class EnemyPokemon extends Pokemon {
 
             const target = this.scene.getField()[mt];
             let targetScore = move.getUserBenefitScore(this, target, move) + move.getTargetBenefitScore(this, target, move) * (mt < BattlerIndex.ENEMY === this.isPlayer() ? 1 : -1);
-            if ((move.name.endsWith(" (N)") || !move.applyConditions(this, target, move)) && ![Moves.SUCKER_PUNCH, Moves.UPPER_HAND].includes(move.id)) {
+            if ((move.name.endsWith(" (N)") || !move.applyConditions(this, target, move)) && ![Moves.SUCKER_PUNCH, Moves.UPPER_HAND, Moves.THUNDERCLAP].includes(move.id)) {
               targetScore = -20;
             } else if (move instanceof AttackMove) {
               const effectiveness = target.getAttackMoveEffectiveness(this, pokemonMove);


### PR DESCRIPTION
## What are the changes?
Thunderclap should not let the AI read player inputs

## Why am I doing these changes?
Matching behavior of sucker punch and upper hand

## What did change?
Added thunderclap to the AI move selection portion that's next to sucker punch and upper hand

### Screenshots/Videos
n/a

## How to test the changes?
Override an opponent with thunderclap and verify their actions are the same between using an attacking and non attacking move

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?