### PR TITLE
[Move] Rototiller implementation

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6683,7 +6683,7 @@ export function initMoves() {
       .condition((user, target, move) => user.battleData.berriesEaten.length > 0),
     new StatusMove(Moves.ROTOTILLER, Type.GROUND, -1, 10, 100, 0, 6)
       .target(MoveTarget.ALL)
-      .unimplemented(),
+      .attr(StatChangeAttr, [BattleStat.ATK, BattleStat.SPATK], 1, false, (user, target, move) => target.isGrounded() && target.isOfType(Type.GRASS)),
     new StatusMove(Moves.STICKY_WEB, Type.BUG, -1, 20, -1, 0, 6)
       .attr(AddArenaTrapTagAttr, ArenaTagType.STICKY_WEB)
       .target(MoveTarget.ENEMY_SIDE),

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6683,7 +6683,11 @@ export function initMoves() {
       .condition((user, target, move) => user.battleData.berriesEaten.length > 0),
     new StatusMove(Moves.ROTOTILLER, Type.GROUND, -1, 10, 100, 0, 6)
       .target(MoveTarget.ALL)
-      .attr(StatChangeAttr, [BattleStat.ATK, BattleStat.SPATK], 1, false, (user, target, move) => target.isGrounded() && target.isOfType(Type.GRASS)),
+      .condition((user,target,move) => {
+        // If any fielded pokémon is grass-type and grounded.
+        return [...user.scene.getEnemyParty(),...user.scene.getParty()].some((poke) => poke.isOfType(Type.GRASS) && poke.isGrounded());
+      })
+      .attr(StatChangeAttr, [BattleStat.ATK, BattleStat.SPATK], 1, false, (user, target, move) => target.isOfType(Type.GRASS) && target.isGrounded()),
     new StatusMove(Moves.STICKY_WEB, Type.BUG, -1, 20, -1, 0, 6)
       .attr(AddArenaTrapTagAttr, ArenaTagType.STICKY_WEB)
       .target(MoveTarget.ENEMY_SIDE),


### PR DESCRIPTION
## What are the changes?
Added Rototiller, which gives +1 Atk. and Sp.Atk to every grounded plant pokémon on the battlefield.

### Screenshots/Videos
Singles Example
https://github.com/pagefaultgames/pokerogue/assets/73134872/70e7debe-5a17-42b1-a5af-70786b55c608
Doubles Examples
https://github.com/pagefaultgames/pokerogue/assets/73134872/ea9c5bdc-794c-4416-a166-35351a2a1392


## How to test the changes?
Play a non-grass, grounded grass and ungrounded grass type pokémon, and make any of them use Rototiller.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?