### PR TITLE
[Bug] Show C-Button on Mobile during Modifier Selection

### DIFF
--- a/index.css
+++ b/index.css
@@ -152,7 +152,7 @@ body {
   display: none;
 }
 
-#touchControls:not([data-ui-mode='COMMAND']):not([data-ui-mode='FIGHT']):not([data-ui-mode='BALL']):not([data-ui-mode='TARGET_SELECT']) #apad .apadBattle {
+#touchControls:not([data-ui-mode='COMMAND']):not([data-ui-mode='FIGHT']):not([data-ui-mode='BALL']):not([data-ui-mode='TARGET_SELECT']):not([data-ui-mode='MODIFIER_SELECT']) #apad .apadBattle {
   display: none;
 }
 


### PR DESCRIPTION
## What are the changes?
The C-Button is now shown on Mobule when selecting a modifier.

## Why am I doing these changes?
The C-Button is required to access additional information for the move a TM teaches.

## What did change?
Adjusted CSS Rule responsible for hiding the button during modifier selection to show the button.

### Screenshots/Videos
Before:
![IMG_0247](https://github.com/pagefaultgames/pokerogue/assets/10091050/2dc782ed-3055-49dc-bcf3-72fad5e14326)

Now a C Button appears in the bottom right corner, similar to the combat menu.

## How to test the changes?
Enter a fight, end the fight, the button should still be present.

Though, to be more specific:
Change the following override to get a TM as a reward.
`export const ITEM_REWARD_OVERRIDE: Array<String> = [];`
with
`export const ITEM_REWARD_OVERRIDE: Array<String> = ["TM_COMMON"];`
When hovering over the TM, before selecting it, you should be able to press C to view additional information.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?