### PR TITLE
[Bug] Fix speed tie code

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -637,8 +637,26 @@ export abstract class FieldPhase extends BattlePhase {
       const aSpeed = a?.getBattleStat(Stat.SPD) || 0;
       const bSpeed = b?.getBattleStat(Stat.SPD) || 0;
 
-      return aSpeed < bSpeed ? 1 : aSpeed > bSpeed ? -1 : !this.scene.randBattleSeedInt(2) ? -1 : 1;
+      // The pokemon with the higher speed stat goes first if not tied, if tied the pokemon with the lower id goes first
+      return bSpeed - aSpeed !== 0 ? bSpeed - aSpeed : a.id - b.id;
     });
+
+    // Randomisation of speed tie code.
+    // We do this outside of the sort function because how sort functions work is
+    // an implementation detail which differs by browser.
+    const speeds = orderedTargets.map(p => p.getBattleStat(Stat.SPD));
+    for (let i = 1; i < orderedTargets.length; i++) {
+      if (speeds[i] === speeds[i-1]) {
+        const lower = i - 1;
+        let upper = i;
+        while (upper + 1 < orderedTargets.length && speeds[upper] === speeds[i]) {
+          upper++;
+        }
+        const tiedPokemon = Utils.randSeedShuffle(orderedTargets.splice(lower, upper - lower + 1));
+        orderedTargets.splice(lower, 0, ...tiedPokemon);
+        i = upper;
+      }
+    }
 
     const speedReversed = new Utils.BooleanHolder(false);
     this.scene.arena.applyTags(TrickRoomTag, speedReversed);

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -633,30 +633,13 @@ export abstract class FieldPhase extends BattlePhase {
     const playerField = this.scene.getPlayerField().filter(p => p.isActive()) as Pokemon[];
     const enemyField = this.scene.getEnemyField().filter(p => p.isActive()) as Pokemon[];
 
-    let orderedTargets: Pokemon[] = playerField.concat(enemyField).sort((a: Pokemon, b: Pokemon) => {
+    // We shuffle the list before sorting so speed ties produce random results
+    let orderedTargets: Pokemon[] = Utils.randSeedShuffle(playerField.concat(enemyField)).sort((a: Pokemon, b: Pokemon) => {
       const aSpeed = a?.getBattleStat(Stat.SPD) || 0;
       const bSpeed = b?.getBattleStat(Stat.SPD) || 0;
 
-      // The pokemon with the higher speed stat goes first if not tied, if tied the pokemon with the lower id goes first
-      return bSpeed - aSpeed !== 0 ? bSpeed - aSpeed : a.id - b.id;
+      return bSpeed - aSpeed;
     });
-
-    // Randomisation of speed tie code.
-    // We do this outside of the sort function because how sort functions work is
-    // an implementation detail which differs by browser.
-    const speeds = orderedTargets.map(p => p.getBattleStat(Stat.SPD));
-    for (let i = 1; i < orderedTargets.length; i++) {
-      if (speeds[i] === speeds[i-1]) {
-        const lower = i - 1;
-        let upper = i;
-        while (upper + 1 < orderedTargets.length && speeds[upper + 1] === speeds[i]) {
-          upper++;
-        }
-        const tiedPokemon = Utils.randSeedShuffle(orderedTargets.splice(lower, upper - lower + 1));
-        orderedTargets.splice(lower, 0, ...tiedPokemon);
-        i = upper;
-      }
-    }
 
     const speedReversed = new Utils.BooleanHolder(false);
     this.scene.arena.applyTags(TrickRoomTag, speedReversed);

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -649,7 +649,7 @@ export abstract class FieldPhase extends BattlePhase {
       if (speeds[i] === speeds[i-1]) {
         const lower = i - 1;
         let upper = i;
-        while (upper + 1 < orderedTargets.length && speeds[upper] === speeds[i]) {
+        while (upper + 1 < orderedTargets.length && speeds[upper + 1] === speeds[i]) {
           upper++;
         }
         const tiedPokemon = Utils.randSeedShuffle(orderedTargets.splice(lower, upper - lower + 1));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -127,6 +127,23 @@ export function randSeedEasedWeightedItem<T>(items: T[], easingFunction: string 
   return items[Math.floor(easedValue * items.length)];
 }
 
+/**
+ * Shuffle a list using the seeded rng. Utilises the Fisher-Yates algorithm.
+ * @param {Array} items An array of items.
+ * @returns {Array} A new shuffled array of items.
+ */
+export function randSeedShuffle<T>(items: T[]): T[] {
+  if (items.length <= 1) {
+    return items;
+  }
+  const newArray = items.slice(0);
+  for (let i = items.length - 1; i > 0; i--) {
+    const j = Phaser.Math.RND.integerInRange(0, i);
+    [newArray[i], newArray[j]] = [newArray[j], newArray[i]];
+  }
+  return newArray;
+}
+
 export function getFrameMs(frameCount: integer): integer {
   return Math.floor((1 / 60) * 1000 * frameCount);
 }


### PR DESCRIPTION
## What are the changes?
Speed ties are being refactored to sort then shuffle, preventing browser inconsistency.

## Why am I doing these changes?
Firefox and chrome would produce different results for speed ties sometimes due to the details of the sort function which we relied on being an implementation detail that differed by browser.

## What did change?
The sort function used for speed order no longer also randomises the order on ties, instead after all pokemon have been sorted by speed it goes through and internally shuffles any group of pokemon that are tied on speed.

## How to test the changes?
Produce any fight which involves a speed tie, via overrides or a daily seed. An easy way to test with a daily seed is by forcing the seed `ww72CMRSJYns+1ZuvidsAw==`. Use a pokeball on the first fight, take the great ball, use payback twice, reroll rewards, potion your turtonator, and then you should be in a fight vs a cubone. This is a speed tie.

Previously on firefox, cubone would win on the first turn while on chrome turtonator would win on the first turn. In my tests with this change cubone wins on the first turn, turtonator on the second, and cubone on the first if you click only incinerate.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)