### PR TITLE
[Refactor] Move enum ExpNotification into separated file

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -62,6 +62,7 @@ import { NewArenaEvent } from "./battle-scene-events";
 import { Abilities } from "./data/enums/abilities";
 import ArenaFlyout from "./ui/arena-flyout";
 import { EaseType } from "./ui/enums/ease-type";
+import { ExpNotification } from "./enums/exp-notification";
 
 export const bypassLogin = import.meta.env.VITE_BYPASS_LOGIN === "1";
 
@@ -141,7 +142,7 @@ export default class BattleScene extends SceneBase {
      * Modes `1` and `2` are still compatible with stats display, level up, new move, etc.
      * @default 0 - Uses the default normal experience gain display.
      */
-  public expParty: integer = 0;
+  public expParty: ExpNotification = 0;
   public hpBarSpeed: integer = 0;
   public fusionPaletteSwaps: boolean = true;
   public enableTouchControls: boolean = false;

--- a/src/enums/exp-notification.ts
+++ b/src/enums/exp-notification.ts
@@ -1,0 +1,11 @@
+/**
+ * Determines exp notification style.
+ * - Default - the normal exp gain display, nothing changed
+ * - Only level up - we display the level up in the small frame instead of a message
+ * - Skip - no level up frame nor message
+*/
+export enum ExpNotification {
+    DEFAULT,
+    ONLY_LEVEL_UP,
+    SKIP
+}

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -4303,7 +4303,7 @@ export class ShowPartyExpBarPhase extends PlayerPartyMemberPokemonPhase {
         this.end();
       }
     } else if (this.scene.expGainsSpeed < 3) {
-      this.scene.partyExpBar.showPokemonExp(pokemon, exp.value, this.scene.expParty === ExpNotification.ONLY_LEVEL_UP, newLevel).then(() => {
+      this.scene.partyExpBar.showPokemonExp(pokemon, exp.value, false, newLevel).then(() => {
         setTimeout(() => this.end(), 500 / Math.pow(2, this.scene.expGainsSpeed));
       });
     } else {

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -63,6 +63,7 @@ import * as Overrides from "./overrides";
 import { TextStyle, addTextObject } from "./ui/text";
 import { Type } from "./data/type";
 import { BerryUsedEvent, EncounterPhaseEvent, MoveUsedEvent, TurnEndEvent, TurnInitEvent } from "./battle-scene-events";
+import { ExpNotification } from "./enums/exp-notification";
 
 
 export class LoginPhase extends Phase {
@@ -4289,20 +4290,20 @@ export class ShowPartyExpBarPhase extends PlayerPartyMemberPokemonPhase {
     this.scene.unshiftPhase(new HidePartyExpBarPhase(this.scene));
     pokemon.updateInfo();
 
-    if (this.scene.expParty === 2) { // 2 - Skip - no level up frame nor message
+    if (this.scene.expParty === ExpNotification.SKIP) {
       this.end();
-    } else if (this.scene.expParty === 1) { // 1 - Only level up - we display the level up in the small frame instead of a message
+    } else if (this.scene.expParty === ExpNotification.ONLY_LEVEL_UP) {
       if (newLevel > lastLevel) { // this means if we level up
         // instead of displaying the exp gain in the small frame, we display the new level
         // we use the same method for mode 0 & 1, by giving a parameter saying to display the exp or the level
-        this.scene.partyExpBar.showPokemonExp(pokemon, exp.value, this.scene.expParty === 1, newLevel).then(() => {
+        this.scene.partyExpBar.showPokemonExp(pokemon, exp.value, this.scene.expParty === ExpNotification.ONLY_LEVEL_UP, newLevel).then(() => {
           setTimeout(() => this.end(), 800 / Math.pow(2, this.scene.expGainsSpeed));
         });
       } else {
         this.end();
       }
     } else if (this.scene.expGainsSpeed < 3) {
-      this.scene.partyExpBar.showPokemonExp(pokemon, exp.value, this.scene.expParty === 1, newLevel).then(() => {
+      this.scene.partyExpBar.showPokemonExp(pokemon, exp.value, this.scene.expParty === ExpNotification.ONLY_LEVEL_UP, newLevel).then(() => {
         setTimeout(() => this.end(), 500 / Math.pow(2, this.scene.expGainsSpeed));
       });
     } else {
@@ -4349,12 +4350,12 @@ export class LevelUpPhase extends PlayerPartyMemberPokemonPhase {
     const prevStats = pokemon.stats.slice(0);
     pokemon.calculateStats();
     pokemon.updateInfo();
-    if (this.scene.expParty === 0) { // 0 - default - the normal exp gain display, nothing changed
+    if (this.scene.expParty === ExpNotification.DEFAULT) {
       this.scene.playSound("level_up_fanfare");
       this.scene.ui.showText(i18next.t("battle:levelUp", { pokemonName: this.getPokemon().name, level: this.level }), null, () => this.scene.ui.getMessageHandler().promptLevelUpStats(this.partyMemberIndex, prevStats, false).then(() => this.end()), null, true);
-    } else if (this.scene.expParty === 2) { // 2 - Skip - no level up frame nor message
+    } else if (this.scene.expParty === ExpNotification.SKIP) {
       this.end();
-    } else { // 1 - Only level up - we display the level up in the small frame instead of a message
+    } else {
       // we still want to display the stats if activated
       this.scene.ui.getMessageHandler().promptLevelUpStats(this.partyMemberIndex, prevStats, false).then(() => this.end());
     }


### PR DESCRIPTION
## What are the changes?
I've moved exp-notification enum into their own files inside src/data/enums

## Why am I doing these changes?
Moving enum to respective files
Avoiding hardcoded magic numbers and replace them with enums

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?