### PR TITLE
[Bug] Update Sweet Scent to reduce evasion by 2

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5972,7 +5972,7 @@ export function initMoves() {
       ], true)
       .attr(RemoveArenaTrapAttr),
     new StatusMove(Moves.SWEET_SCENT, Type.NORMAL, 100, 20, -1, 0, 2)
-      .attr(StatChangeAttr, BattleStat.EVA, -1)
+      .attr(StatChangeAttr, BattleStat.EVA, -2)
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new AttackMove(Moves.IRON_TAIL, Type.STEEL, MoveCategory.PHYSICAL, 100, 75, 15, 30, 0, 2)
       .attr(StatChangeAttr, BattleStat.DEF, -1),


### PR DESCRIPTION
cf https://bulbapedia.bulbagarden.net/wiki/Sweet_Scent_(move)

This changes the Sweet Scent move to reduce foes' evasion by 2 stages instead of 1, as per Gen6+. This modifies line 5975 of src/data/move.ts
That's it, just a single character change.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?