### PR TITLE
[Localization] Ability Bar can now be localized. In a way that pokemonName abilityNa…

### DIFF
--- a/src/locales/de/fight-ui-handler.ts
+++ b/src/locales/de/fight-ui-handler.ts
@@ -4,4 +4,6 @@ export const fightUiHandler: SimpleTranslationEntries = {
   "pp": "AP",
   "power": "Stärke",
   "accuracy": "Genauigkeit",
+  "abilityFlyInText": "{{passive}}{{abilityName}} von {{pokemonName}} wirkt",
+  "passive": "Passive Fähigkeit ", // The space at the end is important
 } as const;

--- a/src/locales/de/fight-ui-handler.ts
+++ b/src/locales/de/fight-ui-handler.ts
@@ -4,6 +4,6 @@ export const fightUiHandler: SimpleTranslationEntries = {
   "pp": "AP",
   "power": "Stärke",
   "accuracy": "Genauigkeit",
-  "abilityFlyInText": "{{passive}}{{abilityName}} von {{pokemonName}} wirkt",
+  "abilityFlyInText": "{{passive}}{{abilityName}} von {{pokemonName}} wirkt.",
   "passive": "Passive Fähigkeit ", // The space at the end is important
 } as const;

--- a/src/locales/de/fight-ui-handler.ts
+++ b/src/locales/de/fight-ui-handler.ts
@@ -4,6 +4,6 @@ export const fightUiHandler: SimpleTranslationEntries = {
   "pp": "AP",
   "power": "Stärke",
   "accuracy": "Genauigkeit",
-  "abilityFlyInText": "{{passive}}{{abilityName}} von {{pokemonName}} wirkt.",
+  "abilityFlyInText": "{{passive}}{{abilityName}} von {{pokemonName}} wirkt!",
   "passive": "Passive Fähigkeit ", // The space at the end is important
 } as const;

--- a/src/locales/en/fight-ui-handler.ts
+++ b/src/locales/en/fight-ui-handler.ts
@@ -4,4 +4,6 @@ export const fightUiHandler: SimpleTranslationEntries = {
   "pp": "PP",
   "power": "Power",
   "accuracy": "Accuracy",
+  "abilityFlyInText": " {{pokemonName}}'s {{passive}}{{abilityName}}",
+  "passive": "Passive ", // The space at the end is important
 } as const;

--- a/src/locales/es/fight-ui-handler.ts
+++ b/src/locales/es/fight-ui-handler.ts
@@ -4,4 +4,6 @@ export const fightUiHandler: SimpleTranslationEntries = {
   "pp": "PP",
   "power": "Potencia",
   "accuracy": "Precisión",
+  "abilityFlyInText": " {{pokemonName}}'s {{passive}}{{abilityName}}",
+  "passive": "Passive ", // The space at the end is important
 } as const;

--- a/src/locales/fr/fight-ui-handler.ts
+++ b/src/locales/fr/fight-ui-handler.ts
@@ -4,4 +4,6 @@ export const fightUiHandler: SimpleTranslationEntries = {
   "pp": "PP",
   "power": "Puissance",
   "accuracy": "Précision",
+  "abilityFlyInText": " {{pokemonName}}'s {{passive}}{{abilityName}}",
+  "passive": "Passive ", // The space at the end is important
 } as const;

--- a/src/locales/it/fight-ui-handler.ts
+++ b/src/locales/it/fight-ui-handler.ts
@@ -4,4 +4,6 @@ export const fightUiHandler: SimpleTranslationEntries = {
   "pp": "PP",
   "power": "Potenza",
   "accuracy": "Precisione",
+  "abilityFlyInText": " {{pokemonName}}'s {{passive}}{{abilityName}}",
+  "passive": "Passive ", // The space at the end is important
 } as const;

--- a/src/locales/ko/fight-ui-handler.ts
+++ b/src/locales/ko/fight-ui-handler.ts
@@ -4,4 +4,6 @@ export const fightUiHandler: SimpleTranslationEntries = {
   "pp": "PP",
   "power": "위력",
   "accuracy": "명중률",
+  "abilityFlyInText": " {{pokemonName}}'s {{passive}}{{abilityName}}",
+  "passive": "Passive ", // The space at the end is important
 } as const;

--- a/src/locales/ko/fight-ui-handler.ts
+++ b/src/locales/ko/fight-ui-handler.ts
@@ -4,6 +4,6 @@ export const fightUiHandler: SimpleTranslationEntries = {
   "pp": "PP",
   "power": "위력",
   "accuracy": "명중률",
-  "abilityFlyInText": " {{pokemonName}}'s {{passive}}{{abilityName}}",
-  "passive": "Passive ", // The space at the end is important
+  "abilityFlyInText": " {{pokemonName}}의 {{passive}}{{abilityName}}",
+  "passive": "패시브 ", // The space at the end is important
 } as const;

--- a/src/locales/pt_BR/fight-ui-handler.ts
+++ b/src/locales/pt_BR/fight-ui-handler.ts
@@ -4,4 +4,6 @@ export const fightUiHandler: SimpleTranslationEntries = {
   "pp": "PP",
   "power": "Poder",
   "accuracy": "Precisão",
+  "abilityFlyInText": " {{pokemonName}}'s {{passive}}{{abilityName}}",
+  "passive": "Passive ", // The space at the end is important
 } as const;

--- a/src/locales/zh_CN/fight-ui-handler.ts
+++ b/src/locales/zh_CN/fight-ui-handler.ts
@@ -4,4 +4,6 @@ export const fightUiHandler: SimpleTranslationEntries = {
   "pp": "PP",
   "power": "威力",
   "accuracy": "命中",
+  "abilityFlyInText": " {{pokemonName}}'s {{passive}}{{abilityName}}",
+  "passive": "Passive ", // The space at the end is important
 } as const;

--- a/src/locales/zh_TW/fight-ui-handler.ts
+++ b/src/locales/zh_TW/fight-ui-handler.ts
@@ -4,4 +4,6 @@ export const fightUiHandler: SimpleTranslationEntries = {
   "pp": "PP",
   "power": "威力",
   "accuracy": "命中率",
+  "abilityFlyInText": " {{pokemonName}}'s {{passive}}{{abilityName}}",
+  "passive": "Passive ", // The space at the end is important
 } as const;

--- a/src/ui/ability-bar.ts
+++ b/src/ui/ability-bar.ts
@@ -1,6 +1,7 @@
 import BattleScene from "../battle-scene";
 import Pokemon from "../field/pokemon";
 import { TextStyle, addTextObject } from "./text";
+import i18next from "i18next";
 
 const hiddenX = -118;
 const shownX = 0;
@@ -8,8 +9,7 @@ const baseY = -116;
 
 export default class AbilityBar extends Phaser.GameObjects.Container {
   private bg: Phaser.GameObjects.Image;
-  private pokemonNameText: Phaser.GameObjects.Text;
-  private abilityNameText: Phaser.GameObjects.Text;
+  private abilityBarText: Phaser.GameObjects.Text;
 
   private tween: Phaser.Tweens.Tween;
   private autoHideTimer: NodeJS.Timeout;
@@ -26,21 +26,17 @@ export default class AbilityBar extends Phaser.GameObjects.Container {
 
     this.add(this.bg);
 
-    this.pokemonNameText = addTextObject(this.scene, 15, 3, "", TextStyle.MESSAGE, { fontSize: "72px" });
-    this.pokemonNameText.setOrigin(0, 0);
-    this.add(this.pokemonNameText);
-
-    this.abilityNameText = addTextObject(this.scene, 97, 16, "", TextStyle.WINDOW, { fontSize: "72px" });
-    this.abilityNameText.setOrigin(1, 0);
-    this.add(this.abilityNameText);
+    this.abilityBarText = addTextObject(this.scene, 15, 3, "", TextStyle.MESSAGE, { fontSize: "72px" });
+    this.abilityBarText.setOrigin(0, 0);
+    this.abilityBarText.setWordWrapWidth(600, true);
+    this.add(this.abilityBarText);
 
     this.setVisible(false);
     this.shown = false;
   }
 
   showAbility(pokemon: Pokemon, passive: boolean = false): void {
-    this.pokemonNameText.setText(`${pokemon.name}'s${passive ? " Passive" : ""}`);
-    this.abilityNameText.setText((!passive ? pokemon.getAbility() : pokemon.getPassiveAbility()).name);
+    this.abilityBarText.setText(`${i18next.t("fightUiHandler:abilityFlyInText", { pokemonName: pokemon.name, passive: passive ? i18next.t("fightUiHandler:passive") : "", abilityName: !passive ?  pokemon.getAbility().name : pokemon.getPassiveAbility().name })}`);
 
     if (this.shown) {
       return;


### PR DESCRIPTION
…me and passive string can be ordered freely

<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
The ability bar can now be localized and also wraps automatically if the text is too long

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Because the way it was before only made sense in english (well at least it didnt in german)

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Made it localizable with the ability to place abilityName, pokemonName and passive freely

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

- Ability that is no passive
https://github.com/pagefaultgames/pokerogue/assets/38758606/2427362e-d7bf-4afe-89a4-6ba0f47275cc

- Ability that is a passive
https://github.com/pagefaultgames/pokerogue/assets/38758606/dd39713d-56ac-4a25-a832-dddbe523ef69

English Text remains unchanged to how it was before

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Use any pokemon with a ability that triggers such a box (like kyogre or groudon)

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?