### PR TITLE
[Localization] party-ui-handler.ts Spanish translations

### DIFF
--- a/src/locales/es/party-ui-handler.ts
+++ b/src/locales/es/party-ui-handler.ts
@@ -1,10 +1,10 @@
 import { SimpleTranslationEntries } from "#app/plugins/i18n";
 
 export const partyUiHandler: SimpleTranslationEntries = {
-  "SEND_OUT": "Send Out",
-  "SUMMARY": "Summary",
-  "CANCEL": "Cancel",
-  "RELEASE": "Release",
-  "APPLY": "Apply",
-  "TEACH": "Teach"
+  "SEND_OUT": "Cambiar",
+  "SUMMARY": "Datos",
+  "CANCEL": "Cancelar",
+  "RELEASE": "Liberar",
+  "APPLY": "Usar",
+  "TEACH": "Aprender"
 } as const;


### PR DESCRIPTION
## What are the changes?
- Updated party-ui-handler-ts

## Why am I doing these changes?
I decided to introduce these changes to improve the overall user experience, particularly for Spanish-speaking players who may not understand English well.
Added Spanish translations based on PR #1712

## What did change?
Translated party ui.

### Screenshots/Videos
Sending out a Pokemon
![Captura](https://github.com/pagefaultgames/pokerogue/assets/162721984/525f9204-c70d-4362-8fa5-b59c4b9bb581)
Teaching a TM move
![Captura1](https://github.com/pagefaultgames/pokerogue/assets/162721984/7de93244-96a6-4e56-8ed9-3b6b3a73371f)
Applying an item
![Captura2](https://github.com/pagefaultgames/pokerogue/assets/162721984/4462f173-6394-4c2f-8925-de238c658cf6)



## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?