### PR TITLE
[Localization] Abbreviate long german translations in pokemon info boxes

### DIFF
--- a/src/locales/de/pokemon-info-container.ts
+++ b/src/locales/de/pokemon-info-container.ts
@@ -2,8 +2,8 @@ import { SimpleTranslationEntries } from "#app/plugins/i18n";
 
 export const pokemonInfoContainer: SimpleTranslationEntries = {
   "moveset": "Attacken",
-  "gender": "Geschlecht:",
-  "ability": "Fähigkeit:",
+  "gender": "Geschl.:",
+  "ability": "Fähigk.:",
   "nature": "Wesen:",
   "epic": "Episch",
   "rare": "Selten",

--- a/src/locales/de/starter-select-ui-handler.ts
+++ b/src/locales/de/starter-select-ui-handler.ts
@@ -17,7 +17,7 @@ export const starterSelectUiHandler: SimpleTranslationEntries = {
   "gen8": "VIII",
   "gen9": "IX",
   "growthRate": "Wachstum:",
-  "ability": "Fähigkeit:",
+  "ability": "Fähigk.:",
   "passive": "Passiv:",
   "nature": "Wesen:",
   "eggMoves": "Ei-Attacken",


### PR DESCRIPTION
As in many games, some german words tend to be a lot longer than their translations in other languages. Therefore they often clip out of frames or overlap. Pokerogue is no exception.
This PR abbreviates the words for Ability (=Fähigkeit) and Gender (=Geschlecht) on the starter screen and the pokemon info screen (for catches and hatches).

## What are the changes?
Abbreviates german translations on starter and pokemon info screen to avoid overlapping.

## Why am I doing these changes?
It slightly annoyed me while playing.

## What did change?
Fixes overlapping of german translations on starter and pokemon info screen by abbreviating the words.
As I understand, moving or changing the layout of these frames is not an option, so abbreviation seems to be the best solution.
There are no official dictionary abbreviations for these words, but I would say that it' still easy to understand given the context.

### Screenshots/Videos
Before the change:
<img width="1440" alt="Bildschirmfoto 2024-06-08 um 03 18 10" src="https://github.com/pagefaultgames/pokerogue/assets/67913362/8642fa46-6bea-49a2-829d-e7cc88911684">
<img width="1440" alt="Bildschirmfoto 2024-06-08 um 03 20 18" src="https://github.com/pagefaultgames/pokerogue/assets/67913362/1a71052f-2551-4bba-976e-8ace0b78684f">

After the change:
<img width="1440" alt="Bildschirmfoto 2024-06-08 um 03 22 15" src="https://github.com/pagefaultgames/pokerogue/assets/67913362/127a82b5-a6c9-483e-8c79-8916b8c73f66">
<img width="1440" alt="Bildschirmfoto 2024-06-08 um 03 21 44" src="https://github.com/pagefaultgames/pokerogue/assets/67913362/c8809bc5-0805-4910-9728-0b1222aec47b">


## How to test the changes?
1. Set the game to german.
2. Check a pokemon on starter screen.
3. Start a run and catch or hatch a pokemon.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?