### PR TITLE
Let Flame Body, Magma Armor and Steam Engine decrement hatch count by two

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -5088,7 +5088,15 @@ export class EggLapsePhase extends Phase {
     super.start();
 
     const eggsToHatch: Egg[] = this.scene.gameData.eggs.filter((egg: Egg) => {
-      return Overrides.IMMEDIATE_HATCH_EGGS_OVERRIDE ? true : --egg.hatchWaves < 1;
+      let doubledEggHatch = false;
+      for (const pokemon of this.scene.getParty()) {
+        if (pokemon.hasAbility(Abilities.FLAME_BODY) || pokemon.hasAbility(Abilities.MAGMA_ARMOR) || pokemon.hasAbility(Abilities.STEAM_ENGINE)) {
+          doubledEggHatch = true;
+        }
+      }
+      egg.hatchWaves -= doubledEggHatch ? 2 : 1;
+
+      return Overrides.IMMEDIATE_HATCH_EGGS_OVERRIDE ? true : egg.hatchWaves < 1;
     });
 
     let eggsToHatchCount: integer = eggsToHatch.length;

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -5088,12 +5088,9 @@ export class EggLapsePhase extends Phase {
     super.start();
 
     const eggsToHatch: Egg[] = this.scene.gameData.eggs.filter((egg: Egg) => {
-      let doubledEggHatch = false;
-      for (const pokemon of this.scene.getParty()) {
-        if (pokemon.hasAbility(Abilities.FLAME_BODY) || pokemon.hasAbility(Abilities.MAGMA_ARMOR) || pokemon.hasAbility(Abilities.STEAM_ENGINE)) {
-          doubledEggHatch = true;
-        }
-      }
+      const doubledEggHatch = this.scene.getParty().some(pokemon => pokemon.hasAbility(Abilities.FLAME_BODY) ||
+          pokemon.hasAbility(Abilities.MAGMA_ARMOR) || pokemon.hasAbility(Abilities.STEAM_ENGINE));
+
       egg.hatchWaves -= doubledEggHatch ? 2 : 1;
 
       return Overrides.IMMEDIATE_HATCH_EGGS_OVERRIDE ? true : egg.hatchWaves < 1;


### PR DESCRIPTION
## What are the changes?
Let players with Pokemon that have the abilities Flame Body, Magma Armor and Steam Engine decrement hatches by two each floor.

## Why am I doing these changes?
In games that had eggs, these abilities allowed players to hatch faster.

## What did change?
Check to see if pokemon has said abilities, decrement hatch counter by two, otherwise decrement by one.

### Screenshots/Videos
Could someone test this for me? My computer's slow to do any testing on...

## How to test the changes?
Get a pokemon in your party with said ability, count number of floors are needed to hatch.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?