### PR TITLE
[Bug] Fix to show current locale in setting

### DIFF
--- a/src/ui/settings/settings-display-ui-handler.ts
+++ b/src/ui/settings/settings-display-ui-handler.ts
@@ -2,7 +2,7 @@ import BattleScene from "../../battle-scene";
 import { Mode } from "../ui";
 "#app/inputs-controller.js";
 import AbstractSettingsUiHandler from "./abstract-settings-ui-handler";
-import { Setting, SettingType } from "#app/system/settings/settings";
+import { Setting, SettingKeys, SettingType } from "#app/system/settings/settings";
 
 export default class SettingsDisplayUiHandler extends AbstractSettingsUiHandler {
   /**
@@ -15,6 +15,45 @@ export default class SettingsDisplayUiHandler extends AbstractSettingsUiHandler 
     super(scene, mode);
     this.title = "Display";
     this.settings = Setting.filter(s => s.type === SettingType.DISPLAY);
+
+    /**
+     * Update to current language from default value.
+     * - default value is 'English'
+     */
+    const languageIndex = this.settings.findIndex(s => s.key === SettingKeys.Language);
+    if (languageIndex >= 0) {
+      const currentLocale = localStorage.getItem("prLang");
+      switch (currentLocale) {
+      case "en":
+        this.settings[languageIndex].options[0] = "English";
+        break;
+      case "es":
+        this.settings[languageIndex].options[0] = "Español";
+        break;
+      case "it":
+        this.settings[languageIndex].options[0] = "Italiano";
+        break;
+      case "fr":
+        this.settings[languageIndex].options[0] = "Français";
+        break;
+      case "de":
+        this.settings[languageIndex].options[0] = "Deutsch";
+        break;
+      case "pt-BR":
+        this.settings[languageIndex].options[0] = "Português (BR)";
+        break;
+      case "zh-CN":
+        this.settings[languageIndex].options[0] = "简体中文";
+        break;
+      case "zh-TW":
+        this.settings[languageIndex].options[0] = "繁體中文";
+        break;
+      case "ko":
+        this.settings[languageIndex].options[0] = "한국어";
+        break;
+      }
+    }
+
     this.localStorageKey = "settings";
   }
 }

--- a/src/ui/settings/settings-display-ui-handler.ts
+++ b/src/ui/settings/settings-display-ui-handler.ts
@@ -51,6 +51,9 @@ export default class SettingsDisplayUiHandler extends AbstractSettingsUiHandler 
       case "ko":
         this.settings[languageIndex].options[0] = "한국어";
         break;
+      default:
+        this.settings[languageIndex].options[0] = "English";
+        break;
       }
     }
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Language option has been shown only English whenever what current locale is it. so that fix to show current locale in setting.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
It is bug I think, so it needs to fix.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Change option value to current locale when initialize Language option in `setting-display-ui-handler.ts`

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
https://github.com/pagefaultgames/pokerogue/assets/13056250/27ee65e4-29d2-4766-b10d-18480c4dd0dc


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
- Check out this PR.
- Check current language in setting.
- Change language.
- After reload, check language option is current locale in setting.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?