### PR TITLE
Fixed Spelling mistake in Tate & Lizas Double Dialogue

### DIFF
--- a/src/locales/en/dialogue.ts
+++ b/src/locales/en/dialogue.ts
@@ -2372,7 +2372,7 @@ export const PGMdoubleBattleDialogue: DialogueTranslationEntries = {
   },
   "tate_liza_double": {
     "encounter": {
-      1: `Tate: Are you suprised?
+      1: `Tate: Are you surprised?
                   $Liza: We are two gym leaders at once!
                   $Tate: We are twins!
                   $Liza: We dont need to talk to understand each other!
@@ -2386,7 +2386,7 @@ export const PGMdoubleBattleDialogue: DialogueTranslationEntries = {
   },
   "liza_tate_double": {
     "encounter": {
-      1: `Liza: Hihihi... Are you suprised?
+      1: `Liza: Hihihi... Are you surprised?
                   $Tate: Yes, we are really two gym leaders at once!
                   $Liza: This is my twin brother Tate!
                   $Tate: And this is my twin sister Liza!


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Added a missing r

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Because it was spelled wrong

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
I literally added only the r in the word.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
Before:
![image](https://github.com/pagefaultgames/pokerogue/assets/38758606/8936c6a8-4571-4fea-97eb-0c3986428fc8)
After:
![image](https://github.com/pagefaultgames/pokerogue/assets/38758606/2fb2ab0a-e59b-4ddf-adce-9aeeb25a89e3)

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Force Tate (or Liza) to spawn as a double (for example by changing battle.ts)

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?