### PR TITLE
[Bug] Override battles into single only if not fighting with trainers

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1010,7 +1010,8 @@ export default class BattleScene extends SceneBase {
     if (Overrides.DOUBLE_BATTLE_OVERRIDE) {
       newDouble = true;
     }
-    if (Overrides.SINGLE_BATTLE_OVERRIDE) {
+    /* Override battles into single only if not fighting with trainers */
+    if (newBattleType !== BattleType.TRAINER && Overrides.SINGLE_BATTLE_OVERRIDE) {
       newDouble = false;
     }
 


### PR DESCRIPTION
## What are the changes?
Override battles into single only if not fighting with trainers

## Why am I doing these changes?
Game crashing if double fight with trainer and set override single battles to true
Fix https://github.com/pagefaultgames/pokerogue/issues/1948

## What did change?
Override battles into single only if not fighting with trainers

## How to test the changes?
set SINGLE_BATTLE_OVERRIDE to true
fight with trainer with double fight

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?