### PR TITLE
[Localization] Fixed the localization of getModeName and "Wave" text

### DIFF
--- a/src/game-mode.ts
+++ b/src/game-mode.ts
@@ -285,15 +285,15 @@ export class GameMode implements GameModeConfig {
   static getModeName(modeId: GameModes): string {
     switch (modeId) {
     case GameModes.CLASSIC:
-      return "Classic";
+      return i18next.t("gameMode:classic");
     case GameModes.ENDLESS:
-      return "Endless";
+      return i18next.t("gameMode:endless");
     case GameModes.SPLICED_ENDLESS:
-      return "Endless (Spliced)";
+      return i18next.t("gameMode:endlessSpliced");
     case GameModes.DAILY:
-      return "Daily Run";
+      return i18next.t("gameMode:dailyRun");
     case GameModes.CHALLENGE:
-      return "Challenge";
+      return i18next.t("gameMode:challenge");
     }
   }
 }

--- a/src/ui/save-slot-select-ui-handler.ts
+++ b/src/ui/save-slot-select-ui-handler.ts
@@ -266,7 +266,7 @@ class SessionSlot extends Phaser.GameObjects.Container {
   async setupWithData(data: SessionSaveData) {
     this.remove(this.loadingLabel, true);
 
-    const gameModeLabel = addTextObject(this.scene, 8, 5, `${GameMode.getModeName(data.gameMode) || i18next.t("gameMode:unkown")} - ${i18next.t("gameMode:wave")} ${data.waveIndex}`, TextStyle.WINDOW);
+    const gameModeLabel = addTextObject(this.scene, 8, 5, `${GameMode.getModeName(data.gameMode) || i18next.t("gameMode:unkown")} - ${i18next.t("saveSlotSelectUiHandler:wave")} ${data.waveIndex}`, TextStyle.WINDOW);
     this.add(gameModeLabel);
 
     const timestampLabel = addTextObject(this.scene, 8, 19, new Date(data.timestamp).toLocaleString(), TextStyle.WINDOW);


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Localized getModeName and fixed the localization of "Wave"

## Before (ptBR)
![image](https://github.com/pagefaultgames/pokerogue/assets/79599290/0dc26737-d606-478f-81f4-9756af6f8d5c)
![image](https://github.com/pagefaultgames/pokerogue/assets/79599290/77d5727c-b447-4684-a096-56da4e2c8b90)

## After (ptBR)
![image](https://github.com/pagefaultgames/pokerogue/assets/79599290/9b9fe4b9-da56-4700-90b1-d757c0e34424)
![image](https://github.com/pagefaultgames/pokerogue/assets/79599290/bc41eca2-4813-40f2-9e21-ff8d7fa8d46c)

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?