### PR TITLE
[QoL] Hide useCandies if passive unlocked and cost reduction maxed

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1278,13 +1278,17 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
             });
           };
           if (!pokemonPrevolutions.hasOwnProperty(this.lastSpecies.speciesId)) {
-            options.push({
-              label: i18next.t("starterSelectUiHandler:useCandies"),
-              handler: () => {
-                ui.setMode(Mode.STARTER_SELECT).then(() => showUseCandies());
-                return true;
-              }
-            });
+            const passiveAvailable = !(passiveAttr & PassiveAttr.UNLOCKED);
+            const reductionCostAvailable = starterData.valueReduction < 2;
+            if (passiveAvailable || reductionCostAvailable) {
+              options.push({
+                label: i18next.t("starterSelectUiHandler:useCandies"),
+                handler: () => {
+                  ui.setMode(Mode.STARTER_SELECT).then(() => showUseCandies());
+                  return true;
+                }
+              });
+            }
           }
           options.push({
             label: i18next.t("menu:cancel"),


### PR DESCRIPTION
## What are the changes?
Hide `use candies` if passive unlocked and cost reduction maxed

## Why am I doing these changes?
Hiding item which is empty inside

## What did change?
Before: After opening `use candy`, only `Cancel` item was displayed
After: item useCandy removed from UI

### Screenshots/Videos
Before
<img width="1613" alt="Screenshot 2024-06-08 at 18 16 07" src="https://github.com/pagefaultgames/pokerogue/assets/19636010/bb769059-17da-41c8-b9fb-ec5d24cc41b0">

<img width="1614" alt="Screenshot 2024-06-08 at 18 16 18" src="https://github.com/pagefaultgames/pokerogue/assets/19636010/9fe0d7c6-0062-4152-b2b1-9b75458e5ea5">

After
<img width="1613" alt="Screenshot 2024-06-08 at 18 14 12" src="https://github.com/pagefaultgames/pokerogue/assets/19636010/131463aa-eb8b-429d-8859-6cad81b73a97">


## How to test the changes?
Open starter view
Choose pokemon with unlocked passive and reduction cost maxed

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?