### PR TITLE
[Localization][es] menu.ts full Spanish translation

### DIFF
--- a/src/locales/es/menu.ts
+++ b/src/locales/es/menu.ts
@@ -45,10 +45,10 @@ export const menu: SimpleTranslationEntries = {
   "weeklyRankings": "Rankings Semanales",
   "noRankings": "Sin Rankings",
   "loading": "Cargando…",
-  "loadingAsset": "Loading asset: {{assetName}}",
+  "loadingAsset": "Cargando recurso: {{assetName}}",
   "playersOnline": "Jugadores en Línea",
   "yes":"Sí",
   "no":"No",
-  "disclaimer": "DISCLAIMER",
-  "disclaimerDescription": "This game is an unfinished product; it might have playability issues (including the potential loss of save data),\n change without notice, and may or may not be updated further or completed."
+  "disclaimer": "AVISO",
+  "disclaimerDescription": "Este juego es un producto inacabado; puede tener problemas de jugabilidad (incluyendo la posible pérdida de datos de guardado),\ncambiar sin avisar, y puede o no puede ser actualizado hasta ser completado."
 } as const;


### PR DESCRIPTION
## What are the changes?
Localization changes

## Why am I doing these changes?
Since menu.ts got updates, I wanted to translate it

## What did change?
I translated the "Loading asset" and the disclaimer in menu.ts

### Screenshots/Videos
Not needed, just localization

## How to test the changes?
Not needed, just localization

## Checklist
- [x ] There is no overlap with another PR?
- [ x] The PR is self-contained and cannot be split into smaller PRs?
- [ x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?