### PR TITLE
[Tests] added silent flag to run tests and added a missing properties in the MockText

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"test": "vitest run",
 		"test:cov": "vitest run --coverage",
 		"test:watch": "vitest watch --coverage",
+		"test:silent": "vitest run --silent",
 		"eslint": "eslint --fix .",
 		"eslint-ci": "eslint .",
 		"docs": "typedoc"

--- a/src/test/utils/mocks/mocksContainer/mockText.ts
+++ b/src/test/utils/mocks/mocksContainer/mockText.ts
@@ -7,9 +7,11 @@ export default class MockText {
   private scene;
   private textureManager;
   public list = [];
+  public style;
   constructor(textureManager, x, y, content, styleOptions) {
     this.scene = textureManager.scene;
     this.textureManager = textureManager;
+    this.style = {};
     // Phaser.GameObjects.TextStyle.prototype.setStyle = () => null;
     // Phaser.GameObjects.Text.prototype.updateText = () => null;
     // Phaser.Textures.TextureManager.prototype.addCanvas = () => {};


### PR DESCRIPTION
added a way to silent the console.log by using the command:
npm run test:silent


+ added a missing property in MockText (style), to fix this:
![webstorm64_BDcIJwaeB9](https://github.com/pagefaultgames/pokerogue/assets/44787002/86b8593c-c6bd-4e7c-a650-b7196ce3cd93)
