### PR TITLE
[Bug] Fix switching moves in challenge mode

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -4416,7 +4416,7 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
       }
 
       const party = player ? user.scene.getParty() : user.scene.getEnemyParty();
-      return (!player && !user.scene.currentBattle.battleType) || party.filter(p => !p.isFainted() && (player || (p as EnemyPokemon).trainerSlot === (switchOutTarget as EnemyPokemon).trainerSlot)).length > user.scene.currentBattle.getBattlerCount();
+      return (!player && !user.scene.currentBattle.battleType) || party.filter(p => p.isAllowedInBattle() && (player || (p as EnemyPokemon).trainerSlot === (switchOutTarget as EnemyPokemon).trainerSlot)).length > user.scene.currentBattle.getBattlerCount();
     };
   }
 


### PR DESCRIPTION
## What are the changes?
Make switching moves check for challenges.

## Why am I doing these changes?
Switching moves weren't checking for challenges.

## What did change?
Switching moves use isAllowedInBattle instead of !isFainted.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
Attempt to use a switching move in a challenge while you've got only illegal pokemon in the back.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [] Are the changes visual?
  - [] Have I provided screenshots/videos of the changes?