### PR TITLE
[Bug] Fix Victini's generation for challenges.

### DIFF
--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -267,6 +267,12 @@ export class SingleGenerationChallenge extends Challenge {
       return false;
     }
 
+    /**
+     * We have special code below for victini because it is classed as a generation 4 pokemon in the code
+     * despite being a generation 5 pokemon. This is due to UI constraints, the starter select screen has
+     * no more room for pokemon so victini is put in the gen 4 section instead. This code just overrides the
+     * normal generation check to correctly treat victini as gen 5.
+     */
     switch (challengeType) {
     case ChallengeType.STARTER_CHOICE:
       const species = args[0] as PokemonSpecies;

--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -271,7 +271,8 @@ export class SingleGenerationChallenge extends Challenge {
     case ChallengeType.STARTER_CHOICE:
       const species = args[0] as PokemonSpecies;
       const isValidStarter = args[1] as Utils.BooleanHolder;
-      if (species.generation !== this.value) {
+      const starterGeneration = species.speciesId === Species.VICTINI ? 5 : species.generation;
+      if (starterGeneration !== this.value) {
         isValidStarter.value = false;
         return true;
       }
@@ -279,7 +280,9 @@ export class SingleGenerationChallenge extends Challenge {
     case ChallengeType.POKEMON_IN_BATTLE:
       const pokemon = args[0] as Pokemon;
       const isValidPokemon = args[1] as Utils.BooleanHolder;
-      if (pokemon.isPlayer() && ((pokemon.species.formIndex === 0 ? pokemon.species : getPokemonSpecies(pokemon.species.speciesId)).generation !== this.value || (pokemon.isFusion() && (pokemon.fusionSpecies.formIndex === 0 ? pokemon.fusionSpecies : getPokemonSpecies(pokemon.fusionSpecies.speciesId)).generation !== this.value))) {
+      const baseGeneration = pokemon.species.speciesId === Species.VICTINI ? 5 : getPokemonSpecies(pokemon.species.speciesId).generation;
+      const fusionGeneration = pokemon.isFusion() ? pokemon.fusionSpecies.speciesId === Species.VICTINI ? 5 : getPokemonSpecies(pokemon.fusionSpecies.speciesId).generation : 0;
+      if (pokemon.isPlayer() && (baseGeneration !== this.value || (pokemon.isFusion() && fusionGeneration !== this.value))) {
         isValidPokemon.value = false;
         return true;
       }


### PR DESCRIPTION
## What are the changes?
Victini is in gen 4 partially for UI reasons, this overrides that change but only for monogen challenge runs.

## Why am I doing these changes?
Victini currently counts as gen 4, but they're from gen 5.

## What did change?
Code to treat Victini as gen 5 for monogen challenges in the challenge code.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?