### PR TITLE
Bugfix: Fixing multi-hit drain moves so they heal based on individual hit and not total damage dealt

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1467,7 +1467,7 @@ export class HitHealAttr extends MoveEffectAttr {
       message = i18next.t("battle:drainMessage", {pokemonName: target.name});
     } else {
       // Default healing formula used by draining moves like Absorb, Draining Kiss, Bitter Blade, etc.
-      healAmount = Math.max(Math.floor(user.turnData.damageDealt * this.healRatio), 1);
+      healAmount = Math.max(Math.floor(user.turnData.currDamageDealt * this.healRatio), 1);
       message = i18next.t("battle:regainHealth", {pokemonName: user.name});
     }
     if (reverseDrain) {


### PR DESCRIPTION
## What are the changes?
Makes it so multi-hit drain moves heal based on damage the dealt per hit and not total damage dealt.

## Why am I doing these changes?
If you had a multi-lens and used a drain move like `Absorb`, `Drain Punch`, etc. it would heal you based on your total damage dealt that turn and not the damage the individual hits. This means that if you did 4, 4, and 4 damage you would heal 2, 4, and 6 instead of 2, 2, and 2.

## What did change?
`HitHealAttr` in `move.ts` calcs using `user.turnData.currDamageDealt` instead of `user.turnData.damageDealt`.

### Screenshots/Videos
How it is on live branch right now (bugged)

https://github.com/pagefaultgames/pokerogue/assets/85713900/1fcb4f01-0c4f-45a0-9323-384413b43cac

With this bugfix:

https://github.com/pagefaultgames/pokerogue/assets/85713900/33c811b3-baa6-4623-90b9-b11ab6e74df3


## How to test the changes?
Chuck these into src/overrides.ts
```
export const MOVESET_OVERRIDE: Array<Moves> = [Moves.DRAIN_PUNCH, Moves.DRAINING_KISS, Moves.ABSORB, Moves.TACKLE];
export const OPP_SPECIES_OVERRIDE: Species.BLISSEY | integer = 242;
export const OPP_LEVEL_OVERRIDE: number = 20;
export const OPP_MOVESET_OVERRIDE: Array<Moves> = [Moves.FALSE_SWIPE, Moves.FALSE_SWIPE, Moves.FALSE_SWIPE, Moves.FALSE_SWIPE];
export const STARTING_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [{name: "MULTI_LENS", count: 2}];
```
## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`) - Some weren't passing when I made no changes :S but no new ones failed after my change
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?