### PR TITLE
[Bug] Make getTypes ignore transform when ignoring overrides

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -857,11 +857,11 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       if (!ignoreOverride && this.summonData?.types) {
         this.summonData.types.forEach(t => types.push(t));
       } else {
-        const speciesForm = this.getSpeciesForm();
+        const speciesForm = this.getSpeciesForm(ignoreOverride);
 
         types.push(speciesForm.type1);
 
-        const fusionSpeciesForm = this.getFusionSpeciesForm();
+        const fusionSpeciesForm = this.getFusionSpeciesForm(ignoreOverride);
         if (fusionSpeciesForm) {
           if (fusionSpeciesForm.type2 !== null && fusionSpeciesForm.type2 !== speciesForm.type1) {
             types.push(fusionSpeciesForm.type2);


### PR DESCRIPTION
## What are the changes?
Type checking effects that were meant to check only the base types now ignore transform. This most notably means that transform no longer breaks challenge runs, though it also affects pancham's evolution and tera shard type selection.

## Why am I doing these changes?
Transform was violating monotype runs.

## What did change?
ignoreOverride is now passed into the getSpeciesForm and getFusionSpeciesForm functions in getTypes.

## How to test the changes?
Use transform on anything that would violate a monotype challenge.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)