### PR TITLE
[Feature] Add setting for rival gender

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -424,15 +424,15 @@ export const classicFixedBattles: FixedBattleConfigs = {
   [5]: new FixedBattleConfig().setBattleType(BattleType.TRAINER)
     .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.YOUNGSTER, Utils.randSeedInt(2) ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT)),
   [8]: new FixedBattleConfig().setBattleType(BattleType.TRAINER)
-    .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL, scene.gameData.gender === PlayerGender.MALE ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT)),
+    .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL, scene.gameData.rivalGender === PlayerGender.MALE ? TrainerVariant.DEFAULT : TrainerVariant.FEMALE)),
   [25]: new FixedBattleConfig().setBattleType(BattleType.TRAINER)
-    .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL_2, scene.gameData.gender === PlayerGender.MALE ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT)),
+    .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL_2, scene.gameData.rivalGender === PlayerGender.MALE ? TrainerVariant.DEFAULT : TrainerVariant.FEMALE)),
   [55]: new FixedBattleConfig().setBattleType(BattleType.TRAINER)
-    .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL_3, scene.gameData.gender === PlayerGender.MALE ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT)),
+    .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL_3, scene.gameData.rivalGender === PlayerGender.MALE ? TrainerVariant.DEFAULT : TrainerVariant.FEMALE)),
   [95]: new FixedBattleConfig().setBattleType(BattleType.TRAINER)
-    .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL_4, scene.gameData.gender === PlayerGender.MALE ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT)),
+    .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL_4, scene.gameData.rivalGender === PlayerGender.MALE ? TrainerVariant.DEFAULT : TrainerVariant.FEMALE)),
   [145]: new FixedBattleConfig().setBattleType(BattleType.TRAINER)
-    .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL_5, scene.gameData.gender === PlayerGender.MALE ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT)),
+    .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL_5, scene.gameData.rivalGender === PlayerGender.MALE ? TrainerVariant.DEFAULT : TrainerVariant.FEMALE)),
   [182]: new FixedBattleConfig().setBattleType(BattleType.TRAINER)
     .setGetTrainerFunc(getRandomTrainerFunc([ TrainerType.LORELEI, TrainerType.WILL, TrainerType.SIDNEY, TrainerType.AARON, TrainerType.SHAUNTAL, TrainerType.MALVA, [ TrainerType.HALA, TrainerType.MOLAYNE ],TrainerType.MARNIE_ELITE, TrainerType.RIKA, TrainerType.CRISPIN ])),
   [184]: new FixedBattleConfig().setBattleType(BattleType.TRAINER).setSeedOffsetWave(182)
@@ -444,5 +444,5 @@ export const classicFixedBattles: FixedBattleConfigs = {
   [190]: new FixedBattleConfig().setBattleType(BattleType.TRAINER).setSeedOffsetWave(182)
     .setGetTrainerFunc(getRandomTrainerFunc([ TrainerType.BLUE, [ TrainerType.RED, TrainerType.LANCE_CHAMPION ], [ TrainerType.STEVEN, TrainerType.WALLACE ], TrainerType.CYNTHIA, [ TrainerType.ALDER, TrainerType.IRIS ], TrainerType.DIANTHA, TrainerType.HAU, TrainerType.LEON, [ TrainerType.GEETA, TrainerType.NEMONA ], TrainerType.KIERAN ])),
   [195]: new FixedBattleConfig().setBattleType(BattleType.TRAINER)
-    .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL_6, scene.gameData.gender === PlayerGender.MALE ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT))
+    .setGetTrainerFunc(scene => new Trainer(scene, TrainerType.RIVAL_6, scene.gameData.rivalGender === PlayerGender.MALE ? TrainerVariant.DEFAULT : TrainerVariant.FEMALE))
 };

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -30,7 +30,7 @@ export const SEED_OVERRIDE: string = "";
 export const WEATHER_OVERRIDE: WeatherType = WeatherType.NONE;
 export const DOUBLE_BATTLE_OVERRIDE: boolean = false;
 export const SINGLE_BATTLE_OVERRIDE: boolean = false;
-export const STARTING_WAVE_OVERRIDE: integer = 25;
+export const STARTING_WAVE_OVERRIDE: integer = 0;
 export const STARTING_BIOME_OVERRIDE: Biome = Biome.TOWN;
 export const ARENA_TINT_OVERRIDE: TimeOfDay = null;
 // Multiplies XP gained by this value including 0. Set to null to ignore the override
@@ -56,7 +56,7 @@ export const POKEBALL_OVERRIDE: { active: boolean, pokeballs: PokeballCounts } =
 // forms can be found in pokemon-species.ts
 export const STARTER_FORM_OVERRIDE: integer = 0;
 // default 5 or 20 for Daily
-export const STARTING_LEVEL_OVERRIDE: integer = 200;
+export const STARTING_LEVEL_OVERRIDE: integer = 0;
 /**
  * SPECIES OVERRIDE
  * will only apply to the first starter in your party or each enemy pokemon

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -30,7 +30,7 @@ export const SEED_OVERRIDE: string = "";
 export const WEATHER_OVERRIDE: WeatherType = WeatherType.NONE;
 export const DOUBLE_BATTLE_OVERRIDE: boolean = false;
 export const SINGLE_BATTLE_OVERRIDE: boolean = false;
-export const STARTING_WAVE_OVERRIDE: integer = 0;
+export const STARTING_WAVE_OVERRIDE: integer = 25;
 export const STARTING_BIOME_OVERRIDE: Biome = Biome.TOWN;
 export const ARENA_TINT_OVERRIDE: TimeOfDay = null;
 // Multiplies XP gained by this value including 0. Set to null to ignore the override
@@ -56,7 +56,7 @@ export const POKEBALL_OVERRIDE: { active: boolean, pokeballs: PokeballCounts } =
 // forms can be found in pokemon-species.ts
 export const STARTER_FORM_OVERRIDE: integer = 0;
 // default 5 or 20 for Daily
-export const STARTING_LEVEL_OVERRIDE: integer = 0;
+export const STARTING_LEVEL_OVERRIDE: integer = 200;
 /**
  * SPECIES OVERRIDE
  * will only apply to the first starter in your party or each enemy pokemon

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -223,6 +223,7 @@ export class GameData {
   public secretId: integer;
 
   public gender: PlayerGender;
+  public rivalGender: PlayerGender;
 
   public dexData: DexData;
   private defaultDexData: DexData;

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -64,6 +64,7 @@ export const SettingKeys = {
   Sprite_Set: "SPRITE_SET",
   Fusion_Palette_Swaps: "FUSION_PALETTE_SWAPS",
   Player_Gender: "PLAYER_GENDER",
+  Rival_Gender: "RIVAL_GENDER",
   Type_Hints: "TYPE_HINTS",
   Master_Volume: "MASTER_VOLUME",
   BGM_Volume: "BGM_VOLUME",
@@ -270,6 +271,13 @@ export const Setting: Array<Setting> = [
     type: SettingType.DISPLAY
   },
   {
+    key: SettingKeys.Rival_Gender,
+    label: "Rival Gender",
+    options: ["Boy", "Girl"],
+    default: 0,
+    type: SettingType.DISPLAY
+  },
+  {
     key: SettingKeys.Type_Hints,
     label: "Type hints",
     options: OFF_ON,
@@ -441,6 +449,14 @@ export function setSetting(scene: BattleScene, setting: string, value: integer):
       const female = Setting[index].options[value] === "Girl";
       scene.gameData.gender = female ? PlayerGender.FEMALE : PlayerGender.MALE;
       scene.trainer.setTexture(scene.trainer.texture.key.replace(female ? "m" : "f", female ? "f" : "m"));
+    } else {
+      return false;
+    }
+    break;
+  case SettingKeys.Rival_Gender:
+    if (scene.gameData) {
+      const female = Setting[index].options[value] === "Girl";
+      scene.gameData.rivalGender = female ? PlayerGender.FEMALE : PlayerGender.MALE;
     } else {
       return false;
     }


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This change allows you to set which rival character gender you fight. It adds an option to the display settings under Player Gender. 

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
This change enables setting the rival gender/character independently of the player character's gender, allowing you to play as a boy and have Finn as a rival or play as a girl and have Ivy as a rival in addition to being able to have a rival of the opposite gender. 

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Changes were made to src/battle.ts, src/system/game-data.ts, and src/system/settings/settings.ts to introduce a new setting to manually set the rival gender. Specifically, a new `SettingKeys` member was added, as well as supporting code to correctly update/save that setting & apply it to the trainer instance in the relevant battles.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
![image](https://github.com/pagefaultgames/pokerogue/assets/76229782/0f8610e3-ab87-4116-9f0d-d09a582415af)
![image](https://github.com/pagefaultgames/pokerogue/assets/76229782/740cefc4-2d45-4b47-a4a3-67a9cd06127e)

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Set src/override to any wave with a rival fight (8, 25, 55, 95, 145, and 195). Go into settings > Display and toggle the rival gender to Girl. When starting a new save, ensure Ivy appears as the rival you fight and the expected dialogue is present.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
         - Before making any changes, 9 unit tests related to input were failing. Afterwards, those same 9 were failing, so these are likely unrelated to our changes.
- [x] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?