### PR TITLE
[Bug] resolve issue with input text persisting in top left of game screen in certain cases

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -191,8 +191,21 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
   private pokemonCaughtCountText: Phaser.GameObjects.Text;
   private pokemonHatchedCountText: Phaser.GameObjects.Text;
   private genOptionsText: Phaser.GameObjects.Text;
+
   private instructionsContainer: Phaser.GameObjects.Container;
-  private instructionsText: Phaser.GameObjects.Text;
+  private shinyIconElement: Phaser.GameObjects.Sprite;
+  private formIconElement: Phaser.GameObjects.Sprite;
+  private abilityIconElement: Phaser.GameObjects.Sprite;
+  private genderIconElement: Phaser.GameObjects.Sprite;
+  private natureIconElement: Phaser.GameObjects.Sprite;
+  private variantIconElement: Phaser.GameObjects.Sprite;
+  private shinyLabel: Phaser.GameObjects.Text;
+  private formLabel: Phaser.GameObjects.Text;
+  private genderLabel: Phaser.GameObjects.Text;
+  private abilityLabel: Phaser.GameObjects.Text;
+  private natureLabel: Phaser.GameObjects.Text;
+  private variantLabel: Phaser.GameObjects.Text;
+
   private starterSelectMessageBox: Phaser.GameObjects.NineSlice;
   private starterSelectMessageBoxContainer: Phaser.GameObjects.Container;
   private statsContainer: StatsContainer;
@@ -654,9 +667,42 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.starterSelectContainer.add(this.pokemonEggMovesContainer);
 
     // The font size should be set per language
+    const instructionTextSize = textSettings.instructionTextSize;
+
     this.instructionsContainer = this.scene.add.container(4, 156);
     this.instructionsContainer.setVisible(true);
     this.starterSelectContainer.add(this.instructionsContainer);
+
+    // instruction rows that will be pushed into the container dynamically based on need
+    this.shinyIconElement = this.scene.add.sprite(this.instructionRowX, this.instructionRowY, "keyboard", "R.png");
+    this.shinyIconElement.setScale(0.675);
+    this.shinyIconElement.setOrigin(0.0, 0.0);
+    this.shinyLabel = addTextObject(this.scene, this.instructionRowX + this.instructionRowTextOffset, this.instructionRowY, i18next.t("starterSelectUiHandler:cycleShiny"), TextStyle.PARTY, { fontSize: instructionTextSize });
+
+    this.formIconElement = this.scene.add.sprite(this.instructionRowX, this.instructionRowY, "keyboard", "F.png");
+    this.formIconElement.setScale(0.675);
+    this.formIconElement.setOrigin(0.0, 0.0);
+    this.formLabel = addTextObject(this.scene, this.instructionRowX + this.instructionRowTextOffset, this.instructionRowY, i18next.t("starterSelectUiHandler:cycleForm"), TextStyle.PARTY, { fontSize: instructionTextSize });
+
+    this.genderIconElement = this.scene.add.sprite(this.instructionRowX, this.instructionRowY, "keyboard", "G.png");
+    this.genderIconElement.setScale(0.675);
+    this.genderIconElement.setOrigin(0.0, 0.0);
+    this.genderLabel = addTextObject(this.scene, this.instructionRowX + this.instructionRowTextOffset, this.instructionRowY, i18next.t("starterSelectUiHandler:cycleGender"), TextStyle.PARTY, { fontSize: instructionTextSize });
+
+    this.abilityIconElement = this.scene.add.sprite(this.instructionRowX, this.instructionRowY, "keyboard", "E.png");
+    this.abilityIconElement.setScale(0.675);
+    this.abilityIconElement.setOrigin(0.0, 0.0);
+    this.abilityLabel = addTextObject(this.scene, this.instructionRowX + this.instructionRowTextOffset, this.instructionRowY, i18next.t("starterSelectUiHandler:cycleAbility"), TextStyle.PARTY, { fontSize: instructionTextSize });
+
+    this.natureIconElement = this.scene.add.sprite(this.instructionRowX, this.instructionRowY, "keyboard", "N.png");
+    this.natureIconElement.setScale(0.675);
+    this.natureIconElement.setOrigin(0.0, 0.0);
+    this.natureLabel = addTextObject(this.scene, this.instructionRowX + this.instructionRowTextOffset, this.instructionRowY, i18next.t("starterSelectUiHandler:cycleNature"), TextStyle.PARTY, { fontSize: instructionTextSize });
+
+    this.variantIconElement = this.scene.add.sprite(this.instructionRowX, this.instructionRowY, "keyboard", "V.png");
+    this.variantIconElement.setScale(0.675);
+    this.variantIconElement.setOrigin(0.0, 0.0);
+    this.variantLabel = addTextObject(this.scene, this.instructionRowX + this.instructionRowTextOffset, this.instructionRowY, i18next.t("starterSelectUiHandler:cycleVariant"), TextStyle.PARTY, { fontSize: instructionTextSize });
 
     this.starterSelectMessageBoxContainer = this.scene.add.container(0, this.scene.game.canvas.height / 6);
     this.starterSelectMessageBoxContainer.setVisible(false);
@@ -1492,7 +1538,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.setSpeciesDetails(this.lastSpecies, undefined, undefined, undefined, undefined, undefined, undefined, false);
   }
 
-  createButtonFromIconText(iconSetting, gamepadType, translatedText, instructionTextSize): void {
+  updateButtonIcon(iconSetting, gamepadType, iconElement, controlLabel): void {
     let iconPath;
     // touch controls cannot be rebound as is, and are just emulating a keyboard event.
     // Additionally, since keyboard controls can be rebound (and will be displayed when they are), we need to have special handling for the touch controls
@@ -1523,10 +1569,9 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     } else {
       iconPath = this.scene.inputController?.getIconForLatestInputRecorded(iconSetting);
     }
-    const iconElement = this.scene.add.sprite(this.instructionRowX, this.instructionRowY, gamepadType, iconPath);
-    iconElement.setScale(0.675);
-    iconElement.setOrigin(0.0, 0.0);
-    const controlLabel = addTextObject(this.scene, this.instructionRowX + this.instructionRowTextOffset, this.instructionRowY, translatedText, TextStyle.PARTY, { fontSize: instructionTextSize });
+    iconElement.setTexture(gamepadType, iconPath);
+    iconElement.setPosition(this.instructionRowX, this.instructionRowY);
+    controlLabel.setPosition(this.instructionRowX + this.instructionRowTextOffset, this.instructionRowY);
     this.instructionsContainer.add([iconElement, controlLabel]);
     this.instructionRowY += 8;
     if (this.instructionRowY >= 24) {
@@ -1536,13 +1581,9 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
   }
 
   updateInstructions(): void {
-    const currentLanguage = i18next.resolvedLanguage;
-    const langSettingKey = Object.keys(languageSettings).find(lang => currentLanguage.includes(lang));
-    const textSettings = languageSettings[langSettingKey];
-    const instructionTextSize = textSettings.instructionTextSize;
     this.instructionRowX = 0;
     this.instructionRowY = 0;
-    this.instructionsContainer.removeAll(true);
+    this.instructionsContainer.removeAll();
     let gamepadType;
     if (this.scene.inputMethod === "gamepad") {
       gamepadType = this.scene.inputController.getConfig(this.scene.inputController.selectedDevice[Device.GAMEPAD]).padType;
@@ -1552,22 +1593,22 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
     if (this.speciesStarterDexEntry?.caughtAttr) {
       if (this.canCycleShiny) {
-        this.createButtonFromIconText(SettingKeyboard.Button_Cycle_Shiny, gamepadType, i18next.t("starterSelectUiHandler:cycleShiny"), instructionTextSize);
+        this.updateButtonIcon(SettingKeyboard.Button_Cycle_Shiny, gamepadType, this.shinyIconElement, this.shinyLabel);
       }
       if (this.canCycleForm) {
-        this.createButtonFromIconText(SettingKeyboard.Button_Cycle_Form, gamepadType, i18next.t("starterSelectUiHandler:cycleForm"), instructionTextSize);
+        this.updateButtonIcon(SettingKeyboard.Button_Cycle_Form, gamepadType, this.formIconElement, this.formLabel);
       }
       if (this.canCycleGender) {
-        this.createButtonFromIconText(SettingKeyboard.Button_Cycle_Gender, gamepadType, i18next.t("starterSelectUiHandler:cycleGender"), instructionTextSize);
+        this.updateButtonIcon(SettingKeyboard.Button_Cycle_Gender, gamepadType, this.genderIconElement, this.genderLabel);
       }
       if (this.canCycleAbility) {
-        this.createButtonFromIconText(SettingKeyboard.Button_Cycle_Ability, gamepadType, i18next.t("starterSelectUiHandler:cycleAbility"), instructionTextSize);
+        this.updateButtonIcon(SettingKeyboard.Button_Cycle_Ability, gamepadType, this.abilityIconElement, this.abilityLabel);
       }
       if (this.canCycleNature) {
-        this.createButtonFromIconText(SettingKeyboard.Button_Cycle_Nature, gamepadType, i18next.t("starterSelectUiHandler:cycleNature"), instructionTextSize);
+        this.updateButtonIcon(SettingKeyboard.Button_Cycle_Nature, gamepadType, this.natureIconElement, this.natureLabel);
       }
       if (this.canCycleVariant) {
-        this.createButtonFromIconText(SettingKeyboard.Button_Cycle_Variant, gamepadType, i18next.t("starterSelectUiHandler:cycleVariant"), instructionTextSize);
+        this.updateButtonIcon(SettingKeyboard.Button_Cycle_Variant, gamepadType, this.variantIconElement, this.variantLabel);
       }
     }
   }
@@ -2322,9 +2363,25 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     super.clearText();
   }
 
+  hideInstructions(): void {
+    this.shinyIconElement.setVisible(false);
+    this.shinyLabel.setVisible(false);
+    this.formIconElement.setVisible(false);
+    this.formLabel.setVisible(false);
+    this.genderIconElement.setVisible(false);
+    this.genderLabel.setVisible(false);
+    this.abilityIconElement.setVisible(false);
+    this.abilityLabel.setVisible(false);
+    this.natureIconElement.setVisible(false);
+    this.natureLabel.setVisible(false);
+    this.variantIconElement.setVisible(false);
+    this.variantLabel.setVisible(false);
+  }
+
   clear(): void {
     super.clear();
     this.cursor = -1;
+    this.hideInstructions();
     this.starterSelectContainer.setVisible(false);
     this.blockInput = false;
 

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1542,7 +1542,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     const instructionTextSize = textSettings.instructionTextSize;
     this.instructionRowX = 0;
     this.instructionRowY = 0;
-    this.instructionsContainer.removeAll();
+    this.instructionsContainer.removeAll(true);
     let gamepadType;
     if (this.scene.inputMethod === "gamepad") {
       gamepadType = this.scene.inputController.getConfig(this.scene.inputController.selectedDevice[Device.GAMEPAD]).padType;


### PR DESCRIPTION
## What are the changes?
these changes fix a bug where inputs would persist on the ui where they should not

## Why am I doing these changes?
a bug was found where the starter select input prompts would still be visible at the top left of the screen in some cases, this is to fix that
![image](https://github.com/pagefaultgames/pokerogue/assets/170910983/4540cd73-6f11-4c79-8625-244db35ab53a)

## What did change?
The ui objects are now being appropriately destroyed so that they don't get added the scene without a container 

### Screenshots/Videos
before my fix 
[pre-inputFix.webm](https://github.com/pagefaultgames/pokerogue/assets/170910983/b0ab378c-c5c4-47c8-b5c8-237b00b947c7)

after my fix 
[post-inputFix.webm](https://github.com/pagefaultgames/pokerogue/assets/170910983/b2e41115-7895-4ea5-843c-3cc145a84e4a)

## How to test the changes?
From my experience, reproducing was as simple as...
 - going to the start screen
 - selecting a pokemon with some options to cycle (gender, shiny, etc.) 
 - moving cursor to the start button 
 - clicking start

As stated above, the options that were previously shown in the bottom left of starter select would then move to the top left of the battle scene

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?