### PR TITLE
Fix doubles battles bugs with challenges

### DIFF
--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -426,7 +426,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
     const party = this.scene.getEnemyParty();
     const nonFaintedPartyMembers = party.slice(this.scene.currentBattle.getBattlerCount()).filter(p => !p.isFainted()).filter(p => !trainerSlot || p.trainerSlot === trainerSlot);
     const partyMemberScores = nonFaintedPartyMembers.map(p => {
-      const playerField = this.scene.getPlayerField();
+      const playerField = this.scene.getPlayerField().filter(p => p.isActive(true));
       let score = 0;
       for (const playerPokemon of playerField) {
         score += p.getMatchupScore(playerPokemon);

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -4291,12 +4291,12 @@ export class SwitchPhase extends BattlePhase {
     super.start();
 
     // Skip modal switch if impossible
-    if (this.isModal && !this.scene.getParty().filter(p => !p.isAllowedInBattle() && !p.isActive(true)).length) {
+    if (this.isModal && !this.scene.getParty().filter(p => p.isAllowedInBattle() && !p.isActive(true)).length) {
       return super.end();
     }
 
     // Check if there is any space still in field
-    if (this.isModal && this.scene.getPlayerField().filter(p => !p.isAllowedInBattle() && p.isActive(true)).length >= this.scene.currentBattle.getBattlerCount()) {
+    if (this.isModal && this.scene.getPlayerField().filter(p => p.isAllowedInBattle() && p.isActive(true)).length >= this.scene.currentBattle.getBattlerCount()) {
       return super.end();
     }
 

--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -388,7 +388,7 @@ export default class PartyUiHandler extends MessageUiHandler {
         } else if (option === PartyOption.RELEASE) {
           this.clearOptions();
           ui.playSelect();
-          if (this.cursor >= this.scene.currentBattle.getBattlerCount()) {
+          if (this.cursor >= this.scene.currentBattle.getBattlerCount() || !pokemon.isAllowedInBattle()) {
             this.showText(`Do you really want to release ${pokemon.name}?`, null, () => {
               ui.setModeWithoutClear(Mode.CONFIRM, () => {
                 ui.setMode(Mode.PARTY);


### PR DESCRIPTION
## What are the changes?
Three related small changes to double battles with challenges to fix a UI error, a soft lock, and an error.

## Why am I doing these changes?
The game is locking up in certain edge cases in double battles.

## What did change?
The AI was checking pokemon that weren't on the field, the release option wasn't allowing you to release pokemon that weren't on the field but were still in slot 2 in a double battle, and it was incorrectly checking allowed status when switching in doubles.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)