### PR TITLE
[Bug] Fixed moves with type multiplier effects not being considered in type hints and enemy AI

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1085,6 +1085,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     const typeless = move.hasAttr(TypelessAttr);
     const typeMultiplier = new Utils.NumberHolder(this.getAttackTypeEffectiveness(move.type, source));
     const cancelled = new Utils.BooleanHolder(false);
+    applyMoveAttrs(VariableMoveTypeMultiplierAttr, source, this, move, typeMultiplier);
     if (!typeless) {
       applyPreDefendAbAttrs(TypeImmunityAbAttr, this, source, move, cancelled, typeMultiplier, true);
     }


### PR DESCRIPTION
## What are the changes?
Fixed a bug where move type multiplier effects (such as Freeze-Dry being super effective against water) is not considered in the type hints and enemy AI.

## Why am I doing these changes?
Currently, moves like Freeze-Dry against water are shown as orange (not very effective) in the type hint, and not prioritized by the enemy, despite being super effective.

## What did change?
Added a single line of `applyMoveAttrs` in `Pokemon.getAttackMoveEffectiveness`.

`getAttackMoveEffectiveness` is only used in
1. `Pokemon.getMoveEffectiveness`, which is used for the text and colour in type hints. 
2. `EnemyPokemon.getNextMove`, using it for assigning move scores.

So it should not affect anything else.

## Screenshots/Videos
Before:
![image](https://github.com/pagefaultgames/pokerogue/assets/59531041/bf9b1acf-7dfc-45f3-924b-5f51e4ba9c73)

After:
![image](https://github.com/pagefaultgames/pokerogue/assets/59531041/abdda9a2-1804-4226-8960-013c89fd5011)


## How to test the changes?
1. Turn on type hints
2. Use a pokemon with moves that have special type multiplier effects, such as Freeze-Dry and Thousand Arrows.
3. Fight against an enemy of the boosted type.
4. It should now be shown as green with a x2. 

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?