### PR TITLE
[Enhancement] Color code for used PP in fight UI

### DIFF
--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -179,6 +179,7 @@ export default class FightUiHandler extends UiHandler {
       const pp = maxPP - pokemonMove.ppUsed;
 
       this.ppText.setText(`${Utils.padInt(pp, 2, "  ")}/${Utils.padInt(maxPP, 2, "  ")}`);
+      this.ppText.setColor(pp / maxPP <= 0.25 ? "red" : pp / maxPP <= 0.5 ? "yellow" : "white");
       this.powerText.setText(`${power >= 0 ? power : "---"}`);
       this.accuracyText.setText(`${accuracy >= 0 ? accuracy : "---"}`);
 

--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -179,7 +179,10 @@ export default class FightUiHandler extends UiHandler {
       const pp = maxPP - pokemonMove.ppUsed;
 
       this.ppText.setText(`${Utils.padInt(pp, 2, "  ")}/${Utils.padInt(maxPP, 2, "  ")}`);
-      this.ppText.setColor(pp / maxPP <= 0.25 ? "red" : pp / maxPP <= 0.5 ? "yellow" : "white");
+      this.ppText.setColor(pp === 0
+        ? "red" : pp / maxPP <= 0.25
+          ? "orange" : pp / maxPP <= 0.5
+            ? "yellow" : "white");
       this.powerText.setText(`${power >= 0 ? power : "---"}`);
       this.accuracyText.setText(`${accuracy >= 0 ? accuracy : "---"}`);
 

--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -179,10 +179,18 @@ export default class FightUiHandler extends UiHandler {
       const pp = maxPP - pokemonMove.ppUsed;
 
       this.ppText.setText(`${Utils.padInt(pp, 2, "  ")}/${Utils.padInt(maxPP, 2, "  ")}`);
-      this.ppText.setColor(pp === 0
-        ? "red" : pp / maxPP <= 0.25
-          ? "orange" : pp / maxPP <= 0.5
-            ? "yellow" : "white");
+      const ppPercentLeft = pp / maxPP;
+      let ppColor = "white";
+      if (ppPercentLeft <= 0.5) {
+        ppColor = "yellow";
+      }
+      if (ppPercentLeft <= 0.25) {
+        ppColor = "orange";
+      }
+      if (pp === 0) {
+        ppColor = "red";
+      }
+      this.ppText.setColor(ppColor);
       this.powerText.setText(`${power >= 0 ? power : "---"}`);
       this.accuracyText.setText(`${accuracy >= 0 ? accuracy : "---"}`);
 


### PR DESCRIPTION
This small change adds a color coding to the pp number in the fight UI. The PP number will now appear yellow if only half or less PP are left, orange when a quarter or less is left and red if 0 PP are left.

## What are the changes?
Color coding the PP in fight UI to fit main line games.

## Why am I doing these changes?
I often didn't realise I was low on PP while playing and thought some color might help here. 

## What did change?
The numbers of used and max PP in the fight UI are now colored according to how many PP are remaining.

### Screenshots/Videos
![image](https://github.com/pagefaultgames/pokerogue/assets/67913362/94346185-8305-49b6-b979-b0721d00cb98)
![image](https://github.com/pagefaultgames/pokerogue/assets/67913362/ed19bf62-86e5-48e8-85da-ba4bad0c60f0)
![image](https://github.com/pagefaultgames/pokerogue/assets/67913362/1c3d7244-ed91-4935-bb27-c5d346e4c5f2)


## How to test the changes?
Get into a run (preferably with a mon that has a move with 5 or 10 max PP).
Use a move until it has half PP left, a quarter PP left, no PP left.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?