### PR TITLE
[Enhancement] Golden IVs Chart when all IVs are perfect

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -68,6 +68,12 @@ export const bypassLogin = import.meta.env.VITE_BYPASS_LOGIN === "1";
 
 const DEBUG_RNG = false;
 
+const OPP_IVS_OVERRIDE_VALIDATED : integer[] = (
+  Array.isArray(Overrides.OPP_IVS_OVERRIDE) ?
+    Overrides.OPP_IVS_OVERRIDE :
+    new Array(6).fill(Overrides.OPP_IVS_OVERRIDE)
+).map(iv => isNaN(iv) || iv === null || iv > 31 ? -1 : iv);
+
 export const startingWave = Overrides.STARTING_WAVE_OVERRIDE || 1;
 
 const expSpriteKeys: string[] = [];
@@ -765,6 +771,13 @@ export default class BattleScene extends SceneBase {
     if (postProcess) {
       postProcess(pokemon);
     }
+
+    for (let i = 0; i < pokemon.ivs.length; i++) {
+      if (OPP_IVS_OVERRIDE_VALIDATED[i] > -1) {
+        pokemon.ivs[i] = OPP_IVS_OVERRIDE_VALIDATED[i];
+      }
+    }
+
     pokemon.init();
     return pokemon;
   }

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -85,6 +85,7 @@ export const OPP_GENDER_OVERRIDE: Gender = null;
 export const OPP_MOVESET_OVERRIDE: Array<Moves> = [];
 export const OPP_SHINY_OVERRIDE: boolean = false;
 export const OPP_VARIANT_OVERRIDE: Variant = 0;
+export const OPP_IVS_OVERRIDE: integer | integer[] = [];
 
 /**
  * MODIFIER / ITEM OVERRIDES

--- a/src/ui/stats-container.ts
+++ b/src/ui/stats-container.ts
@@ -8,6 +8,12 @@ const ivChartStatCoordMultipliers = [ [ 0, -1 ], [ 0.825, -0.5 ], [ 0.825, 0.5 ]
 const ivChartStatIndexes = [0,1,2,5,4,3]; // swap special attack and speed
 const defaultIvChartData = new Array(12).fill(null).map(() => 0);
 
+declare global {
+  interface Window {
+    perfectIVsChartColor: integer;
+  }
+}
+
 export class StatsContainer extends Phaser.GameObjects.Container {
   private showDiff: boolean;
   private statsIvsCache: integer[];


### PR DESCRIPTION
## What are the changes?
The IVs chart is now golden in case all IVs are perfect.


## Why am I doing these changes?
Dynamic colors for the IV chart was already part of a different mod so i thought i might as well as this effectively only requires one line of code to change.
Though the additional code for testing overrides added some more changes...


## What did change?
The IV chart shown for new captures and starters will now appear golden, in case all IVs are perfect (31).
This color change is also animated on the starter selection screen.

For testing purposes the following overrides have been introduced:
- `OPP_IVS_OVERRIDE : integer | integer[]`
    This may take an integer to replace all enemy IVs or an array with each element replacing the respective IV.
- `window.perfectIVsChartColor`
    This global variable can be set by the user and changes the default golden color for perfect IVs. This is intended temporarily to allow testers to modify the color and chose a better one than the current default setting. However, as it has no functional influence on the game itself, i'm inclined to leave this variable in the game.


### Screenshots/Videos
![golden-chart](https://github.com/pagefaultgames/pokerogue/assets/10091050/64ede9d5-f3e2-4023-8bbd-6bc6ec3c0d7e)

@ edit: alternative chart with `window.perfectIVsChartColor = 0xFFD700;`
![golden-chart2](https://github.com/pagefaultgames/pokerogue/assets/10091050/dbbc3d56-d6c9-485c-a6ec-068cb5c50ee7)
as suggested by DerTapp from discord.

## How to test the changes?
During the starter selection, when toggling IVs, the altered color can appear, assuming all IVs are perfect.

Please use the following overrides for the `src/overrides.ts` file to generate any required IVs:
- replace `[PokeballType.MASTER_BALL]: 0,` with `[PokeballType.MASTER_BALL]: 1,` to get a masterball for a new run.
- replace `export const OPP_IVS_OVERRIDE: integer | integer[] = [];` with `export const OPP_IVS_OVERRIDE: integer | integer[] = 31;` to force any enemy pokemon to spawn with perfect IVs

Assign any color as a number to `window.perfectIVsChartColor` in the dev console to adjust the color of the chart. E.g. 0xFF0000, 0xFFFF00, etc.
A restart of the game isn't necessary, however a pokemon with perfect IV has to be reselected as the variable is only checked each time a pokemon is selected.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?