### PR TITLE
[QoL] Revert input delay default and add setting

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -154,6 +154,13 @@ export default class BattleScene extends SceneBase {
    * - 1 = 'Set' - The option to switch the active pokemon at the start of a battle will not display.
    */
   public battleStyle: integer = 0;
+  /**
+   * Determines the repeat input delay.
+   * - 0 = 'Short' or 125ms delay
+   * - 1 = 'Normal' or 250ms delay being the default
+   * - 2 = 'Long' or 500ms delay
+   */
+  public repeatInputDelay: integer = 1;
 
   /**
   * Defines whether or not to show type effectiveness hints

--- a/src/inputs-controller.ts
+++ b/src/inputs-controller.ts
@@ -48,7 +48,7 @@ export interface InterfaceConfig {
     custom?: MappingLayout;
 }
 
-const repeatInputDelayMillis = 500;
+let repeatInputDelayMillis = 250;
 
 // Phaser.Input.Gamepad.GamepadPlugin#refreshPads
 declare module "phaser" {
@@ -547,6 +547,19 @@ export class InputsController {
   repeatInputDurationJustPassed(button: Button): boolean {
     if (!this.isButtonLocked(button)) {
       return false;
+    }
+    if (typeof this.scene.repeatInputDelay !== "undefined") {
+      switch (this.scene.inputDelay) {
+      case 0:
+        repeatInputDelayMillis = 125;
+        break;
+      case 1:
+        repeatInputDelayMillis = 250;
+        break;
+      case 2:
+        repeatInputDelayMillis = 500;
+        break;
+      }
     }
     const duration = Date.now() - this.interactions[button].pressTime;
     if (duration >= repeatInputDelayMillis) {

--- a/src/inputs-controller.ts
+++ b/src/inputs-controller.ts
@@ -549,7 +549,7 @@ export class InputsController {
       return false;
     }
     if (typeof this.scene.repeatInputDelay !== "undefined") {
-      switch (this.scene.inputDelay) {
+      switch (this.scene.repeatInputDelay) {
       case 0:
         repeatInputDelayMillis = 125;
         break;

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -47,6 +47,7 @@ export const SettingKeys = {
   Tutorials: "TUTORIALS",
   Touch_Controls: "TOUCH_CONTROLS",
   Vibration: "VIBRATION",
+  Repeat_Input_Delay: "REPEAT INPUT DELAY",
   Language: "LANGUAGE",
   UI_Theme: "UI_THEME",
   Window_Type: "WINDOW_TYPE",
@@ -143,6 +144,13 @@ export const Setting: Array<Setting> = [
     label: "Vibration",
     options: AUTO_DISABLED,
     default: 0,
+    type: SettingType.GENERAL
+  },
+  {
+    key: SettingKeys.Repeat_Input_Delay,
+    label: "Repeat Input Delay",
+    options: ["Short","Normal","Long"],
+    default: 1,
     type: SettingType.GENERAL
   },
   {
@@ -457,6 +465,9 @@ export function setSetting(scene: BattleScene, setting: string, value: integer):
     break;
   case SettingKeys.Type_Hints:
     scene.typeHints = Setting[index].options[value] === "On";
+    break;
+  case SettingKeys.Repeat_Input_Delay:
+    scene.repeatInputDelay = value;
     break;
   case SettingKeys.Language:
     if (value) {


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Users will notice the speed of the game returning to normal when a key is pressed and held. Additionally the setting to change the repeat input delay to allow for customization in the case that a longer delay is required.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
The vast, vast majority of users will have their QoL improved by having the repeat input delay set back to where it was previously at 250ms. Many noticed that holding any key down had become much slower without knowing why. A change was implemented to double that number to 500ms to fix a problem for a very small subset of users experiencing double keypresses, while making the gameplay experience worse for almost the entire playerbase.

While making the setting for it, I figured I'd add the option to speed up this delay for players that prefer this delay to be even shorter than the default.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

- Added `repeatInputDelay` as a setting with three options: `["Short","Normal","Long"]` translating to 125ms, 250ms, and 500ms respectively.
- Added the switch statement to set `repeatInputDelayMillis` to the corrseponding milliseconds.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
UI:
<img width="503" alt="image" src="https://github.com/pagefaultgames/pokerogue/assets/132619649/c98c9d6b-997c-4fe3-b440-768c4fe18ea3">

In action:

https://github.com/pagefaultgames/pokerogue/assets/132619649/38149012-6b1a-4db7-8947-68846f879ad5

You can see in the video, the delay is tested by simply holding down on the arrow key. At the current default of 500ms, it is painfully slow. Once it is set to 250ms it is visibly more responsive. And then the final setting of 125ms gives a much quicker scrolling experience. 

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
One can perform the test pictured in the video, or simple play through a few rounds holding key presses to feel the difference.


## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
  
## Unit Tests
No idea what is going on with `npm run test` right now but these are the failing tests on main:
  main:
<img width="316" alt="image" src="https://github.com/pagefaultgames/pokerogue/assets/132619649/27e9ad68-5175-4b1a-9cd1-199dd3eaf6d5">

This branch setting the repeat input delay default back to 250ms fixes some of these failed tests, but there are still failing tests.

input_delay:
<img width="307" alt="image" src="https://github.com/pagefaultgames/pokerogue/assets/132619649/931340fc-6139-43a7-b184-9629c6738dbf">

¯\\\_(ツ)\_/¯


