### PR TITLE
[Localization] Fix FR typo 'Desert' instead of 'Désert'

### DIFF
--- a/src/locales/fr/biome.ts
+++ b/src/locales/fr/biome.ts
@@ -16,7 +16,7 @@ export const biome: SimpleTranslationEntries = {
   "MOUNTAIN": "Montagne",
   "BADLANDS": "Terres Sauvages",
   "CAVE": "Grotte",
-  "DESERT": "Desert",
+  "DESERT": "Désert",
   "ICE_CAVE": "Caverne Gelée",
   "MEADOW": "Prairie",
   "POWER_PLANT": "Centrale",


### PR DESCRIPTION
## What are the changes?
Fix FR typo in `biome.ts`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?