### PR TITLE
[Move] Implement Core Enforcer

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5115,12 +5115,18 @@ export class SuppressAbilitiesAttr extends MoveEffectAttr {
 }
 
 /**
- * Adds a secondary effect to a move which applies the effects of {@linkcode SuppressAbilitiesAttr} to the target
- * if it has already moved this turn.
+ * Applies the effects of {@linkcode SuppressAbilitiesAttr} if the target has already moved this turn.
  * @extends MoveEffectAttr
  * @see {@linkcode Moves.CORE_ENFORCER} (the move which uses this effect)
  */
 export class SuppressAbilitiesIfActedAttr extends MoveEffectAttr {
+  /**
+   * If the target has already acted this turn, apply a {@linkcode SuppressAbilitiesAttr} effect unless the
+   * abillity cannot be suppressed. This is a secondary effect and has no bearing on the success or failure of the move.
+   *
+   * @returns True if the move occurred, otherwise false. Note that true will be returned even if the target has not
+   * yet moved or if the target's abiilty is un-suppressable.
+   */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     if (!super.apply(user, target, move, args)) {
       return false;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5114,6 +5114,12 @@ export class SuppressAbilitiesAttr extends MoveEffectAttr {
   }
 }
 
+/**
+ * Adds a secondary effect to a move which applies the effects of {@linkcode SuppressAbilitiesAttr} to the target
+ * if it has already moved this turn.
+ * @extends MoveEffectAttr
+ * @see {@linkcode Moves.CORE_ENFORCER} (the move which uses this effect)
+ */
 export class SuppressAbilitiesIfActedAttr extends MoveEffectAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     if (!super.apply(user, target, move, args)) {

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5104,13 +5104,30 @@ export class SuppressAbilitiesAttr extends MoveEffectAttr {
 
     target.summonData.abilitySuppressed = true;
 
-    target.scene.queueMessage(getPokemonMessage(target, " ability\nwas suppressed!"));
+    target.scene.queueMessage(getPokemonMessage(target, "'s ability\nwas suppressed!"));
 
     return true;
   }
 
   getCondition(): MoveConditionFunc {
     return (user, target, move) => !target.getAbility().hasAttr(UnsuppressableAbilityAbAttr);
+  }
+}
+
+export class SuppressAbilitiesIfActedAttr extends MoveEffectAttr {
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    if (!super.apply(user, target, move, args)) {
+      return false;
+    }
+
+    if (target.turnData.acted) {
+      const suppressAttr = new SuppressAbilitiesAttr();
+      if (suppressAttr.getCondition()(user, target, move)) {
+        suppressAttr.apply(user, target, move, args);
+      }
+    }
+
+    return true;
   }
 }
 
@@ -7298,7 +7315,7 @@ export function initMoves() {
       .attr(MatchUserTypeAttr),
     new AttackMove(Moves.CORE_ENFORCER, Type.DRAGON, MoveCategory.SPECIAL, 100, 100, 10, -1, 0, 7)
       .target(MoveTarget.ALL_NEAR_ENEMIES)
-      .partial(),
+      .attr(SuppressAbilitiesIfActedAttr),
     new AttackMove(Moves.TROP_KICK, Type.GRASS, MoveCategory.PHYSICAL, 70, 100, 15, 100, 0, 7)
       .attr(StatChangeAttr, BattleStat.ATK, -1),
     new StatusMove(Moves.INSTRUCT, Type.PSYCHIC, -1, 15, -1, 0, 7)


### PR DESCRIPTION
## What are the changes?
Implement the move [Core Enforcer](https://bulbapedia.bulbagarden.net/wiki/Core_Enforcer_(move)).

## Why am I doing these changes?
Core Enforcer lacked its secondary effect of suppressing the target's ability when used after the target in a turn.

## What did change?
Added a new `MoveEffectAttr` called `SuppressAbilitiesIfActedAttr`. This basically just calls `SuppressAbilitiesAttr` under the hood; since this move succeeds regardless of whether the suppression happens, we need to make a separate effect with no extra condition.

Also fixed the text for ability suppression to include `'s` at the start.

### Screenshots/Videos

Case 1: Core Enforcer is used after the Slaking moves. Slaking's ability Truant is suppressed and it can use a move on the next turn.

https://github.com/pagefaultgames/pokerogue/assets/6374275/1fbb9c50-ee01-4a4e-a1a6-6dac5c553bb6

Case 2: Core Enforcer is used before the Slaking moves. Slaking's ability is not suppressed, and it undergoes Truant on the next turn.

https://github.com/pagefaultgames/pokerogue/assets/6374275/e612306f-9265-49c0-83f3-cf759c2d0aa6

## How to test the changes?
Use the following player and opponent overrides:

```ts
/**
 * PLAYER OVERRIDES
 */

// forms can be found in pokemon-species.ts
export const STARTER_FORM_OVERRIDE: integer = 0;
// default 5 or 20 for Daily
export const STARTING_LEVEL_OVERRIDE: integer = 5;
/**
 * SPECIES OVERRIDE
 * will only apply to the first starter in your party or each enemy pokemon
 * default is 0 to not override
 * @example SPECIES_OVERRIDE = Species.Bulbasaur;
 */
export const STARTER_SPECIES_OVERRIDE: Species | integer = Species.SKRELP;
export const ABILITY_OVERRIDE: Abilities = Abilities.NONE;
export const PASSIVE_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
export const STATUS_OVERRIDE: StatusEffect = StatusEffect.NONE;
export const GENDER_OVERRIDE: Gender = null;
export const MOVESET_OVERRIDE: Array<Moves> = [Moves.CORE_ENFORCER, Moves.SPLASH, Moves.SCARY_FACE, Moves.NONE];
export const SHINY_OVERRIDE: boolean = false;
export const VARIANT_OVERRIDE: Variant = 0;

/**
 * OPPONENT / ENEMY OVERRIDES
 */

export const OPP_SPECIES_OVERRIDE: Species | integer = Species.SLAKING;
export const OPP_LEVEL_OVERRIDE: number = 10;
export const OPP_ABILITY_OVERRIDE: Abilities = Abilities.TRUANT;
export const OPP_PASSIVE_ABILITY_OVERRIDE = Abilities.NONE;
export const OPP_STATUS_OVERRIDE: StatusEffect = null;
export const OPP_GENDER_OVERRIDE: Gender = null;
export const OPP_MOVESET_OVERRIDE: Array<Moves> = [Moves.SPLASH, Moves.SPLASH, Moves.SPLASH, Moves.SPLASH];
export const OPP_SHINY_OVERRIDE: boolean = false;
export const OPP_VARIANT_OVERRIDE: Variant = 0;
```

Observe that using Core Enforcer suppresses Slaking's ability because Skrelp moves after it. Then, reload and use Scary Face until Skrelp outspeeds Slaking. Observe that Core Enforcer does not suppress Slaking's ability because Skrelp moves before it. Repeat this in a doubles battle to observe the effects on multiple targets.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?