### PR TITLE
[Bug] Fix Clear terrains upon Trainer Battle

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1069,7 +1069,7 @@ export default class BattleScene extends SceneBase {
         this.arena.updatePoolsForTimeOfDay();
       }
       if (resetArenaState) {
-        this.arena.removeAllTags();
+        this.arena.resetArenaEffects();
         playerField.forEach((_, p) => this.unshiftPhase(new ReturnPhase(this, p)));
 
         for (const pokemon of this.getParty()) {

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -621,6 +621,14 @@ export class Arena {
     }
   }
 
+  /**
+   * Clears terrain and arena tags when entering new biome or trainer battle.
+   */
+  resetArenaEffects(): void {
+    this.trySetTerrain(TerrainType.NONE, false, true);
+    this.removeAllTags();
+  }
+
   preloadBgm(): void {
     this.scene.loadBgm(this.bgm);
   }

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -621,9 +621,7 @@ export class Arena {
     }
   }
 
-  /**
-   * Clears terrain and arena tags when entering new biome or trainer battle.
-   */
+  /** Clears terrain and arena tags when entering new biome or trainer battle. */
   resetArenaEffects(): void {
     this.trySetTerrain(TerrainType.NONE, false, true);
     this.removeAllTags();


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Terrains would persist over to trainer battles. This line would clear any terrains upon entering a Trainer Battle.
## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
closes #2018
## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

https://github.com/pagefaultgames/pokerogue/assets/63990624/1eb9cee7-bc56-49b2-b90e-fd834f33ca9d


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Override pokemon ability to Psychic Terrain. Activate it on wave 4. Observe it ends before going into the trainer battle on wave 5.
## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [Well... none of the errors have to do with this] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?