### PR TITLE
[Bug] Fixed bug where pokemon info container shows form of pokemon that doesn't have it if the previously caught pokemon has a form

### DIFF
--- a/src/ui/pokemon-info-container.ts
+++ b/src/ui/pokemon-info-container.ts
@@ -247,6 +247,9 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
         } else {
           this.pokemonFormText.disableInteractive();
         }
+      } else {
+        this.pokemonFormLabelText.setVisible(false);
+        this.pokemonFormText.setVisible(false);
       }
 
       const abilityTextStyle = pokemon.abilityIndex === (pokemon.species.ability2 ? 2 : 1) ? TextStyle.MONEY : TextStyle.WINDOW;

--- a/src/ui/pokemon-info-container.ts
+++ b/src/ui/pokemon-info-container.ts
@@ -250,6 +250,7 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
       } else {
         this.pokemonFormLabelText.setVisible(false);
         this.pokemonFormText.setVisible(false);
+        this.pokemonFormText.disableInteractive();
       }
 
       const abilityTextStyle = pokemon.abilityIndex === (pokemon.species.ability2 ? 2 : 1) ? TextStyle.MONEY : TextStyle.WINDOW;


### PR DESCRIPTION
## What are the changes?
Previously PR #1754 went through to update the pokemon info container, but there was a slight bug where the form label and text will show on a pokemon that doesn't have a form if the previous pokemon had a form. This PR aims to fix that 

## Why am I doing these changes?
The previous PR #1754 that went live recently introduced this display bug, so this fixes that.

## What did change?
Added some logic on the form label to hide if there's no form on the pokemon - previously it would show the form label if the pokemon had a form but that's it; now it should hide the label and text if the pokemon doesn't have a form

### Screenshots/Videos
The attached video shows catching a pokemon with a form and then a second pokemon without a form, and the form label not showing up 


https://github.com/pagefaultgames/pokerogue/assets/66582645/d336445a-1b31-4e5d-a40e-1aeadc173e00



## How to test the changes?
Use the provided save file to load into a session. You should be facing a scatterbug at wave 1 with 99 master balls. When you catch it, you should see the form label show up. Go to the next fight and it should be a different pokemon - hopefully one without a form - throw a masterball at it to catch it and confirm there's no label now.

The save file can be found [here](https://discord.com/channels/1125469663833370665/1176874654015684739/1249597961491451924)

Alternatively there's some overrides you can use to do this yourself:

Line 41-48 - this makes it so that you have 99 masterballs when you start a run:

```
  active: true,
  pokeballs: {
    [PokeballType.POKEBALL]: 5,
    [PokeballType.GREAT_BALL]: 0,
    [PokeballType.ULTRA_BALL]: 0,
    [PokeballType.ROGUE_BALL]: 0,
    [PokeballType.MASTER_BALL]: 99,
  }
```

Line 78 - this changes all the enemy pokemon to be Scatterbugs. I used Scatterbugs because they have a lot of forms to test which made it easy, but feel free to change the enemy to whatever you want/need:

`export const OPP_SPECIES_OVERRIDE: Species | integer = Species.SCATTERBUG;`

Once this is done, start a new run. When you're facing against the first pokemon, quit the game, reset your overrides to default and load the game back up and continue your previous run. You should be facing the scatterbug (or whatever you chose to face). Catch it with a masterball to see the form, then in the next wave you'll face a different pokemon - hopefully one without a form. Go to catch that too and confirm the form label doesn't appear

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?