### PR TITLE
[Bug] Add dynamic default pp color

### DIFF
--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -10,6 +10,7 @@ import { MoveCategory } from "#app/data/move.js";
 import i18next from "../plugins/i18n";
 import {Button} from "../enums/buttons";
 import Pokemon, { PokemonMove } from "#app/field/pokemon.js";
+import { UiTheme } from "#app/enums/ui-theme.js";
 
 export default class FightUiHandler extends UiHandler {
   private movesContainer: Phaser.GameObjects.Container;
@@ -180,7 +181,9 @@ export default class FightUiHandler extends UiHandler {
 
       this.ppText.setText(`${Utils.padInt(pp, 2, "  ")}/${Utils.padInt(maxPP, 2, "  ")}`);
       const ppPercentLeft = pp / maxPP;
-      let ppColor = "white";
+
+      let ppColor = this.scene.uiTheme === UiTheme.DEFAULT ? "white" : "black";
+
       if (ppPercentLeft <= 0.5) {
         ppColor = "yellow";
       }


### PR DESCRIPTION
## What are the changes?
- Update default PP color based on ui theme

## Why am I doing these changes?
- Unreadable PP on Legacy Theme
![image](https://github.com/pagefaultgames/pokerogue/assets/68144167/82b8b640-b725-447c-a9fa-d2d80ae8024a)


## What did change?
- default pp color based on ui theme

### Screenshots/Videos
- Default UI theme
<img width="773" alt="Screenshot 2024-06-10 at 6 40 35 PM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/177e32ad-e405-453f-82c1-77307651821a">


- Legacy UI theme
<img width="771" alt="Screenshot 2024-06-10 at 6 41 09 PM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/c24f2dfb-0274-46db-9caa-da5d12e4a4c5">



## How to test the changes?
- set UI theme to Default/Legacy, enter a battle and check PP color

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
- [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
- [x] Have I provided screenshots/videos of the changes?