### PR TITLE
[Bug] [Localization] [pt] Small UI fix pokemon-info-container

### DIFF
--- a/src/ui/pokemon-info-container.ts
+++ b/src/ui/pokemon-info-container.ts
@@ -6,12 +6,12 @@ import { getNatureName } from "../data/nature";
 import { Type } from "../data/type";
 import Pokemon from "../field/pokemon";
 import i18next from "../plugins/i18n";
+import { DexAttr } from "../system/game-data";
 import * as Utils from "../utils";
 import ConfirmUiHandler from "./confirm-ui-handler";
 import { StatsContainer } from "./stats-container";
 import { TextStyle, addBBCodeTextObject, addTextObject, getTextColor } from "./text";
 import { addWindow } from "./ui-theme";
-import { DexAttr } from "../system/game-data";
 
 interface LanguageSetting {
   infoContainerTextSize: string;
@@ -40,7 +40,7 @@ const languageSettings: { [key: string]: LanguageSetting } = {
   },
   "pt": {
     infoContainerTextSize: "60px",
-    infoContainerLabelXPos: -16,
+    infoContainerLabelXPos: -15,
     infoContainerTextXPos: -12,
   },
 };


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Moved the label text a bit to the right
## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
The "Habilidade" text was phasing through the container border
## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Label Text X position
### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
## Before
![image](https://github.com/pagefaultgames/pokerogue/assets/79599290/2e855f12-45c2-4b0b-9bfd-d52d52e00b64)

## After
![image](https://github.com/pagefaultgames/pokerogue/assets/79599290/339f9a67-2299-4e7c-a796-45a8ca7a3e31)

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Capture a Pokémon
## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?