### PR TITLE
[Bug] Add check to ignore ability when using type hints

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1070,6 +1070,10 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
+   * Calculates the effectiveness of a move against the Pokémon.
+   *
+   * @param source - The Pokémon using the move.
+   * @param move - The move being used.
    * @returns The type damage multiplier or undefined if it's a status move
    */
   getMoveEffectiveness(source: Pokemon, move: PokemonMove): TypeDamageMultiplier | undefined {
@@ -1077,19 +1081,27 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       return undefined;
     }
 
-    return this.getAttackMoveEffectiveness(source, move);
+    return this.getAttackMoveEffectiveness(source, move, true);
   }
 
-  getAttackMoveEffectiveness(source: Pokemon, pokemonMove: PokemonMove): TypeDamageMultiplier {
+  /**
+   * Calculates the effectiveness of an attack move against the Pokémon.
+   *
+   * @param source - The attacking Pokémon.
+   * @param pokemonMove - The move being used by the attacking Pokémon.
+   * @param ignoreAbility - Whether to check for abilities that might affect type effectiveness or immunity.
+   * @returns The type damage multiplier, indicating the effectiveness of the move
+   */
+  getAttackMoveEffectiveness(source: Pokemon, pokemonMove: PokemonMove, ignoreAbility: boolean = false): TypeDamageMultiplier {
     const move = pokemonMove.getMove();
     const typeless = move.hasAttr(TypelessAttr);
     const typeMultiplier = new Utils.NumberHolder(this.getAttackTypeEffectiveness(move.type, source));
     const cancelled = new Utils.BooleanHolder(false);
     applyMoveAttrs(VariableMoveTypeMultiplierAttr, source, this, move, typeMultiplier);
-    if (!typeless) {
+    if (!typeless && !ignoreAbility) {
       applyPreDefendAbAttrs(TypeImmunityAbAttr, this, source, move, cancelled, typeMultiplier, true);
     }
-    if (!cancelled.value) {
+    if (!cancelled.value && !ignoreAbility) {
       applyPreDefendAbAttrs(MoveImmunityAbAttr, this, source, move, cancelled, typeMultiplier, true);
     }
     return (!cancelled.value ? typeMultiplier.value : 0) as TypeDamageMultiplier;


### PR DESCRIPTION
## What are the changes?
- ignore ability for type hints

## Why am I doing these changes?
- closes #2025 

## What did change?
- added `ignoreAbility` parameter

### Screenshots/Videos
- enemy with Volt Absorb

https://github.com/pagefaultgames/pokerogue/assets/68144167/07665f66-1f76-4718-912e-5afdff859605




- enemy with Storm Drain


https://github.com/pagefaultgames/pokerogue/assets/68144167/c4b178b0-013d-4e44-a783-c6b9609c3505




- enemy with Flash Fire


https://github.com/pagefaultgames/pokerogue/assets/68144167/79fe2424-37ae-48ef-84e4-f9d259ae81bc




- enemy with Wind Rider


https://github.com/pagefaultgames/pokerogue/assets/68144167/d68a3e7d-7aea-43ca-84b2-d2971ca55b13




## How to test the changes
- set opponent ability to ability with class that extends `TypeImmunityAbAttr` or `MoveImmunityAbAttr`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
- [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
- [x] Have I provided screenshots/videos of the changes?