### PR TITLE
[Bug] Make speed ties seed based on current turn

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -661,7 +661,14 @@ export abstract class FieldPhase extends BattlePhase {
     const enemyField = this.scene.getEnemyField().filter(p => p.isActive()) as Pokemon[];
 
     // We shuffle the list before sorting so speed ties produce random results
-    let orderedTargets: Pokemon[] = Utils.randSeedShuffle(playerField.concat(enemyField)).sort((a: Pokemon, b: Pokemon) => {
+    let orderedTargets: Pokemon[] = playerField.concat(enemyField);
+    // We seed it with the current turn to prevent an inconsistency where it
+    // was varying based on how long since you last reloaded
+    this.scene.executeWithSeedOffset(() => {
+      orderedTargets = Utils.randSeedShuffle(orderedTargets);
+    }, this.scene.currentBattle.turn, this.scene.waveSeed);
+
+    orderedTargets.sort((a: Pokemon, b: Pokemon) => {
       const aSpeed = a?.getBattleStat(Stat.SPD) || 0;
       const bSpeed = b?.getBattleStat(Stat.SPD) || 0;
 


### PR DESCRIPTION
## What are the changes?
Speed ties should no longer vary based on reload.

## Why am I doing these changes?
Speed ties currently resolve differently based on how long it's been since a reload.

## What did change?
Previously, speed ties used the default wave rng offset which can vary based on a reload. This changes them to instead seed based on the current turn, making it consistent across reloads.

## How to test the changes?
Turn the rng debugger on then start a battle in a new save, reload in a new tab/session and retry the same battle. Specifically look at the RNG call made after TurnStartPhase, this should be different without this patch and the same with this patch.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)