### PR TITLE
[QoL] Apply valid Pokemon check only for the first one

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1044,7 +1044,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
                 const isValidForChallenge = new Utils.BooleanHolder(true);
                 Challenge.applyChallenges(this.scene.gameMode, Challenge.ChallengeType.STARTER_CHOICE, species, isValidForChallenge);
 
-                if (!isDupe && isValidForChallenge.value && this.tryUpdateValue(this.scene.gameData.getSpeciesStarterValue(species.speciesId))) {
+                if (!isDupe && (isValidForChallenge.value || this.starterCursors.length !== 0) && this.tryUpdateValue(this.scene.gameData.getSpeciesStarterValue(species.speciesId))) {
                   const cursorObj = this.starterCursorObjs[this.starterCursors.length];
                   cursorObj.setVisible(true);
                   cursorObj.setPosition(this.cursorObj.x, this.cursorObj.y);


### PR DESCRIPTION
## What are the changes?
Allows players to take starters that don't match the criteria into challenge runs

## Why am I doing these changes?
There's a lot of cross-generation evos and Pokemon that gain types but cannot be taken as starters. This now lets players take Magikarp as a starter for a mono-flying run and Yanma/Swinub for gen4 runs

## What did change?
Disabled the `isValidForChallenge` check for selecting starters if it is not the first one

### Screenshots/Videos
Gen1 mono normal
![](https://cdn.discordapp.com/attachments/1241164581997510656/1249793231416459396/image.png?ex=66689826&is=666746a6&hm=cc155dae6d9734bbc9d011c2b7a769992a78033d8f3d8be1b6815be3b09f4d5b&)

## How to test the changes?
Pull the changes then start a new challenge run and select starters

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?