### PR TITLE
[Bug] Fix inputs being annoying again

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -706,6 +706,8 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.variantIconElement.setOrigin(0.0, 0.0);
     this.variantLabel = addTextObject(this.scene, this.instructionRowX + this.instructionRowTextOffset, this.instructionRowY, i18next.t("starterSelectUiHandler:cycleVariant"), TextStyle.PARTY, { fontSize: instructionTextSize });
 
+    this.hideInstructions();
+
     this.starterSelectMessageBoxContainer = this.scene.add.container(0, this.scene.game.canvas.height / 6);
     this.starterSelectMessageBoxContainer.setVisible(false);
     this.starterSelectContainer.add(this.starterSelectMessageBoxContainer);
@@ -1574,6 +1576,8 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     iconElement.setTexture(gamepadType, iconPath);
     iconElement.setPosition(this.instructionRowX, this.instructionRowY);
     controlLabel.setPosition(this.instructionRowX + this.instructionRowTextOffset, this.instructionRowY);
+    iconElement.setVisible(true);
+    controlLabel.setVisible(true);
     this.instructionsContainer.add([iconElement, controlLabel]);
     this.instructionRowY += 8;
     if (this.instructionRowY >= 24) {
@@ -1585,6 +1589,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
   updateInstructions(): void {
     this.instructionRowX = 0;
     this.instructionRowY = 0;
+    this.hideInstructions();
     this.instructionsContainer.removeAll();
     let gamepadType;
     if (this.scene.inputMethod === "gamepad") {


### PR DESCRIPTION
## What are the changes?
this resolves the inputs being present in the top left of the screen

## Why am I doing these changes?
the input lines from the starter select screen were present on the main menu

## What did change?
The input lines are now being properly hidden when they are not actively placed within the starter select instruction container

### Screenshots/Videos
prior to my change:
![image](https://github.com/pagefaultgames/pokerogue/assets/170910983/a3452f6d-4060-4fb3-8560-e6b95f48778e)

after my change:
![image](https://github.com/pagefaultgames/pokerogue/assets/170910983/0c3dd1fc-8c0e-414c-8e33-aa60ec0cfb89)

## How to test the changes?
prior to this change, opening the game at all would show the small lines of text in the top left of the screen, so
- open the game
- ensure the inputs aren't present in the top left
- go to starter select
- choose a starter with forms/gender/etc. to cycle through
- start your new game
- ensure the inputs aren't present in the top left

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?