### PR TITLE
[localization] fixing typo in zh_cn challenge.ts

### DIFF
--- a/src/locales/zh_CN/challenges.ts
+++ b/src/locales/zh_CN/challenges.ts
@@ -39,7 +39,7 @@ export const challenges: SimpleTranslationEntries = {
   "singleType.value.5": "地面",
   "singleType.desc.5": "你只能使用地面属性的宝可梦",
   "singleType.value.6": "岩石",
-  "singleType.desc.6": "你只能使用所选属性的宝可梦",
+  "singleType.desc.6": "你只能使用岩石属性的宝可梦",
   "singleType.value.7": "虫",
   "singleType.desc.7": "你只能使用虫属性的宝可梦",
   "singleType.value.8": "幽灵",

--- a/src/locales/zh_CN/challenges.ts
+++ b/src/locales/zh_CN/challenges.ts
@@ -23,7 +23,7 @@ export const challenges: SimpleTranslationEntries = {
   "singleGeneration.desc.7": "你只能使用第七世代的宝可梦",
   "singleGeneration.value.8": "第八世代",
   "singleGeneration.desc.8": "你只能使用第八世代的宝可梦",
-  "singleGeneration.value.9": "第久世代",
+  "singleGeneration.value.9": "第九世代",
   "singleGeneration.desc.9": "你只能使用第九世代的宝可梦",
   "singleType.name": "单属性",
   "singleType.value.0": "关闭",


### PR DESCRIPTION
![ec29989314a28ca4eda8866a1ce18abe](https://github.com/pagefaultgames/pokerogue/assets/47717431/e683a87c-4c54-4618-a8ce-2351a3895fdf)
my bad... :(