### PR TITLE
Fix english names of monotype achievements

### DIFF
--- a/src/locales/en/achv.ts
+++ b/src/locales/en/achv.ts
@@ -211,58 +211,58 @@ export const PGMachv: AchievementTranslationEntries = {
     description: "Complete the {{type}} monotype challenge.",
   },
   "MONO_NORMAL": {
-    name: "Mono NORMAL",
+    name: "Extra Ordinary",
   },
   "MONO_FIGHTING": {
     name: "I Know Kung Fu",
   },
   "MONO_FLYING": {
-    name: "Mono FLYING",
+    name: "Angry Birds",
   },
   "MONO_POISON": {
     name: "Kanto's Favourite",
   },
   "MONO_GROUND": {
-    name: "Mono GROUND",
+    name: "Forecast: Earthquakes",
   },
   "MONO_ROCK": {
     name: "Brock Hard",
   },
   "MONO_BUG": {
-    name: "Sting Like A Beedrill",
+    name: "You Like Jazz?",
   },
   "MONO_GHOST": {
-    name: "Who you gonna call?",
+    name: "Who You Gonna Call?",
   },
   "MONO_STEEL": {
-    name: "Mono STEEL",
+    name: "Iron Giant",
   },
   "MONO_FIRE": {
-    name: "Mono FIRE",
+    name: "I Cast Fireball!",
   },
   "MONO_WATER": {
     name: "When It Rains, It Pours",
   },
   "MONO_GRASS": {
-    name: "Mono GRASS",
+    name: "Can't Touch This",
   },
   "MONO_ELECTRIC": {
-    name: "Mono ELECTRIC",
+    name: "Aim For The Horn!",
   },
   "MONO_PSYCHIC": {
-    name: "Mono PSYCHIC",
+    name: "Big Brain Energy",
   },
   "MONO_ICE": {
-    name: "Mono ICE",
+    name: "Walking On Thin Ice",
   },
   "MONO_DRAGON": {
-    name: "Mono DRAGON",
+    name: "Pseudo-Legend Club",
   },
   "MONO_DARK": {
-    name: "It's just a phase",
+    name: "It's Just A Phase",
   },
   "MONO_FAIRY": {
-    name: "Mono FAIRY",
+    name: "Hey! Listen!",
   },
 } as const;
 


### PR DESCRIPTION
## What are the changes?
Changes the names of monotype achievements.

## Why am I doing these changes?
Several of the names somehow didn't make it in.

## What did change?
The localisation entries for english for the monotype achievement names changed.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)