### PR TITLE
[Localization]new proofread zh_cn achv names updated

### DIFF
--- a/src/locales/zh_CN/achv.ts
+++ b/src/locales/zh_CN/achv.ts
@@ -122,7 +122,7 @@ export const PGMachv: AchievementTranslationEntries = {
     description: "获得一个迷你黑洞",
   },
   "CATCH_MYTHICAL": {
-    name: "幻兽",
+    name: "神秘礼物",
     description: "捕捉一只幻之宝可梦",
   },
   "CATCH_SUB_LEGENDARY": {
@@ -154,7 +154,7 @@ export const PGMachv: AchievementTranslationEntries = {
     description: "从蛋中孵化出一只传说宝可梦",
   },
   "HATCH_SHINY": {
-    name: "金色传说",
+    name: "金色传说！",
     description: "从蛋中孵化出一只闪光宝可梦",
   },
   "HIDDEN_ABILITY": {

--- a/src/locales/zh_CN/achv.ts
+++ b/src/locales/zh_CN/achv.ts
@@ -99,7 +99,7 @@ export const PGMachv: AchievementTranslationEntries = {
   },
   "MEGA_EVOLVE": {
     name: "大变身",
-    description: "Mega进化一只宝可梦",
+    description: "超级进化一只宝可梦",
   },
   "GIGANTAMAX": {
     name: "这位更是重量级",

--- a/src/locales/zh_CN/achv.ts
+++ b/src/locales/zh_CN/achv.ts
@@ -16,26 +16,26 @@ export const PGMachv: AchievementTranslationEntries = {
     name: "小有积蓄",
   },
   "100K_MONEY": {
-    name: "富裕",
+    name: "大户人家",
   },
   "1M_MONEY": {
     name: "百万富翁",
   },
   "10M_MONEY": {
-    name: "百分之一",
+    name: "暴发户",
   },
 
   "DamageAchv": {
     description: "在单次攻击中造成 {{damageAmount}} 点伤害",
   },
   "250_DMG": {
-    name: "强力攻击者",
+    name: "重拳出击",
   },
   "1000_DMG": {
-    name: "更强力攻击者",
+    name: "神拳猛击",
   },
   "2500_DMG": {
-    name: "伤害真高!",
+    name: "夺少？",
   },
   "10000_DMG": {
     name: "一拳超人",
@@ -45,68 +45,68 @@ export const PGMachv: AchievementTranslationEntries = {
     description: "通过技能、能力或携带的道具一次性治疗 {{healAmount}} {{HP}}点",
   },
   "250_HEAL": {
-    name: "新手治疗师",
+    name: "新手奶妈",
   },
   "1000_HEAL": {
-    name: "高阶治疗师",
+    name: "治疗担当",
   },
   "2500_HEAL": {
     name: "牧师",
   },
   "10000_HEAL": {
-    name: "恢复大师",
+    name: "泉水",
   },
 
   "LevelAchv": {
     description: "将一只宝可梦提升到 Lv{{level}}",
   },
   "LV_100": {
-    name: "不止于此, 还有更多!",
+    name: "别急，后面还有",
   },
   "LV_250": {
     name: "精英",
   },
   "LV_1000": {
-    name: "超越极限",
+    name: "天外有天",
   },
 
   "RibbonAchv": {
     description: "累计获得 {{ribbonAmount}} 个勋章",
   },
   "10_RIBBONS": {
-    name: "宝可梦联赛冠军",
+    name: "宝可梦联盟冠军",
   },
   "25_RIBBONS": {
-    name: "超级联赛冠军",
+    name: "超级球联盟冠军",
   },
   "50_RIBBONS": {
-    name: "至尊联赛冠军",
+    name: "高级球联盟冠军",
   },
   "75_RIBBONS": {
-    name: "肉鸽联赛冠军",
+    name: "肉鸽球联盟冠军",
   },
   "100_RIBBONS": {
-    name: "大师联赛冠军",
+    name: "大师球联盟冠军",
   },
 
   "TRANSFER_MAX_BATTLE_STAT": {
     name: "团队协作",
-    description: "Baton pass to another party member with at least one stat maxed out",
+    description: "在一项属性强化至最大时用接力棒传递给其他宝可梦",
   },
   "MAX_FRIENDSHIP": {
-    name: "亲密度最大化",
+    name: "亲密无间",
     description: "使一只宝可梦的亲密度达到最大值",
   },
   "MEGA_EVOLVE": {
-    name: "Mega进化",
+    name: "大变身",
     description: "Mega进化一只宝可梦",
   },
   "GIGANTAMAX": {
-    name: "极巨化",
+    name: "这位更是重量级",
     description: "极巨化一只宝可梦",
   },
   "TERASTALLIZE": {
-    name: "太晶狂热者",
+    name: "本系爱好者",
     description: "太晶化一只宝可梦",
   },
   "STELLAR_TERASTALLIZE": {
@@ -118,60 +118,60 @@ export const PGMachv: AchievementTranslationEntries = {
     description: "使用基因之楔将两只宝可梦融合在一起",
   },
   "MINI_BLACK_HOLE": {
-    name: "巨量道具",
+    name: "一大洞的道具",
     description: "获得一个迷你黑洞",
   },
   "CATCH_MYTHICAL": {
-    name: "幻之宝可梦",
+    name: "幻兽",
     description: "捕捉一只幻之宝可梦",
   },
   "CATCH_SUB_LEGENDARY": {
-    name: "准-传说宝可梦",
+    name: "二级传说",
     description: "捕捉一只准传说宝可梦",
   },
   "CATCH_LEGENDARY": {
-    name: "传说宝可梦",
+    name: "传说",
     description: "捕捉一只传说宝可梦",
   },
   "SEE_SHINY": {
-    name: "异色宝可梦",
-    description: "在野外找到一只异色宝可梦",
+    name: "闪耀夺目",
+    description: "在野外找到一只闪光宝可梦",
   },
   "SHINY_PARTY": {
-    name: "全队异色",
-    description: "拥有一支由异色宝可梦组成的满员队伍",
+    name: "呕心沥血",
+    description: "拥有一支由闪光宝可梦组成的满员队伍",
   },
   "HATCH_MYTHICAL": {
-    name: "幻之蛋",
+    name: "幻兽蛋",
     description: "从蛋中孵化出一只幻之宝可梦",
   },
   "HATCH_SUB_LEGENDARY": {
-    name: "准-传说蛋",
-    description: "从蛋中孵化出一只准传说宝可梦",
+    name: "二级传说蛋",
+    description: "从蛋中孵化出一只二级传说宝可梦",
   },
   "HATCH_LEGENDARY": {
     name: "传说蛋",
-    description: "从蛋中孵化出一只准-传说宝可梦",
+    description: "从蛋中孵化出一只传说宝可梦",
   },
   "HATCH_SHINY": {
-    name: "异色蛋",
-    description: "从蛋中孵化出一只异色宝可梦",
+    name: "金色传说",
+    description: "从蛋中孵化出一只闪光宝可梦",
   },
   "HIDDEN_ABILITY": {
-    name: "隐藏潜力",
+    name: "隐藏实力",
     description: "捕捉一只拥有隐藏特性的宝可梦",
   },
   "PERFECT_IVS": {
-    name: "完美个体",
+    name: "合格证",
     description: "获得一只拥有完美个体值的宝可梦",
   },
   "CLASSIC_VICTORY": {
-    name: "经典无敌",
+    name: "战无不胜",
     description: "在经典模式中通关游戏",
   },
 
   "MONO_GEN_ONE": {
-    name: "初代劲敌",
+    name: "最初的劲敌",
     description: "完成仅限第一世代的挑战.",
   },
   "MONO_GEN_TWO": {
@@ -179,31 +179,31 @@ export const PGMachv: AchievementTranslationEntries = {
     description: "完成仅限第二世代的挑战.",
   },
   "MONO_GEN_THREE": {
-    name: "水太多了？",
+    name: "“水太多了”",
     description: "完成仅限第三世代的挑战.",
   },
   "MONO_GEN_FOUR": {
-    name: "她真的是最难的吗？",
+    name: "她真是最强冠军吗？",
     description: "完成仅限第四世代的挑战.",
   },
   "MONO_GEN_FIVE": {
-    name: "全为原创",
+    name: "完全原创",
     description: "完成仅限第五世代的挑战.",
   },
   "MONO_GEN_SIX": {
-    name: "近乎贵族",
+    name: "女大公",
     description: "完成仅限第六世代的挑战.",
   },
   "MONO_GEN_SEVEN": {
-    name: "仅技术上(可行)",
+    name: "首届冠军",
     description: "完成仅限第七世代的挑战.",
   },
   "MONO_GEN_EIGHT": {
-    name: "冠军时刻!",
+    name: "冠军时刻！",
     description: "完成仅限第八世代的挑战.",
   },
   "MONO_GEN_NINE": {
-    name: "她对你手下留情了",
+    name: "她又放水了",
     description: "完成仅限第九世代的挑战.",
   },
 
@@ -211,58 +211,58 @@ export const PGMachv: AchievementTranslationEntries = {
     description: "完成 {{type}} 单属性挑战.",
   },
   "MONO_NORMAL": {
-    name: "Mono 一般",
+    name: "异乎寻常的寻常",
   },
   "MONO_FIGHTING": {
-    name: "功夫高手",
+    name: "我有真功夫",
   },
   "MONO_FLYING": {
-    name: "Mono 飞行",
+    name: "愤怒的小鸟",
   },
   "MONO_POISON": {
-    name: "关东的最爱",
+    name: "关都地区特色",
   },
   "MONO_GROUND": {
-    name: "Mono 地面",
+    name: "地震预报",
   },
   "MONO_ROCK": {
     name: "坚如磐石",
   },
   "MONO_BUG": {
-    name: "如大针蜂般刺痛",
+    name: "音箱蟀侠",
   },
   "MONO_GHOST": {
-    name: "你将要召唤谁?",
+    name: "捉鬼敢死队",
   },
   "MONO_STEEL": {
-    name: "Mono 钢",
+    name: "铁巨人",
   },
   "MONO_FIRE": {
-    name: "Mono 火",
+    name: "搓火球解决一切",
   },
   "MONO_WATER": {
     name: "当雨来临，倾盆而下",
   },
   "MONO_GRASS": {
-    name: "Mono 草",
+    name: "别踏这个青",
   },
   "MONO_ELECTRIC": {
-    name: "Mono 电",
+    name: "瞄准大岩蛇的角！",
   },
   "MONO_PSYCHIC": {
-    name: "Mono 超能力",
+    name: "脑洞大开",
   },
   "MONO_ICE": {
-    name: "Mono 冰",
+    name: "如履薄冰",
   },
   "MONO_DRAGON": {
-    name: "Mono 龙",
+    name: "准神俱乐部",
   },
   "MONO_DARK": {
-    name: "这只是一个阶段",
+    name: "总有叛逆期",
   },
   "MONO_FAIRY": {
-    name: "Mono 妖精",
+    name: "林克，醒醒！",
   },
 } as const;
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
a new set of zh_cn achv names.
These names are discussed and translated by 4 zh_cn translators.
Jokes and references from original english names are also translated into the new names
adding translation of missing mono-type achv names.

## Why am I doing these changes?
the previous translation is rough and not accurate, missing several monotype achv names.

## What did change?
achv.ts in zh_cn


## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?