### PR TITLE
[Localization] naive typo fix (was ingenuaa is now ingenua)

### DIFF
--- a/src/locales/it/nature.ts
+++ b/src/locales/it/nature.ts
@@ -15,7 +15,7 @@ export const nature: SimpleTranslationEntries = {
   "Hasty": "Lesta",
   "Serious": "Seria",
   "Jolly": "Allegra",
-  "Naive": "Ingenuaa",
+  "Naive": "Ingenua",
   "Modest": "Modesta",
   "Mild": "Mite",
   "Quiet": "Quieta",


### PR DESCRIPTION
## What are the changes?
- Changed `Naive : "Ingenuaa"`  to `Naive :"Ingenua"` 

## Why am I doing these changes?
The typo was bugging me

## What did change?
I removed the typo double a at the end of the italian word "ingenua"

### Screenshots/Videos
Left side is local change, rightside old result
![image](https://github.com/pagefaultgames/pokerogue/assets/124930934/b0a2ea0c-89f7-4727-b490-e4cd8337f75f)

## How to test the changes?
Set language to Italian, select a pokemon with "naive" nature (ingenua)

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)? *
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
  
* Note that intimidate test is not passing, with or without the change
src/test/abilities/intimidate.test.ts > Abilities - Intimidate > INTIMIDATE
AssertionError: expected undefined not to be undefined
 ❯ src/test/abilities/intimidate.test.ts:50:53
     48| 
     49| 
     50|     expect(game.scene.getParty()[0].summonData).not.toBeUndefined();
       |                                                     ^
     51|     let battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
     52|     expect(battleStatsPokemon[BattleStat.ATK]).toBe(0);