### PR TITLE
[Bug] Fix Opponent Abilities Triggering at Start of Turn instead only after summon

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1798,7 +1798,12 @@ export class TurnInitPhase extends FieldPhase {
   start() {
     super.start();
     const enemyField = this.scene.getEnemyField().filter(p => p.isActive()) as Pokemon[];
-    enemyField.map(p => this.scene.unshiftPhase(new PostSummonPhase(this.scene, p.getBattlerIndex())));
+    enemyField.map(p => {
+      if (p.battleSummonData.turnCount !== 1) {
+        return;
+      }
+      return this.scene.unshiftPhase(new PostSummonPhase(this.scene, p.getBattlerIndex()));
+    });
 
     this.scene.getPlayerField().forEach(p => {
       // If this pokemon is in play and evolved into something illegal under the current challenge, force a switch

--- a/src/test/abilities/intimidate.test.ts
+++ b/src/test/abilities/intimidate.test.ts
@@ -5,11 +5,15 @@ import * as overrides from "#app/overrides";
 import {Abilities} from "#app/data/enums/abilities";
 import {Species} from "#app/data/enums/species";
 import {
-  CommandPhase, TurnInitPhase
+  CommandPhase, DamagePhase,
+  EnemyCommandPhase,
+  TurnInitPhase,
 } from "#app/phases";
 import {Mode} from "#app/ui/ui";
 import {BattleStat} from "#app/data/battle-stat";
 import {Moves} from "#app/data/enums/moves";
+import {getMovePosition} from "#app/test/utils/gameManagerUtils";
+import {Command} from "#app/ui/command-ui-handler";
 
 
 describe("Abilities - Intimidate", () => {
@@ -56,7 +60,7 @@ describe("Abilities - Intimidate", () => {
     expect(game.scene.getParty()[0].species.speciesId).toBe(Species.POOCHYENA);
 
     battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
-    expect(battleStatsPokemon[BattleStat.ATK]).toBe(-1);
+    expect(battleStatsPokemon[BattleStat.ATK]).toBe(0);
 
     battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
     expect(battleStatsOpponent[BattleStat.ATK]).toBe(-2);
@@ -81,7 +85,7 @@ describe("Abilities - Intimidate", () => {
     expect(game.scene.getParty()[0].species.speciesId).toBe(Species.POOCHYENA);
 
     battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
-    expect(battleStatsPokemon[BattleStat.ATK]).toBe(-1);
+    expect(battleStatsPokemon[BattleStat.ATK]).toBe(0);
 
     battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
     expect(battleStatsOpponent[BattleStat.ATK]).toBe(-2);
@@ -106,7 +110,7 @@ describe("Abilities - Intimidate", () => {
     expect(game.scene.getParty()[0].species.speciesId).toBe(Species.POOCHYENA);
 
     battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
-    expect(battleStatsPokemon[BattleStat.ATK]).toBe(-1);
+    expect(battleStatsPokemon[BattleStat.ATK]).toBe(0);
 
     battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
     expect(battleStatsOpponent[BattleStat.ATK]).toBe(-2);
@@ -186,4 +190,146 @@ describe("Abilities - Intimidate", () => {
     const battleStatsPokemon2 = game.scene.getParty()[1].summonData.battleStats;
     expect(battleStatsPokemon2[BattleStat.ATK]).toBe(-2);
   }, 20000);
+
+  it("single - wild next wave opp triger once, us: none", async() => {
+    vi.spyOn(overrides, "STARTING_WAVE_OVERRIDE", "get").mockReturnValue(2);
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.AERIAL_ACE]);
+    await game.startBattle([
+      Species.MIGHTYENA,
+      Species.POOCHYENA,
+    ]);
+    let battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
+    expect(battleStatsOpponent[BattleStat.ATK]).toBe(-1);
+    let battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
+    expect(battleStatsPokemon[BattleStat.ATK]).toBe(-1);
+
+    game.onNextPrompt("CommandPhase", Mode.COMMAND, () => {
+      game.scene.ui.setMode(Mode.FIGHT, (game.scene.getCurrentPhase() as CommandPhase).getFieldIndex());
+    });
+    game.onNextPrompt("CommandPhase", Mode.FIGHT, () => {
+      const movePosition = getMovePosition(game.scene, 0, Moves.AERIAL_ACE);
+      (game.scene.getCurrentPhase() as CommandPhase).handleCommand(Command.FIGHT, movePosition, false);
+    });
+    await game.phaseInterceptor.runFrom(EnemyCommandPhase).to(DamagePhase);
+    await game.killPokemon(game.scene.currentBattle.enemyParty[0]);
+    expect(game.scene.currentBattle.enemyParty[0].isFainted()).toBe(true);
+    await game.toNextWave();
+    battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
+    expect(battleStatsPokemon[BattleStat.ATK]).toBe(-2);
+    battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
+    expect(battleStatsOpponent[BattleStat.ATK]).toBe(0);
+  }, 20000);
+
+  it("single - wild next turn - no retrigger on next turn", async() => {
+    vi.spyOn(overrides, "STARTING_WAVE_OVERRIDE", "get").mockReturnValue(2);
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH]);
+    await game.startBattle([
+      Species.MIGHTYENA,
+      Species.POOCHYENA,
+    ]);
+    let battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
+    expect(battleStatsOpponent[BattleStat.ATK]).toBe(-1);
+    let battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
+    expect(battleStatsPokemon[BattleStat.ATK]).toBe(-1);
+
+    game.onNextPrompt("CommandPhase", Mode.COMMAND, () => {
+      game.scene.ui.setMode(Mode.FIGHT, (game.scene.getCurrentPhase() as CommandPhase).getFieldIndex());
+    });
+    game.onNextPrompt("CommandPhase", Mode.FIGHT, () => {
+      const movePosition = getMovePosition(game.scene, 0, Moves.AERIAL_ACE);
+      (game.scene.getCurrentPhase() as CommandPhase).handleCommand(Command.FIGHT, movePosition, false);
+    });
+    console.log("===to new turn===");
+    await game.toNextTurn();
+    battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
+    expect(battleStatsPokemon[BattleStat.ATK]).toBe(-1);
+    battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
+    expect(battleStatsOpponent[BattleStat.ATK]).toBe(-1);
+  }, 20000);
+
+  it("single - trainer should only trigger once and each time he switch", async() => {
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH]);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.VOLT_SWITCH,Moves.VOLT_SWITCH,Moves.VOLT_SWITCH,Moves.VOLT_SWITCH]);
+    vi.spyOn(overrides, "STARTING_WAVE_OVERRIDE", "get").mockReturnValue(5);
+    await game.startBattle([
+      Species.MIGHTYENA,
+      Species.POOCHYENA,
+    ]);
+    let battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
+    expect(battleStatsOpponent[BattleStat.ATK]).toBe(-1);
+    let battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
+    expect(battleStatsPokemon[BattleStat.ATK]).toBe(-1);
+
+    game.onNextPrompt("CommandPhase", Mode.COMMAND, () => {
+      game.scene.ui.setMode(Mode.FIGHT, (game.scene.getCurrentPhase() as CommandPhase).getFieldIndex());
+    });
+    game.onNextPrompt("CommandPhase", Mode.FIGHT, () => {
+      const movePosition = getMovePosition(game.scene, 0, Moves.AERIAL_ACE);
+      (game.scene.getCurrentPhase() as CommandPhase).handleCommand(Command.FIGHT, movePosition, false);
+    });
+    console.log("===to new turn===");
+    await game.toNextTurn();
+    battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
+    expect(battleStatsPokemon[BattleStat.ATK]).toBe(-2);
+    battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
+    expect(battleStatsOpponent[BattleStat.ATK]).toBe(0);
+
+
+    game.onNextPrompt("CommandPhase", Mode.COMMAND, () => {
+      game.scene.ui.setMode(Mode.FIGHT, (game.scene.getCurrentPhase() as CommandPhase).getFieldIndex());
+    });
+    game.onNextPrompt("CommandPhase", Mode.FIGHT, () => {
+      const movePosition = getMovePosition(game.scene, 0, Moves.AERIAL_ACE);
+      (game.scene.getCurrentPhase() as CommandPhase).handleCommand(Command.FIGHT, movePosition, false);
+    });
+    console.log("===to new turn===");
+    await game.toNextTurn();
+    battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
+    expect(battleStatsPokemon[BattleStat.ATK]).toBe(-3);
+    battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
+    expect(battleStatsOpponent[BattleStat.ATK]).toBe(0);
+  }, 200000);
+
+  it("single - trainer should only trigger once whatever turn we are", async() => {
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH]);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH,Moves.SPLASH,Moves.SPLASH,Moves.SPLASH]);
+    vi.spyOn(overrides, "STARTING_WAVE_OVERRIDE", "get").mockReturnValue(5);
+    await game.startBattle([
+      Species.MIGHTYENA,
+      Species.POOCHYENA,
+    ]);
+    let battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
+    expect(battleStatsOpponent[BattleStat.ATK]).toBe(-1);
+    let battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
+    expect(battleStatsPokemon[BattleStat.ATK]).toBe(-1);
+
+    game.onNextPrompt("CommandPhase", Mode.COMMAND, () => {
+      game.scene.ui.setMode(Mode.FIGHT, (game.scene.getCurrentPhase() as CommandPhase).getFieldIndex());
+    });
+    game.onNextPrompt("CommandPhase", Mode.FIGHT, () => {
+      const movePosition = getMovePosition(game.scene, 0, Moves.AERIAL_ACE);
+      (game.scene.getCurrentPhase() as CommandPhase).handleCommand(Command.FIGHT, movePosition, false);
+    });
+    console.log("===to new turn===");
+    await game.toNextTurn();
+    battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
+    expect(battleStatsPokemon[BattleStat.ATK]).toBe(-1);
+    battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
+    expect(battleStatsOpponent[BattleStat.ATK]).toBe(-1);
+
+
+    game.onNextPrompt("CommandPhase", Mode.COMMAND, () => {
+      game.scene.ui.setMode(Mode.FIGHT, (game.scene.getCurrentPhase() as CommandPhase).getFieldIndex());
+    });
+    game.onNextPrompt("CommandPhase", Mode.FIGHT, () => {
+      const movePosition = getMovePosition(game.scene, 0, Moves.AERIAL_ACE);
+      (game.scene.getCurrentPhase() as CommandPhase).handleCommand(Command.FIGHT, movePosition, false);
+    });
+    console.log("===to new turn===");
+    await game.toNextTurn();
+    battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
+    expect(battleStatsPokemon[BattleStat.ATK]).toBe(-1);
+    battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
+    expect(battleStatsOpponent[BattleStat.ATK]).toBe(-1);
+  }, 200000);
 });


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## [Bug] Fix Opponent Triggering Abilities Incorrectly

## What are the changes?
Fixed the bug where the opponent would trigger his postSummon abilities at the start of each turn instead of just after he summons.

## What did change?
Before: The opponent's postSummon abilities were triggered at the start of every turn.
After: The opponent's postSummon abilities are now only triggered after he summons, as intended.

### Screenshots/Videos
![webstorm64_I0dwDs10QI](https://github.com/pagefaultgames/pokerogue/assets/44787002/1e16f874-2ee5-4382-922f-8b1e11dd089b)

## How to test the changes?
To test these changes:
1. Checkout the branch with these fixes.
2. Start a game session and observe the opponent's behavior at the start of each turn and after summoning.
3. Ensure that abilities are not triggered at the start of the turn but only after summoning.
4. Run all unit tests using `npm run test` to ensure no other functionalities are broken.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
