### PR TITLE
Correction to French ability.ts

### DIFF
--- a/src/locales/fr/ability.ts
+++ b/src/locales/fr/ability.ts
@@ -897,7 +897,7 @@ export const ability: AbilityTranslationEntries = {
     name: "Boost Chimère",
     description: "Augmente la stat la plus élevée du Pokémon quand il met K.O. un autre Pokémon.",
   },
-  rKSSystem: {
+  rksSystem: {
     name: "Système Alpha",
     description: "Change le type du Pokémon en fonction de la ROM équipée.",
   },


### PR DESCRIPTION
## What are the changes?
Changed rKSSystem to rksSystem varable in French ability.ts

## Why am I doing these changes?
rksSystem varable in French ability.ts file was wrong

## What did change?
Corrected rksSystem varable name in French

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?