### PR TITLE
[QoL] Added Able/Not Able label for evolutionary/form change items

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -15,7 +15,7 @@ import { PokeballType } from "../data/pokeball";
 import { Gender } from "../data/gender";
 import { initMoveAnim, loadMoveAnimAssets } from "../data/battle-anims";
 import { Status, StatusEffect, getRandomStatus } from "../data/status-effect";
-import { pokemonEvolutions, pokemonPrevolutions, SpeciesFormEvolution, SpeciesEvolutionCondition, FusionSpeciesFormEvolution } from "../data/pokemon-evolutions";
+import { pokemonEvolutions, pokemonPrevolutions, SpeciesFormEvolution, SpeciesEvolutionCondition, FusionSpeciesFormEvolution, EvolutionItem } from "../data/pokemon-evolutions";
 import { reverseCompatibleTms, tmSpecies, tmPoolTiers } from "../data/tms";
 import { DamagePhase, FaintPhase, LearnMovePhase, ObtainStatusEffectPhase, StatChangePhase, SwitchSummonPhase, ToggleDoublePositionPhase  } from "../phases";
 import { BattleStat } from "../data/battle-stat";
@@ -40,7 +40,7 @@ import { DamageAchv, achvs } from "../system/achv";
 import { DexAttr, StarterDataEntry, StarterMoveset } from "../system/game-data";
 import { QuantizerCelebi, argbFromRgba, rgbaFromArgb } from "@material/material-color-utilities";
 import { Nature, getNatureStatMultiplier } from "../data/nature";
-import { SpeciesFormChange, SpeciesFormChangeActiveTrigger, SpeciesFormChangeMoveLearnedTrigger, SpeciesFormChangePostMoveTrigger, SpeciesFormChangeStatusEffectTrigger } from "../data/pokemon-forms";
+import { FormChangeItem, SpeciesFormChange, SpeciesFormChangeActiveTrigger, SpeciesFormChangeItemTrigger, SpeciesFormChangeMoveLearnedTrigger, SpeciesFormChangePostMoveTrigger, SpeciesFormChangeStatusEffectTrigger, pokemonFormChanges } from "../data/pokemon-forms";
 import { TerrainType } from "../data/terrain";
 import { TrainerSlot } from "../data/trainer-config";
 import * as Overrides from "../overrides";
@@ -49,6 +49,7 @@ import i18next from "../plugins/i18n";
 import { speciesEggMoves } from "../data/egg-moves";
 import { ModifierTier } from "../modifier/modifier-tier";
 import { applyChallenges, ChallengeType } from "#app/data/challenge.js";
+import * as Modifiers from "../modifier/modifier";
 
 export enum FieldPosition {
   CENTER,
@@ -2873,6 +2874,8 @@ export default interface Pokemon {
 
 export class PlayerPokemon extends Pokemon {
   public compatibleTms: Moves[];
+  public evolutionItems: EvolutionItem[];
+  public formChangeItems: FormChangeItem[];
 
   constructor(scene: BattleScene, species: PokemonSpecies, level: integer, abilityIndex: integer, formIndex: integer, gender: Gender, shiny: boolean, variant: Variant, ivs: integer[], nature: Nature, dataSource: Pokemon | PokemonData) {
     super(scene, 106, 148, species, level, abilityIndex, formIndex, gender, shiny, variant, ivs, nature, dataSource);
@@ -2893,6 +2896,8 @@ export class PlayerPokemon extends Pokemon {
       this.generateAndPopulateMoveset();
     }
     this.generateCompatibleTms();
+    this.generatePossibleEvolutionItems();
+    this.generatePossibleFormChangeItems();
   }
 
   initBattleInfo(): void {
@@ -2945,6 +2950,46 @@ export class PlayerPokemon extends Pokemon {
         this.compatibleTms.push(moveId);
       }
     }
+  }
+
+  /**
+   * Sets evolutionItems to be all possible evolutionary items for the Pokemon.
+   * Based on EvolutionItemModifierTypeGenerator from modifier-types.ts
+   */
+  generatePossibleEvolutionItems(): void {
+    this.evolutionItems = [];
+    let speciesFormEvolutions = [];
+
+    if (pokemonEvolutions.hasOwnProperty(this.species.speciesId)) {
+      const evolutions = pokemonEvolutions[this.species.speciesId];
+      speciesFormEvolutions = evolutions.filter(e => e.item !== EvolutionItem.NONE && (e.evoFormKey === null || (e.preFormKey || "") === this.getFormKey()) && (!e.condition || e.condition.predicate(this))); // this as Pokemon?
+    }
+
+    if (this.isFusion() && pokemonEvolutions.hasOwnProperty(this.fusionSpecies.speciesId)) { // this hsould be add on not else if
+      const evolutions = pokemonEvolutions[this.fusionSpecies.speciesId];
+      speciesFormEvolutions.concat(evolutions.filter(e => e.item !== EvolutionItem.NONE && (e.evoFormKey === null || (e.preFormKey || "") === this.getFusionFormKey()) && (!e.condition || e.condition.predicate(this))));
+    }
+    const possibleEvolutionItems = speciesFormEvolutions.flat().flatMap(e => e.item);
+
+    this.evolutionItems = possibleEvolutionItems;
+  }
+
+  /**
+   * Sets formChangeItems to be all possible form change items for the Pokemon.
+   * Based on FormChangeItemModifierTypeGenerator from modifier-types.ts
+   */
+  generatePossibleFormChangeItems(): void {
+    this.formChangeItems = [];
+    let speciesFormEvolutions = [];
+    if (pokemonFormChanges.hasOwnProperty(this.species.speciesId)) {
+      const formChanges = pokemonFormChanges[this.species.speciesId];
+      speciesFormEvolutions = formChanges.filter(fc => ((fc.formKey.indexOf(SpeciesFormKey.MEGA) === -1 && fc.formKey.indexOf(SpeciesFormKey.PRIMAL) === -1) || this.scene.getModifiers(Modifiers.MegaEvolutionAccessModifier).length)
+        && ((fc.formKey.indexOf(SpeciesFormKey.GIGANTAMAX) === -1 && fc.formKey.indexOf(SpeciesFormKey.ETERNAMAX) === -1) || this.scene.getModifiers(Modifiers.GigantamaxAccessModifier).length))
+        .map(fc => fc.findTrigger(SpeciesFormChangeItemTrigger) as SpeciesFormChangeItemTrigger)
+        .filter(t => t && t.active && !this.scene.findModifier(m => m instanceof Modifiers.PokemonFormChangeItemModifier && m.pokemonId === this.id && m.formChangeItem === t.item))
+        .flat().flatMap(fc => fc.item);
+    }
+    this.formChangeItems = speciesFormEvolutions;
   }
 
   tryPopulateMoveset(moveset: StarterMoveset): boolean {
@@ -3101,6 +3146,8 @@ export class PlayerPokemon extends Pokemon {
           this.fusionAbilityIndex = abilityCount - 1;
         }
       }
+      this.generatePossibleEvolutionItems();
+      this.generatePossibleFormChangeItems();
       this.compatibleTms.splice(0, this.compatibleTms.length);
       this.generateCompatibleTms();
       const updateAndResolve = () => {
@@ -3192,6 +3239,8 @@ export class PlayerPokemon extends Pokemon {
   clearFusionSpecies(): void {
     super.clearFusionSpecies();
     this.generateCompatibleTms();
+    this.generatePossibleEvolutionItems();
+    this.generatePossibleFormChangeItems();
   }
 
   /**
@@ -3228,8 +3277,9 @@ export class PlayerPokemon extends Pokemon {
         this.hp = Math.max(this.hp, 1);
         this.status = pokemon.status; // Inherit the other Pokemon's status
       }
-
       this.generateCompatibleTms();
+      this.generatePossibleEvolutionItems();
+      this.generatePossibleFormChangeItems();
       this.updateInfo(true);
       const fusedPartyMemberIndex = this.scene.getParty().indexOf(pokemon);
       let partyMemberIndex = this.scene.getParty().indexOf(this);

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -19,7 +19,7 @@ import { BattleStat, getBattleStatLevelChangeDescription, getBattleStatName } fr
 import { biomeLinks, getBiomeName } from "./data/biomes";
 import { Biome } from "./data/enums/biome";
 import { ModifierTier } from "./modifier/modifier-tier";
-import { FusePokemonModifierType, ModifierPoolType, ModifierType, ModifierTypeFunc, ModifierTypeOption, PokemonModifierType, PokemonMoveModifierType, PokemonPpRestoreModifierType, PokemonPpUpModifierType, RememberMoveModifierType, TmModifierType, getDailyRunStarterModifiers, getEnemyBuffModifierForWave, getModifierType, getPlayerModifierTypeOptions, getPlayerShopModifierTypeOptionsForWave, modifierTypes, regenerateModifierPoolThresholds } from "./modifier/modifier-type";
+import { EvolutionItemModifierType, FormChangeItemModifierType, FusePokemonModifierType, ModifierPoolType, ModifierType, ModifierTypeFunc, ModifierTypeOption, PokemonModifierType, PokemonMoveModifierType, PokemonPpRestoreModifierType, PokemonPpUpModifierType, RememberMoveModifierType, TmModifierType, getDailyRunStarterModifiers, getEnemyBuffModifierForWave, getModifierType, getPlayerModifierTypeOptions, getPlayerShopModifierTypeOptionsForWave, modifierTypes, regenerateModifierPoolThresholds } from "./modifier/modifier-type";
 import SoundFade from "phaser3-rex-plugins/plugins/soundfade";
 import { BattlerTagLapseType, EncoreTag, HideSpriteTag as HiddenTag, ProtectedTag, TrappedTag } from "./data/battler-tags";
 import { BattlerTagType } from "./data/enums/battler-tag-type";
@@ -5096,12 +5096,20 @@ export class SelectModifierPhase extends BattlePhase {
           const isTmModifier = modifierType instanceof TmModifierType;
           const isRememberMoveModifier = modifierType instanceof RememberMoveModifierType;
           const isPpRestoreModifier = (modifierType instanceof PokemonPpRestoreModifierType || modifierType instanceof PokemonPpUpModifierType);
+          const isEvolutionItemModifier = modifierType instanceof EvolutionItemModifierType;
+          const isFormItemModifier = modifierType instanceof FormChangeItemModifierType;
           const partyUiMode = isMoveModifier ? PartyUiMode.MOVE_MODIFIER
             : isTmModifier ? PartyUiMode.TM_MODIFIER
               : isRememberMoveModifier ? PartyUiMode.REMEMBER_MOVE_MODIFIER
                 : PartyUiMode.MODIFIER;
           const tmMoveId = isTmModifier
             ? (modifierType as TmModifierType).moveId
+            : undefined;
+          const evolutionItemId = isEvolutionItemModifier
+            ? (modifierType as EvolutionItemModifierType).evolutionItem
+            : undefined;
+          const formItemId = isFormItemModifier
+            ? (modifierType as FormChangeItemModifierType).formChangeItem
             : undefined;
           this.scene.ui.setModeWithoutClear(Mode.PARTY, partyUiMode, -1, (slotIndex: integer, option: PartyOption) => {
             if (slotIndex < 6) {
@@ -5116,7 +5124,7 @@ export class SelectModifierPhase extends BattlePhase {
             } else {
               this.scene.ui.setMode(Mode.MODIFIER_SELECT, this.isPlayer(), typeOptions, modifierSelectCallback, this.getRerollCost(typeOptions, this.scene.lockModifierTiers));
             }
-          }, pokemonModifierType.selectFilter, modifierType instanceof PokemonMoveModifierType ? (modifierType as PokemonMoveModifierType).moveSelectFilter : undefined, tmMoveId, isPpRestoreModifier);
+          }, pokemonModifierType.selectFilter, modifierType instanceof PokemonMoveModifierType ? (modifierType as PokemonMoveModifierType).moveSelectFilter : undefined, tmMoveId, isPpRestoreModifier, evolutionItemId, formItemId);
         }
       } else {
         applyModifier(modifierType.newModifier());

--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -12,9 +12,9 @@ import { Moves } from "../data/enums/moves";
 import { getGenderColor, getGenderSymbol } from "../data/gender";
 import { StatusEffect } from "../data/status-effect";
 import PokemonIconAnimHandler, { PokemonIconAnimMode } from "./pokemon-icon-anim-handler";
-import { pokemonEvolutions } from "../data/pokemon-evolutions";
+import { EvolutionItem, pokemonEvolutions } from "../data/pokemon-evolutions";
 import { addWindow } from "./ui-theme";
-import { SpeciesFormChangeItemTrigger } from "../data/pokemon-forms";
+import { FormChangeItem, SpeciesFormChangeItemTrigger } from "../data/pokemon-forms";
 import { getVariantTint } from "#app/data/variant";
 import {Button} from "../enums/buttons";
 import { applyChallenges, ChallengeType } from "#app/data/challenge.js";
@@ -103,6 +103,8 @@ export default class PartyUiHandler extends MessageUiHandler {
   private moveSelectFilter: PokemonMoveSelectFilter;
   private tmMoveId: Moves;
   private showMovePp: boolean;
+  private evolutionItemId: EvolutionItem;
+  private formItemId: FormChangeItem;
 
   private iconAnimHandler: PokemonIconAnimHandler;
 
@@ -239,7 +241,8 @@ export default class PartyUiHandler extends MessageUiHandler {
       : PartyUiHandler.FilterAllMoves;
     this.tmMoveId = args.length > 5 && args[5] ? args[5] : Moves.NONE;
     this.showMovePp = args.length > 6 && args[6];
-
+    this.evolutionItemId = args.length > 7 && args[7] ? args[7] : EvolutionItem.NONE;
+    this.formItemId = args.length > 8 && args[8] ? args[8] : FormChangeItem.NONE;
     this.partyContainer.setVisible(true);
     this.partyBg.setTexture(`party_bg${this.scene.currentBattle.double ? "_double" : ""}`);
     this.populatePartySlots();
@@ -542,7 +545,7 @@ export default class PartyUiHandler extends MessageUiHandler {
 
     for (const p in party) {
       const slotIndex = parseInt(p);
-      const partySlot = new PartySlot(this.scene, slotIndex, party[p], this.iconAnimHandler, this.partyUiMode, this.tmMoveId);
+      const partySlot = new PartySlot(this.scene, slotIndex, party[p], this.iconAnimHandler, this.partyUiMode, this.tmMoveId, this.evolutionItemId, this.formItemId);
       this.scene.add.existing(partySlot);
       this.partySlotsContainer.add(partySlot);
       this.partySlots.push(partySlot);
@@ -981,7 +984,7 @@ class PartySlot extends Phaser.GameObjects.Container {
   private pokemonIcon: Phaser.GameObjects.Container;
   private iconAnimHandler: PokemonIconAnimHandler;
 
-  constructor(scene: BattleScene, slotIndex: integer, pokemon: PlayerPokemon, iconAnimHandler: PokemonIconAnimHandler, partyUiMode: PartyUiMode, tmMoveId: Moves) {
+  constructor(scene: BattleScene, slotIndex: integer, pokemon: PlayerPokemon, iconAnimHandler: PokemonIconAnimHandler, partyUiMode: PartyUiMode, tmMoveId: Moves, evolutionItemId: EvolutionItem, formItemId: FormChangeItem) {
     super(scene, slotIndex >= scene.currentBattle.getBattlerCount() ? 230.5 : 64,
       slotIndex >= scene.currentBattle.getBattlerCount() ? -184 + (scene.currentBattle.double ? -40 : 0)
       + (28 + (scene.currentBattle.double ? 8 : 0)) * slotIndex : -124 + (scene.currentBattle.double ? -8 : 0) + slotIndex * 64);
@@ -990,10 +993,10 @@ class PartySlot extends Phaser.GameObjects.Container {
     this.pokemon = pokemon;
     this.iconAnimHandler = iconAnimHandler;
 
-    this.setup(partyUiMode, tmMoveId);
+    this.setup(partyUiMode, tmMoveId, evolutionItemId, formItemId);
   }
 
-  setup(partyUiMode: PartyUiMode, tmMoveId: Moves) {
+  setup(partyUiMode: PartyUiMode, tmMoveId: Moves, evolutionItemId: EvolutionItem, formItemId: FormChangeItem) {
     const battlerCount = (this.scene as BattleScene).currentBattle.getBattlerCount();
 
     const slotKey = `party_slot${this.slotIndex >= battlerCount ? "" : "_main"}`;
@@ -1103,24 +1106,7 @@ class PartySlot extends Phaser.GameObjects.Container {
       }
     }
 
-    if (partyUiMode !== PartyUiMode.TM_MODIFIER) {
-      const slotHpBar = this.scene.add.image(0, 0, "party_slot_hp_bar");
-      slotHpBar.setPositionRelative(slotBg, this.slotIndex >= battlerCount ? 72 : 8, this.slotIndex >= battlerCount ? 6 : 31);
-      slotHpBar.setOrigin(0, 0);
-
-      const hpRatio = this.pokemon.getHpRatio();
-
-      const slotHpOverlay = this.scene.add.sprite(0, 0, "party_slot_hp_overlay", hpRatio > 0.5 ? "high" : hpRatio > 0.25 ? "medium" : "low");
-      slotHpOverlay.setPositionRelative(slotHpBar, 16, 2);
-      slotHpOverlay.setOrigin(0, 0);
-      slotHpOverlay.setScale(hpRatio, 1);
-
-      const slotHpText = addTextObject(this.scene, 0, 0, `${this.pokemon.hp}/${this.pokemon.getMaxHp()}`, TextStyle.PARTY);
-      slotHpText.setPositionRelative(slotHpBar, slotHpBar.width - 3, slotHpBar.height - 2);
-      slotHpText.setOrigin(1, 0);
-
-      slotInfoContainer.add([ slotHpBar, slotHpOverlay, slotHpText ]);
-    } else {
+    if (partyUiMode === PartyUiMode.TM_MODIFIER) {
       let slotTmText: string;
       switch (true) {
       case (this.pokemon.compatibleTms.indexOf(tmMoveId) === -1):
@@ -1139,6 +1125,44 @@ class PartySlot extends Phaser.GameObjects.Container {
       slotTmLabel.setOrigin(0, 1);
 
       slotInfoContainer.add(slotTmLabel);
+    } else if (partyUiMode === PartyUiMode.MODIFIER && (evolutionItemId || formItemId)) {
+      let slotItemText = "";
+      if (evolutionItemId) {
+        if (this.pokemon.evolutionItems.indexOf(evolutionItemId) !== -1) {
+          slotItemText = "Able";
+        } else {
+          slotItemText = "Not Able";
+        }
+      } else if (formItemId) {
+        if (this.pokemon.formChangeItems.indexOf(formItemId) !== -1) {
+          slotItemText = "Able";
+        } else {
+          slotItemText = "Not Able";
+        }
+      }
+
+      const slotItemLabel = addTextObject(this.scene, 0, 0, slotItemText, TextStyle.MESSAGE);
+      slotItemLabel.setPositionRelative(slotBg, this.slotIndex >= battlerCount ? 94 : 32, this.slotIndex >= battlerCount ? 16 : 46);
+      slotItemLabel.setOrigin(0, 1);
+
+      slotInfoContainer.add(slotItemLabel);
+    } else {
+      const slotHpBar = this.scene.add.image(0, 0, "party_slot_hp_bar");
+      slotHpBar.setPositionRelative(slotBg, this.slotIndex >= battlerCount ? 72 : 8, this.slotIndex >= battlerCount ? 6 : 31);
+      slotHpBar.setOrigin(0, 0);
+
+      const hpRatio = this.pokemon.getHpRatio();
+
+      const slotHpOverlay = this.scene.add.sprite(0, 0, "party_slot_hp_overlay", hpRatio > 0.5 ? "high" : hpRatio > 0.25 ? "medium" : "low");
+      slotHpOverlay.setPositionRelative(slotHpBar, 16, 2);
+      slotHpOverlay.setOrigin(0, 0);
+      slotHpOverlay.setScale(hpRatio, 1);
+
+      const slotHpText = addTextObject(this.scene, 0, 0, `${this.pokemon.hp}/${this.pokemon.getMaxHp()}`, TextStyle.PARTY);
+      slotHpText.setPositionRelative(slotHpBar, slotHpBar.width - 3, slotHpBar.height - 2);
+      slotHpText.setOrigin(1, 0);
+
+      slotInfoContainer.add([ slotHpBar, slotHpOverlay, slotHpText ]);
     }
   }
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Adds "Able/Not Able" text to party screen when applying a evolutionary/form change item similar to TMs.
## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Closes #1957 . Gives an indicator as to if a Pokemon can use the item.
## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Added generate compatible evolutionary/form change items functions and variable inside` PlayerPokemon` in `pokemon.ts`.
Like when generating compatible TM's, these will be called whenever a new Pokemon object is created.
### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
_Taking a Thunder Stone for example_
![Screenshot (5)](https://github.com/pagefaultgames/pokerogue/assets/63990624/a37873a0-f407-4f4e-b15d-b8a132e4bac3)

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [Nothing that affects these changes] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?