### PR TITLE
[Bug Fix] Correct PostSummonPhase Timing for Abilities and Entry Hazards

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -168,6 +168,7 @@ export default class BattleScene extends SceneBase {
   public sessionSlotId: integer;
 
   public phaseQueue: Phase[];
+  public conditionalQueue: Array<[() => boolean, Phase]>;
   private phaseQueuePrepend: Phase[];
   private phaseQueuePrependSpliceIndex: integer;
   private nextCommandPhaseQueue: Phase[];
@@ -252,6 +253,7 @@ export default class BattleScene extends SceneBase {
     super("battle");
     this.phaseQueue = [];
     this.phaseQueuePrepend = [];
+    this.conditionalQueue = [];
     this.phaseQueuePrependSpliceIndex = -1;
     this.nextCommandPhaseQueue = [];
     this.updateGameInfo();
@@ -1843,6 +1845,21 @@ export default class BattleScene extends SceneBase {
     return this.standbyPhase;
   }
 
+  /**
+   * Adds a phase to the conditional queue and ensures it is executed only when the specified condition is met.
+   *
+   * This method allows deferring the execution of a phase until certain conditions are met, which is useful for handling
+   * situations like abilities and entry hazards that depend on specific game states.
+   *
+   * @param {Phase} phase - The phase to be added to the conditional queue.
+   * @param {() => boolean} condition - A function that returns a boolean indicating whether the phase should be executed.
+   *
+   */
+  pushConditionalPhase(phase: Phase, condition: () => boolean): void {
+    this.conditionalQueue.push([condition, phase]);
+  }
+
+
   pushPhase(phase: Phase, defer: boolean = false): void {
     (!defer ? this.phaseQueue : this.nextCommandPhaseQueue).push(phase);
   }
@@ -1886,6 +1903,21 @@ export default class BattleScene extends SceneBase {
       this.populatePhaseQueue();
     }
     this.currentPhase = this.phaseQueue.shift();
+
+    // Check if there are any conditional phases queued
+    if (this.conditionalQueue?.length) {
+      // Retrieve the first conditional phase from the queue
+      const conditionalPhase = this.conditionalQueue.shift();
+      // Evaluate the condition associated with the phase
+      if (conditionalPhase[0]()) {
+        // If the condition is met, add the phase to the front of the phase queue
+        this.unshiftPhase(conditionalPhase[1]);
+      } else {
+        // If the condition is not met, re-add the phase back to the front of the conditional queue
+        this.conditionalQueue.unshift(conditionalPhase);
+      }
+    }
+
     this.currentPhase.start();
   }
 

--- a/src/test/moves/spikes.test.ts
+++ b/src/test/moves/spikes.test.ts
@@ -1,0 +1,128 @@
+import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
+import Phaser from "phaser";
+import GameManager from "#app/test/utils/gameManager";
+import * as overrides from "#app/overrides";
+import {Abilities} from "#app/data/enums/abilities";
+import {Species} from "#app/data/enums/species";
+import {
+  CommandPhase
+} from "#app/phases";
+import {Moves} from "#app/data/enums/moves";
+
+
+describe("Moves - Spikes", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.scene.battleStyle = 1;
+    vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.RATTATA);
+    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.HYDRATION);
+    vi.spyOn(overrides, "OPP_PASSIVE_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.HYDRATION);
+    vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.HYDRATION);
+    vi.spyOn(overrides, "PASSIVE_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.HYDRATION);
+    vi.spyOn(overrides, "STARTING_WAVE_OVERRIDE", "get").mockReturnValue(3);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH,Moves.SPLASH,Moves.SPLASH,Moves.SPLASH]);
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPIKES,Moves.SPLASH, Moves.ROAR]);
+  });
+
+  it("single - wild - stay on field - no damage", async() => {
+    // player set spikes on the field and do splash for 3 turns
+    // opponent do splash for 4 turns
+    // nobody should take damage
+    await game.runToSummon([
+      Species.MIGHTYENA,
+      Species.POOCHYENA,
+    ]);
+    await game.phaseInterceptor.to(CommandPhase, true);
+    const initialHp = game.scene.getParty()[0].hp;
+    expect(game.scene.getParty()[0].hp).toBe(initialHp);
+    game.doAttack(0);
+    await game.toNextTurn();
+    game.doAttack(1);
+    await game.toNextTurn();
+    game.doAttack(1);
+    await game.toNextTurn();
+    game.doAttack(1);
+    await game.toNextTurn();
+    game.doAttack(1);
+    await game.toNextTurn();
+    expect(game.scene.getParty()[0].hp).toBe(initialHp);
+    console.log(game.textInterceptor.logs);
+  }, 20000);
+
+  it("single - wild - take some damage", async() => {
+    // player set spikes on the field and switch back to back
+    // opponent do splash for 2 turns
+    // nobody should take damage
+    await game.runToSummon([
+      Species.MIGHTYENA,
+      Species.POOCHYENA,
+    ]);
+    await game.phaseInterceptor.to(CommandPhase, false);
+
+    const initialHp = game.scene.getParty()[0].hp;
+    await game.switchPokemon(1, false);
+    await game.phaseInterceptor.run(CommandPhase);
+    await game.phaseInterceptor.to(CommandPhase, false);
+
+    await game.switchPokemon(1, false);
+    await game.phaseInterceptor.run(CommandPhase);
+    await game.phaseInterceptor.to(CommandPhase, false);
+
+    expect(game.scene.getParty()[0].hp).toBe(initialHp);
+  }, 20000);
+
+  it("trainer - wild - force switch opponent - should take damage", async() => {
+    vi.spyOn(overrides, "STARTING_WAVE_OVERRIDE", "get").mockReturnValue(5);
+    // player set spikes on the field and do splash for 3 turns
+    // opponent do splash for 4 turns
+    // nobody should take damage
+    await game.runToSummon([
+      Species.MIGHTYENA,
+      Species.POOCHYENA,
+    ]);
+    await game.phaseInterceptor.to(CommandPhase, true);
+    const initialHpOpponent = game.scene.currentBattle.enemyParty[1].hp;
+    game.doAttack(0);
+    await game.toNextTurn();
+    game.doAttack(2);
+    await game.toNextTurn();
+    expect(game.scene.currentBattle.enemyParty[0].hp).toBeLessThan(initialHpOpponent);
+  }, 20000);
+
+  it("trainer - wild - force switch by himself opponent - should take damage", async() => {
+    vi.spyOn(overrides, "STARTING_WAVE_OVERRIDE", "get").mockReturnValue(5);
+    vi.spyOn(overrides, "STARTING_LEVEL_OVERRIDE", "get").mockReturnValue(5000);
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(0);
+    // turn 1: player set spikes, opponent do splash
+    // turn 2: player do splash, opponent switch pokemon
+    // opponent pokemon should trigger spikes and lose HP
+    await game.runToSummon([
+      Species.MIGHTYENA,
+      Species.POOCHYENA,
+    ]);
+    await game.phaseInterceptor.to(CommandPhase, true);
+    const initialHpOpponent = game.scene.currentBattle.enemyParty[1].hp;
+    game.doAttack(0);
+    await game.toNextTurn();
+
+    game.forceOpponentToSwitch();
+    game.doAttack(1);
+    await game.toNextTurn();
+    expect(game.scene.currentBattle.enemyParty[0].hp).toBeLessThan(initialHpOpponent);
+  }, 2000000);
+
+});

--- a/src/test/moves/spikes.test.ts
+++ b/src/test/moves/spikes.test.ts
@@ -123,6 +123,6 @@ describe("Moves - Spikes", () => {
     game.doAttack(1);
     await game.toNextTurn();
     expect(game.scene.currentBattle.enemyParty[0].hp).toBeLessThan(initialHpOpponent);
-  }, 2000000);
+  }, 20000);
 
 });

--- a/src/test/utils/TextInterceptor.ts
+++ b/src/test/utils/TextInterceptor.ts
@@ -7,6 +7,7 @@ export default class TextInterceptor {
   }
 
   showText(text: string, delay?: integer, callback?: Function, callbackDelay?: integer, prompt?: boolean, promptDelay?: integer): void {
+    console.log(text);
     this.logs.push(text);
   }
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This PR introduces a fix to the handling of the PostSummonPhase for abilities like Intimidate and entry hazards. It ensures that the phase is triggered correctly after a Pokémon is switched into battle.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
### Before:
- The PostSummonPhase for the opponent was triggered prematurely, causing issues with ability and entry hazard activation.
- A solution was implemented, but did not work for subsequent switches.

### After:
- Introduced a conditional phase execution mechanism.
- The PostSummonPhase is now queued and only executed when specific conditions (like the correct number of Pokémon on the field) are met.
- This ensures abilities like Intimidate and entry hazards trigger correctly after switches.

### Screenshots/Videos
![webstorm64_qSUF6IKmmf](https://github.com/pagefaultgames/pokerogue/assets/44787002/5679f0c6-4c3e-4c4b-96f4-15dcf435b451)
![webstorm64_fms8eDtfAT](https://github.com/pagefaultgames/pokerogue/assets/44787002/0f0503e3-79ad-4a5a-96ec-0d9ef8a44db0)


## How to test the changes?
Run all unit tests (`npm run test`) to ensure no existing functionality is broken.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes? (N/A)
