### PR TITLE
[Feature] Add Missing Champion Dialogue

### DIFF
--- a/src/data/dialogue.ts
+++ b/src/data/dialogue.ts
@@ -2301,6 +2301,17 @@ export const trainerTypeDialogue: TrainerTypeDialogue = {
       "dialogue:alder.defeat.1"
     ]
   },
+  [TrainerType.KIERAN]: {
+    encounter: [
+      "dialogue:kieran.encounter.1"
+    ],
+    victory: [
+      "dialogue:kieran.victory.1"
+    ],
+    defeat: [
+      "dialogue:kieran.defeat.1"
+    ]
+  },
   [TrainerType.RIVAL]: [
     {
       encounter: [

--- a/src/data/dialogue.ts
+++ b/src/data/dialogue.ts
@@ -2290,6 +2290,17 @@ export const trainerTypeDialogue: TrainerTypeDialogue = {
       "dialogue:raihan_elite.defeat.2"
     ]
   },
+  [TrainerType.ALDER]: {
+    encounter: [
+      "dialogue:alder.encounter.1"
+    ],
+    victory: [
+      "dialogue:alder.victory.1"
+    ],
+    defeat: [
+      "dialogue:alder.defeat.1"
+    ]
+  },
   [TrainerType.RIVAL]: [
     {
       encounter: [

--- a/src/locales/de/dialogue.ts
+++ b/src/locales/de/dialogue.ts
@@ -2349,6 +2349,32 @@ export const PGMdialogue: DialogueTranslationEntries = {
       2: "Du bist in meinen Sturm geraten! Viel Glück beim nächsten Mal!"
     }
   },
+  "alder": {
+    "encounter": {
+      1: "Prepare yourself for a match against the strongest Trainer in Unova!"
+    },
+    "victory": {
+      1: "Well done! You certainly are an unmatched talent."
+    },
+    "defeat": {
+      1: `A fresh wind blows through my heart...
+          $What an extraordinary effort!`
+    }
+  },
+  "kieran": {
+    "encounter": {
+      1: `Through hard work, I become stronger and stronger!
+          $I don't lose.`
+    },
+    "victory": {
+      1: `I don't believe it...
+          $What a fun and heart-pounding battle!`
+    },
+    "defeat": {
+      1: `Wowzers, what a battle!
+          $Time for you to train even harder.`
+    }
+  },
 
   "rival": {
     "encounter": {

--- a/src/locales/en/dialogue.ts
+++ b/src/locales/en/dialogue.ts
@@ -2292,10 +2292,21 @@ export const PGMdialogue: DialogueTranslationEntries = {
       1: "Prepare yourself for a match against the strongest Trainer in Unova!"
     },
     "victory": {
-      1: "Well done! You certainly are an unmatched talent"
+      1: "Well done! You certainly are an unmatched talent."
     },
     "defeat": {
       1: "A fresh wind blows through my heart... What an extraordinary effort!"
+    }
+  },
+  "kieran": {
+    "encounter": {
+      1: "Through hard work, I become stronger and stronger! I don't lose."
+    },
+    "victory": {
+      1: "I don't believe it... What a fun and heart-punding battle!"
+    },
+    "defeat": {
+      1: "Wowzers, what a battle! Time for you to train even harder."
     }
   },
   "rival": {

--- a/src/locales/en/dialogue.ts
+++ b/src/locales/en/dialogue.ts
@@ -2295,18 +2295,22 @@ export const PGMdialogue: DialogueTranslationEntries = {
       1: "Well done! You certainly are an unmatched talent."
     },
     "defeat": {
-      1: "A fresh wind blows through my heart... What an extraordinary effort!"
+      1: `A fresh wind blows through my heart...
+          $What an extraordinary effort!`
     }
   },
   "kieran": {
     "encounter": {
-      1: "Through hard work, I become stronger and stronger! I don't lose."
+      1: `Through hard work, I become stronger and stronger!
+          $I don't lose.`
     },
     "victory": {
-      1: "I don't believe it... What a fun and heart-punding battle!"
+      1: `I don't believe it...
+          $What a fun and heart-punding battle!`
     },
     "defeat": {
-      1: "Wowzers, what a battle! Time for you to train even harder."
+      1: `Wowzers, what a battle!
+          $Time for you to train even harder.`
     }
   },
   "rival": {

--- a/src/locales/en/dialogue.ts
+++ b/src/locales/en/dialogue.ts
@@ -2287,6 +2287,17 @@ export const PGMdialogue: DialogueTranslationEntries = {
       2: "You got caught in my storm! Better luck next time!"
     }
   },
+  "alder": {
+    "encounter": {
+      1: "Prepare yourself for a match against the strongest Trainer in Unova!"
+    },
+    "victory": {
+      1: "Well done! You certainly are an unmatched talent"
+    },
+    "defeat": {
+      1: "A fresh wind blows through my heart... What an extraordinary effort!"
+    }
+  },
   "rival": {
     "encounter": {
       1: `@c{smile}Hey, I was looking for you! I knew you were eager to get going but I expected at least a goodbye…

--- a/src/locales/en/dialogue.ts
+++ b/src/locales/en/dialogue.ts
@@ -2306,7 +2306,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
     },
     "victory": {
       1: `I don't believe it...
-          $What a fun and heart-punding battle!`
+          $What a fun and heart-pounding battle!`
     },
     "defeat": {
       1: `Wowzers, what a battle!

--- a/src/locales/es/dialogue.ts
+++ b/src/locales/es/dialogue.ts
@@ -2107,6 +2107,32 @@ export const PGMdialogue: DialogueTranslationEntries = {
       2: "You got caught in my storm! Better luck next time!"
     }
   },
+  "alder": {
+    "encounter": {
+      1: "Prepare yourself for a match against the strongest Trainer in Unova!"
+    },
+    "victory": {
+      1: "Well done! You certainly are an unmatched talent."
+    },
+    "defeat": {
+      1: `A fresh wind blows through my heart...
+          $What an extraordinary effort!`
+    }
+  },
+  "kieran": {
+    "encounter": {
+      1: `Through hard work, I become stronger and stronger!
+          $I don't lose.`
+    },
+    "victory": {
+      1: `I don't believe it...
+          $What a fun and heart-pounding battle!`
+    },
+    "defeat": {
+      1: `Wowzers, what a battle!
+          $Time for you to train even harder.`
+    }
+  },
   "rival": {
     "encounter": {
       1: `@c{smile}Hey, I was looking for you! I knew you were eager to get going but I expected at least a goodbye…

--- a/src/locales/fr/dialogue.ts
+++ b/src/locales/fr/dialogue.ts
@@ -2107,6 +2107,32 @@ export const PGMdialogue: DialogueTranslationEntries = {
       2: "You got caught in my storm! Better luck next time!"
     }
   },
+  "alder": {
+    "encounter": {
+      1: "Prepare yourself for a match against the strongest Trainer in Unova!"
+    },
+    "victory": {
+      1: "Well done! You certainly are an unmatched talent."
+    },
+    "defeat": {
+      1: `A fresh wind blows through my heart...
+          $What an extraordinary effort!`
+    }
+  },
+  "kieran": {
+    "encounter": {
+      1: `Through hard work, I become stronger and stronger!
+          $I don't lose.`
+    },
+    "victory": {
+      1: `I don't believe it...
+          $What a fun and heart-pounding battle!`
+    },
+    "defeat": {
+      1: `Wowzers, what a battle!
+          $Time for you to train even harder.`
+    }
+  },
   "rival": {
     "encounter": {
 	  1: `@c{smile}Ah, je te cherchais ! Je savais que t’étais pressée de partir, mais je m’attendais quand même à un au revoir…

--- a/src/locales/it/dialogue.ts
+++ b/src/locales/it/dialogue.ts
@@ -2107,6 +2107,32 @@ export const PGMdialogue: DialogueTranslationEntries = {
       2: "You got caught in my storm! Better luck next time!"
     }
   },
+  "alder": {
+    "encounter": {
+      1: "Prepare yourself for a match against the strongest Trainer in Unova!"
+    },
+    "victory": {
+      1: "Well done! You certainly are an unmatched talent."
+    },
+    "defeat": {
+      1: `A fresh wind blows through my heart...
+          $What an extraordinary effort!`
+    }
+  },
+  "kieran": {
+    "encounter": {
+      1: `Through hard work, I become stronger and stronger!
+          $I don't lose.`
+    },
+    "victory": {
+      1: `I don't believe it...
+          $What a fun and heart-pounding battle!`
+    },
+    "defeat": {
+      1: `Wowzers, what a battle!
+          $Time for you to train even harder.`
+    }
+  },
   "rival": {
     "encounter": {
       1: `@c{smile}Hey, I was looking for you! I knew you were eager to get going but I expected at least a goodbye…

--- a/src/locales/ko/dialogue.ts
+++ b/src/locales/ko/dialogue.ts
@@ -2287,6 +2287,32 @@ export const PGMdialogue: DialogueTranslationEntries = {
       2: "You got caught in my storm! Better luck next time!"
     }
   },
+  "alder": {
+    "encounter": {
+      1: "Prepare yourself for a match against the strongest Trainer in Unova!"
+    },
+    "victory": {
+      1: "Well done! You certainly are an unmatched talent."
+    },
+    "defeat": {
+      1: `A fresh wind blows through my heart...
+          $What an extraordinary effort!`
+    }
+  },
+  "kieran": {
+    "encounter": {
+      1: `Through hard work, I become stronger and stronger!
+          $I don't lose.`
+    },
+    "victory": {
+      1: `I don't believe it...
+          $What a fun and heart-pounding battle!`
+    },
+    "defeat": {
+      1: `Wowzers, what a battle!
+          $Time for you to train even harder.`
+    }
+  },
   "rival": {
     "encounter": {
       1: `@c{smile}오, 찾았다! 떠나려는 건 알고 있었지만\n인사정도는 해줄 줄 알았는데…

--- a/src/locales/pt_BR/dialogue.ts
+++ b/src/locales/pt_BR/dialogue.ts
@@ -2096,6 +2096,32 @@ export const PGMdialogue: DialogueTranslationEntries = {
       2: "Você foi pego na minha tempestade! Melhor sorte na próxima vez!"
     }
   },
+  "alder": {
+    "encounter": {
+      1: "Prepare yourself for a match against the strongest Trainer in Unova!"
+    },
+    "victory": {
+      1: "Well done! You certainly are an unmatched talent."
+    },
+    "defeat": {
+      1: `A fresh wind blows through my heart...
+          $What an extraordinary effort!`
+    }
+  },
+  "kieran": {
+    "encounter": {
+      1: `Through hard work, I become stronger and stronger!
+          $I don't lose.`
+    },
+    "victory": {
+      1: `I don't believe it...
+          $What a fun and heart-pounding battle!`
+    },
+    "defeat": {
+      1: `Wowzers, what a battle!
+          $Time for you to train even harder.`
+    }
+  },
   "rival": {
     "encounter": {
       1: `@c{smile}Eai, estava procurando você! Sabia que você estava ansioso para começar, mas esperava pelo menos um tchau…

--- a/src/locales/zh_CN/dialogue.ts
+++ b/src/locales/zh_CN/dialogue.ts
@@ -2007,6 +2007,32 @@ export const PGMdialogue: DialogueTranslationEntries = {
       2: "你被我的风暴卷入了！祝你下次好运！",
     }
   },
+  "alder": {
+    "encounter": {
+      1: "Prepare yourself for a match against the strongest Trainer in Unova!"
+    },
+    "victory": {
+      1: "Well done! You certainly are an unmatched talent."
+    },
+    "defeat": {
+      1: `A fresh wind blows through my heart...
+          $What an extraordinary effort!`
+    }
+  },
+  "kieran": {
+    "encounter": {
+      1: `Through hard work, I become stronger and stronger!
+          $I don't lose.`
+    },
+    "victory": {
+      1: `I don't believe it...
+          $What a fun and heart-pounding battle!`
+    },
+    "defeat": {
+      1: `Wowzers, what a battle!
+          $Time for you to train even harder.`
+    }
+  },
   "rival": {
     "encounter": {
       1: "@c{smile}嘿，我在找你呢！我知道你急着上路，\n但至少说个再见吧…$@c{smile_eclosed}所以你终于要开始追逐梦想了？\n我几乎不敢相信。$@c{serious_smile_fists}来都来了，来一场对战怎么样？\n毕竟，我想看看你是不是准备周全了。$@c{serious_mopen_fists}不要手下留情，我想让你全力以赴！",

--- a/src/locales/zh_TW/dialogue.ts
+++ b/src/locales/zh_TW/dialogue.ts
@@ -2007,6 +2007,32 @@ export const PGMdialogue: DialogueTranslationEntries = {
       2: "你被我的風暴捲入了！祝你下次好運！",
     }
   },
+  "alder": {
+    "encounter": {
+      1: "Prepare yourself for a match against the strongest Trainer in Unova!"
+    },
+    "victory": {
+      1: "Well done! You certainly are an unmatched talent."
+    },
+    "defeat": {
+      1: `A fresh wind blows through my heart...
+          $What an extraordinary effort!`
+    }
+  },
+  "kieran": {
+    "encounter": {
+      1: `Through hard work, I become stronger and stronger!
+          $I don't lose.`
+    },
+    "victory": {
+      1: `I don't believe it...
+          $What a fun and heart-pounding battle!`
+    },
+    "defeat": {
+      1: `Wowzers, what a battle!
+          $Time for you to train even harder.`
+    }
+  },
   "rival": {
     "encounter": {
       1: "@c{smile}嘿，我在找你呢！我知道你急著上路，\n但至少說個再見吧…$@c{smile_eclosed}所以你終於要開始追逐夢想了？\n我幾乎不敢相信。$@c{serious_smile_fists}來都來了，來一場對戰怎麼樣？\n畢竟，我想看看你是不是準備周全了。$@c{serious_mopen_fists}不要手下留情，我想讓你全力以赴！",


### PR DESCRIPTION
## What are the changes?
1. Add missing dialogue for Alder Champion encounter.
2. Add missing dialogue for Kieran Champion encounter.

## Why am I doing these changes?
1. Alder and Kieran were missing dialogue making their encounters in Classic mode bland (and weird).

## What did change?
1. Now when Alder or Kieran are encountered as the Champion, the dialogue should carry out as normal.

### Screenshots/Videos
![image](https://github.com/pagefaultgames/pokerogue/assets/6127618/7287ca5c-2e48-49d5-8e28-2ccd0856a91e)
![image](https://github.com/pagefaultgames/pokerogue/assets/6127618/abeb33a4-270d-4ce2-8684-f893de968a44)


## How to test the changes?
1. overrides.ts:
```export const STARTING_WAVE_OVERRIDE: integer = 190;```
2. Kieran session:
[kieran.txt](https://github.com/user-attachments/files/15799833/kieran.txt)
3. Alder session:
[alder.txt](https://github.com/user-attachments/files/15799964/alder.txt)


## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?