### PR TITLE
[Localization] [ES] Fainted Pokemon localization

### DIFF
--- a/src/locales/es/battle.ts
+++ b/src/locales/es/battle.ts
@@ -61,5 +61,5 @@ export const battle: SimpleTranslationEntries = {
   "useMove": "¡{{pokemonNameWithAffix}} usó {{moveName}}!",
   "drainMessage": "¡{{pokemonName}} tuvo su\nenergía absorbida!",
   "regainHealth": "¡{{pokemonName}} recuperó\nPS!",
-  "fainted": "{{pokemonNameWithAffix}} fainted!"
+  "fainted": "¡El {{pokemonNameWithAffix}} se debilitó!"
 } as const;


### PR DESCRIPTION
## What are the changes?
-Updated battle.ts

## Why am I doing these changes?
I decided to introduce these changes to improve the overall user experience, particularly for Spanish-speaking players who may not understand English well.

## What did change?
Translated fainted pokemon.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?