### PR TITLE
[Localization] Italian achievements (achv.ts)

### DIFF
--- a/src/locales/it/ability-trigger.ts
+++ b/src/locales/it/ability-trigger.ts
@@ -3,6 +3,6 @@ import { SimpleTranslationEntries } from "#app/plugins/i18n";
 export const abilityTriggers: SimpleTranslationEntries = {
   "blockRecoilDamage" : "{{abilityName}} di {{pokemonName}}\nl'ha protetto dal contraccolpo!",
   "badDreams": "{{pokemonName}} è tormentato!",
-  "windPowerCharged": "Being hit by {{moveName}} charged {{pokemonName}} with power!",
-  "iceFaceAvoidedDamage": "{{pokemonName}} avoided\ndamage with {{abilityName}}!"
+  "windPowerCharged": "{{moveName}} carica {{pokemonName}} di potenza!",
+  "iceFaceAvoidedDamage": "{{pokemonName}} evita il \ndanno con {{abilityName}}!"
 } as const;

--- a/src/locales/it/ability-trigger.ts
+++ b/src/locales/it/ability-trigger.ts
@@ -3,6 +3,6 @@ import { SimpleTranslationEntries } from "#app/plugins/i18n";
 export const abilityTriggers: SimpleTranslationEntries = {
   "blockRecoilDamage" : "{{abilityName}} di {{pokemonName}}\nl'ha protetto dal contraccolpo!",
   "badDreams": "{{pokemonName}} è tormentato!",
-  "windPowerCharged": "{{moveName}} carica {{pokemonName}} di potenza!",
-  "iceFaceAvoidedDamage": "{{pokemonName}} evita il \ndanno con {{abilityName}}!"
+  "windPowerCharged": "Being hit by {{moveName}} charged {{pokemonName}} with power!",
+  "iceFaceAvoidedDamage": "{{pokemonName}} avoided\ndamage with {{abilityName}}!"
 } as const;

--- a/src/locales/it/achv.ts
+++ b/src/locales/it/achv.ts
@@ -13,7 +13,7 @@ export const PGMachv: AchievementTranslationEntries = {
     description: "Accumula ₽{{moneyAmount}} PokéDollari",
   },
   "10K_MONEY": {
-    name: "Coi Soldi",
+    name: "Benestante",
   },
   "100K_MONEY": {
     name: "Ricco",
@@ -90,11 +90,11 @@ export const PGMachv: AchievementTranslationEntries = {
   },
 
   "TRANSFER_MAX_BATTLE_STAT": {
-    name: "Teamwork",
+    name: "Lavoro di Squadra",
     description: "Trasferisci almeno sei bonus statistiche tramite staffetta",
   },
   "MAX_FRIENDSHIP": {
-    name: "Amiciziando",
+    name: "Amiconi",
     description: "Raggiungi amicizia massima con un Pokémon",
   },
   "MEGA_EVOLVE": {
@@ -102,7 +102,7 @@ export const PGMachv: AchievementTranslationEntries = {
     description: "Megaevolvi un pokémon",
   },
   "GIGANTAMAX": {
-    name: "Absolute Unit",
+    name: "Grosso e Cattivo",
     description: "Ottieni una gigamax",
   },
   "TERASTALLIZE": {
@@ -110,7 +110,7 @@ export const PGMachv: AchievementTranslationEntries = {
     description: "Teracristallizza un Pokémon",
   },
   "STELLAR_TERASTALLIZE": {
-    name: "Un Tipo Segreto",
+    name: "Tipo Segreto",
     description: "Teracristallizza un Pokémon stellare",
   },
   "SPLICE": {
@@ -130,11 +130,11 @@ export const PGMachv: AchievementTranslationEntries = {
     description: "Cattura un Pokémon semileggendario",
   },
   "CATCH_LEGENDARY": {
-    name: "Legendary",
+    name: "Leggendario",
     description: "Cattura un Pokémon leggendario",
   },
   "SEE_SHINY": {
-    name: "Shiny",
+    name: "Cromatico",
     description: "Trova un Pokémon shiny in natura",
   },
   "SHINY_PARTY": {
@@ -259,7 +259,7 @@ export const PGMachv: AchievementTranslationEntries = {
     name: "Mono DRAGO",
   },
   "MONO_DARK": {
-    name: "Non è solo una fase!",
+    name: "Solo una fase",
   },
   "MONO_FAIRY": {
     name: "Mono FATA",

--- a/src/locales/it/achv.ts
+++ b/src/locales/it/achv.ts
@@ -22,20 +22,20 @@ export const PGMachv: AchievementTranslationEntries = {
     name: "Milionario",
   },
   "10M_MONEY": {
-    name: "Nell'un percento",
+    name: "L'Un Percento",
   },
 
   "DamageAchv": {
     description: "Infliggi {{damageAmount}} danno in un colpo",
   },
   "250_DMG": {
-    name: "Gran danni!",
+    name: "Gran Danni!",
   },
   "1000_DMG": {
-    name: "Incredibili danni",
+    name: "Incredibili Danni",
   },
   "2500_DMG": {
-    name: "Danni a palate!",
+    name: "Danni a Palate!",
   },
   "10000_DMG": {
     name: "One Punch Man",
@@ -61,17 +61,17 @@ export const PGMachv: AchievementTranslationEntries = {
     description: "Porta un pokémon a Lv{{level}}",
   },
   "LV_100": {
-    name: "E non finisce qui!",
+    name: "E Non Finisce Qui!",
   },
   "LV_250": {
     name: "Elite",
   },
   "LV_1000": {
-    name: "Verso l'infinito ed oltre!",
+    name: "Verso l'Infinito ed Oltre!",
   },
 
   "RibbonAchv": {
-    description: "Accumula un totale di {{ribbonAmount}} Nastri",
+    description: "Accumula un Totale di {{ribbonAmount}} Nastri",
   },
   "10_RIBBONS": {
     name: "Campione Lega Pokémon",
@@ -98,7 +98,7 @@ export const PGMachv: AchievementTranslationEntries = {
     description: "Raggiungi amicizia massima con un Pokémon",
   },
   "MEGA_EVOLVE": {
-    name: "Megamorph",
+    name: "Megamorfosi",
     description: "Megaevolvi un pokémon",
   },
   "GIGANTAMAX": {
@@ -118,7 +118,7 @@ export const PGMachv: AchievementTranslationEntries = {
     description: "Fondi due Pokémon insieme tramite cuneo DNA",
   },
   "MINI_BLACK_HOLE": {
-    name: "Universo di oggetti",
+    name: "Universo di Oggetti",
     description: "Ottieni un Mini Buco Nero",
   },
   "CATCH_MYTHICAL": {
@@ -126,7 +126,7 @@ export const PGMachv: AchievementTranslationEntries = {
     description: "Cattura un Pokémon mitico",
   },
   "CATCH_SUB_LEGENDARY": {
-    name: "(Semi-)Leggendario",
+    name: "(Semi)Leggendario",
     description: "Cattura un Pokémon semileggendario",
   },
   "CATCH_LEGENDARY": {
@@ -146,7 +146,7 @@ export const PGMachv: AchievementTranslationEntries = {
     description: "Schiudi l'uovo di un Pokémon mitico",
   },
   "HATCH_SUB_LEGENDARY": {
-    name:  "Uovo (Semi-)Leggendario",
+    name:  "Uovo (Semi)Leggendario",
     description: "Schiudi l'uovo di un Pokémon semileggendario",
   },
   "HATCH_LEGENDARY": {
@@ -154,7 +154,7 @@ export const PGMachv: AchievementTranslationEntries = {
     description: "Schiudi l'uovo di un Pokémon leggendario",
   },
   "HATCH_SHINY": {
-    name: "Uovo Shiny",
+    name: "Uovo Cromatico",
     description: "Schiudi l'uovo di un Pokémon shiny",
   },
   "HIDDEN_ABILITY": {
@@ -171,7 +171,7 @@ export const PGMachv: AchievementTranslationEntries = {
   },
 
   "MONO_GEN_ONE": {
-    name: "Il Rivale Originale",
+    name: "Rivale Originale",
     description: "Completa la modalità sfida generazione uno.",
   },
   "MONO_GEN_TWO": {
@@ -179,11 +179,11 @@ export const PGMachv: AchievementTranslationEntries = {
     description: "Completa la modalità sfida generazione due.",
   },
   "MONO_GEN_THREE": {
-    name: "Troppa acqua?",
+    name: "Troppa Acqua?",
     description: "Completa la modalità sfida generazione tre.",
   },
   "MONO_GEN_FOUR": {
-    name: "È veramente lei la più forte?",
+    name: "È Davvero La Più Forte?",
     description: "Completa la modalità sfida generazione quattro.",
   },
   "MONO_GEN_FIVE": {
@@ -203,7 +203,7 @@ export const PGMachv: AchievementTranslationEntries = {
     description:  "Completa la modalità sfida generazione otto.",
   },
   "MONO_GEN_NINE": {
-    name: "Non si stava impegnando",
+    name: "Non si Stava Impegnando...",
     description:  "Completa la modalità sfida generazione nove.",
   },
 
@@ -229,10 +229,10 @@ export const PGMachv: AchievementTranslationEntries = {
     name: "Brock-o Forte!",
   },
   "MONO_BUG": {
-    name: "Pungi come un Beedrill",
+    name: "Pungi Come un Beedrill",
   },
   "MONO_GHOST": {
-    name: "Chi chiamerai?",
+    name: "Chi Chiamerai?",
   },
   "MONO_STEEL": {
     name: "Mono ACCIAIO",
@@ -241,7 +241,7 @@ export const PGMachv: AchievementTranslationEntries = {
     name: "Mono FUOCO",
   },
   "MONO_WATER": {
-    name: "Se piove diluvia",
+    name: "Piove Sempre Sul Bagnato",
   },
   "MONO_GRASS": {
     name: "Mono ERBA",

--- a/src/locales/it/achv.ts
+++ b/src/locales/it/achv.ts
@@ -3,266 +3,266 @@ import { AchievementTranslationEntries } from "#app/plugins/i18n.js";
 // Achievement translations for the when the player character is male
 export const PGMachv: AchievementTranslationEntries = {
   "Achievements": {
-    name: "Achievements",
+    name: "Trofei",
   },
   "Locked": {
-    name: "Locked",
+    name: "Bloccato",
   },
 
   "MoneyAchv": {
-    description: "Accumulate a total of ₽{{moneyAmount}}",
+    description: "Accumula ₽{{moneyAmount}} PokéDollari",
   },
   "10K_MONEY": {
-    name: "Money Haver",
+    name: "Coi Soldi",
   },
   "100K_MONEY": {
-    name: "Rich",
+    name: "Ricco",
   },
   "1M_MONEY": {
-    name: "Millionaire",
+    name: "Milionario",
   },
   "10M_MONEY": {
-    name: "One Percenter",
+    name: "Nell'un percento",
   },
 
   "DamageAchv": {
-    description: "Inflict {{damageAmount}} damage in one hit",
+    description: "Infliggi {{damageAmount}} danno in un colpo",
   },
   "250_DMG": {
-    name: "Hard Hitter",
+    name: "Gran danni!",
   },
   "1000_DMG": {
-    name: "Harder Hitter",
+    name: "Incredibili danni",
   },
   "2500_DMG": {
-    name: "That's a Lotta Damage!",
+    name: "Danni a palate!",
   },
   "10000_DMG": {
     name: "One Punch Man",
   },
 
   "HealAchv": {
-    description: "Heal {{healAmount}} {{HP}} at once with a move, ability, or held item",
+    description: "Cura {{healAmount}} {{HP}} tramite mossa, abilità, o oggetto",
   },
   "250_HEAL": {
-    name: "Novice Healer",
+    name: "Paramedico",
   },
   "1000_HEAL": {
-    name: "Big Healer",
+    name: "Dottore",
   },
   "2500_HEAL": {
-    name: "Cleric",
+    name: "Chierico",
   },
   "10000_HEAL": {
-    name: "Recovery Master",
+    name: "Mastro Curatore",
   },
 
   "LevelAchv": {
-    description: "Level up a Pokémon to Lv{{level}}",
+    description: "Porta un pokémon a Lv{{level}}",
   },
   "LV_100": {
-    name: "But Wait, There's More!",
+    name: "E non finisce qui!",
   },
   "LV_250": {
     name: "Elite",
   },
   "LV_1000": {
-    name: "To Go Even Further Beyond",
+    name: "Verso l'infinito ed oltre!",
   },
 
   "RibbonAchv": {
-    description: "Accumulate a total of {{ribbonAmount}} Ribbons",
+    description: "Accumula un totale di {{ribbonAmount}} Nastri",
   },
   "10_RIBBONS": {
-    name: "Pokémon League Champion",
+    name: "Campione Lega Pokémon",
   },
   "25_RIBBONS": {
-    name: "Great League Champion",
+    name: "Campione Lega Estesa",
   },
   "50_RIBBONS": {
-    name: "Ultra League Champion",
+    name: "Campione Lega Ultra",
   },
   "75_RIBBONS": {
-    name: "Rogue League Champion",
+    name: "Campione Lega Rogue",
   },
   "100_RIBBONS": {
-    name: "Master League Champion",
+    name: "Campione Lega Assoluta",
   },
 
   "TRANSFER_MAX_BATTLE_STAT": {
     name: "Teamwork",
-    description: "Baton pass to another party member with at least one stat maxed out",
+    description: "Trasferisci almeno sei bonus statistiche tramite staffetta",
   },
   "MAX_FRIENDSHIP": {
-    name: "Friendmaxxing",
-    description: "Reach max friendship on a Pokémon",
+    name: "Amiciziando",
+    description: "Raggiungi amicizia massima con un Pokémon",
   },
   "MEGA_EVOLVE": {
     name: "Megamorph",
-    description: "Mega evolve a Pokémon",
+    description: "Megaevolvi un pokémon",
   },
   "GIGANTAMAX": {
     name: "Absolute Unit",
-    description: "Gigantamax a Pokémon",
+    description: "Ottieni una gigamax",
   },
   "TERASTALLIZE": {
-    name: "STAB Enthusiast",
-    description: "Terastallize a Pokémon",
+    name: "STAB Per Tutti",
+    description: "Teracristallizza un Pokémon",
   },
   "STELLAR_TERASTALLIZE": {
-    name: "The Hidden Type",
-    description: "Stellar Terastallize a Pokémon",
+    name: "Un Tipo Segreto",
+    description: "Teracristallizza un Pokémon stellare",
   },
   "SPLICE": {
-    name: "Infinite Fusion",
-    description: "Splice two Pokémon together with DNA Splicers",
+    name: "Fusione Infinita",
+    description: "Fondi due Pokémon insieme tramite cuneo DNA",
   },
   "MINI_BLACK_HOLE": {
-    name: "A Hole Lot of Items",
-    description: "Acquire a Mini Black Hole",
+    name: "Universo di oggetti",
+    description: "Ottieni un Mini Buco Nero",
   },
   "CATCH_MYTHICAL": {
-    name: "Mythical",
-    description: "Catch a mythical Pokémon",
+    name: "Mitico",
+    description: "Cattura un Pokémon mitico",
   },
   "CATCH_SUB_LEGENDARY": {
-    name: "(Sub-)Legendary",
-    description: "Catch a sub-legendary Pokémon",
+    name: "(Semi-)Leggendario",
+    description: "Cattura un Pokémon semileggendario",
   },
   "CATCH_LEGENDARY": {
     name: "Legendary",
-    description: "Catch a legendary Pokémon",
+    description: "Cattura un Pokémon leggendario",
   },
   "SEE_SHINY": {
     name: "Shiny",
-    description: "Find a shiny Pokémon in the wild",
+    description: "Trova un Pokémon shiny in natura",
   },
   "SHINY_PARTY": {
-    name: "That's Dedication",
-    description: "Have a full party of shiny Pokémon",
+    name: "Dedizione Totale",
+    description: "Riempi la squadra di Pokémon shiny",
   },
   "HATCH_MYTHICAL": {
-    name: "Mythical Egg",
-    description: "Hatch a mythical Pokémon from an egg",
+    name: "Uovo Mitico",
+    description: "Schiudi l'uovo di un Pokémon mitico",
   },
   "HATCH_SUB_LEGENDARY": {
-    name: "Sub-Legendary Egg",
-    description: "Hatch a sub-legendary Pokémon from an egg",
+    name:  "Uovo (Semi-)Leggendario",
+    description: "Schiudi l'uovo di un Pokémon semileggendario",
   },
   "HATCH_LEGENDARY": {
-    name: "Legendary Egg",
-    description: "Hatch a legendary Pokémon from an egg",
+    name: "Uovo Leggendario",
+    description: "Schiudi l'uovo di un Pokémon leggendario",
   },
   "HATCH_SHINY": {
-    name: "Shiny Egg",
-    description: "Hatch a shiny Pokémon from an egg",
+    name: "Uovo Shiny",
+    description: "Schiudi l'uovo di un Pokémon shiny",
   },
   "HIDDEN_ABILITY": {
-    name: "Hidden Potential",
-    description: "Catch a Pokémon with a hidden ability",
+    name: "Potenziale Nascosto",
+    description: "Cattura un Pokémon con abilità nascosta",
   },
   "PERFECT_IVS": {
-    name: "Certificate of Authenticity",
-    description: "Get perfect IVs on a Pokémon",
+    name: "Certificato di Autenticità",
+    description: "Ottieni un Pokémon con IV perfetti",
   },
   "CLASSIC_VICTORY": {
-    name: "Undefeated",
-    description: "Beat the game in classic mode",
+    name: "Imbattuto",
+    description: "Vinci in modalità classica",
   },
 
   "MONO_GEN_ONE": {
-    name: "The Original Rival",
-    description: "Complete the generation one only challenge.",
+    name: "Il Rivale Originale",
+    description: "Completa la modalità sfida generazione uno.",
   },
   "MONO_GEN_TWO": {
-    name: "Generation 1.5",
-    description: "Complete the generation two only challenge.",
+    name: "Generazione 1.5",
+    description: "Completa la modalità sfida generazione due.",
   },
   "MONO_GEN_THREE": {
-    name: "Too much water?",
-    description: "Complete the generation three only challenge.",
+    name: "Troppa acqua?",
+    description: "Completa la modalità sfida generazione tre.",
   },
   "MONO_GEN_FOUR": {
-    name: "Is she really the hardest?",
-    description: "Complete the generation four only challenge.",
+    name: "È veramente lei la più forte?",
+    description: "Completa la modalità sfida generazione quattro.",
   },
   "MONO_GEN_FIVE": {
-    name: "All Original",
-    description: "Complete the generation five only challenge.",
+    name: "Tutti Originali",
+    description: "Completa la modalità sfida generazione cinque.",
   },
   "MONO_GEN_SIX": {
-    name: "Almost Royalty",
-    description: "Complete the generation six only challenge.",
+    name: "Quasi Reali",
+    description: "Completa la modalità sfida generazione sei.",
   },
   "MONO_GEN_SEVEN": {
-    name: "Only Technically",
-    description: "Complete the generation seven only challenge.",
+    name: "Solo In Teoria",
+    description:  "Completa la modalità sfida generazione sette.",
   },
   "MONO_GEN_EIGHT": {
-    name: "A Champion Time!",
-    description: "Complete the generation eight only challenge.",
+    name: "È Champion-time!",
+    description:  "Completa la modalità sfida generazione otto.",
   },
   "MONO_GEN_NINE": {
-    name: "She was going easy on you",
-    description: "Complete the generation nine only challenge.",
+    name: "Non si stava impegnando",
+    description:  "Completa la modalità sfida generazione nove.",
   },
 
   "MonoType": {
-    description: "Complete the {{type}} monotype challenge.",
+    description: "Completa la modalità sfida monotipo {{type}}",
   },
   "MONO_NORMAL": {
-    name: "Mono NORMAL",
+    name: "Mono NORMALE",
   },
   "MONO_FIGHTING": {
-    name: "I Know Kung Fu",
+    name: "Conosco il Kung-fu",
   },
   "MONO_FLYING": {
-    name: "Mono FLYING",
+    name: "Mono VOLANTE",
   },
   "MONO_POISON": {
-    name: "Kanto's Favourite",
+    name: "I migliori di Kanto",
   },
   "MONO_GROUND": {
-    name: "Mono GROUND",
+    name: "Mono TERRA",
   },
   "MONO_ROCK": {
-    name: "Brock Hard",
+    name: "Brock-o Forte!",
   },
   "MONO_BUG": {
-    name: "Sting Like A Beedrill",
+    name: "Pungi come un Beedrill",
   },
   "MONO_GHOST": {
-    name: "Who you gonna call?",
+    name: "Chi chiamerai?",
   },
   "MONO_STEEL": {
-    name: "Mono STEEL",
+    name: "Mono ACCIAIO",
   },
   "MONO_FIRE": {
-    name: "Mono FIRE",
+    name: "Mono FUOCO",
   },
   "MONO_WATER": {
-    name: "When It Rains, It Pours",
+    name: "Se piove diluvia",
   },
   "MONO_GRASS": {
-    name: "Mono GRASS",
+    name: "Mono ERBA",
   },
   "MONO_ELECTRIC": {
-    name: "Mono ELECTRIC",
+    name: "Mono ELETTRO",
   },
   "MONO_PSYCHIC": {
-    name: "Mono PSYCHIC",
+    name: "Mono PSICO",
   },
   "MONO_ICE": {
-    name: "Mono ICE",
+    name: "Mono GHIACCIO",
   },
   "MONO_DRAGON": {
-    name: "Mono DRAGON",
+    name: "Mono DRAGO",
   },
   "MONO_DARK": {
-    name: "It's just a phase",
+    name: "Non è solo una fase!",
   },
   "MONO_FAIRY": {
-    name: "Mono FAIRY",
+    name: "Mono FATA",
   },
 } as const;
 

--- a/src/locales/it/menu-ui-handler.ts
+++ b/src/locales/it/menu-ui-handler.ts
@@ -2,7 +2,7 @@ import { SimpleTranslationEntries } from "#app/plugins/i18n";
 
 export const menuUiHandler: SimpleTranslationEntries = {
   "GAME_SETTINGS": "Impostazioni",
-  "ACHIEVEMENTS": "Risultati",
+  "ACHIEVEMENTS": "Trofei",
   "STATS": "Statistiche",
   "VOUCHERS": "Biglietti",
   "EGG_LIST": "Lista Uova",


### PR DESCRIPTION
# [Localization] Italian achievements (achv.ts)
## What are the changes?
Achievements now localized in Italian.
Changed the main menu "Risultati" to "Trofei" as "Risultati" is more akin to "consequences" in Italian.

Context on "Trofei" change
The translation was needed in achv.ts and my professional opinion is that "Risultati" is a bit ambiguous in this instance.
As Achievements is not directly translatable (e.g. Steam keeps it in English) I would advise against using "risultati" here as a user would not know what happens when they select it.

## Why am I doing these changes?
As a professional translator and developer, I'm hoping to be able to contribute to this awesome project, by providing some simple PR for translation before maybe getting involved with some new features in the future. 
Feel free to reach out about it.

## What did change?
All of the achievements in  src/locales/it/achv.ts translated to italian

### Screenshots/Videos
![immagine](https://github.com/pagefaultgames/pokerogue/assets/124930934/300490d5-fb8d-4d4d-a8c2-0c77beb28021)

## How to test the changes?
Switch to Italian language, go to the "trofei" menu voice

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?