### PR TITLE
[Localization][es] Update Spanish ability bar and fix fainted localization 

### DIFF
--- a/src/locales/es/battle.ts
+++ b/src/locales/es/battle.ts
@@ -61,5 +61,5 @@ export const battle: SimpleTranslationEntries = {
   "useMove": "¡{{pokemonNameWithAffix}} usó {{moveName}}!",
   "drainMessage": "¡{{pokemonName}} tuvo su\nenergía absorbida!",
   "regainHealth": "¡{{pokemonName}} recuperó\nPS!",
-  "fainted": "¡El {{pokemonNameWithAffix}} se debilitó!"
+  "fainted": "¡{{pokemonNameWithAffix}} se debilitó!"
 } as const;

--- a/src/locales/es/fight-ui-handler.ts
+++ b/src/locales/es/fight-ui-handler.ts
@@ -4,6 +4,6 @@ export const fightUiHandler: SimpleTranslationEntries = {
   "pp": "PP",
   "power": "Potencia",
   "accuracy": "Precisión",
-  "abilityFlyInText": " {{pokemonName}}'s {{passive}}{{abilityName}}",
-  "passive": "Passive ", // The space at the end is important
+  "abilityFlyInText": " {{passive}}{{pokemonName}}\n{{abilityName}}",
+  "passive": "Pasiva de ", // The space at the end is important
 } as const;


### PR DESCRIPTION
## What are the changes?
-Update battle.ts
-Update fight-ui-handler

## Why am I doing these changes?
I decided to introduce these changes to improve the overall user experience, particularly for Spanish-speaking players who may not understand English well.

## What did change?
Fix fainted translation
Translations of ability bar

### Screenshots/Videos
![image](https://github.com/pagefaultgames/pokerogue/assets/162721984/fa403a4b-1767-43ee-9aac-ef7eef47e05f)

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?