### PR TITLE
[Enhancement][ui] Fix the display size of inputs

### DIFF
--- a/index.css
+++ b/index.css
@@ -31,6 +31,11 @@ body {
   transform-origin: top !important;
 }
 
+/* Need adjust input font-size */
+input {
+  font-size: 3.2rem;
+}
+
 #touchControls:not(.visible) {
   display: none;
 }
@@ -243,8 +248,4 @@ input:-internal-autofill-selected {
     -webkit-animation: blink normal 4s infinite ease-in-out; /* Webkit */
     -ms-animation: blink normal 4s infinite ease-in-out; /* IE */
     animation: blink normal 4s infinite ease-in-out; /* Opera and prob css3 final iteration */
-}
-
-input {
-  font-size: 16px;
 }


### PR DESCRIPTION
## What are the changes?
Fix the display size of inputs which is MUCH too small, and should be dependent on screen size rather than a fixed value

## What did change?
Replaces the value in fixed units with a relative unit in `index.css`

### Screenshots/Videos
> Before
![image](https://github.com/pagefaultgames/pokerogue/assets/8146474/5e32ba9b-600b-478c-aa4f-64790b4bb56a)

> After
![image](https://github.com/pagefaultgames/pokerogue/assets/8146474/f06df534-e8dc-45d9-8146-6660bb002349)

## How to test the changes?
By displaying the login page from this branch

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?