### PR TITLE
[Move] Fix type immunities granted by abilities only applying to attacks

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -9,7 +9,7 @@ import { BattlerTag } from "./battler-tags";
 import { BattlerTagType } from "./enums/battler-tag-type";
 import { StatusEffect, getNonVolatileStatusEffects, getStatusEffectDescriptor, getStatusEffectHealText } from "./status-effect";
 import { Gender } from "./gender";
-import Move, { AttackMove, MoveCategory, MoveFlags, MoveTarget, StatusMoveTypeImmunityAttr, FlinchAttr, OneHitKOAttr, HitHealAttr, allMoves, StatusMove, SelfStatusMove, VariablePowerAttr, applyMoveAttrs, IncrementMovePriorityAttr  } from "./move";
+import Move, { AttackMove, MoveCategory, MoveFlags, MoveTarget, FlinchAttr, OneHitKOAttr, HitHealAttr, allMoves, StatusMove, SelfStatusMove, VariablePowerAttr, applyMoveAttrs, IncrementMovePriorityAttr  } from "./move";
 import { ArenaTagSide, ArenaTrapTag } from "./arena-tag";
 import { ArenaTagType } from "./enums/arena-tag-type";
 import { Stat, getStatName } from "./pokemon-stat";
@@ -357,6 +357,7 @@ export class TypeImmunityAbAttr extends PreDefendAbAttr {
   }
 
   /**
+   * Applies immunity if this ability grants immunity to the type of the given move.
    * @param pokemon {@linkcode Pokemon} the defending Pokemon
    * @param passive N/A
    * @param attacker {@linkcode Pokemon} the attacking Pokemon
@@ -366,7 +367,12 @@ export class TypeImmunityAbAttr extends PreDefendAbAttr {
    * @param args [1] {@linkcode Utils.NumberHolder} type of move being defended against in case it has changed from default type
    */
   applyPreDefend(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): boolean {
-    if ((move instanceof AttackMove || move.getAttrs(StatusMoveTypeImmunityAttr).find(attr => attr.immuneType === this.immuneType)) && move.type === this.immuneType) {
+    // Field moves should ignore immunity
+    if ([ MoveTarget.BOTH_SIDES, MoveTarget.ENEMY_SIDE, MoveTarget.USER_SIDE ].includes(move.moveTarget)) {
+      return false;
+    }
+
+    if (move.type === this.immuneType) {
       (args[0] as Utils.NumberHolder).value = 0;
       return true;
     }

--- a/src/test/battle/ability-type-immunity.test.ts
+++ b/src/test/battle/ability-type-immunity.test.ts
@@ -1,0 +1,129 @@
+import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
+import Phaser from "phaser";
+import GameManager from "#app/test/utils/gameManager";
+import * as overrides from "#app/overrides";
+import {Species} from "#app/data/enums/species";
+import {
+  CommandPhase,
+  EnemyCommandPhase, TurnEndPhase,
+} from "#app/phases";
+import {Mode} from "#app/ui/ui";
+import {Moves} from "#app/data/enums/moves";
+import {getMovePosition} from "#app/test/utils/gameManagerUtils";
+import {Command} from "#app/ui/command-ui-handler";
+import {Stat} from "#app/data/pokemon-stat";
+import { Abilities } from "#app/data/enums/abilities.js";
+import { ArenaTagType } from "#app/data/enums/arena-tag-type.js";
+import { ArenaTagSide, ArenaTrapTag } from "#app/data/arena-tag.js";
+import { BattleStat } from "#app/data/battle-stat.js";
+
+// See also: ArenaTypeAbAttr
+describe("Test type immunity granted by abilities", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(overrides, "NEVER_CRIT_OVERRIDE", "get").mockReturnValue(true);
+  });
+
+  it("causes attacks to fail", async() => {
+    // Check that EARTHQUAKE is blocked by LEVITATE
+
+    const moveToUse = Moves.LEAFAGE;
+    const enemyAbility = Abilities.SAP_SIPPER;
+
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([moveToUse]);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.NONE, Moves.NONE, Moves.NONE]);
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.DUSKULL);
+    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(enemyAbility);
+
+    await game.startBattle([
+      Species.BIDOOF,
+      Species.BIDOOF
+    ]);
+
+    const startingOppHp = game.scene.currentBattle.enemyParty[0].hp;
+
+    game.onNextPrompt("CommandPhase", Mode.COMMAND, () => {
+      game.scene.ui.setMode(Mode.FIGHT, (game.scene.getCurrentPhase() as CommandPhase).getFieldIndex());
+    });
+    game.onNextPrompt("CommandPhase", Mode.FIGHT, () => {
+      const movePosition = getMovePosition(game.scene, 0, moveToUse);
+      (game.scene.getCurrentPhase() as CommandPhase).handleCommand(Command.FIGHT, movePosition, false);
+    });
+
+    await game.phaseInterceptor.runFrom(EnemyCommandPhase).to(TurnEndPhase);
+
+    expect(startingOppHp - game.scene.getEnemyParty()[0].hp).toBe(0);
+  });
+
+  it("causes non-field status moves to fail", async() => {
+    // Check that SPORE is blocked by SAP SIPPER.
+
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPORE]);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.NONE, Moves.NONE, Moves.NONE]);
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.RATTATA);
+    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.SAP_SIPPER);
+
+    await game.startBattle();
+
+    game.scene.currentBattle.enemyParty[0].stats[Stat.SPD] = 1;
+    game.scene.getParty()[0].stats[Stat.SPD] = 2;
+
+    game.onNextPrompt("CommandPhase", Mode.COMMAND, () => {
+      game.scene.ui.setMode(Mode.FIGHT, (game.scene.getCurrentPhase() as CommandPhase).getFieldIndex());
+    });
+    game.onNextPrompt("CommandPhase", Mode.FIGHT, () => {
+      const movePosition = getMovePosition(game.scene, 0, Moves.SPORE);
+      (game.scene.getCurrentPhase() as CommandPhase).handleCommand(Command.FIGHT, movePosition, false);
+    });
+
+    await game.phaseInterceptor.runFrom(EnemyCommandPhase).to(TurnEndPhase);
+
+    expect(game.scene.getEnemyParty()[0].summonData.battleStats[BattleStat.ATK]).toBe(1);
+    expect(game.scene.getEnemyParty()[0].status).toBeUndefined();
+  }, 20000);
+
+  it("does not cause field moves to fail", async() => {
+    // Field moves should NOT be affected by immunity abilities
+    // Check that SPIKES (ground-type) is not blocked by LEVITATE (immunity to ground-type)
+
+    const moveToUse = Moves.SPIKES;
+
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([moveToUse]);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.NONE, Moves.NONE, Moves.NONE]);
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.RATTATA);
+    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.LEVITATE);
+
+    await game.startBattle();
+
+    game.scene.currentBattle.enemyParty[0].stats[Stat.SPD] = 1;
+    game.scene.getParty()[0].stats[Stat.SPD] = 2;
+
+    game.onNextPrompt("CommandPhase", Mode.COMMAND, () => {
+      game.scene.ui.setMode(Mode.FIGHT, (game.scene.getCurrentPhase() as CommandPhase).getFieldIndex());
+    });
+    game.onNextPrompt("CommandPhase", Mode.FIGHT, () => {
+      const movePosition = getMovePosition(game.scene, 0, moveToUse);
+      (game.scene.getCurrentPhase() as CommandPhase).handleCommand(Command.FIGHT, movePosition, false);
+    });
+
+    await game.phaseInterceptor.runFrom(EnemyCommandPhase).to(TurnEndPhase);
+
+    const spikesTag = game.scene.arena.getTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.ENEMY);
+    expect(spikesTag).not.toBeUndefined();
+    expect((spikesTag as ArenaTrapTag).layers).toBe(1);
+  }, 20000);
+});


### PR DESCRIPTION
Revival of #240.

## What are the changes?
Type immunity abilities (such as Levitate and Sap Sipper) apply to non-field status moves, not just attacks.

## Why am I doing these changes?
Fixes #278. The current behavior of these abilities is incorrect.

## What did change?
In `TypeImmunityAbAttr.applyPreDefend()`, instead of just blocking attacks, block any move that does not target the field. Also remove an incorrect check there for `StatusMoveTypeImmunityAttr`, since that attribute applies to types of Pokemon, not types of Moves.

Add tests for Sap Sipper.

## How to test the changes?
The provided unit tests should be enough to verify the functionality. If you want to test it on the current build, consider these overrides:

```ts
export const STARTER_SPECIES_OVERRIDE: Species | integer = Species.BIDOOF;
export const MOVESET_OVERRIDE: Array<Moves> = [Moves.SPORE];
export const OPP_ABILITY_OVERRIDE: Abilities = Abilities.SAP_SIPPER;
```

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?