### PR TITLE
[Bug] Hotfix type hint

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -3125,7 +3125,9 @@ export class ShowAbilityPhase extends PokemonPhase {
     const pokemon = this.getPokemon();
 
     this.scene.abilityBar.showAbility(pokemon, this.passive);
-    pokemon.battleData.abilityRevealed = true;
+    if (pokemon.battleData) {
+      pokemon.battleData.abilityRevealed = true;
+    }
 
     this.end();
   }


### PR DESCRIPTION
## What are the changes?
- not technically caused by the recent type hint change https://github.com/pagefaultgames/pokerogue/pull/2105
- a pokemon's ability outside of battle is being activated - which should have not, thats why battleData is undefined, hence the error
- see [video](https://discord.com/channels/1125469663833370665/1125894949020381285/1250517257642315837)
- **it seems to happen to mons with Scrappy ability**

## Why am I doing these changes?
- hotfixes above bug

## What did change?
- added if condition

### Screenshots/Videos
(Video)[https://discord.com/channels/1125469663833370665/1125894949020381285/1250519161549885650]

## How to test the changes?
- get to wave 167 https://discord.com/channels/1125469663833370665/1125894949020381285/1250513165339328634

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - [x] Have I provided screenshots/videos of the changes?