### PR TITLE
[Test] Update gameManager switchPokemon to match other menu utilities

### DIFF
--- a/src/test/abilities/intimidate.test.ts
+++ b/src/test/abilities/intimidate.test.ts
@@ -56,7 +56,9 @@ describe("Abilities - Intimidate", () => {
     expect(battleStatsOpponent[BattleStat.ATK]).toBe(-1);
     let battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
     expect(battleStatsPokemon[BattleStat.ATK]).toBe(-1);
-    await game.switchPokemon(1);
+    game.doSwitchPokemon(1);
+    await game.phaseInterceptor.run(CommandPhase);
+    await game.phaseInterceptor.to(CommandPhase);
     expect(game.scene.getParty()[0].species.speciesId).toBe(Species.POOCHYENA);
 
     battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
@@ -81,7 +83,9 @@ describe("Abilities - Intimidate", () => {
     expect(battleStatsOpponent[BattleStat.ATK]).toBe(-1);
     let battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
     expect(battleStatsPokemon[BattleStat.ATK]).toBe(-1);
-    await game.switchPokemon(1);
+    game.doSwitchPokemon(1);
+    await game.phaseInterceptor.run(CommandPhase);
+    await game.phaseInterceptor.to(CommandPhase);
     expect(game.scene.getParty()[0].species.speciesId).toBe(Species.POOCHYENA);
 
     battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
@@ -106,7 +110,9 @@ describe("Abilities - Intimidate", () => {
     expect(battleStatsOpponent[BattleStat.ATK]).toBe(-1);
     let battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
     expect(battleStatsPokemon[BattleStat.ATK]).toBe(-1);
-    await game.switchPokemon(1);
+    game.doSwitchPokemon(1);
+    await game.phaseInterceptor.run(CommandPhase);
+    await game.phaseInterceptor.to(CommandPhase);
     expect(game.scene.getParty()[0].species.speciesId).toBe(Species.POOCHYENA);
 
     battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;

--- a/src/test/moves/spikes.test.ts
+++ b/src/test/moves/spikes.test.ts
@@ -74,11 +74,11 @@ describe("Moves - Spikes", () => {
     await game.phaseInterceptor.to(CommandPhase, false);
 
     const initialHp = game.scene.getParty()[0].hp;
-    await game.switchPokemon(1, false);
+    game.doSwitchPokemon(1);
     await game.phaseInterceptor.run(CommandPhase);
     await game.phaseInterceptor.to(CommandPhase, false);
 
-    await game.switchPokemon(1, false);
+    game.doSwitchPokemon(1);
     await game.phaseInterceptor.run(CommandPhase);
     await game.phaseInterceptor.to(CommandPhase, false);
 

--- a/src/test/utils/gameManager.ts
+++ b/src/test/utils/gameManager.ts
@@ -290,16 +290,16 @@ export default class GameManager {
     });
   }
 
-  async switchPokemon(pokemonIndex: number, toNext: boolean = true) {
+  /**
+   * Switch pokemon and transition to the enemy command phase
+   * @param pokemonIndex the index of the pokemon in your party to switch to
+   */
+  doSwitchPokemon(pokemonIndex: number) {
     this.onNextPrompt("CommandPhase", Mode.COMMAND, () => {
       this.scene.ui.setMode(Mode.PARTY, PartyUiMode.SWITCH, (this.scene.getCurrentPhase() as CommandPhase).getPokemon().getFieldIndex(), null, PartyUiHandler.FilterNonFainted);
     });
     this.onNextPrompt("CommandPhase", Mode.PARTY, () => {
       (this.scene.getCurrentPhase() as CommandPhase).handleCommand(Command.POKEMON, pokemonIndex, false);
     });
-    if (toNext) {
-      await this.phaseInterceptor.run(CommandPhase);
-      await this.phaseInterceptor.to(CommandPhase);
-    }
   }
 }


### PR DESCRIPTION
## What are the changes?
Convert `async gameManager.switchPokemon()` to `game.doSwitchPokemon()`

## Why am I doing these changes?
So that the game manager menu utility matches the utilities that do the same thing 

## What did change?
Convert `async gameManager.switchPokemon()` to `game.doSwitchPokemon()`
Add missing `.run()` and `.to()` invokations

## How to test the changes?
npm run test:silent

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)