### PR TITLE
[Bug] Add condition before applying IgnoreTypeImmunityAbAttr

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1146,7 +1146,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     let multiplier = types.map(defType => {
       if (source) {
         const ignoreImmunity = new Utils.BooleanHolder(false);
-        applyAbAttrs(IgnoreTypeImmunityAbAttr, source, ignoreImmunity, moveType, defType);
+        if (source.isActive(true) && source.hasAbilityWithAttr(IgnoreTypeImmunityAbAttr)) {
+          applyAbAttrs(IgnoreTypeImmunityAbAttr, source, ignoreImmunity, moveType, defType);
+        }
         if (ignoreImmunity.value) {
           return 1;
         }


### PR DESCRIPTION
## What are the changes?
- Add condition if pokemon with ability `IgnoreTypeImmunityAbAttr` is active/on field
- `IgnoreTypeImmunityAbAttr` is currently being used by abilities `SCRAPPY` and `MINDS_EYE`

[Mind's Eye](https://bulbapedia.bulbagarden.net/wiki/Mind%27s_Eye_(Ability)):
> Outside of battle
> Mind's Eye has no effect outside of battle.

[Scrappy](https://bulbapedia.bulbagarden.net/wiki/Scrappy_(Ability)):
> Outside of battle
> Scrappy has no effect outside of battle. 

## Why am I doing these changes?
- closes https://github.com/pagefaultgames/pokerogue/issues/2148

## What did change?
- added condition before applying `IgnoreTypeImmunityAbAttr`

### Screenshots/Videos
- Kangaskhan's Scrappy no longer procs outside of battle


https://github.com/pagefaultgames/pokerogue/assets/68144167/9bad84f1-23fe-46b7-92e7-745578dbd464




## How to test the changes?
- import [session data](https://discord.com/channels/1125469663833370665/1125894949020381285/1250513165339328634)
- play to wave 167 and switch in gengar

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] ~Are the changes visual?~
  - [x] Have I provided screenshots/videos of the changes?