### PR TITLE
[Bug] Fixed reviving while transformed not resetting the sprite

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2545,6 +2545,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         this.lapseTag(BattlerTagType.CONFUSED);
       }
     }
+    this.loadAssets(false).then(() => this.playAnim());
   }
 
   primeSummonData(summonDataPrimer: PokemonSummonData): void {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2527,8 +2527,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   * Resets the status of a pokemon.
   * @param revive Whether revive should be cured; defaults to true.
   * @param confusion Whether resetStatus should include confusion or not; defaults to false.
+  * @param reloadAssets Whether to reload the assets or not; defaults to false.
   */
-  resetStatus(revive: boolean = true, confusion: boolean = false): void {
+  resetStatus(revive: boolean = true, confusion: boolean = false, reloadAssets: boolean = false): void {
     const lastStatus = this.status?.effect;
     if (!revive && lastStatus === StatusEffect.FAINT) {
       return;
@@ -2545,7 +2546,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         this.lapseTag(BattlerTagType.CONFUSED);
       }
     }
-    this.loadAssets(false).then(() => this.playAnim());
+    if (reloadAssets) {
+      this.loadAssets(false).then(() => this.playAnim());
+    }
   }
 
   primeSummonData(summonDataPrimer: PokemonSummonData): void {

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -1091,8 +1091,7 @@ export class PokemonInstantReviveModifier extends PokemonHeldItemModifier {
     pokemon.scene.unshiftPhase(new PokemonHealPhase(pokemon.scene, pokemon.getBattlerIndex(),
       Math.max(Math.floor(pokemon.getMaxHp() / 2), 1), getPokemonMessage(pokemon, ` was revived\nby its ${this.type.name}!`), false, false, true));
 
-    pokemon.resetStatus();
-
+    pokemon.resetStatus(true, false, true);
     return true;
   }
 


### PR DESCRIPTION
## What are the changes?
The sprite now reloads during instant revive

## Why am I doing these changes?
Fixes #2151

## What did change?
Added an option in `Pokemon.resetStatus` to reload assets
`PokemonInstantReviveModifier.apply` now reloads assets

Not sure if there are still any other cases other than `PokemonInstantReviveModifier` where this is necessary.

### Screenshots/Videos

When Mew is revived during transform:

Before

![image](https://github.com/pagefaultgames/pokerogue/assets/59531041/6c037e4f-2c6f-4b68-b5a8-b3e9a5bccd4e)


After

![image](https://github.com/pagefaultgames/pokerogue/assets/59531041/6039160a-d91f-4e15-b623-b8f538b3111c)


## How to test the changes?
In `overrides.ts`,
`export const MOVESET_OVERRIDE: Array<Moves> = [Moves.TRANSFORM];`
`export const STARTING_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [{name: "REVIVER_SEED"}];`
And start a game, transform, die, revive.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?