### PR TITLE
[BUG] Add secondary update to biome pool loading

### DIFF
--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -55,6 +55,10 @@ export class Arena {
     this.scene.arenaNextEnemy.setBiome(this.biomeType);
     this.scene.arenaBg.setTexture(`${biomeKey}_bg`);
     this.scene.arenaBgTransition.setTexture(`${biomeKey}_bg`);
+
+    // Redo this on initialise because during save/load the current wave isn't always
+    // set correctly during construction
+    this.updatePoolsForTimeOfDay();
   }
 
   updatePoolsForTimeOfDay(): void {


### PR DESCRIPTION
## What are the changes?
A small change to how arenas are initialised to prevent a bug where sometimes the biome pools are initialised before the time of day is.

## Why am I doing these changes?
Sometimes during loading the biome pools will be initialised before the current wave is, causing it to generate biome pools as if you were on wave 0.

## What did change?
Update the biome pools during the initialise function of arenas instead of just the constructor.

## How to test the changes?
You'll need a debugger so you can look at the actual biome pools, but after reload a save the game can be using the wave 0 encounter table instead of the correct table.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)