### PR TITLE
[QoL] Post-Reroll UI Targeting

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -106,7 +106,9 @@ export default class BattleScene extends SceneBase {
   public seVolume: number = 1;
   public gameSpeed: integer = 1;
   public damageNumbersMode: integer = 0;
+  public hasRerolled: boolean = false;
   public reroll: boolean = false;
+  public rerollTarget: integer = 1;
   public showMovesetFlyout: boolean = true;
   public showArenaFlyout: boolean = true;
   public showTimeOfDayWidget: boolean = true;

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -4985,6 +4985,7 @@ export class SelectModifierPhase extends BattlePhase {
   constructor(scene: BattleScene, rerollCount: integer = 0, modifierTiers?: ModifierTier[]) {
     super(scene);
 
+    this.scene.hasRerolled = rerollCount > 0;
     this.rerollCount = rerollCount;
     this.modifierTiers = modifierTiers;
   }

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -54,6 +54,7 @@ export const SettingKeys = {
   Damage_Numbers: "DAMAGE_NUMBERS",
   Move_Animations: "MOVE_ANIMATIONS",
   Show_Stats_on_Level_Up: "SHOW_LEVEL_UP_STATS",
+  Reroll_Target: "REROLL_TARGET",
   Candy_Upgrade_Notification: "CANDY_UPGRADE_NOTIFICATION",
   Candy_Upgrade_Display: "CANDY_UPGRADE_DISPLAY",
   Move_Info: "MOVE_INFO",
@@ -193,6 +194,13 @@ export const Setting: Array<Setting> = [
     key: SettingKeys.Show_Stats_on_Level_Up,
     label: "Show Stats on Level Up",
     options: OFF_ON,
+    default: 1,
+    type: SettingType.DISPLAY
+  },
+  {
+    key: SettingKeys.Reroll_Target,
+    label: "Reroll Target",
+    options: ["Reroll", "Items", "Shop"],
     default: 1,
     type: SettingType.DISPLAY
   },
@@ -424,6 +432,8 @@ export function setSetting(scene: BattleScene, setting: string, value: integer):
   case SettingKeys.Show_Stats_on_Level_Up:
     scene.showLevelUpStats = Setting[index].options[value] === "On";
     break;
+  case SettingKeys.Reroll_Target:
+    scene.rerollTarget = value;
   case SettingKeys.EXP_Gains_Speed:
     scene.expGainsSpeed = value;
     break;

--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -231,7 +231,11 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
       });
 
       this.setCursor(0);
-      this.setRowCursor(1);
+      if(this.scene.hasRerolled){
+        this.setRowCursor(this.scene.rerollTarget);
+      } else {
+        this.setRowCursor(1);
+      }
 
       handleTutorial(this.scene, Tutorial.Select_Item).then(() => {
         this.setCursor(0);


### PR DESCRIPTION
## What are the changes?
This PR added a requesting QoL change for the OPTION of not jumping to the 1st item after rerolling.  It adds new reroll target options to the Display section of Game Settings.

## Why am I doing these changes?
Highly upvoted/bump/requested change in the feature-vote section of the discord.  Very nice convenience change for people who want to multi-reroll. 

## What did change?
* Added a setting to manage where the cursor will target after an item reroll
* Added logic in shop ui to handle cursor targeting following a reroll
* Tracks if user has rerolled at parent scene level with boolean, while handling that boolean at the child shop scene level

### Screenshots/Videos

## How to test the changes?
* change in overrides.ts to give yourself a lot of money
* change in display settings where you would like to target after rerolling
* win a wave fight by any means and see while it starts on the first item, it should switch to your preferred option after reroll

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?