### PR TITLE
[Localization] Fix bouncy bubble description for es fr it ko zh

### DIFF
--- a/src/locales/es/move.ts
+++ b/src/locales/es/move.ts
@@ -2931,7 +2931,7 @@ export const move: MoveTranslationEntries = {
   },
   bouncyBubble: {
     name: "Vapodrenaje",
-    effect: "Ataca lanzando proyectiles de agua y recupera una cantidad de PS equivalente a la mitad del daño causado.",
+    effect: "Ataca lanzando proyectiles de agua y recupera una cantidad de PS equivalente a la del daño causado.",
   },
   buzzyBuzz: {
     name: "Joltioparálisis",

--- a/src/locales/fr/move.ts
+++ b/src/locales/fr/move.ts
@@ -2931,7 +2931,7 @@ export const move: MoveTranslationEntries = {
   },
   "bouncyBubble": {
     name: "Évo-Thalasso",
-    effect: "Évoli frappe l’adversaire avec des bulles d’eau qu’il absorbe ensuite pour récupérer un nombre de PV égal à la des dégâts infligés à l’ennemi."
+    effect: "Évoli frappe l’adversaire avec des bulles d’eau qu’il absorbe ensuite pour récupérer un nombre de PV égal aux dégâts infligés à l’ennemi."
   },
   "buzzyBuzz": {
     name: "Évo-Dynamo",

--- a/src/locales/fr/move.ts
+++ b/src/locales/fr/move.ts
@@ -2931,7 +2931,7 @@ export const move: MoveTranslationEntries = {
   },
   "bouncyBubble": {
     name: "Évo-Thalasso",
-    effect: "Évoli frappe l’adversaire avec des bulles d’eau qu’il absorbe ensuite pour récupérer un nombre de PV égal aux dégâts infligés à l’ennemi."
+    effect: "L’adversaire est frappé par des bulles d’eau qui sont ensuite absorbées pour récupérer un nombre de PV égal aux dégâts infligés à l’ennemi."
   },
   "buzzyBuzz": {
     name: "Évo-Dynamo",

--- a/src/locales/fr/move.ts
+++ b/src/locales/fr/move.ts
@@ -2931,7 +2931,7 @@ export const move: MoveTranslationEntries = {
   },
   "bouncyBubble": {
     name: "Évo-Thalasso",
-    effect: "Évoli frappe l’adversaire avec des bulles d’eau qu’il absorbe ensuite pour récupérer un nombre de PV égal à la moitié des dégâts infligés à l’ennemi."
+    effect: "Évoli frappe l’adversaire avec des bulles d’eau qu’il absorbe ensuite pour récupérer un nombre de PV égal à la des dégâts infligés à l’ennemi."
   },
   "buzzyBuzz": {
     name: "Évo-Dynamo",

--- a/src/locales/it/move.ts
+++ b/src/locales/it/move.ts
@@ -2931,7 +2931,7 @@ export const move: MoveTranslationEntries = {
   },
   bouncyBubble: {
     name: "Bollaslurp",
-    effect: "Chi la usa colpisce il bersaglio con una raffica di bolle, per poi assorbirle e recuperare una quantità di PS pari alla metà del danno inferto.",
+    effect: "Chi la usa colpisce il bersaglio con una raffica di bolle, per poi assorbirle e recuperare una quantità di PS pari alla del danno inferto.",
   },
   buzzyBuzz: {
     name: "Elettrozap",

--- a/src/locales/ko/move.ts
+++ b/src/locales/ko/move.ts
@@ -2937,7 +2937,7 @@ export const move: MoveTranslationEntries = {
   },
   bouncyBubble: {
     name: "생생버블",
-    effect: "물덩어리를 부딪쳐서 공격한다. 물을 흡수하여 데미지의 절반만큼 HP를 회복한다."
+    effect: "물덩어리를 부딪쳐서 공격한다. 물을 흡수하여 데미지의 절만큼 HP를 회복한다."
   },
   buzzyBuzz: {
     name: "찌릿찌릿일렉",

--- a/src/locales/zh_CN/move.ts
+++ b/src/locales/zh_CN/move.ts
@@ -2931,7 +2931,7 @@ export const move: MoveTranslationEntries = {
   },
   "bouncyBubble": {
     name: "活活气泡",
-    effect: "投掷水球进行攻击。吸水后\n能回复等同于造成的伤害一\n半的HP",
+    effect: "投掷水球进行攻击。吸水后\n能回复等同于造成的伤害\n的HP",
   },
   "buzzyBuzz": {
     name: "麻麻电击",

--- a/src/locales/zh_TW/move.ts
+++ b/src/locales/zh_TW/move.ts
@@ -2817,7 +2817,7 @@ export const move: MoveTranslationEntries = {
   },
   bouncyBubble: {
     name: "活活氣泡",
-    effect: "投擲水球進行攻擊。吸水後\n能回覆等同於造成的傷害一\n半的HP",
+    effect: "投擲水球進行攻擊。吸水後\n能回覆等同於造成的傷害\n的HP",
   },
   buzzyBuzz: {
     name: "麻麻電擊",


### PR DESCRIPTION
## What are the changes?
Updated bouncy bubble description

## Why am I doing these changes?
It should say 100% of damage dealt as healing instead of 50%

## What did change?
Changed es, fr, it, ko, and both zh localizations for bouncy bubble. Let me know if I've severely butchered anything

### Screenshots/Videos
n/a

## How to test the changes?
Pull

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?