### PR TITLE
[Bug] Fix audio setting scroll behavior

### DIFF
--- a/src/ui/settings/abstract-settings-ui-handler.ts
+++ b/src/ui/settings/abstract-settings-ui-handler.ts
@@ -33,8 +33,8 @@ export default class AbstractSettingsUiHandler extends UiHandler {
 
   private reloadSettings: Array<Setting>;
   private reloadRequired: boolean;
-  private rowsToDisplay: number;
 
+  protected rowsToDisplay: number;
   protected title: string;
   protected settings: Array<Setting>;
   protected localStorageKey: string;

--- a/src/ui/settings/settings-audio-ui-handler.ts
+++ b/src/ui/settings/settings-audio-ui-handler.ts
@@ -6,7 +6,7 @@ import { Setting, SettingType } from "#app/system/settings/settings";
 
 export default class SettingsAudioUiHandler extends AbstractSettingsUiHandler {
   /**
-   * Creates an instance of SettingsGamepadUiHandler.
+   * Creates an instance of SettingsAudioUiHandler.
    *
    * @param scene - The BattleScene instance.
    * @param mode - The UI mode, optional.
@@ -16,5 +16,6 @@ export default class SettingsAudioUiHandler extends AbstractSettingsUiHandler {
     this.title = "Audio";
     this.settings = Setting.filter(s => s.type === SettingType.AUDIO);
     this.localStorageKey = "settings";
+    this.rowsToDisplay = 4;
   }
 }


### PR DESCRIPTION
## What are the changes?
- fixes scroll behavior of audio settings

## Why am I doing these changes?
- closes #2172 

## What did change?
- added condition to check if all rows are filled

### Screenshots/Videos
- Audio settings 

https://github.com/pagefaultgames/pokerogue/assets/68144167/55e730c6-0007-4204-9eaf-bc685ebf6096




- General and Display settings still work fine

https://github.com/pagefaultgames/pokerogue/assets/68144167/f55bca7e-12ac-40b5-93f8-a181459e3ddb





## How to test the changes?
- go to settings and navigate

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?