### PR TITLE
[QoL] Language option cursor resets after cancelling or switching language

### DIFF
--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -463,8 +463,7 @@ export function setSetting(scene: BattleScene, setting: string, value: integer):
       if (scene.ui) {
         const cancelHandler = () => {
           scene.ui.revertMode();
-          const languageSetting = Setting.find(setting => setting.key === SettingKeys.Language);
-          (scene.ui.getHandler() as SettingsUiHandler).setOptionCursor(Setting.indexOf(languageSetting), 0, true);
+          (scene.ui.getHandler() as SettingsUiHandler).setOptionCursor(0, 0, true);
         };
         const changeLocaleHandler = (locale: string): boolean => {
           try {


### PR DESCRIPTION
## What are the changes?
After you switch language or cancel switching language, the option cursor now resets back to being on the language instead of on "change"
![image](https://github.com/pagefaultgames/pokerogue/assets/59531041/be2aa519-4f76-4854-9be8-13c174231e80)


## Why am I doing these changes?
The way switching language works right now is, you have to move from your language to change for the options to pop up.

However, after switching languages, the cursor stayed on change, you have to move back to your language then back to change to switch languages again. 

It makes more sense for the cursor to be hovering over the new language instead of on change, and makes it a bit more convenient for people testing localization changes.

## What did change?
`cancelHandler` when setting language

## How to test the changes?
1. Switch languages
2. Go to settings again

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?