### PR TITLE
[Bug] Fix mythical pokemon hatched stat

### DIFF
--- a/src/ui/game-stats-ui-handler.ts
+++ b/src/ui/game-stats-ui-handler.ts
@@ -157,7 +157,7 @@ const displayStats: DisplayStats = {
   },
   mythicalPokemonHatched: {
     label_key: "mythicalsHatched",
-    sourceFunc: gameData => gameData.gameStats.legendaryPokemonHatched.toString(),
+    sourceFunc: gameData => gameData.gameStats.mythicalPokemonHatched.toString(),
     hidden: true
   },
   shinyPokemonSeen: {


### PR DESCRIPTION
## What are the changes?
Fixed mythical pokemon hatched

## Why am I doing these changes?
Mythical pokemon hatched was displaying legend pokemon hatched

## What did change?
Changed legendary -> mythical

### Screenshots/Videos
n/a

## How to test the changes?
pull

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?