### PR TITLE
[Bug] Fix Animation for Variant Exp Meadow Vivillon 

### DIFF
--- a/public/images/pokemon/variant/exp/666-meadow_2.json
+++ b/public/images/pokemon/variant/exp/666-meadow_2.json
@@ -4,177 +4,30 @@
 			"image": "666-meadow_2.png",
 			"format": "RGBA8888",
 			"size": {
-				"w": 243,
-				"h": 243
+				"w": 346,
+				"h": 346
 			},
 			"scale": 1,
 			"frames": [
-				{
-					"filename": "0001.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 0,
-						"y": 5,
-						"w": 84,
-						"h": 88
-					},
-					"frame": {
-						"x": 0,
-						"y": 0,
-						"w": 84,
-						"h": 88
-					}
-				},
-				{
-					"filename": "0002.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 3,
-						"y": 4,
-						"w": 77,
-						"h": 89
-					},
-					"frame": {
-						"x": 0,
-						"y": 88,
-						"w": 77,
-						"h": 89
-					}
-				},
-				{
-					"filename": "0014.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 3,
-						"y": 4,
-						"w": 77,
-						"h": 89
-					},
-					"frame": {
-						"x": 0,
-						"y": 88,
-						"w": 77,
-						"h": 89
-					}
-				},
 				{
 					"filename": "0003.png",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
-						"w": 84,
-						"h": 93
+						"w": 67,
+						"h": 74
 					},
 					"spriteSourceSize": {
-						"x": 7,
-						"y": 3,
-						"w": 69,
-						"h": 89
+						"x": 0,
+						"y": 1,
+						"w": 67,
+						"h": 69
 					},
 					"frame": {
-						"x": 77,
-						"y": 88,
-						"w": 69,
-						"h": 89
-					}
-				},
-				{
-					"filename": "0013.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 7,
-						"y": 3,
-						"w": 69,
-						"h": 89
-					},
-					"frame": {
-						"x": 77,
-						"y": 88,
-						"w": 69,
-						"h": 89
-					}
-				},
-				{
-					"filename": "0004.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 10,
-						"y": 3,
-						"w": 62,
-						"h": 87
-					},
-					"frame": {
-						"x": 84,
+						"x": 0,
 						"y": 0,
-						"w": 62,
-						"h": 87
-					}
-				},
-				{
-					"filename": "0012.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 10,
-						"y": 3,
-						"w": 62,
-						"h": 87
-					},
-					"frame": {
-						"x": 84,
-						"y": 0,
-						"w": 62,
-						"h": 87
-					}
-				},
-				{
-					"filename": "0005.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 13,
-						"y": 2,
-						"w": 56,
-						"h": 86
-					},
-					"frame": {
-						"x": 146,
-						"y": 0,
-						"w": 56,
-						"h": 86
+						"w": 67,
+						"h": 69
 					}
 				},
 				{
@@ -182,104 +35,125 @@
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
-						"w": 84,
-						"h": 93
+						"w": 67,
+						"h": 74
 					},
 					"spriteSourceSize": {
-						"x": 13,
-						"y": 2,
-						"w": 56,
-						"h": 86
-					},
-					"frame": {
-						"x": 146,
-						"y": 0,
-						"w": 56,
-						"h": 86
-					}
-				},
-				{
-					"filename": "0008.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 19,
-						"y": 0,
-						"w": 41,
-						"h": 85
-					},
-					"frame": {
-						"x": 202,
-						"y": 0,
-						"w": 41,
-						"h": 85
-					}
-				},
-				{
-					"filename": "0006.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 15,
+						"x": 0,
 						"y": 1,
-						"w": 51,
-						"h": 86
+						"w": 67,
+						"h": 69
 					},
 					"frame": {
-						"x": 146,
-						"y": 86,
-						"w": 51,
-						"h": 86
-					}
-				},
-				{
-					"filename": "0010.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 15,
-						"y": 1,
-						"w": 51,
-						"h": 86
-					},
-					"frame": {
-						"x": 146,
-						"y": 86,
-						"w": 51,
-						"h": 86
-					}
-				},
-				{
-					"filename": "0007.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 17,
+						"x": 0,
 						"y": 0,
-						"w": 46,
-						"h": 86
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0015.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 1,
+						"w": 67,
+						"h": 69
 					},
 					"frame": {
-						"x": 197,
-						"y": 86,
-						"w": 46,
-						"h": 86
+						"x": 0,
+						"y": 0,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0023.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 1,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 0,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0027.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 1,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 0,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0035.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 1,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 0,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0005.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 3,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 69,
+						"w": 67,
+						"h": 69
 					}
 				},
 				{
@@ -287,20 +161,1112 @@
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
-						"w": 84,
-						"h": 93
+						"w": 67,
+						"h": 74
 					},
 					"spriteSourceSize": {
-						"x": 17,
-						"y": 0,
-						"w": 46,
-						"h": 86
+						"x": 0,
+						"y": 3,
+						"w": 67,
+						"h": 69
 					},
 					"frame": {
-						"x": 197,
-						"y": 86,
-						"w": 46,
-						"h": 86
+						"x": 0,
+						"y": 69,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0017.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 3,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 69,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0021.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 3,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 69,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0029.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 3,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 69,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0033.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 3,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 69,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0039.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 1,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 138,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0041.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 3,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 207,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0043.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 5,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 276,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0045.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 3,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 67,
+						"y": 0,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0047.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 1,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 134,
+						"y": 0,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0051.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 1,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 201,
+						"y": 0,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0053.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 3,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 268,
+						"y": 0,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0055.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 5,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 67,
+						"y": 69,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0057.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 3,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 67,
+						"y": 138,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0059.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 1,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 67,
+						"y": 207,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0001.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 0,
+						"w": 67,
+						"h": 68
+					},
+					"frame": {
+						"x": 67,
+						"y": 276,
+						"w": 67,
+						"h": 68
+					}
+				},
+				{
+					"filename": "0013.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 0,
+						"w": 67,
+						"h": 68
+					},
+					"frame": {
+						"x": 67,
+						"y": 276,
+						"w": 67,
+						"h": 68
+					}
+				},
+				{
+					"filename": "0025.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 0,
+						"w": 67,
+						"h": 68
+					},
+					"frame": {
+						"x": 67,
+						"y": 276,
+						"w": 67,
+						"h": 68
+					}
+				},
+				{
+					"filename": "0037.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 0,
+						"w": 67,
+						"h": 68
+					},
+					"frame": {
+						"x": 67,
+						"y": 276,
+						"w": 67,
+						"h": 68
+					}
+				},
+				{
+					"filename": "0007.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 6,
+						"w": 67,
+						"h": 68
+					},
+					"frame": {
+						"x": 134,
+						"y": 69,
+						"w": 67,
+						"h": 68
+					}
+				},
+				{
+					"filename": "0019.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 6,
+						"w": 67,
+						"h": 68
+					},
+					"frame": {
+						"x": 134,
+						"y": 69,
+						"w": 67,
+						"h": 68
+					}
+				},
+				{
+					"filename": "0031.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 6,
+						"w": 67,
+						"h": 68
+					},
+					"frame": {
+						"x": 134,
+						"y": 69,
+						"w": 67,
+						"h": 68
+					}
+				},
+				{
+					"filename": "0049.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 0,
+						"w": 67,
+						"h": 68
+					},
+					"frame": {
+						"x": 201,
+						"y": 69,
+						"w": 67,
+						"h": 68
+					}
+				},
+				{
+					"filename": "0002.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 0,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 268,
+						"y": 69,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0012.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 0,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 268,
+						"y": 69,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0014.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 0,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 268,
+						"y": 69,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0024.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 0,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 268,
+						"y": 69,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0026.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 0,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 268,
+						"y": 69,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0036.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 0,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 268,
+						"y": 69,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0004.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 2,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 134,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0010.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 2,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 134,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0016.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 2,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 134,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0022.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 2,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 134,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0028.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 2,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 134,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0034.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 2,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 134,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0006.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 5,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 187,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0008.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 5,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 187,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0018.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 5,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 187,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0020.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 5,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 187,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0030.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 5,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 187,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0032.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 5,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 187,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0038.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 0,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 240,
+						"y": 138,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0040.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 2,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 293,
+						"y": 138,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0052.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 2,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 293,
+						"y": 138,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0042.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 4,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 134,
+						"y": 206,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0054.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 4,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 134,
+						"y": 206,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0044.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 4,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 187,
+						"y": 206,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0046.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 2,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 240,
+						"y": 207,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0048.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 0,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 134,
+						"y": 275,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0050.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 0,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 187,
+						"y": 275,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0056.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 4,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 240,
+						"y": 276,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0058.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 2,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 293,
+						"y": 207,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0060.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 0,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 293,
+						"y": 276,
+						"w": 53,
+						"h": 69
 					}
 				}
 			]

--- a/public/images/pokemon/variant/exp/666-meadow_3.json
+++ b/public/images/pokemon/variant/exp/666-meadow_3.json
@@ -4,177 +4,30 @@
 			"image": "666-meadow_3.png",
 			"format": "RGBA8888",
 			"size": {
-				"w": 243,
-				"h": 243
+				"w": 346,
+				"h": 346
 			},
 			"scale": 1,
 			"frames": [
-				{
-					"filename": "0001.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 0,
-						"y": 5,
-						"w": 84,
-						"h": 88
-					},
-					"frame": {
-						"x": 0,
-						"y": 0,
-						"w": 84,
-						"h": 88
-					}
-				},
-				{
-					"filename": "0002.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 3,
-						"y": 4,
-						"w": 77,
-						"h": 89
-					},
-					"frame": {
-						"x": 0,
-						"y": 88,
-						"w": 77,
-						"h": 89
-					}
-				},
-				{
-					"filename": "0014.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 3,
-						"y": 4,
-						"w": 77,
-						"h": 89
-					},
-					"frame": {
-						"x": 0,
-						"y": 88,
-						"w": 77,
-						"h": 89
-					}
-				},
 				{
 					"filename": "0003.png",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
-						"w": 84,
-						"h": 93
+						"w": 67,
+						"h": 74
 					},
 					"spriteSourceSize": {
-						"x": 7,
-						"y": 3,
-						"w": 69,
-						"h": 89
+						"x": 0,
+						"y": 1,
+						"w": 67,
+						"h": 69
 					},
 					"frame": {
-						"x": 77,
-						"y": 88,
-						"w": 69,
-						"h": 89
-					}
-				},
-				{
-					"filename": "0013.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 7,
-						"y": 3,
-						"w": 69,
-						"h": 89
-					},
-					"frame": {
-						"x": 77,
-						"y": 88,
-						"w": 69,
-						"h": 89
-					}
-				},
-				{
-					"filename": "0004.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 10,
-						"y": 3,
-						"w": 62,
-						"h": 87
-					},
-					"frame": {
-						"x": 84,
+						"x": 0,
 						"y": 0,
-						"w": 62,
-						"h": 87
-					}
-				},
-				{
-					"filename": "0012.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 10,
-						"y": 3,
-						"w": 62,
-						"h": 87
-					},
-					"frame": {
-						"x": 84,
-						"y": 0,
-						"w": 62,
-						"h": 87
-					}
-				},
-				{
-					"filename": "0005.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 13,
-						"y": 2,
-						"w": 56,
-						"h": 86
-					},
-					"frame": {
-						"x": 146,
-						"y": 0,
-						"w": 56,
-						"h": 86
+						"w": 67,
+						"h": 69
 					}
 				},
 				{
@@ -182,104 +35,125 @@
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
-						"w": 84,
-						"h": 93
+						"w": 67,
+						"h": 74
 					},
 					"spriteSourceSize": {
-						"x": 13,
-						"y": 2,
-						"w": 56,
-						"h": 86
-					},
-					"frame": {
-						"x": 146,
-						"y": 0,
-						"w": 56,
-						"h": 86
-					}
-				},
-				{
-					"filename": "0008.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 19,
-						"y": 0,
-						"w": 41,
-						"h": 85
-					},
-					"frame": {
-						"x": 202,
-						"y": 0,
-						"w": 41,
-						"h": 85
-					}
-				},
-				{
-					"filename": "0006.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 15,
+						"x": 0,
 						"y": 1,
-						"w": 51,
-						"h": 86
+						"w": 67,
+						"h": 69
 					},
 					"frame": {
-						"x": 146,
-						"y": 86,
-						"w": 51,
-						"h": 86
-					}
-				},
-				{
-					"filename": "0010.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 15,
-						"y": 1,
-						"w": 51,
-						"h": 86
-					},
-					"frame": {
-						"x": 146,
-						"y": 86,
-						"w": 51,
-						"h": 86
-					}
-				},
-				{
-					"filename": "0007.png",
-					"rotated": false,
-					"trimmed": true,
-					"sourceSize": {
-						"w": 84,
-						"h": 93
-					},
-					"spriteSourceSize": {
-						"x": 17,
+						"x": 0,
 						"y": 0,
-						"w": 46,
-						"h": 86
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0015.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 1,
+						"w": 67,
+						"h": 69
 					},
 					"frame": {
-						"x": 197,
-						"y": 86,
-						"w": 46,
-						"h": 86
+						"x": 0,
+						"y": 0,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0023.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 1,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 0,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0027.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 1,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 0,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0035.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 1,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 0,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0005.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 3,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 69,
+						"w": 67,
+						"h": 69
 					}
 				},
 				{
@@ -287,20 +161,1112 @@
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
-						"w": 84,
-						"h": 93
+						"w": 67,
+						"h": 74
 					},
 					"spriteSourceSize": {
-						"x": 17,
-						"y": 0,
-						"w": 46,
-						"h": 86
+						"x": 0,
+						"y": 3,
+						"w": 67,
+						"h": 69
 					},
 					"frame": {
-						"x": 197,
-						"y": 86,
-						"w": 46,
-						"h": 86
+						"x": 0,
+						"y": 69,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0017.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 3,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 69,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0021.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 3,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 69,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0029.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 3,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 69,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0033.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 3,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 69,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0039.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 1,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 138,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0041.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 3,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 207,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0043.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 5,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 0,
+						"y": 276,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0045.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 3,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 67,
+						"y": 0,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0047.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 1,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 134,
+						"y": 0,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0051.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 1,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 201,
+						"y": 0,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0053.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 3,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 268,
+						"y": 0,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0055.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 5,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 67,
+						"y": 69,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0057.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 3,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 67,
+						"y": 138,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0059.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 1,
+						"w": 67,
+						"h": 69
+					},
+					"frame": {
+						"x": 67,
+						"y": 207,
+						"w": 67,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0001.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 0,
+						"w": 67,
+						"h": 68
+					},
+					"frame": {
+						"x": 67,
+						"y": 276,
+						"w": 67,
+						"h": 68
+					}
+				},
+				{
+					"filename": "0013.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 0,
+						"w": 67,
+						"h": 68
+					},
+					"frame": {
+						"x": 67,
+						"y": 276,
+						"w": 67,
+						"h": 68
+					}
+				},
+				{
+					"filename": "0025.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 0,
+						"w": 67,
+						"h": 68
+					},
+					"frame": {
+						"x": 67,
+						"y": 276,
+						"w": 67,
+						"h": 68
+					}
+				},
+				{
+					"filename": "0037.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 0,
+						"w": 67,
+						"h": 68
+					},
+					"frame": {
+						"x": 67,
+						"y": 276,
+						"w": 67,
+						"h": 68
+					}
+				},
+				{
+					"filename": "0007.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 6,
+						"w": 67,
+						"h": 68
+					},
+					"frame": {
+						"x": 134,
+						"y": 69,
+						"w": 67,
+						"h": 68
+					}
+				},
+				{
+					"filename": "0019.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 6,
+						"w": 67,
+						"h": 68
+					},
+					"frame": {
+						"x": 134,
+						"y": 69,
+						"w": 67,
+						"h": 68
+					}
+				},
+				{
+					"filename": "0031.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 6,
+						"w": 67,
+						"h": 68
+					},
+					"frame": {
+						"x": 134,
+						"y": 69,
+						"w": 67,
+						"h": 68
+					}
+				},
+				{
+					"filename": "0049.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 0,
+						"y": 0,
+						"w": 67,
+						"h": 68
+					},
+					"frame": {
+						"x": 201,
+						"y": 69,
+						"w": 67,
+						"h": 68
+					}
+				},
+				{
+					"filename": "0002.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 0,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 268,
+						"y": 69,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0012.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 0,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 268,
+						"y": 69,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0014.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 0,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 268,
+						"y": 69,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0024.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 0,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 268,
+						"y": 69,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0026.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 0,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 268,
+						"y": 69,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0036.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 0,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 268,
+						"y": 69,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0004.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 2,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 134,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0010.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 2,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 134,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0016.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 2,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 134,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0022.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 2,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 134,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0028.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 2,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 134,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0034.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 2,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 134,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0006.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 5,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 187,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0008.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 5,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 187,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0018.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 5,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 187,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0020.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 5,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 187,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0030.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 5,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 187,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0032.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 5,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 187,
+						"y": 137,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0038.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 0,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 240,
+						"y": 138,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0040.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 2,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 293,
+						"y": 138,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0052.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 2,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 293,
+						"y": 138,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0042.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 4,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 134,
+						"y": 206,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0054.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 4,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 134,
+						"y": 206,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0044.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 4,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 187,
+						"y": 206,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0046.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 2,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 240,
+						"y": 207,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0048.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 0,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 134,
+						"y": 275,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0050.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 0,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 187,
+						"y": 275,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0056.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 4,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 240,
+						"y": 276,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0058.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 2,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 293,
+						"y": 207,
+						"w": 53,
+						"h": 69
+					}
+				},
+				{
+					"filename": "0060.png",
+					"rotated": false,
+					"trimmed": true,
+					"sourceSize": {
+						"w": 67,
+						"h": 74
+					},
+					"spriteSourceSize": {
+						"x": 7,
+						"y": 0,
+						"w": 53,
+						"h": 69
+					},
+					"frame": {
+						"x": 293,
+						"y": 276,
+						"w": 53,
+						"h": 69
 					}
 				}
 			]


### PR DESCRIPTION
## What are the changes?
Rare and epic shiny Meadow Pattern Vivillon (n666)'s Experimental animations are now appropriate for its spritesheet, instead of taken from the non-shiny spritesheet, and which uses a completely different sprite.

## Why am I doing these changes?
It's been reported! A lot!
https://discord.com/channels/1125469663833370665/1238339524778790922/1250180831469899808
https://discord.com/channels/1125469663833370665/1238339524778790922/1250018721729220668
https://discord.com/channels/1125469663833370665/1238339524778790922/1250018721729220668
And yeah, ideally the animation a Pokemon gets is the right one for its sprite.
![image](https://github.com/pagefaultgames/pokerogue/assets/31082757/c59f9c0e-2bf1-47a9-b403-22c930c8189b)

## What did change?
Took the animation frame data from Fancy Vivillon (rare), which animates properly and has an identically shaped spritesheet.
This does mean the Texture Packer link is now Not Correct, and a new one was not generated in its place. If someone still regularly uses TP lmk.

### Screenshots/Videos
#### Before
![image](https://github.com/pagefaultgames/pokerogue/assets/31082757/d3b1f493-5001-4c36-be8e-3a3233226010)

#### After
![image](https://github.com/pagefaultgames/pokerogue/assets/31082757/fdd670a7-d7f8-4d15-9244-a7beb157391f)
![image](https://github.com/pagefaultgames/pokerogue/assets/31082757/05b50ff3-e65d-40e0-b5ed-f6e930172b99)


## How to test the changes?
Overrides were used. Meadow Pattern Vivillon are relatively common in the first several areas, so `OPP_SPECIES_OVERRIDE` does work, but one could also simply bring in a variant Meadow Pattern Spewpa (n664), possibly with its starting level increased. If it is possible to override form at the same time as species please do let me know.
Ensuring that the `Sprite Set` used is `Mixed Animated` will be necessary to see the changes.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?