### PR TITLE
 [Bug] #2056 added another check for applying form change items to pokemon

### DIFF
--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -777,8 +777,7 @@ export class FormChangeItemModifierType extends PokemonModifierType implements G
         // Make sure the Pokemon has alternate forms
         if (pokemonFormChanges.hasOwnProperty(pokemon.species.speciesId)
           // Get all form changes for this species with an item trigger, including any compound triggers
-          && pokemonFormChanges[pokemon.species.speciesId].filter(fc => fc.trigger.hasTriggerType(SpeciesFormChangeItemTrigger))
-          // Returns true if any form changes match this item
+          && pokemonFormChanges[pokemon.species.speciesId].filter(fc => fc.trigger.hasTriggerType(SpeciesFormChangeItemTrigger) && fc.preFormKey === pokemon.getFormKey())          // Returns true if any form changes match this item and are in the correct preform
             .map(fc => fc.findTrigger(SpeciesFormChangeItemTrigger) as SpeciesFormChangeItemTrigger)
             .flat().flatMap(fc => fc.item).includes(this.formChangeItem)
         ) {


### PR DESCRIPTION
## What are the changes?
Added an additional check when applying a form change item to make sure the pokemon is in the correct preform

## Why am I doing these changes?
Closes #2056 

## What did change?
Added the check `fc.preFormKey === pokemon.getFormKey()`  in the constructor for FormChangeItemModifierType when it's getting the valid form changes.

### Screenshots/Videos
Before
![image](https://github.com/pagefaultgames/pokerogue/assets/22311832/eccaa68c-1cc1-448a-bd99-0caac81aae5f)

After
![image](https://github.com/pagefaultgames/pokerogue/assets/22311832/2858fca1-ffc2-4a29-b168-63ed450a874b)

After (Valid)
![image](https://github.com/pagefaultgames/pokerogue/assets/22311832/f85b9c59-9331-4e5a-b348-592755f8c319)


## How to test the changes?
Made the following changes in `overrides.ts`
```
export const STARTER_FORM_OVERRIDES: Partial<Record<Species, number>> = {
  [Species.PIKACHU]: 3,
};

export const STARTER_SPECIES_OVERRIDE: Species | integer = Species.PIKACHU;

export const ITEM_REWARD_OVERRIDE: Array<String> = [
  "MEGA_BRACELET",
  "FORM_CHANGE_ITEM",
  "RARE_CANDY",
];
```

I also manually would just push the max mushroom in FormChangeItemModifierTypeGenerator 

## Checklist
- [x] There is no overlap with another PR?
   - It might overlap with https://github.com/pagefaultgames/pokerogue/pull/1857
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
