### PR TITLE
Variant Label Color Change [QOL]

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1447,13 +1447,8 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
             } while (newVariant !== props.variant);
             this.setSpeciesDetails(this.lastSpecies, undefined, undefined, undefined, newVariant, undefined, undefined);
 
-            // Get the luck value
-            const luck = this.scene.gameData.getDexAttrLuck(this.speciesStarterDexEntry.caughtAttr);
-
-            // Get the tint based on the luck value
-            const tint = getVariantTint(Math.min(luck - 1, 2) as Variant);
-
-            // Set the color of variantLabel to the luck tint
+            // Cycle tint based on current sprite tint
+            const tint = getVariantTint(newVariant);
             this.variantLabel.setTint(tint);
 
             success = true;
@@ -1725,8 +1720,15 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
       this.cursorObj.setPosition(150 + 18 * (cursor % 9), 10 + 18 * Math.floor(cursor / 9));
 
-      this.setSpecies(this.genSpecies[this.getGenCursorWithScroll()][cursor]);
+      const species = this.genSpecies[this.getGenCursorWithScroll()][cursor];
 
+      const defaultDexAttr = this.scene.gameData.getSpeciesDefaultDexAttr(species, false, true);
+      const defaultProps = this.scene.gameData.getSpeciesDexAttrProps(species, defaultDexAttr);
+      const variant = defaultProps.variant;
+      const tint = getVariantTint(variant);
+
+      this.variantLabel.setTint(tint);
+      this.setSpecies(species);
       this.updateInstructions();
     }
 

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1446,6 +1446,16 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
               }
             } while (newVariant !== props.variant);
             this.setSpeciesDetails(this.lastSpecies, undefined, undefined, undefined, newVariant, undefined, undefined);
+
+            // Get the luck value
+            const luck = this.scene.gameData.getDexAttrLuck(this.speciesStarterDexEntry.caughtAttr);
+
+            // Get the tint based on the luck value
+            const tint = getVariantTint(Math.min(luck - 1, 2) as Variant);
+
+            // Set the color of variantLabel to the luck tint
+            this.variantLabel.setTint(tint);
+
             success = true;
           }
           break;


### PR DESCRIPTION
## What are the changes?

A QOL improvement on a visual element to see which rarity variant your pokemon sprite is on.

## Why am I doing these changes?

For fun! Plus, I've had personal confusion with not knowing for sure which was the rarer sprite and this helps making my team cooler :P.

## What did change?

Changed so that the trigger variant button would cycle variant color on the variant label based on associated sprite rarity between standard, rare and epic shiny variants.

Made sure that changing pokemon would successfully trigger the correct variant color on immediate change. // this was a pain to understand


### Screenshots/Videos

https://github.com/pagefaultgames/pokerogue/assets/112661751/bff28e71-29a2-44b4-b532-71953e124d8f


## How to test the changes?

No override changes or automated tests included.

## Checklist

- [X] There is no overlap with another PR? (I think)
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
- [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
