### PR TITLE
[BUG] Fixed frisk not setting revealedAbility flag

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2439,6 +2439,9 @@ export class FriskAbAttr extends PostSummonAbAttr {
   applyPostSummon(pokemon: Pokemon, passive: boolean, args: any[]): boolean {
     for (const opponent of pokemon.getOpponents()) {
       pokemon.scene.queueMessage(getPokemonMessage(pokemon, " frisked " + opponent.name + "'s " + opponent.getAbility().name + "!"));
+      if (opponent.battleData) {
+        opponent.battleData.abilityRevealed = true;
+      }
     }
     return true;
   }


### PR DESCRIPTION
## What are the changes?
Frisking an ability now sets the revealedAbility flag

## Why am I doing these changes?
Fixes #2233

## What did change?
`FriskAbAttr.applyPostSummon()` now sets flag.

## How to test the changes?
In `override.ts`
```
export const OPP_ABILITY_OVERRIDE: Abilities = Abilities.WATER_ABSORB;
export const MOVESET_OVERRIDE: Array<Moves> = [Moves.LIQUIDATION];
export const ABILITY_OVERRIDE: Abilities = Abilities.FRISK;
```
Liquidation should now be x0 once Water Absorb is frisked.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?