### PR TITLE
[QoL] Summary option when new Pokemon caught and party is full

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -4820,7 +4820,7 @@ export class AttemptCapturePhase extends PokemonPhase {
                   }
                 },
                 onComplete: () => {
-                  this.scene.unshiftPhase(new VictoryPhase(this.scene, this.battlerIndex)); this.catch();
+                  this.scene.unshiftPhase(new VictoryPhase(this.scene, this.battlerIndex)); this.scene.gameData.setPokemonCaught(pokemon); this.catch();
                 }
               });
             };
@@ -4915,7 +4915,7 @@ export class AttemptCapturePhase extends PokemonPhase {
           }
         });
       };
-      Promise.all([ pokemon.hideInfo(), this.scene.gameData.setPokemonCaught(pokemon) ]).then(() => {
+      Promise.all([ pokemon.hideInfo() ]).then(() => {
         if (this.scene.getParty().length === 6) {
           const promptRelease = () => {
             this.scene.ui.showText(i18next.t("battle:partyFull", { pokemonName: pokemon.name }), null, () => {

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -4819,7 +4819,9 @@ export class AttemptCapturePhase extends PokemonPhase {
                     });
                   }
                 },
-                onComplete: () => this.catch()
+                onComplete: () => {
+                  this.scene.unshiftPhase(new VictoryPhase(this.scene, this.battlerIndex)); this.catch();
+                }
               });
             };
 
@@ -4860,7 +4862,6 @@ export class AttemptCapturePhase extends PokemonPhase {
 
   catch() {
     const pokemon = this.getPokemon() as EnemyPokemon;
-    this.scene.unshiftPhase(new VictoryPhase(this.scene, this.battlerIndex));
 
     const speciesForm = !pokemon.fusionSpecies ? pokemon.getSpeciesForm() : pokemon.getFusionSpeciesForm();
 
@@ -4920,6 +4921,12 @@ export class AttemptCapturePhase extends PokemonPhase {
             this.scene.ui.showText(i18next.t("battle:partyFull", { pokemonName: pokemon.name }), null, () => {
               this.scene.pokemonInfoContainer.makeRoomForConfirmUi();
               this.scene.ui.setMode(Mode.CONFIRM, () => {
+                const newPokemon = this.scene.addPlayerPokemon(pokemon.species, pokemon.level, pokemon.abilityIndex, pokemon.formIndex, pokemon.gender, pokemon.shiny, pokemon.variant, pokemon.ivs, pokemon.nature, pokemon);
+                this.scene.ui.setMode(Mode.SUMMARY, newPokemon).then(() => {
+                  this.catch();
+                  return;
+                });
+              }, () => {
                 this.scene.ui.setMode(Mode.PARTY, PartyUiMode.RELEASE, this.fieldIndex, (slotIndex: integer, _option: PartyOption) => {
                   this.scene.ui.setMode(Mode.MESSAGE).then(() => {
                     if (slotIndex < 6) {

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -4919,7 +4919,7 @@ export class AttemptCapturePhase extends PokemonPhase {
         if (this.scene.getParty().length === 6) {
           const promptRelease = () => {
             this.scene.ui.showText(i18next.t("battle:partyFull", { pokemonName: pokemon.name }), null, () => {
-              this.scene.pokemonInfoContainer.makeRoomForConfirmUi();
+              this.scene.pokemonInfoContainer.makeRoomForConfirmUi(1, true);
               this.scene.ui.setMode(Mode.CONFIRM, () => {
                 const newPokemon = this.scene.addPlayerPokemon(pokemon.species, pokemon.level, pokemon.abilityIndex, pokemon.formIndex, pokemon.gender, pokemon.shiny, pokemon.variant, pokemon.ivs, pokemon.nature, pokemon);
                 this.scene.ui.setMode(Mode.SUMMARY, newPokemon).then(() => {

--- a/src/ui/confirm-ui-handler.ts
+++ b/src/ui/confirm-ui-handler.ts
@@ -20,7 +20,45 @@ export default class ConfirmUiHandler extends AbstractOptionSelectUiHandler {
   }
 
   show(args: any[]): boolean {
-    if (args.length >= 2 && args[0] instanceof Function && args[1] instanceof Function) {
+    if (args.length === 3 && args[0].toString().includes("newPokemon")) {
+      const config: OptionSelectConfig = {
+        options: [
+          {
+            label: i18next.t("partyUiHandler:SUMMARY"),
+            handler: () => {
+              args[0]();
+              return false;
+            },
+          }, {
+            label: i18next.t("menu:yes"),
+            handler: () => {
+              args[1]();
+              return true;
+            }
+          }, {
+            label: i18next.t("menu:no"),
+            handler: () => {
+              args[2]();
+              return true;
+            }
+          }
+        ],
+        delay: args.length >= 7 && args[6] !== null ? args[6] as integer : 0
+      };
+
+      super.show([ config ]);
+
+      this.switchCheck = args.length >= 4 && args[3] !== null && args[3] as boolean;
+
+      const xOffset = (args.length >= 5 && args[4] !== null ? args[4] as number : 0);
+      const yOffset = (args.length >= 6 && args[5] !== null ? args[5] as number : 0);
+
+      this.optionSelectContainer.setPosition((this.scene.game.canvas.width / 6) - 1 + xOffset, -48 + yOffset);
+
+      this.setCursor(this.switchCheck ? this.switchCheckCursor : 0);
+
+      return true;
+    } else if (args.length >= 2 && args[0] instanceof Function && args[1] instanceof Function) {
       const config: OptionSelectConfig = {
         options: [
           {
@@ -54,7 +92,6 @@ export default class ConfirmUiHandler extends AbstractOptionSelectUiHandler {
 
       return true;
     }
-
     return false;
   }
 

--- a/src/ui/pokemon-info-container.ts
+++ b/src/ui/pokemon-info-container.ts
@@ -364,13 +364,14 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
     });
   }
 
-  makeRoomForConfirmUi(speedMultiplier: number = 1): Promise<void> {
+  makeRoomForConfirmUi(speedMultiplier: number = 1, fromCatch: boolean = false): Promise<void> {
+    const xPosition = fromCatch ? this.initialX - this.infoWindowWidth - 65 : this.initialX - this.infoWindowWidth - ConfirmUiHandler.windowWidth;
     return new Promise<void>(resolve => {
       this.scene.tweens.add({
         targets: this,
         duration: Utils.fixedInt(Math.floor(150 / speedMultiplier)),
         ease: "Cubic.easeInOut",
-        x: this.initialX - this.infoWindowWidth - ConfirmUiHandler.windowWidth,
+        x: xPosition,
         onComplete: () => {
           resolve();
         }

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -485,7 +485,11 @@ export default class SummaryUiHandler extends UiHandler {
         if (this.summaryUiMode === SummaryUiMode.LEARN_MOVE) {
           this.hideMoveSelect();
         } else {
-          ui.setMode(Mode.PARTY);
+          if (!ui.getMessageHandler().onActionInput) {
+            ui.setMode(Mode.PARTY);
+          } else {
+            ui.setMode(Mode.MESSAGE);
+          }
         }
         success = true;
       } else {

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -485,10 +485,10 @@ export default class SummaryUiHandler extends UiHandler {
         if (this.summaryUiMode === SummaryUiMode.LEARN_MOVE) {
           this.hideMoveSelect();
         } else {
-          if (!ui.getMessageHandler().onActionInput) {
-            ui.setMode(Mode.PARTY);
-          } else {
+          if (ui.getMessageHandler().onActionInput) {
             ui.setMode(Mode.MESSAGE);
+          } else {
+            ui.setMode(Mode.PARTY);
           }
         }
         success = true;
@@ -498,6 +498,8 @@ export default class SummaryUiHandler extends UiHandler {
         case Button.UP:
         case Button.DOWN:
           if (this.summaryUiMode === SummaryUiMode.LEARN_MOVE) {
+            break;
+          } else if (ui.getMessageHandler().onActionInput) {
             break;
           }
           const isDown = button === Button.DOWN;


### PR DESCRIPTION
Recreated because of git issues
Original Found at : https://github.com/pagefaultgames/pokerogue/pull/2210 

## What are the changes?
When a player's party is full, they are presented with yes/no options to add the Pokemon to the party or release the newly caught Pokemon. This adds a 'SUMMARY' option so that the player could look at the caught Pokemon's summary before making a decision. 

## Why am I doing these changes?
I decided to make these decisions following a discussion in the Discord about the UI and the player's access to essential information regarding party formation. In addition, this feature brings PokeRogue in line to the mainline Pokemon games, which do allow the player to look at the summary page of a newly caught Pokemon. 

## What did change?
This alters the presentation of confirm-ui-handler.ts when a new Pokemon is caught and the player's party is at max from {YES, NO} to {SUMMARY, YES, NO}
In addition, it changes summary-ui-handler.ts behavior in regards to the cancellation button using differences found in setModeWithoutClear() and setMode(). The video will be also demonstrating that the Summary-UI in other occasions has not been altered in behavior in the comments. 

### Screenshots/Videos
Please see Discord. https://discord.com/channels/1125469663833370665/1249614808400007198/1249614815345901629

## How to test the changes?
Catch a Pokemon with a full party. 

## Checklist
- [ x ] There is no overlap with another PR?
- [ x ] The PR is self-contained and cannot be split into smaller PRs?
- [ x ] Have I provided a clear explanation of the changes?
- [ x ] Have I tested the changes (manually)?
    - [ x ] Are all unit tests still passing? (`npm run test`)
- [ x ] Are the changes visual?
  - [ x ] Have I provided screenshots/videos of the changes?