### PR TITLE
[Bug] Call preSwitchOutAb when Transitioning Double > Single Battle

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -1959,10 +1959,7 @@ export class PreSwitchOutClearWeatherAbAttr extends PreSwitchOutAbAttr {
    */
   applyPreSwitchOut(pokemon: Pokemon, passive: boolean, args: any[]): boolean | Promise<boolean> {
     let turnOffWeather = false;
-    let weatherType = WeatherType.NONE;
-    if (pokemon.scene.arena.weather.weatherType) {
-      weatherType = pokemon.scene.arena.weather.weatherType;
-    }
+    const weatherType = pokemon.scene.arena?.weather?.weatherType ?? WeatherType.NONE;
 
     // Clear weather only if user's ability matches the weather and no other pokemon has the ability.
     switch (weatherType) {
@@ -3145,8 +3142,8 @@ export class PostFaintClearWeatherAbAttr extends PostFaintAbAttr {
    * @returns {boolean} Returns true if the weather clears, otherwise false.
    */
   applyPostFaint(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: Move, hitResult: HitResult, args: any[]): boolean {
-    const weatherType = pokemon.scene.arena.weather.weatherType;
     let turnOffWeather = false;
+    const weatherType = pokemon.scene.arena?.weather?.weatherType ?? WeatherType.NONE;
 
     // Clear weather only if user's ability matches the weather and no other pokemon has the ability.
     switch (weatherType) {

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -1958,8 +1958,11 @@ export class PreSwitchOutClearWeatherAbAttr extends PreSwitchOutAbAttr {
    * @returns {boolean} Returns true if the weather clears, otherwise false.
    */
   applyPreSwitchOut(pokemon: Pokemon, passive: boolean, args: any[]): boolean | Promise<boolean> {
-    const weatherType = pokemon.scene.arena.weather.weatherType;
     let turnOffWeather = false;
+    let weatherType = WeatherType.NONE;
+    if (pokemon.scene.arena.weather.weatherType) {
+      weatherType = pokemon.scene.arena.weather.weatherType;
+    }
 
     // Clear weather only if user's ability matches the weather and no other pokemon has the ability.
     switch (weatherType) {

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1679,6 +1679,11 @@ export class ReturnPhase extends SwitchSummonPhase {
 
     this.scene.updateFieldScale();
 
+    const preSwitchAbList = pokemon.getAbilityAttrs(PreSwitchOutAbAttr);
+    if (preSwitchAbList.length > 0) {
+      applyPreSwitchOutAbAttrs(PreSwitchOutAbAttr, pokemon);
+    }
+
     this.scene.triggerPokemonFormChange(pokemon, SpeciesFormChangeActiveTrigger);
   }
 }

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1678,11 +1678,7 @@ export class ReturnPhase extends SwitchSummonPhase {
     pokemon.resetSummonData();
 
     this.scene.updateFieldScale();
-
-    const preSwitchAbList = pokemon.getAbilityAttrs(PreSwitchOutAbAttr);
-    if (preSwitchAbList.length > 0) {
-      applyPreSwitchOutAbAttrs(PreSwitchOutAbAttr, pokemon);
-    }
+    applyPreSwitchOutAbAttrs(PreSwitchOutAbAttr, pokemon);
 
     this.scene.triggerPokemonFormChange(pokemon, SpeciesFormChangeActiveTrigger);
   }


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Weather clears upon the pokemon returning.
## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Didn't apply before. Example: Double -> Single battle, if Primal Groudon returned, its weather would remain.
## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Added a preSwitchOutAb call on the Return phase.
This makes sure other abilities that extend PreSwitchOutAbAttr will activate correctly in the same scenario as well.
### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

https://github.com/pagefaultgames/pokerogue/assets/63990624/8044a328-9782-4558-a963-b4402e6ed3bd


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?