### PR TITLE
[Ability]  Implemented Aura Break

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -4449,7 +4449,8 @@ export function initAbilities() {
       .attr(FieldMoveTypePowerBoostAbAttr, Type.FAIRY, 4 / 3),
     new Ability(Abilities.AURA_BREAK, 6)
       .ignorable()
-      .unimplemented(),
+      .conditionalAttr(target => target.hasAbility(Abilities.DARK_AURA), FieldMoveTypePowerBoostAbAttr, Type.DARK, 9 / 16)
+      .conditionalAttr(target => target.hasAbility(Abilities.FAIRY_AURA), FieldMoveTypePowerBoostAbAttr, Type.FAIRY, 9 / 16),
     new Ability(Abilities.PRIMORDIAL_SEA, 6)
       .attr(PostSummonWeatherChangeAbAttr, WeatherType.HEAVY_RAIN)
       .attr(PostBiomeChangeWeatherChangeAbAttr, WeatherType.HEAVY_RAIN)

--- a/src/test/abilities/aura_break.test.ts
+++ b/src/test/abilities/aura_break.test.ts
@@ -37,6 +37,7 @@ describe("Abilities - Aura Break", () => {
   it("reverses the effect of fairy aura", async () => {
     vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.FAIRY_AURA);
     const basePower = allMoves[Moves.MOONBLAST].power;
+    const multiplier = 9 / 16;
     await game.startBattle([Species.MAGIKARP]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.MOONBLAST));
@@ -47,12 +48,13 @@ describe("Abilities - Aura Break", () => {
 
     expect(appliedPower).not.toBe(undefined);
     expect(appliedPower).not.toBe(basePower);
-    expect(appliedPower).lessThan(basePower);
+    expect(appliedPower).toBe(basePower * multiplier);
 
   });
   it("reverses the effect of dark aura", async () => {
     vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.DARK_AURA);
     const basePower = allMoves[Moves.DARK_PULSE].power;
+    const multiplier = 9 / 16;
     await game.startBattle([Species.MAGIKARP]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.DARK_PULSE));
@@ -63,7 +65,7 @@ describe("Abilities - Aura Break", () => {
 
     expect(appliedPower).not.toBe(undefined);
     expect(appliedPower).not.toBe(basePower);
-    expect(appliedPower).lessThan(basePower);
+    expect(appliedPower).toBe(basePower * multiplier);
   });
 });
 

--- a/src/test/abilities/aura_break.test.ts
+++ b/src/test/abilities/aura_break.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import Phaser from "phaser";
+import GameManager from "#app/test/utils/gameManager";
+import * as overrides from "#app/overrides";
+import { Species } from "#enums/species";
+import { TurnEndPhase, } from "#app/phases";
+import { Moves } from "#enums/moves";
+import { getMovePosition } from "#app/test/utils/gameManagerUtils";
+import { Abilities } from "#enums/abilities";
+import Move, { allMoves } from "#app/data/move.js";
+import Pokemon from "#app/field/pokemon.js";
+import { FieldMoveTypePowerBoostAbAttr } from "#app/data/ability.js";
+import { NumberHolder } from "#app/utils.js";
+
+
+
+describe("Abilities - Aura Break", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.MOONBLAST, Moves.DARK_PULSE, Moves.MOONBLAST, Moves.DARK_PULSE]);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.SPLASH, Moves.SPLASH, Moves.SPLASH]);
+    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.AURA_BREAK);
+  });
+
+  it("reverses the effect of fairy aura", async () => {
+    vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.FAIRY_AURA);
+    const basePower = allMoves[Moves.MOONBLAST].power;
+    await game.startBattle([Species.MAGIKARP]);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.MOONBLAST));
+
+    const appliedPower = getAppliedMovePower(game.scene.getEnemyField()[0], game.scene.getPlayerField()[0], allMoves[Moves.MOONBLAST]);
+
+
+    await game.phaseInterceptor.to(TurnEndPhase);
+
+    expect(appliedPower).not.toBe(undefined);
+    expect(appliedPower).not.toBe(basePower);
+    expect(appliedPower).lessThan(basePower);
+
+  });
+  it("reverses the effect of dark aura", async () => {
+    vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.DARK_AURA);
+    const basePower = allMoves[Moves.DARK_PULSE].power;
+    await game.startBattle([Species.MAGIKARP]);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.DARK_PULSE));
+
+    const appliedPower = getAppliedMovePower(game.scene.getEnemyField()[0], game.scene.getPlayerField()[0], allMoves[Moves.DARK_PULSE]);
+
+    await game.phaseInterceptor.to(TurnEndPhase);
+
+    expect(appliedPower).not.toBe(undefined);
+    expect(appliedPower).not.toBe(basePower);
+    expect(appliedPower).lessThan(basePower);
+  });
+});
+
+const getAppliedMovePower = (defender: Pokemon, attacker: Pokemon, move: Move) => {
+  const powerHolder = new NumberHolder(move.power);
+
+  if (defender.hasAbilityWithAttr(FieldMoveTypePowerBoostAbAttr)) {
+    const auraBreakInstance = new FieldMoveTypePowerBoostAbAttr(move.type, 9 / 16);
+    auraBreakInstance.applyPreAttack(attacker, false, defender, move, [powerHolder]);
+  }
+
+  return powerHolder.value;
+};

--- a/src/test/abilities/aura_break.test.ts
+++ b/src/test/abilities/aura_break.test.ts
@@ -3,7 +3,7 @@ import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
 import * as overrides from "#app/overrides";
 import { Species } from "#enums/species";
-import { TurnEndPhase, } from "#app/phases";
+import { MoveEffectPhase } from "#app/phases";
 import { Moves } from "#enums/moves";
 import { getMovePosition } from "#app/test/utils/gameManagerUtils";
 import { Abilities } from "#enums/abilities";
@@ -11,8 +11,6 @@ import Move, { allMoves } from "#app/data/move.js";
 import Pokemon from "#app/field/pokemon.js";
 import { FieldMoveTypePowerBoostAbAttr } from "#app/data/ability.js";
 import { NumberHolder } from "#app/utils.js";
-
-
 
 describe("Abilities - Aura Break", () => {
   let phaserGame: Phaser.Game;
@@ -43,10 +41,9 @@ describe("Abilities - Aura Break", () => {
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.MOONBLAST));
 
-    const appliedPower = getAppliedMovePower(game.scene.getEnemyField()[0], game.scene.getPlayerField()[0], allMoves[Moves.MOONBLAST]);
+    const appliedPower = getMockedMovePower(game.scene.getEnemyField()[0], game.scene.getPlayerField()[0], allMoves[Moves.MOONBLAST]);
 
-
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to(MoveEffectPhase);
 
     expect(appliedPower).not.toBe(undefined);
     expect(appliedPower).not.toBe(basePower);
@@ -60,9 +57,9 @@ describe("Abilities - Aura Break", () => {
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.DARK_PULSE));
 
-    const appliedPower = getAppliedMovePower(game.scene.getEnemyField()[0], game.scene.getPlayerField()[0], allMoves[Moves.DARK_PULSE]);
+    const appliedPower = getMockedMovePower(game.scene.getEnemyField()[0], game.scene.getPlayerField()[0], allMoves[Moves.DARK_PULSE]);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to(MoveEffectPhase);
 
     expect(appliedPower).not.toBe(undefined);
     expect(appliedPower).not.toBe(basePower);
@@ -70,7 +67,7 @@ describe("Abilities - Aura Break", () => {
   });
 });
 
-const getAppliedMovePower = (defender: Pokemon, attacker: Pokemon, move: Move) => {
+const getMockedMovePower = (defender: Pokemon, attacker: Pokemon, move: Move) => {
   const powerHolder = new NumberHolder(move.power);
 
   if (defender.hasAbilityWithAttr(FieldMoveTypePowerBoostAbAttr)) {

--- a/src/test/abilities/aura_break.test.ts
+++ b/src/test/abilities/aura_break.test.ts
@@ -67,7 +67,21 @@ describe("Abilities - Aura Break", () => {
   });
 });
 
-const getMockedMovePower = (defender: Pokemon, attacker: Pokemon, move: Move) => {
+/**
+ * Calculates the mocked power of a move in a Pokémon battle, taking into account certain abilities.
+ *
+ * @param defender - The defending Pokémon.
+ * @param attacker - The attacking Pokémon.
+ * @param move - The move being used in the attack.
+ * @returns The calculated power of the move after applying any relevant ability effects.
+ *
+ * @remarks
+ * This function creates a NumberHolder with the initial power of the move.
+ * It then checks if the defender has an ability with the FieldMoveTypePowerBoostAbAttr.
+ * If so, it applies a power modification of 9/16 using an instance of FieldMoveTypePowerBoostAbAttr.
+ * The final calculated power is then returned.
+ */
+const getMockedMovePower = (defender: Pokemon, attacker: Pokemon, move: Move): number => {
   const powerHolder = new NumberHolder(move.power);
 
   if (defender.hasAbilityWithAttr(FieldMoveTypePowerBoostAbAttr)) {


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Added functionality to make the Aura Break ability work. I also added the changes from #2246 which are needed in order to make this ability work. Aura Break reverses the effect of the Fairy Aura and Dark Aura abilities, lowering the damage of either fairy or dark moves by 25% depending on which ability the opposing pokemon possesses.
## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
The changes in #2246 are vital to the function of this PR and are the main inspiration behind this PR. The bug previously made implementing this ability difficult, as the effect of fairy aura and dark aura was not clear.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Before this PR, Aura Break, Fairy Aura, and Dark Aura were not functional. The lack of functionality in Fairy Aura and Dark Aura was due to a bug, and I added the functionality for Aura Break. 
### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
With Aura Break

https://github.com/pagefaultgames/pokerogue/assets/152253273/fcee427c-7753-4f0e-9e95-920175365152

Without Aura Break

https://github.com/pagefaultgames/pokerogue/assets/152253273/a955a4d2-f89e-4e1e-8f69-738a467d3957

With Aura Break


https://github.com/pagefaultgames/pokerogue/assets/152253273/324fc6e6-87f8-4fc7-a6ae-c34635cb90ac

Without Aura Break


https://github.com/pagefaultgames/pokerogue/assets/152253273/e2972e9c-f5f5-426c-bfac-0a29e86236fd



## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
I tested using Zygarde with Aura Break against a Xerneas with Fairy Aura or a Yveltal with Dark Aura.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?