### PR TITLE
[Localization] Fix french translations

### DIFF
--- a/src/locales/fr/ability-trigger.ts
+++ b/src/locales/fr/ability-trigger.ts
@@ -4,7 +4,7 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "blockRecoilDamage" : "{{abilityName}}\nde {{pokemonName}} le protège du contrecoup !",
   "badDreams": "{{pokemonName}} a le sommeil agité !",
   "windPowerCharged": "{{pokemonName}} a été touché par la capacité {{moveName}} et se charge en électricité !",
-  "perishBody": "{{abilityName}} de {{pokemonName}} \névanouira les deux pokémons en 3 tours !",
-  "poisonHeal": "{{abilityName}} de {{pokemonName}} \nrétablit un peu ses HP !",
+  "perishBody": "{{abilityName}} de {{pokemonName}} \nmettra KO les deux pokémons dans 3 tours !",
+  "poisonHeal": "{{abilityName}} de {{pokemonName}} \nrétablit un peu ses PV !",
   "iceFaceAvoidedDamage": "{{pokemonName}} a évité les\ndommages avec {{abilityName}}!"
 } as const;

--- a/src/locales/fr/ability-trigger.ts
+++ b/src/locales/fr/ability-trigger.ts
@@ -4,5 +4,7 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "blockRecoilDamage" : "{{abilityName}}\nde {{pokemonName}} le protège du contrecoup !",
   "badDreams": "{{pokemonName}} a le sommeil agité !",
   "windPowerCharged": "{{pokemonName}} a été touché par la capacité {{moveName}} et se charge en électricité !",
-  "iceFaceAvoidedDamage": "{{pokemonName}} avoided\ndamage with {{abilityName}}!"
+  "perishBody": "{{abilityName}} de {{pokemonName}} \névanouira les deux pokémons en 3 tours !",
+  "poisonHeal": "{{abilityName}} de {{pokemonName}} \nrétablit un peu ses HP !",
+  "iceFaceAvoidedDamage": "{{pokemonName}} a évité les\ndommages avec {{abilityName}}!"
 } as const;

--- a/src/locales/fr/achv.ts
+++ b/src/locales/fr/achv.ts
@@ -162,7 +162,7 @@ export const PGMachv: AchievementTranslationEntries = {
     description: "Capturer un Pokémon possédant un talent caché",
   },
   "PERFECT_IVS": {
-    name: "Certificat d’Authenticité",
+    name: "Certificat d’authenticité",
     description: "Avoir des IV parfaits sur un Pokémon",
   },
   "CLASSIC_VICTORY": {
@@ -171,98 +171,98 @@ export const PGMachv: AchievementTranslationEntries = {
   },
 
   "MONO_GEN_ONE": {
-    name: "The Original Rival",
-    description: "Complete the generation one only challenge.",
+    name: "Le rival originel",
+    description: "Compléter le défi de la génération 1 uniquement.",
   },
   "MONO_GEN_TWO": {
-    name: "Generation 1.5",
-    description: "Complete the generation two only challenge.",
+    name: "Entre tradition et modernité",
+    description: "Compléter le défi de la génération 2 uniquement.",
   },
   "MONO_GEN_THREE": {
     name: "Too much water?",
-    description: "Complete the generation three only challenge.",
+    description: "Compléter le défi de la génération 3 uniquement.",
   },
   "MONO_GEN_FOUR": {
-    name: "Is she really the hardest?",
-    description: "Complete the generation four only challenge.",
+    name: "Est-elle vraiment la plus difficile?",
+    description: "Compléter le défi de la génération 4 uniquement.",
   },
   "MONO_GEN_FIVE": {
-    name: "All Original",
-    description: "Complete the generation five only challenge.",
+    name: "Tous les originaux",
+    description: "Compléter le défi de la génération 5 uniquement.",
   },
   "MONO_GEN_SIX": {
-    name: "Almost Royalty",
-    description: "Complete the generation six only challenge.",
+    name: "Aristocrate",
+    description: "Compléter le défi de la génération 6 uniquement.",
   },
   "MONO_GEN_SEVEN": {
-    name: "Only Technically",
-    description: "Complete the generation seven only challenge.",
+    name: "Seulement sur le plan technique",
+    description: "Compléter le défi de la génération 7 uniquement.",
   },
   "MONO_GEN_EIGHT": {
-    name: "A Champion Time!",
-    description: "Complete the generation eight only challenge.",
+    name: "Le temps d'un champion !",
+    description: "Compléter le défi de la génération 8 uniquement.",
   },
   "MONO_GEN_NINE": {
-    name: "She was going easy on you",
-    description: "Complete the generation nine only challenge.",
+    name: "Elle y est allée doucement avec toi",
+    description: "Compléter le défi de la génération 9 uniquement.",
   },
 
   "MonoType": {
-    description: "Complete the {{type}} monotype challenge.",
+    description: "Compléter le défi du monotype {{type}}.",
   },
   "MONO_NORMAL": {
-    name: "Mono NORMAL",
+    name: "Normalement extraordinaire",
   },
   "MONO_FIGHTING": {
-    name: "I Know Kung Fu",
+    name: "Je connais le kung-fu",
   },
   "MONO_FLYING": {
-    name: "Mono FLYING",
+    name: "Maître des oiseaux",
   },
   "MONO_POISON": {
-    name: "Kanto's Favourite",
+    name: "Touche moi je t'empoissonne !",
   },
   "MONO_GROUND": {
-    name: "Mono GROUND",
+    name: "Prévisions: Tremblements de terre",
   },
   "MONO_ROCK": {
-    name: "Brock Hard",
+    name: "Solide comme un roc",
   },
   "MONO_BUG": {
-    name: "Sting Like A Beedrill",
+    name: "Une chenille !!!",
   },
   "MONO_GHOST": {
     name: "Who you gonna call?",
   },
   "MONO_STEEL": {
-    name: "Mono STEEL",
+    name: "Acier galvanisé",
   },
   "MONO_FIRE": {
-    name: "Mono FIRE",
+    name: "Allumer le feu !!",
   },
   "MONO_WATER": {
-    name: "When It Rains, It Pours",
+    name: "Quand il pleut, il pleut",
   },
   "MONO_GRASS": {
-    name: "Mono GRASS",
+    name: "Ne pas toucher !",
   },
   "MONO_ELECTRIC": {
-    name: "Mono ELECTRIC",
+    name: "Survolté",
   },
   "MONO_PSYCHIC": {
-    name: "Mono PSYCHIC",
+    name: "Télépathe",
   },
   "MONO_ICE": {
-    name: "Mono ICE",
+    name: "Froid comme la glace",
   },
   "MONO_DRAGON": {
-    name: "Mono DRAGON",
+    name: "Sort le dragon !",
   },
   "MONO_DARK": {
-    name: "It's just a phase",
+    name: "Dresseur bresom",
   },
   "MONO_FAIRY": {
-    name: "Mono FAIRY",
+    name: "Juste un peu de magie",
   },
 } as const;
 

--- a/src/locales/fr/battle.ts
+++ b/src/locales/fr/battle.ts
@@ -59,7 +59,7 @@ export const battle: SimpleTranslationEntries = {
   "wildPokemonWithAffix": "{{pokemonName}} sauvage",
   "foePokemonWithAffix": "{{pokemonName}} ennemi",
   "useMove": "{{pokemonNameWithAffix}} utilise\n{{moveName}} !",
-  "drainMessage": "{{pokemonName}} had its\nenergy drained!",
+  "drainMessage": "{{pokemonName}} a été\nvidée de son énergie !",
   "regainHealth": "{{pokemonName}} a récupéré\ndes PV!",
   "fainted": "{{pokemonNameWithAffix}} est tombé KO!"
 } as const;

--- a/src/locales/fr/challenges.ts
+++ b/src/locales/fr/challenges.ts
@@ -2,8 +2,8 @@ import { SimpleTranslationEntries } from "#app/plugins/i18n";
 
 export const challenges: SimpleTranslationEntries = {
   "title": "Paramètres du Challenge",
-  "points": "Bad Ideas",
-  "confirm_start": "Continuer avec ces paramètres ?",
+  "start": "Démarrer",
+  "illegalEvolution": "{{pokemon}} s'est transformé en pokemon\ninéligible pour ce défi !",
   "singleGeneration.name": "Mono-génération",
   "singleGeneration.value.0": "Désactivé",
   "singleGeneration.desc.0": "Vous ne pouvez choisir que des Pokémon de la génération sélectionnée.",

--- a/src/locales/fr/fight-ui-handler.ts
+++ b/src/locales/fr/fight-ui-handler.ts
@@ -4,6 +4,6 @@ export const fightUiHandler: SimpleTranslationEntries = {
   "pp": "PP",
   "power": "Puissance",
   "accuracy": "Précision",
-  "abilityFlyInText": " {{pokemonName}}'s {{passive}}{{abilityName}}",
-  "passive": "Passive ", // The space at the end is important
+  "abilityFlyInText": " {{passive}}{{abilityName}} de {{pokemonName}}",
+  "passive": "Passif ", // The space at the end is important
 } as const;

--- a/src/locales/fr/party-ui-handler.ts
+++ b/src/locales/fr/party-ui-handler.ts
@@ -1,10 +1,10 @@
 import { SimpleTranslationEntries } from "#app/plugins/i18n";
 
 export const partyUiHandler: SimpleTranslationEntries = {
-  "SEND_OUT": "Send Out",
-  "SUMMARY": "Summary",
-  "CANCEL": "Cancel",
-  "RELEASE": "Release",
-  "APPLY": "Apply",
-  "TEACH": "Teach"
+  "SEND_OUT": "Envoyer",
+  "SUMMARY": "Résumé",
+  "CANCEL": "Annuler",
+  "RELEASE": "Relâcher",
+  "APPLY": "Appliquer",
+  "TEACH": "Apprendre"
 } as const;

--- a/src/locales/fr/pokemon-info-container.ts
+++ b/src/locales/fr/pokemon-info-container.ts
@@ -7,5 +7,6 @@ export const pokemonInfoContainer: SimpleTranslationEntries = {
   "nature": "Nature :",
   "epic": "Épique",
   "rare": "Rare",
-  "common": "Commun"
+  "common": "Commun",
+  "form": "Forme:"
 } as const;

--- a/src/locales/fr/trainers.ts
+++ b/src/locales/fr/trainers.ts
@@ -13,6 +13,12 @@ export const titles: SimpleTranslationEntries = {
   "rival": "Rival·e", //Written in gender-inclusive language in wait of a potential split of the entry
   "professor": "Professeur·e", //Written in gender-inclusive language in wait of a potential split of the entry
   "frontier_brain": "Meneur·euse de Zone", //Written in gender-inclusive language in wait of a potential split of the entry
+  "rocket_boss": "Leader Team Rocket",
+  "magma_boss": "Leader Team Magma",
+  "aqua_boss": "Leader Team Aqua",
+  "galactic_boss": "Leader Team Galaxy",
+  "plasma_boss": "Leader Team Plasma",
+  "flare_boss": "Leader Team Flare",
   // Maybe if we add the evil teams we can add "Team Rocket" and "Team Aqua" etc. here as well as "Team Rocket Boss" and "Team Aqua Admin" etc.
 } as const;
 
@@ -118,7 +124,19 @@ export const trainerClasses: SimpleTranslationEntries = {
   "worker": "Ouvrier",
   "worker_female": "Ouvrière",
   "workers": "Ouvriers",
-  "youngster": "Gamin"
+  "youngster": "Gamin",
+  "rocket_grunt": "Sbire Team Rocket",
+  "rocket_grunt_female": "Sbire Team Rocket",
+  "magma_grunt": "Sbire Team Magma",
+  "magma_grunt_female": "Sbire Team Magma",
+  "aqua_grunt": "Sbire Team Aqua",
+  "aqua_grunt_female": "Sbire Team Aqua",
+  "galactic_grunt": "Sbire Team Galaxy",
+  "galactic_grunt_female": "Sbire Team Galaxy",
+  "plasma_grunt": "Sbire Team Plasma",
+  "plasma_grunt_female": "Sbire Team Plasma",
+  "flare_grunt": "Sbire Team Flare",
+  "flare_grunt_female": "Sbire Team Flare",
 } as const;
 
 // Names of special trainers like gym leaders, elite four, and the champion


### PR DESCRIPTION
## What are the changes?
Translate missing translation for the french language.

## Why am I doing these changes?
Because a lot of text isn't translated.

## What did change?
A lot of sentences and words are translated in french.

### Screenshots/Videos
![image](https://github.com/pagefaultgames/pokerogue/assets/3711182/fc91771d-d5cd-454f-95d7-99361f762406)
![image](https://github.com/pagefaultgames/pokerogue/assets/3711182/d147c6a3-d7ae-4d39-aa77-8cc6ab0f53c2)

## How to test the changes?
Select the french language and go in-game.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?