### PR TITLE
[Bug] Add revealedAbility for trace, refactor for frisk

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -1881,6 +1881,7 @@ export class TraceAbAttr extends PostSummonAbAttr {
     pokemon.summonData.ability = target.getAbility().id;
 
     pokemon.scene.queueMessage(getPokemonMessage(pokemon, ` traced ${target.name}'s\n${allAbilities[target.getAbility().id].name}!`));
+    setAbilityRevealed(target);
 
     return true;
   }
@@ -2439,9 +2440,7 @@ export class FriskAbAttr extends PostSummonAbAttr {
   applyPostSummon(pokemon: Pokemon, passive: boolean, args: any[]): boolean {
     for (const opponent of pokemon.getOpponents()) {
       pokemon.scene.queueMessage(getPokemonMessage(pokemon, " frisked " + opponent.name + "'s " + opponent.getAbility().name + "!"));
-      if (opponent.battleData) {
-        opponent.battleData.abilityRevealed = true;
-      }
+      setAbilityRevealed(opponent);
     }
     return true;
   }
@@ -3800,6 +3799,17 @@ function canApplyAttr(pokemon: Pokemon, attr: AbAttr): boolean {
 function queueShowAbility(pokemon: Pokemon, passive: boolean): void {
   pokemon.scene.unshiftPhase(new ShowAbilityPhase(pokemon.scene, pokemon.id, passive));
   pokemon.scene.clearPhaseQueueSplice();
+}
+
+/**
+ * Sets the ability of a Pokémon as revealed.
+ *
+ * @param pokemon - The Pokémon whose ability is being revealed.
+ */
+function setAbilityRevealed(pokemon: Pokemon): void {
+  if (pokemon.battleData) {
+    pokemon.battleData.abilityRevealed = true;
+  }
 }
 
 export const allAbilities = [ new Ability(Abilities.NONE, 3) ];


### PR DESCRIPTION
## What are the changes?
- refactors https://github.com/pagefaultgames/pokerogue/pull/2238 , added to Trace as well

## Why am I doing these changes?
- set `revealedAbility` for traced ability

## What did change?
- set `revealedAbility` for traced ability
- refactor for Frisk

### Screenshots/Videos

https://github.com/pagefaultgames/pokerogue/assets/68144167/2699e0ae-b503-4c8a-9083-400c8afa7e3d




## How to test the changes?
- `export const ABILITY_OVERRIDE: Abilities = Abilities.TRACE;`
- `export const MOVESET_OVERRIDE: Array<Moves> = [Moves.EMBER];`
- `export const OPP_ABILITY_OVERRIDE: Abilities = Abilities.FLASH_FIRE;`
Ember should be displayed as 0x/grayed out

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?