### PR TITLE
Added the localized dialogue for alder and kieran

### DIFF
--- a/src/locales/de/dialogue.ts
+++ b/src/locales/de/dialogue.ts
@@ -2351,31 +2351,30 @@ export const PGMdialogue: DialogueTranslationEntries = {
   },
   "alder": {
     "encounter": {
-      1: "Prepare yourself for a match against the strongest Trainer in Unova!"
+      1: "Mach dich bereit für einen Kampf gegen den stärksten Trainer in Einall! Mich - Lauro!"
     },
     "victory": {
-      1: "Well done! You certainly are an unmatched talent."
+      1: "Gut gemacht! Du hast wirklich ein unvergleichliches Talent."
     },
     "defeat": {
-      1: `A fresh wind blows through my heart...
-          $What an extraordinary effort!`
+      1: `Ein frischer Wind weht durch mein Herz...
+          $Was für ein außergewöhnliches Gefühl!`
     }
   },
   "kieran": {
     "encounter": {
-      1: `Through hard work, I become stronger and stronger!
-          $I don't lose.`
+      1: `Durch harte Arbeit werde ich immer stärker und stärker!
+         $Ich verliere nicht.`
     },
     "victory": {
-      1: `I don't believe it...
-          $What a fun and heart-pounding battle!`
+      1: `Ich kann es nicht glauben...
+          $Was für ein lustiger und herzzerreißender Kampf!`
     },
     "defeat": {
-      1: `Wowzers, what a battle!
-          $Time for you to train even harder.`
+      1: `Wow, was für ein Kampf!
+          $Es ist Zeit für dich, noch härter zu trainieren.`
     }
   },
-
   "rival": {
     "encounter": {
       1: `@c{smile}Hey, ich habe dich gesucht! Ich weiß, dass du es nicht erwarten konntest loszugehen,

--- a/src/locales/es/dialogue.ts
+++ b/src/locales/es/dialogue.ts
@@ -2109,28 +2109,28 @@ export const PGMdialogue: DialogueTranslationEntries = {
   },
   "alder": {
     "encounter": {
-      1: "Prepare yourself for a match against the strongest Trainer in Unova!"
+      1: "Prepárate para una batalla contra el entrenador más fuerte en Unova!"
     },
     "victory": {
-      1: "Well done! You certainly are an unmatched talent."
+      1: "Bien hecho! Tienes ciertamente un talento inigualable"
     },
     "defeat": {
-      1: `A fresh wind blows through my heart...
-          $What an extraordinary effort!`
+      1: `Un viento fresco sopla a través en mi corazón
+         $Qué esfuerzo extraordinario!`
     }
   },
   "kieran": {
     "encounter": {
-      1: `Through hard work, I become stronger and stronger!
-          $I don't lose.`
+      1: `A través del trabajo duro, me he vuelto más y más fuerte!
+          $No pierdo.`
     },
     "victory": {
-      1: `I don't believe it...
-          $What a fun and heart-pounding battle!`
+      1: `No puedo creerlo...
+          $¡Qué batalla tan divertida y trepidante!`
     },
     "defeat": {
-      1: `Wowzers, what a battle!
-          $Time for you to train even harder.`
+      1: `Asombroso, que batalla!
+          $Es hora de que entrenes aún más duro.`
     }
   },
   "rival": {

--- a/src/locales/fr/dialogue.ts
+++ b/src/locales/fr/dialogue.ts
@@ -2109,28 +2109,28 @@ export const PGMdialogue: DialogueTranslationEntries = {
   },
   "alder": {
     "encounter": {
-      1: "Prepare yourself for a match against the strongest Trainer in Unova!"
+      1: "Prépare-toi pour un combat contre le meilleur Dresseur d'Unys !",
     },
     "victory": {
-      1: "Well done! You certainly are an unmatched talent."
+      1: "Bien joué ! Tu as sans aucun doute un talent inégalé.",
     },
     "defeat": {
-      1: `A fresh wind blows through my heart...
-          $What an extraordinary effort!`
+      1: `Une brise fraîche traverse mon cœur…
+          $Quel effort extraordinaire !`,
     }
   },
   "kieran": {
     "encounter": {
-      1: `Through hard work, I become stronger and stronger!
-          $I don't lose.`
+      1: `Grâce à un travail acharné, je deviens de plus en plus fort !
+          $Je ne perdrai pas.`,
     },
     "victory": {
-      1: `I don't believe it...
-          $What a fun and heart-pounding battle!`
+      1: `Je n'y crois pas…
+          $Quel combat amusant et palpitant !`
     },
     "defeat": {
-      1: `Wowzers, what a battle!
-          $Time for you to train even harder.`
+      1: `Eh beh, quel combat !
+          $Il est temps pour toi de t'entraîner encore plus dur.`,
     }
   },
   "rival": {

--- a/src/locales/it/dialogue.ts
+++ b/src/locales/it/dialogue.ts
@@ -2109,28 +2109,28 @@ export const PGMdialogue: DialogueTranslationEntries = {
   },
   "alder": {
     "encounter": {
-      1: "Prepare yourself for a match against the strongest Trainer in Unova!"
+      1: "Preparati ad affrontare l’allenatore più in gamba di Unima!"
     },
     "victory": {
-      1: "Well done! You certainly are an unmatched talent."
+      1: "Ben fatto! Hai un talento invidiabile."
     },
     "defeat": {
-      1: `A fresh wind blows through my heart...
-          $What an extraordinary effort!`
+      1: `Un freddo vento attraversa il mio cuore...
+          $Che battaglia!`
     }
   },
   "kieran": {
     "encounter": {
-      1: `Through hard work, I become stronger and stronger!
-          $I don't lose.`
+      1: `Attraverso il duro lavoro, divento sempre più forte!
+          $Non perdo mai.`
     },
     "victory": {
-      1: `I don't believe it...
-          $What a fun and heart-pounding battle!`
+      1: `Non posso crederci…
+          $Che battaglia mozzafiato!`
     },
     "defeat": {
-      1: `Wowzers, what a battle!
-          $Time for you to train even harder.`
+      1: `Cavoli, che scontro!
+          $È ora che tu ti alleni ancora più duramente.`
     }
   },
   "rival": {

--- a/src/locales/ko/dialogue.ts
+++ b/src/locales/ko/dialogue.ts
@@ -2289,28 +2289,28 @@ export const PGMdialogue: DialogueTranslationEntries = {
   },
   "alder": {
     "encounter": {
-      1: "Prepare yourself for a match against the strongest Trainer in Unova!"
+      1: "하나지방에서 가장 강한 트레이너를 상대할 준비는 됐나?"
     },
     "victory": {
-      1: "Well done! You certainly are an unmatched talent."
+      1: "장하구나! 실로 견줄 자가 천하에 없도다!"
     },
     "defeat": {
-      1: `A fresh wind blows through my heart...
-          $What an extraordinary effort!`
+      1: `나의 마음에 상쾌한 바람이 지나갔다...
+          $정말 대단한 노력이다!`
     }
   },
   "kieran": {
     "encounter": {
-      1: `Through hard work, I become stronger and stronger!
-          $I don't lose.`
+      1: `난 노력을 통해 강해지고 또 강해지지!
+          $난 지지 않아.`
     },
     "victory": {
-      1: `I don't believe it...
-          $What a fun and heart-pounding battle!`
+      1: `믿을 수 없어...
+          $정말 재밌고 가슴 뛰는 배틀이었어!`
     },
     "defeat": {
-      1: `Wowzers, what a battle!
-          $Time for you to train even harder.`
+      1: `세상에 마상에! 정말 멋진 배틀이었어!
+          $네가 더 열심히 훈련할 시간이야.`
     }
   },
   "rival": {

--- a/src/locales/zh_CN/dialogue.ts
+++ b/src/locales/zh_CN/dialogue.ts
@@ -2009,28 +2009,28 @@ export const PGMdialogue: DialogueTranslationEntries = {
   },
   "alder": {
     "encounter": {
-      1: "Prepare yourself for a match against the strongest Trainer in Unova!"
+      1: "准备好和合众最强的训练家交手吧！"
     },
     "victory": {
-      1: "Well done! You certainly are an unmatched talent."
+      1: "精彩！简直就是天下无双！"
     },
     "defeat": {
-      1: `A fresh wind blows through my heart...
-          $What an extraordinary effort!`
+      1: `战斗结束后，我的心像是吹过了温和的风……
+          $真是厉害！`
     }
   },
   "kieran": {
     "encounter": {
-      1: `Through hard work, I become stronger and stronger!
-          $I don't lose.`
+      1: `我的努力让我越来越强！
+          $所以我不会输。`
     },
     "victory": {
-      1: `I don't believe it...
-          $What a fun and heart-pounding battle!`
+      1: `不可能……
+          $真是一场有趣又激动人心的战斗啊！`
     },
     "defeat": {
-      1: `Wowzers, what a battle!
-          $Time for you to train even harder.`
+      1: `哇塞，好一场战斗！
+          $你得多练练了。`
     }
   },
   "rival": {

--- a/src/locales/zh_TW/dialogue.ts
+++ b/src/locales/zh_TW/dialogue.ts
@@ -2009,28 +2009,28 @@ export const PGMdialogue: DialogueTranslationEntries = {
   },
   "alder": {
     "encounter": {
-      1: "Prepare yourself for a match against the strongest Trainer in Unova!"
+      1: "準備好和合眾最強的訓練家交手吧！"
     },
     "victory": {
-      1: "Well done! You certainly are an unmatched talent."
+      1: "精彩！簡直就是天下無雙！"
     },
     "defeat": {
-      1: `A fresh wind blows through my heart...
-          $What an extraordinary effort!`
+      1: `戰鬥結束後，我的心像是吹過了溫和的風…
+	  	$真是厲害！`
     }
   },
   "kieran": {
     "encounter": {
-      1: `Through hard work, I become stronger and stronger!
-          $I don't lose.`
+      1: `我的努力讓我越來越強！
+	  	$所以我不會輸。`
     },
     "victory": {
-      1: `I don't believe it...
-          $What a fun and heart-pounding battle!`
+      1: `不可能…
+	  	$真是一場有趣又激動人心的戰鬥啊！`
     },
     "defeat": {
-      1: `Wowzers, what a battle!
-          $Time for you to train even harder.`
+      1: `哇塞，好一場戰鬥！
+	  	$你得多練練了。`
     }
   },
   "rival": {


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
The Dialogue will appear in their native languages

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Because it is currently only english

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Text in DE, FR, Zh_CN, Ko, It
(DE by myself, others by the wiki team)

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
For the german version:

Alder:
https://github.com/pagefaultgames/pokerogue/assets/38758606/28913987-c4b7-42e4-9f04-f39d7ee59abe

Kieran:
https://github.com/pagefaultgames/pokerogue/assets/38758606/ed8e536c-234c-4e18-a6a3-ade3403afb17



## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Let them spawn (by changing battle.ts)

## Checklist
- [x] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?