### PR TITLE
[Bug] Issue #2260 Fix black screen on new game after exiting.

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -787,6 +787,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
       this.starterSelectContainer.setVisible(true);
 
+      this.setCursor(0);
       this.setGenMode(false);
       this.setCursor(0);
       this.setGenMode(true);


### PR DESCRIPTION
## What are the changes?
Setting cursor to 0 (previously -1).

## Why am I doing these changes?
To fix issue #2260 
this.cursor is set to -1 after quitting the new game UI. When entering this UI again, we use the cursor (-1) to set a variable species on line 1724. species ends up being undefined and this causes the black screen.
![image](https://github.com/pagefaultgames/pokerogue/assets/28794446/5879cd0d-c79c-459a-95ab-f9e3ebcdac9a)

## What did change?
The black screen issue is not happening anymore.

### Screenshots/Videos
Before : 
https://github.com/pagefaultgames/pokerogue/assets/28794446/d9ca52c6-daa0-4af9-81e4-0da710612e23

After : 
https://github.com/pagefaultgames/pokerogue/assets/28794446/5ad4ec2e-cab3-4723-99f1-ebb2c390bce3

## How to test the changes?
1. Go to New Game > Classic
2. Press on X to quit
3. Go to New Game > Classic 
4. No black screen.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?