### PR TITLE
[Enhancement] Add Fee Waiving Overrides

### DIFF
--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -53,6 +53,10 @@ class DefaultOverrides {
   readonly XP_MULTIPLIER_OVERRIDE: number = null;
   /** default 1000 */
   readonly STARTING_MONEY_OVERRIDE: integer = 0;
+  /** Sets all shop item prices to 0 */
+  readonly WAIVE_SHOP_FEES_OVERRIDE: boolean = false;
+  /** Sets reroll price to 0 */
+  readonly WAIVE_ROLL_FEE_OVERRIDE: boolean = false;
   readonly FREE_CANDY_UPGRADE_OVERRIDE: boolean = false;
   readonly POKEBALL_OVERRIDE: { active: boolean; pokeballs: PokeballCounts } = {
     active: false,

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -5178,9 +5178,11 @@ export class SelectModifierPhase extends BattlePhase {
             this.scene.unshiftPhase(new SelectModifierPhase(this.scene, this.rerollCount + 1, typeOptions.map(o => o.type.tier)));
             this.scene.ui.clearText();
             this.scene.ui.setMode(Mode.MESSAGE).then(() => super.end());
-            this.scene.money -= rerollCost;
-            this.scene.updateMoneyText();
-            this.scene.animateMoneyChanged(false);
+            if (!Overrides.WAIVE_ROLL_FEE_OVERRIDE) {
+              this.scene.money -= rerollCost;
+              this.scene.updateMoneyText();
+              this.scene.animateMoneyChanged(false);
+            }
             this.scene.playSound("buy");
           }
           break;
@@ -5221,7 +5223,7 @@ export class SelectModifierPhase extends BattlePhase {
         break;
       }
 
-      if (cost && this.scene.money < cost) {
+      if (cost && (this.scene.money < cost) && !Overrides.WAIVE_ROLL_FEE_OVERRIDE) {
         this.scene.ui.playError();
         return false;
       }
@@ -5231,9 +5233,11 @@ export class SelectModifierPhase extends BattlePhase {
         if (cost) {
           result.then(success => {
             if (success) {
-              this.scene.money -= cost;
-              this.scene.updateMoneyText();
-              this.scene.animateMoneyChanged(false);
+              if (!Overrides.WAIVE_ROLL_FEE_OVERRIDE) {
+                this.scene.money -= cost;
+                this.scene.updateMoneyText();
+                this.scene.animateMoneyChanged(false);
+              }
               this.scene.playSound("buy");
               (this.scene.ui.getHandler() as ModifierSelectUiHandler).updateCostText();
             } else {
@@ -5313,7 +5317,9 @@ export class SelectModifierPhase extends BattlePhase {
 
   getRerollCost(typeOptions: ModifierTypeOption[], lockRarities: boolean): integer {
     let baseValue = 0;
-    if (lockRarities) {
+    if (Overrides.WAIVE_ROLL_FEE_OVERRIDE) {
+      return baseValue;
+    } else if (lockRarities) {
       const tierValues = [50, 125, 300, 750, 2000];
       for (const opt of typeOptions) {
         baseValue += tierValues[opt.type.tier];

--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -10,6 +10,7 @@ import {Button} from "#enums/buttons";
 import MoveInfoOverlay from "./move-info-overlay";
 import { allMoves } from "../data/move";
 import * as Utils from "./../utils";
+import Overrides from "#app/overrides";
 import i18next from "i18next";
 
 export const SHOP_OPTIONS_ROW_LIMIT = 6;
@@ -726,9 +727,10 @@ class ModifierOption extends Phaser.GameObjects.Container {
 
   updateCostText(): void {
     const scene = this.scene as BattleScene;
-    const textStyle = this.modifierTypeOption.cost <= scene.money ? TextStyle.MONEY : TextStyle.PARTY_RED;
+    const cost = Overrides.WAIVE_ROLL_FEE_OVERRIDE ? 0 : this.modifierTypeOption.cost;
+    const textStyle = cost <= scene.money ? TextStyle.MONEY : TextStyle.PARTY_RED;
 
-    const formattedMoney = Utils.formatMoney(scene.moneyFormat, this.modifierTypeOption.cost);
+    const formattedMoney = Utils.formatMoney(scene.moneyFormat, cost);
 
     this.itemCostText.setText(i18next.t("modifierSelectUiHandler:itemCost", { formattedMoney }));
     this.itemCostText.setColor(getTextColor(textStyle, false, scene.uiTheme));


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->

Adds two new boolean overrides: `WAIVE_SHOP_FEES_OVERRIDE` and `WAIVE_REROLL_FEE_OVERRIDE`.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

Whenever I'm testing item weights for really rare items and making sure that they actually appear in a "normal" reward fetching context outside of `STARTING_HELD_ITEMS_OVERRIDE` and `ITEM_REWARD_OVERRIDE`, I end up having to either use an all shiny team to bolster luck or set `STARTING_MONEY_OVERRIDE` to a really large number. This usually works if luck comes through, but because reroll prices exponentially grow, you end up running out of money pretty fast and then having to restart to get the `STARTING_MONEY_OVERRIDE` to kick in again. The reroll override directly addresses this by keeping the reroll price at 0 forever, which was the primary motivation.

Alongside the reroll override, I figured I would bundle this with a shop fee override since it also pertains to test runs in general, making it easier to do a full run for testing purposes without having to necessarily play a *real* run of Classic. In a similar sense, it helps gauge what items can be realistically be obtained in a mostly normal run and has applications in unit tests, removing the necessity to coordinate money and shop prices with waves or pad values to account for swings in RNG.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

Along with the two override variables, checks and ternaries for these variables were added to the `SelectModifierPhase` at the appropriate points to make sure that cost is 0 for the corresponding things. For reroll pricing, this involves directly placing the override in `getRerollCost` and, for visual purposes, surrounding the animation and cost subtraction code in an `if`. For shop pricing though, a lot of logic already relies on cost being 0 or null; that is, anything with a cost of 0 or null is treated as a modifier roll, which makes picking up a truly free shop item turn into picking up a modifier and moving immediately into the next wave. As a result, cost isn't mutated at all. Instead, the cost subtraction is wrapped in an `if` and the `updateCostText` is changed to display 0 rather than the actual cost of the shop item. Both of these things give the effect of the shop item cost being 0 but doesn't actually change the shop item value internally.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

#### Reroll and Shop Prices - Before

<img width="673" alt="rerollBefore" src="https://github.com/pagefaultgames/pokerogue/assets/109637146/c04ebcdc-62a5-441c-9194-e95a9ad9345c"> 

#### Reroll and Shop Prices - After (w/ Overrides set to `true`)

https://github.com/pagefaultgames/pokerogue/assets/109637146/f9a69703-c689-49b6-94b0-4073707a7caf

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

All that's needed to test is to set either of the new override variables, `WAIVE_SHOP_FEES_OVERRIDE` or `WAIVE_REROLL_FEE_OVERRIDE`, to `true` in `src/overrides.ts`, going into an existing or new run, winning a wave to enter the `SelectModifierPhase`, and try buying any item or rerolling.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?