### PR TITLE
[Bug] Friendship-based moves have Base Power -1 when Pokemon is wild

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -3034,10 +3034,8 @@ export class FriendshipPowerAttr extends VariablePowerAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const power = args[0] as Utils.NumberHolder;
 
-    if (user instanceof PlayerPokemon) {
-      const friendshipPower = Math.floor(Math.min(user.friendship, 255) / 2.5);
-      power.value = Math.max(!this.invert ? friendshipPower : 102 - friendshipPower, 1);
-    }
+    const friendshipPower = Math.floor(Math.min(user instanceof PlayerPokemon ? user.friendship : user.species.baseFriendship, 255) / 2.5);
+    power.value = Math.max(!this.invert ? friendshipPower : 102 - friendshipPower, 1);
 
     return true;
   }


### PR DESCRIPTION
## What are the changes?
Friendship-based moves, which do a percentage of their maximum damage based on the user's percentage of friendship level, were previously only friendship-dependent for `PlayerPokemon` 'mons.
Pokemon in wild encounters would instead find their move to have a base power of minus one.

This PR fixes that, by scaling it to the base friendship for that Species. Essentially, the Move will be exactly as powerful during a wild encounter, as it will be immediately after you've caught them.

## Why am I doing these changes?
This bug affects RETURN, FRUSTRATION, PIKA_POW, and VEEVEE_VOLLEY.
The full effects of the bug are not immediately apparent in the level range of the typical Classic run. At those levels, friendship-based moves *will* be insultingly weaker than other moves, but believably so for moves that mention the bond between Trainer and Pokemon in their descriptions.
![image](https://github.com/pagefaultgames/pokerogue/assets/31082757/4e90a122-a293-4ed3-8210-cdf01f578a9d)
![image](https://github.com/pagefaultgames/pokerogue/assets/31082757/cae10e09-52ca-4976-97f1-cdb9a3b34165)

At higher levels, the resulting damage, from `-1` base power, will also be negative, causing the target to gain HP.
![image](https://github.com/pagefaultgames/pokerogue/assets/31082757/ba1fccac-fbe5-43c9-a519-e479e007a13d)
![image](https://github.com/pagefaultgames/pokerogue/assets/31082757/819fd7ec-8665-4766-9485-e1a50e7183a7)
[The attacking Pokemon was Lv.2000.]

Although the HP does not persist between encounters, it's still not intended or canonically-consistent behaviour.

## What did change?
Instead of leaving the base power unchanged when the user is *not* a PlayerPokemon, defaulting to the `-1` specified in the declaration of each `new AttackMove()` in `moves.ts`, the section of the formula that requires the user's friendship level is now a ternary, `user.friendship` if the Pokemon is a PlayerPokemon and `user.species.baseFriendship` to get the default value for the wild Pokemon's Species. 

### Screenshots/Videos

#### Before
![image](https://github.com/pagefaultgames/pokerogue/assets/31082757/41ffb74c-84a9-4f16-bc21-0f4d5245a56d)
![image](https://github.com/pagefaultgames/pokerogue/assets/31082757/ec2f6183-9ede-43d7-bca5-dce2a110a27e)
#### After (at Lv.2000)
![image](https://github.com/pagefaultgames/pokerogue/assets/31082757/d9bf228c-89a8-4126-acfe-3770979f5710)
![image](https://github.com/pagefaultgames/pokerogue/assets/31082757/eb85e76d-1a0e-4162-ba10-7a9750454e34)


## How to test the changes?
Overriding opponent moveset guarantees that relevant Moves are used by the opponent. Overriding opponent level is not necessary to ensure functionality, but was made use of.
```ts
export const OPP_MOVESET_OVERRIDE: Array<Moves> = [Moves.VEEVEE_VOLLEY, Moves.PIKA_PAPOW, Moves.RETURN, Moves.FRUSTRATION];
```

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?