### PR TITLE
[localization] zh_cn ability fly in text translation

### DIFF
--- a/src/locales/zh_CN/fight-ui-handler.ts
+++ b/src/locales/zh_CN/fight-ui-handler.ts
@@ -4,6 +4,6 @@ export const fightUiHandler: SimpleTranslationEntries = {
   "pp": "PP",
   "power": "威力",
   "accuracy": "命中",
-  "abilityFlyInText": " {{pokemonName}}'s {{passive}}{{abilityName}}",
-  "passive": "Passive ", // The space at the end is important
+  "abilityFlyInText": " {{pokemonName}} 的 {{passive}}{{abilityName}}",
+  "passive": "被动 ", // The space at the end is important
 } as const;


### PR DESCRIPTION


## What are the changes?
 zh_cn ability fly in text translation



## What did change?
fight-ui-handler,ts in zh_cn


## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?