### PR TITLE
[localization] zh_cn game-mode text translation

### DIFF
--- a/src/locales/zh_CN/game-mode.ts
+++ b/src/locales/zh_CN/game-mode.ts
@@ -1,10 +1,10 @@
 import { SimpleTranslationEntries } from "#app/plugins/i18n";
 
 export const gameMode: SimpleTranslationEntries = {
-  "classic": "Classic",
-  "endless": "Endless",
-  "endlessSpliced": "Endless (Spliced)",
-  "dailyRun": "Daily Run",
-  "unknown": "Unknown",
-  "challenge": "Challenge",
+  "classic": "经典模式",
+  "endless": "无尽模式",
+  "endlessSpliced": "融合无尽模式",
+  "dailyRun": "每日挑战",
+  "unknown": "未知",
+  "challenge": "挑战模式",
 } as const;


### PR DESCRIPTION
## What are the changes?
zh_cn game-mode text translation


## What did change?
game-mode.ts in zh_cn

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?