### PR TITLE
[localization] fixing growth text in zh_cn

### DIFF
--- a/src/locales/zh_CN/growth.ts
+++ b/src/locales/zh_CN/growth.ts
@@ -1,10 +1,10 @@
 import { SimpleTranslationEntries } from "#app/plugins/i18n";
 
 export const growth: SimpleTranslationEntries = {
-  "Erratic": "最快",
-  "Fast": "较快",
-  "Medium_Fast": "快",
-  "Medium_Slow": "慢",
-  "Slow": "较慢",
-  "Fluctuating": "最慢"
+  "Erratic": "非常快",
+  "Fast": "快",
+  "Medium_Fast": "较快",
+  "Medium_Slow": "较慢",
+  "Slow": "慢",
+  "Fluctuating": "非常慢"
 } as const;


### PR DESCRIPTION
## What are the changes?
growth text in zh_cn

## Why am I doing these changes?
the previous translation has mistakes.
The translation of fast/medium fast and slow/medium slow is reversed



## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?