### PR TITLE
[Bug] block input while waiting for transition to prevent changing starter during move select

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1149,6 +1149,9 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
           ];
           if (this.speciesStarterMoves.length > 1) {
             const showSwapOptions = (moveset: StarterMoveset) => {
+
+              this.blockInput = true;
+
               ui.setMode(Mode.STARTER_SELECT).then(() => {
                 ui.showText(i18next.t("starterSelectUiHandler:selectMoveSwapOut"), null, () => {
                   this.moveInfoOverlay.show(allMoves[moveset[0]]);
@@ -1158,6 +1161,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
                       const option: OptionSelectItem = {
                         label: allMoves[m].name,
                         handler: () => {
+                          this.blockInput = true;
                           ui.setMode(Mode.STARTER_SELECT).then(() => {
                             ui.showText(`${i18next.t("starterSelectUiHandler:selectMoveSwapWith")} ${allMoves[m].name}.`, null, () => {
                               const possibleMoves = this.speciesStarterMoves.filter((sm: Moves) => sm !== m);
@@ -1192,6 +1196,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
                                 maxOptions: 8,
                                 yOffset: 19
                               });
+                              this.blockInput = false;
                             });
                           });
                           return true;
@@ -1217,6 +1222,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
                     maxOptions: 8,
                     yOffset: 19
                   });
+                  this.blockInput = false;
                 });
               });
             };

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1239,6 +1239,9 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
           if (this.canCycleNature) {
             // if we could cycle natures, enable the improved nature menu
             const showNatureOptions = () => {
+
+              this.blockInput = true;
+
               ui.setMode(Mode.STARTER_SELECT).then(() => {
                 ui.showText(i18next.t("starterSelectUiHandler:selectNature"), null, () => {
                   const natures = this.scene.gameData.getNaturesForAttr(this.speciesStarterDexEntry.natureAttr);
@@ -1257,6 +1260,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
                           ui.setMode(Mode.STARTER_SELECT);
                           // set nature for starter
                           this.setSpeciesDetails(this.lastSpecies, undefined, undefined, undefined, undefined, undefined, n, undefined);
+                          this.blockInput = false;
                           return true;
                         }
                       };
@@ -1266,6 +1270,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
                       handler: () => {
                         this.clearText();
                         ui.setMode(Mode.STARTER_SELECT);
+                        this.blockInput = false;
                         return true;
                       }
                     }),


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This uses the existing blockInput flag to prevent inputs from changing the starter when opening the manage moves menu.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
addresses these copies of the same bug
https://github.com/pagefaultgames/pokerogue/issues/1879
https://github.com/pagefaultgames/pokerogue/issues/2283

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Previously inputs that happened in between the triggering of swap to options mode and before it completed would be handled by the starter select, changing the starter selection. 

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
a video wouldn't really prove that i'm hitting the buttons as described in the bug ;/

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Pull this down, open starter select, pick bulbasaur and very quickly input a right movement action.
Previously bulbasaur's moveset would open with charmander selected
With this branch bulbasaur's moves are shown and bulbasaur remains the selection

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?