### PR TITLE
[Ability] Implement Screen Cleaner

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -1633,6 +1633,25 @@ export class PostSummonAbAttr extends AbAttr {
   }
 }
 
+export class PostSummonRemoveArenaTagAbAttr extends PostSummonAbAttr {
+  private arenaTags: ArenaTagType[];
+
+  constructor(arenaTags: ArenaTagType[]) {
+    super(true);
+
+    this.arenaTags = arenaTags;
+  }
+
+  applyPostSummon(pokemon: Pokemon, passive: boolean, args: any[]): boolean | Promise<boolean> {
+    console.log("tags before summon", pokemon.scene.arena.tags);
+    for (const arena of this.arenaTags) {
+      pokemon.scene.arena.removeTag(arena);
+    }
+    console.log("tags after summon", pokemon.scene.arena.tags);
+    return true;
+  }
+}
+
 export class PostSummonMessageAbAttr extends PostSummonAbAttr {
   private messageFunc: (pokemon: Pokemon) => string;
 
@@ -4642,7 +4661,7 @@ export function initAbilities() {
     new Ability(Abilities.MIMICRY, 8)
       .unimplemented(),
     new Ability(Abilities.SCREEN_CLEANER, 8)
-      .unimplemented(),
+      .attr(PostSummonRemoveArenaTagAbAttr, [ArenaTagType.AURORA_VEIL, ArenaTagType.LIGHT_SCREEN, ArenaTagType.REFLECT]),
     new Ability(Abilities.STEELY_SPIRIT, 8)
       .attr(MoveTypePowerBoostAbAttr, Type.STEEL)
       .partial(),

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -1648,8 +1648,8 @@ export class PostSummonRemoveArenaTagAbAttr extends PostSummonAbAttr {
   }
 
   applyPostSummon(pokemon: Pokemon, passive: boolean, args: any[]): boolean | Promise<boolean> {
-    for (const arena of this.arenaTags) {
-      pokemon.scene.arena.removeTag(arena);
+    for (const arenaTag of this.arenaTags) {
+      pokemon.scene.arena.removeTag(arenaTag);
     }
     return true;
   }

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -1632,10 +1632,15 @@ export class PostSummonAbAttr extends AbAttr {
     return false;
   }
 }
-
+/**
+ * Removes specified arena tags when a Pokemon is summoned.
+ */
 export class PostSummonRemoveArenaTagAbAttr extends PostSummonAbAttr {
   private arenaTags: ArenaTagType[];
 
+  /**
+   * @param arenaTags {@linkcode ArenaTagType[]} - the arena tags to be removed
+   */
   constructor(arenaTags: ArenaTagType[]) {
     super(true);
 
@@ -1643,11 +1648,9 @@ export class PostSummonRemoveArenaTagAbAttr extends PostSummonAbAttr {
   }
 
   applyPostSummon(pokemon: Pokemon, passive: boolean, args: any[]): boolean | Promise<boolean> {
-    console.log("tags before summon", pokemon.scene.arena.tags);
     for (const arena of this.arenaTags) {
       pokemon.scene.arena.removeTag(arena);
     }
-    console.log("tags after summon", pokemon.scene.arena.tags);
     return true;
   }
 }

--- a/src/test/abilities/screen_cleaner.test.ts
+++ b/src/test/abilities/screen_cleaner.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import Phaser from "phaser";
+import GameManager from "#app/test/utils/gameManager";
+import * as overrides from "#app/overrides";
+import { Species } from "#enums/species";
+import { PostSummonPhase, TurnEndPhase, } from "#app/phases";
+import { Moves } from "#enums/moves";
+import { getMovePosition } from "#app/test/utils/gameManagerUtils";
+import { Abilities } from "#enums/abilities";
+import { ArenaTagType } from "#app/enums/arena-tag-type.js";
+
+describe("Abilities - Screen Cleaner", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.SCREEN_CLEANER);
+  });
+
+  it("removes Aurora Veil", async () => {
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.HAIL]);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.AURORA_VEIL, Moves.AURORA_VEIL, Moves.AURORA_VEIL, Moves.AURORA_VEIL]);
+
+    await game.startBattle([Species.MAGIKARP, Species.MAGIKARP]);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.HAIL));
+    await game.phaseInterceptor.to(TurnEndPhase);
+
+    expect(game.scene.arena.getTag(ArenaTagType.AURORA_VEIL)).toBeDefined();
+
+    await game.toNextTurn();
+    game.doSwitchPokemon(1);
+    await game.phaseInterceptor.to(PostSummonPhase);
+
+    expect(game.scene.arena.getTag(ArenaTagType.AURORA_VEIL)).toBeUndefined();
+  });
+
+  it("removes Light Screen", async () => {
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.LIGHT_SCREEN, Moves.LIGHT_SCREEN, Moves.LIGHT_SCREEN, Moves.LIGHT_SCREEN]);
+
+    await game.startBattle([Species.MAGIKARP, Species.MAGIKARP]);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
+    await game.phaseInterceptor.to(TurnEndPhase);
+
+    expect(game.scene.arena.getTag(ArenaTagType.LIGHT_SCREEN)).toBeDefined();
+
+    await game.toNextTurn();
+    game.doSwitchPokemon(1);
+    await game.phaseInterceptor.to(PostSummonPhase);
+
+    expect(game.scene.arena.getTag(ArenaTagType.LIGHT_SCREEN)).toBeUndefined();
+  });
+
+  it("removes Reflect", async () => {
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.REFLECT, Moves.REFLECT, Moves.REFLECT, Moves.REFLECT]);
+
+    await game.startBattle([Species.MAGIKARP, Species.MAGIKARP]);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
+    await game.phaseInterceptor.to(TurnEndPhase);
+
+    expect(game.scene.arena.getTag(ArenaTagType.REFLECT)).toBeDefined();
+
+    await game.toNextTurn();
+    game.doSwitchPokemon(1);
+    await game.phaseInterceptor.to(PostSummonPhase);
+
+    expect(game.scene.arena.getTag(ArenaTagType.REFLECT)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What are the changes?
- implements screen cleaner

## Why am I doing these changes?
- implements screen cleaner

## What did change?
- new class `PostSummonRemoveArenaTagAbAttr`

### Screenshots/Videos
Refer to console logs

https://github.com/pagefaultgames/pokerogue/assets/68144167/939a6ba7-4831-4f6e-ba2d-1cee00e85b23





Unit tests passing
<img width="410" alt="Screenshot 2024-06-18 at 3 29 29 AM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/ca837f1f-e7f0-4b74-8d53-56355b82501e">


## How to test the changes?
- use Reflect/Light Screen/Aurora Veil
- summon pokemon with Screen Cleaner

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - [x] Have I provided screenshots/videos of the changes?