### PR TITLE
[Ability] Add Dark-type immunity to Prankster

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -278,12 +278,14 @@ export default class Move implements Localizable {
   }
 
   /**
-   * Checks if the move is immune to certain types
-   * currently only look at case of Grass types and powder moves
-   * @param type {@linkcode Type} enum
+   * Checks if the move is immune to certain types.
+   * Currently looks at cases of Grass types with powder moves and Dark types with moves affected by Prankster.
+   * @param {Pokemon} user the source of this move
+   * @param {Pokemon} target the target of this move
+   * @param {Type} type the type of the move's target
    * @returns boolean
    */
-  isTypeImmune(type: Type): boolean {
+  isTypeImmune(user: Pokemon, target: Pokemon, type: Type): boolean {
     if (this.moveTarget === MoveTarget.USER) {
       return false;
     }
@@ -291,6 +293,11 @@ export default class Move implements Localizable {
     switch (type) {
     case Type.GRASS:
       if (this.hasFlag(MoveFlags.POWDER_MOVE)) {
+        return true;
+      }
+      break;
+    case Type.DARK:
+      if (user.hasAbility(Abilities.PRANKSTER) && this.category === MoveCategory.STATUS && (user.isPlayer() !== target.isPlayer())) {
         return true;
       }
       break;
@@ -4556,7 +4563,7 @@ export class RemoveTypeAttr extends MoveEffectAttr {
 
 export class CopyTypeAttr extends MoveEffectAttr {
   constructor() {
-    super(true);
+    super(false);
   }
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1730,10 +1730,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     if (typeless) {
       typeMultiplier.value = 1;
     }
-    if (types.find(t => move.isTypeImmune(t))) {
+    if (types.find(t => move.isTypeImmune(source, this, t))) {
       typeMultiplier.value = 0;
     }
-
 
     // Apply arena tags for conditional protection
     if (!move.checkFlag(MoveFlags.IGNORE_PROTECT, source, this) && !move.isAllyTarget()) {


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This changes the ability [Prankster](https://bulbapedia.bulbagarden.net/wiki/Prankster_(Ability)) to function as it does in Gen VII+ by giving Dark types immunity to Status moves from a source with the ability.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
In its current implementation, Prankster functions as in older generations of the main series without a Dark-type immunity. With this change, Prankster is functionally up to date with the main Pokemon games.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- `move`: `Move.isTypeImmune()` now includes the case of Dark types being immune to *Status moves* from *opponents* with the ability Prankster. The parameters to this function were updated to support this case.
- `move`: `CopyTypeAttr` is no longer a self-targeted attribute. This was changed because if a Pokemon with Prankster used Reflect Type against a Dark-type opponent, the user's type would still change.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

#### Test Video
The test video below shows the following cases:
- A Prankster Pokemon using a status move against a Dark-type opponent, with the immunity taking effect.
- A Prankster Pokemon using a status move against a non-Dark-type opponent (whose type changed via Reflect Type). The immunity does not take effect.
- A Prankster Pokemon using a status move against a Dark-type ally. The immunity does not take effect.
**Note**: This video was recorded before the changes to `CopyTypeAttr` were in effect, so Charmander's type incorrectly changes after it uses Reflect Type.

https://github.com/pagefaultgames/pokerogue/assets/168692175/8fb9f78e-f738-4c66-b17c-7a99bb5f5f91

This video shows the effects of Reflect being properly suppressed after the changes to `CopyTypeAttr`.

https://github.com/pagefaultgames/pokerogue/assets/168692175/6f9e02b1-1212-41b6-ba5d-cc95bc5be0ce


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

### To test manually:

In `src/overrides.ts`:
- Set `ABILITY_OVERRIDE` to `Abilities.PRANKSTER`
- Set `MOVESET_OVERRIDE` to include the Status moves you want to test (e.g. `[ Moves.GLARE, Moves.REFLECT_TYPE]`)
- Set `OPP_SPECIES_OVERRIDE` to a Dark-type species (e.g. `Species.POOCHYENA`)
- Set `OPP_MOVESET_OVERRIDE` to `[ Moves.REFLECT_TYPE, Moves.REFLECT_TYPE, Moves.REFLECT_TYPE, Moves.REFLECT_TYPE ]`. This allows you to test Status moves' effects on different types within the same battle.
- Set `STARTER_SPECIES_OVERRIDE` to a Dark-type species. This allows you to test Status moves' effects on Dark-type allies.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?