### PR TITLE
[enhancement] Move up form text when candies and hatched eggs are hidden

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1975,6 +1975,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
             this.pokemonHatchedIcon,
             this.pokemonHatchedCountText
           ].map(c => c.setVisible(false));
+          this.pokemonFormText.setY(25);
         } else if (species.speciesId === Species.ETERNATUS) {
           this.pokemonHatchedIcon.setVisible(false);
           this.pokemonHatchedCountText.setVisible(false);
@@ -1988,6 +1989,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
           this.pokemonCandyCountText.setText(`x${this.scene.gameData.starterData[species.speciesId].candyCount}`);
           this.pokemonCandyCountText.setVisible(true);
           this.pokemonFormText.setVisible(true);
+          this.pokemonFormText.setY(42);
           this.pokemonHatchedIcon.setVisible(true);
           this.pokemonHatchedCountText.setVisible(true);
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?

Follow up of  one of my previous PRs
- https://github.com/pagefaultgames/pokerogue/pull/1933

When a Pokemon does not need to display the  candy count the form text remains on the same place, creating a big empty space between the pokeball icon and the text.

This PR just moves the text up to avoid empty space

## Why am I doing these changes?

I forgot this UI detail on my last PR

## What did change?

Starter select UI form text location for pikachu (no other species has forms and cross gen prevolutions)

### Screenshots/Videos

## **BEFORE / AFTER**
![image](https://github.com/pagefaultgames/pokerogue/assets/31145813/3fe1a3d4-9369-436e-a6c5-4109f8a3a4db)

**Starters for whose we display eggs and candy are unaffected.**

![image](https://github.com/pagefaultgames/pokerogue/assets/31145813/2e1326b6-6b02-4583-93c4-c5fc5e0e0d87)

## How to test the changes?
- Open starter select UI and change Pikachu form
