### PR TITLE
[ability][test] Add tests to sturdy

### DIFF
--- a/src/test/abilities/sturdy.test.ts
+++ b/src/test/abilities/sturdy.test.ts
@@ -1,0 +1,95 @@
+import {afterEach, beforeAll, beforeEach, describe, expect, test, vi} from "vitest";
+import Phaser from "phaser";
+import GameManager from "#app/test/utils/gameManager";
+import * as overrides from "#app/overrides";
+import {
+  TurnEndPhase,
+} from "#app/phases";
+import {getMovePosition} from "#app/test/utils/gameManagerUtils";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { EnemyPokemon } from "#app/field/pokemon.js";
+
+const TIMEOUT = 20 * 1000;
+
+describe("Abilities - Sturdy", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+
+    vi.spyOn(overrides, "STARTER_SPECIES_OVERRIDE", "get").mockReturnValue(Species.LUCARIO);
+    vi.spyOn(overrides, "STARTING_LEVEL_OVERRIDE", "get").mockReturnValue(100);
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.CLOSE_COMBAT, Moves.FISSURE]);
+
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.ARON);
+    vi.spyOn(overrides, "OPP_LEVEL_OVERRIDE", "get").mockReturnValue(5);
+    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.STURDY);
+  });
+
+  test(
+    "Sturdy activates when user is at full HP",
+    async () => {
+      await game.startBattle();
+      game.doAttack(getMovePosition(game.scene, 0, Moves.CLOSE_COMBAT));
+      await game.phaseInterceptor.to(TurnEndPhase);
+      expect(game.scene.getEnemyParty()[0].hp).toBe(1);
+    },
+    TIMEOUT
+  );
+
+  test(
+    "Sturdy doesn't activate when user is not at full HP",
+    async () => {
+      await game.startBattle();
+      const enemyPokemon: EnemyPokemon = game.scene.getEnemyParty()[0];
+      enemyPokemon.hp = enemyPokemon.getMaxHp() - 1;
+      game.doAttack(getMovePosition(game.scene, 0, Moves.CLOSE_COMBAT));
+      await game.phaseInterceptor.to(TurnEndPhase);
+      expect(enemyPokemon.hp).toBe(0);
+      expect(enemyPokemon.isFainted()).toBe(true);
+    },
+    TIMEOUT
+  );
+
+  test(
+    "Sturdy pokemon should be inmune to OHKO moves",
+    async () => {
+      await game.startBattle();
+      game.doAttack(getMovePosition(game.scene, 0, Moves.FISSURE));
+      await game.phaseInterceptor.to(TurnEndPhase);
+      const enemyPokemon: EnemyPokemon = game.scene.getEnemyParty()[0];
+      expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
+    },
+    TIMEOUT
+  );
+
+  test(
+    "Sturdy is ignored by pokemon with `Abilities.MOLD_BREAKER`",
+    async () => {
+      vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.MOLD_BREAKER);
+
+      await game.startBattle();
+      game.doAttack(getMovePosition(game.scene, 0, Moves.CLOSE_COMBAT));
+      await game.phaseInterceptor.to(TurnEndPhase);
+      const enemyPokemon: EnemyPokemon = game.scene.getEnemyParty()[0];
+      expect(enemyPokemon.hp).toBe(0);
+      expect(enemyPokemon.isFainted()).toBe(true);
+    },
+    TIMEOUT
+  );
+
+});


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
Adding tests for Abilities.STURDY
## Why am I doing these changes?
Improving test coverage.
## What did change?
No new changes only new test cases
### Screenshots/Videos
N/A
## How to test the changes?
` npm run test sturdy.test.ts `
## Tested scenarios
- [x] Sturdy activates when Pokemon is at full HP
- [x] Sturdy does not activate if Pokemon is not at full HP
- [x] Sturdy Pokemon are inmune to OHKO moves
- [x] Moldbreaker ignores sturdy
