### PR TITLE
[Hotfix] uturn with kings rock

### DIFF
--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -525,6 +525,10 @@ export abstract class PokemonHeldItemModifier extends PersistentModifier {
 
   //Applies to items with chance of activating secondary effects ie Kings Rock
   getSecondaryChanceMultiplier(pokemon: Pokemon): integer {
+    // Temporary quickfix to stop game from freezing when the opponet uses u-turn while holding on to king's rock
+    if (!pokemon.getLastXMoves(0)[0]) {
+      return 1;
+    }
     const sheerForceAffected = allMoves[pokemon.getLastXMoves(0)[0].move].chance >= 0 && pokemon.hasAbility(Abilities.SHEER_FORCE);
 
     if (sheerForceAffected) {


### PR DESCRIPTION
## What are the changes?
Fixes a freeze with U-turn and King's rock

## Why am I doing these changes?
Fixes a freeze

## What did change?
Added a temporary check for if `pokemon.getLastXMoves(0)[0]` is undefined

### Screenshots/Videos
n/a

## How to test the changes?
https://discord.com/channels/1125469663833370665/1125894949020381285/1252699516419965069

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?