### PR TITLE
[Localization] Korean - fix small typo

### DIFF
--- a/src/locales/ko/trainers.ts
+++ b/src/locales/ko/trainers.ts
@@ -112,7 +112,7 @@ export const trainerClasses: SimpleTranslationEntries = {
   "school_kid": "학원끝난 아이",
   "school_kid_female": "학원끝난 아이",
   "school_kids": "학원끝난 아이",
-  "swimmer": "수연팬티 소년",
+  "swimmer": "수영팬티 소년",
   "swimmer_female": "비키니 아가씨",
   "swimmers": "수영팬티 소년 & 비키니 아가씨", // 확인 필요
   "twins": "쌍둥이",


### PR DESCRIPTION
## What are the changes?
Fix of small typo
![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/09b6a939-e900-4ce8-8626-da873b1b1f80)
수연팬티 -> 수영팬티

## Why am I doing these changes?
'Swim' of Swimmer must be translated by '수영' but it was '수연' so I changed.

## What did change?
```typescript
(-)  "swimmer": "수연팬티 소년",
(+)  "swimmer": "수영팬티 소년",
```

### Screenshots/Videos
Very small change and hard to meet him.

## How to test the changes?

## Checklist
- [X] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?