### PR TITLE
[Bug] Fix ice face blocking all hits from multihit moves

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -3682,7 +3682,7 @@ export class PostSummonStatChangeOnArenaAbAttr extends PostSummonStatChangeAbAtt
 }
 
 /**
- * Blocks the first hit of a physical move.
+ * Takes no damage from the first hit of a physical move.
  * This is used in Ice Face ability.
  */
 export class IceFaceBlockPhysicalAbAttr extends ReceivedMoveDamageMultiplierAbAttr {

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -3682,13 +3682,21 @@ export class PostSummonStatChangeOnArenaAbAttr extends PostSummonStatChangeAbAtt
 }
 
 /**
- * Applies immunity to physical moves.
+ * Blocks the first hit of a physical move.
  * This is used in Ice Face ability.
  */
-export class IceFaceMoveImmunityAbAttr extends MoveImmunityAbAttr {
+export class IceFaceBlockPhysicalAbAttr extends ReceivedMoveDamageMultiplierAbAttr {
+  private multiplier: number;
+
+  constructor(condition: PokemonDefendCondition, multiplier: number) {
+    super(condition, multiplier);
+
+    this.multiplier = multiplier;
+  }
+
   /**
    * Applies the Ice Face pre-defense ability to the Pokémon.
-   * Removes BattlerTagType.ICE_FACE hit by physical attack and is in Ice Face form.
+   * Removes BattlerTagType.ICE_FACE when hit by physical attack and is in Ice Face form.
    *
    * @param {Pokemon} pokemon - The Pokémon with the Ice Face ability.
    * @param {boolean} passive - Whether the ability is passive.
@@ -3699,16 +3707,13 @@ export class IceFaceMoveImmunityAbAttr extends MoveImmunityAbAttr {
    * @returns {boolean} - Whether the immunity was applied.
    */
   applyPreDefend(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): boolean {
-    const isImmune = super.applyPreDefend(pokemon, passive, attacker, move, cancelled, args);
-
-    if (isImmune) {
-      const simulated = args.length > 1 && args[1];
-      if (!simulated) {
-        pokemon.removeTag(BattlerTagType.ICE_FACE);
-      }
+    if (this.condition(pokemon, attacker, move)) {
+      (args[0] as Utils.NumberHolder).value = this.multiplier;
+      pokemon.removeTag(BattlerTagType.ICE_FACE);
+      return true;
     }
 
-    return isImmune;
+    return false;
   }
 
   /**
@@ -4768,7 +4773,7 @@ export function initAbilities() {
       .conditionalAttr(getWeatherCondition(WeatherType.HAIL, WeatherType.SNOW), PostSummonAddBattlerTagAbAttr, BattlerTagType.ICE_FACE, 0)
       // When weather changes to HAIL or SNOW while pokemon is fielded, add BattlerTagType.ICE_FACE
       .attr(PostWeatherChangeAddBattlerTagAttr, BattlerTagType.ICE_FACE, 0, WeatherType.HAIL, WeatherType.SNOW)
-      .attr(IceFaceMoveImmunityAbAttr, (target, user, move) => move.category === MoveCategory.PHYSICAL && !!target.getTag(BattlerTagType.ICE_FACE))
+      .attr(IceFaceBlockPhysicalAbAttr, (target, user, move) => move.category === MoveCategory.PHYSICAL && !!target.getTag(BattlerTagType.ICE_FACE), 0)
       .ignorable(),
     new Ability(Abilities.POWER_SPOT, 8)
       .attr(AllyMoveCategoryPowerBoostAbAttr, [MoveCategory.SPECIAL, MoveCategory.PHYSICAL], 1.3),

--- a/src/test/abilities/ice_face.test.ts
+++ b/src/test/abilities/ice_face.test.ts
@@ -4,6 +4,7 @@ import GameManager from "#app/test/utils/gameManager";
 import * as overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import {
+  MoveEffectPhase,
   MoveEndPhase,
   TurnEndPhase,
   TurnInitPhase,
@@ -50,6 +51,34 @@ describe("Abilities - Ice Face", () => {
     expect(eiscue.hp).equals(eiscue.getMaxHp());
     expect(eiscue.formIndex).toBe(noiceForm);
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).toBe(undefined);
+  });
+
+  it("takes no damage from multihit physical move and transforms to Noice", async () => {
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SURGING_STRIKES]);
+    vi.spyOn(overrides, "OPP_LEVEL_OVERRIDE", "get").mockReturnValue(5);
+    await game.startBattle([Species.HITMONLEE]);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.SURGING_STRIKES));
+
+    const eiscue = game.scene.getEnemyPokemon();
+    expect(eiscue.getTag(BattlerTagType.ICE_FACE)).toBeDefined();
+
+    // First hit
+    await game.phaseInterceptor.to(MoveEffectPhase);
+    expect(eiscue.hp).equals(eiscue.getMaxHp());
+    expect(eiscue.formIndex).toBe(icefaceForm);
+    expect(eiscue.getTag(BattlerTagType.ICE_FACE)).toBeUndefined();
+
+    // Second hit
+    await game.phaseInterceptor.to(MoveEffectPhase);
+    expect(eiscue.hp).lessThan(eiscue.getMaxHp());
+    expect(eiscue.formIndex).toBe(noiceForm);
+
+    await game.phaseInterceptor.to(MoveEndPhase);
+
+    expect(eiscue.hp).lessThan(eiscue.getMaxHp());
+    expect(eiscue.formIndex).toBe(noiceForm);
+    expect(eiscue.getTag(BattlerTagType.ICE_FACE)).toBeUndefined();
   });
 
   it("takes damage from special moves", async () => {


### PR DESCRIPTION
## What are the changes?
- fixes ice face bug being immune to all physical hits from multihit move

## Why am I doing these changes?
- ice face OP. closes #2388 

## What did change?
- replaced base class `MoveImmunityAbAttr` with `ReceivedMoveDamageMultiplierAbAttr`
- added unit test for multihit move

### Screenshots/Videos
<img width="691" alt="Screenshot 2024-06-19 at 9 01 32 AM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/4dbd01c5-6f28-499e-ba41-14b4940b750a">


## How to test the changes?
unit test should be enough: `npm run test ice_face`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?