### PR TITLE
[Bug] fix not changing moveset after add to starter

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1613,6 +1613,16 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       this.scene.gameData.starterData[speciesId].moveset = this.starterMoveset.slice(0) as StarterMoveset;
     }
     this.setSpeciesDetails(this.lastSpecies, undefined, undefined, undefined, undefined, undefined, undefined, false);
+
+    // switch moves of starter if exists
+    if (this.starterMovesets.length) {
+      Array.from({ length: this.starterGens.length }, (_, i) => {
+        const starterSpecies = this.genSpecies[this.starterGens[i]][this.starterCursors[i]];
+        if (starterSpecies.speciesId === speciesId) {
+          this.starterMovesets[i] = this.starterMoveset;
+        }
+      });
+    }
   }
 
   updateButtonIcon(iconSetting, gamepadType, iconElement, controlLabel): void {


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Fix the bug not changing movesets after adding the pokemon to starter as refered in #1932 

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
I thought it's pretty simple to resolve but annoying bug.
As mentioned above, it fixes the issue #1932.

Users usually think all the pokemon has same instance, and this bug was being produced because the real code is not.
So this PR changes behavior as predicted.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
when chaning the moveset, 
check if there's a moveset in starter entry.
if so, find the latest pokemon seleted and change its movesets to current moveset which is swapped.

I referenced the logic from [this](https://github.com/pagefaultgames/pokerogue/blob/be208d48b64885e8eb04f297900a2c344df1fad1/src/ui/starter-select-ui-handler.ts#L2487)

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
[스크린캐스트 2024-06-19 15-04-41.webm](https://github.com/pagefaultgames/pokerogue/assets/61226524/c3476117-7f78-45b4-850d-3c170cfa1210)


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
1. Make up starters
2. Change the movesets of starters
3. See if changed movesets are applied well after starting the game

As you can see in the video, I haven't tested cases where there are a lot of skills to set, or where the Pokémon have forms.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?