### PR TITLE
[Bug] Fixes dragon tail vs ice face eiscue interaction

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -3743,7 +3743,7 @@ function applyAbAttrsInternal<TAttr extends AbAttr>(attrType: { new(...args: any
     const attrs = ability.getAttrs(attrType);
 
     const clearSpliceQueueAndResolve = () => {
-      pokemon.scene.clearPhaseQueueSplice();
+      pokemon.scene?.clearPhaseQueueSplice();
       if (!passive) {
         return applyAbAttrsInternal(attrType, pokemon, applyFunc, args, isAsync, showAbilityInstant, quiet, true).then(() => resolve());
       } else {

--- a/src/form-change-phase.ts
+++ b/src/form-change-phase.ts
@@ -278,7 +278,7 @@ export class QuietFormChangePhase extends BattlePhase {
   }
 
   end(): void {
-    if (this.pokemon.scene.currentBattle.battleSpec === BattleSpec.FINAL_BOSS && this.pokemon instanceof EnemyPokemon) {
+    if (this.pokemon.scene?.currentBattle.battleSpec === BattleSpec.FINAL_BOSS && this.pokemon instanceof EnemyPokemon) {
       this.scene.playBgm();
       this.pokemon.summonData.battleStats = [ 0, 0, 0, 0, 0, 0, 0 ];
       this.scene.unshiftPhase(new PokemonHealPhase(this.scene, this.pokemon.getBattlerIndex(), this.pokemon.getMaxHp(), null, false, false, false, true));

--- a/src/test/abilities/ice_face.test.ts
+++ b/src/test/abilities/ice_face.test.ts
@@ -53,7 +53,7 @@ describe("Abilities - Ice Face", () => {
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).toBe(undefined);
   });
 
-  it("takes no damage from multihit physical move and transforms to Noice", async () => {
+  it("takes no damage from the first hit of multihit physical move and transforms to Noice", async () => {
     vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SURGING_STRIKES]);
     vi.spyOn(overrides, "OPP_LEVEL_OVERRIDE", "get").mockReturnValue(5);
     await game.startBattle([Species.HITMONLEE]);


### PR DESCRIPTION
## What are the changes?
- fixes issue where game crashes upon using dragon tail on ice face eiscue

## Why am I doing these changes?
- fixes [bug report sent on discord](https://discord.com/channels/1125469663833370665/1252857373890969710) (`scene` is undefined when eiscue is force switched out while transforming)

## What did change?
- added optional chaining to `scene`

### Screenshots/Videos

https://github.com/pagefaultgames/pokerogue/assets/68144167/fb7704e9-a414-4105-a74a-8993e5f7e04e




## How to test the changes?
- single or double battle
- hit eiscue ice face with dragon tail

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?