### PR TITLE
[Localization] [Ko] Add translate untranslated settings word

### DIFF
--- a/src/locales/ko/settings.ts
+++ b/src/locales/ko/settings.ts
@@ -92,7 +92,7 @@ export const settings: SimpleTranslationEntries = {
   "buttonSpeedUp": "속도 올리기",
   "buttonSlowDown": "속도 내리기",
   "alt": " (대체)",
-  "mute": "Mute",
-  "controller": "Controller",
-  "gamepadSupport": "Gamepad Support"
+  "mute": "음소거",
+  "controller": "컨트롤러",
+  "gamepadSupport": "게임패드 지원"
 } as const;


### PR DESCRIPTION
## What are the changes?
Translated missing text to Korean at settings.ts

## Why am I doing these changes?
To make localizable text to be Korean.

## What did change?
See title and files changed

### Screenshots/Videos
![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/45daa9af-7eba-49f3-ba24-d0b4578fcc18)

## How to test the changes?
(Manually) Change language to Korean, go to Settings menu.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?