### PR TITLE
[Localization] [ko] Translate battle:ppReduced message

### DIFF
--- a/src/locales/ko/battle.ts
+++ b/src/locales/ko/battle.ts
@@ -70,5 +70,5 @@ export const battle: SimpleTranslationEntries = {
   "statHarshlyFell": "[[가]] 크게 떨어졌다!",
   "statSeverelyFell": "[[가]] 매우 크게 떨어졌다!",
   "statWontGoAnyLower": "[[는]] 더 떨어지지 않는다!",
-  "ppReduced": "It reduced the PP of {{targetName}}'s\n{{moveName}} by {{reduction}}!",
+  "ppReduced": "{{targetName}}의\n{{moveName}}[[를]] {{reduction}} 깎았다!",
 } as const;


### PR DESCRIPTION
## What are the changes?
Translate ppReduced message

## Why am I doing these changes?
It's not translated so users who is not used to English are hard to understand.

## What did change?
modify src/locales/ko/battle.ts -> ppReduced
(Referred to Sw/Sh for the Korean translation.)

### Screenshots/Videos
| As-is | To-be |
| --- | --- |
| ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/10f63d7c-2ebe-4304-bd79-1f016ea4e2fc) | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/5d864547-a8fb-496b-8e16-d770173d8ffb) |

## How to test the changes?
### Manually
 - set `overrides.ts`
```typescript
export const MOVESET_OVERRIDE: Array<Moves> = [ Moves.SPITE ];
```
 - Run dev and execute moves 'Spite' and check the message.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?