### PR TITLE
[hotfix] fix message when helping hand

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -572,7 +572,7 @@ export class HelpingHandTag extends BattlerTag {
   onAdd(pokemon: Pokemon): void {
     pokemon.scene.queueMessage(
       i18next.t("battle:battlerTagsHelpingHandOnAdd", {
-        pokemonNameWithAffix: pokemon.scene.getPokemonById(this.sourceId),
+        pokemonNameWithAffix: getPokemonNameWithAffix(pokemon.scene.getPokemonById(this.sourceId)),
         pokemonName: pokemon.name
       })
     );


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
Change localized helping hand message logic.

## Why am I doing these changes?
![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/0be70328-83fa-4c8b-8bff-2d5772f5860f)
To fix this message issue.

## What did change?
add missed getPokemonNameWithAffix function to pokemon object.

### Screenshots/Videos
![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/394fa438-af5b-471a-b86b-d5782af7c5b9)

## How to test the changes?
 - test with overrides.ts
 - ```DOUBLE_BATTLE_OVERRIDE = true;```
 - ```MOVESET_OVERRIDE = [ Moves.HELPING_HAND ];```

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?