### PR TITLE
[Localization] French typo battle.ts

### DIFF
--- a/src/locales/fr/battle.ts
+++ b/src/locales/fr/battle.ts
@@ -125,7 +125,7 @@ export const battle: SimpleTranslationEntries = {
   "battlerTagsCritBoostOnAdd": "{{pokemonNameWithAffix}}\nest prêt à tout donner !",
   "battlerTagsCritBoostOnRemove": "{{pokemonNameWithAffix}} se détend.",
   "battlerTagsSaltCuredOnAdd": "{{pokemonNameWithAffix}}\nest couvert de sel !",
-  "battlerTagsSaltCuredLapse": "{{pokemonNameWithAffix}}est blessé\npar la capacité {{moveName}} !",
+  "battlerTagsSaltCuredLapse": "{{pokemonNameWithAffix}} est blessé\npar la capacité {{moveName}} !",
   "battlerTagsCursedOnAdd": "{{pokemonNameWithAffix}} sacrifie des PV\net lance une malédiction sur {{pokemonName}} !",
   "battlerTagsCursedLapse": "{{pokemonNameWithAffix}} est touché par la malédiction !"
 } as const;


### PR DESCRIPTION
## What are the changes?
A typo in French battle.ts

## Why am I doing these changes?
To remove e typo

## What did change?
French typo removed in battle.ts

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?