### PR TITLE
[Bug] Fix pre defend power multiplier

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1769,8 +1769,6 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         aura.applyPreAttack(null, null, null, move, [power]);
       }
 
-      applyPreDefendAbAttrs(ReceivedMoveDamageMultiplierAbAttr, this, source, move, cancelled, power);
-
       power.value *= typeChangeMovePowerMultiplier.value;
 
       if (!typeless) {
@@ -1796,7 +1794,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         if (this.scene.arena.getTerrainType() === TerrainType.GRASSY && this.isGrounded() && move.type === Type.GROUND && move.moveTarget === MoveTarget.ALL_NEAR_OTHERS) {
           power.value /= 2;
         }
+
         applyMoveAttrs(VariablePowerAttr, source, this, move, power);
+
         this.scene.applyModifiers(PokemonMultiHitModifier, source.isPlayer(), source, new Utils.IntegerHolder(0), power);
         if (!typeless) {
           this.scene.arena.applyTags(WeakenMoveTypeTag, move.type, power);
@@ -1934,6 +1934,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         }
 
         applyMoveAttrs(ModifiedDamageAttr, source, this, move, damage);
+        applyPreDefendAbAttrs(ReceivedMoveDamageMultiplierAbAttr, this, source, move, cancelled, power);
 
         if (power.value === 0) {
           damage.value = 0;


### PR DESCRIPTION
## What are the changes?
- fixes received move damage multiplier not appying other power calculations

## Why am I doing these changes?
- fixes [discord bug report](https://discord.com/channels/1125469663833370665/1253055799874293771) , this is not an Eiscue issue but for any abilities that extend `ReceivedMoveDamageMultiplierAbAttr`
- damage calculations were not yet finished before `ReceivedMoveDamageMultiplierAbAttr` is called

## What did change?
- move where `ReceivedMoveDamageMultiplierAbAttr` is called

### Screenshots/Videos
<img width="692" alt="Screenshot 2024-06-20 at 3 33 24 AM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/293b2848-3a16-4009-ac78-d66c077af459">


## How to test the changes?
- set your mon with an ability that extends `ReceivedMoveDamageMultiplierAbAttr`, check if damage calculation is right with moves like Power Trip
- [session data](https://discord.com/channels/1125469663833370665/1253055799874293771/1253061251387494552)

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?