### PR TITLE
[Bug] Fix bug in doubles after 1 opponent is phazed

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2484,6 +2484,9 @@ function getSheerForceHitDisableAbCondition(): AbAttrCondition {
 
 function getWeatherCondition(...weatherTypes: WeatherType[]): AbAttrCondition {
   return (pokemon: Pokemon) => {
+    if (!pokemon.scene?.arena) {
+      return false;
+    }
     if (pokemon.scene.arena.weather?.isEffectSuppressed(pokemon.scene)) {
       return false;
     }


### PR DESCRIPTION
## What are the changes?
Added an undefined check on pokemon.scene

## Why am I doing these changes?
Was causing a crash

## What did change?
Added an undefined check on pokemon.scene

### Screenshots/Videos
n/a

## How to test the changes?
Manually tested with https://discord.com/channels/1125469663833370665/1252713217738801163/1252719579474563203

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?