### PR TITLE
[Fix] Ability suppression effects not failing correctly

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5290,7 +5290,16 @@ export class SwitchAbilitiesAttr extends MoveEffectAttr {
   }
 }
 
+/**
+ * Attribute used for moves that suppress abilities like {@linkcode Moves.GASTRO_ACID}.
+ * A suppressed ability cannot be activated.
+ *
+ * @extends MoveEffectAttr
+ * @see {@linkcode apply}
+ * @see {@linkcode getCondition}
+ */
 export class SuppressAbilitiesAttr extends MoveEffectAttr {
+  /** Sets ability suppression for the target pokemon and displays a message. */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     if (!super.apply(user, target, move, args)) {
       return false;
@@ -5303,6 +5312,7 @@ export class SuppressAbilitiesAttr extends MoveEffectAttr {
     return true;
   }
 
+  /** Causes the effect to fail when the target's ability is unsupressable or already suppressed. */
   getCondition(): MoveConditionFunc {
     return (user, target, move) => !target.getAbility().hasAttr(UnsuppressableAbilityAbAttr) && !target.summonData.abilitySuppressed;
   }

--- a/src/test/moves/gastro_acid.test.ts
+++ b/src/test/moves/gastro_acid.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import GameManager from "../utils/gameManager";
+import {
+  Moves
+} from "#app/enums/moves.js";
+import * as overrides from "#app/overrides";
+import { Abilities } from "#app/enums/abilities.js";
+import { BattlerIndex } from "#app/battle.js";
+import { getMovePosition } from "../utils/gameManagerUtils";
+import { MoveResult } from "#app/field/pokemon.js";
+import { Stat } from "#app/data/pokemon-stat.js";
+
+const TIMEOUT = 20 * 1000;
+
+describe("Moves - Gastro Acid", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    vi.spyOn(overrides, "DOUBLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(overrides, "STARTING_LEVEL_OVERRIDE", "get").mockReturnValue(1);
+    vi.spyOn(overrides, "OPP_LEVEL_OVERRIDE", "get").mockReturnValue(100);
+    vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.NONE);
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.GASTRO_ACID, Moves.WATER_GUN, Moves.SPLASH, Moves.CORE_ENFORCER]);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.SPLASH, Moves.SPLASH, Moves.SPLASH]);
+    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.WATER_ABSORB);
+  });
+
+  it("suppresses effect of ability", async () => {
+    /*
+     * Expected flow (enemies have WATER ABSORD, can only use SPLASH)
+     * - player mon 1 uses GASTRO ACID, player mon 2 uses SPLASH
+     * - both player mons use WATER GUN on their respective enemy mon
+     * - player mon 1 should have dealt damage, player mon 2 should have not
+     */
+
+    await game.startBattle();
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.GASTRO_ACID));
+    game.doSelectTarget(BattlerIndex.ENEMY);
+    game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
+    game.doSelectTarget(BattlerIndex.PLAYER_2);
+
+    await game.phaseInterceptor.to("TurnInitPhase");
+
+    const enemyField = game.scene.getEnemyField();
+    expect(enemyField[0].summonData.abilitySuppressed).toBe(true);
+    expect(enemyField[1].summonData.abilitySuppressed).toBe(false);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.WATER_GUN));
+    game.doSelectTarget(BattlerIndex.ENEMY);
+    game.doAttack(getMovePosition(game.scene, 0, Moves.WATER_GUN));
+    game.doSelectTarget(BattlerIndex.ENEMY_2);
+
+    await game.phaseInterceptor.to("TurnEndPhase");
+
+    expect(enemyField[0].hp).toBeLessThan(enemyField[0].getMaxHp());
+    expect(enemyField[1].hp).toBe(enemyField[1].getMaxHp());
+  }, TIMEOUT);
+
+  it("fails if used on an enemy with an already-suppressed ability", async () => {
+    vi.spyOn(overrides, "DOUBLE_BATTLE_OVERRIDE", "get").mockReturnValue(false);
+
+    await game.startBattle();
+
+    // Force player to be slower to enable Core Enforcer to proc its suppression effect
+    game.scene.getPlayerPokemon().stats[Stat.SPD] = 1;
+    game.scene.getEnemyPokemon().stats[Stat.SPD] = 2;
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.CORE_ENFORCER));
+
+    await game.phaseInterceptor.to("TurnInitPhase");
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.GASTRO_ACID));
+
+    await game.phaseInterceptor.to("TurnInitPhase");
+
+    expect(game.scene.getPlayerPokemon().getLastXMoves()[0].result).toBe(MoveResult.FAIL);
+  }, TIMEOUT);
+});


### PR DESCRIPTION
## What are the changes?
Add condition to SuppressAbilityAttr to make the attr fail if the target's ability is already suppressed.

## Why am I doing these changes?
Current behavior deviates from games in that ability suppression effects can happen even if the ability is already suppressed. This means repeated uses of Gastro Acid will be successful instead of failing like they should. This doesn't matter except for if they somehow know Stomping Tantrum, but it's slightly annoying for Core Enforcer users to see the suppression message every time the effect activates.

## What did change?
* Add a check to `SuppressAbilitiesAttr` that fails if the target's ability is already suppressed
* Document `SuppressAbilitiesAttr` and add unit tests for Gastro Acid

### Screenshots/Videos
Expected behavior:

![firefox_FYbvFotTQM](https://github.com/pagefaultgames/pokerogue/assets/6374275/42012af8-1b6f-4f7b-819e-d17be750976e)

Current behavior:

https://github.com/pagefaultgames/pokerogue/assets/6374275/6221d350-8b6b-4c6a-b575-69c2d3f20dba

New behavior:

https://github.com/pagefaultgames/pokerogue/assets/6374275/3f45eb1e-0d22-4a73-8db7-c7c0c016b72f

## How to test the changes?
Unit tests.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?