### PR TITLE
[Bug] Fix Minimize AI and add NaN AI score safeguard

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -3964,6 +3964,8 @@ export class AddBattlerTagAttr extends MoveEffectAttr {
       return -3;
     case BattlerTagType.ENCORE:
       return -2;
+    case BattlerTagType.MINIMIZED:
+      return 0;
     case BattlerTagType.INGRAIN:
     case BattlerTagType.IGNORE_ACCURACY:
     case BattlerTagType.AQUA_RING:

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3505,6 +3505,10 @@ export class EnemyPokemon extends Pokemon {
 
             const target = this.scene.getField()[mt];
             let targetScore = move.getUserBenefitScore(this, target, move) + move.getTargetBenefitScore(this, target, move) * (mt < BattlerIndex.ENEMY === this.isPlayer() ? 1 : -1);
+            if (Number.isNaN(targetScore)) {
+              console.error(`Move ${move.name} returned score of NaN`);
+              targetScore = 0;
+            }
             if ((move.name.endsWith(" (N)") || !move.applyConditions(this, target, move)) && ![Moves.SUCKER_PUNCH, Moves.UPPER_HAND, Moves.THUNDERCLAP].includes(move.id)) {
               targetScore = -20;
             } else if (move instanceof AttackMove) {


### PR DESCRIPTION
## What are the changes?
Different browsers will no longer treat Minimize differently for the AI.

## Why am I doing these changes?
Minimize was being chosen inconsistently across browsers and causing other moves to also be used inconsistently.

## What did change?
The minimized battler tag now has a score of 0. In addition if a target's score is NaN it'll now be logged in the console and treated as 0 instead.

## How to test the changes?
Give an AI minimize and some other moves, try in firefox vs chrome and notice that the list of moves sorted by score was different without this patch and consistent with this patch.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)