### PR TITLE
[Unit Test] Remove HP assignment from Follow Me, Rage Powder, and Spotlight tests

### DIFF
--- a/src/test/moves/follow_me.test.ts
+++ b/src/test/moves/follow_me.test.ts
@@ -54,7 +54,7 @@ describe("Moves - Follow Me", () => {
       expect(enemyPokemon.length).toBe(2);
       enemyPokemon.forEach(p => expect(p).not.toBe(undefined));
 
-      playerPokemon.forEach(p => p.hp = 200);
+      const playerStartingHp = playerPokemon.map(p => p.hp);
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.FOLLOW_ME));
       await game.phaseInterceptor.to(CommandPhase);
@@ -65,8 +65,8 @@ describe("Moves - Follow Me", () => {
       game.doSelectTarget(BattlerIndex.ENEMY);
       await game.phaseInterceptor.to(TurnEndPhase, false);
 
-      expect(playerPokemon[0].hp).toBeLessThan(200);
-      expect(playerPokemon[1].hp).toBe(200);
+      expect(playerPokemon[0].hp).toBeLessThan(playerStartingHp[0]);
+      expect(playerPokemon[1].hp).toBe(playerStartingHp[1]);
     }, TIMEOUT
   );
 
@@ -83,7 +83,7 @@ describe("Moves - Follow Me", () => {
       expect(enemyPokemon.length).toBe(2);
       enemyPokemon.forEach(p => expect(p).not.toBe(undefined));
 
-      playerPokemon.forEach(p => p.hp = 200);
+      const playerStartingHp = playerPokemon.map(p => p.hp);
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.FOLLOW_ME));
       await game.phaseInterceptor.to(CommandPhase);
@@ -93,8 +93,8 @@ describe("Moves - Follow Me", () => {
 
       playerPokemon.sort((a, b) => a.getBattleStat(Stat.SPD) - b.getBattleStat(Stat.SPD));
 
-      expect(playerPokemon[1].hp).toBeLessThan(200);
-      expect(playerPokemon[0].hp).toBe(200);
+      expect(playerPokemon[1].hp).toBeLessThan(playerStartingHp[1]);
+      expect(playerPokemon[0].hp).toBe(playerStartingHp[0]);
     }, TIMEOUT
   );
 
@@ -115,7 +115,7 @@ describe("Moves - Follow Me", () => {
       expect(enemyPokemon.length).toBe(2);
       enemyPokemon.forEach(p => expect(p).not.toBe(undefined));
 
-      enemyPokemon.forEach(p => p.hp = 200);
+      const enemyStartingHp = enemyPokemon.map(p => p.hp);
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.QUICK_ATTACK));
       await game.phaseInterceptor.to(SelectTargetPhase, false);
@@ -128,7 +128,8 @@ describe("Moves - Follow Me", () => {
       await game.phaseInterceptor.to(TurnEndPhase, false);
 
       // If redirection was bypassed, both enemies should be damaged
-      enemyPokemon.forEach(p => expect(p.hp).toBeLessThan(200));
+      expect(enemyPokemon[0].hp).toBeLessThan(enemyStartingHp[0]);
+      expect(enemyPokemon[1].hp).toBeLessThan(enemyStartingHp[1]);
     }, TIMEOUT
   );
 
@@ -148,7 +149,7 @@ describe("Moves - Follow Me", () => {
       expect(enemyPokemon.length).toBe(2);
       enemyPokemon.forEach(p => expect(p).not.toBe(undefined));
 
-      enemyPokemon.forEach(p => p.hp = 200);
+      const enemyStartingHp = enemyPokemon.map(p => p.hp);
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.SNIPE_SHOT));
       await game.phaseInterceptor.to(SelectTargetPhase, false);
@@ -161,7 +162,8 @@ describe("Moves - Follow Me", () => {
       await game.phaseInterceptor.to(TurnEndPhase, false);
 
       // If redirection was bypassed, both enemies should be damaged
-      enemyPokemon.forEach(p => expect(p.hp).toBeLessThan(200));
+      expect(enemyPokemon[0].hp).toBeLessThan(enemyStartingHp[0]);
+      expect(enemyPokemon[1].hp).toBeLessThan(enemyStartingHp[1]);
     }, TIMEOUT
   );
 });

--- a/src/test/moves/rage_powder.test.ts
+++ b/src/test/moves/rage_powder.test.ts
@@ -55,7 +55,7 @@ describe("Moves - Rage Powder", () => {
       expect(enemyPokemon.length).toBe(2);
       enemyPokemon.forEach(p => expect(p).not.toBe(undefined));
 
-      enemyPokemon.forEach(p => p.hp = 200);
+      const enemyStartingHp = enemyPokemon.map(p => p.hp);
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.QUICK_ATTACK));
       await game.phaseInterceptor.to(SelectTargetPhase, false);
@@ -68,7 +68,8 @@ describe("Moves - Rage Powder", () => {
       await game.phaseInterceptor.to(TurnEndPhase, false);
 
       // If redirection was bypassed, both enemies should be damaged
-      enemyPokemon.forEach(p => expect(p.hp).toBeLessThan(200));
+      expect(enemyPokemon[0].hp).toBeLessThan(enemyStartingHp[0]);
+      expect(enemyPokemon[1].hp).toBeLessThan(enemyStartingHp[1]);
     }, TIMEOUT
   );
 
@@ -89,7 +90,7 @@ describe("Moves - Rage Powder", () => {
       expect(enemyPokemon.length).toBe(2);
       enemyPokemon.forEach(p => expect(p).not.toBe(undefined));
 
-      enemyPokemon.forEach(p => p.hp = 200);
+      const enemyStartingHp = enemyPokemon.map(p => p.hp);
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.QUICK_ATTACK));
       await game.phaseInterceptor.to(SelectTargetPhase, false);
@@ -102,7 +103,8 @@ describe("Moves - Rage Powder", () => {
       await game.phaseInterceptor.to(TurnEndPhase, false);
 
       // If redirection was bypassed, both enemies should be damaged
-      enemyPokemon.forEach(p => expect(p.hp).toBeLessThan(200));
+      expect(enemyPokemon[0].hp).toBeLessThan(enemyStartingHp[0]);
+      expect(enemyPokemon[1].hp).toBeLessThan(enemyStartingHp[1]);
     }, TIMEOUT
   );
 });

--- a/src/test/moves/spotlight.test.ts
+++ b/src/test/moves/spotlight.test.ts
@@ -53,7 +53,7 @@ describe("Moves - Spotlight", () => {
       expect(enemyPokemon.length).toBe(2);
       enemyPokemon.forEach(p => expect(p).not.toBe(undefined));
 
-      enemyPokemon.forEach(p => p.hp = 200);
+      const enemyStartingHp = enemyPokemon.map(p => p.hp);
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.SPOTLIGHT));
       await game.phaseInterceptor.to(SelectTargetPhase, false);
@@ -65,8 +65,8 @@ describe("Moves - Spotlight", () => {
       game.doSelectTarget(BattlerIndex.ENEMY_2);
       await game.phaseInterceptor.to(TurnEndPhase, false);
 
-      expect(enemyPokemon[0].hp).toBeLessThan(200);
-      expect(enemyPokemon[1].hp).toBe(200);
+      expect(enemyPokemon[0].hp).toBeLessThan(enemyStartingHp[0]);
+      expect(enemyPokemon[1].hp).toBe(enemyStartingHp[1]);
     }, TIMEOUT
   );
 
@@ -85,8 +85,6 @@ describe("Moves - Spotlight", () => {
       expect(enemyPokemon.length).toBe(2);
       enemyPokemon.forEach(p => expect(p).not.toBe(undefined));
 
-      enemyPokemon.forEach(p => p.hp = 200);
-
       /**
        * Spotlight will target the slower enemy. In this situation without Spotlight being used,
        * the faster enemy would normally end up with the Center of Attention tag.
@@ -94,6 +92,8 @@ describe("Moves - Spotlight", () => {
       enemyPokemon.sort((a, b) => b.getBattleStat(Stat.SPD) - a.getBattleStat(Stat.SPD));
       const spotTarget = enemyPokemon[1].getBattlerIndex();
       const attackTarget = enemyPokemon[0].getBattlerIndex();
+
+      const enemyStartingHp = enemyPokemon.map(p => p.hp);
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.SPOTLIGHT));
       await game.phaseInterceptor.to(SelectTargetPhase, false);
@@ -105,8 +105,8 @@ describe("Moves - Spotlight", () => {
       game.doSelectTarget(attackTarget);
       await game.phaseInterceptor.to(TurnEndPhase, false);
 
-      expect(enemyPokemon[1].hp).toBeLessThan(200);
-      expect(enemyPokemon[0].hp).toBe(200);
+      expect(enemyPokemon[1].hp).toBeLessThan(enemyStartingHp[1]);
+      expect(enemyPokemon[0].hp).toBe(enemyStartingHp[0]);
     }, TIMEOUT
   );
 });


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This fixes an issue where direct assignment to a Pokemon's HP would sometimes cause the Follow Me, Rage Powder, and Spotlight unit tests to fail.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Other unrelated PRs are sometimes failing tests in part due to this issue.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Damage checks in these unit tests are now based on the enemy's max HP.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
N/A

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
`npm run test`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [N/A] Are the changes visual?
  - [N/A] Have I provided screenshots/videos of the changes?