### PR TITLE
[QoL] Move fusion icon to right of gender icon in party ui

### DIFF
--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -1073,7 +1073,7 @@ class PartySlot extends Phaser.GameObjects.Container {
       if (this.slotIndex >= battlerCount) {
         slotGenderText.setPositionRelative(slotLevelLabel, 36, 0);
       } else {
-        slotGenderText.setPositionRelative(slotName, 76, 3);
+        slotGenderText.setPositionRelative(slotName, 76 - (this.pokemon.fusionSpecies ? 8 : 0), 3);
       }
       slotGenderText.setOrigin(0, 0.25);
 
@@ -1085,9 +1085,9 @@ class PartySlot extends Phaser.GameObjects.Container {
       splicedIcon.setScale(0.5);
       splicedIcon.setOrigin(0, 0);
       if (this.slotIndex >= battlerCount) {
-        splicedIcon.setPositionRelative(slotLevelLabel, 36 - (genderSymbol ? 8 : 0), 0.5);
+        splicedIcon.setPositionRelative(slotLevelLabel, 36 + (genderSymbol ? 8 : 0), 0.5);
       } else {
-        splicedIcon.setPositionRelative(slotName, 76 - (genderSymbol ? 8 : 0), 3.5);
+        splicedIcon.setPositionRelative(slotName, 76, 3.5);
       }
 
       slotInfoContainer.add(splicedIcon);


### PR DESCRIPTION
## What are the changes?
Moved the Pokemon fusion icon from the left to the right of the gender icon

## Why am I doing these changes?
Fix issue #2458 

## What did change?
The icon moved

### Screenshots/Videos
Before
![before-1](https://i.ember.zone/scooPlVzJxuNMlWw.png)
![before-2](https://i.ember.zone/ucHIHfnSQXaqNYca.png)
After
![after-1](https://i.ember.zone/VlPYRHEsRBQBYrs7.png)
![after-2](https://i.ember.zone/mfqsAlrSMmFeqXOK.png)

## How to test the changes?
You can get some DNA Splicers with this override
```js
export const ITEM_REWARD_OVERRIDE: Array<String> = ["DNA_SPLICERS"];
```

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?

![tests](https://i.ember.zone/8cTzuD9LwEJ59vzZ.png)