### PR TITLE
[Balance] Protean / Libero changed to Gen 6-8 Implementation

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -4490,7 +4490,7 @@ export function initAbilities() {
       .partial(), // Healing not blocked by Heal Block
     new Ability(Abilities.PROTEAN, 6)
       .attr(PokemonTypeChangeAbAttr),
-      //.condition((p) => !p.summonData?.abilitiesApplied.includes(Abilities.PROTEAN)), //Gen 9 Implementation
+    //.condition((p) => !p.summonData?.abilitiesApplied.includes(Abilities.PROTEAN)), //Gen 9 Implementation
     new Ability(Abilities.FUR_COAT, 6)
       .attr(ReceivedMoveDamageMultiplierAbAttr, (target, user, move) => move.category === MoveCategory.PHYSICAL, 0.5)
       .ignorable(),
@@ -4733,7 +4733,7 @@ export function initAbilities() {
       .condition(getOncePerBattleCondition(Abilities.DAUNTLESS_SHIELD)),
     new Ability(Abilities.LIBERO, 8)
       .attr(PokemonTypeChangeAbAttr),
-      //.condition((p) => !p.summonData?.abilitiesApplied.includes(Abilities.LIBERO)), //Gen 9 Implementation
+    //.condition((p) => !p.summonData?.abilitiesApplied.includes(Abilities.LIBERO)), //Gen 9 Implementation
     new Ability(Abilities.BALL_FETCH, 8)
       .attr(FetchBallAbAttr)
       .condition(getOncePerBattleCondition(Abilities.BALL_FETCH)),

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -4489,8 +4489,8 @@ export function initAbilities() {
       .attr(HealFromBerryUseAbAttr, 1/3)
       .partial(), // Healing not blocked by Heal Block
     new Ability(Abilities.PROTEAN, 6)
-      .attr(PokemonTypeChangeAbAttr)
-      .condition((p) => !p.summonData?.abilitiesApplied.includes(Abilities.PROTEAN)),
+      .attr(PokemonTypeChangeAbAttr),
+//      .condition((p) => !p.summonData?.abilitiesApplied.includes(Abilities.PROTEAN)), //Gen 9 Implementation
     new Ability(Abilities.FUR_COAT, 6)
       .attr(ReceivedMoveDamageMultiplierAbAttr, (target, user, move) => move.category === MoveCategory.PHYSICAL, 0.5)
       .ignorable(),
@@ -4732,8 +4732,8 @@ export function initAbilities() {
       .attr(PostSummonStatChangeAbAttr, BattleStat.DEF, 1, true)
       .condition(getOncePerBattleCondition(Abilities.DAUNTLESS_SHIELD)),
     new Ability(Abilities.LIBERO, 8)
-      .attr(PokemonTypeChangeAbAttr)
-      .condition((p) => !p.summonData?.abilitiesApplied.includes(Abilities.LIBERO)),
+      .attr(PokemonTypeChangeAbAttr),
+//      .condition((p) => !p.summonData?.abilitiesApplied.includes(Abilities.LIBERO)), //Gen 9 Implementation
     new Ability(Abilities.BALL_FETCH, 8)
       .attr(FetchBallAbAttr)
       .condition(getOncePerBattleCondition(Abilities.BALL_FETCH)),

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -4490,7 +4490,7 @@ export function initAbilities() {
       .partial(), // Healing not blocked by Heal Block
     new Ability(Abilities.PROTEAN, 6)
       .attr(PokemonTypeChangeAbAttr),
-//      .condition((p) => !p.summonData?.abilitiesApplied.includes(Abilities.PROTEAN)), //Gen 9 Implementation
+      //.condition((p) => !p.summonData?.abilitiesApplied.includes(Abilities.PROTEAN)), //Gen 9 Implementation
     new Ability(Abilities.FUR_COAT, 6)
       .attr(ReceivedMoveDamageMultiplierAbAttr, (target, user, move) => move.category === MoveCategory.PHYSICAL, 0.5)
       .ignorable(),
@@ -4733,7 +4733,7 @@ export function initAbilities() {
       .condition(getOncePerBattleCondition(Abilities.DAUNTLESS_SHIELD)),
     new Ability(Abilities.LIBERO, 8)
       .attr(PokemonTypeChangeAbAttr),
-//      .condition((p) => !p.summonData?.abilitiesApplied.includes(Abilities.LIBERO)), //Gen 9 Implementation
+      //.condition((p) => !p.summonData?.abilitiesApplied.includes(Abilities.LIBERO)), //Gen 9 Implementation
     new Ability(Abilities.BALL_FETCH, 8)
       .attr(FetchBallAbAttr)
       .condition(getOncePerBattleCondition(Abilities.BALL_FETCH)),

--- a/src/test/abilities/libero.test.ts
+++ b/src/test/abilities/libero.test.ts
@@ -57,7 +57,7 @@ describe("Abilities - Protean", () => {
     TIMEOUT,
   );
 
-  test(
+  test.skip(
     "ability applies only once per switch in",
     async () => {
       vi.spyOn(Overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.AGILITY]);

--- a/src/test/abilities/protean.test.ts
+++ b/src/test/abilities/protean.test.ts
@@ -57,7 +57,7 @@ describe("Abilities - Protean", () => {
     TIMEOUT,
   );
 
-  test(
+  test.skip(
     "ability applies only once per switch in",
     async () => {
       vi.spyOn(Overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.AGILITY]);


### PR DESCRIPTION
## What are the changes?
Commented out the Gen 9 once-per-time-on-field condition for Protean and Libero.

## Why am I doing these changes?
Overall a better change for the player experience, especially with how battles can swap environments constantly.

## What did change?
// Commented out and labelled the .condition for both Protean and Libero

### Screenshots/Videos


https://github.com/pagefaultgames/pokerogue/assets/21964105/55ea8412-8a6a-4bf9-8374-d62edb997e59


## How to test the changes?
Grab any pokemon with Protean or Libero and spam moves of different types.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?