### PR TITLE
[Bug] Fix arena traps on flyout

### DIFF
--- a/src/ui/arena-flyout.ts
+++ b/src/ui/arena-flyout.ts
@@ -273,12 +273,14 @@ export default class ArenaFlyout extends Phaser.GameObjects.Container {
       const existingTrapTagIndex = isArenaTrapTag ? this.fieldEffectInfo.findIndex(e => tagAddedEvent.arenaTagType === e.tagType && arenaEffectType === e.effecType) : -1;
       let name: string = ArenaTagType[tagAddedEvent.arenaTagType];
 
-      if (existingTrapTagIndex !== -1) {
-        const layers = tagAddedEvent.arenaTagMaxLayers > 1 ? ` (${tagAddedEvent.arenaTagLayers})` : "";
-        this.fieldEffectInfo[existingTrapTagIndex].name = `${name}${layers}`;
-        break;
-      } else if (tagAddedEvent.arenaTagMaxLayers > 1) {
-        name = `${name} (${tagAddedEvent.arenaTagLayers})`;
+      if (isArenaTrapTag) {
+        if (existingTrapTagIndex !== -1) {
+          const layers = tagAddedEvent.arenaTagMaxLayers > 1 ? ` (${tagAddedEvent.arenaTagLayers})` : "";
+          this.fieldEffectInfo[existingTrapTagIndex].name = `${name}${layers}`;
+          break;
+        } else if (tagAddedEvent.arenaTagMaxLayers > 1) {
+          name = `${name} (${tagAddedEvent.arenaTagLayers})`;
+        }
       }
 
       this.fieldEffectInfo.push({

--- a/src/ui/arena-flyout.ts
+++ b/src/ui/arena-flyout.ts
@@ -273,15 +273,13 @@ export default class ArenaFlyout extends Phaser.GameObjects.Container {
       const existingTrapTagIndex = isArenaTrapTag ? this.fieldEffectInfo.findIndex(e => tagAddedEvent.arenaTagType === e.tagType && arenaEffectType === e.effecType) : -1;
       let name: string = ArenaTagType[tagAddedEvent.arenaTagType];
 
-      if (isArenaTrapTag && tagAddedEvent.arenaTagMaxLayers > 1) {
-        if (existingTrapTagIndex !== -1) {
-          this.fieldEffectInfo[existingTrapTagIndex].name = `${name} (${tagAddedEvent.arenaTagLayers})`;
-          break;
-        } else {
-          name = `${name} (${tagAddedEvent.arenaTagLayers})`;
-        }
+      if (existingTrapTagIndex !== -1) {
+        const layers = tagAddedEvent.arenaTagMaxLayers > 1 ? ` (${tagAddedEvent.arenaTagLayers})` : "";
+        this.fieldEffectInfo[existingTrapTagIndex].name = `${name}${layers}`;
+        break;
+      } else if (tagAddedEvent.arenaTagMaxLayers > 1) {
+        name = `${name} (${tagAddedEvent.arenaTagLayers})`;
       }
-
 
       this.fieldEffectInfo.push({
         name,


### PR DESCRIPTION
## What are the changes?
- fixex multiple traps showing because of moves like Stone Axe and Ceaseless Edge

## Why am I doing these changes?
copied from discord
![image](https://github.com/pagefaultgames/pokerogue/assets/68144167/952b7b6e-f1d5-4af6-b3eb-3b08ad072d16)


## What did change?
- arena traps fix (UI)

### Screenshots/Videos


https://github.com/pagefaultgames/pokerogue/assets/68144167/2093d266-e888-48e4-93a7-3d7f38c93f9d



## How to test the changes?
- use Stealth Rock + Stone Axe
- use Spikes + Ceaseless Edge

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?