### PR TITLE
[Bug] Fix Thousand Arrows grounding opponents before use

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -3672,20 +3672,6 @@ export class NeutralDamageAgainstFlyingTypeMultiplierAttr extends VariableMoveTy
   }
 }
 
-export class AddIgnoreFlyingTagAttr extends MoveEffectAttr {
-  constructor() {
-    super(false, MoveEffectTrigger.PRE_APPLY, true);
-  }
-
-  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    if (!target.getTag(BattlerTagType.IGNORE_FLYING)) {
-      target.addTag(BattlerTagType.IGNORE_FLYING, 20, move.id, user.id); //TODO: Grounded effect should not have turn limit
-      return true;
-    }
-    return false;
-  }
-}
-
 export class WaterSuperEffectTypeMultiplierAttr extends VariableMoveTypeMultiplierAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const multiplier = args[0] as Utils.NumberHolder;
@@ -7345,7 +7331,7 @@ export function initMoves() {
       .triageMove(),
     new AttackMove(Moves.THOUSAND_ARROWS, Type.GROUND, MoveCategory.PHYSICAL, 90, 100, 10, -1, 0, 6)
       .attr(NeutralDamageAgainstFlyingTypeMultiplierAttr)
-      .attr(AddIgnoreFlyingTagAttr)
+      .attr(AddBattlerTagAttr, BattlerTagType.IGNORE_FLYING, false, false, 20) // TODO: remove this turn count
       .attr(HitsTagAttr, BattlerTagType.FLYING, false)
       .attr(AddBattlerTagAttr, BattlerTagType.INTERRUPTED)
       .attr(RemoveBattlerTagAttr, [BattlerTagType.FLYING, BattlerTagType.MAGNET_RISEN])

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -3665,10 +3665,23 @@ export class NeutralDamageAgainstFlyingTypeMultiplierAttr extends VariableMoveTy
       if (target.isOfType(Type.FLYING)) {
         multiplier.value = 1;
       }
-      target.addTag(BattlerTagType.IGNORE_FLYING, 20, move.id, user.id); //TODO: Grounded effect should not have turn limit
       return true;
     }
 
+    return false;
+  }
+}
+
+export class AddIgnoreFlyingTagAttr extends MoveEffectAttr {
+  constructor() {
+    super(false, MoveEffectTrigger.PRE_APPLY, true);
+  }
+
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    if (!target.getTag(BattlerTagType.IGNORE_FLYING)) {
+      target.addTag(BattlerTagType.IGNORE_FLYING, 20, move.id, user.id); //TODO: Grounded effect should not have turn limit
+      return true;
+    }
     return false;
   }
 }
@@ -7332,6 +7345,7 @@ export function initMoves() {
       .triageMove(),
     new AttackMove(Moves.THOUSAND_ARROWS, Type.GROUND, MoveCategory.PHYSICAL, 90, 100, 10, -1, 0, 6)
       .attr(NeutralDamageAgainstFlyingTypeMultiplierAttr)
+      .attr(AddIgnoreFlyingTagAttr)
       .attr(HitsTagAttr, BattlerTagType.FLYING, false)
       .attr(AddBattlerTagAttr, BattlerTagType.INTERRUPTED)
       .attr(RemoveBattlerTagAttr, [BattlerTagType.FLYING, BattlerTagType.MAGNET_RISEN])

--- a/src/test/moves/thousand_arrows.test.ts
+++ b/src/test/moves/thousand_arrows.test.ts
@@ -1,0 +1,67 @@
+import {afterEach, beforeAll, beforeEach, describe, expect, test, vi} from "vitest";
+import Phaser from "phaser";
+import GameManager from "#app/test/utils/gameManager";
+import * as overrides from "#app/overrides";
+import {
+  DamagePhase,
+  MoveEffectPhase
+} from "#app/phases";
+import {getMovePosition} from "#app/test/utils/gameManagerUtils";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { BattlerTagType } from "#app/enums/battler-tag-type.js";
+
+const TIMEOUT = 20 * 1000;
+
+describe("Moves - Thousand Arrows", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.TOGETIC);
+    vi.spyOn(overrides, "STARTING_LEVEL_OVERRIDE", "get").mockReturnValue(100);
+    vi.spyOn(overrides, "OPP_LEVEL_OVERRIDE", "get").mockReturnValue(100);
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([ Moves.THOUSAND_ARROWS ]);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH,Moves.SPLASH,Moves.SPLASH,Moves.SPLASH]);
+  });
+
+  test(
+    "move should hit and ground Flying-type targets",
+    async () => {
+      await game.startBattle([ Species.ILLUMISE ]);
+
+      const leadPokemon = game.scene.getPlayerPokemon();
+      expect(leadPokemon).toBeDefined();
+
+      const enemyPokemon = game.scene.getEnemyPokemon();
+      expect(enemyPokemon).toBeDefined();
+
+      const enemyStartingHp = enemyPokemon.hp;
+
+      game.doAttack(getMovePosition(game.scene, 0, Moves.THOUSAND_ARROWS));
+
+      await game.phaseInterceptor.to(MoveEffectPhase, false);
+      // Enemy should not be grounded before move effect is applied
+      expect(enemyPokemon.getTag(BattlerTagType.IGNORE_FLYING)).toBeUndefined();
+
+      await game.phaseInterceptor.to(DamagePhase, false);
+      // Enemy should be grounded before damage is applied
+      expect(enemyPokemon.getTag(BattlerTagType.IGNORE_FLYING)).toBeDefined();
+
+      await game.phaseInterceptor.to(DamagePhase);
+      expect(enemyPokemon.hp).toBeLessThan(enemyStartingHp);
+    }, TIMEOUT
+  );
+});

--- a/src/test/moves/thousand_arrows.test.ts
+++ b/src/test/moves/thousand_arrows.test.ts
@@ -3,8 +3,8 @@ import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
 import * as overrides from "#app/overrides";
 import {
-  DamagePhase,
-  MoveEffectPhase
+  MoveEffectPhase,
+  TurnEndPhase
 } from "#app/phases";
 import {getMovePosition} from "#app/test/utils/gameManagerUtils";
 import { Moves } from "#enums/moves";
@@ -56,11 +56,9 @@ describe("Moves - Thousand Arrows", () => {
       // Enemy should not be grounded before move effect is applied
       expect(enemyPokemon.getTag(BattlerTagType.IGNORE_FLYING)).toBeUndefined();
 
-      await game.phaseInterceptor.to(DamagePhase, false);
-      // Enemy should be grounded before damage is applied
-      expect(enemyPokemon.getTag(BattlerTagType.IGNORE_FLYING)).toBeDefined();
+      await game.phaseInterceptor.to(TurnEndPhase, false);
 
-      await game.phaseInterceptor.to(DamagePhase);
+      expect(enemyPokemon.getTag(BattlerTagType.IGNORE_FLYING)).toBeDefined();
       expect(enemyPokemon.hp).toBeLessThan(enemyStartingHp);
     }, TIMEOUT
   );


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This fixes the issue #2464 where a Pokemon with the move Thousand Arrows grounds opponents before using the move.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Thousand Arrows is not applying its effects properly.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- `data/move`: Fixed an issue where Thousand Arrows would apply the `IGNORE_FLYING` battler tag to opposing Pokemon whenever `Pokemon.apply()` was called, even in simulated calls for UI elements.
- `test/thousand_arrows.test`: New unit test to check battler tag behavior and damage against Flying types.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
Can be provided upon request.

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
`npm run test thousand_arrows`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [?] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?