### PR TITLE
[Bug] troubleshooting language setting mismatch error (prlang=ko-KR)

### DIFF
--- a/src/ui/settings/settings-display-ui-handler.ts
+++ b/src/ui/settings/settings-display-ui-handler.ts
@@ -73,12 +73,7 @@ export default class SettingsDisplayUiHandler extends AbstractSettingsUiHandler 
         };
         break;
       case "ko":
-        this.settings[languageIndex].options[0] = {
-          value: "한국어",
-          label: "한국어",
-        };
-        break;
-      case ("ko-KR"):
+      case "ko-KR":
         this.settings[languageIndex].options[0] = {
           value: "한국어",
           label: "한국어",

--- a/src/ui/settings/settings-display-ui-handler.ts
+++ b/src/ui/settings/settings-display-ui-handler.ts
@@ -78,6 +78,12 @@ export default class SettingsDisplayUiHandler extends AbstractSettingsUiHandler 
           label: "한국어",
         };
         break;
+      case ("ko-KR"):
+        this.settings[languageIndex].options[0] = {
+          value: "한국어",
+          label: "한국어",
+        };
+        break;
       default:
         this.settings[languageIndex].options[0] = {
           value: "English",


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
language setting mismatch error `prlang=ko-KR`

<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

it is very small issue. 
I'm currently in south korea. of course, the game language setting was `korean`.
so I tried to change language setting `korean` to `english` but game setting ui displayed `English`

<img width="1491" alt="스크린샷 2024-06-21 오후 7 09 59" src="https://github.com/pagefaultgames/pokerogue/assets/71657609/6e022006-90da-45b6-a9a3-e3605e2b3589">


## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
After Checking Code, I found prLang on localStorage. When the game FIRST running , it's set `prLang='ko-KR'` by `i18n`.

`src/ui/settings/settings-display-ui-handler.ts` is not managed `prLang='ko-KR'` for swtch case. so, setting language ui displayed `English`.

<img width="1501" alt="스크린샷 2024-06-21 오후 7 12 05" src="https://github.com/pagefaultgames/pokerogue/assets/71657609/2605ea2e-421e-4b2a-ad1e-241a3ae6ada4">

```typescript
export default class SettingsDisplayUiHandler extends AbstractSettingsUiHandler {
  /**
   * Creates an instance of SettingsGamepadUiHandler.
   *
   * @param scene - The BattleScene instance.
   * @param mode - The UI mode, optional.
   */
  constructor(scene: BattleScene, mode?: Mode) {
    super(scene, mode);
    this.title = "Display";
    this.settings = Setting.filter(s => s.type === SettingType.DISPLAY);

    /**
     * Update to current language from default value.
     * - default value is 'English'
     */
    const languageIndex = this.settings.findIndex(s => s.key === SettingKeys.Language);
    if (languageIndex >= 0) {
      const currentLocale = localStorage.getItem("prLang");
      switch (currentLocale) {
      ...
      ...
      default:
        this.settings[languageIndex].options[0] = {
          value: "English",
          label: "English",
        };
        break;
      }
    }

    this.localStorageKey = "settings";
  }
}
```

Additionaly, if the language setting is changed to `Korean`, `prLang` is set to `'ko'`. Most users in Korea, estimate that `prLang` is either `'ko'` or `'ko-KR'` through languages settings. Therefore, I added `switch case` for `prlang=ko-KR`.


### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
<img width="1501" alt="스크린샷 2024-06-21 오후 7 12 48" src="https://github.com/pagefaultgames/pokerogue/assets/71657609/38454cd4-7465-48c3-8615-584578973382">
<img width="1503" alt="스크린샷 2024-06-21 오후 7 13 38" src="https://github.com/pagefaultgames/pokerogue/assets/71657609/053f0ec1-cc2d-4b71-9a7e-a1347ab14331">


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
None

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [ ] ~~Have I tested the changes (manually)?~~ 
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?