### PR TITLE
[Enhancement] - The wave is no longer displayed under the overlay 

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1447,6 +1447,7 @@ export default class BattleScene extends SceneBase {
   updateBiomeWaveText(): void {
     const isBoss = !(this.currentBattle.waveIndex % 10);
     const biomeString: string = getBiomeName(this.arena.biomeType);
+    this.fieldUI.moveAbove(this.biomeWaveText, this.luckText);
     this.biomeWaveText.setText( biomeString + " - " + this.currentBattle.waveIndex.toString());
     this.biomeWaveText.setColor(!isBoss ? "#ffffff" : "#f89890");
     this.biomeWaveText.setShadowColor(!isBoss ? "#636363" : "#984038");

--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -185,6 +185,7 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
 
     this.scene.showShopOverlay(750);
     this.scene.updateAndShowText(750);
+    this.scene.updateBiomeWaveText();
     this.scene.updateMoneyText();
 
     let i = 0;


### PR DESCRIPTION
## What are the changes?
The wave is no longer displayed under the overlay as it used to be (even before the black overlay ...)
Its previous color just made it harder to see that the text was underneath the overlay

## Why am I doing these changes?
To better distinguish the current wave

### Screenshots/Videos
> Before
![2024-06-22_02-34](https://github.com/pagefaultgames/pokerogue/assets/8146474/0c40ab15-163c-4177-82bb-76e8bf620a00)
![2024-06-22_02-35](https://github.com/pagefaultgames/pokerogue/assets/8146474/0d181af0-6ed0-40ff-a6a4-e72ddb49740e)

> After
![2024-06-22_02-37](https://github.com/pagefaultgames/pokerogue/assets/8146474/7c9a5684-d72c-4d17-bd06-68958baf691c)


## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?