### PR TITLE
[Bug] Fix typo in encore

### DIFF
--- a/src/locales/de/battle.ts
+++ b/src/locales/de/battle.ts
@@ -93,7 +93,7 @@ export const battle: SimpleTranslationEntries = {
   "battlerTagsNightmareOnAdd": "Nachtmahr sucht {{pokemonNameWithAffix}} heim!",
   "battlerTagsNightmareOnOverlap": "{{pokemonNameWithAffix}} wird bereits von Nachtmahr heimgesucht!",
   "battlerTagsNightmareLapse": "Nachtmahr schadet {{pokemonNameWithAffix}}!",
-  "battlerTagsEncoreOnAdd": "({{pokemonNameWithAffix}} gibt eine Zugabe",
+  "battlerTagsEncoreOnAdd": "{{pokemonNameWithAffix}} gibt eine Zugabe",
   "battlerTagsEncoreOnRemove": "Die Zugabe von {{pokemonNameWithAffix}} ist beendet!",
   "battlerTagsHelpingHandOnAdd": "{{pokemonNameWithAffix}} will {{pokemonName}} helfen!",
   "battlerTagsIngrainLapse": "{{pokemonNameWithAffix}} nimmt über seine Wurzeln Nährstoffe auf!",

--- a/src/locales/en/battle.ts
+++ b/src/locales/en/battle.ts
@@ -93,7 +93,7 @@ export const battle: SimpleTranslationEntries = {
   "battlerTagsNightmareOnAdd": "{{pokemonNameWithAffix}} began\nhaving a Nightmare!",
   "battlerTagsNightmareOnOverlap": "{{pokemonNameWithAffix}} is\nalready locked in a Nightmare!",
   "battlerTagsNightmareLapse": "{{pokemonNameWithAffix}} is locked\nin a Nightmare!",
-  "battlerTagsEncoreOnAdd": "({{pokemonNameWithAffix}} got\nan Encore!",
+  "battlerTagsEncoreOnAdd": "{{pokemonNameWithAffix}} got\nan Encore!",
   "battlerTagsEncoreOnRemove": "{{pokemonNameWithAffix}}'s Encore\nended!",
   "battlerTagsHelpingHandOnAdd": "{{pokemonNameWithAffix}} is ready to\nhelp {{pokemonName}}!",
   "battlerTagsIngrainLapse": "{{pokemonNameWithAffix}} absorbed\nnutrients with its roots!",

--- a/src/locales/es/battle.ts
+++ b/src/locales/es/battle.ts
@@ -93,7 +93,7 @@ export const battle: SimpleTranslationEntries = {
   "battlerTagsNightmareOnAdd": "{{pokemonNameWithAffix}} began\nhaving a Nightmare!",
   "battlerTagsNightmareOnOverlap": "{{pokemonNameWithAffix}} is\nalready locked in a Nightmare!",
   "battlerTagsNightmareLapse": "{{pokemonNameWithAffix}} is locked\nin a Nightmare!",
-  "battlerTagsEncoreOnAdd": "({{pokemonNameWithAffix}} got\nan Encore!",
+  "battlerTagsEncoreOnAdd": "{{pokemonNameWithAffix}} got\nan Encore!",
   "battlerTagsEncoreOnRemove": "{{pokemonNameWithAffix}}'s Encore\nended!",
   "battlerTagsHelpingHandOnAdd": "{{pokemonNameWithAffix}} is ready to\nhelp {{pokemonName}}!",
   "battlerTagsIngrainLapse": "{{pokemonNameWithAffix}} absorbed\nnutrients with its roots!",

--- a/src/locales/it/battle.ts
+++ b/src/locales/it/battle.ts
@@ -93,7 +93,7 @@ export const battle: SimpleTranslationEntries = {
   "battlerTagsNightmareOnAdd": "{{pokemonNameWithAffix}} sta\navendo un Incubo!",
   "battlerTagsNightmareOnOverlap": "{{pokemonNameWithAffix}} sta\ngià avendo un Incubo!",
   "battlerTagsNightmareLapse": "{{pokemonNameWithAffix}} è bloccato\nin un Incubo!",
-  "battlerTagsEncoreOnAdd": "({{pokemonNameWithAffix}} ha\nsubito Ripeti!",
+  "battlerTagsEncoreOnAdd": "{{pokemonNameWithAffix}} ha\nsubito Ripeti!",
   "battlerTagsEncoreOnRemove": "L'effetto di Ripeti su {{pokemonNameWithAffix}}\n è terminato!",
   "battlerTagsHelpingHandOnAdd": "{{pokemonNameWithAffix}} è pronto ad\naiutare {{pokemonName}}!",
   "battlerTagsIngrainLapse": "{{pokemonNameWithAffix}} assorbe\nnutrienti dalle sue radici!",

--- a/src/locales/pt_BR/battle.ts
+++ b/src/locales/pt_BR/battle.ts
@@ -93,7 +93,7 @@ export const battle: SimpleTranslationEntries = {
   "battlerTagsNightmareOnAdd": "{{pokemonNameWithAffix}} começou\na ter um Nightmare!",
   "battlerTagsNightmareOnOverlap": "{{pokemonNameWithAffix}} já\nestá preso em um Nightmare!",
   "battlerTagsNightmareLapse": "{{pokemonNameWithAffix}} está preso\nem um Nightmare!",
-  "battlerTagsEncoreOnAdd": "({{pokemonNameWithAffix}} ganhou\num Encore!",
+  "battlerTagsEncoreOnAdd": "{{pokemonNameWithAffix}} ganhou\num Encore!",
   "battlerTagsEncoreOnRemove": "O Encore de {{pokemonNameWithAffix}}\nacabou!",
   "battlerTagsHelpingHandOnAdd": "{{pokemonNameWithAffix}} está pronto para\najudar {{pokemonName}}!",
   "battlerTagsIngrainLapse": "{{pokemonNameWithAffix}} absorveu\nnutrientes com suas raízes!",

--- a/src/locales/zh_CN/battle.ts
+++ b/src/locales/zh_CN/battle.ts
@@ -93,7 +93,7 @@ export const battle: SimpleTranslationEntries = {
   "battlerTagsNightmareOnAdd": "{{pokemonNameWithAffix}}开始做恶梦了！",
   "battlerTagsNightmareOnOverlap": "{{pokemonNameWithAffix}}已经被恶梦缠身！",
   "battlerTagsNightmareLapse": "{{pokemonNameWithAffix}}正被恶梦缠身！",
-  "battlerTagsEncoreOnAdd": "({{pokemonNameWithAffix}}接受了再来一次！",
+  "battlerTagsEncoreOnAdd": "{{pokemonNameWithAffix}}接受了再来一次！",
   "battlerTagsEncoreOnRemove": "{{pokemonNameWithAffix}}的再来一次状态解除了！",
   "battlerTagsHelpingHandOnAdd": "{{pokemonNameWithAffix}}摆出了帮助{{pokemonName}} 的架势！",
   "battlerTagsIngrainLapse": "{{pokemonNameWithAffix}}用扎根回复了体力！",

--- a/src/locales/zh_TW/battle.ts
+++ b/src/locales/zh_TW/battle.ts
@@ -90,7 +90,7 @@ export const battle: SimpleTranslationEntries = {
   "battlerTagsNightmareOnAdd": "{{pokemonNameWithAffix}} began\nhaving a Nightmare!",
   "battlerTagsNightmareOnOverlap": "{{pokemonNameWithAffix}} is\nalready locked in a Nightmare!",
   "battlerTagsNightmareLapse": "{{pokemonNameWithAffix}} is locked\nin a Nightmare!",
-  "battlerTagsEncoreOnAdd": "({{pokemonNameWithAffix}} got\nan Encore!",
+  "battlerTagsEncoreOnAdd": "{{pokemonNameWithAffix}} got\nan Encore!",
   "battlerTagsEncoreOnRemove": "{{pokemonNameWithAffix}}'s Encore\nended!",
   "battlerTagsHelpingHandOnAdd": "{{pokemonNameWithAffix}} is ready to\nhelp {{pokemonName}}!",
   "battlerTagsIngrainLapse": "{{pokemonNameWithAffix}} absorbed\nnutrients with its roots!",


### PR DESCRIPTION
## What are the changes?
Fixed a typo in encore add message

## Why am I doing these changes?
Extra ( showed up

## What did change?
Removed (

### Screenshots/Videos
![](https://cdn.discordapp.com/attachments/1125662770629709935/1253875033231593544/image.png?ex=6677719f&is=6676201f&hm=3e23edc339caa04754d6e6b4d6ef837bddf841a3f73166dc8a450d6e59774603&)

## How to test the changes?
Pull and test

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?