### PR TITLE
[Enhancement] Avoids 'flashbanging' for players in Shop UI

### DIFF
--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -184,7 +184,6 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
     this.scene.getModifierBar().updateModifiers(this.scene.modifiers, true);
 
     /* Multiplies the appearance duration by the speed parameter so that it is always constant, and avoids "flashbangs" at game speed x5 */
-    console.log(this.scene.gameSpeed);
     this.scene.showShopOverlay(750 * this.scene.gameSpeed);
     this.scene.updateAndShowText(750);
     this.scene.updateBiomeWaveText();

--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -183,7 +183,9 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
     /* Force updateModifiers without pokemonSpecificModifiers */
     this.scene.getModifierBar().updateModifiers(this.scene.modifiers, true);
 
-    this.scene.showShopOverlay(750);
+    /* Multiplies the appearance duration by the speed parameter so that it is always constant, and avoids "flashbangs" at game speed x5 */
+    console.log(this.scene.gameSpeed);
+    this.scene.showShopOverlay(750 * this.scene.gameSpeed);
     this.scene.updateAndShowText(750);
     this.scene.updateBiomeWaveText();
     this.scene.updateMoneyText();
@@ -476,7 +478,8 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
     this.getUi().clearText();
     this.eraseCursor();
 
-    this.scene.hideShopOverlay(750);
+    /* Multiplies the fade time duration by the speed parameter so that it is always constant, and avoids "flashbangs" at game speed x5 */
+    this.scene.hideShopOverlay(750 * this.scene.gameSpeed);
     this.scene.hideLuckText(250);
 
     /* Normally already called just after the shop, but not sure if it happens in 100% of cases */


### PR DESCRIPTION
## What are the changes?
Avoids 'flashbanging' for players playing at x5 speed by making the transition time constant regardless of the speed chosen

### Screenshots/Videos
> Before (_at x5 speed_)
https://github.com/pagefaultgames/pokerogue/assets/8146474/717be947-c5e8-4841-9f50-79b730313171

> After (_at x5 speed_)
https://github.com/pagefaultgames/pokerogue/assets/8146474/f3da227c-c58a-4440-abd6-32924d86019a

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?