### PR TITLE
Hotfix: Rare Egg move rate from bought eggs where always common tier rates

### DIFF
--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -163,7 +163,6 @@ export class Egg {
 
     this._overrideHiddenAbility = eggOptions.overrideHiddenAbility ?? false;
 
-
     // Override egg tier and hatchwaves if species was given
     if (eggOptions.species) {
       this._tier = this.getEggTierFromSpeciesStarterValue();

--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -162,7 +162,7 @@ export class Egg {
     this._species = eggOptions.species ?? this.rollSpecies(eggOptions.scene);
 
     this._overrideHiddenAbility = eggOptions.overrideHiddenAbility ?? false;
-    this._eggMoveIndex = eggOptions.eggMoveIndex ?? this.rollEggMoveIndex();
+
 
     // Override egg tier and hatchwaves if species was given
     if (eggOptions.species) {
@@ -175,6 +175,8 @@ export class Egg {
         this._variantTier = VariantTier.COMMON;
       }
     }
+    // Needs this._tier so it needs to be generated afer the tier override if bought from same species
+    this._eggMoveIndex = eggOptions.eggMoveIndex ?? this.rollEggMoveIndex();
     if (eggOptions.pulled) {
       this.addEggToGameData(eggOptions.scene);
     }


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Bought eggs where always using rare egg move rates from common tier eggs because the correct egg tier of bought eggs get's set AFTER the egg move was rolled

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?