### PR TITLE
[Accessbility] Remove screen inversion if move animations are off

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -3580,7 +3580,9 @@ export class DamagePhase extends PokemonPhase {
     super.start();
 
     if (this.damageResult === HitResult.ONE_HIT_KO) {
-      this.scene.toggleInvert(true);
+      if (this.scene.moveAnimations) {
+        this.scene.toggleInvert(true);
+      }
       this.scene.time.delayedCall(Utils.fixedInt(1000), () => {
         this.scene.toggleInvert(false);
         this.applyDamage();


### PR DESCRIPTION
## What are the changes?
Made the screen inversion part of OHKO moves tied to move animations

## Why am I doing these changes?
closes https://github.com/pagefaultgames/pokerogue/issues/2491
The OHKO screen flash is unpleasant to people prone to seizures or epilepsy

## What did change?
Added an `if (this.scene.moveAnimations)` to check that move animations are on before inverting the scene

### Screenshots/Videos
[![](https://cdn.discordapp.com/attachments/1176874654015684739/1254085546632941638/image.png?ex=667835ae&is=6676e42e&hm=e9d1a11d91b7764a92404db5ef7274b353f98dca1be8f4f967f5a642b3981832&)](https://github.com/pagefaultgames/pokerogue/assets/163687446/311c602d-a6f9-4374-a245-5d7919b179fa)

## How to test the changes?
Override no guard and a OHKO move then turn move animations on and off

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?