### PR TITLE
[Localization] localized status-effect.ts and translate.

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2781,7 +2781,7 @@ export class PostTurnResetStatusAbAttr extends PostTurnAbAttr {
     }
     if (this.target?.status) {
 
-      this.target.scene.queueMessage(getPokemonMessage(this.target, getStatusEffectHealText(this.target.status?.effect)));
+      this.target.scene.queueMessage(getStatusEffectHealText(this.target.status?.effect, getPokemonNameWithAffix(this.target)));
       this.target.resetStatus(false);
       this.target.updateInfo();
       return true;

--- a/src/data/berry.ts
+++ b/src/data/berry.ts
@@ -1,5 +1,5 @@
 import { PokemonHealPhase, StatChangePhase } from "../phases";
-import { getPokemonMessage } from "../messages";
+import { getPokemonMessage, getPokemonNameWithAffix } from "../messages";
 import Pokemon, { HitResult } from "../field/pokemon";
 import { BattleStat } from "./battle-stat";
 import { getStatusEffectHealText } from "./status-effect";
@@ -80,7 +80,7 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
         pokemon.battleData.berriesEaten.push(berryType);
       }
       if (pokemon.status) {
-        pokemon.scene.queueMessage(getPokemonMessage(pokemon, getStatusEffectHealText(pokemon.status.effect)));
+        pokemon.scene.queueMessage(getStatusEffectHealText(pokemon.status.effect, getPokemonNameWithAffix(pokemon)));
       }
       pokemon.resetStatus(true, true);
       pokemon.updateInfo();

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1757,7 +1757,7 @@ export class PsychoShiftEffectAttr extends MoveEffectAttr {
     if (!target.status || (target.status.effect === statusToApply && move.chance < 0)) {
       const statusAfflictResult = target.trySetStatus(statusToApply, true, user);
       if (statusAfflictResult) {
-        user.scene.queueMessage(getPokemonMessage(user, getStatusEffectHealText(user.status.effect)));
+        user.scene.queueMessage(getStatusEffectHealText(user.status.effect, getPokemonNameWithAffix(user)));
         user.resetStatus();
         user.updateInfo();
       }
@@ -2031,7 +2031,7 @@ export class HealStatusEffectAttr extends MoveEffectAttr {
 
     const pokemon = this.selfTarget ? user : target;
     if (pokemon.status && this.effects.includes(pokemon.status.effect)) {
-      pokemon.scene.queueMessage(getPokemonMessage(pokemon, getStatusEffectHealText(pokemon.status.effect)));
+      pokemon.scene.queueMessage(getStatusEffectHealText(pokemon.status.effect, getPokemonNameWithAffix(pokemon)));
       pokemon.resetStatus();
       pokemon.updateInfo();
 

--- a/src/data/status-effect.ts
+++ b/src/data/status-effect.ts
@@ -1,5 +1,5 @@
 import * as Utils from "../utils";
-import i18next, {ParseKeys} from "i18next";
+import i18next, { ParseKeys } from "i18next";
 
 export enum StatusEffect {
   NONE,
@@ -52,7 +52,11 @@ function getStatusEffectMessageKey(statusEffect: StatusEffect): string {
 }
 
 export function getStatusEffectObtainText(statusEffect: StatusEffect, pokemonNameWithAffix: string, sourceText?: string): string {
-  const i18nKey = `${getStatusEffectMessageKey(statusEffect)}.obtain`as ParseKeys;
+  if (!sourceText) {
+    const i18nKey = `${getStatusEffectMessageKey(statusEffect)}.obtain`as ParseKeys;
+    return i18next.t(i18nKey, { pokemonNameWithAffix: pokemonNameWithAffix });
+  }
+  const i18nKey = `${getStatusEffectMessageKey(statusEffect)}.obtainSource`as ParseKeys;
   return !sourceText ? i18next.t(i18nKey, { pokemonNameWithAffix: pokemonNameWithAffix }) : i18next.t(i18nKey, { pokemonNameWithAffix: pokemonNameWithAffix, sourceText: sourceText });
 }
 

--- a/src/data/status-effect.ts
+++ b/src/data/status-effect.ts
@@ -1,4 +1,5 @@
 import * as Utils from "../utils";
+import i18next, {ParseKeys} from "i18next";
 
 export enum StatusEffect {
   NONE,
@@ -31,94 +32,48 @@ export class Status {
   }
 }
 
-export function getStatusEffectObtainText(statusEffect: StatusEffect, sourceText?: string): string {
-  const sourceClause = sourceText || "";
+function getStatusEffectMessageKey(statusEffect: StatusEffect): string {
   switch (statusEffect) {
   case StatusEffect.POISON:
-    return `\nwas poisoned from ${sourceClause}!`;
+    return "statusEffect:poison";
   case StatusEffect.TOXIC:
-    return `\nwas badly poisoned from ${sourceClause}!`;
+    return "statusEffect:toxic";
   case StatusEffect.PARALYSIS:
-    return ` was paralyzed from ${sourceClause}!\nIt may be unable to move!`;
+    return "statusEffect:paralysis";
   case StatusEffect.SLEEP:
-    return `\nfell asleep by ${sourceClause}!`;
+    return "statusEffect:sleep";
   case StatusEffect.FREEZE:
-    return `\nwas frozen solid from ${sourceClause}!`;
+    return "statusEffect:freeze";
   case StatusEffect.BURN:
-    return `\nwas burned from ${sourceClause}!`;
+    return "statusEffect:burn";
+  default:
+    return "statusEffect:none";
   }
-
-  return "";
 }
 
-export function getStatusEffectActivationText(statusEffect: StatusEffect): string {
-  switch (statusEffect) {
-  case StatusEffect.POISON:
-  case StatusEffect.TOXIC:
-    return " is hurt\nby poison!";
-  case StatusEffect.PARALYSIS:
-    return " is paralyzed!\nIt can't move!";
-  case StatusEffect.SLEEP:
-    return " is fast asleep.";
-  case StatusEffect.FREEZE:
-    return " is\nfrozen solid!";
-  case StatusEffect.BURN:
-    return " is hurt\nby its burn!";
-  }
-
-  return "";
+export function getStatusEffectObtainText(statusEffect: StatusEffect, pokemonNameWithAffix: string, sourceText?: string): string {
+  const i18nKey = `${getStatusEffectMessageKey(statusEffect)}.obtain`as ParseKeys;
+  return !sourceText ? i18next.t(i18nKey, { pokemonNameWithAffix: pokemonNameWithAffix }) : i18next.t(i18nKey, { pokemonNameWithAffix: pokemonNameWithAffix, sourceText: sourceText });
 }
 
-export function getStatusEffectOverlapText(statusEffect: StatusEffect): string {
-  switch (statusEffect) {
-  case StatusEffect.POISON:
-  case StatusEffect.TOXIC:
-    return " is\nalready poisoned!";
-  case StatusEffect.PARALYSIS:
-    return " is\nalready paralyzed!";
-  case StatusEffect.SLEEP:
-    return " is\nalready asleep!";
-  case StatusEffect.FREEZE:
-    return " is\nalready frozen!";
-  case StatusEffect.BURN:
-    return " is\nalready burned!";
-  }
-
-  return "";
+export function getStatusEffectActivationText(statusEffect: StatusEffect, pokemonNameWithAffix: string): string {
+  const i18nKey = `${getStatusEffectMessageKey(statusEffect)}.activation` as ParseKeys;
+  return i18next.t(i18nKey, { pokemonNameWithAffix: pokemonNameWithAffix });
 }
 
-export function getStatusEffectHealText(statusEffect: StatusEffect): string {
-  switch (statusEffect) {
-  case StatusEffect.POISON:
-  case StatusEffect.TOXIC:
-    return " was\ncured of its poison!";
-  case StatusEffect.PARALYSIS:
-    return " was\nhealed of paralysis!";
-  case StatusEffect.SLEEP:
-    return " woke up!";
-  case StatusEffect.FREEZE:
-    return " was\ndefrosted!";
-  case StatusEffect.BURN:
-    return " was\nhealed of its burn!";
-  }
+export function getStatusEffectOverlapText(statusEffect: StatusEffect, pokemonNameWithAffix: string): string {
+  const i18nKey = `${getStatusEffectMessageKey(statusEffect)}.overlap` as ParseKeys;
+  return i18next.t(i18nKey, { pokemonNameWithAffix: pokemonNameWithAffix });
+}
 
-  return "";
+export function getStatusEffectHealText(statusEffect: StatusEffect, pokemonNameWithAffix: string): string {
+  const i18nKey = `${getStatusEffectMessageKey(statusEffect)}.heal` as ParseKeys;
+  return i18next.t(i18nKey, { pokemonNameWithAffix: pokemonNameWithAffix });
 }
 
 export function getStatusEffectDescriptor(statusEffect: StatusEffect): string {
-  switch (statusEffect) {
-  case StatusEffect.POISON:
-  case StatusEffect.TOXIC:
-    return "poisoning";
-  case StatusEffect.PARALYSIS:
-    return "paralysis";
-  case StatusEffect.SLEEP:
-    return "sleep";
-  case StatusEffect.FREEZE:
-    return "freezing";
-  case StatusEffect.BURN:
-    return "burn";
-  }
+  const i18nKey = `${getStatusEffectMessageKey(statusEffect)}.description` as ParseKeys;
+  return i18next.t(i18nKey);
 }
 
 export function getStatusEffectCatchRateMultiplier(statusEffect: StatusEffect): number {

--- a/src/data/status-effect.ts
+++ b/src/data/status-effect.ts
@@ -32,20 +32,20 @@ export class Status {
 }
 
 export function getStatusEffectObtainText(statusEffect: StatusEffect, sourceText?: string): string {
-  const sourceClause = sourceText ? ` ${statusEffect !== StatusEffect.SLEEP ? "by" : "from"} ${sourceText}` : "";
+  const sourceClause = sourceText || "";
   switch (statusEffect) {
   case StatusEffect.POISON:
-    return `\nwas poisoned${sourceClause}!`;
+    return `\nwas poisoned from ${sourceClause}!`;
   case StatusEffect.TOXIC:
-    return `\nwas badly poisoned${sourceClause}!`;
+    return `\nwas badly poisoned from ${sourceClause}!`;
   case StatusEffect.PARALYSIS:
-    return ` was paralyzed${sourceClause}!\nIt may be unable to move!`;
+    return ` was paralyzed from ${sourceClause}!\nIt may be unable to move!`;
   case StatusEffect.SLEEP:
-    return `\nfell asleep${sourceClause}!`;
+    return `\nfell asleep by ${sourceClause}!`;
   case StatusEffect.FREEZE:
-    return `\nwas frozen solid${sourceClause}!`;
+    return `\nwas frozen solid from ${sourceClause}!`;
   case StatusEffect.BURN:
-    return `\nwas burned${sourceClause}!`;
+    return `\nwas burned from ${sourceClause}!`;
   }
 
   return "";

--- a/src/interfaces/locales.ts
+++ b/src/interfaces/locales.ts
@@ -57,6 +57,20 @@ export interface BerryTranslationEntries {
     [key: string]: BerryTranslationEntry
   }
 
+export interface StatusEffectTranslationEntries {
+  [key: string]: StatusEffectTranslationEntry
+}
+
+export interface StatusEffectTranslationEntry {
+  name: string,
+  obtain: string,
+  obtainSource: string,
+  activation: string,
+  overlap: string,
+  heal: string
+  description: string,
+}
+
 export interface AchievementTranslationEntry {
     name?: string,
     description?: string,

--- a/src/locales/de/config.ts
+++ b/src/locales/de/config.ts
@@ -34,13 +34,14 @@ import { pokemonInfoContainer } from "./pokemon-info-container";
 import { saveSlotSelectUiHandler } from "./save-slot-select-ui-handler";
 import { splashMessages } from "./splash-messages";
 import { starterSelectUiHandler } from "./starter-select-ui-handler";
+import { statusEffect } from "./status-effect";
 import { titles, trainerClasses, trainerNames } from "./trainers";
 import { tutorial } from "./tutorial";
 import { voucher } from "./voucher";
 import { weather } from "./weather";
 import { partyUiHandler } from "./party-ui-handler";
-import { settings } from "#app/locales/de/settings.js";
-import { common } from "#app/locales/de/common.js";
+import { settings } from "./settings.js";
+import { common } from "./common.js";
 
 export const deConfig = {
   ability: ability,
@@ -80,6 +81,7 @@ export const deConfig = {
   settings: settings,
   splashMessages: splashMessages,
   starterSelectUiHandler: starterSelectUiHandler,
+  statusEffect: statusEffect,
   titles: titles,
   trainerClasses: trainerClasses,
   trainerNames: trainerNames,

--- a/src/locales/de/status-effect.ts
+++ b/src/locales/de/status-effect.ts
@@ -14,7 +14,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Poison",
     description: "poisoning",
     obtain: "{{pokemonNameWithAffix}}\nwas poisoned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
     overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
     heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
@@ -23,7 +23,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Toxic",
     description: "poisoning",
     obtain: "{{pokemonNameWithAffix}}\nwas badly poisoned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
     overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
     heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
@@ -32,7 +32,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Paralysis",
     description: "paralysis",
     obtain: "{{pokemonNameWithAffix}} was paralyzed,\nIt may be unable to move!",
-    obtainSource: "{{pokemonNameWithAffix}} was paralyzed from {{sourceText}},\nIt may be unable to move!",
+    obtainSource: "{{pokemonNameWithAffix}} was paralyzed by {{sourceText}},\nIt may be unable to move!",
     activation: "{{pokemonNameWithAffix}} is paralyzed!\nIt can't move!",
     overlap: "{{pokemonNameWithAffix}} is\nalready paralyzed!",
     heal: "{{pokemonNameWithAffix}} was\nhealed of paralysis!"
@@ -41,7 +41,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Sleep",
     description: "sleep",
     obtain: "{{pokemonNameWithAffix}}\nfell asleep!",
-    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep by {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep from {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is fast asleep.",
     overlap: "{{pokemonNameWithAffix}} is\nalready asleep!",
     heal: "{{pokemonNameWithAffix}} woke up!"
@@ -50,7 +50,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Freeze",
     description: "freezing",
     obtain: "{{pokemonNameWithAffix}}\nwas frozen solid!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is\nfrozen solid!",
     overlap: "{{pokemonNameWithAffix}} is\nalready frozen!",
     heal: "{{pokemonNameWithAffix}} was\ndefrosted!"
@@ -59,7 +59,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Burn",
     description: "burn",
     obtain: "{{pokemonNameWithAffix}}\nwas burned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas burned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas burned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby its burn!",
     overlap: "{{pokemonNameWithAffix}} is\nalready burned!",
     heal: "{{pokemonNameWithAffix}} was\nhealed of its burn!"

--- a/src/locales/de/status-effect.ts
+++ b/src/locales/de/status-effect.ts
@@ -1,0 +1,67 @@
+import { StatusEffectTranslationEntries } from "#app/interfaces/locales.js";
+
+export const statusEffect: StatusEffectTranslationEntries = {
+  none: {
+    name: "None",
+    description: "",
+    obtain: "",
+    obtainSource: "",
+    activation: "",
+    overlap: "",
+    heal: ""
+  },
+  poison: {
+    name: "Poison",
+    description: "poisoning",
+    obtain: "{{pokemonNameWithAffix}}\nwas poisoned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
+    heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
+  },
+  toxic: {
+    name: "Toxic",
+    description: "poisoning",
+    obtain: "{{pokemonNameWithAffix}}\nwas badly poisoned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
+    heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
+  },
+  paralysis: {
+    name: "Paralysis",
+    description: "paralysis",
+    obtain: "{{pokemonNameWithAffix}} was paralyzed,\nIt may be unable to move!",
+    obtainSource: "{{pokemonNameWithAffix}} was paralyzed from {{sourceText}},\nIt may be unable to move!",
+    activation: "{{pokemonNameWithAffix}} is paralyzed!\nIt can't move!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready paralyzed!",
+    heal: "{{pokemonNameWithAffix}} was\nhealed of paralysis!"
+  },
+  sleep: {
+    name: "Sleep",
+    description: "sleep",
+    obtain: "{{pokemonNameWithAffix}}\nfell asleep!",
+    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep by {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is fast asleep.",
+    overlap: "{{pokemonNameWithAffix}} is\nalready asleep!",
+    heal: "{{pokemonNameWithAffix}} woke up!"
+  },
+  freeze: {
+    name: "Freeze",
+    description: "freezing",
+    obtain: "{{pokemonNameWithAffix}}\nwas frozen solid!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is\nfrozen solid!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready frozen!",
+    heal: "{{pokemonNameWithAffix}} was\ndefrosted!"
+  },
+  burn: {
+    name: "Burn",
+    description: "burn",
+    obtain: "{{pokemonNameWithAffix}}\nwas burned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas burned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby its burn!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready burned!",
+    heal: "{{pokemonNameWithAffix}} was\nhealed of its burn!"
+  },
+} as const;

--- a/src/locales/en/config.ts
+++ b/src/locales/en/config.ts
@@ -1,5 +1,5 @@
-import { common } from "#app/locales/en/common.js";
-import { settings } from "#app/locales/en/settings.js";
+import { common } from "./common.js";
+import { settings } from "./settings.js";
 import { ability } from "./ability";
 import { abilityTriggers } from "./ability-trigger";
 import { PGFachv, PGMachv } from "./achv";
@@ -37,6 +37,7 @@ import { pokemonInfoContainer } from "./pokemon-info-container";
 import { saveSlotSelectUiHandler } from "./save-slot-select-ui-handler";
 import { splashMessages } from "./splash-messages";
 import { starterSelectUiHandler } from "./starter-select-ui-handler";
+import { statusEffect } from "./status-effect";
 import { titles, trainerClasses, trainerNames } from "./trainers";
 import { tutorial } from "./tutorial";
 import { voucher } from "./voucher";
@@ -81,6 +82,7 @@ export const enConfig = {
   settings: settings,
   splashMessages: splashMessages,
   starterSelectUiHandler: starterSelectUiHandler,
+  statusEffect: statusEffect,
   titles: titles,
   trainerClasses: trainerClasses,
   trainerNames: trainerNames,

--- a/src/locales/en/status-effect.ts
+++ b/src/locales/en/status-effect.ts
@@ -14,7 +14,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Poison",
     description: "poisoning",
     obtain: "{{pokemonNameWithAffix}}\nwas poisoned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
     overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
     heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
@@ -23,7 +23,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Toxic",
     description: "poisoning",
     obtain: "{{pokemonNameWithAffix}}\nwas badly poisoned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
     overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
     heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
@@ -32,7 +32,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Paralysis",
     description: "paralysis",
     obtain: "{{pokemonNameWithAffix}} was paralyzed,\nIt may be unable to move!",
-    obtainSource: "{{pokemonNameWithAffix}} was paralyzed from {{sourceText}},\nIt may be unable to move!",
+    obtainSource: "{{pokemonNameWithAffix}} was paralyzed by {{sourceText}},\nIt may be unable to move!",
     activation: "{{pokemonNameWithAffix}} is paralyzed!\nIt can't move!",
     overlap: "{{pokemonNameWithAffix}} is\nalready paralyzed!",
     heal: "{{pokemonNameWithAffix}} was\nhealed of paralysis!"
@@ -41,7 +41,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Sleep",
     description: "sleep",
     obtain: "{{pokemonNameWithAffix}}\nfell asleep!",
-    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep by {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep from {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is fast asleep.",
     overlap: "{{pokemonNameWithAffix}} is\nalready asleep!",
     heal: "{{pokemonNameWithAffix}} woke up!"
@@ -50,7 +50,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Freeze",
     description: "freezing",
     obtain: "{{pokemonNameWithAffix}}\nwas frozen solid!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is\nfrozen solid!",
     overlap: "{{pokemonNameWithAffix}} is\nalready frozen!",
     heal: "{{pokemonNameWithAffix}} was\ndefrosted!"
@@ -59,7 +59,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Burn",
     description: "burn",
     obtain: "{{pokemonNameWithAffix}}\nwas burned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas burned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas burned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby its burn!",
     overlap: "{{pokemonNameWithAffix}} is\nalready burned!",
     heal: "{{pokemonNameWithAffix}} was\nhealed of its burn!"

--- a/src/locales/en/status-effect.ts
+++ b/src/locales/en/status-effect.ts
@@ -1,0 +1,67 @@
+import { StatusEffectTranslationEntries } from "#app/interfaces/locales.js";
+
+export const statusEffect: StatusEffectTranslationEntries = {
+  none: {
+    name: "None",
+    description: "",
+    obtain: "",
+    obtainSource: "",
+    activation: "",
+    overlap: "",
+    heal: ""
+  },
+  poison: {
+    name: "Poison",
+    description: "poisoning",
+    obtain: "{{pokemonNameWithAffix}}\nwas poisoned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
+    heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
+  },
+  toxic: {
+    name: "Toxic",
+    description: "poisoning",
+    obtain: "{{pokemonNameWithAffix}}\nwas badly poisoned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
+    heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
+  },
+  paralysis: {
+    name: "Paralysis",
+    description: "paralysis",
+    obtain: "{{pokemonNameWithAffix}} was paralyzed,\nIt may be unable to move!",
+    obtainSource: "{{pokemonNameWithAffix}} was paralyzed from {{sourceText}},\nIt may be unable to move!",
+    activation: "{{pokemonNameWithAffix}} is paralyzed!\nIt can't move!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready paralyzed!",
+    heal: "{{pokemonNameWithAffix}} was\nhealed of paralysis!"
+  },
+  sleep: {
+    name: "Sleep",
+    description: "sleep",
+    obtain: "{{pokemonNameWithAffix}}\nfell asleep!",
+    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep by {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is fast asleep.",
+    overlap: "{{pokemonNameWithAffix}} is\nalready asleep!",
+    heal: "{{pokemonNameWithAffix}} woke up!"
+  },
+  freeze: {
+    name: "Freeze",
+    description: "freezing",
+    obtain: "{{pokemonNameWithAffix}}\nwas frozen solid!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is\nfrozen solid!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready frozen!",
+    heal: "{{pokemonNameWithAffix}} was\ndefrosted!"
+  },
+  burn: {
+    name: "Burn",
+    description: "burn",
+    obtain: "{{pokemonNameWithAffix}}\nwas burned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas burned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby its burn!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready burned!",
+    heal: "{{pokemonNameWithAffix}} was\nhealed of its burn!"
+  },
+} as const;

--- a/src/locales/es/config.ts
+++ b/src/locales/es/config.ts
@@ -34,13 +34,14 @@ import { pokemonInfoContainer } from "./pokemon-info-container";
 import { saveSlotSelectUiHandler } from "./save-slot-select-ui-handler";
 import { splashMessages } from "./splash-messages";
 import { starterSelectUiHandler } from "./starter-select-ui-handler";
+import { statusEffect } from "./status-effect";
 import { titles, trainerClasses, trainerNames } from "./trainers";
 import { tutorial } from "./tutorial";
 import { voucher } from "./voucher";
 import { weather } from "./weather";
 import { partyUiHandler } from "./party-ui-handler";
-import { settings } from "#app/locales/es/settings.js";
-import { common } from "#app/locales/es/common.js";
+import { settings } from "./settings.js";
+import { common } from "./common.js";
 
 export const esConfig = {
   ability: ability,
@@ -80,6 +81,7 @@ export const esConfig = {
   settings: settings,
   splashMessages: splashMessages,
   starterSelectUiHandler: starterSelectUiHandler,
+  statusEffect: statusEffect,
   titles: titles,
   trainerClasses: trainerClasses,
   trainerNames: trainerNames,

--- a/src/locales/es/status-effect.ts
+++ b/src/locales/es/status-effect.ts
@@ -14,7 +14,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Poison",
     description: "poisoning",
     obtain: "{{pokemonNameWithAffix}}\nwas poisoned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
     overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
     heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
@@ -23,7 +23,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Toxic",
     description: "poisoning",
     obtain: "{{pokemonNameWithAffix}}\nwas badly poisoned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
     overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
     heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
@@ -32,7 +32,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Paralysis",
     description: "paralysis",
     obtain: "{{pokemonNameWithAffix}} was paralyzed,\nIt may be unable to move!",
-    obtainSource: "{{pokemonNameWithAffix}} was paralyzed from {{sourceText}},\nIt may be unable to move!",
+    obtainSource: "{{pokemonNameWithAffix}} was paralyzed by {{sourceText}},\nIt may be unable to move!",
     activation: "{{pokemonNameWithAffix}} is paralyzed!\nIt can't move!",
     overlap: "{{pokemonNameWithAffix}} is\nalready paralyzed!",
     heal: "{{pokemonNameWithAffix}} was\nhealed of paralysis!"
@@ -41,7 +41,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Sleep",
     description: "sleep",
     obtain: "{{pokemonNameWithAffix}}\nfell asleep!",
-    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep by {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep from {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is fast asleep.",
     overlap: "{{pokemonNameWithAffix}} is\nalready asleep!",
     heal: "{{pokemonNameWithAffix}} woke up!"
@@ -50,7 +50,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Freeze",
     description: "freezing",
     obtain: "{{pokemonNameWithAffix}}\nwas frozen solid!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is\nfrozen solid!",
     overlap: "{{pokemonNameWithAffix}} is\nalready frozen!",
     heal: "{{pokemonNameWithAffix}} was\ndefrosted!"
@@ -59,7 +59,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Burn",
     description: "burn",
     obtain: "{{pokemonNameWithAffix}}\nwas burned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas burned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas burned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby its burn!",
     overlap: "{{pokemonNameWithAffix}} is\nalready burned!",
     heal: "{{pokemonNameWithAffix}} was\nhealed of its burn!"

--- a/src/locales/es/status-effect.ts
+++ b/src/locales/es/status-effect.ts
@@ -1,0 +1,67 @@
+import { StatusEffectTranslationEntries } from "#app/interfaces/locales.js";
+
+export const statusEffect: StatusEffectTranslationEntries = {
+  none: {
+    name: "None",
+    description: "",
+    obtain: "",
+    obtainSource: "",
+    activation: "",
+    overlap: "",
+    heal: ""
+  },
+  poison: {
+    name: "Poison",
+    description: "poisoning",
+    obtain: "{{pokemonNameWithAffix}}\nwas poisoned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
+    heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
+  },
+  toxic: {
+    name: "Toxic",
+    description: "poisoning",
+    obtain: "{{pokemonNameWithAffix}}\nwas badly poisoned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
+    heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
+  },
+  paralysis: {
+    name: "Paralysis",
+    description: "paralysis",
+    obtain: "{{pokemonNameWithAffix}} was paralyzed,\nIt may be unable to move!",
+    obtainSource: "{{pokemonNameWithAffix}} was paralyzed from {{sourceText}},\nIt may be unable to move!",
+    activation: "{{pokemonNameWithAffix}} is paralyzed!\nIt can't move!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready paralyzed!",
+    heal: "{{pokemonNameWithAffix}} was\nhealed of paralysis!"
+  },
+  sleep: {
+    name: "Sleep",
+    description: "sleep",
+    obtain: "{{pokemonNameWithAffix}}\nfell asleep!",
+    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep by {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is fast asleep.",
+    overlap: "{{pokemonNameWithAffix}} is\nalready asleep!",
+    heal: "{{pokemonNameWithAffix}} woke up!"
+  },
+  freeze: {
+    name: "Freeze",
+    description: "freezing",
+    obtain: "{{pokemonNameWithAffix}}\nwas frozen solid!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is\nfrozen solid!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready frozen!",
+    heal: "{{pokemonNameWithAffix}} was\ndefrosted!"
+  },
+  burn: {
+    name: "Burn",
+    description: "burn",
+    obtain: "{{pokemonNameWithAffix}}\nwas burned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas burned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby its burn!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready burned!",
+    heal: "{{pokemonNameWithAffix}} was\nhealed of its burn!"
+  },
+} as const;

--- a/src/locales/fr/config.ts
+++ b/src/locales/fr/config.ts
@@ -34,13 +34,14 @@ import { pokemonInfoContainer } from "./pokemon-info-container";
 import { saveSlotSelectUiHandler } from "./save-slot-select-ui-handler";
 import { splashMessages } from "./splash-messages";
 import { starterSelectUiHandler } from "./starter-select-ui-handler";
+import { statusEffect } from "./status-effect";
 import { titles, trainerClasses, trainerNames } from "./trainers";
 import { tutorial } from "./tutorial";
 import { voucher } from "./voucher";
 import { weather } from "./weather";
 import { partyUiHandler } from "./party-ui-handler";
-import { settings } from "#app/locales/fr/settings.js";
-import { common } from "#app/locales/fr/common.js";
+import { settings } from "./settings.js";
+import { common } from "./common.js";
 
 export const frConfig = {
   ability: ability,
@@ -80,6 +81,7 @@ export const frConfig = {
   settings: settings,
   splashMessages: splashMessages,
   starterSelectUiHandler: starterSelectUiHandler,
+  statusEffect: statusEffect,
   titles: titles,
   trainerClasses: trainerClasses,
   trainerNames: trainerNames,

--- a/src/locales/fr/status-effect.ts
+++ b/src/locales/fr/status-effect.ts
@@ -14,7 +14,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Poison",
     description: "poisoning",
     obtain: "{{pokemonNameWithAffix}}\nwas poisoned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
     overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
     heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
@@ -23,7 +23,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Toxic",
     description: "poisoning",
     obtain: "{{pokemonNameWithAffix}}\nwas badly poisoned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
     overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
     heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
@@ -32,7 +32,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Paralysis",
     description: "paralysis",
     obtain: "{{pokemonNameWithAffix}} was paralyzed,\nIt may be unable to move!",
-    obtainSource: "{{pokemonNameWithAffix}} was paralyzed from {{sourceText}},\nIt may be unable to move!",
+    obtainSource: "{{pokemonNameWithAffix}} was paralyzed by {{sourceText}},\nIt may be unable to move!",
     activation: "{{pokemonNameWithAffix}} is paralyzed!\nIt can't move!",
     overlap: "{{pokemonNameWithAffix}} is\nalready paralyzed!",
     heal: "{{pokemonNameWithAffix}} was\nhealed of paralysis!"
@@ -41,7 +41,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Sleep",
     description: "sleep",
     obtain: "{{pokemonNameWithAffix}}\nfell asleep!",
-    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep by {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep from {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is fast asleep.",
     overlap: "{{pokemonNameWithAffix}} is\nalready asleep!",
     heal: "{{pokemonNameWithAffix}} woke up!"
@@ -50,7 +50,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Freeze",
     description: "freezing",
     obtain: "{{pokemonNameWithAffix}}\nwas frozen solid!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is\nfrozen solid!",
     overlap: "{{pokemonNameWithAffix}} is\nalready frozen!",
     heal: "{{pokemonNameWithAffix}} was\ndefrosted!"
@@ -59,7 +59,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Burn",
     description: "burn",
     obtain: "{{pokemonNameWithAffix}}\nwas burned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas burned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas burned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby its burn!",
     overlap: "{{pokemonNameWithAffix}} is\nalready burned!",
     heal: "{{pokemonNameWithAffix}} was\nhealed of its burn!"

--- a/src/locales/fr/status-effect.ts
+++ b/src/locales/fr/status-effect.ts
@@ -1,0 +1,67 @@
+import { StatusEffectTranslationEntries } from "#app/interfaces/locales.js";
+
+export const statusEffect: StatusEffectTranslationEntries = {
+  none: {
+    name: "None",
+    description: "",
+    obtain: "",
+    obtainSource: "",
+    activation: "",
+    overlap: "",
+    heal: ""
+  },
+  poison: {
+    name: "Poison",
+    description: "poisoning",
+    obtain: "{{pokemonNameWithAffix}}\nwas poisoned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
+    heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
+  },
+  toxic: {
+    name: "Toxic",
+    description: "poisoning",
+    obtain: "{{pokemonNameWithAffix}}\nwas badly poisoned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
+    heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
+  },
+  paralysis: {
+    name: "Paralysis",
+    description: "paralysis",
+    obtain: "{{pokemonNameWithAffix}} was paralyzed,\nIt may be unable to move!",
+    obtainSource: "{{pokemonNameWithAffix}} was paralyzed from {{sourceText}},\nIt may be unable to move!",
+    activation: "{{pokemonNameWithAffix}} is paralyzed!\nIt can't move!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready paralyzed!",
+    heal: "{{pokemonNameWithAffix}} was\nhealed of paralysis!"
+  },
+  sleep: {
+    name: "Sleep",
+    description: "sleep",
+    obtain: "{{pokemonNameWithAffix}}\nfell asleep!",
+    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep by {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is fast asleep.",
+    overlap: "{{pokemonNameWithAffix}} is\nalready asleep!",
+    heal: "{{pokemonNameWithAffix}} woke up!"
+  },
+  freeze: {
+    name: "Freeze",
+    description: "freezing",
+    obtain: "{{pokemonNameWithAffix}}\nwas frozen solid!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is\nfrozen solid!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready frozen!",
+    heal: "{{pokemonNameWithAffix}} was\ndefrosted!"
+  },
+  burn: {
+    name: "Burn",
+    description: "burn",
+    obtain: "{{pokemonNameWithAffix}}\nwas burned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas burned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby its burn!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready burned!",
+    heal: "{{pokemonNameWithAffix}} was\nhealed of its burn!"
+  },
+} as const;

--- a/src/locales/it/config.ts
+++ b/src/locales/it/config.ts
@@ -34,13 +34,14 @@ import { pokemonInfoContainer } from "./pokemon-info-container";
 import { saveSlotSelectUiHandler } from "./save-slot-select-ui-handler";
 import { splashMessages } from "./splash-messages";
 import { starterSelectUiHandler } from "./starter-select-ui-handler";
+import { statusEffect } from "./status-effect";
 import { titles, trainerClasses, trainerNames } from "./trainers";
 import { tutorial } from "./tutorial";
 import { voucher } from "./voucher";
 import { weather } from "./weather";
 import { partyUiHandler } from "./party-ui-handler";
-import { settings } from "#app/locales/it/settings.js";
-import { common } from "#app/locales/it/common.js";
+import { settings } from "./settings.js";
+import { common } from "./common.js";
 
 export const itConfig = {
   ability: ability,
@@ -80,6 +81,7 @@ export const itConfig = {
   settings: settings,
   splashMessages: splashMessages,
   starterSelectUiHandler: starterSelectUiHandler,
+  statusEffect: statusEffect,
   titles: titles,
   trainerClasses: trainerClasses,
   trainerNames: trainerNames,

--- a/src/locales/it/status-effect.ts
+++ b/src/locales/it/status-effect.ts
@@ -14,7 +14,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Poison",
     description: "poisoning",
     obtain: "{{pokemonNameWithAffix}}\nwas poisoned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
     overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
     heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
@@ -23,7 +23,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Toxic",
     description: "poisoning",
     obtain: "{{pokemonNameWithAffix}}\nwas badly poisoned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
     overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
     heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
@@ -32,7 +32,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Paralysis",
     description: "paralysis",
     obtain: "{{pokemonNameWithAffix}} was paralyzed,\nIt may be unable to move!",
-    obtainSource: "{{pokemonNameWithAffix}} was paralyzed from {{sourceText}},\nIt may be unable to move!",
+    obtainSource: "{{pokemonNameWithAffix}} was paralyzed by {{sourceText}},\nIt may be unable to move!",
     activation: "{{pokemonNameWithAffix}} is paralyzed!\nIt can't move!",
     overlap: "{{pokemonNameWithAffix}} is\nalready paralyzed!",
     heal: "{{pokemonNameWithAffix}} was\nhealed of paralysis!"
@@ -41,7 +41,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Sleep",
     description: "sleep",
     obtain: "{{pokemonNameWithAffix}}\nfell asleep!",
-    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep by {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep from {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is fast asleep.",
     overlap: "{{pokemonNameWithAffix}} is\nalready asleep!",
     heal: "{{pokemonNameWithAffix}} woke up!"
@@ -50,7 +50,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Freeze",
     description: "freezing",
     obtain: "{{pokemonNameWithAffix}}\nwas frozen solid!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is\nfrozen solid!",
     overlap: "{{pokemonNameWithAffix}} is\nalready frozen!",
     heal: "{{pokemonNameWithAffix}} was\ndefrosted!"
@@ -59,7 +59,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Burn",
     description: "burn",
     obtain: "{{pokemonNameWithAffix}}\nwas burned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas burned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas burned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby its burn!",
     overlap: "{{pokemonNameWithAffix}} is\nalready burned!",
     heal: "{{pokemonNameWithAffix}} was\nhealed of its burn!"

--- a/src/locales/it/status-effect.ts
+++ b/src/locales/it/status-effect.ts
@@ -1,0 +1,67 @@
+import { StatusEffectTranslationEntries } from "#app/interfaces/locales.js";
+
+export const statusEffect: StatusEffectTranslationEntries = {
+  none: {
+    name: "None",
+    description: "",
+    obtain: "",
+    obtainSource: "",
+    activation: "",
+    overlap: "",
+    heal: ""
+  },
+  poison: {
+    name: "Poison",
+    description: "poisoning",
+    obtain: "{{pokemonNameWithAffix}}\nwas poisoned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
+    heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
+  },
+  toxic: {
+    name: "Toxic",
+    description: "poisoning",
+    obtain: "{{pokemonNameWithAffix}}\nwas badly poisoned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
+    heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
+  },
+  paralysis: {
+    name: "Paralysis",
+    description: "paralysis",
+    obtain: "{{pokemonNameWithAffix}} was paralyzed,\nIt may be unable to move!",
+    obtainSource: "{{pokemonNameWithAffix}} was paralyzed from {{sourceText}},\nIt may be unable to move!",
+    activation: "{{pokemonNameWithAffix}} is paralyzed!\nIt can't move!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready paralyzed!",
+    heal: "{{pokemonNameWithAffix}} was\nhealed of paralysis!"
+  },
+  sleep: {
+    name: "Sleep",
+    description: "sleep",
+    obtain: "{{pokemonNameWithAffix}}\nfell asleep!",
+    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep by {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is fast asleep.",
+    overlap: "{{pokemonNameWithAffix}} is\nalready asleep!",
+    heal: "{{pokemonNameWithAffix}} woke up!"
+  },
+  freeze: {
+    name: "Freeze",
+    description: "freezing",
+    obtain: "{{pokemonNameWithAffix}}\nwas frozen solid!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is\nfrozen solid!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready frozen!",
+    heal: "{{pokemonNameWithAffix}} was\ndefrosted!"
+  },
+  burn: {
+    name: "Burn",
+    description: "burn",
+    obtain: "{{pokemonNameWithAffix}}\nwas burned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas burned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby its burn!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready burned!",
+    heal: "{{pokemonNameWithAffix}} was\nhealed of its burn!"
+  },
+} as const;

--- a/src/locales/ko/config.ts
+++ b/src/locales/ko/config.ts
@@ -34,13 +34,14 @@ import { pokemonInfoContainer } from "./pokemon-info-container";
 import { saveSlotSelectUiHandler } from "./save-slot-select-ui-handler";
 import { splashMessages } from "./splash-messages";
 import { starterSelectUiHandler } from "./starter-select-ui-handler";
+import { statusEffect } from "./status-effect";
 import { titles, trainerClasses, trainerNames } from "./trainers";
 import { tutorial } from "./tutorial";
 import { voucher } from "./voucher";
 import { weather } from "./weather";
 import { partyUiHandler } from "./party-ui-handler";
-import { settings } from "#app/locales/ko/settings.js";
-import { common } from "#app/locales/ko/common.js";
+import { settings } from "./settings.js";
+import { common } from "./common.js";
 
 export const koConfig = {
   ability: ability,
@@ -80,6 +81,7 @@ export const koConfig = {
   settings: settings,
   splashMessages: splashMessages,
   starterSelectUiHandler: starterSelectUiHandler,
+  statusEffect: statusEffect,
   titles: titles,
   trainerClasses: trainerClasses,
   trainerNames: trainerNames,

--- a/src/locales/ko/status-effect.ts
+++ b/src/locales/ko/status-effect.ts
@@ -1,0 +1,67 @@
+import { StatusEffectTranslationEntries } from "#app/interfaces/locales.js";
+
+export const statusEffect: StatusEffectTranslationEntries = {
+  none: {
+    name: "없음",
+    description: "",
+    obtain: "",
+    obtainSource: "",
+    activation: "",
+    overlap: "",
+    heal: ""
+  },
+  poison: {
+    name: "독",
+    description: "독",
+    obtain: "{{pokemonNameWithAffix}}의\n몸에 독이 퍼졌다!",
+    obtainSource: "{{pokemonNameWithAffix}}[[는]]\n{{sourceText}} 때문에 몸에 독이 퍼졌다!",
+    activation: "{{pokemonNameWithAffix}}[[는]]\n독에 의한 데미지를 입었다!",
+    overlap: "{{pokemonNameWithAffix}}[[는]] 이미\n몸에 독이 퍼진 상태다.",
+    heal: "{{pokemonNameWithAffix}}의 독은\n말끔하게 해독됐다!"
+  },
+  toxic: {
+    name: "맹독",
+    description: "독",
+    obtain: "{{pokemonNameWithAffix}}의\n몸에 맹독이 퍼졌다!",
+    obtainSource: "{{pokemonNameWithAffix}}[[는]]\n{{sourceText}} 때문에 몸에 맹독이 퍼졌다!",
+    activation: "{{pokemonNameWithAffix}}[[는]]\n독에 의한 데미지를 입었다!",
+    overlap: "{{pokemonNameWithAffix}}[[는]] 이미\n몸에 독이 퍼진 상태다.",
+    heal: "{{pokemonNameWithAffix}}의 독은\n말끔하게 해독됐다!"
+  },
+  paralysis: {
+    name: "마비",
+    description: "마비",
+    obtain: "{{pokemonNameWithAffix}}[[는]] 마비되어\n기술이 나오기 어려워졌다!",
+    obtainSource: "{{pokemonNameWithAffix}}[[는]] {{sourceText}} 때문에\n마비되어 기술이 나오기 어려워졌다!",
+    activation: "{{pokemonNameWithAffix}}[[는]]\n몸이 저려서 움직일 수 없다!",
+    overlap: "{{pokemonNameWithAffix}}[[는]]\n이미 마비되어 있다!",
+    heal: "{{pokemonNameWithAffix}}의\n몸저림이 풀렸다!"
+  },
+  sleep: {
+    name: "잠듦",
+    description: "잠듦",
+    obtain: "{{pokemonNameWithAffix}}[[는]]\n잠들어 버렸다!",
+    obtainSource: "{{pokemonNameWithAffix}}[[는]]\n{{sourceText}} 때문에 잠들어 버렸다!",
+    activation: "{{pokemonNameWithAffix}}[[는]]\n쿨쿨 잠들어 있다.",
+    overlap: "{{pokemonNameWithAffix}}[[는]]\n이미 잠들어 있다.",
+    heal: "{{pokemonNameWithAffix}}[[는]]\n눈을 떴다!"
+  },
+  freeze: {
+    name: "얼음",
+    description: "얼음",
+    obtain: "{{pokemonNameWithAffix}}[[는]]\n얼어붙었다!",
+    obtainSource: "{{pokemonNameWithAffix}}[[는]]\n{{sourceText}} 때문에 얼어붙었다!",
+    activation: "{{pokemonNameWithAffix}}[[는]]\n얼어 버려서 움직일 수 없다!",
+    overlap: "{{pokemonNameWithAffix}}[[는]]\n이미 얼어 있다.",
+    heal: "{{pokemonNameWithAffix}}의\n얼음 상태가 나았다!"
+  },
+  burn: {
+    name: "화상",
+    description: "화상",
+    obtain: "{{pokemonNameWithAffix}}[[는]]\n화상을 입었다!",
+    obtainSource: "{{pokemonNameWithAffix}}[[는]]\n{{sourceText}} 때문에 화상을 입었다!",
+    activation: "{{pokemonNameWithAffix}}[[는]]\n화상 데미지를 입었다!",
+    overlap: "{{pokemonNameWithAffix}}[[는]] 이미\n화상을 입은 상태다.",
+    heal: "{{pokemonNameWithAffix}}의\n화상이 나았다!"
+  },
+} as const;

--- a/src/locales/pt_BR/config.ts
+++ b/src/locales/pt_BR/config.ts
@@ -34,13 +34,14 @@ import { pokemonInfoContainer } from "./pokemon-info-container";
 import { saveSlotSelectUiHandler } from "./save-slot-select-ui-handler";
 import { splashMessages } from "./splash-messages";
 import { starterSelectUiHandler } from "./starter-select-ui-handler";
+import { statusEffect } from "./status-effect";
 import { titles, trainerClasses, trainerNames } from "./trainers";
 import { tutorial } from "./tutorial";
 import { voucher } from "./voucher";
 import { weather } from "./weather";
 import { partyUiHandler } from "./party-ui-handler";
-import { settings } from "#app/locales/pt_BR/settings.js";
-import { common } from "#app/locales/pt_BR/common.js";
+import { settings } from "./settings.js";
+import { common } from "./common.js";
 
 export const ptBrConfig = {
   ability: ability,
@@ -78,6 +79,7 @@ export const ptBrConfig = {
   pokemonInfo: pokemonInfo,
   pokemonInfoContainer: pokemonInfoContainer,
   saveSlotSelectUiHandler: saveSlotSelectUiHandler,
+  statusEffect: statusEffect,
   settings: settings,
   splashMessages: splashMessages,
   starterSelectUiHandler: starterSelectUiHandler,

--- a/src/locales/pt_BR/status-effect.ts
+++ b/src/locales/pt_BR/status-effect.ts
@@ -14,7 +14,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Poison",
     description: "poisoning",
     obtain: "{{pokemonNameWithAffix}}\nwas poisoned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
     overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
     heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
@@ -23,7 +23,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Toxic",
     description: "poisoning",
     obtain: "{{pokemonNameWithAffix}}\nwas badly poisoned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
     overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
     heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
@@ -32,7 +32,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Paralysis",
     description: "paralysis",
     obtain: "{{pokemonNameWithAffix}} was paralyzed,\nIt may be unable to move!",
-    obtainSource: "{{pokemonNameWithAffix}} was paralyzed from {{sourceText}},\nIt may be unable to move!",
+    obtainSource: "{{pokemonNameWithAffix}} was paralyzed by {{sourceText}},\nIt may be unable to move!",
     activation: "{{pokemonNameWithAffix}} is paralyzed!\nIt can't move!",
     overlap: "{{pokemonNameWithAffix}} is\nalready paralyzed!",
     heal: "{{pokemonNameWithAffix}} was\nhealed of paralysis!"
@@ -41,7 +41,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Sleep",
     description: "sleep",
     obtain: "{{pokemonNameWithAffix}}\nfell asleep!",
-    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep by {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep from {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is fast asleep.",
     overlap: "{{pokemonNameWithAffix}} is\nalready asleep!",
     heal: "{{pokemonNameWithAffix}} woke up!"
@@ -50,7 +50,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Freeze",
     description: "freezing",
     obtain: "{{pokemonNameWithAffix}}\nwas frozen solid!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is\nfrozen solid!",
     overlap: "{{pokemonNameWithAffix}} is\nalready frozen!",
     heal: "{{pokemonNameWithAffix}} was\ndefrosted!"
@@ -59,7 +59,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Burn",
     description: "burn",
     obtain: "{{pokemonNameWithAffix}}\nwas burned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas burned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas burned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby its burn!",
     overlap: "{{pokemonNameWithAffix}} is\nalready burned!",
     heal: "{{pokemonNameWithAffix}} was\nhealed of its burn!"

--- a/src/locales/pt_BR/status-effect.ts
+++ b/src/locales/pt_BR/status-effect.ts
@@ -1,0 +1,67 @@
+import { StatusEffectTranslationEntries } from "#app/interfaces/locales.js";
+
+export const statusEffect: StatusEffectTranslationEntries = {
+  none: {
+    name: "None",
+    description: "",
+    obtain: "",
+    obtainSource: "",
+    activation: "",
+    overlap: "",
+    heal: ""
+  },
+  poison: {
+    name: "Poison",
+    description: "poisoning",
+    obtain: "{{pokemonNameWithAffix}}\nwas poisoned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
+    heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
+  },
+  toxic: {
+    name: "Toxic",
+    description: "poisoning",
+    obtain: "{{pokemonNameWithAffix}}\nwas badly poisoned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
+    heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
+  },
+  paralysis: {
+    name: "Paralysis",
+    description: "paralysis",
+    obtain: "{{pokemonNameWithAffix}} was paralyzed,\nIt may be unable to move!",
+    obtainSource: "{{pokemonNameWithAffix}} was paralyzed from {{sourceText}},\nIt may be unable to move!",
+    activation: "{{pokemonNameWithAffix}} is paralyzed!\nIt can't move!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready paralyzed!",
+    heal: "{{pokemonNameWithAffix}} was\nhealed of paralysis!"
+  },
+  sleep: {
+    name: "Sleep",
+    description: "sleep",
+    obtain: "{{pokemonNameWithAffix}}\nfell asleep!",
+    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep by {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is fast asleep.",
+    overlap: "{{pokemonNameWithAffix}} is\nalready asleep!",
+    heal: "{{pokemonNameWithAffix}} woke up!"
+  },
+  freeze: {
+    name: "Freeze",
+    description: "freezing",
+    obtain: "{{pokemonNameWithAffix}}\nwas frozen solid!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is\nfrozen solid!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready frozen!",
+    heal: "{{pokemonNameWithAffix}} was\ndefrosted!"
+  },
+  burn: {
+    name: "Burn",
+    description: "burn",
+    obtain: "{{pokemonNameWithAffix}}\nwas burned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas burned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby its burn!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready burned!",
+    heal: "{{pokemonNameWithAffix}} was\nhealed of its burn!"
+  },
+} as const;

--- a/src/locales/zh_CN/config.ts
+++ b/src/locales/zh_CN/config.ts
@@ -34,13 +34,14 @@ import { pokemonInfoContainer } from "./pokemon-info-container";
 import { saveSlotSelectUiHandler } from "./save-slot-select-ui-handler";
 import { splashMessages } from "./splash-messages";
 import { starterSelectUiHandler } from "./starter-select-ui-handler";
+import { statusEffect } from "./status-effect";
 import { titles, trainerClasses, trainerNames } from "./trainers";
 import { tutorial } from "./tutorial";
 import { voucher } from "./voucher";
 import { weather } from "./weather";
 import { partyUiHandler } from "./party-ui-handler";
-import { settings } from "#app/locales/zh_CN/settings.js";
-import { common } from "#app/locales/zh_CN/common.js";
+import { settings } from "./settings.js";
+import { common } from "./common.js";
 
 export const zhCnConfig = {
   ability: ability,
@@ -80,6 +81,7 @@ export const zhCnConfig = {
   settings: settings,
   splashMessages: splashMessages,
   starterSelectUiHandler: starterSelectUiHandler,
+  statusEffect: statusEffect,
   titles: titles,
   trainerClasses: trainerClasses,
   trainerNames: trainerNames,

--- a/src/locales/zh_CN/status-effect.ts
+++ b/src/locales/zh_CN/status-effect.ts
@@ -14,7 +14,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Poison",
     description: "poisoning",
     obtain: "{{pokemonNameWithAffix}}\nwas poisoned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
     overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
     heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
@@ -23,7 +23,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Toxic",
     description: "poisoning",
     obtain: "{{pokemonNameWithAffix}}\nwas badly poisoned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
     overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
     heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
@@ -32,7 +32,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Paralysis",
     description: "paralysis",
     obtain: "{{pokemonNameWithAffix}} was paralyzed,\nIt may be unable to move!",
-    obtainSource: "{{pokemonNameWithAffix}} was paralyzed from {{sourceText}},\nIt may be unable to move!",
+    obtainSource: "{{pokemonNameWithAffix}} was paralyzed by {{sourceText}},\nIt may be unable to move!",
     activation: "{{pokemonNameWithAffix}} is paralyzed!\nIt can't move!",
     overlap: "{{pokemonNameWithAffix}} is\nalready paralyzed!",
     heal: "{{pokemonNameWithAffix}} was\nhealed of paralysis!"
@@ -41,7 +41,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Sleep",
     description: "sleep",
     obtain: "{{pokemonNameWithAffix}}\nfell asleep!",
-    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep by {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep from {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is fast asleep.",
     overlap: "{{pokemonNameWithAffix}} is\nalready asleep!",
     heal: "{{pokemonNameWithAffix}} woke up!"
@@ -50,7 +50,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Freeze",
     description: "freezing",
     obtain: "{{pokemonNameWithAffix}}\nwas frozen solid!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is\nfrozen solid!",
     overlap: "{{pokemonNameWithAffix}} is\nalready frozen!",
     heal: "{{pokemonNameWithAffix}} was\ndefrosted!"
@@ -59,7 +59,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Burn",
     description: "burn",
     obtain: "{{pokemonNameWithAffix}}\nwas burned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas burned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas burned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby its burn!",
     overlap: "{{pokemonNameWithAffix}} is\nalready burned!",
     heal: "{{pokemonNameWithAffix}} was\nhealed of its burn!"

--- a/src/locales/zh_CN/status-effect.ts
+++ b/src/locales/zh_CN/status-effect.ts
@@ -1,0 +1,67 @@
+import { StatusEffectTranslationEntries } from "#app/interfaces/locales.js";
+
+export const statusEffect: StatusEffectTranslationEntries = {
+  none: {
+    name: "None",
+    description: "",
+    obtain: "",
+    obtainSource: "",
+    activation: "",
+    overlap: "",
+    heal: ""
+  },
+  poison: {
+    name: "Poison",
+    description: "poisoning",
+    obtain: "{{pokemonNameWithAffix}}\nwas poisoned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
+    heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
+  },
+  toxic: {
+    name: "Toxic",
+    description: "poisoning",
+    obtain: "{{pokemonNameWithAffix}}\nwas badly poisoned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
+    heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
+  },
+  paralysis: {
+    name: "Paralysis",
+    description: "paralysis",
+    obtain: "{{pokemonNameWithAffix}} was paralyzed,\nIt may be unable to move!",
+    obtainSource: "{{pokemonNameWithAffix}} was paralyzed from {{sourceText}},\nIt may be unable to move!",
+    activation: "{{pokemonNameWithAffix}} is paralyzed!\nIt can't move!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready paralyzed!",
+    heal: "{{pokemonNameWithAffix}} was\nhealed of paralysis!"
+  },
+  sleep: {
+    name: "Sleep",
+    description: "sleep",
+    obtain: "{{pokemonNameWithAffix}}\nfell asleep!",
+    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep by {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is fast asleep.",
+    overlap: "{{pokemonNameWithAffix}} is\nalready asleep!",
+    heal: "{{pokemonNameWithAffix}} woke up!"
+  },
+  freeze: {
+    name: "Freeze",
+    description: "freezing",
+    obtain: "{{pokemonNameWithAffix}}\nwas frozen solid!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is\nfrozen solid!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready frozen!",
+    heal: "{{pokemonNameWithAffix}} was\ndefrosted!"
+  },
+  burn: {
+    name: "Burn",
+    description: "burn",
+    obtain: "{{pokemonNameWithAffix}}\nwas burned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas burned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby its burn!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready burned!",
+    heal: "{{pokemonNameWithAffix}} was\nhealed of its burn!"
+  },
+} as const;

--- a/src/locales/zh_TW/config.ts
+++ b/src/locales/zh_TW/config.ts
@@ -34,13 +34,14 @@ import { pokemonInfoContainer } from "./pokemon-info-container";
 import { saveSlotSelectUiHandler } from "./save-slot-select-ui-handler";
 import { splashMessages } from "./splash-messages";
 import { starterSelectUiHandler } from "./starter-select-ui-handler";
+import { statusEffect } from "./status-effect";
 import { titles, trainerClasses, trainerNames } from "./trainers";
 import { tutorial } from "./tutorial";
 import { voucher } from "./voucher";
 import { weather } from "./weather";
 import { partyUiHandler } from "./party-ui-handler";
-import { settings } from "#app/locales/zh_TW/settings.js";
-import { common } from "#app/locales/zh_TW/common.js";
+import { settings } from "./settings.js";
+import { common } from "./common.js";
 
 export const zhTwConfig = {
   ability: ability,
@@ -80,6 +81,7 @@ export const zhTwConfig = {
   settings: settings,
   splashMessages: splashMessages,
   starterSelectUiHandler: starterSelectUiHandler,
+  statusEffect: statusEffect,
   titles: titles,
   trainerClasses: trainerClasses,
   trainerNames: trainerNames,

--- a/src/locales/zh_TW/status-effect.ts
+++ b/src/locales/zh_TW/status-effect.ts
@@ -14,7 +14,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Poison",
     description: "poisoning",
     obtain: "{{pokemonNameWithAffix}}\nwas poisoned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
     overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
     heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
@@ -23,7 +23,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Toxic",
     description: "poisoning",
     obtain: "{{pokemonNameWithAffix}}\nwas badly poisoned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
     overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
     heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
@@ -32,7 +32,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Paralysis",
     description: "paralysis",
     obtain: "{{pokemonNameWithAffix}} was paralyzed,\nIt may be unable to move!",
-    obtainSource: "{{pokemonNameWithAffix}} was paralyzed from {{sourceText}},\nIt may be unable to move!",
+    obtainSource: "{{pokemonNameWithAffix}} was paralyzed by {{sourceText}},\nIt may be unable to move!",
     activation: "{{pokemonNameWithAffix}} is paralyzed!\nIt can't move!",
     overlap: "{{pokemonNameWithAffix}} is\nalready paralyzed!",
     heal: "{{pokemonNameWithAffix}} was\nhealed of paralysis!"
@@ -41,7 +41,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Sleep",
     description: "sleep",
     obtain: "{{pokemonNameWithAffix}}\nfell asleep!",
-    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep by {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep from {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is fast asleep.",
     overlap: "{{pokemonNameWithAffix}} is\nalready asleep!",
     heal: "{{pokemonNameWithAffix}} woke up!"
@@ -50,7 +50,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Freeze",
     description: "freezing",
     obtain: "{{pokemonNameWithAffix}}\nwas frozen solid!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is\nfrozen solid!",
     overlap: "{{pokemonNameWithAffix}} is\nalready frozen!",
     heal: "{{pokemonNameWithAffix}} was\ndefrosted!"
@@ -59,7 +59,7 @@ export const statusEffect: StatusEffectTranslationEntries = {
     name: "Burn",
     description: "burn",
     obtain: "{{pokemonNameWithAffix}}\nwas burned!",
-    obtainSource: "{{pokemonNameWithAffix}}\nwas burned from {{sourceText}}!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas burned by {{sourceText}}!",
     activation: "{{pokemonNameWithAffix}} is hurt\nby its burn!",
     overlap: "{{pokemonNameWithAffix}} is\nalready burned!",
     heal: "{{pokemonNameWithAffix}} was\nhealed of its burn!"

--- a/src/locales/zh_TW/status-effect.ts
+++ b/src/locales/zh_TW/status-effect.ts
@@ -1,0 +1,67 @@
+import { StatusEffectTranslationEntries } from "#app/interfaces/locales.js";
+
+export const statusEffect: StatusEffectTranslationEntries = {
+  none: {
+    name: "None",
+    description: "",
+    obtain: "",
+    obtainSource: "",
+    activation: "",
+    overlap: "",
+    heal: ""
+  },
+  poison: {
+    name: "Poison",
+    description: "poisoning",
+    obtain: "{{pokemonNameWithAffix}}\nwas poisoned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas poisoned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
+    heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
+  },
+  toxic: {
+    name: "Toxic",
+    description: "poisoning",
+    obtain: "{{pokemonNameWithAffix}}\nwas badly poisoned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas badly poisoned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby poison!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready poisoned!",
+    heal: "{{pokemonNameWithAffix}} was\ncured of its poison!"
+  },
+  paralysis: {
+    name: "Paralysis",
+    description: "paralysis",
+    obtain: "{{pokemonNameWithAffix}} was paralyzed,\nIt may be unable to move!",
+    obtainSource: "{{pokemonNameWithAffix}} was paralyzed from {{sourceText}},\nIt may be unable to move!",
+    activation: "{{pokemonNameWithAffix}} is paralyzed!\nIt can't move!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready paralyzed!",
+    heal: "{{pokemonNameWithAffix}} was\nhealed of paralysis!"
+  },
+  sleep: {
+    name: "Sleep",
+    description: "sleep",
+    obtain: "{{pokemonNameWithAffix}}\nfell asleep!",
+    obtainSource: "{{pokemonNameWithAffix}}\nfell asleep by {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is fast asleep.",
+    overlap: "{{pokemonNameWithAffix}} is\nalready asleep!",
+    heal: "{{pokemonNameWithAffix}} woke up!"
+  },
+  freeze: {
+    name: "Freeze",
+    description: "freezing",
+    obtain: "{{pokemonNameWithAffix}}\nwas frozen solid!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas frozen solid from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is\nfrozen solid!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready frozen!",
+    heal: "{{pokemonNameWithAffix}} was\ndefrosted!"
+  },
+  burn: {
+    name: "Burn",
+    description: "burn",
+    obtain: "{{pokemonNameWithAffix}}\nwas burned!",
+    obtainSource: "{{pokemonNameWithAffix}}\nwas burned from {{sourceText}}!",
+    activation: "{{pokemonNameWithAffix}} is hurt\nby its burn!",
+    overlap: "{{pokemonNameWithAffix}} is\nalready burned!",
+    heal: "{{pokemonNameWithAffix}} was\nhealed of its burn!"
+  },
+} as const;

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -9,7 +9,7 @@ import { addTextObject, TextStyle } from "../ui/text";
 import { Type } from "../data/type";
 import { EvolutionPhase } from "../evolution-phase";
 import { FusionSpeciesFormEvolution, pokemonEvolutions, pokemonPrevolutions } from "../data/pokemon-evolutions";
-import { getPokemonMessage } from "../messages";
+import {getPokemonMessage, getPokemonNameWithAffix} from "../messages";
 import * as Utils from "../utils";
 import { TempBattleStat } from "../data/temp-battle-stat";
 import { getBerryEffectFunc, getBerryPredicate } from "../data/berry";
@@ -2281,7 +2281,7 @@ export class EnemyStatusEffectHealChanceModifier extends EnemyPersistentModifier
   apply(args: any[]): boolean {
     const target = (args[0] as Pokemon);
     if (target.status && Phaser.Math.RND.realInRange(0, 1) < (this.chance * this.getStackCount())) {
-      target.scene.queueMessage(getPokemonMessage(target, getStatusEffectHealText(target.status.effect)));
+      target.scene.queueMessage(getStatusEffectHealText(target.status.effect, getPokemonNameWithAffix(target)));
       target.resetStatus();
       target.updateInfo();
       return true;

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2778,12 +2778,12 @@ export class MovePhase extends BattlePhase {
       }
 
       if (activated) {
-        this.scene.queueMessage(getPokemonMessage(this.pokemon, getStatusEffectActivationText(this.pokemon.status.effect)));
+        this.scene.queueMessage(getStatusEffectActivationText(this.pokemon.status.effect, getPokemonNameWithAffix(this.pokemon)));
         this.scene.unshiftPhase(new CommonAnimPhase(this.scene, this.pokemon.getBattlerIndex(), undefined, CommonAnim.POISON + (this.pokemon.status.effect - 1)));
         doMove();
       } else {
         if (healed) {
-          this.scene.queueMessage(getPokemonMessage(this.pokemon, getStatusEffectHealText(this.pokemon.status.effect)));
+          this.scene.queueMessage(getStatusEffectHealText(this.pokemon.status.effect, getPokemonNameWithAffix(this.pokemon)));
           this.pokemon.resetStatus();
           this.pokemon.updateInfo();
         }
@@ -3470,7 +3470,7 @@ export class ObtainStatusEffectPhase extends PokemonPhase {
         }
         pokemon.updateInfo(true);
         new CommonBattleAnim(CommonAnim.POISON + (this.statusEffect - 1), pokemon).play(this.scene, () => {
-          this.scene.queueMessage(getPokemonMessage(pokemon, getStatusEffectObtainText(this.statusEffect, this.sourceText)));
+          this.scene.queueMessage(getStatusEffectObtainText(this.statusEffect, getPokemonNameWithAffix(pokemon), this.sourceText));
           if (pokemon.status.isPostTurn()) {
             this.scene.pushPhase(new PostTurnStatusEffectPhase(this.scene, this.battlerIndex));
           }
@@ -3479,7 +3479,7 @@ export class ObtainStatusEffectPhase extends PokemonPhase {
         return;
       }
     } else if (pokemon.status.effect === this.statusEffect) {
-      this.scene.queueMessage(getPokemonMessage(pokemon, getStatusEffectOverlapText(this.statusEffect)));
+      this.scene.queueMessage(getStatusEffectOverlapText(this.statusEffect, getPokemonNameWithAffix(pokemon)));
     }
     this.end();
   }
@@ -3499,7 +3499,7 @@ export class PostTurnStatusEffectPhase extends PokemonPhase {
       applyAbAttrs(BlockStatusDamageAbAttr, pokemon, cancelled);
 
       if (!cancelled.value) {
-        this.scene.queueMessage(getPokemonMessage(pokemon, getStatusEffectActivationText(pokemon.status.effect)));
+        this.scene.queueMessage(getStatusEffectActivationText(pokemon.status.effect, getPokemonNameWithAffix(pokemon)));
         let damage: integer = 0;
         switch (pokemon.status.effect) {
         case StatusEffect.POISON:
@@ -4717,7 +4717,7 @@ export class PokemonHealPhase extends CommonAnimPhase {
     }
 
     if (this.healStatus && lastStatusEffect && !hasMessage) {
-      this.scene.queueMessage(getPokemonMessage(pokemon, getStatusEffectHealText(lastStatusEffect)));
+      this.scene.queueMessage(getStatusEffectHealText(lastStatusEffect, getPokemonNameWithAffix(pokemon)));
     }
 
     if (!healOrDamage && !lastStatusEffect) {

--- a/src/test/items/toxic_orb.test.ts
+++ b/src/test/items/toxic_orb.test.ts
@@ -15,6 +15,7 @@ import {StatusEffect} from "#app/data/status-effect";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
+import i18next, { initI18n } from "#app/plugins/i18n";
 
 
 describe("Items - Toxic orb", () => {
@@ -48,6 +49,8 @@ describe("Items - Toxic orb", () => {
   });
 
   it("TOXIC ORB", async() => {
+    initI18n();
+    i18next.changeLanguage("en");
     const moveToUse = Moves.GROWTH;
     await game.startBattle([
       Species.MIGHTYENA,

--- a/src/test/lokalisation/status-effect.test.ts
+++ b/src/test/lokalisation/status-effect.test.ts
@@ -1,0 +1,185 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { StatusEffect } from "#app/data/status-effect";
+import { getStatusEffectObtainText, getStatusEffectActivationText, getStatusEffectOverlapText, getStatusEffectHealText, getStatusEffectDescriptor } from "#app/data/status-effect";
+import { statusEffect as enStatusEffect } from "#app/locales/en/status-effect.js";
+import { statusEffect as deStatusEffect } from "#app/locales/de/status-effect.js";
+import { statusEffect as esStatusEffect } from "#app/locales/es/status-effect.js";
+import { statusEffect as frStatusEffect } from "#app/locales/fr/status-effect.js";
+import { statusEffect as itStatusEffect } from "#app/locales/it/status-effect.js";
+import { statusEffect as koStatusEffect } from "#app/locales/ko/status-effect.js";
+import { statusEffect as ptBrStatusEffect } from "#app/locales/pt_BR/status-effect.js";
+import { statusEffect as zhCnStatusEffect } from "#app/locales/zh_CN/status-effect.js";
+import { statusEffect as zhTwStatusEffect } from "#app/locales/zh_TW/status-effect.js";
+
+import i18next, {initI18n} from "#app/plugins/i18n";
+import { KoreanPostpositionProcessor } from "i18next-korean-postposition-processor";
+
+
+interface StatusEffectTestUnit {
+  stat: StatusEffect,
+  key: string
+}
+
+const testPokemonNameWithoutBinding = "{{pokemonNameWithAffix}}";
+const testSourceTextWithoutBinding = "{{sourceText}}";
+
+function testStatusEffectObtainText(stat: StatusEffect, expectMessage: string) {
+  const message = getStatusEffectObtainText(stat, testPokemonNameWithoutBinding);
+  console.log(`message ${message}, expected ${expectMessage}`);
+  expect(message).toBe(expectMessage);
+}
+
+function testStatusEffectObtainTextWithSource(stat: StatusEffect, expectMessage: string) {
+  const message = getStatusEffectObtainText(stat, testPokemonNameWithoutBinding, testSourceTextWithoutBinding);
+  console.log(`message ${message}, expected ${expectMessage}`);
+  expect(message).toBe(expectMessage);
+}
+
+function testStatusEffectActivationText(stat: StatusEffect, expectMessage: string) {
+  const message = getStatusEffectActivationText(stat, testPokemonNameWithoutBinding);
+  console.log(`message ${message}, expected ${expectMessage}`);
+  expect(message).toBe(expectMessage);
+}
+
+function testStatusEffectOverlapText(stat: StatusEffect, expectMessage: string) {
+  const message = getStatusEffectOverlapText(stat, testPokemonNameWithoutBinding);
+  console.log(`message ${message}, expected ${expectMessage}`);
+  expect(message).toBe(expectMessage);
+}
+
+function testStatusEffectHealText(stat: StatusEffect, expectMessage: string) {
+  const message = getStatusEffectHealText(stat, testPokemonNameWithoutBinding);
+  console.log(`message ${message}, expected ${expectMessage}`);
+  expect(message).toBe(expectMessage);
+}
+
+function testStatusEffectDescriptor(stat: StatusEffect, expectMessage: string) {
+  const message = getStatusEffectDescriptor(stat);
+  console.log(`message ${message}, expected ${expectMessage}`);
+  expect(message).toBe(expectMessage);
+}
+
+describe("Test for StatusEffect Localization", () => {
+  const statusEffectUnits: StatusEffectTestUnit[] = [];
+
+  beforeAll(() => {
+    initI18n();
+
+    statusEffectUnits.push({ stat: StatusEffect.NONE, key: "none" });
+    statusEffectUnits.push({ stat: StatusEffect.POISON, key: "poison" });
+    statusEffectUnits.push({ stat: StatusEffect.TOXIC, key: "toxic" });
+    statusEffectUnits.push({ stat: StatusEffect.PARALYSIS, key: "paralysis" });
+    statusEffectUnits.push({ stat: StatusEffect.SLEEP, key: "sleep" });
+    statusEffectUnits.push({ stat: StatusEffect.FREEZE, key: "freeze" });
+    statusEffectUnits.push({ stat: StatusEffect.BURN, key: "burn" });
+  });
+
+  it("Test getStatusEffectMessages in English", async () => {
+    i18next.changeLanguage("en");
+    statusEffectUnits.forEach(unit => {
+      testStatusEffectObtainText(unit.stat, enStatusEffect[unit.key].obtain);
+      testStatusEffectObtainTextWithSource(unit.stat, enStatusEffect[unit.key].obtainSource);
+      testStatusEffectActivationText(unit.stat, enStatusEffect[unit.key].activation);
+      testStatusEffectOverlapText(unit.stat, enStatusEffect[unit.key].overlap);
+      testStatusEffectHealText(unit.stat, enStatusEffect[unit.key].heal);
+      testStatusEffectDescriptor(unit.stat, enStatusEffect[unit.key].description);
+    });
+  });
+
+  it("Test getStatusEffectMessages in Español", async () => {
+    i18next.changeLanguage("es");
+    statusEffectUnits.forEach(unit => {
+      testStatusEffectObtainText(unit.stat, esStatusEffect[unit.key].obtain);
+      testStatusEffectObtainTextWithSource(unit.stat, esStatusEffect[unit.key].obtainSource);
+      testStatusEffectActivationText(unit.stat, esStatusEffect[unit.key].activation);
+      testStatusEffectOverlapText(unit.stat, esStatusEffect[unit.key].overlap);
+      testStatusEffectHealText(unit.stat, esStatusEffect[unit.key].heal);
+      testStatusEffectDescriptor(unit.stat, esStatusEffect[unit.key].description);
+    });
+  });
+
+  it("Test getStatusEffectMessages in Italiano", async () => {
+    i18next.changeLanguage("it");
+    statusEffectUnits.forEach(unit => {
+      testStatusEffectObtainText(unit.stat, itStatusEffect[unit.key].obtain);
+      testStatusEffectObtainTextWithSource(unit.stat, itStatusEffect[unit.key].obtainSource);
+      testStatusEffectActivationText(unit.stat, itStatusEffect[unit.key].activation);
+      testStatusEffectOverlapText(unit.stat, itStatusEffect[unit.key].overlap);
+      testStatusEffectHealText(unit.stat, itStatusEffect[unit.key].heal);
+      testStatusEffectDescriptor(unit.stat, itStatusEffect[unit.key].description);
+    });
+  });
+
+  it("Test getStatusEffectMessages in Français", async () => {
+    i18next.changeLanguage("fr");
+    statusEffectUnits.forEach(unit => {
+      testStatusEffectObtainText(unit.stat, frStatusEffect[unit.key].obtain);
+      testStatusEffectObtainTextWithSource(unit.stat, frStatusEffect[unit.key].obtainSource);
+      testStatusEffectActivationText(unit.stat, frStatusEffect[unit.key].activation);
+      testStatusEffectOverlapText(unit.stat, frStatusEffect[unit.key].overlap);
+      testStatusEffectHealText(unit.stat, frStatusEffect[unit.key].heal);
+      testStatusEffectDescriptor(unit.stat, frStatusEffect[unit.key].description);
+    });
+  });
+
+  it("Test getStatusEffectMessages in Deutsch", async () => {
+    i18next.changeLanguage("de");
+    statusEffectUnits.forEach(unit => {
+      testStatusEffectObtainText(unit.stat, deStatusEffect[unit.key].obtain);
+      testStatusEffectObtainTextWithSource(unit.stat, deStatusEffect[unit.key].obtainSource);
+      testStatusEffectActivationText(unit.stat, deStatusEffect[unit.key].activation);
+      testStatusEffectOverlapText(unit.stat, deStatusEffect[unit.key].overlap);
+      testStatusEffectHealText(unit.stat, deStatusEffect[unit.key].heal);
+      testStatusEffectDescriptor(unit.stat, deStatusEffect[unit.key].description);
+    });
+  });
+
+  it("Test getStatusEffectMessages in Português (BR)", async () => {
+    i18next.changeLanguage("pt-BR");
+    statusEffectUnits.forEach(unit => {
+      testStatusEffectObtainText(unit.stat, ptBrStatusEffect[unit.key].obtain);
+      testStatusEffectObtainTextWithSource(unit.stat, ptBrStatusEffect[unit.key].obtainSource);
+      testStatusEffectActivationText(unit.stat, ptBrStatusEffect[unit.key].activation);
+      testStatusEffectOverlapText(unit.stat, ptBrStatusEffect[unit.key].overlap);
+      testStatusEffectHealText(unit.stat, ptBrStatusEffect[unit.key].heal);
+      testStatusEffectDescriptor(unit.stat, ptBrStatusEffect[unit.key].description);
+    });
+  });
+
+  it("Test getStatusEffectMessages in 简体中文", async () => {
+    i18next.changeLanguage("zh-CN");
+    statusEffectUnits.forEach(unit => {
+      testStatusEffectObtainText(unit.stat, zhCnStatusEffect[unit.key].obtain);
+      testStatusEffectObtainTextWithSource(unit.stat, zhCnStatusEffect[unit.key].obtainSource);
+      testStatusEffectActivationText(unit.stat, zhCnStatusEffect[unit.key].activation);
+      testStatusEffectOverlapText(unit.stat, zhCnStatusEffect[unit.key].overlap);
+      testStatusEffectHealText(unit.stat, zhCnStatusEffect[unit.key].heal);
+      testStatusEffectDescriptor(unit.stat, zhCnStatusEffect[unit.key].description);
+    });
+  });
+
+  it("Test getStatusEffectMessages in 繁體中文", async () => {
+    i18next.changeLanguage("zh-TW");
+    statusEffectUnits.forEach(unit => {
+      testStatusEffectObtainText(unit.stat, zhTwStatusEffect[unit.key].obtain);
+      testStatusEffectObtainTextWithSource(unit.stat, zhTwStatusEffect[unit.key].obtainSource);
+      testStatusEffectActivationText(unit.stat, zhTwStatusEffect[unit.key].activation);
+      testStatusEffectOverlapText(unit.stat, zhTwStatusEffect[unit.key].overlap);
+      testStatusEffectHealText(unit.stat, zhTwStatusEffect[unit.key].heal);
+      testStatusEffectDescriptor(unit.stat, zhTwStatusEffect[unit.key].description);
+    });
+  });
+
+  it("Test getStatusEffectMessages in 한국어", async () => {
+    await i18next.changeLanguage("ko");
+    statusEffectUnits.forEach(unit => {
+      const processor = new KoreanPostpositionProcessor();
+      testStatusEffectObtainText(unit.stat, processor.process(koStatusEffect[unit.key].obtain));
+      testStatusEffectObtainTextWithSource(unit.stat, processor.process(koStatusEffect[unit.key].obtainSource));
+      testStatusEffectActivationText(unit.stat, processor.process(koStatusEffect[unit.key].activation));
+      testStatusEffectOverlapText(unit.stat, processor.process(koStatusEffect[unit.key].overlap));
+      testStatusEffectHealText(unit.stat, processor.process(koStatusEffect[unit.key].heal));
+      testStatusEffectDescriptor(unit.stat, processor.process(koStatusEffect[unit.key].description));
+    });
+  });
+});


### PR DESCRIPTION
## What are the changes?
Add the option to localize message text of status effects. (at status-effects.ts)

## Why am I doing these changes?
All text should be localizable, status effect message is important to play the game.

## What did change?
 - Change the code for localize
 - Added config and new locale files > status-effect.ts
 - Added localization key in each language folders.
 - Translated of them to Korean.

### Screenshots/Videos
![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/15914ef5-b789-4967-8319-5b3e90d3dc51)
English

![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/16e51655-aba4-4bb8-878f-60e9bdda50c7)
Korean


## How to test the changes?
 - Using test code : Run ```src/test/lokalisation/status-effect.test.ts```
 - Manually : modify overrides.ts to test status-effect using MOVESET, for example.
```typescript
export const WEATHER_OVERRIDE: WeatherType = WeatherType.SNOW; // To increase the probability of Freeze if need
export const STARTING_BIOME_OVERRIDE: Biome = Biome.ICE_CAVE; // To increase the probability of Freeze if need

export const MOVESET_OVERRIDE: Array<Moves> = [ Moves.POISON_GAS, Moves.TOXIC, Moves.NUZZLE, Moves.SPORE ];
// export const MOVESET_OVERRIDE: Array<Moves> = [ Moves.SIZZLY_SLIDE, Moves.TOXIC_SPIKES, Moves.POWDER_SNOW ];
```


## Checklist
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?