### PR TITLE
[Bug] Prevent attempting to use a move with no pp when pokemon is not on the field

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2582,7 +2582,7 @@ export class MovePhase extends BattlePhase {
       if (this.move.moveId && this.pokemon.summonData?.disabledMove === this.move.moveId) {
         this.scene.queueMessage(`${this.move.getName()} is disabled!`);
       }
-      if (!this.pokemon.isFainted() && this.move.ppUsed >= this.move.getMovePp()) { // if the move PP was reduced from Spite or otherwise, the move fails
+      if (this.pokemon.isActive(true) && this.move.ppUsed >= this.move.getMovePp()) { // if the move PP was reduced from Spite or otherwise, the move fails
         this.fail();
         this.showMoveText();
         this.showFailedText();

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2582,7 +2582,7 @@ export class MovePhase extends BattlePhase {
       if (this.move.moveId && this.pokemon.summonData?.disabledMove === this.move.moveId) {
         this.scene.queueMessage(`${this.move.getName()} is disabled!`);
       }
-      if (this.move.ppUsed >= this.move.getMovePp()) { // if the move PP was reduced from Spite or otherwise, the move fails
+      if (!this.pokemon.isFainted() && this.move.ppUsed >= this.move.getMovePp()) { // if the move PP was reduced from Spite or otherwise, the move fails
         this.fail();
         this.showMoveText();
         this.showFailedText();


### PR DESCRIPTION
## What are the changes?
- see title
- fixes bug introduced by https://github.com/pagefaultgames/pokerogue/pull/2244

## Why am I doing these changes?
- closes [discord bug report](https://discord.com/channels/1125469663833370665/1253222114874626139)

## What did change?
- added `!this.pokemon.isFainted()` check

### Screenshots/Videos
- no longer crashes when entering shop

https://github.com/pagefaultgames/pokerogue/assets/68144167/c644491b-12a3-4fef-8df6-a667a6417ec8




## How to test the changes?
- export [session data](https://discord.com/channels/1125469663833370665/1253222114874626139/1254052071032885259)
- to replicate the bug:
1. Switch to sableye
2. attempt to catch smeargle until success
3. bug occurs upon entering shop because its trying to use the move


## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?