### PR TITLE
[Localization] #1761 Korean trainer dialogue (olympia, grant, korrina, clemont)

### DIFF
--- a/src/locales/ko/dialogue.ts
+++ b/src/locales/ko/dialogue.ts
@@ -1924,13 +1924,13 @@ export const PGMdialogue: DialogueTranslationEntries = {
   },
   "olympia": {
     "encounter": {
-      1: "An ancient custom deciding one's destiny. The battle begins!"
+      1: "이 의식은 앞으로의 길을 정하는 것입니다. 포켓몬 승부를 시작해볼까요!"
     },
     "victory": {
-      1: "Create your own path. Let nothing get in your way. Your fate, your future."
+      1: "당신이라면 별이라도 움직여서 가야 할 길을 만들어 낼 것 같습니다."
     },
     "defeat": {
-      1: "Our path is clear now."
+      1: "우리의 길은 이제 분명해졌습니다."
     }
   },
   "volkner": {
@@ -2016,38 +2016,38 @@ export const PGMdialogue: DialogueTranslationEntries = {
   },
   "grant": {
     "encounter": {
-      1: `There is only one thing I wish for. 
-                    $That by surpassing one another, we find a way to even greater heights.`,
+      1: `제가 바라는 것은 단 하나뿐입니다. 
+                    $서로가 서로를 뛰어넘어, 더 높은 벽에 도달하는 것입니다.`,
     },
     "victory": {
-      1: "You are a wall that I am unable to surmount!"
+      1: "내 앞에 솟아 있는 높은 벽… 그건 바로 당신입니다."
     },
     "defeat": {
-      1: `Do not give up. 
-                    $That is all there really is to it. 
-                    $The most important lessons in life are simple.`,
+      1: `인생에서 중요한 교훈은 간단합니다.
+                    $포기하지 않는 것.
+                    $이것이 전부입니다.`,
     }
   },
   "korrina": {
     "encounter": {
-      1: "Time for Lady Korrina's big appearance!"
+      1: "코르니 납시오!"
     },
     "victory": {
-      1: "It's your very being that allows your Pokémon to evolve!"
+      1: "네 존재가 너의 포켓몬을 점점 진화시키고 있어!"
     },
     "defeat": {
-      1: "What an explosive battle!"
+      1: "정말 멋진 배틀이었어!"
     }
   },
   "clemont": {
     "encounter": {
-      1: "Oh! I'm glad that we got to meet!"
+      1: "아앗! 잘 부탁드립니다!"
     },
     "victory": {
-      1: "Your passion for battle inspires me!"
+      1: "당신들의 승부를 향한 마음에 자극을 받았습니다!"
     },
     "defeat": {
-      1: "Looks like my Trainer-Grow-Stronger Machine, Mach 2 is really working!"
+      1: "저의 슈퍼트레이닝 발명품이 효과가 있는 것 같군요!"
     }
   },
   "valerie": {


### PR DESCRIPTION
## What are the changes?
Translating locales\ko\dialogue.ts into Korean.
This PR is added korean dialogue for four gym leader in Kalos region (olympia, grant, korrina, clemont).

칼로스 지방 체육관 관장 olympia(고지카), grant(자크로), korrina(코르니), clemont(시트론) 대사를
한국어로 번역 및 로컬라이징 작업을 진행하였습니다.

@sodaMelon @Ohmry @returntoice now participating in https://github.com/pagefaultgames/pokerogue/issues/1761 translating project.

## Why am I doing these changes?
Few trainers's dialogue have been translated into Korean yet.

## What did change?
Translated dialogue of four gym leader in Kalos region (olympia, grant, korrina, clemont) to Korean.

칼로스 지방 체육관 관장 고지카, 자크로, 코르니, 시트론 대사 번역하였습니다..
포켓몬스터 XY 정발 번역을 최대한 참고했습니다만..
자료를 찾지 못할 경우 제가 번역했습니다..


- 고지카 승리대사의 경우 향전체육관에서 트레이너가 승리했을시 나오는 대사임을 영문 위키를 통해 확인하였습니다. 향전체육관 승리 대사 정발 번역을 참고하여 작성하였습니다. (느낌이 좀 많이 다르네요..)
- 자크로 승리대사 또한 정발 번역을 참고하였습니다. 문장부호가 좀 다르더군요.. 우선 정발번역을 따라갔습니다.
- 자크로 패배 대사의 경우 자연스럽다고 느껴지는 문장 순서로 배치 및 변경하였습니다.

### Screenshots/Videos

## How to test the changes?

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~