### PR TITLE
[Move] Implement Flower Shield

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -1258,7 +1258,7 @@ export class TerrainHighestStatBoostTag extends HighestStatBoostTag implements T
   }
 }
 
-export class HideSpriteTag extends BattlerTag {
+export class SemiInvulnerableTag extends BattlerTag {
   constructor(tagType: BattlerTagType, turnCount: integer, sourceMove: Moves) {
     super(tagType, BattlerTagLapseType.MOVE_EFFECT, turnCount, sourceMove);
   }
@@ -1604,7 +1604,7 @@ export function getBattlerTag(tagType: BattlerTagType, turnCount: integer, sourc
   case BattlerTagType.UNDERGROUND:
   case BattlerTagType.UNDERWATER:
   case BattlerTagType.HIDDEN:
-    return new HideSpriteTag(tagType, turnCount, sourceMove);
+    return new SemiInvulnerableTag(tagType, turnCount, sourceMove);
   case BattlerTagType.FIRE_BOOST:
     return new TypeBoostTag(tagType, sourceMove, Type.FIRE, 1.5, false);
   case BattlerTagType.CRIT_BOOST:

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -7238,7 +7238,7 @@ export function initMoves() {
       .attr(AddArenaTagAttr, ArenaTagType.CRAFTY_SHIELD, 1, true, true),
     new StatusMove(Moves.FLOWER_SHIELD, Type.FAIRY, -1, 10, -1, 0, 6)
       .target(MoveTarget.ALL)
-      .attr(StatChangeAttr, BattleStat.DEF, 1, false, (user, target, move) => target.getTypes().includes(Type.GRASS) && !target.getTag(BattlerTagType.FLYING) && !target.getTag(BattlerTagType.UNDERGROUND)),
+      .attr(StatChangeAttr, BattleStat.DEF, 1, false, (user, target, move) => target.getTypes().includes(Type.GRASS) && !target.isInSemiVulnerableState()),
     new StatusMove(Moves.GRASSY_TERRAIN, Type.GRASS, -1, 10, -1, 0, 6)
       .attr(TerrainChangeAttr, TerrainType.GRASSY)
       .target(MoveTarget.BOTH_SIDES),

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1,7 +1,7 @@
 import { ChargeAnim, MoveChargeAnim, initMoveAnim, loadMoveAnimAssets } from "./battle-anims";
 import { BattleEndPhase, MovePhase, NewBattlePhase, PartyStatusCurePhase, PokemonHealPhase, StatChangePhase, SwitchSummonPhase } from "../phases";
 import { BattleStat, getBattleStatName } from "./battle-stat";
-import { EncoreTag } from "./battler-tags";
+import { EncoreTag, HideSpriteTag as SemiInvulnerableTag } from "./battler-tags";
 import { getPokemonMessage, getPokemonNameWithAffix } from "../messages";
 import Pokemon, { AttackMoveResult, EnemyPokemon, HitResult, MoveResult, PlayerPokemon, PokemonMove, TurnMove } from "../field/pokemon";
 import { StatusEffect, getStatusEffectHealText, isNonVolatileStatusEffect, getNonVolatileStatusEffects} from "./status-effect";
@@ -7238,7 +7238,7 @@ export function initMoves() {
       .attr(AddArenaTagAttr, ArenaTagType.CRAFTY_SHIELD, 1, true, true),
     new StatusMove(Moves.FLOWER_SHIELD, Type.FAIRY, -1, 10, -1, 0, 6)
       .target(MoveTarget.ALL)
-      .attr(StatChangeAttr, BattleStat.DEF, 1, false, (user, target, move) => target.getTypes().includes(Type.GRASS) && !target.isInSemiVulnerableState()),
+      .attr(StatChangeAttr, BattleStat.DEF, 1, false, (user, target, move) => target.getTypes().includes(Type.GRASS) && !target.getTag(SemiInvulnerableTag)),
     new StatusMove(Moves.GRASSY_TERRAIN, Type.GRASS, -1, 10, -1, 0, 6)
       .attr(TerrainChangeAttr, TerrainType.GRASSY)
       .target(MoveTarget.BOTH_SIDES),

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -7238,7 +7238,7 @@ export function initMoves() {
       .attr(AddArenaTagAttr, ArenaTagType.CRAFTY_SHIELD, 1, true, true),
     new StatusMove(Moves.FLOWER_SHIELD, Type.FAIRY, -1, 10, -1, 0, 6)
       .target(MoveTarget.ALL)
-      .unimplemented(),
+      .attr(StatChangeAttr, BattleStat.DEF, 1, false, (user, target, move) => target.getTypes().includes(Type.GRASS) && !target.getTag(BattlerTagType.FLYING) && !target.getTag(BattlerTagType.UNDERGROUND)),
     new StatusMove(Moves.GRASSY_TERRAIN, Type.GRASS, -1, 10, -1, 0, 6)
       .attr(TerrainChangeAttr, TerrainType.GRASSY)
       .target(MoveTarget.BOTH_SIDES),

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1,7 +1,7 @@
 import { ChargeAnim, MoveChargeAnim, initMoveAnim, loadMoveAnimAssets } from "./battle-anims";
 import { BattleEndPhase, MovePhase, NewBattlePhase, PartyStatusCurePhase, PokemonHealPhase, StatChangePhase, SwitchSummonPhase } from "../phases";
 import { BattleStat, getBattleStatName } from "./battle-stat";
-import { EncoreTag, HideSpriteTag as SemiInvulnerableTag } from "./battler-tags";
+import { EncoreTag, SemiInvulnerableTag } from "./battler-tags";
 import { getPokemonMessage, getPokemonNameWithAffix } from "../messages";
 import Pokemon, { AttackMoveResult, EnemyPokemon, HitResult, MoveResult, PlayerPokemon, PokemonMove, TurnMove } from "../field/pokemon";
 import { StatusEffect, getStatusEffectHealText, isNonVolatileStatusEffect, getNonVolatileStatusEffects} from "./status-effect";

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -286,26 +286,6 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     return this.isAllowedInBattle() && !!this.scene && (!onField || this.isOnField());
   }
 
-  /**
-   * Checks if the Pokémon is in a semi-invulnerable state due to certain tags.
-   *
-   * @returns `true` if the Pokémon is in a semi-invulnerable state, otherwise `false`.
-   */
-  isInSemiVulnerableState(): boolean {
-    if (!this.scene) {
-      return false;
-    }
-
-    const semiInvulnerableTags = [
-      BattlerTagType.UNDERGROUND,
-      BattlerTagType.UNDERWATER,
-      BattlerTagType.HIDDEN,
-      BattlerTagType.FLYING
-    ];
-
-    return semiInvulnerableTags.some(tag => !!this.getTag(tag));
-  }
-
   getDexAttr(): bigint {
     let ret = 0n;
     ret |= this.gender !== Gender.FEMALE ? DexAttr.MALE : DexAttr.FEMALE;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -286,6 +286,26 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     return this.isAllowedInBattle() && !!this.scene && (!onField || this.isOnField());
   }
 
+  /**
+   * Checks if the Pokémon is in a semi-invulnerable state due to certain tags.
+   *
+   * @returns `true` if the Pokémon is in a semi-invulnerable state, otherwise `false`.
+   */
+  isInSemiVulnerableState(): boolean {
+    if (!this.scene) {
+      return false;
+    }
+
+    const semiInvulnerableTags = [
+      BattlerTagType.UNDERGROUND,
+      BattlerTagType.UNDERWATER,
+      BattlerTagType.HIDDEN,
+      BattlerTagType.FLYING
+    ];
+
+    return semiInvulnerableTags.some(tag => !!this.getTag(tag));
+  }
+
   getDexAttr(): bigint {
     let ret = 0n;
     ret |= this.gender !== Gender.FEMALE ? DexAttr.MALE : DexAttr.FEMALE;

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -19,7 +19,7 @@ import { biomeLinks, getBiomeName } from "./data/biomes";
 import { ModifierTier } from "./modifier/modifier-tier";
 import { FusePokemonModifierType, ModifierPoolType, ModifierType, ModifierTypeFunc, ModifierTypeOption, PokemonModifierType, PokemonMoveModifierType, PokemonPpRestoreModifierType, PokemonPpUpModifierType, RememberMoveModifierType, TmModifierType, getDailyRunStarterModifiers, getEnemyBuffModifierForWave, getModifierType, getPlayerModifierTypeOptions, getPlayerShopModifierTypeOptionsForWave, modifierTypes, regenerateModifierPoolThresholds } from "./modifier/modifier-type";
 import SoundFade from "phaser3-rex-plugins/plugins/soundfade";
-import { BattlerTagLapseType, CenterOfAttentionTag, EncoreTag, HideSpriteTag as HiddenTag, ProtectedTag, TrappedTag } from "./data/battler-tags";
+import { BattlerTagLapseType, CenterOfAttentionTag, EncoreTag, ProtectedTag, SemiInvulnerableTag, TrappedTag } from "./data/battler-tags";
 import { getPokemonMessage, getPokemonNameWithAffix } from "./messages";
 import { Starter } from "./ui/starter-select-ui-handler";
 import { Gender } from "./data/gender";
@@ -3033,7 +3033,7 @@ export class MoveEffectPhase extends PokemonPhase {
       return true;
     }
 
-    const hiddenTag = target.getTag(HiddenTag);
+    const hiddenTag = target.getTag(SemiInvulnerableTag);
     if (hiddenTag && !this.move.getMove().getAttrs(HitsTagAttr).some(hta => hta.tagType === hiddenTag.tagType)) {
       return false;
     }

--- a/src/test/moves/flower_shield.test.ts
+++ b/src/test/moves/flower_shield.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import Phaser from "phaser";
+import GameManager from "#app/test/utils/gameManager";
+import * as overrides from "#app/overrides";
+import { Species } from "#enums/species";
+import {
+  TurnEndPhase,
+} from "#app/phases";
+import { Moves } from "#enums/moves";
+import { getMovePosition } from "#app/test/utils/gameManagerUtils";
+import { Abilities } from "#enums/abilities";
+import { BattleStat } from "#app/data/battle-stat.js";
+import { Biome } from "#app/enums/biome.js";
+import { Type } from "#app/data/type.js";
+
+describe("Moves - Flower Shield", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.NONE);
+    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.NONE);
+    vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.FLOWER_SHIELD, Moves.SPLASH]);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.SPLASH, Moves.SPLASH, Moves.SPLASH]);
+  });
+
+  it("increases defense of all Grass-type Pokemon on the field by one stage - single battle", async () => {
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.CHERRIM);
+
+    await game.startBattle([Species.MAGIKARP]);
+    const cherrim = game.scene.getEnemyPokemon();
+    const magikarp = game.scene.getPlayerPokemon();
+
+    expect(magikarp.summonData.battleStats[BattleStat.DEF]).toBe(0);
+    expect(cherrim.summonData.battleStats[BattleStat.DEF]).toBe(0);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.FLOWER_SHIELD));
+    await game.phaseInterceptor.to(TurnEndPhase);
+
+    expect(magikarp.summonData.battleStats[BattleStat.DEF]).toBe(0);
+    expect(cherrim.summonData.battleStats[BattleStat.DEF]).toBe(1);
+  });
+
+  it("increases defense of all Grass-type Pokemon on the field by one stage - double battle", async () => {
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.MAGIKARP);
+    vi.spyOn(overrides, "STARTING_BIOME_OVERRIDE", "get").mockReturnValue(Biome.GRASS);
+    vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(false);
+    vi.spyOn(overrides, "DOUBLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+
+    await game.startBattle([Species.CHERRIM, Species.MAGIKARP]);
+    const field = game.scene.getField(true);
+
+    const grassPokemons = field.filter(p => p.getTypes().includes(Type.GRASS));
+    const nonGrassPokemons = field.filter(pokemon => !grassPokemons.includes(pokemon));
+
+    grassPokemons.forEach(p => expect(p.summonData.battleStats[BattleStat.DEF]).toBe(0));
+    nonGrassPokemons.forEach(p => expect(p.summonData.battleStats[BattleStat.DEF]).toBe(0));
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.FLOWER_SHIELD));
+    game.doAttack(getMovePosition(game.scene, 1, Moves.SPLASH));
+    await game.phaseInterceptor.to(TurnEndPhase);
+
+    grassPokemons.forEach(p => expect(p.summonData.battleStats[BattleStat.DEF]).toBe(1));
+    nonGrassPokemons.forEach(p => expect(p.summonData.battleStats[BattleStat.DEF]).toBe(0));
+  });
+
+  it("does not increase defense of a pokemon in semi-vulnerable state - BattlerTagType.FLYING", async () => {
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.TROPIUS);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.FLY, Moves.FLY, Moves.FLY, Moves.FLY]);
+    vi.spyOn(overrides, "OPP_LEVEL_OVERRIDE", "get").mockReturnValue(50);
+
+    await game.startBattle([Species.CHERRIM]);
+    const tropius = game.scene.getEnemyPokemon();
+    const cherrim = game.scene.getPlayerPokemon();
+
+    expect(tropius.summonData.battleStats[BattleStat.DEF]).toBe(0);
+    expect(cherrim.summonData.battleStats[BattleStat.DEF]).toBe(0);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.FLOWER_SHIELD));
+    await game.phaseInterceptor.to(TurnEndPhase);
+
+    expect(tropius.summonData.battleStats[BattleStat.DEF]).toBe(0);
+    expect(cherrim.summonData.battleStats[BattleStat.DEF]).toBe(1);
+  });
+
+  it("does not increase defense of a pokemon in semi-vulnerable state - BattlerTagType.UNDERGROUND", async () => {
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.PARAS);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.DIG, Moves.DIG, Moves.DIG, Moves.DIG]);
+    vi.spyOn(overrides, "OPP_LEVEL_OVERRIDE", "get").mockReturnValue(50);
+
+    await game.startBattle([Species.CHERRIM]);
+    const paras = game.scene.getEnemyPokemon();
+    const cherrim = game.scene.getPlayerPokemon();
+
+    expect(paras.summonData.battleStats[BattleStat.DEF]).toBe(0);
+    expect(cherrim.summonData.battleStats[BattleStat.DEF]).toBe(0);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.FLOWER_SHIELD));
+    await game.phaseInterceptor.to(TurnEndPhase);
+
+    expect(paras.summonData.battleStats[BattleStat.DEF]).toBe(0);
+    expect(cherrim.summonData.battleStats[BattleStat.DEF]).toBe(1);
+  });
+});

--- a/src/test/moves/flower_shield.test.ts
+++ b/src/test/moves/flower_shield.test.ts
@@ -12,6 +12,7 @@ import { Abilities } from "#enums/abilities";
 import { BattleStat } from "#app/data/battle-stat.js";
 import { Biome } from "#app/enums/biome.js";
 import { Type } from "#app/data/type.js";
+import { HideSpriteTag as SemiInvulnerableTag } from "#app/data/battler-tags.js";
 
 describe("Moves - Flower Shield", () => {
   let phaserGame: Phaser.Game;
@@ -90,12 +91,12 @@ describe("Moves - Flower Shield", () => {
 
     expect(paras.summonData.battleStats[BattleStat.DEF]).toBe(0);
     expect(cherrim.summonData.battleStats[BattleStat.DEF]).toBe(0);
-    expect(paras.isInSemiVulnerableState()).toBe(false);
+    expect(paras.getTag(SemiInvulnerableTag)).toBeUndefined;
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.FLOWER_SHIELD));
     await game.phaseInterceptor.to(TurnEndPhase);
 
-    expect(paras.isInSemiVulnerableState()).toBe(true);
+    expect(paras.getTag(SemiInvulnerableTag)).toBeDefined();
     expect(paras.summonData.battleStats[BattleStat.DEF]).toBe(0);
     expect(cherrim.summonData.battleStats[BattleStat.DEF]).toBe(1);
   });

--- a/src/test/moves/flower_shield.test.ts
+++ b/src/test/moves/flower_shield.test.ts
@@ -78,7 +78,7 @@ describe("Moves - Flower Shield", () => {
   });
 
   /**
-   * See semi-vulnerable state tags. {@see Pokemon.isInSemiVulnerableState }
+   * See semi-vulnerable state tags. {@linkcode HideSpriteTag}
   */
   it("does not increase defense of a pokemon in semi-vulnerable state", async () => {
     vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.PARAS);

--- a/src/test/moves/flower_shield.test.ts
+++ b/src/test/moves/flower_shield.test.ts
@@ -12,7 +12,7 @@ import { Abilities } from "#enums/abilities";
 import { BattleStat } from "#app/data/battle-stat.js";
 import { Biome } from "#app/enums/biome.js";
 import { Type } from "#app/data/type.js";
-import { HideSpriteTag as SemiInvulnerableTag } from "#app/data/battler-tags.js";
+import { SemiInvulnerableTag } from "#app/data/battler-tags.js";
 
 describe("Moves - Flower Shield", () => {
   let phaserGame: Phaser.Game;
@@ -78,7 +78,7 @@ describe("Moves - Flower Shield", () => {
   });
 
   /**
-   * See semi-vulnerable state tags. {@linkcode HideSpriteTag}
+   * See semi-vulnerable state tags. {@linkcode SemiInvulnerableTag}
   */
   it("does not increase defense of a pokemon in semi-vulnerable state", async () => {
     vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.PARAS);

--- a/src/test/moves/flower_shield.test.ts
+++ b/src/test/moves/flower_shield.test.ts
@@ -76,26 +76,10 @@ describe("Moves - Flower Shield", () => {
     nonGrassPokemons.forEach(p => expect(p.summonData.battleStats[BattleStat.DEF]).toBe(0));
   });
 
-  it("does not increase defense of a pokemon in semi-vulnerable state - BattlerTagType.FLYING", async () => {
-    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.TROPIUS);
-    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.FLY, Moves.FLY, Moves.FLY, Moves.FLY]);
-    vi.spyOn(overrides, "OPP_LEVEL_OVERRIDE", "get").mockReturnValue(50);
-
-    await game.startBattle([Species.CHERRIM]);
-    const tropius = game.scene.getEnemyPokemon();
-    const cherrim = game.scene.getPlayerPokemon();
-
-    expect(tropius.summonData.battleStats[BattleStat.DEF]).toBe(0);
-    expect(cherrim.summonData.battleStats[BattleStat.DEF]).toBe(0);
-
-    game.doAttack(getMovePosition(game.scene, 0, Moves.FLOWER_SHIELD));
-    await game.phaseInterceptor.to(TurnEndPhase);
-
-    expect(tropius.summonData.battleStats[BattleStat.DEF]).toBe(0);
-    expect(cherrim.summonData.battleStats[BattleStat.DEF]).toBe(1);
-  });
-
-  it("does not increase defense of a pokemon in semi-vulnerable state - BattlerTagType.UNDERGROUND", async () => {
+  /**
+   * See semi-vulnerable state tags. {@see Pokemon.isInSemiVulnerableState }
+  */
+  it("does not increase defense of a pokemon in semi-vulnerable state", async () => {
     vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.PARAS);
     vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.DIG, Moves.DIG, Moves.DIG, Moves.DIG]);
     vi.spyOn(overrides, "OPP_LEVEL_OVERRIDE", "get").mockReturnValue(50);
@@ -106,11 +90,30 @@ describe("Moves - Flower Shield", () => {
 
     expect(paras.summonData.battleStats[BattleStat.DEF]).toBe(0);
     expect(cherrim.summonData.battleStats[BattleStat.DEF]).toBe(0);
+    expect(paras.isInSemiVulnerableState()).toBe(false);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.FLOWER_SHIELD));
     await game.phaseInterceptor.to(TurnEndPhase);
 
+    expect(paras.isInSemiVulnerableState()).toBe(true);
     expect(paras.summonData.battleStats[BattleStat.DEF]).toBe(0);
     expect(cherrim.summonData.battleStats[BattleStat.DEF]).toBe(1);
+  });
+
+  it("does nothing if there are no Grass-type pokemon on the field", async () => {
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.MAGIKARP);
+
+    await game.startBattle([Species.MAGIKARP]);
+    const enemy = game.scene.getEnemyPokemon();
+    const ally = game.scene.getPlayerPokemon();
+
+    expect(enemy.summonData.battleStats[BattleStat.DEF]).toBe(0);
+    expect(ally.summonData.battleStats[BattleStat.DEF]).toBe(0);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.FLOWER_SHIELD));
+    await game.phaseInterceptor.to(TurnEndPhase);
+
+    expect(enemy.summonData.battleStats[BattleStat.DEF]).toBe(0);
+    expect(ally.summonData.battleStats[BattleStat.DEF]).toBe(0);
   });
 });


### PR DESCRIPTION
## What are the changes?
- implemented [flower shield](https://bulbapedia.bulbagarden.net/wiki/Flower_Shield_(move))

## Why am I doing these changes?
- unimplemented move

## What did change?
- implemented flower shield

### Screenshots/Videos


https://github.com/pagefaultgames/pokerogue/assets/68144167/7de33be2-509b-4bcc-a005-78c2e00be661




<img width="757" alt="Screenshot 2024-06-23 at 11 46 16 PM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/d1334d8d-24de-492c-80ac-53910b30c280">


### How to test the changes?
- give your mon Flower Shield
- have a grass type mon in field
- `$ npm run test flower_shield`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?