### PR TITLE
[Localization] Fixed missing punctuation when being freed from trapping moves

### DIFF
--- a/src/locales/en/battle.ts
+++ b/src/locales/en/battle.ts
@@ -75,7 +75,7 @@ export const battle: SimpleTranslationEntries = {
   "ppReduced": "It reduced the PP of {{targetName}}'s\n{{moveName}} by {{reduction}}!",
   "battlerTagsRechargingLapse": "{{pokemonNameWithAffix}} must\nrecharge!",
   "battlerTagsTrappedOnAdd": "{{pokemonNameWithAffix}} can no\nlonger escape!",
-  "battlerTagsTrappedOnRemove": "{{pokemonNameWithAffix}} was freed\nfrom {{moveName}}",
+  "battlerTagsTrappedOnRemove": "{{pokemonNameWithAffix}} was freed\nfrom {{moveName}}!",
   "battlerTagsFlinchedLapse": "{{pokemonNameWithAffix}} flinched!",
   "battlerTagsConfusedOnAdd": "{{pokemonNameWithAffix}} became\nconfused!",
   "battlerTagsConfusedOnRemove": "{{pokemonNameWithAffix}} snapped\nout of confusion!",

--- a/src/locales/es/battle.ts
+++ b/src/locales/es/battle.ts
@@ -75,7 +75,7 @@ export const battle: SimpleTranslationEntries = {
   "ppReduced": "It reduced the PP of {{targetName}}'s\n{{moveName}} by {{reduction}}!",
   "battlerTagsRechargingLapse": "{{pokemonNameWithAffix}} must\nrecharge!",
   "battlerTagsTrappedOnAdd": "{{pokemonNameWithAffix}} can no\nlonger escape!",
-  "battlerTagsTrappedOnRemove": "{{pokemonNameWithAffix}} was freed\nfrom {{moveName}}",
+  "battlerTagsTrappedOnRemove": "{{pokemonNameWithAffix}} was freed\nfrom {{moveName}}!",
   "battlerTagsFlinchedLapse": "{{pokemonNameWithAffix}} flinched!",
   "battlerTagsConfusedOnAdd": "{{pokemonNameWithAffix}} became\nconfused!",
   "battlerTagsConfusedOnRemove": "{{pokemonNameWithAffix}} snapped\nout of confusion!",

--- a/src/locales/pt_BR/battle.ts
+++ b/src/locales/pt_BR/battle.ts
@@ -75,7 +75,7 @@ export const battle: SimpleTranslationEntries = {
   "ppReduced": "O PP do movimento {{moveName}} de\n{{targetName}} foi reduzido em {{reduction}}!",
   "battlerTagsRechargingLapse": "{{pokemonNameWithAffix}} precisa\nrecarregar!",
   "battlerTagsTrappedOnAdd": "{{pokemonNameWithAffix}} não pode\nmais escapar!",
-  "battlerTagsTrappedOnRemove": "{{pokemonNameWithAffix}} foi liberto\nde {{moveName}}",
+  "battlerTagsTrappedOnRemove": "{{pokemonNameWithAffix}} foi liberto\nde {{moveName}}!",
   "battlerTagsFlinchedLapse": "{{pokemonNameWithAffix}} hesitou!",
   "battlerTagsConfusedOnAdd": "{{pokemonNameWithAffix}} ficou\nconfuso!",
   "battlerTagsConfusedOnRemove": "{{pokemonNameWithAffix}} saiu\nde sua confusão!",

--- a/src/locales/zh_CN/battle.ts
+++ b/src/locales/zh_CN/battle.ts
@@ -75,7 +75,7 @@ export const battle: SimpleTranslationEntries = {
   "ppReduced": "降低了 {{targetName}} 的\n{{moveName}} 的PP{{reduction}}点！",
   "battlerTagsRechargingLapse": "{{pokemonNameWithAffix}}因攻击的反作用力而无法动弹！",
   "battlerTagsTrappedOnAdd": "{{pokemonNameWithAffix}}不能逃跑！",
-  "battlerTagsTrappedOnRemove": "{{pokemonNameWithAffix}}摆脱了{{moveName}}",
+  "battlerTagsTrappedOnRemove": "{{pokemonNameWithAffix}}摆脱了{{moveName}}！",
   "battlerTagsFlinchedLapse": "{{pokemonNameWithAffix}}畏缩了！",
   "battlerTagsConfusedOnAdd": "{{pokemonNameWithAffix}}混乱了！",
   "battlerTagsConfusedOnRemove": "{{pokemonNameWithAffix}}的混乱解除了！",

--- a/src/locales/zh_TW/battle.ts
+++ b/src/locales/zh_TW/battle.ts
@@ -72,7 +72,7 @@ export const battle: SimpleTranslationEntries = {
   "ppReduced": "It reduced the PP of {{targetName}}'s\n{{moveName}} by {{reduction}}!",
   "battlerTagsRechargingLapse": "{{pokemonNameWithAffix}} must\nrecharge!",
   "battlerTagsTrappedOnAdd": "{{pokemonNameWithAffix}} can no\nlonger escape!",
-  "battlerTagsTrappedOnRemove": "{{pokemonNameWithAffix}} was freed\nfrom {{moveName}}",
+  "battlerTagsTrappedOnRemove": "{{pokemonNameWithAffix}} was freed\nfrom {{moveName}}!",
   "battlerTagsFlinchedLapse": "{{pokemonNameWithAffix}} flinched!",
   "battlerTagsConfusedOnAdd": "{{pokemonNameWithAffix}} became\nconfused!",
   "battlerTagsConfusedOnRemove": "{{pokemonNameWithAffix}} snapped\nout of confusion!",


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
- Adds punctuation to the message that shows after being freed from wrap

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
- It was missing punctuation and that looked weird

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- Added an exclamation point to the end of battlerTagsTrappedOnRemove where it was missing

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
![image](https://github.com/pagefaultgames/pokerogue/assets/36677462/c306d3f0-ba45-4b0d-b895-0102c60f9023)

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
- Use a trapping move like Wrap or Whirlpool
- Wait for the opponent to be freed

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?