### PR TITLE
[Localization] "Choose a Pokémon." French & Korean translation

### DIFF
--- a/src/locales/fr/menu.ts
+++ b/src/locales/fr/menu.ts
@@ -48,5 +48,5 @@ export const menu: SimpleTranslationEntries = {
   "no":"Non",
   "disclaimer": "AVERTISSEMENT",
   "disclaimerDescription": "Ce jeu n’est pas un produit fini et peut contenir des problèmes de jouabilité, dont de possibles pertes de sauvegardes,\ndes modifications sans avertissement et pourrait ou non encore être mis à jour ou terminé.",
-  "choosePokemon": "Choose a Pokémon.",
+  "choosePokemon": "Sélectionnez un Pokémon.",
 } as const;

--- a/src/locales/ko/menu.ts
+++ b/src/locales/ko/menu.ts
@@ -53,5 +53,5 @@ export const menu: SimpleTranslationEntries = {
   "no":"아니오",
   "disclaimer": "면책 조항",
   "disclaimerDescription": "이 게임은 완전히 개발되지 않았습니다- (세이브 데이터 소실을 포함) 플레이에 지장을 주는 문제가 생길 수 있으며,\n공지 없이 업데이트가 진행 혹은 중지될 수 있습니다.",
-  "choosePokemon": "Choose a Pokémon.",
+  "choosePokemon": "포켓몬을 선택하세요.",
 } as const;


### PR DESCRIPTION
EDIT : Also added Korean on behalf of [returntoice](https://github.com/returntoice)

## What are the changes?
Transaltion of "Choose a Pokémon." entry in French

## Why am I doing these changes?
To have it in French

## What did change?
"Choose a Pokémon." entry in translated in French locale menu.ts

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?