### PR TITLE
[Bug] Prevent lures from stacking different tiers

### DIFF
--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -328,7 +328,8 @@ export class DoubleBattleChanceBoosterModifier extends LapsingPersistentModifier
 
   match(modifier: Modifier): boolean {
     if (modifier instanceof DoubleBattleChanceBoosterModifier) {
-      return (modifier as DoubleBattleChanceBoosterModifier).battlesLeft === this.battlesLeft;
+      // Check type id to not match different tiers of lures
+      return modifier.type.id === this.type.id && modifier.battlesLeft === this.battlesLeft;
     }
     return false;
   }

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -341,9 +341,15 @@ export class DoubleBattleChanceBoosterModifier extends LapsingPersistentModifier
   getArgs(): any[] {
     return [ this.battlesLeft ];
   }
-
+  /**
+   * Modifies the chance of a double battle occurring
+   * @param args A single element array containing the double battle chance as a NumberHolder
+   * @returns {boolean} Returns true if the modifier was applied
+   */
   apply(args: any[]): boolean {
     const doubleBattleChance = args[0] as Utils.NumberHolder;
+    // This is divided because the chance is generated as a number from 0 to doubleBattleChance.value using Utils.randSeedInt
+    // A double battle will initiate if the generated number is 0
     doubleBattleChance.value = Math.ceil(doubleBattleChance.value / 2);
 
     return true;

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -342,19 +342,9 @@ export class DoubleBattleChanceBoosterModifier extends LapsingPersistentModifier
     return [ this.battlesLeft ];
   }
 
-  /**
-   * Modifies the chance of a double battle occurring
-   * @param args A single element array containing the double battle chance as a NumberHolder
-   * @returns {boolean} Returns true if the modifier was applied
-   */
   apply(args: any[]): boolean {
-    // Use Math.max to ensure no dividing by 0
-    const chanceMultiplier = 2 * Math.max(1, this.getStackCount());
-
     const doubleBattleChance = args[0] as Utils.NumberHolder;
-    // This is divided because the chance is generated as a number from 0 to doubleBattleChance.value using Utils.randSeedInt
-    // A double battle will initiate if the generated number is 0
-    doubleBattleChance.value = Math.ceil(doubleBattleChance.value / chanceMultiplier);
+    doubleBattleChance.value = Math.ceil(doubleBattleChance.value / 2);
 
     return true;
   }

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -342,9 +342,19 @@ export class DoubleBattleChanceBoosterModifier extends LapsingPersistentModifier
     return [ this.battlesLeft ];
   }
 
+  /**
+   * Modifies the chance of a double battle occurring
+   * @param args A single element array containing the double battle chance as a NumberHolder
+   * @returns {boolean} Returns true if the modifier was applied
+   */
   apply(args: any[]): boolean {
+    // Use Math.max to ensure no dividing by 0
+    const chanceMultiplier = 2 * Math.max(1, this.getStackCount());
+
     const doubleBattleChance = args[0] as Utils.NumberHolder;
-    doubleBattleChance.value = Math.ceil(doubleBattleChance.value / 2);
+    // This is divided because the chance is generated as a number from 0 to doubleBattleChance.value using Utils.randSeedInt
+    // A double battle will initiate if the generated number is 0
+    doubleBattleChance.value = Math.ceil(doubleBattleChance.value / chanceMultiplier);
 
     return true;
   }


### PR DESCRIPTION
## What are the changes?
Checks the ModifierType#id when attempting to stack Lures

## Why am I doing these changes?
Fix multiple issues #1912 #2523

## What did change?
Added a check for ModifierType#id to the match(Modifier) method inside the DoubleBattleChanceBoosterModifier class

### Screenshots/Videos
Before vs After
![before](https://i.ember.zone/kT9QkclRz4u6MnY9.png)
![after](https://i.ember.zone/p0DzNsOPsuJNhKIf.png)

## How to test the changes?
```ts
export const ITEM_REWARD_OVERRIDE: Array<String> = ["LURE", "SUPER_LURE", "MAX_LURE"];
```

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?