### PR TITLE
[Bug] fix softlock/runtime error after roar in doubles

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1070,7 +1070,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * in effect, and both passive and non-passive. This is one of the two primary ways to check
    * whether a pokemon has a particular ability.
    * @param {AbAttr} attrType The ability attribute to check for
-   * @param {boolean} canApply If false, it doesn't check whether the abiltiy is currently active
+   * @param {boolean} canApply If false, it doesn't check whether the ability is currently active
    * @param {boolean} ignoreOverride If true, it ignores ability changing effects
    * @returns {boolean} Whether an ability with that attribute is present and active
    */
@@ -1097,13 +1097,15 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    */
   getTeraType(): Type {
     // this.scene can be undefined for a fainted mon in doubles
-    // use nullish coalescing to auto-set to false to avoid runtime errors
-    const teraModifier = false ?? this.scene.findModifier(m => m instanceof TerastallizeModifier
-      && m.pokemonId === this.id && !!m.getBattlesLeft(), this.isPlayer()) as TerastallizeModifier;
-    if (teraModifier) {
-      return teraModifier.teraType;
+    if (this.scene !== undefined) {
+      const teraModifier = false ?? this.scene.findModifier(m => m instanceof TerastallizeModifier
+        && m.pokemonId === this.id && !!m.getBattlesLeft(), this.isPlayer()) as TerastallizeModifier;
+      // return teraType
+      if (teraModifier) {
+        return teraModifier.teraType;
+      }
     }
-
+    // if scene is undefined, or if teraModifier is considered false, then return unknown type
     return Type.UNKNOWN;
   }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -851,6 +851,13 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     return this.getLevelMoves(1, true).map(lm => lm[1]).filter(lm => !this.moveset.filter(m => m.moveId === lm).length).filter((move: Moves, i: integer, array: Moves[]) => array.indexOf(move) === i);
   }
 
+  /**
+   * Gets the types of a pokemon
+   * @param includeTeraType boolean to include tera-formed type, default false
+   * @param forDefend boolean if the pokemon is defending from an attack
+   * @param ignoreOverride boolean if true, ignore ability changing effects
+   * @returns array of {@linkcode Type}
+   */
   getTypes(includeTeraType = false, forDefend: boolean = false, ignoreOverride?: boolean): Type[] {
     const types = [];
 
@@ -1084,8 +1091,11 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     return weight.value;
   }
 
+  /**
+   * Gets the tera-formed type of the pokemon, or UNKNOWN if not present
+   * @returns the {@linkcode Type}
+   */
   getTeraType(): Type {
-
     // this.scene can be undefined for a fainted mon in doubles
     // use nullish coalescing to auto-set to false to avoid runtime errors
     const teraModifier = false ?? this.scene.findModifier(m => m instanceof TerastallizeModifier

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1098,7 +1098,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   getTeraType(): Type {
     // this.scene can be undefined for a fainted mon in doubles
     if (this.scene !== undefined) {
-      const teraModifier = false ?? this.scene.findModifier(m => m instanceof TerastallizeModifier
+      const teraModifier = this.scene.findModifier(m => m instanceof TerastallizeModifier
         && m.pokemonId === this.id && !!m.getBattlesLeft(), this.isPlayer()) as TerastallizeModifier;
       // return teraType
       if (teraModifier) {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -884,7 +884,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       }
     }
 
-    if (forDefend && (this.getTag(GroundedTag) || this.scene.arena.getTag(ArenaTagType.GRAVITY))) {
+    // this.scene potentially can be undefined for a fainted pokemon in doubles
+    // use optional chaining to avoid runtime errors
+    if (forDefend && (this.getTag(GroundedTag) || this.scene?.arena.getTag(ArenaTagType.GRAVITY))) {
       const flyingIndex = types.indexOf(Type.FLYING);
       if (flyingIndex > -1) {
         types.splice(flyingIndex, 1);
@@ -1083,7 +1085,10 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   getTeraType(): Type {
-    const teraModifier = this.scene.findModifier(m => m instanceof TerastallizeModifier
+
+    // this.scene can be undefined for a fainted mon in doubles
+    // use nullish coalescing to auto-set to false to avoid runtime errors
+    const teraModifier = false ?? this.scene.findModifier(m => m instanceof TerastallizeModifier
       && m.pokemonId === this.id && !!m.getBattlesLeft(), this.isPlayer()) as TerastallizeModifier;
     if (teraModifier) {
       return teraModifier.teraType;


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->


## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Added undefined/null checks to 2 places where `this.scene` is traced back to from the error


## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Solves issue #2190 

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
The bug as discussed in issue #2190 is running away from a battle when one of the opponent pokemon's fainted. This bug doesn't happen anymore and transitions to the next battle.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->


https://github.com/pagefaultgames/pokerogue/assets/39450497/8b08c31b-a315-473f-9cc3-0009466932bb


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

Reproduce using roar on one pokemon, and trying to run the next turn.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?