### PR TITLE
Localization: Add "has been added as a starter!" localization

### DIFF
--- a/src/locales/de/battle.ts
+++ b/src/locales/de/battle.ts
@@ -15,6 +15,7 @@ export const battle: SimpleTranslationEntries = {
   "trainerDefeated": "{{trainerName}}\nwurde besiegt!",
   "moneyWon": "Du gewinnst\n{{moneyAmount}} ₽!",
   "pokemonCaught": "{{pokemonName}} wurde gefangen!",
+  "addedAsAStarter": "{{pokemonName}} has been\nadded as a starter!",
   "partyFull": "Dein Team ist voll.\nMöchtest du ein Pokémon durch {{pokemonName}} ersetzen?",
   "pokemon": "Pokémon",
   "sendOutPokemon": "Los, {{pokemonName}}!",

--- a/src/locales/de/battle.ts
+++ b/src/locales/de/battle.ts
@@ -15,7 +15,7 @@ export const battle: SimpleTranslationEntries = {
   "trainerDefeated": "{{trainerName}}\nwurde besiegt!",
   "moneyWon": "Du gewinnst\n{{moneyAmount}} ₽!",
   "pokemonCaught": "{{pokemonName}} wurde gefangen!",
-  "addedAsAStarter": "{{pokemonName}} has been\nadded as a starter!",
+  "addedAsAStarter": "{{pokemonName}} wurde als Starterpokémon hinzugefügt!",
   "partyFull": "Dein Team ist voll.\nMöchtest du ein Pokémon durch {{pokemonName}} ersetzen?",
   "pokemon": "Pokémon",
   "sendOutPokemon": "Los, {{pokemonName}}!",

--- a/src/locales/en/battle.ts
+++ b/src/locales/en/battle.ts
@@ -15,6 +15,7 @@ export const battle: SimpleTranslationEntries = {
   "trainerDefeated": "You defeated\n{{trainerName}}!",
   "moneyWon": "You got\n₽{{moneyAmount}} for winning!",
   "pokemonCaught": "{{pokemonName}} was caught!",
+  "addedAsAStarter": "{{pokemonName}} has been\nadded as a starter!",
   "partyFull": "Your party is full.\nRelease a Pokémon to make room for {{pokemonName}}?",
   "pokemon": "Pokémon",
   "sendOutPokemon": "Go! {{pokemonName}}!",

--- a/src/locales/es/battle.ts
+++ b/src/locales/es/battle.ts
@@ -15,7 +15,7 @@ export const battle: SimpleTranslationEntries = {
   "trainerDefeated": "¡Has derrotado a\n{{trainerName}}!",
   "moneyWon": "¡Has ganado\n₽{{moneyAmount}} por vencer!",
   "pokemonCaught": "¡{{pokemonName}} atrapado!",
-  "addedAsAStarter": "{{pokemonName}} has been\nadded as a starter!",
+  "addedAsAStarter": "{{pokemonName}} ha sido añadido\ncomo un inicial!",
   "partyFull": "Tu equipo esta completo.\n¿Quieres liberar un Pokémon para meter a {{pokemonName}}?",
   "pokemon": "Pokémon",
   "sendOutPokemon": "¡Adelante, {{pokemonName}}!",

--- a/src/locales/es/battle.ts
+++ b/src/locales/es/battle.ts
@@ -15,6 +15,7 @@ export const battle: SimpleTranslationEntries = {
   "trainerDefeated": "¡Has derrotado a\n{{trainerName}}!",
   "moneyWon": "¡Has ganado\n₽{{moneyAmount}} por vencer!",
   "pokemonCaught": "¡{{pokemonName}} atrapado!",
+  "addedAsAStarter": "{{pokemonName}} has been\nadded as a starter!",
   "partyFull": "Tu equipo esta completo.\n¿Quieres liberar un Pokémon para meter a {{pokemonName}}?",
   "pokemon": "Pokémon",
   "sendOutPokemon": "¡Adelante, {{pokemonName}}!",

--- a/src/locales/es/battle.ts
+++ b/src/locales/es/battle.ts
@@ -15,7 +15,7 @@ export const battle: SimpleTranslationEntries = {
   "trainerDefeated": "¡Has derrotado a\n{{trainerName}}!",
   "moneyWon": "¡Has ganado\n₽{{moneyAmount}} por vencer!",
   "pokemonCaught": "¡{{pokemonName}} atrapado!",
-  "addedAsAStarter": "{{pokemonName}} ha sido añadido\ncomo un inicial!",
+  "addedAsAStarter": "{{pokemonName}} ha sido añadido\na tus iniciales!",
   "partyFull": "Tu equipo esta completo.\n¿Quieres liberar un Pokémon para meter a {{pokemonName}}?",
   "pokemon": "Pokémon",
   "sendOutPokemon": "¡Adelante, {{pokemonName}}!",

--- a/src/locales/fr/battle.ts
+++ b/src/locales/fr/battle.ts
@@ -15,6 +15,7 @@ export const battle: SimpleTranslationEntries = {
   "trainerDefeated": "Vous avez battu\n{{trainerName}} !",
   "moneyWon": "Vous remportez\n{{moneyAmount}} ₽ !",
   "pokemonCaught": "Vous avez attrapé {{pokemonName}} !",
+  "addedAsAStarter": "{{pokemonName}} has been\nadded as a starter!",
   "partyFull": "Votre équipe est pleine.\nRelâcher un Pokémon pour {{pokemonName}} ?",
   "pokemon": "Pokémon",
   "sendOutPokemon": "{{pokemonName}} ! Go !",

--- a/src/locales/fr/battle.ts
+++ b/src/locales/fr/battle.ts
@@ -15,7 +15,7 @@ export const battle: SimpleTranslationEntries = {
   "trainerDefeated": "Vous avez battu\n{{trainerName}} !",
   "moneyWon": "Vous remportez\n{{moneyAmount}} ₽ !",
   "pokemonCaught": "Vous avez attrapé {{pokemonName}} !",
-  "addedAsAStarter": "{{pokemonName}} has been\nadded as a starter!",
+  "addedAsAStarter": "{{pokemonName}} est ajouté\ncomme starter !",
   "partyFull": "Votre équipe est pleine.\nRelâcher un Pokémon pour {{pokemonName}} ?",
   "pokemon": "Pokémon",
   "sendOutPokemon": "{{pokemonName}} ! Go !",

--- a/src/locales/it/battle.ts
+++ b/src/locales/it/battle.ts
@@ -15,6 +15,7 @@ export const battle: SimpleTranslationEntries = {
   "trainerDefeated": "Hai sconfitto\n{{trainerName}}!",
   "moneyWon": "Hai vinto {{moneyAmount}}₽",
   "pokemonCaught": "Preso! {{pokemonName}} è stato catturato!",
+  "addedAsAStarter": "{{pokemonName}} has been\nadded as a starter!",
   "partyFull": "La tua squadra è al completo.\nVuoi liberare un Pokémon per far spazio a {{pokemonName}}?",
   "pokemon": "Pokémon",
   "sendOutPokemon": "Vai! {{pokemonName}}!",

--- a/src/locales/ko/battle.ts
+++ b/src/locales/ko/battle.ts
@@ -15,7 +15,7 @@ export const battle: SimpleTranslationEntries = {
   "trainerDefeated": "{{trainerName}}[[와]]의\n승부에서 이겼다!",
   "moneyWon": "상금으로\n₽{{moneyAmount}}을 손에 넣었다!",
   "pokemonCaught": "신난다-!\n{{pokemonName}}[[를]] 잡았다!",
-  "addedAsAStarter": "{{pokemonName}} has been\nadded as a starter!",
+  "addedAsAStarter": "{{pokemonName}}[[가]]\n스타팅 포켓몬에 추가되었다!",
   "partyFull": "지닌 포켓몬이 가득 찼습니다. {{pokemonName}}[[를]]\n대신해 포켓몬을 놓아주시겠습니까?",
   "pokemon": "포켓몬",
   "sendOutPokemon": "가랏! {{pokemonName}}!",

--- a/src/locales/ko/battle.ts
+++ b/src/locales/ko/battle.ts
@@ -15,6 +15,7 @@ export const battle: SimpleTranslationEntries = {
   "trainerDefeated": "{{trainerName}}[[와]]의\n승부에서 이겼다!",
   "moneyWon": "상금으로\n₽{{moneyAmount}}을 손에 넣었다!",
   "pokemonCaught": "신난다-!\n{{pokemonName}}[[를]] 잡았다!",
+  "addedAsAStarter": "{{pokemonName}} has been\nadded as a starter!",
   "partyFull": "지닌 포켓몬이 가득 찼습니다. {{pokemonName}}[[를]]\n대신해 포켓몬을 놓아주시겠습니까?",
   "pokemon": "포켓몬",
   "sendOutPokemon": "가랏! {{pokemonName}}!",

--- a/src/locales/pt_BR/battle.ts
+++ b/src/locales/pt_BR/battle.ts
@@ -15,6 +15,7 @@ export const battle: SimpleTranslationEntries = {
   "trainerDefeated": "Você derrotou\n{{trainerName}}!",
   "moneyWon": "Você ganhou\n₽{{moneyAmount}} por ganhar!",
   "pokemonCaught": "{{pokemonName}} foi capturado!",
+  "addedAsAStarter": "{{pokemonName}} foi adicionado\ncomo um inicial!",
   "partyFull": "Sua equipe está cheia.\nSolte um Pokémon para ter espaço para {{pokemonName}}?",
   "pokemon": "Pokémon",
   "sendOutPokemon": "{{pokemonName}}, eu escolho você!!",

--- a/src/locales/pt_BR/battle.ts
+++ b/src/locales/pt_BR/battle.ts
@@ -15,7 +15,7 @@ export const battle: SimpleTranslationEntries = {
   "trainerDefeated": "Você derrotou\n{{trainerName}}!",
   "moneyWon": "Você ganhou\n₽{{moneyAmount}} por ganhar!",
   "pokemonCaught": "{{pokemonName}} foi capturado!",
-  "addedAsAStarter": "{{pokemonName}} foi adicionado\ncomo um inicial!",
+  "addedAsAStarter": "{{pokemonName}} foi adicionado\naos seus inicias!",
   "partyFull": "Sua equipe está cheia.\nSolte um Pokémon para ter espaço para {{pokemonName}}?",
   "pokemon": "Pokémon",
   "sendOutPokemon": "{{pokemonName}}, eu escolho você!!",

--- a/src/locales/pt_BR/egg.ts
+++ b/src/locales/pt_BR/egg.ts
@@ -19,7 +19,7 @@ export const egg: SimpleTranslationEntries = {
   "pull": "Prêmio",
   "pulls": "Prêmios",
   "sameSpeciesEgg": "{{species}} vai rachar desse ovo!",
-  "hatchFromTheEgg": "{{pokemonName}} hatched from the egg!",
-  "eggMoveUnlock": "Egg Move unlocked: {{moveName}}",
-  "rareEggMoveUnlock": "Rare Egg Move unlocked: {{moveName}}",
+  "hatchFromTheEgg": "{{pokemonName}} nasceu do ovo!",
+  "eggMoveUnlock": "Movimento de Ovo desbloqueado: {{moveName}}",
+  "rareEggMoveUnlock": "Movimento Raro de Ovo desbloqueado: {{moveName}}",
 } as const;

--- a/src/locales/pt_BR/egg.ts
+++ b/src/locales/pt_BR/egg.ts
@@ -19,7 +19,7 @@ export const egg: SimpleTranslationEntries = {
   "pull": "Prêmio",
   "pulls": "Prêmios",
   "sameSpeciesEgg": "{{species}} vai rachar desse ovo!",
-  "hatchFromTheEgg": "{{pokemonName}} nasceu do ovo!",
-  "eggMoveUnlock": "Movimento de Ovo desbloqueado: {{moveName}}",
-  "rareEggMoveUnlock": "Movimento Raro de Ovo desbloqueado: {{moveName}}",
+  "hatchFromTheEgg": "{{pokemonName}} hatched from the egg!",
+  "eggMoveUnlock": "Egg Move unlocked: {{moveName}}",
+  "rareEggMoveUnlock": "Rare Egg Move unlocked: {{moveName}}",
 } as const;

--- a/src/locales/zh_CN/battle.ts
+++ b/src/locales/zh_CN/battle.ts
@@ -15,6 +15,7 @@ export const battle: SimpleTranslationEntries = {
   "trainerDefeated": "你击败了\n{{trainerName}}！",
   "moneyWon": "你赢得了\n₽{{moneyAmount}}！",
   "pokemonCaught": "{{pokemonName}} 被抓住了！",
+  "addedAsAStarter": "{{pokemonName}} has been\nadded as a starter!",
   "partyFull": "你的队伍已满员.是否放生其他宝可梦\n为 {{pokemonName}} 腾出空间?",
   "pokemon": "宝可梦",
   "sendOutPokemon": "上吧！\n{{pokemonName}}！",

--- a/src/locales/zh_TW/battle.ts
+++ b/src/locales/zh_TW/battle.ts
@@ -13,6 +13,7 @@ export const battle: SimpleTranslationEntries = {
   "switchQuestion": "要更換\n{{pokemonName}}嗎？",
   "trainerDefeated": "你擊敗了\n{{trainerName}}！",
   "pokemonCaught": "{{pokemonName}} 被抓住了！",
+  "addedAsAStarter": "{{pokemonName}} has been\nadded as a starter!",
   "pokemon": "寶可夢",
   "sendOutPokemon": "上吧！ {{pokemonName}}！",
   "hitResultCriticalHit": "擊中了要害！",

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1486,7 +1486,7 @@ export class GameData {
 
       if (newCatch && speciesStarters.hasOwnProperty(species.speciesId)) {
         this.scene.playSound("level_up_fanfare");
-        this.scene.ui.showText(`${species.name} has been\nadded as a starter!`, null, () => checkPrevolution(), null, true);
+        this.scene.ui.showText(i18next.t("battle:addedAsAStarter", { pokemonName: species.name }), null, () => checkPrevolution(), null, true);
       } else {
         checkPrevolution();
       }


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Localizing and translations

## Capturing (en)
![image](https://github.com/pagefaultgames/pokerogue/assets/79599290/334b0d23-3667-4a2a-add5-20e1e8018334)

## Egg Hatching Phase (en)
![image](https://github.com/pagefaultgames/pokerogue/assets/79599290/fc6df272-7c79-4e5a-a0bf-17e899ecaff6)


## Capturing (pt_BR)
![image](https://github.com/pagefaultgames/pokerogue/assets/79599290/d3ef6e6b-8ed5-4365-93c0-a2b6b94e6bcb)

## Egg Hatching Phase (pt_BR)
![image](https://github.com/pagefaultgames/pokerogue/assets/79599290/767e70c3-b63c-4640-8f1e-37078fa5e212)

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?