### PR TITLE
localize reward message (You received ~)

### DIFF
--- a/src/locales/de/battle.ts
+++ b/src/locales/de/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultOneHitKO": "Ein K.O.-Treffer!",
   "attackFailed": "Es ist fehlgeschlagen!",
   "attackHitsCount": "{{count}}-mal getroffen!",
-  "rewardGain": "You received\n{{modifierName}}!",
+  "rewardGain": "Du erhältst\n{{modifierName}}!",
   "expGain": "{{pokemonName}} erhält\n{{exp}} Erfahrungspunkte!",
   "levelUp": "{{pokemonName}} erreicht\nLv. {{level}}!",
   "learnMove": "{{pokemonName}} erlernt\n{{moveName}}!",

--- a/src/locales/de/battle.ts
+++ b/src/locales/de/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultOneHitKO": "Ein K.O.-Treffer!",
   "attackFailed": "Es ist fehlgeschlagen!",
   "attackHitsCount": "{{count}}-mal getroffen!",
+  "rewardGain": "You received\n{{modifierName}}!",
   "expGain": "{{pokemonName}} erhält\n{{exp}} Erfahrungspunkte!",
   "levelUp": "{{pokemonName}} erreicht\nLv. {{level}}!",
   "learnMove": "{{pokemonName}} erlernt\n{{moveName}}!",

--- a/src/locales/en/battle.ts
+++ b/src/locales/en/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultOneHitKO": "It's a one-hit KO!",
   "attackFailed": "But it failed!",
   "attackHitsCount": "Hit {{count}} time(s)!",
+  "rewardGain": "You received\n{{modifierName}}!",
   "expGain": "{{pokemonName}} gained\n{{exp}} EXP. Points!",
   "levelUp": "{{pokemonName}} grew to\nLv. {{level}}!",
   "learnMove": "{{pokemonName}} learned\n{{moveName}}!",

--- a/src/locales/es/battle.ts
+++ b/src/locales/es/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultOneHitKO": "¡KO en 1 golpe!",
   "attackFailed": "¡Pero ha fallado!",
   "attackHitsCount": "N.º de golpes: {{count}}.",
+  "rewardGain": "You received\n{{modifierName}}!",
   "expGain": "{{pokemonName}} ha ganado\n{{exp}} puntos de experiencia.",
   "levelUp": "¡{{pokemonName}} ha subido al \nNv. {{level}}!",
   "learnMove": "¡{{pokemonName}} ha aprendido {{moveName}}!",

--- a/src/locales/es/battle.ts
+++ b/src/locales/es/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultOneHitKO": "¡KO en 1 golpe!",
   "attackFailed": "¡Pero ha fallado!",
   "attackHitsCount": "N.º de golpes: {{count}}.",
-  "rewardGain": "You received\n{{modifierName}}!",
+  "rewardGain": "¡Has obtenido\n{{modifierName}}!",
   "expGain": "{{pokemonName}} ha ganado\n{{exp}} puntos de experiencia.",
   "levelUp": "¡{{pokemonName}} ha subido al \nNv. {{level}}!",
   "learnMove": "¡{{pokemonName}} ha aprendido {{moveName}}!",

--- a/src/locales/fr/battle.ts
+++ b/src/locales/fr/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultOneHitKO": "K.O. en un coup !",
   "attackFailed": "Mais cela échoue !",
   "attackHitsCount": "Touché {{count}} fois !",
-  "rewardGain": "You received\n{{modifierName}}!",
+  "rewardGain": "Vous recevez\n{{modifierName}} !",
   "expGain": "{{pokemonName}} gagne\n{{exp}} Points d’Exp !",
   "levelUp": "{{pokemonName}} monte au\nN. {{level}} !",
   "learnMove": "{{pokemonName}} apprend\n{{moveName}} !",

--- a/src/locales/fr/battle.ts
+++ b/src/locales/fr/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultOneHitKO": "K.O. en un coup !",
   "attackFailed": "Mais cela échoue !",
   "attackHitsCount": "Touché {{count}} fois !",
+  "rewardGain": "You received\n{{modifierName}}!",
   "expGain": "{{pokemonName}} gagne\n{{exp}} Points d’Exp !",
   "levelUp": "{{pokemonName}} monte au\nN. {{level}} !",
   "learnMove": "{{pokemonName}} apprend\n{{moveName}} !",

--- a/src/locales/it/battle.ts
+++ b/src/locales/it/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultOneHitKO": "KO con un colpo!",
   "attackFailed": "Ma ha fallito!",
   "attackHitsCount": "Colpito {{count}} volta/e!",
+  "rewardGain": "You received\n{{modifierName}}!",
   "expGain": "{{pokemonName}} ha guadagnato\n{{exp}} Punti Esperienza!",
   "levelUp": "{{pokemonName}} è salito al\nlivello {{level}}!",
   "learnMove": "{{pokemonName}} impara\n{{moveName}}!",

--- a/src/locales/ko/battle.ts
+++ b/src/locales/ko/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultOneHitKO": "일격필살!",
   "attackFailed": "하지만 실패했다!",
   "attackHitsCount": "{{count}}번 맞았다!",
+  "rewardGain": "{{modifierName}}[[를]] 받았다!",
   "expGain": "{{pokemonName}}[[는]]\n{{exp}} 경험치를 얻었다!",
   "levelUp": "{{pokemonName}}[[는]]\n레벨 {{level}}[[로]] 올랐다!",
   "learnMove": "{{pokemonName}}[[는]] 새로\n{{moveName}}[[를]] 배웠다!",

--- a/src/locales/pt_BR/battle.ts
+++ b/src/locales/pt_BR/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultOneHitKO": "Foi um nocaute de um golpe!",
   "attackFailed": "Mas falhou!",
   "attackHitsCount": "Acertou {{count}} vezes.",
+  "rewardGain": "You received\n{{modifierName}}!",
   "expGain": "{{pokemonName}} ganhou\n{{exp}} pontos de experiência.",
   "levelUp": "{{pokemonName}} subiu para \nNv. {{level}}!",
   "learnMove": "{{pokemonName}} aprendeu {{moveName}}!",

--- a/src/locales/pt_BR/battle.ts
+++ b/src/locales/pt_BR/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultOneHitKO": "Foi um nocaute de um golpe!",
   "attackFailed": "Mas falhou!",
   "attackHitsCount": "Acertou {{count}} vezes.",
-  "rewardGain": "You received\n{{modifierName}}!",
+  "rewardGain": "Você recebeu\n{{modifierName}}!",
   "expGain": "{{pokemonName}} ganhou\n{{exp}} pontos de experiência.",
   "levelUp": "{{pokemonName}} subiu para \nNv. {{level}}!",
   "learnMove": "{{pokemonName}} aprendeu {{moveName}}!",

--- a/src/locales/zh_CN/battle.ts
+++ b/src/locales/zh_CN/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultOneHitKO": "一击必杀！",
   "attackFailed": "但是失败了！",
   "attackHitsCount": "击中 {{count}} 次！",
-  "rewardGain": "You received\n{{modifierName}}!",
+  "rewardGain": "你获得了\n{{modifierName}}！",
   "expGain": "{{pokemonName}} 获得了 {{exp}} 经验值！",
   "levelUp": "{{pokemonName}} 升级到 Lv.{{level}}！",
   "learnMove": "{{pokemonName}} 学会了 {{moveName}}！",

--- a/src/locales/zh_CN/battle.ts
+++ b/src/locales/zh_CN/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultOneHitKO": "一击必杀！",
   "attackFailed": "但是失败了！",
   "attackHitsCount": "击中 {{count}} 次！",
+  "rewardGain": "You received\n{{modifierName}}!",
   "expGain": "{{pokemonName}} 获得了 {{exp}} 经验值！",
   "levelUp": "{{pokemonName}} 升级到 Lv.{{level}}！",
   "learnMove": "{{pokemonName}} 学会了 {{moveName}}！",

--- a/src/locales/zh_TW/battle.ts
+++ b/src/locales/zh_TW/battle.ts
@@ -22,6 +22,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultOneHitKO": "一擊切殺！",
   "attackFailed": "但是失敗了！",
   "attackHitsCount": "擊中 {{count}} 次！",
+  "rewardGain": "You received\n{{modifierName}}!",
   "expGain": "{{pokemonName}} 獲得了 {{exp}} 經驗值！",
   "levelUp": "{{pokemonName}} 升級到 Lv. {{level}}！",
   "learnMove": "{{pokemonName}} 學會了{{moveName}}！",

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -4044,7 +4044,7 @@ export class ModifierRewardPhase extends BattlePhase {
       const newModifier = this.modifierType.newModifier();
       this.scene.addModifier(newModifier).then(() => {
         this.scene.playSound("item_fanfare");
-        this.scene.ui.showText(`You received\n${newModifier.type.name}!`, null, () => resolve(), null, true);
+        this.scene.ui.showText(i18next.t("battle:rewardGain", { modifierName: newModifier.type.name }), null, () => resolve(), null, true);
       });
     });
   }
@@ -4062,7 +4062,7 @@ export class GameOverModifierRewardPhase extends ModifierRewardPhase {
         this.scene.playSound("level_up_fanfare");
         this.scene.ui.setMode(Mode.MESSAGE);
         this.scene.ui.fadeIn(250).then(() => {
-          this.scene.ui.showText(`You received\n${newModifier.type.name}!`, null, () => {
+          this.scene.ui.showText(i18next.t("battle:rewardGain", { modifierName: newModifier.type.name }), null, () => {
             this.scene.time.delayedCall(1500, () => this.scene.arenaBg.setVisible(true));
             resolve();
           }, null, true, 1500);


### PR DESCRIPTION
## What are the changes?
Add the option to localize message text when you receive modifier.

## Why am I doing these changes?
All text should be localizable.

## What did change?
 - Change the code for localize.
 - Added localization key in each language folders.
 - Translated it to Korean.

### Screenshots/Videos

| Lang | Result |
| :-----: | :---: |
| En | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/0b428d42-bef0-4a8d-931f-94391442df72) |
| De | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/cb718b1b-6fbf-4457-840f-eb64634fd399) |
| Es | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/80526db2-b4dd-4b56-a525-c9e7d50816cf) |
| Fr | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/346d7abd-b99f-4dab-8505-b1a3c18e3f4f) |
| Ko | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/b3f98d9d-8445-4177-bb42-92800da7c064) |
| pt_BR | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/b4b4e666-6522-481d-ad21-9220b9eaef72) |
| zh_CN | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/4675dfc6-9a74-4aef-8ae3-d4ffa84a691a) |


## How to test the changes?
Manually.
Try wave clear with a fixed reward, like
classic 8 : rival (EXP. All)
classic 20 : Gym leader (Super EXP. Charm)
(find onReward of ModifierRewardPhase)

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?