### PR TITLE
[Bug] Fix noice eiscue crashing on arena reset

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -37,7 +37,7 @@ import UIPlugin from "phaser3-rex-plugins/templates/ui/ui-plugin";
 import { addUiThemeOverrides } from "./ui/ui-theme";
 import PokemonData from "./system/pokemon-data";
 import { Nature } from "./data/nature";
-import { SpeciesFormChangeTimeOfDayTrigger, SpeciesFormChangeTrigger, pokemonFormChanges } from "./data/pokemon-forms";
+import { SpeciesFormChangeManualTrigger, SpeciesFormChangeTimeOfDayTrigger, SpeciesFormChangeTrigger, pokemonFormChanges } from "./data/pokemon-forms";
 import { FormChangePhase, QuietFormChangePhase } from "./form-change-phase";
 import { getTypeRgb } from "./data/type";
 import PokemonSpriteSparkleHandler from "./field/pokemon-sprite-sparkle-handler";
@@ -1121,7 +1121,7 @@ export default class BattleScene extends SceneBase {
 
         for (const pokemon of this.getParty()) {
           if (pokemon.hasAbility(Abilities.ICE_FACE)) {
-            pokemon.formIndex = 0;
+            this.triggerPokemonFormChange(pokemon, SpeciesFormChangeManualTrigger);
           }
 
           pokemon.resetBattleData();


### PR DESCRIPTION
## What are the changes?
- fixes crash caused by noice eiscue on arena reset
- unit test did not catch this because the error came from the pokemon's cry 

## Why am I doing these changes?
- when the arena resets, the game loads the noice form audio file (875-no-ice.m4a) instead of the 875.m4a
- my best guess is that the game loads the audio first before the `pokemon.formIndex = 0` was called, hence why it cant find the audio and the game crashes

## What did change?
- change manually setting `pokemon.formIndex = 0` to `triggerPokemonFormChange()`

### Screenshots/Videos

https://github.com/pagefaultgames/pokerogue/assets/68144167/d55f0c16-57d8-4f46-9bb6-ed6ecc3f3f19




## How to test the changes?
- use noice eiscue on wave 4, play to wave 5

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?