### PR TITLE
[Bug] Eiscue changing form regardless of previous form on arena reset

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1123,7 +1123,8 @@ export default class BattleScene extends SceneBase {
 
         for (const pokemon of this.getParty()) {
           // Only trigger form change when Eiscue is in Noice form
-          if (pokemon.hasAbility(Abilities.ICE_FACE) && pokemon.formIndex === 1) {
+          // Hardcoded Eiscue for now in case it is fused with another pokemon
+          if (pokemon.species.speciesId === Species.EISCUE && pokemon.hasAbility(Abilities.ICE_FACE) && pokemon.formIndex === 1) {
             this.triggerPokemonFormChange(pokemon, SpeciesFormChangeManualTrigger);
           }
 

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1122,7 +1122,8 @@ export default class BattleScene extends SceneBase {
         playerField.forEach((_, p) => this.unshiftPhase(new ReturnPhase(this, p)));
 
         for (const pokemon of this.getParty()) {
-          if (pokemon.hasAbility(Abilities.ICE_FACE)) {
+          // Only trigger form change when Eiscue is in Noice form
+          if (pokemon.hasAbility(Abilities.ICE_FACE) && pokemon.formIndex === 1) {
             this.triggerPokemonFormChange(pokemon, SpeciesFormChangeManualTrigger);
           }
 


### PR DESCRIPTION
## What are the changes?
- added condition to only trigger form change if eiscue is on noice form

## Why am I doing these changes?
- see title


## What did change?
- added condition

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
- get eiscue until arena resets

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?