### PR TITLE
[Bug] Fix trainer double battle crash

### DIFF
--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -432,8 +432,8 @@ export default class Trainer extends Phaser.GameObjects.Container {
     }
 
     const party = this.scene.getEnemyParty();
-    const nonFaintedPartyMembers = party.slice(this.scene.currentBattle.getBattlerCount()).filter(p => !p.isFainted()).filter(p => !trainerSlot || p.trainerSlot === trainerSlot);
-    const partyMemberScores = nonFaintedPartyMembers.map(p => {
+    const nonFaintedLegalPartyMembers = party.slice(this.scene.currentBattle.getBattlerCount()).filter(p => !p.isAllowedInBattle()).filter(p => !trainerSlot || p.trainerSlot === trainerSlot);
+    const partyMemberScores = nonFaintedLegalPartyMembers.map(p => {
       const playerField = this.scene.getPlayerField();
       let score = 0;
       for (const playerPokemon of playerField) {

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -432,7 +432,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
     }
 
     const party = this.scene.getEnemyParty();
-    const nonFaintedLegalPartyMembers = party.slice(this.scene.currentBattle.getBattlerCount()).filter(p => !p.isAllowedInBattle()).filter(p => !trainerSlot || p.trainerSlot === trainerSlot);
+    const nonFaintedLegalPartyMembers = party.slice(this.scene.currentBattle.getBattlerCount()).filter(p => p.isAllowedInBattle()).filter(p => !trainerSlot || p.trainerSlot === trainerSlot);
     const partyMemberScores = nonFaintedLegalPartyMembers.map(p => {
       const playerField = this.scene.getPlayerField();
       let score = 0;

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -434,7 +434,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
     const party = this.scene.getEnemyParty();
     const nonFaintedLegalPartyMembers = party.slice(this.scene.currentBattle.getBattlerCount()).filter(p => p.isAllowedInBattle()).filter(p => !trainerSlot || p.trainerSlot === trainerSlot);
     const partyMemberScores = nonFaintedLegalPartyMembers.map(p => {
-      const playerField = this.scene.getPlayerField();
+      const playerField = this.scene.getPlayerField().filter(p => p.isAllowedInBattle());
       let score = 0;
       for (const playerPokemon of playerField) {
         score += p.getMatchupScore(playerPokemon);


### PR DESCRIPTION
## What are the changes?
- fixes double battle crashes on challenge mode

## Why am I doing these changes?
- `getPlayerField()` always returns 2 pokemons in a double battle, even in a challenge mode where 1 pokemon is ineligible.
- this means it will run `getMatchupScore()` on a non-fielded (ineligible) pokemon, which then causes the game to crash

## What did change?
- change `!isFainted()` to `isAllowedInBattle()`
- added a `filter` to `getPlayerField()`

### Screenshots/Videos
- no longer crashes the game

https://github.com/pagefaultgames/pokerogue/assets/68144167/2ed72e06-d991-49c4-a5ec-3d5e085c46db





## How to test the changes?
- import [session data](https://discord.com/channels/1125469663833370665/1125894949020381285/1254593572406300683) and get to wave 26

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?