### PR TITLE
[QoL] Allow swapping keyboard bindings

### DIFF
--- a/src/configs/inputs/configHandler.ts
+++ b/src/configs/inputs/configHandler.ts
@@ -118,17 +118,25 @@ export function assign(config, settingNameTarget, keycode): boolean {
   if (!canIAssignThisKey(config, getKeyWithKeycode(config, keycode)) || !canIOverrideThisSetting(config, settingNameTarget)) {
     return false;
   }
+
+  // Check if the new key pressed already exists for a keybind
   const previousSettingName = getSettingNameWithKeycode(config, keycode);
-  // if it was already bound, we delete the bind
-  if (previousSettingName) {
-    const previousKey = getKeyWithSettingName(config, previousSettingName);
-    config.custom[previousKey] = -1;
-  }
-  // then, we need to delete the current key for this settingName
+  const previousKey = getKeyWithSettingName(config, previousSettingName);
+
+  // This is key currently assigned to the keybind we want to change
   const currentKey = getKeyWithSettingName(config, settingNameTarget);
+
+  // If the new key pressed is already assigned to another settingName, swap them
+  if (previousSettingName !== -1) {
+    config.custom[previousKey] = settingNameTarget;
+    config.custom[currentKey] = previousSettingName;
+    return true;
+  }
+
+  // Unbind the current key
   config.custom[currentKey] = -1;
 
-  // then, the new key is assigned to the new settingName
+  // Assign the new key to the settingNameTarget
   const newKey = getKeyWithKeycode(config, keycode);
   config.custom[newKey] = settingNameTarget;
   return true;

--- a/src/test/settingMenu/rebinding_setting.test.ts
+++ b/src/test/settingMenu/rebinding_setting.test.ts
@@ -14,9 +14,9 @@ import { Button } from "#enums/buttons";
 
 
 describe("Test Rebinding", () => {
-  let config;
-  let inGame;
-  let inTheSettingMenu;
+  let config: any;
+  let inGame: InGameManip;
+  let inTheSettingMenu: MenuManip;
   const configs: Map<string, InterfaceConfig> = new Map();
   const selectedDevice = {
     [Device.GAMEPAD]: null,
@@ -96,7 +96,7 @@ describe("Test Rebinding", () => {
     inTheSettingMenu.whenCursorIsOnSetting("Alt_Button_Left").iconDisplayedIs("A");
     inTheSettingMenu.whenCursorIsOnSetting("Alt_Button_Right").iconDisplayedIs("D");
     inTheSettingMenu.whenCursorIsOnSetting("Alt_Button_Left").iconDisplayedIs("A").weWantThisBindInstead("D").confirm();
-    inGame.whenWePressOnKeyboard("A").nothingShouldHappen();
+    inGame.whenWePressOnKeyboard("A").weShouldTriggerTheButton("Alt_Button_Right");
     inGame.whenWePressOnKeyboard("D").weShouldTriggerTheButton("Alt_Button_Left");
   });
 
@@ -147,21 +147,21 @@ describe("Test Rebinding", () => {
 
     inTheSettingMenu.whenCursorIsOnSetting("Alt_Button_Left").iconDisplayedIs("KEY_A").weWantThisBindInstead("D").confirm();
 
-    inGame.whenWePressOnKeyboard("A").nothingShouldHappen();
+    inGame.whenWePressOnKeyboard("A").weShouldTriggerTheButton("Alt_Button_Right");
     inGame.whenWePressOnKeyboard("D").weShouldTriggerTheButton("Alt_Button_Left");
     inGame.whenWePressOnKeyboard("W").weShouldTriggerTheButton("Alt_Button_Up");
 
     inTheSettingMenu.whenCursorIsOnSetting("Alt_Button_Left").iconDisplayedIs("KEY_D").weWantThisBindInstead("W").confirm();
 
-    inGame.whenWePressOnKeyboard("A").nothingShouldHappen();
-    inGame.whenWePressOnKeyboard("D").nothingShouldHappen();
+    inGame.whenWePressOnKeyboard("A").weShouldTriggerTheButton("Alt_Button_Right");
+    inGame.whenWePressOnKeyboard("D").weShouldTriggerTheButton("Alt_Button_Up");
     inGame.whenWePressOnKeyboard("W").weShouldTriggerTheButton("Alt_Button_Left");
 
     inTheSettingMenu.whenCursorIsOnSetting("Alt_Button_Left").iconDisplayedIs("KEY_W").weWantThisBindInstead("D").confirm();
 
-    inGame.whenWePressOnKeyboard("A").nothingShouldHappen();
+    inGame.whenWePressOnKeyboard("A").weShouldTriggerTheButton("Alt_Button_Right");
     inGame.whenWePressOnKeyboard("D").weShouldTriggerTheButton("Alt_Button_Left");
-    inGame.whenWePressOnKeyboard("W").nothingShouldHappen();
+    inGame.whenWePressOnKeyboard("W").weShouldTriggerTheButton("Alt_Button_Up");
   });
 
   it("Check if triple swap d-pad is prevented", () => {
@@ -189,20 +189,20 @@ describe("Test Rebinding", () => {
 
     inTheSettingMenu.whenCursorIsOnSetting("Alt_Button_Left").iconDisplayedIs("KEY_A").weWantThisBindInstead("D").confirm();
 
-    inGame.whenWePressOnKeyboard("A").nothingShouldHappen();
+    inGame.whenWePressOnKeyboard("A").weShouldTriggerTheButton("Alt_Button_Right");
     inGame.whenWePressOnKeyboard("D").weShouldTriggerTheButton("Alt_Button_Left");
     inGame.whenWePressOnKeyboard("W").weShouldTriggerTheButton("Alt_Button_Up");
 
-    inTheSettingMenu.whenCursorIsOnSetting("Alt_Button_Right").thereShouldBeNoIcon().weWantThisBindInstead("W").confirm();
+    inTheSettingMenu.whenCursorIsOnSetting("Alt_Button_Right").iconDisplayedIs("KEY_A").weWantThisBindInstead("W").confirm();
 
-    inGame.whenWePressOnKeyboard("A").nothingShouldHappen();
+    inGame.whenWePressOnKeyboard("A").weShouldTriggerTheButton("Alt_Button_Up");
     inGame.whenWePressOnKeyboard("D").weShouldTriggerTheButton("Alt_Button_Left");
     inGame.whenWePressOnKeyboard("W").weShouldTriggerTheButton("Alt_Button_Right");
 
     inTheSettingMenu.whenCursorIsOnSetting("Alt_Button_Left").iconDisplayedIs("KEY_D").weWantThisBindInstead("A").confirm();
 
     inGame.whenWePressOnKeyboard("A").weShouldTriggerTheButton("Alt_Button_Left");
-    inGame.whenWePressOnKeyboard("D").nothingShouldHappen();
+    inGame.whenWePressOnKeyboard("D").weShouldTriggerTheButton("Alt_Button_Up");
     inGame.whenWePressOnKeyboard("W").weShouldTriggerTheButton("Alt_Button_Right");
   });
 
@@ -211,7 +211,7 @@ describe("Test Rebinding", () => {
     inGame.whenWePressOnKeyboard("R").weShouldTriggerTheButton("Cycle_Shiny");
     inTheSettingMenu.whenCursorIsOnSetting("Cycle_Shiny").iconDisplayedIs("KEY_R").weWantThisBindInstead("D").confirm();
     inGame.whenWePressOnKeyboard("D").weShouldTriggerTheButton("Cycle_Shiny");
-    inGame.whenWePressOnKeyboard("R").nothingShouldHappen();
+    inGame.whenWePressOnKeyboard("R").weShouldTriggerTheButton("Alt_Button_Right");
   });
 
   it("multiple Swap alt with another main", () => {
@@ -221,14 +221,14 @@ describe("Test Rebinding", () => {
     inGame.whenWePressOnKeyboard("F").weShouldTriggerTheButton("Button_Cycle_Form");
     inTheSettingMenu.whenCursorIsOnSetting("Button_Cycle_Shiny").iconDisplayedIs("KEY_R").weWantThisBindInstead("D").confirm();
     inGame.whenWePressOnKeyboard("D").weShouldTriggerTheButton("Button_Cycle_Shiny");
-    inGame.whenWePressOnKeyboard("R").nothingShouldHappen();
+    inGame.whenWePressOnKeyboard("R").weShouldTriggerTheButton("Alt_Button_Right");
     inGame.whenWePressOnKeyboard("A").weShouldTriggerTheButton("Alt_Button_Left");
     inGame.whenWePressOnKeyboard("F").weShouldTriggerTheButton("Button_Cycle_Form");
     inTheSettingMenu.whenCursorIsOnSetting("Button_Cycle_Form").iconDisplayedIs("KEY_F").weWantThisBindInstead("R").confirm();
     inGame.whenWePressOnKeyboard("D").weShouldTriggerTheButton("Button_Cycle_Shiny");
     inGame.whenWePressOnKeyboard("R").weShouldTriggerTheButton("Button_Cycle_Form");
     inGame.whenWePressOnKeyboard("A").weShouldTriggerTheButton("Alt_Button_Left");
-    inGame.whenWePressOnKeyboard("F").nothingShouldHappen();
+    inGame.whenWePressOnKeyboard("F").weShouldTriggerTheButton("Alt_Button_Right");
   });
 
   it("Swap alt with a key not binded yet", () => {
@@ -265,21 +265,21 @@ describe("Test Rebinding", () => {
     inGame.whenWePressOnKeyboard("W").weShouldTriggerTheButton("Alt_Button_Up");
     inGame.whenWePressOnKeyboard("D").weShouldTriggerTheButton("Alt_Button_Right");
     inTheSettingMenu.whenCursorIsOnSetting("Button_Cycle_Shiny").iconDisplayedIs("KEY_R").weWantThisBindInstead("D").confirm();
-    inGame.whenWePressOnKeyboard("R").nothingShouldHappen();
+    inGame.whenWePressOnKeyboard("R").weShouldTriggerTheButton("Alt_Button_Right");
     inGame.whenWePressOnKeyboard("F").weShouldTriggerTheButton("Button_Cycle_Form");
     inGame.whenWePressOnKeyboard("W").weShouldTriggerTheButton("Alt_Button_Up");
     inGame.whenWePressOnKeyboard("D").weShouldTriggerTheButton("Button_Cycle_Shiny");
 
     inTheSettingMenu.whenCursorIsOnSetting("Button_Cycle_Form").iconDisplayedIs("KEY_F").weWantThisBindInstead("W").confirm();
-    inGame.whenWePressOnKeyboard("R").nothingShouldHappen();
-    inGame.whenWePressOnKeyboard("F").nothingShouldHappen();
+    inGame.whenWePressOnKeyboard("R").weShouldTriggerTheButton("Alt_Button_Right");
+    inGame.whenWePressOnKeyboard("F").weShouldTriggerTheButton("Alt_Button_Up");
     inGame.whenWePressOnKeyboard("W").weShouldTriggerTheButton("Button_Cycle_Form");
     inGame.whenWePressOnKeyboard("D").weShouldTriggerTheButton("Button_Cycle_Shiny");
     inGame.whenWePressOnKeyboard("A").weShouldTriggerTheButton("Alt_Button_Left");
 
     inTheSettingMenu.whenWeDelete("Alt_Button_Left").thereShouldBeNoIconAnymore();
-    inGame.whenWePressOnKeyboard("R").nothingShouldHappen();
-    inGame.whenWePressOnKeyboard("F").nothingShouldHappen();
+    inGame.whenWePressOnKeyboard("R").weShouldTriggerTheButton("Alt_Button_Right");
+    inGame.whenWePressOnKeyboard("F").weShouldTriggerTheButton("Alt_Button_Up");
     inGame.whenWePressOnKeyboard("W").weShouldTriggerTheButton("Button_Cycle_Form");
     inGame.whenWePressOnKeyboard("D").weShouldTriggerTheButton("Button_Cycle_Shiny");
     inGame.whenWePressOnKeyboard("S").weShouldTriggerTheButton("Alt_Button_Down");
@@ -287,8 +287,8 @@ describe("Test Rebinding", () => {
     inGame.whenWePressOnKeyboard("B").nothingShouldHappen();
 
     inTheSettingMenu.whenCursorIsOnSetting("Alt_Button_Down").iconDisplayedIs("KEY_S").weWantThisBindInstead("B").confirm();
-    inGame.whenWePressOnKeyboard("R").nothingShouldHappen();
-    inGame.whenWePressOnKeyboard("F").nothingShouldHappen();
+    inGame.whenWePressOnKeyboard("R").weShouldTriggerTheButton("Alt_Button_Right");
+    inGame.whenWePressOnKeyboard("F").weShouldTriggerTheButton("Alt_Button_Up");
     inGame.whenWePressOnKeyboard("W").weShouldTriggerTheButton("Button_Cycle_Form");
     inGame.whenWePressOnKeyboard("D").weShouldTriggerTheButton("Button_Cycle_Shiny");
     inGame.whenWePressOnKeyboard("S").nothingShouldHappen();
@@ -342,13 +342,13 @@ describe("Test Rebinding", () => {
     inTheSettingMenu.whenCursorIsOnSetting("Alt_Button_Up").iconDisplayedIs("KEY_W").weWantThisBindInstead("D").confirm();
     inGame.whenWePressOnKeyboard("UP").weShouldTriggerTheButton("Button_Up");
     inGame.whenWePressOnKeyboard("RIGHT").weShouldTriggerTheButton("Button_Right");
-    inGame.whenWePressOnKeyboard("W").nothingShouldHappen();
+    inGame.whenWePressOnKeyboard("W").weShouldTriggerTheButton("Alt_Button_Right");
     inGame.whenWePressOnKeyboard("D").weShouldTriggerTheButton("Alt_Button_Up");
     inTheSettingMenu.whenCursorIsOnSetting("Alt_Button_Up").iconDisplayedIs("KEY_D").weWantThisBindInstead("W").confirm();
     inGame.whenWePressOnKeyboard("UP").weShouldTriggerTheButton("Button_Up");
     inGame.whenWePressOnKeyboard("RIGHT").weShouldTriggerTheButton("Button_Right");
     inGame.whenWePressOnKeyboard("W").weShouldTriggerTheButton("Alt_Button_Up");
-    inGame.whenWePressOnKeyboard("D").nothingShouldHappen();
+    inGame.whenWePressOnKeyboard("D").weShouldTriggerTheButton("Alt_Button_Right");
   });
 
 

--- a/src/ui/settings/keyboard-binding-ui-handler.ts
+++ b/src/ui/settings/keyboard-binding-ui-handler.ts
@@ -1,7 +1,7 @@
 import BattleScene from "../../battle-scene";
 import AbstractBindingUiHandler from "./abstract-binding-ui-handler";
 import {Mode} from "../ui";
-import { getKeyWithKeycode} from "#app/configs/inputs/configHandler";
+import {getIconWithSettingName, getKeyWithKeycode} from "#app/configs/inputs/configHandler";
 import {Device} from "#enums/devices";
 import {addTextObject, TextStyle} from "#app/ui/text";
 
@@ -18,9 +18,19 @@ export default class KeyboardBindingUiHandler extends AbstractBindingUiHandler {
 
     // New button icon setup.
     this.newButtonIcon = this.scene.add.sprite(0, 0, "keyboard");
-    this.newButtonIcon.setPositionRelative(this.optionSelectBg, 78, 32);
+    this.newButtonIcon.setPositionRelative(this.optionSelectBg, 78, 16);
     this.newButtonIcon.setOrigin(0.5);
     this.newButtonIcon.setVisible(false);
+
+    this.swapText = addTextObject(this.scene, 0, 0, "will swap with", TextStyle.WINDOW);
+    this.swapText.setOrigin(0.5);
+    this.swapText.setPositionRelative(this.optionSelectBg, this.optionSelectBg.width / 2 - 2, this.optionSelectBg.height / 2 - 2);
+    this.swapText.setVisible(false);
+
+    this.targetButtonIcon = this.scene.add.sprite(0, 0, "keyboard");
+    this.targetButtonIcon.setPositionRelative(this.optionSelectBg, 78, 48);
+    this.targetButtonIcon.setOrigin(0.5);
+    this.targetButtonIcon.setVisible(false);
 
     this.actionLabel = addTextObject(this.scene, 0, 0, "Assign button", TextStyle.SETTINGS_LABEL);
     this.actionLabel.setOrigin(0, 0.5);
@@ -28,6 +38,8 @@ export default class KeyboardBindingUiHandler extends AbstractBindingUiHandler {
     this.actionsContainer.add(this.actionLabel);
 
     this.optionSelectContainer.add(this.newButtonIcon);
+    this.optionSelectContainer.add(this.swapText);
+    this.optionSelectContainer.add(this.targetButtonIcon);
   }
 
   getSelectedDevice() {
@@ -57,8 +69,8 @@ export default class KeyboardBindingUiHandler extends AbstractBindingUiHandler {
       return;
     }
     this.buttonPressed = key;
-    // const assignedButtonIcon = getIconWithSettingName(activeConfig, this.target);
-    this.onInputDown(buttonIcon, null, "keyboard");
+    const assignedButtonIcon = getIconWithSettingName(activeConfig, this.target);
+    this.onInputDown(buttonIcon, assignedButtonIcon, "keyboard");
   }
 
   swapAction(): boolean {
@@ -68,6 +80,15 @@ export default class KeyboardBindingUiHandler extends AbstractBindingUiHandler {
       return true;
     }
     return false;
+  }
+
+  /**
+     * Clear the UI elements and state.
+     */
+  clear() {
+    super.clear();
+    this.swapText.setVisible(false);
+    this.targetButtonIcon.setVisible(false);
   }
 
 }


### PR DESCRIPTION
## What are the changes?
Allow users to swap keyboard bindings instead of just removing the old one without warning

## Why am I doing these changes?
Fixes #2511 

## What did change?
The keyboard keybind change screen now shows what you're changing from and to.

### Screenshots/Videos
Before vs After
![before](https://i.ember.zone/eQrs6UTdB18ONKpe.png)
![new](https://i.ember.zone/9KEDQnASvfdE0tGp.png)

## How to test the changes?
1. Go to Game Settings > Keyboard
2. Setting Up (Alt) to S will set it to S and change Down (Alt) to W, swapping the keybinds

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?

![tests](https://i.ember.zone/MkQ2ynhUgdtMgaq8.png)