### PR TITLE
Fix enemy trainers not sending out pokemon

### DIFF
--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -436,16 +436,20 @@ export default class Trainer extends Phaser.GameObjects.Container {
     const partyMemberScores = nonFaintedLegalPartyMembers.map(p => {
       const playerField = this.scene.getPlayerField().filter(p => p.isAllowedInBattle());
       let score = 0;
-      for (const playerPokemon of playerField) {
-        score += p.getMatchupScore(playerPokemon);
-        if (playerPokemon.species.legendary) {
-          score /= 2;
+
+      if (playerField.length > 0) {
+        for (const playerPokemon of playerField) {
+          score += p.getMatchupScore(playerPokemon);
+          if (playerPokemon.species.legendary) {
+            score /= 2;
+          }
+        }
+        score /= playerField.length;
+        if (forSwitch && !p.isOnField()) {
+          this.scene.arena.findTagsOnSide(t => t instanceof ArenaTrapTag, ArenaTagSide.ENEMY).map(t => score *= (t as ArenaTrapTag).getMatchupScoreMultiplier(p));
         }
       }
-      score /= playerField.length;
-      if (forSwitch && !p.isOnField()) {
-        this.scene.arena.findTagsOnSide(t => t instanceof ArenaTrapTag, ArenaTagSide.ENEMY).map(t => score *= (t as ArenaTrapTag).getMatchupScoreMultiplier(p));
-      }
+
       return [party.indexOf(p), score];
     }) as [integer, integer][];
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->

With https://github.com/pagefaultgames/pokerogue/commit/2bab7d3778f988beafba7f0b93ddac774792ff03 there was a bug introduced causing enemy trainers not to send out pokemons anymore.
I did some debugging and found that there was division `/0` happening which might be causing this issue.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

To fix this bug

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

I've added a length check on the `playerfield` variable before calculating the `score`

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

- Download [this](https://cdn.discordapp.com/attachments/1176874654015684739/1254993704075133000/sessionData_Guest.prsv?ex=667b8377&is=667a31f7&hm=c9acabd9356c814dde04754b7f2347a7aa6256a1d3d54b26d9a32056fc48ec89&) session file from discord
- Import it into your local instance
- make sure to edit `overrides.ts`
    - ```ts
       // ...
       export const MOVESET_OVERRIDE: Array<Moves> = [Moves.EXPLOSION];
       // ...
       ```
- play the imported session and use `explosion`. After both pokemon fainted the enemy should still send out a new pokemon

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~~[ ] Are the changes visual?~~