### PR TITLE
[Bug] Fix Dry Skin and ReceivedMoveDamageMultiplierAbAttr abilities

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2726,7 +2726,7 @@ export class PostWeatherLapseDamageAbAttr extends PostWeatherLapseAbAttr {
   }
 
   applyPostWeatherLapse(pokemon: Pokemon, passive: boolean, weather: Weather, args: any[]): boolean {
-    if (pokemon.getHpRatio() < 1) {
+    if (pokemon.getHpRatio() <= 1) {
       const scene = pokemon.scene;
       const abilityName = (!passive ? pokemon.getAbility() : pokemon.getPassiveAbility()).name;
       scene.queueMessage(getPokemonMessage(pokemon, ` is hurt\nby its ${abilityName}!`));

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2726,15 +2726,11 @@ export class PostWeatherLapseDamageAbAttr extends PostWeatherLapseAbAttr {
   }
 
   applyPostWeatherLapse(pokemon: Pokemon, passive: boolean, weather: Weather, args: any[]): boolean {
-    if (pokemon.getHpRatio() <= 1) {
-      const scene = pokemon.scene;
-      const abilityName = (!passive ? pokemon.getAbility() : pokemon.getPassiveAbility()).name;
-      scene.queueMessage(getPokemonMessage(pokemon, ` is hurt\nby its ${abilityName}!`));
-      pokemon.damageAndUpdate(Math.ceil(pokemon.getMaxHp() / (16 / this.damageFactor)), HitResult.OTHER);
-      return true;
-    }
-
-    return false;
+    const scene = pokemon.scene;
+    const abilityName = (!passive ? pokemon.getAbility() : pokemon.getPassiveAbility()).name;
+    scene.queueMessage(getPokemonMessage(pokemon, ` is hurt\nby its ${abilityName}!`));
+    pokemon.damageAndUpdate(Math.ceil(pokemon.getMaxHp() / (16 / this.damageFactor)), HitResult.OTHER);
+    return true;
   }
 }
 

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -326,7 +326,7 @@ export class ReceivedTypeDamageMultiplierAbAttr extends ReceivedMoveDamageMultip
   }
 }
 
-export class PreDefendMovePowerToOneAbAttr extends ReceivedMoveDamageMultiplierAbAttr {
+export class PreDefendMoveDamageToOneAbAttr extends ReceivedMoveDamageMultiplierAbAttr {
   constructor(condition: PokemonDefendCondition) {
     super(condition, 1);
   }
@@ -4717,7 +4717,7 @@ export function initAbilities() {
       .attr(NoFusionAbilityAbAttr)
       .bypassFaint(),
     new Ability(Abilities.DISGUISE, 7)
-      .attr(PreDefendMovePowerToOneAbAttr, (target, user, move) => target.formIndex === 0 && target.getAttackTypeEffectiveness(move.type, user) > 0)
+      .attr(PreDefendMoveDamageToOneAbAttr, (target, user, move) => target.formIndex === 0 && target.getAttackTypeEffectiveness(move.type, user) > 0)
       .attr(PostSummonFormChangeAbAttr, p => p.battleData.hitCount === 0 ? 0 : 1)
       .attr(PostBattleInitFormChangeAbAttr, () => 0)
       .attr(PostDefendFormChangeAbAttr, p => p.battleData.hitCount === 0 ? 0 : 1)

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -301,18 +301,18 @@ export class StabBoostAbAttr extends AbAttr {
 
 export class ReceivedMoveDamageMultiplierAbAttr extends PreDefendAbAttr {
   protected condition: PokemonDefendCondition;
-  private powerMultiplier: number;
+  private damageMultiplier: number;
 
-  constructor(condition: PokemonDefendCondition, powerMultiplier: number) {
+  constructor(condition: PokemonDefendCondition, damageMultiplier: number) {
     super();
 
     this.condition = condition;
-    this.powerMultiplier = powerMultiplier;
+    this.damageMultiplier = damageMultiplier;
   }
 
   applyPreDefend(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): boolean {
     if (this.condition(pokemon, attacker, move)) {
-      (args[0] as Utils.NumberHolder).value *= this.powerMultiplier;
+      (args[0] as Utils.NumberHolder).value *= this.damageMultiplier;
       return true;
     }
 
@@ -321,8 +321,8 @@ export class ReceivedMoveDamageMultiplierAbAttr extends PreDefendAbAttr {
 }
 
 export class ReceivedTypeDamageMultiplierAbAttr extends ReceivedMoveDamageMultiplierAbAttr {
-  constructor(moveType: Type, powerMultiplier: number) {
-    super((user, target, move) => move.type === moveType, powerMultiplier);
+  constructor(moveType: Type, damageMultiplier: number) {
+    super((user, target, move) => move.type === moveType, damageMultiplier);
   }
 }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1954,11 +1954,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         }
 
         applyMoveAttrs(ModifiedDamageAttr, source, this, move, damage);
-        applyPreDefendAbAttrs(ReceivedMoveDamageMultiplierAbAttr, this, source, move, cancelled, power);
-
-        if (power.value === 0) {
-          damage.value = 0;
-        }
+        applyPreDefendAbAttrs(ReceivedMoveDamageMultiplierAbAttr, this, source, move, cancelled, damage);
 
         console.log("damage", damage.value, move.name, power.value, sourceAtk, targetDef);
 

--- a/src/test/abilities/dry_skin.test.ts
+++ b/src/test/abilities/dry_skin.test.ts
@@ -115,7 +115,7 @@ describe("Abilities - Dry Skin", () => {
     expect(enemy.hp).toBeGreaterThan(1);
   });
 
-  it("opposing water attacks do not yield the above affect if they were protected from", async () => {
+  it("opposing water attacks do not heal if they were protected from", async () => {
     vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.WATER_GUN]);
 
     await game.startBattle();
@@ -131,7 +131,7 @@ describe("Abilities - Dry Skin", () => {
     expect(enemy.hp).toBe(1);
   });
 
-  it("multi-strike water attacks only proc the above affect once", async () => {
+  it("multi-strike water attacks only heal once", async () => {
     vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.WATER_GUN, Moves.WATER_SHURIKEN]);
 
     await game.startBattle();

--- a/src/test/abilities/dry_skin.test.ts
+++ b/src/test/abilities/dry_skin.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import Phaser from "phaser";
+import GameManager from "#app/test/utils/gameManager";
+import * as overrides from "#app/overrides";
+import { TurnEndPhase } from "#app/phases";
+import { Moves } from "#enums/moves";
+import { getMovePosition } from "#app/test/utils/gameManagerUtils";
+import { Abilities } from "#enums/abilities";
+
+describe("Abilities - Dry Skin", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.DRY_SKIN);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.SPLASH, Moves.SPLASH, Moves.SPLASH]);
+  });
+
+  it("during sunlight, lose 1/8 of maximum health at the end of each turn", async () => {
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SUNNY_DAY, Moves.SPLASH]);
+
+    await game.startBattle();
+
+    const enemy = game.scene.getEnemyPokemon();
+    expect(enemy).not.toBe(undefined);
+
+    // first turn
+    let previousEnemyHp = enemy.hp;
+    game.doAttack(getMovePosition(game.scene, 0, Moves.SUNNY_DAY));
+    await game.phaseInterceptor.to(TurnEndPhase);
+    expect(enemy.hp).toBeLessThan(previousEnemyHp);
+
+    // second turn
+    previousEnemyHp = enemy.hp;
+    game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
+    await game.phaseInterceptor.to(TurnEndPhase);
+    expect(enemy.hp).toBeLessThan(previousEnemyHp);
+  });
+
+  it("during rain, gain 1/8 of maximum health at the end of each turn", async () => {
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.RAIN_DANCE, Moves.SPLASH]);
+
+    await game.startBattle();
+
+    const enemy = game.scene.getEnemyPokemon();
+    expect(enemy).not.toBe(undefined);
+
+    enemy.hp = 1;
+
+    // first turn
+    let previousEnemyHp = enemy.hp;
+    game.doAttack(getMovePosition(game.scene, 0, Moves.RAIN_DANCE));
+    await game.phaseInterceptor.to(TurnEndPhase);
+    expect(enemy.hp).toBeGreaterThan(previousEnemyHp);
+
+    // second turn
+    previousEnemyHp = enemy.hp;
+    game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
+    await game.phaseInterceptor.to(TurnEndPhase);
+    expect(enemy.hp).toBeGreaterThan(previousEnemyHp);
+  });
+
+  it("opposing fire attacks do 25% more damage", async () => {
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.EMBER]);
+
+    // ensure the enemy doesn't die to this
+    vi.spyOn(overrides, "OPP_LEVEL_OVERRIDE", "get").mockReturnValue(30);
+
+    await game.startBattle();
+
+    const enemy = game.scene.getEnemyPokemon();
+    expect(enemy).not.toBe(undefined);
+
+    // first turn
+    game.doAttack(getMovePosition(game.scene, 0, Moves.EMBER));
+    await game.phaseInterceptor.to(TurnEndPhase);
+    const fireDamageTakenWithDrySkin = enemy.getMaxHp() - enemy.hp;
+
+    expect(enemy.hp > 0);
+    enemy.hp = enemy.getMaxHp();
+    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.NONE);
+
+    // second turn
+    game.doAttack(getMovePosition(game.scene, 0, Moves.EMBER));
+    await game.phaseInterceptor.to(TurnEndPhase);
+    const fireDamageTakenWithoutDrySkin = enemy.getMaxHp() - enemy.hp;
+
+    expect(fireDamageTakenWithDrySkin).toBeGreaterThan(fireDamageTakenWithoutDrySkin);
+  });
+
+  it("opposing water attacks heal 1/4 of maximum health and deal no damage", async () => {
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.WATER_GUN]);
+
+    await game.startBattle();
+
+    const enemy = game.scene.getEnemyPokemon();
+    expect(enemy).not.toBe(undefined);
+
+    enemy.hp = 1;
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.WATER_GUN));
+    await game.phaseInterceptor.to(TurnEndPhase);
+    expect(enemy.hp).toBeGreaterThan(1);
+  });
+
+  it("opposing water attacks do not yield the above affect if they were protected from", async () => {
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.WATER_GUN]);
+
+    await game.startBattle();
+
+    const enemy = game.scene.getEnemyPokemon();
+    expect(enemy).not.toBe(undefined);
+
+    enemy.hp = 1;
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.PROTECT, Moves.PROTECT, Moves.PROTECT, Moves.PROTECT]);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.WATER_GUN));
+    await game.phaseInterceptor.to(TurnEndPhase);
+    expect(enemy.hp).toBe(1);
+  });
+
+  it("multi-strike water attacks only proc the above affect once", async () => {
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.WATER_GUN, Moves.WATER_SHURIKEN]);
+
+    await game.startBattle();
+
+    const enemy = game.scene.getEnemyPokemon();
+    expect(enemy).not.toBe(undefined);
+
+    enemy.hp = 1;
+
+    // first turn
+    game.doAttack(getMovePosition(game.scene, 0, Moves.WATER_SHURIKEN));
+    await game.phaseInterceptor.to(TurnEndPhase);
+    const healthGainedFromWaterShuriken = enemy.hp - 1;
+
+    enemy.hp = 1;
+
+    // second turn
+    game.doAttack(getMovePosition(game.scene, 0, Moves.WATER_GUN));
+    await game.phaseInterceptor.to(TurnEndPhase);
+    const healthGainedFromWaterGun = enemy.hp - 1;
+
+    expect(healthGainedFromWaterShuriken).toBe(healthGainedFromWaterGun);
+  });
+});


### PR DESCRIPTION
## What are the changes?
- Fixed Dry Skin's damage during sunlight not applying to Pokemon at maximum health
- Fixed ReceivedMoveDamageMultiplierAbAttr not working for all values != 0 (i.e. it was broken for everything except Ice Face), which fixes the damage modification part of the following abilities: Filter, Solid Rock, Multiscale, Fur Coat, Fluffy, Shadow Shield, Prism Armor, Punk Rock, Ice Scales, Thick Fat, Heatproof, Dry Skin, Water Bubble, Purifying Salt, Disguise
- Added tests for Dry Skin

## Why am I doing these changes?
- Bug fixes

## What did change?
- ReceivedMoveDamageMultiplierAbAttr changes damage instead of power in pokemon.ts
- PostWeatherLapseDamageAbAttr is fixed to damage Pokemon at max HP in ability.ts
- Renamed "power" to "damage" in ReceivedMoveDamageMultiplierAbAttr and friends (checking Bulbapedia, it's indeed appropriate to scale damage rather than (or) power for all the abilities above)

### Screenshots/Videos
- N/A

## How to test the changes?
- Run the "dry_skin" test suite. Reverse either change in ability.ts or pokemon.ts and observe respective failures in the "during sunlight, lose 1/8 of maximum health at the end of each turn" and "opposing fire attacks do 25% more damage" test cases.
- The bugs in the other abilities can be observed using overrides.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [No] Are the changes visual?
  - [N/A] Have I provided screenshots/videos of the changes?