### PR TITLE
[Localization] Fixed typo in infatuation message

### DIFF
--- a/src/locales/fr/battle.ts
+++ b/src/locales/fr/battle.ts
@@ -87,7 +87,7 @@ export const battle: SimpleTranslationEntries = {
   "battlerTagsDestinyBondLapse": "{{pokemonNameWithAffix}} entraine\n{{pokemonNameWithAffix2}} dans sa chute !",
   "battlerTagsInfatuatedOnAdd": "{{pokemonNameWithAffix}} est amoureux\nde {{sourcePokemonName}} !",
   "battlerTagsInfatuatedOnOverlap": "{{pokemonNameWithAffix}} est\ndéjà amoureux !",
-  "battlerTagsInfatuatedLapse": "{{pokemonNameWithAffix}}] est amoureux\nde {{sourcePokemonName}} !",
+  "battlerTagsInfatuatedLapse": "{{pokemonNameWithAffix}} est amoureux\nde {{sourcePokemonName}} !",
   "battlerTagsInfatuatedLapseImmobilize": "L’amour empêche {{pokemonNameWithAffix}}\nd’agir !",
   "battlerTagsInfatuatedOnRemove": "{{pokemonNameWithAffix}}\nn’est plus amoureux !",
   "battlerTagsSeededOnAdd": "{{pokemonNameWithAffix}} est infecté !",


### PR DESCRIPTION
## What are the changes?
There is an extra '[' in the french message when your pokemon is infatuated

## What did change?
One line of localized text


## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?