### PR TITLE
[Ability] Adjust damage taken by disguise

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -333,7 +333,7 @@ export class PreDefendMoveDamageToOneAbAttr extends ReceivedMoveDamageMultiplier
 
   applyPreDefend(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): boolean {
     if (this.condition(pokemon, attacker, move)) {
-      (args[0] as Utils.NumberHolder).value = 1;
+      (args[0] as Utils.NumberHolder).value = Math.floor(pokemon.getMaxHp() / 8);
       return true;
     }
 

--- a/src/test/abilities/disguise.test.ts
+++ b/src/test/abilities/disguise.test.ts
@@ -64,4 +64,35 @@ describe("Abilities - DISGUISE", () => {
     },
     TIMEOUT
   );
+
+  test(
+    "damage taken should be equal to 1/8 of its maximum HP, rounded down",
+    async () => {
+      const baseForm = 0,
+        bustedForm = 1;
+
+      vi.spyOn(Overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.DARK_PULSE, Moves.DARK_PULSE, Moves.DARK_PULSE, Moves.DARK_PULSE]);
+      vi.spyOn(Overrides, "STARTING_LEVEL_OVERRIDE", "get").mockReturnValue(20);
+      vi.spyOn(Overrides, "OPP_LEVEL_OVERRIDE", "get").mockReturnValue(20);
+      vi.spyOn(Overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.MAGIKARP);
+      vi.spyOn(Overrides, "STARTER_FORM_OVERRIDES", "get").mockReturnValue({
+        [Species.MIMIKYU]: baseForm,
+      });
+
+      await game.startBattle([Species.MIMIKYU]);
+
+      const mimikyu = game.scene.getPlayerPokemon();
+      const damage = (Math.floor(mimikyu.getMaxHp()/8));
+
+      expect(mimikyu).not.toBe(undefined);
+      expect(mimikyu.formIndex).toBe(baseForm);
+
+      game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
+      await game.phaseInterceptor.to(TurnEndPhase);
+
+      expect(mimikyu.formIndex).toBe(bustedForm);
+      expect(game.scene.getEnemyPokemon().turnData.currDamageDealt).toBe(damage);
+    },
+    TIMEOUT
+  );
 });


### PR DESCRIPTION
## What are the changes?
- adjusts the damage taken by disguise from flat 1 damage to 1/8 of user's max hp

## Why am I doing these changes?
- damage taken is now consistent to [bulba](https://bulbapedia.bulbagarden.net/wiki/Disguise_(Ability))

## What did change?
- damage taken by disguise

### Screenshots/Videos
<img width="580" alt="Screenshot 2024-06-26 at 3 28 14 AM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/ce5cea14-42cb-4e40-bc22-78700f56825f">


## How to test the changes?
`$ npm run test disguise`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?