### PR TITLE
Fix 2 typos in Cyrus and Lucian en dialogue

### DIFF
--- a/src/locales/en/dialogue.ts
+++ b/src/locales/en/dialogue.ts
@@ -499,7 +499,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
   },
   "galactic_boss_cyrus_1": {
     "encounter": {
-      1: "You were compelled to come here by such vacuous sentimentality\nI will make you regret paying heed to your heart!"
+      1: "You were compelled to come here by such vacuous sentimentality.\nI will make you regret paying heed to your heart!"
     },
     "victory": {
       1: "Interesting. And quite curious."
@@ -1641,7 +1641,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
       1: `Just a moment, please. The book I'm reading has nearly reached its thrilling climax… 
                 $The hero has obtained a mystic sword and is about to face their final trial… Ah, never mind. 
                 $Since you've made it this far, I'll put that aside and battle you. 
-                $Let me see if you'll achieve as much glory as the hero of my book!,`
+                $Let me see if you'll achieve as much glory as the hero of my book!`
     },
     "victory": {
       1: "I see… It appears you've put me in checkmate."


### PR DESCRIPTION
## What are the changes?
Added a period to Cyrus1's dialogue. Removed a comma form Lucian's dialogue.

## Why am I doing these changes?
They are now grammatically correct

## What did change?
Fixes

### Screenshots/Videos
Before: https://github.com/pagefaultgames/pokerogue/issues/2609
![](https://private-user-images.githubusercontent.com/56032555/342968841-d94dd62b-a094-40cc-b720-b74609820d81.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTkzNzA2MjMsIm5iZiI6MTcxOTM3MDMyMywicGF0aCI6Ii81NjAzMjU1NS8zNDI5Njg4NDEtZDk0ZGQ2MmItYTA5NC00MGNjLWI3MjAtYjc0NjA5ODIwZDgxLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA2MjYlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNjI2VDAyNTIwM1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTgwYjU2Y2I4YTI2MzZlM2Q2MmUyOWFlNWE5Y2VhYWIxNzA3MTJlNzFmY2IwMGI1MTM2MTM5OTFhZjRmYTExMDgmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.9kp2-Dvo1WT2tfsEtjj3-jJ9dYjprg8Twdl8855f48w)

After
![](https://cdn.discordapp.com/attachments/1241250945120206890/1255358406257021019/image.png?ex=667cd71f&is=667b859f&hm=0f2be023646288ce0350d7235f19f9dc2a346d15ea939811b0225b80b3c4caed&)

## How to test the changes?
Pull and test

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?