### PR TITLE
[Bug] Fix issue with refreshing changing trainer boss HP bars

### DIFF
--- a/src/data/trainer-config.ts
+++ b/src/data/trainer-config.ts
@@ -1460,12 +1460,12 @@ export const trainerConfigs: TrainerConfigs = {
     }),
   [TrainerType.RIVAL_5]: new TrainerConfig(++t).setName("Finn").setHasGenders("Ivy").setHasCharSprite().setTitle("Rival").setBoss().setStaticParty().setMoneyMultiplier(2.25).setEncounterBgm(TrainerType.RIVAL).setBattleBgm("battle_rival_3").setMixedBattleBgm("battle_rival_3").setPartyTemplates(trainerPartyTemplates.RIVAL_5)
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([Species.VENUSAUR, Species.CHARIZARD, Species.BLASTOISE, Species.MEGANIUM, Species.TYPHLOSION, Species.FERALIGATR, Species.SCEPTILE, Species.BLAZIKEN, Species.SWAMPERT, Species.TORTERRA, Species.INFERNAPE, Species.EMPOLEON, Species.SERPERIOR, Species.EMBOAR, Species.SAMUROTT, Species.CHESNAUGHT, Species.DELPHOX, Species.GRENINJA, Species.DECIDUEYE, Species.INCINEROAR, Species.PRIMARINA, Species.RILLABOOM, Species.CINDERACE, Species.INTELEON, Species.MEOWSCARADA, Species.SKELEDIRGE, Species.QUAQUAVAL], TrainerSlot.TRAINER, true,
-      p => p.setBoss(true, 2)))
+      p => p.setBoss()))
     .setPartyMemberFunc(1, getRandomPartyMemberFunc([Species.PIDGEOT, Species.NOCTOWL, Species.SWELLOW, Species.STARAPTOR, Species.UNFEZANT, Species.TALONFLAME, Species.TOUCANNON, Species.CORVIKNIGHT, Species.KILOWATTREL], TrainerSlot.TRAINER, true))
     .setPartyMemberFunc(2, getSpeciesFilterRandomPartyMemberFunc((species: PokemonSpecies) => !pokemonEvolutions.hasOwnProperty(species.speciesId) && !pokemonPrevolutions.hasOwnProperty(species.speciesId) && species.baseTotal >= 450))
     .setSpeciesFilter(species => species.baseTotal >= 540)
     .setPartyMemberFunc(5, getRandomPartyMemberFunc([Species.RAYQUAZA], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 3);
+      p.setBoss();
       p.pokeball = PokeballType.MASTER_BALL;
       p.shiny = true;
       p.variant = 1;
@@ -1477,12 +1477,12 @@ export const trainerConfigs: TrainerConfigs = {
   [TrainerType.RIVAL_6]: new TrainerConfig(++t).setName("Finn").setHasGenders("Ivy").setHasCharSprite().setTitle("Rival").setBoss().setStaticParty().setMoneyMultiplier(3).setEncounterBgm("final").setBattleBgm("battle_rival_3").setMixedBattleBgm("battle_rival_3").setPartyTemplates(trainerPartyTemplates.RIVAL_6)
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([Species.VENUSAUR, Species.CHARIZARD, Species.BLASTOISE, Species.MEGANIUM, Species.TYPHLOSION, Species.FERALIGATR, Species.SCEPTILE, Species.BLAZIKEN, Species.SWAMPERT, Species.TORTERRA, Species.INFERNAPE, Species.EMPOLEON, Species.SERPERIOR, Species.EMBOAR, Species.SAMUROTT, Species.CHESNAUGHT, Species.DELPHOX, Species.GRENINJA, Species.DECIDUEYE, Species.INCINEROAR, Species.PRIMARINA, Species.RILLABOOM, Species.CINDERACE, Species.INTELEON, Species.MEOWSCARADA, Species.SKELEDIRGE, Species.QUAQUAVAL], TrainerSlot.TRAINER, true,
       p => {
-        p.setBoss(true, 3);
+        p.setBoss();
         p.generateAndPopulateMoveset();
       }))
     .setPartyMemberFunc(1, getRandomPartyMemberFunc([Species.PIDGEOT, Species.NOCTOWL, Species.SWELLOW, Species.STARAPTOR, Species.UNFEZANT, Species.TALONFLAME, Species.TOUCANNON, Species.CORVIKNIGHT, Species.KILOWATTREL], TrainerSlot.TRAINER, true,
       p => {
-        p.setBoss(true, 2);
+        p.setBoss();
         p.generateAndPopulateMoveset();
       }))
     .setPartyMemberFunc(2, getSpeciesFilterRandomPartyMemberFunc((species: PokemonSpecies) => !pokemonEvolutions.hasOwnProperty(species.speciesId) && !pokemonPrevolutions.hasOwnProperty(species.speciesId) && species.baseTotal >= 450))
@@ -1507,28 +1507,28 @@ export const trainerConfigs: TrainerConfigs = {
     .setPartyMemberFunc(3, getRandomPartyMemberFunc([ Species.DUGTRIO, Species.ALOLA_DUGTRIO ]))
     .setPartyMemberFunc(4, getRandomPartyMemberFunc([ Species.MAROWAK , Species.ALOLA_MAROWAK]))
     .setPartyMemberFunc(5, getRandomPartyMemberFunc([ Species.KANGASKHAN ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.ULTRA_BALL;
       p.formIndex = 1;
     })),
   [TrainerType.ROCKET_BOSS_GIOVANNI_2]: new TrainerConfig(++t).setName("Giovanni").initForEvilTeamLeader("Rocket Boss", [], true).setMixedBattleBgm("battle_rocket_boss").setVictoryBgm("victory_team_plasma")
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([ Species.TYRANITAR , Species.IRON_THORNS], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.ULTRA_BALL;
     }))
     .setPartyMemberFunc(1, getRandomPartyMemberFunc([ Species.HIPPOWDON ]))
     .setPartyMemberFunc(2, getRandomPartyMemberFunc([ Species.EXCADRILL ]))
     .setPartyMemberFunc(3, getRandomPartyMemberFunc([ Species.KANGASKHAN ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.ULTRA_BALL;
       p.formIndex = 1;
     }))
     .setPartyMemberFunc(4, getRandomPartyMemberFunc([ Species.GASTRODON]))
     .setPartyMemberFunc(5, getRandomPartyMemberFunc([ Species.MEWTWO ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.MASTER_BALL;
     })),
@@ -1539,14 +1539,14 @@ export const trainerConfigs: TrainerConfigs = {
     .setPartyMemberFunc(3, getRandomPartyMemberFunc([ Species.MAGMORTAR, Species.TORKOAL ]))
     .setPartyMemberFunc(4, getRandomPartyMemberFunc([ Species.FLYGON]))
     .setPartyMemberFunc(5, getRandomPartyMemberFunc([ Species.CAMERUPT ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.ULTRA_BALL;
       p.formIndex = 1;
     })),
   [TrainerType.MAXIE_2]: new TrainerConfig(++t).setName("Maxie").initForEvilTeamLeader("Magma Boss",[], true).setMixedBattleBgm("battle_aqua_magma_boss").setVictoryBgm("victory_team_plasma")
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([ Species.SOLROCK, Species.TYPHLOSION ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.ULTRA_BALL;
     }))
@@ -1560,13 +1560,13 @@ export const trainerConfigs: TrainerConfigs = {
     }))
     .setPartyMemberFunc(3, getRandomPartyMemberFunc([ Species.GREAT_TUSK ]))
     .setPartyMemberFunc(4, getRandomPartyMemberFunc([ Species.CAMERUPT ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.ULTRA_BALL;
       p.formIndex = 1;
     }))
     .setPartyMemberFunc(5, getRandomPartyMemberFunc([ Species.GROUDON ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.MASTER_BALL;
     })),
@@ -1577,14 +1577,14 @@ export const trainerConfigs: TrainerConfigs = {
     .setPartyMemberFunc(3, getRandomPartyMemberFunc([ Species.TENTACRUEL ]))
     .setPartyMemberFunc(4, getRandomPartyMemberFunc([ Species.RELICANTH, Species.WAILORD ]))
     .setPartyMemberFunc(5, getRandomPartyMemberFunc([ Species.SHARPEDO ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.ULTRA_BALL;
       p.formIndex = 1;
     })),
   [TrainerType.ARCHIE_2]: new TrainerConfig(++t).setName("Archie").initForEvilTeamLeader("Aqua Boss",[], true).setMixedBattleBgm("battle_aqua_magma_boss").setVictoryBgm("victory_team_plasma")
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([ Species.KINGDRA, Species.LUDICOLO ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.ULTRA_BALL;
     }))
@@ -1601,13 +1601,13 @@ export const trainerConfigs: TrainerConfigs = {
       p.abilityIndex = 0; // Swift Swim
     }))
     .setPartyMemberFunc(4, getRandomPartyMemberFunc([ Species.SHARPEDO ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.ULTRA_BALL;
       p.formIndex = 1;
     }))
     .setPartyMemberFunc(5, getRandomPartyMemberFunc([ Species.KYOGRE ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.MASTER_BALL;
     })),
@@ -1622,13 +1622,13 @@ export const trainerConfigs: TrainerConfigs = {
       p.formIndex = 1;
     }))
     .setPartyMemberFunc(5, getRandomPartyMemberFunc([ Species.WEAVILE ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.ULTRA_BALL;
     })),
   [TrainerType.CYRUS_2]: new TrainerConfig(++t).setName("Cyrus").initForEvilTeamLeader("Galactic Boss",[], true).setMixedBattleBgm("battle_galactic_boss").setVictoryBgm("victory_team_plasma")
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([ Species.AZELF, Species.UXIE, Species.MESPRIT ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
     }))
     .setPartyMemberFunc(1, getRandomPartyMemberFunc([ Species.ELECTRODE, Species.HISUI_ELECTRODE ]))
@@ -1639,12 +1639,12 @@ export const trainerConfigs: TrainerConfigs = {
       p.formIndex = 1;
     }))
     .setPartyMemberFunc(4, getRandomPartyMemberFunc([ Species.WEAVILE ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.ULTRA_BALL;
     }))
     .setPartyMemberFunc(5, getRandomPartyMemberFunc([ Species.DARKRAI ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.MASTER_BALL;
     })),
@@ -1655,13 +1655,13 @@ export const trainerConfigs: TrainerConfigs = {
     .setPartyMemberFunc(3, getRandomPartyMemberFunc([ Species.EELEKTROSS, Species.GALVANTULA ]))
     .setPartyMemberFunc(4, getRandomPartyMemberFunc([ Species.VOLCARONA ]))
     .setPartyMemberFunc(5, getRandomPartyMemberFunc([ Species.HYDREIGON ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.ULTRA_BALL;
     })),
   [TrainerType.GHETSIS_2]: new TrainerConfig(++t).setName("Ghetsis").initForEvilTeamLeader("Plasma Boss",[], true).setMixedBattleBgm("battle_plasma_boss").setVictoryBgm("victory_team_plasma")
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([ Species.SLITHER_WING, Species.IRON_MOTH ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.ULTRA_BALL;
     }))
@@ -1669,12 +1669,12 @@ export const trainerConfigs: TrainerConfigs = {
     .setPartyMemberFunc(2, getRandomPartyMemberFunc([ Species.DARMANITAN, Species.GALAR_DARMANITAN ]))
     .setPartyMemberFunc(3, getRandomPartyMemberFunc([ Species.KINGAMBIT ]))
     .setPartyMemberFunc(4, getRandomPartyMemberFunc([ Species.HYDREIGON, Species.IRON_JUGULIS ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.ULTRA_BALL;
     }))
     .setPartyMemberFunc(5, getRandomPartyMemberFunc([ Species.KYUREM ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.MASTER_BALL;
     })),
@@ -1685,14 +1685,14 @@ export const trainerConfigs: TrainerConfigs = {
     .setPartyMemberFunc(3, getRandomPartyMemberFunc([ Species.MILOTIC ]))
     .setPartyMemberFunc(4, getRandomPartyMemberFunc([ Species.HELIOLISK ]))
     .setPartyMemberFunc(5, getRandomPartyMemberFunc([ Species.GYARADOS ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.ULTRA_BALL;
       p.formIndex = 1;
     })),
   [TrainerType.LYSANDRE_2]: new TrainerConfig(++t).setName("Lysandre").initForEvilTeamLeader("Flare Boss",[], true).setMixedBattleBgm("battle_flare_boss").setVictoryBgm("victory_team_plasma")
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([ Species.SCREAM_TAIL, Species.FLUTTER_MANE ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.ULTRA_BALL;
     }))
@@ -1700,13 +1700,13 @@ export const trainerConfigs: TrainerConfigs = {
     .setPartyMemberFunc(2, getRandomPartyMemberFunc([ Species.PYROAR ]))
     .setPartyMemberFunc(3, getRandomPartyMemberFunc([ Species.GOODRA, Species.HISUI_GOODRA ]))
     .setPartyMemberFunc(4, getRandomPartyMemberFunc([ Species.GYARADOS ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.ULTRA_BALL;
       p.formIndex = 1;
     }))
     .setPartyMemberFunc(5, getRandomPartyMemberFunc([ Species.YVELTAL ], TrainerSlot.TRAINER, true, p => {
-      p.setBoss(true, 2);
+      p.setBoss();
       p.generateAndPopulateMoveset();
       p.pokeball = PokeballType.MASTER_BALL;
     })),

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3433,10 +3433,54 @@ export class EnemyPokemon extends Pokemon {
     }
   }
 
+  /**
+   * Sets the boss HP bars to persist through refresh/retry for classic mode
+   * 4: 195 Mega Rayquaza
+   * 3: 145 Rayquaza, 195 Starter
+   * 2: all else (195 rival bird, all evil team bosses)
+   */
+  setBossForClassic(): void {
+    const waveIndex = this.scene.currentBattle.waveIndex;
+    const rivalStarters = [Species.VENUSAUR, Species.CHARIZARD, Species.BLASTOISE,
+      Species.MEGANIUM, Species.TYPHLOSION, Species.FERALIGATR,
+      Species.SCEPTILE, Species.BLAZIKEN, Species.SWAMPERT,
+      Species.TORTERRA, Species.INFERNAPE, Species.EMPOLEON,
+      Species.SERPERIOR, Species.EMBOAR, Species.SAMUROTT,
+      Species.CHESNAUGHT, Species.DELPHOX, Species.GRENINJA,
+      Species.DECIDUEYE, Species.INCINEROAR, Species.PRIMARINA,
+      Species.RILLABOOM, Species.CINDERACE, Species.INTELEON,
+      Species.MEOWSCARADA, Species.SKELEDIRGE, Species.QUAQUAVAL];
+    let bossSegments = 2;
+    if ((waveIndex === 145 && this.species.speciesId === Species.RAYQUAZA)
+        || (waveIndex === 195 && rivalStarters.includes(this.species.speciesId))) {
+      bossSegments = 3;
+    }
+    if (waveIndex === 195 && this.species.speciesId === Species.RAYQUAZA) {
+      bossSegments = 4;
+    }
+    this.bossSegments = bossSegments;
+    this.bossSegmentIndex = bossSegments - 1;
+  }
+
+  /**
+   * Sets boss HP segments
+   * @param boss whether or not the Pokemon is a boss
+   * @param bossSegments how many boss segments the Pokemon should have
+   */
   setBoss(boss: boolean = true, bossSegments: integer = 0): void {
     if (boss) {
-      this.bossSegments = bossSegments || this.scene.getEncounterBossSegments(this.scene.currentBattle.waveIndex, this.level, this.species, true);
-      this.bossSegmentIndex = this.bossSegments - 1;
+      /**
+       * bossSegments is not saved in the Pokemon savedata so it will be set to 0
+       * whenever a refresh or retry is done. This means that classic trainers with
+       * boss Pokemon will have their HP bar segments recalculated and usually end up
+       * higher than the intended number
+       */
+      if (this.scene.gameMode.isClassic) {
+        this.setBossForClassic();
+      } else {
+        this.bossSegments = bossSegments || this.scene.getEncounterBossSegments(this.scene.currentBattle.waveIndex, this.level, this.species, true);
+        this.bossSegmentIndex = this.bossSegments - 1;
+      }
     } else {
       this.bossSegments = 0;
       this.bossSegmentIndex = 0;


### PR DESCRIPTION
## What are the changes?
Fixes the bug where refreshing or retrying on a trainer with boss Pokemon would result in their hp bars changing

## Why am I doing these changes?
See https://github.com/pagefaultgames/pokerogue/issues/1697 for more discussion

More of an issue now since evil team bosses are in and refreshing on them will result in their legendary going from 2->4 bars which is a big difference.

This is the simplest (though pretty ugly) fix

## What did change?
Created a new hardcoded function `setBossForClassic` that will correctly set the boss hp bar to the same no matter what

### Screenshots/Videos
Before:
![](https://cdn.discordapp.com/attachments/1241164581997510656/1255363322933547028/image.png?ex=667cdbb3&is=667b8a33&hm=d711af5c5b2f4b0e7e0f7d486c5487bcd368be0d1f8a0b9519c1ef97f2d66087&)
![](https://cdn.discordapp.com/attachments/1241164581997510656/1255363668590465066/image.png?ex=667cdc06&is=667b8a86&hm=b8ac4945967b154641fb16f96289142ea9c31bc6dba042a26d616582e6c6fde8&)

After:
![](https://cdn.discordapp.com/attachments/1241164581997510656/1255372864782340177/image.png?ex=667ce496&is=667b9316&hm=2596af97d733b7b1a739cc71785ddf7bb7c00d1b1b5f4f6b6f45917d12085138&)

## How to test the changes?
Pull and override to 145/165/195

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?