### PR TITLE
Fix boss-segment reload issue

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3385,7 +3385,7 @@ export class EnemyPokemon extends Pokemon {
 
     this.trainerSlot = trainerSlot;
     if (boss) {
-      this.setBoss();
+      this.setBoss(boss, dataSource?.bossSegments);
     }
 
     if (Overrides.OPP_STATUS_OVERRIDE) {

--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -50,6 +50,7 @@ export default class PokemonData {
   public fusionLuck: integer;
 
   public boss: boolean;
+  public bossSegments?: integer;
 
   public summonData: PokemonSummonData;
 
@@ -96,6 +97,7 @@ export default class PokemonData {
 
     if (!forHistory) {
       this.boss = (source instanceof EnemyPokemon && !!source.bossSegments) || (!this.player && !!source.boss);
+      this.bossSegments = source.bossSegments;
     }
 
     if (sourcePokemon) {


### PR DESCRIPTION
add boss-segments to into pokemon-data & load it in EnemyPokemon constructor

<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->

I've added the boss segments number to the pokemon-data to persist it throughout reloads

fixes #1697

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

Previously (as described here: https://github.com/pagefaultgames/pokerogue/issues/1697#issuecomment-2189151817) the boss segments were inconsistent with hard-coded trainers. This should fix it

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

persisting the segments into the pokemon-data object (which is saved to the session)

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->


https://github.com/pagefaultgames/pokerogue/assets/50131232/da15b8ef-48f1-4770-aa23-985d66420e56


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

overrides.ts
```ts
export const STARTING_WAVE_OVERRIDE: integer = 145;
```
- Start a new game
- count the boss sections on the first trainer pokemon
- reload
- continue
- check again -> Should be still 2

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
       - **The failing test is a known and not my fault!**
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?