### PR TITLE
[Enhancement][QoL] Add option to adjust shop overlay opacity

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -222,6 +222,8 @@ export default class BattleScene extends SceneBase {
 
   private fieldOverlay: Phaser.GameObjects.Rectangle;
   private shopOverlay: Phaser.GameObjects.Rectangle;
+  private shopOverlayOpacity: number = .80;
+
   public modifiers: PersistentModifier[];
   private enemyModifiers: PersistentModifier[];
   public uiContainer: Phaser.GameObjects.Container;
@@ -1421,13 +1423,21 @@ export default class BattleScene extends SceneBase {
     });
   }
 
+  updateShopOverlayOpacity(value: number): void {
+    this.shopOverlayOpacity = value;
+
+    if (this.shopOverlay) {
+      this.shopOverlay.setAlpha(this.shopOverlayOpacity);
+    }
+  }
+
   showShopOverlay(duration: integer): Promise<void> {
     return new Promise(resolve => {
       this.tweens.add({
         targets: this.shopOverlay,
-        alpha: 0.8,
+        alpha: this.shopOverlayOpacity,
         ease: "Sine.easeOut",
-        duration: duration,
+        duration,
         onComplete: () => resolve()
       });
     });

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -222,6 +222,7 @@ export default class BattleScene extends SceneBase {
 
   private fieldOverlay: Phaser.GameObjects.Rectangle;
   private shopOverlay: Phaser.GameObjects.Rectangle;
+  private shopOverlayShown: boolean = false;
   private shopOverlayOpacity: number = .80;
 
   public modifiers: PersistentModifier[];
@@ -1426,12 +1427,13 @@ export default class BattleScene extends SceneBase {
   updateShopOverlayOpacity(value: number): void {
     this.shopOverlayOpacity = value;
 
-    if (this.shopOverlay) {
+    if (this.shopOverlayShown) {
       this.shopOverlay.setAlpha(this.shopOverlayOpacity);
     }
   }
 
   showShopOverlay(duration: integer): Promise<void> {
+    this.shopOverlayShown = true;
     return new Promise(resolve => {
       this.tweens.add({
         targets: this.shopOverlay,
@@ -1444,6 +1446,7 @@ export default class BattleScene extends SceneBase {
   }
 
   hideShopOverlay(duration: integer): Promise<void> {
+    this.shopOverlayShown = false;
     return new Promise(resolve => {
       this.tweens.add({
         targets: this.shopOverlay,

--- a/src/locales/de/settings.ts
+++ b/src/locales/de/settings.ts
@@ -96,4 +96,6 @@ export const settings: SimpleTranslationEntries = {
   "controller": "Controller",
   "gamepadSupport": "Controllerunterstützung",
   "showBgmBar": "Musiknamen anzeigen",
+  "none": "None",
+  "shopOverlayOpacity": "Shop Overlay Opacity"
 } as const;

--- a/src/locales/de/settings.ts
+++ b/src/locales/de/settings.ts
@@ -96,6 +96,5 @@ export const settings: SimpleTranslationEntries = {
   "controller": "Controller",
   "gamepadSupport": "Controllerunterstützung",
   "showBgmBar": "Musiknamen anzeigen",
-  "none": "None",
   "shopOverlayOpacity": "Shop Overlay Opacity"
 } as const;

--- a/src/locales/en/dialogue.ts
+++ b/src/locales/en/dialogue.ts
@@ -499,7 +499,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
   },
   "galactic_boss_cyrus_1": {
     "encounter": {
-      1: "You were compelled to come here by such vacuous sentimentality\nI will make you regret paying heed to your heart!"
+      1: "You were compelled to come here by such vacuous sentimentality.\nI will make you regret paying heed to your heart!"
     },
     "victory": {
       1: "Interesting. And quite curious."
@@ -1641,7 +1641,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
       1: `Just a moment, please. The book I'm reading has nearly reached its thrilling climax… 
                 $The hero has obtained a mystic sword and is about to face their final trial… Ah, never mind. 
                 $Since you've made it this far, I'll put that aside and battle you. 
-                $Let me see if you'll achieve as much glory as the hero of my book!,`
+                $Let me see if you'll achieve as much glory as the hero of my book!`
     },
     "victory": {
       1: "I see… It appears you've put me in checkmate."

--- a/src/locales/en/settings.ts
+++ b/src/locales/en/settings.ts
@@ -96,4 +96,6 @@ export const settings: SimpleTranslationEntries = {
   "controller": "Controller",
   "gamepadSupport": "Gamepad Support",
   "showBgmBar": "Show Music Names",
+  "none": "None",
+  "shopOverlayOpacity": "Shop Overlay Opacity"
 } as const;

--- a/src/locales/en/settings.ts
+++ b/src/locales/en/settings.ts
@@ -96,6 +96,5 @@ export const settings: SimpleTranslationEntries = {
   "controller": "Controller",
   "gamepadSupport": "Gamepad Support",
   "showBgmBar": "Show Music Names",
-  "none": "None",
   "shopOverlayOpacity": "Shop Overlay Opacity"
 } as const;

--- a/src/locales/es/settings.ts
+++ b/src/locales/es/settings.ts
@@ -96,5 +96,5 @@ export const settings: SimpleTranslationEntries = {
   "controller": "Controller",
   "gamepadSupport": "Gamepad Support",
   "showBgmBar": "Show Music Names",
-  "shopOverlayOpacity": "Shop Overlay Opacity"
+  "shopOverlayOpacity": "Opacidad de la fase de compra"
 } as const;

--- a/src/locales/es/settings.ts
+++ b/src/locales/es/settings.ts
@@ -96,4 +96,6 @@ export const settings: SimpleTranslationEntries = {
   "controller": "Controller",
   "gamepadSupport": "Gamepad Support",
   "showBgmBar": "Show Music Names",
+  "none": "None",
+  "shopOverlayOpacity": "Shop Overlay Opacity"
 } as const;

--- a/src/locales/es/settings.ts
+++ b/src/locales/es/settings.ts
@@ -96,6 +96,5 @@ export const settings: SimpleTranslationEntries = {
   "controller": "Controller",
   "gamepadSupport": "Gamepad Support",
   "showBgmBar": "Show Music Names",
-  "none": "None",
   "shopOverlayOpacity": "Shop Overlay Opacity"
 } as const;

--- a/src/locales/fr/settings.ts
+++ b/src/locales/fr/settings.ts
@@ -95,7 +95,7 @@ export const settings: SimpleTranslationEntries = {
   "mute": "Muet",
   "controller": "Controller",
   "gamepadSupport": "Gamepad Support",
-  "showBgmBar": "Montrer titre de la musique",
+  "showBgmBar": "Titre de la musique",
   "none": "Aucune",
   "shopOverlayOpacity": "Opacité boutique"
 } as const;

--- a/src/locales/fr/settings.ts
+++ b/src/locales/fr/settings.ts
@@ -96,6 +96,5 @@ export const settings: SimpleTranslationEntries = {
   "controller": "Controller",
   "gamepadSupport": "Gamepad Support",
   "showBgmBar": "Titre de la musique",
-  "none": "Aucune",
   "shopOverlayOpacity": "Opacité boutique"
 } as const;

--- a/src/locales/fr/settings.ts
+++ b/src/locales/fr/settings.ts
@@ -96,4 +96,6 @@ export const settings: SimpleTranslationEntries = {
   "controller": "Controller",
   "gamepadSupport": "Gamepad Support",
   "showBgmBar": "Montrer titre de la musique",
+  "none": "None",
+  "shopOverlayOpacity": "Shop Overlay Opacity"
 } as const;

--- a/src/locales/fr/settings.ts
+++ b/src/locales/fr/settings.ts
@@ -96,6 +96,6 @@ export const settings: SimpleTranslationEntries = {
   "controller": "Controller",
   "gamepadSupport": "Gamepad Support",
   "showBgmBar": "Montrer titre de la musique",
-  "none": "None",
-  "shopOverlayOpacity": "Shop Overlay Opacity"
+  "none": "Aucune",
+  "shopOverlayOpacity": "Opacité boutique"
 } as const;

--- a/src/locales/it/settings.ts
+++ b/src/locales/it/settings.ts
@@ -96,4 +96,6 @@ export const settings: SimpleTranslationEntries = {
   "controller": "Controller",
   "gamepadSupport": "Gamepad Support",
   "showBgmBar": "Show Music Names",
+  "none": "None",
+  "shopOverlayOpacity": "Shop Overlay Opacity"
 } as const;

--- a/src/locales/it/settings.ts
+++ b/src/locales/it/settings.ts
@@ -96,6 +96,5 @@ export const settings: SimpleTranslationEntries = {
   "controller": "Controller",
   "gamepadSupport": "Gamepad Support",
   "showBgmBar": "Show Music Names",
-  "none": "None",
   "shopOverlayOpacity": "Shop Overlay Opacity"
 } as const;

--- a/src/locales/ko/settings.ts
+++ b/src/locales/ko/settings.ts
@@ -96,4 +96,6 @@ export const settings: SimpleTranslationEntries = {
   "controller": "컨트롤러",
   "gamepadSupport": "게임패드 지원",
   "showBgmBar": "BGM 제목 보여주기",
+  "none": "None",
+  "shopOverlayOpacity": "Shop Overlay Opacity"
 } as const;

--- a/src/locales/ko/settings.ts
+++ b/src/locales/ko/settings.ts
@@ -96,5 +96,5 @@ export const settings: SimpleTranslationEntries = {
   "controller": "컨트롤러",
   "gamepadSupport": "게임패드 지원",
   "showBgmBar": "BGM 제목 보여주기",
-  "shopOverlayOpacity": "Shop Overlay Opacity"
+  "shopOverlayOpacity": "상점 오버레이 투명도"
 } as const;

--- a/src/locales/ko/settings.ts
+++ b/src/locales/ko/settings.ts
@@ -96,6 +96,5 @@ export const settings: SimpleTranslationEntries = {
   "controller": "컨트롤러",
   "gamepadSupport": "게임패드 지원",
   "showBgmBar": "BGM 제목 보여주기",
-  "none": "None",
   "shopOverlayOpacity": "Shop Overlay Opacity"
 } as const;

--- a/src/locales/pt_BR/settings.ts
+++ b/src/locales/pt_BR/settings.ts
@@ -96,5 +96,5 @@ export const settings: SimpleTranslationEntries = {
   "controller": "Controle",
   "gamepadSupport": "Suporte para Controle",
   "showBgmBar": "Show Music Names",
-  "shopOverlayOpacity": "Shop Overlay Opacity"
+  "shopOverlayOpacity": "Opacidade da Loja"
 } as const;

--- a/src/locales/pt_BR/settings.ts
+++ b/src/locales/pt_BR/settings.ts
@@ -96,6 +96,5 @@ export const settings: SimpleTranslationEntries = {
   "controller": "Controle",
   "gamepadSupport": "Suporte para Controle",
   "showBgmBar": "Show Music Names",
-  "none": "None",
   "shopOverlayOpacity": "Shop Overlay Opacity"
 } as const;

--- a/src/locales/pt_BR/settings.ts
+++ b/src/locales/pt_BR/settings.ts
@@ -96,4 +96,6 @@ export const settings: SimpleTranslationEntries = {
   "controller": "Controle",
   "gamepadSupport": "Suporte para Controle",
   "showBgmBar": "Show Music Names",
+  "none": "None",
+  "shopOverlayOpacity": "Shop Overlay Opacity"
 } as const;

--- a/src/locales/zh_CN/settings.ts
+++ b/src/locales/zh_CN/settings.ts
@@ -96,4 +96,6 @@ export const settings: SimpleTranslationEntries = {
   "controller": "控制器",
   "gamepadSupport": "手柄支持",
   "showBgmBar": "显示音乐名称",
+  "none": "None",
+  "shopOverlayOpacity": "Shop Overlay Opacity"
 } as const;

--- a/src/locales/zh_CN/settings.ts
+++ b/src/locales/zh_CN/settings.ts
@@ -96,6 +96,6 @@ export const settings: SimpleTranslationEntries = {
   "controller": "控制器",
   "gamepadSupport": "手柄支持",
   "showBgmBar": "显示音乐名称",
-  "none": "None",
-  "shopOverlayOpacity": "Shop Overlay Opacity"
+  "none": "无",
+  "shopOverlayOpacity": "商店显示不透明度"
 } as const;

--- a/src/locales/zh_CN/settings.ts
+++ b/src/locales/zh_CN/settings.ts
@@ -96,6 +96,5 @@ export const settings: SimpleTranslationEntries = {
   "controller": "控制器",
   "gamepadSupport": "手柄支持",
   "showBgmBar": "显示音乐名称",
-  "none": "无",
   "shopOverlayOpacity": "商店显示不透明度"
 } as const;

--- a/src/locales/zh_TW/settings.ts
+++ b/src/locales/zh_TW/settings.ts
@@ -96,4 +96,6 @@ export const settings: SimpleTranslationEntries = {
   "controller": "控制器",
   "gamepadSupport": "手柄支持",
   "showBgmBar": "Show Music Names",
+  "none": "None",
+  "shopOverlayOpacity": "Shop Overlay Opacity"
 } as const;

--- a/src/locales/zh_TW/settings.ts
+++ b/src/locales/zh_TW/settings.ts
@@ -96,6 +96,5 @@ export const settings: SimpleTranslationEntries = {
   "controller": "控制器",
   "gamepadSupport": "手柄支持",
   "showBgmBar": "Show Music Names",
-  "none": "None",
   "shopOverlayOpacity": "Shop Overlay Opacity"
 } as const;

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -547,7 +547,7 @@ export const Setting: Array<Setting> = [
     key: SettingKeys.Shop_Overlay_Opacity,
     label: i18next.t("settings:shopOverlayOpacity"),
     options: SHOP_OVERLAY_OPACITY_OPTIONS,
-    default: 4,
+    default: 8,
     type: SettingType.DISPLAY,
     requireReload: false
   },

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -16,12 +16,12 @@ const VOLUME_OPTIONS: SettingOption[] = new Array(11).fill(null).map((_, i) => i
   value: "Mute",
   label: i18next.t("settings:mute")
 });
-const SHOP_OVERLAY_OPACITY_OPTIONS: SettingOption[] = new Array(10).fill(null).map((_, i) => i ? {
-  value: (i * 10).toString(),
-  label: (i * 10).toString(),
-} : {
-  value: "None",
-  label: i18next.t("settings:none")
+const SHOP_OVERLAY_OPACITY_OPTIONS: SettingOption[] = new Array(8).fill(null).map((_, i) => {
+  const value = ((i + 2) * 10).toString();
+  return {
+    value,
+    label: value,
+  };
 });
 const OFF_ON: SettingOption[] = [
   {
@@ -547,7 +547,7 @@ export const Setting: Array<Setting> = [
     key: SettingKeys.Shop_Overlay_Opacity,
     label: i18next.t("settings:shopOverlayOpacity"),
     options: SHOP_OVERLAY_OPACITY_OPTIONS,
-    default: 8,
+    default: 6,
     type: SettingType.DISPLAY,
     requireReload: false
   },
@@ -776,8 +776,7 @@ export function setSetting(scene: BattleScene, setting: string, value: integer):
     }
     break;
   case SettingKeys.Shop_Overlay_Opacity:
-    const settingVal = parseInt(Setting[index].options[value].value);
-    scene.updateShopOverlayOpacity(Number.isNaN(settingVal) ? 0 : settingVal * .01);
+    scene.updateShopOverlayOpacity(parseInt(Setting[index].options[value].value) * .01);
     break;
   }
 

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -16,8 +16,8 @@ const VOLUME_OPTIONS: SettingOption[] = new Array(11).fill(null).map((_, i) => i
   value: "Mute",
   label: i18next.t("settings:mute")
 });
-const SHOP_OVERLAY_OPACITY_OPTIONS: SettingOption[] = new Array(8).fill(null).map((_, i) => {
-  const value = ((i + 2) * 10).toString();
+const SHOP_OVERLAY_OPACITY_OPTIONS: SettingOption[] = new Array(9).fill(null).map((_, i) => {
+  const value = ((i + 1) * 10).toString();
   return {
     value,
     label: value,
@@ -547,7 +547,7 @@ export const Setting: Array<Setting> = [
     key: SettingKeys.Shop_Overlay_Opacity,
     label: i18next.t("settings:shopOverlayOpacity"),
     options: SHOP_OVERLAY_OPACITY_OPTIONS,
-    default: 6,
+    default: 7,
     type: SettingType.DISPLAY,
     requireReload: false
   },

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -16,6 +16,13 @@ const VOLUME_OPTIONS: SettingOption[] = new Array(11).fill(null).map((_, i) => i
   value: "Mute",
   label: i18next.t("settings:mute")
 });
+const SHOP_OVERLAY_OPACITY_OPTIONS: SettingOption[] = new Array(10).fill(null).map((_, i) => i ? {
+  value: (i * 10).toString(),
+  label: (i * 10).toString(),
+} : {
+  value: "None",
+  label: "None"
+});
 const OFF_ON: SettingOption[] = [
   {
     value: "Off",
@@ -98,6 +105,7 @@ export const SettingKeys = {
   SE_Volume: "SE_VOLUME",
   Music_Preference: "MUSIC_PREFERENCE",
   Show_BGM_Bar: "SHOW_BGM_BAR",
+  Shop_Overlay_Opacity: "SHOP_OVERLAY_OPACITY"
 };
 
 /**
@@ -535,7 +543,14 @@ export const Setting: Array<Setting> = [
     type: SettingType.AUDIO,
     requireReload: true
   },
-
+  {
+    key: SettingKeys.Shop_Overlay_Opacity,
+    label: "Shop Overlay Opacity", // TODO: add localization
+    options: SHOP_OVERLAY_OPACITY_OPTIONS,
+    default: 4,
+    type: SettingType.DISPLAY,
+    requireReload: false
+  },
 ];
 
 /**
@@ -759,6 +774,10 @@ export function setSetting(scene: BattleScene, setting: string, value: integer):
         return false;
       }
     }
+    break;
+  case SettingKeys.Shop_Overlay_Opacity:
+    const settingVal = parseInt(Setting[index].options[value].value);
+    scene.updateShopOverlayOpacity(Number.isNaN(settingVal) ? 0 : settingVal * .01);
     break;
   }
 

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -21,7 +21,7 @@ const SHOP_OVERLAY_OPACITY_OPTIONS: SettingOption[] = new Array(10).fill(null).m
   label: (i * 10).toString(),
 } : {
   value: "None",
-  label: "None"
+  label: i18next.t("settings:none")
 });
 const OFF_ON: SettingOption[] = [
   {
@@ -545,7 +545,7 @@ export const Setting: Array<Setting> = [
   },
   {
     key: SettingKeys.Shop_Overlay_Opacity,
-    label: "Shop Overlay Opacity", // TODO: add localization
+    label: i18next.t("settings:shopOverlayOpacity"),
     options: SHOP_OVERLAY_OPACITY_OPTIONS,
     default: 4,
     type: SettingType.DISPLAY,


### PR DESCRIPTION
## What are the changes?
- see title
- option is only up to 90%

## Why am I doing these changes?
- some players are still not happy with how dark/light the current opacity is
- adding option instead would allow users to customize their experience

## What did change?
- new Shop Overlay Opacity setting

### Screenshots/Videos
- Menu
<img width="1306" alt="Screenshot 2024-07-11 at 11 52 25 PM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/ca0d53d7-ad7f-4046-8138-7da20a5f6b26">

- 90%
<img width="1300" alt="Screenshot 2024-07-11 at 11 48 44 PM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/b7db0111-49a4-45d5-a938-7d6dfdcf0972">

- 80% (default)
<img width="1303" alt="Screenshot 2024-07-11 at 11 46 35 PM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/c145cbb4-2624-4427-a70c-db508c94b9f7">

- 70%
<img width="1302" alt="Screenshot 2024-07-11 at 11 49 10 PM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/da5ce029-724b-4b9c-bd78-8a445480222a">

- 60%
<img width="1303" alt="Screenshot 2024-07-11 at 11 49 42 PM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/409ba169-e064-4efd-8154-d5f3b0ec1baa">

- 50%
<img width="1301" alt="Screenshot 2024-07-11 at 11 50 07 PM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/e3e4681b-0724-483f-b273-867449af4d59">

- 40%
<img width="1298" alt="Screenshot 2024-07-11 at 11 50 36 PM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/e7142e8d-b384-4a03-a72d-1db282a97100">

- 30%
<img width="1300" alt="Screenshot 2024-07-11 at 11 50 55 PM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/de5be715-6937-41da-ab41-c701914067d5">

- 20%
<img width="1300" alt="Screenshot 2024-07-11 at 11 51 19 PM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/abe15de0-4146-452f-96c1-feddca986ff4">

- 10%
<img width="1303" alt="Screenshot 2024-07-11 at 11 51 39 PM" src="https://github.com/pagefaultgames/pokerogue/assets/68144167/9da4381a-449b-435a-a083-e8efce7ece05">


## How to test the changes?
- get to shop phase
- change overlay value and check the change

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?