### PR TITLE
[QoL] Add fusion options to overrides

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -785,6 +785,10 @@ export default class BattleScene extends SceneBase {
       species = getPokemonSpecies(Overrides.OPP_SPECIES_OVERRIDE);
     }
     const pokemon = new EnemyPokemon(this, species, level, trainerSlot, boss, dataSource);
+    if (Overrides.OPP_FUSION_OVERRIDE) {
+      pokemon.generateFusionSpecies();
+    }
+
     if (Overrides.OPP_LEVEL_OVERRIDE !== 0) {
       pokemon.level = Overrides.OPP_LEVEL_OVERRIDE;
     }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1417,7 +1417,15 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       && species.speciesId !== this.species.speciesId;
       };
 
-    this.fusionSpecies = this.scene.randomSpecies(this.scene.currentBattle?.waveIndex || 0, this.level, false, filter, true);
+    let fusionOverride: PokemonSpecies = undefined;
+
+    if (forStarter && this instanceof PlayerPokemon && Overrides.STARTER_FUSION_SPECIES_OVERRIDE) {
+      fusionOverride = getPokemonSpecies(Overrides.STARTER_FUSION_SPECIES_OVERRIDE);
+    } else if (this instanceof EnemyPokemon && Overrides.OPP_FUSION_SPECIES_OVERRIDE) {
+      fusionOverride = getPokemonSpecies(Overrides.OPP_FUSION_SPECIES_OVERRIDE);
+    }
+
+    this.fusionSpecies = fusionOverride ?? this.scene.randomSpecies(this.scene.currentBattle?.waveIndex || 0, this.level, false, filter, true);
     this.fusionAbilityIndex = (this.fusionSpecies.abilityHidden && hasHiddenAbility ? this.fusionSpecies.ability2 ? 2 : 1 : this.fusionSpecies.ability2 ? randAbilityIndex : 0);
     this.fusionShiny = this.shiny;
     this.fusionVariant = this.variant;

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -77,6 +77,14 @@ export const STARTING_LEVEL_OVERRIDE: integer = 0;
  * @example SPECIES_OVERRIDE = Species.Bulbasaur;
  */
 export const STARTER_SPECIES_OVERRIDE: Species | integer = 0;
+/**
+ * This will force your starter to be a random fusion
+ */
+export const STARTER_FUSION_OVERRIDE: boolean = false;
+/**
+ * This will override the species of the fusion
+ */
+export const STARTER_FUSION_SPECIES_OVERRIDE: Species | integer = 0;
 export const ABILITY_OVERRIDE: Abilities = Abilities.NONE;
 export const PASSIVE_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
 export const STATUS_OVERRIDE: StatusEffect = StatusEffect.NONE;
@@ -90,6 +98,14 @@ export const VARIANT_OVERRIDE: Variant = 0;
  */
 
 export const OPP_SPECIES_OVERRIDE: Species | integer = 0;
+/**
+ * This will make all opponents fused Pokemon
+ */
+export const OPP_FUSION_OVERRIDE: boolean = false;
+/**
+ * This will override the species of the fusion only when the opponent is already a fusion
+ */
+export const OPP_FUSION_SPECIES_OVERRIDE: Species | integer = 0;
 export const OPP_LEVEL_OVERRIDE: number = 0;
 export const OPP_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
 export const OPP_PASSIVE_ABILITY_OVERRIDE: Abilities = Abilities.NONE;

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -610,7 +610,7 @@ export class SelectStarterPhase extends Phase {
       if (starter.pokerus) {
         starterPokemon.pokerus = true;
       }
-      if (this.scene.gameMode.isSplicedOnly) {
+      if (this.scene.gameMode.isSplicedOnly || Overrides.STARTER_FUSION_OVERRIDE) {
         starterPokemon.generateFusionSpecies(true);
       }
       starterPokemon.setVisible(false);


### PR DESCRIPTION
## What are the changes?
Create override options for starter fusions and enemy fusions

## Why am I doing these changes?
Make testing easier

## What did change?
Added options in the `overrides.ts` for fusions
```ts
export const STARTER_FUSION_OVERRIDE: boolean = false;
export const STARTER_FUSION_SPECIES_OVERRIDE: Species | integer = 0;
export const OPP_FUSION_OVERRIDE: boolean = false;
export const OPP_FUSION_SPECIES_OVERRIDE: Species | integer = 0;
```

### Screenshots/Videos
STARTER_FUSION_OVERRIDE
![starter-fusion](https://i.ember.zone/bCOe5CMzYELkJ5JQ.png)
STARTER_FUSION_SPECIES_OVERRIDE
![starter-fusion-species](https://i.ember.zone/mcVLeVKOkXEknHM2.png)
OPP_FUSION_OVERRIDE
![opp-fusion](https://i.ember.zone/NHPJ8oiiErqISeGk.png)
OPP_FUSION_SPECIES_OVERRIDE
![opp-fusion-species](https://i.ember.zone/lZCUWUgRBGsfpmRm.png)

## How to test the changes?
Change the new options in `overrides.ts`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?

![tests](https://i.ember.zone/RNocUTAHKyn85uBi.png)