### PR TITLE
[Test] Optimize Quick Draw tests

### DIFF
--- a/src/test/abilities/quick_draw.test.ts
+++ b/src/test/abilities/quick_draw.test.ts
@@ -1,16 +1,14 @@
-import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
-import {Abilities} from "#enums/abilities";
-import {Species} from "#enums/species";
-import {EnemyCommandPhase,  TitlePhase, TurnEndPhase, TurnStartPhase,
-} from "#app/phases";
+import * as Overrides from "#app/overrides";
+import { Abilities } from "#enums/abilities";
+import { Species } from "#enums/species";
+import { FaintPhase } from "#app/phases";
 import { Moves } from "#enums/moves";
 import { Stat } from "#app/data/pokemon-stat";
 import { getMovePosition } from "#app/test/utils/gameManagerUtils";
 import { allAbilities, BypassSpeedChanceAbAttr } from "#app/data/ability";
-
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
 describe("Abilities - Quick Draw", () => {
   let phaserGame: Phaser.Game;
@@ -28,31 +26,20 @@ describe("Abilities - Quick Draw", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
-    vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(
-      Abilities.QUICK_DRAW
-    );
-    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(
-      Species.RATTATA
-    );
-    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([
-      Moves.TACKLE,
-      Moves.TACKLE,
-      Moves.TACKLE,
-      Moves.TACKLE,
-    ]);
+    vi.spyOn(Overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(Overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.QUICK_DRAW);
+    vi.spyOn(Overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.TACKLE, Moves.TAIL_WHIP]);
+    vi.spyOn(Overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.RATTATA);
+    vi.spyOn(Overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE]);
 
-    vi.spyOn(
-      allAbilities[Abilities.QUICK_DRAW].getAttrs(BypassSpeedChanceAbAttr)[0],
-      "chance","get"
-    ).mockReturnValue(100);
+    vi.spyOn(allAbilities[Abilities.QUICK_DRAW].getAttrs(BypassSpeedChanceAbAttr)[0], "chance", "get").mockReturnValue(100);
   });
 
-  it("makes pokemon going first in its priority bracket", async() => {
+  test("makes pokemon going first in its priority bracket", async () => {
     await game.startBattle([Species.SLOWBRO]);
 
-    const pokemon = game.scene.getParty()[0];
-    const enemy = game.scene.getEnemyParty()[0];
+    const pokemon = game.scene.getPlayerPokemon();
+    const enemy = game.scene.getEnemyPokemon();
 
     pokemon.stats[Stat.SPD] = 50;
     enemy.stats[Stat.SPD] = 150;
@@ -60,46 +47,39 @@ describe("Abilities - Quick Draw", () => {
     enemy.hp = 1;
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.TACKLE));
+    await game.phaseInterceptor.to(FaintPhase, false);
 
-    await game.phaseInterceptor.run(EnemyCommandPhase);
-    await game.phaseInterceptor.run(TurnStartPhase);
-    await game.phaseInterceptor.to(TurnEndPhase);
-
-    expect(pokemon.battleData.abilityRevealed).toBe(true);
+    expect(pokemon.isFainted()).toBe(false);
+    expect(enemy.isFainted()).toBe(true);
+    expect(pokemon.battleData.abilitiesApplied).contain(Abilities.QUICK_DRAW);
   }, 20000);
 
-  it("does not triggered by non damage moves", async () => {
+  test("does not triggered by non damage moves", async () => {
     await game.startBattle([Species.SLOWBRO]);
 
-    const pokemon = game.scene.getParty()[0];
-    const enemy = game.scene.getEnemyParty()[0];
+    const pokemon = game.scene.getPlayerPokemon();
+    const enemy = game.scene.getEnemyPokemon();
 
     pokemon.stats[Stat.SPD] = 50;
     enemy.stats[Stat.SPD] = 150;
     pokemon.hp = 1;
     enemy.hp = 1;
 
-    game.doAttack(getMovePosition(game.scene, 0, Moves.TOXIC));
+    game.doAttack(getMovePosition(game.scene, 0, Moves.TAIL_WHIP));
+    await game.phaseInterceptor.to(FaintPhase, false);
 
-    await game.phaseInterceptor.run(EnemyCommandPhase);
-    await game.phaseInterceptor.run(TurnStartPhase);
-    await game.phaseInterceptor.to(TitlePhase);
-
-    expect(pokemon.battleData.abilityRevealed).not.toBe(true);
+    expect(pokemon.isFainted()).toBe(true);
+    expect(enemy.isFainted()).toBe(false);
+    expect(pokemon.battleData.abilitiesApplied).not.contain(Abilities.QUICK_DRAW);
   }, 20000);
 
-  it("does not increase priority", async () => {
-    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([
-      Moves.EXTREME_SPEED,
-      Moves.EXTREME_SPEED,
-      Moves.EXTREME_SPEED,
-      Moves.EXTREME_SPEED,
-    ]);
+  test("does not increase priority", async () => {
+    vi.spyOn(Overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue(Array(4).fill(Moves.EXTREME_SPEED));
 
     await game.startBattle([Species.SLOWBRO]);
 
-    const pokemon = game.scene.getParty()[0];
-    const enemy = game.scene.getEnemyParty()[0];
+    const pokemon = game.scene.getPlayerPokemon();
+    const enemy = game.scene.getEnemyPokemon();
 
     pokemon.stats[Stat.SPD] = 50;
     enemy.stats[Stat.SPD] = 150;
@@ -107,11 +87,10 @@ describe("Abilities - Quick Draw", () => {
     enemy.hp = 1;
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.TACKLE));
+    await game.phaseInterceptor.to(FaintPhase, false);
 
-    await game.phaseInterceptor.run(EnemyCommandPhase);
-    await game.phaseInterceptor.run(TurnStartPhase);
-    await game.phaseInterceptor.to(TitlePhase);
-
-    expect(pokemon.battleData.abilityRevealed).toBe(true);
+    expect(pokemon.isFainted()).toBe(true);
+    expect(enemy.isFainted()).toBe(false);
+    expect(pokemon.battleData.abilitiesApplied).contain(Abilities.QUICK_DRAW);
   }, 20000);
 });

--- a/src/test/abilities/quick_draw.test.ts
+++ b/src/test/abilities/quick_draw.test.ts
@@ -5,7 +5,6 @@ import { Abilities } from "#enums/abilities";
 import { Species } from "#enums/species";
 import { FaintPhase } from "#app/phases";
 import { Moves } from "#enums/moves";
-import { Stat } from "#app/data/pokemon-stat";
 import { getMovePosition } from "#app/test/utils/gameManagerUtils";
 import { allAbilities, BypassSpeedChanceAbAttr } from "#app/data/ability";
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
@@ -29,6 +28,7 @@ describe("Abilities - Quick Draw", () => {
     vi.spyOn(Overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
     vi.spyOn(Overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.QUICK_DRAW);
     vi.spyOn(Overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.TACKLE, Moves.TAIL_WHIP]);
+    vi.spyOn(Overrides, "OPP_LEVEL_OVERRIDE", "get").mockReturnValue(100);
     vi.spyOn(Overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.RATTATA);
     vi.spyOn(Overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE]);
 
@@ -41,8 +41,6 @@ describe("Abilities - Quick Draw", () => {
     const pokemon = game.scene.getPlayerPokemon();
     const enemy = game.scene.getEnemyPokemon();
 
-    pokemon.stats[Stat.SPD] = 50;
-    enemy.stats[Stat.SPD] = 150;
     pokemon.hp = 1;
     enemy.hp = 1;
 
@@ -60,8 +58,6 @@ describe("Abilities - Quick Draw", () => {
     const pokemon = game.scene.getPlayerPokemon();
     const enemy = game.scene.getEnemyPokemon();
 
-    pokemon.stats[Stat.SPD] = 50;
-    enemy.stats[Stat.SPD] = 150;
     pokemon.hp = 1;
     enemy.hp = 1;
 
@@ -81,8 +77,6 @@ describe("Abilities - Quick Draw", () => {
     const pokemon = game.scene.getPlayerPokemon();
     const enemy = game.scene.getEnemyPokemon();
 
-    pokemon.stats[Stat.SPD] = 50;
-    enemy.stats[Stat.SPD] = 150;
     pokemon.hp = 1;
     enemy.hp = 1;
 


### PR DESCRIPTION
## What are the changes?
Optimize the quick draw tests so they don't take so long

## Why am I doing these changes?
Quick draw tests are timing out when run in CI

## What did change?
Stop the phase interceptor right before the faint phase before checking if the ability was applied / the pokemon have fainted

## How to test the changes?
`pnpm test:silent`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)