### PR TITLE
[Bug] Prevent RNG from breaking Dry Skin tests

### DIFF
--- a/src/test/abilities/dry_skin.test.ts
+++ b/src/test/abilities/dry_skin.test.ts
@@ -26,6 +26,7 @@ describe("Abilities - Dry Skin", () => {
     vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
     vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.DRY_SKIN);
     vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.SPLASH, Moves.SPLASH, Moves.SPLASH]);
+    vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.BALL_FETCH);
   });
 
   it("during sunlight, lose 1/8 of maximum health at the end of each turn", async () => {


### PR DESCRIPTION
## What are the changes?
The Dry Skin ability tests no longer fail due to randomness of the generated player Pokémon's ability.

## Why am I doing these changes?
Tests failing due to randomness causes workflow problems.

## What did change?
Add an ability override for the player Pokémon to prevent the test from randomly failing if the test generates a player Pokémon with an ability that modifies the battle state (ie: Drizzle). The change is to line 29 of `src/test/abilities/dry_skin.test.ts`.

### Screenshots/Videos

![image](https://github.com/pagefaultgames/pokerogue/assets/34855794/d6f9528c-515b-46c6-b5b3-91512b38b2b3)

## How to test the changes?
`npm run test:silent dry_skin`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?