### PR TITLE
[Balance] Quick Adjustments to Rogue Tier Items

### DIFF
--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1513,11 +1513,11 @@ const modifierPool: ModifierPool = {
     new WeightedModifierType(modifierTypes.FOCUS_BAND, 5),
     new WeightedModifierType(modifierTypes.KINGS_ROCK, 3),
     new WeightedModifierType(modifierTypes.LOCK_CAPSULE, 3),
-    new WeightedModifierType(modifierTypes.SUPER_EXP_CHARM, 9),
-    new WeightedModifierType(modifierTypes.FORM_CHANGE_ITEM, (party: Pokemon[]) => Math.min(Math.ceil(party[0].scene.currentBattle.waveIndex / 50), 4) * 5, 20),
-    new WeightedModifierType(modifierTypes.MEGA_BRACELET, (party: Pokemon[]) => Math.min(Math.ceil(party[0].scene.currentBattle.waveIndex / 50), 4) * 8, 32),
-    new WeightedModifierType(modifierTypes.DYNAMAX_BAND, (party: Pokemon[]) => Math.min(Math.ceil(party[0].scene.currentBattle.waveIndex / 50), 4) * 8, 32),
-    new WeightedModifierType(modifierTypes.VOUCHER_PLUS, (party: Pokemon[], rerollCount: integer) => !party[0].scene.gameMode.isDaily ? Math.max(3 - rerollCount * 2, 0) : 0, 3),
+    new WeightedModifierType(modifierTypes.SUPER_EXP_CHARM, 8),
+    new WeightedModifierType(modifierTypes.FORM_CHANGE_ITEM, (party: Pokemon[]) => Math.min(Math.ceil(party[0].scene.currentBattle.waveIndex / 50), 4) * 6, 24),
+    new WeightedModifierType(modifierTypes.MEGA_BRACELET, (party: Pokemon[]) => Math.min(Math.ceil(party[0].scene.currentBattle.waveIndex / 50), 4) * 9, 36),
+    new WeightedModifierType(modifierTypes.DYNAMAX_BAND, (party: Pokemon[]) => Math.min(Math.ceil(party[0].scene.currentBattle.waveIndex / 50), 4) * 9, 36),
+    new WeightedModifierType(modifierTypes.VOUCHER_PLUS, (party: Pokemon[], rerollCount: integer) => !party[0].scene.gameMode.isDaily ? Math.max(3 - rerollCount * 1, 0) : 0, 3),
   ].map(m => {
     m.setTier(ModifierTier.ROGUE); return m;
   }),


### PR DESCRIPTION
## What are the changes?
Adjusted Super EXP Charm, Form Change Items, Mega Bracelet/Band, and Voucher Plus (to only drop weight by 1 each reroll, making it take another reroll to disappear)
Super EXP Charms appearing too often, Mega Bracelet/Band still a problem to lead into the form change item changes, and Voucher Plus disappeared too quickly.

## Why am I doing these changes?
Adjustments to last list of changes.

## What did change?
Super EXP Charm - 9 -> 8
Voucher Plus - 3 weight, 2 descending per reroll to 0 -> 3 weight, 1 descending per reroll to 0
Form Change Items - 5 base x wave count multiple of 50 = 20 max -> 6 base x wave count multiple of 50 = 24 max
Mega Bracelet - 8 base x wave count multiple of 50 = 32 max -> 9 base x wave count of 50 = 36 max
Dynamax Band - 8 base x wave count multiple of 50 = 32 max -> 9 base x wave count of 50 = 36 max

## How to test the changes?
Math.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)