### PR TITLE
[Hotfix] Stat Booster Held Items Applying to Entire Party

### DIFF
--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -753,7 +753,7 @@ export class StatBoosterModifier extends PokemonHeldItemModifier {
    * @returns true if the stat could be boosted, false otherwise
    */
   shouldApply(args: any[]): boolean {
-    return this.stats.includes(args[1] as Stat);
+    return super.shouldApply(args) && this.stats.includes(args[1] as Stat);
   }
 
   /**


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->

Fixes stat booster held items (evolution and species stat boosters by extension) applying to all party members in battle even if they're not the member holding the item. 

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

Allowed other members to benefit from another member holding a stat boosting item (i.e., Pikachu would get the stat boost from Light Ball in battle despite another member holding it) which is unintended.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

Added a `super.getArgs(args)` call to the overridden `getArgs` function in `StatBoosterModifier`.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

N/A

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

Pick a starting Pokemon that would benefit from any of the stat booster items (Eviolite, Light Ball, etc.) and pick another that doesn't. The choices I used were Pikachu and Geodude with the following override to get Light Ball:
```ts
export const ITEM_REWARD_OVERRIDE: Array<String> = [ "SPECIES_STAT_BOOSTER" ];
```

Complete a wave, give the stat booster item to the member that wouldn't benefit from having the item, and then switch to the member who would. Now, for example, Pikachu should not benefit from the other member's Light Ball (evident by whether "Applied Light Ball" appears right before the "damage" string in the console).

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?