### PR TITLE
Added more dialogue options for evil team grunts [Enhancement]

### DIFF
--- a/src/data/dialogue.ts
+++ b/src/data/dialogue.ts
@@ -463,6 +463,7 @@ export const trainerTypeDialogue: TrainerTypeDialogue = {
         "dialogue:rocket_grunt.encounter.9",
         "dialogue:rocket_grunt.encounter.10",
         "dialogue:rocket_grunt.encounter.11",
+        "dialogue:rocket_grunt.encounter.12",
       ],
       victory: [
         "dialogue:rocket_grunt.victory.1",
@@ -476,6 +477,7 @@ export const trainerTypeDialogue: TrainerTypeDialogue = {
         "dialogue:rocket_grunt.victory.9",
         "dialogue:rocket_grunt.victory.10",
         "dialogue:rocket_grunt.victory.11",
+        "dialogue:rocket_grunt.victory.12",
       ]
     }
   ],
@@ -559,6 +561,8 @@ export const trainerTypeDialogue: TrainerTypeDialogue = {
         "dialogue:galactic_grunt.encounter.9",
         "dialogue:galactic_grunt.encounter.10",
         "dialogue:galactic_grunt.encounter.11",
+        "dialogue:galactic_grunt.encounter.12",
+        "dialogue:galactic_grunt.encounter.13",
       ],
       victory: [
         "dialogue:galactic_grunt.victory.1",
@@ -572,6 +576,8 @@ export const trainerTypeDialogue: TrainerTypeDialogue = {
         "dialogue:galactic_grunt.victory.9",
         "dialogue:galactic_grunt.victory.10",
         "dialogue:galactic_grunt.victory.11",
+        "dialogue:galactic_grunt.victory.12",
+        "dialogue:galactic_grunt.victory.13",
       ]
     }
   ],
@@ -587,6 +593,7 @@ export const trainerTypeDialogue: TrainerTypeDialogue = {
         "dialogue:plasma_grunt.encounter.7",
         "dialogue:plasma_grunt.encounter.8",
         "dialogue:plasma_grunt.encounter.9",
+        "dialogue:plasma_grunt.encounter.10",
       ],
       victory: [
         "dialogue:plasma_grunt.victory.1",
@@ -598,6 +605,7 @@ export const trainerTypeDialogue: TrainerTypeDialogue = {
         "dialogue:plasma_grunt.victory.7",
         "dialogue:plasma_grunt.victory.8",
         "dialogue:plasma_grunt.victory.9",
+        "dialogue:plasma_grunt.victory.10",
       ]
     }
   ],

--- a/src/data/dialogue.ts
+++ b/src/data/dialogue.ts
@@ -452,60 +452,159 @@ export const trainerTypeDialogue: TrainerTypeDialogue = {
   [TrainerType.ROCKET_GRUNT]: [
     {
       encounter: [
-        "dialogue:rocket_grunt.encounter.1"
+        "dialogue:rocket_grunt.encounter.1",
+        "dialogue:rocket_grunt.encounter.2",
+        "dialogue:rocket_grunt.encounter.3",
+        "dialogue:rocket_grunt.encounter.4",
+        "dialogue:rocket_grunt.encounter.5",
+        "dialogue:rocket_grunt.encounter.6",
+        "dialogue:rocket_grunt.encounter.7"
       ],
       victory: [
-        "dialogue:rocket_grunt.victory.1"
+        "dialogue:rocket_grunt.victory.1",
+        "dialogue:rocket_grunt.victory.2",
+        "dialogue:rocket_grunt.victory.3",
+        "dialogue:rocket_grunt.victory.4",
+        "dialogue:rocket_grunt.victory.5",
+        "dialogue:rocket_grunt.victory.6",
+        "dialogue:rocket_grunt.victory.7",
+        "dialogue:rocket_grunt.victory.8",
+        "dialogue:rocket_grunt.victory.9",
+        "dialogue:rocket_grunt.victory.10",
+        "dialogue:rocket_grunt.victory.11",
       ]
     }
   ],
   [TrainerType.MAGMA_GRUNT]: [
     {
       encounter: [
-        "dialogue:magma_grunt.encounter.1"
+        "dialogue:magma_grunt.encounter.1",
+        "dialogue:magma_grunt.encounter.2",
+        "dialogue:magma_grunt.encounter.3",
+        "dialogue:magma_grunt.encounter.4",
+        "dialogue:magma_grunt.encounter.5",
+        "dialogue:magma_grunt.encounter.6",
+        "dialogue:magma_grunt.encounter.7",
+        "dialogue:magma_grunt.encounter.8",
+        "dialogue:magma_grunt.encounter.9",
+        "dialogue:magma_grunt.encounter.10",
+        "dialogue:magma_grunt.encounter.11",
+        "dialogue:magma_grunt.encounter.12",
+        "dialogue:magma_grunt.encounter.13",
+        "dialogue:magma_grunt.encounter.14",
+        "dialogue:magma_grunt.encounter.15",
       ],
       victory: [
-        "dialogue:magma_grunt.victory.1"
+        "dialogue:magma_grunt.victory.1",
+        "dialogue:magma_grunt.victory.2",
+        "dialogue:magma_grunt.victory.3",
+        "dialogue:magma_grunt.victory.4",
+        "dialogue:magma_grunt.victory.5",
+        "dialogue:magma_grunt.victory.6",
+        "dialogue:magma_grunt.victory.7",
+        "dialogue:magma_grunt.victory.8",
+        "dialogue:magma_grunt.victory.9",
+        "dialogue:magma_grunt.victory.10",
+        "dialogue:magma_grunt.victory.11",
+        "dialogue:magma_grunt.victory.12",
+        "dialogue:magma_grunt.victory.13",
+        "dialogue:magma_grunt.victory.14",
+        "dialogue:magma_grunt.victory.15",
+        "dialogue:magma_grunt.victory.16",
+        "dialogue:magma_grunt.victory.17",
       ]
     }
   ],
   [TrainerType.AQUA_GRUNT]: [
     {
       encounter: [
-        "dialogue:aqua_grunt.encounter.1"
+        "dialogue:aqua_grunt.encounter.1",
+        "dialogue:aqua_grunt.encounter.2",
+        "dialogue:aqua_grunt.encounter.3",
+        "dialogue:aqua_grunt.encounter.4",
+        "dialogue:aqua_grunt.encounter.5",
+        "dialogue:aqua_grunt.encounter.6",
+        "dialogue:aqua_grunt.encounter.7",
+        "dialogue:aqua_grunt.encounter.8",
       ],
       victory: [
-        "dialogue:aqua_grunt.victory.1"
+        "dialogue:aqua_grunt.victory.1",
+        "dialogue:aqua_grunt.victory.2",
+        "dialogue:aqua_grunt.victory.3",
+        "dialogue:aqua_grunt.victory.4",
+        "dialogue:aqua_grunt.victory.5",
+        "dialogue:aqua_grunt.victory.6",
+        "dialogue:aqua_grunt.victory.7",
+        "dialogue:aqua_grunt.victory.8",
       ]
     }
   ],
   [TrainerType.GALACTIC_GRUNT]: [
     {
       encounter: [
-        "dialogue:galactic_grunt.encounter.1"
+        "dialogue:galactic_grunt.encounter.1",
+        "dialogue:galactic_grunt.encounter.2",
+        "dialogue:galactic_grunt.encounter.3",
+        "dialogue:galactic_grunt.encounter.4",
+        "dialogue:galactic_grunt.encounter.5",
+        "dialogue:galactic_grunt.encounter.6",
+        "dialogue:galactic_grunt.encounter.7",
       ],
       victory: [
-        "dialogue:galactic_grunt.victory.1"
+        "dialogue:galactic_grunt.victory.1",
+        "dialogue:galactic_grunt.victory.2",
+        "dialogue:galactic_grunt.victory.3",
+        "dialogue:galactic_grunt.victory.4",
+        "dialogue:galactic_grunt.victory.5",
+        "dialogue:galactic_grunt.victory.6",
+        "dialogue:galactic_grunt.victory.7",
+        "dialogue:galactic_grunt.victory.8",
+        "dialogue:galactic_grunt.victory.9",
+        "dialogue:galactic_grunt.victory.10",
+        "dialogue:galactic_grunt.victory.11",
       ]
     }
   ],
   [TrainerType.PLASMA_GRUNT]: [
     {
       encounter: [
-        "dialogue:plasma_grunt.encounter.1"
+        "dialogue:plasma_grunt.encounter.1",
+        "dialogue:plasma_grunt.encounter.2",
+        "dialogue:plasma_grunt.encounter.3",
+        "dialogue:plasma_grunt.encounter.4",
+        "dialogue:plasma_grunt.encounter.5",
+        "dialogue:plasma_grunt.encounter.6",
+        "dialogue:plasma_grunt.encounter.7",
+        "dialogue:plasma_grunt.encounter.8",
+        "dialogue:plasma_grunt.encounter.9",
       ],
       victory: [
-        "dialogue:plasma_grunt.victory.1"
+        "dialogue:plasma_grunt.victory.1",
+        "dialogue:plasma_grunt.victory.2",
+        "dialogue:plasma_grunt.victory.3",
+        "dialogue:plasma_grunt.victory.4",
+        "dialogue:plasma_grunt.victory.5",
+        "dialogue:plasma_grunt.victory.6",
+        "dialogue:plasma_grunt.victory.7",
       ]
     }
   ],
   [TrainerType.FLARE_GRUNT]: [
     {
       encounter: [
-        "dialogue:flare_grunt.encounter.1"
+        "dialogue:flare_grunt.encounter.1",
+        "dialogue:flare_grunt.encounter.2",
+        "dialogue:flare_grunt.encounter.3",
+        "dialogue:flare_grunt.encounter.4",
+        "dialogue:flare_grunt.encounter.5",
       ],
       victory: [
-        "dialogue:flare_grunt.victory.1"
+        "dialogue:flare_grunt.victory.1",
+        "dialogue:flare_grunt.victory.2",
+        "dialogue:flare_grunt.victory.3",
+        "dialogue:flare_grunt.victory.4",
+        "dialogue:flare_grunt.victory.5",
+        "dialogue:flare_grunt.victory.6",
       ]
     }
   ],

--- a/src/data/dialogue.ts
+++ b/src/data/dialogue.ts
@@ -458,7 +458,11 @@ export const trainerTypeDialogue: TrainerTypeDialogue = {
         "dialogue:rocket_grunt.encounter.4",
         "dialogue:rocket_grunt.encounter.5",
         "dialogue:rocket_grunt.encounter.6",
-        "dialogue:rocket_grunt.encounter.7"
+        "dialogue:rocket_grunt.encounter.7",
+        "dialogue:rocket_grunt.encounter.8",
+        "dialogue:rocket_grunt.encounter.9",
+        "dialogue:rocket_grunt.encounter.10",
+        "dialogue:rocket_grunt.encounter.11",
       ],
       victory: [
         "dialogue:rocket_grunt.victory.1",
@@ -493,6 +497,8 @@ export const trainerTypeDialogue: TrainerTypeDialogue = {
         "dialogue:magma_grunt.encounter.13",
         "dialogue:magma_grunt.encounter.14",
         "dialogue:magma_grunt.encounter.15",
+        "dialogue:magma_grunt.encounter.16",
+        "dialogue:magma_grunt.encounter.17",
       ],
       victory: [
         "dialogue:magma_grunt.victory.1",
@@ -549,6 +555,10 @@ export const trainerTypeDialogue: TrainerTypeDialogue = {
         "dialogue:galactic_grunt.encounter.5",
         "dialogue:galactic_grunt.encounter.6",
         "dialogue:galactic_grunt.encounter.7",
+        "dialogue:galactic_grunt.encounter.8",
+        "dialogue:galactic_grunt.encounter.9",
+        "dialogue:galactic_grunt.encounter.10",
+        "dialogue:galactic_grunt.encounter.11",
       ],
       victory: [
         "dialogue:galactic_grunt.victory.1",
@@ -586,6 +596,8 @@ export const trainerTypeDialogue: TrainerTypeDialogue = {
         "dialogue:plasma_grunt.victory.5",
         "dialogue:plasma_grunt.victory.6",
         "dialogue:plasma_grunt.victory.7",
+        "dialogue:plasma_grunt.victory.8",
+        "dialogue:plasma_grunt.victory.9",
       ]
     }
   ],
@@ -597,6 +609,7 @@ export const trainerTypeDialogue: TrainerTypeDialogue = {
         "dialogue:flare_grunt.encounter.3",
         "dialogue:flare_grunt.encounter.4",
         "dialogue:flare_grunt.encounter.5",
+        "dialogue:flare_grunt.encounter.6",
       ],
       victory: [
         "dialogue:flare_grunt.victory.1",

--- a/src/locales/de/dialogue.ts
+++ b/src/locales/de/dialogue.ts
@@ -367,33 +367,6 @@ export const PGMdialogue: DialogueTranslationEntries = {
       1: "Ich werde für das nächste Rennen tunen."
     },
   },
-  "rocket_grunt": {
-    "encounter": {
-      1: `Jetzt gibt es Ärger!…
-          $und es kommt noch härter!
-          $Wir wollen über die Erde regieren…
-          $und naja du kennst den Rest…!`,
-      2: "Come from Johto will they, mine allies, yes. Will revenge they are",
-      3: "You say what? Team Rocket bye-bye a go-go? Broken up it is says you?",
-      4: "To denounce the evils of truth and love!",
-      5: "We Team Rocket are Pokémon gangsters!",
-      6: "We're pulling a big job here! Get lost, kid!",
-      7: "You broke into our operation? You must be lost!",
-    },
-    "victory": {
-      1: "Das war mal wieder ein Schuss in den Ofen!",
-      2: "Winning is for winners.",
-      3: "You will regret this!",
-      4: "Blastin' off at the speed of light!",
-      5: "Blasting off again....",
-      6: "Stop! I give up! I'll leave quietly!",
-      7: "You made me mad! Team Rocket will blacklist you!",
-      8: "I blew it!",
-      9: "My associates won't stand for this!",
-      10: "So, you are good…",
-      11: "I'm steamed..."
-    },
-  },
   "firebreather": {
     "encounter": {
       1: "Meine Flammen werden dich verschlingen!",
@@ -419,6 +392,37 @@ export const PGMdialogue: DialogueTranslationEntries = {
       3: "Ich glaube, ich bin der der seekrank ist..."
     },
   },
+  "rocket_grunt": {
+    "encounter": {
+      1: `Jetzt gibt es Ärger!…
+          $und es kommt noch härter!
+          $Wir wollen über die Erde regieren…
+          $und naja du kennst den Rest…!`,
+      2: "Come from Johto will they, mine allies, yes. Will revenge they are",
+      3: "You say what? Team Rocket bye-bye a go-go? Broken up it is says you?",
+      4: "To denounce the evils of truth and love!",
+      5: "We Team Rocket are Pokémon gangsters!",
+      6: "We're pulling a big job here! Get lost, kid!",
+      7: "You broke into our operation? You must be lost!",
+      8: "Hand over your Pokémon, or face the wrath of Team Rocket!",
+      9: "We are Team Rocket, and we're here to steal your Pokémon!",
+      10: "You're about to experience the true terror of Team Rocket!",
+      11: "Resistance is futile! Give us your Pokémon or face the consequences!"
+    },
+    "victory": {
+      1: "Das war mal wieder ein Schuss in den Ofen!",
+      2: "Winning is for winners.",
+      3: "You will regret this!",
+      4: "Blastin' off at the speed of light!",
+      5: "Blasting off again....",
+      6: "Stop! I give up! I'll leave quietly!",
+      7: "You made me mad! Team Rocket will blacklist you!",
+      8: "I blew it!",
+      9: "My associates won't stand for this!",
+      10: "So, you are good…",
+      11: "I'm steamed..."
+    },
+  },
   "magma_grunt": {
     "encounter": {
       1: "Keiner, der sich Team Magma in den Weg stellt, bekommt Gnade, nicht einmal Kinder!",
@@ -435,7 +439,10 @@ export const PGMdialogue: DialogueTranslationEntries = {
       12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
       13: "I hope you brought marshmallows because things are about to heat up!",
       14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
-      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!"
+      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!",
+      16: "Hope you brought sunscreen, 'cause you're about to get burned!",
+      17: "You're in the way! Team Magma has no time for kids like you!",
+
     },
     "victory": {
       1: "Wie kann das sein? Ich bin Teil vom mächtigen Team Magma! Wir wollen doch nur die Welt verbessern…",
@@ -488,6 +495,10 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "Get ready to lose!",
       6: "You dare to challenge Team Galactic?",
       7: "Team Galactic will conquer all!",
+      8: "Hope you're ready for a cosmic beatdown!",
+      9: "Witness the power of our technology and the future we envision!",
+      10: "In the name of Team Galactic, I'll eliminate anyone who stands in our way!",
+      11: "Looks like you're about to get starstruck...by our Pokémon!"
     },
     "victory": {
       1: "Zyrus wird uns für diese Niederlage bestrafen…",
@@ -522,7 +533,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       4: "How could I lose...",
       5: "I think Lord N would approve of a rematch clause.",
       6: "I guess my Pokémon liberation degree needs updating.",
-      7: "Note to self: practice Pokémon battling, liberate Pokémon better."
+      7: "Note to self: practice Pokémon battling, liberate Pokémon better.",
+      8: "Better luck next time! Maybe join Team Plasma for a change?",
+      9: "We came, we saw, we Plasma'd!"
     },
   },
   "flare_grunt": {
@@ -532,7 +545,8 @@ export const PGMdialogue: DialogueTranslationEntries = {
       2: "Team Flare will cleanse the world of imperfection!",
       3: "Prepare to face the brilliance of Team Flare!",
       4: "Team Flare's style and grace will outshine any opponent!",
-      5: "Your Pokémon are no match for the elegance of Team Flare."
+      5: "Your Pokémon are no match for the elegance of Team Flare.",
+      6: "Hope you brought your sunglasses, because things are about to get bright!"
     },
     "victory": {
       1: "Stil ist wohl doch nicht alles…",

--- a/src/locales/de/dialogue.ts
+++ b/src/locales/de/dialogue.ts
@@ -372,17 +372,34 @@ export const PGMdialogue: DialogueTranslationEntries = {
       1: `Jetzt gibt es Ärger!…
           $und es kommt noch härter!
           $Wir wollen über die Erde regieren…
-          $und naja du kennst den Rest…!`
+          $und naja du kennst den Rest…!`,
+      2: "Come from Johto will they, mine allies, yes. Will revenge they are",
+      3: "You say what? Team Rocket bye-bye a go-go? Broken up it is says you?",
+      4: "To denounce the evils of truth and love!",
+      5: "We Team Rocket are Pokémon gangsters!",
+      6: "We're pulling a big job here! Get lost, kid!",
+      7: "You broke into our operation? You must be lost!",
     },
     "victory": {
-      1: "Das war mal wieder ein Schuss in den Ofen!"
+      1: "Das war mal wieder ein Schuss in den Ofen!",
+      2: "Winning is for winners.",
+      3: "You will regret this!",
+      4: "Blastin' off at the speed of light!",
+      5: "Blasting off again....",
+      6: "Stop! I give up! I'll leave quietly!",
+      7: "You made me mad! Team Rocket will blacklist you!",
+      8: "I blew it!",
+      9: "My associates won't stand for this!",
+      10: "So, you are good…",
+      11: "I'm steamed..."
     },
   },
   "firebreather": {
     "encounter": {
       1: "Meine Flammen werden dich verschlingen!",
       2: "Meine Seele hat Feuer gefangen. Ich werde dir zeigen, wie heiß sie brennt!",
-      3: "Komm näher und sieh dir meine Flammen an!"
+      3: "Komm näher und sieh dir meine Flammen an!",
+
     },
     "victory": {
       1: "Verbrannt bis zur Asche...",
@@ -404,43 +421,127 @@ export const PGMdialogue: DialogueTranslationEntries = {
   },
   "magma_grunt": {
     "encounter": {
-      1: "Keiner, der sich Team Magma in den Weg stellt, bekommt Gnade, nicht einmal Kinder!"
+      1: "Keiner, der sich Team Magma in den Weg stellt, bekommt Gnade, nicht einmal Kinder!",
+      2: "I should've brought my Game Boy Advance SP to play some Pokémon Sapphire  instead.",
+      3: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
+      4: "Heh, I'd like to you see try!",
+      5: "Huh? What are you doing here?",
+      6: "Don't get any ideas about going easy on us just because you're a kid! We'll show you the power of Team Magma's amazing technology!",
+      7: "We, Team Magma, are working hard for everyone's sake. If there's more land, there'll be more places to live! Everyone would be happy!",
+      8: "You'd better not interfere with our plans! We're making the world a better place!",
+      9: "You're in the way! Team Magma has no time for kids like you!",
+      10: "Do you really think you can take on Team Magma? You're just a kid!",
+      11: "We're going to use the power of a volcano! It's gonna be... explosive! Get it? Heh heh!",
+      12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
+      13: "I hope you brought marshmallows because things are about to heat up!",
+      14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
+      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!"
     },
     "victory": {
-      1: "Wie kann das sein? Ich bin Teil vom mächtigen Team Magma! Wir wollen doch nur die Welt verbessern…"
+      1: "Wie kann das sein? Ich bin Teil vom mächtigen Team Magma! Wir wollen doch nur die Welt verbessern…",
+      2: "Urrrgh…I should've ducked into our hideout right away…",
+      3: "Okay, oh-kay! I admit it—you're strong!",
+      4: "Don't worry about me. Go wherever you want!",
+      5: "What, what, what?",
+      6: "I'm getting heat exhaustion…",
+      7: "I failed to win, I should've planned better...",
+      8: "I'm steamed...",
+      9: "Oof... you got me.",
+      10: "What?! I lost?! How could this be...?",
+      11: "No way! You're just a kid!",
+      12: "What? I lost? But... but I was supposed to win!",
+      13:  "I lost?! Now I'll never get promoted to Team Magma Senior Grunt!",
+      14: "You beat me... Do you think the boss will dock my pay for this?",
+      15: "I can't believe I lost! I even skipped lunch for this!",
+      16: "Defeated... I guess evil masterminds don't get sick days, huh?",
+      17: "I should have brought more potions... and a better strategy."
     },
   },
   "aqua_grunt": {
     "encounter": {
       1: "Du willst dich also mit Team Aqua anlegen? Du traust dich ja was… Dich werfe ich über Bord!",
+      2: "I should've brought my Game Boy Advance SP to play some Pokémon Ruby instead.",
+      3: "I was going to ambush you, but you had to dawdle in Petalburg Woods forever, didn't you?",
+      4: "Grrr…You've got some nerve meddling with Team Aqua!",
+      5: "Hey, you there! Don't butt in!",
+      6: "Hey, there! Quit pushing! This is the line, can't you see?",
+      7: "We, Team Aqua, exist for the good of all!",
+      8: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
     },
     "victory": {
       1: "Vielleicht sollte ich wohl lieber selber über die Planke gehen…",
+      2: "Come on and battle me again!",
+      3: "I'll let you go today!",
+      4: "What?! I lost, too!",
+      5: "Arrgh, I didn't count on being meddled with by some meddling kid!",
+      6: "I lost?! Guess I'll have to swim back to the hideout now...",
+      7: "You beat me... Do you think the boss will make me walk the plank for this?",
+      8: "I lost?!"
     },
   },
   "galactic_grunt": {
     "encounter": {
-      1: "Team Galaktik wird die Welt in eine bessere Welt verwandeln! Und du wirst uns nicht aufhalten!"
+      1: "Team Galaktik wird die Welt in eine bessere Welt verwandeln! Und du wirst uns nicht aufhalten!",
+      2: "Our time has come!",
+      3: "It's team galactic's time now!",
+      4: "Hey, wanna join Team Galactic?",
+      5: "Get ready to lose!",
+      6: "You dare to challenge Team Galactic?",
+      7: "Team Galactic will conquer all!",
     },
     "victory": {
-      1: "Zyrus wird uns für diese Niederlage bestrafen…"
+      1: "Zyrus wird uns für diese Niederlage bestrafen…",
+      2: "Not bad...",
+      3: "How?!",
+      4: "I'll be back..",
+      5: "I'm outta here!",
+      6: "Maybe we should stick to evil plans and leave battling to someone else.",
+      7: "Note to self: practice Pokémon battling, ASAP.",
+      8: "Oops, our evil was no match for your Pokémon.",
+      9: "This setback means nothing in the grand scheme.",
+      10: "Our plans are bigger than this defeat.",
+      11: "I knew I should have trained more and evil-planned less."
     },
   },
   "plasma_grunt": {
     "encounter": {
-      1: "Pokémon sollten frei sein! Team Plasma wird sie befreien!"
+      1: "Pokémon sollten frei sein! Team Plasma wird sie befreien!",
+      2: "Bad for Team Plasma! Or Plasbad, for short!",
+      3: "There's no room for obstacles like you getting in the way of Unova's new dawn!",
+      4: "Pokémon that work with humans might look happy, but they're suffering, count on it! No doubt about it!",
+      5: "If I win against you, release your Pokémon !",
+      6: "As a proud member of Team Plasma, I will gladly battle with you.",
+      7: "YOU! To please my Pokémon , lose!",
+      8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
+      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
     },
     "victory": {
-      1: "Wie konnte ich verlieren? Ich dachte, ich würde die Welt retten…"
+      1: "Wie konnte ich verlieren? Ich dachte, ich würde die Welt retten…",
+      2: "You daft codger, your mask's absurd!",
+      3: "If you try to mess with me, I'll shut you down with a Pokémon battle.",
+      4: "How could I lose...",
+      5: "I think Lord N would approve of a rematch clause.",
+      6: "I guess my Pokémon liberation degree needs updating.",
+      7: "Note to self: practice Pokémon battling, liberate Pokémon better."
     },
   },
   "flare_grunt": {
     "encounter": {
       1: `Ich bin ein Mitglied von Team Flare! Das sieht man mir doch an. Mein Stil ist unverkennbar!
-          $Du kannst definitiv ein Umstyling gebrauchen!`
+          $Du kannst definitiv ein Umstyling gebrauchen!`,
+      2: "Team Flare will cleanse the world of imperfection!",
+      3: "Prepare to face the brilliance of Team Flare!",
+      4: "Team Flare's style and grace will outshine any opponent!",
+      5: "Your Pokémon are no match for the elegance of Team Flare."
     },
     "victory": {
-      1: "Stil ist wohl doch nicht alles…"
+      1: "Stil ist wohl doch nicht alles…",
+      2: "Gahh?! I lost?!",
+      3: "I guess our beauty treatments didn't include battling skills.",
+      4: "Your victory today won't stop Team Flare's quest for a beautiful world.",
+      5: "Even in defeat, Team Flare's elegance shines through.",
+      6: "Perhaps there's more to battling than I thought. Back to the drawing board."
+
     },
   },
   "rocket_boss_giovanni_1": {

--- a/src/locales/de/dialogue.ts
+++ b/src/locales/de/dialogue.ts
@@ -398,7 +398,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
           $und es kommt noch härter!
           $Wir wollen über die Erde regieren…
           $und naja du kennst den Rest…!`,
-      2: "Come from Johto will they, mine allies, yes. Will revenge they are",
+      2: "OH NO! I DROPPED THE LIFT KEY!",
       3: "You say what? Team Rocket bye-bye a go-go? Broken up it is says you?",
       4: "To denounce the evils of truth and love!",
       5: "We Team Rocket are Pokémon gangsters!",
@@ -407,7 +407,8 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Hand over your Pokémon, or face the wrath of Team Rocket!",
       9: "We are Team Rocket, and we're here to steal your Pokémon!",
       10: "You're about to experience the true terror of Team Rocket!",
-      11: "Resistance is futile! Give us your Pokémon or face the consequences!"
+      11: "Resistance is futile! Give us your Pokémon or face the consequences!",
+      12: "STEAL for team rocket EXPLOIT for team rocket"
     },
     "victory": {
       1: "Das war mal wieder ein Schuss in den Ofen!",
@@ -420,18 +421,19 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "I blew it!",
       9: "My associates won't stand for this!",
       10: "So, you are good…",
-      11: "I'm steamed..."
+      11: "I'm steamed...",
+      12: "Come from Johto will they, mine allies, yes. Will revenge they are",
     },
   },
   "magma_grunt": {
     "encounter": {
       1: "Keiner, der sich Team Magma in den Weg stellt, bekommt Gnade, nicht einmal Kinder!",
-      2: "I should've brought my Game Boy Advance SP to play some Pokémon Sapphire  instead.",
+      2: "Get ready to feel the heat! And by heat, I mean my burning desire to win!",
       3: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
       4: "Heh, I'd like to you see try!",
       5: "Huh? What are you doing here?",
-      6: "Don't get any ideas about going easy on us just because you're a kid! We'll show you the power of Team Magma's amazing technology!",
-      7: "We, Team Magma, are working hard for everyone's sake. If there's more land, there'll be more places to live! Everyone would be happy!",
+      6: "We'll show you the power of Team Magma's amazing technology!",
+      7: "If there's more land, there'll be more places to live!",
       8: "You'd better not interfere with our plans! We're making the world a better place!",
       9: "You're in the way! Team Magma has no time for kids like you!",
       10: "Do you really think you can take on Team Magma? You're just a kid!",
@@ -442,7 +444,6 @@ export const PGMdialogue: DialogueTranslationEntries = {
       15: "Prepare to face my wrath... and my slightly underleveled Pokémon!",
       16: "Hope you brought sunscreen, 'cause you're about to get burned!",
       17: "You're in the way! Team Magma has no time for kids like you!",
-
     },
     "victory": {
       1: "Wie kann das sein? Ich bin Teil vom mächtigen Team Magma! Wir wollen doch nur die Welt verbessern…",
@@ -452,7 +453,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "What, what, what?",
       6: "I'm getting heat exhaustion…",
       7: "I failed to win, I should've planned better...",
-      8: "I'm steamed...",
+      8: "I'm heated...",
       9: "Oof... you got me.",
       10: "What?! I lost?! How could this be...?",
       11: "No way! You're just a kid!",
@@ -467,13 +468,13 @@ export const PGMdialogue: DialogueTranslationEntries = {
   "aqua_grunt": {
     "encounter": {
       1: "Du willst dich also mit Team Aqua anlegen? Du traust dich ja was… Dich werfe ich über Bord!",
-      2: "I should've brought my Game Boy Advance SP to play some Pokémon Ruby instead.",
-      3: "I was going to ambush you, but you had to dawdle in Petalburg Woods forever, didn't you?",
+      2: "I was going to ambush you, but you had to dawdle in the Plains forever, didn't you?",
+      3: "You're about to get soaked! And not just from my Pokémon's Water Gun.",
       4: "Grrr…You've got some nerve meddling with Team Aqua!",
       5: "Hey, you there! Don't butt in!",
       6: "Hey, there! Quit pushing! This is the line, can't you see?",
       7: "We, Team Aqua, exist for the good of all!",
-      8: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
+      8: "Prepare to be washed away by the tides of my… uh, Pokémon! Yeah, my Pokémon!",
     },
     "victory": {
       1: "Vielleicht sollte ich wohl lieber selber über die Planke gehen…",
@@ -498,7 +499,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Hope you're ready for a cosmic beatdown!",
       9: "Witness the power of our technology and the future we envision!",
       10: "In the name of Team Galactic, I'll eliminate anyone who stands in our way!",
-      11: "Looks like you're about to get starstruck...by our Pokémon!"
+      11: "Looks like you're about to get starstruck...by our Pokémon!",
+      12: "Because of you, they took my CLEFAIRY away...",
+      13: "If you try to mess with me, I'll shut you down with a Pokémon battle. So, what's it going to be? Are you going to mess with me?"
     },
     "victory": {
       1: "Zyrus wird uns für diese Niederlage bestrafen…",
@@ -511,31 +514,35 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Oops, our evil was no match for your Pokémon.",
       9: "This setback means nothing in the grand scheme.",
       10: "Our plans are bigger than this defeat.",
-      11: "I knew I should have trained more and evil-planned less."
+      11: "I knew I should have trained more and evil-planned less.",
+      12:"Looks like I need a new cosmic plan. This one fizzled out.",
+      13: "Defeated by a mere earthling… how embarrassing."
     },
   },
   "plasma_grunt": {
     "encounter": {
       1: "Pokémon sollten frei sein! Team Plasma wird sie befreien!",
-      2: "Bad for Team Plasma! Or Plasbad, for short!",
+      2: "Prepare to be dazzled by our galactic style! And by that, I mean defeated.",
       3: "There's no room for obstacles like you getting in the way of Unova's new dawn!",
       4: "Pokémon that work with humans might look happy, but they're suffering, count on it! No doubt about it!",
-      5: "If I win against you, release your Pokémon !",
+      5: "If I win against you, release your Pokémon!",
       6: "As a proud member of Team Plasma, I will gladly battle with you.",
-      7: "YOU! To please my Pokémon , lose!",
+      7: "YOU! To please my Pokémon, lose!",
       8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
-      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
+      9: "Team Plasma will liberate Pokémon from selfish humans like you!",
+      10: "Our hairstyles are out of this world... but our battling skills? You'll find out soon enough."
     },
     "victory": {
       1: "Wie konnte ich verlieren? Ich dachte, ich würde die Welt retten…",
-      2: "You daft codger, your mask's absurd!",
+      2: "Looks like you're not ready for a galactic takeover!",
       3: "If you try to mess with me, I'll shut you down with a Pokémon battle.",
       4: "How could I lose...",
       5: "I think Lord N would approve of a rematch clause.",
       6: "I guess my Pokémon liberation degree needs updating.",
       7: "Note to self: practice Pokémon battling, liberate Pokémon better.",
       8: "Better luck next time! Maybe join Team Plasma for a change?",
-      9: "We came, we saw, we Plasma'd!"
+      9: "We came, we saw, we Plasma'd!",
+      10: "This is bad... Badbadbadbadbadbadbad! Bad for Team Plasma! Or Plasbad, for short!"
     },
   },
   "flare_grunt": {
@@ -555,7 +562,6 @@ export const PGMdialogue: DialogueTranslationEntries = {
       4: "Your victory today won't stop Team Flare's quest for a beautiful world.",
       5: "Even in defeat, Team Flare's elegance shines through.",
       6: "Perhaps there's more to battling than I thought. Back to the drawing board."
-
     },
   },
   "rocket_boss_giovanni_1": {

--- a/src/locales/en/dialogue.ts
+++ b/src/locales/en/dialogue.ts
@@ -392,6 +392,10 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "We Team Rocket are Pokémon gangsters!",
       6: "We're pulling a big job here! Get lost, kid!",
       7: "You broke into our operation? You must be lost!",
+      8: "Hand over your Pokémon, or face the wrath of Team Rocket!",
+      9: "We are Team Rocket, and we're here to steal your Pokémon!",
+      10: "You're about to experience the true terror of Team Rocket!",
+      11: "Resistance is futile! Give us your Pokémon or face the consequences!"
     },
     "victory": {
       1: "Team Rocket blasting off again!",
@@ -423,7 +427,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
       13: "I hope you brought marshmallows because things are about to heat up!",
       14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
-      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!"
+      16: "Hope you brought sunscreen, 'cause you're about to get burned!",
+      17: "You're in the way! Team Magma has no time for kids like you!",
+
 
     },
     "victory": {
@@ -477,6 +483,10 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "Get ready to lose!",
       6: "You dare to challenge Team Galactic?",
       7: "Team Galactic will conquer all!",
+      8: "Hope you're ready for a cosmic beatdown!",
+      9: "Witness the power of our technology and the future we envision!",
+      10: "In the name of Team Galactic, I'll eliminate anyone who stands in our way!",
+      11: "Looks like you're about to get starstruck...by our Pokémon!"
 
     },
     "victory": {
@@ -512,7 +522,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       4: "How could I lose...",
       5: "I think Lord N would approve of a rematch clause.",
       6: "I guess my Pokémon liberation degree needs updating.",
-      7: "Note to self: practice Pokémon battling, liberate Pokémon better."
+      7: "Note to self: practice Pokémon battling, liberate Pokémon better.",
+      8: "Better luck next time! Maybe join Team Plasma for a change?",
+      9: "We came, we saw, we Plasma'd!"
     },
   },
   "flare_grunt": {

--- a/src/locales/en/dialogue.ts
+++ b/src/locales/en/dialogue.ts
@@ -385,42 +385,86 @@ export const PGMdialogue: DialogueTranslationEntries = {
   },
   "rocket_grunt": {
     "encounter": {
-      1: "Prepare for trouble!"
+      1: "Prepare for trouble!",
+      2: "Come from Johto will they, mine allies, yes. Will revenge they are",
+      3: "You say what? Team Rocket bye-bye a go-go? Broken up it is says you?",
+      4: "To denounce the evils of truth and love!",
+      5: "Stop! I give up! I'll leave quietly!"
     },
     "victory": {
-      1: "Team Rocket blasting off again!"
+      1: "Team Rocket blasting off again!",
+      2: "Winning is for winners.",
+      3: "You will regret this!",
+      4: "Blastin' off at the speed of light!",
+      5: "Blasting off again...."
     },
   },
   "magma_grunt": {
     "encounter": {
-      1: " If you get in the way of Team Magma, don’t expect any mercy!"
+      1: "If you get in the way of Team Magma, don't expect any mercy!",
+      2: "I should've brought my Game Boy Advance SP to play some Pokémon Sapphire  instead.",
+      3: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?"
     },
     "victory": {
-      1: "Huh? I lost?!"
+      1: "Huh? I lost?!",
+      2: "Urrrgh…I should've ducked into our hideout right away…",
+      3: "Okay, oh-kay! I admit it—you're strong!",
+      4: "Don't worry about me. Go wherever you want!",
+      5: "What, what, what?",
+      6: " I'm getting heat exhaustion…"
     },
   },
   "aqua_grunt": {
     "encounter": {
-      1: "No one who crosses Team Aqua gets any mercy, not even kids!"
+      1: "No one who crosses Team Aqua gets any mercy, not even kids!",
+      2: "I should've brought my Game Boy Advance SP to play some Pokémon Ruby instead.",
+      3: "I was going to ambush you, but you had to dawdle in Petalburg Woods forever, didn't you?",
+      4: "Grrr…You've got some nerve meddling with Team Aqua!",
+      5: "Hey, you there! Don't butt in!",
+      6: "Hey, there! Quit pushing! This is the line, can't you see?",
+      7: "We, Team Aqua, exist for the good of all!",
+      8: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?"
     },
     "victory": {
-      1: "You're kidding me!"
+      1: "You're kidding me!",
+      2: "Come on and battle me again!",
+      3: "I'll let you go today!",
+      4: "What?! I lost, too!",
+      5: "Arrgh, I didn't count on being meddled with by some meddling kid!"
     },
   },
   "galactic_grunt": {
     "encounter": {
-      1: "Don't mess with Team Galactic!"
+      1: "Don't mess with Team Galactic!",
+      2: "Our time has come!",
+      3: "It's team galactic's time now!",
+      4: "Hey, wanna join Team Galactic?",
+      5: "Get ready to lose!"
+
     },
     "victory": {
-      1: "Shut down..."
+      1: "Shut down...",
+      2: "Not bad...",
+      3: "How?!",
+      4: "I'll be back..",
+      5: "I'm outta here!"
     },
   },
   "plasma_grunt": {
     "encounter": {
-      1: "We won't tolerate people who have different ideas!"
+      1: "We won't tolerate people who have different ideas!",
+      2: "Bad for Team Plasma! Or Plasbad, for short!",
+      3: "There's no room for obstacles like you getting in the way of Unova's new dawn!",
+      4: "Pokémon that work with humans might look happy, but they're suffering, count on it! No doubt about it!",
+      5: "If I win against you, release your Pokémon !",
+      6: "As a proud member of Team Plasma, I will gladly battle with you.",
+      7: "YOU! To please my Pokémon , lose!"
     },
     "victory": {
-      1: "Plasmaaaaaaaaa!"
+      1: "Plasmaaaaaaaaa!",
+      2: "You daft codger, your mask's absurd!",
+      3: "If you try to mess with me, I'll shut you down with a Pokémon battle.",
+      4: "How could I lose..."
     },
   },
   "flare_grunt": {
@@ -428,7 +472,8 @@ export const PGMdialogue: DialogueTranslationEntries = {
       1: "Fashion is most important to us!"
     },
     "victory": {
-      1: "The future doesn't look bright for me."
+      1: "The future doesn't look bright for me.",
+      2: "Gahh?! I lost?!"
     },
   },
   "rocket_boss_giovanni_1": {

--- a/src/locales/en/dialogue.ts
+++ b/src/locales/en/dialogue.ts
@@ -502,7 +502,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
       9: "This setback means nothing in the grand scheme.",
       10: "Our plans are bigger than this defeat.",
       11: "I knew I should have trained more and evil-planned less.",
-      12:"Looks like I need a new cosmic plan. This one fizzled out.",
+      12: "Looks like I need a new cosmic plan. This one fizzled out.",
       13: "Defeated by a mere earthling… how embarrassing."
     },
   },

--- a/src/locales/en/dialogue.ts
+++ b/src/locales/en/dialogue.ts
@@ -386,7 +386,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
   "rocket_grunt": {
     "encounter": {
       1: "Prepare for trouble!",
-      2: "Come from Johto will they, mine allies, yes. Will revenge they are",
+      2: "OH NO! I DROPPED THE LIFT KEY!",
       3: "You say what? Team Rocket bye-bye a go-go? Broken up it is says you?",
       4: "To denounce the evils of truth and love!",
       5: "We Team Rocket are Pokémon gangsters!",
@@ -395,7 +395,8 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Hand over your Pokémon, or face the wrath of Team Rocket!",
       9: "We are Team Rocket, and we're here to steal your Pokémon!",
       10: "You're about to experience the true terror of Team Rocket!",
-      11: "Resistance is futile! Give us your Pokémon or face the consequences!"
+      11: "Resistance is futile! Give us your Pokémon or face the consequences!",
+      12: "STEAL for team rocket EXPLOIT for team rocket"
     },
     "victory": {
       1: "Team Rocket blasting off again!",
@@ -408,18 +409,19 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "I blew it!",
       9: "My associates won't stand for this!",
       10: "So, you are good…",
-      11: "I'm steamed..."
+      11: "I'm steamed...",
+      12: "Come from Johto will they, mine allies, yes. Will revenge they are",
     },
   },
   "magma_grunt": {
     "encounter": {
       1: "If you get in the way of Team Magma, don't expect any mercy!",
-      2: "I should've brought my Game Boy Advance SP to play some Pokémon Sapphire  instead.",
+      2: "Get ready to feel the heat! And by heat, I mean my burning desire to win!",
       3: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
       4: "Heh, I'd like to you see try!",
       5: "Huh? What are you doing here?",
-      6: "Don't get any ideas about going easy on us just because you're a kid! We'll show you the power of Team Magma's amazing technology!",
-      7: "We, Team Magma, are working hard for everyone's sake. If there's more land, there'll be more places to live! Everyone would be happy!",
+      6: "We'll show you the power of Team Magma's amazing technology!",
+      7: "If there's more land, there'll be more places to live!",
       8: "You'd better not interfere with our plans! We're making the world a better place!",
       9: "You're in the way! Team Magma has no time for kids like you!",
       10: "Do you really think you can take on Team Magma? You're just a kid!",
@@ -429,8 +431,6 @@ export const PGMdialogue: DialogueTranslationEntries = {
       14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
       16: "Hope you brought sunscreen, 'cause you're about to get burned!",
       17: "You're in the way! Team Magma has no time for kids like you!",
-
-
     },
     "victory": {
       1: "Huh? I lost?!",
@@ -440,7 +440,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "What, what, what?",
       6: "I'm getting heat exhaustion…",
       7: "I failed to win, I should've planned better...",
-      8: "I'm steamed...",
+      8: "I'm heated...",
       9: "Oof... you got me.",
       10: "What?! I lost?! How could this be...?",
       11: "No way! You're just a kid!",
@@ -455,13 +455,13 @@ export const PGMdialogue: DialogueTranslationEntries = {
   "aqua_grunt": {
     "encounter": {
       1: "No one who crosses Team Aqua gets any mercy, not even kids!",
-      2: "I should've brought my Game Boy Advance SP to play some Pokémon Ruby instead.",
-      3: "I was going to ambush you, but you had to dawdle in Petalburg Woods forever, didn't you?",
+      2: "I was going to ambush you, but you had to dawdle in the Plains forever, didn't you?",
+      3: "You're about to get soaked! And not just from my Pokémon's Water Gun.",
       4: "Grrr…You've got some nerve meddling with Team Aqua!",
       5: "Hey, you there! Don't butt in!",
       6: "Hey, there! Quit pushing! This is the line, can't you see?",
       7: "We, Team Aqua, exist for the good of all!",
-      8: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
+      8: "Prepare to be washed away by the tides of my… uh, Pokémon! Yeah, my Pokémon!",
     },
     "victory": {
       1: "You're kidding me!",
@@ -486,8 +486,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Hope you're ready for a cosmic beatdown!",
       9: "Witness the power of our technology and the future we envision!",
       10: "In the name of Team Galactic, I'll eliminate anyone who stands in our way!",
-      11: "Looks like you're about to get starstruck...by our Pokémon!"
-
+      11: "Looks like you're about to get starstruck...by our Pokémon!",
+      12: "Because of you, they took my CLEFAIRY away...",
+      13: "If you try to mess with me, I'll shut you down with a Pokémon battle. So, what's it going to be? Are you going to mess with me?"
     },
     "victory": {
       1: "Shut down...",
@@ -500,31 +501,35 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Oops, our evil was no match for your Pokémon.",
       9: "This setback means nothing in the grand scheme.",
       10: "Our plans are bigger than this defeat.",
-      11: "I knew I should have trained more and evil-planned less."
+      11: "I knew I should have trained more and evil-planned less.",
+      12:"Looks like I need a new cosmic plan. This one fizzled out.",
+      13: "Defeated by a mere earthling… how embarrassing."
     },
   },
   "plasma_grunt": {
     "encounter": {
       1: "We won't tolerate people who have different ideas!",
-      2: "Bad for Team Plasma! Or Plasbad, for short!",
+      2: "Prepare to be dazzled by our galactic style! And by that, I mean defeated.",
       3: "There's no room for obstacles like you getting in the way of Unova's new dawn!",
       4: "Pokémon that work with humans might look happy, but they're suffering, count on it! No doubt about it!",
-      5: "If I win against you, release your Pokémon !",
+      5: "If I win against you, release your Pokémon!",
       6: "As a proud member of Team Plasma, I will gladly battle with you.",
-      7: "YOU! To please my Pokémon , lose!",
+      7: "YOU! To please my Pokémon, lose!",
       8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
-      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
+      9: "Team Plasma will liberate Pokémon from selfish humans like you!",
+      10: "Our hairstyles are out of this world... but our battling skills? You'll find out soon enough."
     },
     "victory": {
       1: "Plasmaaaaaaaaa!",
-      2: "You daft codger, your mask's absurd!",
+      2: "Looks like you're not ready for a galactic takeover!",
       3: "If you try to mess with me, I'll shut you down with a Pokémon battle.",
       4: "How could I lose...",
       5: "I think Lord N would approve of a rematch clause.",
       6: "I guess my Pokémon liberation degree needs updating.",
       7: "Note to self: practice Pokémon battling, liberate Pokémon better.",
       8: "Better luck next time! Maybe join Team Plasma for a change?",
-      9: "We came, we saw, we Plasma'd!"
+      9: "We came, we saw, we Plasma'd!",
+      10: "This is bad... Badbadbadbadbadbadbad! Bad for Team Plasma! Or Plasbad, for short!"
     },
   },
   "flare_grunt": {
@@ -533,7 +538,8 @@ export const PGMdialogue: DialogueTranslationEntries = {
       2: "Team Flare will cleanse the world of imperfection!",
       3: "Prepare to face the brilliance of Team Flare!",
       4: "Team Flare's style and grace will outshine any opponent!",
-      5: "Your Pokémon are no match for the elegance of Team Flare."
+      5: "Your Pokémon are no match for the elegance of Team Flare.",
+      6: "Hope you brought your sunglasses, because things are about to get bright!"
     },
     "victory": {
       1: "The future doesn't look bright for me.",
@@ -542,7 +548,6 @@ export const PGMdialogue: DialogueTranslationEntries = {
       4: "Your victory today won't stop Team Flare's quest for a beautiful world.",
       5: "Even in defeat, Team Flare's elegance shines through.",
       6: "Perhaps there's more to battling than I thought. Back to the drawing board."
-
     },
   },
   "rocket_boss_giovanni_1": {

--- a/src/locales/en/dialogue.ts
+++ b/src/locales/en/dialogue.ts
@@ -428,7 +428,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
       11: "We're going to use the power of a volcano! It's gonna be... explosive! Get it? Heh heh!",
       12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
       13: "I hope you brought marshmallows because things are about to heat up!",
-      14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
+      14: "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
       16: "Hope you brought sunscreen, 'cause you're about to get burned!",
       17: "You're in the way! Team Magma has no time for kids like you!",
     },

--- a/src/locales/en/dialogue.ts
+++ b/src/locales/en/dialogue.ts
@@ -445,7 +445,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
       10: "What?! I lost?! How could this be...?",
       11: "No way! You're just a kid!",
       12: "What? I lost? But... but I was supposed to win!",
-      13:  "I lost?! Now I'll never get promoted to Team Magma Senior Grunt!",
+      13: "I lost?! Now I'll never get promoted to Team Magma Senior Grunt!",
       14: "You beat me... Do you think the boss will dock my pay for this?",
       15: "I can't believe I lost! I even skipped lunch for this!",
       16: "Defeated... I guess evil masterminds don't get sick days, huh?",

--- a/src/locales/en/dialogue.ts
+++ b/src/locales/en/dialogue.ts
@@ -389,21 +389,42 @@ export const PGMdialogue: DialogueTranslationEntries = {
       2: "Come from Johto will they, mine allies, yes. Will revenge they are",
       3: "You say what? Team Rocket bye-bye a go-go? Broken up it is says you?",
       4: "To denounce the evils of truth and love!",
-      5: "Stop! I give up! I'll leave quietly!"
+      5: "We Team Rocket are Pokémon gangsters!",
+      6: "We're pulling a big job here! Get lost, kid!",
+      7: "You broke into our operation? You must be lost!",
     },
     "victory": {
       1: "Team Rocket blasting off again!",
       2: "Winning is for winners.",
       3: "You will regret this!",
       4: "Blastin' off at the speed of light!",
-      5: "Blasting off again...."
+      5: "Blasting off again....",
+      6: "Stop! I give up! I'll leave quietly!",
+      7: "You made me mad! Team Rocket will blacklist you!",
+      8: "I blew it!",
+      9: "My associates won't stand for this!",
+      10: "So, you are good…",
+      11: "I'm steamed..."
     },
   },
   "magma_grunt": {
     "encounter": {
       1: "If you get in the way of Team Magma, don't expect any mercy!",
       2: "I should've brought my Game Boy Advance SP to play some Pokémon Sapphire  instead.",
-      3: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?"
+      3: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
+      4: "Heh, I'd like to you see try!",
+      5: "Huh? What are you doing here?",
+      6: "Don't get any ideas about going easy on us just because you're a kid! We'll show you the power of Team Magma's amazing technology!",
+      7: "We, Team Magma, are working hard for everyone's sake. If there's more land, there'll be more places to live! Everyone would be happy!",
+      8: "You'd better not interfere with our plans! We're making the world a better place!",
+      9: "You're in the way! Team Magma has no time for kids like you!",
+      10: "Do you really think you can take on Team Magma? You're just a kid!",
+      11: "We're going to use the power of a volcano! It's gonna be... explosive! Get it? Heh heh!",
+      12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
+      13: "I hope you brought marshmallows because things are about to heat up!",
+      14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
+      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!"
+
     },
     "victory": {
       1: "Huh? I lost?!",
@@ -411,7 +432,18 @@ export const PGMdialogue: DialogueTranslationEntries = {
       3: "Okay, oh-kay! I admit it—you're strong!",
       4: "Don't worry about me. Go wherever you want!",
       5: "What, what, what?",
-      6: " I'm getting heat exhaustion…"
+      6: "I'm getting heat exhaustion…",
+      7: "I failed to win, I should've planned better...",
+      8: "I'm steamed...",
+      9: "Oof... you got me.",
+      10: "What?! I lost?! How could this be...?",
+      11: "No way! You're just a kid!",
+      12: "What? I lost? But... but I was supposed to win!",
+      13:  "I lost?! Now I'll never get promoted to Team Magma Senior Grunt!",
+      14: "You beat me... Do you think the boss will dock my pay for this?",
+      15: "I can't believe I lost! I even skipped lunch for this!",
+      16: "Defeated... I guess evil masterminds don't get sick days, huh?",
+      17: "I should have brought more potions... and a better strategy."
     },
   },
   "aqua_grunt": {
@@ -423,14 +455,17 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "Hey, you there! Don't butt in!",
       6: "Hey, there! Quit pushing! This is the line, can't you see?",
       7: "We, Team Aqua, exist for the good of all!",
-      8: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?"
+      8: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
     },
     "victory": {
       1: "You're kidding me!",
       2: "Come on and battle me again!",
       3: "I'll let you go today!",
       4: "What?! I lost, too!",
-      5: "Arrgh, I didn't count on being meddled with by some meddling kid!"
+      5: "Arrgh, I didn't count on being meddled with by some meddling kid!",
+      6: "I lost?! Guess I'll have to swim back to the hideout now...",
+      7: "You beat me... Do you think the boss will make me walk the plank for this?",
+      8: "I lost?!"
     },
   },
   "galactic_grunt": {
@@ -439,7 +474,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       2: "Our time has come!",
       3: "It's team galactic's time now!",
       4: "Hey, wanna join Team Galactic?",
-      5: "Get ready to lose!"
+      5: "Get ready to lose!",
+      6: "You dare to challenge Team Galactic?",
+      7: "Team Galactic will conquer all!",
 
     },
     "victory": {
@@ -447,7 +484,13 @@ export const PGMdialogue: DialogueTranslationEntries = {
       2: "Not bad...",
       3: "How?!",
       4: "I'll be back..",
-      5: "I'm outta here!"
+      5: "I'm outta here!",
+      6: "Maybe we should stick to evil plans and leave battling to someone else.",
+      7: "Note to self: practice Pokémon battling, ASAP.",
+      8: "Oops, our evil was no match for your Pokémon.",
+      9: "This setback means nothing in the grand scheme.",
+      10: "Our plans are bigger than this defeat.",
+      11: "I knew I should have trained more and evil-planned less."
     },
   },
   "plasma_grunt": {
@@ -458,22 +501,36 @@ export const PGMdialogue: DialogueTranslationEntries = {
       4: "Pokémon that work with humans might look happy, but they're suffering, count on it! No doubt about it!",
       5: "If I win against you, release your Pokémon !",
       6: "As a proud member of Team Plasma, I will gladly battle with you.",
-      7: "YOU! To please my Pokémon , lose!"
+      7: "YOU! To please my Pokémon , lose!",
+      8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
+      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
     },
     "victory": {
       1: "Plasmaaaaaaaaa!",
       2: "You daft codger, your mask's absurd!",
       3: "If you try to mess with me, I'll shut you down with a Pokémon battle.",
-      4: "How could I lose..."
+      4: "How could I lose...",
+      5: "I think Lord N would approve of a rematch clause.",
+      6: "I guess my Pokémon liberation degree needs updating.",
+      7: "Note to self: practice Pokémon battling, liberate Pokémon better."
     },
   },
   "flare_grunt": {
     "encounter": {
-      1: "Fashion is most important to us!"
+      1: "Fashion is most important to us!",
+      2: "Team Flare will cleanse the world of imperfection!",
+      3: "Prepare to face the brilliance of Team Flare!",
+      4: "Team Flare's style and grace will outshine any opponent!",
+      5: "Your Pokémon are no match for the elegance of Team Flare."
     },
     "victory": {
       1: "The future doesn't look bright for me.",
-      2: "Gahh?! I lost?!"
+      2: "Gahh?! I lost?!",
+      3: "I guess our beauty treatments didn't include battling skills.",
+      4: "Your victory today won't stop Team Flare's quest for a beautiful world.",
+      5: "Even in defeat, Team Flare's elegance shines through.",
+      6: "Perhaps there's more to battling than I thought. Back to the drawing board."
+
     },
   },
   "rocket_boss_giovanni_1": {

--- a/src/locales/es/dialogue.ts
+++ b/src/locales/es/dialogue.ts
@@ -392,6 +392,10 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "We Team Rocket are Pokémon gangsters!",
       6: "We're pulling a big job here! Get lost, kid!",
       7: "You broke into our operation? You must be lost!",
+      8: "Hand over your Pokémon, or face the wrath of Team Rocket!",
+      9: "We are Team Rocket, and we're here to steal your Pokémon!",
+      10: "You're about to experience the true terror of Team Rocket!",
+      11: "Resistance is futile! Give us your Pokémon or face the consequences!"
     },
     "victory": {
       1: "¡El Team Rocket despega de nuevo!",
@@ -423,7 +427,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
       13: "I hope you brought marshmallows because things are about to heat up!",
       14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
-      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!"
+      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!",
+      16: "Hope you brought sunscreen, 'cause you're about to get burned!",
+      17: "You're in the way! Team Magma has no time for kids like you!",
     },
     "victory": {
       1: "¿Eh? ¿He perdido?",
@@ -476,6 +482,10 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "Get ready to lose!",
       6: "You dare to challenge Team Galactic?",
       7: "Team Galactic will conquer all!",
+      8: "Hope you're ready for a cosmic beatdown!",
+      9: "Witness the power of our technology and the future we envision!",
+      10: "In the name of Team Galactic, I'll eliminate anyone who stands in our way!",
+      11: "Looks like you're about to get starstruck...by our Pokémon!"
     },
     "victory": {
       1: "Me callaste la boca...",
@@ -510,7 +520,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       4: "How could I lose...",
       5: "I think Lord N would approve of a rematch clause.",
       6: "I guess my Pokémon liberation degree needs updating.",
-      7: "Note to self: practice Pokémon battling, liberate Pokémon better."
+      7: "Note to self: practice Pokémon battling, liberate Pokémon better.",
+      8: "Better luck next time! Maybe join Team Plasma for a change?",
+      9: "We came, we saw, we Plasma'd!"
     },
   },
   "flare_grunt": {
@@ -519,7 +531,8 @@ export const PGMdialogue: DialogueTranslationEntries = {
       2: "Team Flare will cleanse the world of imperfection!",
       3: "Prepare to face the brilliance of Team Flare!",
       4: "Team Flare's style and grace will outshine any opponent!",
-      5: "Your Pokémon are no match for the elegance of Team Flare."
+      5: "Your Pokémon are no match for the elegance of Team Flare.",
+      6: "Hope you brought your sunglasses, because things are about to get bright!"
     },
     "victory": {
       1: "Me temo que se me avecina un futuro oscuro...",

--- a/src/locales/es/dialogue.ts
+++ b/src/locales/es/dialogue.ts
@@ -385,50 +385,149 @@ export const PGMdialogue: DialogueTranslationEntries = {
   },
   "rocket_grunt": {
     "encounter": {
-      1: "¡Ríndete ahora, o prepárate para luchar!"
+      1: "¡Ríndete ahora, o prepárate para luchar!",
+      2: "Come from Johto will they, mine allies, yes. Will revenge they are",
+      3: "You say what? Team Rocket bye-bye a go-go? Broken up it is says you?",
+      4: "To denounce the evils of truth and love!",
+      5: "We Team Rocket are Pokémon gangsters!",
+      6: "We're pulling a big job here! Get lost, kid!",
+      7: "You broke into our operation? You must be lost!",
     },
     "victory": {
-      1: "¡El Team Rocket despega de nuevo!"
+      1: "¡El Team Rocket despega de nuevo!",
+      2: "Winning is for winners.",
+      3: "You will regret this!",
+      4: "Blastin' off at the speed of light!",
+      5: "Blasting off again....",
+      6: "Stop! I give up! I'll leave quietly!",
+      7: "You made me mad! Team Rocket will blacklist you!",
+      8: "I blew it!",
+      9: "My associates won't stand for this!",
+      10: "So, you are good…",
+      11: "I'm steamed..."
     },
   },
   "magma_grunt": {
     "encounter": {
-      1: "¡No esperes piedad si te interpones al Team Magma!"
+      1: "¡No esperes piedad si te interpones al Team Magma!",
+      2: "I should've brought my Game Boy Advance SP to play some Pokémon Sapphire  instead.",
+      3: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
+      4: "Heh, I'd like to you see try!",
+      5: "Huh? What are you doing here?",
+      6: "Don't get any ideas about going easy on us just because you're a kid! We'll show you the power of Team Magma's amazing technology!",
+      7: "We, Team Magma, are working hard for everyone's sake. If there's more land, there'll be more places to live! Everyone would be happy!",
+      8: "You'd better not interfere with our plans! We're making the world a better place!",
+      9: "You're in the way! Team Magma has no time for kids like you!",
+      10: "Do you really think you can take on Team Magma? You're just a kid!",
+      11: "We're going to use the power of a volcano! It's gonna be... explosive! Get it? Heh heh!",
+      12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
+      13: "I hope you brought marshmallows because things are about to heat up!",
+      14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
+      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!"
     },
     "victory": {
-      1: "¿Eh? ¿He perdido?"
+      1: "¿Eh? ¿He perdido?",
+      2: "Urrrgh…I should've ducked into our hideout right away…",
+      3: "Okay, oh-kay! I admit it—you're strong!",
+      4: "Don't worry about me. Go wherever you want!",
+      5: "What, what, what?",
+      6: "I'm getting heat exhaustion…",
+      7: "I failed to win, I should've planned better...",
+      8: "I'm steamed...",
+      9: "Oof... you got me.",
+      10: "What?! I lost?! How could this be...?",
+      11: "No way! You're just a kid!",
+      12: "What? I lost? But... but I was supposed to win!",
+      13:  "I lost?! Now I'll never get promoted to Team Magma Senior Grunt!",
+      14: "You beat me... Do you think the boss will dock my pay for this?",
+      15: "I can't believe I lost! I even skipped lunch for this!",
+      16: "Defeated... I guess evil masterminds don't get sick days, huh?",
+      17: "I should have brought more potions... and a better strategy."
     },
   },
   "aqua_grunt": {
     "encounter": {
-      1: "El Team Aqua no muestra piedad, ¡ni siquiera a los niños!"
+      1: "El Team Aqua no muestra piedad, ¡ni siquiera a los niños!",
+      2: "I should've brought my Game Boy Advance SP to play some Pokémon Ruby instead.",
+      3: "I was going to ambush you, but you had to dawdle in Petalburg Woods forever, didn't you?",
+      4: "Grrr…You've got some nerve meddling with Team Aqua!",
+      5: "Hey, you there! Don't butt in!",
+      6: "Hey, there! Quit pushing! This is the line, can't you see?",
+      7: "We, Team Aqua, exist for the good of all!",
+      8: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
     },
     "victory": {
-      1: "¡Bromeas! ¡No me lo creo!"
+      1: "¡Bromeas! ¡No me lo creo!",
+      2: "Come on and battle me again!",
+      3: "I'll let you go today!",
+      4: "What?! I lost, too!",
+      5: "Arrgh, I didn't count on being meddled with by some meddling kid!",
+      6: "I lost?! Guess I'll have to swim back to the hideout now...",
+      7: "You beat me... Do you think the boss will make me walk the plank for this?",
+      8: "I lost?!"
     },
   },
   "galactic_grunt": {
     "encounter": {
-      1: "¡No desafíes al Equipo Galaxia, te arrepentirás!"
+      1: "¡No desafíes al Equipo Galaxia, te arrepentirás!",
+      2: "Our time has come!",
+      3: "It's team galactic's time now!",
+      4: "Hey, wanna join Team Galactic?",
+      5: "Get ready to lose!",
+      6: "You dare to challenge Team Galactic?",
+      7: "Team Galactic will conquer all!",
     },
     "victory": {
-      1: "Me callaste la boca..."
+      1: "Me callaste la boca...",
+      2: "Not bad...",
+      3: "How?!",
+      4: "I'll be back..",
+      5: "I'm outta here!",
+      6: "Maybe we should stick to evil plans and leave battling to someone else.",
+      7: "Note to self: practice Pokémon battling, ASAP.",
+      8: "Oops, our evil was no match for your Pokémon.",
+      9: "This setback means nothing in the grand scheme.",
+      10: "Our plans are bigger than this defeat.",
+      11: "I knew I should have trained more and evil-planned less."
     },
   },
   "plasma_grunt": {
     "encounter": {
-      1: "¡El Equipo Plasma no tolerará otros ideales!"
+      1: "¡El Equipo Plasma no tolerará otros ideales!",
+      2: "Bad for Team Plasma! Or Plasbad, for short!",
+      3: "There's no room for obstacles like you getting in the way of Unova's new dawn!",
+      4: "Pokémon that work with humans might look happy, but they're suffering, count on it! No doubt about it!",
+      5: "If I win against you, release your Pokémon !",
+      6: "As a proud member of Team Plasma, I will gladly battle with you.",
+      7: "YOU! To please my Pokémon , lose!",
+      8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
+      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
     },
     "victory": {
-      1: "Plasmaaaaaaaaa!"
+      1: "Plasmaaaaaaaaa!",
+      2: "You daft codger, your mask's absurd!",
+      3: "If you try to mess with me, I'll shut you down with a Pokémon battle.",
+      4: "How could I lose...",
+      5: "I think Lord N would approve of a rematch clause.",
+      6: "I guess my Pokémon liberation degree needs updating.",
+      7: "Note to self: practice Pokémon battling, liberate Pokémon better."
     },
   },
   "flare_grunt": {
     "encounter": {
-      1: "¡La moda es lo más importante para nosotros!"
+      1: "¡La moda es lo más importante para nosotros!",
+      2: "Team Flare will cleanse the world of imperfection!",
+      3: "Prepare to face the brilliance of Team Flare!",
+      4: "Team Flare's style and grace will outshine any opponent!",
+      5: "Your Pokémon are no match for the elegance of Team Flare."
     },
     "victory": {
-      1: "Me temo que se me avecina un futuro oscuro..."
+      1: "Me temo que se me avecina un futuro oscuro...",
+      2: "Gahh?! I lost?!",
+      3: "I guess our beauty treatments didn't include battling skills.",
+      4: "Your victory today won't stop Team Flare's quest for a beautiful world.",
+      5: "Even in defeat, Team Flare's elegance shines through.",
+      6: "Perhaps there's more to battling than I thought. Back to the drawing board."
     },
   },
   "rocket_boss_giovanni_1": {

--- a/src/locales/es/dialogue.ts
+++ b/src/locales/es/dialogue.ts
@@ -386,7 +386,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
   "rocket_grunt": {
     "encounter": {
       1: "¡Ríndete ahora, o prepárate para luchar!",
-      2: "Come from Johto will they, mine allies, yes. Will revenge they are",
+      2: "OH NO! I DROPPED THE LIFT KEY!",
       3: "You say what? Team Rocket bye-bye a go-go? Broken up it is says you?",
       4: "To denounce the evils of truth and love!",
       5: "We Team Rocket are Pokémon gangsters!",
@@ -395,7 +395,8 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Hand over your Pokémon, or face the wrath of Team Rocket!",
       9: "We are Team Rocket, and we're here to steal your Pokémon!",
       10: "You're about to experience the true terror of Team Rocket!",
-      11: "Resistance is futile! Give us your Pokémon or face the consequences!"
+      11: "Resistance is futile! Give us your Pokémon or face the consequences!",
+      12: "STEAL for team rocket EXPLOIT for team rocket"
     },
     "victory": {
       1: "¡El Team Rocket despega de nuevo!",
@@ -408,18 +409,19 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "I blew it!",
       9: "My associates won't stand for this!",
       10: "So, you are good…",
-      11: "I'm steamed..."
+      11: "I'm steamed...",
+      12: "Come from Johto will they, mine allies, yes. Will revenge they are",
     },
   },
   "magma_grunt": {
     "encounter": {
       1: "¡No esperes piedad si te interpones al Team Magma!",
-      2: "I should've brought my Game Boy Advance SP to play some Pokémon Sapphire  instead.",
+      2: "Get ready to feel the heat! And by heat, I mean my burning desire to win!",
       3: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
       4: "Heh, I'd like to you see try!",
       5: "Huh? What are you doing here?",
-      6: "Don't get any ideas about going easy on us just because you're a kid! We'll show you the power of Team Magma's amazing technology!",
-      7: "We, Team Magma, are working hard for everyone's sake. If there's more land, there'll be more places to live! Everyone would be happy!",
+      6: "We'll show you the power of Team Magma's amazing technology!",
+      7: "If there's more land, there'll be more places to live!",
       8: "You'd better not interfere with our plans! We're making the world a better place!",
       9: "You're in the way! Team Magma has no time for kids like you!",
       10: "Do you really think you can take on Team Magma? You're just a kid!",
@@ -427,7 +429,6 @@ export const PGMdialogue: DialogueTranslationEntries = {
       12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
       13: "I hope you brought marshmallows because things are about to heat up!",
       14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
-      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!",
       16: "Hope you brought sunscreen, 'cause you're about to get burned!",
       17: "You're in the way! Team Magma has no time for kids like you!",
     },
@@ -439,7 +440,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "What, what, what?",
       6: "I'm getting heat exhaustion…",
       7: "I failed to win, I should've planned better...",
-      8: "I'm steamed...",
+      8: "I'm heated...",
       9: "Oof... you got me.",
       10: "What?! I lost?! How could this be...?",
       11: "No way! You're just a kid!",
@@ -454,13 +455,13 @@ export const PGMdialogue: DialogueTranslationEntries = {
   "aqua_grunt": {
     "encounter": {
       1: "El Team Aqua no muestra piedad, ¡ni siquiera a los niños!",
-      2: "I should've brought my Game Boy Advance SP to play some Pokémon Ruby instead.",
-      3: "I was going to ambush you, but you had to dawdle in Petalburg Woods forever, didn't you?",
+      2: "I was going to ambush you, but you had to dawdle in the Plains forever, didn't you?",
+      3: "You're about to get soaked! And not just from my Pokémon's Water Gun.",
       4: "Grrr…You've got some nerve meddling with Team Aqua!",
       5: "Hey, you there! Don't butt in!",
       6: "Hey, there! Quit pushing! This is the line, can't you see?",
       7: "We, Team Aqua, exist for the good of all!",
-      8: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
+      8: "Prepare to be washed away by the tides of my… uh, Pokémon! Yeah, my Pokémon!",
     },
     "victory": {
       1: "¡Bromeas! ¡No me lo creo!",
@@ -485,7 +486,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Hope you're ready for a cosmic beatdown!",
       9: "Witness the power of our technology and the future we envision!",
       10: "In the name of Team Galactic, I'll eliminate anyone who stands in our way!",
-      11: "Looks like you're about to get starstruck...by our Pokémon!"
+      11: "Looks like you're about to get starstruck...by our Pokémon!",
+      12: "Because of you, they took my CLEFAIRY away...",
+      13: "If you try to mess with me, I'll shut you down with a Pokémon battle. So, what's it going to be? Are you going to mess with me?"
     },
     "victory": {
       1: "Me callaste la boca...",
@@ -498,31 +501,35 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Oops, our evil was no match for your Pokémon.",
       9: "This setback means nothing in the grand scheme.",
       10: "Our plans are bigger than this defeat.",
-      11: "I knew I should have trained more and evil-planned less."
+      11: "I knew I should have trained more and evil-planned less.",
+      12:"Looks like I need a new cosmic plan. This one fizzled out.",
+      13: "Defeated by a mere earthling… how embarrassing."
     },
   },
   "plasma_grunt": {
     "encounter": {
       1: "¡El Equipo Plasma no tolerará otros ideales!",
-      2: "Bad for Team Plasma! Or Plasbad, for short!",
+      2: "Prepare to be dazzled by our galactic style! And by that, I mean defeated.",
       3: "There's no room for obstacles like you getting in the way of Unova's new dawn!",
       4: "Pokémon that work with humans might look happy, but they're suffering, count on it! No doubt about it!",
-      5: "If I win against you, release your Pokémon !",
+      5: "If I win against you, release your Pokémon!",
       6: "As a proud member of Team Plasma, I will gladly battle with you.",
-      7: "YOU! To please my Pokémon , lose!",
+      7: "YOU! To please my Pokémon, lose!",
       8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
-      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
+      9: "Team Plasma will liberate Pokémon from selfish humans like you!",
+      10: "Our hairstyles are out of this world... but our battling skills? You'll find out soon enough."
     },
     "victory": {
       1: "Plasmaaaaaaaaa!",
-      2: "You daft codger, your mask's absurd!",
+      2: "Looks like you're not ready for a galactic takeover!",
       3: "If you try to mess with me, I'll shut you down with a Pokémon battle.",
       4: "How could I lose...",
       5: "I think Lord N would approve of a rematch clause.",
       6: "I guess my Pokémon liberation degree needs updating.",
       7: "Note to self: practice Pokémon battling, liberate Pokémon better.",
       8: "Better luck next time! Maybe join Team Plasma for a change?",
-      9: "We came, we saw, we Plasma'd!"
+      9: "We came, we saw, we Plasma'd!",
+      10: "This is bad... Badbadbadbadbadbadbad! Bad for Team Plasma! Or Plasbad, for short!"
     },
   },
   "flare_grunt": {

--- a/src/locales/fr/dialogue.ts
+++ b/src/locales/fr/dialogue.ts
@@ -385,50 +385,149 @@ export const PGMdialogue: DialogueTranslationEntries = {
   },
   "rocket_grunt": {
     "encounter": {
-      1: "Nous sommes de retour !"
+      1: "Nous sommes de retour !",
+      2: "Come from Johto will they, mine allies, yes. Will revenge they are",
+      3: "You say what? Team Rocket bye-bye a go-go? Broken up it is says you?",
+      4: "To denounce the evils of truth and love!",
+      5: "We Team Rocket are Pokémon gangsters!",
+      6: "We're pulling a big job here! Get lost, kid!",
+      7: "You broke into our operation? You must be lost!",
     },
     "victory": {
-      1: "Une fois de plus la Team Rocket s’envole vers d’autres cieux !"
+      1: "Une fois de plus la Team Rocket s’envole vers d’autres cieux !",
+      2: "Winning is for winners.",
+      3: "You will regret this!",
+      4: "Blastin' off at the speed of light!",
+      5: "Blasting off again....",
+      6: "Stop! I give up! I'll leave quietly!",
+      7: "You made me mad! Team Rocket will blacklist you!",
+      8: "I blew it!",
+      9: "My associates won't stand for this!",
+      10: "So, you are good…",
+      11: "I'm steamed..."
     },
   },
   "magma_grunt": {
     "encounter": {
-      1: "N’espère pas recevoir de la pitié si tu te mets sur le chemin de la Team Magma !"
+      1: "N’espère pas recevoir de la pitié si tu te mets sur le chemin de la Team Magma !",
+      2: "I should've brought my Game Boy Advance SP to play some Pokémon Sapphire  instead.",
+      3: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
+      4: "Heh, I'd like to you see try!",
+      5: "Huh? What are you doing here?",
+      6: "Don't get any ideas about going easy on us just because you're a kid! We'll show you the power of Team Magma's amazing technology!",
+      7: "We, Team Magma, are working hard for everyone's sake. If there's more land, there'll be more places to live! Everyone would be happy!",
+      8: "You'd better not interfere with our plans! We're making the world a better place!",
+      9: "You're in the way! Team Magma has no time for kids like you!",
+      10: "Do you really think you can take on Team Magma? You're just a kid!",
+      11: "We're going to use the power of a volcano! It's gonna be... explosive! Get it? Heh heh!",
+      12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
+      13: "I hope you brought marshmallows because things are about to heat up!",
+      14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
+      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!"
     },
     "victory": {
-      1: "Je…?\nJ’ai perdu ?!"
+      1: "Je…?\nJ’ai perdu ?!",
+      2: "Urrrgh…I should've ducked into our hideout right away…",
+      3: "Okay, oh-kay! I admit it—you're strong!",
+      4: "Don't worry about me. Go wherever you want!",
+      5: "What, what, what?",
+      6: "I'm getting heat exhaustion…",
+      7: "I failed to win, I should've planned better...",
+      8: "I'm steamed...",
+      9: "Oof... you got me.",
+      10: "What?! I lost?! How could this be...?",
+      11: "No way! You're just a kid!",
+      12: "What? I lost? But... but I was supposed to win!",
+      13:  "I lost?! Now I'll never get promoted to Team Magma Senior Grunt!",
+      14: "You beat me... Do you think the boss will dock my pay for this?",
+      15: "I can't believe I lost! I even skipped lunch for this!",
+      16: "Defeated... I guess evil masterminds don't get sick days, huh?",
+      17: "I should have brought more potions... and a better strategy."
     },
   },
   "aqua_grunt": {
     "encounter": {
-      1: "Aucune pitié si tu te mets sur le chemin de la Team Aqua, même pour un gamin !"
+      1: "Aucune pitié si tu te mets sur le chemin de la Team Aqua, même pour un gamin !",
+      2: "I should've brought my Game Boy Advance SP to play some Pokémon Ruby instead.",
+      3: "I was going to ambush you, but you had to dawdle in Petalburg Woods forever, didn't you?",
+      4: "Grrr…You've got some nerve meddling with Team Aqua!",
+      5: "Hey, you there! Don't butt in!",
+      6: "Hey, there! Quit pushing! This is the line, can't you see?",
+      7: "We, Team Aqua, exist for the good of all!",
+      8: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
     },
     "victory": {
-      1: "Comment ça ?"
+      1: "Comment ça ?",
+      2: "Come on and battle me again!",
+      3: "I'll let you go today!",
+      4: "What?! I lost, too!",
+      5: "Arrgh, I didn't count on being meddled with by some meddling kid!",
+      6: "I lost?! Guess I'll have to swim back to the hideout now...",
+      7: "You beat me... Do you think the boss will make me walk the plank for this?",
+      8: "I lost?!"
     },
   },
   "galactic_grunt": {
     "encounter": {
-      1: "Ne te mets pas en travers de la Team Galaxie !"
+      1: "Ne te mets pas en travers de la Team Galaxie !",
+      2: "Our time has come!",
+      3: "It's team galactic's time now!",
+      4: "Hey, wanna join Team Galactic?",
+      5: "Get ready to lose!",
+      6: "You dare to challenge Team Galactic?",
+      7: "Team Galactic will conquer all!",
     },
     "victory": {
-      1: "Désactivation…"
+      1: "Désactivation…",
+      2: "Not bad...",
+      3: "How?!",
+      4: "I'll be back..",
+      5: "I'm outta here!",
+      6: "Maybe we should stick to evil plans and leave battling to someone else.",
+      7: "Note to self: practice Pokémon battling, ASAP.",
+      8: "Oops, our evil was no match for your Pokémon.",
+      9: "This setback means nothing in the grand scheme.",
+      10: "Our plans are bigger than this defeat.",
+      11: "I knew I should have trained more and evil-planned less."
     },
   },
   "plasma_grunt": {
     "encounter": {
-      1: "Pas de quatiers à ceux qui ne suivent pas notre idéal !"
+      1: "Pas de quatiers à ceux qui ne suivent pas notre idéal !",
+      2: "Bad for Team Plasma! Or Plasbad, for short!",
+      3: "There's no room for obstacles like you getting in the way of Unova's new dawn!",
+      4: "Pokémon that work with humans might look happy, but they're suffering, count on it! No doubt about it!",
+      5: "If I win against you, release your Pokémon !",
+      6: "As a proud member of Team Plasma, I will gladly battle with you.",
+      7: "YOU! To please my Pokémon , lose!",
+      8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
+      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
     },
     "victory": {
-      1: "Plasmaaaaaaaaa !"
+      1: "Plasmaaaaaaaaa !",
+      2: "You daft codger, your mask's absurd!",
+      3: "If you try to mess with me, I'll shut you down with a Pokémon battle.",
+      4: "How could I lose...",
+      5: "I think Lord N would approve of a rematch clause.",
+      6: "I guess my Pokémon liberation degree needs updating.",
+      7: "Note to self: practice Pokémon battling, liberate Pokémon better."
     },
   },
   "flare_grunt": {
     "encounter": {
-      1: "Le style et le bon gout, il n’y a que ça qui compte !"
+      1: "Le style et le bon gout, il n’y a que ça qui compte !",
+      2: "Team Flare will cleanse the world of imperfection!",
+      3: "Prepare to face the brilliance of Team Flare!",
+      4: "Team Flare's style and grace will outshine any opponent!",
+      5: "Your Pokémon are no match for the elegance of Team Flare."
     },
     "victory": {
-      1: "Mon futur me semble guère radieux."
+      1: "Mon futur me semble guère radieux.",
+      2: "Gahh?! I lost?!",
+      3: "I guess our beauty treatments didn't include battling skills.",
+      4: "Your victory today won't stop Team Flare's quest for a beautiful world.",
+      5: "Even in defeat, Team Flare's elegance shines through.",
+      6: "Perhaps there's more to battling than I thought. Back to the drawing board."
     },
   },
   "rocket_boss_giovanni_1": {

--- a/src/locales/fr/dialogue.ts
+++ b/src/locales/fr/dialogue.ts
@@ -386,7 +386,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
   "rocket_grunt": {
     "encounter": {
       1: "Nous sommes de retour !",
-      2: "Come from Johto will they, mine allies, yes. Will revenge they are",
+      2: "OH NO! I DROPPED THE LIFT KEY!",
       3: "You say what? Team Rocket bye-bye a go-go? Broken up it is says you?",
       4: "To denounce the evils of truth and love!",
       5: "We Team Rocket are Pokémon gangsters!",
@@ -395,7 +395,8 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Hand over your Pokémon, or face the wrath of Team Rocket!",
       9: "We are Team Rocket, and we're here to steal your Pokémon!",
       10: "You're about to experience the true terror of Team Rocket!",
-      11: "Resistance is futile! Give us your Pokémon or face the consequences!"
+      11: "Resistance is futile! Give us your Pokémon or face the consequences!",
+      12: "STEAL for team rocket EXPLOIT for team rocket"
     },
     "victory": {
       1: "Une fois de plus la Team Rocket s’envole vers d’autres cieux !",
@@ -408,18 +409,19 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "I blew it!",
       9: "My associates won't stand for this!",
       10: "So, you are good…",
-      11: "I'm steamed..."
+      11: "I'm steamed...",
+      12: "Come from Johto will they, mine allies, yes. Will revenge they are",
     },
   },
   "magma_grunt": {
     "encounter": {
       1: "N’espère pas recevoir de la pitié si tu te mets sur le chemin de la Team Magma !",
-      2: "I should've brought my Game Boy Advance SP to play some Pokémon Sapphire  instead.",
+      2: "Get ready to feel the heat! And by heat, I mean my burning desire to win!",
       3: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
       4: "Heh, I'd like to you see try!",
       5: "Huh? What are you doing here?",
-      6: "Don't get any ideas about going easy on us just because you're a kid! We'll show you the power of Team Magma's amazing technology!",
-      7: "We, Team Magma, are working hard for everyone's sake. If there's more land, there'll be more places to live! Everyone would be happy!",
+      6: "We'll show you the power of Team Magma's amazing technology!",
+      7: "If there's more land, there'll be more places to live!",
       8: "You'd better not interfere with our plans! We're making the world a better place!",
       9: "You're in the way! Team Magma has no time for kids like you!",
       10: "Do you really think you can take on Team Magma? You're just a kid!",
@@ -427,7 +429,6 @@ export const PGMdialogue: DialogueTranslationEntries = {
       12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
       13: "I hope you brought marshmallows because things are about to heat up!",
       14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
-      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!",
       16: "Hope you brought sunscreen, 'cause you're about to get burned!",
       17: "You're in the way! Team Magma has no time for kids like you!",
     },
@@ -439,12 +440,12 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "What, what, what?",
       6: "I'm getting heat exhaustion…",
       7: "I failed to win, I should've planned better...",
-      8: "I'm steamed...",
+      8: "I'm heated...",
       9: "Oof... you got me.",
       10: "What?! I lost?! How could this be...?",
       11: "No way! You're just a kid!",
       12: "What? I lost? But... but I was supposed to win!",
-      13:  "I lost?! Now I'll never get promoted to Team Magma Senior Grunt!",
+      13: "I lost?! Now I'll never get promoted to Team Magma Senior Grunt!",
       14: "You beat me... Do you think the boss will dock my pay for this?",
       15: "I can't believe I lost! I even skipped lunch for this!",
       16: "Defeated... I guess evil masterminds don't get sick days, huh?",
@@ -454,13 +455,13 @@ export const PGMdialogue: DialogueTranslationEntries = {
   "aqua_grunt": {
     "encounter": {
       1: "Aucune pitié si tu te mets sur le chemin de la Team Aqua, même pour un gamin !",
-      2: "I should've brought my Game Boy Advance SP to play some Pokémon Ruby instead.",
-      3: "I was going to ambush you, but you had to dawdle in Petalburg Woods forever, didn't you?",
+      2: "I was going to ambush you, but you had to dawdle in the Plains forever, didn't you?",
+      3: "You're about to get soaked! And not just from my Pokémon's Water Gun.",
       4: "Grrr…You've got some nerve meddling with Team Aqua!",
       5: "Hey, you there! Don't butt in!",
       6: "Hey, there! Quit pushing! This is the line, can't you see?",
       7: "We, Team Aqua, exist for the good of all!",
-      8: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
+      8: "Prepare to be washed away by the tides of my… uh, Pokémon! Yeah, my Pokémon!",
     },
     "victory": {
       1: "Comment ça ?",
@@ -485,7 +486,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Hope you're ready for a cosmic beatdown!",
       9: "Witness the power of our technology and the future we envision!",
       10: "In the name of Team Galactic, I'll eliminate anyone who stands in our way!",
-      11: "Looks like you're about to get starstruck...by our Pokémon!"
+      11: "Looks like you're about to get starstruck...by our Pokémon!",
+      12: "Because of you, they took my CLEFAIRY away...",
+      13: "If you try to mess with me, I'll shut you down with a Pokémon battle. So, what's it going to be? Are you going to mess with me?"
     },
     "victory": {
       1: "Désactivation…",
@@ -498,31 +501,35 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Oops, our evil was no match for your Pokémon.",
       9: "This setback means nothing in the grand scheme.",
       10: "Our plans are bigger than this defeat.",
-      11: "I knew I should have trained more and evil-planned less."
+      11: "I knew I should have trained more and evil-planned less.",
+      12:"Looks like I need a new cosmic plan. This one fizzled out.",
+      13: "Defeated by a mere earthling… how embarrassing."
     },
   },
   "plasma_grunt": {
     "encounter": {
       1: "Pas de quatiers à ceux qui ne suivent pas notre idéal !",
-      2: "Bad for Team Plasma! Or Plasbad, for short!",
+      2: "Prepare to be dazzled by our galactic style! And by that, I mean defeated.",
       3: "There's no room for obstacles like you getting in the way of Unova's new dawn!",
       4: "Pokémon that work with humans might look happy, but they're suffering, count on it! No doubt about it!",
-      5: "If I win against you, release your Pokémon !",
+      5: "If I win against you, release your Pokémon!",
       6: "As a proud member of Team Plasma, I will gladly battle with you.",
-      7: "YOU! To please my Pokémon , lose!",
+      7: "YOU! To please my Pokémon, lose!",
       8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
-      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
+      9: "Team Plasma will liberate Pokémon from selfish humans like you!",
+      10: "Our hairstyles are out of this world... but our battling skills? You'll find out soon enough."
     },
     "victory": {
       1: "Plasmaaaaaaaaa !",
-      2: "You daft codger, your mask's absurd!",
+      2: "Looks like you're not ready for a galactic takeover!",
       3: "If you try to mess with me, I'll shut you down with a Pokémon battle.",
       4: "How could I lose...",
       5: "I think Lord N would approve of a rematch clause.",
       6: "I guess my Pokémon liberation degree needs updating.",
       7: "Note to self: practice Pokémon battling, liberate Pokémon better.",
       8: "Better luck next time! Maybe join Team Plasma for a change?",
-      9: "We came, we saw, we Plasma'd!"
+      9: "We came, we saw, we Plasma'd!",
+      10: "This is bad... Badbadbadbadbadbadbad! Bad for Team Plasma! Or Plasbad, for short!"
     },
   },
   "flare_grunt": {
@@ -533,7 +540,6 @@ export const PGMdialogue: DialogueTranslationEntries = {
       4: "Team Flare's style and grace will outshine any opponent!",
       5: "Your Pokémon are no match for the elegance of Team Flare.",
       6: "Hope you brought your sunglasses, because things are about to get bright!"
-
     },
     "victory": {
       1: "Mon futur me semble guère radieux.",

--- a/src/locales/fr/dialogue.ts
+++ b/src/locales/fr/dialogue.ts
@@ -392,6 +392,10 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "We Team Rocket are Pokémon gangsters!",
       6: "We're pulling a big job here! Get lost, kid!",
       7: "You broke into our operation? You must be lost!",
+      8: "Hand over your Pokémon, or face the wrath of Team Rocket!",
+      9: "We are Team Rocket, and we're here to steal your Pokémon!",
+      10: "You're about to experience the true terror of Team Rocket!",
+      11: "Resistance is futile! Give us your Pokémon or face the consequences!"
     },
     "victory": {
       1: "Une fois de plus la Team Rocket s’envole vers d’autres cieux !",
@@ -423,7 +427,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
       13: "I hope you brought marshmallows because things are about to heat up!",
       14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
-      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!"
+      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!",
+      16: "Hope you brought sunscreen, 'cause you're about to get burned!",
+      17: "You're in the way! Team Magma has no time for kids like you!",
     },
     "victory": {
       1: "Je…?\nJ’ai perdu ?!",
@@ -476,6 +482,10 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "Get ready to lose!",
       6: "You dare to challenge Team Galactic?",
       7: "Team Galactic will conquer all!",
+      8: "Hope you're ready for a cosmic beatdown!",
+      9: "Witness the power of our technology and the future we envision!",
+      10: "In the name of Team Galactic, I'll eliminate anyone who stands in our way!",
+      11: "Looks like you're about to get starstruck...by our Pokémon!"
     },
     "victory": {
       1: "Désactivation…",
@@ -510,7 +520,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       4: "How could I lose...",
       5: "I think Lord N would approve of a rematch clause.",
       6: "I guess my Pokémon liberation degree needs updating.",
-      7: "Note to self: practice Pokémon battling, liberate Pokémon better."
+      7: "Note to self: practice Pokémon battling, liberate Pokémon better.",
+      8: "Better luck next time! Maybe join Team Plasma for a change?",
+      9: "We came, we saw, we Plasma'd!"
     },
   },
   "flare_grunt": {
@@ -519,7 +531,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       2: "Team Flare will cleanse the world of imperfection!",
       3: "Prepare to face the brilliance of Team Flare!",
       4: "Team Flare's style and grace will outshine any opponent!",
-      5: "Your Pokémon are no match for the elegance of Team Flare."
+      5: "Your Pokémon are no match for the elegance of Team Flare.",
+      6: "Hope you brought your sunglasses, because things are about to get bright!"
+
     },
     "victory": {
       1: "Mon futur me semble guère radieux.",

--- a/src/locales/it/dialogue.ts
+++ b/src/locales/it/dialogue.ts
@@ -386,7 +386,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
   "rocket_grunt": {
     "encounter": {
       1: "Prepare for trouble!",
-      2: "Come from Johto will they, mine allies, yes. Will revenge they are",
+      2: "OH NO! I DROPPED THE LIFT KEY!",
       3: "You say what? Team Rocket bye-bye a go-go? Broken up it is says you?",
       4: "To denounce the evils of truth and love!",
       5: "We Team Rocket are Pokémon gangsters!",
@@ -395,7 +395,8 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Hand over your Pokémon, or face the wrath of Team Rocket!",
       9: "We are Team Rocket, and we're here to steal your Pokémon!",
       10: "You're about to experience the true terror of Team Rocket!",
-      11: "Resistance is futile! Give us your Pokémon or face the consequences!"
+      11: "Resistance is futile! Give us your Pokémon or face the consequences!",
+      12: "STEAL for team rocket EXPLOIT for team rocket"
     },
     "victory": {
       1: "Team Rocket blasting off again!",
@@ -408,18 +409,19 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "I blew it!",
       9: "My associates won't stand for this!",
       10: "So, you are good…",
-      11: "I'm steamed..."
+      11: "I'm steamed...",
+      12: "Come from Johto will they, mine allies, yes. Will revenge they are",
     },
   },
   "magma_grunt": {
     "encounter": {
       1: " If you get in the way of Team Magma, don’t expect any mercy!",
-      2: "I should've brought my Game Boy Advance SP to play some Pokémon Sapphire  instead.",
+      2: "Get ready to feel the heat! And by heat, I mean my burning desire to win!",
       3: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
       4: "Heh, I'd like to you see try!",
       5: "Huh? What are you doing here?",
-      6: "Don't get any ideas about going easy on us just because you're a kid! We'll show you the power of Team Magma's amazing technology!",
-      7: "We, Team Magma, are working hard for everyone's sake. If there's more land, there'll be more places to live! Everyone would be happy!",
+      6: "We'll show you the power of Team Magma's amazing technology!",
+      7: "If there's more land, there'll be more places to live!",
       8: "You'd better not interfere with our plans! We're making the world a better place!",
       9: "You're in the way! Team Magma has no time for kids like you!",
       10: "Do you really think you can take on Team Magma? You're just a kid!",
@@ -427,7 +429,6 @@ export const PGMdialogue: DialogueTranslationEntries = {
       12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
       13: "I hope you brought marshmallows because things are about to heat up!",
       14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
-      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!",
       16: "Hope you brought sunscreen, 'cause you're about to get burned!",
       17: "You're in the way! Team Magma has no time for kids like you!",
     },
@@ -439,7 +440,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "What, what, what?",
       6: "I'm getting heat exhaustion…",
       7: "I failed to win, I should've planned better...",
-      8: "I'm steamed...",
+      8: "I'm heated...",
       9: "Oof... you got me.",
       10: "What?! I lost?! How could this be...?",
       11: "No way! You're just a kid!",
@@ -454,13 +455,13 @@ export const PGMdialogue: DialogueTranslationEntries = {
   "aqua_grunt": {
     "encounter": {
       1: "No one who crosses Team Aqua gets any mercy, not even kids!",
-      2: "I should've brought my Game Boy Advance SP to play some Pokémon Ruby instead.",
+      2: "I was going to ambush you, but you had to dawdle in the Plains forever, didn't you?",
       3: "I was going to ambush you, but you had to dawdle in Petalburg Woods forever, didn't you?",
       4: "Grrr…You've got some nerve meddling with Team Aqua!",
       5: "Hey, you there! Don't butt in!",
       6: "Hey, there! Quit pushing! This is the line, can't you see?",
       7: "We, Team Aqua, exist for the good of all!",
-      8: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
+      8: "Prepare to be washed away by the tides of my… uh, Pokémon! Yeah, my Pokémon!",
     },
     "victory": {
       1: "You're kidding me!",
@@ -485,7 +486,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Hope you're ready for a cosmic beatdown!",
       9: "Witness the power of our technology and the future we envision!",
       10: "In the name of Team Galactic, I'll eliminate anyone who stands in our way!",
-      11: "Looks like you're about to get starstruck...by our Pokémon!"
+      11: "Looks like you're about to get starstruck...by our Pokémon!",
+      12: "Because of you, they took my CLEFAIRY away...",
+      13: "If you try to mess with me, I'll shut you down with a Pokémon battle. So, what's it going to be? Are you going to mess with me?"
     },
     "victory": {
       1: "Shut down...",
@@ -498,31 +501,35 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Oops, our evil was no match for your Pokémon.",
       9: "This setback means nothing in the grand scheme.",
       10: "Our plans are bigger than this defeat.",
-      11: "I knew I should have trained more and evil-planned less."
+      11: "I knew I should have trained more and evil-planned less.",
+      12:"Looks like I need a new cosmic plan. This one fizzled out.",
+      13: "Defeated by a mere earthling… how embarrassing."
     },
   },
   "plasma_grunt": {
     "encounter": {
       1: "We won't tolerate people who have different ideas!",
-      2: "Bad for Team Plasma! Or Plasbad, for short!",
+      2: "Prepare to be dazzled by our galactic style! And by that, I mean defeated.",
       3: "There's no room for obstacles like you getting in the way of Unova's new dawn!",
       4: "Pokémon that work with humans might look happy, but they're suffering, count on it! No doubt about it!",
-      5: "If I win against you, release your Pokémon !",
+      5: "If I win against you, release your Pokémon!",
       6: "As a proud member of Team Plasma, I will gladly battle with you.",
-      7: "YOU! To please my Pokémon , lose!",
+      7: "YOU! To please my Pokémon, lose!",
       8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
-      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
+      9: "Team Plasma will liberate Pokémon from selfish humans like you!",
+      10: "Our hairstyles are out of this world... but our battling skills? You'll find out soon enough."
     },
     "victory": {
       1: "Plasmaaaaaaaaa!",
-      2: "You daft codger, your mask's absurd!",
+      2: "Looks like you're not ready for a galactic takeover!",
       3: "If you try to mess with me, I'll shut you down with a Pokémon battle.",
       4: "How could I lose...",
       5: "I think Lord N would approve of a rematch clause.",
       6: "I guess my Pokémon liberation degree needs updating.",
       7: "Note to self: practice Pokémon battling, liberate Pokémon better.",
       8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
-      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
+      9: "We came, we saw, we Plasma'd!",
+      10: "This is bad... Badbadbadbadbadbadbad! Bad for Team Plasma! Or Plasbad, for short!"
     },
   },
   "flare_grunt": {

--- a/src/locales/it/dialogue.ts
+++ b/src/locales/it/dialogue.ts
@@ -392,6 +392,10 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "We Team Rocket are Pokémon gangsters!",
       6: "We're pulling a big job here! Get lost, kid!",
       7: "You broke into our operation? You must be lost!",
+      8: "Hand over your Pokémon, or face the wrath of Team Rocket!",
+      9: "We are Team Rocket, and we're here to steal your Pokémon!",
+      10: "You're about to experience the true terror of Team Rocket!",
+      11: "Resistance is futile! Give us your Pokémon or face the consequences!"
     },
     "victory": {
       1: "Team Rocket blasting off again!",
@@ -423,7 +427,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
       13: "I hope you brought marshmallows because things are about to heat up!",
       14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
-      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!"
+      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!",
+      16: "Hope you brought sunscreen, 'cause you're about to get burned!",
+      17: "You're in the way! Team Magma has no time for kids like you!",
     },
     "victory": {
       1: "Huh? I lost?!",
@@ -476,6 +482,10 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "Get ready to lose!",
       6: "You dare to challenge Team Galactic?",
       7: "Team Galactic will conquer all!",
+      8: "Hope you're ready for a cosmic beatdown!",
+      9: "Witness the power of our technology and the future we envision!",
+      10: "In the name of Team Galactic, I'll eliminate anyone who stands in our way!",
+      11: "Looks like you're about to get starstruck...by our Pokémon!"
     },
     "victory": {
       1: "Shut down...",
@@ -510,7 +520,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       4: "How could I lose...",
       5: "I think Lord N would approve of a rematch clause.",
       6: "I guess my Pokémon liberation degree needs updating.",
-      7: "Note to self: practice Pokémon battling, liberate Pokémon better."
+      7: "Note to self: practice Pokémon battling, liberate Pokémon better.",
+      8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
+      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
     },
   },
   "flare_grunt": {
@@ -519,7 +531,8 @@ export const PGMdialogue: DialogueTranslationEntries = {
       2: "Team Flare will cleanse the world of imperfection!",
       3: "Prepare to face the brilliance of Team Flare!",
       4: "Team Flare's style and grace will outshine any opponent!",
-      5: "Your Pokémon are no match for the elegance of Team Flare."
+      5: "Your Pokémon are no match for the elegance of Team Flare.",
+      6: "Hope you brought your sunglasses, because things are about to get bright!"
     },
     "victory": {
       1: "The future doesn't look bright for me.",

--- a/src/locales/it/dialogue.ts
+++ b/src/locales/it/dialogue.ts
@@ -385,50 +385,149 @@ export const PGMdialogue: DialogueTranslationEntries = {
   },
   "rocket_grunt": {
     "encounter": {
-      1: "Prepare for trouble!"
+      1: "Prepare for trouble!",
+      2: "Come from Johto will they, mine allies, yes. Will revenge they are",
+      3: "You say what? Team Rocket bye-bye a go-go? Broken up it is says you?",
+      4: "To denounce the evils of truth and love!",
+      5: "We Team Rocket are Pokémon gangsters!",
+      6: "We're pulling a big job here! Get lost, kid!",
+      7: "You broke into our operation? You must be lost!",
     },
     "victory": {
-      1: "Team Rocket blasting off again!"
+      1: "Team Rocket blasting off again!",
+      2: "Winning is for winners.",
+      3: "You will regret this!",
+      4: "Blastin' off at the speed of light!",
+      5: "Blasting off again....",
+      6: "Stop! I give up! I'll leave quietly!",
+      7: "You made me mad! Team Rocket will blacklist you!",
+      8: "I blew it!",
+      9: "My associates won't stand for this!",
+      10: "So, you are good…",
+      11: "I'm steamed..."
     },
   },
   "magma_grunt": {
     "encounter": {
-      1: " If you get in the way of Team Magma, don’t expect any mercy!"
+      1: " If you get in the way of Team Magma, don’t expect any mercy!",
+      2: "I should've brought my Game Boy Advance SP to play some Pokémon Sapphire  instead.",
+      3: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
+      4: "Heh, I'd like to you see try!",
+      5: "Huh? What are you doing here?",
+      6: "Don't get any ideas about going easy on us just because you're a kid! We'll show you the power of Team Magma's amazing technology!",
+      7: "We, Team Magma, are working hard for everyone's sake. If there's more land, there'll be more places to live! Everyone would be happy!",
+      8: "You'd better not interfere with our plans! We're making the world a better place!",
+      9: "You're in the way! Team Magma has no time for kids like you!",
+      10: "Do you really think you can take on Team Magma? You're just a kid!",
+      11: "We're going to use the power of a volcano! It's gonna be... explosive! Get it? Heh heh!",
+      12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
+      13: "I hope you brought marshmallows because things are about to heat up!",
+      14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
+      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!"
     },
     "victory": {
-      1: "Huh? I lost?!"
+      1: "Huh? I lost?!",
+      2: "Urrrgh…I should've ducked into our hideout right away…",
+      3: "Okay, oh-kay! I admit it—you're strong!",
+      4: "Don't worry about me. Go wherever you want!",
+      5: "What, what, what?",
+      6: "I'm getting heat exhaustion…",
+      7: "I failed to win, I should've planned better...",
+      8: "I'm steamed...",
+      9: "Oof... you got me.",
+      10: "What?! I lost?! How could this be...?",
+      11: "No way! You're just a kid!",
+      12: "What? I lost? But... but I was supposed to win!",
+      13:  "I lost?! Now I'll never get promoted to Team Magma Senior Grunt!",
+      14: "You beat me... Do you think the boss will dock my pay for this?",
+      15: "I can't believe I lost! I even skipped lunch for this!",
+      16: "Defeated... I guess evil masterminds don't get sick days, huh?",
+      17: "I should have brought more potions... and a better strategy."
     },
   },
   "aqua_grunt": {
     "encounter": {
-      1: "No one who crosses Team Aqua gets any mercy, not even kids!"
+      1: "No one who crosses Team Aqua gets any mercy, not even kids!",
+      2: "I should've brought my Game Boy Advance SP to play some Pokémon Ruby instead.",
+      3: "I was going to ambush you, but you had to dawdle in Petalburg Woods forever, didn't you?",
+      4: "Grrr…You've got some nerve meddling with Team Aqua!",
+      5: "Hey, you there! Don't butt in!",
+      6: "Hey, there! Quit pushing! This is the line, can't you see?",
+      7: "We, Team Aqua, exist for the good of all!",
+      8: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
     },
     "victory": {
-      1: "You're kidding me!"
+      1: "You're kidding me!",
+      2: "Come on and battle me again!",
+      3: "I'll let you go today!",
+      4: "What?! I lost, too!",
+      5: "Arrgh, I didn't count on being meddled with by some meddling kid!",
+      6: "I lost?! Guess I'll have to swim back to the hideout now...",
+      7: "You beat me... Do you think the boss will make me walk the plank for this?",
+      8: "I lost?!"
     },
   },
   "galactic_grunt": {
     "encounter": {
-      1: "Don't mess with Team Galactic!"
+      1: "Don't mess with Team Galactic!",
+      2: "Our time has come!",
+      3: "It's team galactic's time now!",
+      4: "Hey, wanna join Team Galactic?",
+      5: "Get ready to lose!",
+      6: "You dare to challenge Team Galactic?",
+      7: "Team Galactic will conquer all!",
     },
     "victory": {
-      1: "Shut down..."
+      1: "Shut down...",
+      2: "Not bad...",
+      3: "How?!",
+      4: "I'll be back..",
+      5: "I'm outta here!",
+      6: "Maybe we should stick to evil plans and leave battling to someone else.",
+      7: "Note to self: practice Pokémon battling, ASAP.",
+      8: "Oops, our evil was no match for your Pokémon.",
+      9: "This setback means nothing in the grand scheme.",
+      10: "Our plans are bigger than this defeat.",
+      11: "I knew I should have trained more and evil-planned less."
     },
   },
   "plasma_grunt": {
     "encounter": {
-      1: "We won't tolerate people who have different ideas!"
+      1: "We won't tolerate people who have different ideas!",
+      2: "Bad for Team Plasma! Or Plasbad, for short!",
+      3: "There's no room for obstacles like you getting in the way of Unova's new dawn!",
+      4: "Pokémon that work with humans might look happy, but they're suffering, count on it! No doubt about it!",
+      5: "If I win against you, release your Pokémon !",
+      6: "As a proud member of Team Plasma, I will gladly battle with you.",
+      7: "YOU! To please my Pokémon , lose!",
+      8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
+      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
     },
     "victory": {
-      1: "Plasmaaaaaaaaa!"
+      1: "Plasmaaaaaaaaa!",
+      2: "You daft codger, your mask's absurd!",
+      3: "If you try to mess with me, I'll shut you down with a Pokémon battle.",
+      4: "How could I lose...",
+      5: "I think Lord N would approve of a rematch clause.",
+      6: "I guess my Pokémon liberation degree needs updating.",
+      7: "Note to self: practice Pokémon battling, liberate Pokémon better."
     },
   },
   "flare_grunt": {
     "encounter": {
-      1: "Fashion is most important to us!"
+      1: "Fashion is most important to us!",
+      2: "Team Flare will cleanse the world of imperfection!",
+      3: "Prepare to face the brilliance of Team Flare!",
+      4: "Team Flare's style and grace will outshine any opponent!",
+      5: "Your Pokémon are no match for the elegance of Team Flare."
     },
     "victory": {
-      1: "The future doesn't look bright for me."
+      1: "The future doesn't look bright for me.",
+      2: "Gahh?! I lost?!",
+      3: "I guess our beauty treatments didn't include battling skills.",
+      4: "Your victory today won't stop Team Flare's quest for a beautiful world.",
+      5: "Even in defeat, Team Flare's elegance shines through.",
+      6: "Perhaps there's more to battling than I thought. Back to the drawing board."
     },
   },
   "rocket_boss_giovanni_1": {

--- a/src/locales/ko/dialogue.ts
+++ b/src/locales/ko/dialogue.ts
@@ -385,50 +385,150 @@ export const PGMdialogue: DialogueTranslationEntries = {
   },
   "rocket_grunt": {
     "encounter": {
-      1: "트러블에 대비하도록!"
+      1: "트러블에 대비하도록!",
+      2: "Come from Johto will they, mine allies, yes. Will revenge they are",
+      3: "You say what? Team Rocket bye-bye a go-go? Broken up it is says you?",
+      4: "To denounce the evils of truth and love!",
+      5: "We Team Rocket are Pokémon gangsters!",
+      6: "We're pulling a big job here! Get lost, kid!",
+      7: "You broke into our operation? You must be lost!",
     },
     "victory": {
-      1: "로켓단은 다시 떠오를 거니까!"
+      1: "로켓단은 다시 떠오를 거니까!",
+      2: "Winning is for winners.",
+      3: "You will regret this!",
+      4: "Blastin' off at the speed of light!",
+      5: "Blasting off again....",
+      6: "Stop! I give up! I'll leave quietly!",
+      7: "You made me mad! Team Rocket will blacklist you!",
+      8: "I blew it!",
+      9: "My associates won't stand for this!",
+      10: "So, you are good…",
+      11: "I'm steamed..."
     },
   },
   "magma_grunt": {
     "encounter": {
-      1: " 마그마단을 방해한다면, 자비는 없닷!"
+      1: " 마그마단을 방해한다면, 자비는 없닷!",
+      2: "I should've brought my Game Boy Advance SP to play some Pokémon Sapphire  instead.",
+      3: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
+      4: "Heh, I'd like to you see try!",
+      5: "Huh? What are you doing here?",
+      6: "Don't get any ideas about going easy on us just because you're a kid! We'll show you the power of Team Magma's amazing technology!",
+      7: "We, Team Magma, are working hard for everyone's sake. If there's more land, there'll be more places to live! Everyone would be happy!",
+      8: "You'd better not interfere with our plans! We're making the world a better place!",
+      9: "You're in the way! Team Magma has no time for kids like you!",
+      10: "Do you really think you can take on Team Magma? You're just a kid!",
+      11: "We're going to use the power of a volcano! It's gonna be... explosive! Get it? Heh heh!",
+      12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
+      13: "I hope you brought marshmallows because things are about to heat up!",
+      14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
+      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!"
     },
     "victory": {
-      1: "하? 내가 졌어?!"
+      1: "하? 내가 졌어?!",
+      2: "Urrrgh…I should've ducked into our hideout right away…",
+      3: "Okay, oh-kay! I admit it—you're strong!",
+      4: "Don't worry about me. Go wherever you want!",
+      5: "What, what, what?",
+      6: "I'm getting heat exhaustion…",
+      7: "I failed to win, I should've planned better...",
+      8: "I'm steamed...",
+      9: "Oof... you got me.",
+      10: "What?! I lost?! How could this be...?",
+      11: "No way! You're just a kid!",
+      12: "What? I lost? But... but I was supposed to win!",
+      13:  "I lost?! Now I'll never get promoted to Team Magma Senior Grunt!",
+      14: "You beat me... Do you think the boss will dock my pay for this?",
+      15: "I can't believe I lost! I even skipped lunch for this!",
+      16: "Defeated... I guess evil masterminds don't get sick days, huh?",
+      17: "I should have brought more potions... and a better strategy."
     },
   },
   "aqua_grunt": {
     "encounter": {
-      1: "아쿠아단을 넘본 사람에게는 자비는 없다, 꼬마도 마찬가지야!"
+      1: "아쿠아단을 넘본 사람에게는 자비는 없다, 꼬마도 마찬가지야!",
+      2: "I should've brought my Game Boy Advance SP to play some Pokémon Ruby instead.",
+      3: "I was going to ambush you, but you had to dawdle in Petalburg Woods forever, didn't you?",
+      4: "Grrr…You've got some nerve meddling with Team Aqua!",
+      5: "Hey, you there! Don't butt in!",
+      6: "Hey, there! Quit pushing! This is the line, can't you see?",
+      7: "We, Team Aqua, exist for the good of all!",
+      8: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
     },
     "victory": {
-      1: "말도 안돼!"
+      1: "말도 안돼!",
+      2: "Come on and battle me again!",
+      3: "I'll let you go today!",
+      4: "What?! I lost, too!",
+      5: "Arrgh, I didn't count on being meddled with by some meddling kid!",
+      6: "I lost?! Guess I'll have to swim back to the hideout now...",
+      7: "You beat me... Do you think the boss will make me walk the plank for this?",
+      8: "I lost?!"
     },
   },
   "galactic_grunt": {
     "encounter": {
-      1: "갤럭시단을 방해하지 마!"
+      1: "갤럭시단을 방해하지 마!",
+      2: "Our time has come!",
+      3: "It's team galactic's time now!",
+      4: "Hey, wanna join Team Galactic?",
+      5: "Get ready to lose!",
+      6: "You dare to challenge Team Galactic?",
+      7: "Team Galactic will conquer all!",
     },
     "victory": {
-      1: "사격 중지…… "
+      1: "사격 중지…… ",
+      2: "Not bad...",
+      3: "How?!",
+      4: "I'll be back..",
+      5: "I'm outta here!",
+      6: "Maybe we should stick to evil plans and leave battling to someone else.",
+      7: "Note to self: practice Pokémon battling, ASAP.",
+      8: "Oops, our evil was no match for your Pokémon.",
+      9: "This setback means nothing in the grand scheme.",
+      10: "Our plans are bigger than this defeat.",
+      11: "I knew I should have trained more and evil-planned less."
     },
   },
   "plasma_grunt": {
     "encounter": {
-      1: "다른 생각을 가진사람들은 용납하지 않겠다!"
+      1: "다른 생각을 가진사람들은 용납하지 않겠다!",
+      2: "Bad for Team Plasma! Or Plasbad, for short!",
+      3: "There's no room for obstacles like you getting in the way of Unova's new dawn!",
+      4: "Pokémon that work with humans might look happy, but they're suffering, count on it! No doubt about it!",
+      5: "If I win against you, release your Pokémon !",
+      6: "As a proud member of Team Plasma, I will gladly battle with you.",
+      7: "YOU! To please my Pokémon , lose!",
+      8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
+      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
     },
     "victory": {
-      1: "플라-스마-!"
+      1: "플라-스마-!",
+      2: "You daft codger, your mask's absurd!",
+      3: "If you try to mess with me, I'll shut you down with a Pokémon battle.",
+      4: "How could I lose...",
+      5: "I think Lord N would approve of a rematch clause.",
+      6: "I guess my Pokémon liberation degree needs updating.",
+      7: "Note to self: practice Pokémon battling, liberate Pokémon better."
     },
   },
   "flare_grunt": {
     "encounter": {
-      1: "패션이 우리한텐 가장 중요하다고!"
+      1: "패션이 우리한텐 가장 중요하다고!",
+      2: "Team Flare will cleanse the world of imperfection!",
+      3: "Prepare to face the brilliance of Team Flare!",
+      4: "Team Flare's style and grace will outshine any opponent!",
+      5: "Your Pokémon are no match for the elegance of Team Flare."
     },
     "victory": {
-      1: "미래가 밝아 보이질 않네."
+      1: "미래가 밝아 보이질 않네.",
+      2: "Gahh?! I lost?!",
+      3: "I guess our beauty treatments didn't include battling skills.",
+      4: "Your victory today won't stop Team Flare's quest for a beautiful world.",
+      5: "Even in defeat, Team Flare's elegance shines through.",
+      6: "Perhaps there's more to battling than I thought. Back to the drawing board."
+
     },
   },
   "rocket_boss_giovanni_1": {

--- a/src/locales/ko/dialogue.ts
+++ b/src/locales/ko/dialogue.ts
@@ -392,6 +392,10 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "We Team Rocket are Pokémon gangsters!",
       6: "We're pulling a big job here! Get lost, kid!",
       7: "You broke into our operation? You must be lost!",
+      8: "Hand over your Pokémon, or face the wrath of Team Rocket!",
+      9: "We are Team Rocket, and we're here to steal your Pokémon!",
+      10: "You're about to experience the true terror of Team Rocket!",
+      11: "Resistance is futile! Give us your Pokémon or face the consequences!"
     },
     "victory": {
       1: "로켓단은 다시 떠오를 거니까!",
@@ -423,7 +427,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
       13: "I hope you brought marshmallows because things are about to heat up!",
       14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
-      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!"
+      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!",
+      16: "Hope you brought sunscreen, 'cause you're about to get burned!",
+      17: "You're in the way! Team Magma has no time for kids like you!",
     },
     "victory": {
       1: "하? 내가 졌어?!",
@@ -476,6 +482,10 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "Get ready to lose!",
       6: "You dare to challenge Team Galactic?",
       7: "Team Galactic will conquer all!",
+      8: "Hope you're ready for a cosmic beatdown!",
+      9: "Witness the power of our technology and the future we envision!",
+      10: "In the name of Team Galactic, I'll eliminate anyone who stands in our way!",
+      11: "Looks like you're about to get starstruck...by our Pokémon!"
     },
     "victory": {
       1: "사격 중지…… ",
@@ -510,7 +520,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       4: "How could I lose...",
       5: "I think Lord N would approve of a rematch clause.",
       6: "I guess my Pokémon liberation degree needs updating.",
-      7: "Note to self: practice Pokémon battling, liberate Pokémon better."
+      7: "Note to self: practice Pokémon battling, liberate Pokémon better.",
+      8: "Better luck next time! Maybe join Team Plasma for a change?",
+      9: "We came, we saw, we Plasma'd!"
     },
   },
   "flare_grunt": {
@@ -519,7 +531,8 @@ export const PGMdialogue: DialogueTranslationEntries = {
       2: "Team Flare will cleanse the world of imperfection!",
       3: "Prepare to face the brilliance of Team Flare!",
       4: "Team Flare's style and grace will outshine any opponent!",
-      5: "Your Pokémon are no match for the elegance of Team Flare."
+      5: "Your Pokémon are no match for the elegance of Team Flare.",
+      6: "Hope you brought your sunglasses, because things are about to get bright!"
     },
     "victory": {
       1: "미래가 밝아 보이질 않네.",

--- a/src/locales/ko/dialogue.ts
+++ b/src/locales/ko/dialogue.ts
@@ -386,7 +386,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
   "rocket_grunt": {
     "encounter": {
       1: "트러블에 대비하도록!",
-      2: "Come from Johto will they, mine allies, yes. Will revenge they are",
+      2: "OH NO! I DROPPED THE LIFT KEY!",
       3: "You say what? Team Rocket bye-bye a go-go? Broken up it is says you?",
       4: "To denounce the evils of truth and love!",
       5: "We Team Rocket are Pokémon gangsters!",
@@ -395,7 +395,8 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Hand over your Pokémon, or face the wrath of Team Rocket!",
       9: "We are Team Rocket, and we're here to steal your Pokémon!",
       10: "You're about to experience the true terror of Team Rocket!",
-      11: "Resistance is futile! Give us your Pokémon or face the consequences!"
+      11: "Resistance is futile! Give us your Pokémon or face the consequences!",
+      12: "STEAL for team rocket EXPLOIT for team rocket"
     },
     "victory": {
       1: "로켓단은 다시 떠오를 거니까!",
@@ -408,18 +409,19 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "I blew it!",
       9: "My associates won't stand for this!",
       10: "So, you are good…",
-      11: "I'm steamed..."
+      11: "I'm steamed...",
+      12: "Come from Johto will they, mine allies, yes. Will revenge they are",
     },
   },
   "magma_grunt": {
     "encounter": {
       1: " 마그마단을 방해한다면, 자비는 없닷!",
-      2: "I should've brought my Game Boy Advance SP to play some Pokémon Sapphire  instead.",
+      2: "Get ready to feel the heat! And by heat, I mean my burning desire to win!",
       3: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
       4: "Heh, I'd like to you see try!",
       5: "Huh? What are you doing here?",
-      6: "Don't get any ideas about going easy on us just because you're a kid! We'll show you the power of Team Magma's amazing technology!",
-      7: "We, Team Magma, are working hard for everyone's sake. If there's more land, there'll be more places to live! Everyone would be happy!",
+      6: "We'll show you the power of Team Magma's amazing technology!",
+      7: "If there's more land, there'll be more places to live!",
       8: "You'd better not interfere with our plans! We're making the world a better place!",
       9: "You're in the way! Team Magma has no time for kids like you!",
       10: "Do you really think you can take on Team Magma? You're just a kid!",
@@ -427,7 +429,6 @@ export const PGMdialogue: DialogueTranslationEntries = {
       12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
       13: "I hope you brought marshmallows because things are about to heat up!",
       14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
-      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!",
       16: "Hope you brought sunscreen, 'cause you're about to get burned!",
       17: "You're in the way! Team Magma has no time for kids like you!",
     },
@@ -439,7 +440,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "What, what, what?",
       6: "I'm getting heat exhaustion…",
       7: "I failed to win, I should've planned better...",
-      8: "I'm steamed...",
+      8: "I'm heated...",
       9: "Oof... you got me.",
       10: "What?! I lost?! How could this be...?",
       11: "No way! You're just a kid!",
@@ -454,13 +455,13 @@ export const PGMdialogue: DialogueTranslationEntries = {
   "aqua_grunt": {
     "encounter": {
       1: "아쿠아단을 넘본 사람에게는 자비는 없다, 꼬마도 마찬가지야!",
-      2: "I should've brought my Game Boy Advance SP to play some Pokémon Ruby instead.",
-      3: "I was going to ambush you, but you had to dawdle in Petalburg Woods forever, didn't you?",
+      2: "I was going to ambush you, but you had to dawdle in the Plains forever, didn't you?",
+      3: "You're about to get soaked! And not just from my Pokémon's Water Gun.",
       4: "Grrr…You've got some nerve meddling with Team Aqua!",
       5: "Hey, you there! Don't butt in!",
       6: "Hey, there! Quit pushing! This is the line, can't you see?",
       7: "We, Team Aqua, exist for the good of all!",
-      8: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
+      8: "Prepare to be washed away by the tides of my… uh, Pokémon! Yeah, my Pokémon!",
     },
     "victory": {
       1: "말도 안돼!",
@@ -485,7 +486,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Hope you're ready for a cosmic beatdown!",
       9: "Witness the power of our technology and the future we envision!",
       10: "In the name of Team Galactic, I'll eliminate anyone who stands in our way!",
-      11: "Looks like you're about to get starstruck...by our Pokémon!"
+      11: "Looks like you're about to get starstruck...by our Pokémon!",
+      12: "Because of you, they took my CLEFAIRY away...",
+      13: "If you try to mess with me, I'll shut you down with a Pokémon battle. So, what's it going to be? Are you going to mess with me?"
     },
     "victory": {
       1: "사격 중지…… ",
@@ -498,31 +501,35 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Oops, our evil was no match for your Pokémon.",
       9: "This setback means nothing in the grand scheme.",
       10: "Our plans are bigger than this defeat.",
-      11: "I knew I should have trained more and evil-planned less."
+      11: "I knew I should have trained more and evil-planned less.",
+      12:"Looks like I need a new cosmic plan. This one fizzled out.",
+      13: "Defeated by a mere earthling… how embarrassing."
     },
   },
   "plasma_grunt": {
     "encounter": {
       1: "다른 생각을 가진사람들은 용납하지 않겠다!",
-      2: "Bad for Team Plasma! Or Plasbad, for short!",
+      2: "Prepare to be dazzled by our galactic style! And by that, I mean defeated.",
       3: "There's no room for obstacles like you getting in the way of Unova's new dawn!",
       4: "Pokémon that work with humans might look happy, but they're suffering, count on it! No doubt about it!",
-      5: "If I win against you, release your Pokémon !",
+      5: "If I win against you, release your Pokémon!",
       6: "As a proud member of Team Plasma, I will gladly battle with you.",
-      7: "YOU! To please my Pokémon , lose!",
+      7: "YOU! To please my Pokémon, lose!",
       8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
-      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
+      9: "Team Plasma will liberate Pokémon from selfish humans like you!",
+      10: "Our hairstyles are out of this world... but our battling skills? You'll find out soon enough."
     },
     "victory": {
       1: "플라-스마-!",
-      2: "You daft codger, your mask's absurd!",
+      2: "Looks like you're not ready for a galactic takeover!",
       3: "If you try to mess with me, I'll shut you down with a Pokémon battle.",
       4: "How could I lose...",
       5: "I think Lord N would approve of a rematch clause.",
       6: "I guess my Pokémon liberation degree needs updating.",
       7: "Note to self: practice Pokémon battling, liberate Pokémon better.",
       8: "Better luck next time! Maybe join Team Plasma for a change?",
-      9: "We came, we saw, we Plasma'd!"
+      9: "We came, we saw, we Plasma'd!",
+      10: "This is bad... Badbadbadbadbadbadbad! Bad for Team Plasma! Or Plasbad, for short!"
     },
   },
   "flare_grunt": {
@@ -541,7 +548,6 @@ export const PGMdialogue: DialogueTranslationEntries = {
       4: "Your victory today won't stop Team Flare's quest for a beautiful world.",
       5: "Even in defeat, Team Flare's elegance shines through.",
       6: "Perhaps there's more to battling than I thought. Back to the drawing board."
-
     },
   },
   "rocket_boss_giovanni_1": {

--- a/src/locales/pt_BR/dialogue.ts
+++ b/src/locales/pt_BR/dialogue.ts
@@ -385,50 +385,150 @@ export const PGMdialogue: DialogueTranslationEntries = {
   },
   "rocket_grunt": {
     "encounter": {
-      1: "Se prepara pra encrenca!"
+      1: "Se prepara pra encrenca!",
+      2: "Come from Johto will they, mine allies, yes. Will revenge they are",
+      3: "You say what? Team Rocket bye-bye a go-go? Broken up it is says you?",
+      4: "To denounce the evils of truth and love!",
+      5: "We Team Rocket are Pokémon gangsters!",
+      6: "We're pulling a big job here! Get lost, kid!",
+      7: "You broke into our operation? You must be lost!",
     },
     "victory": {
-      1: "Equipe Rocket decolando de novo!"
+      1: "Equipe Rocket decolando de novo!",
+      2: "Winning is for winners.",
+      3: "You will regret this!",
+      4: "Blastin' off at the speed of light!",
+      5: "Blasting off again....",
+      6: "Stop! I give up! I'll leave quietly!",
+      7: "You made me mad! Team Rocket will blacklist you!",
+      8: "I blew it!",
+      9: "My associates won't stand for this!",
+      10: "So, you are good…",
+      11: "I'm steamed..."
     },
   },
   "magma_grunt": {
     "encounter": {
-      1: "Se você se meter com a Equipe Magma, não teremos piedade!"
+      1: "Se você se meter com a Equipe Magma, não teremos piedade!",
+      2: "I should've brought my Game Boy Advance SP to play some Pokémon Sapphire  instead.",
+      3: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
+      4: "Heh, I'd like to you see try!",
+      5: "Huh? What are you doing here?",
+      6: "Don't get any ideas about going easy on us just because you're a kid! We'll show you the power of Team Magma's amazing technology!",
+      7: "We, Team Magma, are working hard for everyone's sake. If there's more land, there'll be more places to live! Everyone would be happy!",
+      8: "You'd better not interfere with our plans! We're making the world a better place!",
+      9: "You're in the way! Team Magma has no time for kids like you!",
+      10: "Do you really think you can take on Team Magma? You're just a kid!",
+      11: "We're going to use the power of a volcano! It's gonna be... explosive! Get it? Heh heh!",
+      12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
+      13: "I hope you brought marshmallows because things are about to heat up!",
+      14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
+      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!"
+
     },
     "victory": {
-      1: "Ahn? Eu perdi?!"
+      1: "Ahn? Eu perdi?!",
+      2: "Urrrgh…I should've ducked into our hideout right away…",
+      3: "Okay, oh-kay! I admit it—you're strong!",
+      4: "Don't worry about me. Go wherever you want!",
+      5: "What, what, what?",
+      6: "I'm getting heat exhaustion…",
+      7: "I failed to win, I should've planned better...",
+      8: "I'm steamed...",
+      9: "Oof... you got me.",
+      10: "What?! I lost?! How could this be...?",
+      11: "No way! You're just a kid!",
+      12: "What? I lost? But... but I was supposed to win!",
+      13:  "I lost?! Now I'll never get promoted to Team Magma Senior Grunt!",
+      14: "You beat me... Do you think the boss will dock my pay for this?",
+      15: "I can't believe I lost! I even skipped lunch for this!",
+      16: "Defeated... I guess evil masterminds don't get sick days, huh?",
+      17: "I should have brought more potions... and a better strategy."
     },
   },
   "aqua_grunt": {
     "encounter": {
-      1: "Não pegamos leve com quem se mete com a Equipe Aqua, nem mesmo crianças!"
+      1: "Não pegamos leve com quem se mete com a Equipe Aqua, nem mesmo crianças!",
+      2: "I should've brought my Game Boy Advance SP to play some Pokémon Ruby instead.",
+      3: "I was going to ambush you, but you had to dawdle in Petalburg Woods forever, didn't you?",
+      4: "Grrr…You've got some nerve meddling with Team Aqua!",
+      5: "Hey, you there! Don't butt in!",
+      6: "Hey, there! Quit pushing! This is the line, can't you see?",
+      7: "We, Team Aqua, exist for the good of all!",
+      8: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
     },
     "victory": {
-      1: "Tá de brincadeira!"
+      1: "Tá de brincadeira!",
+      2: "Come on and battle me again!",
+      3: "I'll let you go today!",
+      4: "What?! I lost, too!",
+      5: "Arrgh, I didn't count on being meddled with by some meddling kid!",
+      6: "I lost?! Guess I'll have to swim back to the hideout now...",
+      7: "You beat me... Do you think the boss will make me walk the plank for this?",
+      8: "I lost?!"
     },
   },
   "galactic_grunt": {
     "encounter": {
-      1: "Não mexe com a Equipe Galáctica!"
+      1: "Não mexe com a Equipe Galáctica!",
+      2: "Our time has come!",
+      3: "It's team galactic's time now!",
+      4: "Hey, wanna join Team Galactic?",
+      5: "Get ready to lose!",
+      6: "You dare to challenge Team Galactic?",
+      7: "Team Galactic will conquer all!",
     },
     "victory": {
-      1: "Fui amassado..."
+      1: "Fui amassado...",
+      2: "Not bad...",
+      3: "How?!",
+      4: "I'll be back..",
+      5: "I'm outta here!",
+      6: "Maybe we should stick to evil plans and leave battling to someone else.",
+      7: "Note to self: practice Pokémon battling, ASAP.",
+      8: "Oops, our evil was no match for your Pokémon.",
+      9: "This setback means nothing in the grand scheme.",
+      10: "Our plans are bigger than this defeat.",
+      11: "I knew I should have trained more and evil-planned less."
     },
   },
   "plasma_grunt": {
     "encounter": {
-      1: "Não toleramos pessoas que pensam diferente de nós!"
+      1: "Não toleramos pessoas que pensam diferente de nós!",
+      2: "Bad for Team Plasma! Or Plasbad, for short!",
+      3: "There's no room for obstacles like you getting in the way of Unova's new dawn!",
+      4: "Pokémon that work with humans might look happy, but they're suffering, count on it! No doubt about it!",
+      5: "If I win against you, release your Pokémon !",
+      6: "As a proud member of Team Plasma, I will gladly battle with you.",
+      7: "YOU! To please my Pokémon , lose!",
+      8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
+      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
     },
     "victory": {
-      1: "Plasmaaaaaaaaa!"
+      1: "Plasmaaaaaaaaa!",
+      2: "You daft codger, your mask's absurd!",
+      3: "If you try to mess with me, I'll shut you down with a Pokémon battle.",
+      4: "How could I lose...",
+      5: "I think Lord N would approve of a rematch clause.",
+      6: "I guess my Pokémon liberation degree needs updating.",
+      7: "Note to self: practice Pokémon battling, liberate Pokémon better."
     },
   },
   "flare_grunt": {
     "encounter": {
-      1: "A moda é a coisa mais importante pra gente!"
+      1: "A moda é a coisa mais importante pra gente!",
+      2: "Team Flare will cleanse the world of imperfection!",
+      3: "Prepare to face the brilliance of Team Flare!",
+      4: "Team Flare's style and grace will outshine any opponent!",
+      5: "Your Pokémon are no match for the elegance of Team Flare."
     },
     "victory": {
-      1: "O futuro não parece brilhante pra mim."
+      1: "O futuro não parece brilhante pra mim.",
+      2: "Gahh?! I lost?!",
+      3: "I guess our beauty treatments didn't include battling skills.",
+      4: "Your victory today won't stop Team Flare's quest for a beautiful world.",
+      5: "Even in defeat, Team Flare's elegance shines through.",
+      6: "Perhaps there's more to battling than I thought. Back to the drawing board."
     },
   },
   "rocket_boss_giovanni_1": {

--- a/src/locales/pt_BR/dialogue.ts
+++ b/src/locales/pt_BR/dialogue.ts
@@ -392,6 +392,10 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "We Team Rocket are Pokémon gangsters!",
       6: "We're pulling a big job here! Get lost, kid!",
       7: "You broke into our operation? You must be lost!",
+      8: "Hand over your Pokémon, or face the wrath of Team Rocket!",
+      9: "We are Team Rocket, and we're here to steal your Pokémon!",
+      10: "You're about to experience the true terror of Team Rocket!",
+      11: "Resistance is futile! Give us your Pokémon or face the consequences!"
     },
     "victory": {
       1: "Equipe Rocket decolando de novo!",
@@ -423,7 +427,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
       13: "I hope you brought marshmallows because things are about to heat up!",
       14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
-      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!"
+      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!",
+      16: "Hope you brought sunscreen, 'cause you're about to get burned!",
+      17: "You're in the way! Team Magma has no time for kids like you!",
 
     },
     "victory": {
@@ -477,6 +483,10 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "Get ready to lose!",
       6: "You dare to challenge Team Galactic?",
       7: "Team Galactic will conquer all!",
+      8: "Hope you're ready for a cosmic beatdown!",
+      9: "Witness the power of our technology and the future we envision!",
+      10: "In the name of Team Galactic, I'll eliminate anyone who stands in our way!",
+      11: "Looks like you're about to get starstruck...by our Pokémon!"
     },
     "victory": {
       1: "Fui amassado...",
@@ -511,7 +521,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       4: "How could I lose...",
       5: "I think Lord N would approve of a rematch clause.",
       6: "I guess my Pokémon liberation degree needs updating.",
-      7: "Note to self: practice Pokémon battling, liberate Pokémon better."
+      7: "Note to self: practice Pokémon battling, liberate Pokémon better.",
+      8: "Better luck next time! Maybe join Team Plasma for a change?",
+      9: "We came, we saw, we Plasma'd!"
     },
   },
   "flare_grunt": {
@@ -520,7 +532,8 @@ export const PGMdialogue: DialogueTranslationEntries = {
       2: "Team Flare will cleanse the world of imperfection!",
       3: "Prepare to face the brilliance of Team Flare!",
       4: "Team Flare's style and grace will outshine any opponent!",
-      5: "Your Pokémon are no match for the elegance of Team Flare."
+      5: "Your Pokémon are no match for the elegance of Team Flare.",
+      6: "Hope you brought your sunglasses, because things are about to get bright!"
     },
     "victory": {
       1: "O futuro não parece brilhante pra mim.",

--- a/src/locales/pt_BR/dialogue.ts
+++ b/src/locales/pt_BR/dialogue.ts
@@ -386,7 +386,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
   "rocket_grunt": {
     "encounter": {
       1: "Se prepara pra encrenca!",
-      2: "Come from Johto will they, mine allies, yes. Will revenge they are",
+      2: "OH NO! I DROPPED THE LIFT KEY!",
       3: "You say what? Team Rocket bye-bye a go-go? Broken up it is says you?",
       4: "To denounce the evils of truth and love!",
       5: "We Team Rocket are Pokémon gangsters!",
@@ -395,7 +395,8 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Hand over your Pokémon, or face the wrath of Team Rocket!",
       9: "We are Team Rocket, and we're here to steal your Pokémon!",
       10: "You're about to experience the true terror of Team Rocket!",
-      11: "Resistance is futile! Give us your Pokémon or face the consequences!"
+      11: "Resistance is futile! Give us your Pokémon or face the consequences!",
+      12: "STEAL for team rocket EXPLOIT for team rocket"
     },
     "victory": {
       1: "Equipe Rocket decolando de novo!",
@@ -408,18 +409,19 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "I blew it!",
       9: "My associates won't stand for this!",
       10: "So, you are good…",
-      11: "I'm steamed..."
+      11: "I'm steamed...",
+      12: "Come from Johto will they, mine allies, yes. Will revenge they are",
     },
   },
   "magma_grunt": {
     "encounter": {
       1: "Se você se meter com a Equipe Magma, não teremos piedade!",
-      2: "I should've brought my Game Boy Advance SP to play some Pokémon Sapphire  instead.",
+      2: "Get ready to feel the heat! And by heat, I mean my burning desire to win!",
       3: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
       4: "Heh, I'd like to you see try!",
       5: "Huh? What are you doing here?",
-      6: "Don't get any ideas about going easy on us just because you're a kid! We'll show you the power of Team Magma's amazing technology!",
-      7: "We, Team Magma, are working hard for everyone's sake. If there's more land, there'll be more places to live! Everyone would be happy!",
+      6: "We'll show you the power of Team Magma's amazing technology!",
+      7: "If there's more land, there'll be more places to live!",
       8: "You'd better not interfere with our plans! We're making the world a better place!",
       9: "You're in the way! Team Magma has no time for kids like you!",
       10: "Do you really think you can take on Team Magma? You're just a kid!",
@@ -427,10 +429,8 @@ export const PGMdialogue: DialogueTranslationEntries = {
       12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
       13: "I hope you brought marshmallows because things are about to heat up!",
       14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
-      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!",
       16: "Hope you brought sunscreen, 'cause you're about to get burned!",
       17: "You're in the way! Team Magma has no time for kids like you!",
-
     },
     "victory": {
       1: "Ahn? Eu perdi?!",
@@ -440,7 +440,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "What, what, what?",
       6: "I'm getting heat exhaustion…",
       7: "I failed to win, I should've planned better...",
-      8: "I'm steamed...",
+      8: "I'm heated...",
       9: "Oof... you got me.",
       10: "What?! I lost?! How could this be...?",
       11: "No way! You're just a kid!",
@@ -455,13 +455,13 @@ export const PGMdialogue: DialogueTranslationEntries = {
   "aqua_grunt": {
     "encounter": {
       1: "Não pegamos leve com quem se mete com a Equipe Aqua, nem mesmo crianças!",
-      2: "I should've brought my Game Boy Advance SP to play some Pokémon Ruby instead.",
-      3: "I was going to ambush you, but you had to dawdle in Petalburg Woods forever, didn't you?",
+      2: "I was going to ambush you, but you had to dawdle in the Plains forever, didn't you?",
+      3: "You're about to get soaked! And not just from my Pokémon's Water Gun.",
       4: "Grrr…You've got some nerve meddling with Team Aqua!",
       5: "Hey, you there! Don't butt in!",
       6: "Hey, there! Quit pushing! This is the line, can't you see?",
       7: "We, Team Aqua, exist for the good of all!",
-      8: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
+      8: "Prepare to be washed away by the tides of my… uh, Pokémon! Yeah, my Pokémon!",
     },
     "victory": {
       1: "Tá de brincadeira!",
@@ -486,7 +486,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Hope you're ready for a cosmic beatdown!",
       9: "Witness the power of our technology and the future we envision!",
       10: "In the name of Team Galactic, I'll eliminate anyone who stands in our way!",
-      11: "Looks like you're about to get starstruck...by our Pokémon!"
+      11: "Looks like you're about to get starstruck...by our Pokémon!",
+      12: "Because of you, they took my CLEFAIRY away...",
+      13: "If you try to mess with me, I'll shut you down with a Pokémon battle. So, what's it going to be? Are you going to mess with me?"
     },
     "victory": {
       1: "Fui amassado...",
@@ -499,31 +501,35 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Oops, our evil was no match for your Pokémon.",
       9: "This setback means nothing in the grand scheme.",
       10: "Our plans are bigger than this defeat.",
-      11: "I knew I should have trained more and evil-planned less."
+      11: "I knew I should have trained more and evil-planned less.",
+      12:"Looks like I need a new cosmic plan. This one fizzled out.",
+      13: "Defeated by a mere earthling… how embarrassing."
     },
   },
   "plasma_grunt": {
     "encounter": {
       1: "Não toleramos pessoas que pensam diferente de nós!",
-      2: "Bad for Team Plasma! Or Plasbad, for short!",
+      2: "Prepare to be dazzled by our galactic style! And by that, I mean defeated.",
       3: "There's no room for obstacles like you getting in the way of Unova's new dawn!",
       4: "Pokémon that work with humans might look happy, but they're suffering, count on it! No doubt about it!",
-      5: "If I win against you, release your Pokémon !",
+      5: "If I win against you, release your Pokémon!",
       6: "As a proud member of Team Plasma, I will gladly battle with you.",
-      7: "YOU! To please my Pokémon , lose!",
+      7: "YOU! To please my Pokémon, lose!",
       8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
-      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
+      9: "Team Plasma will liberate Pokémon from selfish humans like you!",
+      10: "Our hairstyles are out of this world... but our battling skills? You'll find out soon enough."
     },
     "victory": {
       1: "Plasmaaaaaaaaa!",
-      2: "You daft codger, your mask's absurd!",
+      2: "Looks like you're not ready for a galactic takeover!",
       3: "If you try to mess with me, I'll shut you down with a Pokémon battle.",
       4: "How could I lose...",
       5: "I think Lord N would approve of a rematch clause.",
       6: "I guess my Pokémon liberation degree needs updating.",
       7: "Note to self: practice Pokémon battling, liberate Pokémon better.",
       8: "Better luck next time! Maybe join Team Plasma for a change?",
-      9: "We came, we saw, we Plasma'd!"
+      9: "We came, we saw, we Plasma'd!",
+      10: "This is bad... Badbadbadbadbadbadbad! Bad for Team Plasma! Or Plasbad, for short!"
     },
   },
   "flare_grunt": {

--- a/src/locales/zh_CN/dialogue.ts
+++ b/src/locales/zh_CN/dialogue.ts
@@ -384,50 +384,149 @@ export const PGMdialogue: DialogueTranslationEntries = {
   },
   "rocket_grunt": {
     "encounter": {
-      1: "你要有麻烦了！"
+      1: "你要有麻烦了！",
+      2: "Come from Johto will they, mine allies, yes. Will revenge they are",
+      3: "You say what? Team Rocket bye-bye a go-go? Broken up it is says you?",
+      4: "To denounce the evils of truth and love!",
+      5: "We Team Rocket are Pokémon gangsters!",
+      6: "We're pulling a big job here! Get lost, kid!",
+      7: "You broke into our operation? You must be lost!",
     },
     "victory": {
-      1: "好讨厌的感觉啊！"
+      1: "好讨厌的感觉啊！",
+      2: "Winning is for winners.",
+      3: "You will regret this!",
+      4: "Blastin' off at the speed of light!",
+      5: "Blasting off again....",
+      6: "Stop! I give up! I'll leave quietly!",
+      7: "You made me mad! Team Rocket will blacklist you!",
+      8: "I blew it!",
+      9: "My associates won't stand for this!",
+      10: "So, you are good…",
+      11: "I'm steamed..."
     },
   },
   "magma_grunt": {
     "encounter": {
-      1: "如果你挡在熔岩队路上，那就别指望我们手下留情！"
+      1: "如果你挡在熔岩队路上，那就别指望我们手下留情！",
+      2: "I should've brought my Game Boy Advance SP to play some Pokémon Sapphire  instead.",
+      3: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
+      4: "Heh, I'd like to you see try!",
+      5: "Huh? What are you doing here?",
+      6: "Don't get any ideas about going easy on us just because you're a kid! We'll show you the power of Team Magma's amazing technology!",
+      7: "We, Team Magma, are working hard for everyone's sake. If there's more land, there'll be more places to live! Everyone would be happy!",
+      8: "You'd better not interfere with our plans! We're making the world a better place!",
+      9: "You're in the way! Team Magma has no time for kids like you!",
+      10: "Do you really think you can take on Team Magma? You're just a kid!",
+      11: "We're going to use the power of a volcano! It's gonna be... explosive! Get it? Heh heh!",
+      12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
+      13: "I hope you brought marshmallows because things are about to heat up!",
+      14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
+      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!"
     },
     "victory": {
-      1: "哈？我输了？！"
+      1: "哈？我输了？！",
+      2: "Urrrgh…I should've ducked into our hideout right away…",
+      3: "Okay, oh-kay! I admit it—you're strong!",
+      4: "Don't worry about me. Go wherever you want!",
+      5: "What, what, what?",
+      6: "I'm getting heat exhaustion…",
+      7: "I failed to win, I should've planned better...",
+      8: "I'm steamed...",
+      9: "Oof... you got me.",
+      10: "What?! I lost?! How could this be...?",
+      11: "No way! You're just a kid!",
+      12: "What? I lost? But... but I was supposed to win!",
+      13:  "I lost?! Now I'll never get promoted to Team Magma Senior Grunt!",
+      14: "You beat me... Do you think the boss will dock my pay for this?",
+      15: "I can't believe I lost! I even skipped lunch for this!",
+      16: "Defeated... I guess evil masterminds don't get sick days, huh?",
+      17: "I should have brought more potions... and a better strategy."
     },
   },
   "aqua_grunt": {
     "encounter": {
-      1: "即使是小孩，如果要和海洋队作对，也别指望我们手下留情！"
+      1: "即使是小孩，如果要和海洋队作对，也别指望我们手下留情！",
+      2: "I should've brought my Game Boy Advance SP to play some Pokémon Ruby instead.",
+      3: "I was going to ambush you, but you had to dawdle in Petalburg Woods forever, didn't you?",
+      4: "Grrr…You've got some nerve meddling with Team Aqua!",
+      5: "Hey, you there! Don't butt in!",
+      6: "Hey, there! Quit pushing! This is the line, can't you see?",
+      7: "We, Team Aqua, exist for the good of all!",
+      8: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
     },
     "victory": {
-      1: "你在开玩笑吧？"
+      1: "你在开玩笑吧？",
+      2: "Come on and battle me again!",
+      3: "I'll let you go today!",
+      4: "What?! I lost, too!",
+      5: "Arrgh, I didn't count on being meddled with by some meddling kid!",
+      6: "I lost?! Guess I'll have to swim back to the hideout now...",
+      7: "You beat me... Do you think the boss will make me walk the plank for this?",
+      8: "I lost?!"
     },
   },
   "galactic_grunt": {
     "encounter": {
-      1: "别惹银河队！"
+      1: "别惹银河队！",
+      2: "Our time has come!",
+      3: "It's team galactic's time now!",
+      4: "Hey, wanna join Team Galactic?",
+      5: "Get ready to lose!",
+      6: "You dare to challenge Team Galactic?",
+      7: "Team Galactic will conquer all!",
     },
     "victory": {
-      1: "停机了…"
+      1: "停机了…",
+      2: "Not bad...",
+      3: "How?!",
+      4: "I'll be back..",
+      5: "I'm outta here!",
+      6: "Maybe we should stick to evil plans and leave battling to someone else.",
+      7: "Note to self: practice Pokémon battling, ASAP.",
+      8: "Oops, our evil was no match for your Pokémon.",
+      9: "This setback means nothing in the grand scheme.",
+      10: "Our plans are bigger than this defeat.",
+      11: "I knew I should have trained more and evil-planned less."
     },
   },
   "plasma_grunt": {
     "encounter": {
-      1: "异端不共戴天！"
+      1: "异端不共戴天！",
+      2: "Bad for Team Plasma! Or Plasbad, for short!",
+      3: "There's no room for obstacles like you getting in the way of Unova's new dawn!",
+      4: "Pokémon that work with humans might look happy, but they're suffering, count on it! No doubt about it!",
+      5: "If I win against you, release your Pokémon !",
+      6: "As a proud member of Team Plasma, I will gladly battle with you.",
+      7: "YOU! To please my Pokémon , lose!",
+      8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
+      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
     },
     "victory": {
-      1: "等离子子子子子子！"
+      1: "等离子子子子子子！",
+      2: "You daft codger, your mask's absurd!",
+      3: "If you try to mess with me, I'll shut you down with a Pokémon battle.",
+      4: "How could I lose...",
+      5: "I think Lord N would approve of a rematch clause.",
+      6: "I guess my Pokémon liberation degree needs updating.",
+      7: "Note to self: practice Pokémon battling, liberate Pokémon better."
     },
   },
   "flare_grunt": {
     "encounter": {
-      1: "时尚最重要！"
+      1: "时尚最重要！",
+      2: "Team Flare will cleanse the world of imperfection!",
+      3: "Prepare to face the brilliance of Team Flare!",
+      4: "Team Flare's style and grace will outshine any opponent!",
+      5: "Your Pokémon are no match for the elegance of Team Flare."
     },
     "victory": {
-      1: "未来一片黑暗啊…"
+      1: "未来一片黑暗啊…",
+      2: "Gahh?! I lost?!",
+      3: "I guess our beauty treatments didn't include battling skills.",
+      4: "Your victory today won't stop Team Flare's quest for a beautiful world.",
+      5: "Even in defeat, Team Flare's elegance shines through.",
+      6: "Perhaps there's more to battling than I thought. Back to the drawing board."
     },
   },
   "rocket_boss_giovanni_1": {

--- a/src/locales/zh_CN/dialogue.ts
+++ b/src/locales/zh_CN/dialogue.ts
@@ -385,7 +385,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
   "rocket_grunt": {
     "encounter": {
       1: "你要有麻烦了！",
-      2: "Come from Johto will they, mine allies, yes. Will revenge they are",
+      2: "OH NO! I DROPPED THE LIFT KEY!",
       3: "You say what? Team Rocket bye-bye a go-go? Broken up it is says you?",
       4: "To denounce the evils of truth and love!",
       5: "We Team Rocket are Pokémon gangsters!",
@@ -394,7 +394,8 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Hand over your Pokémon, or face the wrath of Team Rocket!",
       9: "We are Team Rocket, and we're here to steal your Pokémon!",
       10: "You're about to experience the true terror of Team Rocket!",
-      11: "Resistance is futile! Give us your Pokémon or face the consequences!"
+      11: "Resistance is futile! Give us your Pokémon or face the consequences!",
+      12: "STEAL for team rocket EXPLOIT for team rocket"
     },
     "victory": {
       1: "好讨厌的感觉啊！",
@@ -407,18 +408,19 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "I blew it!",
       9: "My associates won't stand for this!",
       10: "So, you are good…",
-      11: "I'm steamed..."
+      11: "I'm steamed...",
+      12: "Come from Johto will they, mine allies, yes. Will revenge they are",
     },
   },
   "magma_grunt": {
     "encounter": {
       1: "如果你挡在熔岩队路上，那就别指望我们手下留情！",
-      2: "I should've brought my Game Boy Advance SP to play some Pokémon Sapphire  instead.",
+      2: "Get ready to feel the heat! And by heat, I mean my burning desire to win!",
       3: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
       4: "Heh, I'd like to you see try!",
       5: "Huh? What are you doing here?",
-      6: "Don't get any ideas about going easy on us just because you're a kid! We'll show you the power of Team Magma's amazing technology!",
-      7: "We, Team Magma, are working hard for everyone's sake. If there's more land, there'll be more places to live! Everyone would be happy!",
+      6: "We'll show you the power of Team Magma's amazing technology!",
+      7: "If there's more land, there'll be more places to live!",
       8: "You'd better not interfere with our plans! We're making the world a better place!",
       9: "You're in the way! Team Magma has no time for kids like you!",
       10: "Do you really think you can take on Team Magma? You're just a kid!",
@@ -426,7 +428,6 @@ export const PGMdialogue: DialogueTranslationEntries = {
       12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
       13: "I hope you brought marshmallows because things are about to heat up!",
       14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
-      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!",
       16: "Hope you brought sunscreen, 'cause you're about to get burned!",
       17: "You're in the way! Team Magma has no time for kids like you!",
     },
@@ -438,7 +439,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "What, what, what?",
       6: "I'm getting heat exhaustion…",
       7: "I failed to win, I should've planned better...",
-      8: "I'm steamed...",
+      8: "I'm heated...",
       9: "Oof... you got me.",
       10: "What?! I lost?! How could this be...?",
       11: "No way! You're just a kid!",
@@ -453,13 +454,13 @@ export const PGMdialogue: DialogueTranslationEntries = {
   "aqua_grunt": {
     "encounter": {
       1: "即使是小孩，如果要和海洋队作对，也别指望我们手下留情！",
-      2: "I should've brought my Game Boy Advance SP to play some Pokémon Ruby instead.",
-      3: "I was going to ambush you, but you had to dawdle in Petalburg Woods forever, didn't you?",
+      2: "I was going to ambush you, but you had to dawdle in the Plains forever, didn't you?",
+      3: "You're about to get soaked! And not just from my Pokémon's Water Gun.",
       4: "Grrr…You've got some nerve meddling with Team Aqua!",
       5: "Hey, you there! Don't butt in!",
       6: "Hey, there! Quit pushing! This is the line, can't you see?",
       7: "We, Team Aqua, exist for the good of all!",
-      8: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
+      8: "Prepare to be washed away by the tides of my… uh, Pokémon! Yeah, my Pokémon!",
     },
     "victory": {
       1: "你在开玩笑吧？",
@@ -484,7 +485,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Hope you're ready for a cosmic beatdown!",
       9: "Witness the power of our technology and the future we envision!",
       10: "In the name of Team Galactic, I'll eliminate anyone who stands in our way!",
-      11: "Looks like you're about to get starstruck...by our Pokémon!"
+      11: "Looks like you're about to get starstruck...by our Pokémon!",
+      12: "Because of you, they took my CLEFAIRY away...",
+      13: "If you try to mess with me, I'll shut you down with a Pokémon battle. So, what's it going to be? Are you going to mess with me?"
     },
     "victory": {
       1: "停机了…",
@@ -497,31 +500,34 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Oops, our evil was no match for your Pokémon.",
       9: "This setback means nothing in the grand scheme.",
       10: "Our plans are bigger than this defeat.",
-      11: "I knew I should have trained more and evil-planned less."
-    },
+      11: "I knew I should have trained more and evil-planned less.",
+      12:"Looks like I need a new cosmic plan. This one fizzled out.",
+      13: "Defeated by a mere earthling… how embarrassing."    },
   },
   "plasma_grunt": {
     "encounter": {
       1: "异端不共戴天！",
-      2: "Bad for Team Plasma! Or Plasbad, for short!",
+      2: "Prepare to be dazzled by our galactic style! And by that, I mean defeated.",
       3: "There's no room for obstacles like you getting in the way of Unova's new dawn!",
       4: "Pokémon that work with humans might look happy, but they're suffering, count on it! No doubt about it!",
-      5: "If I win against you, release your Pokémon !",
+      5: "If I win against you, release your Pokémon!",
       6: "As a proud member of Team Plasma, I will gladly battle with you.",
-      7: "YOU! To please my Pokémon , lose!",
+      7: "YOU! To please my Pokémon, lose!",
       8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
-      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
+      9: "Team Plasma will liberate Pokémon from selfish humans like you!",
+      10: "Our hairstyles are out of this world... but our battling skills? You'll find out soon enough."
     },
     "victory": {
       1: "等离子子子子子子！",
-      2: "You daft codger, your mask's absurd!",
+      2: "Looks like you're not ready for a galactic takeover!",
       3: "If you try to mess with me, I'll shut you down with a Pokémon battle.",
       4: "How could I lose...",
       5: "I think Lord N would approve of a rematch clause.",
       6: "I guess my Pokémon liberation degree needs updating.",
       7: "Note to self: practice Pokémon battling, liberate Pokémon better.",
-      8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
-      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
+      8: "Better luck next time! Maybe join Team Plasma for a change?",
+      9: "We came, we saw, we Plasma'd!",
+      10: "This is bad... Badbadbadbadbadbadbad! Bad for Team Plasma! Or Plasbad, for short!"
     },
   },
   "flare_grunt": {

--- a/src/locales/zh_CN/dialogue.ts
+++ b/src/locales/zh_CN/dialogue.ts
@@ -391,6 +391,10 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "We Team Rocket are Pokémon gangsters!",
       6: "We're pulling a big job here! Get lost, kid!",
       7: "You broke into our operation? You must be lost!",
+      8: "Hand over your Pokémon, or face the wrath of Team Rocket!",
+      9: "We are Team Rocket, and we're here to steal your Pokémon!",
+      10: "You're about to experience the true terror of Team Rocket!",
+      11: "Resistance is futile! Give us your Pokémon or face the consequences!"
     },
     "victory": {
       1: "好讨厌的感觉啊！",
@@ -422,7 +426,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
       13: "I hope you brought marshmallows because things are about to heat up!",
       14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
-      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!"
+      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!",
+      16: "Hope you brought sunscreen, 'cause you're about to get burned!",
+      17: "You're in the way! Team Magma has no time for kids like you!",
     },
     "victory": {
       1: "哈？我输了？！",
@@ -475,6 +481,10 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "Get ready to lose!",
       6: "You dare to challenge Team Galactic?",
       7: "Team Galactic will conquer all!",
+      8: "Hope you're ready for a cosmic beatdown!",
+      9: "Witness the power of our technology and the future we envision!",
+      10: "In the name of Team Galactic, I'll eliminate anyone who stands in our way!",
+      11: "Looks like you're about to get starstruck...by our Pokémon!"
     },
     "victory": {
       1: "停机了…",
@@ -509,7 +519,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       4: "How could I lose...",
       5: "I think Lord N would approve of a rematch clause.",
       6: "I guess my Pokémon liberation degree needs updating.",
-      7: "Note to self: practice Pokémon battling, liberate Pokémon better."
+      7: "Note to self: practice Pokémon battling, liberate Pokémon better.",
+      8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
+      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
     },
   },
   "flare_grunt": {
@@ -518,7 +530,8 @@ export const PGMdialogue: DialogueTranslationEntries = {
       2: "Team Flare will cleanse the world of imperfection!",
       3: "Prepare to face the brilliance of Team Flare!",
       4: "Team Flare's style and grace will outshine any opponent!",
-      5: "Your Pokémon are no match for the elegance of Team Flare."
+      5: "Your Pokémon are no match for the elegance of Team Flare.",
+      6: "Hope you brought your sunglasses, because things are about to get bright!"
     },
     "victory": {
       1: "未来一片黑暗啊…",

--- a/src/locales/zh_TW/dialogue.ts
+++ b/src/locales/zh_TW/dialogue.ts
@@ -385,7 +385,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
   "rocket_grunt": {
     "encounter": {
       1: "Prepare for trouble!",
-      2: "Come from Johto will they, mine allies, yes. Will revenge they are",
+      2: "OH NO! I DROPPED THE LIFT KEY!",
       3: "You say what? Team Rocket bye-bye a go-go? Broken up it is says you?",
       4: "To denounce the evils of truth and love!",
       5: "We Team Rocket are Pokémon gangsters!",
@@ -394,7 +394,8 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Hand over your Pokémon, or face the wrath of Team Rocket!",
       9: "We are Team Rocket, and we're here to steal your Pokémon!",
       10: "You're about to experience the true terror of Team Rocket!",
-      11: "Resistance is futile! Give us your Pokémon or face the consequences!"
+      11: "Resistance is futile! Give us your Pokémon or face the consequences!",
+      12: "STEAL for team rocket EXPLOIT for team rocket"
     },
     "victory": {
       1: "Team Rocket blasting off again!",
@@ -407,18 +408,19 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "I blew it!",
       9: "My associates won't stand for this!",
       10: "So, you are good…",
-      11: "I'm steamed..."
+      11: "I'm steamed...",
+      12: "Come from Johto will they, mine allies, yes. Will revenge they are",
     },
   },
   "magma_grunt": {
     "encounter": {
       1: " If you get in the way of Team Magma, don’t expect any mercy!",
-      2: "I should've brought my Game Boy Advance SP to play some Pokémon Sapphire  instead.",
+      2: "Get ready to feel the heat! And by heat, I mean my burning desire to win!",
       3: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
       4: "Heh, I'd like to you see try!",
       5: "Huh? What are you doing here?",
-      6: "Don't get any ideas about going easy on us just because you're a kid! We'll show you the power of Team Magma's amazing technology!",
-      7: "We, Team Magma, are working hard for everyone's sake. If there's more land, there'll be more places to live! Everyone would be happy!",
+      6: "We'll show you the power of Team Magma's amazing technology!",
+      7: "If there's more land, there'll be more places to live!",
       8: "You'd better not interfere with our plans! We're making the world a better place!",
       9: "You're in the way! Team Magma has no time for kids like you!",
       10: "Do you really think you can take on Team Magma? You're just a kid!",
@@ -426,7 +428,6 @@ export const PGMdialogue: DialogueTranslationEntries = {
       12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
       13: "I hope you brought marshmallows because things are about to heat up!",
       14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
-      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!",
       16: "Hope you brought sunscreen, 'cause you're about to get burned!",
       17: "You're in the way! Team Magma has no time for kids like you!",
     },
@@ -438,7 +439,7 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "What, what, what?",
       6: "I'm getting heat exhaustion…",
       7: "I failed to win, I should've planned better...",
-      8: "I'm steamed...",
+      8: "I'm heated...",
       9: "Oof... you got me.",
       10: "What?! I lost?! How could this be...?",
       11: "No way! You're just a kid!",
@@ -453,13 +454,13 @@ export const PGMdialogue: DialogueTranslationEntries = {
   "aqua_grunt": {
     "encounter": {
       1: "No one who crosses Team Aqua gets any mercy, not even kids!",
-      2: "I should've brought my Game Boy Advance SP to play some Pokémon Ruby instead.",
-      3: "I was going to ambush you, but you had to dawdle in Petalburg Woods forever, didn't you?",
+      2: "I was going to ambush you, but you had to dawdle in the Plains forever, didn't you?",
+      3: "You're about to get soaked! And not just from my Pokémon's Water Gun.",
       4: "Grrr…You've got some nerve meddling with Team Aqua!",
       5: "Hey, you there! Don't butt in!",
       6: "Hey, there! Quit pushing! This is the line, can't you see?",
       7: "We, Team Aqua, exist for the good of all!",
-      8: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
+      8: "Prepare to be washed away by the tides of my… uh, Pokémon! Yeah, my Pokémon!",
     },
     "victory": {
       1: "You're kidding me!",
@@ -484,8 +485,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Hope you're ready for a cosmic beatdown!",
       9: "Witness the power of our technology and the future we envision!",
       10: "In the name of Team Galactic, I'll eliminate anyone who stands in our way!",
-      11: "Looks like you're about to get starstruck...by our Pokémon!"
-    },
+      11: "Looks like you're about to get starstruck...by our Pokémon!",
+      12: "Because of you, they took my CLEFAIRY away...",
+      13: "If you try to mess with me, I'll shut you down with a Pokémon battle. So, what's it going to be? Are you going to mess with me?"    },
     "victory": {
       1: "Shut down...",
       2: "Not bad...",
@@ -497,31 +499,35 @@ export const PGMdialogue: DialogueTranslationEntries = {
       8: "Oops, our evil was no match for your Pokémon.",
       9: "This setback means nothing in the grand scheme.",
       10: "Our plans are bigger than this defeat.",
-      11: "I knew I should have trained more and evil-planned less."
+      11: "I knew I should have trained more and evil-planned less.",
+      12:"Looks like I need a new cosmic plan. This one fizzled out.",
+      13: "Defeated by a mere earthling… how embarrassing."
     },
   },
   "plasma_grunt": {
     "encounter": {
       1: "We won't tolerate people who have different ideas!",
-      2: "Bad for Team Plasma! Or Plasbad, for short!",
+      2: "Prepare to be dazzled by our galactic style! And by that, I mean defeated.",
       3: "There's no room for obstacles like you getting in the way of Unova's new dawn!",
       4: "Pokémon that work with humans might look happy, but they're suffering, count on it! No doubt about it!",
-      5: "If I win against you, release your Pokémon !",
+      5: "If I win against you, release your Pokémon!",
       6: "As a proud member of Team Plasma, I will gladly battle with you.",
-      7: "YOU! To please my Pokémon , lose!",
+      7: "YOU! To please my Pokémon, lose!",
       8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
-      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
+      9: "Team Plasma will liberate Pokémon from selfish humans like you!",
+      10: "Our hairstyles are out of this world... but our battling skills? You'll find out soon enough."
     },
     "victory": {
       1: "Plasmaaaaaaaaa!",
-      2: "You daft codger, your mask's absurd!",
+      2: "Looks like you're not ready for a galactic takeover!",
       3: "If you try to mess with me, I'll shut you down with a Pokémon battle.",
       4: "How could I lose...",
       5: "I think Lord N would approve of a rematch clause.",
       6: "I guess my Pokémon liberation degree needs updating.",
       7: "Note to self: practice Pokémon battling, liberate Pokémon better.",
-      8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
-      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
+      8: "Better luck next time! Maybe join Team Plasma for a change?",
+      9: "We came, we saw, we Plasma'd!",
+      10: "This is bad... Badbadbadbadbadbadbad! Bad for Team Plasma! Or Plasbad, for short!"
     },
   },
   "flare_grunt": {
@@ -532,7 +538,6 @@ export const PGMdialogue: DialogueTranslationEntries = {
       4: "Team Flare's style and grace will outshine any opponent!",
       5: "Your Pokémon are no match for the elegance of Team Flare.",
       6: "Hope you brought your sunglasses, because things are about to get bright!"
-
     },
     "victory": {
       1: "The future doesn't look bright for me.",

--- a/src/locales/zh_TW/dialogue.ts
+++ b/src/locales/zh_TW/dialogue.ts
@@ -391,6 +391,10 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "We Team Rocket are Pokémon gangsters!",
       6: "We're pulling a big job here! Get lost, kid!",
       7: "You broke into our operation? You must be lost!",
+      8: "Hand over your Pokémon, or face the wrath of Team Rocket!",
+      9: "We are Team Rocket, and we're here to steal your Pokémon!",
+      10: "You're about to experience the true terror of Team Rocket!",
+      11: "Resistance is futile! Give us your Pokémon or face the consequences!"
     },
     "victory": {
       1: "Team Rocket blasting off again!",
@@ -422,7 +426,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
       13: "I hope you brought marshmallows because things are about to heat up!",
       14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
-      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!"
+      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!",
+      16: "Hope you brought sunscreen, 'cause you're about to get burned!",
+      17: "You're in the way! Team Magma has no time for kids like you!",
     },
     "victory": {
       1: "Huh? I lost?!",
@@ -475,6 +481,10 @@ export const PGMdialogue: DialogueTranslationEntries = {
       5: "Get ready to lose!",
       6: "You dare to challenge Team Galactic?",
       7: "Team Galactic will conquer all!",
+      8: "Hope you're ready for a cosmic beatdown!",
+      9: "Witness the power of our technology and the future we envision!",
+      10: "In the name of Team Galactic, I'll eliminate anyone who stands in our way!",
+      11: "Looks like you're about to get starstruck...by our Pokémon!"
     },
     "victory": {
       1: "Shut down...",
@@ -509,7 +519,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       4: "How could I lose...",
       5: "I think Lord N would approve of a rematch clause.",
       6: "I guess my Pokémon liberation degree needs updating.",
-      7: "Note to self: practice Pokémon battling, liberate Pokémon better."
+      7: "Note to self: practice Pokémon battling, liberate Pokémon better.",
+      8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
+      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
     },
   },
   "flare_grunt": {
@@ -518,7 +530,9 @@ export const PGMdialogue: DialogueTranslationEntries = {
       2: "Team Flare will cleanse the world of imperfection!",
       3: "Prepare to face the brilliance of Team Flare!",
       4: "Team Flare's style and grace will outshine any opponent!",
-      5: "Your Pokémon are no match for the elegance of Team Flare."
+      5: "Your Pokémon are no match for the elegance of Team Flare.",
+      6: "Hope you brought your sunglasses, because things are about to get bright!"
+
     },
     "victory": {
       1: "The future doesn't look bright for me.",

--- a/src/locales/zh_TW/dialogue.ts
+++ b/src/locales/zh_TW/dialogue.ts
@@ -384,50 +384,149 @@ export const PGMdialogue: DialogueTranslationEntries = {
   },
   "rocket_grunt": {
     "encounter": {
-      1: "Prepare for trouble!"
+      1: "Prepare for trouble!",
+      2: "Come from Johto will they, mine allies, yes. Will revenge they are",
+      3: "You say what? Team Rocket bye-bye a go-go? Broken up it is says you?",
+      4: "To denounce the evils of truth and love!",
+      5: "We Team Rocket are Pokémon gangsters!",
+      6: "We're pulling a big job here! Get lost, kid!",
+      7: "You broke into our operation? You must be lost!",
     },
     "victory": {
-      1: "Team Rocket blasting off again!"
+      1: "Team Rocket blasting off again!",
+      2: "Winning is for winners.",
+      3: "You will regret this!",
+      4: "Blastin' off at the speed of light!",
+      5: "Blasting off again....",
+      6: "Stop! I give up! I'll leave quietly!",
+      7: "You made me mad! Team Rocket will blacklist you!",
+      8: "I blew it!",
+      9: "My associates won't stand for this!",
+      10: "So, you are good…",
+      11: "I'm steamed..."
     },
   },
   "magma_grunt": {
     "encounter": {
-      1: " If you get in the way of Team Magma, don’t expect any mercy!"
+      1: " If you get in the way of Team Magma, don’t expect any mercy!",
+      2: "I should've brought my Game Boy Advance SP to play some Pokémon Sapphire  instead.",
+      3: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
+      4: "Heh, I'd like to you see try!",
+      5: "Huh? What are you doing here?",
+      6: "Don't get any ideas about going easy on us just because you're a kid! We'll show you the power of Team Magma's amazing technology!",
+      7: "We, Team Magma, are working hard for everyone's sake. If there's more land, there'll be more places to live! Everyone would be happy!",
+      8: "You'd better not interfere with our plans! We're making the world a better place!",
+      9: "You're in the way! Team Magma has no time for kids like you!",
+      10: "Do you really think you can take on Team Magma? You're just a kid!",
+      11: "We're going to use the power of a volcano! It's gonna be... explosive! Get it? Heh heh!",
+      12: "Oh, you're here to stop us? Do you have any idea how much paperwork I'd have to do if you succeed?",
+      13: "I hope you brought marshmallows because things are about to heat up!",
+      14:  "You're here to stop our plans? Good luck! I've been practicing my 'evil laugh' all week!",
+      15: "Prepare to face my wrath... and my slightly underleveled Pokémon!"
     },
     "victory": {
-      1: "Huh? I lost?!"
+      1: "Huh? I lost?!",
+      2: "Urrrgh…I should've ducked into our hideout right away…",
+      3: "Okay, oh-kay! I admit it—you're strong!",
+      4: "Don't worry about me. Go wherever you want!",
+      5: "What, what, what?",
+      6: "I'm getting heat exhaustion…",
+      7: "I failed to win, I should've planned better...",
+      8: "I'm steamed...",
+      9: "Oof... you got me.",
+      10: "What?! I lost?! How could this be...?",
+      11: "No way! You're just a kid!",
+      12: "What? I lost? But... but I was supposed to win!",
+      13:  "I lost?! Now I'll never get promoted to Team Magma Senior Grunt!",
+      14: "You beat me... Do you think the boss will dock my pay for this?",
+      15: "I can't believe I lost! I even skipped lunch for this!",
+      16: "Defeated... I guess evil masterminds don't get sick days, huh?",
+      17: "I should have brought more potions... and a better strategy."
     },
   },
   "aqua_grunt": {
     "encounter": {
-      1: "No one who crosses Team Aqua gets any mercy, not even kids!"
+      1: "No one who crosses Team Aqua gets any mercy, not even kids!",
+      2: "I should've brought my Game Boy Advance SP to play some Pokémon Ruby instead.",
+      3: "I was going to ambush you, but you had to dawdle in Petalburg Woods forever, didn't you?",
+      4: "Grrr…You've got some nerve meddling with Team Aqua!",
+      5: "Hey, you there! Don't butt in!",
+      6: "Hey, there! Quit pushing! This is the line, can't you see?",
+      7: "We, Team Aqua, exist for the good of all!",
+      8: "Hey! You there! Which do you think is cooler? Team Aqua's uniform or Team Magma's?",
     },
     "victory": {
-      1: "You're kidding me!"
+      1: "You're kidding me!",
+      2: "Come on and battle me again!",
+      3: "I'll let you go today!",
+      4: "What?! I lost, too!",
+      5: "Arrgh, I didn't count on being meddled with by some meddling kid!",
+      6: "I lost?! Guess I'll have to swim back to the hideout now...",
+      7: "You beat me... Do you think the boss will make me walk the plank for this?",
+      8: "I lost?!"
     },
   },
   "galactic_grunt": {
     "encounter": {
-      1: "Don't mess with Team Galactic!"
+      1: "Don't mess with Team Galactic!",
+      2: "Our time has come!",
+      3: "It's team galactic's time now!",
+      4: "Hey, wanna join Team Galactic?",
+      5: "Get ready to lose!",
+      6: "You dare to challenge Team Galactic?",
+      7: "Team Galactic will conquer all!",
     },
     "victory": {
-      1: "Shut down..."
+      1: "Shut down...",
+      2: "Not bad...",
+      3: "How?!",
+      4: "I'll be back..",
+      5: "I'm outta here!",
+      6: "Maybe we should stick to evil plans and leave battling to someone else.",
+      7: "Note to self: practice Pokémon battling, ASAP.",
+      8: "Oops, our evil was no match for your Pokémon.",
+      9: "This setback means nothing in the grand scheme.",
+      10: "Our plans are bigger than this defeat.",
+      11: "I knew I should have trained more and evil-planned less."
     },
   },
   "plasma_grunt": {
     "encounter": {
-      1: "We won't tolerate people who have different ideas!"
+      1: "We won't tolerate people who have different ideas!",
+      2: "Bad for Team Plasma! Or Plasbad, for short!",
+      3: "There's no room for obstacles like you getting in the way of Unova's new dawn!",
+      4: "Pokémon that work with humans might look happy, but they're suffering, count on it! No doubt about it!",
+      5: "If I win against you, release your Pokémon !",
+      6: "As a proud member of Team Plasma, I will gladly battle with you.",
+      7: "YOU! To please my Pokémon , lose!",
+      8: "Your Pokémon will serve a greater purpose under Lord N's vision.",
+      9: "Team Plasma will liberate Pokémon from selfish humans like you!"
     },
     "victory": {
-      1: "Plasmaaaaaaaaa!"
+      1: "Plasmaaaaaaaaa!",
+      2: "You daft codger, your mask's absurd!",
+      3: "If you try to mess with me, I'll shut you down with a Pokémon battle.",
+      4: "How could I lose...",
+      5: "I think Lord N would approve of a rematch clause.",
+      6: "I guess my Pokémon liberation degree needs updating.",
+      7: "Note to self: practice Pokémon battling, liberate Pokémon better."
     },
   },
   "flare_grunt": {
     "encounter": {
-      1: "Fashion is most important to us!"
+      1: "Fashion is most important to us!",
+      2: "Team Flare will cleanse the world of imperfection!",
+      3: "Prepare to face the brilliance of Team Flare!",
+      4: "Team Flare's style and grace will outshine any opponent!",
+      5: "Your Pokémon are no match for the elegance of Team Flare."
     },
     "victory": {
-      1: "The future doesn't look bright for me."
+      1: "The future doesn't look bright for me.",
+      2: "Gahh?! I lost?!",
+      3: "I guess our beauty treatments didn't include battling skills.",
+      4: "Your victory today won't stop Team Flare's quest for a beautiful world.",
+      5: "Even in defeat, Team Flare's elegance shines through.",
+      6: "Perhaps there's more to battling than I thought. Back to the drawing board."
     },
   },
   "rocket_boss_giovanni_1": {


### PR DESCRIPTION
## What are the changes?
Adding more dialogue for grunts

## Why am I doing these changes?
closes : (https://github.com/pagefaultgames/pokerogue/issues/2095)

## What did change?
various dialogue files to support new dialogue for team evil.

### Screenshots/Videos
![rocket1](https://github.com/pagefaultgames/pokerogue/assets/65863220/dc118305-e2b6-4d04-8f9e-e69d29028bdc)
![rocket2](https://github.com/pagefaultgames/pokerogue/assets/65863220/cc6efbdd-62c5-4bf7-ace2-aa74c7a1a26c)


## How to test the changes?
Set trainer battles to all be one of the following different types

  ROCKET_GRUNT,
  MAGMA_GRUNT,
  AQUA_GRUNT,
  GALACTIC_GRUNT,
  PLASMA_GRUNT,
  FLARE_GRUNT,

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?