### PR TITLE
Localization: Localize luck indicator text and shiny labels

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -66,6 +66,7 @@ import { PlayerGender } from "#enums/player-gender";
 import { Species } from "#enums/species";
 import { UiTheme } from "#enums/ui-theme";
 import { TimedEventManager } from "#app/timed-event-manager.js";
+import i18next from "i18next";
 
 export const bypassLogin = import.meta.env.VITE_BYPASS_LOGIN === "1";
 
@@ -463,7 +464,7 @@ export default class BattleScene extends SceneBase {
     this.luckText.setVisible(false);
     this.fieldUI.add(this.luckText);
 
-    this.luckLabelText = addTextObject(this, (this.game.canvas.width / 6) - 2, 0, "Luck:", TextStyle.PARTY, { fontSize: "54px" });
+    this.luckLabelText = addTextObject(this, (this.game.canvas.width / 6) - 2, 0, i18next.t("common:luckIndicator"), TextStyle.PARTY, { fontSize: "54px" });
     this.luckLabelText.setName("text-luck-label");
     this.luckLabelText.setOrigin(1, 0.5);
     this.luckLabelText.setVisible(false);

--- a/src/locales/de/common.ts
+++ b/src/locales/de/common.ts
@@ -2,8 +2,8 @@ import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const common: SimpleTranslationEntries = {
   "start": "Start",
-  "luckIndicator": "Sorte:",
-  "shinyOnHover": "Shiny",
+  "luckIndicator": "Glück:",
+  "shinyOnHover": "Schillernd",
   "commonShiny": "Gewöhnlich",
   "rareShiny": "Selten",
   "epicShiny": "Episch",

--- a/src/locales/de/common.ts
+++ b/src/locales/de/common.ts
@@ -2,4 +2,9 @@ import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const common: SimpleTranslationEntries = {
   "start": "Start",
+  "luckIndicator": "Sorte:",
+  "shinyOnHover": "Shiny",
+  "commonShiny": "Gewöhnlich",
+  "rareShiny": "Selten",
+  "epicShiny": "Episch",
 } as const;

--- a/src/locales/de/pokemon-info-container.ts
+++ b/src/locales/de/pokemon-info-container.ts
@@ -5,7 +5,4 @@ export const pokemonInfoContainer: SimpleTranslationEntries = {
   "gender": "Geschlecht:",
   "ability": "Fähigkeit:",
   "nature": "Wesen:",
-  "epic": "Episch",
-  "rare": "Selten",
-  "common": "Gewöhnlich"
 } as const;

--- a/src/locales/en/common.ts
+++ b/src/locales/en/common.ts
@@ -2,4 +2,9 @@ import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const common: SimpleTranslationEntries = {
   "start": "Start",
+  "luckIndicator": "Luck:",
+  "shinyOnHover": "Shiny",
+  "commonShiny": "Common",
+  "rareShiny": "Rare",
+  "epicShiny": "Epic",
 } as const;

--- a/src/locales/en/pokemon-info-container.ts
+++ b/src/locales/en/pokemon-info-container.ts
@@ -5,8 +5,5 @@ export const pokemonInfoContainer: SimpleTranslationEntries = {
   "gender": "Gender:",
   "ability": "Ability:",
   "nature": "Nature:",
-  "epic": "Epic",
-  "rare": "Rare",
-  "common": "Common",
   "form": "Form:"
 } as const;

--- a/src/locales/es/common.ts
+++ b/src/locales/es/common.ts
@@ -2,4 +2,9 @@ import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const common: SimpleTranslationEntries = {
   "start": "Start",
+  "luckIndicator": "Luck:",
+  "shinyOnHover": "Shiny",
+  "commonShiny": "Común",
+  "rareShiny": "Raro",
+  "epicShiny": "Épico",
 } as const;

--- a/src/locales/es/common.ts
+++ b/src/locales/es/common.ts
@@ -2,7 +2,7 @@ import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const common: SimpleTranslationEntries = {
   "start": "Start",
-  "luckIndicator": "Luck:",
+  "luckIndicator": "Suerte:",
   "shinyOnHover": "Shiny",
   "commonShiny": "Común",
   "rareShiny": "Raro",

--- a/src/locales/es/pokemon-info-container.ts
+++ b/src/locales/es/pokemon-info-container.ts
@@ -5,7 +5,4 @@ export const pokemonInfoContainer: SimpleTranslationEntries = {
   "gender": "Género:",
   "ability": "Habilid:",
   "nature": "Natur:",
-  "epic": "Épico",
-  "rare": "Raro",
-  "common": "Común"
 } as const;

--- a/src/locales/fr/common.ts
+++ b/src/locales/fr/common.ts
@@ -2,8 +2,8 @@ import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const common: SimpleTranslationEntries = {
   "start": "Lancer",
-  "luckIndicator": "Luck:",
-  "shinyOnHover": "Shiny",
+  "luckIndicator": "Chance :",
+  "shinyOnHover": "Chromatique",
   "commonShiny": "Commun",
   "rareShiny": "Rare",
   "epicShiny": "Épique",

--- a/src/locales/fr/common.ts
+++ b/src/locales/fr/common.ts
@@ -2,4 +2,9 @@ import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const common: SimpleTranslationEntries = {
   "start": "Lancer",
+  "luckIndicator": "Luck:",
+  "shinyOnHover": "Shiny",
+  "commonShiny": "Commun",
+  "rareShiny": "Rare",
+  "epicShiny": "Épique",
 } as const;

--- a/src/locales/fr/pokemon-info-container.ts
+++ b/src/locales/fr/pokemon-info-container.ts
@@ -5,8 +5,5 @@ export const pokemonInfoContainer: SimpleTranslationEntries = {
   "gender": "Sexe :",
   "ability": "Talent :",
   "nature": "Nature :",
-  "epic": "Épique",
-  "rare": "Rare",
-  "common": "Commun",
   "form": "Forme :"
 } as const;

--- a/src/locales/it/common.ts
+++ b/src/locales/it/common.ts
@@ -2,4 +2,9 @@ import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const common: SimpleTranslationEntries = {
   "start": "Inizia",
+  "luckIndicator": "Luck:",
+  "shinyOnHover": "Shiny",
+  "commonShiny": "Comune",
+  "rareShiny": "Raro",
+  "epicShiny": "Epico",
 } as const;

--- a/src/locales/it/pokemon-info-container.ts
+++ b/src/locales/it/pokemon-info-container.ts
@@ -5,7 +5,4 @@ export const pokemonInfoContainer: SimpleTranslationEntries = {
   "gender": "Genere:",
   "ability": "Abilità:",
   "nature": "Natura:",
-  "epic": "Epico",
-  "rare": "Raro",
-  "common": "Comune"
 } as const;

--- a/src/locales/ko/common.ts
+++ b/src/locales/ko/common.ts
@@ -2,8 +2,8 @@ import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const common: SimpleTranslationEntries = {
   "start": "시작",
-  "luckIndicator": "Luck:",
-  "shinyOnHover": "Shiny",
+  "luckIndicator": "행운:",
+  "shinyOnHover": "색이 다른",
   "commonShiny": "커먼",
   "rareShiny": "레어",
   "epicShiny": "에픽",

--- a/src/locales/ko/common.ts
+++ b/src/locales/ko/common.ts
@@ -2,4 +2,9 @@ import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const common: SimpleTranslationEntries = {
   "start": "시작",
+  "luckIndicator": "Luck:",
+  "shinyOnHover": "Shiny",
+  "commonShiny": "커먼",
+  "rareShiny": "레어",
+  "epicShiny": "에픽",
 } as const;

--- a/src/locales/ko/pokemon-info-container.ts
+++ b/src/locales/ko/pokemon-info-container.ts
@@ -5,8 +5,5 @@ export const pokemonInfoContainer: SimpleTranslationEntries = {
   "gender": "성별:",
   "ability": "특성:",
   "nature": "성격:",
-  "epic": "에픽",
-  "rare": "레어",
-  "common": "커먼",
   "form": "폼:"
 } as const;

--- a/src/locales/pt_BR/common.ts
+++ b/src/locales/pt_BR/common.ts
@@ -3,4 +3,8 @@ import { SimpleTranslationEntries } from "#app/interfaces/locales";
 export const common: SimpleTranslationEntries = {
   "start": "Iniciar",
   "luckIndicator": "Sorte:",
+  "shinyOnHover": "Shiny",
+  "commonShiny": "Comum",
+  "rareShiny": "Raro",
+  "epicShiny": "Épico",
 } as const;

--- a/src/locales/pt_BR/common.ts
+++ b/src/locales/pt_BR/common.ts
@@ -2,4 +2,5 @@ import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const common: SimpleTranslationEntries = {
   "start": "Iniciar",
+  "luckIndicator": "Sorte:",
 } as const;

--- a/src/locales/pt_BR/pokemon-info-container.ts
+++ b/src/locales/pt_BR/pokemon-info-container.ts
@@ -5,7 +5,5 @@ export const pokemonInfoContainer: SimpleTranslationEntries = {
   "gender": "Gênero:",
   "ability": "Habilidade:",
   "nature": "Natureza:",
-  "epic": "Épico",
-  "rare": "Raro",
-  "common": "Comum",
+  "form": "Forma:",
 } as const;

--- a/src/locales/zh_CN/common.ts
+++ b/src/locales/zh_CN/common.ts
@@ -2,4 +2,9 @@ import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const common: SimpleTranslationEntries = {
   "start": "开始",
+  "luckIndicator": "Luck:",
+  "shinyOnHover": "Shiny",
+  "commonShiny": "常见",
+  "rareShiny": "稀有",
+  "epicShiny": "史诗",
 } as const;

--- a/src/locales/zh_CN/common.ts
+++ b/src/locales/zh_CN/common.ts
@@ -2,8 +2,8 @@ import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const common: SimpleTranslationEntries = {
   "start": "开始",
-  "luckIndicator": "Luck:",
-  "shinyOnHover": "Shiny",
+  "luckIndicator": "幸运：",
+  "shinyOnHover": "闪光",
   "commonShiny": "常见",
   "rareShiny": "稀有",
   "epicShiny": "史诗",

--- a/src/locales/zh_CN/pokemon-info-container.ts
+++ b/src/locales/zh_CN/pokemon-info-container.ts
@@ -5,7 +5,4 @@ export const pokemonInfoContainer: SimpleTranslationEntries = {
   "gender": "性别:",
   "ability": "特性:",
   "nature": "性格:",
-  "epic": "史诗",
-  "rare": "稀有",
-  "common": "常见"
 } as const;

--- a/src/locales/zh_TW/common.ts
+++ b/src/locales/zh_TW/common.ts
@@ -2,4 +2,9 @@ import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const common: SimpleTranslationEntries = {
   "start": "開始",
+  "luckIndicator": "Luck:",
+  "shinyOnHover": "Shiny",
+  "commonShiny": "常見",
+  "rareShiny": "稀有",
+  "epicShiny": "史詩",
 } as const;

--- a/src/locales/zh_TW/pokemon-info-container.ts
+++ b/src/locales/zh_TW/pokemon-info-container.ts
@@ -5,7 +5,4 @@ export const pokemonInfoContainer: SimpleTranslationEntries = {
   "gender": "性别:",
   "ability": "特性:",
   "nature": "性格:",
-  "epic": "史詩",
-  "rare": "稀有",
-  "common": "常見"
 } as const;

--- a/src/ui/battle-info.ts
+++ b/src/ui/battle-info.ts
@@ -10,6 +10,7 @@ import { getVariantTint } from "#app/data/variant";
 import { BattleStat } from "#app/data/battle-stat";
 import BattleFlyout from "./battle-flyout";
 import { WindowVariant, addWindow } from "./ui-theme";
+import i18next from "i18next";
 
 const battleStatOrder = [ BattleStat.ATK, BattleStat.DEF, BattleStat.SPATK, BattleStat.SPDEF, BattleStat.ACC, BattleStat.EVA, BattleStat.SPD ];
 
@@ -315,9 +316,9 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
     this.shinyIcon.setTint(getVariantTint(baseVariant));
     if (this.shinyIcon.visible) {
       const shinyDescriptor = doubleShiny || baseVariant ?
-        `${baseVariant === 2 ? "Epic" : baseVariant === 1 ? "Rare" : "Common"}${doubleShiny ? `/${pokemon.fusionVariant === 2 ? "Epic" : pokemon.fusionVariant === 1 ? "Rare" : "Common"}` : ""}`
+        `${baseVariant === 2 ? i18next.t("common:epicShiny") : baseVariant === 1 ? i18next.t("common:rareShiny") : i18next.t("common:commonShiny")}${doubleShiny ? `/${pokemon.fusionVariant === 2 ? i18next.t("common:epicShiny") : pokemon.fusionVariant === 1 ? i18next.t("common:rareShiny") : i18next.t("common:commonShiny")}` : ""}`
         : "";
-      this.shinyIcon.on("pointerover", () => (this.scene as BattleScene).ui.showTooltip(null, `Shiny${shinyDescriptor ? ` (${shinyDescriptor})` : ""}`));
+      this.shinyIcon.on("pointerover", () => (this.scene as BattleScene).ui.showTooltip(null, `${i18next.t("common:shinyOnHover")}${shinyDescriptor ? ` (${shinyDescriptor})` : ""}`));
       this.shinyIcon.on("pointerout", () => (this.scene as BattleScene).ui.hideTooltip());
     }
 

--- a/src/ui/pokemon-info-container.ts
+++ b/src/ui/pokemon-info-container.ts
@@ -300,9 +300,9 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
       this.pokemonShinyIcon.setTint(getVariantTint(baseVariant));
       if (this.pokemonShinyIcon.visible) {
         const shinyDescriptor = doubleShiny || baseVariant ?
-          `${baseVariant === 2 ? i18next.t("pokemonInfoContainer:epic") : baseVariant === 1 ? i18next.t("pokemonInfoContainer:rare") : i18next.t("pokemonInfoContainer:common")}${doubleShiny ? `/${pokemon.fusionVariant === 2 ? i18next.t("pokemonInfoContainer:epic") : pokemon.fusionVariant === 1 ? i18next.t("pokemonInfoContainer:rare") : i18next.t("pokemonInfoContainer:common")}` : ""}`
+          `${baseVariant === 2 ? i18next.t("common:epicShiny") : baseVariant === 1 ? i18next.t("common:rareShiny") : i18next.t("common:commonShiny")}${doubleShiny ? `/${pokemon.fusionVariant === 2 ? i18next.t("common:epicShiny") : pokemon.fusionVariant === 1 ? i18next.t("common:rareShiny") : i18next.t("common:commonShiny")}` : ""}`
           : "";
-        this.pokemonShinyIcon.on("pointerover", () => (this.scene as BattleScene).ui.showTooltip(null, `Shiny${shinyDescriptor ? ` (${shinyDescriptor})` : ""}`, true));
+        this.pokemonShinyIcon.on("pointerover", () => (this.scene as BattleScene).ui.showTooltip(null, `${i18next.t("common:shinyOnHover")}${shinyDescriptor ? ` (${shinyDescriptor})` : ""}`, true));
         this.pokemonShinyIcon.on("pointerout", () => (this.scene as BattleScene).ui.hideTooltip());
 
         const newShiny = BigInt(Math.pow(2, (pokemon.shiny ? 1 : 0)));

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -565,7 +565,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.type2Icon.setOrigin(0, 0);
     this.starterSelectContainer.add(this.type2Icon);
 
-    this.pokemonLuckLabelText = addTextObject(this.scene, 8, 89, "Luck:", TextStyle.WINDOW_ALT, { fontSize: "56px" });
+    this.pokemonLuckLabelText = addTextObject(this.scene, 8, 89, i18next.t("common:luckIndicator"), TextStyle.WINDOW_ALT, { fontSize: "56px" });
     this.pokemonLuckLabelText.setOrigin(0, 0);
     this.starterSelectContainer.add(this.pokemonLuckLabelText);
 

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -345,9 +345,9 @@ export default class SummaryUiHandler extends UiHandler {
     this.shinyIcon.setTint(getVariantTint(baseVariant));
     if (this.shinyIcon.visible) {
       const shinyDescriptor = doubleShiny || baseVariant ?
-        `${baseVariant === 2 ? "Epic" : baseVariant === 1 ? "Rare" : "Common"}${doubleShiny ? `/${this.pokemon.fusionVariant === 2 ? "Epic" : this.pokemon.fusionVariant === 1 ? "Rare" : "Common"}` : ""}`
+        `${baseVariant === 2 ? i18next.t("common:epicShiny") : baseVariant === 1 ? i18next.t("common:rareShiny") : i18next.t("common:commonShiny")}${doubleShiny ? `/${this.pokemon.fusionVariant === 2 ? i18next.t("common:epicShiny") : this.pokemon.fusionVariant === 1 ? i18next.t("common:rareShiny") : i18next.t("common:commonShiny")}` : ""}`
         : "";
-      this.shinyIcon.on("pointerover", () => (this.scene as BattleScene).ui.showTooltip(null, `Shiny${shinyDescriptor ? ` (${shinyDescriptor})` : ""}`, true));
+      this.shinyIcon.on("pointerover", () => (this.scene as BattleScene).ui.showTooltip(null, `${i18next.t("common:shinyOnHover")}${shinyDescriptor ? ` (${shinyDescriptor})` : ""}`, true));
       this.shinyIcon.on("pointerout", () => (this.scene as BattleScene).ui.hideTooltip());
     }
 

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -717,7 +717,7 @@ export default class SummaryUiHandler extends UiHandler {
       }
 
       if (this.pokemon.getLuck()) {
-        const luckLabelText = addTextObject(this.scene, 141, 28, "Luck:", TextStyle.SUMMARY_ALT);
+        const luckLabelText = addTextObject(this.scene, 141, 28, i18next.t("common:luckIndicator"), TextStyle.SUMMARY_ALT);
         luckLabelText.setOrigin(0, 0);
         profileContainer.add(luckLabelText);
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Localization of the luck text and the shiny text that appears OnHover

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
They weren't localized

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
There was only an existing localization in the pokemon-info-container for the shiny rarities, so I revamped it.
Added entries for each word and, since the shiny and luck texts were used in 3 different files each, I added them to the `common` locale folder.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
## Luck (Starter Menu)
![image](https://github.com/pagefaultgames/pokerogue/assets/79599290/8c014976-eabc-4068-9bac-94bf6e7e6cb0)

## Luck (Shop)
![image](https://github.com/pagefaultgames/pokerogue/assets/79599290/6fba04c5-b92e-40c6-b798-c42f277b286d)

## Shiny (Battle)
![image](https://github.com/pagefaultgames/pokerogue/assets/79599290/b30fc5f1-6fd9-4ddd-82b7-065836e8d8ca)

## Shiny (Pokémon Info Container)
![image](https://github.com/pagefaultgames/pokerogue/assets/79599290/9bfa53d2-6b68-4245-97fe-ab2259a8fb69)

## Luck and Shiny (Summary)
![image](https://github.com/pagefaultgames/pokerogue/assets/79599290/dc98b6cc-066a-4149-bc5e-8a3cc796129f)

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Check every screen that the text appears.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?