### PR TITLE
[Bug] Remove more RNG from Dry Skin tests

### DIFF
--- a/src/test/abilities/dry_skin.test.ts
+++ b/src/test/abilities/dry_skin.test.ts
@@ -6,6 +6,7 @@ import { TurnEndPhase } from "#app/phases";
 import { Moves } from "#enums/moves";
 import { getMovePosition } from "#app/test/utils/gameManagerUtils";
 import { Abilities } from "#enums/abilities";
+import { Species } from "#app/enums/species.js";
 
 describe("Abilities - Dry Skin", () => {
   let phaserGame: Phaser.Game;
@@ -26,7 +27,9 @@ describe("Abilities - Dry Skin", () => {
     vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
     vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.DRY_SKIN);
     vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.SPLASH, Moves.SPLASH, Moves.SPLASH]);
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.CHARMANDER);
     vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.BALL_FETCH);
+    vi.spyOn(overrides, "STARTER_SPECIES_OVERRIDE", "get").mockReturnValue(Species.CHANDELURE);
   });
 
   it("during sunlight, lose 1/8 of maximum health at the end of each turn", async () => {
@@ -85,6 +88,7 @@ describe("Abilities - Dry Skin", () => {
     expect(enemy).not.toBe(undefined);
 
     // first turn
+    vi.spyOn(game.scene, "randBattleSeedInt").mockReturnValue(0); // this makes moves always deal 85% damage
     game.doAttack(getMovePosition(game.scene, 0, Moves.EMBER));
     await game.phaseInterceptor.to(TurnEndPhase);
     const fireDamageTakenWithDrySkin = enemy.getMaxHp() - enemy.hp;


### PR DESCRIPTION
## What are the changes?
More instances of potential randomness were removed from the Dry Skin tests.

## Why am I doing these changes?
Further potential for RNG to cause the test to fail was pointed out in Discord.

## What did change?
The player and opponent Pokémon are now manually set, and the random damage roll (normally 85%-100%) is now always the same in the test that checks damage. Also, the opponent was set to a fire-type Pokémon to prevent the Burn status from interfering.

## How to test the changes?
`npm run test:silent dry_skin`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?