### PR TITLE
[Bug] Fix multi-hit early stopping on spread moves

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -900,8 +900,7 @@ export class ProtectedTag extends BattlerTag {
       // Stop multi-hit moves early
       const effectPhase = pokemon.scene.getCurrentPhase();
       if (effectPhase instanceof MoveEffectPhase) {
-        const attacker = effectPhase.getPokemon();
-        attacker.stopMultiHit();
+        effectPhase.stopMultiHit(pokemon);
       }
       return true;
     }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1800,7 +1800,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       }
 
       if (cancelled.value) {
-        source.stopMultiHit();
+        source.stopMultiHit(this);
         result = HitResult.NO_EFFECT;
       } else {
         const typeBoost = source.findTag(t => t instanceof TypeBoostTag && t.boostedType === move.type) as TypeBoostTag;
@@ -2261,15 +2261,14 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * If this Pokemon is using a multi-hit move, stop the move
-   * after the next hit resolves.
+   * If this Pokemon is using a multi-hit move, cancels all subsequent strikes
+   * @param {Pokemon} target If specified, this only cancels subsequent strikes against this Pokemon
    */
-  stopMultiHit(): void {
-    if (!this.turnData) {
-      return;
+  stopMultiHit(target?: Pokemon): void {
+    const effectPhase = this.scene.getCurrentPhase();
+    if (effectPhase instanceof MoveEffectPhase) {
+      effectPhase.stopMultiHit(target);
     }
-    this.turnData.hitCount = 1;
-    this.turnData.hitsLeft = 1;
   }
 
   changeForm(formChange: SpeciesFormChange): Promise<void> {


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This fixes a bug where a spread move (e.g. Earthquake) from a source holding Multi-Lens only strikes each target once if one of those targets is protected or has an ability that nullifies damage.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
This bug was reported in the Discord. You can see Discharge incorrectly stopping in the video below

https://github.com/pagefaultgames/pokerogue/assets/168692175/351fee92-c861-45af-a32a-1654a8437415

The user also provided beautiful artwork of the move's current behavior:

![image](https://github.com/pagefaultgames/pokerogue/assets/168692175/a87bbbec-b941-4ea4-8a9f-e7b4c2dd06fd)
![image](https://github.com/pagefaultgames/pokerogue/assets/168692175/d306f9e2-01ee-44f3-8c87-4a79696bdf41)


## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
`Pokemon.stopMultiHit()` now has an optional `target` parameter. If `target` is specified, the target is removed from the `targets` list in `MoveEffectPhase` for future strikes of the move.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
The video below shows Earthquake hitting the opponents multiple times despite the user's ally using Protect in the same turn.

https://github.com/pagefaultgames/pokerogue/assets/168692175/a8a6b9ee-142d-46c2-96a8-bf1b28ddaaf8


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
To test via `overrides.ts`:
- Force double battles.
- Give player pokemon a spread move (e.g. `Moves.EARTHQUAKE`) and `Moves.PROTECT`)
- Add `{name: "MULTI_LENS"} to the starting held item override array
- In battle, make the Pokemon with Multi-Lens use the spread move, and have the other Pokemon use Protect. The spread move should hit the enemies twice and hit into your ally's Protect once.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?