### PR TITLE
[Bug} Fix Tidy Up buff

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6830,6 +6830,7 @@ export function initMoves() {
       .attr(ClearTerrainAttr)
       .attr(RemoveScreensAttr, false)
       .attr(RemoveArenaTrapAttr, true),
+
     new StatusMove(Moves.TRICK_ROOM, Type.PSYCHIC, -1, 5, -1, -7, 4)
       .attr(AddArenaTagAttr, ArenaTagType.TRICK_ROOM, 5)
       .ignoresProtect()

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6830,7 +6830,6 @@ export function initMoves() {
       .attr(ClearTerrainAttr)
       .attr(RemoveScreensAttr, false)
       .attr(RemoveArenaTrapAttr, true),
-
     new StatusMove(Moves.TRICK_ROOM, Type.PSYCHIC, -1, 5, -1, -7, 4)
       .attr(AddArenaTagAttr, ArenaTagType.TRICK_ROOM, 5)
       .ignoresProtect()

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -8280,8 +8280,7 @@ export function initMoves() {
       .target(MoveTarget.BOTH_SIDES),
     new SelfStatusMove(Moves.TIDY_UP, Type.NORMAL, -1, 10, -1, 0, 9)
       .attr(StatChangeAttr, [ BattleStat.ATK, BattleStat.SPD ], 1, true, null, true, true)
-      .attr(RemoveArenaTrapAttr)
-      .target(MoveTarget.BOTH_SIDES),
+      .attr(RemoveArenaTrapAttr, true),
     new StatusMove(Moves.SNOWSCAPE, Type.ICE, -1, 10, -1, 0, 9)
       .attr(WeatherChangeAttr, WeatherType.SNOW)
       .target(MoveTarget.BOTH_SIDES),


### PR DESCRIPTION
## What are the changes?
1. Fixes Tidy Up buff to only go up 1 stage as intended.

## Why am I doing these changes?
1. Fixes: https://github.com/pagefaultgames/pokerogue/issues/2629

## What did change?
1. Changes the both sides targeting so that the calculation didn't run twice.

## How to test the changes?
overrides.ts: ```export const MOVESET_OVERRIDE: Array<Moves> = [Moves.TIDY_UP];```

## Checklist
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?