### PR TITLE
[BUG] Fix Tidy-Up boosting stats multiple times right now

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -8279,7 +8279,7 @@ export function initMoves() {
       .attr(ForceSwitchOutAttr, true, false)
       .target(MoveTarget.BOTH_SIDES),
     new SelfStatusMove(Moves.TIDY_UP, Type.NORMAL, -1, 10, -1, 0, 9)
-      .attr(StatChangeAttr, [ BattleStat.ATK, BattleStat.SPD ], 1, true, null, true, true)
+      .attr(StatChangeAttr, [ BattleStat.ATK, BattleStat.SPD ], 1, true, ({ id }, target) => id === target.id, true, true)
       .attr(RemoveArenaTrapAttr)
       .target(MoveTarget.BOTH_SIDES),
     new StatusMove(Moves.SNOWSCAPE, Type.ICE, -1, 10, -1, 0, 9)


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->

Tidy up is broken right now.
This should close #2629.
Eventually close #2649 since either of these PRs are a duplicate

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

Tidy up is being applied to both sides due to the arena-trap clearing but it's also boosting the stats more times then necessary making it extremely strong right now

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

I've added a condition to the `StatusChangeAttr` to only apply when `user.id === target.id` (since the target is the enemy pkm on the second apply)

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->


https://github.com/pagefaultgames/pokerogue/assets/50131232/af54beb5-83fe-4267-ab82-2e93d809b3d1



## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

### Overrides Used

```ts
export const MOVESET_OVERRIDE: Array<Moves> = [ Moves.STEALTH_ROCK, Moves.TOXIC_SPIKES, Moves.DRAGON_DANCE, Moves.TIDY_UP ];
```
```ts
export const OPP_SPECIES_OVERRIDE: Species | integer = Species.MAGIKARP;
```
```ts
export const OPP_MOVESET_OVERRIDE: Array<Moves> = [Moves.STEALTH_ROCK, Moves.TOXIC_SPIKES, Moves.SPIKES];
```

- Start a new game
- Set up some arena traps (enemy should be doing the same)
- Press `V` to check the traps
- Use `Tidy Up`
- All arena traps should be cleared and the stats should be +1 ATK +1 SPD
- Use `Tidy Up` again
- +2 ATK +2 SPD 
- and so on

no more +6 ATK +6 SPD on the 2nd use already (hopefully)

## Checklist
- [ ] There is no overlap with another PR?
   -  There is #2649. But it's the wrong approach unfortunately
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- ~~[ ] Are the changes visual?~~
  - [X] Have I provided screenshots/videos of the changes?