### PR TITLE
[Bug] Fix Parental Bond multiplier sometimes applying during first strike

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -1300,7 +1300,7 @@ export class AddSecondStrikeAbAttr extends PreAttackAbAttr {
         hitCount.value *= 2;
       }
 
-      if (!!multiplier?.value && pokemon.turnData.hitsLeft % 2 === 1) {
+      if (!!multiplier?.value && pokemon.turnData.hitsLeft % 2 === 1 && pokemon.turnData.hitsLeft !== pokemon.turnData.hitCount) {
         multiplier.value *= this.damageMultiplier;
       }
       return true;


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This fixes a bug where if a Pokemon with Parental Bond uses a spread move (e.g. Dragon Energy), and it KO's the first opponent it hits, Parental Bond will apply a 0.25x damage multiplier when it hits the next opponent.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
This bug was reported in the Discord: https://discord.com/channels/1125469663833370665/1255747592348766420

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
`data/ability`: Parental Bond can no longer apply its damage multiplier on the first hit of a move.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
N/A

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
`npm run test parental_bond`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [n/a] Are the changes visual?
  - [n/a] Have I provided screenshots/videos of the changes?