### PR TITLE
[Bug] More non-contacting physical moves

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -8016,6 +8016,7 @@ export function initMoves() {
     new AttackMove(Moves.MYSTICAL_POWER, Type.PSYCHIC, MoveCategory.SPECIAL, 70, 90, 10, 100, 0, 8)
       .attr(StatChangeAttr, BattleStat.SPATK, 1, true),
     new AttackMove(Moves.RAGING_FURY, Type.FIRE, MoveCategory.PHYSICAL, 120, 100, 10, -1, 0, 8)
+      .makesContact(false)
       .attr(FrenzyAttr)
       .attr(MissEffectAttr, frenzyMissFunc)
       .target(MoveTarget.RANDOM_NEAR_ENEMY),
@@ -8034,6 +8035,7 @@ export function initMoves() {
       .attr(StatChangeAttr, [ BattleStat.DEF, BattleStat.SPDEF ], -1, true)
       .punchingMove(),
     new AttackMove(Moves.BARB_BARRAGE, Type.POISON, MoveCategory.PHYSICAL, 60, 100, 10, 50, 0, 8)
+      .makesContact(false)
       .attr(MovePowerMultiplierAttr, (user, target, move) => target.status && (target.status.effect === StatusEffect.POISON || target.status.effect === StatusEffect.TOXIC) ? 2 : 1)
       .attr(StatusEffectAttr, StatusEffect.POISON),
     new AttackMove(Moves.ESPER_WING, Type.PSYCHIC, MoveCategory.SPECIAL, 80, 100, 10, 100, 0, 8)
@@ -8044,6 +8046,7 @@ export function initMoves() {
     new SelfStatusMove(Moves.SHELTER, Type.STEEL, -1, 10, 100, 0, 8)
       .attr(StatChangeAttr, BattleStat.DEF, 2, true),
     new AttackMove(Moves.TRIPLE_ARROWS, Type.FIGHTING, MoveCategory.PHYSICAL, 90, 100, 10, 30, 0, 8)
+      .makesContact(false)
       .attr(HighCritAttr)
       .attr(StatChangeAttr, BattleStat.DEF, -1)
       .attr(FlinchAttr)


### PR DESCRIPTION
## What are the changes?
Fixes Raging Fury, Barb Barrage, and Triple Arrows, three moves that were making contact when they shouldn't have been making contact.

## Why am I doing these changes?
The moves making contact constituted unexpected behaviour, as events that trigger upon contact would, including Abilities, when they shouldn't have.

## What did change?
The `makesContact` attribute was used to tell the game that those moves do not make contact, despite being Physical Moves.

## How to test the changes?
Overrides can help, by giving Pokemon these Moves, and the target Pokemon an Ability like Iron Barbs.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
    - [x] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?