### PR TITLE
[Bug] Fix Make It Rain not applying effect on KO

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5513,11 +5513,21 @@ const userSleptOrComatoseCondition: MoveConditionFunc = (user: Pokemon, target: 
 
 const targetSleptOrComatoseCondition: MoveConditionFunc = (user: Pokemon, target: Pokemon, move: Move) =>  target.status?.effect === StatusEffect.SLEEP || target.hasAbility(Abilities.COMATOSE);
 
+/**
+ * Condition to apply effects only upon applying the move to its last target.
+ * Currently only used for Make It Rain.
+ * @param {Pokemon} user The user of the move.
+ * @param {Pokemon} target The current target of the move.
+ * @param {Move} move The move to which this condition applies.
+ * @returns true if the target is the last target to which the move applies.
+ */
 const lastTargetOnlyCondition: MoveConditionFunc = (user: Pokemon, target: Pokemon, move: Move) => {
   const effectPhase = user.scene.getCurrentPhase();
+  const targetIndex = target.getFieldIndex() + (target.isPlayer() ? 0 : BattlerIndex.ENEMY);
 
   if (effectPhase instanceof MoveEffectPhase) {
-    return target === effectPhase.getTargets().at(-1);
+    const activeTargets = effectPhase.getTargets();
+    return (activeTargets.length === 0 || targetIndex >= activeTargets.at(-1).getBattlerIndex());
   }
   return false;
 };

--- a/src/test/moves/make_it_rain.test.ts
+++ b/src/test/moves/make_it_rain.test.ts
@@ -6,6 +6,7 @@ import { Species } from "#enums/species";
 import {
   CommandPhase,
   MoveEndPhase,
+  StatChangePhase,
 } from "#app/phases";
 import { Moves } from "#enums/moves";
 import { getMovePosition } from "#app/test/utils/gameManagerUtils";
@@ -56,5 +57,26 @@ describe("Moves - Make It Rain", () => {
     await game.phaseInterceptor.to(MoveEndPhase);
 
     expect(playerPokemon[0].summonData.battleStats[BattleStat.SPATK]).toBe(-1);
+  });
+
+  it("should apply effects even if the target faints", async () => {
+    vi.spyOn(overrides, "OPP_LEVEL_OVERRIDE", "get").mockReturnValue(1); // ensures the enemy will faint
+    vi.spyOn(overrides, "DOUBLE_BATTLE_OVERRIDE", "get").mockReturnValue(false);
+    vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+
+    await game.startBattle([Species.CHARIZARD]);
+
+    const playerPokemon = game.scene.getPlayerPokemon();
+    expect(playerPokemon).toBeDefined();
+
+    const enemyPokemon = game.scene.getEnemyPokemon();
+    expect(enemyPokemon).toBeDefined();
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.MAKE_IT_RAIN));
+
+    await game.phaseInterceptor.to(StatChangePhase);
+
+    expect(enemyPokemon.isFainted()).toBe(true);
+    expect(playerPokemon.summonData.battleStats[BattleStat.SPATK]).toBe(-1);
   });
 });


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This fixes a bug where if Make It Rain KO's the last of the Pokemon it targets, it will not reduce the user's Sp. Atk. for that hit.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Make It Rain is still bugged after earlier fixes (#2664 ) :(

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- `data/move`: The `lastTargetOnlyCondition` used by Make It Rain now accounts for the target fainting from the move's current strike.
- `test/moves/make_it_rain.test`: New test case checking effects for when the target faints.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
n/a

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
`npm run test make_it_rain`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [n/a] Are the changes visual?
  - [n/a] Have I provided screenshots/videos of the changes?