### PR TITLE
[Bug] Fix Boss segments for double-battles (in endless?)

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3398,12 +3398,14 @@ export class EnemyPokemon extends Pokemon {
   public aiType: AiType;
   public bossSegments: integer;
   public bossSegmentIndex: integer;
+  public readonly isPopulatedFromDataSource: boolean;
 
   constructor(scene: BattleScene, species: PokemonSpecies, level: integer, trainerSlot: TrainerSlot, boss: boolean, dataSource: PokemonData) {
     super(scene, 236, 84, species, level, dataSource?.abilityIndex, dataSource?.formIndex,
       dataSource?.gender, dataSource ? dataSource.shiny : false, dataSource ? dataSource.variant : undefined, null, dataSource ? dataSource.nature : undefined, dataSource);
 
     this.trainerSlot = trainerSlot;
+    this.isPopulatedFromDataSource = !!dataSource;
     if (boss) {
       this.setBoss(boss, dataSource?.bossSegments);
     }

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -870,7 +870,7 @@ export class EncounterPhase extends BattlePhase {
     } else {
       if (battle.enemyParty.filter(p => p.isBoss()).length > 1) {
         for (const enemyPokemon of battle.enemyParty) {
-          if (enemyPokemon.isBoss()) {
+          if (enemyPokemon.isBoss() && !enemyPokemon.isPopulatedFromDataSource) {
             enemyPokemon.setBoss(true, Math.ceil(enemyPokemon.bossSegments * (enemyPokemon.getSpeciesForm().baseTotal / totalBst)));
             enemyPokemon.initBattleInfo();
           }


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->

fix boss segments not being overwritten by some code when loading a session that is a double battle.
closes #2668

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

Right now when you reload in a double battle the boss segments are reduced after loading back in

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

remove some odd logic changing the segments on load even though there is a persisted value

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->


https://github.com/pagefaultgames/pokerogue/assets/50131232/0998761e-9cf8-43bc-93a2-1701e8614629


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

1. import [this](https://cdn.discordapp.com/attachments/1256001530033606772/1256023015234207825/2668_debug-session-data.prsv?ex=667f4216&is=667df096&hm=78631e8d6b25619b83b67acca221425ef85667d33531fb5533864c095862b73e&) session data into a slot
2. Move 1 wave ahead by defeating the previous one
3. Count the boss segments
4. `Esc` and Save & Quit.
5. Load the same session
6. Count the boss segments -> should be the same
7. reload page
8. load the same session
9. Count the boss segments -> should be the same

## Checklist
- [X] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?