### PR TITLE
[Fix] Prevent berries from interfering with Dry Skin tests

### DIFF
--- a/src/test/abilities/dry_skin.test.ts
+++ b/src/test/abilities/dry_skin.test.ts
@@ -28,7 +28,7 @@ describe("Abilities - Dry Skin", () => {
     vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.DRY_SKIN);
     vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.SPLASH, Moves.SPLASH, Moves.SPLASH]);
     vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.CHARMANDER);
-    vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.BALL_FETCH);
+    vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.UNNERVE);
     vi.spyOn(overrides, "STARTER_SPECIES_OVERRIDE", "get").mockReturnValue(Species.CHANDELURE);
   });
 


### PR DESCRIPTION
## What are the changes?
The Dry Skin test is modified to disable opponents' berries.

## Why am I doing these changes?

![image](https://github.com/pagefaultgames/pokerogue/assets/34855794/31347aaf-796a-4073-b891-73f5cf7f2a77)
![image](https://github.com/pagefaultgames/pokerogue/assets/34855794/2b54513e-a31c-4e68-9eac-a207cf1ef658)


## What did change?
The player Pokémon's ability is set to Unnerve to prevent opponents' randomly spawned berries from activating.

## How to test the changes?
`npm run test dry_skin`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?