### PR TITLE
[Sprite] Implement female Pyroar icon

### DIFF
--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -319,6 +319,7 @@ export abstract class PokemonSpeciesForm {
     case Species.UNFEZANT:
     case Species.FRILLISH:
     case Species.JELLICENT:
+    case Species.PYROAR:
       ret += female ? "-f" : "";
       break;
     }


### PR DESCRIPTION
## What are the changes?
Pyroar's hair differs based on gender, similarly to lions in real life. As a result, their icons now reflects this difference.

## Why am I doing these changes?
![image](https://github.com/pagefaultgames/pokerogue/assets/31082757/0432f332-c50b-4c35-88b6-545b75112789)

## What did change?
Pyroar was added to the list of Pokemon where a female-form icon should be used when the Pokemon is female.

### Screenshots/Videos
#### Before
![image](https://github.com/pagefaultgames/pokerogue/assets/31082757/9248ee73-74f4-45cb-9156-a8509e29e5e0)
#### After
![image](https://github.com/pagefaultgames/pokerogue/assets/31082757/790abd5e-34db-4423-aad5-00dc64af1575)

## How to test the changes?
Overrides can be used to generate a Pyroar, as well as give them a held item.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?