### PR TITLE
[Bug] Fix mocked value in Volt Absorb test

### DIFF
--- a/src/test/abilities/volt_absorb.test.ts
+++ b/src/test/abilities/volt_absorb.test.ts
@@ -41,7 +41,7 @@ describe("Abilities - Volt Absorb", () => {
     vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(ability);
     vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.NONE, Moves.NONE, Moves.NONE]);
     vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.DUSKULL);
-    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.NONE);
+    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.BALL_FETCH);
 
     await game.startBattle();
 


### PR DESCRIPTION
## What are the changes?
A mocked value in the Volt Absorb test is fixed so that it properly applies.

## Why am I doing these changes?
The hidden ability of Duskull can rarely be rolled and randomly interfere with the test.

## What did change?
The opponent's mocked ability is set to Ball Fetch. The previous value of "None" was equivalent to not setting a mocked ability at all, so the Pokémon's normal abilities would be used instead, causing interference when the hidden ability of Frisk was randomly rolled.

## How to test the changes?
`npm test volt_absorb`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?