### PR TITLE
[QoL] Auto center the window vertically

### DIFF
--- a/index.css
+++ b/index.css
@@ -26,10 +26,36 @@ body {
 #app {
   display: flex;
   justify-content: center;
+  align-items: center;
 }
 
 #app > div:first-child {
-  transform-origin: top !important;
+  transform-origin: center !important;
+}
+
+/*
+  Supports automatic vertical centering as suggested in PR#1114, but only via CSS
+
+  Condition factorized to deduce CSS rules:
+  true if (isLandscape && !isMobile() && !hasTouchscreen() || (hasTouchscreen() && !isTouchControlsEnabled))
+*/
+
+/* isLandscape && !isMobile() && !hasTouchscreen() */
+@media (orientation: landscape) and (pointer: fine) {
+  #app {
+    align-items: center;
+  }
+}
+
+@media (pointer: coarse) {
+  /* hasTouchscreen() && !isTouchControlsEnabled */
+  body:has(> #touchControls[class=visible]) #app {
+    align-items: start;
+  }
+
+  body:has(> #touchControls[class=visible]) #app > div:first-child {
+    transform-origin: top !important;
+  }
 }
 
 #layout:fullscreen #dpad, #layout:fullscreen {


### PR DESCRIPTION
## What are the changes?
Auto center the window vertically when the game is played in landscape format or in portrait format when touch controls are not displayed

## Why am I doing these changes?
It was a request, and an old PR closed in advance in favor of this one (See #1114) (cc @torranx)

## What did change?
CSS modification to achieve alignment without having to tweak any config in the game code directly

### Screenshots/Videos
> Before
![2024-06-28_19-19](https://github.com/pagefaultgames/pokerogue/assets/8146474/25504434-f001-44fe-9663-24b33a7ebe6d)
![2024-06-28_19-19_1](https://github.com/pagefaultgames/pokerogue/assets/8146474/a22d68e7-4b51-437b-8263-f730873880c8)

> After
![2024-06-28_19-15](https://github.com/pagefaultgames/pokerogue/assets/8146474/1f5a60ef-1c55-401c-b8fe-5345c5490ea2)
![2024-06-28_19-16](https://github.com/pagefaultgames/pokerogue/assets/8146474/c29cf1d6-d676-4512-bee3-38519892a30f)

![centered-vertical](https://github.com/pagefaultgames/pokerogue/assets/8146474/00a31a49-6cfb-4f61-8a8d-b40b6e866d80)

## How to test the changes?
Launch from a mobile or using an adaptive browser view

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?