### PR TITLE
[move] Fix purify implementation

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -7577,9 +7577,9 @@ export function initMoves() {
     new AttackMove(Moves.SMART_STRIKE, Type.STEEL, MoveCategory.PHYSICAL, 70, -1, 10, -1, 0, 7),
     new StatusMove(Moves.PURIFY, Type.POISON, -1, 20, -1, 0, 7)
       .condition(
-        (user: Pokemon, target: Pokemon, move: Move) => isNonVolatileStatusEffect(user.status?.effect))
+        (user: Pokemon, target: Pokemon, move: Move) => isNonVolatileStatusEffect(target.status?.effect))
       .attr(HealAttr, 0.5)
-      .attr(HealStatusEffectAttr, true, ...getNonVolatileStatusEffects())
+      .attr(HealStatusEffectAttr, false, ...getNonVolatileStatusEffects())
       .triageMove(),
     new AttackMove(Moves.REVELATION_DANCE, Type.NORMAL, MoveCategory.SPECIAL, 90, 100, 15, -1, 0, 7)
       .danceMove()

--- a/src/test/moves/purify.test.ts
+++ b/src/test/moves/purify.test.ts
@@ -1,0 +1,81 @@
+import {afterEach, beforeAll, beforeEach, describe, expect, test, vi} from "vitest";
+import Phaser from "phaser";
+import GameManager from "#app/test/utils/gameManager";
+import * as overrides from "#app/overrides";
+import {
+  MoveEndPhase,
+} from "#app/phases";
+import {getMovePosition} from "#app/test/utils/gameManagerUtils";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { EnemyPokemon, PlayerPokemon } from "#app/field/pokemon.js";
+import { Status, StatusEffect } from "#app/data/status-effect.js";
+
+const TIMEOUT = 20 * 1000;
+
+describe("Moves - Purify", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+
+    vi.spyOn(overrides, "STARTER_SPECIES_OVERRIDE", "get").mockReturnValue(Species.PYUKUMUKU);
+    vi.spyOn(overrides, "STARTING_LEVEL_OVERRIDE", "get").mockReturnValue(10);
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.PURIFY, Moves.SIZZLY_SLIDE]);
+
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.MAGIKARP);
+    vi.spyOn(overrides, "OPP_LEVEL_OVERRIDE", "get").mockReturnValue(10);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.NONE, Moves.NONE, Moves.NONE]);
+  });
+
+  test(
+    "Purify heals opponent status effect and restores user hp",
+    async () => {
+      await game.startBattle();
+
+      const enemyPokemon: EnemyPokemon = game.scene.getEnemyPokemon();
+      const playerPokemon: PlayerPokemon = game.scene.getPlayerPokemon();
+
+      playerPokemon.hp = playerPokemon.getMaxHp() - 1;
+      enemyPokemon.status = new Status(StatusEffect.BURN);
+
+      game.doAttack(getMovePosition(game.scene, 0, Moves.PURIFY));
+      await game.phaseInterceptor.to(MoveEndPhase);
+
+      expect(enemyPokemon.status).toBe(undefined);
+      expect(playerPokemon.hp).toBe(playerPokemon.getMaxHp());
+    },
+    TIMEOUT
+  );
+
+  test(
+    "Purify does not heal if opponent doesnt have any status effect",
+    async () => {
+      await game.startBattle();
+
+      const playerPokemon: PlayerPokemon = game.scene.getPlayerPokemon();
+
+      playerPokemon.hp = playerPokemon.getMaxHp() - 1;
+      const playerInitialHp = playerPokemon.hp;
+
+      game.doAttack(getMovePosition(game.scene, 0, Moves.PURIFY));
+      await game.phaseInterceptor.to(MoveEndPhase);
+
+      expect(playerPokemon.hp).toBe(playerInitialHp);
+    },
+    TIMEOUT
+  );
+
+});


### PR DESCRIPTION
## What are the changes?
Changing purify implementation, to match real behavior ([bulbapedia link](https://bulbapedia.bulbagarden.net/wiki/Purify_(move)))

## Why am I doing these changes?
![image](https://github.com/pagefaultgames/pokerogue/assets/31145813/7911f0fb-f35f-4e88-a65a-dd70464bf865)
## What did change?

Purify implementation. 
- Move depends on the target status and not on the user status.
- Move cures target status not user status

### Screenshots/Videos
 
**Fails when opponent does not have a status**

https://github.com/pagefaultgames/pokerogue/assets/31145813/dedcbbb5-d3a6-4160-8243-47e3c2f6da62

**Works when opponent has a status**

https://github.com/pagefaultgames/pokerogue/assets/31145813/ab3ca94b-b13d-4854-9d14-4ff2bb8b1d4c

**Does not heal user status**

https://github.com/pagefaultgames/pokerogue/assets/31145813/4cf2edc3-ac17-41b1-bf89-c049443d7634


## How to test the changes?

`npm run test purify`

