### PR TITLE
[miscellaneous] Create single variable for max pokeballs

### DIFF
--- a/src/data/pokeball.ts
+++ b/src/data/pokeball.ts
@@ -10,7 +10,7 @@ export enum PokeballType {
   LUXURY_BALL
 }
 
-export const MAX_PER_TYPE_POKEBALL_COUNT: integer = 99;
+export const MAX_PER_TYPE_POKEBALLS: integer = 99;
 
 export function getPokeballAtlasKey(type: PokeballType): string {
   switch (type) {

--- a/src/data/pokeball.ts
+++ b/src/data/pokeball.ts
@@ -10,6 +10,8 @@ export enum PokeballType {
   LUXURY_BALL
 }
 
+export const MAX_PER_TYPE_POKEBALL_COUNT: integer = 99;
+
 export function getPokeballAtlasKey(type: PokeballType): string {
   switch (type) {
   case PokeballType.POKEBALL:

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1,6 +1,6 @@
 import * as Modifiers from "./modifier";
 import { AttackMove, allMoves } from "../data/move";
-import { MAX_PER_TYPE_POKEBALL_COUNT, PokeballType, getPokeballCatchMultiplier, getPokeballName } from "../data/pokeball";
+import { MAX_PER_TYPE_POKEBALLS, PokeballType, getPokeballCatchMultiplier, getPokeballName } from "../data/pokeball";
 import Pokemon, { EnemyPokemon, PlayerPokemon, PokemonMove } from "../field/pokemon";
 import { EvolutionItem, pokemonEvolutions } from "../data/pokemon-evolutions";
 import { Stat, getStatName } from "../data/pokemon-stat";
@@ -1369,7 +1369,7 @@ interface ModifierPool {
  * @returns boolean: true if the player has the maximum of a given ball type
  */
 function hasMaximumBalls(party: Pokemon[], ballType: PokeballType): boolean {
-  return (party[0].scene.gameMode.isClassic && party[0].scene.pokeballCounts[ballType] >= MAX_PER_TYPE_POKEBALL_COUNT);
+  return (party[0].scene.gameMode.isClassic && party[0].scene.pokeballCounts[ballType] >= MAX_PER_TYPE_POKEBALLS);
 }
 
 const modifierPool: ModifierPool = {

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1,6 +1,6 @@
 import * as Modifiers from "./modifier";
 import { AttackMove, allMoves } from "../data/move";
-import { PokeballType, getPokeballCatchMultiplier, getPokeballName } from "../data/pokeball";
+import { MAX_PER_TYPE_POKEBALL_COUNT, PokeballType, getPokeballCatchMultiplier, getPokeballName } from "../data/pokeball";
 import Pokemon, { EnemyPokemon, PlayerPokemon, PokemonMove } from "../field/pokemon";
 import { EvolutionItem, pokemonEvolutions } from "../data/pokemon-evolutions";
 import { Stat, getStatName } from "../data/pokemon-stat";
@@ -1362,8 +1362,6 @@ interface ModifierPool {
   [tier: string]: WeightedModifierType[]
 }
 
-const MAX_BALLS = 99;
-
 /**
  * Used to check if the player has max of a given ball type in Classic
  * @param party The player's party, just used to access the scene
@@ -1371,7 +1369,7 @@ const MAX_BALLS = 99;
  * @returns boolean: true if the player has the maximum of a given ball type
  */
 function hasMaximumBalls(party: Pokemon[], ballType: PokeballType): boolean {
-  return (party[0].scene.gameMode.isClassic && party[0].scene.pokeballCounts[ballType] >= MAX_BALLS);
+  return (party[0].scene.gameMode.isClassic && party[0].scene.pokeballCounts[ballType] >= MAX_PER_TYPE_POKEBALL_COUNT);
 }
 
 const modifierPool: ModifierPool = {

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -2,7 +2,7 @@ import * as ModifierTypes from "./modifier-type";
 import { LearnMovePhase, LevelUpPhase, PokemonHealPhase } from "../phases";
 import BattleScene from "../battle-scene";
 import { getLevelTotalExp } from "../data/exp";
-import { PokeballType } from "../data/pokeball";
+import { MAX_PER_TYPE_POKEBALL_COUNT, PokeballType } from "../data/pokeball";
 import Pokemon, { PlayerPokemon } from "../field/pokemon";
 import { Stat } from "../data/pokemon-stat";
 import { addTextObject, TextStyle } from "../ui/text";
@@ -263,7 +263,7 @@ export class AddPokeballModifier extends ConsumableModifier {
 
   apply(args: any[]): boolean {
     const pokeballCounts = (args[0] as BattleScene).pokeballCounts;
-    pokeballCounts[this.pokeballType] = Math.min(pokeballCounts[this.pokeballType] + this.count, 99);
+    pokeballCounts[this.pokeballType] = Math.min(pokeballCounts[this.pokeballType] + this.count, MAX_PER_TYPE_POKEBALL_COUNT);
 
     return true;
   }

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -2,7 +2,7 @@ import * as ModifierTypes from "./modifier-type";
 import { LearnMovePhase, LevelUpPhase, PokemonHealPhase } from "../phases";
 import BattleScene from "../battle-scene";
 import { getLevelTotalExp } from "../data/exp";
-import { MAX_PER_TYPE_POKEBALL_COUNT, PokeballType } from "../data/pokeball";
+import { MAX_PER_TYPE_POKEBALLS, PokeballType } from "../data/pokeball";
 import Pokemon, { PlayerPokemon } from "../field/pokemon";
 import { Stat } from "../data/pokemon-stat";
 import { addTextObject, TextStyle } from "../ui/text";
@@ -263,7 +263,7 @@ export class AddPokeballModifier extends ConsumableModifier {
 
   apply(args: any[]): boolean {
     const pokeballCounts = (args[0] as BattleScene).pokeballCounts;
-    pokeballCounts[this.pokeballType] = Math.min(pokeballCounts[this.pokeballType] + this.count, MAX_PER_TYPE_POKEBALL_COUNT);
+    pokeballCounts[this.pokeballType] = Math.min(pokeballCounts[this.pokeballType] + this.count, MAX_PER_TYPE_POKEBALLS);
 
     return true;
   }


### PR DESCRIPTION
## What are the changes?
There are two places where we check the user shouldn't have more than 99 pokeballs. 

- The Pokeball modifier that adds 5 Pokeballs to your bag.
- The item roll modifier that checks if player has the max ammount of balls in order to avoid rolling this item

This change just makes both of them to use the same variable.

## Why am I doing these changes?
Avoiding hardcoded constants.

## What did change?
  NA

### Screenshots/Videos
NA

## How to test the changes?
NA