### PR TITLE
[Balance] Allows the user to swap pokemon at the start of a trainer battle

### DIFF
--- a/src/locales/en/party-ui-handler.ts
+++ b/src/locales/en/party-ui-handler.ts
@@ -4,6 +4,7 @@ export const partyUiHandler: SimpleTranslationEntries = {
   "ALL": "All",
   "SEND_OUT": "Send Out",
   "SUMMARY": "Summary",
+  "SWITCH": "Switch",
   "CANCEL": "Cancel",
   "RELEASE": "Release",
   "APPLY": "Apply",

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -416,7 +416,7 @@ export class TitlePhase extends Phase {
         this.scene.pushPhase(new SummonPhase(this.scene, 1, true, true));
       }
 
-      if (this.scene.currentBattle.battleType !== BattleType.TRAINER && (this.scene.currentBattle.waveIndex > 1 || !this.scene.gameMode.isDaily)) {
+      if (this.scene.currentBattle.waveIndex > 1 || !this.scene.gameMode.isDaily) {
         const minPartySize = this.scene.currentBattle.double ? 2 : 1;
         if (availablePartyMembers > minPartySize) {
           this.scene.pushPhase(new CheckSwitchPhase(this.scene, 0, this.scene.currentBattle.double));
@@ -1093,7 +1093,7 @@ export class EncounterPhase extends BattlePhase {
         this.scene.pushPhase(new ToggleDoublePositionPhase(this.scene, false));
       }
 
-      if (this.scene.currentBattle.battleType !== BattleType.TRAINER && (this.scene.currentBattle.waveIndex > 1 || !this.scene.gameMode.isDaily)) {
+      if (this.scene.currentBattle.waveIndex > 1 || !this.scene.gameMode.isDaily) {
         const minPartySize = this.scene.currentBattle.double ? 2 : 1;
         if (availablePartyMembers.length > minPartySize) {
           this.scene.pushPhase(new CheckSwitchPhase(this.scene, 0, this.scene.currentBattle.double));

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -416,7 +416,7 @@ export class TitlePhase extends Phase {
         this.scene.pushPhase(new SummonPhase(this.scene, 1, true, true));
       }
 
-      if (this.scene.currentBattle.waveIndex > 1 || !this.scene.gameMode.isDaily) {
+      if (this.scene.currentBattle.battleType !== BattleType.TRAINER && (this.scene.currentBattle.waveIndex > 1 || !this.scene.gameMode.isDaily)) {
         const minPartySize = this.scene.currentBattle.double ? 2 : 1;
         if (availablePartyMembers > minPartySize) {
           this.scene.pushPhase(new CheckSwitchPhase(this.scene, 0, this.scene.currentBattle.double));
@@ -1093,7 +1093,7 @@ export class EncounterPhase extends BattlePhase {
         this.scene.pushPhase(new ToggleDoublePositionPhase(this.scene, false));
       }
 
-      if (this.scene.currentBattle.waveIndex > 1 || !this.scene.gameMode.isDaily) {
+      if (this.scene.currentBattle.battleType !== BattleType.TRAINER && (this.scene.currentBattle.waveIndex > 1 || !this.scene.gameMode.isDaily)) {
         const minPartySize = this.scene.currentBattle.double ? 2 : 1;
         if (availablePartyMembers.length > minPartySize) {
           this.scene.pushPhase(new CheckSwitchPhase(this.scene, 0, this.scene.currentBattle.double));
@@ -5112,6 +5112,7 @@ export class SelectModifierPhase extends BattlePhase {
           }, PartyUiHandler.FilterItemMaxStacks);
           break;
         case 2:
+          // this defines our check team thing, we need to modify the partyuimode.check
           this.scene.ui.setModeWithoutClear(Mode.PARTY, PartyUiMode.CHECK, -1, () => {
             this.scene.ui.setMode(Mode.MODIFIER_SELECT, this.isPlayer(), typeOptions, modifierSelectCallback, this.getRerollCost(typeOptions, this.scene.lockModifierTiers));
           });

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -382,6 +382,7 @@ export default class SummaryUiHandler extends UiHandler {
     const fromSummary = args.length >= 2;
 
     if (this.pokemon.status || this.pokemon.pokerus) {
+      console.log("haily mary triggered");
       this.showStatus(!fromSummary);
       this.status.setFrame(this.pokemon.status ? StatusEffect[this.pokemon.status.effect].toLowerCase() : "pokerus");
     } else {


### PR DESCRIPTION

## What are the changes?
At the beginning of a pokemon trainer battle, the system will ask the user if they want to switch their current pokemon

## Why am I doing these changes?
Keeps the game consistent, we can do this with other encounters, like WILD and DOUBLE.

## What did change?
Logic change

### Screenshots/Videos
![trainer](https://github.com/pagefaultgames/pokerogue/assets/65863220/687cf57e-1190-4b49-bb51-8f67e5c024d7)
![swap prompt](https://github.com/pagefaultgames/pokerogue/assets/65863220/1b3ae4b2-53c9-4249-8675-8b6937cc463e)

## How to test the changes?

Start a trainer battle and see if you get the prompt to switch your pokemon at the start of the battle 

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?

    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?