### PR TITLE
[Sprite] One more Mimikyu Disguised form tag

### DIFF
--- a/public/images/pokemon_icons_7.json
+++ b/public/images/pokemon_icons_7.json
@@ -5260,7 +5260,7 @@
 					}
 				},
 				{
-					"filename": "778",
+					"filename": "778-disguised",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {
@@ -5281,7 +5281,7 @@
 					}
 				},
 				{
-					"filename": "778s",
+					"filename": "778s-disguised",
 					"rotated": false,
 					"trimmed": true,
 					"sourceSize": {


### PR DESCRIPTION
## What are the changes?
Now that all Mimikyu-disguised form sprites are indicated as such in the game files, they should have been changed here too.

## Why am I doing these changes?
When the game can't find `778-disguised`, since those icons are currently named merely `778`, they default to the first sprite on the icon spritesheet, Melmetal.
![image](https://github.com/pagefaultgames/pokerogue/assets/31082757/9ec3d3b0-ea99-4f9b-88d3-b4431c2b7a89)

## What did change?
Icons previously named `778` are now named `778-disguised`.

### Screenshots/Videos
#### Before
![image](https://github.com/pagefaultgames/pokerogue/assets/31082757/b4351274-de7e-491a-b780-42b1667ad3f6)
![image](https://github.com/pagefaultgames/pokerogue/assets/31082757/59f8b672-1ff6-478d-85ed-dea0eb881c2e)
#### After
![image](https://github.com/pagefaultgames/pokerogue/assets/31082757/bc0381b6-5f31-43d3-9b94-81c06e573315)


## How to test the changes?
Look at Mimikyu's icon in Starter Select.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?