### PR TITLE
[Bug] Fix multi-hit moves persisting after sleep/freeze

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2545,6 +2545,14 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       return false;
     }
 
+    /**
+     * If this Pokemon falls asleep or freezes in the middle of a multi-hit attack,
+     * cancel the attack's subsequent hits.
+     */
+    if (effect === StatusEffect.SLEEP || effect === StatusEffect.FREEZE) {
+      this.stopMultiHit();
+    }
+
     if (asPhase) {
       this.scene.unshiftPhase(new ObtainStatusEffectPhase(this.scene, this.getBattlerIndex(), effect, cureTurn, sourceText, sourcePokemon));
       return true;


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This fixes an issue where multi-hit moves are not cancelled when the user falls asleep or is frozen mid-move (e.g. from the target's Effect Spore)

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Multi-hit moves currently continue to hit the opponent even after the user falls asleep or freezes.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
`field/pokemon`: `trySetStatus` now stops the user's multi-hit move if it has one in progress when the effect is `SLEEP` or `FREEZE`.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

https://github.com/pagefaultgames/pokerogue/assets/168692175/265f328e-98cf-4b6d-8cc7-60deb135cd3c

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
These steps were used for the test video above:
- `data/ability`: Change `EffectSporeAttr` to only afflict `StatusEffect.SLEEP`.
- `overrides`: Give your starter Population Bomb and Compound Eyes, and set the opponent to a bulky Pokemon (e.g. Snorlax) that only knows Splash.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?