### PR TITLE
[Localization] update modifier-select-ui options

### DIFF
--- a/src/interfaces/locales.ts
+++ b/src/interfaces/locales.ts
@@ -33,7 +33,13 @@ export interface ModifierTypeTranslationEntry {
     extra?: SimpleTranslationEntries
   }
 
+export interface ModifierOptionTypeTranslationEntry {
+  name: string,
+  description: string
+}
+
 export interface ModifierTypeTranslationEntries {
+    ModifierOptionType: { [key: string]: ModifierOptionTypeTranslationEntry },
     ModifierType: { [key: string]: ModifierTypeTranslationEntry },
     SpeciesBoosterItem: { [key: string]: ModifierTypeTranslationEntry },
     AttackTypeBoosterItem: SimpleTranslationEntries,

--- a/src/locales/de/modifier-type.ts
+++ b/src/locales/de/modifier-type.ts
@@ -1,6 +1,24 @@
 import { ModifierTypeTranslationEntries } from "#app/interfaces/locales";
 
 export const modifierType: ModifierTypeTranslationEntries = {
+  ModifierOptionType: {
+    "Reroll": {
+      name: "Neuwahl",
+      description: "Geben Sie Geld aus, um Ihre Gegenstandsoptionen neu zu würfeln.",
+    },
+    Transfer: {
+      name: "Übertragung",
+      description: "Übertrage ein gehaltenes Item von einem Pokémon auf ein anderes.",
+    },
+    "CheckTeam": {
+      name: "Team prüfen",
+      description: "Überprüfen Sie Ihr Team oder verwenden Sie ein Formular zum Ändern der Position.",
+    },
+    "LockRarities": {
+      name: "Schloss Raritäten",
+      description: "Sperre von Gegenstandsraritäten beim Wiederholungswurf (wirkt sich auf die Kosten des Wiederholungswurfs aus).",
+    },
+  },
   ModifierType: {
     "AddPokeballModifierType": {
       name: "{{modifierCount}}x {{pokeballName}}",

--- a/src/locales/en/modifier-type.ts
+++ b/src/locales/en/modifier-type.ts
@@ -1,6 +1,24 @@
 import { ModifierTypeTranslationEntries } from "#app/interfaces/locales";
 
 export const modifierType: ModifierTypeTranslationEntries = {
+  ModifierOptionType: {
+    "Reroll": {
+      name: "Reroll",
+      description: "Spend money to reroll your item options.",
+    },
+    Transfer: {
+      name: "Transfer",
+      description: "Transfer a held item from one Pokémon to another.",
+    },
+    "CheckTeam": {
+      name: "Check Team",
+      description: "Check your team or use a form changing item.",
+    },
+    "LockRarities": {
+      name: "Lock Rarities",
+      description: "Lock item rarities on reroll (affects reroll cost).",
+    },
+  },
   ModifierType: {
     "AddPokeballModifierType": {
       name: "{{modifierCount}}x {{pokeballName}}",

--- a/src/locales/es/modifier-type.ts
+++ b/src/locales/es/modifier-type.ts
@@ -1,6 +1,24 @@
 import { ModifierTypeTranslationEntries } from "#app/interfaces/locales";
 
 export const modifierType: ModifierTypeTranslationEntries = {
+  ModifierOptionType: {
+    "Reroll": {
+      name: "Reroll",
+      description: "Gasta dinero para rerollar tus opciones de artículos.",
+    },
+    Transfer: {
+      name: "Transferencia",
+      description: "Transfiere un objeto retenido de un Pokémon a otro.",
+    },
+    "CheckTeam": {
+      name: "Equipo de comprobación",
+      description: "Check your team or use a form changing item.",
+    },
+    "LockRarities": {
+      name: "Raridades bloqueadas",
+      description: "Bloquear las raridades de artículo en el reroll (afecta el costo del reroll).",
+    },
+  },
   ModifierType: {
     "AddPokeballModifierType": {
       name: "{{modifierCount}}x {{pokeballName}}",

--- a/src/locales/fr/modifier-type.ts
+++ b/src/locales/fr/modifier-type.ts
@@ -1,6 +1,24 @@
 import { ModifierTypeTranslationEntries } from "#app/interfaces/locales";
 
 export const modifierType: ModifierTypeTranslationEntries = {
+  ModifierOptionType: {
+    "Reroll": {
+      name: "Reroll",
+      description: "Dépensez de l'argent pour relancer vos options d'objets.",
+    },
+    Transfer: {
+      name: "Transfert",
+      description: "Transférer un objet détenu d'un Pokémon à un autre.",
+    },
+    "CheckTeam": {
+      name: "Équipe de contrôle",
+      description: "Vérifiez votre équipe ou utilisez un élément de changement de forme.",
+    },
+    "LockRarities": {
+      name: "Rarités de l'écluse",
+      description: "Verrouiller la rareté des objets lors du relancement (affecte le coût du relancement).",
+    },
+  },
   ModifierType: {
     "AddPokeballModifierType": {
       name: "{{pokeballName}} x{{modifierCount}}",

--- a/src/locales/it/modifier-type.ts
+++ b/src/locales/it/modifier-type.ts
@@ -1,6 +1,24 @@
 import { ModifierTypeTranslationEntries } from "#app/interfaces/locales";
 
 export const modifierType: ModifierTypeTranslationEntries = {
+  ModifierOptionType: {
+    "Reroll": {
+      name: "Rilancio",
+      description: "Spendere denaro per ricalcolare le opzioni degli oggetti.",
+    },
+    Transfer: {
+      name: "Trasferimento",
+      description: "Trasferire un oggetto detenuto da un Pokémon a un altro.",
+    },
+    "CheckTeam": {
+      name: "Squadra di controllo",
+      description: "Controllare la propria squadra o utilizzare un oggetto che cambia forma.",
+    },
+    "LockRarities": {
+      name: "Rarità del lucchetto",
+      description: "Blocca la rarità degli oggetti al momento del reroll (influisce sul costo del reroll).",
+    },
+  },
   ModifierType: {
     "AddPokeballModifierType": {
       name: "{{modifierCount}}x {{pokeballName}}",

--- a/src/locales/ko/modifier-type.ts
+++ b/src/locales/ko/modifier-type.ts
@@ -1,6 +1,24 @@
 import { ModifierTypeTranslationEntries } from "#app/interfaces/locales";
 
 export const modifierType: ModifierTypeTranslationEntries = {
+  ModifierOptionType: {
+    "Reroll": {
+      name: "새로고침",
+      description: "돈을 사용해 아이템 목록을 다시 추천받을 수 있습니다.",
+    },
+    Transfer: {
+      name: "도구 교체",
+      description: "포켓몬이 보유한 아이템을 다른 포켓몬으로 옮길 수 있습니다.",
+    },
+    "CheckTeam": {
+      name: "파티 보기",
+      description: "현재 포켓몬 파티를 확인할 수 있습니다.",
+    },
+    "LockRarities": {
+      name: "희귀도 고정",
+      description: "아이템 목록의 희귀도를 고정합니다(비용 증가).",
+    },
+  },
   ModifierType: {
     "AddPokeballModifierType": {
       name: "{{pokeballName}} {{modifierCount}}개",

--- a/src/locales/pt_BR/modifier-type.ts
+++ b/src/locales/pt_BR/modifier-type.ts
@@ -1,6 +1,24 @@
 import { ModifierTypeTranslationEntries } from "#app/interfaces/locales";
 
 export const modifierType: ModifierTypeTranslationEntries = {
+  ModifierOptionType: {
+    "Reroll": {
+      name: "Reroll",
+      description: "Gastar dinheiro para fazer o reroll de suas opções de itens.",
+    },
+    Transfer: {
+      name: "Transferência",
+      description: "Transferir um item retido de um Pokémon para outro.",
+    },
+    "CheckTeam": {
+      name: "Equipe de verificação",
+      description: "Verifique sua equipe ou use um item de alteração de formulário.",
+    },
+    "LockRarities": {
+      name: "Raridades do Lock",
+      description: "Bloquear raridades de itens na rolagem (afeta o custo da rolagem).",
+    },
+  },
   ModifierType: {
     "AddPokeballModifierType": {
       name: "{{modifierCount}}x {{pokeballName}}",

--- a/src/locales/zh_CN/modifier-type.ts
+++ b/src/locales/zh_CN/modifier-type.ts
@@ -1,6 +1,24 @@
 import { ModifierTypeTranslationEntries } from "#app/interfaces/locales";
 
 export const modifierType: ModifierTypeTranslationEntries = {
+  ModifierOptionType: {
+    "Reroll": {
+      name: "重掷",
+      description: "花钱重选物品选项。",
+    },
+    Transfer: {
+      name: "转让",
+      description: "将持有的物品从一只神奇宝贝转移到另一只。",
+    },
+    "CheckTeam": {
+      name: "检查小组",
+      description: "检查您的团队或使用表格更改项目。",
+    },
+    "LockRarities": {
+      name: "锁具珍品",
+      description: "在重选时锁定物品稀有度（影响重选成本）。",
+    },
+  },
   ModifierType: {
     "AddPokeballModifierType": {
       name: "{{modifierCount}}x {{pokeballName}}",

--- a/src/locales/zh_TW/modifier-type.ts
+++ b/src/locales/zh_TW/modifier-type.ts
@@ -1,6 +1,24 @@
 import { ModifierTypeTranslationEntries } from "#app/interfaces/locales";
 
 export const modifierType: ModifierTypeTranslationEntries = {
+  ModifierOptionType: {
+    "Reroll": {
+      name: "重新捲動",
+      description: "花錢重新滾動你的物品選項。",
+    },
+    Transfer: {
+      name: "轉移",
+      description: "將持有的物品從一隻神奇寶貝轉移到另一隻神奇寶貝。",
+    },
+    "CheckTeam": {
+      name: "檢查團隊",
+      description: "檢查您的團隊或使用表單更改項目。",
+    },
+    "LockRarities": {
+      name: "鎖稀有度",
+      description: "重新滾動時鎖定物品稀有度（影響重新滾動成本）。",
+    },
+  },
   ModifierType: {
     AddPokeballModifierType: {
       name: "{{modifierCount}}x {{pokeballName}}",

--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -10,6 +10,7 @@ import {Button} from "#enums/buttons";
 import MoveInfoOverlay from "./move-info-overlay";
 import { allMoves } from "../data/move";
 import * as Utils from "./../utils";
+import i18next from "i18next";
 
 export const SHOP_OPTIONS_ROW_LIMIT = 6;
 
@@ -390,16 +391,16 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
       }
     } else if (cursor === 0) {
       this.cursorObj.setPosition(6, this.lockRarityButtonContainer.visible ? -72 : -60);
-      ui.showText("Spend money to reroll your item options.");
+      ui.showText(i18next.t("modifierType:ModifierOptionType.Reroll.description"));
     } else if (cursor === 1) {
       this.cursorObj.setPosition((this.scene.game.canvas.width / 6) - 120, -60);
-      ui.showText("Transfer a held item from one Pokémon to another.");
+      ui.showText(i18next.t("modifierType:ModifierOptionType.Transfer.description"));
     } else if (cursor === 2) {
       this.cursorObj.setPosition((this.scene.game.canvas.width / 6) - 60, -60);
-      ui.showText("Check your team or use a form changing item.");
+      ui.showText(i18next.t("modifierType:ModifierOptionType.CheckTeam.description"));
     } else {
       this.cursorObj.setPosition(6, -60);
-      ui.showText("Lock item rarities on reroll (affects reroll cost).");
+      ui.showText(i18next.t("modifierType:ModifierOptionType.LockRarities.description"));
     }
 
     return ret;


### PR DESCRIPTION
## What are the changes?
After the battle, I applied localization on the reward phase.

## Why am I doing these changes?
To display the role of the feature in the description in select-ui

## What did change?
- add `ModifierOptionType` field in `modifier-type.ts`.

I'm Korean, and I am not good at other languages. so I translated the rest of the languages through Google translation and Deepl.
**If there's anything awkward, please revise it further!**



### Screenshots/Videos
![image](https://github.com/pagefaultgames/pokerogue/assets/92131474/483a024b-d4f2-49b4-be8c-04fda5981715)


## How to test the changes?
![image](https://github.com/pagefaultgames/pokerogue/assets/92131474/9b0c4be6-b911-4f24-a964-94b7c2eeff3c)
I've tried running all the languages locally, including the German phrase "Lock rarities" with the longest description, which doesn't overflow UI-wise.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?

### As a side note
Thank you to the team that is running the fun game. I want to contribute what I can do while using the game in the future!

