### PR TITLE
[Bug] Fix multi-hit moves stopping if the move freezes an opponent

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2262,11 +2262,11 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * If this Pokemon is using a multi-hit move, cancels all subsequent strikes
-   * @param {Pokemon} target If specified, this only cancels subsequent strikes against this Pokemon
+   * @param {Pokemon} target If specified, this only cancels subsequent strikes against the given target
    */
   stopMultiHit(target?: Pokemon): void {
     const effectPhase = this.scene.getCurrentPhase();
-    if (effectPhase instanceof MoveEffectPhase) {
+    if (effectPhase instanceof MoveEffectPhase && effectPhase.getUserPokemon() === this) {
       effectPhase.stopMultiHit(target);
     }
   }


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This change fixes a bug where freezing an opponent with a Multi-Lens-boosted attack move (e.g. Ice Beam) would cancel subsequent strikes of the move.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
This bug was reported [in the Discord](https://discord.com/channels/1125469663833370665/1256914504844054560).

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- `field/pokemon`: `this.stopMultiHit()` now checks that the `MoveEffectPhase`'s source move originated from `this`. As a result, calling `p.stopMultiHit()` for a Pokemon `p` should no longer affect any other Pokemon's moves.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

Ice Beam + Multi-Lens' behavior after the changes:

https://github.com/pagefaultgames/pokerogue/assets/168692175/9ec92255-cf10-4ca9-a230-93364898f953

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
To reproduce the results from the video:
- `data/move`: Set the `chance` field of `Moves.ICE_BEAM` to 100 in `allMoves`
- `overrides`: Give your starter Ice Beam and Multi-Lens (x3). You can set other overrides to make sure the opponent doesn't get OHKO'd.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?