### PR TITLE
[Bug] Let eternatus keep stat changes when changing form

### DIFF
--- a/src/form-change-phase.ts
+++ b/src/form-change-phase.ts
@@ -280,7 +280,6 @@ export class QuietFormChangePhase extends BattlePhase {
   end(): void {
     if (this.pokemon.scene?.currentBattle.battleSpec === BattleSpec.FINAL_BOSS && this.pokemon instanceof EnemyPokemon) {
       this.scene.playBgm();
-      this.pokemon.summonData.battleStats = [ 0, 0, 0, 0, 0, 0, 0 ];
       this.scene.unshiftPhase(new PokemonHealPhase(this.scene, this.pokemon.getBattlerIndex(), this.pokemon.getMaxHp(), null, false, false, false, true));
       this.pokemon.findAndRemoveTags(() => true);
       this.pokemon.bossSegments = 5;


### PR DESCRIPTION
## What are the changes?
Eternatus was resetting stat stages on changing form.

## Why am I doing these changes?
Per discussion on discord, this is a bug. The reason why it has two buffing moves is its meant to keep the stat boosts.

## What did change?
Remove the stat stage reset on changing form.

### Screenshots/Videos
<img width="937" alt="phase1" src="https://github.com/pagefaultgames/pokerogue/assets/3487253/e0fbf5ec-3d99-40ab-9e86-efae85e78659">
<img width="924" alt="phase2" src="https://github.com/pagefaultgames/pokerogue/assets/3487253/fa0b89a8-7a54-48ad-96d3-0e7705ab48dc">


## How to test the changes?
KO eternatus at wave 200, without this PR it'll lose the stat boosts its acquired on changing form, with it it'll keep them.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?