### PR TITLE
[Bug] Thief Causing Crash with Species Stat Boosters

### DIFF
--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -45,7 +45,6 @@ type NewModifierFunc = (type: ModifierType, args: any[]) => Modifier;
 
 export class ModifierType {
   public id: string;
-  public generatorId: string;
   public localeKey: string;
   public iconImage: string;
   public group: string;
@@ -102,7 +101,7 @@ export class ModifierType {
         if (!pool.hasOwnProperty(tier)) {
           continue;
         }
-        if (pool[tier].find(m => (m as WeightedModifierType).modifierType.id === (this.generatorId || this.id))) {
+        if (pool[tier].find(m => (m as WeightedModifierType).modifierType.id === this.id)) {
           return (this.tier = tier);
         }
       }
@@ -133,7 +132,6 @@ export class ModifierTypeGenerator extends ModifierType {
   generateType(party: Pokemon[], pregenArgs?: any[]) {
     const ret = this.genTypeFunc(party, pregenArgs);
     if (ret) {
-      ret.generatorId = ret.id;
       ret.id = this.id;
       ret.setTier(this.tier);
     }
@@ -554,7 +552,7 @@ export class SpeciesStatBoosterModifierType extends PokemonHeldItemModifierType 
     const item = SpeciesStatBoosterModifierTypeGenerator.items[key];
     super(`modifierType:SpeciesBoosterItem.${key}`, key.toLowerCase(), (type, args) => new Modifiers.SpeciesStatBoosterModifier(type, (args[0] as Pokemon).id, item.stats, item.multiplier, item.species));
 
-    this.id = this.key = key;
+    this.key = key;
   }
 
   getPregenArgs(): any[] {
@@ -1742,7 +1740,7 @@ export function regenerateModifierPoolThresholds(party: Pokemon[], poolType: Mod
     let i = 0;
     pool[t].reduce((total: integer, modifierType: WeightedModifierType) => {
       const weightedModifierType = modifierType as WeightedModifierType;
-      const existingModifiers = party[0].scene.findModifiers(m => (m.type.generatorId || m.type.id) === weightedModifierType.modifierType.id, poolType === ModifierPoolType.PLAYER);
+      const existingModifiers = party[0].scene.findModifiers(m => m.type.id === weightedModifierType.modifierType.id, poolType === ModifierPoolType.PLAYER);
       const itemModifierType = weightedModifierType.modifierType instanceof ModifierTypeGenerator
         ? weightedModifierType.modifierType.generateType(party)
         : weightedModifierType.modifierType;
@@ -1755,7 +1753,7 @@ export function regenerateModifierPoolThresholds(party: Pokemon[], poolType: Mod
           : weightedModifierType.weight as integer
         : 0;
       if (weightedModifierType.maxWeight) {
-        const modifierId = weightedModifierType.modifierType.generatorId || weightedModifierType.modifierType.id;
+        const modifierId = weightedModifierType.modifierType.id;
         tierModifierIds.push(modifierId);
         const outputWeight = useMaxWeightForOutput ? weightedModifierType.maxWeight : weight;
         modifierTableData[modifierId] = { weight: outputWeight, tier: parseInt(t), tierPercent: 0, totalPercent: 0 };

--- a/src/system/modifier-data.ts
+++ b/src/system/modifier-data.ts
@@ -5,7 +5,6 @@ import { GeneratedPersistentModifierType, ModifierTypeGenerator, getModifierType
 export default class ModifierData {
   private player: boolean;
   private typeId: string;
-  private typeGeneratorId: string;
   private typePregenArgs: any[];
   private args: any[];
   private stackCount: integer;
@@ -16,7 +15,6 @@ export default class ModifierData {
     const sourceModifier = source instanceof PersistentModifier ? source as PersistentModifier : null;
     this.player = player;
     this.typeId = sourceModifier ? sourceModifier.type.id : source.typeId;
-    this.typeGeneratorId = sourceModifier ? sourceModifier.type.generatorId : source.typeGeneratorId;
     if (sourceModifier) {
       if ("getPregenArgs" in source.type) {
         this.typePregenArgs = (source.type as GeneratedPersistentModifierType).getPregenArgs();
@@ -38,7 +36,6 @@ export default class ModifierData {
     try {
       let type = typeFunc();
       type.id = this.typeId;
-      type.generatorId = this.typeGeneratorId;
 
       if (type instanceof ModifierTypeGenerator) {
         type = (type as ModifierTypeGenerator).generateType(this.player ? scene.getParty() : scene.getEnemyField(), this.typePregenArgs);


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->

Fixes an issue where using `Thief` on any item from the `SPECIES_STAT_BOOSTER` generator and successfully stealing the held item would cause a crash.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

As brought up by #2736, this bug would cause the game to hang. Even though `Thick Club` was the only item to be reported in the issue, investigation showed that this would happen with any of the items, which makes the chance to experience stalling higher than if it was just one item and increases the necessity to address the bug.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

As it turns out, the issue stemmed on the items writing their `SpeciesStatBoosterItem` key to their `id`, which, upon calling `generateType`, was set to their `generatorId` with `id` being replaced by `SPECIES_STAT_BOOSTER`, the identifier for the generator in the `modifierTypes` array. This would cause an issue where the `generatorId` was used instead of the `id` to infer the tier of the necessary modifier type, causing the `stolenItem` to be `null`. As a result, the fix was simply not assigning the `key` to the `id`.

However, I had already previously noticed that other generator items like `TEMP_STAT_BOOSTER` never set `generatorId` at all, making it perpetually `null` in saves and never used on reload. As such, I also took the opportunity to remove `generatorId` from game logic and saving/loading logic, since it doesn't do anything besides defer back to `id` in all cases.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

Compared to #2736, `Thief` now works as intended without causing the game to hang.

https://github.com/pagefaultgames/pokerogue/assets/109637146/583e824a-1c65-44d5-9034-0ec2378f93f6

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

To test a similar scenario to the issue, a new run was started with Cubone as the only starter along with the following overrides:
- To force `Thick Club` to be held as the only held item,
```ts
export const STARTING_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [{ name: "SPECIES_STAT_BOOSTER", type: "THICK_CLUB" }]; 
```
- To force a wild Pokemon to use `Thief`,
```ts
export const OPP_MOVESET_OVERRIDE: Array<Moves> = [ Moves.THIEF, Moves.THIEF, Moves.THIEF, Moves.THIEF ];
```

Because `Thief` has a 30% chance to steal an item, multiple tries might be needed before the interaction involving the item stealing logic occurs.

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?