### PR TITLE
[Bug] Fix incorrect move effectiveness

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1155,10 +1155,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       applyPreDefendAbAttrs(MoveImmunityAbAttr, this, source, move, cancelled, typeMultiplier, true);
     }
 
-    if (typeof typeMultiplier.value === "boolean") {
-      typeMultiplier.value = Number(typeMultiplier.value);
-    }
-    return (!cancelled.value ? typeMultiplier.value : 0) as TypeDamageMultiplier;
+    return (!cancelled.value ? Number(typeMultiplier.value) : 0) as TypeDamageMultiplier;
   }
 
   getAttackTypeEffectiveness(moveType: Type, source?: Pokemon, ignoreStrongWinds: boolean = false): TypeDamageMultiplier {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1155,6 +1155,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       applyPreDefendAbAttrs(MoveImmunityAbAttr, this, source, move, cancelled, typeMultiplier, true);
     }
 
+    if (typeof typeMultiplier.value === "boolean") {
+      typeMultiplier.value = Number(typeMultiplier.value);
+    }
     return (!cancelled.value ? typeMultiplier.value : 0) as TypeDamageMultiplier;
   }
 


### PR DESCRIPTION
## What are the changes?
Correct type for move effectiveness

## Why am I doing these changes?
Fix https://github.com/pagefaultgames/pokerogue/issues/2756

## What did change?
Convert incorrect type (Boolean into Number)

### Screenshots/Videos
Before:
![345063523-ca628bc3-97fd-448c-9b2a-8cbeab1474ad](https://github.com/pagefaultgames/pokerogue/assets/19636010/c765a1d1-52ae-499e-8493-17ddd8c662cc)

After:
<img width="971" alt="Screenshot 2024-07-02 at 17 34 40" src="https://github.com/pagefaultgames/pokerogue/assets/19636010/53f8cae9-9c89-4031-ac02-e1e6d9d32f4d">


## How to test the changes?
```javascript
export const MOVESET_OVERRIDE: Array<Moves> = [Moves.SHEER_COLD];
export const OPP_SPECIES_OVERRIDE: Species | integer = Species.JYNX;
```

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?