### PR TITLE
[bug][ui] Fix eternatus candy count and display hatched egg count

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -2077,9 +2077,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
             this.pokemonHatchedIcon,
             this.pokemonHatchedCountText
           ].map(c => c.setVisible(false));
-        } else if (species.speciesId === Species.ETERNATUS) {
-          this.pokemonHatchedIcon.setVisible(false);
-          this.pokemonHatchedCountText.setVisible(false);
+          this.pokemonFormText.setY(25);
         } else {
           this.pokemonCaughtHatchedContainer.setY(25);
           this.pokemonShinyIcon.setY(117);
@@ -2091,6 +2089,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
           this.pokemonCandyCountText.setText(`x${this.scene.gameData.starterData[species.speciesId].candyCount}`);
           this.pokemonCandyCountText.setVisible(true);
           this.pokemonFormText.setVisible(true);
+          this.pokemonFormText.setY(42);
           this.pokemonHatchedIcon.setVisible(true);
           this.pokemonHatchedCountText.setVisible(true);
 


### PR DESCRIPTION
## What are the changes?
Display how many ETERNATUS eggs the player has hatched.

## Why am I doing these changes?
Previously Egg count was hidden for ETERNATUS, because it was imposible to hatch Eternatus eggs.
Now that eggs are buyable  with candy ETERNATUS egg count should be visible.

## What did change?
Deleted special logic for handling ETERNATUS icons.
This also fixes:
- https://github.com/pagefaultgames/pokerogue/issues/2693

This PR also reintroduces changes made at:
- https://github.com/pagefaultgames/pokerogue/pull/2359
Since they where unintentionally removed at:
- https://github.com/pagefaultgames/pokerogue/pull/2372

### Screenshots/Videos
**BEFORE**
![image](https://github.com/pagefaultgames/pokerogue/assets/31145813/e9f37aff-7475-42bb-8932-e7ace8dba7a1)

**AFTER**
![image](https://github.com/pagefaultgames/pokerogue/assets/31145813/8f538e17-39e5-4fbe-9d85-063de3cc0bc8)

## How to test the changes?
Openning starter select UI

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?