### PR TITLE
[Bug] Fix evasion multiplier in hit check

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -3095,7 +3095,7 @@ export class MoveEffectPhase extends PokemonPhase {
     applyBattleStatMultiplierAbAttrs(BattleStatMultiplierAbAttr, user, BattleStat.ACC, accuracyMultiplier, this.move.getMove());
 
     const evasionMultiplier = new Utils.NumberHolder(1);
-    applyBattleStatMultiplierAbAttrs(BattleStatMultiplierAbAttr, this.getTarget(), BattleStat.EVA, evasionMultiplier);
+    applyBattleStatMultiplierAbAttrs(BattleStatMultiplierAbAttr, target, BattleStat.EVA, evasionMultiplier);
 
     accuracyMultiplier.value /= evasionMultiplier.value;
 

--- a/src/test/abilities/sand_veil.test.ts
+++ b/src/test/abilities/sand_veil.test.ts
@@ -1,0 +1,80 @@
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import GameManager from "../utils/gameManager";
+import * as Overrides from "#app/overrides";
+import { Species } from "#enums/species";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { getMovePosition } from "../utils/gameManagerUtils";
+import { CommandPhase, MoveEffectPhase, MoveEndPhase } from "#app/phases.js";
+import { BattleStat } from "#app/data/battle-stat.js";
+import { WeatherType } from "#app/data/weather.js";
+import * as Utils from "#app/utils.js";
+import { BattleStatMultiplierAbAttr, allAbilities, applyBattleStatMultiplierAbAttrs } from "#app/data/ability.js";
+
+const TIMEOUT = 20 * 1000;
+
+describe("Abilities - Sand Veil", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    vi.spyOn(Overrides, "DOUBLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(Overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH]);
+    vi.spyOn(Overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.MEOWSCARADA);
+    vi.spyOn(Overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.INSOMNIA);
+    vi.spyOn(Overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.TWISTER, Moves.TWISTER, Moves.TWISTER, Moves.TWISTER]);
+    vi.spyOn(Overrides, "STARTING_LEVEL_OVERRIDE", "get").mockReturnValue(100);
+    vi.spyOn(Overrides, "OPP_LEVEL_OVERRIDE", "get").mockReturnValue(100);
+    vi.spyOn(Overrides, "WEATHER_OVERRIDE", "get").mockReturnValue(WeatherType.SANDSTORM);
+  });
+
+  test(
+    "ability should increase the evasiveness of the source",
+    async () => {
+      await game.startBattle([Species.SNORLAX, Species.BLISSEY]);
+
+      const leadPokemon = game.scene.getPlayerField();
+      leadPokemon.forEach(p => expect(p).toBeDefined());
+
+      const enemyPokemon = game.scene.getEnemyField();
+      enemyPokemon.forEach(p => expect(p).toBeDefined());
+
+      vi.spyOn(leadPokemon[0], "getAbility").mockReturnValue(allAbilities[Abilities.SAND_VEIL]);
+
+      expect(leadPokemon[0].hasAbility(Abilities.SAND_VEIL)).toBe(true);
+      expect(leadPokemon[1].hasAbility(Abilities.SAND_VEIL)).toBe(false);
+
+      game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
+
+      await game.phaseInterceptor.to(CommandPhase);
+
+      game.doAttack(getMovePosition(game.scene, 1, Moves.SPLASH));
+
+      await game.phaseInterceptor.to(MoveEffectPhase, false);
+
+      // Mock implementation of hitCheck causes attack to miss if a multiplier is applied
+      vi.spyOn(game.scene.getCurrentPhase() as MoveEffectPhase, "hitCheck").mockImplementation((target) => {
+        const evasionMultiplier = new Utils.NumberHolder(1);
+        applyBattleStatMultiplierAbAttrs(BattleStatMultiplierAbAttr, target, BattleStat.EVA, evasionMultiplier);
+        return evasionMultiplier.value <= 1;
+      });
+
+      await game.phaseInterceptor.to(MoveEndPhase, false);
+
+      expect(leadPokemon[0].hp).toBe(leadPokemon[0].getMaxHp());
+      expect(leadPokemon[1].hp).toBeLessThan(leadPokemon[1].getMaxHp());
+    }, TIMEOUT
+  );
+});

--- a/src/test/lokalisation/status-effect.test.ts
+++ b/src/test/lokalisation/status-effect.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, afterEach, expect, it, vi } from "vitest";
 import {
   StatusEffect,
   getStatusEffectActivationText,
@@ -8,7 +8,6 @@ import {
   getStatusEffectOverlapText,
 } from "#app/data/status-effect";
 import i18next, { ParseKeys } from "i18next";
-import { afterEach } from "node:test";
 
 const tMock = (key: ParseKeys) => key;
 const pokemonName = "PKM";


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This fixes a bug where when a Pokemon uses a spread move in a double battle, the evasiveness multipliers from the first target are applied to all targets.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
This bug was reported in the [Discord](https://discord.com/channels/1125469663833370665/1257436464942284880)

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- `phases`: `MoveEffectPhase.hitCheck()` now bases evasiveness multipliers off of the `target` argument instead of `getTarget()`, which always returns the first active target.
- `test/abilities/sand_veil.test`: New test to check that Sand Veil applies its effects correctly to the user (and only to the user).
- `test/lokalisation/status-effect.test`: Fixed a broken import that sometimes caused `npm run test` to fail.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
N/A

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
`npm run test sand_veil`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [n/a] Are the changes visual?
  - [n/a] Have I provided screenshots/videos of the changes?