### PR TITLE
[Feature] Allow Phione eggs to have a 1/8 chance to hatch Manaphy

### DIFF
--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -17,7 +17,7 @@ const DEFAULT_SHINY_RATE = 128;
 const GACHA_SHINY_UP_SHINY_RATE = 64;
 const SAME_SPECIES_EGG_SHINY_RATE = 32;
 const SAME_SPECIES_EGG_HA_RATE = 16;
-const MANAPHY_EGG_MANAPHY_RATE = 8;
+const MANAPHY_EGG_MANAPHY_RATE = 2;
 
 // 1/x for legendary eggs, 1/x*2 for epic eggs, 1/x*4 for rare eggs, and 1/x*8 for common eggs
 const DEFAULT_RARE_EGGMOVE_RATE = 6;
@@ -152,7 +152,7 @@ export class Egg {
     this._id = eggOptions.id ?? Utils.randInt(EGG_SEED, EGG_SEED * this._tier);
 
     this._sourceType = eggOptions.sourceType ?? undefined;
-    this._hatchWaves = eggOptions.hatchWaves ?? this.getEggTierDefaultHatchWaves();
+    this._hatchWaves = 1; // eggOptions.hatchWaves ?? this.getEggTierDefaultHatchWaves();
     this._timestamp = eggOptions.timestamp ?? new Date().getTime();
 
     // First roll shiny and variant so we can filter if species with an variant exist
@@ -165,7 +165,7 @@ export class Egg {
     // Override egg tier and hatchwaves if species was given
     if (eggOptions.species) {
       this._tier = this.getEggTierFromSpeciesStarterValue();
-      this._hatchWaves = eggOptions.hatchWaves ?? this.getEggTierDefaultHatchWaves();
+      this._hatchWaves = 1;// eggOptions.hatchWaves ?? this.getEggTierDefaultHatchWaves();
       // If species has no variant, set variantTier to common. This needs to
       // be done because species with no variants get filtered at rollSpecies but since the
       // species is set the check never happens
@@ -205,7 +205,11 @@ export class Egg {
       this._species = this.rollSpecies(scene);
     }
 
-    const pokemonSpecies = getPokemonSpecies(this._species);
+    let pokemonSpecies = getPokemonSpecies(this._species);
+    // Special condition to have Phione eggs also have a chance of generating Manaphy
+    if (this._species === Species.PHIONE) {
+      pokemonSpecies = getPokemonSpecies(Utils.randSeedInt(MANAPHY_EGG_MANAPHY_RATE) ? Species.PHIONE : Species.MANAPHY);
+    }
 
     // Sets the hidden ability if a hidden ability exists and the override is set
     // or if the same species egg hits the chance

--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -17,7 +17,7 @@ const DEFAULT_SHINY_RATE = 128;
 const GACHA_SHINY_UP_SHINY_RATE = 64;
 const SAME_SPECIES_EGG_SHINY_RATE = 32;
 const SAME_SPECIES_EGG_HA_RATE = 16;
-const MANAPHY_EGG_MANAPHY_RATE = 2;
+const MANAPHY_EGG_MANAPHY_RATE = 8;
 
 // 1/x for legendary eggs, 1/x*2 for epic eggs, 1/x*4 for rare eggs, and 1/x*8 for common eggs
 const DEFAULT_RARE_EGGMOVE_RATE = 6;
@@ -152,7 +152,7 @@ export class Egg {
     this._id = eggOptions.id ?? Utils.randInt(EGG_SEED, EGG_SEED * this._tier);
 
     this._sourceType = eggOptions.sourceType ?? undefined;
-    this._hatchWaves = 1; // eggOptions.hatchWaves ?? this.getEggTierDefaultHatchWaves();
+    this._hatchWaves = eggOptions.hatchWaves ?? this.getEggTierDefaultHatchWaves();
     this._timestamp = eggOptions.timestamp ?? new Date().getTime();
 
     // First roll shiny and variant so we can filter if species with an variant exist
@@ -165,7 +165,7 @@ export class Egg {
     // Override egg tier and hatchwaves if species was given
     if (eggOptions.species) {
       this._tier = this.getEggTierFromSpeciesStarterValue();
-      this._hatchWaves = 1;// eggOptions.hatchWaves ?? this.getEggTierDefaultHatchWaves();
+      this._hatchWaves = eggOptions.hatchWaves ?? this.getEggTierDefaultHatchWaves();
       // If species has no variant, set variantTier to common. This needs to
       // be done because species with no variants get filtered at rollSpecies but since the
       // species is set the check never happens

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1423,8 +1423,8 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
             }
 
             // Same species egg menu option. Only visible if passive is bought
-            if (true) {
-              const sameSpeciesEggCost = 0;// getSameSpeciesEggCandyCounts(speciesStarters[this.lastSpecies.speciesId]);
+            if (passiveAttr & PassiveAttr.UNLOCKED) {
+              const sameSpeciesEggCost = getSameSpeciesEggCandyCounts(speciesStarters[this.lastSpecies.speciesId]);
               options.push({
                 label: `x${sameSpeciesEggCost} ${i18next.t("starterSelectUiHandler:sameSpeciesEgg")}`,
                 handler: () => {

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1423,8 +1423,8 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
             }
 
             // Same species egg menu option. Only visible if passive is bought
-            if (passiveAttr & PassiveAttr.UNLOCKED) {
-              const sameSpeciesEggCost = getSameSpeciesEggCandyCounts(speciesStarters[this.lastSpecies.speciesId]);
+            if (true) {
+              const sameSpeciesEggCost = 0;// getSameSpeciesEggCandyCounts(speciesStarters[this.lastSpecies.speciesId]);
               options.push({
                 label: `x${sameSpeciesEggCost} ${i18next.t("starterSelectUiHandler:sameSpeciesEgg")}`,
                 handler: () => {


### PR DESCRIPTION
## What are the changes?
Allow Phione species-eggs to have a 1/8 chance to hatch Manaphy

## Why am I doing these changes?
Manaphy is obnoxiously hard to obtain right now since it is unaffected by pity.

## What did change?
Added the following in `egg.ts`
```ts
if (this._species === Species.PHIONE) {
      pokemonSpecies = getPokemonSpecies(Utils.randSeedInt(MANAPHY_EGG_MANAPHY_RATE) ? Species.PHIONE : Species.MANAPHY);
    }
```

### Screenshots/Videos
Obtained a lot of free 1 wave Phione eggs
![](https://cdn.discordapp.com/attachments/1241164581997510656/1258301805771620403/image.png?ex=66878c60&is=66863ae0&hm=d8d9ef2bbf82d667edce1eebfe750ebe4c00b49f359d9b861c1622980a809fce&)
Verify Manaphy hatched out
![](https://cdn.discordapp.com/attachments/1241164581997510656/1258304920822481046/image.png?ex=66878f47&is=66863dc7&hm=6695edc3b708868b0438f0398ad3082ca97d7394bacf6a8cde61bac3a52dfb30&)

## How to test the changes?
Pull [the commit with the debug features](https://github.com/pagefaultgames/pokerogue/pull/2787/commits/deab6243865fe9eafce58c6226f79762363450a9)

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?