### PR TITLE
[Bug] Starter Screen: Update pokemon sprite's alpha value correctly when cursor is over pokemon

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -2325,7 +2325,8 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         Challenge.applyChallenges(this.scene.gameMode, Challenge.ChallengeType.STARTER_CHOICE, species, isValidForChallenge, this.scene.gameData.getSpeciesDexAttrProps(species, this.dexAttrCursor), this.starterGens.length);
         const starterSprite = this.starterSelectGenIconContainers[this.getGenCursorWithScroll()].getAt(this.cursor) as Phaser.GameObjects.Sprite;
         starterSprite.setTexture(species.getIconAtlasKey(formIndex, shiny, variant), species.getIconId(female, formIndex, shiny, variant));
-        starterSprite.setAlpha(isValidForChallenge.value ? 1 : 0.375);
+        const isValidByCost = this.getValueLimit() - this.getCurrentValue() >=  this.scene.gameData.getSpeciesStarterValue(species.speciesId);
+        starterSprite.setAlpha(isValidForChallenge.value && isValidByCost ? 1 : 0.375);
         this.checkIconId((this.starterSelectGenIconContainers[this.getGenCursorWithScroll()].getAt(this.cursor) as Phaser.GameObjects.Sprite), species, female, formIndex, shiny, variant);
         this.canCycleShiny = !!(dexEntry.caughtAttr & DexAttr.NON_SHINY && dexEntry.caughtAttr & DexAttr.SHINY);
         this.canCycleGender = !!(dexEntry.caughtAttr & DexAttr.MALE && dexEntry.caughtAttr & DexAttr.FEMALE);
@@ -2503,8 +2504,15 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.starterValueLabels[cursor].setShadowColor(this.getTextColor(textStyle, true));
   }
 
+  /**
+   * Calculates the value/cost currently used with chosen starters.
+   */
+  getCurrentValue(): integer {
+    return this.starterGens.reduce((total: integer, gen: integer, i: integer) => total += this.scene.gameData.getSpeciesStarterValue(this.genSpecies[gen][this.starterCursors[i]].speciesId), 0);
+  }
+
   tryUpdateValue(add?: integer): boolean {
-    const value = this.starterGens.reduce((total: integer, gen: integer, i: integer) => total += this.scene.gameData.getSpeciesStarterValue(this.genSpecies[gen][this.starterCursors[i]].speciesId), 0);
+    const value = this.getCurrentValue();
     const newValue = value + (add || 0);
     const valueLimit = this.getValueLimit();
     const overLimit = newValue > valueLimit;


### PR DESCRIPTION
On starter screen, the alpha value for each pokemon sprite indicates whether this pokemon can be added to the team or not. This does currently not correctly work when the cursor moves over a pokemon that can't be added to the team anymore because it's too expensive. The cost calculation is not (re-)considered. (see videos below)

## What are the changes?
Now correctly considers a pokemon's cost when the cursor is above it's sprite and updates the sprite's alpha value correctly. The sprite therefor keeps it's correct alpha value.

## Why am I doing these changes?
I noticed the error a few times when starting a new run. It made it more unclear, what my remaining options for my team are.

## What did change?
On the starter screen, the alpha value of a pokemon's sprite is now correctly updated when the cursor is on that sprite depending on the pokemon's cost and the available cost.

### Screenshots/Videos
Before (Pokemon sprites become bright again when cursor is on them):
https://github.com/pagefaultgames/pokerogue/assets/67913362/398a4e91-ea43-431f-8ab9-fd96f2b7528a

After (Pokemon sprites keep the correct alpha value when cursor is above them):
https://github.com/pagefaultgames/pokerogue/assets/67913362/763a7c69-8602-427d-b8ed-69b9186961cd

## How to test the changes?
- start a new run
- select a few starters till you're near/at the limit of cost
- move your cursor above pokemon that are now too expensive to join the team
- their sprites keep the correct alpha value

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?