### PR TITLE
[BUG] Fixes SacrificialAttrOnHit attribute so that the pokemon does not faint if the move (final gambit, memento) fails

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1155,7 +1155,7 @@ export class SacrificialAttr extends MoveEffectAttr {
  **/
 export class SacrificialAttrOnHit extends MoveEffectAttr {
   constructor() {
-    super(true, MoveEffectTrigger.POST_TARGET);
+    super(true, MoveEffectTrigger.HIT);
   }
 
   /**


### PR DESCRIPTION
## What are the changes?
Solves the issue of https://github.com/pagefaultgames/pokerogue/issues/2778
Sacrificial moves like final gambit and memento will now check for the move hitting before the sacrifice occurs.

## Why am I doing these changes?
Sacrificial moves should not cause the pokemon to faint if the move is going to fail.

## What did change?
The SacrificialAttrOnHit attribute now uses the HIT MoveEffectTrigger so that the pokemon using the move is not sacrificed if the move does not hit the target.

### Screenshots/Videos
## Before:

https://github.com/pagefaultgames/pokerogue/assets/98116601/c4a6596e-41f3-4e91-b20f-5061fc460052


https://github.com/pagefaultgames/pokerogue/assets/98116601/fdc44479-bd7e-4a5f-8f0e-7b8e96127681


## After:

https://github.com/pagefaultgames/pokerogue/assets/98116601/96a0afcb-77e7-45a5-bb2e-0dade58f731b

https://github.com/pagefaultgames/pokerogue/assets/98116601/a5da7f86-e6de-4bf6-b1ef-011765805165


## How to test the changes?
For final gambit, select any ghost type as your pokemon and any ghost type as the opponent. Select final gambit as your move and you should see that the move fails due to not affecting the target.
For memento, select any pokemon with prankster as your pokemon and any dark type as the opponent. Select memento as your move and you should see that the move fails due to how prankster works against dark types.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?

