### PR TITLE
[Bug] Magic Guard blocks damage from Iron Barbs/Rough Skin

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -879,7 +879,7 @@ export class PostDefendContactDamageAbAttr extends PostDefendAbAttr {
   }
 
   applyPostDefend(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: Move, hitResult: HitResult, args: any[]): boolean {
-    if (move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)) {
+    if (move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon) && !attacker.hasAbilityWithAttr(BlockNonDirectDamageAbAttr)) {
       attacker.damageAndUpdate(Math.ceil(attacker.getMaxHp() * (1 / this.damageRatio)), HitResult.OTHER);
       attacker.turnData.damageTaken += Math.ceil(attacker.getMaxHp() * (1 / this.damageRatio));
       return true;


### PR DESCRIPTION
## What are the changes?
The ability Magic Guard will block damage from making contact with a pokemon with the Iron Barbs or Rough Skin abilities. 

## Why am I doing these changes?
I saw this issue in the Discord's #bug-reports channel - https://discord.com/channels/1125469663833370665/1258512208762241096 

## What did change?
ApplyPostContactDamageAbAttr now checks if the attacking pokemon's current ability has a BlockNonDirectDamageAbAttr before applying damage. 

### Screenshots/Videos
Recording #1: Starly has Rough Skin + Bulbasaur has Magic Guard
https://github.com/pagefaultgames/pokerogue/assets/171087428/22ce1669-1be6-447f-9d1b-79ab9e1a7940

Recording #2: Sunkern has Iron Barbs + Bulbasaur has Magic Guard
https://github.com/pagefaultgames/pokerogue/assets/171087428/2dfb138d-1020-4e39-8aba-5ec7a5041430

## How to test the changes?
I changed these settings in overrides.ts 
![image](https://github.com/pagefaultgames/pokerogue/assets/171087428/96293164-dcf0-41b1-9136-ff37a1bb28f0)
I am trying to write a test for Magic Guard as well, but because a test for Magic Guard quite complex I decided to push this first. If the devs believe that it would be best, I can wait for this to be committed until I finish the test. 

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?