### PR TITLE
[BUG] Magic Guard-Spiky Shield Fix 

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -879,7 +879,7 @@ export class PostDefendContactDamageAbAttr extends PostDefendAbAttr {
   }
 
   applyPostDefend(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: Move, hitResult: HitResult, args: any[]): boolean {
-    if (move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)) {
+    if (move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon) && !attacker.hasAbilityWithAttr(BlockNonDirectDamageAbAttr)) {
       attacker.damageAndUpdate(Math.ceil(attacker.getMaxHp() * (1 / this.damageRatio)), HitResult.OTHER);
       attacker.turnData.damageTaken += Math.ceil(attacker.getMaxHp() * (1 / this.damageRatio));
       return true;

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -934,7 +934,9 @@ export class ContactDamageProtectedTag extends ProtectedTag {
       const effectPhase = pokemon.scene.getCurrentPhase();
       if (effectPhase instanceof MoveEffectPhase && effectPhase.move.getMove().hasFlag(MoveFlags.MAKES_CONTACT)) {
         const attacker = effectPhase.getPokemon();
-        attacker.damageAndUpdate(Math.ceil(attacker.getMaxHp() * (1 / this.damageRatio)), HitResult.OTHER);
+        if (!attacker.hasAbilityWithAttr(BlockNonDirectDamageAbAttr)) {
+          attacker.damageAndUpdate(Math.ceil(attacker.getMaxHp() * (1 / this.damageRatio)), HitResult.OTHER);
+        }
       }
     }
 


### PR DESCRIPTION
## What are the changes?
Pokemon with Magic Guard should be immune to Spiky Shield damage post-contact. 

## Why am I doing these changes?
Extension of this PR - https://github.com/pagefaultgames/pokerogue/pull/2793
I didn't realize that Spiky Shield wasn't covered by Magic Guard, my bad!

## What did change?
ContactDamageProtectedTag now checks if the attacking pokemon's current ability has a BlockNonDirectDamageAbAttr before applying damage.

### Screenshots/Videos
Bulbasaur with Magic Guard + Tailow with Spiky Shield
https://github.com/pagefaultgames/pokerogue/assets/171087428/f29d7766-6549-423c-b75e-77b7c9f8da92

## How to test the changes?
I used overrides to force a testable scenario. 
![image](https://github.com/pagefaultgames/pokerogue/assets/171087428/93b4d9ef-76b9-425e-9f6a-847d7dc89c0e)

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Have I provided screenshots/videos of the changes?