### PR TITLE
[Localization] Localize 'attack missed!' message and translate in Korean

### DIFF
--- a/src/locales/de/battle.ts
+++ b/src/locales/de/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "Es hat keine Wirkung auf {{pokemonName}}…",
   "hitResultOneHitKO": "Ein K.O.-Treffer!",
   "attackFailed": "Es ist fehlgeschlagen!",
+  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
   "attackHitsCount": "{{count}}-mal getroffen!",
   "rewardGain": "Du erhältst\n{{modifierName}}!",
   "expGain": "{{pokemonName}} erhält\n{{exp}} Erfahrungspunkte!",

--- a/src/locales/en/battle.ts
+++ b/src/locales/en/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "It doesn't affect {{pokemonName}}!",
   "hitResultOneHitKO": "It's a one-hit KO!",
   "attackFailed": "But it failed!",
+  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
   "attackHitsCount": "Hit {{count}} time(s)!",
   "rewardGain": "You received\n{{modifierName}}!",
   "expGain": "{{pokemonName}} gained\n{{exp}} EXP. Points!",

--- a/src/locales/es/battle.ts
+++ b/src/locales/es/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "No afecta a {{pokemonName}}!",
   "hitResultOneHitKO": "¡KO en 1 golpe!",
   "attackFailed": "¡Pero ha fallado!",
+  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
   "attackHitsCount": "N.º de golpes: {{count}}.",
   "rewardGain": "¡Has obtenido\n{{modifierName}}!",
   "expGain": "{{pokemonName}} ha ganado\n{{exp}} puntos de experiencia.",

--- a/src/locales/fr/battle.ts
+++ b/src/locales/fr/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "Ça n’affecte pas {{pokemonName}}…",
   "hitResultOneHitKO": "K.O. en un coup !",
   "attackFailed": "Mais cela échoue !",
+  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
   "attackHitsCount": "Touché {{count}} fois !",
   "rewardGain": "Vous recevez\n{{modifierName}} !",
   "expGain": "{{pokemonName}} gagne\n{{exp}} Points d’Exp !",

--- a/src/locales/it/battle.ts
+++ b/src/locales/it/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "Non ha effetto su {{pokemonName}}!",
   "hitResultOneHitKO": "KO con un colpo!",
   "attackFailed": "Ma ha fallito!",
+  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
   "attackHitsCount": "Colpito {{count}} volta/e!",
   "rewardGain": "You received\n{{modifierName}}!",
   "expGain": "{{pokemonName}} ha guadagnato\n{{exp}} Punti Esperienza!",

--- a/src/locales/ko/battle.ts
+++ b/src/locales/ko/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "{{pokemonName}}에게는\n효과가 없는 것 같다…",
   "hitResultOneHitKO": "일격필살!",
   "attackFailed": "그러나 실패하고 말았다!!",
+  "attackMissed": "{{pokemonNameWithAffix}}의\n공격이 빗나갔다!",
   "attackHitsCount": "{{count}}번 맞았다!",
   "rewardGain": "{{modifierName}}[[를]] 받았다!",
   "expGain": "{{pokemonName}}[[는]]\n{{exp}} 경험치를 얻었다!",

--- a/src/locales/pt_BR/battle.ts
+++ b/src/locales/pt_BR/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "Isso não afeta {{pokemonName}}!",
   "hitResultOneHitKO": "Foi um nocaute de um golpe!",
   "attackFailed": "Mas falhou!",
+  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
   "attackHitsCount": "Acertou {{count}} vezes.",
   "rewardGain": "Você recebeu\n{{modifierName}}!",
   "expGain": "{{pokemonName}} ganhou\n{{exp}} pontos de experiência.",

--- a/src/locales/zh_CN/battle.ts
+++ b/src/locales/zh_CN/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "对{{pokemonName}}没有效果！！",
   "hitResultOneHitKO": "一击必杀！",
   "attackFailed": "但是失败了！",
+  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
   "attackHitsCount": "击中{{count}}次！",
   "rewardGain": "你获得了\n{{modifierName}}！",
   "expGain": "{{pokemonName}}获得了 {{exp}} 点经验值！",

--- a/src/locales/zh_TW/battle.ts
+++ b/src/locales/zh_TW/battle.ts
@@ -22,6 +22,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "對 {{pokemonName}} 沒有效果！",
   "hitResultOneHitKO": "一擊切殺！",
   "attackFailed": "但是失敗了！",
+  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
   "attackHitsCount": "擊中 {{count}} 次！",
   "rewardGain": "You received\n{{modifierName}}!",
   "expGain": "{{pokemonName}} 獲得了 {{exp}} 經驗值！",

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2894,7 +2894,7 @@ export class MoveEffectPhase extends PokemonPhase {
       if (!activeTargets.length || (!move.hasAttr(VariableTargetAttr) && !move.isMultiTarget() && !targetHitChecks[this.targets[0]])) {
         this.stopMultiHit();
         if (activeTargets.length) {
-          this.scene.queueMessage(getPokemonMessage(user, "'s\nattack missed!"));
+          this.scene.queueMessage(i18next.t("battle:attackMissed", { pokemonNameWithAffix: getPokemonNameWithAffix(user) }));
           moveHistoryEntry.result = MoveResult.MISS;
           applyMoveAttrs(MissEffectAttr, user, null, move);
         } else {
@@ -2912,7 +2912,7 @@ export class MoveEffectPhase extends PokemonPhase {
         for (const target of targets) {
           if (!targetHitChecks[target.getBattlerIndex()]) {
             this.stopMultiHit(target);
-            this.scene.queueMessage(getPokemonMessage(user, "'s\nattack missed!"));
+            this.scene.queueMessage(i18next.t("battle:attackMissed", { pokemonNameWithAffix: getPokemonNameWithAffix(user) }));
             if (moveHistoryEntry.result === MoveResult.PENDING) {
               moveHistoryEntry.result = MoveResult.MISS;
             }


### PR DESCRIPTION
## What are the changes?
Add the option to localize message text when pokemon's attack missed.

## Why am I doing these changes?
All text should be localizable and I don't want to show message with mixed language.

## What did change?
 - Change the code for localize (2 lines)
 - Added localization key in each language folders.
 - Translated it to Korean.

### Screenshots/Videos
TBD (After review of translation team)

## How to test the changes?
Manually.

## Checklist
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?