### PR TITLE
[Localization] Attack missed text is now localizable and uses the Gen 9 format instead of Gen 4 like before

### DIFF
--- a/src/locales/de/battle.ts
+++ b/src/locales/de/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "Es hat keine Wirkung auf {{pokemonName}}…",
   "hitResultOneHitKO": "Ein K.O.-Treffer!",
   "attackFailed": "Es ist fehlgeschlagen!",
-  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
+  "attackMissed": "Attacke von {{pokemonNameWithAffix}} ging daneben!",
   "attackHitsCount": "{{count}}-mal getroffen!",
   "rewardGain": "Du erhältst\n{{modifierName}}!",
   "expGain": "{{pokemonName}} erhält\n{{exp}} Erfahrungspunkte!",

--- a/src/locales/de/battle.ts
+++ b/src/locales/de/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "Es hat keine Wirkung auf {{pokemonName}}…",
   "hitResultOneHitKO": "Ein K.O.-Treffer!",
   "attackFailed": "Es ist fehlgeschlagen!",
+  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
   "attackHitsCount": "{{count}}-mal getroffen!",
   "rewardGain": "Du erhältst\n{{modifierName}}!",
   "expGain": "{{pokemonName}} erhält\n{{exp}} Erfahrungspunkte!",

--- a/src/locales/de/battle.ts
+++ b/src/locales/de/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "Es hat keine Wirkung auf {{pokemonName}}…",
   "hitResultOneHitKO": "Ein K.O.-Treffer!",
   "attackFailed": "Es ist fehlgeschlagen!",
-  "attackMissed": "Attacke von {{pokemonNameWithAffix}} ging daneben!",
+  "attackMissed": "Die Attacke hat {{pokemonNameWithAffix}} verfehlt!",
   "attackHitsCount": "{{count}}-mal getroffen!",
   "rewardGain": "Du erhältst\n{{modifierName}}!",
   "expGain": "{{pokemonName}} erhält\n{{exp}} Erfahrungspunkte!",

--- a/src/locales/en/battle.ts
+++ b/src/locales/en/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "It doesn't affect {{pokemonName}}!",
   "hitResultOneHitKO": "It's a one-hit KO!",
   "attackFailed": "But it failed!",
+  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
   "attackHitsCount": "Hit {{count}} time(s)!",
   "rewardGain": "You received\n{{modifierName}}!",
   "expGain": "{{pokemonName}} gained\n{{exp}} EXP. Points!",

--- a/src/locales/en/battle.ts
+++ b/src/locales/en/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "It doesn't affect {{pokemonName}}!",
   "hitResultOneHitKO": "It's a one-hit KO!",
   "attackFailed": "But it failed!",
-  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
+  "attackMissed": "{{pokemonNameWithAffix}} avoided the attack!",
   "attackHitsCount": "Hit {{count}} time(s)!",
   "rewardGain": "You received\n{{modifierName}}!",
   "expGain": "{{pokemonName}} gained\n{{exp}} EXP. Points!",

--- a/src/locales/es/battle.ts
+++ b/src/locales/es/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "No afecta a {{pokemonName}}!",
   "hitResultOneHitKO": "¡KO en 1 golpe!",
   "attackFailed": "¡Pero ha fallado!",
-  "attackMissed": "{{pokemonNameWithAffix}} avoided the attack!",
+  "attackMissed": "¡{{pokemonNameWithAffix}}\nha evitado el ataque!",
   "attackHitsCount": "N.º de golpes: {{count}}.",
   "rewardGain": "¡Has obtenido\n{{modifierName}}!",
   "expGain": "{{pokemonName}} ha ganado\n{{exp}} puntos de experiencia.",

--- a/src/locales/es/battle.ts
+++ b/src/locales/es/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "No afecta a {{pokemonName}}!",
   "hitResultOneHitKO": "¡KO en 1 golpe!",
   "attackFailed": "¡Pero ha fallado!",
-  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
+  "attackMissed": "{{pokemonNameWithAffix}} avoided the attack!",
   "attackHitsCount": "N.º de golpes: {{count}}.",
   "rewardGain": "¡Has obtenido\n{{modifierName}}!",
   "expGain": "{{pokemonName}} ha ganado\n{{exp}} puntos de experiencia.",

--- a/src/locales/es/battle.ts
+++ b/src/locales/es/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "No afecta a {{pokemonName}}!",
   "hitResultOneHitKO": "¡KO en 1 golpe!",
   "attackFailed": "¡Pero ha fallado!",
+  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
   "attackHitsCount": "N.º de golpes: {{count}}.",
   "rewardGain": "¡Has obtenido\n{{modifierName}}!",
   "expGain": "{{pokemonName}} ha ganado\n{{exp}} puntos de experiencia.",

--- a/src/locales/fr/battle.ts
+++ b/src/locales/fr/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "Ça n’affecte pas {{pokemonName}}…",
   "hitResultOneHitKO": "K.O. en un coup !",
   "attackFailed": "Mais cela échoue !",
-  "attackMissed": "{{pokemonNameWithAffix}} avoided the attack!",
+  "attackMissed": "{{pokemonNameWithAffix}}\névite l’attaque !",
   "attackHitsCount": "Touché {{count}} fois !",
   "rewardGain": "Vous recevez\n{{modifierName}} !",
   "expGain": "{{pokemonName}} gagne\n{{exp}} Points d’Exp !",

--- a/src/locales/fr/battle.ts
+++ b/src/locales/fr/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "Ça n’affecte pas {{pokemonName}}…",
   "hitResultOneHitKO": "K.O. en un coup !",
   "attackFailed": "Mais cela échoue !",
-  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
+  "attackMissed": "{{pokemonNameWithAffix}}\nrate son attaque !",
   "attackHitsCount": "Touché {{count}} fois !",
   "rewardGain": "Vous recevez\n{{modifierName}} !",
   "expGain": "{{pokemonName}} gagne\n{{exp}} Points d’Exp !",

--- a/src/locales/fr/battle.ts
+++ b/src/locales/fr/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "Ça n’affecte pas {{pokemonName}}…",
   "hitResultOneHitKO": "K.O. en un coup !",
   "attackFailed": "Mais cela échoue !",
+  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
   "attackHitsCount": "Touché {{count}} fois !",
   "rewardGain": "Vous recevez\n{{modifierName}} !",
   "expGain": "{{pokemonName}} gagne\n{{exp}} Points d’Exp !",

--- a/src/locales/fr/battle.ts
+++ b/src/locales/fr/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "Ça n’affecte pas {{pokemonName}}…",
   "hitResultOneHitKO": "K.O. en un coup !",
   "attackFailed": "Mais cela échoue !",
-  "attackMissed": "{{pokemonNameWithAffix}}\nrate son attaque !",
+  "attackMissed": "{{pokemonNameWithAffix}} avoided the attack!",
   "attackHitsCount": "Touché {{count}} fois !",
   "rewardGain": "Vous recevez\n{{modifierName}} !",
   "expGain": "{{pokemonName}} gagne\n{{exp}} Points d’Exp !",

--- a/src/locales/it/battle.ts
+++ b/src/locales/it/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "Non ha effetto su {{pokemonName}}!",
   "hitResultOneHitKO": "KO con un colpo!",
   "attackFailed": "Ma ha fallito!",
-  "attackMissed": "{{pokemonNameWithAffix}} avoided the attack!",
+  "attackMissed": "{{pokemonNameWithAffix}}\nevita l’attacco!",
   "attackHitsCount": "Colpito {{count}} volta/e!",
   "rewardGain": "You received\n{{modifierName}}!",
   "expGain": "{{pokemonName}} ha guadagnato\n{{exp}} Punti Esperienza!",

--- a/src/locales/it/battle.ts
+++ b/src/locales/it/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "Non ha effetto su {{pokemonName}}!",
   "hitResultOneHitKO": "KO con un colpo!",
   "attackFailed": "Ma ha fallito!",
+  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
   "attackHitsCount": "Colpito {{count}} volta/e!",
   "rewardGain": "You received\n{{modifierName}}!",
   "expGain": "{{pokemonName}} ha guadagnato\n{{exp}} Punti Esperienza!",

--- a/src/locales/it/battle.ts
+++ b/src/locales/it/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "Non ha effetto su {{pokemonName}}!",
   "hitResultOneHitKO": "KO con un colpo!",
   "attackFailed": "Ma ha fallito!",
-  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
+  "attackMissed": "{{pokemonNameWithAffix}} avoided the attack!",
   "attackHitsCount": "Colpito {{count}} volta/e!",
   "rewardGain": "You received\n{{modifierName}}!",
   "expGain": "{{pokemonName}} ha guadagnato\n{{exp}} Punti Esperienza!",

--- a/src/locales/ko/battle.ts
+++ b/src/locales/ko/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "{{pokemonName}}에게는\n효과가 없는 것 같다…",
   "hitResultOneHitKO": "일격필살!",
   "attackFailed": "그러나 실패하고 말았다!!",
-  "attackMissed": "{{pokemonNameWithAffix}} avoided the attack!",
+  "attackMissed": "{{pokemonNameWithAffix}}에게는\n맞지 않았다!",
   "attackHitsCount": "{{count}}번 맞았다!",
   "rewardGain": "{{modifierName}}[[를]] 받았다!",
   "expGain": "{{pokemonName}}[[는]]\n{{exp}} 경험치를 얻었다!",

--- a/src/locales/ko/battle.ts
+++ b/src/locales/ko/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "{{pokemonName}}에게는\n효과가 없는 것 같다…",
   "hitResultOneHitKO": "일격필살!",
   "attackFailed": "그러나 실패하고 말았다!!",
+  "attackMissed": "{{pokemonNameWithAffix}}의\n공격이 빗나갔다!",
   "attackHitsCount": "{{count}}번 맞았다!",
   "rewardGain": "{{modifierName}}[[를]] 받았다!",
   "expGain": "{{pokemonName}}[[는]]\n{{exp}} 경험치를 얻었다!",

--- a/src/locales/ko/battle.ts
+++ b/src/locales/ko/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "{{pokemonName}}에게는\n효과가 없는 것 같다…",
   "hitResultOneHitKO": "일격필살!",
   "attackFailed": "그러나 실패하고 말았다!!",
-  "attackMissed": "그러나 {{pokemonNameWithAffix}}의\n공격은 빗나갔다!",
+  "attackMissed": "{{pokemonNameWithAffix}} avoided the attack!",
   "attackHitsCount": "{{count}}번 맞았다!",
   "rewardGain": "{{modifierName}}[[를]] 받았다!",
   "expGain": "{{pokemonName}}[[는]]\n{{exp}} 경험치를 얻었다!",

--- a/src/locales/ko/battle.ts
+++ b/src/locales/ko/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "{{pokemonName}}에게는\n효과가 없는 것 같다…",
   "hitResultOneHitKO": "일격필살!",
   "attackFailed": "그러나 실패하고 말았다!!",
-  "attackMissed": "{{pokemonNameWithAffix}}의\n공격이 빗나갔다!",
+  "attackMissed": "그러나 {{pokemonNameWithAffix}}의\n공격은 빗나갔다!",
   "attackHitsCount": "{{count}}번 맞았다!",
   "rewardGain": "{{modifierName}}[[를]] 받았다!",
   "expGain": "{{pokemonName}}[[는]]\n{{exp}} 경험치를 얻었다!",

--- a/src/locales/pt_BR/battle.ts
+++ b/src/locales/pt_BR/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "Isso não afeta {{pokemonName}}!",
   "hitResultOneHitKO": "Foi um nocaute de um golpe!",
   "attackFailed": "Mas falhou!",
-  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
+  "attackMissed": "{{pokemonNameWithAffix}} errou\nseu ataque!",
   "attackHitsCount": "Acertou {{count}} vezes.",
   "rewardGain": "Você recebeu\n{{modifierName}}!",
   "expGain": "{{pokemonName}} ganhou\n{{exp}} pontos de experiência.",

--- a/src/locales/pt_BR/battle.ts
+++ b/src/locales/pt_BR/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "Isso não afeta {{pokemonName}}!",
   "hitResultOneHitKO": "Foi um nocaute de um golpe!",
   "attackFailed": "Mas falhou!",
-  "attackMissed": "{{pokemonNameWithAffix}} avoided the attack!",
+  "attackMissed": "{{pokemonNameWithAffix}} desviou do ataque!",
   "attackHitsCount": "Acertou {{count}} vezes.",
   "rewardGain": "Você recebeu\n{{modifierName}}!",
   "expGain": "{{pokemonName}} ganhou\n{{exp}} pontos de experiência.",

--- a/src/locales/pt_BR/battle.ts
+++ b/src/locales/pt_BR/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "Isso não afeta {{pokemonName}}!",
   "hitResultOneHitKO": "Foi um nocaute de um golpe!",
   "attackFailed": "Mas falhou!",
-  "attackMissed": "{{pokemonNameWithAffix}} errou\nseu ataque!",
+  "attackMissed": "{{pokemonNameWithAffix}} avoided the attack!",
   "attackHitsCount": "Acertou {{count}} vezes.",
   "rewardGain": "Você recebeu\n{{modifierName}}!",
   "expGain": "{{pokemonName}} ganhou\n{{exp}} pontos de experiência.",

--- a/src/locales/pt_BR/battle.ts
+++ b/src/locales/pt_BR/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "Isso não afeta {{pokemonName}}!",
   "hitResultOneHitKO": "Foi um nocaute de um golpe!",
   "attackFailed": "Mas falhou!",
+  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
   "attackHitsCount": "Acertou {{count}} vezes.",
   "rewardGain": "Você recebeu\n{{modifierName}}!",
   "expGain": "{{pokemonName}} ganhou\n{{exp}} pontos de experiência.",

--- a/src/locales/zh_CN/battle.ts
+++ b/src/locales/zh_CN/battle.ts
@@ -25,6 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "对{{pokemonName}}没有效果！！",
   "hitResultOneHitKO": "一击必杀！",
   "attackFailed": "但是失败了！",
+  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
   "attackHitsCount": "击中{{count}}次！",
   "rewardGain": "你获得了\n{{modifierName}}！",
   "expGain": "{{pokemonName}}获得了 {{exp}} 点经验值！",

--- a/src/locales/zh_CN/battle.ts
+++ b/src/locales/zh_CN/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "对{{pokemonName}}没有效果！！",
   "hitResultOneHitKO": "一击必杀！",
   "attackFailed": "但是失败了！",
-  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
+  "attackMissed": "{{pokemonNameWithAffix}} avoided the attack!",
   "attackHitsCount": "击中{{count}}次！",
   "rewardGain": "你获得了\n{{modifierName}}！",
   "expGain": "{{pokemonName}}获得了 {{exp}} 点经验值！",

--- a/src/locales/zh_CN/battle.ts
+++ b/src/locales/zh_CN/battle.ts
@@ -25,7 +25,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "对{{pokemonName}}没有效果！！",
   "hitResultOneHitKO": "一击必杀！",
   "attackFailed": "但是失败了！",
-  "attackMissed": "{{pokemonNameWithAffix}} avoided the attack!",
+  "attackMissed": "没有命中{{pokemonNameWithAffix}}！",
   "attackHitsCount": "击中{{count}}次！",
   "rewardGain": "你获得了\n{{modifierName}}！",
   "expGain": "{{pokemonName}}获得了 {{exp}} 点经验值！",

--- a/src/locales/zh_TW/battle.ts
+++ b/src/locales/zh_TW/battle.ts
@@ -22,7 +22,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "對 {{pokemonName}} 沒有效果！",
   "hitResultOneHitKO": "一擊切殺！",
   "attackFailed": "但是失敗了！",
-  "attackMissed": "{{pokemonNameWithAffix}} avoided the attack!",
+  "attackMissed": "沒有命中{{pokemonNameWithAffix}}！",
   "attackHitsCount": "擊中 {{count}} 次！",
   "rewardGain": "You received\n{{modifierName}}!",
   "expGain": "{{pokemonName}} 獲得了 {{exp}} 經驗值！",

--- a/src/locales/zh_TW/battle.ts
+++ b/src/locales/zh_TW/battle.ts
@@ -22,6 +22,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "對 {{pokemonName}} 沒有效果！",
   "hitResultOneHitKO": "一擊切殺！",
   "attackFailed": "但是失敗了！",
+  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
   "attackHitsCount": "擊中 {{count}} 次！",
   "rewardGain": "You received\n{{modifierName}}!",
   "expGain": "{{pokemonName}} 獲得了 {{exp}} 經驗值！",

--- a/src/locales/zh_TW/battle.ts
+++ b/src/locales/zh_TW/battle.ts
@@ -22,7 +22,7 @@ export const battle: SimpleTranslationEntries = {
   "hitResultNoEffect": "對 {{pokemonName}} 沒有效果！",
   "hitResultOneHitKO": "一擊切殺！",
   "attackFailed": "但是失敗了！",
-  "attackMissed": "{{pokemonNameWithAffix}}'s\nattack missed!",
+  "attackMissed": "{{pokemonNameWithAffix}} avoided the attack!",
   "attackHitsCount": "擊中 {{count}} 次！",
   "rewardGain": "You received\n{{modifierName}}!",
   "expGain": "{{pokemonName}} 獲得了 {{exp}} 經驗值！",

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2894,10 +2894,7 @@ export class MoveEffectPhase extends PokemonPhase {
       if (!activeTargets.length || (!move.hasAttr(VariableTargetAttr) && !move.isMultiTarget() && !targetHitChecks[this.targets[0]])) {
         this.stopMultiHit();
         if (activeTargets.length) {
-
           this.scene.queueMessage(i18next.t("battle:attackMissed", { pokemonNameWithAffix: getPokemonNameWithAffix(this.getTarget()) }));
-
-
           moveHistoryEntry.result = MoveResult.MISS;
           applyMoveAttrs(MissEffectAttr, user, null, move);
         } else {

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2894,7 +2894,10 @@ export class MoveEffectPhase extends PokemonPhase {
       if (!activeTargets.length || (!move.hasAttr(VariableTargetAttr) && !move.isMultiTarget() && !targetHitChecks[this.targets[0]])) {
         this.stopMultiHit();
         if (activeTargets.length) {
-          this.scene.queueMessage(i18next.t("battle:attackMissed", { pokemonNameWithAffix: getPokemonNameWithAffix(user) }));
+
+          this.scene.queueMessage(i18next.t("battle:attackMissed", { pokemonNameWithAffix: getPokemonNameWithAffix(this.getTarget()) }));
+
+
           moveHistoryEntry.result = MoveResult.MISS;
           applyMoveAttrs(MissEffectAttr, user, null, move);
         } else {
@@ -2912,7 +2915,7 @@ export class MoveEffectPhase extends PokemonPhase {
         for (const target of targets) {
           if (!targetHitChecks[target.getBattlerIndex()]) {
             this.stopMultiHit(target);
-            this.scene.queueMessage(i18next.t("battle:attackMissed", { pokemonNameWithAffix: getPokemonNameWithAffix(user) }));
+            this.scene.queueMessage(i18next.t("battle:attackMissed", { pokemonNameWithAffix: getPokemonNameWithAffix(target) }));
             if (moveHistoryEntry.result === MoveResult.PENDING) {
               moveHistoryEntry.result = MoveResult.MISS;
             }

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2894,7 +2894,7 @@ export class MoveEffectPhase extends PokemonPhase {
       if (!activeTargets.length || (!move.hasAttr(VariableTargetAttr) && !move.isMultiTarget() && !targetHitChecks[this.targets[0]])) {
         this.stopMultiHit();
         if (activeTargets.length) {
-          this.scene.queueMessage(getPokemonMessage(user, "'s\nattack missed!"));
+          this.scene.queueMessage(i18next.t("battle:attackMissed", { pokemonNameWithAffix: getPokemonNameWithAffix(user) }));
           moveHistoryEntry.result = MoveResult.MISS;
           applyMoveAttrs(MissEffectAttr, user, null, move);
         } else {
@@ -2912,7 +2912,7 @@ export class MoveEffectPhase extends PokemonPhase {
         for (const target of targets) {
           if (!targetHitChecks[target.getBattlerIndex()]) {
             this.stopMultiHit(target);
-            this.scene.queueMessage(getPokemonMessage(user, "'s\nattack missed!"));
+            this.scene.queueMessage(i18next.t("battle:attackMissed", { pokemonNameWithAffix: getPokemonNameWithAffix(user) }));
             if (moveHistoryEntry.result === MoveResult.PENDING) {
               moveHistoryEntry.result = MoveResult.MISS;
             }


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
It now uses the Gen 9 Format of "attackMissed". (Showing which pokemon was missed). Also localizable

Line from the orignal games:
https://abcboy101.github.io/poke-corpus/#id=sv.btl_set.BTL_STRID_SET_WazaAvoid


## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Because we in the wiki discord agreed that localizing the Gen 4 Message was not what we wanted.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
See Video

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

Before:

https://github.com/pagefaultgames/pokerogue/assets/38758606/df45c8a2-a811-405e-969c-f846779273c0


After: 

https://github.com/pagefaultgames/pokerogue/assets/38758606/c5222d9e-15d2-41ed-8906-6b3be3a22dad


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Use a KO-Move for the single target. 
For Multi Target set accuracy for earth quake for example to 1

## Checklist
- [x] There is no overlap with another PR?
  - Only with https://github.com/pagefaultgames/pokerogue/pull/2806 which was closed 
- [x] The PR is self-contained and cannot be split into smaller PRs?
  - Technically yes. But its pointless to split this up in 2 (making it localizable and the localization itself)
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?