### PR TITLE
[Bug] fixing game breaking u-turn faint switch interaction

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -67,7 +67,7 @@ import { Species } from "#enums/species";
 import { UiTheme } from "#enums/ui-theme";
 import { TimedEventManager } from "#app/timed-event-manager.js";
 
-export const bypassLogin = true;
+export const bypassLogin = import.meta.env.VITE_BYPASS_LOGIN === "1";
 
 const DEBUG_RNG = false;
 
@@ -180,10 +180,8 @@ export default class BattleScene extends SceneBase {
 
   public phaseQueue: Phase[];
   public conditionalQueue: Array<[() => boolean, Phase]>;
-  public phaseQueuePrepend: Phase[];
-
-  public phaseQueuePrependSpliceIndex: integer;
-
+  private phaseQueuePrepend: Phase[];
+  private phaseQueuePrependSpliceIndex: integer;
   private nextCommandPhaseQueue: Phase[];
   private currentPhase: Phase;
   private standbyPhase: Phase;

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2065,26 +2065,23 @@ export default class BattleScene extends SceneBase {
   }
 
   /**
-   * Tries to add the input phase to right before the MoveEndPhase, useful for resolving moves before the end-of-turn phases start
+   * Tries to add the input phase to index before target phase in the phaseQueue, else simply calls unshiftPhase()
    * @param phase {@linkcode Phase} the phase to be added
-   * @returns boolean if a MoveEndPhase was found
+   * @param targetPhase {@linkcode Phase} the type of phase to search for in phaseQueue
+   * @returns boolean if a targetPhase was found and added
    */
-  prependToMoveEndPhase(phase: Phase): boolean {
-    let flag = false;
-    // want to add the pahse after MoveEnd of U-turn? so it can ge the effects of whatever
-    for (let i = 0; i < this.phaseQueue.length; i++) {
-      if (this.phaseQueue[i].constructor.name === "MoveEndPhase") {
-        this.phaseQueue.splice(i, 0, phase);
-        flag = true;
-        break;
-      }
-    }
-    if (flag === false) {
-      // what to do here if there is none?
-      // it should be the case that during combat there is always a MoveEndPhase when a move is being used, extensive testing/reasoning needed
+  prependToPhase(phase: Phase, targetPhase: Constructor<Phase>): boolean {
+    // want to add the target phase before the targetPhase
+    const targetIndex = this.phaseQueue.findIndex(ph => ph instanceof targetPhase);
+
+    // targetIndex === 1 iff findIndex() can't find a phase matching targetPhase
+    if (targetIndex !== -1) {
+      this.phaseQueue.splice(targetIndex, 0, phase);
+      return true;
+    } else {
       this.unshiftPhase(phase);
+      return false;
     }
-    return flag;
   }
 
   queueMessage(message: string, callbackDelay?: integer, prompt?: boolean, promptDelay?: integer, defer?: boolean) {

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -4497,6 +4497,7 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
 	  if (switchOutTarget instanceof PlayerPokemon) {
 	  	if (switchOutTarget.hp) {
 	  	  applyPreSwitchOutAbAttrs(PreSwitchOutAbAttr, switchOutTarget);
+          // switchOut below sets the UI to select party(this is not a separate Phase), then adds a SwitchSummonPhase with selected 'mon
 	  	  (switchOutTarget as PlayerPokemon).switchOut(this.batonPass, true).then(() => resolve(true));
 	  	} else {
           resolve(false);
@@ -4512,7 +4513,8 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
 	  	user.scene.triggerPokemonFormChange(switchOutTarget, SpeciesFormChangeActiveTrigger, true);
 
 	  	if (switchOutTarget.hp) {
-          user.scene.unshiftPhase(new SwitchSummonPhase(user.scene, switchOutTarget.getFieldIndex(), user.scene.currentBattle.trainer.getNextSummonIndex((switchOutTarget as EnemyPokemon).trainerSlot), false, this.batonPass, false));
+        // for opponent switching out
+          user.scene.prependToMoveEndPhase(new SwitchSummonPhase(user.scene, switchOutTarget.getFieldIndex(), user.scene.currentBattle.trainer.getNextSummonIndex((switchOutTarget as EnemyPokemon).trainerSlot), false, this.batonPass, false));
         }
 	  } else {
 	    // Switch out logic for everything else

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1,5 +1,5 @@
 import { ChargeAnim, MoveChargeAnim, initMoveAnim, loadMoveAnimAssets } from "./battle-anims";
-import { BattleEndPhase, MovePhase, NewBattlePhase, PartyStatusCurePhase, PokemonHealPhase, StatChangePhase, SwitchSummonPhase } from "../phases";
+import { BattleEndPhase, MoveEndPhase, MovePhase, NewBattlePhase, PartyStatusCurePhase, PokemonHealPhase, StatChangePhase, SwitchSummonPhase } from "../phases";
 import { BattleStat, getBattleStatName } from "./battle-stat";
 import { EncoreTag, SemiInvulnerableTag } from "./battler-tags";
 import { getPokemonMessage, getPokemonNameWithAffix } from "../messages";
@@ -4514,7 +4514,7 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
 
 	  	if (switchOutTarget.hp) {
         // for opponent switching out
-          user.scene.prependToMoveEndPhase(new SwitchSummonPhase(user.scene, switchOutTarget.getFieldIndex(), user.scene.currentBattle.trainer.getNextSummonIndex((switchOutTarget as EnemyPokemon).trainerSlot), false, this.batonPass, false));
+          user.scene.prependToPhase(new SwitchSummonPhase(user.scene, switchOutTarget.getFieldIndex(), user.scene.currentBattle.trainer.getNextSummonIndex((switchOutTarget as EnemyPokemon).trainerSlot), false, this.batonPass, false), MoveEndPhase);
         }
 	  } else {
 	    // Switch out logic for everything else

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -17,7 +17,7 @@ import { initMoveAnim, loadMoveAnimAssets } from "../data/battle-anims";
 import { Status, StatusEffect, getRandomStatus } from "../data/status-effect";
 import { pokemonEvolutions, pokemonPrevolutions, SpeciesFormEvolution, SpeciesEvolutionCondition, FusionSpeciesFormEvolution } from "../data/pokemon-evolutions";
 import { reverseCompatibleTms, tmSpecies, tmPoolTiers } from "../data/tms";
-import { DamagePhase, FaintPhase, LearnMovePhase, MoveEffectPhase, ObtainStatusEffectPhase, StatChangePhase, SwitchSummonPhase, ToggleDoublePositionPhase  } from "../phases";
+import { DamagePhase, FaintPhase, LearnMovePhase, MoveEffectPhase, ObtainStatusEffectPhase, StatChangePhase, SwitchSummonPhase, ToggleDoublePositionPhase, MoveEndPhase } from "../phases";
 import { BattleStat } from "../data/battle-stat";
 import { BattlerTag, BattlerTagLapseType, EncoreTag, GroundedTag, HelpingHandTag, HighestStatBoostTag, TypeBoostTag, TypeImmuneTag, getBattlerTag } from "../data/battler-tags";
 import { WeatherType } from "../data/weather";
@@ -3095,7 +3095,7 @@ export class PlayerPokemon extends Pokemon {
       this.scene.ui.setMode(Mode.PARTY, PartyUiMode.FAINT_SWITCH, this.getFieldIndex(), (slotIndex: integer, option: PartyOption) => {
         if (slotIndex >= this.scene.currentBattle.getBattlerCount() && slotIndex < 6) {
           // add a SwitchSummonPhase
-          this.scene.prependToMoveEndPhase(new SwitchSummonPhase(this.scene, this.getFieldIndex(), slotIndex, false, batonPass));
+          this.scene.prependToPhase(new SwitchSummonPhase(this.scene, this.getFieldIndex(), slotIndex, false, batonPass), MoveEndPhase);
         }
         if (removeFromField) {
           this.setVisible(false);

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3094,7 +3094,8 @@ export class PlayerPokemon extends Pokemon {
 
       this.scene.ui.setMode(Mode.PARTY, PartyUiMode.FAINT_SWITCH, this.getFieldIndex(), (slotIndex: integer, option: PartyOption) => {
         if (slotIndex >= this.scene.currentBattle.getBattlerCount() && slotIndex < 6) {
-          this.scene.unshiftPhase(new SwitchSummonPhase(this.scene, this.getFieldIndex(), slotIndex, false, batonPass));
+          // add a SwitchSummonPhase
+          this.scene.prependToMoveEndPhase(new SwitchSummonPhase(this.scene, this.getFieldIndex(), slotIndex, false, batonPass));
         }
         if (removeFromField) {
           this.setVisible(false);

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1545,6 +1545,15 @@ export class SwitchSummonPhase extends SummonPhase {
 
   private lastPokemon: Pokemon;
 
+  /**
+   * Constructor for creating a new SwitchSummonPhase
+   * @param scene {@linkcode BattleScene} the scene the phase is associated with
+   * @param fieldIndex integer representing position on the battle field
+   * @param slotIndex integer for the index of pokemon (in party of 6) to switch into
+   * @param doReturn boolean whether to render "comeback" dialogue
+   * @param batonPass boolean if the switch is from baton pass
+   * @param player boolean if the switch is from the player
+   */
   constructor(scene: BattleScene, fieldIndex: integer, slotIndex: integer, doReturn: boolean, batonPass: boolean, player?: boolean) {
     super(scene, fieldIndex, player !== undefined ? player : true);
 
@@ -1568,6 +1577,8 @@ export class SwitchSummonPhase extends SummonPhase {
       }
     }
 
+    // if doReturn === False OR slotIndex !== -1 (slotIndex is valid) and the pokemon doesn't exist/is false
+    // then switchAndSummon(), manually pick pokemon to switch into
     if (!this.doReturn || (this.slotIndex !== -1 && !(this.player ? this.scene.getParty() : this.scene.getEnemyParty())[this.slotIndex])) {
       if (this.player) {
         return this.switchAndSummon();


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
The proper interaction now occurs (using pokemon now faints, and a new one is swapped in).

The dialogue boxes are still out of order from fainting, but hopefully #2743 addresses the problem.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Closes #2680 

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

Currently the `SwitchSummonPhase` is being added in the phase queues' in the wrong order for multi hit moves. It is being added too early (before the `DamagePhase`  and `FaintPhase` of the last multi-hit), which is causing the switch-in faint issue of #2680. I've written a call to add the phase right before the `MoveEndPhase` (which ensures that it wont interfere with anything of the multi-hit move, and the swapped in 'mon is present for the end-of-turn effects such as weather, abilities, field hazards).

I tried playing around with the existing functions, namely playing around with `phaseQueueSpliceIndex` to manipulate the order of the phases being added. The problem with this is that queuing ability-effects related phases also calls `setPhaseQueueSplice()`, which messes up the idea of trying to add all the phases before `SwitchSummonPhase`.


The solution I've come up with relies on the fact that `PhaseQueue` contains a `MoveEndPhase` (since it essentially does a linear search for it). I believe this should always be true, since these force-switches/damages occur during Moves. However this should be tested/confirmed.


### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->



(can look at the `main` branch behavior from the linked issue)

- pr fix:

https://github.com/pagefaultgames/pokerogue/assets/39450497/ba14269c-6395-43ca-8953-de43b007accb

- interaction with weather, abilities:

https://github.com/pagefaultgames/pokerogue/assets/39450497/39bf64a4-0cfb-4968-b14f-5b5b9787d20f

- interaction with hazards:

https://github.com/pagefaultgames/pokerogue/assets/39450497/836ad2a8-83df-4a7a-89dd-f8dc15f66270

- enemy fixes as well


https://github.com/pagefaultgames/pokerogue/assets/39450497/3acd5c45-83fe-4e4c-9174-d902aba2309e


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

3x Multi-Lens, and with the abilities Rough Skin and Iron Barbs gives the fainting from move effect (i used level 5 vs 15 to ensure it faints/survives)

I've only tested all the above with U-turn, we should make sure the other moves which use the ForceSwitch attribute still behave as normal

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [] Have I provided a clear explanation of the changes?
-[x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?