### PR TITLE
[Bugfix] Fix a bug during bgm-bar initialization

### DIFF
--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -493,7 +493,7 @@ export const Setting: Array<Setting> = [
     key: SettingKeys.Show_BGM_Bar,
     label: i18next.t("settings:showBgmBar"),
     options: OFF_ON,
-    default: 0,
+    default: 1,
     type: SettingType.DISPLAY
   },
   {

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -494,8 +494,7 @@ export const Setting: Array<Setting> = [
     label: i18next.t("settings:showBgmBar"),
     options: OFF_ON,
     default: 0,
-    type: SettingType.DISPLAY,
-    requireReload: true
+    type: SettingType.DISPLAY
   },
   {
     key: SettingKeys.Master_Volume,

--- a/src/ui/bgm-bar.ts
+++ b/src/ui/bgm-bar.ts
@@ -45,9 +45,6 @@ export default class BgmBar extends Phaser.GameObjects.Container {
    */
   setBgmToBgmBar(bgmName: string): void {
     this.musicText.setText(`${i18next.t("bgmName:music")}${this.getRealBgmName(bgmName)}`);
-    if (!(this.scene as BattleScene).showBgmBar) {
-      return;
-    }
 
     this.musicText.width = this.bg.width - 20;
     this.musicText.setWordWrapWidth(this.defaultWidth * 4);

--- a/src/ui/settings/abstract-settings-ui-handler.ts
+++ b/src/ui/settings/abstract-settings-ui-handler.ts
@@ -375,6 +375,7 @@ export default class AbstractSettingsUiHandler extends UiHandler {
     super.clear();
     this.settingsContainer.setVisible(false);
     this.eraseCursor();
+    this.getUi().bgmBar.toggleBgmBar(this.scene.showBgmBar);
     if (this.reloadRequired) {
       this.reloadRequired = false;
       this.scene.reset(true, false, true);


### PR DESCRIPTION
## What are the changes?
Found during my previous PR #2603, and pointed out by a user on the Discord [here](https://discord.com/channels/1125469663833370665/1256331738318376960/1256331738318376960)
When the bgm-bar is first initialized, it takes on its maximum size, and remains empty. Most likely a residual behavior from its former mode of operation (when it was supposed to be displayed not only in the pause menu)

## What did change?
I've managed to solve this problem.
I've also made sure that displaying/hiding the bgm-bar is no longer dependent on a reboot.
As well as enabling the bgm-bar by default, as it is now displayed in the pause menu, contrary to what was originally intended when it was disabled by default.

### Screenshots/Videos
> Before
![bgm-bar_before](https://github.com/pagefaultgames/pokerogue/assets/8146474/245fbdb0-4caf-42fa-b4e7-3b4f15cb1ef4)

> After
![bgm-bar_after](https://github.com/pagefaultgames/pokerogue/assets/8146474/ce92af38-1aca-4178-8089-4b837454eb0f)

## How to test the changes?
Activate/deactivate the bgm-bar in the options, and check that the behavior is normal.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?