### PR TITLE
[Enhancement] Add Move Header phase and attributes

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -861,6 +861,47 @@ export class MoveEffectAttr extends MoveAttr {
   }
 }
 
+/**
+ * Base class defining all Move Header attributes.
+ * Move Header effects apply at the beginning of a turn before any moves are resolved.
+ * They can be used to apply effects to the field (e.g. queueing a message) or to the user
+ * (e.g. adding a battler tag).
+ */
+export class MoveHeaderAttr extends MoveAttr {
+  constructor() {
+    super(true);
+  }
+
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean | Promise<boolean> {
+    return true;
+  }
+}
+
+/**
+ * Header attribute to queue a message at the beginning of a turn.
+ * @see {@link MoveHeaderAttr}
+ */
+export class MessageHeaderAttr extends MoveHeaderAttr {
+  private message: string | ((user: Pokemon, move: Move) => string);
+
+  constructor(message: string | ((user: Pokemon, move: Move) => string)) {
+    super();
+    this.message = message;
+  }
+
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    const message = typeof this.message === "string"
+      ? this.message as string
+      : this.message(user, move);
+
+    if (message) {
+      user.scene.queueMessage(message);
+      return true;
+    }
+    return false;
+  }
+}
+
 export class PreMoveMessageAttr extends MoveAttr {
   private message: string | ((user: Pokemon, target: Pokemon, move: Move) => string);
 
@@ -6374,6 +6415,7 @@ export function initMoves() {
         && (user.status.effect === StatusEffect.BURN || user.status.effect === StatusEffect.POISON || user.status.effect === StatusEffect.TOXIC || user.status.effect === StatusEffect.PARALYSIS) ? 2 : 1)
       .attr(BypassBurnDamageReductionAttr),
     new AttackMove(Moves.FOCUS_PUNCH, Type.FIGHTING, MoveCategory.PHYSICAL, 150, 100, 20, -1, -3, 3)
+      .attr(MessageHeaderAttr, (user, move) => getPokemonMessage(user, " is tightening its focus!"))
       .punchingMove()
       .ignoresVirtual()
       .condition((user, target, move) => !user.turnData.attacksReceived.find(r => r.damage)),

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2608,13 +2608,13 @@ export class MoveHeaderPhase extends BattlePhase {
         }
 
         if (activated) {
-          this.scene.queueMessage(getPokemonMessage(this.pokemon, getStatusEffectActivationText(this.pokemon.status.effect)));
+          this.scene.queueMessage(getStatusEffectActivationText(this.pokemon.status.effect, getPokemonNameWithAffix(this.pokemon)));
           this.scene.unshiftPhase(new CommonAnimPhase(this.scene, this.pokemon.getBattlerIndex(), undefined, CommonAnim.POISON + (this.pokemon.status.effect - 1)));
           this.cancelMove();
           this.end();
         } else {
           if (healed) {
-            this.scene.queueMessage(getPokemonMessage(this.pokemon, getStatusEffectHealText(this.pokemon.status.effect)));
+            this.scene.queueMessage(getStatusEffectHealText(this.pokemon.status.effect, getPokemonNameWithAffix(this.pokemon)));
             this.pokemon.resetStatus();
             this.pokemon.updateInfo();
           }

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1,7 +1,7 @@
 import BattleScene, { bypassLogin } from "./battle-scene";
 import { default as Pokemon, PlayerPokemon, EnemyPokemon, PokemonMove, MoveResult, DamageResult, FieldPosition, HitResult, TurnMove } from "./field/pokemon";
 import * as Utils from "./utils";
-import { allMoves, applyMoveAttrs, BypassSleepAttr, ChargeAttr, applyFilteredMoveAttrs, HitsTagAttr, MissEffectAttr, MoveAttr, MoveEffectAttr, MoveFlags, MultiHitAttr, OverrideMoveEffectAttr, VariableAccuracyAttr, MoveTarget, getMoveTargets, MoveTargetSet, MoveEffectTrigger, CopyMoveAttr, AttackMove, SelfStatusMove, PreMoveMessageAttr, HealStatusEffectAttr, IgnoreOpponentStatChangesAttr, NoEffectAttr, BypassRedirectAttr, FixedDamageAttr, PostVictoryStatChangeAttr, OneHitKOAccuracyAttr, ForceSwitchOutAttr, VariableTargetAttr, IncrementMovePriorityAttr } from "./data/move";
+import { allMoves, applyMoveAttrs, BypassSleepAttr, ChargeAttr, applyFilteredMoveAttrs, HitsTagAttr, MissEffectAttr, MoveAttr, MoveEffectAttr, MoveFlags, MultiHitAttr, OverrideMoveEffectAttr, VariableAccuracyAttr, MoveTarget, getMoveTargets, MoveTargetSet, MoveEffectTrigger, CopyMoveAttr, AttackMove, SelfStatusMove, PreMoveMessageAttr, HealStatusEffectAttr, IgnoreOpponentStatChangesAttr, NoEffectAttr, BypassRedirectAttr, FixedDamageAttr, PostVictoryStatChangeAttr, OneHitKOAccuracyAttr, ForceSwitchOutAttr, VariableTargetAttr, IncrementMovePriorityAttr, MoveHeaderAttr } from "./data/move";
 import { Mode } from "./ui/ui";
 import { Command } from "./ui/command-ui-handler";
 import { Stat } from "./data/pokemon-stat";
@@ -2286,6 +2286,7 @@ export class TurnStartPhase extends FieldPhase {
       return aIndex < bIndex ? -1 : aIndex > bIndex ? 1 : 0;
     });
 
+    this.queueMoveHeaders(moveOrder);
     for (const o of moveOrder) {
 
       const pokemon = field[o];
@@ -2356,6 +2357,23 @@ export class TurnStartPhase extends FieldPhase {
     this.scene.pushPhase(new TurnEndPhase(this.scene));
 
     this.end();
+  }
+
+  queueMoveHeaders(moveOrder: BattlerIndex[]): void {
+    moveOrder.forEach(o => {
+      const pokemon = this.scene.getField()[o];
+      const turnCommand = this.scene.currentBattle.turnCommands[o];
+
+      if (turnCommand.command === Command.FIGHT) {
+        const queuedMove = turnCommand.move;
+        if (!!queuedMove) {
+          const move = pokemon.getMoveset().find(m => m.moveId === queuedMove.move) || new PokemonMove(queuedMove.move);
+          if (move.getMove().hasAttr(MoveHeaderAttr)) {
+            this.scene.pushPhase(new MoveHeaderPhase(this.scene, pokemon, move));
+          }
+        }
+      }
+    });
   }
 }
 
@@ -2541,6 +2559,100 @@ export class CommonAnimPhase extends PokemonPhase {
   }
 }
 
+export class MoveHeaderPhase extends BattlePhase {
+  public pokemon: Pokemon;
+  public move: PokemonMove;
+
+  constructor(scene: BattleScene, pokemon: Pokemon, move: PokemonMove) {
+    super(scene);
+
+    this.pokemon = pokemon;
+    this.move = move;
+  }
+
+  canMove(): boolean {
+    return this.pokemon.isActive(true) && this.move.isUsable(this.pokemon, true);
+  }
+
+  start() {
+    super.start();
+
+    if (this.canMove()) {
+      /**
+       * Preemptively apply status effects (Paralysis, Sleep, and Freeze).
+       * If this move would be cancelled by the user's status, it's cancelled
+       * here before applying header effects.
+       * If the user has one of these statuses, but the move isn't cancelled, the same status
+       * check in this move's respective `MovePhase` is ignored.
+       */
+      if (this.pokemon.status && !this.pokemon.status.isPostTurn()) {
+        this.pokemon.status.incrementTurn();
+        let activated = false;
+        let healed = false;
+
+        switch (this.pokemon.status.effect) {
+        case StatusEffect.PARALYSIS:
+          if (!this.pokemon.randSeedInt(4)) {
+            activated = true;
+          }
+          break;
+        case StatusEffect.SLEEP:
+          healed = this.pokemon.status.turnCount === this.pokemon.status.cureTurn;
+          activated = !healed;
+          break;
+        case StatusEffect.FREEZE:
+          healed = !!this.move.getMove().findAttr(attr => attr instanceof HealStatusEffectAttr && attr.selfTarget && attr.isOfEffect(StatusEffect.FREEZE)) || !this.pokemon.randSeedInt(5);
+          activated = !healed;
+          break;
+        }
+
+        if (activated) {
+          this.scene.queueMessage(getPokemonMessage(this.pokemon, getStatusEffectActivationText(this.pokemon.status.effect)));
+          this.scene.unshiftPhase(new CommonAnimPhase(this.scene, this.pokemon.getBattlerIndex(), undefined, CommonAnim.POISON + (this.pokemon.status.effect - 1)));
+          this.cancelMove();
+          this.end();
+        } else {
+          if (healed) {
+            this.scene.queueMessage(getPokemonMessage(this.pokemon, getStatusEffectHealText(this.pokemon.status.effect)));
+            this.pokemon.resetStatus();
+            this.pokemon.updateInfo();
+          }
+          const movePhase = this.scene.findPhase(phase => phase instanceof MovePhase && phase.pokemon === this.pokemon);
+          if (movePhase instanceof MovePhase) {
+            movePhase.setIgnoreStatusCheck();
+          }
+          applyMoveAttrs(MoveHeaderAttr, this.pokemon, null, this.move.getMove()).then(() => this.end());
+        }
+      } else {
+        applyMoveAttrs(MoveHeaderAttr, this.pokemon, null, this.move.getMove()).then(() => this.end());
+      }
+    } else {
+      this.end();
+    }
+  }
+
+  cancelMove(): void {
+    this.pokemon.turnData.acted = true; // Record that the move was attempted
+
+    this.pokemon.lapseTags(BattlerTagLapseType.PRE_MOVE);
+
+    const moveQueue = this.pokemon.getMoveQueue();
+
+    // Record a failed move so Abilities like Truant don't trigger next turn and soft-lock
+    this.pokemon.pushMoveHistory({ move: Moves.NONE, result: MoveResult.FAIL });
+
+    this.pokemon.lapseTags(BattlerTagLapseType.MOVE_EFFECT); // Remove any tags from moves like Fly/Dive/etc.
+    moveQueue.shift(); // Remove the second turn of charge moves
+
+    // Remove the MovePhase from this turn with the same user Pokemon
+    this.scene.tryRemovePhase(phase => phase instanceof MovePhase && phase.pokemon === this.pokemon);
+  }
+
+  end() {
+    super.end();
+  }
+}
+
 export class MovePhase extends BattlePhase {
   public pokemon: Pokemon;
   public move: PokemonMove;
@@ -2549,6 +2661,7 @@ export class MovePhase extends BattlePhase {
   protected ignorePp: boolean;
   protected failed: boolean;
   protected cancelled: boolean;
+  protected ignoreStatusCheck: boolean;
 
   constructor(scene: BattleScene, pokemon: Pokemon, targets: BattlerIndex[], move: PokemonMove, followUp?: boolean, ignorePp?: boolean) {
     super(scene);
@@ -2560,6 +2673,7 @@ export class MovePhase extends BattlePhase {
     this.ignorePp = !!ignorePp;
     this.failed = false;
     this.cancelled = false;
+    this.ignoreStatusCheck = false;
   }
 
   canMove(): boolean {
@@ -2755,7 +2869,7 @@ export class MovePhase extends BattlePhase {
       this.end();
     };
 
-    if (!this.followUp && this.pokemon.status && !this.pokemon.status.isPostTurn()) {
+    if (!this.followUp && this.pokemon.status && !this.pokemon.status.isPostTurn() && !this.ignoreStatusCheck) {
       this.pokemon.status.incrementTurn();
       let activated = false;
       let healed = false;
@@ -2826,6 +2940,10 @@ export class MovePhase extends BattlePhase {
 
   showFailedText(failedText: string = null): void {
     this.scene.queueMessage(failedText || i18next.t("battle:attackFailed"));
+  }
+
+  setIgnoreStatusCheck(): void {
+    this.ignoreStatusCheck = true;
   }
 
   end() {

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2293,6 +2293,7 @@ export class TurnStartPhase extends FieldPhase {
       const turnCommand = this.scene.currentBattle.turnCommands[o];
 
       if (turnCommand.skip) {
+        this.scene.tryRemovePhase(phase => phase instanceof MoveHeaderPhase && phase.pokemon === pokemon);
         continue;
       }
 
@@ -2646,10 +2647,6 @@ export class MoveHeaderPhase extends BattlePhase {
 
     // Remove the MovePhase from this turn with the same user Pokemon
     this.scene.tryRemovePhase(phase => phase instanceof MovePhase && phase.pokemon === this.pokemon);
-  }
-
-  end() {
-    super.end();
   }
 }
 

--- a/src/test/moves/focus_punch.test.ts
+++ b/src/test/moves/focus_punch.test.ts
@@ -1,0 +1,123 @@
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import GameManager from "../utils/gameManager";
+import * as Overrides from "#app/overrides";
+import { Species } from "#enums/species";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { getMovePosition } from "../utils/gameManagerUtils";
+import { BerryPhase, MessagePhase } from "#app/phases.js";
+import { StatusEffect } from "#app/data/status-effect.js";
+
+const TIMEOUT = 20 * 1000;
+
+describe("Moves - Focus Punch", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    vi.spyOn(Overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(Overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.UNNERVE);
+    vi.spyOn(Overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.FOCUS_PUNCH]);
+    vi.spyOn(Overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.GROUDON);
+    vi.spyOn(Overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.INSOMNIA);
+    vi.spyOn(Overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.SPLASH, Moves.SPLASH, Moves.SPLASH]);
+    vi.spyOn(Overrides, "STARTING_LEVEL_OVERRIDE", "get").mockReturnValue(100);
+    vi.spyOn(Overrides, "OPP_LEVEL_OVERRIDE", "get").mockReturnValue(100);
+  });
+
+  test(
+    "move should deal damage at the end of turn if uninterrupted",
+    async () => {
+      await game.startBattle([Species.CHARIZARD]);
+
+      const leadPokemon = game.scene.getPlayerPokemon();
+      expect(leadPokemon).not.toBe(undefined);
+
+      const enemyPokemon = game.scene.getEnemyPokemon();
+      expect(enemyPokemon).not.toBe(undefined);
+
+      const enemyStartingHp = enemyPokemon.hp;
+
+      game.doAttack(getMovePosition(game.scene, 0, Moves.FOCUS_PUNCH));
+
+      await game.phaseInterceptor.to(MessagePhase);
+
+      expect(enemyPokemon.hp).toBe(enemyStartingHp);
+      expect(leadPokemon.getMoveHistory().length).toBe(0);
+
+      await game.phaseInterceptor.to(BerryPhase, false);
+
+      expect(enemyPokemon.hp).toBeLessThan(enemyStartingHp);
+      expect(leadPokemon.getMoveHistory().length).toBe(1);
+      expect(leadPokemon.turnData.damageDealt).toBe(enemyStartingHp - enemyPokemon.hp);
+    }, TIMEOUT
+  );
+
+  test(
+    "move should fail if the user is hit",
+    async () => {
+      vi.spyOn(Overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE]);
+
+      await game.startBattle([Species.CHARIZARD]);
+
+      const leadPokemon = game.scene.getPlayerPokemon();
+      expect(leadPokemon).not.toBe(undefined);
+
+      const enemyPokemon = game.scene.getEnemyPokemon();
+      expect(enemyPokemon).not.toBe(undefined);
+
+      const enemyStartingHp = enemyPokemon.hp;
+
+      game.doAttack(getMovePosition(game.scene, 0, Moves.FOCUS_PUNCH));
+
+      await game.phaseInterceptor.to(MessagePhase);
+
+      expect(enemyPokemon.hp).toBe(enemyStartingHp);
+      expect(leadPokemon.getMoveHistory().length).toBe(0);
+
+      await game.phaseInterceptor.to(BerryPhase, false);
+
+      expect(enemyPokemon.hp).toBe(enemyStartingHp);
+      expect(leadPokemon.getMoveHistory().length).toBe(1);
+      expect(leadPokemon.turnData.damageDealt).toBe(0);
+    }, TIMEOUT
+  );
+
+  test(
+    "move should be cancelled if the user is asleep",
+    async () => {
+      vi.spyOn(Overrides, "STATUS_OVERRIDE", "get").mockReturnValue(StatusEffect.SLEEP);
+
+      await game.startBattle([Species.CHARIZARD]);
+
+      const leadPokemon = game.scene.getPlayerPokemon();
+      expect(leadPokemon).not.toBe(undefined);
+
+      const enemyPokemon = game.scene.getEnemyPokemon();
+      expect(enemyPokemon).not.toBe(undefined);
+
+      game.doAttack(getMovePosition(game.scene, 0, Moves.FOCUS_PUNCH));
+
+      await game.phaseInterceptor.to(MessagePhase);
+
+      expect(leadPokemon.getMoveHistory().length).toBe(1);
+
+      await game.phaseInterceptor.to(BerryPhase, false);
+
+      expect(leadPokemon.getMoveHistory().length).toBe(1);
+      expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
+    }, TIMEOUT
+  );
+});

--- a/src/test/moves/focus_punch.test.ts
+++ b/src/test/moves/focus_punch.test.ts
@@ -120,4 +120,30 @@ describe("Moves - Focus Punch", () => {
       expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
     }, TIMEOUT
   );
+
+  test(
+    "move should be cancelled if the user falls asleep mid-turn",
+    async () => {
+      vi.spyOn(Overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPORE, Moves.SPORE, Moves.SPORE, Moves.SPORE]);
+
+      await game.startBattle([Species.CHARIZARD]);
+
+      const leadPokemon = game.scene.getPlayerPokemon();
+      expect(leadPokemon).toBeDefined();
+
+      const enemyPokemon = game.scene.getEnemyPokemon();
+      expect(enemyPokemon).toBeDefined();
+
+      game.doAttack(getMovePosition(game.scene, 0, Moves.FOCUS_PUNCH));
+
+      await game.phaseInterceptor.to(MessagePhase); // Header message
+
+      expect(leadPokemon.getMoveHistory().length).toBe(0);
+
+      await game.phaseInterceptor.to(BerryPhase, false);
+
+      expect(leadPokemon.getMoveHistory().length).toBe(1);
+      expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
+    }, TIMEOUT
+  );
 });


### PR DESCRIPTION
This adds a new phase, `MoveHeaderPhase`, which takes place before all moves in a turn and applies all the `MoveHeaderAttr` attributes of a move.

At the moment, the only move that uses a Move Header is Focus Punch for its pre-move message, but the intent is to reimplement Beak Blast and Shell Trap using the new phase and attributes.

For more information, see [this branch's PR for the live branch](https://github.com/pagefaultgames/pokerogue/pull/2716).