### PR TITLE
[Localization][ko] Modify Korean 'shiny' and gacha texts to match original

### DIFF
--- a/src/locales/ko/egg.ts
+++ b/src/locales/ko/egg.ts
@@ -22,7 +22,7 @@ export const egg: SimpleTranslationEntries = {
   "hatchFromTheEgg": "알이 부화해서\n{{pokemonName}}[[가]] 태어났다!",
   "eggMoveUnlock": "알 기술 {{moveName}}[[를]]\n사용할 수 있게 되었다!",
   "rareEggMoveUnlock": "레어 알 기술 {{moveName}}[[를]]\n사용할 수 있게 되었다!",
-  "moveUPGacha": "기술 UP!",
-  "shinyUPGacha": "특별색 UP!",
+  "moveUPGacha": "알 기술 UP!",
+  "shinyUPGacha": "색이 다른 포켓몬\nUP!",
   "legendaryUPGacha": "UP!",
 } as const;

--- a/src/locales/ko/settings.ts
+++ b/src/locales/ko/settings.ts
@@ -84,7 +84,7 @@ export const settings: SimpleTranslationEntries = {
   "buttonCancel": "취소",
   "buttonStats": "스탯",
   "buttonCycleForm": "폼 변환",
-  "buttonCycleShiny": "특별한 색 변환",
+  "buttonCycleShiny": "색이 다른 변환",
   "buttonCycleGender": "성별 변환",
   "buttonCycleAbility": "특성 변환",
   "buttonCycleNature": "성격 변환",

--- a/src/locales/ko/starter-select-ui-handler.ts
+++ b/src/locales/ko/starter-select-ui-handler.ts
@@ -32,7 +32,7 @@ export const starterSelectUiHandler: SimpleTranslationEntries = {
   "unlockPassive": "패시브 해금",
   "reduceCost": "코스트 줄이기",
   "sameSpeciesEgg": "알 구매하기",
-  "cycleShiny": ": 특별한 색",
+  "cycleShiny": ": 색이 다른",
   "cycleForm": ": 폼",
   "cycleGender": ": 암수",
   "cycleAbility": ": 특성",

--- a/src/ui/egg-gacha-ui-handler.ts
+++ b/src/ui/egg-gacha-ui-handler.ts
@@ -103,7 +103,7 @@ export default class EggGachaUiHandler extends MessageUiHandler {
       let pokemonIconX = -20;
       let pokemonIconY = 6;
 
-      if (["de", "es", "fr", "pt-BR"].includes(currentLanguage)) {
+      if (["de", "es", "fr", "ko", "pt-BR"].includes(currentLanguage)) {
         gachaTextStyle = TextStyle.SMALLER_WINDOW_ALT;
         gachaX = 2;
         gachaY = 2;
@@ -155,7 +155,7 @@ export default class EggGachaUiHandler extends MessageUiHandler {
         gachaUpLabel.setOrigin(0.5, 0);
         break;
       case GachaType.SHINY:
-        if (["de", "fr"].includes(currentLanguage)) {
+        if (["de", "fr", "ko"].includes(currentLanguage)) {
           gachaUpLabel.setAlign("center");
           gachaUpLabel.setY(0);
         }


### PR DESCRIPTION
## What are the changes?
Changed Korean text 'shiny' and some gacha machine text.

## Why am I doing these changes?
1. Gacha machine text could be resized, so changed the text to be clear for understanding.
2. Modified 'Shiny' translation to be closer to the original game.

## What did change?
1. Changed gacha machine font size, position of text for Korean.
2. Changed 'Shiny' text.

### Screenshots/Videos
1.
![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/e9158b31-70a4-4e39-a43c-bffa00d34eb8)
![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/91b45abf-5298-463b-b9e5-f1924055b27d)
![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/6500162f-9699-4a39-b10b-574efefd5d5b)

2.
![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/8e2ea599-7c4c-4240-91d3-4e12f2b51788)


## How to test the changes?
Manually.
1. Go to 'Egg Gacha' menu from title.
2. Go to 'New Game' and select a Pokémon that has both Normal and Shiny Pokémon registered.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?