### PR TITLE
Type move on pokemon switch

### DIFF
--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -11,6 +11,30 @@ import i18next from "i18next";
 import {Button} from "#enums/buttons";
 import Pokemon, { PokemonMove } from "#app/field/pokemon.js";
 
+/**
+ * Returns a specific move's color based on its type effectiveness against opponents
+ * If there are multiple opponents, the highest effectiveness' color is returned
+ * @returns A color or undefined if the default color should be used
+ */
+export function getMoveColor(pokemon: Pokemon, pokemonMove: PokemonMove): string | undefined {
+  if (!pokemon.scene.typeHints) {
+    return undefined;
+  }
+
+  const opponents = pokemon.getOpponents();
+  if (opponents.length <= 0) {
+    return undefined;
+  }
+
+  const moveColors = opponents.map((opponent) => {
+    return opponent.getMoveEffectiveness(pokemon, pokemonMove);
+  }).sort((a, b) => b - a).map((effectiveness) => {
+    return getTypeDamageMultiplierColor(effectiveness, "offense");
+  });
+
+  return moveColors[0];
+}
+
 export default class FightUiHandler extends UiHandler {
   private movesContainer: Phaser.GameObjects.Container;
   private moveInfoContainer: Phaser.GameObjects.Container;
@@ -249,35 +273,11 @@ export default class FightUiHandler extends UiHandler {
         const pokemonMove = moveset[moveIndex];
         moveText.setText(pokemonMove.getName());
         moveText.setName(pokemonMove.getName());
-        moveText.setColor(this.getMoveColor(pokemon, pokemonMove) ?? moveText.style.color);
+        moveText.setColor(getMoveColor(pokemon, pokemonMove) ?? moveText.style.color);
       }
 
       this.movesContainer.add(moveText);
     }
-  }
-
-  /**
-   * Returns a specific move's color based on its type effectiveness against opponents
-   * If there are multiple opponents, the highest effectiveness' color is returned
-   * @returns A color or undefined if the default color should be used
-   */
-  private getMoveColor(pokemon: Pokemon, pokemonMove: PokemonMove): string | undefined {
-    if (!this.scene.typeHints) {
-      return undefined;
-    }
-
-    const opponents = pokemon.getOpponents();
-    if (opponents.length <= 0) {
-      return undefined;
-    }
-
-    const moveColors = opponents.map((opponent) => {
-      return opponent.getMoveEffectiveness(pokemon, pokemonMove);
-    }).sort((a, b) => b - a).map((effectiveness) => {
-      return getTypeDamageMultiplierColor(effectiveness, "offense");
-    });
-
-    return moveColors[0];
   }
 
   clear() {

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -24,6 +24,7 @@ import i18next from "i18next";
 import {modifierSortFunc} from "../modifier/modifier";
 import { PlayerGender } from "#enums/player-gender";
 import { getMoveColor } from "./fight-ui-handler";
+import Phaser from "phaser";
 
 
 enum Page {
@@ -923,14 +924,17 @@ export default class SummaryUiHandler extends UiHandler {
         const moveRowContainer = this.scene.add.container(0, 16 * m);
         this.moveRowsContainer.add(moveRowContainer);
 
+        let moveColour = TextStyle.SUMMARY;
         if (move) {
           const typeIcon = this.scene.add.sprite(0, 0, `types${Utils.verifyLang(i18next.resolvedLanguage) ? `_${i18next.resolvedLanguage}` : ""}`, Type[move.getMove().type].toLowerCase());          typeIcon.setOrigin(0, 1);
           moveRowContainer.add(typeIcon);
+          const effectiveColour = getMoveColor(this.pokemon, move);
+          if (effectiveColour) {
+            moveColour = effectiveColour;
+          }
         }
 
-        const test = getMoveColor(this.pokemon, move);
-        console.log(test);
-        const moveText = addTextObject(this.scene, 35, 0, move ? move.getName() : "-", TextStyle.SUMMARY);
+        const moveText = addTextObject(this.scene, 35, 0, move ? move.getName() : "-", moveColour);
         moveText.setOrigin(0, 1);
         moveRowContainer.add(moveText);
 

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -6,7 +6,7 @@ import { PlayerPokemon } from "../field/pokemon";
 import { getStarterValueFriendshipCap, speciesStarters } from "../data/pokemon-species";
 import { argbFromRgba } from "@material/material-color-utilities";
 import { Type, getTypeRgb } from "../data/type";
-import { TextStyle, addBBCodeTextObject, addTextObject, getBBCodeFrag } from "./text";
+import { TextStyle, addBBCodeTextObject, addTextObject, getBBCodeFrag, getTextColor } from "./text";
 import Move, { MoveCategory } from "../data/move";
 import { getPokeballAtlasKey } from "../data/pokeball";
 import { getGenderColor, getGenderSymbol } from "../data/gender";
@@ -919,12 +919,14 @@ export default class SummaryUiHandler extends UiHandler {
       this.moveRowsContainer = this.scene.add.container(0, 0);
       this.movesContainer.add(this.moveRowsContainer);
 
+      const uiTheme = (this.scene as BattleScene).uiTheme; // Assuming uiTheme is accessible
+
       for (let m = 0; m < 4; m++) {
         const move = m < this.pokemon.moveset.length ? this.pokemon.moveset[m] : null;
         const moveRowContainer = this.scene.add.container(0, 16 * m);
         this.moveRowsContainer.add(moveRowContainer);
 
-        let moveColour = TextStyle.SUMMARY;
+        let moveColour = getTextColor(TextStyle.SUMMARY, false, uiTheme);
         if (move) {
           const typeIcon = this.scene.add.sprite(0, 0, `types${Utils.verifyLang(i18next.resolvedLanguage) ? `_${i18next.resolvedLanguage}` : ""}`, Type[move.getMove().type].toLowerCase());          typeIcon.setOrigin(0, 1);
           moveRowContainer.add(typeIcon);
@@ -934,7 +936,8 @@ export default class SummaryUiHandler extends UiHandler {
           }
         }
 
-        const moveText = addTextObject(this.scene, 35, 0, move ? move.getName() : "-", moveColour);
+        const moveText = addTextObject(this.scene, 35, 0, move ? move.getName() : "-", TextStyle.SUMMARY);
+        moveText.setColor(moveColour);
         moveText.setOrigin(0, 1);
         moveRowContainer.add(moveText);
 

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -23,6 +23,7 @@ import { Ability } from "../data/ability.js";
 import i18next from "i18next";
 import {modifierSortFunc} from "../modifier/modifier";
 import { PlayerGender } from "#enums/player-gender";
+import { getMoveColor } from "./fight-ui-handler";
 
 
 enum Page {
@@ -927,6 +928,8 @@ export default class SummaryUiHandler extends UiHandler {
           moveRowContainer.add(typeIcon);
         }
 
+        const test = getMoveColor(this.pokemon, move);
+        console.log(test);
         const moveText = addTextObject(this.scene, 35, 0, move ? move.getName() : "-", TextStyle.SUMMARY);
         moveText.setOrigin(0, 1);
         moveRowContainer.add(moveText);


### PR DESCRIPTION
This PR makes it so when you go to the summary screen during a battle, it shows you the type effectiveness of moves against the enemy team (if you have the type effectiveness setting on)

## What are the changes?
I've reused the code from the type effectiveness section for moves during a fight and have put it in the summary screen for moves when you go to switch out pokemon during a battle

## Why am I doing these changes?
Someone suggested to make it, so here we are

## What did change?
I added logic for the move page of the summary screen to check the type effectiveness of each move. It reuses the same logic as the current type effectiveness, so that means it doesn't know about abilities until they're used - as an example, if a pokemon has levitate but you don't know about it yet, using a ground type ability may show as super effective in the right conditions until you use a ground move, which will then show that it's not effective at all

Note, I haven't tested this against trainers since trainers are currently bugged in beta until #2841 goes through, but I've tested it in single and double wild battles. There's also some unit tests that I suspect are relating to #2841 that are failing, but I think it should be ok once this is fixed

### Screenshots/Videos
Below is a video of me going up against a klink. I open my party and as I do, I go between different pokemon in my party. I have a poison move (greyed out because it's not effective), a fighting move (green because it's super effective), and various non effective moves (red).

https://github.com/pagefaultgames/pokerogue/assets/66582645/81b552f0-0297-4ea8-9ac4-1dfe11c0d2ac

Below is another video of me going up against a koffing with levitate. Since it's a poison type, normally ground would be super effective against it, but since it has levitate ground type moves will actually be not effective. However, since we start the battle without knowing what ability the koffing has, it shows up as super effective. Only once we actually use a ground type move and see the enemy's ability making koffing immune does the text change from green to grey.

https://github.com/pagefaultgames/pokerogue/assets/66582645/ceef4e72-7583-4295-8701-391817404f1a

## How to test the changes?
Download the PR and play through various levels and enemies. s

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?