### PR TITLE
[QoL] Highlight targets of multitarget moves instead of immediate execution

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1961,6 +1961,9 @@ export class CommandPhase extends FieldPhase {
           turnCommand.targets = [this.fieldIndex];
         }
         console.log(moveTargets, playerPokemon.name);
+        if (moveTargets.targets.length > 1 && moveTargets.multiple) {
+          this.scene.unshiftPhase(new SelectTargetPhase(this.scene, this.fieldIndex));
+        }
         if (moveTargets.targets.length <= 1 || moveTargets.multiple) {
           turnCommand.move.targets = moveTargets.targets;
         } else if (playerPokemon.getTag(BattlerTagType.CHARGING) && playerPokemon.getMoveQueue().length >= 1) {

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1,7 +1,7 @@
 import BattleScene, { bypassLogin } from "./battle-scene";
 import { default as Pokemon, PlayerPokemon, EnemyPokemon, PokemonMove, MoveResult, DamageResult, FieldPosition, HitResult, TurnMove } from "./field/pokemon";
 import * as Utils from "./utils";
-import { allMoves, applyMoveAttrs, BypassSleepAttr, ChargeAttr, applyFilteredMoveAttrs, HitsTagAttr, MissEffectAttr, MoveAttr, MoveEffectAttr, MoveFlags, MultiHitAttr, OverrideMoveEffectAttr, VariableAccuracyAttr, MoveTarget, getMoveTargets, MoveTargetSet, MoveEffectTrigger, CopyMoveAttr, AttackMove, SelfStatusMove, PreMoveMessageAttr, HealStatusEffectAttr, IgnoreOpponentStatChangesAttr, NoEffectAttr, BypassRedirectAttr, FixedDamageAttr, PostVictoryStatChangeAttr, OneHitKOAccuracyAttr, ForceSwitchOutAttr, VariableTargetAttr, IncrementMovePriorityAttr, MoveCategory } from "./data/move";
+import { allMoves, applyMoveAttrs, BypassSleepAttr, ChargeAttr, applyFilteredMoveAttrs, HitsTagAttr, MissEffectAttr, MoveAttr, MoveEffectAttr, MoveFlags, MultiHitAttr, OverrideMoveEffectAttr, VariableAccuracyAttr, MoveTarget, getMoveTargets, MoveTargetSet, MoveEffectTrigger, CopyMoveAttr, AttackMove, SelfStatusMove, PreMoveMessageAttr, HealStatusEffectAttr, IgnoreOpponentStatChangesAttr, NoEffectAttr, BypassRedirectAttr, FixedDamageAttr, PostVictoryStatChangeAttr, OneHitKOAccuracyAttr, ForceSwitchOutAttr, VariableTargetAttr, IncrementMovePriorityAttr } from "./data/move";
 import { Mode } from "./ui/ui";
 import { Command } from "./ui/command-ui-handler";
 import { Stat } from "./data/pokemon-stat";
@@ -1961,7 +1961,7 @@ export class CommandPhase extends FieldPhase {
           turnCommand.targets = [this.fieldIndex];
         }
         console.log(moveTargets, playerPokemon.name);
-        if (moveTargets.targets.length > 1 && moveTargets.multiple && allMoves[moveId].category !== MoveCategory.STATUS) {
+        if (moveTargets.targets.length > 1 && moveTargets.multiple) {
           this.scene.unshiftPhase(new SelectTargetPhase(this.scene, this.fieldIndex));
         }
         if (moveTargets.targets.length <= 1 || moveTargets.multiple) {

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2213,13 +2213,13 @@ export class SelectTargetPhase extends PokemonPhase {
 
     const turnCommand = this.scene.currentBattle.turnCommands[this.fieldIndex];
     const move = turnCommand.move?.move;
-    this.scene.ui.setMode(Mode.TARGET_SELECT, this.fieldIndex, move, (cursor: integer) => {
+    this.scene.ui.setMode(Mode.TARGET_SELECT, this.fieldIndex, move, (targets: BattlerIndex[]) => {
       this.scene.ui.setMode(Mode.MESSAGE);
-      if (cursor === -1) {
+      if (targets.length < 1) {
         this.scene.currentBattle.turnCommands[this.fieldIndex] = null;
         this.scene.unshiftPhase(new CommandPhase(this.scene, this.fieldIndex));
       } else {
-        turnCommand.targets = [cursor];
+        turnCommand.targets = targets;
       }
       if (turnCommand.command === Command.BALL && this.fieldIndex) {
         this.scene.currentBattle.turnCommands[this.fieldIndex - 1].skip = true;

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1,7 +1,7 @@
 import BattleScene, { bypassLogin } from "./battle-scene";
 import { default as Pokemon, PlayerPokemon, EnemyPokemon, PokemonMove, MoveResult, DamageResult, FieldPosition, HitResult, TurnMove } from "./field/pokemon";
 import * as Utils from "./utils";
-import { allMoves, applyMoveAttrs, BypassSleepAttr, ChargeAttr, applyFilteredMoveAttrs, HitsTagAttr, MissEffectAttr, MoveAttr, MoveEffectAttr, MoveFlags, MultiHitAttr, OverrideMoveEffectAttr, VariableAccuracyAttr, MoveTarget, getMoveTargets, MoveTargetSet, MoveEffectTrigger, CopyMoveAttr, AttackMove, SelfStatusMove, PreMoveMessageAttr, HealStatusEffectAttr, IgnoreOpponentStatChangesAttr, NoEffectAttr, BypassRedirectAttr, FixedDamageAttr, PostVictoryStatChangeAttr, OneHitKOAccuracyAttr, ForceSwitchOutAttr, VariableTargetAttr, IncrementMovePriorityAttr } from "./data/move";
+import { allMoves, applyMoveAttrs, BypassSleepAttr, ChargeAttr, applyFilteredMoveAttrs, HitsTagAttr, MissEffectAttr, MoveAttr, MoveEffectAttr, MoveFlags, MultiHitAttr, OverrideMoveEffectAttr, VariableAccuracyAttr, MoveTarget, getMoveTargets, MoveTargetSet, MoveEffectTrigger, CopyMoveAttr, AttackMove, SelfStatusMove, PreMoveMessageAttr, HealStatusEffectAttr, IgnoreOpponentStatChangesAttr, NoEffectAttr, BypassRedirectAttr, FixedDamageAttr, PostVictoryStatChangeAttr, OneHitKOAccuracyAttr, ForceSwitchOutAttr, VariableTargetAttr, IncrementMovePriorityAttr, MoveCategory } from "./data/move";
 import { Mode } from "./ui/ui";
 import { Command } from "./ui/command-ui-handler";
 import { Stat } from "./data/pokemon-stat";
@@ -1961,7 +1961,7 @@ export class CommandPhase extends FieldPhase {
           turnCommand.targets = [this.fieldIndex];
         }
         console.log(moveTargets, playerPokemon.name);
-        if (moveTargets.targets.length > 1 && moveTargets.multiple) {
+        if (moveTargets.targets.length > 1 && moveTargets.multiple && allMoves[moveId].category !== MoveCategory.STATUS) {
           this.scene.unshiftPhase(new SelectTargetPhase(this.scene, this.fieldIndex));
         }
         if (moveTargets.targets.length <= 1 || moveTargets.multiple) {

--- a/src/test/utils/gameManager.ts
+++ b/src/test/utils/gameManager.ts
@@ -6,8 +6,10 @@ import {
   EncounterPhase,
   FaintPhase,
   LoginPhase,
+  MoveEndPhase,
   NewBattlePhase,
   SelectStarterPhase,
+  SelectTargetPhase,
   TitlePhase, TurnInitPhase,
   TurnStartPhase,
 } from "#app/phases";
@@ -170,6 +172,15 @@ export default class GameManager {
     this.onNextPrompt("CommandPhase", Mode.FIGHT, () => {
       (this.scene.getCurrentPhase() as CommandPhase).handleCommand(Command.FIGHT, movePosition, false);
     });
+
+    // Immediately confirm target selection if move is multi-target
+    this.onNextPrompt("SelectTargetPhase", Mode.TARGET_SELECT, () => {
+      const handler = this.scene.ui.getHandler() as TargetSelectUiHandler;
+      const move = (this.scene.getCurrentPhase() as SelectTargetPhase).getPokemon().getMoveset()[movePosition].getMove();
+      if (move.isMultiTarget()) {
+        handler.processInput(Button.ACTION);
+      }
+    }, () => this.isCurrentPhase(CommandPhase) || this.isCurrentPhase(MoveEndPhase));
   }
 
   /**

--- a/src/test/utils/gameManager.ts
+++ b/src/test/utils/gameManager.ts
@@ -172,7 +172,7 @@ export default class GameManager {
       (this.scene.getCurrentPhase() as CommandPhase).handleCommand(Command.FIGHT, movePosition, false);
     });
 
-    // Auto confirm target selection if move is multi-target
+    // Confirm target selection if move is multi-target
     this.onNextPrompt("SelectTargetPhase", Mode.TARGET_SELECT, () => {
       const handler = this.scene.ui.getHandler() as TargetSelectUiHandler;
       const move = (this.scene.getCurrentPhase() as SelectTargetPhase).getPokemon().getMoveset()[movePosition].getMove();

--- a/src/test/utils/gameManager.ts
+++ b/src/test/utils/gameManager.ts
@@ -6,11 +6,10 @@ import {
   EncounterPhase,
   FaintPhase,
   LoginPhase,
-  MoveEndPhase,
   NewBattlePhase,
   SelectStarterPhase,
   SelectTargetPhase,
-  TitlePhase, TurnInitPhase,
+  TitlePhase, TurnEndPhase, TurnInitPhase,
   TurnStartPhase,
 } from "#app/phases";
 import BattleScene from "#app/battle-scene.js";
@@ -180,7 +179,7 @@ export default class GameManager {
       if (move.isMultiTarget()) {
         handler.processInput(Button.ACTION);
       }
-    }, () => this.isCurrentPhase(CommandPhase) || this.isCurrentPhase(MoveEndPhase));
+    }, () => this.isCurrentPhase(CommandPhase) || this.isCurrentPhase(TurnEndPhase));
   }
 
   /**

--- a/src/test/utils/gameManager.ts
+++ b/src/test/utils/gameManager.ts
@@ -172,7 +172,7 @@ export default class GameManager {
       (this.scene.getCurrentPhase() as CommandPhase).handleCommand(Command.FIGHT, movePosition, false);
     });
 
-    // Immediately confirm target selection if move is multi-target
+    // Auto confirm target selection if move is multi-target
     this.onNextPrompt("SelectTargetPhase", Mode.TARGET_SELECT, () => {
       const handler = this.scene.ui.getHandler() as TargetSelectUiHandler;
       const move = (this.scene.getCurrentPhase() as SelectTargetPhase).getPokemon().getMoveset()[movePosition].getMove();

--- a/src/ui/target-select-ui-handler.ts
+++ b/src/ui/target-select-ui-handler.ts
@@ -6,6 +6,7 @@ import * as Utils from "../utils";
 import { getMoveTargets } from "../data/move";
 import {Button} from "#enums/buttons";
 import { Moves } from "#enums/moves";
+import Pokemon from "#app/field/pokemon.js";
 
 export type TargetSelectCallback = (cursor: integer) => void;
 
@@ -14,9 +15,11 @@ export default class TargetSelectUiHandler extends UiHandler {
   private move: Moves;
   private targetSelectCallback: TargetSelectCallback;
 
+  private isMultipleTargets: boolean = false;
   private targets: BattlerIndex[];
+  private targetsTakingHit: Pokemon[];
   private targetFlashTween: Phaser.Tweens.Tween;
-  private targetBattleInfoMoveTween: Phaser.Tweens.Tween;
+  private targetBattleInfoMoveTween: Phaser.Tweens.Tween[] = [];
 
   constructor(scene: BattleScene) {
     super(scene, Mode.TARGET_SELECT);
@@ -37,19 +40,22 @@ export default class TargetSelectUiHandler extends UiHandler {
     this.move = args[1] as Moves;
     this.targetSelectCallback = args[2] as TargetSelectCallback;
 
-    this.targets = getMoveTargets(this.scene.getPlayerField()[this.fieldIndex], this.move).targets;
+    const moveTargets = getMoveTargets(this.scene.getPlayerField()[this.fieldIndex], this.move);
+    this.targets = moveTargets.targets;
+    this.isMultipleTargets = moveTargets.multiple ?? false;
 
     if (!this.targets.length) {
       return false;
     }
 
-    this.setCursor(this.targets.indexOf(this.cursor) > -1 ? this.cursor : this.targets[0]);
+    this.setCursor(this.targets.includes(this.cursor) ? this.cursor : this.targets[0]);
 
     return true;
   }
 
   processInput(button: Button): boolean {
     const ui = this.getUi();
+    console.log("cursor", this.cursor);
 
     let success = false;
 
@@ -88,74 +94,77 @@ export default class TargetSelectUiHandler extends UiHandler {
     return success;
   }
 
+  // cursor is battlerIndex
   setCursor(cursor: integer): boolean {
-    const lastCursor = this.cursor;
+    const singleTarget = this.scene.getField()[cursor];
+    const multipleTargets = this.targets.map(index => this.scene.getField()[index]);
+
+    this.targetsTakingHit = this.isMultipleTargets ? multipleTargets : [ singleTarget ];
 
     const ret = super.setCursor(cursor);
 
     if (this.targetFlashTween) {
       this.targetFlashTween.stop();
-      const lastTarget = this.scene.getField()[lastCursor];
-      if (lastTarget) {
-        lastTarget.setAlpha(1);
+      for (const pokemon of multipleTargets) {
+        pokemon.setAlpha(1);
       }
     }
 
-    const target = this.scene.getField()[cursor];
-
     this.targetFlashTween = this.scene.tweens.add({
-      targets: [ target ],
+      targets: [...this.targetsTakingHit],
       alpha: 0,
       loop: -1,
       duration: Utils.fixedInt(250),
       ease: "Sine.easeIn",
       yoyo: true,
+      // this creates the "flashing" pokemon
       onUpdate: t => {
-        if (target) {
+        for (const target of this.targetsTakingHit) {
           target.setAlpha(t.getValue());
         }
       }
     });
 
-    if (this.targetBattleInfoMoveTween) {
-      this.targetBattleInfoMoveTween.stop();
-      const lastTarget = this.scene.getField()[lastCursor];
-      if (lastTarget) {
-        lastTarget.getBattleInfo().resetY();
+    if (this.targetBattleInfoMoveTween.length >= 1) {
+      this.targetBattleInfoMoveTween.forEach(tween => tween.stop());
+      for (const pokemon of multipleTargets) {
+        pokemon.getBattleInfo().resetY();
       }
     }
 
-    const targetBattleInfo = target.getBattleInfo();
+    console.log("targetBattleInfoMoveTween", this.targetBattleInfoMoveTween);
 
-    this.targetBattleInfoMoveTween = this.scene.tweens.add({
-      targets: [ targetBattleInfo ],
-      y: { start: targetBattleInfo.getBaseY(), to: targetBattleInfo.getBaseY() + 1 },
-      loop: -1,
-      duration: Utils.fixedInt(250),
-      ease: "Linear",
-      yoyo: true
+    const targetsBattleInfo = this.targetsTakingHit.map(target => target.getBattleInfo());
+
+    targetsBattleInfo.map(info => {
+      this.targetBattleInfoMoveTween.push(this.scene.tweens.add({
+        targets: [ info ],
+        y: { start: info.getBaseY(), to: info.getBaseY() + 1 },
+        loop: -1,
+        duration: Utils.fixedInt(250),
+        ease: "Linear",
+        yoyo: true
+      }));
     });
 
     return ret;
   }
 
   eraseCursor() {
-    const target = this.scene.getField()[this.cursor];
     if (this.targetFlashTween) {
       this.targetFlashTween.stop();
       this.targetFlashTween = null;
     }
-    if (target) {
-      target.setAlpha(1);
+    for (const pokemon of this.targetsTakingHit) {
+      pokemon.setAlpha(1);
     }
 
-    const targetBattleInfo = target.getBattleInfo();
-    if (this.targetBattleInfoMoveTween) {
-      this.targetBattleInfoMoveTween.stop();
-      this.targetBattleInfoMoveTween = null;
+    if (this.targetBattleInfoMoveTween.length >= 1) {
+      this.targetBattleInfoMoveTween.forEach(tween => tween.stop());
+      this.targetBattleInfoMoveTween = [];
     }
-    if (targetBattleInfo) {
-      targetBattleInfo.resetY();
+    for (const pokemon of this.targetsTakingHit) {
+      pokemon.getBattleInfo().resetY();
     }
   }
 

--- a/src/ui/target-select-ui-handler.ts
+++ b/src/ui/target-select-ui-handler.ts
@@ -62,6 +62,8 @@ export default class TargetSelectUiHandler extends UiHandler {
     if (button === Button.ACTION || button === Button.CANCEL) {
       this.targetSelectCallback(button === Button.ACTION ? this.cursor : -1);
       success = true;
+    } else if (this.isMultipleTargets) {
+      success = false;
     } else {
       switch (button) {
       case Button.UP:

--- a/src/ui/target-select-ui-handler.ts
+++ b/src/ui/target-select-ui-handler.ts
@@ -17,7 +17,7 @@ export default class TargetSelectUiHandler extends UiHandler {
 
   private isMultipleTargets: boolean = false;
   private targets: BattlerIndex[];
-  private targetsTakingHit: Pokemon[];
+  private targetsHighlighted: Pokemon[];
   private targetFlashTween: Phaser.Tweens.Tween;
   private targetBattleInfoMoveTween: Phaser.Tweens.Tween[] = [];
 
@@ -96,12 +96,11 @@ export default class TargetSelectUiHandler extends UiHandler {
     return success;
   }
 
-  // cursor is battlerIndex
   setCursor(cursor: integer): boolean {
     const singleTarget = this.scene.getField()[cursor];
     const multipleTargets = this.targets.map(index => this.scene.getField()[index]);
 
-    this.targetsTakingHit = this.isMultipleTargets ? multipleTargets : [ singleTarget ];
+    this.targetsHighlighted = this.isMultipleTargets ? multipleTargets : [ singleTarget ];
 
     const ret = super.setCursor(cursor);
 
@@ -113,15 +112,14 @@ export default class TargetSelectUiHandler extends UiHandler {
     }
 
     this.targetFlashTween = this.scene.tweens.add({
-      targets: [...this.targetsTakingHit],
+      targets: [...this.targetsHighlighted],
       alpha: 0,
       loop: -1,
       duration: Utils.fixedInt(250),
       ease: "Sine.easeIn",
       yoyo: true,
-      // this creates the "flashing" pokemon
       onUpdate: t => {
-        for (const target of this.targetsTakingHit) {
+        for (const target of this.targetsHighlighted) {
           target.setAlpha(t.getValue());
         }
       }
@@ -134,9 +132,7 @@ export default class TargetSelectUiHandler extends UiHandler {
       }
     }
 
-    console.log("targetBattleInfoMoveTween", this.targetBattleInfoMoveTween);
-
-    const targetsBattleInfo = this.targetsTakingHit.map(target => target.getBattleInfo());
+    const targetsBattleInfo = this.targetsHighlighted.map(target => target.getBattleInfo());
 
     targetsBattleInfo.map(info => {
       this.targetBattleInfoMoveTween.push(this.scene.tweens.add({
@@ -157,7 +153,7 @@ export default class TargetSelectUiHandler extends UiHandler {
       this.targetFlashTween.stop();
       this.targetFlashTween = null;
     }
-    for (const pokemon of this.targetsTakingHit) {
+    for (const pokemon of this.targetsHighlighted) {
       pokemon.setAlpha(1);
     }
 
@@ -165,7 +161,7 @@ export default class TargetSelectUiHandler extends UiHandler {
       this.targetBattleInfoMoveTween.forEach(tween => tween.stop());
       this.targetBattleInfoMoveTween = [];
     }
-    for (const pokemon of this.targetsTakingHit) {
+    for (const pokemon of this.targetsHighlighted) {
       pokemon.getBattleInfo().resetY();
     }
   }

--- a/src/ui/target-select-ui-handler.ts
+++ b/src/ui/target-select-ui-handler.ts
@@ -124,9 +124,8 @@ export default class TargetSelectUiHandler extends UiHandler {
         }
       }
     });
-
     if (this.targetBattleInfoMoveTween.length >= 1) {
-      this.targetBattleInfoMoveTween.forEach(tween => tween.stop());
+      this.targetBattleInfoMoveTween.filter(t => t !== undefined).forEach(tween => tween.stop());
       for (const pokemon of multipleTargets) {
         pokemon.getBattleInfo().resetY();
       }
@@ -158,7 +157,7 @@ export default class TargetSelectUiHandler extends UiHandler {
     }
 
     if (this.targetBattleInfoMoveTween.length >= 1) {
-      this.targetBattleInfoMoveTween.forEach(tween => tween.stop());
+      this.targetBattleInfoMoveTween.filter(t => t !== undefined).forEach(tween => tween.stop());
       this.targetBattleInfoMoveTween = [];
     }
     for (const pokemon of this.targetsHighlighted) {

--- a/src/ui/target-select-ui-handler.ts
+++ b/src/ui/target-select-ui-handler.ts
@@ -112,7 +112,7 @@ export default class TargetSelectUiHandler extends UiHandler {
     }
 
     this.targetFlashTween = this.scene.tweens.add({
-      targets: [...this.targetsHighlighted],
+      targets: this.targetsHighlighted,
       alpha: 0,
       loop: -1,
       duration: Utils.fixedInt(250),

--- a/src/ui/target-select-ui-handler.ts
+++ b/src/ui/target-select-ui-handler.ts
@@ -8,7 +8,7 @@ import {Button} from "#enums/buttons";
 import { Moves } from "#enums/moves";
 import Pokemon from "#app/field/pokemon.js";
 
-export type TargetSelectCallback = (cursor: integer) => void;
+export type TargetSelectCallback = (targets: BattlerIndex[]) => void;
 
 export default class TargetSelectUiHandler extends UiHandler {
   private fieldIndex: integer;
@@ -55,12 +55,12 @@ export default class TargetSelectUiHandler extends UiHandler {
 
   processInput(button: Button): boolean {
     const ui = this.getUi();
-    console.log("cursor", this.cursor);
 
     let success = false;
 
     if (button === Button.ACTION || button === Button.CANCEL) {
-      this.targetSelectCallback(button === Button.ACTION ? this.cursor : -1);
+      const targetIndexes: BattlerIndex[] = this.isMultipleTargets ? this.targets : [this.cursor];
+      this.targetSelectCallback(button === Button.ACTION ? targetIndexes : []);
       success = true;
     } else if (this.isMultipleTargets) {
       success = false;


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
- see title

## Why am I doing these changes?
- high upvotes from [discord](https://discord.com/channels/1125469663833370665/1239820415891935232) and QoL that makes sense

## What did change?
- see title
- changed single target highlights to use arrays
- updated some parameter/variable namings and types to be more descriptive/accurate

### Screenshots/Videos
- SINGLE BATTLE: Moves targeting multiple mons still function the same

https://github.com/pagefaultgames/pokerogue/assets/68144167/92d70882-6819-4ea3-bc11-dbcd320ffa32




- DOUBLE BATTLE: Moves targeting multiple mons now highlight the targets first


https://github.com/pagefaultgames/pokerogue/assets/68144167/39af97fc-71e1-4ea3-be2d-44f6b239784d




- DOUBLE BATTLE: Moves with single target still function the same


https://github.com/pagefaultgames/pokerogue/assets/68144167/6af1793e-c9dc-45ef-82df-c96509cf5703




## How to test the changes?
- `export const MOVESET_OVERRIDE: Array<Moves> = [Moves.DAZZLING_GLEAM, Moves.TACKLE, Moves.EARTHQUAKE, Moves.HELPING_HAND];`
- test in single and double

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual? (sort of)
  - [x] Have I provided screenshots/videos of the changes?