### PR TITLE
[Localization] localize modifier.ts apply event message & translate in Korean

### DIFF
--- a/src/locales/de/config.ts
+++ b/src/locales/de/config.ts
@@ -25,6 +25,7 @@ import { gameStatsUiHandler } from "./game-stats-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
 import { menuUiHandler } from "./menu-ui-handler";
+import { modifier } from "./modifier";
 import { modifierType } from "./modifier-type";
 import { move } from "./move";
 import { nature } from "./nature";
@@ -73,6 +74,7 @@ export const deConfig = {
   growth: growth,
   menu: menu,
   menuUiHandler: menuUiHandler,
+  modifier: modifier,
   modifierType: modifierType,
   move: move,
   nature: nature,

--- a/src/locales/de/modifier.ts
+++ b/src/locales/de/modifier.ts
@@ -1,0 +1,12 @@
+import { SimpleTranslationEntries } from "#app/interfaces/locales";
+
+export const modifier: SimpleTranslationEntries = {
+  "surviveDamageApply": "{{pokemonNameWithAffix}} hung on\nusing its {{typeName}}!",
+  "turnHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
+  "hitHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
+  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} was revived\nby its {{typeName}}!",
+  "moneyInterestApply": "You received interest of ₽{{moneyAmount}}\nfrom the {{typeName}}!",
+  "turnHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was absorbed\nby {{pokemonName}}'s {{typeName}}!",
+  "contactHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was snatched\nby {{pokemonName}}'s {{typeName}}!",
+  "enemyTurnHealApply": "{{pokemonNameWithAffix}}\nrestored some HP!",
+} as const;

--- a/src/locales/de/modifier.ts
+++ b/src/locales/de/modifier.ts
@@ -1,12 +1,12 @@
 import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const modifier: SimpleTranslationEntries = {
-  "surviveDamageApply": "{{pokemonNameWithAffix}} hung on\nusing its {{typeName}}!",
-  "turnHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
-  "hitHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
-  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} was revived\nby its {{typeName}}!",
-  "moneyInterestApply": "You received interest of ₽{{moneyAmount}}\nfrom the {{typeName}}!",
-  "turnHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was absorbed\nby {{pokemonName}}'s {{typeName}}!",
-  "contactHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was snatched\nby {{pokemonName}}'s {{typeName}}!",
-  "enemyTurnHealApply": "{{pokemonNameWithAffix}}\nrestored some HP!",
+  "surviveDamageApply": "{{pokemonNameWithAffix}} hält mithilfe des Items {{typeName}} durch!",
+  "turnHealApply": "{{typeName}} von {{pokemonNameWithAffix}} füllt einige KP auf!",
+  "hitHealApply": "{{typeName}} von {{pokemonNameWithAffix}} füllt einige KP auf!",
+  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} wurde durch {{typeName}} wiederbelebt!",
+  "moneyInterestApply": "Du erhählst {{moneyAmount}} ₽ durch das Item {{typeName}}!",
+  "turnHeldItemTransferApply": "{{itemName}} von {{pokemonNameWithAffix}} wurde durch {{typeName}} von {{pokemonName}} absorbiert!",
+  "contactHeldItemTransferApply": "{{itemName}} von {{pokemonNameWithAffix}} wurde durch {{typeName}} von  {{pokemonName}} geklaut!",
+  "enemyTurnHealApply": "{{pokemonNameWithAffix}} stellt einige KP wieder her!",
 } as const;

--- a/src/locales/en/config.ts
+++ b/src/locales/en/config.ts
@@ -27,6 +27,7 @@ import { gameStatsUiHandler } from "./game-stats-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
 import { menuUiHandler } from "./menu-ui-handler";
+import { modifier } from "./modifier";
 import { modifierType } from "./modifier-type";
 import { move } from "./move";
 import { nature } from "./nature";
@@ -73,6 +74,7 @@ export const enConfig = {
   growth: growth,
   menu: menu,
   menuUiHandler: menuUiHandler,
+  modifier: modifier,
   modifierType: modifierType,
   move: move,
   nature: nature,

--- a/src/locales/en/modifier.ts
+++ b/src/locales/en/modifier.ts
@@ -1,0 +1,12 @@
+import { SimpleTranslationEntries } from "#app/interfaces/locales";
+
+export const modifier: SimpleTranslationEntries = {
+  "surviveDamageApply": "{{pokemonNameWithAffix}} hung on\nusing its {{typeName}}!",
+  "turnHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
+  "hitHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
+  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} was revived\nby its {{typeName}}!",
+  "moneyInterestApply": "You received interest of ₽{{moneyAmount}}\nfrom the {{typeName}}!",
+  "turnHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was absorbed\nby {{pokemonName}}'s {{typeName}}!",
+  "contactHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was snatched\nby {{pokemonName}}'s {{typeName}}!",
+  "enemyTurnHealApply": "{{pokemonNameWithAffix}}\nrestored some HP!",
+} as const;

--- a/src/locales/es/config.ts
+++ b/src/locales/es/config.ts
@@ -25,6 +25,7 @@ import { gameStatsUiHandler } from "./game-stats-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
 import { menuUiHandler } from "./menu-ui-handler";
+import { modifier } from "./modifier";
 import { modifierType } from "./modifier-type";
 import { move } from "./move";
 import { nature } from "./nature";
@@ -73,6 +74,7 @@ export const esConfig = {
   growth: growth,
   menu: menu,
   menuUiHandler: menuUiHandler,
+  modifier: modifier,
   modifierType: modifierType,
   move: move,
   nature: nature,

--- a/src/locales/es/modifier.ts
+++ b/src/locales/es/modifier.ts
@@ -1,0 +1,12 @@
+import { SimpleTranslationEntries } from "#app/interfaces/locales";
+
+export const modifier: SimpleTranslationEntries = {
+  "surviveDamageApply": "{{pokemonNameWithAffix}} hung on\nusing its {{typeName}}!",
+  "turnHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
+  "hitHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
+  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} was revived\nby its {{typeName}}!",
+  "moneyInterestApply": "You received interest of ₽{{moneyAmount}}\nfrom the {{typeName}}!",
+  "turnHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was absorbed\nby {{pokemonName}}'s {{typeName}}!",
+  "contactHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was snatched\nby {{pokemonName}}'s {{typeName}}!",
+  "enemyTurnHealApply": "{{pokemonNameWithAffix}}\nrestored some HP!",
+} as const;

--- a/src/locales/fr/config.ts
+++ b/src/locales/fr/config.ts
@@ -25,6 +25,7 @@ import { gameStatsUiHandler } from "./game-stats-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
 import { menuUiHandler } from "./menu-ui-handler";
+import { modifier } from "./modifier";
 import { modifierType } from "./modifier-type";
 import { move } from "./move";
 import { nature } from "./nature";
@@ -73,6 +74,7 @@ export const frConfig = {
   growth: growth,
   menu: menu,
   menuUiHandler: menuUiHandler,
+  modifier: modifier,
   modifierType: modifierType,
   move: move,
   nature: nature,

--- a/src/locales/fr/modifier.ts
+++ b/src/locales/fr/modifier.ts
@@ -1,0 +1,12 @@
+import { SimpleTranslationEntries } from "#app/interfaces/locales";
+
+export const modifier: SimpleTranslationEntries = {
+  "surviveDamageApply": "{{pokemonNameWithAffix}} hung on\nusing its {{typeName}}!",
+  "turnHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
+  "hitHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
+  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} was revived\nby its {{typeName}}!",
+  "moneyInterestApply": "You received interest of ₽{{moneyAmount}}\nfrom the {{typeName}}!",
+  "turnHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was absorbed\nby {{pokemonName}}'s {{typeName}}!",
+  "contactHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was snatched\nby {{pokemonName}}'s {{typeName}}!",
+  "enemyTurnHealApply": "{{pokemonNameWithAffix}}\nrestored some HP!",
+} as const;

--- a/src/locales/fr/modifier.ts
+++ b/src/locales/fr/modifier.ts
@@ -6,7 +6,7 @@ export const modifier: SimpleTranslationEntries = {
   "hitHealApply": "Les PV de {{pokemonNameWithAffix}}\nsont un peu restaurés par le {{typeName}} !",
   "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} a repris connaissance\navec sa {{typeName}} et est prêt à se battre de nouveau !",
   "moneyInterestApply": "La {{typeName}} vous rapporte\n{{moneyAmount}} ₽ d’intérêts !",
-  "turnHeldItemTransferApply": "{{itemName}} de {{pokemonNameWithAffix}} est absorbé\npar le {{typeName}} de {{pokemonName}} !",
-  "contactHeldItemTransferApply": "{{itemName}} de {{pokemonNameWithAffix}} est volé\npar l’{{typeName}} de {{pokemonName}} !",
+  "turnHeldItemTransferApply": "{{itemName}} de {{pokemonNameWithAffix}} est absorbé·e\npar le {{typeName}} de {{pokemonName}} !",
+  "contactHeldItemTransferApply": "{{itemName}} de {{pokemonNameWithAffix}} est volé·e\npar l’{{typeName}} de {{pokemonName}} !",
   "enemyTurnHealApply": "{{pokemonNameWithAffix}}\nrestaure un peu ses PV !",
 } as const;

--- a/src/locales/fr/modifier.ts
+++ b/src/locales/fr/modifier.ts
@@ -1,12 +1,12 @@
 import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const modifier: SimpleTranslationEntries = {
-  "surviveDamageApply": "{{pokemonNameWithAffix}} tient bon grâce à {{typeName}} !",
-  "turnHealApply": "Les PV du {{pokemonNameWithAffix}}\nsont un peu restaurés par {{typeName}} !",
-  "hitHealApply": "Les PV du {{pokemonNameWithAffix}}\nsont un peu restaurés par {{typeName}} !",
-  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} a repris connaissance\navec {{typeName}} et est prêt à se battre de nouveau !",
-  "moneyInterestApply": "Vous recevez {{moneyAmount}} ₽\nd’intérets de la {{typeName}} !",
+  "surviveDamageApply": "{{pokemonNameWithAffix}} tient bon\ngrâce à son {{typeName}} !",
+  "turnHealApply": "Les PV de {{pokemonNameWithAffix}}\nsont un peu restaurés par les {{typeName}} !",
+  "hitHealApply": "Les PV de {{pokemonNameWithAffix}}\nsont un peu restaurés par le {{typeName}} !",
+  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} a repris connaissance\navec sa {{typeName}} et est prêt à se battre de nouveau !",
+  "moneyInterestApply": "La {{typeName}} vous rapporte\n{{moneyAmount}} ₽ d’intérêts !",
   "turnHeldItemTransferApply": "{{itemName}} de {{pokemonNameWithAffix}} est absorbé\npar le {{typeName}} de {{pokemonName}} !",
-  "contactHeldItemTransferApply": "{{itemName}} de {{pokemonNameWithAffix}} est volé\npar {{typeName}} de {{pokemonName}} !",
+  "contactHeldItemTransferApply": "{{itemName}} de {{pokemonNameWithAffix}} est volé\npar l’{{typeName}} de {{pokemonName}} !",
   "enemyTurnHealApply": "{{pokemonNameWithAffix}}\nrestaure un peu ses PV !",
 } as const;

--- a/src/locales/fr/modifier.ts
+++ b/src/locales/fr/modifier.ts
@@ -1,12 +1,12 @@
 import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const modifier: SimpleTranslationEntries = {
-  "surviveDamageApply": "{{pokemonNameWithAffix}} hung on\nusing its {{typeName}}!",
-  "turnHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
-  "hitHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
-  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} was revived\nby its {{typeName}}!",
-  "moneyInterestApply": "You received interest of ₽{{moneyAmount}}\nfrom the {{typeName}}!",
-  "turnHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was absorbed\nby {{pokemonName}}'s {{typeName}}!",
-  "contactHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was snatched\nby {{pokemonName}}'s {{typeName}}!",
-  "enemyTurnHealApply": "{{pokemonNameWithAffix}}\nrestored some HP!",
+  "surviveDamageApply": "{{pokemonNameWithAffix}} tient bon grâce à {{typeName}} !",
+  "turnHealApply": "Les PV du {{pokemonNameWithAffix}}\nsont un peu restaurés par {{typeName}} !",
+  "hitHealApply": "Les PV du {{pokemonNameWithAffix}}\nsont un peu restaurés par {{typeName}} !",
+  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} a repris connaissance\navec {{typeName}} et est prêt à se battre de nouveau !",
+  "moneyInterestApply": "Vous recevez {{moneyAmount}} ₽\nd’intérets de la {{typeName}} !",
+  "turnHeldItemTransferApply": "{{itemName}} de {{pokemonNameWithAffix}} est absorbé\npar le {{typeName}} de {{pokemonName}} !",
+  "contactHeldItemTransferApply": "{{itemName}} de {{pokemonNameWithAffix}} est volé\npar {{typeName}} de {{pokemonName}} !",
+  "enemyTurnHealApply": "{{pokemonNameWithAffix}}\nrestaure un peu ses PV !",
 } as const;

--- a/src/locales/it/config.ts
+++ b/src/locales/it/config.ts
@@ -25,6 +25,7 @@ import { gameStatsUiHandler } from "./game-stats-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
 import { menuUiHandler } from "./menu-ui-handler";
+import { modifier } from "./modifier";
 import { modifierType } from "./modifier-type";
 import { move } from "./move";
 import { nature } from "./nature";
@@ -73,6 +74,7 @@ export const itConfig = {
   growth: growth,
   menu: menu,
   menuUiHandler: menuUiHandler,
+  modifier: modifier,
   modifierType: modifierType,
   move: move,
   nature: nature,

--- a/src/locales/it/modifier.ts
+++ b/src/locales/it/modifier.ts
@@ -1,0 +1,12 @@
+import { SimpleTranslationEntries } from "#app/interfaces/locales";
+
+export const modifier: SimpleTranslationEntries = {
+  "surviveDamageApply": "{{pokemonNameWithAffix}} hung on\nusing its {{typeName}}!",
+  "turnHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
+  "hitHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
+  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} was revived\nby its {{typeName}}!",
+  "moneyInterestApply": "You received interest of ₽{{moneyAmount}}\nfrom the {{typeName}}!",
+  "turnHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was absorbed\nby {{pokemonName}}'s {{typeName}}!",
+  "contactHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was snatched\nby {{pokemonName}}'s {{typeName}}!",
+  "enemyTurnHealApply": "{{pokemonNameWithAffix}}\nrestored some HP!",
+} as const;

--- a/src/locales/ko/config.ts
+++ b/src/locales/ko/config.ts
@@ -25,6 +25,7 @@ import { gameStatsUiHandler } from "./game-stats-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
 import { menuUiHandler } from "./menu-ui-handler";
+import { modifier } from "./modifier";
 import { modifierType } from "./modifier-type";
 import { move } from "./move";
 import { nature } from "./nature";
@@ -73,6 +74,7 @@ export const koConfig = {
   growth: growth,
   menu: menu,
   menuUiHandler: menuUiHandler,
+  modifier: modifier,
   modifierType: modifierType,
   move: move,
   nature: nature,

--- a/src/locales/ko/modifier.ts
+++ b/src/locales/ko/modifier.ts
@@ -8,5 +8,5 @@ export const modifier: SimpleTranslationEntries = {
   "moneyInterestApply": "{{typeName}}[[로]]부터\n₽{{moneyAmount}}[[를]] 받았다!",
   "turnHeldItemTransferApply": "{{pokemonName}}의 {{typeName}}[[는]]\n{{pokemonNameWithAffix}}의 {{itemName}}[[를]] 흡수했다!",
   "contactHeldItemTransferApply": "{{pokemonName}}의 {{typeName}}[[는]]\n{{pokemonNameWithAffix}}의 {{itemName}}[[를]] 가로챘다!",
-  "enemyTurnHealApply": "{{pokemonNameWithAffix}}[[의]]\n체력이 약간 회복되었다!",
+  "enemyTurnHealApply": "{{pokemonNameWithAffix}}의\n체력이 약간 회복되었다!",
 } as const;

--- a/src/locales/ko/modifier.ts
+++ b/src/locales/ko/modifier.ts
@@ -1,0 +1,12 @@
+import { SimpleTranslationEntries } from "#app/interfaces/locales";
+
+export const modifier: SimpleTranslationEntries = {
+  "surviveDamageApply": "{{pokemonNameWithAffix}}[[는]]\n{{typeName}}[[로]] 버텼다!!",
+  "turnHealApply": "{{pokemonNameWithAffix}}[[는]]\n{{typeName}}[[로]] 인해 조금 회복했다.",
+  "hitHealApply": "{{pokemonNameWithAffix}}[[는]]\n{{typeName}}[[로]] 인해 조금 회복했다.",
+  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}}[[는]] {{typeName}}[[로]]\n정신을 차려 싸울 수 있게 되었다!",
+  "moneyInterestApply": "{{typeName}}[[로]]부터\n₽{{moneyAmount}}[[를]] 받았다!",
+  "turnHeldItemTransferApply": "{{pokemonName}}의 {{typeName}}[[는]]\n{{pokemonNameWithAffix}}의 {{itemName}}[[를]] 흡수했다!",
+  "contactHeldItemTransferApply": "{{pokemonName}}의 {{typeName}}[[는]]\n{{pokemonNameWithAffix}}의 {{itemName}}[[를]] 가로챘다!",
+  "enemyTurnHealApply": "{{pokemonNameWithAffix}}[[의]]\n체력이 약간 회복되었다!",
+} as const;

--- a/src/locales/pt_BR/config.ts
+++ b/src/locales/pt_BR/config.ts
@@ -25,6 +25,7 @@ import { gameStatsUiHandler } from "./game-stats-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
 import { menuUiHandler } from "./menu-ui-handler";
+import { modifier } from "./modifier";
 import { modifierType } from "./modifier-type";
 import { move } from "./move";
 import { nature } from "./nature";
@@ -73,6 +74,7 @@ export const ptBrConfig = {
   growth: growth,
   menu: menu,
   menuUiHandler: menuUiHandler,
+  modifier: modifier,
   modifierType: modifierType,
   move: move,
   nature: nature,

--- a/src/locales/pt_BR/modifier.ts
+++ b/src/locales/pt_BR/modifier.ts
@@ -1,0 +1,12 @@
+import { SimpleTranslationEntries } from "#app/interfaces/locales";
+
+export const modifier: SimpleTranslationEntries = {
+  "surviveDamageApply": "{{pokemonNameWithAffix}} hung on\nusing its {{typeName}}!",
+  "turnHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
+  "hitHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
+  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} was revived\nby its {{typeName}}!",
+  "moneyInterestApply": "You received interest of ₽{{moneyAmount}}\nfrom the {{typeName}}!",
+  "turnHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was absorbed\nby {{pokemonName}}'s {{typeName}}!",
+  "contactHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was snatched\nby {{pokemonName}}'s {{typeName}}!",
+  "enemyTurnHealApply": "{{pokemonNameWithAffix}}\nrestored some HP!",
+} as const;

--- a/src/locales/pt_BR/modifier.ts
+++ b/src/locales/pt_BR/modifier.ts
@@ -1,12 +1,12 @@
 import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const modifier: SimpleTranslationEntries = {
-  "surviveDamageApply": "{{pokemonNameWithAffix}} hung on\nusing its {{typeName}}!",
-  "turnHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
-  "hitHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
-  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} was revived\nby its {{typeName}}!",
-  "moneyInterestApply": "You received interest of ₽{{moneyAmount}}\nfrom the {{typeName}}!",
-  "turnHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was absorbed\nby {{pokemonName}}'s {{typeName}}!",
-  "contactHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was snatched\nby {{pokemonName}}'s {{typeName}}!",
-  "enemyTurnHealApply": "{{pokemonNameWithAffix}}\nrestored some HP!",
+  "surviveDamageApply": "{{pokemonNameWithAffix}} aguentou o tranco\nusando sua {{typeName}}!",
+  "turnHealApply": "{{pokemonNameWithAffix}} restaurou um pouco de PS usando\nseu {{typeName}}!",
+  "hitHealApply": "{{pokemonNameWithAffix}} restaurou um pouco de PS usando\nsua {{typeName}}!",
+  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} foi revivido\npor seu {{typeName}}!",
+  "moneyInterestApply": "Você recebeu um juros de ₽{{moneyAmount}}\nde sua {{typeName}}!",
+  "turnHeldItemTransferApply": "{{itemName}} de {{pokemonNameWithAffix}} foi absorvido(a)\npelo {{typeName}} de {{pokemonName}}!",
+  "contactHeldItemTransferApply": "{{itemName}} de {{pokemonNameWithAffix}} foi pego(a)\npela {{typeName}} de {{pokemonName}}!",
+  "enemyTurnHealApply": "{{pokemonNameWithAffix}}\nrestaurou um pouco de PS!",
 } as const;

--- a/src/locales/pt_BR/modifier.ts
+++ b/src/locales/pt_BR/modifier.ts
@@ -2,7 +2,7 @@ import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const modifier: SimpleTranslationEntries = {
   "surviveDamageApply": "{{pokemonNameWithAffix}} aguentou o tranco\nusando sua {{typeName}}!",
-  "turnHealApply": "{{pokemonNameWithAffix}} restaurou um pouco de PS usando\nseu {{typeName}}!",
+  "turnHealApply": "{{pokemonNameWithAffix}} restaurou um pouco de PS usando\nsuas {{typeName}}!",
   "hitHealApply": "{{pokemonNameWithAffix}} restaurou um pouco de PS usando\nsua {{typeName}}!",
   "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} foi revivido\npor sua {{typeName}}!",
   "moneyInterestApply": "Você recebeu um juros de ₽{{moneyAmount}}\nde sua {{typeName}}!",

--- a/src/locales/pt_BR/modifier.ts
+++ b/src/locales/pt_BR/modifier.ts
@@ -4,7 +4,7 @@ export const modifier: SimpleTranslationEntries = {
   "surviveDamageApply": "{{pokemonNameWithAffix}} aguentou o tranco\nusando sua {{typeName}}!",
   "turnHealApply": "{{pokemonNameWithAffix}} restaurou um pouco de PS usando\nseu {{typeName}}!",
   "hitHealApply": "{{pokemonNameWithAffix}} restaurou um pouco de PS usando\nsua {{typeName}}!",
-  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} foi revivido\npor seu {{typeName}}!",
+  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} foi revivido\npor sua {{typeName}}!",
   "moneyInterestApply": "Você recebeu um juros de ₽{{moneyAmount}}\nde sua {{typeName}}!",
   "turnHeldItemTransferApply": "{{itemName}} de {{pokemonNameWithAffix}} foi absorvido(a)\npelo {{typeName}} de {{pokemonName}}!",
   "contactHeldItemTransferApply": "{{itemName}} de {{pokemonNameWithAffix}} foi pego(a)\npela {{typeName}} de {{pokemonName}}!",

--- a/src/locales/pt_BR/modifier.ts
+++ b/src/locales/pt_BR/modifier.ts
@@ -8,5 +8,5 @@ export const modifier: SimpleTranslationEntries = {
   "moneyInterestApply": "Você recebeu um juros de ₽{{moneyAmount}}\nde sua {{typeName}}!",
   "turnHeldItemTransferApply": "{{itemName}} de {{pokemonNameWithAffix}} foi absorvido(a)\npelo {{typeName}} de {{pokemonName}}!",
   "contactHeldItemTransferApply": "{{itemName}} de {{pokemonNameWithAffix}} foi pego(a)\npela {{typeName}} de {{pokemonName}}!",
-  "enemyTurnHealApply": "{{pokemonNameWithAffix}}\nrestaurou um pouco de PS!",
+  "enemyTurnHealApply": "{{pokemonNameWithAffix}}\nrestaurou um pouco de seus PS!",
 } as const;

--- a/src/locales/zh_CN/config.ts
+++ b/src/locales/zh_CN/config.ts
@@ -25,6 +25,7 @@ import { gameStatsUiHandler } from "./game-stats-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
 import { menuUiHandler } from "./menu-ui-handler";
+import { modifier } from "./modifier";
 import { modifierType } from "./modifier-type";
 import { move } from "./move";
 import { nature } from "./nature";
@@ -73,6 +74,7 @@ export const zhCnConfig = {
   growth: growth,
   menu: menu,
   menuUiHandler: menuUiHandler,
+  modifier: modifier,
   modifierType: modifierType,
   move: move,
   nature: nature,

--- a/src/locales/zh_CN/modifier.ts
+++ b/src/locales/zh_CN/modifier.ts
@@ -1,0 +1,12 @@
+import { SimpleTranslationEntries } from "#app/interfaces/locales";
+
+export const modifier: SimpleTranslationEntries = {
+  "surviveDamageApply": "{{pokemonNameWithAffix}} hung on\nusing its {{typeName}}!",
+  "turnHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
+  "hitHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
+  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} was revived\nby its {{typeName}}!",
+  "moneyInterestApply": "You received interest of ₽{{moneyAmount}}\nfrom the {{typeName}}!",
+  "turnHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was absorbed\nby {{pokemonName}}'s {{typeName}}!",
+  "contactHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was snatched\nby {{pokemonName}}'s {{typeName}}!",
+  "enemyTurnHealApply": "{{pokemonNameWithAffix}}\nrestored some HP!",
+} as const;

--- a/src/locales/zh_CN/modifier.ts
+++ b/src/locales/zh_CN/modifier.ts
@@ -1,12 +1,12 @@
 import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const modifier: SimpleTranslationEntries = {
-  "surviveDamageApply": "{{pokemonNameWithAffix}} hung on\nusing its {{typeName}}!",
-  "turnHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
-  "hitHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
-  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} was revived\nby its {{typeName}}!",
-  "moneyInterestApply": "You received interest of ₽{{moneyAmount}}\nfrom the {{typeName}}!",
-  "turnHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was absorbed\nby {{pokemonName}}'s {{typeName}}!",
-  "contactHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was snatched\nby {{pokemonName}}'s {{typeName}}!",
-  "enemyTurnHealApply": "{{pokemonNameWithAffix}}\nrestored some HP!",
+  "surviveDamageApply": "{{pokemonNameWithAffix}}用{{typeName}}\n撑住了！",
+  "turnHealApply": "{{pokemonNameWithAffix}}用{{typeName}}\n回复了体力！",
+  "hitHealApply": "{{pokemonNameWithAffix}}用{{typeName}}\n回复了体力！",
+  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}}用{{typeName}}\n恢复了活力！",
+  "moneyInterestApply": "用{{typeName}}\n获得了 ₽{{moneyAmount}} 利息！",
+  "turnHeldItemTransferApply": "{{pokemonNameWithAffix}}的{{itemName}}被\n{{pokemonName}}的{{typeName}}吸收了！",
+  "contactHeldItemTransferApply": "{{pokemonNameWithAffix}}的{{itemName}}被\n{{pokemonName}}的{{typeName}}夺取了！",
+  "enemyTurnHealApply": "{{pokemonNameWithAffix}}\n回复了一些体力！",
 } as const;

--- a/src/locales/zh_TW/config.ts
+++ b/src/locales/zh_TW/config.ts
@@ -25,6 +25,7 @@ import { gameStatsUiHandler } from "./game-stats-ui-handler";
 import { growth } from "./growth";
 import { menu } from "./menu";
 import { menuUiHandler } from "./menu-ui-handler";
+import { modifier } from "./modifier";
 import { modifierType } from "./modifier-type";
 import { move } from "./move";
 import { nature } from "./nature";
@@ -73,6 +74,7 @@ export const zhTwConfig = {
   growth: growth,
   menu: menu,
   menuUiHandler: menuUiHandler,
+  modifier: modifier,
   modifierType: modifierType,
   move: move,
   nature: nature,

--- a/src/locales/zh_TW/modifier.ts
+++ b/src/locales/zh_TW/modifier.ts
@@ -1,0 +1,12 @@
+import { SimpleTranslationEntries } from "#app/interfaces/locales";
+
+export const modifier: SimpleTranslationEntries = {
+  "surviveDamageApply": "{{pokemonNameWithAffix}} hung on\nusing its {{typeName}}!",
+  "turnHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
+  "hitHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
+  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} was revived\nby its {{typeName}}!",
+  "moneyInterestApply": "You received interest of ₽{{moneyAmount}}\nfrom the {{typeName}}!",
+  "turnHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was absorbed\nby {{pokemonName}}'s {{typeName}}!",
+  "contactHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was snatched\nby {{pokemonName}}'s {{typeName}}!",
+  "enemyTurnHealApply": "{{pokemonNameWithAffix}}\nrestored some HP!",
+} as const;

--- a/src/locales/zh_TW/modifier.ts
+++ b/src/locales/zh_TW/modifier.ts
@@ -1,12 +1,12 @@
 import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const modifier: SimpleTranslationEntries = {
-  "surviveDamageApply": "{{pokemonNameWithAffix}} hung on\nusing its {{typeName}}!",
-  "turnHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
-  "hitHealApply": "{{pokemonNameWithAffix}} restored a little HP using\nits {{typeName}}!",
-  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}} was revived\nby its {{typeName}}!",
-  "moneyInterestApply": "You received interest of ₽{{moneyAmount}}\nfrom the {{typeName}}!",
-  "turnHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was absorbed\nby {{pokemonName}}'s {{typeName}}!",
-  "contactHeldItemTransferApply": "{{pokemonNameWithAffix}}'s {{itemName}} was snatched\nby {{pokemonName}}'s {{typeName}}!",
-  "enemyTurnHealApply": "{{pokemonNameWithAffix}}\nrestored some HP!",
+  "surviveDamageApply": "{{pokemonNameWithAffix}}用{{typeName}}\n撐住了！",
+  "turnHealApply": "{{pokemonNameWithAffix}}用{{typeName}}\n回復了體力！",
+  "hitHealApply": "{{pokemonNameWithAffix}}用{{typeName}}\n回復了體力！",
+  "pokemonInstantReviveApply": "{{pokemonNameWithAffix}}用{{typeName}}\n回復了活力！",
+  "moneyInterestApply": "用{{typeName}}\n獲得了 ₽{{moneyAmount}} 利息！",
+  "turnHeldItemTransferApply": "{{pokemonNameWithAffix}}的{{itemName}}被\n{{pokemonName}}的{{typeName}}吸收了！",
+  "contactHeldItemTransferApply": "{{pokemonNameWithAffix}}的{{itemName}}被\n{{pokemonName}}的{{typeName}}奪取了！",
+  "enemyTurnHealApply": "{{pokemonNameWithAffix}}\n回復了一些體力！",
 } as const;

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -24,6 +24,7 @@ import * as Overrides from "../overrides";
 import { ModifierType, modifierTypes } from "./modifier-type";
 import { Command } from "#app/ui/command-ui-handler.js";
 import { Species } from "#enums/species";
+import i18next from "i18next";
 
 import { allMoves } from "#app/data/move.js";
 import { Abilities } from "#app/enums/abilities.js";
@@ -965,7 +966,7 @@ export class SurviveDamageModifier extends PokemonHeldItemModifier {
     if (!surviveDamage.value && pokemon.randSeedInt(10) < this.getStackCount()) {
       surviveDamage.value = true;
 
-      pokemon.scene.queueMessage(getPokemonMessage(pokemon, ` hung on\nusing its ${this.type.name}!`));
+      pokemon.scene.queueMessage(i18next.t("modifier:surviveDamageApply", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon), typeName: this.type.name }));
       return true;
     }
 
@@ -1070,7 +1071,7 @@ export class TurnHealModifier extends PokemonHeldItemModifier {
     if (pokemon.getHpRatio() < 1) {
       const scene = pokemon.scene;
       scene.unshiftPhase(new PokemonHealPhase(scene, pokemon.getBattlerIndex(),
-        Math.max(Math.floor(pokemon.getMaxHp() / 16) * this.stackCount, 1), getPokemonMessage(pokemon, `'s ${this.type.name}\nrestored its HP a little!`), true));
+        Math.max(Math.floor(pokemon.getMaxHp() / 16) * this.stackCount, 1), i18next.t("modifier:turnHealApply", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon), typeName: this.type.name }), true));
       return true;
     }
 
@@ -1161,7 +1162,7 @@ export class HitHealModifier extends PokemonHeldItemModifier {
     if (pokemon.turnData.damageDealt && pokemon.getHpRatio() < 1) {
       const scene = pokemon.scene;
       scene.unshiftPhase(new PokemonHealPhase(scene, pokemon.getBattlerIndex(),
-        Math.max(Math.floor(pokemon.turnData.damageDealt / 8) * this.stackCount, 1), getPokemonMessage(pokemon, `'s ${this.type.name}\nrestored its HP a little!`), true));
+        Math.max(Math.floor(pokemon.turnData.damageDealt / 8) * this.stackCount, 1), i18next.t("modifier:hitHealApply", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon), typeName: this.type.name }), true));
     }
 
     return true;
@@ -1296,7 +1297,7 @@ export class PokemonInstantReviveModifier extends PokemonHeldItemModifier {
     const pokemon = args[0] as Pokemon;
 
     pokemon.scene.unshiftPhase(new PokemonHealPhase(pokemon.scene, pokemon.getBattlerIndex(),
-      Math.max(Math.floor(pokemon.getMaxHp() / 2), 1), getPokemonMessage(pokemon, ` was revived\nby its ${this.type.name}!`), false, false, true));
+      Math.max(Math.floor(pokemon.getMaxHp() / 2), 1), i18next.t("modifier:pokemonInstantReviveApply", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon), typeName: this.type.name }), false, false, true));
 
     pokemon.resetStatus(true, false, true);
     return true;
@@ -2010,7 +2011,10 @@ export class MoneyInterestModifier extends PersistentModifier {
     const interestAmount = Math.floor(scene.money * 0.1 * this.getStackCount());
     scene.addMoney(interestAmount);
 
-    scene.queueMessage(`You received interest of ₽${interestAmount.toLocaleString("en-US")}\nfrom the ${this.type.name}!`, null, true);
+    const userLocale = navigator.language || "en-US";
+    const formattedMoneyAmount = interestAmount.toLocaleString(userLocale);
+    const message = i18next.t("modifier:moneyInterestApply", { moneyAmount: formattedMoneyAmount, typeName: this.type.name });
+    scene.queueMessage(message, null, true);
 
     return true;
   }
@@ -2231,7 +2235,7 @@ export class TurnHeldItemTransferModifier extends HeldItemTransferModifier {
   }
 
   getTransferMessage(pokemon: Pokemon, targetPokemon: Pokemon, item: ModifierTypes.ModifierType): string {
-    return getPokemonMessage(targetPokemon, `'s ${item.name} was absorbed\nby ${pokemon.name}'s ${this.type.name}!`);
+    return i18next.t("modifier:turnHeldItemTransferApply", { pokemonNameWithAffix: getPokemonNameWithAffix(targetPokemon), itemName: item.name, pokemonName: pokemon.name, typeName: this.type.name });
   }
 
   getMaxHeldItemCount(pokemon: Pokemon): integer {
@@ -2285,7 +2289,7 @@ export class ContactHeldItemTransferChanceModifier extends HeldItemTransferModif
   }
 
   getTransferMessage(pokemon: Pokemon, targetPokemon: Pokemon, item: ModifierTypes.ModifierType): string {
-    return getPokemonMessage(targetPokemon, `'s ${item.name} was snatched\nby ${pokemon.name}'s ${this.type.name}!`);
+    return i18next.t("modifier:contactHeldItemTransferApply", { pokemonNameWithAffix: getPokemonNameWithAffix(targetPokemon), itemName: item.name, pokemonName: pokemon.name, typeName: this.type.name });
   }
 
   getMaxHeldItemCount(pokemon: Pokemon): integer {
@@ -2443,7 +2447,7 @@ export class EnemyTurnHealModifier extends EnemyPersistentModifier {
     if (pokemon.getHpRatio() < 1) {
       const scene = pokemon.scene;
       scene.unshiftPhase(new PokemonHealPhase(scene, pokemon.getBattlerIndex(),
-        Math.max(Math.floor(pokemon.getMaxHp() / (100 / this.healPercent)) * this.stackCount, 1), getPokemonMessage(pokemon, "\nrestored some HP!"), true, false, false, false, true));
+        Math.max(Math.floor(pokemon.getMaxHp() / (100 / this.healPercent)) * this.stackCount, 1), i18next.t("modifier:enemyTurnHealApply", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }), true, false, false, false, true));
       return true;
     }
 


### PR DESCRIPTION
## What are the changes?
Add the option to localize message text when specific modifier applied.
 - survive damage : FOCUS_BAND (10%)
 - hit heal : SHELL_BELL
 - turn heal : LEFTOVERS
 - instant revive pokemon : REVIVER_SEED
 - money interest : COIN_CASE (each 10 turn)
 - turn held item transfer : MINI_BLACK_HOLE
 - contact held item transfer : GRIP_CLAW (10%)
 - enemy turn heal : ENEMY_HEAL

## Why am I doing these changes?
All text should be localizable.
In particular, these messages are harder for non-English users to see when messages go by quickly.

## What did change?
 - Change the code for localize > src/modifier/modifier.ts
 - Added locale files, config, localization keys in each language folders.
 - Translated them to Korean.
 - Modified hit heal, turn heal English message to match original games.
![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/9411e1d1-42c3-4d73-b500-9c48e1c8ad32)


### Screenshots/Videos
#### 1. En

<details>
<summary>Detail (Click to expand)</summary>

| Case | Result |
| :-----: | :-----: |
| FOCUS_BAND | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/78579f88-2dc3-4633-b2d1-35ca789c73b4) |
| SHELL_BELL | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/c0f42323-ddcf-4341-8431-fde56981c8d2) |
| LEFTOVERS | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/a021664c-3de2-4b68-a218-93cbc366a32c) |
| REVIVER_SEED | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/35209db6-65ed-4d02-8dc2-d83e20d4a781) |
| COIN_CASE | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/5b190090-092e-4aea-bc9c-660fc0b30635) |
| MINI_BLACK_HOLE | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/81523033-488a-45ba-87c3-15888df1b68b) |
| ENEMY_HEAL | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/5467e623-9f25-4806-b28c-f8f304e6234c) |

</details>



#### 2. Ko

<details>
<summary>Detail (Click to expand)</summary>

| Case | Result |
| :-----: | :-----: |
| FOCUS_BAND | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/8c338a90-5560-46dd-a4dc-22cc3e74ec16) |
| SHELL_BELL | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/bc03faa6-da98-468a-9f51-29a83f32f5ee) |
| LEFTOVERS | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/179eaf71-d7dc-4b9d-914b-185704b79fe9) |
| REVIVER_SEED | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/6a5beae1-2af2-48b1-a885-7338ef34f43e) |
| COIN_CASE | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/8ae86b88-90e8-42db-9f74-a785294f5c79) |
| MINI_BLACK_HOLE | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/4454ca97-48f9-44ae-87e5-f1fa1e369737) |
| ENEMY_HEAL | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/f9d88466-4d31-4805-8294-12f8bb6ff7bf) |

</details>


#### 3. De

<details>
<summary>Detail (Click to expand)</summary>

| Case | Result |
| :-----: | :-----: |
| FOCUS_BAND | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/29162e62-12f4-4c95-a1cd-c103a67c9a92) |
| SHELL_BELL | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/a16aff06-bbc9-4b67-ab80-cb4eb7f57dd0) |
| LEFTOVERS | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/8915477c-76c9-4989-a97e-da0faf19886b) |
| REVIVER_SEED | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/ad87e366-4580-43be-b42b-508c79afd3ee) |
| COIN_CASE | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/1d94fb70-c6e5-4f13-b03b-9a9095f6b304) |
| MINI_BLACK_HOLE | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/3404e9d6-f97d-46b3-bbeb-4f67bf89c85a) |
| ENEMY_HEAL | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/3c5b2e02-4c1c-4d7f-9a52-7ab5d14d1139) |

</details>


#### 4. Fr

<details>
<summary>Detail (Click to expand)</summary>

| Case | Result |
| :-----: | :-----: |
| FOCUS_BAND | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/203cc045-2084-40c8-89b4-a56a9d5d86a8) |
| SHELL_BELL | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/669b6e93-e7ae-4d1c-83ad-49a17b33a5c7) |
| LEFTOVERS | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/642d85de-eacd-49a9-bc96-b12cebe3db08) |
| REVIVER_SEED | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/09ffb6de-8f42-4476-8b99-be6c54d92e34) |
| COIN_CASE | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/d581fffc-26d7-4920-85f8-037d06514ada) |
| MINI_BLACK_HOLE | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/b12ba701-3a71-4779-af2f-bbcd58928280) |
| ENEMY_HEAL | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/92b1cad3-982f-43f6-b860-12876975e06f) |

</details>


#### 5. Pt_BR

<details>
<summary>Detail (Click to expand)</summary>

| Case | Result |
| :-----: | :-----: |
| FOCUS_BAND | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/70770dcc-cb6b-400a-88cc-00984a48ee1b) |
| SHELL_BELL | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/4d694bc0-d90e-4935-93ec-597950f6e54a) |
| LEFTOVERS | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/b5512989-e1fd-4415-b853-45f5466ea736) |
| REVIVER_SEED | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/abe92849-8180-4edc-b8e3-b08b78d56c30) |
| COIN_CASE | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/9624a8b1-96ef-4c47-bf5b-2ab8db3c45ed) |
| MINI_BLACK_HOLE | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/715f4054-bcd0-4168-9bca-f7e219235a75) |
| ENEMY_HEAL | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/df0bad63-00b5-4118-af91-ffcc35914bb8) |

</details>


#### 6. Zh_CN

<details>
<summary>Detail (Click to expand)</summary>

| Case | Result |
| :-----: | :-----: |
| FOCUS_BAND | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/144d815a-4856-408c-af75-069a2816af05) |
| SHELL_BELL | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/1b75b495-4ee2-4381-b01a-18d157eb839b) |
| LEFTOVERS | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/c4e4af84-a676-4e61-813e-9fc7597a1393) |
| REVIVER_SEED | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/66ea4720-7155-492f-a667-8431bb48dd9e) |
| COIN_CASE | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/48c873e0-483c-4fa3-8abe-0cec858b4b45) |
| MINI_BLACK_HOLE | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/1592f023-9995-450b-b921-3af995262d28) |
| ENEMY_HEAL | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/4ff1d9f2-3394-4b1b-a370-d16ff412e4ec) |

</details>


#### 7. Zh_TW

<details>
<summary>Detail (Click to expand)</summary>

| Case | Result |
| :-----: | :-----: |
| FOCUS_BAND | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/a589be8b-f396-4a08-9701-2ab9ccec896b) |
| SHELL_BELL | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/97f8428f-4cc1-4248-90c3-2a3bc3c16d04) |
| LEFTOVERS | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/cd793d95-2a93-449e-8393-fe5abfc61b8a) |
| REVIVER_SEED | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/2fda760d-4bf1-4286-9ddc-0942472dda09) |
| COIN_CASE | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/1a6dc8a1-88b2-4654-9232-26f4141b22f7) |
| MINI_BLACK_HOLE | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/e20e67af-bd54-4bc5-8d87-8bf30e695051) |
| ENEMY_HEAL | ![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/5bc78095-2cb8-4a56-8657-7dcb74b596c0) |

</details>

## How to test the changes?
Manually.
1. Checkout this PR and change language
2. set overrides.ts
```typescript
export const STARTING_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [ {name: "SHELL_BELL"}, {name: "COIN_CASE"}, {name: "GRIP_CLAW"}, {name: "MINI_BLACK_HOLE"} ];
export const OPP_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [ {name: "FOCUS_BAND"}, {name: "LEFTOVERS"}, {name: "REVIVER_SEED"}, {name: "ENEMY_HEAL"} ];
```
then start new game and watch modifier apply event.


## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?