### PR TITLE
[Bug] Fix #2821 to show correct type hints for abilities like Pixilate

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1149,6 +1149,11 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   getAttackMoveEffectiveness(source: Pokemon, pokemonMove: PokemonMove, ignoreAbility: boolean = false): TypeDamageMultiplier {
     const move = pokemonMove.getMove();
     const typeless = move.hasAttr(TypelessAttr);
+    // Apply abilities that change the move type
+    const typeChangeMovePowerMultiplier = new Utils.NumberHolder(1);
+    applyMoveAttrs(VariableMoveTypeAttr, source, this, move);
+    applyPreAttackAbAttrs(MoveTypeChangeAttr, source, this, move, typeChangeMovePowerMultiplier);
+
     const typeMultiplier = new Utils.NumberHolder(this.getAttackTypeEffectiveness(move.type, source));
     const cancelled = new Utils.BooleanHolder(false);
     applyMoveAttrs(VariableMoveTypeMultiplierAttr, source, this, move, typeMultiplier);

--- a/src/test/field/pokemon.test.ts
+++ b/src/test/field/pokemon.test.ts
@@ -44,7 +44,6 @@ describe("Test Pokemon methods", () => {
       const playerPokemon = game.gameWrapper.scene.getPlayerPokemon();
       const tackle = new PokemonMove(Moves.TACKLE);
       const enemyPokemon = game.gameWrapper.scene.getEnemyPokemon();
-      console.log(playerPokemon.getAbility());
       const typeEffectiveness = enemyPokemon.getAttackMoveEffectiveness(playerPokemon, tackle, false);
       expect(typeEffectiveness.valueOf()).toEqual(2);
     }, 20000);

--- a/src/test/field/pokemon.test.ts
+++ b/src/test/field/pokemon.test.ts
@@ -1,0 +1,53 @@
+import { PokemonMove } from "#app/field/pokemon.js";
+import GameManager from "#app/test/utils/gameManager";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import * as overrides from "../../overrides";
+
+describe("Test Pokemon methods", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+  });
+
+  describe("getAttackMoveEffectiveness", () => {
+    it("checks for abilities like Pixilate that change type effectiveness of attacking mon", async() => {
+      vi.spyOn(overrides, "STARTER_SPECIES_OVERRIDE", "get").mockReturnValue(Species.DUSKULL);
+      vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.PIXILATE);
+      vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.SABLEYE);
+      vi.spyOn(overrides, "STARTING_LEVEL_OVERRIDE", "get").mockReturnValue(5);
+      vi.spyOn(overrides, "STARTING_WAVE_OVERRIDE", "get").mockReturnValue(3);
+      vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([
+        Moves.TACKLE,
+        Moves.GROWL,
+        Moves.SCRATCH,
+        Moves.ASTONISH,
+      ]
+      );
+      vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+      await game.startBattle();
+      const playerPokemon = game.gameWrapper.scene.getPlayerPokemon();
+      const tackle = new PokemonMove(Moves.TACKLE);
+      const enemyPokemon = game.gameWrapper.scene.getEnemyPokemon();
+      console.log(playerPokemon.getAbility());
+      const typeEffectiveness = enemyPokemon.getAttackMoveEffectiveness(playerPokemon, tackle, false);
+      expect(typeEffectiveness.valueOf()).toEqual(2);
+    }, 20000);
+  });
+});
+


### PR DESCRIPTION
## What are the changes?
The user now gets correct type hints when their mon has abilities like [Pixilate](https://bulbapedia.bulbagarden.net/wiki/Pixilate_(Ability)). For a full list of abilities that may change a move's type, see [here](https://bulbapedia.bulbagarden.net/wiki/Category:Abilities_that_can_modify_move_types

As it is my first PR for this repo, I would be grateful for better and faster ways to test. In my mind, the test I introduced would not need to set up a game scene, but I could not find a way to instantiate a Pokemon outside of a Scene/Game.

## Why am I doing these changes?
See #2821 for the original issue. It helps players with type hints to correctly assess the effectiveness of their attack.

## What did change?
Add test for the Pixilate ability, tackling a Sableye.
Add a check during `getAttackMoveEffectiveness` for the abilities of the attacker mon.

### Screenshots/Videos
Before, Tackle was type hinted incorrectly when the pokemon had Pixilate (should be super effective against dark, should hit against ghost):
![grafik](https://github.com/pagefaultgames/pokerogue/assets/20730499/02f0618f-f687-4e43-9253-de15b6a9ab1f)
After: 
![grafik](https://github.com/pagefaultgames/pokerogue/assets/20730499/54bda52f-c7ea-4405-ab5c-521c2de52317)


## How to test the changes?
Get a pokemon with Pixilate as starting ability with Tackle move against Sableye. 
Tackle should now be super effective as a Fairy move against Dark.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?