### PR TITLE
[Hotfix][Localization] Modify wrong import path (ko config)

### DIFF
--- a/src/locales/ko/config.ts
+++ b/src/locales/ko/config.ts
@@ -1,4 +1,4 @@
-import { pokemonForm } from "../es/pokemon-form";
+import { pokemonForm } from "./pokemon-form";
 import { ability } from "./ability";
 import { abilityTriggers } from "./ability-trigger";
 import { PGFachv, PGMachv } from "./achv";


### PR DESCRIPTION
## What are the changes?
Change import path of Korean locale config

## Why am I doing these changes?
Import path is /es/ so Korean translation of form is not working.

## What did change?
Modify import path

### Screenshots/Videos
![image](https://github.com/pagefaultgames/pokerogue/assets/19601207/fc8c2fee-0554-4ed8-8795-04848dc23f29)

## How to test the changes?
Manually.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?