### PR TITLE
[Enhancement] Decouple move accuracy and accuracy multiplier calculation from phases.ts

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1,11 +1,11 @@
 import BattleScene, { bypassLogin } from "./battle-scene";
 import { default as Pokemon, PlayerPokemon, EnemyPokemon, PokemonMove, MoveResult, DamageResult, FieldPosition, HitResult, TurnMove } from "./field/pokemon";
 import * as Utils from "./utils";
-import { allMoves, applyMoveAttrs, BypassSleepAttr, ChargeAttr, applyFilteredMoveAttrs, HitsTagAttr, MissEffectAttr, MoveAttr, MoveEffectAttr, MoveFlags, MultiHitAttr, OverrideMoveEffectAttr, VariableAccuracyAttr, MoveTarget, getMoveTargets, MoveTargetSet, MoveEffectTrigger, CopyMoveAttr, AttackMove, SelfStatusMove, PreMoveMessageAttr, HealStatusEffectAttr, IgnoreOpponentStatChangesAttr, NoEffectAttr, BypassRedirectAttr, FixedDamageAttr, PostVictoryStatChangeAttr, OneHitKOAccuracyAttr, ForceSwitchOutAttr, VariableTargetAttr, IncrementMovePriorityAttr } from "./data/move";
+import { allMoves, applyMoveAttrs, BypassSleepAttr, ChargeAttr, applyFilteredMoveAttrs, HitsTagAttr, MissEffectAttr, MoveAttr, MoveEffectAttr, MoveFlags, MultiHitAttr, OverrideMoveEffectAttr, MoveTarget, getMoveTargets, MoveTargetSet, MoveEffectTrigger, CopyMoveAttr, AttackMove, SelfStatusMove, PreMoveMessageAttr, HealStatusEffectAttr, NoEffectAttr, BypassRedirectAttr, FixedDamageAttr, PostVictoryStatChangeAttr, ForceSwitchOutAttr, VariableTargetAttr, IncrementMovePriorityAttr } from "./data/move";
 import { Mode } from "./ui/ui";
 import { Command } from "./ui/command-ui-handler";
 import { Stat } from "./data/pokemon-stat";
-import { BerryModifier, ContactHeldItemTransferChanceModifier, EnemyAttackStatusEffectChanceModifier, EnemyPersistentModifier, EnemyStatusEffectHealChanceModifier, EnemyTurnHealModifier, ExpBalanceModifier, ExpBoosterModifier, ExpShareModifier, ExtraModifierModifier, FlinchChanceModifier, HealingBoosterModifier, HitHealModifier, LapsingPersistentModifier, MapModifier, Modifier, MultipleParticipantExpBonusModifier, PersistentModifier, PokemonExpBoosterModifier, PokemonHeldItemModifier, PokemonInstantReviveModifier, SwitchEffectTransferModifier, TempBattleStatBoosterModifier, TurnHealModifier, TurnHeldItemTransferModifier, MoneyMultiplierModifier, MoneyInterestModifier, IvScannerModifier, LapsingPokemonHeldItemModifier, PokemonMultiHitModifier, PokemonMoveAccuracyBoosterModifier, overrideModifiers, overrideHeldItems, BypassSpeedChanceModifier, TurnStatusEffectModifier } from "./modifier/modifier";
+import { BerryModifier, ContactHeldItemTransferChanceModifier, EnemyAttackStatusEffectChanceModifier, EnemyPersistentModifier, EnemyStatusEffectHealChanceModifier, EnemyTurnHealModifier, ExpBalanceModifier, ExpBoosterModifier, ExpShareModifier, ExtraModifierModifier, FlinchChanceModifier, HealingBoosterModifier, HitHealModifier, LapsingPersistentModifier, MapModifier, Modifier, MultipleParticipantExpBonusModifier, PersistentModifier, PokemonExpBoosterModifier, PokemonHeldItemModifier, PokemonInstantReviveModifier, SwitchEffectTransferModifier, TurnHealModifier, TurnHeldItemTransferModifier, MoneyMultiplierModifier, MoneyInterestModifier, IvScannerModifier, LapsingPokemonHeldItemModifier, PokemonMultiHitModifier, overrideModifiers, overrideHeldItems, BypassSpeedChanceModifier, TurnStatusEffectModifier } from "./modifier/modifier";
 import PartyUiHandler, { PartyOption, PartyUiMode } from "./ui/party-ui-handler";
 import { doPokeballBounceAnim, getPokeballAtlasKey, getPokeballCatchMultiplier, getPokeballTintColor, PokeballType } from "./data/pokeball";
 import { CommonAnim, CommonBattleAnim, MoveAnim, initMoveAnim, loadMoveAnimAssets } from "./data/battle-anims";
@@ -24,9 +24,8 @@ import { getPokemonMessage, getPokemonNameWithAffix } from "./messages";
 import { Starter } from "./ui/starter-select-ui-handler";
 import { Gender } from "./data/gender";
 import { Weather, WeatherType, getRandomWeatherType, getTerrainBlockMessage, getWeatherDamageMessage, getWeatherLapseMessage } from "./data/weather";
-import { TempBattleStat } from "./data/temp-battle-stat";
 import { ArenaTagSide, ArenaTrapTag, MistTag, TrickRoomTag } from "./data/arena-tag";
-import { CheckTrappedAbAttr, IgnoreOpponentStatChangesAbAttr, IgnoreOpponentEvasionAbAttr, PostAttackAbAttr, PostBattleAbAttr, PostDefendAbAttr, PostSummonAbAttr, PostTurnAbAttr, PostWeatherLapseAbAttr, PreSwitchOutAbAttr, PreWeatherDamageAbAttr, ProtectStatAbAttr, RedirectMoveAbAttr, BlockRedirectAbAttr, RunSuccessAbAttr, StatChangeMultiplierAbAttr, SuppressWeatherEffectAbAttr, SyncEncounterNatureAbAttr, applyAbAttrs, applyCheckTrappedAbAttrs, applyPostAttackAbAttrs, applyPostBattleAbAttrs, applyPostDefendAbAttrs, applyPostSummonAbAttrs, applyPostTurnAbAttrs, applyPostWeatherLapseAbAttrs, applyPreStatChangeAbAttrs, applyPreSwitchOutAbAttrs, applyPreWeatherEffectAbAttrs, BattleStatMultiplierAbAttr, applyBattleStatMultiplierAbAttrs, IncrementMovePriorityAbAttr, applyPostVictoryAbAttrs, PostVictoryAbAttr, BlockNonDirectDamageAbAttr as BlockNonDirectDamageAbAttr, applyPostKnockOutAbAttrs, PostKnockOutAbAttr, PostBiomeChangeAbAttr, applyPostFaintAbAttrs, PostFaintAbAttr, IncreasePpAbAttr, PostStatChangeAbAttr, applyPostStatChangeAbAttrs, AlwaysHitAbAttr, PreventBerryUseAbAttr, StatChangeCopyAbAttr, PokemonTypeChangeAbAttr, applyPreAttackAbAttrs, applyPostMoveUsedAbAttrs, PostMoveUsedAbAttr, MaxMultiHitAbAttr, HealFromBerryUseAbAttr, WonderSkinAbAttr, applyPreDefendAbAttrs, IgnoreMoveEffectsAbAttr, BlockStatusDamageAbAttr, BypassSpeedChanceAbAttr, AddSecondStrikeAbAttr } from "./data/ability";
+import { CheckTrappedAbAttr, PostAttackAbAttr, PostBattleAbAttr, PostDefendAbAttr, PostSummonAbAttr, PostTurnAbAttr, PostWeatherLapseAbAttr, PreSwitchOutAbAttr, PreWeatherDamageAbAttr, ProtectStatAbAttr, RedirectMoveAbAttr, BlockRedirectAbAttr, RunSuccessAbAttr, StatChangeMultiplierAbAttr, SuppressWeatherEffectAbAttr, SyncEncounterNatureAbAttr, applyAbAttrs, applyCheckTrappedAbAttrs, applyPostAttackAbAttrs, applyPostBattleAbAttrs, applyPostDefendAbAttrs, applyPostSummonAbAttrs, applyPostTurnAbAttrs, applyPostWeatherLapseAbAttrs, applyPreStatChangeAbAttrs, applyPreSwitchOutAbAttrs, applyPreWeatherEffectAbAttrs, IncrementMovePriorityAbAttr, applyPostVictoryAbAttrs, PostVictoryAbAttr, BlockNonDirectDamageAbAttr as BlockNonDirectDamageAbAttr, applyPostKnockOutAbAttrs, PostKnockOutAbAttr, PostBiomeChangeAbAttr, applyPostFaintAbAttrs, PostFaintAbAttr, IncreasePpAbAttr, PostStatChangeAbAttr, applyPostStatChangeAbAttrs, AlwaysHitAbAttr, PreventBerryUseAbAttr, StatChangeCopyAbAttr, PokemonTypeChangeAbAttr, applyPreAttackAbAttrs, applyPostMoveUsedAbAttrs, PostMoveUsedAbAttr, MaxMultiHitAbAttr, HealFromBerryUseAbAttr, IgnoreMoveEffectsAbAttr, BlockStatusDamageAbAttr, BypassSpeedChanceAbAttr, AddSecondStrikeAbAttr } from "./data/ability";
 import { Unlockables, getUnlockableName } from "./system/unlockables";
 import { getBiomeKey } from "./field/arena";
 import { BattleType, BattlerIndex, TurnCommand } from "./battle";
@@ -3067,54 +3066,16 @@ export class MoveEffectPhase extends PokemonPhase {
       return false;
     }
 
-    const moveAccuracy = new Utils.NumberHolder(this.move.getMove().accuracy);
+    const moveAccuracy = this.move.getMove().calculateBattleAccuracy(user, target);
 
-    applyMoveAttrs(VariableAccuracyAttr, user, target, this.move.getMove(), moveAccuracy);
-    applyPreDefendAbAttrs(WonderSkinAbAttr, target, user, this.move.getMove(), { value: false }, moveAccuracy);
-
-    if (moveAccuracy.value === -1) {
+    if (moveAccuracy === -1) {
       return true;
     }
 
-    const isOhko = this.move.getMove().hasAttr(OneHitKOAccuracyAttr);
-
-    if (!isOhko) {
-      user.scene.applyModifiers(PokemonMoveAccuracyBoosterModifier, user.isPlayer(), user, moveAccuracy);
-    }
-
-    if (this.scene.arena.weather?.weatherType === WeatherType.FOG) {
-      moveAccuracy.value = Math.floor(moveAccuracy.value * 0.9);
-    }
-
-    if (!isOhko && this.scene.arena.getTag(ArenaTagType.GRAVITY)) {
-      moveAccuracy.value = Math.floor(moveAccuracy.value * 1.67);
-    }
-
-    const userAccuracyLevel = new Utils.IntegerHolder(user.summonData.battleStats[BattleStat.ACC]);
-    const targetEvasionLevel = new Utils.IntegerHolder(target.summonData.battleStats[BattleStat.EVA]);
-    applyAbAttrs(IgnoreOpponentStatChangesAbAttr, target, null, userAccuracyLevel);
-    applyAbAttrs(IgnoreOpponentStatChangesAbAttr, user, null, targetEvasionLevel);
-    applyAbAttrs(IgnoreOpponentEvasionAbAttr, user, null, targetEvasionLevel);
-    applyMoveAttrs(IgnoreOpponentStatChangesAttr, user, target, this.move.getMove(), targetEvasionLevel);
-    this.scene.applyModifiers(TempBattleStatBoosterModifier, this.player, TempBattleStat.ACC, userAccuracyLevel);
-
+    const accuracyMultiplier = user.getAccuracyMultiplier(target, this.move.getMove());
     const rand = user.randSeedInt(100, 1);
 
-    const accuracyMultiplier = new Utils.NumberHolder(1);
-    if (userAccuracyLevel.value !== targetEvasionLevel.value) {
-      accuracyMultiplier.value = userAccuracyLevel.value > targetEvasionLevel.value
-        ? (3 + Math.min(userAccuracyLevel.value - targetEvasionLevel.value, 6)) / 3
-        : 3 / (3 + Math.min(targetEvasionLevel.value - userAccuracyLevel.value, 6));
-    }
-
-    applyBattleStatMultiplierAbAttrs(BattleStatMultiplierAbAttr, user, BattleStat.ACC, accuracyMultiplier, this.move.getMove());
-
-    const evasionMultiplier = new Utils.NumberHolder(1);
-    applyBattleStatMultiplierAbAttrs(BattleStatMultiplierAbAttr, target, BattleStat.EVA, evasionMultiplier);
-
-    accuracyMultiplier.value /= evasionMultiplier.value;
-
-    return rand <= moveAccuracy.value * accuracyMultiplier.value;
+    return rand <= moveAccuracy * accuracyMultiplier;
   }
 
   getUserPokemon(): Pokemon {

--- a/src/test/abilities/wonder_skin.test.ts
+++ b/src/test/abilities/wonder_skin.test.ts
@@ -3,11 +3,12 @@ import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
 import overrides from "#app/overrides";
 import { Species } from "#enums/species";
-import { MoveEffectPhase, TurnEndPhase, } from "#app/phases";
+import { MoveEffectPhase } from "#app/phases";
 import { Moves } from "#enums/moves";
 import { getMovePosition } from "#app/test/utils/gameManagerUtils";
 import { Abilities } from "#enums/abilities";
-import { allMoves, MoveFlags } from "#app/data/move.js";
+import { allMoves } from "#app/data/move.js";
+import { allAbilities } from "#app/data/ability.js";
 
 describe("Abilities - Wonder Skin", () => {
   let phaserGame: Phaser.Game;
@@ -26,81 +27,51 @@ describe("Abilities - Wonder Skin", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
-    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.WONDER_SKIN);
     vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.TACKLE, Moves.CHARM]);
+    vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.BALL_FETCH);
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.SHUCKLE);
+    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.WONDER_SKIN);
     vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.SPLASH, Moves.SPLASH, Moves.SPLASH]);
   });
 
   it("lowers accuracy of status moves to 50%", async () => {
-    await game.startBattle([Species.MAGIKARP]);
+    const moveToCheck = allMoves[Moves.CHARM];
 
+    vi.spyOn(moveToCheck, "calculateBattleAccuracy");
+
+    await game.startBattle([Species.PIKACHU]);
     game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
+    await game.phaseInterceptor.to(MoveEffectPhase);
 
-    const moveAccuracy = allMoves[Moves.CHARM].calculateBattleAccuracy(game.scene.getPlayerPokemon(), game.scene.getEnemyPokemon());
-
-    await game.phaseInterceptor.to(TurnEndPhase);
-    expect(moveAccuracy).toBe(50);
+    expect(moveToCheck.calculateBattleAccuracy).toHaveReturnedWith(50);
   });
 
   it("does not lower accuracy of non-status moves", async () => {
-    await game.startBattle([Species.MAGIKARP]);
+    const moveToCheck = allMoves[Moves.TACKLE];
 
+    vi.spyOn(moveToCheck, "calculateBattleAccuracy");
+
+    await game.startBattle([Species.PIKACHU]);
     game.doAttack(getMovePosition(game.scene, 0, Moves.TACKLE));
+    await game.phaseInterceptor.to(MoveEffectPhase);
 
-    const moveAccuracy = allMoves[Moves.TACKLE].calculateBattleAccuracy(game.scene.getPlayerPokemon(), game.scene.getEnemyPokemon());
-
-    await game.phaseInterceptor.to(TurnEndPhase);
-    expect(moveAccuracy).not.toBe(50);
+    expect(moveToCheck.calculateBattleAccuracy).toHaveReturnedWith(100);
   });
 
-  it("does not affect pokemon with Mold Breaker", async () => {
-    vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.MOLD_BREAKER);
+  const bypassAbilities = [Abilities.MOLD_BREAKER, Abilities.TERAVOLT, Abilities.TURBOBLAZE];
 
-    await game.startBattle([Species.MAGIKARP]);
+  bypassAbilities.forEach(ability => {
+    it(`does not affect pokemon with ${allAbilities[ability].name}`, async () => {
+      const moveToCheck = allMoves[Moves.CHARM];
 
-    game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+      vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(ability);
+      vi.spyOn(moveToCheck, "calculateBattleAccuracy");
 
-    const shouldIgnoreAbility = allMoves[Moves.CHARM].checkFlag(MoveFlags.IGNORE_ABILITIES, game.scene.getPlayerPokemon(), game.scene.getEnemyPokemon());
-    const hitCheck = (game.scene.getCurrentPhase() as MoveEffectPhase).hitCheck(game.scene.getEnemyPokemon());
+      await game.startBattle([Species.PIKACHU]);
+      game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
+      await game.phaseInterceptor.to(MoveEffectPhase);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
-
-    expect(shouldIgnoreAbility).toBe(true);
-    expect(hitCheck).toBe(true);
-  });
-
-  it("does not affect pokemon with Teravolt", async () => {
-    vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.TERAVOLT);
-
-    await game.startBattle([Species.MAGIKARP]);
-
-    game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
-
-    const shouldIgnoreAbility = allMoves[Moves.CHARM].checkFlag(MoveFlags.IGNORE_ABILITIES, game.scene.getPlayerPokemon(), game.scene.getEnemyPokemon());
-    const hitCheck = (game.scene.getCurrentPhase() as MoveEffectPhase).hitCheck(game.scene.getEnemyPokemon());
-
-    await game.phaseInterceptor.to(TurnEndPhase);
-
-    expect(shouldIgnoreAbility).toBe(true);
-    expect(hitCheck).toBe(true);
-  });
-
-  it("does not affect pokemon with Turboblaze", async () => {
-    vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.TURBOBLAZE);
-
-    await game.startBattle([Species.MAGIKARP]);
-
-    game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
-
-    const shouldIgnoreAbility = allMoves[Moves.CHARM].checkFlag(MoveFlags.IGNORE_ABILITIES, game.scene.getPlayerPokemon(), game.scene.getEnemyPokemon());
-    const hitCheck = (game.scene.getCurrentPhase() as MoveEffectPhase).hitCheck(game.scene.getEnemyPokemon());
-
-    await game.phaseInterceptor.to(TurnEndPhase);
-
-    expect(shouldIgnoreAbility).toBe(true);
-    expect(hitCheck).toBe(true);
+      expect(moveToCheck.calculateBattleAccuracy).toHaveReturnedWith(100);
+    });
   });
 });

--- a/src/test/abilities/wonder_skin.test.ts
+++ b/src/test/abilities/wonder_skin.test.ts
@@ -3,14 +3,11 @@ import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
 import overrides from "#app/overrides";
 import { Species } from "#enums/species";
-import { TurnEndPhase, } from "#app/phases";
+import { MoveEffectPhase, TurnEndPhase, } from "#app/phases";
 import { Moves } from "#enums/moves";
 import { getMovePosition } from "#app/test/utils/gameManagerUtils";
 import { Abilities } from "#enums/abilities";
-import Move, { allMoves } from "#app/data/move.js";
-import { MoveAbilityBypassAbAttr, WonderSkinAbAttr } from "#app/data/ability.js";
-import { NumberHolder } from "#app/utils.js";
-import Pokemon from "#app/field/pokemon.js";
+import { allMoves, MoveFlags } from "#app/data/move.js";
 
 describe("Abilities - Wonder Skin", () => {
   let phaserGame: Phaser.Game;
@@ -39,13 +36,10 @@ describe("Abilities - Wonder Skin", () => {
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
 
-    const mockedAccuracy = getMockedMoveAccuracy(game.scene.getEnemyPokemon(), game.scene.getPlayerPokemon(), allMoves[Moves.CHARM]);
+    const moveAccuracy = allMoves[Moves.CHARM].calculateBattleAccuracy(game.scene.getPlayerPokemon(), game.scene.getEnemyPokemon());
 
     await game.phaseInterceptor.to(TurnEndPhase);
-
-    expect(mockedAccuracy).not.toBe(undefined);
-    expect(mockedAccuracy).not.toBe(100);
-    expect(mockedAccuracy).toBe(50);
+    expect(moveAccuracy).toBe(50);
   });
 
   it("does not lower accuracy of non-status moves", async () => {
@@ -53,13 +47,10 @@ describe("Abilities - Wonder Skin", () => {
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.TACKLE));
 
-    const mockedAccuracy = getMockedMoveAccuracy(game.scene.getEnemyPokemon(), game.scene.getPlayerPokemon(), allMoves[Moves.TACKLE]);
+    const moveAccuracy = allMoves[Moves.TACKLE].calculateBattleAccuracy(game.scene.getPlayerPokemon(), game.scene.getEnemyPokemon());
 
     await game.phaseInterceptor.to(TurnEndPhase);
-
-    expect(mockedAccuracy).not.toBe(undefined);
-    expect(mockedAccuracy).toBe(100);
-    expect(mockedAccuracy).not.toBe(50);
+    expect(moveAccuracy).not.toBe(50);
   });
 
   it("does not affect pokemon with Mold Breaker", async () => {
@@ -68,14 +59,15 @@ describe("Abilities - Wonder Skin", () => {
     await game.startBattle([Species.MAGIKARP]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
 
-    const mockedAccuracy = getMockedMoveAccuracy(game.scene.getEnemyPokemon(), game.scene.getPlayerPokemon(), allMoves[Moves.CHARM]);
+    const shouldIgnoreAbility = allMoves[Moves.CHARM].checkFlag(MoveFlags.IGNORE_ABILITIES, game.scene.getPlayerPokemon(), game.scene.getEnemyPokemon());
+    const hitCheck = (game.scene.getCurrentPhase() as MoveEffectPhase).hitCheck(game.scene.getEnemyPokemon());
 
     await game.phaseInterceptor.to(TurnEndPhase);
 
-    expect(mockedAccuracy).not.toBe(undefined);
-    expect(mockedAccuracy).toBe(100);
-    expect(mockedAccuracy).not.toBe(50);
+    expect(shouldIgnoreAbility).toBe(true);
+    expect(hitCheck).toBe(true);
   });
 
   it("does not affect pokemon with Teravolt", async () => {
@@ -84,14 +76,15 @@ describe("Abilities - Wonder Skin", () => {
     await game.startBattle([Species.MAGIKARP]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
 
-    const mockedAccuracy = getMockedMoveAccuracy(game.scene.getEnemyPokemon(), game.scene.getPlayerPokemon(), allMoves[Moves.CHARM]);
+    const shouldIgnoreAbility = allMoves[Moves.CHARM].checkFlag(MoveFlags.IGNORE_ABILITIES, game.scene.getPlayerPokemon(), game.scene.getEnemyPokemon());
+    const hitCheck = (game.scene.getCurrentPhase() as MoveEffectPhase).hitCheck(game.scene.getEnemyPokemon());
 
     await game.phaseInterceptor.to(TurnEndPhase);
 
-    expect(mockedAccuracy).not.toBe(undefined);
-    expect(mockedAccuracy).toBe(100);
-    expect(mockedAccuracy).not.toBe(50);
+    expect(shouldIgnoreAbility).toBe(true);
+    expect(hitCheck).toBe(true);
   });
 
   it("does not affect pokemon with Turboblaze", async () => {
@@ -100,42 +93,14 @@ describe("Abilities - Wonder Skin", () => {
     await game.startBattle([Species.MAGIKARP]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
 
-    const mockedAccuracy = getMockedMoveAccuracy(game.scene.getEnemyPokemon(), game.scene.getPlayerPokemon(), allMoves[Moves.CHARM]);
+    const shouldIgnoreAbility = allMoves[Moves.CHARM].checkFlag(MoveFlags.IGNORE_ABILITIES, game.scene.getPlayerPokemon(), game.scene.getEnemyPokemon());
+    const hitCheck = (game.scene.getCurrentPhase() as MoveEffectPhase).hitCheck(game.scene.getEnemyPokemon());
 
     await game.phaseInterceptor.to(TurnEndPhase);
 
-    expect(mockedAccuracy).not.toBe(undefined);
-    expect(mockedAccuracy).toBe(100);
-    expect(mockedAccuracy).not.toBe(50);
+    expect(shouldIgnoreAbility).toBe(true);
+    expect(hitCheck).toBe(true);
   });
 });
-
-/**
- * Calculates the mocked accuracy of a move.
- * Note this does not consider other accuracy calculations
- * except the power multiplier from Wonder Skin.
- * Bypassed by MoveAbilityBypassAbAttr {@linkcode MoveAbilityBypassAbAttr}
- *
- * @param defender - The defending Pokémon.
- * @param attacker - The attacking Pokémon.
- * @param move - The move being used by the attacker.
- * @returns The adjusted accuracy of the move.
- */
-const getMockedMoveAccuracy = (defender: Pokemon, attacker: Pokemon, move: Move) => {
-  const accuracyHolder = new NumberHolder(move.accuracy);
-
-  /**
-     * Simulate ignoring ability
-     * @see MoveAbilityBypassAbAttr
-     */
-  if (attacker.hasAbilityWithAttr(MoveAbilityBypassAbAttr)) {
-    return accuracyHolder.value;
-  }
-
-  const wonderSkinInstance = new WonderSkinAbAttr();
-
-  wonderSkinInstance.applyPreDefend(defender, false, attacker, move, { value: false }, [ accuracyHolder ]);
-
-  return accuracyHolder.value;
-};

--- a/src/test/arena/arena_gravity.test.ts
+++ b/src/test/arena/arena_gravity.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import {
   TurnEndPhase,

--- a/src/test/arena/arena_gravity.test.ts
+++ b/src/test/arena/arena_gravity.test.ts
@@ -4,12 +4,14 @@ import GameManager from "#app/test/utils/gameManager";
 import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import {
+  MoveEffectPhase,
   TurnEndPhase,
 } from "#app/phases";
 import { Moves } from "#enums/moves";
 import { getMovePosition } from "#app/test/utils/gameManagerUtils";
 import { allMoves } from "#app/data/move.js";
 import { ArenaTagType } from "#app/enums/arena-tag-type.js";
+import { Abilities } from "#app/enums/abilities.js";
 
 describe("Arena - Gravity", () => {
   let phaserGame: Phaser.Game;
@@ -28,26 +30,30 @@ describe("Arena - Gravity", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
-    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.MAGIKARP);
     vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.TACKLE, Moves.GRAVITY]);
+    vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.BALL_FETCH);
+    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.BALL_FETCH);
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.SHUCKLE);
     vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue(new Array(4).fill(Moves.SPLASH));
   });
 
   it("non-OHKO move accuracy is multiplied by 1.67", async () => {
     const moveToCheck = allMoves[Moves.TACKLE];
-    await game.startBattle([Species.MAGIKARP]);
 
-    const preGravityMoveAccuracy = moveToCheck.calculateBattleAccuracy(game.scene.getPlayerPokemon(), game.scene.getEnemyPokemon());
-    expect(preGravityMoveAccuracy).not.toBe(moveToCheck.accuracy * 1.67);
+    vi.spyOn(moveToCheck, "calculateBattleAccuracy");
 
+    // Setup Gravity on first turn
+    await game.startBattle([Species.PIKACHU]);
     game.doAttack(getMovePosition(game.scene, 0, Moves.GRAVITY));
-
     await game.phaseInterceptor.to(TurnEndPhase);
-    await game.toNextTurn();
 
     expect(game.scene.arena.getTag(ArenaTagType.GRAVITY)).toBeDefined();
 
-    const postGravityMoveAccuracy = moveToCheck.calculateBattleAccuracy(game.scene.getPlayerPokemon(), game.scene.getEnemyPokemon());
-    expect(postGravityMoveAccuracy).toBe(Math.floor(moveToCheck.accuracy * 1.67));
+    // Use non-OHKO move on second turn
+    await game.toNextTurn();
+    game.doAttack(getMovePosition(game.scene, 0, Moves.TACKLE));
+    await game.phaseInterceptor.to(MoveEffectPhase);
+
+    expect(moveToCheck.calculateBattleAccuracy).toHaveReturnedWith(100 * 1.67);
   });
 });

--- a/src/test/arena/arena_gravity.test.ts
+++ b/src/test/arena/arena_gravity.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import Phaser from "phaser";
+import GameManager from "#app/test/utils/gameManager";
+import * as overrides from "#app/overrides";
+import { Species } from "#enums/species";
+import {
+  TurnEndPhase,
+} from "#app/phases";
+import { Moves } from "#enums/moves";
+import { getMovePosition } from "#app/test/utils/gameManagerUtils";
+import { allMoves } from "#app/data/move.js";
+import { ArenaTagType } from "#app/enums/arena-tag-type.js";
+
+describe("Arena - Gravity", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.MAGIKARP);
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.TACKLE, Moves.GRAVITY]);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue(new Array(4).fill(Moves.SPLASH));
+  });
+
+  it("non-OHKO move accuracy is multiplied by 1.67", async () => {
+    const moveToCheck = allMoves[Moves.TACKLE];
+    await game.startBattle([Species.MAGIKARP]);
+
+    const preGravityMoveAccuracy = moveToCheck.calculateBattleAccuracy(game.scene.getPlayerPokemon(), game.scene.getEnemyPokemon());
+    expect(preGravityMoveAccuracy).not.toBe(moveToCheck.accuracy * 1.67);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.GRAVITY));
+
+    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.toNextTurn();
+
+    expect(game.scene.arena.getTag(ArenaTagType.GRAVITY)).toBeDefined();
+
+    const postGravityMoveAccuracy = moveToCheck.calculateBattleAccuracy(game.scene.getPlayerPokemon(), game.scene.getEnemyPokemon());
+    expect(postGravityMoveAccuracy).toBe(Math.floor(moveToCheck.accuracy * 1.67));
+  });
+});

--- a/src/test/arena/weather_fog.test.ts
+++ b/src/test/arena/weather_fog.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import {
   MoveEndPhase,

--- a/src/test/arena/weather_fog.test.ts
+++ b/src/test/arena/weather_fog.test.ts
@@ -4,12 +4,13 @@ import GameManager from "#app/test/utils/gameManager";
 import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import {
-  MoveEndPhase,
+  MoveEffectPhase,
 } from "#app/phases";
 import { Moves } from "#enums/moves";
 import { getMovePosition } from "#app/test/utils/gameManagerUtils";
 import { allMoves } from "#app/data/move.js";
 import { WeatherType } from "#app/data/weather.js";
+import { Abilities } from "#app/enums/abilities.js";
 
 describe("Weather - Fog", () => {
   let phaserGame: Phaser.Game;
@@ -29,21 +30,22 @@ describe("Weather - Fog", () => {
     game = new GameManager(phaserGame);
     vi.spyOn(overrides, "WEATHER_OVERRIDE", "get").mockReturnValue(WeatherType.FOG);
     vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
-    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.MAGIKARP);
     vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.TACKLE]);
+    vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.BALL_FETCH);
+    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.BALL_FETCH);
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.MAGIKARP);
     vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue(new Array(4).fill(Moves.SPLASH));
   });
 
   it("move accuracy is multiplied by 90%", async () => {
     const moveToCheck = allMoves[Moves.TACKLE];
+
+    vi.spyOn(moveToCheck, "calculateBattleAccuracy");
+
     await game.startBattle([Species.MAGIKARP]);
-
     game.doAttack(getMovePosition(game.scene, 0, Moves.TACKLE));
-    const moveAccuracy = moveToCheck.calculateBattleAccuracy(game.scene.getPlayerPokemon(), game.scene.getEnemyPokemon());
+    await game.phaseInterceptor.to(MoveEffectPhase);
 
-    await game.phaseInterceptor.to(MoveEndPhase);
-
-    expect(moveAccuracy).not.toBe(moveToCheck.accuracy);
-    expect(moveAccuracy).toBe(moveToCheck.accuracy * 0.9);
+    expect(moveToCheck.calculateBattleAccuracy).toHaveReturnedWith(100 * 0.9);
   });
 });

--- a/src/test/arena/weather_fog.test.ts
+++ b/src/test/arena/weather_fog.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import Phaser from "phaser";
+import GameManager from "#app/test/utils/gameManager";
+import * as overrides from "#app/overrides";
+import { Species } from "#enums/species";
+import {
+  MoveEndPhase,
+} from "#app/phases";
+import { Moves } from "#enums/moves";
+import { getMovePosition } from "#app/test/utils/gameManagerUtils";
+import { allMoves } from "#app/data/move.js";
+import { WeatherType } from "#app/data/weather.js";
+
+describe("Weather - Fog", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    vi.spyOn(overrides, "WEATHER_OVERRIDE", "get").mockReturnValue(WeatherType.FOG);
+    vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.MAGIKARP);
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.TACKLE]);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue(new Array(4).fill(Moves.SPLASH));
+  });
+
+  it("move accuracy is multiplied by 90%", async () => {
+    const moveToCheck = allMoves[Moves.TACKLE];
+    await game.startBattle([Species.MAGIKARP]);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.TACKLE));
+    const moveAccuracy = moveToCheck.calculateBattleAccuracy(game.scene.getPlayerPokemon(), game.scene.getEnemyPokemon());
+
+    await game.phaseInterceptor.to(MoveEndPhase);
+
+    expect(moveAccuracy).not.toBe(moveToCheck.accuracy);
+    expect(moveAccuracy).toBe(moveToCheck.accuracy * 0.9);
+  });
+});

--- a/src/test/moves/double_team.test.ts
+++ b/src/test/moves/double_team.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import {
   TurnEndPhase,

--- a/src/test/moves/double_team.test.ts
+++ b/src/test/moves/double_team.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import Phaser from "phaser";
+import GameManager from "#app/test/utils/gameManager";
+import * as overrides from "#app/overrides";
+import { Species } from "#enums/species";
+import {
+  TurnEndPhase,
+} from "#app/phases";
+import { Moves } from "#enums/moves";
+import { getMovePosition } from "#app/test/utils/gameManagerUtils";
+import { BattleStat } from "#app/data/battle-stat.js";
+import { allMoves } from "#app/data/move.js";
+import { Abilities } from "#app/enums/abilities.js";
+
+describe("Moves - Double Team", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.DOUBLE_TEAM]);
+    vi.spyOn(overrides, "NEVER_CRIT_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.BALL_FETCH);
+    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.BALL_FETCH);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE]);
+  });
+
+  it("increases the user's evasion by one stage.", async () => {
+    const moveToCheck = allMoves[Moves.TACKLE];
+    await game.startBattle([Species.MAGIKARP]);
+
+    const ally = game.scene.getPlayerPokemon();
+    const enemy = game.scene.getEnemyPokemon();
+    const preMoveAccMultiplier = enemy.getAccuracyMultiplier(ally, moveToCheck);
+
+    expect(ally.summonData.battleStats[BattleStat.EVA]).toBe(0);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.DOUBLE_TEAM));
+    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.toNextTurn();
+
+    const postMoveAccMultiplier = enemy.getAccuracyMultiplier(ally, moveToCheck);
+    expect(ally.summonData.battleStats[BattleStat.EVA]).toBe(1);
+    expect(postMoveAccMultiplier).toBeLessThan(preMoveAccMultiplier);
+  });
+});

--- a/src/test/moves/double_team.test.ts
+++ b/src/test/moves/double_team.test.ts
@@ -9,7 +9,6 @@ import {
 import { Moves } from "#enums/moves";
 import { getMovePosition } from "#app/test/utils/gameManagerUtils";
 import { BattleStat } from "#app/data/battle-stat.js";
-import { allMoves } from "#app/data/move.js";
 import { Abilities } from "#app/enums/abilities.js";
 
 describe("Moves - Double Team", () => {
@@ -32,26 +31,25 @@ describe("Moves - Double Team", () => {
     vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.DOUBLE_TEAM]);
     vi.spyOn(overrides, "NEVER_CRIT_OVERRIDE", "get").mockReturnValue(true);
     vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.BALL_FETCH);
+    vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.SHUCKLE);
     vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.BALL_FETCH);
     vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE]);
   });
 
   it("increases the user's evasion by one stage.", async () => {
-    const moveToCheck = allMoves[Moves.TACKLE];
     await game.startBattle([Species.MAGIKARP]);
 
     const ally = game.scene.getPlayerPokemon();
     const enemy = game.scene.getEnemyPokemon();
-    const preMoveAccMultiplier = enemy.getAccuracyMultiplier(ally, moveToCheck);
 
+    vi.spyOn(enemy, "getAccuracyMultiplier");
     expect(ally.summonData.battleStats[BattleStat.EVA]).toBe(0);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.DOUBLE_TEAM));
     await game.phaseInterceptor.to(TurnEndPhase);
     await game.toNextTurn();
 
-    const postMoveAccMultiplier = enemy.getAccuracyMultiplier(ally, moveToCheck);
     expect(ally.summonData.battleStats[BattleStat.EVA]).toBe(1);
-    expect(postMoveAccMultiplier).toBeLessThan(preMoveAccMultiplier);
+    expect(enemy.getAccuracyMultiplier).toHaveReturnedWith(.75);
   });
 });


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
- see title
- updated Wonder Skin unit tests to use the new method `calculateBattleAccuracy()`
- added unit tests involving the use of `calculateBattleAccuracy()` and `getAccuracyMultiplier()`

## Why am I doing these changes?
- cleaner phases file
- easier unit tests on move accuracy / accuracy multiplier
- more maintainable

## What did change?
- see title

### Screenshots/Videos
n/a

## How to test the changes?
play the game/run unit tests

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?