### PR TITLE
[Test] Prevent Arena Trap/etc from breaking Costar test

### DIFF
--- a/src/test/abilities/costar.test.ts
+++ b/src/test/abilities/costar.test.ts
@@ -29,7 +29,7 @@ describe("Abilities - COSTAR", () => {
     game = new GameManager(phaserGame);
     vi.spyOn(Overrides, "DOUBLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
     vi.spyOn(Overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.COSTAR);
-    vi.spyOn(Overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.NASTY_PLOT, Moves.CURSE]);
+    vi.spyOn(Overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.NASTY_PLOT]);
     vi.spyOn(Overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.SPLASH, Moves.SPLASH, Moves.SPLASH]);
   });
 
@@ -37,15 +37,17 @@ describe("Abilities - COSTAR", () => {
   test(
     "ability copies positive stat changes",
     async () => {
+      vi.spyOn(Overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.BALL_FETCH);
+
       await game.startBattle([Species.MAGIKARP, Species.MAGIKARP, Species.FLAMIGO]);
 
       let [leftPokemon, rightPokemon] = game.scene.getPlayerField();
-      expect(leftPokemon).not.toBe(undefined);
-      expect(rightPokemon).not.toBe(undefined);
+      expect(leftPokemon).toBeDefined();
+      expect(rightPokemon).toBeDefined();
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.NASTY_PLOT));
       await game.phaseInterceptor.to(CommandPhase);
-      game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
+      game.doAttack(getMovePosition(game.scene, 1, Moves.SPLASH));
       await game.toNextTurn();
 
       expect(leftPokemon.summonData.battleStats[BattleStat.SPATK]).toBe(+2);
@@ -71,8 +73,8 @@ describe("Abilities - COSTAR", () => {
       await game.startBattle([Species.MAGIKARP, Species.MAGIKARP, Species.FLAMIGO]);
 
       let [leftPokemon, rightPokemon] = game.scene.getPlayerField();
-      expect(leftPokemon).not.toBe(undefined);
-      expect(rightPokemon).not.toBe(undefined);
+      expect(leftPokemon).toBeDefined();
+      expect(rightPokemon).toBeDefined();
 
       expect(leftPokemon.summonData.battleStats[BattleStat.ATK]).toBe(-2);
       expect(leftPokemon.summonData.battleStats[BattleStat.ATK]).toBe(-2);


### PR DESCRIPTION
## What are the changes?
Fix Costar test so ability RNG doesn't break the test.

## Why am I doing these changes?
![image](https://github.com/pagefaultgames/pokerogue/assets/34855794/e9b46286-12e9-4b37-801d-322f6cb0e2bc)

## What did change?
Specify an ability for the opposing Pokémon in the first test so they can't have Arena Trap, Shadow Tag, etc which prevents the switching required for the test.

### Screenshots/Videos
![image](https://github.com/pagefaultgames/pokerogue/assets/34855794/ad36035c-b8a7-4575-8ec0-0ea4e268a3f7)

## How to test the changes?
`npm run test costar`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - [x] Have I provided screenshots/videos of the changes?