### PR TITLE
[Beta] Modifier/Item Override Refactor + Fee Waiving Overrides

### DIFF
--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1911,10 +1911,8 @@ export function getPlayerModifierTypeOptions(count: integer, party: PlayerPokemo
   }
 
   // Replace rolled options if any override entries are present
-  for (let i = 0; i < Overrides.ITEM_REWARD_OVERRIDE.length; i++) {
-    if (options.length <= i) {
-      break;
-    }
+  const minLength = Math.min(options.length, Overrides.ITEM_REWARD_OVERRIDE.length);
+  for (let i = 0; i < minLength; i++) {
     const override = Overrides.ITEM_REWARD_OVERRIDE[i];
     if (override.name in modifierTypes) {
       const modifierFunc = modifierTypes[override.name];

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1918,7 +1918,7 @@ export function getPlayerModifierTypeOptions(count: integer, party: PlayerPokemo
       let modifierType = modifierFunc();
 
       if (modifierType instanceof ModifierTypeGenerator) {
-        modifierType = modifierType.generateType(party, "type" in override ? [override.type] : null);
+        modifierType = modifierType.generateType(party, ("type" in override) && (override.type !== null) ? [override.type] : null);
       }
 
       if (modifierType) {

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -2212,9 +2212,11 @@ type GeneratorModifierOverride = {
  * not set, the generator will either use the party to weight item choice or randomly
  * pick an item.
  *
- * @example STARTING_MODIFIER_OVERRIDE = [{name: "EXP_SHARE", count: 2}] // will have a quantity of 2 in-game
- * @example STARTING_HELD_ITEM_OVERRIDE = [{name: "LUCKY_EGG"}] // will have a quantity of 1 in-game
- * @example {name: "BERRY", type: BerryType.SITRUS} // type must be given to get a specific berry
- * @example {name: "BERRY"} // a random berry will be generated at runtime
+ * @example ```ts
+ * STARTING_MODIFIER_OVERRIDE = [{name: "EXP_SHARE", count: 2}] // will have a quantity of 2 in-game
+ * STARTING_HELD_ITEM_OVERRIDE = [{name: "LUCKY_EGG"}] // will have a quantity of 1 in-game
+ * {name: "BERRY", type: BerryType.SITRUS} // type must be given to get a specific berry
+ * {name: "BERRY"} // a random berry will be generated at runtime
+ * ```
  */
 export type ModifierOverride = GeneratorModifierOverride | BaseModifierOverride;

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1907,24 +1907,20 @@ export function getPlayerModifierTypeOptions(count: integer, party: PlayerPokemo
     }
   }
 
-  // Override rolled options if any override entries are present
+  // Replace rolled options if any override entries are present
   for (let i = 0; i < Overrides.ITEM_REWARD_OVERRIDE.length; i++) {
     if (options.length >= i) {
       break;
     }
     const override = Overrides.ITEM_REWARD_OVERRIDE[i];
-    // If the item does not exist in modifierTypes, skip it
-    if (modifierTypes.hasOwnProperty(override.name)) {
-      // Retrieve the item entry from modifierTypes
+    if (override.name in modifierTypes) {
       const modifierFunc = modifierTypes[override.name];
       let modifierType = modifierFunc();
 
-      // Generate modifier type if necessary
       if (modifierType instanceof ModifierTypeGenerator) {
         modifierType = modifierType.generateType(party, (override.type !== null) ? [override.type] : null);
       }
 
-      // Replace the corresponding original option
       options[i].type = modifierType.withIdFromFunc(modifierFunc);
     }
   }

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -2160,7 +2160,6 @@ type BaseModifierOverride = {
 };
 
 type GeneratorModifierOverride = {
-    /** Quantity of the held item or modifier desired */
     count?: number
   } & (
   | {

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -968,7 +968,10 @@ class SpeciesStatBoosterModifierTypeGenerator extends ModifierTypeGenerator {
 
 class TmModifierTypeGenerator extends ModifierTypeGenerator {
   constructor(tier: ModifierTier) {
-    super((party: Pokemon[]) => {
+    super((party: Pokemon[], pregenArgs?: any[]) => {
+      if (pregenArgs) {
+        return new TmModifierType(pregenArgs[0] as Moves);
+      }
       const partyMemberCompatibleTms = party.map(p => (p as PlayerPokemon).compatibleTms.filter(tm => !p.moveset.find(m => m.moveId === tm)));
       const tierUniqueCompatibleTms = partyMemberCompatibleTms.flat().filter(tm => tmPoolTiers[tm] === tier).filter(tm => !allMoves[tm].name.endsWith(" (N)")).filter((tm, i, array) => array.indexOf(tm) === i);
       if (!tierUniqueCompatibleTms.length) {
@@ -2192,6 +2195,7 @@ type GeneratorModifierOverride = {
     }
   | {
       name: "TM_COMMON" | "TM_GREAT" | "TM_ULTRA";
+      type?: Moves;
     }
 );
 

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -2166,6 +2166,10 @@ type GeneratorModifierOverride = {
     count?: number
   } & (
   | {
+      name: "SPECIES_STAT_BOOSTER";
+      type?: SpeciesStatBoosterItem;
+    }
+  | {
       name: "TEMP_STAT_BOOSTER";
       type?: TempBattleStat;
     }

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -2704,7 +2704,7 @@ export function overrideHeldItems(scene: BattleScene, pokemon: Pokemon, isPlayer
       const qty = item.count || 1;
 
       if (modifierType instanceof ModifierTypes.ModifierTypeGenerator) {
-        modifierType = modifierType.generateType(null, "type" in item ? [item.type] : null);
+        modifierType = modifierType.generateType(null, ("type" in item) && (item.type !== null) ? [item.type] : null);
       }
 
       const heldItemModifier = modifierType.withIdFromFunc(modifierFunc).newModifier(pokemon) as PokemonHeldItemModifier;

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -2704,7 +2704,7 @@ export function overrideHeldItems(scene: BattleScene, pokemon: Pokemon, isPlayer
       const qty = item.count || 1;
 
       if (modifierType instanceof ModifierTypes.ModifierTypeGenerator) {
-        modifierType = modifierType.generateType(null, (item.type !== null) ? [item.type] : null);
+        modifierType = modifierType.generateType(null, "type" in item ? [item.type] : null);
       }
 
       const heldItemModifier = modifierType.withIdFromFunc(modifierFunc).newModifier(pokemon) as PokemonHeldItemModifier;

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -2651,68 +2651,80 @@ export class EnemyFusionChanceModifier extends EnemyPersistentModifier {
 }
 
 /**
- * Uses override from overrides.ts to set PersistentModifiers for starting a new game
- * @param scene current BattleScene
- * @param player is this for player for enemy
+ * Uses either `MODIFIER_OVERRIDE` in overrides.ts to set {@linkcode PersistentModifier}s for either:
+ *  - The player
+ *  - The enemy
+ * @param scene current {@linkcode BattleScene}
+ * @param isPlayer {@linkcode boolean} for whether the the player or enemy is being overridden
  */
-export function overrideModifiers(scene: BattleScene, player: boolean = true): void {
-  const modifierOverride = player ? Overrides.STARTING_MODIFIER_OVERRIDE : Overrides.OPP_MODIFIER_OVERRIDE;
-  if (!modifierOverride || modifierOverride.length === 0 || !scene) {
+export function overrideModifiers(scene: BattleScene, isPlayer: boolean = true): void {
+  const modifiersOverride = isPlayer ? Overrides.STARTING_MODIFIER_OVERRIDE : Overrides.OPP_MODIFIER_OVERRIDE;
+  if (!modifiersOverride || modifiersOverride.length === 0 || !scene) {
     return;
-  } // if no override, do nothing
-  // if it's the opponent, we clear all his current modifiers to avoid stacking
-  if (!player) {
+  } // If no override is provided, do nothing
+
+  // If it's the opponent, clear all of their current modifiers to avoid stacking
+  if (!isPlayer) {
     scene.clearEnemyModifiers();
   }
-  // we loop through all the modifier name given in the override file
-  modifierOverride.forEach(item => {
-    const modifierName = item.name;
-    const qty = item.count || 1;
-    if (!modifierTypes.hasOwnProperty(modifierName)) {
-      return;
-    } // if the modifier does not exist, we skip it
-    const modifierType: ModifierType = modifierTypes[modifierName]();
-    const modifier: PersistentModifier = modifierType.withIdFromFunc(modifierTypes[modifierName]).newModifier() as PersistentModifier;
-    modifier.stackCount = qty;
-    if (player) {
-      scene.addModifier(modifier, true, false, false, true);
-    } else {
-      scene.addEnemyModifier(modifier, true, true);
+
+  // Loop through all the override items given
+  modifiersOverride.forEach(item => {
+    // If the item does not exist in modifierTypes, skip it
+    if (modifierTypes.hasOwnProperty(item.name)) {
+      // Retrieve the item entry from modifierTypes
+      const modifierFunc = modifierTypes[item.name];
+      const modifier = modifierFunc().withIdFromFunc(modifierFunc).newModifier() as PersistentModifier;
+      modifier.stackCount = item.count || 1; // Set quantity
+
+      if (isPlayer) {
+        scene.addModifier(modifier, true, false, false, true);
+      } else {
+        scene.addEnemyModifier(modifier, true, true);
+      }
     }
   });
 }
 
 /**
- * Uses override from overrides.ts to set PokemonHeldItemModifiers for starting a new game
- * @param scene current BattleScene
- * @param player is this for player for enemy
+ * Uses either `HELD_ITEMS_OVERRIDE` in overrides.ts to set {@linkcode PokemonHeldItemModifier}s for either:
+ *  - The first member of the player's team when starting a new game
+ *  - An enemy {@linkcode Pokemon} being spawned in
+ * @param scene current {@linkcode BattleScene}
+ * @param pokemon {@linkcode Pokemon} whose held items are being overridden
+ * @param isPlayer {@linkcode boolean} for whether the {@linkcode pokemon} is the player's or an enemy
  */
-export function overrideHeldItems(scene: BattleScene, pokemon: Pokemon, player: boolean = true): void {
-  const heldItemsOverride = player ? Overrides.STARTING_HELD_ITEMS_OVERRIDE : Overrides.OPP_HELD_ITEMS_OVERRIDE;
+export function overrideHeldItems(scene: BattleScene, pokemon: Pokemon, isPlayer: boolean = true): void {
+  const heldItemsOverride = isPlayer ? Overrides.STARTING_HELD_ITEMS_OVERRIDE : Overrides.OPP_HELD_ITEMS_OVERRIDE;
   if (!heldItemsOverride || heldItemsOverride.length === 0 || !scene) {
     return;
-  } // if no override, do nothing
-  // we loop through all the itemName given in the override file
+  } // If no override is provided, do nothing
+
+  // Loop through all the override items given
   heldItemsOverride.forEach(item => {
-    const itemName = item.name;
-    const qty = item.count || 1;
-    if (!modifierTypes.hasOwnProperty(itemName)) {
-      return;
-    } // if the item does not exist, we skip it
-    const modifierType: ModifierType = modifierTypes[itemName](); // we retrieve the item in the list
-    let itemModifier: PokemonHeldItemModifier;
-    if (modifierType instanceof ModifierTypes.ModifierTypeGenerator) {
-      itemModifier = modifierType.generateType(null, [item.type]).withIdFromFunc(modifierTypes[itemName]).newModifier(pokemon) as PokemonHeldItemModifier;
-    } else {
-      itemModifier = modifierType.withIdFromFunc(modifierTypes[itemName]).newModifier(pokemon) as PokemonHeldItemModifier;
-    }
-    // we create the item
-    itemModifier.pokemonId = pokemon.id; // we assign the created item to the pokemon
-    itemModifier.stackCount = qty; // we say how many items we want
-    if (player) {
-      scene.addModifier(itemModifier, true, false, false, true);
-    } else {
-      scene.addEnemyModifier(itemModifier, true, true);
+    // If the item does not exist in modifierTypes, skip it
+    if (modifierTypes.hasOwnProperty(item.name)) {
+      // Retrieve the item entry from modifierTypes
+      const modifierFunc = modifierTypes[item.name];
+      let modifierType = modifierFunc();
+      const qty = item.count || 1;
+
+      // Generate modifier type if necessary
+      if (modifierType instanceof ModifierTypes.ModifierTypeGenerator) {
+        modifierType = modifierType.generateType(null, (item.type !== null) ? [item.type] : null);
+      }
+
+      // Create the held item
+      const heldItemModifier = modifierType.withIdFromFunc(modifierFunc).newModifier(pokemon) as PokemonHeldItemModifier;
+      heldItemModifier.pokemonId = pokemon.id; // Assign the created item to the pokemon
+      heldItemModifier.stackCount = qty; // Set quantity
+
+      // Give it to the appropriate Pokemon
+      if (isPlayer) {
+        scene.addModifier(heldItemModifier, true, false, false, true);
+      } else {
+        scene.addEnemyModifier(heldItemModifier, true, true);
+      }
     }
   });
 }

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -2655,27 +2655,24 @@ export class EnemyFusionChanceModifier extends EnemyPersistentModifier {
  *  - The player
  *  - The enemy
  * @param scene current {@linkcode BattleScene}
- * @param isPlayer {@linkcode boolean} for whether the the player or enemy is being overridden
+ * @param isPlayer {@linkcode boolean} for whether the the player (`true`) or enemy (`false`) is being overridden
  */
 export function overrideModifiers(scene: BattleScene, isPlayer: boolean = true): void {
   const modifiersOverride = isPlayer ? Overrides.STARTING_MODIFIER_OVERRIDE : Overrides.OPP_MODIFIER_OVERRIDE;
   if (!modifiersOverride || modifiersOverride.length === 0 || !scene) {
     return;
-  } // If no override is provided, do nothing
+  }
 
   // If it's the opponent, clear all of their current modifiers to avoid stacking
   if (!isPlayer) {
     scene.clearEnemyModifiers();
   }
 
-  // Loop through all the override items given
   modifiersOverride.forEach(item => {
-    // If the item does not exist in modifierTypes, skip it
-    if (modifierTypes.hasOwnProperty(item.name)) {
-      // Retrieve the item entry from modifierTypes
+    if (item.name in modifierTypes) {
       const modifierFunc = modifierTypes[item.name];
       const modifier = modifierFunc().withIdFromFunc(modifierFunc).newModifier() as PersistentModifier;
-      modifier.stackCount = item.count || 1; // Set quantity
+      modifier.stackCount = item.count || 1;
 
       if (isPlayer) {
         scene.addModifier(modifier, true, false, false, true);
@@ -2692,34 +2689,28 @@ export function overrideModifiers(scene: BattleScene, isPlayer: boolean = true):
  *  - An enemy {@linkcode Pokemon} being spawned in
  * @param scene current {@linkcode BattleScene}
  * @param pokemon {@linkcode Pokemon} whose held items are being overridden
- * @param isPlayer {@linkcode boolean} for whether the {@linkcode pokemon} is the player's or an enemy
+ * @param isPlayer {@linkcode boolean} for whether the {@linkcode pokemon} is the player's (`true`) or an enemy (`false`)
  */
 export function overrideHeldItems(scene: BattleScene, pokemon: Pokemon, isPlayer: boolean = true): void {
   const heldItemsOverride = isPlayer ? Overrides.STARTING_HELD_ITEMS_OVERRIDE : Overrides.OPP_HELD_ITEMS_OVERRIDE;
   if (!heldItemsOverride || heldItemsOverride.length === 0 || !scene) {
     return;
-  } // If no override is provided, do nothing
+  }
 
-  // Loop through all the override items given
   heldItemsOverride.forEach(item => {
-    // If the item does not exist in modifierTypes, skip it
-    if (modifierTypes.hasOwnProperty(item.name)) {
-      // Retrieve the item entry from modifierTypes
+    if (item.name in modifierTypes) {
       const modifierFunc = modifierTypes[item.name];
       let modifierType = modifierFunc();
       const qty = item.count || 1;
 
-      // Generate modifier type if necessary
       if (modifierType instanceof ModifierTypes.ModifierTypeGenerator) {
         modifierType = modifierType.generateType(null, (item.type !== null) ? [item.type] : null);
       }
 
-      // Create the held item
       const heldItemModifier = modifierType.withIdFromFunc(modifierFunc).newModifier(pokemon) as PokemonHeldItemModifier;
-      heldItemModifier.pokemonId = pokemon.id; // Assign the created item to the pokemon
-      heldItemModifier.stackCount = qty; // Set quantity
+      heldItemModifier.pokemonId = pokemon.id;
+      heldItemModifier.stackCount = qty;
 
-      // Give it to the appropriate Pokemon
       if (isPlayer) {
         scene.addModifier(heldItemModifier, true, false, false, true);
       } else {

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -4,7 +4,9 @@ import { PokeballCounts } from "./battle-scene";
 import { PokeballType } from "./data/pokeball";
 import { Gender } from "./data/gender";
 import { StatusEffect } from "./data/status-effect";
-import { ModifierOverride } from "./modifier/modifier-type";
+import { type ModifierOverride } from "#app/modifier/modifier-type";
+import { VariantTier } from "./enums/variant-tiers";
+import { EggTier } from "#enums/egg-type";
 import { allSpecies } from "./data/pokemon-species"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { Abilities } from "#enums/abilities";
 import { Biome } from "#enums/biome";

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -36,9 +36,9 @@ export const SINGLE_BATTLE_OVERRIDE: boolean = false;
 export const STARTING_WAVE_OVERRIDE: integer = 0;
 export const STARTING_BIOME_OVERRIDE: Biome = Biome.TOWN;
 export const ARENA_TINT_OVERRIDE: TimeOfDay = null;
-// Multiplies XP gained by this value including 0. Set to null to ignore the override
-export const NEVER_CRIT_OVERRIDE: boolean = false;
+/** Multiplies XP gained by this value including 0. Set to null to ignore the override */
 export const XP_MULTIPLIER_OVERRIDE: number = null;
+export const NEVER_CRIT_OVERRIDE: boolean = false;
 // default 1000
 export const STARTING_MONEY_OVERRIDE: integer = 0;
 export const FREE_CANDY_UPGRADE_OVERRIDE: boolean = false;

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -1,14 +1,5 @@
 import { WeatherType } from "./data/weather";
 import { Variant } from "./data/variant";
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { TempBattleStat } from "./data/temp-battle-stat";
-import { Nature } from "./data/nature";
-import { Type } from "./data/type";
-import { Stat } from "./data/pokemon-stat";
-import { EvolutionItem } from "./data/pokemon-evolutions";
-import { FormChangeItem } from "./data/pokemon-forms";
-import { BerryType } from "#enums/berry-type";
-/* eslint-enable @typescript-eslint/no-unused-vars */
 import { PokeballCounts } from "./battle-scene";
 import { PokeballType } from "./data/pokeball";
 import { Gender } from "./data/gender";

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -1,17 +1,21 @@
 import { WeatherType } from "./data/weather";
 import { Variant } from "./data/variant";
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { TempBattleStat } from "./data/temp-battle-stat";
 import { Nature } from "./data/nature";
 import { Type } from "./data/type";
 import { Stat } from "./data/pokemon-stat";
+import { EvolutionItem } from "./data/pokemon-evolutions";
+import { FormChangeItem } from "./data/pokemon-forms";
+import { BerryType } from "#enums/berry-type";
+/* eslint-enable @typescript-eslint/no-unused-vars */
 import { PokeballCounts } from "./battle-scene";
 import { PokeballType } from "./data/pokeball";
 import { Gender } from "./data/gender";
 import { StatusEffect } from "./data/status-effect";
-import { modifierTypes, PokemonHeldItemModifierType, ModifierType, ModifierTypeGenerator } from "./modifier/modifier-type"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { ModifierOverride } from "./modifier/modifier-type";
 import { allSpecies } from "./data/pokemon-species"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { Abilities } from "#enums/abilities";
-import { BerryType } from "#enums/berry-type";
 import { Biome } from "#enums/biome";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
@@ -125,39 +129,6 @@ export const MYSTERY_ENCOUNTER_OVERRIDE: MysteryEncounterType = null;
  * MODIFIER / HELD ITEM OVERRIDES
  */
 
-/**
- * Type used to construct modifiers and held items for overriding purposes.
- *
- * While both pertain to modifiers in the class hierarchy, overrides labeled `HELD_ITEM`
- * specifically pertain to any entry in {@linkcode modifierTypes} that is, extends, or generates
- * {@linkcode PokemonHeldItemModifierType}s, like `SOUL_DEW`, `TOXIC_ORB`, etc. Overrides
- * labeled `MODIFIER` deal with any modifier so long as it doesn't require a party
- * member to hold it (typically is, extends, or generates {@linkcode ModifierType}s),
- * like `EXP_SHARE`, `CANDY_JAR`, etc.
- *
- * Note that, if count is not provided, it will default to 1. Additionally, note that some
- * held items and modifiers are grouped together via a {@linkcode ModifierTypeGenerator} and
- * require pre-generation arguments to get a specific item.
- *
- * @example STARTING_MODIFIER_OVERRIDE = [{name: "EXP_SHARE", count: 2}] // will have a quantity of 2 in-game
- * @example STARTING_HELD_ITEM_OVERRIDE = [{name: "LUCKY_EGG"}] // will have a quantity of 1 in-game
- * @example {name: "BERRY", count: 5, type: BerryType.SITRUS} // type must be given to get a specific berry
- */
-type ModifierOverride = {
-    /** Key for any given modifier, held item, or generator in {@linkcode modifierTypes} */
-    name: keyof typeof modifierTypes & string,
-    /** Quantity of the held item or modifier desired */
-    count?: integer
-    /** Sub-type used for generator-based held items and modifiers. The available types are:
-     * - {@linkcode TempBattleStat}, for {@linkcode modifierTypes.TEMP_STAT_BOOSTER} / X-stat items (Dire Hit is separate)
-     * - {@linkcode Stat}, for {@linkcode modifierTypes.BASE_STAT_BOOSTER} / Vitamins
-     * - {@linkcode Nature}, for {@linkcode modifierTypes.MINT}
-     * - {@linkcode Type}, for {@linkcode modifierTypes.TERA_SHARD} or {@linkcode modifierTypes.ATTACK_TYPE_BOOSTER} / Type-boosting items
-     * - {@linkcode BerryType}, for {@linkcode modifierTypes.BERRY}
-     */
-    type?: TempBattleStat|Stat|Nature|Type|BerryType
-};
-
 /** Override array of {@linkcode ModifierOverride}s used to provide modifiers to the player when starting a new game */
 export const STARTING_MODIFIER_OVERRIDE: ModifierOverride[] = [];
 /**
@@ -177,5 +148,7 @@ export const OPP_HELD_ITEMS_OVERRIDE: ModifierOverride[] = [];
  *
  * If less entries are listed than rolled, only those entries will be used to replace the corresponding items while the rest randomly generated.
  * If more entries are listed than rolled, only the first X entries will be used, where X is the number of items rolled.
+ *
+ * Note that, for all items in the array, `count` is not used.
  */
 export const ITEM_REWARD_OVERRIDE: ModifierOverride[] = [];

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -122,7 +122,7 @@ export const MYSTERY_ENCOUNTER_OVERRIDE: MysteryEncounterType = null;
  * MODIFIER / HELD ITEM OVERRIDES
  */
 
-/** Override array of {@linkcode ModifierOverride}s used to provide modifiers to the player when starting a new game */
+/** Override array of {@linkcode ModifierOverride}s used to provide modifiers to the player when starting a new game. */
 export const STARTING_MODIFIER_OVERRIDE: ModifierOverride[] = [];
 /**
  * Override array of {@linkcode ModifierOverride}s used to provide modifiers to enemies.
@@ -131,9 +131,9 @@ export const STARTING_MODIFIER_OVERRIDE: ModifierOverride[] = [];
  */
 export const OPP_MODIFIER_OVERRIDE: ModifierOverride[] = [];
 
-/** Override array of {@linkcode ModifierOverride}s used to provide held items to first party member when starting a new game*/
+/** Override array of {@linkcode ModifierOverride}s used to provide held items to first party member when starting a new game. */
 export const STARTING_HELD_ITEMS_OVERRIDE: ModifierOverride[] = [];
-/** Override array of {@linkcode ModifierOverride}s used to provide held items to enemies on spawn */
+/** Override array of {@linkcode ModifierOverride}s used to provide held items to enemies on spawn. */
 export const OPP_HELD_ITEMS_OVERRIDE: ModifierOverride[] = [];
 
 /**

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -38,6 +38,10 @@ export const XP_MULTIPLIER_OVERRIDE: number = null;
 export const NEVER_CRIT_OVERRIDE: boolean = false;
 // default 1000
 export const STARTING_MONEY_OVERRIDE: integer = 0;
+/** Sets all shop item prices to 0 */
+export const WAIVE_SHOP_FEES_OVERRIDE: boolean = false;
+/** Sets reroll price to 0 */
+export const WAIVE_REROLL_FEE_OVERRIDE: boolean = false;
 export const FREE_CANDY_UPGRADE_OVERRIDE: boolean = false;
 export const POKEBALL_OVERRIDE: { active: boolean, pokeballs: PokeballCounts } = {
   active: false,

--- a/src/phases/select-modifier-phase.ts
+++ b/src/phases/select-modifier-phase.ts
@@ -22,6 +22,7 @@ import PartyUiHandler, {PartyOption, PartyUiMode} from "#app/ui/party-ui-handler
 import ModifierSelectUiHandler, {SHOP_OPTIONS_ROW_LIMIT} from "#app/ui/modifier-select-ui-handler";
 import {BattlePhase} from "#app/phases/battle-phase";
 import {isNullOrUndefined} from "#app/utils";
+import * as Overrides from "#app/overrides";
 
 export class SelectModifierPhase extends BattlePhase {
   private rerollCount: integer;

--- a/src/phases/select-modifier-phase.ts
+++ b/src/phases/select-modifier-phase.ts
@@ -85,7 +85,7 @@ export class SelectModifierPhase extends BattlePhase {
         switch (cursor) {
         case 0:
           const rerollCost = this.getRerollCost(typeOptions, this.scene.lockModifierTiers);
-          if (rerollCost === 0 || this.scene.money < rerollCost) {
+          if (this.scene.money < rerollCost) {
             this.scene.ui.playError();
             return false;
           } else {
@@ -93,9 +93,11 @@ export class SelectModifierPhase extends BattlePhase {
             this.scene.unshiftPhase(new SelectModifierPhase(this.scene, this.rerollCount + 1, typeOptions.map(o => o.type.tier)));
             this.scene.ui.clearText();
             this.scene.ui.setMode(Mode.MESSAGE).then(() => super.end());
-            this.scene.money -= rerollCost;
-            this.scene.updateMoneyText();
-            this.scene.animateMoneyChanged(false);
+            if (!Overrides.WAIVE_REROLL_FEE_OVERRIDE) {
+              this.scene.money -= rerollCost;
+              this.scene.updateMoneyText();
+              this.scene.animateMoneyChanged(false);
+            }
             this.scene.playSound("buy");
           }
           break;
@@ -141,7 +143,7 @@ export class SelectModifierPhase extends BattlePhase {
         break;
       }
 
-      if (cost && this.scene.money < cost) {
+      if (cost && (this.scene.money < cost) && !Overrides.WAIVE_SHOP_FEES_OVERRIDE) {
         this.scene.ui.playError();
         return false;
       }
@@ -151,9 +153,11 @@ export class SelectModifierPhase extends BattlePhase {
         if (cost) {
           result.then(success => {
             if (success) {
-              this.scene.money -= cost;
-              this.scene.updateMoneyText();
-              this.scene.animateMoneyChanged(false);
+              if (!Overrides.WAIVE_SHOP_FEES_OVERRIDE) {
+                this.scene.money -= cost;
+                this.scene.updateMoneyText();
+                this.scene.animateMoneyChanged(false);
+              }
               this.scene.playSound("buy");
               (this.scene.ui.getHandler() as ModifierSelectUiHandler).updateCostText();
             } else {
@@ -233,7 +237,9 @@ export class SelectModifierPhase extends BattlePhase {
 
   getRerollCost(typeOptions: ModifierTypeOption[], lockRarities: boolean): integer {
     let baseValue = 0;
-    if (lockRarities) {
+    if (Overrides.WAIVE_REROLL_FEE_OVERRIDE) {
+      return baseValue;
+    } else if (lockRarities) {
       const tierValues = [50, 125, 300, 750, 2000];
       for (const opt of typeOptions) {
         baseValue += tierValues[opt.type.tier];

--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -10,6 +10,7 @@ import {Button} from "#enums/buttons";
 import MoveInfoOverlay from "./move-info-overlay";
 import { allMoves } from "../data/move";
 import * as Utils from "./../utils";
+import * as Overrides from "#app/overrides";
 import i18next from "i18next";
 
 export const SHOP_OPTIONS_ROW_LIMIT = 6;
@@ -764,9 +765,10 @@ class ModifierOption extends Phaser.GameObjects.Container {
 
   updateCostText(): void {
     const scene = this.scene as BattleScene;
-    const textStyle = this.modifierTypeOption.cost <= scene.money ? TextStyle.MONEY : TextStyle.PARTY_RED;
+    const cost = Overrides.WAIVE_SHOP_FEES_OVERRIDE ? 0 : this.modifierTypeOption.cost;
+    const textStyle = cost <= scene.money ? TextStyle.MONEY : TextStyle.PARTY_RED;
 
-    const formattedMoney = Utils.formatMoney(scene.moneyFormat, this.modifierTypeOption.cost);
+    const formattedMoney = Utils.formatMoney(scene.moneyFormat, cost);
 
     this.itemCostText.setText(i18next.t("modifierSelectUiHandler:itemCost", { formattedMoney }));
     this.itemCostText.setColor(getTextColor(textStyle, false, scene.uiTheme));


### PR DESCRIPTION
This PR is a mirror of both #2266 and #2320 for the `beta` branch.

Both PRs were combined since they're both effectively "new" overrides and are relatively small; as such, the main aim of this PR is to make sure they don't break anything unintentionally.

It's worth noting that because #2824 shifts the `SelectModifierPhase` to its own file, the logic used for the fee waiving overrides was also shifted to this file. This was a relatively straightforward change, but this specifically differs from the `main` branch PRs.