### PR TITLE
[Bug] Fix battler tags lapsing at incorrect times

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -154,6 +154,9 @@ export class TrappedTag extends BattlerTag {
   }
 }
 
+/**
+ * BattlerTag that represents the {@link https://bulbapedia.bulbagarden.net/wiki/Flinch Flinch} status condition
+ */
 export class FlinchedTag extends BattlerTag {
   constructor(sourceMove: Moves) {
     super(BattlerTagType.FLINCHED, [ BattlerTagLapseType.PRE_MOVE, BattlerTagLapseType.TURN_END ], 0, sourceMove);
@@ -169,6 +172,12 @@ export class FlinchedTag extends BattlerTag {
     return !pokemon.isMax();
   }
 
+  /**
+   * Cancels the Pokemon's next Move on the turn this tag is applied
+   * @param pokemon The {@linkcode Pokemon} with this tag
+   * @param lapseType The {@linkcode BattlerTagLapseType lapse type} used for this function call
+   * @returns `false` (This tag is always removed after applying its effects)
+   */
   lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
     if (lapseType === BattlerTagLapseType.PRE_MOVE) {
       (pokemon.scene.getCurrentPhase() as MovePhase).cancel();
@@ -206,7 +215,7 @@ export class InterruptedTag extends BattlerTag {
 }
 
 /**
- * BattlerTag that represents the {@link https://bulbapedia.bulbagarden.net/wiki/Confusion_(status_condition)}
+ * BattlerTag that represents the {@link https://bulbapedia.bulbagarden.net/wiki/Confusion_(status_condition) Confusion} status condition
  */
 export class ConfusedTag extends BattlerTag {
   constructor(turnCount: integer, sourceMove: Moves) {

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -31,14 +31,14 @@ export enum BattlerTagLapseType {
 
 export class BattlerTag {
   public tagType: BattlerTagType;
-  public lapseType: BattlerTagLapseType;
+  public lapseType: BattlerTagLapseType[];
   public turnCount: integer;
   public sourceMove: Moves;
   public sourceId?: integer;
 
-  constructor(tagType: BattlerTagType, lapseType: BattlerTagLapseType, turnCount: integer, sourceMove: Moves, sourceId?: integer) {
+  constructor(tagType: BattlerTagType, lapseType: BattlerTagLapseType | BattlerTagLapseType[], turnCount: integer, sourceMove: Moves, sourceId?: integer) {
     this.tagType = tagType;
-    this.lapseType = lapseType;
+    this.lapseType = typeof lapseType === "number" ? [ lapseType ] : lapseType;
     this.turnCount = turnCount;
     this.sourceMove = sourceMove;
     this.sourceId = sourceId;
@@ -156,7 +156,7 @@ export class TrappedTag extends BattlerTag {
 
 export class FlinchedTag extends BattlerTag {
   constructor(sourceMove: Moves) {
-    super(BattlerTagType.FLINCHED, BattlerTagLapseType.PRE_MOVE, 0, sourceMove);
+    super(BattlerTagType.FLINCHED, [ BattlerTagLapseType.PRE_MOVE, BattlerTagLapseType.TURN_END ], 0, sourceMove);
   }
 
   onAdd(pokemon: Pokemon): void {
@@ -170,12 +170,12 @@ export class FlinchedTag extends BattlerTag {
   }
 
   lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
-    super.lapse(pokemon, lapseType);
+    if (lapseType === BattlerTagLapseType.PRE_MOVE) {
+      (pokemon.scene.getCurrentPhase() as MovePhase).cancel();
+      pokemon.scene.queueMessage(i18next.t("battle:battlerTagsFlinchedLapse", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }));
+    }
 
-    (pokemon.scene.getCurrentPhase() as MovePhase).cancel();
-    pokemon.scene.queueMessage(i18next.t("battle:battlerTagsFlinchedLapse", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }));
-
-    return true;
+    return super.lapse(pokemon, lapseType);
   }
 
   getDescriptor(): string {
@@ -200,9 +200,8 @@ export class InterruptedTag extends BattlerTag {
   }
 
   lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
-    super.lapse(pokemon, lapseType);
     (pokemon.scene.getCurrentPhase() as MovePhase).cancel();
-    return true;
+    return super.lapse(pokemon, lapseType);
   }
 }
 
@@ -883,7 +882,7 @@ export class InfestationTag extends DamagingTrapTag {
 
 export class ProtectedTag extends BattlerTag {
   constructor(sourceMove: Moves, tagType: BattlerTagType = BattlerTagType.PROTECTED) {
-    super(tagType, BattlerTagLapseType.CUSTOM, 0, sourceMove);
+    super(tagType, BattlerTagLapseType.TURN_END, 0, sourceMove);
   }
 
   onAdd(pokemon: Pokemon): void {
@@ -1477,8 +1476,8 @@ export class CursedTag extends BattlerTag {
 
 /**
  * Battler tag for effects that ground the source, allowing Ground-type moves to hit them. Encompasses two tag types:
- * @item IGNORE_FLYING: Persistent grounding effects (i.e. from Smack Down and Thousand Waves)
- * @item ROOSTED: One-turn grounding effects (i.e. from Roost)
+ * @item `IGNORE_FLYING`: Persistent grounding effects (i.e. from Smack Down and Thousand Waves)
+ * @item `ROOSTED`: One-turn grounding effects (i.e. from Roost)
  */
 export class GroundedTag extends BattlerTag {
   constructor(tagType: BattlerTagType, lapseType: BattlerTagLapseType, sourceMove: Moves) {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2184,7 +2184,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   lapseTags(lapseType: BattlerTagLapseType): void {
     const tags = this.summonData.tags;
-    tags.filter(t => lapseType === BattlerTagLapseType.FAINT || ((t.lapseType === lapseType) && !(t.lapse(this, lapseType))) || (lapseType === BattlerTagLapseType.TURN_END && t.turnCount < 1)).forEach(t => {
+    tags.filter(t => lapseType === BattlerTagLapseType.FAINT || ((t.lapseType.some(lType => lType === lapseType)) && !(t.lapse(this, lapseType)))).forEach(t => {
       t.onRemove(this);
       tags.splice(tags.indexOf(t), 1);
     });

--- a/src/test/abilities/parental_bond.test.ts
+++ b/src/test/abilities/parental_bond.test.ts
@@ -449,7 +449,7 @@ describe("Abilities - Parental Bond", () => {
   );
 
   /** TODO: Fix TRAPPED tag lapsing incorrectly, then run this test */
-  test.skip(
+  test(
     "Anchor Shot boosted by this ability should only trap the target after the second hit",
     async () => {
       vi.spyOn(Overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.ANCHOR_SHOT]);

--- a/src/test/moves/astonish.test.ts
+++ b/src/test/moves/astonish.test.ts
@@ -1,0 +1,73 @@
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import GameManager from "../utils/gameManager";
+import * as Overrides from "#app/overrides";
+import { Species } from "#enums/species";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { getMovePosition } from "../utils/gameManagerUtils";
+import { BerryPhase, CommandPhase, MoveEndPhase, TurnEndPhase } from "#app/phases.js";
+import { BattlerTagType } from "#app/enums/battler-tag-type.js";
+import { allMoves } from "#app/data/move.js";
+
+const TIMEOUT = 20 * 1000;
+
+describe("Moves - Astonish", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    vi.spyOn(Overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(Overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.ASTONISH, Moves.SPLASH]);
+    vi.spyOn(Overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.BLASTOISE);
+    vi.spyOn(Overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.INSOMNIA);
+    vi.spyOn(Overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE]);
+    vi.spyOn(Overrides, "STARTING_LEVEL_OVERRIDE", "get").mockReturnValue(100);
+    vi.spyOn(Overrides, "OPP_LEVEL_OVERRIDE", "get").mockReturnValue(100);
+
+    vi.spyOn(allMoves[Moves.ASTONISH], "chance", "get").mockReturnValue(100);
+  });
+
+  test(
+    "move effect should cancel the target's move on the turn it applies",
+    async () => {
+      await game.startBattle([Species.MEOWSCARADA]);
+
+      const leadPokemon = game.scene.getPlayerPokemon();
+      expect(leadPokemon).toBeDefined();
+
+      const enemyPokemon = game.scene.getEnemyPokemon();
+      expect(enemyPokemon).toBeDefined();
+
+      game.doAttack(getMovePosition(game.scene, 0, Moves.ASTONISH));
+
+      await game.phaseInterceptor.to(MoveEndPhase, false);
+
+      expect(enemyPokemon.getTag(BattlerTagType.FLINCHED)).toBeDefined();
+
+      await game.phaseInterceptor.to(TurnEndPhase);
+
+      expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
+      expect(enemyPokemon.getTag(BattlerTagType.FLINCHED)).toBeUndefined();
+
+      await game.phaseInterceptor.to(CommandPhase, false);
+
+      game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
+
+      await game.phaseInterceptor.to(BerryPhase, false);
+
+      expect(leadPokemon.hp).toBeLessThan(leadPokemon.getMaxHp());
+    }, TIMEOUT
+  );
+});


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This fixes a bug were some battler tags that don't use the `TURN_END` lapse type would incorrectly get removed at the end of the turn they are applied.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
`Pokemon.lapseTags(BattlerTagLapseType.TURN_END)` currently checks all of the Pokemon's battler tags and removes them if their turn count is below 1. This is necessary check for the current implementation of the "flinching" mechanic, but it also creates some nasty side effects for other tag types. Many tags that use a lapse type where `turnCount` is irrelevant set their `turnCount` to 0, 1, or `null`, so when `Pokemon.lapseTags` is called at the end of a turn, it wrongfully detects that those tags have expired and removes them. Spirit Shackle and Thousand Arrows are some examples of moves with effects that incorrectly lapse out.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- `field/pokemon`: Removed the additional `TURN_END` condition in `Pokemon.lapseTags()`
- `data/battler-tags`:  Battler tags can now support multiple lapse types. A battler tag's `lapse` function is now called whenever `Pokemon.lapseTags` is called with a lapse type that matches one of the battler tag's lapse types. `FlinchedTag` is also rewritten to use both `PRE_MOVE` and `TURN_END` lapse types; it should be functionally identical to upstream.
- `test/abilities/parental_bond.test`: Enabled a test that failed because of this bug.
- `test/moves/astonish.test`: New test for basic flinch mechanics. The test covers the `FlinchedTag`'s behavior on the turn it is applied and on the turn after.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
N/A

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
`npm run test astonish`
`npm run test parental_bond` (see the Anchor Shot test)

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [n/a] Are the changes visual?
  - [n/a] Have I provided screenshots/videos of the changes?