### PR TITLE
[QoL] Offset the status indicator to keep pokeball in view

### DIFF
--- a/src/ui/battle-info.ts
+++ b/src/ui/battle-info.ts
@@ -118,7 +118,7 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
       this.championRibbon.setName("icon_champion_ribbon");
       this.championRibbon.setVisible(false);
       this.championRibbon.setOrigin(0, 0);
-      this.championRibbon.setPositionRelative(this.nameText, 9, 11.75);
+      this.championRibbon.setPositionRelative(this.nameText, 8, 11.75);
       this.add(this.championRibbon);
     }
 
@@ -534,7 +534,7 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
           this.statusIndicator.setFrame(StatusEffect[this.lastStatus].toLowerCase());
         }
 
-        const offsetX = !this.player ? (this.ownedIcon.visible ? 9 : 0) + (this.championRibbon.visible ? 9 : 0) : 0;
+        const offsetX = !this.player ? (this.ownedIcon.visible ? 8 : 0) + (this.championRibbon.visible ? 8 : 0) : 0;
         this.statusIndicator.setPositionRelative(this.nameText, offsetX, 11.5);
 
         this.statusIndicator.setVisible(!!this.lastStatus);

--- a/src/ui/battle-info.ts
+++ b/src/ui/battle-info.ts
@@ -118,7 +118,7 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
       this.championRibbon.setName("icon_champion_ribbon");
       this.championRibbon.setVisible(false);
       this.championRibbon.setOrigin(0, 0);
-      this.championRibbon.setPositionRelative(this.nameText, 11.75, 11.75);
+      this.championRibbon.setPositionRelative(this.nameText, 9, 11.75);
       this.add(this.championRibbon);
     }
 
@@ -533,11 +533,11 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
         if (this.lastStatus !== StatusEffect.NONE) {
           this.statusIndicator.setFrame(StatusEffect[this.lastStatus].toLowerCase());
         }
-        this.statusIndicator.setVisible(!!this.lastStatus);
 
-        if (!this.player && this.ownedIcon.visible) {
-          this.ownedIcon.setAlpha(this.statusIndicator.visible ? 0 : 1);
-        }
+        const offsetX = (this.ownedIcon.visible ? 9 : 0) + (this.championRibbon.visible ? 9 : 0);
+        this.statusIndicator.setPositionRelative(this.nameText, offsetX, 11.5);
+
+        this.statusIndicator.setVisible(!!this.lastStatus);
       }
 
       const types = pokemon.getTypes(true);

--- a/src/ui/battle-info.ts
+++ b/src/ui/battle-info.ts
@@ -534,7 +534,7 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
           this.statusIndicator.setFrame(StatusEffect[this.lastStatus].toLowerCase());
         }
 
-        const offsetX = (this.ownedIcon.visible ? 9 : 0) + (this.championRibbon.visible ? 9 : 0);
+        const offsetX = !this.player ? (this.ownedIcon.visible ? 9 : 0) + (this.championRibbon.visible ? 9 : 0) : 0;
         this.statusIndicator.setPositionRelative(this.nameText, offsetX, 11.5);
 
         this.statusIndicator.setVisible(!!this.lastStatus);


### PR DESCRIPTION
## What are the changes?
Keeps the caught Pokeball indicator and champion ribbon in view when the enemy gets a status effect

## Why am I doing these changes?
Someone asked in [Discord](https://discord.com/channels/1125469663833370665/1258135619247280200)

## What did change?
Added an x offset for the status indicator when Pokeball or Ribbon are shown

### Screenshots/Videos
Before
![before-1](https://i.ember.zone/9C4TfGdtKOtfei95.png)
![before-2](https://i.ember.zone/HAk9nSvn7w2rWwYC.png)
After
![after-1](https://i.ember.zone/o7btl4Gpp8ilBJJe.png)
![after-2](https://i.ember.zone/fdRkp1qDFSEVthMv.png)
![after-3](https://i.ember.zone/3BEDL7M454Kr7RTR.png)

## How to test the changes?
```ts
export const MOVESET_OVERRIDE: Array<Moves> = [Moves.THUNDER_WAVE]];
```

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?

![tests](https://i.ember.zone/L410NHTQ3blKzWMp.png)