### PR TITLE
[Bug] Fix off-by-one error in damage calc

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1909,7 +1909,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         applyPreAttackAbAttrs(AddSecondStrikeAbAttr, source, this, move, numTargets, new Utils.IntegerHolder(0), twoStrikeMultiplier);
 
         if (!isTypeImmune) {
-          damage.value = Math.ceil(((((2 * source.level / 5 + 2) * power.value * sourceAtk.value / targetDef.value) / 50) + 2) * stabMultiplier.value * typeMultiplier.value * arenaAttackTypeMultiplier.value * screenMultiplier.value * twoStrikeMultiplier.value * ((this.scene.randBattleSeedInt(15) + 85) / 100) * criticalMultiplier.value);
+          damage.value = Math.ceil(
+            ((((2 * source.level / 5 + 2) * power.value * sourceAtk.value / targetDef.value) / 50) + 2)
+            * stabMultiplier.value * typeMultiplier.value * arenaAttackTypeMultiplier.value * screenMultiplier.value * twoStrikeMultiplier.value * ((this.scene.randBattleSeedInt(16) + 85) / 100) * criticalMultiplier.value);
           if (isPhysical && source.status && source.status.effect === StatusEffect.BURN) {
             if (!move.hasAttr(BypassBurnDamageReductionAttr)) {
               const burnDamageReductionCancelled = new Utils.BooleanHolder(false);

--- a/src/test/battle/battle.test.ts
+++ b/src/test/battle/battle.test.ts
@@ -151,8 +151,8 @@ describe("Test Battle Phase", () => {
 
   it("test remove random battle seed int", async() => {
     for (let i=0; i<10; i++) {
-      const rand = game.scene.randBattleSeedInt(15);
-      expect(rand).toBe(14);
+      const rand = game.scene.randBattleSeedInt(16);
+      expect(rand).toBe(15);
     }
   });
 


### PR DESCRIPTION
## What are the changes?
The damage calc and a related test are updated.

## Why am I doing these changes?
The damage calc contained an off-by-one error.

## What did change?
The random damage roll is changed to be 85-100% instead of 85-99% by changing `randBattleSeedInt(15)` to `randBattleSeedInt(16)` in the damage calc formula, and a related test in `src/test/battle/battle.test.ts` is updated to reflect this change.

## How to test the changes?
Uh... use the developer tools in your browser I guess?

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~