### PR TITLE
[Test] Update tests to enable no-crits override

### DIFF
--- a/src/test/abilities/dry_skin.test.ts
+++ b/src/test/abilities/dry_skin.test.ts
@@ -25,6 +25,7 @@ describe("Abilities - Dry Skin", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(overrides, "NEVER_CRIT_OVERRIDE", "get").mockReturnValue(true);
     vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.DRY_SKIN);
     vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.SPLASH, Moves.SPLASH, Moves.SPLASH]);
     vi.spyOn(overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.CHARMANDER);
@@ -77,30 +78,28 @@ describe("Abilities - Dry Skin", () => {
   });
 
   it("opposing fire attacks do 25% more damage", async () => {
-    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.EMBER]);
-
-    // ensure the enemy doesn't die to this
-    vi.spyOn(overrides, "OPP_LEVEL_OVERRIDE", "get").mockReturnValue(30);
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.FLAMETHROWER]);
 
     await game.startBattle();
 
     const enemy = game.scene.getEnemyPokemon();
-    expect(enemy).not.toBe(undefined);
+    expect(enemy).toBeDefined();
+    const maxHP = 1000;
+    enemy.hp = maxHP;
 
     // first turn
-    vi.spyOn(game.scene, "randBattleSeedInt").mockReturnValue(0); // this makes moves always deal 85% damage
-    game.doAttack(getMovePosition(game.scene, 0, Moves.EMBER));
+    game.doAttack(getMovePosition(game.scene, 0, Moves.FLAMETHROWER));
     await game.phaseInterceptor.to(TurnEndPhase);
-    const fireDamageTakenWithDrySkin = enemy.getMaxHp() - enemy.hp;
+    const fireDamageTakenWithDrySkin = maxHP - enemy.hp;
 
     expect(enemy.hp > 0);
-    enemy.hp = enemy.getMaxHp();
+    enemy.hp = maxHP;
     vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.NONE);
 
     // second turn
-    game.doAttack(getMovePosition(game.scene, 0, Moves.EMBER));
+    game.doAttack(getMovePosition(game.scene, 0, Moves.FLAMETHROWER));
     await game.phaseInterceptor.to(TurnEndPhase);
-    const fireDamageTakenWithoutDrySkin = enemy.getMaxHp() - enemy.hp;
+    const fireDamageTakenWithoutDrySkin = maxHP - enemy.hp;
 
     expect(fireDamageTakenWithDrySkin).toBeGreaterThan(fireDamageTakenWithoutDrySkin);
   });

--- a/src/test/abilities/dry_skin.test.ts
+++ b/src/test/abilities/dry_skin.test.ts
@@ -84,22 +84,22 @@ describe("Abilities - Dry Skin", () => {
 
     const enemy = game.scene.getEnemyPokemon();
     expect(enemy).toBeDefined();
-    const maxHP = 1000;
-    enemy.hp = maxHP;
+    const initialHP = 1000;
+    enemy.hp = initialHP;
 
     // first turn
     game.doAttack(getMovePosition(game.scene, 0, Moves.FLAMETHROWER));
     await game.phaseInterceptor.to(TurnEndPhase);
-    const fireDamageTakenWithDrySkin = maxHP - enemy.hp;
+    const fireDamageTakenWithDrySkin = initialHP - enemy.hp;
 
     expect(enemy.hp > 0);
-    enemy.hp = maxHP;
+    enemy.hp = initialHP;
     vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.NONE);
 
     // second turn
     game.doAttack(getMovePosition(game.scene, 0, Moves.FLAMETHROWER));
     await game.phaseInterceptor.to(TurnEndPhase);
-    const fireDamageTakenWithoutDrySkin = maxHP - enemy.hp;
+    const fireDamageTakenWithoutDrySkin = initialHP - enemy.hp;
 
     expect(fireDamageTakenWithDrySkin).toBeGreaterThan(fireDamageTakenWithoutDrySkin);
   });

--- a/src/test/abilities/parental_bond.test.ts
+++ b/src/test/abilities/parental_bond.test.ts
@@ -31,6 +31,7 @@ describe("Abilities - Parental Bond", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     vi.spyOn(Overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(Overrides, "NEVER_CRIT_OVERRIDE", "get").mockReturnValue(true);
     vi.spyOn(Overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.PARENTAL_BOND);
     vi.spyOn(Overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.SNORLAX);
     vi.spyOn(Overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.INSOMNIA);
@@ -57,7 +58,6 @@ describe("Abilities - Parental Bond", () => {
       game.doAttack(getMovePosition(game.scene, 0, Moves.TACKLE));
 
       await game.phaseInterceptor.to(MoveEffectPhase, false);
-      vi.spyOn(game.scene, "randBattleSeedInt").mockReturnValue(15);
 
       await game.phaseInterceptor.to(DamagePhase);
       const firstStrikeDamage = enemyStartingHp - enemyPokemon.hp;
@@ -636,7 +636,6 @@ describe("Abilities - Parental Bond", () => {
       game.doAttack(getMovePosition(game.scene, 1, Moves.SPLASH));
 
       await game.phaseInterceptor.to(MoveEffectPhase, false);
-      vi.spyOn(game.scene, "randBattleSeedInt").mockReturnValue(15);
 
       await game.phaseInterceptor.to(DamagePhase);
       const enemyFirstHitDamage = enemyStartingHp.map((hp, i) => hp - enemyPokemon[i].hp);


### PR DESCRIPTION
## What are the changes?
Two tests are updated to enable the override that prevents crits.

## Why am I doing these changes?
The tests used some unnecessary RNG workarounds when the problem was crits all along.

## What did change?
`NEVER_CRIT_OVERRIDE` is set to true for the Dry Skin and Parental Bond tests, and the hacky damage roll workaround is removed since it's not necessary.

## How to test the changes?
`npm run test dry_skin` and `npm run test parental_bond`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~