### PR TITLE
[Beta][Localization] French translation mistake in pokemon-summary.ts

### DIFF
--- a/src/locales/fr/pokemon-summary.ts
+++ b/src/locales/fr/pokemon-summary.ts
@@ -2,7 +2,7 @@ import { TranslationEntries } from "#app/interfaces/locales";
 
 export const pokemonSummary: TranslationEntries = {
   "pokemonInfo": "Info Pokémon",
-  "status": "Résumé",
+  "status": "Statut",
   "powerAccuracyCategory": "Puissance\nPrécision\nCatégorie",
   "type": "Type",
   "unknownTrainer": "Inconnu",


### PR DESCRIPTION
## What are the changes?
Changed "Resumé" for "Statut" in French pokemon-summary.ts

## Why am I doing these changes?
"Status" translated as "Résumé" in this context is wrong, it has to be "Statut"
**Before**
![image](https://github.com/pagefaultgames/pokerogue/assets/2070109/a08e9412-a581-4717-9f5c-76d296aad581)

**After**
![image](https://github.com/pagefaultgames/pokerogue/assets/2070109/328bd7aa-148f-4fc8-b38f-7138165a148a)

## What did change?
Because the current translation is wrong in this context

## How to test the changes?
Open a Pokémon summary in French while having status issue (frozen, fainted, etc...)

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?