### PR TITLE
[QoL] Remove unneeded PP Up and PP Max

### DIFF
--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1399,7 +1399,11 @@ const modifierPool: ModifierPool = {
   }),
   [ModifierTier.GREAT]: [
     new WeightedModifierType(modifierTypes.GREAT_BALL, (party: Pokemon[]) => (hasMaximumBalls(party, PokeballType.GREAT_BALL)) ? 0 : 6, 6),
-    new WeightedModifierType(modifierTypes.PP_UP, 2),
+    new WeightedModifierType(modifierTypes.PP_UP, (party: Pokemon[]) => {
+      // This find function will search for any move in the party that has less than 3 pp ups
+      const needsPpUp = party.find((p: Pokemon) => p.getMoveset().find(m => m.ppUp !== 3)) !== undefined;
+      return needsPpUp ? 2 : 0;
+    }),
     new WeightedModifierType(modifierTypes.FULL_HEAL, (party: Pokemon[]) => {
       const statusEffectPartyMemberCount = Math.min(party.filter(p => p.hp && !!p.status && !p.getHeldItems().some(i => {
         if (i instanceof Modifiers.TurnStatusEffectModifier) {
@@ -1472,7 +1476,11 @@ const modifierPool: ModifierPool = {
     new WeightedModifierType(modifierTypes.ULTRA_BALL, (party: Pokemon[]) => (hasMaximumBalls(party, PokeballType.ULTRA_BALL)) ? 0 : 15, 15),
     new WeightedModifierType(modifierTypes.MAX_LURE, 4),
     new WeightedModifierType(modifierTypes.BIG_NUGGET, skipInLastClassicWaveOrDefault(12)),
-    new WeightedModifierType(modifierTypes.PP_MAX, 3),
+    new WeightedModifierType(modifierTypes.PP_MAX, (party: Pokemon[]) => {
+      // This find function will search for any move in the party that has less than 3 pp ups
+      const needsPpUp = party.find((p: Pokemon) => p.getMoveset().find(m => m.ppUp !== 3)) !== undefined;
+      return needsPpUp ? 3 : 0;
+    }),
     new WeightedModifierType(modifierTypes.MINT, 4),
     new WeightedModifierType(modifierTypes.RARE_EVOLUTION_ITEM, (party: Pokemon[]) => Math.min(Math.ceil(party[0].scene.currentBattle.waveIndex / 15) * 4, 32), 32),
     new WeightedModifierType(modifierTypes.AMULET_COIN, skipInLastClassicWaveOrDefault(3)),


### PR DESCRIPTION
## What are the changes?
Removes PP Up and PP Max from the shop if all Party Pokemon have maxed PP Up

## Why am I doing these changes?
Someone asked in [Discord](https://discord.com/channels/1125469663833370665/1239793884553547838)

## What did change?
PP Up and PP Max no longer appear in shop if all Party Pokemon have 3/3 PP Up on all their moves

## How to test the changes?
Change the `WeightedModifierType` for `PP_UP` and `PP_MAX` to `1000`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?

![tests](https://i.ember.zone/5Cy8tKIMBEWxJHN1.png)