### PR TITLE
[Feature] Change Smeargle/Sketch to pre-gen9 implementation

### DIFF
--- a/src/data/pokemon-level-moves.ts
+++ b/src/data/pokemon-level-moves.ts
@@ -4074,11 +4074,18 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
     [ 49, Moves.IMPRISON ],
     [ 55, Moves.DOUBLE_EDGE ],
   ],
+  // Reverting Smeargle back to pre gen9 implementation, to make it less dependent on access to Memory Mushrooms
   [Species.SMEARGLE]: [
     [ 1, Moves.SKETCH ],
-    [ 1, Moves.SKETCH ],
-    [ 1, Moves.SKETCH ],
-    [ 1, Moves.SKETCH ],
+    [ 11, Moves.SKETCH ],
+    [ 21, Moves.SKETCH ],
+    [ 31, Moves.SKETCH ],
+    [ 41, Moves.SKETCH ],
+    [ 51, Moves.SKETCH ],
+    [ 61, Moves.SKETCH ],
+    [ 71, Moves.SKETCH ],
+    [ 81, Moves.SKETCH ],
+    [ 91, Moves.SKETCH ],
   ],
   [Species.TYROGUE]: [
     [ 1, Moves.TACKLE ],


### PR DESCRIPTION
## What are the changes?
Changed Smeargle to relearn Sketch at levels 11, 21, 31, etc, up to level 91 so that it is in line with its learnset in previous generations, as opposed to the current gen 9 implementation. 

## Why am I doing these changes? 
Currently, Smeargle requires a high amount of investment in the form of Memory Mushrooms. This makes Smeargle difficult to use, particularly when obtained early on due to the increased rarity of said Mushrooms at lower levels. This change would make Smeargle more useful early on as a Starter, without impacting its strength or flexibility beyond level 91. 

## What did change?
Smeargle's learn-set has been updated to learn Sketch at levels 11, 21, 31, 41, 51, 61, 71, 81, and 91. 

Pokemon.getLevelMoves() has been updated to narrow the Species level moves by level first, and then filter out any duplicates after, as the other way around was causing any higher level Sketch learns to be missed. 

## How to test the changes?
Level a Smeargle up to level 11, and have it relearn Sketch. 
NOTE: You must have actually used sketch in order to relearn it. 

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?