### PR TITLE
[Bug] Evolution ability fix

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3211,13 +3211,22 @@ export class PlayerPokemon extends Pokemon {
       this.generateName();
       if (!isFusion) {
         const abilityCount = this.getSpeciesForm().getAbilityCount();
-        if (this.abilityIndex >= abilityCount) { // Shouldn't happen
-          this.abilityIndex = abilityCount - 1;
+        // If a pokemon has its second ability and it evolves into a pokemon that doesn't have a second ability, switch to its first ability instead of its hidden ability
+        if (this.getSpeciesForm().ability2 === Abilities.NONE && this.abilityIndex === 1) {
+          this.abilityIndex = 0;
         }
-      } else {
+        // Prevent pokemon with an illegal ability value from breaking things too badly
+        if (this.abilityIndex >= abilityCount) {
+          console.warn("this.abilityIndex is somehow an illegal value, please report this");
+          console.warn(this.abilityIndex);
+          this.abilityIndex = 0;
+        }
+      } else { // Do the same as above, but for fusions
         const abilityCount = this.getFusionSpeciesForm().getAbilityCount();
-        if (this.fusionAbilityIndex >= abilityCount) {// Shouldn't happen
-          this.fusionAbilityIndex = abilityCount - 1;
+        if (this.fusionAbilityIndex >= abilityCount) {
+          console.warn("this.fusionAbilityIndex is somehow an illegal value, please report this");
+          console.warn(this.fusionAbilityIndex);
+          this.fusionAbilityIndex = 0;
         }
       }
       this.compatibleTms.splice(0, this.compatibleTms.length);

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3210,18 +3210,21 @@ export class PlayerPokemon extends Pokemon {
       }
       this.generateName();
       if (!isFusion) {
-        const abilityCount = this.getSpeciesForm().getAbilityCount();
         // If a pokemon has its second ability and it evolves into a pokemon that doesn't have a second ability, switch to its first ability instead of its hidden ability
         if (this.getSpeciesForm().ability2 === Abilities.NONE && this.abilityIndex === 1) {
           this.abilityIndex = 0;
         }
         // Prevent pokemon with an illegal ability value from breaking things too badly
+        const abilityCount = this.getSpeciesForm().getAbilityCount();
         if (this.abilityIndex >= abilityCount) {
           console.warn("this.abilityIndex is somehow an illegal value, please report this");
           console.warn(this.abilityIndex);
           this.abilityIndex = 0;
         }
       } else { // Do the same as above, but for fusions
+        if (this.getFusionSpeciesForm().ability2 === Abilities.NONE && this.fusionAbilityIndex === 1) {
+          this.fusionAbilityIndex = 0;
+        }
         const abilityCount = this.getFusionSpeciesForm().getAbilityCount();
         if (this.fusionAbilityIndex >= abilityCount) {
           console.warn("this.fusionAbilityIndex is somehow an illegal value, please report this");


### PR DESCRIPTION
## What are the changes?
If a Pokémon with their second ability evolves, it will swap to its first ability if the evolution has no second ability, instead of improperly "upgrading" to its hidden ability.

## Why am I doing these changes?
I noticed a bug report about the issue
https://discord.com/channels/1125469663833370665/1254274565627187211

cf [Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Ability#Mechanics)
> In technical terms, a species' Abilities may be thought of as having separate slots, with an individual Pokémon's non-Hidden slot determined by its [personality value](https://bulbapedia.bulbagarden.net/wiki/Personality_value). For example, an [Eevee](https://bulbapedia.bulbagarden.net/wiki/Eevee_(Pok%C3%A9mon)) — with two non-Hidden Abilities — has [Run Away](https://bulbapedia.bulbagarden.net/wiki/Run_Away_(Ability)) for its first non-Hidden slot, [Adaptability](https://bulbapedia.bulbagarden.net/wiki/Adaptability_(Ability)) for its second, and [Anticipation](https://bulbapedia.bulbagarden.net/wiki/Anticipation_(Ability)) for its Hidden Ability slot. [Vaporeon](https://bulbapedia.bulbagarden.net/wiki/Vaporeon_(Pok%C3%A9mon)) — with only one non-Hidden Ability — can be considered to have [Water Absorb](https://bulbapedia.bulbagarden.net/wiki/Water_Absorb_(Ability)) for both non-Hidden slots. When a Pokémon evolves, its Ability slot remains the same.

## What did change?
A check is added in the `evolve()` function in `src/field/pokemon.ts` to ensure a Pokémon whose second ability is "NONE" (aka it doesn't have a second ability) is swapped to its first ability.

### Screenshots/Videos
Incorrect behavior (current on beta):

https://github.com/user-attachments/assets/3f7d2a15-92b8-4098-b06a-663794accbfe

Demonstration of correct behavior after the fix is applied:

https://github.com/user-attachments/assets/1a81b59c-33a8-473d-ae35-d79d2917141c

https://github.com/user-attachments/assets/a79d8c54-e137-4fe5-b494-03e474c94e10

<!-- old video https://github.com/user-attachments/assets/373be944-0d25-43c9-9265-3bf0a0a11118 -->

## How to test the changes?
Start a run with an Eevee with Adaptability (its second ability) and evolve it with a Fire/Water/Thunder stone. It should now have its first ability (Flash Fire/Water Absorb/Volt Absorb) rather than its hidden ability (Guts/Hydration/Quick Feet).

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?