### PR TITLE
[Test] Separate enum from i18 import

### DIFF
--- a/src/data/status-effect.ts
+++ b/src/data/status-effect.ts
@@ -1,16 +1,8 @@
 import * as Utils from "../utils";
+import { StatusEffect } from "#enums/status-effect";
 import i18next, { ParseKeys } from "i18next";
 
-export enum StatusEffect {
-  NONE,
-  POISON,
-  TOXIC,
-  PARALYSIS,
-  SLEEP,
-  FREEZE,
-  BURN,
-  FAINT
-}
+export { StatusEffect };
 
 export class Status {
   public effect: StatusEffect;

--- a/src/enums/status-effect.ts
+++ b/src/enums/status-effect.ts
@@ -1,0 +1,10 @@
+export enum StatusEffect {
+  NONE,
+  POISON,
+  TOXIC,
+  PARALYSIS,
+  SLEEP,
+  FREEZE,
+  BURN,
+  FAINT,
+}

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -1,23 +1,23 @@
 import { Abilities } from "#enums/abilities";
-import { BerryType } from "#enums/berry-type";
+import { type BerryType } from "#enums/berry-type";
 import { Biome } from "#enums/biome";
+import { EggTier } from "#enums/egg-type";
 import { Moves } from "#enums/moves";
 import { Nature } from "#enums/nature";
 import { PokeballType } from "#enums/pokeball";
 import { Species } from "#enums/species";
-import { Stat } from "#enums/stat";
+import { type Stat } from "#enums/stat";
+import { StatusEffect } from "#enums/status-effect";
 import { TimeOfDay } from "#enums/time-of-day";
-import { WeatherType } from "#enums/weather-type";
 import { VariantTier } from "#enums/variant-tiers";
-import { EggTier } from "#enums/egg-type";
+import { WeatherType } from "#enums/weather-type";
 import { type PokeballCounts } from "./battle-scene";
 import { Gender } from "./data/gender";
 import { allSpecies } from "./data/pokemon-species"; // eslint-disable-line @typescript-eslint/no-unused-vars
-import { StatusEffect } from "./data/status-effect";
-import { TempBattleStat } from "./data/temp-battle-stat";
-import { Type } from "./data/type";
-import { Variant } from "./data/variant";
-import { type SpeciesStatBoosterItem, type ModifierTypes } from "./modifier/modifier-type";
+import { type TempBattleStat } from "./data/temp-battle-stat";
+import { type Type } from "./data/type";
+import { type Variant } from "./data/variant";
+import { type ModifierTypes, type SpeciesStatBoosterItem } from "./modifier/modifier-type";
 
 /**
  * Overrides for testing different in game situations


### PR DESCRIPTION
## What are the changes?
Status effect enum was importing i18 and breaking pre tests

## Why am I doing these changes?
Status effect enum was importing i18 and breaking pre tests

## What did change?
Move Status Effect enum into separate file and explicitly state which enums are just used by typescript in overrides.ts

### Screenshots/Videos
N/A

## How to test the changes?
`npm run test:silent`
`npm run docs`

## Checklist
- [x] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
~~- [] Are the changes visual?~~
  ~~- [ ] Have I provided screenshots/videos of the changes?~~