### PR TITLE
[QoL] Create default overrides class and export that with custom overrides

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -49,7 +49,7 @@ import { SceneBase } from "./scene-base";
 import CandyBar from "./ui/candy-bar";
 import { Variant, variantData } from "./data/variant";
 import { Localizable } from "#app/interfaces/locales";
-import * as Overrides from "./overrides";
+import Overrides from "#app/overrides";
 import {InputsController} from "./inputs-controller";
 import {UiInputs} from "./ui-inputs";
 import { NewArenaEvent } from "./events/battle-scene";

--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -2,7 +2,7 @@ import BattleScene from "../battle-scene";
 import PokemonSpecies, { getPokemonSpecies, speciesStarters } from "./pokemon-species";
 import { VariantTier } from "../enums/variant-tiers";
 import * as Utils from "../utils";
-import * as Overrides from "../overrides";
+import Overrides from "../overrides";
 import { pokemonPrevolutions } from "./pokemon-evolutions";
 import { PlayerPokemon } from "#app/field/pokemon";
 import i18next from "i18next";

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -13,7 +13,7 @@ import { BattlerIndex } from "../battle";
 import { Terrain, TerrainType } from "../data/terrain";
 import { PostTerrainChangeAbAttr, PostWeatherChangeAbAttr, applyPostTerrainChangeAbAttrs, applyPostWeatherChangeAbAttrs } from "../data/ability";
 import Pokemon from "./pokemon";
-import * as Overrides from "../overrides";
+import Overrides from "../overrides";
 import { WeatherChangedEvent, TerrainChangedEvent, TagAddedEvent, TagRemovedEvent } from "../events/arena";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { Biome } from "#enums/biome";

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -37,7 +37,7 @@ import { Nature, getNatureStatMultiplier } from "../data/nature";
 import { SpeciesFormChange, SpeciesFormChangeActiveTrigger, SpeciesFormChangeMoveLearnedTrigger, SpeciesFormChangePostMoveTrigger, SpeciesFormChangeStatusEffectTrigger } from "../data/pokemon-forms";
 import { TerrainType } from "../data/terrain";
 import { TrainerSlot } from "../data/trainer-config";
-import * as Overrides from "../overrides";
+import Overrides from "../overrides";
 import i18next from "i18next";
 import { speciesEggMoves } from "../data/egg-moves";
 import { ModifierTier } from "../modifier/modifier-tier";

--- a/src/game-mode.ts
+++ b/src/game-mode.ts
@@ -4,7 +4,7 @@ import BattleScene from "./battle-scene";
 import { allChallenges, applyChallenges, Challenge, ChallengeType, copyChallenge } from "./data/challenge";
 import PokemonSpecies, { allSpecies } from "./data/pokemon-species";
 import { Arena } from "./field/arena";
-import * as Overrides from "./overrides";
+import Overrides from "./overrides";
 import * as Utils from "./utils";
 import { Biome } from "#enums/biome";
 import { Species } from "#enums/species";

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -20,7 +20,7 @@ import { ModifierTier } from "./modifier-tier";
 import { Nature, getNatureName, getNatureStatMultiplier } from "#app/data/nature";
 import i18next from "i18next";
 import { getModifierTierTextTint } from "#app/ui/text";
-import * as Overrides from "../overrides";
+import Overrides from "#app/overrides";
 import { MoneyMultiplierModifier } from "./modifier";
 import { Abilities } from "#enums/abilities";
 import { BattlerTagType } from "#enums/battler-tag-type";
@@ -1164,7 +1164,57 @@ class WeightedModifierType {
   }
 }
 
-export type ModifierTypes = keyof typeof modifierTypes;
+type BaseModifierOverride = {
+  name: Exclude<ModifierTypeKeys, GeneratorModifierOverride["name"]>;
+  count?: number;
+};
+
+/** Type for modifiers and held items that are constructed via {@linkcode ModifierTypeGenerator}. */
+export type GeneratorModifierOverride = {
+    count?: number
+  } & (
+  | {
+      name: "SPECIES_STAT_BOOSTER";
+      type?: SpeciesStatBoosterItem;
+    }
+  | {
+      name: "TEMP_STAT_BOOSTER";
+      type?: TempBattleStat;
+    }
+  | {
+      name: "BASE_STAT_BOOSTER";
+      type?: Stat;
+    }
+  | {
+      name: "MINT";
+      type?: Nature;
+    }
+  | {
+      name: "TERA_SHARD" | "ATTACK_TYPE_BOOSTER";
+      type?: Type;
+    }
+  | {
+      name: "BERRY";
+      type?: BerryType;
+    }
+  | {
+      name: "EVOLUTION_ITEM" | "RARE_EVOLUTION_ITEM";
+      type?: EvolutionItem;
+    }
+  | {
+      name: "FORM_CHANGE_ITEM";
+      type?: FormChangeItem;
+    }
+  | {
+      name: "TM_COMMON" | "TM_GREAT" | "TM_ULTRA";
+      type?: Moves;
+    }
+);
+
+/** Type used to construct modifiers and held items for overriding purposes. */
+export type ModifierOverride = GeneratorModifierOverride | BaseModifierOverride;
+
+export type ModifierTypeKeys = keyof typeof modifierTypes;
 
 export const modifierTypes = {
   POKEBALL: () => new AddPokeballModifierType("pb", PokeballType.POKEBALL, 5),
@@ -1831,8 +1881,7 @@ export function getPlayerModifierTypeOptions(count: integer, party: PlayerPokemo
   // OVERRIDE IF NECESSARY
   if (Overrides.ITEM_REWARD_OVERRIDE?.length) {
     options.forEach((mod, i) => {
-      // @ts-ignore: keeps throwing don't use string as index error in typedoc run
-      const override = modifierTypes[Overrides.ITEM_REWARD_OVERRIDE[i]]?.();
+      const override = modifierTypes[Overrides.ITEM_REWARD_OVERRIDE[i]]();
       mod.type = (override instanceof ModifierTypeGenerator ? override.generateType(party) : override) || mod.type;
     });
   }

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1171,42 +1171,42 @@ type BaseModifierOverride = {
 
 /** Type for modifiers and held items that are constructed via {@linkcode ModifierTypeGenerator}. */
 export type GeneratorModifierOverride = {
-    count?: number
-  } & (
+  count?: number;
+} & (
   | {
-      name: "SPECIES_STAT_BOOSTER";
+      name: keyof Pick<typeof modifierTypes, "SPECIES_STAT_BOOSTER">;
       type?: SpeciesStatBoosterItem;
     }
   | {
-      name: "TEMP_STAT_BOOSTER";
+      name: keyof Pick<typeof modifierTypes, "TEMP_STAT_BOOSTER">;
       type?: TempBattleStat;
     }
   | {
-      name: "BASE_STAT_BOOSTER";
+      name: keyof Pick<typeof modifierTypes, "BASE_STAT_BOOSTER">;
       type?: Stat;
     }
   | {
-      name: "MINT";
+      name: keyof Pick<typeof modifierTypes, "MINT">;
       type?: Nature;
     }
   | {
-      name: "TERA_SHARD" | "ATTACK_TYPE_BOOSTER";
+      name: keyof Pick<typeof modifierTypes, "ATTACK_TYPE_BOOSTER" | "TERA_SHARD">;
       type?: Type;
     }
   | {
-      name: "BERRY";
+      name: keyof Pick<typeof modifierTypes, "BERRY">;
       type?: BerryType;
     }
   | {
-      name: "EVOLUTION_ITEM" | "RARE_EVOLUTION_ITEM";
+      name: keyof Pick<typeof modifierTypes, "EVOLUTION_ITEM" | "RARE_EVOLUTION_ITEM">;
       type?: EvolutionItem;
     }
   | {
-      name: "FORM_CHANGE_ITEM";
+      name: keyof Pick<typeof modifierTypes, "FORM_CHANGE_ITEM">;
       type?: FormChangeItem;
     }
   | {
-      name: "TM_COMMON" | "TM_GREAT" | "TM_ULTRA";
+      name: keyof Pick<typeof modifierTypes, "TM_COMMON" | "TM_GREAT" | "TM_ULTRA">;
       type?: Moves;
     }
 );

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -2665,7 +2665,8 @@ export function overrideHeldItems(scene: BattleScene, pokemon: Pokemon, player: 
     const modifierType: ModifierType = modifierTypes[itemName](); // we retrieve the item in the list
     let itemModifier: PokemonHeldItemModifier;
     if (modifierType instanceof ModifierTypes.ModifierTypeGenerator) {
-      itemModifier = modifierType.generateType(null, [(item as ModifierTypes.GeneratorModifierOverride).type]).withIdFromFunc(modifierTypes[itemName]).newModifier(pokemon) as PokemonHeldItemModifier;
+      const pregenArgs = "type" in item ? [item.type] : null;
+      itemModifier = modifierType.generateType(null, pregenArgs).withIdFromFunc(modifierTypes[itemName]).newModifier(pokemon) as PokemonHeldItemModifier;
     } else {
       itemModifier = modifierType.withIdFromFunc(modifierTypes[itemName]).newModifier(pokemon) as PokemonHeldItemModifier;
     }

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -20,7 +20,7 @@ import { achvs } from "../system/achv";
 import { VoucherType } from "../system/voucher";
 import { FormChangeItem, SpeciesFormChangeItemTrigger } from "../data/pokemon-forms";
 import { Nature } from "#app/data/nature";
-import * as Overrides from "../overrides";
+import Overrides from "../overrides";
 import { ModifierType, modifierTypes } from "./modifier-type";
 import { Command } from "#app/ui/command-ui-handler.js";
 import { Species } from "#enums/species";
@@ -2665,7 +2665,7 @@ export function overrideHeldItems(scene: BattleScene, pokemon: Pokemon, player: 
     const modifierType: ModifierType = modifierTypes[itemName](); // we retrieve the item in the list
     let itemModifier: PokemonHeldItemModifier;
     if (modifierType instanceof ModifierTypes.ModifierTypeGenerator) {
-      itemModifier = modifierType.generateType(null, [item.type]).withIdFromFunc(modifierTypes[itemName]).newModifier(pokemon) as PokemonHeldItemModifier;
+      itemModifier = modifierType.generateType(null, [(item as ModifierTypes.GeneratorModifierOverride).type]).withIdFromFunc(modifierTypes[itemName]).newModifier(pokemon) as PokemonHeldItemModifier;
     } else {
       itemModifier = modifierType.withIdFromFunc(modifierTypes[itemName]).newModifier(pokemon) as PokemonHeldItemModifier;
     }

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -1,12 +1,9 @@
 import { Abilities } from "#enums/abilities";
-import { type BerryType } from "#enums/berry-type";
 import { Biome } from "#enums/biome";
 import { EggTier } from "#enums/egg-type";
 import { Moves } from "#enums/moves";
-import { Nature } from "#enums/nature";
 import { PokeballType } from "#enums/pokeball";
 import { Species } from "#enums/species";
-import { type Stat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
 import { TimeOfDay } from "#enums/time-of-day";
 import { VariantTier } from "#enums/variant-tiers";
@@ -14,135 +11,166 @@ import { WeatherType } from "#enums/weather-type";
 import { type PokeballCounts } from "./battle-scene";
 import { Gender } from "./data/gender";
 import { allSpecies } from "./data/pokemon-species"; // eslint-disable-line @typescript-eslint/no-unused-vars
-import { type TempBattleStat } from "./data/temp-battle-stat";
-import { type Type } from "./data/type";
-import { type Variant } from "./data/variant";
-import { type ModifierTypes, type SpeciesStatBoosterItem } from "./modifier/modifier-type";
+import { Variant } from "./data/variant";
+import { type ModifierOverride, type ModifierTypeKeys } from "./modifier/modifier-type";
 
 /**
- * Overrides for testing different in game situations
- * if an override name starts with "STARTING", it will apply when a new run begins
- */
-
-/**
- * OVERALL OVERRIDES
- */
-
-// a specific seed (default: a random string of 24 characters)
-export const SEED_OVERRIDE: string = "";
-export const WEATHER_OVERRIDE: WeatherType = WeatherType.NONE;
-export const DOUBLE_BATTLE_OVERRIDE: boolean = false;
-export const SINGLE_BATTLE_OVERRIDE: boolean = false;
-export const STARTING_WAVE_OVERRIDE: integer = 0;
-export const STARTING_BIOME_OVERRIDE: Biome = Biome.TOWN;
-export const ARENA_TINT_OVERRIDE: TimeOfDay = null;
-// Multiplies XP gained by this value including 0. Set to null to ignore the override
-export const XP_MULTIPLIER_OVERRIDE: number = null;
-// default 1000
-export const STARTING_MONEY_OVERRIDE: integer = 0;
-export const FREE_CANDY_UPGRADE_OVERRIDE: boolean = false;
-export const POKEBALL_OVERRIDE: { active: boolean, pokeballs: PokeballCounts } = {
-  active: false,
-  pokeballs: {
-    [PokeballType.POKEBALL]: 5,
-    [PokeballType.GREAT_BALL]: 0,
-    [PokeballType.ULTRA_BALL]: 0,
-    [PokeballType.ROGUE_BALL]: 0,
-    [PokeballType.MASTER_BALL]: 0,
-  }
-};
-
-/**
- * PLAYER OVERRIDES
- */
-
-/**
- * Set the form index of any starter in the party whose `speciesId` is inside this override
- * @see {@link allSpecies} in `src/data/pokemon-species.ts` for form indexes
+ * Overrides that are using when testing different in game situations
+ *
+ * Any override added here will be used instead of the value in {@linkcode DefaultOverrides}
+ *
+ * If an override name starts with "STARTING", it will apply when a new run begins
+ *
  * @example
  * ```
- * const STARTER_FORM_OVERRIDES = {
- *   [Species.DARMANITAN]: 1
+ * const overrides = {
+ *   ABILITY_OVERRIDE: Abilities.PROTEAN,
+ *   PASSIVE_ABILITY_OVERRIDE: Abilities.PIXILATE,
  * }
  * ```
  */
-export const STARTER_FORM_OVERRIDES: Partial<Record<Species, number>> = {};
-
-// default 5 or 20 for Daily
-export const STARTING_LEVEL_OVERRIDE: integer = 0;
-/**
- * SPECIES OVERRIDE
- * will only apply to the first starter in your party or each enemy pokemon
- * default is 0 to not override
- * @example SPECIES_OVERRIDE = Species.Bulbasaur;
- */
-export const STARTER_SPECIES_OVERRIDE: Species | integer = 0;
-export const ABILITY_OVERRIDE: Abilities = Abilities.NONE;
-export const PASSIVE_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
-export const STATUS_OVERRIDE: StatusEffect = StatusEffect.NONE;
-export const GENDER_OVERRIDE: Gender = null;
-export const MOVESET_OVERRIDE: Array<Moves> = [];
-export const SHINY_OVERRIDE: boolean = false;
-export const VARIANT_OVERRIDE: Variant = 0;
+const overrides = {} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
 
 /**
- * OPPONENT / ENEMY OVERRIDES
- */
-
-export const OPP_SPECIES_OVERRIDE: Species | integer = 0;
-export const OPP_LEVEL_OVERRIDE: number = 0;
-export const OPP_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
-export const OPP_PASSIVE_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
-export const OPP_STATUS_OVERRIDE: StatusEffect = StatusEffect.NONE;
-export const OPP_GENDER_OVERRIDE: Gender = null;
-export const OPP_MOVESET_OVERRIDE: Array<Moves> = [];
-export const OPP_SHINY_OVERRIDE: boolean = false;
-export const OPP_VARIANT_OVERRIDE: Variant = 0;
-export const OPP_IVS_OVERRIDE: integer | integer[] = [];
-
-/**
- * EGG OVERRIDES
- */
-
-export const EGG_IMMEDIATE_HATCH_OVERRIDE: boolean = false;
-export const EGG_TIER_OVERRIDE: EggTier = null;
-export const EGG_SHINY_OVERRIDE: boolean = false;
-export const EGG_VARIANT_OVERRIDE: VariantTier = null;
-export const EGG_FREE_GACHA_PULLS_OVERRIDE: boolean = false;
-export const EGG_GACHA_PULL_COUNT_OVERRIDE: number = 0;
-
-/**
- * MODIFIER / ITEM OVERRIDES
- * if count is not provided, it will default to 1
- * @example Modifier Override [{name: "EXP_SHARE", count: 2}]
- * @example Held Item Override [{name: "LUCKY_EGG"}]
+ * If you need to add Overrides values for local testing do that inside {@linkcode overrides}
+ * ---
+ * Defaults for Overrides that are used when testing different in game situations
  *
- * Some items are generated based on a sub-type (i.e. berries), to override those:
- * @example [{name: "BERRY", count: 5, type: BerryType.SITRUS}]
- * types are listed in interface below
- * - TempBattleStat is for TEMP_STAT_BOOSTER / X Items (Dire hit is separate)
- * - Stat is for BASE_STAT_BOOSTER / Vitamin
- * - Nature is for MINT
- * - Type is for TERA_SHARD or ATTACK_TYPE_BOOSTER (type boosting items i.e Silk Scarf)
- * - BerryType is for BERRY
- * - SpeciesStatBoosterItem is for SPECIES_STAT_BOOSTER
+ * If an override name starts with "STARTING", it will apply when a new run begins
  */
-interface ModifierOverride {
-    name: ModifierTypes & string,
-    count?: integer
-    type?: TempBattleStat|Stat|Nature|Type|BerryType|SpeciesStatBoosterItem
+class DefaultOverrides {
+  // -----------------
+  // OVERALL OVERRIDES
+  // -----------------
+  /** a specific seed (default: a random string of 24 characters) */
+  readonly SEED_OVERRIDE: string = "";
+  readonly WEATHER_OVERRIDE: WeatherType = WeatherType.NONE;
+  readonly DOUBLE_BATTLE_OVERRIDE: boolean = false;
+  readonly SINGLE_BATTLE_OVERRIDE: boolean = false;
+  readonly STARTING_WAVE_OVERRIDE: integer = 0;
+  readonly STARTING_BIOME_OVERRIDE: Biome = Biome.TOWN;
+  readonly ARENA_TINT_OVERRIDE: TimeOfDay = null;
+  /** Multiplies XP gained by this value including 0. Set to null to ignore the override */
+  readonly XP_MULTIPLIER_OVERRIDE: number = null;
+  /** default 1000 */
+  readonly STARTING_MONEY_OVERRIDE: integer = 0;
+  readonly FREE_CANDY_UPGRADE_OVERRIDE: boolean = false;
+  readonly POKEBALL_OVERRIDE: { active: boolean; pokeballs: PokeballCounts } = {
+    active: false,
+    pokeballs: {
+      [PokeballType.POKEBALL]: 5,
+      [PokeballType.GREAT_BALL]: 0,
+      [PokeballType.ULTRA_BALL]: 0,
+      [PokeballType.ROGUE_BALL]: 0,
+      [PokeballType.MASTER_BALL]: 0,
+    },
+  };
+
+  // ----------------
+  // PLAYER OVERRIDES
+  // ----------------
+  /**
+   * Set the form index of any starter in the party whose `speciesId` is inside this override
+   * @see {@link allSpecies} in `src/data/pokemon-species.ts` for form indexes
+   * @example
+   * ```
+   * const STARTER_FORM_OVERRIDES = {
+   *   [Species.DARMANITAN]: 1
+   * }
+   * ```
+   */
+  readonly STARTER_FORM_OVERRIDES: Partial<Record<Species, number>> = {};
+
+  /** default 5 or 20 for Daily */
+  readonly STARTING_LEVEL_OVERRIDE: integer = 0;
+  /**
+   * SPECIES OVERRIDE
+   * will only apply to the first starter in your party or each enemy pokemon
+   * default is 0 to not override
+   * @example SPECIES_OVERRIDE = Species.Bulbasaur;
+   */
+  readonly STARTER_SPECIES_OVERRIDE: Species | integer = 0;
+  readonly ABILITY_OVERRIDE: Abilities = Abilities.NONE;
+  readonly PASSIVE_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
+  readonly STATUS_OVERRIDE: StatusEffect = StatusEffect.NONE;
+  readonly GENDER_OVERRIDE: Gender = null;
+  readonly MOVESET_OVERRIDE: Array<Moves> = [];
+  readonly SHINY_OVERRIDE: boolean = false;
+  readonly VARIANT_OVERRIDE: Variant = 0;
+
+  // --------------------------
+  // OPPONENT / ENEMY OVERRIDES
+  // --------------------------
+  readonly OPP_SPECIES_OVERRIDE: Species | integer = 0;
+  readonly OPP_LEVEL_OVERRIDE: number = 0;
+  readonly OPP_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
+  readonly OPP_PASSIVE_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
+  readonly OPP_STATUS_OVERRIDE: StatusEffect = StatusEffect.NONE;
+  readonly OPP_GENDER_OVERRIDE: Gender = null;
+  readonly OPP_MOVESET_OVERRIDE: Array<Moves> = [];
+  readonly OPP_SHINY_OVERRIDE: boolean = false;
+  readonly OPP_VARIANT_OVERRIDE: Variant = 0;
+  readonly OPP_IVS_OVERRIDE: integer | integer[] = [];
+
+  // -------------
+  // EGG OVERRIDES
+  // -------------
+  readonly EGG_IMMEDIATE_HATCH_OVERRIDE: boolean = false;
+  readonly EGG_TIER_OVERRIDE: EggTier = null;
+  readonly EGG_SHINY_OVERRIDE: boolean = false;
+  readonly EGG_VARIANT_OVERRIDE: VariantTier = null;
+  readonly EGG_FREE_GACHA_PULLS_OVERRIDE: boolean = false;
+  readonly EGG_GACHA_PULL_COUNT_OVERRIDE: number = 0;
+
+  // -------------------------
+  // MODIFIER / ITEM OVERRIDES
+  // -------------------------
+  /**
+   * Overrides labeled `MODIFIER` deal with any modifier so long as it doesn't require a party
+   * member to hold it (typically this is, extends, or generates a {@linkcode ModifierType}),
+   * like `EXP_SHARE`, `CANDY_JAR`, etc.
+   *
+   * Overrides labeled `HELD_ITEM` specifically pertain to any entry in {@linkcode modifierTypes} that
+   * extends, or generates a {@linkcode PokemonHeldItemModifierType}, like `SOUL_DEW`, `TOXIC_ORB`, etc.
+   *
+   * Note that, if count is not provided, it will default to 1.
+   *
+   * Additionally, note that some held items and modifiers are grouped together via
+   * a {@linkcode ModifierTypeGenerator} and require pre-generation arguments to get
+   * a specific item from that group. If a type is not set, the generator will either
+   * use the party to weight item choice or randomly pick an item.
+   *
+   * @example
+   * ```
+   * // Will have a quantity of 2 in-game
+   * STARTING_MODIFIER_OVERRIDE = [{name: "EXP_SHARE", count: 2}]
+   * // Will have a quantity of 1 in-game
+   * STARTING_HELD_ITEM_OVERRIDE = [{name: "LUCKY_EGG"}]
+   * // Type must be given to get a specific berry
+   * STARTING_HELD_ITEM_OVERRIDE = [{name: "BERRY", type: BerryType.SITRUS}]
+   * // A random berry will be generated at runtime
+   * STARTING_HELD_ITEM_OVERRIDE = [{name: "BERRY"}]
+   * ```
+   */
+  readonly STARTING_MODIFIER_OVERRIDE: Array<ModifierOverride> = [];
+  readonly OPP_MODIFIER_OVERRIDE: Array<ModifierOverride> = [];
+
+  readonly STARTING_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [];
+  readonly OPP_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [];
+  readonly NEVER_CRIT_OVERRIDE: boolean = false;
+
+  /**
+   * An array of items by keys as defined in the "modifierTypes" object in the "modifier/modifier-type.ts" file.
+   * Items listed will replace the normal rolls.
+   * If less items are listed than rolled, only some items will be replaced
+   * If more items are listed than rolled, only the first X items will be shown, where X is the number of items rolled.
+   */
+  readonly ITEM_REWARD_OVERRIDE: Array<ModifierTypeKeys> = [];
 }
-export const STARTING_MODIFIER_OVERRIDE: Array<ModifierOverride> = [];
-export const OPP_MODIFIER_OVERRIDE: Array<ModifierOverride> = [];
 
-export const STARTING_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [];
-export const OPP_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [];
-export const NEVER_CRIT_OVERRIDE: boolean = false;
+export const defaultOverrides = new DefaultOverrides();
 
-/**
- * An array of items by keys as defined in the "modifierTypes" object in the "modifier/modifier-type.ts" file.
- * Items listed will replace the normal rolls.
- * If less items are listed than rolled, only some items will be replaced
- * If more items are listed than rolled, only the first X items will be shown, where X is the number of items rolled.
- */
-export const ITEM_REWARD_OVERRIDE: Array<String> = [];
+export default {
+  ...defaultOverrides,
+  ...overrides
+} satisfies InstanceType<typeof DefaultOverrides>;

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -50,7 +50,7 @@ import { fetchDailyRunSeed, getDailyRunStarters } from "./data/daily-run";
 import { GameMode, GameModes, getGameMode } from "./game-mode";
 import PokemonSpecies, { getPokemonSpecies, speciesStarters } from "./data/pokemon-species";
 import i18next from "./plugins/i18n";
-import * as Overrides from "./overrides";
+import Overrides from "./overrides";
 import { TextStyle, addTextObject } from "./ui/text";
 import { Type } from "./data/type";
 import { BerryUsedEvent, EncounterPhaseEvent, MoveUsedEvent, TurnEndEvent, TurnInitEvent } from "./events/battle-scene";

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -4,7 +4,7 @@ import Pokemon, { EnemyPokemon, PlayerPokemon } from "../field/pokemon";
 import { pokemonEvolutions, pokemonPrevolutions } from "../data/pokemon-evolutions";
 import PokemonSpecies, { allSpecies, getPokemonSpecies, noStarterFormKeys, speciesStarters } from "../data/pokemon-species";
 import * as Utils from "../utils";
-import * as Overrides from "../overrides";
+import Overrides from "../overrides";
 import PokemonData from "./pokemon-data";
 import PersistentModifierData from "./modifier-data";
 import ArenaData from "./arena-data";

--- a/src/test/abilities/aura_break.test.ts
+++ b/src/test/abilities/aura_break.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import { MoveEffectPhase } from "#app/phases";
 import { Moves } from "#enums/moves";

--- a/src/test/abilities/battery.test.ts
+++ b/src/test/abilities/battery.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import { Moves } from "#enums/moves";
 import { getMovePosition } from "#app/test/utils/gameManagerUtils";

--- a/src/test/abilities/battle_bond.test.ts
+++ b/src/test/abilities/battle_bond.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import GameManager from "#test/utils/gameManager";
 import { getMovePosition } from "#test/utils/gameManagerUtils";
-import * as Overrides from "#app/overrides";
+import Overrides from "#app/overrides";
 import { Moves } from "#enums/moves";
 import { Abilities } from "#enums/abilities";
 import { Species } from "#enums/species";

--- a/src/test/abilities/costar.test.ts
+++ b/src/test/abilities/costar.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import GameManager from "../utils/gameManager";
 import Phaser from "phaser";
-import * as Overrides from "#app/overrides";
+import Overrides from "#app/overrides";
 import { BattleStat } from "#app/data/battle-stat.js";
 import { CommandPhase, MessagePhase } from "#app/phases.js";
 import { getMovePosition } from "../utils/gameManagerUtils";

--- a/src/test/abilities/disguise.test.ts
+++ b/src/test/abilities/disguise.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import GameManager from "#test/utils/gameManager";
 import { getMovePosition } from "#test/utils/gameManagerUtils";
-import * as Overrides from "#app/overrides";
+import Overrides from "#app/overrides";
 import { Moves } from "#enums/moves";
 import { Abilities } from "#enums/abilities";
 import { Species } from "#enums/species";

--- a/src/test/abilities/dry_skin.test.ts
+++ b/src/test/abilities/dry_skin.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { TurnEndPhase } from "#app/phases";
 import { Moves } from "#enums/moves";
 import { getMovePosition } from "#app/test/utils/gameManagerUtils";

--- a/src/test/abilities/ice_face.test.ts
+++ b/src/test/abilities/ice_face.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import {
   MoveEffectPhase,

--- a/src/test/abilities/intimidate.test.ts
+++ b/src/test/abilities/intimidate.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {
   CommandPhase, DamagePhase, EncounterPhase,
   EnemyCommandPhase, SelectStarterPhase,

--- a/src/test/abilities/intrepid_sword.test.ts
+++ b/src/test/abilities/intrepid_sword.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {Abilities} from "#enums/abilities";
 import {Species} from "#enums/species";
 import {

--- a/src/test/abilities/libero.test.ts
+++ b/src/test/abilities/libero.test.ts
@@ -1,7 +1,7 @@
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import GameManager from "../utils/gameManager";
-import * as Overrides from "#app/overrides";
+import Overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";

--- a/src/test/abilities/moxie.test.ts
+++ b/src/test/abilities/moxie.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {
   CommandPhase,
   EnemyCommandPhase,

--- a/src/test/abilities/parental_bond.test.ts
+++ b/src/test/abilities/parental_bond.test.ts
@@ -1,7 +1,7 @@
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import GameManager from "../utils/gameManager";
-import * as Overrides from "#app/overrides";
+import Overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";

--- a/src/test/abilities/power_construct.test.ts
+++ b/src/test/abilities/power_construct.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import GameManager from "#test/utils/gameManager";
 import { getMovePosition } from "#test/utils/gameManagerUtils";
-import * as Overrides from "#app/overrides";
+import Overrides from "#app/overrides";
 import { Moves } from "#enums/moves";
 import { Abilities } from "#enums/abilities";
 import { Species } from "#enums/species";

--- a/src/test/abilities/power_spot.test.ts
+++ b/src/test/abilities/power_spot.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import { Moves } from "#enums/moves";
 import { getMovePosition } from "#app/test/utils/gameManagerUtils";

--- a/src/test/abilities/protean.test.ts
+++ b/src/test/abilities/protean.test.ts
@@ -1,7 +1,7 @@
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import GameManager from "../utils/gameManager";
-import * as Overrides from "#app/overrides";
+import Overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";

--- a/src/test/abilities/quick_draw.test.ts
+++ b/src/test/abilities/quick_draw.test.ts
@@ -1,6 +1,6 @@
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as Overrides from "#app/overrides";
+import Overrides from "#app/overrides";
 import { Abilities } from "#enums/abilities";
 import { Species } from "#enums/species";
 import { FaintPhase } from "#app/phases";

--- a/src/test/abilities/sand_veil.test.ts
+++ b/src/test/abilities/sand_veil.test.ts
@@ -1,7 +1,7 @@
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import GameManager from "../utils/gameManager";
-import * as Overrides from "#app/overrides";
+import Overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";

--- a/src/test/abilities/sap_sipper.test.ts
+++ b/src/test/abilities/sap_sipper.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {
   MoveEndPhase, TurnEndPhase,
 } from "#app/phases";
@@ -139,10 +139,9 @@ describe("Abilities - Sap Sipper", () => {
     expect(game.phaseInterceptor.log).not.toContain("ShowAbilityPhase");
   });
 
-  /*
   // TODO Add METRONOME outcome override
   // To run this testcase, manually modify the METRONOME move to always give SAP_SIPPER, then uncomment
-  it("activate once against multi-hit grass attacks (metronome)", async() => {
+  it.todo("activate once against multi-hit grass attacks (metronome)", async() => {
     const moveToUse = Moves.METRONOME;
     const enemyAbility = Abilities.SAP_SIPPER;
 
@@ -162,5 +161,4 @@ describe("Abilities - Sap Sipper", () => {
     expect(startingOppHp - game.scene.getEnemyParty()[0].hp).toBe(0);
     expect(game.scene.getEnemyParty()[0].summonData.battleStats[BattleStat.ATK]).toBe(1);
   });
-  */
 });

--- a/src/test/abilities/schooling.test.ts
+++ b/src/test/abilities/schooling.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import GameManager from "#test/utils/gameManager";
 import { getMovePosition } from "#test/utils/gameManagerUtils";
-import * as Overrides from "#app/overrides";
+import Overrides from "#app/overrides";
 import { Moves } from "#enums/moves";
 import { Abilities } from "#enums/abilities";
 import { Species } from "#enums/species";

--- a/src/test/abilities/screen_cleaner.test.ts
+++ b/src/test/abilities/screen_cleaner.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import { PostSummonPhase, TurnEndPhase, } from "#app/phases";
 import { Moves } from "#enums/moves";

--- a/src/test/abilities/serene_grace.test.ts
+++ b/src/test/abilities/serene_grace.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {Abilities} from "#enums/abilities";
 import {applyAbAttrs ,MoveEffectChanceMultiplierAbAttr} from "#app/data/ability";
 import {Species} from "#enums/species";

--- a/src/test/abilities/sheer_force.test.ts
+++ b/src/test/abilities/sheer_force.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {Abilities} from "#enums/abilities";
 import {applyAbAttrs ,applyPreAttackAbAttrs,applyPostDefendAbAttrs, MoveEffectChanceMultiplierAbAttr, MovePowerBoostAbAttr, PostDefendTypeChangeAbAttr} from "#app/data/ability";
 import {Species} from "#enums/species";

--- a/src/test/abilities/shield_dust.test.ts
+++ b/src/test/abilities/shield_dust.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Abilities } from "#enums/abilities";
 import {applyAbAttrs ,applyPreDefendAbAttrs,IgnoreMoveEffectsAbAttr,MoveEffectChanceMultiplierAbAttr} from "#app/data/ability";
 import {Species} from "#enums/species";

--- a/src/test/abilities/shields_down.test.ts
+++ b/src/test/abilities/shields_down.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import GameManager from "#test/utils/gameManager";
 import { getMovePosition } from "#test/utils/gameManagerUtils";
-import * as Overrides from "#app/overrides";
+import Overrides from "#app/overrides";
 import { Moves } from "#enums/moves";
 import { Abilities } from "#enums/abilities";
 import { Species } from "#enums/species";

--- a/src/test/abilities/steely_spirit.test.ts
+++ b/src/test/abilities/steely_spirit.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import { Moves } from "#enums/moves";
 import { getMovePosition } from "#app/test/utils/gameManagerUtils";

--- a/src/test/abilities/sturdy.test.ts
+++ b/src/test/abilities/sturdy.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, test, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {
   DamagePhase,
   MoveEndPhase,

--- a/src/test/abilities/unseen_fist.test.ts
+++ b/src/test/abilities/unseen_fist.test.ts
@@ -1,7 +1,7 @@
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import GameManager from "../utils/gameManager";
-import * as Overrides from "#app/overrides";
+import Overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";

--- a/src/test/abilities/volt_absorb.test.ts
+++ b/src/test/abilities/volt_absorb.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {
   TurnEndPhase,
 } from "#app/phases";

--- a/src/test/abilities/wind_power.test.ts
+++ b/src/test/abilities/wind_power.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import {
   TurnEndPhase,

--- a/src/test/abilities/wind_rider.test.ts
+++ b/src/test/abilities/wind_rider.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import {
   TurnEndPhase,

--- a/src/test/abilities/wonder_skin.test.ts
+++ b/src/test/abilities/wonder_skin.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import { TurnEndPhase, } from "#app/phases";
 import { Moves } from "#enums/moves";

--- a/src/test/abilities/zen_mode.test.ts
+++ b/src/test/abilities/zen_mode.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as Overrides from "#app/overrides";
+import Overrides from "#app/overrides";
 import {
   CommandPhase,
   DamagePhase,

--- a/src/test/abilities/zero_to_hero.test.ts
+++ b/src/test/abilities/zero_to_hero.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import GameManager from "#test/utils/gameManager";
 import { getMovePosition } from "#test/utils/gameManagerUtils";
-import * as Overrides from "#app/overrides";
+import Overrides from "#app/overrides";
 import { Moves } from "#enums/moves";
 import { Abilities } from "#enums/abilities";
 import { Species } from "#enums/species";

--- a/src/test/achievements/achievement.test.ts
+++ b/src/test/achievements/achievement.test.ts
@@ -5,7 +5,7 @@ import { IntegerHolder, NumberHolder } from "#app/utils.js";
 import { TurnHeldItemTransferModifier } from "#app/modifier/modifier.js";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 
 describe("check some Achievement related stuff", () => {
   it ("should check Achievement creation", () => {

--- a/src/test/arena/weather_strong_winds.test.ts
+++ b/src/test/arena/weather_strong_winds.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import {
   TurnStartPhase,

--- a/src/test/battle/battle-order.test.ts
+++ b/src/test/battle/battle-order.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {
   CommandPhase, EnemyCommandPhase, SelectTargetPhase,
   TurnStartPhase

--- a/src/test/battle/battle.test.ts
+++ b/src/test/battle/battle.test.ts
@@ -2,7 +2,7 @@ import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest
 import {generateStarter, getMovePosition,} from "#app/test/utils/gameManagerUtils";
 import {Mode} from "#app/ui/ui";
 import {GameModes} from "#app/game-mode";
-import * as overrides from "../../overrides";
+import overrides from "../../overrides";
 import {Command} from "#app/ui/command-ui-handler";
 import {
   CommandPhase, DamagePhase,

--- a/src/test/battle/error-handling.test.ts
+++ b/src/test/battle/error-handling.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import GameManager from "#app/test/utils/gameManager";
 import Phaser from "phaser";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";

--- a/src/test/battle/special_battle.test.ts
+++ b/src/test/battle/special_battle.test.ts
@@ -1,6 +1,6 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import {Mode} from "#app/ui/ui";
-import * as overrides from "../../overrides";
+import overrides from "../../overrides";
 import {
   CommandPhase,
 } from "#app/phases";

--- a/src/test/items/eviolite.test.ts
+++ b/src/test/items/eviolite.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phase from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Stat } from "#app/data/pokemon-stat";
 import { EvolutionStatBoosterModifier } from "#app/modifier/modifier";
 import { modifierTypes } from "#app/modifier/modifier-type";

--- a/src/test/items/grip_claw.test.ts
+++ b/src/test/items/grip_claw.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phase from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Moves } from "#app/enums/moves.js";
 import { Species } from "#app/enums/species.js";
 import { BerryType } from "#app/enums/berry-type.js";

--- a/src/test/items/light_ball.test.ts
+++ b/src/test/items/light_ball.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phase from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import { Stat } from "#app/data/pokemon-stat";
 import { SpeciesStatBoosterModifier } from "#app/modifier/modifier";

--- a/src/test/items/metal_powder.test.ts
+++ b/src/test/items/metal_powder.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phase from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import { Stat } from "#app/data/pokemon-stat";
 import { SpeciesStatBoosterModifier } from "#app/modifier/modifier";

--- a/src/test/items/quick_powder.test.ts
+++ b/src/test/items/quick_powder.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phase from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import { Stat } from "#app/data/pokemon-stat";
 import { SpeciesStatBoosterModifier } from "#app/modifier/modifier";

--- a/src/test/items/thick_club.test.ts
+++ b/src/test/items/thick_club.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phase from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import { Stat } from "#app/data/pokemon-stat";
 import { SpeciesStatBoosterModifier } from "#app/modifier/modifier";

--- a/src/test/items/toxic_orb.test.ts
+++ b/src/test/items/toxic_orb.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {
   CommandPhase,
   EnemyCommandPhase,

--- a/src/test/localization/terrain.test.ts
+++ b/src/test/localization/terrain.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, beforeEach, afterEach, expect, it, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import { TerrainType, getTerrainName } from "#app/data/terrain";
 import { getTerrainStartMessage, getTerrainClearMessage, getTerrainBlockMessage } from "#app/data/weather";

--- a/src/test/moves/astonish.test.ts
+++ b/src/test/moves/astonish.test.ts
@@ -1,7 +1,7 @@
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import GameManager from "../utils/gameManager";
-import * as Overrides from "#app/overrides";
+import Overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";

--- a/src/test/moves/aurora_veil.test.ts
+++ b/src/test/moves/aurora_veil.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {
   TurnEndPhase,
 } from "#app/phases";

--- a/src/test/moves/ceaseless_edge.test.ts
+++ b/src/test/moves/ceaseless_edge.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, test, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {
   MoveEffectPhase,
   TurnEndPhase

--- a/src/test/moves/dynamax_cannon.test.ts
+++ b/src/test/moves/dynamax_cannon.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { MoveEffectPhase } from "#app/phases";
 import { getMovePosition } from "#app/test/utils/gameManagerUtils";
 import { Stat } from "#app/data/pokemon-stat";

--- a/src/test/moves/flower_shield.test.ts
+++ b/src/test/moves/flower_shield.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import {
   TurnEndPhase,

--- a/src/test/moves/follow_me.test.ts
+++ b/src/test/moves/follow_me.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, test, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {
   CommandPhase,
   SelectTargetPhase,

--- a/src/test/moves/gastro_acid.test.ts
+++ b/src/test/moves/gastro_acid.test.ts
@@ -3,7 +3,7 @@ import GameManager from "../utils/gameManager";
 import {
   Moves
 } from "#app/enums/moves.js";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Abilities } from "#app/enums/abilities.js";
 import { BattlerIndex } from "#app/battle.js";
 import { getMovePosition } from "../utils/gameManagerUtils";

--- a/src/test/moves/growth.test.ts
+++ b/src/test/moves/growth.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {
   CommandPhase,
   EnemyCommandPhase,

--- a/src/test/moves/hard_press.test.ts
+++ b/src/test/moves/hard_press.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import {
   MoveEffectPhase,

--- a/src/test/moves/light_screen.test.ts
+++ b/src/test/moves/light_screen.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {
   TurnEndPhase,
 } from "#app/phases";

--- a/src/test/moves/magnet_rise.test.ts
+++ b/src/test/moves/magnet_rise.test.ts
@@ -1,7 +1,7 @@
 import {beforeAll, afterEach, beforeEach, describe, vi, it, expect} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {Moves} from "#enums/moves";
 import {Species} from "#enums/species";
 import {CommandPhase, TurnEndPhase} from "#app/phases.js";

--- a/src/test/moves/make_it_rain.test.ts
+++ b/src/test/moves/make_it_rain.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import {
   CommandPhase,

--- a/src/test/moves/purify.test.ts
+++ b/src/test/moves/purify.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, test, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {
   MoveEndPhase,
 } from "#app/phases";

--- a/src/test/moves/rage_powder.test.ts
+++ b/src/test/moves/rage_powder.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, test, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {
   CommandPhase,
   SelectTargetPhase,

--- a/src/test/moves/reflect.test.ts
+++ b/src/test/moves/reflect.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {
   TurnEndPhase,
 } from "#app/phases";

--- a/src/test/moves/roost.test.ts
+++ b/src/test/moves/roost.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, test, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#app/enums/species.js";
 import { Moves } from "#app/enums/moves.js";
 import { getMovePosition } from "../utils/gameManagerUtils";

--- a/src/test/moves/spikes.test.ts
+++ b/src/test/moves/spikes.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {
   CommandPhase
 } from "#app/phases";

--- a/src/test/moves/spotlight.test.ts
+++ b/src/test/moves/spotlight.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, test, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {
   CommandPhase,
   SelectTargetPhase,

--- a/src/test/moves/tackle.test.ts
+++ b/src/test/moves/tackle.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {
   CommandPhase,
   EnemyCommandPhase, TurnEndPhase,

--- a/src/test/moves/tail_whip.test.ts
+++ b/src/test/moves/tail_whip.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {
   CommandPhase,
   EnemyCommandPhase,

--- a/src/test/moves/tailwind.test.ts
+++ b/src/test/moves/tailwind.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { Species } from "#enums/species";
 import {
   TurnEndPhase,

--- a/src/test/moves/thousand_arrows.test.ts
+++ b/src/test/moves/thousand_arrows.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, test, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {
   MoveEffectPhase,
   TurnEndPhase

--- a/src/test/moves/tidy_up.test.ts
+++ b/src/test/moves/tidy_up.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { MoveEndPhase, TurnEndPhase } from "#app/phases";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";

--- a/src/test/pre.test.ts
+++ b/src/test/pre.test.ts
@@ -1,61 +1,6 @@
-import { StatusEffect } from "#app/data/status-effect";
-import * as _Overrides from "#app/overrides";
-import { Abilities } from "#enums/abilities";
-import { Biome } from "#enums/biome";
-import { WeatherType } from "#enums/weather-type";
+import Overrides, { defaultOverrides } from "#app/overrides";
 import { expect, test } from "vitest";
 
 test("Overrides are default values", () => {
-  const defaultOverrides = {
-    SEED_OVERRIDE: "",
-    WEATHER_OVERRIDE: WeatherType.NONE,
-    DOUBLE_BATTLE_OVERRIDE: false,
-    SINGLE_BATTLE_OVERRIDE: false,
-    STARTING_WAVE_OVERRIDE: 0,
-    STARTING_BIOME_OVERRIDE: Biome.TOWN,
-    ARENA_TINT_OVERRIDE: null,
-    XP_MULTIPLIER_OVERRIDE: null,
-    STARTING_MONEY_OVERRIDE: 0,
-    FREE_CANDY_UPGRADE_OVERRIDE: false,
-    POKEBALL_OVERRIDE: _Overrides.POKEBALL_OVERRIDE, // Pass through pokeballs
-    // Player
-    STARTER_FORM_OVERRIDES: {},
-    STARTING_LEVEL_OVERRIDE: 0,
-    STARTER_SPECIES_OVERRIDE: 0,
-    ABILITY_OVERRIDE: Abilities.NONE,
-    PASSIVE_ABILITY_OVERRIDE: Abilities.NONE,
-    STATUS_OVERRIDE: StatusEffect.NONE,
-    GENDER_OVERRIDE: null,
-    MOVESET_OVERRIDE: [],
-    SHINY_OVERRIDE: false,
-    VARIANT_OVERRIDE: 0,
-    // Opponent
-    OPP_SPECIES_OVERRIDE: 0,
-    OPP_LEVEL_OVERRIDE: 0,
-    OPP_ABILITY_OVERRIDE: Abilities.NONE,
-    OPP_PASSIVE_ABILITY_OVERRIDE: Abilities.NONE,
-    OPP_STATUS_OVERRIDE: StatusEffect.NONE,
-    OPP_GENDER_OVERRIDE: null,
-    OPP_MOVESET_OVERRIDE: [],
-    OPP_SHINY_OVERRIDE: false,
-    OPP_VARIANT_OVERRIDE: 0,
-    OPP_IVS_OVERRIDE: [],
-    // Eggs
-    EGG_IMMEDIATE_HATCH_OVERRIDE: false,
-    EGG_TIER_OVERRIDE: null,
-    EGG_SHINY_OVERRIDE: false,
-    EGG_VARIANT_OVERRIDE: null,
-    EGG_FREE_GACHA_PULLS_OVERRIDE: false,
-    EGG_GACHA_PULL_COUNT_OVERRIDE: 0,
-    // Items
-    STARTING_MODIFIER_OVERRIDE: [],
-    OPP_MODIFIER_OVERRIDE: [],
-    STARTING_HELD_ITEMS_OVERRIDE: [],
-    OPP_HELD_ITEMS_OVERRIDE: [],
-    NEVER_CRIT_OVERRIDE: false,
-    ITEM_REWARD_OVERRIDE: [],
-  } satisfies typeof _Overrides;
-
-  const Overrides = Object.assign({}, _Overrides);
   expect(Overrides).toEqual(defaultOverrides);
 });

--- a/src/test/ui/transfer-item.test.ts
+++ b/src/test/ui/transfer-item.test.ts
@@ -2,7 +2,7 @@ import { BerryType } from "#app/enums/berry-type";
 import { Moves } from "#app/enums/moves";
 import { Species } from "#app/enums/species";
 import { Button } from "#app/enums/buttons";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import {
   BattleEndPhase,
   SelectModifierPhase

--- a/src/test/vitest.setup.ts
+++ b/src/test/vitest.setup.ts
@@ -15,6 +15,7 @@ import { initStatsKeys } from "#app/ui/game-stats-ui-handler";
 
 import { beforeAll, vi } from "vitest";
 
+/** Mock the override import to always return default values, ignoring any custom overrides. */
 vi.mock("#app/overrides", async (importOriginal) => {
   const { defaultOverrides } = await importOriginal<typeof import("#app/overrides")>();
 

--- a/src/test/vitest.setup.ts
+++ b/src/test/vitest.setup.ts
@@ -13,7 +13,16 @@ import { initAchievements } from "#app/system/achv.js";
 import { initVouchers } from "#app/system/voucher.js";
 import { initStatsKeys } from "#app/ui/game-stats-ui-handler";
 
-import { beforeAll } from "vitest";
+import { beforeAll, vi } from "vitest";
+
+vi.mock("#app/overrides", async (importOriginal) => {
+  const { defaultOverrides } = await importOriginal<typeof import("#app/overrides")>();
+
+  return {
+    default: defaultOverrides,
+    defaultOverrides
+  } satisfies typeof import("#app/overrides");
+});
 
 initVouchers();
 initAchievements();

--- a/src/ui/egg-gacha-ui-handler.ts
+++ b/src/ui/egg-gacha-ui-handler.ts
@@ -9,7 +9,7 @@ import { getPokemonSpecies } from "../data/pokemon-species";
 import { addWindow } from "./ui-theme";
 import { Tutorial, handleTutorial } from "../tutorial";
 import {Button} from "#enums/buttons";
-import * as Overrides from "../overrides";
+import Overrides from "../overrides";
 import { GachaType } from "#app/enums/gacha-types";
 import i18next from "i18next";
 import { EggTier } from "#enums/egg-type";

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -28,7 +28,7 @@ import { TextStyle, addBBCodeTextObject, addTextObject } from "./text";
 import { Mode } from "./ui";
 import { addWindow } from "./ui-theme";
 import { Egg } from "#app/data/egg";
-import * as Overrides from "../overrides";
+import Overrides from "../overrides";
 import {SettingKeyboard} from "#app/system/settings/settings-keyboard";
 import {Passive as PassiveAttr} from "#enums/passive";
 import * as Challenge from "../data/challenge";


### PR DESCRIPTION
## What are the changes?
Separate Default Overrides from custom ones used for testing.

## Why am I doing these changes?
As per our discussion regarding how annoying it would be to maintain the default override values inside pre.tests.ts

## What did change?
Separate Default Overrides from custom ones used for testing.
Move Default Overrides into overrides.ts
Check if default export of overrides.ts is deeply equal to the defaults.
Add better type annotation for the modifier overrides

### Screenshots/Videos
N/A

## How to test the changes?
`tsc --noEmit --project tsconfig.json`
`npm run test:silent`
`npm rum docs`

## Checklist
- [x] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
~~- [ ] Are the changes visual?~~
  ~~- [ ] Have I provided screenshots/videos of the changes?~~