### PR TITLE
[Bug] Fixes bug with Lock-On and Zap Cannon where Zap Cannon misses if Lock-On is the first move on entering battle.

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -3058,7 +3058,7 @@ export class MoveEffectPhase extends PokemonPhase {
     }
 
     // If the user should ignore accuracy on a target, check who the user targeted last turn and see if they match
-    if (user.getTag(BattlerTagType.IGNORE_ACCURACY) && (user.getLastXMoves().slice(1).find(() => true)?.targets || []).indexOf(target.getBattlerIndex()) !== -1) {
+    if (user.getTag(BattlerTagType.IGNORE_ACCURACY) && (user.getLastXMoves().find(() => true)?.targets || []).indexOf(target.getBattlerIndex()) !== -1) {
       return true;
     }
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Fixes bug with Lock-On and Zap Cannon where Zap Cannon misses if Lock-On is the first move on entering battle.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Lock-On should guarantee a hit regardless of when it is used. 

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Removed the ```.slice(1)``` call on ```getLastXMoves()``` so that the condition no longer skips over the first turn made.
```getLastXMoves().find(() => true)``` gets the most recent move used in the pokemon's move history.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
Before fix

https://github.com/user-attachments/assets/61604fa9-aa54-432a-a6ae-31e14b66b72e

After fix

https://github.com/user-attachments/assets/ac76a790-4e9e-44a6-9f81-2ae97fea80d9

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Give your mon Lock-On and Zap Cannon. Go to wave 5 and use Lock-On followed by Zap Cannon. See the result.
Be sure to test multiple times. Lock On should never fail with Zap Cannon. 

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?