### PR TITLE
[Fix] BGM Bar display error when the 1st track of the game takes too long to arrive

### DIFF
--- a/src/ui/bgm-bar.ts
+++ b/src/ui/bgm-bar.ts
@@ -62,6 +62,16 @@ export default class BgmBar extends Phaser.GameObjects.Container {
     @param {boolean} visible Whether to show or hide the BGM bar.
    */
   public toggleBgmBar(visible: boolean): void {
+    /*
+      Prevents the bar from being displayed if musicText is completely empty.
+      This can be the case, for example, when the game's 1st music track takes a long time to reach the client,
+      and the menu is opened before it is played.
+    */
+    if (this.musicText.text === "") {
+      this.setVisible(false);
+      return;
+    }
+
     if (!(this.scene as BattleScene).showBgmBar) {
       this.setVisible(false);
       return;


### PR DESCRIPTION
## What are the changes?
Prevents the bar from being displayed if `musicText` is completely empty.
This can be the case, for example, when the game's 1st music track takes a long time to reach the client, and the menu is opened before it is played.

## Why am I doing these changes?
Because for the few people with a slow connection, it displays a big ugly rectangle in the menu as long as the music hasn't triggered the `setBgmToBgmBar` method when it starts playing.

## What did change?
Add condition to block display as long as `musicText` is empty

### Screenshots/Videos
> Before (Current Bêta)

https://github.com/user-attachments/assets/2a08c7d2-f44d-4c2c-a06f-f12062816432

> After

https://github.com/user-attachments/assets/4c467c4b-6d92-432e-a979-9cbf3f896c49

## How to test the changes?
Simply use the browser's "request blocking" mode to block music from the title screen and try to open the menu in this condition after page refresh.
![image](https://github.com/user-attachments/assets/b7dc7381-67d1-445b-a19d-4f208695a7c9)
**⚠️ WARNING:** The request blocking mode prevents the game from working properly once it has blocked a track (probably the Phaser load doesn't like it too much). The game can no longer load other music, and so ends up freezing relentlessly on the battle scene.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?