### PR TITLE
[Hotfix] Change Korean line-break position of ghost type curse add message

### DIFF
--- a/src/locales/ko/battle.ts
+++ b/src/locales/ko/battle.ts
@@ -133,6 +133,6 @@ export const battle: SimpleTranslationEntries = {
   "battlerTagsCritBoostOnRemove": "{{pokemonNameWithAffix}}[[는]] 평소로 돌아왔다.",
   "battlerTagsSaltCuredOnAdd": "{{pokemonNameWithAffix}}[[는]]\n소금에 절여졌다!",
   "battlerTagsSaltCuredLapse": "{{pokemonNameWithAffix}}[[는]] 소금절이의\n데미지를 입고 있다.",
-  "battlerTagsCursedOnAdd": "{{pokemonNameWithAffix}}[[는]]\n자신의 체력을 깎아서\n{{pokemonName}}에게 저주를 걸었다!",
+  "battlerTagsCursedOnAdd": "{{pokemonNameWithAffix}}[[는]] 자신의 체력을 깎아서\n{{pokemonName}}에게 저주를 걸었다!",
   "battlerTagsCursedLapse": "{{pokemonNameWithAffix}}[[는]]\n저주받고 있다!",
 } as const;


### PR DESCRIPTION
## What are the changes?
Change line-break position of ghost type curse add message.

## Why am I doing these changes?
Original message was 3 lines but pokerogue provides 2 lines normally.

## What did change?
Just replaced one \n to space.
```
"{{pokemonNameWithAffix}}[[는]]\n자신의 체력을 깎아서\n{{pokemonName}}에게 저주를 걸었다!" // as-is
"{{pokemonNameWithAffix}}[[는]] 자신의 체력을 깎아서\n{{pokemonName}}에게 저주를 걸었다!" // to-be
```

### Screenshots/Videos
![image](https://github.com/user-attachments/assets/b1dfdbd1-df2f-4938-856b-61b3ecd6149d)

## How to test the changes?
Manually (Using overrides.ts)
```Typescript
export const STARTER_SPECIES_OVERRIDE: Species | integer = Species.GENGAR;
export const MOVESET_OVERRIDE: Array<Moves> = [ Moves.CURSE ];
```
Then use CURSE.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?