### PR TITLE
[Bug] Fix import of overrides in Octolock test

### DIFF
--- a/src/test/moves/octolock.test.ts
+++ b/src/test/moves/octolock.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
-import * as overrides from "#app/overrides";
+import overrides from "#app/overrides";
 import { CommandPhase, MoveEndPhase, TurnInitPhase } from "#app/phases";
 import {getMovePosition} from "#app/test/utils/gameManagerUtils";
 import {BattleStat} from "#app/data/battle-stat";


### PR DESCRIPTION
## What are the changes?
Octolock tests did not have the override import changes implemented in #2999, and are currently broken in beta.

This PR just updates the import.

## Why am I doing these changes?
To fix the tests.

## What did change?
`import * as overrides` (old way) -> `import overrides` (new way)

### Screenshots/Videos

## How to test the changes?
`npm test`

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?