### PR TITLE
[Bug] Fix item reward overrides going out of bounds

### DIFF
--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1878,13 +1878,13 @@ export function getPlayerModifierTypeOptions(count: integer, party: PlayerPokemo
     }
     options.push(candidate);
   });
+
   // OVERRIDE IF NECESSARY
-  if (Overrides.ITEM_REWARD_OVERRIDE?.length) {
-    options.forEach((mod, i) => {
-      const override = modifierTypes[Overrides.ITEM_REWARD_OVERRIDE[i]]();
-      mod.type = (override instanceof ModifierTypeGenerator ? override.generateType(party) : override) || mod.type;
-    });
-  }
+  Overrides.ITEM_REWARD_OVERRIDE.forEach((item, i) => {
+    const override = modifierTypes[item]();
+    options[i].type = override instanceof ModifierTypeGenerator ? override.generateType(party) : override;
+  });
+
   return options;
 }
 


### PR DESCRIPTION
## What are the changes?
Fix item reward overrides going out of bounds

## Why am I doing these changes?
Previous change to override created this error

## What did change?
Iterate over item reward override directly for replacement instead of generated item options

### Screenshots/Videos
N/A

## How to test the changes?
Get to the item reward screen with an override defined
```ts
const overrides = {
  ITEM_REWARD_OVERRIDE: ["RARER_CANDY"]
}
```

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
~~- [] Are the changes visual?~~
  ~~- [ ] Have I provided screenshots/videos of the changes?~~