### PR TITLE
[Bug] Fix Text for Future Sight and Doom Desire

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2309,7 +2309,9 @@ export class DelayedAttackAttr extends OverrideMoveEffectAttr {
       if (args.length < 2 || !args[1]) {
         new MoveChargeAnim(this.chargeAnim, move.id, user).play(user.scene, () => {
           (args[0] as Utils.BooleanHolder).value = true;
-          user.scene.queueMessage(getPokemonMessage(user, ` ${this.chargeText.replace("{TARGET}", target.name)}`));
+          this.chargeText = this.chargeText.replace("{USER}", getPokemonNameWithAffix(user));
+          this.chargeText = this.chargeText.replace("{TARGET}", getPokemonNameWithAffix(target));
+          user.scene.queueMessage(this.chargeText);
           user.pushMoveHistory({ move: move.id, targets: [ target.getBattlerIndex() ], result: MoveResult.OTHER });
           user.scene.arena.addTag(this.tagType, 3, move.id, user.id, ArenaTagSide.BOTH, false, target.getBattlerIndex());
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
It now correctly uses pokemonNameWithAffix and also doesnt show {{user}} randomly in the middle

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
It was a bug introduced in https://github.com/pagefaultgames/pokerogue/pull/2913 so i went through all changed moves there and found those two were wrong

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Changed the attribute they were using to replace the placeholder correctly and also dont use "getPokemonMessage" anymore which we want to phase out anyways

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
Before:

https://github.com/user-attachments/assets/620eb4fe-5768-4ca2-877c-fbdefd8958df


After:

https://github.com/user-attachments/assets/0d0c48e7-b86d-4510-998c-b99daebb3f52



## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Override your pokemon to have those two moves and use them

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?