### PR TITLE
[Bug] Fix and replacement for getSheerForceHitDisableAbCondition() loop

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -4282,10 +4282,7 @@ export class AddArenaTrapTagAttr extends AddArenaTagAttr {
     return (user, target, move) => {
       const side = (this.selfSideTarget ? user : target).isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY;
       const tag = user.scene.arena.getTagOnSide(this.tagType, side) as ArenaTrapTag;
-      if (!tag) {
-        return true;
-      }
-      return tag.layers < tag.maxLayers;
+      return !tag || (tag.layers < tag.maxLayers);
     };
   }
 }
@@ -4293,6 +4290,9 @@ export class AddArenaTrapTagAttr extends AddArenaTagAttr {
 /**
  * Attribute used for Stone Axe and Ceaseless Edge.
  * Applies the given ArenaTrapTag when move is used.
+ * This was created because of a niche interaction with Sheer Force and Shield Dust,
+ * applying AddArenaTrapTagAttr normally with the moveChance check will cause
+ * these moves to fail.
  * @extends AddArenaTagAttr
  * @see {@linkcode apply}
  */
@@ -4308,10 +4308,7 @@ export class AddArenaTrapTagHitAttr extends AddArenaTagAttr {
     const tag = user.scene.arena.getTagOnSide(this.tagType, side) as ArenaTrapTag;
     if ((moveChance < 0 || moveChance === 100 || user.randSeedInt(100) < moveChance)) {
       user.scene.arena.addTag(this.tagType, 0, move.id, user.id, side);
-      if (!tag) {
-        return true;
-      }
-      return tag.layers < tag.maxLayers;
+      return !tag || (tag.layers < tag.maxLayers);
     }
     return false;
   }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -23,7 +23,7 @@ import { BattlerTag, BattlerTagLapseType, EncoreTag, GroundedTag, HelpingHandTag
 import { WeatherType } from "../data/weather";
 import { TempBattleStat } from "../data/temp-battle-stat";
 import { ArenaTagSide, WeakenMoveScreenTag, WeakenMoveTypeTag } from "../data/arena-tag";
-import { Ability, AbAttr, BattleStatMultiplierAbAttr, BlockCritAbAttr, BonusCritAbAttr, BypassBurnDamageReductionAbAttr, FieldPriorityMoveImmunityAbAttr, IgnoreOpponentStatChangesAbAttr, MoveImmunityAbAttr, MoveTypeChangeAttr, PreApplyBattlerTagAbAttr, PreDefendFullHpEndureAbAttr, ReceivedMoveDamageMultiplierAbAttr, ReduceStatusEffectDurationAbAttr, StabBoostAbAttr, StatusEffectImmunityAbAttr, TypeImmunityAbAttr, VariableMovePowerAbAttr, WeightMultiplierAbAttr, allAbilities, applyAbAttrs, applyBattleStatMultiplierAbAttrs, applyPreApplyBattlerTagAbAttrs, applyPreAttackAbAttrs, applyPreDefendAbAttrs, applyPreSetStatusAbAttrs, UnsuppressableAbilityAbAttr, SuppressFieldAbilitiesAbAttr, NoFusionAbilityAbAttr, MultCritAbAttr, IgnoreTypeImmunityAbAttr, DamageBoostAbAttr, IgnoreTypeStatusEffectImmunityAbAttr, ConditionalCritAbAttr, applyFieldBattleStatMultiplierAbAttrs, FieldMultiplyBattleStatAbAttr, AllyMoveCategoryPowerBoostAbAttr, FieldMoveTypePowerBoostAbAttr, AddSecondStrikeAbAttr, UserFieldMoveTypePowerBoostAbAttr } from "../data/ability";
+import { Ability, AbAttr, BattleStatMultiplierAbAttr, BlockCritAbAttr, BonusCritAbAttr, BypassBurnDamageReductionAbAttr, FieldPriorityMoveImmunityAbAttr, IgnoreOpponentStatChangesAbAttr, MoveImmunityAbAttr, MoveTypeChangeAttr, PreApplyBattlerTagAbAttr, PreDefendFullHpEndureAbAttr, ReceivedMoveDamageMultiplierAbAttr, ReduceStatusEffectDurationAbAttr, StabBoostAbAttr, StatusEffectImmunityAbAttr, TypeImmunityAbAttr, VariableMovePowerAbAttr, WeightMultiplierAbAttr, allAbilities, applyAbAttrs, applyBattleStatMultiplierAbAttrs, applyPreApplyBattlerTagAbAttrs, applyPreAttackAbAttrs, applyPreDefendAbAttrs, applyPreSetStatusAbAttrs, UnsuppressableAbilityAbAttr, SuppressFieldAbilitiesAbAttr, NoFusionAbilityAbAttr, MultCritAbAttr, IgnoreTypeImmunityAbAttr, DamageBoostAbAttr, IgnoreTypeStatusEffectImmunityAbAttr, ConditionalCritAbAttr, applyFieldBattleStatMultiplierAbAttrs, FieldMultiplyBattleStatAbAttr, AllyMoveCategoryPowerBoostAbAttr, FieldMoveTypePowerBoostAbAttr, AddSecondStrikeAbAttr, UserFieldMoveTypePowerBoostAbAttr, SheerForceHitDisableAbAttr } from "../data/ability";
 import PokemonData from "../system/pokemon-data";
 import { BattlerIndex } from "../battle";
 import { Mode } from "../ui/ui";
@@ -1744,6 +1744,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
     const typeChangeMovePowerMultiplier = new Utils.NumberHolder(1);
     applyMoveAttrs(VariableMoveTypeAttr, source, this, move);
+    applyPreAttackAbAttrs(SheerForceHitDisableAbAttr, source, this, move);
     applyPreAttackAbAttrs(MoveTypeChangeAttr, source, this, move, typeChangeMovePowerMultiplier);
     const types = this.getTypes(true, true);
 


### PR DESCRIPTION
## What are the changes?
SheerForceHitDisabled for abilities that can get disabled by Sheer Force.
SheerForceHitDisableAbAttr for Sheer Force to check the opponent's ability.
A few format and info changes also were made to a previous Sheer Force related commit.

## Why am I doing these changes?
Both implemented to fix an infinite loop between abilities with the old getSheerForceHitDisableAbCondition() condition.
Abilities tried to check for Sheer Force between each other, causing the loop.
Affected abilities: Color Change, Pickpocket, Wimp Out, Emergency Exit, Berserk, Anger Shell.

## What did change?
Instead of using a condition, this Sheer Force edge case now uses attributes.

## Important Note 
**This implementation still has one main issue**, since it depends on the ability suppressed status, Sheer Force can cause previous suppressed from other sources to be altered (ability enabled) but this is only against the affected abilities. 

- This PR was requested by @demi.glace.sauce. 