### PR TITLE
[Re][Hotfix] Change Korean line-break position of ghost type curse add message

### DIFF
--- a/src/locales/ko/battle.ts
+++ b/src/locales/ko/battle.ts
@@ -133,6 +133,6 @@ export const battle: SimpleTranslationEntries = {
   "battlerTagsCritBoostOnRemove": "{{pokemonNameWithAffix}}[[는]] 평소로 돌아왔다.",
   "battlerTagsSaltCuredOnAdd": "{{pokemonNameWithAffix}}[[는]]\n소금에 절여졌다!",
   "battlerTagsSaltCuredLapse": "{{pokemonNameWithAffix}}[[는]] 소금절이의\n데미지를 입고 있다.",
-  "battlerTagsCursedOnAdd": "{{pokemonNameWithAffix}}[[는]]\n자신의 체력을 깎아서\n{{pokemonName}}에게 저주를 걸었다!",
+  "battlerTagsCursedOnAdd": "{{pokemonNameWithAffix}}[[는]] 자신의 체력을 깎아서\n{{pokemonName}}에게 저주를 걸었다!",
   "battlerTagsCursedLapse": "{{pokemonNameWithAffix}}[[는]]\n저주받고 있다!",
 } as const;


### PR DESCRIPTION
Mirror #3008 but target changed.

@Tempo-anon 