### PR TITLE
[Localization][FR] Fix typo ability-trigger.ts

### DIFF
--- a/src/locales/fr/ability-trigger.ts
+++ b/src/locales/fr/ability-trigger.ts
@@ -9,7 +9,7 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "poisonHeal": "{{abilityName}} de {{pokemonName}}\nrestaure un peu ses PV !",
   "trace": "{{pokemonName}} copie le talent {{abilityName}}\nde {{targetName}} !",
   "windPowerCharged": "{{pokemonName}} a été touché par la capacité {{moveName}} et se charge en électricité !",
-  "quickDraw": "Tif Vif permet à {{pokemonName}}\nd’agir plus vite que d’habitude !",
+  "quickDraw": "Tir Vif permet à {{pokemonName}}\nd’agir plus vite que d’habitude !",
   "blockItemTheft": "{{abilityName}} de {{pokemonNameWithAffix}}\nempêche son objet d’être volé !",
   "typeImmunityHeal": "{{abilityName}} de {{pokemonNameWithAffix}}\nrestaure un peu ses PV !",
   "nonSuperEffectiveImmunity": "{{pokemonNameWithAffix}} évite\nles dégâts avec {{abilityName}} !",


### PR DESCRIPTION
## What are the changes?
Correct a typo

## What did change?
I've corrected “Tif Vif” to “Tir Vif”

### Screenshots/Videos
> Before
![image](https://github.com/user-attachments/assets/a7430c87-7589-4589-bc99-9468487af504)

> After
![image](https://github.com/user-attachments/assets/2eb1670c-04f3-48c1-8e63-aac81e2c08ca)

> Source
`ability.ts`
![image](https://github.com/user-attachments/assets/bd4dab6b-d6a5-4dd3-a3bc-d75808d35d08)
`Poképédia`: [Tir Vif](https://www.pokepedia.fr/Tir_Vif)
![image](https://github.com/user-attachments/assets/8cff1758-8182-4e11-8d4d-27f6497ba22c)

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?