### PR TITLE
[Misc] Allow Necrozma forms to play their special music

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -294,8 +294,19 @@ export default class Battle {
           if (pokemon.species.speciesId === Species.TAPU_KOKO || pokemon.species.speciesId === Species.TAPU_LELE || pokemon.species.speciesId === Species.TAPU_BULU || pokemon.species.speciesId === Species.TAPU_FINI) {
             return "battle_legendary_tapu";
           }
-          if (pokemon.species.speciesId === Species.COSMOG || pokemon.species.speciesId === Species.COSMOEM || pokemon.species.speciesId === Species.SOLGALEO || pokemon.species.speciesId === Species.LUNALA || pokemon.species.speciesId === Species.NECROZMA) {
+          if (pokemon.species.speciesId === Species.COSMOG || pokemon.species.speciesId === Species.COSMOEM || pokemon.species.speciesId === Species.SOLGALEO || pokemon.species.speciesId === Species.LUNALA) {
             return "battle_legendary_sol_lun";
+          }
+          if (pokemon.species.speciesId === Species.NECROZMA) {
+            if (pokemon.getFormKey() === "") {
+              return "battle_legendary_sol_lun";
+            }
+            if (pokemon.getFormKey() === "dusk-mane" || pokemon.getFormKey() === "dawn-wings") {
+              return "battle_legendary_dusk_dawn";
+            }
+            if (pokemon.getFormKey() === "ultra") {
+              return "battle_legendary_ultra_nec";
+            }
           }
           if (pokemon.species.speciesId === Species.NIHILEGO || pokemon.species.speciesId === Species.BUZZWOLE || pokemon.species.speciesId === Species.PHEROMOSA || pokemon.species.speciesId === Species.XURKITREE || pokemon.species.speciesId === Species.CELESTEELA || pokemon.species.speciesId === Species.KARTANA || pokemon.species.speciesId === Species.GUZZLORD || pokemon.species.speciesId === Species.POIPOLE || pokemon.species.speciesId === Species.NAGANADEL || pokemon.species.speciesId === Species.STAKATAKA || pokemon.species.speciesId === Species.BLACEPHALON) {
             return "battle_legendary_ub";


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Necrozma's unique battle music can now play for the Dusk Mane, Dawn Wings, and Ultra forms (These forms still cannot be found in the wild normally, but these will play if forced into an encounter).

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
I previously added their music for some future use, such as if someone wanted to use them as unique boss fights. Since they now play their unique battle themes naturally with this change, it makes the music "used" now.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Necrozma no longer just plays the Solgaleo & Lunala battle theme no matter what. It plays that theme in its base form, plays the Dusk Mane & Dawn Wings theme in those respective forms, and plays the Ultra Necrozma theme in that form.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

https://github.com/user-attachments/assets/85cfbb9b-b6b4-4f35-9249-8633a740e537

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
There isn't a way to force the form index of an opponent at present, so the easiest way to test would be to temporarily add Necrozma to the `getSpeciesFormIndex` in `battle-scene.ts` and encounter the forms randomly to see the music changes.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
  - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?