### PR TITLE
[Optimization] Minify json files in build directory

### DIFF
--- a/src/plugins/vite/vite-minify-json-plugin.ts
+++ b/src/plugins/vite/vite-minify-json-plugin.ts
@@ -1,0 +1,56 @@
+import path from "path";
+import fs from "fs";
+import { type Plugin as VitePlugin } from "vite";
+
+/**
+ * Crawl a directory (recursively if wanted) for json files and minifies found ones.
+ * @param dir the directory to crawl
+ * @param recursive if true, will crawl subdirectories
+ */
+function applyToDir(dir: string, recursive?: boolean) {
+  const files = fs.readdirSync(dir).filter((file) => !/^\..*/.test(file));
+
+  for (const file of files) {
+    const filePath = path.join(dir, file);
+    const stat = fs.lstatSync(filePath);
+
+    if (stat.isDirectory() && recursive) {
+      applyToDir(filePath, recursive); // only if recursive is true
+    } else if (path.extname(file) === ".json") {
+      const contents = fs.readFileSync(filePath, "utf8");
+      const minifiedContent = JSON.stringify(JSON.parse(contents));
+
+      fs.writeFileSync(filePath, minifiedContent, "utf8");
+    }
+  }
+}
+
+/**
+ * Plugin to mnify json files in the build folder after the bundling is done.
+ * @param basePath base path/es starting inside the build dir (e.g. will always start with "/dist" if dist is the build dir)
+ * @param recursive if true, will crawl subdirectories
+ */
+export function minifyJsonPlugin(basePath: string | string[], recursive?: boolean): VitePlugin {
+  let buildDir = "dist"; // Default build dir
+
+  return {
+    name: "flx-minify-json",
+    configResolved(config) {
+      buildDir = config.build.outDir; // Read the build output directory from Vite config
+    },
+    async closeBundle() {
+      console.log("Minifying JSON files...");
+      const basePathes = Array.isArray(basePath) ? basePath : [basePath];
+
+      basePathes.forEach((basePath) => {
+        const baseDir = path.resolve(buildDir, basePath);
+        if (fs.existsSync(baseDir)) {
+          applyToDir(baseDir, recursive);
+        } else {
+          console.error(`Path ${baseDir} does not exist!`);
+        }
+      });
+      console.log("Finished minifying JSON files!");
+    },
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,12 @@
 import { defineConfig, loadEnv } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
+import { minifyJsonPlugin } from "./src/plugins/vite/vite-minify-json-plugin";
 
 export const defaultConfig = {
-	plugins: [tsconfigPaths() as any],
+	plugins: [
+		tsconfigPaths() as any, 
+		minifyJsonPlugin(["images", "battle-anims"], true)
+	],
 	clearScreen: false,
 	build: {
 		minify: 'esbuild' as const,


### PR DESCRIPTION
it minifies all the json files in the given directorties (currently `/dist/images` and `/dist/battle-anim`). That way we can work with the beautified jsons but the users retrieve the minified ones.

<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->

it minifies all the json files in the given directorties (currently `/dist/images` and `/dist/battle-anim`). That way we can work with the beautified jsons but the users retrieve the minified ones.

## Why am I doing these changes?

Reduce file-size load

## What did change?

Added the `minifyJson` plugin to the vite.config.

### Screenshots/Videos

<img width="942" alt="image" src="https://github.com/user-attachments/assets/ae0f6cd1-72e5-4799-baeb-7af628bf42cd">

<img width="1122" alt="image" src="https://github.com/user-attachments/assets/e86ff754-cd41-405d-832b-a42cc9d30f86">


## How to test the changes?

1. Run `npm run build`
2. Check the `/dist/images` and `/dist/battle-anim` folders for json files
3. they should be minified

## Checklist
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)