### PR TITLE
[Localization] Add minor Korean translations to ability-trigger file (costar,trace)

### DIFF
--- a/src/locales/ko/ability-trigger.ts
+++ b/src/locales/ko/ability-trigger.ts
@@ -3,11 +3,11 @@ import { SimpleTranslationEntries } from "#app/interfaces/locales";
 export const abilityTriggers: SimpleTranslationEntries = {
   "blockRecoilDamage" : "{{pokemonName}}[[는]] {{abilityName}} 때문에\n반동 데미지를 받지 않는다!",
   "badDreams": "{{pokemonName}}[[는]]\n나이트메어 때문에 시달리고 있다!",
-  "costar": "{{pokemonName}} copied {{allyName}}'s stat changes!",
+  "costar": "{{pokemonName}}[[는]] {{allyName}} 의 능력 변화를 복사했다!",
   "iceFaceAvoidedDamage": "{{pokemonName}}[[는]] {{abilityName}} 때문에\n데미지를 받지 않는다!",
   "perishBody": "{{pokemonName}}의 {{abilityName}} 때문에\n양쪽 포켓몬 모두는 3턴 후에 쓰러져 버린다!",
   "poisonHeal": "{{pokemonName}}[[는]] {{abilityName}}[[로]]인해\n조금 회복했다.",
-  "trace": "{{pokemonName}} copied {{targetName}}'s\n{{abilityName}}!",
+  "trace": "{{pokemonName}}[[는]] 상대 {{targetName}}'의 \n{{abilityName}}[[를]] 트레이스했다!",
   "windPowerCharged": "{{pokemonName}}[[는]]\n{{moveName}}에 맞아 충전되었다!",
   "quickDraw": "{{pokemonName}}[[는]]\n퀵드로에 의해 행동이 빨라졌다!",
 } as const;

--- a/src/locales/ko/ability-trigger.ts
+++ b/src/locales/ko/ability-trigger.ts
@@ -7,7 +7,7 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "iceFaceAvoidedDamage": "{{pokemonName}}[[는]] {{abilityName}} 때문에\n데미지를 받지 않는다!",
   "perishBody": "{{pokemonName}}의 {{abilityName}} 때문에\n양쪽 포켓몬 모두는 3턴 후에 쓰러져 버린다!",
   "poisonHeal": "{{pokemonName}}[[는]] {{abilityName}}[[로]]인해\n조금 회복했다.",
-  "trace": "{{pokemonName}}[[는]] 상대 {{targetName}}'의 \n{{abilityName}}[[를]] 트레이스했다!",
+  "trace": "{{pokemonName}}[[는]] 상대 {{targetName}}의 \n{{abilityName}}[[를]] 트레이스했다!",
   "windPowerCharged": "{{pokemonName}}[[는]]\n{{moveName}}에 맞아 충전되었다!",
   "quickDraw": "{{pokemonName}}[[는]]\n퀵드로에 의해 행동이 빨라졌다!",
 } as const;


### PR DESCRIPTION
Add minor Korean translations to ability-trigger file.

1. Add Korean translation for costar ability trigger
2. Add Korean translation for trace ability trigger

## What are the changes?
1. Add Korean translation for costar ability trigger
2. Add Korean translation for trace ability trigger

refer from Pokémon Scarlet and Violet's official translation.

## Why am I doing these changes?

Fix missing Korean translations for costar and trace abilities in ability-trigger file to enhance user immersion.


## What did change?

**Before the PR**
The abilities costar and trace lacked Korean translations.
Korean-native players faced interruptions in immersion due to untranslated ability descriptions.
**After the PR**
Added Korean translations for the costar and trace abilities.
Korean-native players will now see consistent translations, improving their gaming experience and immersion.

### Screenshots/Videos


## How to test the changes?
1. Installed the project locally using npm install.
2. Played with Polygon and Flamigo to ensure costar and trace description is shown correctly.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [v] Have I provided a clear explanation of the changes?
- [v] Have I tested the changes (manually)?
    - [v] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?