### PR TITLE
[Localization] Add minor Korean translations to ability-trigger file (trace)

### DIFF
--- a/src/locales/ko/ability-trigger.ts
+++ b/src/locales/ko/ability-trigger.ts
@@ -7,7 +7,7 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "iceFaceAvoidedDamage": "{{pokemonName}}[[는]] {{abilityName}} 때문에\n데미지를 받지 않는다!",
   "perishBody": "{{pokemonName}}의 {{abilityName}} 때문에\n양쪽 포켓몬 모두는 3턴 후에 쓰러져 버린다!",
   "poisonHeal": "{{pokemonName}}[[는]] {{abilityName}}[[로]]인해\n조금 회복했다.",
-  "trace": "{{pokemonName}}[[는]] {{targetName}}의\n{{abilityName}}[[를]] 복사했다!",
+  "trace": "{{pokemonName}}[[는]] 상대 {{targetName}}'의 \n{{abilityName}}[[를]] 트레이스했다!",
   "windPowerCharged": "{{pokemonName}}[[는]]\n{{moveName}}에 맞아 충전되었다!",
   "quickDraw": "{{pokemonName}}[[는]]\n퀵드로에 의해 행동이 빨라졌다!",
   "blockItemTheft": "{{pokemonNameWithAffix}}의 {{abilityName}}에 의해\n도구를 빼앗기지 않는다!",

--- a/src/locales/ko/ability-trigger.ts
+++ b/src/locales/ko/ability-trigger.ts
@@ -7,7 +7,7 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "iceFaceAvoidedDamage": "{{pokemonName}}[[는]] {{abilityName}} 때문에\n데미지를 받지 않는다!",
   "perishBody": "{{pokemonName}}의 {{abilityName}} 때문에\n양쪽 포켓몬 모두는 3턴 후에 쓰러져 버린다!",
   "poisonHeal": "{{pokemonName}}[[는]] {{abilityName}}[[로]]인해\n조금 회복했다.",
-  "trace": "{{pokemonName}}[[는]] 상대 {{targetName}}'의 \n{{abilityName}}[[를]] 트레이스했다!",
+  "trace": "{{pokemonName}}[[는]] 상대 {{targetName}}의 \n{{abilityName}}[[를]] 트레이스했다!",
   "windPowerCharged": "{{pokemonName}}[[는]]\n{{moveName}}에 맞아 충전되었다!",
   "quickDraw": "{{pokemonName}}[[는]]\n퀵드로에 의해 행동이 빨라졌다!",
   "blockItemTheft": "{{pokemonNameWithAffix}}의 {{abilityName}}에 의해\n도구를 빼앗기지 않는다!",


### PR DESCRIPTION
is following pr of #3087 

## What are the changes?
Add Korean translation for trace ability trigger
refered from Pokémon Scarlet and Violet's official translation.

## Why am I doing these changes?
Modify to offcial Korean translation for trace abilities in ability-trigger file to enhance user immersion.

## What did change?

After the PR
Modified a Korean translation for the trace abilities. 
Korean-native players will now see consistent translations, improving their gaming experience and immersion.

### Screenshots/Videos
![trace_ko_description](https://github.com/user-attachments/assets/f79890a5-dae0-48af-a40d-e3a9647eaed7)

## Checklist
[v] There is no overlap with another PR?
[v] The PR is self-contained and cannot be split into smaller PRs?
[v] Have I provided a clear explanation of the changes?
[v] Have I tested the changes (manually)?
[v] Are all unit tests still passing? (npm run test)