### PR TITLE
[Bug] Make EXP boosting items stack additively and not multiplicatively

### DIFF
--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -1774,7 +1774,7 @@ export class PokemonExpBoosterModifier extends PokemonHeldItemModifier {
   }
 
   apply(args: any[]): boolean {
-    (args[1] as Utils.NumberHolder).value = Math.floor((args[1] as Utils.NumberHolder).value * (1 + (this.getStackCount() * this.boostMultiplier)));
+    (args[1] as Utils.NumberHolder).value += (this.getStackCount() * this.boostMultiplier);
 
     return true;
   }

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -3927,7 +3927,9 @@ export class VictoryPhase extends PokemonPhase {
           expMultiplier = Overrides.XP_MULTIPLIER_OVERRIDE;
         }
         const pokemonExp = new Utils.NumberHolder(expValue * expMultiplier);
-        this.scene.applyModifiers(PokemonExpBoosterModifier, true, partyMember, pokemonExp);
+        const modifierBonusExp = new Utils.NumberHolder(1);
+        this.scene.applyModifiers(PokemonExpBoosterModifier, true, partyMember, modifierBonusExp);
+        pokemonExp.value *= modifierBonusExp.value;
         partyMemberExp.push(Math.floor(pokemonExp.value));
       }
 

--- a/src/test/items/exp_booster.test.ts
+++ b/src/test/items/exp_booster.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import Phase from "phaser";
+import GameManager from "#app/test/utils/gameManager";
+import overrides from "#app/overrides";
+import { Abilities } from "#app/enums/abilities.js";
+import { PokemonExpBoosterModifier } from "#app/modifier/modifier.js";
+import * as Utils from "#app/utils";
+
+describe("EXP Modifier Items", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phase.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+
+    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.BALL_FETCH);
+    vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.BALL_FETCH);
+    vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+  });
+
+  it("EXP booster items stack additively", async() => {
+    vi.spyOn(overrides, "STARTING_HELD_ITEMS_OVERRIDE", "get").mockReturnValue([{name: "LUCKY_EGG"}, {name: "GOLDEN_EGG"}]);
+    await game.startBattle();
+
+    const partyMember = game.scene.getPlayerPokemon();
+    const modifierBonusExp = new Utils.NumberHolder(1);
+    partyMember.scene.applyModifiers(PokemonExpBoosterModifier, true, partyMember, modifierBonusExp);
+    expect(modifierBonusExp.value).toBe(2.4);
+  }, 20000);
+});


### PR DESCRIPTION
## What are the changes?
EXP boosting items are changed to stack additively instead of multiplicatively.

## Why am I doing these changes?
#2040

## What did change?
The modifier increments a `modifierBonusExp` variable instead of acting on the gained EXP variable directly, and then after all the bonus modifiers are added to the bonus multiplier variable it's applied to the gained EXP.

## How to test the changes?
`npm run test exp_booster`
Alternatively, defeat a lv5 Gyarados with a lv5 Mewtwo that's holding 1 Lucky Egg and 1 Golden Egg and observe the gained EXP being 456 (2.4x) and not 532 (2.8x) as it is now on main.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~