### PR TITLE
[BUG][UI/UX] Correction of errors when ``` Save & Quit``` and ``` Log out```

### DIFF
--- a/src/ui/menu-ui-handler.ts
+++ b/src/ui/menu-ui-handler.ts
@@ -352,6 +352,7 @@ export default class MenuUiHandler extends MessageUiHandler {
           }
         }
       }
+      this.showText("", 0);
       switch (adjustedCursor) {
       case MenuOptions.GAME_SETTINGS:
         ui.setOverlayMode(Mode.SETTINGS);
@@ -442,9 +443,13 @@ export default class MenuUiHandler extends MessageUiHandler {
           success = true;
           if (this.scene.currentBattle.turn > 1) {
             ui.showText(i18next.t("menuUiHandler:losingProgressionWarning"), null, () => {
+              if (!this.active) {
+                this.showText("", 0);
+                return;
+              }
               ui.setOverlayMode(Mode.CONFIRM, () => this.scene.gameData.saveAll(this.scene, true, true, true, true).then(() => this.scene.reset(true)), () => {
                 ui.revertMode();
-                ui.showText("", 0);
+                this.showText("", 0);
               }, false, -98);
             });
           } else {
@@ -467,9 +472,13 @@ export default class MenuUiHandler extends MessageUiHandler {
         };
         if (this.scene.currentBattle) {
           ui.showText(i18next.t("menuUiHandler:losingProgressionWarning"), null, () => {
+            if (!this.active) {
+              this.showText("", 0);
+              return;
+            }
             ui.setOverlayMode(Mode.CONFIRM, doLogout, () => {
               ui.revertMode();
-              ui.showText("", 0);
+              this.showText("", 0);
             }, false, -98);
           });
         } else {

--- a/src/ui/modal-ui-handler.ts
+++ b/src/ui/modal-ui-handler.ts
@@ -83,6 +83,20 @@ export abstract class ModalUiHandler extends UiHandler {
   show(args: any[]): boolean {
     if (args.length >= 1 && "buttonActions" in args[0]) {
       super.show(args);
+      if ("fadeOut" in args[0]) {
+        const overlay = this.scene.add.rectangle((( (this.getWidth() + (this.getMargin()[0] - this.getMargin()[3]))) / 2), ((this.getHeight() + (this.getMargin()[1] - this.getMargin()[2])) / 2),this.scene.game.canvas.width ,this.scene.game.canvas.height , 0);
+        overlay.setName("rect-ui-overlay-modal");
+        overlay.setAlpha(0);
+        this.modalContainer.add(overlay);
+        this.modalContainer.moveTo(overlay,0);
+        this.scene.tweens.add({
+          targets: overlay,
+          alpha: 1,
+          duration: 250,
+          ease: "Sine.easeOut",
+          onComplete: args[0].fadeOut
+        });
+      }
 
       const config = args[0] as ModalConfig;
 

--- a/src/ui/modal-ui-handler.ts
+++ b/src/ui/modal-ui-handler.ts
@@ -83,7 +83,7 @@ export abstract class ModalUiHandler extends UiHandler {
   show(args: any[]): boolean {
     if (args.length >= 1 && "buttonActions" in args[0]) {
       super.show(args);
-      if ("fadeOut" in args[0]) {
+      if (args[0].hasOwnProperty("fadeOut") && typeof args[0].fadeOut === "function") {
         const overlay = this.scene.add.rectangle((( (this.getWidth() + (this.getMargin()[0] - this.getMargin()[3]))) / 2), ((this.getHeight() + (this.getMargin()[1] - this.getMargin()[2])) / 2),this.scene.game.canvas.width ,this.scene.game.canvas.height , 0);
         overlay.setName("rect-ui-overlay-modal");
         overlay.setAlpha(0);

--- a/src/ui/modal-ui-handler.ts
+++ b/src/ui/modal-ui-handler.ts
@@ -84,11 +84,16 @@ export abstract class ModalUiHandler extends UiHandler {
     if (args.length >= 1 && "buttonActions" in args[0]) {
       super.show(args);
       if (args[0].hasOwnProperty("fadeOut") && typeof args[0].fadeOut === "function") {
-        const overlay = this.scene.add.rectangle((( (this.getWidth() + (this.getMargin()[0] - this.getMargin()[3]))) / 2), ((this.getHeight() + (this.getMargin()[1] - this.getMargin()[2])) / 2),this.scene.game.canvas.width ,this.scene.game.canvas.height , 0);
+        const [ marginTop, marginRight, marginBottom, marginLeft ] = this.getMargin();
+
+        const overlay = this.scene.add.rectangle(( this.getWidth() + marginLeft + marginRight) / 2, (this.getHeight() + marginTop + marginBottom) / 2,this.scene.game.canvas.width / 6,this.scene.game.canvas.height /6, 0);
+        overlay.setOrigin(0.5,0.5);
         overlay.setName("rect-ui-overlay-modal");
         overlay.setAlpha(0);
+
         this.modalContainer.add(overlay);
         this.modalContainer.moveTo(overlay,0);
+
         this.scene.tweens.add({
           targets: overlay,
           alpha: 1,


### PR DESCRIPTION
### **What are the changes?**
That the page does not crash when spamming Save & exit/Log out, interaction bugs when selecting and exiting quickly and optional integration of black background for modals

### **Why am I doing these changes?**
Fixes https://github.com/pagefaultgames/pokerogue/pull/3084#pullrequestreview-2192059356

Resolves https://github.com/pagefaultgames/pokerogue/issues/3048 by @flx-sta

### **What did change?**
Incorporating ``` LOADING ``` modal to avoid spam on buttons and I changed the ui.showText to this.showText so that it references the menu correctly, as well as including a showText("",0) to remove whatever may be on the screen before displaying the following.

Additionally i added the black background option to the modals.

## **Screenshots/Videos**

### Before
![image](https://github.com/user-attachments/assets/7f7f7280-58a8-4be8-b173-283f55448e27)
![image](https://github.com/user-attachments/assets/81325d31-f471-4393-89d0-e7dca8986448)

[requests.webm](https://github.com/user-attachments/assets/1c28097f-b86f-4e55-bae6-acc621fc4dd5)

_saturation of requests_

### After

[Screencast from 2024-08-09 19-06-16.webm](https://github.com/user-attachments/assets/f62144d2-2821-40e6-a0cc-6394d66605e8)


### **How to test the changes?**
Using database (from rogueserver) and "Slowed 3G" (Presets from Network) for simulation.

### Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?