### PR TITLE
[Bug] fix label for bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Create a report to help us improve
 title: "[Bug] "
-labels: ["bug"]
+labels: ["Bug"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
# `main` branch on purpose

It's not setting the label properly. 
Cause of the wrong capitalization.