### PR TITLE
[Bug] Revert evolution ability swap fix

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3318,10 +3318,6 @@ export class PlayerPokemon extends Pokemon {
       }
       this.generateName();
       if (!isFusion) {
-        // If a pokemon has its second ability and it evolves into a pokemon that doesn't have a second ability, switch to its first ability instead of its hidden ability
-        if (this.getSpeciesForm().ability2 === Abilities.NONE && this.abilityIndex === 1) {
-          this.abilityIndex = 0;
-        }
         // Prevent pokemon with an illegal ability value from breaking things too badly
         const abilityCount = this.getSpeciesForm().getAbilityCount();
         if (this.abilityIndex >= abilityCount) {
@@ -3330,9 +3326,6 @@ export class PlayerPokemon extends Pokemon {
           this.abilityIndex = 0;
         }
       } else { // Do the same as above, but for fusions
-        if (this.getFusionSpeciesForm().ability2 === Abilities.NONE && this.fusionAbilityIndex === 1) {
-          this.fusionAbilityIndex = 0;
-        }
         const abilityCount = this.getFusionSpeciesForm().getAbilityCount();
         if (this.fusionAbilityIndex >= abilityCount) {
           console.warn("this.fusionAbilityIndex is somehow an illegal value, please report this");


### PR DESCRIPTION
## What are the changes?
Reverts the ability swap portion of #2995

## Why am I doing these changes?
A different bug was introduced causing Pokémon with only Ability1 and a Hidden Ability to lose their HA when evolving.

## What did change?
The code that swaps `abilityIndex` from 1 to 0 for Pokémon that don't have a second normal ability is removed.

## How to test the changes?
Evolve any starter trio Pokémon with its Hidden Ability and observe it doesn't lose its ability upon evolution.

## Screenshots/Video

https://github.com/user-attachments/assets/36fc8011-dba3-409b-a35a-65311437df35

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
