### PR TITLE
[Bug] Make on-summon abilities trigger after the switch check

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2056,8 +2056,8 @@ export default class BattleScene extends SceneBase {
       const conditionalPhase = this.conditionalQueue.shift();
       // Evaluate the condition associated with the phase
       if (conditionalPhase[0]()) {
-        // If the condition is met, add the phase to the front of the phase queue
-        this.unshiftPhase(conditionalPhase[1]);
+        // If the condition is met, add the phase to the phase queue
+        this.pushPhase(conditionalPhase[1]);
       } else {
         // If the condition is not met, re-add the phase back to the front of the conditional queue
         this.conditionalQueue.unshift(conditionalPhase);

--- a/src/test/abilities/ability_timing.test.ts
+++ b/src/test/abilities/ability_timing.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import Phaser from "phaser";
+import GameManager from "#app/test/utils/gameManager";
+import Overrides from "#app/overrides";
+import { CommandPhase, MessagePhase, TurnInitPhase } from "#app/phases";
+import { Mode } from "#app/ui/ui";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import i18next, { initI18n } from "#app/plugins/i18n";
+
+
+describe("Ability Timing", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    vi.spyOn(Overrides, "BATTLE_TYPE_OVERRIDE", "get").mockReturnValue("single");
+
+    vi.spyOn(Overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.PIDGEY);
+    vi.spyOn(Overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.INTIMIDATE);
+    vi.spyOn(Overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue(Array(4).fill(Moves.SPLASH));
+
+    vi.spyOn(Overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.BALL_FETCH);
+    vi.spyOn(Overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.ICE_BEAM]);
+  });
+
+  it("should trigger after switch check", async() => {
+    initI18n();
+    i18next.changeLanguage("en");
+    await game.runToSummon([Species.EEVEE, Species.FEEBAS]);
+
+    game.onNextPrompt("CheckSwitchPhase", Mode.CONFIRM, () => {
+      game.setMode(Mode.MESSAGE);
+      game.endPhase();
+    }, () => game.isCurrentPhase(CommandPhase) || game.isCurrentPhase(TurnInitPhase));
+
+    await game.phaseInterceptor.to(MessagePhase);
+    const message = game.textInterceptor.getLatestMessage();
+    expect(message).toContain("Attack fell");
+  }, 5000);
+});


### PR DESCRIPTION
## What are the changes?
Change on-summon abilities to trigger after the switch check occurs at the start of a battle when playing in "Switch" mode rather than "Set" mode.

## Why am I doing these changes?
The timing was incorrect, letting you nullify an opposing Pokémon's intimidate/etc by switching for free at the start of a battle (as long as you don't reload the game).

## What did change?
The timing of conditional phases was changed from `unshiftPhase()` to `pushPhase()`. Currently the only time conditional phases are used is [exactly once](https://github.com/user-attachments/assets/790b825e-dcde-4d78-829a-0339bfe79a2c), for on-summon abilities at the start of a battle.

### Screenshots/Videos
Incorrect behavior (on current beta):

https://github.com/user-attachments/assets/f85a6446-24c0-4f95-8958-ec45c8886d39

Correct behavior (after fix):

https://github.com/user-attachments/assets/20acd2f5-7b37-4b29-9fd5-4c8566e1bee9

## How to test the changes?
Make sure "Battle Style" is "Switch" in the settings menu.
Start a new classic run with `OPP_ABILITY_OVERRIDE` set to `Abilities.INTIMIDATE` and at least 2 Pokémon in your party. Defeat the wave 1 encounter and move to wave 2. Then refresh the page and load the same save slot.
Alternatively, `npm run test ability_timing`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - [x] Have I provided screenshots/videos of the changes?
