### PR TITLE
[Bug] Fix tags not resetting on switch

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1655,6 +1655,11 @@ export class SwitchSummonPhase extends SummonPhase {
             pokemonName: getPokemonNameWithAffix(this.getPokemon())
           })
         );
+        // Ensure improperly persisted summon data (such as tags) is cleared upon switching
+        if (!this.batonPass) {
+          party[this.fieldIndex].resetBattleData();
+          party[this.fieldIndex].resetSummonData();
+        }
         this.summon();
       };
       if (this.player) {


### PR DESCRIPTION
## What are the changes?
Fixes moves (such as Perish Song) improperly persisting when switching Pokémon after a loading a save game.

## Why am I doing these changes?
Fixes #2982

## What did change?
`resetBattleData()` and `resetSummonData()` are called in `SwitchSummonPhase` to clear any residual data that is improperly persisted.

### Screenshots/Videos
No switch = Perish Song activates as expected

https://github.com/user-attachments/assets/d5c6c0d4-8021-4e57-8145-1b4bed295046

Current behavior (bugged): Perish Song still activates after switch

https://github.com/user-attachments/assets/f8ea079f-749e-4263-9861-3a52eb8e207c

Behavior after fix: Perish Song no longer activates after switch

https://github.com/user-attachments/assets/340d379c-8177-42f9-b401-29bb1f174dcd

## How to test the changes?
There is unfortunately a bit of RNG involved unless you also modify the encounter logic so that double battles only occur on Wave 1.
```ts
const overrides = { // Overrides I used for testing
  OPP_SPECIES_OVERRIDE: Species.PIDGEY,
  OPP_MOVESET_OVERRIDE: Array(4).fill(Moves.SPLASH),
  MOVESET_OVERRIDE: [Moves.ICE_BEAM, Moves.PERISH_SONG, Moves.SPLASH],
  BATTLE_TYPE_OVERRIDE: "double", // Remove this override after starting the first battle
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```
* Start a double battle with 2 Pokémon
* Save and quit to the main menu to disable the double battle override if enabled then reload the save, otherwise skip this step
* Turn 1: Use Perish Song (-> Count drops to 3)
* Turn 2: Pass the turn with Splash (-> Count drops to 2)
* Turn 3: Faint the opposing Pokémon (-> Count drops to 1)
* Continue to the next battle which should (hopefully) be a single battle; if it's not, restart from the beginning, otherwise continue
* Switch out the current Pokémon with the second Pokémon
* Pass the turn; at this point the Pokémon should not faint
* Refresh the page and load the saved game
* Switch out the current Pokémon with the second Pokémon
* Pass the turn; the player Pokémon will faint from Perish Song

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - [x] Have I provided screenshots/videos of the changes?
