### PR TITLE
[Bug] Hotfix for Starter select UI with Filter

### DIFF
--- a/src/ui/dropdown.ts
+++ b/src/ui/dropdown.ts
@@ -176,6 +176,8 @@ export class DropDown extends Phaser.GameObjects.Container {
           this.options[0].setOptionState(DropDownState.OFF);
         } else if (this.checkForAllOn()) {
           this.options[0].setOptionState(DropDownState.ON);
+        } else {
+          this.options[0].setOptionState(DropDownState.OFF);
         }
       }
     } else {

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -2020,7 +2020,6 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.starterSelectScrollBar.setPage(this.scrollCursor);
 
     let pokerusCursorIndex = 0;
-    let starterCursorIndex = 0;
     this.filteredStarterContainers.forEach((container, i) => {
       const pos = calcStarterPosition(i, this.scrollCursor);
       container.setPosition(pos.x, pos.y);
@@ -2033,14 +2032,23 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
       if (this.pokerusSpecies.includes(container.species)) {
         this.pokerusCursorObjs[pokerusCursorIndex].setPosition(pos.x - 1, pos.y + 1);
-        this.pokerusCursorObjs[pokerusCursorIndex].setVisible(true);
+
+        if (i < (maxRows + this.scrollCursor) * perRow && i >= this.scrollCursor * perRow) {
+          this.pokerusCursorObjs[pokerusCursorIndex].setVisible(true);
+        } else {
+          this.pokerusCursorObjs[pokerusCursorIndex].setVisible(false);
+        }
         pokerusCursorIndex++;
       }
 
       if (this.starterSpecies.includes(container.species)) {
-        this.starterCursorObjs[starterCursorIndex].setPosition(pos.x - 1, pos.y + 1);
-        this.starterCursorObjs[starterCursorIndex].setVisible(true);
-        starterCursorIndex++;
+        this.starterCursorObjs[this.starterSpecies.indexOf(container.species)].setPosition(pos.x - 1, pos.y + 1);
+
+        if (i < (maxRows + this.scrollCursor) * perRow && i >= this.scrollCursor * perRow) {
+          this.starterCursorObjs[this.starterSpecies.indexOf(container.species)].setVisible(true);
+        } else {
+          this.starterCursorObjs[this.starterSpecies.indexOf(container.species)].setVisible(false);
+        }
       }
 
       const speciesId = container.species.speciesId;

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1155,9 +1155,9 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         if (!this.speciesStarterDexEntry?.caughtAttr) {
           error = true;
         } else if (this.starterSpecies.length < 6) { // checks to see you have less than 6 pokemon in your party
-          
+
           let species;
-          
+
           // this gets the correct generation and pokemon cursor depending on whether you're in the starter screen or the party icons
           if (!this.starterIconsCursorObj.visible) {
             species = this.filteredStarterContainers[this.cursor].species;

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1150,66 +1150,61 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       if (button === Button.ACTION) {
         if (!this.speciesStarterDexEntry?.caughtAttr) {
           error = true;
-        } else if (this.starterSpecies.length < 6) {
-          const options = [
-            {
-              label: i18next.t("starterSelectUiHandler:addToParty"),
+        } else if (this.starterSpecies.length < 6) { // checks to see you have less than 6 pokemon in your party
+          
+          let species;
+          
+          // this gets the correct generation and pokemon cursor depending on whether you're in the starter screen or the party icons
+          if (!this.starterIconsCursorObj.visible) {
+            species = this.filteredStarterContainers[this.cursor].species;
+          } else {
+            species = this.starterSpecies[this.starterIconsCursorIndex];
+          }
+          const ui = this.getUi();
+          let options = [];
+
+          const [isDupe, removeIndex]: [boolean, number] = this.isInParty(species); // checks to see if the pokemon is a duplicate; if it is, returns the index that will be removed
+
+
+          const isPartyValid = this.isPartyValid();
+          const isValidForChallenge = new Utils.BooleanHolder(true);
+          if (isPartyValid) {
+            Challenge.applyChallenges(this.scene.gameMode, Challenge.ChallengeType.STARTER_CHOICE, species, isValidForChallenge, this.scene.gameData.getSpeciesDexAttrProps(species, this.scene.gameData.getSpeciesDefaultDexAttr(species, false, true)), !!(this.starterSpecies.length));
+          } else {
+            Challenge.applyChallenges(this.scene.gameMode, Challenge.ChallengeType.STARTER_CHOICE, species, isValidForChallenge, this.scene.gameData.getSpeciesDexAttrProps(species, this.scene.gameData.getSpeciesDefaultDexAttr(species, false, true)), !!(this.starterSpecies.length), false, false);
+          }
+
+          const currentPartyValue = this.starterSpecies.map(s => s.generation).reduce((total: number, gen: number, i: number) => total += this.scene.gameData.getSpeciesStarterValue(this.starterSpecies[i].speciesId), 0);
+          const newCost = this.scene.gameData.getSpeciesStarterValue(species.speciesId);
+          if (!isDupe && isValidForChallenge.value && currentPartyValue + newCost <= this.getValueLimit()) { // this checks to make sure the pokemon doesn't exist in your party, it's valid for the challenge and that it won't go over the cost limit; if it meets all these criteria it will add it to your party
+            options = [
+              {
+                label: i18next.t("starterSelectUiHandler:addToParty"),
+                handler: () => {
+                  ui.setMode(Mode.STARTER_SELECT);
+
+                  if (!isDupe && isValidForChallenge.value && this.tryUpdateValue(this.scene.gameData.getSpeciesStarterValue(species.speciesId), true)) {
+                    this.addToParty(species);
+                    ui.playSelect();
+                  } else {
+                    ui.playError(); // this should be redundant as there is now a trigger for when a pokemon can't be added to party
+                  }
+                  return true;
+                },
+                overrideSound: true
+              }];
+          } else if (isDupe) { // if it already exists in your party, it will give you the option to remove from your party
+            options = [{
+              label: i18next.t("starterSelectUiHandler:removeFromParty"),
               handler: () => {
+                this.popStarter(removeIndex);
                 ui.setMode(Mode.STARTER_SELECT);
-                let isDupe = false;
-
-                const species = this.filteredStarterContainers[this.cursor].species;
-                for (let s = 0; s < this.starterSpecies.length; s++) {
-                  if (species === this.starterSpecies[s]) {
-                    isDupe = true;
-                    break;
-                  }
-                }
-
-                const isValidForChallenge = new Utils.BooleanHolder(true);
-                Challenge.applyChallenges(this.scene.gameMode, Challenge.ChallengeType.STARTER_CHOICE, species, isValidForChallenge, this.scene.gameData.getSpeciesDexAttrProps(species, this.dexAttrCursor), !!this.starterSpecies.length);
-
-
-                if (!isDupe && isValidForChallenge.value && this.tryUpdateValue(this.scene.gameData.getSpeciesStarterValue(species.speciesId))) {
-                  const cursorObj = this.starterCursorObjs[this.starterSpecies.length];
-                  cursorObj.setVisible(true);
-                  cursorObj.setPosition(this.cursorObj.x, this.cursorObj.y);
-                  const props = this.scene.gameData.getSpeciesDexAttrProps(species, this.dexAttrCursor);
-                  this.starterIcons[this.starterSpecies.length].setTexture(species.getIconAtlasKey(props.formIndex, props.shiny, props.variant));
-                  this.starterIcons[this.starterSpecies.length].setFrame(species.getIconId(props.female, props.formIndex, props.shiny, props.variant));
-                  this.checkIconId(this.starterIcons[this.starterSpecies.length], species, props.female, props.formIndex, props.shiny, props.variant);
-                  this.starterSpecies.push(species);
-                  this.starterAttr.push(this.dexAttrCursor);
-                  this.starterAbilityIndexes.push(this.abilityCursor);
-                  this.starterNatures.push(this.natureCursor as unknown as Nature);
-                  this.starterMovesets.push(this.starterMoveset.slice(0) as StarterMoveset);
-                  if (this.speciesLoaded.get(species.speciesId)) {
-                    getPokemonSpeciesForm(species.speciesId, props.formIndex).cry(this.scene);
-                  }
-                  if (this.starterSpecies.length === 6 || this.value === this.getValueLimit()) {
-                    this.cursorObj.setVisible(false);
-                    this.setSpecies(null);
-                    this.startCursorObj.setVisible(true);
-                    this.tryStart();
-                  }
-                  this.updateInstructions();
-
-                  /**
-                   * If the user can't select a pokemon anymore,
-                   * go to start button.
-                   */
-                  if (!this.canAddParty) {
-                    this.startCursorObj.setVisible(true);
-                  }
-
-                  ui.playSelect();
-                } else {
-                  ui.playError();
-                }
                 return true;
-              },
-              overrideSound: true
-            },
+              }
+            }];
+          }
+
+          options.push( // this shows the IVs for the pokemon
             {
               label: i18next.t("starterSelectUiHandler:toggleIVs"),
               handler: () => {
@@ -1217,8 +1212,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
                 ui.setMode(Mode.STARTER_SELECT);
                 return true;
               }
-            }
-          ];
+            });
           if (this.speciesStarterMoves.length > 1) { // this lets you change the pokemon moves
             const showSwapOptions = (moveset: StarterMoveset) => {
               ui.setMode(Mode.STARTER_SELECT).then(() => {
@@ -1765,6 +1759,25 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       }
     }
     return [isDupe, removeIndex];
+  }
+
+  addToParty(species: PokemonSpecies) {
+    const cursorObj = this.starterCursorObjs[this.starterSpecies.length];
+    cursorObj.setVisible(true);
+    cursorObj.setPosition(this.cursorObj.x, this.cursorObj.y);
+    const props = this.scene.gameData.getSpeciesDexAttrProps(species, this.dexAttrCursor);
+    this.starterIcons[this.starterSpecies.length].setTexture(species.getIconAtlasKey(props.formIndex, props.shiny, props.variant));
+    this.starterIcons[this.starterSpecies.length].setFrame(species.getIconId(props.female, props.formIndex, props.shiny, props.variant));
+    this.checkIconId(this.starterIcons[this.starterSpecies.length], species, props.female, props.formIndex, props.shiny, props.variant);
+    this.starterSpecies.push(species);
+    this.starterAttr.push(this.dexAttrCursor);
+    this.starterAbilityIndexes.push(this.abilityCursor);
+    this.starterNatures.push(this.natureCursor as unknown as Nature);
+    this.starterMovesets.push(this.starterMoveset.slice(0) as StarterMoveset);
+    if (this.speciesLoaded.get(species.speciesId)) {
+      getPokemonSpeciesForm(species.speciesId, props.formIndex).cry(this.scene);
+    }
+    this.updateInstructions();
   }
 
   switchMoveHandler(i: number, newMove: Moves, move: Moves) {

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1075,8 +1075,12 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         break;
       case Button.DOWN:
         this.startCursorObj.setVisible(false);
-        this.starterIconsCursorIndex = 0;
-        this.moveStarterIconsCursor(this.starterIconsCursorIndex);
+        if (this.starterSpecies.length > 0) {
+          this.starterIconsCursorIndex = 0;
+          this.moveStarterIconsCursor(this.starterIconsCursorIndex);
+        } else {
+          this.setFilterMode(true);
+        }
         success = true;
         break;
       case Button.LEFT:

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -2772,10 +2772,12 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       this.scene.time.delayedCall(Utils.fixedInt(500), () => this.tryUpdateValue());
       return false;
     }
+    let isPartyValid: boolean = this.isPartyValid(); // this checks to see if the party is valid
     if (addingToParty) { // this does a check to see if the pokemon being added is valid; if so, it will update the isPartyValid boolean
       const isNewPokemonValid = new Utils.BooleanHolder(true);
       const species = this.filteredStarterContainers[this.cursor].species;
-      Challenge.applyChallenges(this.scene.gameMode, Challenge.ChallengeType.STARTER_CHOICE, species, isNewPokemonValid, this.scene.gameData.getSpeciesDexAttrProps(species, this.scene.gameData.getSpeciesDefaultDexAttr(species, false, true)), !!(this.starterSpecies.length + (add ? 1 : 0)));
+      Challenge.applyChallenges(this.scene.gameMode, Challenge.ChallengeType.STARTER_CHOICE, species, isNewPokemonValid, this.scene.gameData.getSpeciesDexAttrProps(species, this.scene.gameData.getSpeciesDefaultDexAttr(species, false, true)), !!(this.starterSpecies.length), false, false);
+      isPartyValid = isPartyValid || isNewPokemonValid.value;
     }
 
     /**
@@ -2803,7 +2805,11 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
        * we change to can AddParty value to true since the user has enough cost to choose this pokemon and this pokemon registered too.
        */
       const isValidForChallenge = new Utils.BooleanHolder(true);
-      Challenge.applyChallenges(this.scene.gameMode, Challenge.ChallengeType.STARTER_CHOICE, this.allSpecies[s], isValidForChallenge, this.scene.gameData.getSpeciesDexAttrProps(this.allSpecies[s], this.scene.gameData.getSpeciesDefaultDexAttr(this.allSpecies[s], false, true)), !!(this.starterSpecies.length + (add ? 1 : 0)));
+      if (isPartyValid) { // we have two checks here - one for the party being valid and one for not. This comes from mono type challenges - if the party is valid it will check pokemon's evolutions and forms, and if it's not valid it won't check their evolutions and forms
+        Challenge.applyChallenges(this.scene.gameMode, Challenge.ChallengeType.STARTER_CHOICE, this.allSpecies[s], isValidForChallenge, this.scene.gameData.getSpeciesDexAttrProps(this.allSpecies[s], this.scene.gameData.getSpeciesDefaultDexAttr(this.allSpecies[s], false, true)), !!(this.starterSpecies.length + (add ? 1 : 0)));
+      } else {
+        Challenge.applyChallenges(this.scene.gameMode, Challenge.ChallengeType.STARTER_CHOICE, this.allSpecies[s], isValidForChallenge, this.scene.gameData.getSpeciesDexAttrProps(this.allSpecies[s], this.scene.gameData.getSpeciesDefaultDexAttr(this.allSpecies[s], false, true)), !!(this.starterSpecies.length + (add ? 1 : 0)), false, false);
+      }
 
       const canBeChosen = remainValue >= speciesStarterValue && isValidForChallenge.value;
 
@@ -2892,7 +2898,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     for (let s = 0; s < this.starterSpecies.length; s++) {
       const isValidForChallenge = new Utils.BooleanHolder(true);
       const species = this.starterSpecies[s];
-      Challenge.applyChallenges(this.scene.gameMode, Challenge.ChallengeType.STARTER_CHOICE, species, isValidForChallenge, this.scene.gameData.getSpeciesDexAttrProps(species, this.dexAttrCursor), !!this.starterSpecies.length);
+      Challenge.applyChallenges(this.scene.gameMode, Challenge.ChallengeType.STARTER_CHOICE, species, isValidForChallenge, this.scene.gameData.getSpeciesDexAttrProps(species, this.dexAttrCursor), !!(this.starterSpecies.length), false, false);
       canStart = canStart || isValidForChallenge.value;
     }
     return canStart;


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This PR fixes the bug between the starter select UI with filter #2916 merged in beta and @Opaque02 's Starter UI selection update #1983 .

Most of the bugs were identified with the help of the previous PR contributor, @Opaque02

[bug discussion thread in discord](https://discord.com/channels/1125469663833370665/1265591426851409973)

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
The bugs in question range from mildly annoying ones to very dangerous issues, such as being able to select Pokémon that are not unlocked.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
The bugs are as follows:
- [x] 1. When re-selecting the chosen Pokémon, the remove Pokémon menu does not appear.
- [x] 2. A bug in challenge mode where the "add to party" menu appears for invalid Pokémon.
- [x] 3. A bug where the starter Pokémon is removed from an incorrect position when removing Pokémon.
- [x] 4. When no starter Pokémon is selected, the cursor disappears when pressing the down button on the start button.
- [x] 5. A bug where the 'on' indicator for the ALL filter dropdown remains even when the entire dropdown is not activated.
- [x] 6. A bug where the starter cursor and Pokerus cursor appear outside the screen.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
plan to add videos and images
1. When re-selecting the chosen Pokémon, the remove Pokémon menu does not appear.
- before ( bug )
`remove from party` menu doesn't show.

https://github.com/user-attachments/assets/c435d5af-4f4b-459d-9b5f-7e45cf0ab539


- after ( fixed )
`remove from party` menu show and work properly

https://github.com/user-attachments/assets/8909b9e8-a542-4657-9767-a85d5b057685



2. A bug in challenge mode where the "add to party" menu appears for invalid Pokémon.
- before ( bug )

`add to party` menu show when select invalid pokemon

https://github.com/user-attachments/assets/285c2706-a16d-4c61-b20c-098edd383662


- after ( fixed )
`add to party` menu doesn't show when select invalid pokemon

https://github.com/user-attachments/assets/32211c13-9976-46dd-8e30-e7e57a648b13



3. A bug where the starter Pokémon is removed from an incorrect position when removing Pokémon.
- before ( bug )
When adding Pokémon in the reverse order displayed on the screen, the `starterCursor` is incorrectly removed during `remove from party`.

https://github.com/user-attachments/assets/f62b887c-3cde-4a19-a865-b34205f3f65d


- after ( fixed )
In all other cases, the removal happens correctly during `remove from party`.

https://github.com/user-attachments/assets/7fe11c16-de9e-4bde-8a13-8919b8096625



4. When no starter Pokémon is selected, the cursor disappears when pressing the down button on the start button.
- before ( bug )
If nothing is selected in the starter state and you press the down arrow key on the start button, the UI breaks.

https://github.com/user-attachments/assets/e77f75b0-1277-4ef2-8509-4b94cfb5d45a


- after ( fixed )
If nothing is selected in the starter state and you press the down arrow key on the start button, the cursor moves to the filter.

https://github.com/user-attachments/assets/65c416c1-063b-4a4d-bbe9-1b771ba28a9b



5. A bug where the 'on' indicator for the ALL filter dropdown remains even when the entire dropdown is not activated.
- before ( bug )
When some dropdowns are turned OFF in the filter, ALL remains ON.

https://github.com/user-attachments/assets/68e3d117-758f-4333-aa0c-7de738001e48


- after ( fixed )
When some dropdowns are turned OFF in the filter, ALL will also turn OFF.

https://github.com/user-attachments/assets/67a937b2-fa42-43eb-ba21-d481f8d31365



6. A bug where the starter cursor and Pokerus cursor appear outside the screen.
- before ( bug )
The pokerus cursor and starter cursor outside the screen are visible.

https://github.com/user-attachments/assets/7f39b153-9f4a-4a74-aef1-b9fbf96fde64


- after ( fixed )
The pokerus cursor and starter cursor outside the screen are no longer visible.

https://github.com/user-attachments/assets/81968ae5-b5e6-4796-af08-7239f4e015ba



## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
For the beta branch, all bugs can be reproduced.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
