### PR TITLE
[Bug] Game Stats Sub-Legendary NaN bug for new game files

### DIFF
--- a/src/system/game-stats.ts
+++ b/src/system/game-stats.ts
@@ -58,9 +58,9 @@ export class GameStats {
     this.pokemonCaught = source?.pokemonCaught || 0;
     this.pokemonHatched = source?.pokemonHatched || 0;
     // Currently handled by migration
-    this.subLegendaryPokemonSeen = source?.subLegendaryPokemonSeen;
-    this.subLegendaryPokemonCaught = source?.subLegendaryPokemonCaught;
-    this.subLegendaryPokemonHatched = source?.subLegendaryPokemonHatched;
+    this.subLegendaryPokemonSeen = source?.subLegendaryPokemonSeen || 0;
+    this.subLegendaryPokemonCaught = source?.subLegendaryPokemonCaught || 0;
+    this.subLegendaryPokemonHatched = source?.subLegendaryPokemonHatched || 0;
     this.legendaryPokemonSeen = source?.legendaryPokemonSeen || 0;
     this.legendaryPokemonCaught = source?.legendaryPokemonCaught || 0;
     this.legendaryPokemonHatched = source?.legendaryPokemonHatched || 0;

--- a/src/system/game-stats.ts
+++ b/src/system/game-stats.ts
@@ -58,9 +58,9 @@ export class GameStats {
     this.pokemonCaught = source?.pokemonCaught || 0;
     this.pokemonHatched = source?.pokemonHatched || 0;
     // Currently handled by migration
-    this.subLegendaryPokemonSeen = source?.subLegendaryPokemonSeen || 0;
-    this.subLegendaryPokemonCaught = source?.subLegendaryPokemonCaught || 0;
-    this.subLegendaryPokemonHatched = source?.subLegendaryPokemonHatched || 0;
+    this.subLegendaryPokemonSeen = source?.subLegendaryPokemonSeen ?? 0;
+    this.subLegendaryPokemonCaught = source?.subLegendaryPokemonCaught ?? 0;
+    this.subLegendaryPokemonHatched = source?.subLegendaryPokemonHatched ?? 0;
     this.legendaryPokemonSeen = source?.legendaryPokemonSeen || 0;
     this.legendaryPokemonCaught = source?.legendaryPokemonCaught || 0;
     this.legendaryPokemonHatched = source?.legendaryPokemonHatched || 0;

--- a/src/test/items/leftovers.test.ts
+++ b/src/test/items/leftovers.test.ts
@@ -25,7 +25,7 @@ describe("Items - Leftovers", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(overrides, "BATTLE_TYPE_OVERRIDE", "get").mockReturnValue("single");
     vi.spyOn(overrides, "STARTING_LEVEL_OVERRIDE", "get").mockReturnValue(2000);
     vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.UNNERVE);
     vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH]);

--- a/src/test/items/leftovers.test.ts
+++ b/src/test/items/leftovers.test.ts
@@ -25,7 +25,7 @@ describe("Items - Leftovers", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    vi.spyOn(overrides, "BATTLE_TYPE_OVERRIDE", "get").mockReturnValue("single");
+    vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
     vi.spyOn(overrides, "STARTING_LEVEL_OVERRIDE", "get").mockReturnValue(2000);
     vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.UNNERVE);
     vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH]);


### PR DESCRIPTION
## What are the changes?
This PR addresses the bug reported here: https://github.com/pagefaultgames/pokerogue/issues/3076 

## What did change?
Added a || 0 to the sub-legendary values stored in system/game-stats.ts

### Screenshots/Videos
I purposely edited game-stats-ui-handler to show all stat names for easier error checking. 
![image](https://github.com/user-attachments/assets/709b7ae6-0cbf-441c-87f6-bf1f70d37943)

## How to test the changes?
This bug only appears on a completely new user file. 
The tester should immediately go to the 'Game Stats' page in the menu after gender selection. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
