### PR TITLE
[BUG] Not being able to see new details of caught Pokemon

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -4917,7 +4917,6 @@ export class AttemptCapturePhase extends PokemonPhase {
                   }
                 },
                 onComplete: () => {
-                  this.scene.gameData.setPokemonCaught(pokemon);
                   this.catch();
                 }
               });
@@ -5014,7 +5013,7 @@ export class AttemptCapturePhase extends PokemonPhase {
           }
         });
       };
-      Promise.all([pokemon.hideInfo()]).then(() => {
+      Promise.all([pokemon.hideInfo(), this.scene.gameData.setPokemonCaught(pokemon)]).then(() => {
         if (this.scene.getParty().length === 6) {
           const promptRelease = () => {
             this.scene.ui.showText(i18next.t("battle:partyFull", { pokemonName: getPokemonNameWithAffix(pokemon) }), null, () => {


### PR DESCRIPTION
## What are the changes?
In PR #2921 setPokemonCaught(pokemon) was applied before Pokemon Info Container was generated, which meant that the save data would be updated with the new pokemon and so, the game was unable to compare and contrast the newly caught Pokemon to the player's save data correctly. This moves setPokemonCaught to its original location. 

## Why am I doing these changes?
It was my mess. I moved setPokemonCaught upwards for reasons that no longer apply to this PR.

### Screenshots/Videos
https://github.com/user-attachments/assets/39ccd60e-535d-4396-a978-60286085fe42

## How to test the changes?
Catch Pokemon with a full party / Catch a new Pokemon

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
