### PR TITLE
[Bug] fix and condition of unlocks filter in starter select UI

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1949,7 +1949,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
       const fitsGen =   this.filterBar.getVals(DropDownColumn.GEN).includes(container.species.generation);
       const fitsType =  this.filterBar.getVals(DropDownColumn.TYPES).some(type => container.species.isOfType((type as number) - 1));
-      const fitsUnlocks = this.filterBar.getVals(DropDownColumn.UNLOCKS).some(variant => {
+      const fitsShiny = this.filterBar.getVals(DropDownColumn.UNLOCKS).some(variant => {
         if (variant === "SHINY3") {
           return isVariant3Caught;
         } else if (variant === "SHINY2") {
@@ -1960,7 +1960,10 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
           return isCaught && !isVariantCaught && !isVariant2Caught && !isVariant3Caught;
         } else if (variant === "UNCAUGHT") {
           return isUncaught;
-        } else if (variant === "PASSIVEUNLOCKED") {
+        }
+      });
+      const fitsPassive = this.filterBar.getVals(DropDownColumn.UNLOCKS).some(variant => {
+        if (variant === "PASSIVEUNLOCKED") {
           return isPassiveUnlocked;
         } else if (variant === "PASSIVELOCKED") {
           return !isPassiveUnlocked;
@@ -1978,7 +1981,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         }
       });
 
-      if (fitsGen && fitsType && fitsUnlocks && fitsWin) {
+      if (fitsGen && fitsType && fitsShiny && fitsPassive && fitsWin) {
         this.filteredStarterContainers.push(container);
       }
     });


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This is a PR that resolves the issue where the shiny dropdown and passive dropdown operate with an "or" condition in the existing unlocks filter.
[related discord thread](https://discord.com/channels/1125469663833370665/1265872164364615680)

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
The existing method, as shown in the attached photo, operates in a much less intuitive manner.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
I modified the conditions that were checked with 'or' in the unlocks filter to be separated into shiny and passive, and processed the two conditions with 'and'.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
- before
Both normal Pokémon and passive unlocked Pokémon are searched using an "or" condition. This is non-intuitive.

<img width="454" alt="1" src="https://github.com/user-attachments/assets/cce27baf-1fec-4817-94c9-fc804c31e769">


- after
1.  Only Pokémon that satisfy both normal Pokémon and passive unlocked Pokémon conditions through an "and" condition are searched.
<img width="810" alt="2" src="https://github.com/user-attachments/assets/8fd0a77a-0976-4ffe-a9f6-0cfedaa54d26">

2. works on other cases
<img width="456" alt="3" src="https://github.com/user-attachments/assets/981502d3-a7de-4249-ba7c-04643fc8179d">


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
