### PR TITLE
[Bug] Prevent evolution causing a swap from the second ability to the HA

### DIFF
--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -147,7 +147,7 @@ export abstract class PokemonSpeciesForm {
     this.height = height;
     this.weight = weight;
     this.ability1 = ability1;
-    this.ability2 = ability2;
+    this.ability2 = ability2 === Abilities.NONE ? ability1 : ability2;
     this.abilityHidden = abilityHidden;
     this.baseTotal = baseTotal;
     this.baseStats = [ baseHp, baseAtk, baseDef, baseSpatk, baseSpdef, baseSpd ];

--- a/src/evolution-phase.ts
+++ b/src/evolution-phase.ts
@@ -219,7 +219,7 @@ export class EvolutionPhase extends Phase {
                         this.scene.time.delayedCall(900, () => {
                           evolutionHandler.canCancel = false;
 
-                          this.pokemon.evolve(this.evolution).then(() => {
+                          this.pokemon.evolve(this.evolution, this.pokemon.species).then(() => {
                             const levelMoves = this.pokemon.getLevelMoves(this.lastLevel + 1, true);
                             for (const lm of levelMoves) {
                               this.scene.unshiftPhase(new LearnMovePhase(this.scene, this.scene.getParty().indexOf(this.pokemon), lm[1]));

--- a/src/test/evolution.test.ts
+++ b/src/test/evolution.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import Phaser from "phaser";
+import GameManager from "#app/test/utils/gameManager";
+import { Species } from "#app/enums/species.js";
+import { Abilities } from "#app/enums/abilities.js";
+import Overrides from "#app/overrides";
+import { pokemonEvolutions } from "#app/data/pokemon-evolutions.js";
+
+describe("Evolution", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+  const TIMEOUT = 1000 * 20;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+
+    vi.spyOn(Overrides, "BATTLE_TYPE_OVERRIDE", "get").mockReturnValue("single");
+
+    vi.spyOn(Overrides, "OPP_SPECIES_OVERRIDE", "get").mockReturnValue(Species.MAGIKARP);
+    vi.spyOn(Overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.BALL_FETCH);
+
+    vi.spyOn(Overrides, "STARTING_LEVEL_OVERRIDE", "get").mockReturnValue(60);
+  });
+
+  it("should keep hidden ability after evolving", async () => {
+    await game.runToSummon([Species.EEVEE, Species.TRAPINCH]);
+
+    const eevee = game.scene.getParty()[0];
+    const trapinch = game.scene.getParty()[1];
+    eevee.abilityIndex = 2;
+    trapinch.abilityIndex = 2;
+
+    eevee.evolve(pokemonEvolutions[Species.EEVEE][6], eevee.getSpeciesForm());
+    expect(eevee.abilityIndex).toBe(2);
+
+    trapinch.evolve(pokemonEvolutions[Species.TRAPINCH][0], trapinch.getSpeciesForm());
+    expect(trapinch.abilityIndex).toBe(1);
+  }, TIMEOUT);
+
+  it("should keep same ability slot after evolving", async () => {
+    await game.runToSummon([Species.BULBASAUR, Species.CHARMANDER]);
+
+    const bulbasaur = game.scene.getParty()[0];
+    const charmander = game.scene.getParty()[1];
+    bulbasaur.abilityIndex = 0;
+    charmander.abilityIndex = 1;
+
+    bulbasaur.evolve(pokemonEvolutions[Species.BULBASAUR][0], bulbasaur.getSpeciesForm());
+    expect(bulbasaur.abilityIndex).toBe(0);
+
+    charmander.evolve(pokemonEvolutions[Species.CHARMANDER][0], charmander.getSpeciesForm());
+    expect(charmander.abilityIndex).toBe(1);
+  }, TIMEOUT);
+
+  it("should handle illegal abilityIndex values", async () => {
+    await game.runToSummon([Species.SQUIRTLE]);
+
+    const squirtle = game.scene.getPlayerPokemon();
+    squirtle.abilityIndex = 5;
+
+    squirtle.evolve(pokemonEvolutions[Species.SQUIRTLE][0], squirtle.getSpeciesForm());
+    expect(squirtle.abilityIndex).toBe(0);
+  }, TIMEOUT);
+
+  it("should handle nincada's unique evolution", async () => {
+    await game.runToSummon([Species.NINCADA]);
+
+    const nincada = game.scene.getPlayerPokemon();
+    nincada.abilityIndex = 2;
+
+    nincada.evolve(pokemonEvolutions[Species.NINCADA][0], nincada.getSpeciesForm());
+    const ninjask = game.scene.getParty()[0];
+    const shedinja = game.scene.getParty()[1];
+    expect(ninjask.abilityIndex).toBe(2);
+    expect(shedinja.abilityIndex).toBe(1);
+  }, TIMEOUT);
+});

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1574,9 +1574,10 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
                   break;
                 }
               } else if (newAbilityIndex === 1) {
-                if (abilityAttr & (this.lastSpecies.ability2 ? AbilityAttr.ABILITY_2 : AbilityAttr.ABILITY_HIDDEN)) {
-                  break;
+                if (this.lastSpecies.ability1 === this.lastSpecies.ability2) {
+                  newAbilityIndex = (newAbilityIndex + 1) % abilityCount;
                 }
+                break;
               } else {
                 if (abilityAttr & AbilityAttr.ABILITY_HIDDEN) {
                   break;


### PR DESCRIPTION
## What are the changes?
If a Pokémon with their second ability evolves, it will swap to its first ability if the evolution has no second ability, instead of improperly "upgrading" to its hidden ability.

## Why am I doing these changes?
I noticed a bug report about the issue
https://discord.com/channels/1125469663833370665/1254274565627187211

cf [Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Ability#Mechanics)
> In technical terms, a species' Abilities may be thought of as having separate slots, with an individual Pokémon's non-Hidden slot determined by its [personality value](https://bulbapedia.bulbagarden.net/wiki/Personality_value). For example, an [Eevee](https://bulbapedia.bulbagarden.net/wiki/Eevee_(Pok%C3%A9mon)) — with two non-Hidden Abilities — has [Run Away](https://bulbapedia.bulbagarden.net/wiki/Run_Away_(Ability)) for its first non-Hidden slot, [Adaptability](https://bulbapedia.bulbagarden.net/wiki/Adaptability_(Ability)) for its second, and [Anticipation](https://bulbapedia.bulbagarden.net/wiki/Anticipation_(Ability)) for its Hidden Ability slot. [Vaporeon](https://bulbapedia.bulbagarden.net/wiki/Vaporeon_(Pok%C3%A9mon)) — with only one non-Hidden Ability — can be considered to have [Water Absorb](https://bulbapedia.bulbagarden.net/wiki/Water_Absorb_(Ability)) for both non-Hidden slots. When a Pokémon evolves, its Ability slot remains the same.

## What did change?
`src/data/pokemon-species.ts`: If a Pokémon doesn't have a second ability, its second ability is set to be the same as its first ability.
The `PlayerPokemon.evolve()` function is updated to account for Pokémon with 3 abilities evolving into a Pokémon with 2 abilities, including an added parameter `preEvolution: PokemonSpeciesForm`. Each instance of the function being called is updated accordingly.
Tests were added for the `evolve()` function.
The starter select UI was updated to account for the duplicated abilities.

### Screenshots/Videos

https://github.com/user-attachments/assets/93f4e5e6-1b94-47eb-905c-3b49c5373bba

## How to test the changes?
Start a run with an Eevee with Adaptability (its second ability) and evolve it with a Fire/Water/Thunder stone. It should now have its first ability (Flash Fire/Water Absorb/Volt Absorb) rather than its hidden ability (Guts/Hydration/Quick Feet).

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?