### PR TITLE
[Bug] Fixed form names that have a space not showing up correctly in starter select

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -2621,7 +2621,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
           }) as StarterMoveset;
 
         const speciesForm = getPokemonSpeciesForm(species.speciesId, formIndex);
-        const formText = Utils.capitalizeString(species?.forms[formIndex]?.formKey, "_", false, false);
+        const formText = Utils.capitalizeString(species?.forms[formIndex]?.formKey, "-", false, false);
 
         const speciesName = Utils.capitalizeString(Species[species.speciesId], "_", true, false);
 


### PR DESCRIPTION
## What are the changes?
When #3030 went into beta, it changed how the form text shows up on the starter select screen. This PR should fix it

## Why am I doing these changes?
With PR 3030, when trying to display the form key on the starter select, it splits the form key (if available) as per [this code](https://github.com/Kiriox94/pokerogue/blob/da262d2eb70adfe45944a4544d3d6a7eb9a27a7f/src/ui/starter-select-ui-handler.ts#L2399). However, "_" should be used to split the pokemon name (for example on line 2401), but the form keys that have a space are actually have a delimiter of "-". This meant when it tried to split by "_" to get the i18 value, it didn't exist, causing issues.

## What did change?
I changed a single instance for a text split to use a delimiter of "_" to use a delimiter of "-".

### Screenshots/Videos
This is the current behaviour on live (beta) with various pokemon:

Pikachu's cosplay form:
![image](https://github.com/user-attachments/assets/23f85f72-6f9a-483d-81bc-7a08c4a52df3)

Here is sandshrew with no form
![image](https://github.com/user-attachments/assets/d75538b7-585d-4328-aa71-29491898a067)

Here is unown ! form
![image](https://github.com/user-attachments/assets/30ffe0be-d8d3-488a-b9c8-3dd9b7914feb)

Shellos: 
![image](https://github.com/user-attachments/assets/493aca78-9673-4af8-93ea-d6a993234206)

High Plains scatterbug:
![image](https://github.com/user-attachments/assets/1e4b029f-415f-4d03-a3c1-9093ff3f9d3c)

Battle bond froakie:
![image](https://github.com/user-attachments/assets/c0b4db4c-6d09-45da-a10f-4d637212b989)

This is an update with this PR:

As you can see, pikachu's form with a space has the correct value:
![image](https://github.com/user-attachments/assets/78451976-103d-4d60-be7e-68a88f322f2a)

Here is sandshrew with no form
![image](https://github.com/user-attachments/assets/faf2eccd-ca66-40e9-b597-f068ac558370)

Here is unown ! form
![image](https://github.com/user-attachments/assets/d6c6d82a-6462-4b15-8714-883de9ff8f98)

Shellos: 
![image](https://github.com/user-attachments/assets/f8d1bb00-557b-4fba-876b-f1007ab0e56e)

High Plains scatterbug:
![image](https://github.com/user-attachments/assets/a142b701-4090-4a50-9fa4-7848006e7274)

Battle bond froakie:
![image](https://github.com/user-attachments/assets/0b239055-2959-45bf-b0f7-7337ccb32a65)

## How to test the changes?
Test out various forms on the starter screen. If you don't have any forms, you can either import the fully unlocked save file from [here](https://github.com/pagefaultgames/pokerogue/tree/main/src/test/utils/saves), or use the unlock all option in the menu (menu->manage data->unlock all), which will unlock all the forms for all pokemon.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
