### PR TITLE
[Bug] Caught Pokemon Summary-Modifier Display Fix

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -5035,12 +5035,11 @@ export class AttemptCapturePhase extends PokemonPhase {
               this.scene.pokemonInfoContainer.makeRoomForConfirmUi(1, true);
               this.scene.ui.setMode(Mode.CONFIRM, () => {
                 const newPokemon = this.scene.addPlayerPokemon(pokemon.species, pokemon.level, pokemon.abilityIndex, pokemon.formIndex, pokemon.gender, pokemon.shiny, pokemon.variant, pokemon.ivs, pokemon.nature, pokemon);
-                newPokemon.battleInfo.player = false;
                 this.scene.ui.setMode(Mode.SUMMARY, newPokemon, 0, SummaryUiMode.DEFAULT, () => {
                   this.scene.ui.setMode(Mode.MESSAGE).then(() => {
                     promptRelease();
                   });
-                });
+                }, false);
               }, () => {
                 this.scene.ui.setMode(Mode.PARTY, PartyUiMode.RELEASE, this.fieldIndex, (slotIndex: integer, _option: PartyOption) => {
                   this.scene.ui.setMode(Mode.MESSAGE).then(() => {

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -5035,6 +5035,7 @@ export class AttemptCapturePhase extends PokemonPhase {
               this.scene.pokemonInfoContainer.makeRoomForConfirmUi(1, true);
               this.scene.ui.setMode(Mode.CONFIRM, () => {
                 const newPokemon = this.scene.addPlayerPokemon(pokemon.species, pokemon.level, pokemon.abilityIndex, pokemon.formIndex, pokemon.gender, pokemon.shiny, pokemon.variant, pokemon.ivs, pokemon.nature, pokemon);
+                newPokemon.battleInfo.player = false;
                 this.scene.ui.setMode(Mode.SUMMARY, newPokemon, 0, SummaryUiMode.DEFAULT, () => {
                   this.scene.ui.setMode(Mode.MESSAGE).then(() => {
                     promptRelease();

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -93,6 +93,7 @@ export default class SummaryUiHandler extends UiHandler {
   private moveCursorBlinkTimer: Phaser.Time.TimerEvent;
 
   private pokemon: PlayerPokemon;
+  private playerParty: boolean;
   private newMove: Move;
   private moveSelectFunction: Function;
   private transitioning: boolean;
@@ -272,7 +273,7 @@ export default class SummaryUiHandler extends UiHandler {
 
     this.pokemon = args[0] as PlayerPokemon;
     this.summaryUiMode = args.length > 1 ? args[1] as SummaryUiMode : SummaryUiMode.DEFAULT;
-
+    this.playerParty = args[4] ?? true;
     this.scene.ui.bringToTop(this.summaryContainer);
 
     this.summaryContainer.setVisible(true);
@@ -853,7 +854,7 @@ export default class SummaryUiHandler extends UiHandler {
       });
 
       const itemModifiers = (this.scene.findModifiers(m => m instanceof PokemonHeldItemModifier
-          && m.pokemonId === this.pokemon.id, this.pokemon.battleInfo.player) as PokemonHeldItemModifier[])
+          && m.pokemonId === this.pokemon.id, this.playerParty) as PokemonHeldItemModifier[])
         .sort(modifierSortFunc);
 
       itemModifiers.forEach((item, i) => {

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -853,7 +853,7 @@ export default class SummaryUiHandler extends UiHandler {
       });
 
       const itemModifiers = (this.scene.findModifiers(m => m instanceof PokemonHeldItemModifier
-          && m.pokemonId === this.pokemon.id, true) as PokemonHeldItemModifier[])
+          && m.pokemonId === this.pokemon.id, this.pokemon.battleInfo.player) as PokemonHeldItemModifier[])
         .sort(modifierSortFunc);
 
       itemModifiers.forEach((item, i) => {

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -94,6 +94,7 @@ export default class SummaryUiHandler extends UiHandler {
 
   private pokemon: PlayerPokemon;
   private playerParty: boolean;
+  /**This is set to false when checking the summary of a freshly caught Pokemon as it is not part of a player's party yet but still needs to display its items**/
   private newMove: Move;
   private moveSelectFunction: Function;
   private transitioning: boolean;
@@ -271,6 +272,13 @@ export default class SummaryUiHandler extends UiHandler {
   show(args: any[]): boolean {
     super.show(args);
 
+    /* args[] information
+    * args[0] : the Pokemon displayed in the Summary-UI
+    * args[1] : the summaryUiMode (defaults to 0)
+    * args[2] : the start page (defaults to Page.PROFILE)
+    * args[3] : contains the function executed when the user exits out of Summary UI
+    * args[4] : optional boolean used to determine if the Pokemon is part of the player's party or not (defaults to true, necessary for PR #2921 to display all relevant information)
+    */
     this.pokemon = args[0] as PlayerPokemon;
     this.summaryUiMode = args.length > 1 ? args[1] as SummaryUiMode : SummaryUiMode.DEFAULT;
     this.playerParty = args[4] ?? true;


### PR DESCRIPTION
## What are the changes?
Modifiers were not displaying on the caught pokemon's summary because of how the game stores and determines possession of modifiers. summary-ui-handler.ts now uses the pokemon's ownership boolean (pokemon.battleInfo.player) to determine where to look for modifiers. 

## Why am I doing these changes?
As a player, I would like to see the modifiers of my caught pokemon + my PR, my responsibility 

## What did change?
- Temporary Pokemon object has tempPokemon.battleInfo.player set to false in phases.ts
- summary-ui-handler.ts uses pokemon.battleInfo.player as an argument in findModifiers()

### Screenshots/Videos

https://github.com/user-attachments/assets/e12af32d-a687-4d91-954b-2f7bdc1f642f

## How to test the changes?
Catch a wild Pokemon with modifiers with a full party and press the Summary Option

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
