### PR TITLE
[Misc] Remove redundant BattlerTag sub-classes

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -1414,30 +1414,6 @@ export class CritBoostTag extends BattlerTag {
   }
 }
 
-export class AlwaysCritTag extends BattlerTag {
-  constructor(sourceMove: Moves) {
-    super(BattlerTagType.ALWAYS_CRIT, BattlerTagLapseType.TURN_END, 2, sourceMove);
-  }
-}
-
-export class IgnoreAccuracyTag extends BattlerTag {
-  constructor(sourceMove: Moves) {
-    super(BattlerTagType.IGNORE_ACCURACY, BattlerTagLapseType.TURN_END, 2, sourceMove);
-  }
-}
-
-export class AlwaysGetHitTag extends BattlerTag {
-  constructor(sourceMove: Moves) {
-    super(BattlerTagType.ALWAYS_GET_HIT, BattlerTagLapseType.PRE_MOVE, 1, sourceMove);
-  }
-}
-
-export class ReceiveDoubleDamageTag extends BattlerTag {
-  constructor(sourceMove: Moves) {
-    super(BattlerTagType.RECEIVE_DOUBLE_DAMAGE, BattlerTagLapseType.PRE_MOVE, 1, sourceMove);
-  }
-}
-
 export class SaltCuredTag extends BattlerTag {
   private sourceIndex: number;
 
@@ -1770,15 +1746,13 @@ export function getBattlerTag(tagType: BattlerTagType, turnCount: number, source
   case BattlerTagType.CRIT_BOOST:
     return new CritBoostTag(tagType, sourceMove);
   case BattlerTagType.ALWAYS_CRIT:
-    return new AlwaysCritTag(sourceMove);
+  case BattlerTagType.IGNORE_ACCURACY:
+    return new BattlerTag(tagType, BattlerTagLapseType.TURN_END, 2, sourceMove);
   case BattlerTagType.NO_CRIT:
     return new BattlerTag(tagType, BattlerTagLapseType.AFTER_MOVE, turnCount, sourceMove);
-  case BattlerTagType.IGNORE_ACCURACY:
-    return new IgnoreAccuracyTag(sourceMove);
   case BattlerTagType.ALWAYS_GET_HIT:
-    return new AlwaysGetHitTag(sourceMove);
   case BattlerTagType.RECEIVE_DOUBLE_DAMAGE:
-    return new ReceiveDoubleDamageTag(sourceMove);
+    return new BattlerTag(tagType, BattlerTagLapseType.PRE_MOVE, 1, sourceMove);
   case BattlerTagType.BYPASS_SLEEP:
     return new BattlerTag(BattlerTagType.BYPASS_SLEEP, BattlerTagLapseType.TURN_END, turnCount, sourceMove);
   case BattlerTagType.IGNORE_FLYING:


### PR DESCRIPTION
## What are the changes?
There are no user-facing changes.

## Why am I doing these changes?
These sub-classes are redundant as the only thing they do is call the constructor of their super-class.

## What did change?
4 `BattlerTag` sub-classes were removed, and the `getBattlerTag()` function was updated accordingly.

## How to test the changes?
`npm run test`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~[ ] Have I tested the changes (manually)?~
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
