### PR TITLE
[Misc] Remove redundant `ChargingTag`

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -497,12 +497,6 @@ export class FrenzyTag extends BattlerTag {
   }
 }
 
-export class ChargingTag extends BattlerTag {
-  constructor(sourceMove: Moves, sourceId: number) {
-    super(BattlerTagType.CHARGING, BattlerTagLapseType.CUSTOM, 1, sourceMove, sourceId);
-  }
-}
-
 export class EncoreTag extends BattlerTag {
   public moveId: Moves;
 
@@ -1696,7 +1690,7 @@ export function getBattlerTag(tagType: BattlerTagType, turnCount: number, source
   case BattlerTagType.FRENZY:
     return new FrenzyTag(turnCount, sourceMove, sourceId);
   case BattlerTagType.CHARGING:
-    return new ChargingTag(sourceMove, sourceId);
+    return new BattlerTag(tagType, BattlerTagLapseType.CUSTOM, 1, sourceMove, sourceId);
   case BattlerTagType.ENCORE:
     return new EncoreTag(sourceId);
   case BattlerTagType.HELPING_HAND:


### PR DESCRIPTION
## What are the changes?
There are no user facing changes.

## Why am I doing these changes?
Found another redundant `BattlerTag` class that only called its super-class's constructor.

## What did change?
The `ChargingTag` class was removed and its use replaced with use of its super-class instead.

## How to test the changes?
Use Dig or some other move that uses `ChargeAttr`.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
