### PR TITLE
[Bug] Self effect moves fix for Shield Dust

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -974,7 +974,7 @@ export class MoveEffectAttr extends MoveAttr {
     const moveChance = new Utils.NumberHolder(move.chance);
     applyAbAttrs(MoveEffectChanceMultiplierAbAttr, user, null, moveChance, move, target, selfEffect, showAbility);
     if (!selfEffect) {
-      applyPreDefendAbAttrs(IgnoreMoveEffectsAbAttr,target,user,null,null, moveChance);
+      applyPreDefendAbAttrs(IgnoreMoveEffectsAbAttr, target, user, null, null, moveChance);
     }
     return moveChance.value;
   }

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -973,7 +973,9 @@ export class MoveEffectAttr extends MoveAttr {
   getMoveChance(user: Pokemon, target: Pokemon, move: Move, selfEffect?: Boolean, showAbility?: Boolean): integer {
     const moveChance = new Utils.NumberHolder(move.chance);
     applyAbAttrs(MoveEffectChanceMultiplierAbAttr, user, null, moveChance, move, target, selfEffect, showAbility);
-    applyPreDefendAbAttrs(IgnoreMoveEffectsAbAttr,target,user,null,null, moveChance);
+    if (!selfEffect) {
+      applyPreDefendAbAttrs(IgnoreMoveEffectsAbAttr,target,user,null,null, moveChance);
+    }
     return moveChance.value;
   }
 }


### PR DESCRIPTION
Moves like Meteor Mash had their self effects disabled by Shield Dust.

## What are the changes?
Added a condition to the application of IgnoreMoveEffectsAbAttr.

## Why am I doing these changes?
[Bug report at Discord](https://discord.com/channels/1125469663833370665/1265299187378028586)

## What did change?
Moves with self effects no longer affected by Shield Dust. 

