### PR TITLE
[Feature] [Ability] Shield Dust and Sparkling Aria interaction

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2148,7 +2148,8 @@ export class HealStatusEffectAttr extends MoveEffectAttr {
     if (!super.apply(user, target, move, args)) {
       return false;
     }
-// Special edge case for shield dust blocking Sparkling Aria curing burn
+
+    // Special edge case for shield dust blocking Sparkling Aria curing burn
     const moveTargets = getMoveTargets(user, move.id);
     if (target.hasAbilityWithAttr(IgnoreMoveEffectsAbAttr) && move.id === Moves.SPARKLING_ARIA && moveTargets.targets.length === 1) {
       return false;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2148,7 +2148,7 @@ export class HealStatusEffectAttr extends MoveEffectAttr {
     if (!super.apply(user, target, move, args)) {
       return false;
     }
-
+// Special edge case for shield dust blocking Sparkling Aria curing burn
     const moveTargets = getMoveTargets(user, move.id);
     if (target.hasAbilityWithAttr(IgnoreMoveEffectsAbAttr) && move.id === Moves.SPARKLING_ARIA && moveTargets.targets.length === 1) {
       return false;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2149,6 +2149,11 @@ export class HealStatusEffectAttr extends MoveEffectAttr {
       return false;
     }
 
+    const moveTargets = getMoveTargets(user, move.id);
+    if (target.hasAbilityWithAttr(IgnoreMoveEffectsAbAttr) && move.id === Moves.SPARKLING_ARIA && moveTargets.targets.length === 1) {
+      return false;
+    }
+
     const pokemon = this.selfTarget ? user : target;
     if (pokemon.status && this.effects.includes(pokemon.status.effect)) {
       pokemon.scene.queueMessage(getStatusEffectHealText(pokemon.status.effect, getPokemonNameWithAffix(pokemon)));


### PR DESCRIPTION
## What are the changes?
Shield Dust now prevents its user's burn being cured by Sparkling Aria if it is the only target of the attack.

## Why am I doing these changes?
It's one of Shield Dust edge case interactions. With this the ability should be complete, with the exception of Secret Power secondary effect nullification, since Secret Power has not been fully implemented yet.

## What did change?
Added a condition to the class HealStatusEffectAttr, to make it false if all conditions are met: 
Shield Dust user is targeted by Sparkling Aria and it's the only target.

### Screenshots/Videos

https://github.com/user-attachments/assets/2e7fb004-22ce-49e3-9654-c8131dd80283

https://github.com/user-attachments/assets/aaa3beb5-c7b0-4da8-8f1c-09f9b1923466

https://github.com/user-attachments/assets/dbf7ef66-6d9f-4341-841a-9dddb900198f

## How to test the changes?
With a single target, burn a Shield Dust user, then use Sparkling Aria, should not heal the burn.
With multiple targets, burn a Shield Dust user, then use Sparkling Aria, burn should be healed.