### PR TITLE
[Hotfix] Fix Pokemon in pre-patch saves swapping abilities

### DIFF
--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -41,6 +41,7 @@ import { Moves } from "#enums/moves";
 import { PlayerGender } from "#enums/player-gender";
 import { Species } from "#enums/species";
 import { applyChallenges, ChallengeType } from "#app/data/challenge.js";
+import { Abilities } from "#app/enums/abilities.js";
 
 export const defaultStarterSpecies: Species[] = [
   Species.BULBASAUR, Species.CHARMANDER, Species.SQUIRTLE,
@@ -851,6 +852,15 @@ export class GameData {
       const handleSessionData = async (sessionDataStr: string) => {
         try {
           const sessionData = this.parseSessionData(sessionDataStr);
+          for (let i = 0; i <= 5; i++) {
+            if (sessionData.party[i]?.abilityIndex === 1) {
+              if (allSpecies[sessionData.party[i].species].ability1 === allSpecies[sessionData.party[i].species].ability2 &&
+              allSpecies[sessionData.party[i].species].abilityHidden !== Abilities.NONE &&
+              allSpecies[sessionData.party[i].species].abilityHidden !== allSpecies[sessionData.party[i].species].ability1) {
+                sessionData.party[i].abilityIndex = 2;
+              }
+            }
+          }
           resolve(sessionData);
         } catch (err) {
           reject(err);


### PR DESCRIPTION
## What are the changes?
Pokémon that had their Hidden Ability swapped to their normal ability when loading a save will now have their ability swapped back to their Hidden Ability again after loading the save.

## Why am I doing these changes?
Pokémon were improperly swapping abilities upon loading a save from before the patch.

## What did change?
When loading a session save, check each Pokémon in the party to see if it used to have its Hidden Ability (`abilityIndex === 1`) and swap back to it in the new scheme (`abilityIndex = 2`).

## How to test the changes?
Modify Bulbasaur's second ability to be Ball Fetch (or anything else that's different from its already existing abilities) in `src/data/pokemon-species.ts` and create a new run with a Bulbasaur using that fake ability. Then after exiting to the menu, change Bulbasaur's second ability back to `NONE` and reload the game. Load the save and see that Bulbasaur's ability is now its Hidden Ability Chlorophyll.

## Checklist
- ~[ ] **I'm using `beta` as my base branch**~
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
