### PR TITLE
[Bug] Tinted Pokeball for Pokemon with only 1 ability

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3097,6 +3097,17 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   getBattleInfo(): BattleInfo {
     return this.battleInfo;
   }
+
+  /**
+   * Checks whether or not the Pokemon's root form has the same ability
+   * @param abilityIndex the given ability index we are checking
+   * @returns true if the abilities are the same
+   */
+  hasSameAbilityInRootForm(abilityIndex: number): boolean {
+    const currentAbilityIndex = this.abilityIndex;
+    const rootForm = getPokemonSpecies(this.species.getRootSpeciesId());
+    return rootForm.getAbility(abilityIndex) === rootForm.getAbility(currentAbilityIndex);
+  }
 }
 
 export default interface Pokemon {

--- a/src/ui/battle-info.ts
+++ b/src/ui/battle-info.ts
@@ -346,18 +346,18 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
       // Check if Player owns all genders and forms of the Pokemon
       const missingDexAttrs = ((dexEntry.caughtAttr & opponentPokemonDexAttr) < opponentPokemonDexAttr);
 
-      /**
-       * If the opposing Pokemon only has 1 normal ability and is using the hidden ability it should have the same behavior
-       * if it had 2 normal abilities. This code checks if that is the case and uses the correct opponent Pokemon abilityIndex (2)
-       * for calculations so it aligns with where the hidden ability is stored in the starter data's abilityAttr (4)
-       */
-      const opponentPokemonOneNormalAbility = (pokemon.species.getAbilityCount() === 2);
-      const opponentPokemonAbilityIndex = (opponentPokemonOneNormalAbility && pokemon.abilityIndex === 1) ? 2 : pokemon.abilityIndex;
-      const opponentPokemonAbilityAttr = Math.pow(2, opponentPokemonAbilityIndex);
+      const ownedAbilityAttrs = pokemon.scene.gameData.starterData[pokemon.species.getRootSpeciesId()].abilityAttr;
 
-      const rootFormHasHiddenAbility = pokemon.scene.gameData.starterData[pokemon.species.getRootSpeciesId()].abilityAttr & opponentPokemonAbilityAttr;
+      let playerOwnsThisAbility = false;
+      // Check if the player owns the ability
+      if ((ownedAbilityAttrs & 1) > 0 && pokemon.hasSameAbilityInRootForm(0)) {
+        playerOwnsThisAbility = true;
+      }
+      if ((ownedAbilityAttrs & 2) > 0 && pokemon.hasSameAbilityInRootForm(1)) {
+        playerOwnsThisAbility = true;
+      }
 
-      if (missingDexAttrs || !rootFormHasHiddenAbility) {
+      if (missingDexAttrs || !playerOwnsThisAbility) {
         this.ownedIcon.setTint(0x808080);
       }
 

--- a/src/ui/battle-info.ts
+++ b/src/ui/battle-info.ts
@@ -11,6 +11,7 @@ import { BattleStat } from "#app/data/battle-stat";
 import BattleFlyout from "./battle-flyout";
 import { WindowVariant, addWindow } from "./ui-theme";
 import i18next from "i18next";
+import { AbilityAttr } from "#app/system/game-data.js";
 
 const battleStatOrder = [ BattleStat.ATK, BattleStat.DEF, BattleStat.SPATK, BattleStat.SPDEF, BattleStat.ACC, BattleStat.EVA, BattleStat.SPD ];
 
@@ -349,11 +350,14 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
       const ownedAbilityAttrs = pokemon.scene.gameData.starterData[pokemon.species.getRootSpeciesId()].abilityAttr;
 
       let playerOwnsThisAbility = false;
-      // Check if the player owns the ability
-      if ((ownedAbilityAttrs & 1) > 0 && pokemon.hasSameAbilityInRootForm(0)) {
+      // Check if the player owns ability for the root form
+      if ((ownedAbilityAttrs & AbilityAttr.ABILITY_1) > 0 && pokemon.hasSameAbilityInRootForm(0)) {
         playerOwnsThisAbility = true;
       }
-      if ((ownedAbilityAttrs & 2) > 0 && pokemon.hasSameAbilityInRootForm(1)) {
+      if ((ownedAbilityAttrs & AbilityAttr.ABILITY_2) > 0 && pokemon.hasSameAbilityInRootForm(1)) {
+        playerOwnsThisAbility = true;
+      }
+      if ((ownedAbilityAttrs & AbilityAttr.ABILITY_HIDDEN) > 0 && pokemon.hasSameAbilityInRootForm(2)) {
         playerOwnsThisAbility = true;
       }
 

--- a/src/ui/battle-info.ts
+++ b/src/ui/battle-info.ts
@@ -11,7 +11,6 @@ import { BattleStat } from "#app/data/battle-stat";
 import BattleFlyout from "./battle-flyout";
 import { WindowVariant, addWindow } from "./ui-theme";
 import i18next from "i18next";
-import { AbilityAttr } from "#app/system/game-data.js";
 
 const battleStatOrder = [ BattleStat.ATK, BattleStat.DEF, BattleStat.SPATK, BattleStat.SPDEF, BattleStat.ACC, BattleStat.EVA, BattleStat.SPD ];
 
@@ -351,13 +350,13 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
 
       let playerOwnsThisAbility = false;
       // Check if the player owns ability for the root form
-      if ((ownedAbilityAttrs & AbilityAttr.ABILITY_1) > 0 && pokemon.hasSameAbilityInRootForm(0)) {
+      if ((ownedAbilityAttrs & 1) > 0 && pokemon.hasSameAbilityInRootForm(0)) {
         playerOwnsThisAbility = true;
       }
-      if ((ownedAbilityAttrs & AbilityAttr.ABILITY_2) > 0 && pokemon.hasSameAbilityInRootForm(1)) {
+      if ((ownedAbilityAttrs & 2) > 0 && pokemon.hasSameAbilityInRootForm(1)) {
         playerOwnsThisAbility = true;
       }
-      if ((ownedAbilityAttrs & AbilityAttr.ABILITY_HIDDEN) > 0 && pokemon.hasSameAbilityInRootForm(2)) {
+      if ((ownedAbilityAttrs & 4) > 0 && pokemon.hasSameAbilityInRootForm(2)) {
         playerOwnsThisAbility = true;
       }
 


### PR DESCRIPTION
## What are the changes?
Fix bug where players would get a tinted Pokeball despite owning the ability, bug introduced in https://github.com/pagefaultgames/pokerogue/pull/3138

## Why am I doing these changes?
Tinted pokeball check was incorrect

## What did change?
Add hasSameAbilityInRootForm function to Pokemon class
Check for if the player owns that ability on the root form for the tinted pokeball check

### Screenshots/Videos
n/a

## How to test the changes?
Test and pull

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
