### PR TITLE
[Hotfix] Fix IVs not being all 10 for fresh start challenge

### DIFF
--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -655,6 +655,7 @@ export class FreshStartChallenge extends Challenge {
     pokemon.variant = 0; // Not shiny
     pokemon.gender = Gender.MALE; // Starters default to male
     pokemon.formIndex = 0; // Froakie should be base form
+    pokemon.ivs = [10, 10, 10, 10, 10, 10]; // Default IVs of 10 for all stats
     return true;
   }
 


### PR DESCRIPTION
## What are the changes?
Make all fresh start starters have 10 IVs in all stats

## Why am I doing these changes?
IVs weren't being reset

## What did change?
Added `    pokemon.ivs = [10, 10, 10, 10, 10, 10]; // Default IVs of 10 for all stats` to `applyStarterModify`

### Screenshots/Videos
n/a

## How to test the changes?
Pull and test

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
