### PR TITLE
[Hotfix] Fix interactions of moves that change type 

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -717,9 +717,13 @@ export default class Move implements Localizable {
    * @returns The calculated power of the move.
    */
   calculateBattlePower(source: Pokemon, target: Pokemon): number {
-    const power = new Utils.NumberHolder(this.power);
+    if (this.category === MoveCategory.STATUS) {
+      return -1;
+    }
 
+    const power = new Utils.NumberHolder(this.power);
     const typeChangeMovePowerMultiplier = new Utils.NumberHolder(1);
+
     applyPreAttackAbAttrs(MoveTypeChangeAttr, source, target, this, typeChangeMovePowerMultiplier);
 
     const sourceTeraType = source.getTeraType();

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1836,7 +1836,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     const types = this.getTypes(true, true);
 
     const cancelled = new Utils.BooleanHolder(false);
+    const power = move.calculateBattlePower(source, this);
     const typeless = move.hasAttr(TypelessAttr);
+
     const typeMultiplier = new Utils.NumberHolder(!typeless && (moveCategory !== MoveCategory.STATUS || move.getAttrs(StatusMoveTypeImmunityAttr).find(attr => types.includes(attr.immuneType)))
       ? this.getAttackTypeEffectiveness(move, source, false, false)
       : 1);
@@ -1861,7 +1863,6 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     case MoveCategory.PHYSICAL:
     case MoveCategory.SPECIAL:
       const isPhysical = moveCategory === MoveCategory.PHYSICAL;
-      const power = move.calculateBattlePower(source, this);
       const sourceTeraType = source.getTeraType();
 
       if (!typeless) {


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
- fixes power and interaction of moves that change type

## Why am I doing these changes?
[this recent change](https://github.com/pagefaultgames/pokerogue/pull/2984/files#diff-1867e67cee517f3348c17ed44e0f02a45a23e59575f38b6e15aacf194768d6dbL1752) caused the relevant moves to only change type [after the typeMultiplier is defined](https://github.com/pagefaultgames/pokerogue/pull/2984/files#diff-1867e67cee517f3348c17ed44e0f02a45a23e59575f38b6e15aacf194768d6dbR1755-R1757) thus not applying the correct type
reference: [discord bug report](https://discord.com/channels/1125469663833370665/1266922986410082344)

## What did change?
- moved the `calculateBattlePower` higher in the code
- updated `calculateBattlePower` to return early with `-1` if move category is of Status

### Screenshots/Videos
- Normalize now properly works


https://github.com/user-attachments/assets/1800945e-d7e9-4fd8-a7d8-072b67f20d2e



## How to test the changes?
- get any ability with attr of `MoveTypeChangeAttr` ie Normalize
- use a move with type other than Normal against a Ghost-type mon

## Checklist
- ~[ ] **I'm using `beta` as my base branch**~
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - [x] Have I provided screenshots/videos of the changes?
