### PR TITLE
[Localization] New Korean translations

### DIFF
--- a/src/locales/ko/achv.ts
+++ b/src/locales/ko/achv.ts
@@ -264,6 +264,10 @@ export const PGMachv: AchievementTranslationEntries = {
   "MONO_FAIRY": {
     name: "설마 자시안으로?",
   },
+  "FRESH_START": {
+    name: "첫트!",
+    description: "새 출발 챌린지 모드 클리어."
+  },
 } as const;
 
 // Achievement translations for the when the player character is female (it for now uses the same translations as the male version)

--- a/src/locales/ko/battle-info.ts
+++ b/src/locales/ko/battle-info.ts
@@ -1,5 +1,9 @@
 import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const battleInfo: SimpleTranslationEntries = {
+<<<<<<< HEAD
+  "generation": "{{generation}}",
+=======
   "generation": "{{generation}}세대",
+>>>>>>> 118db8c7d0a89a6110e280b82be0b4ccab2ea312
 } as const;

--- a/src/locales/ko/battle-info.ts
+++ b/src/locales/ko/battle-info.ts
@@ -1,9 +1,5 @@
 import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
 export const battleInfo: SimpleTranslationEntries = {
-<<<<<<< HEAD
   "generation": "{{generation}}",
-=======
-  "generation": "{{generation}}세대",
->>>>>>> 118db8c7d0a89a6110e280b82be0b4ccab2ea312
 } as const;

--- a/src/locales/ko/challenges.ts
+++ b/src/locales/ko/challenges.ts
@@ -23,4 +23,10 @@ export const challenges: TranslationEntries = {
     "desc_default": "선택한 타입의 포켓몬만 사용할 수 있습니다."
     //type in pokemon-info
   },
+  "freshStart": {
+    "name": "새 출발",
+    "desc": "포켓로그를 처음 시작했던 때처럼 강화가 전혀 되지 않은 오리지널 스타팅 포켓몬만 고를 수 있습니다.",
+    "value.0": "해제",
+    "value.1": "설정",
+  }
 } as const;

--- a/src/locales/ko/modifier-type.ts
+++ b/src/locales/ko/modifier-type.ts
@@ -58,10 +58,10 @@ export const modifierType: ModifierTypeTranslationEntries = {
       description: "지니게 하면 {{moveType}}타입 기술의 위력이 20% 상승한다.",
     },
     "PokemonLevelIncrementModifierType": {
-      description: "포켓몬 1마리의 레벨이 기본 1만큼, 사탕단지의 개수에 따라 최대 {{levels}}까지 상승한다.",
+      description: "포켓몬 1마리의 레벨이 {{levels}}만큼 상승한다.",
     },
     "AllPokemonLevelIncrementModifierType": {
-      description: "자신의 모든 포켓몬의 레벨이 기본 1씩, 사탕단지의 개수에 따라 최대 {{levels}}까지 상승한다.",
+      description: "자신의 모든 포켓몬의 레벨이 {{levels}}만큼 상승한다.",
     },
     "PokemonBaseStatBoosterModifierType": {
       description: "지니게 하면 {{statName}} 종족값을 10% 올려준다. 개체값이 높을수록 더 많이 누적시킬 수 있다.",
@@ -153,7 +153,11 @@ export const modifierType: ModifierTypeTranslationEntries = {
 
     "REVIVER_SEED": { name: "부활의씨앗", description: "포켓몬이 공격을 받고 쓰러지려 할 때 HP를 절반 회복한다." },
 
+<<<<<<< HEAD
+    "WHITE_HERB": { name: "하양허브", description: "지니게 한 포켓몬의 능력이 떨어졌을 때 원래 상태로 돌아온다." },
+=======
     "WHITE_HERB": { name: "White Herb", description: "An item to be held by a Pokémon. It will restore any lowered stat in battle." },
+>>>>>>> 118db8c7d0a89a6110e280b82be0b4ccab2ea312
 
     "ETHER": { name: "PP에이드" },
     "MAX_ETHER": { name: "PP회복" },

--- a/src/locales/ko/modifier-type.ts
+++ b/src/locales/ko/modifier-type.ts
@@ -153,11 +153,7 @@ export const modifierType: ModifierTypeTranslationEntries = {
 
     "REVIVER_SEED": { name: "부활의씨앗", description: "포켓몬이 공격을 받고 쓰러지려 할 때 HP를 절반 회복한다." },
 
-<<<<<<< HEAD
     "WHITE_HERB": { name: "하양허브", description: "지니게 한 포켓몬의 능력이 떨어졌을 때 원래 상태로 돌아온다." },
-=======
-    "WHITE_HERB": { name: "White Herb", description: "An item to be held by a Pokémon. It will restore any lowered stat in battle." },
->>>>>>> 118db8c7d0a89a6110e280b82be0b4ccab2ea312
 
     "ETHER": { name: "PP에이드" },
     "MAX_ETHER": { name: "PP회복" },


### PR DESCRIPTION
## What are the changes?
I mistakenly closed the existing PR

Translations for achv.ts, challenge.ts, modifier-type.ts and battle-info.ts

## Why am I doing these changes?
Some scripts not translated yet

## What did change?
Simple translations for achv.ts, challenge.ts, modifier-type.ts
I deleted the word "세대" in battle-info.ts because there's already the word "세대" in the {{generation}}
Rare/Rarer Candy script modified

### Screenshots/Videos
![캡처](https://github.com/user-attachments/assets/a98e1858-a3a1-43c6-baca-c793879860e2)
It had been "5세대세대", but now fixed

## How to test the changes?

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?