### PR TITLE
[Misc] Remove unnecessary switch case

### DIFF
--- a/src/data/biomes.ts
+++ b/src/data/biomes.ts
@@ -17,8 +17,6 @@ export function getBiomeName(biome: Biome | -1) {
     return i18next.t("biome:GRASS");
   case Biome.RUINS:
     return i18next.t("biome:RUINS");
-  case Biome.ABYSS:
-    return i18next.t("biome:ABYSS");
   case Biome.END:
     return i18next.t("biome:END");
   default:


### PR DESCRIPTION
## What are the changes?
There are no user-facing changes.

## Why am I doing these changes?
`Biome.ABYSS` has the same (English) name as its enum, so it doesn't need a special case for it.

## What did change?
Remove switch case matching `Biome.ABYSS` in `src/data/biomes.ts`.

### Screenshots/Videos
Language: English
![image](https://github.com/user-attachments/assets/9315c89d-3904-4a8c-926b-241fa08b6c92)

Language: Spanish
![image](https://github.com/user-attachments/assets/0c8b7e2f-2740-4585-a090-2ec4e8754809)

## How to test the changes?
`STARTING_BIOME_OVERRIDE: Biome.ABYSS`
Load the game in multiple languages.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - [x] Have I provided screenshots/videos of the changes?
