### PR TITLE
[Bug] fix "Pokemon sprites failing to load after fainting in Gym Leader battle" and related issues

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1133,7 +1133,7 @@ export default class BattleScene extends SceneBase {
       }
       if (resetArenaState) {
         this.arena.resetArenaEffects();
-        playerField.forEach((_, p) => this.unshiftPhase(new ReturnPhase(this, p)));
+        playerField.forEach((_, p) => this.pushPhase(new ReturnPhase(this, p)));
 
         for (const pokemon of this.getParty()) {
           // Only trigger form change when Eiscue is in Noice form
@@ -1146,7 +1146,7 @@ export default class BattleScene extends SceneBase {
           applyPostBattleInitAbAttrs(PostBattleInitAbAttr, pokemon);
         }
 
-        this.unshiftPhase(new ShowTrainerPhase(this));
+        this.pushPhase(new ShowTrainerPhase(this));
       }
 
       for (const pokemon of this.getParty()) {


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->
(I'm quite new to contribution so feel free to leave some guidance to me! )

## What are the changes?
well two lines of code, changing the order of Return & Trainer showing Phase versus Switch Phase. 
<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I doing these changes?
[the classic old issue](https://github.com/pagefaultgames/pokerogue/issues/64)
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What did change?
it happens due to having enemy faint faster than player, that then we are triggering ReturnPhase, which is like to trainer battle or to new biome, that phases were: 
Phase: (after both fainting) -> NewBattle -> (Return and trainer show phase) -> Switch
that not just causing display issue but also shows return message of fainted pokemon. 

and pushPhase made it become: 
Phase: (after both fainting) -> NewBattle -> Switch-> Return and trainer show phase
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
Fix: 

https://github.com/user-attachments/assets/86726e72-e621-4997-96ec-5d7ccf13962c


https://github.com/user-attachments/assets/544c9ee8-6c32-427e-a5ab-ee610909e2c0

Before: 

https://github.com/user-attachments/assets/162047ce-eceb-4efa-96e7-9e86a0c974a7


https://github.com/user-attachments/assets/6df564cd-b0fa-459a-8c7c-c3093e7f784a



## How to test the changes?
I've just use override.ts, this is my setting : 
```
import { Abilities } from "#enums/abilities";
import { Biome } from "#enums/biome";
import { EggTier } from "#enums/egg-type";
import { Moves } from "#enums/moves";
import { PokeballType } from "#enums/pokeball";
import { Species } from "#enums/species";
import { StatusEffect } from "#enums/status-effect";
import { TimeOfDay } from "#enums/time-of-day";
import { VariantTier } from "#enums/variant-tiers";
import { WeatherType } from "#enums/weather-type";
import { type PokeballCounts } from "./battle-scene";
import { Gender } from "./data/gender";
import { allSpecies } from "./data/pokemon-species"; // eslint-disable-line @typescript-eslint/no-unused-vars
import { Variant } from "./data/variant";
import { type ModifierOverride, type ModifierTypeKeys } from "./modifier/modifier-type";

const overrides = {} satisfies Partial<InstanceType<typeof DefaultOverrides>>;

class DefaultOverrides {
  // -----------------
  // OVERALL OVERRIDES
  // -----------------
  /** a specific seed (default: a random string of 24 characters) */
  readonly SEED_OVERRIDE: string = "000000000000000000000000";
  readonly WEATHER_OVERRIDE: WeatherType = WeatherType.NONE;
  readonly BATTLE_TYPE_OVERRIDE: "double" | "single" | null = null;
  readonly STARTING_WAVE_OVERRIDE: integer = 20;
  readonly STARTING_BIOME_OVERRIDE: Biome = Biome.GRASS;
  readonly ARENA_TINT_OVERRIDE: TimeOfDay = null;
  /** Multiplies XP gained by this value including 0. Set to null to ignore the override */
  readonly XP_MULTIPLIER_OVERRIDE: number = null;
  /** default 1000 */
  readonly STARTING_MONEY_OVERRIDE: integer = 0;
  readonly FREE_CANDY_UPGRADE_OVERRIDE: boolean = false;
  readonly POKEBALL_OVERRIDE: { active: boolean; pokeballs: PokeballCounts } = {
    active: false,
    pokeballs: {
      [PokeballType.POKEBALL]: 5,
      [PokeballType.GREAT_BALL]: 0,
      [PokeballType.ULTRA_BALL]: 0,
      [PokeballType.ROGUE_BALL]: 0,
      [PokeballType.MASTER_BALL]: 0,
    },
  };

  // ----------------
  // PLAYER OVERRIDES
  // ----------------
  readonly STARTER_FORM_OVERRIDES: Partial<Record<Species, number>> = {};

  /** default 5 or 20 for Daily */
  readonly STARTING_LEVEL_OVERRIDE: integer = 0;
  readonly STARTER_SPECIES_OVERRIDE: Species | integer = Species.SHEDINJA;
  readonly ABILITY_OVERRIDE: Abilities = Abilities.NONE;
  readonly PASSIVE_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
  readonly STATUS_OVERRIDE: StatusEffect = StatusEffect.NONE;
  readonly GENDER_OVERRIDE: Gender = null;
  readonly MOVESET_OVERRIDE: Array<Moves> = [Moves.TOXIC, Moves.SHADOW_SNEAK, Moves.SHADOW_BALL, Moves.AGILITY];
  readonly SHINY_OVERRIDE: boolean = false;
  readonly VARIANT_OVERRIDE: Variant = 0;

  // --------------------------
  // OPPONENT / ENEMY OVERRIDES
  // --------------------------
  readonly OPP_SPECIES_OVERRIDE: Species | integer = Species.SHEDINJA;
  readonly OPP_LEVEL_OVERRIDE: number = 0;
  readonly OPP_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
  readonly OPP_PASSIVE_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
  readonly OPP_STATUS_OVERRIDE: StatusEffect = StatusEffect.NONE;
  readonly OPP_GENDER_OVERRIDE: Gender = null;
  readonly OPP_MOVESET_OVERRIDE: Array<Moves> = [Moves.TOXIC, Moves.TOXIC, Moves.TOXIC, Moves.TOXIC];
  readonly OPP_SHINY_OVERRIDE: boolean = false;
  readonly OPP_VARIANT_OVERRIDE: Variant = 0;
  readonly OPP_IVS_OVERRIDE: integer | integer[] = [];

  // -------------
  // EGG OVERRIDES
  // -------------
  readonly EGG_IMMEDIATE_HATCH_OVERRIDE: boolean = false;
  readonly EGG_TIER_OVERRIDE: EggTier = null;
  readonly EGG_SHINY_OVERRIDE: boolean = false;
  readonly EGG_VARIANT_OVERRIDE: VariantTier = null;
  readonly EGG_FREE_GACHA_PULLS_OVERRIDE: boolean = false;
  readonly EGG_GACHA_PULL_COUNT_OVERRIDE: number = 0;

  // -------------------------
  // MODIFIER / ITEM OVERRIDES
  // -------------------------
  readonly STARTING_MODIFIER_OVERRIDE: Array<ModifierOverride> = [];
  readonly OPP_MODIFIER_OVERRIDE: Array<ModifierOverride> = [];

  readonly STARTING_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [];
  readonly OPP_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [{"name":"WIDE_LENS", count:2}];
  readonly NEVER_CRIT_OVERRIDE: boolean = false;

  readonly ITEM_REWARD_OVERRIDE: Array<ModifierTypeKeys> = [];
}

export const defaultOverrides = new DefaultOverrides();

export default {
  ...defaultOverrides,
  ...overrides
} satisfies InstanceType<typeof DefaultOverrides>;
```
you can change to 
```
  readonly STARTING_WAVE_OVERRIDE: integer = 4;
```
to test from pokemon to trainer case. 
Test locally or on beta. 
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
(I haven't check but prob no as it's a problem lasting quite long)
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
i don't know how to write test for this?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
    passed locally after rebase
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
