### PR TITLE
[Hotfix] Allow to hatch pokemon with Hidden Ability again

### DIFF
--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -212,7 +212,7 @@ export class Egg {
     let abilityIndex = undefined;
     if (pokemonSpecies.abilityHidden && (this._overrideHiddenAbility
       || (this._sourceType === EggSourceType.SAME_SPECIES_EGG && !Utils.randSeedInt(SAME_SPECIES_EGG_HA_RATE)))) {
-      abilityIndex = pokemonSpecies.ability2 ? 2 : 1;
+      abilityIndex = 2;
     }
 
     // This function has way to many optional parameters


### PR DESCRIPTION
(I could have sworn I already made a PR for this...)

## What are the changes?
Users are able to hatch Pokémon with hidden abilities again.

## Why am I doing these changes?
It's not possible to hatch some Pokémon with hidden abilities right now.

## What did change?
Pokemon that should hatch with hidden abilities are properly set to `abilityIndex = 2`.

## How to test the changes?
Enable the egg override(s) and hatch lots of eggs.

## Checklist
- ~[ ] **I'm using `beta` as my base branch**~
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
