### PR TITLE
[Bug] Magic Guard-Ability Interactions

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -642,7 +642,7 @@ export class ReverseDrainAbAttr extends PostDefendAbAttr {
    * @returns true if healing should be reversed on a healing move, false otherwise.
    */
   applyPostDefend(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: Move, hitResult: HitResult, args: any[]): boolean {
-    if (move.hasAttr(HitHealAttr) && !attacker.hasAbilityWithAttr(BlockNonDirectDamageAbAttr)) {
+    if (move.hasAttr(HitHealAttr)) {
       pokemon.scene.queueMessage(getPokemonMessage(attacker, " sucked up the liquid ooze!"));
       return true;
     }
@@ -3142,7 +3142,7 @@ export class PostTurnHurtIfSleepingAbAttr extends PostTurnAbAttr {
   applyPostTurn(pokemon: Pokemon, passive: boolean, args: any[]): boolean | Promise<boolean> {
     let hadEffect: boolean = false;
     for (const opp of pokemon.getOpponents()) {
-      if (opp.status?.effect === StatusEffect.SLEEP || opp.hasAbility(Abilities.COMATOSE)) {
+      if ((opp.status?.effect === StatusEffect.SLEEP || opp.hasAbility(Abilities.COMATOSE)) && !opp.hasAbilityWithAttr(BlockNonDirectDamageAbAttr)) {
         opp.damageAndUpdate(Math.floor(Math.max(1, opp.getMaxHp() / 8)), HitResult.OTHER);
         pokemon.scene.queueMessage(i18next.t("abilityTriggers:badDreams", {pokemonName: getPokemonNameWithAffix(opp)}));
         hadEffect = true;

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -642,8 +642,8 @@ export class ReverseDrainAbAttr extends PostDefendAbAttr {
    * @returns true if healing should be reversed on a healing move, false otherwise.
    */
   applyPostDefend(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: Move, hitResult: HitResult, args: any[]): boolean {
-    if (move.hasAttr(HitHealAttr)) {
-      pokemon.scene.queueMessage(i18next.t("abilityTriggers:reverseDrain", { pokemonNameWithAffix: getPokemonNameWithAffix(attacker) }));
+    if (move.hasAttr(HitHealAttr) && !attacker.hasAbilityWithAttr(BlockNonDirectDamageAbAttr)) {
+      pokemon.scene.queueMessage(getPokemonMessage(attacker, " sucked up the liquid ooze!"));
       return true;
     }
     return false;

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2862,6 +2862,9 @@ export class PostWeatherLapseDamageAbAttr extends PostWeatherLapseAbAttr {
 
   applyPostWeatherLapse(pokemon: Pokemon, passive: boolean, weather: Weather, args: any[]): boolean {
     const scene = pokemon.scene;
+    if (pokemon.hasAbilityWithAttr(BlockNonDirectDamageAbAttr)) {
+      return false;
+    }
     const abilityName = (!passive ? pokemon.getAbility() : pokemon.getPassiveAbility()).name;
     scene.queueMessage(i18next.t("abilityTriggers:postWeatherLapseDamage", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon), abilityName }));
     pokemon.damageAndUpdate(Math.ceil(pokemon.getMaxHp() / (16 / this.damageFactor)), HitResult.OTHER);
@@ -3528,7 +3531,7 @@ export class PostFaintContactDamageAbAttr extends PostFaintAbAttr {
     if (move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)) {
       const cancelled = new Utils.BooleanHolder(false);
       pokemon.scene.getField(true).map(p=>applyAbAttrs(FieldPreventExplosiveMovesAbAttr, p, cancelled));
-      if (cancelled.value) {
+      if (cancelled.value || attacker.hasAbilityWithAttr(BlockNonDirectDamageAbAttr)) {
         return false;
       }
       attacker.damageAndUpdate(Math.ceil(attacker.getMaxHp() * (1 / this.damageRatio)), HitResult.OTHER);

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -643,7 +643,7 @@ export class ReverseDrainAbAttr extends PostDefendAbAttr {
    */
   applyPostDefend(pokemon: Pokemon, passive: boolean, attacker: Pokemon, move: Move, hitResult: HitResult, args: any[]): boolean {
     if (move.hasAttr(HitHealAttr)) {
-      pokemon.scene.queueMessage(getPokemonMessage(attacker, " sucked up the liquid ooze!"));
+      pokemon.scene.queueMessage(i18next.t("abilityTriggers:reverseDrain", { pokemonNameWithAffix: getPokemonNameWithAffix(attacker) }));
       return true;
     }
     return false;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1638,9 +1638,14 @@ export class HitHealAttr extends MoveEffectAttr {
       message = i18next.t("battle:regainHealth", {pokemonName: getPokemonNameWithAffix(user)});
     }
     if (reverseDrain) {
-      user.turnData.damageTaken += healAmount;
-      healAmount = healAmount * -1;
-      message = null;
+      if (user.hasAbilityWithAttr(BlockNonDirectDamageAbAttr)) {
+        healAmount = 0;
+        message = null;
+      } else {
+        user.turnData.damageTaken += healAmount;
+        healAmount = healAmount * -1;
+        message = null;
+      }
     }
     user.scene.unshiftPhase(new PokemonHealPhase(user.scene, user.getBattlerIndex(), healAmount, message, false, true));
     return true;


### PR DESCRIPTION
## What are the changes?
Magic Guard now prevents damage from Bad Dreams, Solar Power, Dry Skin, Liquid Ooze, Aftermath, and Innards Out. It should also prevent damage from Gulp Missile but that ability has not been implemented yet.

Recreated from [PR 3029](https://github.com/pagefaultgames/pokerogue/pull/3029)

## Why am I doing these changes?
While working on the Magic Guard test, I noticed these inaccuracies and wanted to update the repo so my test would work according to expectations.

## What did change?
data/ability.ts

PostFaintContactDamageAbAttr
PostTurnHurtIfSleepingAbAttr
PostWeatherLapseDamageAbAttr
data/moves.ts
HitHealAttr

## Screenshots/Videos
Versus Pokemon with Liquid Ooze/ReverseDrainAbAttr --> HitHealAttr Moves
https://github.com/user-attachments/assets/3f28b96e-0b58-4d1b-abc3-637197df5774

Versus Pokemon with Aftermath/Innards Out (PostFaintContactDamageAbAttr)
https://github.com/user-attachments/assets/50343561-8998-45ed-8ec8-4e0daa07e3f7

Bad Dreams (PostTurnHurtIfSleepingAbAttr)
https://github.com/user-attachments/assets/41882d5c-f5e0-4359-a752-ff8b5a4dbde8

Solar Power/Dry Skin (Magic Guard set to Passive)
https://github.com/user-attachments/assets/84b8b25a-fdc8-484c-b8f6-b42cf9e7f53e

## How to test the changes?
Would recommend using overrides.ts for testing

## Checklist:
[x] There is no overlap with another PR?
[x] The PR is self-contained and cannot be split into smaller PRs?
[x] Have I provided a clear explanation of the changes?
[x] Have I tested the changes (manually)?
[x] Are all unit tests still passing? (npm run test)
[x] Have I provided screenshots/videos of the changes?