### PR TITLE
[Bug] disallow ghost-type curse to bypass crafty shield

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1855,6 +1855,12 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       this.scene.arena.applyTagsForSide(ArenaTagType.CRAFTY_SHIELD, defendingSide, cancelled, this, move.category, move.moveTarget);
     }
 
+    // Apply exceptional condition of Crafty Shield if the move used is Curse
+    if (move.id === Moves.CURSE) {
+      const defendingSide = this.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY;
+      this.scene.arena.applyTagsForSide(ArenaTagType.CRAFTY_SHIELD, defendingSide, cancelled, this, move.category, move.moveTarget);
+    }
+
     switch (moveCategory) {
     case MoveCategory.PHYSICAL:
     case MoveCategory.SPECIAL:


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
Crafty Shield should block the effect of Curse performed by a Ghost-type Pokemon.
Referring to https://bulbapedia.bulbagarden.net/wiki/Curse_(move)

> This move is not blocked by [Protect](https://bulbapedia.bulbagarden.net/wiki/Protect_(move)), [Detect](https://bulbapedia.bulbagarden.net/wiki/Detect_(move)), or [Spiky Shield](https://bulbapedia.bulbagarden.net/wiki/Spiky_Shield_(move)), but is blocked by [Crafty Shield](https://bulbapedia.bulbagarden.net/wiki/Crafty_Shield_(move)).

## Why am I doing these changes?
Closes #3161 

## What did change?
Do an extra conditional check that checks if Curse is used after the general conditional protection's (Quick Guard, Wide Guard, etc.) are checked if protection-bypass moves are not used
These changes do not interfere with the Protean/Curse self-inflict [interaction](https://youtu.be/5hnTtjni6f4?si=H2dE5oY7OsINPVfU).
> If the user is not already Ghost-type and becomes Ghost-type due to [Protean](https://bulbapedia.bulbagarden.net/wiki/Protean_(Ability)) upon executing Curse, the user will use the Ghost-type Curse on itself (regardless of [Follow Me](https://bulbapedia.bulbagarden.net/wiki/Follow_Me_(move)) or [Rage Powder](https://bulbapedia.bulbagarden.net/wiki/Rage_Powder_(move))). This cannot be blocked by [Crafty Shield](https://bulbapedia.bulbagarden.net/wiki/Crafty_Shield_(move)).

### Screenshots/Videos
Before:
Curse bypassing Crafty Shield
[curse-crafty-shield-before.webm](https://github.com/user-attachments/assets/04e0783d-28eb-4f8a-9085-ba5ea103c19e)

After:
Curse doesn't bypass Crafty Shield
[curse-crafty-shield-after.webm](https://github.com/user-attachments/assets/ced051ea-0e51-4b60-8c68-a6f9b68528f5)

Curse self-inflicts user if user has Protean while opponent uses Crafty Shield
[protean-curse-crafty-shield.webm](https://github.com/user-attachments/assets/eaca70e9-b454-469c-af8c-d41a8c984465)


## How to test the changes?
Override `src/overrides.ts` file for testing.


## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
    - Does not seem necessary
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
