### PR TITLE
[Bug] Caught Pokemon-Summary Option Error Sound

### DIFF
--- a/src/ui/confirm-ui-handler.ts
+++ b/src/ui/confirm-ui-handler.ts
@@ -28,7 +28,7 @@ export default class ConfirmUiHandler extends AbstractOptionSelectUiHandler {
             label: i18next.t("partyUiHandler:SUMMARY"),
             handler: () => {
               args[0]();
-              return false;
+              return true;
             },
           }, {
             label: i18next.t("menu:yes"),


### PR DESCRIPTION
## What are the changes?
When choosing the Summary option (after catching a Pokemon with a full party), the error sound plays. This does not affect functionality and only impacts player experience. 

## Why am I doing these changes?
It is my PR so I should be responsible for it. I don't play with sound so this was an oversight on my part. 

## What did change?
- ui/confirm-ui-handler.ts : This changes the validity of choosing the summary option so that the sound effect of ui.playSelect() plays, not the one of ui.playError()

### Screenshots/Videos
https://github.com/user-attachments/assets/e2809dd9-0941-4a4f-9728-6a6641c3e663

## How to test the changes?
Catch a Pokemon with a full party and listen for the correct sound when choosing Summary.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
