### PR TITLE
[Localization] Localize prevent berry ability phase and translate

### DIFF
--- a/src/locales/de/ability-trigger.ts
+++ b/src/locales/de/ability-trigger.ts
@@ -59,5 +59,5 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "postSummonSwordOfRuin": "Unheilsschwert von {{pokemonNameWithAffix}} schwächt {{statName} aller Pokémon im Umkreis!",
   "postSummonTabletsOfRuin": "Unheilstafeln von {{pokemonNameWithAffix}} schwächt {{statName}} aller Pokémon im Umkreis!",
   "postSummonBeadsOfRuin": "Unheilsjuwelen von {{pokemonNameWithAffix}} schwächt {{statName}} aller Pokémon im Umkreis!",
-  "preventBerryUse": "{{pokemonNameWithAffix}} kriegt vor Anspannung keine Beeren mehr runter!!",
+  "preventBerryUse": "{{pokemonNameWithAffix}} kriegt vor Anspannung keine Beeren mehr runter!",
 } as const;

--- a/src/locales/de/ability-trigger.ts
+++ b/src/locales/de/ability-trigger.ts
@@ -59,5 +59,5 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "postSummonSwordOfRuin": "Unheilsschwert von {{pokemonNameWithAffix}} schwächt {{statName} aller Pokémon im Umkreis!",
   "postSummonTabletsOfRuin": "Unheilstafeln von {{pokemonNameWithAffix}} schwächt {{statName}} aller Pokémon im Umkreis!",
   "postSummonBeadsOfRuin": "Unheilsjuwelen von {{pokemonNameWithAffix}} schwächt {{statName}} aller Pokémon im Umkreis!",
-  "preventBerryUse": "{{pokemonNameWithAffix}} is too\nnervous to eat berries!",
+  "preventBerryUse": "{{pokemonNameWithAffix}} kriegt vor Anspannung keine Beeren mehr runter!!",
 } as const;

--- a/src/locales/de/ability-trigger.ts
+++ b/src/locales/de/ability-trigger.ts
@@ -59,4 +59,5 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "postSummonSwordOfRuin": "Unheilsschwert von {{pokemonNameWithAffix}} schwächt {{statName} aller Pokémon im Umkreis!",
   "postSummonTabletsOfRuin": "Unheilstafeln von {{pokemonNameWithAffix}} schwächt {{statName}} aller Pokémon im Umkreis!",
   "postSummonBeadsOfRuin": "Unheilsjuwelen von {{pokemonNameWithAffix}} schwächt {{statName}} aller Pokémon im Umkreis!",
+  "preventBerryUse": "{{pokemonNameWithAffix}} is too\nnervous to eat berries!",
 } as const;

--- a/src/locales/en/ability-trigger.ts
+++ b/src/locales/en/ability-trigger.ts
@@ -59,4 +59,5 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "postSummonSwordOfRuin": "{{pokemonNameWithAffix}}'s Sword of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",
   "postSummonTabletsOfRuin": "{{pokemonNameWithAffix}}'s Tablets of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",
   "postSummonBeadsOfRuin": "{{pokemonNameWithAffix}}'s Beads of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",
+  "preventBerryUse": "{{pokemonNameWithAffix}} is too\nnervous to eat berries!",
 } as const;

--- a/src/locales/es/ability-trigger.ts
+++ b/src/locales/es/ability-trigger.ts
@@ -59,4 +59,5 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "postSummonSwordOfRuin": "{{pokemonNameWithAffix}}'s Sword of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",
   "postSummonTabletsOfRuin": "{{pokemonNameWithAffix}}'s Tablets of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",
   "postSummonBeadsOfRuin": "{{pokemonNameWithAffix}}'s Beads of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",
+  "preventBerryUse": "{{pokemonNameWithAffix}} is too\nnervous to eat berries!",
 } as const;

--- a/src/locales/es/ability-trigger.ts
+++ b/src/locales/es/ability-trigger.ts
@@ -59,5 +59,5 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "postSummonSwordOfRuin": "{{pokemonNameWithAffix}}'s Sword of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",
   "postSummonTabletsOfRuin": "{{pokemonNameWithAffix}}'s Tablets of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",
   "postSummonBeadsOfRuin": "{{pokemonNameWithAffix}}'s Beads of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",
-  "preventBerryUse": "{{pokemonNameWithAffix}} is too\nnervous to eat berries!",
+  "preventBerryUse": "{{pokemonNameWithAffix}} está muy nervioso y no puede comer bayas!",
 } as const;

--- a/src/locales/fr/ability-trigger.ts
+++ b/src/locales/fr/ability-trigger.ts
@@ -59,4 +59,5 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "postSummonSwordOfRuin": "L’Épée du Fléau de {{pokemonNameWithAffix}}\naffaiblit la {{statName}} des Pokémon alentour !",
   "postSummonTabletsOfRuin": "Le Bois du Fléau de {{pokemonNameWithAffix}}\naffaiblit l’{{statName}} des Pokémon alentour !",
   "postSummonBeadsOfRuin": "Les Perles du Fléau de {{pokemonNameWithAffix}}\naffaiblissent la {{statName}} des Pokémon alentour !",
+  "preventBerryUse": "{{pokemonNameWithAffix}} is too\nnervous to eat berries!",
 } as const;

--- a/src/locales/fr/ability-trigger.ts
+++ b/src/locales/fr/ability-trigger.ts
@@ -59,5 +59,5 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "postSummonSwordOfRuin": "L’Épée du Fléau de {{pokemonNameWithAffix}}\naffaiblit la {{statName}} des Pokémon alentour !",
   "postSummonTabletsOfRuin": "Le Bois du Fléau de {{pokemonNameWithAffix}}\naffaiblit l’{{statName}} des Pokémon alentour !",
   "postSummonBeadsOfRuin": "Les Perles du Fléau de {{pokemonNameWithAffix}}\naffaiblissent la {{statName}} des Pokémon alentour !",
-  "preventBerryUse": "{{pokemonNameWithAffix}} is too\nnervous to eat berries!",
+  "preventBerryUse": "{{pokemonNameWithAffix}} est tendu\net ne peut plus manger de Baies !",
 } as const;

--- a/src/locales/it/ability-trigger.ts
+++ b/src/locales/it/ability-trigger.ts
@@ -59,4 +59,5 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "postSummonSwordOfRuin": "{{pokemonNameWithAffix}}'s Sword of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",
   "postSummonTabletsOfRuin": "{{pokemonNameWithAffix}}'s Tablets of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",
   "postSummonBeadsOfRuin": "{{pokemonNameWithAffix}}'s Beads of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",
+  "preventBerryUse": "{{pokemonNameWithAffix}} is too\nnervous to eat berries!",
 } as const;

--- a/src/locales/it/ability-trigger.ts
+++ b/src/locales/it/ability-trigger.ts
@@ -59,5 +59,5 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "postSummonSwordOfRuin": "{{pokemonNameWithAffix}}'s Sword of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",
   "postSummonTabletsOfRuin": "{{pokemonNameWithAffix}}'s Tablets of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",
   "postSummonBeadsOfRuin": "{{pokemonNameWithAffix}}'s Beads of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",
-  "preventBerryUse": "{{pokemonNameWithAffix}} is too\nnervous to eat berries!",
+  "preventBerryUse": "{{pokemonNameWithAffix}} non riesce a\nmangiare le bacche per l'agitazione!",
 } as const;

--- a/src/locales/ko/ability-trigger.ts
+++ b/src/locales/ko/ability-trigger.ts
@@ -59,4 +59,5 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "postSummonSwordOfRuin": "{{pokemonNameWithAffix}}의 재앙의검에 의해\n주위의 {{statName}}[[가]] 약해졌다!",
   "postSummonTabletsOfRuin": "{{pokemonNameWithAffix}}의 재앙의목간에 의해\n주위의 {{statName}}[[가]] 약해졌다!",
   "postSummonBeadsOfRuin": "{{pokemonNameWithAffix}}의 재앙의구슬에 의해\n주위의 {{statName}}[[가]] 약해졌다!",
+  "preventBerryUse": "{{pokemonNameWithAffix}}[[는]] 긴장해서\n나무열매를 먹을 수 없게 되었다!",
 } as const;

--- a/src/locales/pt_BR/ability-trigger.ts
+++ b/src/locales/pt_BR/ability-trigger.ts
@@ -59,4 +59,5 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "postSummonSwordOfRuin": "Sword of Ruin de {{pokemonNameWithAffix}} reduziu a {{statName}}\nde todos os Pokémon em volta!",
   "postSummonTabletsOfRuin": "Tablets of Ruin de {{pokemonNameWithAffix}} reduziu o {{statName}}\nde todos os Pokémon em volta!",
   "postSummonBeadsOfRuin": "Beads of Ruin de {{pokemonNameWithAffix}} reduziu a {{statName}}\nde todos os Pokémon em volta!",
+  "preventBerryUse": "{{pokemonNameWithAffix}} is too\nnervous to eat berries!",
 } as const;

--- a/src/locales/pt_BR/ability-trigger.ts
+++ b/src/locales/pt_BR/ability-trigger.ts
@@ -59,5 +59,5 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "postSummonSwordOfRuin": "Sword of Ruin de {{pokemonNameWithAffix}} reduziu a {{statName}}\nde todos os Pokémon em volta!",
   "postSummonTabletsOfRuin": "Tablets of Ruin de {{pokemonNameWithAffix}} reduziu o {{statName}}\nde todos os Pokémon em volta!",
   "postSummonBeadsOfRuin": "Beads of Ruin de {{pokemonNameWithAffix}} reduziu a {{statName}}\nde todos os Pokémon em volta!",
-  "preventBerryUse": "{{pokemonNameWithAffix}} is too\nnervous to eat berries!",
+  "preventBerryUse": "{{pokemonNameWithAffix}} está nervoso\ndemais para comer frutas!",
 } as const;

--- a/src/locales/zh_CN/ability-trigger.ts
+++ b/src/locales/zh_CN/ability-trigger.ts
@@ -59,5 +59,5 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "postSummonSwordOfRuin": "{{pokemonNameWithAffix}}的灾祸之剑\n令周围的宝可梦的{{statName}}减弱了！",
   "postSummonTabletsOfRuin": "{{pokemonNameWithAffix}}的灾祸之简\n令周围的宝可梦的{{statName}}减弱了！",
   "postSummonBeadsOfRuin": "{{pokemonNameWithAffix}}的灾祸之玉\n令周围的宝可梦的{{statName}}减弱了！",
-  "preventBerryUse": "{{pokemonNameWithAffix}} is too\nnervous to eat berries!",
+  "preventBerryUse": "{{pokemonNameWithAffix}}因太紧张\n而无法食用树果！",
 } as const;

--- a/src/locales/zh_CN/ability-trigger.ts
+++ b/src/locales/zh_CN/ability-trigger.ts
@@ -59,4 +59,5 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "postSummonSwordOfRuin": "{{pokemonNameWithAffix}}的灾祸之剑\n令周围的宝可梦的{{statName}}减弱了！",
   "postSummonTabletsOfRuin": "{{pokemonNameWithAffix}}的灾祸之简\n令周围的宝可梦的{{statName}}减弱了！",
   "postSummonBeadsOfRuin": "{{pokemonNameWithAffix}}的灾祸之玉\n令周围的宝可梦的{{statName}}减弱了！",
+  "preventBerryUse": "{{pokemonNameWithAffix}} is too\nnervous to eat berries!",
 } as const;

--- a/src/locales/zh_TW/ability-trigger.ts
+++ b/src/locales/zh_TW/ability-trigger.ts
@@ -59,4 +59,5 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "postSummonSwordOfRuin": "{{pokemonNameWithAffix}}'s Sword of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",
   "postSummonTabletsOfRuin": "{{pokemonNameWithAffix}}'s Tablets of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",
   "postSummonBeadsOfRuin": "{{pokemonNameWithAffix}}'s Beads of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",
+  "preventBerryUse": "{{pokemonNameWithAffix}} is too\nnervous to eat berries!",
 } as const;

--- a/src/locales/zh_TW/ability-trigger.ts
+++ b/src/locales/zh_TW/ability-trigger.ts
@@ -59,5 +59,5 @@ export const abilityTriggers: SimpleTranslationEntries = {
   "postSummonSwordOfRuin": "{{pokemonNameWithAffix}}'s Sword of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",
   "postSummonTabletsOfRuin": "{{pokemonNameWithAffix}}'s Tablets of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",
   "postSummonBeadsOfRuin": "{{pokemonNameWithAffix}}'s Beads of Ruin lowered the {{statName}}\nof all surrounding Pokémon!",
-  "preventBerryUse": "{{pokemonNameWithAffix}} is too\nnervous to eat berries!",
+  "preventBerryUse": "{{pokemonNameWithAffix}}因太緊張\n而無法食用樹果！",
 } as const;

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -20,7 +20,7 @@ import { ModifierTier } from "./modifier/modifier-tier";
 import { FusePokemonModifierType, ModifierPoolType, ModifierType, ModifierTypeFunc, ModifierTypeOption, PokemonModifierType, PokemonMoveModifierType, PokemonPpRestoreModifierType, PokemonPpUpModifierType, RememberMoveModifierType, TmModifierType, getDailyRunStarterModifiers, getEnemyBuffModifierForWave, getModifierType, getPlayerModifierTypeOptions, getPlayerShopModifierTypeOptionsForWave, modifierTypes, regenerateModifierPoolThresholds } from "./modifier/modifier-type";
 import SoundFade from "phaser3-rex-plugins/plugins/soundfade";
 import { BattlerTagLapseType, CenterOfAttentionTag, EncoreTag, ProtectedTag, SemiInvulnerableTag, TrappedTag } from "./data/battler-tags";
-import { getPokemonMessage, getPokemonNameWithAffix } from "./messages";
+import { getPokemonNameWithAffix } from "./messages";
 import { Starter } from "./ui/starter-select-ui-handler";
 import { Gender } from "./data/gender";
 import { Weather, WeatherType, getRandomWeatherType, getTerrainBlockMessage, getWeatherDamageMessage, getWeatherLapseMessage } from "./data/weather";
@@ -2410,7 +2410,7 @@ export class BerryPhase extends FieldPhase {
         pokemon.getOpponents().map((opp) => applyAbAttrs(PreventBerryUseAbAttr, opp, cancelled));
 
         if (cancelled.value) {
-          pokemon.scene.queueMessage(getPokemonMessage(pokemon, " is too\nnervous to eat berries!"));
+          pokemon.scene.queueMessage(i18next.t("abilityTriggers:preventBerryUse", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }));
         } else {
           this.scene.unshiftPhase(
             new CommonAnimPhase(this.scene, pokemon.getBattlerIndex(), pokemon.getBattlerIndex(), CommonAnim.USE_ITEM)


### PR DESCRIPTION
## What are the changes?
Add the option to localize message text when PreventBerryUseAbAttr(Like Unnerve) prevents use berry.

## Why am I doing these changes?
All text should be localizable.

## What did change?
 - Change hard-coded text for localize > phases.ts
 - Added localization keys in each language folders. > ability-trigger.ts
 - Translated them to Korean.

### Screenshots/Videos
TBD (After translator's review)

#### En
![image](https://github.com/user-attachments/assets/46520ab8-6cd6-426e-9508-a40b1ca269a9)

#### Fr
![image](https://github.com/user-attachments/assets/3e9298f9-eb60-493f-89f6-d2b639ecfa0c)

#### De
![image](https://github.com/user-attachments/assets/7e95e2df-0da0-4d97-8508-1032283fd57f)

#### Pt_BR
![image](https://github.com/user-attachments/assets/67dac53f-e815-4cee-9d78-c93cc065c5d6)

#### Zh_CN
![image](https://github.com/user-attachments/assets/099ac852-dc56-40a2-a3fb-b76a8e1c6f62)

#### Zh_TW
![image](https://github.com/user-attachments/assets/acb110e8-84fe-47f3-9e23-43fa2e5c8847)

#### Ko
![image](https://github.com/user-attachments/assets/93e7cac4-4d5c-449e-ad7c-95f485ade0d8)

## How to test the changes?
Manually. (Using overrides.ts)
example) preventing 'Sitrus' case
```Typescript
  readonly ABILITY_OVERRIDE: Abilities = Abilities.UNNERVE;
  readonly MOVESET_OVERRIDE: Array<Moves> = [ Moves.FALSE_SWIPE ]; // Not to make opp pokemon faint.
  readonly OPP_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [{name: "BERRY", type: BerryType.SITRUS}];
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
