### PR TITLE
Update achv.ts (it, rework)

### DIFF
--- a/src/locales/it/achv.ts
+++ b/src/locales/it/achv.ts
@@ -10,7 +10,7 @@ export const PGMachv: AchievementTranslationEntries = {
   },
 
   "MoneyAchv": {
-    description: "Accumula ₽{{moneyAmount}} PokéDollari",
+    description: "Accumula {{moneyAmount}} PokéDollari",
   },
   "10K_MONEY": {
     name: "Benestante",
@@ -191,19 +191,19 @@ export const PGMachv: AchievementTranslationEntries = {
     description: "Completa la modalità sfida di quinta generazione.",
   },
   "MONO_GEN_SIX": {
-    name: "Quasi Reali",
+    name: "Vita e Morte",
     description: "Completa la modalità sfida di sesta generazione.",
   },
   "MONO_GEN_SEVEN": {
-    name: "Solo In Teoria",
+    name: "Troppo amichevoli?",
     description:  "Completa la modalità sfida di settima generazione.",
   },
   "MONO_GEN_EIGHT": {
-    name: "È Champion-time!",
+    name: "It's champion time!",
     description:  "Completa la modalità sfida di ottava generazione.",
   },
   "MONO_GEN_NINE": {
-    name: "Non si Stava Impegnando...",
+    name: "Paradossalmente sbalorditivi",
     description:  "Completa la modalità sfida di nona generazione.",
   },
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
I reworked some achievements names 
## Why am I doing these changes?
Because the previous ones didn't make much sense
## What did change?
Description of money accumulation achievements edited, it now makes sense in italian.
Monogens explained:
6) changed from "Quasi Reali" (what's the meaning of that? it means almost real but it didn't make much sense for gen 6) to "Vita e Morte" (Life and Death, as in Xerneas and Yveltal. i was also thinking of something regarding the megas alternatively) 
7) changed from "Solo in Teoria" (again, what's the meaning of that?) to "Troppo amichevoli?" (too friendly?, since gen 7 games always get hate for their friendly characters and battles) 
8) little change on the quote based on how the champion actually says it in the italian games 
9) changed from "Non Si Stava Impegnando..." (now this one actually might've made sense, but i thought of changing it to make it more fitting for gen 9 games) to "Paradossalmente sbalorditivi" (paradoxically astonishing, since paradox pokemon are cool and very strong and they're from gen 9) 
### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
Check the "Obiettivi" tab in italian pokerogue
## Checklist
- [ ] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
