### PR TITLE
[Tests] Test for Ability Magic Guard

### DIFF
--- a/src/test/abilities/magic_guard.test.ts
+++ b/src/test/abilities/magic_guard.test.ts
@@ -45,6 +45,8 @@ describe("Abilities - Magic Guard", () => {
     vi.spyOn(overrides, "OPP_LEVEL_OVERRIDE", "get").mockReturnValue(100);
   });
 
+  //Bulbapedia Reference: https://bulbapedia.bulbagarden.net/wiki/Magic_Guard_(Ability)
+
   it(
     "ability should prevent damage caused by weather",
     async () => {

--- a/src/test/abilities/magic_guard.test.ts
+++ b/src/test/abilities/magic_guard.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import Phaser from "phaser";
+import GameManager from "#app/test/utils/gameManager";
+import * as overrides from "#app/overrides";
+import { Species } from "#enums/species";
+import { TurnEndPhase, } from "#app/phases";
+import { Moves } from "#enums/moves";
+import { getMovePosition } from "#app/test/utils/gameManagerUtils";
+import { Abilities } from "#enums/abilities";
+import Move, { allMoves } from "#app/data/move.js";
+import { BlockNonDirectDamageAbAttr } from "#app/data/ability.js";
+import { NumberHolder } from "#app/utils.js";
+import Pokemon from "#app/field/pokemon.js";
+
+describe("Abilities - Magic Guard", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.WONDER_GUARD);
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.TACKLE, Moves.CHARM]);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.SPLASH, Moves.SPLASH, Moves.SPLASH]);
+  });
+
+  it("Magic Guard prevents damage caused by weather", async () => {
+    await game.startBattle([Species.MAGIKARP]);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
+
+    await game.phaseInterceptor.to(TurnEndPhase);
+  });
+
+  it("Magic Guard prevents damage caused by poison but Pokemon still can be poisoned and take damage upon losing Magic Guard", async () => {
+    await game.startBattle([Species.MAGIKARP]);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
+
+    await game.phaseInterceptor.to(TurnEndPhase);
+  });
+
+  it("Magic Guard prevents damage caused by burn but Pokemon still can be burned and take damage upon losing Magic Guard", async () => {
+    await game.startBattle([Species.MAGIKARP]);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
+
+    await game.phaseInterceptor.to(TurnEndPhase);
+  });
+
+  it("Magic Guard prevents damage caused by entry hazards", async () => {
+    await game.startBattle([Species.MAGIKARP]);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
+
+    await game.phaseInterceptor.to(TurnEndPhase);
+  });
+
+  it("Magic Guard does not prevent poison from Toxic Spikes", async () => {
+    await game.startBattle([Species.MAGIKARP]);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
+
+    await game.phaseInterceptor.to(TurnEndPhase);
+  });
+
+  it("Magic Guard prevents curse status damage", async () => {
+    await game.startBattle([Species.MAGIKARP]);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
+
+    await game.phaseInterceptor.to(TurnEndPhase);
+  });
+
+  it("Magic Guard prevents crash damange", async () => {
+    await game.startBattle([Species.MAGIKARP]);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
+
+    await game.phaseInterceptor.to(TurnEndPhase);
+  });
+
+  it("Magic Guard prevents damage from recoil", async () => {
+    await game.startBattle([Species.MAGIKARP]);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
+
+    await game.phaseInterceptor.to(TurnEndPhase);
+  });
+
+  it("Magic Guard does not prevent damage from Struggle's recoil", async () => {
+    await game.startBattle([Species.MAGIKARP]);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
+
+    await game.phaseInterceptor.to(TurnEndPhase);
+  });
+
+  it("Magic Guard prevents self-damage from attacking moves", async () => {
+    await game.startBattle([Species.MAGIKARP]);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
+
+    await game.phaseInterceptor.to(TurnEndPhase);
+  });
+
+  it("Magic Guard does not prevent self-damage from confusion", async () => {
+    await game.startBattle([Species.MAGIKARP]);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
+
+    await game.phaseInterceptor.to(TurnEndPhase);
+  });
+
+  it("Magic Guard does not prevent self-damage from non-attacking moves", async () => {
+    await game.startBattle([Species.MAGIKARP]);
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
+
+    await game.phaseInterceptor.to(TurnEndPhase);
+  });
+ });

--- a/src/test/abilities/magic_guard.test.ts
+++ b/src/test/abilities/magic_guard.test.ts
@@ -3,14 +3,18 @@ import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
 import * as overrides from "#app/overrides";
 import { Species } from "#enums/species";
-import { TurnEndPhase, } from "#app/phases";
+import { CommandPhase, TurnEndPhase, WeatherEffectPhase, PostTurnStatusEffectPhase } from "#app/phases";
 import { Moves } from "#enums/moves";
 import { getMovePosition } from "#app/test/utils/gameManagerUtils";
 import { Abilities } from "#enums/abilities";
 import Move, { allMoves } from "#app/data/move.js";
 import { BlockNonDirectDamageAbAttr } from "#app/data/ability.js";
+import { WeatherType } from "#app/data/weather.js";
 import { NumberHolder } from "#app/utils.js";
 import Pokemon from "#app/field/pokemon.js";
+import {Mode} from "#app/ui/ui";
+import {Command} from "#app/ui/command-ui-handler";
+import { StatusEffect } from "#app/data/status-effect";
 
 describe("Abilities - Magic Guard", () => {
   let phaserGame: Phaser.Game;
@@ -29,27 +33,44 @@ describe("Abilities - Magic Guard", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     vi.spyOn(overrides, "SINGLE_BATTLE_OVERRIDE", "get").mockReturnValue(true);
-    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.WONDER_GUARD);
-    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.TACKLE, Moves.CHARM]);
+    vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.MAGIC_GUARD);
     vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH, Moves.SPLASH, Moves.SPLASH, Moves.SPLASH]);
   });
 
   it("Magic Guard prevents damage caused by weather", async () => {
+    vi.spyOn(overrides, "WEATHER_OVERRIDE", "get").mockReturnValue(WeatherType.SANDSTORM);
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH]);
     await game.startBattle([Species.MAGIKARP]);
-
-    game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
-
-    await game.phaseInterceptor.to(TurnEndPhase);
+    const hpPokemon = game.scene.getPlayerPokemon().hp;
+    //Attempting to applying weather damage now...
+    new WeatherEffectPhase(game.scene).start();
+    const hpLost = (hpPokemon === game.scene.getPlayerPokemon().hp);
+    expect(hpLost).toBe(true);
   });
 
   it("Magic Guard prevents damage caused by poison but Pokemon still can be poisoned and take damage upon losing Magic Guard", async () => {
+    //Toxic keeps track of the turn counters -> important that Magic Guard keeps track of post-Toxic turns 
+    vi.spyOn(overrides, "STATUS_OVERRIDE", "get").mockReturnValue(StatusEffect.POISON);
+    vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SKILL_SWAP, Moves.SPLASH]);
     await game.startBattle([Species.MAGIKARP]);
-
-    game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
-
+    const pokemonMG = game.scene.getPlayerPokemon();
+    const startingHP = pokemonMG.hp;
+    game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
     await game.phaseInterceptor.to(TurnEndPhase);
+  	const statusEffectPhase = new PostTurnStatusEffectPhase(game.scene, 0);
+    statusEffectPhase.start();
+    const lostHPWithMG = (pokemonMG.hp === startingHP);
+    //await game.toNextTurn();
+    game.doAttack(getMovePosition(game.scene, 0, Moves.SKILL_SWAP));
+    await game.phaseInterceptor.to(TurnEndPhase);
+    statusEffectPhase.start();
+    const lostHPWithNoMG = (pokemonMG.hp < startingHP);
+
+    expect(lostHPWithMG).toBe(true);
+    expect(lostHPWithNoMG).toBe(true);
   });
 
+/*
   it("Magic Guard prevents damage caused by burn but Pokemon still can be burned and take damage upon losing Magic Guard", async () => {
     await game.startBattle([Species.MAGIKARP]);
 
@@ -129,4 +150,5 @@ describe("Abilities - Magic Guard", () => {
 
     await game.phaseInterceptor.to(TurnEndPhase);
   });
- });
+  */
+});

--- a/src/test/abilities/magic_guard.test.ts
+++ b/src/test/abilities/magic_guard.test.ts
@@ -34,6 +34,7 @@ describe("Abilities - Magic Guard", () => {
 
     /** Player Pokemon overrides */
     vi.spyOn(overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.MAGIC_GUARD);
+    vi.spyOn(overrides, "PASSIVE_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.UNNERVE);
     vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPLASH]);
     vi.spyOn(overrides, "STARTING_LEVEL_OVERRIDE", "get").mockReturnValue(100);
 

--- a/src/test/abilities/magic_guard.test.ts
+++ b/src/test/abilities/magic_guard.test.ts
@@ -145,9 +145,9 @@ describe("Abilities - Magic Guard", () => {
 
       /**
        * Expect:
-       * - The player Pokemon (with Magic Guard) has not taken damage from burn
-       * - The player Pokemon's physical attack damage is halved (TBD)
-       * - The player Pokemon's hypothetical CatchRateMultiplier should be 1.5
+       * - The enemy Pokemon (with Magic Guard) has not taken damage from burn
+       * - The enemy Pokemon's physical attack damage is halved (TBD)
+       * - The enemy Pokemon's hypothetical CatchRateMultiplier should be 1.5
        */
       expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
       expect(getStatusEffectCatchRateMultiplier(enemyPokemon.status.effect)).toBe(1.5);
@@ -176,9 +176,9 @@ describe("Abilities - Magic Guard", () => {
 
       /**
        * Expect:
-       * - The player Pokemon (with Magic Guard) has not taken damage from toxic
-       * - The player Pokemon's status effect duration should be incremented
-       * - The player Pokemon's hypothetical CatchRateMultiplier should be 1.5
+       * - The enemy Pokemon (with Magic Guard) has not taken damage from toxic
+       * - The enemy Pokemon's status effect duration should be incremented
+       * - The enemy Pokemon's hypothetical CatchRateMultiplier should be 1.5
        */
       expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
       expect(enemyPokemon.status.turnCount).toBeGreaterThan(toxicStartCounter);
@@ -273,8 +273,8 @@ describe("Abilities - Magic Guard", () => {
   );
 
   it("Magic Guard prevents crash damage", async () => {
-    await game.startBattle([Species.MAGIKARP]);
     vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.HIGH_JUMP_KICK]);
+    await game.startBattle([Species.MAGIKARP]);
 
     const leadPokemon = game.scene.getPlayerPokemon();
     expect(leadPokemon).toBeDefined();
@@ -294,8 +294,8 @@ describe("Abilities - Magic Guard", () => {
   );
 
   it("Magic Guard prevents damage from recoil", async () => {
-    await game.startBattle([Species.MAGIKARP]);
     vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.TAKE_DOWN]);
+    await game.startBattle([Species.MAGIKARP]);
 
     const leadPokemon = game.scene.getPlayerPokemon();
     expect(leadPokemon).toBeDefined();
@@ -313,8 +313,8 @@ describe("Abilities - Magic Guard", () => {
   );
 
   it("Magic Guard does not prevent damage from Struggle's recoil", async () => {
-    await game.startBattle([Species.MAGIKARP]);
     vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.STRUGGLE]);
+    await game.startBattle([Species.MAGIKARP]);
 
     const leadPokemon = game.scene.getPlayerPokemon();
     expect(leadPokemon).toBeDefined();
@@ -333,8 +333,8 @@ describe("Abilities - Magic Guard", () => {
 
   //This tests different move attributes than the recoil tests above
   it("Magic Guard prevents self-damage from attacking moves", async () => {
-    await game.startBattle([Species.MAGIKARP]);
     vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.STEEL_BEAM]);
+    await game.startBattle([Species.MAGIKARP]);
 
     const leadPokemon = game.scene.getPlayerPokemon();
     expect(leadPokemon).toBeDefined();
@@ -362,8 +362,8 @@ describe("Abilities - Magic Guard", () => {
 */
 
   it("Magic Guard does not prevent self-damage from non-attacking moves", async () => {
-    await game.startBattle([Species.MAGIKARP]);
     vi.spyOn(overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([Moves.BELLY_DRUM]);
+    await game.startBattle([Species.MAGIKARP]);
 
     const leadPokemon = game.scene.getPlayerPokemon();
     expect(leadPokemon).toBeDefined();
@@ -379,4 +379,41 @@ describe("Abilities - Magic Guard", () => {
     expect(leadPokemon.hp).toBeLessThan(leadPokemon.getMaxHp());
   }, TIMEOUT
   );
+
+  it("Magic Guard prevents damage from abilities with PostTurnHurtIfSleepingAbAttr", async() => {
+    vi.spyOn(overrides, "STATUS_OVERRIDE", "get").mockReturnValue(StatusEffect.SLEEP);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPORE, Moves.SPORE, Moves.SPORE, Moves.SPORE]);
+    vi.spyOn(overrides, "OPP_ABILITY_OVERRIDE", "get").mockReturnValue(Abilities.BAD_DREAMS);
+
+    await game.startBattle([Species.MAGIKARP]);
+
+    const leadPokemon = game.scene.getPlayerPokemon();
+    expect(leadPokemon).toBeDefined();
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
+
+    await game.phaseInterceptor.to(TurnEndPhase);
+
+    expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
+  }, TIMEOUT
+  );
+
+  /*
+  it("Magic Guard prevents damage from abilities with PostDefendContactDamageAbAttr", async() => {
+    await game.startBattle([Species.MAGIKARP]);
+    vi.spyOn(overrides, "STATUS_OVERRIDE", "get").mockReturnValue(StatusEffect.SLEEP);
+    vi.spyOn(overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([Moves.SPORE, Moves.SPORE, Moves.SPORE, Moves.SPORE]);
+
+    }, TIMEOUT
+  );
+*/
+  //Ability Immunities
+  //Iron Barbs/Rough Skin --> PostDefendContactDamageAbAttr
+  //Solar Power/Dry Skin --> PostWeatherLapseDamageAbAttr
+  //Bad Dreams --> PostTurnHurtIfSleepingAbAttr
+  //Aftermath/Innards Out --> PostFaintContactDamageAbAttr
+  //Liquid Ooze --> ReverseDrainAbAttr
+  //
+  //Gulp Missle (not implemented)
+
 });


### PR DESCRIPTION
## What are the changes?
This tests if Magic Guard functionality is working as intended. Tests are based on this Bulbapedia article here: https://bulbapedia.bulbagarden.net/wiki/Magic_Guard_(Ability)
Please let me know if there are other cases that should be added to this test while I finish this up. 

Old PR: https://github.com/pagefaultgames/pokerogue/pull/2799

## Why am I doing these changes?
I was working on a bug involving Magic Guard and saw that there wasn't a test for it. Since Magic Guard is an ability with different interactions I thought it would be nice to develop a test to make sure it is working according to expectations.

## What did change?
New File: src/test/abilities/magic_guard.test.ts

## How to test the changes?
npm run test magic_guard
![image](https://github.com/user-attachments/assets/2185f063-7f57-4dd2-8735-52011963dff0)

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)