### PR TITLE
[Bug] fix blinds animation (broken after loading-scene delete PR)

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -387,7 +387,6 @@ export default class BattleScene extends SceneBase {
       duration: 1250,
     });
     transition.once("complete", () => {
-      this.textures.remove("loading_bg");
       transition.destroy();
     });
 


### PR DESCRIPTION
## What are the changes?

Fix blinds animation on 2nd++ run. Was broken by #3215.
Closes #3237

## Why am I doing these changes?

Cause I screwed it up in the first place

## Screenshots/Videos

<details>
     <summary>Broken (current) | click to view video</summary>

https://github.com/user-attachments/assets/ffdf8f42-9135-4aee-904f-eee4050b6e19

</details>

### Fixed

https://github.com/user-attachments/assets/12853def-2e20-4402-802b-0e46a7e656fa

## How to test the changes?

1. Start or Continue a run on `beta` branch
2. use `Save & Quit`
    - See the odd green thing at the top left
3. Start or Continue a run on this branch
4. Use `Save & Quit`
    - blinds animation should work as expected

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
