### PR TITLE
[Misc] Remove single-use `EndureAttr`

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -4392,12 +4392,6 @@ export class ProtectAttr extends AddBattlerTagAttr {
   }
 }
 
-export class EndureAttr extends ProtectAttr {
-  constructor() {
-    super(BattlerTagType.ENDURING);
-  }
-}
-
 export class IgnoreAccuracyAttr extends AddBattlerTagAttr {
   constructor() {
     super(BattlerTagType.IGNORE_ACCURACY, true, false, 2);
@@ -6514,7 +6508,7 @@ export function initMoves() {
       .attr(HitHealAttr)
       .triageMove(),
     new SelfStatusMove(Moves.ENDURE, Type.NORMAL, -1, 10, -1, 4, 2)
-      .attr(EndureAttr),
+      .attr(ProtectAttr, BattlerTagType.ENDURING),
     new StatusMove(Moves.CHARM, Type.FAIRY, 100, 20, -1, 0, 2)
       .attr(StatChangeAttr, BattleStat.ATK, -2),
     new AttackMove(Moves.ROLLOUT, Type.ROCK, MoveCategory.PHYSICAL, 30, 90, 20, -1, 0, 2)


### PR DESCRIPTION
## What are the changes?
There are no user-facing changes.

## Why am I doing these changes?
`EndureAttr` was a single-use move attr that only called its super-class constructor.

## What did change?
`EndureAttr` was removed and its one invocation replaced with the use of its super-class `ProtectAttr`.

## How to test the changes?
Use Endure in a battle.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
