### PR TITLE
[Bug] fix double battle edge case stuck/sprite issue when double battle both died and only one bench pokemon not fainted. 

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -3789,11 +3789,10 @@ export class FaintPhase extends PokemonPhase {
       const nonFaintedPartyMemberCount = nonFaintedLegalPartyMembers.length;
       if (!nonFaintedPartyMemberCount) {
         this.scene.unshiftPhase(new GameOverPhase(this.scene));
-      } else if (nonFaintedPartyMemberCount >= this.scene.currentBattle.getBattlerCount() || (this.scene.currentBattle.double && !nonFaintedLegalPartyMembers[0].isActive(true))) {
-        this.scene.pushPhase(new SwitchPhase(this.scene, this.fieldIndex, true, false));
-      }
-      if (nonFaintedPartyMemberCount === 1 && this.scene.currentBattle.double) {
+      } else if (nonFaintedPartyMemberCount === 1 && this.scene.currentBattle.double) {
         this.scene.unshiftPhase(new ToggleDoublePositionPhase(this.scene, true));
+      } else if (nonFaintedPartyMemberCount >= this.scene.currentBattle.getBattlerCount()) {
+        this.scene.pushPhase(new SwitchPhase(this.scene, this.fieldIndex, true, false));
       }
     } else {
       this.scene.unshiftPhase(new VictoryPhase(this.scene, this.battlerIndex));


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
I've changed the ordering of adding phase with ToggleDoublePositionPhase, and delete the "|| (this.scene.currentBattle.double && !nonFaintedLegalPartyMembers[0].isActive(true))" that in the end only one summon phase would be pushed if double battle both fainting and only one pokemon in party is alive
<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I doing these changes?
some msg in this channel catch my eyes that i guess i am able to reproduce out. 
https://discord.com/channels/1125469663833370665/1263924432813035612/1266796567915008101
here's some video to showcase, some shows sprite and positioning issue, some stucks in pokemon selection menu completely: 

https://github.com/user-attachments/assets/b627fd79-bb9d-402d-87eb-e5ddfcf3297c


https://github.com/user-attachments/assets/a1b1e5d7-fb15-426b-8135-6ef0e2caab30


https://github.com/user-attachments/assets/c9636ea4-c2ad-435a-ae4a-acbc3354ceda

(this one still works)

https://github.com/user-attachments/assets/22472b32-1280-426e-8e3c-5db2160445bd



<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What did change?
As what I've said, changed the ordering of adding phase with ToggleDoublePositionPhase, and delete the "|| (this.scene.currentBattle.double && !nonFaintedLegalPartyMembers[0].isActive(true))"

The problem occurs due to double summon phase that occurs when double battle both died and we have only one pokemon alive in party, that then we have the shop in between two summon phases. 

It seems the summon phase's checking at start not working properly, so new code cancelled the second summon phase when there's only one pokemon, even if next battle is double battle and we have revived another pokemon in shop phase. (You might worrying if this case of single pokemon facing say another wild encounter, but the video below shows that is not the case. ) 

the deletion of code is due to that condition is handled by the else if statement one line before, that we no longer need it. that makes that line useless, "nonFaintedPartyMemberCount >= this.scene.currentBattle.getBattlerCount()" only return false when double battle only one pokemon alive, and that is as I said, handled by the else if statement one line before. 


but of course this might give some issue if we want to implement triple battle in future. 
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos

https://github.com/user-attachments/assets/6a0279a9-7c6e-4e77-b97e-082323ae035d


https://github.com/user-attachments/assets/c3dbf514-0b38-4391-a397-a74674cd5725


https://github.com/user-attachments/assets/d5deeae1-4ac6-4609-a373-03fddb840039


https://github.com/user-attachments/assets/13c69f25-3004-4694-bfbb-5177cdc2d83b


<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
I use this override.ts 
```
import { Abilities } from "#enums/abilities";
import { Biome } from "#enums/biome";
import { EggTier } from "#enums/egg-type";
import { Moves } from "#enums/moves";
import { PokeballType } from "#enums/pokeball";
import { Species } from "#enums/species";
import { StatusEffect } from "#enums/status-effect";
import { TimeOfDay } from "#enums/time-of-day";
import { VariantTier } from "#enums/variant-tiers";
import { WeatherType } from "#enums/weather-type";
import { type PokeballCounts } from "./battle-scene";
import { Gender } from "./data/gender";
import { allSpecies } from "./data/pokemon-species"; // eslint-disable-line @typescript-eslint/no-unused-vars
import { Variant } from "./data/variant";
import { type ModifierOverride, type ModifierTypeKeys } from "./modifier/modifier-type";

const overrides = {} satisfies Partial<InstanceType<typeof DefaultOverrides>>;

class DefaultOverrides {
  // -----------------
  // OVERALL OVERRIDES
  // -----------------
  /** a specific seed (default: a random string of 24 characters) */
  readonly SEED_OVERRIDE: string = "";
  readonly WEATHER_OVERRIDE: WeatherType = WeatherType.NONE;
  readonly BATTLE_TYPE_OVERRIDE: "double" | "single" | null = "double";
  readonly STARTING_WAVE_OVERRIDE: integer = 6;
  readonly STARTING_BIOME_OVERRIDE: Biome = Biome.TOWN;
  readonly ARENA_TINT_OVERRIDE: TimeOfDay = null;
  readonly XP_MULTIPLIER_OVERRIDE: number = null;
  readonly STARTING_MONEY_OVERRIDE: integer = 0;
  readonly FREE_CANDY_UPGRADE_OVERRIDE: boolean = false;
  readonly POKEBALL_OVERRIDE: { active: boolean; pokeballs: PokeballCounts } = {
    active: false,
    pokeballs: {
      [PokeballType.POKEBALL]: 5,
      [PokeballType.GREAT_BALL]: 0,
      [PokeballType.ULTRA_BALL]: 0,
      [PokeballType.ROGUE_BALL]: 0,
      [PokeballType.MASTER_BALL]: 0,
    },
  };

  // ----------------
  // PLAYER OVERRIDES
  // ----------------
  readonly STARTER_FORM_OVERRIDES: Partial<Record<Species, number>> = {};

  /** default 5 or 20 for Daily */
  readonly STARTING_LEVEL_OVERRIDE: integer = 0;
  readonly STARTER_SPECIES_OVERRIDE: Species | integer = 0;
  readonly ABILITY_OVERRIDE: Abilities = Abilities.NONE;
  readonly PASSIVE_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
  readonly STATUS_OVERRIDE: StatusEffect = StatusEffect.NONE;
  readonly GENDER_OVERRIDE: Gender = null;
  readonly MOVESET_OVERRIDE: Array<Moves> = [Moves.SHADOW_SNEAK, Moves.SHADOW_BALL, Moves.AGILITY, Moves.TOXIC];
  readonly SHINY_OVERRIDE: boolean = false;
  readonly VARIANT_OVERRIDE: Variant = 0;

  // --------------------------
  // OPPONENT / ENEMY OVERRIDES
  // --------------------------
  readonly OPP_SPECIES_OVERRIDE: Species | integer = Species.SHEDINJA;
  readonly OPP_LEVEL_OVERRIDE: number = 0;
  readonly OPP_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
  readonly OPP_PASSIVE_ABILITY_OVERRIDE: Abilities = Abilities.PRANKSTER;
  readonly OPP_STATUS_OVERRIDE: StatusEffect = StatusEffect.NONE;
  readonly OPP_GENDER_OVERRIDE: Gender = null;
  readonly OPP_MOVESET_OVERRIDE: Array<Moves> = [Moves.DESTINY_BOND, Moves.DESTINY_BOND, Moves.DESTINY_BOND, Moves.DESTINY_BOND];
  readonly OPP_SHINY_OVERRIDE: boolean = false;
  readonly OPP_VARIANT_OVERRIDE: Variant = 0;
  readonly OPP_IVS_OVERRIDE: integer | integer[] = [];

  // -------------
  // EGG OVERRIDES
  // -------------
  readonly EGG_IMMEDIATE_HATCH_OVERRIDE: boolean = false;
  readonly EGG_TIER_OVERRIDE: EggTier = null;
  readonly EGG_SHINY_OVERRIDE: boolean = false;
  readonly EGG_VARIANT_OVERRIDE: VariantTier = null;
  readonly EGG_FREE_GACHA_PULLS_OVERRIDE: boolean = false;
  readonly EGG_GACHA_PULL_COUNT_OVERRIDE: number = 0;

  // -------------------------
  // MODIFIER / ITEM OVERRIDES
  // -------------------------
  readonly STARTING_MODIFIER_OVERRIDE: Array<ModifierOverride> = [];
  readonly OPP_MODIFIER_OVERRIDE: Array<ModifierOverride> = [];

  readonly STARTING_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [{name:"WIDE_LENS", count: 3}];
  readonly OPP_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [{name:"WIDE_LENS", count: 3}];
  readonly NEVER_CRIT_OVERRIDE: boolean = false;

  readonly ITEM_REWARD_OVERRIDE: Array<ModifierTypeKeys> = [];
}

export const defaultOverrides = new DefaultOverrides();

export default {
  ...defaultOverrides,
  ...overrides
} satisfies InstanceType<typeof DefaultOverrides>;

```
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
