### PR TITLE
[Bug] Show arena trap/shadow tag dialog immediately w/o locking instead of as a buffered message

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -4094,6 +4094,7 @@ async function applyAbAttrsInternal<TAttr extends AbAttr>(
   args: any[],
   showAbilityInstant: boolean = false,
   quiet: boolean = false,
+  messages: string[] = undefined,
 ) {
   for (const passive of [false, true]) {
     if (!pokemon.canApplyAbility(passive)) {
@@ -4131,10 +4132,13 @@ async function applyAbAttrsInternal<TAttr extends AbAttr>(
           }
         }
 
-        if (!quiet) {
-          const message = attr.getTriggerMessage(pokemon, ability.name, args);
-          if (message) {
+        const message = attr.getTriggerMessage(pokemon, ability.name, args);
+        if (message) {
+          if (!quiet) {
             pokemon.scene.queueMessage(message);
+          }
+          if (messages !== undefined) {
+            messages.push(message);
           }
         }
       }
@@ -4266,8 +4270,8 @@ export function applyPostTerrainChangeAbAttrs(attrType: Constructor<PostTerrainC
 }
 
 export function applyCheckTrappedAbAttrs(attrType: Constructor<CheckTrappedAbAttr>,
-  pokemon: Pokemon, trapped: Utils.BooleanHolder, otherPokemon: Pokemon, ...args: any[]): Promise<void> {
-  return applyAbAttrsInternal<CheckTrappedAbAttr>(attrType, pokemon, (attr, passive) => attr.applyCheckTrapped(pokemon, passive, trapped, otherPokemon, args), args);
+  pokemon: Pokemon, trapped: Utils.BooleanHolder, otherPokemon: Pokemon, quiet: boolean, messages: string[], ...args: any[]): Promise<void> {
+  return applyAbAttrsInternal<CheckTrappedAbAttr>(attrType, pokemon, (attr, passive) => attr.applyCheckTrapped(pokemon, passive, trapped, otherPokemon, args), args, false, quiet, messages);
 }
 
 export function applyPostBattleAbAttrs(attrType: Constructor<PostBattleAbAttr>,

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2079,8 +2079,9 @@ export class CommandPhase extends FieldPhase {
         const trapTag = playerPokemon.findTag(t => t instanceof TrappedTag) as TrappedTag;
         const trapped = new Utils.BooleanHolder(false);
         const batonPass = isSwitch && args[0] as boolean;
+        const trappedAbMessages: string[] = [];
         if (!batonPass) {
-          enemyField.forEach(enemyPokemon => applyCheckTrappedAbAttrs(CheckTrappedAbAttr, enemyPokemon, trapped, playerPokemon));
+          enemyField.forEach(enemyPokemon => applyCheckTrappedAbAttrs(CheckTrappedAbAttr, enemyPokemon, trapped, playerPokemon, true, trappedAbMessages));
         }
         if (batonPass || (!trapTag && !trapped.value)) {
           this.scene.currentBattle.turnCommands[this.fieldIndex] = isSwitch
@@ -2115,6 +2116,16 @@ export class CommandPhase extends FieldPhase {
                 this.scene.ui.setMode(Mode.COMMAND, this.fieldIndex);
               }
             }, null, true);
+        } else if (trapped.value && trappedAbMessages.length > 0) {
+          if (!isSwitch) {
+            this.scene.ui.setMode(Mode.MESSAGE);
+          }
+          this.scene.ui.showText(trappedAbMessages[0], null, () => {
+            this.scene.ui.showText(null, 0);
+            if (!isSwitch) {
+              this.scene.ui.setMode(Mode.COMMAND, this.fieldIndex);
+            }
+          }, null, true);
         }
       }
       break;
@@ -2191,7 +2202,7 @@ export class EnemyCommandPhase extends FieldPhase {
 
       const trapTag = enemyPokemon.findTag(t => t instanceof TrappedTag) as TrappedTag;
       const trapped = new Utils.BooleanHolder(false);
-      opponents.forEach(playerPokemon => applyCheckTrappedAbAttrs(CheckTrappedAbAttr, playerPokemon, trapped, enemyPokemon));
+      opponents.forEach(playerPokemon => applyCheckTrappedAbAttrs(CheckTrappedAbAttr, playerPokemon, trapped, enemyPokemon, false, undefined));
       if (!trapTag && !trapped.value) {
         const partyMemberScores = trainer.getPartyMemberMatchupScores(enemyPokemon.trainerSlot, true);
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
The user will receive dialog that their Pokemon cannot switch out/run as their enemy pokemon has a arena trap-related ability (Arena Trap, Magnet Pull, Shadow Tag). This feedback will now not soft-lock the user as well. 
In the past, the user would receive feedback in an inappropriate time or get soft-locked by these abilities.

## Why am I doing these changes?
Closes #3217, #2524

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
The condition-checking stayed the same, but the side effect was modified. Instead of calling queueMessage(), the code will immediately show a dialog in the CommandPhase. 

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
Before (currently):
All arena traps don't show anything until the user selects a command
[magnet-pull.webm](https://github.com/user-attachments/assets/af971038-ba59-462b-b248-a64958fec670)
[shadow-tag.webm](https://github.com/user-attachments/assets/fe4af576-d7f0-4e14-ad1a-976f38884820)
[arena-trap.webm](https://github.com/user-attachments/assets/0827cbd9-a9c3-4b75-8c58-b49ed06ebdb7)


Before (a month ago / tested from commit e2507a2):
User gets soft-locked
[soft-lock.webm](https://github.com/user-attachments/assets/b411aba3-2d82-4063-b3cf-b1a41fa156a6)


Changes:
[magnet-pull-2.webm](https://github.com/user-attachments/assets/3d629e01-0d8a-440e-8ba2-f55c0b406ce0)
[shadow-tag-2.webm](https://github.com/user-attachments/assets/58ac9051-66b2-45f0-9ff2-c72519d79525)
[arena-trap-2.webm](https://github.com/user-attachments/assets/94c56fa4-e7d8-4059-bffa-84b2e32bdf3b)


if pokemon can escape successfully
[escape.webm](https://github.com/user-attachments/assets/5b667460-7430-4a1f-8dc2-7cc4cc4a90f1)




## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Edit the src/overrides.ts file to test it
I did not introduce any automated tests, but not sure if it should be part of this PR or a new PR.

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
   - Yes, would like to have feedback if this is necessary.
- [X] Have I tested the changes (manually)?
   - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
