### PR TITLE
[Misc?] Removes the temporary save-fix code that swaps abilities

### DIFF
--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -41,7 +41,6 @@ import { Moves } from "#enums/moves";
 import { PlayerGender } from "#enums/player-gender";
 import { Species } from "#enums/species";
 import { applyChallenges, ChallengeType } from "#app/data/challenge.js";
-import { Abilities } from "#app/enums/abilities.js";
 
 export const defaultStarterSpecies: Species[] = [
   Species.BULBASAUR, Species.CHARMANDER, Species.SQUIRTLE,
@@ -852,14 +851,6 @@ export class GameData {
       const handleSessionData = async (sessionDataStr: string) => {
         try {
           const sessionData = this.parseSessionData(sessionDataStr);
-          for (let i = 0; i <= 5; i++) {
-            const speciesToCheck = getPokemonSpecies(sessionData.party[i]?.species);
-            if (sessionData.party[i]?.abilityIndex === 1) {
-              if (speciesToCheck.ability1 === speciesToCheck.ability2 && speciesToCheck.abilityHidden !== Abilities.NONE && speciesToCheck.abilityHidden !== speciesToCheck.ability1) {
-                sessionData.party[i].abilityIndex = 2;
-              }
-            }
-          }
           resolve(sessionData);
         } catch (err) {
           reject(err);


### PR DESCRIPTION
## What are the changes?
Removes the ability-swap code from session loading.

## Why am I doing these changes?
It was temporary, also there's a bug anyway.

## What did change?
Check to swap from `abilityIndex` of 1 to 2 is removed from session loading.

## How to test the changes?
Start with a Scatterbug with its second ability, evolve it (and move forward 1 wave to force a save), then reload the session.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
