### PR TITLE
[Localization] Localize pokemon form change message and translate

### DIFF
--- a/src/data/pokemon-forms.ts
+++ b/src/data/pokemon-forms.ts
@@ -9,6 +9,7 @@ import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
 import { TimeOfDay } from "#enums/time-of-day";
 import { getPokemonNameWithAffix } from "#app/messages.js";
+import i18next from "i18next";
 
 export enum FormChangeItem {
   NONE,
@@ -357,22 +358,21 @@ export class SpeciesDefaultFormMatchTrigger extends SpeciesFormChangeTrigger {
 export function getSpeciesFormChangeMessage(pokemon: Pokemon, formChange: SpeciesFormChange, preName: string): string {
   const isMega = formChange.formKey.indexOf(SpeciesFormKey.MEGA) > -1;
   const isGmax = formChange.formKey.indexOf(SpeciesFormKey.GIGANTAMAX) > -1;
-  const isEmax = formChange.formKey.indexOf("eternamax") > -1;
+  const isEmax = formChange.formKey.indexOf(SpeciesFormKey.ETERNAMAX) > -1;
   const isRevert = !isMega && formChange.formKey === pokemon.species.forms[0].formKey;
-  const prefix = !pokemon.isPlayer() ? pokemon.hasTrainer() ? "Foe " : "Wild " : "Your ";
   if (isMega) {
-    return `${prefix}${preName} Mega Evolved\ninto ${pokemon.name}!`;
+    return i18next.t("battlePokemonForm:megaChange", { preName, pokemonName: pokemon.name });
   }
   if (isGmax) {
-    return `${prefix}${preName} Gigantamaxed\ninto ${pokemon.name}!`;
+    return i18next.t("battlePokemonForm:gigantamaxChange", { preName, pokemonName: pokemon.name });
   }
   if (isEmax) {
-    return `${prefix}${preName} Eternamaxed\ninto ${pokemon.name}!`;
+    return i18next.t("battlePokemonForm:eternamaxChange", { preName, pokemonName: pokemon.name });
   }
   if (isRevert) {
-    return `${prefix}${getPokemonNameWithAffix(pokemon)} reverted\nto its original form!`;
+    return i18next.t("battlePokemonForm:revertChange", { pokemonName: getPokemonNameWithAffix(pokemon) });
   }
-  return `${prefix}${preName} changed form!`;
+  return i18next.t("battlePokemonForm:formChange", { preName });
 }
 
 /**

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -630,7 +630,7 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
       }
 
       if (key) {
-        return i18next.t(`pokemonForm:${key}`, {pokemonName: this.name});
+        return i18next.t(`battlePokemonForm:${key}`, {pokemonName: this.name});
       }
     }
     return this.name;

--- a/src/locales/de/config.ts
+++ b/src/locales/de/config.ts
@@ -36,7 +36,7 @@ import { move } from "./move";
 import { nature } from "./nature";
 import { pokeball } from "./pokeball";
 import { pokemon } from "./pokemon";
-import { pokemonForm } from "./pokemon-form";
+import { pokemonForm, battlePokemonForm } from "./pokemon-form";
 import { pokemonInfo } from "./pokemon-info";
 import { pokemonInfoContainer } from "./pokemon-info-container";
 import { pokemonSummary } from "./pokemon-summary";
@@ -62,6 +62,7 @@ export const deConfig = {
   battle: battle,
   battleInfo: battleInfo,
   battleMessageUiHandler: battleMessageUiHandler,
+  battlePokemonForm: battlePokemonForm,
   battlerTags: battlerTags,
   berry: berry,
   bgmName: bgmName,

--- a/src/locales/de/pokemon-form.ts
+++ b/src/locales/de/pokemon-form.ts
@@ -9,11 +9,11 @@ export const battlePokemonForm: SimpleTranslationEntries = {
   "gigantamax": "G-Dyna-{{pokemonName}}",
   "eternamax": "U-Dyna-{{pokemonName}}",
 
-  "megaChange": "{{preName}} Mega Evolved\ninto {{pokemonName}}!",
-  "gigantamaxChange": "{{preName}} Gigantamaxed\ninto {{pokemonName}}!",
-  "eternamaxChange": "{{preName}} Eternamaxed\ninto {{pokemonName}}!",
-  "revertChange": "{{pokemonName}} reverted\nto its original form!",
-  "formChange": "{{preName}} changed form!",
+  "megaChange": "{{preName}} hat sich zu {{pokemonName}} mega-entwickelt!",
+  "gigantamaxChange": "{{preName}} hat sich zu {{pokemonName}} gigadynamaximiert!",
+  "eternamaxChange": "{{preName}} hat sich zu {{pokemonName}} unendynamaximiert!",
+  "revertChange": "{{pokemonName}} hat seine ursprüngliche Form zurückerlangt!",
+  "formChange": "{{preName}} hat seine Form geändert!",
 } as const;
 
 export const pokemonForm: SimpleTranslationEntries = {

--- a/src/locales/de/pokemon-form.ts
+++ b/src/locales/de/pokemon-form.ts
@@ -1,6 +1,6 @@
 import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
-export const pokemonForm: SimpleTranslationEntries = {
+export const battlePokemonForm: SimpleTranslationEntries = {
   // Battle forms
   "mega": "Mega-{{pokemonName}}",
   "mega-x": "Mega-{{pokemonName}} X",
@@ -9,6 +9,14 @@ export const pokemonForm: SimpleTranslationEntries = {
   "gigantamax": "G-Dyna-{{pokemonName}}",
   "eternamax": "U-Dyna-{{pokemonName}}",
 
+  "megaChange": "{{preName}} Mega Evolved\ninto {{pokemonName}}!",
+  "gigantamaxChange": "{{preName}} Gigantamaxed\ninto {{pokemonName}}!",
+  "eternamaxChange": "{{preName}} Eternamaxed\ninto {{pokemonName}}!",
+  "revertChange": "{{pokemonName}} reverted\nto its original form!",
+  "formChange": "{{preName}} changed form!",
+} as const;
+
+export const pokemonForm: SimpleTranslationEntries = {
   // Starters forms
   // 1G
   "pikachuCosplay": "Cosplay",

--- a/src/locales/en/config.ts
+++ b/src/locales/en/config.ts
@@ -39,7 +39,7 @@ import { nature } from "./nature";
 import { partyUiHandler } from "./party-ui-handler";
 import { pokeball } from "./pokeball";
 import { pokemon } from "./pokemon";
-import { pokemonForm } from "./pokemon-form";
+import { pokemonForm, battlePokemonForm } from "./pokemon-form";
 import { pokemonInfo } from "./pokemon-info";
 import { pokemonInfoContainer } from "./pokemon-info-container";
 import { pokemonSummary } from "./pokemon-summary";
@@ -62,6 +62,7 @@ export const enConfig = {
   battle: battle,
   battleInfo: battleInfo,
   battleMessageUiHandler: battleMessageUiHandler,
+  battlePokemonForm: battlePokemonForm,
   battlerTags: battlerTags,
   berry: berry,
   bgmName: bgmName,

--- a/src/locales/en/pokemon-form.ts
+++ b/src/locales/en/pokemon-form.ts
@@ -1,7 +1,6 @@
 import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
-export const pokemonForm: SimpleTranslationEntries = {
-  // Battle forms
+export const battlePokemonForm: SimpleTranslationEntries = {
   "mega": "Mega {{pokemonName}}",
   "mega-x": "Mega {{pokemonName}} X",
   "mega-y": "Mega {{pokemonName}} Y",
@@ -9,6 +8,14 @@ export const pokemonForm: SimpleTranslationEntries = {
   "gigantamax": "G-Max {{pokemonName}}",
   "eternamax": "E-Max {{pokemonName}}",
 
+  "megaChange": "{{preName}} Mega Evolved\ninto {{pokemonName}}!",
+  "gigantamaxChange": "{{preName}} Gigantamaxed\ninto {{pokemonName}}!",
+  "eternamaxChange": "{{preName}} Eternamaxed\ninto {{pokemonName}}!",
+  "revertChange": "{{pokemonName}} reverted\nto its original form!",
+  "formChange": "{{preName}} changed form!",
+} as const;
+
+export const pokemonForm: SimpleTranslationEntries = {
   // Starters forms
   // 1G
   "pikachuCosplay": "Cosplay",

--- a/src/locales/es/config.ts
+++ b/src/locales/es/config.ts
@@ -36,7 +36,7 @@ import { move } from "./move";
 import { nature } from "./nature";
 import { pokeball } from "./pokeball";
 import { pokemon } from "./pokemon";
-import { pokemonForm } from "./pokemon-form";
+import { pokemonForm, battlePokemonForm } from "./pokemon-form";
 import { pokemonInfo } from "./pokemon-info";
 import { pokemonInfoContainer } from "./pokemon-info-container";
 import { pokemonSummary } from "./pokemon-summary";
@@ -62,6 +62,7 @@ export const esConfig = {
   battle: battle,
   battleInfo: battleInfo,
   battleMessageUiHandler: battleMessageUiHandler,
+  battlePokemonForm: battlePokemonForm,
   battlerTags: battlerTags,
   berry: berry,
   bgmName: bgmName,

--- a/src/locales/es/pokemon-form.ts
+++ b/src/locales/es/pokemon-form.ts
@@ -1,7 +1,6 @@
 import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
-export const pokemonForm: SimpleTranslationEntries = {
-  // Battle forms
+export const battlePokemonForm: SimpleTranslationEntries = {
   "mega": "Mega {{pokemonName}}",
   "mega-x": "Mega {{pokemonName}} X",
   "mega-y": "Mega {{pokemonName}} Y",
@@ -9,6 +8,14 @@ export const pokemonForm: SimpleTranslationEntries = {
   "gigantamax": "G-Max {{pokemonName}}",
   "eternamax": "E-Max {{pokemonName}}",
 
+  "megaChange": "{{preName}} Mega Evolved\ninto {{pokemonName}}!",
+  "gigantamaxChange": "{{preName}} Gigantamaxed\ninto {{pokemonName}}!",
+  "eternamaxChange": "{{preName}} Eternamaxed\ninto {{pokemonName}}!",
+  "revertChange": "{{pokemonName}} reverted\nto its original form!",
+  "formChange": "{{preName}} changed form!",
+} as const;
+
+export const pokemonForm: SimpleTranslationEntries = {
   // Starters forms
   // 1G
   "pikachuCosplay": "Coqueta",

--- a/src/locales/fr/config.ts
+++ b/src/locales/fr/config.ts
@@ -36,7 +36,7 @@ import { move } from "./move";
 import { nature } from "./nature";
 import { pokeball } from "./pokeball";
 import { pokemon } from "./pokemon";
-import { pokemonForm } from "./pokemon-form";
+import { pokemonForm, battlePokemonForm } from "./pokemon-form";
 import { pokemonInfo } from "./pokemon-info";
 import { pokemonInfoContainer } from "./pokemon-info-container";
 import { pokemonSummary } from "./pokemon-summary";
@@ -62,6 +62,7 @@ export const frConfig = {
   battle: battle,
   battleInfo: battleInfo,
   battleMessageUiHandler: battleMessageUiHandler,
+  battlePokemonForm: battlePokemonForm,
   battlerTags: battlerTags,
   berry: berry,
   bgmName: bgmName,

--- a/src/locales/fr/pokemon-form.ts
+++ b/src/locales/fr/pokemon-form.ts
@@ -1,7 +1,6 @@
 import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
-export const pokemonForm: SimpleTranslationEntries = {
-  // Battle forms
+export const battlePokemonForm: SimpleTranslationEntries = {
   "mega": "Méga-{{pokemonName}}",
   "mega-x": "Méga-{{pokemonName}} X",
   "mega-y": "Méga-{{pokemonName}} Y",
@@ -9,6 +8,14 @@ export const pokemonForm: SimpleTranslationEntries = {
   "gigantamax": "{{pokemonName}} Gigamax",
   "eternamax": "{{pokemonName}} Infinimax",
 
+  "megaChange": "{{preName}} Mega Evolved\ninto {{pokemonName}}!",
+  "gigantamaxChange": "{{preName}} Gigantamaxed\ninto {{pokemonName}}!",
+  "eternamaxChange": "{{preName}} Eternamaxed\ninto {{pokemonName}}!",
+  "revertChange": "{{pokemonName}} reverted\nto its original form!",
+  "formChange": "{{preName}} changed form!",
+} as const;
+
+export const pokemonForm: SimpleTranslationEntries = {
   // Starters forms
   // 1G
   "pikachuCosplay": "Cosplayeur",

--- a/src/locales/fr/pokemon-form.ts
+++ b/src/locales/fr/pokemon-form.ts
@@ -8,11 +8,11 @@ export const battlePokemonForm: SimpleTranslationEntries = {
   "gigantamax": "{{pokemonName}} Gigamax",
   "eternamax": "{{pokemonName}} Infinimax",
 
-  "megaChange": "{{preName}} Mega Evolved\ninto {{pokemonName}}!",
-  "gigantamaxChange": "{{preName}} Gigantamaxed\ninto {{pokemonName}}!",
-  "eternamaxChange": "{{preName}} Eternamaxed\ninto {{pokemonName}}!",
-  "revertChange": "{{pokemonName}} reverted\nto its original form!",
-  "formChange": "{{preName}} changed form!",
+  "megaChange": "{{preName}} méga-évolue\nen {{pokemonName}} !",
+  "gigantamaxChange": "{{preName}} se gigamaxe\nen {{pokemonName}} !",
+  "eternamaxChange": "{{preName}} devient\n{{pokemonName}} !",
+  "revertChange": "{{pokemonName}} retourne\nà sa forme initiale !",
+  "formChange": "{{preName}} change de forme !",
 } as const;
 
 export const pokemonForm: SimpleTranslationEntries = {

--- a/src/locales/it/config.ts
+++ b/src/locales/it/config.ts
@@ -36,7 +36,7 @@ import { move } from "./move";
 import { nature } from "./nature";
 import { pokeball } from "./pokeball";
 import { pokemon } from "./pokemon";
-import { pokemonForm } from "./pokemon-form";
+import { pokemonForm, battlePokemonForm } from "./pokemon-form";
 import { pokemonInfo } from "./pokemon-info";
 import { pokemonInfoContainer } from "./pokemon-info-container";
 import { pokemonSummary } from "./pokemon-summary";
@@ -62,6 +62,7 @@ export const itConfig = {
   battle: battle,
   battleInfo: battleInfo,
   battleMessageUiHandler: battleMessageUiHandler,
+  battlePokemonForm: battlePokemonForm,
   battlerTags: battlerTags,
   berry: berry,
   bgmName: bgmName,

--- a/src/locales/it/pokemon-form.ts
+++ b/src/locales/it/pokemon-form.ts
@@ -8,11 +8,11 @@ export const battlePokemonForm: SimpleTranslationEntries = {
   "gigantamax": "GigaMax {{pokemonName}}",
   "eternamax": "EternaMax {{pokemonName}}",
 
-  "megaChange": "{{preName}} Mega Evolved\ninto {{pokemonName}}!",
-  "gigantamaxChange": "{{preName}} Gigantamaxed\ninto {{pokemonName}}!",
-  "eternamaxChange": "{{preName}} Eternamaxed\ninto {{pokemonName}}!",
-  "revertChange": "{{pokemonName}} reverted\nto its original form!",
-  "formChange": "{{preName}} changed form!",
+  "megaChange": "{{preName}} si evolve\nin {{pokemonName}}!",
+  "gigantamaxChange": "{{preName}} si Gigamaxxizza\nin {{pokemonName}}!",
+  "eternamaxChange": "{{preName}} si Dynamaxxa infinitamente\nin {{pokemonName}}!",
+  "revertChange": "{{pokemonName}} è tornato\nalla sua forma originaria!",
+  "formChange": "{{preName}} ha cambiato forma!",
 } as const;
 
 export const pokemonForm: SimpleTranslationEntries = {

--- a/src/locales/it/pokemon-form.ts
+++ b/src/locales/it/pokemon-form.ts
@@ -1,7 +1,6 @@
 import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
-export const pokemonForm: SimpleTranslationEntries = {
-  // Battle forms
+export const battlePokemonForm: SimpleTranslationEntries = {
   "mega": "Mega {{pokemonName}}",
   "mega-x": "Mega {{pokemonName}} X",
   "mega-y": "Mega {{pokemonName}} Y",
@@ -9,6 +8,14 @@ export const pokemonForm: SimpleTranslationEntries = {
   "gigantamax": "GigaMax {{pokemonName}}",
   "eternamax": "EternaMax {{pokemonName}}",
 
+  "megaChange": "{{preName}} Mega Evolved\ninto {{pokemonName}}!",
+  "gigantamaxChange": "{{preName}} Gigantamaxed\ninto {{pokemonName}}!",
+  "eternamaxChange": "{{preName}} Eternamaxed\ninto {{pokemonName}}!",
+  "revertChange": "{{pokemonName}} reverted\nto its original form!",
+  "formChange": "{{preName}} changed form!",
+} as const;
+
+export const pokemonForm: SimpleTranslationEntries = {
   // Starters forms
   // 1G
   "pikachuCosplay": "Cosplay",

--- a/src/locales/ko/config.ts
+++ b/src/locales/ko/config.ts
@@ -1,4 +1,3 @@
-import { pokemonForm } from "./pokemon-form";
 import { ability } from "./ability";
 import { abilityTriggers } from "./ability-trigger";
 import { arenaFlyout } from "./arena-flyout";
@@ -37,6 +36,7 @@ import { move } from "./move";
 import { nature } from "./nature";
 import { pokeball } from "./pokeball";
 import { pokemon } from "./pokemon";
+import { pokemonForm, battlePokemonForm } from "./pokemon-form";
 import { pokemonInfo } from "./pokemon-info";
 import { pokemonInfoContainer } from "./pokemon-info-container";
 import { pokemonSummary } from "./pokemon-summary";
@@ -62,6 +62,7 @@ export const koConfig = {
   battle: battle,
   battleInfo: battleInfo,
   battleMessageUiHandler: battleMessageUiHandler,
+  battlePokemonForm: battlePokemonForm,
   battlerTags: battlerTags,
   berry: berry,
   bgmName: bgmName,

--- a/src/locales/ko/pokemon-form.ts
+++ b/src/locales/ko/pokemon-form.ts
@@ -1,7 +1,6 @@
 import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
-export const pokemonForm: SimpleTranslationEntries = {
-  // Battle forms
+export const battlePokemonForm: SimpleTranslationEntries = {
   "mega": "메가{{pokemonName}}",
   "mega-x": "메가{{pokemonName}}X",
   "mega-y": "메가{{pokemonName}}Y",
@@ -9,6 +8,14 @@ export const pokemonForm: SimpleTranslationEntries = {
   "gigantamax": "거다이맥스 {{pokemonName}}",
   "eternamax": "무한다이맥스 {{pokemonName}}",
 
+  "megaChange": "{{preName}}[[는]]\n{{pokemonName}}[[로]] 메가진화했다!",
+  "gigantamaxChange": "{{preName}}[[는]]\n{{pokemonName}}가 되었다!",
+  "eternamaxChange": "{{preName}}[[는]]\n{{pokemonName}}가 되었다!",
+  "revertChange": "{{pokemonName}}[[는]]\n원래 모습으로 되돌아왔다!",
+  "formChange": "{{preName}}[[는]]\n다른 모습으로 변화했다!",
+} as const;
+
+export const pokemonForm: SimpleTranslationEntries = {
   // Starters forms
   // 1G
   "pikachuCosplay": "옷갈아입기",

--- a/src/locales/pt_BR/config.ts
+++ b/src/locales/pt_BR/config.ts
@@ -39,7 +39,7 @@ import { nature } from "./nature";
 import { partyUiHandler } from "./party-ui-handler";
 import { pokeball } from "./pokeball";
 import { pokemon } from "./pokemon";
-import { pokemonForm } from "./pokemon-form";
+import { pokemonForm, battlePokemonForm } from "./pokemon-form";
 import { pokemonInfo } from "./pokemon-info";
 import { pokemonInfoContainer } from "./pokemon-info-container";
 import { pokemonSummary } from "./pokemon-summary";
@@ -62,6 +62,7 @@ export const ptBrConfig = {
   battle: battle,
   battleInfo: battleInfo,
   battleMessageUiHandler: battleMessageUiHandler,
+  battlePokemonForm: battlePokemonForm,
   battlerTags: battlerTags,
   berry: berry,
   bgmName: bgmName,

--- a/src/locales/pt_BR/pokemon-form.ts
+++ b/src/locales/pt_BR/pokemon-form.ts
@@ -1,13 +1,21 @@
 import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
-export const pokemonForm: SimpleTranslationEntries = {
-  // Battle forms
+export const battlePokemonForm: SimpleTranslationEntries = {
   "mega": "Mega {{pokemonName}}",
   "mega-x": "Mega {{pokemonName}} X",
   "mega-y": "Mega {{pokemonName}} Y",
   "primal": "{{pokemonName}} Primordial",
   "gigantamax": "G-Max {{pokemonName}}",
   "eternamax": "E-Max {{pokemonName}}",
+
+  "megaChange": "{{preName}} Mega Evolved\ninto {{pokemonName}}!",
+  "gigantamaxChange": "{{preName}} Gigantamaxed\ninto {{pokemonName}}!",
+  "eternamaxChange": "{{preName}} Eternamaxed\ninto {{pokemonName}}!",
+  "revertChange": "{{pokemonName}} reverted\nto its original form!",
+  "formChange": "{{preName}} changed form!",
+} as const;
+
+export const pokemonForm: SimpleTranslationEntries = {
 
   // Starters forms
   // 1G

--- a/src/locales/pt_BR/pokemon-form.ts
+++ b/src/locales/pt_BR/pokemon-form.ts
@@ -8,11 +8,11 @@ export const battlePokemonForm: SimpleTranslationEntries = {
   "gigantamax": "G-Max {{pokemonName}}",
   "eternamax": "E-Max {{pokemonName}}",
 
-  "megaChange": "{{preName}} Mega Evolved\ninto {{pokemonName}}!",
-  "gigantamaxChange": "{{preName}} Gigantamaxed\ninto {{pokemonName}}!",
-  "eternamaxChange": "{{preName}} Eternamaxed\ninto {{pokemonName}}!",
-  "revertChange": "{{pokemonName}} reverted\nto its original form!",
-  "formChange": "{{preName}} changed form!",
+  "megaChange": "{{preName}} Mega Evoluiu\npara {{pokemonName}}!",
+  "gigantamaxChange": "{{preName}} Gigantamaxou\npara {{pokemonName}}!",
+  "eternamaxChange": "{{preName}} Eternamaxou\npara {{pokemonName}}!",
+  "revertChange": "{{pokemonName}} voltou\npara sua forma original!",
+  "formChange": "{{preName}} mudou de forma!",
 } as const;
 
 export const pokemonForm: SimpleTranslationEntries = {

--- a/src/locales/zh_CN/config.ts
+++ b/src/locales/zh_CN/config.ts
@@ -36,7 +36,7 @@ import { move } from "./move";
 import { nature } from "./nature";
 import { pokeball } from "./pokeball";
 import { pokemon } from "./pokemon";
-import { pokemonForm } from "./pokemon-form";
+import { pokemonForm, battlePokemonForm } from "./pokemon-form";
 import { pokemonInfo } from "./pokemon-info";
 import { pokemonInfoContainer } from "./pokemon-info-container";
 import { pokemonSummary } from "./pokemon-summary";
@@ -62,6 +62,7 @@ export const zhCnConfig = {
   battle: battle,
   battleInfo: battleInfo,
   battleMessageUiHandler: battleMessageUiHandler,
+  battlePokemonForm: battlePokemonForm,
   battlerTags: battlerTags,
   berry: berry,
   bgmName: bgmName,

--- a/src/locales/zh_CN/pokemon-form.ts
+++ b/src/locales/zh_CN/pokemon-form.ts
@@ -1,7 +1,6 @@
 import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
-export const pokemonForm: SimpleTranslationEntries = {
-  // Battle forms
+export const battlePokemonForm: SimpleTranslationEntries = {
   "mega": "Mega {{pokemonName}}",
   "mega-x": "Mega {{pokemonName}} X",
   "mega-y": "Mega {{pokemonName}} Y",
@@ -9,6 +8,14 @@ export const pokemonForm: SimpleTranslationEntries = {
   "gigantamax": "超极巨{{pokemonName}}",
   "eternamax": "无极巨{{pokemonName}}",
 
+  "megaChange": "{{preName}} Mega Evolved\ninto {{pokemonName}}!",
+  "gigantamaxChange": "{{preName}} Gigantamaxed\ninto {{pokemonName}}!",
+  "eternamaxChange": "{{preName}} Eternamaxed\ninto {{pokemonName}}!",
+  "revertChange": "{{pokemonName}} reverted\nto its original form!",
+  "formChange": "{{preName}} changed form!",
+} as const;
+
+export const pokemonForm: SimpleTranslationEntries = {
   // Starters forms
   // 1G
   "pikachuCosplay": "服装",

--- a/src/locales/zh_CN/pokemon-form.ts
+++ b/src/locales/zh_CN/pokemon-form.ts
@@ -8,11 +8,11 @@ export const battlePokemonForm: SimpleTranslationEntries = {
   "gigantamax": "超极巨{{pokemonName}}",
   "eternamax": "无极巨{{pokemonName}}",
 
-  "megaChange": "{{preName}} Mega Evolved\ninto {{pokemonName}}!",
-  "gigantamaxChange": "{{preName}} Gigantamaxed\ninto {{pokemonName}}!",
-  "eternamaxChange": "{{preName}} Eternamaxed\ninto {{pokemonName}}!",
-  "revertChange": "{{pokemonName}} reverted\nto its original form!",
-  "formChange": "{{preName}} changed form!",
+  "megaChange": "{{preName}}超级进化成了\n{{pokemonName}}！",
+  "gigantamaxChange": "{{preName}}超极巨化成了\n{{pokemonName}}！",
+  "eternamaxChange": "{{preName}}无极巨化成了\n{{pokemonName}}！",
+  "revertChange": "{{pokemonName}}变回了\n原本的样子！",
+  "formChange": "{{preName}}变成其他样子了。",
 } as const;
 
 export const pokemonForm: SimpleTranslationEntries = {

--- a/src/locales/zh_TW/config.ts
+++ b/src/locales/zh_TW/config.ts
@@ -36,7 +36,7 @@ import { move } from "./move";
 import { nature } from "./nature";
 import { pokeball } from "./pokeball";
 import { pokemon } from "./pokemon";
-import { pokemonForm } from "./pokemon-form";
+import { pokemonForm, battlePokemonForm } from "./pokemon-form";
 import { pokemonInfo } from "./pokemon-info";
 import { pokemonInfoContainer } from "./pokemon-info-container";
 import { pokemonSummary } from "./pokemon-summary";
@@ -62,6 +62,7 @@ export const zhTwConfig = {
   battle: battle,
   battleInfo: battleInfo,
   battleMessageUiHandler: battleMessageUiHandler,
+  battlePokemonForm: battlePokemonForm,
   battlerTags: battlerTags,
   berry: berry,
   bgmName: bgmName,

--- a/src/locales/zh_TW/pokemon-form.ts
+++ b/src/locales/zh_TW/pokemon-form.ts
@@ -1,7 +1,6 @@
 import { SimpleTranslationEntries } from "#app/interfaces/locales";
 
-export const pokemonForm: SimpleTranslationEntries = {
-  // Battle forms
+export const battlePokemonForm: SimpleTranslationEntries = {
   "mega": "Mega {{pokemonName}}",
   "mega-x": "Mega {{pokemonName}} X",
   "mega-y": "Mega {{pokemonName}} Y",
@@ -9,6 +8,14 @@ export const pokemonForm: SimpleTranslationEntries = {
   "gigantamax": "G-Max {{pokemonName}}",
   "eternamax": "E-Max {{pokemonName}}",
 
+  "megaChange": "{{preName}} Mega Evolved\ninto {{pokemonName}}!",
+  "gigantamaxChange": "{{preName}} Gigantamaxed\ninto {{pokemonName}}!",
+  "eternamaxChange": "{{preName}} Eternamaxed\ninto {{pokemonName}}!",
+  "revertChange": "{{pokemonName}} reverted\nto its original form!",
+  "formChange": "{{preName}} changed form!",
+} as const;
+
+export const pokemonForm: SimpleTranslationEntries = {
   // Starters forms
   // 1G
   "pikachuCosplay": "Cosplay",

--- a/src/locales/zh_TW/pokemon-form.ts
+++ b/src/locales/zh_TW/pokemon-form.ts
@@ -8,11 +8,11 @@ export const battlePokemonForm: SimpleTranslationEntries = {
   "gigantamax": "G-Max {{pokemonName}}",
   "eternamax": "E-Max {{pokemonName}}",
 
-  "megaChange": "{{preName}} Mega Evolved\ninto {{pokemonName}}!",
-  "gigantamaxChange": "{{preName}} Gigantamaxed\ninto {{pokemonName}}!",
-  "eternamaxChange": "{{preName}} Eternamaxed\ninto {{pokemonName}}!",
-  "revertChange": "{{pokemonName}} reverted\nto its original form!",
-  "formChange": "{{preName}} changed form!",
+  "megaChange": "{{preName}}超級進化成了\n{{pokemonName}}！",
+  "gigantamaxChange": "{{preName}}超極巨化成了\n{{pokemonName}}！",
+  "eternamaxChange": "{{preName}}無極巨化成了\n{{pokemonName}}！",
+  "revertChange": "{{pokemonName}}變回了\n原本的樣子！",
+  "formChange": "{{preName}}變為其他樣子了。",
 } as const;
 
 export const pokemonForm: SimpleTranslationEntries = {


### PR DESCRIPTION
## What are the changes?
Add the option to localize message text when pokemon battle form is changed.

## Why am I doing these changes?
All text should be localizable.

## What did change?
 - Change pokemon-form.ts > getSpeciesFormChangeMessage
  - Remove duplicate prefix in form change method (because preName is normally from getPokemonNameWithAffix)
  - Change hard-coded key "eternamax" -> SpeciesFormKey.ETERNAMAX
  - Change hard-coded message for localize
 - Added config, localization keys in each language folders.
 - Separated battle form message keys to distinguish between battle form(with item) and pokemon's form.
 - Translated them to Korean. (+ each language after review)

### Screenshots/Videos

#### En
<details>
<summary>Click to expand/collapse</summary>

| Case | Result |
| :-----: | :-----: |
| Mega | ![image](https://github.com/user-attachments/assets/520a6a82-80ec-4883-9d1e-ac61a58b479e) |
| Gigantmax | ![image](https://github.com/user-attachments/assets/43e29240-45d1-4592-8a1c-4001568ba447) |
| Eternamax | ![image](https://github.com/user-attachments/assets/926e79fa-70c4-4a98-92ab-8e518787be99) |
| Other | ![image](https://github.com/user-attachments/assets/357159ea-2d61-4b34-9eb8-3d2cb0ab2ba8) |
| Revert | ![image](https://github.com/user-attachments/assets/431719e5-23b1-47dc-a8bf-d9d21e798b69) |

</details>

#### It
<details>
<summary>Click to expand/collapse</summary>

| Case | Result |
| :-----: | :-----: |
| Mega | ![image](https://github.com/user-attachments/assets/0f40ba8e-ef9a-4695-9e0d-67dc7b05778e) |
| Gigantmax | ![image](https://github.com/user-attachments/assets/c5526492-2103-4981-a118-146632b01be8) |
| Eternamax | ![image](https://github.com/user-attachments/assets/1ccc2831-21f4-4042-aacb-464a31146b98) |
| Other | ![image](https://github.com/user-attachments/assets/b7e73b3b-8210-48d0-b5e1-c5483dcf5088) |
| Revert | ![image](https://github.com/user-attachments/assets/9568ca5f-f739-4a50-82e0-3c985c712a29) |

</details>

#### De
<details>
<summary>Click to expand/collapse</summary>

| Case | Result |
| :-----: | :-----: |
| Mega | ![image](https://github.com/user-attachments/assets/cd21d168-2f09-4197-af9f-045f2d67e049) |
| Gigantmax | ![image](https://github.com/user-attachments/assets/4b5087d5-3450-4660-a2a1-8b240d5a69b4) |
| Eternamax | ![image](https://github.com/user-attachments/assets/d2653393-a94f-4e4c-b5df-96f178cd2b5d) |
| Other | ![image](https://github.com/user-attachments/assets/0eff9e72-0257-4dd2-bd10-b97e0f4d97f0) |
| Revert | ![image](https://github.com/user-attachments/assets/c4574adc-dc85-425d-96d4-97d68a741fae) |

</details>

#### Fr
<details>
<summary>Click to expand/collapse</summary>

| Case | Result |
| :-----: | :-----: |
| Mega | ![image](https://github.com/user-attachments/assets/43280b43-8621-47d8-90b6-90597259fd66) |
| Gigantmax | ![image](https://github.com/user-attachments/assets/f7b8a7fd-b54b-42ac-9a91-1a7af7e0ecf9) |
| Eternamax | ![image](https://github.com/user-attachments/assets/eaebd494-bb9b-44fb-8085-88d7a8eb9d5a) |
| Other | ![image](https://github.com/user-attachments/assets/7449b30e-eb00-43d3-aca1-7e203d9e8979) |
| Revert | ![image](https://github.com/user-attachments/assets/64d0e972-0ecb-4b5f-b7fa-07c821aa5b62) |

</details>

#### Pt_BR
<details>
<summary>Click to expand/collapse</summary>

| Case | Result |
| :-----: | :-----: |
| Mega | ![image](https://github.com/user-attachments/assets/6ac1be7c-b635-4321-90b9-d25caa79ea92) |
| Gigantmax | ![image](https://github.com/user-attachments/assets/ab88253f-8e68-4c8d-8b92-17d3659a275f) |
| Eternamax | ![image](https://github.com/user-attachments/assets/bad9b8e5-42d2-4516-98bf-0d6615fd8bf8) |
| Other | ![image](https://github.com/user-attachments/assets/1df31a42-5ff4-4676-ab46-c6998998467a) |
| Revert | ![image](https://github.com/user-attachments/assets/9e639df2-b250-436d-b254-f0dbd628b42f) |

</details>

#### Zh_CN
<details>
<summary>Click to expand/collapse</summary>

| Case | Result |
| :-----: | :-----: |
| Mega | ![image](https://github.com/user-attachments/assets/85f3d81a-df5a-469e-a9f8-454aadbdc995) |
| Gigantmax | ![image](https://github.com/user-attachments/assets/ae95eef9-4973-4997-b554-d6e2c76b492a) |
| Eternamax | ![image](https://github.com/user-attachments/assets/e36962d8-505f-4511-9156-f09b22adde8c) |
| Other | ![image](https://github.com/user-attachments/assets/532483a4-deee-49e0-bb4e-82ac464da310) |
| Revert | ![image](https://github.com/user-attachments/assets/b2d68882-798a-4923-9f09-bc1144b2743f) |

</details>

#### Zh_TW
<details>
<summary>Click to expand/collapse</summary>

| Case | Result |
| :-----: | :-----: |
| Mega | ![image](https://github.com/user-attachments/assets/40e2d92a-fc76-47a4-b7b8-85534ca845c4) |
| Gigantmax | ![image](https://github.com/user-attachments/assets/1c2526c3-7f4b-4e91-8e7a-86fe1720819c) |
| Eternamax | ![image](https://github.com/user-attachments/assets/fa7859d5-b674-4e13-bee7-144b3fe5a36a) |
| Other | ![image](https://github.com/user-attachments/assets/959f1ff3-596b-4d55-b7a9-e37b8148f801) |
| Revert | ![image](https://github.com/user-attachments/assets/d083898a-71eb-449b-9122-c9ef4c8b2b07) |

</details>

#### Ko
<details>
<summary>Click to expand/collapse</summary>

| Case | Result |
| :-----: | :-----: |
| Mega | ![image](https://github.com/user-attachments/assets/0571819e-b472-4ffa-8326-03e098fff970) |
| Gigantmax | ![image](https://github.com/user-attachments/assets/aae8bce9-6b46-4b18-b6ca-7dc4f5a45a30) |
| Eternamax | ![image](https://github.com/user-attachments/assets/93b45b57-a09a-41e1-b8fd-d415cf07ef8e) |
| Other | ![image](https://github.com/user-attachments/assets/8a81b7e9-70fe-4fd6-853e-f02e8920b0b6) |
| Revert | ![image](https://github.com/user-attachments/assets/85e66948-c386-49d6-aa91-9fbc5e039b38) |

</details>

## How to test the changes?
Manually (with src/overrides.ts)
Need to execute 'New Game', can test in 'check team' menu.

1. For test Mega form change message
```Typescript
  readonly STARTER_SPECIES_OVERRIDE: Species | integer = Species.MEWTWO;
  readonly STARTING_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [ {name: "FORM_CHANGE_ITEM", type: FormChangeItem.MEWTWONITE_X}, {name: "MEGA_BRACELET"}];
```

2. For test Gigantamax
```Typescript
  readonly STARTER_SPECIES_OVERRIDE: Species | integer = Species.PIKACHU;
  readonly STARTING_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [ {name: "FORM_CHANGE_ITEM", type: FormChangeItem.MAX_MUSHROOMS}, {name: "DYNAMAX_BAND"}];
```

3. For test Eternamax
```Typescript
  readonly STARTER_SPECIES_OVERRIDE: Species | integer = Species.ETERNATUS;
  readonly STARTING_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [ {name: "FORM_CHANGE_ITEM", type: FormChangeItem.MAX_MUSHROOMS}, {name: "DYNAMAX_BAND"}];
```

4. For test Primal
```Typescript
  readonly STARTER_SPECIES_OVERRIDE: Species | integer = Species.KYOGRE;
  readonly STARTING_HELD_ITEMS_OVERRIDE: Array<ModifierOverride> = [ {name: "FORM_CHANGE_ITEM", type: FormChangeItem.BLUE_ORB}, {name: "MEGA_BRACELET"}];
```


## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
