### PR TITLE
[Refactor/Bug] Use Bit Shifting & Masking

### DIFF
--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -435,7 +435,7 @@ export abstract class PokemonSpeciesForm {
     for (const moveId of moveset) {
       if (speciesEggMoves.hasOwnProperty(rootSpeciesId)) {
         const eggMoveIndex = speciesEggMoves[rootSpeciesId].findIndex(m => m === moveId);
-        if (eggMoveIndex > -1 && eggMoves & Math.pow(2, eggMoveIndex)) {
+        if (eggMoveIndex > -1 && (eggMoves & (1 << eggMoveIndex))) {
           continue;
         }
       }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1389,8 +1389,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       return false;
     }
 
-    const rand1 = Utils.binToDec(Utils.decToBin(this.id).substring(0, 16));
-    const rand2 = Utils.binToDec(Utils.decToBin(this.id).substring(16, 32));
+    const rand1 = (this.id & 0xFFFF0000) >>> 16;
+    const rand2 = (this.id & 0x0000FFFF);
 
     const E = this.scene.gameData.trainerId ^ this.scene.gameData.secretId;
     const F = rand1 ^ rand2;

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -1576,11 +1576,11 @@ export class PokemonNatureChangeModifier extends ConsumablePokemonModifier {
     const pokemon = args[0] as Pokemon;
     pokemon.natureOverride = this.nature;
     let speciesId = pokemon.species.speciesId;
-    pokemon.scene.gameData.dexData[speciesId].natureAttr |= Math.pow(2, this.nature + 1);
+    pokemon.scene.gameData.dexData[speciesId].natureAttr |= 1 << (this.nature + 1);
 
     while (pokemonPrevolutions.hasOwnProperty(speciesId)) {
       speciesId = pokemonPrevolutions[speciesId];
-      pokemon.scene.gameData.dexData[speciesId].natureAttr |= Math.pow(2, this.nature + 1);
+      pokemon.scene.gameData.dexData[speciesId].natureAttr |= 1 << (this.nature + 1);
     }
 
     return true;

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -350,7 +350,7 @@ export class GameData {
       this.scene.ui.savingIcon.show();
       const data = this.getSystemSaveData();
 
-      const maxIntAttrValue = Math.pow(2, 31);
+      const maxIntAttrValue = 0x80000000;
       const systemData = JSON.stringify(data, (k: any, v: any) => typeof v === "bigint" ? v <= maxIntAttrValue ? Number(v) : v.toString() : v);
 
       localStorage.setItem(`data_${loggedInUser.username}`, encrypt(systemData, bypassLogin));
@@ -1172,7 +1172,7 @@ export class GameData {
         }
         const sessionData = useCachedSession ? this.parseSessionData(decrypt(localStorage.getItem(`sessionData${scene.sessionSlotId ? scene.sessionSlotId : ""}_${loggedInUser.username}`), bypassLogin)) : this.getSessionSaveData(scene);
 
-        const maxIntAttrValue = Math.pow(2, 31);
+        const maxIntAttrValue = 0x80000000;
         const systemData = useCachedSystem ? this.parseSystemData(decrypt(localStorage.getItem(`data_${loggedInUser.username}`), bypassLogin)) : this.getSystemSaveData();
 
         const request = {
@@ -1377,7 +1377,7 @@ export class GameData {
       const entry = data[defaultStarterSpecies[ds]] as DexEntry;
       entry.seenAttr = defaultStarterAttr;
       entry.caughtAttr = defaultStarterAttr;
-      entry.natureAttr = Math.pow(2, defaultStarterNatures[ds] + 1);
+      entry.natureAttr = 1 << (defaultStarterNatures[ds] + 1);
       for (const i in entry.ivs) {
         entry.ivs[i] = 10;
       }
@@ -1444,10 +1444,10 @@ export class GameData {
       dexEntry.caughtAttr |= dexAttr;
       if (speciesStarters.hasOwnProperty(species.speciesId)) {
         this.starterData[species.speciesId].abilityAttr |= pokemon.abilityIndex !== 1 || pokemon.species.ability2
-          ? Math.pow(2, pokemon.abilityIndex)
+          ? 1 << pokemon.abilityIndex
           : AbilityAttr.ABILITY_HIDDEN;
       }
-      dexEntry.natureAttr |= Math.pow(2, pokemon.nature + 1);
+      dexEntry.natureAttr |= 1 << (pokemon.nature + 1);
 
       const hasPrevolution = pokemonPrevolutions.hasOwnProperty(species.speciesId);
       const newCatch = !caughtAttr;
@@ -1483,7 +1483,7 @@ export class GameData {
         }
 
         if (!hasPrevolution && (!pokemon.scene.gameMode.isDaily || hasNewAttr || fromEgg)) {
-          this.addStarterCandy(species, (1 * (pokemon.isShiny() ? 5 * Math.pow(2, pokemon.variant || 0) : 1)) * (fromEgg || pokemon.isBoss() ? 2 : 1));
+          this.addStarterCandy(species, (1 * (pokemon.isShiny() ? 5 * (1 << (pokemon.variant ?? 0)) : 1)) * (fromEgg || pokemon.isBoss() ? 2 : 1));
         }
       }
 
@@ -1554,7 +1554,7 @@ export class GameData {
         this.starterData[speciesId].eggMoves = 0;
       }
 
-      const value = Math.pow(2, eggMoveIndex);
+      const value = 1 << eggMoveIndex;
 
       if (this.starterData[speciesId].eggMoves & value) {
         resolve(false);
@@ -1646,7 +1646,7 @@ export class GameData {
   getSpeciesDefaultNature(species: PokemonSpecies): Nature {
     const dexEntry = this.dexData[species.speciesId];
     for (let n = 0; n < 25; n++) {
-      if (dexEntry.natureAttr & Math.pow(2, n + 1)) {
+      if (dexEntry.natureAttr & (1 << (n + 1))) {
         return n as Nature;
       }
     }
@@ -1654,7 +1654,7 @@ export class GameData {
   }
 
   getSpeciesDefaultNatureAttr(species: PokemonSpecies): integer {
-    return Math.pow(2, this.getSpeciesDefaultNature(species));
+    return 1 << (this.getSpeciesDefaultNature(species));
   }
 
   getDexAttrLuck(dexAttr: bigint): integer {
@@ -1664,7 +1664,7 @@ export class GameData {
   getNaturesForAttr(natureAttr: integer): Nature[] {
     const ret: Nature[] = [];
     for (let n = 0; n < 25; n++) {
-      if (natureAttr & Math.pow(2, n + 1)) {
+      if (natureAttr & (1 << (n + 1))) {
         ret.push(n);
       }
     }
@@ -1706,7 +1706,7 @@ export class GameData {
   }
 
   getFormAttr(formIndex: integer): bigint {
-    return BigInt(Math.pow(2, 7 + formIndex));
+    return BigInt(1 << (7 + formIndex));
   }
 
   consolidateDexData(dexData: DexData): void {
@@ -1716,7 +1716,7 @@ export class GameData {
         entry.hatchedCount = 0;
       }
       if (!entry.hasOwnProperty("natureAttr") || (entry.caughtAttr && !entry.natureAttr)) {
-        entry.natureAttr = this.defaultDexData[k].natureAttr || Math.pow(2, Utils.randInt(25, 1));
+        entry.natureAttr = this.defaultDexData[k].natureAttr || (1 << Utils.randInt(25, 1));
       }
     }
   }

--- a/src/ui/pokemon-info-container.ts
+++ b/src/ui/pokemon-info-container.ts
@@ -216,7 +216,7 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
         this.pokemonGenderText.setShadowColor(getGenderColor(pokemon.gender, true));
         this.pokemonGenderText.setVisible(true);
 
-        const newGender = BigInt(Math.pow(2, pokemon.gender)) * DexAttr.MALE;
+        const newGender = BigInt(1 << pokemon.gender) * DexAttr.MALE;
         this.pokemonGenderNewText.setText("(+)");
         this.pokemonGenderNewText.setColor(getTextColor(TextStyle.SUMMARY_BLUE, false, this.scene.uiTheme));
         this.pokemonGenderNewText.setShadowColor(getTextColor(TextStyle.SUMMARY_BLUE, true, this.scene.uiTheme));
@@ -229,7 +229,7 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
       if (pokemon.species.forms?.[pokemon.formIndex]?.formName) {
         this.pokemonFormLabelText.setVisible(true);
         this.pokemonFormText.setVisible(true);
-        const newForm = BigInt(Math.pow(2, pokemon.formIndex)) * DexAttr.DEFAULT_FORM;
+        const newForm = BigInt(1 << pokemon.formIndex) * DexAttr.DEFAULT_FORM;
 
         if ((newForm & caughtAttr) === BigInt(0)) {
           this.pokemonFormLabelText.setColor(getTextColor(TextStyle.SUMMARY_BLUE, false, this.scene.uiTheme));
@@ -266,7 +266,7 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
        */
       const opponentPokemonOneNormalAbility = (pokemon.species.getAbilityCount() === 2);
       const opponentPokemonAbilityIndex = (opponentPokemonOneNormalAbility && pokemon.abilityIndex === 1) ? 2 : pokemon.abilityIndex;
-      const opponentPokemonAbilityAttr = Math.pow(2, opponentPokemonAbilityIndex);
+      const opponentPokemonAbilityAttr = 1 << opponentPokemonAbilityIndex;
 
       const rootFormHasHiddenAbility = pokemon.scene.gameData.starterData[pokemon.species.getRootSpeciesId()].abilityAttr & opponentPokemonAbilityAttr;
 
@@ -281,7 +281,7 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
       this.pokemonNatureText.setText(getNatureName(pokemon.getNature(), true, false, false, this.scene.uiTheme));
 
       const dexNatures = pokemon.scene.gameData.dexData[pokemon.species.speciesId].natureAttr;
-      const newNature = Math.pow(2, pokemon.nature + 1);
+      const newNature = 1 << (pokemon.nature + 1);
 
       if (!(dexNatures & newNature)) {
         this.pokemonNatureLabelText.setColor(getTextColor(TextStyle.SUMMARY_BLUE, false, this.scene.uiTheme));
@@ -305,8 +305,8 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
         this.pokemonShinyIcon.on("pointerover", () => (this.scene as BattleScene).ui.showTooltip(null, `${i18next.t("common:shinyOnHover")}${shinyDescriptor ? ` (${shinyDescriptor})` : ""}`, true));
         this.pokemonShinyIcon.on("pointerout", () => (this.scene as BattleScene).ui.hideTooltip());
 
-        const newShiny = BigInt(Math.pow(2, (pokemon.shiny ? 1 : 0)));
-        const newVariant = BigInt(Math.pow(2, pokemon.variant + 4));
+        const newShiny = BigInt(1 << (pokemon.shiny ? 1 : 0));
+        const newVariant = BigInt(1 << (pokemon.variant + 4));
 
         this.pokemonShinyNewIcon.setText("(+)");
         this.pokemonShinyNewIcon.setColor(getTextColor(TextStyle.SUMMARY_BLUE, false, this.scene.uiTheme));

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -2607,7 +2607,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         this.speciesStarterMoves.push(...levelMoves.filter(lm => lm[0] > 0 && lm[0] <= 5).map(lm => lm[1]));
         if (speciesEggMoves.hasOwnProperty(species.speciesId)) {
           for (let em = 0; em < 4; em++) {
-            if (this.scene.gameData.starterData[species.speciesId].eggMoves & Math.pow(2, em)) {
+            if (this.scene.gameData.starterData[species.speciesId].eggMoves & (1 << em)) {
               this.speciesStarterMoves.push(speciesEggMoves[species.speciesId][em]);
             }
           }
@@ -2619,7 +2619,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
             ? speciesMoveData as StarterMoveset
             : (speciesMoveData as StarterFormMoveData)[formIndex]
           : null;
-        const availableStarterMoves = this.speciesStarterMoves.concat(speciesEggMoves.hasOwnProperty(species.speciesId) ? speciesEggMoves[species.speciesId].filter((_, em: integer) => this.scene.gameData.starterData[species.speciesId].eggMoves & Math.pow(2, em)) : []);
+        const availableStarterMoves = this.speciesStarterMoves.concat(speciesEggMoves.hasOwnProperty(species.speciesId) ? speciesEggMoves[species.speciesId].filter((_, em: integer) => this.scene.gameData.starterData[species.speciesId].eggMoves & (1 << em)) : []);
         this.starterMoveset = (moveData || (this.speciesStarterMoves.slice(0, 4) as StarterMoveset)).filter(m => availableStarterMoves.find(sm => sm === m)) as StarterMoveset;
         // Consolidate move data if it contains an incompatible move
         if (this.starterMoveset.length < 4 && this.starterMoveset.length < availableStarterMoves.length) {
@@ -2676,7 +2676,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
     for (let em = 0; em < 4; em++) {
       const eggMove = hasEggMoves ? allMoves[speciesEggMoves[species.speciesId][em]] : null;
-      const eggMoveUnlocked = eggMove && this.scene.gameData.starterData[species.speciesId].eggMoves & Math.pow(2, em);
+      const eggMoveUnlocked = eggMove && this.scene.gameData.starterData[species.speciesId].eggMoves & (1 << em);
       this.pokemonEggMoveBgs[em].setFrame(Type[eggMove ? eggMove.type : Type.UNKNOWN].toString().toLowerCase());
       this.pokemonEggMoveLabels[em].setText(eggMove && eggMoveUnlocked ? eggMove.name : "???");
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -165,40 +165,20 @@ export function getPlayTimeString(totalSeconds: integer): string {
   return `${days.padStart(2, "0")}:${hours.padStart(2, "0")}:${minutes.padStart(2, "0")}:${seconds.padStart(2, "0")}`;
 }
 
-export function binToDec(input: string): integer {
-  const place: integer[] = [];
-  const binary: string[] = [];
-
-  let decimalNum = 0;
-
-  for (let i = 0; i < input.length; i++) {
-    binary.push(input[i]);
-    place.push(Math.pow(2, i));
-    decimalNum += place[i] * parseInt(binary[i]);
-  }
-
-  return decimalNum;
-}
-
-export function decToBin(input: integer): string {
-  let bin = "";
-  let intNum = input;
-  while (intNum > 0) {
-    bin = intNum % 2 ? `1${bin}` : `0${bin}`;
-    intNum = Math.floor(intNum * 0.5);
-  }
-
-  return bin;
-}
-
-export function getIvsFromId(id: integer): integer[] {
+/**
+ * Generates IVs from a given {@linkcode id} by extracting 5 bits at a time
+ * starting from the least significant bit up to the 30th most significant bit.
+ * @param id 32-bit number
+ * @returns An array of six numbers corresponding to 5-bit chunks from {@linkcode id}
+ */
+export function getIvsFromId(id: number): number[] {
   return [
-    binToDec(decToBin(id).substring(0, 5)),
-    binToDec(decToBin(id).substring(5, 10)),
-    binToDec(decToBin(id).substring(10, 15)),
-    binToDec(decToBin(id).substring(15, 20)),
-    binToDec(decToBin(id).substring(20, 25)),
-    binToDec(decToBin(id).substring(25, 30))
+    (id & 0x3E000000) >>> 25,
+    (id & 0x01F00000) >>> 20,
+    (id & 0x000F8000) >>> 15,
+    (id & 0x00007C00) >>> 10,
+    (id & 0x000003E0) >>> 5,
+    (id & 0x0000001F)
   ];
 }
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->

May have the effect of improving randomly-generated IV distributions and shiny Pokemon since they were not generated correctly before, but realistically it should have no effect from the user perspective.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

A majority of the motivation comes from seeing 2 raised to different powers in order to simulate left bit shifting instead of just using bit shifting directly, adding performance complexity with no benefit. While doing that, more instances were found where bit manipulation would be more performant (see `decToBin` and `binToDec` in `src/utils.ts`), so I aimed to address those as well.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

- Refactored `getIvsFromId` such that it uses bit manipulation to extract IVs directly.
  - This will be explained a bit more in the Screenshots section.
- Change constants in `trySetShiny` to use bit manipulation to extract the lower and higher 16 bits directly.
- Remove `decToBin` and `binToDec` since they were only used in two specific scenarios addressed above.
- Changed most instances of `Math.pow(2, ...)` to `1 << ...` where it made sense or implied the usage of bit flags rather than trying to raise a value to the second power literally.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

In regards to `getIvsFromId`, it was first directly refactored to use bit manipulation, demonstrating that there was a mismatch between the input `id` and the output array with the extracted IVs.
<img width="245" alt="generateIVs" src="https://github.com/user-attachments/assets/4015990e-6c67-4581-bc5d-f062da1f87ac">
Note that the above array are the expected values and the bottom array was the behavior before this PR. To verify this, the `id` was manually deconstructed: 
- The `id`, 2326818241, gives `10001010101100000110110111000001`
  - `10001` gives 17
  - `01010` gives 10
  - `11000` gives 24
  - `00110` gives 6
  - `11011` gives 27
  - `10000` gives 16
  - Last 2 bits are unused/ignored
 
As such, the original function seemingly did not generate IVs correctly.

This would carry over into `trySetShiny`, where bits were not correctly extracted:
<img width="110" alt="generateShinyValues" src="https://github.com/user-attachments/assets/528c2bca-7234-4410-9cd2-55886fa49362">
Note that the first two values are the expected values and the last two are the values extracted before this PR. Again, to verify this, the `id` was manually deconstructed:
- The `id`, 349173278, gives `00010100110011111111011000011110`
  - `0001010011001111` gives 5327
  - `1111011000011110` gives 63006

Back to `getIvsFromId`, I also realized that, because [bit shifting converts operands to 32-bit integers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Left_shift) and the `randInt` used to generate `id` values ranges from `0` to the largest positive 32-bit value, the most significant bit may not ever be `1` by definition of positive numbers in two's complement. I didn't test it, but I figured the correct change would be the use the bits starting from the least significant bits since this is [what the mainline games do](https://bulbapedia.bulbagarden.net/wiki/Individual_values#Storage) anyway. As a result, the function was refactored and changed entirely to now generate IVs from `id`, ignoring the two most significant bits.

Lastly, note that all `console.log` calls were purely just for testing and aren't included in the PR.

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

These changes are a bit scattered around, but the best way would most likely be at the starter select screen since that's where data reloading (unlocked egg moves, abilities, natures, etc.) can be verified as correct.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
