### PR TITLE
[Refactor] PokemonHeldItemModifier Refactoring

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -69,6 +69,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   public shiny: boolean;
   public variant: Variant;
   public pokeball: PokeballType;
+  public heldItems: PersistentModifierData[];
   protected battleInfo: BattleInfo;
   public level: integer;
   public exp: integer;
@@ -110,7 +111,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   private shinySparkle: Phaser.GameObjects.Sprite;
 
-  constructor(scene: BattleScene, x: number, y: number, species: PokemonSpecies, level: integer, abilityIndex?: integer, formIndex?: integer, gender?: Gender, shiny?: boolean, variant?: Variant, ivs?: integer[], nature?: Nature, dataSource?: Pokemon | PokemonData) {
+  constructor(scene: BattleScene, x: number, y: number, species: PokemonSpecies, level: integer, abilityIndex?: integer, formIndex?: integer, gender?: Gender, shiny?: boolean, variant?: Variant, ivs?: integer[], nature?: Nature, dataSource?: Pokemon | PokemonData, heldItems?: PersistentModifierData[]) {
     super(scene, x, y);
 
     if (!species.isObtainable() && this.isPlayer()) {
@@ -128,6 +129,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     this.species = species;
     this.pokeball = dataSource?.pokeball || PokeballType.POKEBALL;
     this.level = level;
+    this.heldItems = heldItems ?? (dataSource ? dataSource.heldItems : []);
     // Determine the ability index
     if (abilityIndex !== undefined) {
       this.abilityIndex = abilityIndex; // Use the provided ability index if it is defined
@@ -4007,7 +4009,7 @@ export class EnemyPokemon extends Pokemon {
       this.pokeball = pokeballType;
       this.metLevel = this.level;
       this.metBiome = this.scene.arena.biomeType;
-      const newPokemon = this.scene.addPlayerPokemon(this.species, this.level, this.abilityIndex, this.formIndex, this.gender, this.shiny, this.variant, this.ivs, this.nature, this);
+      const newPokemon = this.scene.addPlayerPokemon(this.species, this.level, this.abilityIndex, this.formIndex, this.gender, this.shiny, this.variant, this.ivs, this.nature, this, null, this.heldItems);
       party.push(newPokemon);
       ret = newPokemon;
       this.scene.triggerPokemonFormChange(newPokemon, SpeciesFormChangeActiveTrigger, true);

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -550,10 +550,10 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   getHeldItems(): PokemonHeldItemModifier[] {
-    if (!this.scene) {
+    if (!this.heldItems.length) {
       return [];
     }
-    return this.scene.findModifiers(m => m instanceof PokemonHeldItemModifier && m.pokemonId === this.id, this.isPlayer()) as PokemonHeldItemModifier[];
+    return this.heldItems as PokemonHeldItemModifier[];
   }
 
   updateScale(): void {
@@ -3517,8 +3517,7 @@ export class PlayerPokemon extends Pokemon {
       if (partyMemberIndex > fusedPartyMemberIndex) {
         partyMemberIndex--;
       }
-      const fusedPartyMemberHeldModifiers = this.scene.findModifiers(m => m instanceof PokemonHeldItemModifier
-        && m.pokemonId === pokemon.id, true) as PokemonHeldItemModifier[];
+      const fusedPartyMemberHeldModifiers = this.getHeldItems() as PokemonHeldItemModifier[];
       const transferModifiers: Promise<boolean>[] = [];
       for (const modifier of fusedPartyMemberHeldModifiers) {
         transferModifiers.push(this.scene.tryTransferHeldItemModifier(modifier, this, false, modifier.getStackCount(), true, true));

--- a/src/modifier/moveItems.ts
+++ b/src/modifier/moveItems.ts
@@ -1,0 +1,49 @@
+import { tmPoolTiers, tmSpecies } from "../data/tms";
+
+
+
+
+export class MoveReminderItem {
+  constructor(localeKey: string, iconImage: string, group?: string) {
+    super(localeKey, iconImage, (type, args) => new Modifiers.RememberMoveModifier(type, (args[0] as PlayerPokemon).id, (args[1] as integer)),
+      (pokemon: PlayerPokemon) => {
+        if (!pokemon.getLearnableLevelMoves().length) {
+          return PartyUiHandler.NoEffectMessage;
+        }
+        return null;
+      }, group);
+  }
+}
+
+export class technicalMachine {
+  public moveId: Moves;
+
+  constructor(moveId: Moves) {
+    super("", `tm_${Type[allMoves[this.moveId].type].toLowerCase()}`, (_type, args) => new Modifiers.TmModifier(this, (args[0] as PlayerPokemon).id),
+      (pokemon: PlayerPokemon) => {
+        if (pokemon.compatibleTms.indexOf(this.moveId) === -1 || pokemon.getMoveset().filter(m => m?.moveId === moveId).length) {
+          return PartyUiHandler.NoEffectMessage;
+        }
+        return null;
+      }, "tm");
+
+    this.moveId = moveId;
+  }
+
+  get name(): string {
+    return i18next.t("modifierType:ModifierType.TmModifierType.name", {
+      moveId: Utils.padInt(Object.keys(tmSpecies).indexOf(this.moveId.toString()) + 1, 3),
+      moveName: allMoves[this.moveId].name,
+    });
+  }
+
+  getDescription(scene: BattleScene): string {
+    return i18next.t(scene.enableMoveInfo ? "modifierType:ModifierType.TmModifierTypeWithInfo.description" : "modifierType:ModifierType.TmModifierType.description", { moveName: allMoves[this.moveId].name });
+  }
+}
+
+export const moveItems = {
+	MEMORY_MUSHROOM: () => new RememberMoveModifierType("modifierType:ModifierType.MEMORY_MUSHROOM", "big_mushroom"),
+
+	
+}

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -5021,7 +5021,7 @@ export class AttemptCapturePhase extends PokemonPhase {
             this.scene.ui.showText(i18next.t("battle:partyFull", { pokemonName: getPokemonNameWithAffix(pokemon) }), null, () => {
               this.scene.pokemonInfoContainer.makeRoomForConfirmUi(1, true);
               this.scene.ui.setMode(Mode.CONFIRM, () => {
-                const newPokemon = this.scene.addPlayerPokemon(pokemon.species, pokemon.level, pokemon.abilityIndex, pokemon.formIndex, pokemon.gender, pokemon.shiny, pokemon.variant, pokemon.ivs, pokemon.nature, pokemon);
+                const newPokemon = this.scene.addPlayerPokemon(pokemon.species, pokemon.level, pokemon.abilityIndex, pokemon.formIndex, pokemon.gender, pokemon.shiny, pokemon.variant, pokemon.ivs, pokemon.nature, pokemon, null, pokemon.heldItems);
                 this.scene.ui.setMode(Mode.SUMMARY, newPokemon, 0, SummaryUiMode.DEFAULT, () => {
                   this.scene.ui.setMode(Mode.MESSAGE).then(() => {
                     promptRelease();

--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -25,6 +25,7 @@ export default class PokemonData {
   public variant: Variant;
   public pokeball: PokeballType;
   public level: integer;
+  public heldItems: PersistentModifierData[];
   public exp: integer;
   public levelExp: integer;
   public gender: Gender;
@@ -78,6 +79,7 @@ export default class PokemonData {
     }
     this.stats = source.stats;
     this.ivs = source.ivs;
+    this.heldItems = source.heldItems ?? [];
     this.nature = source.nature !== undefined ? source.nature : 0 as Nature;
     this.natureOverride = source.natureOverride !== undefined ? source.natureOverride : -1;
     this.friendship = source.friendship !== undefined ? source.friendship : getPokemonSpecies(this.species).baseFriendship;
@@ -147,7 +149,7 @@ export default class PokemonData {
         if (this.nickname) {
           playerPokemon.nickname = this.nickname;
         }
-      })
+      }, this.heldItems)
       : scene.addEnemyPokemon(species, this.level, battleType === BattleType.TRAINER ? !double || !(partyMemberIndex % 2) ? TrainerSlot.TRAINER : TrainerSlot.TRAINER_PARTNER : TrainerSlot.NONE, this.boss, this);
     if (this.summonData) {
       ret.primeSummonData(this.summonData);

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -861,9 +861,7 @@ export default class SummaryUiHandler extends UiHandler {
         statsContainer.add(statValue);
       });
 
-      const itemModifiers = (this.scene.findModifiers(m => m instanceof PokemonHeldItemModifier
-          && m.pokemonId === this.pokemon.id, this.playerParty) as PokemonHeldItemModifier[])
-        .sort(modifierSortFunc);
+      const itemModifiers = (this.pokemon.heldItems as PokemonHeldItemModifier[]).sort(modifierSortFunc);
 
       itemModifiers.forEach((item, i) => {
         const icon = item.getIcon(this.scene, true);


### PR DESCRIPTION
## What are the changes?
This moves modifiers of the class PokemonHeldItemModifier to a PokemonData class member 'heldItems', an array of PersistentModifierData[]

## Why am I doing these changes?
The current implementation of Modifiers is clunky and difficult to extend. By doing this, I hope to improve the code's logic / readability and expand the possibilities for future implementations of various held items. In addition, this ideally will improve debugging as well.

## What did change?
- [ ] Stage 1: Have the new class member 'heldItems' consistently reflect what is stored in modifiers / enemyModifiers 
- [ ] Stage 2: Move relevant functions referring to modifiers / enemyModifiers to pokemon.heldItems 
- [ ] Stage 3: Transition away from storing PokemonHeldItemModifier modifiers in modifiers / enemyModifiers to store items within the PokemonData itself 

### Stage 1
- system/pokemon-data.ts: Added class property + Changed how new Pokemon are initialized. 
- field/pokemon.ts: Added class property + Changed how new Pokemon are initialized.
- phases.ts : Changed how new Pokemon are initialized when caught.
- battle-scene.ts : Changed updateModifiers() to edit pokemon.heldItems as well.

### Stage 2
- summary-ui-handler.ts: Game now looks at pokemon.heldItems to display modifiers

## How to test the changes?
Play and see what breaks.  

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`) - to be updated
