### PR TITLE
[Bug][Mirror] Fixed impossible forced switch

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -4449,9 +4449,10 @@ export class SwitchPhase extends BattlePhase {
 
   start() {
     super.start();
+    const availablePartyMembers = this.scene.getParty().filter(p => !p.isFainted());
 
     // Skip modal switch if impossible
-    if (this.isModal && !this.scene.getParty().filter(p => p.isAllowedInBattle() && !p.isActive(true)).length) {
+    if (this.isModal && (!availablePartyMembers.filter(p => !p.isActive(true)).length || (!this.scene.currentBattle.started && availablePartyMembers.length === 1))) {
       return super.end();
     }
 
@@ -4461,7 +4462,7 @@ export class SwitchPhase extends BattlePhase {
     }
 
     // Override field index to 0 in case of double battle where 2/3 remaining legal party members fainted at once
-    const fieldIndex = this.scene.currentBattle.getBattlerCount() === 1 || this.scene.getParty().filter(p => p.isAllowedInBattle()).length > 1 ? this.fieldIndex : 0;
+    const fieldIndex = this.scene.currentBattle.getBattlerCount() === 1 || availablePartyMembers.length > 1 ? this.fieldIndex : 0;
 
     this.scene.ui.setMode(Mode.PARTY, this.isModal ? PartyUiMode.FAINT_SWITCH : PartyUiMode.POST_BATTLE_SWITCH, fieldIndex, (slotIndex: integer, option: PartyOption) => {
       if (slotIndex >= this.scene.currentBattle.getBattlerCount() && slotIndex < 6) {


### PR DESCRIPTION
This is simply a mirror of #1333 
We need this fix and the original author isn't responding.

## What are the changes?

> 
> Here's what changed:
> 
> - I added an extra exception for the switch phase to be skipped if the battle hasn't started yet and you only have 1 Pokemon remaining after a faint in the previous 
> 
> This is what changed from the player's point of view:
> 
> - Player no longer sees the switch menu, meaning they don't know that the next battle is a double battle and they no longer get stuck in an impossible 
> - As a consequence, the player can't pick the final Pokemon in their party before a battle, instead it is sent automatically.
> 

----

⚠️ Make sure to check out #1333 for more details, videos etc.! ⚠️

----

## Why am I doing these changes?

To fix it finally

### Screenshots/Videos


https://github.com/user-attachments/assets/71287d7d-6e5b-404d-920f-8c047a401802



## How to test the changes?

It's a bit tricky as you can't really use overrides because you gotta switch from single to double.

1. I used these overrides:
```ts
const overrides = {
  STARTING_WAVE_OVERRIDE: 5,
  STARTING_LEVEL_OVERRIDE: 10,
  STATUS_OVERRIDE: StatusEffect.TOXIC,
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```
2. Next in `battle-scene.ts` line `1094` insert this to force the 6th wave to be a double battle:
```
    if (newWaveIndex === 6) {
      newDouble = true;
    }
```
3. Next in `phases.ts` in line `3582` replace the line with to ensure your pokemon faints in 2 turns from TOXIC:
```ts
          damage = Math.ceil(pokemon.getMaxHp() / 2);
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR? => #1333 
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue? => Tried but bug doesn't seem to occur in testing scenarios.. lol
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
