### PR TITLE
[Balance] [Beta] Give Dipplin Dragon Cheer as a relearn move

### DIFF
--- a/src/data/egg-moves.ts
+++ b/src/data/egg-moves.ts
@@ -438,7 +438,7 @@ export const speciesEggMoves = {
   [Species.CHEWTLE]: [ Moves.FIRE_FANG, Moves.ACCELEROCK, Moves.SHELL_SMASH, Moves.FISHIOUS_REND ],
   [Species.YAMPER]: [ Moves.ICE_FANG, Moves.SWORDS_DANCE, Moves.THUNDER_FANG, Moves.ZIPPY_ZAP ],
   [Species.ROLYCOLY]: [ Moves.BITTER_BLADE, Moves.BODY_PRESS, Moves.BULK_UP, Moves.DIAMOND_STORM ],
-  [Species.APPLIN]: [ Moves.DRAGON_CHEER, Moves.DRAGON_HAMMER, Moves.FLOWER_TRICK, Moves.STRENGTH_SAP ],
+  [Species.APPLIN]: [ Moves.MATCHA_GOTCHA, Moves.DRAGON_HAMMER, Moves.FLOWER_TRICK, Moves.STRENGTH_SAP ],
   [Species.SILICOBRA]: [ Moves.SHORE_UP, Moves.SHED_TAIL, Moves.STONE_EDGE, Moves.PRECIPICE_BLADES ],
   [Species.CRAMORANT]: [ Moves.APPLE_ACID, Moves.SURF, Moves.SCORCHING_SANDS, Moves.OBLIVION_WING ],
   [Species.ARROKUDA]: [ Moves.SUPERCELL_SLAM, Moves.KNOCK_OFF, Moves.ICE_SPINNER, Moves.FILLET_AWAY ],

--- a/src/data/pokemon-level-moves.ts
+++ b/src/data/pokemon-level-moves.ts
@@ -17287,7 +17287,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   ],
   [Species.DIPPLIN]: [
     [ EVOLVE_MOVE, Moves.DOUBLE_HIT ],
-    [ RELEARN_MOVE, Moves.INFESTATION ],
+    [ RELEARN_MOVE, Moves.DRAGON_CHEER ], // Custom
     [ 1, Moves.WITHDRAW ],
     [ 1, Moves.SWEET_SCENT ],
     [ 1, Moves.RECYCLE ],


### PR DESCRIPTION
## What are the changes?
Dipplin gets access to Dragon Cheer via Memory Mushroom
Applin's Dragon Cheer Egg Move is changed to Matcha Gotcha

## Why am I doing these changes?
As of right now, players are reliant on the Egg Move to evolve their Applin into the very commitment-heavy Hydrapple (Syrupy Apple is a different rarity from the other Apple items for some strange reason, then to evolve into Hydrapple you would have to luck out and get the TM within the same run which requires you to EVOLVE Applin first since Applin doesn't learn it OR the player must have the Egg Move unlocked. All while Appletun / Flapple can get their evolutions relatively early on and have access to their G-Max Forms.) Stantler currently has Psyshield Bash as a custom level up move when in mainline it is an egg move normally, so initially I would have wanted to make Dragon Cheer a level up move but after discussion with Damo and the other balance members we decided it would be better to have it via Memory Mushroom.

## What did change?
- Changed Applin's Learnset
- Changed Applin's Egg Move


### Screenshots/Videos
![image](https://github.com/user-attachments/assets/3e4c7039-7eb6-455c-84de-db3ef1c3ec13)
![image](https://github.com/user-attachments/assets/87b8e469-729a-4eb3-bf20-cf4e33e7c4ae)



## How to test the changes?
Use a Memory Mushroom on Dipplin

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?