### PR TITLE
[Test] Remove held items and abilities from octolock test

### DIFF
--- a/src/test/moves/octolock.test.ts
+++ b/src/test/moves/octolock.test.ts
@@ -8,7 +8,7 @@ import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { SPLASH_ONLY } from "../utils/testUtils";
+import { removeEnemyHeldItems, SPLASH_ONLY } from "../utils/testUtils";
 
 describe("Moves - Octolock", () => {
   describe("integration tests", () => {
@@ -32,15 +32,16 @@ describe("Moves - Octolock", () => {
 
       game.override.enemySpecies(Species.RATTATA);
       game.override.enemyMoveset(SPLASH_ONLY);
-      game.override.enemyAbility(Abilities.NONE);
+      game.override.enemyAbility(Abilities.BALL_FETCH);
 
       game.override.startingLevel(2000);
       game.override.moveset([Moves.OCTOLOCK, Moves.SPLASH]);
-      game.override.ability(Abilities.NONE);
+      game.override.ability(Abilities.BALL_FETCH);
     });
 
     it("Reduces DEf and SPDEF by 1 each turn", { timeout: 10000 }, async () => {
       await game.startBattle([Species.GRAPPLOCT]);
+      removeEnemyHeldItems(game.scene);
 
       const enemyPokemon = game.scene.getEnemyField();
 
@@ -62,6 +63,7 @@ describe("Moves - Octolock", () => {
 
     it("Traps the target pokemon", { timeout: 10000 }, async () => {
       await game.startBattle([Species.GRAPPLOCT]);
+      removeEnemyHeldItems(game.scene);
 
       const enemyPokemon = game.scene.getEnemyField();
 


### PR DESCRIPTION
## What are the changes?
There are no user facing changes.

## Why am I doing these changes?
![image](https://github.com/user-attachments/assets/adea4e9f-1632-444e-9578-9cbcfd80fe34)

## What did change?
Removes enemy held items and abilities from Pokémon.

## How to test the changes?
`npm run test octolock`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
