### PR TITLE
[Bug] Weather should be reset upon arena reset

### DIFF
--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -639,11 +639,11 @@ export class Arena {
   }
 
   /**
-   * Clears terrain and arena tags when entering new biome or trainer battle.
+   * Clears weather, terrain and arena tags when entering new biome or trainer battle.
    */
   resetArenaEffects(): void {
     // Don't reset weather if a Biome's permanent weather is active
-    if (!(this.weather?.turnsLeft === 0)) {
+    if (this.weather?.turnsLeft !== 0) {
       this.trySetWeather(WeatherType.NONE, false);
     }
     this.trySetTerrain(TerrainType.NONE, false, true);

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -642,6 +642,10 @@ export class Arena {
    * Clears terrain and arena tags when entering new biome or trainer battle.
    */
   resetArenaEffects(): void {
+    // Don't reset weather if a Biome's permanent weather is active
+    if (!(this.weather?.turnsLeft === 0)) {
+      this.trySetWeather(WeatherType.NONE, false);
+    }
     this.trySetTerrain(TerrainType.NONE, false, true);
     this.removeAllTags();
   }


### PR DESCRIPTION
## What are the changes?
Weather will now be reset when arena effects are cleared at the start of trainer battles (unless the weather is from the Biome's permanent weather effect).

## Why am I doing these changes?
Weather should be reset at the start of a new battle, like everything else.

## What did change?
A call to clear the weather is added to `Arena.resetArenaEffects()`.

### Screenshots/Videos
Permanent biome weather does not get reset:

https://github.com/user-attachments/assets/66aed64e-36de-4db6-88d8-d1cdd1c032cd

Temporary weather gets reset:

https://github.com/user-attachments/assets/d07af01c-08e6-4ad7-8d8d-c6c2b40ecffb



## How to test the changes?
```ts
MOVESET_OVERRIDE: [Moves.RAIN_DANCE, Moves.DRAIN_PUNCH, Moves.THUNDERBOLT, Moves.SUNNY_DAY],
BATTLE_TYPE_OVERRIDE: "single",
STARTING_WAVE_OVERRIDE: 24,
STARTING_LEVEL_OVERRIDE: 100,
STARTING_BIOME_OVERRIDE: Biome.SEA,
```
Start a new run and go to wave 25 with the biome's weather active (may take a couple of tries to get a run with it active), and the rival battle should start with the Biome's permanent weather still active.
Start a second run, use Sunny Day to set temporary weather, then advance to wave 25 and the weather should be removed at the start of the rival battle.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - [x] Have I provided screenshots/videos of the changes?
