### PR TITLE
[QoL] Add victory screen after run win

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -4373,6 +4373,44 @@ export class EndCardPhase extends Phase {
     this.endCard.setScale(0.5);
     this.scene.field.add(this.endCard);
 
+    const topRectangle = this.scene.add.polygon(0, 0, [
+      new Phaser.Math.Vector2(0, 63),
+      new Phaser.Math.Vector2(this.endCard.width, 100),
+      new Phaser.Math.Vector2(this.endCard.width, 0),
+    ], 0x000000, 0.5);
+    this.scene.field.add(topRectangle);
+
+    const bottomRectangle = this.scene.add.polygon(topRectangle.x + 100, topRectangle.y + 115, [
+      new Phaser.Math.Vector2(topRectangle.x + 100, topRectangle.y + 50),
+      new Phaser.Math.Vector2(topRectangle.x + 140, topRectangle.y + 100),
+      new Phaser.Math.Vector2(topRectangle.width, topRectangle.y + 120),
+      new Phaser.Math.Vector2(topRectangle.width, topRectangle.y + 90),
+    ], 0x000000, 0.5);
+
+    this.scene.field.add(bottomRectangle);
+
+    this.scene.getParty().forEach((species, i) => {
+      const row = i % 2;
+      const id = species.id;
+      const shiny = species.shiny;
+      const formIndex = species.formIndex;
+      const variant = species.variant;
+      const pokemonSprite: Phaser.GameObjects.Sprite = this.scene.add.sprite(50 + 40 * i, 50 + row  * 80, "pkmn__sub");
+      pokemonSprite.setPipeline(this.scene.spritePipeline, { tone: [ 0.0, 0.0, 0.0, 0.0 ], ignoreTimeTint: true });
+      this.scene.field.add(pokemonSprite);
+      const speciesLoaded: Map<Species, boolean> = new Map<Species, boolean>();
+      speciesLoaded.set(id, false);
+
+      const female = species.gender === Gender.FEMALE;
+      species.species.loadAssets(this.scene, female, formIndex, shiny, variant, true).then(() => {
+        speciesLoaded.set(id, true);
+        pokemonSprite.play(species.species.getSpriteKey(female, formIndex, shiny, variant));
+        pokemonSprite.setPipelineData("shiny", shiny);
+        pokemonSprite.setPipelineData("variant", variant);
+        pokemonSprite.setPipelineData("spriteKey", species.species.getSpriteKey(female, formIndex, shiny, variant));
+        pokemonSprite.setVisible(true);
+      });
+    });
     this.text = addTextObject(this.scene, this.scene.game.canvas.width / 12, (this.scene.game.canvas.height / 6) - 16, i18next.t("battle:congratulations"), TextStyle.SUMMARY, { fontSize: "128px" });
     this.text.setOrigin(0.5);
     this.scene.field.add(this.text);


### PR DESCRIPTION
## What are the changes?
After win user will see whole party taken part in game. (Like a hall of fame after elite 4)

## Why am I doing these changes?
Resolves #621 

## What did change?
Add pokemon sprites in the end game screen

### Screenshots/Videos
Small species
<img width="1620" alt="346110462-6053a997-7b9b-46ad-bcb4-878480636c24" src="https://github.com/pagefaultgames/pokerogue/assets/19636010/b8bebd1b-3fc4-4f65-ba24-befffbed2e8a">

Bigger species
<img width="1618" alt="Screenshot 2024-07-05 at 13 35 40" src="https://github.com/pagefaultgames/pokerogue/assets/19636010/a72542e6-623d-45ad-8d31-173c1effc5cb">


## How to test the changes?
1. Win the game
2. (speed up solution) - Move to EndCardPhase
```javascript
(4233 line in phases.ts)
this.scene.pushPhase(new EndCardPhase(this.scene));
// this.scene.pushPhase(new PostGameOverPhase(this.scene, endCardPhase));            
```
Using code above, end game screen will be displayed after losing the game

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?