### PR TITLE
[Challenge] Eevee only challenge

### DIFF
--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -56,6 +56,11 @@ export enum ChallengeType {
   */
   FIXED_BATTLES,
   /**
+   * Allow to duplicate species
+   * @param args [0] {@link Utils.BooleanHolder} Sets to false if illegal, pass in true.
+  */
+  DUPLICATE_SPECIES,
+  /**
    * Modifies what level the AI pokemon are. UNIMPLEMENTED.
    */
   AI_LEVEL,
@@ -393,6 +398,15 @@ export abstract class Challenge {
   applyMoveWeight(pokemon: Pokemon, moveSource: MoveSourceType, move: Moves, level: Utils.IntegerHolder): boolean {
     return false;
   }
+
+  /**
+   * An apply function for DUPLICATE_SPECIES. Derived classes should alter this.
+   * @param allowDuplicates {@link Utils.BooleanHolder} Is allowing duplicates.
+   * @returns {@link boolean} Whether this function did anything.
+   */
+  applyDuplicateSpecies(allowDuplicates: Utils.BooleanHolder): boolean {
+    return false;
+  }
 }
 
 type ChallengeCondition = (data: GameData) => boolean;
@@ -515,6 +529,67 @@ export class SingleGenerationChallenge extends Challenge {
     newChallenge.value = source.value;
     newChallenge.severity = source.severity;
     return newChallenge;
+  }
+}
+
+export class EeveeOnlyChallenge extends Challenge {
+  constructor() {
+    super(Challenges.EEVEE_ONLY, 1);
+  }
+
+  getValue(overrideValue?: integer): string {
+    if (overrideValue === undefined) {
+      overrideValue = this.value;
+    }
+    if (overrideValue === 0) {
+      return i18next.t("challenges:off");
+    }
+    return i18next.t("challenges:on");
+  }
+
+  getDescription(overrideValue?: integer): string {
+    if (overrideValue === undefined) {
+      overrideValue = this.value;
+    }
+
+    return i18next.t("challenges:eeveeOnly.desc");
+  }
+
+  applyPokemonInBattle(pokemon: Pokemon, valid: Utils.BooleanHolder): boolean {
+    if (pokemon.isPlayer() && (pokemon.species.getRootSpeciesId() !== Species.EEVEE || (pokemon.isFusion() && pokemon.species.getRootSpeciesId() !== Species.EEVEE))) {
+      valid.value = false;
+      return true;
+    }
+    return false;
+  }
+
+  applyStarterChoice(pokemon: PokemonSpecies, valid: Utils.BooleanHolder, dexAttr: DexAttrProps, soft?: boolean, checkEvolutions?: boolean, checkForms?: boolean): boolean {
+    if (pokemon.getRootSpeciesId() !== Species.EEVEE) {
+      valid.value = false;
+      return true;
+    }
+    return false;
+  }
+
+  applyStarterPoints(points: Utils.NumberHolder): boolean {
+    points.value = 24;
+    return true;
+  }
+
+  applyDuplicateSpecies(allowDuplicates: Utils.BooleanHolder): boolean {
+    allowDuplicates.value = true;
+    return true;
+  }
+
+  static loadChallenge(source: Challenge | any): Challenge {
+    const newChallenge = new EeveeOnlyChallenge();
+    newChallenge.value = source.value;
+    newChallenge.severity = source.severity;
+    return newChallenge;
+  }
+
+  getDifficulty(): integer {
+    return this.value > 0 ? 1 : 0;
   }
 }
 
@@ -854,6 +929,15 @@ export function applyChallenges(gameMode: GameMode, challengeType: ChallengeType
  * @returns True if any challenge was successfully applied.
  */
 export function applyChallenges(gameMode: GameMode, challengeType: ChallengeType.MOVE_WEIGHT, pokemon: Pokemon, moveSource: MoveSourceType, move: Moves, weight: Utils.IntegerHolder): boolean;
+
+/**
+ * Apply all challenges that modify what weight a pokemon gives to move generation
+ * @param gameMode {@link GameMode} The current gameMode
+ * @param challengeType {@link ChallengeType} ChallengeType.DUPLICATE_SPECIES
+ * @param allowDuplicates {@link Utils.BooleanHolder} is allowing duplicates.
+ * @returns True if any challenge was successfully applied.
+ */
+export function applyChallenges(gameMode: GameMode, challengeType: ChallengeType.DUPLICATE_SPECIES, allowDuplicates: Utils.BooleanHolder): boolean;
 export function applyChallenges(gameMode: GameMode, challengeType: ChallengeType, ...args: any[]): boolean {
   let ret = false;
   gameMode.challenges.forEach(c => {
@@ -895,6 +979,9 @@ export function applyChallenges(gameMode: GameMode, challengeType: ChallengeType
       case ChallengeType.MOVE_WEIGHT:
         ret ||= c.applyMoveWeight(args[0], args[1], args[2], args[3]);
         break;
+      case ChallengeType.DUPLICATE_SPECIES:
+        ret ||= c.applyDuplicateSpecies(args[0]);
+        break;
       }
     }
   });
@@ -918,6 +1005,8 @@ export function copyChallenge(source: Challenge | any): Challenge {
     return LowerStarterPointsChallenge.loadChallenge(source);
   case Challenges.FRESH_START:
     return FreshStartChallenge.loadChallenge(source);
+  case Challenges.EEVEE_ONLY:
+    return EeveeOnlyChallenge.loadChallenge(source);
   }
   throw new Error("Unknown challenge copied");
 }
@@ -929,5 +1018,6 @@ export function initChallenges() {
     new SingleGenerationChallenge(),
     new SingleTypeChallenge(),
     new FreshStartChallenge(),
+    new EeveeOnlyChallenge(),
   );
 }

--- a/src/enums/challenges.ts
+++ b/src/enums/challenges.ts
@@ -3,5 +3,6 @@ export enum Challenges {
     SINGLE_TYPE,
     LOWER_MAX_STARTER_COST,
     LOWER_STARTER_POINTS,
-    FRESH_START
+    FRESH_START,
+    EEVEE_ONLY,
 }

--- a/src/locales/de/achv.ts
+++ b/src/locales/de/achv.ts
@@ -264,6 +264,10 @@ export const PGMachv: AchievementTranslationEntries = {
   "MONO_FAIRY": {
     name: "Ein ewiges Abenteuer!",
   },
+  "EEVEE_TRAINER": {
+    name: "E wie Evoli",
+    description: "Beende die 'Nur-Evoli' Herausforderung.",
+  },
 } as const;
 
 // Achievement translations for the when the player character is female

--- a/src/locales/de/challenges.ts
+++ b/src/locales/de/challenges.ts
@@ -1,6 +1,8 @@
 import { TranslationEntries } from "#app/interfaces/locales";
 
 export const challenges: TranslationEntries = {
+  "on": "An",
+  "off": "Aus",
   "title": "Herausforderungsmodifikatoren",
   "illegalEvolution": "{{pokemon}} hat sich in ein Pokémon verwandelt, dass für diese Herausforderung nicht zulässig ist!",
   "singleGeneration": {
@@ -22,6 +24,10 @@ export const challenges: TranslationEntries = {
     "desc": "Du kannst nur Pokémon des Typs {{type}} verwenden.",
     "desc_default": "Du kannst nur Pokémon des gewählten Typs verwenden."
     // types in pokemon-info
+  },
+  "eeveeOnly": {
+    "name": "Nur-Evoli",
+    "desc": "Du kannst nur Evoli und dessen Entwicklungen in dieser Herausforderung verwenden.",
   },
   "freshStart": {
     "name": "Neuanfang",

--- a/src/locales/en/achv.ts
+++ b/src/locales/en/achv.ts
@@ -264,6 +264,10 @@ export const PGMachv: AchievementTranslationEntries = {
   "MONO_FAIRY": {
     name: "Hey! Listen!",
   },
+  "EEVEE_TRAINER": {
+    name: "Eevee Trainer",
+    description: "Complete Eevee Only challenge.",
+  },
   "FRESH_START": {
     name: "First Try!",
     description: "Complete the fresh start challenge."

--- a/src/locales/en/challenges.ts
+++ b/src/locales/en/challenges.ts
@@ -1,6 +1,8 @@
 import { TranslationEntries } from "#app/interfaces/locales.js";
 
 export const challenges: TranslationEntries = {
+  "on": "On",
+  "off": "Off",
   "title": "Challenge Modifiers",
   "illegalEvolution": "{{pokemon}} changed into an ineligble pokémon\nfor this challenge!",
   "singleGeneration": {
@@ -22,6 +24,10 @@ export const challenges: TranslationEntries = {
     "desc": "You can only use Pokémon with the {{type}} type.",
     "desc_default": "You can only use Pokémon of the chosen type."
     //types in pokemon-info
+  },
+  "eeveeOnly": {
+    "name": "Eevee only",
+    "desc": "You can use only Eevee and its evolutions in this challenge",
   },
   "freshStart": {
     "name": "Fresh Start",

--- a/src/locales/es/achv.ts
+++ b/src/locales/es/achv.ts
@@ -264,6 +264,10 @@ export const PGMachv: AchievementTranslationEntries = {
   "MONO_FAIRY": {
     name: "Mono FAIRY",
   },
+  "EEVEE_TRAINER": {
+    name: "Entrenador de Eevee",
+    description: "Completa el desafío de solo Eevee.",
+  },
 } as const;
 
 // Achievement translations for the when the player character is female (it for now uses the same translations as the male version)

--- a/src/locales/es/challenges.ts
+++ b/src/locales/es/challenges.ts
@@ -1,6 +1,8 @@
 import { TranslationEntries } from "#app/interfaces/locales";
 
 export const challenges: TranslationEntries = {
+  "on": "Activado",
+  "off": "Desactivado",
   "title": "Parámetros de Desafíos",
   "illegalEvolution": "{{pokemon}} changed into an ineligble pokémon\nfor this challenge!",
   "singleGeneration": {
@@ -22,4 +24,8 @@ export const challenges: TranslationEntries = {
     "desc": "Solo puedes usar Pokémon with the {{type}} type.",
     "desc_default": "Solo puedes usar Pokémon del tipo elegido.",
   },
+  "eeveeOnly": {
+    "name": "Solamente Eevee",
+    "desc": "Solo puedes usar a Eevee o a sus evoluciones en este desafío",
+  }
 } as const;

--- a/src/locales/fr/achv.ts
+++ b/src/locales/fr/achv.ts
@@ -264,6 +264,10 @@ export const PGMachv: AchievementTranslationEntries = {
   "MONO_FAIRY": {
     name: "Hey ! Listen !",
   },
+  "EEVEE_TRAINER": {
+    name: "RP Pania",
+    description: "Terminer un challenge Évoli.",
+  },
 } as const;
 
 // Achievement translations for the when the player character is female (it for now uses the same translations as the male version)
@@ -529,5 +533,9 @@ export const PGFachv: AchievementTranslationEntries = {
   },
   "MONO_FAIRY": {
     name: "Hey ! Listen !",
+  },
+  "EEVEE_TRAINER": {
+    name: "RP Pania",
+    description: "Terminer un challenge Évoli.",
   },
 } as const;

--- a/src/locales/fr/challenges.ts
+++ b/src/locales/fr/challenges.ts
@@ -1,6 +1,8 @@
 import { TranslationEntries } from "#app/interfaces/locales";
 
 export const challenges: TranslationEntries = {
+  "on": "Activé",
+  "off": "Désactivé",
   "title": "Paramètres du Challenge",
   "illegalEvolution": "{{pokemon}} s’est transformé en Pokémon\ninéligible pour ce challenge !",
   "singleGeneration": {
@@ -23,4 +25,8 @@ export const challenges: TranslationEntries = {
     "desc_default": "Vous ne pouvez choisir que des Pokémon du type sélectionné."
     //type in pokemon-info
   },
+  "eeveeOnly": {
+    "name": "Évoli uniquement",
+    "desc": "Vous ne pouvez utiliser que des Évoli et leurs évolutions.",
+  }
 } as const;

--- a/src/locales/it/challenges.ts
+++ b/src/locales/it/challenges.ts
@@ -1,8 +1,10 @@
 import { TranslationEntries } from "#app/interfaces/locales";
 
 export const challenges: TranslationEntries = {
+  "on": "On",
+  "off": "Off",
   "title": "Modificatori delle sfide",
-  "illegalEvolution": "{{pokemon}} changed into an ineligble pokémon\nfor this challenge!",
+  "illegalEvolution": "{{pokemon}} non è più un Pokémon\nvalido per la sfida!",
   "singleGeneration": {
     "name": "Mono gen",
     "desc": "Puoi usare solo Pokémon di {{gen}} generazione.",
@@ -22,4 +24,8 @@ export const challenges: TranslationEntries = {
     "desc": "Puoi usare solo Pokémon di tipo {{type}}.",
     "desc_default": "Puoi usare solo Pokémon del tipo selezionato."
   },
+  "eeveeOnly": {
+    "name": "Mono-Eevee",
+    "desc": "Puoi usare solo Eevee e le sue evoluzioni.",
+  }
 } as const;

--- a/src/locales/ko/achv.ts
+++ b/src/locales/ko/achv.ts
@@ -268,6 +268,10 @@ export const PGMachv: AchievementTranslationEntries = {
     name: "첫트!",
     description: "새 출발 챌린지 모드 클리어."
   },
+  "EEVEE_TRAINER": {
+    name: "이브이 트레이너",
+    description: "이브이 모드 챌린지 클리어.",
+  },
 } as const;
 
 // Achievement translations for the when the player character is female (it for now uses the same translations as the male version)

--- a/src/locales/ko/challenges.ts
+++ b/src/locales/ko/challenges.ts
@@ -1,6 +1,8 @@
 import { TranslationEntries } from "#app/interfaces/locales";
 
 export const challenges: TranslationEntries = {
+  "on": "설정",
+  "off": "해제",
   "title": "챌린지 조건 설정",
   "illegalEvolution": "{{pokemon}}[[는]] 현재의 챌린지에\n부적합한 포켓몬이 되었습니다!",
   "singleGeneration": {
@@ -28,5 +30,9 @@ export const challenges: TranslationEntries = {
     "desc": "포켓로그를 처음 시작했던 때처럼 강화가 전혀 되지 않은 오리지널 스타팅 포켓몬만 고를 수 있습니다.",
     "value.0": "해제",
     "value.1": "설정",
+  },
+  "eeveeOnly": {
+    "name": "이브이 모드",
+    "desc": "이 챌린지는 이브이와 이브이의 진화체만 사용할 수 있습니다.",
   }
 } as const;

--- a/src/locales/pt_BR/achv.ts
+++ b/src/locales/pt_BR/achv.ts
@@ -269,6 +269,10 @@ export const PGMachv: AchievementTranslationEntries = {
     name: "De Primeira!",
     description: "Complete o desafio de novo começo."
   },
+  "EEVEE_TRAINER": {
+    name: "Treinador de Eevee",
+    description: "Complete o desafio Somente Eevees.",
+  },
 } as const;
 
 // Achievement translations for the when the player character is female
@@ -539,5 +543,9 @@ export const PGFachv: AchievementTranslationEntries = {
   "FRESH_START": {
     name: "De Primeira!",
     description: "Complete o desafio de novo começo."
+  },
+  "EEVEE_TRAINER": {
+    name: "Treinador de Eevee",
+    description: "Complete o desafio Somente Eevees.",
   },
 } as const;

--- a/src/locales/pt_BR/challenges.ts
+++ b/src/locales/pt_BR/challenges.ts
@@ -1,6 +1,8 @@
 import { TranslationEntries } from "#app/interfaces/locales";
 
 export const challenges: TranslationEntries = {
+  "on": "Ligado",
+  "off": "Desligado",
   "title": "Desafios",
   "illegalEvolution": "{{pokemon}} não pode ser escolhido\nnesse desafio!",
   "singleGeneration": {
@@ -19,7 +21,11 @@ export const challenges: TranslationEntries = {
   },
   "singleType": {
     "name": "Monotipo",
-    "desc": "Você só pode user Pokémon do tipo {{type}}.",
-    "desc_default": "Você só pode user Pokémon de um único tipo."
+    "desc": "Você só pode usar Pokémon do tipo {{type}}.",
+    "desc_default": "Você só pode usar Pokémon de um único tipo."
   },
+  "eeveeOnly": {
+    "name": "Somente Eevees",
+    "desc": "Você só pode usar Eevee e suas evoluções nesse desafio",
+  }
 } as const;

--- a/src/locales/zh_CN/achv.ts
+++ b/src/locales/zh_CN/achv.ts
@@ -267,7 +267,11 @@ export const PGMachv: AchievementTranslationEntries = {
   "FRESH_START": {
     name: "初次尝试！",
     description: "完成初次尝试挑战"
-  }
+  },
+  "EEVEE_TRAINER": {
+    name: "唯布独尊",
+    description: "完成伊布限定挑战。",
+  },
 } as const;
 
 // Achievement translations for the when the player character is female (it for now uses the same translations as the male version)

--- a/src/locales/zh_CN/challenges.ts
+++ b/src/locales/zh_CN/challenges.ts
@@ -1,6 +1,8 @@
 import { TranslationEntries } from "#app/interfaces/locales";
 
 export const challenges: TranslationEntries = {
+  "on": "启用",
+  "off": "禁用",
   "title": "适用挑战条件",
   "illegalEvolution": "{{pokemon}}变成了\n不符合此挑战条件的宝可梦！",
   "singleGeneration": {
@@ -28,4 +30,8 @@ export const challenges: TranslationEntries = {
     "value.0": "关闭",
     "value.1": "开启",
   },
+  "eeveeOnly": {
+    "name": "伊布限定",
+    "desc": "在这个挑战中你只能使用伊布",
+  }
 } as const;

--- a/src/locales/zh_TW/achv.ts
+++ b/src/locales/zh_TW/achv.ts
@@ -264,6 +264,10 @@ export const PGMachv: AchievementTranslationEntries = {
   "MONO_FAIRY": {
     name: "林克，醒醒！",
   },
+  "EEVEE_TRAINER": {
+    name: "Eevee Trainer",
+    description: "Complete Eevee Only challenge.",
+  },
 } as const;
 
 // Achievement translations for the when the player character is female (it for now uses the same translations as the male version)

--- a/src/locales/zh_TW/challenges.ts
+++ b/src/locales/zh_TW/challenges.ts
@@ -1,6 +1,8 @@
 import { TranslationEntries } from "#app/interfaces/locales";
 
 export const challenges: TranslationEntries = {
+  "on": "On",
+  "off": "Off",
   "title": "適用挑戰條件",
   "illegalEvolution": "{{pokemon}} 進化成了不符合\n挑戰條件的寶可夢！",
   "singleGeneration": {
@@ -22,4 +24,8 @@ export const challenges: TranslationEntries = {
     "desc": "你只能使用{{type}}\n屬性的寶可夢",
     "desc_default": "你只能使用所選\n屬性的寶可夢"
   },
+  "eeveeOnly": {
+    "name": "Eevee only",
+    "desc": "You can use only Eevee and its evolutions in this challenge",
+  }
 } as const;

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -228,7 +228,7 @@ export class TitlePhase extends Phase {
           this.scene.ui.clearText();
           this.end();
         };
-        if (this.scene.gameData.unlocks[Unlockables.ENDLESS_MODE]) {
+        if (!this.scene.gameData.unlocks[Unlockables.ENDLESS_MODE]) {
           const options: OptionSelectItem[] = [
             {
               label: GameMode.getModeName(GameModes.CLASSIC),

--- a/src/system/achv.ts
+++ b/src/system/achv.ts
@@ -5,7 +5,7 @@ import i18next from "i18next";
 import * as Utils from "../utils";
 import { PlayerGender } from "#enums/player-gender";
 import { ParseKeys } from "i18next";
-import { Challenge, FreshStartChallenge, SingleGenerationChallenge, SingleTypeChallenge } from "#app/data/challenge.js";
+import { Challenge, EeveeOnlyChallenge, FreshStartChallenge, SingleGenerationChallenge, SingleTypeChallenge } from "#app/data/challenge.js";
 
 export enum AchvTier {
   COMMON,
@@ -276,6 +276,8 @@ export function getAchievementDescription(localizationKey: string): string {
   case "MONO_DARK":
   case "MONO_FAIRY":
     return i18next.t(`${genderPrefix}achv:MonoType.description` as ParseKeys, {"type": i18next.t(`pokemonInfo:Type.${localizationKey.slice(5)}`)});
+  case "EEVEE_TRAINER":
+    return i18next.t(`${genderPrefix}achv:EEVEE_TRAINER.description` as ParseKeys);
   case "FRESH_START":
     return i18next.t(`${genderPrefix}achv:FRESH_START.description` as ParseKeys);
   default:
@@ -352,6 +354,7 @@ export const achvs = {
   MONO_DRAGON: new ChallengeAchv("MONO_DRAGON","", "MONO_DRAGON.description", "dragon_fang", 100, c => c instanceof SingleTypeChallenge && c.value === 16),
   MONO_DARK: new ChallengeAchv("MONO_DARK","", "MONO_DARK.description", "black_glasses", 100, c => c instanceof SingleTypeChallenge && c.value === 17),
   MONO_FAIRY: new ChallengeAchv("MONO_FAIRY","", "MONO_FAIRY.description", "fairy_feather", 100, c => c instanceof SingleTypeChallenge && c.value === 18),
+  EEVEE_TRAINER: new ChallengeAchv("EEVEE_TRAINER","", "EEVEE_TRAINER.description", "fire_stone", 100, c => c instanceof EeveeOnlyChallenge && c.value === 1),
   FRESH_START: new ChallengeAchv("FRESH_START","", "FRESH_START.description", "reviver_seed", 100, c => c instanceof FreshStartChallenge && c.value === 1),
 };
 

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1196,16 +1196,18 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
             Challenge.applyChallenges(this.scene.gameMode, Challenge.ChallengeType.STARTER_CHOICE, species, isValidForChallenge, this.scene.gameData.getSpeciesDexAttrProps(species, this.scene.gameData.getSpeciesDefaultDexAttr(species, false, true)), this.starterSpecies.length !== 0, false, false);
           }
 
+          const allowDuplicateSpecies = new Utils.BooleanHolder(false);
+          Challenge.applyChallenges(this.scene.gameMode, Challenge.ChallengeType.DUPLICATE_SPECIES, allowDuplicateSpecies);
           const currentPartyValue = this.starterSpecies.map(s => s.generation).reduce((total: number, gen: number, i: number) => total += this.scene.gameData.getSpeciesStarterValue(this.starterSpecies[i].speciesId), 0);
           const newCost = this.scene.gameData.getSpeciesStarterValue(species.speciesId);
-          if (!isDupe && isValidForChallenge.value && currentPartyValue + newCost <= this.getValueLimit()) { // this checks to make sure the pokemon doesn't exist in your party, it's valid for the challenge and that it won't go over the cost limit; if it meets all these criteria it will add it to your party
+          if ((!isDupe && isValidForChallenge.value || allowDuplicateSpecies.value) && currentPartyValue + newCost <= this.getValueLimit()) { // this checks to make sure the pokemon doesn't exist in your party, it's valid for the challenge and that it won't go over the cost limit; if it meets all these criteria it will add it to your party
             options = [
               {
                 label: i18next.t("starterSelectUiHandler:addToParty"),
                 handler: () => {
                   ui.setMode(Mode.STARTER_SELECT);
                   const isOverValueLimit = this.tryUpdateValue(this.scene.gameData.getSpeciesStarterValue(species.speciesId), true);
-                  if (!isDupe && isValidForChallenge.value && isOverValueLimit) {
+                  if ((!isDupe || allowDuplicateSpecies.value) && isValidForChallenge.value && isOverValueLimit) {
                     const cursorObj = this.starterCursorObjs[this.starterSpecies.length];
                     cursorObj.setVisible(true);
                     cursorObj.setPosition(this.cursorObj.x, this.cursorObj.y);


### PR DESCRIPTION
## What are the changes?
Add new challenge mode

## Why am I doing these changes?
Make challenge more interesting

## What did change?
Added new option in challenge
Allow to use only Eevee
Allow to use duplicated species
Not allow to use other pokemon than Eeveelutions

### Screenshots/Videos
New option in challenge menu
<img width="1671" alt="Screenshot 2024-07-02 at 10 50 44" src="https://github.com/pagefaultgames/pokerogue/assets/19636010/11d525ce-fdba-43ac-80bc-576ff2861122">
Allow to use *only* Eevee
<img width="1614" alt="Screenshot 2024-07-02 at 10 50 59" src="https://github.com/pagefaultgames/pokerogue/assets/19636010/55e02ed9-074c-4690-b45d-45a4411638f7">
Allow to have duplicated species
<img width="1617" alt="Screenshot 2024-07-02 at 10 51 14" src="https://github.com/pagefaultgames/pokerogue/assets/19636010/2bb9963f-143c-4fdf-9f3f-9268f3e38ab0">
Cannot use other pokemon than Eevee
<img width="1614" alt="Screenshot 2024-07-02 at 10 51 47" src="https://github.com/pagefaultgames/pokerogue/assets/19636010/5fe18d88-2d46-4493-8e2a-00d3d8ef1759">
Completed challenge
<img width="1614" alt="Screenshot 2024-07-04 at 04 36 51" src="https://github.com/pagefaultgames/pokerogue/assets/19636010/dcc2bffb-5b4f-4400-8d6b-aa607bae44ab">


## How to test the changes?
Choose new challenge

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?