### PR TITLE
[Beta][Localization] Fresh Start challenge entries added to French locales

### DIFF
--- a/src/locales/fr/achv.ts
+++ b/src/locales/fr/achv.ts
@@ -266,7 +266,7 @@ export const PGMachv: AchievementTranslationEntries = {
   },
   "FRESH_START": {
     name: "Du premier coup !",
-    description: "Complete the fresh start challenge."
+    description: "Terminer un challenge « Nouveau départ »."
   }
 } as const;
 
@@ -536,6 +536,6 @@ export const PGFachv: AchievementTranslationEntries = {
   },
   "FRESH_START": {
     name: "Du premier coup !",
-    description: "Complete the fresh start challenge."
+    description: "Terminer un challenge « Nouveau départ »."
   }
 } as const;

--- a/src/locales/fr/achv.ts
+++ b/src/locales/fr/achv.ts
@@ -264,6 +264,10 @@ export const PGMachv: AchievementTranslationEntries = {
   "MONO_FAIRY": {
     name: "Hey ! Listen !",
   },
+  "FRESH_START": {
+    name: "Du premier coup !",
+    description: "Complete the fresh start challenge."
+  }
 } as const;
 
 // Achievement translations for the when the player character is female (it for now uses the same translations as the male version)
@@ -530,4 +534,8 @@ export const PGFachv: AchievementTranslationEntries = {
   "MONO_FAIRY": {
     name: "Hey ! Listen !",
   },
+  "FRESH_START": {
+    name: "Du premier coup !",
+    description: "Complete the fresh start challenge."
+  }
 } as const;

--- a/src/locales/fr/challenges.ts
+++ b/src/locales/fr/challenges.ts
@@ -23,4 +23,10 @@ export const challenges: TranslationEntries = {
     "desc_default": "Vous ne pouvez choisir que des Pokémon du type sélectionné."
     //type in pokemon-info
   },
+  "freshStart": {
+    "name": "Nouveau départ",
+    "desc": "Vous ne pouvez choisir que les starters de base du jeu, comme si vous le recommenciez.",
+    "value.0": "Non",
+    "value.1": "Oui",
+  }
 } as const;


### PR DESCRIPTION
## What are the changes?
Added entries related to the Fresh Start challenge that have never been added to French local files

## Why am I doing these changes?
To improve Frenchness

## What did change?
Addition of Fresh Start challenge related entries in French achiv.ts and challenge.ts

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?