### PR TITLE
[Bug,Enhancement] Fix and improve Starter selector UI

### DIFF
--- a/src/ui/dropdown.ts
+++ b/src/ui/dropdown.ts
@@ -27,10 +27,10 @@ export class DropDownLabel {
   public text: string;
   public sprite?: Phaser.GameObjects.Sprite;
 
-  constructor(label: string, sprite?: Phaser.GameObjects.Sprite, state: DropDownState = DropDownState.ON) {
+  constructor(label: string, sprite?: Phaser.GameObjects.Sprite, state: DropDownState = DropDownState.OFF) {
     this.text = label || "";
     this.sprite = sprite;
-    this.state = state || DropDownState.ON;
+    this.state = state;
   }
 }
 
@@ -267,7 +267,7 @@ export class DropDown extends Phaser.GameObjects.Container {
   public defaultCursor: number = 0;
   private onChange: () => void;
   private lastDir: SortDirection = SortDirection.ASC;
-  private defaultValues: any[];
+  private defaultSettings: any[];
 
   constructor(scene: BattleScene, x: number, y: number, options: DropDownOption[], onChange: () => void, type: DropDownType = DropDownType.MULTI, optionSpacing: number = 2) {
     const windowPadding = 5;
@@ -292,7 +292,7 @@ export class DropDown extends Phaser.GameObjects.Container {
       this.options.unshift(new DropDownOption(scene, "ALL", new DropDownLabel(i18next.t("filterBar:all"), undefined, this.checkForAllOn() ? DropDownState.ON : DropDownState.OFF)));
     }
 
-    this.defaultValues = this.getVals();
+    this.defaultSettings = this.getSettings();
 
     // Place ui elements in the correct spot
     options.forEach((option, index) => {
@@ -458,23 +458,34 @@ export class DropDown extends Phaser.GameObjects.Container {
   }
 
   /**
+   * Get the current selected settings dictionary for each option
+   * @returns an array of dictionaries with the current state of each option
+   */
+  getSettings(): any[] {
+    const settings = [];
+    for (const option of this.options) {
+      settings.push({ val: option.val, state: option.state , cursor: (this.cursor === this.options.indexOf(option)), dir: option.dir });
+    }
+    return settings;
+  }
+
+  /**
    * Check whether the values of all options are the same as the default ones
    * @returns true if they are the same, false otherwise
    */
   public hasDefaultValues(): boolean {
-    const currentValues = this.getVals();
+    const currentValues = this.getSettings();
 
     switch (this.dropDownType) {
     case DropDownType.MULTI:
-    case DropDownType.HYBRID:
-      return currentValues.length === this.defaultValues.length && currentValues.every((value, index) => value === this.defaultValues[index]);
-
     case DropDownType.RADIAL:
-      return currentValues.every((value, index) => value["val"] === this.defaultValues[index]["val"] && value["state"] === this.defaultValues[index]["state"]);
+      return currentValues.length === this.defaultSettings.length && currentValues.every((value, index) => value["val"] === this.defaultSettings[index]["val"] && value["state"] === this.defaultSettings[index]["state"]);
+
+    case DropDownType.HYBRID:
+      return currentValues.length === this.defaultSettings.length && currentValues.every((value, index) => value["val"] === this.defaultSettings[index]["val"] && value["state"] === this.defaultSettings[index]["state"] && value["cursor"] === this.defaultSettings[index]["cursor"]);
 
     case DropDownType.SINGLE:
-      return currentValues[0]["dir"] === this.defaultValues[0]["dir"] && currentValues[0]["val"] === this.defaultValues[0]["val"];
-
+      return currentValues.length === this.defaultSettings.length && currentValues.every((value, index) => value["val"] === this.defaultSettings[index]["val"] && value["dir"] === this.defaultSettings[index]["dir"]);
     default:
       return false;
     }
@@ -484,46 +495,24 @@ export class DropDown extends Phaser.GameObjects.Container {
    * Set all values to their default state
    */
   public resetToDefault(): void {
-    this.setCursor(this.defaultCursor);
+    if (this.defaultSettings.length > 0) {
+      this.setCursor(this.defaultCursor);
 
-    for (let i = 0; i < this.options.length; i++) {
-      const option = this.options[i];
-      // reset values
-      switch (this.dropDownType) {
-      case DropDownType.HYBRID:
-      case DropDownType.MULTI:
-        if (this.defaultValues.includes(option.val)) {
-          option.setOptionState(DropDownState.ON);
+      for (let i = 0; i < this.options.length; i++) {
+        // reset values with the defaultValues
+        if (this.dropDownType === DropDownType.SINGLE) {
+          if (this.options[i].val === this.defaultSettings[i].val) {
+            if (this.options[i].state !== DropDownState.ON && this.defaultSettings[i].state === DropDownState.ON) {
+              this.toggleOptionState(i);
+            }
+          }
         } else {
-          option.setOptionState(DropDownState.OFF);
-        }
-        break;
-      case DropDownType.RADIAL:
-        const targetValue = this.defaultValues.find(value => value.val === option.val);
-        option.setOptionState(targetValue.state);
-        break;
-      case DropDownType.SINGLE:
-        if (option.val === this.defaultValues[0].val) {
-          if (option.state !== DropDownState.ON) {
-            this.toggleOptionState(i);
-          }
-          if (option.dir !== this.defaultValues[0].dir) {
-            this.toggleOptionState(i);
+          if (this.defaultSettings[i]) {
+            this.options[i].setOptionState(this.defaultSettings[i]["state"]);
           }
         }
-        break;
       }
     }
-
-    // Select or unselect "ALL" button if applicable
-    if (this.dropDownType === DropDownType.MULTI || this.dropDownType === DropDownType.HYBRID) {
-      if (this.checkForAllOn()) {
-        this.options[0].setOptionState(DropDownState.ON);
-      } else {
-        this.options[0].setOptionState(DropDownState.OFF);
-      }
-    }
-
   }
 
   /**

--- a/src/ui/dropdown.ts
+++ b/src/ui/dropdown.ts
@@ -262,7 +262,7 @@ export class DropDown extends Phaser.GameObjects.Container {
   public options: DropDownOption[];
   private window: Phaser.GameObjects.NineSlice;
   private cursorObj: Phaser.GameObjects.Image;
-  private dropDownType: DropDownType = DropDownType.MULTI;
+  public dropDownType: DropDownType = DropDownType.MULTI;
   public cursor: number = 0;
   public defaultCursor: number = 0;
   private onChange: () => void;

--- a/src/ui/dropdown.ts
+++ b/src/ui/dropdown.ts
@@ -479,16 +479,24 @@ export class DropDown extends Phaser.GameObjects.Container {
   public hasDefaultValues(): boolean {
     const currentValues = this.getSettings();
 
+    const compareValues = (keys: string[]): boolean => {
+      return currentValues.length === this.defaultSettings.length &&
+               currentValues.every((value, index) =>
+                 keys.every(key => value[key] === this.defaultSettings[index][key])
+               );
+    };
+
     switch (this.dropDownType) {
     case DropDownType.MULTI:
     case DropDownType.RADIAL:
-      return currentValues.length === this.defaultSettings.length && currentValues.every((value, index) => value["val"] === this.defaultSettings[index]["val"] && value["state"] === this.defaultSettings[index]["state"]);
+      return compareValues(["val", "state"]);
 
     case DropDownType.HYBRID:
-      return currentValues.length === this.defaultSettings.length && currentValues.every((value, index) => value["val"] === this.defaultSettings[index]["val"] && value["state"] === this.defaultSettings[index]["state"] && value["cursor"] === this.defaultSettings[index]["cursor"]);
+      return compareValues(["val", "state", "cursor"]);
 
     case DropDownType.SINGLE:
-      return currentValues.length === this.defaultSettings.length && currentValues.every((value, index) => value["val"] === this.defaultSettings[index]["val"] && value["state"] === this.defaultSettings[index]["state"] && value["dir"] === this.defaultSettings[index]["dir"]);
+      return compareValues(["val", "state", "dir"]);
+
     default:
       return false;
     }

--- a/src/ui/dropdown.ts
+++ b/src/ui/dropdown.ts
@@ -469,7 +469,6 @@ export class DropDown extends Phaser.GameObjects.Container {
     for (let i = 0; i < this.options.length; i++) {
       settings.push({ val: this.options[i].val, state: this.options[i].state , cursor: (this.cursor === i), dir: this.options[i].dir });
     }
-    console.log(settings);
     return settings;
   }
 

--- a/src/ui/dropdown.ts
+++ b/src/ui/dropdown.ts
@@ -503,10 +503,14 @@ export class DropDown extends Phaser.GameObjects.Container {
       for (let i = 0; i < this.options.length; i++) {
         // reset values with the defaultValues
         if (this.dropDownType === DropDownType.SINGLE) {
-          if (this.options[i].val === this.defaultSettings[i].val) {
-            if (this.options[i].state !== DropDownState.ON && this.defaultSettings[i].state === DropDownState.ON) {
-              this.toggleOptionState(i);
-            }
+          if (this.defaultSettings[i].state === DropDownState.OFF) {
+            this.options[i].setOptionState(DropDownState.OFF);
+            this.options[i].setDirection(SortDirection.ASC);
+            this.options[i].toggle.setVisible(false);
+          } else {
+            this.options[i].setOptionState(DropDownState.ON);
+            this.options[i].setDirection(SortDirection.ASC);
+            this.options[i].toggle.setVisible(true);
           }
         } else {
           if (this.defaultSettings[i]) {

--- a/src/ui/dropdown.ts
+++ b/src/ui/dropdown.ts
@@ -264,6 +264,7 @@ export class DropDown extends Phaser.GameObjects.Container {
   private cursorObj: Phaser.GameObjects.Image;
   public dropDownType: DropDownType = DropDownType.MULTI;
   public cursor: number = 0;
+  public lastCursor: number = -1;
   public defaultCursor: number = 0;
   private onChange: () => void;
   private lastDir: SortDirection = SortDirection.ASC;
@@ -339,8 +340,8 @@ export class DropDown extends Phaser.GameObjects.Container {
 
   resetCursor(): boolean {
     // If we are an hybrid dropdown in "hover" mode, don't move the cursor back to 0
-    if (this.dropDownType === DropDownType.HYBRID && this.checkForAllOff() && this.cursor > 0) {
-      return false;
+    if (this.dropDownType === DropDownType.HYBRID && this.checkForAllOff()) {
+      return this.setCursor(this.lastCursor);
     }
     return this.setCursor(this.defaultCursor);
   }
@@ -361,6 +362,7 @@ export class DropDown extends Phaser.GameObjects.Container {
       this.cursorObj.setVisible(true);
       // If hydrid type, we need to update the filters when going up/down in the list
       if (this.dropDownType === DropDownType.HYBRID) {
+        this.lastCursor = cursor;
         this.onChange();
       }
     }

--- a/src/ui/dropdown.ts
+++ b/src/ui/dropdown.ts
@@ -508,6 +508,7 @@ export class DropDown extends Phaser.GameObjects.Container {
   public resetToDefault(): void {
     if (this.defaultSettings.length > 0) {
       this.setCursor(this.defaultCursor);
+      this.lastDir = SortDirection.ASC;
 
       for (let i = 0; i < this.options.length; i++) {
         // reset values with the defaultValues

--- a/src/ui/dropdown.ts
+++ b/src/ui/dropdown.ts
@@ -264,7 +264,7 @@ export class DropDown extends Phaser.GameObjects.Container {
   private cursorObj: Phaser.GameObjects.Image;
   public dropDownType: DropDownType = DropDownType.MULTI;
   public cursor: number = 0;
-  public lastCursor: number = -1;
+  private lastCursor: number = -1;
   public defaultCursor: number = 0;
   private onChange: () => void;
   private lastDir: SortDirection = SortDirection.ASC;
@@ -462,12 +462,14 @@ export class DropDown extends Phaser.GameObjects.Container {
   /**
    * Get the current selected settings dictionary for each option
    * @returns an array of dictionaries with the current state of each option
+   * - the settings dictionary is like this { val: any, state: DropDownState, cursor: boolean, dir: SortDirection }
    */
-  getSettings(): any[] {
+  private getSettings(): any[] {
     const settings = [];
-    for (const option of this.options) {
-      settings.push({ val: option.val, state: option.state , cursor: (this.cursor === this.options.indexOf(option)), dir: option.dir });
+    for (let i = 0; i < this.options.length; i++) {
+      settings.push({ val: this.options[i].val, state: this.options[i].state , cursor: (this.cursor === i), dir: this.options[i].dir });
     }
+    console.log(settings);
     return settings;
   }
 

--- a/src/ui/dropdown.ts
+++ b/src/ui/dropdown.ts
@@ -488,7 +488,7 @@ export class DropDown extends Phaser.GameObjects.Container {
       return currentValues.length === this.defaultSettings.length && currentValues.every((value, index) => value["val"] === this.defaultSettings[index]["val"] && value["state"] === this.defaultSettings[index]["state"] && value["cursor"] === this.defaultSettings[index]["cursor"]);
 
     case DropDownType.SINGLE:
-      return currentValues.length === this.defaultSettings.length && currentValues.every((value, index) => value["val"] === this.defaultSettings[index]["val"] && value["dir"] === this.defaultSettings[index]["dir"]);
+      return currentValues.length === this.defaultSettings.length && currentValues.every((value, index) => value["val"] === this.defaultSettings[index]["val"] && value["state"] === this.defaultSettings[index]["state"] && value["dir"] === this.defaultSettings[index]["dir"]);
     default:
       return false;
     }

--- a/src/ui/filter-bar.ts
+++ b/src/ui/filter-bar.ts
@@ -120,7 +120,7 @@ export class FilterBar extends Phaser.GameObjects.Container {
   /**
    * Move the leftmost dropdown to the left of the FilterBar instead of below it
    */
-  offsetHybridFilter(): void {
+  offsetHybridFilters(): void {
     for (let i=0; i<this.dropDowns.length; i++) {
       if (this.dropDowns[i].dropDownType === DropDownType.HYBRID) {
         this.dropDowns[i].autoSize();

--- a/src/ui/filter-bar.ts
+++ b/src/ui/filter-bar.ts
@@ -1,5 +1,5 @@
 import BattleScene from "#app/battle-scene.js";
-import { DropDown } from "./dropdown";
+import { DropDown, DropDownType } from "./dropdown";
 import { StarterContainer } from "./starter-container";
 import { addTextObject, getTextColor, TextStyle } from "./text";
 import { UiTheme } from "#enums/ui-theme";
@@ -120,11 +120,13 @@ export class FilterBar extends Phaser.GameObjects.Container {
   /**
    * Move the leftmost dropdown to the left of the FilterBar instead of below it
    */
-  offsetFirstFilter(): void {
-    if (this.dropDowns[0]) {
-      this.dropDowns[0].autoSize();
-      this.dropDowns[0].x -= this.dropDowns[0].getWidth();
-      this.dropDowns[0].y = 0;
+  offsetHybridFilter(): void {
+    for (let i=0; i<this.dropDowns.length; i++) {
+      if (this.dropDowns[i].dropDownType === DropDownType.HYBRID) {
+        this.dropDowns[i].autoSize();
+        this.dropDowns[i].x = - this.dropDowns[i].getWidth();
+        this.dropDowns[i].y = 0;
+      }
     }
   }
 

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -914,15 +914,13 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
    */
   resetFilters() : void {
     const genDropDown: DropDown = this.filterBar.getFilter(DropDownColumn.GEN);
-    if (this.scene.gameMode.isChallenge) {
-      // In challenge mode all gens are selected by default
-      genDropDown.defaultCursor = 0;
-    } else {
-      // in other modes, gen 1 is selected by default, and all options disabled
-      genDropDown.defaultCursor = 1;
-    }
 
     this.filterBar.setValsToDefault();
+
+    if (!this.scene.gameMode.isChallenge) {
+      // if not in a challenge, in Gen hybrid filter hovering mode, set the cursor to the Gen1
+      genDropDown.setCursor(1);
+    }
   }
 
   showText(text: string, delay?: integer, callback?: Function, callbackDelay?: integer, prompt?: boolean, promptDelay?: integer) {

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -2999,7 +2999,6 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     };
     ui.showText(i18next.t("starterSelectUiHandler:confirmExit"), null, () => {
       ui.setModeWithoutClear(Mode.CONFIRM, () => {
-        this.resetFilters();
         ui.setMode(Mode.STARTER_SELECT);
         this.scene.clearPhaseQueue();
         if (this.scene.gameMode.isChallenge) {

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -462,7 +462,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.starterSelectContainer.add(this.filterBarContainer);
 
     // Offset the generation filter dropdown to avoid covering the filtered pokemon
-    this.filterBar.offsetHybridFilter();
+    this.filterBar.offsetHybridFilters();
 
     if (!this.scene.uiTheme) {
       starterContainerWindow.setVisible(false);

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -462,7 +462,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.starterSelectContainer.add(this.filterBarContainer);
 
     // Offset the generation filter dropdown to avoid covering the filtered pokemon
-    this.filterBar.offsetFirstFilter();
+    this.filterBar.offsetHybridFilter();
 
     if (!this.scene.uiTheme) {
       starterContainerWindow.setVisible(false);

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -450,11 +450,11 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
     // sort filter
     const sortOptions = [
-      new DropDownOption(this.scene, 0, new DropDownLabel(i18next.t("filterBar:sortByNumber"))),
-      new DropDownOption(this.scene, 1, new DropDownLabel(i18next.t("filterBar:sortByCost"), undefined, DropDownState.OFF)),
-      new DropDownOption(this.scene, 2, new DropDownLabel(i18next.t("filterBar:sortByCandies"), undefined, DropDownState.OFF)),
-      new DropDownOption(this.scene, 3, new DropDownLabel(i18next.t("filterBar:sortByIVs"), undefined, DropDownState.OFF)),
-      new DropDownOption(this.scene, 4, new DropDownLabel(i18next.t("filterBar:sortByName"), undefined, DropDownState.OFF))
+      new DropDownOption(this.scene, 0, new DropDownLabel(i18next.t("filterBar:sortByNumber"), undefined, DropDownState.ON)),
+      new DropDownOption(this.scene, 1, new DropDownLabel(i18next.t("filterBar:sortByCost"))),
+      new DropDownOption(this.scene, 2, new DropDownLabel(i18next.t("filterBar:sortByCandies"))),
+      new DropDownOption(this.scene, 3, new DropDownLabel(i18next.t("filterBar:sortByIVs"))),
+      new DropDownOption(this.scene, 4, new DropDownLabel(i18next.t("filterBar:sortByName")))
     ];
     this.filterBar.addFilter(DropDownColumn.SORT, i18next.t("filterBar:sortFilter"), new DropDown(this.scene, 0, 0, sortOptions, this.updateStarters, DropDownType.SINGLE));
     this.filterBarContainer.add(this.filterBar);
@@ -923,11 +923,6 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     }
 
     this.filterBar.setValsToDefault();
-
-    // for all modes except challenge, disable all gen options to enable hovering behavior
-    if (!this.scene.gameMode.isChallenge) {
-      genDropDown.unselectAllOptions();
-    }
   }
 
   showText(text: string, delay?: integer, callback?: Function, callbackDelay?: integer, prompt?: boolean, promptDelay?: integer) {
@@ -3004,6 +2999,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     };
     ui.showText(i18next.t("starterSelectUiHandler:confirmExit"), null, () => {
       ui.setModeWithoutClear(Mode.CONFIRM, () => {
+        this.resetFilters();
         ui.setMode(Mode.STARTER_SELECT);
         this.scene.clearPhaseQueue();
         if (this.scene.gameMode.isChallenge) {


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This PR enhances the hybrid filters with hovering functionality.
1. The dropdowns of all hybrid filters no longer obscure the Pokémon list.
2. The default setting for hybrid filters is ALL OFF. (In classic mode, the Gen filter defaults to Gen 1 with the cursor hovering over it.)

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
1. Hybrid filters change the filtered list in real-time with cursor movement, and it is much more useful to not obscure the Pokémon list in hovering mode.
2. The default setting for all hybrid filters should be hovering, as multi-selecting when necessary is the standard usage. Keeping the default settings for type and dex as all selected, as before, is inconvenient since most users will need to clear all selections before using filters effectively.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
1. Changed all hybrid windows to appear to the left of the Pokémon list. This adjustment ensures that any additional hybrid filters added in the future will automatically be positioned to the left.
2. Refactored the way default settings are stored. The previous method could not remember the active cursor position. This allows the resetFilter function to be more intuitive and concise. 
 -> This fixes the bug where the Gen ALL hover mode wasn't saved when moving filters, as seen in the before video.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
before

https://github.com/user-attachments/assets/24f15b69-f6b5-4651-b2ae-6a0b25241545



after

https://github.com/user-attachments/assets/ce1152a2-ebca-4f8b-9ba6-701463336080



## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
