### PR TITLE
[BUG] - dragon tail switchout ability in wild battles proc crashes game

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -765,6 +765,27 @@ export default class BattleScene extends SceneBase {
   }
 
   /**
+   * Used in doubles battles to redirect moves from one pokemon to another when one faints or is removed from the field
+   * @param removedPokemon {@linkcode Pokemon} the pokemon that is being removed from the field (flee, faint), moves to be redirected FROM
+   * @param allyPokemon {@linkcode Pokemon} the pokemon that will have the moves be redirected TO
+   */
+  redirectPokemonMoves(removedPokemon: Pokemon, allyPokemon: Pokemon): void {
+    // failsafe: if not a double battle just return
+    if (this.currentBattle.double === false) {
+      return;
+    }
+    if (allyPokemon?.isActive(true)) {
+      let targetingMovePhase: MovePhase;
+      do {
+        targetingMovePhase = this.findPhase(mp => mp instanceof MovePhase && mp.targets.length === 1 && mp.targets[0] === removedPokemon.getBattlerIndex() && mp.pokemon.isPlayer() !== allyPokemon.isPlayer()) as MovePhase;
+        if (targetingMovePhase && targetingMovePhase.targets[0] !== allyPokemon.getBattlerIndex()) {
+          targetingMovePhase.targets[0] = allyPokemon.getBattlerIndex();
+        }
+      } while (targetingMovePhase);
+    }
+  }
+
+  /**
    * Returns the ModifierBar of this scene, which is declared private and therefore not accessible elsewhere
    * @returns {ModifierBar}
    */

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -4772,13 +4772,18 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
           user.scene.prependToPhase(new SwitchSummonPhase(user.scene, switchOutTarget.getFieldIndex(), user.scene.currentBattle.trainer.getNextSummonIndex((switchOutTarget as EnemyPokemon).trainerSlot), false, this.batonPass, false), MoveEndPhase);
         }
 	  } else {
-	    // Switch out logic for everything else
-	  	switchOutTarget.setVisible(false);
+	    // Switch out logic for everything else (eg: WILD battles)
+	  	switchOutTarget.leaveField(false);
 
 	  	if (switchOutTarget.hp) {
-	  	  switchOutTarget.hideInfo().then(() => switchOutTarget.destroy());
-	  	  switchOutTarget.scene.field.remove(switchOutTarget);
+          switchOutTarget.setWildFlee(true);
 	  	  user.scene.queueMessage(i18next.t("moveTriggers:fled", {pokemonName: getPokemonNameWithAffix(switchOutTarget)}), null, true, 500);
+
+          // in double battles redirect potential moves off fled pokemon
+          if (switchOutTarget.scene.currentBattle.double) {
+            const allyPokemon = switchOutTarget.getAlly();
+            switchOutTarget.scene.redirectPokemonMoves(switchOutTarget, allyPokemon);
+          }
 	  	}
 
 	  	if (!switchOutTarget.getAlly()?.isActive(true)) {
@@ -7407,7 +7412,8 @@ export function initMoves() {
     new AttackMove(Moves.FROST_BREATH, Type.ICE, MoveCategory.SPECIAL, 60, 90, 10, 100, 0, 5)
       .attr(CritOnlyAttr),
     new AttackMove(Moves.DRAGON_TAIL, Type.DRAGON, MoveCategory.PHYSICAL, 60, 90, 10, -1, -6, 5)
-      .attr(ForceSwitchOutAttr),
+      .attr(ForceSwitchOutAttr)
+      .hidesTarget(),
     new SelfStatusMove(Moves.WORK_UP, Type.NORMAL, -1, 30, -1, 0, 5)
       .attr(StatChangeAttr, [ BattleStat.ATK, BattleStat.SPATK ], 1, true),
     new AttackMove(Moves.ELECTROWEB, Type.ELECTRIC, MoveCategory.SPECIAL, 55, 95, 15, 100, 0, 5)

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -88,6 +88,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   public luck: integer;
   public pauseEvolutions: boolean;
   public pokerus: boolean;
+  public wildFlee: boolean;
 
   public fusionSpecies: PokemonSpecies;
   public fusionFormIndex: integer;
@@ -129,6 +130,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     this.species = species;
     this.pokeball = dataSource?.pokeball || PokeballType.POKEBALL;
     this.level = level;
+    this.wildFlee = false;
+
     // Determine the ability index
     if (abilityIndex !== undefined) {
       this.abilityIndex = abilityIndex; // Use the provided ability index if it is defined
@@ -298,14 +301,14 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Check if this pokemon is both not fainted and allowed to be in battle.
+   * Check if this pokemon is both not fainted (or a fled wild pokemon) and allowed to be in battle.
    * This is frequently a better alternative to {@link isFainted}
    * @returns {boolean} True if pokemon is allowed in battle
    */
   isAllowedInBattle(): boolean {
     const challengeAllowed = new Utils.BooleanHolder(true);
     applyChallenges(this.scene.gameMode, ChallengeType.POKEMON_IN_BATTLE, this, challengeAllowed);
-    return !this.isFainted() && challengeAllowed.value;
+    return !this.isFainted() && !this.wildFlee && challengeAllowed.value;
   }
 
   isActive(onField?: boolean): boolean {
@@ -1771,6 +1774,14 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         resolve();
       }
     });
+  }
+
+  /**
+   * sets if the pokemon has fled (implies it's a wild pokemon)
+   * @param status - boolean
+   */
+  setWildFlee(status: boolean): void {
+    this.wildFlee = status;
   }
 
   updateInfo(instant?: boolean): Promise<void> {

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2556,6 +2556,15 @@ export class BattleEndPhase extends BattlePhase {
 
     this.scene.updateModifiers().then(() => this.end());
   }
+
+  end() {
+    // removing pokemon at the end of a battle
+    for (const p of this.scene.getEnemyParty()) {
+      p.destroy();
+    }
+
+    super.end();
+  }
 }
 
 export class NewBattlePhase extends BattlePhase {
@@ -3767,6 +3776,7 @@ export class FaintPhase extends PokemonPhase {
   doFaint(): void {
     const pokemon = this.getPokemon();
 
+
     // Track total times pokemon have been KO'd for supreme overlord/last respects
     if (pokemon.isPlayer()) {
       this.scene.currentBattle.playerFaints += 1;
@@ -3817,17 +3827,10 @@ export class FaintPhase extends PokemonPhase {
       }
     }
 
+    // in double battles redirect potential moves off fainted pokemon
     if (this.scene.currentBattle.double) {
       const allyPokemon = pokemon.getAlly();
-      if (allyPokemon?.isActive(true)) {
-        let targetingMovePhase: MovePhase;
-        do {
-          targetingMovePhase = this.scene.findPhase(mp => mp instanceof MovePhase && mp.targets.length === 1 && mp.targets[0] === pokemon.getBattlerIndex() && mp.pokemon.isPlayer() !== allyPokemon.isPlayer()) as MovePhase;
-          if (targetingMovePhase && targetingMovePhase.targets[0] !== allyPokemon.getBattlerIndex()) {
-            targetingMovePhase.targets[0] = allyPokemon.getBattlerIndex();
-          }
-        } while (targetingMovePhase);
-      }
+      this.scene.redirectPokemonMoves(pokemon, allyPokemon);
     }
 
     pokemon.lapseTags(BattlerTagLapseType.FAINT);

--- a/src/test/moves/dragon_tail.test.ts
+++ b/src/test/moves/dragon_tail.test.ts
@@ -43,15 +43,15 @@ describe("Moves - Dragon Tail", () => {
     async () => {
       await game.startBattle([Species.DRATINI]);
 
-      const enemyPokemon = game.scene.getEnemyPokemon();
+      const enemyPokemon = game.scene.getEnemyPokemon()!;
       expect(enemyPokemon).toBeDefined();
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.DRAGON_TAIL));
 
       await game.phaseInterceptor.to(BerryPhase);
 
-      const isVisible = enemyPokemon?.visible;
-      const hasFled = enemyPokemon?.wildFlee;
+      const isVisible = enemyPokemon.visible;
+      const hasFled = enemyPokemon.wildFlee;
       expect(!isVisible && hasFled ).toBe(true);
 
       // simply want to test that the game makes it this far without crashing
@@ -66,22 +66,20 @@ describe("Moves - Dragon Tail", () => {
       await game.startBattle([Species.DRATINI]);
       game.override.enemyAbility(Abilities.ROUGH_SKIN);
 
-      const leadPokemon = game.scene.getPlayerPokemon();
+      const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).toBeDefined();
 
-      const enemyPokemon = game.scene.getEnemyPokemon();
+      const enemyPokemon = game.scene.getEnemyPokemon()!;
       expect(enemyPokemon).toBeDefined();
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.DRAGON_TAIL));
 
       await game.phaseInterceptor.to(BerryPhase);
 
-      const isVisible = enemyPokemon?.visible;
-      const hasFled = enemyPokemon?.wildFlee;
+      const isVisible = enemyPokemon.visible;
+      const hasFled = enemyPokemon.wildFlee;
       expect(!isVisible && hasFled ).toBe(true);
       expect(leadPokemon?.hp < leadPokemon?.getMaxHp());
-
-      await game.phaseInterceptor.to(BattleEndPhase);
     }, TIMEOUT
   );
 
@@ -93,13 +91,13 @@ describe("Moves - Dragon Tail", () => {
       game.override.moveset([Moves.DRAGON_TAIL, Moves.SPLASH, Moves.FLAMETHROWER]);
       game.override.enemyAbility(Abilities.ROUGH_SKIN);
 
-      const leadPokemon = game.scene.getParty()[0];
-      const secPokemon = game.scene.getParty()[1];
+      const leadPokemon = game.scene.getParty()[0]!;
+      const secPokemon = game.scene.getParty()[1]!;
       expect(leadPokemon).toBeDefined();
       expect(secPokemon).toBeDefined();
 
-      const enemyLeadPokemon = game.scene.currentBattle.enemyParty[0];
-      const enemySecPokemon = game.scene.currentBattle.enemyParty[1];
+      const enemyLeadPokemon = game.scene.currentBattle.enemyParty[0]!;
+      const enemySecPokemon = game.scene.currentBattle.enemyParty[1]!;
       expect(enemyLeadPokemon).toBeDefined();
       expect(enemySecPokemon).toBeDefined();
 
@@ -138,13 +136,13 @@ describe("Moves - Dragon Tail", () => {
       game.override.moveset([Moves.DRAGON_TAIL, Moves.SPLASH, Moves.FLAMETHROWER]);
       game.override.enemyAbility(Abilities.ROUGH_SKIN);
 
-      const leadPokemon = game.scene.getParty()[0];
-      const secPokemon = game.scene.getParty()[1];
+      const leadPokemon = game.scene.getParty()[0]!;
+      const secPokemon = game.scene.getParty()[1]!;
       expect(leadPokemon).toBeDefined();
       expect(secPokemon).toBeDefined();
 
-      const enemyLeadPokemon = game.scene.currentBattle.enemyParty[0];
-      const enemySecPokemon = game.scene.currentBattle.enemyParty[1];
+      const enemyLeadPokemon = game.scene.currentBattle.enemyParty[0]!;
+      const enemySecPokemon = game.scene.currentBattle.enemyParty[1]!;
       expect(enemyLeadPokemon).toBeDefined();
       expect(enemySecPokemon).toBeDefined();
 

--- a/src/test/moves/dragon_tail.test.ts
+++ b/src/test/moves/dragon_tail.test.ts
@@ -1,0 +1,166 @@
+import { allMoves } from "#app/data/move.js";
+import { SPLASH_ONLY } from "../utils/testUtils";
+import { BattleEndPhase, BerryPhase, TurnEndPhase} from "#app/phases.js";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import GameManager from "../utils/gameManager";
+import { getMovePosition } from "../utils/gameManagerUtils";
+import { BattlerIndex } from "#app/battle.js";
+
+const TIMEOUT = 20 * 1000;
+
+describe("Moves - Dragon Tail", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override.battleType("single");
+    game.override.moveset([Moves.DRAGON_TAIL, Moves.SPLASH]);
+    game.override.enemySpecies(Species.WAILORD);
+    game.override.enemyMoveset(SPLASH_ONLY);
+    game.override.startingLevel(5);
+    game.override.enemyLevel(5);
+
+    vi.spyOn(allMoves[Moves.DRAGON_TAIL], "accuracy", "get").mockReturnValue(100);
+  });
+
+  test(
+    "Single battle should cause opponent to flee, and not crash",
+    async () => {
+      await game.startBattle([Species.DRATINI]);
+
+      const enemyPokemon = game.scene.getEnemyPokemon();
+
+      game.doAttack(getMovePosition(game.scene, 0, Moves.DRAGON_TAIL));
+
+      await game.phaseInterceptor.to(BerryPhase);
+
+      const isVisible = enemyPokemon.visible;
+      const hasFled = enemyPokemon.wildFlee;
+      expect(!isVisible && hasFled ).toBe(true);
+
+      // simply want to test that the game makes it this far without crashing
+      await game.phaseInterceptor.to(BattleEndPhase);
+      expect(true).toBe(true);
+    }, TIMEOUT
+  );
+
+  test(
+    "Single battle should cause opponent to flee, display ability, and not crash",
+    async () => {
+      await game.startBattle([Species.DRATINI]);
+      game.override.enemyAbility(Abilities.ROUGH_SKIN);
+
+      const leadPokemon = game.scene.getPlayerPokemon();
+
+      const enemyPokemon = game.scene.getEnemyPokemon();
+
+      game.doAttack(getMovePosition(game.scene, 0, Moves.DRAGON_TAIL));
+
+      await game.phaseInterceptor.to(BerryPhase);
+
+      const isVisible = enemyPokemon.visible;
+      const hasFled = enemyPokemon.wildFlee;
+      expect(!isVisible && hasFled ).toBe(true);
+
+      await game.phaseInterceptor.to(BattleEndPhase);
+      expect(leadPokemon.hp).toBeLessThan(leadPokemon.getMaxHp());
+    }, TIMEOUT
+  );
+
+  test(
+    "Double battles should proceed without crashing" ,
+    async () => {
+      game.override.battleType("double").enemyMoveset(SPLASH_ONLY);
+      await game.startBattle([Species.DRATINI, Species.DRATINI, Species.WAILORD, Species.WAILORD]);
+      game.override.moveset([Moves.DRAGON_TAIL, Moves.SPLASH, Moves.FLAMETHROWER]);
+      game.override.enemyAbility(Abilities.ROUGH_SKIN);
+
+      const leadPokemon = game.scene.getParty()[0];
+      const secPokemon = game.scene.getParty()[1];
+      expect(leadPokemon).toBeDefined();
+      expect(secPokemon).toBeDefined();
+
+      const enemyLeadPokemon = game.scene.currentBattle.enemyParty[0];
+      const enemySecPokemon = game.scene.currentBattle.enemyParty[1];
+
+      game.doAttack(getMovePosition(game.scene, 0, Moves.DRAGON_TAIL));
+      game.doSelectTarget(BattlerIndex.ENEMY);
+
+      game.doAttack(getMovePosition(game.scene, 1, Moves.SPLASH));
+
+      await game.phaseInterceptor.to(TurnEndPhase);
+
+      const isVisibleLead = enemyLeadPokemon.visible;
+      const hasFledLead = enemyLeadPokemon.wildFlee;
+      const isVisibleSec = enemySecPokemon.visible;
+      const hasFledSec = enemySecPokemon.wildFlee;
+      expect(!isVisibleLead && hasFledLead && isVisibleSec && !hasFledSec ).toBe(true);
+
+      expect(leadPokemon.hp < leadPokemon.getMaxHp());
+
+      // second turn
+
+      game.doAttack(getMovePosition(game.scene, 0, Moves.FLAMETHROWER));
+      game.doSelectTarget(BattlerIndex.ENEMY_2);
+      game.doAttack(getMovePosition(game.scene, 1, Moves.SPLASH));
+
+      await game.phaseInterceptor.to(BerryPhase);
+      expect(enemySecPokemon.hp < enemySecPokemon.getMaxHp() ).toBe(true);
+
+    }, TIMEOUT
+  );
+
+  test(
+    "Flee move redirection works" ,
+    async () => {
+      game.override.battleType("double").enemyMoveset(SPLASH_ONLY);
+      await game.startBattle([Species.DRATINI, Species.DRATINI, Species.WAILORD, Species.WAILORD]);
+      game.override.moveset([Moves.DRAGON_TAIL, Moves.SPLASH, Moves.FLAMETHROWER]);
+      game.override.enemyAbility(Abilities.ROUGH_SKIN);
+
+      const leadPokemon = game.scene.getParty()[0];
+      const secPokemon = game.scene.getParty()[1];
+      expect(leadPokemon).toBeDefined();
+      expect(secPokemon).toBeDefined();
+
+      const enemyLeadPokemon = game.scene.currentBattle.enemyParty[0];
+      const enemySecPokemon = game.scene.currentBattle.enemyParty[1];
+
+      game.doAttack(getMovePosition(game.scene, 0, Moves.DRAGON_TAIL));
+      game.doSelectTarget(BattlerIndex.ENEMY);
+
+      // target the same pokemon, second move should be redirected after first flees
+      game.doAttack(getMovePosition(game.scene, 0, Moves.DRAGON_TAIL));
+      game.doSelectTarget(BattlerIndex.ENEMY);
+
+      await game.phaseInterceptor.to(BerryPhase);
+
+      const isVisibleLead = enemyLeadPokemon.visible;
+      const hasFledLead = enemyLeadPokemon.wildFlee;
+      const isVisibleSec = enemySecPokemon.visible;
+      const hasFledSec = enemySecPokemon.wildFlee;
+      expect(!isVisibleLead && hasFledLead && !isVisibleSec && hasFledSec ).toBe(true);
+
+      expect(leadPokemon.hp < leadPokemon.getMaxHp());
+      expect(secPokemon.hp < secPokemon.getMaxHp());
+      expect(enemyLeadPokemon.hp < enemyLeadPokemon.getMaxHp());
+      expect(enemySecPokemon.hp < enemySecPokemon.getMaxHp());
+
+    }, TIMEOUT
+  );
+});

--- a/src/test/moves/dragon_tail.test.ts
+++ b/src/test/moves/dragon_tail.test.ts
@@ -62,8 +62,8 @@ describe("Moves - Dragon Tail", () => {
   test(
     "Single battle should cause opponent to flee, display ability, and not crash",
     async () => {
-      await game.startBattle([Species.DRATINI]);
       game.override.enemyAbility(Abilities.ROUGH_SKIN);
+      await game.startBattle([Species.DRATINI]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).toBeDefined();
@@ -86,9 +86,9 @@ describe("Moves - Dragon Tail", () => {
     "Double battles should proceed without crashing" ,
     async () => {
       game.override.battleType("double").enemyMoveset(SPLASH_ONLY);
-      await game.startBattle([Species.DRATINI, Species.DRATINI, Species.WAILORD, Species.WAILORD]);
       game.override.moveset([Moves.DRAGON_TAIL, Moves.SPLASH, Moves.FLAMETHROWER])
         .enemyAbility(Abilities.ROUGH_SKIN);
+      await game.startBattle([Species.DRATINI, Species.DRATINI, Species.WAILORD, Species.WAILORD]);
 
       const leadPokemon = game.scene.getParty()[0]!;
       const secPokemon = game.scene.getParty()[1]!;
@@ -129,9 +129,9 @@ describe("Moves - Dragon Tail", () => {
     "Flee move redirection works" ,
     async () => {
       game.override.battleType("double").enemyMoveset(SPLASH_ONLY);
-      await game.startBattle([Species.DRATINI, Species.DRATINI, Species.WAILORD, Species.WAILORD]);
       game.override.moveset([Moves.DRAGON_TAIL, Moves.SPLASH, Moves.FLAMETHROWER]);
       game.override.enemyAbility(Abilities.ROUGH_SKIN);
+      await game.startBattle([Species.DRATINI, Species.DRATINI, Species.WAILORD, Species.WAILORD]);
 
       const leadPokemon = game.scene.getParty()[0]!;
       const secPokemon = game.scene.getParty()[1]!;

--- a/src/test/moves/dragon_tail.test.ts
+++ b/src/test/moves/dragon_tail.test.ts
@@ -79,9 +79,9 @@ describe("Moves - Dragon Tail", () => {
       const isVisible = enemyPokemon?.visible;
       const hasFled = enemyPokemon?.wildFlee;
       expect(!isVisible && hasFled ).toBe(true);
+      expect(leadPokemon?.hp < leadPokemon?.getMaxHp());
 
       await game.phaseInterceptor.to(BattleEndPhase);
-      expect(leadPokemon?.hp < leadPokemon?.getMaxHp());
     }, TIMEOUT
   );
 

--- a/src/test/moves/dragon_tail.test.ts
+++ b/src/test/moves/dragon_tail.test.ts
@@ -28,12 +28,12 @@ describe("Moves - Dragon Tail", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleType("single");
-    game.override.moveset([Moves.DRAGON_TAIL, Moves.SPLASH]);
-    game.override.enemySpecies(Species.WAILORD);
-    game.override.enemyMoveset(SPLASH_ONLY);
-    game.override.startingLevel(5);
-    game.override.enemyLevel(5);
+    game.override.battleType("single")
+      .moveset([Moves.DRAGON_TAIL, Moves.SPLASH])
+      .enemySpecies(Species.WAILORD)
+      .enemyMoveset(SPLASH_ONLY)
+      .startingLevel(5)
+      .enemyLevel(5);
 
     vi.spyOn(allMoves[Moves.DRAGON_TAIL], "accuracy", "get").mockReturnValue(100);
   });
@@ -52,11 +52,10 @@ describe("Moves - Dragon Tail", () => {
 
       const isVisible = enemyPokemon.visible;
       const hasFled = enemyPokemon.wildFlee;
-      expect(!isVisible && hasFled ).toBe(true);
+      expect(!isVisible && hasFled).toBe(true);
 
       // simply want to test that the game makes it this far without crashing
       await game.phaseInterceptor.to(BattleEndPhase);
-      expect(true).toBe(true);
     }, TIMEOUT
   );
 
@@ -78,8 +77,8 @@ describe("Moves - Dragon Tail", () => {
 
       const isVisible = enemyPokemon.visible;
       const hasFled = enemyPokemon.wildFlee;
-      expect(!isVisible && hasFled ).toBe(true);
-      expect(leadPokemon?.hp < leadPokemon?.getMaxHp());
+      expect(!isVisible && hasFled).toBe(true);
+      expect(leadPokemon.hp).toBeLessThan(leadPokemon.getMaxHp());
     }, TIMEOUT
   );
 
@@ -88,8 +87,8 @@ describe("Moves - Dragon Tail", () => {
     async () => {
       game.override.battleType("double").enemyMoveset(SPLASH_ONLY);
       await game.startBattle([Species.DRATINI, Species.DRATINI, Species.WAILORD, Species.WAILORD]);
-      game.override.moveset([Moves.DRAGON_TAIL, Moves.SPLASH, Moves.FLAMETHROWER]);
-      game.override.enemyAbility(Abilities.ROUGH_SKIN);
+      game.override.moveset([Moves.DRAGON_TAIL, Moves.SPLASH, Moves.FLAMETHROWER])
+        .enemyAbility(Abilities.ROUGH_SKIN);
 
       const leadPokemon = game.scene.getParty()[0]!;
       const secPokemon = game.scene.getParty()[1]!;
@@ -112,9 +111,8 @@ describe("Moves - Dragon Tail", () => {
       const hasFledLead = enemyLeadPokemon.wildFlee;
       const isVisibleSec = enemySecPokemon.visible;
       const hasFledSec = enemySecPokemon.wildFlee;
-      expect(!isVisibleLead && hasFledLead && isVisibleSec && !hasFledSec ).toBe(true);
-
-      expect(leadPokemon.hp < leadPokemon.getMaxHp());
+      expect(!isVisibleLead && hasFledLead && isVisibleSec && !hasFledSec).toBe(true);
+      expect(leadPokemon.hp).toBeLessThan(leadPokemon.getMaxHp());
 
       // second turn
 
@@ -123,8 +121,7 @@ describe("Moves - Dragon Tail", () => {
       game.doAttack(getMovePosition(game.scene, 1, Moves.SPLASH));
 
       await game.phaseInterceptor.to(BerryPhase);
-      expect(enemySecPokemon.hp < enemySecPokemon.getMaxHp() ).toBe(true);
-
+      expect(enemySecPokemon.hp).toBeLessThan(enemySecPokemon.getMaxHp());
     }, TIMEOUT
   );
 
@@ -159,13 +156,11 @@ describe("Moves - Dragon Tail", () => {
       const hasFledLead = enemyLeadPokemon.wildFlee;
       const isVisibleSec = enemySecPokemon.visible;
       const hasFledSec = enemySecPokemon.wildFlee;
-      expect(!isVisibleLead && hasFledLead && !isVisibleSec && hasFledSec ).toBe(true);
-
-      expect(leadPokemon.hp < leadPokemon.getMaxHp());
-      expect(secPokemon.hp < secPokemon.getMaxHp());
-      expect(enemyLeadPokemon.hp < enemyLeadPokemon.getMaxHp());
-      expect(enemySecPokemon.hp < enemySecPokemon.getMaxHp());
-
+      expect(!isVisibleLead && hasFledLead && !isVisibleSec && hasFledSec).toBe(true);
+      expect(leadPokemon.hp).toBeLessThan(leadPokemon.getMaxHp());
+      expect(secPokemon.hp).toBeLessThan(secPokemon.getMaxHp());
+      expect(enemyLeadPokemon.hp).toBeLessThan(enemyLeadPokemon.getMaxHp());
+      expect(enemySecPokemon.hp).toBeLessThan(enemySecPokemon.getMaxHp());
     }, TIMEOUT
   );
 });

--- a/src/test/moves/dragon_tail.test.ts
+++ b/src/test/moves/dragon_tail.test.ts
@@ -81,7 +81,7 @@ describe("Moves - Dragon Tail", () => {
       expect(!isVisible && hasFled ).toBe(true);
 
       await game.phaseInterceptor.to(BattleEndPhase);
-      expect(leadPokemon?.hp).toBeLessThan(leadPokemon?.getMaxHp());
+      expect(leadPokemon?.hp < leadPokemon?.getMaxHp());
     }, TIMEOUT
   );
 

--- a/src/test/moves/dragon_tail.test.ts
+++ b/src/test/moves/dragon_tail.test.ts
@@ -50,8 +50,8 @@ describe("Moves - Dragon Tail", () => {
 
       await game.phaseInterceptor.to(BerryPhase);
 
-      const isVisible = enemyPokemon.visible;
-      const hasFled = enemyPokemon.wildFlee;
+      const isVisible = enemyPokemon?.visible;
+      const hasFled = enemyPokemon?.wildFlee;
       expect(!isVisible && hasFled ).toBe(true);
 
       // simply want to test that the game makes it this far without crashing
@@ -76,12 +76,12 @@ describe("Moves - Dragon Tail", () => {
 
       await game.phaseInterceptor.to(BerryPhase);
 
-      const isVisible = enemyPokemon.visible;
-      const hasFled = enemyPokemon.wildFlee;
+      const isVisible = enemyPokemon?.visible;
+      const hasFled = enemyPokemon?.wildFlee;
       expect(!isVisible && hasFled ).toBe(true);
 
       await game.phaseInterceptor.to(BattleEndPhase);
-      expect(leadPokemon.hp).toBeLessThan(leadPokemon.getMaxHp());
+      expect(leadPokemon?.hp).toBeLessThan(leadPokemon?.getMaxHp());
     }, TIMEOUT
   );
 

--- a/src/test/moves/dragon_tail.test.ts
+++ b/src/test/moves/dragon_tail.test.ts
@@ -44,6 +44,7 @@ describe("Moves - Dragon Tail", () => {
       await game.startBattle([Species.DRATINI]);
 
       const enemyPokemon = game.scene.getEnemyPokemon();
+      expect(enemyPokemon).toBeDefined();
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.DRAGON_TAIL));
 
@@ -66,8 +67,10 @@ describe("Moves - Dragon Tail", () => {
       game.override.enemyAbility(Abilities.ROUGH_SKIN);
 
       const leadPokemon = game.scene.getPlayerPokemon();
+      expect(leadPokemon).toBeDefined();
 
       const enemyPokemon = game.scene.getEnemyPokemon();
+      expect(enemyPokemon).toBeDefined();
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.DRAGON_TAIL));
 
@@ -97,6 +100,8 @@ describe("Moves - Dragon Tail", () => {
 
       const enemyLeadPokemon = game.scene.currentBattle.enemyParty[0];
       const enemySecPokemon = game.scene.currentBattle.enemyParty[1];
+      expect(enemyLeadPokemon).toBeDefined();
+      expect(enemySecPokemon).toBeDefined();
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.DRAGON_TAIL));
       game.doSelectTarget(BattlerIndex.ENEMY);
@@ -140,6 +145,8 @@ describe("Moves - Dragon Tail", () => {
 
       const enemyLeadPokemon = game.scene.currentBattle.enemyParty[0];
       const enemySecPokemon = game.scene.currentBattle.enemyParty[1];
+      expect(enemyLeadPokemon).toBeDefined();
+      expect(enemySecPokemon).toBeDefined();
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.DRAGON_TAIL));
       game.doSelectTarget(BattlerIndex.ENEMY);


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Fixed game freezing bug when force-out moves (commonly dragon tail) in doubles and single wild battles.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Bug often report on discord

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Previous code was immediately destroying the forced-out pokemon object, causing any further reference to it (eg: showing its ability) to reference undefined and crash the game.

To remedy this I made a few changes:
- delay the destroying of wild pokemon objects until the end of the battle
- added an attribute to track wild pokemon that fled, this is to ensure that (since the fled pokemon's object is still around the `BattleScene` but not marked as `fainted`, it isn't selected by `getEnemyPokemon()` to move animations. Without this the game would sometimes crash, as Phaser would try to animate moves hitting a non-visible pokemon.
- added move auto-redirection (moves targeting a fled pokemon would redirect to the other in doubles), this is the same behavior as when a pokemon faints, so refactored code.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
- `beta`


https://github.com/user-attachments/assets/39c8cf24-141a-417c-a4f6-813348bf6c83
![original report](https://github.com/user-attachments/assets/62bfb3bc-68da-438e-b9e4-205cb040d542)

- `pr`
doubles battles
https://github.com/user-attachments/assets/a8fc1963-6798-43b9-986e-dacfb8799fdc

https://github.com/user-attachments/assets/c002c4d9-867a-44e6-9f3e-6a6852dfa917


https://github.com/user-attachments/assets/240ac138-5593-4662-b9a1-e298a23c1b53






single battles
https://github.com/user-attachments/assets/bb1a9e8f-72ca-4f62-82e5-c06e69664e85

https://github.com/user-attachments/assets/7a4d1099-49f0-4359-8fbf-994565dee97b


https://github.com/user-attachments/assets/8ff4f70f-fa38-4ac2-84b2-def552db48b8




## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Commonly reported abilities are "mummy" and "cotton down". There are probably other abilities, but this fix should work for all of them.

This bug ~~should only affect doubles wild battles~~ correction it should only affect *wild* battles


## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
