### PR TITLE
[Balance] Adjust Gallade/Froslass evos to require move of their type

### DIFF
--- a/src/data/pokemon-evolutions.ts
+++ b/src/data/pokemon-evolutions.ts
@@ -425,8 +425,8 @@ export const pokemonEvolutions: PokemonEvolutions = {
     new SpeciesEvolution(Species.KIRLIA, 20, null, null)
   ],
   [Species.KIRLIA]: [
-    new SpeciesEvolution(Species.GARDEVOIR, 30, null, new SpeciesEvolutionCondition(p => p.gender === Gender.FEMALE, p => p.gender = Gender.FEMALE)),
-    new SpeciesEvolution(Species.GALLADE, 30, null, new SpeciesEvolutionCondition(p => p.gender === Gender.MALE, p => p.gender = Gender.MALE))
+    new SpeciesEvolution(Species.GALLADE, 30, null, new SpeciesEvolutionCondition(p => p.gender === Gender.MALE && !!p.getMoveset().find(m => m.getMove().type === Type.FIGHTING), p => p.gender = Gender.MALE)),
+    new SpeciesEvolution(Species.GARDEVOIR, 30, null, null)
   ],
   [Species.SURSKIT]: [
     new SpeciesEvolution(Species.MASQUERAIN, 22, null, null)
@@ -514,8 +514,8 @@ export const pokemonEvolutions: PokemonEvolutions = {
     new SpeciesEvolution(Species.DUSCLOPS, 37, null, null)
   ],
   [Species.SNORUNT]: [
-    new SpeciesEvolution(Species.GLALIE, 42, null, new SpeciesEvolutionCondition(p => p.gender === Gender.MALE, p => p.gender = Gender.MALE)),
-    new SpeciesEvolution(Species.FROSLASS, 42, null, new SpeciesEvolutionCondition(p => p.gender === Gender.FEMALE, p => p.gender = Gender.FEMALE))
+    new SpeciesEvolution(Species.FROSLASS, 42, null, new SpeciesEvolutionCondition(p => p.gender === Gender.FEMALE && !!p.getMoveset().find(m => m.getMove().type === Type.GHOST), p => p.gender = Gender.FEMALE)),
+    new SpeciesEvolution(Species.GLALIE, 42, null, null)
   ],
   [Species.SPHEAL]: [
     new SpeciesEvolution(Species.SEALEO, 32, null, null)

--- a/src/data/pokemon-level-moves.ts
+++ b/src/data/pokemon-level-moves.ts
@@ -4870,6 +4870,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
     [ 39, Moves.FUTURE_SIGHT ],
   ],
   [Species.KIRLIA]: [
+    [ 1, Moves.QUICK_GUARD ],
     [ 1, Moves.GROWL ],
     [ 1, Moves.DISARMING_VOICE ],
     [ 1, Moves.DOUBLE_TEAM ],

--- a/src/data/pokemon-level-moves.ts
+++ b/src/data/pokemon-level-moves.ts
@@ -4870,7 +4870,6 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
     [ 39, Moves.FUTURE_SIGHT ],
   ],
   [Species.KIRLIA]: [
-    [ 1, Moves.QUICK_GUARD ],
     [ 1, Moves.GROWL ],
     [ 1, Moves.DISARMING_VOICE ],
     [ 1, Moves.DOUBLE_TEAM ],
@@ -4880,6 +4879,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
     [ 15, Moves.TELEPORT ],
     [ 18, Moves.PSYBEAM ],
     [ 23, Moves.LIFE_DEW ],
+    [ 25, Moves.QUICK_GUARD ],
     [ 28, Moves.CHARM ],
     [ 33, Moves.CALM_MIND ],
     [ 38, Moves.PSYCHIC ],


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
- Adjust Snorunt and Kirlia evolution methods:
  - Snorunt -> Glalie: Level 42 ~~(male)~~ _(either gender, unless you fulfill Froslass requirements)_
  - Snorunt -> Froslass: Level 42 (female) **while knowing a Ghost-type move**
  - Kirlia -> Gallade: Level 30 (male) **while knowing a Fighting-type move**
  - Kirlia -> Gardevoir: Level 30 ~~(female)~~ _(either gender, unless you fulfill Gallade requirements)_
  - To accommodate Kirlia's new evolution method, it now learns **Quick Guard** at level **25**.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
- Froslass and Gallade's evolutions are custom in Rogue to just require reaching the level as the appropriate gender
- This is for convenience so these mons aren't nerfed by having to search for a Dawn Stone for players to evolve them
- This meant that only male Snorunt evolved into Glalie and only female Kirlia evolved into Gardevoir
- This created issues in cases of certain challenge runs where this custom evolution method, meant for convenience, could make these mons unusable if the player had one of the wrong gender
- The new solution follows more expected behavior in line with the main series, where both genders can evolve into Glalie or Gardevoir, while evolving into Froslass or Gallade requires a player choice (in this case, teaching a Ghost or Fighting move)
- Snorunt learns **Astonish** naturally at level 1. Kirlia was given Quick Guard at level 25 as it's a fitting move which Gallade learns by level up.

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- Kirlia evolving into Gallade requires it being male and knowing a Fighting-type move
- Kirlia now learns Quick Guard at level 25
- Kirlia into Gardevoir now has no conditions other than level, though Gallade's evolution will take precedent if the conditions are met
- Snorunt evolving into Froslass requires it being female and knowing a Ghost-type move
- Snorunt into Glalie now has no conditions other than level, though Froslass's evolution will take precedent if the conditions are met

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
- [X] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
