### PR TITLE
[Test] Fix Power Spot test so Stonjourner always moves second

### DIFF
--- a/src/test/abilities/power_spot.test.ts
+++ b/src/test/abilities/power_spot.test.ts
@@ -40,7 +40,7 @@ describe("Abilities - Power Spot", () => {
 
     vi.spyOn(moveToCheck, "calculateBattlePower");
 
-    await game.startBattle([Species.PIKACHU, Species.STONJOURNER]);
+    await game.startBattle([Species.REGIELEKI, Species.STONJOURNER]);
     game.doAttack(getMovePosition(game.scene, 0, Moves.DAZZLING_GLEAM));
     game.doAttack(getMovePosition(game.scene, 1, Moves.SPLASH));
     await game.phaseInterceptor.to(MoveEffectPhase);
@@ -54,7 +54,7 @@ describe("Abilities - Power Spot", () => {
 
     vi.spyOn(moveToCheck, "calculateBattlePower");
 
-    await game.startBattle([Species.PIKACHU, Species.STONJOURNER]);
+    await game.startBattle([Species.REGIELEKI, Species.STONJOURNER]);
     game.doAttack(getMovePosition(game.scene, 0, Moves.BREAKING_SWIPE));
     game.doAttack(getMovePosition(game.scene, 1, Moves.SPLASH));
     await game.phaseInterceptor.to(MoveEffectPhase);
@@ -68,7 +68,7 @@ describe("Abilities - Power Spot", () => {
 
     vi.spyOn(moveToCheck, "calculateBattlePower");
 
-    await game.startBattle([Species.STONJOURNER, Species.PIKACHU]);
+    await game.startBattle([Species.STONJOURNER, Species.REGIELEKI]);
     game.doAttack(getMovePosition(game.scene, 0, Moves.BREAKING_SWIPE));
     game.doAttack(getMovePosition(game.scene, 1, Moves.SPLASH));
     await game.phaseInterceptor.to(TurnEndPhase);


### PR DESCRIPTION
## What are the changes?
There are no user-facing changes.

## Why am I doing these changes?
The test can randomly break if Pikachu has a -spd nature and Stonjourner has a +spd nature.

## What did change?
Replaced Pikachu with Regieleki (the Pokémon with the highest base speed stat in the game).

## How to test the changes?
`npm run test power_spot`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
