### PR TITLE
[Test] Remove held items from all tests when there are no item overrides

### DIFF
--- a/src/test/abilities/intimidate.test.ts
+++ b/src/test/abilities/intimidate.test.ts
@@ -8,15 +8,10 @@ import { generateStarter, getMovePosition } from "#app/test/utils/gameManagerUti
 import { Command } from "#app/ui/command-ui-handler";
 import { Status, StatusEffect } from "#app/data/status-effect";
 import { GameModes, getGameMode } from "#app/game-mode";
-import {
-  CommandPhase, DamagePhase, EncounterPhase,
-  EnemyCommandPhase, SelectStarterPhase,
-  TurnInitPhase,
-} from "#app/phases";
+import { CommandPhase, DamagePhase, EncounterPhase, EnemyCommandPhase, SelectStarterPhase, TurnInitPhase } from "#app/phases";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
-import { removeEnemyHeldItems } from "../utils/testUtils";
 
 describe("Abilities - Intimidate", () => {
   let phaserGame: Phaser.Game;
@@ -45,7 +40,6 @@ describe("Abilities - Intimidate", () => {
 
   it("single - wild with switch", async () => {
     await game.runToSummon([Species.MIGHTYENA, Species.POOCHYENA]);
-    removeEnemyHeldItems(game.scene);
     game.onNextPrompt(
       "CheckSwitchPhase",
       Mode.CONFIRM,
@@ -76,7 +70,6 @@ describe("Abilities - Intimidate", () => {
   it("single - boss should only trigger once then switch", async () => {
     game.override.startingWave(10);
     await game.runToSummon([Species.MIGHTYENA, Species.POOCHYENA]);
-    removeEnemyHeldItems(game.scene);
     game.onNextPrompt(
       "CheckSwitchPhase",
       Mode.CONFIRM,
@@ -106,7 +99,6 @@ describe("Abilities - Intimidate", () => {
   it("single - trainer should only trigger once with switch", async () => {
     game.override.startingWave(5);
     await game.runToSummon([Species.MIGHTYENA, Species.POOCHYENA]);
-    removeEnemyHeldItems(game.scene);
     game.onNextPrompt(
       "CheckSwitchPhase",
       Mode.CONFIRM,
@@ -137,7 +129,6 @@ describe("Abilities - Intimidate", () => {
     game.override.battleType("double");
     game.override.startingWave(5);
     await game.runToSummon([Species.MIGHTYENA, Species.POOCHYENA]);
-    removeEnemyHeldItems(game.scene);
     game.onNextPrompt(
       "CheckSwitchPhase",
       Mode.CONFIRM,
@@ -164,7 +155,6 @@ describe("Abilities - Intimidate", () => {
     game.override.battleType("double");
     game.override.startingWave(3);
     await game.runToSummon([Species.MIGHTYENA, Species.POOCHYENA]);
-    removeEnemyHeldItems(game.scene);
     game.onNextPrompt(
       "CheckSwitchPhase",
       Mode.CONFIRM,
@@ -191,7 +181,6 @@ describe("Abilities - Intimidate", () => {
     game.override.battleType("double");
     game.override.startingWave(10);
     await game.runToSummon([Species.MIGHTYENA, Species.POOCHYENA]);
-    removeEnemyHeldItems(game.scene);
     game.onNextPrompt(
       "CheckSwitchPhase",
       Mode.CONFIRM,
@@ -218,7 +207,6 @@ describe("Abilities - Intimidate", () => {
     game.override.startingWave(2);
     game.override.moveset([Moves.AERIAL_ACE]);
     await game.startBattle([Species.MIGHTYENA, Species.POOCHYENA]);
-    removeEnemyHeldItems(game.scene);
     let battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
     expect(battleStatsOpponent[BattleStat.ATK]).toBe(-1);
     let battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
@@ -245,7 +233,6 @@ describe("Abilities - Intimidate", () => {
     game.override.startingWave(2);
     game.override.moveset([Moves.SPLASH]);
     await game.startBattle([Species.MIGHTYENA, Species.POOCHYENA]);
-    removeEnemyHeldItems(game.scene);
     let battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
     expect(battleStatsOpponent[BattleStat.ATK]).toBe(-1);
     let battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
@@ -271,7 +258,6 @@ describe("Abilities - Intimidate", () => {
     game.override.enemyMoveset([Moves.VOLT_SWITCH, Moves.VOLT_SWITCH, Moves.VOLT_SWITCH, Moves.VOLT_SWITCH]);
     game.override.startingWave(5);
     await game.startBattle([Species.MIGHTYENA, Species.POOCHYENA]);
-    removeEnemyHeldItems(game.scene);
     let battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
     expect(battleStatsOpponent[BattleStat.ATK]).toBe(-1);
     let battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
@@ -311,7 +297,6 @@ describe("Abilities - Intimidate", () => {
     game.override.enemyMoveset([Moves.SPLASH, Moves.SPLASH, Moves.SPLASH, Moves.SPLASH]);
     game.override.startingWave(5);
     await game.startBattle([Species.MIGHTYENA, Species.POOCHYENA]);
-    removeEnemyHeldItems(game.scene);
     let battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
     expect(battleStatsOpponent[BattleStat.ATK]).toBe(-1);
     let battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
@@ -351,7 +336,6 @@ describe("Abilities - Intimidate", () => {
     game.override.startingWave(3);
     vi.spyOn(Overrides, "OPP_HELD_ITEMS_OVERRIDE", "get").mockReturnValue([{ name: "COIN_CASE" }]);
     await game.runToSummon([Species.MIGHTYENA]);
-    removeEnemyHeldItems(game.scene);
     await game.phaseInterceptor.to(CommandPhase, false);
     const battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
     expect(battleStatsOpponent[BattleStat.ATK]).toBe(-1);
@@ -378,7 +362,6 @@ describe("Abilities - Intimidate", () => {
     });
 
     await game.phaseInterceptor.run(EncounterPhase);
-    removeEnemyHeldItems(game.scene);
 
     await game.phaseInterceptor.to(CommandPhase, false);
     const battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;

--- a/src/test/moves/octolock.test.ts
+++ b/src/test/moves/octolock.test.ts
@@ -8,7 +8,7 @@ import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { removeEnemyHeldItems, SPLASH_ONLY } from "../utils/testUtils";
+import { SPLASH_ONLY } from "../utils/testUtils";
 
 describe("Moves - Octolock", () => {
   describe("integration tests", () => {
@@ -41,7 +41,6 @@ describe("Moves - Octolock", () => {
 
     it("Reduces DEf and SPDEF by 1 each turn", { timeout: 10000 }, async () => {
       await game.startBattle([Species.GRAPPLOCT]);
-      removeEnemyHeldItems(game.scene);
 
       const enemyPokemon = game.scene.getEnemyField();
 
@@ -63,7 +62,6 @@ describe("Moves - Octolock", () => {
 
     it("Traps the target pokemon", { timeout: 10000 }, async () => {
       await game.startBattle([Species.GRAPPLOCT]);
-      removeEnemyHeldItems(game.scene);
 
       const enemyPokemon = game.scene.getEnemyField();
 

--- a/src/test/utils/gameManager.ts
+++ b/src/test/utils/gameManager.ts
@@ -1,31 +1,21 @@
 import GameWrapper from "#app/test/utils/gameWrapper";
-import {Mode} from "#app/ui/ui";
-import {generateStarter, waitUntil} from "#app/test/utils/gameManagerUtils";
-import {
-  CommandPhase,
-  EncounterPhase,
-  FaintPhase,
-  LoginPhase,
-  NewBattlePhase,
-  SelectStarterPhase,
-  SelectTargetPhase,
-  TitlePhase, TurnEndPhase, TurnInitPhase,
-  TurnStartPhase,
-} from "#app/phases";
+import { Mode } from "#app/ui/ui";
+import { generateStarter, waitUntil } from "#app/test/utils/gameManagerUtils";
+import { CommandPhase, EncounterPhase, FaintPhase, LoginPhase, NewBattlePhase, SelectStarterPhase, SelectTargetPhase, TitlePhase, TurnEndPhase, TurnInitPhase, TurnStartPhase } from "#app/phases";
 import BattleScene from "#app/battle-scene.js";
 import PhaseInterceptor from "#app/test/utils/phaseInterceptor";
 import TextInterceptor from "#app/test/utils/TextInterceptor";
-import {GameModes, getGameMode} from "#app/game-mode";
+import { GameModes, getGameMode } from "#app/game-mode";
 import fs from "fs";
-import {AES, enc} from "crypto-js";
-import {updateUserInfo} from "#app/account";
+import { AES, enc } from "crypto-js";
+import { updateUserInfo } from "#app/account";
 import InputsHandler from "#app/test/utils/inputsHandler";
 import ErrorInterceptor from "#app/test/utils/errorInterceptor";
-import {EnemyPokemon, PlayerPokemon} from "#app/field/pokemon";
-import {MockClock} from "#app/test/utils/mocks/mockClock";
-import {Command} from "#app/ui/command-ui-handler";
+import { EnemyPokemon, PlayerPokemon } from "#app/field/pokemon";
+import { MockClock } from "#app/test/utils/mocks/mockClock";
+import { Command } from "#app/ui/command-ui-handler";
 import ModifierSelectUiHandler from "#app/ui/modifier-select-ui-handler";
-import PartyUiHandler, {PartyUiMode} from "#app/ui/party-ui-handler";
+import PartyUiHandler, { PartyUiMode } from "#app/ui/party-ui-handler";
 import Trainer from "#app/field/trainer";
 import { ExpNotification } from "#enums/exp-notification";
 import { GameDataType } from "#enums/game-data-type";
@@ -36,6 +26,8 @@ import { BattlerIndex } from "#app/battle.js";
 import TargetSelectUiHandler from "#app/ui/target-select-ui-handler.js";
 import { OverridesHelper } from "./overridesHelper";
 import { ModifierTypeOption, modifierTypes } from "#app/modifier/modifier-type.js";
+import overrides from "#app/overrides.js";
+import { removeEnemyHeldItems } from "./testUtils";
 
 /**
  * Class to manage the game state and transitions between phases.
@@ -140,6 +132,9 @@ export default class GameManager {
     });
 
     await this.phaseInterceptor.run(EncounterPhase);
+    if (overrides.OPP_HELD_ITEMS_OVERRIDE.length === 0) {
+      removeEnemyHeldItems(this.scene);
+    }
   }
 
   /**

--- a/src/test/utils/testUtils.ts
+++ b/src/test/utils/testUtils.ts
@@ -34,4 +34,5 @@ export function arrayOfRange(start: integer, end: integer) {
 export function removeEnemyHeldItems(scene: BattleScene) {
   scene.clearEnemyHeldItemModifiers();
   scene.clearEnemyModifiers();
+  console.log("Enemy held items removed");
 }


### PR DESCRIPTION
## What are the changes?
There are no user-facing changes.

## Why am I doing these changes?
Item RNG can sometimes break tests, now this should never happen again.

## What did change?
Held items are removed from enemy Pokémon automatically at the start of every test unless an item override is specified.

## How to test the changes?
`npm run test`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
