### PR TITLE
[Bug] Fix tier weights and remove unnecessary `Math.min()`

### DIFF
--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1809,7 +1809,7 @@ export function getModifierPoolForType(poolType: ModifierPoolType): ModifierPool
   return pool;
 }
 
-const tierWeights = [ 769 / 1024, 192 / 1024, 48 / 1024, 12 / 1024, 1 / 1024 ];
+const tierWeights = [ 768 / 1024, 195 / 1024, 48 / 1024, 12 / 1024, 1 / 1024 ];
 
 export function regenerateModifierPoolThresholds(party: Pokemon[], poolType: ModifierPoolType, rerollCount: integer = 0) {
   const pool = getModifierPoolForType(poolType);
@@ -2023,10 +2023,6 @@ function getNewModifierTypeOption(party: Pokemon[], poolType: ModifierPoolType, 
       } while (upgraded);
     }
     tier = tierValue > 255 ? ModifierTier.COMMON : tierValue > 60 ? ModifierTier.GREAT : tierValue > 12 ? ModifierTier.ULTRA : tierValue ? ModifierTier.ROGUE : ModifierTier.MASTER;
-    // Does this actually do anything?
-    if (!upgradeCount) {
-      upgradeCount = Math.min(upgradeCount, ModifierTier.MASTER - tier);
-    }
     tier += upgradeCount;
     while (tier && (!modifierPool.hasOwnProperty(tier) || !modifierPool[tier].length)) {
       tier--;


### PR DESCRIPTION
## What are the changes?
Marginally better item rolls I guess?

## Why am I doing these changes?
![image](https://github.com/user-attachments/assets/496214d0-6016-4a1f-81ea-617bcd1734cb)

## What did change?
Item reward tier weights were changed (they add up to 1024 now, amazing), and a pointless `Math.min()` statement was removed.

## How to test the changes?
Re-roll item rewards a few million times?

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~[ ] Have I tested the changes (manually)?~
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
