### PR TITLE
[Bug] Cosplay Pikachu and Rotom forms not starting with signature moves

### DIFF
--- a/src/data/pokemon-level-moves.ts
+++ b/src/data/pokemon-level-moves.ts
@@ -18666,7 +18666,7 @@ export const pokemonFormLevelMoves: PokemonSpeciesFormLevelMoves = {
       [ 48, Moves.PIKA_PAPOW ],
     ],
     3: [
-      [ EVOLVE_MOVE, Moves.METEOR_MASH ],
+      [ 1, Moves.METEOR_MASH ],
       [ 1, Moves.TAIL_WHIP ],
       [ 1, Moves.GROWL ],
       [ 1, Moves.THUNDER_SHOCK ],
@@ -18690,7 +18690,7 @@ export const pokemonFormLevelMoves: PokemonSpeciesFormLevelMoves = {
       [ 48, Moves.PIKA_PAPOW ],
     ],
     4: [
-      [ EVOLVE_MOVE, Moves.ICICLE_CRASH ],
+      [ 1, Moves.ICICLE_CRASH ],
       [ 1, Moves.TAIL_WHIP ],
       [ 1, Moves.GROWL ],
       [ 1, Moves.THUNDER_SHOCK ],
@@ -18714,7 +18714,7 @@ export const pokemonFormLevelMoves: PokemonSpeciesFormLevelMoves = {
       [ 48, Moves.PIKA_PAPOW ],
     ],
     5: [
-      [ EVOLVE_MOVE, Moves.DRAINING_KISS ],
+      [ 1, Moves.DRAINING_KISS ],
       [ 1, Moves.TAIL_WHIP ],
       [ 1, Moves.GROWL ],
       [ 1, Moves.THUNDER_SHOCK ],
@@ -18738,7 +18738,7 @@ export const pokemonFormLevelMoves: PokemonSpeciesFormLevelMoves = {
       [ 48, Moves.PIKA_PAPOW ],
     ],
     6: [
-      [ EVOLVE_MOVE, Moves.ELECTRIC_TERRAIN ],
+      [ 1, Moves.ELECTRIC_TERRAIN ],
       [ 1, Moves.TAIL_WHIP ],
       [ 1, Moves.GROWL ],
       [ 1, Moves.THUNDER_SHOCK ],
@@ -18762,7 +18762,7 @@ export const pokemonFormLevelMoves: PokemonSpeciesFormLevelMoves = {
       [ 48, Moves.PIKA_PAPOW ],
     ],
     7: [
-      [ EVOLVE_MOVE, Moves.FLYING_PRESS ],
+      [ 1, Moves.FLYING_PRESS ],
       [ 1, Moves.TAIL_WHIP ],
       [ 1, Moves.GROWL ],
       [ 1, Moves.THUNDER_SHOCK ],
@@ -18886,7 +18886,7 @@ export const pokemonFormLevelMoves: PokemonSpeciesFormLevelMoves = {
   },
   [Species.ROTOM]: {
     1: [
-      [ EVOLVE_MOVE, Moves.OVERHEAT ],
+      [ 1, Moves.OVERHEAT ],
       [ 1, Moves.DOUBLE_TEAM ],
       [ 1, Moves.ASTONISH ],
       [ 5, Moves.THUNDER_SHOCK ],
@@ -18902,7 +18902,7 @@ export const pokemonFormLevelMoves: PokemonSpeciesFormLevelMoves = {
       [ 55, Moves.UPROAR ],
     ],
     2: [
-      [ EVOLVE_MOVE, Moves.HYDRO_PUMP ],
+      [ 1, Moves.HYDRO_PUMP ],
       [ 1, Moves.DOUBLE_TEAM ],
       [ 1, Moves.ASTONISH ],
       [ 5, Moves.THUNDER_SHOCK ],
@@ -18918,7 +18918,7 @@ export const pokemonFormLevelMoves: PokemonSpeciesFormLevelMoves = {
       [ 55, Moves.UPROAR ],
     ],
     3: [
-      [ EVOLVE_MOVE, Moves.BLIZZARD ],
+      [ 1, Moves.BLIZZARD ],
       [ 1, Moves.DOUBLE_TEAM ],
       [ 1, Moves.ASTONISH ],
       [ 5, Moves.THUNDER_SHOCK ],
@@ -18934,7 +18934,7 @@ export const pokemonFormLevelMoves: PokemonSpeciesFormLevelMoves = {
       [ 55, Moves.UPROAR ],
     ],
     4: [
-      [ EVOLVE_MOVE, Moves.AIR_SLASH ],
+      [ 1, Moves.AIR_SLASH ],
       [ 1, Moves.DOUBLE_TEAM ],
       [ 1, Moves.ASTONISH ],
       [ 5, Moves.THUNDER_SHOCK ],
@@ -18950,7 +18950,7 @@ export const pokemonFormLevelMoves: PokemonSpeciesFormLevelMoves = {
       [ 55, Moves.UPROAR ],
     ],
     5: [
-      [ EVOLVE_MOVE, Moves.LEAF_STORM ],
+      [ 1, Moves.LEAF_STORM ],
       [ 1, Moves.DOUBLE_TEAM ],
       [ 1, Moves.ASTONISH ],
       [ 5, Moves.THUNDER_SHOCK ],


### PR DESCRIPTION
## What are the changes?
This addresses issue [#2783](https://github.com/pagefaultgames/pokerogue/issues/2783)
This is a mirror of [#2975](https://github.com/pagefaultgames/pokerogue/pull/2975) with merge conflicts fixed. 

The signature moves for the Rotom forms, and the Cosplay Pikachu forms, have been updated to now be selectable as starting moves, rather than having to be relearned using a mushroom. 

## Why am I doing these changes?
These Pokemon should be able to start with their signature moves, as they are supposed to be known by default regardless of level. 

## What did change?
Changed the level of these moves in the pokemon's learn sets from EVOLVE_MOVE (i.e. 0) to 1. Previously these were treated identically, but (apparently) the handling of level 0 vs level 1 moves was changed so that the "starting move" filter misses level 0 moves. 

### Screenshots/Videos
![image](https://github.com/pagefaultgames/pokerogue/assets/132116525/70e8d5c3-8cb4-4a32-a0a6-f722694ee311)
Previously, electric terrain would not have been selectable. 

## How to test the changes?
Go to select a Cosplay Pikachu/Rotom form as a starter, their signature moves should be selectable as a starting move. 
You will need to have these forms unlocked as starters; I am unsure if there is an easy way to do this, but PR #2967 provides a potential solution. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
