### PR TITLE
[Localization] Missing tranlsations placeholder of Fresh Start challenge in some languages

### DIFF
--- a/src/locales/de/achv.ts
+++ b/src/locales/de/achv.ts
@@ -264,6 +264,10 @@ export const PGMachv: AchievementTranslationEntries = {
   "MONO_FAIRY": {
     name: "Ein ewiges Abenteuer!",
   },
+  "FRESH_START": {
+    name: "First Try!",
+    description: "Complete the fresh start challenge."
+  }
 } as const;
 
 // Achievement translations for the when the player character is female
@@ -373,5 +377,7 @@ export const PGFachv: AchievementTranslationEntries = {
   "MONO_DRAGON": PGMachv.MONO_DRAGON,
   "MONO_DARK": PGMachv.MONO_DARK,
   "MONO_FAIRY": PGMachv.MONO_FAIRY,
+  "FRESH_START": PGMachv.FRESH_START
+  }
 } as const;
 

--- a/src/locales/es/achv.ts
+++ b/src/locales/es/achv.ts
@@ -264,6 +264,10 @@ export const PGMachv: AchievementTranslationEntries = {
   "MONO_FAIRY": {
     name: "Mono FAIRY",
   },
+  "FRESH_START": {
+    name: "First Try!",
+    description: "Complete the fresh start challenge."
+  }
 } as const;
 
 // Achievement translations for the when the player character is female (it for now uses the same translations as the male version)

--- a/src/locales/es/challenges.ts
+++ b/src/locales/es/challenges.ts
@@ -22,4 +22,10 @@ export const challenges: TranslationEntries = {
     "desc": "Solo puedes usar Pokémon with the {{type}} type.",
     "desc_default": "Solo puedes usar Pokémon del tipo elegido.",
   },
+  "freshStart": {
+    "name": "Fresh Start",
+    "desc": "You can only use the original starters, and only as if you had just started pokerogue.",
+    "value.0": "Off",
+    "value.1": "On",
+  }
 } as const;

--- a/src/locales/it/achv.ts
+++ b/src/locales/it/achv.ts
@@ -264,6 +264,10 @@ export const PGMachv: AchievementTranslationEntries = {
   "MONO_FAIRY": {
     name: "Follettini e follettine",
   },
+  "FRESH_START": {
+    name: "First Try!",
+    description: "Complete the fresh start challenge."
+  }
 } as const;
 
 // Achievement translations for the when the player character is female (it for now uses the same translations as the male version)

--- a/src/locales/it/challenges.ts
+++ b/src/locales/it/challenges.ts
@@ -22,4 +22,10 @@ export const challenges: TranslationEntries = {
     "desc": "Puoi usare solo Pokémon di tipo {{type}}.",
     "desc_default": "Puoi usare solo Pokémon del tipo selezionato."
   },
+  "freshStart": {
+    "name": "Fresh Start",
+    "desc": "You can only use the original starters, and only as if you had just started pokerogue.",
+    "value.0": "Off",
+    "value.1": "On",
+  }
 } as const;

--- a/src/locales/pt_BR/challenges.ts
+++ b/src/locales/pt_BR/challenges.ts
@@ -22,4 +22,10 @@ export const challenges: TranslationEntries = {
     "desc": "Você só pode user Pokémon do tipo {{type}}.",
     "desc_default": "Você só pode user Pokémon de um único tipo."
   },
+  "freshStart": {
+    "name": "Fresh Start",
+    "desc": "You can only use the original starters, and only as if you had just started pokerogue.",
+    "value.0": "Off",
+    "value.1": "On",
+  }
 } as const;

--- a/src/locales/zh_TW/achv.ts
+++ b/src/locales/zh_TW/achv.ts
@@ -264,6 +264,10 @@ export const PGMachv: AchievementTranslationEntries = {
   "MONO_FAIRY": {
     name: "林克，醒醒！",
   },
+  "FRESH_START": {
+    name: "First Try!",
+    description: "Complete the fresh start challenge."
+  }
 } as const;
 
 // Achievement translations for the when the player character is female (it for now uses the same translations as the male version)

--- a/src/locales/zh_TW/challenges.ts
+++ b/src/locales/zh_TW/challenges.ts
@@ -22,4 +22,10 @@ export const challenges: TranslationEntries = {
     "desc": "你只能使用{{type}}\n屬性的寶可夢",
     "desc_default": "你只能使用所選\n屬性的寶可夢"
   },
+  "freshStart": {
+    "name": "Fresh Start",
+    "desc": "You can only use the original starters, and only as if you had just started pokerogue.",
+    "value.0": "Off",
+    "value.1": "On",
+  }
 } as const;


### PR DESCRIPTION
## What are the changes?
Addition of missing placeholders / translations for entiries relates to the First Start challenge

## Why am I doing these changes?
To allow easy translations for the concerned languages

## What did change?
Addition of missing entries

Missing translations :
German : Missing achivement translation
Brazilian Pt : Missing challenge transaltion
Trad Chinese, Italian and Spanish : Missing everything

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
