### PR TITLE
[Bug] Fix sketch being able to copy some unsketchable moves

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5400,10 +5400,26 @@ export class MovesetCopyMoveAttr extends OverrideMoveEffectAttr {
   }
 }
 
+/**
+ * Attribute for {@linkcode Moves.SKETCH} that causes the user to copy the opponent's last used move
+ * This move copies the last used non-virtual move
+ *  e.g. if Metronome is used, it copies Metronome itself, not the virtual move called by Metronome
+ * Fails if the opponent has not yet used a move.
+ * Fails if used on an uncopiable move, flagged with {@linkcode MoveFlags.UNSKETCHABLE}
+ * Fails if the move is already in the user's moveset
+ */
 export class SketchAttr extends MoveEffectAttr {
   constructor() {
     super(true);
   }
+  /**
+   * User copies the opponent's last used move, if possible
+   * @param {Pokemon} user Pokemon that used the move and will replace Sketch with the copied move
+   * @param {Pokemon} target Pokemon that the user wants to copy a move from
+   * @param {Move} move Move being used
+   * @param {any[]} args Unused
+   * @returns {boolean} true if the function succeeds, otherwise false
+   */
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     if (!super.apply(user, target, move, args)) {
@@ -6275,6 +6291,7 @@ export function initMoves() {
       .ignoresVirtual(),
     new StatusMove(Moves.MIRROR_MOVE, Type.FLYING, -1, 20, -1, 0, 1)
       .attr(CopyMoveAttr)
+      .unsketchableMove()
       .ignoresVirtual(),
     new AttackMove(Moves.SELF_DESTRUCT, Type.NORMAL, MoveCategory.PHYSICAL, 200, 100, 5, -1, 0, 1)
       .attr(SacrificialAttr)
@@ -6407,10 +6424,12 @@ export function initMoves() {
     new AttackMove(Moves.STRUGGLE, Type.NORMAL, MoveCategory.PHYSICAL, 50, -1, 1, -1, 0, 1)
       .attr(RecoilAttr, true, 0.25, true)
       .attr(TypelessAttr)
+      .unsketchableMove()
       .ignoresVirtual()
       .target(MoveTarget.RANDOM_NEAR_ENEMY),
     new StatusMove(Moves.SKETCH, Type.NORMAL, -1, 1, -1, 0, 2)
       .attr(SketchAttr)
+      .unsketchableMove()
       .ignoresVirtual(),
     new AttackMove(Moves.TRIPLE_KICK, Type.FIGHTING, MoveCategory.PHYSICAL, 10, 90, 10, -1, 0, 2)
       .attr(MultiHitAttr, MultiHitType._3)
@@ -6545,6 +6564,7 @@ export function initMoves() {
     new SelfStatusMove(Moves.SLEEP_TALK, Type.NORMAL, -1, 10, -1, 0, 2)
       .attr(BypassSleepAttr)
       .attr(RandomMovesetMoveAttr)
+      .unsketchableMove()
       .condition(userSleptOrComatoseCondition)
       .target(MoveTarget.ALL_ENEMIES)
       .ignoresVirtual(),
@@ -7210,6 +7230,7 @@ export function initMoves() {
       .condition(failOnMaxCondition),
     new AttackMove(Moves.CHATTER, Type.FLYING, MoveCategory.SPECIAL, 65, 100, 20, 100, 0, 4)
       .attr(ConfuseAttr)
+      .unsketchableMove()
       .soundBased(),
     new AttackMove(Moves.JUDGMENT, Type.NORMAL, MoveCategory.SPECIAL, 100, 100, 10, -1, 0, 4)
       .attr(FormChangeItemTypeAttr),
@@ -8715,6 +8736,7 @@ export function initMoves() {
       .ignoresVirtual(),
     new AttackMove(Moves.TERA_STARSTORM, Type.NORMAL, MoveCategory.SPECIAL, 120, 100, 5, -1, 0, 9)
       .attr(TeraBlastCategoryAttr)
+      .unsketchableMove()
       .partial(),
     new AttackMove(Moves.FICKLE_BEAM, Type.DRAGON, MoveCategory.SPECIAL, 80, 100, 5, 30, 0, 9)
       .attr(PreMoveMessageAttr, doublePowerChanceMessageFunc)

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -519,6 +519,11 @@ export default class Move implements Localizable {
     return this;
   }
 
+  unsketchableMove(unsketchableMove?: boolean): this {
+    this.setFlag(MoveFlags.UNSKETCHABLE, unsketchableMove);
+    return this;
+  }
+
   /**
    * Sets the {@linkcode MoveFlags.TRIAGE_MOVE} flag for the calling Move
    * @param triageMove The value (boolean) to set the flag to
@@ -5429,14 +5434,16 @@ export class SketchAttr extends MoveEffectAttr {
         return false;
       }
 
-      const targetMoves = target.getMoveHistory().filter(m => !m.virtual);
-      if (!targetMoves.length) {
+      const targetMove = target.getMoveHistory().filter(m => !m.virtual).at(-1);
+      if (!targetMove) {
         return false;
       }
 
-      const sketchableMove = targetMoves[0];
+      if (allMoves[targetMove.move].hasFlag(MoveFlags.UNSKETCHABLE)) {
+        return false;
+      }
 
-      if (user.getMoveset().find(m => m.moveId === sketchableMove.move)) {
+      if (user.getMoveset().find(m => m.moveId === targetMove.move)) {
         return false;
       }
 

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -519,11 +519,6 @@ export default class Move implements Localizable {
     return this;
   }
 
-  unsketchableMove(unsketchableMove?: boolean): this {
-    this.setFlag(MoveFlags.UNSKETCHABLE, unsketchableMove);
-    return this;
-  }
-
   /**
    * Sets the {@linkcode MoveFlags.TRIAGE_MOVE} flag for the calling Move
    * @param triageMove The value (boolean) to set the flag to
@@ -5405,7 +5400,7 @@ export class MovesetCopyMoveAttr extends OverrideMoveEffectAttr {
  * This move copies the last used non-virtual move
  *  e.g. if Metronome is used, it copies Metronome itself, not the virtual move called by Metronome
  * Fails if the opponent has not yet used a move.
- * Fails if used on an uncopiable move, flagged with {@linkcode MoveFlags.UNSKETCHABLE}
+ * Fails if used on an uncopiable move, listed in unsketchableMoves in getCondition
  * Fails if the move is already in the user's moveset
  */
 export class SketchAttr extends MoveEffectAttr {
@@ -5455,7 +5450,19 @@ export class SketchAttr extends MoveEffectAttr {
         return false;
       }
 
-      if (allMoves[targetMove.move].hasFlag(MoveFlags.UNSKETCHABLE)) {
+      const unsketchableMoves = [
+        Moves.CHATTER,
+        Moves.MIRROR_MOVE,
+        Moves.SLEEP_TALK,
+        Moves.STRUGGLE,
+        Moves.SKETCH,
+        Moves.REVIVAL_BLESSING,
+        Moves.TERA_STARSTORM,
+        Moves.BREAKNECK_BLITZ__PHYSICAL,
+        Moves.BREAKNECK_BLITZ__SPECIAL
+      ];
+
+      if (unsketchableMoves.includes(targetMove.move)) {
         return false;
       }
 
@@ -6291,7 +6298,6 @@ export function initMoves() {
       .ignoresVirtual(),
     new StatusMove(Moves.MIRROR_MOVE, Type.FLYING, -1, 20, -1, 0, 1)
       .attr(CopyMoveAttr)
-      .unsketchableMove()
       .ignoresVirtual(),
     new AttackMove(Moves.SELF_DESTRUCT, Type.NORMAL, MoveCategory.PHYSICAL, 200, 100, 5, -1, 0, 1)
       .attr(SacrificialAttr)
@@ -6424,12 +6430,10 @@ export function initMoves() {
     new AttackMove(Moves.STRUGGLE, Type.NORMAL, MoveCategory.PHYSICAL, 50, -1, 1, -1, 0, 1)
       .attr(RecoilAttr, true, 0.25, true)
       .attr(TypelessAttr)
-      .unsketchableMove()
       .ignoresVirtual()
       .target(MoveTarget.RANDOM_NEAR_ENEMY),
     new StatusMove(Moves.SKETCH, Type.NORMAL, -1, 1, -1, 0, 2)
       .attr(SketchAttr)
-      .unsketchableMove()
       .ignoresVirtual(),
     new AttackMove(Moves.TRIPLE_KICK, Type.FIGHTING, MoveCategory.PHYSICAL, 10, 90, 10, -1, 0, 2)
       .attr(MultiHitAttr, MultiHitType._3)
@@ -6564,7 +6568,6 @@ export function initMoves() {
     new SelfStatusMove(Moves.SLEEP_TALK, Type.NORMAL, -1, 10, -1, 0, 2)
       .attr(BypassSleepAttr)
       .attr(RandomMovesetMoveAttr)
-      .unsketchableMove()
       .condition(userSleptOrComatoseCondition)
       .target(MoveTarget.ALL_ENEMIES)
       .ignoresVirtual(),
@@ -7230,7 +7233,6 @@ export function initMoves() {
       .condition(failOnMaxCondition),
     new AttackMove(Moves.CHATTER, Type.FLYING, MoveCategory.SPECIAL, 65, 100, 20, 100, 0, 4)
       .attr(ConfuseAttr)
-      .unsketchableMove()
       .soundBased(),
     new AttackMove(Moves.JUDGMENT, Type.NORMAL, MoveCategory.SPECIAL, 100, 100, 10, -1, 0, 4)
       .attr(FormChangeItemTypeAttr),
@@ -8736,7 +8738,6 @@ export function initMoves() {
       .ignoresVirtual(),
     new AttackMove(Moves.TERA_STARSTORM, Type.NORMAL, MoveCategory.SPECIAL, 120, 100, 5, -1, 0, 9)
       .attr(TeraBlastCategoryAttr)
-      .unsketchableMove()
       .partial(),
     new AttackMove(Moves.FICKLE_BEAM, Type.DRAGON, MoveCategory.SPECIAL, 80, 100, 5, 30, 0, 9)
       .attr(PreMoveMessageAttr, doublePowerChanceMessageFunc)


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->
Rebranch of #3013
## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Prevents Sketch from copying moves that are supposed to be [unsketchable](https://bulbapedia.bulbagarden.net/wiki/Sketch_(move))

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
To prevent these moves from being sketchable. 

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
With this change, you can no longer copy the following moves:
- Chatter
- Mirror Move
- Sleep Talk
- Struggle
- Sketch
- Revival Blessing
- Tera Starstorm
- Breakneck Blitz

NOTE: There are other moves that are technically unsketchable. I kept these as sketchable as other pokemon are given some of these moves as egg moves. These include:
- Dark Void 
- Hyperspace Fury 
- Wicked/Blazing/Noxious/Magical/Combat Torque 

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
Before changes

https://github.com/user-attachments/assets/47d0bfe6-0763-4cfe-8b47-9dc7b51ce56a

After changes

https://github.com/user-attachments/assets/dda8dead-4886-4c9a-880f-6b5b30dea0fc

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Use Smeargle with Sketch. Do not give a mon Sketch with the overrides file as it does not properly replace the move. 
Give the opponent unsketchable moves, see that Sketch fails. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
