### PR TITLE
[QoL] Disables final boss passive for starter Eternatus passive changes

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1077,6 +1077,12 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         (Overrides.OPP_PASSIVE_ABILITY_OVERRIDE !== Abilities.NONE && !this.isPlayer())) {
       return true;
     }
+
+    // Final boss does not have passive
+    if (this.scene.currentBattle?.battleSpec === BattleSpec.FINAL_BOSS && this instanceof EnemyPokemon) {
+      return false;
+    }
+
     return this.passive || this.isBoss();
   }
 

--- a/src/test/final_boss.test.ts
+++ b/src/test/final_boss.test.ts
@@ -56,6 +56,14 @@ describe("Final Boss", () => {
     expect(game.scene.getEnemyPokemon().species.speciesId).not.toBe(Species.ETERNATUS);
   });
 
+  it("should not have passive enabled on Eternatus", async () => {
+    await runToFinalBossEncounter(game, [Species.BIDOOF]);
+
+    const eternatus = game.scene.getEnemyPokemon();
+    expect(eternatus.species.speciesId).toBe(Species.ETERNATUS);
+    expect(eternatus.hasPassive()).toBe(false);
+  });
+
   it.todo("should change form on direct hit down to last boss fragment", () => {});
 });
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
Disables final boss passive in all modes

## Why am I doing these changes?
Before Eternatus (the starter) gets a real passive, disabling passive on the final boss.

## What did change?
Disables final boss passive in all modes

### Screenshots/Videos

https://github.com/user-attachments/assets/35153f7d-074a-4c8a-a7f3-4a01e67397b9



## How to test the changes?
beta branch, or `npm run dev` locally

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
