### PR TITLE
[Bug] Fix healing modifying the HP stat instead of the Pokemon's HP

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1650,7 +1650,7 @@ export class HitHealAttr extends MoveEffectAttr {
     super(true, MoveEffectTrigger.HIT);
 
     this.healRatio = healRatio!; // TODO: is this bang correct?
-    this.healStat = healStat!; // TODO: is this bang correct?
+    this.healStat = healStat ?? null;
   }
   /**
    * Heals the user the determined amount and possibly displays a message about regaining health.


### PR DESCRIPTION
## What are the changes?
Damaging moves that heal you are fixed.

## Why am I doing these changes?
Damaging moves that heal you were broken.

## What did change?
A variable is changed from `undefined` to `null` to pass a null check properly.

## How to test the changes?
Use an attacking move that heals you based on the damage dealt.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
