### PR TITLE
[Refactor] allow null UI mode (rid of `mode!`)

### DIFF
--- a/src/ui/abstact-option-select-ui-handler.ts
+++ b/src/ui/abstact-option-select-ui-handler.ts
@@ -46,8 +46,8 @@ export default abstract class AbstractOptionSelectUiHandler extends UiHandler {
 
   private cursorObj: Phaser.GameObjects.Image | null;
 
-  constructor(scene: BattleScene, mode?: Mode) {
-    super(scene, mode!); // TODO: is this bang correct?
+  constructor(scene: BattleScene, mode: Mode | null) {
+    super(scene, mode);
   }
 
   abstract getWindowWidth(): integer;
@@ -60,7 +60,7 @@ export default abstract class AbstractOptionSelectUiHandler extends UiHandler {
     const ui = this.getUi();
 
     this.optionSelectContainer = this.scene.add.container((this.scene.game.canvas.width / 6) - 1, -48);
-    this.optionSelectContainer.setName(`option-select-${Mode[this.mode]}`);
+    this.optionSelectContainer.setName(`option-select-${this.mode ? Mode[this.mode] : "UNKNOWN"}`);
     this.optionSelectContainer.setVisible(false);
     ui.add(this.optionSelectContainer);
 

--- a/src/ui/achvs-ui-handler.ts
+++ b/src/ui/achvs-ui-handler.ts
@@ -21,8 +21,8 @@ export default class AchvsUiHandler extends MessageUiHandler {
 
   private cursorObj: Phaser.GameObjects.NineSlice | null;
 
-  constructor(scene: BattleScene, mode?: Mode) {
-    super(scene, mode!); // TODO: is this bang correct?
+  constructor(scene: BattleScene, mode: Mode | null = null) {
+    super(scene, mode);
   }
 
   setup() {

--- a/src/ui/awaitable-ui-handler.ts
+++ b/src/ui/awaitable-ui-handler.ts
@@ -8,7 +8,7 @@ export default abstract class AwaitableUiHandler extends UiHandler {
   protected onActionInput: Function | null;
   public tutorialActive: boolean = false;
 
-  constructor(scene: BattleScene, mode: Mode) {
+  constructor(scene: BattleScene, mode: Mode | null = null) {
     super(scene, mode);
   }
 

--- a/src/ui/challenges-select-ui-handler.ts
+++ b/src/ui/challenges-select-ui-handler.ts
@@ -34,8 +34,8 @@ export default class GameChallengesUiHandler extends UiHandler {
 
   private startCursor: Phaser.GameObjects.NineSlice;
 
-  constructor(scene: BattleScene, mode?: Mode) {
-    super(scene, mode!); // TODO: is this bang correct?
+  constructor(scene: BattleScene, mode: Mode | null = null) {
+    super(scene, mode);
   }
 
   setup() {

--- a/src/ui/form-modal-ui-handler.ts
+++ b/src/ui/form-modal-ui-handler.ts
@@ -20,7 +20,7 @@ export abstract class FormModalUiHandler extends ModalUiHandler {
   protected submitAction: Function | null;
   protected tween: Phaser.Tweens.Tween;
 
-  constructor(scene: BattleScene, mode?: Mode) {
+  constructor(scene: BattleScene, mode: Mode | null = null) {
     super(scene, mode);
 
     this.editing = false;

--- a/src/ui/game-stats-ui-handler.ts
+++ b/src/ui/game-stats-ui-handler.ts
@@ -218,8 +218,8 @@ export default class GameStatsUiHandler extends UiHandler {
   private statLabels: Phaser.GameObjects.Text[];
   private statValues: Phaser.GameObjects.Text[];
 
-  constructor(scene: BattleScene, mode?: Mode) {
-    super(scene, mode!); // TODO: is this bang correct?
+  constructor(scene: BattleScene, mode: Mode | null = null) {
+    super(scene, mode);
 
     this.statLabels = [];
     this.statValues = [];

--- a/src/ui/loading-modal-ui-handler.ts
+++ b/src/ui/loading-modal-ui-handler.ts
@@ -5,7 +5,7 @@ import { addTextObject, TextStyle } from "./text";
 import { Mode } from "./ui";
 
 export default class LoadingModalUiHandler extends ModalUiHandler {
-  constructor(scene: BattleScene, mode?: Mode) {
+  constructor(scene: BattleScene, mode: Mode | null = null) {
     super(scene, mode);
   }
 

--- a/src/ui/login-form-ui-handler.ts
+++ b/src/ui/login-form-ui-handler.ts
@@ -13,7 +13,7 @@ export default class LoginFormUiHandler extends FormModalUiHandler {
   private externalPartyContainer: Phaser.GameObjects.Container;
   private externalPartyBg: Phaser.GameObjects.NineSlice;
   private externalPartyTitle: Phaser.GameObjects.Text;
-  constructor(scene: BattleScene, mode?: Mode) {
+  constructor(scene: BattleScene, mode: Mode | null = null) {
     super(scene, mode);
   }
 

--- a/src/ui/menu-ui-handler.ts
+++ b/src/ui/menu-ui-handler.ts
@@ -51,8 +51,8 @@ export default class MenuUiHandler extends MessageUiHandler {
   public bgmBar: BgmBar;
 
 
-  constructor(scene: BattleScene, mode?: Mode) {
-    super(scene, mode!); // TODO: is this bang correct?
+  constructor(scene: BattleScene, mode: Mode | null = null) {
+    super(scene, mode);
 
     this.excludedMenus = () => [
       { condition: [Mode.COMMAND, Mode.TITLE].includes(mode ?? Mode.TITLE), options: [ MenuOptions.EGG_GACHA, MenuOptions.EGG_LIST] },

--- a/src/ui/message-ui-handler.ts
+++ b/src/ui/message-ui-handler.ts
@@ -11,7 +11,7 @@ export default abstract class MessageUiHandler extends AwaitableUiHandler {
   public message: Phaser.GameObjects.Text;
   public prompt: Phaser.GameObjects.Sprite;
 
-  constructor(scene: BattleScene, mode: Mode) {
+  constructor(scene: BattleScene, mode: Mode | null = null) {
     super(scene, mode);
 
     this.pendingPrompt = false;

--- a/src/ui/modal-ui-handler.ts
+++ b/src/ui/modal-ui-handler.ts
@@ -16,8 +16,8 @@ export abstract class ModalUiHandler extends UiHandler {
   protected buttonContainers: Phaser.GameObjects.Container[];
   protected buttonBgs: Phaser.GameObjects.NineSlice[];
 
-  constructor(scene: BattleScene, mode?: Mode) {
-    super(scene, mode!); // TODO: is this bang correct?
+  constructor(scene: BattleScene, mode: Mode | null = null) {
+    super(scene, mode);
 
     this.buttonContainers = [];
     this.buttonBgs = [];

--- a/src/ui/outdated-modal-ui-handler.ts
+++ b/src/ui/outdated-modal-ui-handler.ts
@@ -4,7 +4,7 @@ import { addTextObject, TextStyle } from "./text";
 import { Mode } from "./ui";
 
 export default class OutdatedModalUiHandler extends ModalUiHandler {
-  constructor(scene: BattleScene, mode?: Mode) {
+  constructor(scene: BattleScene, mode: Mode | null = null) {
     super(scene, mode);
   }
 

--- a/src/ui/session-reload-modal-ui-handler.ts
+++ b/src/ui/session-reload-modal-ui-handler.ts
@@ -4,7 +4,7 @@ import { addTextObject, TextStyle } from "./text";
 import { Mode } from "./ui";
 
 export default class SessionReloadModalUiHandler extends ModalUiHandler {
-  constructor(scene: BattleScene, mode?: Mode) {
+  constructor(scene: BattleScene, mode: Mode | null = null) {
     super(scene, mode);
   }
 

--- a/src/ui/settings/abstract-binding-ui-handler.ts
+++ b/src/ui/settings/abstract-binding-ui-handler.ts
@@ -52,8 +52,8 @@ export default abstract class AbstractBindingUiHandler extends UiHandler {
      * @param scene - The BattleScene instance.
      * @param mode - The UI mode.
      */
-  constructor(scene: BattleScene, mode?: Mode) {
-    super(scene, mode!); // TODO: is this bang correct?
+  constructor(scene: BattleScene, mode: Mode | null = null) {
+    super(scene, mode);
   }
 
   /**

--- a/src/ui/settings/abstract-control-settings-ui-handler.ts
+++ b/src/ui/settings/abstract-control-settings-ui-handler.ts
@@ -73,8 +73,8 @@ export default abstract class AbstractControlSettingsUiHandler extends UiHandler
    * @param scene - The BattleScene instance.
    * @param mode - The UI mode.
    */
-  constructor(scene: BattleScene, mode?: Mode) {
-    super(scene, mode!); // TODO: is this bang correct?
+  constructor(scene: BattleScene, mode: Mode | null = null) {
+    super(scene, mode);
     this.rowsToDisplay = 8;
   }
 

--- a/src/ui/settings/abstract-settings-ui-handler.ts
+++ b/src/ui/settings/abstract-settings-ui-handler.ts
@@ -40,8 +40,8 @@ export default class AbstractSettingsUiHandler extends UiHandler {
   protected settings: Array<Setting>;
   protected localStorageKey: string;
 
-  constructor(scene: BattleScene, mode?: Mode) {
-    super(scene, mode!); // TODO: is this bang correct?
+  constructor(scene: BattleScene, mode: Mode | null = null) {
+    super(scene, mode);
 
     this.reloadRequired = false;
     this.rowsToDisplay = 8;

--- a/src/ui/settings/gamepad-binding-ui-handler.ts
+++ b/src/ui/settings/gamepad-binding-ui-handler.ts
@@ -8,7 +8,7 @@ import {addTextObject, TextStyle} from "#app/ui/text";
 
 export default class GamepadBindingUiHandler extends AbstractBindingUiHandler {
 
-  constructor(scene: BattleScene, mode?: Mode) {
+  constructor(scene: BattleScene, mode: Mode | null = null) {
     super(scene, mode);
     this.scene.input.gamepad?.on("down", this.gamepadButtonDown, this);
   }

--- a/src/ui/settings/keyboard-binding-ui-handler.ts
+++ b/src/ui/settings/keyboard-binding-ui-handler.ts
@@ -8,11 +8,12 @@ import {addTextObject, TextStyle} from "#app/ui/text";
 
 export default class KeyboardBindingUiHandler extends AbstractBindingUiHandler {
 
-  constructor(scene: BattleScene, mode?: Mode) {
+  constructor(scene: BattleScene, mode: Mode | null = null) {
     super(scene, mode);
     // Listen to gamepad button down events to initiate binding.
     scene.input.keyboard?.on("keydown", this.onKeyDown, this);
   }
+
   setup() {
     super.setup();
 

--- a/src/ui/settings/settings-audio-ui-handler.ts
+++ b/src/ui/settings/settings-audio-ui-handler.ts
@@ -11,7 +11,7 @@ export default class SettingsAudioUiHandler extends AbstractSettingsUiHandler {
    * @param scene - The BattleScene instance.
    * @param mode - The UI mode, optional.
    */
-  constructor(scene: BattleScene, mode?: Mode) {
+  constructor(scene: BattleScene, mode: Mode | null = null) {
     super(scene, mode);
     this.title = "Audio";
     this.settings = Setting.filter(s => s.type === SettingType.AUDIO);

--- a/src/ui/settings/settings-display-ui-handler.ts
+++ b/src/ui/settings/settings-display-ui-handler.ts
@@ -11,7 +11,7 @@ export default class SettingsDisplayUiHandler extends AbstractSettingsUiHandler 
    * @param scene - The BattleScene instance.
    * @param mode - The UI mode, optional.
    */
-  constructor(scene: BattleScene, mode?: Mode) {
+  constructor(scene: BattleScene, mode: Mode | null = null) {
     super(scene, mode);
     this.title = "Display";
     this.settings = Setting.filter(s => s.type === SettingType.DISPLAY);

--- a/src/ui/settings/settings-gamepad-ui-handler.ts
+++ b/src/ui/settings/settings-gamepad-ui-handler.ts
@@ -31,7 +31,7 @@ export default class SettingsGamepadUiHandler extends AbstractControlSettingsUiH
      * @param scene - The BattleScene instance.
      * @param mode - The UI mode, optional.
      */
-  constructor(scene: BattleScene, mode?: Mode) {
+  constructor(scene: BattleScene, mode: Mode | null = null) {
     super(scene, mode);
     this.titleSelected = "Gamepad";
     this.setting = SettingGamepad;

--- a/src/ui/settings/settings-keyboard-ui-handler.ts
+++ b/src/ui/settings/settings-keyboard-ui-handler.ts
@@ -29,7 +29,7 @@ export default class SettingsKeyboardUiHandler extends AbstractControlSettingsUi
      * @param scene - The BattleScene instance.
      * @param mode - The UI mode, optional.
      */
-  constructor(scene: BattleScene, mode?: Mode) {
+  constructor(scene: BattleScene, mode: Mode | null = null) {
     super(scene, mode);
     this.titleSelected = "Keyboard";
     this.setting = SettingKeyboard;

--- a/src/ui/settings/settings-ui-handler.ts
+++ b/src/ui/settings/settings-ui-handler.ts
@@ -10,7 +10,7 @@ export default class SettingsUiHandler extends AbstractSettingsUiHandler {
    * @param scene - The BattleScene instance.
    * @param mode - The UI mode, optional.
    */
-  constructor(scene: BattleScene, mode?: Mode) {
+  constructor(scene: BattleScene, mode: Mode | null = null) {
     super(scene, mode);
     this.title = "General";
     this.settings = Setting.filter(s => s.type === SettingType.GENERAL);

--- a/src/ui/ui-handler.ts
+++ b/src/ui/ui-handler.ts
@@ -8,7 +8,7 @@ import {Button} from "#enums/buttons";
  */
 export default abstract class UiHandler {
   protected scene: BattleScene;
-  protected mode: integer;
+  protected mode: integer | null;
   protected cursor: integer = 0;
   public active: boolean = false;
 
@@ -16,7 +16,7 @@ export default abstract class UiHandler {
    * @param {BattleScene} scene The same scene as everything else.
    * @param {Mode} mode The mode of the UI element. These should be unique.
    */
-  constructor(scene: BattleScene, mode: Mode) {
+  constructor(scene: BattleScene, mode: Mode | null = null) {
     this.scene = scene;
     this.mode = mode;
   }

--- a/src/ui/unavailable-modal-ui-handler.ts
+++ b/src/ui/unavailable-modal-ui-handler.ts
@@ -16,7 +16,7 @@ export default class UnavailableModalUiHandler extends ModalUiHandler {
 
   private readonly randVarianceTime = 1000 * 10;
 
-  constructor(scene: BattleScene, mode?: Mode) {
+  constructor(scene: BattleScene, mode: Mode | null = null) {
     super(scene, mode);
     this.reconnectDuration = this.minTime;
   }

--- a/src/ui/vouchers-ui-handler.ts
+++ b/src/ui/vouchers-ui-handler.ts
@@ -24,8 +24,8 @@ export default class VouchersUiHandler extends MessageUiHandler {
 
   private cursorObj: Phaser.GameObjects.NineSlice | null;
 
-  constructor(scene: BattleScene, mode?: Mode) {
-    super(scene, mode!); // TODO: is this bang correct?
+  constructor(scene: BattleScene, mode: Mode | null = null) {
+    super(scene, mode);
 
     this.itemsTotal = Object.keys(vouchers).length;
     this.scrollCursor = 0;


### PR DESCRIPTION
## What are the changes?

the constructor of ui classes now allows `null` for the mode constructor param.

Extension of #3259 

## Why am I doing these changes?

to get rid of the `mode!`

## What did change?

`mode: Mode` is now => `mode: Mode | null = null`

## How to test the changes?

- tests should still succeed.
- Play the game and nothing should crash

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
