### PR TITLE
[TEST] - adding parting shot move test

### DIFF
--- a/src/test/moves/parting_shot.test.ts
+++ b/src/test/moves/parting_shot.test.ts
@@ -36,34 +36,29 @@ describe("Moves - Parting Shot", () => {
   });
 
   test(
-    "Parting shot when buffed by prankster should fail against dark types",
+    "Parting Shot when buffed by prankster should fail against dark types",
     async () => {
-      await game.startBattle([Species.MURKROW]);
-      game.override.ability(Abilities.PRANKSTER);
-      game.override.enemySpecies(Species.POOCHYENA);
-
-      const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).toBeDefined();
-
+      await game.startBattle([Species.MURKROW, Species.MEOWTH]);
+      game.override
+        .enemySpecies(Species.POOCHYENA)
+        .ability(Abilities.PRANKSTER);
       game.doAttack(getMovePosition(game.scene, 0, Moves.PARTING_SHOT));
 
       await game.phaseInterceptor.to(BerryPhase, false);
       const battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
       expect(battleStatsOpponent[BattleStat.ATK]).toBe(0);
       expect(battleStatsOpponent[BattleStat.SPATK]).toBe(0);
-
-
+      expect(game.scene.getPlayerField()[0].species.speciesId).toBe(Species.MURKROW);
     }, TIMEOUT
   );
 
   test(
-    "Parting shot when buffed by prankster should fail against good for gold ability",
+    "Parting shot when buffed by prankster should fail against good as gold ability",
     async () => {
-      await game.startBattle([Species.MURKROW]);
-      game.override.ability(Abilities.PRANKSTER);
-      game.override.enemySpecies(Species.GHOLDENGO);
-      game.override.enemyAbility(Abilities.GOOD_AS_GOLD);
-
+      await game.startBattle([Species.MURKROW, Species.MEOWTH]);
+      game.override
+        .enemySpecies(Species.GHOLDENGO)
+        .enemyAbility(Abilities.GOOD_AS_GOLD);
       const enemyPokemon = game.scene.getEnemyPokemon()!;
       expect(enemyPokemon).toBeDefined();
 
@@ -73,6 +68,7 @@ describe("Moves - Parting Shot", () => {
       const battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
       expect(battleStatsOpponent[BattleStat.ATK]).toBe(0);
       expect(battleStatsOpponent[BattleStat.SPATK]).toBe(0);
+      expect(game.scene.getPlayerField()[0].species.speciesId).toBe(Species.MURKROW);
     }, TIMEOUT
   );
 });

--- a/src/test/moves/parting_shot.test.ts
+++ b/src/test/moves/parting_shot.test.ts
@@ -38,10 +38,11 @@ describe("Moves - Parting Shot", () => {
   test(
     "Parting Shot when buffed by prankster should fail against dark types",
     async () => {
-      await game.startBattle([Species.MURKROW, Species.MEOWTH]);
       game.override
         .enemySpecies(Species.POOCHYENA)
         .ability(Abilities.PRANKSTER);
+      await game.startBattle([Species.MURKROW, Species.MEOWTH]);
+
       game.doAttack(getMovePosition(game.scene, 0, Moves.PARTING_SHOT));
 
       await game.phaseInterceptor.to(BerryPhase, false);
@@ -53,12 +54,13 @@ describe("Moves - Parting Shot", () => {
   );
 
   test(
-    "Parting shot when buffed by prankster should fail against good as gold ability",
+    "Parting shot should fail against good as gold ability",
     async () => {
-      await game.startBattle([Species.MURKROW, Species.MEOWTH]);
       game.override
         .enemySpecies(Species.GHOLDENGO)
         .enemyAbility(Abilities.GOOD_AS_GOLD);
+      await game.startBattle([Species.MURKROW, Species.MEOWTH]);
+
       const enemyPokemon = game.scene.getEnemyPokemon()!;
       expect(enemyPokemon).toBeDefined();
 

--- a/src/test/moves/parting_shot.test.ts
+++ b/src/test/moves/parting_shot.test.ts
@@ -29,7 +29,6 @@ describe("Moves - Parting Shot", () => {
     game = new GameManager(phaserGame);
     game.override.battleType("single");
     game.override.moveset([Moves.PARTING_SHOT, Moves.SPLASH]);
-    game.override.enemySpecies(Species.POOCHYENA);
     game.override.enemyMoveset(SPLASH_ONLY);
     game.override.startingLevel(5);
     game.override.enemyLevel(5);
@@ -41,13 +40,14 @@ describe("Moves - Parting Shot", () => {
     async () => {
       await game.startBattle([Species.MURKROW]);
       game.override.ability(Abilities.PRANKSTER);
+      game.override.enemySpecies(Species.POOCHYENA);
 
       const enemyPokemon = game.scene.getEnemyPokemon()!;
       expect(enemyPokemon).toBeDefined();
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.PARTING_SHOT));
 
-      await game.phaseInterceptor.to(BerryPhase);
+      await game.phaseInterceptor.to(BerryPhase, false);
       const battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
       expect(battleStatsOpponent[BattleStat.ATK]).toBe(0);
       expect(battleStatsOpponent[BattleStat.SPATK]).toBe(0);
@@ -61,6 +61,7 @@ describe("Moves - Parting Shot", () => {
     async () => {
       await game.startBattle([Species.MURKROW]);
       game.override.ability(Abilities.PRANKSTER);
+      game.override.enemySpecies(Species.GHOLDENGO);
       game.override.enemyAbility(Abilities.GOOD_AS_GOLD);
 
       const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -68,7 +69,7 @@ describe("Moves - Parting Shot", () => {
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.PARTING_SHOT));
 
-      await game.phaseInterceptor.to(BerryPhase);
+      await game.phaseInterceptor.to(BerryPhase, false);
       const battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
       expect(battleStatsOpponent[BattleStat.ATK]).toBe(0);
       expect(battleStatsOpponent[BattleStat.SPATK]).toBe(0);

--- a/src/test/moves/parting_shot.test.ts
+++ b/src/test/moves/parting_shot.test.ts
@@ -1,0 +1,77 @@
+import { SPLASH_ONLY } from "../utils/testUtils";
+import { BerryPhase } from "#app/phases.js";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
+import GameManager from "../utils/gameManager";
+import { getMovePosition } from "../utils/gameManagerUtils";
+import { BattleStat } from "#app/data/battle-stat";
+
+const TIMEOUT = 20 * 1000;
+
+describe("Moves - Parting Shot", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override.battleType("single");
+    game.override.moveset([Moves.PARTING_SHOT, Moves.SPLASH]);
+    game.override.enemySpecies(Species.POOCHYENA);
+    game.override.enemyMoveset(SPLASH_ONLY);
+    game.override.startingLevel(5);
+    game.override.enemyLevel(5);
+
+  });
+
+  test(
+    "Parting shot when buffed by prankster should fail against dark types",
+    async () => {
+      await game.startBattle([Species.MURKROW]);
+      game.override.ability(Abilities.PRANKSTER);
+
+      const enemyPokemon = game.scene.getEnemyPokemon()!;
+      expect(enemyPokemon).toBeDefined();
+
+      game.doAttack(getMovePosition(game.scene, 0, Moves.PARTING_SHOT));
+
+      await game.phaseInterceptor.to(BerryPhase);
+      const battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
+      expect(battleStatsOpponent[BattleStat.ATK]).toBe(0);
+      expect(battleStatsOpponent[BattleStat.SPATK]).toBe(0);
+
+
+    }, TIMEOUT
+  );
+
+  test(
+    "Parting shot when buffed by prankster should fail against good for gold ability",
+    async () => {
+      await game.startBattle([Species.MURKROW]);
+      game.override.ability(Abilities.PRANKSTER);
+      game.override.enemyAbility(Abilities.GOOD_AS_GOLD);
+
+      const enemyPokemon = game.scene.getEnemyPokemon()!;
+      expect(enemyPokemon).toBeDefined();
+
+      game.doAttack(getMovePosition(game.scene, 0, Moves.PARTING_SHOT));
+
+      await game.phaseInterceptor.to(BerryPhase);
+      const battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
+      expect(battleStatsOpponent[BattleStat.ATK]).toBe(0);
+      expect(battleStatsOpponent[BattleStat.SPATK]).toBe(0);
+    }, TIMEOUT
+  );
+});


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Adding tests that cover PR #3195 (for parting shot), which originally fix issue #3112: that parting shot still debuffs when the move is supposed to fail

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
More tests
### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
`npm test src/test/moves/parting_shot.test.ts`
## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
