### PR TITLE
[Test] Mock turn order in Miracle Eye test

### DIFF
--- a/src/test/moves/miracle_eye.test.ts
+++ b/src/test/moves/miracle_eye.test.ts
@@ -2,10 +2,11 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#test/utils/gameManager";
 import { Species } from "#app/enums/species.js";
-import { SPLASH_ONLY } from "../utils/testUtils";
+import { mockTurnOrder, SPLASH_ONLY } from "../utils/testUtils";
 import { Moves } from "#app/enums/moves.js";
 import { getMovePosition } from "../utils/gameManagerUtils";
 import { MoveEffectPhase } from "#app/phases.js";
+import { BattlerIndex } from "#app/battle.js";
 
 describe("Internals", () => {
   let phaserGame: Phaser.Game;
@@ -38,6 +39,7 @@ describe("Internals", () => {
     const enemy = game.scene.getEnemyPokemon()!;
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.CONFUSION));
+    await mockTurnOrder(game, [BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
     await game.toNextTurn();
     expect(enemy.hp).toBe(enemy.getMaxHp());
 


### PR DESCRIPTION
## What are the changes?
There are no user-facing changes.

## Why am I doing these changes?
Forgot to mock the turn order when making the test.

## What did change?
The player Pokémon now always moves first in the test.

## How to test the changes?
`npm run test miracle_eye`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
