### PR TITLE
[Balance] Change Some Mainline Starter's Early Learnset

### DIFF
--- a/src/data/pokemon-level-moves.ts
+++ b/src/data/pokemon-level-moves.ts
@@ -2631,7 +2631,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.CHIKORITA]: [
     [ 1, Moves.TACKLE ],
     [ 1, Moves.GROWL ],
-    [ 5, Moves.RAZOR_LEAF ],
+    [ 5, Moves.RAZOR_LEAF ], //Custom, moved from 6 to 5
     [ 9, Moves.POISON_POWDER ],
     [ 12, Moves.SYNTHESIS ],
     [ 17, Moves.REFLECT ],
@@ -2681,8 +2681,8 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.CYNDAQUIL]: [
     [ 1, Moves.TACKLE ],
     [ 1, Moves.LEER ],
-    [ 5, Moves.EMBER ],
-    [ 10, Moves.SMOKESCREEN ],
+    [ 5, Moves.EMBER ], //Custom, moved to 5
+    [ 10, Moves.SMOKESCREEN ], //Custom, moved to 10
     [ 13, Moves.QUICK_ATTACK ],
     [ 19, Moves.FLAME_WHEEL ],
     [ 22, Moves.DEFENSE_CURL ],
@@ -2736,7 +2736,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.TOTODILE]: [
     [ 1, Moves.SCRATCH ],
     [ 1, Moves.LEER ],
-    [ 5, Moves.WATER_GUN ],
+    [ 5, Moves.WATER_GUN ], //Custom, moved from 6 to 5
     [ 9, Moves.BITE ],
     [ 13, Moves.SCARY_FACE ],
     [ 19, Moves.ICE_FANG ],
@@ -6723,7 +6723,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.TURTWIG]: [
     [ 1, Moves.TACKLE ],
     [ 5, Moves.WITHDRAW ],
-    [ 5, Moves.ABSORB ],
+    [ 5, Moves.ABSORB ], //Custom, moved from 9 to 5
     [ 13, Moves.RAZOR_LEAF ],
     [ 17, Moves.CURSE ],
     [ 21, Moves.BITE ],
@@ -6768,7 +6768,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.CHIMCHAR]: [
     [ 1, Moves.SCRATCH ],
     [ 1, Moves.LEER ],
-    [ 5, Moves.EMBER ],
+    [ 5, Moves.EMBER ], //Custom, moved from 7 to 5
     [ 9, Moves.TAUNT ],
     [ 15, Moves.FURY_SWIPES ],
     [ 17, Moves.FLAME_WHEEL ],
@@ -6817,7 +6817,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.PIPLUP]: [
     [ 1, Moves.POUND ],
     [ 4, Moves.GROWL ],
-    [ 5, Moves.WATER_GUN ],
+    [ 5, Moves.WATER_GUN ], //Custom, moved from 8 to 5
     [ 11, Moves.CHARM ],
     [ 15, Moves.PECK ],
     [ 18, Moves.BUBBLE_BEAM ],
@@ -8591,7 +8591,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.SNIVY]: [
     [ 1, Moves.TACKLE ],
     [ 4, Moves.LEER ],
-    [ 5, Moves.VINE_WHIP ],
+    [ 5, Moves.VINE_WHIP ], //Custom, moved from 7 to 5
     [ 10, Moves.WRAP ],
     [ 13, Moves.GROWTH ],
     [ 16, Moves.MAGICAL_LEAF ],
@@ -8639,7 +8639,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.TEPIG]: [
     [ 1, Moves.TACKLE ],
     [ 3, Moves.TAIL_WHIP ],
-    [ 5, Moves.EMBER ],
+    [ 5, Moves.EMBER ], //Custom, moved from 7 to 5
     [ 9, Moves.ENDURE ],
     [ 13, Moves.DEFENSE_CURL ],
     [ 15, Moves.FLAME_CHARGE ],
@@ -8693,7 +8693,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.OSHAWOTT]: [
     [ 1, Moves.TACKLE ],
     [ 5, Moves.TAIL_WHIP ],
-    [ 5, Moves.WATER_GUN ],
+    [ 5, Moves.WATER_GUN ], //Custom, moved from 7 to 5
     [ 11, Moves.SOAK ],
     [ 13, Moves.FOCUS_ENERGY ],
     [ 17, Moves.RAZOR_SHELL ],
@@ -13850,7 +13850,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
     [ 99, Moves.CLOSE_COMBAT ],
   ],
   [Species.POIPOLE]: [
-    [ RELEARN_MOVE, Moves.DRAGON_PULSE ],
+    [ RELEARN_MOVE, Moves.DRAGON_PULSE ], //Custom, made relearn
     [ 1, Moves.GROWL ],
     [ 1, Moves.ACID ],
     [ 1, Moves.PECK ],
@@ -13969,7 +13969,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.GROOKEY]: [
     [ 1, Moves.SCRATCH ],
     [ 1, Moves.GROWL ],
-    [ 5, Moves.BRANCH_POKE ],
+    [ 5, Moves.BRANCH_POKE ], //Custom, moved from 6 to 5
     [ 8, Moves.TAUNT ],
     [ 12, Moves.RAZOR_LEAF ],
     [ 17, Moves.SCREECH ],
@@ -14014,7 +14014,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.SCORBUNNY]: [
     [ 1, Moves.TACKLE ],
     [ 1, Moves.GROWL ],
-    [ 5, Moves.EMBER ],
+    [ 5, Moves.EMBER ], //Custom, moved from 6 to 5
     [ 8, Moves.QUICK_ATTACK ],
     [ 12, Moves.DOUBLE_KICK ],
     [ 17, Moves.FLAME_CHARGE ],
@@ -14056,7 +14056,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.SOBBLE]: [
     [ 1, Moves.POUND ],
     [ 1, Moves.GROWL ],
-    [ 5, Moves.WATER_GUN ],
+    [ 5, Moves.WATER_GUN ], //Custom, moved from 6 to 5
     [ 8, Moves.BIND ],
     [ 12, Moves.WATER_PULSE ],
     [ 17, Moves.TEARFUL_LOOK ],

--- a/src/data/pokemon-level-moves.ts
+++ b/src/data/pokemon-level-moves.ts
@@ -13850,11 +13850,11 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
     [ 99, Moves.CLOSE_COMBAT ],
   ],
   [Species.POIPOLE]: [
+    [ RELEARN_MOVE, Moves.DRAGON_PULSE ],
     [ 1, Moves.GROWL ],
     [ 1, Moves.ACID ],
     [ 1, Moves.PECK ],
     [ 1, Moves.HELPING_HAND ],
-    [ 1, Moves.DRAGON_PULSE ],
     [ 7, Moves.FURY_ATTACK ],
     [ 14, Moves.FELL_STINGER ],
     [ 21, Moves.CHARM ],

--- a/src/data/pokemon-level-moves.ts
+++ b/src/data/pokemon-level-moves.ts
@@ -2631,7 +2631,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.CHIKORITA]: [
     [ 1, Moves.TACKLE ],
     [ 1, Moves.GROWL ],
-    [ 6, Moves.RAZOR_LEAF ],
+    [ 5, Moves.RAZOR_LEAF ],
     [ 9, Moves.POISON_POWDER ],
     [ 12, Moves.SYNTHESIS ],
     [ 17, Moves.REFLECT ],
@@ -2681,8 +2681,8 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.CYNDAQUIL]: [
     [ 1, Moves.TACKLE ],
     [ 1, Moves.LEER ],
-    [ 6, Moves.SMOKESCREEN ],
-    [ 10, Moves.EMBER ],
+    [ 5, Moves.EMBER ],
+    [ 10, Moves.SMOKESCREEN ],
     [ 13, Moves.QUICK_ATTACK ],
     [ 19, Moves.FLAME_WHEEL ],
     [ 22, Moves.DEFENSE_CURL ],
@@ -2736,7 +2736,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.TOTODILE]: [
     [ 1, Moves.SCRATCH ],
     [ 1, Moves.LEER ],
-    [ 6, Moves.WATER_GUN ],
+    [ 5, Moves.WATER_GUN ],
     [ 9, Moves.BITE ],
     [ 13, Moves.SCARY_FACE ],
     [ 19, Moves.ICE_FANG ],
@@ -6723,7 +6723,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.TURTWIG]: [
     [ 1, Moves.TACKLE ],
     [ 5, Moves.WITHDRAW ],
-    [ 9, Moves.ABSORB ],
+    [ 5, Moves.ABSORB ],
     [ 13, Moves.RAZOR_LEAF ],
     [ 17, Moves.CURSE ],
     [ 21, Moves.BITE ],
@@ -6768,7 +6768,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.CHIMCHAR]: [
     [ 1, Moves.SCRATCH ],
     [ 1, Moves.LEER ],
-    [ 7, Moves.EMBER ],
+    [ 5, Moves.EMBER ],
     [ 9, Moves.TAUNT ],
     [ 15, Moves.FURY_SWIPES ],
     [ 17, Moves.FLAME_WHEEL ],
@@ -6817,7 +6817,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.PIPLUP]: [
     [ 1, Moves.POUND ],
     [ 4, Moves.GROWL ],
-    [ 8, Moves.WATER_GUN ],
+    [ 5, Moves.WATER_GUN ],
     [ 11, Moves.CHARM ],
     [ 15, Moves.PECK ],
     [ 18, Moves.BUBBLE_BEAM ],
@@ -8591,7 +8591,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.SNIVY]: [
     [ 1, Moves.TACKLE ],
     [ 4, Moves.LEER ],
-    [ 7, Moves.VINE_WHIP ],
+    [ 5, Moves.VINE_WHIP ],
     [ 10, Moves.WRAP ],
     [ 13, Moves.GROWTH ],
     [ 16, Moves.MAGICAL_LEAF ],
@@ -8639,7 +8639,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.TEPIG]: [
     [ 1, Moves.TACKLE ],
     [ 3, Moves.TAIL_WHIP ],
-    [ 7, Moves.EMBER ],
+    [ 5, Moves.EMBER ],
     [ 9, Moves.ENDURE ],
     [ 13, Moves.DEFENSE_CURL ],
     [ 15, Moves.FLAME_CHARGE ],
@@ -8693,7 +8693,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.OSHAWOTT]: [
     [ 1, Moves.TACKLE ],
     [ 5, Moves.TAIL_WHIP ],
-    [ 7, Moves.WATER_GUN ],
+    [ 5, Moves.WATER_GUN ],
     [ 11, Moves.SOAK ],
     [ 13, Moves.FOCUS_ENERGY ],
     [ 17, Moves.RAZOR_SHELL ],
@@ -13969,7 +13969,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.GROOKEY]: [
     [ 1, Moves.SCRATCH ],
     [ 1, Moves.GROWL ],
-    [ 6, Moves.BRANCH_POKE ],
+    [ 5, Moves.BRANCH_POKE ],
     [ 8, Moves.TAUNT ],
     [ 12, Moves.RAZOR_LEAF ],
     [ 17, Moves.SCREECH ],
@@ -14014,7 +14014,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.SCORBUNNY]: [
     [ 1, Moves.TACKLE ],
     [ 1, Moves.GROWL ],
-    [ 6, Moves.EMBER ],
+    [ 5, Moves.EMBER ],
     [ 8, Moves.QUICK_ATTACK ],
     [ 12, Moves.DOUBLE_KICK ],
     [ 17, Moves.FLAME_CHARGE ],
@@ -14056,7 +14056,7 @@ export const pokemonSpeciesLevelMoves: PokemonSpeciesLevelMoves = {
   [Species.SOBBLE]: [
     [ 1, Moves.POUND ],
     [ 1, Moves.GROWL ],
-    [ 6, Moves.WATER_GUN ],
+    [ 5, Moves.WATER_GUN ],
     [ 8, Moves.BIND ],
     [ 12, Moves.WATER_PULSE ],
     [ 17, Moves.TEARFUL_LOOK ],


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
Changed all mainline starter's learnset to get access to their respective STAB option at Level 5.

## Why am I doing these changes?
Follow up on my previous PR's that helped other Pokemon's early game learnsets, this aims to allow every starter to get access to their STAB option immediately rather have weird variance between each generation. Makes the game ever so slightly easier for a new player / fresh start player and keeps things equal between the options.

## What did change?
Chikorita/Cyndaquil/Totodile, Turtwig/Chimchar/Piplup, Snivy/Tepig/Oshawott, Grookey/Scorbunny/Sobble all had their learnsets adjusted. Poipole had Dragon Pulse set as a relearn move to not start with Naganadel immediately.

### Screenshots/Videos
A saddened Cyndaquil that needs to wait until Level 10 for his early game STAB :(
![image](https://github.com/user-attachments/assets/784540a7-5f55-4a6f-a771-a40a25cfec24)
A happy Cyndaquil knowing he is equal to his starter kind :)
![image](https://github.com/user-attachments/assets/50b845b4-2459-4273-8b62-932650b31041)

## How to test the changes?
Start a run with a starter

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
