### PR TITLE
[Enhancement] Target Selection also highlights target's held items

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -792,10 +792,11 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Returns the ModifierBar of this scene, which is declared private and therefore not accessible elsewhere
+   * @params isEnemy {@linkcode Boolean} accesses BattleScene.enemyModifierBar if true - optional, defaults to returning BattleScene.modifierBar if not present
    * @returns {ModifierBar}
    */
-  getModifierBar(enemy?: boolean): ModifierBar {
-    return enemy ? this.enemyModifierBar : this.modifierBar;
+  getModifierBar(isEnemy?: boolean): ModifierBar {
+    return isEnemy ? this.enemyModifierBar : this.modifierBar;
   }
 
   // store info toggles to be accessible by the ui

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -792,7 +792,7 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Returns the ModifierBar of this scene, which is declared private and therefore not accessible elsewhere
-   * @params isEnemy {@linkcode Boolean} accesses BattleScene.enemyModifierBar if true - optional, defaults to returning BattleScene.modifierBar if not present
+   * @param isEnemy Whether to return the enemy's modifier bar
    * @returns {ModifierBar}
    */
   getModifierBar(isEnemy?: boolean): ModifierBar {

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -794,7 +794,10 @@ export default class BattleScene extends SceneBase {
    * Returns the ModifierBar of this scene, which is declared private and therefore not accessible elsewhere
    * @returns {ModifierBar}
    */
-  getModifierBar(): ModifierBar {
+  getModifierBar(enemy?: boolean): ModifierBar {
+    if (enemy) {
+      return this.enemyModifierBar;
+    }
     return this.modifierBar;
   }
 

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -795,10 +795,7 @@ export default class BattleScene extends SceneBase {
    * @returns {ModifierBar}
    */
   getModifierBar(enemy?: boolean): ModifierBar {
-    if (enemy) {
-      return this.enemyModifierBar;
-    }
-    return this.modifierBar;
+    return enemy ? this.enemyModifierBar : this.modifierBar;
   }
 
   // store info toggles to be accessible by the ui

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -22,12 +22,12 @@ import { FormChangeItem, SpeciesFormChangeItemTrigger } from "../data/pokemon-fo
 import { Nature } from "#app/data/nature";
 import Overrides from "#app/overrides";
 import { ModifierType, modifierTypes } from "./modifier-type";
-import { Command } from "#app/ui/command-ui-handler.js";
+import { Command } from "#app/ui/command-ui-handler";
 import { Species } from "#enums/species";
 import i18next from "i18next";
 
-import { allMoves } from "#app/data/move.js";
-import { Abilities } from "#app/enums/abilities.js";
+import { allMoves } from "#app/data/move";
+import { Abilities } from "#app/enums/abilities";
 
 export type ModifierPredicate = (modifier: Modifier) => boolean;
 

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -506,7 +506,7 @@ export abstract class PokemonHeldItemModifier extends PersistentModifier {
       if (pokemon) {
         const pokemonIcon = scene.addPokemonIcon(pokemon, -2, 10, 0, 0.5);
         container.add(pokemonIcon);
-        container.setName(pokemon.id);
+        container.setName((pokemon.id).toString());
       }
 
       const item = scene.add.sprite(16, this.virtualStackCount ? 8 : 16, "items");

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -506,7 +506,7 @@ export abstract class PokemonHeldItemModifier extends PersistentModifier {
       if (pokemon) {
         const pokemonIcon = scene.addPokemonIcon(pokemon, -2, 10, 0, 0.5);
         container.add(pokemonIcon);
-        container.setName((pokemon.id).toString());
+        container.setName(pokemon.id.toString());
       }
 
       const item = scene.add.sprite(16, this.virtualStackCount ? 8 : 16, "items");

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -506,6 +506,7 @@ export abstract class PokemonHeldItemModifier extends PersistentModifier {
       if (pokemon) {
         const pokemonIcon = scene.addPokemonIcon(pokemon, -2, 10, 0, 0.5);
         container.add(pokemonIcon);
+        container.setName(pokemon.id);
       }
 
       const item = scene.add.sprite(16, this.virtualStackCount ? 8 : 16, "items");

--- a/src/ui/target-select-ui-handler.ts
+++ b/src/ui/target-select-ui-handler.ts
@@ -132,8 +132,6 @@ export default class TargetSelectUiHandler extends UiHandler {
       }
     });
 
-
-
     if (this.targetBattleInfoMoveTween.length >= 1) {
       this.targetBattleInfoMoveTween.filter(t => t !== undefined).forEach(tween => tween.stop());
       for (const pokemon of multipleTargets) {

--- a/src/ui/target-select-ui-handler.ts
+++ b/src/ui/target-select-ui-handler.ts
@@ -109,7 +109,7 @@ export default class TargetSelectUiHandler extends UiHandler {
       this.targetFlashTween.stop();
       for (const pokemon of multipleTargets) {
         pokemon.setAlpha(1);
-        const targetItems = enemyModifiers.getAll("name", pokemon.id);
+        const targetItems = enemyModifiers.getAll("name", (pokemon.id).toString());
         for (const item of targetItems) {
           (item as Phaser.GameObjects.Container).setAlpha(1);
         }
@@ -118,16 +118,16 @@ export default class TargetSelectUiHandler extends UiHandler {
 
     this.targetFlashTween = this.scene.tweens.add({
       targets: [this.targetsHighlighted],
-      key: { start: 0.5, to: 1 },
+      key: { start: 0.65, to: 1 },
       loop: -1,
-      loopDelay: 350,
-      duration: Utils.fixedInt(250),
+      loopDelay: 150,
+      duration: Utils.fixedInt(450),
       ease: "Sine.easeInOut",
       yoyo: true,
       onUpdate: t => {
         for (const target of this.targetsHighlighted) {
           target.setAlpha(t.getValue());
-          const targetItems = enemyModifiers.getAll("name", target.id);
+          const targetItems = enemyModifiers.getAll("name", (target.id).toString());
           for (const item of targetItems) {
             (item as Phaser.GameObjects.Container).setAlpha(t.getValue());
           }
@@ -167,7 +167,7 @@ export default class TargetSelectUiHandler extends UiHandler {
 
     for (const pokemon of this.targetsHighlighted) {
       pokemon.setAlpha(1);
-      const targetItems = enemyModifiers.getAll("name", pokemon.id);
+      const targetItems = enemyModifiers.getAll("name", (pokemon.id).toString());
       for (const item of targetItems) {
         (item as Phaser.GameObjects.Container).setAlpha(1);
       }

--- a/src/ui/target-select-ui-handler.ts
+++ b/src/ui/target-select-ui-handler.ts
@@ -108,19 +108,28 @@ export default class TargetSelectUiHandler extends UiHandler {
       this.targetFlashTween.stop();
       for (const pokemon of multipleTargets) {
         pokemon.setAlpha(1);
+        const targetItems = this.scene.enemyModifierBar.getAll("name", pokemon.id);
+        for (const target of targetItems) {
+          target.setAlpha(1);
+        }
       }
     }
 
     this.targetFlashTween = this.scene.tweens.add({
-      targets: this.targetsHighlighted,
+      targets: [this.targetsHighlighted],
       alpha: 0,
       loop: -1,
+      loopDelay: 450,
       duration: Utils.fixedInt(250),
       ease: "Sine.easeIn",
       yoyo: true,
       onUpdate: t => {
         for (const target of this.targetsHighlighted) {
           target.setAlpha(t.getValue());
+          const targetItems = this.scene.enemyModifierBar.getAll("name", target.id);
+          for (const target of targetItems) {
+            target.setAlpha(t.getValue());
+          }
         }
       }
     });
@@ -152,8 +161,13 @@ export default class TargetSelectUiHandler extends UiHandler {
       this.targetFlashTween.stop();
       this.targetFlashTween = null;
     }
+
     for (const pokemon of this.targetsHighlighted) {
       pokemon.setAlpha(1);
+      const targetItems = this.scene.enemyModifierBar.getAll("name", pokemon.id);
+      for (const item of targetItems) {
+        item.setAlpha(1);
+      }
     }
 
     if (this.targetBattleInfoMoveTween.length >= 1) {

--- a/src/ui/target-select-ui-handler.ts
+++ b/src/ui/target-select-ui-handler.ts
@@ -6,7 +6,7 @@ import * as Utils from "../utils";
 import { getMoveTargets } from "../data/move";
 import {Button} from "#enums/buttons";
 import { Moves } from "#enums/moves";
-import Pokemon from "#app/field/pokemon.js";
+import Pokemon from "#app/field/pokemon";
 
 export type TargetSelectCallback = (targets: BattlerIndex[]) => void;
 

--- a/src/ui/target-select-ui-handler.ts
+++ b/src/ui/target-select-ui-handler.ts
@@ -99,6 +99,7 @@ export default class TargetSelectUiHandler extends UiHandler {
   setCursor(cursor: integer): boolean {
     const singleTarget = this.scene.getField()[cursor];
     const multipleTargets = this.targets.map(index => this.scene.getField()[index]);
+    const enemyModifiers = this.scene.getModifierBar(true);
 
     this.targetsHighlighted = this.isMultipleTargets ? multipleTargets : [ singleTarget ];
 
@@ -108,27 +109,27 @@ export default class TargetSelectUiHandler extends UiHandler {
       this.targetFlashTween.stop();
       for (const pokemon of multipleTargets) {
         pokemon.setAlpha(1);
-        const targetItems = this.scene.enemyModifierBar.getAll("name", pokemon.id);
-        for (const target of targetItems) {
-          target.setAlpha(1);
+        const targetItems = enemyModifiers.getAll("name", pokemon.id);
+        for (const item of targetItems) {
+          (item as Phaser.GameObjects.Container).setAlpha(1);
         }
       }
     }
 
     this.targetFlashTween = this.scene.tweens.add({
       targets: [this.targetsHighlighted],
-      alpha: 0,
+      key: { start: 0.5, to: 1 },
       loop: -1,
-      loopDelay: 450,
+      loopDelay: 350,
       duration: Utils.fixedInt(250),
-      ease: "Sine.easeIn",
+      ease: "Sine.easeInOut",
       yoyo: true,
       onUpdate: t => {
         for (const target of this.targetsHighlighted) {
           target.setAlpha(t.getValue());
-          const targetItems = this.scene.enemyModifierBar.getAll("name", target.id);
-          for (const target of targetItems) {
-            target.setAlpha(t.getValue());
+          const targetItems = enemyModifiers.getAll("name", target.id);
+          for (const item of targetItems) {
+            (item as Phaser.GameObjects.Container).setAlpha(t.getValue());
           }
         }
       }
@@ -162,11 +163,13 @@ export default class TargetSelectUiHandler extends UiHandler {
       this.targetFlashTween = null;
     }
 
+    const enemyModifiers = this.scene.getModifierBar(true);
+
     for (const pokemon of this.targetsHighlighted) {
       pokemon.setAlpha(1);
-      const targetItems = this.scene.enemyModifierBar.getAll("name", pokemon.id);
+      const targetItems = enemyModifiers.getAll("name", pokemon.id);
       for (const item of targetItems) {
-        item.setAlpha(1);
+        (item as Phaser.GameObjects.Container).setAlpha(1);
       }
     }
 

--- a/src/ui/target-select-ui-handler.ts
+++ b/src/ui/target-select-ui-handler.ts
@@ -179,8 +179,8 @@ export default class TargetSelectUiHandler extends UiHandler {
 
   private highlightItems(targetId: number, val: number) : void {
     const targetItems = this.enemyModifiers.getAll("name", targetId.toString());
-    for (const item of targetItems) {
-      (item as Phaser.GameObjects.Container).setAlpha(val);
+    for (const item of targetItems as Phaser.GameObjects.Container[]) {
+      item.setAlpha(val);
     }
   }
 


### PR DESCRIPTION
## What are the changes?
The held items of the target also flash with the target during the target selection phase. 

## Why am I doing these changes?
It is difficult to tell which Pokemon have which modifiers during double battles especially if they share the same icons. This helps differentiate them, allowing the player to make the same quality of decisions as they do in double battles with different Pokemon. 

## What did change?
- src/modifier/modifiers.ts : Each PokemonHeldItemModifier container (item, Pokemon, stack count) is now named with the pokemon's unique ID. The battle-scene class objects ModifierBar and EnemyModiferBar are made of such containers. This allows for Pokemon-specific interactions with the contents of ModifierBar/EnemyModifierBar without altering the whole container. 
- src/ui/target-select-ui-handler.ts: Functions that incorporate the target Pokemon's held items into the flashing animation + added a loop delay to decrease the resulting fast rate of the animation 
- src/battle-scene.ts : getModifierBar() now can take an optional parameter that returns the enemyModifierBar. This adjustment is necessary because enemyModifierBar is a private variable

### Screenshots/Videos
https://github.com/user-attachments/assets/40ce8ebf-b723-4e83-8d4a-c1782e4705f0

## How to test the changes?
I used overrides.ts to set an artificially high floor in Endless mode. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
