### PR TITLE
[Test] Fix test RNG

### DIFF
--- a/src/test/moves/hyper_beam.test.ts
+++ b/src/test/moves/hyper_beam.test.ts
@@ -33,6 +33,7 @@ describe("Moves - Hyper Beam", () => {
     game.override.enemySpecies(Species.SNORLAX);
     game.override.enemyAbility(Abilities.BALL_FETCH);
     game.override.enemyMoveset(Array(4).fill(Moves.SPLASH));
+    game.override.enemyLevel(100);
 
     game.override.moveset([Moves.HYPER_BEAM, Moves.TACKLE]);
     vi.spyOn(allMoves[Moves.HYPER_BEAM], "accuracy", "get").mockReturnValue(100);

--- a/src/test/moves/purify.test.ts
+++ b/src/test/moves/purify.test.ts
@@ -7,6 +7,8 @@ import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
+import { mockTurnOrder } from "../utils/testUtils";
+import { BattlerIndex } from "#app/battle.js";
 
 const TIMEOUT = 20 * 1000;
 
@@ -49,6 +51,7 @@ describe("Moves - Purify", () => {
       enemyPokemon.status = new Status(StatusEffect.BURN);
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.PURIFY));
+      await mockTurnOrder(game, [BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
       await game.phaseInterceptor.to(MoveEndPhase);
 
       expect(enemyPokemon.status).toBeNull();
@@ -68,6 +71,7 @@ describe("Moves - Purify", () => {
       const playerInitialHp = playerPokemon.hp;
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.PURIFY));
+      await mockTurnOrder(game, [BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
       await game.phaseInterceptor.to(MoveEndPhase);
 
       expect(playerPokemon.hp).toBe(playerInitialHp);


### PR DESCRIPTION
## What are the changes?
There are no user-facing changes.

## Why am I doing these changes?
There is RNG in the tests.

## What did change?
Turn order is mocked in the Purify test, and the enemy is set to level 100 in the Hyper Beam test to prevent it from fainting.

## How to test the changes?
`npm run test hyper_beam`
`npm run test purify`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
