### PR TITLE
[Bug] DNA-splicer broken

### DIFF
--- a/src/data/status-effect.ts
+++ b/src/data/status-effect.ts
@@ -115,11 +115,11 @@ export function getRandomStatusEffect(statusEffectA: StatusEffect, statusEffectB
 * @param statusA The first Status
 * @param statusB The second Status
 */
-export function getRandomStatus(statusA: Status, statusB: Status): Status {
-  if (statusA === undefined || statusA.effect === StatusEffect.NONE || statusA.effect === StatusEffect.FAINT) {
+export function getRandomStatus(statusA: Status | null, statusB: Status | null): Status | null {
+  if (!statusA || statusA.effect === StatusEffect.NONE || statusA.effect === StatusEffect.FAINT) {
     return statusB;
   }
-  if (statusB === undefined || statusB.effect === StatusEffect.NONE || statusB.effect === StatusEffect.FAINT) {
+  if (!statusB || statusB.effect === StatusEffect.NONE || statusB.effect === StatusEffect.FAINT) {
     return statusA;
   }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3614,7 +3614,7 @@ export class PlayerPokemon extends Pokemon {
       if (!this.isFainted()) {
         // If this Pokemon hasn't fainted, make sure the HP wasn't set over the new maximum
         this.hp = Math.min(this.hp, this.stats[Stat.HP]);
-        this.status = getRandomStatus(this.status!, pokemon.status!); // Get a random valid status between the two  // TODO: are the bangs correct?
+        this.status = getRandomStatus(this.status, pokemon.status); // Get a random valid status between the two
       } else if (!pokemon.isFainted()) {
         // If this Pokemon fainted but the other hasn't, make sure the HP wasn't set to zero
         this.hp = Math.max(this.hp, 1);


### PR DESCRIPTION
## What are the changes?

Fix `getRandomStatus` to check for `null` and `undefined` (not just `undefined`) thus DNA-splicer works again.

## Why am I doing these changes?

### before
`Starkrieg` reported [on discord](https://discord.com/channels/1125469663833370665/1245857678991822879/1271285637278072928) that dna-splicing is broken.
This was caused by the introduction of `strict-null`.

### Screenshots/Videos

![starkrieg discord image](https://media.discordapp.net/attachments/1245857678991822879/1271285637290397746/image.png?ex=66b6c883&is=66b57703&hm=c2f32396f774e2fec3551268f6d96615e73c92ca05bad61ba833eff1ed7ec9cc&=&format=webp&quality=lossless&width=2268&height=582)
<sub>But this was fixed now</sub>

## How to test the changes?
- Use [sessionData_starkrieg (4).txt](https://github.com/user-attachments/files/16555820/sessionData_starkrieg.4.txt)
session-data (change file-extension to `.prsv`
- Import it into a slot
- Run the game
- try to use DNA-splicer => should work

try the same on `beta` (not PR branch) => console.error

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
