### PR TITLE
[Bug][Localhost] fix Json parse issue when trying to load battle-anim

### DIFF
--- a/src/data/battle-anims.ts
+++ b/src/data/battle-anims.ts
@@ -485,7 +485,8 @@ export function initMoveAnim(scene: BattleScene, move: Moves): Promise<void> {
       const fetchAnimAndResolve = (move: Moves) => {
         scene.cachedFetch(`./battle-anims/${moveName}.json`)
           .then(response => {
-            if (!response.ok) {
+            const contentType = response.headers.get("content-type");
+            if (!response.ok || contentType?.indexOf("application/json") === -1) {
               console.error(`Could not load animation file for move '${moveName}'`, response.status, response.statusText);
               populateMoveAnim(move, moveAnims.get(defaultMoveAnim));
               return resolve();

--- a/src/test/utils/gameWrapper.ts
+++ b/src/test/utils/gameWrapper.ts
@@ -242,6 +242,7 @@ function createFetchResponse(data) {
   return {
     ok: true,
     status: 200,
+    headers: new Headers(),
     json: () => Promise.resolve(data),
     text: () => Promise.resolve(JSON.stringify(data)),
   };
@@ -251,6 +252,7 @@ function createFetchBadResponse(data) {
   return {
     ok: false,
     status: 404,
+    headers: new Headers(),
     json: () => Promise.resolve(data),
     text: () => Promise.resolve(JSON.stringify(data)),
   };

--- a/src/test/utils/mocks/mockFetch.ts
+++ b/src/test/utils/mocks/mockFetch.ts
@@ -23,10 +23,13 @@ export const MockFetch = (input, init) => {
     }
   }
 
-  return Promise.resolve({
+  const response: Partial<Response> = {
     ok: true,
     status: 200,
     json: responseHandler,
     text: responseText,
-  });
+    headers: new Headers({}),
+  };
+
+  return Promise.resolve(response);
 };


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?

when loading battle-anim files the content-type of the response is checked too (not just `response.ok`)

## Why am I doing these changes?

Sometimes the local deployment soft-locks the user when trying to load a non existing battle-anim json file. This is annoying.

## What did change?

It now checks the `content-type` of the response. If it doesn't contain `application/json` it's considered FAILED too

## How to test the changes?
idk. Just play and see that it doesn't occur anymore? I'm not sure how to 100% reproduce the issue

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
