### PR TITLE
[Bug] Immediately update the passive background upon unlocking

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1629,6 +1629,8 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
                       this.setUpgradeAnimation(starterContainer.icon, this.lastSpecies, true);
                     }
 
+                    starterContainer.starterPassiveBgs.setVisible(!!this.scene.gameData.starterData[this.lastSpecies.speciesId].passiveAttr);
+
                     return true;
                   }
                   return false;


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
- Now, when a passive ability is unlocked, the passive background is immediately displayed.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
- Because I like it. (You do too, right?)

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- Upon unlocking a passive ability, `starterPassiveBgs` is now immediately set to visible.
- Previously, this was only updated during a scroll check.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
- before ( after unlock passive, update passive background when press up or down key )

https://github.com/user-attachments/assets/a4fc8229-e5d7-40ec-982f-95038e0bf7bb

- after ( update passive background Immediately )

https://github.com/user-attachments/assets/2e0b0d8f-a676-4b13-8f68-1769ffda1692



## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
