### PR TITLE
[Enhancement] Add "open filter" button for mobile touch pad

### DIFF
--- a/index.css
+++ b/index.css
@@ -69,7 +69,9 @@ input:-internal-autofill-selected {
   --controls-padding: 1rem;
 
   --controls-size-with-padding: calc(var(--controls-size) + var(--controls-padding));
+  --controls-size-with-wide-padding: calc(var(--controls-size) *1.2 + var(--controls-padding));
   --control-group-extra-size: calc(var(--controls-size) * 0.8);
+  --control-group-extra-wide-size: calc(var(--controls-size) * 1.2);
 
   --control-group-extra-2-offset: calc(var(--controls-size-with-padding) + (var(--controls-size) - var(--control-group-extra-size)) / 2);
   --control-group-extra-1-offset: calc(var(--controls-padding) + (var(--controls-size) - var(--control-group-extra-size)) / 2);
@@ -117,25 +119,31 @@ input:-internal-autofill-selected {
   width: var(--control-group-extra-size);
   height: var(--control-group-extra-size);
 }
+
 /* Hide buttons on specific UIs */
 
-/* Show #cycleForm and #cycleShiny only on STARTER_SELECT and SETTINGS */
-#touchControls:not([data-ui-mode='STARTER_SELECT']):not([data-ui-mode^='SETTINGS']) #apadCycleForm,
-#touchControls:not([data-ui-mode='STARTER_SELECT']):not([data-ui-mode^='SETTINGS']) #apadCycleShiny {
+/* Show #apadPreviousTab and #apadNextTab only in settings, except in touch configuration panel */
+#touchControls:not([data-ui-mode^='SETTINGS']) #apadPreviousTab,
+#touchControls:not([data-ui-mode^='SETTINGS']) #apadNextTab,
+#touchControls:is(.config-mode) #apadPreviousTab,
+#touchControls:is(.config-mode) #apadNextTab {
   display: none;
 }
 
 /* Show #apadInfo only in battle */
-#touchControls:not([data-ui-mode='COMMAND']):not([data-ui-mode='FIGHT']):not([data-ui-mode='BALL']) #apadInfo {
+#touchControls:not([data-ui-mode='COMMAND']):not([data-ui-mode='FIGHT']):not([data-ui-mode='BALL']):not([data-ui-mode='TARGET_SELECT']) #apadInfo {
   display: none;
 }
 
-/* Show #apadInfo only in battle and target select */
+/* Show #apadStats only in battle and shop */
 #touchControls:not([data-ui-mode='COMMAND']):not([data-ui-mode='FIGHT']):not([data-ui-mode='BALL']):not([data-ui-mode='TARGET_SELECT']):not([data-ui-mode='MODIFIER_SELECT']) #apadStats {
   display: none;
 }
 
 /* Show cycle buttons only on STARTER_SELECT and on touch configuration panel */
+#touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT']) #apadOpenFilters,
+#touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT']) #apadCycleForm,
+#touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT']) #apadCycleShiny,
 #touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT']) #apadCycleNature,
 #touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT']) #apadCycleAbility,
 #touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT']) #apadCycleGender,
@@ -272,8 +280,8 @@ input:-internal-autofill-selected {
 }
 
 #control-group-cancel {
-  right: var(--controls-size-with-padding);
-  bottom: var(--controls-padding);;
+  right: var(--controls-size-with-wide-padding);
+  bottom: var(--controls-padding);
 }
 
 #control-group-extra-1 {
@@ -282,6 +290,7 @@ input:-internal-autofill-selected {
 }
 
 #control-group-extra-2 {
+  width: var(--control-group-extra-wide-size);
   right: var(--control-group-extra-2-offset);
   bottom: var(--control-group-extra-2-offset);
 }

--- a/index.html
+++ b/index.html
@@ -96,26 +96,33 @@
 			</div>
 
 			<div id="control-group-extra-1" class="control-group control-group-extra">
-				<div id="apadCycleShiny" class="apad-button apad-square apad-small" data-key="CYCLE_SHINY">
+				<!-- buttons to navigate settings tabs -->
+				<div id="apadPreviousTab" class="apad-button apad-square apad-small" data-key="CYCLE_FORM">
+					<span class="apad-label">F</span>
+				</div>
+				<div id="apadNextTab" class="apad-button apad-square apad-small" data-key="CYCLE_SHINY">
 					<span class="apad-label">R</span>
 				</div>
-				<div id="apadCycleVariant" class="apad-button apad-square apad-small" data-key="V">
-					<span class="apad-label">V</span>
-				</div>
-				<div id="apadStats" class="apad-button apad-rectangle apad-small" data-key="STATS">
+				<!-- buttons to open filter menu in starter select -->
+				<div id="apadOpenFilters" class="apad-button apad-rectangle apad-small" data-key="STATS">
 					<span class="apad-label">C</span>
 				</div>
+				<!-- main menu button -->
 				<div id="apadMenu" class="apad-button apad-rectangle apad-small" data-key="MENU">
 					<span class="apad-label">Menu</span>
 				</div>
 			</div>
 
 			<div id="control-group-extra-2" class="control-group control-group-extra">
+				<!-- buttons to cycle through pokemon characteristics in starter select -->
 				<div id="apadCycleForm" class="apad-button apad-square apad-small" data-key="CYCLE_FORM">
 					<span class="apad-label">F</span>
 				</div>
 				<div id="apadCycleGender" class="apad-button apad-square apad-small" data-key="CYCLE_GENDER">
 					<span class="apad-label">G</span>
+				</div>
+				<div id="apadCycleShiny" class="apad-button apad-square apad-small" data-key="CYCLE_SHINY">
+					<span class="apad-label">R</span>
 				</div>
 				<div id="apadCycleAbility" class="apad-button apad-square apad-small" data-key="CYCLE_ABILITY">
 					<span class="apad-label">E</span>
@@ -123,8 +130,15 @@
 				<div id="apadCycleNature" class="apad-button apad-square apad-small" data-key="CYCLE_NATURE">
 					<span class="apad-label">N</span>
 				</div>
+				<div id="apadCycleVariant" class="apad-button apad-square apad-small" data-key="V">
+					<span class="apad-label">V</span>
+				</div>
+				<!-- buttons to display battle-specific information -->
 				<div id="apadInfo" class="apad-button apad-rectangle apad-small" data-key="V">
 					<span class="apad-label">V</span>
+				</div>
+				<div id="apadStats" class="apad-button apad-rectangle apad-small" data-key="STATS">
+					<span class="apad-label">C</span>
 				</div>
 			</div>
 


### PR DESCRIPTION
## What are the changes?
This PR adds the button to open filter in starter select UI on the mobile touchpad
The touchpad layout was also updated in a few other spots

## Why am I doing these changes?
PR #3345 added a shortcut in the starter select UI to open the filters, but the corresponding button was not available in the touchpad layout for that screen.
In some screens like settings and battle some of buttons that did similar things were located in separate containers, making their use less intuitive especially if the button layout is modified thanks to PR #3256  

## What did change?
* Starter Select: Move all 6 "cycle" buttons next to each other and add the Filter shortcut button where the Shiny and Variant cycle buttons were before

* Battle: Move both buttons to show battle info next to each other

* Settings: Move both buttons to navigate the tabs next to each other

* Touch Control Navigation: Make sure the biggest size possible of the containers is shown

### Screenshots/Videos

Note: for the screenshots and videos, please disregard the fact that the label on the buttons is not centered vertically properly. This has been introduced with PR #3256 but only seems to happen when simulating a mobile device in my browser. All seems fine in this regard on my actual phone as well as those of a few other people who tested it

Starter Select Before: 

https://github.com/user-attachments/assets/e583a436-879f-4eec-868d-84e32ff92b26

Starter Select After: 

https://github.com/user-attachments/assets/8531c6bc-e5a5-495f-91e7-d8314b7af4ff


Battle before: 
![__battle_before](https://github.com/user-attachments/assets/f0fbb8c6-dd69-41ed-b212-7ce5537e2ed4)

Battle after:
![_battle_after](https://github.com/user-attachments/assets/428f7323-f4bd-46f5-96fa-d2252e92bc7b)

Settings before:
![__settings_inter](https://github.com/user-attachments/assets/0fe65eb8-1506-4f69-b4e2-7ccd6dbc8242)

Settings after: 
![__settings_after2](https://github.com/user-attachments/assets/34efacc6-e698-46b3-9106-9b0abed6f4a3)

Touch configuration before:

https://github.com/user-attachments/assets/f2efd48c-112a-472b-a8a8-3dfefb73f1fb

Touch configuration after:

https://github.com/user-attachments/assets/832ba245-384b-4cff-981f-67d05f3fa3ba


## How to test the changes?
* From your browser, enable the adaptative view to see the touch controls
* Ideally, run the game with --host option and try it out on a mobile device
* Try to go to various states of the game (menus, settings, battle, shop, starter select) and see that the proper buttons are shown every time
* In starter select, try accessing the filters via the new C button

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
