### PR TITLE
[Bug] [3485] Prevent Destiny Bond to be used twice in a row

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5838,6 +5838,18 @@ export class DestinyBondAttr extends MoveEffectAttr {
   constructor() {
     super(true, MoveEffectTrigger.PRE_APPLY);
   }
+  getCondition(): MoveConditionFunc {
+    return (user: Pokemon, target: Pokemon, move: Move) => {
+      const moves = user.getMoveHistory();
+      if (moves.length > 0) {
+        const lastMove = moves[moves.length - 1];
+        if (lastMove.move === move.id && lastMove.result === MoveResult.SUCCESS) {
+          return false;
+        }
+      }
+      return true;
+    };
+  }
 
   /**
    * Applies {@linkcode BattlerTagType.DESTINY_BOND} to the user.


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

FYI: my first PR here, please let me know if I made any mistakes about format

## What are the changes?
Adds a condition to the Destiny Bond ability

## Why am I doing these changes?
[Issue 3485](https://github.com/pagefaultgames/pokerogue/issues/3485)

## What did change?
Destiny Bond cannot be used twice in a row if successful the first time

### Screenshots/Videos

https://github.com/user-attachments/assets/67501689-fe8d-4db1-a99c-907ddab18850



## How to test the changes?
I start a new game with Wobbuffet and use Destiny Bond twice in a row in the first fight

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
