### PR TITLE
[QoL][UI] Add cursor wrap around to option select menus

### DIFF
--- a/src/ui/abstact-option-select-ui-handler.ts
+++ b/src/ui/abstact-option-select-ui-handler.ts
@@ -197,11 +197,15 @@ export default abstract class AbstractOptionSelectUiHandler extends UiHandler {
       case Button.UP:
         if (this.cursor) {
           success = this.setCursor(this.cursor - 1);
+        } else if (this.cursor === 0) {
+          success = this.setCursor(options.length -1);
         }
         break;
       case Button.DOWN:
         if (this.cursor < options.length - 1) {
           success = this.setCursor(this.cursor + 1);
+        } else {
+          success = this.setCursor(0);
         }
         break;
       }
@@ -268,11 +272,13 @@ export default abstract class AbstractOptionSelectUiHandler extends UiHandler {
     let isScroll = false;
     const options = this.getOptionsWithScroll();
     if (changed && this.config?.maxOptions && this.config.options.length > this.config.maxOptions) {
-      const optionsScrollTotal = options.length;
       if (Math.abs(cursor - this.cursor) === options.length - 1) {
+        // Wrap around the list
+        const optionsScrollTotal = this.config.options.length;
         this.scrollCursor = cursor ? optionsScrollTotal - (this.config.maxOptions - 1) : 0;
         this.setupOptions();
       } else {
+        // Move the cursor up or down by 1
         const isDown = cursor && cursor > this.cursor;
         if (isDown) {
           if (options[cursor].label === scrollDownLabel) {


### PR DESCRIPTION
## What are the changes?
Enable cursor wrap around for some menus that didn't have it

## Why am I doing these changes?
Some menus especially in the starter select UI are starting to have a lot of options and not being able to wrap around quickly to the top or bottom is annoying.
Closes issue #3218 

## What did change?
Update the `AbstractOptionSelectUiHandler` to enable cursor wrap around. All of the following menus that didn't have them now have it (there may be more):
- Opening menu
- Main menu: Manage Data / Import Session / Export Session
- Settings: Language choice / Controller choice
- All Yes/No menus
- Game mode choice
- Starter UI: Pokemon menu
- Starter UI: Manage Nature menu
- Starter UI: Manage Move menus (menu with current moves and menu with moves to pick from)
- Starter UI: Use Candies menu

Note:
Since all menus in the game don't necessarily use that handler class it's possible that some still don't wrap around. It might be good to make an inventory of these at some point

### Screenshots/Videos

https://github.com/user-attachments/assets/de6f6e60-c07f-44ed-85a3-fda7b30523c8


## How to test the changes?
Run the game and try to wrap around in as many menus as possible, including those with potentially a lot of options like the Manage Nature menu in stater select ui

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
