### PR TITLE
[Test] Fix Flash Fire tests to remove enemy ability RNG

### DIFF
--- a/src/test/abilities/flash_fire.test.ts
+++ b/src/test/abilities/flash_fire.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { SPLASH_ONLY } from "#test/utils/testUtils";
 import { MovePhase, TurnEndPhase } from "#app/phases";
 import { getMovePosition } from "#test/utils/gameManagerUtils";
-import { Status, StatusEffect } from "#app/data/status-effect.js";
+import { StatusEffect } from "#app/data/status-effect.js";
 import { BattlerTagType } from "#app/enums/battler-tag-type.js";
 import { BattlerIndex } from "#app/battle.js";
 
@@ -76,12 +76,10 @@ describe("Abilities - Flash Fire", () => {
 
   it("activated after being frozen", async() => {
     game.override.enemyMoveset(Array(4).fill(Moves.EMBER)).moveset(SPLASH_ONLY);
+    game.override.statusEffect(StatusEffect.FREEZE);
     await game.startBattle([Species.BLISSEY]);
 
     const blissey = game.scene.getPlayerPokemon()!;
-
-    blissey!.status = new Status(StatusEffect.FREEZE);
-    expect(blissey.status?.effect).toBe(StatusEffect.FREEZE);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
 

--- a/src/test/abilities/flash_fire.test.ts
+++ b/src/test/abilities/flash_fire.test.ts
@@ -30,6 +30,7 @@ describe("Abilities - Flash Fire", () => {
     game.override
       .battleType("single")
       .ability(Abilities.FLASH_FIRE)
+      .enemyAbility(Abilities.BALL_FETCH)
       .startingLevel(20)
       .enemyLevel(20)
       .disableCrits();


### PR DESCRIPTION
## What are the changes?
There are no user-facing changes.

## Why am I doing these changes?
[Test randomly broke](https://github.com/pagefaultgames/pokerogue/actions/runs/10361460682/job/28681819652?pr=3513).

## What did change?
Enemy ability is now specified/locked in the test.

## How to test the changes?
`npm run test flash_fire`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
