### PR TITLE
[Bug] fix/update invalid `vite.config.ts`

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,27 +1,27 @@
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig, loadEnv, Rollup, UserConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { minifyJsonPlugin } from "./src/plugins/vite/vite-minify-json-plugin";
 
-export const defaultConfig = {
+export const defaultConfig: UserConfig  = {
 	plugins: [
-		tsconfigPaths() as any, 
+		tsconfigPaths(), 
 		minifyJsonPlugin(["images", "battle-anims"], true)
 	],
 	clearScreen: false,
+	appType: "mpa",
 	build: {
-		minify: 'esbuild' as const,
+		minify: 'esbuild',
 		sourcemap: false,
-	},
-	rollupOptions: {
-		onwarn(warning, warn) {
-			// Suppress "Module level directives cause errors when bundled" warnings
-			if (warning.code === "MODULE_LEVEL_DIRECTIVE") {
-				return;
-			}
-			warn(warning);
+		rollupOptions: {
+			onwarn(warning: Rollup.RollupLog, defaultHandler: (warning: string | Rollup.RollupLog) => void) {
+				// Suppress "Module level directives cause errors when bundled" warnings
+				if (warning.code === "MODULE_LEVEL_DIRECTIVE") {
+					return;
+				}
+				defaultHandler(warning);
+			},
 		},
 	},
-	appType: "mpa",
 };
 
 


### PR DESCRIPTION
## What are the changes?

Fixing/Updating the existing `vite.config.ts` without changing any of it's behavior

## Why am I doing these changes?

To resolve errors shown in the IDE

## What did change?

Simply adding proper TS types to the objects and fixing the definition object so no more errors are shown in the IDE

## How to test the changes?
1. Open `vite.config.ts`
2. Your IDE shouldn't complain anymore
-----
1. Open `vitest.config.ts`
2. Your IDE shouldn't complain anymore
----
1. open `vitest.workspace.ts`
2. Your IDE shouldn't complain anymore

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [X] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
