### PR TITLE
[Balance] Added Flamethrower to Phase 1 / Endless Eternatus

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3775,7 +3775,7 @@ export class EnemyPokemon extends Pokemon {
         : [
           new PokemonMove(Moves.ETERNABEAM),
           new PokemonMove(Moves.SLUDGE_BOMB),
-          new PokemonMove(Moves.DRAGON_DANCE),
+          new PokemonMove(Moves.FLAMETHROWER),
           new PokemonMove(Moves.COSMIC_POWER)
         ];
       break;


### PR DESCRIPTION
## What are the changes?
Added Flamethrower > Dragon Dance on Eternatus Phase 1 Boss.

## Why am I doing these changes?
Meant to change this for a while, no one ever bothered putting a PR up for it.

## What did change?
Dragon Dance on Phase 1 Eternatus -> Flamethrower so both phases have it

## Screenshots/Videos
![image](https://github.com/user-attachments/assets/f3091050-710b-4d90-959f-cd8d42cfc0e6)

## How to test the changes?
Get to the end of a classic run, send out a fairy/steel type, if it uses Flamethrower then it works.

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
