### PR TITLE
[Balance] [QoL] Allow Pirouette Meloetta to be selectable on starter screen

### DIFF
--- a/src/data/pokemon-forms.ts
+++ b/src/data/pokemon-forms.ts
@@ -632,7 +632,6 @@ export const pokemonFormChanges: PokemonFormChanges = {
   [Species.MELOETTA]: [
     new SpeciesFormChange(Species.MELOETTA, "aria", "pirouette", new SpeciesFormChangePostMoveTrigger(Moves.RELIC_SONG), true),
     new SpeciesFormChange(Species.MELOETTA, "pirouette", "aria", new SpeciesFormChangePostMoveTrigger(Moves.RELIC_SONG), true),
-    new SpeciesFormChange(Species.MELOETTA, "pirouette", "aria", new SpeciesFormChangeActiveTrigger(false), true)
   ],
   [Species.GENESECT]: [
     new SpeciesFormChange(Species.GENESECT, "", "shock", new SpeciesFormChangeItemTrigger(FormChangeItem.SHOCK_DRIVE)),

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -1870,7 +1870,7 @@ export function initSpecies() {
     ),
     new PokemonSpecies(Species.MELOETTA, 5, false, false, true, "Melody Pokémon", Type.NORMAL, Type.PSYCHIC, 0.6, 6.5, Abilities.SERENE_GRACE, Abilities.NONE, Abilities.NONE, 600, 100, 77, 77, 128, 128, 90, 3, 100, 270, GrowthRate.SLOW, null, false, true,
       new PokemonForm("Aria Forme", "aria", Type.NORMAL, Type.PSYCHIC, 0.6, 6.5, Abilities.SERENE_GRACE, Abilities.NONE, Abilities.NONE, 600, 100, 77, 77, 128, 128, 90, 3, 100, 270, false, null, true),
-      new PokemonForm("Pirouette Forme", "pirouette", Type.NORMAL, Type.FIGHTING, 0.6, 6.5, Abilities.SERENE_GRACE, Abilities.NONE, Abilities.NONE, 600, 100, 128, 90, 77, 77, 128, 3, 100, 270),
+      new PokemonForm("Pirouette Forme", "pirouette", Type.NORMAL, Type.FIGHTING, 0.6, 6.5, Abilities.SERENE_GRACE, Abilities.NONE, Abilities.NONE, 600, 100, 128, 90, 77, 77, 128, 3, 100, 270, false, null, true),
     ),
     new PokemonSpecies(Species.GENESECT, 5, false, false, true, "Paleozoic Pokémon", Type.BUG, Type.STEEL, 1.5, 82.5, Abilities.DOWNLOAD, Abilities.NONE, Abilities.NONE, 600, 71, 120, 95, 120, 95, 99, 3, 0, 300, GrowthRate.SLOW, null, false, true,
       new PokemonForm("Normal", "", Type.BUG, Type.STEEL, 1.5, 82.5, Abilities.DOWNLOAD, Abilities.NONE, Abilities.NONE, 600, 71, 120, 95, 120, 95, 99, 3, 0, 300, false, null, true),

--- a/src/locales/ca_ES/pokemon-form.ts
+++ b/src/locales/ca_ES/pokemon-form.ts
@@ -88,6 +88,7 @@ export const pokemonForm: SimpleTranslationEntries = {
   "landorusIncarnate": "Incarnate",
   "keldeoOrdinary": "Ordinary",
   "meloettaAria": "Aria",
+  "meloettaPirouette": "Pirouette",
   // 6G
   "froakieBattleBond": "Battle Bond",
   "scatterbugMeadow": "Meadow",

--- a/src/locales/de/pokemon-form.ts
+++ b/src/locales/de/pokemon-form.ts
@@ -89,6 +89,7 @@ export const pokemonForm: SimpleTranslationEntries = {
   "landorusIncarnate": "Inkarnationsform",
   "keldeoOrdinary": "Standardform",
   "meloettaAria": "Gesangsform",
+  "meloettaPirouette": "Pirouette",
   // 6G
   "froakieBattleBond": "Ash-Form",
   "scatterbugMeadow": "Blumenmeermuster",

--- a/src/locales/de/pokemon-form.ts
+++ b/src/locales/de/pokemon-form.ts
@@ -89,7 +89,7 @@ export const pokemonForm: SimpleTranslationEntries = {
   "landorusIncarnate": "Inkarnationsform",
   "keldeoOrdinary": "Standardform",
   "meloettaAria": "Gesangsform",
-  "meloettaPirouette": "Pirouette",
+  "meloettaPirouette": "Tanzform",
   // 6G
   "froakieBattleBond": "Ash-Form",
   "scatterbugMeadow": "Blumenmeermuster",

--- a/src/locales/en/pokemon-form.ts
+++ b/src/locales/en/pokemon-form.ts
@@ -88,6 +88,7 @@ export const pokemonForm: SimpleTranslationEntries = {
   "landorusIncarnate": "Incarnate",
   "keldeoOrdinary": "Ordinary",
   "meloettaAria": "Aria",
+  "meloettaPirouette": "Pirouette",
   // 6G
   "froakieBattleBond": "Battle Bond",
   "scatterbugMeadow": "Meadow",

--- a/src/locales/es/pokemon-form.ts
+++ b/src/locales/es/pokemon-form.ts
@@ -88,6 +88,7 @@ export const pokemonForm: SimpleTranslationEntries = {
   "landorusIncarnate": "Incarnate",
   "keldeoOrdinary": "Ordinary",
   "meloettaAria": "Aria",
+  "meloettaPirouette": "Pirouette", 
   // 6G
   "froakieBattleBond": "Fuerte Afecto",
   "scatterbugMeadow": "Floral",

--- a/src/locales/es/pokemon-form.ts
+++ b/src/locales/es/pokemon-form.ts
@@ -88,7 +88,7 @@ export const pokemonForm: SimpleTranslationEntries = {
   "landorusIncarnate": "Incarnate",
   "keldeoOrdinary": "Ordinary",
   "meloettaAria": "Lírica",
-  "meloettaPirouette": "Danza", 
+  "meloettaPirouette": "Danza",
   // 6G
   "froakieBattleBond": "Fuerte Afecto",
   "scatterbugMeadow": "Floral",

--- a/src/locales/es/pokemon-form.ts
+++ b/src/locales/es/pokemon-form.ts
@@ -87,8 +87,8 @@ export const pokemonForm: SimpleTranslationEntries = {
   "thundurusIncarnate": "Incarnate",
   "landorusIncarnate": "Incarnate",
   "keldeoOrdinary": "Ordinary",
-  "meloettaAria": "Aria",
-  "meloettaPirouette": "Pirouette", 
+  "meloettaAria": "Lírica",
+  "meloettaPirouette": "Danza", 
   // 6G
   "froakieBattleBond": "Fuerte Afecto",
   "scatterbugMeadow": "Floral",

--- a/src/locales/fr/pokemon-form.ts
+++ b/src/locales/fr/pokemon-form.ts
@@ -88,7 +88,7 @@ export const pokemonForm: SimpleTranslationEntries = {
   "landorusIncarnate": "Avatar",
   "keldeoOrdinary": "Normal",
   "meloettaAria": "Chant",
-  "meloettaPirouette": "Pirouette",
+  "meloettaPirouette": "Danse",
   // 6G
   "froakieBattleBond": "Synergie",
   "scatterbugMeadow": "Floraison",

--- a/src/locales/fr/pokemon-form.ts
+++ b/src/locales/fr/pokemon-form.ts
@@ -88,6 +88,7 @@ export const pokemonForm: SimpleTranslationEntries = {
   "landorusIncarnate": "Avatar",
   "keldeoOrdinary": "Normal",
   "meloettaAria": "Chant",
+  "meloettaPirouette": "Pirouette",
   // 6G
   "froakieBattleBond": "Synergie",
   "scatterbugMeadow": "Floraison",

--- a/src/locales/it/pokemon-form.ts
+++ b/src/locales/it/pokemon-form.ts
@@ -88,6 +88,7 @@ export const pokemonForm: SimpleTranslationEntries = {
   "landorusIncarnate": "Incarnazione",
   "keldeoOrdinary": "Normale",
   "meloettaAria": "Canto",
+  "meloettaPirouette": "Pirouette",
   // 6G
   "froakieBattleBond": "Morfosintonia",
   "scatterbugMeadow": "Giardinfiore",

--- a/src/locales/it/pokemon-form.ts
+++ b/src/locales/it/pokemon-form.ts
@@ -88,7 +88,7 @@ export const pokemonForm: SimpleTranslationEntries = {
   "landorusIncarnate": "Incarnazione",
   "keldeoOrdinary": "Normale",
   "meloettaAria": "Canto",
-  "meloettaPirouette": "Pirouette",
+  "meloettaPirouette": "Danza",
   // 6G
   "froakieBattleBond": "Morfosintonia",
   "scatterbugMeadow": "Giardinfiore",

--- a/src/locales/ja/pokemon-form.ts
+++ b/src/locales/ja/pokemon-form.ts
@@ -88,6 +88,7 @@ export const pokemonForm: SimpleTranslationEntries = {
   "landorusIncarnate": "Incarnate",
   "keldeoOrdinary": "Ordinary",
   "meloettaAria": "Aria",
+  "meloettaPirouette": "Pirouette",
   // 6G
   "froakieBattleBond": "Battle Bond",
   "scatterbugMeadow": "Meadow",

--- a/src/locales/ko/pokemon-form.ts
+++ b/src/locales/ko/pokemon-form.ts
@@ -88,6 +88,7 @@ export const pokemonForm: SimpleTranslationEntries = {
   "landorusIncarnate": "화신폼",
   "keldeoOrdinary": "평상시 모습",
   "meloettaAria": "보이스폼",
+  "meloettaPirouette": "Pirouette",
   // 6G
   "froakieBattleBond": "유대변화",
   "scatterbugMeadow": "화원의 모양",

--- a/src/locales/ko/pokemon-form.ts
+++ b/src/locales/ko/pokemon-form.ts
@@ -88,7 +88,7 @@ export const pokemonForm: SimpleTranslationEntries = {
   "landorusIncarnate": "화신폼",
   "keldeoOrdinary": "평상시 모습",
   "meloettaAria": "보이스폼",
-  "meloettaPirouette": "Pirouette",
+  "meloettaPirouette": "스텝폼",
   // 6G
   "froakieBattleBond": "유대변화",
   "scatterbugMeadow": "화원의 모양",

--- a/src/locales/pt_BR/pokemon-form.ts
+++ b/src/locales/pt_BR/pokemon-form.ts
@@ -89,7 +89,7 @@ export const pokemonForm: SimpleTranslationEntries = {
   "landorusIncarnate": "Incarnate",
   "keldeoOrdinary": "Ordinary",
   "meloettaAria": "Aria",
-  "meloettaPirouette": "Pirouette",
+  "meloettaPirouette": "Pirueta",
   // 6G
   "froakieBattleBond": "Vínculo de Batalha",
   "scatterbugMeadow": "Prado",

--- a/src/locales/pt_BR/pokemon-form.ts
+++ b/src/locales/pt_BR/pokemon-form.ts
@@ -89,6 +89,7 @@ export const pokemonForm: SimpleTranslationEntries = {
   "landorusIncarnate": "Incarnate",
   "keldeoOrdinary": "Ordinary",
   "meloettaAria": "Aria",
+  "meloettaPirouette": "Pirouette",
   // 6G
   "froakieBattleBond": "Vínculo de Batalha",
   "scatterbugMeadow": "Prado",

--- a/src/locales/zh_CN/pokemon-form.ts
+++ b/src/locales/zh_CN/pokemon-form.ts
@@ -88,6 +88,7 @@ export const pokemonForm: SimpleTranslationEntries = {
   "landorusIncarnate": "化身",
   "keldeoOrdinary": "通常",
   "meloettaAria": "歌声",
+  "meloettaPirouette": "Pirouette",
   // 6G
   "froakieBattleBond": "牵绊变身",
   "scatterbugMeadow": "花园花纹",

--- a/src/locales/zh_TW/pokemon-form.ts
+++ b/src/locales/zh_TW/pokemon-form.ts
@@ -88,6 +88,7 @@ export const pokemonForm: SimpleTranslationEntries = {
   "landorusIncarnate": "Incarnate",
   "keldeoOrdinary": "Ordinary",
   "meloettaAria": "Aria",
+  "meloettaPirouette": "Pirouette",
   // 6G
   "froakieBattleBond": "Battle Bond",
   "scatterbugMeadow": "Meadow",

--- a/src/test/abilities/flash_fire.test.ts
+++ b/src/test/abilities/flash_fire.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { SPLASH_ONLY } from "#test/utils/testUtils";
 import { MovePhase, TurnEndPhase } from "#app/phases";
 import { getMovePosition } from "#test/utils/gameManagerUtils";
-import { Status, StatusEffect } from "#app/data/status-effect.js";
+import { StatusEffect } from "#app/data/status-effect.js";
 import { BattlerTagType } from "#app/enums/battler-tag-type.js";
 import { BattlerIndex } from "#app/battle.js";
 
@@ -30,6 +30,7 @@ describe("Abilities - Flash Fire", () => {
     game.override
       .battleType("single")
       .ability(Abilities.FLASH_FIRE)
+      .enemyAbility(Abilities.BALL_FETCH)
       .startingLevel(20)
       .enemyLevel(20)
       .disableCrits();
@@ -75,12 +76,10 @@ describe("Abilities - Flash Fire", () => {
 
   it("activated after being frozen", async() => {
     game.override.enemyMoveset(Array(4).fill(Moves.EMBER)).moveset(SPLASH_ONLY);
+    game.override.statusEffect(StatusEffect.FREEZE);
     await game.startBattle([Species.BLISSEY]);
 
     const blissey = game.scene.getPlayerPokemon()!;
-
-    blissey!.status = new Status(StatusEffect.FREEZE);
-    expect(blissey.status?.effect).toBe(StatusEffect.FREEZE);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
Allows Meloetta's Pirouette Form to be selectable on the starter select.

## Why am I doing these changes?
Purely QoL change, Meloetta is not able to use Pirouette to its fullest extent due to the nature of how PokeRogue plays so this allows player further options if they would want to use this Pokemon. As well as setting it free from its previous restriction of wasting a moveslot to use the form.

## What did change?
Pirouette as a selectable form
Meloetta no longer changes forms between biome changes or trainer battles.

### Screenshots/Videos
![image](https://github.com/user-attachments/assets/9268b5c2-bd24-45f2-b992-4c6cec35047c)

## How to test the changes?
Pick Meloetta on the starter select
## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
