### PR TITLE
[Bug] Export Game Data fix

### DIFF
--- a/src/ui/menu-ui-handler.ts
+++ b/src/ui/menu-ui-handler.ts
@@ -224,7 +224,8 @@ export default class MenuUiHandler extends MessageUiHandler {
       handler: () => {
         this.scene.gameData.tryExportData(GameDataType.SYSTEM);
         return true;
-      }
+      },
+      keepOpen: true
     },
     {
       label: "Consent Preferences",


### PR DESCRIPTION
## What are the changes?
Right now, the player cannot close the menu after they export their Game Data. This is because the option lacks a keepOpen: true in its configuration, causing the player to be stuck.

Issue Link: https://github.com/pagefaultgames/pokerogue/issues/3533

## Why am I doing these changes?
It is a straightforward fix that could help with debugging + player experience. 

## What did change?
Export Data's configuration now has keepOpen: true

### Screenshots/Videos
https://github.com/user-attachments/assets/000c6329-f408-41cd-9fbf-f39fe7ff5de2

## How to test the changes?
Export Data > check for freeze. 
Note: there should be a slight pause as the file is downloaded onto device.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
