### PR TITLE
[Bug] Make weather damage round down for consistency

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -3743,7 +3743,7 @@ export class WeatherEffectPhase extends CommonAnimPhase {
             return;
           }
 
-          const damage = Math.ceil(pokemon.getMaxHp() / 16);
+          const damage = Math.floor(pokemon.getMaxHp() / 16);
 
           this.scene.queueMessage(getWeatherDamageMessage(this.weather?.weatherType!, pokemon)!); // TODO: are those bangs correct?
           pokemon.damageAndUpdate(damage, HitResult.EFFECTIVE, false, false, true);


### PR DESCRIPTION
## What are the changes?
Weather damage rounds down now, improving consistency with effects like Leftovers, etc.

## Why am I doing these changes?
![image](https://github.com/user-attachments/assets/2968d71f-fb6f-44b8-9d94-6c539ee9016e)
Pokémon rounds everything down.

## What did change?
Changed `Math.ceil()` to `Math.floor()` in weather damage calculation.

## How to test the changes?
Have a Pokémon with `16n + 1` max HP take damage from a weather effect. Compare damage from before and after the change.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
