### PR TITLE
[Bug] Revert Map Item Table

### DIFF
--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1571,7 +1571,7 @@ const modifierPool: ModifierPool = {
     new WeightedModifierType(modifierTypes.EVOLUTION_ITEM, (party: Pokemon[]) => {
       return Math.min(Math.ceil(party[0].scene.currentBattle.waveIndex / 15), 8);
     }, 8),
-    new WeightedModifierType(modifierTypes.MAP, skipInClassicAfterWave(180, 1)),
+    new WeightedModifierType(modifierTypes.MAP, (party: Pokemon[]) => party[0].scene.gameMode.isClassic && party[0].scene.currentBattle.waveIndex < 180 ? 1 : 0, 1),
     new WeightedModifierType(modifierTypes.TM_GREAT, 3),
     new WeightedModifierType(modifierTypes.MEMORY_MUSHROOM, (party: Pokemon[]) => {
       if (!party.find(p => p.getLearnableLevelMoves().length)) {


### PR DESCRIPTION
## What are the changes?
Reverted changes to map, nothing changes for Classic.

## Why am I doing these changes?
isClassic was removed and allowed it to spawn in Endless.

## What did change?
Reverted line 1574 of src/modifier/modifier-type.ts

### Screenshots/Videos
![image](https://github.com/user-attachments/assets/95a6e47a-2f4d-4486-b5a7-e4be5b8a6f4d)

## How to test the changes?
Play Beta or slap onto your local.

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
