### PR TITLE
[UI/UX][LOCALIZATION] Responsive messages on menu for multiple Languages

### DIFF
--- a/src/locales/ca_ES/menu-ui-handler.ts
+++ b/src/locales/ca_ES/menu-ui-handler.ts
@@ -25,5 +25,5 @@ export const menuUiHandler: SimpleTranslationEntries = {
   "unlinkGoogle": "Unlink Google",
   "cancel": "Cancel",
   "losingProgressionWarning": "You will lose any progress since the beginning of the battle. Proceed?",
-  "noEggs": "You are not hatching\nany eggs at the moment!"
+  "noEggs": "You are not hatching any eggs at the moment!"
 } as const;

--- a/src/locales/en/menu-ui-handler.ts
+++ b/src/locales/en/menu-ui-handler.ts
@@ -25,5 +25,5 @@ export const menuUiHandler: SimpleTranslationEntries = {
   "unlinkGoogle": "Unlink Google",
   "cancel": "Cancel",
   "losingProgressionWarning": "You will lose any progress since the beginning of the battle. Proceed?",
-  "noEggs": "You are not hatching\nany eggs at the moment!"
+  "noEggs": "You are not hatching any eggs at the moment!"
 } as const;

--- a/src/locales/es/menu-ui-handler.ts
+++ b/src/locales/es/menu-ui-handler.ts
@@ -25,5 +25,5 @@ export const menuUiHandler: SimpleTranslationEntries = {
   "unlinkGoogle": "Desconectar Google",
   "cancel": "Cancelar",
   "losingProgressionWarning": "Perderás cualquier progreso desde el inicio de la batalla. ¿Continuar?",
-  "noEggs": "You are not hatching\nany eggs at the moment!"
+  "noEggs": "You are not hatching any eggs at the moment!"
 } as const;

--- a/src/locales/fr/menu-ui-handler.ts
+++ b/src/locales/fr/menu-ui-handler.ts
@@ -25,5 +25,5 @@ export const menuUiHandler: SimpleTranslationEntries = {
   "unlinkGoogle": "Délier Google",
   "cancel": "Retour",
   "losingProgressionWarning": "Vous allez perdre votre progression depuis le début du combat. Continuer ?",
-  "noEggs": "Vous ne faites actuellement\néclore aucun Œuf !"
+  "noEggs": "Vous ne faitesactuellement éclore aucun Œuf !"
 } as const;

--- a/src/locales/it/menu-ui-handler.ts
+++ b/src/locales/it/menu-ui-handler.ts
@@ -25,5 +25,5 @@ export const menuUiHandler: SimpleTranslationEntries = {
   "unlinkGoogle": "Scollega Google",
   "cancel": "Annulla",
   "losingProgressionWarning": "Perderai tutti i progressi dall'inizio della battaglia. Confermi?",
-  "noEggs": "You are not hatching\nany eggs at the moment!"
+  "noEggs": "You are not hatching any eggs at the moment!"
 } as const;

--- a/src/locales/ja/menu-ui-handler.ts
+++ b/src/locales/ja/menu-ui-handler.ts
@@ -25,5 +25,5 @@ export const menuUiHandler: SimpleTranslationEntries = {
   "unlinkGoogle": "Unlink Google",
   "cancel": "キャンセル",
   "losingProgressionWarning": "You will lose any progress since the beginning of the battle. Proceed?",
-  "noEggs": "You are not hatching\nany eggs at the moment!",
+  "noEggs": "You are not hatching any eggs at the moment!",
 } as const;

--- a/src/locales/pt_BR/menu-ui-handler.ts
+++ b/src/locales/pt_BR/menu-ui-handler.ts
@@ -25,5 +25,5 @@ export const menuUiHandler: SimpleTranslationEntries = {
   "unlinkGoogle": "Desconectar Google",
   "cancel": "Cancelar",
   "losingProgressionWarning": "Você vai perder todo o progresso desde o início da batalha. Confirmar?",
-  "noEggs": "Você não está chocando\nnenhum ovo no momento!"
+  "noEggs": "Você não está chocando nenhum ovo no momento!"
 } as const;

--- a/src/locales/zh_CN/menu-ui-handler.ts
+++ b/src/locales/zh_CN/menu-ui-handler.ts
@@ -24,6 +24,6 @@ export const menuUiHandler: SimpleTranslationEntries = {
   "linkGoogle": "关联Google",
   "unlinkGoogle": "解除关联Google",
   "cancel": "取消",
-  "losingProgressionWarning": "你将失去自战斗开始以来的所有进度。\n是否继续？",
-  "noEggs": "当前没有任何蛋\n正在孵化中！"
+  "losingProgressionWarning": "你将失去自战斗开始以来的所有进度。是否继续？",
+  "noEggs": "当前没有任何蛋 正在孵化中！"
 } as const;

--- a/src/locales/zh_TW/menu-ui-handler.ts
+++ b/src/locales/zh_TW/menu-ui-handler.ts
@@ -24,6 +24,6 @@ export const menuUiHandler: SimpleTranslationEntries = {
   "linkGoogle": "Link Google",
   "unlinkGoogle": "Unlink Google",
   "cancel": "取消",
-  "losingProgressionWarning": "你將失去自戰鬥開始以來的所有進度。是否\n繼續？",
-  "noEggs": "You are not hatching\nany eggs at the moment!"
+  "losingProgressionWarning": "你將失去自戰鬥開始以來的所有進度。是否 繼續？",
+  "noEggs": "You are not hatching any eggs at the moment!"
 } as const;


### PR DESCRIPTION
## What are the changes?
Good coupling of the messages container and the menu options container

## Why am I doing these changes?
Mainly, I wanted to couple the containers since it changes depending on the language, but I noticed that the German text was complicated because only the 'losingProgressionWarning' message didn't fit well.

So, instead of making a manual adjustment for each message in each language, I think it's better for it to auto-adjust depending on the message.

## What did change?
- Less the width of menuBg to the necessary elements so they fit correctly.
- Configure wordWrap according to the container.
- When calling showText from `src/ui/menu-ui-handler`, check if the number of line breaks is greater than the limit or if the text width is greater than the container's width; if so, reduce the font size as needed until the condition is met.
- Remove all line breaks ( \n ) from 'losingProgressionWarning' and 'noEggs', as they are not necessary.

### Screenshots/Videos
![DE modals](https://github.com/user-attachments/assets/02f294b8-614c-4a7c-a598-af91554cab8c)

>While I was checking how the texts for 'losingProgressionWarning' and some of 'noEggs' fit for each language, I created a separate branch with screenshots so as not to overload this PR with images: https://github.com/Vassiat/pokerogue/tree/images/multilanguage-support

## Checklist
- [x] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
