### PR TITLE
[Localization] Quick portuguese dialogue fix

### DIFF
--- a/src/locales/pt_BR/dialogue.ts
+++ b/src/locales/pt_BR/dialogue.ts
@@ -2585,8 +2585,8 @@ export const PGMdialogue: DialogueTranslationEntries = {
     "victory": {
       1: `@c{neutral}Eu… não era para eu perder dessa vez…
             $@c{smile}Ah bem. Isso só significa que vou ter que treinar ainda mais para a próxima vez!
-            $@c{smile_wave}Também consegui mais um desses para você!\n@c{smile_wave_wink}Não precisa me agradecer~.
-            $@c{angry_mopen}Este é o último, hein! Você não vai ganhar mais nenhum presente de mim depois desse!
+            $@c{smile_wave}Também consegui mais dois desses para você!\n@c{smile_wave_wink}Não precisa me agradecer~.
+            $@c{angry_mopen}Estes são os últimos, hein! Você não vai ganhar mais nenhum presente de mim depois desse!
             $@c{smile_wave}Continue assim!`
     },
     "defeat": {
@@ -3819,7 +3819,8 @@ export const PGFdialogue: DialogueTranslationEntries = {
       1: `@c{shock}Caramba… Você me limpou.\nVocê é mesmo uma novata?
                 $@c{smile}Talvez tenha sido um pouco de sorte, mas…\nQuem sabe você consiga chegar até o fim.
                 $Aliás, o professor me pediu para te dar esses itens. Eles parecem bem legais.
-                $@c{serious_smile_fists}Boa sorte lá fora!`
+                $@c{serious_smile_fists}Boa sorte lá fora!
+                $@c{smile}Ah- e eu espero que você aproveite o evento!`
     },
   },
   "rival_female": {
@@ -3833,7 +3834,8 @@ export const PGFdialogue: DialogueTranslationEntries = {
       1: `@c{shock}Você acabou de começar e já está tão forte?!@d{96}\n@c{angry}Você trapaceou, não foi?
                 $@c{smile_wave_wink}Brincadeirinha!@d{64} @c{smile_eclosed}Eu perdi de forma justa… Tenho a sensação de que você vai se sair muito bem lá fora.
                 $@c{smile}Aliás, o professor pediu para eu te dar alguns itens. Espero que sejam úteis!
-                $@c{smile_wave}Dê o seu melhor, como sempre! Eu acredito em você!`
+                $@c{smile_wave}Dê o seu melhor, como sempre! Eu acredito em você!
+                $@c{smile}Ah- e eu espero que você aproveite o evento!`
     },
   },
   "rival_2": {
@@ -3849,7 +3851,7 @@ export const PGFdialogue: DialogueTranslationEntries = {
             $@c{smile}Tudo bem, no entanto. Eu imaginei que isso poderia acontecer.\n@c{serious_mopen_fists}Isso só significa que preciso me esforçar mais para a próxima vez!\n
             $@c{smile}Ah, não que você precise realmente de ajuda, mas eu tinha um extra desses itens e pensei que você poderia querer.
             $@c{serious_smile_fists}Não espere outro depois deste!\nNão posso continuar dando vantagem ao meu oponente.
-            $@c{smile}Enfim, cuide-se!`
+            $@c{smile}Enfim, cuide-se, e aproveite o evento!`
     },
   },
   "rival_2_female": {
@@ -3865,7 +3867,7 @@ export const PGFdialogue: DialogueTranslationEntries = {
             $@c{smile}Ah bem. Isso só significa que vou ter que treinar ainda mais para a próxima vez!
             $@c{smile_wave}Também consegui mais um desses para você!\n@c{smile_wave_wink}Não precisa me agradecer~.
             $@c{angry_mopen}Este é o último, hein! Você não vai ganhar mais nenhum presente de mim depois desse!
-            $@c{smile_wave}Continue assim!`
+            $@c{smile_wave}Continue assim, e aproveite o evento!`
     },
     "defeat": {
       1: "Está tudo bem perder às vezes…"

--- a/src/locales/pt_BR/dialogue.ts
+++ b/src/locales/pt_BR/dialogue.ts
@@ -3865,8 +3865,8 @@ export const PGFdialogue: DialogueTranslationEntries = {
     "victory": {
       1: `@c{neutral}Eu… não era para eu perder dessa vez…
             $@c{smile}Ah bem. Isso só significa que vou ter que treinar ainda mais para a próxima vez!
-            $@c{smile_wave}Também consegui mais um desses para você!\n@c{smile_wave_wink}Não precisa me agradecer~.
-            $@c{angry_mopen}Este é o último, hein! Você não vai ganhar mais nenhum presente de mim depois desse!
+            $@c{smile_wave}Também consegui mais dois desses para você!\n@c{smile_wave_wink}Não precisa me agradecer~.
+            $@c{angry_mopen}Estes são os últimos, hein! Você não vai ganhar mais nenhum presente de mim depois desse!
             $@c{smile_wave}Continue assim, e aproveite o evento!`
     },
     "defeat": {


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
#3583 adds new translation to male dialogues. This PR adds the female ones and fixes a dialogue when the player now recieves 2 items instead of 1

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
