### PR TITLE
[Bug][Beta] Fix Pokemon info flyout disappearing on switch-out

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1643,9 +1643,9 @@ export class SwitchSummonPhase extends SummonPhase {
       ease: "Sine.easeIn",
       scale: 0.5,
       onComplete: () => {
-        // 250ms delay on leaveField is necessary to avoid calling hideInfo() twice
+        // 300ms delay on leaveField is necessary to avoid calling hideInfo() twice
         // and double-animating the stats panel slideout
-        this.scene.time.delayedCall(250, () => pokemon.leaveField(!this.batonPass));
+        this.scene.time.delayedCall(300, () => pokemon.leaveField(!this.batonPass));
         this.scene.time.delayedCall(750, () => this.switchAndSummon());
       }
     });


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
This fixes a bug in beta that causes a Pokemon's info flyout to not appear correctly after the Pokemon switches or is returned before a Trainer battle.

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
closes #3571 

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- `phases.ts`: Removed a possible race condition with calls to `Pokemon.hideInfo` in `SwitchSummonPhase` by adding a 50 ms delay

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
In game:
- Switch Pokemon while quickly mashing inputs
- Enter a Trainer battle (e.g. Wave 5) while quickly mashing inputs

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
