### PR TITLE
[BUG] - fixing parting shot

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5007,7 +5007,7 @@ export class PartingShotAttr extends ForceSwitchOutAttr {
   getCondition(): MoveConditionFunc {
     return (user, target, move) => {
       // conditions on if move should fail or not don't depend on if user is able to switch
-      // getCondition() is called before move is applied: move will only switch out if canLowerStats
+      // getCondition() is called before move is applied: move will only switch out if canLowerStats === true
       if (target.hasAbility(Abilities.CLEAR_BODY, true, false) ||
           (target.summonData.battleStats[0] === -6 && target.summonData.battleStats[2] === -6) || target.scene.arena.findTagsOnSide(t => t.tagType === ArenaTagType.MIST, ArenaTagSide.ENEMY).length > 0
       ) {

--- a/src/test/moves/parting_shot.test.ts
+++ b/src/test/moves/parting_shot.test.ts
@@ -4,7 +4,7 @@ import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, expect, test, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
 import GameManager from "../utils/gameManager";
 import { getMovePosition } from "../utils/gameManagerUtils";
 import { BattleStat } from "#app/data/battle-stat";
@@ -77,8 +77,8 @@ describe("Moves - Parting Shot", () => {
     }, TIMEOUT
   );
 
-  it.skip( // TODO: fix this bug to pass the test!
-    "Parting shot should fail if target is -6/-6 de-buffed",
+  test(
+    "Parting shot should not switch out if target is -6/-6 de-buffed",
     async () => {
       game.override.moveset([Moves.PARTING_SHOT, Moves.MEMENTO, Moves.SPLASH]);
       await game.startBattle([Species.MEOWTH, Species.MEOWTH, Species.MEOWTH, Species.MURKROW, Species.ABRA]);
@@ -120,7 +120,7 @@ describe("Moves - Parting Shot", () => {
     }, TIMEOUT
   );
 
-  it.skip( // TODO: fix this bug to pass the test!
+  test(
     "Parting shot shouldn't allow switch out when mist is active",
     async () => {
       game.override
@@ -138,11 +138,11 @@ describe("Moves - Parting Shot", () => {
       const battleStatsOpponent = enemyPokemon.summonData.battleStats;
       expect(battleStatsOpponent[BattleStat.ATK]).toBe(0);
       expect(battleStatsOpponent[BattleStat.SPATK]).toBe(0);
-      expect(game.scene.getPlayerField()[0].species.speciesId).toBe(Species.MURKROW);
+      expect(game.scene.getPlayerField()[0].species.speciesId).toBe(Species.SNORLAX);
     }, TIMEOUT
   );
 
-  it.skip( // TODO: fix this bug to pass the test!
+  test(
     "Parting shot shouldn't allow switch out against clear body ability",
     async () => {
       game.override
@@ -159,11 +159,11 @@ describe("Moves - Parting Shot", () => {
       const battleStatsOpponent = enemyPokemon.summonData.battleStats;
       expect(battleStatsOpponent[BattleStat.ATK]).toBe(0);
       expect(battleStatsOpponent[BattleStat.SPATK]).toBe(0);
-      expect(game.scene.getPlayerField()[0].species.speciesId).toBe(Species.MURKROW);
+      expect(game.scene.getPlayerField()[0].species.speciesId).toBe(Species.SNORLAX);
     }, TIMEOUT
   );
 
-  it.skip( // TODO: fix this bug to pass the test!
+  test(
     "Parting shot should de-buff and not fail if no party available to switch - party size 1",
     async () => {
       await game.startBattle([Species.MURKROW]);
@@ -181,7 +181,7 @@ describe("Moves - Parting Shot", () => {
     }, TIMEOUT
   );
 
-  it.skip( // TODO: fix this bug to pass the test!
+  test(
     "Parting shot regularly not fail if no party available to switch - party fainted",
     async () => {
       await game.startBattle([Species.MURKROW, Species.MEOWTH]);

--- a/src/test/moves/parting_shot.test.ts
+++ b/src/test/moves/parting_shot.test.ts
@@ -198,8 +198,8 @@ describe("Moves - Parting Shot", () => {
 
       await game.phaseInterceptor.to(BerryPhase, false);
       const battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
-      expect(battleStatsOpponent[BattleStat.ATK]).toBe(0);
-      expect(battleStatsOpponent[BattleStat.SPATK]).toBe(0);
+      expect(battleStatsOpponent[BattleStat.ATK]).toBe(-1);
+      expect(battleStatsOpponent[BattleStat.SPATK]).toBe(-1);
       expect(game.scene.getPlayerField()[0].species.speciesId).toBe(Species.MEOWTH);
     }, TIMEOUT
   );


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes?
<!-- Summarize what are the changes from a user perspective on the application -->
Making parting shot do the expected behavior (passing all the tests in #3412 )

## Why am I doing these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Closes issue #3471 

## What did change?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Created a new move attribute tag `PartingShotAttr` that implements the behavior of parting shot. The move is unique due to the fact that certain attributes should/shouldn't `apply()` based on the `getCondition()`. Namely, we still want to try all stat changes (and if it fails then the resulting messages/abilities will show correctly), but *don't* want to prompt switch-out at the same time.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
`overrides.ts` and `npm test src/tests/move/parting_shot.test.ts`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
