### PR TITLE
[Bug] Lock Capsule no longer treats common items as free

### DIFF
--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -2209,7 +2209,7 @@ export function getDefaultModifierTypeForTier(tier: ModifierTier): ModifierType 
 }
 
 export class ModifierTypeOption {
-  public type: ModifierType | null;
+  public type: ModifierType;
   public upgradeCount: integer;
   public cost: integer;
 

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -5580,7 +5580,7 @@ export class SelectModifierPhase extends BattlePhase {
     } else if (lockRarities) {
       const tierValues = [50, 125, 300, 750, 2000];
       for (const opt of typeOptions) {
-        baseValue += opt.type?.tier ? tierValues[opt.type.tier] : 0;
+        baseValue += tierValues[opt.type.tier ?? 0];
       }
     } else {
       baseValue = 250;

--- a/src/test/items/lock_capsule.test.ts
+++ b/src/test/items/lock_capsule.test.ts
@@ -1,0 +1,47 @@
+import GameManager from "#test/utils/gameManager";
+import Phase from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { Abilities } from "#app/enums/abilities.js";
+import { Moves } from "#app/enums/moves.js";
+import { getMovePosition } from "../utils/gameManagerUtils";
+import { SelectModifierPhase } from "#app/phases.js";
+import { ModifierTypeOption, modifierTypes } from "#app/modifier/modifier-type.js";
+
+describe("Items - Lock Capsule", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phase.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+
+    game.override
+      .battleType("single")
+      .startingLevel(200)
+      .moveset([Moves.SURF])
+      .enemyAbility(Abilities.BALL_FETCH)
+      .startingModifier([{name: "LOCK_CAPSULE"}]);
+  });
+
+  it("doesn't set the cost of common tier items to 0", async() => {
+    await game.startBattle();
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.SURF));
+    await game.phaseInterceptor.to(SelectModifierPhase, false);
+
+    const rewards = game.scene.getCurrentPhase() as SelectModifierPhase;
+    const potion = new ModifierTypeOption(modifierTypes.POTION(), 0, 40); // Common tier item
+    const rerollCost = rewards.getRerollCost([potion, potion, potion], true);
+
+    expect(rerollCost).toBe(150);
+  }, 20000);
+});

--- a/src/test/utils/helpers/overridesHelper.ts
+++ b/src/test/utils/helpers/overridesHelper.ts
@@ -84,6 +84,12 @@ export class OverridesHelper extends GameManagerHelper {
     return this;
   }
 
+  startingModifier(modifiers: ModifierOverride[]): this {
+    vi.spyOn(Overrides, "STARTING_MODIFIER_OVERRIDE", "get").mockReturnValue(modifiers);
+    this.log(`Player starting modifiers set to: ${modifiers}`);
+    return this;
+  }
+
   /**
    * Override the player (pokemon) {@linkcode Abilities | ability}
    * @param ability the (pokemon) {@linkcode Abilities | ability} to set

--- a/src/test/utils/helpers/overridesHelper.ts
+++ b/src/test/utils/helpers/overridesHelper.ts
@@ -84,6 +84,11 @@ export class OverridesHelper extends GameManagerHelper {
     return this;
   }
 
+  /**
+   * Override the player's starting modifiers
+   * @param modifiers the modifiers to set
+   * @returns this
+   */
   startingModifier(modifiers: ModifierOverride[]): this {
     vi.spyOn(Overrides, "STARTING_MODIFIER_OVERRIDE", "get").mockReturnValue(modifiers);
     this.log(`Player starting modifiers set to: ${modifiers}`);


### PR DESCRIPTION
## What are the changes?
Common items now appropriately increase the cost of rerolling if the lock capsule item is being used instead of being free.

## Why am I doing these changes?
It was bugged and making rerolls potentially much cheaper than intended.

## What did change?
A check intended to prevent `null` values is changed to no longer also prevent `0` values.

### Screenshots/Videos
Base reroll cost:
![image](https://github.com/user-attachments/assets/d288ba1b-9c0e-45a3-97dd-f1170299fb19)
With fix:
![image](https://github.com/user-attachments/assets/6a73a562-4c94-4f0d-a820-513e20e47dcc)
Without fix:
![image](https://github.com/user-attachments/assets/d793101a-0e90-444c-a145-5ab80ef5e9e3)

## How to test the changes?
Start a run with the override `STARTING_MODIFIER_OVERRIDE: [{name: "LOCK_CAPSULE"}]` set, then toggle the lock capsule on-off and observe the cost change pre- and post-fix with at least one common tier item in the rewards.
`npm run test lock_capsule`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - [x] Have I provided screenshots/videos of the changes?
