### PR TITLE
[Hotfix] Fix Pokemon info not fully appearing after switch-out

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3224,13 +3224,15 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * @param clearEffects Indicates if effects should be cleared (true) or passed
    * to the next pokemon, such as during a baton pass (false)
    */
-  leaveField(clearEffects: boolean = true) {
+  leaveField(clearEffects: boolean = true, hideInfo: boolean = true) {
     this.resetTurnData();
     if (clearEffects) {
       this.resetSummonData();
       this.resetBattleData();
     }
-    this.hideInfo();
+    if (hideInfo) {
+      this.hideInfo();
+    }
     this.setVisible(false);
     this.scene.field.remove(this);
     this.scene.triggerPokemonFormChange(this, SpeciesFormChangeActiveTrigger, true);

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3223,6 +3223,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * Causes a Pokemon to leave the field (such as in preparation for a switch out/escape).
    * @param clearEffects Indicates if effects should be cleared (true) or passed
    * to the next pokemon, such as during a baton pass (false)
+   * @param hideInfo Indicates if this should also play the animation to hide the Pokemon's
+   * info container.
    */
   leaveField(clearEffects: boolean = true, hideInfo: boolean = true) {
     this.resetTurnData();

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1635,7 +1635,7 @@ export class SwitchSummonPhase extends SummonPhase {
       })
     );
     this.scene.playSound("pb_rel");
-    pokemon.hideInfo(); // this is also done by pokemon.leaveField(), but needs to go earlier for animation purposes
+    pokemon.hideInfo();
     pokemon.tint(getPokeballTintColor(pokemon.pokeball), 1, 250, "Sine.easeIn");
     this.scene.tweens.add({
       targets: pokemon,
@@ -1643,9 +1643,7 @@ export class SwitchSummonPhase extends SummonPhase {
       ease: "Sine.easeIn",
       scale: 0.5,
       onComplete: () => {
-        // 300ms delay on leaveField is necessary to avoid calling hideInfo() twice
-        // and double-animating the stats panel slideout
-        this.scene.time.delayedCall(300, () => pokemon.leaveField(!this.batonPass));
+        pokemon.leaveField(!this.batonPass, false);
         this.scene.time.delayedCall(750, () => this.switchAndSummon());
       }
     });


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
This fixes a bug where a Pokemon's info container does not appear correctly after the Pokemon is switched out, then returned to the field.

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
My last PR on this (#3588) did not fully fix the bug from (#3550) 😔 

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- `field/pokemon`: Added a parameter to `Pokemon#leaveField` to make the internal `hideInfo` call optional.
- `phases`: `SwitchSummonPhase` now uses the new `leaveField()` parameter so that `hideInfo` is not invoked twice when returning a Pokemon.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
In game (needs testing on different devices, 5x game speed preferred):
- Switch back and forth between Pokemon during a battle.
- Enter a Trainer battle (e.g. Wave 5) while mashing inputs.

## Checklist
- [n/a] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [n/a] Have I considered writing automated tests for the issue?
- [n/a] If I have text, did I add placeholders for them in locales?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [?] Have I provided screenshots/videos of the changes?
