### PR TITLE
[Hotfix] Fix missing form change logic for Cramorant

### DIFF
--- a/src/data/pokemon-forms.ts
+++ b/src/data/pokemon-forms.ts
@@ -837,6 +837,8 @@ export const pokemonFormChanges: PokemonFormChanges = {
     new SpeciesFormChange(Species.CRAMORANT, "", "gorging", new SpeciesFormChangeManualTrigger, true, new SpeciesFormChangeCondition(p => p.getHpRatio() < .5)),
     new SpeciesFormChange(Species.CRAMORANT, "gulping", "", new SpeciesFormChangeManualTrigger, true),
     new SpeciesFormChange(Species.CRAMORANT, "gorging", "", new SpeciesFormChangeManualTrigger, true),
+    new SpeciesFormChange(Species.CRAMORANT, "gulping", "", new SpeciesFormChangeActiveTrigger(false), true),
+    new SpeciesFormChange(Species.CRAMORANT, "gorging", "", new SpeciesFormChangeActiveTrigger(false), true),
   ]
 };
 

--- a/src/test/abilities/gulp_missile.test.ts
+++ b/src/test/abilities/gulp_missile.test.ts
@@ -84,6 +84,21 @@ describe("Abilities - Gulp Missile", () => {
     expect(cramorant.formIndex).toBe(GORGING_FORM);
   });
 
+  it("changes to base form when switched out after Surf or Dive is used", async () => {
+    await game.startBattle([Species.CRAMORANT, Species.MAGIKARP]);
+    const cramorant = game.scene.getPlayerPokemon()!;
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.SURF));
+    await game.toNextTurn();
+
+    game.doSwitchPokemon(1);
+    await game.toNextTurn(); // form change is delayed until after end of turn
+
+    expect(cramorant.formIndex).toBe(NORMAL_FORM);
+    expect(cramorant.getTag(BattlerTagType.GULP_MISSILE_ARROKUDA)).toBeUndefined();
+    expect(cramorant.getTag(BattlerTagType.GULP_MISSILE_PIKACHU)).toBeUndefined();
+  });
+
   it("changes form during Dive's charge turn", async () => {
     await game.startBattle([Species.CRAMORANT]);
     const cramorant = game.scene.getPlayerPokemon()!;


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
This fixes a bug where Cramorant could be stuck in Gulp Missile form after switching out, effectively stopping the ability from triggering.

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
This bug was reported [in the Discord](https://discord.com/channels/1125469663833370665/1274440885748367360)

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- `data/pokemon-forms`: Added "Active" form change triggers for Cramorant's gulp missile forms --> base form.
- `test/abilities/gulp_missile.test`: Added test to verify Cramorant changes to base form after switching out.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
`npm run test gulp_missile`

## Checklist
- [n/a] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I add placeholders for them in locales?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
