### PR TITLE
[Hotfix] End Biome Catch Problems 

### DIFF
--- a/src/game-mode.ts
+++ b/src/game-mode.ts
@@ -62,7 +62,7 @@ export class GameMode implements GameModeConfig {
    * @returns true if the game mode has that challenge
    */
   hasChallenge(challenge: Challenges): boolean {
-    return this.challenges.some(c => c.id === challenge);
+    return this.challenges.some(c => c.id === challenge && c.value !== 0);
   }
 
   /**

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2036,7 +2036,11 @@ export class CommandPhase extends FieldPhase {
       }
       break;
     case Command.BALL:
-      if (this.scene.arena.biomeType === Biome.END && (!this.scene.gameMode.isClassic || this.scene.gameMode.isFreshStartChallenge() || (this.scene.getEnemyField().filter(p => p.isActive(true)).some(p => !p.scene.gameData.dexData[p.species.speciesId].caughtAttr) && this.scene.gameData.getStarterCount(d => !!d.caughtAttr) < Object.keys(speciesStarters).length - 1))) {
+      const notInDex = (this.scene.getEnemyField().filter(p => p.isActive(true)).some(p => !p.scene.gameData.dexData[p.species.speciesId].caughtAttr) && this.scene.gameData.getStarterCount(d => !!d.caughtAttr) < Object.keys(speciesStarters).length - 1); //&& !this.scene.gameMode.isFreshStartChallenge();
+      console.log(notInDex);
+      console.log(!this.scene.gameMode.isClassic);
+      console.log(this.scene.gameMode.isFreshStartChallenge());
+      if (this.scene.arena.biomeType === Biome.END && (!this.scene.gameMode.isClassic || this.scene.gameMode.isFreshStartChallenge() || notInDex )) {
         this.scene.ui.setMode(Mode.COMMAND, this.fieldIndex);
         this.scene.ui.setMode(Mode.MESSAGE);
         this.scene.ui.showText(i18next.t("battle:noPokeballForce"), null, () => {

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -2036,10 +2036,7 @@ export class CommandPhase extends FieldPhase {
       }
       break;
     case Command.BALL:
-      const notInDex = (this.scene.getEnemyField().filter(p => p.isActive(true)).some(p => !p.scene.gameData.dexData[p.species.speciesId].caughtAttr) && this.scene.gameData.getStarterCount(d => !!d.caughtAttr) < Object.keys(speciesStarters).length - 1); //&& !this.scene.gameMode.isFreshStartChallenge();
-      console.log(notInDex);
-      console.log(!this.scene.gameMode.isClassic);
-      console.log(this.scene.gameMode.isFreshStartChallenge());
+      const notInDex = (this.scene.getEnemyField().filter(p => p.isActive(true)).some(p => !p.scene.gameData.dexData[p.species.speciesId].caughtAttr) && this.scene.gameData.getStarterCount(d => !!d.caughtAttr) < Object.keys(speciesStarters).length - 1);
       if (this.scene.arena.biomeType === Biome.END && (!this.scene.gameMode.isClassic || this.scene.gameMode.isFreshStartChallenge() || notInDex )) {
         this.scene.ui.setMode(Mode.COMMAND, this.fieldIndex);
         this.scene.ui.setMode(Mode.MESSAGE);


### PR DESCRIPTION
## What are the changes the user will see?
Users are unable to catch Pokemon in the End Biome because of a bad conditional + an error in how gameMode.hasChallenge() determines active challenges.

## Why am I making these changes?
Against user experience. 

## What are the changes from a developer perspective?
gameMode.isFreshStartChallenge() would always return true because gameMode.hasChallenge() would only check for the id of a challenge object and not check if it was activated or not (based on its value). The challenge object regardless of activation would always be present, meaning that isFreshStartChallenge() / hasChallenge() would always return true. This also cleans up the conditional used to block catches for easier reading. 

### Screenshots/Videos
Fresh Start Uncaught Pokemon
![Screenshot 2024-08-17 at 2 50 09 PM](https://github.com/user-attachments/assets/f40830a2-60ea-408b-821b-615bdeb5fc60)
Fresh Start Caught Pokemon
![Screenshot 2024-08-17 at 2 51 36 PM](https://github.com/user-attachments/assets/c38dc4af-7b4f-4345-a86c-884cb87854e0)

MonoGen Challenge Caught Pokemon
https://github.com/user-attachments/assets/d1038b79-1647-41e3-83f1-43cac1a35a15

MonoGen Challenge Uncaught Pokemon
![image](https://github.com/user-attachments/assets/97a08c4d-907d-4da1-90ec-1ee92c95c9c9)

## How to test the changes?
- Fresh Start --> End Biome - Player should not be able to catch Pokemon
- Challenges/Classic --> End Biome - Player should be able to catch previously hatched Pokemon + Player should not be able to catch unknown Pokemon
- Endless/Daily/Endless Spliced --> End Biome - Player should not be able to catch Pokemon

## Checklist
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
