### PR TITLE
[Hotfix] Fixed a bug occurring when only single rare/epic variant or a single rare form in Starter UI

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -2916,14 +2916,18 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       const isCaught = this.scene.gameData.dexData[species.speciesId]?.caughtAttr || BigInt(0);
       const isVariant3Caught = !!(isCaught & DexAttr.VARIANT_3);
       const isVariant2Caught = !!(isCaught & DexAttr.VARIANT_2);
+      const isDefaultVariantCaught = !!(isCaught & DexAttr.DEFAULT_VARIANT);
       const isVariantCaught = !!(isCaught & DexAttr.SHINY);
       const isMaleCaught = !!(isCaught & DexAttr.MALE);
       const isFemaleCaught = !!(isCaught & DexAttr.FEMALE);
 
+      const starterAttributes = this.starterPreferences[species.speciesId];
+
+      const props = this.scene.gameData.getSpeciesDexAttrProps(species, this.getCurrentDexProps(species.speciesId));
+      const defaultAbilityIndex = this.scene.gameData.getStarterSpeciesDefaultAbilityIndex(species);
+      const defaultNature = this.scene.gameData.getSpeciesDefaultNature(species);
+
       if (!dexEntry.caughtAttr) {
-        const props = this.scene.gameData.getSpeciesDexAttrProps(species, this.getCurrentDexProps(species.speciesId));
-        const defaultAbilityIndex = this.scene.gameData.getStarterSpeciesDefaultAbilityIndex(species);
-        const defaultNature = this.scene.gameData.getSpeciesDefaultNature(species);
         if (shiny === undefined || shiny !== props.shiny) {
           shiny = props.shiny;
         }
@@ -2941,6 +2945,83 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         }
         if (natureIndex === undefined || natureIndex !== defaultNature) {
           natureIndex = defaultNature;
+        }
+      } else {
+        // compare current shiny, formIndex, female, variant, abilityIndex, natureIndex with the caught ones
+        // if the current ones are not caught, we need to find the next caught ones
+        if (shiny) {
+          if (!(isVariantCaught || isVariant2Caught || isVariant3Caught)) {
+            shiny = false;
+            starterAttributes.shiny = false;
+            variant = 0;
+            starterAttributes.variant = 0;
+          } else {
+            shiny = true;
+            starterAttributes.shiny = true;
+            if (variant === 0 && !isDefaultVariantCaught) {
+              if (isVariant2Caught) {
+                variant = 1;
+                starterAttributes.variant = 1;
+              } else if (isVariant3Caught) {
+                variant = 2;
+                starterAttributes.variant = 2;
+              } else {
+                variant = 0;
+                starterAttributes.variant = 0;
+              }
+            } else if (variant === 1 && !isVariant2Caught) {
+              if (isVariantCaught) {
+                variant = 0;
+                starterAttributes.variant = 0;
+              } else if (isVariant3Caught) {
+                variant = 2;
+                starterAttributes.variant = 2;
+              } else {
+                variant = 0;
+                starterAttributes.variant = 0;
+              }
+            } else if (variant === 2 && !isVariant3Caught) {
+              if (isVariantCaught) {
+                variant = 0;
+                starterAttributes.variant = 0;
+              } else if (isVariant2Caught) {
+                variant = 1;
+                starterAttributes.variant = 1;
+              } else {
+                variant = 0;
+                starterAttributes.variant = 0;
+              }
+            }
+          }
+        }
+        if (female) {
+          if (!isFemaleCaught) {
+            female = false;
+            starterAttributes.female = false;
+          }
+        } else {
+          if (!isMaleCaught) {
+            female = true;
+            starterAttributes.female = true;
+          }
+        }
+
+        if (species.forms) {
+          const formCount = species.forms.length;
+          let newFormIndex = formIndex??0;
+          if (species.forms[newFormIndex]) {
+            const isValidForm = species.forms[newFormIndex].isStarterSelectable && dexEntry.caughtAttr & this.scene.gameData.getFormAttr(newFormIndex);
+            if (!isValidForm) {
+              do {
+                newFormIndex = (newFormIndex + 1) % formCount;
+                if (species.forms[newFormIndex].isStarterSelectable && dexEntry.caughtAttr & this.scene.gameData.getFormAttr(newFormIndex)) {
+                  break;
+                }
+              } while (newFormIndex !== props.formIndex);
+              formIndex = newFormIndex;
+              starterAttributes.form = formIndex;
+            }
+          }
         }
       }
 
@@ -2993,12 +3074,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       }
 
       if (dexEntry.caughtAttr && species.malePercent !== null) {
-        let gender: Gender;
-        if ((female && isFemaleCaught) || (!female && !isMaleCaught)) {
-          gender = Gender.FEMALE;
-        } else {
-          gender = Gender.MALE;
-        }
+        const gender = !female ? Gender.MALE : Gender.FEMALE;
         this.pokemonGenderText.setText(getGenderSymbol(gender));
         this.pokemonGenderText.setColor(getGenderColor(gender));
         this.pokemonGenderText.setShadowColor(getGenderColor(gender, true));
@@ -3479,7 +3555,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
   checkIconId(icon: Phaser.GameObjects.Sprite, species: PokemonSpecies, female: boolean, formIndex: number, shiny: boolean, variant: number) {
     if (icon.frame.name !== species.getIconId(female, formIndex, shiny, variant)) {
-      console.log(`${species.name}'s variant icon does not exist. Replacing with default.`);
+      console.log(`${species.name}'s icon ${icon.frame.name} does not match getIconId with female: ${female}, formIndex: ${formIndex}, shiny: ${shiny}, variant: ${variant}`);
       icon.setTexture(species.getIconAtlasKey(formIndex, false, variant));
       icon.setFrame(species.getIconId(female, formIndex, false, variant));
     }


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
Fixed a bug occurring when only single rare/epic variant or a single rare form in Starter UI

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
If this bug exists, it prevents you from using a particular Pokémon's variant or form as your starting option even if you already possess it.

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
1. In the `setSpeciesDetails` function, when updating information such as shiny, variant, gender, and form via arguments, it was previously impossible to correct these settings if the default options were invalid or incorrect. Therefore, I added a process to correct these values to valid ones when calling `setSpeciesDetails`.
2. This fix also includes a correction process for gender, so the previous hotfix in #3601 is no longer needed. Executing this correction uniformly with variant, shiny, form at the function's start improves readability, so I will revert that change.
3. I corrected an inaccurate log message in `checkIconId`. Leaving it as it was could lead to incorrect debugging.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
- before ( magearna should 500 years form / manaphy should 2 shiny )
<img width="1201" alt="image" src="https://github.com/user-attachments/assets/05a4e231-e968-42a8-ace2-c22a00b2b630">
<img width="1204" alt="image" src="https://github.com/user-attachments/assets/4fb7e07e-a0a5-4ba7-b393-ee92a2f6de73">

- after ( fixed when cursor on, after fixed once, it is saved and apply )
<img width="1203" alt="image" src="https://github.com/user-attachments/assets/a6a23eda-7d43-4a85-9fa8-72f8a58b8f17">
<img width="1202" alt="image" src="https://github.com/user-attachments/assets/9a835a34-c4ff-4ab2-a298-00b437b0eaf8">



## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I add placeholders for them in locales?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
