### PR TITLE
[Hotfix] Abilities that prevent ATK drops no longer stop other stat drops

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2404,7 +2404,7 @@ export class ProtectStatAbAttr extends PreStatChangeAbAttr {
   }
 
   applyPreStatChange(pokemon: Pokemon, passive: boolean, stat: BattleStat, cancelled: Utils.BooleanHolder, args: any[]): boolean {
-    if (this.protectedStat === undefined || this.protectedStat === null || stat === this.protectedStat) {
+    if (Utils.isNullOrUndefined(this.protectedStat) || stat === this.protectedStat) {
       cancelled.value = true;
       return true;
     }

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2395,16 +2395,16 @@ export class PreStatChangeAbAttr extends AbAttr {
 }
 
 export class ProtectStatAbAttr extends PreStatChangeAbAttr {
-  private protectedStat: BattleStat | null;
+  private protectedStat?: BattleStat;
 
   constructor(protectedStat?: BattleStat) {
     super();
 
-    this.protectedStat = protectedStat ?? null;
+    this.protectedStat = protectedStat;
   }
 
   applyPreStatChange(pokemon: Pokemon, passive: boolean, stat: BattleStat, cancelled: Utils.BooleanHolder, args: any[]): boolean {
-    if (!this.protectedStat || stat === this.protectedStat) {
+    if (this.protectedStat === undefined || this.protectedStat === null || stat === this.protectedStat) {
       cancelled.value = true;
       return true;
     }

--- a/src/test/abilities/hyper_cutter.test.ts
+++ b/src/test/abilities/hyper_cutter.test.ts
@@ -1,4 +1,4 @@
-import { BattleStat } from "#app/data/battle-stat.js";
+import { BattleStat } from "#app/data/battle-stat";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
@@ -32,6 +32,8 @@ describe("Abilities - Hyper Cutter", () => {
       .enemyAbility(Abilities.HYPER_CUTTER)
       .enemyMoveset(SPLASH_ONLY);
   });
+
+// Reference Link: https://bulbapedia.bulbagarden.net/wiki/Hyper_Cutter_(Ability)
 
   it("only prevents ATK drops", async () => {
     await game.startBattle();

--- a/src/test/abilities/hyper_cutter.test.ts
+++ b/src/test/abilities/hyper_cutter.test.ts
@@ -1,0 +1,56 @@
+import { BattleStat } from "#app/data/battle-stat.js";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/utils/gameManager";
+import { getMovePosition } from "#test/utils/gameManagerUtils";
+import { SPLASH_ONLY } from "#test/utils/testUtils";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Abilities - Hyper Cutter", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .moveset([Moves.SAND_ATTACK, Moves.NOBLE_ROAR, Moves.DEFOG, Moves.OCTOLOCK])
+      .ability(Abilities.BALL_FETCH)
+      .enemySpecies(Species.SHUCKLE)
+      .enemyAbility(Abilities.HYPER_CUTTER)
+      .enemyMoveset(SPLASH_ONLY);
+  });
+
+  it("only prevents ATK drops", async () => {
+    await game.startBattle();
+
+    const enemy = game.scene.getEnemyPokemon()!;
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.OCTOLOCK));
+    await game.toNextTurn();
+    game.doAttack(getMovePosition(game.scene, 0, Moves.DEFOG));
+    await game.toNextTurn();
+    game.doAttack(getMovePosition(game.scene, 0, Moves.NOBLE_ROAR));
+    await game.toNextTurn();
+    game.doAttack(getMovePosition(game.scene, 0, Moves.SAND_ATTACK));
+    await game.toNextTurn();
+    game.override.moveset([Moves.STRING_SHOT]);
+    game.doAttack(getMovePosition(game.scene, 0, Moves.STRING_SHOT));
+    await game.toNextTurn();
+
+    expect(enemy.summonData.battleStats[BattleStat.ATK]).toEqual(0);
+    [BattleStat.ACC, BattleStat.DEF, BattleStat.EVA, BattleStat.SPATK, BattleStat.SPDEF, BattleStat.SPD].forEach((stat: number) => expect(enemy.summonData.battleStats[stat]).toBeLessThan(0));
+  });
+});

--- a/src/test/abilities/hyper_cutter.test.ts
+++ b/src/test/abilities/hyper_cutter.test.ts
@@ -33,7 +33,7 @@ describe("Abilities - Hyper Cutter", () => {
       .enemyMoveset(SPLASH_ONLY);
   });
 
-// Reference Link: https://bulbapedia.bulbagarden.net/wiki/Hyper_Cutter_(Ability)
+  // Reference Link: https://bulbapedia.bulbagarden.net/wiki/Hyper_Cutter_(Ability)
 
   it("only prevents ATK drops", async () => {
     await game.startBattle();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -552,3 +552,11 @@ export function capitalizeString(str: string, sep: string, lowerFirstChar: boole
   }
   return null;
 }
+
+/**
+ * Returns if an object is null or undefined
+ * @param object
+ */
+export function isNullOrUndefined(object: any): boolean {
+  return null === object || undefined === object;
+}


### PR DESCRIPTION
## What are the changes the user will see?
Hyper Cutter (and similar abilities that prevented ATK drops via `ProtectStatAbAttr`) will only prevent the appropriate stat drops now.

## Why am I making these changes?
`ProtectStatAbAttr` would prevent all stat drops if it was specified to prevent ATK drops only due to a `null` check incorrectly checking for `false`.

## What are the changes from a developer perspective?
The `null` check is fixed to only check for `null` and `undefined`, and a test was added.

## How to test the changes?
Attempt to inflict various stat drops against a Pokémon with Hyper Cutter.

## Checklist
- ~[ ] **I'm using `beta` as my base branch**~
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~[ ] If I have text, did I add placeholders for them in locales?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
