### PR TITLE
[Enhancement] Make the scrollbar cursor size more natural in the starter select UI

### DIFF
--- a/src/ui/scroll-bar.ts
+++ b/src/ui/scroll-bar.ts
@@ -29,8 +29,8 @@ export class ScrollBar extends Phaser.GameObjects.Container {
 
   setPages(pages: number): void {
     this.pages = pages;
-    this.handleBody.height = (this.bg.displayHeight - 1 - this.handleBottom.displayHeight) / this.pages;
+    this.handleBody.height = (this.bg.displayHeight - 1 - this.handleBottom.displayHeight) * 9 / this.pages;
 
-    this.setVisible(this.pages > 1);
+    this.setVisible(this.pages > 9);
   }
 }

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -2415,7 +2415,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       }
     });
 
-    this.starterSelectScrollBar.setPages(Math.max(Math.ceil(this.filteredStarterContainers.length / 9)), 1);
+    this.starterSelectScrollBar.setPages(Math.max(Math.ceil(this.filteredStarterContainers.length / 9), 1));
     this.starterSelectScrollBar.setPage(0);
 
     // sort

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -2415,7 +2415,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       }
     });
 
-    this.starterSelectScrollBar.setPages(Math.ceil(this.filteredStarterContainers.length / 9));
+    this.starterSelectScrollBar.setPages(Math.max(Math.ceil(this.filteredStarterContainers.length / 9)), 1);
     this.starterSelectScrollBar.setPage(0);
 
     // sort

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -2415,7 +2415,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       }
     });
 
-    this.starterSelectScrollBar.setPages(Math.ceil((this.filteredStarterContainers.length - 81) / 9) + 1);
+    this.starterSelectScrollBar.setPages(Math.ceil(this.filteredStarterContainers.length / 9));
     this.starterSelectScrollBar.setPage(0);
 
     // sort


### PR DESCRIPTION
Improves on the scroll bar graphic by making it resize like a proper scroll bar.

## What are the changes the user will see?
The scroll bar is sized differently, to correctly show the size of the starters list.

## Why am I making these changes?
I simply wanted the scroll bar to reflect the actual size of the window.
Genesect doesn't need its own page, trust me.

## What are the changes from a developer perspective?
Instead of `page` in `scroll-bar.ts`  representing the number of 9x9 windows shown, it represents the number of rows onscreen. When Gen 5 is shown, 10 rows (9 full rows + 1) are visible, so the scroll bar should take up 9/10 of its rectangle.
Other values using `page` are updated to reflect this new value range.

### Screenshots/Videos
Gen 5 before.
![image](https://github.com/user-attachments/assets/03e276fc-f282-4455-855b-90a17ee029aa)
Gen 5 after.
![image](https://github.com/user-attachments/assets/4e3c9ce4-dbee-4c2a-87b4-a1016adfdc2d)

All starters before.
![image](https://github.com/user-attachments/assets/73a5d588-54c8-4e70-a487-a9b83663fd65)
All starters after.
![image](https://github.com/user-attachments/assets/77c8df0f-a3e1-461b-98d6-d2964d17f4b3)

## How to test the changes?
Simply open the starter menu (press New Game). The difference will be immediately apparent.
It's most obvious when filtered to show Generation 5.
This does not rely on any `overrides`, and doesn't add any tests, nor should it affect any as it is a purely visual change.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
    - How do I check this?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I add placeholders for them in locales?
- [x] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
*I didn't run any tests because I cannot see any world in which these 3 lines of code break one, but I can run the tests if required*
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?