### PR TITLE
[Hotfix] Steal-able Mini Black Hole Pt 2 

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2419,13 +2419,7 @@ export default class BattleScene extends SceneBase {
           count = Math.max(count, Math.floor(chances / 2));
         }
         getEnemyModifierTypesForWave(difficultyWaveIndex, count, [ enemyPokemon ], this.currentBattle.battleType === BattleType.TRAINER ? ModifierPoolType.TRAINER : ModifierPoolType.WILD, upgradeChance)
-          .map(mt => {
-            const enemyModifier = mt.newModifier(enemyPokemon);
-            if (enemyModifier instanceof TurnHeldItemTransferModifier) {
-              enemyModifier.setTransferrableFalse();
-            }
-            enemyModifier.add(this.enemyModifiers, false, this);
-          });
+          .map(mt => mt.newModifier(enemyPokemon).add(this.enemyModifiers, false, this));
       });
       this.updateModifiers(false).then(() => resolve());
     });

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -878,10 +878,10 @@ export class EncounterPhase extends BattlePhase {
         } else if (!(battle.waveIndex % 1000)) {
           enemyPokemon.formIndex = 1;
           enemyPokemon.updateScale();
-          const bossMBH = this.scene.findModifier(m => m instanceof TurnHeldItemTransferModifier && m.pokemonId === enemyPokemon.id, false);
-          this.scene.removeModifier(bossMBH);
-          bossMBH.setTransferrableFalse();
-          this.scene.addEnemyModifier(bossMBH);
+          const bossMBH = this.scene.findModifier(m => m instanceof TurnHeldItemTransferModifier && m.pokemonId === enemyPokemon.id, false) as TurnHeldItemTransferModifier;
+          this.scene.removeModifier(bossMBH!);
+          bossMBH?.setTransferrableFalse();
+          this.scene.addEnemyModifier(bossMBH!);
         }
       }
 

--- a/src/phases.ts
+++ b/src/phases.ts
@@ -878,6 +878,10 @@ export class EncounterPhase extends BattlePhase {
         } else if (!(battle.waveIndex % 1000)) {
           enemyPokemon.formIndex = 1;
           enemyPokemon.updateScale();
+          const bossMBH = this.scene.findModifier(m => m instanceof TurnHeldItemTransferModifier && m.pokemonId === enemyPokemon.id, false);
+          this.scene.removeModifier(bossMBH);
+          bossMBH.setTransferrableFalse();
+          this.scene.addEnemyModifier(bossMBH);
         }
       }
 


### PR DESCRIPTION
## What are the changes the user will see?
The user will not be able to steal MBH anymore. 

## Why am I making these changes?
Against game design.

## What are the changes from a developer perspective?
Previously, I believed that generateEnemyModifiers() in battle-scene.ts where Eternatus was given its MBH and applied a fix there. However, because generateEnemyModifiers() is random, there is a chance that Eternatus may not receive its MBH from this function and it must be given the MBH through some other function. This MBH does not have isTransferrable set to false.

Instead of chasing down these random functions, I edited the code found in EncounterPhase to remove the faulty MBH and manually add a MBH with a isTransferrable property set to false. This means the code written in generateEnemyModifiers() is useless. 

### Screenshots/Videos

https://github.com/user-attachments/assets/1df00947-e202-4269-a81d-b6fd021f92c1

## How to test the changes?
Wave X000 - Face Eternatus with grip claw / magician / pick up pokemon. 

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
