### PR TITLE
[Localization][KO] Fix wrong line break character

### DIFF
--- a/src/locales/ko/move-trigger.ts
+++ b/src/locales/ko/move-trigger.ts
@@ -8,7 +8,7 @@ export const moveTriggers: SimpleTranslationEntries = {
   "goingAllOutForAttack": "{{pokemonName}}[[는]]\n전력을 다하기 시작했다!",
   "regainedHealth": "{{pokemonName}}[[는]]\n기력을 회복했다!",
   "keptGoingAndCrashed": "{{pokemonName}}[[는]]\n의욕이 넘쳐서 땅에 부딪쳤다!",
-  "fled": "{{pokemonName}}[[는]]\N도망쳤다!",
+  "fled": "{{pokemonName}}[[는]]\n도망쳤다!",
   "cannotBeSwitchedOut": "{{pokemonName}}[[를]]\n돌아오게 할 수 없습니다!",
   "swappedAbilitiesWithTarget": "{{pokemonName}}[[는]]\n서로의 특성을 교체했다!",
   "coinsScatteredEverywhere": "돈이 주위에 흩어졌다!",


### PR DESCRIPTION
## What are the changes the user will see?
Users don't see wrong 'N' character anymore.

## Why am I making these changes?
Line break should be \n but \N was found.

## What are the changes from a developer perspective?
Just replace \N to \n

### Screenshots/Videos
#### Before
![image](https://github.com/user-attachments/assets/5711cad9-e43c-4783-8e62-4591b08c41ce)

#### After
![image](https://github.com/user-attachments/assets/8e84e0f4-768f-46e5-9de8-25ee3cd521e2)

## How to test the changes?
N/A

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I add placeholders for them in locales?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
