### PR TITLE
[Hotfix] Grip Claw activation message uses nickname now

### DIFF
--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -2414,7 +2414,7 @@ export class ContactHeldItemTransferChanceModifier extends HeldItemTransferModif
   }
 
   getTransferMessage(pokemon: Pokemon, targetPokemon: Pokemon, item: ModifierTypes.ModifierType): string {
-    return i18next.t("modifier:contactHeldItemTransferApply", { pokemonNameWithAffix: getPokemonNameWithAffix(targetPokemon), itemName: item.name, pokemonName: pokemon.name, typeName: this.type.name });
+    return i18next.t("modifier:contactHeldItemTransferApply", { pokemonNameWithAffix: getPokemonNameWithAffix(targetPokemon), itemName: item.name, pokemonName: getPokemonNameWithAffix(pokemon), typeName: this.type.name });
   }
 
   getMaxHeldItemCount(pokemon: Pokemon): integer {


### PR DESCRIPTION
## What are the changes the user will see?
When Grip Claw activates, the Pokemon's nickname will be used. 

## Why am I making these changes?
Snailman Bug Report

## What are the changes from a developer perspective?
The pokemon with grip claw's name is retrieved from GetPokemonNameWithAffix() now. 

### Screenshots/Videos
https://github.com/user-attachments/assets/a9c94a0e-2567-4478-ad3c-d2eeb1d957ef

## How to test the changes?
Use a Pokemon holding Grip Claw against a Pokemon with an held item that is transferrable

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
