### PR TITLE
[Misc] Improve settings behavior: notify users of data loss risk and no reloads unnecessary

### DIFF
--- a/src/ui/settings/abstract-settings-ui-handler.ts
+++ b/src/ui/settings/abstract-settings-ui-handler.ts
@@ -231,9 +231,8 @@ export default class AbstractSettingsUiHandler extends MessageUiHandler {
 
     let success = false;
 
-    if (button === Button.CANCEL) {
+    const progressLosing = () => {
       if (this.reloadRequired && this.scene.currentBattle && this.scene.currentBattle.turn > 1) {
-        const ui = this.getUi();
 
         this.showText(i18next.t("menuUiHandler:losingProgressionWarning"), null, () => {
           ui.setOverlayMode(Mode.CONFIRM, () => {
@@ -250,8 +249,14 @@ export default class AbstractSettingsUiHandler extends MessageUiHandler {
             ui.showText("", 0);
           }, false, 0,0);
         });
+        return false;
 
-      } else {
+      }
+      return true;
+    };
+
+    if (button === Button.CANCEL) {
+      if (progressLosing()) {
         NavigationManager.getInstance().reset();
         this.scene.ui.revertMode();
       }
@@ -305,26 +310,7 @@ export default class AbstractSettingsUiHandler extends MessageUiHandler {
         break;
       case Button.CYCLE_FORM:
       case Button.CYCLE_SHINY:
-        if (this.reloadRequired && this.scene.currentBattle && this.scene.currentBattle.turn > 1) {
-          const ui = this.getUi();
-
-          this.showText(i18next.t("menuUiHandler:losingProgressionWarning"), null, () => {
-            ui.setOverlayMode(Mode.CONFIRM, () => {
-              NavigationManager.getInstance().reset();
-              this.scene.ui.revertMode();
-              this.scene.ui.revertMode();
-            }, () => {
-              this.reloadSettings.forEach((s,i) => {
-                if (s !== null && s !== this.optionCursors[i]) {
-                  this.setOptionCursor(this.cursor + this.scrollCursor,s,true);
-                }
-              });
-              this.scene.ui.revertMode();
-              ui.showText("", 0);
-            }, false, 0,0);
-          });
-
-        } else {
+        if (progressLosing()) {
           success = this.navigationContainer.navigate(button);
         }
         break;


### PR DESCRIPTION
## What are the changes the user will see?
No reload if there are no real changes in settings and warn for data loss in battle (If refused, revert the changes that need to be reloaded).

## Why am I making these changes?
Small improvement in user experience, as when saving and exiting it also warns about data loss, I think it's fair that data reloading also warns, besides, if it warns, it means it can be reversed.

## What are the changes from a developer perspective?
The `abstract-settings-ui-handler` class is now extended from `message-ui-handler`, the `reloadSettings` variable has changed from an array filtering options with `reloadRequired` to an array that stores the indices of options with `reloadRequired` or null for those that don't have it, integration for messages in settings, and a function that restricts reloading if data loss is possible in battle.

## Before
### _Podemos ver al usuario saliendo con los mismos datos que salió y igualmente hacer la "recarga necesaria"_
https://github.com/user-attachments/assets/866a0673-b17c-4900-bc85-e5dd24f34477

## After
https://github.com/user-attachments/assets/8439a90c-dd28-40d8-8377-3abc13e8fc58

https://github.com/user-attachments/assets/3f486a2c-d6b3-4be9-83a4-4c6907fe64d1

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] ~Have I considered writing automated tests for the issue?~
- [ ] If I have text, did I add placeholders for them in locales?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?