### PR TITLE
[Bug] Apply exp gains speed to animation

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -83,6 +83,7 @@ import { SwitchPhase } from "./phases/switch-phase";
 import { TitlePhase } from "./phases/title-phase";
 import { ToggleDoublePositionPhase } from "./phases/toggle-double-position-phase";
 import { TurnInitPhase } from "./phases/turn-init-phase";
+import { ExpGainsSpeed } from "./enums/exp-gains-speed";
 
 export const bypassLogin = import.meta.env.VITE_BYPASS_LOGIN === "1";
 
@@ -155,7 +156,7 @@ export default class BattleScene extends SceneBase {
   public experimentalSprites: boolean = false;
   public musicPreference: integer = 0;
   public moveAnimations: boolean = true;
-  public expGainsSpeed: integer = 0;
+  public expGainsSpeed: ExpGainsSpeed = ExpGainsSpeed.NORMAL;
   public skipSeenDialogues: boolean = false;
 
   /**

--- a/src/enums/exp-gains-speed.ts
+++ b/src/enums/exp-gains-speed.ts
@@ -1,0 +1,13 @@
+/**
+ * Determines exp gains speeed.
+ */
+export enum ExpGainsSpeed {
+    /** Normal animation speed */
+    NORMAL,
+    /** Fast animation speed */
+    FAST,
+    /** Faster animation speed */
+    FASTER,
+    /** Skip animation (instant) */
+    SKIP,
+}

--- a/src/phases/show-party-exp-bar-phase.ts
+++ b/src/phases/show-party-exp-bar-phase.ts
@@ -1,4 +1,5 @@
 import BattleScene from "#app/battle-scene.js";
+import { ExpGainsSpeed } from "#app/enums/exp-gains-speed.js";
 import { ExpNotification } from "#app/enums/exp-notification.js";
 import { ExpBoosterModifier } from "#app/modifier/modifier.js";
 import * as Utils from "#app/utils.js";
@@ -44,7 +45,7 @@ export class ShowPartyExpBarPhase extends PlayerPartyMemberPokemonPhase {
       } else {
         this.end();
       }
-    } else if (this.scene.expGainsSpeed < 3) {
+    } else if (this.scene.expGainsSpeed < ExpGainsSpeed.SKIP) {
       this.scene.partyExpBar.showPokemonExp(pokemon, exp.value, false, newLevel).then(() => {
         setTimeout(() => this.end(), 500 / Math.pow(2, this.scene.expGainsSpeed));
       });

--- a/src/test/abilities/aura_break.test.ts
+++ b/src/test/abilities/aura_break.test.ts
@@ -41,7 +41,7 @@ describe("Abilities - Aura Break", () => {
     game.override.ability(Abilities.FAIRY_AURA);
     vi.spyOn(moveToCheck, "calculateBattlePower");
 
-    await game.startBattle([Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU]);
     game.doAttack(getMovePosition(game.scene, 0, Moves.MOONBLAST));
     await game.phaseInterceptor.to(MoveEffectPhase);
 
@@ -55,7 +55,7 @@ describe("Abilities - Aura Break", () => {
     game.override.ability(Abilities.DARK_AURA);
     vi.spyOn(moveToCheck, "calculateBattlePower");
 
-    await game.startBattle([Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU]);
     game.doAttack(getMovePosition(game.scene, 0, Moves.DARK_PULSE));
     await game.phaseInterceptor.to(MoveEffectPhase);
 

--- a/src/test/abilities/battery.test.ts
+++ b/src/test/abilities/battery.test.ts
@@ -41,7 +41,7 @@ describe("Abilities - Battery", () => {
 
     vi.spyOn(moveToCheck, "calculateBattlePower");
 
-    await game.startBattle([Species.PIKACHU, Species.CHARJABUG]);
+    await game.classicMode.startBattle([Species.PIKACHU, Species.CHARJABUG]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.DAZZLING_GLEAM));
     game.doAttack(getMovePosition(game.scene, 1, Moves.SPLASH));
@@ -56,7 +56,7 @@ describe("Abilities - Battery", () => {
 
     vi.spyOn(moveToCheck, "calculateBattlePower");
 
-    await game.startBattle([Species.PIKACHU, Species.CHARJABUG]);
+    await game.classicMode.startBattle([Species.PIKACHU, Species.CHARJABUG]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.BREAKING_SWIPE));
     game.doAttack(getMovePosition(game.scene, 1, Moves.SPLASH));
@@ -71,7 +71,7 @@ describe("Abilities - Battery", () => {
 
     vi.spyOn(moveToCheck, "calculateBattlePower");
 
-    await game.startBattle([Species.CHARJABUG, Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.CHARJABUG, Species.PIKACHU]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.DAZZLING_GLEAM));
     game.doAttack(getMovePosition(game.scene, 1, Moves.SPLASH));

--- a/src/test/abilities/battle_bond.test.ts
+++ b/src/test/abilities/battle_bond.test.ts
@@ -43,7 +43,7 @@ describe("Abilities - BATTLE BOND", () => {
         [Species.GRENINJA]: ashForm,
       });
 
-      await game.startBattle([Species.MAGIKARP, Species.GRENINJA]);
+      await game.classicMode.startBattle([Species.MAGIKARP, Species.GRENINJA]);
 
       const greninja = game.scene.getParty().find((p) => p.species.speciesId === Species.GRENINJA);
       expect(greninja).toBeDefined();

--- a/src/test/abilities/costar.test.ts
+++ b/src/test/abilities/costar.test.ts
@@ -40,7 +40,7 @@ describe("Abilities - COSTAR", () => {
     async () => {
       game.override.enemyAbility(Abilities.BALL_FETCH);
 
-      await game.startBattle([Species.MAGIKARP, Species.MAGIKARP, Species.FLAMIGO]);
+      await game.classicMode.startBattle([Species.MAGIKARP, Species.MAGIKARP, Species.FLAMIGO]);
 
       let [leftPokemon, rightPokemon] = game.scene.getPlayerField();
 
@@ -69,7 +69,7 @@ describe("Abilities - COSTAR", () => {
     async () => {
       game.override.enemyAbility(Abilities.INTIMIDATE);
 
-      await game.startBattle([Species.MAGIKARP, Species.MAGIKARP, Species.FLAMIGO]);
+      await game.classicMode.startBattle([Species.MAGIKARP, Species.MAGIKARP, Species.FLAMIGO]);
 
       let [leftPokemon, rightPokemon] = game.scene.getPlayerField();
 

--- a/src/test/abilities/disguise.test.ts
+++ b/src/test/abilities/disguise.test.ts
@@ -43,7 +43,7 @@ describe("Abilities - Disguise", () => {
   }, TIMEOUT);
 
   it("takes no damage from attacking move and transforms to Busted form, takes 1/8 max HP damage from the disguise breaking", async () => {
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const mimikyu = game.scene.getEnemyPokemon()!;
     const maxHp = mimikyu.getMaxHp();
@@ -60,7 +60,7 @@ describe("Abilities - Disguise", () => {
   }, TIMEOUT);
 
   it("doesn't break disguise when attacked with ineffective move", async () => {
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const mimikyu = game.scene.getEnemyPokemon()!;
 
@@ -76,7 +76,7 @@ describe("Abilities - Disguise", () => {
   it("takes no damage from the first hit of a multihit move and transforms to Busted form, then takes damage from the second hit", async () => {
     game.override.moveset([Moves.SURGING_STRIKES]);
     game.override.enemyLevel(5);
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const mimikyu = game.scene.getEnemyPokemon()!;
     const maxHp = mimikyu.getMaxHp();
@@ -98,7 +98,7 @@ describe("Abilities - Disguise", () => {
   }, TIMEOUT);
 
   it("takes effects from status moves and damage from status effects", async () => {
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const mimikyu = game.scene.getEnemyPokemon()!;
     expect(mimikyu.hp).toBe(mimikyu.getMaxHp());
@@ -117,7 +117,7 @@ describe("Abilities - Disguise", () => {
     game.override.enemyMoveset(Array(4).fill(Moves.SHADOW_SNEAK));
     game.override.starterSpecies(0);
 
-    await game.startBattle([Species.MIMIKYU, Species.FURRET]);
+    await game.classicMode.startBattle([Species.MIMIKYU, Species.FURRET]);
 
     const mimikyu = game.scene.getPlayerPokemon()!;
     const maxHp = mimikyu.getMaxHp();
@@ -143,7 +143,7 @@ describe("Abilities - Disguise", () => {
     game.override.starterForms({
       [Species.MIMIKYU]: bustedForm
     });
-    await game.startBattle([Species.FURRET, Species.MIMIKYU]);
+    await game.classicMode.startBattle([Species.FURRET, Species.MIMIKYU]);
 
     const mimikyu = game.scene.getParty()[1]!;
     expect(mimikyu.formIndex).toBe(bustedForm);
@@ -162,7 +162,7 @@ describe("Abilities - Disguise", () => {
       [Species.MIMIKYU]: bustedForm
     });
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const mimikyu = game.scene.getPlayerPokemon()!;
 
@@ -182,7 +182,7 @@ describe("Abilities - Disguise", () => {
       [Species.MIMIKYU]: bustedForm
     });
 
-    await game.startBattle([Species.MIMIKYU, Species.FURRET]);
+    await game.classicMode.startBattle([Species.MIMIKYU, Species.FURRET]);
 
     const mimikyu1 = game.scene.getPlayerPokemon()!;
 

--- a/src/test/abilities/dry_skin.test.ts
+++ b/src/test/abilities/dry_skin.test.ts
@@ -36,7 +36,7 @@ describe("Abilities - Dry Skin", () => {
   it("during sunlight, lose 1/8 of maximum health at the end of each turn", async () => {
     game.override.moveset([Moves.SUNNY_DAY, Moves.SPLASH]);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const enemy = game.scene.getEnemyPokemon()!;
     expect(enemy).not.toBe(undefined);
@@ -57,7 +57,7 @@ describe("Abilities - Dry Skin", () => {
   it("during rain, gain 1/8 of maximum health at the end of each turn", async () => {
     game.override.moveset([Moves.RAIN_DANCE, Moves.SPLASH]);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const enemy = game.scene.getEnemyPokemon()!;
     expect(enemy).not.toBe(undefined);
@@ -80,7 +80,7 @@ describe("Abilities - Dry Skin", () => {
   it("opposing fire attacks do 25% more damage", async () => {
     game.override.moveset([Moves.FLAMETHROWER]);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const enemy = game.scene.getEnemyPokemon()!;
     const initialHP = 1000;
@@ -106,7 +106,7 @@ describe("Abilities - Dry Skin", () => {
   it("opposing water attacks heal 1/4 of maximum health and deal no damage", async () => {
     game.override.moveset([Moves.WATER_GUN]);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const enemy = game.scene.getEnemyPokemon()!;
     expect(enemy).not.toBe(undefined);
@@ -121,7 +121,7 @@ describe("Abilities - Dry Skin", () => {
   it("opposing water attacks do not heal if they were protected from", async () => {
     game.override.moveset([Moves.WATER_GUN]);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const enemy = game.scene.getEnemyPokemon()!;
     expect(enemy).not.toBe(undefined);
@@ -137,7 +137,7 @@ describe("Abilities - Dry Skin", () => {
   it("multi-strike water attacks only heal once", async () => {
     game.override.moveset([Moves.WATER_GUN, Moves.WATER_SHURIKEN]);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const enemy = game.scene.getEnemyPokemon()!;
     expect(enemy).not.toBe(undefined);

--- a/src/test/abilities/flash_fire.test.ts
+++ b/src/test/abilities/flash_fire.test.ts
@@ -40,7 +40,7 @@ describe("Abilities - Flash Fire", () => {
 
   it("immune to Fire-type moves", async() => {
     game.override.enemyMoveset(Array(4).fill(Moves.EMBER)).moveset(SPLASH_ONLY);
-    await game.startBattle([Species.BLISSEY]);
+    await game.classicMode.startBattle([Species.BLISSEY]);
 
     const blissey = game.scene.getPlayerPokemon()!;
 
@@ -51,7 +51,7 @@ describe("Abilities - Flash Fire", () => {
 
   it("not activate if the Pokémon is protected from the Fire-type move", async() => {
     game.override.enemyMoveset(Array(4).fill(Moves.EMBER)).moveset([Moves.PROTECT]);
-    await game.startBattle([Species.BLISSEY]);
+    await game.classicMode.startBattle([Species.BLISSEY]);
 
     const blissey = game.scene.getPlayerPokemon()!;
 
@@ -62,7 +62,7 @@ describe("Abilities - Flash Fire", () => {
 
   it("activated by Will-O-Wisp", async() => {
     game.override.enemyMoveset(Array(4).fill(Moves.WILL_O_WISP)).moveset(SPLASH_ONLY);
-    await game.startBattle([Species.BLISSEY]);
+    await game.classicMode.startBattle([Species.BLISSEY]);
 
     const blissey = game.scene.getPlayerPokemon()!;
 
@@ -78,7 +78,7 @@ describe("Abilities - Flash Fire", () => {
   it("activated after being frozen", async() => {
     game.override.enemyMoveset(Array(4).fill(Moves.EMBER)).moveset(SPLASH_ONLY);
     game.override.statusEffect(StatusEffect.FREEZE);
-    await game.startBattle([Species.BLISSEY]);
+    await game.classicMode.startBattle([Species.BLISSEY]);
 
     const blissey = game.scene.getPlayerPokemon()!;
 
@@ -90,7 +90,7 @@ describe("Abilities - Flash Fire", () => {
 
   it("not passing with baton pass", async() => {
     game.override.enemyMoveset(Array(4).fill(Moves.EMBER)).moveset([Moves.BATON_PASS]);
-    await game.startBattle([Species.BLISSEY, Species.CHANSEY]);
+    await game.classicMode.startBattle([Species.BLISSEY, Species.CHANSEY]);
 
     // ensure use baton pass after enemy moved
     game.doAttack(getMovePosition(game.scene, 0, Moves.BATON_PASS));
@@ -107,7 +107,7 @@ describe("Abilities - Flash Fire", () => {
   it("boosts Fire-type move when the ability is activated", async() => {
     game.override.enemyMoveset(Array(4).fill(Moves.FIRE_PLEDGE)).moveset([Moves.EMBER, Moves.SPLASH]);
     game.override.enemyAbility(Abilities.FLASH_FIRE).ability(Abilities.NONE);
-    await game.startBattle([Species.BLISSEY]);
+    await game.classicMode.startBattle([Species.BLISSEY]);
     const blissey = game.scene.getPlayerPokemon()!;
     const initialHP = 1000;
     blissey.hp = initialHP;

--- a/src/test/abilities/gulp_missile.test.ts
+++ b/src/test/abilities/gulp_missile.test.ts
@@ -55,7 +55,7 @@ describe("Abilities - Gulp Missile", () => {
   });
 
   it("changes to Gulping Form if HP is over half when Surf or Dive is used", async () => {
-    await game.startBattle([Species.CRAMORANT]);
+    await game.classicMode.startBattle([Species.CRAMORANT]);
     const cramorant = game.scene.getPlayerPokemon()!;
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.DIVE));
@@ -69,7 +69,7 @@ describe("Abilities - Gulp Missile", () => {
   });
 
   it("changes to Gorging Form if HP is under half when Surf or Dive is used", async () => {
-    await game.startBattle([Species.CRAMORANT]);
+    await game.classicMode.startBattle([Species.CRAMORANT]);
     const cramorant = game.scene.getPlayerPokemon()!;
 
     vi.spyOn(cramorant, "getHpRatio").mockReturnValue(.49);
@@ -83,7 +83,7 @@ describe("Abilities - Gulp Missile", () => {
   });
 
   it("changes to base form when switched out after Surf or Dive is used", async () => {
-    await game.startBattle([Species.CRAMORANT, Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.CRAMORANT, Species.MAGIKARP]);
     const cramorant = game.scene.getPlayerPokemon()!;
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.SURF));
@@ -98,7 +98,7 @@ describe("Abilities - Gulp Missile", () => {
   });
 
   it("changes form during Dive's charge turn", async () => {
-    await game.startBattle([Species.CRAMORANT]);
+    await game.classicMode.startBattle([Species.CRAMORANT]);
     const cramorant = game.scene.getPlayerPokemon()!;
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.DIVE));
@@ -110,7 +110,7 @@ describe("Abilities - Gulp Missile", () => {
 
   it("deals ¼ of the attacker's maximum HP when hit by a damaging attack", async () => {
     game.override.enemyMoveset(Array(4).fill(Moves.TACKLE));
-    await game.startBattle([Species.CRAMORANT]);
+    await game.classicMode.startBattle([Species.CRAMORANT]);
 
     const enemy = game.scene.getEnemyPokemon()!;
     vi.spyOn(enemy, "damageAndUpdate");
@@ -123,7 +123,7 @@ describe("Abilities - Gulp Missile", () => {
 
   it("does not have any effect when hit by non-damaging attack", async () => {
     game.override.enemyMoveset(Array(4).fill(Moves.TAIL_WHIP));
-    await game.startBattle([Species.CRAMORANT]);
+    await game.classicMode.startBattle([Species.CRAMORANT]);
 
     const cramorant = game.scene.getPlayerPokemon()!;
     vi.spyOn(cramorant, "getHpRatio").mockReturnValue(.55);
@@ -142,7 +142,7 @@ describe("Abilities - Gulp Missile", () => {
 
   it("lowers the attacker's Defense by 1 stage when hit in Gulping form", async () => {
     game.override.enemyMoveset(Array(4).fill(Moves.TACKLE));
-    await game.startBattle([Species.CRAMORANT]);
+    await game.classicMode.startBattle([Species.CRAMORANT]);
 
     const cramorant = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;
@@ -166,7 +166,7 @@ describe("Abilities - Gulp Missile", () => {
 
   it("paralyzes the enemy when hit in Gorging form", async () => {
     game.override.enemyMoveset(Array(4).fill(Moves.TACKLE));
-    await game.startBattle([Species.CRAMORANT]);
+    await game.classicMode.startBattle([Species.CRAMORANT]);
 
     const cramorant = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;
@@ -190,7 +190,7 @@ describe("Abilities - Gulp Missile", () => {
 
   it("does not activate the ability when underwater", async () => {
     game.override.enemyMoveset(Array(4).fill(Moves.SURF));
-    await game.startBattle([Species.CRAMORANT]);
+    await game.classicMode.startBattle([Species.CRAMORANT]);
 
     const cramorant = game.scene.getPlayerPokemon()!;
 
@@ -203,7 +203,7 @@ describe("Abilities - Gulp Missile", () => {
 
   it("prevents effect damage but inflicts secondary effect on attacker with Magic Guard", async () => {
     game.override.enemyMoveset(Array(4).fill(Moves.TACKLE)).enemyAbility(Abilities.MAGIC_GUARD);
-    await game.startBattle([Species.CRAMORANT]);
+    await game.classicMode.startBattle([Species.CRAMORANT]);
 
     const cramorant = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;
@@ -227,7 +227,7 @@ describe("Abilities - Gulp Missile", () => {
 
   it("cannot be suppressed", async () => {
     game.override.enemyMoveset(Array(4).fill(Moves.GASTRO_ACID));
-    await game.startBattle([Species.CRAMORANT]);
+    await game.classicMode.startBattle([Species.CRAMORANT]);
 
     const cramorant = game.scene.getPlayerPokemon()!;
     vi.spyOn(cramorant, "getHpRatio").mockReturnValue(.55);
@@ -247,7 +247,7 @@ describe("Abilities - Gulp Missile", () => {
 
   it("cannot be swapped with another ability", async () => {
     game.override.enemyMoveset(Array(4).fill(Moves.SKILL_SWAP));
-    await game.startBattle([Species.CRAMORANT]);
+    await game.classicMode.startBattle([Species.CRAMORANT]);
 
     const cramorant = game.scene.getPlayerPokemon()!;
     vi.spyOn(cramorant, "getHpRatio").mockReturnValue(.55);
@@ -268,7 +268,7 @@ describe("Abilities - Gulp Missile", () => {
   it("cannot be copied", async () => {
     game.override.enemyAbility(Abilities.TRACE);
 
-    await game.startBattle([Species.CRAMORANT]);
+    await game.classicMode.startBattle([Species.CRAMORANT]);
     game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
     await game.phaseInterceptor.to(TurnStartPhase);
 

--- a/src/test/abilities/heatproof.test.ts
+++ b/src/test/abilities/heatproof.test.ts
@@ -39,7 +39,7 @@ describe("Abilities - Heatproof", () => {
   });
 
   it("reduces Fire type damage by half", async () => {
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const enemy = game.scene.getEnemyPokemon()!;
     const initialHP = 1000;
@@ -64,7 +64,7 @@ describe("Abilities - Heatproof", () => {
     game.override
       .enemyStatusEffect(StatusEffect.BURN)
       .enemySpecies(Species.ABRA);
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const enemy = game.scene.getEnemyPokemon()!;
 

--- a/src/test/abilities/hustle.test.ts
+++ b/src/test/abilities/hustle.test.ts
@@ -38,7 +38,7 @@ describe("Abilities - Hustle", () => {
   });
 
   it("increases the user's Attack stat by 50%", async () => {
-    await game.startBattle([Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU]);
     const pikachu = game.scene.getPlayerPokemon()!;
     const atk = pikachu.stats[Stat.ATK];
 
@@ -52,7 +52,7 @@ describe("Abilities - Hustle", () => {
   });
 
   it("lowers the accuracy of the user's physical moves by 20%", async () => {
-    await game.startBattle([Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU]);
     const pikachu = game.scene.getPlayerPokemon()!;
 
     vi.spyOn(pikachu, "getAccuracyMultiplier");
@@ -64,7 +64,7 @@ describe("Abilities - Hustle", () => {
   });
 
   it("does not affect non-physical moves", async () => {
-    await game.startBattle([Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU]);
     const pikachu = game.scene.getPlayerPokemon()!;
     const spatk = pikachu.stats[Stat.SPATK];
 
@@ -82,7 +82,7 @@ describe("Abilities - Hustle", () => {
     game.override.startingLevel(100);
     game.override.enemyLevel(30);
 
-    await game.startBattle([Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU]);
     const pikachu = game.scene.getPlayerPokemon()!;
     const enemyPokemon = game.scene.getEnemyPokemon()!;
 

--- a/src/test/abilities/hyper_cutter.test.ts
+++ b/src/test/abilities/hyper_cutter.test.ts
@@ -36,7 +36,7 @@ describe("Abilities - Hyper Cutter", () => {
   // Reference Link: https://bulbapedia.bulbagarden.net/wiki/Hyper_Cutter_(Ability)
 
   it("only prevents ATK drops", async () => {
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const enemy = game.scene.getEnemyPokemon()!;
 

--- a/src/test/abilities/ice_face.test.ts
+++ b/src/test/abilities/ice_face.test.ts
@@ -37,7 +37,7 @@ describe("Abilities - Ice Face", () => {
   });
 
   it("takes no damage from physical move and transforms to Noice", async () => {
-    await game.startBattle([Species.HITMONLEE]);
+    await game.classicMode.startBattle([Species.HITMONLEE]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.TACKLE));
 
@@ -53,7 +53,7 @@ describe("Abilities - Ice Face", () => {
   it("takes no damage from the first hit of multihit physical move and transforms to Noice", async () => {
     game.override.moveset([Moves.SURGING_STRIKES]);
     game.override.enemyLevel(1);
-    await game.startBattle([Species.HITMONLEE]);
+    await game.classicMode.startBattle([Species.HITMONLEE]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.SURGING_STRIKES));
 
@@ -79,7 +79,7 @@ describe("Abilities - Ice Face", () => {
   });
 
   it("takes damage from special moves", async () => {
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.ICE_BEAM));
 
@@ -93,7 +93,7 @@ describe("Abilities - Ice Face", () => {
   });
 
   it("takes effects from status moves", async () => {
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.TOXIC_THREAD));
 
@@ -109,7 +109,7 @@ describe("Abilities - Ice Face", () => {
     game.override.moveset([Moves.QUICK_ATTACK]);
     game.override.enemyMoveset([Moves.HAIL, Moves.HAIL, Moves.HAIL, Moves.HAIL]);
 
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.QUICK_ATTACK));
 
@@ -131,7 +131,7 @@ describe("Abilities - Ice Face", () => {
     game.override.enemyMoveset([Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE]);
     game.override.moveset([Moves.SNOWSCAPE]);
 
-    await game.startBattle([Species.EISCUE, Species.NINJASK]);
+    await game.classicMode.startBattle([Species.EISCUE, Species.NINJASK]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.SNOWSCAPE));
 
@@ -158,7 +158,7 @@ describe("Abilities - Ice Face", () => {
     game.override.enemySpecies(Species.SHUCKLE);
     game.override.enemyMoveset([Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE]);
 
-    await game.startBattle([Species.EISCUE]);
+    await game.classicMode.startBattle([Species.EISCUE]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.HAIL));
     const eiscue = game.scene.getPlayerPokemon()!;
@@ -177,7 +177,7 @@ describe("Abilities - Ice Face", () => {
   it("persists form change when switched out", async () => {
     game.override.enemyMoveset([Moves.QUICK_ATTACK, Moves.QUICK_ATTACK, Moves.QUICK_ATTACK, Moves.QUICK_ATTACK]);
 
-    await game.startBattle([Species.EISCUE, Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.EISCUE, Species.MAGIKARP]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.ICE_BEAM));
 
@@ -206,7 +206,7 @@ describe("Abilities - Ice Face", () => {
       [Species.EISCUE]: noiceForm,
     });
 
-    await game.startBattle([Species.EISCUE]);
+    await game.classicMode.startBattle([Species.EISCUE]);
 
     const eiscue = game.scene.getPlayerPokemon()!;
 
@@ -226,7 +226,7 @@ describe("Abilities - Ice Face", () => {
   it("cannot be suppressed", async () => {
     game.override.moveset([Moves.GASTRO_ACID]);
 
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.GASTRO_ACID));
 
@@ -242,7 +242,7 @@ describe("Abilities - Ice Face", () => {
   it("cannot be swapped with another ability", async () => {
     game.override.moveset([Moves.SKILL_SWAP]);
 
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.SKILL_SWAP));
 
@@ -258,7 +258,7 @@ describe("Abilities - Ice Face", () => {
   it("cannot be copied", async () => {
     game.override.ability(Abilities.TRACE);
 
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.SIMPLE_BEAM));
 

--- a/src/test/abilities/intimidate.test.ts
+++ b/src/test/abilities/intimidate.test.ts
@@ -211,7 +211,7 @@ describe("Abilities - Intimidate", () => {
   it("single - wild next wave opp triger once, us: none", async () => {
     game.override.startingWave(2);
     game.override.moveset([Moves.AERIAL_ACE]);
-    await game.startBattle([Species.MIGHTYENA, Species.POOCHYENA]);
+    await game.classicMode.startBattle([Species.MIGHTYENA, Species.POOCHYENA]);
     let battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
     expect(battleStatsOpponent[BattleStat.ATK]).toBe(-1);
     let battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
@@ -237,7 +237,7 @@ describe("Abilities - Intimidate", () => {
   it("single - wild next turn - no retrigger on next turn", async () => {
     game.override.startingWave(2);
     game.override.moveset([Moves.SPLASH]);
-    await game.startBattle([Species.MIGHTYENA, Species.POOCHYENA]);
+    await game.classicMode.startBattle([Species.MIGHTYENA, Species.POOCHYENA]);
     let battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
     expect(battleStatsOpponent[BattleStat.ATK]).toBe(-1);
     let battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
@@ -262,7 +262,7 @@ describe("Abilities - Intimidate", () => {
     game.override.moveset([Moves.SPLASH]);
     game.override.enemyMoveset([Moves.VOLT_SWITCH, Moves.VOLT_SWITCH, Moves.VOLT_SWITCH, Moves.VOLT_SWITCH]);
     game.override.startingWave(5);
-    await game.startBattle([Species.MIGHTYENA, Species.POOCHYENA]);
+    await game.classicMode.startBattle([Species.MIGHTYENA, Species.POOCHYENA]);
     let battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
     expect(battleStatsOpponent[BattleStat.ATK]).toBe(-1);
     let battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;
@@ -301,7 +301,7 @@ describe("Abilities - Intimidate", () => {
     game.override.moveset([Moves.SPLASH]);
     game.override.enemyMoveset(SPLASH_ONLY);
     game.override.startingWave(5);
-    await game.startBattle([Species.MIGHTYENA, Species.POOCHYENA]);
+    await game.classicMode.startBattle([Species.MIGHTYENA, Species.POOCHYENA]);
     let battleStatsOpponent = game.scene.currentBattle.enemyParty[0].summonData.battleStats;
     expect(battleStatsOpponent[BattleStat.ATK]).toBe(-1);
     let battleStatsPokemon = game.scene.getParty()[0].summonData.battleStats;

--- a/src/test/abilities/libero.test.ts
+++ b/src/test/abilities/libero.test.ts
@@ -44,7 +44,7 @@ describe("Abilities - Libero", () => {
     async () => {
       game.override.moveset([Moves.SPLASH]);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -62,7 +62,7 @@ describe("Abilities - Libero", () => {
     async () => {
       game.override.moveset([Moves.SPLASH, Moves.AGILITY]);
 
-      await game.startBattle([Species.MAGIKARP, Species.BULBASAUR]);
+      await game.classicMode.startBattle([Species.MAGIKARP, Species.BULBASAUR]);
 
       let leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -102,7 +102,7 @@ describe("Abilities - Libero", () => {
     async () => {
       game.override.moveset([Moves.WEATHER_BALL]);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -126,7 +126,7 @@ describe("Abilities - Libero", () => {
       game.override.moveset([Moves.TACKLE]);
       game.override.passiveAbility(Abilities.REFRIGERATE);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -148,7 +148,7 @@ describe("Abilities - Libero", () => {
     async () => {
       game.override.moveset([Moves.NATURE_POWER]);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -167,7 +167,7 @@ describe("Abilities - Libero", () => {
     async () => {
       game.override.moveset([Moves.DIG]);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -186,7 +186,7 @@ describe("Abilities - Libero", () => {
       game.override.moveset([Moves.TACKLE]);
       game.override.enemyMoveset(SPLASH_ONLY);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -208,7 +208,7 @@ describe("Abilities - Libero", () => {
       game.override.moveset([Moves.TACKLE]);
       game.override.enemyMoveset([Moves.PROTECT, Moves.PROTECT, Moves.PROTECT, Moves.PROTECT]);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -227,7 +227,7 @@ describe("Abilities - Libero", () => {
       game.override.moveset([Moves.TACKLE]);
       game.override.enemySpecies(Species.GASTLY);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -245,7 +245,7 @@ describe("Abilities - Libero", () => {
     async () => {
       game.override.moveset([Moves.SPLASH]);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -264,7 +264,7 @@ describe("Abilities - Libero", () => {
     async () => {
       game.override.moveset([Moves.SPLASH]);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -284,7 +284,7 @@ describe("Abilities - Libero", () => {
     async () => {
       game.override.moveset([Moves.STRUGGLE]);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -302,7 +302,7 @@ describe("Abilities - Libero", () => {
     async () => {
       game.override.moveset([Moves.BURN_UP]);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -321,7 +321,7 @@ describe("Abilities - Libero", () => {
       game.override.moveset([Moves.TRICK_OR_TREAT]);
       game.override.enemySpecies(Species.GASTLY);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -339,7 +339,7 @@ describe("Abilities - Libero", () => {
     async () => {
       game.override.moveset([Moves.CURSE]);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);

--- a/src/test/abilities/magic_guard.test.ts
+++ b/src/test/abilities/magic_guard.test.ts
@@ -51,7 +51,7 @@ describe("Abilities - Magic Guard", () => {
     async () => {
       game.override.weather(WeatherType.SANDSTORM);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
 
@@ -78,7 +78,7 @@ describe("Abilities - Magic Guard", () => {
       //Toxic keeps track of the turn counters -> important that Magic Guard keeps track of post-Toxic turns
       game.override.statusEffect(StatusEffect.POISON);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
 
@@ -102,7 +102,7 @@ describe("Abilities - Magic Guard", () => {
       game.override.enemyMoveset([Moves.WORRY_SEED,Moves.WORRY_SEED,Moves.WORRY_SEED,Moves.WORRY_SEED]);
       game.override.statusEffect(StatusEffect.POISON);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
 
@@ -124,7 +124,7 @@ describe("Abilities - Magic Guard", () => {
       game.override.enemyStatusEffect(StatusEffect.BURN);
       game.override.enemyAbility(Abilities.MAGIC_GUARD);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
 
@@ -148,7 +148,7 @@ describe("Abilities - Magic Guard", () => {
       game.override.enemyStatusEffect(StatusEffect.TOXIC);
       game.override.enemyAbility(Abilities.MAGIC_GUARD);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
 
@@ -177,7 +177,7 @@ describe("Abilities - Magic Guard", () => {
     const newTag = getArenaTag(ArenaTagType.SPIKES, 5, Moves.SPIKES, 0, 0, ArenaTagSide.BOTH)!;
     game.scene.arena.tags.push(newTag);
 
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
     const leadPokemon = game.scene.getPlayerPokemon()!;
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
@@ -203,7 +203,7 @@ describe("Abilities - Magic Guard", () => {
     game.scene.arena.tags.push(playerTag);
     game.scene.arena.tags.push(enemyTag);
 
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
     const leadPokemon = game.scene.getPlayerPokemon()!;
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
@@ -227,7 +227,7 @@ describe("Abilities - Magic Guard", () => {
 
   it("Magic Guard prevents against damage from volatile status effects",
     async () => {
-      await game.startBattle([Species.DUSKULL]);
+      await game.classicMode.startBattle([Species.DUSKULL]);
       game.override.moveset([Moves.CURSE]);
       game.override.enemyAbility(Abilities.MAGIC_GUARD);
 
@@ -253,7 +253,7 @@ describe("Abilities - Magic Guard", () => {
 
   it("Magic Guard prevents crash damage", async () => {
     game.override.moveset([Moves.HIGH_JUMP_KICK]);
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
 
     const leadPokemon = game.scene.getPlayerPokemon()!;
 
@@ -272,7 +272,7 @@ describe("Abilities - Magic Guard", () => {
 
   it("Magic Guard prevents damage from recoil", async () => {
     game.override.moveset([Moves.TAKE_DOWN]);
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
 
     const leadPokemon = game.scene.getPlayerPokemon()!;
 
@@ -290,7 +290,7 @@ describe("Abilities - Magic Guard", () => {
 
   it("Magic Guard does not prevent damage from Struggle's recoil", async () => {
     game.override.moveset([Moves.STRUGGLE]);
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
 
     const leadPokemon = game.scene.getPlayerPokemon()!;
 
@@ -309,7 +309,7 @@ describe("Abilities - Magic Guard", () => {
   //This tests different move attributes than the recoil tests above
   it("Magic Guard prevents self-damage from attacking moves", async () => {
     game.override.moveset([Moves.STEEL_BEAM]);
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
 
     const leadPokemon = game.scene.getPlayerPokemon()!;
 
@@ -327,7 +327,7 @@ describe("Abilities - Magic Guard", () => {
 
   /*
   it("Magic Guard does not prevent self-damage from confusion", async () => {
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
 
@@ -337,7 +337,7 @@ describe("Abilities - Magic Guard", () => {
 
   it("Magic Guard does not prevent self-damage from non-attacking moves", async () => {
     game.override.moveset([Moves.BELLY_DRUM]);
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
 
     const leadPokemon = game.scene.getPlayerPokemon()!;
 
@@ -360,7 +360,7 @@ describe("Abilities - Magic Guard", () => {
     game.override.enemyMoveset([Moves.SPORE, Moves.SPORE, Moves.SPORE, Moves.SPORE]);
     game.override.enemyAbility(Abilities.BAD_DREAMS);
 
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
 
     const leadPokemon = game.scene.getPlayerPokemon()!;
 
@@ -383,7 +383,7 @@ describe("Abilities - Magic Guard", () => {
     game.override.moveset([Moves.TACKLE]);
     game.override.enemyAbility(Abilities.AFTERMATH);
 
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
 
     const leadPokemon = game.scene.getPlayerPokemon()!;
 
@@ -408,7 +408,7 @@ describe("Abilities - Magic Guard", () => {
     game.override.moveset([Moves.TACKLE]);
     game.override.enemyAbility(Abilities.IRON_BARBS);
 
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
 
     const leadPokemon = game.scene.getPlayerPokemon()!;
 
@@ -432,7 +432,7 @@ describe("Abilities - Magic Guard", () => {
     game.override.moveset([Moves.ABSORB]);
     game.override.enemyAbility(Abilities.LIQUID_OOZE);
 
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
 
     const leadPokemon = game.scene.getPlayerPokemon()!;
 
@@ -456,7 +456,7 @@ describe("Abilities - Magic Guard", () => {
     game.override.passiveAbility(Abilities.SOLAR_POWER);
     game.override.weather(WeatherType.SUNNY);
 
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
     const leadPokemon = game.scene.getPlayerPokemon()!;
     game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
     await game.phaseInterceptor.to(TurnEndPhase);

--- a/src/test/abilities/moxie.test.ts
+++ b/src/test/abilities/moxie.test.ts
@@ -42,7 +42,7 @@ describe("Abilities - Moxie", () => {
 
   it("MOXIE", async() => {
     const moveToUse = Moves.AERIAL_ACE;
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.MIGHTYENA,
       Species.MIGHTYENA,
     ]);

--- a/src/test/abilities/mycelium_might.test.ts
+++ b/src/test/abilities/mycelium_might.test.ts
@@ -43,7 +43,7 @@ describe("Abilities - Mycelium Might", () => {
    **/
 
   it("If a Pokemon with Mycelium Might uses a status move, it will always move last but the status move will ignore protective abilities", async() => {
-    await game.startBattle([ Species.REGIELEKI ]);
+    await game.classicMode.startBattle([ Species.REGIELEKI ]);
 
     const leadIndex = game.scene.getPlayerPokemon()!.getBattlerIndex();
     const enemyPokemon = game.scene.getEnemyPokemon();
@@ -66,7 +66,7 @@ describe("Abilities - Mycelium Might", () => {
 
   it("Pokemon with Mycelium Might will go first if a status move that is in a higher priority bracket than the opponent's move is used", async() => {
     game.override.enemyMoveset([Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE]);
-    await game.startBattle([ Species.REGIELEKI ]);
+    await game.classicMode.startBattle([ Species.REGIELEKI ]);
 
     const leadIndex = game.scene.getPlayerPokemon()!.getBattlerIndex();
     const enemyPokemon = game.scene.getEnemyPokemon();
@@ -87,7 +87,7 @@ describe("Abilities - Mycelium Might", () => {
   }, 20000);
 
   it("Order is established normally if the Pokemon uses a non-status move", async() => {
-    await game.startBattle([ Species.REGIELEKI ]);
+    await game.classicMode.startBattle([ Species.REGIELEKI ]);
 
     const leadIndex = game.scene.getPlayerPokemon()!.getBattlerIndex();
     const enemyIndex = game.scene.getEnemyPokemon()!.getBattlerIndex();

--- a/src/test/abilities/parental_bond.test.ts
+++ b/src/test/abilities/parental_bond.test.ts
@@ -50,7 +50,7 @@ describe("Abilities - Parental Bond", () => {
     async () => {
       game.override.moveset([Moves.TACKLE]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -83,7 +83,7 @@ describe("Abilities - Parental Bond", () => {
       game.override.moveset([Moves.POWER_UP_PUNCH]);
       game.override.enemySpecies(Species.AMOONGUSS);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -105,7 +105,7 @@ describe("Abilities - Parental Bond", () => {
     async () => {
       game.override.moveset([Moves.BABY_DOLL_EYES]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -125,7 +125,7 @@ describe("Abilities - Parental Bond", () => {
     async () => {
       game.override.moveset([Moves.DOUBLE_HIT]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -147,7 +147,7 @@ describe("Abilities - Parental Bond", () => {
     async () => {
       game.override.moveset([Moves.SELF_DESTRUCT]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -168,7 +168,7 @@ describe("Abilities - Parental Bond", () => {
     async () => {
       game.override.moveset([Moves.ROLLOUT]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -190,7 +190,7 @@ describe("Abilities - Parental Bond", () => {
     async () => {
       game.override.moveset([Moves.DRAGON_RAGE]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -213,7 +213,7 @@ describe("Abilities - Parental Bond", () => {
       game.override.moveset([Moves.COUNTER]);
       game.override.enemyMoveset([Moves.TACKLE,Moves.TACKLE,Moves.TACKLE,Moves.TACKLE]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -241,7 +241,7 @@ describe("Abilities - Parental Bond", () => {
       game.override.battleType("double");
       game.override.moveset([Moves.EARTHQUAKE]);
 
-      await game.startBattle([Species.CHARIZARD, Species.PIDGEOT]);
+      await game.classicMode.startBattle([Species.CHARIZARD, Species.PIDGEOT]);
 
       const playerPokemon = game.scene.getPlayerField();
       expect(playerPokemon.length).toBe(2);
@@ -266,7 +266,7 @@ describe("Abilities - Parental Bond", () => {
     async () => {
       game.override.moveset([Moves.EARTHQUAKE]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -286,7 +286,7 @@ describe("Abilities - Parental Bond", () => {
     async () => {
       game.override.moveset([Moves.MIND_BLOWN]);
 
-      await game.startBattle([Species.PIDGEOT]);
+      await game.classicMode.startBattle([Species.PIDGEOT]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -312,7 +312,7 @@ describe("Abilities - Parental Bond", () => {
     async () => {
       game.override.moveset([Moves.BURN_UP]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -340,7 +340,7 @@ describe("Abilities - Parental Bond", () => {
       game.override.moveset([Moves.TACKLE]);
       game.override.startingHeldItems([{name: "MULTI_LENS", count: 1}]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -362,7 +362,7 @@ describe("Abilities - Parental Bond", () => {
       game.override.moveset([Moves.SUPER_FANG]);
       game.override.startingHeldItems([{name: "MULTI_LENS", count: 1}]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -391,7 +391,7 @@ describe("Abilities - Parental Bond", () => {
       game.override.moveset([Moves.SEISMIC_TOSS]);
       game.override.startingHeldItems([{name: "MULTI_LENS", count: 1}]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -419,7 +419,7 @@ describe("Abilities - Parental Bond", () => {
     async () => {
       game.override.moveset([Moves.HYPER_BEAM]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -447,7 +447,7 @@ describe("Abilities - Parental Bond", () => {
     async () => {
       game.override.moveset([Moves.ANCHOR_SHOT]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -477,7 +477,7 @@ describe("Abilities - Parental Bond", () => {
     async () => {
       game.override.moveset([Moves.SMACK_DOWN]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -504,7 +504,7 @@ describe("Abilities - Parental Bond", () => {
     async () => {
       game.override.moveset([Moves.U_TURN]);
 
-      await game.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
+      await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -528,7 +528,7 @@ describe("Abilities - Parental Bond", () => {
     async () => {
       game.override.moveset([Moves.WAKE_UP_SLAP]).enemyStatusEffect(StatusEffect.SLEEP);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -556,7 +556,7 @@ describe("Abilities - Parental Bond", () => {
       game.override.moveset([Moves.TACKLE]);
       game.override.enemyMoveset([Moves.KINGS_SHIELD,Moves.KINGS_SHIELD,Moves.KINGS_SHIELD,Moves.KINGS_SHIELD]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -578,7 +578,7 @@ describe("Abilities - Parental Bond", () => {
       game.override.moveset([Moves.WATER_GUN]);
       game.override.enemyAbility(Abilities.STORM_DRAIN);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -601,7 +601,7 @@ describe("Abilities - Parental Bond", () => {
       game.override.moveset([Moves.EARTHQUAKE, Moves.SPLASH]);
       game.override.startingHeldItems([{name: "MULTI_LENS", count: 1}]);
 
-      await game.startBattle([Species.CHARIZARD, Species.PIDGEOT]);
+      await game.classicMode.startBattle([Species.CHARIZARD, Species.PIDGEOT]);
 
       const playerPokemon = game.scene.getPlayerField();
       expect(playerPokemon.length).toBe(2);

--- a/src/test/abilities/pastel_veil.test.ts
+++ b/src/test/abilities/pastel_veil.test.ts
@@ -35,7 +35,7 @@ describe("Abilities - Pastel Veil", () => {
   });
 
   it("prevents the user and its allies from being afflicted by poison", async () => {
-    await game.startBattle([Species.GALAR_PONYTA, Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.GALAR_PONYTA, Species.MAGIKARP]);
     const ponyta = game.scene.getPlayerField()[0];
 
     vi.spyOn(ponyta, "getAbility").mockReturnValue(allAbilities[Abilities.PASTEL_VEIL]);
@@ -51,7 +51,7 @@ describe("Abilities - Pastel Veil", () => {
   });
 
   it("it heals the poisoned status condition of allies if user is sent out into battle", async () => {
-    await game.startBattle([Species.MAGIKARP, Species.MAGIKARP, Species.GALAR_PONYTA]);
+    await game.classicMode.startBattle([Species.MAGIKARP, Species.MAGIKARP, Species.GALAR_PONYTA]);
     const ponyta = game.scene.getParty().find(p => p.species.speciesId === Species.GALAR_PONYTA)!;
 
     vi.spyOn(ponyta, "getAbility").mockReturnValue(allAbilities[Abilities.PASTEL_VEIL]);

--- a/src/test/abilities/power_construct.test.ts
+++ b/src/test/abilities/power_construct.test.ts
@@ -43,7 +43,7 @@ describe("Abilities - POWER CONSTRUCT", () => {
         [Species.ZYGARDE]: completeForm,
       });
 
-      await game.startBattle([Species.MAGIKARP, Species.ZYGARDE]);
+      await game.classicMode.startBattle([Species.MAGIKARP, Species.ZYGARDE]);
 
       const zygarde = game.scene.getParty().find((p) => p.species.speciesId === Species.ZYGARDE);
       expect(zygarde).not.toBe(undefined);

--- a/src/test/abilities/power_spot.test.ts
+++ b/src/test/abilities/power_spot.test.ts
@@ -41,7 +41,7 @@ describe("Abilities - Power Spot", () => {
 
     vi.spyOn(moveToCheck, "calculateBattlePower");
 
-    await game.startBattle([Species.REGIELEKI, Species.STONJOURNER]);
+    await game.classicMode.startBattle([Species.REGIELEKI, Species.STONJOURNER]);
     game.doAttack(getMovePosition(game.scene, 0, Moves.DAZZLING_GLEAM));
     game.doAttack(getMovePosition(game.scene, 1, Moves.SPLASH));
     await game.phaseInterceptor.to(MoveEffectPhase);
@@ -55,7 +55,7 @@ describe("Abilities - Power Spot", () => {
 
     vi.spyOn(moveToCheck, "calculateBattlePower");
 
-    await game.startBattle([Species.REGIELEKI, Species.STONJOURNER]);
+    await game.classicMode.startBattle([Species.REGIELEKI, Species.STONJOURNER]);
     game.doAttack(getMovePosition(game.scene, 0, Moves.BREAKING_SWIPE));
     game.doAttack(getMovePosition(game.scene, 1, Moves.SPLASH));
     await game.phaseInterceptor.to(MoveEffectPhase);
@@ -69,7 +69,7 @@ describe("Abilities - Power Spot", () => {
 
     vi.spyOn(moveToCheck, "calculateBattlePower");
 
-    await game.startBattle([Species.STONJOURNER, Species.REGIELEKI]);
+    await game.classicMode.startBattle([Species.STONJOURNER, Species.REGIELEKI]);
     game.doAttack(getMovePosition(game.scene, 0, Moves.BREAKING_SWIPE));
     game.doAttack(getMovePosition(game.scene, 1, Moves.SPLASH));
     await game.phaseInterceptor.to(TurnEndPhase);

--- a/src/test/abilities/protean.test.ts
+++ b/src/test/abilities/protean.test.ts
@@ -44,7 +44,7 @@ describe("Abilities - Protean", () => {
     async () => {
       game.override.moveset([Moves.SPLASH]);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -62,7 +62,7 @@ describe("Abilities - Protean", () => {
     async () => {
       game.override.moveset([Moves.SPLASH, Moves.AGILITY]);
 
-      await game.startBattle([Species.MAGIKARP, Species.BULBASAUR]);
+      await game.classicMode.startBattle([Species.MAGIKARP, Species.BULBASAUR]);
 
       let leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -102,7 +102,7 @@ describe("Abilities - Protean", () => {
     async () => {
       game.override.moveset([Moves.WEATHER_BALL]);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -126,7 +126,7 @@ describe("Abilities - Protean", () => {
       game.override.moveset([Moves.TACKLE]);
       game.override.passiveAbility(Abilities.REFRIGERATE);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -148,7 +148,7 @@ describe("Abilities - Protean", () => {
     async () => {
       game.override.moveset([Moves.NATURE_POWER]);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -167,7 +167,7 @@ describe("Abilities - Protean", () => {
     async () => {
       game.override.moveset([Moves.DIG]);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -186,7 +186,7 @@ describe("Abilities - Protean", () => {
       game.override.moveset([Moves.TACKLE]);
       game.override.enemyMoveset(SPLASH_ONLY);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -208,7 +208,7 @@ describe("Abilities - Protean", () => {
       game.override.moveset([Moves.TACKLE]);
       game.override.enemyMoveset([Moves.PROTECT, Moves.PROTECT, Moves.PROTECT, Moves.PROTECT]);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -227,7 +227,7 @@ describe("Abilities - Protean", () => {
       game.override.moveset([Moves.TACKLE]);
       game.override.enemySpecies(Species.GASTLY);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -245,7 +245,7 @@ describe("Abilities - Protean", () => {
     async () => {
       game.override.moveset([Moves.SPLASH]);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -264,7 +264,7 @@ describe("Abilities - Protean", () => {
     async () => {
       game.override.moveset([Moves.SPLASH]);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -284,7 +284,7 @@ describe("Abilities - Protean", () => {
     async () => {
       game.override.moveset([Moves.STRUGGLE]);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -302,7 +302,7 @@ describe("Abilities - Protean", () => {
     async () => {
       game.override.moveset([Moves.BURN_UP]);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -321,7 +321,7 @@ describe("Abilities - Protean", () => {
       game.override.moveset([Moves.TRICK_OR_TREAT]);
       game.override.enemySpecies(Species.GASTLY);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);
@@ -339,7 +339,7 @@ describe("Abilities - Protean", () => {
     async () => {
       game.override.moveset([Moves.CURSE]);
 
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).not.toBe(undefined);

--- a/src/test/abilities/quick_draw.test.ts
+++ b/src/test/abilities/quick_draw.test.ts
@@ -39,7 +39,7 @@ describe("Abilities - Quick Draw", () => {
   });
 
   test("makes pokemon going first in its priority bracket", async () => {
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const pokemon = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;
@@ -59,7 +59,7 @@ describe("Abilities - Quick Draw", () => {
     timeout: 20000,
     retry: 5
   }, async () => {
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const pokemon = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;
@@ -79,7 +79,7 @@ describe("Abilities - Quick Draw", () => {
   test("does not increase priority", async () => {
     game.override.enemyMoveset(Array(4).fill(Moves.EXTREME_SPEED));
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const pokemon = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;

--- a/src/test/abilities/sand_spit.test.ts
+++ b/src/test/abilities/sand_spit.test.ts
@@ -37,7 +37,7 @@ describe("Abilities - Sand Spit", () => {
 
   it("should trigger when hit with damaging move", async() => {
     game.override.enemyMoveset(Array(4).fill(Moves.TACKLE));
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
     await game.toNextTurn();
@@ -47,7 +47,7 @@ describe("Abilities - Sand Spit", () => {
 
   it("should not trigger when targetted with status moves", async() => {
     game.override.enemyMoveset(Array(4).fill(Moves.GROWL));
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.COIL));
     await game.toNextTurn();

--- a/src/test/abilities/sand_veil.test.ts
+++ b/src/test/abilities/sand_veil.test.ts
@@ -44,7 +44,7 @@ describe("Abilities - Sand Veil", () => {
   test(
     "ability should increase the evasiveness of the source",
     async () => {
-      await game.startBattle([Species.SNORLAX, Species.BLISSEY]);
+      await game.classicMode.startBattle([Species.SNORLAX, Species.BLISSEY]);
 
       const leadPokemon = game.scene.getPlayerField();
 

--- a/src/test/abilities/sap_sipper.test.ts
+++ b/src/test/abilities/sap_sipper.test.ts
@@ -41,7 +41,7 @@ describe("Abilities - Sap Sipper", () => {
     game.override.enemySpecies(Species.DUSKULL);
     game.override.enemyAbility(enemyAbility);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const startingOppHp = game.scene.currentBattle.enemyParty[0].hp;
 
@@ -62,7 +62,7 @@ describe("Abilities - Sap Sipper", () => {
     game.override.enemySpecies(Species.RATTATA);
     game.override.enemyAbility(enemyAbility);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     game.doAttack(getMovePosition(game.scene, 0, moveToUse));
 
@@ -81,7 +81,7 @@ describe("Abilities - Sap Sipper", () => {
     game.override.enemySpecies(Species.RATTATA);
     game.override.enemyAbility(enemyAbility);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     game.doAttack(getMovePosition(game.scene, 0, moveToUse));
 
@@ -101,7 +101,7 @@ describe("Abilities - Sap Sipper", () => {
     game.override.enemySpecies(Species.RATTATA);
     game.override.enemyAbility(enemyAbility);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const startingOppHp = game.scene.currentBattle.enemyParty[0].hp;
 
@@ -123,7 +123,7 @@ describe("Abilities - Sap Sipper", () => {
     game.override.enemySpecies(Species.RATTATA);
     game.override.enemyAbility(Abilities.NONE);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     game.doAttack(getMovePosition(game.scene, 0, moveToUse));
 
@@ -148,7 +148,7 @@ describe("Abilities - Sap Sipper", () => {
     game.override.enemySpecies(Species.RATTATA);
     game.override.enemyAbility(enemyAbility);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const startingOppHp = game.scene.currentBattle.enemyParty[0].hp;
 

--- a/src/test/abilities/schooling.test.ts
+++ b/src/test/abilities/schooling.test.ts
@@ -43,7 +43,7 @@ describe("Abilities - SCHOOLING", () => {
         [Species.WISHIWASHI]: schoolForm,
       });
 
-      await game.startBattle([Species.MAGIKARP, Species.WISHIWASHI]);
+      await game.classicMode.startBattle([Species.MAGIKARP, Species.WISHIWASHI]);
 
       const wishiwashi = game.scene.getParty().find((p) => p.species.speciesId === Species.WISHIWASHI)!;
       expect(wishiwashi).not.toBe(undefined);

--- a/src/test/abilities/screen_cleaner.test.ts
+++ b/src/test/abilities/screen_cleaner.test.ts
@@ -34,7 +34,7 @@ describe("Abilities - Screen Cleaner", () => {
     game.override.moveset([Moves.HAIL]);
     game.override.enemyMoveset([Moves.AURORA_VEIL, Moves.AURORA_VEIL, Moves.AURORA_VEIL, Moves.AURORA_VEIL]);
 
-    await game.startBattle([Species.MAGIKARP, Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP, Species.MAGIKARP]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.HAIL));
     await game.phaseInterceptor.to(TurnEndPhase);
@@ -51,7 +51,7 @@ describe("Abilities - Screen Cleaner", () => {
   it("removes Light Screen", async () => {
     game.override.enemyMoveset([Moves.LIGHT_SCREEN, Moves.LIGHT_SCREEN, Moves.LIGHT_SCREEN, Moves.LIGHT_SCREEN]);
 
-    await game.startBattle([Species.MAGIKARP, Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP, Species.MAGIKARP]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
     await game.phaseInterceptor.to(TurnEndPhase);
@@ -68,7 +68,7 @@ describe("Abilities - Screen Cleaner", () => {
   it("removes Reflect", async () => {
     game.override.enemyMoveset([Moves.REFLECT, Moves.REFLECT, Moves.REFLECT, Moves.REFLECT]);
 
-    await game.startBattle([Species.MAGIKARP, Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP, Species.MAGIKARP]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
     await game.phaseInterceptor.to(TurnEndPhase);

--- a/src/test/abilities/serene_grace.test.ts
+++ b/src/test/abilities/serene_grace.test.ts
@@ -41,7 +41,7 @@ describe("Abilities - Serene Grace", () => {
 
   it("Move chance without Serene Grace", async() => {
     const moveToUse = Moves.AIR_SLASH;
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PIDGEOT
     ]);
 
@@ -75,7 +75,7 @@ describe("Abilities - Serene Grace", () => {
   it("Move chance with Serene Grace", async() => {
     const moveToUse = Moves.AIR_SLASH;
     game.override.ability(Abilities.SERENE_GRACE);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.TOGEKISS
     ]);
 

--- a/src/test/abilities/sheer_force.test.ts
+++ b/src/test/abilities/sheer_force.test.ts
@@ -42,7 +42,7 @@ describe("Abilities - Sheer Force", () => {
   it("Sheer Force", async() => {
     const moveToUse = Moves.AIR_SLASH;
     game.override.ability(Abilities.SHEER_FORCE);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PIDGEOT
     ]);
 
@@ -81,7 +81,7 @@ describe("Abilities - Sheer Force", () => {
   it("Sheer Force with exceptions including binding moves", async() => {
     const moveToUse = Moves.BIND;
     game.override.ability(Abilities.SHEER_FORCE);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PIDGEOT
     ]);
 
@@ -120,7 +120,7 @@ describe("Abilities - Sheer Force", () => {
   it("Sheer Force with moves with no secondary effect", async() => {
     const moveToUse = Moves.TACKLE;
     game.override.ability(Abilities.SHEER_FORCE);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PIDGEOT
     ]);
 
@@ -161,7 +161,7 @@ describe("Abilities - Sheer Force", () => {
     game.override.enemyAbility(Abilities.COLOR_CHANGE);
     game.override.startingHeldItems([{name: "KINGS_ROCK", count: 1}]);
     game.override.ability(Abilities.SHEER_FORCE);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PIDGEOT
     ]);
 

--- a/src/test/abilities/shield_dust.test.ts
+++ b/src/test/abilities/shield_dust.test.ts
@@ -42,7 +42,7 @@ describe("Abilities - Shield Dust", () => {
 
   it("Shield Dust", async() => {
     const moveToUse = Moves.AIR_SLASH;
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PIDGEOT
     ]);
 

--- a/src/test/abilities/shields_down.test.ts
+++ b/src/test/abilities/shields_down.test.ts
@@ -43,7 +43,7 @@ describe("Abilities - SHIELDS DOWN", () => {
         [Species.MINIOR]: coreForm,
       });
 
-      await game.startBattle([Species.MAGIKARP, Species.MINIOR]);
+      await game.classicMode.startBattle([Species.MAGIKARP, Species.MINIOR]);
 
       const minior = game.scene.getParty().find((p) => p.species.speciesId === Species.MINIOR)!;
       expect(minior).not.toBe(undefined);

--- a/src/test/abilities/stall.test.ts
+++ b/src/test/abilities/stall.test.ts
@@ -39,7 +39,7 @@ describe("Abilities - Stall", () => {
    **/
 
   it("Pokemon with Stall should move last in its priority bracket regardless of speed", async() => {
-    await game.startBattle([ Species.SHUCKLE ]);
+    await game.classicMode.startBattle([ Species.SHUCKLE ]);
 
     const leadIndex = game.scene.getPlayerPokemon()!.getBattlerIndex();
     const enemyIndex = game.scene.getEnemyPokemon()!.getBattlerIndex();
@@ -57,7 +57,7 @@ describe("Abilities - Stall", () => {
   }, 20000);
 
   it("Pokemon with Stall will go first if a move that is in a higher priority bracket than the opponent's move is used", async() => {
-    await game.startBattle([ Species.SHUCKLE ]);
+    await game.classicMode.startBattle([ Species.SHUCKLE ]);
 
     const leadIndex = game.scene.getPlayerPokemon()!.getBattlerIndex();
     const enemyIndex = game.scene.getEnemyPokemon()!.getBattlerIndex();
@@ -76,7 +76,7 @@ describe("Abilities - Stall", () => {
 
   it("If both Pokemon have stall and use the same move, speed is used to determine who goes first.", async() => {
     game.override.ability(Abilities.STALL);
-    await game.startBattle([ Species.SHUCKLE ]);
+    await game.classicMode.startBattle([ Species.SHUCKLE ]);
 
     const leadIndex = game.scene.getPlayerPokemon()!.getBattlerIndex();
     const enemyIndex = game.scene.getEnemyPokemon()!.getBattlerIndex();

--- a/src/test/abilities/steely_spirit.test.ts
+++ b/src/test/abilities/steely_spirit.test.ts
@@ -39,7 +39,7 @@ describe("Abilities - Steely Spirit", () => {
   });
 
   it("increases Steel-type moves' power used by the user and its allies by 50%", async () => {
-    await game.startBattle([Species.PIKACHU, Species.SHUCKLE]);
+    await game.classicMode.startBattle([Species.PIKACHU, Species.SHUCKLE]);
     const boostSource = game.scene.getPlayerField()[1];
     const enemyToCheck = game.scene.getEnemyPokemon()!;
 
@@ -57,7 +57,7 @@ describe("Abilities - Steely Spirit", () => {
   });
 
   it("stacks if multiple users with this ability are on the field.", async () => {
-    await game.startBattle([Species.PIKACHU, Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU, Species.PIKACHU]);
     const enemyToCheck = game.scene.getEnemyPokemon()!;
 
     game.scene.getPlayerField().forEach(p => {
@@ -78,7 +78,7 @@ describe("Abilities - Steely Spirit", () => {
   });
 
   it("does not take effect when suppressed", async () => {
-    await game.startBattle([Species.PIKACHU, Species.SHUCKLE]);
+    await game.classicMode.startBattle([Species.PIKACHU, Species.SHUCKLE]);
     const boostSource = game.scene.getPlayerField()[1];
     const enemyToCheck = game.scene.getEnemyPokemon()!;
 

--- a/src/test/abilities/sturdy.test.ts
+++ b/src/test/abilities/sturdy.test.ts
@@ -41,7 +41,7 @@ describe("Abilities - Sturdy", () => {
   test(
     "Sturdy activates when user is at full HP",
     async () => {
-      await game.startBattle();
+      await game.classicMode.startBattle();
       game.doAttack(getMovePosition(game.scene, 0, Moves.CLOSE_COMBAT));
       await game.phaseInterceptor.to(MoveEndPhase);
       expect(game.scene.getEnemyParty()[0].hp).toBe(1);
@@ -52,7 +52,7 @@ describe("Abilities - Sturdy", () => {
   test(
     "Sturdy doesn't activate when user is not at full HP",
     async () => {
-      await game.startBattle();
+      await game.classicMode.startBattle();
 
       const enemyPokemon: EnemyPokemon = game.scene.getEnemyParty()[0];
       enemyPokemon.hp = enemyPokemon.getMaxHp() - 1;
@@ -69,7 +69,7 @@ describe("Abilities - Sturdy", () => {
   test(
     "Sturdy pokemon should be immune to OHKO moves",
     async () => {
-      await game.startBattle();
+      await game.classicMode.startBattle();
       game.doAttack(getMovePosition(game.scene, 0, Moves.FISSURE));
       await game.phaseInterceptor.to(MoveEndPhase);
 
@@ -84,7 +84,7 @@ describe("Abilities - Sturdy", () => {
     async () => {
       game.override.ability(Abilities.MOLD_BREAKER);
 
-      await game.startBattle();
+      await game.classicMode.startBattle();
       game.doAttack(getMovePosition(game.scene, 0, Moves.CLOSE_COMBAT));
       await game.phaseInterceptor.to(DamagePhase);
 

--- a/src/test/abilities/sweet_veil.test.ts
+++ b/src/test/abilities/sweet_veil.test.ts
@@ -36,7 +36,7 @@ describe("Abilities - Sweet Veil", () => {
   });
 
   it("prevents the user and its allies from falling asleep", async () => {
-    await game.startBattle([Species.SWIRLIX, Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.SWIRLIX, Species.MAGIKARP]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
     game.doAttack(getMovePosition(game.scene, 1, Moves.SPLASH));
@@ -48,7 +48,7 @@ describe("Abilities - Sweet Veil", () => {
 
   it("causes Rest to fail when used by the user or its allies", async () => {
     game.override.enemyMoveset(SPLASH_ONLY);
-    await game.startBattle([Species.SWIRLIX, Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.SWIRLIX, Species.MAGIKARP]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
     game.doAttack(getMovePosition(game.scene, 1, Moves.REST));
@@ -60,7 +60,7 @@ describe("Abilities - Sweet Veil", () => {
 
   it("causes Yawn to fail if used on the user or its allies", async () => {
     game.override.enemyMoveset([Moves.YAWN, Moves.YAWN, Moves.YAWN, Moves.YAWN]);
-    await game.startBattle([Species.SWIRLIX, Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.SWIRLIX, Species.MAGIKARP]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
     game.doAttack(getMovePosition(game.scene, 1, Moves.SPLASH));
@@ -76,7 +76,7 @@ describe("Abilities - Sweet Veil", () => {
     game.override.startingLevel(5);
     game.override.enemyMoveset([Moves.YAWN, Moves.YAWN, Moves.YAWN, Moves.YAWN]);
 
-    await game.startBattle([Species.SHUCKLE, Species.SHUCKLE, Species.SWIRLIX]);
+    await game.classicMode.startBattle([Species.SHUCKLE, Species.SHUCKLE, Species.SWIRLIX]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
     game.doAttack(getMovePosition(game.scene, 1, Moves.SPLASH));

--- a/src/test/abilities/unseen_fist.test.ts
+++ b/src/test/abilities/unseen_fist.test.ts
@@ -70,7 +70,7 @@ async function testUnseenFistHitResult(game: GameManager, attackMove: Moves, pro
   game.override.moveset([attackMove]);
   game.override.enemyMoveset([protectMove, protectMove, protectMove, protectMove]);
 
-  await game.startBattle();
+  await game.classicMode.startBattle();
 
   const leadPokemon = game.scene.getPlayerPokemon()!;
   expect(leadPokemon).not.toBe(undefined);

--- a/src/test/abilities/volt_absorb.test.ts
+++ b/src/test/abilities/volt_absorb.test.ts
@@ -40,7 +40,7 @@ describe("Abilities - Volt Absorb", () => {
     game.override.enemySpecies(Species.DUSKULL);
     game.override.enemyAbility(Abilities.BALL_FETCH);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     game.doAttack(getMovePosition(game.scene, 0, moveToUse));
 

--- a/src/test/abilities/wind_power.test.ts
+++ b/src/test/abilities/wind_power.test.ts
@@ -33,7 +33,7 @@ describe("Abilities - Wind Power", () => {
   });
 
   it("it becomes charged when hit by wind moves", async () => {
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
     const shiftry = game.scene.getEnemyPokemon()!;
 
     expect(shiftry.getTag(BattlerTagType.CHARGED)).toBeUndefined();
@@ -48,7 +48,7 @@ describe("Abilities - Wind Power", () => {
     game.override.ability(Abilities.WIND_POWER);
     game.override.enemySpecies(Species.MAGIKARP);
 
-    await game.startBattle([Species.SHIFTRY]);
+    await game.classicMode.startBattle([Species.SHIFTRY]);
     const shiftry = game.scene.getPlayerPokemon()!;
 
     expect(shiftry.getTag(BattlerTagType.CHARGED)).toBeUndefined();
@@ -63,7 +63,7 @@ describe("Abilities - Wind Power", () => {
     game.override.enemySpecies(Species.MAGIKARP);
     game.override.ability(Abilities.WIND_POWER);
 
-    await game.startBattle([Species.SHIFTRY]);
+    await game.classicMode.startBattle([Species.SHIFTRY]);
     const magikarp = game.scene.getEnemyPokemon()!;
     const shiftry = game.scene.getPlayerPokemon()!;
 
@@ -81,7 +81,7 @@ describe("Abilities - Wind Power", () => {
   it("does not interact with Sandstorm", async () => {
     game.override.enemySpecies(Species.MAGIKARP);
 
-    await game.startBattle([Species.SHIFTRY]);
+    await game.classicMode.startBattle([Species.SHIFTRY]);
     const shiftry = game.scene.getPlayerPokemon()!;
 
     expect(shiftry.getTag(BattlerTagType.CHARGED)).toBeUndefined();

--- a/src/test/abilities/wind_rider.test.ts
+++ b/src/test/abilities/wind_rider.test.ts
@@ -33,7 +33,7 @@ describe("Abilities - Wind Rider", () => {
   });
 
   it("takes no damage from wind moves and its Attack is increased by one stage when hit by one", async () => {
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
     const shiftry = game.scene.getEnemyPokemon()!;
 
     expect(shiftry.summonData.battleStats[BattleStat.ATK]).toBe(0);
@@ -50,7 +50,7 @@ describe("Abilities - Wind Rider", () => {
     game.override.ability(Abilities.WIND_RIDER);
     game.override.enemySpecies(Species.MAGIKARP);
 
-    await game.startBattle([Species.SHIFTRY]);
+    await game.classicMode.startBattle([Species.SHIFTRY]);
     const shiftry = game.scene.getPlayerPokemon()!;
 
     expect(shiftry.summonData.battleStats[BattleStat.ATK]).toBe(0);
@@ -66,7 +66,7 @@ describe("Abilities - Wind Rider", () => {
     game.override.ability(Abilities.WIND_RIDER);
     game.override.enemySpecies(Species.MAGIKARP);
 
-    await game.startBattle([Species.SHIFTRY]);
+    await game.classicMode.startBattle([Species.SHIFTRY]);
     const magikarp = game.scene.getEnemyPokemon()!;
     const shiftry = game.scene.getPlayerPokemon()!;
 
@@ -84,7 +84,7 @@ describe("Abilities - Wind Rider", () => {
   it("does not increase Attack when Tailwind is present on opposing side", async () => {
     game.override.enemySpecies(Species.MAGIKARP);
 
-    await game.startBattle([Species.SHIFTRY]);
+    await game.classicMode.startBattle([Species.SHIFTRY]);
     const magikarp = game.scene.getEnemyPokemon()!;
     const shiftry = game.scene.getPlayerPokemon()!;
 
@@ -102,7 +102,7 @@ describe("Abilities - Wind Rider", () => {
   it("does not interact with Sandstorm", async () => {
     game.override.enemySpecies(Species.MAGIKARP);
 
-    await game.startBattle([Species.SHIFTRY]);
+    await game.classicMode.startBattle([Species.SHIFTRY]);
     const shiftry = game.scene.getPlayerPokemon()!;
 
     expect(shiftry.summonData.battleStats[BattleStat.ATK]).toBe(0);

--- a/src/test/abilities/wonder_skin.test.ts
+++ b/src/test/abilities/wonder_skin.test.ts
@@ -39,7 +39,7 @@ describe("Abilities - Wonder Skin", () => {
 
     vi.spyOn(moveToCheck, "calculateBattleAccuracy");
 
-    await game.startBattle([Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU]);
     game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
     await game.phaseInterceptor.to(MoveEffectPhase);
 
@@ -51,7 +51,7 @@ describe("Abilities - Wonder Skin", () => {
 
     vi.spyOn(moveToCheck, "calculateBattleAccuracy");
 
-    await game.startBattle([Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU]);
     game.doAttack(getMovePosition(game.scene, 0, Moves.TACKLE));
     await game.phaseInterceptor.to(MoveEffectPhase);
 
@@ -67,7 +67,7 @@ describe("Abilities - Wonder Skin", () => {
       game.override.ability(ability);
       vi.spyOn(moveToCheck, "calculateBattleAccuracy");
 
-      await game.startBattle([Species.PIKACHU]);
+      await game.classicMode.startBattle([Species.PIKACHU]);
       game.doAttack(getMovePosition(game.scene, 0, Moves.CHARM));
       await game.phaseInterceptor.to(MoveEffectPhase);
 

--- a/src/test/abilities/zen_mode.test.ts
+++ b/src/test/abilities/zen_mode.test.ts
@@ -54,7 +54,7 @@ describe("Abilities - ZEN MODE", () => {
     "not enough damage to change form",
     async () => {
       const moveToUse = Moves.SPLASH;
-      await game.startBattle([Species.DARMANITAN]);
+      await game.classicMode.startBattle([Species.DARMANITAN]);
       game.scene.getParty()[0].stats[Stat.HP] = 100;
       game.scene.getParty()[0].hp = 100;
       expect(game.scene.getParty()[0].formIndex).toBe(0);
@@ -83,7 +83,7 @@ describe("Abilities - ZEN MODE", () => {
     "enough damage to change form",
     async () => {
       const moveToUse = Moves.SPLASH;
-      await game.startBattle([Species.DARMANITAN]);
+      await game.classicMode.startBattle([Species.DARMANITAN]);
       game.scene.getParty()[0].stats[Stat.HP] = 1000;
       game.scene.getParty()[0].hp = 100;
       expect(game.scene.getParty()[0].formIndex).toBe(0);
@@ -109,7 +109,7 @@ describe("Abilities - ZEN MODE", () => {
     "kill pokemon while on zen mode",
     async () => {
       const moveToUse = Moves.SPLASH;
-      await game.startBattle([Species.DARMANITAN, Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.DARMANITAN, Species.CHARIZARD]);
       game.scene.getParty()[0].stats[Stat.HP] = 1000;
       game.scene.getParty()[0].hp = 100;
       expect(game.scene.getParty()[0].formIndex).toBe(0);
@@ -159,7 +159,7 @@ describe("Abilities - ZEN MODE", () => {
         [Species.DARMANITAN]: zenForm,
       });
 
-      await game.startBattle([Species.MAGIKARP, Species.DARMANITAN]);
+      await game.classicMode.startBattle([Species.MAGIKARP, Species.DARMANITAN]);
 
       const darmanitan = game.scene.getParty().find((p) => p.species.speciesId === Species.DARMANITAN)!;
       expect(darmanitan).not.toBe(undefined);

--- a/src/test/abilities/zero_to_hero.test.ts
+++ b/src/test/abilities/zero_to_hero.test.ts
@@ -42,7 +42,7 @@ describe("Abilities - ZERO TO HERO", () => {
       [Species.PALAFIN]: heroForm,
     });
 
-    await game.startBattle([Species.FEEBAS, Species.PALAFIN, Species.PALAFIN]);
+    await game.classicMode.startBattle([Species.FEEBAS, Species.PALAFIN, Species.PALAFIN]);
 
     const palafin1 = game.scene.getParty()[1];
     const palafin2 = game.scene.getParty()[2];
@@ -64,7 +64,7 @@ describe("Abilities - ZERO TO HERO", () => {
   }, TIMEOUT);
 
   it("should swap to Hero form when switching out during a battle", async () => {
-    await game.startBattle([Species.PALAFIN, Species.FEEBAS]);
+    await game.classicMode.startBattle([Species.PALAFIN, Species.FEEBAS]);
 
     const palafin = game.scene.getPlayerPokemon()!;
     expect(palafin.formIndex).toBe(baseForm);
@@ -75,7 +75,7 @@ describe("Abilities - ZERO TO HERO", () => {
   }, TIMEOUT);
 
   it("should not swap to Hero form if switching due to faint", async () => {
-    await game.startBattle([Species.PALAFIN, Species.FEEBAS]);
+    await game.classicMode.startBattle([Species.PALAFIN, Species.FEEBAS]);
 
     const palafin = game.scene.getPlayerPokemon()!;
     expect(palafin.formIndex).toBe(baseForm);
@@ -92,7 +92,7 @@ describe("Abilities - ZERO TO HERO", () => {
       [Species.PALAFIN]: heroForm,
     });
 
-    await game.startBattle([Species.PALAFIN, Species.FEEBAS]);
+    await game.classicMode.startBattle([Species.PALAFIN, Species.FEEBAS]);
 
     const palafin = game.scene.getPlayerPokemon()!;
     expect(palafin.formIndex).toBe(heroForm);

--- a/src/test/arena/arena_gravity.test.ts
+++ b/src/test/arena/arena_gravity.test.ts
@@ -40,7 +40,7 @@ describe("Arena - Gravity", () => {
     vi.spyOn(moveToCheck, "calculateBattleAccuracy");
 
     // Setup Gravity on first turn
-    await game.startBattle([Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU]);
     game.doAttack(getMovePosition(game.scene, 0, Moves.GRAVITY));
     await game.phaseInterceptor.to(TurnEndPhase);
 
@@ -64,7 +64,7 @@ describe("Arena - Gravity", () => {
     vi.spyOn(moveToCheck, "calculateBattleAccuracy");
 
     // Setup Gravity on first turn
-    await game.startBattle([Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU]);
     game.doAttack(getMovePosition(game.scene, 0, Moves.GRAVITY));
     await game.phaseInterceptor.to(TurnEndPhase);
 

--- a/src/test/arena/weather_fog.test.ts
+++ b/src/test/arena/weather_fog.test.ts
@@ -40,7 +40,7 @@ describe("Weather - Fog", () => {
 
     vi.spyOn(moveToCheck, "calculateBattleAccuracy");
 
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
     game.doAttack(getMovePosition(game.scene, 0, Moves.TACKLE));
     await game.phaseInterceptor.to(MoveEffectPhase);
 

--- a/src/test/arena/weather_strong_winds.test.ts
+++ b/src/test/arena/weather_strong_winds.test.ts
@@ -34,7 +34,7 @@ describe("Weather - Strong Winds", () => {
   it("electric type move is not very effective on Rayquaza", async () => {
     game.override.enemySpecies(Species.RAYQUAZA);
 
-    await game.startBattle([Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU]);
     const pikachu = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;
 
@@ -45,7 +45,7 @@ describe("Weather - Strong Winds", () => {
   });
 
   it("electric type move is neutral for flying type pokemon", async () => {
-    await game.startBattle([Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU]);
     const pikachu = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;
 
@@ -56,7 +56,7 @@ describe("Weather - Strong Winds", () => {
   });
 
   it("ice type move is neutral for flying type pokemon", async () => {
-    await game.startBattle([Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU]);
     const pikachu = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;
 
@@ -67,7 +67,7 @@ describe("Weather - Strong Winds", () => {
   });
 
   it("rock type move is neutral for flying type pokemon", async () => {
-    await game.startBattle([Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU]);
     const pikachu = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;
 

--- a/src/test/battle/battle-order.test.ts
+++ b/src/test/battle/battle-order.test.ts
@@ -40,7 +40,7 @@ describe("Battle order", () => {
   });
 
   it("opponent faster than player 50 vs 150", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.BULBASAUR,
     ]);
     game.scene.getParty()[0].stats[Stat.SPD] = 50;
@@ -61,7 +61,7 @@ describe("Battle order", () => {
   }, 20000);
 
   it("Player faster than opponent 150 vs 50", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.BULBASAUR,
     ]);
     game.scene.getParty()[0].stats[Stat.SPD] = 150;
@@ -83,7 +83,7 @@ describe("Battle order", () => {
 
   it("double - both opponents faster than player 50/50 vs 150/150", async() => {
     game.override.battleType("double");
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.BULBASAUR,
       Species.BLASTOISE,
     ]);
@@ -125,7 +125,7 @@ describe("Battle order", () => {
 
   it("double - speed tie except 1 - 100/100 vs 100/150", async() => {
     game.override.battleType("double");
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.BULBASAUR,
       Species.BLASTOISE,
     ]);
@@ -166,7 +166,7 @@ describe("Battle order", () => {
 
   it("double - speed tie 100/150 vs 100/150", async() => {
     game.override.battleType("double");
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.BULBASAUR,
       Species.BLASTOISE,
     ]);

--- a/src/test/battle/battle.test.ts
+++ b/src/test/battle/battle.test.ts
@@ -88,7 +88,7 @@ describe("Test Battle Phase", () => {
   }, 20000);
 
   it("newGame one-liner", async() => {
-    await game.startBattle();
+    await game.classicMode.startBattle();
     expect(game.scene.ui?.getMode()).toBe(Mode.COMMAND);
     expect(game.scene.getCurrentPhase()!.constructor.name).toBe(CommandPhase.name);
   }, 20000);
@@ -103,7 +103,7 @@ describe("Test Battle Phase", () => {
     game.override.moveset([Moves.TACKLE]);
     game.override.enemyAbility(Abilities.HYDRATION);
     game.override.enemyMoveset([Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE]);
-    await game.startBattle();
+    await game.classicMode.startBattle();
     game.onNextPrompt("CommandPhase", Mode.COMMAND, () => {
       game.scene.ui.setMode(Mode.FIGHT, (game.scene.getCurrentPhase() as CommandPhase).getFieldIndex());
     });
@@ -123,7 +123,7 @@ describe("Test Battle Phase", () => {
     game.override.enemyAbility(Abilities.HYDRATION);
     game.override.enemyMoveset([Moves.TAIL_WHIP, Moves.TAIL_WHIP, Moves.TAIL_WHIP, Moves.TAIL_WHIP]);
     game.override.battleType("single");
-    await game.startBattle();
+    await game.classicMode.startBattle();
     game.onNextPrompt("CommandPhase", Mode.COMMAND, () => {
       game.scene.ui.setMode(Mode.FIGHT, (game.scene.getCurrentPhase() as CommandPhase).getFieldIndex());
     });
@@ -144,7 +144,7 @@ describe("Test Battle Phase", () => {
   }, 20000);
 
   it("start battle with selected team", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.CHARIZARD,
       Species.CHANSEY,
       Species.MEW
@@ -213,7 +213,7 @@ describe("Test Battle Phase", () => {
     game.override.enemySpecies(Species.MIGHTYENA);
     game.override.enemyAbility(Abilities.HYDRATION);
     game.override.ability(Abilities.HYDRATION);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.BLASTOISE,
       Species.CHARIZARD,
     ]);
@@ -226,7 +226,7 @@ describe("Test Battle Phase", () => {
     game.override.enemySpecies(Species.MIGHTYENA);
     game.override.enemyAbility(Abilities.HYDRATION);
     game.override.ability(Abilities.HYDRATION);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.BLASTOISE,
     ]);
     expect(game.scene.ui?.getMode()).toBe(Mode.COMMAND);
@@ -239,7 +239,7 @@ describe("Test Battle Phase", () => {
     game.override.enemyAbility(Abilities.HYDRATION);
     game.override.ability(Abilities.HYDRATION);
     game.override.startingWave(3);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.BLASTOISE,
       Species.CHARIZARD,
     ]);
@@ -253,7 +253,7 @@ describe("Test Battle Phase", () => {
     game.override.enemyAbility(Abilities.HYDRATION);
     game.override.ability(Abilities.HYDRATION);
     game.override.startingWave(3);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.BLASTOISE,
       Species.CHARIZARD,
       Species.DARKRAI,
@@ -274,7 +274,7 @@ describe("Test Battle Phase", () => {
     game.override.startingWave(3);
     game.override.moveset([moveToUse]);
     game.override.enemyMoveset([Moves.TACKLE,Moves.TACKLE,Moves.TACKLE,Moves.TACKLE]);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.DARMANITAN,
       Species.CHARIZARD,
     ]);
@@ -303,7 +303,7 @@ describe("Test Battle Phase", () => {
     game.override.startingWave(3);
     game.override.moveset([moveToUse]);
     game.override.enemyMoveset([Moves.TACKLE,Moves.TACKLE,Moves.TACKLE,Moves.TACKLE]);
-    await game.startBattle();
+    await game.classicMode.startBattle();
     const turn = game.scene.currentBattle.turn;
     game.doAttack(0);
     await game.toNextTurn();
@@ -321,7 +321,7 @@ describe("Test Battle Phase", () => {
     game.override.startingWave(3);
     game.override.moveset([moveToUse]);
     game.override.enemyMoveset([Moves.TACKLE,Moves.TACKLE,Moves.TACKLE,Moves.TACKLE]);
-    await game.startBattle();
+    await game.classicMode.startBattle();
     const waveIndex = game.scene.currentBattle.waveIndex;
     game.doAttack(0);
     await game.doKillOpponents();
@@ -341,7 +341,7 @@ describe("Test Battle Phase", () => {
       .enemyMoveset(SPLASH_ONLY)
       .startingHeldItems([{ name: "TEMP_STAT_BOOSTER", type: TempBattleStat.ACC }]);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
     game.scene.getPlayerPokemon()!.hp = 1;
     game.doAttack(getMovePosition(game.scene, 0, moveToUse));
 

--- a/src/test/battle/double_battle.test.ts
+++ b/src/test/battle/double_battle.test.ts
@@ -31,7 +31,7 @@ describe("Double Battles", () => {
   // (There were bugs that either only summon one when can summon two, player stuck in switchPhase etc)
   it("3v2 edge case: player summons 2 pokemon on the next battle after being fainted and revived", async() => {
     game.override.battleType("double").enemyMoveset(SPLASH_ONLY).moveset(SPLASH_ONLY);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.BULBASAUR,
       Species.CHARIZARD,
       Species.SQUIRTLE,

--- a/src/test/battle/error-handling.test.ts
+++ b/src/test/battle/error-handling.test.ts
@@ -35,7 +35,7 @@ describe("Error Handling", () => {
   });
 
   it.skip("to next turn", async() => {
-    await game.startBattle();
+    await game.classicMode.startBattle();
     const turn = game.scene.currentBattle.turn;
     game.doAttack(0);
     await game.toNextTurn();

--- a/src/test/battle/special_battle.test.ts
+++ b/src/test/battle/special_battle.test.ts
@@ -35,7 +35,7 @@ describe("Test Battle Phase", () => {
     game.override
       .battleType("single")
       .startingWave(10);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.BLASTOISE,
       Species.CHARIZARD,
     ]);
@@ -47,7 +47,7 @@ describe("Test Battle Phase", () => {
     game.override
       .battleType("double")
       .startingWave(10);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.BLASTOISE,
       Species.CHARIZARD,
     ]);
@@ -59,7 +59,7 @@ describe("Test Battle Phase", () => {
     game.override
       .battleType("double")
       .startingWave(5);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.BLASTOISE,
       Species.CHARIZARD,
     ]);
@@ -71,7 +71,7 @@ describe("Test Battle Phase", () => {
     game.override
       .battleType("single")
       .startingWave(5);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.BLASTOISE,
       Species.CHARIZARD,
     ]);
@@ -83,7 +83,7 @@ describe("Test Battle Phase", () => {
     game.override
       .battleType("single")
       .startingWave(8);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.BLASTOISE,
       Species.CHARIZARD,
     ]);
@@ -95,7 +95,7 @@ describe("Test Battle Phase", () => {
     game.override
       .battleType("double")
       .startingWave(8);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.BLASTOISE,
       Species.CHARIZARD,
     ]);
@@ -107,7 +107,7 @@ describe("Test Battle Phase", () => {
     game.override
       .battleType("single")
       .startingWave(5);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.BLASTOISE,
     ]);
     expect(game.scene.ui?.getMode()).toBe(Mode.COMMAND);
@@ -118,7 +118,7 @@ describe("Test Battle Phase", () => {
     game.override
       .battleType("double")
       .startingWave(5);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.BLASTOISE,
       Species.CHARIZARD,
     ]);
@@ -130,7 +130,7 @@ describe("Test Battle Phase", () => {
     game.override
       .battleType("double")
       .startingWave(5);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.BLASTOISE,
       Species.CHARIZARD,
       Species.DARKRAI,

--- a/src/test/evolutions/evolutions.test.ts
+++ b/src/test/evolutions/evolutions.test.ts
@@ -33,7 +33,7 @@ describe("Evolution tests", () => {
      * If the value is 0, it's a 3 family maushold, whereas if the value is
      * 1, 2 or 3, it's a 4 family maushold
      */
-    await game.startBattle([Species.TANDEMAUS]); // starts us off with a tandemaus
+    await game.classicMode.startBattle([Species.TANDEMAUS]); // starts us off with a tandemaus
     const playerPokemon = game.scene.getPlayerPokemon()!;
     playerPokemon.level = 25; // tandemaus evolves at level 25
     vi.spyOn(Utils, "randSeedInt").mockReturnValue(0); // setting the random generator to be 0 to force a three family maushold

--- a/src/test/items/eviolite.test.ts
+++ b/src/test/items/eviolite.test.ts
@@ -31,7 +31,7 @@ describe("Items - Eviolite", () => {
   it("EVIOLITE activates in battle correctly", async() => {
     game.override.startingHeldItems([{ name: "EVIOLITE" }]);
     const consoleSpy = vi.spyOn(console, "log");
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PICHU
     ]);
 
@@ -64,7 +64,7 @@ describe("Items - Eviolite", () => {
   });
 
   it("EVIOLITE held by unevolved, unfused pokemon", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PICHU
     ]);
 
@@ -92,7 +92,7 @@ describe("Items - Eviolite", () => {
   }, 20000);
 
   it("EVIOLITE held by fully evolved, unfused pokemon", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.RAICHU,
     ]);
 
@@ -120,7 +120,7 @@ describe("Items - Eviolite", () => {
   }, 20000);
 
   it("EVIOLITE held by completely unevolved, fused pokemon", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PICHU,
       Species.CLEFFA
     ]);
@@ -159,7 +159,7 @@ describe("Items - Eviolite", () => {
   }, 20000);
 
   it("EVIOLITE held by partially unevolved (base), fused pokemon", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PICHU,
       Species.CLEFABLE
     ]);
@@ -198,7 +198,7 @@ describe("Items - Eviolite", () => {
   }, 20000);
 
   it("EVIOLITE held by partially unevolved (fusion), fused pokemon", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.RAICHU,
       Species.CLEFFA
     ]);
@@ -237,7 +237,7 @@ describe("Items - Eviolite", () => {
   }, 20000);
 
   it("EVIOLITE held by completely evolved, fused pokemon", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.RAICHU,
       Species.CLEFABLE
     ]);

--- a/src/test/items/exp_booster.test.ts
+++ b/src/test/items/exp_booster.test.ts
@@ -29,7 +29,7 @@ describe("EXP Modifier Items", () => {
 
   it("EXP booster items stack multiplicatively", async() => {
     game.override.startingHeldItems([{name: "LUCKY_EGG", count: 3}, {name: "GOLDEN_EGG"}]);
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const partyMember = game.scene.getPlayerPokemon()!;
     partyMember.exp = 100;

--- a/src/test/items/grip_claw.test.ts
+++ b/src/test/items/grip_claw.test.ts
@@ -54,7 +54,7 @@ describe("Items - Grip Claw", () => {
   it(
     "should only steal items from the attack target",
     async () => {
-      await game.startBattle([Species.PANSEAR, Species.ROWLET, Species.PANPOUR, Species.PANSAGE, Species.CHARMANDER, Species.SQUIRTLE]);
+      await game.classicMode.startBattle([Species.PANSEAR, Species.ROWLET, Species.PANPOUR, Species.PANSAGE, Species.CHARMANDER, Species.SQUIRTLE]);
 
       const enemyPokemon = game.scene.getEnemyField();
 

--- a/src/test/items/leek.test.ts
+++ b/src/test/items/leek.test.ts
@@ -37,7 +37,7 @@ describe("Items - Leek", () => {
     game.override.startingHeldItems([{ name: "LEEK" }]);
     game.override.moveset([ Moves.POUND ]);
     const consoleSpy = vi.spyOn(console, "log");
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.FARFETCHD
     ]);
 
@@ -51,7 +51,7 @@ describe("Items - Leek", () => {
   }, 20000);
 
   it("LEEK held by FARFETCHD", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.FARFETCHD
     ]);
 
@@ -71,7 +71,7 @@ describe("Items - Leek", () => {
   }, 20000);
 
   it("LEEK held by GALAR_FARFETCHD", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.GALAR_FARFETCHD
     ]);
 
@@ -91,7 +91,7 @@ describe("Items - Leek", () => {
   }, 20000);
 
   it("LEEK held by SIRFETCHD", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.SIRFETCHD
     ]);
 
@@ -114,7 +114,7 @@ describe("Items - Leek", () => {
     // Randomly choose from the Farfetch'd line
     const species = [ Species.FARFETCHD, Species.GALAR_FARFETCHD, Species.SIRFETCHD ];
 
-    await game.startBattle([
+    await game.classicMode.startBattle([
       species[Utils.randInt(species.length)],
       Species.PIKACHU,
     ]);
@@ -149,7 +149,7 @@ describe("Items - Leek", () => {
     // Randomly choose from the Farfetch'd line
     const species = [ Species.FARFETCHD, Species.GALAR_FARFETCHD, Species.SIRFETCHD ];
 
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PIKACHU,
       species[Utils.randInt(species.length)]
     ]);
@@ -181,7 +181,7 @@ describe("Items - Leek", () => {
   }, 20000);
 
   it("LEEK not held by FARFETCHD line", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PIKACHU
     ]);
 

--- a/src/test/items/leftovers.test.ts
+++ b/src/test/items/leftovers.test.ts
@@ -36,7 +36,7 @@ describe("Items - Leftovers", () => {
   });
 
   it("leftovers works", async() => {
-    await game.startBattle([Species.ARCANINE]);
+    await game.classicMode.startBattle([Species.ARCANINE]);
 
     // Make sure leftovers are there
     expect(game.scene.modifiers[0].type.id).toBe("LEFTOVERS");

--- a/src/test/items/light_ball.test.ts
+++ b/src/test/items/light_ball.test.ts
@@ -31,7 +31,7 @@ describe("Items - Light Ball", () => {
   it("LIGHT_BALL activates in battle correctly", async() => {
     game.override.startingHeldItems([{ name: "SPECIES_STAT_BOOSTER", type: "LIGHT_BALL" }]);
     const consoleSpy = vi.spyOn(console, "log");
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PIKACHU
     ]);
 
@@ -64,7 +64,7 @@ describe("Items - Light Ball", () => {
   });
 
   it("LIGHT_BALL held by PIKACHU", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PIKACHU
     ]);
 
@@ -92,7 +92,7 @@ describe("Items - Light Ball", () => {
   }, 20000);
 
   it("LIGHT_BALL held by fused PIKACHU (base)", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PIKACHU,
       Species.MAROWAK
     ]);
@@ -131,7 +131,7 @@ describe("Items - Light Ball", () => {
   }, 20000);
 
   it("LIGHT_BALL held by fused PIKACHU (part)", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.MAROWAK,
       Species.PIKACHU
     ]);
@@ -170,7 +170,7 @@ describe("Items - Light Ball", () => {
   }, 20000);
 
   it("LIGHT_BALL not held by PIKACHU", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.MAROWAK
     ]);
 

--- a/src/test/items/lock_capsule.test.ts
+++ b/src/test/items/lock_capsule.test.ts
@@ -33,7 +33,7 @@ describe("Items - Lock Capsule", () => {
   });
 
   it("doesn't set the cost of common tier items to 0", async() => {
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.SURF));
     await game.phaseInterceptor.to(SelectModifierPhase, false);

--- a/src/test/items/metal_powder.test.ts
+++ b/src/test/items/metal_powder.test.ts
@@ -31,7 +31,7 @@ describe("Items - Metal Powder", () => {
   it("METAL_POWDER activates in battle correctly", async() => {
     game.override.startingHeldItems([{ name: "SPECIES_STAT_BOOSTER", type: "METAL_POWDER" }]);
     const consoleSpy = vi.spyOn(console, "log");
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.DITTO
     ]);
 
@@ -64,7 +64,7 @@ describe("Items - Metal Powder", () => {
   });
 
   it("METAL_POWDER held by DITTO", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.DITTO
     ]);
 
@@ -86,7 +86,7 @@ describe("Items - Metal Powder", () => {
   }, 20000);
 
   it("METAL_POWDER held by fused DITTO (base)", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.DITTO,
       Species.MAROWAK
     ]);
@@ -119,7 +119,7 @@ describe("Items - Metal Powder", () => {
   }, 20000);
 
   it("METAL_POWDER held by fused DITTO (part)", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.MAROWAK,
       Species.DITTO
     ]);
@@ -152,7 +152,7 @@ describe("Items - Metal Powder", () => {
   }, 20000);
 
   it("METAL_POWDER not held by DITTO", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.MAROWAK
     ]);
 

--- a/src/test/items/quick_powder.test.ts
+++ b/src/test/items/quick_powder.test.ts
@@ -31,7 +31,7 @@ describe("Items - Quick Powder", () => {
   it("QUICK_POWDER activates in battle correctly", async() => {
     game.override.startingHeldItems([{ name: "SPECIES_STAT_BOOSTER", type: "QUICK_POWDER" }]);
     const consoleSpy = vi.spyOn(console, "log");
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.DITTO
     ]);
 
@@ -64,7 +64,7 @@ describe("Items - Quick Powder", () => {
   });
 
   it("QUICK_POWDER held by DITTO", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.DITTO
     ]);
 
@@ -86,7 +86,7 @@ describe("Items - Quick Powder", () => {
   }, 20000);
 
   it("QUICK_POWDER held by fused DITTO (base)", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.DITTO,
       Species.MAROWAK
     ]);
@@ -119,7 +119,7 @@ describe("Items - Quick Powder", () => {
   }, 20000);
 
   it("QUICK_POWDER held by fused DITTO (part)", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.MAROWAK,
       Species.DITTO
     ]);
@@ -152,7 +152,7 @@ describe("Items - Quick Powder", () => {
   }, 20000);
 
   it("QUICK_POWDER not held by DITTO", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.MAROWAK
     ]);
 

--- a/src/test/items/scope_lens.test.ts
+++ b/src/test/items/scope_lens.test.ts
@@ -37,7 +37,7 @@ describe("Items - Scope Lens", () => {
     game.override.startingHeldItems([{ name: "SCOPE_LENS" }]);
     game.override.moveset([ Moves.POUND ]);
     const consoleSpy = vi.spyOn(console, "log");
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.GASTLY
     ]);
 
@@ -51,7 +51,7 @@ describe("Items - Scope Lens", () => {
   }, 20000);
 
   it("SCOPE_LENS held by random pokemon", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.GASTLY
     ]);
 

--- a/src/test/items/thick_club.test.ts
+++ b/src/test/items/thick_club.test.ts
@@ -31,7 +31,7 @@ describe("Items - Thick Club", () => {
   it("THICK_CLUB activates in battle correctly", async() => {
     game.override.startingHeldItems([{ name: "SPECIES_STAT_BOOSTER", type: "THICK_CLUB" }]);
     const consoleSpy = vi.spyOn(console, "log");
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.CUBONE
     ]);
 
@@ -64,7 +64,7 @@ describe("Items - Thick Club", () => {
   });
 
   it("THICK_CLUB held by CUBONE", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.CUBONE
     ]);
 
@@ -86,7 +86,7 @@ describe("Items - Thick Club", () => {
   }, 20000);
 
   it("THICK_CLUB held by MAROWAK", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.MAROWAK
     ]);
 
@@ -108,7 +108,7 @@ describe("Items - Thick Club", () => {
   }, 20000);
 
   it("THICK_CLUB held by ALOLA_MAROWAK", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.ALOLA_MAROWAK
     ]);
 
@@ -134,7 +134,7 @@ describe("Items - Thick Club", () => {
     const species = [ Species.CUBONE, Species.MAROWAK, Species.ALOLA_MAROWAK ];
     const randSpecies = Utils.randInt(species.length);
 
-    await game.startBattle([
+    await game.classicMode.startBattle([
       species[randSpecies],
       Species.PIKACHU
     ]);
@@ -171,7 +171,7 @@ describe("Items - Thick Club", () => {
     const species = [ Species.CUBONE, Species.MAROWAK, Species.ALOLA_MAROWAK ];
     const randSpecies = Utils.randInt(species.length);
 
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PIKACHU,
       species[randSpecies]
     ]);
@@ -204,7 +204,7 @@ describe("Items - Thick Club", () => {
   }, 20000);
 
   it("THICK_CLUB not held by CUBONE", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PIKACHU
     ]);
 

--- a/src/test/items/toxic_orb.test.ts
+++ b/src/test/items/toxic_orb.test.ts
@@ -49,7 +49,7 @@ describe("Items - Toxic orb", () => {
     initI18n();
     i18next.changeLanguage("en");
     const moveToUse = Moves.GROWTH;
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.MIGHTYENA,
       Species.MIGHTYENA,
     ]);

--- a/src/test/localization/french.test.ts
+++ b/src/test/localization/french.test.ts
@@ -22,7 +22,7 @@ describe("Lokalization - french", () => {
 
   it("test bulbasaur name english", async () => {
     game = new GameManager(phaserGame);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.BULBASAUR,
     ]);
     expect(game.scene.getParty()[0].name).toBe("Bulbasaur");
@@ -34,7 +34,7 @@ describe("Lokalization - french", () => {
     localStorage.setItem("prLang", locale);
     game = new GameManager(phaserGame);
 
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.BULBASAUR,
     ]);
     expect(game.scene.getParty()[0].name).toBe("Bulbizarre");

--- a/src/test/localization/terrain.test.ts
+++ b/src/test/localization/terrain.test.ts
@@ -47,7 +47,7 @@ describe("terrain", () => {
     });
 
     it("should return the block text", async () => {
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
       const pokemon = game.scene.getPlayerPokemon()!;
       mockI18next();
       const text = getTerrainBlockMessage(pokemon, terrainType);
@@ -79,7 +79,7 @@ describe("terrain", () => {
     });
 
     it("should return the block text", async () => {
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
       const pokemon = game.scene.getPlayerPokemon()!;
       mockI18next();
       const text = getTerrainBlockMessage(pokemon, terrainType);
@@ -111,7 +111,7 @@ describe("terrain", () => {
     });
 
     it("should return the block text", async () => {
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
       const pokemon = game.scene.getPlayerPokemon()!;
       mockI18next();
       const text = getTerrainBlockMessage(pokemon, terrainType);
@@ -143,7 +143,7 @@ describe("terrain", () => {
     });
 
     it("should return the block text", async () => {
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
       const pokemon = game.scene.getPlayerPokemon()!;
       mockI18next();
       const text = getTerrainBlockMessage(pokemon, terrainType);
@@ -175,7 +175,7 @@ describe("terrain", () => {
     });
 
     it("should return the block text", async () => {
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
       const pokemon = game.scene.getPlayerPokemon()!;
       mockI18next();
       const text = getTerrainBlockMessage(pokemon, terrainType);

--- a/src/test/moves/astonish.test.ts
+++ b/src/test/moves/astonish.test.ts
@@ -44,7 +44,7 @@ describe("Moves - Astonish", () => {
   test(
     "move effect should cancel the target's move on the turn it applies",
     async () => {
-      await game.startBattle([Species.MEOWSCARADA]);
+      await game.classicMode.startBattle([Species.MEOWSCARADA]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
 

--- a/src/test/moves/aurora_veil.test.ts
+++ b/src/test/moves/aurora_veil.test.ts
@@ -44,7 +44,7 @@ describe("Moves - Aurora Veil", () => {
 
   it("reduces damage of physical attacks by half in a single battle", async() => {
     const moveToUse = Moves.TACKLE;
-    await game.startBattle([Species.SHUCKLE]);
+    await game.classicMode.startBattle([Species.SHUCKLE]);
 
     game.doAttack(getMovePosition(game.scene, 0, moveToUse));
 
@@ -58,7 +58,7 @@ describe("Moves - Aurora Veil", () => {
     game.override.battleType("double");
 
     const moveToUse = Moves.ROCK_SLIDE;
-    await game.startBattle([Species.SHUCKLE, Species.SHUCKLE]);
+    await game.classicMode.startBattle([Species.SHUCKLE, Species.SHUCKLE]);
 
     game.doAttack(getMovePosition(game.scene, 0, moveToUse));
     game.doAttack(getMovePosition(game.scene, 1, moveToUse));
@@ -71,7 +71,7 @@ describe("Moves - Aurora Veil", () => {
 
   it("reduces damage of special attacks by half in a single battle", async() => {
     const moveToUse = Moves.ABSORB;
-    await game.startBattle([Species.SHUCKLE]);
+    await game.classicMode.startBattle([Species.SHUCKLE]);
 
     game.doAttack(getMovePosition(game.scene, 0, moveToUse));
 
@@ -86,7 +86,7 @@ describe("Moves - Aurora Veil", () => {
     game.override.battleType("double");
 
     const moveToUse = Moves.DAZZLING_GLEAM;
-    await game.startBattle([Species.SHUCKLE, Species.SHUCKLE]);
+    await game.classicMode.startBattle([Species.SHUCKLE, Species.SHUCKLE]);
 
     game.doAttack(getMovePosition(game.scene, 0, moveToUse));
     game.doAttack(getMovePosition(game.scene, 1, moveToUse));

--- a/src/test/moves/baton_pass.test.ts
+++ b/src/test/moves/baton_pass.test.ts
@@ -38,7 +38,7 @@ describe("Moves - Baton Pass", () => {
 
   it("passes stat stage buffs when player uses it", async() => {
     // arrange
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.RAICHU,
       Species.SHUCKLE
     ]);
@@ -64,7 +64,7 @@ describe("Moves - Baton Pass", () => {
     game.override
       .startingWave(5)
       .enemyMoveset(new Array(4).fill([Moves.NASTY_PLOT]));
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.RAICHU,
       Species.SHUCKLE
     ]);

--- a/src/test/moves/beak_blast.test.ts
+++ b/src/test/moves/beak_blast.test.ts
@@ -43,7 +43,7 @@ describe("Moves - Beak Blast", () => {
   it(
     "should add a charge effect that burns attackers on contact",
     async () => {
-      await game.startBattle([Species.BLASTOISE]);
+      await game.classicMode.startBattle([Species.BLASTOISE]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -63,7 +63,7 @@ describe("Moves - Beak Blast", () => {
     async () => {
       game.override.statusEffect(StatusEffect.SLEEP);
 
-      await game.startBattle([Species.BLASTOISE]);
+      await game.classicMode.startBattle([Species.BLASTOISE]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -83,7 +83,7 @@ describe("Moves - Beak Blast", () => {
     async () => {
       game.override.enemyMoveset(Array(4).fill(Moves.WATER_GUN));
 
-      await game.startBattle([Species.BLASTOISE]);
+      await game.classicMode.startBattle([Species.BLASTOISE]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -103,7 +103,7 @@ describe("Moves - Beak Blast", () => {
     async () => {
       game.override.startingHeldItems([{name: "MULTI_LENS", count: 1}]);
 
-      await game.startBattle([Species.BLASTOISE]);
+      await game.classicMode.startBattle([Species.BLASTOISE]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
 
@@ -119,7 +119,7 @@ describe("Moves - Beak Blast", () => {
     async () => {
       game.override.enemyMoveset(Array(4).fill(Moves.PROTECT));
 
-      await game.startBattle([Species.BLASTOISE]);
+      await game.classicMode.startBattle([Species.BLASTOISE]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       const enemyPokemon = game.scene.getEnemyPokemon()!;

--- a/src/test/moves/beat_up.test.ts
+++ b/src/test/moves/beat_up.test.ts
@@ -40,7 +40,7 @@ describe("Moves - Beat Up", () => {
   it(
     "should hit once for each healthy player Pokemon",
     async () => {
-      await game.startBattle([Species.MAGIKARP, Species.BULBASAUR, Species.CHARMANDER, Species.SQUIRTLE, Species.PIKACHU, Species.EEVEE]);
+      await game.classicMode.startBattle([Species.MAGIKARP, Species.BULBASAUR, Species.CHARMANDER, Species.SQUIRTLE, Species.PIKACHU, Species.EEVEE]);
 
       const playerPokemon = game.scene.getPlayerPokemon()!;
       const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -64,7 +64,7 @@ describe("Moves - Beat Up", () => {
   it(
     "should not count player Pokemon with status effects towards hit count",
     async () => {
-      await game.startBattle([Species.MAGIKARP, Species.BULBASAUR, Species.CHARMANDER, Species.SQUIRTLE, Species.PIKACHU, Species.EEVEE]);
+      await game.classicMode.startBattle([Species.MAGIKARP, Species.BULBASAUR, Species.CHARMANDER, Species.SQUIRTLE, Species.PIKACHU, Species.EEVEE]);
 
       const playerPokemon = game.scene.getPlayerPokemon()!;
 
@@ -82,7 +82,7 @@ describe("Moves - Beat Up", () => {
     "should hit twice for each player Pokemon if the user has Multi-Lens",
     async () => {
       game.override.startingHeldItems([{name: "MULTI_LENS", count: 1}]);
-      await game.startBattle([Species.MAGIKARP, Species.BULBASAUR, Species.CHARMANDER, Species.SQUIRTLE, Species.PIKACHU, Species.EEVEE]);
+      await game.classicMode.startBattle([Species.MAGIKARP, Species.BULBASAUR, Species.CHARMANDER, Species.SQUIRTLE, Species.PIKACHU, Species.EEVEE]);
 
       const playerPokemon = game.scene.getPlayerPokemon()!;
       const enemyPokemon = game.scene.getEnemyPokemon()!;

--- a/src/test/moves/belly_drum.test.ts
+++ b/src/test/moves/belly_drum.test.ts
@@ -41,7 +41,7 @@ describe("Moves - BELLY DRUM", () => {
 
   test("Belly Drum raises the user's Attack to its max, at the cost of 1/2 of its maximum HP",
     async() => {
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       const hpLost = Math.floor(leadPokemon.getMaxHp() / RATIO);
@@ -56,7 +56,7 @@ describe("Moves - BELLY DRUM", () => {
 
   test("Belly Drum will still take effect if an uninvolved stat is at max",
     async() => {
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       const hpLost = Math.floor(leadPokemon.getMaxHp() / RATIO);
@@ -76,7 +76,7 @@ describe("Moves - BELLY DRUM", () => {
 
   test("Belly Drum fails if the pokemon's attack stat is at its maximum",
     async() => {
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
 
@@ -92,7 +92,7 @@ describe("Moves - BELLY DRUM", () => {
 
   test("Belly Drum fails if the user's health is less than 1/2",
     async() => {
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       const hpLost = Math.floor(leadPokemon.getMaxHp() / RATIO);

--- a/src/test/moves/ceaseless_edge.test.ts
+++ b/src/test/moves/ceaseless_edge.test.ts
@@ -44,7 +44,7 @@ describe("Moves - Ceaseless Edge", () => {
   test(
     "move should hit and apply spikes",
     async () => {
-      await game.startBattle([ Species.ILLUMISE ]);
+      await game.classicMode.startBattle([ Species.ILLUMISE ]);
 
       const enemyPokemon = game.scene.getEnemyPokemon()!;
 
@@ -69,7 +69,7 @@ describe("Moves - Ceaseless Edge", () => {
     "move should hit twice with multi lens and apply two layers of spikes",
     async () => {
       game.override.startingHeldItems([{name: "MULTI_LENS"}]);
-      await game.startBattle([ Species.ILLUMISE ]);
+      await game.classicMode.startBattle([ Species.ILLUMISE ]);
 
       const enemyPokemon = game.scene.getEnemyPokemon()!;
 
@@ -96,7 +96,7 @@ describe("Moves - Ceaseless Edge", () => {
       game.override.startingHeldItems([{name: "MULTI_LENS"}]);
       game.override.startingWave(5);
 
-      await game.startBattle([ Species.ILLUMISE ]);
+      await game.classicMode.startBattle([ Species.ILLUMISE ]);
 
       game.doAttack(getMovePosition(game.scene, 0, Moves.CEASELESS_EDGE));
       await game.phaseInterceptor.to(MoveEffectPhase, false);

--- a/src/test/moves/clangorous_soul.test.ts
+++ b/src/test/moves/clangorous_soul.test.ts
@@ -42,7 +42,7 @@ describe("Moves - CLANGOROUS_SOUL", () => {
 
   test("Clangorous Soul raises the user's Attack, Defense, Special Attack, Special Defense and Speed by one stage each, at the cost of 1/3 of its maximum HP",
   	async() => {
-  	 	await game.startBattle([Species.MAGIKARP]);
+  	 	await game.classicMode.startBattle([Species.MAGIKARP]);
 
      	const leadPokemon = game.scene.getPlayerPokemon()!;
       const hpLost = Math.floor(leadPokemon.getMaxHp() / RATIO);
@@ -61,7 +61,7 @@ describe("Moves - CLANGOROUS_SOUL", () => {
 
   test("Clangorous Soul will still take effect if one or more of the involved stats are not at max",
     async() => {
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       const hpLost = Math.floor(leadPokemon.getMaxHp() / RATIO);
@@ -86,7 +86,7 @@ describe("Moves - CLANGOROUS_SOUL", () => {
 
   test("Clangorous Soul fails if all stats involved are at max",
     async() => {
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
 
@@ -110,7 +110,7 @@ describe("Moves - CLANGOROUS_SOUL", () => {
 
   test("Clangorous Soul fails if the user's health is less than 1/3",
     async() => {
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       const hpLost = Math.floor(leadPokemon.getMaxHp() / RATIO);

--- a/src/test/moves/crafty_shield.test.ts
+++ b/src/test/moves/crafty_shield.test.ts
@@ -44,7 +44,7 @@ describe("Moves - Crafty Shield", () => {
   test(
     "should protect the user and allies from status moves",
     async () => {
-      await game.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
+      await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
 
       const leadPokemon = game.scene.getPlayerField();
 
@@ -65,7 +65,7 @@ describe("Moves - Crafty Shield", () => {
     async () => {
       game.override.enemyMoveset(Array(4).fill(Moves.TACKLE));
 
-      await game.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
+      await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
 
       const leadPokemon = game.scene.getPlayerField();
 
@@ -87,7 +87,7 @@ describe("Moves - Crafty Shield", () => {
       game.override.enemySpecies(Species.DUSCLOPS);
       game.override.enemyMoveset(Array(4).fill(Moves.CURSE));
 
-      await game.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
+      await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
 
       const leadPokemon = game.scene.getPlayerField();
 
@@ -106,7 +106,7 @@ describe("Moves - Crafty Shield", () => {
   test(
     "should not block allies' self-targeted moves",
     async () => {
-      await game.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
+      await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
 
       const leadPokemon = game.scene.getPlayerField();
 

--- a/src/test/moves/double_team.test.ts
+++ b/src/test/moves/double_team.test.ts
@@ -34,7 +34,7 @@ describe("Moves - Double Team", () => {
   });
 
   it("increases the user's evasion by one stage.", async () => {
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
 
     const ally = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;

--- a/src/test/moves/dragon_rage.test.ts
+++ b/src/test/moves/dragon_rage.test.ts
@@ -48,7 +48,7 @@ describe("Moves - Dragon Rage", () => {
     game.override.enemyPassiveAbility(Abilities.BALL_FETCH);
     game.override.enemyLevel(100);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     partyPokemon = game.scene.getParty()[0];
     enemyPokemon = game.scene.getEnemyPokemon()!;

--- a/src/test/moves/dragon_tail.test.ts
+++ b/src/test/moves/dragon_tail.test.ts
@@ -43,7 +43,7 @@ describe("Moves - Dragon Tail", () => {
   test(
     "Single battle should cause opponent to flee, and not crash",
     async () => {
-      await game.startBattle([Species.DRATINI]);
+      await game.classicMode.startBattle([Species.DRATINI]);
 
       const enemyPokemon = game.scene.getEnemyPokemon()!;
       expect(enemyPokemon).toBeDefined();
@@ -65,7 +65,7 @@ describe("Moves - Dragon Tail", () => {
     "Single battle should cause opponent to flee, display ability, and not crash",
     async () => {
       game.override.enemyAbility(Abilities.ROUGH_SKIN);
-      await game.startBattle([Species.DRATINI]);
+      await game.classicMode.startBattle([Species.DRATINI]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       expect(leadPokemon).toBeDefined();
@@ -90,7 +90,7 @@ describe("Moves - Dragon Tail", () => {
       game.override.battleType("double").enemyMoveset(SPLASH_ONLY);
       game.override.moveset([Moves.DRAGON_TAIL, Moves.SPLASH, Moves.FLAMETHROWER])
         .enemyAbility(Abilities.ROUGH_SKIN);
-      await game.startBattle([Species.DRATINI, Species.DRATINI, Species.WAILORD, Species.WAILORD]);
+      await game.classicMode.startBattle([Species.DRATINI, Species.DRATINI, Species.WAILORD, Species.WAILORD]);
 
       const leadPokemon = game.scene.getParty()[0]!;
       const secPokemon = game.scene.getParty()[1]!;
@@ -133,7 +133,7 @@ describe("Moves - Dragon Tail", () => {
       game.override.battleType("double").enemyMoveset(SPLASH_ONLY);
       game.override.moveset([Moves.DRAGON_TAIL, Moves.SPLASH, Moves.FLAMETHROWER]);
       game.override.enemyAbility(Abilities.ROUGH_SKIN);
-      await game.startBattle([Species.DRATINI, Species.DRATINI, Species.WAILORD, Species.WAILORD]);
+      await game.classicMode.startBattle([Species.DRATINI, Species.DRATINI, Species.WAILORD, Species.WAILORD]);
 
       const leadPokemon = game.scene.getParty()[0]!;
       const secPokemon = game.scene.getParty()[1]!;

--- a/src/test/moves/dynamax_cannon.test.ts
+++ b/src/test/moves/dynamax_cannon.test.ts
@@ -45,7 +45,7 @@ describe("Moves - Dynamax Cannon", () => {
 
   it("should return 100 power against an enemy below level cap", async() => {
     game.override.enemyLevel(1);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.ETERNATUS,
     ]);
 
@@ -59,7 +59,7 @@ describe("Moves - Dynamax Cannon", () => {
 
   it("should return 100 power against an enemy at level cap", async() => {
     game.override.enemyLevel(10);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.ETERNATUS,
     ]);
 
@@ -73,7 +73,7 @@ describe("Moves - Dynamax Cannon", () => {
 
   it("should return 120 power against an enemy 1% above level cap", async() => {
     game.override.enemyLevel(101);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.ETERNATUS,
     ]);
 
@@ -90,7 +90,7 @@ describe("Moves - Dynamax Cannon", () => {
 
   it("should return 140 power against an enemy 2% above level capp", async() => {
     game.override.enemyLevel(102);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.ETERNATUS,
     ]);
 
@@ -107,7 +107,7 @@ describe("Moves - Dynamax Cannon", () => {
 
   it("should return 160 power against an enemy 3% above level cap", async() => {
     game.override.enemyLevel(103);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.ETERNATUS,
     ]);
 
@@ -124,7 +124,7 @@ describe("Moves - Dynamax Cannon", () => {
 
   it("should return 180 power against an enemy 4% above level cap", async() => {
     game.override.enemyLevel(104);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.ETERNATUS,
     ]);
 
@@ -141,7 +141,7 @@ describe("Moves - Dynamax Cannon", () => {
 
   it("should return 200 power against an enemy 5% above level cap", async() => {
     game.override.enemyLevel(105);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.ETERNATUS,
     ]);
 
@@ -158,7 +158,7 @@ describe("Moves - Dynamax Cannon", () => {
 
   it("should return 200 power against an enemy way above level cap", async() => {
     game.override.enemyLevel(999);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.ETERNATUS,
     ]);
 

--- a/src/test/moves/fillet_away.test.ts
+++ b/src/test/moves/fillet_away.test.ts
@@ -42,7 +42,7 @@ describe("Moves - FILLET AWAY", () => {
 
   test("Fillet Away raises the user's Attack, Special Attack, and Speed by two stages each, at the cost of 1/2 of its maximum HP",
     async() => {
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       const hpLost = Math.floor(leadPokemon.getMaxHp() / RATIO);
@@ -59,7 +59,7 @@ describe("Moves - FILLET AWAY", () => {
 
   test("Fillet Away will still take effect if one or more of the involved stats are not at max",
     async() => {
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       const hpLost = Math.floor(leadPokemon.getMaxHp() / RATIO);
@@ -80,7 +80,7 @@ describe("Moves - FILLET AWAY", () => {
 
   test("Fillet Away fails if all stats involved are at max",
     async() => {
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
 
@@ -100,7 +100,7 @@ describe("Moves - FILLET AWAY", () => {
 
   test("Fillet Away fails if the user's health is less than 1/2",
     async() => {
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       const hpLost = Math.floor(leadPokemon.getMaxHp() / RATIO);

--- a/src/test/moves/fissure.test.ts
+++ b/src/test/moves/fissure.test.ts
@@ -43,7 +43,7 @@ describe("Moves - Fissure", () => {
     game.override.enemyPassiveAbility(Abilities.BALL_FETCH);
     game.override.enemyLevel(100);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     partyPokemon = game.scene.getParty()[0];
     enemyPokemon = game.scene.getEnemyPokemon()!;

--- a/src/test/moves/flame_burst.test.ts
+++ b/src/test/moves/flame_burst.test.ts
@@ -48,7 +48,7 @@ describe("Moves - Flame Burst", () => {
   });
 
   it("inflicts damage to the target's ally equal to 1/16 of its max HP", async () => {
-    await game.startBattle([Species.PIKACHU, Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU, Species.PIKACHU]);
     const [ leftEnemy, rightEnemy ] = game.scene.getEnemyField();
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.FLAME_BURST));
@@ -64,7 +64,7 @@ describe("Moves - Flame Burst", () => {
   it("does not inflict damage to the target's ally if the target was not affected by Flame Burst", async () => {
     game.override.enemyAbility(Abilities.FLASH_FIRE);
 
-    await game.startBattle([Species.PIKACHU, Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU, Species.PIKACHU]);
     const [ leftEnemy, rightEnemy ] = game.scene.getEnemyField();
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.FLAME_BURST));
@@ -78,7 +78,7 @@ describe("Moves - Flame Burst", () => {
   });
 
   it("does not interact with the target ally's abilities", async () => {
-    await game.startBattle([Species.PIKACHU, Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU, Species.PIKACHU]);
     const [ leftEnemy, rightEnemy ] = game.scene.getEnemyField();
 
     vi.spyOn(rightEnemy, "getAbility").mockReturnValue(allAbilities[Abilities.FLASH_FIRE]);
@@ -94,7 +94,7 @@ describe("Moves - Flame Burst", () => {
   });
 
   it("effect damage is prevented by Magic Guard", async () => {
-    await game.startBattle([Species.PIKACHU, Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU, Species.PIKACHU]);
     const [ leftEnemy, rightEnemy ] = game.scene.getEnemyField();
 
     vi.spyOn(rightEnemy, "getAbility").mockReturnValue(allAbilities[Abilities.MAGIC_GUARD]);

--- a/src/test/moves/flower_shield.test.ts
+++ b/src/test/moves/flower_shield.test.ts
@@ -38,7 +38,7 @@ describe("Moves - Flower Shield", () => {
   it("increases defense of all Grass-type Pokemon on the field by one stage - single battle", async () => {
     game.override.enemySpecies(Species.CHERRIM);
 
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
     const cherrim = game.scene.getEnemyPokemon()!;
     const magikarp = game.scene.getPlayerPokemon()!;
 
@@ -55,7 +55,7 @@ describe("Moves - Flower Shield", () => {
   it("increases defense of all Grass-type Pokemon on the field by one stage - double battle", async () => {
     game.override.enemySpecies(Species.MAGIKARP).startingBiome(Biome.GRASS).battleType("double");
 
-    await game.startBattle([Species.CHERRIM, Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.CHERRIM, Species.MAGIKARP]);
     const field = game.scene.getField(true);
 
     const grassPokemons = field.filter(p => p.getTypes().includes(Type.GRASS));
@@ -80,7 +80,7 @@ describe("Moves - Flower Shield", () => {
     game.override.enemyMoveset([Moves.DIG, Moves.DIG, Moves.DIG, Moves.DIG]);
     game.override.enemyLevel(50);
 
-    await game.startBattle([Species.CHERRIM]);
+    await game.classicMode.startBattle([Species.CHERRIM]);
     const paras = game.scene.getEnemyPokemon()!;
     const cherrim = game.scene.getPlayerPokemon()!;
 
@@ -99,7 +99,7 @@ describe("Moves - Flower Shield", () => {
   it("does nothing if there are no Grass-type pokemon on the field", async () => {
     game.override.enemySpecies(Species.MAGIKARP);
 
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
     const enemy = game.scene.getEnemyPokemon()!;
     const ally = game.scene.getPlayerPokemon()!;
 

--- a/src/test/moves/focus_punch.test.ts
+++ b/src/test/moves/focus_punch.test.ts
@@ -44,7 +44,7 @@ describe("Moves - Focus Punch", () => {
   it(
     "should deal damage at the end of turn if uninterrupted",
     async () => {
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -71,7 +71,7 @@ describe("Moves - Focus Punch", () => {
     async () => {
       game.override.enemyMoveset(Array(4).fill(Moves.TACKLE));
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -98,7 +98,7 @@ describe("Moves - Focus Punch", () => {
     async () => {
       game.override.enemyMoveset(Array(4).fill(Moves.SPORE));
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -122,7 +122,7 @@ describe("Moves - Focus Punch", () => {
       /** Guarantee a Trainer battle with multiple enemy Pokemon */
       game.override.startingWave(25);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       game.forceOpponentToSwitch();
       game.doAttack(getMovePosition(game.scene, 0, Moves.FOCUS_PUNCH));

--- a/src/test/moves/follow_me.test.ts
+++ b/src/test/moves/follow_me.test.ts
@@ -41,7 +41,7 @@ describe("Moves - Follow Me", () => {
   test(
     "move should redirect enemy attacks to the user",
     async () => {
-      await game.startBattle([ Species.AMOONGUSS, Species.CHARIZARD ]);
+      await game.classicMode.startBattle([ Species.AMOONGUSS, Species.CHARIZARD ]);
 
       const playerPokemon = game.scene.getPlayerField();
       expect(playerPokemon.length).toBe(2);
@@ -70,7 +70,7 @@ describe("Moves - Follow Me", () => {
   test(
     "move should redirect enemy attacks to the first ally that uses it",
     async () => {
-      await game.startBattle([ Species.AMOONGUSS, Species.CHARIZARD ]);
+      await game.classicMode.startBattle([ Species.AMOONGUSS, Species.CHARIZARD ]);
 
       const playerPokemon = game.scene.getPlayerField();
       expect(playerPokemon.length).toBe(2);
@@ -102,7 +102,7 @@ describe("Moves - Follow Me", () => {
       game.override.moveset([ Moves.QUICK_ATTACK ]);
       game.override.enemyMoveset([ Moves.FOLLOW_ME, Moves.FOLLOW_ME, Moves.FOLLOW_ME, Moves.FOLLOW_ME ]);
 
-      await game.startBattle([ Species.AMOONGUSS, Species.CHARIZARD ]);
+      await game.classicMode.startBattle([ Species.AMOONGUSS, Species.CHARIZARD ]);
 
       const playerPokemon = game.scene.getPlayerField();
       expect(playerPokemon.length).toBe(2);
@@ -136,7 +136,7 @@ describe("Moves - Follow Me", () => {
       game.override.moveset([ Moves.SNIPE_SHOT ]);
       game.override.enemyMoveset([ Moves.FOLLOW_ME, Moves.FOLLOW_ME, Moves.FOLLOW_ME, Moves.FOLLOW_ME ]);
 
-      await game.startBattle([ Species.AMOONGUSS, Species.CHARIZARD ]);
+      await game.classicMode.startBattle([ Species.AMOONGUSS, Species.CHARIZARD ]);
 
       const playerPokemon = game.scene.getPlayerField();
       expect(playerPokemon.length).toBe(2);

--- a/src/test/moves/foresight.test.ts
+++ b/src/test/moves/foresight.test.ts
@@ -33,7 +33,7 @@ describe("Moves - Foresight", () => {
   });
 
   it("should allow Normal and Fighting moves to hit Ghost types", async () => {
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const enemy = game.scene.getEnemyPokemon()!;
 
@@ -57,7 +57,7 @@ describe("Moves - Foresight", () => {
 
   it("should ignore target's evasiveness boosts", async () => {
     game.override.enemyMoveset(Array(4).fill(Moves.MINIMIZE));
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const pokemon = game.scene.getPlayerPokemon()!;
     vi.spyOn(pokemon, "getAccuracyMultiplier");

--- a/src/test/moves/freezy_frost.test.ts
+++ b/src/test/moves/freezy_frost.test.ts
@@ -41,7 +41,7 @@ describe("Moves - Freezy Frost", () => {
     });
 
     it("Uses Swords Dance to raise own ATK by 2, Charm to lower enemy ATK by 2, player uses Freezy Frost to clear all stat changes", { timeout: 10000 }, async () => {
-      await game.startBattle([Species.RATTATA]);
+      await game.classicMode.startBattle([Species.RATTATA]);
       const user = game.scene.getPlayerPokemon()!;
       const enemy = game.scene.getEnemyPokemon()!;
       expect(user.summonData.battleStats[BattleStat.ATK]).toBe(0);
@@ -65,7 +65,7 @@ describe("Moves - Freezy Frost", () => {
 
     it("Uses Swords Dance to raise own ATK by 2, Charm to lower enemy ATK by 2, enemy uses Freezy Frost to clear all stat changes", { timeout: 10000 }, async () => {
       game.override.enemyMoveset([Moves.FREEZY_FROST, Moves.FREEZY_FROST, Moves.FREEZY_FROST, Moves.FREEZY_FROST]);
-      await game.startBattle([Species.SHUCKLE]); // Shuckle for slower Swords Dance on first turn so Freezy Frost doesn't affect it.
+      await game.classicMode.startBattle([Species.SHUCKLE]); // Shuckle for slower Swords Dance on first turn so Freezy Frost doesn't affect it.
       const user = game.scene.getPlayerPokemon()!;
       expect(user.summonData.battleStats[BattleStat.ATK]).toBe(0);
 

--- a/src/test/moves/fusion_bolt.test.ts
+++ b/src/test/moves/fusion_bolt.test.ts
@@ -37,7 +37,7 @@ describe("Moves - Fusion Bolt", () => {
   });
 
   it("should not make contact", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.ZEKROM,
     ]);
 

--- a/src/test/moves/fusion_flare.test.ts
+++ b/src/test/moves/fusion_flare.test.ts
@@ -37,7 +37,7 @@ describe("Moves - Fusion Flare", () => {
   });
 
   it("should thaw freeze status condition", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.RESHIRAM,
     ]);
 

--- a/src/test/moves/fusion_flare_bolt.test.ts
+++ b/src/test/moves/fusion_flare_bolt.test.ts
@@ -46,7 +46,7 @@ describe("Moves - Fusion Flare and Fusion Bolt", () => {
   });
 
   it("FUSION_FLARE should double power of subsequent FUSION_BOLT", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.ZEKROM,
       Species.ZEKROM
     ]);
@@ -72,7 +72,7 @@ describe("Moves - Fusion Flare and Fusion Bolt", () => {
   }, 20000);
 
   it("FUSION_BOLT should double power of subsequent FUSION_FLARE", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.ZEKROM,
       Species.ZEKROM
     ]);
@@ -98,7 +98,7 @@ describe("Moves - Fusion Flare and Fusion Bolt", () => {
   }, 20000);
 
   it("FUSION_FLARE should double power of subsequent FUSION_BOLT if a move failed in between", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.ZEKROM,
       Species.ZEKROM
     ]);
@@ -130,7 +130,7 @@ describe("Moves - Fusion Flare and Fusion Bolt", () => {
 
   it("FUSION_FLARE should not double power of subsequent FUSION_BOLT if a move succeeded in between", async() => {
     game.override.enemyMoveset([ Moves.SPLASH, Moves.SPLASH, Moves.SPLASH, Moves.SPLASH ]);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.ZEKROM,
       Species.ZEKROM
     ]);
@@ -160,7 +160,7 @@ describe("Moves - Fusion Flare and Fusion Bolt", () => {
   }, 20000);
 
   it("FUSION_FLARE should double power of subsequent FUSION_BOLT if moves are aimed at allies", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.ZEKROM,
       Species.RESHIRAM
     ]);
@@ -187,7 +187,7 @@ describe("Moves - Fusion Flare and Fusion Bolt", () => {
 
   it("FUSION_FLARE and FUSION_BOLT alternating throughout turn should double power of subsequent moves", async() => {
     game.override.enemyMoveset([ fusionFlare.id, fusionFlare.id, fusionFlare.id, fusionFlare.id ]);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.ZEKROM,
       Species.ZEKROM
     ]);
@@ -249,7 +249,7 @@ describe("Moves - Fusion Flare and Fusion Bolt", () => {
 
   it("FUSION_FLARE and FUSION_BOLT alternating throughout turn should double power of subsequent moves if moves are aimed at allies", async() => {
     game.override.enemyMoveset([ fusionFlare.id, fusionFlare.id, fusionFlare.id, fusionFlare.id ]);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.ZEKROM,
       Species.ZEKROM
     ]);

--- a/src/test/moves/gastro_acid.test.ts
+++ b/src/test/moves/gastro_acid.test.ts
@@ -44,7 +44,7 @@ describe("Moves - Gastro Acid", () => {
      * - player mon 1 should have dealt damage, player mon 2 should have not
      */
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.GASTRO_ACID));
     game.doSelectTarget(BattlerIndex.ENEMY);
@@ -71,7 +71,7 @@ describe("Moves - Gastro Acid", () => {
   it("fails if used on an enemy with an already-suppressed ability", async () => {
     game.override.battleType(null);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.CORE_ENFORCER));
     // Force player to be slower to enable Core Enforcer to proc its suppression effect

--- a/src/test/moves/glaive_rush.test.ts
+++ b/src/test/moves/glaive_rush.test.ts
@@ -38,7 +38,7 @@ describe("Moves - Glaive Rush", () => {
   });
 
   it("takes double damage from attacks", async() => {
-    await game.startBattle();
+    await game.classicMode.startBattle();
     const enemy = game.scene.getEnemyPokemon()!;
     enemy.hp = 1000;
 
@@ -54,7 +54,7 @@ describe("Moves - Glaive Rush", () => {
   }, 5000); // TODO: revert back to 20s
 
   it("always gets hit by attacks", async() => {
-    await game.startBattle();
+    await game.classicMode.startBattle();
     const enemy = game.scene.getEnemyPokemon()!;
     enemy.hp = 1000;
 
@@ -68,7 +68,7 @@ describe("Moves - Glaive Rush", () => {
   it("interacts properly with multi-lens", async() => {
     game.override.startingHeldItems([{name: "MULTI_LENS", count: 2}]);
     game.override.enemyMoveset(Array(4).fill(Moves.AVALANCHE));
-    await game.startBattle();
+    await game.classicMode.startBattle();
     const player = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;
     enemy.hp = 1000;
@@ -87,7 +87,7 @@ describe("Moves - Glaive Rush", () => {
 
   it("secondary effects only last until next move", async() => {
     game.override.enemyMoveset(Array(4).fill(Moves.SHADOW_SNEAK));
-    await game.startBattle();
+    await game.classicMode.startBattle();
     const player = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;
     enemy.hp = 1000;
@@ -112,7 +112,7 @@ describe("Moves - Glaive Rush", () => {
   it("secondary effects are removed upon switching", async() => {
     game.override.enemyMoveset(Array(4).fill(Moves.SHADOW_SNEAK));
     game.override.starterSpecies(0);
-    await game.startBattle([Species.KLINK, Species.FEEBAS]);
+    await game.classicMode.startBattle([Species.KLINK, Species.FEEBAS]);
     const player = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;
     enemy.hp = 1000;
@@ -132,7 +132,7 @@ describe("Moves - Glaive Rush", () => {
 
   it("secondary effects don't activate if move fails", async() => {
     game.override.moveset([Moves.SHADOW_SNEAK, Moves.PROTECT, Moves.SPLASH, Moves.GLAIVE_RUSH]);
-    await game.startBattle();
+    await game.classicMode.startBattle();
     const player = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;
     enemy.hp = 1000;

--- a/src/test/moves/growth.test.ts
+++ b/src/test/moves/growth.test.ts
@@ -42,7 +42,7 @@ describe("Moves - Growth", () => {
 
   it("GROWTH", async() => {
     const moveToUse = Moves.GROWTH;
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.MIGHTYENA,
       Species.MIGHTYENA,
     ]);

--- a/src/test/moves/hard_press.test.ts
+++ b/src/test/moves/hard_press.test.ts
@@ -37,7 +37,7 @@ describe("Moves - Hard Press", () => {
   });
 
   it("should return 100 power if target HP ratio is at 100%", async () => {
-    await game.startBattle([Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.HARD_PRESS));
     await game.phaseInterceptor.to(MoveEffectPhase);
@@ -46,7 +46,7 @@ describe("Moves - Hard Press", () => {
   });
 
   it("should return 50 power if target HP ratio is at 50%", async () => {
-    await game.startBattle([Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU]);
     const targetHpRatio = .5;
     const enemy = game.scene.getEnemyPokemon()!;
 
@@ -59,7 +59,7 @@ describe("Moves - Hard Press", () => {
   });
 
   it("should return 1 power if target HP ratio is at 1%", async () => {
-    await game.startBattle([Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU]);
     const targetHpRatio = .01;
     const enemy = game.scene.getEnemyPokemon()!;
 
@@ -72,7 +72,7 @@ describe("Moves - Hard Press", () => {
   });
 
   it("should return 1 power if target HP ratio is less than 1%", async () => {
-    await game.startBattle([Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU]);
     const targetHpRatio = .005;
     const enemy = game.scene.getEnemyPokemon()!;
 

--- a/src/test/moves/haze.test.ts
+++ b/src/test/moves/haze.test.ts
@@ -39,7 +39,7 @@ describe("Moves - Haze", () => {
     });
 
     it("Uses Swords Dance to raise own ATK by 2, Charm to lower enemy ATK by 2, player uses Haze to clear all stat changes", { timeout: 10000 }, async () => {
-      await game.startBattle([Species.RATTATA]);
+      await game.classicMode.startBattle([Species.RATTATA]);
       const user = game.scene.getPlayerPokemon()!;
       const enemy = game.scene.getEnemyPokemon()!;
       expect(user.summonData.battleStats[BattleStat.ATK]).toBe(0);
@@ -63,7 +63,7 @@ describe("Moves - Haze", () => {
 
     it("Uses Swords Dance to raise own ATK by 2, Charm to lower enemy ATK by 2, enemy uses Haze to clear all stat changes", { timeout: 10000 }, async () => {
       game.override.enemyMoveset([Moves.HAZE, Moves.HAZE, Moves.HAZE, Moves.HAZE]);
-      await game.startBattle([Species.SHUCKLE]); // Shuckle for slower Swords Dance on first turn so Haze doesn't affect it.
+      await game.classicMode.startBattle([Species.SHUCKLE]); // Shuckle for slower Swords Dance on first turn so Haze doesn't affect it.
       const user = game.scene.getPlayerPokemon()!;
       expect(user.summonData.battleStats[BattleStat.ATK]).toBe(0);
 

--- a/src/test/moves/hyper_beam.test.ts
+++ b/src/test/moves/hyper_beam.test.ts
@@ -43,7 +43,7 @@ describe("Moves - Hyper Beam", () => {
   it(
     "should force the user to recharge on the next turn (and only that turn)",
     async () => {
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
       const enemyPokemon = game.scene.getEnemyPokemon()!;

--- a/src/test/moves/light_screen.test.ts
+++ b/src/test/moves/light_screen.test.ts
@@ -42,7 +42,7 @@ describe("Moves - Light Screen", () => {
 
   it("reduces damage of special attacks by half in a single battle", async() => {
     const moveToUse = Moves.ABSORB;
-    await game.startBattle([Species.SHUCKLE]);
+    await game.classicMode.startBattle([Species.SHUCKLE]);
 
     game.doAttack(getMovePosition(game.scene, 0, moveToUse));
 
@@ -57,7 +57,7 @@ describe("Moves - Light Screen", () => {
     game.override.battleType("double");
 
     const moveToUse = Moves.DAZZLING_GLEAM;
-    await game.startBattle([Species.SHUCKLE, Species.SHUCKLE]);
+    await game.classicMode.startBattle([Species.SHUCKLE, Species.SHUCKLE]);
 
     game.doAttack(getMovePosition(game.scene, 0, moveToUse));
     game.doAttack(getMovePosition(game.scene, 1, moveToUse));
@@ -70,7 +70,7 @@ describe("Moves - Light Screen", () => {
 
   it("does not affect physical attacks", async() => {
     const moveToUse = Moves.TACKLE;
-    await game.startBattle([Species.SHUCKLE]);
+    await game.classicMode.startBattle([Species.SHUCKLE]);
 
     game.doAttack(getMovePosition(game.scene, 0, moveToUse));
 

--- a/src/test/moves/lucky_chant.test.ts
+++ b/src/test/moves/lucky_chant.test.ts
@@ -40,7 +40,7 @@ describe("Moves - Lucky Chant", () => {
   it(
     "should prevent critical hits from moves",
     async () => {
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const playerPokemon = game.scene.getPlayerPokemon()!;
 
@@ -64,7 +64,7 @@ describe("Moves - Lucky Chant", () => {
     async () => {
       game.override.battleType("double");
 
-      await game.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
+      await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
 
       const playerPokemon = game.scene.getPlayerField();
 
@@ -90,7 +90,7 @@ describe("Moves - Lucky Chant", () => {
     async () => {
       game.override.enemyMoveset(Array(4).fill(Moves.TACKLE));
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const playerPokemon = game.scene.getPlayerPokemon()!;
       const enemyPokemon = game.scene.getEnemyPokemon()!;

--- a/src/test/moves/magnet_rise.test.ts
+++ b/src/test/moves/magnet_rise.test.ts
@@ -33,7 +33,7 @@ describe("Moves - Magnet Rise", () => {
   });
 
   it("MAGNET RISE", async () => {
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const startingHp = game.scene.getParty()[0].hp;
     game.doAttack(0);
@@ -44,7 +44,7 @@ describe("Moves - Magnet Rise", () => {
   }, 20000);
 
   it("MAGNET RISE - Gravity", async () => {
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const startingHp = game.scene.getParty()[0].hp;
     game.doAttack(0);

--- a/src/test/moves/make_it_rain.test.ts
+++ b/src/test/moves/make_it_rain.test.ts
@@ -38,7 +38,7 @@ describe("Moves - Make It Rain", () => {
   });
 
   it("should only reduce Sp. Atk. once in a double battle", async () => {
-    await game.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
+    await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
 
     const playerPokemon = game.scene.getPlayerField();
 
@@ -54,7 +54,7 @@ describe("Moves - Make It Rain", () => {
     game.override.enemyLevel(1); // ensures the enemy will faint
     game.override.battleType("single");
 
-    await game.startBattle([Species.CHARIZARD]);
+    await game.classicMode.startBattle([Species.CHARIZARD]);
 
     const playerPokemon = game.scene.getPlayerPokemon()!;
     const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -70,7 +70,7 @@ describe("Moves - Make It Rain", () => {
   it("should reduce Sp. Atk. once after KOing two enemies", async () => {
     game.override.enemyLevel(1); // ensures the enemy will faint
 
-    await game.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
+    await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
 
     const playerPokemon = game.scene.getPlayerField();
     const enemyPokemon = game.scene.getEnemyField();
@@ -85,7 +85,7 @@ describe("Moves - Make It Rain", () => {
   }, TIMEOUT);
 
   it("should reduce Sp. Atk if it only hits the second target", async () => {
-    await game.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
+    await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
 
     const playerPokemon = game.scene.getPlayerField();
 

--- a/src/test/moves/mat_block.test.ts
+++ b/src/test/moves/mat_block.test.ts
@@ -44,7 +44,7 @@ describe("Moves - Mat Block", () => {
   test(
     "should protect the user and allies from attack moves",
     async () => {
-      await game.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
+      await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
 
       const leadPokemon = game.scene.getPlayerField();
 
@@ -65,7 +65,7 @@ describe("Moves - Mat Block", () => {
     async () => {
       game.override.enemyMoveset(Array(4).fill(Moves.GROWL));
 
-      await game.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
+      await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
 
       const leadPokemon = game.scene.getPlayerField();
 
@@ -84,7 +84,7 @@ describe("Moves - Mat Block", () => {
   test(
     "should fail when used after the first turn",
     async () => {
-      await game.startBattle([Species.BLASTOISE, Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.BLASTOISE, Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerField();
 

--- a/src/test/moves/miracle_eye.test.ts
+++ b/src/test/moves/miracle_eye.test.ts
@@ -34,7 +34,7 @@ describe("Moves - Miracle Eye", () => {
   });
 
   it("should allow Psychic moves to hit Dark types", async () => {
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const enemy = game.scene.getEnemyPokemon()!;
 

--- a/src/test/moves/multi_target.test.ts
+++ b/src/test/moves/multi_target.test.ts
@@ -70,7 +70,7 @@ describe("Moves - Multi target", () => {
 async function checkTargetMultiplier(game: GameManager, attackMove: Moves, killAlly: boolean, killSecondEnemy: boolean, shouldMultiplied: boolean, oppAbility?: Abilities) {
   // play an attack and check target count
   game.override.enemyAbility(oppAbility ? oppAbility : Abilities.BALL_FETCH);
-  await game.startBattle();
+  await game.classicMode.startBattle();
 
   const playerPokemonRepr = game.scene.getPlayerField();
 

--- a/src/test/moves/octolock.test.ts
+++ b/src/test/moves/octolock.test.ts
@@ -42,7 +42,7 @@ describe("Moves - Octolock", () => {
     });
 
     it("Reduces DEf and SPDEF by 1 each turn", { timeout: 10000 }, async () => {
-      await game.startBattle([Species.GRAPPLOCT]);
+      await game.classicMode.startBattle([Species.GRAPPLOCT]);
 
       const enemyPokemon = game.scene.getEnemyField();
 
@@ -63,7 +63,7 @@ describe("Moves - Octolock", () => {
     });
 
     it("Traps the target pokemon", { timeout: 10000 }, async () => {
-      await game.startBattle([Species.GRAPPLOCT]);
+      await game.classicMode.startBattle([Species.GRAPPLOCT]);
 
       const enemyPokemon = game.scene.getEnemyField();
 

--- a/src/test/moves/parting_shot.test.ts
+++ b/src/test/moves/parting_shot.test.ts
@@ -44,7 +44,7 @@ describe("Moves - Parting Shot", () => {
       game.override
         .enemySpecies(Species.POOCHYENA)
         .ability(Abilities.PRANKSTER);
-      await game.startBattle([Species.MURKROW, Species.MEOWTH]);
+      await game.classicMode.startBattle([Species.MURKROW, Species.MEOWTH]);
 
       const enemyPokemon = game.scene.getEnemyPokemon()!;
       expect(enemyPokemon).toBeDefined();
@@ -65,7 +65,7 @@ describe("Moves - Parting Shot", () => {
       game.override
         .enemySpecies(Species.GHOLDENGO)
         .enemyAbility(Abilities.GOOD_AS_GOLD);
-      await game.startBattle([Species.MURKROW, Species.MEOWTH]);
+      await game.classicMode.startBattle([Species.MURKROW, Species.MEOWTH]);
 
       const enemyPokemon = game.scene.getEnemyPokemon()!;
       expect(enemyPokemon).toBeDefined();
@@ -84,7 +84,7 @@ describe("Moves - Parting Shot", () => {
     "Parting shot should fail if target is -6/-6 de-buffed",
     async () => {
       game.override.moveset([Moves.PARTING_SHOT, Moves.MEMENTO, Moves.SPLASH]);
-      await game.startBattle([Species.MEOWTH, Species.MEOWTH, Species.MEOWTH, Species.MURKROW, Species.ABRA]);
+      await game.classicMode.startBattle([Species.MEOWTH, Species.MEOWTH, Species.MEOWTH, Species.MURKROW, Species.ABRA]);
 
       // use Memento 3 times to debuff enemy
       game.doAttack(getMovePosition(game.scene, 0, Moves.MEMENTO));
@@ -130,7 +130,7 @@ describe("Moves - Parting Shot", () => {
         .enemySpecies(Species.ALTARIA)
         .enemyAbility(Abilities.NONE)
         .enemyMoveset(Array(4).fill(Moves.MIST));
-      await game.startBattle([Species.SNORLAX, Species.MEOWTH]);
+      await game.classicMode.startBattle([Species.SNORLAX, Species.MEOWTH]);
 
       const enemyPokemon = game.scene.getEnemyPokemon()!;
       expect(enemyPokemon).toBeDefined();
@@ -151,7 +151,7 @@ describe("Moves - Parting Shot", () => {
       game.override
         .enemySpecies(Species.TENTACOOL)
         .enemyAbility(Abilities.CLEAR_BODY);
-      await game.startBattle([Species.SNORLAX, Species.MEOWTH]);
+      await game.classicMode.startBattle([Species.SNORLAX, Species.MEOWTH]);
 
       const enemyPokemon = game.scene.getEnemyPokemon()!;
       expect(enemyPokemon).toBeDefined();
@@ -169,7 +169,7 @@ describe("Moves - Parting Shot", () => {
   it.skip( // TODO: fix this bug to pass the test!
     "Parting shot should de-buff and not fail if no party available to switch - party size 1",
     async () => {
-      await game.startBattle([Species.MURKROW]);
+      await game.classicMode.startBattle([Species.MURKROW]);
 
       const enemyPokemon = game.scene.getEnemyPokemon()!;
       expect(enemyPokemon).toBeDefined();
@@ -187,7 +187,7 @@ describe("Moves - Parting Shot", () => {
   it.skip( // TODO: fix this bug to pass the test!
     "Parting shot regularly not fail if no party available to switch - party fainted",
     async () => {
-      await game.startBattle([Species.MURKROW, Species.MEOWTH]);
+      await game.classicMode.startBattle([Species.MURKROW, Species.MEOWTH]);
       game.doAttack(getMovePosition(game.scene, 0, Moves.SPLASH));
 
       // intentionally kill party pokemon, switch to second slot (now 1 party mon is fainted)

--- a/src/test/moves/protect.test.ts
+++ b/src/test/moves/protect.test.ts
@@ -44,7 +44,7 @@ describe("Moves - Protect", () => {
   test(
     "should protect the user from attacks",
     async () => {
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
 
@@ -62,7 +62,7 @@ describe("Moves - Protect", () => {
       game.override.enemyMoveset(Array(4).fill(Moves.CEASELESS_EDGE));
       vi.spyOn(allMoves[Moves.CEASELESS_EDGE], "accuracy", "get").mockReturnValue(100);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
 
@@ -80,7 +80,7 @@ describe("Moves - Protect", () => {
     async () => {
       game.override.enemyMoveset(Array(4).fill(Moves.CHARM));
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
 
@@ -97,7 +97,7 @@ describe("Moves - Protect", () => {
     async () => {
       game.override.enemyMoveset(Array(4).fill(Moves.TACHYON_CUTTER));
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
 

--- a/src/test/moves/purify.test.ts
+++ b/src/test/moves/purify.test.ts
@@ -41,7 +41,7 @@ describe("Moves - Purify", () => {
   test(
     "Purify heals opponent status effect and restores user hp",
     async () => {
-      await game.startBattle();
+      await game.classicMode.startBattle();
 
       const enemyPokemon: EnemyPokemon = game.scene.getEnemyPokemon()!;
       const playerPokemon: PlayerPokemon = game.scene.getPlayerPokemon()!;
@@ -62,7 +62,7 @@ describe("Moves - Purify", () => {
   test(
     "Purify does not heal if opponent doesnt have any status effect",
     async () => {
-      await game.startBattle();
+      await game.classicMode.startBattle();
 
       const playerPokemon: PlayerPokemon = game.scene.getPlayerPokemon()!;
 

--- a/src/test/moves/quick_guard.test.ts
+++ b/src/test/moves/quick_guard.test.ts
@@ -43,7 +43,7 @@ describe("Moves - Quick Guard", () => {
   test(
     "should protect the user and allies from priority moves",
     async () => {
-      await game.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
+      await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
 
       const leadPokemon = game.scene.getPlayerField();
 
@@ -65,7 +65,7 @@ describe("Moves - Quick Guard", () => {
       game.override.enemyAbility(Abilities.PRANKSTER);
       game.override.enemyMoveset(Array(4).fill(Moves.GROWL));
 
-      await game.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
+      await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
 
       const leadPokemon = game.scene.getPlayerField();
 
@@ -86,7 +86,7 @@ describe("Moves - Quick Guard", () => {
     async () => {
       game.override.enemyMoveset(Array(4).fill(Moves.WATER_SHURIKEN));
 
-      await game.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
+      await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
 
       const leadPokemon = game.scene.getPlayerField();
       const enemyPokemon = game.scene.getEnemyField();

--- a/src/test/moves/rage_powder.test.ts
+++ b/src/test/moves/rage_powder.test.ts
@@ -42,7 +42,7 @@ describe("Moves - Rage Powder", () => {
     async () => {
       game.override.enemyMoveset([ Moves.RAGE_POWDER, Moves.RAGE_POWDER, Moves.RAGE_POWDER, Moves.RAGE_POWDER ]);
 
-      await game.startBattle([ Species.AMOONGUSS, Species.VENUSAUR ]);
+      await game.classicMode.startBattle([ Species.AMOONGUSS, Species.VENUSAUR ]);
 
       const playerPokemon = game.scene.getPlayerField();
       expect(playerPokemon.length).toBe(2);
@@ -77,7 +77,7 @@ describe("Moves - Rage Powder", () => {
       game.override.enemyMoveset([ Moves.RAGE_POWDER, Moves.RAGE_POWDER, Moves.RAGE_POWDER, Moves.RAGE_POWDER ]);
 
       // Test with two non-Grass type player Pokemon
-      await game.startBattle([ Species.BLASTOISE, Species.CHARIZARD ]);
+      await game.classicMode.startBattle([ Species.BLASTOISE, Species.CHARIZARD ]);
 
       const playerPokemon = game.scene.getPlayerField();
       expect(playerPokemon.length).toBe(2);

--- a/src/test/moves/reflect.test.ts
+++ b/src/test/moves/reflect.test.ts
@@ -42,7 +42,7 @@ describe("Moves - Reflect", () => {
 
   it("reduces damage of physical attacks by half in a single battle", async() => {
     const moveToUse = Moves.TACKLE;
-    await game.startBattle([Species.SHUCKLE]);
+    await game.classicMode.startBattle([Species.SHUCKLE]);
 
     game.doAttack(getMovePosition(game.scene, 0, moveToUse));
 
@@ -56,7 +56,7 @@ describe("Moves - Reflect", () => {
     game.override.battleType("double");
 
     const moveToUse = Moves.ROCK_SLIDE;
-    await game.startBattle([Species.SHUCKLE, Species.SHUCKLE]);
+    await game.classicMode.startBattle([Species.SHUCKLE, Species.SHUCKLE]);
 
     game.doAttack(getMovePosition(game.scene, 0, moveToUse));
     game.doAttack(getMovePosition(game.scene, 1, moveToUse));
@@ -69,7 +69,7 @@ describe("Moves - Reflect", () => {
 
   it("does not affect special attacks", async() => {
     const moveToUse = Moves.ABSORB;
-    await game.startBattle([Species.SHUCKLE]);
+    await game.classicMode.startBattle([Species.SHUCKLE]);
 
     game.doAttack(getMovePosition(game.scene, 0, moveToUse));
 

--- a/src/test/moves/rollout.test.ts
+++ b/src/test/moves/rollout.test.ts
@@ -45,7 +45,7 @@ describe("Moves - Rollout", () => {
     const turns = 6;
     const dmgHistory: number[] = [];
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     const playerPkm = game.scene.getParty()[0];
     vi.spyOn(playerPkm, "stats", "get").mockReturnValue([500000, 1, 1, 1, 1, 1]); // HP, ATK, DEF, SPATK, SPDEF, SPD

--- a/src/test/moves/roost.test.ts
+++ b/src/test/moves/roost.test.ts
@@ -39,7 +39,7 @@ describe("Moves - Roost", () => {
   test(
     "move should ground the user until the end of turn",
     async () => {
-      await game.startBattle([Species.MAGIKARP]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const enemyPokemon = game.scene.getEnemyPokemon()!;
 

--- a/src/test/moves/shell_trap.test.ts
+++ b/src/test/moves/shell_trap.test.ts
@@ -44,7 +44,7 @@ describe("Moves - Shell Trap", () => {
   it(
     "should activate after the user is hit by a physical attack",
     async () => {
-      await game.startBattle([Species.CHARIZARD, Species.TURTONATOR]);
+      await game.classicMode.startBattle([Species.CHARIZARD, Species.TURTONATOR]);
 
       const playerPokemon = game.scene.getPlayerField();
       const enemyPokemon = game.scene.getEnemyField();
@@ -70,7 +70,7 @@ describe("Moves - Shell Trap", () => {
     async () => {
       game.override.enemyMoveset(Array(4).fill(Moves.SWIFT));
 
-      await game.startBattle([Species.CHARIZARD, Species.TURTONATOR]);
+      await game.classicMode.startBattle([Species.CHARIZARD, Species.TURTONATOR]);
 
       const playerPokemon = game.scene.getPlayerField();
       const enemyPokemon = game.scene.getEnemyField();
@@ -96,7 +96,7 @@ describe("Moves - Shell Trap", () => {
     async () => {
       game.override.enemyMoveset(SPLASH_ONLY);
 
-      await game.startBattle([Species.CHARIZARD, Species.TURTONATOR]);
+      await game.classicMode.startBattle([Species.CHARIZARD, Species.TURTONATOR]);
 
       const playerPokemon = game.scene.getPlayerField();
       const enemyPokemon = game.scene.getEnemyField();
@@ -122,7 +122,7 @@ describe("Moves - Shell Trap", () => {
     async () => {
       game.override.enemyMoveset(SPLASH_ONLY);
 
-      await game.startBattle([Species.BLASTOISE, Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.BLASTOISE, Species.CHARIZARD]);
 
       const playerPokemon = game.scene.getPlayerField();
       const enemyPokemon = game.scene.getEnemyField();
@@ -149,7 +149,7 @@ describe("Moves - Shell Trap", () => {
       game.override.battleType("single");
       vi.spyOn(allMoves[Moves.RAZOR_LEAF], "priority", "get").mockReturnValue(-4);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const playerPokemon = game.scene.getPlayerPokemon()!;
       const enemyPokemon = game.scene.getEnemyPokemon()!;

--- a/src/test/moves/spit_up.test.ts
+++ b/src/test/moves/spit_up.test.ts
@@ -44,7 +44,7 @@ describe("Moves - Spit Up", () => {
       const stacksToSetup = 1;
       const expectedPower = 100;
 
-      await game.startBattle([Species.ABOMASNOW]);
+      await game.classicMode.startBattle([Species.ABOMASNOW]);
 
       const pokemon = game.scene.getPlayerPokemon()!;
       pokemon.addTag(BattlerTagType.STOCKPILING);
@@ -68,7 +68,7 @@ describe("Moves - Spit Up", () => {
       const stacksToSetup = 2;
       const expectedPower = 200;
 
-      await game.startBattle([Species.ABOMASNOW]);
+      await game.classicMode.startBattle([Species.ABOMASNOW]);
 
       const pokemon = game.scene.getPlayerPokemon()!;
       pokemon.addTag(BattlerTagType.STOCKPILING);
@@ -93,7 +93,7 @@ describe("Moves - Spit Up", () => {
       const stacksToSetup = 3;
       const expectedPower = 300;
 
-      await game.startBattle([Species.ABOMASNOW]);
+      await game.classicMode.startBattle([Species.ABOMASNOW]);
 
       const pokemon = game.scene.getPlayerPokemon()!;
       pokemon.addTag(BattlerTagType.STOCKPILING);
@@ -117,7 +117,7 @@ describe("Moves - Spit Up", () => {
   });
 
   it("fails without stacks", { timeout: 10000 }, async () => {
-    await game.startBattle([Species.ABOMASNOW]);
+    await game.classicMode.startBattle([Species.ABOMASNOW]);
 
     const pokemon = game.scene.getPlayerPokemon()!;
 
@@ -136,7 +136,7 @@ describe("Moves - Spit Up", () => {
 
   describe("restores stat boosts granted by stacks", () => {
     it("decreases stats based on stored values (both boosts equal)", { timeout: 10000 }, async () => {
-      await game.startBattle([Species.ABOMASNOW]);
+      await game.classicMode.startBattle([Species.ABOMASNOW]);
 
       const pokemon = game.scene.getPlayerPokemon()!;
       pokemon.addTag(BattlerTagType.STOCKPILING);
@@ -165,7 +165,7 @@ describe("Moves - Spit Up", () => {
     });
 
     it("decreases stats based on stored values (different boosts)", { timeout: 10000 }, async () => {
-      await game.startBattle([Species.ABOMASNOW]);
+      await game.classicMode.startBattle([Species.ABOMASNOW]);
 
       const pokemon = game.scene.getPlayerPokemon()!;
       pokemon.addTag(BattlerTagType.STOCKPILING);

--- a/src/test/moves/spotlight.test.ts
+++ b/src/test/moves/spotlight.test.ts
@@ -40,7 +40,7 @@ describe("Moves - Spotlight", () => {
   test(
     "move should redirect attacks to the target",
     async () => {
-      await game.startBattle([ Species.AMOONGUSS, Species.CHARIZARD ]);
+      await game.classicMode.startBattle([ Species.AMOONGUSS, Species.CHARIZARD ]);
 
       const playerPokemon = game.scene.getPlayerField();
       expect(playerPokemon.length).toBe(2);
@@ -72,7 +72,7 @@ describe("Moves - Spotlight", () => {
     async () => {
       game.override.enemyMoveset([ Moves.FOLLOW_ME, Moves.FOLLOW_ME, Moves.FOLLOW_ME, Moves.FOLLOW_ME ]);
 
-      await game.startBattle([ Species.AMOONGUSS, Species.CHARIZARD ]);
+      await game.classicMode.startBattle([ Species.AMOONGUSS, Species.CHARIZARD ]);
 
       const playerPokemon = game.scene.getPlayerField();
       expect(playerPokemon.length).toBe(2);

--- a/src/test/moves/stockpile.test.ts
+++ b/src/test/moves/stockpile.test.ts
@@ -40,7 +40,7 @@ describe("Moves - Stockpile", () => {
     });
 
     it("Gains a stockpile stack and increases DEF and SPDEF by 1 on each use, fails at max stacks (3)", { timeout: 10000 }, async () => {
-      await game.startBattle([Species.ABOMASNOW]);
+      await game.classicMode.startBattle([Species.ABOMASNOW]);
 
       const user = game.scene.getPlayerPokemon()!;
 
@@ -81,7 +81,7 @@ describe("Moves - Stockpile", () => {
     });
 
     it("Gains a stockpile stack even if DEF and SPDEF are at +6", { timeout: 10000 }, async () => {
-      await game.startBattle([Species.ABOMASNOW]);
+      await game.classicMode.startBattle([Species.ABOMASNOW]);
 
       const user = game.scene.getPlayerPokemon()!;
 

--- a/src/test/moves/swallow.test.ts
+++ b/src/test/moves/swallow.test.ts
@@ -43,7 +43,7 @@ describe("Moves - Swallow", () => {
       const stacksToSetup = 1;
       const expectedHeal = 25;
 
-      await game.startBattle([Species.ABOMASNOW]);
+      await game.classicMode.startBattle([Species.ABOMASNOW]);
 
       const pokemon = game.scene.getPlayerPokemon()!;
       vi.spyOn(pokemon, "getMaxHp").mockReturnValue(100);
@@ -70,7 +70,7 @@ describe("Moves - Swallow", () => {
       const stacksToSetup = 2;
       const expectedHeal = 50;
 
-      await game.startBattle([Species.ABOMASNOW]);
+      await game.classicMode.startBattle([Species.ABOMASNOW]);
 
       const pokemon = game.scene.getPlayerPokemon()!;
       vi.spyOn(pokemon, "getMaxHp").mockReturnValue(100);
@@ -98,7 +98,7 @@ describe("Moves - Swallow", () => {
       const stacksToSetup = 3;
       const expectedHeal = 100;
 
-      await game.startBattle([Species.ABOMASNOW]);
+      await game.classicMode.startBattle([Species.ABOMASNOW]);
 
       const pokemon = game.scene.getPlayerPokemon()!;
       vi.spyOn(pokemon, "getMaxHp").mockReturnValue(100);
@@ -125,7 +125,7 @@ describe("Moves - Swallow", () => {
   });
 
   it("fails without stacks", { timeout: 10000 }, async () => {
-    await game.startBattle([Species.ABOMASNOW]);
+    await game.classicMode.startBattle([Species.ABOMASNOW]);
 
     const pokemon = game.scene.getPlayerPokemon()!;
 
@@ -140,7 +140,7 @@ describe("Moves - Swallow", () => {
 
   describe("restores stat boosts granted by stacks", () => {
     it("decreases stats based on stored values (both boosts equal)", { timeout: 10000 }, async () => {
-      await game.startBattle([Species.ABOMASNOW]);
+      await game.classicMode.startBattle([Species.ABOMASNOW]);
 
       const pokemon = game.scene.getPlayerPokemon()!;
       pokemon.addTag(BattlerTagType.STOCKPILING);
@@ -165,7 +165,7 @@ describe("Moves - Swallow", () => {
     });
 
     it("decreases stats based on stored values (different boosts)", { timeout: 10000 }, async () => {
-      await game.startBattle([Species.ABOMASNOW]);
+      await game.classicMode.startBattle([Species.ABOMASNOW]);
 
       const pokemon = game.scene.getPlayerPokemon()!;
       pokemon.addTag(BattlerTagType.STOCKPILING);

--- a/src/test/moves/tackle.test.ts
+++ b/src/test/moves/tackle.test.ts
@@ -41,7 +41,7 @@ describe("Moves - Tackle", () => {
   it("TACKLE against ghost", async() => {
     const moveToUse = Moves.TACKLE;
     game.override.enemySpecies(Species.GENGAR);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.MIGHTYENA,
     ]);
     const hpOpponent = game.scene.currentBattle.enemyParty[0].hp;
@@ -59,7 +59,7 @@ describe("Moves - Tackle", () => {
 
   it("TACKLE against not resistant", async() => {
     const moveToUse = Moves.TACKLE;
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.MIGHTYENA,
     ]);
     game.scene.currentBattle.enemyParty[0].stats[Stat.DEF] = 50;

--- a/src/test/moves/tail_whip.test.ts
+++ b/src/test/moves/tail_whip.test.ts
@@ -41,7 +41,7 @@ describe("Moves - Tail whip", () => {
 
   it("TAIL_WHIP", async() => {
     const moveToUse = Moves.TAIL_WHIP;
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.MIGHTYENA,
       Species.MIGHTYENA,
     ]);

--- a/src/test/moves/tailwind.test.ts
+++ b/src/test/moves/tailwind.test.ts
@@ -32,7 +32,7 @@ describe("Moves - Tailwind", () => {
   });
 
   it("doubles the Speed stat of the Pokemons on its side", async () => {
-    await game.startBattle([Species.MAGIKARP, Species.MEOWTH]);
+    await game.classicMode.startBattle([Species.MAGIKARP, Species.MEOWTH]);
     const magikarp = game.scene.getPlayerField()[0];
     const meowth = game.scene.getPlayerField()[1];
 
@@ -55,7 +55,7 @@ describe("Moves - Tailwind", () => {
   it("lasts for 4 turns", async () => {
     game.override.battleType("single");
 
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.TAILWIND));
     await game.toNextTurn();
@@ -78,7 +78,7 @@ describe("Moves - Tailwind", () => {
   it("does not affect the opposing side", async () => {
     game.override.battleType("single");
 
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
 
     const ally = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;

--- a/src/test/moves/thousand_arrows.test.ts
+++ b/src/test/moves/thousand_arrows.test.ts
@@ -38,7 +38,7 @@ describe("Moves - Thousand Arrows", () => {
   it(
     "move should hit and ground Flying-type targets",
     async () => {
-      await game.startBattle([ Species.ILLUMISE ]);
+      await game.classicMode.startBattle([ Species.ILLUMISE ]);
 
       const enemyPokemon = game.scene.getEnemyPokemon()!;
 
@@ -61,7 +61,7 @@ describe("Moves - Thousand Arrows", () => {
       game.override.enemySpecies(Species.SNORLAX);
       game.override.enemyAbility(Abilities.LEVITATE);
 
-      await game.startBattle([ Species.ILLUMISE ]);
+      await game.classicMode.startBattle([ Species.ILLUMISE ]);
 
       const enemyPokemon = game.scene.getEnemyPokemon()!;
 
@@ -83,7 +83,7 @@ describe("Moves - Thousand Arrows", () => {
     async () => {
       game.override.enemySpecies(Species.SNORLAX);
 
-      await game.startBattle([ Species.ILLUMISE ]);
+      await game.classicMode.startBattle([ Species.ILLUMISE ]);
 
       const enemyPokemon = game.scene.getEnemyPokemon()!;
 

--- a/src/test/moves/tidy_up.test.ts
+++ b/src/test/moves/tidy_up.test.ts
@@ -41,7 +41,7 @@ describe("Moves - Tidy Up", () => {
   it("spikes are cleared", async() => {
     game.override.moveset([Moves.SPIKES, Moves.TIDY_UP]);
     game.override.enemyMoveset([Moves.SPIKES, Moves.SPIKES, Moves.SPIKES, Moves.SPIKES]);
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.SPIKES));
     await game.phaseInterceptor.to(TurnEndPhase);
@@ -54,7 +54,7 @@ describe("Moves - Tidy Up", () => {
   it("stealth rocks are cleared", async() => {
     game.override.moveset([Moves.STEALTH_ROCK, Moves.TIDY_UP]);
     game.override.enemyMoveset([Moves.STEALTH_ROCK, Moves.STEALTH_ROCK, Moves.STEALTH_ROCK, Moves.STEALTH_ROCK]);
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.STEALTH_ROCK));
     await game.phaseInterceptor.to(TurnEndPhase);
@@ -67,7 +67,7 @@ describe("Moves - Tidy Up", () => {
   it("toxic spikes are cleared", async() => {
     game.override.moveset([Moves.TOXIC_SPIKES, Moves.TIDY_UP]);
     game.override.enemyMoveset([Moves.TOXIC_SPIKES, Moves.TOXIC_SPIKES, Moves.TOXIC_SPIKES, Moves.TOXIC_SPIKES]);
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.TOXIC_SPIKES));
     await game.phaseInterceptor.to(TurnEndPhase);
@@ -81,7 +81,7 @@ describe("Moves - Tidy Up", () => {
     game.override.moveset([Moves.STICKY_WEB, Moves.TIDY_UP]);
     game.override.enemyMoveset([Moves.STICKY_WEB, Moves.STICKY_WEB, Moves.STICKY_WEB, Moves.STICKY_WEB]);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.STICKY_WEB));
     await game.phaseInterceptor.to(TurnEndPhase);
@@ -95,7 +95,7 @@ describe("Moves - Tidy Up", () => {
     game.override.moveset([Moves.SUBSTITUTE, Moves.TIDY_UP]);
     game.override.enemyMoveset([Moves.SUBSTITUTE, Moves.SUBSTITUTE, Moves.SUBSTITUTE, Moves.SUBSTITUTE]);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.SUBSTITUTE));
     await game.phaseInterceptor.to(TurnEndPhase);
@@ -106,7 +106,7 @@ describe("Moves - Tidy Up", () => {
   }, 20000);
 
   it("user's stats are raised with no traps set", async() => {
-    await game.startBattle();
+    await game.classicMode.startBattle();
     const player = game.scene.getPlayerPokemon()!.summonData.battleStats;
 
     expect(player[BattleStat.ATK]).toBe(0);

--- a/src/test/moves/u_turn.test.ts
+++ b/src/test/moves/u_turn.test.ts
@@ -40,7 +40,7 @@ describe("Moves - U-turn", () => {
     // arrange
     const playerHp = 1;
     game.override.ability(Abilities.REGENERATOR);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.RAICHU,
       Species.SHUCKLE
     ]);
@@ -60,7 +60,7 @@ describe("Moves - U-turn", () => {
   it("triggers rough skin on the u-turn user before a new pokemon is switched in", async() => {
     // arrange
     game.override.enemyAbility(Abilities.ROUGH_SKIN);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.RAICHU,
       Species.SHUCKLE
     ]);
@@ -81,7 +81,7 @@ describe("Moves - U-turn", () => {
   it("triggers contact abilities on the u-turn user (eg poison point) before a new pokemon is switched in", async() => {
     // arrange
     game.override.enemyAbility(Abilities.POISON_POINT);
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.RAICHU,
       Species.SHUCKLE
     ]);

--- a/src/test/moves/wide_guard.test.ts
+++ b/src/test/moves/wide_guard.test.ts
@@ -43,7 +43,7 @@ describe("Moves - Wide Guard", () => {
   test(
     "should protect the user and allies from multi-target attack moves",
     async () => {
-      await game.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
+      await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
 
       const leadPokemon = game.scene.getPlayerField();
 
@@ -64,7 +64,7 @@ describe("Moves - Wide Guard", () => {
     async () => {
       game.override.enemyMoveset(Array(4).fill(Moves.GROWL));
 
-      await game.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
+      await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
 
       const leadPokemon = game.scene.getPlayerField();
 
@@ -85,7 +85,7 @@ describe("Moves - Wide Guard", () => {
     async () => {
       game.override.enemyMoveset(Array(4).fill(Moves.TACKLE));
 
-      await game.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
+      await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
 
       const leadPokemon = game.scene.getPlayerField();
 
@@ -106,7 +106,7 @@ describe("Moves - Wide Guard", () => {
     async () => {
       game.override.enemyMoveset(Array(4).fill(Moves.SPLASH));
 
-      await game.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
+      await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
 
       const leadPokemon = game.scene.getPlayerField();
       const enemyPokemon = game.scene.getEnemyField();

--- a/src/test/ui/battle-info.test.ts
+++ b/src/test/ui/battle-info.test.ts
@@ -1,0 +1,59 @@
+import { ExpGainsSpeed } from "#app/enums/exp-gains-speed.js";
+import { Moves } from "#app/enums/moves.js";
+import { Species } from "#app/enums/species.js";
+import { BattleEndPhase } from "#app/phases/battle-end-phase.js";
+import GameManager from "#test/utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { getMovePosition } from "../utils/gameManagerUtils";
+import { SPLASH_ONLY } from "../utils/testUtils";
+
+describe("UI - Battle Info", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(async () => {
+    game = new GameManager(phaserGame);
+    game.override.battleType("single").enemyMoveset(SPLASH_ONLY).moveset([Moves.DRAGON_CLAW]);
+  });
+
+  it("skip exp animation when exp-gains-speed is SKIP ", async () => {
+    await game.classicMode.startBattle([Species.ABRA]);
+    game.settings.expGainsSpeed(ExpGainsSpeed.SKIP);
+
+    const abra = game.scene.getPlayerPokemon()!;
+    const battleInfo = abra.getBattleInfo();
+    vi.spyOn(battleInfo, "updatePokemonExp");
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.DRAGON_CLAW));
+    await game.doKillOpponents();
+    await game.phaseInterceptor.to(BattleEndPhase, true);
+
+    expect(battleInfo.updatePokemonExp).toHaveBeenCalledWith(abra, true, expect.anything());
+  });
+
+  it("DO NOT skip exp animation when exp-gains-speed is NOT skip ", async () => {
+    await game.classicMode.startBattle([Species.ABRA]);
+    game.settings.expGainsSpeed(ExpGainsSpeed.NORMAL);
+
+    const abra = game.scene.getPlayerPokemon()!;
+    const battleInfo = abra.getBattleInfo();
+    vi.spyOn(battleInfo, "updatePokemonExp");
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.DRAGON_CLAW));
+    await game.doKillOpponents();
+    await game.phaseInterceptor.to(BattleEndPhase, true);
+
+    expect(battleInfo.updatePokemonExp).not.toHaveBeenCalledWith(abra, true, expect.anything());
+  });
+});

--- a/src/test/ui/transfer-item.test.ts
+++ b/src/test/ui/transfer-item.test.ts
@@ -42,7 +42,7 @@ describe("UI - Transfer Items", () => {
     game.override.enemySpecies(Species.MAGIKARP);
     game.override.enemyMoveset([Moves.SPLASH]);
 
-    await game.startBattle([Species.RAYQUAZA, Species.RAYQUAZA, Species.RAYQUAZA]);
+    await game.classicMode.startBattle([Species.RAYQUAZA, Species.RAYQUAZA, Species.RAYQUAZA]);
 
     game.doAttack(getMovePosition(game.scene, 0, Moves.DRAGON_CLAW));
 

--- a/src/test/ui/type-hints.test.ts
+++ b/src/test/ui/type-hints.test.ts
@@ -40,7 +40,7 @@ describe("UI - Type Hints", () => {
       .moveset([Moves.DRAGON_CLAW]);
     game.settings.typeHints(true); //activate type hints
 
-    await game.startBattle([Species.RAYQUAZA]);
+    await game.classicMode.startBattle([Species.RAYQUAZA]);
 
     game.onNextPrompt("CommandPhase", Mode.COMMAND, () => {
       const { ui } = game.scene;
@@ -65,7 +65,7 @@ describe("UI - Type Hints", () => {
   it("check status move color", async () => {
     game.override.enemySpecies(Species.FLORGES).moveset([Moves.GROWL]);
 
-    await game.startBattle([Species.RAYQUAZA]);
+    await game.classicMode.startBattle([Species.RAYQUAZA]);
 
     game.onNextPrompt("CommandPhase", Mode.COMMAND, () => {
       const { ui } = game.scene;

--- a/src/test/utils/gameManager.ts
+++ b/src/test/utils/gameManager.ts
@@ -171,28 +171,6 @@ export default class GameManager {
   }
 
   /**
-   * Transitions to the start of a battle.
-   * @param species - Optional array of species to start the battle with.
-   * @returns A promise that resolves when the battle is started.
-   */
-  async startBattle(species?: Species[]) {
-    await this.classicMode.runToSummon(species);
-
-    this.onNextPrompt("CheckSwitchPhase", Mode.CONFIRM, () => {
-      this.setMode(Mode.MESSAGE);
-      this.endPhase();
-    }, () => this.isCurrentPhase(CommandPhase) || this.isCurrentPhase(TurnInitPhase));
-
-    this.onNextPrompt("CheckSwitchPhase", Mode.CONFIRM, () => {
-      this.setMode(Mode.MESSAGE);
-      this.endPhase();
-    }, () => this.isCurrentPhase(CommandPhase) || this.isCurrentPhase(TurnInitPhase));
-
-    await this.phaseInterceptor.to(CommandPhase);
-    console.log("==================[New Turn]==================");
-  }
-
-  /**
    * Emulate a player attack
    * @param movePosition the index of the move in the pokemon's moveset array
    */

--- a/src/test/utils/gameManager.ts
+++ b/src/test/utils/gameManager.ts
@@ -42,6 +42,7 @@ import { TitlePhase } from "#app/phases/title-phase.js";
 import { TurnEndPhase } from "#app/phases/turn-end-phase.js";
 import { TurnInitPhase } from "#app/phases/turn-init-phase.js";
 import { TurnStartPhase } from "#app/phases/turn-start-phase.js";
+import { ExpGainsSpeed } from "#app/enums/exp-gains-speed.js";
 
 /**
  * Class to manage the game state and transitions between phases.
@@ -129,7 +130,7 @@ export default class GameManager {
     this.scene.gameSpeed = 5;
     this.scene.moveAnimations = false;
     this.scene.showLevelUpStats = false;
-    this.scene.expGainsSpeed = 3;
+    this.scene.expGainsSpeed = ExpGainsSpeed.SKIP;
     this.scene.expParty = ExpNotification.SKIP;
     this.scene.hpBarSpeed = 3;
     this.scene.enableTutorials = false;

--- a/src/test/utils/helpers/settingsHelper.ts
+++ b/src/test/utils/helpers/settingsHelper.ts
@@ -1,3 +1,4 @@
+import { ExpGainsSpeed } from "#app/enums/exp-gains-speed.js";
 import { GameManagerHelper } from "./gameManagerHelper";
 
 /**
@@ -11,5 +12,13 @@ export class SettingsHelper extends GameManagerHelper {
    */
   typeHints(enable: boolean) {
     this.game.scene.typeHints = enable;
+  }
+
+  /**
+   * Set the EXP gains speed settings
+   * @param speed exp gains speed to set
+   */
+  expGainsSpeed(speed: ExpGainsSpeed) {
+    this.game.scene.expGainsSpeed = speed;
   }
 }

--- a/src/test/utils/helpers/settingsHelper.ts
+++ b/src/test/utils/helpers/settingsHelper.ts
@@ -12,6 +12,7 @@ export class SettingsHelper extends GameManagerHelper {
    */
   typeHints(enable: boolean) {
     this.game.scene.typeHints = enable;
+    this.log(`type-hints ${enable? "enabled" : "disabled"}!`);
   }
 
   /**
@@ -20,5 +21,10 @@ export class SettingsHelper extends GameManagerHelper {
    */
   expGainsSpeed(speed: ExpGainsSpeed) {
     this.game.scene.expGainsSpeed = speed;
+    this.log(`exp-gains-speed set to ${ExpGainsSpeed[speed]} (=${speed})!`);
+  }
+
+  private log(...params: any[]) {
+    console.log("Settings:", ...params);
   }
 }

--- a/src/ui/battle-info.ts
+++ b/src/ui/battle-info.ts
@@ -11,6 +11,7 @@ import { BattleStat } from "#app/data/battle-stat";
 import BattleFlyout from "./battle-flyout";
 import { WindowVariant, addWindow } from "./ui-theme";
 import i18next from "i18next";
+import { ExpGainsSpeed } from "#app/enums/exp-gains-speed.js";
 
 export default class BattleInfo extends Phaser.GameObjects.Container {
   private baseY: number;
@@ -630,12 +631,13 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
       };
 
       if (this.player) {
-        const isLevelCapped = pokemon.level >= (this.scene as BattleScene).getMaxExpLevel();
+        const scene = this.scene as BattleScene;
+        const isLevelCapped = pokemon.level >= scene.getMaxExpLevel();
 
         if ((this.lastExp !== pokemon.exp || this.lastLevel !== pokemon.level)) {
           const originalResolve = resolve;
           const durationMultipler = Math.max(Phaser.Tweens.Builders.GetEaseFunction("Cubic.easeIn")(1 - (Math.min(pokemon.level - this.lastLevel, 10) / 10)), 0.1);
-          resolve = () => this.updatePokemonExp(pokemon, false, durationMultipler).then(() => originalResolve());
+          resolve = () => this.updatePokemonExp(pokemon, scene.expGainsSpeed === ExpGainsSpeed.SKIP, durationMultipler).then(() => originalResolve());
         } else if (isLevelCapped !== this.lastLevelCapped) {
           this.setLevel(pokemon.level);
         }


### PR DESCRIPTION
fixed #3644

## What are the changes the user will see?

The user will not have to wait for the exp-animation of the currently active PKM when set to `skip`

## Why am I making these changes?

Exp-Gains-Speed should have always affected the animation of the currently fighting PKM

## What are the changes from a developer perspective?

Added a `ExpGainsSpeed` enum.

### Screenshots/Videos

https://github.com/user-attachments/assets/4c375f5e-a0af-45f4-bfdd-cb7c6d9d2577\

## How to test the changes?

- Set the Exp-Gains-Speed in the settings to `Skip`
- Fight a wave and have a look at the animatio of the exp-gain : it won't play

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
    - Technically the change for `startBattle` to move into classicModeHelper could be a separate one.. but .. meh
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
