### PR TITLE
[Enhancement] Delete the existing starter preferences when new save data is imported

### DIFF
--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -233,6 +233,10 @@ export class StarterPrefs {
       localStorage.setItem(`starterPrefs_${loggedInUser?.username}`, pStr);
     }
   }
+
+  static delete(): void {
+    localStorage.removeItem(`starterPrefs_${loggedInUser?.username}`);
+  }
 }
 
 export interface StarterDataEntry {
@@ -1315,6 +1319,11 @@ export class GameData {
             this.scene.ui.showText(`Your ${dataName} data will be overridden and the page will reload. Proceed?`, null, () => {
               this.scene.ui.setOverlayMode(Mode.CONFIRM, () => {
                 localStorage.setItem(dataKey, encrypt(dataStr, bypassLogin));
+
+                // If we imported main game data, delete the existing starter preferences
+                if (dataType === GameDataType.SYSTEM && (Utils.isLocal || Utils.isBeta)) {
+                  StarterPrefs.delete();
+                }
 
                 if (!bypassLogin && dataType < GameDataType.SETTINGS) {
                   updateUserInfo().then(success => {


### PR DESCRIPTION
## What are the changes the user will see?
When importing a save file, the local starter preferences for shiny variant, form, nickname, etc. are deleted.

## Why am I making these changes?
At the moment the settings for preferred gender, form, shiny, variant, nickname and favorite status for starters are saved locally and not on the server. This means that when importing a different save data those preferences were kept, resulting in Pokemon potentially showing a shiny variant or form that is not actually unlocked, or the favorite ribbon and nickname that was set previously.
This is only useful for beta/local play where importing save data is possible, but would really help in preventing weird behavior when testing things out for the starter select screen

## What are the changes from a developer perspective?
Creates a delete() method for StarterPrefs and calls it after importing new game data (not when importing session or other type of Game Data)
Note: I added a safeguard to make sure that we are in local or beta, but technically it shouldn't be necessary. let me know if I should keep or remove it

### Screenshots/Videos
Before: Nidoran has a nickname, Caterpie and Vulpix are set to show shiny tier 1 and 2 respectively
<img width="699" alt="__before_1" src="https://github.com/user-attachments/assets/2cd1f7f0-b1aa-4da1-b9bc-406740fec3ed">

Before, but after importing a different save file: Caterpie and Vulpix show variant colors that have not been actually unlocked for this new save, Nidoran still has its nickname
<img width="702" alt="__before_2" src="https://github.com/user-attachments/assets/8c0e5333-2c6e-4dd6-a81f-38f0ba76db6f">

After: Nidoran has a nickname, Vulpix and Rattata are set to show shiny tier 1 and 2 respectively, Rattata is a "favorite" Pokemon
<img width="699" alt="_after_1" src="https://github.com/user-attachments/assets/71ab8521-6a22-47a4-aea1-13474fa03876">

After importing a different save file: Nidoran's nickname, Vulpix and Rattata shiny and favorite status are all back to default
<img width="703" alt="_after_2" src="https://github.com/user-attachments/assets/29cd4c0e-c7a7-4094-a727-7a896ac9dcea">

## How to test the changes?
- If you don't want to mess with your local data, do all this in a new incognito window
- It's best to test with save data with a good amount of things unlocked like [this one](https://discord.com/channels/1125469663833370665/1267339517371875361/1275142522603180104)
- Play around with the starter preferences for nickname, favorite, form, gender, shiny and variant (I'm not exactly sure when they are saved right now but if you start a run after changing stuff it will be saved for sure).
- Go to Main Menu > Manage Data > Import Data and import a different save file like [this one](https://discord.com/channels/1125469663833370665/1267339517371875361/1275141551957217384)
- After it's done reloading, check that the preferences you set previously are gone
- If you want you can also double check that this does not happen when importing Session Data

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I add placeholders for them in locales?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
