### PR TITLE
[Refactor][Misc] Languages in one array for no repeat key/label

### DIFF
--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -79,6 +79,67 @@ export interface Setting {
   isHidden?: () => boolean
 }
 
+type LanguageType = {
+  key:string|`${string}-${string}`;
+  label:string;
+  handler?:()=>{};
+  value?:string;
+};
+
+const languages: Array<LanguageType> = [
+  {
+    key:"en",
+    label: "English",
+  },
+  {
+    key:"es",
+    label: "Español",
+  },
+  {
+    key:"it",
+    label: "Italiano",
+  },
+  {
+    key:"fr",
+    label: "Français",
+  },
+  {
+    key:"de",
+    label: "Deutsch",
+  },
+  {
+    key:"pt-BR",
+    label: "Português (BR)",
+  },
+  {
+    key:"zh-CN",
+    label: "简体中文",
+  },
+  {
+    key:"zh-TW",
+    label: "繁體中文",
+  },
+  {
+    key:"ko",
+    label: "한국어",
+  },
+  {
+    key:"ko-KR",
+    label: "한국어",
+  },
+  {
+    key:"ja",
+    label: "日本語",
+  },
+  // {
+  //   key:"ca-ES",
+  //   label: "Català",
+  // },
+];
+
+// default is English
+const currentLanguage = languages.find((locale) => i18next.resolvedLanguage! === locale.key)?.label ?? "English";
+
 /**
  * Setting Keys for existing settings
  * to be used when trying to find or update Settings
@@ -296,9 +357,12 @@ export const Setting: Array<Setting> = [
     key: SettingKeys.Language,
     label: i18next.t("settings:language"),
     options: [
+      /**
+     * Update to current language or return default value.
+     */
       {
-        value: "English",
-        label: "English"
+        value: currentLanguage,
+        label: currentLanguage
       },
       {
         value: "Change",
@@ -764,56 +828,17 @@ export function setSetting(scene: BattleScene, setting: string, value: integer):
           }
         };
         scene.ui.setOverlayMode(Mode.OPTION_SELECT, {
-          options: [
-            {
-              label: "English",
-              handler: () => changeLocaleHandler("en")
-            },
-            {
-              label: "Español",
-              handler: () => changeLocaleHandler("es")
-            },
-            {
-              label: "Italiano",
-              handler: () => changeLocaleHandler("it")
-            },
-            {
-              label: "Français",
-              handler: () => changeLocaleHandler("fr")
-            },
-            {
-              label: "Deutsch",
-              handler: () => changeLocaleHandler("de")
-            },
-            {
-              label: "Português (BR)",
-              handler: () => changeLocaleHandler("pt-BR")
-            },
-            {
-              label: "简体中文",
-              handler: () => changeLocaleHandler("zh-CN")
-            },
-            {
-              label: "繁體中文",
-              handler: () => changeLocaleHandler("zh-TW")
-            },
-            {
-              label: "한국어",
-              handler: () => changeLocaleHandler("ko")
-            },
-            {
-              label: "日本語",
-              handler: () => changeLocaleHandler("ja")
-            },
-            // {
-            //   label: "Català",
-            //   handler: () => changeLocaleHandler("ca-ES")
-            // },
-            {
-              label: i18next.t("settings:back"),
-              handler: () => cancelHandler()
+          options: [...languages.filter((locale,i,a) => {
+            // Remove language active and sames labels
+            if (currentLanguage !== locale.label && a.findIndex((t) => t.label === locale.label) === i) {
+              locale.handler = () => changeLocaleHandler(locale.key);
+              return locale;
             }
-          ],
+          }),
+          {
+            label: i18next.t("settings:back"),
+            handler: () => cancelHandler(),
+          }],
           maxOptions: 7
         });
         return false;

--- a/src/ui/settings/settings-display-ui-handler.ts
+++ b/src/ui/settings/settings-display-ui-handler.ts
@@ -2,11 +2,11 @@ import BattleScene from "../../battle-scene";
 import { Mode } from "../ui";
 "#app/inputs-controller.js";
 import AbstractSettingsUiHandler from "./abstract-settings-ui-handler";
-import { SettingKeys, SettingType } from "#app/system/settings/settings";
+import { SettingType } from "#app/system/settings/settings";
 
 export default class SettingsDisplayUiHandler extends AbstractSettingsUiHandler {
   /**
-   * Creates an instance of SettingsGamepadUiHandler.
+   * Creates an instance of SettingsDisplayUiHandler.
    *
    * @param scene - The BattleScene instance.
    * @param mode - The UI mode, optional.
@@ -14,91 +14,6 @@ export default class SettingsDisplayUiHandler extends AbstractSettingsUiHandler 
   constructor(scene: BattleScene, mode: Mode | null = null) {
     super(scene, SettingType.DISPLAY, mode);
     this.title = "Display";
-
-    /**
-     * Update to current language from default value.
-     * - default value is 'English'
-     */
-    const languageIndex = this.settings.findIndex(s => s.key === SettingKeys.Language);
-    if (languageIndex >= 0) {
-      const currentLocale = localStorage.getItem("prLang");
-      switch (currentLocale) {
-      case "en":
-        this.settings[languageIndex].options[0] = {
-          value: "English",
-          label: "English",
-        };
-        break;
-      case "es":
-        this.settings[languageIndex].options[0] = {
-          value: "Español",
-          label: "Español",
-        };
-        break;
-      case "it":
-        this.settings[languageIndex].options[0] = {
-          value: "Italiano",
-          label: "Italiano",
-        };
-        break;
-      case "fr":
-        this.settings[languageIndex].options[0] = {
-          value: "Français",
-          label: "Français",
-        };
-        break;
-      case "de":
-        this.settings[languageIndex].options[0] = {
-          value: "Deutsch",
-          label: "Deutsch",
-        };
-        break;
-      case "pt-BR":
-        this.settings[languageIndex].options[0] = {
-          value: "Português (BR)",
-          label: "Português (BR)",
-        };
-        break;
-      case "zh-CN":
-        this.settings[languageIndex].options[0] = {
-          value: "简体中文",
-          label: "简体中文",
-        };
-        break;
-      case "zh-TW":
-        this.settings[languageIndex].options[0] = {
-          value: "繁體中文",
-          label: "繁體中文",
-        };
-        break;
-      case "ko":
-      case "ko-KR":
-        this.settings[languageIndex].options[0] = {
-          value: "한국어",
-          label: "한국어",
-        };
-        break;
-      case "ja":
-        this.settings[languageIndex].options[0] = {
-          value: "日本語",
-          label: "日本語",
-        };
-        break;
-      case "ca-ES":
-        this.settings[languageIndex].options[0] = {
-          value: "Català",
-          label: "Català",
-        };
-        break;
-      default:
-        this.settings[languageIndex].options[0] = {
-          value: "English",
-          label: "English",
-        };
-        break;
-      }
-    }
-
     this.localStorageKey = "settings";
   }
 }


### PR DESCRIPTION
## What are the changes the user will see?
The user will no longer see the active language in the list of available languages.

## Why am I making these changes?
I was trying to find another issue and it became difficult because the language keys were located in both `setting-display-ui-handler` and `system/settings`. I saw that I could reduce some lines and improve the implementation of new languages, so I did it.

I also added the functionality to remove the current language from the available options for the user, as it doesn't make much sense to choose the selected one, right? I didn't want to make another PR just for this, so I included it here, but I can remove it since it's not the main goal of this PR.

## What are the changes from a developer perspective?
The language logic will be removed from `setting-display-ui-handler`, making it a bit less complex to add a new language.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] ~Have I considered writing automated tests for the issue?~
- [ ] ~If I have text, did I add placeholders for them in locales?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [ ] ~Have I provided screenshots/videos of the changes?~