### PR TITLE
[Test] Fix Rollout test

### DIFF
--- a/src/test/moves/rollout.test.ts
+++ b/src/test/moves/rollout.test.ts
@@ -1,13 +1,13 @@
 import { allMoves } from "#app/data/move.js";
 import { CommandPhase } from "#app/phases/command-phase.js";
-import GameManager from "#test/utils/gameManager";
-import { getMovePosition } from "#test/utils/gameManagerUtils";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
+import GameManager from "#test/utils/gameManager";
+import { getMovePosition } from "#test/utils/gameManagerUtils";
+import { SPLASH_ONLY } from "#test/utils/testUtils";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { SPLASH_ONLY } from "#test/utils/testUtils";
 
 describe("Moves - Rollout", () => {
   let phaserGame: Phaser.Game;
@@ -29,9 +29,9 @@ describe("Moves - Rollout", () => {
     game.override.disableCrits();
     game.override.battleType("single");
     game.override.starterSpecies(Species.RATTATA);
-    game.override.ability(Abilities.NONE);
+    game.override.ability(Abilities.BALL_FETCH);
     game.override.enemySpecies(Species.BIDOOF);
-    game.override.enemyAbility(Abilities.NONE);
+    game.override.enemyAbility(Abilities.BALL_FETCH);
     game.override.startingLevel(100);
     game.override.enemyLevel(100);
     game.override.enemyMoveset(SPLASH_ONLY);


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
The Rollout test can randomly fail if the player Pokémon gets Hustle as its ability.

## What are the changes from a developer perspective?
The ability override is set to `Abilities.BALL_FETCH` to prevent ability interference.

Note that setting the ability override to `Abilities.NONE` is equivalent to disabling the override and letting the Pokémon use their normal abilities.

## How to test the changes?
`npm run test rollout`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~[ ] If I have text, did I add placeholders for them in locales?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
