### PR TITLE
[Bug] Update damaging traps to affect Ghost-type Pokémon

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -220,7 +220,9 @@ export class TrappedTag extends BattlerTag {
   onAdd(pokemon: Pokemon): void {
     super.onAdd(pokemon);
 
-    pokemon.scene.queueMessage(this.getTrapMessage(pokemon));
+    if (!pokemon.isOfType(Type.GHOST)) {
+      pokemon.scene.queueMessage(this.getTrapMessage(pokemon));
+    }
   }
 
   onRemove(pokemon: Pokemon): void {
@@ -864,7 +866,7 @@ export abstract class DamagingTrapTag extends TrappedTag {
   }
 
   canAdd(pokemon: Pokemon): boolean {
-    return !pokemon.isOfType(Type.GHOST) && !pokemon.findTag(t => t instanceof DamagingTrapTag);
+    return !pokemon.findTag(t => t instanceof DamagingTrapTag);
   }
 
   lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {

--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -1,21 +1,21 @@
-import BattleScene from "#app/battle-scene.js";
-import { TurnCommand, BattleType } from "#app/battle.js";
-import { applyCheckTrappedAbAttrs, CheckTrappedAbAttr } from "#app/data/ability.js";
-import { TrappedTag, EncoreTag } from "#app/data/battler-tags.js";
-import { MoveTargetSet, getMoveTargets } from "#app/data/move.js";
-import { speciesStarters } from "#app/data/pokemon-species.js";
-import { Type } from "#app/data/type.js";
-import { Abilities } from "#app/enums/abilities.js";
-import { BattlerTagType } from "#app/enums/battler-tag-type.js";
-import { Biome } from "#app/enums/biome.js";
-import { Moves } from "#app/enums/moves.js";
-import { PokeballType } from "#app/enums/pokeball.js";
-import { FieldPosition, PlayerPokemon } from "#app/field/pokemon.js";
-import { getPokemonNameWithAffix } from "#app/messages.js";
-import { Command } from "#app/ui/command-ui-handler.js";
-import { Mode } from "#app/ui/ui.js";
+import { BattleType, TurnCommand } from "#app/battle";
+import BattleScene from "#app/battle-scene";
+import { applyCheckTrappedAbAttrs, CheckTrappedAbAttr } from "#app/data/ability";
+import { DamagingTrapTag, EncoreTag, TrappedTag } from "#app/data/battler-tags";
+import { getMoveTargets, MoveTargetSet } from "#app/data/move";
+import { speciesStarters } from "#app/data/pokemon-species";
+import { Type } from "#app/data/type";
+import { Abilities } from "#app/enums/abilities";
+import { BattlerTagType } from "#app/enums/battler-tag-type";
+import { Biome } from "#app/enums/biome";
+import { Moves } from "#app/enums/moves";
+import { PokeballType } from "#app/enums/pokeball";
+import { FieldPosition, PlayerPokemon } from "#app/field/pokemon";
+import { getPokemonNameWithAffix } from "#app/messages";
+import { Command } from "#app/ui/command-ui-handler";
+import { Mode } from "#app/ui/ui";
+import * as Utils from "#app/utils";
 import i18next from "i18next";
-import * as Utils from "#app/utils.js";
 import { FieldPhase } from "./field-phase";
 import { SelectTargetPhase } from "./select-target-phase";
 
@@ -184,7 +184,7 @@ export class CommandPhase extends FieldPhase {
           this.scene.ui.setMode(Mode.COMMAND, this.fieldIndex);
         }, null, true);
       } else {
-        const trapTag = playerPokemon.findTag(t => t instanceof TrappedTag) as TrappedTag;
+        const trapTag = playerPokemon.findTag(t => t instanceof TrappedTag);
         const trapped = new Utils.BooleanHolder(false);
         const batonPass = isSwitch && args[0] as boolean;
         const trappedAbMessages: string[] = [];
@@ -200,7 +200,9 @@ export class CommandPhase extends FieldPhase {
               this.scene.currentBattle.turnCommands[this.fieldIndex - 1]!.skip = true;
           }
         } else if (trapTag) {
-          if (trapTag.sourceMove === Moves.INGRAIN && trapTag.sourceId && this.scene.getPokemonById(trapTag.sourceId)?.isOfType(Type.GHOST)) {
+          const isGhostPokemon = this.scene.getPokemonById(trapTag.sourceId!)?.isOfType(Type.GHOST);
+          const canSwitch = (trapTag.sourceMove === Moves.INGRAIN && isGhostPokemon) || (trapTag instanceof DamagingTrapTag && isGhostPokemon);
+          if (canSwitch) {
             success = true;
             this.scene.currentBattle.turnCommands[this.fieldIndex] = isSwitch
               ? { command: Command.POKEMON, cursor: cursor, args: args }


### PR DESCRIPTION
Text copied/updated from #1929

## What are the changes?
Fixes Damaging Trap moves to apply the damaging effect while still allowing them to switch out.

## Why am I doing these changes?
Fixes: #1915

## What did change?
Binding moves as listed here: https://bulbapedia.bulbagarden.net/wiki/Bound#Binding_moves can be applied to Ghost types in order to get the Damage over Time effects (e.g. 1/8 max HP at the end of the turn).

## How to test the changes?
1. Set your overrides.ts:
```ts
const overrides = {
  MOVESET_OVERRIDE: [Moves.SPLASH, Moves.PROTECT, Moves.MEMENTO],
  OPP_MOVESET_OVERRIDE: Array(4).fill(Moves.INFESTATION),
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```
2. Get into a battle with 2 non-Ghost Pokémon and a Ghost Pokémon.
3. Use Splash and let the opponent hit you with the Binding move (Infestation) on a non-Ghost.
4. Verify with Protect that you are taking the DoT damage.
5. Try to switch out to a different Pokémon (it should not let you).
6. Use Memento to faint your Pokémon, then switch to the Ghost Pokémon.
7. Use Splash and let the opponent hit you with the Binding move (Infestation).
8. Verify with Protect that you are taking the DoT damage. (**new**)
9. Try to switch out to a different Pokémon (it **should** let you). (**new**)

## Checklist
- [x] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
  - Updated version of #1929
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue? (in progress)
- ~[ ] If I have text, did I add placeholders for them in locales?~
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
