### PR TITLE
[Bug] Prevent being able to start with a hidden ability that's not unlocked for some Pokemon

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -3067,7 +3067,10 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
         this.canCycleShiny = isVariantCaught || isVariant2Caught || isVariant3Caught;
         this.canCycleGender = isMaleCaught && isFemaleCaught;
-        this.canCycleAbility = [ abilityAttr & AbilityAttr.ABILITY_1, (abilityAttr & AbilityAttr.ABILITY_2) && species.ability2, abilityAttr & AbilityAttr.ABILITY_HIDDEN ].filter(a => a).length > 1;
+        const hasAbility1 = abilityAttr & AbilityAttr.ABILITY_1;
+        const hasAbility2 = (abilityAttr & AbilityAttr.ABILITY_2) && (species.ability2 !== species.ability1);
+        const hasHiddenAbility = abilityAttr & AbilityAttr.ABILITY_HIDDEN;
+        this.canCycleAbility = [ hasAbility1, hasAbility2, hasHiddenAbility ].filter(a => a).length > 1;
         this.canCycleForm = species.forms.filter(f => f.isStarterSelectable || !pokemonFormChanges[species.speciesId]?.find(fc => fc.formKey))
           .map((_, f) => dexEntry.caughtAttr & this.scene.gameData.getFormAttr(f)).filter(f => f).length > 1;
         this.canCycleNature = this.scene.gameData.getNaturesForAttr(dexEntry.natureAttr).length > 1;


### PR DESCRIPTION
## What are the changes the user will see?
For some Pokemon it was possible to cycle to the Hidden Ability even if it wasn't properly unlocked. This fixes that

## Why am I making these changes?
In #3138 the way HA is handled for Pokemon with a single ability was changed and for some time before it was fixed it was possible to catch Pokemon with their ability 2, thus unlocking it in the dex attributes
For these specific Pokemon it is now possible to switch to the HA at starter select even if the HA wasn't actually unlocked properly.
Starting the run like this and evolving the Pokemon would then result in the HA getting actually unlocked
This PR prevents starting with an invalid HA in the first place

## What are the changes from a developer perspective?
The Pokemon with this issue have ability 2 marked as unlocked even though it's the same as ability 1.
The code handling cycling through abilities took this into account and would skip over ability 2 in this case. However the code checking whether we should be able to cycle through abilities did not. So if a Pokemon had both ability 1 and 2 unlocked it would be possible to cycle through, the cycling code would then skip over ability 2 since it was the same as ability 1 and fall back on the hidden ability even if it wasn't actually unlocked.
This adds the proper check that ability 1 and ability 2 are different to prevent cycling through abilities in this specific case
This also updates the cycling code to not skip over ability 2 in case ability 1 was not unlocked

### Screenshots/Videos
Before: it was possible to switch to the HA for this Weedle even though the HA wasn't actually unlocked (you can see it doesn't have the HA icon)
<img width="709" alt="weedle_before" src="https://github.com/user-attachments/assets/d1f7c022-5558-48e7-8dbd-f91a077c14cc">

[Video of me starting a run with a non unlocked HA](https://discord.com/channels/1125469663833370665/1267339517371875361/1274766844397490309)

After: the cycle ability prompt is no longer here
<img width="709" alt="weedle_after" src="https://github.com/user-attachments/assets/7f824419-1ca2-44e5-a2d2-bb83b030dc3b">

## How to test the changes?
- [Take this save file](https://discord.com/channels/1125469663833370665/1273628495339323423/1274683966024318976)
- Start a new run
- You shouldn't be able to cycle to the hidden ability for Pokemon without the ability icon like Weedle, Zangoose and other Pokemon the player cited in their message
- You should be able to cycle through abilities for Pokemon with 2 different non HA abilities like Horsea
- You should be able to cycle through abilities for Pokemon with at least one ability + HA like Mareep and Eevee
- You should be able to cycle through abilities for Landorus, which falls in the specific case where ability 1 == ability 2, ability 1 is not unlocked, but ability 2 and Hidden Ability are

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue? starter ui tests are planned for a future (much bigger) PR
- [ ] If I have text, did I add placeholders for them in locales? N/A
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
