### PR TITLE
[UI] Increase Target Select UI Opacitiy

### DIFF
--- a/src/ui/target-select-ui-handler.ts
+++ b/src/ui/target-select-ui-handler.ts
@@ -118,7 +118,7 @@ export default class TargetSelectUiHandler extends UiHandler {
 
     this.targetFlashTween = this.scene.tweens.add({
       targets: this.targetsHighlighted,
-      key: { start: 0.55, to: 1 },
+      key: { start: 1, to: 0.25 },
       loop: -1,
       loopDelay: 150,
       duration: Utils.fixedInt(450),


### PR DESCRIPTION
## What are the changes the user will see?
The Target Select UI will have a wider range of opacity and so, resolve current complaints about it being too subtle. 

https://github.com/user-attachments/assets/17d6e81b-b4a9-49dd-8078-3905e8536b5e

## Why am I making these changes?
Some people did not like the current change + I wanted to put it to a vote + have more time for this change to cook in beta.

## What are the changes from a developer perspective?
The opacity cycles through 1 to 0.25. 

## How to test the changes?
Double Battle

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
