### PR TITLE
[Bug] Fix duplicate `FaintPhase` if Mimikyu faints to Disguise damage

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -4229,7 +4229,7 @@ export class FormBlockDamageAbAttr extends ReceivedMoveDamageMultiplierAbAttr {
         (args[0] as Utils.NumberHolder).value = this.multiplier;
         pokemon.removeTag(this.tagType);
         if (this.recoilDamageFunc) {
-          pokemon.damageAndUpdate(this.recoilDamageFunc(pokemon), HitResult.OTHER);
+          pokemon.damageAndUpdate(this.recoilDamageFunc(pokemon), HitResult.OTHER, false, false, true, true);
         }
       }
       return true;

--- a/src/test/abilities/disguise.test.ts
+++ b/src/test/abilities/disguise.test.ts
@@ -207,4 +207,18 @@ describe("Abilities - Disguise", () => {
 
     expect(mimikyu1.formIndex).toBe(disguisedForm);
   }, TIMEOUT);
+
+  it("doesn't faint twice when fainting due to Disguise break damage, nor prevent faint from Disguise break damage if using Endure", async () => {
+    game.override.enemyMoveset(Array(4).fill(Moves.ENDURE));
+    await game.startBattle();
+
+    const mimikyu = game.scene.getEnemyPokemon()!;
+    mimikyu.hp = 1;
+
+    game.doAttack(getMovePosition(game.scene, 0, Moves.SHADOW_SNEAK));
+    await game.toNextWave();
+
+    expect(game.scene.getCurrentPhase()?.constructor.name).toBe("CommandPhase");
+    expect(game.scene.currentBattle.waveIndex).toBe(2);
+  }, TIMEOUT);
 });


### PR DESCRIPTION
## What are the changes the user will see?
If Mimikyu faints due to taking damage from its Disguise breaking, it will no longer faint twice (which would potentially clear 2 waves at once).

## Why am I making these changes?
Fixes #3676 

## What are the changes from a developer perspective?
The call to `damageAndUpdate()` in `FormBlockDamageAbAttr` now passes `true` to the `preventEndure` and `ignoreFaintPhase` parameters.

### Screenshots/Videos

https://github.com/user-attachments/assets/779684fa-2c75-448f-b7ae-1af75477e2da

## How to test the changes?
Use a move like Leech Seed or some other damage-over-time status move (not an attacking move) to get an enemy Mimiyku to 1 HP, then hit it with an attacking move to break the Disguise and cause it to faint from the Disguise break damage. Alternatively just console its HP to 1.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~[ ] If I have text, did I add placeholders for them in locales?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - [x] Have I provided screenshots/videos of the changes?
