### PR TITLE
[Bug] Fixes Unseen Fist ignoring abilities

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -595,6 +595,7 @@ export default class Move implements Localizable {
           return true;
         }
       }
+      break;
     case MoveFlags.IGNORE_PROTECT:
       if (user.hasAbilityWithAttr(IgnoreProtectOnContactAbAttr) &&
           this.checkFlag(MoveFlags.MAKES_CONTACT, user, target)) {

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -601,6 +601,7 @@ export default class Move implements Localizable {
           this.checkFlag(MoveFlags.MAKES_CONTACT, user, target)) {
         return true;
       }
+      break;
     }
 
     return !!(this.flags & flag);

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -601,7 +601,6 @@ export default class Move implements Localizable {
           this.checkFlag(MoveFlags.MAKES_CONTACT, user, target)) {
         return true;
       }
-      break;
     }
 
     return !!(this.flags & flag);

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -29,7 +29,13 @@ import { type ModifierOverride } from "./modifier/modifier-type";
  * }
  * ```
  */
-const overrides = {} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
+const overrides = {
+  ABILITY_OVERRIDE: Abilities.STURDY,
+  OPP_ABILITY_OVERRIDE: Abilities.UNSEEN_FIST,
+  MOVESET_OVERRIDE: [Moves.SPLASH],
+  OPP_MOVESET_OVERRIDE: [Moves.WICKED_BLOW, Moves.WICKED_BLOW, Moves.WICKED_BLOW, Moves.WICKED_BLOW],
+  OPP_LEVEL_OVERRIDE: 20
+} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
 
 /**
  * If you need to add Overrides values for local testing do that inside {@linkcode overrides}

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -29,13 +29,7 @@ import { type ModifierOverride } from "./modifier/modifier-type";
  * }
  * ```
  */
-const overrides = {
-  ABILITY_OVERRIDE: Abilities.STURDY,
-  OPP_ABILITY_OVERRIDE: Abilities.UNSEEN_FIST,
-  MOVESET_OVERRIDE: [Moves.SPLASH],
-  OPP_MOVESET_OVERRIDE: [Moves.WICKED_BLOW, Moves.WICKED_BLOW, Moves.WICKED_BLOW, Moves.WICKED_BLOW],
-  OPP_LEVEL_OVERRIDE: 20
-} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
+const overrides = {} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
 
 /**
  * If you need to add Overrides values for local testing do that inside {@linkcode overrides}


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
Unseen Fist + direct contact moves allow the user to ignore abilities (e.g. Sturdy)

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
It's a bug
Discord report: https://discord.com/channels/1125469663833370665/1274675083872436235

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Adds a break in the switch case, so that it doesn't fall through to `IGNORE_PROTECT` when checking if a move should ignore abilities.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

https://github.com/user-attachments/assets/3307af07-dd60-4cf6-accf-c57dd0a7c26b

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Give pokemon Unseen Fist + direct contact move. Give opponent Sturdy, see that it no longer KOs through Sturdy

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [n/a] If I have text, did I add placeholders for them in locales?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
