### PR TITLE
[Bug] Run history export data patch

### DIFF
--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1366,7 +1366,8 @@ export class GameData {
       } else {
         const data = localStorage.getItem(dataKey);
         if (data) {
-          handleData(decrypt(data, bypassLogin));
+          handleData(decrypt(data, (dataType !== GameDataType.RUN_HISTORY) ? bypassLogin : true));
+          // This conditional is necessary because at the moment, run history is stored locally only so it has to be decoded from Base64 as if it was local
         }
         resolve(!!data);
       }


### PR DESCRIPTION
## What are the changes the user will see?
The user will be able to export data in live versions of the game.

## Why am I making these changes?
When I was testing, I mostly stuck to a local environment and I did not realize that Run History's exportation would be treated differently in live b/c of the state of bypassLogin. I apologize for the oversight. 

## What are the changes from a developer perspective?
A ternary is used to determine if the data needs to be decrypted or decoded from Base64 based on whether the datatype is GameDataType.RUN_HISTORY

## How to test the changes?
Use a non-guest account or set bypassLogin to false. You should still be able to export your run history without issue. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
