### PR TITLE
[Bug] Run History Day 1 patch

### DIFF
--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1411,6 +1411,7 @@ export class GameData {
               case GameDataType.RUN_HISTORY:
                 const data = JSON.parse(dataStr);
                 const keys = Object.keys(data);
+                dataName = i18next.t("menuUiHandler:RUN_HISTORY").toLowerCase();
                 keys.forEach((key) => {
                   const entryKeys = Object.keys(data[key]);
                   valid = ["isFavorite", "isVictory", "entry"].every(v => entryKeys.includes(v)) && entryKeys.length === 3;

--- a/src/ui/run-info-ui-handler.ts
+++ b/src/ui/run-info-ui-handler.ts
@@ -409,7 +409,9 @@ export default class RunInfoUiHandler extends UiHandler {
 
     // Duration + Money
     const runInfoTextContainer = this.scene.add.container(0, 0);
-    const runInfoText = addBBCodeTextObject(this.scene, 7, 0, "", TextStyle.WINDOW, {fontSize : "50px", lineSpacing:3});
+    // Japanese is set to a greater line spacing of 35px in addBBCodeTextObject() if lineSpacing < 12.
+    const lineSpacing = (i18next.resolvedLanguage === "ja") ? 12 : 3;
+    const runInfoText = addBBCodeTextObject(this.scene, 7, 0, "", TextStyle.WINDOW, {fontSize: "50px", lineSpacing: lineSpacing});
     const runTime = Utils.getPlayTimeString(this.runInfo.playTime);
     runInfoText.appendText(`${i18next.t("runHistory:runLength")}: ${runTime}`, false);
     const runMoney = Utils.formatMoney(this.scene.moneyFormat, this.runInfo.money);
@@ -513,7 +515,9 @@ export default class RunInfoUiHandler extends UiHandler {
       }
       const pPassiveInfo = pokemon.passive ? passiveLabel+": "+pokemon.getPassiveAbility().name : "";
       const pAbilityInfo = abilityLabel + ": " + pokemon.getAbility().name;
-      const pokeInfoText = addBBCodeTextObject(this.scene, 0, 0, pName, TextStyle.SUMMARY, {fontSize: textContainerFontSize, lineSpacing:3});
+      // Japanese is set to a greater line spacing of 35px in addBBCodeTextObject() if lineSpacing < 12.
+      const lineSpacing = (i18next.resolvedLanguage === "ja") ? 12 : 3;
+      const pokeInfoText = addBBCodeTextObject(this.scene, 0, 0, pName, TextStyle.SUMMARY, {fontSize: textContainerFontSize, lineSpacing: lineSpacing});
       pokeInfoText.appendText(`${i18next.t("saveSlotSelectUiHandler:lv")}${Utils.formatFancyLargeNumber(pokemon.level, 1)} - ${pNature}`);
       pokeInfoText.appendText(pAbilityInfo);
       pokeInfoText.appendText(pPassiveInfo);
@@ -537,12 +541,12 @@ export default class RunInfoUiHandler extends UiHandler {
       const speedLabel = (currentLanguage==="es"||currentLanguage==="pt_BR") ? i18next.t("runHistory:SPDshortened") : i18next.t("pokemonInfo:Stat.SPDshortened");
       const speed = speedLabel+": "+pStats[5];
       // Column 1: HP Atk Def
-      const pokeStatText1 = addBBCodeTextObject(this.scene, -5, 0, hp, TextStyle.SUMMARY, {fontSize: textContainerFontSize, lineSpacing:3});
+      const pokeStatText1 = addBBCodeTextObject(this.scene, -5, 0, hp, TextStyle.SUMMARY, {fontSize: textContainerFontSize, lineSpacing: lineSpacing});
       pokeStatText1.appendText(atk);
       pokeStatText1.appendText(def);
       pokeStatTextContainer.add(pokeStatText1);
       // Column 2: SpAtk SpDef Speed
-      const pokeStatText2 = addBBCodeTextObject(this.scene, 25, 0, spatk, TextStyle.SUMMARY, {fontSize: textContainerFontSize, lineSpacing:3});
+      const pokeStatText2 = addBBCodeTextObject(this.scene, 25, 0, spatk, TextStyle.SUMMARY, {fontSize: textContainerFontSize, lineSpacing: lineSpacing});
       pokeStatText2.appendText(spdef);
       pokeStatText2.appendText(speed);
       pokeStatTextContainer.add(pokeStatText2);

--- a/src/ui/run-info-ui-handler.ts
+++ b/src/ui/run-info-ui-handler.ts
@@ -412,7 +412,7 @@ export default class RunInfoUiHandler extends UiHandler {
     const runInfoText = addBBCodeTextObject(this.scene, 7, 0, "", TextStyle.WINDOW, {fontSize : "50px", lineSpacing:3});
     const runTime = Utils.getPlayTimeString(this.runInfo.playTime);
     runInfoText.appendText(`${i18next.t("runHistory:runLength")}: ${runTime}`, false);
-    const runMoney = Utils.formatMoney(this.runInfo.money, 1000);
+    const runMoney = Utils.formatMoney(this.scene.moneyFormat, this.runInfo.money);
     runInfoText.appendText(`[color=${getTextColor(TextStyle.MONEY)}]${i18next.t("battleScene:moneyOwned", {formattedMoney : runMoney})}[/color]`);
     runInfoText.setPosition(7, 70);
     runInfoTextContainer.add(runInfoText);


### PR DESCRIPTION
## What are the changes the user will see?
Money displayed correctly. 
Import message cleaned up a little. 
Japanese text corrected.
Responsive Header Button

## Why am I making these changes?
Because I'm silly. 

## What are the changes from a developer perspective?
- Money was not being displayed correctly because I misread how Utils.formatMoney() worked when implementing the changes from #3646 - The UI would then show the player 1000 pokedollars regardless of result.
- I noticed the message that warns you about your data being overwritten before import was not localized. I feel like this should be left to a separate PR by the localization team, but because it used the data name - "run_history", it looked awkward so I tried sprucing it up a bit.
- Japanese text was assigned a higher lineSpacing value during its creation if its lineSpacing was less than 12. This patch corrects for it so that Japanese text does not escape from box bounds. 

![image](https://github.com/user-attachments/assets/01abc562-f5f1-455e-b9ca-6b592c5608f3)

- Header button is now responsive based on whether user is viewing held items or pokemon info.

https://github.com/user-attachments/assets/949c86f5-42ef-4134-9141-addd68955252


https://github.com/user-attachments/assets/c2bb277a-4b81-434e-80aa-feb8af6044e9

## Known Bugs and Issues
- Menu now too big #3424 
- Fusion names in non-Latin languages are too long #3262 

## How to test the changes?
Use Run History. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?

