### PR TITLE
[Bug] Multi-target damage reduction is now properly calculated

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2075,8 +2075,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
           stabMultiplier.value = Math.min(stabMultiplier.value + 0.5, 2.25);
         }
 
-        const targetCount = getMoveTargets(source, move.id).targets.length;
-        const targetMultiplier = targetCount > 1 ? 0.75 : 1; // 25% damage debuff on multi-target hits (even if it's immune)
+        // 25% damage debuff on moves hitting more than one non-fainted target (regardless of immunities)
+        const { targets, multiple } = getMoveTargets(source, move.id);
+        const targetMultiplier = (multiple && targets.length > 1) ? 0.75 : 1;
 
         applyMoveAttrs(VariableAtkAttr, source, this, move, sourceAtk);
         applyMoveAttrs(VariableDefAttr, source, this, move, targetDef);

--- a/src/test/moves/multi_target.test.ts
+++ b/src/test/moves/multi_target.test.ts
@@ -1,7 +1,7 @@
-import { getMoveTargets } from "#app/data/move";
+import { BattlerIndex } from "#app/battle";
 import { Abilities } from "#app/enums/abilities";
 import { Species } from "#app/enums/species";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
+import * as Utils from "#app/utils";
 import { Moves } from "#enums/moves";
 import GameManager from "#test/utils/gameManager";
 import { SPLASH_ONLY } from "#test/utils/testUtils";
@@ -10,7 +10,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 const TIMEOUT = 20 * 1000;
 
-describe("Moves - Multi target", () => {
+describe("Multi-target damage reduction", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
 
@@ -21,160 +21,111 @@ describe("Moves - Multi target", () => {
   });
 
   afterEach(() => {
-    afterTrial(game);
+    game.phaseInterceptor.restoreOg();
   });
 
   beforeEach(() => {
-    game = beforeTrial(phaserGame);
+    game = new GameManager(phaserGame);
+    game.override
+      .disableCrits()
+      .battleType("double")
+      .enemyLevel(100)
+      .startingLevel(100)
+      .enemySpecies(Species.POLIWAG)
+      .enemyMoveset(SPLASH_ONLY)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .moveset([Moves.TACKLE, Moves.DAZZLING_GLEAM, Moves.EARTHQUAKE, Moves.SPLASH])
+      .ability(Abilities.BALL_FETCH);
   });
 
-  it("2v2 - target all near others - check modifier", () => checkTargetMultiplier(game, Moves.EARTHQUAKE, false, false, true), TIMEOUT);
+  it("should reduce d.gleam damage when multiple enemies but not tackle", async () => {
+    await game.startBattle([Species.MAGIKARP, Species.FEEBAS]);
 
-  it("2v2 - target all near others - damage decrase", () => checkDamageDecrease(game, Moves.EARTHQUAKE, false, false, true), TIMEOUT);
+    const [enemy1, enemy2] = game.scene.getEnemyField();
 
-  it("2v1 - target all near others - check modifier", () => checkTargetMultiplier(game, Moves.EARTHQUAKE, false, true, true), TIMEOUT);
+    game.move.select(Moves.DAZZLING_GLEAM);
+    game.move.select(Moves.TACKLE, 1, BattlerIndex.ENEMY);
+    await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
-  it("2v1 - target all near others - damage decrase", () => checkDamageDecrease(game, Moves.EARTHQUAKE, false, true, true), TIMEOUT);
+    const gleam1 = enemy1.getMaxHp() - enemy1.hp;
+    enemy1.hp = enemy1.getMaxHp();
 
-  it("1v2 - target all near others - check modifier", () => checkTargetMultiplier(game, Moves.EARTHQUAKE, true, false, true), TIMEOUT);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
-  it("1v2 - target all near others - damage decrase", () => checkDamageDecrease(game, Moves.EARTHQUAKE, true, false, true), TIMEOUT);
+    const tackle1 = enemy1.getMaxHp() - enemy1.hp;
+    enemy1.hp = enemy1.getMaxHp();
 
-  it("1v1 - target all near others - check modifier", () => checkTargetMultiplier(game, Moves.EARTHQUAKE, true, true, false), TIMEOUT);
+    await game.killPokemon(enemy2);
+    await game.toNextTurn();
 
-  it("2v2 (immune) - target all near others - check modifier", () => checkTargetMultiplier(game, Moves.EARTHQUAKE, false, false, true, Abilities.LEVITATE), TIMEOUT);
+    game.move.select(Moves.DAZZLING_GLEAM);
+    game.move.select(Moves.TACKLE, 1, BattlerIndex.ENEMY);
+    await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY]);
 
-  it("2v2 (immune) - target all near others - damage decrase", () => checkDamageDecrease(game, Moves.EARTHQUAKE, false, false, true, Abilities.LEVITATE), TIMEOUT);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
-  it("2v2 - target all near enemies - check modifier", () => checkTargetMultiplier(game, Moves.HYPER_VOICE, false, false, true), TIMEOUT);
+    const gleam2 = enemy1.getMaxHp() - enemy1.hp;
+    enemy1.hp = enemy1.getMaxHp();
 
-  it("2v2 - target all near enemies - damage decrase", () => checkDamageDecrease(game, Moves.HYPER_VOICE, false, false, true), TIMEOUT);
+    await game.phaseInterceptor.to("MoveEndPhase");
+    const tackle2 = enemy1.getMaxHp() - enemy1.hp;
 
-  it("2v1 - target all near enemies - check modifier", () => checkTargetMultiplier(game, Moves.HYPER_VOICE, false, true, false), TIMEOUT);
+    // Single target moves don't get reduced
+    expect(tackle1).toBe(tackle2);
+    // Moves that target all enemies get reduced if there's more than one enemy
+    expect(gleam1).toBeLessThanOrEqual(Utils.toDmgValue(gleam2 * 0.75) + 1);
+    expect(gleam1).toBeGreaterThanOrEqual(Utils.toDmgValue(gleam2 * 0.75) - 1);
+  }, TIMEOUT);
 
-  it("2v1 - target all near enemies - no damage decrase", () => checkDamageDecrease(game, Moves.HYPER_VOICE, false, true, false), TIMEOUT);
+  it("should reduce earthquake when more than one pokemon other than user is not fainted", async () => {
+    await game.startBattle([Species.MAGIKARP, Species.FEEBAS]);
 
-  it("1v2 - target all near enemies - check modifier", () => checkTargetMultiplier(game, Moves.HYPER_VOICE, true, false, true), TIMEOUT);
+    const player2 = game.scene.getParty()[1];
+    const [enemy1, enemy2] = game.scene.getEnemyField();
 
-  it("1v2 - target all near enemies - damage decrase", () => checkDamageDecrease(game, Moves.HYPER_VOICE, true, false, true), TIMEOUT);
-
-  it("1v1 - target all near enemies - check modifier", () => checkTargetMultiplier(game, Moves.HYPER_VOICE, true, true, false), TIMEOUT);
-
-  it("2v2 (immune) - target all near enemies - check modifier", () => checkTargetMultiplier(game, Moves.HYPER_VOICE, false, false, true, Abilities.SOUNDPROOF), TIMEOUT);
-
-  it("2v2 (immune) - target all near enemies - damage decrase", () => checkDamageDecrease(game, Moves.HYPER_VOICE, false, false, true, Abilities.SOUNDPROOF), TIMEOUT);
-
-});
-
-async function checkTargetMultiplier(game: GameManager, attackMove: Moves, killAlly: boolean, killSecondEnemy: boolean, shouldMultiplied: boolean, oppAbility?: Abilities) {
-  // play an attack and check target count
-  game.override.enemyAbility(oppAbility ? oppAbility : Abilities.BALL_FETCH);
-  await game.startBattle();
-
-  const playerPokemonRepr = game.scene.getPlayerField();
-
-  killAllyAndEnemy(game, killAlly, killSecondEnemy);
-
-  const targetCount = getMoveTargets(playerPokemonRepr[0], attackMove).targets.length;
-  const targetMultiplier = targetCount > 1 ? 0.75 : 1;
-
-  if (shouldMultiplied) {
-    expect(targetMultiplier).toBe(0.75);
-  } else {
-    expect(targetMultiplier).toBe(1);
-  }
-}
-
-async function checkDamageDecrease(game: GameManager, attackMove: Moves, killAlly: boolean, killSecondEnemy: boolean, shouldDecreased: boolean, ability?: Abilities) {
-  // Tested combination on first turn, 1v1 on second turn
-  await game.classicMode.runToSummon([Species.EEVEE, Species.EEVEE]);
-
-  if (ability !== undefined) {
-    game.scene.getPlayerField()[1].abilityIndex = ability;
-    game.scene.getEnemyField()[1].abilityIndex = ability;
-  }
-
-  game.move.select(Moves.SPLASH);
-  game.move.select(Moves.SPLASH, 1);
-
-
-  await game.phaseInterceptor.to(TurnEndPhase);
-
-  killAllyAndEnemy(game, killAlly, killSecondEnemy);
-  await game.toNextTurn();
-
-  const initialHp = game.scene.getEnemyField()[0].hp;
-  game.move.select(attackMove);
-  if (!killAlly) {
+    game.move.select(Moves.EARTHQUAKE);
     game.move.select(Moves.SPLASH, 1);
-  }
+    await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
 
-  await game.phaseInterceptor.to(TurnEndPhase);
-  const afterHp = game.scene.getEnemyField()[0].hp;
+    await game.phaseInterceptor.to("MoveEndPhase");
 
-  killAllyAndEnemy(game, true, true);
-  await game.toNextTurn();
+    const damagePlayer2Turn1 = player2.getMaxHp() - player2.hp;
+    const damageEnemy1Turn1 = enemy1.getMaxHp() - enemy1.hp;
 
-  game.scene.getEnemyField()[0].hp = initialHp;
+    player2.hp = player2.getMaxHp();
+    enemy1.hp = enemy1.getMaxHp();
 
-  const initialHp1v1 = game.scene.getEnemyField()[0].hp;
-  game.move.select(attackMove);
+    await game.killPokemon(enemy2);
+    await game.toNextTurn();
 
-  await game.phaseInterceptor.to(TurnEndPhase);
-  const afterHp1v1 = game.scene.getEnemyField()[0].hp;
+    game.move.select(Moves.EARTHQUAKE);
+    game.move.select(Moves.SPLASH, 1);
+    await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY]);
 
-  if (shouldDecreased) {
-    expect(initialHp - afterHp).toBeLessThan(0.75 * (initialHp1v1 - afterHp1v1) + 2);
-    expect(initialHp - afterHp).toBeGreaterThan(0.75 * (initialHp1v1 - afterHp1v1) - 2);
-  } else {
-    expect(initialHp - afterHp).toBeLessThan(initialHp1v1 - afterHp1v1 + 2);
-    expect(initialHp - afterHp).toBeGreaterThan(initialHp1v1 - afterHp1v1 - 2);
-  }
+    await game.phaseInterceptor.to("MoveEndPhase");
 
-}
+    const damagePlayer2Turn2 = player2.getMaxHp() - player2.hp;
+    const damageEnemy1Turn2 = enemy1.getMaxHp() - enemy1.hp;
 
-// To simulate the situation where all of the enemies or the player's Pokemons dies except for one.
-function killAllyAndEnemy(game: GameManager, killAlly: boolean, killSecondEnemy: boolean) {
-  if (killAlly) {
-    leaveOnePlayerPokemon(game);
-    expect(game.scene.getPlayerField().filter(p => p.isActive()).length).toBe(1);
-  }
-  if (killSecondEnemy) {
-    leaveOneEnemyPokemon(game);
-    expect(game.scene.getEnemyField().filter(p => p.isActive()).length).toBe(1);
-  }
-}
+    enemy1.hp = enemy1.getMaxHp();
 
-function leaveOnePlayerPokemon(game: GameManager) {
-  const playerPokemons = game.scene.getParty();
-  for (let i = 1; i < playerPokemons.length; i++) {
-    playerPokemons[i].hp = 0;
-  }
-  expect(playerPokemons.filter(pokemon => pokemon.hp > 0).length).toBe(1);
-}
+    // Turn 1: 3 targets, turn 2: 2 targets
+    // Both should have damage reduction
+    expect(damageEnemy1Turn1).toBe(damageEnemy1Turn2);
+    expect(damagePlayer2Turn1).toBe(damagePlayer2Turn2);
 
-function leaveOneEnemyPokemon(game: GameManager) {
-  const enemyPokemons = game.scene.getEnemyParty();
-  for (let i = 1; i < enemyPokemons.length; i++) {
-    enemyPokemons[i].hp = 0;
-  }
-}
+    await game.killPokemon(player2);
+    await game.toNextTurn();
 
-function beforeTrial(phaserGame: Phaser.Game, single: boolean = false) {
-  const game = new GameManager(phaserGame);
-  game.override
-    .battleType("double")
-    .moveset([Moves.EARTHQUAKE, Moves.HYPER_VOICE, Moves.SURF, Moves.SPLASH])
-    .ability(Abilities.BALL_FETCH)
-    .passiveAbility(Abilities.UNNERVE)
-    .enemyMoveset(SPLASH_ONLY)
-    .disableCrits()
-    .startingLevel(50)
-    .enemyLevel(40)
-    .enemySpecies(Species.EEVEE);
-  return game;
-}
+    game.move.select(Moves.EARTHQUAKE);
+    await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
 
-function afterTrial(game: GameManager) {
-  game.phaseInterceptor.restoreOg();
-}
+    await game.phaseInterceptor.to("MoveEndPhase");
+
+    const damageEnemy1Turn3 = enemy1.getMaxHp() - enemy1.hp;
+    // Turn 3: 1 target, should be no damage reduction
+    expect(damageEnemy1Turn1).toBeLessThanOrEqual(Utils.toDmgValue(damageEnemy1Turn3 * 0.75) + 1);
+    expect(damageEnemy1Turn1).toBeGreaterThanOrEqual(Utils.toDmgValue(damageEnemy1Turn3 * 0.75) - 1);
+  }, TIMEOUT);
+});


### PR DESCRIPTION
## What are the changes the user will see?
Single-target moves won't incorrectly deal reduced damage in double battles.

## Why am I making these changes?
Damage was being calculated incorrectly in double battles.

## What are the changes from a developer perspective?
`Pokemon:apply()` now takes an additional parameter `targets` which is the number of targets being hit by the move, which is used to calculate the multi-target damage reduction.

## How to test the changes?
`npm run test multi_target`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~[ ] If I have text, did I add placeholders for them in locales?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
