### PR TITLE
[Bug] Fix lock rarities behavior

### DIFF
--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -334,7 +334,7 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
             success = false;
             break;
           case 1:
-            if (this.transferButtonContainer.visible) {
+            if (this.lockRarityButtonContainer.visible) {
               success = this.setCursor(3);
             } else {
               success = this.rerollButtonContainer.visible && this.setCursor(0);


### PR DESCRIPTION
## What are the changes the user will see?

no longer this:
![image](https://github.com/user-attachments/assets/6ed04220-d54e-4b9e-9d57-64a6f23c32b0)


## Why am I making these changes?

Cause I broke it 

## What are the changes from a developer perspective?

I've fixed the condition that checks the cursor movement. I put the wrong check into the lock rarities cursor ID

### Screenshots/Videos

https://github.com/user-attachments/assets/2288f7f8-84f8-43d3-9c26-ba0605bf1262

https://github.com/user-attachments/assets/2400716a-ce49-409f-8494-3f453642092b


## How to test the changes?

Win a wave and move the cursor at the bottom.

to test with the extra button

`src/ui/modifier-select-ui-handler.ts#L145`
```ts
    //     const canLockRarities = !!this.scene.findModifier(m => m instanceof LockModifierTiersModifier);
    const canLockRarities = true;
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
