### PR TITLE
[Bug] Achievements/Vouchers doesn't update if Cursor doesn't move

### DIFF
--- a/src/ui/achvs-ui-handler.ts
+++ b/src/ui/achvs-ui-handler.ts
@@ -211,12 +211,11 @@ export default class AchvsUiHandler extends MessageUiHandler {
       if (this.currentPage === Page.ACHIEVEMENTS) {
         this.currentPage = Page.VOUCHERS;
         this.updateVoucherIcons();
-        this.setCursor(0);
       } else if (this.currentPage === Page.VOUCHERS) {
         this.currentPage = Page.ACHIEVEMENTS;
         this.updateAchvIcons();
-        this.setCursor(0);
       }
+      this.setCursor(0, true);
       this.mainContainer.update();
     }
     if (button === Button.CANCEL) {


### PR DESCRIPTION
## What are the changes the user will see?
The user will see the description of the first achievement or voucher change even if they only pressed the action button and did not move their cursor. 

## Why am I making these changes?
I fixed this issue when making this PR but when chasing down a different bug, I overlooked what I did to fix this bug and this bug went into the main release. 

## What are the changes from a developer perspective?
this.setScrollCursor(0) gets called twice. this.setCursor is called as this.setCursor(0, pageChange = true) so that the achievement/voucher updates correctly. 

### Screenshots/Videos

https://github.com/user-attachments/assets/7a73212d-f168-436f-899a-7314d91a1520

## How to test the changes?
Go to Achievements and press the Action button. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
