### PR TITLE
[Test] Fix egg tests (memory use: ~2.4G -> ~550M)

### DIFF
--- a/src/test/eggs/egg.test.ts
+++ b/src/test/eggs/egg.test.ts
@@ -8,7 +8,6 @@ import { Species } from "#enums/species";
 import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import BattleScene from "../../battle-scene";
 
 describe("Egg Generation Tests", () => {
   let phaserGame: Phaser.Game;
@@ -18,6 +17,7 @@ describe("Egg Generation Tests", () => {
     phaserGame = new Phaser.Game({
       type: Phaser.HEADLESS,
     });
+    game = new GameManager(phaserGame);
   });
 
   afterEach(() => {
@@ -25,13 +25,12 @@ describe("Egg Generation Tests", () => {
     vi.restoreAllMocks();
   });
 
-  beforeEach(async() => {
-    game = new GameManager(phaserGame);
+  beforeEach(async () => {
     await game.importData("src/test/utils/saves/everything.prsv");
   });
 
   it("should return Arceus for the 10th of June", () => {
-    const scene = new BattleScene();
+    const scene = game.scene;
     const timestamp = new Date(2024, 5, 10, 15, 0, 0, 0).getTime();
     const expectedSpecies = Species.ARCEUS;
 
@@ -40,7 +39,7 @@ describe("Egg Generation Tests", () => {
     expect(result).toBe(expectedSpecies);
   });
   it("should return Arceus for the 10th of July", () => {
-    const scene = new BattleScene();
+    const scene = game.scene;
     const timestamp = new Date(2024, 6, 10, 15, 0, 0, 0).getTime();
     const expectedSpecies = Species.ARCEUS;
 
@@ -48,12 +47,12 @@ describe("Egg Generation Tests", () => {
 
     expect(result).toBe(expectedSpecies);
   });
-  it("should hatch an Arceus. Set from legendary gacha", async() => {
+  it("should hatch an Arceus. Set from legendary gacha", async () => {
     const scene = game.scene;
     const timestamp = new Date(2024, 6, 10, 15, 0, 0, 0).getTime();
     const expectedSpecies = Species.ARCEUS;
 
-    const result = new Egg({scene, timestamp, sourceType: EggSourceType.GACHA_LEGENDARY, tier: EggTier.MASTER}).generatePlayerPokemon(scene).species.speciesId;
+    const result = new Egg({ scene, timestamp, sourceType: EggSourceType.GACHA_LEGENDARY, tier: EggTier.MASTER }).generatePlayerPokemon(scene).species.speciesId;
 
     expect(result).toBe(expectedSpecies);
   });
@@ -61,7 +60,7 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const expectedSpecies = Species.ARCEUS;
 
-    const result = new Egg({scene, species: expectedSpecies}).generatePlayerPokemon(scene).species.speciesId;
+    const result = new Egg({ scene, species: expectedSpecies }).generatePlayerPokemon(scene).species.speciesId;
 
     expect(result).toBe(expectedSpecies);
   });
@@ -69,7 +68,7 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const expectedTier = EggTier.COMMON;
 
-    const result = new Egg({scene, tier: expectedTier}).tier;
+    const result = new Egg({ scene, tier: expectedTier }).tier;
 
     expect(result).toBe(expectedTier);
   });
@@ -77,7 +76,7 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const expectedTier = EggTier.GREAT;
 
-    const result = new Egg({scene, tier: expectedTier}).tier;
+    const result = new Egg({ scene, tier: expectedTier }).tier;
 
     expect(result).toBe(expectedTier);
   });
@@ -85,7 +84,7 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const expectedTier = EggTier.ULTRA;
 
-    const result = new Egg({scene, tier: expectedTier}).tier;
+    const result = new Egg({ scene, tier: expectedTier }).tier;
 
     expect(result).toBe(expectedTier);
   });
@@ -93,7 +92,7 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const expectedTier = EggTier.MASTER;
 
-    const result = new Egg({scene, tier: expectedTier}).tier;
+    const result = new Egg({ scene, tier: expectedTier }).tier;
 
     expect(result).toBe(expectedTier);
   });
@@ -101,7 +100,7 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const expectedResult = true;
 
-    const result = new Egg({scene, species: Species.MANAPHY}).isManaphyEgg();
+    const result = new Egg({ scene, species: Species.MANAPHY }).isManaphyEgg();
 
     expect(result).toBe(expectedResult);
   });
@@ -109,7 +108,7 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const expectedResult = true;
 
-    const result = new Egg({scene, tier: EggTier.COMMON, id: 204}).isManaphyEgg();
+    const result = new Egg({ scene, tier: EggTier.COMMON, id: 204 }).isManaphyEgg();
 
     expect(result).toBe(expectedResult);
   });
@@ -117,7 +116,7 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const expectedHatchWaves = 1000;
 
-    const result = new Egg({scene, hatchWaves: expectedHatchWaves}).hatchWaves;
+    const result = new Egg({ scene, hatchWaves: expectedHatchWaves }).hatchWaves;
 
     expect(result).toBe(expectedHatchWaves);
   });
@@ -125,7 +124,7 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const expectedResult = true;
 
-    const result = new Egg({scene, isShiny: expectedResult, species: Species.BULBASAUR}).generatePlayerPokemon(scene).isShiny();
+    const result = new Egg({ scene, isShiny: expectedResult, species: Species.BULBASAUR }).generatePlayerPokemon(scene).isShiny();
 
     expect(result).toBe(expectedResult);
   });
@@ -133,7 +132,7 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const expectedVariantTier = VariantTier.COMMON;
 
-    const result = new Egg({scene, isShiny: true, variantTier: expectedVariantTier, species: Species.BULBASAUR}).generatePlayerPokemon(scene).variant;
+    const result = new Egg({ scene, isShiny: true, variantTier: expectedVariantTier, species: Species.BULBASAUR }).generatePlayerPokemon(scene).variant;
 
     expect(result).toBe(expectedVariantTier);
   });
@@ -141,7 +140,7 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const expectedVariantTier = VariantTier.RARE;
 
-    const result = new Egg({scene, isShiny: true, variantTier: expectedVariantTier, species: Species.BULBASAUR}).generatePlayerPokemon(scene).variant;
+    const result = new Egg({ scene, isShiny: true, variantTier: expectedVariantTier, species: Species.BULBASAUR }).generatePlayerPokemon(scene).variant;
 
     expect(result).toBe(expectedVariantTier);
   });
@@ -149,14 +148,14 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const expectedVariantTier = VariantTier.EPIC;
 
-    const result = new Egg({scene, isShiny: true, variantTier: expectedVariantTier, species: Species.BULBASAUR}).generatePlayerPokemon(scene).variant;
+    const result = new Egg({ scene, isShiny: true, variantTier: expectedVariantTier, species: Species.BULBASAUR }).generatePlayerPokemon(scene).variant;
 
     expect(result).toBe(expectedVariantTier);
   });
   it("should return an egg with an egg move index of 0, 1, 2 or 3", () => {
     const scene = game.scene;
 
-    const eggMoveIndex = new Egg({scene}).eggMoveIndex;
+    const eggMoveIndex = new Egg({ scene }).eggMoveIndex;
     const result = eggMoveIndex && eggMoveIndex >= 0 && eggMoveIndex <= 3;
 
     expect(result).toBe(true);
@@ -165,14 +164,14 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const expectedEggMoveIndex = 3;
 
-    const result = new Egg({scene, eggMoveIndex: expectedEggMoveIndex}).eggMoveIndex;
+    const result = new Egg({ scene, eggMoveIndex: expectedEggMoveIndex }).eggMoveIndex;
 
     expect(result).toBe(expectedEggMoveIndex);
   });
   it("should return a hatched pokemon with a hidden ability", () => {
     const scene = game.scene;
 
-    const playerPokemon = new Egg({scene, overrideHiddenAbility: true, species: Species.BULBASAUR}).generatePlayerPokemon(scene);
+    const playerPokemon = new Egg({ scene, overrideHiddenAbility: true, species: Species.BULBASAUR }).generatePlayerPokemon(scene);
     const expectedAbilityIndex = playerPokemon.species.ability2 ? 2 : 1;
 
     const result = playerPokemon.abilityIndex;
@@ -183,7 +182,7 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const expectedEggCount = 1;
 
-    new Egg({scene, sourceType: EggSourceType.GACHA_LEGENDARY, pulled: true});
+    new Egg({ scene, sourceType: EggSourceType.GACHA_LEGENDARY, pulled: true });
 
     const result = scene.gameData.eggs.length;
 
@@ -193,7 +192,7 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const expectedEggTier = EggTier.COMMON;
 
-    const result = new Egg({scene, tier: EggTier.MASTER, species: Species.BULBASAUR}).tier;
+    const result = new Egg({ scene, tier: EggTier.MASTER, species: Species.BULBASAUR }).tier;
 
     expect(result).toBe(expectedEggTier);
   });
@@ -201,7 +200,7 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const expectedHatchWaves = 10;
 
-    const result = new Egg({scene, tier: EggTier.MASTER, species: Species.BULBASAUR}).hatchWaves;
+    const result = new Egg({ scene, tier: EggTier.MASTER, species: Species.BULBASAUR }).hatchWaves;
 
     expect(result).toBe(expectedHatchWaves);
   });
@@ -232,7 +231,7 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const startPityValues = [...scene.gameData.eggPity];
 
-    new Egg({scene, sourceType: EggSourceType.GACHA_MOVE, pulled: true, tier: EggTier.COMMON});
+    new Egg({ scene, sourceType: EggSourceType.GACHA_MOVE, pulled: true, tier: EggTier.COMMON });
 
     expect(scene.gameData.eggPity[EggTier.GREAT]).toBe(startPityValues[EggTier.GREAT] + 1);
     expect(scene.gameData.eggPity[EggTier.ULTRA]).toBe(startPityValues[EggTier.ULTRA] + 1);
@@ -242,7 +241,7 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const startPityValues = [...scene.gameData.eggPity];
 
-    new Egg({scene, sourceType: EggSourceType.GACHA_LEGENDARY, pulled: true, tier: EggTier.COMMON});
+    new Egg({ scene, sourceType: EggSourceType.GACHA_LEGENDARY, pulled: true, tier: EggTier.COMMON });
 
     expect(scene.gameData.eggPity[EggTier.GREAT]).toBe(startPityValues[EggTier.GREAT] + 1);
     expect(scene.gameData.eggPity[EggTier.ULTRA]).toBe(startPityValues[EggTier.ULTRA] + 1);
@@ -253,7 +252,7 @@ describe("Egg Generation Tests", () => {
     const startingManaphyEggCount = scene.gameData.gameStats.manaphyEggsPulled;
 
     for (let i = 0; i < 200; i++) {
-      new Egg({scene, sourceType: EggSourceType.GACHA_MOVE, pulled: true, species: Species.BULBASAUR});
+      new Egg({ scene, sourceType: EggSourceType.GACHA_MOVE, pulled: true, species: Species.BULBASAUR });
     }
 
     expect(scene.gameData.gameStats.manaphyEggsPulled).toBe(startingManaphyEggCount);
@@ -262,7 +261,7 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const startingManaphyEggCount = scene.gameData.gameStats.manaphyEggsPulled;
 
-    new Egg({scene, sourceType: EggSourceType.GACHA_MOVE, pulled: true, id: 204, tier: EggTier.COMMON});
+    new Egg({ scene, sourceType: EggSourceType.GACHA_MOVE, pulled: true, id: 204, tier: EggTier.COMMON });
 
     expect(scene.gameData.gameStats.manaphyEggsPulled).toBe(startingManaphyEggCount + 1);
   });
@@ -270,7 +269,7 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const startingRareEggsPulled = scene.gameData.gameStats.rareEggsPulled;
 
-    new Egg({scene, sourceType: EggSourceType.GACHA_MOVE, pulled: true, tier: EggTier.GREAT});
+    new Egg({ scene, sourceType: EggSourceType.GACHA_MOVE, pulled: true, tier: EggTier.GREAT });
 
     expect(scene.gameData.gameStats.rareEggsPulled).toBe(startingRareEggsPulled + 1);
   });
@@ -278,7 +277,7 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const startingEpicEggsPulled = scene.gameData.gameStats.epicEggsPulled;
 
-    new Egg({scene, sourceType: EggSourceType.GACHA_MOVE, pulled: true, tier: EggTier.ULTRA});
+    new Egg({ scene, sourceType: EggSourceType.GACHA_MOVE, pulled: true, tier: EggTier.ULTRA });
 
     expect(scene.gameData.gameStats.epicEggsPulled).toBe(startingEpicEggsPulled + 1);
   });
@@ -286,7 +285,7 @@ describe("Egg Generation Tests", () => {
     const scene = game.scene;
     const startingLegendaryEggsPulled = scene.gameData.gameStats.legendaryEggsPulled;
 
-    new Egg({scene, sourceType: EggSourceType.GACHA_MOVE, pulled: true, tier: EggTier.MASTER});
+    new Egg({ scene, sourceType: EggSourceType.GACHA_MOVE, pulled: true, tier: EggTier.MASTER });
 
     expect(scene.gameData.gameStats.legendaryEggsPulled).toBe(startingLegendaryEggsPulled + 1);
   });
@@ -297,8 +296,8 @@ describe("Egg Generation Tests", () => {
     const expectedTier1 = EggTier.MASTER;
     const expectedTier2 = EggTier.ULTRA;
 
-    const result1 = new Egg({scene, sourceType: EggSourceType.GACHA_LEGENDARY, pulled: true}).tier;
-    const result2 = new Egg({scene, sourceType: EggSourceType.GACHA_MOVE, pulled: true}).tier;
+    const result1 = new Egg({ scene, sourceType: EggSourceType.GACHA_LEGENDARY, pulled: true }).tier;
+    const result2 = new Egg({ scene, sourceType: EggSourceType.GACHA_MOVE, pulled: true }).tier;
 
     expect(result1).toBe(expectedTier1);
     expect(result2).toBe(expectedTier2);
@@ -306,7 +305,7 @@ describe("Egg Generation Tests", () => {
 
   it("should generate an epic shiny from pokemon with a different form", () => {
     const scene = game.scene;
-    const egg = new Egg({scene, isShiny: true, variantTier: VariantTier.EPIC, species: Species.MIRAIDON});
+    const egg = new Egg({ scene, isShiny: true, variantTier: VariantTier.EPIC, species: Species.MIRAIDON });
 
     expect(egg.variantTier).toBe(VariantTier.EPIC);
   });


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
The test file needlessly created a whole new game/scene for every test when it didn't need to.

## What are the changes from a developer perspective?
The test file uses ~75% less memory now by only creating a single game/scene at the beginning, and takes ~10 less seconds to complete too. Also the rest of the test file got auto-formatted by my IDE 🤷.

## How to test the changes?
`npm run test egg -- --logHeapUsage`

### Screenshots/video
Before:
![image](https://github.com/user-attachments/assets/580cfcde-0d91-4ed9-bd8d-c3d64a695545)
After:
![image](https://github.com/user-attachments/assets/8f4fffc8-3233-4280-b63b-1f0f7b896d5c)

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
