### PR TITLE
[Bug] Fix abilities with PostFaintAbAttr not proccing

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1339,6 +1339,7 @@ export class SacrificialAttr extends MoveEffectAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     user.damageAndUpdate(user.hp, HitResult.OTHER, false, true, true);
 	  user.turnData.damageTaken += user.hp;
+    user.pushMoveHistory({ move: move.id, targets: [ user.getBattlerIndex() ], result: MoveResult.OTHER });
 
     return true;
   }
@@ -1377,6 +1378,7 @@ export class SacrificialAttrOnHit extends MoveEffectAttr {
 
     user.damageAndUpdate(user.hp, HitResult.OTHER, false, true, true);
     user.turnData.damageTaken += user.hp;
+    user.pushMoveHistory({ move: move.id, targets: [ user.getBattlerIndex() ], result: MoveResult.OTHER });
 
     return true;
   }


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
Abilities with `PostFaintAbAttr` should now correctly trigger when a pokemon is fainted ie Desolate Lands on enemy wild Groudon should now be removed when it is fainted

## Why am I making these changes?
Abilities with `PostFaintAbAttr` does not trigger when the pokemon hasn't received any attacks yet and is fainted on the same turn. This is because the condition used is `pokemon.turnData?.attacksReceived?.length`. The bug can only be observed against wild mons because `PreSwitchOutAbAttr` procs the same logic of `PostFaintAbAttr`. This closes https://github.com/pagefaultgames/pokerogue/issues/3548

## What are the changes from a developer perspective?
- Added a new condition to check whether the last used move has an attribute of `SacrificialAttr` or `SacrificialAttrOnHit`
- Added move history record for sacrificial moves

### Screenshots/Videos
Before fix:

https://github.com/user-attachments/assets/c662620c-c951-48e3-9dd8-19454990a068




After fix:


https://github.com/user-attachments/assets/89b2b507-cc25-4219-91fd-a2e9919de81b




## How to test the changes?
overrides used:
```ts 
const overrides = {
  OPP_SPECIES_OVERRIDE: Species.KYOGRE,
  OPP_MOVESET_OVERRIDE: [Moves.MEMENTO, Moves.MEMENTO, Moves.MEMENTO, Moves.MEMENTO]
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

Set Kyogre's form to Primal: add `pokemon.formIndex = 1` inside `BattleScene.addEnemyPokemon()`

To test:
- do not attack the enemy and let it use Memento

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
