### PR TITLE
[Bug] Show variant icons when forms share masterlist entry

### DIFF
--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -301,7 +301,7 @@ export abstract class PokemonSpeciesForm {
     let variantDataIndex: integer | string = this.speciesId;
     const species = getPokemonSpecies(this.speciesId);
     if (species.forms.length > 0 && formIndex !== undefined) {
-      formkey = species.forms[formIndex]?.formSpriteKey;
+      formkey = species.forms[formIndex]?.getFormSpriteKey(formIndex);
       if (formkey) {
         variantDataIndex = `${this.speciesId}-${formkey}`;
       }


### PR DESCRIPTION
## What are the changes the user will see?
When a Pokemon's forms rely on the same variant `_masterlist` entry, instead of having one per form, variant icons will now correctly appear.

## Why am I making these changes?
Reported [here](https://discord.com/channels/1125469663833370665/1238339524778790922/1275188605316501596) and [here](https://discord.com/channels/1125469663833370665/1229465263532019712/1274491742821027894).

Although #3322 addressed a different set of variant icons not appearing, it in turn caused the current batch of issues.

## What are the changes from a developer perspective?
The way that variant icons work is that the game does not know to load them unless it finds an entry in the `_masterlist` that tells it to. When each form is loaded, the affected code determines the name of the form that the game looks for in the `_masterlist`.

#3322 replaced `formKey` with `formSpriteKey`. This distinction allows multiple forms to use the same assets. This is generally useful when they are indistinguishable at icon-scale, or select cases like Sinistea or Poltchageist, where the marks of authenticity (or lack thereof) are not visible in any sprites. It also can be used to reduce the number of characters used to name each asset for that form, by giving it a shorter alias, though at the expense of clarity.
Since generally a form's `formSpriteKey` was used on the `_masterlist`, instead of its `formKey`, the assumption was that the solution simply was that simple.

Unfortunately, many forms have a `formSpriteKey` of `null`. This appears to be the cause of the following function.
```
  getFormSpriteKey(_formIndex?: integer) {
    return this.formSpriteKey !== null ? this.formSpriteKey : this.formKey;
  }
```
By using this function instead, all of the variant icons previously malfunctioning now appear as intended.

### Screenshots/Videos
#### Before
![image](https://github.com/user-attachments/assets/5ca90a81-10fd-4543-a327-fa9e7922ec21)
![image](https://github.com/user-attachments/assets/34a8c46d-25cd-4e04-92c9-ac13c49dcddb)
![image](https://github.com/user-attachments/assets/0f4ef504-9f1e-45b7-97f6-e526b511dc6f)

#### After
![image](https://github.com/user-attachments/assets/286285d0-5b8e-49ac-ac00-e2315c2ecff8)
![image](https://github.com/user-attachments/assets/9b28126a-0472-46c3-8f40-9f5f632f264d)
![image](https://github.com/user-attachments/assets/f2333c87-b9f8-419b-b67d-69ecc532ee7a)

And some other variant icons tested:
![image](https://github.com/user-attachments/assets/5dcd0e5f-abb3-4f85-be31-cd52a6fa14cd)
![image](https://github.com/user-attachments/assets/b986e477-c3ba-4e90-82c7-e5e5211402a7)
![image](https://github.com/user-attachments/assets/8600aaeb-3a22-4cc9-ba40-4401746b911e)
![image](https://github.com/user-attachments/assets/0922f8ba-084d-4b1a-a076-f82ab089b959)



## How to test the changes?
Use an unlocked savefile to test variant icons, or perhaps use overrides to do specific alternative icon tests.

Note:
Something about the new starter select sorting system produces an "Variant Icon Missing" warning every time the sort criteria changes, if that variant tier is the one currently preserved as a preference for that Pokemon. This is unrelated, and the game is only able to do so if it can register the icon's key on the `_masterlist` to realise that it is missing.
Just set that Pokemon's `R: Shiny` to not shiny and it should go away.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
~~- [] Have I considered writing automated tests for the issue?~~
~~- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
