### PR TITLE
[Test] Fix failing belly drum test

### DIFF
--- a/src/test/moves/belly_drum.test.ts
+++ b/src/test/moves/belly_drum.test.ts
@@ -6,6 +6,8 @@ import { Species } from "#enums/species";
 import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
+import { SPLASH_ONLY } from "../utils/testUtils";
+import { Abilities } from "#app/enums/abilities";
 
 const TIMEOUT = 20 * 1000;
 // RATIO : HP Cost of Move
@@ -29,12 +31,14 @@ describe("Moves - BELLY DRUM", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.starterSpecies(Species.MAGIKARP);
-    game.override.enemySpecies(Species.SNORLAX);
-    game.override.startingLevel(100);
-    game.override.enemyLevel(100);
-    game.override.moveset([Moves.BELLY_DRUM]);
-    game.override.enemyMoveset([Moves.SPLASH]);
+    game.override
+      .starterSpecies(Species.MAGIKARP)
+      .enemySpecies(Species.SNORLAX)
+      .startingLevel(100)
+      .enemyLevel(100)
+      .moveset([Moves.BELLY_DRUM])
+      .enemyMoveset(SPLASH_ONLY)
+      .enemyAbility(Abilities.BALL_FETCH);
   });
 
   // Bulbapedia Reference: https://bulbapedia.bulbagarden.net/wiki/Belly_Drum_(move)


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
n/a

## Why am I making these changes?
belly drum tests can fail if the player pokemon faints when the enemy mon uses a damaging move

## What are the changes from a developer perspective?
replaced enemy's moveset with splash only

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
`npm run test belly_drum`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
