### PR TITLE
[Bug] Some Audio changes and adjustments

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1756,6 +1756,7 @@ export default class BattleScene extends SceneBase {
         } else {
           const soundDetails = sound.key.split("/");
           switch (soundDetails[0]) {
+
           case "battle_anims":
           case "cry":
             if (soundDetails[1].startsWith("PRSFX- ")) {
@@ -1792,6 +1793,16 @@ export default class BattleScene extends SceneBase {
     try {
       const keyDetails = key.split("/");
       switch (keyDetails[0]) {
+      case "level_up_fanfare":
+      case "item_fanfare":
+      case "minor_fanfare":
+      case "heal":
+      case "evolution":
+      case "evolution_fanfare":
+        // These sounds are loaded in as BGM, but played as sound effects
+        // When these sounds are updated in updateVolume(), they are treated as BGM however because they are placed in the BGM Cache through being called by playSoundWithoutBGM()
+        config["volume"] = this.masterVolume * this.bgmVolume;
+        break;
       case "battle_anims":
       case "cry":
         config["volume"] = this.masterVolume * this.fieldVolume;
@@ -1805,10 +1816,8 @@ export default class BattleScene extends SceneBase {
         config["volume"] = this.masterVolume * this.uiVolume;
         break;
       case "se":
-      default:
         config["volume"] = this.masterVolume * this.seVolume;
         break;
-
       }
       this.sound.play(key, config);
       return this.sound.get(key) as AnySound;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2641,7 +2641,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   private fusionFaintCry(callback: Function): void {
-    const key = this.getSpeciesForm().getCryKey(this.formIndex);
+    const key = `cry/${this.getSpeciesForm().getCryKey(this.formIndex)}`;
     let i = 0;
     let rate = 0.85;
     const cry = this.scene.playSound(key, { rate: rate }) as AnySound;
@@ -2649,7 +2649,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     const tintSprite = this.getTintSprite();
     let duration = cry.totalDuration * 1000;
 
-    let fusionCry = this.scene.playSound(this.getFusionSpeciesForm().getCryKey(this.fusionFormIndex), { rate: rate }) as AnySound;
+    const fusionCryKey = `cry/${this.getFusionSpeciesForm().getCryKey(this.fusionFormIndex)}`;
+    let fusionCry = this.scene.playSound(fusionCryKey, { rate: rate }) as AnySound;
     fusionCry.stop();
     duration = Math.min(duration, fusionCry.totalDuration * 1000);
     fusionCry.destroy();
@@ -2693,7 +2694,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         }
         if (i === transitionIndex) {
           SoundFade.fadeOut(this.scene, cry, Utils.fixedInt(Math.ceil((duration / rate) * 0.2)));
-          fusionCry = this.scene.playSound(this.getFusionSpeciesForm().getCryKey(this.fusionFormIndex), Object.assign({ seek: Math.max(fusionCry.totalDuration * 0.4, 0), rate: rate }));
+          fusionCry = this.scene.playSound(fusionCryKey, Object.assign({ seek: Math.max(fusionCry.totalDuration * 0.4, 0), rate: rate }));
           SoundFade.fadeIn(this.scene, fusionCry, Utils.fixedInt(Math.ceil((duration / rate) * 0.2)), this.scene.masterVolume * this.scene.seVolume, 0);
         }
         rate *= 0.99;

--- a/src/ui/egg-gacha-ui-handler.ts
+++ b/src/ui/egg-gacha-ui-handler.ts
@@ -359,7 +359,7 @@ export default class EggGachaUiHandler extends MessageUiHandler {
         this.scene.time.delayedCall(this.getDelayValue(count ? 500 : 1250), () => {
           this.scene.playSound("se/gacha_dispense");
           this.scene.time.delayedCall(this.getDelayValue(750), () => {
-            this.scene.sound.stopByKey("gacha_running");
+            this.scene.sound.stopByKey("se/gacha_running");
             this.scene.tweens.add({
               targets: egg,
               duration: this.getDelayValue(350),

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1701,7 +1701,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
                     }
                   });
                   ui.setMode(Mode.STARTER_SELECT);
-                  this.scene.playSound("buy");
+                  this.scene.playSound("se/buy");
 
                   return true;
                 }
@@ -1753,7 +1753,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
             starterAttributes.shiny = starterAttributes.shiny ? !starterAttributes.shiny : true;
             this.setSpeciesDetails(this.lastSpecies, !props.shiny, undefined, undefined, props.shiny ? 0 : undefined, undefined, undefined);
             if (starterAttributes.shiny) {
-              this.scene.playSound("sparkle");
+              this.scene.playSound("se/sparkle");
               // Set the variant label to the shiny tint
               const tint = getVariantTint(newVariant);
               this.pokemonShinyIcon.setFrame(getVariantIcon(newVariant));


### PR DESCRIPTION
## What are the changes the user will see?
The sounds below will be moved from SE to BGM:
- "level_up_fanfare"
- "item_fanfare"
- "minor_fanfare"
- "heal"
- "evolution"
- "evolution_fanfare"
In addition, some sound effects were missing the correct keys. Fusion cries in particular.

## Why am I making these changes?
I wasn't sure how to classify the above sounds since they are common sounds heard in gameplay. However, after playing in Beta, I realized that these short sounds would be better fit under the category of BGM. 

## What are the changes from a developer perspective?
battle-scene.ts: playSound() has been updated to treat these sounds as BGM. I felt that it was better to stack the various cases instead of resorting to default: b/c developers would be able to easily see which sounds fell under the BGM umbrella. 
key references have their correct categorization added if missing. 

## How to test the changes?
- Tinker with BGM settings and level up / acquire EXP items from rival / evolve / pass wave X0 
- Play Endless Spliced to check fusion cries

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
