### PR TITLE
[Beta][Bug] Sounds in Dialogue Changes

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1796,7 +1796,7 @@ export default class BattleScene extends SceneBase {
       case "cry":
         config["volume"] = this.masterVolume * this.fieldVolume;
         //PRSFX sound files are unusually loud
-        if (key.startsWith("PRSFX- ")) {
+        if (keyDetails[1].startsWith("PRSFX- ")) {
           config["volume"] *= 0.5;
         }
         break;

--- a/src/locales/de/battle.json
+++ b/src/locales/de/battle.json
@@ -38,7 +38,7 @@
   "learnMoveNotLearned": "{{pokemonName}} hat {{moveName}} nicht erlernt.",
   "learnMoveForgetQuestion": "Welche Attacke soll vergessen werden?",
   "learnMoveForgetSuccess": "{{pokemonName}} hat {{moveName}} vergessen.",
-  "countdownPoof": "@d{32}Eins, @d{15}zwei @d{15}und@d{15}… @d{15}… @d{15}… @d{15}@s{pb_bounce_1}schwupp!",
+  "countdownPoof": "@d{32}Eins, @d{15}zwei @d{15}und@d{15}… @d{15}… @d{15}… @d{15}@s{se/pb_bounce_1}schwupp!",
   "learnMoveAnd": "Und…",
   "levelCapUp": "Die Levelbeschränkung wurde auf {{levelCap}} erhöht!",
   "moveNotImplemented": "{{moveName}} ist noch nicht implementiert und kann nicht ausgewählt werden.",

--- a/src/locales/en/battle.json
+++ b/src/locales/en/battle.json
@@ -38,7 +38,7 @@
   "learnMoveNotLearned": "{{pokemonName}} did not learn the\nmove {{moveName}}.",
   "learnMoveForgetQuestion": "Which move should be forgotten?",
   "learnMoveForgetSuccess": "{{pokemonName}} forgot how to\nuse {{moveName}}.",
-  "countdownPoof": "@d{32}1, @d{15}2, and@d{15}… @d{15}… @d{15}… @d{15}@s{pb_bounce_1}Poof!",
+  "countdownPoof": "@d{32}1, @d{15}2, and@d{15}… @d{15}… @d{15}… @d{15}@s{se/pb_bounce_1}Poof!",
   "learnMoveAnd": "And…",
   "levelCapUp": "The level cap\nhas increased to {{levelCap}}!",
   "moveNotImplemented": "{{moveName}} is not yet implemented and cannot be selected.",

--- a/src/locales/es/battle.json
+++ b/src/locales/es/battle.json
@@ -36,7 +36,7 @@
   "learnMoveNotLearned": "{{pokemonName}} no ha aprendido {{moveName}}.",
   "learnMoveForgetQuestion": "¿Qué movimiento quieres que olvide?",
   "learnMoveForgetSuccess": "{{pokemonName}} ha olvidado cómo utilizar {{moveName}}.",
-  "countdownPoof": "@d{32}1, @d{15}2, @d{15}y@d{15}… @d{15}… @d{15}… @d{15}@s{pb_bounce_1}¡Puf!",
+  "countdownPoof": "@d{32}1, @d{15}2, @d{15}y@d{15}… @d{15}… @d{15}… @d{15}@s{se/pb_bounce_1}¡Puf!",
   "learnMoveAnd": "Y…",
   "levelCapUp": "¡Se ha incrementado el\nnivel máximo a {{levelCap}}!",
   "moveNotImplemented": "{{moveName}} aún no está implementado y no se puede seleccionar.",

--- a/src/locales/fr/battle.json
+++ b/src/locales/fr/battle.json
@@ -38,7 +38,7 @@
   "learnMoveNotLearned": "{{pokemonName}} n’a pas appris\n{{moveName}}.",
   "learnMoveForgetQuestion": "Quelle capacité doit être oubliée ?",
   "learnMoveForgetSuccess": "{{pokemonName}} oublie comment\nutiliser {{moveName}}.",
-  "countdownPoof": "@d{32}1, @d{15}2, @d{15}et@d{15}… @d{15}… @d{15}… @d{15}@s{pb_bounce_1}Tadaaa !",
+  "countdownPoof": "@d{32}1, @d{15}2, @d{15}et@d{15}… @d{15}… @d{15}… @d{15}@s{se/pb_bounce_1}Tadaaa !",
   "learnMoveAnd": "Et…",
   "levelCapUp": "La limite de niveau\na été augmentée à {{levelCap}} !",
   "moveNotImplemented": "{{moveName}} n’est pas encore implémenté et ne peut pas être sélectionné.",

--- a/src/locales/it/battle.json
+++ b/src/locales/it/battle.json
@@ -38,7 +38,7 @@
   "learnMoveNotLearned": "{{pokemonName}} non ha imparato\n{{moveName}}.",
   "learnMoveForgetQuestion": "Quale mossa deve dimenticare?",
   "learnMoveForgetSuccess": "{{pokemonName}} ha dimenticato la mossa\n{{moveName}}.",
-  "countdownPoof": "@d{32}1, @d{15}2, @d{15}e@d{15}… @d{15}… @d{15}… @d{15}@s{pb_bounce_1}ta-daaaa!",
+  "countdownPoof": "@d{32}1, @d{15}2, @d{15}e@d{15}… @d{15}… @d{15}… @d{15}@s{se/pb_bounce_1}ta-daaaa!",
   "learnMoveAnd": "E…",
   "levelCapUp": "Il livello massimo\nè aumentato a {{levelCap}}!",
   "moveNotImplemented": "{{moveName}} non è ancora implementata e non può essere selezionata.",

--- a/src/locales/ja/battle.json
+++ b/src/locales/ja/battle.json
@@ -38,7 +38,7 @@
   "learnMoveNotLearned": "{{pokemonName}}は　{{moveName}}を\n覚えずに　終わった！",
   "learnMoveForgetQuestion": "どの　技を\n忘れさせたい？",
   "learnMoveForgetSuccess": "{{pokemonName}}は　{{moveName}}の\n使い方を　きれいに　忘れた！",
-  "countdownPoof": "@d{32}1 @d{15}2の @d{15}… @d{15}… @d{15}… @d{15}@s{pb_bounce_1}ポカン！",
+  "countdownPoof": "@d{32}1 @d{15}2の @d{15}… @d{15}… @d{15}… @d{15}@s{se/pb_bounce_1}ポカン！",
   "learnMoveAnd": "そして…",
   "levelCapUp": "レベルキャップの\n{{levelCap}}に　上がった！",
   "moveNotImplemented": "{{moveName}}は　まだ　実装されておらず　選択できません。",

--- a/src/locales/ko/battle.json
+++ b/src/locales/ko/battle.json
@@ -38,7 +38,7 @@
   "learnMoveNotLearned": "{{pokemonName}}[[는]] {{moveName}}[[를]]\n결국 배우지 않았다!",
   "learnMoveForgetQuestion": "어느 기술을 잊게 하고싶은가?",
   "learnMoveForgetSuccess": "{{pokemonName}}[[는]] {{moveName}}[[를]] 깨끗이 잊었다!",
-  "countdownPoof": "@d{32}1, @d{15}2, @d{15}… @d{15}… @d{30}@s{pb_bounce_1}짠!",
+  "countdownPoof": "@d{32}1, @d{15}2, @d{15}… @d{15}… @d{30}@s{se/pb_bounce_1}짠!",
   "learnMoveAnd": "그리고…",
   "levelCapUp": "레벨의 최대치가\n{{levelCap}}까지 상승했다!",
   "moveNotImplemented": "{{moveName}}[[는]] 아직 구현되지 않아 사용할 수 없다…",

--- a/src/locales/pt_BR/battle.json
+++ b/src/locales/pt_BR/battle.json
@@ -38,7 +38,7 @@
   "learnMoveNotLearned": "{{pokemonName}} não aprendeu {{moveName}}.",
   "learnMoveForgetQuestion": "Qual movimento quer esquecer?",
   "learnMoveForgetSuccess": "{{pokemonName}} esqueceu como usar {{moveName}}.",
-  "countdownPoof": "@d{32}1, @d{15}2, @d{15}e@d{15}… @d{15}… @d{15}… @d{15}@s{pb_bounce_1}Puf!",
+  "countdownPoof": "@d{32}1, @d{15}2, @d{15}e@d{15}… @d{15}… @d{15}… @d{15}@s{se/pb_bounce_1}Puf!",
   "learnMoveAnd": "E…",
   "levelCapUp": "O nível máximo aumentou\npara {{levelCap}}!",
   "moveNotImplemented": "{{moveName}} ainda não foi implementado e não pode ser usado.",

--- a/src/locales/zh_CN/battle.json
+++ b/src/locales/zh_CN/battle.json
@@ -38,7 +38,7 @@
   "learnMoveNotLearned": "{{pokemonName}}没有学会{{moveName}}。",
   "learnMoveForgetQuestion": "要忘记哪个技能？",
   "learnMoveForgetSuccess": "{{pokemonName}}忘记了\n如何使用{{moveName}}。",
-  "countdownPoof": "@d{32}1, @d{15}2 @d{15}… @d{15}… @d{15}@s{pb_bounce_1}空！",
+  "countdownPoof": "@d{32}1, @d{15}2 @d{15}… @d{15}… @d{15}@s{se/pb_bounce_1}空！",
   "learnMoveAnd": "然后……",
   "levelCapUp": "等级上限提升到{{levelCap}}！",
   "moveNotImplemented": "{{moveName}}尚未实装，无法选择。",

--- a/src/locales/zh_TW/battle.json
+++ b/src/locales/zh_TW/battle.json
@@ -34,7 +34,7 @@
   "learnMoveNotLearned": "{{pokemonName}} 沒有學會 {{moveName}}.",
   "learnMoveForgetQuestion": "要忘記哪個技能？",
   "learnMoveForgetSuccess": "{{pokemonName}} 忘記了 {{moveName}}.",
-  "countdownPoof": "@d{32}1, @d{15}2, 和@d{15}… @d{15}… @d{15}… @d{15}@s{pb_bounce_1}噗！",
+  "countdownPoof": "@d{32}1, @d{15}2, 和@d{15}… @d{15}… @d{15}… @d{15}@s{se/pb_bounce_1}噗！",
   "learnMoveAnd": "然後…",
   "levelCapUp": "等級上限提升到 {{levelCap}}！",
   "moveNotImplemented": "{{moveName}} 未實裝，無法選擇。",

--- a/src/ui/message-ui-handler.ts
+++ b/src/ui/message-ui-handler.ts
@@ -109,7 +109,7 @@ export default abstract class MessageUiHandler extends AwaitableUiHandler {
               this.scene.charSprite.setVariant(charVar);
             }
             if (charSound) {
-              this.scene.playSound(`se/${charSound}`);
+              this.scene.playSound(charSound);
             }
             if (callback && !this.textTimer?.repeatCount) {
               if (callbackDelay && !prompt) {


### PR DESCRIPTION
## What are the changes the user will see?
In messages-ui-handler, the category 'se/' was incorrectly prefixed to the audio key and would lead to a freeze/issue when a Pokemon forgot a move during LearnMovePhase.
In addition, the conditional checking for extra loud move sounds wasn't correct. 

## Why am I making these changes?
This is my responsibility + I believe that this prefix isn't helpful for those who want to add more sound effects to dialogue found in locales. 

## What are the changes from a developer perspective?
- '/se' prefixing removed from message-ui-handler.ts
- Dialogue updated so that it refers to the correct sound key. 
- Conditional updated. 

## How to test the changes?
Have a Pokemon forget a move. The correct sound effect should play during the '1.. 2... 3... and Poof (pokeball-release sound)' 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
