### PR TITLE
[Bug] Prevent daily runs from breaking due to very (un)lucky RNG

### DIFF
--- a/src/data/daily-run.ts
+++ b/src/data/daily-run.ts
@@ -40,7 +40,7 @@ export function getDailyRunStarters(scene: BattleScene, seed: string): Starter[]
     }
 
     const starterCosts: integer[] = [];
-    starterCosts.push(Math.round(3.5 + Math.abs(Utils.randSeedGauss(1))));
+    starterCosts.push(Math.min(Math.round(3.5 + Math.abs(Utils.randSeedGauss(1))), 8));
     starterCosts.push(Utils.randSeedInt(9 - starterCosts[0], 1));
     starterCosts.push(10 - (starterCosts[0] + starterCosts[1]));
 


### PR DESCRIPTION
## What are the changes the user will see?
In a way... none.

## Why am I making these changes?
It was possible (though extremely unlikely) for the RNG to generate a 9+ cost Pokémon as the first starter in Daily Run mode, thus causing the third Pokémon to be a 0 cost (which doesn't exist) and crashing the game.

## What are the changes from a developer perspective?
The cost of the first starter in Daily Run mode is now capped at 8.

## How to test the changes?
Start a Daily Run and see that the game doesn't crash. et voilà

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
