### PR TITLE
[Test] Create the appropriate `startBattle()` functions in the helper classes

### DIFF
--- a/src/test/utils/gameManager.ts
+++ b/src/test/utils/gameManager.ts
@@ -1,6 +1,7 @@
 import { updateUserInfo } from "#app/account";
 import { BattlerIndex } from "#app/battle";
 import BattleScene from "#app/battle-scene";
+import { BattleStyle } from "#app/enums/battle-style";
 import { EnemyPokemon, PlayerPokemon } from "#app/field/pokemon";
 import Trainer from "#app/field/trainer";
 import { GameModes, getGameMode } from "#app/game-mode";
@@ -170,6 +171,8 @@ export default class GameManager {
   }
 
   /**
+   * @deprecated Use `game.classicMode.startBattle()` or `game.dailyMode.startBattle()` instead
+   *
    * Transitions to the start of a battle.
    * @param species - Optional array of species to start the battle with.
    * @returns A promise that resolves when the battle is started.
@@ -177,15 +180,17 @@ export default class GameManager {
   async startBattle(species?: Species[]) {
     await this.classicMode.runToSummon(species);
 
-    this.onNextPrompt("CheckSwitchPhase", Mode.CONFIRM, () => {
-      this.setMode(Mode.MESSAGE);
-      this.endPhase();
-    }, () => this.isCurrentPhase(CommandPhase) || this.isCurrentPhase(TurnInitPhase));
+    if (this.scene.battleStyle === BattleStyle.SWITCH) {
+      this.onNextPrompt("CheckSwitchPhase", Mode.CONFIRM, () => {
+        this.setMode(Mode.MESSAGE);
+        this.endPhase();
+      }, () => this.isCurrentPhase(CommandPhase) || this.isCurrentPhase(TurnInitPhase));
 
-    this.onNextPrompt("CheckSwitchPhase", Mode.CONFIRM, () => {
-      this.setMode(Mode.MESSAGE);
-      this.endPhase();
-    }, () => this.isCurrentPhase(CommandPhase) || this.isCurrentPhase(TurnInitPhase));
+      this.onNextPrompt("CheckSwitchPhase", Mode.CONFIRM, () => {
+        this.setMode(Mode.MESSAGE);
+        this.endPhase();
+      }, () => this.isCurrentPhase(CommandPhase) || this.isCurrentPhase(TurnInitPhase));
+    }
 
     await this.phaseInterceptor.to(CommandPhase);
     console.log("==================[New Turn]==================");

--- a/src/test/utils/helpers/classicModeHelper.ts
+++ b/src/test/utils/helpers/classicModeHelper.ts
@@ -1,8 +1,11 @@
+import { BattleStyle } from "#app/enums/battle-style";
 import { Species } from "#app/enums/species";
 import { GameModes, getGameMode } from "#app/game-mode";
 import overrides from "#app/overrides";
+import { CommandPhase } from "#app/phases/command-phase";
 import { EncounterPhase } from "#app/phases/encounter-phase";
 import { SelectStarterPhase } from "#app/phases/select-starter-phase";
+import { TurnInitPhase } from "#app/phases/turn-init-phase";
 import { Mode } from "#app/ui/ui";
 import { generateStarter } from "../gameManagerUtils";
 import { GameManagerHelper } from "./gameManagerHelper";
@@ -32,5 +35,29 @@ export class ClassicModeHelper extends GameManagerHelper {
     if (overrides.OPP_HELD_ITEMS_OVERRIDE.length === 0) {
       this.game.removeEnemyHeldItems();
     }
+  }
+
+  /**
+   * Transitions to the start of a battle.
+   * @param species - Optional array of species to start the battle with.
+   * @returns A promise that resolves when the battle is started.
+   */
+  async startBattle(species?: Species[]) {
+    await this.runToSummon(species);
+
+    if (this.game.scene.battleStyle === BattleStyle.SWITCH) {
+      this.game.onNextPrompt("CheckSwitchPhase", Mode.CONFIRM, () => {
+        this.game.setMode(Mode.MESSAGE);
+        this.game.endPhase();
+      }, () => this.game.isCurrentPhase(CommandPhase) || this.game.isCurrentPhase(TurnInitPhase));
+
+      this.game.onNextPrompt("CheckSwitchPhase", Mode.CONFIRM, () => {
+        this.game.setMode(Mode.MESSAGE);
+        this.game.endPhase();
+      }, () => this.game.isCurrentPhase(CommandPhase) || this.game.isCurrentPhase(TurnInitPhase));
+    }
+
+    await this.game.phaseInterceptor.to(CommandPhase);
+    console.log("==================[New Turn]==================");
   }
 }

--- a/src/test/utils/helpers/dailyModeHelper.ts
+++ b/src/test/utils/helpers/dailyModeHelper.ts
@@ -1,7 +1,10 @@
+import { BattleStyle } from "#app/enums/battle-style";
 import { Button } from "#app/enums/buttons";
 import overrides from "#app/overrides";
+import { CommandPhase } from "#app/phases/command-phase";
 import { EncounterPhase } from "#app/phases/encounter-phase";
 import { TitlePhase } from "#app/phases/title-phase";
+import { TurnInitPhase } from "#app/phases/turn-init-phase";
 import SaveSlotSelectUiHandler from "#app/ui/save-slot-select-ui-handler";
 import { Mode } from "#app/ui/ui";
 import { GameManagerHelper } from "./gameManagerHelper";
@@ -33,5 +36,28 @@ export class DailyModeHelper extends GameManagerHelper {
     if (overrides.OPP_HELD_ITEMS_OVERRIDE.length === 0) {
       this.game.removeEnemyHeldItems();
     }
+  }
+
+  /**
+   * Transitions to the start of a battle.
+   * @returns A promise that resolves when the battle is started.
+   */
+  async startBattle() {
+    await this.runToSummon();
+
+    if (this.game.scene.battleStyle === BattleStyle.SWITCH) {
+      this.game.onNextPrompt("CheckSwitchPhase", Mode.CONFIRM, () => {
+        this.game.setMode(Mode.MESSAGE);
+        this.game.endPhase();
+      }, () => this.game.isCurrentPhase(CommandPhase) || this.game.isCurrentPhase(TurnInitPhase));
+
+      this.game.onNextPrompt("CheckSwitchPhase", Mode.CONFIRM, () => {
+        this.game.setMode(Mode.MESSAGE);
+        this.game.endPhase();
+      }, () => this.game.isCurrentPhase(CommandPhase) || this.game.isCurrentPhase(TurnInitPhase));
+    }
+
+    await this.game.phaseInterceptor.to(CommandPhase);
+    console.log("==================[New Turn]==================");
   }
 }


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Daily Mode was missing a function to run to the start of a battle

## What are the changes from a developer perspective?
Tests for Daily Mode can now start a wave and continue from there.

## How to test the changes?
Write a test using the new functions.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
