### PR TITLE
[Fix][Localization] Add missing pokemon summary natureFragment

### DIFF
--- a/src/locales/en/pokemon-summary.json
+++ b/src/locales/en/pokemon-summary.json
@@ -13,5 +13,32 @@
   "metFragment": {
     "normal": "met at Lv{{level}},\n{{biome}}.",
     "apparently": "apparently met at Lv{{level}},\n{{biome}}."
+  },
+  "natureFragment": {
+    "Hardy": "{{nature}}",
+    "Lonely": "{{nature}}",
+    "Brave": "{{nature}}",
+    "Adamant": "{{nature}}",
+    "Naughty": "{{nature}}",
+    "Bold": "{{nature}}",
+    "Docile": "{{nature}}",
+    "Relaxed": "{{nature}}",
+    "Impish": "{{nature}}",
+    "Lax": "{{nature}}",
+    "Timid": "{{nature}}",
+    "Hasty": "{{nature}}",
+    "Serious": "{{nature}}",
+    "Jolly": "{{nature}}",
+    "Naive": "{{nature}}",
+    "Modest": "{{nature}}",
+    "Mild": "{{nature}}",
+    "Quiet": "{{nature}}",
+    "Bashful": "{{nature}}",
+    "Rash": "{{nature}}",
+    "Calm": "{{nature}}",
+    "Gentle": "{{nature}}",
+    "Sassy": "{{nature}}",
+    "Careful": "{{nature}}",
+    "Quirky": "{{nature}}"
   }
 }

--- a/src/locales/ko/pokemon-summary.json
+++ b/src/locales/ko/pokemon-summary.json
@@ -13,5 +13,32 @@
   "metFragment": {
     "normal": "{{biome}}에서\n레벨 {{level}}일 때 만났다.",
     "apparently": "{{biome}}에서\n레벨 {{level}}일 때 만난 것 같다."
+  },
+  "natureFragment": {
+    "Hardy": "{{nature}}하는 성격",
+    "Lonely": "{{nature}}을 타는 성격",
+    "Brave": "{{nature}}한 성격",
+    "Adamant": "{{nature}}스러운 성격",
+    "Naughty": "{{nature}}같은 성격",
+    "Bold": "{{nature}}한 성격",
+    "Docile": "{{nature}}한 성격",
+    "Relaxed": "{{nature}}한 성격",
+    "Impish": "{{nature}}같은 성격",
+    "Lax": "{{nature}}거리는 성격",
+    "Timid": "{{nature}}같은 성격",
+    "Hasty": "{{nature}}한 성격",
+    "Serious": "{{nature}}한 성격",
+    "Jolly": "{{nature}}한 성격",
+    "Naive": "{{nature}}한 성격",
+    "Modest": "{{nature}}스러운 성격",
+    "Mild": "{{nature}}한 성격",
+    "Quiet": "{{nature}}한 성격",
+    "Bashful": "{{nature}}을 타는 성격",
+    "Rash": "{{nature}}거리는 성격",
+    "Calm": "{{nature}}한 성격",
+    "Gentle": "{{nature}}한 성격",
+    "Sassy": "{{nature}}진 성격",
+    "Careful": "{{nature}}한 성격",
+    "Quirky": "{{nature}}스러운 성격"
   }
 }

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -825,10 +825,7 @@ export default class SummaryUiHandler extends UiHandler {
           biome: `${getBBCodeFrag(getBiomeName(this.pokemon?.metBiome!), TextStyle.SUMMARY_RED)}${closeFragment}`, // TODO: is this bang correct?
           level: `${getBBCodeFrag(this.pokemon?.metLevel.toString()!, TextStyle.SUMMARY_RED)}${closeFragment}`, // TODO: is this bang correct?
         }),
-        natureFragment:
-          i18next.exists(`pokemonSummary:natureFragment.${rawNature}`) ?
-            i18next.t(`pokemonSummary:natureFragment.${rawNature}`, { nature: nature }) :
-            nature,
+        natureFragment: i18next.t(`pokemonSummary:natureFragment.${rawNature}`, { nature: nature })
       });
 
       const memoText = addBBCodeTextObject(this.scene, 7, 113, String(memoString), TextStyle.WINDOW_ALT);


### PR DESCRIPTION
## What are the changes the user will see?
Other language : No changes
Korean : Can see nature as og games. (like curren main, before 3rd beta merged.)

## Why am I making these changes?
gitlocalize removed Korean translation. https://github.com/pagefaultgames/pokerogue/pull/3773/files

## What are the changes from a developer perspective?
1. Add natureFragment key and value in en, ko > pokemon-summary.json
2. modify summary-ui-handler.ts to call it, not conditional(because condition always return true.)

### Screenshots/Videos
#### KO
* current main
![image](https://github.com/user-attachments/assets/b1399b3f-98ae-4288-8acf-9278996a1e79)

* current beta HEAD (After gitlocalize https://github.com/pagefaultgames/pokerogue/pull/3773)
![image](https://github.com/user-attachments/assets/c0132b6e-9ede-4a65-8474-9fdf169cfd4c)

* after fix
![image](https://github.com/user-attachments/assets/b8961acd-621b-43bf-a614-890209d14ee8)

#### EN (Test EN is safe)
![image](https://github.com/user-attachments/assets/b5b46325-8c81-4f38-b711-651c21732a86)

#### Other language (Without translation, also safe)
![image](https://github.com/user-attachments/assets/51bca9d5-a879-4cc6-b133-9ff189b904e5)

## How to test the changes?
Manually. (Just run game and open pokemon > choose pokemon > go Summary

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
