### PR TITLE
[Misc] Convert `trainer-config.ts` back to `\LF` eol

### DIFF
--- a/src/data/trainer-config.ts
+++ b/src/data/trainer-config.ts
@@ -1,22 +1,22 @@
-import BattleScene, {startingWave} from "../battle-scene";
-import {ModifierTypeFunc, modifierTypes} from "../modifier/modifier-type";
-import {EnemyPokemon} from "../field/pokemon";
+import BattleScene, { startingWave } from "../battle-scene";
+import { ModifierTypeFunc, modifierTypes } from "../modifier/modifier-type";
+import { EnemyPokemon } from "../field/pokemon";
 import * as Utils from "../utils";
-import {PokeballType} from "./pokeball";
-import {pokemonEvolutions, pokemonPrevolutions} from "./pokemon-evolutions";
-import PokemonSpecies, {getPokemonSpecies, PokemonSpeciesFilter} from "./pokemon-species";
-import {tmSpecies} from "./tms";
-import {Type} from "./type";
-import {doubleBattleDialogue} from "./dialogue";
-import {PersistentModifier} from "../modifier/modifier";
-import {TrainerVariant} from "../field/trainer";
-import {getIsInitialized, initI18n} from "#app/plugins/i18n";
+import { PokeballType } from "./pokeball";
+import { pokemonEvolutions, pokemonPrevolutions } from "./pokemon-evolutions";
+import PokemonSpecies, { getPokemonSpecies, PokemonSpeciesFilter } from "./pokemon-species";
+import { tmSpecies } from "./tms";
+import { Type } from "./type";
+import { doubleBattleDialogue } from "./dialogue";
+import { PersistentModifier } from "../modifier/modifier";
+import { TrainerVariant } from "../field/trainer";
+import { getIsInitialized, initI18n } from "#app/plugins/i18n";
 import i18next from "i18next";
-import {Moves} from "#enums/moves";
-import {PartyMemberStrength} from "#enums/party-member-strength";
-import {Species} from "#enums/species";
-import {TrainerType} from "#enums/trainer-type";
-import {Gender} from "./gender";
+import { Moves } from "#enums/moves";
+import { PartyMemberStrength } from "#enums/party-member-strength";
+import { Species } from "#enums/species";
+import { TrainerType } from "#enums/trainer-type";
+import { Gender } from "./gender";
 
 export enum TrainerPoolTier {
     COMMON,


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
The line endings got messed up.

## What are the changes from a developer perspective?
Should prevent the line endings from causing non-existent merge conflicts.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- ~[ ] Have I tested the changes (manually)?~
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
