### PR TITLE
[Bug][Beta] Run History Limit-Infinite Loop

### DIFF
--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -635,13 +635,13 @@ export class GameData {
   async saveRunHistory(scene: BattleScene, runEntry : SessionSaveData, isVictory: boolean): Promise<boolean> {
     const runHistoryData = await this.getRunHistoryData(scene);
     // runHistoryData should always return run history or {} empty object
-    const timestamps = Object.keys(runHistoryData);
-    const timestampsNo = timestamps.map(Number);
+    let timestamps = Object.keys(runHistoryData).map(Number);
 
     // Arbitrary limit of 25 entries per user --> Can increase or decrease
     while (timestamps.length >= RUN_HISTORY_LIMIT ) {
-      const oldestTimestamp = Math.min.apply(Math, timestampsNo);
+      const oldestTimestamp = (Math.min.apply(Math, timestamps)).toString();
       delete runHistoryData[oldestTimestamp];
+      timestamps = Object.keys(runHistoryData).map(Number);
     }
 
     const timestamp = (runEntry.timestamp).toString();


### PR DESCRIPTION
## What are the changes the user will see?
PokeRogue will no longer freeze when the user hits more than 25/the provided limit of entries in run history. 

## Why am I making these changes?
My feature, my mistake. 
I swear I fixed this earlier...

## What are the changes from a developer perspective?
The variable timestamps is no longer a constant and is updated at the end of the loop. 

### Screenshots/Videos

https://github.com/user-attachments/assets/fa5f64a3-8578-456e-99c0-ef2202d1a9c7

## How to test the changes?
- Have a full run history
- Complete a run
- The run should end normally and the run should be logged as expected.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
