### PR TITLE
[Balance] Randomized Biome after End Biome

### DIFF
--- a/src/data/biomes.ts
+++ b/src/data/biomes.ts
@@ -7664,8 +7664,9 @@ export function initBiomes() {
 
   const traverseBiome = (biome: Biome, depth: integer) => {
     while (biome === Biome.END) {
-      const randIndex = Utils.randInt(Object.values(Biome).length, 1);
-      biome = Biome[randIndex];
+      const biomeList = Object.values(Biome);
+      const randIndex = Utils.randInt(biomeList.length, 1);
+      biome = biomeList[randIndex];
     }
     const linkedBiomes: (Biome | [ Biome, integer ])[] = Array.isArray(biomeLinks[biome])
       ? biomeLinks[biome] as (Biome | [ Biome, integer ])[]

--- a/src/data/biomes.ts
+++ b/src/data/biomes.ts
@@ -7663,10 +7663,11 @@ export function initBiomes() {
   biomeDepths[Biome.TOWN] = [ 0, 1 ];
 
   const traverseBiome = (biome: Biome, depth: integer) => {
-    while (biome === Biome.END) {
-      const biomeList = Object.values(Biome);
+    if (biome === Biome.END) {
+      const biomeList = Object.keys(Biome).filter(key => !isNaN(Number(key)));
+      biomeList.pop(); // Removes Biome.END from the list
       const randIndex = Utils.randInt(biomeList.length, 2); // Will never be Biome.TOWN or Biome.PLAINS
-      biome = biomeList[randIndex];
+      biome = Biome[biomeList[randIndex]];
     }
     const linkedBiomes: (Biome | [ Biome, integer ])[] = Array.isArray(biomeLinks[biome])
       ? biomeLinks[biome] as (Biome | [ Biome, integer ])[]

--- a/src/data/biomes.ts
+++ b/src/data/biomes.ts
@@ -7665,7 +7665,7 @@ export function initBiomes() {
   const traverseBiome = (biome: Biome, depth: integer) => {
     while (biome === Biome.END) {
       const biomeList = Object.values(Biome);
-      const randIndex = Utils.randInt(biomeList.length, 1);
+      const randIndex = Utils.randInt(biomeList.length, 2); // Will never be Biome.TOWN or Biome.PLAINS
       biome = biomeList[randIndex];
     }
     const linkedBiomes: (Biome | [ Biome, integer ])[] = Array.isArray(biomeLinks[biome])

--- a/src/data/biomes.ts
+++ b/src/data/biomes.ts
@@ -7663,6 +7663,10 @@ export function initBiomes() {
   biomeDepths[Biome.TOWN] = [ 0, 1 ];
 
   const traverseBiome = (biome: Biome, depth: integer) => {
+    while (biome === Biome.END) {
+      const randIndex = Utils.randInt(Object.values(Biome).length, 1);
+      biome = Biome[randIndex];
+    }
     const linkedBiomes: (Biome | [ Biome, integer ])[] = Array.isArray(biomeLinks[biome])
       ? biomeLinks[biome] as (Biome | [ Biome, integer ])[]
       : [ biomeLinks[biome] as Biome ];


### PR DESCRIPTION
## What are the changes the user will see?
Users will no longer be stuck in a loop with Plains. 

## Why am I making these changes?
Damo please give all cat Pokemon OP moves and amazing passives. 

## What are the changes from a developer perspective?
In the function traverseBiome, if the Biome.END is passed to it, a random Biome is picked out of the list of biomes and the game then determines the new path based on that biome. This is achieved by using a while loop with a conditional that the new biome is not Biome.END again. 

### Screenshots/Videos

https://github.com/user-attachments/assets/901c8289-9540-4da9-99b7-6bac3b705d10

https://github.com/user-attachments/assets/2c236d97-b283-4360-9010-ce5b200e1de5

## How to test the changes?
- Defeat the boss on Wave X50/X00 of Endless
- The biome should be random. (Note: the biomes will never be end / plains / town)

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
