### PR TITLE
[UI] [QoL] [Enhancement] Exclude redundant species from certain filters in starter select

### DIFF
--- a/src/ui/dropdown.ts
+++ b/src/ui/dropdown.ts
@@ -23,6 +23,14 @@ export enum SortDirection {
   DESC = 1
 }
 
+export enum SortCriteria {
+  NUMBER = 0,
+  COST = 1,
+  CANDY = 2,
+  IV = 3,
+  NAME = 4
+}
+
 export class DropDownLabel {
   public state: DropDownState;
   public text: string;

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -39,13 +39,13 @@ import { Species } from "#enums/species";
 import {Button} from "#enums/buttons";
 import { EggSourceType } from "#app/enums/egg-source-types.js";
 import AwaitableUiHandler from "./awaitable-ui-handler";
-import { DropDown, DropDownLabel, DropDownOption, DropDownState, DropDownType } from "./dropdown";
+import { DropDown, DropDownLabel, DropDownOption, DropDownState, DropDownType, SortCriteria } from "./dropdown";
 import { StarterContainer } from "./starter-container";
 import { DropDownColumn, FilterBar } from "./filter-bar";
 import { ScrollBar } from "./scroll-bar";
 import { SelectChallengePhase } from "#app/phases/select-challenge-phase.js";
 import { TitlePhase } from "#app/phases/title-phase.js";
-import { Abilities } from "#app/enums/abilities.js";
+import { Abilities } from "#app/enums/abilities";
 
 export type StarterSelectCallback = (starters: Starter[]) => void;
 
@@ -502,11 +502,11 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
     // sort filter
     const sortOptions = [
-      new DropDownOption(this.scene, 0, new DropDownLabel(i18next.t("filterBar:sortByNumber"), undefined, DropDownState.ON)),
-      new DropDownOption(this.scene, 1, new DropDownLabel(i18next.t("filterBar:sortByCost"))),
-      new DropDownOption(this.scene, 2, new DropDownLabel(i18next.t("filterBar:sortByCandies"))),
-      new DropDownOption(this.scene, 3, new DropDownLabel(i18next.t("filterBar:sortByIVs"))),
-      new DropDownOption(this.scene, 4, new DropDownLabel(i18next.t("filterBar:sortByName")))
+      new DropDownOption(this.scene, SortCriteria.NUMBER, new DropDownLabel(i18next.t("filterBar:sortByNumber"), undefined, DropDownState.ON)),
+      new DropDownOption(this.scene, SortCriteria.COST, new DropDownLabel(i18next.t("filterBar:sortByCost"))),
+      new DropDownOption(this.scene, SortCriteria.CANDY, new DropDownLabel(i18next.t("filterBar:sortByCandies"))),
+      new DropDownOption(this.scene, SortCriteria.IV, new DropDownLabel(i18next.t("filterBar:sortByIVs"))),
+      new DropDownOption(this.scene, SortCriteria.NAME, new DropDownLabel(i18next.t("filterBar:sortByName")))
     ];
     this.filterBar.addFilter(DropDownColumn.SORT, i18next.t("filterBar:sortFilter"), new DropDown(this.scene, 0, 0, sortOptions, this.updateStarters, DropDownType.SINGLE));
     this.filterBarContainer.add(this.filterBar);
@@ -2364,6 +2364,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       // First, ensure you have the caught attributes for the species else default to bigint 0
       const caughtAttr = this.scene.gameData.dexData[container.species.speciesId]?.caughtAttr || BigInt(0);
       const starterData = this.scene.gameData.starterData[container.species.speciesId];
+      const isStarterProgressable = speciesEggMoves.hasOwnProperty(container.species.speciesId);
 
       // Gen filter
       const fitsGen =   this.filterBar.getVals(DropDownColumn.GEN).includes(container.species.generation);
@@ -2399,7 +2400,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         if (unlocks.val === "PASSIVE" && unlocks.state === DropDownState.ON) {
           return isPassiveUnlocked;
         } else if (unlocks.val === "PASSIVE" && unlocks.state === DropDownState.EXCLUDE) {
-          return !isPassiveUnlocked;
+          return isStarterProgressable && !isPassiveUnlocked;
         } else if (unlocks.val === "PASSIVE" && unlocks.state === DropDownState.UNLOCKABLE) {
           return isPassiveUnlockable;
         } else if (unlocks.val === "PASSIVE" && unlocks.state === DropDownState.OFF) {
@@ -2414,7 +2415,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         if (unlocks.val === "COST_REDUCTION" && unlocks.state === DropDownState.ON) {
           return isCostReduced;
         } else if (unlocks.val === "COST_REDUCTION" && unlocks.state === DropDownState.EXCLUDE) {
-          return !isCostReduced;
+          return isStarterProgressable && !isCostReduced;
         } else if (unlocks.val === "COST_REDUCTION" && unlocks.state === DropDownState.UNLOCKABLE) {
           return isCostReductionUnlockable;
         } else if (unlocks.val === "COST_REDUCTION" && unlocks.state === DropDownState.OFF) {
@@ -2469,7 +2470,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         if (misc.val === "EGG" && misc.state === DropDownState.ON) {
           return isEggPurchasable;
         } else if (misc.val === "EGG" && misc.state === DropDownState.EXCLUDE) {
-          return !isEggPurchasable;
+          return isStarterProgressable && !isEggPurchasable;
         } else if (misc.val === "EGG" && misc.state === DropDownState.OFF) {
           return true;
         }
@@ -2500,19 +2501,19 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       switch (sort.val) {
       default:
         break;
-      case 0:
+      case SortCriteria.NUMBER:
         return (a.species.speciesId - b.species.speciesId) * -sort.dir;
-      case 1:
+      case SortCriteria.COST:
         return (a.cost - b.cost) * -sort.dir;
-      case 2:
+      case SortCriteria.CANDY:
         const candyCountA = this.scene.gameData.starterData[a.species.speciesId].candyCount;
         const candyCountB = this.scene.gameData.starterData[b.species.speciesId].candyCount;
         return (candyCountA - candyCountB) * -sort.dir;
-      case 3:
+      case SortCriteria.IV:
         const avgIVsA = this.scene.gameData.dexData[a.species.speciesId].ivs.reduce((a, b) => a + b, 0) / this.scene.gameData.dexData[a.species.speciesId].ivs.length;
         const avgIVsB = this.scene.gameData.dexData[b.species.speciesId].ivs.reduce((a, b) => a + b, 0) / this.scene.gameData.dexData[b.species.speciesId].ivs.length;
         return (avgIVsA - avgIVsB) * -sort.dir;
-      case 4:
+      case SortCriteria.NAME:
         return a.species.name.localeCompare(b.species.name) * -sort.dir;
       }
       return 0;

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -45,6 +45,7 @@ import { DropDownColumn, FilterBar } from "./filter-bar";
 import { ScrollBar } from "./scroll-bar";
 import { SelectChallengePhase } from "#app/phases/select-challenge-phase.js";
 import { TitlePhase } from "#app/phases/title-phase.js";
+import { Abilities } from "#app/enums/abilities.js";
 
 export type StarterSelectCallback = (starters: Starter[]) => void;
 
@@ -2450,12 +2451,13 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       });
 
       // HA Filter
+      const speciesHasHiddenAbility = container.species.abilityHidden !== container.species.ability1 && container.species.abilityHidden !== Abilities.NONE;
       const hasHA = starterData.abilityAttr & AbilityAttr.ABILITY_HIDDEN;
       const fitsHA = this.filterBar.getVals(DropDownColumn.MISC).some(misc => {
         if (misc.val === "HIDDEN_ABILITY" && misc.state === DropDownState.ON) {
           return hasHA;
         } else if (misc.val === "HIDDEN_ABILITY" && misc.state === DropDownState.EXCLUDE) {
-          return !hasHA;
+          return speciesHasHiddenAbility && !hasHA;
         } else if (misc.val === "HIDDEN_ABILITY" && misc.state === DropDownState.OFF) {
           return true;
         }


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
- In the starter select UI, when filtering for mons you don't have the hidden ability of, mons who don't have an HA at all will be excluded
- When filtering for mons you don't have passive or any cost reduction unlocked for yet, starters who don't have candy (Pikachu et al) will be excluded

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
- The "Hidden Ability- No" option is useful for seeing which mons you haven't found the hidden ability of
- It's redundant and possibly misleading to show the player mons with nonexistent hidden abilities alongside mons with hidden abilities the player just hasn't found
- Same applies even moreso to passives and cost reductions
- This makes the filters more useful for giving an overview of goals for the player

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- Adds a speciesHasHiddenAbility check for the HA filter
- The condition for the exclude state now requires speciesHasHiddenAbility to be true as well as it not being unlocked
- Adds a isStarterProgressable check for a few other filters, whether that starter gets candy/egg moves/etc
- Adds an enum SortCriteria in dropdown.ts for the criteria by which the player can sort the starters

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
Before:
<img width="503" alt="Screenshot_868" src="https://github.com/user-attachments/assets/4e86d6fb-bf19-4267-8fc6-ea8cf35cd338">
Note the presence of Mew, which does not have a Hidden Ability at all.

After:
![image](https://github.com/user-attachments/assets/c95f9ee2-33b2-48da-a873-1f1d4c3fe724)
Note the absence of Mew between Mewtwo and Cyndaquil, as well as the rows starting with Drowzee appearing to have shifted one slot- Gastly has no hidden ability (unless #1845 is reconsidered), so Onix takes its place on that row and everything else shifts to the left.

Before:
<img width="763" alt="Screenshot_871" src="https://github.com/user-attachments/assets/2ba66d91-5b0a-4e6f-8fcb-7a17a79157be">
Note that many starters without candy, such as the Hitmons, Chansey, Snorlax etc. are shown

After:
<img width="759" alt="Screenshot_869" src="https://github.com/user-attachments/assets/be2a2dc9-ab64-4f32-a7c3-e8b2123f4625">
Bye bye

Before:
<img width="763" alt="Screenshot_872" src="https://github.com/user-attachments/assets/b0f53abc-3e33-4404-b855-e9a9e9c9be04">
Same as passive

After:
<img width="758" alt="Screenshot_870" src="https://github.com/user-attachments/assets/baf38461-c282-4d60-8b4b-3cface8d1969">

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
- [X] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
