### PR TITLE
Fix enemy sprite disappearing on Roar or Dragon Tail

### DIFF
--- a/src/data/battle-anims.ts
+++ b/src/data/battle-anims.ts
@@ -1,7 +1,7 @@
 //import { battleAnimRawData } from "./battle-anim-raw-data";
 import BattleScene from "../battle-scene";
 import { AttackMove, BeakBlastHeaderAttr, ChargeAttr, DelayedAttackAttr, MoveFlags, SelfStatusMove, allMoves } from "./move";
-import Pokemon from "../field/pokemon";
+import Pokemon, { EnemyPokemon } from "../field/pokemon";
 import * as Utils from "../utils";
 import { BattlerIndex } from "../battle";
 import { Element } from "json-stable-stringify";
@@ -787,12 +787,20 @@ export abstract class BattleAnim {
         targetSprite.setAlpha(1);
         targetSprite.pipelineData["tone"] = [ 0.0, 0.0, 0.0, 0.0 ];
         targetSprite.setAngle(0);
+        console.log(
+          "anim: ", this.getAnim()?.graphic,
+          "\n\tUser", user.name, " | this.user:", this.user?.name,
+          "\n\tTarget", target.name, " | this.target:", this.target?.name,
+          "\n\tIs Opponen Animation:", isOppAnim,
+          "\n\ttarget instanceof EnemyPokemon:", target instanceof EnemyPokemon,
+        );
         if (!this.isHideUser() && userSprite) {
           userSprite.setVisible(true);
         }
-        if (!this.isHideTarget() && (targetSprite !== userSprite || !this.isHideUser())) {
-          targetSprite.setVisible(true);
-        }
+        targetSprite.setVisible(true);
+        // if (!this.isHideTarget() && (targetSprite !== userSprite || !this.isHideUser())) {
+        //   targetSprite.setVisible(true);
+        // }
         for (const ms of Object.values(spriteCache).flat()) {
           if (ms) {
             ms.destroy();
@@ -1019,7 +1027,7 @@ export class MoveAnim extends BattleAnim {
   }
 
   isOppAnim(): boolean {
-    return !this.user?.isPlayer() && Array.isArray(moveAnims.get(this.move));
+    return !this.user?.isPlayer();
   }
 
   protected isHideUser(): boolean {


### PR DESCRIPTION
Fixes #481 

## What are the changes the user will see?

When an enemy uses `Roar` or `Dragon Tail` the sprite won't disappear anymore

## Why am I making these changes?

To fix #481 

## What are the changes from a developer perspective?

A battle animation was considered `isEnemy()` only if it wasn't the player pokemon and if `Array.isArray(moveAnims.get(this.move))` is `true`. According to @pom-eranian this might be a relict of the past as animation used to have definitions for player usage & enemy usage. 

After removing the `Array.isArray()` check Roar and Dragon Tail worked as expected.
The reason why it fixes it can be seen in [this](https://github.com/pagefaultgames/pokerogue/issues/481#issuecomment-2322322749) comment in issue #481 

### Screenshots/Videos

https://github.com/user-attachments/assets/069121f7-3b1c-4910-8e13-cb102824dbee

## How to test the changes?

```ts
const overrides = {
  OPP_MOVESET_OVERRIDE: [ Moves.ROAR, Moves.ROAR, Moves.ROAR, Moves.ROAR ],
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```
or
```ts
const overrides = {
  OPP_MOVESET_OVERRIDE: [ Moves.DRAGON_TAIL, Moves.DRAGON_TAIL, Moves.DRAGON_TAIL, Moves.DRAGON_TAIL ],
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
