### PR TITLE
[Bug] Menu can't be opened in shop after a trainer battle

### DIFF
--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -122,6 +122,9 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
   }
 
   show(args: any[]): boolean {
+
+    this.scene.disableMenu = false;
+
     if (this.active) {
       if (args.length >= 3) {
         this.awaitingActionInput = true;


### PR DESCRIPTION
## What are the changes the user will see?
This attempts to fix a bug where the menu can't be opened up in the shop after a trainer battle

## Why am I making these changes?
Currently you can't open the menu in a shop after a trainer battle

## What are the changes from a developer perspective?
scene has a boolean for disableMenu. During the trainer victory phase, this is set to true, which is then used throughout the shop, disabling the menu. This makes it so whenever the shop is opened, disableMenu is set to false, thus enabling the menu.

### Screenshots/Videos
This is how it currently is in beta (even when trying to open the menu):

![image](https://github.com/user-attachments/assets/c895fb7a-0668-4c69-9e6f-035d6b8d4b19)

This is how it is with the fix:

![image](https://github.com/user-attachments/assets/a13a1bd3-728c-4d1c-9f2a-61cc5ce4c523)

## How to test the changes?
Download this PR, get to trainer wave and attempt to open the menu. Also make sure that this doesn't have any negative side effects of allowing the menu to open where it shouldn't. It doesn't open when you go to "check team" - this is intended and separate to this, so that functionality should still work

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
