### PR TITLE
 [Bug] Fix Octolock Ignores Clear Body, White Smoke, Big Pecks #3876

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -750,7 +750,7 @@ export class OctolockTag extends TrappedTag {
     const shouldLapse = lapseType !== BattlerTagLapseType.CUSTOM || super.lapse(pokemon, lapseType);
 
     if (shouldLapse) {
-      pokemon.scene.unshiftPhase(new StatChangePhase(pokemon.scene, pokemon.getBattlerIndex(), true, [BattleStat.DEF, BattleStat.SPDEF], -1));
+      pokemon.scene.unshiftPhase(new StatChangePhase(pokemon.scene, pokemon.getBattlerIndex(), false, [BattleStat.DEF, BattleStat.SPDEF], -1));
       return true;
     }
 

--- a/src/test/moves/octolock.test.ts
+++ b/src/test/moves/octolock.test.ts
@@ -61,6 +61,48 @@ describe("Moves - Octolock", () => {
       expect(enemyPokemon[0].summonData.battleStats[BattleStat.SPDEF]).toBe(-2);
     });
 
+    it("If target pokemon has Big Pecks, Octolock should only reduce spdef by 1", { timeout: 10000 }, async () => {
+      game.override.enemyAbility(Abilities.BIG_PECKS);
+      await game.startBattle([Species.GRAPPLOCT]);
+
+      const enemyPokemon = game.scene.getEnemyField();
+
+      // use Octolock and advance to init phase of next turn to check for stat changes
+      game.move.select(Moves.OCTOLOCK);
+      await game.phaseInterceptor.to(TurnInitPhase);
+
+      expect(enemyPokemon[0].summonData.battleStats[BattleStat.DEF]).toBe(0);
+      expect(enemyPokemon[0].summonData.battleStats[BattleStat.SPDEF]).toBe(-1);
+    });
+
+    it("If target pokemon has White Smoke, Octolock should not reduce any stats", { timeout: 10000 }, async () => {
+      game.override.enemyAbility(Abilities.WHITE_SMOKE);
+      await game.startBattle([Species.GRAPPLOCT]);
+
+      const enemyPokemon = game.scene.getEnemyField();
+
+      // use Octolock and advance to init phase of next turn to check for stat changes
+      game.move.select(Moves.OCTOLOCK);
+      await game.phaseInterceptor.to(TurnInitPhase);
+
+      expect(enemyPokemon[0].summonData.battleStats[BattleStat.DEF]).toBe(0);
+      expect(enemyPokemon[0].summonData.battleStats[BattleStat.SPDEF]).toBe(0);
+    });
+
+    it("If target pokemon has Clear Body, Octolock should not reduce any stats", { timeout: 10000 }, async () => {
+      game.override.enemyAbility(Abilities.CLEAR_BODY);
+      await game.startBattle([Species.GRAPPLOCT]);
+
+      const enemyPokemon = game.scene.getEnemyField();
+
+      // use Octolock and advance to init phase of next turn to check for stat changes
+      game.move.select(Moves.OCTOLOCK);
+      await game.phaseInterceptor.to(TurnInitPhase);
+
+      expect(enemyPokemon[0].summonData.battleStats[BattleStat.DEF]).toBe(0);
+      expect(enemyPokemon[0].summonData.battleStats[BattleStat.SPDEF]).toBe(0);
+    });
+
     it("Traps the target pokemon", { timeout: 10000 }, async () => {
       await game.startBattle([Species.GRAPPLOCT]);
 


### PR DESCRIPTION
## What are the changes the user will see?
Fix https://github.com/pagefaultgames/pokerogue/issues/3876
User should now appropriately see octolock lowering only spdef for big pecks, and lowering neither stat for white smoke and clear body users

## Why am I making these changes?
To fix [https://github.com/pagefaultgames/pokerogue/issues/3876](link)

## What are the changes from a developer perspective?
In src/battler-tags.ts, on line 753 
`      pokemon.scene.unshiftPhase(new StatChangePhase(pokemon.scene, pokemon.getBattlerIndex(), true, [BattleStat.DEF, BattleStat.SPDEF], -1));
`

The system incorrectly assumed that octolock was a self targeting move, which was messing with the ability from cancelling out the effect as intended. I changed it to: 

'      pokemon.scene.unshiftPhase(new StatChangePhase(pokemon.scene, pokemon.getBattlerIndex(), false, [BattleStat.DEF, BattleStat.SPDEF], -1));
'


### Screenshots/Videos


https://github.com/user-attachments/assets/35342e57-6530-42ba-85d5-e8558d7b40c0


## How to test the changes?
Use the override file to give the opponent octolock, and your own pokemon clear body, white smoke, or big pecks 
Use the new tests provided in the src/tests/moves/octolock.test.ts file

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
