### PR TITLE
[Beta][Bug] Run info game pad fix

### DIFF
--- a/index.css
+++ b/index.css
@@ -148,10 +148,10 @@ input:-internal-autofill-selected {
 
 /* Show cycle buttons only on STARTER_SELECT and on touch configuration panel */
 #touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT']) #apadOpenFilters,
-#touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT']) #apadCycleForm,
-#touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT']) #apadCycleShiny,
+#touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT'], [data-ui-mode='RUN_INFO']) #apadCycleForm,
+#touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT'], [data-ui-mode='RUN_INFO']) #apadCycleShiny,
 #touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT']) #apadCycleNature,
-#touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT']) #apadCycleAbility,
+#touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT'], [data-ui-mode='RUN_INFO']) #apadCycleAbility,
 #touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT']) #apadCycleGender,
 #touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT']) #apadCycleVariant {
  display: none;


### PR DESCRIPTION
## What are the changes the user will see?
Mobile users can access buttons on RunInfo.

## Why am I making these changes?
My feature. Mobile users may be unable to see the screen but they will have their buttons.

## What are the changes from a developer perspective?
CSS updated to have gamepad buttons visible if Mode = RUN_INFO too.

### Screenshots/Videos
![image](https://github.com/user-attachments/assets/b717a066-8079-4179-a277-bbf0893c2857)
![image](https://github.com/user-attachments/assets/8d4d5a4c-451b-41e1-a8de-08c2db98de52)

## How to test the changes?
Go to Run Info with the gamepad open.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
