### PR TITLE
[UI][Misc] Force users to have an active challenge

### DIFF
--- a/src/locales/en/challenges.json
+++ b/src/locales/en/challenges.json
@@ -1,6 +1,7 @@
 {
   "title": "Challenge Modifiers",
   "illegalEvolution": "{{pokemon}} changed into an ineligble pokémon\nfor this challenge!",
+  "noneSelected": "None Selected",
   "singleGeneration": {
     "name": "Mono Gen",
     "desc": "You can only use Pokémon from Generation {{gen}}.",

--- a/src/ui/challenges-select-ui-handler.ts
+++ b/src/ui/challenges-select-ui-handler.ts
@@ -276,14 +276,10 @@ export default class GameChallengesUiHandler extends UiHandler {
     let success = false;
 
     if (button === Button.CANCEL) {
-      if (this.startCursor.visible) {
-        this.startCursor.setVisible(false);
-        this.cursorObj?.setVisible(true);
-      } else {
-        this.scene.clearPhaseQueue();
-        this.scene.pushPhase(new TitlePhase(this.scene));
-        this.scene.getCurrentPhase()?.end();
-      }
+
+      this.scene.clearPhaseQueue();
+      this.scene.pushPhase(new TitlePhase(this.scene));
+      this.scene.getCurrentPhase()?.end();
       success = true;
     } else if (button === Button.SUBMIT || button === Button.ACTION) {
       if (this.hasSelectedChallenge) {

--- a/src/ui/challenges-select-ui-handler.ts
+++ b/src/ui/challenges-select-ui-handler.ts
@@ -28,7 +28,6 @@ export default class GameChallengesUiHandler extends UiHandler {
 
   private descriptionText: BBCodeText;
 
-
   private challengeLabels: Array<{ label: Phaser.GameObjects.Text, value: Phaser.GameObjects.Text }>;
   private monoTypeValue: Phaser.GameObjects.Sprite;
 

--- a/src/ui/challenges-select-ui-handler.ts
+++ b/src/ui/challenges-select-ui-handler.ts
@@ -37,7 +37,7 @@ export default class GameChallengesUiHandler extends UiHandler {
   private startBg: Phaser.GameObjects.NineSlice;
   private startCursor: Phaser.GameObjects.NineSlice;
   private startText: Phaser.GameObjects.Text;
-  private hasActiveChallenge: boolean;
+  private hasSelectedChallenge: boolean;
 
   private optionsWidth: number;
 
@@ -220,8 +220,8 @@ export default class GameChallengesUiHandler extends UiHandler {
       this.monoTypeValue.setVisible(false);
     }
 
-    this.hasActiveChallenge = this.scene.gameMode.challenges.some(c => c.value !== 0);
-    if (this.hasActiveChallenge) {
+    this.hasSelectedChallenge = this.scene.gameMode.challenges.some(c => c.value !== 0);
+    if (this.hasSelectedChallenge) {
       this.startText.setText(i18next.t("common:start"));
       this.startText.setAlpha(1);
       this.startText.setPositionRelative(this.startBg, (this.startBg.width - this.startText.displayWidth) / 2, 4);
@@ -243,7 +243,7 @@ export default class GameChallengesUiHandler extends UiHandler {
 
     this.startCursor.setVisible(false);
     this.challengesContainer.setVisible(true);
-    this.hasActiveChallenge = this.scene.gameMode.challenges.some(c => c.value !== 0);
+    this.hasSelectedChallenge = this.scene.gameMode.challenges.some(c => c.value !== 0);
     this.setCursor(0);
 
     this.initLabels();
@@ -283,7 +283,7 @@ export default class GameChallengesUiHandler extends UiHandler {
       }
       success = true;
     } else if (button === Button.SUBMIT || button === Button.ACTION) {
-      if (this.hasActiveChallenge) {
+      if (this.hasSelectedChallenge) {
         this.startCursor.setVisible(true);
         this.cursorObj?.setVisible(false);
         if (this.startCursor.visible) {

--- a/src/ui/challenges-select-ui-handler.ts
+++ b/src/ui/challenges-select-ui-handler.ts
@@ -221,10 +221,14 @@ export default class GameChallengesUiHandler extends UiHandler {
 
     this.hasSelectedChallenge = this.scene.gameMode.challenges.some(c => c.value !== 0);
     if (this.hasSelectedChallenge) {
+
+      this.startCursor.setVisible(true);
       this.startText.setText(i18next.t("common:start"));
       this.startText.setAlpha(1);
       this.startText.setPositionRelative(this.startBg, (this.startBg.width - this.startText.displayWidth) / 2, 4);
     } else {
+
+      this.startCursor.setVisible(false);
       this.startText.setText(i18next.t("challenges:noneSelected"));
       this.startText.setAlpha(0.5);
       this.startText.setPositionRelative(this.startBg, (this.startBg.width - this.startText.displayWidth) / 2, 4);
@@ -283,8 +287,6 @@ export default class GameChallengesUiHandler extends UiHandler {
       success = true;
     } else if (button === Button.SUBMIT || button === Button.ACTION) {
       if (this.hasSelectedChallenge) {
-        this.startCursor.setVisible(true);
-        this.cursorObj?.setVisible(false);
         if (this.startCursor.visible) {
           this.scene.unshiftPhase(new SelectStarterPhase(this.scene));
           this.scene.getCurrentPhase()?.end();

--- a/src/ui/challenges-select-ui-handler.ts
+++ b/src/ui/challenges-select-ui-handler.ts
@@ -219,6 +219,7 @@ export default class GameChallengesUiHandler extends UiHandler {
       this.monoTypeValue.setVisible(false);
     }
 
+    // This checks if a challenge has been selected by the user and updates the text/its opacity accordingly.
     this.hasSelectedChallenge = this.scene.gameMode.challenges.some(c => c.value !== 0);
     if (this.hasSelectedChallenge) {
 
@@ -244,6 +245,7 @@ export default class GameChallengesUiHandler extends UiHandler {
 
     this.startCursor.setVisible(false);
     this.challengesContainer.setVisible(true);
+    // Should always be false at the start
     this.hasSelectedChallenge = this.scene.gameMode.challenges.some(c => c.value !== 0);
     this.setCursor(0);
 
@@ -275,6 +277,7 @@ export default class GameChallengesUiHandler extends UiHandler {
 
     if (button === Button.CANCEL) {
       if (this.startCursor.visible) {
+        // If the user presses cancel when the start cursor has been activated, the game deactivates the start cursor and allows typical challenge selection behavior
         this.startCursor.setVisible(false);
         this.cursorObj?.setVisible(true);
       } else {


### PR DESCRIPTION
## What are the changes the user will see?
The user will not able to continue from the Challenges Select UI if no challenges are currently active. The 'Start' button text will only appear if the user has activated a challenge. If the user hasn't, the button text will be set to "None Selected"

## Why am I making these changes?
pokemon go to school

## What are the changes from a developer perspective?
- new class variable 'hasActiveChallenge' that is a boolean determined by if the user has activated a challenge and determines if the user is eligible to continue into the starter select screen
- new UI behavior that responsively reacts to the user's actions and indicate to them whether a challenge has been selected or not

### Screenshots/Videos

https://github.com/user-attachments/assets/984a61b7-539f-4925-9d62-f51952ace36d

## How to test the changes?
Try to access the starter select UI without activating a challenge

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
