### PR TITLE
[Hotfix][Bug] Unneeded RNG calls

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -133,9 +133,6 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       this.scene.applyModifiers(HiddenAbilityRateBoosterModifier, true, hiddenAbilityChance);
     }
 
-    const hasHiddenAbility = !Utils.randSeedInt(hiddenAbilityChance.value);
-    const randAbilityIndex = Utils.randSeedInt(2);
-
     this.species = species;
     this.pokeball = dataSource?.pokeball || PokeballType.POKEBALL;
     this.level = level;
@@ -146,6 +143,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       this.abilityIndex = abilityIndex; // Use the provided ability index if it is defined
     } else {
       // If abilityIndex is not provided, determine it based on species and hidden ability
+      const hasHiddenAbility = !Utils.randSeedInt(hiddenAbilityChance.value);
+      const randAbilityIndex = Utils.randSeedInt(2);
       if (species.abilityHidden && hasHiddenAbility) {
         // If the species has a hidden ability and the hidden ability is present
         this.abilityIndex = 2;


### PR DESCRIPTION
## What are the changes the user will see?
RNG will be unaffected by accessing save-slot-select UI, run history UI, or run-info UI.  

## Why am I making these changes?
Bug Report: https://discord.com/channels/1125469663833370665/1279928555186290698/1280005345321816136 

## What are the changes from a developer perspective?
The RNG calls have been moved until after the Pokemon has been checked for an ability index. Because the PokemonData involved in these UIs already have an ability index, the RNG calls will not be called. This will not affect Pokemon generation for battle. 

### Screenshots/Videos
Will upload a run tomorrow morning. Sorry, very tired. Feel free to test though.

## How to test the changes?
Start and play a wave (do not complete) --> Save and Quit --> Open Run History/Load Save/Run Info --> Go back to the wave and repeat the same actions.
The second playthrough should be identical in results to the first playthrough. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
