### PR TITLE
 [Bug] Fix sleep move failure text not appearing on Electric Terrain

### DIFF
--- a/src/data/dialogue.ts
+++ b/src/data/dialogue.ts
@@ -1,6 +1,6 @@
 import { BattleSpec } from "#enums/battle-spec";
 import { TrainerType } from "#enums/trainer-type";
-import {trainerConfigs} from "./trainer-config";
+import { trainerConfigs } from "./trainer-config";
 
 export interface TrainerTypeMessages {
     encounter?: string | string[],
@@ -704,6 +704,20 @@ export const trainerTypeDialogue: TrainerTypeDialogue = {
         "dialogue:zinzolin.victory.1",
         "dialogue:zinzolin.victory.2",
         "dialogue:zinzolin.victory.3",
+      ]
+    }
+  ],
+  [TrainerType.ROOD]: [
+    {
+      encounter: [
+        "dialogue:rood.encounter.1",
+        "dialogue:rood.encounter.2",
+        "dialogue:rood.encounter.3",
+      ],
+      victory: [
+        "dialogue:rood.victory.1",
+        "dialogue:rood.victory.2",
+        "dialogue:rood.victory.3",
       ]
     }
   ],

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2861,10 +2861,10 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * @param quiet a boolean value that is sometimes used as the asPhase boolean which in this case affects that.
    * @param overrideStatus a boolean value to determine whether a status should be overriden.  If true, the pokemon cannot be statused essentially
    * @param sourcePokemon {@linkcode Pokemon} The pokemon causing the status.  The target pokemon is 'this'.
-   * @returns true if the pokemon can be affected by the status, false if not.
+   * @returns true if the pokemon can be affected by the status, false if not.  Also, while not a return value, it will apply applyPreSetStatusAbAttrs which means this function should be used sparingly compared to checkIfCanSetStatus
    */
   canSetStatus(effect: StatusEffect | undefined, quiet: boolean = false, overrideStatus: boolean = false, sourcePokemon: Pokemon | null = null): boolean {
-    const canSetStatus = this.checkIfCanSetStatus(effect, quiet, overrideStatus, sourcePokemon);
+    const canSetStatusResult = this.checkIfCanSetStatus(effect, quiet, overrideStatus, sourcePokemon);
 
     const cancelled = new Utils.BooleanHolder(false);
     applyPreSetStatusAbAttrs(StatusEffectImmunityAbAttr, this, effect, cancelled, quiet);
@@ -2876,7 +2876,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       return false;
     }
 
-    return canSetStatus;
+    return canSetStatusResult;
   }
 
   trySetStatus(effect: StatusEffect | undefined, asPhase: boolean = false, sourcePokemon: Pokemon | null = null, cureTurn: integer | null = 0, sourceText: string | null = null): boolean {


### PR DESCRIPTION
This fix is for this issue:
https://github.com/pagefaultgames/pokerogue/issues/3722

## What are the changes the user will see?
The user will now, when attempting to put a pokemon to sleep on electric terrain, will receive a message why it failed

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
I needed to add fixes to drowsy (from yawn) as well as to the tryStatusEffect 
<!-- Does it come from an issue or another PR? Please link it -->

<!-- Explain why you believe this can enhance user experience -->
Makes it more similar to the mainline games and pokemon showdown

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
A simple change was added in the drowsy state check so that the message will appear.  I also had to add logic to the final


### Screenshots/Videos
See below

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
I used override, I honestly am not sure how best to test yet.  I set my pokemon to Tapu Koko with spore and yawn as moves and the opponent as well to test.   Below is the basic override to see things. 
```
  readonly STARTER_SPECIES_OVERRIDE: Species | number = Species.TAPU_KOKO;
  readonly ABILITY_OVERRIDE: Abilities = Abilities.NONE;
  readonly PASSIVE_ABILITY_OVERRIDE: Abilities = Abilities.NONE;
  readonly STATUS_OVERRIDE: StatusEffect = StatusEffect.NONE;
  readonly GENDER_OVERRIDE: Gender | null = null;
  readonly MOVESET_OVERRIDE: Array<Moves> = [Moves.SPORE, Moves.YAWN];
  readonly SHINY_OVERRIDE: boolean = false;
  readonly VARIANT_OVERRIDE: Variant = 0;
```




## Checklist
- [x] **I'm using `beta` as my base branch**
- I set the target branch to beta
- [x] There is no overlap with another PR?
- Not sure how best to look at this but I confirmed in the issue that I would fix it
- [x] The PR is self-contained and cannot be split into smaller PRs?
- Yes
- [x] Have I provided a clear explanation of the changes?
- Yes
- [ ] Have I considered writing automated tests for the issue?
- I considered it but decided no for now
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- Text was already there.  Just no triggering logic
- [x] Have I tested the changes (manually)?
-  Yes
    - [ ] Are all unit tests still passing? (`npm run test`)
    - No?  But I honestly am not sure how my code might be causing issues.  
    

> FAIL  |main| src/test/moves/flower_shield.test.ts > Moves - Flower Shield > does not increase defense of a pokemon in semi-vulnerable state
> AssertionError: expected +0 to be 1 // Object.is equality
> 
> - Expected
> + Received
> 
> - 1
> + 0
> 

- [x] Are the changes visual?
  - Yes

Original Issue on display

https://github.com/user-attachments/assets/9658fa79-3638-4274-9a0a-b6f48862a5ec

Fixes both with spore and sing to showcase 


https://github.com/user-attachments/assets/92bb4ba5-5a34-4019-8069-9d0a88a61027


https://github.com/user-attachments/assets/044916ef-c235-4aaa-b343-54e8c079406c

 