### PR TITLE
[Bug] Ineligible Pokemon will not contribute to luck in a challenge

### DIFF
--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -2225,7 +2225,7 @@ export class ModifierTypeOption {
 }
 
 export function getPartyLuckValue(party: Pokemon[]): integer {
-  const luck = Phaser.Math.Clamp(party.map(p => p.isFainted() ? 0 : p.getLuck())
+  const luck = Phaser.Math.Clamp(party.map(p => p.isAllowedInBattle() ? p.getLuck() : 0)
     .reduce((total: integer, value: integer) => total += value, 0), 0, 14);
   return luck || 0;
 }


### PR DESCRIPTION
## What are the changes the user will see?
Ineligible Pokemon will not contribute to luck in a challenge.

## Why am I making these changes?
Against game design.
Issue #3955

## What are the changes from a developer perspective?
The conditional used in getPartyLuckValue() to filter eligible Pokemon has been changed from p.isFainted() to p.isAllowedInBattle() --> which also checks if the Pokemon is fainted.
The ternary has also been reversed for readability to the below.
p.isAllowedInBattle() ? p.getLuckValue : 0

### Screenshots/Videos
Video #1 : MonoGen 3 -> numerous shiny ineligible Pokemon were caught with no change to luck

https://github.com/user-attachments/assets/c9483066-34aa-4413-96db-214f3d0ac617

Video #2 : MonoGen 1 --> eligible shiny Weedle caught (Luck up!) + ineligible shiny Bidoof caught (No change to Luck) 

https://github.com/user-attachments/assets/2b79b726-72fd-4947-8f40-6264f11928be


## How to test the changes?
Be lucky like me.

Or use the overrides to guarantee shinies and start a species-restrictive challenge. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
