### PR TITLE
[Test] Set boss Pokémon test timeout to 20 seconds instead of 2.5 seconds

### DIFF
--- a/src/test/boss-pokemon.test.ts
+++ b/src/test/boss-pokemon.test.ts
@@ -10,7 +10,7 @@ import { EnemyPokemon } from "#app/field/pokemon";
 import { toDmgValue } from "#app/utils";
 
 describe("Boss Pokemon / Shields", () => {
-  const TIMEOUT = 2500;
+  const TIMEOUT = 20 * 1000;
 
   let phaserGame: Phaser.Game;
   let game: GameManager;


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
The timeout was set too short, causing the test to fail due to running too long.

## What are the changes from a developer perspective?
The timeout for tests in the `boss-pokemon.test.ts` file was changed from 2.5 seconds to 20 seconds.

## How to test the changes?
`npm run test boss-pokemon`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
