### PR TITLE
[Test] Remove nature RNG from Beast Boost tests

### DIFF
--- a/src/test/abilities/beast_boost.test.ts
+++ b/src/test/abilities/beast_boost.test.ts
@@ -1,15 +1,12 @@
-import { Stat } from "#enums/stat";
-import GameManager from "#test/utils/gameManager";
+import { BattlerIndex } from "#app/battle";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
+import { Stat } from "#enums/stat";
+import GameManager from "#test/utils/gameManager";
+import { SPLASH_ONLY } from "#test/utils/testUtils";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { SPLASH_ONLY } from "../utils/testUtils";
-import { EnemyCommandPhase } from "#app/phases/enemy-command-phase";
-import { VictoryPhase } from "#app/phases/victory-phase";
-import { TurnStartPhase } from "#app/phases/turn-start-phase";
-import { BattlerIndex } from "#app/battle";
 
 describe("Abilities - Beast Boost", () => {
   let phaserGame: Phaser.Game;
@@ -37,49 +34,44 @@ describe("Abilities - Beast Boost", () => {
       .enemyMoveset(SPLASH_ONLY);
   });
 
-  // Note that both MOXIE and BEAST_BOOST test for their current implementation and not their mainline behavior.
   it("should prefer highest stat to boost its corresponding stat stage by 1 when winning a battle", async() => {
-    // SLOWBRO's highest stat is DEF, so it should be picked here
-    await game.startBattle([
-      Species.SLOWBRO
-    ]);
+    await game.classicMode.startBattle([Species.SLOWBRO]);
 
     const playerPokemon = game.scene.getPlayerPokemon()!;
+    // Set the pokemon's highest stat to DEF, so it should be picked by Beast Boost
+    vi.spyOn(playerPokemon, "stats", "get").mockReturnValue([ 10000, 100, 1000, 200, 100, 100 ]);
+    console.log(playerPokemon.stats);
 
     expect(playerPokemon.getStatStage(Stat.DEF)).toBe(0);
 
     game.move.select(Moves.FLAMETHROWER);
-    await game.phaseInterceptor.runFrom(EnemyCommandPhase).to(VictoryPhase);
+    await game.phaseInterceptor.to("VictoryPhase");
 
     expect(playerPokemon.getStatStage(Stat.DEF)).toBe(1);
   }, 20000);
 
   it("should use in-battle overriden stats when determining the stat stage to raise by 1", async() => {
-    // If the opponent can GUARD_SPLIT, SLOWBRO's second highest stat should be SPATK
     game.override.enemyMoveset(new Array(4).fill(Moves.GUARD_SPLIT));
 
-    await game.startBattle([
-      Species.SLOWBRO
-    ]);
+    await game.classicMode.startBattle([Species.SLOWBRO]);
 
     const playerPokemon = game.scene.getPlayerPokemon()!;
+    // If the opponent uses Guard Split, the pokemon's second highest stat (SPATK) should be chosen
+    vi.spyOn(playerPokemon, "stats", "get").mockReturnValue([ 10000, 100, 201, 200, 100, 100 ]);
 
     expect(playerPokemon.getStatStage(Stat.SPATK)).toBe(0);
 
     game.move.select(Moves.FLAMETHROWER);
 
     await game.setTurnOrder([ BattlerIndex.ENEMY, BattlerIndex.PLAYER ]);
-
-    await game.phaseInterceptor.runFrom(TurnStartPhase).to(VictoryPhase);
+    await game.phaseInterceptor.to("VictoryPhase");
 
     expect(playerPokemon.getStatStage(Stat.SPATK)).toBe(1);
   }, 20000);
 
   it("should have order preference in case of stat ties", async() => {
     // Order preference follows the order of EFFECTIVE_STAT
-    await game.startBattle([
-      Species.SLOWBRO
-    ]);
+    await game.classicMode.startBattle([Species.SLOWBRO]);
 
     const playerPokemon = game.scene.getPlayerPokemon()!;
 
@@ -90,7 +82,7 @@ describe("Abilities - Beast Boost", () => {
 
     game.move.select(Moves.FLAMETHROWER);
 
-    await game.phaseInterceptor.runFrom(EnemyCommandPhase).to(VictoryPhase);
+    await game.phaseInterceptor.to("VictoryPhase");
 
     expect(playerPokemon.getStatStage(Stat.SPATK)).toBe(1);
   }, 20000);


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
The test can randomly fail.

## What are the changes from a developer perspective?
The player Pokémon's stats array is mocked so that the test assumptions are always true.

## How to test the changes?
`npm run test beast_boost`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
