### PR TITLE
Starter select defaults to shiny with highest variant again

### DIFF
--- a/src/test/ui/starter-select.test.ts
+++ b/src/test/ui/starter-select.test.ts
@@ -53,9 +53,6 @@ describe("UI - Starter select", () => {
       const handler = game.scene.ui.getHandler() as StarterSelectUiHandler;
       handler.processInput(Button.RIGHT);
       handler.processInput(Button.LEFT);
-      handler.processInput(Button.CYCLE_SHINY);
-      handler.processInput(Button.V);
-      handler.processInput(Button.V);
       handler.processInput(Button.ACTION);
       game.phaseInterceptor.unlock();
     });
@@ -117,9 +114,6 @@ describe("UI - Starter select", () => {
       handler.processInput(Button.RIGHT);
       handler.processInput(Button.LEFT);
       handler.processInput(Button.CYCLE_GENDER);
-      handler.processInput(Button.CYCLE_SHINY);
-      handler.processInput(Button.V);
-      handler.processInput(Button.V);
       handler.processInput(Button.ACTION);
       game.phaseInterceptor.unlock();
     });
@@ -184,9 +178,6 @@ describe("UI - Starter select", () => {
       handler.processInput(Button.CYCLE_GENDER);
       handler.processInput(Button.CYCLE_NATURE);
       handler.processInput(Button.CYCLE_ABILITY);
-      handler.processInput(Button.CYCLE_SHINY);
-      handler.processInput(Button.V);
-      handler.processInput(Button.V);
       handler.processInput(Button.ACTION);
       game.phaseInterceptor.unlock();
     });
@@ -227,11 +218,12 @@ describe("UI - Starter select", () => {
     expect(game.scene.getParty()[0].species.speciesId).toBe(Species.BULBASAUR);
     expect(game.scene.getParty()[0].shiny).toBe(true);
     expect(game.scene.getParty()[0].variant).toBe(2);
+    expect(game.scene.getParty()[0].gender).toBe(Gender.FEMALE);
     expect(game.scene.getParty()[0].nature).toBe(Nature.LONELY);
     expect(game.scene.getParty()[0].getAbility().id).toBe(Abilities.CHLOROPHYLL);
   }, 20000);
 
-  it("Bulbasaur - shiny - variant 2 female lonely chlorophyl", async() => {
+  it("Bulbasaur - shiny - variant 2 female", async() => {
     await game.importData("src/test/utils/saves/everything.prsv");
     const caughtCount = Object.keys(game.scene.gameData.dexData).filter((key) => {
       const species = game.scene.gameData.dexData[key];
@@ -249,9 +241,6 @@ describe("UI - Starter select", () => {
       handler.processInput(Button.RIGHT);
       handler.processInput(Button.LEFT);
       handler.processInput(Button.CYCLE_GENDER);
-      handler.processInput(Button.CYCLE_SHINY);
-      handler.processInput(Button.V);
-      handler.processInput(Button.V);
       handler.processInput(Button.ACTION);
       game.phaseInterceptor.unlock();
     });
@@ -313,6 +302,7 @@ describe("UI - Starter select", () => {
       handler.processInput(Button.RIGHT);
       handler.processInput(Button.LEFT);
       handler.processInput(Button.ACTION);
+      handler.processInput(Button.CYCLE_SHINY);
       game.phaseInterceptor.unlock();
     });
     await game.phaseInterceptor.run(SelectStarterPhase);
@@ -371,7 +361,7 @@ describe("UI - Starter select", () => {
       const handler = game.scene.ui.getHandler() as StarterSelectUiHandler;
       handler.processInput(Button.RIGHT);
       handler.processInput(Button.LEFT);
-      handler.processInput(Button.CYCLE_SHINY);
+      handler.processInput(Button.V);
       handler.processInput(Button.V);
       handler.processInput(Button.ACTION);
       game.phaseInterceptor.unlock();
@@ -415,7 +405,7 @@ describe("UI - Starter select", () => {
     expect(game.scene.getParty()[0].variant).toBe(1);
   }, 20000);
 
-  it("Bulbasaur - shiny - variant 2", async() => {
+  it("Bulbasaur - shiny - variant 0", async() => {
     await game.importData("src/test/utils/saves/everything.prsv");
     const caughtCount = Object.keys(game.scene.gameData.dexData).filter((key) => {
       const species = game.scene.gameData.dexData[key];
@@ -432,8 +422,6 @@ describe("UI - Starter select", () => {
       const handler = game.scene.ui.getHandler() as StarterSelectUiHandler;
       handler.processInput(Button.RIGHT);
       handler.processInput(Button.LEFT);
-      handler.processInput(Button.CYCLE_SHINY);
-      handler.processInput(Button.V);
       handler.processInput(Button.V);
       handler.processInput(Button.ACTION);
       game.phaseInterceptor.unlock();
@@ -474,7 +462,7 @@ describe("UI - Starter select", () => {
 
     expect(game.scene.getParty()[0].species.speciesId).toBe(Species.BULBASAUR);
     expect(game.scene.getParty()[0].shiny).toBe(true);
-    expect(game.scene.getParty()[0].variant).toBe(2);
+    expect(game.scene.getParty()[0].variant).toBe(0);
   }, 20000);
 
   it("Check if first pokemon in party is caterpie from gen 1 and 1rd row, 3rd column", async() => {


### PR DESCRIPTION
## What are the changes the user will see?
Shiny with highest variant being enabled by default on starter select is back!

## Why am I making these changes?
Since #3373, the starter UI has defaulted to Pokemon being non shiny, and the lowest unlocked variant being selected by default when enabling shiny.
This has caused some frustration and confusion for players especially since the preferred setting is kept only locally, so switching device, deleting cookies or getting a new variant requires to change the setting manually each time. 

## What are the changes from a developer perspective?
* updated `getCurrentDexProps` to return the highest unlocked variant
* updated the logic when enabling / disabling shiny state
* updated starter select test to account for the change

### Screenshots/Videos
Before:
<img width="1035" alt="__before" src="https://github.com/user-attachments/assets/45416d37-5ba2-437e-8167-91234a49150e">

After: ✨ 
<img width="679" alt="__after" src="https://github.com/user-attachments/assets/075c4621-50ad-44a9-a668-7f20f56ad59b">


## How to test the changes?

There are (somewhat incomplete) tests for the UI that check for switching shiny and variants:
`npm run test src/test/ui/starter-select.test.ts`

Load a save file with some shinies like [this](https://discord.com/channels/1125469663833370665/1267339517371875361/1278397459462226082) or  [this](https://discord.com/channels/1125469663833370665/1267339517371875361/1278397521647108222)

(keep in mind that if you had changed the settings before for some Pokemon the game will use that so the default values will not be applied for these Pokemon. To avoid this you can do your testing in an incognito window)

Play around in starter select with the shiny pokemon, add them to the team, change variant, form, disable shiny, make sure the icons get updated properly and the correct variant and shiny state is used when starting a run

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
- ~~[] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
