### PR TITLE
[Misc][UI] Default Cursor Positioning for Command / Fight / Party

### DIFF
--- a/src/ui/command-ui-handler.ts
+++ b/src/ui/command-ui-handler.ts
@@ -68,7 +68,7 @@ export default class CommandUiHandler extends UiHandler {
     messageHandler.movesWindowContainer.setVisible(false);
     messageHandler.message.setWordWrapWidth(1110);
     messageHandler.showText(i18next.t("commandUiHandler:actionMessage", {pokemonName: getPokemonNameWithAffix(commandPhase.getPokemon())}), 0);
-    this.setCursor(this.getCursor());
+    this.setCursor(0);
 
     return true;
   }

--- a/src/ui/command-ui-handler.ts
+++ b/src/ui/command-ui-handler.ts
@@ -68,7 +68,11 @@ export default class CommandUiHandler extends UiHandler {
     messageHandler.movesWindowContainer.setVisible(false);
     messageHandler.message.setWordWrapWidth(1110);
     messageHandler.showText(i18next.t("commandUiHandler:actionMessage", {pokemonName: getPokemonNameWithAffix(commandPhase.getPokemon())}), 0);
-    this.setCursor(0);
+    if (this.getCursor() === Command.POKEMON) {
+      this.setCursor(Command.FIGHT);
+    } else {
+      this.setCursor(this.getCursor());
+    }
 
     return true;
   }
@@ -85,7 +89,7 @@ export default class CommandUiHandler extends UiHandler {
       if (button === Button.ACTION) {
         switch (cursor) {
         // Fight
-        case 0:
+        case Command.FIGHT:
           if ((this.scene.getCurrentPhase() as CommandPhase).checkFightOverride()) {
             return true;
           }
@@ -93,17 +97,17 @@ export default class CommandUiHandler extends UiHandler {
           success = true;
           break;
           // Ball
-        case 1:
+        case Command.BALL:
           ui.setModeWithoutClear(Mode.BALL);
           success = true;
           break;
           // Pokemon
-        case 2:
+        case Command.POKEMON:
           ui.setMode(Mode.PARTY, PartyUiMode.SWITCH, (this.scene.getCurrentPhase() as CommandPhase).getPokemon().getFieldIndex(), null, PartyUiHandler.FilterNonFainted);
           success = true;
           break;
           // Run
-        case 3:
+        case Command.RUN:
           (this.scene.getCurrentPhase() as CommandPhase).handleCommand(Command.RUN, 0);
           success = true;
           break;

--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -95,9 +95,13 @@ export default class FightUiHandler extends UiHandler {
     messageHandler.bg.setVisible(false);
     messageHandler.commandWindow.setVisible(false);
     messageHandler.movesWindowContainer.setVisible(true);
-    this.setCursor(this.getCursor());
+    const pokemon = (this.scene.getCurrentPhase() as CommandPhase).getPokemon();
+    if (pokemon.battleSummonData.turnCount <= 1) {
+      this.setCursor(0);
+    } else {
+      this.setCursor(this.getCursor());
+    }
     this.displayMoves();
-
     return true;
   }
 

--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -311,7 +311,7 @@ export default class PartyUiHandler extends MessageUiHandler {
     this.partyContainer.setVisible(true);
     this.partyBg.setTexture(`party_bg${this.scene.currentBattle.double ? "_double" : ""}`);
     this.populatePartySlots();
-    this.setCursor(this.cursor < 6 ? this.cursor : 0);
+    this.setCursor(0);
 
     return true;
   }


### PR DESCRIPTION
## What are the changes the user will see?
In the command UI, the cursor will default to FIGHT if the previous cursor position was FIGHT or POKEMON.
In the fight UI, the cursor will default to the upper-left move / first move when a Pokemon has its first turn. Otherwise, it will remember its last position. 
In the party UI, the cursor will default to the first Pokemon.

## Why am I making these changes?
Seems straightforward. 

## What are the changes from a developer perspective?
The setCursor() is set to 0 when the UI is first displayed + meets the requirements. 
Changed the cursor-based switch statement to use the Command enum instead of integers for better readability.

### Screenshots/Videos

https://github.com/user-attachments/assets/6f77e0d4-e2f8-419a-8386-bde697c70050


https://github.com/user-attachments/assets/36c46c00-e9d5-4595-aa18-51b3880f32ea

Works for doubles. See below video. 

https://github.com/user-attachments/assets/1bc72707-1a02-4921-9e4a-5c61969b8f73

## How to test the changes?
Play normally. Cursor position should follow the changes described above. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
