### PR TITLE
[P1 Bug][UI/UX] Address shop cursor target feedbacks

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -130,7 +130,7 @@ export default class BattleScene extends SceneBase {
   public gameSpeed: integer = 1;
   public damageNumbersMode: integer = 0;
   public reroll: boolean = false;
-  public shopCursorTarget: number = ShopCursorTarget.CHECK_TEAM;
+  public shopCursorTarget: number = ShopCursorTarget.REWARDS;
   public showMovesetFlyout: boolean = true;
   public showArenaFlyout: boolean = true;
   public showTimeOfDayWidget: boolean = true;

--- a/src/enums/shop-cursor-target.ts
+++ b/src/enums/shop-cursor-target.ts
@@ -1,13 +1,13 @@
 /**
- * Determines the cursor target when entering the shop phase.
+ * Determines the row cursor target when entering the shop phase.
  */
 export enum ShopCursorTarget {
-  /** Cursor points to Reroll */
+  /** Cursor points to Reroll row */
   REROLL,
-  /** Cursor points to Items */
-  ITEMS,
-  /** Cursor points to Shop */
+  /** Cursor points to Rewards row */
+  REWARDS,
+  /** Cursor points to Shop row */
   SHOP,
-  /** Cursor points to Check Team */
+  /** Cursor points to Check Team row */
   CHECK_TEAM
 }

--- a/src/locales/de/settings.json
+++ b/src/locales/de/settings.json
@@ -100,7 +100,7 @@
   "moveTouchControls": "Bewegung Touch Steuerung",
   "shopOverlayOpacity": "Shop Overlay Deckkraft",
   "shopCursorTarget": "Shop-Cursor Ziel",
-  "items": "Items",
+  "rewards": "Items",
   "reroll": "Neu rollen",
   "shop": "Shop",
   "checkTeam": "Team überprüfen"

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -100,7 +100,7 @@
   "moveTouchControls": "Move Touch Controls",
   "shopOverlayOpacity": "Shop Overlay Opacity",
   "shopCursorTarget": "Shop Cursor Target",
-  "items": "Items",
+  "rewards": "Rewards",
   "reroll": "Reroll",
   "shop": "Shop",
   "checkTeam": "Check Team"

--- a/src/locales/es/settings.json
+++ b/src/locales/es/settings.json
@@ -100,7 +100,7 @@
   "moveTouchControls": "Controles táctiles",
   "shopOverlayOpacity": "Opacidad de la fase de compra",
   "shopCursorTarget": "Cursor de la tienda",
-  "items": "Objetos",
+  "rewards": "Objetos",
   "reroll": "Actualizar",
   "shop": "Tienda",
   "checkTeam": "Ver equipo"

--- a/src/locales/fr/settings.json
+++ b/src/locales/fr/settings.json
@@ -100,7 +100,7 @@
   "moveTouchControls": "Déplacer les contrôles tactiles",
   "shopOverlayOpacity": "Opacité boutique",
   "shopCursorTarget": "Choix après relance",
-  "items": "Obj. gratuits",
+  "rewards": "Obj. gratuits",
   "reroll": "Relance",
   "shop": "Boutique",
   "checkTeam": "Équipe"

--- a/src/locales/it/settings.json
+++ b/src/locales/it/settings.json
@@ -8,7 +8,7 @@
   "moveTouchControls": "Move Touch Controls",
   "shopOverlayOpacity": "Opacità Finestra Negozio",
   "shopCursorTarget": "Target Cursore Negozio",
-  "items": "Oggetti",
+  "rewards": "Oggetti",
   "reroll": "Rerolla",
   "shop": "Negozio",
   "checkTeam": "Squadra"

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -100,7 +100,7 @@
   "moveTouchControls": "タッチ移動操作",
   "shopOverlayOpacity": "ショップオーバレイ不透明度",
   "shopCursorTarget": "ショップカーソル初位置",
-  "items": "アイテム",
+  "rewards": "アイテム",
   "reroll": "選択肢変更",
   "shop": "ショップ",
   "checkTeam": "手持ちを確認"

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -100,7 +100,7 @@
   "moveTouchControls": "タッチ移動操作",
   "shopOverlayOpacity": "ショップオーバレイ不透明度",
   "shopCursorTarget": "ショップカーソル初位置",
-  "rewards": "アイテム",
+  "rewards": "ご褒美",
   "reroll": "選択肢変更",
   "shop": "ショップ",
   "checkTeam": "手持ちを確認"

--- a/src/locales/ko/settings.json
+++ b/src/locales/ko/settings.json
@@ -100,7 +100,7 @@
   "moveTouchControls": "터치 컨트롤 이동",
   "shopOverlayOpacity": "상점 오버레이 투명도",
   "shopCursorTarget": "상점 커서 위치",
-  "items": "아이템",
+  "rewards": "아이템",
   "reroll": "갱신",
   "shop": "상점",
   "checkTeam": "파티 확인"

--- a/src/locales/pt_BR/settings.json
+++ b/src/locales/pt_BR/settings.json
@@ -100,7 +100,7 @@
   "moveTouchControls": "Mover Controles de Toque",
   "shopOverlayOpacity": "Opacidade da Loja",
   "shopCursorTarget": "Alvo do Cursor da Loja",
-  "items": "Itens",
+  "rewards": "Itens",
   "reroll": "Atualizar",
   "shop": "Loja",
   "checkTeam": "Checar Time"

--- a/src/locales/zh_CN/settings.json
+++ b/src/locales/zh_CN/settings.json
@@ -99,7 +99,7 @@
   "moveTouchControls": "移动触摸控制",
   "shopOverlayOpacity": "商店显示不透明度",
   "shopCursorTarget": "商店指针位置",
-  "items": "道具",
+  "rewards": "道具",
   "reroll": "刷新",
   "shop": "购买",
   "checkTeam": "检查队伍"

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -635,7 +635,7 @@ export const Setting: Array<Setting> = [
     key: SettingKeys.Shop_Cursor_Target,
     label: i18next.t("settings:shopCursorTarget"),
     options: SHOP_CURSOR_TARGET_OPTIONS,
-    default: ShopCursorTarget.REWARDS,
+    default: 0,
     type: SettingType.DISPLAY
   },
   {

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -25,6 +25,7 @@ const VOLUME_OPTIONS: SettingOption[] = new Array(11).fill(null).map((_, i) => i
   value: "Mute",
   label: getTranslation("settings:mute")
 });
+
 const SHOP_OVERLAY_OPACITY_OPTIONS: SettingOption[] = new Array(9).fill(null).map((_, i) => {
   const value = ((i + 1) * 10).toString();
   return {
@@ -32,6 +33,7 @@ const SHOP_OVERLAY_OPACITY_OPTIONS: SettingOption[] = new Array(9).fill(null).ma
     label: value,
   };
 });
+
 const OFF_ON: SettingOption[] = [
   {
     value: "Off",
@@ -52,6 +54,40 @@ const AUTO_DISABLED: SettingOption[] = [
     label: i18next.t("settings:disabled")
   }
 ];
+
+const SHOP_CURSOR_TARGET_OPTIONS: SettingOption[] = [
+  {
+    value: "Shop",
+    label: i18next.t("settings:shop")
+  },
+  {
+    value: "Reroll",
+    label: i18next.t("settings:reroll")
+  },
+  {
+    value: "Rewards",
+    label: i18next.t("settings:rewards")
+  },
+  {
+    value: "Check Team",
+    label: i18next.t("settings:checkTeam")
+  }
+];
+
+const shopCursorTargetIndexMap = SHOP_CURSOR_TARGET_OPTIONS.map(option => {
+  switch (option.value) {
+  case "Shop":
+    return ShopCursorTarget.SHOP;
+  case "Reroll":
+    return ShopCursorTarget.REROLL;
+  case "Rewards":
+    return ShopCursorTarget.REWARDS;
+  case "Check Team":
+    return ShopCursorTarget.CHECK_TEAM;
+  default:
+    throw new Error(`Unknown value: ${option.value}`);
+  }
+});
 
 /**
  * Types for helping separate settings to different menus
@@ -103,7 +139,7 @@ export const SettingKeys = {
   Damage_Numbers: "DAMAGE_NUMBERS",
   Move_Animations: "MOVE_ANIMATIONS",
   Show_Stats_on_Level_Up: "SHOW_LEVEL_UP_STATS",
-  Reroll_Target: "REROLL_TARGET",
+  Shop_Cursor_Target: "SHOP_CURSOR_TARGET",
   Candy_Upgrade_Notification: "CANDY_UPGRADE_NOTIFICATION",
   Candy_Upgrade_Display: "CANDY_UPGRADE_DISPLAY",
   Move_Info: "MOVE_INFO",
@@ -596,27 +632,10 @@ export const Setting: Array<Setting> = [
     isHidden: () => !hasTouchscreen()
   },
   {
-    key: SettingKeys.Reroll_Target,
+    key: SettingKeys.Shop_Cursor_Target,
     label: i18next.t("settings:shopCursorTarget"),
-    options: [
-      {
-        value:"Reroll",
-        label: i18next.t("settings:reroll")
-      },
-      {
-        value:"Items",
-        label: i18next.t("settings:items")
-      },
-      {
-        value:"Shop",
-        label: i18next.t("settings:shop")
-      },
-      {
-        value:"Check Team",
-        label: i18next.t("settings:checkTeam")
-      }
-    ],
-    default: ShopCursorTarget.CHECK_TEAM,
+    options: SHOP_CURSOR_TARGET_OPTIONS,
+    default: ShopCursorTarget.REWARDS,
     type: SettingType.DISPLAY
   },
   {
@@ -758,8 +777,10 @@ export function setSetting(scene: BattleScene, setting: string, value: integer):
   case SettingKeys.Show_Stats_on_Level_Up:
     scene.showLevelUpStats = Setting[index].options[value].value === "On";
     break;
-  case SettingKeys.Reroll_Target:
-    scene.shopCursorTarget = value;
+  case SettingKeys.Shop_Cursor_Target:
+    const selectedValue = shopCursorTargetIndexMap[value];
+    scene.shopCursorTarget = selectedValue;
+    break;
   case SettingKeys.EXP_Gains_Speed:
     scene.expGainsSpeed = value;
     break;

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -76,12 +76,12 @@ const SHOP_CURSOR_TARGET_OPTIONS: SettingOption[] = [
 
 const shopCursorTargetIndexMap = SHOP_CURSOR_TARGET_OPTIONS.map(option => {
   switch (option.value) {
+  case "Rewards":
+    return ShopCursorTarget.REWARDS;
   case "Shop":
     return ShopCursorTarget.SHOP;
   case "Reroll":
     return ShopCursorTarget.REROLL;
-  case "Rewards":
-    return ShopCursorTarget.REWARDS;
   case "Check Team":
     return ShopCursorTarget.CHECK_TEAM;
   default:

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -57,16 +57,16 @@ const AUTO_DISABLED: SettingOption[] = [
 
 const SHOP_CURSOR_TARGET_OPTIONS: SettingOption[] = [
   {
+    value: "Rewards",
+    label: i18next.t("settings:rewards")
+  },
+  {
     value: "Shop",
     label: i18next.t("settings:shop")
   },
   {
     value: "Reroll",
     label: i18next.t("settings:reroll")
-  },
-  {
-    value: "Rewards",
-    label: i18next.t("settings:rewards")
   },
   {
     value: "Check Team",

--- a/src/test/items/dire_hit.test.ts
+++ b/src/test/items/dire_hit.test.ts
@@ -13,7 +13,7 @@ import { Button } from "#app/enums/buttons";
 import { CommandPhase } from "#app/phases/command-phase";
 import { NewBattlePhase } from "#app/phases/new-battle-phase";
 import { TurnInitPhase } from "#app/phases/turn-init-phase";
-import { ShopCursorTarget } from "#app/enums/shop-cursor-target.js";
+import { ShopCursorTarget } from "#app/enums/shop-cursor-target";
 
 describe("Items - Dire Hit", () => {
   let phaserGame: Phaser.Game;

--- a/src/test/items/dire_hit.test.ts
+++ b/src/test/items/dire_hit.test.ts
@@ -13,6 +13,7 @@ import { Button } from "#app/enums/buttons";
 import { CommandPhase } from "#app/phases/command-phase";
 import { NewBattlePhase } from "#app/phases/new-battle-phase";
 import { TurnInitPhase } from "#app/phases/turn-init-phase";
+import { ShopCursorTarget } from "#app/enums/shop-cursor-target.js";
 
 describe("Items - Dire Hit", () => {
   let phaserGame: Phaser.Game;
@@ -77,8 +78,8 @@ describe("Items - Dire Hit", () => {
     game.onNextPrompt("SelectModifierPhase", Mode.MODIFIER_SELECT, () => {
       const handler = game.scene.ui.getHandler() as ModifierSelectUiHandler;
       // Traverse to first modifier slot
-      handler.processInput(Button.LEFT);
-      handler.processInput(Button.UP);
+      handler.setCursor(0);
+      handler.setRowCursor(ShopCursorTarget.REWARDS);
       handler.processInput(Button.ACTION);
     }, () => game.isCurrentPhase(CommandPhase) || game.isCurrentPhase(NewBattlePhase), true);
 

--- a/src/test/items/temp_stat_stage_booster.test.ts
+++ b/src/test/items/temp_stat_stage_booster.test.ts
@@ -16,6 +16,7 @@ import ModifierSelectUiHandler from "#app/ui/modifier-select-ui-handler";
 import { TurnInitPhase } from "#app/phases/turn-init-phase";
 import { BattleEndPhase } from "#app/phases/battle-end-phase";
 import { EnemyCommandPhase } from "#app/phases/enemy-command-phase";
+import { ShopCursorTarget } from "#app/enums/shop-cursor-target.js";
 
 
 describe("Items - Temporary Stat Stage Boosters", () => {
@@ -154,8 +155,8 @@ describe("Items - Temporary Stat Stage Boosters", () => {
     game.onNextPrompt("SelectModifierPhase", Mode.MODIFIER_SELECT, () => {
       const handler = game.scene.ui.getHandler() as ModifierSelectUiHandler;
       // Traverse to first modifier slot
-      handler.processInput(Button.LEFT);
-      handler.processInput(Button.UP);
+      handler.setCursor(0);
+      handler.setRowCursor(ShopCursorTarget.REWARDS);
       handler.processInput(Button.ACTION);
     }, () => game.isCurrentPhase(CommandPhase) || game.isCurrentPhase(NewBattlePhase), true);
 

--- a/src/test/items/temp_stat_stage_booster.test.ts
+++ b/src/test/items/temp_stat_stage_booster.test.ts
@@ -16,7 +16,7 @@ import ModifierSelectUiHandler from "#app/ui/modifier-select-ui-handler";
 import { TurnInitPhase } from "#app/phases/turn-init-phase";
 import { BattleEndPhase } from "#app/phases/battle-end-phase";
 import { EnemyCommandPhase } from "#app/phases/enemy-command-phase";
-import { ShopCursorTarget } from "#app/enums/shop-cursor-target.js";
+import { ShopCursorTarget } from "#app/enums/shop-cursor-target";
 
 
 describe("Items - Temporary Stat Stage Boosters", () => {

--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -257,6 +257,9 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
         if (this.scene.shopCursorTarget === ShopCursorTarget.CHECK_TEAM) {
           this.setRowCursor(0);
           this.setCursor(2);
+        } else if ((this.scene.shopCursorTarget === ShopCursorTarget.SHOP) && this.scene.gameMode.hasNoShop) {
+          this.setRowCursor(ShopCursorTarget.REWARDS);
+          this.setCursor(0);
         } else {
           this.setRowCursor(this.scene.shopCursorTarget);
           this.setCursor(0);


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
- entering daily run's rewards phase should no longer soft lock when the shop cursor target is set to `Shop`
- changed "Items" label to "Rewards"
- set the default option to `Rewards`
- set the default option to be left-most/first option

## Why am I making these changes?
Addressing feedbacks:
- P1: Game can softlock if it's set to "Shop" before buyable shop items introduced - in Daily Run mode
- Some of the terms are ambiguous. "Items" can refer to the buyable items, the free ones, or transferring items. Someone suggested "Rewards"
- Move the default option back to the original please (Rewards)
- The default most common option (Rewards) should be the first option

## What are the changes from a developer perspective?
- added an index mapping of options-enum to avoid the risk of mismatching the option keys and the shop cursor targets enum
- added condition to check the current game mode and the current set shop cursor target option

### Screenshots/Videos
Updated options
<img width="1310" alt="Screenshot 2024-09-04 at 4 02 25 AM" src="https://github.com/user-attachments/assets/2c84563a-b9d6-4317-a36c-4e04d8005b0a">


Daily run no longer softlocks when shop cursor target is set to `Shop`


https://github.com/user-attachments/assets/30f61a8c-c947-41a0-b753-5f35bbd4e97c




## How to test the changes?
set settings, enter rewards/shop phase

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
