### PR TITLE
[Test] Add Dragon Cheer tests

### DIFF
--- a/src/test/moves/dragon_cheer.test.ts
+++ b/src/test/moves/dragon_cheer.test.ts
@@ -1,5 +1,4 @@
 import { BattlerIndex } from "#app/battle";
-import { DragonCheerTag } from "#app/data/battler-tags";
 import { Type } from "#app/data/type";
 import { Moves } from "#app/enums/moves";
 import { Species } from "#app/enums/species";
@@ -37,7 +36,6 @@ describe("Moves - Dragon Cheer", () => {
   it("increases the user's allies' critical hit ratio by one stage", async () => {
     await game.classicMode.startBattle([Species.DRAGONAIR, Species.MAGIKARP]);
 
-    const magikarp = game.scene.getPlayerField()[1];
     const enemy = game.scene.getEnemyField()[0];
 
     vi.spyOn(enemy, "getCritStage");
@@ -47,19 +45,14 @@ describe("Moves - Dragon Cheer", () => {
 
     await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
 
-    // After Dragon Cheer
-    await game.phaseInterceptor.to("MoveEndPhase");
-    expect(magikarp.getTag(DragonCheerTag)).toBeDefined();
-
     // After Tackle
-    await game.phaseInterceptor.to("MoveEndPhase");
+    await game.phaseInterceptor.to("TurnEndPhase");
     expect(enemy.getCritStage).toHaveReturnedWith(1); // getCritStage is called on defender
   }, TIMEOUT);
 
   it("increases the user's Dragon-type allies' critical hit ratio by two stages", async () => {
     await game.classicMode.startBattle([Species.MAGIKARP, Species.DRAGONAIR]);
 
-    const dragonair = game.scene.getPlayerField()[1];
     const enemy = game.scene.getEnemyField()[0];
 
     vi.spyOn(enemy, "getCritStage");
@@ -69,12 +62,8 @@ describe("Moves - Dragon Cheer", () => {
 
     await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
 
-    // After Dragon Cheer
-    await game.phaseInterceptor.to("MoveEndPhase");
-    expect(dragonair.getTag(DragonCheerTag)).toBeDefined();
-
     // After Tackle
-    await game.phaseInterceptor.to("MoveEndPhase");
+    await game.phaseInterceptor.to("TurnEndPhase");
     expect(enemy.getCritStage).toHaveReturnedWith(2); // getCritStage is called on defender
   }, TIMEOUT);
 
@@ -91,12 +80,8 @@ describe("Moves - Dragon Cheer", () => {
 
     await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
 
-    // After Dragon Cheer
-    await game.phaseInterceptor.to("MoveEndPhase");
-    expect(magikarp.getTag(DragonCheerTag)).toBeDefined();
-
     // After Tackle
-    await game.phaseInterceptor.to("MoveEndPhase");
+    await game.phaseInterceptor.to("TurnEndPhase");
     expect(enemy.getCritStage).toHaveReturnedWith(1); // getCritStage is called on defender
 
     await game.toNextTurn();

--- a/src/test/moves/dragon_cheer.test.ts
+++ b/src/test/moves/dragon_cheer.test.ts
@@ -1,0 +1,117 @@
+import { BattlerIndex } from "#app/battle";
+import { DragonCheerTag } from "#app/data/battler-tags";
+import { Type } from "#app/data/type";
+import { Moves } from "#app/enums/moves";
+import { Species } from "#app/enums/species";
+import { Abilities } from "#enums/abilities";
+import GameManager from "#test/utils/gameManager";
+import { SPLASH_ONLY } from "#test/utils/testUtils";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Moves - Dragon Cheer", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+  const TIMEOUT = 20 * 1000;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("double")
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(SPLASH_ONLY)
+      .enemyLevel(20)
+      .startingWave(4)
+      .moveset([Moves.DRAGON_CHEER, Moves.TACKLE, Moves.SPLASH]);
+  });
+
+  it("increases the user's allies' critical hit ratio by one stage", async () => {
+    await game.classicMode.startBattle([Species.DRAGONAIR, Species.MAGIKARP]);
+
+    const magikarp = game.scene.getPlayerField()[1];
+    const enemy = game.scene.getEnemyField()[0];
+
+    vi.spyOn(enemy, "getCritStage");
+
+    game.move.select(Moves.DRAGON_CHEER, 0);
+    game.move.select(Moves.TACKLE, 1, BattlerIndex.ENEMY);
+
+    await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
+
+    // After Dragon Cheer
+    await game.phaseInterceptor.to("MoveEndPhase");
+    expect(magikarp.getTag(DragonCheerTag)).toBeDefined();
+
+    // After Tackle
+    await game.phaseInterceptor.to("MoveEndPhase");
+    expect(enemy.getCritStage).toHaveReturnedWith(1); // getCritStage is called on defender
+  }, TIMEOUT);
+
+  it("increases the user's Dragon-type allies' critical hit ratio by two stages", async () => {
+    await game.classicMode.startBattle([Species.MAGIKARP, Species.DRAGONAIR]);
+
+    const dragonair = game.scene.getPlayerField()[1];
+    const enemy = game.scene.getEnemyField()[0];
+
+    vi.spyOn(enemy, "getCritStage");
+
+    game.move.select(Moves.DRAGON_CHEER, 0);
+    game.move.select(Moves.TACKLE, 1, BattlerIndex.ENEMY);
+
+    await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
+
+    // After Dragon Cheer
+    await game.phaseInterceptor.to("MoveEndPhase");
+    expect(dragonair.getTag(DragonCheerTag)).toBeDefined();
+
+    // After Tackle
+    await game.phaseInterceptor.to("MoveEndPhase");
+    expect(enemy.getCritStage).toHaveReturnedWith(2); // getCritStage is called on defender
+  }, TIMEOUT);
+
+  it("applies the effect based on the allies' type upon use of the move, and do not change if the allies' type changes later in battle", async () => {
+    await game.classicMode.startBattle([Species.DRAGONAIR, Species.MAGIKARP]);
+
+    const magikarp = game.scene.getPlayerField()[1];
+    const enemy = game.scene.getEnemyField()[0];
+
+    vi.spyOn(enemy, "getCritStage");
+
+    game.move.select(Moves.DRAGON_CHEER, 0);
+    game.move.select(Moves.TACKLE, 1, BattlerIndex.ENEMY);
+
+    await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
+
+    // After Dragon Cheer
+    await game.phaseInterceptor.to("MoveEndPhase");
+    expect(magikarp.getTag(DragonCheerTag)).toBeDefined();
+
+    // After Tackle
+    await game.phaseInterceptor.to("MoveEndPhase");
+    expect(enemy.getCritStage).toHaveReturnedWith(1); // getCritStage is called on defender
+
+    await game.toNextTurn();
+
+    // Change Magikarp's type to Dragon
+    vi.spyOn(magikarp, "getTypes").mockReturnValue([Type.DRAGON]);
+    expect(magikarp.getTypes()).toEqual([Type.DRAGON]);
+
+    game.move.select(Moves.SPLASH, 0);
+    game.move.select(Moves.TACKLE, 1, BattlerIndex.ENEMY);
+
+    await game.setTurnOrder([BattlerIndex.PLAYER_2, BattlerIndex.PLAYER, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
+
+    await game.phaseInterceptor.to("MoveEndPhase");
+    expect(enemy.getCritStage).toHaveReturnedWith(1); // getCritStage is called on defender
+  }, TIMEOUT);
+});

--- a/src/test/moves/dragon_cheer.test.ts
+++ b/src/test/moves/dragon_cheer.test.ts
@@ -31,7 +31,6 @@ describe("Moves - Dragon Cheer", () => {
       .enemyAbility(Abilities.BALL_FETCH)
       .enemyMoveset(SPLASH_ONLY)
       .enemyLevel(20)
-      .startingWave(4)
       .moveset([Moves.DRAGON_CHEER, Moves.TACKLE, Moves.SPLASH]);
   });
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
none

## Why am I making these changes?
adding tests to https://github.com/pagefaultgames/pokerogue/pull/3959 now that it is possible


## What are the changes from a developer perspective?
dragon cheer test

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
`npm run test dragon_cheer`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
