### PR TITLE
[Bug] Fix getting the highest ivs for the iv scanner

### DIFF
--- a/src/ui/battle-message-ui-handler.ts
+++ b/src/ui/battle-message-ui-handler.ts
@@ -215,12 +215,11 @@ export default class BattleMessageUiHandler extends MessageUiHandler {
   getTopIvs(ivs: integer[], shownIvsCount: integer): Stat[] {
     let shownStats: Stat[] = [];
     if (shownIvsCount < 6) {
-      let highestIv = -1;
+      const statsPool = PERMANENT_STATS.slice();
+      // Sort the stats from highest to lowest iv
+      statsPool.sort((s1, s2) => ivs[s2] - ivs[s1]);
       for (let i = 0; i < shownIvsCount; i++) {
-        if (ivs[i] > highestIv) {
-          shownStats.push(PERMANENT_STATS[i]);
-          highestIv = ivs[i];
-        }
+        shownStats.push(statsPool[i]);
       }
     } else {
       shownStats = PERMANENT_STATS.slice();


### PR DESCRIPTION
## What are the changes the user will see?
The IV scanner properly reveals the highest stats

## Why am I making these changes?
The logic for showing the highest IVs when using the IV Scanner was lost somewhere along the way during the stats refactoring, this PR fixes that
[full bug report on discord](https://discord.com/channels/1125469663833370665/1280876551247892580/1280876551247892580)

## What are the changes from a developer perspective?
Sort the stats pools by highest IV and return the top stats

### Screenshots/Videos
Before (current beta), the first IVs would always get shown instead of the highest ones: 
<img width="1172" alt="_beta_1" src="https://github.com/user-attachments/assets/9c48218e-534b-4cc1-8ee2-b50a080d1ea6">
<img width="1175" alt="_beta_3" src="https://github.com/user-attachments/assets/a4722b06-0ab5-4fa1-98da-619c3bcdf834">


After: 
<img width="764" alt="Screenshot 2024-09-04 at 17 01 09" src="https://github.com/user-attachments/assets/04d8d899-9685-4582-8390-2af77a568e4c">
<img width="1163" alt="Screenshot 2024-09-04 at 16 45 45" src="https://github.com/user-attachments/assets/1ce5b996-9254-4741-b111-b95a7bdfe8b0">

## How to test the changes?

You can use the save files [from the bug report](https://discord.com/channels/1125469663833370665/1280876551247892580/1280887442307809312) 

Or an override: 
`STARTING_MODIFIER_OVERRIDE: [{name: "IV_SCANNER", count: 1}]`

<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
