### PR TITLE
[i18n] Re-add lost i18n strings for Safeguard

### DIFF
--- a/src/locales/en/arena-flyout.json
+++ b/src/locales/en/arena-flyout.json
@@ -39,5 +39,6 @@
   "matBlock": "Mat Block",
   "craftyShield": "Crafty Shield",
   "tailwind": "Tailwind",
-  "happyHour": "Happy Hour"
+  "happyHour": "Happy Hour",
+  "safeguard": "Safeguard"
 }

--- a/src/locales/en/arena-tag.json
+++ b/src/locales/en/arena-tag.json
@@ -47,5 +47,11 @@
   "tailwindOnRemovePlayer": "Your team's Tailwind petered out!",
   "tailwindOnRemoveEnemy": "The opposing team's Tailwind petered out!",
   "happyHourOnAdd": "Everyone is caught up in the happy atmosphere!",
-  "happyHourOnRemove": "The atmosphere returned to normal."
+  "happyHourOnRemove": "The atmosphere returned to normal.",
+  "safeguardOnAdd": "The whole field is cloaked in a mystical veil!",
+  "safeguardOnAddPlayer": "Your team cloaked itself in a mystical veil!",
+  "safeguardOnAddEnemy": "The opposing team cloaked itself in a mystical veil!",
+  "safeguardOnRemove": "The field is no longer protected by Safeguard!",
+  "safeguardOnRemovePlayer": "Your team is no longer protected by Safeguard!",
+  "safeguardOnRemoveEnemy": "The opposing team is no longer protected by Safeguard!"
 }

--- a/src/locales/en/move-trigger.json
+++ b/src/locales/en/move-trigger.json
@@ -65,5 +65,6 @@
   "suppressAbilities": "{{pokemonName}}'s ability\nwas suppressed!",
   "revivalBlessing": "{{pokemonName}} was revived!",
   "swapArenaTags": "{{pokemonName}} swapped the battle effects affecting each side of the field!",
-  "exposedMove": "{{pokemonName}} identified\n{{targetPokemonName}}!"
+  "exposedMove": "{{pokemonName}} identified\n{{targetPokemonName}}!",
+  "safeguard": "{{targetName}} is protected by Safeguard!"
 }


### PR DESCRIPTION
## What are the changes the user will see?
Safeguard will have English text now.

## Why am I making these changes?
The English text for Safeguard got removed during the i18n switchover.

## What are the changes from a developer perspective?
English text was added to `en/arena-tag.json` and `en/move-trigger.json` for Safeguard.

### Screenshots/video
![image](https://github.com/user-attachments/assets/9696f43a-79fe-4dde-831f-5441ec6d92e9)
![image](https://github.com/user-attachments/assets/e013a498-321c-422b-9b7d-31213f146869)

## How to test the changes?
Use Safeguard in a battle.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
