### PR TITLE
[Localization] Restoring "Safeguard" entries in arena-flyout.json of all locales where it existed

### DIFF
--- a/src/locales/de/arena-flyout.json
+++ b/src/locales/de/arena-flyout.json
@@ -36,5 +36,6 @@
   "matBlock": "Tatami-Schild",
   "craftyShield": "Trickschutz",
   "tailwind": "Rückenwind",
-  "happyHour": "Goldene Zeiten"
+  "happyHour": "Goldene Zeiten",
+  "safeguard": "Bodyguard"
 }

--- a/src/locales/es/arena-flyout.json
+++ b/src/locales/es/arena-flyout.json
@@ -36,5 +36,6 @@
   "matBlock": "Escudo Tatami",
   "craftyShield": "Truco Defensa",
   "tailwind": "Viento Afín",
-  "happyHour": "Paga Extra"
+  "happyHour": "Paga Extra",
+  "safeguard": "Velo Sagrado"
 }

--- a/src/locales/fr/arena-flyout.json
+++ b/src/locales/fr/arena-flyout.json
@@ -36,5 +36,6 @@
   "matBlock": "Tatamigaeshi",
   "craftyShield": "Vigilance",
   "tailwind": "Vent Arrière",
-  "happyHour": "Étrennes"
+  "happyHour": "Étrennes",
+  "safeguard": "Rune Protect"
 }

--- a/src/locales/it/arena-flyout.json
+++ b/src/locales/it/arena-flyout.json
@@ -36,5 +36,6 @@
   "matBlock": "Ribaltappeto",
   "craftyShield": "Truccodifesa",
   "tailwind": "Ventoincoda",
-  "happyHour": "Cuccagna"
+  "happyHour": "Cuccagna",
+  "safeguard": "Salvaguardia"
 }

--- a/src/locales/ko/arena-flyout.json
+++ b/src/locales/ko/arena-flyout.json
@@ -36,5 +36,6 @@
   "matBlock": "마룻바닥세워막기",
   "craftyShield": "트릭가드",
   "tailwind": "순풍",
-  "happyHour": "해피타임"
+  "happyHour": "해피타임",
+  "safeguard": "신비의부적"
 }

--- a/src/locales/pt_BR/arena-flyout.json
+++ b/src/locales/pt_BR/arena-flyout.json
@@ -39,4 +39,3 @@
   "happyHour": "Happy Hour",
   "safeguard": "Safeguard"
 }
-}

--- a/src/locales/pt_BR/arena-flyout.json
+++ b/src/locales/pt_BR/arena-flyout.json
@@ -36,5 +36,7 @@
   "matBlock": "Mat Block",
   "craftyShield": "Crafty Shield",
   "tailwind": "Tailwind",
-  "happyHour": "Happy Hour"
+  "happyHour": "Happy Hour",
+  "safeguard": "Safeguard"
+}
 }

--- a/src/locales/zh_CN/arena-flyout.json
+++ b/src/locales/zh_CN/arena-flyout.json
@@ -36,5 +36,6 @@
   "matBlock": "掀榻榻米",
   "craftyShield": "戏法防守",
   "tailwind": "顺风",
-  "happyHour": "快乐时光"
+  "happyHour": "快乐时光",
+  "safeguard": "神秘守护"
 }


### PR DESCRIPTION
## What are the changes the user will see?
Restoring "Safeguard" entries in arena arena-flyout.json of all locales where it existed, like #4024 does with English

## Why am I making these changes?
To restore them

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?