### PR TITLE
[Bug][Beta] Garbage Collection should ignore active cry keys of bottom-half fusions

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2755,12 +2755,18 @@ export default class BattleScene extends SceneBase {
       keys.push("pkmn__" + p.species.getSpriteId(p.gender === Gender.FEMALE, p.species.formIndex, p.shiny, p.variant));
       keys.push("pkmn__" + p.species.getSpriteId(p.gender === Gender.FEMALE, p.species.formIndex, p.shiny, p.variant, true));
       keys.push("cry/" + p.species.getCryKey(p.species.formIndex));
+      if (p.fusionSpecies && p.getSpeciesForm() !== p.getFusionSpeciesForm()) {
+        keys.push("cry/"+p.getFusionSpeciesForm().getCryKey(p.fusionSpecies.formIndex));
+      }
     });
     // enemyParty has to be operated on separately from playerParty because playerPokemon =/= enemyPokemon
     const enemyParty = this.getEnemyParty();
     enemyParty.forEach(p => {
       keys.push(p.species.getSpriteKey(p.gender === Gender.FEMALE, p.species.formIndex, p.shiny, p.variant));
       keys.push("cry/" + p.species.getCryKey(p.species.formIndex));
+      if (p.fusionSpecies && p.getSpeciesForm() !== p.getFusionSpeciesForm()) {
+        keys.push("cry/"+p.getFusionSpeciesForm().getCryKey(p.fusionSpecies.formIndex));
+      }
     });
     return keys;
   }


### PR DESCRIPTION
## What are the changes the user will see?
No game crash between biomes b/c a cry was accidentally deleted. 

## Why am I making these changes?
My mistake, my cheese brain. 

## What are the changes from a developer perspective?
When a player changes biomes, a Pokemon's cries - if missing - are not reloaded. This could lead to a crash if an active Pokemon is missing their cry from the game files. 
The function scene.getActiveKeys() forgot to check and include the bottom-half of fused Pokemon in its white-list of keys. This meant that garbage collection would accidentally deleted it. 

### Screenshots/Videos

https://github.com/user-attachments/assets/e460bfac-dc9a-4ceb-bb3e-6af607dd0a04

## How to test the changes?
Play game on a Biome Change with a fused Pokemon.
Overrides -> Free Eggs, Instant Hatch

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
