### PR TITLE
[P3 Bug] Fixed mbh not using the user's nickname

### DIFF
--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -2488,7 +2488,7 @@ export class TurnHeldItemTransferModifier extends HeldItemTransferModifier {
   }
 
   getTransferMessage(pokemon: Pokemon, targetPokemon: Pokemon, item: ModifierTypes.ModifierType): string {
-    return i18next.t("modifier:turnHeldItemTransferApply", { pokemonNameWithAffix: getPokemonNameWithAffix(targetPokemon), itemName: item.name, pokemonName: pokemon.name, typeName: this.type.name });
+    return i18next.t("modifier:turnHeldItemTransferApply", { pokemonNameWithAffix: getPokemonNameWithAffix(targetPokemon), itemName: item.name, pokemonName: pokemon.getNameToRender(), typeName: this.type.name });
   }
 
   getMaxHeldItemCount(pokemon: Pokemon): integer {


### PR DESCRIPTION
## What are the changes the user will see?
mbh activation message will now show the user's nickname

## Why am I making these changes?
Consistency. Also closes https://github.com/pagefaultgames/pokerogue/issues/4030

## What are the changes from a developer perspective?
changed `pokemon.name` to `pokemon.getNameToRender()` 

### Screenshots/Videos
![](https://cdn.discordapp.com/attachments/1280936852345323532/1281072123896532993/image.png?ex=66da62e3&is=66d91163&hm=b7806684ee913be9af76514652b024b357f8dea510e4971b40417729c13a4a82&)

## How to test the changes?
```ts
readonly STARTING_HELD_ITEMS_OVERRIDE: ModifierOverride[] = [{name: "MINI_BLACK_HOLE", count: 1}];
readonly OPP_HELD_ITEMS_OVERRIDE: ModifierOverride[] = [{name: "LUCKY_EGG", count: 99}];
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
