### PR TITLE
[Test] Fix random failure in Parental Bond tests

### DIFF
--- a/src/test/abilities/parental_bond.test.ts
+++ b/src/test/abilities/parental_bond.test.ts
@@ -2,12 +2,6 @@ import { Stat } from "#enums/stat";
 import { StatusEffect } from "#app/data/status-effect";
 import { Type } from "#app/data/type";
 import { BattlerTagType } from "#app/enums/battler-tag-type";
-import { BerryPhase } from "#app/phases/berry-phase";
-import { CommandPhase } from "#app/phases/command-phase";
-import { DamagePhase } from "#app/phases/damage-phase";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
-import { MoveEndPhase } from "#app/phases/move-end-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { toDmgValue } from "#app/utils";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
@@ -15,7 +9,7 @@ import { Species } from "#enums/species";
 import GameManager from "#test/utils/gameManager";
 import { SPLASH_ONLY } from "#test/utils/testUtils";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 const TIMEOUT = 20 * 1000;
 
@@ -39,36 +33,31 @@ describe("Abilities - Parental Bond", () => {
     game.override.disableCrits();
     game.override.ability(Abilities.PARENTAL_BOND);
     game.override.enemySpecies(Species.SNORLAX);
-    game.override.enemyAbility(Abilities.INSOMNIA);
+    game.override.enemyAbility(Abilities.FUR_COAT);
     game.override.enemyMoveset(SPLASH_ONLY);
     game.override.startingLevel(100);
     game.override.enemyLevel(100);
   });
 
-  test(
-    "ability should add second strike to attack move",
+  it(
+    "should add second strike to attack move",
     async () => {
       game.override.moveset([Moves.TACKLE]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
-      expect(leadPokemon).not.toBe(undefined);
-
       const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).not.toBe(undefined);
 
       let enemyStartingHp = enemyPokemon.hp;
 
       game.move.select(Moves.TACKLE);
 
-      await game.phaseInterceptor.to(MoveEffectPhase, false);
-
-      await game.phaseInterceptor.to(DamagePhase);
+      await game.phaseInterceptor.to("DamagePhase");
       const firstStrikeDamage = enemyStartingHp - enemyPokemon.hp;
       enemyStartingHp = enemyPokemon.hp;
 
-      await game.phaseInterceptor.to(BerryPhase, false);
+      await game.phaseInterceptor.to("BerryPhase", false);
 
       const secondStrikeDamage = enemyStartingHp - enemyPokemon.hp;
 
@@ -77,556 +66,460 @@ describe("Abilities - Parental Bond", () => {
     }, TIMEOUT
   );
 
-  test(
-    "ability should apply secondary effects to both strikes",
+  it(
+    "should apply secondary effects to both strikes",
     async () => {
       game.override.moveset([Moves.POWER_UP_PUNCH]);
       game.override.enemySpecies(Species.AMOONGUSS);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
-      expect(leadPokemon).not.toBe(undefined);
-
-      const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).not.toBe(undefined);
 
       game.move.select(Moves.POWER_UP_PUNCH);
 
-      await game.phaseInterceptor.to(BerryPhase, false);
+      await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(leadPokemon.turnData.hitCount).toBe(2);
       expect(leadPokemon.getStatStage(Stat.ATK)).toBe(2);
     }, TIMEOUT
   );
 
-  test(
-    "ability should not apply to Status moves",
+  it(
+    "should not apply to Status moves",
     async () => {
       game.override.moveset([Moves.BABY_DOLL_EYES]);
 
-      await game.startBattle([Species.CHARIZARD]);
-
-      const leadPokemon = game.scene.getPlayerPokemon()!;
-      expect(leadPokemon).not.toBe(undefined);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).not.toBe(undefined);
 
       game.move.select(Moves.BABY_DOLL_EYES);
-      await game.phaseInterceptor.to(BerryPhase, false);
+
+      await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(-1);
     }, TIMEOUT
   );
 
-  test(
-    "ability should not apply to multi-hit moves",
+  it(
+    "should not apply to multi-hit moves",
     async () => {
       game.override.moveset([Moves.DOUBLE_HIT]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
-      expect(leadPokemon).not.toBe(undefined);
-
-      const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).not.toBe(undefined);
 
       game.move.select(Moves.DOUBLE_HIT);
       await game.move.forceHit();
 
-      await game.phaseInterceptor.to(BerryPhase, false);
+      await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(leadPokemon.turnData.hitCount).toBe(2);
     }, TIMEOUT
   );
 
-  test(
-    "ability should not apply to self-sacrifice moves",
+  it(
+    "should not apply to self-sacrifice moves",
     async () => {
       game.override.moveset([Moves.SELF_DESTRUCT]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
-      expect(leadPokemon).not.toBe(undefined);
-
-      const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).not.toBe(undefined);
 
       game.move.select(Moves.SELF_DESTRUCT);
 
-      await game.phaseInterceptor.to(DamagePhase, false);
+      await game.phaseInterceptor.to("DamagePhase", false);
 
       expect(leadPokemon.turnData.hitCount).toBe(1);
     }, TIMEOUT
   );
 
-  test(
-    "ability should not apply to Rollout",
+  it(
+    "should not apply to Rollout",
     async () => {
       game.override.moveset([Moves.ROLLOUT]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
-      expect(leadPokemon).not.toBe(undefined);
-
-      const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).not.toBe(undefined);
 
       game.move.select(Moves.ROLLOUT);
       await game.move.forceHit();
 
-      await game.phaseInterceptor.to(DamagePhase, false);
+      await game.phaseInterceptor.to("DamagePhase", false);
 
       expect(leadPokemon.turnData.hitCount).toBe(1);
     }, TIMEOUT
   );
 
-  test(
-    "ability should not apply multiplier to fixed-damage moves",
+  it(
+    "should not apply multiplier to fixed-damage moves",
     async () => {
       game.override.moveset([Moves.DRAGON_RAGE]);
 
-      await game.startBattle([Species.CHARIZARD]);
-
-      const leadPokemon = game.scene.getPlayerPokemon()!;
-      expect(leadPokemon).not.toBe(undefined);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).not.toBe(undefined);
-
-      const enemyStartingHp = enemyPokemon.hp;
 
       game.move.select(Moves.DRAGON_RAGE);
-      await game.phaseInterceptor.to(BerryPhase, false);
+      await game.phaseInterceptor.to("BerryPhase", false);
 
-      expect(enemyPokemon.hp).toBe(enemyStartingHp - 80);
+      expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp() - 80);
     }, TIMEOUT
   );
 
-  test(
-    "ability should not apply multiplier to counter moves",
+  it(
+    "should not apply multiplier to counter moves",
     async () => {
       game.override.moveset([Moves.COUNTER]);
-      game.override.enemyMoveset([Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE]);
+      game.override.enemyMoveset(Array(4).fill(Moves.TACKLE));
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.SHUCKLE]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
-      expect(leadPokemon).not.toBe(undefined);
-
       const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).not.toBe(undefined);
-
-      const playerStartingHp = leadPokemon.hp;
-      const enemyStartingHp = enemyPokemon.hp;
 
       game.move.select(Moves.COUNTER);
-      await game.phaseInterceptor.to(DamagePhase);
+      await game.phaseInterceptor.to("DamagePhase");
 
-      const playerDamage = playerStartingHp - leadPokemon.hp;
+      const playerDamage = leadPokemon.getMaxHp() - leadPokemon.hp;
 
-      await game.phaseInterceptor.to(BerryPhase, false);
+      await game.phaseInterceptor.to("BerryPhase", false);
 
-      expect(enemyPokemon.hp).toBe(enemyStartingHp - 4 * playerDamage);
+      expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp() - 4 * playerDamage);
     }, TIMEOUT
   );
 
-  test(
-    "ability should not apply to multi-target moves",
+  it(
+    "should not apply to multi-target moves",
     async () => {
       game.override.battleType("double");
       game.override.moveset([Moves.EARTHQUAKE]);
+      game.override.passiveAbility(Abilities.LEVITATE);
 
-      await game.startBattle([Species.CHARIZARD, Species.PIDGEOT]);
+      await game.classicMode.startBattle([Species.MAGIKARP, Species.FEEBAS]);
 
       const playerPokemon = game.scene.getPlayerField();
-      expect(playerPokemon.length).toBe(2);
-      playerPokemon.forEach(p => expect(p).not.toBe(undefined));
-
-      const enemyPokemon = game.scene.getEnemyField();
-      expect(enemyPokemon.length).toBe(2);
-      enemyPokemon.forEach(p => expect(p).not.toBe(undefined));
 
       game.move.select(Moves.EARTHQUAKE);
-      await game.phaseInterceptor.to(CommandPhase);
-
       game.move.select(Moves.EARTHQUAKE, 1);
-      await game.phaseInterceptor.to(BerryPhase, false);
+
+      await game.phaseInterceptor.to("BerryPhase", false);
 
       playerPokemon.forEach(p => expect(p.turnData.hitCount).toBe(1));
     }, TIMEOUT
   );
 
-  test(
-    "ability should apply to multi-target moves when hitting only one target",
+  it(
+    "should apply to multi-target moves when hitting only one target",
     async () => {
       game.override.moveset([Moves.EARTHQUAKE]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
-      expect(leadPokemon).not.toBe(undefined);
-
-      const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).not.toBe(undefined);
 
       game.move.select(Moves.EARTHQUAKE);
-      await game.phaseInterceptor.to(DamagePhase, false);
+      await game.phaseInterceptor.to("DamagePhase", false);
 
       expect(leadPokemon.turnData.hitCount).toBe(2);
     }, TIMEOUT
   );
 
-  test(
-    "ability should only trigger post-target move effects once",
+  it(
+    "should only trigger post-target move effects once",
     async () => {
       game.override.moveset([Moves.MIND_BLOWN]);
 
-      await game.startBattle([Species.PIDGEOT]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
-      expect(leadPokemon).not.toBe(undefined);
-
-      const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).not.toBe(undefined);
 
       game.move.select(Moves.MIND_BLOWN);
 
-      await game.phaseInterceptor.to(DamagePhase, false);
+      await game.phaseInterceptor.to("DamagePhase", false);
 
       expect(leadPokemon.turnData.hitCount).toBe(2);
 
       // This test will time out if the user faints
-      await game.phaseInterceptor.to(BerryPhase, false);
+      await game.phaseInterceptor.to("BerryPhase", false);
 
-      expect(leadPokemon.hp).toBe(toDmgValue(leadPokemon.getMaxHp() / 2));
+      expect(leadPokemon.hp).toBe(Math.ceil(leadPokemon.getMaxHp() / 2));
     }, TIMEOUT
   );
 
-  test(
-    "Burn Up only removes type after second strike with this ability",
+  it(
+    "Burn Up only removes type after the second strike",
     async () => {
       game.override.moveset([Moves.BURN_UP]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.CHARIZARD]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
-      expect(leadPokemon).not.toBe(undefined);
-
       const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).not.toBe(undefined);
 
       game.move.select(Moves.BURN_UP);
 
-      await game.phaseInterceptor.to(DamagePhase);
+      await game.phaseInterceptor.to("MoveEffectPhase");
 
       expect(leadPokemon.turnData.hitCount).toBe(2);
       expect(enemyPokemon.hp).toBeGreaterThan(0);
       expect(leadPokemon.isOfType(Type.FIRE)).toBe(true);
 
-      await game.phaseInterceptor.to(BerryPhase, false);
+      await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(leadPokemon.isOfType(Type.FIRE)).toBe(false);
     }, TIMEOUT
   );
 
-  test(
+  it(
     "Moves boosted by this ability and Multi-Lens should strike 4 times",
     async () => {
       game.override.moveset([Moves.TACKLE]);
       game.override.startingHeldItems([{ name: "MULTI_LENS", count: 1 }]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
-      expect(leadPokemon).not.toBe(undefined);
-
-      const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).not.toBe(undefined);
 
       game.move.select(Moves.TACKLE);
 
-      await game.phaseInterceptor.to(DamagePhase);
+      await game.phaseInterceptor.to("DamagePhase");
 
       expect(leadPokemon.turnData.hitCount).toBe(4);
     }, TIMEOUT
   );
 
-  test(
+  it(
     "Super Fang boosted by this ability and Multi-Lens should strike twice",
     async () => {
       game.override.moveset([Moves.SUPER_FANG]);
       game.override.startingHeldItems([{ name: "MULTI_LENS", count: 1 }]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
-      expect(leadPokemon).not.toBe(undefined);
-
       const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).not.toBe(undefined);
-
-      const enemyStartingHp = enemyPokemon.hp;
 
       game.move.select(Moves.SUPER_FANG);
       await game.move.forceHit();
 
-      await game.phaseInterceptor.to(DamagePhase);
+      await game.phaseInterceptor.to("DamagePhase");
 
       expect(leadPokemon.turnData.hitCount).toBe(2);
 
-      await game.phaseInterceptor.to(MoveEndPhase, false);
+      await game.phaseInterceptor.to("MoveEndPhase", false);
 
-      expect(enemyPokemon.hp).toBe(Math.ceil(enemyStartingHp * 0.25));
+      expect(enemyPokemon.hp).toBe(Math.ceil(enemyPokemon.getMaxHp() * 0.25));
     }, TIMEOUT
   );
 
-  test(
+  it(
     "Seismic Toss boosted by this ability and Multi-Lens should strike twice",
     async () => {
       game.override.moveset([Moves.SEISMIC_TOSS]);
       game.override.startingHeldItems([{ name: "MULTI_LENS", count: 1 }]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
-      expect(leadPokemon).not.toBe(undefined);
-
       const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).not.toBe(undefined);
 
       const enemyStartingHp = enemyPokemon.hp;
 
       game.move.select(Moves.SEISMIC_TOSS);
       await game.move.forceHit();
 
-      await game.phaseInterceptor.to(DamagePhase);
+      await game.phaseInterceptor.to("DamagePhase");
 
       expect(leadPokemon.turnData.hitCount).toBe(2);
 
-      await game.phaseInterceptor.to(MoveEndPhase, false);
+      await game.phaseInterceptor.to("MoveEndPhase", false);
 
       expect(enemyPokemon.hp).toBe(enemyStartingHp - 200);
     }, TIMEOUT
   );
 
-  test(
+  it(
     "Hyper Beam boosted by this ability should strike twice, then recharge",
     async () => {
       game.override.moveset([Moves.HYPER_BEAM]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
-      expect(leadPokemon).not.toBe(undefined);
-
-      const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).not.toBe(undefined);
 
       game.move.select(Moves.HYPER_BEAM);
       await game.move.forceHit();
 
-      await game.phaseInterceptor.to(DamagePhase);
+      await game.phaseInterceptor.to("DamagePhase");
 
       expect(leadPokemon.turnData.hitCount).toBe(2);
       expect(leadPokemon.getTag(BattlerTagType.RECHARGING)).toBeUndefined();
 
-      await game.phaseInterceptor.to(TurnEndPhase);
+      await game.phaseInterceptor.to("TurnEndPhase");
 
       expect(leadPokemon.getTag(BattlerTagType.RECHARGING)).toBeDefined();
     }, TIMEOUT
   );
 
-  /** TODO: Fix TRAPPED tag lapsing incorrectly, then run this test */
-  test(
+  it(
     "Anchor Shot boosted by this ability should only trap the target after the second hit",
     async () => {
       game.override.moveset([Moves.ANCHOR_SHOT]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
-      expect(leadPokemon).not.toBe(undefined);
-
       const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).not.toBe(undefined);
 
       game.move.select(Moves.ANCHOR_SHOT);
       await game.move.forceHit();
 
-      await game.phaseInterceptor.to(DamagePhase);
+      await game.phaseInterceptor.to("DamagePhase");
 
       expect(leadPokemon.turnData.hitCount).toBe(2);
-      expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined(); // Passes
+      expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
 
-      await game.phaseInterceptor.to(MoveEndPhase);
-      expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeDefined(); // Passes
+      await game.phaseInterceptor.to("MoveEndPhase");
+      expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeDefined();
 
-      await game.phaseInterceptor.to(TurnEndPhase);
+      await game.phaseInterceptor.to("TurnEndPhase");
 
-      expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeDefined(); // Fails :(
+      expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeDefined();
     }, TIMEOUT
   );
 
-  test(
+  it(
     "Smack Down boosted by this ability should only ground the target after the second hit",
     async () => {
       game.override.moveset([Moves.SMACK_DOWN]);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
-      expect(leadPokemon).not.toBe(undefined);
-
       const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).not.toBe(undefined);
 
       game.move.select(Moves.SMACK_DOWN);
       await game.move.forceHit();
 
-      await game.phaseInterceptor.to(DamagePhase);
+      await game.phaseInterceptor.to("DamagePhase");
 
       expect(leadPokemon.turnData.hitCount).toBe(2);
       expect(enemyPokemon.getTag(BattlerTagType.IGNORE_FLYING)).toBeUndefined();
 
-      await game.phaseInterceptor.to(TurnEndPhase);
+      await game.phaseInterceptor.to("TurnEndPhase");
 
       expect(enemyPokemon.getTag(BattlerTagType.IGNORE_FLYING)).toBeDefined();
     }, TIMEOUT
   );
 
-  test(
+  it(
     "U-turn boosted by this ability should strike twice before forcing a switch",
     async () => {
       game.override.moveset([Moves.U_TURN]);
 
-      await game.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
+      await game.classicMode.startBattle([Species.MAGIKARP, Species.BLASTOISE]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
-      expect(leadPokemon).not.toBe(undefined);
-
-      const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).not.toBe(undefined);
 
       game.move.select(Moves.U_TURN);
       await game.move.forceHit();
 
-      await game.phaseInterceptor.to(MoveEffectPhase);
+      await game.phaseInterceptor.to("MoveEffectPhase");
       expect(leadPokemon.turnData.hitCount).toBe(2);
 
       // This will cause this test to time out if the switch was forced on the first hit.
-      await game.phaseInterceptor.to(MoveEffectPhase, false);
+      await game.phaseInterceptor.to("MoveEffectPhase", false);
     }, TIMEOUT
   );
 
-  test(
+  it(
     "Wake-Up Slap boosted by this ability should only wake up the target after the second hit",
     async () => {
       game.override.moveset([Moves.WAKE_UP_SLAP]).enemyStatusEffect(StatusEffect.SLEEP);
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
-      expect(leadPokemon).not.toBe(undefined);
-
       const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).not.toBe(undefined);
 
       game.move.select(Moves.WAKE_UP_SLAP);
       await game.move.forceHit();
 
-      await game.phaseInterceptor.to(DamagePhase);
+      await game.phaseInterceptor.to("DamagePhase");
 
       expect(leadPokemon.turnData.hitCount).toBe(2);
       expect(enemyPokemon.status?.effect).toBe(StatusEffect.SLEEP);
 
-      await game.phaseInterceptor.to(BerryPhase, false);
+      await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(enemyPokemon.status?.effect).toBeUndefined();
     }, TIMEOUT
   );
 
-  test(
-    "ability should not cause user to hit into King's Shield more than once",
+  it(
+    "should not cause user to hit into King's Shield more than once",
     async () => {
       game.override.moveset([Moves.TACKLE]);
-      game.override.enemyMoveset([Moves.KINGS_SHIELD, Moves.KINGS_SHIELD, Moves.KINGS_SHIELD, Moves.KINGS_SHIELD]);
+      game.override.enemyMoveset(Array(4).fill(Moves.KINGS_SHIELD));
 
-      await game.startBattle([Species.CHARIZARD]);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const leadPokemon = game.scene.getPlayerPokemon()!;
-      expect(leadPokemon).not.toBe(undefined);
-
-      const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).not.toBe(undefined);
 
       game.move.select(Moves.TACKLE);
 
-      await game.phaseInterceptor.to(BerryPhase, false);
+      await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(leadPokemon.getStatStage(Stat.ATK)).toBe(-1);
     }, TIMEOUT
   );
 
-  test(
-    "ability should not cause user to hit into Storm Drain more than once",
+  it(
+    "should not cause user to hit into Storm Drain more than once",
     async () => {
       game.override.moveset([Moves.WATER_GUN]);
       game.override.enemyAbility(Abilities.STORM_DRAIN);
 
-      await game.startBattle([Species.CHARIZARD]);
-
-      const leadPokemon = game.scene.getPlayerPokemon()!;
-      expect(leadPokemon).not.toBe(undefined);
+      await game.classicMode.startBattle([Species.MAGIKARP]);
 
       const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).not.toBe(undefined);
 
       game.move.select(Moves.WATER_GUN);
 
-      await game.phaseInterceptor.to(BerryPhase, false);
+      await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(1);
     }, TIMEOUT
   );
 
-  test(
-    "ability should not apply to multi-target moves with Multi-Lens",
+  it(
+    "should not apply to multi-target moves with Multi-Lens",
     async () => {
       game.override.battleType("double");
       game.override.moveset([Moves.EARTHQUAKE, Moves.SPLASH]);
+      game.override.passiveAbility(Abilities.LEVITATE);
       game.override.startingHeldItems([{ name: "MULTI_LENS", count: 1 }]);
 
-      await game.startBattle([Species.CHARIZARD, Species.PIDGEOT]);
-
-      const playerPokemon = game.scene.getPlayerField();
-      expect(playerPokemon.length).toBe(2);
-      playerPokemon.forEach(p => expect(p).not.toBe(undefined));
+      await game.classicMode.startBattle([Species.MAGIKARP, Species.FEEBAS]);
 
       const enemyPokemon = game.scene.getEnemyField();
-      expect(enemyPokemon.length).toBe(2);
-      enemyPokemon.forEach(p => expect(p).not.toBe(undefined));
 
       const enemyStartingHp = enemyPokemon.map(p => p.hp);
 
       game.move.select(Moves.EARTHQUAKE);
-      await game.phaseInterceptor.to(CommandPhase);
-
       game.move.select(Moves.SPLASH, 1);
 
-      await game.phaseInterceptor.to(MoveEffectPhase, false);
-
-      await game.phaseInterceptor.to(DamagePhase);
+      await game.phaseInterceptor.to("DamagePhase");
       const enemyFirstHitDamage = enemyStartingHp.map((hp, i) => hp - enemyPokemon[i].hp);
 
-      await game.phaseInterceptor.to(BerryPhase, false);
+      await game.phaseInterceptor.to("BerryPhase", false);
 
       enemyPokemon.forEach((p, i) => expect(enemyStartingHp[i] - p.hp).toBe(2 * enemyFirstHitDamage[i]));
-
     }, TIMEOUT
   );
 });


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
A test for Parental Bond failed randomly in a PR, and the tests could use some cleanup

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
`test/abilities/parental_bond.test`:
- Magikarp/Feebas are now used as player Pokemon for most of the tests instead of Charizard/Pidgeot to eliminate the risk of unexpectedly KOing enemy Pokemon. Previously, the Wake-Up Slap test would sometimes fail because Charizard had a chance to OHKO the enemy Snorlax if Snorlax spawned with a -Def nature.
- Removed unnecessary checks on whether the player and enemy Pokemon were defined (`battle` tests already cover this)
- Updated deprecated `startBattle` calls to `classicMode.startBattle`
- Removed outdated comments
- Other small style changes

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
N/A

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
`npm run test parental_bond`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [n/a] Are the changes visual?
  - [n/a] Have I provided screenshots/videos of the changes?
