### PR TITLE
[Test] Fix Rage Powder test failing randomly

### DIFF
--- a/src/test/moves/rage_powder.test.ts
+++ b/src/test/moves/rage_powder.test.ts
@@ -68,6 +68,10 @@ describe("Moves - Rage Powder", () => {
 
       game.move.select(Moves.QUICK_ATTACK, 0, BattlerIndex.ENEMY);
       game.move.select(Moves.QUICK_ATTACK, 1, BattlerIndex.ENEMY_2);
+
+      await game.forceEnemyMove(Moves.RAGE_POWDER);
+      await game.forceEnemyMove(Moves.SPLASH);
+
       await game.phaseInterceptor.to("BerryPhase", false);
 
       // If redirection was bypassed, both enemies should be damaged

--- a/src/test/moves/rage_powder.test.ts
+++ b/src/test/moves/rage_powder.test.ts
@@ -25,7 +25,6 @@ describe("Moves - Rage Powder", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     game.override.battleType("double");
-    game.override.starterSpecies(Species.AMOONGUSS);
     game.override.enemySpecies(Species.SNORLAX);
     game.override.startingLevel(100);
     game.override.enemyLevel(100);


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
closes #4034 

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
`test/moves/rage_powder.test`:
- Added missing calls to `forceEnemyMove`. Exactly one enemy is now forced to use Rage Powder in the test that was failing
- Removed a redundant `starterSpecies` override

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
N/A

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
`npm run test rage_powder`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [n/a] Are the changes visual?
  - [n/a] Have I provided screenshots/videos of the changes?
