### PR TITLE
[Balance] Same-Species Eggs Shiny Rate Increase

### DIFF
--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -15,7 +15,7 @@ export const EGG_SEED = 1073741824;
 // Rates for specific random properties in 1/x
 const DEFAULT_SHINY_RATE = 128;
 const GACHA_SHINY_UP_SHINY_RATE = 64;
-const SAME_SPECIES_EGG_SHINY_RATE = 24;
+const SAME_SPECIES_EGG_SHINY_RATE = 12;
 const SAME_SPECIES_EGG_HA_RATE = 8;
 const MANAPHY_EGG_MANAPHY_RATE = 8;
 const GACHA_EGG_HA_RATE = 192;


### PR DESCRIPTION
## What are the changes the user will see?
Higher likelihood of Same-Species Eggs giving shiny pokemon.
- Rates have gone from 1/24 -> 1/12

## Why am I making these changes?
The MATH ain't MATHING! It might be cooked.

## What are the changes from a developer perspective?
A 24 -> 12

## How to test the changes?
Merge to a local or play on the beta, spam same-species eggs.
Or just do math.

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)