### PR TITLE
[Bug] Fix Aura Break applying without Dark/Fairy Aura present

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -5334,7 +5334,9 @@ export function initAbilities() {
     new Ability(Abilities.AURA_BREAK, 6)
       .ignorable()
       .conditionalAttr(pokemon => pokemon.scene.getField(true).some(p => p.hasAbility(Abilities.DARK_AURA)), FieldMoveTypePowerBoostAbAttr, Type.DARK, 9 / 16)
-      .conditionalAttr(pokemon => pokemon.scene.getField(true).some(p => p.hasAbility(Abilities.FAIRY_AURA)), FieldMoveTypePowerBoostAbAttr, Type.FAIRY, 9 / 16),
+      .conditionalAttr(pokemon => pokemon.scene.getField(true).some(p => p.hasAbility(Abilities.FAIRY_AURA)), FieldMoveTypePowerBoostAbAttr, Type.FAIRY, 9 / 16)
+      .conditionalAttr(pokemon => pokemon.scene.getField(true).some(p => p.hasAbility(Abilities.DARK_AURA) || p.hasAbility(Abilities.FAIRY_AURA)),
+        PostSummonMessageAbAttr, (pokemon: Pokemon) => i18next.t("abilityTriggers:postSummonAuraBreak", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) })),
     new Ability(Abilities.PRIMORDIAL_SEA, 6)
       .attr(PostSummonWeatherChangeAbAttr, WeatherType.HEAVY_RAIN)
       .attr(PostBiomeChangeWeatherChangeAbAttr, WeatherType.HEAVY_RAIN)

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -5333,8 +5333,8 @@ export function initAbilities() {
       .attr(FieldMoveTypePowerBoostAbAttr, Type.FAIRY, 4 / 3),
     new Ability(Abilities.AURA_BREAK, 6)
       .ignorable()
-      .conditionalAttr(target => target.hasAbility(Abilities.DARK_AURA), FieldMoveTypePowerBoostAbAttr, Type.DARK, 9 / 16)
-      .conditionalAttr(target => target.hasAbility(Abilities.FAIRY_AURA), FieldMoveTypePowerBoostAbAttr, Type.FAIRY, 9 / 16),
+      .conditionalAttr(pokemon => pokemon.scene.getField(true).some(p => p.hasAbility(Abilities.DARK_AURA)), FieldMoveTypePowerBoostAbAttr, Type.DARK, 9 / 16)
+      .conditionalAttr(pokemon => pokemon.scene.getField(true).some(p => p.hasAbility(Abilities.FAIRY_AURA)), FieldMoveTypePowerBoostAbAttr, Type.FAIRY, 9 / 16),
     new Ability(Abilities.PRIMORDIAL_SEA, 6)
       .attr(PostSummonWeatherChangeAbAttr, WeatherType.HEAVY_RAIN)
       .attr(PostBiomeChangeWeatherChangeAbAttr, WeatherType.HEAVY_RAIN)

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -757,7 +757,10 @@ export default class Move implements Localizable {
 
     const fieldAuras = new Set(
       source.scene.getField(true)
-        .map((p) => p.getAbilityAttrs(FieldMoveTypePowerBoostAbAttr) as FieldMoveTypePowerBoostAbAttr[])
+        .map((p) => p.getAbilityAttrs(FieldMoveTypePowerBoostAbAttr).filter(attr => {
+          const condition = attr.getCondition();
+          return (!condition || condition(p));
+        }) as FieldMoveTypePowerBoostAbAttr[])
         .flat(),
     );
     for (const aura of fieldAuras) {

--- a/src/locales/en/ability-trigger.json
+++ b/src/locales/en/ability-trigger.json
@@ -52,6 +52,7 @@
   "postSummonTeravolt": "{{pokemonNameWithAffix}} is radiating a bursting aura!",
   "postSummonDarkAura": "{{pokemonNameWithAffix}} is radiating a Dark Aura!",
   "postSummonFairyAura": "{{pokemonNameWithAffix}} is radiating a Fairy Aura!",
+  "postSummonAuraBreak": "{{pokemonNameWithAffix}} reversed all other Pokémon's auras!",
   "postSummonNeutralizingGas": "{{pokemonNameWithAffix}}'s Neutralizing Gas filled the area!",
   "postSummonAsOneGlastrier": "{{pokemonNameWithAffix}} has two Abilities!",
   "postSummonAsOneSpectrier": "{{pokemonNameWithAffix}} has two Abilities!",

--- a/src/test/abilities/aura_break.test.ts
+++ b/src/test/abilities/aura_break.test.ts
@@ -1,5 +1,4 @@
 import { allMoves } from "#app/data/move";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
@@ -33,31 +32,45 @@ describe("Abilities - Aura Break", () => {
     game.override.enemySpecies(Species.SHUCKLE);
   });
 
-  it("reverses the effect of fairy aura", async () => {
+  it("reverses the effect of Fairy Aura", async () => {
     const moveToCheck = allMoves[Moves.MOONBLAST];
     const basePower = moveToCheck.power;
 
     game.override.ability(Abilities.FAIRY_AURA);
     vi.spyOn(moveToCheck, "calculateBattlePower");
 
-    await game.startBattle([Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU]);
     game.move.select(Moves.MOONBLAST);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(moveToCheck.calculateBattlePower).toHaveReturnedWith(expect.closeTo(basePower * auraBreakMultiplier));
   });
 
-  it("reverses the effect of dark aura", async () => {
+  it("reverses the effect of Dark Aura", async () => {
     const moveToCheck = allMoves[Moves.DARK_PULSE];
     const basePower = moveToCheck.power;
 
     game.override.ability(Abilities.DARK_AURA);
     vi.spyOn(moveToCheck, "calculateBattlePower");
 
-    await game.startBattle([Species.PIKACHU]);
+    await game.classicMode.startBattle([Species.PIKACHU]);
     game.move.select(Moves.DARK_PULSE);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(moveToCheck.calculateBattlePower).toHaveReturnedWith(expect.closeTo(basePower * auraBreakMultiplier));
+  });
+
+  it("has no effect if neither Fairy Aura nor Dark Aura are present", async () => {
+    const moveToCheck = allMoves[Moves.MOONBLAST];
+    const basePower = moveToCheck.power;
+
+    game.override.ability(Abilities.BALL_FETCH);
+    vi.spyOn(moveToCheck, "calculateBattlePower");
+
+    await game.classicMode.startBattle([Species.PIKACHU]);
+    game.move.select(Moves.MOONBLAST);
+    await game.phaseInterceptor.to("MoveEffectPhase");
+
+    expect(moveToCheck.calculateBattlePower).toHaveReturnedWith(basePower);
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?
This fixes a bug where Aura Break would apply its power debuff despite Dark and/or Fairy Aura not being present on the field

## Why am I making these changes?
closes #4050 

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- `data/ability`: Changed Aura Break's condition (in its `conditionalAttr`s) to check all active Pokemon on the field for Dark/Fairy Aura instead of a single "target" Pokemon (or, really, just Aura Break's source under a misnamed arg).
- `data/move`: Changed `Move#calculateBattlePower` so that field aura attributes that don't satisfy their conditions from `getCondition()` are filtered out before applying.
- `test/abilities/aura_break.test`: New test covering the case where neither Dark Aura nor Fairy Aura are present.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
`npm run test aura_break`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [?] Are the changes visual?
  - [?] Have I provided screenshots/videos of the changes?
