### PR TITLE
[Bug] Missing endless end dialogue

### DIFF
--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -49,7 +49,9 @@ export class GameOverPhase extends BattlePhase {
     }
 
     if (this.victory && this.scene.gameMode.isEndless) {
-      this.scene.ui.showDialogue(i18next.t("PGMmiscDialogue:ending_endless"), i18next.t("PGMmiscDialogue:ending_name"), 0, () => this.handleGameOver());
+      const genderIndex = this.scene.gameData.gender ?? PlayerGender.UNSET;
+      const genderStr = PlayerGender[genderIndex].toLowerCase();
+      this.scene.ui.showDialogue(i18next.t("miscDialogue:ending_endless", { context: genderStr }), i18next.t("miscDialogue:ending_name"), 0, () => this.handleGameOver());
     } else if (this.victory || !this.scene.enableRetries) {
       this.handleGameOver();
     } else {


### PR DESCRIPTION
## What are the changes the user will see?
They will see the actual endless end dialogue

## Why am I making these changes?
It was only displaying `ending_endless` because the `PGM` prefix was still present

## What are the changes from a developer perspective?
`PGM` prefix was removed. Gender context is now passed

## Screenshots/Videos

### Before

<details>
  <summary>📷 Screenshot (Before)</summary>

![image](https://github.com/user-attachments/assets/386a27b4-e140-4916-8a61-c2cc694d7c41)

</details>

### After

https://github.com/user-attachments/assets/f22dc6e3-3b1d-4c9f-9706-9578432ef8bf

## How to test the changes?

### Overrides

```ts
const overrides = {
  STARTING_WAVE_OVERRIDE: 5850,
  OPP_LEVEL_OVERRIDE: 1,
  OPP_SPECIES_OVERRIDE: Species.MAGIKARP,
  STARTING_LEVEL_OVERRIDE: 10000,
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~~[ ] Have I considered writing automated tests for the issue?~~
- ~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
