### PR TITLE
[Feature] Toggle Pokemon cries (during battle)

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -140,6 +140,8 @@ export default class BattleScene extends SceneBase {
   public enableMoveInfo: boolean = true;
   public enableRetries: boolean = false;
   public hideIvs: boolean = false;
+  /** Toggle Pokemon cries */
+  public enablePokemonCries: boolean = true;
   /**
    * Determines the condition for a notification should be shown for Candy Upgrades
    * - 0 = 'Off'

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2767,6 +2767,10 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   faintCry(callback: Function): void {
+    if (!this.scene.enablePokemonCries) {
+      return callback();
+    } //skip cry and callback immediately
+
     if (this.fusionSpecies && this.getSpeciesForm() !== this.getFusionSpeciesForm()) {
       return this.fusionFaintCry(callback);
     }

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -104,5 +104,5 @@
   "reroll": "Reroll",
   "shop": "Shop",
   "checkTeam": "Check Team",
-  "pokemonCries": "Pokemon Cries"
+  "pokemonCries": "Pokémon Cries"
 }

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -103,5 +103,6 @@
   "rewards": "Rewards",
   "reroll": "Reroll",
   "shop": "Shop",
-  "checkTeam": "Check Team"
+  "checkTeam": "Check Team",
+  "pokemonCries": "Pokemon Cries"
 }

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -232,7 +232,9 @@ export class EncounterPhase extends BattlePhase {
     if (this.scene.currentBattle.battleType === BattleType.WILD) {
       enemyField.forEach(enemyPokemon => {
         enemyPokemon.untint(100, "Sine.easeOut");
-        enemyPokemon.cry();
+        if (this.scene.enablePokemonCries) {
+          enemyPokemon.cry();
+        }
         enemyPokemon.showInfo();
         if (enemyPokemon.isShiny()) {
           this.scene.validateAchv(achvs.SEE_SHINY);

--- a/src/phases/summon-phase.ts
+++ b/src/phases/summon-phase.ts
@@ -155,10 +155,12 @@ export class SummonPhase extends PartyMemberPokemonPhase {
               ease: "Sine.easeIn",
               scale: pokemon.getSpriteScale(),
               onComplete: () => {
-                pokemon.cry(pokemon.getHpRatio() > 0.25 ? undefined : { rate: 0.85 });
+                if (this.scene.enablePokemonCries) {
+                  pokemon.cry(pokemon.getHpRatio() > 0.25 ? undefined : { rate: 0.85 });
+                }
                 pokemon.getSprite().clearTint();
                 pokemon.resetSummonData();
-                this.scene.time.delayedCall(1000, () => this.end());
+                this.scene.time.delayedCall(this.scene.enablePokemonCries ? 1000 : 100, () => this.end());
               }
             });
           }

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -159,7 +159,8 @@ export const SettingKeys = {
   Music_Preference: "MUSIC_PREFERENCE",
   Show_BGM_Bar: "SHOW_BGM_BAR",
   Move_Touch_Controls: "MOVE_TOUCH_CONTROLS",
-  Shop_Overlay_Opacity: "SHOP_OVERLAY_OPACITY"
+  Shop_Overlay_Opacity: "SHOP_OVERLAY_OPACITY",
+  Pokemon_Cries: "POKEMON_CRIES",
 };
 
 /**
@@ -618,6 +619,22 @@ export const Setting: Array<Setting> = [
     requireReload: true
   },
   {
+    key: SettingKeys.Pokemon_Cries,
+    label: i18next.t("settings:pokemonCries"),
+    options: [
+      {
+        value: "On",
+        label: i18next.t("settings:on")
+      },
+      {
+        value: "Off",
+        label: i18next.t("settings:off")
+      }
+    ],
+    default: 0,
+    type: SettingType.AUDIO,
+  },
+  {
     key: SettingKeys.Move_Touch_Controls,
     label: i18next.t("settings:moveTouchControls"),
     options: [
@@ -894,6 +911,9 @@ export function setSetting(scene: BattleScene, setting: string, value: integer):
     break;
   case SettingKeys.Shop_Overlay_Opacity:
     scene.updateShopOverlayOpacity(parseInt(Setting[index].options[value].value) * .01);
+    break;
+  case SettingKeys.Pokemon_Cries:
+    scene.enablePokemonCries = Setting[index].options[value].value === "On";
     break;
   }
 

--- a/src/test/utils/gameManager.ts
+++ b/src/test/utils/gameManager.ts
@@ -147,6 +147,8 @@ export default class GameManager {
     this.scene.enableTutorials = false;
     this.scene.gameData.gender = PlayerGender.MALE; // set initial player gender
     this.scene.battleStyle = this.settings.battleStyle;
+
+    this.settings.enablePokemonCries(false);
   }
 
   /**

--- a/src/test/utils/helpers/settingsHelper.ts
+++ b/src/test/utils/helpers/settingsHelper.ts
@@ -38,7 +38,17 @@ export class SettingsHelper extends GameManagerHelper {
     this.log(`Gender set to: ${PlayerGender[gender]} (=${gender})` );
   }
 
+  /**
+   * Toggle Pokemon cries (during battle only)
+   * @param enable true to enable, false to disable
+   */
+  enablePokemonCries(enable: boolean) {
+    this.game.scene.enablePokemonCries = enable;
+    this.log(`Pokemon Cries have been ${enable? "enabled" : "disabled"}!` );
+  }
+
   private log(...params: any[]) {
     console.log("Settings:", ...params);
   }
+
 }

--- a/src/ui/settings/settings-audio-ui-handler.ts
+++ b/src/ui/settings/settings-audio-ui-handler.ts
@@ -15,6 +15,6 @@ export default class SettingsAudioUiHandler extends AbstractSettingsUiHandler {
     super(scene, SettingType.AUDIO, mode);
     this.title = "Audio";
     this.localStorageKey = "settings";
-    this.rowsToDisplay = 6;
+    this.rowsToDisplay = 7;
   }
 }


### PR DESCRIPTION
## What are the changes the user will see?

A new setting will be available to turn PKM cries on/off during battle. 
> [!WARNING]
> This will not affect cries in the starter-select screen or in the evolution phase!

## Why am I making these changes?
It's a highly requested feature and can also speed up tests

## What are the changes from a developer perspective?
The `BattleScene` has a new field called `enablePokemonCries` (Same old...).
This fields value is checked during `faintCry()`, `encounter-phase` and `summon-phase`.
Some callback delay values are automatically adjusted too as we don't want the player to have to wait for a cry that isn't even being played.

### Screenshots/Videos

<img width="946" alt="image" src="https://github.com/user-attachments/assets/22e0bef1-b1d5-4375-a0d2-625adb8e028d">

## How to test the changes?

- Adjust the setting to on or off
- Play 1 wave and make sure that both your pokemon and the enemy pokemon is fainted to check if the faint cries are also (not) playing

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~~[ ] Have I considered writing automated tests for the issue?~~
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
