### PR TITLE
[Bug] Fix line spacing in level up stats and move info for japanese

### DIFF
--- a/src/ui/battle-message-ui-handler.ts
+++ b/src/ui/battle-message-ui-handler.ts
@@ -97,6 +97,7 @@ export default class BattleMessageUiHandler extends MessageUiHandler {
     this.levelUpStatsContainer = levelUpStatsContainer;
 
     const levelUpStatsLabelsContent = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 73, -94, "", TextStyle.WINDOW, { maxLines: 6 });
+    levelUpStatsLabelsContent.setLineSpacing(i18next.resolvedLanguage === "ja" ? 25 : 5);
     let levelUpStatsLabelText = "";
 
     for (const s of PERMANENT_STATS) {
@@ -112,11 +113,13 @@ export default class BattleMessageUiHandler extends MessageUiHandler {
     levelUpStatsContainer.add(levelUpStatsLabelsContent);
 
     const levelUpStatsIncrContent = addTextObject(this.scene, (this.scene.game.canvas.width / 6) - 50, -94, "+\n+\n+\n+\n+\n+", TextStyle.WINDOW, { maxLines: 6 });
+    levelUpStatsIncrContent.setLineSpacing(i18next.resolvedLanguage === "ja" ? 25 : 5);
     levelUpStatsContainer.add(levelUpStatsIncrContent);
 
     this.levelUpStatsIncrContent = levelUpStatsIncrContent;
 
     const levelUpStatsValuesContent = addBBCodeTextObject(this.scene, (this.scene.game.canvas.width / 6) - 7, -94, "", TextStyle.WINDOW, { maxLines: 6, lineSpacing: 5});
+    levelUpStatsValuesContent.setLineSpacing(i18next.resolvedLanguage === "ja" ? 25 : 5);
     levelUpStatsValuesContent.setOrigin(1, 0);
     levelUpStatsValuesContent.setAlign("right");
     levelUpStatsContainer.add(levelUpStatsValuesContent);

--- a/src/ui/move-info-overlay.ts
+++ b/src/ui/move-info-overlay.ts
@@ -58,6 +58,7 @@ export default class MoveInfoOverlay extends Phaser.GameObjects.Container implem
 
     // set up the description; wordWrap uses true pixels, unaffected by any scaling, while other values are affected
     this.desc = addTextObject(scene, (options?.onSide && !options?.right ? EFF_WIDTH : 0) + BORDER, (options?.top ? EFF_HEIGHT : 0) + BORDER - 2, "", TextStyle.BATTLE_INFO, { wordWrap: { width: (width - (BORDER - 2) * 2 - (options?.onSide ? EFF_WIDTH : 0)) * GLOBAL_SCALE } });
+    this.desc.setLineSpacing(i18next.resolvedLanguage === "ja" ? 25 : 5);
 
     // limit the text rendering, required for scrolling later on
     const maskPointOrigin = {


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
Adjusted line spacing for move descriptions and level-up stats specifically in the Japanese language.

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
These changes were requested by the Japanese translation team.

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- The code now explicitly sets the line spacing for Japanese (ja) text using `setLineSpacing`. 
- For non-Japanese languages, the original line spacing values are retained to ensure no impact.

Additional Context:
- From the beginning of the Japanese support Pull Request ([PR](https://github.com/pagefaultgames/pokerogue/pull/2771/files#diff-0c7c16933483d4f2435326a1a85bf96441cadd77b72b1110fa6836cd886d6636)), the codebase has accumulated numerous `if` conditions to handle edge cases pertaining to the Japanese language. This PR's changes are a continuation of such special handling.
- Efforts to verify the initial purpose and the appropriateness of this strategy were undertaken via communication on [Discord](https://discord.com/channels/1125469663833370665/1176874654015684739/1281992507726757921). However, the original author of the code is currently [unavailable.](https://discord.com/channels/1125469663833370665/1176874654015684739/1281993435443892316) 
- With [@Tempo-anon approval](https://discord.com/channels/1125469663833370665/1176874654015684739/1282002261077393529), it was decided to override the line spacing specifically for the Japanese language in the affected areas.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
- before
![Screenshot_2024-09-04_195836](https://github.com/user-attachments/assets/7dfda417-baf4-401f-80c3-f74bf1989972)
![Screenshot_2024-09-04_192021](https://github.com/user-attachments/assets/45935062-c2b4-43b1-a179-46dd13c0c8e3)

- after
<img width="1728" alt="Screenshot 2024-09-08 at 12 40 21 PM" src="https://github.com/user-attachments/assets/f44cb271-ee48-479f-afd6-c574440bb9e0">
<img width="1728" alt="Screenshot 2024-09-08 at 12 46 00 PM" src="https://github.com/user-attachments/assets/7ce08e48-1b5a-4c15-9f62-e8423daee284">


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
