### PR TITLE
[Hotfix] Fix harsh weather cancelling moves based on base type

### DIFF
--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -88,12 +88,14 @@ export class Weather {
     return 1;
   }
 
-  isMoveWeatherCancelled(move: Move): boolean {
+  isMoveWeatherCancelled(user: Pokemon, move: Move): boolean {
+    const moveType = user.getMoveType(move);
+
     switch (this.weatherType) {
     case WeatherType.HARSH_SUN:
-      return move instanceof AttackMove && move.type === Type.WATER;
+      return move instanceof AttackMove && moveType === Type.WATER;
     case WeatherType.HEAVY_RAIN:
-      return move instanceof AttackMove && move.type === Type.FIRE;
+      return move instanceof AttackMove && moveType === Type.FIRE;
     }
 
     return false;

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -391,8 +391,8 @@ export class Arena {
     return true;
   }
 
-  isMoveWeatherCancelled(move: Move) {
-    return this.weather && !this.weather.isEffectSuppressed(this.scene) && this.weather.isMoveWeatherCancelled(move);
+  isMoveWeatherCancelled(user: Pokemon, move: Move) {
+    return this.weather && !this.weather.isEffectSuppressed(this.scene) && this.weather.isMoveWeatherCancelled(user, move);
   }
 
   isMoveTerrainCancelled(user: Pokemon, targets: BattlerIndex[], move: Move) {

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -204,7 +204,7 @@ export class MovePhase extends BattlePhase {
       let success = this.move.getMove().applyConditions(this.pokemon, targets[0], this.move.getMove());
       const cancelled = new Utils.BooleanHolder(false);
       let failedText = this.move.getMove().getFailedText(this.pokemon, targets[0], this.move.getMove(), cancelled);
-      if (success && this.scene.arena.isMoveWeatherCancelled(this.move.getMove())) {
+      if (success && this.scene.arena.isMoveWeatherCancelled(this.pokemon, this.move.getMove())) {
         success = false;
       } else if (success && this.scene.arena.isMoveTerrainCancelled(this.pokemon, this.targets, this.move.getMove())) {
         success = false;


### PR DESCRIPTION
## What are the changes the user will see?
This fixes a bug where Harsh Sunlight and Heavy Rain would cancel moves based on their base type rather than their final type after move and ability effects are applied. For example, if a Tera-Water Pokemon uses Tera Blast in harsh sunlight, the Tera Blast will now have no effect.

## Why am I making these changes?
This type check is done outside of `Pokemon.apply`, so I missed this when updating type effectiveness earlier.

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
`data/arena` and `data/weather`: The `isMoveWeatherCancelled` functions in these files now take a new argument `user: Pokemon` and use `user.getMoveType(move)` instead of `move.type` in their type checks.

### Screenshots/Videos

https://github.com/user-attachments/assets/2fec1588-9222-4634-9087-ef043bf19a42

## How to test the changes?

## Checklist
- [n/a] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
