### PR TITLE
[Test] Fix Safeguard test that relied on a now-fixed bug

### DIFF
--- a/src/test/moves/safeguard.test.ts
+++ b/src/test/moves/safeguard.test.ts
@@ -38,7 +38,7 @@ describe("Moves - Safeguard", () => {
   });
 
   it("protects from damaging moves with additional effects", async () => {
-    await game.startBattle();
+    await game.classicMode.startBattle();
     const enemy = game.scene.getEnemyPokemon()!;
 
     game.move.select(Moves.NUZZLE);
@@ -49,7 +49,7 @@ describe("Moves - Safeguard", () => {
   }, TIMEOUT);
 
   it("protects from status moves", async () => {
-    await game.startBattle();
+    await game.classicMode.startBattle();
     const enemyPokemon = game.scene.getEnemyPokemon()!;
 
     game.move.select(Moves.SPORE);
@@ -61,7 +61,7 @@ describe("Moves - Safeguard", () => {
 
   it("protects from confusion", async () => {
     game.override.moveset([Moves.CONFUSE_RAY]);
-    await game.startBattle();
+    await game.classicMode.startBattle();
     const enemyPokemon = game.scene.getEnemyPokemon()!;
 
     game.move.select(Moves.CONFUSE_RAY);
@@ -74,7 +74,7 @@ describe("Moves - Safeguard", () => {
   it("protects ally from status", async () => {
     game.override.battleType("double");
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     game.move.select(Moves.SPORE, 0, BattlerIndex.ENEMY_2);
     game.move.select(Moves.NUZZLE, 1, BattlerIndex.ENEMY_2);
@@ -90,7 +90,7 @@ describe("Moves - Safeguard", () => {
   }, TIMEOUT);
 
   it("protects from Yawn", async () => {
-    await game.startBattle();
+    await game.classicMode.startBattle();
     const enemyPokemon = game.scene.getEnemyPokemon()!;
 
     game.move.select(Moves.YAWN);
@@ -101,7 +101,7 @@ describe("Moves - Safeguard", () => {
   }, TIMEOUT);
 
   it("doesn't protect from already existing Yawn", async () => {
-    await game.startBattle();
+    await game.classicMode.startBattle();
     const enemyPokemon = game.scene.getEnemyPokemon()!;
 
     game.move.select(Moves.YAWN);
@@ -116,12 +116,13 @@ describe("Moves - Safeguard", () => {
 
   it("doesn't protect from self-inflicted via Rest or Flame Orb", async () => {
     game.override.enemyHeldItems([{name: "FLAME_ORB"}]);
-    await game.startBattle();
+    await game.classicMode.startBattle();
     const enemyPokemon = game.scene.getEnemyPokemon()!;
 
     game.move.select(Moves.SPLASH);
     await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.toNextTurn();
+    enemyPokemon.damageAndUpdate(1);
 
     expect(enemyPokemon.status?.effect).toEqual(StatusEffect.BURN);
 
@@ -135,7 +136,7 @@ describe("Moves - Safeguard", () => {
   it("protects from ability-inflicted status", async () => {
     game.override.ability(Abilities.STATIC);
     vi.spyOn(allAbilities[Abilities.STATIC].getAttrs(PostDefendContactApplyStatusEffectAbAttr)[0], "chance", "get").mockReturnValue(100);
-    await game.startBattle();
+    await game.classicMode.startBattle();
     const enemyPokemon = game.scene.getEnemyPokemon()!;
 
     game.move.select(Moves.SPLASH);


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
The test is broken.

## What are the changes from a developer perspective?
The enemy Pokémon is now damaged before using Rest so that it will properly activate.

## How to test the changes?
`npm run test safeguard`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
