### PR TITLE
HOTFIX show enemy icons after egg summary

### DIFF
--- a/src/phases/egg-summary-phase.ts
+++ b/src/phases/egg-summary-phase.ts
@@ -45,6 +45,7 @@ export class EggSummaryPhase extends Phase {
   end() {
     this.eggHatchHandler.clear();
     this.scene.ui.setModeForceTransition(Mode.MESSAGE).then(() => {});
+    this.scene.time.delayedCall(250, () => this.scene.setModifiersVisible(true));
     super.end();
   }
 }


### PR DESCRIPTION

<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->
Fix missing line from egg summary phase. Sets enemy modifiers back to visible after the egg summary ends
### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

Before fix: missing enemy modifiers after egg summary page
<img width="1026" alt="Screenshot 2024-09-08 at 15 49 57" src="https://github.com/user-attachments/assets/c4c05108-b725-42c5-8fe7-5a727af59712">
<img width="1026" alt="Screenshot 2024-09-08 at 15 50 10" src="https://github.com/user-attachments/assets/cb7f4c75-9860-41e2-8e1a-01f323441e84">
<img width="1026" alt="Screenshot 2024-09-08 at 15 50 22" src="https://github.com/user-attachments/assets/599a3ac2-793e-431b-bef2-ab5dcf19ccb5">

WITH FIX:
<img width="1026" alt="Screenshot 2024-09-08 at 16 00 05" src="https://github.com/user-attachments/assets/eec6f69e-a5a9-452f-b057-385a5edced36">
Hatch eggs after wave 143:
<img width="1026" alt="Screenshot 2024-09-08 at 16 00 56" src="https://github.com/user-attachments/assets/7e4ce68a-203e-4907-973c-79ccd31bb1b6">
<img width="1026" alt="Screenshot 2024-09-08 at 16 01 03" src="https://github.com/user-attachments/assets/0ac79aba-68f8-4103-8e9a-e5435d7ccbcc">