### PR TITLE
[Hotfix] add catch for undefined egg moves

### DIFF
--- a/src/phases/egg-hatch-phase.ts
+++ b/src/phases/egg-hatch-phase.ts
@@ -448,6 +448,7 @@ export class EggHatchPhase extends Phase {
    */
   generatePokemon(): PlayerPokemon {
     this.eggHatchData = this.eggLapsePhase.generatePokemon(this.egg);
+    this.eggMoveIndex = this.eggHatchData.eggMoveIndex;
     return this.eggHatchData.pokemon;
   }
 }


### PR DESCRIPTION
When hatching regularly (one by one) the setEggMoves() was undefined, this was usually caught by the egg summary page which has a redundancy for setting the dex for the hatchData. However if there is no egg summary (less than 5 eggs) then the egg move is not set or displayed right.

Added a simply adaptation to set the egg hatch phase this.eggMoveIndex variable from the hatchData egg move index variable.
