### PR TITLE
[Hotfix] Remove extra Roark victory line, fix i18n in `achv.ts`

### DIFF
--- a/src/data/dialogue.ts
+++ b/src/data/dialogue.ts
@@ -1569,8 +1569,7 @@ export const trainerTypeDialogue: TrainerTypeDialogue = {
       "dialogue:roark.victory.1",
       "dialogue:roark.victory.2",
       "dialogue:roark.victory.3",
-      "dialogue:roark.victory.4",
-      "dialogue:roark.victory.5"
+      "dialogue:roark.victory.4"
     ],
     defeat: [
       "dialogue:roark.defeat.1",

--- a/src/system/achv.ts
+++ b/src/system/achv.ts
@@ -7,7 +7,7 @@ import * as Utils from "../utils";
 import { PlayerGender } from "#enums/player-gender";
 import { Challenge, FreshStartChallenge, SingleGenerationChallenge, SingleTypeChallenge, InverseBattleChallenge } from "#app/data/challenge";
 import { ConditionFn } from "#app/@types/common";
-import { Stat, getShortenedStatKey  } from "#app/enums/stat";
+import { Stat, getShortenedStatKey } from "#app/enums/stat";
 import { Challenges } from "#app/enums/challenges";
 
 export enum AchvTier {
@@ -197,7 +197,7 @@ export function getAchievementDescription(localizationKey: string): string {
   case "100_RIBBONS":
     return i18next.t("achv:RibbonAchv.description", {context: genderStr, "ribbonAmount": achvs._100_RIBBONS.ribbonAmount.toLocaleString("en-US")});
   case "TRANSFER_MAX_STAT_STAGE":
-    return i18next.t("achv:TRANSFER_MAX_BATTLE_STAT.description", { context: genderStr });
+    return i18next.t("achv:TRANSFER_MAX_STAT_STAGE.description", { context: genderStr });
   case "MAX_FRIENDSHIP":
     return i18next.t("achv:MAX_FRIENDSHIP.description", { context: genderStr });
   case "MEGA_EVOLVE":


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/286bdd77-3623-4bed-9640-934e60aeafb5)

![image](https://github.com/user-attachments/assets/1cf83373-428f-4209-95b4-73ccbcd43ace)
