### PR TITLE
[Bug] Fix reloads causing lures to refresh, and fix game version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pokemon-rogue-battle",
 	"private": true,
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"type": "module",
 	"scripts": {
 		"start": "vite",

--- a/src/test/items/double_battle_chance_booster.test.ts
+++ b/src/test/items/double_battle_chance_booster.test.ts
@@ -102,4 +102,30 @@ describe("Items - Double Battle Chance Boosters", () => {
     }
     expect(count).toBe(1);
   }, TIMEOUT);
+
+  // TODO: Fix this test
+  it.skip("should have the same remaining battle count after a reload", async() => {
+    game.override
+      .startingModifier([{ name: "LURE" }])
+      .moveset(SPLASH_ONLY)
+      .startingLevel(200);
+
+    await game.classicMode.startBattle([
+      Species.PIKACHU
+    ]);
+
+    game.move.select(Moves.SPLASH);
+    await game.doKillOpponents();
+    await game.toNextWave();
+
+    const preReloadModifier = game.scene.findModifier(m => m instanceof DoubleBattleChanceBoosterModifier) as DoubleBattleChanceBoosterModifier;
+    const preReloadCount = preReloadModifier.getBattleCount();
+
+    await game.reload.reloadSession();
+
+    const postReloadModifier = game.scene.findModifier(m => m instanceof DoubleBattleChanceBoosterModifier) as DoubleBattleChanceBoosterModifier;
+    const postReloadCount = postReloadModifier.getBattleCount();
+
+    expect(postReloadCount).toBe(preReloadCount);
+  }, TIMEOUT);
 });


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
Fixes #4100, so reloading the game will no longer cause lures to refresh their durations. (Based on my manual testing, X items and Dire Hit do not refresh their durations, both before and after the changes in this PR.)

May also introduce other fixes and/or side effects that I am not aware of.

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
A fix for #4100.

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
The version in `package.json` is now updated to the game's current version of 1.0.5. This means that all saved game data will store the correct game version of 1.0.5, so `version-converter.ts` will no longer interfere with them.

TODO: Fix the added test case for this issue.
TODO: Does `package-lock.json` also need to be updated to 1.0.5?

## Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

### Before the changes

https://github.com/user-attachments/assets/d758cecf-c883-436c-a9b3-cdecc208f06b

After the reload, the lure's duration gets reset to 10.

### After the changes

https://github.com/user-attachments/assets/864ab28f-05f7-4682-96a2-edf8c59e7f0a

After the reload, the lure's duration stays at 7.

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
1. While playing a run, obtain a lure.
2. Advance to the next wave to count down the lure's duration.
3. Reload the session.
4. The lure's duration should not refresh.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue? (TODO)
- ~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
