### PR TITLE
[Hotfix] Fix Lures Refreshing on Reload

### DIFF
--- a/src/system/version-converter.ts
+++ b/src/system/version-converter.ts
@@ -31,7 +31,7 @@ export function applySessionDataPatches(data: SessionSaveData) {
 
           // From [ stat, battlesLeft ] to [ stat, maxBattles, battleCount ]
           m.args = [ newStat, 5, m.args[1] ];
-        } else if (m.className === "DoubleBattleChanceBoosterModifier") {
+        } else if (m.className === "DoubleBattleChanceBoosterModifier" && m.args.length === 1) {
           let maxBattles: number;
           switch (m.typeId) {
           case "MAX_LURE":
@@ -53,6 +53,8 @@ export function applySessionDataPatches(data: SessionSaveData) {
       data.enemyModifiers.forEach((m) => {
         if (m.className === "PokemonBaseStatModifier") {
           m.className = "BaseStatModifier";
+        } else if (m.className === "PokemonResetNegativeStatStageModifier") {
+          m.className = "ResetNegativeStatStageModifier";
         }
       });
     }


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->

Lures will no longer "refresh" when reloading save data or refreshing the page after data is saved after a wave finishes.

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

This was an oversight in the save migration algorithm; it was never intended to run more than once, which is essentially forced by the fact that the version number cannot be incremented past `1.0.4` at the moment.

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

The reason why lures were being set back to their `maxBattles` on reload is because the initial conversion from old lures to new lures takes the first argument of the `ModifierData` `args` array and setting it to the `battleCount`. This effectively takes the old `battleCount` to the new `battleCount` for accurate conversion. However, a side effect of the version number never incrementing is that the conversion would run again on reload/data parsing. As such, the `maxBattles` field would be put into `battleCount` on subsequent reloads because the conversion still thinks the game data is transitioning from `1.0.4` to a new version, which is why simply incrementing the version to `1.0.5` is also a valid fix for this scenario. To get around that though, the length of the `args` array can be checked since it was initially length 1, becoming a length 2 array on conversion. This prevents the conversion from re-running more than once after conversion is done without *needing* the version increment. In addition to this, I also made sure to convert any lingering `White Herb`s on enemies purely for conversion accuracy.

Worth noting that we still need to increment version at some point because this can definitely cause issues in the future with conversion patches (as it did here).

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

N/A

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

Grab a lure in a run, save the game manually or let the game get to the next wave, and reload. Loading up the save after the fact should retain the `battleCount` it left off with instead of going back to its fresh maximum.

## Checklist
- [ ] There is no overlap with another PR?
  - https://github.com/pagefaultgames/pokerogue/pull/4114
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
