### PR TITLE
[Bug][UI] Fix HA icon not always showing in egg summary screen

### DIFF
--- a/src/ui/pokemon-info-container.ts
+++ b/src/ui/pokemon-info-container.ts
@@ -262,7 +262,7 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
         this.pokemonFormText.disableInteractive();
       }
 
-      const abilityTextStyle = pokemon.abilityIndex === (pokemon.species.ability2 ? 2 : 1) ? TextStyle.MONEY : TextStyle.WINDOW;
+      const abilityTextStyle = pokemon.abilityIndex === 2 ? TextStyle.MONEY : TextStyle.WINDOW;
       this.pokemonAbilityText.setText(pokemon.getAbility(true).name);
       this.pokemonAbilityText.setColor(getTextColor(abilityTextStyle, false, this.scene.uiTheme));
       this.pokemonAbilityText.setShadowColor(getTextColor(abilityTextStyle, true, this.scene.uiTheme));


### PR DESCRIPTION
## What are the changes the user will see?
In egg summary, HA icon is now shown for all Pokemon who hatched with their HA, while before in some cases it wasn't
The icons for unlocks now show on top of the Pokemon sprite as well, while before it could get hidden by the Pokemon sprite or cursor

## Why am I making these changes?
Fix issue #4134 
TDLR:
* problem 1: for some Pokemon species the HA icon is not showing even if the Pokemon has its HA
* problem 2: for Ferroseed the HA icon is always showing, even if it doesn't have its HA

## What are the changes from a developer perspective?
- Check for the presence of the HA by using the `Pokemon.abilityIndex` instead of calling `Pokemon.hasAbility` which would always return true in the case of Ferroseed since its HA is the same as its normal ability
- (note: this also fixes issue 1, which was caused by the fact that by default `Pokemon.hasAbility` checks that the ability applies to the current battle conditions, so for some HAs like weather ones it would return false even if the Pokemon has the HA. If it wasn't for Ferroseed's special case doing `displayPokemon.hasAbility(displayPokemon.species.abilityHidden, false, true)` instead of `displayPokemon.hasAbility(displayPokemon.species.abilityHidden)` would have been just fine to fix that)
- removed ternary in the HA check for `src/ui/pokemon-info-container.ts` since the HA is always at index 2 since PR 3138
- renamed icon variables for better code readability
- display the icons on top of the Pokemon and cursor and move them around a little to better match the starter UI

### Screenshots/Videos
Before: HA icon doesn't show for Bulbasaur & Charmander
<img width="848" alt="_egg_ha_bulbasaur" src="https://github.com/user-attachments/assets/3ec6fc69-a9e6-4808-b5d6-77b8b366aa32">
After: 
<img width="1175" alt="_after_bulb" src="https://github.com/user-attachments/assets/589948c9-20be-46a2-917b-e0639ccfa9a7">

Before: HA icon always shows for Ferossed
<img width="821" alt="_egg_ferroseed" src="https://github.com/user-attachments/assets/a820abd3-9f0d-4db6-9007-ccac6f35b073">
After:
<img width="1174" alt="_after_fer" src="https://github.com/user-attachments/assets/05d0e4b8-b69f-4924-9ab1-45a85af42a2d">

Before / After of icon placement:
<img width="200" alt="1_current" src="https://github.com/user-attachments/assets/a61df8ca-9c7f-47d7-ad8d-7e247f464fcf"> <img width="208" alt="_after_icons" src="https://github.com/user-attachments/assets/b4d5e014-8b41-4566-b1bc-97710b228cba">

<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?

Use override:
`EGG_IMMEDIATE_HATCH_OVERRIDE: true`

Load one of these, clear a wave and check egg summary:
- [Save with Bulbasaur & Charmander eggs](https://github.com/user-attachments/files/16944432/_ha_missing_icons.txt)
- [Save with Ferosseed eggs](https://github.com/user-attachments/files/16944433/_ha_ferroseed_eggs.txt)
- [Save with eggs for Pokemon with varying sprite sizes](https://github.com/user-attachments/files/16944467/_ha_various.txt)

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
