### PR TITLE
[Hotfix] Fix Lapsing Modifiers Not Rolling

### DIFF
--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -367,6 +367,10 @@ export abstract class LapsingPersistentModifier extends PersistentModifier {
     return container;
   }
 
+  getIconStackText(_scene: BattleScene, _virtual?: boolean): Phaser.GameObjects.BitmapText | null {
+    return null;
+  }
+
   getBattleCount(): number {
     return this.battleCount;
   }
@@ -384,7 +388,8 @@ export abstract class LapsingPersistentModifier extends PersistentModifier {
   }
 
   getMaxStackCount(_scene: BattleScene, _forThreshold?: boolean): number {
-    return 1;
+    // Must be an abitrary number greater than 1
+    return 2;
   }
 }
 
@@ -787,7 +792,7 @@ export class TerastallizeModifier extends LapsingPokemonHeldItemModifier {
 /**
  * Modifier used for held items, specifically vitamins like Carbos, Hp Up, etc., that
  * increase the value of a given {@linkcode PermanentStat}.
- * @extends LapsingPersistentModifier
+ * @extends PokemonHeldItemModifier
  * @see {@linkcode apply}
  */
 export class BaseStatModifier extends PokemonHeldItemModifier {


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->

Picking up one battle item, lure, or `Dire Hit` will now no longer prevent an item of the same type.

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

Lapsing modifiers were intended to spawn more items of their same type to make its "refreshing" mechanic useful during runs.

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

`getMaxStackCount` was set to return `1` purely for getting rid of the stack count text that appears below an item at the top left of the screen, but this was causing lapsing modifiers to have no weighting during reward rolls. To get the best of both worlds, `getMaxStackCount` was set to `2` so that the `m.stackCount < m.getMaxStackCount` boolean doesn't equal `false` during weighting, and `getIconStackText` was overridden to always be `null`, effectively removing the text.

While I was doing that, I also changed a copy-paste typo in documentation.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

https://github.com/user-attachments/assets/38a2f2c4-d78a-43d5-9a4b-e5263c7b7aea

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

The easiest way to check is to enable the `WAIVE_ROLL_FEE_OVERRIDE`, start a new Classic run, clear a wave, and roll rewards until you get any lapsing modifier. After that, win another wave and roll again to make sure that the same type of lapsing modifier can be rolled at all.

## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
