### PR TITLE
[Bug][UI] fix candy upgrade icon not updating after purchasing eggs

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1221,6 +1221,19 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
   }
 
   /**
+   * Update the display of candy upgrade icons or animations for the given StarterContainer
+   * @param starterContainer the container for the Pokemon to update
+   */
+  updateCandyUpgradeDisplay(starterContainer: StarterContainer) {
+    if (this.isUpgradeIconEnabled() ) {
+      this.setUpgradeIcon(starterContainer);
+    }
+    if (this.isUpgradeAnimationEnabled()) {
+      this.setUpgradeAnimation(starterContainer.icon, this.lastSpecies, true);
+    }
+  }
+
+  /**
    * Processes an {@linkcode CandyUpgradeNotificationChangedEvent} sent when the corresponding setting changes
    * @param event {@linkcode Event} sent by the callback
    */
@@ -1624,7 +1637,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
               }
             });
           }
-          const candyCount = starterData.candyCount;
+
           const passiveAttr = starterData.passiveAttr;
           if (passiveAttr & PassiveAttr.UNLOCKED) { // this is for enabling and disabling the passive
             if (!(passiveAttr & PassiveAttr.ENABLED)) {
@@ -1705,8 +1718,13 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
               return true;
             }
           });
-          const showUseCandies = () => { // this lets you use your candies
+
+          // Purchases with Candy
+          const candyCount = starterData.candyCount;
+          const showUseCandies = () => {
             const options: any[] = []; // TODO: add proper type
+
+            // Unlock passive option
             if (!(passiveAttr & PassiveAttr.UNLOCKED)) {
               const passiveCost = getPassiveCandyCount(speciesStarters[this.lastSpecies.speciesId]);
               options.push({
@@ -1726,16 +1744,9 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
                     ui.setMode(Mode.STARTER_SELECT);
                     this.setSpeciesDetails(this.lastSpecies, undefined, undefined, undefined, undefined, undefined, undefined);
 
-                    // if starterContainer exists, update the passive background
+                    // update the passive background and icon/animation for available upgrade
                     if (starterContainer) {
-                      // Update the candy upgrade display
-                      if (this.isUpgradeIconEnabled() ) {
-                        this.setUpgradeIcon(starterContainer);
-                      }
-                      if (this.isUpgradeAnimationEnabled()) {
-                        this.setUpgradeAnimation(starterContainer.icon, this.lastSpecies, true);
-                      }
-
+                      this.updateCandyUpgradeDisplay(starterContainer);
                       starterContainer.starterPassiveBgs.setVisible(!!this.scene.gameData.starterData[this.lastSpecies.speciesId].passiveAttr);
                     }
                     return true;
@@ -1746,6 +1757,8 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
                 itemArgs: starterColors[this.lastSpecies.speciesId]
               });
             }
+
+            // Reduce cost option
             const valueReduction = starterData.valueReduction;
             if (valueReduction < valueReductionMax) {
               const reductionCost = getValueReductionCandyCounts(speciesStarters[this.lastSpecies.speciesId])[valueReduction];
@@ -1767,19 +1780,10 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
                     ui.setMode(Mode.STARTER_SELECT);
                     this.scene.playSound("se/buy");
 
-                    // if starterContainer exists, update the value reduction background
+                    // update the value label and icon/animation for available upgrade
                     if (starterContainer) {
                       this.updateStarterValueLabel(starterContainer);
-
-                      // If the notification setting is set to 'On', update the candy upgrade display
-                      if (this.scene.candyUpgradeNotification === 2) {
-                        if (this.isUpgradeIconEnabled() ) {
-                          this.setUpgradeIcon(starterContainer);
-                        }
-                        if (this.isUpgradeAnimationEnabled()) {
-                          this.setUpgradeAnimation(starterContainer.icon, this.lastSpecies, true);
-                        }
-                      }
+                      this.updateCandyUpgradeDisplay(starterContainer);
                     }
                     return true;
                   }
@@ -1811,6 +1815,11 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
                   });
                   ui.setMode(Mode.STARTER_SELECT);
                   this.scene.playSound("se/buy");
+
+                  // update the icon/animation for available upgrade
+                  if (starterContainer) {
+                    this.updateCandyUpgradeDisplay(starterContainer);
+                  }
 
                   return true;
                 }


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
If enabled, the icon or animation for available candy upgrade will get updated properly after purchasing eggs, unlike now

<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?
Note: I will be referring only to the "candy upgrade icon" in the PR, but it's the same for the "animation" setting

There are two issue with the icon when purchasing candy upgrades currently:
- After purchasing an egg the icon showing that an upgrade is available is not removed even if there is not enough candy left to purchase more
- If the icon setting is set to "passive only", the icon is also not removed after reducing cost, even if there is not enough candy left anymore to purchase the passive


## What are the changes from a developer perspective?
- Movde the code that handles updating the icon/animation to its own function `updateCandyUpgradeDisplay`
- Call it after all successfull candy purchases

### Screenshots/Videos
Before: purchasing passive stops the animation for Vanillite, as it should, but purchasing egg for Deerling does not 

https://github.com/user-attachments/assets/4d9bb9bf-3fe4-46a6-9acc-1324697e30ff

After:

https://github.com/user-attachments/assets/905ba5d2-f644-4c45-89ac-954c5e0556e2


## How to test the changes?
In the Display Settings, set "Candy upgrade Notification" to "Passive Only" or "On" and the "Candy Upgrade Display" to whichever one you want to test:
<img width="815" alt="Screenshot 2024-09-10 at 15 47 39" src="https://github.com/user-attachments/assets/5876f4ce-adda-4964-9c5c-46324411abb1">

Load a file with a decent amount of candy like [this one](https://github.com/user-attachments/files/16946886/_ha_missing_icons.txt)

Go to New Game, play with purchasing various egg upgrades and make sure the icon/animation get cleared as they should (if that helps you can use the filters for available upgrades and/or sort the starters by number of candy)
<img width="325" alt="Screenshot 2024-09-10 at 17 03 56" src="https://github.com/user-attachments/assets/5731fae3-3a9a-400c-9aea-8f8069bd1e96"> <img width="170" alt="Screenshot 2024-09-10 at 17 04 06" src="https://github.com/user-attachments/assets/87f15b52-7aeb-44ea-a293-42ccd46944c5">


## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
