### PR TITLE
[Test] Replace `vi.fn()` with `() => null` whenenver possible

### DIFF
--- a/src/test/utils/gameWrapper.ts
+++ b/src/test/utils/gameWrapper.ts
@@ -41,7 +41,7 @@ window.URL.createObjectURL = (blob: Blob) => {
   });
   return null;
 };
-navigator.getGamepads = vi.fn().mockReturnValue([]);
+navigator.getGamepads = () => [];
 global.fetch = vi.fn(MockFetch);
 Utils.setCookie(Utils.sessionIdKey, 'fake_token');
 

--- a/src/test/utils/mocks/mockGameObjectCreator.ts
+++ b/src/test/utils/mocks/mockGameObjectCreator.ts
@@ -1,4 +1,3 @@
-import { vi } from "vitest";
 import MockGraphics from "./mocksContainer/mockGraphics";
 import MockTextureManager from "./mockTextureManager";
 
@@ -16,8 +15,8 @@ export class MockGameObjectCreator {
 
   rexTransitionImagePack() {
     return {
-      transit: vi.fn(),
-      once: vi.fn(),
+      transit: () => null,
+      once: () => null,
     };
   }
 }

--- a/src/test/utils/mocks/mockVideoGameObject.ts
+++ b/src/test/utils/mocks/mockVideoGameObject.ts
@@ -1,13 +1,12 @@
-import { vi } from "vitest";
 import { MockGameObject } from "./mockGameObject";
 
 /** Mocks video-related stuff */
 export class MockVideoGameObject implements MockGameObject {
   constructor() {}
 
-  public play = vi.fn();
-  public stop = vi.fn(() => this);
-  public setOrigin = vi.fn();
-  public setScale = vi.fn();
-  public setVisible = vi.fn();
+  public play = () => null;
+  public stop = () => this;
+  public setOrigin = () => null;
+  public setScale = () => null;
+  public setVisible = () => null;
 }

--- a/src/test/utils/mocks/mocksContainer/mockContainer.ts
+++ b/src/test/utils/mocks/mocksContainer/mockContainer.ts
@@ -1,5 +1,4 @@
 import MockTextureManager from "#test/utils/mocks/mockTextureManager";
-import { vi } from "vitest";
 import { MockGameObject } from "../mockGameObject";
 
 export default class MockContainer implements MockGameObject {
@@ -52,7 +51,7 @@ export default class MockContainer implements MockGameObject {
     /// Sets the position of this Game Object to be a relative position from the source Game Object.
   }
 
-  setInteractive = vi.fn();
+  setInteractive = () => null;
 
   setOrigin(x, y) {
     this.x = x;
@@ -160,10 +159,9 @@ export default class MockContainer implements MockGameObject {
     // Moves this Game Object to be below the given Game Object in the display list.
   }
 
-  setName = vi.fn((name: string) => {
+  setName = (name: string) => {
     this.name = name;
-    // return this.phaserSprite.setName(name);
-  });
+  };
 
   bringToTop(obj) {
     // Brings this Game Object to the top of its parents display list.
@@ -207,5 +205,5 @@ export default class MockContainer implements MockGameObject {
     return this.list;
   }
 
-  disableInteractive = vi.fn();
+  disableInteractive = () => null;
 }

--- a/src/test/utils/mocks/mocksContainer/mockSprite.ts
+++ b/src/test/utils/mocks/mocksContainer/mockSprite.ts
@@ -1,6 +1,5 @@
 import Phaser from "phaser";
 import { MockGameObject } from "../mockGameObject";
-import { vi } from "vitest";
 import Sprite = Phaser.GameObjects.Sprite;
 import Frame = Phaser.Textures.Frame;
 
@@ -102,7 +101,7 @@ export default class MockSprite implements MockGameObject {
     return this.phaserSprite.stop();
   }
 
-  setInteractive = vi.fn();
+  setInteractive = () => null;
 
   on(event, callback, source) {
     return this.phaserSprite.on(event, callback, source);

--- a/src/test/utils/mocks/mocksContainer/mockText.ts
+++ b/src/test/utils/mocks/mocksContainer/mockText.ts
@@ -1,5 +1,4 @@
 import UI from "#app/ui/ui";
-import { vi } from "vitest";
 import { MockGameObject } from "../mockGameObject";
 
 export default class MockText implements MockGameObject {
@@ -193,11 +192,11 @@ export default class MockText implements MockGameObject {
     };
   }
 
-  setColor = vi.fn((color: string) => {
+  setColor = (color: string) => {
     this.color = color;
-  });
+  };
 
-  setInteractive = vi.fn();
+  setInteractive = () => null;
 
   setShadowColor(color) {
     // Sets the shadow color.
@@ -223,9 +222,9 @@ export default class MockText implements MockGameObject {
     // return this.phaserText.setAlpha(alpha);
   }
 
-  setName = vi.fn((name: string) => {
+  setName = (name: string) => {
     this.name = name;
-  });
+  };
 
   setAlign(align) {
     // return this.phaserText.setAlign(align);


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Memory usage and performance of tests is becoming untenable.

## What are the changes from a developer perspective?
Where possible, `vi.fn()` is replaced with `() => null` (or similar) in the various mock objects.

Btw if you had trouble running tests locally before you might be able to run them now.

### Screenshots/Videos
Before:
![image](https://github.com/user-attachments/assets/29f286b8-89cc-4433-876c-6f02701e25dc)
After:
![image](https://github.com/user-attachments/assets/fbfd33e6-d211-4ba5-a15b-6842dc5379de)

## How to test the changes?
`npm run test`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
