### PR TITLE
[Balance] Tweak trainer evolution delay

### DIFF
--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -666,9 +666,9 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
     case PartyMemberStrength.WEAK:
       return 20;
     case PartyMemberStrength.AVERAGE:
-      return 10;
+      return 8;
     case PartyMemberStrength.STRONG:
-      return 5;
+      return 4;
     default:
       return 0;
     }
@@ -734,11 +734,6 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
 
           evolutionChance = Math.min(0.65 * easeInFunc(Math.min(Math.max(level - evolutionLevel, 0), preferredMinLevel) / preferredMinLevel) + 0.35 * easeOutFunc(Math.min(Math.max(level - evolutionLevel, 0), preferredMinLevel * 2.5) / (preferredMinLevel * 2.5)), 1);
         }
-      }
-      /* (Most) Trainers shouldn't be using unevolved Pokemon by the third gym leader / wave 80. Exceptions to this include Breeders, whose large teams are balanced by the use of weaker pokemon */
-      if (currentWave >= 80 && forTrainer && strength > PartyMemberStrength.WEAKER) {
-        evolutionChance = 1;
-        noEvolutionChance = 0;
       }
 
       if (evolutionChance > 0) {


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
- Adjusted minimum evolution levels so trainers are more likely to use evolved mons at appropriate waves.
- Remove temporary hardcoded 100% chance for trainer mons to be evolved at floor 80

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
- The admins at 66 were still using unevolved mons occasionally
- Trainer mons not set as "weaker" are pretty much hardcoded to evolve at/after wave 80. To my understanding this is more of a temporary measure until we figure out how to actually fix evolution delays. I removed it so this can be tested as an alternative.

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- In the function getStrengthLevelDiff, the values for average and strong mons were lowered from 10 and 5 to 8 and 4, respectively. These are nice, neat powers of 2. This shrinks the margins in which a mon can remain unevolved on an admin or gym leader team.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Face trainers particularly in the range between the 2 evil team admin fights and see if there's any unevolved mons who should be evolved. Mons with Very Long evolution delays might take longer to evolve (obviously), though a lot of those will be changed with #2732 

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
