### PR TITLE
[Misc] Allow Meloetta's starting form to be selected

### DIFF
--- a/src/data/pokemon-forms.ts
+++ b/src/data/pokemon-forms.ts
@@ -12,6 +12,7 @@ import { TimeOfDay } from "#enums/time-of-day";
 import { getPokemonNameWithAffix } from "#app/messages";
 import i18next from "i18next";
 import { WeatherType } from "./weather";
+import { Challenges } from "#app/enums/challenges";
 
 export enum FormChangeItem {
   NONE,
@@ -342,6 +343,16 @@ export class SpeciesFormChangePreMoveTrigger extends SpeciesFormChangeMoveTrigge
 export class SpeciesFormChangePostMoveTrigger extends SpeciesFormChangeMoveTrigger {
   canChange(pokemon: Pokemon): boolean {
     return pokemon.summonData && !!pokemon.getLastXMoves(1).filter(m => this.movePredicate(m.move)).length === this.used;
+  }
+}
+
+export class MeloettaFormChangePostMoveTrigger extends SpeciesFormChangePostMoveTrigger {
+  override canChange(pokemon: Pokemon): boolean {
+    if (pokemon.scene.gameMode.hasChallenge(Challenges.SINGLE_TYPE)) {
+      return false;
+    } else {
+      return super.canChange(pokemon);
+    }
   }
 }
 
@@ -759,9 +770,8 @@ export const pokemonFormChanges: PokemonFormChanges = {
     new SpeciesFormChange(Species.KELDEO, "resolute", "ordinary", new SpeciesFormChangeMoveLearnedTrigger(Moves.SECRET_SWORD, false))
   ],
   [Species.MELOETTA]: [
-    new SpeciesFormChange(Species.MELOETTA, "aria", "pirouette", new SpeciesFormChangePostMoveTrigger(Moves.RELIC_SONG), true),
-    new SpeciesFormChange(Species.MELOETTA, "pirouette", "aria", new SpeciesFormChangePostMoveTrigger(Moves.RELIC_SONG), true),
-    new SpeciesFormChange(Species.MELOETTA, "pirouette", "aria", new SpeciesFormChangeActiveTrigger(false), true)
+    new SpeciesFormChange(Species.MELOETTA, "aria", "pirouette", new MeloettaFormChangePostMoveTrigger(Moves.RELIC_SONG), true),
+    new SpeciesFormChange(Species.MELOETTA, "pirouette", "aria", new MeloettaFormChangePostMoveTrigger(Moves.RELIC_SONG), true)
   ],
   [Species.GENESECT]: [
     new SpeciesFormChange(Species.GENESECT, "", "shock", new SpeciesFormChangeItemTrigger(FormChangeItem.SHOCK_DRIVE)),

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -1880,7 +1880,7 @@ export function initSpecies() {
     ),
     new PokemonSpecies(Species.MELOETTA, 5, false, false, true, "Melody Pokémon", Type.NORMAL, Type.PSYCHIC, 0.6, 6.5, Abilities.SERENE_GRACE, Abilities.NONE, Abilities.NONE, 600, 100, 77, 77, 128, 128, 90, 3, 100, 270, GrowthRate.SLOW, null, false, true,
       new PokemonForm("Aria Forme", "aria", Type.NORMAL, Type.PSYCHIC, 0.6, 6.5, Abilities.SERENE_GRACE, Abilities.NONE, Abilities.NONE, 600, 100, 77, 77, 128, 128, 90, 3, 100, 270, false, null, true),
-      new PokemonForm("Pirouette Forme", "pirouette", Type.NORMAL, Type.FIGHTING, 0.6, 6.5, Abilities.SERENE_GRACE, Abilities.NONE, Abilities.NONE, 600, 100, 128, 90, 77, 77, 128, 3, 100, 270),
+      new PokemonForm("Pirouette Forme", "pirouette", Type.NORMAL, Type.FIGHTING, 0.6, 6.5, Abilities.SERENE_GRACE, Abilities.NONE, Abilities.NONE, 600, 100, 128, 90, 77, 77, 128, 3, 100, 270, false, null, true),
     ),
     new PokemonSpecies(Species.GENESECT, 5, false, false, true, "Paleozoic Pokémon", Type.BUG, Type.STEEL, 1.5, 82.5, Abilities.DOWNLOAD, Abilities.NONE, Abilities.NONE, 600, 71, 120, 95, 120, 95, 99, 3, 0, 300, GrowthRate.SLOW, null, false, true,
       new PokemonForm("Normal", "", Type.BUG, Type.STEEL, 1.5, 82.5, Abilities.DOWNLOAD, Abilities.NONE, Abilities.NONE, 600, 71, 120, 95, 120, 95, 99, 3, 0, 300, false, null, true),

--- a/src/test/moves/relic_song.test.ts
+++ b/src/test/moves/relic_song.test.ts
@@ -1,0 +1,81 @@
+import { Type } from "#app/data/type";
+import { Challenges } from "#app/enums/challenges";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Moves - Relic Song", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+  const TIMEOUT = 20 * 1000;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([Moves.RELIC_SONG, Moves.SPLASH])
+      .battleType("single")
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH)
+      .enemySpecies(Species.MAGIKARP)
+      .enemyLevel(100);
+  });
+
+  it("swaps Meloetta's form between Aria and Pirouette", async () => {
+    await game.classicMode.startBattle([Species.MELOETTA]);
+
+    const meloetta = game.scene.getPlayerPokemon()!;
+
+    game.move.select(Moves.RELIC_SONG);
+    await game.toNextTurn();
+
+    expect(meloetta.formIndex).toBe(1);
+
+    game.move.select(Moves.RELIC_SONG);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(meloetta.formIndex).toBe(0);
+  }, TIMEOUT);
+
+  it("doesn't swap Meloetta's form during a mono-type challenge", async () => {
+    game.challengeMode.addChallenge(Challenges.SINGLE_TYPE, Type.PSYCHIC + 1, 0);
+    await game.challengeMode.startBattle([Species.MELOETTA]);
+
+    const meloetta = game.scene.getPlayerPokemon()!;
+
+    expect(meloetta.formIndex).toBe(0);
+
+    game.move.select(Moves.RELIC_SONG);
+    await game.phaseInterceptor.to("BerryPhase");
+    await game.toNextTurn();
+
+    expect(meloetta.formIndex).toBe(0);
+  }, TIMEOUT);
+
+  it("doesn't swap Meloetta's form during biome change (arena reset)", async () => {
+    game.override
+      .starterForms({[Species.MELOETTA]: 1})
+      .startingWave(10);
+    await game.classicMode.startBattle([Species.MELOETTA]);
+
+    const meloetta = game.scene.getPlayerPokemon()!;
+
+    game.move.select(Moves.SPLASH);
+    await game.doKillOpponents();
+    await game.toNextWave();
+
+    expect(meloetta.formIndex).toBe(1);
+  }, TIMEOUT);
+});


### PR DESCRIPTION
## What are the changes the user will see?
Players can now choose between Meloetta's different forms on the starter select screen.
Additionally, Meloetta will not change forms during a mono-type challenge when using Relic Song nor automatically revert to Aria form on arena reset.

## Why am I making these changes?
![image](https://github.com/user-attachments/assets/c7aa2735-d2e4-4bdc-81a2-7fc30ba9bc43)
![image](https://github.com/user-attachments/assets/3fff840a-be50-4faa-9811-84738edb51ec)
![image](https://github.com/user-attachments/assets/bdfd78fa-cd5c-454f-9ee8-cba9cabe95b1)

## What are the changes from a developer perspective?
Marked the second form as selectable in `pokemon-species.ts`.
Created `MeloettaFormChangePostMoveTrigger` which extends `SpeciesFormChangePostMoveTrigger` and adds a check for whether a mono-type challenge is currently active.
Removed `SpeciesFormChangeActiveTrigger(false)` which caused Meloetta to revert to Aria form automatically.

### Screenshots/Videos
![image](https://github.com/user-attachments/assets/f139be46-0d22-4bd4-9fe8-fd6f1f86561b)
![image](https://github.com/user-attachments/assets/26d3448f-fbdb-4b83-8fd9-8fec31614aa7)

## How to test the changes?
Go to the starter select screen and try to change Meloetta's form.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - [x] Have I provided screenshots/videos of the changes?
