### PR TITLE
[Test] Speed up tests and make enemy item override remove existing items

### DIFF
--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -21,7 +21,7 @@ import Overrides from "#app/overrides";
 import { ModifierType, modifierTypes } from "./modifier-type";
 import { Command } from "#app/ui/command-ui-handler";
 import { Species } from "#enums/species";
-import { Stat, type PermanentStat, type TempBattleStat, BATTLE_STATS, TEMP_BATTLE_STATS  } from "#app/enums/stat";
+import { Stat, type PermanentStat, type TempBattleStat, BATTLE_STATS, TEMP_BATTLE_STATS } from "#app/enums/stat";
 import i18next from "i18next";
 
 import { allMoves } from "#app/data/move";
@@ -2945,6 +2945,10 @@ export function overrideHeldItems(scene: BattleScene, pokemon: Pokemon, isPlayer
   const heldItemsOverride: ModifierTypes.ModifierOverride[] = isPlayer ? Overrides.STARTING_HELD_ITEMS_OVERRIDE : Overrides.OPP_HELD_ITEMS_OVERRIDE;
   if (!heldItemsOverride || heldItemsOverride.length === 0 || !scene) {
     return;
+  }
+
+  if (!isPlayer) {
+    scene.clearEnemyHeldItemModifiers();
   }
 
   heldItemsOverride.forEach(item => {

--- a/src/test/utils/gameManager.ts
+++ b/src/test/utils/gameManager.ts
@@ -24,7 +24,6 @@ import { TurnInitPhase } from "#app/phases/turn-init-phase";
 import { TurnStartPhase } from "#app/phases/turn-start-phase";
 import ErrorInterceptor from "#app/test/utils/errorInterceptor";
 import InputsHandler from "#app/test/utils/inputsHandler";
-import { MockClock } from "#app/test/utils/mocks/mockClock";
 import CommandUiHandler from "#app/ui/command-ui-handler";
 import ModifierSelectUiHandler from "#app/ui/modifier-select-ui-handler";
 import PartyUiHandler from "#app/ui/party-ui-handler";
@@ -360,12 +359,10 @@ export default class GameManager {
   }
 
   async killPokemon(pokemon: PlayerPokemon | EnemyPokemon) {
-    (this.scene.time as MockClock).overrideDelay = 0.01;
     return new Promise<void>(async (resolve, reject) => {
       pokemon.hp = 0;
       this.scene.pushPhase(new FaintPhase(this.scene, pokemon.getBattlerIndex(), true));
       await this.phaseInterceptor.to(FaintPhase).catch((e) => reject(e));
-      (this.scene.time as MockClock).overrideDelay = undefined;
       resolve();
     });
   }

--- a/src/test/utils/gameWrapper.ts
+++ b/src/test/utils/gameWrapper.ts
@@ -87,6 +87,8 @@ export default class GameWrapper {
     });
     Pokemon.prototype.enableMask = () => null;
     Pokemon.prototype.updateFusionPalette = () => null;
+    Pokemon.prototype.cry = () => null;
+    Pokemon.prototype.faintCry = (cb) => { if (cb) cb(); };
   }
 
   setScene(scene: BattleScene) {

--- a/src/test/utils/mocks/mockClock.ts
+++ b/src/test/utils/mocks/mockClock.ts
@@ -2,23 +2,22 @@ import Clock = Phaser.Time.Clock;
 
 
 export class MockClock extends Clock {
-  public overrideDelay: number | undefined;
+  public overrideDelay: number | null = 1;
   constructor(scene) {
     super(scene);
-    this.overrideDelay = undefined;
     setInterval(() => {
       /*
         To simulate frame update
         eventEmitter.on(SceneEvents.PRE_UPDATE, this.preUpdate, this);
         eventEmitter.on(SceneEvents.UPDATE, this.update, this);
        */
-      this.preUpdate(this.systems.game.loop.time, 100);
-      this.update(this.systems.game.loop.time, 100);
-    }, 100);
+      this.preUpdate(this.systems.game.loop.time, 1);
+      this.update(this.systems.game.loop.time, 1);
+    }, 1);
   }
 
   addEvent(config: Phaser.Time.TimerEvent | Phaser.Types.Time.TimerEventConfig): Phaser.Time.TimerEvent {
-    const cfg = { ...config, delay: this.overrideDelay || config.delay};
+    const cfg = { ...config, delay: this.overrideDelay ?? config.delay};
     return super.addEvent(cfg);
   }
 }


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Improve speed and reliability of tests.

## What are the changes from a developer perspective?
Tests will complete more quickly now.
Tests that give enemy Pokémon held items will not randomly fail because the enemy was given a randomly generated item.

## How to test the changes?
`npm run test`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
