### PR TITLE
[Bug] fix starter select crash when a variant preference is incorrect

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -995,15 +995,14 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       delete starterAttributes.shiny;
     }
 
-    if (starterAttributes.variant !== undefined && !isNaN(starterAttributes.variant)) {
+    if (starterAttributes.variant !== undefined) {
       const unlockedVariants = [
-        hasNonShiny,
         hasShiny && caughtAttr & DexAttr.DEFAULT_VARIANT,
         hasShiny && caughtAttr & DexAttr.VARIANT_2,
         hasShiny && caughtAttr & DexAttr.VARIANT_3
       ];
-      if (!unlockedVariants[starterAttributes.variant + 1]) { // add 1 as -1 = non-shiny
-        // requested variant wasn't unlocked, purging setting
+      if (isNaN(starterAttributes.variant) || starterAttributes.variant < 0 || !unlockedVariants[starterAttributes.variant]) {
+        // variant value is invalid or requested variant wasn't unlocked, purging setting
         delete starterAttributes.variant;
       }
     }


### PR DESCRIPTION

## What are the changes the user will see?
No more crash when trying to create a new run

## Why am I making these changes?
Fixes #4208 
At some point in the past the starter UI would register -1 as a preference for a starter's variant if shiny was turned off, which my changes in #3870 did not take properly into account. As a result if someone had such a preference set the game would crash when trying to open the UI and assign that -1 variant to the starter

## What are the changes from a developer perspective?
Updated `initStarterPrefs` to delete the variant preference if its value is -1, as it's just a result of past implementation that is no longer relevant


### Screenshots/Videos
Before: black screen and crash
![image](https://github.com/user-attachments/assets/802ee988-0df3-4b4f-ae0c-82fb0e23db7f)

After: able to create a new game 
<img width="1166" alt="Screenshot 2024-09-13 at 11 54 20" src="https://github.com/user-attachments/assets/1d2039d5-d852-45bf-8510-4424c34202a4">


## How to test the changes?

- Load a save with shiny Paldean Tauros unlocked
- Open your dev tools and in Storage > Local Storage, replace the `starterPrefs_Guest` with the contents of  [this file](https://github.com/user-attachments/files/16992152/starterPrefs_Guest.txt)
- The preference for Pokemon `8128` (P. Tauros) should now be `{"variant":-1,"form":0}`
- New Game
- The starter UI should open and work as usual, 

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?