### PR TITLE
[Bug] Fix `SwapStatStagesAttr` Oversight

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2836,7 +2836,7 @@ export class SwapStatStagesAttr extends MoveEffectAttr {
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any []): boolean {
     if (super.apply(user, target, move, args)) {
-      for (const s of BATTLE_STATS) {
+      for (const s of this.stats) {
         const temp = user.getStatStage(s);
         user.setStatStage(s, target.getStatStage(s));
         target.setStatStage(s, temp);

--- a/src/test/moves/heart_swap.test.ts
+++ b/src/test/moves/heart_swap.test.ts
@@ -4,11 +4,12 @@ import GameManager from "#app/test/utils/gameManager";
 import { Species } from "#enums/species";
 import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { Moves } from "#enums/moves";
-import { Stat, BATTLE_STATS } from "#enums/stat";
+import { BATTLE_STATS } from "#enums/stat";
 import { Abilities } from "#enums/abilities";
 import { MoveEndPhase } from "#app/phases/move-end-phase";
+import { SPLASH_ONLY } from "../utils/testUtils";
 
-describe("Moves - Guard Swap", () => {
+describe("Moves - Heart Swap", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
   const TIMEOUT = 20 * 1000;
@@ -28,16 +29,16 @@ describe("Moves - Guard Swap", () => {
     game.override
       .battleType("single")
       .enemyAbility(Abilities.BALL_FETCH)
-      .enemyMoveset(Moves.SPLASH)
+      .enemyMoveset(SPLASH_ONLY)
       .enemySpecies(Species.INDEEDEE)
       .enemyLevel(200)
-      .moveset([ Moves.GUARD_SWAP ])
+      .moveset([ Moves.HEART_SWAP ])
       .ability(Abilities.NONE);
   });
 
-  it("should swap the user's DEF and SPDEF stat stages with the target's", async () => {
+  it("should swap all of the user's stat stages with the target's", async () => {
     await game.classicMode.startBattle([
-      Species.INDEEDEE
+      Species.MANAPHY
     ]);
 
     const player = game.scene.getPlayerPokemon()!;
@@ -45,7 +46,7 @@ describe("Moves - Guard Swap", () => {
 
     vi.spyOn(enemy.summonData, "statStages", "get").mockReturnValue(new Array(BATTLE_STATS.length).fill(1));
 
-    game.move.select(Moves.GUARD_SWAP);
+    game.move.select(Moves.HEART_SWAP);
 
     await game.phaseInterceptor.to(MoveEndPhase);
 
@@ -57,13 +58,8 @@ describe("Moves - Guard Swap", () => {
     await game.phaseInterceptor.to(TurnEndPhase);
 
     for (const s of BATTLE_STATS) {
-      if (s === Stat.DEF || s === Stat.SPDEF) {
-        expect(player.getStatStage(s)).toBe(1);
-        expect(enemy.getStatStage(s)).toBe(0);
-      } else {
-        expect(player.getStatStage(s)).toBe(0);
-        expect(enemy.getStatStage(s)).toBe(1);
-      }
+      expect(enemy.getStatStage(s)).toBe(0);
+      expect(player.getStatStage(s)).toBe(1);
     }
   }, TIMEOUT);
 });

--- a/src/test/moves/power_swap.test.ts
+++ b/src/test/moves/power_swap.test.ts
@@ -1,16 +1,17 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Phaser from "phaser";
 import GameManager from "#app/test/utils/gameManager";
 import { Species } from "#enums/species";
 import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { Moves } from "#enums/moves";
-import { Stat } from "#enums/stat";
+import { Stat, BATTLE_STATS } from "#enums/stat";
 import { Abilities } from "#enums/abilities";
 import { MoveEndPhase } from "#app/phases/move-end-phase";
 
 describe("Moves - Power Swap", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
+  const TIMEOUT = 20 * 1000;
 
   beforeAll(() => {
     phaserGame = new Phaser.Game({
@@ -27,36 +28,42 @@ describe("Moves - Power Swap", () => {
     game.override
       .battleType("single")
       .enemyAbility(Abilities.BALL_FETCH)
-      .enemyMoveset([Moves.SHELL_SMASH])
-      .enemySpecies(Species.MEW)
+      .enemyMoveset(Moves.SPLASH)
+      .enemySpecies(Species.INDEEDEE)
       .enemyLevel(200)
       .moveset([ Moves.POWER_SWAP ])
       .ability(Abilities.NONE);
   });
 
-  it("should swap the user's ATK AND SPATK stat stages with the target's", async () => {
-    await game.startBattle([
+  it("should swap the user's ATK and SPATK stat stages with the target's", async () => {
+    await game.classicMode.startBattle([
       Species.INDEEDEE
     ]);
 
-    // Should start with no stat stages
     const player = game.scene.getPlayerPokemon()!;
-    // After Shell Smash, should have +2 in ATK and SPATK, -1 in DEF and SPDEF
     const enemy = game.scene.getEnemyPokemon()!;
+
+    vi.spyOn(enemy.summonData, "statStages", "get").mockReturnValue(new Array(BATTLE_STATS.length).fill(1));
+
     game.move.select(Moves.POWER_SWAP);
 
     await game.phaseInterceptor.to(MoveEndPhase);
 
-    expect(player.getStatStage(Stat.ATK)).toBe(0);
-    expect(player.getStatStage(Stat.SPATK)).toBe(0);
-    expect(enemy.getStatStage(Stat.ATK)).toBe(2);
-    expect(enemy.getStatStage(Stat.SPATK)).toBe(2);
+    for (const s of BATTLE_STATS) {
+      expect(player.getStatStage(s)).toBe(0);
+      expect(enemy.getStatStage(s)).toBe(1);
+    }
 
     await game.phaseInterceptor.to(TurnEndPhase);
 
-    expect(player.getStatStage(Stat.ATK)).toBe(2);
-    expect(player.getStatStage(Stat.SPATK)).toBe(2);
-    expect(enemy.getStatStage(Stat.ATK)).toBe(0);
-    expect(enemy.getStatStage(Stat.SPATK)).toBe(0);
-  }, 20000);
+    for (const s of BATTLE_STATS) {
+      if (s === Stat.ATK || s === Stat.SPATK) {
+        expect(player.getStatStage(s)).toBe(1);
+        expect(enemy.getStatStage(s)).toBe(0);
+      } else {
+        expect(player.getStatStage(s)).toBe(0);
+        expect(enemy.getStatStage(s)).toBe(1);
+      }
+    }
+  }, TIMEOUT);
 });


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->

`Guard Swap` and `Power Swap` will now swap their intended stat stages instead of swapping all stat stages like `Heart Swap`.

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

`Guard Swap` and `Power Swap` were not behaving as intended.

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

There was a mistake in the loop that swaps each stat stage: instead of looping over the given list of stats in the `SwapStatStagesAttr` constructor, it would always loop over `BATTLE_STATS`, effectively swapping all stat stages regardless of what was passed in. As such, the `for` loop was changed to use the class's `stats` field instead of `BATTLE_STATS`.

In addition to the changes, the unit tests for `Guard Swap` and `Power Swap` were made to be more rigorous in that it checks the expected value of all stat stages (since this oversight slipped by because it only checked DEF and SPDEF for both the player and the enemy). Along with that change, a unit test was made for `Heart Swap` as well.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

Each move was used in the following order to test if the moves worked correctly now:

- Initial `Power Swap` from player (does nothing), `Shell Smash` twice from enemy, `Power Swap` from player

<div align=center>
<img width="680" alt="powerSwapFirst" src="https://github.com/user-attachments/assets/1a49b2d2-cb12-4c91-9dfb-44b32925b53f">
</div>

- `Shell Smash` from enemy, `Guard Swap` from player
<div align=center>
<img width="680" alt="guardSwapSecond" src="https://github.com/user-attachments/assets/6d7a2e75-8398-46f5-b050-13a3d7a8695e">
</div>

- `Shell Smash` from enemy, `Heart Swap` from player
<div align=center>
<img width="680" alt="heartSwapLast" src="https://github.com/user-attachments/assets/ec766eba-1259-4f29-a143-8c528c41305c">
</div>

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

The following overrides when starting a new Classic run can be used to replicate the move demonstration in the screenshots:

```ts
const overrides = {
  MOVESET_OVERRIDE: [ Moves.GUARD_SWAP, Moves.POWER_SWAP, Moves.HEART_SWAP ],
  OPP_MOVESET_OVERRIDE: Moves.SHELL_SMASH,
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
~- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?