### PR TITLE
[P3] Run Result 'Victory!' Text not displaying correctly in Legacy UI Mode

### DIFF
--- a/src/ui/run-info-ui-handler.ts
+++ b/src/ui/run-info-ui-handler.ts
@@ -180,9 +180,9 @@ export default class RunInfoUiHandler extends UiHandler {
   private async parseRunResult() {
     const genderIndex = this.scene.gameData.gender ?? PlayerGender.UNSET;
     const genderStr = PlayerGender[genderIndex];
-    const runResultTextStyle = this.isVictory ? TextStyle.SUMMARY : TextStyle.SUMMARY_RED;
+    const runResultTextStyle = this.isVictory ? TextStyle.SUMMARY_ALT : TextStyle.SUMMARY_RED;
     const runResultTitle = this.isVictory ? i18next.t("runHistory:victory") : i18next.t("runHistory:defeated", { context: genderStr });
-    const runResultText = addBBCodeTextObject(this.scene, 6, 5, `${runResultTitle} - ${i18next.t("saveSlotSelectUiHandler:wave")} ${this.runInfo.waveIndex}`, runResultTextStyle, {fontSize : "65px", lineSpacing: 0.1});
+    const runResultText = addTextObject(this.scene, 6, 5, `${runResultTitle} - ${i18next.t("saveSlotSelectUiHandler:wave")} ${this.runInfo.waveIndex}`, runResultTextStyle, {fontSize : "65px", lineSpacing: 0.1});
 
     if (this.isVictory) {
       const hallofFameInstructionContainer = this.scene.add.container(0, 0);

--- a/src/ui/run-info-ui-handler.ts
+++ b/src/ui/run-info-ui-handler.ts
@@ -180,7 +180,7 @@ export default class RunInfoUiHandler extends UiHandler {
   private async parseRunResult() {
     const genderIndex = this.scene.gameData.gender ?? PlayerGender.UNSET;
     const genderStr = PlayerGender[genderIndex];
-    const runResultTextStyle = this.isVictory ? TextStyle.SUMMARY_ALT : TextStyle.SUMMARY_RED;
+    const runResultTextStyle = this.isVictory ? TextStyle.PERFECT_IV : TextStyle.SUMMARY_RED;
     const runResultTitle = this.isVictory ? i18next.t("runHistory:victory") : i18next.t("runHistory:defeated", { context: genderStr });
     const runResultText = addTextObject(this.scene, 6, 5, `${runResultTitle} - ${i18next.t("saveSlotSelectUiHandler:wave")} ${this.runInfo.waveIndex}`, runResultTextStyle, {fontSize : "65px", lineSpacing: 0.1});
 

--- a/src/ui/text.ts
+++ b/src/ui/text.ts
@@ -270,9 +270,9 @@ export function getTextColor(textStyle: TextStyle, shadow?: boolean, uiTheme: Ui
     return !shadow ? "#f8f8f8" : "#636363";
   case TextStyle.SUMMARY_ALT:
     if (isLegacyTheme) {
-      return !shadow ? "#484848" : "#d0d0c8";
+      return !shadow ? "#f8f8f8" : "#636363";
     }
-    return !shadow ? "#f8f8f8" : "#636363";
+    return !shadow ? "#484848" : "#d0d0c8";
   case TextStyle.SUMMARY_RED:
   case TextStyle.TOOLTIP_TITLE:
     return !shadow ? "#e70808" : "#ffbd73";

--- a/src/ui/text.ts
+++ b/src/ui/text.ts
@@ -270,9 +270,9 @@ export function getTextColor(textStyle: TextStyle, shadow?: boolean, uiTheme: Ui
     return !shadow ? "#f8f8f8" : "#636363";
   case TextStyle.SUMMARY_ALT:
     if (isLegacyTheme) {
-      return !shadow ? "#f8f8f8" : "#636363";
+      return !shadow ? "#484848" : "#d0d0c8";
     }
-    return !shadow ? "#484848" : "#d0d0c8";
+    return !shadow ? "#f8f8f8" : "#636363";
   case TextStyle.SUMMARY_RED:
   case TextStyle.TOOLTIP_TITLE:
     return !shadow ? "#e70808" : "#ffbd73";


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
If the user was using legacy UI mode, the 'Victory' text would be white, and as a result, it would blend in with the white background and be impossible to see. This fixes that. 

## Why am I making these changes?
My feature, my mistake. 

## What are the changes from a developer perspective?
The text style was changed from TextStyle.SUMMARY to TextStyle.PERFECT_IV

### Screenshots/Videos
![image](https://github.com/user-attachments/assets/c482e9a8-093f-4a39-b5a3-6f7794660889)
![image](https://github.com/user-attachments/assets/f3b96fea-6b3c-4c7c-9856-7ad65ecd2fb4)

## How to test the changes?
Use Legacy UI mode and view a victorious run in Run History

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
