### PR TITLE
[Bug][Beta] Fix bugs from Substitute implementation

### DIFF
--- a/src/data/battle-anims.ts
+++ b/src/data/battle-anims.ts
@@ -870,7 +870,7 @@ export abstract class BattleAnim {
               const sprites = spriteCache[isUser ? AnimFrameTarget.USER : AnimFrameTarget.TARGET];
               const spriteSource = isUser ? userSprite : targetSprite;
               if ((isUser ? u : t) === sprites.length) {
-                if (!isUser && !!targetSubstitute) {
+                if (isUser || !targetSubstitute) {
                   const sprite = scene.addPokemonSprite(isUser ? user! : target, 0, 0, spriteSource!.texture, spriteSource!.frame.name, true); // TODO: are those bangs correct?
                   [ "spriteColors", "fusionSpriteColors" ].map(k => sprite.pipelineData[k] = (isUser ? user! : target).getSprite().pipelineData[k]); // TODO: are those bangs correct?
                   sprite.setPipelineData("spriteKey", (isUser ? user! : target).getBattleSpriteKey());

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2238,8 +2238,8 @@ export class SubstituteTag extends BattlerTag {
     pokemon.scene.triggerPokemonBattleAnim(pokemon, PokemonAnimType.SUBSTITUTE_ADD);
     pokemon.scene.queueMessage(i18next.t("battlerTags:substituteOnAdd", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }), 1500);
 
-    // Remove any trapping effects from the user
-    pokemon.findAndRemoveTags(tag => tag instanceof TrappedTag);
+    // Remove any binding effects from the user
+    pokemon.findAndRemoveTags(tag => tag instanceof DamagingTrapTag);
   }
 
   /** Queues an on-remove battle animation that removes the Substitute's sprite. */

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -124,9 +124,6 @@ export class FaintPhase extends PokemonPhase {
       this.scene.redirectPokemonMoves(pokemon, allyPokemon);
     }
 
-    pokemon.lapseTags(BattlerTagLapseType.FAINT);
-    this.scene.getField(true).filter(p => p !== pokemon).forEach(p => p.removeTagsBySourceId(pokemon.id));
-
     pokemon.faintCry(() => {
       if (pokemon instanceof PlayerPokemon) {
         pokemon.addFriendship(-10);
@@ -140,6 +137,9 @@ export class FaintPhase extends PokemonPhase {
         ease: "Sine.easeIn",
         onComplete: () => {
           pokemon.resetSprite();
+          pokemon.lapseTags(BattlerTagLapseType.FAINT);
+          this.scene.getField(true).filter(p => p !== pokemon).forEach(p => p.removeTagsBySourceId(pokemon.id));
+
           pokemon.y -= 150;
           pokemon.trySetStatus(StatusEffect.FAINT);
           if (pokemon.isPlayer()) {

--- a/src/test/battlerTags/substitute.test.ts
+++ b/src/test/battlerTags/substitute.test.ts
@@ -1,8 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import Pokemon, { MoveResult, PokemonTurnData, TurnMove, PokemonMove } from "#app/field/pokemon";
 import BattleScene from "#app/battle-scene";
-import { BattlerTagLapseType, SubstituteTag, TrappedTag } from "#app/data/battler-tags";
-import { BattlerTagType } from "#app/enums/battler-tag-type";
+import { BattlerTagLapseType, BindTag, SubstituteTag } from "#app/data/battler-tags";
 import { Moves } from "#app/enums/moves";
 import { PokemonAnimType } from "#app/enums/pokemon-anim-type";
 import * as messages from "#app/messages";
@@ -25,7 +24,7 @@ describe("BattlerTag - SubstituteTag", () => {
         getMaxHp: vi.fn().mockReturnValue(101) as Pokemon["getMaxHp"],
         findAndRemoveTags: vi.fn().mockImplementation((tagFilter) => {
           // simulate a Trapped tag set by another Pokemon, then expect the filter to catch it.
-          const trapTag = new TrappedTag(BattlerTagType.TRAPPED, BattlerTagLapseType.CUSTOM, 0, Moves.NONE, 1);
+          const trapTag = new BindTag(5, 0);
           expect(tagFilter(trapTag)).toBeTruthy();
           return true;
         }) as Pokemon["findAndRemoveTags"]


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
This fixes the following bugs that were introduced with Substitute's release onto beta:
- Sprite pipeline effects (including shiny variants) on the target are ignored during move animations where the target has a substitute.
- When a Pokemon faints while it has a substitute, its position isn't reset correctly.
- Non-damaging trap effects (e.g. Spirit Shackle) are incorrectly removed when the afflicted Pokemon puts in a substitute.

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Reported in the Discord: https://discord.com/channels/1125469663833370665/1284249564429160549

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- `data/battle-anims`: Fixed a check to apply pipeline effects using an incorrect condition
- `phases/faint-phase`: The fainted Pokemon's battler tags now lapse *after* the faint animation plays and the Pokemon's sprite is reset (while invisible).
- `data/battler-tags`: Adding a `SubstituteTag` now removes `DamagingTrapTag`s instead of all `TrappedTag`s

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

User with Sub/Protect after battle anim fixes:

https://github.com/user-attachments/assets/2c1cd030-28fb-412f-af63-094cb414dbc7

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
