### PR TITLE
[Move] Implement autotomization weight effects

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -4214,6 +4214,10 @@ export class ReduceBerryUseThresholdAbAttr extends AbAttr {
   }
 }
 
+/**
+ * Ability attribute used for abilites that change the ability owner's weight
+ * Used for Heavy Metal (doubling weight) and Light Metal (halving weight)
+ */
 export class WeightMultiplierAbAttr extends AbAttr {
   private multiplier: integer;
 

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2217,6 +2217,36 @@ export class TarShotTag extends BattlerTag {
   }
 }
 
+/**
+ * Battler Tag that keeps track of how many times the user has Autotomized
+ * Each count of Autotomization reduces the weight by 100kg
+ */
+export class AutotomizedTag extends BattlerTag {
+  public autotomizeCount: number = 0;
+  constructor(sourceMove: Moves = Moves.NONE) {
+    super(BattlerTagType.AUTOTOMIZED, BattlerTagLapseType.CUSTOM, 1, sourceMove);
+  }
+
+  /**
+   * Adds an autotmize count to the Pokemon. Each stack reduces weight by 100kg
+   * If the Pokemon is over 0.1kg it also displays a message.
+   * @param pokemon The Pokemon that is being autotomized
+   */
+  onAdd(pokemon: Pokemon): void {
+    const minWeight = 0.1;
+    if (pokemon.getWeight() > minWeight) {
+      pokemon.scene.queueMessage(i18next.t("battlerTags:autotomizeOnAdd", {
+        pokemonNameWithAffix: getPokemonNameWithAffix(pokemon)
+      }));
+    }
+    this.autotomizeCount += 1;
+  }
+
+  onOverlap(pokemon: Pokemon): void {
+    this.onAdd(pokemon);
+  }
+}
+
 export class SubstituteTag extends BattlerTag {
   /** The substitute's remaining HP. If HP is depleted, the Substitute fades. */
   public hp: number;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -8079,7 +8079,7 @@ export function initMoves() {
       .attr(MovePowerMultiplierAttr, (user, target, move) => target.status && (target.status.effect === StatusEffect.POISON || target.status.effect === StatusEffect.TOXIC) ? 2 : 1),
     new SelfStatusMove(Moves.AUTOTOMIZE, Type.STEEL, -1, 15, -1, 0, 5)
       .attr(StatStageChangeAttr, [ Stat.SPD ], 2, true)
-      .partial(),
+      .attr(AddBattlerTagAttr, BattlerTagType.AUTOTOMIZED, true),
     new SelfStatusMove(Moves.RAGE_POWDER, Type.BUG, -1, 20, -1, 2, 5)
       .powderMove()
       .attr(AddBattlerTagAttr, BattlerTagType.CENTER_OF_ATTENTION, true),

--- a/src/enums/battler-tag-type.ts
+++ b/src/enums/battler-tag-type.ts
@@ -79,4 +79,5 @@ export enum BattlerTagType {
   TAR_SHOT = "TAR_SHOT",
   BURNED_UP = "BURNED_UP",
   DOUBLE_SHOCKED = "DOUBLE_SHOCKED",
+  AUTOTOMIZED = "AUTOTOMIZED",
 }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -17,7 +17,7 @@ import { initMoveAnim, loadMoveAnimAssets } from "../data/battle-anims";
 import { Status, StatusEffect, getRandomStatus } from "../data/status-effect";
 import { pokemonEvolutions, pokemonPrevolutions, SpeciesFormEvolution, SpeciesEvolutionCondition, FusionSpeciesFormEvolution } from "../data/pokemon-evolutions";
 import { reverseCompatibleTms, tmSpecies, tmPoolTiers } from "../data/tms";
-import { BattlerTag, BattlerTagLapseType, EncoreTag, GroundedTag, HighestStatBoostTag, SubstituteTag, TypeImmuneTag, getBattlerTag, SemiInvulnerableTag, TypeBoostTag, MoveRestrictionBattlerTag, ExposedTag, DragonCheerTag, CritBoostTag, TrappedTag, TarShotTag } from "../data/battler-tags";
+import { BattlerTag, BattlerTagLapseType, EncoreTag, GroundedTag, HighestStatBoostTag, SubstituteTag, TypeImmuneTag, getBattlerTag, SemiInvulnerableTag, TypeBoostTag, MoveRestrictionBattlerTag, ExposedTag, DragonCheerTag, CritBoostTag, TrappedTag, TarShotTag, AutotomizedTag } from "../data/battler-tags";
 import { WeatherType } from "../data/weather";
 import { ArenaTagSide, NoCritTag, WeakenMoveScreenTag } from "../data/arena-tag";
 import { Ability, AbAttr, StatMultiplierAbAttr, BlockCritAbAttr, BonusCritAbAttr, BypassBurnDamageReductionAbAttr, FieldPriorityMoveImmunityAbAttr, IgnoreOpponentStatStagesAbAttr, MoveImmunityAbAttr, PreDefendFullHpEndureAbAttr, ReceivedMoveDamageMultiplierAbAttr, ReduceStatusEffectDurationAbAttr, StabBoostAbAttr, StatusEffectImmunityAbAttr, TypeImmunityAbAttr, WeightMultiplierAbAttr, allAbilities, applyAbAttrs, applyStatMultiplierAbAttrs, applyPreApplyBattlerTagAbAttrs, applyPreAttackAbAttrs, applyPreDefendAbAttrs, applyPreSetStatusAbAttrs, UnsuppressableAbilityAbAttr, SuppressFieldAbilitiesAbAttr, NoFusionAbilityAbAttr, MultCritAbAttr, IgnoreTypeImmunityAbAttr, DamageBoostAbAttr, IgnoreTypeStatusEffectImmunityAbAttr, ConditionalCritAbAttr, applyFieldStatMultiplierAbAttrs, FieldMultiplyStatAbAttr, AddSecondStrikeAbAttr, UserFieldStatusEffectImmunityAbAttr, UserFieldBattlerTagImmunityAbAttr, BattlerTagImmunityAbAttr, MoveTypeChangeAbAttr, FullHpResistTypeAbAttr, applyCheckTrappedAbAttrs, CheckTrappedAbAttr } from "../data/ability";
@@ -1342,11 +1342,23 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     return false;
   }
 
+  /**
+   * Gets the weight of the Pokemon with subtractive modifiers (Autotomize) happening first
+   * and then multiplicative modifiers happening after (Heavy Metal and Light Metal)
+   * @returns the kg of the Pokemon (minimum of 0.1)
+   */
   getWeight(): number {
-    const weight = new Utils.NumberHolder(this.species.weight);
+    const autotomizedTag = this.getTag(AutotomizedTag);
+    let weightRemoved = 0;
+    if (autotomizedTag !== null) {
+      weightRemoved = 100 * autotomizedTag.autotomizeCount;
+    }
+    const minWeight = 0.1;
+    const weight = new Utils.NumberHolder(this.species.weight - weightRemoved);
+
     // This will trigger the ability overlay so only call this function when necessary
     applyAbAttrs(WeightMultiplierAbAttr, this, null, false, weight);
-    return weight.value;
+    return Math.max(minWeight, weight.value);
   }
 
   /**

--- a/src/locales/en/battler-tags.json
+++ b/src/locales/en/battler-tags.json
@@ -73,5 +73,6 @@
   "tarShotOnAdd": "{{pokemonNameWithAffix}} became weaker to fire!",
   "substituteOnAdd": "{{pokemonNameWithAffix}} put in a substitute!",
   "substituteOnHit": "The substitute took damage for {{pokemonNameWithAffix}}!",
-  "substituteOnRemove": "{{pokemonNameWithAffix}}'s substitute faded!"
+  "substituteOnRemove": "{{pokemonNameWithAffix}}'s substitute faded!",
+  "autotomizeOnAdd": "{{pokemonNameWIthAffix}} became nimble!"
 }

--- a/src/test/moves/autotomize.test.ts
+++ b/src/test/moves/autotomize.test.ts
@@ -1,0 +1,55 @@
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, it, expect } from "vitest";
+
+describe("Moves - Autotomize", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+  const TIMEOUT = 20 * 1000;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([Moves.AUTOTOMIZE])
+      .battleType("single")
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH);
+  });
+
+  it("Autotomize should reduce weight", async () => {
+    const baseDracozoltWeight = 190;
+    const oneAutotomizeDracozoltWeight = 90;
+    const twoAutotomizeDracozoltWeight = 0.1;
+    const threeAutotomizeDracozoltWeight = 0.1;
+    const playerPokemon = game.scene.getPlayerPokemon()!;
+
+    await game.classicMode.startBattle([Species.DRACOZOLT]);
+    expect(playerPokemon.getWeight()).toBe(baseDracozoltWeight);
+    game.move.select(Moves.AUTOTOMIZE);
+    // expect a queued message here
+    expect(playerPokemon.getWeight()).toBe(oneAutotomizeDracozoltWeight);
+    await game.toNextTurn();
+
+    game.move.select(Moves.AUTOTOMIZE);
+    //expect a queued message here
+    expect(playerPokemon.getWeight()).toBe(twoAutotomizeDracozoltWeight);
+    await game.toNextTurn();
+
+    game.move.select(Moves.AUTOTOMIZE);
+    // expect no queued message here
+    expect(playerPokemon.getWeight()).toBe(threeAutotomizeDracozoltWeight);
+  }, TIMEOUT);
+});


### PR DESCRIPTION
## What are the changes the user will see?
Autotomize will now reduce weight

## Why am I making these changes?
Less (P)

## What are the changes from a developer perspective?
* Created a new battlertag that keeps track of how many times Autotomize has been used
* Changed the pokemon.getWeight() function to account for Autotomize and minimum weight

To do
- [ ]  The BattlerTag should be removed upon form change (relevant for Aegislash and Minior)
- [ ]  More unit tests

### Screenshots/Videos
n/a

## How to test the changes?
Override with Autotomize

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
