### PR TITLE
[Misc][AI] Fix KO filter not accounting for move conditions

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4410,7 +4410,10 @@ export class EnemyPokemon extends Pokemon {
           const isCritical = move.hasAttr(CritOnlyAttr) || !!this.getTag(BattlerTagType.ALWAYS_CRIT);
 
           return move.category !== MoveCategory.STATUS
-            && moveTargets.some(p => p.getAttackDamage(this, move, !p.battleData.abilityRevealed, false, isCritical).damage >= p.hp);
+            && moveTargets.some(p => {
+              const doesNotFail = move.applyConditions(this, p, move) || [Moves.SUCKER_PUNCH, Moves.UPPER_HAND, Moves.THUNDERCLAP].includes(move.id);
+              return doesNotFail && p.getAttackDamage(this, move, !p.battleData.abilityRevealed, false, isCritical).damage >= p.hp;
+            });
         }, this);
 
         if (koMoves.length > 0) {

--- a/src/test/enemy_command.test.ts
+++ b/src/test/enemy_command.test.ts
@@ -6,7 +6,7 @@ import { AiType, EnemyPokemon } from "#app/field/pokemon";
 import { randSeedInt } from "#app/utils";
 import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const TIMEOUT = 20 * 1000;
 const NUM_TRIALS = 300;
@@ -36,12 +36,18 @@ describe("Enemy Commands - Move Selection", () => {
     phaserGame = new Phaser.Game({
       type: Phaser.HEADLESS,
     });
-    game = new GameManager(phaserGame);
-    game.override.ability(Abilities.BALL_FETCH);
   });
 
   afterEach(() => {
     game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+
+    game.override
+      .ability(Abilities.BALL_FETCH)
+      .enemyAbility(Abilities.BALL_FETCH);
   });
 
   it(
@@ -50,8 +56,6 @@ describe("Enemy Commands - Move Selection", () => {
       game.override
         .enemySpecies(Species.ETERNATUS)
         .enemyMoveset([Moves.ETERNABEAM, Moves.SLUDGE_BOMB, Moves.DRAGON_DANCE, Moves.COSMIC_POWER])
-        .enemyAbility(Abilities.BALL_FETCH)
-        .ability(Abilities.BALL_FETCH)
         .startingLevel(1)
         .enemyLevel(100);
 
@@ -67,6 +71,33 @@ describe("Enemy Commands - Move Selection", () => {
 
       enemyMoveset.forEach(mv => {
         if (mv?.getMove().category === MoveCategory.STATUS) {
+          expect(moveChoices[mv.moveId]).toBe(0);
+        }
+      });
+    }, TIMEOUT
+  );
+
+  it(
+    "should not select Last Resort if it would fail, even if the move KOs otherwise",
+    async () => {
+      game.override
+        .enemySpecies(Species.KANGASKHAN)
+        .enemyMoveset([Moves.LAST_RESORT, Moves.GIGA_IMPACT, Moves.SPLASH, Moves.SWORDS_DANCE])
+        .startingLevel(1)
+        .enemyLevel(100);
+
+      await game.classicMode.startBattle([Species.MAGIKARP]);
+
+      const enemyPokemon = game.scene.getEnemyPokemon()!;
+      enemyPokemon.aiType = AiType.SMART_RANDOM;
+
+      const moveChoices: MoveChoiceSet = {};
+      const enemyMoveset = enemyPokemon.getMoveset();
+      enemyMoveset.forEach(mv => moveChoices[mv!.moveId] = 0);
+      getEnemyMoveChoices(enemyPokemon, moveChoices);
+
+      enemyMoveset.forEach(mv => {
+        if (mv?.getMove().category === MoveCategory.STATUS || mv?.moveId === Moves.LAST_RESORT) {
           expect(moveChoices[mv.moveId]).toBe(0);
         }
       });


### PR DESCRIPTION
## What are the changes the user will see?
Enemies will no longer include moves that are known to fail (e.g. Last Resort before the enemy's other move's are used) in the KO filter when selecting a move.

## Why am I making these changes?
Enemies spam failing moves too much after #3975 

## What are the changes from a developer perspective?
- `field/pokemon`: The filter for KO moves in `EnemyPokemon` now filters out moves that are known to not meet their conditions. The added logic is identical to a similar check during the move scoring process.
- `test/enemy_command.test`: New test checking that Last Resort is never used when it would fail.

### Screenshots/Videos

Before the included changes (both Last Resort and Giga Impact KO if they successfully hit):

![image](https://github.com/user-attachments/assets/13d82c5f-e19c-45c0-a7c8-a38f8bd7ed9c)

After the included changes:

![image](https://github.com/user-attachments/assets/2e165921-f18c-4c12-a7a8-46d49b1f3620)

## How to test the changes?
`npm run test enemy_command`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
