### PR TITLE
[Bug] Run History Not Saving Correctly

### DIFF
--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -238,7 +238,7 @@ export class GameOverPhase extends BattlePhase {
       gameVersion: this.scene.game.config.gameVersion,
       timestamp: new Date().getTime(),
       challenges: this.scene.gameMode.challenges.map(c => new ChallengeData(c)),
-      mysteryEncounterType: this.scene.currentBattle.mysteryEncounter?.encounterType,
+      mysteryEncounterType: this.scene.currentBattle.mysteryEncounter?.encounterType ?? -1,
       mysteryEncounterSaveData: this.scene.mysteryEncounterSaveData
     } as SessionSaveData;
   }


### PR DESCRIPTION
## What are the changes the user will see?
Their run history may work again.

## Why am I making these changes?
Guh.

## What are the changes from a developer perspective?
The method to retrieve the last wave's information was not updated while game-data.ts' getSessionSaveData() was. This would mean that when the parseSessionSaveData hit the changed line, it would read an undefined and explode, meaning that it would fail to read the rest of the data.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
Finish a run and check if run history is logged correctly. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
