### PR TITLE
[Hotfix] Fix Dire Hit & System Data Conversion Failure

### DIFF
--- a/src/system/version-converter.ts
+++ b/src/system/version-converter.ts
@@ -22,15 +22,25 @@ export function applySessionDataPatches(data: SessionSaveData) {
         } else if (m.className === "PokemonResetNegativeStatStageModifier") {
           m.className = "ResetNegativeStatStageModifier";
         } else if (m.className === "TempBattleStatBoosterModifier") {
-          m.className = "TempStatStageBoosterModifier";
-          m.typeId = "TEMP_STAT_STAGE_BOOSTER";
+          // Dire Hit no longer a part of the TempBattleStatBoosterModifierTypeGenerator
+          if (m.typeId !== "DIRE_HIT") {
+            m.className = "TempStatStageBoosterModifier";
+            m.typeId = "TEMP_STAT_STAGE_BOOSTER";
 
-          // Migration from TempBattleStat to Stat
-          const newStat = m.typePregenArgs[0] + 1;
-          m.typePregenArgs[0] = newStat;
+            // Migration from TempBattleStat to Stat
+            const newStat = m.typePregenArgs[0] + 1;
+            m.typePregenArgs[0] = newStat;
 
-          // From [ stat, battlesLeft ] to [ stat, maxBattles, battleCount ]
-          m.args = [ newStat, 5, m.args[1] ];
+            // From [ stat, battlesLeft ] to [ stat, maxBattles, battleCount ]
+            m.args = [ newStat, 5, m.args[1] ];
+          } else {
+            m.className = "TempCritBoosterModifier";
+            m.typePregenArgs = [];
+
+            // From [ stat, battlesLeft ] to [ maxBattles, battleCount ]
+            m.args = [ 5, m.args[1] ];
+          }
+
         } else if (m.className === "DoubleBattleChanceBoosterModifier" && m.args.length === 1) {
           let maxBattles: number;
           switch (m.typeId) {
@@ -73,7 +83,7 @@ export function applySystemDataPatches(data: SystemSaveData) {
     case "1.0.3":
     case "1.0.4":
       // --- LEGACY PATCHES ---
-      if (data.starterData) {
+      if (data.starterData && data.dexData) {
         // Migrate ability starter data if empty for caught species
         Object.keys(data.starterData).forEach(sd => {
           if (data.dexData[sd]?.caughtAttr && (data.starterData[sd] && !data.starterData[sd].abilityAttr)) {
@@ -104,12 +114,14 @@ export function applySystemDataPatches(data: SystemSaveData) {
       // --- PATCHES ---
 
       // Fix Starter Data
-      for (const starterId of defaultStarterSpecies) {
-        if (data.starterData[starterId]?.abilityAttr) {
-          data.starterData[starterId].abilityAttr |= AbilityAttr.ABILITY_1;
-        }
-        if (data.dexData[starterId]?.caughtAttr) {
-          data.dexData[starterId].caughtAttr |= DexAttr.FEMALE;
+      if (data.starterData && data.dexData) {
+        for (const starterId of defaultStarterSpecies) {
+          if (data.starterData[starterId]?.abilityAttr) {
+            data.starterData[starterId].abilityAttr |= AbilityAttr.ABILITY_1;
+          }
+          if (data.dexData[starterId]?.caughtAttr) {
+            data.dexData[starterId].caughtAttr |= DexAttr.FEMALE;
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->

- For any users who could not load into the game due to an error (Cannot read properties of null) within `applySystemDataPatches`, they should be able to now.
- `Dire Hit` will now be converter properly

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

- Users were essentially blocked from being able to enter the game due to an null access, forcing them into the "Failed to load system data" screen.
- `Dire Hit` had changed its class and fundamental `ModifierType` when it got decoupled from `TempBattleStat`s and was not properly converted from old saves until now.

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

- Added more `undefined`/`null` guards to prevent trying to access fields in objects that weren't initialized yet during the save migration process.
- Added an `if-else` block wrapping the conversion done for `TempBattleStatBoosterModifier`s such that `Dire Hit` and the other battle items are converted separately since they are structurally different.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

In regards to `Dire Hit`'s conversion,

#### Before (Courtesy of @MokaStitcher)

![beforeDireHit](https://github.com/user-attachments/assets/127a7676-e661-4293-938f-64dc9e639724)

#### After

<img width="1176" alt="afterDireHit" src="https://github.com/user-attachments/assets/094b4881-1ffa-4df8-ae1a-bf609c09dcb4">

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

- For the system data conversion error, the instructions are essentially the same as #4159; however, the provided system data can be found in [this bug report](https://discord.com/channels/1125469663833370665/1284407251905544303) on Discord instead.
- For `Dire Hit`, the following [session data](https://discord.com/channels/1125469663833370665/1281859097481711648/1284524769403863051) (Again, courtesy of @MokaStitcher) on Discord can be used to see the conversion working as intended compared to the previous behavior of getting an anomalous item out of `TempBattleStat` bounds.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- ~[ ] The PR is self-contained and cannot be split into smaller PRs?~
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
