### PR TITLE
[Bug][Beta] Fix "Critical Hit" message appearing before dealing damage

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2621,10 +2621,6 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         return result;
       }
 
-      if (isCritical) {
-        this.scene.queueMessage(i18next.t("battle:hitResultCriticalHit"));
-      }
-
       // In case of fatal damage, this tag would have gotten cleared before we could lapse it.
       const destinyTag = this.getTag(BattlerTagType.DESTINY_BOND);
 
@@ -2665,6 +2661,10 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
             this.scene.applyModifiers(DamageMoneyRewardModifier, true, source, new Utils.NumberHolder(damage));
           }
         }
+      }
+
+      if (isCritical) {
+        this.scene.queueMessage(i18next.t("battle:hitResultCriticalHit"));
       }
 
       // want to include is.Fainted() in case multi hit move ends early, still want to render message


### PR DESCRIPTION
## What are the changes the user will see?
The message "A critical hit!" now correctly appears after damage is dealt.

## Why am I making these changes?
fixes #4251 

## What are the changes from a developer perspective?
`field/pokemon`: The critical hit message generated in `Pokemon#apply` now occurs after the call to `Pokemon.damageAndUpdate` instead of before.

### Screenshots/Videos

https://github.com/user-attachments/assets/0fa76d87-0d00-4279-b40d-e1c4d058cc1a

## How to test the changes?

1. Give your Pokemon Flower Trick with `MOVESET_OVERRIDE` in `src/overrides.ts`
2. Use Flower Trick
3. The critical hit message should happen after damage animations

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
