### PR TITLE
[Bug][Beta] Fix Pokemon info flyouts being offset after switching out from a double battle

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -592,8 +592,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     // Resetting properties should not be shown on the field
     this.setVisible(false);
 
-    // Reset field position
-    this.setFieldPosition(FieldPosition.CENTER);
+    // Remove the offset from having a Substitute active
     if (this.isOffsetBySubstitute()) {
       this.x -= this.getSubstituteOffset()[0];
       this.y -= this.getSubstituteOffset()[1];


### PR DESCRIPTION
## What are the changes the user will see?
This fixes a bug where if a Pokemon switches out in a double battle, its info flyout will sometimes appear partially off-screen after switching back in.

## Why am I making these changes?
This was reported in the Discord. Some screenshots of the bug's effects:

![image](https://github.com/user-attachments/assets/d7a1f306-1b25-4357-b9f2-5202a5eafbc9)

![image](https://github.com/user-attachments/assets/ce3f58ab-ecca-4ee0-84ea-5056f4f478d6)

![image](https://github.com/user-attachments/assets/11bb364c-28e0-485b-9c51-cf556bc94477)

## What are the changes from a developer perspective?
The [Substitute PR](#2559 ) introduced `Pokemon#resetSprite`, a function called in `Pokemon#leaveField` to revert changes to the Pokemon's appearance after using Substitute or applying other effects. Before the changes from this PR, `resetSprite` also "centered" the Pokemon with `setFieldPosition`, which changes the appearance and position of the Pokemon's info flyout. However, the repositioning interfered with the call to hide the info flyout in `leaveField`, potentially because the position was adjusted based on its current position during the `hideInfo` tween animation.

This PR fixes the issue by removing the call to `setFieldPosition` within `resetSprite`. This shouldn't have any adverse effects since before the changes from the Substitute PR, a Pokemon's field position was only set when summoned.

### Screenshots/Videos

Switching in a double battle after the changes

https://github.com/user-attachments/assets/5f47778c-e267-4107-a5af-5072677b1d01

## How to test the changes?
1. Force double battles with `BATTLE_TYPE_OVERRIDE: "double"` in `src/overrides.ts`
2. Try switching out the right-side Pokemon multiple times
3. The switched Pokemon's info flyout's displayed position should not change.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
