### PR TITLE
[Refactor] Refactor code for Grassy Terrain halving the power of Earthquake, Magnitude, and Bulldoze

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -813,10 +813,6 @@ export default class Move implements Localizable {
       power.value *= typeBoost.boostValue;
     }
 
-    if (source.scene.arena.getTerrainType() === TerrainType.GRASSY && target.isGrounded() && this.type === Type.GROUND && this.moveTarget === MoveTarget.ALL_NEAR_OTHERS) {
-      power.value /= 2;
-    }
-
     applyMoveAttrs(VariablePowerAttr, source, target, this, power);
 
     source.scene.applyModifiers(PokemonMultiHitModifier, source.isPlayer(), source, new Utils.IntegerHolder(0), power);

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -9115,7 +9115,7 @@ export function initMoves() {
       .condition(failIfDampCondition)
       .makesContact(false),
     new AttackMove(Moves.GRASSY_GLIDE, Type.GRASS, MoveCategory.PHYSICAL, 55, 100, 20, -1, 0, 8)
-      .attr(IncrementMovePriorityAttr, (user, target, move) =>user.scene.arena.getTerrainType()===TerrainType.GRASSY && user.isGrounded()),
+      .attr(IncrementMovePriorityAttr, (user, target, move) => user.scene.arena.getTerrainType() === TerrainType.GRASSY && user.isGrounded()),
     new AttackMove(Moves.RISING_VOLTAGE, Type.ELECTRIC, MoveCategory.SPECIAL, 70, 100, 20, -1, 0, 8)
       .attr(MovePowerMultiplierAttr, (user, target, move) => user.scene.arena.getTerrainType() === TerrainType.ELECTRIC && target.isGrounded() ? 2 : 1),
     new AttackMove(Moves.TERRAIN_PULSE, Type.NORMAL, MoveCategory.SPECIAL, 50, 100, 10, -1, 0, 8)

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6956,6 +6956,7 @@ export function initMoves() {
       .makesContact(false),
     new AttackMove(Moves.EARTHQUAKE, Type.GROUND, MoveCategory.PHYSICAL, 100, 100, 10, -1, 0, 1)
       .attr(HitsTagAttr, BattlerTagType.UNDERGROUND, true)
+      .attr(MovePowerMultiplierAttr, (user, target, move) => user.scene.arena.getTerrainType() === TerrainType.GRASSY ? 0.5 : 1)
       .makesContact(false)
       .target(MoveTarget.ALL_NEAR_OTHERS),
     new AttackMove(Moves.FISSURE, Type.GROUND, MoveCategory.PHYSICAL, 200, 30, 5, -1, 0, 1)
@@ -7349,6 +7350,7 @@ export function initMoves() {
     new AttackMove(Moves.MAGNITUDE, Type.GROUND, MoveCategory.PHYSICAL, -1, 100, 30, -1, 0, 2)
       .attr(PreMoveMessageAttr, magnitudeMessageFunc)
       .attr(MagnitudePowerAttr)
+      .attr(MovePowerMultiplierAttr, (user, target, move) => user.scene.arena.getTerrainType() === TerrainType.GRASSY ? 0.5 : 1)
       .attr(HitsTagAttr, BattlerTagType.UNDERGROUND, true)
       .makesContact(false)
       .target(MoveTarget.ALL_NEAR_OTHERS),
@@ -8223,6 +8225,7 @@ export function initMoves() {
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new AttackMove(Moves.BULLDOZE, Type.GROUND, MoveCategory.PHYSICAL, 60, 100, 20, 100, 0, 5)
       .attr(StatStageChangeAttr, [ Stat.SPD ], -1)
+      .attr(MovePowerMultiplierAttr, (user, target, move) => user.scene.arena.getTerrainType() === TerrainType.GRASSY ? 0.5 : 1)
       .makesContact(false)
       .target(MoveTarget.ALL_NEAR_OTHERS),
     new AttackMove(Moves.FROST_BREATH, Type.ICE, MoveCategory.SPECIAL, 60, 90, 10, 100, 0, 5)
@@ -9112,7 +9115,7 @@ export function initMoves() {
       .condition(failIfDampCondition)
       .makesContact(false),
     new AttackMove(Moves.GRASSY_GLIDE, Type.GRASS, MoveCategory.PHYSICAL, 55, 100, 20, -1, 0, 8)
-      .attr(IncrementMovePriorityAttr, (user, target, move) =>user.scene.arena.getTerrainType()===TerrainType.GRASSY&&user.isGrounded()),
+      .attr(IncrementMovePriorityAttr, (user, target, move) =>user.scene.arena.getTerrainType()===TerrainType.GRASSY && user.isGrounded()),
     new AttackMove(Moves.RISING_VOLTAGE, Type.ELECTRIC, MoveCategory.SPECIAL, 70, 100, 20, -1, 0, 8)
       .attr(MovePowerMultiplierAttr, (user, target, move) => user.scene.arena.getTerrainType() === TerrainType.ELECTRIC && target.isGrounded() ? 2 : 1),
     new AttackMove(Moves.TERRAIN_PULSE, Type.NORMAL, MoveCategory.SPECIAL, 50, 100, 10, -1, 0, 8)

--- a/src/test/arena/grassy_terrain.test.ts
+++ b/src/test/arena/grassy_terrain.test.ts
@@ -1,0 +1,56 @@
+import { allMoves } from "#app/data/move";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Arena - Grassy Terrain", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+  const TIMEOUT = 20 * 1000;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .disableCrits()
+      .enemyLevel(30)
+      .enemySpecies(Species.SNORLAX)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH)
+      .moveset([Moves.GRASSY_TERRAIN, Moves.EARTHQUAKE])
+      .ability(Abilities.BALL_FETCH);
+  });
+
+  it("halves the damage of Earthquake", async () => {
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    const eq = allMoves[Moves.EARTHQUAKE];
+    vi.spyOn(eq, "calculateBattlePower");
+
+    game.move.select(Moves.EARTHQUAKE);
+    await game.toNextTurn();
+
+    expect(eq.calculateBattlePower).toHaveReturnedWith(100);
+
+    game.move.select(Moves.GRASSY_TERRAIN);
+    await game.toNextTurn();
+
+    game.move.select(Moves.EARTHQUAKE);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(eq.calculateBattlePower).toHaveReturnedWith(50);
+  }, TIMEOUT);
+});


### PR DESCRIPTION
## What are the changes the user will see?
* Grassy Terrain halves the power of Earthquake, Magnitude, and Bulldoze like it does in the mainline games.

## Why am I making these changes?
* This feature was never implemented
* Makes Grassy Terrain more unique
* https://github.com/pagefaultgames/pokerogue/issues/4238
## What are the changes from a developer perspective?
* Added `.attr(MovePowerMultiplierAttr, (user, target, move) => user.scene.arena.getTerrainType() === TerrainType.GRASSY ? 0.5 : 1)` to the three moves
* Fixed some formatting in grassy glide

### Screenshots/Videos
n/a

## How to test the changes?
Override and test

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
