### PR TITLE
[Balance] Pokerus Starter Count 3 -> 5, made pokerus count a constant as to only require one line change

### DIFF
--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -3348,7 +3348,8 @@ export function getStarterValueFriendshipCap(value: integer): integer {
   }
 }
 
-/**
+export const POKERUS_STARTER_COUNT = 5; //adjust here!
+/** 
 * Method to get the daily list of starters with Pokerus.
 * @param scene {@linkcode BattleScene} used as part of RNG
 * @returns A list of starters with Pokerus
@@ -3356,10 +3357,9 @@ export function getStarterValueFriendshipCap(value: integer): integer {
 export function getPokerusStarters(scene: BattleScene): PokemonSpecies[] {
   const pokerusStarters: PokemonSpecies[] = [];
   const date = new Date();
-  const starterCount = 5; //for easy future adjustment!
   date.setUTCHours(0, 0, 0, 0);
   scene.executeWithSeedOffset(() => {
-    while (pokerusStarters.length < starterCount) {
+    while (pokerusStarters.length < POKERUS_STARTER_COUNT) {
       const randomSpeciesId = parseInt(Utils.randSeedItem(Object.keys(speciesStarters)), 10);
       const species = getPokemonSpecies(randomSpeciesId);
       if (!pokerusStarters.includes(species)) {

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -3349,7 +3349,7 @@ export function getStarterValueFriendshipCap(value: integer): integer {
 }
 
 export const POKERUS_STARTER_COUNT = 5; //adjust here!
-/** 
+/**
 * Method to get the daily list of starters with Pokerus.
 * @param scene {@linkcode BattleScene} used as part of RNG
 * @returns A list of starters with Pokerus

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -3356,7 +3356,7 @@ export function getStarterValueFriendshipCap(value: integer): integer {
 export function getPokerusStarters(scene: BattleScene): PokemonSpecies[] {
   const pokerusStarters: PokemonSpecies[] = [];
   const date = new Date();
-  const starterCount = 3; //for easy future adjustment!
+  const starterCount = 5; //for easy future adjustment!
   date.setUTCHours(0, 0, 0, 0);
   scene.executeWithSeedOffset(() => {
     while (pokerusStarters.length < starterCount) {

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -631,7 +631,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
     starterBoxContainer.add(this.starterSelectScrollBar);
 
-    this.pokerusCursorObjs = new Array(3).fill(null).map(() => {
+    this.pokerusCursorObjs = new Array(5).fill(null).map(() => {
       const cursorObj = this.scene.add.image(0, 0, "select_cursor_pokerus");
       cursorObj.setVisible(false);
       cursorObj.setOrigin(0, 0);

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -13,7 +13,7 @@ import { allMoves } from "../data/move";
 import { Nature, getNatureName } from "../data/nature";
 import { pokemonFormChanges } from "../data/pokemon-forms";
 import { LevelMoves, pokemonFormLevelMoves, pokemonSpeciesLevelMoves } from "../data/pokemon-level-moves";
-import PokemonSpecies, { allSpecies, getPokemonSpeciesForm, getStarterValueFriendshipCap, speciesStarters, starterPassiveAbilities, getPokerusStarters } from "../data/pokemon-species";
+import PokemonSpecies, { allSpecies, getPokemonSpeciesForm, getStarterValueFriendshipCap, speciesStarters, starterPassiveAbilities, POKERUS_STARTER_COUNT, getPokerusStarters } from "../data/pokemon-species";
 import { Type } from "../data/type";
 import { GameModes } from "../game-mode";
 import { AbilityAttr, DexAttr, DexAttrProps, DexEntry, StarterMoveset, StarterAttributes, StarterPreferences, StarterPrefs } from "../system/game-data";
@@ -631,7 +631,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
     starterBoxContainer.add(this.starterSelectScrollBar);
 
-    this.pokerusCursorObjs = new Array(5).fill(null).map(() => {
+    this.pokerusCursorObjs = new Array(POKERUS_STARTER_COUNT).fill(null).map(() => {
       const cursorObj = this.scene.add.image(0, 0, "select_cursor_pokerus");
       cursorObj.setVisible(false);
       cursorObj.setOrigin(0, 0);


### PR DESCRIPTION
## What are the changes the user will see?
Changed the Pokerus starter count from 3 -> 5

## Why am I making these changes?
3 was too low. Heavily requested to up the count and wanted to start testing, minor change.
Only other change I'd make but cannot do myself is filter so they're all from a different generation, but that can come another time.

## How to test the changes?
Merge to local or play on the beta.

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
