### PR TITLE
[Enhancement] Add Met Wave to Pokemon Data

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -95,6 +95,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   public metLevel: integer;
   public metBiome: Biome | -1;
   public metSpecies: Species;
+  public metWave: integer;
   public luck: integer;
   public pauseEvolutions: boolean;
   public pokerus: boolean;
@@ -194,6 +195,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       this.luck = dataSource.luck;
       this.metBiome = dataSource.metBiome;
       this.metSpecies = dataSource.metSpecies ?? (this.metBiome !== -1 ? this.species.speciesId : this.species.getRootSpeciesId(true));
+      this.metWave = dataSource.metWave ?? (this.metBiome === -1 ? -1: 0);
       this.pauseEvolutions = dataSource.pauseEvolutions;
       this.pokerus = !!dataSource.pokerus;
       this.evoCounter = dataSource.evoCounter ?? 0;
@@ -240,6 +242,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       this.metLevel = level;
       this.metBiome = scene.currentBattle ? scene.arena.biomeType : -1;
       this.metSpecies = species.speciesId;
+      this.metWave = scene.currentBattle ? scene.currentBattle.waveIndex : -1;
       this.pokerus = false;
 
       if (level > 1) {
@@ -4081,6 +4084,7 @@ export class PlayerPokemon extends Pokemon {
         newPokemon.metLevel = this.metLevel;
         newPokemon.metBiome = this.metBiome;
         newPokemon.metSpecies = this.metSpecies;
+        newPokemon.metWave = this.metWave;
         newPokemon.fusionSpecies = this.fusionSpecies;
         newPokemon.fusionFormIndex = this.fusionFormIndex;
         newPokemon.fusionAbilityIndex = this.fusionAbilityIndex;
@@ -4088,6 +4092,7 @@ export class PlayerPokemon extends Pokemon {
         newPokemon.fusionVariant = this.fusionVariant;
         newPokemon.fusionGender = this.fusionGender;
         newPokemon.fusionLuck = this.fusionLuck;
+        newPokemon.usedTMs = this.usedTMs;
 
         this.scene.getParty().push(newPokemon);
         newPokemon.evolve((!isFusion ? newEvolution : new FusionSpeciesFormEvolution(this.id, newEvolution)), evoSpecies);
@@ -4779,6 +4784,7 @@ export class EnemyPokemon extends Pokemon {
       this.pokeball = pokeballType;
       this.metLevel = this.level;
       this.metBiome = this.scene.arena.biomeType;
+      this.metWave = this.scene.currentBattle.waveIndex;
       this.metSpecies = this.species.speciesId;
       const newPokemon = this.scene.addPlayerPokemon(this.species, this.level, this.abilityIndex, this.formIndex, this.gender, this.shiny, this.variant, this.ivs, this.nature, this);
 

--- a/src/locales/en/pokemon-summary.json
+++ b/src/locales/en/pokemon-summary.json
@@ -11,7 +11,7 @@
   "cancel": "Cancel",
   "memoString": "{{natureFragment}} nature,\n{{metFragment}}",
   "metFragment": {
-    "normal": "met at Lv{{level}},\n{{biome}}.",
+    "normal": "met at Lv{{level}},\n{{biome}}, Wave {{wave}}.",
     "apparently": "apparently met at Lv{{level}},\n{{biome}}."
   },
   "natureFragment": {

--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -38,8 +38,9 @@ export default class PokemonData {
   public status: Status | null;
   public friendship: integer;
   public metLevel: integer;
-  public metBiome: Biome | -1;
+  public metBiome: Biome | -1;        // -1 for starters
   public metSpecies: Species;
+  public metWave: integer;            // 0 for unknown (previous saves), -1 for starters
   public luck: integer;
   public pauseEvolutions: boolean;
   public pokerus: boolean;
@@ -90,13 +91,13 @@ export default class PokemonData {
     this.metLevel = source.metLevel || 5;
     this.metBiome = source.metBiome !== undefined ? source.metBiome : -1;
     this.metSpecies = source.metSpecies;
+    this.metWave = source.metWave !== undefined ? source.metWave : 0;
     this.luck = source.luck !== undefined ? source.luck : (source.shiny ? (source.variant + 1) : 0);
     if (!forHistory) {
       this.pauseEvolutions = !!source.pauseEvolutions;
+      this.evoCounter = source.evoCounter ?? 0;
     }
     this.pokerus = !!source.pokerus;
-
-    this.evoCounter = source.evoCounter ?? 0;
 
     this.fusionSpecies = sourcePokemon ? sourcePokemon.fusionSpecies?.speciesId : source.fusionSpecies;
     this.fusionFormIndex = source.fusionFormIndex;

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -824,6 +824,7 @@ export default class SummaryUiHandler extends UiHandler {
         metFragment: i18next.t(`pokemonSummary:metFragment.${this.pokemon?.metBiome === -1? "apparently": "normal"}`, {
           biome: `${getBBCodeFrag(getBiomeName(this.pokemon?.metBiome!), TextStyle.SUMMARY_RED)}${closeFragment}`, // TODO: is this bang correct?
           level: `${getBBCodeFrag(this.pokemon?.metLevel.toString()!, TextStyle.SUMMARY_RED)}${closeFragment}`, // TODO: is this bang correct?
+          wave: `${getBBCodeFrag((this.pokemon?.metWave ? this.pokemon.metWave.toString()! : i18next.t("pokemonSummary:unknownTrainer")), TextStyle.SUMMARY_RED)}${closeFragment}`, // TODO: is this bang correct?
         }),
         natureFragment: i18next.t(`pokemonSummary:natureFragment.${rawNature}`, { nature: nature })
       });


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
- Pokemon now track the wave they're met
- This is displayed in summary next to biome

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
- Information of interest to player
- Can be used for future or current features/content (for example, a summary after clearing a biome in classic could mark party members caught in the past 10 waves as "new")

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- Adds integer field `metWave` to Pokemon and PokemonData classes
  - -1 for starters, 0 for mons from old saves
- Adds new fragment `wave` to `met-fragment` in the `pokemon-summary` translation file
- While I was there, did some cleanup with `evoCounter` and `usedTms`

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
Newly caught mons have their met locations set
![image](https://github.com/user-attachments/assets/ae3a244c-8fe7-4730-a89f-5b0651953d83)

Starters have theirs set to -1 and will not show
![image](https://github.com/user-attachments/assets/8e78e3f2-82d1-4c0f-831b-3f8877b3c424)

Mons from previous saves will have theirs set to 0 and will show as unknown
![image](https://github.com/user-attachments/assets/adc73465-fdc8-4323-9018-697fd64e7ef8)


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
- [X] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
