### PR TITLE
[Move][Beta] Add back grounded condition to ground shaky moves and grassy terrain

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6952,7 +6952,7 @@ export function initMoves() {
       .makesContact(false),
     new AttackMove(Moves.EARTHQUAKE, Type.GROUND, MoveCategory.PHYSICAL, 100, 100, 10, -1, 0, 1)
       .attr(HitsTagAttr, BattlerTagType.UNDERGROUND, true)
-      .attr(MovePowerMultiplierAttr, (user, target, move) => user.scene.arena.getTerrainType() === TerrainType.GRASSY ? 0.5 : 1)
+      .attr(MovePowerMultiplierAttr, (user, target, move) => user.scene.arena.getTerrainType() === TerrainType.GRASSY && target.isGrounded() ? 0.5 : 1)
       .makesContact(false)
       .target(MoveTarget.ALL_NEAR_OTHERS),
     new AttackMove(Moves.FISSURE, Type.GROUND, MoveCategory.PHYSICAL, 200, 30, 5, -1, 0, 1)
@@ -7346,7 +7346,7 @@ export function initMoves() {
     new AttackMove(Moves.MAGNITUDE, Type.GROUND, MoveCategory.PHYSICAL, -1, 100, 30, -1, 0, 2)
       .attr(PreMoveMessageAttr, magnitudeMessageFunc)
       .attr(MagnitudePowerAttr)
-      .attr(MovePowerMultiplierAttr, (user, target, move) => user.scene.arena.getTerrainType() === TerrainType.GRASSY ? 0.5 : 1)
+      .attr(MovePowerMultiplierAttr, (user, target, move) => user.scene.arena.getTerrainType() === TerrainType.GRASSY && target.isGrounded() ? 0.5 : 1)
       .attr(HitsTagAttr, BattlerTagType.UNDERGROUND, true)
       .makesContact(false)
       .target(MoveTarget.ALL_NEAR_OTHERS),
@@ -8221,7 +8221,7 @@ export function initMoves() {
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new AttackMove(Moves.BULLDOZE, Type.GROUND, MoveCategory.PHYSICAL, 60, 100, 20, 100, 0, 5)
       .attr(StatStageChangeAttr, [ Stat.SPD ], -1)
-      .attr(MovePowerMultiplierAttr, (user, target, move) => user.scene.arena.getTerrainType() === TerrainType.GRASSY ? 0.5 : 1)
+      .attr(MovePowerMultiplierAttr, (user, target, move) => user.scene.arena.getTerrainType() === TerrainType.GRASSY && target.isGrounded() ? 0.5 : 1)
       .makesContact(false)
       .target(MoveTarget.ALL_NEAR_OTHERS),
     new AttackMove(Moves.FROST_BREATH, Type.ICE, MoveCategory.SPECIAL, 60, 90, 10, 100, 0, 5)

--- a/src/test/arena/grassy_terrain.test.ts
+++ b/src/test/arena/grassy_terrain.test.ts
@@ -26,16 +26,16 @@ describe("Arena - Grassy Terrain", () => {
     game.override
       .battleType("single")
       .disableCrits()
-      .enemyLevel(30)
-      .enemySpecies(Species.SNORLAX)
-      .enemyAbility(Abilities.BALL_FETCH)
-      .enemyMoveset(Moves.SPLASH)
+      .enemyLevel(1)
+      .enemySpecies(Species.SHUCKLE)
+      .enemyAbility(Abilities.STURDY)
+      .enemyMoveset(Moves.FLY)
       .moveset([Moves.GRASSY_TERRAIN, Moves.EARTHQUAKE])
-      .ability(Abilities.BALL_FETCH);
+      .ability(Abilities.NO_GUARD);
   });
 
   it("halves the damage of Earthquake", async () => {
-    await game.classicMode.startBattle([Species.FEEBAS]);
+    await game.classicMode.startBattle([Species.TAUROS]);
 
     const eq = allMoves[Moves.EARTHQUAKE];
     vi.spyOn(eq, "calculateBattlePower");
@@ -52,5 +52,20 @@ describe("Arena - Grassy Terrain", () => {
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(eq.calculateBattlePower).toHaveReturnedWith(50);
+  }, TIMEOUT);
+
+  it("Does not halve the damage of Earthquake if opponent is not grounded", async () => {
+    await game.classicMode.startBattle([Species.NINJASK]);
+
+    const eq = allMoves[Moves.EARTHQUAKE];
+    vi.spyOn(eq, "calculateBattlePower");
+
+    game.move.select(Moves.GRASSY_TERRAIN);
+    await game.toNextTurn();
+
+    game.move.select(Moves.EARTHQUAKE);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(eq.calculateBattlePower).toHaveReturnedWith(100);
   }, TIMEOUT);
 });


### PR DESCRIPTION
## What are the changes the user will see?
Fixing a missed condition in https://github.com/pagefaultgames/pokerogue/pull/4263

## Why am I making these changes?
I was informed the damage penalty does not apply if the opponent is not grounded or semi-invulnerable

## What are the changes from a developer perspective?
the grounded tag checks for semi invulnerability

### Screenshots/Videos
n/a

## How to test the changes?
override and test

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
