### PR TITLE
[Bug] Keyboard press is repeated after letting go of the key

### DIFF
--- a/src/inputs-controller.ts
+++ b/src/inputs-controller.ts
@@ -349,12 +349,16 @@ export class InputsController {
      * Handles the keydown event for the keyboard.
      *
      * @param event The keyboard event.
+     *
+     * @remarks On Mac the keyup event for a pressed key is not fired if the meta key is held down. To
+     * insure that that key is not repeatedly input until the user presses it again only emit events
+     * when the meta key is not held.
      */
   keyboardKeyDown(event): void {
     this.lastSource = "keyboard";
     this.ensureKeyboardIsInit();
     const buttonDown = getButtonWithKeycode(this.getActiveConfig(Device.KEYBOARD), event.keyCode);
-    if (buttonDown !== undefined) {
+    if (buttonDown !== undefined && !event.metaKey) {
       if (this.buttonLock.includes(buttonDown)) {
         return;
       }

--- a/src/test/inputs/inputs.test.ts
+++ b/src/test/inputs/inputs.test.ts
@@ -52,6 +52,11 @@ describe("Inputs", () => {
     expect(game.inputsHandler.log.length).toBe(5);
   });
 
+  it("keyboard - test input holding meta key - 0 input", async() => {
+    await game.inputsHandler.pressKeyboardKey(cfg_keyboard_qwerty.deviceMapping.KEY_ARROW_UP, 1, true);
+    expect(game.inputsHandler.log.length).toBe(0);
+  });
+
   it("keyboard - test input holding for 200ms - 1 input", async() => {
     await game.inputsHandler.pressKeyboardKey(cfg_keyboard_qwerty.deviceMapping.KEY_ARROW_UP, 200);
     expect(game.inputsHandler.log.length).toBe(1);

--- a/src/test/utils/inputsHandler.ts
+++ b/src/test/utils/inputsHandler.ts
@@ -48,9 +48,9 @@ export default class InputsHandler {
     });
   }
 
-  pressKeyboardKey(key: integer, duration: integer): Promise<void> {
+  pressKeyboardKey(key: integer, duration: integer, isMetaPressed: boolean = false): Promise<void> {
     return new Promise(async (resolve) => {
-      this.scene.input.keyboard?.emit("keydown", {keyCode: key});
+      this.scene.input.keyboard?.emit("keydown", {keyCode: key, metaKey: isMetaPressed});
       await holdOn(duration);
       this.scene.input.keyboard?.emit("keyup", {keyCode: key});
       resolve();


### PR DESCRIPTION
## What are the changes the user will see?
- Key press will no longer be registered and repeated when the meta key is being held down

## Why am I making these changes?
- Key presses are being input when using shortcuts on the computer accessing browser/application menus

## What are the changes from a developer perspective?
- Insuring that meta key is not held before triggering input

### Screenshots/Videos
- Hard to show in video since behavior would be the same as if I were manually holding down the key

## How to test the changes?
- Run the build and test on the main menu
- Added unit test

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
