### PR TITLE
[QoL] [ui] Make tutorials harder to miss

### DIFF
--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -70,7 +70,7 @@ class DefaultOverrides {
       [PokeballType.MASTER_BALL]: 0,
     },
   };
-  /** Set to true to show all tutorials */
+  /** Set to `true` to show all tutorials */
   readonly BYPASS_TUTORIAL_SKIP: boolean = false;
 
   // ----------------

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -70,6 +70,8 @@ class DefaultOverrides {
       [PokeballType.MASTER_BALL]: 0,
     },
   };
+  /** Set to true to show all tutorials */
+  readonly BYPASS_TUTORIAL_SKIP: boolean = false;
 
   // ----------------
   // PLAYER OVERRIDES

--- a/src/tutorial.ts
+++ b/src/tutorial.ts
@@ -71,7 +71,7 @@ const tutorialHandlers = {
  * The main menu will also get disabled while the tutorial is running
  * @param scene the current {@linkcode BattleScene}
  * @param tutorial the {@linkcode Tutorial} to play
- * @returns a promise with result true is the tutorial was run and finished, false otherwise
+ * @returns a promise with result `true` if the tutorial was run and finished, `false` otherwise
  */
 export async function handleTutorial(scene: BattleScene, tutorial: Tutorial): Promise<boolean> {
   if (!scene.enableTutorials && !Overrides.BYPASS_TUTORIAL_SKIP) {
@@ -109,7 +109,7 @@ export async function handleTutorial(scene: BattleScene, tutorial: Tutorial): Pr
  * Show the tutorial overlay if there is one
  * @param scene the current BattleScene
  * @param handler the current UiHandler
- * @returns true once the overlay has finished appearing, or if there is no overlay
+ * @returns `true` once the overlay has finished appearing, or if there is no overlay
  */
 async function showTutorialOverlay(scene: BattleScene, handler: UiHandler) {
   if (handler instanceof AwaitableUiHandler && handler.tutorialOverlay) {
@@ -131,7 +131,7 @@ async function showTutorialOverlay(scene: BattleScene, handler: UiHandler) {
  * Hide the tutorial overlay if there is one
  * @param scene the current BattleScene
  * @param handler the current UiHandler
- * @returns true once the overlay has finished disappearing, or if there is no overlay
+ * @returns `true` once the overlay has finished disappearing, or if there is no overlay
  */
 async function hideTutorialOverlay(scene: BattleScene, handler: UiHandler) {
   if (handler instanceof AwaitableUiHandler && handler.tutorialOverlay) {

--- a/src/tutorial.ts
+++ b/src/tutorial.ts
@@ -1,7 +1,9 @@
 import BattleScene from "./battle-scene";
 import AwaitableUiHandler from "./ui/awaitable-ui-handler";
+import UiHandler from "./ui/ui-handler";
 import { Mode } from "./ui/ui";
 import i18next from "i18next";
+import Overrides from "#app/overrides";
 
 export enum Tutorial {
   Intro = "INTRO",
@@ -39,7 +41,7 @@ const tutorialHandlers = {
       scene.ui.showText(i18next.t("tutorial:starterSelect"), null, () => scene.ui.showText("", null, () => resolve()), null, true);
     });
   },
-  [Tutorial.Pokerus]:  (scene: BattleScene) => {
+  [Tutorial.Pokerus]: (scene: BattleScene) => {
     return new Promise<void>(resolve => {
       scene.ui.showText(i18next.t("tutorial:pokerus"), null, () => scene.ui.showText("", null, () => resolve()), null, true);
     });
@@ -63,26 +65,79 @@ const tutorialHandlers = {
   },
 };
 
-export function handleTutorial(scene: BattleScene, tutorial: Tutorial): Promise<boolean> {
-  return new Promise<boolean>(resolve => {
-    if (!scene.enableTutorials) {
-      return resolve(false);
-    }
+export async function handleTutorial(scene: BattleScene, tutorial: Tutorial): Promise<boolean> {
+  if (!scene.enableTutorials && !Overrides.BYPASS_TUTORIAL_SKIP) {
+    return false;
+  }
 
-    if (scene.gameData.getTutorialFlags()[tutorial]) {
-      return resolve(false);
-    }
+  if (scene.gameData.getTutorialFlags()[tutorial] && !Overrides.BYPASS_TUTORIAL_SKIP) {
+    return false;
+  }
 
-    const handler = scene.ui.getHandler();
-    if (handler instanceof AwaitableUiHandler) {
-      handler.tutorialActive = true;
-    }
-    tutorialHandlers[tutorial](scene).then(() => {
-      scene.gameData.saveTutorialFlag(tutorial, true);
-      if (handler instanceof AwaitableUiHandler) {
-        handler.tutorialActive = false;
-      }
-      resolve(true);
-    });
-  });
+  const handler = scene.ui.getHandler();
+  const isMenuDisabled = scene.disableMenu;
+
+  // starting tutorial, disable menu
+  scene.disableMenu = true;
+  if (handler instanceof AwaitableUiHandler) {
+    handler.tutorialActive = true;
+  }
+
+  await showTutorialOverlay(scene, handler);
+  await tutorialHandlers[tutorial](scene);
+  await hideTutorialOverlay(scene, handler);
+
+  // tutorial finished and overlay gone, re-enable menu, save tutorial as seen
+  scene.disableMenu = isMenuDisabled;
+  scene.gameData.saveTutorialFlag(tutorial, true);
+  if (handler instanceof AwaitableUiHandler) {
+    handler.tutorialActive = false;
+  }
+
+  return true;
 }
+
+/**
+ * Show the tutorial overlay if there is one
+ * @param scene the current BattleScene
+ * @param handler the current UiHandler
+ * @returns true once the overlay has finished appearing, or if there is no overlay
+ */
+async function showTutorialOverlay(scene: BattleScene, handler: UiHandler) {
+  if (handler instanceof AwaitableUiHandler && handler.tutorialOverlay) {
+    scene.tweens.add({
+      targets: handler.tutorialOverlay,
+      alpha: 0.5,
+      duration: 750,
+      ease: "Sine.easeOut",
+      onComplete: () => {
+        return true;
+      }
+    });
+  } else {
+    return true;
+  }
+}
+
+/**
+ * Hide the tutorial overlay if there is one
+ * @param scene the current BattleScene
+ * @param handler the current UiHandler
+ * @returns true once the overlay has finished disappearing, or if there is no overlay
+ */
+async function hideTutorialOverlay(scene: BattleScene, handler: UiHandler) {
+  if (handler instanceof AwaitableUiHandler && handler.tutorialOverlay) {
+    scene.tweens.add({
+      targets: handler.tutorialOverlay,
+      alpha: 0,
+      duration: 500,
+      ease: "Sine.easeOut",
+      onComplete: () => {
+        return true;
+      }
+    });
+  } else {
+    return true;
+  }
+}
+

--- a/src/tutorial.ts
+++ b/src/tutorial.ts
@@ -65,6 +65,14 @@ const tutorialHandlers = {
   },
 };
 
+/**
+ * Run through the specified tutorial if it hasn't been seen before and mark it as seen once done
+ * This will show a tutorial overlay if defined in the current {@linkcode AwaitableUiHandler}
+ * The main menu will also get disabled while the tutorial is running
+ * @param scene the current {@linkcode BattleScene}
+ * @param tutorial the {@linkcode Tutorial} to play
+ * @returns a promise with result true is the tutorial was run and finished, false otherwise
+ */
 export async function handleTutorial(scene: BattleScene, tutorial: Tutorial): Promise<boolean> {
   if (!scene.enableTutorials && !Overrides.BYPASS_TUTORIAL_SKIP) {
     return false;

--- a/src/ui/awaitable-ui-handler.ts
+++ b/src/ui/awaitable-ui-handler.ts
@@ -7,6 +7,7 @@ export default abstract class AwaitableUiHandler extends UiHandler {
   protected awaitingActionInput: boolean;
   protected onActionInput: Function | null;
   public tutorialActive: boolean = false;
+  public tutorialOverlay: Phaser.GameObjects.Rectangle;
 
   constructor(scene: BattleScene, mode: Mode | null = null) {
     super(scene, mode);
@@ -23,5 +24,22 @@ export default abstract class AwaitableUiHandler extends UiHandler {
     }
 
     return false;
+  }
+
+  /**
+   * Create a semi transparent overlay that will get shown during tutorials
+   * @param container the container to add the overlay to
+   */
+  initTutorialOverlay(container: Phaser.GameObjects.Container) {
+    if (!this.tutorialOverlay) {
+      this.tutorialOverlay = new Phaser.GameObjects.Rectangle(this.scene, -1, -1, this.scene.scaledCanvas.width, this.scene.scaledCanvas.height, 0x070707);
+      this.tutorialOverlay.setName("tutorial-overlay");
+      this.tutorialOverlay.setOrigin(0, 0);
+      this.tutorialOverlay.setAlpha(0);
+    }
+
+    if (container) {
+      container.add(this.tutorialOverlay);
+    }
   }
 }

--- a/src/ui/battle-message-ui-handler.ts
+++ b/src/ui/battle-message-ui-handler.ts
@@ -83,12 +83,7 @@ export default class BattleMessageUiHandler extends MessageUiHandler {
     this.nameBoxContainer.add(this.nameText);
     messageContainer.add(this.nameBoxContainer);
 
-    const prompt = this.scene.add.sprite(0, 0, "prompt");
-    prompt.setVisible(false);
-    prompt.setOrigin(0, 0);
-    messageContainer.add(prompt);
-
-    this.prompt = prompt;
+    this.initPromptSprite(messageContainer);
 
     const levelUpStatsContainer = this.scene.add.container(0, 0);
     levelUpStatsContainer.setVisible(false);

--- a/src/ui/egg-gacha-ui-handler.ts
+++ b/src/ui/egg-gacha-ui-handler.ts
@@ -287,7 +287,6 @@ export default class EggGachaUiHandler extends MessageUiHandler {
     this.eggGachaContainer.add(this.eggGachaSummaryContainer);
 
     const gachaMessageBoxContainer = this.scene.add.container(0, 148);
-    this.eggGachaContainer.add(gachaMessageBoxContainer);
 
     const gachaMessageBox = addWindow(this.scene, 0, 0, 320, 32);
     gachaMessageBox.setOrigin(0, 0);
@@ -301,6 +300,7 @@ export default class EggGachaUiHandler extends MessageUiHandler {
 
     this.message = gachaMessageText;
 
+    this.initTutorialOverlay(this.eggGachaContainer);
     this.eggGachaContainer.add(gachaMessageBoxContainer);
 
     this.initPromptSprite(gachaMessageBoxContainer);

--- a/src/ui/egg-gacha-ui-handler.ts
+++ b/src/ui/egg-gacha-ui-handler.ts
@@ -303,6 +303,8 @@ export default class EggGachaUiHandler extends MessageUiHandler {
 
     this.eggGachaContainer.add(gachaMessageBoxContainer);
 
+    this.initPromptSprite(gachaMessageBoxContainer);
+
     this.setCursor(0);
   }
 

--- a/src/ui/evolution-scene-handler.ts
+++ b/src/ui/evolution-scene-handler.ts
@@ -45,12 +45,7 @@ export default class EvolutionSceneHandler extends MessageUiHandler {
 
     this.message = message;
 
-    const prompt = this.scene.add.sprite(0, 0, "prompt");
-    prompt.setVisible(false);
-    prompt.setOrigin(0, 0);
-    this.messageContainer.add(prompt);
-
-    this.prompt = prompt;
+    this.initPromptSprite(this.messageContainer);
   }
 
   show(_args: any[]): boolean {

--- a/src/ui/menu-ui-handler.ts
+++ b/src/ui/menu-ui-handler.ts
@@ -157,6 +157,7 @@ export default class MenuUiHandler extends MessageUiHandler {
     menuMessageText.setOrigin(0, 0);
     this.menuMessageBoxContainer.add(menuMessageText);
 
+    this.initTutorialOverlay(this.menuContainer);
     this.initPromptSprite(this.menuMessageBoxContainer);
 
     this.message = menuMessageText;
@@ -435,6 +436,9 @@ export default class MenuUiHandler extends MessageUiHandler {
 
     this.scene.playSound("ui/menu_open");
 
+    // Make sure the tutorial overlay sits above everything, but below the message box
+    this.menuContainer.bringToTop(this.tutorialOverlay);
+    this.menuContainer.bringToTop(this.menuMessageBoxContainer);
     handleTutorial(this.scene, Tutorial.Menu);
 
     this.bgmBar.toggleBgmBar(true);

--- a/src/ui/menu-ui-handler.ts
+++ b/src/ui/menu-ui-handler.ts
@@ -157,6 +157,8 @@ export default class MenuUiHandler extends MessageUiHandler {
     menuMessageText.setOrigin(0, 0);
     this.menuMessageBoxContainer.add(menuMessageText);
 
+    this.initPromptSprite(this.menuMessageBoxContainer);
+
     this.message = menuMessageText;
 
     // By default we use the general purpose message window

--- a/src/ui/message-ui-handler.ts
+++ b/src/ui/message-ui-handler.ts
@@ -17,6 +17,21 @@ export default abstract class MessageUiHandler extends AwaitableUiHandler {
     this.pendingPrompt = false;
   }
 
+  /**
+   * Add the sprite to be displayed at the end of messages with prompts
+   * @param container the container to add the sprite to
+   */
+  initPromptSprite(container: Phaser.GameObjects.Container) {
+    if (container && !this.prompt) {
+      const promptSprite = this.scene.add.sprite(0, 0, "prompt");
+      promptSprite.setVisible(false);
+      promptSprite.setOrigin(0, 0);
+      container.add(promptSprite);
+
+      this.prompt = promptSprite;
+    }
+  }
+
   showText(text: string, delay?: integer | null, callback?: Function | null, callbackDelay?: integer | null, prompt?: boolean | null, promptDelay?: integer | null) {
     this.showTextInternal(text, delay, callback, callbackDelay, prompt, promptDelay);
   }
@@ -180,7 +195,7 @@ export default abstract class MessageUiHandler extends AwaitableUiHandler {
     const lastLineWidth = lastLineTest.displayWidth;
     lastLineTest.destroy();
     if (this.prompt) {
-      this.prompt.setPosition(lastLineWidth + 2, (textLinesCount - 1) * 18 + 2);
+      this.prompt.setPosition(this.message.x + lastLineWidth + 2, this.message.y + (textLinesCount - 1) * 18 + 2);
       this.prompt.play("prompt");
     }
     this.pendingPrompt = false;

--- a/src/ui/message-ui-handler.ts
+++ b/src/ui/message-ui-handler.ts
@@ -22,13 +22,15 @@ export default abstract class MessageUiHandler extends AwaitableUiHandler {
    * @param container the container to add the sprite to
    */
   initPromptSprite(container: Phaser.GameObjects.Container) {
-    if (container && !this.prompt) {
+    if (!this.prompt) {
       const promptSprite = this.scene.add.sprite(0, 0, "prompt");
       promptSprite.setVisible(false);
       promptSprite.setOrigin(0, 0);
-      container.add(promptSprite);
-
       this.prompt = promptSprite;
+    }
+
+    if (container) {
+      container.add(this.prompt);
     }
   }
 

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -914,7 +914,11 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       y: this.scene.game.canvas.height / 6 - MoveInfoOverlay.getHeight(overlayScale) - 29,
     });
     this.starterSelectContainer.add(this.moveInfoOverlay);
+
+    // Filter bar sits above everything, except the tutorial overlay and message box
     this.starterSelectContainer.bringToTop(this.filterBarContainer);
+    this.initTutorialOverlay(this.starterSelectContainer);
+    this.starterSelectContainer.bringToTop(this.starterSelectMessageBoxContainer);
 
     this.scene.eventTarget.addEventListener(BattleSceneEventType.CANDY_UPGRADE_NOTIFICATION_CHANGED, (e) => this.onCandyUpgradeDisplayChanged(e));
 

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -894,6 +894,9 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.message.setOrigin(0, 0);
     this.starterSelectMessageBoxContainer.add(this.message);
 
+    // arrow icon for the message box
+    this.initPromptSprite(this.starterSelectMessageBoxContainer);
+
     this.statsContainer = new StatsContainer(this.scene, 6, 16);
 
     this.scene.add.existing(this.statsContainer);


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->

- All tutorials now have an animated cursor icon to show that player input is needed
- All tutorials now have an overlay that dims the UI to make the tutorial stand out (*)
- It's no longer possible to open or close the main menu during tutorials

(*) except the shop one, because that tutorial is a bit buggy and fixing it seems like it would require a good amount of refactoring that I'll leave for a future PR

## Why am I making these changes?

A good number of new players make bug reports about not being able to use the menu because they don't see the tutorial or understand that the text needs to be skipped
This PR addresses this issue while also making the overall feel of text messages more consistent across the game thanks to the cursor icon

Until now it was also possible to open the menu while tutorial text was appearing, which could cause visual issues and lingering text boxes. Now the menu gets disabled at the beginning of all tutorials, and re-enabled after they're done

<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What are the changes from a developer perspective?

background: The `MessageUiHandler` that most handlers in the game extends already handles showing the cursor icon automatically when calling `showText` with prompt=true. It only requires the handler to initialize the sprite during setup, but so far it was only done for the BattleMessageUiHandler and EvolutionSceneHandler, so only the texts shown during battle and evolution would have the cursor show up.

- *MessageUiHandler*: Updated the prompt icon position to work in other places than the battle scene
- *MessageUiHandler*: Added an `initPromptSprite` function to create the sprite for the cursor arrow that will be shown in text messages
- *AwaitableUiHandler*: Added an `initTutorialOverlay` function, that creates an overlay to display during tutorials
- Call these in the handlers that need it
- *tutorial.ts*: Rewrite `handleTutorial` to:
  - use async/await instead of Promises
  - show and hide the tutorial overlay if applicable
  - disable the menu during tutorial and reenable it after
- Added an new override `BYPASS_TUTORIAL_SKIP` to always show tutorials

<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos

Before - menu tutorial:
<img width="720" alt="_before_menu" src="https://github.com/user-attachments/assets/d570d559-bee5-4c4f-a3ee-2a077aeb514c">

After - menu tutorial:

https://github.com/user-attachments/assets/8d288b56-f939-401f-a640-0741745424fc


Before/After for the other affected tutorials:
<img width="300" alt="_before_gacha" src="https://github.com/user-attachments/assets/b8700476-d9e6-4868-909d-a9accb2c04ee"><img width="300" alt="_after_gacha" src="https://github.com/user-attachments/assets/eb174557-0d17-42e7-8846-544354564f7f">

<img width="300" alt="_before_starter" src="https://github.com/user-attachments/assets/abbecdab-6a18-4dd2-9bc3-f7cee273bdf1"><img width="300" alt="_after_starter" src="https://github.com/user-attachments/assets/139e061d-1807-4760-82d8-e39a2dad39ce">

<img width="300" alt="_before_pokerus" src="https://github.com/user-attachments/assets/fb5a9d47-c67c-47b6-ba27-cb362086c808"><img width="300" alt="_after_pokerus" src="https://github.com/user-attachments/assets/69183203-db2b-4af8-9995-bf6191212a45">

The other tutorials are unchanged

Of note, for text that fit tightly in the text box the cursor icon oversteps a bit on the window, hopefully that's not too much of an issue and can be fixed by small adjustments by translators if it is

<img width="700" alt="Screenshot 2024-09-16 at 16 24 59" src="https://github.com/user-attachments/assets/65bfea07-7efa-4587-8694-f3c8897d67f3">



<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?

To see the tutorials, run the game in an incognito window or use the override:
`BYPASS_TUTORIAL_SKIP: true`

Here's how to see the various tutorials in the game:
- Open the main menu
- Open the egg gacha
- Open starter select ui
- Put your cursor over a Pokemon with Pokerus in starter select ui (the Pokemon needs to be owned)

The other tutorials are unchanged, but you can still check that they behave properly
- Get to title screen
- Start a battle
- Have a Pokemon's stats change in battle
- Get to the shop/reward screen (this tutorial will need a separate rework, the cursor arrow doesn't even show for the first line for some reason. This was already the case before this PR)

<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
