### PR TITLE
[Balance] Remove Dragon Ascent Requirement for Mega Rayquaza

### DIFF
--- a/src/data/pokemon-forms.ts
+++ b/src/data/pokemon-forms.ts
@@ -684,7 +684,7 @@ export const pokemonFormChanges: PokemonFormChanges = {
     new SpeciesFormChange(Species.GROUDON, "", SpeciesFormKey.PRIMAL, new SpeciesFormChangeItemTrigger(FormChangeItem.RED_ORB))
   ],
   [Species.RAYQUAZA]: [
-    new SpeciesFormChange(Species.RAYQUAZA, "", SpeciesFormKey.MEGA, new SpeciesFormChangeCompoundTrigger(new SpeciesFormChangeItemTrigger(FormChangeItem.RAYQUAZITE), new SpeciesFormChangeMoveLearnedTrigger(Moves.DRAGON_ASCENT)))
+    new SpeciesFormChange(Species.RAYQUAZA, "", SpeciesFormKey.MEGA, new SpeciesFormChangeItemTrigger(FormChangeItem.RAYQUAZITE))
   ],
   [Species.DEOXYS]: [
     new SpeciesFormChange(Species.DEOXYS, "normal", "attack", new SpeciesFormChangeItemTrigger(FormChangeItem.SHARP_METEORITE)),


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
Rayquaza no longer requires Dragon Ascent to Mega Evolve

## Why am I making these changes?
Normally in mainline Pokemon, Rayquaza does not have a mega stone and instead Mega Evolves through knowing the move Dragon Ascent. However in Pokerogue we do have a Rayquazite, but Rayquaza is still forced to know Dragon Ascent to keep the form change despite requiring two rogue tier items. This limits playstyles and options especially in PokeRogue, as the restriction in mainline is mainly due to Rayquaza being allowed an item slot while the other Megas / Primals are forced into holding their respective stones. That restriction is completely nonexistent in PokeRogue however, since Megas / Primals can hold items other than their Mega Stone here. This was also a requested change in the balance feedback threads. 

## What are the changes from a developer perspective?
Change Rayquaza's Mega Requirements to that of other Mega Evolutions.

### Screenshots/Videos
Rayquaza with no moves
![image](https://github.com/user-attachments/assets/7e917a13-a789-466c-9fd1-39f89a1538d0)

Rayquaza Mega Evolving
![image](https://github.com/user-attachments/assets/302601b0-d3c0-4cf9-946f-1293d2d97461)

## How to test the changes?
Overrides

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
