### PR TITLE
[Bug]Fix 'Clanging Scales' moving player pokemon out of frame

### DIFF
--- a/public/battle-anims/clanging-scales.json
+++ b/public/battle-anims/clanging-scales.json
@@ -27,7 +27,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": 0,
@@ -115,7 +115,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": 0,
@@ -215,7 +215,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": 0,
@@ -315,7 +315,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": 0,
@@ -414,7 +414,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": 0,
@@ -538,7 +538,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": 23,
@@ -685,7 +685,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": -19,
@@ -784,7 +784,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": 26,
@@ -883,7 +883,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": 23.5,
@@ -994,7 +994,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": 9,
@@ -1069,7 +1069,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": -18.5,
@@ -1157,7 +1157,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": 37.5,
@@ -1221,7 +1221,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": 0,
@@ -1284,7 +1284,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": 0,
@@ -1348,7 +1348,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": 0,
@@ -1448,7 +1448,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": 0,
@@ -1548,7 +1548,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": 0,
@@ -1647,7 +1647,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": 0,
@@ -1759,7 +1759,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": -25.5,
@@ -1870,7 +1870,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": 12,
@@ -1957,7 +1957,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": -27,
@@ -2044,7 +2044,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": -16,
@@ -2143,7 +2143,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": -26.5,
@@ -2230,7 +2230,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": 23,
@@ -2306,7 +2306,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": 24,
@@ -2346,7 +2346,7 @@
         "opacity": 255,
         "locked": true,
         "priority": 1,
-        "focus": 2
+        "focus": 1
       },
       {
         "x": -27,


### PR DESCRIPTION

## What are the changes the user will see?
Player pokemon will no longer be offset in position while the opponent uses Clanging Scales. 

Report:
https://discord.com/channels/1125469663833370665/1285201636410654721/1285201636410654721

## What are the changes from a developer perspective?
on file `clanging-scales.json` :
set `"focus": 1` on every object where `"target": 1`

Linking this PR:  [[Bug] Fix Roar & Dragon Tail making enemy sprite disappear #3927](https://github.com/pagefaultgames/pokerogue/pull/3927) 
It is possible that position errors on other move animations have appeared since that change, however it simply means the affected move animations were already set up incorrectly.

### Screenshots/Videos
https://github.com/user-attachments/assets/b7fafe1f-721b-4304-8c5b-ebd3e419ac31

## How to test the changes?
MOVESET_OVERRIDE: = [Moves.CLANGING_SCALES]
OPP_MOVESET_OVERRIDE: = [Moves.CLANGING_SCALES]

optional:
STARTER_FORM_OVERRIDES:  = {[Species.PIKACHU]: 8}
STARTER_SPECIES_OVERRIDE: = Species.PIKACHU

While opponent uses clanging scales the player pokemon should not change location.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
~~- [ ] Have I considered writing automated tests for the issue?~~
~~- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
