### PR TITLE
[Bug] Experimental variation loading doesnt happen for some sprites

### DIFF
--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -294,7 +294,7 @@ export abstract class PokemonSpeciesForm {
     `${back ? "back__" : ""}${baseSpriteKey}`.split("__").map(p => config ? config = config[p] : null);
     const variantSet = config as VariantSet;
 
-    return `${back ? "back__" : ""}${shiny && (!variantSet || (!variant && !variantSet[variant || 0])) ? "shiny__" : ""}${baseSpriteKey}${shiny && variantSet && variantSet[variant] === 2 ? `_${variant + 1}` : ""}`;
+    return `${back ? "back__" : ""}${shiny && (!variantSet || (!variant && !variantSet[variant || 0])) ? "shiny__" : ""}${baseSpriteKey}${shiny && variantSet && variantSet[variant] > 0 ? `_${variant + 1}` : ""}`;
   }
 
   getSpriteKey(female: boolean, formIndex?: integer, shiny?: boolean, variant?: integer): string {
@@ -491,7 +491,7 @@ export abstract class PokemonSpeciesForm {
         let config = variantData;
         spritePath.split("/").map(p => config ? config = config[p] : null);
         const variantSet = config as VariantSet;
-        if (variantSet && (variant !== undefined && variantSet[variant] === 1)) {
+        if (variantSet && (variant !== undefined && variantSet[variant] > 0)) {
           const populateVariantColors = (key: string): Promise<void> => {
             return new Promise(resolve => {
               if (variantColorCache.hasOwnProperty(key)) {


### PR DESCRIPTION
## What are the changes the user will see?
- Experimental variation color variation sprite is loaded properly.

## Why am I making these changes?
- So that the already existing experimental sprites are loaded

## What are the changes from a developer perspective?
- Someone correct me if I'm wrong but the logic for variation coloration seems a bit off. Instead of checking for a specific type of variant, in the places we do check just see if one exists. If so follow the variant logic rather than the normal.

### Screenshots/Videos
#### Before
https://github.com/user-attachments/assets/f99b0ac8-e3ee-47c5-90be-75ff94385c46

#### After
https://github.com/user-attachments/assets/b0a47775-04ef-4648-857c-22667ecd3484



## How to test the changes?
- Follow instructions and save from https://github.com/pagefaultgames/pokerogue/pull/4315 to notice the sprite not loading properly in beta as well.

## Issue:
- https://github.com/pagefaultgames/pokerogue/issues/4322
- https://discord.com/channels/1125469663833370665/1286136806852792353

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
