### PR TITLE
[Bug][UI] Fix run history scrolling and other small bugs

### DIFF
--- a/src/ui/run-info-ui-handler.ts
+++ b/src/ui/run-info-ui-handler.ts
@@ -49,15 +49,11 @@ export default class RunInfoUiHandler extends UiHandler {
   private runResultContainer: Phaser.GameObjects.Container;
   private runInfoContainer: Phaser.GameObjects.Container;
   private partyContainer: Phaser.GameObjects.Container;
-  private partyHeldItemsContainer: Phaser.GameObjects.Container;
   private statsBgWidth: integer;
-  private partyContainerHeight: integer;
-  private partyContainerWidth: integer;
 
   private hallofFameContainer: Phaser.GameObjects.Container;
   private endCardContainer: Phaser.GameObjects.Container;
 
-  private partyInfo: Phaser.GameObjects.Container[];
   private partyVisibility: Boolean;
   private modifiersModule: any;
 
@@ -866,7 +862,7 @@ export default class RunInfoUiHandler extends UiHandler {
   private buttonCycleOption(button: Button) {
     switch (button) {
     case Button.CYCLE_FORM:
-      if (this.isVictory) {
+      if (this.isVictory && this.pageMode !== RunInfoUiMode.HALL_OF_FAME) {
         if (!this.endCardContainer || !this.endCardContainer.visible) {
           this.createVictorySplash();
           this.endCardContainer.setVisible(true);
@@ -880,7 +876,7 @@ export default class RunInfoUiHandler extends UiHandler {
       }
       break;
     case Button.CYCLE_SHINY:
-      if (this.isVictory) {
+      if (this.isVictory && this.pageMode !== RunInfoUiMode.ENDING_ART) {
         if (!this.hallofFameContainer.visible) {
           this.hallofFameContainer.setVisible(true);
           this.pageMode = RunInfoUiMode.HALL_OF_FAME;
@@ -891,7 +887,7 @@ export default class RunInfoUiHandler extends UiHandler {
       }
       break;
     case Button.CYCLE_ABILITY:
-      if (this.runInfo.modifiers.length !== 0) {
+      if (this.runInfo.modifiers.length !== 0 && this.pageMode === RunInfoUiMode.MAIN) {
         if (this.partyVisibility) {
           this.showParty(false);
         } else {

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -139,7 +139,8 @@ const noTransitionModes = [
   Mode.TEST_DIALOGUE,
   Mode.AUTO_COMPLETE,
   Mode.ADMIN,
-  Mode.MYSTERY_ENCOUNTER
+  Mode.MYSTERY_ENCOUNTER,
+  Mode.RUN_INFO
 ];
 
 export default class UI extends Phaser.GameObjects.Container {


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
Small adjustments to the run history UI
- The cursor now shows properly when opening the run history
- It is no longer possible to move the cursor to empty slots
- The cursor now wraps around the run history list
- Scrolling is reset when exiting the run history
- No more flashing when exiting a run detail and coming back to the run history
- It is no longer possible to open the victory screen and hall of fame at the same time

<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?
Just small adjustments and fixes for a more polished feel

<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What are the changes from a developer perspective?
- *`ui.ts`*: added `RunInfoUiHandler` to the list of Modes with no transition since it was causing flashing when exiting due to it being shown as an overlay above `RunHistoryUiHandler`
- *`RunInfoUiHandler`*: added safeguards to the cycle button actions
- *`RunHistoryUiHandler`*: improved navigation and scrolling behavior
- Cleaned up some unused attributes in `RunInfoUiHandler`, `RunHistoryUiHandler`

<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos
Before: No cursor when opening run history + cursor to empty slot 

https://github.com/user-attachments/assets/99c8a64d-993d-48c4-b081-5587f0a3a602

Before: flashing when exiting out of run info (half speed to see better)

https://github.com/user-attachments/assets/30841491-49eb-4e78-b26b-738e607ebf60

Before: opening hall of fame + victory screen at the same time, would end end getting back to the run history list by pressing Cancel twice  

https://github.com/user-attachments/assets/89b7fc9a-57c0-4c43-8c88-91b4c99b3ae9

Before: scrolling back up the list when exiting and re-entering run history

https://github.com/user-attachments/assets/51f723a8-5af8-4c6c-affd-26e3731423d3

After:

https://github.com/user-attachments/assets/06811277-dd6d-4aac-b57a-40c9183ed078



<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?

Play around with run history with [few runs](https://github.com/user-attachments/files/17061339/runHistoryData_2runs.txt), or [a bigger amount of runs](https://github.com/user-attachments/files/17061338/runHistoryData_manyruns.txt)


<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
