### PR TITLE
[BETA][P3] Fix `NaN battles won`

### DIFF
--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -76,7 +76,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
       .then(stats => {
         this.playerCountLabel.setText(`${stats.playerCount} ${i18next.t("menu:playersOnline")}`);
         if (this.splashMessage === "splashMessages:battlesWon") {
-          this.splashMessageText.setText(i18next.t(this.splashMessage, { count: stats.battlesWon }));
+          this.splashMessageText.setText(i18next.t(this.splashMessage, { count: stats.battleCount }));
         }
       })
       .catch(err => {


### PR DESCRIPTION
## What are the changes the user will see?

Won't see any more `NaN battles won`

## What are the changes from a developer perspective?

Using `battleCount` from stats instead of `battlesWon`

## How to test the changes?

it's tricky. You have to launch the server.
I would just trust me and check it on beta

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
