### PR TITLE
[Refactor][Tests] Set default test timeout to `20s`

### DIFF
--- a/create-test-boilerplate.js
+++ b/create-test-boilerplate.js
@@ -76,7 +76,6 @@ import { afterEach, beforeAll, beforeEach, describe, it, expect } from "vitest";
 describe("${description}", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const TIMEOUT = 20 * 1000;
 
   beforeAll(() => {
     phaserGame = new Phaser.Game({
@@ -100,7 +99,7 @@ describe("${description}", () => {
   it("test case", async () => {
     // await game.classicMode.startBattle([Species.MAGIKARP]);
     // game.move.select(Moves.SPLASH);
-  }, TIMEOUT);
+  });
 });
 `;
 

--- a/src/test/abilities/battle_bond.test.ts
+++ b/src/test/abilities/battle_bond.test.ts
@@ -7,7 +7,7 @@ import { Species } from "#enums/species";
 import GameManager from "#test/utils/gameManager";
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Abilities - BATTLE BOND", () => {
   let phaserGame: Phaser.Game;
@@ -60,6 +60,5 @@ describe("Abilities - BATTLE BOND", () => {
 
       expect(greninja!.formIndex).toBe(baseForm);
     },
-    TIMEOUT
   );
 });

--- a/src/test/abilities/costar.test.ts
+++ b/src/test/abilities/costar.test.ts
@@ -8,7 +8,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Abilities - COSTAR", () => {
   let phaserGame: Phaser.Game;
@@ -59,7 +59,6 @@ describe("Abilities - COSTAR", () => {
       expect(leftPokemon.getStatStage(Stat.SPATK)).toBe(2);
       expect(rightPokemon.getStatStage(Stat.SPATK)).toBe(2);
     },
-    TIMEOUT,
   );
 
   test(
@@ -83,6 +82,5 @@ describe("Abilities - COSTAR", () => {
       expect(leftPokemon.getStatStage(Stat.ATK)).toBe(-2);
       expect(rightPokemon.getStatStage(Stat.ATK)).toBe(-2);
     },
-    TIMEOUT,
   );
 });

--- a/src/test/abilities/dancer.test.ts
+++ b/src/test/abilities/dancer.test.ts
@@ -7,7 +7,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Abilities - Dancer", () => {
   let phaserGame: Phaser.Game;
@@ -60,5 +60,5 @@ describe("Abilities - Dancer", () => {
 
     // doesn't use PP if copied move is also in moveset
     expect(oricorio.moveset[0]?.ppUsed).toBe(0);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/abilities/disguise.test.ts
+++ b/src/test/abilities/disguise.test.ts
@@ -7,7 +7,7 @@ import { Stat } from "#enums/stat";
 import GameManager from "#test/utils/gameManager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Abilities - Disguise", () => {
   let phaserGame: Phaser.Game;
@@ -33,7 +33,7 @@ describe("Abilities - Disguise", () => {
       .enemyMoveset(Moves.SPLASH)
       .starterSpecies(Species.REGIELEKI)
       .moveset([Moves.SHADOW_SNEAK, Moves.VACUUM_WAVE, Moves.TOXIC_THREAD, Moves.SPLASH]);
-  }, TIMEOUT);
+  });
 
   it("takes no damage from attacking move and transforms to Busted form, takes 1/8 max HP damage from the disguise breaking", async () => {
     await game.classicMode.startBattle();
@@ -50,7 +50,7 @@ describe("Abilities - Disguise", () => {
 
     expect(mimikyu.hp).equals(maxHp - disguiseDamage);
     expect(mimikyu.formIndex).toBe(bustedForm);
-  }, TIMEOUT);
+  });
 
   it("doesn't break disguise when attacked with ineffective move", async () => {
     await game.classicMode.startBattle();
@@ -64,7 +64,7 @@ describe("Abilities - Disguise", () => {
     await game.phaseInterceptor.to("MoveEndPhase");
 
     expect(mimikyu.formIndex).toBe(disguisedForm);
-  }, TIMEOUT);
+  });
 
   it("takes no damage from the first hit of a multihit move and transforms to Busted form, then takes damage from the second hit", async () => {
     game.override.moveset([ Moves.SURGING_STRIKES ]);
@@ -88,7 +88,7 @@ describe("Abilities - Disguise", () => {
     await game.phaseInterceptor.to("MoveEffectPhase");
     expect(mimikyu.hp).lessThan(maxHp - disguiseDamage);
     expect(mimikyu.formIndex).toBe(bustedForm);
-  }, TIMEOUT);
+  });
 
   it("takes effects from status moves and damage from status effects", async () => {
     await game.classicMode.startBattle();
@@ -104,7 +104,7 @@ describe("Abilities - Disguise", () => {
     expect(mimikyu.status?.effect).toBe(StatusEffect.POISON);
     expect(mimikyu.getStatStage(Stat.SPD)).toBe(-1);
     expect(mimikyu.hp).toBeLessThan(mimikyu.getMaxHp());
-  }, TIMEOUT);
+  });
 
   it("persists form change when switched out", async () => {
     game.override.enemyMoveset([Moves.SHADOW_SNEAK]);
@@ -129,7 +129,7 @@ describe("Abilities - Disguise", () => {
     await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(mimikyu.formIndex).toBe(bustedForm);
-  }, TIMEOUT);
+  });
 
   it("persists form change when wave changes with no arena reset", async () => {
     game.override.starterSpecies(0);
@@ -146,7 +146,7 @@ describe("Abilities - Disguise", () => {
     await game.toNextWave();
 
     expect(mimikyu.formIndex).toBe(bustedForm);
-  }, TIMEOUT);
+  });
 
   it("reverts to Disguised form on arena reset", async () => {
     game.override.startingWave(4);
@@ -166,7 +166,7 @@ describe("Abilities - Disguise", () => {
     await game.toNextWave();
 
     expect(mimikyu.formIndex).toBe(disguisedForm);
-  }, TIMEOUT);
+  });
 
   it("reverts to Disguised form on biome change when fainted", async () => {
     game.override.startingWave(10);
@@ -190,7 +190,7 @@ describe("Abilities - Disguise", () => {
     await game.phaseInterceptor.to("PartyHealPhase");
 
     expect(mimikyu1.formIndex).toBe(disguisedForm);
-  }, TIMEOUT);
+  });
 
   it("doesn't faint twice when fainting due to Disguise break damage, nor prevent faint from Disguise break damage if using Endure", async () => {
     game.override.enemyMoveset([Moves.ENDURE]);
@@ -204,7 +204,7 @@ describe("Abilities - Disguise", () => {
 
     expect(game.scene.getCurrentPhase()?.constructor.name).toBe("CommandPhase");
     expect(game.scene.currentBattle.waveIndex).toBe(2);
-  }, TIMEOUT);
+  });
 
   it("activates when Aerilate circumvents immunity to the move's base type", async () => {
     game.override.ability(Abilities.AERILATE);
@@ -222,5 +222,5 @@ describe("Abilities - Disguise", () => {
 
     expect(mimikyu.formIndex).toBe(bustedForm);
     expect(mimikyu.hp).toBe(maxHp - disguiseDamage);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/abilities/galvanize.test.ts
+++ b/src/test/abilities/galvanize.test.ts
@@ -9,7 +9,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Abilities - Galvanize", () => {
   let phaserGame: Phaser.Game;
@@ -59,7 +59,7 @@ describe("Abilities - Galvanize", () => {
     expect(enemyPokemon.apply).toHaveReturnedWith(HitResult.EFFECTIVE);
     expect(move.calculateBattlePower).toHaveReturnedWith(48);
     expect(enemyPokemon.hp).toBeLessThan(enemyPokemon.getMaxHp());
-  }, TIMEOUT);
+  });
 
   it("should cause Normal-type attacks to activate Volt Absorb", async () => {
     game.override.enemyAbility(Abilities.VOLT_ABSORB);
@@ -81,7 +81,7 @@ describe("Abilities - Galvanize", () => {
     expect(playerPokemon.getMoveType).toHaveLastReturnedWith(Type.ELECTRIC);
     expect(enemyPokemon.apply).toHaveReturnedWith(HitResult.NO_EFFECT);
     expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
-  }, TIMEOUT);
+  });
 
   it("should not change the type of variable-type moves", async () => {
     game.override.enemySpecies(Species.MIGHTYENA);
@@ -100,7 +100,7 @@ describe("Abilities - Galvanize", () => {
     expect(playerPokemon.getMoveType).not.toHaveLastReturnedWith(Type.ELECTRIC);
     expect(enemyPokemon.apply).toHaveReturnedWith(HitResult.NO_EFFECT);
     expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
-  }, TIMEOUT);
+  });
 
   it("should affect all hits of a Normal-type multi-hit move", async () => {
     await game.startBattle();
@@ -128,5 +128,5 @@ describe("Abilities - Galvanize", () => {
     }
 
     expect(enemyPokemon.apply).not.toHaveReturnedWith(HitResult.NO_EFFECT);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/abilities/gorilla_tactics.test.ts
+++ b/src/test/abilities/gorilla_tactics.test.ts
@@ -10,8 +10,6 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 describe("Abilities - Gorilla Tactics", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const TIMEOUT = 20 * 1000;
-
   beforeAll(() => {
     phaserGame = new Phaser.Game({
       type: Phaser.HEADLESS,
@@ -49,7 +47,7 @@ describe("Abilities - Gorilla Tactics", () => {
     // Other moves should be restricted
     expect(darmanitan.isMoveRestricted(Moves.TACKLE)).toBe(true);
     expect(darmanitan.isMoveRestricted(Moves.SPLASH)).toBe(false);
-  }, TIMEOUT);
+  });
 
   it("should struggle if the only usable move is disabled", async () => {
     await game.classicMode.startBattle([Species.GALAR_DARMANITAN]);
@@ -79,5 +77,5 @@ describe("Abilities - Gorilla Tactics", () => {
 
     await game.phaseInterceptor.to("MoveEndPhase");
     expect(darmanitan.hp).toBeLessThan(darmanitan.getMaxHp());
-  }, TIMEOUT);
+  });
 });

--- a/src/test/abilities/libero.test.ts
+++ b/src/test/abilities/libero.test.ts
@@ -12,7 +12,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Abilities - Libero", () => {
   let phaserGame: Phaser.Game;
@@ -52,7 +52,6 @@ describe("Abilities - Libero", () => {
 
       testPokemonTypeMatchesDefaultMoveType(leadPokemon, Moves.SPLASH);
     },
-    TIMEOUT,
   );
 
   test.skip(
@@ -92,7 +91,6 @@ describe("Abilities - Libero", () => {
 
       testPokemonTypeMatchesDefaultMoveType(leadPokemon, Moves.SPLASH);
     },
-    TIMEOUT,
   );
 
   test(
@@ -115,7 +113,6 @@ describe("Abilities - Libero", () => {
         moveType = Type[Type.FIRE];
       expect(leadPokemonType).toBe(moveType);
     },
-    TIMEOUT,
   );
 
   test(
@@ -138,7 +135,6 @@ describe("Abilities - Libero", () => {
         moveType = Type[Type.ICE];
       expect(leadPokemonType).toBe(moveType);
     },
-    TIMEOUT,
   );
 
   test(
@@ -157,7 +153,6 @@ describe("Abilities - Libero", () => {
 
       testPokemonTypeMatchesDefaultMoveType(leadPokemon, Moves.AIR_SLASH);
     },
-    TIMEOUT,
   );
 
   test(
@@ -175,7 +170,6 @@ describe("Abilities - Libero", () => {
 
       testPokemonTypeMatchesDefaultMoveType(leadPokemon, Moves.DIG);
     },
-    TIMEOUT,
   );
 
   test(
@@ -197,7 +191,6 @@ describe("Abilities - Libero", () => {
       expect(enemyPokemon.isFullHp()).toBe(true);
       testPokemonTypeMatchesDefaultMoveType(leadPokemon, Moves.TACKLE);
     },
-    TIMEOUT,
   );
 
   test(
@@ -216,7 +209,6 @@ describe("Abilities - Libero", () => {
 
       testPokemonTypeMatchesDefaultMoveType(leadPokemon, Moves.TACKLE);
     },
-    TIMEOUT,
   );
 
   test(
@@ -235,7 +227,6 @@ describe("Abilities - Libero", () => {
 
       testPokemonTypeMatchesDefaultMoveType(leadPokemon, Moves.TACKLE);
     },
-    TIMEOUT,
   );
 
   test(
@@ -254,7 +245,6 @@ describe("Abilities - Libero", () => {
 
       expect(leadPokemon.summonData.abilitiesApplied).not.toContain(Abilities.LIBERO);
     },
-    TIMEOUT,
   );
 
   test(
@@ -274,7 +264,6 @@ describe("Abilities - Libero", () => {
 
       expect(leadPokemon.summonData.abilitiesApplied).not.toContain(Abilities.LIBERO);
     },
-    TIMEOUT,
   );
 
   test(
@@ -292,7 +281,6 @@ describe("Abilities - Libero", () => {
 
       expect(leadPokemon.summonData.abilitiesApplied).not.toContain(Abilities.LIBERO);
     },
-    TIMEOUT,
   );
 
   test(
@@ -310,7 +298,6 @@ describe("Abilities - Libero", () => {
 
       expect(leadPokemon.summonData.abilitiesApplied).not.toContain(Abilities.LIBERO);
     },
-    TIMEOUT,
   );
 
   test(
@@ -329,7 +316,6 @@ describe("Abilities - Libero", () => {
 
       testPokemonTypeMatchesDefaultMoveType(leadPokemon, Moves.TRICK_OR_TREAT);
     },
-    TIMEOUT,
   );
 
   test(
@@ -348,7 +334,6 @@ describe("Abilities - Libero", () => {
       testPokemonTypeMatchesDefaultMoveType(leadPokemon, Moves.CURSE);
       expect(leadPokemon.getTag(BattlerTagType.CURSED)).not.toBe(undefined);
     },
-    TIMEOUT,
   );
 });
 

--- a/src/test/abilities/magic_guard.test.ts
+++ b/src/test/abilities/magic_guard.test.ts
@@ -11,7 +11,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-const TIMEOUT = 20 * 1000; // 20 sec timeout
+// 20 sec timeout
 
 describe("Abilities - Magic Guard", () => {
   let phaserGame: Phaser.Game;
@@ -67,7 +67,7 @@ describe("Abilities - Magic Guard", () => {
        */
       expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
       expect(enemyPokemon.hp).toBeLessThan(enemyPokemon.getMaxHp());
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -91,7 +91,7 @@ describe("Abilities - Magic Guard", () => {
        */
       expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
       expect(getStatusEffectCatchRateMultiplier(leadPokemon.status!.effect)).toBe(1.5);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -113,7 +113,7 @@ describe("Abilities - Magic Guard", () => {
        * - The player Pokemon (that just lost its Magic Guard ability) has taken damage from poison
        */
       expect(leadPokemon.hp).toBeLessThan(leadPokemon.getMaxHp());
-    }, TIMEOUT
+    }
   );
 
 
@@ -138,7 +138,7 @@ describe("Abilities - Magic Guard", () => {
        */
       expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
       expect(getStatusEffectCatchRateMultiplier(enemyPokemon.status!.effect)).toBe(1.5);
-    }, TIMEOUT
+    }
   );
 
   it("Magic Guard prevents damage caused by toxic but other non-damaging effects are still applied",
@@ -166,7 +166,7 @@ describe("Abilities - Magic Guard", () => {
       expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
       expect(enemyPokemon.status!.turnCount).toBeGreaterThan(toxicStartCounter);
       expect(getStatusEffectCatchRateMultiplier(enemyPokemon.status!.effect)).toBe(1.5);
-    }, TIMEOUT
+    }
   );
 
 
@@ -191,7 +191,7 @@ describe("Abilities - Magic Guard", () => {
     */
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
     expect(enemyPokemon.hp).toBeLessThan(enemyPokemon.getMaxHp());
-  }, TIMEOUT
+  }
   );
 
   it("Magic Guard does not prevent poison from Toxic Spikes", async () => {
@@ -220,7 +220,7 @@ describe("Abilities - Magic Guard", () => {
     expect(enemyPokemon.status!.effect).toBe(StatusEffect.POISON);
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
     expect(enemyPokemon.hp).toBeLessThan(enemyPokemon.getMaxHp());
-  }, TIMEOUT
+  }
   );
 
   it("Magic Guard prevents against damage from volatile status effects",
@@ -246,7 +246,7 @@ describe("Abilities - Magic Guard", () => {
       expect(leadPokemon.hp).toBeLessThan(leadPokemon.getMaxHp());
       expect(enemyPokemon.getTag(BattlerTagType.CURSED)).not.toBe(undefined);
       expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
-    }, TIMEOUT
+    }
   );
 
   it("Magic Guard prevents crash damage", async () => {
@@ -265,7 +265,7 @@ describe("Abilities - Magic Guard", () => {
     * - The player Pokemon (with Magic Guard) misses High Jump Kick but does not lose HP as a result
     */
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
-  }, TIMEOUT
+  }
   );
 
   it("Magic Guard prevents damage from recoil", async () => {
@@ -283,7 +283,7 @@ describe("Abilities - Magic Guard", () => {
     * - The player Pokemon (with Magic Guard) uses a recoil move but does not lose HP from recoil
     */
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
-  }, TIMEOUT
+  }
   );
 
   it("Magic Guard does not prevent damage from Struggle's recoil", async () => {
@@ -301,7 +301,7 @@ describe("Abilities - Magic Guard", () => {
     * - The player Pokemon (with Magic Guard) uses Struggle but does lose HP from Struggle's recoil
     */
     expect(leadPokemon.hp).toBeLessThan(leadPokemon.getMaxHp());
-  }, TIMEOUT
+  }
   );
 
   //This tests different move attributes than the recoil tests above
@@ -320,7 +320,7 @@ describe("Abilities - Magic Guard", () => {
     * - The player Pokemon (with Magic Guard) uses a move with an HP cost but does not lose HP from using it
     */
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
-  }, TIMEOUT
+  }
   );
 
   /*
@@ -348,7 +348,7 @@ describe("Abilities - Magic Guard", () => {
     * - The player Pokemon (with Magic Guard) uses a non-attacking move with an HP cost and thus loses HP from using it
     */
     expect(leadPokemon.hp).toBeLessThan(leadPokemon.getMaxHp());
-  }, TIMEOUT
+  }
   );
 
   it("Magic Guard prevents damage from abilities with PostTurnHurtIfSleepingAbAttr", async () => {
@@ -373,7 +373,7 @@ describe("Abilities - Magic Guard", () => {
     */
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
     expect(leadPokemon.status!.effect).toBe(StatusEffect.SLEEP);
-  }, TIMEOUT
+  }
   );
 
   it("Magic Guard prevents damage from abilities with PostFaintContactDamageAbAttr", async () => {
@@ -398,7 +398,7 @@ describe("Abilities - Magic Guard", () => {
     */
     expect(enemyPokemon.hp).toBe(0);
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
-  }, TIMEOUT
+  }
   );
 
   it("Magic Guard prevents damage from abilities with PostDefendContactDamageAbAttr", async () => {
@@ -422,7 +422,7 @@ describe("Abilities - Magic Guard", () => {
     */
     expect(enemyPokemon.hp).toBeLessThan(enemyPokemon.getMaxHp());
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
-  }, TIMEOUT
+  }
   );
 
   it("Magic Guard prevents damage from abilities with ReverseDrainAbAttr", async () => {
@@ -446,7 +446,7 @@ describe("Abilities - Magic Guard", () => {
     */
     expect(enemyPokemon.hp).toBeLessThan(enemyPokemon.getMaxHp());
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
-  }, TIMEOUT
+  }
   );
 
   it("Magic Guard prevents HP loss from abilities with PostWeatherLapseDamageAbAttr", async () => {
@@ -464,6 +464,6 @@ describe("Abilities - Magic Guard", () => {
     * - The player Pokemon (with Magic Guard) should not lose HP due to this ability attribute
     */
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
-  }, TIMEOUT
+  }
   );
 });

--- a/src/test/abilities/magic_guard.test.ts
+++ b/src/test/abilities/magic_guard.test.ts
@@ -11,8 +11,6 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-// 20 sec timeout
-
 describe("Abilities - Magic Guard", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;

--- a/src/test/abilities/parental_bond.test.ts
+++ b/src/test/abilities/parental_bond.test.ts
@@ -10,7 +10,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Abilities - Parental Bond", () => {
   let phaserGame: Phaser.Game;
@@ -62,7 +62,7 @@ describe("Abilities - Parental Bond", () => {
 
       expect(leadPokemon.turnData.hitCount).toBe(2);
       expect(secondStrikeDamage).toBe(toDmgValue(0.25 * firstStrikeDamage));
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -81,7 +81,7 @@ describe("Abilities - Parental Bond", () => {
 
       expect(leadPokemon.turnData.hitCount).toBe(2);
       expect(leadPokemon.getStatStage(Stat.ATK)).toBe(2);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -98,7 +98,7 @@ describe("Abilities - Parental Bond", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(-1);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -116,7 +116,7 @@ describe("Abilities - Parental Bond", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(leadPokemon.turnData.hitCount).toBe(2);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -133,7 +133,7 @@ describe("Abilities - Parental Bond", () => {
       await game.phaseInterceptor.to("DamagePhase", false);
 
       expect(leadPokemon.turnData.hitCount).toBe(1);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -151,7 +151,7 @@ describe("Abilities - Parental Bond", () => {
       await game.phaseInterceptor.to("DamagePhase", false);
 
       expect(leadPokemon.turnData.hitCount).toBe(1);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -167,7 +167,7 @@ describe("Abilities - Parental Bond", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp() - 80);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -189,7 +189,7 @@ describe("Abilities - Parental Bond", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp() - 4 * playerDamage);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -209,7 +209,7 @@ describe("Abilities - Parental Bond", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       playerPokemon.forEach(p => expect(p.turnData.hitCount).toBe(1));
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -225,7 +225,7 @@ describe("Abilities - Parental Bond", () => {
       await game.phaseInterceptor.to("DamagePhase", false);
 
       expect(leadPokemon.turnData.hitCount).toBe(2);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -247,7 +247,7 @@ describe("Abilities - Parental Bond", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(leadPokemon.hp).toBe(Math.ceil(leadPokemon.getMaxHp() / 2));
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -271,7 +271,7 @@ describe("Abilities - Parental Bond", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(leadPokemon.isOfType(Type.FIRE)).toBe(false);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -289,7 +289,7 @@ describe("Abilities - Parental Bond", () => {
       await game.phaseInterceptor.to("DamagePhase");
 
       expect(leadPokemon.turnData.hitCount).toBe(4);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -313,7 +313,7 @@ describe("Abilities - Parental Bond", () => {
       await game.phaseInterceptor.to("MoveEndPhase", false);
 
       expect(enemyPokemon.hp).toBe(Math.ceil(enemyPokemon.getMaxHp() * 0.25));
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -339,7 +339,7 @@ describe("Abilities - Parental Bond", () => {
       await game.phaseInterceptor.to("MoveEndPhase", false);
 
       expect(enemyPokemon.hp).toBe(enemyStartingHp - 200);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -362,7 +362,7 @@ describe("Abilities - Parental Bond", () => {
       await game.phaseInterceptor.to("TurnEndPhase");
 
       expect(leadPokemon.getTag(BattlerTagType.RECHARGING)).toBeDefined();
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -389,7 +389,7 @@ describe("Abilities - Parental Bond", () => {
       await game.phaseInterceptor.to("TurnEndPhase");
 
       expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeDefined();
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -413,7 +413,7 @@ describe("Abilities - Parental Bond", () => {
       await game.phaseInterceptor.to("TurnEndPhase");
 
       expect(enemyPokemon.getTag(BattlerTagType.IGNORE_FLYING)).toBeDefined();
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -433,7 +433,7 @@ describe("Abilities - Parental Bond", () => {
 
       // This will cause this test to time out if the switch was forced on the first hit.
       await game.phaseInterceptor.to("MoveEffectPhase", false);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -457,7 +457,7 @@ describe("Abilities - Parental Bond", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(enemyPokemon.status?.effect).toBeUndefined();
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -475,7 +475,7 @@ describe("Abilities - Parental Bond", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(leadPokemon.getStatStage(Stat.ATK)).toBe(-1);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -493,7 +493,7 @@ describe("Abilities - Parental Bond", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(1);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -519,6 +519,6 @@ describe("Abilities - Parental Bond", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       enemyPokemon.forEach((p, i) => expect(enemyStartingHp[i] - p.hp).toBe(2 * enemyFirstHitDamage[i]));
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/abilities/power_construct.test.ts
+++ b/src/test/abilities/power_construct.test.ts
@@ -7,7 +7,7 @@ import { Species } from "#enums/species";
 import GameManager from "#test/utils/gameManager";
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Abilities - POWER CONSTRUCT", () => {
   let phaserGame: Phaser.Game;
@@ -60,6 +60,5 @@ describe("Abilities - POWER CONSTRUCT", () => {
 
       expect(zygarde!.formIndex).toBe(baseForm);
     },
-    TIMEOUT
   );
 });

--- a/src/test/abilities/protean.test.ts
+++ b/src/test/abilities/protean.test.ts
@@ -12,7 +12,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Abilities - Protean", () => {
   let phaserGame: Phaser.Game;
@@ -52,7 +52,6 @@ describe("Abilities - Protean", () => {
 
       testPokemonTypeMatchesDefaultMoveType(leadPokemon, Moves.SPLASH);
     },
-    TIMEOUT,
   );
 
   test.skip(
@@ -92,7 +91,6 @@ describe("Abilities - Protean", () => {
 
       testPokemonTypeMatchesDefaultMoveType(leadPokemon, Moves.SPLASH);
     },
-    TIMEOUT,
   );
 
   test(
@@ -115,7 +113,6 @@ describe("Abilities - Protean", () => {
         moveType = Type[Type.FIRE];
       expect(leadPokemonType).toBe(moveType);
     },
-    TIMEOUT,
   );
 
   test(
@@ -138,7 +135,6 @@ describe("Abilities - Protean", () => {
         moveType = Type[Type.ICE];
       expect(leadPokemonType).toBe(moveType);
     },
-    TIMEOUT,
   );
 
   test(
@@ -157,7 +153,6 @@ describe("Abilities - Protean", () => {
 
       testPokemonTypeMatchesDefaultMoveType(leadPokemon, Moves.AIR_SLASH);
     },
-    TIMEOUT,
   );
 
   test(
@@ -175,7 +170,6 @@ describe("Abilities - Protean", () => {
 
       testPokemonTypeMatchesDefaultMoveType(leadPokemon, Moves.DIG);
     },
-    TIMEOUT,
   );
 
   test(
@@ -197,7 +191,6 @@ describe("Abilities - Protean", () => {
       expect(enemyPokemon.isFullHp()).toBe(true);
       testPokemonTypeMatchesDefaultMoveType(leadPokemon, Moves.TACKLE);
     },
-    TIMEOUT,
   );
 
   test(
@@ -216,7 +209,6 @@ describe("Abilities - Protean", () => {
 
       testPokemonTypeMatchesDefaultMoveType(leadPokemon, Moves.TACKLE);
     },
-    TIMEOUT,
   );
 
   test(
@@ -235,7 +227,6 @@ describe("Abilities - Protean", () => {
 
       testPokemonTypeMatchesDefaultMoveType(leadPokemon, Moves.TACKLE);
     },
-    TIMEOUT,
   );
 
   test(
@@ -254,7 +245,6 @@ describe("Abilities - Protean", () => {
 
       expect(leadPokemon.summonData.abilitiesApplied).not.toContain(Abilities.PROTEAN);
     },
-    TIMEOUT,
   );
 
   test(
@@ -274,7 +264,6 @@ describe("Abilities - Protean", () => {
 
       expect(leadPokemon.summonData.abilitiesApplied).not.toContain(Abilities.PROTEAN);
     },
-    TIMEOUT,
   );
 
   test(
@@ -292,7 +281,6 @@ describe("Abilities - Protean", () => {
 
       expect(leadPokemon.summonData.abilitiesApplied).not.toContain(Abilities.PROTEAN);
     },
-    TIMEOUT,
   );
 
   test(
@@ -310,7 +298,6 @@ describe("Abilities - Protean", () => {
 
       expect(leadPokemon.summonData.abilitiesApplied).not.toContain(Abilities.PROTEAN);
     },
-    TIMEOUT,
   );
 
   test(
@@ -329,7 +316,6 @@ describe("Abilities - Protean", () => {
 
       testPokemonTypeMatchesDefaultMoveType(leadPokemon, Moves.TRICK_OR_TREAT);
     },
-    TIMEOUT,
   );
 
   test(
@@ -348,7 +334,6 @@ describe("Abilities - Protean", () => {
       testPokemonTypeMatchesDefaultMoveType(leadPokemon, Moves.CURSE);
       expect(leadPokemon.getTag(BattlerTagType.CURSED)).not.toBe(undefined);
     },
-    TIMEOUT,
   );
 });
 

--- a/src/test/abilities/sand_veil.test.ts
+++ b/src/test/abilities/sand_veil.test.ts
@@ -11,7 +11,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Abilities - Sand Veil", () => {
   let phaserGame: Phaser.Game;
@@ -75,6 +75,6 @@ describe("Abilities - Sand Veil", () => {
 
       expect(leadPokemon[0].isFullHp()).toBe(true);
       expect(leadPokemon[1].hp).toBeLessThan(leadPokemon[1].getMaxHp());
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/abilities/schooling.test.ts
+++ b/src/test/abilities/schooling.test.ts
@@ -7,7 +7,7 @@ import { Species } from "#enums/species";
 import GameManager from "#test/utils/gameManager";
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Abilities - SCHOOLING", () => {
   let phaserGame: Phaser.Game;
@@ -60,6 +60,5 @@ describe("Abilities - SCHOOLING", () => {
 
       expect(wishiwashi.formIndex).toBe(soloForm);
     },
-    TIMEOUT
   );
 });

--- a/src/test/abilities/shields_down.test.ts
+++ b/src/test/abilities/shields_down.test.ts
@@ -7,7 +7,7 @@ import { Species } from "#enums/species";
 import GameManager from "#test/utils/gameManager";
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Abilities - SHIELDS DOWN", () => {
   let phaserGame: Phaser.Game;
@@ -60,6 +60,5 @@ describe("Abilities - SHIELDS DOWN", () => {
 
       expect(minior.formIndex).toBe(meteorForm);
     },
-    TIMEOUT
   );
 });

--- a/src/test/abilities/sturdy.test.ts
+++ b/src/test/abilities/sturdy.test.ts
@@ -8,7 +8,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Abilities - Sturdy", () => {
   let phaserGame: Phaser.Game;
@@ -45,7 +45,6 @@ describe("Abilities - Sturdy", () => {
       await game.phaseInterceptor.to(MoveEndPhase);
       expect(game.scene.getEnemyParty()[0].hp).toBe(1);
     },
-    TIMEOUT
   );
 
   test(
@@ -62,7 +61,6 @@ describe("Abilities - Sturdy", () => {
       expect(enemyPokemon.hp).toBe(0);
       expect(enemyPokemon.isFainted()).toBe(true);
     },
-    TIMEOUT
   );
 
   test(
@@ -75,7 +73,6 @@ describe("Abilities - Sturdy", () => {
       const enemyPokemon: EnemyPokemon = game.scene.getEnemyParty()[0];
       expect(enemyPokemon.isFullHp()).toBe(true);
     },
-    TIMEOUT
   );
 
   test(
@@ -91,7 +88,6 @@ describe("Abilities - Sturdy", () => {
       expect(enemyPokemon.hp).toBe(0);
       expect(enemyPokemon.isFainted()).toBe(true);
     },
-    TIMEOUT
   );
 
 });

--- a/src/test/abilities/tera_shell.test.ts
+++ b/src/test/abilities/tera_shell.test.ts
@@ -6,8 +6,6 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const TIMEOUT = 10 * 1000; // 10 second timeout
-
 describe("Abilities - Tera Shell", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
@@ -54,7 +52,7 @@ describe("Abilities - Tera Shell", () => {
 
       await game.phaseInterceptor.to("MoveEndPhase");
       expect(playerPokemon.getMoveEffectiveness).toHaveLastReturnedWith(2);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -71,7 +69,7 @@ describe("Abilities - Tera Shell", () => {
 
       await game.phaseInterceptor.to("MoveEndPhase");
       expect(playerPokemon.getMoveEffectiveness).toHaveLastReturnedWith(0);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -88,7 +86,7 @@ describe("Abilities - Tera Shell", () => {
 
       await game.phaseInterceptor.to("MoveEndPhase");
       expect(playerPokemon.getMoveEffectiveness).toHaveLastReturnedWith(0.25);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -106,6 +104,6 @@ describe("Abilities - Tera Shell", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
       expect(playerPokemon.apply).toHaveLastReturnedWith(HitResult.EFFECTIVE);
       expect(playerPokemon.hp).toBe(playerPokemon.getMaxHp() - 40);
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/abilities/unseen_fist.test.ts
+++ b/src/test/abilities/unseen_fist.test.ts
@@ -8,7 +8,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { BattlerTagType } from "#app/enums/battler-tag-type";
 import { BerryPhase } from "#app/phases/berry-phase";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Abilities - Unseen Fist", () => {
   let phaserGame: Phaser.Game;
@@ -37,13 +37,11 @@ describe("Abilities - Unseen Fist", () => {
   it(
     "should cause a contact move to ignore Protect",
     () => testUnseenFistHitResult(game, Moves.QUICK_ATTACK, Moves.PROTECT, true),
-    TIMEOUT
   );
 
   it(
     "should not cause a non-contact move to ignore Protect",
     () => testUnseenFistHitResult(game, Moves.ABSORB, Moves.PROTECT, false),
-    TIMEOUT
   );
 
   it(
@@ -51,19 +49,17 @@ describe("Abilities - Unseen Fist", () => {
     () => {
       game.override.passiveAbility(Abilities.LONG_REACH);
       testUnseenFistHitResult(game, Moves.QUICK_ATTACK, Moves.PROTECT, false);
-    }, TIMEOUT
+    }
   );
 
   it(
     "should cause a contact move to ignore Wide Guard",
     () => testUnseenFistHitResult(game, Moves.BREAKING_SWIPE, Moves.WIDE_GUARD, true),
-    TIMEOUT
   );
 
   it(
     "should not cause a non-contact move to ignore Wide Guard",
     () => testUnseenFistHitResult(game, Moves.BULLDOZE, Moves.WIDE_GUARD, false),
-    TIMEOUT
   );
 
   it(
@@ -83,7 +79,7 @@ describe("Abilities - Unseen Fist", () => {
 
       expect(enemyPokemon.getTag(BattlerTagType.SUBSTITUTE)).toBeUndefined();
       expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
-    }, TIMEOUT
+    }
   );
 });
 

--- a/src/test/abilities/zen_mode.test.ts
+++ b/src/test/abilities/zen_mode.test.ts
@@ -19,7 +19,7 @@ import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
 import { Status, StatusEffect } from "#app/data/status-effect";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Abilities - ZEN MODE", () => {
   let phaserGame: Phaser.Game;
@@ -67,7 +67,6 @@ describe("Abilities - ZEN MODE", () => {
       expect(game.scene.getParty()[0].hp).toBeLessThan(100);
       expect(game.scene.getParty()[0].formIndex).toBe(0);
     },
-    TIMEOUT
   );
 
   test(
@@ -87,7 +86,6 @@ describe("Abilities - ZEN MODE", () => {
       expect(game.scene.getParty()[0].hp).not.toBe(100);
       expect(game.scene.getParty()[0].formIndex).not.toBe(0);
     },
-    TIMEOUT
   );
 
   test(
@@ -125,7 +123,6 @@ describe("Abilities - ZEN MODE", () => {
       await game.phaseInterceptor.to(PostSummonPhase);
       expect(game.scene.getParty()[1].formIndex).toBe(1);
     },
-    TIMEOUT
   );
 
   test(
@@ -156,6 +153,5 @@ describe("Abilities - ZEN MODE", () => {
 
       expect(darmanitan.formIndex).toBe(baseForm);
     },
-    TIMEOUT
   );
 });

--- a/src/test/abilities/zero_to_hero.test.ts
+++ b/src/test/abilities/zero_to_hero.test.ts
@@ -7,7 +7,7 @@ import { Species } from "#enums/species";
 import GameManager from "#test/utils/gameManager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Abilities - ZERO TO HERO", () => {
   let phaserGame: Phaser.Game;
@@ -59,7 +59,7 @@ describe("Abilities - ZERO TO HERO", () => {
 
     expect(palafin1.formIndex).toBe(baseForm);
     expect(palafin2.formIndex).toBe(baseForm);
-  }, TIMEOUT);
+  });
 
   it("should swap to Hero form when switching out during a battle", async () => {
     await game.startBattle([Species.PALAFIN, Species.FEEBAS]);
@@ -70,7 +70,7 @@ describe("Abilities - ZERO TO HERO", () => {
     game.doSwitchPokemon(1);
     await game.phaseInterceptor.to(QuietFormChangePhase);
     expect(palafin.formIndex).toBe(heroForm);
-  }, TIMEOUT);
+  });
 
   it("should not swap to Hero form if switching due to faint", async () => {
     await game.startBattle([Species.PALAFIN, Species.FEEBAS]);
@@ -83,7 +83,7 @@ describe("Abilities - ZERO TO HERO", () => {
     game.doSelectPartyPokemon(1);
     await game.toNextTurn();
     expect(palafin.formIndex).toBe(baseForm);
-  }, TIMEOUT);
+  });
 
   it("should stay hero form if fainted and then revived", async () => {
     game.override.starterForms({
@@ -105,5 +105,5 @@ describe("Abilities - ZERO TO HERO", () => {
     await game.toNextTurn();
 
     expect(palafin.formIndex).toBe(heroForm);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/arena/grassy_terrain.test.ts
+++ b/src/test/arena/grassy_terrain.test.ts
@@ -9,8 +9,6 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 describe("Arena - Grassy Terrain", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const TIMEOUT = 20 * 1000;
-
   beforeAll(() => {
     phaserGame = new Phaser.Game({
       type: Phaser.HEADLESS,
@@ -52,7 +50,7 @@ describe("Arena - Grassy Terrain", () => {
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(eq.calculateBattlePower).toHaveReturnedWith(50);
-  }, TIMEOUT);
+  });
 
   it("Does not halve the damage of Earthquake if opponent is not grounded", async () => {
     await game.classicMode.startBattle([Species.NINJASK]);
@@ -67,5 +65,5 @@ describe("Arena - Grassy Terrain", () => {
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(eq.calculateBattlePower).toHaveReturnedWith(100);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/battle/inverse_battle.test.ts
+++ b/src/test/battle/inverse_battle.test.ts
@@ -10,7 +10,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Inverse Battle", () => {
   let phaserGame: Phaser.Game;
@@ -56,7 +56,7 @@ describe("Inverse Battle", () => {
     await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(enemy.getMoveEffectiveness).toHaveLastReturnedWith(2);
-  }, TIMEOUT);
+  });
 
   it("2x effective types are 0.5x effective - Thunderbolt against Flying Type", async () => {
     game.override
@@ -73,7 +73,7 @@ describe("Inverse Battle", () => {
     await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(enemy.getMoveEffectiveness).toHaveLastReturnedWith(0.5);
-  }, TIMEOUT);
+  });
 
   it("0.5x effective types are 2x effective - Thunderbolt against Electric Type", async () => {
     game.override
@@ -90,7 +90,7 @@ describe("Inverse Battle", () => {
     await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(enemy.getMoveEffectiveness).toHaveLastReturnedWith(2);
-  }, TIMEOUT);
+  });
 
   it("Stealth Rock follows the inverse matchups - Stealth Rock against Charizard deals 1/32 of max HP", async () => {
     game.scene.arena.addTag(ArenaTagType.STEALTH_ROCK, 1, Moves.STEALTH_ROCK, 0);
@@ -110,7 +110,7 @@ describe("Inverse Battle", () => {
 
     console.log("Charizard's max HP: " + maxHp, "Damage: " + damage_prediction, "Current HP: " + currentHp, "Expected HP: " + expectedHP);
     expect(currentHp).toBeGreaterThan(maxHp * 31 / 32 - 1);
-  }, TIMEOUT);
+  });
 
   it("Freeze Dry is 2x effective against Water Type like other Ice type Move - Freeze Dry against Squirtle", async () => {
     game.override
@@ -127,7 +127,7 @@ describe("Inverse Battle", () => {
     await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(enemy.getMoveEffectiveness).toHaveLastReturnedWith(2);
-  }, TIMEOUT);
+  });
 
   it("Water Absorb should heal against water moves - Water Absorb against Water gun", async () => {
     game.override
@@ -143,7 +143,7 @@ describe("Inverse Battle", () => {
     await game.phaseInterceptor.to("MoveEndPhase");
 
     expect(enemy.hp).toBe(enemy.getMaxHp());
-  }, TIMEOUT);
+  });
 
   it("Fire type does not get burned - Will-O-Wisp against Charmander", async () => {
     game.override
@@ -160,7 +160,7 @@ describe("Inverse Battle", () => {
     await game.phaseInterceptor.to("MoveEndPhase");
 
     expect(enemy.status?.effect).not.toBe(StatusEffect.BURN);
-  }, TIMEOUT);
+  });
 
   it("Electric type does not get paralyzed - Nuzzle against Pikachu", async () => {
     game.override
@@ -177,7 +177,7 @@ describe("Inverse Battle", () => {
     await game.phaseInterceptor.to("MoveEndPhase");
 
     expect(enemy.status?.effect).not.toBe(StatusEffect.PARALYSIS);
-  }, TIMEOUT);
+  });
 
   it("Ground type is not immune to Thunder Wave - Thunder Wave against Sandshrew", async () => {
     game.override
@@ -194,7 +194,7 @@ describe("Inverse Battle", () => {
     await game.phaseInterceptor.to("MoveEndPhase");
 
     expect(enemy.status?.effect).toBe(StatusEffect.PARALYSIS);
-  }, TIMEOUT);
+  });
 
 
   it("Anticipation should trigger on 2x effective moves - Anticipation against Thunderbolt", async () => {
@@ -206,7 +206,7 @@ describe("Inverse Battle", () => {
     await game.challengeMode.startBattle();
 
     expect(game.scene.getEnemyPokemon()?.summonData.abilitiesApplied[0]).toBe(Abilities.ANTICIPATION);
-  }, TIMEOUT);
+  });
 
   it("Conversion 2 should change the type to the resistive type - Conversion 2 against Dragonite", async () => {
     game.override
@@ -223,7 +223,7 @@ describe("Inverse Battle", () => {
     await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(player.getTypes()[0]).toBe(Type.DRAGON);
-  }, TIMEOUT);
+  });
 
   it("Flying Press should be 0.25x effective against Grass + Dark Type - Flying Press against Meowscarada", async () => {
     game.override
@@ -240,7 +240,7 @@ describe("Inverse Battle", () => {
     await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(enemy.getMoveEffectiveness).toHaveLastReturnedWith(0.25);
-  }, TIMEOUT);
+  });
 
   it("Scrappy ability has no effect - Tackle against Ghost Type still 2x effective with Scrappy", async () => {
     game.override
@@ -258,7 +258,7 @@ describe("Inverse Battle", () => {
     await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(enemy.getMoveEffectiveness).toHaveLastReturnedWith(2);
-  }, TIMEOUT);
+  });
 
   it("FORESIGHT has no effect - Tackle against Ghost Type still 2x effective with Foresight", async () => {
     game.override
@@ -279,5 +279,5 @@ describe("Inverse Battle", () => {
     await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(enemy.getMoveEffectiveness).toHaveLastReturnedWith(2);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/battlerTags/substitute.test.ts
+++ b/src/test/battlerTags/substitute.test.ts
@@ -10,8 +10,6 @@ import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 
 vi.mock("#app/battle-scene.js");
 
-const TIMEOUT = 5 * 1000; // 5 sec timeout
-
 describe("BattlerTag - SubstituteTag", () => {
   let mockPokemon: Pokemon;
 
@@ -45,7 +43,7 @@ describe("BattlerTag - SubstituteTag", () => {
         subject.onAdd(mockPokemon);
 
         expect(subject.hp).toBe(25);
-      }, TIMEOUT
+      }
     );
 
     it(
@@ -67,7 +65,7 @@ describe("BattlerTag - SubstituteTag", () => {
         expect(subject.sourceInFocus).toBeFalsy();
         expect(mockPokemon.scene.triggerPokemonBattleAnim).toHaveBeenCalledTimes(1);
         expect(mockPokemon.scene.queueMessage).toHaveBeenCalledTimes(1);
-      }, TIMEOUT
+      }
     );
 
     it(
@@ -79,7 +77,7 @@ describe("BattlerTag - SubstituteTag", () => {
 
         subject.onAdd(mockPokemon);
         expect(mockPokemon.findAndRemoveTags).toHaveBeenCalledTimes(1);
-      }, TIMEOUT
+      }
     );
   });
 
@@ -114,7 +112,7 @@ describe("BattlerTag - SubstituteTag", () => {
 
         expect(mockPokemon.scene.triggerPokemonBattleAnim).toHaveBeenCalledTimes(1);
         expect(mockPokemon.scene.queueMessage).toHaveBeenCalledTimes(1);
-      }, TIMEOUT
+      }
     );
   });
 
@@ -150,7 +148,7 @@ describe("BattlerTag - SubstituteTag", () => {
         expect(subject.sourceInFocus).toBeTruthy();
         expect(mockPokemon.scene.triggerPokemonBattleAnim).toHaveBeenCalledTimes(1);
         expect(mockPokemon.scene.queueMessage).not.toHaveBeenCalled();
-      }, TIMEOUT
+      }
     );
 
     it(
@@ -172,7 +170,7 @@ describe("BattlerTag - SubstituteTag", () => {
         expect(subject.sourceInFocus).toBeFalsy();
         expect(mockPokemon.scene.triggerPokemonBattleAnim).toHaveBeenCalledTimes(1);
         expect(mockPokemon.scene.queueMessage).not.toHaveBeenCalled();
-      }, TIMEOUT
+      }
     );
 
     /** TODO: Figure out how to mock a MoveEffectPhase correctly for this test */
@@ -200,7 +198,7 @@ describe("BattlerTag - SubstituteTag", () => {
 
         expect(mockPokemon.scene.triggerPokemonBattleAnim).not.toHaveBeenCalled();
         expect(mockPokemon.scene.queueMessage).toHaveBeenCalledTimes(1);
-      }, TIMEOUT
+      }
     );
 
     it(
@@ -212,7 +210,7 @@ describe("BattlerTag - SubstituteTag", () => {
         vi.spyOn(mockPokemon.scene, "queueMessage").mockReturnValue();
 
         expect(subject.lapse(mockPokemon, BattlerTagLapseType.CUSTOM)).toBeFalsy();
-      }, TIMEOUT
+      }
     );
 
     it(

--- a/src/test/boss-pokemon.test.ts
+++ b/src/test/boss-pokemon.test.ts
@@ -9,8 +9,6 @@ import { EnemyPokemon } from "#app/field/pokemon";
 import { toDmgValue } from "#app/utils";
 
 describe("Boss Pokemon / Shields", () => {
-  const TIMEOUT = 20 * 1000;
-
   let phaserGame: Phaser.Game;
   let game: GameManager;
 
@@ -62,7 +60,7 @@ describe("Boss Pokemon / Shields", () => {
     // Pokemon above level 100 get an extra shield
     level = 100;
     expect(game.scene.getEncounterBossSegments(wave, level, getPokemonSpecies(Species.RATTATA))).toBe(7);
-  }, TIMEOUT);
+  });
 
   it("should reduce the number of shields if we are in a double battle", async () => {
     game.override
@@ -77,7 +75,7 @@ describe("Boss Pokemon / Shields", () => {
     expect(boss1.bossSegments).toBe(2);
     expect(boss2.isBoss()).toBe(true);
     expect(boss2.bossSegments).toBe(2);
-  }, TIMEOUT);
+  });
 
   it("shields should stop overflow damage and give stat stage boosts when broken", async () => {
     game.override.startingWave(150); // Floor 150 > 2 shields / 3 health segments
@@ -107,7 +105,7 @@ describe("Boss Pokemon / Shields", () => {
     // Breaking the last shield gives a +2 boost to ATK, DEF, SP ATK, SP DEF or SPD
     expect(getTotalStatStageBoosts(enemyPokemon)).toBe(3);
 
-  }, TIMEOUT);
+  });
 
   it("breaking multiple shields at once requires extra damage", async () => {
     game.override
@@ -143,7 +141,7 @@ describe("Boss Pokemon / Shields", () => {
     expect(boss2.bossSegmentIndex).toBe(0);
     expect(boss2.hp).toBe(boss2.getMaxHp() - toDmgValue(boss2SegmentHp * 4));
 
-  }, TIMEOUT);
+  });
 
   it("the number of stat stage boosts is consistent when several shields are broken at once", async () => {
     const shieldsToBreak = 4;
@@ -196,7 +194,7 @@ describe("Boss Pokemon / Shields", () => {
     await game.toNextTurn();
     expect(getTotalStatStageBoosts(boss2)).toBe(totalStatStages);
 
-  }, TIMEOUT);
+  });
 
   /**
    * Gets the sum of the effective stat stage boosts for the given Pokemon

--- a/src/test/enemy_command.test.ts
+++ b/src/test/enemy_command.test.ts
@@ -8,7 +8,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 const NUM_TRIALS = 300;
 
 type MoveChoiceSet = { [key: number]: number };
@@ -74,7 +74,7 @@ describe("Enemy Commands - Move Selection", () => {
           expect(moveChoices[mv.moveId]).toBe(0);
         }
       });
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -101,6 +101,6 @@ describe("Enemy Commands - Move Selection", () => {
           expect(moveChoices[mv.moveId]).toBe(0);
         }
       });
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/evolution.test.ts
+++ b/src/test/evolution.test.ts
@@ -10,7 +10,6 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 describe("Evolution", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const TIMEOUT = 1000 * 20;
 
   beforeAll(() => {
     phaserGame = new Phaser.Game({
@@ -46,7 +45,7 @@ describe("Evolution", () => {
 
     trapinch.evolve(pokemonEvolutions[Species.TRAPINCH][0], trapinch.getSpeciesForm());
     expect(trapinch.abilityIndex).toBe(1);
-  }, TIMEOUT);
+  });
 
   it("should keep same ability slot after evolving", async () => {
     await game.classicMode.runToSummon([Species.BULBASAUR, Species.CHARMANDER]);
@@ -61,7 +60,7 @@ describe("Evolution", () => {
 
     charmander.evolve(pokemonEvolutions[Species.CHARMANDER][0], charmander.getSpeciesForm());
     expect(charmander.abilityIndex).toBe(1);
-  }, TIMEOUT);
+  });
 
   it("should handle illegal abilityIndex values", async () => {
     await game.classicMode.runToSummon([Species.SQUIRTLE]);
@@ -71,7 +70,7 @@ describe("Evolution", () => {
 
     squirtle.evolve(pokemonEvolutions[Species.SQUIRTLE][0], squirtle.getSpeciesForm());
     expect(squirtle.abilityIndex).toBe(0);
-  }, TIMEOUT);
+  });
 
   it("should handle nincada's unique evolution", async () => {
     await game.classicMode.runToSummon([Species.NINCADA]);
@@ -87,7 +86,7 @@ describe("Evolution", () => {
     expect(shedinja.abilityIndex).toBe(1);
     // Regression test for https://github.com/pagefaultgames/pokerogue/issues/3842
     expect(shedinja.metBiome).toBe(-1);
-  }, TIMEOUT);
+  });
 
   it("should set wild delay to NONE by default", () => {
     const speciesFormEvo = new SpeciesFormEvolution(Species.ABRA, null, null, 1000, null, null);
@@ -120,7 +119,7 @@ describe("Evolution", () => {
 
     expect(totodile.hp).toBe(totodile.getMaxHp());
     expect(totodile.hp).toBeGreaterThan(hpBefore);
-  }, TIMEOUT);
+  });
 
   it("should not fully heal HP when evolving", async () => {
     game.override.moveset([Moves.SURF])
@@ -150,7 +149,7 @@ describe("Evolution", () => {
     expect(cyndaquil.getMaxHp()).toBeGreaterThan(maxHpBefore);
     expect(cyndaquil.hp).toBeGreaterThan(hpBefore);
     expect(cyndaquil.hp).toBeLessThan(cyndaquil.getMaxHp());
-  }, TIMEOUT);
+  });
 
   it("should handle rng-based split evolution", async () => {
     /* this test checks to make sure that tandemaus will
@@ -174,5 +173,5 @@ describe("Evolution", () => {
       const fourForm = playerPokemon.getEvolution()!;
       expect(fourForm.evoFormKey).toBe(null); // meanwhile, according to the pokemon-forms, the evoFormKey for a 4 family maushold is null
     }
-  }, TIMEOUT);
+  });
 });

--- a/src/test/items/double_battle_chance_booster.test.ts
+++ b/src/test/items/double_battle_chance_booster.test.ts
@@ -12,8 +12,6 @@ import { Button } from "#app/enums/buttons";
 describe("Items - Double Battle Chance Boosters", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const TIMEOUT = 20 * 1000;
-
   beforeAll(() => {
     phaserGame = new Phaser.Game({
       type: Phaser.HEADLESS,
@@ -39,7 +37,7 @@ describe("Items - Double Battle Chance Boosters", () => {
     await game.classicMode.startBattle();
 
     expect(game.scene.getEnemyField().length).toBe(2);
-  }, TIMEOUT);
+  });
 
   it("should guarantee double boss battle with 3 unique tiers", async () => {
     game.override
@@ -57,7 +55,7 @@ describe("Items - Double Battle Chance Boosters", () => {
     expect(enemyField.length).toBe(2);
     expect(enemyField[0].isBoss()).toBe(true);
     expect(enemyField[1].isBoss()).toBe(true);
-  }, TIMEOUT);
+  });
 
   it("should renew how many battles are left of existing booster when picking up new booster of same tier", async() => {
     game.override
@@ -100,5 +98,5 @@ describe("Items - Double Battle Chance Boosters", () => {
       }
     }
     expect(count).toBe(1);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/items/eviolite.test.ts
+++ b/src/test/items/eviolite.test.ts
@@ -9,8 +9,6 @@ import { StatBoosterModifier } from "#app/modifier/modifier";
 describe("Items - Eviolite", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const TIMEOUT = 20 * 1000;
-
   beforeAll(() => {
     phaserGame = new Phase.Game({
       type: Phaser.HEADLESS,
@@ -50,7 +48,7 @@ describe("Items - Eviolite", () => {
 
     expect(partyMember.getEffectiveStat(Stat.DEF)).toBe(Math.floor(defStat * 1.5));
     expect(partyMember.getEffectiveStat(Stat.SPDEF)).toBe(Math.floor(spDefStat * 1.5));
-  }, TIMEOUT);
+  });
 
   it("should not provide a boost for fully evolved, unfused pokemon", async() => {
     await game.classicMode.startBattle([
@@ -74,7 +72,7 @@ describe("Items - Eviolite", () => {
     expect(partyMember.getEffectiveStat(Stat.DEF)).toBe(defStat);
     expect(partyMember.getEffectiveStat(Stat.SPDEF)).toBe(spDefStat);
 
-  }, TIMEOUT);
+  });
 
   it("should provide 50% boost to DEF and SPDEF for completely unevolved, fused pokemon", async() => {
     await game.classicMode.startBattle([
@@ -107,7 +105,7 @@ describe("Items - Eviolite", () => {
 
     expect(partyMember.getEffectiveStat(Stat.DEF)).toBe(Math.floor(defStat * 1.5));
     expect(partyMember.getEffectiveStat(Stat.SPDEF)).toBe(Math.floor(spDefStat * 1.5));
-  }, TIMEOUT);
+  });
 
   it("should provide 25% boost to DEF and SPDEF for partially unevolved (base), fused pokemon", async() => {
     await game.classicMode.startBattle([
@@ -140,7 +138,7 @@ describe("Items - Eviolite", () => {
 
     expect(partyMember.getEffectiveStat(Stat.DEF)).toBe(Math.floor(defStat * 1.25));
     expect(partyMember.getEffectiveStat(Stat.SPDEF)).toBe(Math.floor(spDefStat * 1.25));
-  }, TIMEOUT);
+  });
 
   it("should provide 25% boost to DEF and SPDEF for partially unevolved (fusion), fused pokemon", async() => {
     await game.classicMode.startBattle([
@@ -173,7 +171,7 @@ describe("Items - Eviolite", () => {
 
     expect(partyMember.getEffectiveStat(Stat.DEF)).toBe(Math.floor(defStat * 1.25));
     expect(partyMember.getEffectiveStat(Stat.SPDEF)).toBe(Math.floor(spDefStat * 1.25));
-  }, TIMEOUT);
+  });
 
   it("should not provide a boost for fully evolved, fused pokemon", async() => {
     await game.classicMode.startBattle([
@@ -206,7 +204,7 @@ describe("Items - Eviolite", () => {
 
     expect(partyMember.getEffectiveStat(Stat.DEF)).toBe(defStat);
     expect(partyMember.getEffectiveStat(Stat.SPDEF)).toBe(spDefStat);
-  }, TIMEOUT);
+  });
 
   it("should not provide a boost for Gigantamax Pokémon", async() => {
     game.override.starterForms({
@@ -238,5 +236,5 @@ describe("Items - Eviolite", () => {
 
     expect(partyMember.getEffectiveStat(Stat.DEF)).toBe(defStat);
     expect(partyMember.getEffectiveStat(Stat.SPDEF)).toBe(spDefStat);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/items/grip_claw.test.ts
+++ b/src/test/items/grip_claw.test.ts
@@ -9,7 +9,7 @@ import GameManager from "#test/utils/gameManager";
 import Phase from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const TIMEOUT = 20 * 1000; // 20 seconds
+// 20 seconds
 
 describe("Items - Grip Claw", () => {
   let phaserGame: Phaser.Game;
@@ -63,6 +63,6 @@ describe("Items - Grip Claw", () => {
       await game.phaseInterceptor.to(MoveEndPhase, false);
 
       expect(enemyPokemon[1].getHeldItems.length).toBe(enemyHeldItemCt[1]);
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/after_you.test.ts
+++ b/src/test/moves/after_you.test.ts
@@ -8,7 +8,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - After You", () => {
   let phaserGame: Phaser.Game;
@@ -47,7 +47,7 @@ describe("Moves - After You", () => {
     const phase = game.scene.getCurrentPhase() as MovePhase;
     expect(phase.pokemon).toBe(game.scene.getPlayerField()[1]);
     await game.phaseInterceptor.to("MoveEndPhase");
-  }, TIMEOUT);
+  });
 
   it("fails if target already moved", async () => {
     game.override.enemySpecies(Species.SHUCKLE);
@@ -61,5 +61,5 @@ describe("Moves - After You", () => {
     await game.phaseInterceptor.to(MovePhase);
 
     expect(game.scene.getPlayerField()[1].getLastXMoves(1)[0].result).toBe(MoveResult.FAIL);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/alluring_voice.test.ts
+++ b/src/test/moves/alluring_voice.test.ts
@@ -8,7 +8,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Alluring Voice", () => {
   let phaserGame: Phaser.Game;
@@ -50,5 +50,5 @@ describe("Moves - Alluring Voice", () => {
     await game.phaseInterceptor.to(BerryPhase);
 
     expect(enemy.getTag(BattlerTagType.CONFUSED)?.tagType).toBe("CONFUSED");
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/astonish.test.ts
+++ b/src/test/moves/astonish.test.ts
@@ -11,7 +11,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Astonish", () => {
   let phaserGame: Phaser.Game;
@@ -67,6 +67,6 @@ describe("Moves - Astonish", () => {
       await game.phaseInterceptor.to(BerryPhase, false);
 
       expect(leadPokemon.hp).toBeLessThan(leadPokemon.getMaxHp());
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/baddy_bad.test.ts
+++ b/src/test/moves/baddy_bad.test.ts
@@ -8,8 +8,6 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 describe("Moves - Baddy Bad", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const TIMEOUT = 20 * 1000;
-
   beforeAll(() => {
     phaserGame = new Phaser.Game({
       type: Phaser.HEADLESS,
@@ -39,5 +37,5 @@ describe("Moves - Baddy Bad", () => {
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(game.scene.arena.tags.length).toBe(0);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/baneful_bunker.test.ts
+++ b/src/test/moves/baneful_bunker.test.ts
@@ -7,7 +7,7 @@ import { Moves } from "#enums/moves";
 import { BattlerIndex } from "#app/battle";
 import { StatusEffect } from "#app/enums/status-effect";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Baneful Bunker", () => {
   let phaserGame: Phaser.Game;
@@ -50,7 +50,7 @@ describe("Moves - Baneful Bunker", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
       expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
       expect(leadPokemon.status?.effect  === StatusEffect.POISON).toBeTruthy();
-    }, TIMEOUT
+    }
   );
   test(
     "should protect the user and poison attackers that make contact, regardless of accuracy checks",
@@ -68,7 +68,7 @@ describe("Moves - Baneful Bunker", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
       expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
       expect(leadPokemon.status?.effect  === StatusEffect.POISON).toBeTruthy();
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -88,6 +88,6 @@ describe("Moves - Baneful Bunker", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
       expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
       expect(leadPokemon.status?.effect  === StatusEffect.POISON).toBeFalsy();
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/beak_blast.test.ts
+++ b/src/test/moves/beak_blast.test.ts
@@ -10,7 +10,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Beak Blast", () => {
   let phaserGame: Phaser.Game;
@@ -54,7 +54,7 @@ describe("Moves - Beak Blast", () => {
 
       await game.phaseInterceptor.to(BerryPhase, false);
       expect(enemyPokemon.status?.effect).toBe(StatusEffect.BURN);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -74,7 +74,7 @@ describe("Moves - Beak Blast", () => {
 
       await game.phaseInterceptor.to(BerryPhase, false);
       expect(enemyPokemon.status?.effect).toBe(StatusEffect.BURN);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -94,7 +94,7 @@ describe("Moves - Beak Blast", () => {
 
       await game.phaseInterceptor.to(BerryPhase, false);
       expect(enemyPokemon.status?.effect).not.toBe(StatusEffect.BURN);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -110,7 +110,7 @@ describe("Moves - Beak Blast", () => {
 
       await game.phaseInterceptor.to(BerryPhase, false);
       expect(leadPokemon.turnData.hitCount).toBe(2);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -131,6 +131,6 @@ describe("Moves - Beak Blast", () => {
       await game.phaseInterceptor.to(TurnEndPhase);
       expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
       expect(leadPokemon.getTag(BattlerTagType.BEAK_BLAST_CHARGING)).toBeUndefined();
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/beat_up.test.ts
+++ b/src/test/moves/beat_up.test.ts
@@ -7,8 +7,6 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-// 20 sec timeout
-
 describe("Moves - Beat Up", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;

--- a/src/test/moves/beat_up.test.ts
+++ b/src/test/moves/beat_up.test.ts
@@ -7,7 +7,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-const TIMEOUT = 20 * 1000; // 20 sec timeout
+// 20 sec timeout
 
 describe("Moves - Beat Up", () => {
   let phaserGame: Phaser.Game;
@@ -57,7 +57,7 @@ describe("Moves - Beat Up", () => {
         await game.phaseInterceptor.to(MoveEffectPhase);
         expect(enemyPokemon.hp).toBeLessThan(enemyStartingHp);
       }
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -74,7 +74,7 @@ describe("Moves - Beat Up", () => {
       await game.phaseInterceptor.to(MoveEffectPhase);
 
       expect(playerPokemon.turnData.hitCount).toBe(5);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -99,6 +99,6 @@ describe("Moves - Beat Up", () => {
         await game.phaseInterceptor.to(MoveEffectPhase);
         expect(enemyPokemon.hp).toBeLessThan(enemyStartingHp);
       }
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/belly_drum.test.ts
+++ b/src/test/moves/belly_drum.test.ts
@@ -8,7 +8,7 @@ import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
 import { Abilities } from "#app/enums/abilities";
 
-const TIMEOUT = 20 * 1000;
+
 // RATIO : HP Cost of Move
 const RATIO = 2;
 // PREDAMAGE : Amount of extra HP lost
@@ -54,7 +54,7 @@ describe("Moves - BELLY DRUM", () => {
 
       expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp() - hpLost);
       expect(leadPokemon.getStatStage(Stat.ATK)).toBe(6);
-    }, TIMEOUT
+    }
   );
 
   test("will still take effect if an uninvolved stat stage is at max",
@@ -74,7 +74,7 @@ describe("Moves - BELLY DRUM", () => {
       expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp() - hpLost);
       expect(leadPokemon.getStatStage(Stat.ATK)).toBe(6);
       expect(leadPokemon.getStatStage(Stat.SPATK)).toBe(6);
-    }, TIMEOUT
+    }
   );
 
   test("fails if the pokemon's ATK stat stage is at its maximum",
@@ -90,7 +90,7 @@ describe("Moves - BELLY DRUM", () => {
 
       expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
       expect(leadPokemon.getStatStage(Stat.ATK)).toBe(6);
-    }, TIMEOUT
+    }
   );
 
   test("fails if the user's health is less than 1/2",
@@ -106,6 +106,6 @@ describe("Moves - BELLY DRUM", () => {
 
       expect(leadPokemon.hp).toBe(hpLost - PREDAMAGE);
       expect(leadPokemon.getStatStage(Stat.ATK)).toBe(0);
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/burning_jealousy.test.ts
+++ b/src/test/moves/burning_jealousy.test.ts
@@ -8,7 +8,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Burning Jealousy", () => {
   let phaserGame: Phaser.Game;
@@ -50,7 +50,7 @@ describe("Moves - Burning Jealousy", () => {
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(enemy.status?.effect).toBe(StatusEffect.BURN);
-  }, TIMEOUT);
+  });
 
   it("should still burn the opponent if their stat stages were both raised and lowered in the same turn", async () => {
     game.override
@@ -66,7 +66,7 @@ describe("Moves - Burning Jealousy", () => {
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(enemy.status?.effect).toBe(StatusEffect.BURN);
-  }, TIMEOUT);
+  });
 
   it("should ignore stat stages raised by IMPOSTER", async () => {
     game.override
@@ -81,11 +81,11 @@ describe("Moves - Burning Jealousy", () => {
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(enemy.status?.effect).toBeUndefined();
-  }, TIMEOUT);
+  });
 
   it.skip("should ignore weakness policy", async () => { // TODO: Make this test if WP is implemented
     await game.classicMode.startBattle();
-  }, TIMEOUT);
+  });
 
   it("should be boosted by Sheer Force even if opponent didn't raise stat stages", async () => {
     game.override
@@ -98,5 +98,5 @@ describe("Moves - Burning Jealousy", () => {
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(allMoves[Moves.BURNING_JEALOUSY].calculateBattlePower).toHaveReturnedWith(allMoves[Moves.BURNING_JEALOUSY].power * 5461 / 4096);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/ceaseless_edge.test.ts
+++ b/src/test/moves/ceaseless_edge.test.ts
@@ -10,7 +10,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Ceaseless Edge", () => {
   let phaserGame: Phaser.Game;
@@ -61,7 +61,7 @@ describe("Moves - Ceaseless Edge", () => {
       expect(tagAfter instanceof ArenaTrapTag).toBeTruthy();
       expect(tagAfter.layers).toBe(1);
       expect(enemyPokemon.hp).toBeLessThan(enemyStartingHp);
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -86,7 +86,7 @@ describe("Moves - Ceaseless Edge", () => {
       expect(tagAfter instanceof ArenaTrapTag).toBeTruthy();
       expect(tagAfter.layers).toBe(2);
       expect(enemyPokemon.hp).toBeLessThan(enemyStartingHp);
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -114,6 +114,6 @@ describe("Moves - Ceaseless Edge", () => {
       game.move.select(Moves.SPLASH);
       await game.phaseInterceptor.to(TurnEndPhase, false);
       expect(game.scene.currentBattle.enemyParty[0].hp).toBeLessThan(hpBeforeSpikes);
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/clangorous_soul.test.ts
+++ b/src/test/moves/clangorous_soul.test.ts
@@ -6,7 +6,7 @@ import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
 import { Stat } from "#enums/stat";
 
-const TIMEOUT = 20 * 1000;
+
 /** HP Cost of Move */
 const RATIO = 3;
 /** Amount of extra HP lost */
@@ -54,7 +54,7 @@ describe("Moves - Clangorous Soul", () => {
       expect(leadPokemon.getStatStage(Stat.SPATK)).toBe(1);
       expect(leadPokemon.getStatStage(Stat.SPDEF)).toBe(1);
       expect(leadPokemon.getStatStage(Stat.SPD)).toBe(1);
-    }, TIMEOUT
+    }
   );
 
   it("will still take effect if one or more of the involved stat stages are not at max",
@@ -79,7 +79,7 @@ describe("Moves - Clangorous Soul", () => {
       expect(leadPokemon.getStatStage(Stat.SPATK)).toBe(6);
       expect(leadPokemon.getStatStage(Stat.SPDEF)).toBe(5);
       expect(leadPokemon.getStatStage(Stat.SPD)).toBe(1);
-    }, TIMEOUT
+    }
   );
 
   it("fails if all stat stages involved are at max",
@@ -103,7 +103,7 @@ describe("Moves - Clangorous Soul", () => {
       expect(leadPokemon.getStatStage(Stat.SPATK)).toBe(6);
       expect(leadPokemon.getStatStage(Stat.SPDEF)).toBe(6);
       expect(leadPokemon.getStatStage(Stat.SPD)).toBe(6);
-    }, TIMEOUT
+    }
   );
 
   it("fails if the user's health is less than 1/3",
@@ -123,6 +123,6 @@ describe("Moves - Clangorous Soul", () => {
       expect(leadPokemon.getStatStage(Stat.SPATK)).toBe(0);
       expect(leadPokemon.getStatStage(Stat.SPDEF)).toBe(0);
       expect(leadPokemon.getStatStage(Stat.SPD)).toBe(0);
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/crafty_shield.test.ts
+++ b/src/test/moves/crafty_shield.test.ts
@@ -9,7 +9,7 @@ import { BattlerTagType } from "#app/enums/battler-tag-type";
 import { BerryPhase } from "#app/phases/berry-phase";
 import { CommandPhase } from "#app/phases/command-phase";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Crafty Shield", () => {
   let phaserGame: Phaser.Game;
@@ -56,7 +56,7 @@ describe("Moves - Crafty Shield", () => {
       await game.phaseInterceptor.to(BerryPhase, false);
 
       leadPokemon.forEach(p => expect(p.getStatStage(Stat.ATK)).toBe(0));
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -77,7 +77,7 @@ describe("Moves - Crafty Shield", () => {
       await game.phaseInterceptor.to(BerryPhase, false);
 
       expect(leadPokemon.some(p => p.hp < p.getMaxHp())).toBeTruthy();
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -99,7 +99,7 @@ describe("Moves - Crafty Shield", () => {
       await game.phaseInterceptor.to(BerryPhase, false);
 
       leadPokemon.forEach(p => expect(p.getTag(BattlerTagType.CURSED)).toBeUndefined());
-    }, TIMEOUT
+    }
   );
 
   test(

--- a/src/test/moves/dragon_cheer.test.ts
+++ b/src/test/moves/dragon_cheer.test.ts
@@ -10,8 +10,6 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 describe("Moves - Dragon Cheer", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const TIMEOUT = 20 * 1000;
-
   beforeAll(() => {
     phaserGame = new Phaser.Game({
       type: Phaser.HEADLESS,
@@ -47,7 +45,7 @@ describe("Moves - Dragon Cheer", () => {
     // After Tackle
     await game.phaseInterceptor.to("TurnEndPhase");
     expect(enemy.getCritStage).toHaveReturnedWith(1); // getCritStage is called on defender
-  }, TIMEOUT);
+  });
 
   it("increases the user's Dragon-type allies' critical hit ratio by two stages", async () => {
     await game.classicMode.startBattle([Species.MAGIKARP, Species.DRAGONAIR]);
@@ -64,7 +62,7 @@ describe("Moves - Dragon Cheer", () => {
     // After Tackle
     await game.phaseInterceptor.to("TurnEndPhase");
     expect(enemy.getCritStage).toHaveReturnedWith(2); // getCritStage is called on defender
-  }, TIMEOUT);
+  });
 
   it("applies the effect based on the allies' type upon use of the move, and do not change if the allies' type changes later in battle", async () => {
     await game.classicMode.startBattle([Species.DRAGONAIR, Species.MAGIKARP]);
@@ -96,5 +94,5 @@ describe("Moves - Dragon Cheer", () => {
 
     await game.phaseInterceptor.to("MoveEndPhase");
     expect(enemy.getCritStage).toHaveReturnedWith(1); // getCritStage is called on defender
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/dragon_tail.test.ts
+++ b/src/test/moves/dragon_tail.test.ts
@@ -10,7 +10,7 @@ import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import GameManager from "../utils/gameManager";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Dragon Tail", () => {
   let phaserGame: Phaser.Game;
@@ -55,7 +55,7 @@ describe("Moves - Dragon Tail", () => {
 
       // simply want to test that the game makes it this far without crashing
       await game.phaseInterceptor.to(BattleEndPhase);
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -75,7 +75,7 @@ describe("Moves - Dragon Tail", () => {
       const hasFled = enemyPokemon.wildFlee;
       expect(!isVisible && hasFled).toBe(true);
       expect(leadPokemon.hp).toBeLessThan(leadPokemon.getMaxHp());
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -109,7 +109,7 @@ describe("Moves - Dragon Tail", () => {
 
       await game.phaseInterceptor.to(BerryPhase);
       expect(enemySecPokemon.hp).toBeLessThan(enemySecPokemon.getMaxHp());
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -141,6 +141,6 @@ describe("Moves - Dragon Tail", () => {
       expect(secPokemon.hp).toBeLessThan(secPokemon.getMaxHp());
       expect(enemyLeadPokemon.hp).toBeLessThan(enemyLeadPokemon.getMaxHp());
       expect(enemySecPokemon.hp).toBeLessThan(enemySecPokemon.getMaxHp());
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/fillet_away.test.ts
+++ b/src/test/moves/fillet_away.test.ts
@@ -7,7 +7,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 /** HP Cost of Move */
 const RATIO = 2;
 /** Amount of extra HP lost */
@@ -53,7 +53,7 @@ describe("Moves - FILLET AWAY", () => {
       expect(leadPokemon.getStatStage(Stat.ATK)).toBe(2);
       expect(leadPokemon.getStatStage(Stat.SPATK)).toBe(2);
       expect(leadPokemon.getStatStage(Stat.SPD)).toBe(2);
-    }, TIMEOUT
+    }
   );
 
   test("still takes effect if one or more of the involved stat stages are not at max",
@@ -74,7 +74,7 @@ describe("Moves - FILLET AWAY", () => {
       expect(leadPokemon.getStatStage(Stat.ATK)).toBe(6);
       expect(leadPokemon.getStatStage(Stat.SPATK)).toBe(5);
       expect(leadPokemon.getStatStage(Stat.SPD)).toBe(2);
-    }, TIMEOUT
+    }
   );
 
   test("fails if all stat stages involved are at max",
@@ -94,7 +94,7 @@ describe("Moves - FILLET AWAY", () => {
       expect(leadPokemon.getStatStage(Stat.ATK)).toBe(6);
       expect(leadPokemon.getStatStage(Stat.SPATK)).toBe(6);
       expect(leadPokemon.getStatStage(Stat.SPD)).toBe(6);
-    }, TIMEOUT
+    }
   );
 
   test("fails if the user's health is less than 1/2",
@@ -112,6 +112,6 @@ describe("Moves - FILLET AWAY", () => {
       expect(leadPokemon.getStatStage(Stat.ATK)).toBe(0);
       expect(leadPokemon.getStatStage(Stat.SPATK)).toBe(0);
       expect(leadPokemon.getStatStage(Stat.SPD)).toBe(0);
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/focus_punch.test.ts
+++ b/src/test/moves/focus_punch.test.ts
@@ -10,7 +10,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Focus Punch", () => {
   let phaserGame: Phaser.Game;
@@ -61,7 +61,7 @@ describe("Moves - Focus Punch", () => {
       expect(enemyPokemon.hp).toBeLessThan(enemyStartingHp);
       expect(leadPokemon.getMoveHistory().length).toBe(1);
       expect(leadPokemon.turnData.damageDealt).toBe(enemyStartingHp - enemyPokemon.hp);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -88,7 +88,7 @@ describe("Moves - Focus Punch", () => {
       expect(enemyPokemon.hp).toBe(enemyStartingHp);
       expect(leadPokemon.getMoveHistory().length).toBe(1);
       expect(leadPokemon.turnData.damageDealt).toBe(0);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -111,7 +111,7 @@ describe("Moves - Focus Punch", () => {
 
       expect(leadPokemon.getMoveHistory().length).toBe(1);
       expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -129,6 +129,6 @@ describe("Moves - Focus Punch", () => {
 
       expect(game.scene.getCurrentPhase() instanceof SwitchSummonPhase).toBeTruthy();
       expect(game.scene.phaseQueue.find(phase => phase instanceof MoveHeaderPhase)).toBeDefined();
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/follow_me.test.ts
+++ b/src/test/moves/follow_me.test.ts
@@ -8,7 +8,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Follow Me", () => {
   let phaserGame: Phaser.Game;
@@ -54,7 +54,7 @@ describe("Moves - Follow Me", () => {
 
       expect(playerPokemon[0].hp).toBeLessThan(playerPokemon[0].getMaxHp());
       expect(playerPokemon[1].hp).toBe(playerPokemon[1].getMaxHp());
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -77,7 +77,7 @@ describe("Moves - Follow Me", () => {
 
       expect(playerPokemon[1].hp).toBeLessThan(playerPokemon[1].getMaxHp());
       expect(playerPokemon[0].hp).toBe(playerPokemon[0].getMaxHp());
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -102,7 +102,7 @@ describe("Moves - Follow Me", () => {
       // If redirection was bypassed, both enemies should be damaged
       expect(enemyPokemon[0].hp).toBeLessThan(enemyPokemon[0].getMaxHp());
       expect(enemyPokemon[1].hp).toBeLessThan(enemyPokemon[1].getMaxHp());
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -125,6 +125,6 @@ describe("Moves - Follow Me", () => {
       // If redirection was bypassed, both enemies should be damaged
       expect(enemyPokemon[0].hp).toBeLessThan(enemyPokemon[0].getMaxHp());
       expect(enemyPokemon[1].hp).toBeLessThan(enemyPokemon[1].getMaxHp());
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/freeze_dry.test.ts
+++ b/src/test/moves/freeze_dry.test.ts
@@ -9,8 +9,6 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 describe("Moves - Freeze-Dry", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const TIMEOUT = 20 * 1000;
-
   beforeAll(() => {
     phaserGame = new Phaser.Game({
       type: Phaser.HEADLESS,
@@ -44,7 +42,7 @@ describe("Moves - Freeze-Dry", () => {
     await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(enemy.getMoveEffectiveness).toHaveReturnedWith(2);
-  }, TIMEOUT);
+  });
 
   it("should deal 4x damage to water/flying types", async () => {
     game.override.enemySpecies(Species.WINGULL);
@@ -58,7 +56,7 @@ describe("Moves - Freeze-Dry", () => {
     await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(enemy.getMoveEffectiveness).toHaveReturnedWith(4);
-  }, TIMEOUT);
+  });
 
   it("should deal 1x damage to water/fire types", async () => {
     game.override.enemySpecies(Species.VOLCANION);
@@ -72,7 +70,7 @@ describe("Moves - Freeze-Dry", () => {
     await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(enemy.getMoveEffectiveness).toHaveReturnedWith(1);
-  }, TIMEOUT);
+  });
 
   // enable if this is ever fixed (lol)
   it.todo("should deal 2x damage to water types under Normalize", async () => {
@@ -87,7 +85,7 @@ describe("Moves - Freeze-Dry", () => {
     await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(enemy.getMoveEffectiveness).toHaveReturnedWith(2);
-  }, TIMEOUT);
+  });
 
   // enable once Electrify is implemented (and the interaction is fixed, as above)
   it.todo("should deal 2x damage to water types under Electrify", async () => {
@@ -102,5 +100,5 @@ describe("Moves - Freeze-Dry", () => {
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(enemy.getMoveEffectiveness).toHaveReturnedWith(2);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/gastro_acid.test.ts
+++ b/src/test/moves/gastro_acid.test.ts
@@ -6,7 +6,7 @@ import { MoveResult } from "#app/field/pokemon";
 import GameManager from "#test/utils/gameManager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Gastro Acid", () => {
   let phaserGame: Phaser.Game;
@@ -60,7 +60,7 @@ describe("Moves - Gastro Acid", () => {
 
     expect(enemyField[0].hp).toBeLessThan(enemyField[0].getMaxHp());
     expect(enemyField[1].isFullHp()).toBe(true);
-  }, TIMEOUT);
+  });
 
   it("fails if used on an enemy with an already-suppressed ability", async () => {
     game.override.battleType(null);
@@ -78,5 +78,5 @@ describe("Moves - Gastro Acid", () => {
     await game.phaseInterceptor.to("TurnInitPhase");
 
     expect(game.scene.getPlayerPokemon()!.getLastXMoves()[0].result).toBe(MoveResult.FAIL);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/glaive_rush.test.ts
+++ b/src/test/moves/glaive_rush.test.ts
@@ -6,7 +6,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Glaive Rush", () => {
   let phaserGame: Phaser.Game;
@@ -49,7 +49,7 @@ describe("Moves - Glaive Rush", () => {
     await game.phaseInterceptor.to("DamagePhase");
     expect(enemy.hp).toBeLessThanOrEqual(1001 - (damageDealt * 3));
 
-  }, TIMEOUT);
+  });
 
   it("always gets hit by attacks", async () => {
     await game.classicMode.startBattle();
@@ -62,7 +62,7 @@ describe("Moves - Glaive Rush", () => {
     await game.phaseInterceptor.to("TurnEndPhase");
     expect(enemy.hp).toBeLessThan(1000);
 
-  }, TIMEOUT);
+  });
 
   it("interacts properly with multi-lens", async () => {
     game.override
@@ -85,7 +85,7 @@ describe("Moves - Glaive Rush", () => {
     await game.phaseInterceptor.to("TurnEndPhase");
     expect(player.hp).toBe(1000);
 
-  }, TIMEOUT);
+  });
 
   it("secondary effects only last until next move", async () => {
     game.override.enemyMoveset([Moves.SHADOW_SNEAK]);
@@ -111,7 +111,7 @@ describe("Moves - Glaive Rush", () => {
     await game.phaseInterceptor.to("TurnEndPhase");
     expect(player.hp).toBe(damagedHp);
 
-  }, TIMEOUT);
+  });
 
   it("secondary effects are removed upon switching", async () => {
     game.override
@@ -135,7 +135,7 @@ describe("Moves - Glaive Rush", () => {
     await game.phaseInterceptor.to("TurnEndPhase");
     expect(player.hp).toBe(player.getMaxHp());
 
-  }, TIMEOUT);
+  });
 
   it("secondary effects don't activate if move fails", async () => {
     game.override.moveset([Moves.SHADOW_SNEAK, Moves.PROTECT, Moves.SPLASH, Moves.GLAIVE_RUSH]);
@@ -161,5 +161,5 @@ describe("Moves - Glaive Rush", () => {
     const damagedHP2 = 1000 - enemy.hp;
 
     expect(damagedHP2).toBeGreaterThanOrEqual((damagedHP1 * 2) - 1);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/guard_swap.test.ts
+++ b/src/test/moves/guard_swap.test.ts
@@ -11,8 +11,6 @@ import { MoveEndPhase } from "#app/phases/move-end-phase";
 describe("Moves - Guard Swap", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const TIMEOUT = 20 * 1000;
-
   beforeAll(() => {
     phaserGame = new Phaser.Game({
       type: Phaser.HEADLESS,
@@ -65,5 +63,5 @@ describe("Moves - Guard Swap", () => {
         expect(enemy.getStatStage(s)).toBe(1);
       }
     }
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/heart_swap.test.ts
+++ b/src/test/moves/heart_swap.test.ts
@@ -11,8 +11,6 @@ import { MoveEndPhase } from "#app/phases/move-end-phase";
 describe("Moves - Heart Swap", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const TIMEOUT = 20 * 1000;
-
   beforeAll(() => {
     phaserGame = new Phaser.Game({
       type: Phaser.HEADLESS,
@@ -60,5 +58,5 @@ describe("Moves - Heart Swap", () => {
       expect(enemy.getStatStage(s)).toBe(0);
       expect(player.getStatStage(s)).toBe(1);
     }
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/hyper_beam.test.ts
+++ b/src/test/moves/hyper_beam.test.ts
@@ -9,8 +9,6 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-// 20 sec timeout for all tests
-
 describe("Moves - Hyper Beam", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;

--- a/src/test/moves/hyper_beam.test.ts
+++ b/src/test/moves/hyper_beam.test.ts
@@ -9,7 +9,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const TIMEOUT = 20 * 1000; // 20 sec timeout for all tests
+// 20 sec timeout for all tests
 
 describe("Moves - Hyper Beam", () => {
   let phaserGame: Phaser.Game;
@@ -67,6 +67,6 @@ describe("Moves - Hyper Beam", () => {
       await game.phaseInterceptor.to(BerryPhase, false);
 
       expect(enemyPokemon.hp).toBeLessThan(enemyPostAttackHp);
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/jaw_lock.test.ts
+++ b/src/test/moves/jaw_lock.test.ts
@@ -11,7 +11,7 @@ import { Species } from "#enums/species";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Jaw Lock", () => {
   let phaserGame: Phaser.Game;
@@ -61,7 +61,7 @@ describe("Moves - Jaw Lock", () => {
 
       expect(leadPokemon.getTag(BattlerTagType.TRAPPED)).toBeDefined();
       expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeDefined();
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -90,7 +90,7 @@ describe("Moves - Jaw Lock", () => {
 
       expect(leadPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
       expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -114,7 +114,7 @@ describe("Moves - Jaw Lock", () => {
       await game.doKillOpponents();
 
       expect(leadPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -146,7 +146,7 @@ describe("Moves - Jaw Lock", () => {
       expect(enemyPokemon[1].getTag(BattlerTagType.TRAPPED)).toBeUndefined();
       expect(playerPokemon[0].getTag(BattlerTagType.TRAPPED)).toBeDefined();
       expect(playerPokemon[0].getTag(BattlerTagType.TRAPPED)?.sourceId).toBe(enemyPokemon[0].id);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -165,6 +165,6 @@ describe("Moves - Jaw Lock", () => {
 
       expect(playerPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
       expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/lash_out.test.ts
+++ b/src/test/moves/lash_out.test.ts
@@ -7,7 +7,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Lash Out", () => {
   let phaserGame: Phaser.Game;
@@ -48,5 +48,5 @@ describe("Moves - Lash Out", () => {
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(allMoves[Moves.LASH_OUT].calculateBattlePower).toHaveReturnedWith(150);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/lucky_chant.test.ts
+++ b/src/test/moves/lucky_chant.test.ts
@@ -7,7 +7,7 @@ import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import GameManager from "../utils/gameManager";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Lucky Chant", () => {
   let phaserGame: Phaser.Game;
@@ -55,7 +55,7 @@ describe("Moves - Lucky Chant", () => {
 
       const secondTurnDamage = playerPokemon.getMaxHp() - playerPokemon.hp - firstTurnDamage;
       expect(secondTurnDamage).toBeLessThan(firstTurnDamage);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -81,7 +81,7 @@ describe("Moves - Lucky Chant", () => {
 
       const secondTurnDamage = playerPokemon[0].getMaxHp() - playerPokemon[0].hp - firstTurnDamage;
       expect(secondTurnDamage).toBeLessThan(firstTurnDamage);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -108,6 +108,6 @@ describe("Moves - Lucky Chant", () => {
 
       const secondTurnDamage = playerPokemon.getMaxHp() - playerPokemon.hp - firstTurnDamage;
       expect(secondTurnDamage).toBeLessThan(firstTurnDamage);
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/make_it_rain.test.ts
+++ b/src/test/moves/make_it_rain.test.ts
@@ -8,7 +8,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { MoveEndPhase } from "#app/phases/move-end-phase";
 import { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Make It Rain", () => {
   let phaserGame: Phaser.Game;
@@ -46,7 +46,7 @@ describe("Moves - Make It Rain", () => {
     await game.phaseInterceptor.to(MoveEndPhase);
 
     expect(playerPokemon.getStatStage(Stat.SPATK)).toBe(-1);
-  }, TIMEOUT);
+  });
 
   it("should apply effects even if the target faints", async () => {
     game.override.enemyLevel(1); // ensures the enemy will faint
@@ -63,7 +63,7 @@ describe("Moves - Make It Rain", () => {
 
     expect(enemyPokemon.isFainted()).toBe(true);
     expect(playerPokemon.getStatStage(Stat.SPATK)).toBe(-1);
-  }, TIMEOUT);
+  });
 
   it("should reduce Sp. Atk. once after KOing two enemies", async () => {
     game.override.enemyLevel(1); // ensures the enemy will faint
@@ -80,7 +80,7 @@ describe("Moves - Make It Rain", () => {
 
     enemyPokemon.forEach(p => expect(p.isFainted()).toBe(true));
     expect(playerPokemon.getStatStage(Stat.SPATK)).toBe(-1);
-  }, TIMEOUT);
+  });
 
   it("should lower SPATK stat stage by 1 if it only hits the second target", async () => {
     await game.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
@@ -96,5 +96,5 @@ describe("Moves - Make It Rain", () => {
     await game.phaseInterceptor.to(MoveEndPhase);
 
     expect(playerPokemon.getStatStage(Stat.SPATK)).toBe(-1);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/mat_block.test.ts
+++ b/src/test/moves/mat_block.test.ts
@@ -9,7 +9,7 @@ import { BerryPhase } from "#app/phases/berry-phase";
 import { CommandPhase } from "#app/phases/command-phase";
 import { TurnEndPhase } from "#app/phases/turn-end-phase";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Mat Block", () => {
   let phaserGame: Phaser.Game;
@@ -56,7 +56,7 @@ describe("Moves - Mat Block", () => {
       await game.phaseInterceptor.to(BerryPhase, false);
 
       leadPokemon.forEach(p => expect(p.hp).toBe(p.getMaxHp()));
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -77,7 +77,7 @@ describe("Moves - Mat Block", () => {
       await game.phaseInterceptor.to(BerryPhase, false);
 
       leadPokemon.forEach(p => expect(p.getStatStage(Stat.ATK)).toBe(-2));
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -103,6 +103,6 @@ describe("Moves - Mat Block", () => {
       await game.phaseInterceptor.to(BerryPhase, false);
 
       expect(leadPokemon.some((p, i) => p.hp < leadStartingHp[i])).toBeTruthy();
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/multi_target.test.ts
+++ b/src/test/moves/multi_target.test.ts
@@ -7,7 +7,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Multi-target damage reduction", () => {
   let phaserGame: Phaser.Game;
@@ -75,7 +75,7 @@ describe("Multi-target damage reduction", () => {
     // Moves that target all enemies get reduced if there's more than one enemy
     expect(gleam1).toBeLessThanOrEqual(Utils.toDmgValue(gleam2 * 0.75) + 1);
     expect(gleam1).toBeGreaterThanOrEqual(Utils.toDmgValue(gleam2 * 0.75) - 1);
-  }, TIMEOUT);
+  });
 
   it("should reduce earthquake when more than one pokemon other than user is not fainted", async () => {
     await game.startBattle([Species.MAGIKARP, Species.FEEBAS]);
@@ -126,5 +126,5 @@ describe("Multi-target damage reduction", () => {
     // Turn 3: 1 target, should be no damage reduction
     expect(damageEnemy1Turn1).toBeLessThanOrEqual(Utils.toDmgValue(damageEnemy1Turn3 * 0.75) + 1);
     expect(damageEnemy1Turn1).toBeGreaterThanOrEqual(Utils.toDmgValue(damageEnemy1Turn3 * 0.75) - 1);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/obstruct.test.ts
+++ b/src/test/moves/obstruct.test.ts
@@ -8,8 +8,6 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 describe("Moves - Obstruct", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const TIMEOUT = 20 * 1000;
-
   beforeAll(() => {
     phaserGame = new Phaser.Game({
       type: Phaser.HEADLESS,
@@ -41,7 +39,7 @@ describe("Moves - Obstruct", () => {
 
     expect(player.isFullHp()).toBe(true);
     expect(enemy.getStatStage(Stat.DEF)).toBe(-2);
-  }, TIMEOUT);
+  });
 
   it("bypasses accuracy checks when applying protection and defense reduction", async () => {
     game.override.enemyMoveset(Array(4).fill(Moves.ICE_PUNCH));
@@ -57,7 +55,7 @@ describe("Moves - Obstruct", () => {
     await game.phaseInterceptor.to("TurnEndPhase");
     expect(player.isFullHp()).toBe(true);
     expect(enemy.getStatStage(Stat.DEF)).toBe(-2);
-  }, TIMEOUT
+  }
   );
 
   it("protects from non-contact damaging moves and doesn't lower the opponent's defense by 2 stages", async () => {
@@ -72,7 +70,7 @@ describe("Moves - Obstruct", () => {
 
     expect(player.isFullHp()).toBe(true);
     expect(enemy.getStatStage(Stat.DEF)).toBe(0);
-  }, TIMEOUT);
+  });
 
   it("doesn't protect from status moves", async () => {
     game.override.enemyMoveset(Array(4).fill(Moves.GROWL));
@@ -84,5 +82,5 @@ describe("Moves - Obstruct", () => {
     const player = game.scene.getPlayerPokemon()!;
 
     expect(player.getStatStage(Stat.ATK)).toBe(-1);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/parting_shot.test.ts
+++ b/src/test/moves/parting_shot.test.ts
@@ -10,7 +10,7 @@ import { FaintPhase } from "#app/phases/faint-phase";
 import { MessagePhase } from "#app/phases/message-phase";
 import { TurnInitPhase } from "#app/phases/turn-init-phase";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Parting Shot", () => {
   let phaserGame: Phaser.Game;
@@ -53,7 +53,7 @@ describe("Moves - Parting Shot", () => {
       expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(0);
       expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(0);
       expect(game.scene.getPlayerField()[0].species.speciesId).toBe(Species.MURKROW);
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -73,7 +73,7 @@ describe("Moves - Parting Shot", () => {
       expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(0);
       expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(0);
       expect(game.scene.getPlayerField()[0].species.speciesId).toBe(Species.MURKROW);
-    }, TIMEOUT
+    }
   );
 
   it.skip( // TODO: fix this bug to pass the test!
@@ -115,7 +115,7 @@ describe("Moves - Parting Shot", () => {
       expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(-6);
       expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(-6);
       expect(game.scene.getPlayerField()[0].species.speciesId).toBe(Species.MURKROW);
-    }, TIMEOUT
+    }
   );
 
   it.skip( // TODO: fix this bug to pass the test!
@@ -136,7 +136,7 @@ describe("Moves - Parting Shot", () => {
       expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(0);
       expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(0);
       expect(game.scene.getPlayerField()[0].species.speciesId).toBe(Species.MURKROW);
-    }, TIMEOUT
+    }
   );
 
   it.skip( // TODO: fix this bug to pass the test!
@@ -156,7 +156,7 @@ describe("Moves - Parting Shot", () => {
       expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(0);
       expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(0);
       expect(game.scene.getPlayerField()[0].species.speciesId).toBe(Species.MURKROW);
-    }, TIMEOUT
+    }
   );
 
   it.skip( // TODO: fix this bug to pass the test!
@@ -173,7 +173,7 @@ describe("Moves - Parting Shot", () => {
       expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(-1);
       expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(-1);
       expect(game.scene.getPlayerField()[0].species.speciesId).toBe(Species.MURKROW);
-    }, TIMEOUT
+    }
   );
 
   it.skip( // TODO: fix this bug to pass the test!
@@ -196,6 +196,6 @@ describe("Moves - Parting Shot", () => {
       expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(0);
       expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(0);
       expect(game.scene.getPlayerField()[0].species.speciesId).toBe(Species.MEOWTH);
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/power_shift.test.ts
+++ b/src/test/moves/power_shift.test.ts
@@ -9,8 +9,6 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 describe("Moves - Power Shift", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const TIMEOUT = 20 * 1000;
-
   beforeAll(() => {
     phaserGame = new Phaser.Game({
       type: Phaser.HEADLESS,
@@ -59,5 +57,5 @@ describe("Moves - Power Shift", () => {
     // Raw stats are swapped
     expect(playerPokemon.getStat(Stat.ATK, false)).toBe(20);
     expect(playerPokemon.getStat(Stat.DEF, false)).toBe(10);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/power_swap.test.ts
+++ b/src/test/moves/power_swap.test.ts
@@ -11,8 +11,6 @@ import { MoveEndPhase } from "#app/phases/move-end-phase";
 describe("Moves - Power Swap", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const TIMEOUT = 20 * 1000;
-
   beforeAll(() => {
     phaserGame = new Phaser.Game({
       type: Phaser.HEADLESS,
@@ -65,5 +63,5 @@ describe("Moves - Power Swap", () => {
         expect(enemy.getStatStage(s)).toBe(1);
       }
     }
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/protect.test.ts
+++ b/src/test/moves/protect.test.ts
@@ -10,7 +10,7 @@ import { ArenaTagSide, ArenaTrapTag } from "#app/data/arena-tag";
 import { BattlerIndex } from "#app/battle";
 import { MoveResult } from "#app/field/pokemon";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Protect", () => {
   let phaserGame: Phaser.Game;
@@ -53,7 +53,7 @@ describe("Moves - Protect", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -72,7 +72,7 @@ describe("Moves - Protect", () => {
 
       expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
       expect(game.scene.arena.getTagOnSide(ArenaTrapTag, ArenaTagSide.ENEMY)).toBeUndefined();
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -89,7 +89,7 @@ describe("Moves - Protect", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(leadPokemon.getStatStage(Stat.ATK)).toBe(0);
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -108,7 +108,7 @@ describe("Moves - Protect", () => {
 
       expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
       expect(enemyPokemon.turnData.hitCount).toBe(1);
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -129,6 +129,6 @@ describe("Moves - Protect", () => {
 
       expect(enemyPokemon.getLastXMoves()[0].result).toBe(MoveResult.SUCCESS);
       expect(leadPokemon.getLastXMoves()[0].result).toBe(MoveResult.FAIL);
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/purify.test.ts
+++ b/src/test/moves/purify.test.ts
@@ -8,7 +8,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Purify", () => {
   let phaserGame: Phaser.Game;
@@ -55,7 +55,6 @@ describe("Moves - Purify", () => {
       expect(enemyPokemon.status).toBeNull();
       expect(playerPokemon.isFullHp()).toBe(true);
     },
-    TIMEOUT
   );
 
   test(
@@ -74,7 +73,6 @@ describe("Moves - Purify", () => {
 
       expect(playerPokemon.hp).toBe(playerInitialHp);
     },
-    TIMEOUT
   );
 
 });

--- a/src/test/moves/quick_guard.test.ts
+++ b/src/test/moves/quick_guard.test.ts
@@ -8,7 +8,7 @@ import { Stat } from "#enums/stat";
 import { BattlerIndex } from "#app/battle";
 import { MoveResult } from "#app/field/pokemon";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Quick Guard", () => {
   let phaserGame: Phaser.Game;
@@ -52,7 +52,7 @@ describe("Moves - Quick Guard", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       playerPokemon.forEach(p => expect(p.hp).toBe(p.getMaxHp()));
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -71,7 +71,7 @@ describe("Moves - Quick Guard", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       playerPokemon.forEach(p => expect(p.getStatStage(Stat.ATK)).toBe(0));
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -113,6 +113,6 @@ describe("Moves - Quick Guard", () => {
 
       expect(enemyPokemon.getLastXMoves()[0].result).toBe(MoveResult.SUCCESS);
       expect(playerPokemon.getLastXMoves()[0].result).toBe(MoveResult.FAIL);
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/rage_powder.test.ts
+++ b/src/test/moves/rage_powder.test.ts
@@ -6,7 +6,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Rage Powder", () => {
   let phaserGame: Phaser.Game;
@@ -50,7 +50,7 @@ describe("Moves - Rage Powder", () => {
       // If redirection was bypassed, both enemies should be damaged
       expect(enemyPokemon[0].hp).toBeLessThan(enemyPokemon[0].getMaxHp());
       expect(enemyPokemon[1].hp).toBeLessThan(enemyPokemon[0].getMaxHp());
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -76,6 +76,6 @@ describe("Moves - Rage Powder", () => {
       // If redirection was bypassed, both enemies should be damaged
       expect(enemyPokemon[0].hp).toBeLessThan(enemyStartingHp[0]);
       expect(enemyPokemon[1].hp).toBeLessThan(enemyStartingHp[1]);
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/relic_song.test.ts
+++ b/src/test/moves/relic_song.test.ts
@@ -10,8 +10,6 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 describe("Moves - Relic Song", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const TIMEOUT = 20 * 1000;
-
   beforeAll(() => {
     phaserGame = new Phaser.Game({
       type: Phaser.HEADLESS,
@@ -47,7 +45,7 @@ describe("Moves - Relic Song", () => {
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(meloetta.formIndex).toBe(0);
-  }, TIMEOUT);
+  });
 
   it("doesn't swap Meloetta's form during a mono-type challenge", async () => {
     game.challengeMode.addChallenge(Challenges.SINGLE_TYPE, Type.PSYCHIC + 1, 0);
@@ -62,7 +60,7 @@ describe("Moves - Relic Song", () => {
     await game.toNextTurn();
 
     expect(meloetta.formIndex).toBe(0);
-  }, TIMEOUT);
+  });
 
   it("doesn't swap Meloetta's form during biome change (arena reset)", async () => {
     game.override
@@ -77,5 +75,5 @@ describe("Moves - Relic Song", () => {
     await game.toNextWave();
 
     expect(meloetta.formIndex).toBe(1);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/roost.test.ts
+++ b/src/test/moves/roost.test.ts
@@ -9,7 +9,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Roost", () => {
   let phaserGame: Phaser.Game;
@@ -72,7 +72,7 @@ describe("Moves - Roost", () => {
       expect(playerPokemonTypes[0] === Type.NORMAL).toBeTruthy();
       expect(playerPokemonTypes.length === 1).toBeTruthy();
       expect(playerPokemon.isGrounded()).toBeTruthy();
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -100,7 +100,7 @@ describe("Moves - Roost", () => {
       expect(playerPokemonTypes[0] === Type.FLYING).toBeTruthy();
       expect(playerPokemon.isGrounded()).toBeFalsy();
 
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -128,7 +128,7 @@ describe("Moves - Roost", () => {
       expect(playerPokemonTypes[1] === Type.FLYING).toBeTruthy();
       expect(playerPokemon.isGrounded()).toBeFalsy();
 
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -157,7 +157,7 @@ describe("Moves - Roost", () => {
       expect(playerPokemonTypes[1] === Type.FLYING).toBeTruthy();
       expect(playerPokemon.isGrounded()).toBeFalsy();
 
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -196,7 +196,7 @@ describe("Moves - Roost", () => {
       expect(playerPokemonTypes.length === 1).toBeTruthy();
       expect(playerPokemon.isGrounded()).toBeFalsy();
 
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -236,7 +236,7 @@ describe("Moves - Roost", () => {
       expect(playerPokemonTypes.length === 1).toBeTruthy();
       expect(playerPokemon.isGrounded()).toBeFalsy();
 
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -263,7 +263,7 @@ describe("Moves - Roost", () => {
       expect(playerPokemonTypes.length === 3).toBeTruthy();
       expect(playerPokemon.isGrounded()).toBeFalsy();
 
-    }, TIMEOUT
+    }
   );
 
 });

--- a/src/test/moves/safeguard.test.ts
+++ b/src/test/moves/safeguard.test.ts
@@ -8,7 +8,7 @@ import { Species } from "#enums/species";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Safeguard", () => {
   let phaserGame: Phaser.Game;
@@ -46,7 +46,7 @@ describe("Moves - Safeguard", () => {
     await game.toNextTurn();
 
     expect(enemy.status).toBeUndefined();
-  }, TIMEOUT);
+  });
 
   it("protects from status moves", async () => {
     await game.classicMode.startBattle();
@@ -57,7 +57,7 @@ describe("Moves - Safeguard", () => {
     await game.toNextTurn();
 
     expect(enemyPokemon.status).toBeUndefined();
-  }, TIMEOUT);
+  });
 
   it("protects from confusion", async () => {
     game.override.moveset([Moves.CONFUSE_RAY]);
@@ -69,7 +69,7 @@ describe("Moves - Safeguard", () => {
     await game.toNextTurn();
 
     expect(enemyPokemon.summonData.tags).toEqual([]);
-  }, TIMEOUT);
+  });
 
   it("protects ally from status", async () => {
     game.override.battleType("double");
@@ -87,7 +87,7 @@ describe("Moves - Safeguard", () => {
 
     expect(enemyPokemon[0].status).toBeUndefined();
     expect(enemyPokemon[1].status).toBeUndefined();
-  }, TIMEOUT);
+  });
 
   it("protects from Yawn", async () => {
     await game.classicMode.startBattle();
@@ -98,7 +98,7 @@ describe("Moves - Safeguard", () => {
     await game.toNextTurn();
 
     expect(enemyPokemon.summonData.tags).toEqual([]);
-  }, TIMEOUT);
+  });
 
   it("doesn't protect from already existing Yawn", async () => {
     await game.classicMode.startBattle();
@@ -112,7 +112,7 @@ describe("Moves - Safeguard", () => {
     await game.toNextTurn();
 
     expect(enemyPokemon.status?.effect).toEqual(StatusEffect.SLEEP);
-  }, TIMEOUT);
+  });
 
   it("doesn't protect from self-inflicted via Rest or Flame Orb", async () => {
     game.override.enemyHeldItems([{name: "FLAME_ORB"}]);
@@ -135,7 +135,7 @@ describe("Moves - Safeguard", () => {
     await game.toNextTurn();
 
     expect(enemyPokemon.status?.effect).toEqual(StatusEffect.SLEEP);
-  }, TIMEOUT);
+  });
 
   it("protects from ability-inflicted status", async () => {
     game.override.ability(Abilities.STATIC);
@@ -151,5 +151,5 @@ describe("Moves - Safeguard", () => {
     await game.toNextTurn();
 
     expect(enemyPokemon.status).toBeUndefined();
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/shell_side_arm.test.ts
+++ b/src/test/moves/shell_side_arm.test.ts
@@ -10,8 +10,6 @@ import { afterEach, beforeAll, beforeEach, describe, it, expect, vi } from "vite
 describe("Moves - Shell Side Arm", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const TIMEOUT = 20 * 1000;
-
   beforeAll(() => {
     phaserGame = new Phaser.Game({
       type: Phaser.HEADLESS,
@@ -47,7 +45,7 @@ describe("Moves - Shell Side Arm", () => {
     await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(shellSideArmAttr.apply).toHaveLastReturnedWith(true);
-  }, TIMEOUT);
+  });
 
   it("remains a special attack if forecasted to deal more damage as special", async () => {
     game.override.enemySpecies(Species.SLOWBRO);
@@ -63,7 +61,7 @@ describe("Moves - Shell Side Arm", () => {
     await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(shellSideArmAttr.apply).toHaveLastReturnedWith(false);
-  }, TIMEOUT);
+  });
 
   it("respects stat stage changes when forecasting base damage", async () => {
     game.override
@@ -83,5 +81,5 @@ describe("Moves - Shell Side Arm", () => {
     await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(shellSideArmAttr.apply).toHaveLastReturnedWith(false);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/shell_trap.test.ts
+++ b/src/test/moves/shell_trap.test.ts
@@ -10,7 +10,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Shell Trap", () => {
   let phaserGame: Phaser.Game;
@@ -60,7 +60,7 @@ describe("Moves - Shell Trap", () => {
 
       await game.phaseInterceptor.to(MoveEndPhase);
       enemyPokemon.forEach(p => expect(p.hp).toBeLessThan(p.getMaxHp()));
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -86,7 +86,7 @@ describe("Moves - Shell Trap", () => {
 
       await game.phaseInterceptor.to(BerryPhase, false);
       enemyPokemon.forEach(p => expect(p.hp).toBe(p.getMaxHp()));
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -112,7 +112,7 @@ describe("Moves - Shell Trap", () => {
 
       await game.phaseInterceptor.to(BerryPhase, false);
       enemyPokemon.forEach(p => expect(p.hp).toBe(p.getMaxHp()));
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -138,7 +138,7 @@ describe("Moves - Shell Trap", () => {
 
       await game.phaseInterceptor.to(BerryPhase, false);
       enemyPokemon.forEach((p, i) => expect(p.hp).toBe(enemyStartingHp[i]));
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -158,6 +158,6 @@ describe("Moves - Shell Trap", () => {
 
       expect(playerPokemon.getLastXMoves()[0].result).toBe(MoveResult.FAIL);
       expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/spotlight.test.ts
+++ b/src/test/moves/spotlight.test.ts
@@ -6,7 +6,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Spotlight", () => {
   let phaserGame: Phaser.Game;
@@ -50,7 +50,7 @@ describe("Moves - Spotlight", () => {
 
       expect(enemyPokemon[0].hp).toBeLessThan(enemyPokemon[0].getMaxHp());
       expect(enemyPokemon[1].hp).toBe(enemyPokemon[1].getMaxHp());
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -70,6 +70,6 @@ describe("Moves - Spotlight", () => {
 
       expect(enemyPokemon[0].hp).toBeLessThan(enemyPokemon[0].getMaxHp());
       expect(enemyPokemon[1].hp).toBe(enemyPokemon[1].getMaxHp());
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/moves/substitute.test.ts
+++ b/src/test/moves/substitute.test.ts
@@ -16,8 +16,6 @@ import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 
-// 20 sec timeout
-
 describe("Moves - Substitute", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;

--- a/src/test/moves/substitute.test.ts
+++ b/src/test/moves/substitute.test.ts
@@ -16,7 +16,7 @@ import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 
-const TIMEOUT = 20 * 1000; // 20 sec timeout
+// 20 sec timeout
 
 describe("Moves - Substitute", () => {
   let phaserGame: Phaser.Game;
@@ -57,7 +57,7 @@ describe("Moves - Substitute", () => {
       await game.phaseInterceptor.to("MoveEndPhase", false);
 
       expect(leadPokemon.hp).toBe(Math.ceil(leadPokemon.getMaxHp() * 3/4));
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -81,7 +81,7 @@ describe("Moves - Substitute", () => {
 
       expect(leadPokemon.hp).toBe(postSubHp);
       expect(leadPokemon.getTag(BattlerTagType.SUBSTITUTE)).toBeDefined();
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -107,7 +107,7 @@ describe("Moves - Substitute", () => {
 
       expect(leadPokemon.hp).toBe(postSubHp);
       expect(leadPokemon.getTag(BattlerTagType.SUBSTITUTE)).toBeUndefined();
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -148,7 +148,7 @@ describe("Moves - Substitute", () => {
 
       expect(leadPokemon.getTag(BattlerTagType.SUBSTITUTE)).toBeDefined();
       expect(leadPokemon.hp).toBeLessThan(postSubHp);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -172,7 +172,7 @@ describe("Moves - Substitute", () => {
 
       expect(leadPokemon.getTag(BattlerTagType.SUBSTITUTE)).toBeDefined();
       expect(leadPokemon.hp).toBeLessThan(postSubHp);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -192,7 +192,7 @@ describe("Moves - Substitute", () => {
       await game.phaseInterceptor.to("MoveEndPhase", false);
 
       expect(leadPokemon.getStatStage(Stat.ATK)).toBe(2);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -213,7 +213,7 @@ describe("Moves - Substitute", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(enemyPokemon.hp).toBeLessThan(enemyPokemon.getMaxHp());
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -233,7 +233,7 @@ describe("Moves - Substitute", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(leadPokemon.getTag(TrappedTag)).toBeUndefined();
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -253,7 +253,7 @@ describe("Moves - Substitute", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(leadPokemon.getStatStage(Stat.DEF)).toBe(0);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -272,7 +272,7 @@ describe("Moves - Substitute", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(leadPokemon.status?.effect).not.toBe(StatusEffect.PARALYSIS);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -293,7 +293,7 @@ describe("Moves - Substitute", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(leadPokemon.getHeldItems().length).toBe(1);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -314,7 +314,7 @@ describe("Moves - Substitute", () => {
       await game.phaseInterceptor.to("MoveEndPhase", false);
 
       expect(enemyPokemon.getHeldItems().length).toBe(enemyNumItems);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -339,7 +339,7 @@ describe("Moves - Substitute", () => {
 
       expect(leadPokemon.getHeldItems().length).toBe(1);
       expect(enemyPokemon.hp).toBe(enemyPostAttackHp);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -358,7 +358,7 @@ describe("Moves - Substitute", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(leadPokemon.getStatStage(Stat.ATK)).toBe(2);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -404,7 +404,7 @@ describe("Moves - Substitute", () => {
       const subTag = switchedPokemon.getTag(SubstituteTag)!;
       expect(subTag).toBeDefined();
       expect(subTag.hp).toBe(Math.floor(leadPokemon.getMaxHp() * 1/4));
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -422,7 +422,7 @@ describe("Moves - Substitute", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -447,7 +447,7 @@ describe("Moves - Substitute", () => {
 
       expect(playerPokemon.getLastXMoves()[0].result).toBe(MoveResult.SUCCESS);
       expect(enemyPokemon.hp).toBeLessThan(enemyPokemon.getMaxHp());
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -467,7 +467,7 @@ describe("Moves - Substitute", () => {
       await game.phaseInterceptor.to("BerryPhase", false);
 
       expect(playerPokemon.getLastXMoves()[0].result).toBe(MoveResult.FAIL);
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -488,7 +488,7 @@ describe("Moves - Substitute", () => {
       await game.phaseInterceptor.to("MoveEndPhase");
 
       expect(enemyPokemon.status?.effect).not.toBe(StatusEffect.BURN);
-    }, TIMEOUT
+    }
   );
 
   it(

--- a/src/test/moves/tar_shot.test.ts
+++ b/src/test/moves/tar_shot.test.ts
@@ -11,8 +11,6 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 describe("Moves - Tar Shot", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const TIMEOUT = 20 * 1000;
-
   beforeAll(() => {
     phaserGame = new Phaser.Game({
       type: Phaser.HEADLESS,
@@ -54,7 +52,7 @@ describe("Moves - Tar Shot", () => {
 
     await game.phaseInterceptor.to("MoveEndPhase");
     expect(enemy.getMoveEffectiveness).toHaveReturnedWith(4);
-  }, TIMEOUT);
+  });
 
   it("will not double the effectiveness of Fire-type moves used on a target that is already under the effect of Tar Shot (but may still lower its Speed)", async () => {
     await game.classicMode.startBattle([Species.PIKACHU]);
@@ -82,7 +80,7 @@ describe("Moves - Tar Shot", () => {
 
     await game.phaseInterceptor.to("MoveEndPhase");
     expect(enemy.getMoveEffectiveness).toHaveReturnedWith(4);
-  }, TIMEOUT);
+  });
 
   it("does not double the effectiveness of Fire-type moves against a Pokémon that is Terastallized", async () => {
     game.override.enemyHeldItems([{ name: "TERA_SHARD", type: Type.GRASS }]).enemySpecies(Species.SPRIGATITO);
@@ -104,7 +102,7 @@ describe("Moves - Tar Shot", () => {
 
     await game.phaseInterceptor.to("MoveEndPhase");
     expect(enemy.getMoveEffectiveness).toHaveReturnedWith(2);
-  }, TIMEOUT);
+  });
 
   it("doubles the effectiveness of Fire-type moves against a Pokémon that is already under the effects of Tar Shot before it Terastallized", async () => {
     game.override.enemySpecies(Species.SPRIGATITO);
@@ -128,5 +126,5 @@ describe("Moves - Tar Shot", () => {
 
     await game.phaseInterceptor.to("MoveEndPhase");
     expect(enemy.getMoveEffectiveness).toHaveReturnedWith(4);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/thousand_arrows.test.ts
+++ b/src/test/moves/thousand_arrows.test.ts
@@ -8,7 +8,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Thousand Arrows", () => {
   let phaserGame: Phaser.Game;
@@ -51,7 +51,7 @@ describe("Moves - Thousand Arrows", () => {
 
       expect(enemyPokemon.getTag(BattlerTagType.IGNORE_FLYING)).toBeDefined();
       expect(enemyPokemon.hp).toBeLessThan(enemyPokemon.getMaxHp());
-    }, TIMEOUT
+    }
   );
 
   it(
@@ -74,7 +74,7 @@ describe("Moves - Thousand Arrows", () => {
 
       expect(enemyPokemon.getTag(BattlerTagType.IGNORE_FLYING)).toBeDefined();
       expect(enemyPokemon.hp).toBeLessThan(enemyPokemon.getMaxHp());
-    }, TIMEOUT
+    }
   );
 
   it(

--- a/src/test/moves/throat_chop.test.ts
+++ b/src/test/moves/throat_chop.test.ts
@@ -10,8 +10,6 @@ import { afterEach, beforeAll, beforeEach, describe, it, expect } from "vitest";
 describe("Moves - Throat Chop", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const TIMEOUT = 20 * 1000;
-
   beforeAll(() => {
     phaserGame = new Phaser.Game({
       type: Phaser.HEADLESS,
@@ -53,5 +51,5 @@ describe("Moves - Throat Chop", () => {
 
     await game.phaseInterceptor.to("MoveEndPhase");
     expect(enemy.isFullHp()).toBe(false);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/thunder_wave.test.ts
+++ b/src/test/moves/thunder_wave.test.ts
@@ -7,7 +7,7 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Thunder Wave", () => {
   let phaserGame: Phaser.Game;
@@ -45,7 +45,7 @@ describe("Moves - Thunder Wave", () => {
     await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(enemyPokemon.status?.effect).toBe(StatusEffect.PARALYSIS);
-  }, TIMEOUT);
+  });
 
   it("does not paralyze if the Pokemon is a Ground-type", async () => {
     game.override.enemySpecies(Species.DIGLETT);
@@ -58,7 +58,7 @@ describe("Moves - Thunder Wave", () => {
     await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(enemyPokemon.status).toBeUndefined();
-  }, TIMEOUT);
+  });
 
   it("does not paralyze if the Pokemon already has a status effect", async () => {
     game.override.enemySpecies(Species.MAGIKARP).enemyStatusEffect(StatusEffect.BURN);
@@ -71,7 +71,7 @@ describe("Moves - Thunder Wave", () => {
     await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(enemyPokemon.status?.effect).not.toBe(StatusEffect.PARALYSIS);
-  }, TIMEOUT);
+  });
 
   it("affects Ground types if the user has Normalize", async () => {
     game.override.ability(Abilities.NORMALIZE).enemySpecies(Species.DIGLETT);
@@ -84,7 +84,7 @@ describe("Moves - Thunder Wave", () => {
     await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(enemyPokemon.status?.effect).toBe(StatusEffect.PARALYSIS);
-  }, TIMEOUT);
+  });
 
   it("does not affect Ghost types if the user has Normalize", async () => {
     game.override.ability(Abilities.NORMALIZE).enemySpecies(Species.HAUNTER);
@@ -97,5 +97,5 @@ describe("Moves - Thunder Wave", () => {
     await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(enemyPokemon.status).toBeUndefined();
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/wide_guard.test.ts
+++ b/src/test/moves/wide_guard.test.ts
@@ -8,7 +8,7 @@ import { Stat } from "#enums/stat";
 import { BerryPhase } from "#app/phases/berry-phase";
 import { CommandPhase } from "#app/phases/command-phase";
 
-const TIMEOUT = 20 * 1000;
+
 
 describe("Moves - Wide Guard", () => {
   let phaserGame: Phaser.Game;
@@ -55,7 +55,7 @@ describe("Moves - Wide Guard", () => {
       await game.phaseInterceptor.to(BerryPhase, false);
 
       leadPokemon.forEach(p => expect(p.hp).toBe(p.getMaxHp()));
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -76,7 +76,7 @@ describe("Moves - Wide Guard", () => {
       await game.phaseInterceptor.to(BerryPhase, false);
 
       leadPokemon.forEach(p => expect(p.getStatStage(Stat.ATK)).toBe(0));
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -97,7 +97,7 @@ describe("Moves - Wide Guard", () => {
       await game.phaseInterceptor.to(BerryPhase, false);
 
       expect(leadPokemon.some(p => p.hp < p.getMaxHp())).toBeTruthy();
-    }, TIMEOUT
+    }
   );
 
   test(
@@ -120,6 +120,6 @@ describe("Moves - Wide Guard", () => {
 
       expect(leadPokemon[0].hp).toBe(leadPokemon[0].getMaxHp());
       enemyPokemon.forEach(p => expect(p.hp).toBeLessThan(p.getMaxHp()));
-    }, TIMEOUT
+    }
   );
 });

--- a/src/test/mystery-encounter/encounters/an-offer-you-cant-refuse-encounter.test.ts
+++ b/src/test/mystery-encounter/encounters/an-offer-you-cant-refuse-encounter.test.ts
@@ -231,7 +231,7 @@ describe("An Offer You Can't Refuse - Mystery Encounter", () => {
   });
 
   describe("Option 3 - Leave", () => {
-    it("should leave encounter without battle", async () => {
+    it.each(Array.from({length: 30}))("should leave encounter without battle", async () => {
       const leaveEncounterWithoutBattleSpy = vi.spyOn(EncounterPhaseUtils, "leaveEncounterWithoutBattle");
 
       await game.runToMysteryEncounter(MysteryEncounterType.AN_OFFER_YOU_CANT_REFUSE, defaultParty);

--- a/src/test/reload.test.ts
+++ b/src/test/reload.test.ts
@@ -35,7 +35,7 @@ describe("Reload", () => {
     expect(preReloadRngState).toBe(postReloadRngState);
   }, 20000);
 
-  it("should not have RNG inconsistencies after a biome switch", async () => {
+  it.each(Array.from({length: 100}))("should not have RNG inconsistencies after a biome switch", async () => {
     game.override
       .startingWave(10)
       .battleType("single")

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ import { defaultConfig } from "./vite.config";
 export default defineProject(({ mode }) => ({
   ...defaultConfig,
   test: {
+    testTimeout: 20000,
     setupFiles: ["./src/test/fontFace.setup.ts", "./src/test/vitest.setup.ts"],
     server: {
       deps: {


### PR DESCRIPTION
## Why am I making these changes?

having the `TIMEOUT` constants redundancy is unnecessary.
Instead we should just set the default timeout to 20s in `vitest.config.ts`

## What are the changes from a developer perspective?

1. `vitest.config` now sets the default test-timeout to `20s`
2. the create-test boilerplate no longer inserts the `TIMEOUT` const
3. remove all references of `TIMEOUT`

## How to test the changes?
```shell
npm run test:silent
```
Probably won't notice a difference.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)