### PR TITLE
[Mystery-Encounter][Tests] Make berries abound test more robust

### DIFF
--- a/src/data/mystery-encounters/encounters/berries-abound-encounter.ts
+++ b/src/data/mystery-encounters/encounters/berries-abound-encounter.ts
@@ -162,10 +162,10 @@ export const BerriesAboundEncounter: MysteryEncounter =
         .withOptionPhase(async (scene: BattleScene) => {
           // Pick race for berries
           const encounter = scene.currentBattle.mysteryEncounter!;
-          const fastestPokemon = encounter.misc.fastestPokemon;
-          const enemySpeed = encounter.misc.enemySpeed;
+          const fastestPokemon: PlayerPokemon = encounter.misc.fastestPokemon;
+          const enemySpeed: number = encounter.misc.enemySpeed;
           const speedDiff = fastestPokemon.getStat(Stat.SPD) / (enemySpeed * 1.1);
-          const numBerries = encounter.misc.numBerries;
+          const numBerries: number = encounter.misc.numBerries;
 
           const shopOptions: ModifierTypeOption[] = [];
           for (let i = 0; i < 5; i++) {

--- a/src/test/mystery-encounter/encounters/berries-abound-encounter.test.ts
+++ b/src/test/mystery-encounter/encounters/berries-abound-encounter.test.ts
@@ -19,7 +19,7 @@ import { CommandPhase } from "#app/phases/command-phase";
 import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
 
 const namespace = "mysteryEncounter:berriesAbound";
-const defaultParty = [Species.PYUKUMUKU];
+const defaultParty = [Species.PYUKUMUKU, Species.MAGIKARP, Species.PIKACHU];
 const defaultBiome = Biome.CAVE;
 const defaultWave = 45;
 
@@ -120,7 +120,7 @@ describe("Berries Abound - Mystery Encounter", () => {
      * Related issue-comment: {@link https://github.com/pagefaultgames/pokerogue/issues/4300#issuecomment-2362849444}
      */
     it("should reward the player with X berries based on wave", async () => {
-      await game.runToMysteryEncounter(MysteryEncounterType.BERRIES_ABOUND, [Species.PYUKUMUKU, Species.MAGIKARP, Species.PIKACHU]);
+      await game.runToMysteryEncounter(MysteryEncounterType.BERRIES_ABOUND, defaultParty);
 
       const numBerries = game.scene.currentBattle.mysteryEncounter!.misc.numBerries;
 

--- a/src/test/mystery-encounter/encounters/berries-abound-encounter.test.ts
+++ b/src/test/mystery-encounter/encounters/berries-abound-encounter.test.ts
@@ -190,15 +190,14 @@ describe("Berries Abound - Mystery Encounter", () => {
     });
 
     it("Should skip battle when fastest pokemon is faster than boss", async () => {
-      const leaveEncounterWithoutBattleSpy = vi.spyOn(EncounterPhaseUtils, "leaveEncounterWithoutBattle");
-      const encounterTextSpy = vi.spyOn(EncounterDialogueUtils, "showEncounterText");
+      vi.spyOn(EncounterPhaseUtils, "leaveEncounterWithoutBattle");
+      vi.spyOn(EncounterDialogueUtils, "showEncounterText");
 
       await game.runToMysteryEncounter(MysteryEncounterType.BERRIES_ABOUND, defaultParty);
 
-      // Setting party pokemon's level arbitrarily high to outspeed
-      const fastestPokemon = scene.getParty()[0];
-      fastestPokemon.level = 1000;
-      fastestPokemon.calculateStats();
+      scene.getParty().forEach(pkm => {
+        vi.spyOn(pkm, "getStat").mockReturnValue(9999); // for ease return for every stat
+      });
 
       await runMysteryEncounterToEnd(game, 2);
       await game.phaseInterceptor.to(SelectModifierPhase, false);
@@ -212,8 +211,8 @@ describe("Berries Abound - Mystery Encounter", () => {
         expect(option.modifierTypeOption.type.id).toContain("BERRY");
       }
 
-      expect(encounterTextSpy).toHaveBeenCalledWith(expect.any(BattleScene), `${namespace}.option.2.selected`);
-      expect(leaveEncounterWithoutBattleSpy).toBeCalled();
+      expect(EncounterDialogueUtils.showEncounterText).toHaveBeenCalledWith(expect.any(BattleScene), `${namespace}.option.2.selected`);
+      expect(EncounterPhaseUtils.leaveEncounterWithoutBattle).toBeCalled();
     });
   });
 

--- a/src/test/mystery-encounter/encounters/berries-abound-encounter.test.ts
+++ b/src/test/mystery-encounter/encounters/berries-abound-encounter.test.ts
@@ -116,9 +116,11 @@ describe("Berries Abound - Mystery Encounter", () => {
       expect(enemyField[0].species.speciesId).toBe(speciesToSpawn);
     });
 
-    // TODO: there is some severe test flakiness occurring for this file, needs to be looked at/addressed in separate issue
+    /**
+     * Related issue-comment: {@link https://github.com/pagefaultgames/pokerogue/issues/4300#issuecomment-2362849444}
+     */
     it("should reward the player with X berries based on wave", async () => {
-      await game.runToMysteryEncounter(MysteryEncounterType.BERRIES_ABOUND, defaultParty);
+      await game.runToMysteryEncounter(MysteryEncounterType.BERRIES_ABOUND, [Species.PYUKUMUKU, Species.MAGIKARP, Species.PIKACHU]);
 
       const numBerries = game.scene.currentBattle.mysteryEncounter!.misc.numBerries;
 


### PR DESCRIPTION
## What are the changes from a developer perspective?

The "should reward the player with X berries based on wave" test was failing due to berry max stacks and the party only having 1 pokemone. Increased it to 3 to reduce that probability

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
