### PR TITLE
[Bug] Fix sturdy and endure causing an extra stat boost to boss Pokemon

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4749,6 +4749,13 @@ export class EnemyPokemon extends Pokemon {
     return true;
   }
 
+  /**
+   * Go through a boss' health segments and give stats boosts for each newly cleared segment
+   * The base boost is 1 to a random stat that's not already maxed out per broken shield
+   * For Pokemon with 3 health segments or more, breaking the last shield gives +2 instead
+   * For Pokemon with 5 health segments or more, breaking the last two shields give +2 each
+   * @param segmentIndex index of the segment to get down to (0 = no shield left, 1 = 1 shield left, etc.)
+   */
   handleBossSegmentCleared(segmentIndex: integer): void {
     while (this.bossSegmentIndex > 0 && segmentIndex - 1 < this.bossSegmentIndex) {
       // Filter out already maxed out stat stages and weigh the rest based on existing stats

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4750,7 +4750,7 @@ export class EnemyPokemon extends Pokemon {
   }
 
   handleBossSegmentCleared(segmentIndex: integer): void {
-    while (segmentIndex - 1 < this.bossSegmentIndex) {
+    while (this.bossSegmentIndex > 0 && segmentIndex - 1 < this.bossSegmentIndex) {
       // Filter out already maxed out stat stages and weigh the rest based on existing stats
       const leftoverStats = EFFECTIVE_STATS.filter((s: EffectiveStat) => this.getStatStage(s) < 6);
       const statWeights = leftoverStats.map((s: EffectiveStat) => this.getStat(s, false));

--- a/src/test/boss-pokemon.test.ts
+++ b/src/test/boss-pokemon.test.ts
@@ -35,7 +35,7 @@ describe("Boss Pokemon / Shields", () => {
       .enemyMoveset(Moves.SPLASH)
       .enemyHeldItems([])
       .startingLevel(1000)
-      .moveset([Moves.FALSE_SWIPE, Moves.SUPER_FANG, Moves.SPLASH])
+      .moveset([Moves.FALSE_SWIPE, Moves.SUPER_FANG, Moves.SPLASH, Moves.PSYCHIC])
       .ability(Abilities.NO_GUARD);
   });
 
@@ -195,6 +195,28 @@ describe("Boss Pokemon / Shields", () => {
     game.move.select(Moves.SPLASH);
     await game.toNextTurn();
     expect(getTotalStatStageBoosts(boss2)).toBe(totalStatStages);
+
+  }, TIMEOUT);
+
+  it("the boss enduring does not proc an extra stat boost", async () => {
+    game.override
+      .enemyHealthSegments(2)
+      .enemyAbility(Abilities.STURDY);
+
+    await game.classicMode.startBattle([ Species.MEWTWO ]);
+
+    const enemyPokemon = game.scene.getEnemyPokemon()!;
+    expect(enemyPokemon.isBoss()).toBe(true);
+    expect(enemyPokemon.bossSegments).toBe(2);
+    expect(getTotalStatStageBoosts(enemyPokemon)).toBe(0);
+
+    game.move.select(Moves.PSYCHIC);
+    await game.toNextTurn();
+
+    // Enemy survived with Sturdy
+    expect(enemyPokemon.bossSegmentIndex).toBe(0);
+    expect(enemyPokemon.hp).toBe(1);
+    expect(getTotalStatStageBoosts(enemyPokemon)).toBe(1);
 
   }, TIMEOUT);
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
no more unwarranted stat boost
<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?
Currently a boss Pokemon resisting one shot with sturdy or endure gives it a stat boost as if an extra shield was broken - [See original bug report on discord](https://discord.com/channels/1125469663833370665/1285906331299086420)
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What are the changes from a developer perspective?
- The loop going through boss segments looped one time too many allowing bossSegmentIndex to go down to -1, giving an extra boost. Typically Pokemon die when this happens so the issue was never noticed until now. Anyway, it now properly stops the loop
- added test for this specific case
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos
(the videos are both using endure tokens but the boss having sturdy produces the same results since it's an issue with the boss code, and not sturdy or endure tokens)

Before:

https://github.com/user-attachments/assets/bb2602bf-2eac-48e9-bbf3-555d0776a34d

After: 

https://github.com/user-attachments/assets/4aef174e-ccbd-462d-b01f-c7df1bd11829




<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
Test: `npm run test src/test/boss-pokemon.test.ts`

Overrides - Sturdy
```
  STARTING_LEVEL_OVERRIDE: 1000,
  OPP_ABILITY_OVERRIDE: Abilities.STURDY,
  OPP_HEALTH_SEGMENTS_OVERRIDE: 2
```
Overrides - Endure Tokens
```
  STARTING_LEVEL_OVERRIDE: 1000,
  OPP_MODIFIER_OVERRIDE: [{name: "ENEMY_ENDURE_CHANCE", count: 46}],
  OPP_HEALTH_SEGMENTS_OVERRIDE: 2
```

<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
- ~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
