### PR TITLE
[Mystery-Encounter][Tests] fix Teleporting Hijinks tests

### DIFF
--- a/src/test/mystery-encounter/encounters/teleporting-hijinks-encounter.test.ts
+++ b/src/test/mystery-encounter/encounters/teleporting-hijinks-encounter.test.ts
@@ -15,6 +15,7 @@ import { TeleportingHijinksEncounter } from "#app/data/mystery-encounters/encoun
 import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
 import { Mode } from "#app/ui/ui";
 import ModifierSelectUiHandler from "#app/ui/modifier-select-ui-handler";
+import { Abilities } from "#app/enums/abilities";
 
 const namespace = "mysteryEncounter:teleportingHijinks";
 const defaultParty = [Species.LAPRAS, Species.GENGAR, Species.ABRA];
@@ -36,10 +37,12 @@ describe("Teleporting Hijinks - Mystery Encounter", () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
     scene.money = 20000;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves()
+      .enemyPassiveAbility(Abilities.BALL_FETCH);
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<Biome, MysteryEncounterType[]>([


### PR DESCRIPTION
## What are the changes from a developer perspective?

set enemy passive ability by default to `Ball Fetch` to prevent random passive abilities that raise stats too

## How to test the changes?

Run the tests as many times as you can.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
