### PR TITLE
[Qol][Tests] Add "Mystery Encounter" type for `create-test` script + minor timeout fixes

### DIFF
--- a/create-test-boilerplate.js
+++ b/create-test-boilerplate.js
@@ -14,7 +14,7 @@ import { fileURLToPath } from "url";
 // Get the directory name of the current module file
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const typeChoices = ["Move", "Ability", "Item"];
+const typeChoices = ["Move", "Ability", "Item", "Mystery Encounter"];
 
 /**
  * Prompts the user to select a type via list.
@@ -95,6 +95,10 @@ async function runInteractive() {
     case "item":
       dir = path.join(__dirname, "src", "test", "items");
       description = `Items - ${formattedName}`;
+      break;
+    case "mystery encounter":
+      dir = path.join(__dirname, "src", "test", "mystery-encounter", "encounters");
+      description = `Mystery Encounter - ${formattedName}`;
       break;
     default:
       console.error('Invalid type. Please use "move", "ability", or "item".');

--- a/create-test-boilerplate.js
+++ b/create-test-boilerplate.js
@@ -76,6 +76,7 @@ async function runInteractive() {
   const fileName = fileNameAnswer.userInput
     .replace(/-+/g, "_") // Convert kebab-case (dashes) to underscores
     .replace(/([a-z])([A-Z])/g, "$1_$2") // Convert camelCase to snake_case
+    .replace(/\s+/g, '_') // Replace spaces with underscores
     .toLowerCase(); // Ensure all lowercase
   // Format the description for the test case
 

--- a/src/test/abilities/quick_draw.test.ts
+++ b/src/test/abilities/quick_draw.test.ts
@@ -55,7 +55,6 @@ describe("Abilities - Quick Draw", () => {
   }, 20000);
 
   test("does not triggered by non damage moves", {
-    timeout: 20000,
     retry: 5
   }, async () => {
     await game.startBattle();

--- a/src/test/battlerTags/octolock.test.ts
+++ b/src/test/battlerTags/octolock.test.ts
@@ -10,7 +10,7 @@ vi.mock("#app/battle-scene.js");
 
 describe("BattlerTag - OctolockTag", () => {
   describe("lapse behavior", () => {
-    it("unshifts a StatStageChangePhase with expected stat stage changes", { timeout: 10000 }, async () => {
+    it("unshifts a StatStageChangePhase with expected stat stage changes", async () => {
       const mockPokemon = {
         scene: new BattleScene(),
         getBattlerIndex: () => 0,
@@ -30,11 +30,11 @@ describe("BattlerTag - OctolockTag", () => {
     });
   });
 
-  it ("traps its target (extends TrappedTag)", { timeout: 2000 }, async () => {
+  it ("traps its target (extends TrappedTag)", async () => {
     expect(new OctolockTag(1)).toBeInstanceOf(TrappedTag);
   });
 
-  it("can be added to pokemon who are not octolocked", { timeout: 2000 }, async => {
+  it("can be added to pokemon who are not octolocked", async => {
     const mockPokemon = {
       getTag: vi.fn().mockReturnValue(undefined) as Pokemon["getTag"],
     } as Pokemon;
@@ -47,7 +47,7 @@ describe("BattlerTag - OctolockTag", () => {
     expect(mockPokemon.getTag).toHaveBeenCalledWith(BattlerTagType.OCTOLOCK);
   });
 
-  it("cannot be added to pokemon who are octolocked", { timeout: 2000 }, async => {
+  it("cannot be added to pokemon who are octolocked", async => {
     const mockPokemon = {
       getTag: vi.fn().mockReturnValue(new BattlerTag(null!, null!, null!, null!)) as Pokemon["getTag"],
     } as Pokemon;

--- a/src/test/battlerTags/stockpiling.test.ts
+++ b/src/test/battlerTags/stockpiling.test.ts
@@ -12,7 +12,7 @@ beforeEach(() => {
 
 describe("BattlerTag - StockpilingTag", () => {
   describe("onAdd", () => {
-    it("unshifts a StatStageChangePhase with expected stat stage changes on add", { timeout: 10000 }, async () => {
+    it("unshifts a StatStageChangePhase with expected stat stage changes on add", async () => {
       const mockPokemon = {
         scene: vi.mocked(new BattleScene()) as BattleScene,
         getBattlerIndex: () => 0,
@@ -35,7 +35,7 @@ describe("BattlerTag - StockpilingTag", () => {
       expect(mockPokemon.scene.unshiftPhase).toBeCalledTimes(1);
     });
 
-    it("unshifts a StatStageChangePhase with expected stat changes on add (one stat maxed)", { timeout: 10000 }, async () => {
+    it("unshifts a StatStageChangePhase with expected stat changes on add (one stat maxed)", async () => {
       const mockPokemon = {
         scene: new BattleScene(),
         summonData: new PokemonSummonData(),
@@ -64,7 +64,7 @@ describe("BattlerTag - StockpilingTag", () => {
   });
 
   describe("onOverlap", () => {
-    it("unshifts a StatStageChangePhase with expected stat changes on overlap", { timeout: 10000 }, async () => {
+    it("unshifts a StatStageChangePhase with expected stat changes on overlap", async () => {
       const mockPokemon = {
         scene: new BattleScene(),
         getBattlerIndex: () => 0,
@@ -89,7 +89,7 @@ describe("BattlerTag - StockpilingTag", () => {
   });
 
   describe("stack limit, stat tracking, and removal", () => {
-    it("can be added up to three times, even when one stat does not change", { timeout: 10000 }, async () => {
+    it("can be added up to three times, even when one stat does not change", async () => {
       const mockPokemon = {
         scene: new BattleScene(),
         summonData: new PokemonSummonData(),

--- a/src/test/boss-pokemon.test.ts
+++ b/src/test/boss-pokemon.test.ts
@@ -216,7 +216,7 @@ describe("Boss Pokemon / Shields", () => {
     expect(enemyPokemon.hp).toBe(1);
     expect(getTotalStatStageBoosts(enemyPokemon)).toBe(1);
 
-  }, TIMEOUT);
+  });
 
   /**
    * Gets the sum of the effective stat stage boosts for the given Pokemon

--- a/src/test/moves/haze.test.ts
+++ b/src/test/moves/haze.test.ts
@@ -35,7 +35,7 @@ describe("Moves - Haze", () => {
       game.override.ability(Abilities.NONE);
     });
 
-    it("should reset all stat changes of all Pokemon on field", { timeout: 10000 }, async () => {
+    it("should reset all stat changes of all Pokemon on field", async () => {
       await game.startBattle([Species.RATTATA]);
       const user = game.scene.getPlayerPokemon()!;
       const enemy = game.scene.getEnemyPokemon()!;

--- a/src/test/moves/octolock.test.ts
+++ b/src/test/moves/octolock.test.ts
@@ -36,7 +36,7 @@ describe("Moves - Octolock", () => {
       .ability(Abilities.BALL_FETCH);
   });
 
-  it("lowers DEF and SPDEF stat stages of the target Pokemon by 1 each turn", { timeout: 10000 }, async () => {
+  it("lowers DEF and SPDEF stat stages of the target Pokemon by 1 each turn", async () => {
     await game.classicMode.startBattle([ Species.GRAPPLOCT ]);
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -57,7 +57,7 @@ describe("Moves - Octolock", () => {
     expect(enemyPokemon.getStatStage(Stat.SPDEF)).toBe(-2);
   });
 
-  it("if target pokemon has BIG_PECKS, should only lower SPDEF stat stage by 1", { timeout: 10000 }, async () => {
+  it("if target pokemon has BIG_PECKS, should only lower SPDEF stat stage by 1", async () => {
     game.override.enemyAbility(Abilities.BIG_PECKS);
     await game.classicMode.startBattle([ Species.GRAPPLOCT ]);
 
@@ -71,7 +71,7 @@ describe("Moves - Octolock", () => {
     expect(enemyPokemon.getStatStage(Stat.SPDEF)).toBe(-1);
   });
 
-  it("if target pokemon has WHITE_SMOKE, should not reduce any stat stages", { timeout: 10000 }, async () => {
+  it("if target pokemon has WHITE_SMOKE, should not reduce any stat stages", async () => {
     game.override.enemyAbility(Abilities.WHITE_SMOKE);
     await game.classicMode.startBattle([ Species.GRAPPLOCT ]);
 
@@ -85,7 +85,7 @@ describe("Moves - Octolock", () => {
     expect(enemyPokemon.getStatStage(Stat.SPDEF)).toBe(0);
   });
 
-  it("if target pokemon has CLEAR_BODY, should not reduce any stat stages", { timeout: 10000 }, async () => {
+  it("if target pokemon has CLEAR_BODY, should not reduce any stat stages", async () => {
     game.override.enemyAbility(Abilities.CLEAR_BODY);
     await game.classicMode.startBattle([ Species.GRAPPLOCT ]);
 
@@ -99,7 +99,7 @@ describe("Moves - Octolock", () => {
     expect(enemyPokemon.getStatStage(Stat.SPDEF)).toBe(0);
   });
 
-  it("traps the target pokemon", { timeout: 10000 }, async () => {
+  it("traps the target pokemon", async () => {
     await game.classicMode.startBattle([ Species.GRAPPLOCT ]);
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;

--- a/src/test/moves/spit_up.test.ts
+++ b/src/test/moves/spit_up.test.ts
@@ -43,7 +43,7 @@ describe("Moves - Spit Up", () => {
   });
 
   describe("consumes all stockpile stacks to deal damage (scaling with stacks)", () => {
-    it("1 stack -> 100 power", { timeout: 10000 }, async () => {
+    it("1 stack -> 100 power", async () => {
       const stacksToSetup = 1;
       const expectedPower = 100;
 
@@ -65,7 +65,7 @@ describe("Moves - Spit Up", () => {
       expect(pokemon.getTag(StockpilingTag)).toBeUndefined();
     });
 
-    it("2 stacks -> 200 power", { timeout: 10000 }, async () => {
+    it("2 stacks -> 200 power", async () => {
       const stacksToSetup = 2;
       const expectedPower = 200;
 
@@ -88,7 +88,7 @@ describe("Moves - Spit Up", () => {
       expect(pokemon.getTag(StockpilingTag)).toBeUndefined();
     });
 
-    it("3 stacks -> 300 power", { timeout: 10000 }, async () => {
+    it("3 stacks -> 300 power", async () => {
       const stacksToSetup = 3;
       const expectedPower = 300;
 
@@ -113,7 +113,7 @@ describe("Moves - Spit Up", () => {
     });
   });
 
-  it("fails without stacks", { timeout: 10000 }, async () => {
+  it("fails without stacks", async () => {
     await game.startBattle([Species.ABOMASNOW]);
 
     const pokemon = game.scene.getPlayerPokemon()!;
@@ -130,7 +130,7 @@ describe("Moves - Spit Up", () => {
   });
 
   describe("restores stat boosts granted by stacks", () => {
-    it("decreases stats based on stored values (both boosts equal)", { timeout: 10000 }, async () => {
+    it("decreases stats based on stored values (both boosts equal)", async () => {
       await game.startBattle([Species.ABOMASNOW]);
 
       const pokemon = game.scene.getPlayerPokemon()!;
@@ -157,7 +157,7 @@ describe("Moves - Spit Up", () => {
       expect(pokemon.getTag(StockpilingTag)).toBeUndefined();
     });
 
-    it("decreases stats based on stored values (different boosts)", { timeout: 10000 }, async () => {
+    it("decreases stats based on stored values (different boosts)", async () => {
       await game.startBattle([Species.ABOMASNOW]);
 
       const pokemon = game.scene.getPlayerPokemon()!;

--- a/src/test/moves/stockpile.test.ts
+++ b/src/test/moves/stockpile.test.ts
@@ -37,7 +37,7 @@ describe("Moves - Stockpile", () => {
       game.override.ability(Abilities.NONE);
     });
 
-    it("gains a stockpile stack and raises user's DEF and SPDEF stat stages by 1 on each use, fails at max stacks (3)", { timeout: 10000 }, async () => {
+    it("gains a stockpile stack and raises user's DEF and SPDEF stat stages by 1 on each use, fails at max stacks (3)", async () => {
       await game.startBattle([Species.ABOMASNOW]);
 
       const user = game.scene.getPlayerPokemon()!;
@@ -76,7 +76,7 @@ describe("Moves - Stockpile", () => {
       }
     });
 
-    it("gains a stockpile stack even if user's DEF and SPDEF stat stages are at +6", { timeout: 10000 }, async () => {
+    it("gains a stockpile stack even if user's DEF and SPDEF stat stages are at +6", async () => {
       await game.startBattle([Species.ABOMASNOW]);
 
       const user = game.scene.getPlayerPokemon()!;

--- a/src/test/moves/swallow.test.ts
+++ b/src/test/moves/swallow.test.ts
@@ -38,7 +38,7 @@ describe("Moves - Swallow", () => {
   });
 
   describe("consumes all stockpile stacks to heal (scaling with stacks)", () => {
-    it("1 stack -> 25% heal", { timeout: 10000 }, async () => {
+    it("1 stack -> 25% heal", async () => {
       const stacksToSetup = 1;
       const expectedHeal = 25;
 
@@ -65,7 +65,7 @@ describe("Moves - Swallow", () => {
       expect(pokemon.getTag(StockpilingTag)).toBeUndefined();
     });
 
-    it("2 stacks -> 50% heal", { timeout: 10000 }, async () => {
+    it("2 stacks -> 50% heal", async () => {
       const stacksToSetup = 2;
       const expectedHeal = 50;
 
@@ -93,7 +93,7 @@ describe("Moves - Swallow", () => {
       expect(pokemon.getTag(StockpilingTag)).toBeUndefined();
     });
 
-    it("3 stacks -> 100% heal", { timeout: 10000 }, async () => {
+    it("3 stacks -> 100% heal", async () => {
       const stacksToSetup = 3;
       const expectedHeal = 100;
 
@@ -123,7 +123,7 @@ describe("Moves - Swallow", () => {
     });
   });
 
-  it("fails without stacks", { timeout: 10000 }, async () => {
+  it("fails without stacks", async () => {
     await game.startBattle([Species.ABOMASNOW]);
 
     const pokemon = game.scene.getPlayerPokemon()!;
@@ -138,7 +138,7 @@ describe("Moves - Swallow", () => {
   });
 
   describe("restores stat stage boosts granted by stacks", () => {
-    it("decreases stats based on stored values (both boosts equal)", { timeout: 10000 }, async () => {
+    it("decreases stats based on stored values (both boosts equal)", async () => {
       await game.startBattle([Species.ABOMASNOW]);
 
       const pokemon = game.scene.getPlayerPokemon()!;
@@ -163,7 +163,7 @@ describe("Moves - Swallow", () => {
       expect(pokemon.getTag(StockpilingTag)).toBeUndefined();
     });
 
-    it("lower stat stages based on stored values (different boosts)", { timeout: 10000 }, async () => {
+    it("lower stat stages based on stored values (different boosts)", async () => {
       await game.startBattle([Species.ABOMASNOW]);
 
       const pokemon = game.scene.getPlayerPokemon()!;


### PR DESCRIPTION
## What are the changes from a developer perspective?

- The `create-test` script now has a 4th type option called `Mystery Encounter`
- Removed some leftover manual `timeout` definitions

### Screenshots/Videos

![image](https://github.com/user-attachments/assets/da30e920-5ab3-4e80-8305-c3ceff35a450)



## How to test the changes?

```
npm run create-test
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
