### PR TITLE
[Qol] Add an option to import/export settings

### DIFF
--- a/src/locales/de/menu-ui-handler.json
+++ b/src/locales/de/menu-ui-handler.json
@@ -16,6 +16,8 @@
   "exportSlotSelect": "Wähle einen Slot zum Exportieren.",
   "importRunHistory": "Laufhistorie importieren",
   "exportRunHistory": "Laufhistorie exportieren",
+  "importSettings": "Einstellungen importieren",
+  "exportSettings": "Einstellungen exportieren",
   "importData": "Daten importieren",
   "exportData": "Daten exportieren",
   "consentPreferences": "Einwilligungspräferenzen",

--- a/src/locales/en/menu-ui-handler.json
+++ b/src/locales/en/menu-ui-handler.json
@@ -16,6 +16,8 @@
   "exportSlotSelect": "Select a slot to export from.",
   "importRunHistory": "Import Run History",
   "exportRunHistory": "Export Run History",
+  "importSettings": "Import Settings",
+  "exportSettings": "Export Settings",
   "importData": "Import Data",
   "exportData": "Export Data",
   "consentPreferences": "Consent Preferences",

--- a/src/locales/es/menu-ui-handler.json
+++ b/src/locales/es/menu-ui-handler.json
@@ -16,6 +16,8 @@
   "exportSlotSelect": "Selecciona una ranura para exportar.",
   "importRunHistory":"Importar Historial de partida",
   "exportRunHistory":"Exportar Historial de partida",
+  "importSettings": "Importar Configuraciones",
+  "exportSettings": "Exportar Configuraciones",
   "importData": "Importar Datos",
   "exportData": "Exportar Datos",
   "consentPreferences": "Consentimiento de datos",

--- a/src/locales/fr/menu-ui-handler.json
+++ b/src/locales/fr/menu-ui-handler.json
@@ -18,6 +18,8 @@
   "exportData": "Exporter données",
   "importRunHistory":"Importer historique",
   "exportRunHistory":"Exporter historique",
+  "importSettings": "Importer paramètres",
+  "exportSettings": "Exporter paramètres",
   "consentPreferences": "Gérer les cookies",
   "linkDiscord": "Lier à Discord",
   "unlinkDiscord": "Délier Discord",

--- a/src/locales/it/menu-ui-handler.json
+++ b/src/locales/it/menu-ui-handler.json
@@ -16,6 +16,8 @@
   "exportSlotSelect": "Seleziona uno slot da cui esportare.",
   "importRunHistory":"Importa run precedenti",
   "exportRunHistory":"Esporta run precedenti",
+  "importSettings": "Importa impostazioni",
+  "exportSettings": "Esporta impostazioni",
   "importData": "Importa dati",
   "exportData": "Esporta dati",
   "consentPreferences": "Consenti preferenze",

--- a/src/locales/ja/menu-ui-handler.json
+++ b/src/locales/ja/menu-ui-handler.json
@@ -16,6 +16,8 @@
   "exportSlotSelect": "エクスポート元の　スロットを　選んでください",
   "importRunHistory": "ラン歴をインポート",
   "exportRunHistory": "ラン歴をエクスポート",
+  "importSettings": "Import Settings",
+  "exportSettings": "Export Settings",
   "importData": "データをインポート",
   "exportData": "データをエクスポート",
   "consentPreferences": "同意設定",

--- a/src/locales/ko/menu-ui-handler.json
+++ b/src/locales/ko/menu-ui-handler.json
@@ -16,6 +16,8 @@
   "exportSlotSelect": "내보낼 슬롯을 골라주세요.",
   "importRunHistory":"플레이 이력 불러오기",
   "exportRunHistory":"플레이 이력 내보내기",
+  "importSettings": "설정 불러오기",
+  "exportSettings": "설정 내보내기",
   "importData": "데이터 불러오기",
   "exportData": "데이터 내보내기",
   "consentPreferences": "쿠키 설정 동의",

--- a/src/locales/pt_BR/menu-ui-handler.json
+++ b/src/locales/pt_BR/menu-ui-handler.json
@@ -16,6 +16,8 @@
   "exportSlotSelect": "Selecione um slot para exportar.",
   "importRunHistory": "Importar Histórico de Jogos",
   "exportRunHistory": "Exportar Histórico de Jogos",
+  "importSettings": "Importar configurações",
+  "exportSettings": "Exportar configurações",
   "importData": "Importar dados",
   "exportData": "Exportar dados",
   "consentPreferences": "Opções de Privacidade",

--- a/src/locales/zh_CN/menu-ui-handler.json
+++ b/src/locales/zh_CN/menu-ui-handler.json
@@ -16,6 +16,8 @@
   "exportSlotSelect": "选择要导出的存档位。",
   "importRunHistory":"导入历史记录",
   "exportRunHistory":"导出历史记录",
+  "importSettings": "导入设置",
+  "exportSettings": "导出设置",
   "importData": "导入数据",
   "exportData": "导出数据",
   "consentPreferences": "同意偏好",

--- a/src/locales/zh_TW/menu-ui-handler.json
+++ b/src/locales/zh_TW/menu-ui-handler.json
@@ -16,6 +16,8 @@
   "exportSlotSelect": "選擇要導出的存檔位。",
   "importRunHistory":"導入歷史記錄",
   "exportRunHistory":"導出歷史記錄",
+  "importSettings": "導入設置",
+  "exportSettings": "導出設置",
   "importData": "導入數據",
   "exportData": "導出數據",
   "consentPreferences": "同意偏好",

--- a/src/ui/menu-ui-handler.ts
+++ b/src/ui/menu-ui-handler.ts
@@ -244,6 +244,22 @@ export default class MenuUiHandler extends MessageUiHandler {
       },
       keepOpen: true
     });
+    manageDataOptions.push({
+      label: i18next.t("menuUiHandler:importSettings"),
+      handler: () => {
+        this.scene.gameData.importData(GameDataType.SETTINGS);
+        return true;
+      },
+      keepOpen: true
+    });
+    manageDataOptions.push({
+      label: i18next.t("menuUiHandler:exportSettings"),
+      handler: () => {
+        this.scene.gameData.tryExportData(GameDataType.SETTINGS);
+        return true;
+      },
+      keepOpen: true
+    });
     if (Utils.isLocal || Utils.isBeta) {
       manageDataOptions.push({
         label: i18next.t("menuUiHandler:importData"),


### PR DESCRIPTION
## What are the changes the user will see?
Added an option in the manage data menu to import and export settings

## Why am I making these changes?
This was already started on an older version in this PR and I found some time to update this on the current version.
This is to avoid re-entering manually all my settings when I delete my cookies.

## What are the changes from a developer perspective?
I added two entries in the manage data menu to import and export the settings and reused the already existing import-export function.

I reused the translation from the old PR, I'm only missing japanese.

### Screenshots/Videos
https://github.com/user-attachments/assets/44ad5295-6383-4b66-b5b9-006dca3f33bb


## How to test the changes?
This can be tested by exporting and importing settings with the new option menu.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
   - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
