### PR TITLE
[Bug] Preventing Duplicate Species in Trainer Battles

### DIFF
--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -425,12 +425,30 @@ export default class Trainer extends Phaser.GameObjects.Container {
       }
     }
 
+    // Prompts reroll of party member species if species already present in the enemy party
+    if (this.checkDuplicateSpecies(ret)) {
+      console.log("Duplicate species detected, prompting reroll...");
+      retry = true;
+    }
+
     if (retry && (attempt || 0) < 10) {
       console.log("Rerolling party member...");
       ret = this.genNewPartyMemberSpecies(level, strength, (attempt || 0) + 1);
     }
 
     return ret;
+  }
+
+  /**
+   * Checks if the enemy trainer already has the Pokemon species in their party
+   * @param {PokemonSpecies} species {@linkcode PokemonSpecies}
+   * @returns `true` if the species is already present in the party
+   */
+  checkDuplicateSpecies(species: PokemonSpecies): boolean {
+    const currentPartySpecies = this.scene.getEnemyParty().map(p => {
+      return p.species.speciesId;
+    });
+    return currentPartySpecies.includes(species.speciesId);
   }
 
   getPartyMemberMatchupScores(trainerSlot: TrainerSlot = TrainerSlot.NONE, forSwitch: boolean = false): [integer, integer][] {

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -431,9 +431,9 @@ export default class Trainer extends Phaser.GameObjects.Container {
       retry = true;
     }
 
-    if (retry && (attempt || 0) < 10) {
+    if (retry && (attempt ?? 0) < 10) {
       console.log("Rerolling party member...");
-      ret = this.genNewPartyMemberSpecies(level, strength, (attempt || 0) + 1);
+      ret = this.genNewPartyMemberSpecies(level, strength, (attempt ?? 0) + 1);
     }
 
     return ret;


### PR DESCRIPTION
## What are the changes the user will see?
Users will no longer have to fight trainers with repeated Pokemon. The game will try to supply unique party members instead. 

## Why am I making these changes?
Quid-pro-quo

## Screenshots
Can't prove definitely that no repeats will occur, but ran through Wave 112 multiple times. 
Console Output: 
![image](https://github.com/user-attachments/assets/7c539741-22fe-4bfd-bd7b-1d2240ea3f73)
Enemy Parties (Wave 112):
![image](https://github.com/user-attachments/assets/7901e59a-e200-4085-8a26-dfa86d20578a)
![image](https://github.com/user-attachments/assets/304e248f-2aff-4686-82d4-e8158be6449b)
![image](https://github.com/user-attachments/assets/6a0dd8d5-f95c-408f-b005-24294b7fea9f)
![image](https://github.com/user-attachments/assets/28657ae6-455a-41f8-818c-cfc6e93f0504)
![image](https://github.com/user-attachments/assets/627becad-2065-4b19-acba-e2c98049d192)

## What are the changes from a developer perspective?
A new function was created 'checkDuplicateSpecies' that checks if the Pokemon Species passed is already found in the party. If it is, it prompts the genNewPartyMemberSpecies to reroll again. An infinite loop is already prevented in the code as the game allows up to 10 retries before settling with the Pokemon chosen. 

## How to test the changes?
Choose any trainer that lacks fixed party members. Would recommend Wave 112.
Evil team leaders and the rivals are not a good choice b/c the all/majority of their party is set in stone.  

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
