### PR TITLE
[Test] Shell Side Arm test should no longer randomly fail

### DIFF
--- a/src/test/moves/shell_side_arm.test.ts
+++ b/src/test/moves/shell_side_arm.test.ts
@@ -5,11 +5,14 @@ import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
 import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, it, expect, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("Moves - Shell Side Arm", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
+  const shellSideArm = allMoves[Moves.SHELL_SIDE_ARM];
+  const shellSideArmAttr = shellSideArm.getAttrs(ShellSideArmCategoryAttr)[0];
+
   beforeAll(() => {
     phaserGame = new Phaser.Game({
       type: Phaser.HEADLESS,
@@ -34,14 +37,11 @@ describe("Moves - Shell Side Arm", () => {
   it("becomes a physical attack if forecasted to deal more damage as physical", async () => {
     game.override.enemySpecies(Species.SNORLAX);
 
-    await game.classicMode.startBattle([Species.MANAPHY]);
+    await game.classicMode.startBattle([Species.RAMPARDOS]);
 
-    const shellSideArm = allMoves[Moves.SHELL_SIDE_ARM];
-    const shellSideArmAttr = shellSideArm.getAttrs(ShellSideArmCategoryAttr)[0];
     vi.spyOn(shellSideArmAttr, "apply");
 
     game.move.select(Moves.SHELL_SIDE_ARM);
-
     await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(shellSideArmAttr.apply).toHaveLastReturnedWith(true);
@@ -50,14 +50,11 @@ describe("Moves - Shell Side Arm", () => {
   it("remains a special attack if forecasted to deal more damage as special", async () => {
     game.override.enemySpecies(Species.SLOWBRO);
 
-    await game.classicMode.startBattle([Species.MANAPHY]);
+    await game.classicMode.startBattle([Species.XURKITREE]);
 
-    const shellSideArm = allMoves[Moves.SHELL_SIDE_ARM];
-    const shellSideArmAttr = shellSideArm.getAttrs(ShellSideArmCategoryAttr)[0];
     vi.spyOn(shellSideArmAttr, "apply");
 
     game.move.select(Moves.SHELL_SIDE_ARM);
-
     await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(shellSideArmAttr.apply).toHaveLastReturnedWith(false);
@@ -70,14 +67,10 @@ describe("Moves - Shell Side Arm", () => {
 
     await game.classicMode.startBattle([Species.MANAPHY]);
 
-    const shellSideArm = allMoves[Moves.SHELL_SIDE_ARM];
-    const shellSideArmAttr = shellSideArm.getAttrs(ShellSideArmCategoryAttr)[0];
     vi.spyOn(shellSideArmAttr, "apply");
 
     game.move.select(Moves.SHELL_SIDE_ARM);
-
     await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
-
     await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(shellSideArmAttr.apply).toHaveLastReturnedWith(false);


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
The test randomly fails.

## What are the changes from a developer perspective?
Changed which Pokémon are used in 2 of the tests so it should be impossible for them to randomly fail now.

## How to test the changes?
`npm run test shell_side_arm`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- ~[ ] Have I tested the changes (manually)?~
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
