### PR TITLE
[Refactor][Tests] Remove manual test timeouts

### DIFF
--- a/src/test/abilities/arena_trap.test.ts
+++ b/src/test/abilities/arena_trap.test.ts
@@ -8,7 +8,6 @@ import { afterEach, beforeAll, beforeEach, describe, it, expect } from "vitest";
 describe("Abilities - Arena Trap", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const TIMEOUT = 20 * 1000;
 
   beforeAll(() => {
     phaserGame = new Phaser.Game({
@@ -43,7 +42,7 @@ describe("Abilities - Arena Trap", () => {
     await game.toNextTurn();
 
     expect(enemy).toBe(game.scene.getEnemyPokemon());
-  }, TIMEOUT);
+  });
 
   it("should guarantee double battle with any one LURE", async () => {
     game.override
@@ -55,5 +54,5 @@ describe("Abilities - Arena Trap", () => {
     await game.classicMode.startBattle();
 
     expect(game.scene.getEnemyField().length).toBe(2);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/abilities/illuminate.test.ts
+++ b/src/test/abilities/illuminate.test.ts
@@ -8,7 +8,6 @@ import { afterEach, beforeAll, beforeEach, describe, it, expect } from "vitest";
 describe("Abilities - Illuminate", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const TIMEOUT = 20 * 1000;
 
   beforeAll(() => {
     phaserGame = new Phaser.Game({
@@ -43,7 +42,7 @@ describe("Abilities - Illuminate", () => {
     await game.toNextTurn();
 
     expect(player.getStatStage(Stat.ACC)).toBe(0);
-  }, TIMEOUT);
+  });
 
   it("should guarantee double battle with any one LURE", async () => {
     game.override
@@ -55,5 +54,5 @@ describe("Abilities - Illuminate", () => {
     await game.classicMode.startBattle();
 
     expect(game.scene.getEnemyField().length).toBe(2);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/abilities/no_guard.test.ts
+++ b/src/test/abilities/no_guard.test.ts
@@ -11,7 +11,6 @@ import { afterEach, beforeAll, beforeEach, describe, it, expect, vi } from "vite
 describe("Abilities - No Guard", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const TIMEOUT = 20 * 1000;
 
   beforeAll(() => {
     phaserGame = new Phaser.Game({
@@ -52,7 +51,7 @@ describe("Abilities - No Guard", () => {
     await game.phaseInterceptor.to(MoveEndPhase);
 
     expect(moveEffectPhase.hitCheck).toHaveReturnedWith(true);
-  }, TIMEOUT);
+  });
 
   it("should guarantee double battle with any one LURE", async () => {
     game.override
@@ -64,5 +63,5 @@ describe("Abilities - No Guard", () => {
     await game.classicMode.startBattle();
 
     expect(game.scene.getEnemyField().length).toBe(2);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/chilly_reception.test.ts
+++ b/src/test/moves/chilly_reception.test.ts
@@ -6,8 +6,6 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-const TIMEOUT = 20 * 1000;
-
 describe("Moves - Chilly Reception", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
@@ -39,7 +37,7 @@ describe("Moves - Chilly Reception", () => {
 
     await game.phaseInterceptor.to("BerryPhase", false);
     expect(game.scene.arena.weather?.weatherType).toBe(WeatherType.SNOW);
-  }, TIMEOUT);
+  });
 
   it("should switch out even if it's snowing", async () => {
     await game.classicMode.startBattle([Species.SLOWKING, Species.MEOWTH]);
@@ -55,7 +53,7 @@ describe("Moves - Chilly Reception", () => {
     await game.phaseInterceptor.to("BerryPhase", false);
     expect(game.scene.arena.weather?.weatherType).toBe(WeatherType.SNOW);
     expect(game.scene.getPlayerField()[0].species.speciesId).toBe(Species.MEOWTH);
-  }, TIMEOUT);
+  });
 
   it("happy case - switch out and weather changes", async () => {
 
@@ -67,5 +65,5 @@ describe("Moves - Chilly Reception", () => {
     await game.phaseInterceptor.to("BerryPhase", false);
     expect(game.scene.arena.weather?.weatherType).toBe(WeatherType.SNOW);
     expect(game.scene.getPlayerField()[0].species.speciesId).toBe(Species.MEOWTH);
-  }, TIMEOUT);
+  });
 });

--- a/src/test/moves/heal_block.test.ts
+++ b/src/test/moves/heal_block.test.ts
@@ -10,8 +10,6 @@ import { Species } from "#enums/species";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-const TIMEOUT = 20 * 1000;
-
 // Bulbapedia Reference: https://bulbapedia.bulbagarden.net/wiki/Heal_Block_(move)
 describe("Moves - Heal Block", () => {
   let phaserGame: Phaser.Game;
@@ -53,8 +51,7 @@ describe("Moves - Heal Block", () => {
 
     expect(player.hp).toBe(1);
     expect(enemy.hp).toBeLessThan(enemy.getMaxHp());
-  }, TIMEOUT
-  );
+  });
 
   it("shouldn't stop Liquid Ooze from dealing damage", async() => {
     game.override.enemyAbility(Abilities.LIQUID_OOZE);
@@ -70,7 +67,7 @@ describe("Moves - Heal Block", () => {
 
     expect(player.isFullHp()).toBe(false);
     expect(enemy.isFullHp()).toBe(false);
-  }, TIMEOUT);
+  });
 
   it("should stop delayed heals, such as from Wish", async() => {
     await game.classicMode.startBattle([Species.CHARIZARD]);
@@ -89,7 +86,7 @@ describe("Moves - Heal Block", () => {
     }
 
     expect(player.hp).toBe(1);
-  }, TIMEOUT);
+  });
 
   it("should prevent Grassy Terrain from restoring HP", async() => {
     game.override.enemyAbility(Abilities.GRASSY_SURGE);
@@ -104,7 +101,7 @@ describe("Moves - Heal Block", () => {
     await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(player.hp).toBe(1);
-  }, TIMEOUT);
+  });
 
   it("should prevent healing from heal-over-time moves", async() => {
     await game.classicMode.startBattle([Species.CHARIZARD]);
@@ -118,7 +115,7 @@ describe("Moves - Heal Block", () => {
 
     expect(player.getTag(BattlerTagType.AQUA_RING)).toBeDefined();
     expect(player.hp).toBe(1);
-  }, TIMEOUT);
+  });
 
   it("should prevent abilities from restoring HP", async() => {
     game.override
@@ -135,7 +132,7 @@ describe("Moves - Heal Block", () => {
     await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(player.hp).toBe(1);
-  }, TIMEOUT);
+  });
 
   it("should stop healing from items", async() => {
     game.override.startingHeldItems([{name: "LEFTOVERS"}]);
@@ -149,5 +146,5 @@ describe("Moves - Heal Block", () => {
     await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(player.hp).toBe(1);
-  }, TIMEOUT);
+  });
 });


### PR DESCRIPTION
## Why am I making these changes?

some more sneaked in after changing the default-timeout to 20s. Possibly older PRs.

## What are the changes from a developer perspective?

remove references of setting manual test timeouts

## How to test the changes?

```
npm run test:silent
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
