### PR TITLE
[UI] Make Egg List and Egg Summary scrollable

### DIFF
--- a/src/ui/egg-list-ui-handler.ts
+++ b/src/ui/egg-list-ui-handler.ts
@@ -120,6 +120,9 @@ export default class EggListUiHandler extends MessageUiHandler {
     return true;
   }
 
+  /**
+   * Create the grid of egg icons to display
+   */
   private initEggIcons() {
     this.eggIcons = [];
     for (let i = 0; i < Math.min(this.ROWS * this.COLUMNS, this.scene.gameData.eggs.length); i++) {
@@ -133,6 +136,9 @@ export default class EggListUiHandler extends MessageUiHandler {
     }
   }
 
+  /**
+   * Show the grid of egg icons
+   */
   private updateEggIcons() {
     const indexOffset = this.scrollGridHandler.getItemOffset();
     const eggsToShow = Math.min(this.eggIcons.length, this.scene.gameData.eggs.length - indexOffset);
@@ -151,6 +157,10 @@ export default class EggListUiHandler extends MessageUiHandler {
     });
   }
 
+  /**
+   * Update the information panel with the information of the given egg
+   * @param index which egg in the list to display the info for
+   */
   private setEggDetails(index: number): void {
     const egg = this.scene.gameData.eggs[index];
     this.eggSprite.setFrame(`egg_${egg.getKey()}`);

--- a/src/ui/egg-list-ui-handler.ts
+++ b/src/ui/egg-list-ui-handler.ts
@@ -3,14 +3,18 @@ import { Mode } from "./ui";
 import PokemonIconAnimHandler, { PokemonIconAnimMode } from "./pokemon-icon-anim-handler";
 import { TextStyle, addTextObject } from "./text";
 import MessageUiHandler from "./message-ui-handler";
-import { Egg } from "../data/egg";
 import { addWindow } from "./ui-theme";
 import {Button} from "#enums/buttons";
 import i18next from "i18next";
+import { ScrollBar } from "./scroll-bar";
 
 export default class EggListUiHandler extends MessageUiHandler {
+  private readonly ROWS = 9;
+  private readonly COLUMNS = 11;
+
   private eggListContainer: Phaser.GameObjects.Container;
   private eggListIconContainer: Phaser.GameObjects.Container;
+  private eggIcons: Phaser.GameObjects.Sprite[];
   private eggSprite: Phaser.GameObjects.Sprite;
   private eggNameText: Phaser.GameObjects.Text;
   private eggDateText: Phaser.GameObjects.Text;
@@ -19,6 +23,8 @@ export default class EggListUiHandler extends MessageUiHandler {
   private eggListMessageBoxContainer: Phaser.GameObjects.Container;
 
   private cursorObj: Phaser.GameObjects.Image;
+  private scrollCursor: number;
+  private scrollBar: ScrollBar;
 
   private iconAnimHandler: PokemonIconAnimHandler;
 
@@ -64,7 +70,7 @@ export default class EggListUiHandler extends MessageUiHandler {
     this.eggGachaInfoText.setWordWrapWidth(540);
     this.eggListContainer.add(this.eggGachaInfoText);
 
-    this.eggListIconContainer = this.scene.add.container(115, 9);
+    this.eggListIconContainer = this.scene.add.container(113, 5);
     this.eggListContainer.add(this.eggListIconContainer);
 
     this.cursorObj = this.scene.add.image(0, 0, "select_cursor");
@@ -73,6 +79,9 @@ export default class EggListUiHandler extends MessageUiHandler {
 
     this.eggSprite = this.scene.add.sprite(54, 37, "egg");
     this.eggListContainer.add(this.eggSprite);
+
+    this.scrollBar = new ScrollBar(this.scene, 310, 5, 4, 170, this.ROWS);
+    this.eggListContainer.add(this.scrollBar);
 
     this.eggListMessageBoxContainer = this.scene.add.container(0, this.scene.game.canvas.height / 6);
     this.eggListMessageBoxContainer.setVisible(false);
@@ -87,32 +96,55 @@ export default class EggListUiHandler extends MessageUiHandler {
     this.eggListMessageBoxContainer.add(this.message);
 
     this.cursor = -1;
+    this.scrollCursor = 0;
   }
 
   show(args: any[]): boolean {
     super.show(args);
 
+    this.initEggIcons();
+
     this.getUi().bringToTop(this.eggListContainer);
 
     this.eggListContainer.setVisible(true);
 
-    let e = 0;
+    this.scrollBar.setTotalRows(Math.ceil(this.scene.gameData.eggs.length / this.COLUMNS));
 
-    for (const egg of this.scene.gameData.eggs) {
-      const x = (e % 11) * 18;
-      const y = Math.floor(e / 11) * 18;
+    this.updateEggIcons();
+    this.setCursor(0);
+    this.setScrollCursor(0);
+
+    return true;
+  }
+
+  private initEggIcons() {
+    this.eggIcons = [];
+    for (let i = 0; i < Math.min(this.ROWS * this.COLUMNS, this.scene.gameData.eggs.length); i++) {
+      const x = (i % this.COLUMNS) * 18;
+      const y = Math.floor(i / this.COLUMNS) * 18;
       const icon = this.scene.add.sprite(x - 2, y + 2, "egg_icons");
       icon.setScale(0.5);
       icon.setOrigin(0, 0);
-      icon.setFrame(egg.getKey());
       this.eggListIconContainer.add(icon);
-      this.iconAnimHandler.addOrUpdate(icon, PokemonIconAnimMode.NONE);
-      e++;
+      this.eggIcons.push(icon);
     }
+  }
 
-    this.setCursor(0);
+  private updateEggIcons() {
+    const indexOffset = this.scrollCursor * this.COLUMNS;
+    const eggsToShow = Math.min(this.eggIcons.length, this.scene.gameData.eggs.length - indexOffset);
 
-    return true;
+    this.eggIcons.forEach((icon, i) => {
+      this.iconAnimHandler.addOrUpdate(icon, PokemonIconAnimMode.NONE);
+      if (i < eggsToShow) {
+        const egg = this.scene.gameData.eggs[i + indexOffset];
+        icon.setFrame(egg.getKey());
+        icon.setVisible(true);
+      } else {
+        icon.setVisible(false);
+      }
+    });
+
   }
 
   processInput(button: Button): boolean {
@@ -125,27 +157,53 @@ export default class EggListUiHandler extends MessageUiHandler {
       ui.revertMode();
       success = true;
     } else {
-      const eggCount = this.eggListIconContainer.getAll().length;
-      const rows = Math.ceil(eggCount / 11);
-      const row = Math.floor(this.cursor / 11);
+      const totalEggs = this.scene.gameData.eggs.length;
+      const onScreenRows = Math.min(this.ROWS,  Math.ceil(this.eggIcons.length / this.COLUMNS));
+      const maxScrollCursor = Math.max(0, Math.ceil(totalEggs / this.COLUMNS) - onScreenRows);
+      const currentRowIndex = Math.floor(this.cursor / this.COLUMNS);
+      const currentColumnIndex = this.cursor % this.COLUMNS;
+      const lastEggIndex = Math.min(this.eggIcons.length - 1, totalEggs - maxScrollCursor * this.COLUMNS - 1);
       switch (button) {
       case Button.UP:
-        if (row) {
-          success = this.setCursor(this.cursor - 11);
+        if (currentRowIndex > 0) {
+          success = this.setCursor(this.cursor - this.COLUMNS);
+        } else if (this.scrollCursor > 0) {
+          success = this.setScrollCursor(this.scrollCursor - 1);
+        } else {
+          // wrap around to the last row
+          const newCursor = this.cursor + (onScreenRows - 1) * this.COLUMNS;
+          if (newCursor > lastEggIndex) {
+            success = this.setCursor(newCursor - this.COLUMNS);
+          } else {
+            success = this.setCursor(newCursor);
+          }
+          success = this.setScrollCursor(maxScrollCursor) || success;
         }
         break;
       case Button.DOWN:
-        if (row < rows - 2 || (row < rows - 1 && this.cursor % 11 <= (eggCount - 1) % 11)) {
-          success = this.setCursor(this.cursor + 11);
+        if (currentRowIndex < onScreenRows - 1) {
+          // Go down one row
+          success = this.setCursor(Math.min(this.cursor + this.COLUMNS, totalEggs - this.scrollCursor * this.COLUMNS - 1));
+        } else if (this.scrollCursor < maxScrollCursor) {
+          // Scroll down one row
+          success = this.setScrollCursor(this.scrollCursor + 1);
+        } else {
+          // Wrap around to the top row
+          success = this.setCursor(this.cursor % this.COLUMNS);
+          success = this.setScrollCursor(0) || success;
         }
         break;
       case Button.LEFT:
-        if (this.cursor % 11) {
+        if (currentColumnIndex > 0) {
           success = this.setCursor(this.cursor - 1);
+        } else {
+          success = this.setCursor(Math.min(this.cursor + this.COLUMNS - 1, lastEggIndex));
         }
         break;
       case Button.RIGHT:
-        if (this.cursor % 11 < (row < rows - 1 ? 10 : (eggCount - 1) % 11)) {
+        if (currentColumnIndex === this.COLUMNS - 1 || this.cursor === lastEggIndex) {
+          success = this.setCursor(this.cursor - currentColumnIndex);
+        } else {
           success = this.setCursor(this.cursor + 1);
         }
         break;
@@ -161,7 +219,8 @@ export default class EggListUiHandler extends MessageUiHandler {
     return success || error;
   }
 
-  setEggDetails(egg: Egg): void {
+  setEggDetails(index: number): void {
+    const egg = this.scene.gameData.eggs[index];
     this.eggSprite.setFrame(`egg_${egg.getKey()}`);
     this.eggNameText.setText(`${i18next.t("egg:egg")} (${egg.getEggDescriptor()})`);
     this.eggDateText.setText(
@@ -176,7 +235,7 @@ export default class EggListUiHandler extends MessageUiHandler {
     this.eggGachaInfoText.setText(egg.getEggTypeDescriptor(this.scene));
   }
 
-  setCursor(cursor: integer): boolean {
+  setCursor(cursor: number): boolean {
     let changed = false;
 
     const lastCursor = this.cursor;
@@ -184,24 +243,46 @@ export default class EggListUiHandler extends MessageUiHandler {
     changed = super.setCursor(cursor);
 
     if (changed) {
-      this.cursorObj.setPosition(114 + 18 * (cursor % 11), 10 + 18 * Math.floor(cursor / 11));
+      const icon = this.eggIcons[cursor];
+      this.cursorObj.setPosition(icon.x + 114, icon.y + 5);
 
       if (lastCursor > -1) {
         this.iconAnimHandler.addOrUpdate(this.eggListIconContainer.getAt(lastCursor) as Phaser.GameObjects.Sprite, PokemonIconAnimMode.NONE);
       }
       this.iconAnimHandler.addOrUpdate(this.eggListIconContainer.getAt(cursor) as Phaser.GameObjects.Sprite, PokemonIconAnimMode.ACTIVE);
 
-      this.setEggDetails(this.scene.gameData.eggs[cursor]);
+      this.setEggDetails(cursor + this.scrollCursor * this.COLUMNS);
     }
 
     return changed;
   }
 
+  setScrollCursor(cursor: number): boolean {
+    if (cursor === this.scrollCursor) {
+      return false;
+    }
+
+    this.scrollCursor = cursor;
+    this.scrollBar.setScrollCursor(cursor);
+
+    const newEggIndex = this.cursor + this.scrollCursor * this.COLUMNS;
+    if (newEggIndex >= this.scene.gameData.eggs.length) {
+      this.setCursor(this.scene.gameData.eggs.length - this.scrollCursor * this.COLUMNS - 1);
+    } else {
+      this.setEggDetails(newEggIndex);
+    }
+
+    this.updateEggIcons();
+    return true;
+  }
+
   clear(): void {
     super.clear();
+    this.setScrollCursor(0);
     this.cursor = -1;
     this.eggListContainer.setVisible(false);
     this.iconAnimHandler.removeAll();
     this.eggListIconContainer.removeAll(true);
+    this.eggIcons = [];
   }
 }

--- a/src/ui/egg-summary-ui-handler.ts
+++ b/src/ui/egg-summary-ui-handler.ts
@@ -3,7 +3,7 @@ import { Mode } from "./ui";
 import PokemonIconAnimHandler, { PokemonIconAnimMode } from "./pokemon-icon-anim-handler";
 import MessageUiHandler from "./message-ui-handler";
 import { getEggTierForSpecies } from "../data/egg";
-import {Button} from "#enums/buttons";
+import { Button } from "#enums/buttons";
 import PokemonHatchInfoContainer from "./pokemon-hatch-info-container";
 import { EggSummaryPhase } from "#app/phases/egg-summary-phase";
 import { EggHatchData } from "#app/data/egg-hatch-data";
@@ -29,6 +29,7 @@ export default class EggSummaryUiHandler extends MessageUiHandler {
   private summaryContainer: Phaser.GameObjects.Container;
   /** container for the each pokemon sprites and icons */
   private pokemonIconsContainer: Phaser.GameObjects.Container;
+  /** list of the containers added to pokemonIconsContainer for easier access */
   private pokemonContainers: HatchedPokemonContainer[];
 
   /** hatch info container that displays the current pokemon / hatch (main element on left hand side) */
@@ -101,6 +102,8 @@ export default class EggSummaryUiHandler extends MessageUiHandler {
     this.cursor = -1;
     this.scrollGridHandler.reset();
     this.summaryContainer.setVisible(false);
+    this.pokemonIconsContainer.removeAll(true);
+    this.pokemonContainers = [];
     this.eggHatchBg.setVisible(false);
     this.getUi().hideTooltip();
 
@@ -167,7 +170,10 @@ export default class EggSummaryUiHandler extends MessageUiHandler {
     return true;
   }
 
-  updatePokemonIcons(): void {
+  /**
+   * Show the grid of Pokemon icons
+   */
+  private updatePokemonIcons(): void {
     const itemOffset = this.scrollGridHandler.getItemOffset();
     const eggsToShow = Math.min(numRows * numCols, this.eggHatchData.length - itemOffset);
 

--- a/src/ui/hatched-pokemon-container.ts
+++ b/src/ui/hatched-pokemon-container.ts
@@ -1,0 +1,136 @@
+import { EggHatchData } from "#app/data/egg-hatch-data";
+import { Gender } from "#app/data/gender";
+import { getVariantTint } from "#app/data/variant";
+import { DexAttr } from "#app/system/game-data";
+import BattleScene from "#app/battle-scene";
+import PokemonSpecies from "#app/data/pokemon-species";
+import PokemonIconAnimHandler, { PokemonIconAnimMode } from "./pokemon-icon-anim-handler";
+
+/**
+ * A container for a Pokemon's sprite and icons to get displayed in the egg summary screen
+ * Shows the Pokemon's sprite, surrounded by icons for:
+ * shiny variant, hidden ability, new egg move, new catch
+ */
+export class HatchedPokemonContainer extends Phaser.GameObjects.Container {
+  public scene: BattleScene;
+  public species: PokemonSpecies;
+  public icon: Phaser.GameObjects.Sprite;
+  public shinyIcon: Phaser.GameObjects.Image;
+  public hiddenAbilityIcon: Phaser.GameObjects.Image;
+  public pokeballIcon: Phaser.GameObjects.Image;
+  public eggMoveIcon: Phaser.GameObjects.Image;
+
+  /**
+   * @param scene the current {@linkcode BattleScene}
+   * @param x x position
+   * @param y y position
+   * @param hatchData the {@linkcode EggHatchData} to load the icons and sprites for
+   */
+  constructor(scene: BattleScene, x: number, y: number, hatchData: EggHatchData) {
+    super(scene, x, y);
+
+    const displayPokemon = hatchData.pokemon;
+    this.species = displayPokemon.species;
+
+    const offset = 2;
+    const rightSideX = 12;
+    const species = displayPokemon.species;
+    const female = displayPokemon.gender === Gender.FEMALE;
+    const formIndex = displayPokemon.formIndex;
+    const variant = displayPokemon.variant;
+    const isShiny = displayPokemon.shiny;
+
+    // Pokemon sprite
+    const pokemonIcon = this.scene.add.sprite(-offset, offset, species.getIconAtlasKey(formIndex, isShiny, variant));
+    pokemonIcon.setScale(0.5);
+    pokemonIcon.setOrigin(0, 0);
+    pokemonIcon.setFrame(species.getIconId(female, formIndex, isShiny, variant));
+    this.icon = pokemonIcon;
+    this.checkIconId(female, formIndex, isShiny, variant);
+    this.add(this.icon);
+
+    // Shiny icon
+    this.shinyIcon = this.scene.add.image(rightSideX, offset, "shiny_star_small");
+    this.shinyIcon.setOrigin(0, 0);
+    this.shinyIcon.setScale(0.5);
+    this.add(this.shinyIcon);
+
+    // Hidden ability icon
+    const haIcon = this.scene.add.image(rightSideX, offset * 4, "ha_capsule");
+    haIcon.setOrigin(0, 0);
+    haIcon.setScale(0.5);
+    this.hiddenAbilityIcon = haIcon;
+    this.add(this.hiddenAbilityIcon);
+
+    // Pokeball icon
+    const pokeballIcon = this.scene.add.image(rightSideX, offset * 7, "icon_owned");
+    pokeballIcon.setOrigin(0, 0);
+    pokeballIcon.setScale(0.5);
+    this.pokeballIcon = pokeballIcon;
+    this.add(this.pokeballIcon);
+
+    // Egg move icon
+    const eggMoveIcon = this.scene.add.image(0, offset, "icon_egg_move");
+    eggMoveIcon.setOrigin(0, 0);
+    eggMoveIcon.setScale(0.5);
+    this.eggMoveIcon = eggMoveIcon;
+    this.add(this.eggMoveIcon);
+  }
+
+  /**
+   * Update the Pokemon's sprite and icons based on new hatch data
+   * Animates the pokemon icon if it has a new form or shiny variant
+   *
+   * @param hatchData the {@linkcode EggHatchData} to base the icons on
+   * @param iconAnimHandler the {@linkcode PokemonIconAnimHandler} to use to animate the sprites
+   */
+  updateAndAnimate(hatchData: EggHatchData, iconAnimHandler: PokemonIconAnimHandler) {
+    const displayPokemon = hatchData.pokemon;
+    this.species = displayPokemon.species;
+
+    const dexEntry = hatchData.dexEntryBeforeUpdate;
+    const caughtAttr = dexEntry.caughtAttr;
+    const newShiny = BigInt(1 << (displayPokemon.shiny ? 1 : 0));
+    const newVariant = BigInt(1 << (displayPokemon.variant + 4));
+    const newShinyOrVariant = ((newShiny & caughtAttr) === BigInt(0)) || ((newVariant & caughtAttr) === BigInt(0));
+    const newForm = (BigInt(1 << displayPokemon.formIndex) * DexAttr.DEFAULT_FORM & caughtAttr) === BigInt(0);
+
+    const female = displayPokemon.gender === Gender.FEMALE;
+    const formIndex = displayPokemon.formIndex;
+    const variant = displayPokemon.variant;
+    const isShiny = displayPokemon.shiny;
+
+    this.icon.setTexture(this.species.getIconAtlasKey(formIndex, isShiny, variant));
+    this.icon.setFrame(this.species.getIconId(female, formIndex, isShiny, variant));
+    this.checkIconId(female, formIndex, isShiny, variant);
+
+    this.shinyIcon.setVisible(displayPokemon.shiny);
+    this.shinyIcon.setTint(getVariantTint(displayPokemon.variant));
+
+    this.eggMoveIcon.setVisible(hatchData.eggMoveUnlocked);
+    this.hiddenAbilityIcon.setVisible(displayPokemon.abilityIndex === 2);
+    this.pokeballIcon.setVisible(!caughtAttr || newForm);
+
+    // add animation to the Pokemon sprite for new unlocks (new catch, new shiny or new form)
+    if (!caughtAttr || newShinyOrVariant || newForm) {
+      iconAnimHandler.addOrUpdate(this.icon, PokemonIconAnimMode.PASSIVE);
+    } else {
+      iconAnimHandler.addOrUpdate(this.icon, PokemonIconAnimMode.NONE);
+    }
+  }
+
+  /**
+   * Check if the given Pokemon icon exists, otherwise replace it with a default one
+   * @param female `true` to get the female icon
+   * @param formIndex the form index
+   * @param shiny whether the Pokemon is shiny
+   * @param variant the shiny variant
+   */
+  private checkIconId(female: boolean, formIndex: number, shiny: boolean, variant: number) {
+    if (this.icon.frame.name !== this.species.getIconId(female, formIndex, shiny, variant)) {
+      console.log(`${this.species.name}'s variant icon does not exist. Replacing with default.`);
+      this.icon.setTexture(this.species.getIconAtlasKey(formIndex, false, variant));
+      this.icon.setFrame(this.species.getIconId(female, formIndex, false, variant));
+    }
+  }
+}

--- a/src/ui/scroll-bar.ts
+++ b/src/ui/scroll-bar.ts
@@ -22,6 +22,8 @@ export class ScrollBar extends Phaser.GameObjects.Container {
     super(scene, x, y);
 
     this.maxRows = maxRows;
+    this.totalRows = maxRows;
+    this.currentRow = 0;
 
     const borderSize = 2;
     width = Math.max(width, 4);
@@ -46,8 +48,7 @@ export class ScrollBar extends Phaser.GameObjects.Container {
    */
   setScrollCursor(scrollCursor: number): void {
     this.currentRow = scrollCursor;
-    this.handleBody.y = 1 + (this.bg.displayHeight - 1 - this.handleBottom.displayHeight) / this.totalRows * this.currentRow;
-    this.handleBottom.y = this.handleBody.y + this.handleBody.displayHeight;
+    this.updateHandlePosition();
   }
 
   /**
@@ -59,7 +60,13 @@ export class ScrollBar extends Phaser.GameObjects.Container {
   setTotalRows(rows: number): void {
     this.totalRows = rows;
     this.handleBody.height = (this.bg.displayHeight - 1 - this.handleBottom.displayHeight) * this.maxRows / this.totalRows;
+    this.updateHandlePosition();
 
     this.setVisible(this.totalRows > this.maxRows);
+  }
+
+  private updateHandlePosition(): void {
+    this.handleBody.y = 1 + (this.bg.displayHeight - 1 - this.handleBottom.displayHeight) / this.totalRows * this.currentRow;
+    this.handleBottom.y = this.handleBody.y + this.handleBody.displayHeight;
   }
 }

--- a/src/ui/scrollable-grid-handler.ts
+++ b/src/ui/scrollable-grid-handler.ts
@@ -1,0 +1,197 @@
+import { Button } from "#enums/buttons";
+import UiHandler from "#app/ui/ui-handler";
+import { ScrollBar } from "#app/ui/scroll-bar";
+
+type UpdateGridCallbackFunction = () => void;
+type UpdateDetailsCallbackFunction = (index: number) => void;
+
+/**
+ * A helper class to handle navigation through a grid of elements that can scroll vertically
+ * Needs to be used by a {@linkcode UiHandler}
+ * How to use:
+ * - in `UiHandler.setup`: Initialize with the {@linkcode UiHandler} that handles the grid,
+ * the number of rows and columns that can be shown at once,
+ * an optional {@linkcode ScrollBar}, and optional callbacks that will get called after scrolling
+ * - in `UiHandler.show`: Set `setTotalElements` to the total number of elements in the list to display
+ * - in `UiHandler.processInput`: call `processNavigationInput` to have it handle the cursor updates while calling the defined callbacks
+ * - in `UiHandler.clear`: call `reset`
+ */
+export default class ScrollableGridUiHandler {
+  private readonly ROWS: number;
+  private readonly COLUMNS: number;
+  private handler: UiHandler;
+  private totalElements: number;
+  private cursor: number;
+  private scrollCursor: number;
+  private scrollBar?: ScrollBar;
+  private updateGridCallback?: UpdateGridCallbackFunction;
+  private updateDetailsCallback?: UpdateDetailsCallbackFunction;
+
+  /**
+   * @param scene the {@linkcode UiHandler} that needs its cursor updated based on the scrolling
+   * @param rows the maximum number of rows shown at once
+   * @param columns the maximum number of columns shown at once
+   * @param updateGridCallback optional function that will get called if the whole grid needs to get updated
+   * @param updateDetailsCallback optional function that will get called if a single element's information needs to get updated
+   */
+  constructor(handler: UiHandler, rows: number, columns: number) {
+    this.handler = handler;
+    this.ROWS = rows;
+    this.COLUMNS = columns;
+    this.scrollCursor = 0;
+    this.cursor = 0;
+    this.totalElements = rows * columns; // default value for the number of elements
+  }
+
+  /**
+   * Set a scrollBar to get updated with the scrolling
+   * @param scrollBar {@linkcode ScrollBar}
+   * @returns this
+   */
+  withScrollBar(scrollBar: ScrollBar): ScrollableGridUiHandler {
+    this.scrollBar = scrollBar;
+    this.scrollBar.setTotalRows(Math.ceil(this.totalElements / this.COLUMNS));
+    return this;
+  }
+
+  /**
+   * Set function that will get called if the whole grid needs to get updated
+   * @param callback {@linkcode UpdateGridCallbackFunction}
+   * @returns this
+   */
+  withUpdateGridCallBack(callback: UpdateGridCallbackFunction): ScrollableGridUiHandler {
+    this.updateGridCallback = callback;
+    return this;
+  }
+
+  /**
+   * Set function that will get called if a single element in the grid needs to get updated
+   * @param callback {@linkcode UpdateDetailsCallbackFunction}
+   * @returns this
+   */
+  withUpdateSingleElementCallback(callback: UpdateDetailsCallbackFunction): ScrollableGridUiHandler {
+    this.updateDetailsCallback = callback;
+    return this;
+  }
+
+  /**
+   * @param totalElements the total number of elements that the grid needs to display
+   */
+  setTotalElements(totalElements: number) {
+    this.totalElements = totalElements;
+    if (this.scrollBar) {
+      this.scrollBar.setTotalRows(Math.ceil(this.totalElements / this.COLUMNS));
+    }
+    this.setScrollCursor(0);
+  }
+
+  /**
+   * @returns how many elements are hidden due to scrolling
+   */
+  getItemOffset(): number {
+    return this.scrollCursor * this.COLUMNS;
+  }
+
+  /**
+   * Update the cursor and scrollCursor based on user input
+   * @param button the button that was pressed
+   * @returns `true` if either the cursor or scrollCursor was updated
+   */
+  processInput(button: Button): boolean {
+    let success = false;
+    const onScreenRows = Math.min(this.ROWS, Math.ceil(this.totalElements / this.COLUMNS));
+    const maxScrollCursor = Math.max(0, Math.ceil(this.totalElements / this.COLUMNS) - onScreenRows);
+    const currentRowIndex = Math.floor(this.cursor / this.COLUMNS);
+    const currentColumnIndex = this.cursor % this.COLUMNS;
+    const itemOffset = this.scrollCursor * this.COLUMNS;
+    const lastVisibleIndex = Math.min(this.totalElements - 1, this.totalElements - maxScrollCursor * this.COLUMNS - 1);
+    switch (button) {
+    case Button.UP:
+      if (currentRowIndex > 0) {
+        success = this.setCursor(this.cursor - this.COLUMNS);
+      } else if (this.scrollCursor > 0) {
+        success = this.setScrollCursor(this.scrollCursor - 1);
+      } else {
+        // wrap around to the last row
+        let newCursor = this.cursor + (onScreenRows - 1) * this.COLUMNS;
+        if (newCursor > lastVisibleIndex) {
+          newCursor -= this.COLUMNS;
+        }
+        success = this.setScrollCursor(maxScrollCursor, newCursor);
+      }
+      break;
+    case Button.DOWN:
+      if (currentRowIndex < onScreenRows - 1) {
+        // Go down one row
+        success = this.setCursor(Math.min(this.cursor + this.COLUMNS, this.totalElements - itemOffset - 1));
+      } else if (this.scrollCursor < maxScrollCursor) {
+        // Scroll down one row
+        success = this.setScrollCursor(this.scrollCursor + 1);
+      } else {
+        // Wrap around to the top row
+        success = this.setScrollCursor(0, this.cursor % this.COLUMNS);
+      }
+      break;
+    case Button.LEFT:
+      if (currentColumnIndex > 0) {
+        success = this.setCursor(this.cursor - 1);
+      } else if (this.scrollCursor === maxScrollCursor && currentRowIndex === onScreenRows - 1) {
+        success = this.setCursor(lastVisibleIndex);
+      } else {
+        success = this.setCursor(this.cursor + this.COLUMNS - 1);
+      }
+      break;
+    case Button.RIGHT:
+      if (currentColumnIndex < this.COLUMNS - 1 && this.cursor + itemOffset < this.totalElements - 1) {
+        success = this.setCursor(this.cursor + 1);
+      } else {
+        success = this.setCursor(this.cursor - currentColumnIndex);
+      }
+      break;
+    }
+    return success;
+  }
+
+  /**
+   * Reset the scrolling
+   */
+  reset(): void {
+    this.setScrollCursor(0);
+    this.setCursor(0);
+  }
+
+  private setCursor(cursor: number): boolean {
+    this.cursor = cursor;
+    return this.handler.setCursor(cursor);
+  }
+
+  private setScrollCursor(scrollCursor: number, cursor?: number): boolean {
+    const scrollChanged = scrollCursor !== this.scrollCursor;
+
+    // update the scrolling cursor
+    if (scrollChanged) {
+      this.scrollCursor = scrollCursor;
+      if (this.scrollBar) {
+        this.scrollBar.setScrollCursor(scrollCursor);
+      }
+      if (this.updateGridCallback) {
+        this.updateGridCallback();
+      }
+    }
+
+    let cursorChanged = false;
+    const newElementIndex = this.cursor + this.scrollCursor * this.COLUMNS;
+    if (cursor !== undefined) {
+      cursorChanged = this.setCursor(cursor);
+    } else if (newElementIndex >= this.totalElements) {
+      // make sure the cursor does not go past the end of the list
+      cursorChanged = this.setCursor(this.totalElements - this.scrollCursor * this.COLUMNS - 1);
+    } else if (scrollChanged && this.updateDetailsCallback) {
+      // scroll was changed but not the normal cursor, update the selected element
+      this.updateDetailsCallback(newElementIndex);
+    }
+
+    return scrollChanged || cursorChanged;
+  }
+
+}


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
- cursor wrap around in Egg List and Egg Summary 
- Egg List and Egg Summary can go past 99 and will have a scrollbar and allow scrolling if so
- Removed egg rarity background in egg summary

## Why am I making these changes?
With the addition of MEs, some of them give specific eggs as a reward which makes it possible that a player holds more than 99 eggs at the same time.
This PR makes sure the UI still works nicely in this case
The egg rarity background removal in egg summary was discussed and agreed upon a while ago as it is confusing and does not give much useful information, this was a good opportunity to do it

<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What are the changes from a developer perspective?
- Created `ScrollableGridUiHandler` class that can handle all cursor update calculations for scrollable grids or lists in the game (other grids in the game will get updated to use this in a future PR)
- For Egg Summary, created `HatchedPokemonContainer` that holds the icons relevant to each hatched Pokemon instead of working with separate lists of icons
- Used the `ScrollableGridUiHandler` in both Egg Summary and Egg List
- For both of these UIs, the sprites and icons needed to fill up the grid are created only once. When scrolling happens, the sprites get updated and icons shown or hidden as needed. This avoids destroying and recreating UI elements all the time when scrolling the view

<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos

<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

Before
<img width="300" alt="_alist_before" src="https://github.com/user-attachments/assets/732244e9-179e-41e4-9f00-d8014b4b15fb"> <img width="300" alt="_asummary_before" src="https://github.com/user-attachments/assets/addc2d84-70e9-448c-9204-388bc755a8bf">

After

https://github.com/user-attachments/assets/290a2908-1c4c-4f50-9760-7f2aaf6aff53


After Egg list Default / Legacy (egg summary is the same in legacy and default theme)
<img width="300" alt="egg-list" src="https://github.com/user-attachments/assets/950597a6-7ce1-4ec3-a974-0e62251255b6"><img width="300" alt="egg-list-legacy" src="https://github.com/user-attachments/assets/d9962d69-8a6d-4ba2-8bc3-aeadb56724b0">



## How to test the changes?

[use a save file with lots of eggs](https://github.com/user-attachments/files/17101245/data_eggs.txt) or get more than 99 eggs with overrides:
```
  EGG_FREE_GACHA_PULLS_OVERRIDE: true,
  EGG_IMMEDIATE_HATCH_OVERRIDE: true,
  EGG_GACHA_PULL_COUNT_OVERRIDE: 115
```
- Play around in the egg list
- Hatch the eggs with `EGG_IMMEDIATE_HATCH_OVERRIDE` and play with the egg summary
- Make sure everything gets updated properly when moving around in various ways, especially in egg summary. Also try to pay attention to the sound effects and cries
- Also test with less than 99 eggs to make sure the scroll bar is hidden and wrap around still works, etc

<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [X] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR? #4370 can get closed once this gets in
- [ ] The PR is self-contained and cannot be split into smaller PRs? kinda '-'
- [X] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue? 💀 
~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
