### PR TITLE
[Enhancement] Remove unnecessary loading of trainer sprites in loading scene

### DIFF
--- a/src/loading-scene.ts
+++ b/src/loading-scene.ts
@@ -1,5 +1,4 @@
 import { GachaType } from "./enums/gacha-types";
-import { trainerConfigs } from "./data/trainer-config";
 import { getBiomeHasProps } from "./field/arena";
 import CacheBustedLoaderPlugin from "./plugins/cache-busted-loader-plugin";
 import { SceneBase } from "./scene-base";
@@ -21,7 +20,6 @@ import i18next from "i18next";
 import { initStatsKeys } from "./ui/game-stats-ui-handler";
 import { initVouchers } from "./system/voucher";
 import { Biome } from "#enums/biome";
-import { TrainerType } from "#enums/trainer-type";
 import {initMysteryEncounters} from "#app/data/mystery-encounters/mystery-encounters";
 
 export class LoadingScene extends SceneBase {
@@ -207,14 +205,6 @@ export class LoadingScene extends SceneBase {
     this.loadAtlas("trainer_m_back_pb", "trainer");
     this.loadAtlas("trainer_f_back", "trainer");
     this.loadAtlas("trainer_f_back_pb", "trainer");
-
-    Utils.getEnumValues(TrainerType).map(tt => {
-      const config = trainerConfigs[tt];
-      this.loadAtlas(config.getSpriteKey(), "trainer");
-      if (config.doubleOnly || config.hasDouble) {
-        this.loadAtlas(config.getSpriteKey(true), "trainer");
-      }
-    });
 
     // Load character sprites
     this.loadAtlas("c_rival_m", "character", "rival_m");

--- a/src/ui/run-info-ui-handler.ts
+++ b/src/ui/run-info-ui-handler.ts
@@ -288,25 +288,29 @@ export default class RunInfoUiHandler extends UiHandler {
   private parseTrainerDefeat(enemyContainer: Phaser.GameObjects.Container) {
     // Creating the trainer sprite and adding it to enemyContainer
     const tObj = this.runInfo.trainer.toTrainer(this.scene);
-    const tObjSpriteKey = tObj.config.getSpriteKey(this.runInfo.trainer.variant === TrainerVariant.FEMALE, false);
-    const tObjSprite = this.scene.add.sprite(0, 5, tObjSpriteKey);
-    if (this.runInfo.trainer.variant === TrainerVariant.DOUBLE) {
-      const doubleContainer = this.scene.add.container(5, 8);
-      tObjSprite.setPosition(-3, -3);
-      const tObjPartnerSpriteKey = tObj.config.getSpriteKey(true, true);
-      const tObjPartnerSprite = this.scene.add.sprite(5, -3, tObjPartnerSpriteKey);
-      // Double Trainers have smaller sprites than Single Trainers
-      tObjPartnerSprite.setScale(0.20);
-      tObjSprite.setScale(0.20);
-      doubleContainer.add(tObjSprite);
-      doubleContainer.add(tObjPartnerSprite);
-      doubleContainer.setPosition(12, 38);
-      enemyContainer.add(doubleContainer);
-    } else {
-      tObjSprite.setScale(0.35, 0.35);
-      tObjSprite.setPosition(12, 28);
-      enemyContainer.add(tObjSprite);
-    }
+
+    // Loads trainer assets on demand, as they are not loaded by default in the scene
+    tObj.config.loadAssets(this.scene, this.runInfo.trainer.variant).then(() => {
+      const tObjSpriteKey = tObj.config.getSpriteKey(this.runInfo.trainer.variant === TrainerVariant.FEMALE, false);
+      const tObjSprite = this.scene.add.sprite(0, 5, tObjSpriteKey);
+      if (this.runInfo.trainer.variant === TrainerVariant.DOUBLE) {
+        const doubleContainer = this.scene.add.container(5, 8);
+        tObjSprite.setPosition(-3, -3);
+        const tObjPartnerSpriteKey = tObj.config.getSpriteKey(true, true);
+        const tObjPartnerSprite = this.scene.add.sprite(5, -3, tObjPartnerSpriteKey);
+        // Double Trainers have smaller sprites than Single Trainers
+        tObjPartnerSprite.setScale(0.20);
+        tObjSprite.setScale(0.20);
+        doubleContainer.add(tObjSprite);
+        doubleContainer.add(tObjPartnerSprite);
+        doubleContainer.setPosition(12, 38);
+        enemyContainer.add(doubleContainer);
+      } else {
+        tObjSprite.setScale(0.35, 0.35);
+        tObjSprite.setPosition(12, 28);
+        enemyContainer.add(tObjSprite);
+      }
+    });
 
     // Determining which Terastallize Modifier belongs to which Pokemon
     // Creates a dictionary {PokemonId: TeraShardType}


### PR DESCRIPTION
Removes ~5 MB of image data (not counting actual heap usage) from being loaded on every session load. These images are already loaded on demand when trainers are spawned, there is no need to keep all of these assets loaded for every session.


https://github.com/user-attachments/assets/bcc05970-703f-4062-a205-55375ae9504e


https://github.com/user-attachments/assets/0b9c7509-2cc4-44fc-a130-a0b1fee7ebc4


https://github.com/user-attachments/assets/4bc9c14d-b30e-4bc8-ac14-c8811b491897

