### PR TITLE
[Beta][P3 Bug] Fix typo in autotomize add message

### DIFF
--- a/src/locales/en/battler-tags.json
+++ b/src/locales/en/battler-tags.json
@@ -74,5 +74,5 @@
   "substituteOnAdd": "{{pokemonNameWithAffix}} put in a substitute!",
   "substituteOnHit": "The substitute took damage for {{pokemonNameWithAffix}}!",
   "substituteOnRemove": "{{pokemonNameWithAffix}}'s substitute faded!",
-  "autotomizeOnAdd": "{{pokemonNameWIthAffix}} became nimble!"
+  "autotomizeOnAdd": "{{pokemonNameWithAffix}} became nimble!"
 }


### PR DESCRIPTION
## What are the changes the user will see?
Autotomize user will now display name properly

## Why am I making these changes?
Typo caused name to not display properly

## What are the changes from a developer perspective?
`pokemonNameWIthAffix` -> `pokemonNameWithAffix`

### Screenshots/Videos
n/a

## How to test the changes?
n/a

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
