### PR TITLE
[Refactor][Localization] Better handling for `StatusEffect.NONE` with i18n

### DIFF
--- a/src/data/status-effect.ts
+++ b/src/data/status-effect.ts
@@ -44,6 +44,10 @@ function getStatusEffectMessageKey(statusEffect: StatusEffect | undefined): stri
 }
 
 export function getStatusEffectObtainText(statusEffect: StatusEffect | undefined, pokemonNameWithAffix: string, sourceText?: string): string {
+  if (statusEffect === StatusEffect.NONE) {
+    return "";
+  }
+
   if (!sourceText) {
     const i18nKey = `${getStatusEffectMessageKey(statusEffect)}.obtain`as ParseKeys;
     return i18next.t(i18nKey, { pokemonNameWithAffix: pokemonNameWithAffix });
@@ -53,21 +57,33 @@ export function getStatusEffectObtainText(statusEffect: StatusEffect | undefined
 }
 
 export function getStatusEffectActivationText(statusEffect: StatusEffect, pokemonNameWithAffix: string): string {
+  if (statusEffect === StatusEffect.NONE) {
+    return "";
+  }
   const i18nKey = `${getStatusEffectMessageKey(statusEffect)}.activation` as ParseKeys;
   return i18next.t(i18nKey, { pokemonNameWithAffix: pokemonNameWithAffix });
 }
 
 export function getStatusEffectOverlapText(statusEffect: StatusEffect, pokemonNameWithAffix: string): string {
+  if (statusEffect === StatusEffect.NONE) {
+    return "";
+  }
   const i18nKey = `${getStatusEffectMessageKey(statusEffect)}.overlap` as ParseKeys;
   return i18next.t(i18nKey, { pokemonNameWithAffix: pokemonNameWithAffix });
 }
 
 export function getStatusEffectHealText(statusEffect: StatusEffect, pokemonNameWithAffix: string): string {
+  if (statusEffect === StatusEffect.NONE) {
+    return "";
+  }
   const i18nKey = `${getStatusEffectMessageKey(statusEffect)}.heal` as ParseKeys;
   return i18next.t(i18nKey, { pokemonNameWithAffix: pokemonNameWithAffix });
 }
 
 export function getStatusEffectDescriptor(statusEffect: StatusEffect): string {
+  if (statusEffect === StatusEffect.NONE) {
+    return "";
+  }
   const i18nKey = `${getStatusEffectMessageKey(statusEffect)}.description` as ParseKeys;
   return i18next.t(i18nKey);
 }

--- a/src/locales/de/status-effect.json
+++ b/src/locales/de/status-effect.json
@@ -1,12 +1,6 @@
 {
   "none": {
-    "name": "None",
-    "description": "",
-    "obtain": "",
-    "obtainSource": "",
-    "activation": "",
-    "overlap": "",
-    "heal": ""
+    "name": "None"
   },
   "poison": {
     "name": "Gift",

--- a/src/locales/en/status-effect.json
+++ b/src/locales/en/status-effect.json
@@ -1,12 +1,6 @@
 {
   "none": {
-    "name": "None",
-    "description": "",
-    "obtain": "",
-    "obtainSource": "",
-    "activation": "",
-    "overlap": "",
-    "heal": ""
+    "name": "None"
   },
   "poison": {
     "name": "Poison",

--- a/src/locales/es/status-effect.json
+++ b/src/locales/es/status-effect.json
@@ -1,12 +1,6 @@
 {
   "none": {
-    "name": "Ninguno",
-    "description": "",
-    "obtain": "",
-    "obtainSource": "",
-    "activation": "",
-    "overlap": "",
-    "heal": ""
+    "name": "Ninguno"
   },
   "poison": {
     "name": "Envenenamiento",

--- a/src/locales/fr/status-effect.json
+++ b/src/locales/fr/status-effect.json
@@ -1,12 +1,6 @@
 {
   "none": {
-    "name": "Aucun",
-    "description": "",
-    "obtain": "",
-    "obtainSource": "",
-    "activation": "",
-    "overlap": "",
-    "heal": ""
+    "name": "Aucun"
   },
   "poison": {
     "name": "Empoisonnement",

--- a/src/locales/it/status-effect.json
+++ b/src/locales/it/status-effect.json
@@ -1,11 +1,5 @@
 {
   "none": {
-    "name": "None",
-    "description": "",
-    "obtain": "",
-    "obtainSource": "",
-    "activation": "",
-    "overlap": "",
-    "heal": ""
+    "name": "None"
   }
 }

--- a/src/locales/ja/status-effect.json
+++ b/src/locales/ja/status-effect.json
@@ -1,12 +1,6 @@
 {
   "none": {
-    "name": "なし",
-    "description": "",
-    "obtain": "",
-    "obtainSource": "",
-    "activation": "",
-    "overlap": "",
-    "heal": ""
+    "name": "なし"
   },
   "poison": {
     "name": "どく",

--- a/src/locales/ko/status-effect.json
+++ b/src/locales/ko/status-effect.json
@@ -1,12 +1,6 @@
 {
   "none": {
-    "name": "없음",
-    "description": "",
-    "obtain": "",
-    "obtainSource": "",
-    "activation": "",
-    "overlap": "",
-    "heal": ""
+    "name": "없음"
   },
   "poison": {
     "name": "독",

--- a/src/locales/pt_BR/status-effect.json
+++ b/src/locales/pt_BR/status-effect.json
@@ -1,12 +1,6 @@
 {
   "none": {
-    "name": "Nenhum",
-    "description": "",
-    "obtain": "",
-    "obtainSource": "",
-    "activation": "",
-    "overlap": "",
-    "heal": ""
+    "name": "Nenhum"
   },
   "poison": {
     "name": "Envenenamento",

--- a/src/locales/zh_CN/status-effect.json
+++ b/src/locales/zh_CN/status-effect.json
@@ -1,12 +1,6 @@
 {
   "none": {
-    "name": "无",
-    "description": "",
-    "obtain": "",
-    "obtainSource": "",
-    "activation": "",
-    "overlap": "",
-    "heal": ""
+    "name": "无"
   },
   "poison": {
     "name": "中毒",

--- a/src/locales/zh_TW/status-effect.json
+++ b/src/locales/zh_TW/status-effect.json
@@ -1,12 +1,6 @@
 {
   "none": {
-    "name": "無",
-    "description": "",
-    "obtain": "",
-    "obtainSource": "",
-    "activation": "",
-    "overlap": "",
-    "heal": ""
+    "name": "無"
   },
   "poison": {
     "name": "中毒",

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -30,7 +30,10 @@ import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
  * }
  * ```
  */
-const overrides = {} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
+const overrides = {
+  OPP_MOVESET_OVERRIDE: Moves.THUNDER_WAVE,
+  MOVESET_OVERRIDE: [Moves.REFRESH]
+} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
 
 /**
  * If you need to add Overrides values for local testing do that inside {@linkcode overrides}

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -30,10 +30,7 @@ import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
  * }
  * ```
  */
-const overrides = {
-  OPP_MOVESET_OVERRIDE: Moves.THUNDER_WAVE,
-  MOVESET_OVERRIDE: [Moves.REFRESH]
-} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
+const overrides = {} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
 
 /**
  * If you need to add Overrides values for local testing do that inside {@linkcode overrides}

--- a/src/test/localization/status-effect.test.ts
+++ b/src/test/localization/status-effect.test.ts
@@ -18,44 +18,45 @@ describe("status-effect", () => {
       mockI18next();
 
       const text = getStatusEffectObtainText(statusEffect, pokemonName);
-      expect(text).toBe("statusEffect:none.obtain");
+      console.log("text:", text);
+      expect(text).toBe("");
 
       const emptySourceText = getStatusEffectObtainText(statusEffect, pokemonName, "");
-      expect(emptySourceText).toBe("statusEffect:none.obtain");
+      expect(emptySourceText).toBe("");
     });
 
     it("should return the source-obtain text", () => {
       mockI18next();
 
       const text = getStatusEffectObtainText(statusEffect, pokemonName, sourceText);
-      expect(text).toBe("statusEffect:none.obtainSource");
+      expect(text).toBe("");
 
       const emptySourceText = getStatusEffectObtainText(statusEffect, pokemonName, "");
-      expect(emptySourceText).not.toBe("statusEffect:none.obtainSource");
+      expect(emptySourceText).toBe("");
     });
 
     it("should return the activation text", () => {
       mockI18next();
       const text = getStatusEffectActivationText(statusEffect, pokemonName);
-      expect(text).toBe("statusEffect:none.activation");
+      expect(text).toBe("");
     });
 
     it("should return the overlap text", () => {
       mockI18next();
       const text = getStatusEffectOverlapText(statusEffect, pokemonName);
-      expect(text).toBe("statusEffect:none.overlap");
+      expect(text).toBe("");
     });
 
     it("should return the heal text", () => {
       mockI18next();
       const text = getStatusEffectHealText(statusEffect, pokemonName);
-      expect(text).toBe("statusEffect:none.heal");
+      expect(text).toBe("");
     });
 
     it("should return the descriptor", () => {
       mockI18next();
       const text = getStatusEffectDescriptor(statusEffect);
-      expect(text).toBe("statusEffect:none.description");
+      expect(text).toBe("");
     });
   });
 


### PR DESCRIPTION
Found this inconvenience for translators with @CodeTappert 

## What are the changes the user will see?

None

## Why am I making these changes?

Currently there is the necessity in translation of a few empty keys. 
Quite inconvenient and useless. Reason for that is to handle the theoretical situation of `statusEffect:none.<obtain | heal etc.>` <sub>Which realistically never occurs afaik</sub>

## What are the changes from a developer perspective?

1. All `getStatusEffect<...>Text()` methods now check for `StatusEffect.NONE` to simply return an empty-string `""`
2. Removed all those (now) obsolete keys from `status-effect.json` file/s
3. Fixed the tests *(Which ironically will be removed in i18n-lazy-load anyway)*

## How to test the changes?

You can't really. Just set a status and remove it again and see if something odd happens.

#### Example Overrides
```ts
const overrides = {
  OPP_MOVESET_OVERRIDE: Moves.THUNDER_WAVE,
  MOVESET_OVERRIDE: [Moves.REFRESH]
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```
## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
