### PR TITLE
[Localization] fix wrong parameter key (itemname -> itemName)

### DIFF
--- a/src/locales/ko/battle.json
+++ b/src/locales/ko/battle.json
@@ -68,7 +68,7 @@
   "turnEndHpRestore": "{{pokemonName}}의\n체력이 회복되었다!",
   "hpIsFull": "그러나 {{pokemonName}}의\n체력이 가득 찬 상태다!",
   "skipItemQuestion": "아이템을 받지 않고 넘어가시겠습니까?",
-  "itemStackFull": "{{fullItemName}}의 소지 한도에 도달했습니다.\n{{itemname}}[[를]] 대신 받습니다.",
+  "itemStackFull": "{{fullItemName}}의 소지 한도에 도달했습니다.\n{{itemName}}[[를]] 대신 받습니다.",
   "eggHatching": "어라…?",
   "eggSkipPrompt": "알 부화 요약 화면으로 바로 넘어가시겠습니까?",
   "ivScannerUseQuestion": "{{pokemonName}}에게 개체값탐지기를 사용하시겠습니까?",


### PR DESCRIPTION
## What are the changes the user will see?
See right item name when user's item stack is full.

## Why am I making these changes?
Only Korean had wrong parameter case.

## What are the changes from a developer perspective?
change param name -> itemname to itemName

### Screenshots/Videos
![image](https://github.com/user-attachments/assets/824e5ca7-cc9b-42be-863c-94a4b7bde7b1)
Before

![image](https://github.com/user-attachments/assets/a2f935ea-b65d-437c-b65f-fa135d6fb33f)
After

## How to test the changes?
Manually. (I tested with ME trash-to-treasure, running 2 waves.)
```Typescript
  readonly MYSTERY_ENCOUNTER_RATE_OVERRIDE: number | null = 256;
  readonly MYSTERY_ENCOUNTER_TIER_OVERRIDE: MysteryEncounterTier | null = null;
  readonly MYSTERY_ENCOUNTER_OVERRIDE: MysteryEncounterType | null = MysteryEncounterType.TRASH_TO_TREASURE;
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
