### PR TITLE
[Localization] A minor translation fix for Korean locales

### DIFF
--- a/src/locales/ko/modifier-type.json
+++ b/src/locales/ko/modifier-type.json
@@ -50,9 +50,9 @@
       "description": "{{battleCount}}번의 배틀 동안 더블 배틀이 등장할 확률이 4배가 된다."
     },
     "TempStatStageBoosterModifierType": {
-      "description": "자신의 모든 포켓몬이 5번의 배틀 동안 {{stat}}[[가]] {{amount}}단계 증가한다.",
+      "description": "자신의 모든 포켓몬이 5번의 배틀 동안 {{stat}}[[가]] {{amount}} 증가한다.",
       "extra": {
-        "stage": "1 스테이지",
+        "stage": "1단계",
         "percentage": "30%"
       }
     },


### PR DESCRIPTION
## What are the changes the user will see?
A minor fix for Korean translation

## Why am I making these changes?
![캡처](https://github.com/user-attachments/assets/c5428967-337e-4d8d-ad32-333e609f8149)
Currently, it marks as "1 스테이지단계" or "30%단계", but in Korean "단계" means "stage" and "스테이지" is a direct transliteration for the word "stage". So I erased the word "단계".

## How to test the changes?
Just a minor translation fix 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
