### PR TITLE
[Bug][Beta] Torment Lapse Condition Fix

### DIFF
--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -933,7 +933,7 @@ class ImprisonTag extends ArenaTrapTag {
   }
 
   /**
-   * Helper function that retrieves the Pokemon effected
+   * Helper function that retrieves the Pokemon affected
    * @param {BattleScene} scene medium to retrieve the involved Pokemon
    * @returns list of PlayerPokemon or EnemyPokemon on the field
    */

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2468,7 +2468,7 @@ export class TormentTag extends MoveRestrictionBattlerTag {
    * @returns `true` if still present | `false` if not
    */
   override lapse(pokemon: Pokemon, _tagType: BattlerTagLapseType): boolean {
-    return !pokemon.isActive(true);
+    return pokemon.isActive(true);
   }
 
   /**


### PR DESCRIPTION
## What are the changes the user will see?
Torment will stick on the target.

## Why am I making these changes?
My bug, my mistake.

## What are the changes from a developer perspective?
The lapse condition for Torment should return True if the Pokemon is active on the field, and false if the Pokemon was not active on the field. 
Small typo in Imprison documentation corrected. 

## How to test the changes?
Use torment.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
