### PR TITLE
[Moves] Fully Implement Syrup Bomb

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2605,10 +2605,8 @@ export class SyrupBombTag extends BattlerTag {
    * @param {Pokemon} pokemon the target Pokemon
    */
   override onAdd(pokemon: Pokemon) {
-    if (Utils.isNullOrUndefined(pokemon.getTag(BattlerTagType.SYRUP_BOMB))) {
-      super.onAdd(pokemon);
-      pokemon.scene.queueMessage(i18next.t("battlerTags:syrupBombOnAdd", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }));
-    }
+    super.onAdd(pokemon);
+    pokemon.scene.queueMessage(i18next.t("battlerTags:syrupBombOnAdd", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }));
   }
 
   /**

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2589,11 +2589,21 @@ export class ImprisonTag extends MoveRestrictionBattlerTag {
   }
 }
 
+/**
+ * Battler Tag that applies the effects of Syrup Bomb to the target Pokemon
+ * For three turns, starting from the turn of hit, at the end of each turn, the target Pokemon's speed will decrease by 1.
+ * The tag can also expire by taking the target Pokemon off the field.
+ */
 export class SyrupBombTag extends BattlerTag {
   constructor() {
     super(BattlerTagType.SYRUP_BOMB, BattlerTagLapseType.TURN_END, 3, Moves.SYRUP_BOMB);
   }
 
+  /**
+   * Adds the Syrup Bomb battler tag to the target Pokemon
+   * In addition, this also contains a check for a pre-existing Syrup Bomb tag on the target Pokemon to determine whether the tag should be applied or not
+   * @param {Pokemon} pokemon the target Pokemon
+   */
   override onAdd(pokemon: Pokemon) {
     if (Utils.isNullOrUndefined(pokemon.getTag(BattlerTagType.SYRUP_BOMB))) {
       super.onAdd(pokemon);
@@ -2601,6 +2611,12 @@ export class SyrupBombTag extends BattlerTag {
     }
   }
 
+  /**
+   * Applies the single-stage speed down to the target Pokemon and decrements the tag's turn count
+   * @param {Pokemon} pokemon the target Pokemon
+   * @param {BattlerTagLapseType} _lapseType
+   * @returns `true` if the turnCount is still greater than 0 | `false` if the turnCount is 0 or the target Pokemon has been removed from the field
+   */
   override lapse(pokemon: Pokemon, _lapseType: BattlerTagLapseType): boolean {
     if (!pokemon.isActive(true)) {
       return false;

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2590,7 +2590,7 @@ export class ImprisonTag extends MoveRestrictionBattlerTag {
 }
 
 /**
- * Battler Tag that applies the effects of Syrup Bomb to the target Pokemon
+ * Battler Tag that applies the effects of Syrup Bomb to the target Pokemon.
  * For three turns, starting from the turn of hit, at the end of each turn, the target Pokemon's speed will decrease by 1.
  * The tag can also expire by taking the target Pokemon off the field.
  */
@@ -2600,7 +2600,7 @@ export class SyrupBombTag extends BattlerTag {
   }
 
   /**
-   * Adds the Syrup Bomb battler tag to the target Pokemon
+   * Adds the Syrup Bomb battler tag to the target Pokemon.
    * In addition, this also contains a check for a pre-existing Syrup Bomb tag on the target Pokemon to determine whether the tag should be applied or not
    * @param {Pokemon} pokemon the target Pokemon
    */

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2589,6 +2589,29 @@ export class ImprisonTag extends MoveRestrictionBattlerTag {
   }
 }
 
+export class SyrupBombTag extends BattlerTag {
+  constructor() {
+    super(BattlerTagType.SYRUP_BOMB, BattlerTagLapseType.TURN_END, 3, Moves.SYRUP_BOMB);
+  }
+
+  override onAdd(pokemon: Pokemon) {
+    if (Utils.isNullOrUndefined(pokemon.getTag(BattlerTagType.SYRUP_BOMB))) {
+      super.onAdd(pokemon);
+      pokemon.scene.queueMessage(i18next.t("battlerTags:syrupBombOnAdd", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }));
+    }
+  }
+
+  override lapse(pokemon: Pokemon, _lapseType: BattlerTagLapseType): boolean {
+    if (!pokemon.isActive(true)) {
+      return false;
+    }
+    pokemon.scene.unshiftPhase(new StatStageChangePhase(
+      pokemon.scene, pokemon.getBattlerIndex(), true,
+      [Stat.SPD], -1, true, false, true
+    ));
+    return --this.turnCount > 0;
+  }
+}
 
 /**
  * Retrieves a {@linkcode BattlerTag} based on the provided tag type, turn count, source move, and source ID.
@@ -2763,6 +2786,8 @@ export function getBattlerTag(tagType: BattlerTagType, turnCount: number, source
     return new TauntTag();
   case BattlerTagType.IMPRISON:
     return new ImprisonTag(sourceId);
+  case BattlerTagType.SYRUP_BOMB:
+    return new SyrupBombTag();
   case BattlerTagType.NONE:
   default:
     return new BattlerTag(tagType, BattlerTagLapseType.CUSTOM, turnCount, sourceMove, sourceId);

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2618,6 +2618,7 @@ export class SyrupBombTag extends BattlerTag {
     if (!pokemon.isActive(true)) {
       return false;
     }
+    pokemon.scene.queueMessage(i18next.t("battlerTags:syrupBombLapse", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) })); // Custom message in lieu of an animation in mainline
     pokemon.scene.unshiftPhase(new StatStageChangePhase(
       pokemon.scene, pokemon.getBattlerIndex(), true,
       [Stat.SPD], -1, true, false, true

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2601,7 +2601,6 @@ export class SyrupBombTag extends BattlerTag {
 
   /**
    * Adds the Syrup Bomb battler tag to the target Pokemon.
-   * In addition, this also contains a check for a pre-existing Syrup Bomb tag on the target Pokemon to determine whether the tag should be applied or not
    * @param {Pokemon} pokemon the target Pokemon
    */
   override onAdd(pokemon: Pokemon) {

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -9584,9 +9584,8 @@ export function initMoves() {
       .target(MoveTarget.ALL_NEAR_ENEMIES)
       .triageMove(),
     new AttackMove(Moves.SYRUP_BOMB, Type.GRASS, MoveCategory.SPECIAL, 60, 85, 10, -1, 0, 9)
-      .attr(StatStageChangeAttr, [ Stat.SPD ], -1) //Temporary
-      .ballBombMove()
-      .partial(),
+      .attr(AddBattlerTagAttr, BattlerTagType.SYRUP_BOMB, false, false, 3)
+      .ballBombMove(),
     new AttackMove(Moves.IVY_CUDGEL, Type.GRASS, MoveCategory.PHYSICAL, 100, 100, 10, -1, 0, 9)
       .attr(IvyCudgelTypeAttr)
       .attr(HighCritAttr)

--- a/src/enums/battler-tag-type.ts
+++ b/src/enums/battler-tag-type.ts
@@ -85,5 +85,5 @@ export enum BattlerTagType {
   TORMENT = "TORMENT",
   TAUNT = "TAUNT",
   IMPRISON = "IMPRISON",
-  SYRUP_BOMB = "SYRUP_BOMB"
+  SYRUP_BOMB = "SYRUP_BOMB",
 }

--- a/src/enums/battler-tag-type.ts
+++ b/src/enums/battler-tag-type.ts
@@ -85,4 +85,5 @@ export enum BattlerTagType {
   TORMENT = "TORMENT",
   TAUNT = "TAUNT",
   IMPRISON = "IMPRISON",
+  SYRUP_BOMB = "SYRUP_BOMB"
 }

--- a/src/locales/en/battler-tags.json
+++ b/src/locales/en/battler-tags.json
@@ -79,5 +79,6 @@
   "tauntOnAdd": "{{pokemonNameWithAffix}} fell for the taunt!",
   "imprisonOnAdd": "{{pokemonNameWithAffix}} sealed the opponents move(s)!",
   "autotomizeOnAdd": "{{pokemonNameWithAffix}} became nimble!",
-  "syrupBombOnAdd": "{{pokemonNameWithAffix}} got covered in sticky, candy syrup!"
+  "syrupBombOnAdd": "{{pokemonNameWithAffix}} got covered in sticky, candy syrup!",
+  "syrupBombLapse": "The sticky syrup slowed down {{pokemonNameWithAffix}}!"
 }

--- a/src/locales/en/battler-tags.json
+++ b/src/locales/en/battler-tags.json
@@ -78,5 +78,6 @@
   "tormentOnAdd": "{{pokemonNameWithAffix}} was subjected to torment!",
   "tauntOnAdd": "{{pokemonNameWithAffix}} fell for the taunt!",
   "imprisonOnAdd": "{{pokemonNameWithAffix}} sealed the opponents move(s)!",
-  "autotomizeOnAdd": "{{pokemonNameWithAffix}} became nimble!"
+  "autotomizeOnAdd": "{{pokemonNameWithAffix}} became nimble!",
+  "syrupBombOnAdd": "{{pokemonNameWithAffix}} got covered in sticky, candy syrup!"
 }

--- a/src/test/moves/syrup_bomb.test.ts
+++ b/src/test/moves/syrup_bomb.test.ts
@@ -2,7 +2,7 @@ import { allMoves } from "#app/data/move";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
 import { Abilities } from "#enums/abilities";
-import { BattlerTagType } from "#enums/battler-tag-types";
+import { BattlerTagType } from "#enums/battler-tag-type";
 import { Stat } from "#enums/stat";
 import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";

--- a/src/test/moves/syrup_bomb.test.ts
+++ b/src/test/moves/syrup_bomb.test.ts
@@ -6,6 +6,7 @@ import { BattlerTagType } from "#enums/battler-tag-type";
 import { Stat } from "#enums/stat";
 import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
+import { BattlerIndex } from "#app/battle";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("Moves - SYRUP BOMB", () => {
@@ -44,6 +45,8 @@ describe("Moves - SYRUP BOMB", () => {
       expect(targetPokemon.getStatStage(Stat.SPD)).toBe(0);
 
       game.move.select(Moves.SYRUP_BOMB);
+      await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+      await game.move.forceHit();
       await game.toNextTurn();
       expect(targetPokemon.getTag(BattlerTagType.SYRUP_BOMB)).toBeDefined();
       expect(targetPokemon.getStatStage(Stat.SPD)).toBe(-1);
@@ -68,6 +71,8 @@ describe("Moves - SYRUP BOMB", () => {
       const targetPokemon = game.scene.getEnemyPokemon()!;
 
       game.move.select(Moves.SYRUP_BOMB);
+      await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+      await game.move.forceHit();
       await game.toNextTurn();
       expect(targetPokemon.isFullHp()).toBe(true);
       expect(targetPokemon.getTag(BattlerTagType.SYRUP_BOMB)).toBeUndefined();

--- a/src/test/moves/syrup_bomb.test.ts
+++ b/src/test/moves/syrup_bomb.test.ts
@@ -6,7 +6,7 @@ import { BattlerTagType } from "#enums/battler-tag-type";
 import { Stat } from "#enums/stat";
 import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("Moves - SYRUP BOMB", () => {
   let phaserGame: Phaser.Game;
@@ -36,8 +36,8 @@ describe("Moves - SYRUP BOMB", () => {
 
   //Bulbapedia Reference: https://bulbapedia.bulbagarden.net/wiki/syrup_bomb_(move)
 
-  test("decreases the target Pokemon's speed stat once per turn for 3 turns",
-    async() => {
+  it("decreases the target Pokemon's speed stat once per turn for 3 turns",
+    async () => {
       await game.startBattle([Species.MAGIKARP]);
 
       const targetPokemon = game.scene.getEnemyPokemon()!;
@@ -60,8 +60,8 @@ describe("Moves - SYRUP BOMB", () => {
     }
   );
 
-  test("does not affect Pokemon with the ability Bulletproof",
-    async() => {
+  it("does not affect Pokemon with the ability Bulletproof",
+    async () => {
       game.override.enemyAbility(Abilities.BULLETPROOF);
       await game.startBattle([Species.MAGIKARP]);
 
@@ -69,7 +69,7 @@ describe("Moves - SYRUP BOMB", () => {
 
       game.move.select(Moves.SYRUP_BOMB);
       await game.toNextTurn();
-      expect(targetPokemon.getMaxHp()).toBe(targetPokemon.hp);
+      expect(targetPokemon.isFullHp()).toBe(true);
       expect(targetPokemon.getTag(BattlerTagType.SYRUP_BOMB)).toBeUndefined();
       expect(targetPokemon.getStatStage(Stat.SPD)).toBe(0);
     }

--- a/src/test/moves/syrup_bomb.test.ts
+++ b/src/test/moves/syrup_bomb.test.ts
@@ -1,0 +1,77 @@
+import { allMoves } from "#app/data/move";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { Abilities } from "#enums/abilities";
+import { BattlerTagType } from "#enums/battler-tag-types";
+import { Stat } from "#enums/stat";
+import GameManager from "#test/utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+describe("Moves - SYRUP BOMB", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .starterSpecies(Species.MAGIKARP)
+      .enemySpecies(Species.SNORLAX)
+      .startingLevel(30)
+      .enemyLevel(100)
+      .moveset([Moves.SYRUP_BOMB, Moves.SPLASH])
+      .enemyMoveset(Moves.SPLASH);
+    vi.spyOn(allMoves[Moves.SYRUP_BOMB], "accuracy", "get").mockReturnValue(100);
+  });
+
+  //Bulbapedia Reference: https://bulbapedia.bulbagarden.net/wiki/syrup_bomb_(move)
+
+  test("decreases the target Pokemon's speed stat once per turn for 3 turns",
+    async() => {
+      await game.startBattle([Species.MAGIKARP]);
+
+      const targetPokemon = game.scene.getEnemyPokemon()!;
+      expect(targetPokemon.getStatStage(Stat.SPD)).toBe(0);
+
+      game.move.select(Moves.SYRUP_BOMB);
+      await game.toNextTurn();
+      expect(targetPokemon.getTag(BattlerTagType.SYRUP_BOMB)).toBeDefined();
+      expect(targetPokemon.getStatStage(Stat.SPD)).toBe(-1);
+
+      game.move.select(Moves.SPLASH);
+      await game.toNextTurn();
+      expect(targetPokemon.getTag(BattlerTagType.SYRUP_BOMB)).toBeDefined();
+      expect(targetPokemon.getStatStage(Stat.SPD)).toBe(-2);
+
+      game.move.select(Moves.SPLASH);
+      await game.toNextTurn();
+      expect(targetPokemon.getTag(BattlerTagType.SYRUP_BOMB)).toBeUndefined();
+      expect(targetPokemon.getStatStage(Stat.SPD)).toBe(-3);
+    }
+  );
+
+  test("does not affect Pokemon with the ability Bulletproof",
+    async() => {
+      game.override.enemyAbility(Abilities.BULLETPROOF);
+      await game.startBattle([Species.MAGIKARP]);
+
+      const targetPokemon = game.scene.getEnemyPokemon()!;
+
+      game.move.select(Moves.SYRUP_BOMB);
+      await game.toNextTurn();
+      expect(targetPokemon.getMaxHp()).toBe(targetPokemon.hp);
+      expect(targetPokemon.getTag(BattlerTagType.SYRUP_BOMB)).toBeUndefined();
+      expect(targetPokemon.getStatStage(Stat.SPD)).toBe(0);
+    }
+  );
+});


### PR DESCRIPTION
## What are the changes the user will see?
Syrup Bomb will have its correct secondary effect of decreasing the afflicted Pokemon's speed once per turn for three turns. 

## Why am I making these changes?
Shareholder value up!

## What are the changes from a developer perspective?
New Battler Tag for Syrup Bomb

### Screenshots/Videos


https://github.com/user-attachments/assets/830c0cf3-097d-4c4c-b1e1-e0eb6f4c8c85



## How to test the changes?
Use Syrup Bomb on a Pokemon without Bulletproof. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
