### PR TITLE
[Bug][Beta] Fix Meloetta-related bugs in mono-type challenges

### DIFF
--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -527,18 +527,19 @@ interface monotypeOverride {
  */
 export class SingleTypeChallenge extends Challenge {
   private static TYPE_OVERRIDES: monotypeOverride[] = [
-    {species: Species.MELOETTA, type: Type.PSYCHIC, fusion: true},
     {species: Species.CASTFORM, type: Type.NORMAL, fusion: false},
   ];
+  // TODO: Find a solution for all Pokemon with this ssui issue, including Basculin and Burmy
+  private static SPECIES_OVERRIDES: Species[] = [Species.MELOETTA];
 
   constructor() {
     super(Challenges.SINGLE_TYPE, 18);
   }
 
-  applyStarterChoice(pokemon: PokemonSpecies, valid: Utils.BooleanHolder, dexAttr: DexAttrProps, soft: boolean = false): boolean {
+  override applyStarterChoice(pokemon: PokemonSpecies, valid: Utils.BooleanHolder, dexAttr: DexAttrProps, soft: boolean = false): boolean {
     const speciesForm = getPokemonSpeciesForm(pokemon.speciesId, dexAttr.formIndex);
     const types = [speciesForm.type1, speciesForm.type2];
-    if (soft) {
+    if (soft && !SingleTypeChallenge.SPECIES_OVERRIDES.includes(pokemon.speciesId)) {
       const speciesToCheck = [pokemon.speciesId];
       while (speciesToCheck.length) {
         const checking = speciesToCheck.pop();


### PR DESCRIPTION
## What are the changes the user will see?
Meloetta can't be sent out into battle if it's the wrong type/form for the current mono-type challenge. Also, wrong type/form Meloetta can't be added to the party in the starter select screen.

## Why am I making these changes?
The behavior is incorrect.

## What are the changes from a developer perspective?
Meloetta is removed from the static `TYPE_OVERRIDES` array in `SingleTypeChallenge` due to its form change behavior being changed as per #4192. This prevents it from being sent into battle if its in the wrong form for the current mono-type challenge.
Added a static `SPECIES_OVERRIDE` array in `SingleTypeChallenge` which is checked to prevent a Pokémon of the incorrect form/type from being added to the party during starter select. Currently only Meloetta is in the array, pending a rework in the next beta cycle.

### Screenshots/Videos
<details>
  <summary>Incorrect form can't be added to party</summary>

![image](https://github.com/user-attachments/assets/edfcef8a-13ed-4101-aea9-ccb118d880f9)
![image](https://github.com/user-attachments/assets/c726c696-aa50-44de-8b72-fba2c41aa867)

</details>
<details>
  <summary>Incorrect form can't be sent into battle if ssui is bypassed</summary>

![image](https://github.com/user-attachments/assets/f41f1726-77db-4d15-b3c7-9c04140286a9)

</details>

## How to test the changes?
Try to add Pirouette Meloetta to a Psychic-only challenge (or Aria in a Fighting-only challenge).

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - [x] Have I provided screenshots/videos of the changes?
