### PR TITLE
[bug] Fix macho brace stat calculation

### DIFF
--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -998,26 +998,26 @@ export class PokemonIncrementingStatModifier extends PokemonHeldItemModifier {
   }
 
   shouldApply(args: any[]): boolean {
-    return super.shouldApply(args) && args.length === 2 && args[1] instanceof Array;
+    return super.shouldApply(args) && args.length === 3 && args[2] instanceof Utils.IntegerHolder;
   }
 
   apply(args: any[]): boolean {
-    // Modifies the passed in stats[] array by +1 per stack for HP, +2 per stack for other stats
+    // Modifies the passed in stat integer holder by +1 per stack for HP, +2 per stack for other stats
     // If the Macho Brace is at max stacks (50), adds additional 5% to total HP and 10% to other stats
-    const targetToApply = args[0] as Pokemon;
+    const isHp = args[1] === Stat.HP;
+    const statHolder = args[2] as Utils.IntegerHolder;
 
-    args[1].forEach((v, i) => {
-      const isHp = i === 0;
-      // Doesn't modify HP if holder has Wonder Guard
-      if (!isHp || !targetToApply.hasAbility(Abilities.WONDER_GUARD)) {
-        let mult = 1;
-        if (this.stackCount === this.getMaxHeldItemCount()) {
-          mult = isHp ? 1.05 : 1.1;
-        }
-        const newVal = Math.floor((v + this.stackCount * (isHp ? 1 : 2)) * mult);
-        args[1][i] = Math.min(Math.max(newVal, 1), 999999);
+    if (isHp) {
+      statHolder.value += this.stackCount;
+      if (this.stackCount === this.getMaxHeldItemCount()) {
+        statHolder.value = Math.floor(statHolder.value * 1.05);
       }
-    });
+    } else {
+      statHolder.value += 2 * this.stackCount;
+      if (this.stackCount === this.getMaxHeldItemCount()) {
+        statHolder.value = Math.floor(statHolder.value * 1.1);
+      }
+    }
 
     return true;
   }


### PR DESCRIPTION
## What are the changes the user will see?
Macho brace won't constantly damage the user's pokemon at the start of every battle.

## Why am I making these changes?
Macho brace was improperly implemented so wasn't increasing stats correctly.

## What are the changes from a developer perspective?
Macho brace now increases stats during stat calculation, instead of after the fact.

### Screenshots/Videos
Can't really screenshot this as it'd just show pokemon at full HP.

## How to test the changes?
Give you starter macho brace via overrides, notice its max HP doesn't drop at the start of every wave.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
