### PR TITLE
[P2] Fix Zippy Zap being boosted by Sheer Force

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -8928,7 +8928,7 @@ export function initMoves() {
       .partial()
       .ignoresVirtual(),
     /* End Unused */
-    new AttackMove(Moves.ZIPPY_ZAP, Type.ELECTRIC, MoveCategory.PHYSICAL, 50, 100, 15, 100, 2, 7) //LGPE Implementation
+    new AttackMove(Moves.ZIPPY_ZAP, Type.ELECTRIC, MoveCategory.PHYSICAL, 50, 100, 15, -1, 2, 7) //LGPE Implementation
       .attr(CritOnlyAttr),
     new AttackMove(Moves.SPLISHY_SPLASH, Type.WATER, MoveCategory.SPECIAL, 90, 100, 15, 30, 0, 7)
       .attr(StatusEffectAttr, StatusEffect.PARALYSIS)


### PR DESCRIPTION
## What are the changes the user will see?
Zippy Zap is no longer erroneously boosted by Sheer Force

## Why am I making these changes?
Reported [in the Discord](https://discord.com/channels/1125469663833370665/1289296539054903336)

## What are the changes from a developer perspective?
`data/move`: Changed Zippy Zap's `chance` parameter from `100` to `-1`, meaning that Zippy Zap's crit-only effect always triggers but is no longer tied to effect chance (and therefore cannot be modified by Sheer Force)

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
Add the overrides below to `src/overrides.ts`.
```ts
const overrides = {
  ABILITY_OVERRIDE: Abilities.SHEER_FORCE,
  MOVESET_OVERRIDE: Moves.ZIPPY_ZAP
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

Then use Zippy Zap in a battle. The move should critically hit, and Sheer Force should not activate on the attack

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [?] Are the changes visual?
  - [?] Have I provided screenshots/videos of the changes?
