### PR TITLE
[Bug] hotfix for expert breeder ME

### DIFF
--- a/src/data/mystery-encounters/encounters/the-expert-pokemon-breeder-encounter.ts
+++ b/src/data/mystery-encounters/encounters/the-expert-pokemon-breeder-encounter.ts
@@ -558,6 +558,10 @@ function onGameOver(scene: BattleScene) {
   // Revert BGM
   scene.playBgm(scene.arena.bgm);
 
+  // Clear any leftover battle phases
+  scene.clearPhaseQueue();
+  scene.clearPhaseQueueSplice();
+
   // Return enemy Pokemon
   const pokemon = scene.getEnemyPokemon();
   if (pokemon) {


### PR DESCRIPTION
Game could crash if the player lost with queued enemy stat change phases leftover in the phase queue. Fixed with this change

https://github.com/user-attachments/assets/2b7f3acf-7229-46be-9c53-1445aac51c34


