### PR TITLE
[Hotfix] Prevent bosses from being forced to flee by Dragon Tail/etc

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5244,6 +5244,9 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
           false, false), MoveEndPhase);
       }
     } else {
+      if (switchOutTarget.isBoss()) {
+        return false;
+      }
       // Switch out logic for everything else (eg: WILD battles)
       switchOutTarget.leaveField(false);
 


### PR DESCRIPTION
## What are the changes the user will see?
Dragon Tail et al can no longer force bosses (like Eternatus) to flee.

## Why am I making these changes?
The condition to prevent bosses from fleeing was forgotten when removing GMax immunities.

## What are the changes from a developer perspective?
Added a `.isBoss()` check to `ForceSwitchOutAttr`.

### Screenshots/Videos
Before fix:

Uploading boss flee bug.mp4…

After fix:

https://github.com/user-attachments/assets/7746e543-c5ac-443d-9ea1-90463484c08b

## How to test the changes?
Give your Pokémon Dragon Tail/etc (and the enemy Splash) and start at wave 200, then use the move.

## Checklist
- ~[ ] **I'm using `beta` as my base branch**~
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - [x] Have I provided screenshots/videos of the changes?
