### PR TITLE
Me battle tag hotfix

### DIFF
--- a/src/phases/mystery-encounter-phases.ts
+++ b/src/phases/mystery-encounter-phases.ts
@@ -25,6 +25,7 @@ import { GameOverPhase } from "#app/phases/game-over-phase";
 import { SwitchPhase } from "#app/phases/switch-phase";
 import { SeenEncounterData } from "#app/data/mystery-encounters/mystery-encounter-save-data";
 import { SwitchType } from "#enums/switch-type";
+import { BattlerTagType } from "#enums/battler-tag-type";
 
 /**
  * Will handle (in order):
@@ -218,9 +219,14 @@ export class MysteryEncounterBattleStartCleanupPhase extends Phase {
   start() {
     super.start();
 
+    // Lapse any residual flinches but ignore all other turn-end battle tags
     const field = this.scene.getField(true).filter(p => p.summonData);
     field.forEach(pokemon => {
-      pokemon.lapseTags(BattlerTagLapseType.TURN_END);
+      const tags = pokemon.summonData.tags;
+      tags.filter(t => t.tagType === BattlerTagType.FLINCHED && !(t.lapse(pokemon, BattlerTagLapseType.TURN_END))).forEach(t => {
+        t.onRemove(pokemon);
+        tags.splice(tags.indexOf(t), 1);
+      });
     });
 
     // Remove any status tick phases

--- a/src/phases/mystery-encounter-phases.ts
+++ b/src/phases/mystery-encounter-phases.ts
@@ -219,11 +219,14 @@ export class MysteryEncounterBattleStartCleanupPhase extends Phase {
   start() {
     super.start();
 
-    // Lapse any residual flinches but ignore all other turn-end battle tags
+    // Lapse any residual flinches/endures but ignore all other turn-end battle tags
+    const includedLapseTags = [BattlerTagType.FLINCHED, BattlerTagType.ENDURING];
     const field = this.scene.getField(true).filter(p => p.summonData);
     field.forEach(pokemon => {
       const tags = pokemon.summonData.tags;
-      tags.filter(t => t.tagType === BattlerTagType.FLINCHED && !(t.lapse(pokemon, BattlerTagLapseType.TURN_END))).forEach(t => {
+      tags.filter(t => includedLapseTags.includes(t.tagType)
+        && t.lapseTypes.includes(BattlerTagLapseType.TURN_END)
+        && !(t.lapse(pokemon, BattlerTagLapseType.TURN_END))).forEach(t => {
         t.onRemove(pokemon);
         tags.splice(tags.indexOf(t), 1);
       });


### PR DESCRIPTION
Fixes MEs that have "start of battle free moves" that the enemy performs (Uncommon Breed, Slumbering Snorlax, Fiery Fallout, etc.)

Instead of lapsing *all* turn end effects (this has severe phase consequences with certain tags), only lapse the ones that were originally intended to be lapsed (flinch, endure).