### PR TITLE
[Hotfix] Prevent the last valid Pokémon from being forced to switch

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5226,6 +5226,9 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
      */
     const switchOutTarget = this.selfSwitch ? user : target;
     if (switchOutTarget instanceof PlayerPokemon) {
+      if (switchOutTarget.scene.getParty().filter((p) => p.isAllowedInBattle() && !p.isOnField()).length < 1) {
+        return false;
+      }
       switchOutTarget.leaveField(this.switchType === SwitchType.SWITCH);
 
       if (switchOutTarget.hp > 0) {
@@ -5234,6 +5237,9 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
       }
       return false;
     } else if (user.scene.currentBattle.battleType !== BattleType.WILD) {
+      if (switchOutTarget.scene.getEnemyParty().filter((p) => p.isAllowedInBattle() && !p.isOnField()).length < 1) {
+        return false;
+      }
       // Switch out logic for trainer battles
       switchOutTarget.leaveField(this.switchType === SwitchType.SWITCH);
 


### PR DESCRIPTION
## What are the changes the user will see?
Dragon Tail/etc will no longer cause a Pokémon to be switched out if there are no valid switch-in Pokémon.

## Why am I making these changes?
It's broken.

## What are the changes from a developer perspective?
Added a party check in `ForceSwitchOutAttr`.

### Screenshots/Videos
Before fix:

https://github.com/user-attachments/assets/b0b00478-473a-4822-891b-861b81556785

After fix:

https://github.com/user-attachments/assets/8a4ea264-a69e-4e09-8804-e424711a5e41

## How to test the changes?
Use Dragon Tail on the last non-fainted Pokémon in a trainer battle (such as wave 5).

## Checklist
- ~[ ] **I'm using `beta` as my base branch**~
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - [x] Have I provided screenshots/videos of the changes?
