### PR TITLE
[Bug] Prevent MEs incorrectly spawning on existing session saves

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -3091,11 +3091,6 @@ export default class BattleScene extends SceneBase {
   private isWaveMysteryEncounter(newBattleType: BattleType, waveIndex: number, sessionDataEncounterType?: MysteryEncounterType): boolean {
     const [lowestMysteryEncounterWave, highestMysteryEncounterWave] = this.gameMode.getMysteryEncounterLegalWaves();
     if (this.gameMode.hasMysteryEncounters && newBattleType === BattleType.WILD && !this.gameMode.isBoss(waveIndex) && waveIndex < highestMysteryEncounterWave && waveIndex > lowestMysteryEncounterWave) {
-      // If ME type is already defined in session data, no need to roll RNG check
-      if (!isNullOrUndefined(sessionDataEncounterType)) {
-        return true;
-      }
-
       // Base spawn weight is BASE_MYSTERY_ENCOUNTER_SPAWN_WEIGHT/256, and increases by WEIGHT_INCREMENT_ON_SPAWN_MISS/256 for each missed attempt at spawning an encounter on a valid floor
       const sessionEncounterRate = this.mysteryEncounterSaveData.encounterSpawnChance;
       const encounteredEvents = this.mysteryEncounterSaveData.encounteredEvents;


### PR DESCRIPTION
Server is returning value of `0` for `mysteryEncounterType` on sessions that existed before the update (`0` is a valid ME, but an ME is not valid for the session state) which causes Mysterious Challengers to spawn on old saves.

This removes the early exit on the check for a ME so that it always must succeed on the roll to spawn a ME (which is seed offset, so refreshes/resets should never affect it).

This will *not* completely solve the fact that *if* a ME randomly determines to spawn on that first wave, it will be forced into Mysterious Challengers. There's not really any workaround to that.