### PR TITLE
[Localization] [P3 Bug] French hotfix

### DIFF
--- a/src/locales/fr/mystery-encounters/training-session-dialogue.json
+++ b/src/locales/fr/mystery-encounters/training-session-dialogue.json
@@ -1,7 +1,7 @@
 {
   "intro": "Vous tombez sur du matériel d’entrainement.",
   "title": "Session d’entrainement",
-  "description": "Ce matériel semble pouvoir être utilisé pour entrainer un membre de votre équipe ! Il existe plusieurs moyens avec lesquels vous pourriez entrainer un Pokémon, comme @[TOOLTIP_TITLE]{en le faisant combattre et vaincre le reste de votre équipe}.",
+  "description": "Ce matériel semble pouvoir être utilisé pour entrainer un membre de votre équipe ! Il existe plusieurs moyens avec lesquels vous pourriez entrainer un Pokémon, comme @[TOOLTIP_TITLE]{en le combattant et le vainquant avec le reste de votre équipe}.",
   "query": "Quel entrainement choisir ?",
   "invalid_selection": "Le Pokémon doit être en bonne santé.",
   "option": {


### PR DESCRIPTION
## What are the changes the user will see?
Right wording in training-session-dialogue.json

## Why am I making these changes?
The way the description of French **training-session-dialogue.json** was written may likely indicate the opposite of what is happening in reality

## What are the changes from a developer perspective?
None

## Checklist
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?