### PR TITLE
[Hotfix] Fix desync issue with Heal Block applying to Pokemon at full HP

### DIFF
--- a/src/phases/pokemon-heal-phase.ts
+++ b/src/phases/pokemon-heal-phase.ts
@@ -46,8 +46,7 @@ export class PokemonHealPhase extends CommonAnimPhase {
     const pokemon = this.getPokemon();
 
     if (!pokemon.isOnField() || (!this.revive && !pokemon.isActive())) {
-      super.end();
-      return;
+      return super.end();
     }
 
     const hasMessage = !!this.message;
@@ -58,7 +57,7 @@ export class PokemonHealPhase extends CommonAnimPhase {
     if (healBlock && this.hpHealed > 0) {
       this.scene.queueMessage(healBlock.onActivation(pokemon));
       this.message = null;
-      super.end();
+      return super.end();
     } else if (healOrDamage) {
       const hpRestoreMultiplier = new Utils.IntegerHolder(1);
       if (!this.revive) {


### PR DESCRIPTION
## What are the changes the user will see?
This fixes an issue where the game would sometimes softlock after a Pokemon under the effect of Heal Block KOs another Pokemon with a draining move (e.g. Bitter Blade) while at full HP.

## Why am I making these changes?
P1 bugs are bad

## What are the changes from a developer perspective?
`phases/pokemon-heal-phase`: `PokemonHealPhase.end` now returns when calling `super.end` if the associated healing effect is blocked by Heal Block. Before this change, it was possible for `super.end` to be called twice if the heal target was at full HP and affected by Heal Block, causing two phases to be queued up at the same time.

### Screenshots/Videos

**Before the change** (courtesy of @PigeonBar )

https://github.com/user-attachments/assets/2c48543d-ddbb-44a0-b200-4c3e242c65c4

**After the change**

https://github.com/user-attachments/assets/83a69063-68b8-47fc-8707-a5f886a02b63

## How to test the changes?
1. Download [this file](https://github.com/user-attachments/files/17176171/20240928.Heal.Block.txt), change the file extension to `.prsv`, and import the session data in a local build of the game.
2. After starting the save file, set the game's speed to 5x, use Bitter Blade, and mash the action button (Z/Space) throughout the turn. You should see that the animation and message for the opponent fainting play in the correct order (animation, then message), and the game correctly advances to the shop after the opponent faints.

## Checklist
- [n/a] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
