### PR TITLE
[Ability] Remove `partial` marker on Super Luck

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -5210,8 +5210,7 @@ export function initAbilities() {
       .attr(PostSummonMessageAbAttr, (pokemon: Pokemon) => i18next.t("abilityTriggers:postSummonMoldBreaker", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }))
       .attr(MoveAbilityBypassAbAttr),
     new Ability(Abilities.SUPER_LUCK, 4)
-      .attr(BonusCritAbAttr)
-      .partial(),
+      .attr(BonusCritAbAttr),
     new Ability(Abilities.AFTERMATH, 4)
       .attr(PostFaintContactDamageAbAttr, 4)
       .bypassFaint(),


### PR DESCRIPTION
## What are the changes the user will see?
This removes the "(P)" marker on Super Luck.

## Why am I making these changes?
Super Luck was previously marked as a partial implementation because it did not implement the ability's out-of-battle effect from Generation VIII. That effect's implementation (#1624) has since been rejected by the Balance Team for not being practically translatable to this game, leaving no reason for Super Luck to keep the "(P)" marking.

## What are the changes from a developer perspective?
`data/ability`: Removed Super Luck's `.partial()` marking.

## How to test the changes?
See Super Luck's summary description in game. It shouldn't be marked (P) anymore.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [?] Are the changes visual?
  - [?] Have I provided screenshots/videos of the changes?
