### PR TITLE
[Balance] Increase Minimum BST Filter for Elite 4 / Champion Teams

### DIFF
--- a/src/data/trainer-config.ts
+++ b/src/data/trainer-config.ts
@@ -863,7 +863,7 @@ export class TrainerConfig {
       this.setSpeciesFilter(p => specialtyTypes.some(t => p.isOfType(t)) && p.baseTotal >= 450);
       this.setSpecialtyTypes(...specialtyTypes);
     } else {
-      this.setSpeciesFilter(p => p.baseTotal >= 450);
+      this.setSpeciesFilter(p => p.baseTotal >= 460);
     }
 
     // Localize the trainer's name by converting it to lowercase and replacing spaces with underscores.

--- a/src/data/trainer-config.ts
+++ b/src/data/trainer-config.ts
@@ -18,6 +18,9 @@ import {Species} from "#enums/species";
 import {TrainerType} from "#enums/trainer-type";
 import {Gender} from "./gender";
 
+const ELITE_FOUR_MINIMUM_BST = 460;
+const CHAMPION_MINIMUM_BST = 508;
+
 export enum TrainerPoolTier {
     COMMON,
     UNCOMMON,
@@ -860,10 +863,10 @@ export class TrainerConfig {
 
     // Set species filter and specialty types if provided, otherwise filter by base total.
     if (specialtyTypes.length) {
-      this.setSpeciesFilter(p => specialtyTypes.some(t => p.isOfType(t)) && p.baseTotal >= 450);
+      this.setSpeciesFilter(p => specialtyTypes.some(t => p.isOfType(t)) && p.baseTotal >= ELITE_FOUR_MINIMUM_BST);
       this.setSpecialtyTypes(...specialtyTypes);
     } else {
-      this.setSpeciesFilter(p => p.baseTotal >= 460);
+      this.setSpeciesFilter(p => p.baseTotal >= ELITE_FOUR_MINIMUM_BST);
     }
 
     // Localize the trainer's name by converting it to lowercase and replacing spaces with underscores.
@@ -914,7 +917,7 @@ export class TrainerConfig {
     });
 
     // Set species filter to only include species with a base total of 508 or higher.
-    this.setSpeciesFilter(p => p.baseTotal >= 508);
+    this.setSpeciesFilter(p => p.baseTotal >= CHAMPION_MINIMUM_BST);
 
     // Localize the trainer's name by converting it to lowercase and replacing spaces with underscores.
     const nameForCall = this.name.toLowerCase().replace(/\s/g, "_");

--- a/src/data/trainer-config.ts
+++ b/src/data/trainer-config.ts
@@ -913,7 +913,7 @@ export class TrainerConfig {
       this.setPartyMemberFunc(-(s + 1), getRandomPartyMemberFunc(speciesPool));
     });
 
-    // Set species filter to only include species with a base total of 470 or higher.
+    // Set species filter to only include species with a base total of 508 or higher.
     this.setSpeciesFilter(p => p.baseTotal >= 508);
 
     // Localize the trainer's name by converting it to lowercase and replacing spaces with underscores.

--- a/src/data/trainer-config.ts
+++ b/src/data/trainer-config.ts
@@ -914,7 +914,7 @@ export class TrainerConfig {
     });
 
     // Set species filter to only include species with a base total of 470 or higher.
-    this.setSpeciesFilter(p => p.baseTotal >= 470);
+    this.setSpeciesFilter(p => p.baseTotal >= 508);
 
     // Localize the trainer's name by converting it to lowercase and replacing spaces with underscores.
     const nameForCall = this.name.toLowerCase().replace(/\s/g, "_");

--- a/src/data/trainer-config.ts
+++ b/src/data/trainer-config.ts
@@ -18,7 +18,9 @@ import {Species} from "#enums/species";
 import {TrainerType} from "#enums/trainer-type";
 import {Gender} from "./gender";
 
+/** Minimum BST for Pokemon generated onto the Elite Four's teams */
 const ELITE_FOUR_MINIMUM_BST = 460;
+/** Minimum BST for Pokemon generated onto the E4 Champion's team */
 const CHAMPION_MINIMUM_BST = 508;
 
 export enum TrainerPoolTier {
@@ -916,7 +918,6 @@ export class TrainerConfig {
       this.setPartyMemberFunc(-(s + 1), getRandomPartyMemberFunc(speciesPool));
     });
 
-    // Set species filter to only include species with a base total of 508 or higher.
     this.setSpeciesFilter(p => p.baseTotal >= CHAMPION_MINIMUM_BST);
 
     // Localize the trainer's name by converting it to lowercase and replacing spaces with underscores.


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
Elite 4 will improve very slightly in mon selection, Champions will now have a pool of way more competent Pokemon.

## Why am I making these changes?
The current minimum BST filter for Champions being 470 was criminally low for an important trainer, who is meant to be a secondary boss to the rival who currently sits with a minimum 540 BST filter in their config. This meant you would see oddities like Champion Red with a Simisear or Wallace with a Leavanny which are extremely unfitting in terms of power. 508 was chosen as a sweet spot in BST that targets slightly more premium Pokemon while fitting in some that aren't at exactly 510 like the Drillbur or Sinistea line. Elite 4 got a +10 BST increase to not limit the pool _too_ much but still cutting out a few weaker tier Pokemon.


damo stepping in, I have a problem and typed the below manually in a surprisingly short time span-
### All Pokemon Removed from Champions upped from 470 -> 508 BST Minimum
<details>
  <summary>Click to expand list</summary>

- Rabsca
- Maushold
- Eiscue
- Stonjourner
- Falinks
- Klefki
- Alomomola
- Cinccino
- Grumpig
- Torkoal
- Xatu
- Dodrio
- Stunfisk + Galarian Stunfisk
- Furfrou
- Galvantula
- Swanna
- Trevenant
- Garbodor
- Vespiquen
- Hariyama
- Tatsugiri
- Indeedee
- Frosmoth
- Cramorant
- Bruxish
- Sawsbuck
- Gastrodon
- Cacturne
- Manectric
- Kingler
- Dewgong
- Mimikyu
- Oricorio
- Dachsbun
- Veluza
- Crabominable
- Skuntank
- Pidgeot
- Lilligant + Hisuian Liligant
- Darmanitan + Galarian Darmanitan
- Orthworm
- Brambleghast
- Grapploct
- Komala
- Palossand
- Salazzle
- Lurantis
- Slurpuff
- Jellicent
- Whimsicott
- Froslass
- Lopunny
- Glalie
- Shiftry
- Ludicolo
- Octillery
- Espathra
- Heliolisk
- Malamar
- Ambipom
- Runerigus
- Golurk
- Cofagrigus
- Hypno
- Clefable
- Durant
- Heatmor
- Raichu + Alolan Raichu
- Bombirdier
- Grafaiai
- Appletun
- Flapple
- Drednaw
- Drampa
- Turtonator
- Comfey
- Toucannon
- Druddigon
- Beheeyem
- Crustle
- Scolipede
- Spiritomb
- Staraptor
- Relicanth
- Gorebyss
- Huntail
- Mantine
- Raichu
- Scovillain
- Lycanroc + Midnight + Dusk
- Musharna
- Houndstone
- Scrafty
- Unfezant
- Oinkologne
- Ferrothorn
- Tauros + Paldea + P. Blaze + P. Aqua
- Electrode + Hisuian Electrode
- Slowbro + Galarian Slowbro
- Slowking + Galarian Slowking
- Weezing + Galarian Weezing 
- Kilowattrel 
- Pawmot
- Barraskewda
- Boltund
- Dubwool
- Passimian
- Orangoru
- Bouffalant
- Reuniclus
- Gothitelle
- Sigilyph
- Toxicroak
- Altaria
- Exploud
- Miltank
- Bellossom
- Kangaskhan
- Victreebel
- Vileplume
- Gourgeist
- Dragalge
- Abomasnow
- Golem + Alolan Golem
- Bellibolt
- Alcremie
- Corviknight
- Toxapex
- Pangoro
- Accelgor
- Escavalier
- Carracosta
- Mismagius
- Floatzel
- Bastiodon
- Rampardos
- Armaldo
- Cradily
- Kabutops
- Omastar
- Zebstrika
- Simipour
- Simisear
- Simisage
- Drifblim
- Talonflame
- Rapidash + Galarian Rapidash
- Muk + Alolan Muk
- Flamigo
- Revavroom
- Garganacl
- Kleavor
- Copperajah 
- Minior
- Bewear
- Mudsdale
- Vikavolt
- Carbink
- Hawlucha
- Clawitzer 
- Barbaracle
- Aegislash
- Leavanny
-  Stoutland
- Drapion
-  Bronzong
-  Claydol
-  Wailord
-  Donphan
-  Houndoom
-  Heracross
- Scizor
-  Politoed
- Pinsir
-  Scyther
-  Gengar
-  Alakazam
-  Golduck
-  Cyclizar
-  Toxtricity
-  Ninetales + Alolan Ninetales
-  Mabosstiff
-  Arctovish
- Dracovish
-  Arctozolt
-  Dracozolt
-  Orbeetle
-  Beartic
-  Conkeldurr
-  Honchkrow
-  Shuckle
-  Machamp
-  Nidoking
-  Nidoqueen
- Tinkaton
-  Sirfetch'd
-  Pyroar
</details>

### All Pokemon Removed from Elite 4 Members upped from 450 -> 460 BST Minimum
<details>
  <summary>Click to expand list</summary>

- Sandslash + Alolan Sandslash
- Klawf
-  Lokix
- Cherrim
-  Granbull
-  Seaking
-  Venomoth
-  Purugly
-  Noctowl
-  Araquanid
-  Carvnivine
-  Masquerain
-  Thievul
-  Chimecho
-  Banette
-  Swellow
-  Hitmontop
-  Girafarig
-  Jynx
-  Hitmonchan
-  Hitmonlee
- Golbat
-  Ninjask
-  Palafin
-  Seviper
-  Zangoose
</details>

## What are the changes from a developer perspective?
Changes in trainer-config, Elite 4 BST Filter 450 -> 460 / Champion BST Filter 470 -> 508

### Screenshots/Videos
<details>
  <summary>An example of a weaker Pokemon spawning on a Champion (Wallace) with the current BST Filter</summary>

![image](https://github.com/user-attachments/assets/3c76fd33-6668-45a1-b1b8-03d1e4817411)

</details>
<details>
  <summary>An example of the pool of Pokemon the new Champion BST filter is around</summary>

![image](https://github.com/user-attachments/assets/9976fb32-1b33-4875-9c06-da4867da0483)

</details>

## How to test the changes?
Override to a E4 / Champion Wave

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
