### PR TITLE
[Hotfix] Fix crash in GTS ME: replace `pokemon` with `tradePokemon`

### DIFF
--- a/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
+++ b/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
@@ -159,7 +159,7 @@ export const GlobalTradeSystemEncounter: MysteryEncounter =
                   return true;
                 },
                 onHover: () => {
-                  const formName = tradePokemon.species.forms && tradePokemon.species.forms.length > tradePokemon.formIndex ? tradePokemon.species.forms[pokemon.formIndex].formName : null;
+                  const formName = tradePokemon.species.forms && tradePokemon.species.forms.length > tradePokemon.formIndex ? tradePokemon.species.forms[tradePokemon.formIndex].formName : null;
                   const line1 = i18next.t("pokemonInfoContainer:ability") + " " + tradePokemon.getAbility().name + (tradePokemon.getGender() !== Gender.GENDERLESS ? "     |     " + i18next.t("pokemonInfoContainer:gender") + " " + getGenderSymbol(tradePokemon.getGender()) : "");
                   const line2 = i18next.t("pokemonInfoContainer:nature") + " " + getNatureName(tradePokemon.getNature()) + (formName ? "     |     " + i18next.t("pokemonInfoContainer:form") + " " + formName : "");
                   showEncounterText(scene, `${line1}\n${line2}`, 0, 0, false);


### PR DESCRIPTION
## What are the changes the user will see?
The GTS ME will no longer crash if you try to trade a Pokémon with many forms like "Unown ?".

## Why am I making these changes?
It's crashing the game.

## What are the changes from a developer perspective?
`tradePokemon.species.forms[pokemon.formIndex].formName` changed to `tradePokemon.species.forms[tradePokemon.formIndex].formName`.

### Screenshots/Videos
Before fix:

https://github.com/user-attachments/assets/d134ce00-cc98-4c69-80fd-dba33a659ee2

After fix:

https://github.com/user-attachments/assets/a18b4321-6bab-4529-a743-7f4dbabc435b

## How to test the changes?
Load this save file and try to trade the Unown: https://cdn.discordapp.com/attachments/1289762905905958984/1289797958807588915/20240928_GTS_Unown_Softlock.prsv?ex=66fa2174&is=66f8cff4&hm=8597bbd7da060e55c57b2965071ebd3acf06f0996934c8c618ce1f2653e1d792&

## Checklist
- ~[ ] **I'm using `beta` as my base branch**~
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - [x] Have I provided screenshots/videos of the changes?
