### PR TITLE
[Bug] Fix duplicate mon ID / RNG not properly resetting after game over

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1040,10 +1040,6 @@ export default class BattleScene extends SceneBase {
 
     this.gameMode = getGameMode(GameModes.CLASSIC);
 
-    this.setSeed(Overrides.SEED_OVERRIDE || Utils.randomString(24));
-    console.log("Seed:", this.seed);
-    this.resetSeed(); // Properly resets RNG after saving and quitting a session
-
     this.disableMenu = false;
 
     this.score = 0;
@@ -1077,6 +1073,12 @@ export default class BattleScene extends SceneBase {
 
     //@ts-ignore  - allowing `null` for currentBattle causes a lot of trouble
     this.currentBattle = null; // TODO: resolve ts-ignore
+
+    // Reset RNG after end of game or save & quit.
+    // This needs to happen after clearing this.currentBattle or the seed will be affected by the last wave played
+    this.setSeed(Overrides.SEED_OVERRIDE || Utils.randomString(24));
+    console.log("Seed:", this.seed);
+    this.resetSeed();
 
     this.biomeWaveText.setText(startingWave.toString());
     this.biomeWaveText.setVisible(false);


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
The game should not generate Pokemon with the same ID anymore
<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?
Currently it's possible that the game gives a wild Pokemon the same ID as one of the Pokemon that was brought into the run from starter select
- This leads to issues with the display of the enemy's items and used moves
- This leads to even bigger issues if the mon with duplicate ID is captured and used alongside its counterpart

<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What are the changes from a developer perspective?
Pokemon IDs are generated with the "Wave Seed", that is the run's seed shifted based on the current wave.
Currently the game's RNG is not reset properly after losing or winning a run. A new seed is generated when going back to the title screen, but the wave seed gets shifted based on the wave where the run finished. Let's call it wave X
So, when finishing a run and starting a new game immediately the starters IDs are generated using that new seed, but shifted by X. Later in that run when reaching wave X, the same seed shifted by X will be used to generate the wild Pokemon's ID, so it's possible that said wild Pokemon shares its IDs with one of the starters that was brought in the run.

Here's a console trace that hopefully helps illustrate it. The numbers to the right of the `Wave seed` is the shift of the seed
<img width="766" alt="_seed_bug" src="https://github.com/user-attachments/assets/1521cb32-c6c9-4a52-a496-2ea5a76e7fc1">

The issue happens because when the new seed gets generated in `battleScene.reset()` the wave of the last battle (`currentBattle`) is used to shift the seed
(this issue does not happen after Save & Quitting a run, because for some reason battleScene.reset is called twice in this case, so the second time it's called `currentBattle`will have been cleared already so the seed doesn't get shifted)

The fix makes the seed reset happen after the `currentBattle` is cleared, instead of before, so the new seed doesn't get shifted

Note that this does not retroactively fix saves that were created with this shift, it only prevents it from happening in future saves.

<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos
Before, final boss generated with the same ID as Stunkfish. Its icon shows Stunkfish's icon instead. Its used move show Stunkfish's used moves as well as its own:
<img width="1170" alt="Screenshot_2024-09-21_at_23 03 43" src="https://github.com/user-attachments/assets/d21e4f01-582a-44ab-9f40-db26ecb62972">

Before, a little glimpse at some of the issues if you capture a Pokemon with a duplicate ID. Squirtle and Blipbug have the same ID here:

https://github.com/user-attachments/assets/e2defc0c-79ba-43b3-9e06-4af39e9c170e



After, hard to prove that this works, but here's a console trace after the fix, showing that the new seed does not get shifted: 

<img width="628" alt="_seed_after" src="https://github.com/user-attachments/assets/fe3b6a77-dbff-493d-825f-800bbfcaf110">



<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
- Load or start a game, and lose or win it
- After going back to the title screen, check the console and ensure that the new "Wave Seed" does not get shifted

If you want to push it a bit farther:
- You can add log in `Pokemon.ts` line 216 to print the generated Pokemon IDs
- Start a new run immediately after the other one finishes
- Add 6 starters if possible, as when testing I needed to add 6 to encounter a duplicate ID mon
- Take note of their ID
- Go to the wave the other run finished
- Make sure the ID of the wild mon that gets generated is not a duplicate to one of your starters

<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [X] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
