### PR TITLE
[P3][UI] Fix egg summary not displaying first mon properly

### DIFF
--- a/src/ui/egg-summary-ui-handler.ts
+++ b/src/ui/egg-summary-ui-handler.ts
@@ -99,8 +99,9 @@ export default class EggSummaryUiHandler extends MessageUiHandler {
 
   clear() {
     super.clear();
-    this.cursor = -1;
     this.scrollGridHandler.reset();
+    this.cursor = -1;
+
     this.summaryContainer.setVisible(false);
     this.pokemonIconsContainer.removeAll(true);
     this.pokemonContainers = [];
@@ -164,8 +165,8 @@ export default class EggSummaryUiHandler extends MessageUiHandler {
 
     this.scrollGridHandler.setTotalElements(this.eggHatchData.length);
     this.updatePokemonIcons();
-
     this.setCursor(0);
+
     this.scene.playSoundWithoutBgm("evolution_fanfare");
     return true;
   }


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
The egg summary no longer fails to show the first Pokemon data
<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?
Messed up when making the egg summary scrollable (PR #4391)  so when viewing the egg summary several times in the same play session the details of the first Pokemon would not get updated until the cursor was moved to another Pokemon and back
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What are the changes from a developer perspective?
Make sure cursor is reset correctly in clear() 

<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos
Before, first and second time seeing the egg summary in the same session:
<img width="330" alt="Screenshot 2024-09-29 at 21 24 35" src="https://github.com/user-attachments/assets/3874a1b2-be16-498a-b97c-8097634e0e94"> <img width="330" alt="Screenshot 2024-09-29 at 21 36 21" src="https://github.com/user-attachments/assets/2de6b982-61e5-4b5a-8c90-c65ce927b75e">

After, seeing the egg summary for the second time of a session:

https://github.com/user-attachments/assets/5ba11a5c-b9ab-4fbc-975d-041565e38068


<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
Use overrides and hatch eggs several times in the same session, making sure to leave the cursor in various spots when exiting.
When getting to the summary next the cursor should always be on the first Pokemon and its information and sprite should be shown in the left panel
```
  EGG_IMMEDIATE_HATCH_OVERRIDE: true,
  EGG_FREE_GACHA_PULLS_OVERRIDE: true
```
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
~~- [ ] Have I considered writing automated tests for the issue?~~
~~- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
