### PR TITLE
[Bug] Add scoring for the Glaive Rush `BattlerTag`s

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -4544,6 +4544,7 @@ export class AddBattlerTagAttr extends MoveEffectAttr {
     case BattlerTagType.DROWSY:
     case BattlerTagType.DISABLED:
     case BattlerTagType.HEAL_BLOCK:
+    case BattlerTagType.RECEIVE_DOUBLE_DAMAGE:
       return -5;
     case BattlerTagType.SEEDED:
     case BattlerTagType.SALT_CURED:
@@ -4564,6 +4565,7 @@ export class AddBattlerTagAttr extends MoveEffectAttr {
     case BattlerTagType.ENCORE:
       return -2;
     case BattlerTagType.MINIMIZED:
+    case BattlerTagType.ALWAYS_GET_HIT:
       return 0;
     case BattlerTagType.INGRAIN:
     case BattlerTagType.IGNORE_ACCURACY:


### PR DESCRIPTION
## What are the changes the user will see?
The AI might use Glaive Rush now.

## Why am I making these changes?
The lack of AI scoring meant the AI would almost never use the move.

## What are the changes from a developer perspective?
The double damage tag is set to `-5`, and the always get hit tag is set to `0`.

## How to test the changes?
Give the enemy Glaive Rush (and other moves like Tackle etc) and check the console logs.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
