### PR TITLE
[Localization] Expert Breeder ME - Egg bug in locales

### DIFF
--- a/src/locales/de/mystery-encounters/the-expert-pokemon-breeder-dialogue.json
+++ b/src/locales/de/mystery-encounters/the-expert-pokemon-breeder-dialogue.json
@@ -25,7 +25,7 @@
   "outro": "Schau wie glücklich dein {{chosenPokemon}} nun ist!$Hier, diese Pokémon-Eier kannst du auch haben.",
   "outro_failed": "Wie enttäuschend...$Es sieht so aus, als hättest du noch einen langen Weg vor dir, um das Vertrauen deines Pokémon zu gewinnen!",
   "gained_eggs": "@s{item_fanfare}Du erhählst {{numEggs}}!",
-  "eggs_tooltip": "\n(+) Erhalte @[TOOLTIP_TITLE]{{{eggs}}}",
+  "eggs_tooltip": "\n(+) Erhalte {{eggs}}",
   "numEggs_one": "{{count}} Ei der Stufe {{rarity}}",
   "numEggs_other": "{{count}} Eier der Stufe {{rarity}}"
 }

--- a/src/locales/fr/mystery-encounters/the-expert-pokemon-breeder-dialogue.json
+++ b/src/locales/fr/mystery-encounters/the-expert-pokemon-breeder-dialogue.json
@@ -25,7 +25,7 @@
   "outro": "Ton {{chosenPokemon}} et toi avez\nl’air très heureux !$Tiens, prends ça aussi.",
   "outro_failed": "Voilà qui est bien décevant…$T’as encore visiblement bien du chemin à faire\npour acquérir la confiance de tes Pokémon !",
   "gained_eggs": "@s{item_fanfare}Vous recevez\n{{numEggs}} !",
-  "eggs_tooltip": "\n(+) Recevez @[TOOLTIP_TITLE]{{{eggs}}}",
+  "eggs_tooltip": "\n(+) Recevez {{eggs}}",
   "numEggs_one": "{{count}} Œuf {{rarity}}",
   "numEggs_other": "{{count}} Œufs {{rarity}}s"
 }

--- a/src/locales/ja/mystery-encounters/the-expert-pokemon-breeder-dialogue.json
+++ b/src/locales/ja/mystery-encounters/the-expert-pokemon-breeder-dialogue.json
@@ -25,7 +25,7 @@
   "outro": "ねえ、　{{chosenPokemon}}　すごく　嬉しくなったわ！$そして、　これらも　どうぞ！",
   "outro_failed": "なんか　ガッカリ　ね……$手持ち　ポケモンの　信用を　得るまで\nまだまだ　みたいんだわ！",
   "gained_eggs": "@s{item_fanfare}{{numEggs}}を　もらいました！",
-  "eggs_tooltip": "\n(+) @[TOOLTIP_TITLE]{{{eggs}}}を得る",
+  "eggs_tooltip": "\n(+) {{eggs}}を得る",
   "numEggs_one": "{{count}}　{{rarity}}　タマゴ",
   "numEggs_other": "{{count}}　{{rarity}}　タマゴ"
 }

--- a/src/locales/ko/mystery-encounters/the-expert-pokemon-breeder-dialogue.json
+++ b/src/locales/ko/mystery-encounters/the-expert-pokemon-breeder-dialogue.json
@@ -26,7 +26,7 @@
   "outro": "{{chosenPokemon}}[[가]] 정말 행복해 보이네요!$여기, 이것도 드릴게요.",
   "outro_failed": "실망이네요….$포켓몬의 신뢰를 얻으려면 아직 멀었어요!",
   "gained_eggs": "@s{item_fanfare}{{numEggs}}[[를]] 받았습니다!",
-  "eggs_tooltip": "\n(+) @[TOOLTIP_TITLE]{{{eggs}}} 획득",
+  "eggs_tooltip": "\n(+) {{eggs}} 획득",
   "numEggs_one": "{{rarity}}알 {{count}}개",
   "numEggs_other": "{{rarity}}알 {{count}}개"
 }

--- a/src/locales/pt_BR/mystery-encounters/the-expert-pokemon-breeder-dialogue.json
+++ b/src/locales/pt_BR/mystery-encounters/the-expert-pokemon-breeder-dialogue.json
@@ -25,7 +25,7 @@
   "outro": "Veja como seu {{chosenPokemon}} está feliz agora!$Aqui, você também pode ficar com isso.",
   "outro_failed": "Que decepção...$Parece que você ainda tem um longo caminho\na percorrer para ganhar a confiança dos seus Pokémon!",
   "gained_eggs": "@s{item_fanfare}Você recebeu {{numEggs}}!",
-  "eggs_tooltip": "\n(+) Ganhe @[TOOLTIP_TITLE]{{{eggs}}}",
+  "eggs_tooltip": "\n(+) Ganhe {{eggs}}",
   "numEggs_one": "{{count}} Ovo {{rarity}}",
   "numEggs_other": "{{count}} Ovos {{rarity}}"
 }


### PR DESCRIPTION
## What are the changes the user will see?
Removed **@[TOOLTIP_TITLE]{{{eggs}}}** into only **{{eggs}}** in many locales.
It prevented the Egg type given by the Expert Breeder to be displayed

## Why am I making these changes?
To have the Egg type given by the Expert Breeder properly displayed

## What are the changes from a developer perspective?
None

### Screenshots/Videos
**Before**
![image](https://github.com/user-attachments/assets/7a5d15b5-410f-4c42-aa9a-27ac60442d4d)

**After**
![image](https://github.com/user-attachments/assets/c2f11c9b-bb97-48d5-8fff-ccfdfd59208f)

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?