### PR TITLE
[Qol] Mark tera shell partial

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -5895,7 +5895,8 @@ export function initAbilities() {
       .attr(FullHpResistTypeAbAttr)
       .attr(UncopiableAbilityAbAttr)
       .attr(UnswappableAbilityAbAttr)
-      .ignorable(),
+      .ignorable()
+      .partial(), // it doesn't interact properly with multihits it should be reducing the entire move, it is not multiscale where it's only the part that breaks full health - Damo, 2024-09-30
     new Ability(Abilities.TERAFORM_ZERO, 9)
       .attr(UncopiableAbilityAbAttr)
       .attr(UnswappableAbilityAbAttr)


### PR DESCRIPTION
## What are the changes the user will see?

Sees `Tera Shell` as partial.

## Why am I making these changes?

> it doesn't interact properly with multihits it should be reducing the entire move, it is not multiscale where it's only the part  that breaks full health 
> At least that's what seems to be reported
> \- damo, 2024-09-30 | [Discord](https://discord.com/channels/1125469663833370665/1250836282926436413/1290264577271140403)

## What are the changes from a developer perspective?

Add `.partial()` to `Tera Shell` + comment why

### Screenshots/Videos

<img width="957" alt="image" src="https://github.com/user-attachments/assets/3b97a362-c2af-4ea9-a26a-701e3657e992">

## How to test the changes?

#### Overrides

```ts
const overrides = {
  ABILITY_OVERRIDE: Abilities.TERA_SHELL
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~~[ ] Have I considered writing automated tests for the issue?~~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
