### PR TITLE
[Bug] Chilly Reception's Snow is called during Enemy AI Move Selection

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5333,7 +5333,7 @@ export class ChillyReceptionAttr extends ForceSwitchOutAttr {
 
   getCondition(): MoveConditionFunc {
     // chilly reception move will go through if the weather is change-able to snow, or the user can switch out, else move will fail
-    return (user, target, move) => user.scene.arena.trySetWeather(WeatherType.SNOW, true) || super.getSwitchOutCondition()(user, target, move);
+    return (user, target, move) => user.scene.arena.weather?.weatherType !== WeatherType.SNOW || super.getSwitchOutCondition()(user, target, move);
   }
 }
 export class RemoveTypeAttr extends MoveEffectAttr {

--- a/src/test/moves/chilly_reception.test.ts
+++ b/src/test/moves/chilly_reception.test.ts
@@ -4,6 +4,7 @@ import { Species } from "#enums/species";
 import { WeatherType } from "#enums/weather-type";
 import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
+//import { TurnInitPhase } from "#app/phases/turn-init-phase";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Moves - Chilly Reception", () => {
@@ -65,5 +66,59 @@ describe("Moves - Chilly Reception", () => {
     await game.phaseInterceptor.to("BerryPhase", false);
     expect(game.scene.arena.weather?.weatherType).toBe(WeatherType.SNOW);
     expect(game.scene.getPlayerField()[0].species.speciesId).toBe(Species.MEOWTH);
+  });
+
+  // enemy uses another move and weather doesn't change
+  it("check case - enemy not selecting chilly reception doesn't change weather ", async () => {
+    game.override.battleType("single")
+      .enemyMoveset([Moves.CHILLY_RECEPTION, Moves.TACKLE])
+      .enemyAbility(Abilities.NONE)
+      .moveset(Array(4).fill(Moves.SPLASH));
+
+    await game.classicMode.startBattle([Species.SLOWKING, Species.MEOWTH]);
+
+    game.move.select(Moves.SPLASH);
+    await game.forceEnemyMove(Moves.TACKLE);
+
+    await game.phaseInterceptor.to("BerryPhase", false);
+    expect(game.scene.arena.weather?.weatherType).toBe(undefined);
+  });
+
+  it("enemy trainer - expected behavior ", async () => {
+    game.override.battleType("single")
+      .startingWave(8)
+      .enemyMoveset(Array(4).fill(Moves.CHILLY_RECEPTION))
+      .enemyAbility(Abilities.NONE)
+      .enemySpecies(Species.MAGIKARP)
+      .moveset([Moves.SPLASH, Moves.THUNDERBOLT]);
+
+    await game.classicMode.startBattle([Species.JOLTEON]);
+    const RIVAL_MAGIKARP1 = game.scene.getEnemyPokemon()?.id;
+
+    game.move.select(Moves.SPLASH);
+    await game.phaseInterceptor.to("BerryPhase", false);
+    expect(game.scene.arena.weather?.weatherType).toBe(WeatherType.SNOW);
+    expect(game.scene.getEnemyPokemon()?.id !== RIVAL_MAGIKARP1);
+
+    await game.phaseInterceptor.to("TurnInitPhase", false);
+    game.move.select(Moves.SPLASH);
+
+    // second chilly reception should still switch out
+    await game.phaseInterceptor.to("BerryPhase", false);
+    expect(game.scene.arena.weather?.weatherType).toBe(WeatherType.SNOW);
+    await game.phaseInterceptor.to("TurnInitPhase", false);
+    expect(game.scene.getEnemyPokemon()?.id === RIVAL_MAGIKARP1);
+    game.move.select(Moves.THUNDERBOLT);
+
+    // enemy chilly recep move should fail: it's snowing and no option to switch out
+    // no crashing
+    await game.phaseInterceptor.to("BerryPhase", false);
+    expect(game.scene.arena.weather?.weatherType).toBe(WeatherType.SNOW);
+    await game.phaseInterceptor.to("TurnInitPhase", false);
+    expect(game.scene.arena.weather?.weatherType).toBe(WeatherType.SNOW);
+    game.move.select(Moves.SPLASH);
+    await game.phaseInterceptor.to("BerryPhase", false);
+    expect(game.scene.arena.weather?.weatherType).toBe(WeatherType.SNOW);
+
   });
 });


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->

Chilly Reception now works properly for enemy 'mons

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Closes issue #4513 (originally from discord)

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
the move attributes `getCondition()` was trying to set the weather (via `trySetWeather()`) when checking the condition, (instead of just checking the weather)


### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

- beta:

https://github.com/user-attachments/assets/2cdcdd97-b8b6-48f8-ad2c-4202c9a59780

- pr

https://github.com/user-attachments/assets/b133347f-38f5-48e4-a137-cf16ad47ac2f

showing checks for trainer battles too

https://github.com/user-attachments/assets/5556fc38-64eb-44e8-8d6b-1f84ff9e912c





## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
set enemy pokemon moves in overrides

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
added some more enemy/trainer tests
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
