### PR TITLE
[P2][Move] Fix Tera Shell to apply to all hits of multi-strike moves

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -519,6 +519,7 @@ export class FullHpResistTypeAbAttr extends PreDefendAbAttr {
 
     if (pokemon.isFullHp() && typeMultiplier.value > 0.5) {
       typeMultiplier.value = 0.5;
+      pokemon.turnData.moveEffectiveness = 0.5;
       return true;
     }
     return false;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1538,9 +1538,10 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * @returns The type damage multiplier, indicating the effectiveness of the move
    */
   getMoveEffectiveness(source: Pokemon, move: Move, ignoreAbility: boolean = false, simulated: boolean = true, cancelled?: Utils.BooleanHolder): TypeDamageMultiplier {
-    if (this.turnData.moveEffectiveness !== null) {
+    if (!Utils.isNullOrUndefined(this.turnData.moveEffectiveness)) {
       return this.turnData.moveEffectiveness;
     }
+
     if (move.hasAttr(TypelessAttr)) {
       return 1;
     }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1538,6 +1538,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * @returns The type damage multiplier, indicating the effectiveness of the move
    */
   getMoveEffectiveness(source: Pokemon, move: Move, ignoreAbility: boolean = false, simulated: boolean = true, cancelled?: Utils.BooleanHolder): TypeDamageMultiplier {
+    if (this.turnData.moveEffectiveness !== null) {
+      return this.turnData.moveEffectiveness;
+    }
     if (move.hasAttr(TypelessAttr)) {
       return 1;
     }
@@ -5019,6 +5022,7 @@ export class PokemonTurnData {
   public order: number;
   public statStagesIncreased: boolean = false;
   public statStagesDecreased: boolean = false;
+  public moveEffectiveness: TypeDamageMultiplier | null = null;
 }
 
 export enum AiType {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1538,8 +1538,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * @returns The type damage multiplier, indicating the effectiveness of the move
    */
   getMoveEffectiveness(source: Pokemon, move: Move, ignoreAbility: boolean = false, simulated: boolean = true, cancelled?: Utils.BooleanHolder): TypeDamageMultiplier {
-    if (!Utils.isNullOrUndefined(this.turnData.moveEffectiveness)) {
-      return this.turnData.moveEffectiveness;
+    if (!Utils.isNullOrUndefined(this.turnData?.moveEffectiveness)) {
+      return this.turnData?.moveEffectiveness;
     }
 
     if (move.hasAttr(TypelessAttr)) {

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -360,6 +360,8 @@ export class MoveEffectPhase extends PokemonPhase {
           this.scene.queueMessage(i18next.t("battle:attackHitsCount", { count: hitsTotal }));
         }
         this.scene.applyModifiers(HitHealModifier, this.player, user);
+        // Clear all cached move effectiveness values among targets
+        this.getTargets().forEach((target) => target.turnData.moveEffectiveness = null);
       }
     }
 

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -354,7 +354,7 @@ export class MoveEffectPhase extends PokemonPhase {
       } else {
         // Queue message for number of hits made by multi-move
         // If multi-hit attack only hits once, still want to render a message
-        const hitsTotal = user.turnData.hitCount! - Math.max(user.turnData.hitsLeft!, 0); // TODO: are those bangs correct?
+        const hitsTotal = user.turnData.hitCount - Math.max(user.turnData.hitsLeft, 0);
         if (hitsTotal > 1 || (user.turnData.hitsLeft && user.turnData.hitsLeft > 0)) {
           // If there are multiple hits, or if there are hits of the multi-hit move left
           this.scene.queueMessage(i18next.t("battle:attackHitsCount", { count: hitsTotal }));


### PR DESCRIPTION
## What are the changes the user will see?
Tera Shell now correctly reduces the effectiveness of all hits of multi-strike moves instead of just the first hit.

## Why am I making these changes?
closes #4218 

## What are the changes from a developer perspective?
- `field/pokemon`: Added new `moveEffectiveness` field to `turnData` which caches a move effectiveness value for the current move being used against the associated Pokemon. If not `null`, this value overrides the output of `Pokemon.getMoveEffectiveness(...)`. This field is currently only used for and modified by Tera Shell's effect.
- `data/ability`: Tera Shell now changes `pokemon.turnData.moveEffectiveness` to 0.5 when the ability applies.
- `phases/move-effect-phase`: now resets `target.turnData.moveEffectiveness` for all targets of the phase's move on the move's last strike.
- `test/abilities/tera_shell.test`: New test for Tera Shell covering all hits of a multi-strike move (specifically Double Hit).

### Screenshots/Videos

## How to test the changes?
`npm run test tera_shell` (includes new test)

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [?] Are the changes visual?
  - [?] Have I provided screenshots/videos of the changes?
