### PR TITLE
[Move] Implement Scale Shot

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2668,6 +2668,20 @@ export class DelayedAttackAttr extends OverrideMoveEffectAttr {
   }
 }
 
+/**
+ * Attribute used for moves that change stat stages
+ * @param stats {@linkcode BattleStat} array of stats to be changed
+ * @param stages stages by which to change the stats, from -6 to 6
+ * @param selfTarget whether the changes are applied to the user (true) or the target (false)
+ * @param condition {@linkcode MoveConditionFunc} optional condition to trigger the stat change
+ * @param firstHitOnly whether the stat change only applies on the first hit of a multi hit move
+ * @param moveEffectTrigger {@linkcode MoveEffectTrigger} the trigger for the effect to take place
+ * @param firstTargetOnly whether, if this is a multi target move, to only apply the effect after the first target is hit, rather than once for each target
+ * @param lastHitOnly whether the effect should only apply after the last hit of a multi hit move
+ *
+ * @extends MoveEffectAttr
+ * @see {@linkcode apply}
+ */
 export class StatStageChangeAttr extends MoveEffectAttr {
   public stats: BattleStat[];
   public stages: integer;
@@ -2682,6 +2696,14 @@ export class StatStageChangeAttr extends MoveEffectAttr {
     this.showMessage = showMessage;
   }
 
+  /**
+   * Attempts to change stats of the user or target (depending on value of selfTarget) if conditions are met
+   * @param user {@linkcode Pokemon} the user of the move
+   * @param target {@linkcode Pokemon} the target of the move
+   * @param move {@linkcode Move} the move
+   * @param args unused
+   * @returns whether stat stages were changed
+   */
   apply(user: Pokemon, target: Pokemon, move: Move, args?: any[]): boolean | Promise<boolean> {
     if (!super.apply(user, target, move, args) || (this.condition && !this.condition(user, target, move))) {
       return false;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2674,8 +2674,8 @@ export class StatStageChangeAttr extends MoveEffectAttr {
   private condition: MoveConditionFunc | null;
   private showMessage: boolean;
 
-  constructor(stats: BattleStat[], stages: integer, selfTarget?: boolean, condition?: MoveConditionFunc | null, showMessage: boolean = true, firstHitOnly: boolean = false, moveEffectTrigger: MoveEffectTrigger = MoveEffectTrigger.HIT, firstTargetOnly: boolean = false) {
-    super(selfTarget, moveEffectTrigger, firstHitOnly, false, firstTargetOnly);
+  constructor(stats: BattleStat[], stages: integer, selfTarget?: boolean, condition?: MoveConditionFunc | null, showMessage: boolean = true, firstHitOnly: boolean = false, moveEffectTrigger: MoveEffectTrigger = MoveEffectTrigger.HIT, firstTargetOnly: boolean = false, lastHitOnly: boolean = false) {
+    super(selfTarget, moveEffectTrigger, firstHitOnly, lastHitOnly, firstTargetOnly);
     this.stats = stats;
     this.stages = stages;
     this.condition = condition!; // TODO: is this bang correct?
@@ -9154,11 +9154,10 @@ export function initMoves() {
       .attr(ClearTerrainAttr)
       .condition((user, target, move) => !!user.scene.arena.terrain),
     new AttackMove(Moves.SCALE_SHOT, Type.DRAGON, MoveCategory.PHYSICAL, 25, 90, 20, -1, 0, 8)
-      //.attr(StatStageChangeAttr, Stat.SPD, 1, true) // TODO: Have boosts only apply at end of move, not after every hit
-      //.attr(StatStageChangeAttr, Stat.DEF, -1, true)
+      .attr(StatStageChangeAttr, [Stat.SPD], 1, true, null, true, false, MoveEffectTrigger.HIT, false, true)
+      .attr(StatStageChangeAttr, [Stat.DEF], -1, true, null, true, false, MoveEffectTrigger.HIT, false, true)
       .attr(MultiHitAttr)
-      .makesContact(false)
-      .partial(),
+      .makesContact(false),
     new AttackMove(Moves.METEOR_BEAM, Type.ROCK, MoveCategory.SPECIAL, 120, 90, 10, 100, 0, 8)
       .attr(ChargeAttr, ChargeAnim.METEOR_BEAM_CHARGING, i18next.t("moveTriggers:isOverflowingWithSpacePower", {pokemonName: "{USER}"}), null, true)
       .attr(StatStageChangeAttr, [ Stat.SPATK ], 1, true)

--- a/src/test/moves/scale_shot.test.ts
+++ b/src/test/moves/scale_shot.test.ts
@@ -1,0 +1,74 @@
+import { DamagePhase } from "#app/phases/damage-phase";
+import { MoveEffectPhase } from "#app/phases/move-effect-phase";
+import { MoveEndPhase } from "#app/phases/move-end-phase";
+import { TurnEndPhase } from "#app/phases/turn-end-phase";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { Stat } from "#enums/stat";
+import GameManager from "#test/utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, it, expect } from "vitest";
+
+describe("Moves - Scale Shot", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([Moves.SCALE_SHOT])
+      .battleType("single")
+      .disableCrits()
+      .starterSpecies(Species.MINCCINO)
+      .ability(Abilities.NO_GUARD)
+      .passiveAbility(Abilities.SKILL_LINK)
+      .enemyAbility(Abilities.SHEER_FORCE)
+      .enemyPassiveAbility(Abilities.STALL)
+      .enemyMoveset(Moves.SKILL_SWAP)
+      .enemyLevel(5);
+  });
+
+  it("applies stat changes after last hit", async () => {
+    await game.classicMode.startBattle([Species.FORRETRESS]);
+    const minccino = game.scene.getPlayerPokemon()!;
+    game.move.select(Moves.SCALE_SHOT);
+    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to(DamagePhase);
+    await game.phaseInterceptor.to(MoveEffectPhase);
+    expect (minccino?.getStatStage(Stat.DEF)).toBe(0);
+    expect (minccino?.getStatStage(Stat.SPD)).toBe(0);
+    await game.phaseInterceptor.to(MoveEndPhase);
+    expect (minccino.getStatStage(Stat.DEF)).toBe(-1);
+    expect (minccino.getStatStage(Stat.SPD)).toBe(1);
+  });
+
+  it("unaffected by sheer force", async () => {
+    await game.classicMode.startBattle([Species.WOBBUFFET]);
+    const minccino = game.scene.getPlayerPokemon()!;
+    const wobbuffet = game.scene.getEnemyPokemon()!;
+    wobbuffet.setStat(Stat.HP, 100, true);
+    wobbuffet.hp = 100;
+    game.move.select(Moves.SCALE_SHOT);
+    await game.phaseInterceptor.to(TurnEndPhase);
+    const hpafter1 = wobbuffet.hp;
+    //effect not nullified by sheer force
+    expect (minccino.getStatStage(Stat.DEF)).toBe(-1);
+    expect (minccino.getStatStage(Stat.SPD)).toBe(1);
+    game.move.select(Moves.SCALE_SHOT);
+    await game.phaseInterceptor.to(MoveEndPhase);
+    const hpafter2 = wobbuffet.hp;
+    //check damage not boosted- make damage before sheer force a little lower than theoretical boosted sheer force damage
+    expect (100 - hpafter1).toBe(hpafter1 - hpafter2);
+  });
+});


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
- Implement Scale Shot

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
- Cool move

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
- Adds a `lastHitOnly` parameter to `StatStageChangeAttr` and uses it for Scale Shot
- Adds docstring for StatStageChangeAttr and its apply function
- Adds test for `scale_shot`

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
Triggers stat change after all hits
![LoadSceneDemo4](https://github.com/user-attachments/assets/629e828a-fd28-4e02-a186-092ab5d3c3b6)

Doesn't trigger change multiple times even with Multi Lens
![LoadSceneDemo5](https://github.com/user-attachments/assets/7c4eeb7d-20b9-4da8-83b7-44a3394c4364)

Per Bulbapedia: "Scale Shot is not considered to have additional effects for the purposes of Sheer Force."
![LoadSceneDemo6](https://github.com/user-attachments/assets/ae6325d1-2e1c-433e-8322-6f83fd52ab7d)

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
- Use Scale Shot (for easy access: Roaring Moon memory mushroom or Dracozolt egg move)
- New test:
  - `npm run test scale_shot`
  - Tests that stat changes are done after the last hit
  - Also tests that it's not boosted by Sheer Force and doesn't have its stat change effect removed by it

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
- [ ] ~~If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
