### PR TITLE
[Beta][P1] Fix rare/-er candy

### DIFF
--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -2204,7 +2204,7 @@ export class PokemonLevelIncrementModifier extends ConsumablePokemonModifier {
    * @param levelCount The amount of levels to increment
    * @returns always `true`
    */
-  override apply(playerPokemon: PlayerPokemon, levelCount: NumberHolder): boolean {
+  override apply(playerPokemon: PlayerPokemon, levelCount: NumberHolder = new NumberHolder(1)): boolean {
     playerPokemon.scene.applyModifiers(LevelIncrementBoosterModifier, true, levelCount);
 
     playerPokemon.level += levelCount.value;


### PR DESCRIPTION
## What are the changes the user will see?

Using rare candies won't crash the game anymore

## Why am I making these changes?

I never wanted them to crash the game

## What are the changes from a developer perspective?

`levelCount` `PokemonLevelIncrementModifier.apply()` now has a default value of `new NumberHolder(1)`

<sub> Apparently if multiple levels are increase the modifiers is simply applied `n` times. instead of putting the value into that  `levelCount`. But that's for another time to fix</sub>

### Screenshots/Videos

https://github.com/user-attachments/assets/57679dbf-d9a2-4889-96c6-7d7f75729679

## How to test the changes?

- Import this session: [sessionData1_bbclover.txt](https://github.com/user-attachments/files/17248329/sessionData1_bbclover.txt)
- Play that session and use the rare-candy

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
    - **Yes and it's awfully complicated**
- ~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~~[ ] Are the changes visual?~~
