### PR TITLE
[Bug][Beta] Fix hit check so Poison-types do not brick semi-invuln.

### DIFF
--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -407,7 +407,7 @@ export class MoveEffectPhase extends PokemonPhase {
     const semiInvulnerableTag = target.getTag(SemiInvulnerableTag);
     if (semiInvulnerableTag
         && !this.move.getMove().getAttrs(HitsTagAttr).some(hta => hta.tagType === semiInvulnerableTag.tagType)
-        && !(this.move.getMove().getAttrs(ToxicAccuracyAttr) && user.isOfType(Type.POISON))
+        && !(this.move.getMove().hasAttr(ToxicAccuracyAttr) && user.isOfType(Type.POISON))
     ) {
       return false;
     }

--- a/src/test/moves/toxic.test.ts
+++ b/src/test/moves/toxic.test.ts
@@ -73,4 +73,17 @@ describe("Moves - Toxic", () => {
 
     expect(game.scene.getEnemyPokemon()!.status).toBeUndefined();
   });
+
+  it("moves other than Toxic should not hit semi-invulnerable targets even if user is Poison-type", async () => {
+    game.override.moveset(Moves.SWIFT);
+    game.override.enemyMoveset(Moves.FLY);
+    await game.classicMode.startBattle([Species.TOXAPEX]);
+
+    game.move.select(Moves.SWIFT);
+    await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+    await game.phaseInterceptor.to("BerryPhase", false);
+
+    const enemyPokemon = game.scene.getEnemyPokemon()!;
+    expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
+  });
 });


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
Currently on beta, all Poison-type Pokemon ignore opposing semi-invulnerability due to a bug introduced by my PR #4445. This bug has not yet hit live servers. This PR fixes the issue so that only Toxic bypasses semi-invuln when used by Poison-types, which is the intended behavior.

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
I broke semi-invuln sorry but this should fix it. Thank you DerTapp, Snailman, and PigeonBar for noticing the bug that I caused and raising it to my attention so quickly on discord.

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Previously my check for Toxic Accuracy attr was incorrect. What I intended to do was bypass semi-invuln if the move used has Toxic Accuracy attr and the user is Poison-type. But instead of checking if the move *has* a Toxic Accuracy attr, I got the array of all the move's attrs matching Toxic Accuracy attr. For all moves other than Toxic itself, this array would be empty. But all arrays in ts/js, even empty ones, are truthy. So in other words my implementation then caused all moves, when used by a Poison-type, to bypass semi-invuln.

This alters the hit check logic to match its intent, which is to actually check if the move has Toxic's accuracy instead of always evaluating that condition to true. I've also added a unit test for Toxic to test for this bug.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
Before: [Screen recording 2024-10-03 4.54.00 PM.webm](https://github.com/user-attachments/assets/1f726f9e-8576-4f3f-a799-6b57cfcac374)

After: [Screen recording 2024-10-03 4.56.59 PM.webm](https://github.com/user-attachments/assets/f8d46e48-44e9-44f8-9187-40f740147a5a)

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Load 
[20241003 Semi-Invulnerable.txt](https://github.com/user-attachments/files/17251178/20241003.Semi-Invulnerable.txt) (Credit: PigeonBar) and select Dive. Without this change, Crobat can hit you even through Dive; with this change, Crobat will no longer be able to hit you.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`) -> no, `src/test/system/game_data.test.ts` is failing. But it's also failing on beta, so I think this change is not the culprit.
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?

