### PR TITLE
[Sprite] Fix variant Farigiraf icon names

### DIFF
--- a/public/images/pokemon_icons_9v.json
+++ b/public/images/pokemon_icons_9v.json
@@ -853,14 +853,14 @@
     "spriteSourceSize": { "x": 7, "y": 2, "w": 27, "h": 26 },
     "sourceSize": { "w": 40, "h": 30 }
    },
-   "981_2.png": {
+   "981_2": {
     "frame": { "x": 108, "y": 87, "w": 23, "h": 30 },
     "rotated": false,
     "trimmed": true,
     "spriteSourceSize": { "x": 9, "y": 0, "w": 23, "h": 30 },
     "sourceSize": { "w": 40, "h": 30 }
    },
-   "981_3.png": {
+   "981_3": {
     "frame": { "x": 246, "y": 86, "w": 23, "h": 30 },
     "rotated": false,
     "trimmed": true,


### PR DESCRIPTION
## What are the changes the user will see?
Variant Farigiraf now use the correct icons for their tier.

## Why am I making these changes?
Reported [here](https://discord.com/channels/1125469663833370665/1238339524778790922/1291624197432414230), Farigiraf was defaulting to its non-shiny icon instead.

## What are the changes from a developer perspective?
No mechanical changes, simple data correction.

### Screenshots/Videos
#### Before
![image](https://github.com/user-attachments/assets/aa93e147-9bd2-4cb6-882e-25320db5fd01)
#### After
![image](https://github.com/user-attachments/assets/d548738d-75e5-4348-a0de-51d89afb59f0)
![image](https://github.com/user-attachments/assets/d862ff63-ac58-491c-b4c9-b35dfd9d665a)

## How to test the changes?
Spawn in a variant Farigiraf using overrides or evolve a Girafarig by teaching it Twin Beam.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
~~- [ ] Have I considered writing automated tests for the issue?~~
~~- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
