### PR TITLE
[P2] Fix evolutions unable to strictly apply to base Pokemon forms

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1707,7 +1707,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     if (pokemonEvolutions.hasOwnProperty(this.species.speciesId)) {
       const evolutions = pokemonEvolutions[this.species.speciesId];
       for (const e of evolutions) {
-        if (!e.item && this.level >= e.level && (!e.preFormKey || this.getFormKey() === e.preFormKey)) {
+        if (!e.item && this.level >= e.level && (isNullOrUndefined(e.preFormKey) || this.getFormKey() === e.preFormKey)) {
           if (e.condition === null || (e.condition as SpeciesEvolutionCondition).predicate(this)) {
             return e;
           }
@@ -1718,7 +1718,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     if (this.isFusion() && this.fusionSpecies && pokemonEvolutions.hasOwnProperty(this.fusionSpecies.speciesId)) {
       const fusionEvolutions = pokemonEvolutions[this.fusionSpecies.speciesId].map(e => new FusionSpeciesFormEvolution(this.species.speciesId, e));
       for (const fe of fusionEvolutions) {
-        if (!fe.item && this.level >= fe.level && (!fe.preFormKey || this.getFusionFormKey() === fe.preFormKey)) {
+        if (!fe.item && this.level >= fe.level && (isNullOrUndefined(fe.preFormKey) || this.getFusionFormKey() === fe.preFormKey)) {
           if (fe.condition === null || (fe.condition as SpeciesEvolutionCondition).predicate(this)) {
             return fe;
           }


### PR DESCRIPTION
## What are the changes the user will see?
G-Max Pikachu, Eevee, Meowth, and Duraludon should no longer be incorrectly prompted or allowed to evolve.

## Why am I making these changes?
Reported [on the Discord](https://discord.com/channels/1125469663833370665/1290042404757438494)

## What are the changes from a developer perspective?
`field/pokemon`: `Pokemon#getEvolution` now uses `isNullOrUndefined(evo.preFormKey)` instead of `!evo.preFormKey` to check if an evolution isn't tied to a specific form. Using `!evo.preFormKey` caused issues because the keys for base forms are `""`,  which is also interpreted as falsy.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
Easiest way using overrides:
1. Give yourself a Level 28 G-Max Meowth.
2. Clear a wave. Then, from the rewards screen, give your G-Max Meowth a Rare Candy.
3. The Meowth should not be prompted to evolve into a Persian.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [?] Are the changes visual?
  - [?] Have I provided screenshots/videos of the changes?
