### PR TITLE
[Test] Update `create-test` script for linting changes

### DIFF
--- a/create-test-boilerplate.js
+++ b/create-test-boilerplate.js
@@ -49,7 +49,7 @@ async function promptFileName(selectedType) {
     {
       type: "input",
       name: "userInput",
-      message: `Please provide a file name for the ${selectedType} test:`,
+      message: `Please provide the name of the ${selectedType}:`,
     },
   ]);
 
@@ -110,7 +110,7 @@ import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
 import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, it, expect } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("${description}", () => {
   let phaserGame: Phaser.Game;
@@ -129,15 +129,22 @@ describe("${description}", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     game.override
-      .moveset([Moves.SPLASH])
+      .moveset([ Moves.SPLASH ])
+      .ability(Abilities.BALL_FETCH)
       .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
       .enemyAbility(Abilities.BALL_FETCH)
       .enemyMoveset(Moves.SPLASH);
   });
 
-  it("test case", async () => {
-    // await game.classicMode.startBattle([Species.MAGIKARP]);
-    // game.move.select(Moves.SPLASH);
+  it("should do X", async () => {
+    await game.classicMode.startBattle([ Species.FEEBAS ]);
+
+    game.move.select(Moves.SPLASH);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(true).toBe(true);
   });
 });
 `;


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
The test creation script would create a test with linting errors due to the recent linting change.

## What are the changes from a developer perspective?
Updated the test creation script to take into account the new linting changes.
Added some extra boilerplate code that is likely to be common across tests.
Updated the test creation prompt to be clearer that you need to enter the name of the move/etc and not the name of the file (since the filename will be derived automatically by the script).

## How to test the changes?
`npm run create-test`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - ~[ ] Are all unit tests still passing? (`npm run test`)~
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
