### PR TITLE
Make duplicate abilities not stack

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -4623,7 +4623,7 @@ async function applyAbAttrsInternal<TAttr extends AbAttr>(
   messages: string[] = [],
 ) {
   for (const passive of [ false, true ]) {
-    if (!pokemon?.canApplyAbility(passive)) {
+    if (!pokemon?.canApplyAbility(passive) || (passive && pokemon.getPassiveAbility().id === pokemon.getAbility().id)) {
       continue;
     }
 

--- a/src/test/abilities/ability_duplication.test.ts
+++ b/src/test/abilities/ability_duplication.test.ts
@@ -1,0 +1,58 @@
+import { Stat } from "#app/enums/stat";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, it, expect } from "vitest";
+
+describe("Ability Duplication", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([ Moves.SPLASH ])
+      .battleType("single")
+      .ability(Abilities.HUGE_POWER)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH);
+  });
+
+  it("huge power should only be applied once if both normal and passive", async () => {
+    game.override.passiveAbility(Abilities.HUGE_POWER);
+
+    await game.classicMode.startBattle([ Species.MAGIKARP ]);
+
+    const [ magikarp ] = game.scene.getPlayerField();
+    const magikarpAttack = magikarp.getEffectiveStat(Stat.ATK);
+
+    magikarp.summonData.abilitySuppressed = true;
+
+    expect(magikarp.getEffectiveStat(Stat.ATK)).toBe(magikarpAttack / 2);
+  });
+
+  it("huge power should stack with pure power", async () => {
+    game.override.passiveAbility(Abilities.PURE_POWER);
+
+    await game.classicMode.startBattle([ Species.MAGIKARP ]);
+
+    const [ magikarp ] = game.scene.getPlayerField();
+    const magikarpAttack = magikarp.getEffectiveStat(Stat.ATK);
+
+    magikarp.summonData.abilitySuppressed = true;
+
+    expect(magikarp.getEffectiveStat(Stat.ATK)).toBe(magikarpAttack / 4);
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?
If due to fusions you have the same ability as both passive and normal, it'll no longer stack with itself.

## Why am I making these changes?
Damo asked.

## What are the changes from a developer perspective?
Duplicate abilities don't stack.

## How to test the changes?
This is difficult to test in game, you'd probably have to look at damage rolls or the like. Or just run the unit tests.

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
