### PR TITLE
[Beta][P1] Fix regression in Metal Burst caused by #3974

### DIFF
--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -375,11 +375,7 @@ export class MovePhase extends BattlePhase {
   protected resolveCounterAttackTarget() {
     if (this.targets.length === 1 && this.targets[0] === BattlerIndex.ATTACKER) {
       if (this.pokemon.turnData.attacksReceived.length) {
-        const attacker = this.pokemon.scene.getPokemonById(this.pokemon.turnData.attacksReceived[0].sourceId);
-
-        if (attacker?.isActive(true)) {
-          this.targets[0] = attacker.getBattlerIndex();
-        }
+        this.targets[0] = this.pokemon.turnData.attacksReceived[0].sourceBattlerIndex;
 
         // account for metal burst and comeuppance hitting remaining targets in double battles
         // counterattack will redirect to remaining ally if original attacker faints

--- a/src/test/moves/metal_burst.test.ts
+++ b/src/test/moves/metal_burst.test.ts
@@ -1,0 +1,80 @@
+import { BattlerIndex } from "#app/battle";
+import { MoveResult } from "#app/field/pokemon";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Moves - Metal Burst", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([ Moves.METAL_BURST, Moves.FISSURE, Moves.PRECIPICE_BLADES ])
+      .ability(Abilities.PURE_POWER)
+      .startingLevel(10)
+      .battleType("double")
+      .disableCrits()
+      .enemySpecies(Species.PICHU)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.TACKLE);
+  });
+
+  it("should redirect target if intended target faints", async () => {
+    await game.classicMode.startBattle([ Species.FEEBAS, Species.FEEBAS ]);
+
+    const [ , enemy2 ] = game.scene.getEnemyField();
+
+    game.move.select(Moves.METAL_BURST);
+    game.move.select(Moves.FISSURE, 1, BattlerIndex.ENEMY);
+
+    await game.forceEnemyMove(Moves.TACKLE, BattlerIndex.PLAYER);
+    await game.forceEnemyMove(Moves.TACKLE, BattlerIndex.PLAYER_2);
+
+    await game.setTurnOrder([ BattlerIndex.ENEMY, BattlerIndex.PLAYER_2, BattlerIndex.PLAYER, BattlerIndex.ENEMY_2 ]);
+
+    await game.phaseInterceptor.to("MoveEndPhase");
+    await game.move.forceHit();
+    await game.phaseInterceptor.to("MoveEndPhase");
+    await game.phaseInterceptor.to("MoveEndPhase");
+
+    expect(enemy2.isFullHp()).toBe(false);
+  });
+
+  it("should not crash if both opponents faint before the move is used", async () => {
+    await game.classicMode.startBattle([ Species.FEEBAS, Species.ARCEUS ]);
+
+    const [ enemy1, enemy2 ] = game.scene.getEnemyField();
+
+    game.move.select(Moves.METAL_BURST);
+    game.move.select(Moves.PRECIPICE_BLADES, 1);
+
+    await game.forceEnemyMove(Moves.TACKLE, BattlerIndex.PLAYER);
+    await game.forceEnemyMove(Moves.TACKLE, BattlerIndex.PLAYER_2);
+
+    await game.setTurnOrder([ BattlerIndex.ENEMY, BattlerIndex.PLAYER_2, BattlerIndex.PLAYER, BattlerIndex.ENEMY_2 ]);
+
+    await game.phaseInterceptor.to("MoveEndPhase");
+    await game.move.forceHit();
+    await game.phaseInterceptor.to("MoveEndPhase");
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(enemy1.isFainted()).toBe(true);
+    expect(enemy2.isFainted()).toBe(true);
+    expect(game.scene.getPlayerField()[0].getLastXMoves(1)[0].result).toBe(MoveResult.FAIL);
+  });
+});

--- a/src/test/utils/helpers/moveHelper.ts
+++ b/src/test/utils/helpers/moveHelper.ts
@@ -13,8 +13,8 @@ import { GameManagerHelper } from "./gameManagerHelper";
  */
 export class MoveHelper extends GameManagerHelper {
   /**
-   * Intercepts `MoveEffectPhase` and mocks the hitCheck's
-   * return value to `true` {@linkcode MoveEffectPhase.hitCheck}.
+   * Intercepts {@linkcode MoveEffectPhase} and mocks the
+   * {@linkcode MoveEffectPhase.hitCheck | hitCheck}'s return value to `true`.
    * Used to force a move to hit.
    */
   async forceHit(): Promise<void> {
@@ -23,8 +23,8 @@ export class MoveHelper extends GameManagerHelper {
   }
 
   /**
-   * Intercepts `MoveEffectPhase` and mocks the hitCheck's
-   * return value to `false` {@linkcode MoveEffectPhase.hitCheck}.
+   * Intercepts {@linkcode MoveEffectPhase} and mocks the
+   * {@linkcode MoveEffectPhase.hitCheck | hitCheck}'s return value to `false`.
    * Used to force a move to miss.
    * @param firstTargetOnly Whether the move should force miss on the first target only, in the case of multi-target moves.
    */


### PR DESCRIPTION
## What are the changes the user will see?
Metal Burst will not crash if the target faints before the user moves.

## Why am I making these changes?
Regression caused by #3974 

## What are the changes from a developer perspective?
The code that accidentally got reverted is put back in, plus tests were added for Metal Burst.

### Screenshots/Videos
For video example of the crash, see #4576 

## How to test the changes?
`npm run test metal_burst`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
