### PR TITLE
[Move] Overhaul Charge Moves

### DIFF
--- a/src/phases/move-charge-phase.ts
+++ b/src/phases/move-charge-phase.ts
@@ -1,0 +1,79 @@
+import BattleScene from "#app/battle-scene";
+import { BattlerIndex } from "#app/battle";
+import { MoveChargeAnim } from "#app/data/battle-anims";
+import { ChargingAttackMove, ChargingSelfStatusMove, applyMoveChargeAttrs, MoveEffectAttr, InstantChargeAttr } from "#app/data/move";
+import Pokemon, { PokemonMove } from "#app/field/pokemon";
+import { BooleanHolder } from "#app/utils";
+import { MovePhase } from "#app/phases/move-phase";
+import { PokemonPhase } from "#app/phases/pokemon-phase";
+import { BattlerTagType } from "#enums/battler-tag-type";
+
+
+export class MoveChargePhase extends PokemonPhase {
+  /** The move instance that this phase applies */
+  public move: PokemonMove;
+  /** The field index targeted by the move (Charging moves assume single target) */
+  public targetIndex: BattlerIndex;
+
+  constructor(scene: BattleScene, battlerIndex: BattlerIndex, targetIndex: BattlerIndex, move: PokemonMove) {
+    super(scene, battlerIndex);
+    this.move = move;
+    this.targetIndex = targetIndex;
+  }
+
+  start() {
+    super.start();
+
+    const user = this.getUserPokemon();
+    const target = this.getTargetPokemon();
+    if (!target) {
+      return this.end();
+    }
+
+    const move = this.move.getMove();
+    if (!(move instanceof ChargingAttackMove || move instanceof ChargingSelfStatusMove)) {
+      return this.end();
+    }
+
+    new MoveChargeAnim(move.chargeAnim, move.id, user).play(this.scene, false, () => {
+      move.showChargeText(user, target);
+      user.getMoveQueue().push({ move: move.id, targets: [ target?.getBattlerIndex() ]});
+
+      if (move instanceof ChargingSelfStatusMove) {
+        user.addTag(BattlerTagType.CHARGING, 1, move.id, user.id);
+        return this.end();
+      }
+
+      applyMoveChargeAttrs(MoveEffectAttr, user, target, move).then(() => {
+        user.addTag(BattlerTagType.CHARGING, 1, move.id, user.id);
+        this.end();
+      });
+    });
+  }
+
+  end() {
+    const user = this.getUserPokemon();
+    const move = this.move.getMove();
+
+    if (move instanceof ChargingAttackMove || move instanceof ChargingSelfStatusMove) {
+      const instantCharge = new BooleanHolder(false);
+
+      applyMoveChargeAttrs(InstantChargeAttr, user, null, move, instantCharge);
+
+      if (instantCharge.value) {
+        this.scene.unshiftPhase(new MovePhase(this.scene, user, [ this.targetIndex ], this.move, true));
+      } else {
+        user.getMoveQueue().push({ move: move.id, targets: [ this.targetIndex ]});
+      }
+    }
+    super.end();
+  }
+
+  getUserPokemon(): Pokemon {
+    return (this.player ? this.scene.getPlayerField() : this.scene.getEnemyField())[this.fieldIndex];
+  }
+
+  getTargetPokemon(): Pokemon | undefined {
+    return this.scene.getField(true).find((p) => this.targetIndex === p.getBattlerIndex());
+  }
+}


### PR DESCRIPTION
## What are the changes the user will see?
This will hopefully fix the myriad of bugs with "charge moves," or moves that have a charging turn. These bugs include
- https://github.com/pagefaultgames/pokerogue/issues/1991
- https://github.com/pagefaultgames/pokerogue/issues/3749
- https://github.com/pagefaultgames/pokerogue/issues/4041
- https://github.com/pagefaultgames/pokerogue/issues/3929
- https://github.com/pagefaultgames/pokerogue/issues/1803

## Why am I making these changes?
`ChargeAttr` and its subclasses are a pile of spaghetti

## What are the changes from a developer perspective?
- `data/move`:
  - Added a new Mixin function `ChargeMove` that adds three fields to the given subclass of `Move`:
    - `chargeAnim`: The charging animation to play during the move's charging phase
    - `chargeText`: The message displayed to the player during the move's charging phase.
    - `chargeAttrs`: an array of `MoveAttrs` applied during the move's charging phase. Some common examples where these are applied are
      1. When the move makes the user semi-invulnerable (e.g. Dig, Fly)
      2. When the move increases the user's stats on the charging turn (e.g. Electro Shot, Skull Bash)
      3. When the move can resolve in 1 turn under certain conditions (e.g. Solar Beam, Electro Shot)

    The Mixin also includes methods analogous to `Move`'s methods for attribute initialization, searching, and filtering. Finally, the Mixin is used to form the following new `Move` subclasses
      - `ChargingAttackMove`
      - `ChargingSelfStatusMove` (currently only used for Geomancy)
    
    This implementation is meant to replace `ChargeAttr` and its subclasses.
- `phases/move-charge-phase`:
  - New phase implementing the charging phase of charge moves. The basic functionality of the phase is as follows:
    1. Play the move's charge animation
    2. Show the move's charge text to the player
    3. Apply all of the move's `MoveEffect` charge attributes
    4. Add a `CHARGING` battler tag to the move's user.
    5. If the move's instant charge conditions are met, unshift a `MovePhase` for the move's attack phase. Otherwise, push this move onto the user's move queue to force the move's use next turn.

- Other planned changes:
  - [ ] `phases/move-phase`: Update `MovePhase` to add a path to `MoveChargePhase` for uncharged charge moves.
  - [ ] `phases/move-effect-phase`: Clean up the `chargeEffect` garbage left over from `ChargeAttr`
  - [ ] `data/battle-anims`: Update how `ChargeAnim`s are loaded to reflect the move away from `ChargeAttr`
  - [ ] Fix Gravity interactions with Fly/Sky Attack
  - [ ] Test coverage for Dig, Fly, Solar Beam, Electro Shot, etc.
  - [ ] Stretch goal: implement Sky Drop

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
Unit test coverage for charge moves will be included soon (tm)

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
