### PR TITLE
[P1] Fix Shop Cursor Indexing Crash

### DIFF
--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -577,6 +577,10 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
     this.getUi().clearText();
     this.eraseCursor();
 
+    // Reset cursor positions
+    this.cursor = 0;
+    this.rowCursor = 0;
+
     /* Multiplies the fade time duration by the speed parameter so that it is always constant, and avoids "flashbangs" at game speed x5 */
     this.scene.hideShopOverlay(750 * this.scene.gameSpeed);
     this.scene.hideLuckText(250);


### PR DESCRIPTION
## What are the changes the user will see?
Having "Shop" as default cursor row should no longer crash the game in certain scenarios when loading into a shop with 0 items.


## Why am I making these changes?
Game was crashing in weird edge cases

## What are the changes from a developer perspective?
Resets cursor indexes when the Shop UI handler is cleared.

### Screenshots/Videos

Before:

![chrome_h13i7BA3Aa](https://github.com/user-attachments/assets/fb86ea99-4687-4caa-9562-8fa52e199a2e)

After (all row indexing behavior for other options remains the same as well):

![chrome_LFCKV3kIlE](https://github.com/user-attachments/assets/e7bdfac9-8b36-4eb6-82ff-f8df64f5f2c5)

Regression for Default Cursor Target "Rewards":

![chrome_DBUJXgDxzT](https://github.com/user-attachments/assets/a399ffa9-e896-4a9f-b877-a76ffec7be71)

Regression for Default Cursor Target "Reroll":

![chrome_nAP5OCseyk](https://github.com/user-attachments/assets/69597eac-eae9-4871-9cdc-4583d0484a95)

Regression for Default Cursor Target "Check Team":

![chrome_UEwvKI7I10](https://github.com/user-attachments/assets/4653d790-807f-4d42-a13e-9cfeafdff884)

## How to test the changes?

Original save for reproducing crash:

[20241002 ME Shop Crash.txt](https://github.com/user-attachments/files/17270313/20241002.ME.Shop.Crash.txt)


## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
- [X] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
