### PR TITLE
[Bug] Fix Battle Bond continuing to affect Water Shuriken after Greninja returns to base form

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1935,19 +1935,21 @@ export class IncrementMovePriorityAttr extends MoveAttr {
  * @see {@linkcode apply}
  */
 export class MultiHitAttr extends MoveAttr {
-  private _intrinsicMultiHitType: MultiHitType;
-  private _multiHitType: MultiHitType;
-
-  // Must be publicly readable for battle_bond.test.ts
-  get multiHitType(): MultiHitType {
-    return this._multiHitType;
-  }
+  /** This move's intrinsic multi-hit type. It should never be modified. */
+  private intrinsicMultiHitType: MultiHitType;
+  /** This move's current multi-hit type. It may be temporarily modified by abilities (e.g., Battle Bond). */
+  private multiHitType: MultiHitType;
 
   constructor(multiHitType?: MultiHitType) {
     super();
 
-    this._intrinsicMultiHitType = multiHitType !== undefined ? multiHitType : MultiHitType._2_TO_5;
-    this._multiHitType = this._intrinsicMultiHitType;
+    this.intrinsicMultiHitType = multiHitType !== undefined ? multiHitType : MultiHitType._2_TO_5;
+    this.multiHitType = this.intrinsicMultiHitType;
+  }
+
+  // Currently used by `battle_bond.test.ts`
+  getMultiHitType(): MultiHitType {
+    return this.multiHitType;
   }
 
   /**
@@ -1961,9 +1963,9 @@ export class MultiHitAttr extends MoveAttr {
    * @returns True
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const hitType = new Utils.NumberHolder(this._intrinsicMultiHitType);
+    const hitType = new Utils.NumberHolder(this.intrinsicMultiHitType);
     applyMoveAttrs(ChangeMultiHitTypeAttr, user, target, move, hitType);
-    this._multiHitType = hitType.value;
+    this.multiHitType = hitType.value;
 
     (args[0] as Utils.NumberHolder).value = this.getHitCount(user, target);
     return true;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1936,7 +1936,7 @@ export class IncrementMovePriorityAttr extends MoveAttr {
  */
 export class MultiHitAttr extends MoveAttr {
   /** This move's intrinsic multi-hit type. It should never be modified. */
-  private intrinsicMultiHitType: MultiHitType;
+  private readonly intrinsicMultiHitType: MultiHitType;
   /** This move's current multi-hit type. It may be temporarily modified by abilities (e.g., Battle Bond). */
   private multiHitType: MultiHitType;
 

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1935,12 +1935,19 @@ export class IncrementMovePriorityAttr extends MoveAttr {
  * @see {@linkcode apply}
  */
 export class MultiHitAttr extends MoveAttr {
-  private multiHitType: MultiHitType;
+  private _intrinsicMultiHitType: MultiHitType;
+  private _multiHitType: MultiHitType;
+
+  // Must be publicly readable for battle_bond.test.ts
+  get multiHitType(): MultiHitType {
+    return this._multiHitType;
+  }
 
   constructor(multiHitType?: MultiHitType) {
     super();
 
-    this.multiHitType = multiHitType !== undefined ? multiHitType : MultiHitType._2_TO_5;
+    this._intrinsicMultiHitType = multiHitType !== undefined ? multiHitType : MultiHitType._2_TO_5;
+    this._multiHitType = this._intrinsicMultiHitType;
   }
 
   /**
@@ -1954,9 +1961,9 @@ export class MultiHitAttr extends MoveAttr {
    * @returns True
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const hitType = new Utils.NumberHolder(this.multiHitType);
+    const hitType = new Utils.NumberHolder(this._intrinsicMultiHitType);
     applyMoveAttrs(ChangeMultiHitTypeAttr, user, target, move, hitType);
-    this.multiHitType = hitType.value;
+    this._multiHitType = hitType.value;
 
     (args[0] as Utils.NumberHolder).value = this.getHitCount(user, target);
     return true;

--- a/src/test/abilities/battle_bond.test.ts
+++ b/src/test/abilities/battle_bond.test.ts
@@ -1,11 +1,10 @@
+import Move, { allMoves, MultiHitAttr, MultiHitType } from "#app/data/move";
 import { Status, StatusEffect } from "#app/data/status-effect";
-import { QuietFormChangePhase } from "#app/phases/quiet-form-change-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
 import GameManager from "#test/utils/gameManager";
-import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 
 describe("Abilities - BATTLE BOND", () => {
@@ -24,40 +23,74 @@ describe("Abilities - BATTLE BOND", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    const moveToUse = Moves.SPLASH;
-    game.override.battleType("single");
-    game.override.ability(Abilities.BATTLE_BOND);
-    game.override.moveset([ moveToUse ]);
-    game.override.enemyMoveset([ Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE ]);
+    game.override.battleType("single")
+      .ability(Abilities.BATTLE_BOND)
+      .moveset([ Moves.SPLASH, Moves.WATER_SHURIKEN ])
+      .enemySpecies(Species.BULBASAUR)
+      .startingLevel(100) // Avoid levelling up
+      .enemyLevel(1000); // Avoid opponent dying before `doKillOpponents()`
   });
 
-  test(
-    "check if fainted pokemon switches to base form on arena reset",
-    async () => {
-      const baseForm = 1;
-      const ashForm = 2;
-      game.override.startingWave(4);
-      game.override.starterForms({
-        [Species.GRENINJA]: ashForm,
-      });
+  it("check if fainted pokemon switches to base form on arena reset", async () => {
+    const baseForm = 1;
+    const ashForm = 2;
+    game.override.startingWave(4)
+      .starterForms({ [Species.GRENINJA]: ashForm, })
+      .enemyMoveset([ Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE ]);
 
-      await game.startBattle([ Species.MAGIKARP, Species.GRENINJA ]);
+    await game.classicMode.startBattle([ Species.MAGIKARP, Species.GRENINJA ]);
 
-      const greninja = game.scene.getParty().find((p) => p.species.speciesId === Species.GRENINJA);
-      expect(greninja).toBeDefined();
-      expect(greninja!.formIndex).toBe(ashForm);
+    const greninja = game.scene.getParty().find((p) => p.species.speciesId === Species.GRENINJA);
+    expect(greninja).toBeDefined();
+    expect(greninja!.formIndex).toBe(ashForm);
 
-      greninja!.hp = 0;
-      greninja!.status = new Status(StatusEffect.FAINT);
-      expect(greninja!.isFainted()).toBe(true);
+    greninja!.hp = 0;
+    greninja!.status = new Status(StatusEffect.FAINT);
+    expect(greninja!.isFainted()).toBe(true);
 
-      game.move.select(Moves.SPLASH);
-      await game.doKillOpponents();
-      await game.phaseInterceptor.to(TurnEndPhase);
-      game.doSelectModifier();
-      await game.phaseInterceptor.to(QuietFormChangePhase);
+    game.move.select(Moves.SPLASH);
+    await game.doKillOpponents();
+    await game.phaseInterceptor.to("TurnEndPhase");
+    game.doSelectModifier();
+    await game.phaseInterceptor.to("QuietFormChangePhase");
 
-      expect(greninja!.formIndex).toBe(baseForm);
-    },
-  );
+    expect(greninja!.formIndex).toBe(baseForm);
+  });
+
+  it("should not keep buffing Water Shuriken after Greninja switches to base form", async () => {
+    const ashForm = 2;
+    game.override.startingWave(4)
+      .starterForms({ [Species.GRENINJA]: ashForm, })
+      .enemyMoveset(Moves.SPLASH);
+    await game.classicMode.startBattle([ Species.GRENINJA ]);
+    // Wave 4: Use Water Shuriken in Ash form
+    let expectedBattlePower = 20;
+    let expectedMultiHitType = MultiHitType._3;
+
+    const waterShuriken = allMoves.find(move => move.id === Moves.WATER_SHURIKEN) as Move;
+    vi.spyOn(waterShuriken, "calculateBattlePower");
+
+    let actualMultiHitType : MultiHitType | null = null;
+    const multiHitAttr = waterShuriken.getAttrs(MultiHitAttr)[0] as MultiHitAttr;
+    vi.spyOn(multiHitAttr, "getHitCount").mockImplementation(() => {
+      actualMultiHitType = multiHitAttr.multiHitType;
+      return 3;
+    });
+
+    game.move.select(Moves.WATER_SHURIKEN);
+    await game.phaseInterceptor.to("BerryPhase", false);
+    expect(waterShuriken.calculateBattlePower).toHaveLastReturnedWith(expectedBattlePower);
+    expect(actualMultiHitType).toBe(expectedMultiHitType);
+
+    await game.doKillOpponents();
+    await game.toNextWave();
+    // Wave 5: Use Water Shuriken in base form
+    expectedBattlePower = 15;
+    expectedMultiHitType = MultiHitType._2_TO_5;
+
+    game.move.select(Moves.WATER_SHURIKEN);
+    await game.phaseInterceptor.to("BerryPhase", false);
+    expect(waterShuriken.calculateBattlePower).toHaveLastReturnedWith(expectedBattlePower);
+    expect(actualMultiHitType).toBe(expectedMultiHitType);
+  });
 });

--- a/src/test/abilities/battle_bond.test.ts
+++ b/src/test/abilities/battle_bond.test.ts
@@ -56,7 +56,7 @@ describe("Abilities - BATTLE BOND", () => {
     expect(greninja.formIndex).toBe(baseForm);
   });
 
-  it("should not keep buffing Water Shuriken after Greninja switches to base form", { repeats: 10 }, async () => {
+  it("should not keep buffing Water Shuriken after Greninja switches to base form", async () => {
     await game.classicMode.startBattle([ Species.GRENINJA ]);
 
     const waterShuriken = allMoves[Moves.WATER_SHURIKEN];
@@ -65,7 +65,7 @@ describe("Abilities - BATTLE BOND", () => {
     let actualMultiHitType: MultiHitType | null = null;
     const multiHitAttr = waterShuriken.getAttrs(MultiHitAttr)[0];
     vi.spyOn(multiHitAttr, "getHitCount").mockImplementation(() => {
-      actualMultiHitType = multiHitAttr.multiHitType;
+      actualMultiHitType = multiHitAttr.getMultiHitType();
       return 3;
     });
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
Base form Greninja will always properly use the base form Water Shuriken (with randomized 2-5 hits), even after transforming into Battle Bond form then returning to base form.

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
I was investigating reported inconsistencies on Wave 35 of the Oct. 2 daily run guide, and this bug turned out to be the root cause.

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
`MultiHitAttr` moves now rely on a new attribute `intrinsicMultiHitType` that never gets modified. This allows such moves to return to their original multiHitType when relevant abilities (such as Battle Bond) stop being applied.

Also added a test.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
Footage explanation:
1. Wave 189: KO the opponent to enter Battle Bond form.
2. Wave 190: Use Water Shuriken once (this triggers the bug), then KO the opponent.
3. Biome transition: Greninja returns to base form.
4. Wave 191: Spam Water Shuriken and note the number of hits each turn.

Before the fix (Base form Greninja always hits 3 times):

https://github.com/user-attachments/assets/f7858522-2e2f-4c2d-ae43-f885be22f7c9

After the fix (Base form Greninja properly hits a variable number of times):

https://github.com/user-attachments/assets/c1a125b5-12bf-46d4-9cce-d1aa2f68ee3e

After the fix (Battle Bond Greninja still always hits 3 times):

https://github.com/user-attachments/assets/d0d5b2c2-ce40-4cf7-9b29-adb0c4962d54

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Testing save file (used for the above recordings):
[20241006 Battle Bond.prsv.txt](https://github.com/user-attachments/files/17270836/20241006.Battle.Bond.prsv.txt)

Also, `npm run test battle_bond`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~~[ ] Are the changes visual?~~
  - [x] Have I provided screenshots/videos of the changes?
