### PR TITLE
[Bug] Syrup Bomb effect is removed when user leaves the field

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2636,16 +2636,16 @@ export class ImprisonTag extends MoveRestrictionBattlerTag {
 /**
  * Battler Tag that applies the effects of Syrup Bomb to the target Pokemon.
  * For three turns, starting from the turn of hit, at the end of each turn, the target Pokemon's speed will decrease by 1.
- * The tag can also expire by taking the target Pokemon off the field.
+ * The tag can also expire by taking the target Pokemon off the field, or the Pokemon that originally used the move.
  */
 export class SyrupBombTag extends BattlerTag {
-  constructor() {
-    super(BattlerTagType.SYRUP_BOMB, BattlerTagLapseType.TURN_END, 3, Moves.SYRUP_BOMB);
+  constructor(sourceId: number) {
+    super(BattlerTagType.SYRUP_BOMB, BattlerTagLapseType.TURN_END, 3, Moves.SYRUP_BOMB, sourceId);
   }
 
   /**
    * Adds the Syrup Bomb battler tag to the target Pokemon.
-   * @param {Pokemon} pokemon the target Pokemon
+   * @param pokemon - The target {@linkcode Pokemon}
    */
   override onAdd(pokemon: Pokemon) {
     super.onAdd(pokemon);
@@ -2654,12 +2654,12 @@ export class SyrupBombTag extends BattlerTag {
 
   /**
    * Applies the single-stage speed down to the target Pokemon and decrements the tag's turn count
-   * @param {Pokemon} pokemon the target Pokemon
-   * @param {BattlerTagLapseType} _lapseType
+   * @param pokemon - The target {@linkcode Pokemon}
+   * @param _lapseType - N/A
    * @returns `true` if the turnCount is still greater than 0 | `false` if the turnCount is 0 or the target Pokemon has been removed from the field
    */
   override lapse(pokemon: Pokemon, _lapseType: BattlerTagLapseType): boolean {
-    if (!pokemon.isActive(true)) {
+    if (!pokemon.isActive(true) || (this.sourceId && !pokemon.scene.getPokemonById(this.sourceId)?.isActive(true))) {
       return false;
     }
     pokemon.scene.queueMessage(i18next.t("battlerTags:syrupBombLapse", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) })); // Custom message in lieu of an animation in mainline
@@ -2673,12 +2673,8 @@ export class SyrupBombTag extends BattlerTag {
 
 /**
  * Retrieves a {@linkcode BattlerTag} based on the provided tag type, turn count, source move, and source ID.
- *
- * @param {BattlerTagType} tagType the type of the {@linkcode BattlerTagType}.
- * @param turnCount the turn count.
- * @param {Moves} sourceMove the source {@linkcode Moves}.
- * @param sourceId the source ID.
- * @returns {BattlerTag} the corresponding {@linkcode BattlerTag} object.
+ * @param sourceId - The ID of the pokemon adding the tag
+ * @returns The corresponding {@linkcode BattlerTag} object.
  */
 export function getBattlerTag(tagType: BattlerTagType, turnCount: number, sourceMove: Moves, sourceId: number): BattlerTag {
   switch (tagType) {
@@ -2847,7 +2843,7 @@ export function getBattlerTag(tagType: BattlerTagType, turnCount: number, source
   case BattlerTagType.IMPRISON:
     return new ImprisonTag(sourceId);
   case BattlerTagType.SYRUP_BOMB:
-    return new SyrupBombTag();
+    return new SyrupBombTag(sourceId);
   case BattlerTagType.NONE:
   default:
     return new BattlerTag(tagType, BattlerTagLapseType.CUSTOM, turnCount, sourceMove, sourceId);

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2656,13 +2656,14 @@ export class SyrupBombTag extends BattlerTag {
    * Applies the single-stage speed down to the target Pokemon and decrements the tag's turn count
    * @param pokemon - The target {@linkcode Pokemon}
    * @param _lapseType - N/A
-   * @returns `true` if the turnCount is still greater than 0 | `false` if the turnCount is 0 or the target Pokemon has been removed from the field
+   * @returns `true` if the `turnCount` is still greater than `0`; `false` if the `turnCount` is `0` or the target or source Pokemon has been removed from the field
    */
   override lapse(pokemon: Pokemon, _lapseType: BattlerTagLapseType): boolean {
-    if (!pokemon.isActive(true) || (this.sourceId && !pokemon.scene.getPokemonById(this.sourceId)?.isActive(true))) {
+    if (this.sourceId && !pokemon.scene.getPokemonById(this.sourceId)?.isActive(true)) {
       return false;
     }
-    pokemon.scene.queueMessage(i18next.t("battlerTags:syrupBombLapse", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) })); // Custom message in lieu of an animation in mainline
+    // Custom message in lieu of an animation in mainline
+    pokemon.scene.queueMessage(i18next.t("battlerTags:syrupBombLapse", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }));
     pokemon.scene.unshiftPhase(new StatStageChangePhase(
       pokemon.scene, pokemon.getBattlerIndex(), true,
       [ Stat.SPD ], -1, true, false, true


### PR DESCRIPTION
## What are the changes the user will see?
When the Pokémon that used Syrup Bomb leaves the field, the end-of-turn speed lowering effect will no longer occur.

## Why am I making these changes?
The current behavior is incorrect.

## What are the changes from a developer perspective?
Added a check to `SyrupBombTag` to see if the source Pokémon is still on the field and remove the tag if it isn't.

## How to test the changes?
`npm run test syrup_bomb`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
