### PR TITLE
hotfix content issue for Weird Dream ME

### DIFF
--- a/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
+++ b/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
@@ -199,11 +199,11 @@ export const WeirdDreamEncounter: MysteryEncounter =
     )
     .withSimpleOption(
       {
-        buttonLabel: `${namespace}.option.2.label`,
-        buttonTooltip: `${namespace}.option.2.tooltip`,
+        buttonLabel: `${namespace}.option.3.label`,
+        buttonTooltip: `${namespace}.option.3.tooltip`,
         selected: [
           {
-            text: `${namespace}.option.2.selected`,
+            text: `${namespace}.option.3.selected`,
           },
         ],
       },

--- a/src/test/mystery-encounter/encounters/weird-dream-encounter.test.ts
+++ b/src/test/mystery-encounter/encounters/weird-dream-encounter.test.ts
@@ -164,11 +164,11 @@ describe("Weird Dream - Mystery Encounter", () => {
       expect(option.optionMode).toBe(MysteryEncounterOptionMode.DEFAULT);
       expect(option.dialogue).toBeDefined();
       expect(option.dialogue).toStrictEqual({
-        buttonLabel: `${namespace}.option.2.label`,
-        buttonTooltip: `${namespace}.option.2.tooltip`,
+        buttonLabel: `${namespace}.option.3.label`,
+        buttonTooltip: `${namespace}.option.3.tooltip`,
         selected: [
           {
-            text: `${namespace}.option.2.selected`,
+            text: `${namespace}.option.3.selected`,
           },
         ],
       });


### PR DESCRIPTION
Incorrect content keys showing in prod because changes were merged in the locales repo before the code changes were deployed to production.

Current production content:
![image](https://github.com/user-attachments/assets/5f18dbdb-e81d-474f-9a6d-629db9bf0ed1)

With fix:
![image](https://github.com/user-attachments/assets/0cb018a1-3571-44dc-a839-6026bda37271)
