### PR TITLE
Undo mistaken hotfix to Weird Dream ME

### DIFF
--- a/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
+++ b/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
@@ -199,11 +199,11 @@ export const WeirdDreamEncounter: MysteryEncounter =
     )
     .withSimpleOption(
       {
-        buttonLabel: `${namespace}.option.3.label`,
-        buttonTooltip: `${namespace}.option.3.tooltip`,
+        buttonLabel: `${namespace}.option.2.label`,
+        buttonTooltip: `${namespace}.option.2.tooltip`,
         selected: [
           {
-            text: `${namespace}.option.3.selected`,
+            text: `${namespace}.option.2.selected`,
           },
         ],
       },

--- a/src/test/mystery-encounter/encounters/weird-dream-encounter.test.ts
+++ b/src/test/mystery-encounter/encounters/weird-dream-encounter.test.ts
@@ -164,11 +164,11 @@ describe("Weird Dream - Mystery Encounter", () => {
       expect(option.optionMode).toBe(MysteryEncounterOptionMode.DEFAULT);
       expect(option.dialogue).toBeDefined();
       expect(option.dialogue).toStrictEqual({
-        buttonLabel: `${namespace}.option.3.label`,
-        buttonTooltip: `${namespace}.option.3.tooltip`,
+        buttonLabel: `${namespace}.option.2.label`,
+        buttonTooltip: `${namespace}.option.2.tooltip`,
         selected: [
           {
-            text: `${namespace}.option.3.selected`,
+            text: `${namespace}.option.2.selected`,
           },
         ],
       });


### PR DESCRIPTION
The bug that was reported was in beta, not production as originally thought. So now prod is actually broken.

![image](https://github.com/user-attachments/assets/c6298fe1-875f-4cd2-b18c-61a79805a30a)

Rollback changes from the hotfix (not undoing the commit so we don't have to force push)