### PR TITLE
[Beta][P3] fix i18n namespaceMap for `mysery-encounter-texts` -> `mysteryEncounterMessages`

### DIFF
--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -82,7 +82,7 @@ const namespaceMap = {
   battleSpecDialogue: "dialogue-final-boss",
   doubleBattleDialogue: "dialogue-double-battle",
   splashMessages: "splash-texts",
-  mysteryEncounterMessages: "mystery-encounter-messages",
+  mysteryEncounterMessages: "mystery-encounter-texts",
 };
 
 //#region Functions


### PR DESCRIPTION
> [!TIP]
> Something I missed in #4611 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- ~~[ ] Have I considered writing automated tests for the issue?~~
- ~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~~[ ] Are the changes visual?~~
