### PR TITLE
[Misc] Enemy item override will now apply to all enemies

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2676,7 +2676,7 @@ export default class BattleScene extends SceneBase {
   }
 
   /**
-    * Removes all modifiers from enemy of PersistentModifier type
+    * Removes all modifiers from enemy pokemon of {@linkcode PersistentModifier} type
     */
   clearEnemyModifiers(): void {
     const modifiersToRemove = this.enemyModifiers.filter(m => m instanceof PersistentModifier);
@@ -2687,7 +2687,8 @@ export default class BattleScene extends SceneBase {
   }
 
   /**
-    * Removes all modifiers from enemy of PokemonHeldItemModifier type
+    * Removes all modifiers from enemy pokemon of {@linkcode PokemonHeldItemModifier} type
+    * @param pokemon - If specified, only removes held items from that {@linkcode Pokemon}
     */
   clearEnemyHeldItemModifiers(pokemon?: Pokemon): void {
     const modifiersToRemove = this.enemyModifiers.filter(m => m instanceof PokemonHeldItemModifier && (!pokemon || m.getPokemon(this) === pokemon));

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2689,8 +2689,8 @@ export default class BattleScene extends SceneBase {
   /**
     * Removes all modifiers from enemy of PokemonHeldItemModifier type
     */
-  clearEnemyHeldItemModifiers(): void {
-    const modifiersToRemove = this.enemyModifiers.filter(m => m instanceof PokemonHeldItemModifier);
+  clearEnemyHeldItemModifiers(pokemon?: Pokemon): void {
+    const modifiersToRemove = this.enemyModifiers.filter(m => m instanceof PokemonHeldItemModifier && (!pokemon || m.getPokemon(this) === pokemon));
     for (const m of modifiersToRemove) {
       this.enemyModifiers.splice(this.enemyModifiers.indexOf(m), 1);
     }

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -3634,7 +3634,7 @@ export function overrideHeldItems(scene: BattleScene, pokemon: Pokemon, isPlayer
   }
 
   if (!isPlayer) {
-    scene.clearEnemyHeldItemModifiers();
+    scene.clearEnemyHeldItemModifiers(pokemon);
   }
 
   heldItemsOverride.forEach(item => {


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Prevents some weirdness if you try to give the opponents a Tera Shard in a double battle

## What are the changes from a developer perspective?
The function that removes held items from enemy Pokémon now takes an optional `pokemon` parameter that specifies which Pokémon to remove items from.

### Screenshots/Videos
![image](https://github.com/user-attachments/assets/a21f4ff2-748e-4408-8857-b5f5d11a1dff)
![image](https://github.com/user-attachments/assets/19f17691-adb7-48ab-b32f-969b230dd403)
(Ignore the random Starf berry on the Roaring Moon, that's a different issue).

## How to test the changes?
Set `OPP_HELD_ITEMS_OVERRIDE` to something and set `BATTLE_TYPE_OVERRIDE: "double"`.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - [x] Have I provided screenshots/videos of the changes?
