### PR TITLE
[Bug] Obstruct/etc no longer reduce stats through Clear Body/etc

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -1376,7 +1376,7 @@ export class ContactStatStageChangeProtectedTag extends DamageProtectedTag {
       const effectPhase = pokemon.scene.getCurrentPhase();
       if (effectPhase instanceof MoveEffectPhase && effectPhase.move.getMove().hasFlag(MoveFlags.MAKES_CONTACT)) {
         const attacker = effectPhase.getPokemon();
-        pokemon.scene.unshiftPhase(new StatStageChangePhase(pokemon.scene, attacker.getBattlerIndex(), true, [ this.stat ], this.levels));
+        pokemon.scene.unshiftPhase(new StatStageChangePhase(pokemon.scene, attacker.getBattlerIndex(), false, [ this.stat ], this.levels));
       }
     }
 

--- a/src/test/moves/obstruct.test.ts
+++ b/src/test/moves/obstruct.test.ts
@@ -1,6 +1,7 @@
-import { Moves } from "#app/enums/moves";
-import { Stat } from "#app/enums/stat";
 import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { Stat } from "#enums/stat";
 import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -22,13 +23,15 @@ describe("Moves - Obstruct", () => {
     game = new GameManager(phaserGame);
     game.override
       .battleType("single")
+      .enemySpecies(Species.MAGIKARP)
+      .enemyMoveset(Moves.TACKLE)
       .enemyAbility(Abilities.BALL_FETCH)
       .ability(Abilities.BALL_FETCH)
-      .moveset([ Moves.OBSTRUCT ]);
+      .moveset([ Moves.OBSTRUCT ])
+      .starterSpecies(Species.FEEBAS);
   });
 
   it("protects from contact damaging moves and lowers the opponent's defense by 2 stages", async () => {
-    game.override.enemyMoveset(Array(4).fill(Moves.ICE_PUNCH));
     await game.classicMode.startBattle();
 
     game.move.select(Moves.OBSTRUCT);
@@ -42,7 +45,6 @@ describe("Moves - Obstruct", () => {
   });
 
   it("bypasses accuracy checks when applying protection and defense reduction", async () => {
-    game.override.enemyMoveset(Array(4).fill(Moves.ICE_PUNCH));
     await game.classicMode.startBattle();
 
     game.move.select(Moves.OBSTRUCT);
@@ -59,7 +61,7 @@ describe("Moves - Obstruct", () => {
   );
 
   it("protects from non-contact damaging moves and doesn't lower the opponent's defense by 2 stages", async () => {
-    game.override.enemyMoveset(Array(4).fill(Moves.WATER_GUN));
+    game.override.enemyMoveset(Moves.WATER_GUN);
     await game.classicMode.startBattle();
 
     game.move.select(Moves.OBSTRUCT);
@@ -73,7 +75,7 @@ describe("Moves - Obstruct", () => {
   });
 
   it("doesn't protect from status moves", async () => {
-    game.override.enemyMoveset(Array(4).fill(Moves.GROWL));
+    game.override.enemyMoveset(Moves.GROWL);
     await game.classicMode.startBattle();
 
     game.move.select(Moves.OBSTRUCT);
@@ -82,5 +84,15 @@ describe("Moves - Obstruct", () => {
     const player = game.scene.getPlayerPokemon()!;
 
     expect(player.getStatStage(Stat.ATK)).toBe(-1);
+  });
+
+  it("doesn't reduce the stats of an opponent with Clear Body/etc", async () => {
+    game.override.enemyAbility(Abilities.CLEAR_BODY);
+    await game.classicMode.startBattle();
+
+    game.move.select(Moves.OBSTRUCT);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(game.scene.getEnemyPokemon()!.getStatStage(Stat.DEF)).toBe(0);
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?
King's Shield/Silk Trap will no longer lower stats if a Pokemon with a protected stat makes contact with the protection. 

## Why am I making these changes?
A bug a day... #4554 

## What are the changes from a developer perspective?
Changed parameter.

### Screenshots/Videos
Correct Interaction

https://github.com/user-attachments/assets/74604f42-8e4d-4882-8548-6757dadb8bdf


Normal Interaction

https://github.com/user-attachments/assets/a1617cca-9ed2-48e4-9097-b690465519f7



## How to test the changes?
Use a Pokemon with a stat protection ability and have it attack a Pokemon using King's Shield or Silk Trap with a contact move. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
