### PR TITLE
[P1 Bug] Fix infinite recursion from abilities disabled by Sheer Force

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1417,10 +1417,10 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * @returns {boolean} Whether the ability is present and active
    */
   hasAbility(ability: Abilities, canApply: boolean = true, ignoreOverride?: boolean): boolean {
-    if ((!canApply || this.canApplyAbility()) && this.getAbility(ignoreOverride).id === ability) {
+    if (this.getAbility(ignoreOverride).id === ability && (!canApply || this.canApplyAbility())) {
       return true;
     }
-    if (this.hasPassive() && (!canApply || this.canApplyAbility(true)) && this.getPassiveAbility().id === ability) {
+    if (this.getPassiveAbility().id === ability && this.hasPassive() && (!canApply || this.canApplyAbility(true))) {
       return true;
     }
     return false;

--- a/src/test/abilities/sheer_force.test.ts
+++ b/src/test/abilities/sheer_force.test.ts
@@ -9,6 +9,7 @@ import { Species } from "#enums/species";
 import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { allMoves } from "#app/data/move";
 
 
 describe("Abilities - Sheer Force", () => {
@@ -173,6 +174,32 @@ describe("Abilities - Sheer Force", () => {
     expect(target.getTypes()[0]).toBe(opponentType);
 
   }, 20000);
+
+  it("Two Pokemon with abilities disabled by Sheer Force hitting each other should not cause a crash", async () => {
+    const moveToUse = Moves.CRUNCH;
+    game.override.enemyAbility(Abilities.COLOR_CHANGE)
+      .ability(Abilities.COLOR_CHANGE)
+      .moveset(moveToUse)
+      .enemyMoveset(moveToUse);
+
+    await game.classicMode.startBattle([
+      Species.PIDGEOT
+    ]);
+
+    const pidgeot = game.scene.getParty()[0];
+    const onix = game.scene.getEnemyParty()[0];
+
+    pidgeot.stats[Stat.DEF] = 10000;
+    onix.stats[Stat.DEF] = 10000;
+
+    game.move.select(moveToUse);
+    await game.toNextTurn();
+
+    // Check that both Pokemon's Color Change activated
+    const expectedTypes = [ allMoves[moveToUse].type ];
+    expect(pidgeot.getTypes()).toStrictEqual(expectedTypes);
+    expect(onix.getTypes()).toStrictEqual(expectedTypes);
+  });
 
   //TODO King's Rock Interaction Unit Test
 });


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
Fixes #2707. Specifically, if two Pokemon have abilities that can be disabled by Sheer Force, and they attack each other using moves with secondary effects, then the game should no longer softlock.

The list of affected abilities is Color Change, Pickpocket, Wimp Out, Emergency Exit, Berserk, and Anger Shell.

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Fixing a crash.

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
When checking whether a Pokemon has a certain ability, the game now checks whether the ability's ID matches before checking whether the ability is disabled. This way, if both sides have abilities that can be disabled by Sheer Force, then the game detects earlier that neither Pokemon has Sheer Force itself and then exits the recursion accordingly.

Also added a test.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
<details>
  <summary>Before the changes: Game softlocks (Berserk vs. Pickpocket)</summary>

https://github.com/user-attachments/assets/e83b344c-4fa7-4417-886c-586dbdc146ae

</details>
<details>
  <summary>After the changes: Game no longer softlocks</summary>

https://github.com/user-attachments/assets/4ed93286-4b74-4db6-977c-542d40e984a9

</details>
<details>
  <summary>After the changes: Sheer Force still correctly disables Pickpocket</summary>

https://github.com/user-attachments/assets/46545e24-7be9-44f6-bb1d-b559e2dddd43

</details>
<details>
  <summary>After the changes: Edge case - Using overrides to give player Pokemon an ability/passive combo of Sheer Force/Berserk, and the opponent Pokemon has Berserk/Sheer Force</summary>

https://github.com/user-attachments/assets/dc5a471e-ade8-4b8c-878f-2b3930200cd1

</details>

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
`npm run test sheer_force`

## Checklist
- [x] **I'm using `beta` as my base branch**
- ~~[ ] There is no overlap with another PR?~~
  - Stale PR: #3018
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~~[ ] Are the changes visual?~~
  - [x] Have I provided screenshots/videos of the changes?
