### PR TITLE
[P3] Fix "Won't Go Any Lower/Higher" Not Appearing

### DIFF
--- a/src/enums/stat.ts
+++ b/src/enums/stat.ts
@@ -50,7 +50,7 @@ export function getStatStageChangeDescriptionKey(stages: number, isIncrease: boo
     return isIncrease ? "battle:statRose" : "battle:statFell";
   } else if (stages === 2) {
     return isIncrease ? "battle:statSharplyRose" : "battle:statHarshlyFell";
-  } else if (stages <= 6) {
+  } else if (stages > 2 && stages <= 6) {
     return isIncrease ? "battle:statRoseDrastically" : "battle:statSeverelyFell";
   }
   return isIncrease ? "battle:statWontGoAnyHigher" : "battle:statWontGoAnyLower";


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->

Lowering or raising a stat stage below -6 or beyond +6 will no longer display the wrong message ("X severely fell" or "X drastically rose").

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

#2699 had replaced the original `getBattleStatLevelChangeDescription`, which incorrectly translated `switch-case` to an `if-else` for the case where stat stages could no longer be lowered/raised. This caused the wrong stat stage change description to get pushed instead of the correct one.

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

Added `stages > 2` to the boolean that triggers the "X severely fell"/"X drastically rose" messages to prevent it from triggering in the case that `stages` is equal to 0, which indicates that a stat cannot be lowered or raised.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

#### Before

Refer to #4537 for a visual of the bug.

#### After

https://github.com/user-attachments/assets/2534e640-fe92-4fa5-9d1d-e8fa4eb0bb78

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

Use any stat stage lowering/increasing move (e.g., `Shell Smash`) and use keep using it until you reach the minimum/maximum most stat stage. Using the move one more time should now display the right message ("X won't go any higher/lower!") as opposed to the current one.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
