### PR TITLE
[P3] Fix "falsex" type hint for Sheer Cold

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -4556,18 +4556,19 @@ export class WaterSuperEffectTypeMultiplierAttr extends VariableMoveTypeMultipli
 export class IceNoEffectTypeAttr extends VariableMoveTypeMultiplierAttr {
   /**
    * Checks to see if the Target is Ice-Type or not. If so, the move will have no effect.
-   * @param {Pokemon} user N/A
-   * @param {Pokemon} target Pokemon that is being checked whether Ice-Type or not.
-   * @param {Move} move N/A
-   * @param {any[]} args Sets to false if the target is Ice-Type, so it should do no damage/no effect.
-   * @returns {boolean} Returns true if move is successful, false if Ice-Type.
+   * @param user n/a
+   * @param target The {@linkcode Pokemon} targeted by the move
+   * @param move n/a
+   * @param args `[0]` a {@linkcode Utils.NumberHolder | NumberHolder} containing a type effectiveness multiplier
+   * @returns `true` if this Ice-type immunity applies; `false` otherwise
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    const multiplier = args[0] as Utils.NumberHolder;
     if (target.isOfType(Type.ICE)) {
-      (args[0] as Utils.BooleanHolder).value = false;
-      return false;
+      multiplier.value = 0;
+      return true;
     }
-    return true;
+    return false;
   }
 }
 


### PR DESCRIPTION
## What are the changes the user will see?
Sheer Cold will no longer show a type hint of "falsex" against Ice-type Pokemon

## Why am I making these changes?
Sheer Cold's code is old as hell but somehow worked with the new type effectiveness code, so I missed it earlier.

## What are the changes from a developer perspective?
`data/move`: Sheer Cold's `IceNoEffectTypeAttr` no longer interprets the type effectiveness multiplier as a boolean, and now sets the type multiplier to 0 instead of `false`.

### Screenshots/Videos

![image](https://github.com/user-attachments/assets/ffa75657-0398-43a4-94e6-74b44c3e53c6)

## How to test the changes?
1. Use `src/overrides.ts` to give your Pokemon Sheer Cold and set the enemy species to an Ice-type.
2. Start a new game
3. Enable type hints
4. Sheer Cold's type hint should show as "0x" instead of "falsex"

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
