### PR TITLE
[Test] Fix several flaky tests

### DIFF
--- a/src/test/moves/safeguard.test.ts
+++ b/src/test/moves/safeguard.test.ts
@@ -33,7 +33,7 @@ describe("Moves - Safeguard", () => {
       .enemyLevel(5)
       .starterSpecies(Species.DRATINI)
       .moveset([ Moves.NUZZLE, Moves.SPORE, Moves.YAWN, Moves.SPLASH ])
-      .ability(Abilities.BALL_FETCH);
+      .ability(Abilities.UNNERVE); // Stop wild Pokemon from potentially eating Lum Berry
   });
 
   it("protects from damaging moves with additional effects", async () => {

--- a/src/test/mystery-encounter/encounters/an-offer-you-cant-refuse-encounter.test.ts
+++ b/src/test/mystery-encounter/encounters/an-offer-you-cant-refuse-encounter.test.ts
@@ -18,6 +18,7 @@ import { Moves } from "#enums/moves";
 import { ShinyRateBoosterModifier } from "#app/modifier/modifier";
 import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
 import i18next from "i18next";
+import { Abilities } from "#enums/abilities";
 
 const namespace = "mysteryEncounters/anOfferYouCantRefuse";
 /** Gyarados for Indimidate */
@@ -37,10 +38,11 @@ describe("An Offer You Can't Refuse - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override.mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves()
+      .ability(Abilities.INTIMIDATE); // Extortion ability
 
     const biomeMap = new Map<Biome, MysteryEncounterType[]>([
       [ Biome.VOLCANO, [ MysteryEncounterType.MYSTERIOUS_CHALLENGERS ]],
@@ -195,6 +197,7 @@ describe("An Offer You Can't Refuse - Mystery Encounter", () => {
     });
 
     it("should award EXP to a pokemon with a move in EXTORTION_MOVES", async () => {
+      game.override.ability(Abilities.SYNCHRONIZE); // Not an extortion ability, so we can test extortion move
       await game.runToMysteryEncounter(MysteryEncounterType.AN_OFFER_YOU_CANT_REFUSE, [ Species.ABRA ]);
       const party = scene.getParty();
       const abra = party.find((pkm) => pkm.species.speciesId === Species.ABRA)!;

--- a/src/test/mystery-encounter/encounters/berries-abound-encounter.test.ts
+++ b/src/test/mystery-encounter/encounters/berries-abound-encounter.test.ts
@@ -176,10 +176,12 @@ describe("Berries Abound - Mystery Encounter", () => {
       const encounterTextSpy = vi.spyOn(EncounterDialogueUtils, "showEncounterText");
       await game.runToMysteryEncounter(MysteryEncounterType.BERRIES_ABOUND, defaultParty);
 
+      scene.getParty().forEach(pkm => {
+        vi.spyOn(pkm, "getStat").mockReturnValue(1); // for ease return for every stat
+      });
+
       const config = game.scene.currentBattle.mysteryEncounter!.enemyPartyConfigs[0];
       const speciesToSpawn = config.pokemonConfigs?.[0].species.speciesId;
-      // Setting enemy's level arbitrarily high to outspeed
-      config.pokemonConfigs![0].dataSource!.level = 1000;
 
       await runMysteryEncounterToEnd(game, 2, undefined, true);
 
@@ -198,10 +200,12 @@ describe("Berries Abound - Mystery Encounter", () => {
       const encounterTextSpy = vi.spyOn(EncounterDialogueUtils, "showEncounterText");
       await game.runToMysteryEncounter(MysteryEncounterType.BERRIES_ABOUND, defaultParty);
 
+      scene.getParty().forEach(pkm => {
+        vi.spyOn(pkm, "getStat").mockReturnValue(1); // for ease return for every stat
+      });
+
       const config = game.scene.currentBattle.mysteryEncounter!.enemyPartyConfigs[0];
       const speciesToSpawn = config.pokemonConfigs?.[0].species.speciesId;
-      // Setting enemy's level arbitrarily high to outspeed
-      config.pokemonConfigs![0].dataSource!.level = 1000;
 
       await runMysteryEncounterToEnd(game, 2, undefined, true);
 

--- a/src/test/mystery-encounter/encounters/the-pokemon-salesman-encounter.test.ts
+++ b/src/test/mystery-encounter/encounters/the-pokemon-salesman-encounter.test.ts
@@ -147,8 +147,8 @@ describe("The Pokemon Salesman - Mystery Encounter", () => {
 
       expect(scene.getParty().length).toBe(initialPartySize + 1);
 
-      const newlyPurchasedPokemon = scene.getParty().find(p => p.name === pokemonName);
-      expect(newlyPurchasedPokemon).toBeDefined();
+      const newlyPurchasedPokemon = scene.getParty()[scene.getParty().length - 1];
+      expect(newlyPurchasedPokemon.name).toBe(pokemonName);
       expect(newlyPurchasedPokemon!.moveset.length > 0).toBeTruthy();
     });
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
N/A

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Fixing several known cases of flaky tests (https://discord.com/channels/1125469663833370665/1286833394277421148), which were each occasionally breaking for different reasons.

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
`an-offer-you-cant-refuse` - Added a proper override to give the ability Intimidate (This test could previously break due to Gyarados having its HA instead of Intimidate).
`pokemon-salesman` - Now checks whether specifically the final Pokemon in the party is the purchased Pokemon (This test could previously break if the purchased Pokemon happens to be the same species as one of the starting Pokemon).
`berries-abound` - For tests where the wild Pokemon is meant to outspeed the party, force the party's speed to be 1 (This test could previously break due to wild Shuckle getting outsped by the party. Truly a Shuckle moment.).
`safeguard` - Added an override to give the player Unnerve to prevent the wild Pokemon from eating a Lum Berry. (Note: Opponent held item overrides currently also allow opponents to spawn with the usual random items on top of the overrides.)

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
N/A

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
To verify that a test is no longer flaky, repeat it a large number of times. Using the `{repeats: ###}` method on ME tests apparently runs into issues with loading font, so you can use this method instead (credit: [flx on Discord](https://discord.com/channels/1125469663833370665/1288886843995324548/1291482332615938097)):

`it.only.each(Array.from({length: ###}))("should etc. etc.", () => {`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~~[ ] Are the changes visual?~~
  - ~~[ ] Have I provided screenshots/videos of the changes?~~
