### PR TITLE
[Refactor] Clean up `StatStageChangePhase` and `PokemonPhase`

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2051,7 +2051,7 @@ export class StockpilingTag extends BattlerTag {
     super(BattlerTagType.STOCKPILING, BattlerTagLapseType.CUSTOM, 1, sourceMove);
   }
 
-  private onStatStagesChanged: StatStageChangeCallback = (_, statsChanged, statChanges) => {
+  private onStatStagesChanged: StatStageChangeCallback = (statsChanged, statChanges, _target) => {
     const defChange = statChanges[statsChanged.indexOf(Stat.DEF)] ?? 0;
     const spDefChange = statChanges[statsChanged.indexOf(Stat.SPDEF)] ?? 0;
 

--- a/src/phases/check-switch-phase.ts
+++ b/src/phases/check-switch-phase.ts
@@ -50,7 +50,7 @@ export class CheckSwitchPhase extends BattlePhase {
     this.scene.ui.showText(i18next.t("battle:switchQuestion", { pokemonName: this.useName ? getPokemonNameWithAffix(pokemon) : i18next.t("battle:pokemon") }), null, () => {
       this.scene.ui.setMode(Mode.CONFIRM, () => {
         this.scene.ui.setMode(Mode.MESSAGE);
-        this.scene.tryRemovePhase(p => p instanceof PostSummonPhase && p.player && p.fieldIndex === this.fieldIndex);
+        this.scene.tryRemovePhase(p => p instanceof PostSummonPhase && p.isPlayer && p.fieldIndex === this.fieldIndex);
         this.scene.unshiftPhase(new SwitchPhase(this.scene, SwitchType.SWITCH, this.fieldIndex, false, true));
         this.end();
       }, () => {

--- a/src/phases/common-anim-phase.ts
+++ b/src/phases/common-anim-phase.ts
@@ -21,7 +21,7 @@ export class CommonAnimPhase extends PokemonPhase {
   }
 
   start() {
-    const target = this.targetIndex !== undefined ? (this.player ? this.scene.getEnemyField() : this.scene.getPlayerField())[this.targetIndex] : this.getPokemon();
+    const target = this.targetIndex !== undefined ? (this.isPlayer ? this.scene.getEnemyField() : this.scene.getPlayerField())[this.targetIndex] : this.getPokemon();
     new CommonBattleAnim(this.anim, this.getPokemon(), target).play(this.scene, false, () => {
       this.end();
     });

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -33,13 +33,13 @@ export class FaintPhase extends PokemonPhase {
     super.start();
 
     if (!this.preventEndure) {
-      const instantReviveModifier = this.scene.applyModifier(PokemonInstantReviveModifier, this.player, this.getPokemon()) as PokemonInstantReviveModifier;
+      const instantReviveModifier = this.scene.applyModifier(PokemonInstantReviveModifier, this.isPlayer, this.getPokemon()) as PokemonInstantReviveModifier;
 
       if (instantReviveModifier) {
         if (!--instantReviveModifier.stackCount) {
           this.scene.removeModifier(instantReviveModifier);
         }
-        this.scene.updateModifiers(this.player);
+        this.scene.updateModifiers(this.isPlayer);
         return this.end();
       }
     }
@@ -88,7 +88,7 @@ export class FaintPhase extends PokemonPhase {
       }
     }
 
-    if (this.player) {
+    if (this.isPlayer) {
       /** The total number of Pokemon in the player's party that can legally fight */
       const legalPlayerPokemon = this.scene.getParty().filter(p => p.isAllowedInBattle());
       /** The total number of legal player Pokemon that aren't currently on the field */
@@ -159,7 +159,7 @@ export class FaintPhase extends PokemonPhase {
   tryOverrideForBattleSpec(): boolean {
     switch (this.scene.currentBattle.battleSpec) {
     case BattleSpec.FINAL_BOSS:
-      if (!this.player) {
+      if (!this.isPlayer) {
         const enemy = this.getPokemon();
         if (enemy.formIndex) {
           this.scene.ui.showDialogue(battleSpecDialogue[BattleSpec.FINAL_BOSS].secondStageWin, enemy.species.name, null, () => this.doFaint());

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -290,7 +290,7 @@ export class MoveEffectPhase extends PokemonPhase {
                                * steal an item from the target granted by Grip Claw
                                */
                             if (this.move.getMove() instanceof AttackMove) {
-                              this.scene.applyModifiers(ContactHeldItemTransferChanceModifier, this.player, user, target);
+                              this.scene.applyModifiers(ContactHeldItemTransferChanceModifier, this.isPlayer, user, target);
                             }
                             resolve();
                           });
@@ -360,7 +360,7 @@ export class MoveEffectPhase extends PokemonPhase {
           // If there are multiple hits, or if there are hits of the multi-hit move left
           this.scene.queueMessage(i18next.t("battle:attackHitsCount", { count: hitsTotal }));
         }
-        this.scene.applyModifiers(HitHealModifier, this.player, user);
+        this.scene.applyModifiers(HitHealModifier, this.isPlayer, user);
         // Clear all cached move effectiveness values among targets
         this.getTargets().forEach((target) => target.turnData.moveEffectiveness = null);
       }
@@ -429,7 +429,7 @@ export class MoveEffectPhase extends PokemonPhase {
     if (this.battlerIndex > BattlerIndex.ENEMY_2) {
       return this.scene.getPokemonById(this.battlerIndex) ?? undefined;
     }
-    return (this.player ? this.scene.getPlayerField() : this.scene.getEnemyField())[this.fieldIndex];
+    return (this.isPlayer ? this.scene.getPlayerField() : this.scene.getEnemyField())[this.fieldIndex];
   }
 
   /** Returns an array of all {@linkcode Pokemon} targeted by this phase's invoked move */

--- a/src/phases/pokemon-heal-phase.ts
+++ b/src/phases/pokemon-heal-phase.ts
@@ -61,7 +61,7 @@ export class PokemonHealPhase extends CommonAnimPhase {
     } else if (healOrDamage) {
       const hpRestoreMultiplier = new Utils.IntegerHolder(1);
       if (!this.revive) {
-        this.scene.applyModifiers(HealingBoosterModifier, this.player, hpRestoreMultiplier);
+        this.scene.applyModifiers(HealingBoosterModifier, this.isPlayer, hpRestoreMultiplier);
       }
       const healAmount = new Utils.NumberHolder(Math.floor(this.hpHealed * hpRestoreMultiplier.value));
       if (healAmount.value < 0) {

--- a/src/phases/pokemon-phase.ts
+++ b/src/phases/pokemon-phase.ts
@@ -1,29 +1,33 @@
-import BattleScene from "#app/battle-scene";
 import { BattlerIndex } from "#app/battle";
+import BattleScene from "#app/battle-scene";
 import Pokemon from "#app/field/pokemon";
-import { FieldPhase } from "./field-phase";
+import { FieldPhase } from "#app/phases/field-phase";
 
 export abstract class PokemonPhase extends FieldPhase {
-  protected battlerIndex: BattlerIndex | integer;
-  public player: boolean;
-  public fieldIndex: integer;
+  protected battlerIndex: BattlerIndex | number;
+  public isPlayer: boolean;
+  public fieldIndex: number;
 
-  constructor(scene: BattleScene, battlerIndex?: BattlerIndex | integer) {
+  constructor(scene: BattleScene, battlerIndex?: BattlerIndex | number) {
     super(scene);
 
     if (battlerIndex === undefined) {
-      battlerIndex = scene.getField().find(p => p?.isActive())!.getBattlerIndex(); // TODO: is the bang correct here?
+      battlerIndex = scene.getField().find(p => p?.isActive())?.getBattlerIndex();
     }
 
-    this.battlerIndex = battlerIndex;
-    this.player = battlerIndex < 2;
-    this.fieldIndex = battlerIndex % 2;
+    if (battlerIndex !== undefined) {
+      this.battlerIndex = battlerIndex;
+      this.isPlayer = battlerIndex < 2;
+      this.fieldIndex = battlerIndex % 2;
+    } else {
+      console.warn("Unable to find pokemon battlerIndex!");
+    }
   }
 
   getPokemon(): Pokemon {
     if (this.battlerIndex > BattlerIndex.ENEMY_2) {
       return this.scene.getPokemonById(this.battlerIndex)!; //TODO: is this bang correct?
     }
-    return this.scene.getField()[this.battlerIndex]!; //TODO: is this bang correct?
+    return this.scene.getField()[this.battlerIndex];
   }
 }

--- a/src/test/battlerTags/stockpiling.test.ts
+++ b/src/test/battlerTags/stockpiling.test.ts
@@ -1,10 +1,10 @@
 import BattleScene from "#app/battle-scene";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import Pokemon, { PokemonSummonData } from "#app/field/pokemon";
 import { StockpilingTag } from "#app/data/battler-tags";
-import { Stat } from "#enums/stat";
+import Pokemon, { PokemonSummonData } from "#app/field/pokemon";
 import * as messages from "#app/messages";
 import { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
+import { Stat } from "#enums/stat";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 beforeEach(() => {
   vi.spyOn(messages, "getPokemonNameWithAffix").mockImplementation(() => "");
@@ -27,7 +27,7 @@ describe("BattlerTag - StockpilingTag", () => {
         expect((phase as StatStageChangePhase)["stages"]).toEqual(1);
         expect((phase as StatStageChangePhase)["stats"]).toEqual(expect.arrayContaining([ Stat.DEF, Stat.SPDEF ]));
 
-        (phase as StatStageChangePhase)["onChange"]!(mockPokemon, [ Stat.DEF, Stat.SPDEF ], [ 1, 1 ]);
+        (phase as StatStageChangePhase)["onChange"]!([ Stat.DEF, Stat.SPDEF ], [ 1, 1 ], mockPokemon);
       });
 
       subject.onAdd(mockPokemon);
@@ -54,7 +54,7 @@ describe("BattlerTag - StockpilingTag", () => {
         expect((phase as StatStageChangePhase)["stages"]).toEqual(1);
         expect((phase as StatStageChangePhase)["stats"]).toEqual(expect.arrayContaining([ Stat.DEF, Stat.SPDEF ]));
 
-        (phase as StatStageChangePhase)["onChange"]!(mockPokemon, [ Stat.DEF, Stat.SPDEF ], [ 1, 1 ]);
+        (phase as StatStageChangePhase)["onChange"]!([ Stat.DEF, Stat.SPDEF ], [ 1, 1 ], mockPokemon);
       });
 
       subject.onAdd(mockPokemon);
@@ -79,7 +79,7 @@ describe("BattlerTag - StockpilingTag", () => {
         expect((phase as StatStageChangePhase)["stages"]).toEqual(1);
         expect((phase as StatStageChangePhase)["stats"]).toEqual(expect.arrayContaining([ Stat.DEF, Stat.SPDEF ]));
 
-        (phase as StatStageChangePhase)["onChange"]!(mockPokemon, [ Stat.DEF, Stat.SPDEF ], [ 1, 1 ]);
+        (phase as StatStageChangePhase)["onChange"]!([ Stat.DEF, Stat.SPDEF ], [ 1, 1 ], mockPokemon);
       });
 
       subject.onOverlap(mockPokemon);
@@ -109,7 +109,7 @@ describe("BattlerTag - StockpilingTag", () => {
         expect((phase as StatStageChangePhase)["stats"]).toEqual(expect.arrayContaining([ Stat.DEF, Stat.SPDEF ]));
 
         // def doesn't change
-        (phase as StatStageChangePhase)["onChange"]!(mockPokemon, [ Stat.SPDEF ], [ 1 ]);
+        (phase as StatStageChangePhase)["onChange"]!([ Stat.SPDEF ], [ 1 ], mockPokemon);
       });
 
       subject.onAdd(mockPokemon);
@@ -121,7 +121,7 @@ describe("BattlerTag - StockpilingTag", () => {
         expect((phase as StatStageChangePhase)["stats"]).toEqual(expect.arrayContaining([ Stat.DEF, Stat.SPDEF ]));
 
         // def doesn't change
-        (phase as StatStageChangePhase)["onChange"]!(mockPokemon, [ Stat.SPDEF ], [ 1 ]);
+        (phase as StatStageChangePhase)["onChange"]!([ Stat.SPDEF ], [ 1 ], mockPokemon);
       });
 
       subject.onOverlap(mockPokemon);


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Because it was there.

## What are the changes from a developer perspective?
The `const end = () => { ... };` inside of the `start()` method was moved into its own class method.
An unused method `aggregateStatStageChanges()` was removed.
`player` was renamed to `isPlayer` in `PokemonPhase` for clarity.

## How to test the changes?
Use moves that alter stat stages.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
