### PR TITLE
[P3][UI] Fix tooltip bugs in Starter Select screen

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -2963,8 +2963,12 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.natureCursor = -1;
 
     if (this.activeTooltip === "CANDY") {
-      const { currentFriendship, friendshipCap } = this.getFriendship(this.lastSpecies.speciesId);
-      this.scene.ui.editTooltip("", `${currentFriendship}/${friendshipCap}`);
+      if (this.lastSpecies) {
+        const { currentFriendship, friendshipCap } = this.getFriendship(this.lastSpecies.speciesId);
+        this.scene.ui.editTooltip("", `${currentFriendship}/${friendshipCap}`);
+      } else {
+        this.scene.ui.hideTooltip();
+      }
     }
 
     if (species?.forms?.find(f => f.formKey === "female")) {

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -3659,6 +3659,9 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     StarterPrefs.save(this.starterPreferences);
     this.cursor = -1;
     this.hideInstructions();
+    this.activeTooltip = undefined;
+    this.scene.ui.hideTooltip();
+
     this.starterSelectContainer.setVisible(false);
     this.blockInput = false;
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
Moving away from a Pokemon while the candy friendship tooltip is shown no longer causes issues
Any tooltip shown when exiting starter select now gets cleared
<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?
In start select if you move from a Pokemon detailed view to the filters or the start button, the Pokemon details are cleared. But if you do that while the candy friendship tooltip is shown, everything bugs out instead

<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What are the changes from a developer perspective?
- Check for undefined `lastSpecies` when updating the tooltip
- hide tooltips in `clear()`
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos
Before:

https://github.com/user-attachments/assets/1c37933b-b9ef-48ba-bd29-af0474462c85

After:

https://github.com/user-attachments/assets/54f85581-6a6c-4bd5-bea4-1b3f0f3a5834

https://github.com/user-attachments/assets/c5699380-4f73-4016-a492-d672a953f5cb


<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
Place your mouse over the candy icon on a starter and move around the UI in various ways, or try opening the filters with the `shift` shortcut

<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
~~- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
