### PR TITLE
[QoL][UI] Add input delay before skipping egg summary

### DIFF
--- a/src/phases/egg-lapse-phase.ts
+++ b/src/phases/egg-lapse-phase.ts
@@ -33,7 +33,7 @@ export class EggLapsePhase extends Phase {
     if (eggsToHatchCount > 0) {
       if (eggsToHatchCount >= this.minEggsToSkip && this.scene.eggSkipPreference === 1) {
         this.scene.ui.showText(i18next.t("battle:eggHatching"), 0, () => {
-          // show prompt for skip
+          // show prompt for skip, blocking inputs for 1 second
           this.scene.ui.showText(i18next.t("battle:eggSkipPrompt"), 0);
           this.scene.ui.setModeWithoutClear(Mode.CONFIRM, () => {
             this.hatchEggsSkipped(eggsToHatch);
@@ -41,7 +41,8 @@ export class EggLapsePhase extends Phase {
           }, () => {
             this.hatchEggsRegular(eggsToHatch);
             this.end();
-          }
+          },
+          null, null, null, 1000, true
           );
         }, 100, true);
       } else if (eggsToHatchCount >= this.minEggsToSkip && this.scene.eggSkipPreference === 2) {

--- a/src/phases/egg-summary-phase.ts
+++ b/src/phases/egg-summary-phase.ts
@@ -1,7 +1,6 @@
 import BattleScene from "#app/battle-scene";
 import { Phase } from "#app/phase";
 import { Mode } from "#app/ui/ui";
-import EggHatchSceneHandler from "#app/ui/egg-hatch-scene-handler";
 import { EggHatchData } from "#app/data/egg-hatch-data";
 
 /**
@@ -11,7 +10,6 @@ import { EggHatchData } from "#app/data/egg-hatch-data";
  */
 export class EggSummaryPhase extends Phase {
   private eggHatchData: EggHatchData[];
-  private eggHatchHandler: EggHatchSceneHandler;
 
   constructor(scene: BattleScene, eggHatchData: EggHatchData[]) {
     super(scene);
@@ -26,7 +24,6 @@ export class EggSummaryPhase extends Phase {
       if (i >= this.eggHatchData.length) {
         this.scene.ui.setModeForceTransition(Mode.EGG_HATCH_SUMMARY, this.eggHatchData).then(() => {
           this.scene.fadeOutBgm(undefined, false);
-          this.eggHatchHandler = this.scene.ui.getHandler() as EggHatchSceneHandler;
         });
 
       } else {

--- a/src/ui/abstact-option-select-ui-handler.ts
+++ b/src/ui/abstact-option-select-ui-handler.ts
@@ -165,6 +165,7 @@ export default abstract class AbstractOptionSelectUiHandler extends UiHandler {
     if (this.config.delay) {
       this.blockInput = true;
       this.optionSelectText.setAlpha(0.5);
+      this.cursorObj?.setAlpha(0.8);
       this.scene.time.delayedCall(Utils.fixedInt(this.config.delay), () => this.unblockInput());
     }
 
@@ -256,6 +257,7 @@ export default abstract class AbstractOptionSelectUiHandler extends UiHandler {
 
     this.blockInput = false;
     this.optionSelectText.setAlpha(1);
+    this.cursorObj?.setAlpha(1);
   }
 
   getOptionsWithScroll(): OptionSelectItem[] {

--- a/src/ui/confirm-ui-handler.ts
+++ b/src/ui/confirm-ui-handler.ts
@@ -76,7 +76,8 @@ export default class ConfirmUiHandler extends AbstractOptionSelectUiHandler {
             }
           }
         ],
-        delay: args.length >= 6 && args[5] !== null ? args[5] as integer : 0
+        delay: args.length >= 6 && args[5] !== null ? args[5] as number : 0,
+        noCancel: args.length >= 7 && args[6] !== null ? args[6] as boolean : false,
       };
 
       super.show([ config ]);
@@ -96,7 +97,7 @@ export default class ConfirmUiHandler extends AbstractOptionSelectUiHandler {
   }
 
   processInput(button: Button): boolean {
-    if (button === Button.CANCEL && this.blockInput) {
+    if (button === Button.CANCEL && this.blockInput && !this.config?.noCancel) {
       this.unblockInput();
     }
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
- The Yes/No menu for skipping to egg summary no longer interprets the `Cancel` input as `No`
- That menu also gets a 1 second input delay before a choice can be made
- The egg summary itself cannot be closed for a few seconds after it gets displayed
<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?
It is way too easy to skip the egg summary on accident if the Skip Hatch setting is set to "Always"
And if it is set to "Ask" it is also way too easy to pick an unwanted option on accident

<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What are the changes from a developer perspective?
- `confirm-ui-handler.ts`: handle the noCancel option and prevent cancelling the input blocking if it is set to `true`
- `egg-lapse-phase`: add 1s input delay to the hatch skip menu + prevent cancelling it 
- `egg-summary-ui-handler`: add 2s input delay if egg hatch setting is set to skip, otherwise to 1 second, for a total of 2 second delay no matter the setting
- `abstact-option-select-ui-handler`: make cursor darker while there is input delay
- `egg-summary-phase`: unrelated, just cleaning up an unused attribute

<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos
<details><summary>Before, Egg Skip setting to `Always`, keeping 'cancel' pressed the whole time:</summary>

https://github.com/user-attachments/assets/758af3b9-4539-4d61-b7f2-78ba809a9ae3

</details>
<details><summary>After, Egg Skip setting to `Always`, keeping 'cancel' pressed the whole time:</summary>

https://github.com/user-attachments/assets/84d2ed3a-654e-4ee0-b0ce-7732be035d20

</details>
<details><summary>After, Egg Skip setting to `Ask`, closing the summary as soon as possible:</summary>

https://github.com/user-attachments/assets/ab025fc1-f0d6-4dbf-b8c8-cbb2d9b22836

</details>

<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
Overrides
```
  EGG_FREE_GACHA_PULLS_OVERRIDE: true,
  EGG_IMMEDIATE_HATCH_OVERRIDE: true
```
Hatch eggs with various states of the "Egg Skip" setting and try skipping the summary
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
~~- [ ] Have I considered writing automated tests for the issue?~~
~~- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
