### PR TITLE
[P3][Move] Fix Substitute visual bugs on wave transition

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -749,9 +749,16 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       const relX = newOffset[0] - initialOffset[0];
       const relY = newOffset[1] - initialOffset[1];
 
+      const subTag = this.getTag(SubstituteTag);
+
       if (duration) {
+        // TODO: can this use stricter typing?
+        const targets: any[] = [ this ];
+        if (subTag?.sprite) {
+          targets.push(subTag.sprite);
+        }
         this.scene.tweens.add({
-          targets: this,
+          targets: targets,
           x: (_target, _key, value: number) => value + relX,
           y: (_target, _key, value: number) => value + relY,
           duration: duration,
@@ -761,6 +768,10 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       } else {
         this.x += relX;
         this.y += relY;
+        if (subTag?.sprite) {
+          subTag.sprite.x += relX;
+          subTag.sprite.y += relY;
+        }
       }
     });
   }


### PR DESCRIPTION
## What are the changes the user will see?
Currently, a player Pokemon's substitute doll does not shift position with the source during transitions between battles of different types (single or double). This change fixes that.

## Why am I making these changes?
My mistake with the Sub implementation; my fix to make. (Reported [in the Discord](https://discord.com/channels/1125469663833370665/1289496377067438192))

## What are the changes from a developer perspective?
`data/pokemon`: `Pokemon#setFieldPosition` now also applies tweens and position changes to the Pokemon's Substitute Doll (if it has one).

### Screenshots/Videos

**Before** (courtesy of @Snailman11)

https://github.com/user-attachments/assets/25bf2541-6cf2-4eef-b935-407f59be670a

**After**

https://github.com/user-attachments/assets/b0ab6977-6c2d-4947-b4d9-76e3deeee8ea

## How to test the changes?
To replicate the above videos:
1. Download [Doublebattle.txt](https://github.com/user-attachments/files/17349328/Doublebattle.txt), change the file extension to `.prsv`, and import the session data onto a local environment under this branch.
2. To speed up testing, use `src/overrides.ts` to give your Pokemon Substitute and Hyper Voice and the opposing Pokemon Splash.
3. Clear Wave 11, making sure Bulbasaur (the left player Pokemon) has a Substitute up at the end of the battle.
4. Continue to Wave 12, a single wild battle. The substitute doll should move with the Bulbasaur to "center" position at the start of the wave.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
