### PR TITLE
[P1 Bug] Fix softlock when a phazing attack activates a reviver seed

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5457,7 +5457,7 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
     private selfSwitch: boolean = false,
     private switchType: SwitchType = SwitchType.SWITCH
   ) {
-    super(false, MoveEffectTrigger.POST_APPLY, false, true);
+    super(selfSwitch, MoveEffectTrigger.POST_APPLY, false, true);
   }
 
   isBatonPass() {
@@ -5465,6 +5465,10 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
   }
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    if (!super.apply(user, target, move, args)) {
+      return false;
+    }
+
     // Check if the move category is not STATUS or if the switch out condition is not met
     if (!this.getSwitchOutCondition()(user, target, move)) {
       return false;

--- a/src/test/moves/dragon_tail.test.ts
+++ b/src/test/moves/dragon_tail.test.ts
@@ -147,7 +147,7 @@ describe("Moves - Dragon Tail", () => {
 
     game.move.select(Moves.DRAGON_TAIL);
 
-    await game.toNextWave();
+    await game.toNextTurn();
 
     // Make sure the enemy switched to a healthy Pokemon
     const enemy = game.scene.getEnemyPokemon()!;
@@ -167,7 +167,7 @@ describe("Moves - Dragon Tail", () => {
 
     game.move.select(Moves.DRAGON_TAIL);
 
-    await game.toNextWave();
+    await game.toNextTurn();
 
     // Make sure the enemy field is not empty and has a revived Pokemon
     const enemy = game.scene.getEnemyPokemon()!;
@@ -183,7 +183,7 @@ describe("Moves - Dragon Tail", () => {
 
     game.move.select(Moves.SPLASH);
 
-    await game.toNextWave();
+    await game.toNextTurn();
 
     // Make sure the player's field is not empty and has a revived Pokemon
     const dratini = game.scene.getPlayerPokemon()!;

--- a/src/test/moves/dragon_tail.test.ts
+++ b/src/test/moves/dragon_tail.test.ts
@@ -152,7 +152,7 @@ describe("Moves - Dragon Tail", () => {
     // Make sure the enemy switched to a healthy Pokemon
     const enemy = game.scene.getEnemyPokemon()!;
     expect(enemy).toBeDefined();
-    expect(enemy.isFullHp).toBeTruthy();
+    expect(enemy.isFullHp()).toBe(true);
 
     // Make sure the enemy has a fainted Pokemon in their party
     const faintedEnemy = game.scene.getEnemyParty().find(p => !p.isAllowedInBattle());

--- a/src/test/moves/dragon_tail.test.ts
+++ b/src/test/moves/dragon_tail.test.ts
@@ -154,9 +154,10 @@ describe("Moves - Dragon Tail", () => {
     expect(enemy).toBeDefined();
     expect(enemy.isFullHp()).toBe(true);
 
-    // Make sure the enemy has a fainted Pokemon in their party
+    // Make sure the enemy has a fainted Pokemon in their party and not on the field
     const faintedEnemy = game.scene.getEnemyParty().find(p => !p.isAllowedInBattle());
     expect(faintedEnemy).toBeDefined();
+    expect(game.scene.getEnemyField().length).toBe(1);
   });
 
   it("should not cause a softlock when activating an opponent trainer's reviver seed", async () => {
@@ -173,6 +174,7 @@ describe("Moves - Dragon Tail", () => {
     const enemy = game.scene.getEnemyPokemon()!;
     expect(enemy).toBeDefined();
     expect(enemy.hp).toBe(Math.floor(enemy.getMaxHp() / 2));
+    expect(game.scene.getEnemyField().length).toBe(1);
   });
 
   it("should not cause a softlock when activating a player's reviver seed", async () => {
@@ -189,5 +191,6 @@ describe("Moves - Dragon Tail", () => {
     const dratini = game.scene.getPlayerPokemon()!;
     expect(dratini).toBeDefined();
     expect(dratini.hp).toBe(Math.floor(dratini.getMaxHp() / 2));
+    expect(game.scene.getPlayerField().length).toBe(1);
   });
 });

--- a/src/test/moves/dragon_tail.test.ts
+++ b/src/test/moves/dragon_tail.test.ts
@@ -139,4 +139,55 @@ describe("Moves - Dragon Tail", () => {
 
     expect(enemy.isFullHp()).toBe(false);
   });
+
+  it("should force a switch upon fainting an opponent normally", async () => {
+    game.override.startingWave(5)
+      .startingLevel(1000); // To make sure Dragon Tail KO's the opponent
+    await game.classicMode.startBattle([ Species.DRATINI ]);
+
+    game.move.select(Moves.DRAGON_TAIL);
+
+    await game.toNextWave();
+
+    // Make sure the enemy switched to a healthy Pokemon
+    const enemy = game.scene.getEnemyPokemon()!;
+    expect(enemy).toBeDefined();
+    expect(enemy.isFullHp).toBeTruthy();
+
+    // Make sure the enemy has a fainted Pokemon in their party
+    const faintedEnemy = game.scene.getEnemyParty().find(p => !p.isAllowedInBattle());
+    expect(faintedEnemy).toBeDefined();
+  });
+
+  it("should not cause a softlock when activating an opponent trainer's reviver seed", async () => {
+    game.override.startingWave(5)
+      .enemyHeldItems([{ name: "REVIVER_SEED" }])
+      .startingLevel(1000); // To make sure Dragon Tail KO's the opponent
+    await game.classicMode.startBattle([ Species.DRATINI ]);
+
+    game.move.select(Moves.DRAGON_TAIL);
+
+    await game.toNextWave();
+
+    // Make sure the enemy field is not empty and has a revived Pokemon
+    const enemy = game.scene.getEnemyPokemon()!;
+    expect(enemy).toBeDefined();
+    expect(enemy.hp).toBe(Math.floor(enemy.getMaxHp() / 2));
+  });
+
+  it("should not cause a softlock when activating a player's reviver seed", async () => {
+    game.override.startingHeldItems([{ name: "REVIVER_SEED" }])
+      .enemyMoveset(Moves.DRAGON_TAIL)
+      .enemyLevel(1000); // To make sure Dragon Tail KO's the player
+    await game.classicMode.startBattle([ Species.DRATINI, Species.BULBASAUR ]);
+
+    game.move.select(Moves.SPLASH);
+
+    await game.toNextWave();
+
+    // Make sure the player's field is not empty and has a revived Pokemon
+    const dratini = game.scene.getPlayerPokemon()!;
+    expect(dratini).toBeDefined();
+    expect(dratini.hp).toBe(Math.floor(dratini.getMaxHp() / 2));
+  });
 });

--- a/src/test/moves/u_turn.test.ts
+++ b/src/test/moves/u_turn.test.ts
@@ -96,4 +96,19 @@ describe("Moves - U-turn", () => {
     expect(game.scene.getEnemyPokemon()!.battleData.abilityRevealed).toBe(true); // proxy for asserting ability activated
     expect(game.phaseInterceptor.log).not.toContain("SwitchSummonPhase");
   }, 20000);
+
+  it("still forces a switch if u-turn KO's the opponent", async () => {
+    game.override.startingLevel(1000); // Ensure that U-Turn KO's the opponent
+    await game.classicMode.startBattle([
+      Species.RAICHU,
+      Species.SHUCKLE
+    ]);
+
+    game.move.select(Moves.U_TURN);
+    game.doSelectPartyPokemon(1);
+    await game.phaseInterceptor.to(TurnEndPhase);
+
+    expect(game.phaseInterceptor.log).toContain("SwitchSummonPhase");
+    expect(game.scene.getPlayerPokemon()!.species.speciesId).toBe(Species.SHUCKLE);
+  });
 });

--- a/src/test/moves/u_turn.test.ts
+++ b/src/test/moves/u_turn.test.ts
@@ -103,11 +103,15 @@ describe("Moves - U-turn", () => {
       Species.RAICHU,
       Species.SHUCKLE
     ]);
+    const enemy = game.scene.getEnemyPokemon()!;
 
+    // KO the opponent with U-Turn
     game.move.select(Moves.U_TURN);
     game.doSelectPartyPokemon(1);
     await game.phaseInterceptor.to(TurnEndPhase);
+    expect(enemy.isFainted()).toBe(true);
 
+    // Check that U-Turn forced a switch
     expect(game.phaseInterceptor.log).toContain("SwitchSummonPhase");
     expect(game.scene.getPlayerPokemon()!.species.speciesId).toBe(Species.SHUCKLE);
   });


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
Fixes #4219: If a phazing attack KO's a Pokemon holding a reviver seed, it no longer causes a softlock due to the revived Pokemon being removed from the field.

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Fixing a softlock.

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
`ForceSwitchOutAttr` now only removes a Pokemon from the field if it is not fainted.
  - If the Pokemon has a reviver seed, it allows the Pokemon to remain on the field.
  - Otherwise, if the Pokemon does not have a reviver seed, then it stays fainted, which then correctly forces its trainer to switch.

Also added a few tests.

**NOT FIXED**: If the user of Dragon Tail faints (e.g., due to Iron Barbs), it still forces the opponent to switch out, which is incorrect according to [Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Dragon_Tail_(move)). There seems to be a separate issue where `MoveEffectPhase` runs all move attributes before running ability attributes, so `ForceSwitchOutAttr` cannot know yet that the Dragon Tail user is about to faint to Iron Barbs.

## Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

<details>
<summary> Before the changes: A softlock occurs. </summary>

https://github.com/user-attachments/assets/028a10ab-7e8d-434e-8620-3edb3b793ed0

</details>

<details>
<summary> After the changes: A softlock no longer occurs on a player's reviver seed. </summary>

https://github.com/user-attachments/assets/2e9e1832-b805-4ded-ba5f-ee640e783ab0

</details>

<details>
<summary> After the changes: A softlock no longer occurs on an opponent trainer's reviver seed. </summary>

https://github.com/user-attachments/assets/9b313da0-1aa3-4929-8156-94ec2c3bbec4

</details>

<details>
<summary> After the changes: Phazing attacks KO'ing a Pokemon without a reviver seed still forces a switch. </summary>

https://github.com/user-attachments/assets/a7dab4b1-153b-4f8b-ac15-f3803de4146b

</details>

<details>
<summary> After the changes: KO'ing an opponent Pokemon using U-Turn still forces a switch. </summary>

https://github.com/user-attachments/assets/a6515100-cf0d-4dcd-886f-6123a6d4616f

</details>

<details>
<summary> (NEW) After the changes: Parting Shot does not force a switch if it fails (e.g., due to Good as Gold). </summary>

https://github.com/user-attachments/assets/0734a816-c50d-41aa-9a23-11abc5f1d295

</details>

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
`npm run test dragon_tail`
`npm run test u_turn`
`npm run test parting_shot`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~~[ ] Are the changes visual?~~
  - [x] Have I provided screenshots/videos of the changes?
