### PR TITLE
[Refactor] Add type inference and support for simulated calls to `ArenaTag.apply`

### DIFF
--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -36,7 +36,7 @@ export abstract class ArenaTag {
     public side: ArenaTagSide = ArenaTagSide.BOTH
   ) {}
 
-  apply(arena: Arena, simulated: boolean, ...args: unknown[]): boolean {
+  apply(arena: Arena, simulated: boolean, ...args: any[]): boolean {
     return true;
   }
 

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -261,12 +261,11 @@ export class ConditionalProtectTag extends ArenaTag {
    * and protects the target if conditions are met
    * @param arena the {@linkcode Arena} containing this tag
    * @param simulated `true` if the tag is applied quietly; `false` otherwise.
-   * @param args the arguments for this tag's application:
-   * - `[0]` a {@linkcode Utils.BooleanHolder | BooleanHolder} used to flag if the move is protected against
-   * - `[1]` the attacking {@linkcode Pokemon}
-   * - `[2]` the defending {@linkcode Pokemon}
-   * - `[3]` the {@linkcode Moves | identifier} for the move being used
-   * - `[4]` a {@linkcode Utils.BooleanHolder | BooleanHolder} used to flag if a protection effect supercedes effects that ignore protection
+   * @param isProtected a {@linkcode Utils.BooleanHolder | BooleanHolder} used to flag if the move is protected against
+   * @param attacker the attacking {@linkcode Pokemon}
+   * @param defender the defending {@linkcode Pokemon}
+   * @param moveId the {@linkcode Moves | identifier} for the move being used
+   * @param ignoresProtectBypass a {@linkcode Utils.BooleanHolder | BooleanHolder} used to flag if a protection effect supercedes effects that ignore protection
    * @returns `true` if this tag protected against the attack; `false` otherwise
    */
   override apply(arena: Arena, simulated: boolean, isProtected: Utils.BooleanHolder, attacker: Pokemon, defender: Pokemon,
@@ -619,6 +618,13 @@ export class ArenaTrapTag extends ArenaTag {
     }
   }
 
+  /**
+   * Activates the hazard effect onto a Pokemon when it enters the field
+   * @param arena the {@linkcode Arena} containing this tag
+   * @param simulated if `true`, only checks if the hazard would activate.
+   * @param pokemon the {@linkcode Pokemon} triggering this hazard
+   * @returns `true` if this hazard affects the given Pokemon; `false` otherwise.
+   */
   override apply(arena: Arena, simulated: boolean, pokemon: Pokemon): boolean {
     if (this.sourceId === pokemon.id || (this.side === ArenaTagSide.PLAYER) !== pokemon.isPlayer()) {
       return false;
@@ -1145,6 +1151,14 @@ class WaterFirePledgeTag extends ArenaTag {
     arena.scene.queueMessage(i18next.t(`arenaTag:waterFirePledgeOnAdd${this.side === ArenaTagSide.PLAYER ? "Player" : this.side === ArenaTagSide.ENEMY ? "Enemy" : ""}`));
   }
 
+  /**
+   * Doubles the chance for the given move's secondary effect(s) to trigger
+   * @param arena the {@linkcode Arena} containing this tag
+   * @param simulated n/a
+   * @param moveChance a {@linkcode Utils.NumberHolder | NumberHolder} containing
+   * the move's current effect chance
+   * @returns `true` if the move's effect chance was doubled (currently always `true`)
+   */
   override apply(arena: Arena, simulated: boolean, moveChance: Utils.NumberHolder): boolean {
     moveChance.value *= 2;
     return true;

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -36,7 +36,7 @@ export abstract class ArenaTag {
     public side: ArenaTagSide = ArenaTagSide.BOTH
   ) {}
 
-  apply(arena: Arena, simulated: boolean, ...args: any[]): boolean {
+  apply(arena: Arena, simulated: boolean, ...args: unknown[]): boolean {
     return true;
   }
 

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -808,7 +808,7 @@ export default class Move implements Localizable {
     source.scene.applyModifiers(PokemonMultiHitModifier, source.isPlayer(), source, new Utils.IntegerHolder(0), power);
 
     if (!this.hasAttr(TypelessAttr)) {
-      source.scene.arena.applyTags(WeakenMoveTypeTag, this.type, power);
+      source.scene.arena.applyTags(WeakenMoveTypeTag, simulated, this.type, power);
       source.scene.applyModifiers(AttackTypeBoosterModifier, source.isPlayer(), source, this.type, power);
     }
 
@@ -1026,7 +1026,7 @@ export class MoveEffectAttr extends MoveAttr {
 
     if (!move.hasAttr(FlinchAttr) || moveChance.value <= move.chance) {
       const userSide = user.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY;
-      user.scene.arena.applyTagsForSide(ArenaTagType.WATER_FIRE_PLEDGE, userSide, moveChance);
+      user.scene.arena.applyTagsForSide(ArenaTagType.WATER_FIRE_PLEDGE, userSide, false, moveChance);
     }
 
     if (!selfEffect) {

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -579,26 +579,28 @@ export class Arena {
    * Applies each `ArenaTag` in this Arena, based on which side (self, enemy, or both) is passed in as a parameter
    * @param tagType Either an {@linkcode ArenaTagType} string, or an actual {@linkcode ArenaTag} class to filter which ones to apply
    * @param side {@linkcode ArenaTagSide} which side's arena tags to apply
+   * @param simulated if `true`, this applies arena tags without changing game state
    * @param args array of parameters that the called upon tags may need
    */
-  applyTagsForSide(tagType: ArenaTagType | Constructor<ArenaTag>, side: ArenaTagSide, ...args: unknown[]): void {
+  applyTagsForSide(tagType: ArenaTagType | Constructor<ArenaTag>, side: ArenaTagSide, simulated: boolean, ...args: unknown[]): void {
     let tags = typeof tagType === "string"
       ? this.tags.filter(t => t.tagType === tagType)
       : this.tags.filter(t => t instanceof tagType);
     if (side !== ArenaTagSide.BOTH) {
       tags = tags.filter(t => t.side === side);
     }
-    tags.forEach(t => t.apply(this, args));
+    tags.forEach(t => t.apply(this, simulated, args));
   }
 
   /**
    * Applies the specified tag to both sides (ie: both user and trainer's tag that match the Tag specified)
    * by calling {@linkcode applyTagsForSide()}
    * @param tagType Either an {@linkcode ArenaTagType} string, or an actual {@linkcode ArenaTag} class to filter which ones to apply
+   * @param simulated if `true`, this applies arena tags without changing game state
    * @param args array of parameters that the called upon tags may need
    */
-  applyTags(tagType: ArenaTagType | Constructor<ArenaTag>, ...args: unknown[]): void {
-    this.applyTagsForSide(tagType, ArenaTagSide.BOTH, ...args);
+  applyTags(tagType: ArenaTagType | Constructor<ArenaTag>, simulated: boolean, ...args: unknown[]): void {
+    this.applyTagsForSide(tagType, ArenaTagSide.BOTH, simulated, ...args);
   }
 
   /**

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -589,7 +589,7 @@ export class Arena {
     if (side !== ArenaTagSide.BOTH) {
       tags = tags.filter(t => t.side === side);
     }
-    tags.forEach(t => t.apply(this, simulated, args));
+    tags.forEach(t => t.apply(this, simulated, ...args));
   }
 
   /**

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2605,7 +2605,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
     /** Reduces damage if this Pokemon has a relevant screen (e.g. Light Screen for special attacks) */
     const screenMultiplier = new Utils.NumberHolder(1);
-    this.scene.arena.applyTagsForSide(WeakenMoveScreenTag, defendingSide, simulated, move.category, this.scene.currentBattle.double, screenMultiplier);
+    this.scene.arena.applyTagsForSide(WeakenMoveScreenTag, defendingSide, simulated, moveCategory, screenMultiplier);
 
     /**
      * For each {@linkcode HitsTagAttr} the move has, doubles the damage of the move if:

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1538,7 +1538,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     applyMoveAttrs(VariableMoveTypeAttr, this, null, move, moveTypeHolder);
     applyPreAttackAbAttrs(MoveTypeChangeAbAttr, this, null, move, simulated, moveTypeHolder);
 
-    this.scene.arena.applyTags(ArenaTagType.ION_DELUGE, moveTypeHolder);
+    this.scene.arena.applyTags(ArenaTagType.ION_DELUGE, simulated, moveTypeHolder);
     if (this.getTag(BattlerTagType.ELECTRIFIED)) {
       moveTypeHolder.value = Type.ELECTRIC;
     }
@@ -2605,7 +2605,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
     /** Reduces damage if this Pokemon has a relevant screen (e.g. Light Screen for special attacks) */
     const screenMultiplier = new Utils.NumberHolder(1);
-    this.scene.arena.applyTagsForSide(WeakenMoveScreenTag, defendingSide, move.category, this.scene.currentBattle.double, screenMultiplier);
+    this.scene.arena.applyTagsForSide(WeakenMoveScreenTag, defendingSide, simulated, move.category, this.scene.currentBattle.double, screenMultiplier);
 
     /**
      * For each {@linkcode HitsTagAttr} the move has, doubles the damage of the move if:

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -140,7 +140,7 @@ export class MoveEffectPhase extends PokemonPhase {
           const bypassIgnoreProtect = new Utils.BooleanHolder(false);
           /** If the move is not targeting a Pokemon on the user's side, try to apply conditional protection effects */
           if (!this.move.getMove().isAllyTarget()) {
-            this.scene.arena.applyTagsForSide(ConditionalProtectTag, targetSide, hasConditionalProtectApplied, user, target, move.id, bypassIgnoreProtect);
+            this.scene.arena.applyTagsForSide(ConditionalProtectTag, targetSide, false, hasConditionalProtectApplied, user, target, move.id, bypassIgnoreProtect);
           }
 
           /** Is the target protected by Protect, etc. or a relevant conditional protection effect? */

--- a/src/phases/post-summon-phase.ts
+++ b/src/phases/post-summon-phase.ts
@@ -20,7 +20,7 @@ export class PostSummonPhase extends PokemonPhase {
     if (pokemon.status?.effect === StatusEffect.TOXIC) {
       pokemon.status.turnCount = 0;
     }
-    this.scene.arena.applyTags(ArenaTrapTag, pokemon);
+    this.scene.arena.applyTags(ArenaTrapTag, false, pokemon);
 
     // If this is mystery encounter and has post summon phase tag, apply post summon effects
     if (this.scene.currentBattle.isBattleMysteryEncounter() && pokemon.findTags(t => t instanceof MysteryEncounterPostSummonTag).length > 0) {

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -64,8 +64,7 @@ export class StatStageChangePhase extends PokemonPhase {
       const cancelled = new BooleanHolder(false);
 
       if (!this.selfTarget && stages.value < 0) {
-        // TODO: Include simulate boolean when tag applications can be simulated
-        this.scene.arena.applyTagsForSide(MistTag, pokemon.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY, cancelled);
+        this.scene.arena.applyTagsForSide(MistTag, pokemon.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY, false, cancelled);
       }
 
       if (!cancelled.value && !this.selfTarget && stages.value < 0) {

--- a/src/phases/turn-start-phase.ts
+++ b/src/phases/turn-start-phase.ts
@@ -45,7 +45,7 @@ export class TurnStartPhase extends FieldPhase {
 
     // Next, a check for Trick Room is applied to determine sort order.
     const speedReversed = new Utils.BooleanHolder(false);
-    this.scene.arena.applyTags(TrickRoomTag, speedReversed);
+    this.scene.arena.applyTags(TrickRoomTag, false, speedReversed);
 
     // Adjust the sort function based on whether Trick Room is active.
     orderedTargets.sort((a: Pokemon, b: Pokemon) => {

--- a/src/test/moves/aurora_veil.test.ts
+++ b/src/test/moves/aurora_veil.test.ts
@@ -111,7 +111,7 @@ const getMockedMoveDamage = (defender: Pokemon, attacker: Pokemon, move: Move) =
   const side = defender.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY;
 
   if (defender.scene.arena.getTagOnSide(ArenaTagType.AURORA_VEIL, side)) {
-    defender.scene.arena.applyTagsForSide(ArenaTagType.AURORA_VEIL, side, false, move.category, defender.scene.currentBattle.double, multiplierHolder);
+    defender.scene.arena.applyTagsForSide(ArenaTagType.AURORA_VEIL, side, false, move.category, multiplierHolder);
   }
 
   return move.power * multiplierHolder.value;

--- a/src/test/moves/aurora_veil.test.ts
+++ b/src/test/moves/aurora_veil.test.ts
@@ -111,7 +111,7 @@ const getMockedMoveDamage = (defender: Pokemon, attacker: Pokemon, move: Move) =
   const side = defender.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY;
 
   if (defender.scene.arena.getTagOnSide(ArenaTagType.AURORA_VEIL, side)) {
-    defender.scene.arena.applyTagsForSide(ArenaTagType.AURORA_VEIL, side, move.category, defender.scene.currentBattle.double, multiplierHolder);
+    defender.scene.arena.applyTagsForSide(ArenaTagType.AURORA_VEIL, side, false, move.category, defender.scene.currentBattle.double, multiplierHolder);
   }
 
   return move.power * multiplierHolder.value;

--- a/src/test/moves/light_screen.test.ts
+++ b/src/test/moves/light_screen.test.ts
@@ -94,7 +94,7 @@ const getMockedMoveDamage = (defender: Pokemon, attacker: Pokemon, move: Move) =
   const side = defender.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY;
 
   if (defender.scene.arena.getTagOnSide(ArenaTagType.LIGHT_SCREEN, side)) {
-    defender.scene.arena.applyTagsForSide(ArenaTagType.LIGHT_SCREEN, side, move.category, defender.scene.currentBattle.double, multiplierHolder);
+    defender.scene.arena.applyTagsForSide(ArenaTagType.LIGHT_SCREEN, side, false, move.category, defender.scene.currentBattle.double, multiplierHolder);
   }
 
   return move.power * multiplierHolder.value;

--- a/src/test/moves/light_screen.test.ts
+++ b/src/test/moves/light_screen.test.ts
@@ -94,7 +94,7 @@ const getMockedMoveDamage = (defender: Pokemon, attacker: Pokemon, move: Move) =
   const side = defender.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY;
 
   if (defender.scene.arena.getTagOnSide(ArenaTagType.LIGHT_SCREEN, side)) {
-    defender.scene.arena.applyTagsForSide(ArenaTagType.LIGHT_SCREEN, side, false, move.category, defender.scene.currentBattle.double, multiplierHolder);
+    defender.scene.arena.applyTagsForSide(ArenaTagType.LIGHT_SCREEN, side, false, move.category, multiplierHolder);
   }
 
   return move.power * multiplierHolder.value;

--- a/src/test/moves/reflect.test.ts
+++ b/src/test/moves/reflect.test.ts
@@ -94,7 +94,7 @@ const getMockedMoveDamage = (defender: Pokemon, attacker: Pokemon, move: Move) =
   const side = defender.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY;
 
   if (defender.scene.arena.getTagOnSide(ArenaTagType.REFLECT, side)) {
-    defender.scene.arena.applyTagsForSide(ArenaTagType.REFLECT, side, move.category, defender.scene.currentBattle.double, multiplierHolder);
+    defender.scene.arena.applyTagsForSide(ArenaTagType.REFLECT, side, false, move.category, defender.scene.currentBattle.double, multiplierHolder);
   }
 
   return move.power * multiplierHolder.value;

--- a/src/test/moves/reflect.test.ts
+++ b/src/test/moves/reflect.test.ts
@@ -94,7 +94,7 @@ const getMockedMoveDamage = (defender: Pokemon, attacker: Pokemon, move: Move) =
   const side = defender.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY;
 
   if (defender.scene.arena.getTagOnSide(ArenaTagType.REFLECT, side)) {
-    defender.scene.arena.applyTagsForSide(ArenaTagType.REFLECT, side, false, move.category, defender.scene.currentBattle.double, multiplierHolder);
+    defender.scene.arena.applyTagsForSide(ArenaTagType.REFLECT, side, false, move.category, multiplierHolder);
   }
 
   return move.power * multiplierHolder.value;


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Simulated calls to arena tags are necessary for the Enemy AI to evaluate turn actions silently, especially when [Infiltrator](#4636) is implemented. With that change, I figured it was also a good time to add type inference to `ArenaTag.apply` along the lines of #4294 

## What are the changes from a developer perspective?
`data/arena-tag`: The signature for `ArenaTag.apply` has changed from
```ts
apply(arena: Arena, args: any[]);
```
to
```ts
apply(arena: Arena, simulated: boolean, ...args: unknown[]);
```

The new `simulated` argument, much like the argument of the same name for abilities' `apply` functions, allows arena tags to be applied without any observable changes to game state. `args` has also been changed to use spread syntax, which allows `overrides` of the function in subclasses to expand `args` into multiple arguments.

`applyTagsOnSide` and `applyTags` have also been changed accordingly, along with all references to the two functions in the codebase.

### Screenshots/Videos
N/A

## How to test the changes?
For a specific example, you can check the screen tests:
`npm run test reflect`
`npm run test light_screen`
`npm run test aurora_veil`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [n/a] Are the changes visual?
  - [n/a] Have I provided screenshots/videos of the changes?
