### PR TITLE
[Bug] Prevent duplicate move failure message

### DIFF
--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -128,7 +128,9 @@ export class MovePhase extends BattlePhase {
 
     this.lapsePreMoveAndMoveTags();
 
-    this.resolveFinalPreMoveCancellationChecks();
+    if (!(this.failed || this.cancelled)) {
+      this.resolveFinalPreMoveCancellationChecks();
+    }
 
     if (this.cancelled || this.failed) {
       this.handlePreMoveFailures();


### PR DESCRIPTION
## What are the changes the user will see?
A duplicate move failure message won't show up.

## Why am I making these changes?
https://discord.com/channels/1125469663833370665/1295393193029931080

## What are the changes from a developer perspective?
A check for whether the move already failed was added around `resolveFinalPreMoveCancellationChecks()` to restore previous behavior.

### Screenshots/Videos
<details>
  <summary>Before fix (taken from Discord thread)</summary>

https://github.com/user-attachments/assets/29da71c6-1a07-4942-ad94-37ee3c50722b

</details>
<details>
  <summary>After fix</summary>

https://github.com/user-attachments/assets/447a15ab-335b-455a-86b3-1feca9941a19

</details>

## How to test the changes?
Use overrides to give the opponent Growl and yourself Metal Burst, make sure the opponent is faster (make them level 50 or whatever), and then use Metal Burst. The failure message should only occur once.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
