### PR TITLE
[Bug Fix] Attacks that miss against pokemon in semi invul state that have abilities such as volt absorb will not trigger while semi invulnerable

### DIFF
--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -151,7 +151,7 @@ export class MoveEffectPhase extends PokemonPhase {
 
           /** Is the pokemon immune due to an ablility, and also not in a semi invulnerable state?  */
           const isImmune = target.hasAbilityWithAttr(TypeImmunityAbAttr) && (target.getAbility()?.getAttrs(TypeImmunityAbAttr)?.[0]?.getImmuneType() === user.getMoveType(move))
-              && !targets[0].getTag(SemiInvulnerableTag);
+              && !target.getTag(SemiInvulnerableTag);
 
           /**
              * If the move missed a target, stop all future hits against that target

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -99,8 +99,9 @@ export class MoveEffectPhase extends PokemonPhase {
       const targetHitChecks = Object.fromEntries(targets.map(p => [ p.getBattlerIndex(), this.hitCheck(p) ]));
       const hasActiveTargets = targets.some(t => t.isActive(true));
 
-      /** Check if the target is immune via ability to the attacking move */
-      const isImmune = targets[0].hasAbilityWithAttr(TypeImmunityAbAttr) && (targets[0].getAbility()?.getAttrs(TypeImmunityAbAttr)?.[0]?.getImmuneType() === user.getMoveType(move));
+      /** Check if the target is immune via ability to the attacking move, and NOT in semi invulnerable state */
+      const isImmune = targets[0].hasAbilityWithAttr(TypeImmunityAbAttr) && (targets[0].getAbility()?.getAttrs(TypeImmunityAbAttr)?.[0]?.getImmuneType() === user.getMoveType(move))
+          && !targets[0].getTag(SemiInvulnerableTag);
 
       /**
          * If no targets are left for the move to hit (FAIL), or the invoked move is single-target
@@ -148,8 +149,9 @@ export class MoveEffectPhase extends PokemonPhase {
               && (hasConditionalProtectApplied.value || (!target.findTags(t => t instanceof DamageProtectedTag).length && target.findTags(t => t instanceof ProtectedTag).find(t => target.lapseTag(t.tagType)))
               || (this.move.getMove().category !== MoveCategory.STATUS && target.findTags(t => t instanceof DamageProtectedTag).find(t => target.lapseTag(t.tagType))));
 
-          /** Is the pokemon immune due to an ablility?  */
-          const isImmune = target.hasAbilityWithAttr(TypeImmunityAbAttr) && (target.getAbility()?.getAttrs(TypeImmunityAbAttr)?.[0]?.getImmuneType() === user.getMoveType(move));
+          /** Is the pokemon immune due to an ablility, and also not in a semi invulnerable state?  */
+          const isImmune = target.hasAbilityWithAttr(TypeImmunityAbAttr) && (target.getAbility()?.getAttrs(TypeImmunityAbAttr)?.[0]?.getImmuneType() === user.getMoveType(move))
+              && !targets[0].getTag(SemiInvulnerableTag);
 
           /**
              * If the move missed a target, stop all future hits against that target

--- a/src/test/abilities/volt_absorb.test.ts
+++ b/src/test/abilities/volt_absorb.test.ts
@@ -71,4 +71,23 @@ describe("Abilities - Volt Absorb", () => {
     await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
   });
+  it("regardless of accuracy should not trigger on pokemon in semi invulnerable state", async () => {
+    game.override.moveset(Moves.THUNDERBOLT);
+    game.override.enemyMoveset(Moves.DIVE);
+    game.override.enemySpecies(Species.MAGIKARP);
+    game.override.enemyAbility(Abilities.VOLT_ABSORB);
+
+    await game.classicMode.startBattle();
+
+    const enemyPokemon = game.scene.getEnemyPokemon()!;
+
+    game.move.select(Moves.THUNDERBOLT);
+    enemyPokemon.hp = enemyPokemon.hp - 1;
+    await game.setTurnOrder([ BattlerIndex.ENEMY, BattlerIndex.PLAYER ]);
+    await game.phaseInterceptor.to("MoveEffectPhase");
+
+    await game.move.forceMiss();
+    await game.phaseInterceptor.to("BerryPhase", false);
+    expect(enemyPokemon.hp).toBeLessThan(enemyPokemon.getMaxHp());
+  });
 });


### PR DESCRIPTION
## What are the changes the user will see?
This interaction will now work properly. For example, if thunderbolt is used against a pokemon with volt absorb, and that pokemon with volt absorb is in a semi invulnerable state, the attack will just miss instead of triggering the ability. 

related to #4337 

## Why am I making these changes?
Bug fix

## What are the changes from a developer perspective?
added check in move-effect-phase.ts for if pokemon is in semi invulnerable state

### Screenshots/Videos

https://github.com/user-attachments/assets/2d704a4f-2116-41cb-b91b-2278f09e9eb4



## How to test the changes?
Override files, run the updated volt absorb test file, and manually change return value of hitcheck() to false. 

## Checklist
- [X ] **I'm using `beta` as my base branch**
- [X ] There is no overlap with another PR?
- [ X] The PR is self-contained and cannot be split into smaller PRs?
- [X ] Have I provided a clear explanation of the changes?
- [X ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [X ] Have I tested the changes (manually)?
    - [X ] Are all unit tests still passing? (`npm run test`)
- [X ] Are the changes visual?
  - [X ] Have I provided screenshots/videos of the changes?
