### PR TITLE
[P3][Beta] Fix missing move text when a move fails

### DIFF
--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -149,7 +149,7 @@ export class MovePhase extends BattlePhase {
     if (targets.length === 0 || (moveQueue.length && moveQueue[0].move === Moves.NONE)) {
       this.showMoveText();
       this.showFailedText();
-      this.cancelled = true;
+      this.cancel();
     }
   }
 

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -147,6 +147,7 @@ export class MovePhase extends BattlePhase {
     const moveQueue = this.pokemon.getMoveQueue();
 
     if (targets.length === 0 || (moveQueue.length && moveQueue[0].move === Moves.NONE)) {
+      this.showMoveText();
       this.showFailedText();
       this.cancelled = true;
     }


### PR DESCRIPTION
## What are the changes the user will see?
This fixes an issue in beta where "{Pokemon} used {Move}!" would not appear when the move would fail, instead immediately showing "But it failed!"

## Why am I making these changes?
Reported [in the Discord](https://discord.com/channels/1125469663833370665/1295517833651814472)

## What are the changes from a developer perspective?
`phases/move-phase`:
- Restored a missing call to `showMoveText` when the move being used would fail or be cancelled.
- `resolveFinalPreMoveCancellationChecks` now uses `this.cancel()` instead of directly setting `this.cancelled`.

### Screenshots/Videos

https://github.com/user-attachments/assets/1e431bfe-7204-4015-bb96-b7642b38d728

## How to test the changes?

1. Download [DOUBLESMEMENTO.txt](https://github.com/user-attachments/files/17370551/DOUBLESMEMENTO.txt) and change the file extension to `.prsv`. Load this file as session data onto a local build
2. On the first turn, use Liquidation on both Shuckle and Regieleki. Both enemies should use Memento and faint, causing Shuckle's Liquidation to fail.
3. The text "Shuckle used Liquidation!" should show when it gets to Shuckle's turn.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
