### PR TITLE
[P1 Bug] Fix several Destiny Bond crashes

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -3834,8 +3834,8 @@ export class LastMoveDoublePowerAttr extends VariablePowerAttr {
 
     for (const p of pokemonActed) {
       const [ lastMove ] = p.getLastXMoves(1);
-      if (lastMove.result !== MoveResult.FAIL) {
-        if ((lastMove.result === MoveResult.SUCCESS) && (lastMove.move === this.move)) {
+      if (lastMove?.result !== MoveResult.FAIL) {
+        if ((lastMove?.result === MoveResult.SUCCESS) && (lastMove?.move === this.move)) {
           power.value *= 2;
           return true;
         } else {
@@ -4736,7 +4736,7 @@ export class AddBattlerTagAttr extends MoveEffectAttr {
   }
 
   canApply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    if (!super.canApply(user, target, move, args) || (this.cancelOnFail === true && user.getLastXMoves(1)[0].result === MoveResult.FAIL)) {
+    if (!super.canApply(user, target, move, args) || (this.cancelOnFail === true && user.getLastXMoves(1)[0]?.result === MoveResult.FAIL)) {
       return false;
     } else {
       return true;
@@ -5174,7 +5174,7 @@ export class AddArenaTagAttr extends MoveEffectAttr {
       return false;
     }
 
-    if ((move.chance < 0 || move.chance === 100 || user.randSeedInt(100) < move.chance) && user.getLastXMoves(1)[0].result === MoveResult.SUCCESS) {
+    if ((move.chance < 0 || move.chance === 100 || user.randSeedInt(100) < move.chance) && user.getLastXMoves(1)[0]?.result === MoveResult.SUCCESS) {
       user.scene.arena.addTag(this.tagType, this.turnCount, move.id, user.id, (this.selfSideTarget ? user : target).isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY);
       return true;
     }
@@ -5249,7 +5249,7 @@ export class AddArenaTrapTagHitAttr extends AddArenaTagAttr {
     const moveChance = this.getMoveChance(user, target, move, this.selfTarget, true);
     const side = (this.selfSideTarget ? user : target).isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY;
     const tag = user.scene.arena.getTagOnSide(this.tagType, side) as ArenaTrapTag;
-    if ((moveChance < 0 || moveChance === 100 || user.randSeedInt(100) < moveChance) && user.getLastXMoves(1)[0].result === MoveResult.SUCCESS) {
+    if ((moveChance < 0 || moveChance === 100 || user.randSeedInt(100) < moveChance) && user.getLastXMoves(1)[0]?.result === MoveResult.SUCCESS) {
       user.scene.arena.addTag(this.tagType, 0, move.id, user.id, side);
       if (!tag) {
         return true;
@@ -5386,7 +5386,7 @@ export class AddPledgeEffectAttr extends AddArenaTagAttr {
 
   override apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     // TODO: add support for `HIT` effect triggering in AddArenaTagAttr to remove the need for this check
-    if (user.getLastXMoves(1)[0].result !== MoveResult.SUCCESS) {
+    if (user.getLastXMoves(1)[0]?.result !== MoveResult.SUCCESS) {
       return false;
     }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2810,13 +2810,14 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       if (this.isFainted()) {
         // set splice index here, so future scene queues happen before FaintedPhase
         this.scene.setPhaseQueueSplice();
-        this.scene.unshiftPhase(new FaintPhase(this.scene, this.getBattlerIndex(), isOneHitKo));
+        if (!isNullOrUndefined(destinyTag) && dmg) {
+          // Destiny Bond will activate during FaintPhase
+          this.scene.unshiftPhase(new FaintPhase(this.scene, this.getBattlerIndex(), isOneHitKo, destinyTag, source));
+        } else {
+          this.scene.unshiftPhase(new FaintPhase(this.scene, this.getBattlerIndex(), isOneHitKo));
+        }
         this.destroySubstitute();
         this.resetSummonData();
-      }
-
-      if (dmg) {
-        destinyTag?.lapse(source, BattlerTagLapseType.CUSTOM);
       }
 
       return result;

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -30,12 +30,12 @@ export class FaintPhase extends PokemonPhase {
   /**
    * Destiny Bond tag belonging to the currently fainting Pokemon, if applicable
    */
-  private destinyTag: DestinyBondTag | undefined;
+  private destinyTag?: DestinyBondTag;
 
   /**
-   * The source that dealt fatal damage and should get KO'd by Destiny Bond, if applicable
+   * The source Pokemon that dealt fatal damage and should get KO'd by Destiny Bond, if applicable
    */
-  private source: Pokemon | undefined;
+  private source?: Pokemon;
 
   constructor(scene: BattleScene, battlerIndex: BattlerIndex, preventEndure: boolean = false, destinyTag?: DestinyBondTag, source?: Pokemon) {
     super(scene, battlerIndex);

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -1,12 +1,12 @@
 import BattleScene from "#app/battle-scene";
 import { BattlerIndex, BattleType } from "#app/battle";
 import { applyPostFaintAbAttrs, PostFaintAbAttr, applyPostKnockOutAbAttrs, PostKnockOutAbAttr, applyPostVictoryAbAttrs, PostVictoryAbAttr } from "#app/data/ability";
-import { BattlerTagLapseType } from "#app/data/battler-tags";
+import { BattlerTagLapseType, DestinyBondTag } from "#app/data/battler-tags";
 import { battleSpecDialogue } from "#app/data/dialogue";
 import { allMoves, PostVictoryStatStageChangeAttr } from "#app/data/move";
 import { BattleSpec } from "#app/enums/battle-spec";
 import { StatusEffect } from "#app/enums/status-effect";
-import { PokemonMove, EnemyPokemon, PlayerPokemon, HitResult } from "#app/field/pokemon";
+import Pokemon, { PokemonMove, EnemyPokemon, PlayerPokemon, HitResult } from "#app/field/pokemon";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { PokemonInstantReviveModifier } from "#app/modifier/modifier";
 import i18next from "i18next";
@@ -19,18 +19,38 @@ import { SwitchPhase } from "./switch-phase";
 import { VictoryPhase } from "./victory-phase";
 import { SpeciesFormChangeActiveTrigger } from "#app/data/pokemon-forms";
 import { SwitchType } from "#enums/switch-type";
+import { isNullOrUndefined } from "#app/utils";
 
 export class FaintPhase extends PokemonPhase {
+  /**
+   * Whether or not enduring (for this phase's purposes, Reviver Seed) should be prevented
+   */
   private preventEndure: boolean;
 
-  constructor(scene: BattleScene, battlerIndex: BattlerIndex, preventEndure?: boolean) {
+  /**
+   * Destiny Bond tag belonging to the currently fainting Pokemon, if applicable
+   */
+  private destinyTag: DestinyBondTag | undefined;
+
+  /**
+   * The source that dealt fatal damage and should get KO'd by Destiny Bond, if applicable
+   */
+  private source: Pokemon | undefined;
+
+  constructor(scene: BattleScene, battlerIndex: BattlerIndex, preventEndure: boolean = false, destinyTag?: DestinyBondTag, source?: Pokemon) {
     super(scene, battlerIndex);
 
-    this.preventEndure = preventEndure!; // TODO: is this bang correct?
+    this.preventEndure = preventEndure;
+    this.destinyTag = destinyTag;
+    this.source = source;
   }
 
   start() {
     super.start();
+
+    if (!isNullOrUndefined(this.destinyTag) && !isNullOrUndefined(this.source)) {
+      this.destinyTag.lapse(this.source, BattlerTagLapseType.CUSTOM);
+    }
 
     if (!this.preventEndure) {
       const instantReviveModifier = this.scene.applyModifier(PokemonInstantReviveModifier, this.player, this.getPokemon()) as PokemonInstantReviveModifier;

--- a/src/test/moves/destiny_bond.test.ts
+++ b/src/test/moves/destiny_bond.test.ts
@@ -43,7 +43,7 @@ describe("Moves - Destiny Bond", () => {
 
   it("should KO the opponent on the same turn", async () => {
     const moveToUse = Moves.TACKLE;
-    vi.spyOn(allMoves[moveToUse], "accuracy", "get").mockReturnValue(100);
+
     game.override.moveset(moveToUse);
     await game.classicMode.startBattle(defaultParty);
 
@@ -60,7 +60,7 @@ describe("Moves - Destiny Bond", () => {
 
   it("should KO the opponent on the next turn", async () => {
     const moveToUse = Moves.TACKLE;
-    vi.spyOn(allMoves[moveToUse], "accuracy", "get").mockReturnValue(100);
+
     game.override.moveset([ Moves.SPLASH, moveToUse ]);
     await game.classicMode.startBattle(defaultParty);
 
@@ -86,7 +86,7 @@ describe("Moves - Destiny Bond", () => {
 
   it("should fail if used twice in a row", async () => {
     const moveToUse = Moves.TACKLE;
-    vi.spyOn(allMoves[moveToUse], "accuracy", "get").mockReturnValue(100);
+
     game.override.moveset([ Moves.SPLASH, moveToUse ]);
     await game.classicMode.startBattle(defaultParty);
 
@@ -113,7 +113,7 @@ describe("Moves - Destiny Bond", () => {
   it("should not KO the opponent if the user dies to weather", async () => {
     // Opponent will be reduced to 1 HP by False Swipe, then faint to Sandstorm
     const moveToUse = Moves.FALSE_SWIPE;
-    vi.spyOn(allMoves[moveToUse], "accuracy", "get").mockReturnValue(100);
+
     game.override.moveset(moveToUse)
       .ability(Abilities.SAND_STREAM);
     await game.classicMode.startBattle(defaultParty);
@@ -131,7 +131,7 @@ describe("Moves - Destiny Bond", () => {
 
   it("should not KO the opponent if the user had another turn", async () => {
     const moveToUse = Moves.TACKLE;
-    vi.spyOn(allMoves[moveToUse], "accuracy", "get").mockReturnValue(100);
+
     game.override.moveset([ Moves.SPORE, moveToUse ]);
     await game.classicMode.startBattle(defaultParty);
 
@@ -157,9 +157,7 @@ describe("Moves - Destiny Bond", () => {
   });
 
   it("should not KO an ally", async () => {
-    const movesToUse = [ Moves.DESTINY_BOND, Moves.CRUNCH ];
-    vi.spyOn(allMoves[movesToUse[1]], "accuracy", "get").mockReturnValue(100);
-    game.override.moveset(movesToUse)
+    game.override.moveset([ Moves.DESTINY_BOND, Moves.CRUNCH ])
       .battleType("double");
     await game.classicMode.startBattle([ Species.SHEDINJA, Species.BULBASAUR, Species.SQUIRTLE ]);
 
@@ -168,9 +166,10 @@ describe("Moves - Destiny Bond", () => {
     const playerPokemon0 = game.scene.getPlayerField()[0];
     const playerPokemon1 = game.scene.getPlayerField()[1];
 
-    game.move.select(movesToUse[0], 0);
-    game.move.select(movesToUse[1], 1, BattlerIndex.PLAYER);
-    await game.setTurnOrder([ BattlerIndex.ENEMY, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER, BattlerIndex.PLAYER_2 ]);
+    // Shedinja uses Destiny Bond, then ally Bulbasaur KO's Shedinja with Crunch
+    game.move.select(Moves.DESTINY_BOND, 0);
+    game.move.select(Moves.CRUNCH, 1, BattlerIndex.PLAYER);
+    await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2 ]);
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(enemyPokemon0?.isFainted()).toBe(false);
@@ -182,6 +181,7 @@ describe("Moves - Destiny Bond", () => {
   it("should not cause a crash if the user is KO'd by Ceaseless Edge", async () => {
     const moveToUse = Moves.CEASELESS_EDGE;
     vi.spyOn(allMoves[moveToUse], "accuracy", "get").mockReturnValue(100);
+
     game.override.moveset(moveToUse);
     await game.classicMode.startBattle(defaultParty);
 
@@ -202,10 +202,7 @@ describe("Moves - Destiny Bond", () => {
   });
 
   it("should not cause a crash if the user is KO'd by Pledge moves", async () => {
-    const movesToUse = [ Moves.GRASS_PLEDGE, Moves.WATER_PLEDGE ];
-    vi.spyOn(allMoves[movesToUse[0]], "accuracy", "get").mockReturnValue(100);
-    vi.spyOn(allMoves[movesToUse[1]], "accuracy", "get").mockReturnValue(100);
-    game.override.moveset(movesToUse)
+    game.override.moveset([ Moves.GRASS_PLEDGE, Moves.WATER_PLEDGE ])
       .battleType("double");
     await game.classicMode.startBattle(defaultParty);
 
@@ -214,8 +211,8 @@ describe("Moves - Destiny Bond", () => {
     const playerPokemon0 = game.scene.getPlayerField()[0];
     const playerPokemon1 = game.scene.getPlayerField()[1];
 
-    game.move.select(movesToUse[0], 0, BattlerIndex.ENEMY);
-    game.move.select(movesToUse[1], 1, BattlerIndex.ENEMY);
+    game.move.select(Moves.GRASS_PLEDGE, 0, BattlerIndex.ENEMY);
+    game.move.select(Moves.WATER_PLEDGE, 1, BattlerIndex.ENEMY);
     await game.setTurnOrder([ BattlerIndex.ENEMY, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER, BattlerIndex.PLAYER_2 ]);
     await game.phaseInterceptor.to("BerryPhase");
 
@@ -236,7 +233,7 @@ describe("Moves - Destiny Bond", () => {
    */
   it("should not allow the opponent to revive via Reviver Seed", async () => {
     const moveToUse = Moves.TACKLE;
-    vi.spyOn(allMoves[moveToUse], "accuracy", "get").mockReturnValue(100);
+
     game.override.moveset(moveToUse)
       .startingHeldItems([{ name: "REVIVER_SEED" }]);
     await game.classicMode.startBattle(defaultParty);

--- a/src/test/moves/destiny_bond.test.ts
+++ b/src/test/moves/destiny_bond.test.ts
@@ -1,0 +1,258 @@
+import { ArenaTagSide, ArenaTrapTag } from "#app/data/arena-tag";
+import { allMoves } from "#app/data/move";
+import { Abilities } from "#enums/abilities";
+import { ArenaTagType } from "#enums/arena-tag-type";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { BattlerIndex } from "#app/battle";
+import { StatusEffect } from "#enums/status-effect";
+import { PokemonInstantReviveModifier } from "#app/modifier/modifier";
+
+
+describe("Moves - Destiny Bond", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  const defaultParty = [ Species.BULBASAUR, Species.SQUIRTLE ];
+  const enemyFirst = [ BattlerIndex.ENEMY, BattlerIndex.PLAYER ];
+  const playerFirst = [ BattlerIndex.PLAYER, BattlerIndex.ENEMY ];
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override.battleType("single")
+      .ability(Abilities.UNNERVE) // Pre-emptively prevent flakiness from opponent berries
+      .enemySpecies(Species.RATTATA)
+      .enemyAbility(Abilities.RUN_AWAY)
+      .startingLevel(100) // Make sure tested moves KO
+      .enemyLevel(5)
+      .enemyMoveset(Moves.DESTINY_BOND);
+  });
+
+  it("should KO the opponent on the same turn", async () => {
+    const moveToUse = Moves.TACKLE;
+    vi.spyOn(allMoves[moveToUse], "accuracy", "get").mockReturnValue(100);
+    game.override.moveset(moveToUse);
+    await game.classicMode.startBattle(defaultParty);
+
+    const enemyPokemon = game.scene.getEnemyPokemon();
+    const playerPokemon = game.scene.getPlayerPokemon();
+
+    game.move.select(moveToUse);
+    await game.setTurnOrder(enemyFirst);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(enemyPokemon?.isFainted()).toBe(true);
+    expect(playerPokemon?.isFainted()).toBe(true);
+  });
+
+  it("should KO the opponent on the next turn", async () => {
+    const moveToUse = Moves.TACKLE;
+    vi.spyOn(allMoves[moveToUse], "accuracy", "get").mockReturnValue(100);
+    game.override.moveset([ Moves.SPLASH, moveToUse ]);
+    await game.classicMode.startBattle(defaultParty);
+
+    const enemyPokemon = game.scene.getEnemyPokemon();
+    const playerPokemon = game.scene.getPlayerPokemon();
+
+    // Turn 1: Enemy uses Destiny Bond and doesn't faint
+    game.move.select(Moves.SPLASH);
+    await game.setTurnOrder(playerFirst);
+    await game.toNextTurn();
+
+    expect(enemyPokemon?.isFainted()).toBe(false);
+    expect(playerPokemon?.isFainted()).toBe(false);
+
+    // Turn 2: Player KO's the enemy before the enemy's turn
+    game.move.select(moveToUse);
+    await game.setTurnOrder(playerFirst);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(enemyPokemon?.isFainted()).toBe(true);
+    expect(playerPokemon?.isFainted()).toBe(true);
+  });
+
+  it("should fail if used twice in a row", async () => {
+    const moveToUse = Moves.TACKLE;
+    vi.spyOn(allMoves[moveToUse], "accuracy", "get").mockReturnValue(100);
+    game.override.moveset([ Moves.SPLASH, moveToUse ]);
+    await game.classicMode.startBattle(defaultParty);
+
+    const enemyPokemon = game.scene.getEnemyPokemon();
+    const playerPokemon = game.scene.getPlayerPokemon();
+
+    // Turn 1: Enemy uses Destiny Bond and doesn't faint
+    game.move.select(Moves.SPLASH);
+    await game.setTurnOrder(enemyFirst);
+    await game.toNextTurn();
+
+    expect(enemyPokemon?.isFainted()).toBe(false);
+    expect(playerPokemon?.isFainted()).toBe(false);
+
+    // Turn 2: Enemy should fail Destiny Bond then get KO'd
+    game.move.select(moveToUse);
+    await game.setTurnOrder(enemyFirst);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(enemyPokemon?.isFainted()).toBe(true);
+    expect(playerPokemon?.isFainted()).toBe(false);
+  });
+
+  it("should not KO the opponent if the user dies to weather", async () => {
+    // Opponent will be reduced to 1 HP by False Swipe, then faint to Sandstorm
+    const moveToUse = Moves.FALSE_SWIPE;
+    vi.spyOn(allMoves[moveToUse], "accuracy", "get").mockReturnValue(100);
+    game.override.moveset(moveToUse)
+      .ability(Abilities.SAND_STREAM);
+    await game.classicMode.startBattle(defaultParty);
+
+    const enemyPokemon = game.scene.getEnemyPokemon();
+    const playerPokemon = game.scene.getPlayerPokemon();
+
+    game.move.select(moveToUse);
+    await game.setTurnOrder(enemyFirst);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(enemyPokemon?.isFainted()).toBe(true);
+    expect(playerPokemon?.isFainted()).toBe(false);
+  });
+
+  it("should not KO the opponent if the user had another turn", async () => {
+    const moveToUse = Moves.TACKLE;
+    vi.spyOn(allMoves[moveToUse], "accuracy", "get").mockReturnValue(100);
+    game.override.moveset([ Moves.SPORE, moveToUse ]);
+    await game.classicMode.startBattle(defaultParty);
+
+    const enemyPokemon = game.scene.getEnemyPokemon();
+    const playerPokemon = game.scene.getPlayerPokemon();
+
+    // Turn 1: Enemy uses Destiny Bond and doesn't faint
+    game.move.select(Moves.SPORE);
+    await game.setTurnOrder(enemyFirst);
+    await game.toNextTurn();
+
+    expect(enemyPokemon?.isFainted()).toBe(false);
+    expect(playerPokemon?.isFainted()).toBe(false);
+    expect(enemyPokemon?.status?.effect).toBe(StatusEffect.SLEEP);
+
+    // Turn 2: Enemy should skip a turn due to sleep, then get KO'd
+    game.move.select(moveToUse);
+    await game.setTurnOrder(enemyFirst);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(enemyPokemon?.isFainted()).toBe(true);
+    expect(playerPokemon?.isFainted()).toBe(false);
+  });
+
+  it("should not KO an ally", async () => {
+    const movesToUse = [ Moves.DESTINY_BOND, Moves.CRUNCH ];
+    vi.spyOn(allMoves[movesToUse[1]], "accuracy", "get").mockReturnValue(100);
+    game.override.moveset(movesToUse)
+      .battleType("double");
+    await game.classicMode.startBattle([ Species.SHEDINJA, Species.BULBASAUR, Species.SQUIRTLE ]);
+
+    const enemyPokemon0 = game.scene.getEnemyField()[0];
+    const enemyPokemon1 = game.scene.getEnemyField()[1];
+    const playerPokemon0 = game.scene.getPlayerField()[0];
+    const playerPokemon1 = game.scene.getPlayerField()[1];
+
+    game.move.select(movesToUse[0], 0);
+    game.move.select(movesToUse[1], 1, BattlerIndex.PLAYER);
+    await game.setTurnOrder([ BattlerIndex.ENEMY, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER, BattlerIndex.PLAYER_2 ]);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(enemyPokemon0?.isFainted()).toBe(false);
+    expect(enemyPokemon1?.isFainted()).toBe(false);
+    expect(playerPokemon0?.isFainted()).toBe(true);
+    expect(playerPokemon1?.isFainted()).toBe(false);
+  });
+
+  it("should not cause a crash if the user is KO'd by Ceaseless Edge", async () => {
+    const moveToUse = Moves.CEASELESS_EDGE;
+    vi.spyOn(allMoves[moveToUse], "accuracy", "get").mockReturnValue(100);
+    game.override.moveset(moveToUse);
+    await game.classicMode.startBattle(defaultParty);
+
+    const enemyPokemon = game.scene.getEnemyPokemon();
+    const playerPokemon = game.scene.getPlayerPokemon();
+
+    game.move.select(moveToUse);
+    await game.setTurnOrder(enemyFirst);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(enemyPokemon?.isFainted()).toBe(true);
+    expect(playerPokemon?.isFainted()).toBe(true);
+
+    // Ceaseless Edge spikes effect should still activate
+    const tagAfter = game.scene.arena.getTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as ArenaTrapTag;
+    expect(tagAfter.tagType).toBe(ArenaTagType.SPIKES);
+    expect(tagAfter.layers).toBe(1);
+  });
+
+  it("should not cause a crash if the user is KO'd by Pledge moves", async () => {
+    const movesToUse = [ Moves.GRASS_PLEDGE, Moves.WATER_PLEDGE ];
+    vi.spyOn(allMoves[movesToUse[0]], "accuracy", "get").mockReturnValue(100);
+    vi.spyOn(allMoves[movesToUse[1]], "accuracy", "get").mockReturnValue(100);
+    game.override.moveset(movesToUse)
+      .battleType("double");
+    await game.classicMode.startBattle(defaultParty);
+
+    const enemyPokemon0 = game.scene.getEnemyField()[0];
+    const enemyPokemon1 = game.scene.getEnemyField()[1];
+    const playerPokemon0 = game.scene.getPlayerField()[0];
+    const playerPokemon1 = game.scene.getPlayerField()[1];
+
+    game.move.select(movesToUse[0], 0, BattlerIndex.ENEMY);
+    game.move.select(movesToUse[1], 1, BattlerIndex.ENEMY);
+    await game.setTurnOrder([ BattlerIndex.ENEMY, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER, BattlerIndex.PLAYER_2 ]);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(enemyPokemon0?.isFainted()).toBe(true);
+    expect(enemyPokemon1?.isFainted()).toBe(false);
+    expect(playerPokemon0?.isFainted()).toBe(false);
+    expect(playerPokemon1?.isFainted()).toBe(true);
+
+    // Pledge secondary effect should still activate
+    const tagAfter = game.scene.arena.getTagOnSide(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.ENEMY) as ArenaTrapTag;
+    expect(tagAfter.tagType).toBe(ArenaTagType.GRASS_WATER_PLEDGE);
+  });
+
+  /**
+   * In particular, this should prevent something like
+   * {@link https://github.com/pagefaultgames/pokerogue/issues/4219}
+   * from occurring with fainting by KO'ing a Destiny Bond user with U-Turn.
+   */
+  it("should not allow the opponent to revive via Reviver Seed", async () => {
+    const moveToUse = Moves.TACKLE;
+    vi.spyOn(allMoves[moveToUse], "accuracy", "get").mockReturnValue(100);
+    game.override.moveset(moveToUse)
+      .startingHeldItems([{ name: "REVIVER_SEED" }]);
+    await game.classicMode.startBattle(defaultParty);
+
+    const enemyPokemon = game.scene.getEnemyPokemon();
+    const playerPokemon = game.scene.getPlayerPokemon();
+
+    game.move.select(moveToUse);
+    await game.setTurnOrder(enemyFirst);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(enemyPokemon?.isFainted()).toBe(true);
+    expect(playerPokemon?.isFainted()).toBe(true);
+
+    // Check that the Tackle user's Reviver Seed did not activate
+    const revSeeds = game.scene.getModifiers(PokemonInstantReviveModifier).filter(m => m.pokemonId === playerPokemon?.id);
+    expect(revSeeds.length).toBe(1);
+  });
+});


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
(Original bug report: https://discord.com/channels/1125469663833370665/1289804691076681728)
If a Pokemon uses Destiny Bond then gets KO'd by certain moves (confirmed examples are Ceaseless Edge, Stone Axe, and Pledge moves), it should no longer cause a crash.

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Fixing a crash.

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
1. Destiny Bond's activation is moved to the Destiny Bond user's FaintPhase so that it occurs after the game applies all move effects. This ensures that the opponent is not fainted yet when applying move effects, which lets us avoid crashes, and also ensures that the move effects are successful, which matches Showdown's implementation:
[20241013 Destiny Bond.html.txt](https://github.com/user-attachments/files/17379272/20241013.Destiny.Bond.html.txt)
2. Certain move effect attributes using `getLastXMoves` now check whether or not the move is undefined. This is mostly future-proofing for interactions like Ceaseless Edge vs. Iron Barbs.
3. Added tests for Destiny Bond.

## Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->


<details>
<summary> Before the changes: Crash from Ceaseless Edge </summary>

https://github.com/user-attachments/assets/47ea888a-68a6-4272-9e53-1b81de630441

</details>

<details>
<summary> After the changes: No crash from Ceaseless Edge </summary>

https://github.com/user-attachments/assets/609e600a-2ee6-4b00-8035-e688990d8eae

</details>

<details>
<summary> After the changes: No crash from Pledge moves </summary>

https://github.com/user-attachments/assets/5988928f-7071-43d2-9e22-25e130bf400e

</details>


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
`npm run test destiny_bond`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~~[ ] Are the changes visual?~~
  - [x] Have I provided screenshots/videos of the changes?
