### PR TITLE
[P1 Bug] Fix party UI crash from unsanitized `lastCursor`

### DIFF
--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -671,6 +671,9 @@ export default class PartyUiHandler extends MessageUiHandler {
     } else if (this.cursor === 6) {
       this.partyCancelButton.select();
     }
+    if (this.lastCursor < 6 && this.lastCursor >= party.length) {
+      this.lastCursor = party.length - 1;
+    }
 
     for (const p in party) {
       const slotIndex = parseInt(p);


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
(Original bug report: https://discord.com/channels/1125469663833370665/1125894949020381285/1296088418387759106)
The party UI will no longer crash from `this.lastCursor` pointing to an empty Pokemon slot without a Pokemon, especially during ME's that take away one of your Pokemon.

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Fixing a crash.

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Right after sanitizing `this.cursor`, the code now also sanitizes `this.lastCursor` by moving it to the last filled Pokemon slot if it is currently at an empty Pokemon slot.

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
1. Reach an ME that takes away one of your Pokemon (e.g., Training Session).
2. Move the cursor to the last Pokemon in your party.
3. Press LEFT to move the cursor to the first Pokemon, and select it for the encounter.
4. During the encounter, go to the party UI (e.g., by fainting).
5. Press RIGHT.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

Before the changes:

https://github.com/user-attachments/assets/f361854d-e054-44e4-9808-630c0db07c74

After the changes:

https://github.com/user-attachments/assets/a1e567ad-a375-495d-9bf8-e20f16295b23

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue? (Writing UI tests is hard :( )
- ~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~~[ ] Are the changes visual?~~
  - [x] Have I provided screenshots/videos of the changes?
