### PR TITLE
[Bug][Beta] Corrected Secret Power's secondary effect chance + removed edgecase tags

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -4913,8 +4913,7 @@ export function initAbilities() {
       .attr(TypeImmunityAddBattlerTagAbAttr, Type.FIRE, BattlerTagType.FIRE_BOOST, 1)
       .ignorable(),
     new Ability(Abilities.SHIELD_DUST, 3)
-      .attr(IgnoreMoveEffectsAbAttr)
-      .edgeCase(), // Does not work with secret power (unimplemented)
+      .attr(IgnoreMoveEffectsAbAttr),
     new Ability(Abilities.OWN_TEMPO, 3)
       .attr(BattlerTagImmunityAbAttr, BattlerTagType.CONFUSED)
       .attr(IntimidateImmunityAbAttr)
@@ -4958,8 +4957,7 @@ export function initAbilities() {
       .attr(TypeImmunityStatStageChangeAbAttr, Type.ELECTRIC, Stat.SPATK, 1)
       .ignorable(),
     new Ability(Abilities.SERENE_GRACE, 3)
-      .attr(MoveEffectChanceMultiplierAbAttr, 2)
-      .edgeCase(), // does not work with secret power (unimplemented)
+      .attr(MoveEffectChanceMultiplierAbAttr, 2),
     new Ability(Abilities.SWIFT_SWIM, 3)
       .attr(StatMultiplierAbAttr, Stat.SPD, 2)
       .condition(getWeatherCondition(WeatherType.RAIN, WeatherType.HEAVY_RAIN)),

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2891,8 +2891,6 @@ export class SecretPowerAttr extends MoveEffectAttr {
     this.effectChanceOverride = move.chance;
     const moveChance = this.getMoveChance(user, target, move, this.selfTarget);
     if (moveChance < 0 || moveChance === 100 || user.randSeedInt(100) < moveChance) {
-      // effectChanceOverride used in the application of the actual secondary effect
-      this.effectChanceOverride = 100;
       return true;
     } else {
       return false;
@@ -2915,6 +2913,8 @@ export class SecretPowerAttr extends MoveEffectAttr {
       const biome = user.scene.arena.biomeType;
       secondaryEffect = this.determineBiomeEffect(biome);
     }
+    // effectChanceOverride used in the application of the actual secondary effect
+    secondaryEffect.effectChanceOverride = 100;
     return secondaryEffect.apply(user, target, move, []);
   }
 


### PR DESCRIPTION
## What are the changes the user will see?
Secret Power has a 30% rate of applying a secondary effect. Previously, it was 30%*30% 

## Why am I making these changes?
oops

## What are the changes from a developer perspective?
- moved effectChanceOverride to the correct attr
- removed edge case tags

## How to test the changes?
Use Secret Power

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
