### PR TITLE
[Beta P3][UI] Fix item/cursor placement in shop screen

### DIFF
--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -17,6 +17,9 @@ import { IntegerHolder } from "./../utils";
 import Phaser from "phaser";
 
 export const SHOP_OPTIONS_ROW_LIMIT = 7;
+const SINGLE_SHOP_ROW_YOFFSET = 12;
+const DOUBLE_SHOP_ROW_YOFFSET = 24;
+const OPTION_BUTTON_YPOSITION = -62;
 
 export default class ModifierSelectUiHandler extends AwaitableUiHandler {
   private modifierContainer: Phaser.GameObjects.Container;
@@ -68,7 +71,7 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
       this.checkButtonWidth = context.measureText(i18next.t("modifierSelectUiHandler:checkTeam")).width;
     }
 
-    this.transferButtonContainer = this.scene.add.container((this.scene.game.canvas.width - this.checkButtonWidth) / 6 - 21, -64);
+    this.transferButtonContainer = this.scene.add.container((this.scene.game.canvas.width - this.checkButtonWidth) / 6 - 21, OPTION_BUTTON_YPOSITION);
     this.transferButtonContainer.setName("transfer-btn");
     this.transferButtonContainer.setVisible(false);
     ui.add(this.transferButtonContainer);
@@ -78,7 +81,7 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
     transferButtonText.setOrigin(1, 0);
     this.transferButtonContainer.add(transferButtonText);
 
-    this.checkButtonContainer = this.scene.add.container((this.scene.game.canvas.width) / 6 - 1, -64);
+    this.checkButtonContainer = this.scene.add.container((this.scene.game.canvas.width) / 6 - 1, OPTION_BUTTON_YPOSITION);
     this.checkButtonContainer.setName("use-btn");
     this.checkButtonContainer.setVisible(false);
     ui.add(this.checkButtonContainer);
@@ -88,7 +91,7 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
     checkButtonText.setOrigin(1, 0);
     this.checkButtonContainer.add(checkButtonText);
 
-    this.rerollButtonContainer = this.scene.add.container(16, -64);
+    this.rerollButtonContainer = this.scene.add.container(16, OPTION_BUTTON_YPOSITION);
     this.rerollButtonContainer.setName("reroll-brn");
     this.rerollButtonContainer.setVisible(false);
     ui.add(this.rerollButtonContainer);
@@ -104,7 +107,7 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
     this.rerollCostText.setPositionRelative(rerollButtonText, rerollButtonText.displayWidth + 5, 1);
     this.rerollButtonContainer.add(this.rerollCostText);
 
-    this.lockRarityButtonContainer = this.scene.add.container(16, -64);
+    this.lockRarityButtonContainer = this.scene.add.container(16, OPTION_BUTTON_YPOSITION);
     this.lockRarityButtonContainer.setVisible(false);
     ui.add(this.lockRarityButtonContainer);
 
@@ -191,7 +194,7 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
     const shopTypeOptions = !removeHealShop
       ? getPlayerShopModifierTypeOptionsForWave(this.scene.currentBattle.waveIndex, baseShopCost.value)
       : [];
-    const optionsYOffset = shopTypeOptions.length >= SHOP_OPTIONS_ROW_LIMIT ? -8 : -24;
+    const optionsYOffset = shopTypeOptions.length > SHOP_OPTIONS_ROW_LIMIT ? -SINGLE_SHOP_ROW_YOFFSET : -DOUBLE_SHOP_ROW_YOFFSET;
 
     for (let m = 0; m < typeOptions.length; m++) {
       const sliceWidth = (this.scene.game.canvas.width / 6) / (typeOptions.length + 2);
@@ -212,7 +215,7 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
       const col = m < SHOP_OPTIONS_ROW_LIMIT ? m : m - SHOP_OPTIONS_ROW_LIMIT;
       const rowOptions = shopTypeOptions.slice(row ? SHOP_OPTIONS_ROW_LIMIT : 0, row ? undefined : SHOP_OPTIONS_ROW_LIMIT);
       const sliceWidth = (this.scene.game.canvas.width / 6) / (rowOptions.length + 2);
-      const option = new ModifierOption(this.scene, sliceWidth * (col + 1) + (sliceWidth * 0.5), ((-this.scene.game.canvas.height / 12) - (this.scene.game.canvas.height / 32) - (40 - (28 * row - 1))), shopTypeOptions[m]);
+      const option = new ModifierOption(this.scene, sliceWidth * (col + 1) + (sliceWidth * 0.5), ((-this.scene.game.canvas.height / 12) - (this.scene.game.canvas.height / 32) - (42 - (28 * row - 1))), shopTypeOptions[m]);
       option.setScale(0.375);
       this.scene.add.existing(option);
       this.modifierContainer.add(option);
@@ -456,16 +459,18 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
       if (this.rowCursor === 1 && options.length === 0) {
         // Continue button when no shop items
         this.cursorObj.setScale(1.25);
-        this.cursorObj.setPosition((this.scene.game.canvas.width / 18) + 23, (-this.scene.game.canvas.height / 12) - (this.shopOptionsRows.length > 1 ? 6 : 22));
+        this.cursorObj.setPosition((this.scene.game.canvas.width / 18) + 23, (-this.scene.game.canvas.height / 12) - (this.shopOptionsRows.length > 1 ? SINGLE_SHOP_ROW_YOFFSET - 2 : DOUBLE_SHOP_ROW_YOFFSET - 2));
         ui.showText(i18next.t("modifierSelectUiHandler:continueNextWaveDescription"));
         return ret;
       }
 
       const sliceWidth = (this.scene.game.canvas.width / 6) / (options.length + 2);
       if (this.rowCursor < 2) {
-        this.cursorObj.setPosition(sliceWidth * (cursor + 1) + (sliceWidth * 0.5) - 20, (-this.scene.game.canvas.height / 12) - (this.shopOptionsRows.length > 1 ? 6 : 22));
+        // Cursor on free items
+        this.cursorObj.setPosition(sliceWidth * (cursor + 1) + (sliceWidth * 0.5) - 20, (-this.scene.game.canvas.height / 12) - (this.shopOptionsRows.length > 1 ? SINGLE_SHOP_ROW_YOFFSET - 2 : DOUBLE_SHOP_ROW_YOFFSET - 2));
       } else {
-        this.cursorObj.setPosition(sliceWidth * (cursor + 1) + (sliceWidth * 0.5) - 16, (-this.scene.game.canvas.height / 12 - this.scene.game.canvas.height / 32) - (-16 + 28 * (this.rowCursor - (this.shopOptionsRows.length - 1))));
+        // Cursor on paying items
+        this.cursorObj.setPosition(sliceWidth * (cursor + 1) + (sliceWidth * 0.5) - 16, (-this.scene.game.canvas.height / 12 - this.scene.game.canvas.height / 32) - (-14 + 28 * (this.rowCursor - (this.shopOptionsRows.length - 1))));
       }
 
       const type = options[this.cursor].modifierTypeOption.type;
@@ -475,16 +480,16 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
         this.moveInfoOverlay.show(allMoves[type.moveId]);
       }
     } else if (cursor === 0) {
-      this.cursorObj.setPosition(6, this.lockRarityButtonContainer.visible ? -72 : -60);
+      this.cursorObj.setPosition(6, this.lockRarityButtonContainer.visible ? OPTION_BUTTON_YPOSITION - 8 : OPTION_BUTTON_YPOSITION + 4);
       ui.showText(i18next.t("modifierSelectUiHandler:rerollDesc"));
     } else if (cursor === 1) {
-      this.cursorObj.setPosition((this.scene.game.canvas.width - this.transferButtonWidth - this.checkButtonWidth) / 6 - 30, -60);
+      this.cursorObj.setPosition((this.scene.game.canvas.width - this.transferButtonWidth - this.checkButtonWidth) / 6 - 30, OPTION_BUTTON_YPOSITION + 4);
       ui.showText(i18next.t("modifierSelectUiHandler:transferDesc"));
     } else if (cursor === 2) {
-      this.cursorObj.setPosition((this.scene.game.canvas.width - this.checkButtonWidth) / 6 - 10, -60);
+      this.cursorObj.setPosition((this.scene.game.canvas.width - this.checkButtonWidth) / 6 - 10, OPTION_BUTTON_YPOSITION + 4);
       ui.showText(i18next.t("modifierSelectUiHandler:checkTeamDesc"));
     } else {
-      this.cursorObj.setPosition(6, -60);
+      this.cursorObj.setPosition(6, OPTION_BUTTON_YPOSITION + 4);
       ui.showText(i18next.t("modifierSelectUiHandler:lockRaritiesDesc"));
     }
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
1) (beta) No more offset cursor between waves 51 and 90 in shop
2) (all) Slight adjustments to element positioning in shop screen to allow more room for the free rewards description
<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?
1) #4555 caused an issue with misaligned shop cursor in some cases
2) Some item descriptions overlap in some languages, so the changes make room for descriptions to potentially take up 2 lines. This PR does not change any item description, only makes room in prevision for future updates that do need it. (for example PR #4065)

<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What are the changes from a developer perspective?
- Replace mistaken `>=` by `>` to fix the cursor placement issue
- Add some constants used to place stuff around so UI so that can it be more easily adjusted
- The following placement adjustments were made:
   - Move paying items slightly up
   - Move Reroll / Lock / Transfer / Party options slightly down
   - Move free items rewards up if there are 2 rows of paying items in the shop

<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos

<details><summary>Before/After - Cursor misalignement:</summary>
<img width="327" alt="_before_continue_1row" src="https://github.com/user-attachments/assets/ead75aed-0adc-41d2-b35d-ad41c45a1115"> <img width="320" alt="_after_continue_1row" src="https://github.com/user-attachments/assets/2a70d23f-7706-4dd8-9470-868f142a99bb">

<img width="326" alt="_before_shop_1row" src="https://github.com/user-attachments/assets/1a9b946b-0dce-4b2d-8f49-c0a834fb50c3"> <img width="325" alt="_after_shop_1row" src="https://github.com/user-attachments/assets/5fde05fe-35d4-4d43-804e-a4374c62f302">
</details>

<details><summary>Before/After - Reward screen with 2 rows of shop:</summary>

<img width="327" alt="_before_shop_2rows" src="https://github.com/user-attachments/assets/867bb546-57ec-4fcd-ab66-5e9f6c4e8d62"> <img width="329" alt="_after_shop_2rows" src="https://github.com/user-attachments/assets/f06fa8ad-94ac-4d34-ae67-e50b62767810">

<img width="326" alt="_before_continue_2rows" src="https://github.com/user-attachments/assets/a1e51c7e-404f-4484-9e29-6d42fd7ce905"> <img width="328" alt="_after_continue_2rows" src="https://github.com/user-attachments/assets/197304eb-93d3-457b-a04a-fab43687751b">

</details>

<details><summary>Before/After - Reward screen with 2 rows of and reroll option:</summary>

<img width="327" alt="_before_reroll" src="https://github.com/user-attachments/assets/651da224-4227-484c-ac97-80416edc3c86"> <img width="329" alt="_after_reroll" src="https://github.com/user-attachments/assets/a6de0e71-6290-40a7-8693-47447f73c0d2">

Same thing but with TMs taking 2 lines (not part of this PR, but to show there is room):
<img width="329" alt="_before_reroll_tm" src="https://github.com/user-attachments/assets/79aa533a-e5ff-4c7d-b307-7e9cb2bcd397"> <img width="323" alt="_after_reroll_tm" src="https://github.com/user-attachments/assets/202e29b4-cf5a-45be-958e-8064df976730">

</details>

<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
- Use overrides to see the reward screen in various states (for exmple through MEs or by changing the starting wave)
- Move the cursor around and make sure everything is aligned properly

<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
~~- [ ] Have I considered writing automated tests for the issue?~~
~~- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
