### PR TITLE
[Move][Ability] Fully Implement Forest's Curse / Trick Or Treat / Mimicry

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5878,11 +5878,7 @@ export class AddTypeAttr extends MoveEffectAttr {
   }
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const types = target.getTypes().slice(0, 2).filter(t => t !== Type.UNKNOWN); // TODO: Figure out some way to actually check if another version of this effect is already applied
-    if (this.type !== Type.UNKNOWN) {
-      types.push(this.type);
-    }
-    target.summonData.types = types;
+    target.summonData.addedType = this.type;
     target.updateInfo();
 
     user.scene.queueMessage(i18next.t("moveTriggers:addType", { typeName: i18next.t(`pokemonInfo:Type.${Type[this.type]}`), pokemonName: getPokemonNameWithAffix(target) }));
@@ -8877,8 +8873,7 @@ export function initMoves() {
       .ignoresProtect()
       .ignoresVirtual(),
     new StatusMove(Moves.TRICK_OR_TREAT, Type.GHOST, 100, 20, -1, 0, 6)
-      .attr(AddTypeAttr, Type.GHOST)
-      .edgeCase(), // Weird interaction with Forest's Curse, reflect type, burn up
+      .attr(AddTypeAttr, Type.GHOST),
     new StatusMove(Moves.NOBLE_ROAR, Type.NORMAL, 100, 30, -1, 0, 6)
       .attr(StatStageChangeAttr, [ Stat.ATK, Stat.SPATK ], -1)
       .soundBased(),
@@ -8890,8 +8885,7 @@ export function initMoves() {
       .target(MoveTarget.ALL_NEAR_OTHERS)
       .triageMove(),
     new StatusMove(Moves.FORESTS_CURSE, Type.GRASS, 100, 20, -1, 0, 6)
-      .attr(AddTypeAttr, Type.GRASS)
-      .edgeCase(), // Weird interaction with Trick or Treat, reflect type, burn up
+      .attr(AddTypeAttr, Type.GRASS),
     new AttackMove(Moves.PETAL_BLIZZARD, Type.GRASS, MoveCategory.PHYSICAL, 90, 100, 15, -1, 0, 6)
       .windMove()
       .makesContact(false)

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1248,6 +1248,11 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       }
     }
 
+    // the type added to Pokemon from moves like Forest's Curse or Trick Or Treat
+    if (this.summonData?.addedType) {
+      types.push(this.summonData?.addedType);
+    }
+
     // this.scene potentially can be undefined for a fainted pokemon in doubles
     // use optional chaining to avoid runtime errors
 
@@ -5029,6 +5034,7 @@ export class PokemonSummonData {
   public moveset: (PokemonMove | null)[];
   // If not initialized this value will not be populated from save data.
   public types: Type[] = [];
+  public addedType: Type | null = null;
 }
 
 export class PokemonBattleData {


### PR DESCRIPTION
## What are the changes the user will see?
Forest's Curse and Trick Or Treat will be fully implemented.
Mimicry will also be implemented since the ability has edge cases with the above moves.  

## Why am I making these changes?
Shareholder value up. 

## What are the changes from a developer perspective?
New summonData field 'addedType' that stores types added by Forest's Curse / Trick Or Treat
New ability attribute. 

Checklist:
- [ ] Test for Forest's Curse
- [ ] Test for Trick Or Treat
- [ ] Mimicry Implementation 
- [ ] Test for Mimicry

### Screenshots/Videos

https://github.com/user-attachments/assets/0803bbaa-06ea-4f8c-826a-aa41266ff875

## How to test the changes?
Use Forest's Curse and Trick Or Treat on the same Pokemon. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
