### PR TITLE
[Bug fix] Fix for No Exp Awarded to Party Members with Exp All if Active Pokémon is KO'd with Opponent

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -3038,6 +3038,7 @@ export default class BattleScene extends SceneBase {
     const expPartyMembers = nonFaintedPartyMembers.filter(p => p.level < this.getMaxExpLevel());
     const partyMemberExp: number[] = [];
     // EXP value calculation is based off Pokemon.getExpValue
+    console.log("PARTIPADOS", this.currentBattle.playerParticipantIds);
     if (useWaveIndexMultiplier) {
       expValue = Math.floor(expValue * this.currentBattle.waveIndex / 5 + 1);
     }
@@ -3116,6 +3117,14 @@ export default class BattleScene extends SceneBase {
 
         if (exp) {
           const partyMemberIndex = party.indexOf(expPartyMembers[pm]);
+          // Maybe here?
+          /*
+            I think that this hyper specific bug is because initally, the pokemon being switched in right before opposing pokemons death is not counted as participant,
+            and not in the expPartyMembers maybe?
+
+            in the other cause where I switched both in but swapped last second before toxic death, then both had already been involved in fight
+
+          */
           this.unshiftPhase(expPartyMembers[pm].isOnField() ? new ExpPhase(this, partyMemberIndex, exp) : new ShowPartyExpBarPhase(this, partyMemberIndex, exp));
         }
       }

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -3038,7 +3038,6 @@ export default class BattleScene extends SceneBase {
     const expPartyMembers = nonFaintedPartyMembers.filter(p => p.level < this.getMaxExpLevel());
     const partyMemberExp: number[] = [];
     // EXP value calculation is based off Pokemon.getExpValue
-    console.log("PARTIPADOS", this.currentBattle.playerParticipantIds);
     if (useWaveIndexMultiplier) {
       expValue = Math.floor(expValue * this.currentBattle.waveIndex / 5 + 1);
     }
@@ -3117,14 +3116,6 @@ export default class BattleScene extends SceneBase {
 
         if (exp) {
           const partyMemberIndex = party.indexOf(expPartyMembers[pm]);
-          // Maybe here?
-          /*
-            I think that this hyper specific bug is because initally, the pokemon being switched in right before opposing pokemons death is not counted as participant,
-            and not in the expPartyMembers maybe?
-
-            in the other cause where I switched both in but swapped last second before toxic death, then both had already been involved in fight
-
-          */
           this.unshiftPhase(expPartyMembers[pm].isOnField() ? new ExpPhase(this, partyMemberIndex, exp) : new ShowPartyExpBarPhase(this, partyMemberIndex, exp));
         }
       }

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -50,7 +50,6 @@ export class FaintPhase extends PokemonPhase {
         if (pokemon.isPlayer()) {
           this.scene.currentBattle.addParticipant(pokemon as PlayerPokemon);
         }
-        pokemon.resetTurnData();
       }
     });
 

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -44,6 +44,16 @@ export class FaintPhase extends PokemonPhase {
       }
     }
 
+    /** In case the current pokemon was just switched in, make sure it is counted as participating in the combat */
+    this.scene.getField().forEach((pokemon, i) => {
+      if (pokemon?.isActive()) {
+        if (pokemon.isPlayer()) {
+          this.scene.currentBattle.addParticipant(pokemon as PlayerPokemon);
+        }
+        pokemon.resetTurnData();
+      }
+    });
+
     if (!this.tryOverrideForBattleSpec()) {
       this.doFaint();
     }

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -44,9 +44,14 @@ export class FaintPhase extends PokemonPhase {
       }
     }
 
-    /** In case the current pokemon was just switched in, make sure it is counted as participating in the combat */
+    /**
+     * In case the current pokemon was just switched in, make sure it is counted as participating in the combat.
+     * For EXP_SHARE purposes, if the current pokemon faints as the combat ends and it was the ONLY player pokemon
+     * involved in combat, it needs to be counted as a participant so the other party pokemon can get their EXP,
+     * so the fainted pokemon has been included.
+    */
     this.scene.getField().forEach((pokemon, i) => {
-      if (pokemon?.isActive()) {
+      if (pokemon?.isActive() || pokemon?.isFainted()) {
         if (pokemon.isPlayer()) {
           this.scene.currentBattle.addParticipant(pokemon as PlayerPokemon);
         }


### PR DESCRIPTION
Fix for #4668 

Related to solution for #4687

## What are the changes the user will see?
Exp share will now properly give xp even if pokemon mutually faint at start of combat

## Why am I making these changes?
bug fix

## What are the changes from a developer perspective?
added faint check to faint-phase participant adding loop

### Screenshots/Videos

https://github.com/user-attachments/assets/e1cfa424-c618-4777-83ee-f29e070e23e5

## How to test the changes?
Override files, browser debugger

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [ ] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
