### PR TITLE
[Bug] The pokemon that set an arena hazard shouldn't ignore it

### DIFF
--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -626,7 +626,7 @@ export class ArenaTrapTag extends ArenaTag {
    * @returns `true` if this hazard affects the given Pokemon; `false` otherwise.
    */
   override apply(arena: Arena, simulated: boolean, pokemon: Pokemon): boolean {
-    if (this.sourceId === pokemon.id || (this.side === ArenaTagSide.PLAYER) !== pokemon.isPlayer()) {
+    if ((this.side === ArenaTagSide.PLAYER) !== pokemon.isPlayer()) {
       return false;
     }
 

--- a/src/test/moves/toxic_spikes.test.ts
+++ b/src/test/moves/toxic_spikes.test.ts
@@ -9,8 +9,6 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-const TIMEOUT = 20 * 1000;
-
 describe("Moves - Toxic Spikes", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
@@ -34,10 +32,10 @@ describe("Moves - Toxic Spikes", () => {
       .enemyAbility(Abilities.BALL_FETCH)
       .ability(Abilities.BALL_FETCH)
       .enemyMoveset(Moves.SPLASH)
-      .moveset([ Moves.TOXIC_SPIKES, Moves.SPLASH, Moves.ROAR ]);
+      .moveset([ Moves.TOXIC_SPIKES, Moves.SPLASH, Moves.ROAR, Moves.COURT_CHANGE ]);
   });
 
-  it("should not affect the opponent if they do not switch", async() => {
+  it("should not affect the opponent if they do not switch", async () => {
     await game.classicMode.runToSummon([ Species.MIGHTYENA, Species.POOCHYENA ]);
 
     const enemy = game.scene.getEnemyField()[0];
@@ -51,9 +49,9 @@ describe("Moves - Toxic Spikes", () => {
 
     expect(enemy.hp).toBe(enemy.getMaxHp());
     expect(enemy.status?.effect).toBeUndefined();
-  }, TIMEOUT);
+  });
 
-  it("should poison the opponent if they switch into 1 layer", async() => {
+  it("should poison the opponent if they switch into 1 layer", async () => {
     await game.classicMode.runToSummon([ Species.MIGHTYENA ]);
 
     game.move.select(Moves.TOXIC_SPIKES);
@@ -65,9 +63,9 @@ describe("Moves - Toxic Spikes", () => {
 
     expect(enemy.hp).toBeLessThan(enemy.getMaxHp());
     expect(enemy.status?.effect).toBe(StatusEffect.POISON);
-  }, TIMEOUT);
+  });
 
-  it("should badly poison the opponent if they switch into 2 layers", async() => {
+  it("should badly poison the opponent if they switch into 2 layers", async () => {
     await game.classicMode.runToSummon([ Species.MIGHTYENA ]);
 
     game.move.select(Moves.TOXIC_SPIKES);
@@ -80,27 +78,32 @@ describe("Moves - Toxic Spikes", () => {
     const enemy = game.scene.getEnemyField()[0];
     expect(enemy.hp).toBeLessThan(enemy.getMaxHp());
     expect(enemy.status?.effect).toBe(StatusEffect.TOXIC);
-  }, TIMEOUT);
+  });
 
-  it("should be removed if a grounded poison pokemon switches in", async() => {
-    game.override.enemySpecies(Species.GRIMER);
-    await game.classicMode.runToSummon([ Species.MIGHTYENA ]);
+  it("should be removed if a grounded poison pokemon switches in", async () => {
+    await game.classicMode.runToSummon([ Species.MUK, Species.PIDGEY ]);
+
+    const muk = game.scene.getPlayerPokemon()!;
 
     game.move.select(Moves.TOXIC_SPIKES);
-    await game.phaseInterceptor.to("TurnEndPhase");
-    game.move.select(Moves.TOXIC_SPIKES);
-    await game.phaseInterceptor.to("TurnEndPhase");
-    game.move.select(Moves.ROAR);
-    await game.phaseInterceptor.to("TurnEndPhase");
+    await game.toNextTurn();
+    // also make sure the toxic spikes are removed even if the pokemon
+    // that set them up is the one switching in (https://github.com/pagefaultgames/pokerogue/issues/935)
+    game.move.select(Moves.COURT_CHANGE);
+    await game.toNextTurn();
+    game.doSwitchPokemon(1);
+    await game.toNextTurn();
+    game.doSwitchPokemon(1);
+    await game.toNextTurn();
+    game.move.select(Moves.SPLASH);
+    await game.toNextTurn();
 
-    const enemy = game.scene.getEnemyField()[0];
-    expect(enemy.hp).toBe(enemy.getMaxHp());
-    expect(enemy.status?.effect).toBeUndefined();
-
+    expect(muk.isFullHp()).toBe(true);
+    expect(muk.status?.effect).toBeUndefined();
     expect(game.scene.arena.tags.length).toBe(0);
-  }, TIMEOUT);
+  });
 
-  it("shouldn't create multiple layers per use in doubles", async() => {
+  it("shouldn't create multiple layers per use in doubles", async () => {
     await game.classicMode.runToSummon([ Species.MIGHTYENA, Species.POOCHYENA ]);
 
     game.move.select(Moves.TOXIC_SPIKES);
@@ -109,9 +112,9 @@ describe("Moves - Toxic Spikes", () => {
     const arenaTags = (game.scene.arena.getTagOnSide(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY) as ArenaTrapTag);
     expect(arenaTags.tagType).toBe(ArenaTagType.TOXIC_SPIKES);
     expect(arenaTags.layers).toBe(1);
-  }, TIMEOUT);
+  });
 
-  it("should persist through reload", async() => {
+  it("should persist through reload", async () => {
     game.override.startingWave(1);
     const scene = game.scene;
     const gameData = new GameData(scene);
@@ -132,5 +135,5 @@ describe("Moves - Toxic Spikes", () => {
 
     expect(sessionData.arena.tags).toEqual(recoveredData.arena.tags);
     localStorage.removeItem("sessionTestData");
-  }, TIMEOUT);
+  });
 });


### PR DESCRIPTION
## What are the changes the user will see?
Arena hazards will properly affect the Pokémon that set them (which can happen due to the hazards being swapped with Court Change, for example). This also means Toxic Spikes will be removed if the Pokémon that set them was a poison type and switches in to them.

## Why am I making these changes?
Fixes #935 

## What are the changes from a developer perspective?
Removed the `this.sourceId === pokemon.id` check in `ArenaTrapTag.apply()`.

## How to test the changes?
`npm run test toxic_spikes`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- ~[ ] Have I tested the changes (manually)?~
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
