### PR TITLE
[P3] Fix mistimed sound effect when replacing a move

### DIFF
--- a/src/phases/learn-move-phase.ts
+++ b/src/phases/learn-move-phase.ts
@@ -170,13 +170,16 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
     pokemon.setMove(index, this.moveId);
     initMoveAnim(this.scene, this.moveId).then(() => {
       loadMoveAnimAssets(this.scene, [ this.moveId ], true);
-      this.scene.playSound("level_up_fanfare"); // Sound loaded into game as is
     });
     this.scene.ui.setMode(this.messageMode);
     const learnMoveText = i18next.t("battle:learnMove", { pokemonName: getPokemonNameWithAffix(pokemon), moveName: move.name });
-    textMessage = textMessage ? textMessage + "$" + learnMoveText : learnMoveText;
-    await this.scene.ui.showTextPromise(textMessage, this.messageMode === Mode.EVOLUTION_SCENE ? 1000 : undefined, true);
-    this.scene.triggerPokemonFormChange(pokemon, SpeciesFormChangeMoveLearnedTrigger, true);
-    this.end();
+    if (textMessage) {
+      await this.scene.ui.showTextPromise(textMessage);
+    }
+    this.scene.playSound("level_up_fanfare"); // Sound loaded into game as is
+    this.scene.ui.showText(learnMoveText, null, () => {
+      this.scene.triggerPokemonFormChange(pokemon, SpeciesFormChangeMoveLearnedTrigger, true);
+      this.end();
+    }, this.messageMode === Mode.EVOLUTION_SCENE ? 1000 : undefined, true);
   }
 }


### PR DESCRIPTION
## What are the changes the user will see?
Currently, the "fanfare" sound effect for learning a move incorrectly plays at the start of the message sequence when replacing a move instead of upon showing "{Pokemon} learned {Move}!". This fixes that.

## Why am I making these changes?
Fixing a bug introduced in #3672 .

## What are the changes from a developer perspective?
`phases/learn-move-phase` -- in `learnMove()`:
- Broke up the `showTextPromise` for the full message into 2 calls: 1 for the "pre-learn" messages (if applicable), and 1 for 
"{Pokemon} learned {Move}!"
- Moved the `level_up_fanfare` sound effect so that it plays between the split `showText` calls.

### Screenshots/Videos

https://github.com/user-attachments/assets/5b9416ee-fe4d-447b-96a1-170d1f10dfea

## How to test the changes?
1. Level up a Pokemon until they are prompted to replace a move with a new move.
2. Replace a move
3. The "fanfare" sound effect should play on "{Pokemon} learned {Move}!"

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
