### PR TITLE
[Misc] Shiny overrides can now force Pokemon to not be shiny

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3982,10 +3982,14 @@ export class PlayerPokemon extends Pokemon {
     if (Overrides.SHINY_OVERRIDE) {
       this.shiny = true;
       this.initShinySparkle();
-      if (Overrides.VARIANT_OVERRIDE) {
-        this.variant = Overrides.VARIANT_OVERRIDE;
-      }
+    } else if (Overrides.SHINY_OVERRIDE === false) {
+      this.shiny = false;
     }
+
+    if (Overrides.VARIANT_OVERRIDE !== null && this.shiny) {
+      this.variant = Overrides.VARIANT_OVERRIDE;
+    }
+
     if (!dataSource) {
       if (this.scene.gameMode.isDaily) {
         this.generateAndPopulateMoveset();
@@ -4474,10 +4478,13 @@ export class EnemyPokemon extends Pokemon {
       if (Overrides.OPP_SHINY_OVERRIDE) {
         this.shiny = true;
         this.initShinySparkle();
+      } else if (Overrides.OPP_SHINY_OVERRIDE === false) {
+        this.shiny = false;
       }
+
       if (this.shiny) {
         this.variant = this.generateVariant();
-        if (Overrides.OPP_VARIANT_OVERRIDE) {
+        if (Overrides.OPP_VARIANT_OVERRIDE !== null) {
           this.variant = Overrides.OPP_VARIANT_OVERRIDE;
         }
       }

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -113,8 +113,8 @@ class DefaultOverrides {
   readonly STATUS_OVERRIDE: StatusEffect = StatusEffect.NONE;
   readonly GENDER_OVERRIDE: Gender | null = null;
   readonly MOVESET_OVERRIDE: Moves | Array<Moves> = [];
-  readonly SHINY_OVERRIDE: boolean = false;
-  readonly VARIANT_OVERRIDE: Variant = 0;
+  readonly SHINY_OVERRIDE: boolean | null = null;
+  readonly VARIANT_OVERRIDE: Variant | null = null;
 
   // --------------------------
   // OPPONENT / ENEMY OVERRIDES
@@ -134,8 +134,8 @@ class DefaultOverrides {
   readonly OPP_STATUS_OVERRIDE: StatusEffect = StatusEffect.NONE;
   readonly OPP_GENDER_OVERRIDE: Gender | null = null;
   readonly OPP_MOVESET_OVERRIDE: Moves | Array<Moves> = [];
-  readonly OPP_SHINY_OVERRIDE: boolean = false;
-  readonly OPP_VARIANT_OVERRIDE: Variant = 0;
+  readonly OPP_SHINY_OVERRIDE: boolean | null = null;
+  readonly OPP_VARIANT_OVERRIDE: Variant | null = null;
   readonly OPP_IVS_OVERRIDE: number | number[] = [];
   readonly OPP_FORM_OVERRIDES: Partial<Record<Species, number>> = {};
   /**

--- a/src/test/utils/helpers/challengeModeHelper.ts
+++ b/src/test/utils/helpers/challengeModeHelper.ts
@@ -38,6 +38,10 @@ export class ChallengeModeHelper extends GameManagerHelper {
   async runToSummon(species?: Species[]) {
     await this.game.runToTitle();
 
+    if (this.game.override.disableShinies) {
+      this.game.override.shiny(false).enemyShiny(false);
+    }
+
     this.game.onNextPrompt("TitlePhase", Mode.TITLE, () => {
       this.game.scene.gameMode.challenges = this.challenges;
       const starters = generateStarter(this.game.scene, species);
@@ -47,7 +51,7 @@ export class ChallengeModeHelper extends GameManagerHelper {
     });
 
     await this.game.phaseInterceptor.run(EncounterPhase);
-    if (overrides.OPP_HELD_ITEMS_OVERRIDE.length === 0) {
+    if (overrides.OPP_HELD_ITEMS_OVERRIDE.length === 0 && this.game.override.removeEnemyStartingItems) {
       this.game.removeEnemyHeldItems();
     }
   }

--- a/src/test/utils/helpers/classicModeHelper.ts
+++ b/src/test/utils/helpers/classicModeHelper.ts
@@ -20,8 +20,12 @@ export class ClassicModeHelper extends GameManagerHelper {
    * @param species - Optional array of species to summon.
    * @returns A promise that resolves when the summon phase is reached.
    */
-  async runToSummon(species?: Species[]) {
+  async runToSummon(species?: Species[]): Promise<void> {
     await this.game.runToTitle();
+
+    if (this.game.override.disableShinies) {
+      this.game.override.shiny(false).enemyShiny(false);
+    }
 
     this.game.onNextPrompt("TitlePhase", Mode.TITLE, () => {
       this.game.scene.gameMode = getGameMode(GameModes.CLASSIC);
@@ -32,7 +36,7 @@ export class ClassicModeHelper extends GameManagerHelper {
     });
 
     await this.game.phaseInterceptor.run(EncounterPhase);
-    if (overrides.OPP_HELD_ITEMS_OVERRIDE.length === 0) {
+    if (overrides.OPP_HELD_ITEMS_OVERRIDE.length === 0 && this.game.override.removeEnemyStartingItems) {
       this.game.removeEnemyHeldItems();
     }
   }
@@ -42,7 +46,7 @@ export class ClassicModeHelper extends GameManagerHelper {
    * @param species - Optional array of species to start the battle with.
    * @returns A promise that resolves when the battle is started.
    */
-  async startBattle(species?: Species[]) {
+  async startBattle(species?: Species[]): Promise<void> {
     await this.runToSummon(species);
 
     if (this.game.scene.battleStyle === BattleStyle.SWITCH) {

--- a/src/test/utils/helpers/dailyModeHelper.ts
+++ b/src/test/utils/helpers/dailyModeHelper.ts
@@ -21,6 +21,10 @@ export class DailyModeHelper extends GameManagerHelper {
   async runToSummon() {
     await this.game.runToTitle();
 
+    if (this.game.override.disableShinies) {
+      this.game.override.shiny(false).enemyShiny(false);
+    }
+
     this.game.onNextPrompt("TitlePhase", Mode.TITLE, () => {
       const titlePhase = new TitlePhase(this.game.scene);
       titlePhase.initDailyRun();
@@ -33,7 +37,7 @@ export class DailyModeHelper extends GameManagerHelper {
 
     await this.game.phaseInterceptor.to(EncounterPhase);
 
-    if (overrides.OPP_HELD_ITEMS_OVERRIDE.length === 0) {
+    if (overrides.OPP_HELD_ITEMS_OVERRIDE.length === 0 && this.game.override.removeEnemyStartingItems) {
       this.game.removeEnemyHeldItems();
     }
   }

--- a/src/test/utils/helpers/overridesHelper.ts
+++ b/src/test/utils/helpers/overridesHelper.ts
@@ -19,6 +19,11 @@ import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
  * Helper to handle overrides in tests
  */
 export class OverridesHelper extends GameManagerHelper {
+  /** If `true`, removes the starting items from enemies at the start of each test; default `true` */
+  public removeEnemyStartingItems: boolean = true;
+  /** If `true`, sets the shiny overrides to disable shinies at the start of each test; default `true` */
+  public disableShinies: boolean = true;
+
   /**
    * Override the starting biome
    * @warning Any event listeners that are attached to [NewArenaEvent](events\battle-scene.ts) may need to be handled down the line
@@ -368,20 +373,47 @@ export class OverridesHelper extends GameManagerHelper {
 
   /**
    * Override player shininess
-   * @param shininess Whether the player's Pokemon should be shiny.
+   * @param shininess - `true` or `false` to force the player's pokemon to be shiny or not shiny,
+   *   `null` to disable the override and re-enable RNG shinies.
    */
-  shinyLevel(shininess: boolean): this {
+  shiny(shininess: boolean | null): this {
     vi.spyOn(Overrides, "SHINY_OVERRIDE", "get").mockReturnValue(shininess);
-    this.log(`Set player Pokemon as ${shininess ? "" : "not "}shiny!`);
+    if (shininess === null) {
+      this.log("Disabled player Pokemon shiny override!");
+    } else {
+      this.log(`Set player Pokemon to be ${shininess ? "" : "not "}shiny!`);
+    }
     return this;
   }
+
   /**
    * Override player shiny variant
-   * @param variant The player's shiny variant.
+   * @param variant - The player's shiny variant.
    */
-  variantLevel(variant: Variant): this {
+  shinyVariant(variant: Variant): this {
     vi.spyOn(Overrides, "VARIANT_OVERRIDE", "get").mockReturnValue(variant);
     this.log(`Set player Pokemon's shiny variant to ${variant}!`);
+    return this;
+  }
+
+  /**
+   * Override enemy shininess
+   * @param shininess - `true` or `false` to force the enemy's pokemon to be shiny or not shiny,
+   *   `null` to disable the override and re-enable RNG shinies.
+   * @param variant - (Optional) The enemy's shiny {@linkcode Variant}.
+   */
+  enemyShiny(shininess: boolean | null, variant?: Variant): this {
+    vi.spyOn(Overrides, "OPP_SHINY_OVERRIDE", "get").mockReturnValue(shininess);
+    if (shininess === null) {
+      this.log("Disabled enemy Pokemon shiny override!");
+    } else {
+      this.log(`Set enemy Pokemon to be ${shininess ? "" : "not "}shiny!`);
+    }
+
+    if (variant !== undefined) {
+      vi.spyOn(Overrides, "OPP_VARIANT_OVERRIDE", "get").mockReturnValue(variant);
+      this.log(`Set enemy shiny variant to be ${variant}!`);
+    }
     return this;
   }
 


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Random shinies could break certain tests. Also, the shiny override could only force Pokémon to be shiny, but not force them not to be shiny.

## What are the changes from a developer perspective?
The default values of the shiny overrides is now `null` instead of `false`, and setting them to `false` will force Pokémon to not be shiny. The variant overrides now also default to `null`, and will be able to specify the base variant (`0`) of the shiny.

## How to test the changes?
`npm run test`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
