### PR TITLE
[Bug Fix] Fix for Nightmare does not work properly

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -838,7 +838,7 @@ export class SeedTag extends BattlerTag {
 
 export class NightmareTag extends BattlerTag {
   constructor() {
-    super(BattlerTagType.NIGHTMARE, BattlerTagLapseType.AFTER_MOVE, 1, Moves.NIGHTMARE);
+    super(BattlerTagType.NIGHTMARE, BattlerTagLapseType.TURN_END, 1, Moves.NIGHTMARE);
   }
 
   onAdd(pokemon: Pokemon): void {

--- a/src/test/moves/nightmare.test.ts
+++ b/src/test/moves/nightmare.test.ts
@@ -1,0 +1,54 @@
+import { CommandPhase } from "#app/phases/command-phase";
+import { TurnInitPhase } from "#app/phases/turn-init-phase";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { StatusEffect } from "#app/data/status-effect";
+
+describe("Moves - Nightmare", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+
+    game.override.battleType("single")
+      .enemySpecies(Species.RATTATA)
+      .enemyMoveset(Moves.SPLASH)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyStatusEffect(StatusEffect.SLEEP)
+      .startingLevel(5)
+      .moveset([ Moves.NIGHTMARE, Moves.SPLASH ]);
+  });
+
+  it("lowers enemy hp by 1/4 each turn while asleep", async () => {
+    await game.classicMode.startBattle([ Species.HYPNO ]);
+
+    const enemyPokemon = game.scene.getEnemyPokemon()!;
+    const enemyMaxHP = enemyPokemon.hp;
+    game.move.select(Moves.NIGHTMARE);
+    await game.phaseInterceptor.to(TurnInitPhase);
+
+    expect(enemyPokemon.hp).toBe(enemyMaxHP - Math.floor(enemyMaxHP / 4));
+
+    // take a second turn to make sure damage occurs again
+    await game.phaseInterceptor.to(CommandPhase);
+    game.move.select(Moves.SPLASH);
+
+    await game.phaseInterceptor.to(TurnInitPhase);
+    expect(enemyPokemon.hp).toBe(enemyMaxHP - Math.floor(enemyMaxHP / 4) - Math.floor(enemyMaxHP / 4));
+  });
+});


### PR DESCRIPTION
Fix for  #4691 

## What are the changes the user will see?
Nightmare was just not working properly before and hitting the pokemon on improper turns and twice a turn. This fixes that.

## Why am I making these changes?
big fix

## What are the changes from a developer perspective?
Changed battler tag for nightmare from working after the move to the end of the turn. 

### Screenshots/Videos

Just when asleep
https://github.com/user-attachments/assets/e9038948-d6ec-4c1b-aa61-8cb36a768965


It works properly when pokemon wakes up and is put back to sleep
https://github.com/user-attachments/assets/60ab9bf9-dbe8-4657-8102-05cee8a0cfdf



## How to test the changes?
override files, and new nightmare unit test

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
