### PR TITLE
[Move implementation] Fully implementing forests curse and trick or treat

### DIFF
--- a/src/test/moves/forests_curse.test.ts
+++ b/src/test/moves/forests_curse.test.ts
@@ -1,0 +1,87 @@
+import { BattlerIndex } from "#app/battle";
+import { Type } from "#app/data/type";
+import { Moves } from "#app/enums/moves";
+import { Species } from "#app/enums/species";
+import { TurnEndPhase } from "#app/phases/turn-end-phase";
+import GameManager from "#test/utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
+
+
+describe("Moves - Forest's Curse", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override.battleType("single");
+    game.override.enemySpecies(Species.RELICANTH);
+    game.override.startingLevel(5);
+    game.override.enemyLevel(100);
+    game.override.enemyMoveset(Moves.FORESTS_CURSE);
+    game.override.moveset([ Moves.SPLASH, Moves.BURN_UP, Moves.DOUBLE_SHOCK ]);
+  });
+  test(
+    "a mono type afflicted with forest's curse should be its type + grass (2 types)",
+    async () => {
+      await game.classicMode.startBattle([ Species.RATTATA ]);
+      const playerPokemon = game.scene.getPlayerPokemon()!;
+      game.move.select(Moves.SPLASH);
+      await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.ENEMY ]);
+      await game.phaseInterceptor.to(TurnEndPhase);
+
+      // Should be normal/grass
+      const playerPokemonTypes = playerPokemon.getTypes();
+      expect(playerPokemonTypes.filter(type => type === Type.NORMAL)).toHaveLength(1);
+      expect(playerPokemonTypes.filter(type => type === Type.GRASS)).toHaveLength(1);
+      expect(playerPokemonTypes.length === 2).toBeTruthy();
+    }
+  );
+
+  test(
+    "a dual type afflicted with forest's curse should be its dual type + grass (3 types)",
+    async () => {
+      await game.classicMode.startBattle([ Species.MOLTRES ]);
+      const playerPokemon = game.scene.getPlayerPokemon()!;
+      game.move.select(Moves.SPLASH);
+      await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.ENEMY ]);
+      await game.phaseInterceptor.to(TurnEndPhase);
+
+      // Should be flying/fire/grass
+      const playerPokemonTypes = playerPokemon.getTypes();
+      expect(playerPokemonTypes.filter(type => type === Type.FLYING)).toHaveLength(1);
+      expect(playerPokemonTypes.filter(type => type === Type.FIRE)).toHaveLength(1);
+      expect(playerPokemonTypes.filter(type => type === Type.GRASS)).toHaveLength(1);
+      expect(playerPokemonTypes.length === 3).toBeTruthy();
+
+    }
+  );
+
+  test(
+    "A fire/flying type that uses burn up, then has forest's curse applied should be flying/grass",
+    async () => {
+      await game.classicMode.startBattle([ Species.MOLTRES ]);
+      const playerPokemon = game.scene.getPlayerPokemon()!;
+      game.move.select(Moves.BURN_UP);
+      await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.ENEMY ]);
+      await game.phaseInterceptor.to(TurnEndPhase);
+
+      // Should be flying/grass
+      const playerPokemonTypes = playerPokemon.getTypes();
+      expect(playerPokemonTypes.filter(type => type === Type.FLYING)).toHaveLength(1);
+      expect(playerPokemonTypes.filter(type => type === Type.FIRE)).toHaveLength(0);
+      expect(playerPokemonTypes.filter(type => type === Type.GRASS)).toHaveLength(1);
+      expect(playerPokemonTypes.length === 2).toBeTruthy();
+    }
+  );
+});


### PR DESCRIPTION
## What are the changes the user will see?
Trick or treat and forests curse should now consistently properly interact with one another and with burn up/dual shock

## Why am I making these changes?
fully implement the moves

## What are the changes from a developer perspective?
Added a check in AddTypeAttr for cases related to these two moves

### Screenshots/Videos

https://github.com/user-attachments/assets/558d9f12-7453-41a8-a310-82b9450ab6f8

https://github.com/user-attachments/assets/f2b57734-635f-42f2-b604-9269909a094a

## How to test the changes?
Override file, and new forests curse file

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
