### PR TITLE
[P2] Fix binding, etc. not being removed when switching with Baton Pass

### DIFF
--- a/src/phases/switch-summon-phase.ts
+++ b/src/phases/switch-summon-phase.ts
@@ -65,8 +65,9 @@ export class SwitchSummonPhase extends SummonPhase {
 
     const pokemon = this.getPokemon();
 
+    (this.player ? this.scene.getEnemyField() : this.scene.getPlayerField()).forEach(enemyPokemon => enemyPokemon.removeTagsBySourceId(pokemon.id));
+
     if (this.switchType === SwitchType.SWITCH) {
-      (this.player ? this.scene.getEnemyField() : this.scene.getPlayerField()).forEach(enemyPokemon => enemyPokemon.removeTagsBySourceId(pokemon.id));
       const substitute = pokemon.getTag(SubstituteTag);
       if (substitute) {
         this.scene.tweens.add({

--- a/src/test/moves/baton_pass.test.ts
+++ b/src/test/moves/baton_pass.test.ts
@@ -34,7 +34,7 @@ describe("Moves - Baton Pass", () => {
       .disableCrits();
   });
 
-  it("transfers all stat stages when player uses it", async() => {
+  it("transfers all stat stages when player uses it", async () => {
     // arrange
     await game.classicMode.startBattle([ Species.RAICHU, Species.SHUCKLE ]);
 
@@ -91,7 +91,7 @@ describe("Moves - Baton Pass", () => {
     ]);
   }, 20000);
 
-  it("doesn't transfer effects that aren't transferrable", async() => {
+  it("doesn't transfer effects that aren't transferrable", async () => {
     game.override.enemyMoveset([ Moves.SALT_CURE ]);
     await game.classicMode.startBattle([ Species.PIKACHU, Species.FEEBAS ]);
 
@@ -106,4 +106,28 @@ describe("Moves - Baton Pass", () => {
 
     expect(player2.findTag((t) => t.tagType === BattlerTagType.SALT_CURED)).toBeUndefined();
   }, 20000);
+
+  it("doesn't allow binding effects from the user to persist", async () => {
+    game.override.moveset([ Moves.FIRE_SPIN, Moves.BATON_PASS ]);
+
+    await game.classicMode.startBattle([ Species.MAGIKARP, Species.FEEBAS ]);
+
+    const enemy = game.scene.getEnemyPokemon()!;
+
+    game.move.select(Moves.FIRE_SPIN);
+    await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.ENEMY ]);
+    await game.move.forceHit();
+
+    await game.toNextTurn();
+
+    expect(enemy.getTag(BattlerTagType.FIRE_SPIN)).toBeDefined();
+
+    game.move.select(Moves.BATON_PASS);
+    await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.ENEMY ]);
+
+    game.doSelectPartyPokemon(1);
+    await game.toNextTurn();
+
+    expect(enemy.getTag(BattlerTagType.FIRE_SPIN)).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## What are the changes the user will see?
This fixes an issue where binding effects (e.g. Bind, Sand Tomb) and other volatile effects would persist after the source used Baton Pass or Shed Tail to switch out.

## Why am I making these changes?
This was discussed [in the Discord](https://discord.com/channels/1125469663833370665/1125894949020381285/1298525704723369984). I assumed this interaction was correct when implementing Shed Tail 🤷‍♂️ 

## What are the changes from a developer perspective?
`phases/switch-summon-phase`: The code to remove tags from enemies with the returning Pokemon as the source no longer only runs for the `SWITCH` switch type.

### Screenshots/Videos


## How to test the changes?
`npm run test baton_pass` (1 new test)

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [?] Are the changes visual?
  - [?] Have I provided screenshots/videos of the changes?
