### PR TITLE
[P2][AI] Fix Enemy AI targeting their allies with Status Effect Moves

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2177,7 +2177,10 @@ export class StatusEffectAttr extends MoveEffectAttr {
 
   getTargetBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
     const moveChance = this.getMoveChance(user, target, move, this.selfTarget, false);
-    return !(this.selfTarget ? user : target).status && (this.selfTarget ? user : target).canSetStatus(this.effect, true, false, user) ? Math.floor(moveChance * -0.1) : 0;
+    const score = (moveChance < 0) ? -10 : Math.floor(moveChance * -0.1);
+    const pokemon = this.selfTarget ? user : target;
+
+    return !pokemon.status && pokemon.canSetStatus(this.effect, true, false, user) ? score : 0;
   }
 }
 
@@ -2197,7 +2200,10 @@ export class MultiStatusEffectAttr extends StatusEffectAttr {
 
   getTargetBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
     const moveChance = this.getMoveChance(user, target, move, this.selfTarget, false);
-    return !(this.selfTarget ? user : target).status && (this.selfTarget ? user : target).canSetStatus(this.effect, true, false, user) ? Math.floor(moveChance * -0.1) : 0;
+    const score = (moveChance < 0) ? -10 : Math.floor(moveChance * -0.1);
+    const pokemon = this.selfTarget ? user : target;
+
+    return !pokemon.status && pokemon.canSetStatus(this.effect, true, false, user) ? score : 0;
   }
 }
 
@@ -2228,7 +2234,7 @@ export class PsychoShiftEffectAttr extends MoveEffectAttr {
   }
 
   getTargetBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
-    return !(this.selfTarget ? user : target).status && (this.selfTarget ? user : target).canSetStatus(user.status?.effect, true, false, user) ? Math.floor(move.chance * -0.1) : 0;
+    return !target.status && target.canSetStatus(user.status?.effect, true, false, user) ? -10 : 0;
   }
 }
 /**


### PR DESCRIPTION
## What are the changes the user will see?
The Enemy AI should no longer favor their allies as targets when using status moves that apply status effects, e.g. Thunder Wave or Sleep Powder

## Why am I making these changes?
A small bug fix to tide shareholders over before the AI gets reworked

## What are the changes from a developer perspective?
`data/move`: Adjusted scoring functions for `StatusEffectAttr` and related attributes so that negative effect chance values (internally used for guaranteed effects) are interpreted in the same way as a 100% effect chance value.

### Screenshots/Videos
N/A

## How to test the changes?
1. Use overrides to force double battles and give enemies various status effect moves
2. The enemies should never target each other with said status effect moves

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [n/a] Are the changes visual?
  - [n/a] Have I provided screenshots/videos of the changes?
