### PR TITLE
[Bug] Chloroblast & Struggle should not recoil if the move failed

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1421,7 +1421,7 @@ export class RecoilAttr extends MoveEffectAttr {
     }
 
     // Chloroblast and Struggle should not deal recoil damage if the move was not successful
-    if (this.useHp && [ MoveResult.FAIL, MoveResult.MISS ].includes(user.getLastXMoves(1)[0].result)) {
+    if (this.useHp && [ MoveResult.FAIL, MoveResult.MISS ].includes(user.getLastXMoves(1)[0]?.result)) {
       return false;
     }
 

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1420,6 +1420,11 @@ export class RecoilAttr extends MoveEffectAttr {
       return false;
     }
 
+    // Chloroblast and Struggle should not deal recoil damage if the move was not successful
+    if (this.useHp && [ MoveResult.FAIL, MoveResult.MISS ].includes(user.getLastXMoves(1)[0].result)) {
+      return false;
+    }
+
     const damageValue = (!this.useHp ? user.turnData.damageDealt : user.getMaxHp()) * this.damageRatio;
     const minValue = user.turnData.damageDealt ? 1 : 0;
     const recoilDamage = Utils.toDmgValue(damageValue, minValue);

--- a/src/test/moves/chloroblast.test.ts
+++ b/src/test/moves/chloroblast.test.ts
@@ -1,0 +1,42 @@
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Moves - Chloroblast", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([ Moves.CHLOROBLAST ])
+      .ability(Abilities.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.PROTECT);
+  });
+
+  it("should not deal recoil damage if the opponent uses protect", async () => {
+    await game.classicMode.startBattle([ Species.FEEBAS ]);
+
+    game.move.select(Moves.CHLOROBLAST);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(game.scene.getPlayerPokemon()!.isFullHp()).toBe(true);
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?
Chloroblast and Struggle won't deal recoil damage if the move fails due to miss or Protect.

## Why am I making these changes?
The behavior is incorrect.
> **If this move is successful**, the user loses 1/2 of its maximum HP, rounded up, unless the user has the Magic Guard Ability.
- https://www.smogon.com/dex/sv/moves/chloroblast/

## What are the changes from a developer perspective?
Added a check for if the move failed or missed and is a move whose recoil is based on the user's HP and not on the move's damage in `RecoilAttr`.

## How to test the changes?
`npm run test chloroblast`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
