### PR TITLE
[Beta] Stop Transform giving copied moves negative fractional `ppUp`

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2455,9 +2455,8 @@ export class PostSummonTransformAbAttr extends PostSummonAbAttr {
 
     pokemon.summonData.moveset = target.getMoveset().map(m => {
       const pp = m?.getMove().pp ?? 0;
-      // if PP value is less than 5, do nothing. If greater, we need to reduce the value to 5 using a negative ppUp value.
-      const ppUp = pp <= 5 ? 0 : (5 - pp) / Math.max(Math.floor(pp / 5), 1);
-      return new PokemonMove(m?.moveId ?? Moves.NONE, 0, ppUp);
+      // If PP value is less than 5, do nothing. If greater, we need to reduce the value to 5.
+      return new PokemonMove(m?.moveId!, 0, 0, false, Math.min(pp, 5));
     });
     pokemon.summonData.types = target.getTypes();
     promises.push(pokemon.updateInfo());

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6670,9 +6670,8 @@ export class TransformAttr extends MoveEffectAttr {
 
     user.summonData.moveset = target.getMoveset().map(m => {
       const pp = m?.getMove().pp ?? 0;
-      // if PP value is less than 5, do nothing. If greater, we need to reduce the value to 5 using a negative ppUp value.
-      const ppUp = pp <= 5 ? 0 : (5 - pp) / Math.max(Math.floor(pp / 5), 1);
-      return new PokemonMove(m?.moveId!, 0, ppUp);
+      // If PP value is less than 5, do nothing. If greater, we need to reduce the value to 5.
+      return new PokemonMove(m?.moveId!, 0, 0, false, Math.min(pp, 5));
     });
     user.summonData.types = target.getTypes();
     promises.push(user.updateInfo());

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4453,7 +4453,7 @@ export class PlayerPokemon extends Pokemon {
   copyMoveset(): PokemonMove[] {
     const newMoveset : PokemonMove[] = [];
     this.moveset.forEach(move =>
-      newMoveset.push(new PokemonMove(move!.moveId, 0, move!.ppUp, move!.virtual))); // TODO: are those bangs correct?
+      newMoveset.push(new PokemonMove(move!.moveId, 0, move!.ppUp, move!.virtual, move!.maxPpOverride))); // TODO: are those bangs correct?
 
     return newMoveset;
   }
@@ -5180,15 +5180,22 @@ export interface DamageCalculationResult {
  **/
 export class PokemonMove {
   public moveId: Moves;
-  public ppUsed: integer;
-  public ppUp: integer;
+  public ppUsed: number;
+  public ppUp: number;
   public virtual: boolean;
 
-  constructor(moveId: Moves, ppUsed?: integer, ppUp?: integer, virtual?: boolean) {
+  /**
+   * If defined and nonzero, overrides the maximum PP of the move (e.g., due to move being copied by Transform).
+   * This also nullifies all effects of `ppUp`.
+   */
+  public maxPpOverride?: number;
+
+  constructor(moveId: Moves, ppUsed?: number, ppUp?: number, virtual?: boolean, maxPpOverride?: number) {
     this.moveId = moveId;
     this.ppUsed = ppUsed || 0;
     this.ppUp = ppUp || 0;
     this.virtual = !!virtual;
+    this.maxPpOverride = maxPpOverride;
   }
 
   /**
@@ -5225,7 +5232,7 @@ export class PokemonMove {
   }
 
   getMovePp(): integer {
-    return this.getMove().pp + this.ppUp * Utils.toDmgValue(this.getMove().pp / 5);
+    return this.maxPpOverride || (this.getMove().pp + this.ppUp * Utils.toDmgValue(this.getMove().pp / 5));
   }
 
   getPpRatio(): number {
@@ -5242,6 +5249,6 @@ export class PokemonMove {
   * @return {PokemonMove} A valid pokemonmove object
   */
   static loadMove(source: PokemonMove | any): PokemonMove {
-    return new PokemonMove(source.moveId, source.ppUsed, source.ppUp, source.virtual);
+    return new PokemonMove(source.moveId, source.ppUsed, source.ppUp, source.virtual, source.maxPpOverride);
   }
 }

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -384,7 +384,7 @@ export class PokemonPpUpModifierType extends PokemonMoveModifierType {
       (_pokemon: PlayerPokemon) => {
         return null;
       }, (pokemonMove: PokemonMove) => {
-        if (pokemonMove.getMove().pp < 5 || pokemonMove.ppUp >= 3) {
+        if (pokemonMove.getMove().pp < 5 || pokemonMove.ppUp >= 3 || pokemonMove.maxPpOverride) {
           return PartyUiHandler.NoEffectMessage;
         }
         return null;

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -2166,7 +2166,7 @@ export class PokemonPpUpModifier extends ConsumablePokemonMoveModifier {
   override apply(playerPokemon: PlayerPokemon): boolean {
     const move = playerPokemon.getMoveset()[this.moveIndex];
 
-    if (move) {
+    if (move && !move.maxPpOverride) {
       move.ppUp = Math.min(move.ppUp + this.upPoints, 3);
     }
 

--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -135,7 +135,7 @@ export default class PokemonData {
         }
       }
     } else {
-      this.moveset = (source.moveset || [ new PokemonMove(Moves.TACKLE), new PokemonMove(Moves.GROWL) ]).filter(m => m).map((m: any) => new PokemonMove(m.moveId, m.ppUsed, m.ppUp));
+      this.moveset = (source.moveset || [ new PokemonMove(Moves.TACKLE), new PokemonMove(Moves.GROWL) ]).filter(m => m).map((m: any) => new PokemonMove(m.moveId, m.ppUsed, m.ppUp, m.virtual, m.maxPpOverride));
       if (!forHistory) {
         this.status = source.status
           ? new Status(source.status.effect, source.status.toxicTurnCount, source.status.sleepTurnsRemaining)

--- a/src/test/abilities/imposter.test.ts
+++ b/src/test/abilities/imposter.test.ts
@@ -60,18 +60,19 @@ describe("Abilities - Imposter", () => {
     const playerMoveset = player.getMoveset();
     const enemyMoveset = player.getMoveset();
 
+    expect(playerMoveset.length).toBe(enemyMoveset.length);
     for (let i = 0; i < playerMoveset.length && i < enemyMoveset.length; i++) {
-      // TODO: Checks for 5 PP should be done here when that gets addressed
       expect(playerMoveset[i]?.moveId).toBe(enemyMoveset[i]?.moveId);
     }
 
     const playerTypes = player.getTypes();
     const enemyTypes = enemy.getTypes();
 
+    expect(playerTypes.length).toBe(enemyTypes.length);
     for (let i = 0; i < playerTypes.length && i < enemyTypes.length; i++) {
       expect(playerTypes[i]).toBe(enemyTypes[i]);
     }
-  }, 20000);
+  });
 
   it("should copy in-battle overridden stats", async () => {
     game.override.enemyMoveset([ Moves.POWER_SPLIT ]);
@@ -104,7 +105,15 @@ describe("Abilities - Imposter", () => {
     await game.phaseInterceptor.to(TurnEndPhase);
 
     player.getMoveset().forEach(move => {
-      expect(move!.getMovePp()).toBeLessThanOrEqual(5);
+      // Should set correct maximum PP without touching `ppUp`
+      if (move) {
+        if (move.moveId === Moves.SKETCH) {
+          expect(move.getMovePp()).toBe(1);
+        } else {
+          expect(move.getMovePp()).toBe(5);
+        }
+        expect(move.ppUp).toBe(0);
+      }
     });
   });
 });

--- a/src/test/moves/transform.test.ts
+++ b/src/test/moves/transform.test.ts
@@ -60,18 +60,19 @@ describe("Moves - Transform", () => {
     const playerMoveset = player.getMoveset();
     const enemyMoveset = player.getMoveset();
 
+    expect(playerMoveset.length).toBe(enemyMoveset.length);
     for (let i = 0; i < playerMoveset.length && i < enemyMoveset.length; i++) {
-      // TODO: Checks for 5 PP should be done here when that gets addressed
       expect(playerMoveset[i]?.moveId).toBe(enemyMoveset[i]?.moveId);
     }
 
     const playerTypes = player.getTypes();
     const enemyTypes = enemy.getTypes();
 
+    expect(playerTypes.length).toBe(enemyTypes.length);
     for (let i = 0; i < playerTypes.length && i < enemyTypes.length; i++) {
       expect(playerTypes[i]).toBe(enemyTypes[i]);
     }
-  }, 20000);
+  });
 
   it("should copy in-battle overridden stats", async () => {
     game.override.enemyMoveset([ Moves.POWER_SPLIT ]);
@@ -94,7 +95,7 @@ describe("Moves - Transform", () => {
     expect(enemy.getStat(Stat.SPATK, false)).toBe(avgSpAtk);
   });
 
-  it ("should set each move's pp to a maximum of 5", async () => {
+  it("should set each move's pp to a maximum of 5", async () => {
     game.override.enemyMoveset([ Moves.SWORDS_DANCE, Moves.GROWL, Moves.SKETCH, Moves.RECOVER ]);
 
     await game.classicMode.startBattle([ Species.DITTO ]);
@@ -104,7 +105,15 @@ describe("Moves - Transform", () => {
     await game.phaseInterceptor.to(TurnEndPhase);
 
     player.getMoveset().forEach(move => {
-      expect(move!.getMovePp()).toBeLessThanOrEqual(5);
+      // Should set correct maximum PP without touching `ppUp`
+      if (move) {
+        if (move.moveId === Moves.SKETCH) {
+          expect(move.getMovePp()).toBe(1);
+        } else {
+          expect(move.getMovePp()).toBe(5);
+        }
+        expect(move.ppUp).toBe(0);
+      }
     });
   });
 });


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
None, hopefully.

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
PR #3462 makes Transform/Imposter set copied moves to 5 maximum PP by assigning a negative `ppUp` value that can be fractional. In case a negative fractional `ppUp` would break something, this PR replaces the `ppUp` method with a new `PokemonMove.maxPpOverride` property.

NOT CHANGED: The final boss's Recover still uses -4 ppUp (did not want to risk breaking it).

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
1. Added `maxPpOverride` property to `PokemonMove`.
2. Updated tests to check that Transform/Imposter does not set a negative fractional `ppUp`.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

<details>
  <summary>After the changes: Transform sets correct max PP</summary>

https://github.com/user-attachments/assets/63441d3b-cb3d-42e9-b6cd-7cdcfed99c5d

</details>
<details>
  <summary>After the changes: Imposter sets correct max PP</summary>

https://github.com/user-attachments/assets/5e252346-3059-42ed-9051-39e7a16d5145

</details>

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
`npm run test [transform|imposter]`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~~[ ] Are the changes visual?~~
  - [x] Have I provided screenshots/videos of the changes?
