### PR TITLE
[Hotfix] Fix status damage triggering before berry usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pokemon-rogue-battle",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pokemon-rogue-battle",
-			"version": "1.1.0",
+			"version": "1.1.1",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@material/material-color-utilities": "^0.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pokemon-rogue-battle",
 	"private": true,
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"type": "module",
 	"scripts": {
 		"start": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pokemon-rogue-battle",
 	"private": true,
-	"version": "1.1.1",
+	"version": "1.1.0",
 	"type": "module",
 	"scripts": {
 		"start": "vite",

--- a/src/phases/turn-start-phase.ts
+++ b/src/phases/turn-start-phase.ts
@@ -205,11 +205,11 @@ export class TurnStartPhase extends FieldPhase {
     }
 
     this.scene.pushPhase(new WeatherEffectPhase(this.scene));
+    this.scene.pushPhase(new BerryPhase(this.scene));
 
     /** Add a new phase to check who should be taking status damage */
     this.scene.pushPhase(new CheckStatusEffectPhase(this.scene, moveOrder));
 
-    this.scene.pushPhase(new BerryPhase(this.scene));
     this.scene.pushPhase(new TurnEndPhase(this.scene));
 
     /**


### PR DESCRIPTION
## What are the changes the user will see?
Lum Berry should now proc before status damage is taken into account.

## Why am I making these changes?
Reported [in the Discord](https://discord.com/channels/1125469663833370665/1125894949020381285/1299859893322256474)

## What are the changes from a developer perspective?
`turn-start-phase`: Swapped the push-order of `BerryPhase` and `CheckStatusEffectPhase`

### Screenshots/Videos

## How to test the changes?
- In `overrides`, give your Pokemon Poison and a Lum Berry
- At the end of the first turn, the Lum Berry should be consumed before Poison damage has a chance to trigger.

## Checklist
- [n/a] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
