### PR TITLE
[UI][QoL] Target Selection Defaults to Left-Most Enemy Pokemon in Doubles

### DIFF
--- a/src/ui/target-select-ui-handler.ts
+++ b/src/ui/target-select-ui-handler.ts
@@ -184,6 +184,7 @@ export default class TargetSelectUiHandler extends UiHandler {
   }
 
   clear() {
+    this.cursor = -1;
     super.clear();
     this.eraseCursor();
   }


### PR DESCRIPTION
## What are the changes the user will see?
During Doubles, the second Pokemon's target will not default to the first Pokemon's target. This will prevent the accidental knockout of allied Pokemon + bring PokeRogue in line with mainline behavior.

## Why am I making these changes?
Who hasn't knocked out their only ally in a double because of this?

## What are the changes from a developer perspective?
this.cursor set to -1 upon ui clear()

### Screenshots/Videos

https://github.com/user-attachments/assets/d1c464f2-40f8-4e37-8b60-437b7f467410



## How to test the changes?
In a doubles battle, the first player pokemon should target an ally. When the second Pokemon chooses a move, the target UI cursor should be on the left-most enemy Pokemon.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
