### PR TITLE
[Hotfix] Fix manifest getting loaded before the game is initialized

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pokemon-rogue-battle",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pokemon-rogue-battle",
-			"version": "1.1.2",
+			"version": "1.1.3",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@material/material-color-utilities": "^0.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pokemon-rogue-battle",
 	"private": true,
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"type": "module",
 	"scripts": {
 		"start": "vite",

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,7 @@ document.fonts.load("16px emerald").then(() => document.fonts.load("10px pkmnems
 
 let game;
 
-const startGame = async () => {
+const startGame = async (manifest?: any) => {
   await initI18n();
   const LoadingScene = (await import("./loading-scene")).LoadingScene;
   const BattleScene = (await import("./battle-scene")).default;
@@ -94,16 +94,18 @@ const startGame = async () => {
     version: version
   });
   game.sound.pauseOnBlur = false;
+  if (manifest) {
+    game["manifest"] = manifest;
+  }
 };
 
 fetch("/manifest.json")
   .then(res => res.json())
   .then(jsonResponse => {
-    startGame();
-    game["manifest"] = jsonResponse.manifest;
+    startGame(jsonResponse.manifest);
   }).catch(() => {
     // Manifest not found (likely local build)
-    // startGame();
+    startGame();
   });
 
 export default game;

--- a/src/main.ts
+++ b/src/main.ts
@@ -99,16 +99,13 @@ const startGame = async (manifest?: any) => {
   }
 };
 
-let manifest: any;
 fetch("/manifest.json")
   .then(res => res.json())
   .then(jsonResponse => {
-    manifest = jsonResponse.manifest;
-  }).catch(err => {
-    // Manifest not found (likely local build or error path on live)
-    console.log(`Manifest not found. ${err}`);
-  }).finally(() => {
-    startGame(manifest);
+    startGame(jsonResponse.manifest);
+  }).catch(() => {
+    // Manifest not found (likely local build)
+    startGame();
   });
 
 export default game;

--- a/src/main.ts
+++ b/src/main.ts
@@ -99,13 +99,16 @@ const startGame = async (manifest?: any) => {
   }
 };
 
+let manifest: any;
 fetch("/manifest.json")
   .then(res => res.json())
   .then(jsonResponse => {
-    startGame(jsonResponse.manifest);
-  }).catch(() => {
-    // Manifest not found (likely local build)
-    startGame();
+    manifest = jsonResponse.manifest;
+  }).catch(err => {
+    // Manifest not found (likely local build or error path on live)
+    console.log(`Manifest not found. ${err}`);
+  }).finally(() => {
+    startGame(manifest);
   });
 
 export default game;

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -164,7 +164,7 @@ export async function initI18n(): Promise<void> {
         } else {
           fileName = camelCaseToKebabCase(ns);
         }
-        return `/locales/${lng}/${fileName}.json?v=${pkg.version}`;
+        return `./locales/${lng}/${fileName}.json?v=${pkg.version}`;
       },
     },
     defaultNS: "menu",


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
Live: if all goes well nothing. If all goes amazing lingering caching/sprite issues could get solved
Offline/local play should work again (potentially needs changes from #4735 to handle locale stuff automatically for non devs)
<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?
PR #4327 made the `startGame` function async, which makes the manifest initialization fail. Causing the game to fallback to a catch statement that launches the game a second time
(we failed to notice this because only live has a manifest)
A temporary hotfix was pushed (commit a9a73863e89caf979f28c4e97be61ff160a0116a), but it breaks offline and local play
This PR should fix the problem for good

<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What are the changes from a developer perspective?
- Put the manifest as an optional parameter of the startGame() function (thank you flx)
- only call startGame() from the `finally` of the manifest fetch request, so that it can only ever be called once no matter what (thank you podarsmarty)

<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos
Before: double game (don't mind my computer dying and not managing to load the second instance lol)
![Screenshot 2024-10-27 at 16-47-38 PokéRogue](https://github.com/user-attachments/assets/cffc5cf2-1a6a-4c19-b417-c0f217302209)


After: single game, with or without manifest
![Screenshot 2024-10-27 at 16-49-59 PokéRogue](https://github.com/user-attachments/assets/22c1505d-96e4-499b-8a61-b70ce9efb979)



<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
- Launch the game as normal. It should start properly
- Add a `manifest.json` file with "{}" content in the root folder of the project
- Launch the game. There should only be one game

<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [X] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
