### PR TITLE
[Sprite] Hotfix cut off Binacle sprite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pokemon-rogue-battle",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pokemon-rogue-battle",
-			"version": "1.1.3",
+			"version": "1.1.4",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@material/material-color-utilities": "^0.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pokemon-rogue-battle",
 	"private": true,
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"type": "module",
 	"scripts": {
 		"start": "vite",

--- a/public/images/pokemon/688.json
+++ b/public/images/pokemon/688.json
@@ -1,19 +1,18 @@
 { "frames": [
    {
     "filename": "0001.png",
-    "frame": { "x": 0, "y": 0, "w": 59, "h": 63 },
+    "frame": { "x": 0, "y": 0, "w": 64, "h": 63 },
     "rotated": false,
-    "trimmed": true,
-    "spriteSourceSize": { "x": 4, "y": 0, "w": 59, "h": 63 },
-    "sourceSize": { "w": 69, "h": 63 }
+    "trimmed": false,
+    "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 63 },
+    "sourceSize": { "w": 64, "h": 63 },
    }
  ],
  "meta": {
   "app": "https://www.aseprite.org/",
-  "version": "1.3.7-dev",
-  "image": "688.png",
+  "version": "1.3.7-x64",
   "format": "I8",
-  "size": { "w": 59, "h": 63 },
+  "size": { "w": 64, "h": 63 },
   "scale": "1"
  }
 }

--- a/public/images/pokemon/688.json
+++ b/public/images/pokemon/688.json
@@ -5,7 +5,7 @@
     "rotated": false,
     "trimmed": false,
     "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 63 },
-    "sourceSize": { "w": 64, "h": 63 },
+    "sourceSize": { "w": 64, "h": 63 }
    }
  ],
  "meta": {

--- a/public/images/pokemon/688.json
+++ b/public/images/pokemon/688.json
@@ -1,19 +1,19 @@
 { "frames": [
    {
     "filename": "0001.png",
-    "frame": { "x": 0, "y": 0, "w": 64, "h": 63 },
+    "frame": { "x": 0, "y": 0, "w": 59, "h": 63 },
     "rotated": false,
-    "trimmed": false,
-    "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 63 },
-    "sourceSize": { "w": 64, "h": 63 },
-    "duration": 100
+    "trimmed": true,
+    "spriteSourceSize": { "x": 4, "y": 0, "w": 59, "h": 63 },
+    "sourceSize": { "w": 69, "h": 63 }
    }
  ],
  "meta": {
   "app": "https://www.aseprite.org/",
-  "version": "1.3.7-x64",
+  "version": "1.3.7-dev",
+  "image": "688.png",
   "format": "I8",
-  "size": { "w": 64, "h": 63 },
+  "size": { "w": 59, "h": 63 },
   "scale": "1"
  }
 }

--- a/public/images/pokemon/back/688.json
+++ b/public/images/pokemon/back/688.json
@@ -1,41 +1,19 @@
-{
-	"textures": [
-		{
-			"image": "688.png",
-			"format": "RGBA8888",
-			"size": {
-				"w": 52,
-				"h": 52
-			},
-			"scale": 1,
-			"frames": [
-				{
-					"filename": "0001.png",
-					"rotated": false,
-					"trimmed": false,
-					"sourceSize": {
-						"w": 41,
-						"h": 52
-					},
-					"spriteSourceSize": {
-						"x": 0,
-						"y": 0,
-						"w": 41,
-						"h": 52
-					},
-					"frame": {
-						"x": 0,
-						"y": 0,
-						"w": 41,
-						"h": 52
-					}
-				}
-			]
-		}
-	],
-	"meta": {
-		"app": "https://www.codeandweb.com/texturepacker",
-		"version": "3.0",
-		"smartupdate": "$TexturePacker:SmartUpdate:ea462f2b1b46327e3b8fcb7ec5e44f08:2d2598cc03dec73182dbea237ad83b34:176060351d0044923af938ba7932a6ef$"
-	}
+{ "frames": [
+   {
+    "filename": "0001.png",
+    "frame": { "x": 0, "y": 0, "w": 51, "h": 65 },
+    "rotated": false,
+    "trimmed": false,
+    "spriteSourceSize": { "x": 0, "y": 0, "w": 51, "h": 65 },
+    "sourceSize": { "w": 51, "h": 65 }
+   }
+ ],
+ "meta": {
+  "app": "https://www.aseprite.org/",
+  "version": "1.3.7-dev",
+  "image": "688.png",
+  "format": "I8",
+  "size": { "w": 51, "h": 65 },
+  "scale": "1"
+ }
 }

--- a/public/images/pokemon/back/shiny/688.json
+++ b/public/images/pokemon/back/shiny/688.json
@@ -1,41 +1,19 @@
-{
-	"textures": [
-		{
-			"image": "688.png",
-			"format": "RGBA8888",
-			"size": {
-				"w": 52,
-				"h": 52
-			},
-			"scale": 1,
-			"frames": [
-				{
-					"filename": "0001.png",
-					"rotated": false,
-					"trimmed": false,
-					"sourceSize": {
-						"w": 41,
-						"h": 52
-					},
-					"spriteSourceSize": {
-						"x": 0,
-						"y": 0,
-						"w": 41,
-						"h": 52
-					},
-					"frame": {
-						"x": 0,
-						"y": 0,
-						"w": 41,
-						"h": 52
-					}
-				}
-			]
-		}
-	],
-	"meta": {
-		"app": "https://www.codeandweb.com/texturepacker",
-		"version": "3.0",
-		"smartupdate": "$TexturePacker:SmartUpdate:0261b6c9242bba728fcfbfc515875b27:de0d9ddceed9311b33ae50ba86e969d1:176060351d0044923af938ba7932a6ef$"
-	}
+{ "frames": [
+   {
+    "filename": "0001.png",
+    "frame": { "x": 0, "y": 0, "w": 51, "h": 65 },
+    "rotated": false,
+    "trimmed": false,
+    "spriteSourceSize": { "x": 0, "y": 0, "w": 51, "h": 65 },
+    "sourceSize": { "w": 51, "h": 65 }
+   }
+ ],
+ "meta": {
+  "app": "https://www.aseprite.org/",
+  "version": "1.3.7-dev",
+  "image": "688.png",
+  "format": "I8",
+  "size": { "w": 51, "h": 65 },
+  "scale": "1"
+ }
 }

--- a/public/images/pokemon/shiny/688.json
+++ b/public/images/pokemon/shiny/688.json
@@ -1,19 +1,18 @@
 { "frames": [
    {
     "filename": "0001.png",
-    "frame": { "x": 0, "y": 0, "w": 59, "h": 63 },
+    "frame": { "x": 0, "y": 0, "w": 64, "h": 63 },
     "rotated": false,
-    "trimmed": true,
-    "spriteSourceSize": { "x": 4, "y": 0, "w": 59, "h": 63 },
-    "sourceSize": { "w": 69, "h": 63 }
+    "trimmed": false,
+    "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 63 },
+    "sourceSize": { "w": 64, "h": 63 },
    }
  ],
  "meta": {
   "app": "https://www.aseprite.org/",
-  "version": "1.3.7-dev",
-  "image": "688.png",
+  "version": "1.3.7-x64",
   "format": "I8",
-  "size": { "w": 59, "h": 63 },
+  "size": { "w": 64, "h": 63 },
   "scale": "1"
  }
 }

--- a/public/images/pokemon/shiny/688.json
+++ b/public/images/pokemon/shiny/688.json
@@ -5,7 +5,7 @@
     "rotated": false,
     "trimmed": false,
     "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 63 },
-    "sourceSize": { "w": 64, "h": 63 },
+    "sourceSize": { "w": 64, "h": 63 }
    }
  ],
  "meta": {

--- a/public/images/pokemon/shiny/688.json
+++ b/public/images/pokemon/shiny/688.json
@@ -1,19 +1,19 @@
 { "frames": [
    {
     "filename": "0001.png",
-    "frame": { "x": 0, "y": 0, "w": 64, "h": 63 },
+    "frame": { "x": 0, "y": 0, "w": 59, "h": 63 },
     "rotated": false,
-    "trimmed": false,
-    "spriteSourceSize": { "x": 0, "y": 0, "w": 64, "h": 63 },
-    "sourceSize": { "w": 64, "h": 63 },
-    "duration": 100
+    "trimmed": true,
+    "spriteSourceSize": { "x": 4, "y": 0, "w": 59, "h": 63 },
+    "sourceSize": { "w": 69, "h": 63 }
    }
  ],
  "meta": {
   "app": "https://www.aseprite.org/",
-  "version": "1.3.7-x64",
+  "version": "1.3.7-dev",
+  "image": "688.png",
   "format": "I8",
-  "size": { "w": 64, "h": 63 },
+  "size": { "w": 59, "h": 63 },
   "scale": "1"
  }
 }


### PR DESCRIPTION
## What are the changes the user will see?
Binacle sprites are now fully on screen

## Why am I making these changes?
Reported [here](https://discord.com/channels/1125469663833370665/1230751815482736640/1300159515634958420). The opportunity was also taken to trim unused fields from the Binacle front .jsons.

## What are the changes from a developer perspective?
No mechanical differences, simple asset data modifications only.

### Screenshots/Videos
#### Before
![image](https://github.com/user-attachments/assets/42e5ed36-5721-4466-8350-40710c2a762e)
#### After
![image](https://github.com/user-attachments/assets/2d025a5e-7bf9-48ca-a787-b40fabe5851c)
![image](https://github.com/user-attachments/assets/1cc4de5f-6778-4827-874c-915c35456bf3)


## How to test the changes?
Start a run with Binacle of any rarity.

## Checklist
~~- [ ] **I'm using `beta` as my base branch**~~
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
~~- [ ] Have I considered writing automated tests for the issue?~~
~~- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
