### PR TITLE
[P3] [Bug] Fixing form name being incorrect for some evolved pokemon

### DIFF
--- a/src/ui/pokemon-info-container.ts
+++ b/src/ui/pokemon-info-container.ts
@@ -244,7 +244,13 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
         formName = i18next.t(`pokemonInfo:Type.${formText?.toUpperCase()}`);
       } else {
         const i18key = `pokemonForm:${speciesName}${formText}`;
-        formName = i18next.exists(i18key) ? i18next.t(i18key) : formText;
+        if (i18next.exists(i18key)) {
+          formName = i18next.t(i18key);
+        } else {
+          const rootSpeciesName = Utils.capitalizeString(Species[pokemon.species.getRootSpeciesId()], "_", true, false);
+          const i18RootKey = `pokemonForm:${rootSpeciesName}${formText}`;
+          formName = i18next.exists(i18RootKey) ? i18next.t(i18RootKey) : formText;
+        }
       }
 
       if (formName) {

--- a/src/ui/pokemon-info-container.ts
+++ b/src/ui/pokemon-info-container.ts
@@ -237,7 +237,7 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
 
       const formKey = (pokemon.species?.forms?.[pokemon.formIndex!]?.formKey);
       const formText = Utils.capitalizeString(formKey, "-", false, false) || "";
-      const speciesName = Utils.capitalizeString(Species[pokemon.species.getRootSpeciesId()], "_", true, false);
+      const speciesName = Utils.capitalizeString(Species[pokemon.species.speciesId], "_", true, false);
 
       let formName = "";
       if (pokemon.species.speciesId === Species.ARCEUS) {


### PR DESCRIPTION
## What are the changes the user will see?
Currently, if there's a form of a caught pokemon, the pokemon info container shows the form name for pokemon using the getRootSpeciesId. Unfortunately this means that the i18 key (if there's a custom one) can be incorrect. This PR changes it to use the speciesId instead of the root pokemon speciesId

## Why am I making these changes?
Currently, if there's a form of a caught pokemon, the pokemon info container shows the form name for pokemon using the getRootSpeciesId. Unfortunately this means that the i18 key (if there's a custom one) can be incorrect. This PR changes it to use the speciesId instead of the root pokemon speciesId

## What are the changes from a developer perspective?
Currently, if there's a form of a caught pokemon, the pokemon info container shows the form name for pokemon using the getRootSpeciesId. Unfortunately this means that the i18 key (if there's a custom one) can be incorrect. This PR changes it to use the speciesId instead of the root pokemon speciesId

The way it currently works is by using the pokemon root species, and checking the i18 key against the pokemon's root species. If that exists, that's our form name to show on the pokemon info container. If it doesn't exist, it falls back to using the formText, which is the formKey (i.e. tough-cosplay) capitalised and with any "-" removed (i.e. "ToughCosplay")

However, the issue we're having is because [the pokemon form locales file](https://github.com/pagefaultgames/pokerogue-locales/blob/main/en/pokemon-form.json) has pikachuToughCosplay listed in the i18 key, but since the root species would be pichu, this fails and the pokemon info container shows a fallback text of "ToughCosplay" instead of the correct form name.

However, not every pokemon is like that - while [darmanitan](https://pokemondb.net/pokedex/darmanitan) has a standard and zen form, the root species [darumaka](https://pokemondb.net/pokedex/darumaka) does not, yet darmanitan uses [the root species for the i18key](https://github.com/pagefaultgames/pokerogue-locales/blob/main/en/pokemon-form.json#L74-L75), as does the [entire scatterbug evolution line](https://github.com/pagefaultgames/pokerogue-locales/blob/main/en/pokemon-form.json#L101-L120), meaning spewpa and vivillion need to look for the root speciesId as well. 

Now we're making it so that the pokemon info container does two things new. Firstly, instead of using the pokemon root species, it checks the i18 key against the pokemon's species. If that exists, that's our form name to show on the pokemon info container. If it doesn't exist, it then checks the root species exists. If so, it uses that, and if not, it falls back to using the formText, which is the formKey (i.e. tough-cosplay) capitalised and with any "-" removed (i.e. "ToughCosplay")


```
const speciesName = Utils.capitalizeString(Species[pokemon.species.getRootSpeciesId], "_", true, false);
````

to this line:

```
const speciesName = Utils.capitalizeString(Species[pokemon.species.speciesId], "_", true, false);
```

### Screenshots/Videos
This is an example of catching a tough cosplay pikachu in live:

![image](https://github.com/user-attachments/assets/d928a2df-d5af-442a-9ca8-17b91adb4af5)

As you can see, there's no space between "Tough" and "Cosplay". This is what it looks like with my changes:

![image](https://github.com/user-attachments/assets/c32a4cd8-4407-455c-ae29-46b8c19cb5cc)

Below is me catching a vivillon with my PR:

![image](https://github.com/user-attachments/assets/3da2cbf2-dcfa-417e-8fba-5ee0fd741987)

## How to test the changes?
You can test this by making some changes to your overrides file. Firstly, change line 125 to something like this:

```
readonly OPP_SPECIES_OVERRIDE: Species | number = Species.PIKACHU;
```

This lets you choose what pokemon you're choosing. In this case, Pikachu, I choose you!

Then change line 143 to something like this:

```
readonly OPP_FORM_OVERRIDES: Partial<Record<Species, number>> = {[Species.PIKACHU]: 7};
```

This tells the game to override pikachu's form to be form 7, which in this case is tough cosplay. You can find the forms by looking at the pokemon-species file:

![image](https://github.com/user-attachments/assets/94b17fe9-42bb-42cd-89fd-237b296f9d07)

As a handy guide, I did some console testing to get a list of all the pokemon with forms, and then compared the output of the code in live vs the code in this PR. To do the console testing, I ran this code in the starter select, since that has access to allSpecies already, but you can run this wherever allSpecies is around. 

<details>
<summary>Full lists of outputs - this is not that helpful</summary>
This section is not that helpful, but these outputs below have every single pokemon with a form and all their forms in live and from this PR. A lot of pokemon won't necessarily have any changes, so this is just here as a just in case. The next section has _just_ the differences between live and this PR for the pokemon that have changed, and you should really be looking at that section instead

Below is the code based in live, as well the output for each pokemon with a form:

[Code and output in live.txt](https://github.com/user-attachments/files/17535721/Code.and.output.in.live.txt)

Below is the code from the PR as well as the output for each pokemon with a form:

[Code and output from PR.txt](https://github.com/user-attachments/files/17535861/Code.and.output.from.PR.txt)
</details>

Below is a list of just the changed pokemon form names from this code, which is just the pikachu forms:

![image](https://github.com/user-attachments/assets/c80d1f59-0909-4fe0-b1d9-658fe74c96ad)

As you can see, the form names are now showing the right text and haven't changed anything else for any other pokemon

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [ ] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
