### PR TITLE
[Sprite][hotfix] Fixed cropping on 658 static greninja and ash greninja

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pokemon-rogue-battle",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pokemon-rogue-battle",
-			"version": "1.1.4",
+			"version": "1.1.5",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@material/material-color-utilities": "^0.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pokemon-rogue-battle",
 	"private": true,
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"type": "module",
 	"scripts": {
 		"start": "vite",

--- a/public/images/pokemon/658-ash.json
+++ b/public/images/pokemon/658-ash.json
@@ -1,41 +1,19 @@
-{
-	"textures": [
-		{
-			"image": "658-ash.png",
-			"format": "RGBA8888",
-			"size": {
-				"w": 79,
-				"h": 79
-			},
-			"scale": 1,
-			"frames": [
-				{
-					"filename": "0001.png",
-					"rotated": false,
-					"trimmed": false,
-					"sourceSize": {
-						"w": 79,
-						"h": 74
-					},
-					"spriteSourceSize": {
-						"x": 0,
-						"y": 0,
-						"w": 79,
-						"h": 74
-					},
-					"frame": {
-						"x": 0,
-						"y": 0,
-						"w": 79,
-						"h": 74
-					}
-				}
-			]
-		}
-	],
-	"meta": {
-		"app": "https://www.codeandweb.com/texturepacker",
-		"version": "3.0",
-		"smartupdate": "$TexturePacker:SmartUpdate:936f62fa49ba4d6e402bb2e2eaf2afd0:ed00ba047a44b4bf1309bc147dd000e3:bfbf521a5c7bd80bcd95a96d9789c0dd$"
-	}
+{ "frames": [
+   {
+    "filename": "0001.png",
+    "frame": { "x": 0, "y": 0, "w": 79, "h": 74 },
+    "rotated": false,
+    "trimmed": false,
+    "spriteSourceSize": { "x": 0, "y": 0, "w": 79, "h": 74 },
+    "sourceSize": { "w": 79, "h": 74 },
+    "duration": 100
+   }
+ ],
+ "meta": {
+  "app": "https://www.aseprite.org/",
+  "version": "1.3.7-x64",
+  "format": "I8",
+  "size": { "w": 79, "h": 74 },
+  "scale": "1"
+ }
 }

--- a/public/images/pokemon/658.json
+++ b/public/images/pokemon/658.json
@@ -1,41 +1,19 @@
-{
-	"textures": [
-		{
-			"image": "658.png",
-			"format": "RGBA8888",
-			"size": {
-				"w": 75,
-				"h": 75
-			},
-			"scale": 1,
-			"frames": [
-				{
-					"filename": "0001.png",
-					"rotated": false,
-					"trimmed": false,
-					"sourceSize": {
-						"w": 75,
-						"h": 65
-					},
-					"spriteSourceSize": {
-						"x": 0,
-						"y": 0,
-						"w": 75,
-						"h": 65
-					},
-					"frame": {
-						"x": 0,
-						"y": 0,
-						"w": 75,
-						"h": 65
-					}
-				}
-			]
-		}
-	],
-	"meta": {
-		"app": "https://www.codeandweb.com/texturepacker",
-		"version": "3.0",
-		"smartupdate": "$TexturePacker:SmartUpdate:e0b10df331bd4ce6760edab61dee144b:061561c45beff89a92bf0158d065204f:5affcab976148657d36bf4ff3410f92d$"
-	}
+{ "frames": [
+   {
+    "filename": "0001.png",
+    "frame": { "x": 0, "y": 0, "w": 85, "h": 67 },
+    "rotated": false,
+    "trimmed": false,
+    "spriteSourceSize": { "x": 0, "y": 0, "w": 85, "h": 67 },
+    "sourceSize": { "w": 85, "h": 67 },
+    "duration": 100
+   }
+ ],
+ "meta": {
+  "app": "https://www.aseprite.org/",
+  "version": "1.3.7-x64",
+  "format": "I8",
+  "size": { "w": 85, "h": 67 },
+  "scale": "1"
+ }
 }

--- a/public/images/pokemon/back/658-ash.json
+++ b/public/images/pokemon/back/658-ash.json
@@ -1,41 +1,19 @@
-{
-	"textures": [
-		{
-			"image": "658-ash.png",
-			"format": "RGBA8888",
-			"size": {
-				"w": 73,
-				"h": 73
-			},
-			"scale": 1,
-			"frames": [
-				{
-					"filename": "0001.png",
-					"rotated": false,
-					"trimmed": false,
-					"sourceSize": {
-						"w": 73,
-						"h": 69
-					},
-					"spriteSourceSize": {
-						"x": 0,
-						"y": 0,
-						"w": 73,
-						"h": 69
-					},
-					"frame": {
-						"x": 0,
-						"y": 0,
-						"w": 73,
-						"h": 69
-					}
-				}
-			]
-		}
-	],
-	"meta": {
-		"app": "https://www.codeandweb.com/texturepacker",
-		"version": "3.0",
-		"smartupdate": "$TexturePacker:SmartUpdate:4f38801bb3afeda5faff04bdcf6a666f:0c78ce2715e7510bf55da0a92b42661c:bfbf521a5c7bd80bcd95a96d9789c0dd$"
-	}
+{ "frames": [
+   {
+    "filename": "0001.png",
+    "frame": { "x": 0, "y": 0, "w": 73, "h": 73 },
+    "rotated": false,
+    "trimmed": false,
+    "spriteSourceSize": { "x": 0, "y": 0, "w": 73, "h": 73 },
+    "sourceSize": { "w": 73, "h": 73 },
+    "duration": 100
+   }
+ ],
+ "meta": {
+  "app": "https://www.aseprite.org/",
+  "version": "1.3.7-x64",
+  "format": "I8",
+  "size": { "w": 73, "h": 73 },
+  "scale": "1"
+ }
 }

--- a/public/images/pokemon/back/658.json
+++ b/public/images/pokemon/back/658.json
@@ -1,41 +1,19 @@
-{
-	"textures": [
-		{
-			"image": "658.png",
-			"format": "RGBA8888",
-			"size": {
-				"w": 77,
-				"h": 77
-			},
-			"scale": 1,
-			"frames": [
-				{
-					"filename": "0001.png",
-					"rotated": false,
-					"trimmed": false,
-					"sourceSize": {
-						"w": 77,
-						"h": 65
-					},
-					"spriteSourceSize": {
-						"x": 0,
-						"y": 0,
-						"w": 77,
-						"h": 65
-					},
-					"frame": {
-						"x": 0,
-						"y": 0,
-						"w": 77,
-						"h": 65
-					}
-				}
-			]
-		}
-	],
-	"meta": {
-		"app": "https://www.codeandweb.com/texturepacker",
-		"version": "3.0",
-		"smartupdate": "$TexturePacker:SmartUpdate:acdb9925f3f23b947504eec7cc28c92d:1a13d9d418f6c107bb9e5d621d9154bb:5affcab976148657d36bf4ff3410f92d$"
-	}
+{ "frames": [
+   {
+    "filename": "0001.png",
+    "frame": { "x": 0, "y": 0, "w": 77, "h": 77 },
+    "rotated": false,
+    "trimmed": false,
+    "spriteSourceSize": { "x": 0, "y": 0, "w": 77, "h": 77 },
+    "sourceSize": { "w": 77, "h": 77 },
+    "duration": 100
+   }
+ ],
+ "meta": {
+  "app": "https://www.aseprite.org/",
+  "version": "1.3.7-x64",
+  "format": "I8",
+  "size": { "w": 77, "h": 77 },
+  "scale": "1"
+ }
 }

--- a/public/images/pokemon/back/shiny/658-ash.json
+++ b/public/images/pokemon/back/shiny/658-ash.json
@@ -1,41 +1,19 @@
-{
-	"textures": [
-		{
-			"image": "658-ash.png",
-			"format": "RGBA8888",
-			"size": {
-				"w": 73,
-				"h": 73
-			},
-			"scale": 1,
-			"frames": [
-				{
-					"filename": "0001.png",
-					"rotated": false,
-					"trimmed": false,
-					"sourceSize": {
-						"w": 73,
-						"h": 69
-					},
-					"spriteSourceSize": {
-						"x": 0,
-						"y": 0,
-						"w": 73,
-						"h": 69
-					},
-					"frame": {
-						"x": 0,
-						"y": 0,
-						"w": 73,
-						"h": 69
-					}
-				}
-			]
-		}
-	],
-	"meta": {
-		"app": "https://www.codeandweb.com/texturepacker",
-		"version": "3.0",
-		"smartupdate": "$TexturePacker:SmartUpdate:d474b821316a87dfe09b397bdc2db5ef:497de0c2ec59ceba163e870b3226c76c:bfbf521a5c7bd80bcd95a96d9789c0dd$"
-	}
+{ "frames": [
+   {
+    "filename": "0001.png",
+    "frame": { "x": 0, "y": 0, "w": 73, "h": 73 },
+    "rotated": false,
+    "trimmed": false,
+    "spriteSourceSize": { "x": 0, "y": 0, "w": 73, "h": 73 },
+    "sourceSize": { "w": 73, "h": 73 },
+    "duration": 100
+   }
+ ],
+ "meta": {
+  "app": "https://www.aseprite.org/",
+  "version": "1.3.7-x64",
+  "format": "I8",
+  "size": { "w": 73, "h": 73 },
+  "scale": "1"
+ }
 }

--- a/public/images/pokemon/back/shiny/658.json
+++ b/public/images/pokemon/back/shiny/658.json
@@ -1,41 +1,19 @@
-{
-	"textures": [
-		{
-			"image": "658.png",
-			"format": "RGBA8888",
-			"size": {
-				"w": 77,
-				"h": 77
-			},
-			"scale": 1,
-			"frames": [
-				{
-					"filename": "0001.png",
-					"rotated": false,
-					"trimmed": false,
-					"sourceSize": {
-						"w": 77,
-						"h": 65
-					},
-					"spriteSourceSize": {
-						"x": 0,
-						"y": 0,
-						"w": 77,
-						"h": 65
-					},
-					"frame": {
-						"x": 0,
-						"y": 0,
-						"w": 77,
-						"h": 65
-					}
-				}
-			]
-		}
-	],
-	"meta": {
-		"app": "https://www.codeandweb.com/texturepacker",
-		"version": "3.0",
-		"smartupdate": "$TexturePacker:SmartUpdate:5891f87a78022cde3402e7d9714cc7bf:756360084290e39c139e3fef91c81759:5affcab976148657d36bf4ff3410f92d$"
-	}
+{ "frames": [
+   {
+    "filename": "0001.png",
+    "frame": { "x": 0, "y": 0, "w": 77, "h": 77 },
+    "rotated": false,
+    "trimmed": false,
+    "spriteSourceSize": { "x": 0, "y": 0, "w": 77, "h": 77 },
+    "sourceSize": { "w": 77, "h": 77 },
+    "duration": 100
+   }
+ ],
+ "meta": {
+  "app": "https://www.aseprite.org/",
+  "version": "1.3.7-x64",
+  "format": "I8",
+  "size": { "w": 77, "h": 77 },
+  "scale": "1"
+ }
 }

--- a/public/images/pokemon/shiny/658-ash.json
+++ b/public/images/pokemon/shiny/658-ash.json
@@ -1,41 +1,19 @@
-{
-	"textures": [
-		{
-			"image": "658-ash.png",
-			"format": "RGBA8888",
-			"size": {
-				"w": 79,
-				"h": 79
-			},
-			"scale": 1,
-			"frames": [
-				{
-					"filename": "0001.png",
-					"rotated": false,
-					"trimmed": false,
-					"sourceSize": {
-						"w": 79,
-						"h": 74
-					},
-					"spriteSourceSize": {
-						"x": 0,
-						"y": 0,
-						"w": 79,
-						"h": 74
-					},
-					"frame": {
-						"x": 0,
-						"y": 0,
-						"w": 79,
-						"h": 74
-					}
-				}
-			]
-		}
-	],
-	"meta": {
-		"app": "https://www.codeandweb.com/texturepacker",
-		"version": "3.0",
-		"smartupdate": "$TexturePacker:SmartUpdate:3dd081ba5490f090a73de8423aac2f6b:f088fafaea755476f2abf488e7340cab:bfbf521a5c7bd80bcd95a96d9789c0dd$"
-	}
+{ "frames": [
+   {
+    "filename": "0001.png",
+    "frame": { "x": 0, "y": 0, "w": 79, "h": 74 },
+    "rotated": false,
+    "trimmed": false,
+    "spriteSourceSize": { "x": 0, "y": 0, "w": 79, "h": 74 },
+    "sourceSize": { "w": 79, "h": 74 },
+    "duration": 100
+   }
+ ],
+ "meta": {
+  "app": "https://www.aseprite.org/",
+  "version": "1.3.7-x64",
+  "format": "I8",
+  "size": { "w": 79, "h": 74 },
+  "scale": "1"
+ }
 }

--- a/public/images/pokemon/shiny/658.json
+++ b/public/images/pokemon/shiny/658.json
@@ -1,41 +1,19 @@
-{
-	"textures": [
-		{
-			"image": "658.png",
-			"format": "RGBA8888",
-			"size": {
-				"w": 75,
-				"h": 75
-			},
-			"scale": 1,
-			"frames": [
-				{
-					"filename": "0001.png",
-					"rotated": false,
-					"trimmed": false,
-					"sourceSize": {
-						"w": 75,
-						"h": 65
-					},
-					"spriteSourceSize": {
-						"x": 0,
-						"y": 0,
-						"w": 75,
-						"h": 65
-					},
-					"frame": {
-						"x": 0,
-						"y": 0,
-						"w": 75,
-						"h": 65
-					}
-				}
-			]
-		}
-	],
-	"meta": {
-		"app": "https://www.codeandweb.com/texturepacker",
-		"version": "3.0",
-		"smartupdate": "$TexturePacker:SmartUpdate:be07c062265a19e890f1e2d2d1b5527d:ad4583a5a0498c496e9a93574c55ee03:5affcab976148657d36bf4ff3410f92d$"
-	}
+{ "frames": [
+   {
+    "filename": "0001.png",
+    "frame": { "x": 0, "y": 0, "w": 85, "h": 67 },
+    "rotated": false,
+    "trimmed": false,
+    "spriteSourceSize": { "x": 0, "y": 0, "w": 85, "h": 67 },
+    "sourceSize": { "w": 85, "h": 67 },
+    "duration": 100
+   }
+ ],
+ "meta": {
+  "app": "https://www.aseprite.org/",
+  "version": "1.3.7-x64",
+  "format": "I8",
+  "size": { "w": 85, "h": 67 },
+  "scale": "1"
+ }
 }


### PR DESCRIPTION
Re-exported json files for static sprites on greninja and ash greninja

### Screenshots/Videos
using base sprite
![d2dff03e-e768-473e-ace4-00ef5a77d7cb](https://github.com/user-attachments/assets/b925fed6-8f4d-41b3-b710-508afbb5aeeb)

shiny sprite
![8930b8d4-eb83-4e09-96dd-b07b5483f8b8](https://github.com/user-attachments/assets/08382ad6-17a5-418e-862e-2b30af1048bc)

ash greninja base sprite
![29412f8c-42a6-4a49-b44f-7233ef7f03b5](https://github.com/user-attachments/assets/da603e20-41ac-417a-aa47-1d8d27f3c36b)
![38310862-690a-4e6a-b6d3-9b759c294ff9](https://github.com/user-attachments/assets/957eeadb-c39d-4080-948c-c41a27f50643)

ash greninja shiny sprite
![f7fd4f57-71ab-44fb-bdea-c7b40d134ccb](https://github.com/user-attachments/assets/73a13981-42be-4727-b14f-58aea856c16c)
![4b40fb46-6c4f-4737-aee7-2e85e7c1a3c9](https://github.com/user-attachments/assets/2e417b17-64cd-4643-a06a-a22e507c9de1)



## Checklist
~~- [ ] **I'm using `beta` as my base branch**~~
- [x] There is no overlap with another PR?
~~- [ ] The PR is self-contained and cannot be split into smaller PRs?~~
- [x] Have I provided a clear explanation of the changes?
~~- [ ] Have I considered writing automated tests for the issue?~~
~~- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
