### PR TITLE
[Hotfix] Fix crash when Mist would block a stat drop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pokemon-rogue-battle",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pokemon-rogue-battle",
-			"version": "1.1.4",
+			"version": "1.1.5",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@material/material-color-utilities": "^0.2.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pokemon-rogue-battle",
-	"version": "1.1.5",
+	"version": "1.1.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pokemon-rogue-battle",
-			"version": "1.1.5",
+			"version": "1.1.6",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@material/material-color-utilities": "^0.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pokemon-rogue-battle",
 	"private": true,
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"type": "module",
 	"scripts": {
 		"start": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pokemon-rogue-battle",
 	"private": true,
-	"version": "1.1.5",
+	"version": "1.1.6",
 	"type": "module",
 	"scripts": {
 		"start": "vite",

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -126,6 +126,7 @@ export class MistTag extends ArenaTag {
    * Cancels the lowering of stats
    * @param arena the {@linkcode Arena} containing this effect
    * @param simulated `true` if the effect should be applied quietly
+   * @param attacker the {@linkcode Pokemon} using a move into this effect.
    * @param cancelled a {@linkcode BooleanHolder} whose value is set to `true`
    * to flag the stat reduction as cancelled
    * @returns `true` if a stat reduction was cancelled; `false` otherwise

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -65,7 +65,7 @@ export class StatStageChangePhase extends PokemonPhase {
 
       if (!this.selfTarget && stages.value < 0) {
         // TODO: add a reference to the source of the stat change to fix Infiltrator interaction
-        this.scene.arena.applyTagsForSide(MistTag, pokemon.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY, false, null, false, cancelled);
+        this.scene.arena.applyTagsForSide(MistTag, pokemon.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY, false, null, cancelled);
       }
 
       if (!cancelled.value && !this.selfTarget && stages.value < 0) {

--- a/src/test/moves/mist.test.ts
+++ b/src/test/moves/mist.test.ts
@@ -1,0 +1,49 @@
+import { Stat } from "#enums/stat";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Moves - Mist", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([ Moves.MIST, Moves.SPLASH ])
+      .ability(Abilities.BALL_FETCH)
+      .battleType("double")
+      .disableCrits()
+      .enemySpecies(Species.SNORLAX)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.GROWL);
+  });
+
+  it("should prevent the user's side from having stats lowered", async () => {
+    await game.classicMode.startBattle([ Species.MAGIKARP, Species.FEEBAS ]);
+
+    const playerPokemon = game.scene.getPlayerField();
+
+    game.move.select(Moves.MIST, 0);
+    game.move.select(Moves.SPLASH, 1);
+
+    await game.phaseInterceptor.to("BerryPhase");
+
+    playerPokemon.forEach(p => expect(p.getStatStage(Stat.ATK)).toBe(0));
+  });
+
+  it.todo("should be ignored by opponents with Infiltrator");
+});


### PR DESCRIPTION
## What are the changes the user will see?
Stat-stage-decreasing effects should no longer crash the game when applying to a target while Mist is active

## Why am I making these changes?
Oversight on my end...

## What are the changes from a developer perspective?
`phases/stat-stage-change-phase`: Fixed incorrect arguments in the `applyTagsForSide` call for Mist (there was an extra `false` that was misplaced)

### Screenshots/Videos

## How to test the changes?
`npm run test mist` (1 new test + 1 new TODO for when Infiltrator is fully implemented)

## Checklist
- [n/a] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [n/a] Are the changes visual?
  - [n/a] Have I provided screenshots/videos of the changes?
