### PR TITLE
[Refactor] Adding Type, Current HP, Max HP, & Status to updateGameInfo()

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2965,7 +2965,7 @@ export default class BattleScene extends SceneBase {
       biome: this.currentBattle ? getBiomeName(this.arena.biomeType) : "",
       wave: this.currentBattle?.waveIndex || 0,
       party: this.party ? this.party.map(p => {
-        return { name: p.name, level: p.level };
+        return { name: p.name, type: p.type[0], level: p.level, currentHP: p.hp, maxHP: p.stats[0], status: p.status };
       }) : [],
       modeChain: this.ui?.getModeChain() ?? [],
     };

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2965,7 +2965,7 @@ export default class BattleScene extends SceneBase {
       biome: this.currentBattle ? getBiomeName(this.arena.biomeType) : "",
       wave: this.currentBattle?.waveIndex || 0,
       party: this.party ? this.party.map(p => {
-        return { name: p.name, type: p.type[0], level: p.level, currentHP: p.hp, maxHP: p.stats[0], status: p.status };
+        return { name: p.name, type: p.getTypes(), level: p.level, currentHP: p.hp, maxHP: p.getMaxHp(), status: p.status };
       }) : [],
       modeChain: this.ui?.getModeChain() ?? [],
     };

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -89,7 +89,13 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   public exp: integer;
   public levelExp: integer;
   public gender: Gender;
-  public hp: integer;
+  private _hp: number;
+  public get hp() {
+    return this._hp;
+  }
+  public set hp(hp: number) {
+    this._hp = hp;
+  }
   public stats: integer[];
   public ivs: integer[];
   public nature: Nature;
@@ -181,6 +187,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     }
     this.exp = dataSource?.exp || getLevelTotalExp(this.level, species.growthRate);
     this.levelExp = dataSource?.levelExp || 0;
+
     if (dataSource) {
       this.id = dataSource.id;
       this.hp = dataSource.hp;

--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -30,6 +30,8 @@ export class CommandPhase extends FieldPhase {
   start() {
     super.start();
 
+    this.scene.updateGameInfo();
+
     const commandUiHandler = this.scene.ui.handlers[Mode.COMMAND];
     if (commandUiHandler) {
       if (this.scene.currentBattle.turn === 1 || commandUiHandler.getCursor() === Command.POKEMON) {


### PR DESCRIPTION
I am looking to create an automatic overlay for streamers that will display basic party information. The script will update on the command phase and at the end of a wave. Altogether it will show:

- Species
- Type
- Level
- Current HP / Max HP
- Status Condition

I have attached a rough idea of what the end product (for my stream) will look like. I will make the code publicly available for users to edit according to their preferences.
![stream mockup 1](https://github.com/user-attachments/assets/b4e8f1fa-4806-4705-a224-c301fda37662)

The average user will not see any changes to gameplay. The info will be accessible through window.gameInfo.

I added updateGameInfo() to the start of the command-phase execution. With this, to grab current HP, I went into pokemon.ts to add a getter/setter. Finally, in battle-scene.ts, I added the titled attributes to gameInfo.

To test, someone will just need to run window.gameInfo in console and the new information will be populated to the party array that already included name and level.

No automated tests, no overrides used, and should be straightforward to test.
