### PR TITLE
[Balance] Change Bouncy Bubble's Attributes

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -9497,8 +9497,8 @@ export function initMoves() {
       .attr(FlinchAttr),
     new AttackMove(Moves.PIKA_PAPOW, Type.ELECTRIC, MoveCategory.SPECIAL, -1, -1, 20, -1, 0, 7)
       .attr(FriendshipPowerAttr),
-    new AttackMove(Moves.BOUNCY_BUBBLE, Type.WATER, MoveCategory.SPECIAL, 60, 100, 20, -1, 0, 7) // Custom
-      .attr(HitHealAttr)
+    new AttackMove(Moves.BOUNCY_BUBBLE, Type.WATER, MoveCategory.SPECIAL, 60, 100, 20, -1, 0, 7)
+      .attr(HitHealAttr) // Custom
       .triageMove()
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new AttackMove(Moves.BUZZY_BUZZ, Type.ELECTRIC, MoveCategory.SPECIAL, 60, 100, 20, 100, 0, 7)

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -9488,7 +9488,7 @@ export function initMoves() {
       .edgeCase() // I assume it needs clanging scales and Kommo-O
       .ignoresVirtual(),
     /* End Unused */
-    new AttackMove(Moves.ZIPPY_ZAP, Type.ELECTRIC, MoveCategory.PHYSICAL, 50, 100, 15, -1, 2, 7) //LGPE Implementation
+    new AttackMove(Moves.ZIPPY_ZAP, Type.ELECTRIC, MoveCategory.PHYSICAL, 50, 100, 15, -1, 2, 7) // LGPE Implementation
       .attr(CritOnlyAttr),
     new AttackMove(Moves.SPLISHY_SPLASH, Type.WATER, MoveCategory.SPECIAL, 90, 100, 15, 30, 0, 7)
       .attr(StatusEffectAttr, StatusEffect.PARALYSIS)
@@ -9497,8 +9497,8 @@ export function initMoves() {
       .attr(FlinchAttr),
     new AttackMove(Moves.PIKA_PAPOW, Type.ELECTRIC, MoveCategory.SPECIAL, -1, -1, 20, -1, 0, 7)
       .attr(FriendshipPowerAttr),
-    new AttackMove(Moves.BOUNCY_BUBBLE, Type.WATER, MoveCategory.SPECIAL, 60, 100, 20, -1, 0, 7)
-      .attr(HitHealAttr, 1.0)
+    new AttackMove(Moves.BOUNCY_BUBBLE, Type.WATER, MoveCategory.SPECIAL, 60, 100, 20, -1, 0, 7) // Custom
+      .attr(HitHealAttr)
       .triageMove()
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new AttackMove(Moves.BUZZY_BUZZ, Type.ELECTRIC, MoveCategory.SPECIAL, 60, 100, 20, 100, 0, 7)


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
Bouncy Bubble's healing has been reduced from 100% drain to 50% drain to match LGPE's drain (without the increase in power).

## Why am I making these changes?
By request of Game Design Head and Game Balance Head, a 60bp spread move with 100% drain was way too much on anything that received the move. Even not accounting for egg moves, the move was VERY powerful on Vaporeon and even Eevee. We were using unused data from Gen 8 when implementing these moves in and it was decided by both Megalith and Damo to give the move a more "custom implementation" to make it not the most egregious thing ever.

## What are the changes from a developer perspective?
Changed HitHealAttr on Bouncy Bubble
Added note to indicate custom implementation, fixed Zippy Zap's note

### Screenshots/Videos
![image](https://github.com/user-attachments/assets/6ad168c4-0a4b-4346-a548-3e9e355abf17)
![image](https://github.com/user-attachments/assets/2c014c75-7960-4d62-8e3f-af12ee2467cc)


## How to test the changes?
Overrides
## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
