### PR TITLE
[Bug] Take weight into account when getting the tier of a modifier

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -323,6 +323,7 @@ export default class BattleScene extends SceneBase {
     this.conditionalQueue = [];
     this.phaseQueuePrependSpliceIndex = -1;
     this.nextCommandPhaseQueue = [];
+    this.eventManager = new TimedEventManager();
     this.updateGameInfo();
   }
 
@@ -378,7 +379,6 @@ export default class BattleScene extends SceneBase {
 
     this.fieldSpritePipeline = new FieldSpritePipeline(this.game);
     (this.renderer as Phaser.Renderer.WebGL.WebGLRenderer).pipelines.add("FieldSprite", this.fieldSpritePipeline);
-    this.eventManager = new TimedEventManager();
 
     this.launchBattle();
   }

--- a/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
+++ b/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
@@ -1,7 +1,7 @@
 import { EnemyPartyConfig, generateModifierType, initBattleWithEnemyConfig, leaveEncounterWithoutBattle, loadCustomMovesForEncounter, selectPokemonForOption, setEncounterRewards, transitionMysteryEncounterIntroVisuals } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
 import { trainerConfigs, TrainerPartyCompoundTemplate, TrainerPartyTemplate, } from "#app/data/trainer-config";
 import { ModifierTier } from "#app/modifier/modifier-tier";
-import { modifierTypes, PokemonHeldItemModifierType } from "#app/modifier/modifier-type";
+import { ModifierPoolType, modifierTypes, PokemonHeldItemModifierType } from "#app/modifier/modifier-type";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { PartyMemberStrength } from "#enums/party-member-strength";
 import BattleScene from "#app/battle-scene";
@@ -280,7 +280,7 @@ export const ClowningAroundEncounter: MysteryEncounter =
           let numRogue = 0;
           items.filter(m => m.isTransferable && !(m instanceof BerryModifier))
             .forEach(m => {
-              const type = m.type.withTierFromPool();
+              const type = m.type.withTierFromPool(ModifierPoolType.PLAYER, party);
               const tier = type.tier ?? ModifierTier.ULTRA;
               if (type.id === "GOLDEN_EGG" || tier === ModifierTier.ROGUE) {
                 numRogue += m.stackCount;

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -418,7 +418,7 @@ export function generateModifierType(scene: BattleScene, modifier: () => Modifie
   // Populates item id and tier (order matters)
   result = result
     .withIdFromFunc(modifierTypes[modifierId])
-    .withTierFromPool();
+    .withTierFromPool(ModifierPoolType.PLAYER, scene.getParty());
 
   return result instanceof ModifierTypeGenerator ? result.generateType(scene.getParty(), pregenArgs) : result;
 }

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -136,14 +136,14 @@ export class ModifierType {
         if (this.id === modifier.modifierType.id) {
           let weight: number;
           if (modifier.weight instanceof Function) {
-            weight = party ? (modifier.weight as Function)(party, rerollCount) : 0;
+            weight = party ? modifier.weight(party, rerollCount) : 0;
           } else {
-            weight = modifier.weight as number;
+            weight = modifier.weight;
           }
           if (weight > 0) {
             this.tier = modifier.modifierType.tier;
             return this;
-          } else if (!isNullOrUndefined(defaultTier)) {
+          } else if (isNullOrUndefined(defaultTier)) {
             // If weight is 0, keep track of the first tier where the item was found
             defaultTier = modifier.modifierType.tier;
           }

--- a/src/test/utils/gameWrapper.ts
+++ b/src/test/utils/gameWrapper.ts
@@ -24,6 +24,7 @@ import GamepadPlugin = Phaser.Input.Gamepad.GamepadPlugin;
 import EventEmitter = Phaser.Events.EventEmitter;
 import UpdateList = Phaser.GameObjects.UpdateList;
 import { version } from "../../../package.json";
+import { MockTimedEventManager } from "./mocks/mockTimedEventManager";
 
 Object.defineProperty(window, "localStorage", {
   value: mockLocalStorage(),
@@ -232,6 +233,7 @@ export default class GameWrapper {
     this.scene.make = new MockGameObjectCreator(mockTextureManager);
     this.scene.time = new MockClock(this.scene);
     this.scene.remove = vi.fn(); // TODO: this should be stubbed differently
+    this.scene.eventManager = new MockTimedEventManager(); // Disable Timed Events
   }
 }
 

--- a/src/test/utils/mocks/mockTimedEventManager.ts
+++ b/src/test/utils/mocks/mockTimedEventManager.ts
@@ -2,10 +2,6 @@ import { TimedEventManager } from "#app/timed-event-manager";
 
 /** Mock TimedEventManager so that ongoing events don't impact tests */
 export class MockTimedEventManager extends TimedEventManager {
-  constructor() {
-    super();
-  }
-
   override activeEvent() {
     return undefined;
   }

--- a/src/test/utils/mocks/mockTimedEventManager.ts
+++ b/src/test/utils/mocks/mockTimedEventManager.ts
@@ -1,0 +1,21 @@
+import { TimedEventManager } from "#app/timed-event-manager";
+
+/** Mock TimedEventManager so that ongoing events don't impact tests */
+export class MockTimedEventManager extends TimedEventManager {
+  constructor() {
+    super();
+  }
+
+  override activeEvent() {
+    return undefined;
+  }
+  override isEventActive(): boolean {
+    return false;
+  }
+  override getFriendshipMultiplier(): number {
+    return 1;
+  }
+  override getShinyMultiplier(): number {
+    return 1;
+  }
+}


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
None / Correct tier displayed for Soothe Bell if it is added as a fixed reward in shop
<!--Soothe Bell should keep showing graphically as Rogue tier after the event is done, without us reverting the pool change-->

<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?
Event PR #4728 put Soothe Bell in two tiers, Great and Rogue tier. During events Rogue tier weight's is 0 so the item gets treated as Great tier, the rest of the time it is in Rogue tier as before, with weight 0 in Great Tier.
MEs use code that looks for the tier of a given modifier type in the item pool. But this code does not take the weight into account, which makes it think that Soothe Bell is a Great Tier item at all times, even if no event is ongoing.
This has notably caused the Clowning Around ME test to fail
This issue would also cause the Soothe Bell to appear visually as a Great Tier item after the event is done if set as a fixed shop reward by a ME

This PR should address both the issue of events impacting tests and the modifier tier issue, allowing us to leave the pool changes in and to have more items in multiple tiers in the future if we want.

<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What are the changes from a developer perspective?
- Mock `TimedEventManager` in tests to disable events
- Update `withTierFromPool` function in `modifier-type` to take in account the modifier weight and skip over tiers where the weight is 0

<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos
Before, with no event ongoing, if an ME set Soothe Bell as a fixed reward it would appear as Great Tier rarity
![image](https://github.com/user-attachments/assets/0e3b5946-00f3-4553-8e93-fa24581c4a93)

After, with no event ongoing, it appears as Rogue Tier:
![image](https://github.com/user-attachments/assets/ecae62e8-2328-435c-b30b-129996fe445b)

<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
Change line 250 of  `clowning-around-encounter.test.ts` to run the test XX times in a row
```it.only.each(Array.from({ length: XX }))("should ...```

`npm run test src/test/mystery-encounter/encounters/clowning-around-encounter.test.ts`

<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [X] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR? at least one other PR that disables the Clowning Around ME
- [ ] The PR is self-contained and cannot be split into smaller PRs? eh...
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [ ] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
