### PR TITLE
[Move][P2] Add "no switch-in" fail condition for Shed Tail and Baton Pass

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5839,7 +5839,6 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
   }
 }
 
-
 export class ChillyReceptionAttr extends ForceSwitchOutAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     user.scene.arena.trySetWeather(WeatherType.SNOW, true);
@@ -7063,6 +7062,11 @@ const targetSleptOrComatoseCondition: MoveConditionFunc = (user: Pokemon, target
 
 const failIfLastCondition: MoveConditionFunc = (user: Pokemon, target: Pokemon, move: Move) => user.scene.phaseQueue.find(phase => phase instanceof MovePhase) !== undefined;
 
+const failIfLastInPartyCondition: MoveConditionFunc = (user: Pokemon, target: Pokemon, move: Move) => {
+  const party: Pokemon[] = user.isPlayer() ? user.scene.getParty() : user.scene.getEnemyParty();
+  return party.some(pokemon => pokemon.isActive() && !pokemon.isOnField());
+};
+
 export type MoveAttrFilter = (attr: MoveAttr) => boolean;
 
 function applyMoveAttrsInternal(attrFilter: MoveAttrFilter, user: Pokemon | null, target: Pokemon | null, move: Move, args: any[]): Promise<void> {
@@ -7972,6 +7976,7 @@ export function initMoves() {
       .attr(StatusEffectAttr, StatusEffect.PARALYSIS),
     new SelfStatusMove(Moves.BATON_PASS, Type.NORMAL, -1, 40, -1, 0, 2)
       .attr(ForceSwitchOutAttr, true, SwitchType.BATON_PASS)
+      .condition(failIfLastInPartyCondition)
       .hidesUser(),
     new StatusMove(Moves.ENCORE, Type.NORMAL, 100, 5, -1, 0, 2)
       .attr(AddBattlerTagAttr, BattlerTagType.ENCORE, false, true)
@@ -10112,7 +10117,8 @@ export function initMoves() {
       .makesContact(),
     new SelfStatusMove(Moves.SHED_TAIL, Type.NORMAL, -1, 10, -1, 0, 9)
       .attr(AddSubstituteAttr, 0.5)
-      .attr(ForceSwitchOutAttr, true, SwitchType.SHED_TAIL),
+      .attr(ForceSwitchOutAttr, true, SwitchType.SHED_TAIL)
+      .condition(failIfLastInPartyCondition),
     new SelfStatusMove(Moves.CHILLY_RECEPTION, Type.ICE, -1, 10, -1, 0, 9)
       .attr(PreMoveMessageAttr, (user, move) => i18next.t("moveTriggers:chillyReception", { pokemonName: getPokemonNameWithAffix(user) }))
       .attr(ChillyReceptionAttr, true),

--- a/src/test/moves/shed_tail.test.ts
+++ b/src/test/moves/shed_tail.test.ts
@@ -1,4 +1,5 @@
 import { SubstituteTag } from "#app/data/battler-tags";
+import { MoveResult } from "#app/field/pokemon";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
@@ -52,5 +53,19 @@ describe("Moves - Shed Tail", () => {
     expect(magikarp.hp).toBe(Math.ceil(magikarp.getMaxHp() / 2));
     expect(substituteTag).toBeDefined();
     expect(substituteTag?.hp).toBe(Math.floor(magikarp.getMaxHp() / 4));
+  });
+
+  it("should fail if no ally is available to switch in", async () => {
+    await game.classicMode.startBattle([ Species.MAGIKARP ]);
+
+    const magikarp = game.scene.getPlayerPokemon()!;
+    expect(game.scene.getParty().length).toBe(1);
+
+    game.move.select(Moves.SHED_TAIL);
+
+    await game.phaseInterceptor.to("TurnEndPhase", false);
+
+    expect(magikarp.isOnField()).toBeTruthy();
+    expect(magikarp.getLastXMoves()[0].result).toBe(MoveResult.FAIL);
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?
Shed Tail and Baton Pass should now correctly fail when used with no available Pokemon in the user's party to switch in

## Why am I making these changes?
Following up on #4643, which didn't completely fix status moves

## What are the changes from a developer perspective?
`data/move`: Added a new condition for Shed Tail and Baton Pass requiring the user to have at least one available Pokemon in their party and not on the field. Note that `Pokemon.isActive()` also checks for challenge-eligibility, so the new condition will not be met by party Pokemon not allowed in battle.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
`npm run test shed_tail` (1 new test)

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [n/a] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [?] Are the changes visual?
  - [?] Have I provided screenshots/videos of the changes?
