### PR TITLE
[Move] Fully Implement Round

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -4157,6 +4157,60 @@ export class CombinedPledgeStabBoostAttr extends MoveAttr {
   }
 }
 
+/**
+ * Variable Power attribute for {@link https://bulbapedia.bulbagarden.net/wiki/Round_(move) | Round}.
+ * Doubles power if another Pokemon has previously selected Round this turn.
+ * @extends VariablePowerAttr
+ */
+export class RoundPowerAttr extends VariablePowerAttr {
+  override apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    const power = args[0];
+    if (!(power instanceof Utils.NumberHolder)) {
+      return false;
+    }
+
+    if (user.turnData?.joinedRound) {
+      power.value *= 2;
+      return true;
+    }
+    return false;
+  }
+}
+
+/**
+ * Attribute for the "combo" effect of {@link https://bulbapedia.bulbagarden.net/wiki/Round_(move) | Round}.
+ * Preempts the next move in the turn order with the first instance of any Pokemon
+ * using Round. Also marks the Pokemon using the cued Round to double the move's power.
+ * @extends MoveEffectAttr
+ * @see {@linkcode RoundPowerAttr}
+ */
+export class CueNextRoundAttr extends MoveEffectAttr {
+  constructor() {
+    super(true, { lastHitOnly: true });
+  }
+
+  override apply(user: Pokemon, target: Pokemon, move: Move, args?: any[]): boolean {
+    const nextRoundPhase = user.scene.findPhase<MovePhase>(phase =>
+      phase instanceof MovePhase && phase.move.moveId === Moves.ROUND
+    );
+
+    if (!nextRoundPhase) {
+      return false;
+    }
+
+    // Update the phase queue so that the next Pokemon using Round moves next
+    const nextRoundIndex = user.scene.phaseQueue.indexOf(nextRoundPhase);
+    const nextMoveIndex = user.scene.phaseQueue.findIndex(phase => phase instanceof MovePhase);
+    if (nextRoundIndex !== nextMoveIndex) {
+      user.scene.prependToPhase(user.scene.phaseQueue.splice(nextRoundIndex, 1)[0], MovePhase);
+    }
+
+    // Mark the corresponding Pokemon as having "joined the Round" (for doubling power later)
+    nextRoundPhase.pokemon.turnData.joinedRound = true;
+    return true;
+  }
+}
+
 export class VariableAtkAttr extends MoveAttr {
   constructor() {
     super();
@@ -8956,8 +9010,9 @@ export function initMoves() {
       .condition((user, target, move) => !target.turnData.acted)
       .attr(AfterYouAttr),
     new AttackMove(Moves.ROUND, Type.NORMAL, MoveCategory.SPECIAL, 60, 100, 15, -1, 0, 5)
-      .soundBased()
-      .partial(), // No effect implemented
+      .attr(CueNextRoundAttr)
+      .attr(RoundPowerAttr)
+      .soundBased(),
     new AttackMove(Moves.ECHOED_VOICE, Type.NORMAL, MoveCategory.SPECIAL, 40, 100, 15, -1, 0, 5)
       .attr(ConsecutiveUseMultiBasePowerAttr, 5, false)
       .soundBased(),

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -5181,6 +5181,7 @@ export class PokemonTurnData {
   public combiningPledge?: Moves;
   public switchedInThisTurn: boolean = false;
   public failedRunAway: boolean = false;
+  public joinedRound: boolean = false;
 }
 
 export enum AiType {

--- a/src/test/moves/round.test.ts
+++ b/src/test/moves/round.test.ts
@@ -1,0 +1,65 @@
+import { BattlerIndex } from "#app/battle";
+import { allMoves } from "#app/data/move";
+import { MoveEffectPhase } from "#app/phases/move-effect-phase";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Moves - Round", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([ Moves.SPLASH, Moves.ROUND ])
+      .ability(Abilities.BALL_FETCH)
+      .battleType("double")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset([ Moves.SPLASH, Moves.ROUND ])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should cue other instances of Round together in Speed order", async () => {
+    await game.classicMode.startBattle([ Species.MAGIKARP, Species.FEEBAS ]);
+
+    const round = allMoves[Moves.ROUND];
+    const spy = vi.spyOn(round, "calculateBattlePower");
+
+    game.move.select(Moves.ROUND, 0, BattlerIndex.ENEMY);
+    game.move.select(Moves.ROUND, 1, BattlerIndex.ENEMY_2);
+
+    await game.forceEnemyMove(Moves.ROUND, BattlerIndex.PLAYER);
+    await game.forceEnemyMove(Moves.SPLASH);
+
+    await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY ]);
+
+    const actualTurnOrder: BattlerIndex[] = [];
+
+    for (let i = 0; i < 4; i++) {
+      await game.phaseInterceptor.to("MoveEffectPhase", false);
+      actualTurnOrder.push((game.scene.getCurrentPhase() as MoveEffectPhase).getUserPokemon()!.getBattlerIndex());
+      await game.phaseInterceptor.to("MoveEndPhase");
+    }
+
+    expect(actualTurnOrder).toEqual([ BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2 ]);
+    const powerResults = spy.mock.results.map(result => result.value);
+    expect(powerResults).toEqual( [ 60, 120, 120 ]);
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?
Round is now fully implemented with the power boost and turn order manipulation effects.

## Why am I making these changes?
less (P) moves pikasmile

## What are the changes from a developer perspective?
- `data/move`: 2 new attributes for Round: one for the power boost from previous Round uses, and the other for manipulating turn order
- `field/pokemon`: New `turnData` field to track if the Pokemon is using Round as a followup to another Pokemon's Round.
- `test/moves/round.test`: New unit test checking turn order manipulation and power boost.

### Screenshots/Videos

**Both allies using Round in a double battle:**

https://github.com/user-attachments/assets/6f755b67-530e-47eb-a30c-52d4162e3674

Note that Shuckle moves immediately after Voltorb [despite having the lowest base Speed out of any evolved Pokemon](https://bulbapedia.bulbagarden.net/wiki/List_of_fully_evolved_Pok%C3%A9mon_by_base_stats).

From the logs for both uses of Round in this turn, we can see that the power of the second Round was doubled compared to the first:

![image](https://github.com/user-attachments/assets/6bd52ab4-b11d-4b3e-b0ae-a7d95f7387cf)

## How to test the changes?
`npm run test round`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [n/a] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?

PS: I did some [testing on Showdown](https://replay.pokemonshowdown.com/gen9nationaldexdoubles-2236675389-h3lu9njwif81cup98cp0ferebchzvoepw) to determine that Round must actually be used (not just selected) in order to apply the combo effect. The turn order manipulation uses a self-targeted `POST_APPLY` trigger, so the current implementation should match Showdown's behavior.
