### PR TITLE
[QoL] Proof of Concept - Transfer held items from released Party Pokemon to new Pokemon

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2632,10 +2632,9 @@ export default class BattleScene extends SceneBase {
     });
   }
 
-  removePartyMemberModifiers(partyMemberIndex: integer): Promise<void> {
+  removePartyMemberModifiers(partyMemberId: integer): Promise<void> {
     return new Promise(resolve => {
-      const pokemonId = this.getPlayerParty()[partyMemberIndex].id;
-      const modifiersToRemove = this.modifiers.filter(m => m instanceof PokemonHeldItemModifier && (m as PokemonHeldItemModifier).pokemonId === pokemonId);
+      const modifiersToRemove = this.modifiers.filter(m => m instanceof PokemonHeldItemModifier && (m as PokemonHeldItemModifier).pokemonId === partyMemberId);
       for (const m of modifiersToRemove) {
         this.modifiers.splice(this.modifiers.indexOf(m), 1);
       }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -5127,8 +5127,8 @@ export class EnemyPokemon extends Pokemon {
           newPokemon.setVisible(false); // Hide if replaced with first pokemon
         }
 
-        if (pokemonReplaced && newPokemon.isAllowedInBattle()) {
-          const modifiersToTransfer = this.scene.findModifiers(m => m instanceof PokemonHeldItemModifier && m.pokemonId === pokemonReplaced, true) as PokemonHeldItemModifier[];
+        if (pokemonReplaced && newPokemon.isAllowedInChallenge()) {
+          const modifiersToTransfer = this.scene.findModifiers(m => m instanceof PokemonHeldItemModifier && !(m instanceof BaseStatModifier) && m.pokemonId === pokemonReplaced, true) as PokemonHeldItemModifier[];
           const transferResults: Promise<boolean>[] = [];
           for (const modifier of modifiersToTransfer) {
             transferResults.push(this.scene.tryTransferHeldItemModifier(modifier, newPokemon, false, modifier.getStackCount(), true, true));

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -5128,7 +5128,7 @@ export class EnemyPokemon extends Pokemon {
         }
 
         if (pokemonReplaced && newPokemon.isAllowedInChallenge()) {
-          const modifiersToTransfer = this.scene.findModifiers(m => m instanceof PokemonHeldItemModifier && !(m instanceof BaseStatModifier) && m.pokemonId === pokemonReplaced, true) as PokemonHeldItemModifier[];
+          const modifiersToTransfer = this.scene.findModifiers(m => m instanceof PokemonHeldItemModifier && !(m instanceof BaseStatModifier) && m.isTransferable && m.pokemonId === pokemonReplaced, true) as PokemonHeldItemModifier[];
           const transferResults: Promise<boolean>[] = [];
           for (const modifier of modifiersToTransfer) {
             transferResults.push(this.scene.tryTransferHeldItemModifier(modifier, newPokemon, false, modifier.getStackCount(), true, true));

--- a/src/phases/attempt-capture-phase.ts
+++ b/src/phases/attempt-capture-phase.ts
@@ -233,8 +233,8 @@ export class AttemptCapturePhase extends PokemonPhase {
         this.scene.clearEnemyHeldItemModifiers();
         this.scene.field.remove(pokemon, true);
       };
-      const addToParty = (slotIndex?: number) => {
-        const newPokemon = pokemon.addToParty(this.pokeballType, slotIndex);
+      const addToParty = (slotIndex?: number, releasedPokemon?: number) => {
+        const newPokemon = pokemon.addToParty(this.pokeballType, slotIndex, releasedPokemon);
         const modifiers = this.scene.findModifiers(m => m instanceof PokemonHeldItemModifier, false);
         if (this.scene.getPlayerParty().filter(p => p.isShiny()).length === PLAYER_PARTY_MAX_SIZE) {
           this.scene.validateAchv(achvs.SHINY_PARTY);
@@ -262,15 +262,15 @@ export class AttemptCapturePhase extends PokemonPhase {
                   });
                 }, false);
               }, () => {
-                this.scene.ui.setMode(Mode.PARTY, PartyUiMode.RELEASE, this.fieldIndex, (slotIndex: integer, _option: PartyOption) => {
+                this.scene.ui.setMode(Mode.PARTY, PartyUiMode.RELEASE, this.fieldIndex, (slotIndex: number, _option: PartyOption, releasedPokemon: number) => {
                   this.scene.ui.setMode(Mode.MESSAGE).then(() => {
                     if (slotIndex < 6) {
-                      addToParty(slotIndex);
+                      addToParty(slotIndex, releasedPokemon);
                     } else {
                       promptRelease();
                     }
                   });
-                });
+                }, );
               }, () => {
                 this.scene.ui.setMode(Mode.MESSAGE).then(() => {
                   removePokemon();

--- a/src/test/moves/dragon_rage.test.ts
+++ b/src/test/moves/dragon_rage.test.ts
@@ -51,8 +51,6 @@ describe("Moves - Dragon Rage", () => {
     partyPokemon = game.scene.getPlayerParty()[0];
     enemyPokemon = game.scene.getEnemyPokemon()!;
 
-    // remove berries
-    game.scene.removePartyMemberModifiers(0);
     game.scene.clearEnemyHeldItemModifiers();
   });
 

--- a/src/test/moves/fissure.test.ts
+++ b/src/test/moves/fissure.test.ts
@@ -46,8 +46,6 @@ describe("Moves - Fissure", () => {
     partyPokemon = game.scene.getPlayerParty()[0];
     enemyPokemon = game.scene.getEnemyPokemon()!;
 
-    // remove berries
-    game.scene.removePartyMemberModifiers(0);
     game.scene.clearEnemyHeldItemModifiers();
   });
 

--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -1063,7 +1063,7 @@ export default class PartyUiHandler extends MessageUiHandler {
       this.clearPartySlots();
       const releasedPokemon = this.scene.getPlayerParty().splice(slotIndex, 1)[0];
       let releasedId: number = 0;
-      if (releasedPokemon.isAllowedInChallenge()) {
+      if (releasedPokemon.isAllowedInChallenge() && releasedPokemon.friendship > 200) {
         releasedId = releasedPokemon.id;
       }
       this.populatePartySlots();

--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -1063,7 +1063,7 @@ export default class PartyUiHandler extends MessageUiHandler {
       this.clearPartySlots();
       const releasedPokemon = this.scene.getPlayerParty().splice(slotIndex, 1)[0];
       let releasedId: number = 0;
-      if (releasedPokemon.isAllowedInBattle()) {
+      if (releasedPokemon.isAllowedInChallenge()) {
         releasedId = releasedPokemon.id;
       }
       this.populatePartySlots();

--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -123,7 +123,7 @@ export enum PartyOption {
   ALL = 4000,
 }
 
-export type PartySelectCallback = (cursor: integer, option: PartyOption) => void;
+export type PartySelectCallback = (cursor: integer, option: PartyOption, args?: any | undefined) => void;
 export type PartyModifierTransferSelectCallback = (fromCursor: integer, index: integer, itemQuantity?: integer, toCursor?: integer) => void;
 export type PartyModifierSpliceSelectCallback = (fromCursor: integer, toCursor?: integer) => void;
 export type PokemonSelectFilter = (pokemon: PlayerPokemon) => string | null;
@@ -1061,9 +1061,11 @@ export default class PartyUiHandler extends MessageUiHandler {
   doRelease(slotIndex: integer): void {
     this.showText(this.getReleaseMessage(getPokemonNameWithAffix(this.scene.getPlayerParty()[slotIndex])), null, () => {
       this.clearPartySlots();
-      this.scene.removePartyMemberModifiers(slotIndex);
       const releasedPokemon = this.scene.getPlayerParty().splice(slotIndex, 1)[0];
-      releasedPokemon.destroy();
+      let releasedId: number = 0;
+      if (releasedPokemon.isAllowedInBattle()) {
+        releasedId = releasedPokemon.id;
+      }
       this.populatePartySlots();
       if (this.cursor >= this.scene.getPlayerParty().length) {
         this.setCursor(this.cursor - 1);
@@ -1071,8 +1073,9 @@ export default class PartyUiHandler extends MessageUiHandler {
       if (this.partyUiMode === PartyUiMode.RELEASE) {
         const selectCallback = this.selectCallback;
         this.selectCallback = null;
-        selectCallback && selectCallback(this.cursor, PartyOption.RELEASE);
+        selectCallback && selectCallback(this.cursor, PartyOption.RELEASE, releasedId);
       }
+      releasedPokemon.destroy();
       this.showText("", 0);
     }, null, true);
   }


### PR DESCRIPTION
## What are the changes the user will see?
The user will be able to automatically transfer the released Party Pokemon's items to the newly caught Pokemon as long as the added items are within the stack limit + the released Pokemon has a certain friendship

## Why am I making these changes?
Felt like it. If Balance approves/requests changes/rejects, then I will accept. Not super attached to this PR's outcome.

## What are the changes from a developer perspective?
Very messed up stuff. 
Item transfer only allowed if both Pokemon are allowed in challenges. 

### Screenshots/Videos
https://github.com/user-attachments/assets/8132aa32-ae73-4635-9780-c9b3e96a2fdd

## How to test the changes?
- Have a Pokemon with items in your party + a full party
- Catch a Pokemon
- Replace the Pokemon with items with the new Pokemon
- Pokemon Held Items should transfer over

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
