### PR TITLE
[Move][Refactor] Create `Move.getPriority` + Fully Implement Upper Hand

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -7,7 +7,7 @@ import { Weather, WeatherType } from "./weather";
 import { BattlerTag, GroundedTag } from "./battler-tags";
 import { StatusEffect, getNonVolatileStatusEffects, getStatusEffectDescriptor, getStatusEffectHealText } from "./status-effect";
 import { Gender } from "./gender";
-import Move, { AttackMove, MoveCategory, MoveFlags, MoveTarget, FlinchAttr, OneHitKOAttr, HitHealAttr, allMoves, StatusMove, SelfStatusMove, VariablePowerAttr, applyMoveAttrs, IncrementMovePriorityAttr, VariableMoveTypeAttr, RandomMovesetMoveAttr, RandomMoveAttr, NaturePowerAttr, CopyMoveAttr, MoveAttr, MultiHitAttr, SacrificialAttr, SacrificialAttrOnHit, NeutralDamageAgainstFlyingTypeMultiplierAttr, FixedDamageAttr } from "./move";
+import Move, { AttackMove, MoveCategory, MoveFlags, MoveTarget, FlinchAttr, OneHitKOAttr, HitHealAttr, allMoves, StatusMove, SelfStatusMove, VariablePowerAttr, applyMoveAttrs, VariableMoveTypeAttr, RandomMovesetMoveAttr, RandomMoveAttr, NaturePowerAttr, CopyMoveAttr, MoveAttr, MultiHitAttr, SacrificialAttr, SacrificialAttrOnHit, NeutralDamageAgainstFlyingTypeMultiplierAttr, FixedDamageAttr } from "./move";
 import { ArenaTagSide, ArenaTrapTag } from "./arena-tag";
 import { BerryModifier, HitHealModifier, PokemonHeldItemModifier } from "../modifier/modifier";
 import { TerrainType } from "./terrain";
@@ -578,15 +578,11 @@ export class PostDefendAbAttr extends AbAttr {
 
 export class FieldPriorityMoveImmunityAbAttr extends PreDefendAbAttr {
   applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): boolean {
-    const attackPriority = new Utils.IntegerHolder(move.priority);
-    applyMoveAttrs(IncrementMovePriorityAttr, attacker, null, move, attackPriority);
-    applyAbAttrs(ChangeMovePriorityAbAttr, attacker, null, simulated, move, attackPriority);
-
     if (move.moveTarget === MoveTarget.USER || move.moveTarget === MoveTarget.NEAR_ALLY) {
       return false;
     }
 
-    if (attackPriority.value > 0 && !move.isMultiTarget()) {
+    if (move.getPriority(attacker) > 0 && !move.isMultiTarget()) {
       cancelled.value = true;
       return true;
     }

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -2,12 +2,12 @@ import { Arena } from "#app/field/arena";
 import BattleScene from "#app/battle-scene";
 import { Type } from "#app/data/type";
 import { BooleanHolder, NumberHolder, toDmgValue } from "#app/utils";
-import { MoveCategory, allMoves, MoveTarget, IncrementMovePriorityAttr, applyMoveAttrs } from "#app/data/move";
+import { MoveCategory, allMoves, MoveTarget } from "#app/data/move";
 import { getPokemonNameWithAffix } from "#app/messages";
 import Pokemon, { HitResult, PokemonMove } from "#app/field/pokemon";
 import { StatusEffect } from "#app/data/status-effect";
 import { BattlerIndex } from "#app/battle";
-import { BlockNonDirectDamageAbAttr, ChangeMovePriorityAbAttr, InfiltratorAbAttr, ProtectStatAbAttr, applyAbAttrs } from "#app/data/ability";
+import { BlockNonDirectDamageAbAttr, InfiltratorAbAttr, ProtectStatAbAttr, applyAbAttrs } from "#app/data/ability";
 import { Stat } from "#enums/stat";
 import { CommonAnim, CommonBattleAnim } from "#app/data/battle-anims";
 import i18next from "i18next";
@@ -318,17 +318,15 @@ export class ConditionalProtectTag extends ArenaTag {
  */
 const QuickGuardConditionFunc: ProtectConditionFunc = (arena, moveId) => {
   const move = allMoves[moveId];
-  const priority = new NumberHolder(move.priority);
   const effectPhase = arena.scene.getCurrentPhase();
 
   if (effectPhase instanceof MoveEffectPhase) {
     const attacker = effectPhase.getUserPokemon();
-    applyMoveAttrs(IncrementMovePriorityAttr, attacker, null, move, priority);
     if (attacker) {
-      applyAbAttrs(ChangeMovePriorityAbAttr, attacker, null, false, move, priority);
+      return move.getPriority(attacker) > 0;
     }
   }
-  return priority.value > 0;
+  return move.priority > 0;
 };
 
 /**

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -7393,6 +7393,12 @@ export class FirstMoveCondition extends MoveCondition {
   }
 }
 
+/**
+ * Condition used by the move {@link https://bulbapedia.bulbagarden.net/wiki/Upper_Hand_(move) | Upper Hand}.
+ * Moves with this condition are only successful when the target has selected
+ * a high-priority attack (after factoring in priority-boosting effects) and
+ * hasn't moved yet this turn.
+ */
 export class UpperHandCondition extends MoveCondition {
   constructor() {
     super((user, target, move) => {

--- a/src/data/terrain.ts
+++ b/src/data/terrain.ts
@@ -1,8 +1,6 @@
 import Pokemon from "../field/pokemon";
 import Move from "./move";
 import { Type } from "./type";
-import * as Utils from "../utils";
-import { ChangeMovePriorityAbAttr, applyAbAttrs } from "./ability";
 import { ProtectAttr } from "./move";
 import { BattlerIndex } from "#app/battle";
 import i18next from "i18next";
@@ -58,10 +56,8 @@ export class Terrain {
     switch (this.terrainType) {
       case TerrainType.PSYCHIC:
         if (!move.hasAttr(ProtectAttr)) {
-          const priority = new Utils.IntegerHolder(move.priority);
-          applyAbAttrs(ChangeMovePriorityAbAttr, user, null, false, move, priority);
           // Cancels move if the move has positive priority and targets a Pokemon grounded on the Psychic Terrain
-          return priority.value > 0 && user.getOpponents().some(o => targets.includes(o.getBattlerIndex()) && o.isGrounded());
+          return move.getPriority(user) > 0 && user.getOpponents().some(o => targets.includes(o.getBattlerIndex()) && o.isGrounded());
         }
     }
 

--- a/src/phases/turn-start-phase.ts
+++ b/src/phases/turn-start-phase.ts
@@ -1,6 +1,6 @@
 import BattleScene from "#app/battle-scene";
-import { applyAbAttrs, BypassSpeedChanceAbAttr, PreventBypassSpeedChanceAbAttr, ChangeMovePriorityAbAttr } from "#app/data/ability";
-import { allMoves, applyMoveAttrs, IncrementMovePriorityAttr, MoveHeaderAttr } from "#app/data/move";
+import { applyAbAttrs, BypassSpeedChanceAbAttr, PreventBypassSpeedChanceAbAttr } from "#app/data/ability";
+import { allMoves, MoveHeaderAttr } from "#app/data/move";
 import { Abilities } from "#app/enums/abilities";
 import { Stat } from "#app/enums/stat";
 import Pokemon, { PokemonMove } from "#app/field/pokemon";
@@ -98,26 +98,22 @@ export class TurnStartPhase extends FieldPhase {
         const aMove = allMoves[aCommand.move!.move];
         const bMove = allMoves[bCommand!.move!.move];
 
-        // The game now considers priority and applies the relevant move and ability attributes
-        const aPriority = new Utils.IntegerHolder(aMove.priority);
-        const bPriority = new Utils.IntegerHolder(bMove.priority);
+        const aUser = this.scene.getField(true).find(p => p.getBattlerIndex() === a)!;
+        const bUser = this.scene.getField(true).find(p => p.getBattlerIndex() === b)!;
 
-        applyMoveAttrs(IncrementMovePriorityAttr, this.scene.getField().find(p => p?.isActive() && p.getBattlerIndex() === a)!, null, aMove, aPriority);
-        applyMoveAttrs(IncrementMovePriorityAttr, this.scene.getField().find(p => p?.isActive() && p.getBattlerIndex() === b)!, null, bMove, bPriority);
-
-        applyAbAttrs(ChangeMovePriorityAbAttr, this.scene.getField().find(p => p?.isActive() && p.getBattlerIndex() === a)!, null, false, aMove, aPriority);
-        applyAbAttrs(ChangeMovePriorityAbAttr, this.scene.getField().find(p => p?.isActive() && p.getBattlerIndex() === b)!, null, false, bMove, bPriority);
+        const aPriority = aMove.getPriority(aUser, false);
+        const bPriority = bMove.getPriority(bUser, false);
 
         // The game now checks for differences in priority levels.
         // If the moves share the same original priority bracket, it can check for differences in battlerBypassSpeed and return the result.
         // This conditional is used to ensure that Quick Claw can still activate with abilities like Stall and Mycelium Might (attack moves only)
         // Otherwise, the game returns the user of the move with the highest priority.
-        const isSameBracket = Math.ceil(aPriority.value) - Math.ceil(bPriority.value) === 0;
-        if (aPriority.value !== bPriority.value) {
+        const isSameBracket = Math.ceil(aPriority) - Math.ceil(bPriority) === 0;
+        if (aPriority !== bPriority) {
           if (isSameBracket && battlerBypassSpeed[a].value !== battlerBypassSpeed[b].value) {
             return battlerBypassSpeed[a].value ? -1 : 1;
           }
-          return aPriority.value < bPriority.value ? 1 : -1;
+          return aPriority < bPriority ? 1 : -1;
         }
       }
 

--- a/src/phases/turn-start-phase.ts
+++ b/src/phases/turn-start-phase.ts
@@ -113,7 +113,7 @@ export class TurnStartPhase extends FieldPhase {
           if (isSameBracket && battlerBypassSpeed[a].value !== battlerBypassSpeed[b].value) {
             return battlerBypassSpeed[a].value ? -1 : 1;
           }
-          return aPriority < bPriority ? 1 : -1;
+          return (aPriority < bPriority) ? 1 : -1;
         }
       }
 

--- a/src/test/moves/upper_hand.test.ts
+++ b/src/test/moves/upper_hand.test.ts
@@ -1,0 +1,84 @@
+import { MoveResult } from "#app/field/pokemon";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Moves - Upper Hand", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset(Moves.UPPER_HAND)
+      .ability(Abilities.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.QUICK_ATTACK)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should flinch the opponent before they use a priority attack", async () => {
+    await game.classicMode.startBattle([ Species.FEEBAS ]);
+
+    const feebas = game.scene.getPlayerPokemon()!;
+    const magikarp = game.scene.getEnemyPokemon()!;
+
+    game.move.select(Moves.UPPER_HAND);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(feebas.getLastXMoves()[0].result).toBe(MoveResult.SUCCESS);
+    expect(magikarp.isFullHp()).toBeFalsy();
+    expect(feebas.isFullHp()).toBeTruthy();
+  });
+
+  it.each([
+    { descriptor: "non-priority attack", move: Moves.TACKLE },
+    { descriptor: "status move", move: Moves.SPLASH }
+  ])("should fail when the opponent selects a $descriptor", async ({ move }) => {
+    game.override.enemyMoveset(move);
+
+    await game.classicMode.startBattle([ Species.FEEBAS ]);
+
+    const feebas = game.scene.getPlayerPokemon()!;
+
+    game.move.select(Moves.UPPER_HAND);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(feebas.getLastXMoves()[0].result).toBe(MoveResult.FAIL);
+  });
+
+  it("should flinch the opponent before they use an attack boosted by Gale Wings", async () => {
+    game.override
+      .enemyAbility(Abilities.GALE_WINGS)
+      .enemyMoveset(Moves.GUST);
+
+    await game.classicMode.startBattle([ Species.FEEBAS ]);
+
+    const feebas = game.scene.getPlayerPokemon()!;
+    const magikarp = game.scene.getEnemyPokemon()!;
+
+    game.move.select(Moves.UPPER_HAND);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(feebas.getLastXMoves()[0].result).toBe(MoveResult.SUCCESS);
+    expect(magikarp.isFullHp()).toBeFalsy();
+    expect(feebas.isFullHp()).toBeTruthy();
+  });
+});

--- a/src/test/moves/upper_hand.test.ts
+++ b/src/test/moves/upper_hand.test.ts
@@ -1,11 +1,11 @@
-import { allMoves } from "#app/data/move";
+import { BattlerIndex } from "#app/battle";
 import { MoveResult } from "#app/field/pokemon";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
 import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Moves - Upper Hand", () => {
   let phaserGame: Phaser.Game;
@@ -84,14 +84,17 @@ describe("Moves - Upper Hand", () => {
   });
 
   it("should fail if the target has already moved", async () => {
-    game.override.enemyMoveset(Moves.TACKLE);
-    vi.spyOn(allMoves[Moves.TACKLE], "priority", "get").mockReturnValue(4);
+    game.override
+      .enemyMoveset(Moves.FAKE_OUT)
+      .enemyAbility(Abilities.SHEER_FORCE);
 
     await game.classicMode.startBattle([ Species.FEEBAS ]);
 
     const feebas = game.scene.getPlayerPokemon()!;
 
     game.move.select(Moves.UPPER_HAND);
+
+    await game.setTurnOrder([ BattlerIndex.ENEMY, BattlerIndex.PLAYER ]);
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(feebas.getLastXMoves()[0].result).toBe(MoveResult.FAIL);


### PR DESCRIPTION
## What are the changes the user will see?
Upper Hand should now work against attacks boosted by Gale Wings, Triage, etc.

## Why am I making these changes?
More implementation + consolidating some recurring code for move priority calculations

## What are the changes from a developer perspective?
- `data/move`:
  - New function `Move.getPriority` returns the move's final priority after applying relevant move and ability attributes (e.g. from Grassy Glide or Prankster)
  - Rewrote Upper Hand's condition into a `UpperHandCondition` class such that it now uses the new `getPriority` function and facilitates condition-based effect scoring for future AI plans.
- Rewrote several instances where move priority is independently calculated to use the new `getPriority` function instead.

### Screenshots/Videos

## How to test the changes?
`npm run test upper_hand` (new)

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [n/a] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [?] Are the changes visual?
  - [?] Have I provided screenshots/videos of the changes?
