### PR TITLE
[P3][UI][QoL] Fix tooltips going out of screen on mobile & other improvements

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -242,6 +242,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
   private pokemonEggMoveContainers: Phaser.GameObjects.Container[];
   private pokemonEggMoveBgs: Phaser.GameObjects.NineSlice[];
   private pokemonEggMoveLabels: Phaser.GameObjects.Text[];
+  private pokemonCandyContainer: Phaser.GameObjects.Container;
   private pokemonCandyIcon: Phaser.GameObjects.Sprite;
   private pokemonCandyDarknessOverlay: Phaser.GameObjects.Sprite;
   private pokemonCandyOverlayIcon: Phaser.GameObjects.Sprite;
@@ -686,31 +687,36 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.pokemonLuckText.setOrigin(0, 0);
     this.starterSelectContainer.add(this.pokemonLuckText);
 
-    this.pokemonCandyIcon = this.scene.add.sprite(4.5, 18, "candy");
+    // Candy icon and count
+    this.pokemonCandyContainer = this.scene.add.container(4.5, 18);
+
+    this.pokemonCandyIcon = this.scene.add.sprite(0, 0, "candy");
     this.pokemonCandyIcon.setScale(0.5);
     this.pokemonCandyIcon.setOrigin(0, 0);
-    this.starterSelectContainer.add(this.pokemonCandyIcon);
+    this.pokemonCandyContainer.add(this.pokemonCandyIcon);
 
-    this.pokemonFormText = addTextObject(this.scene, 6, 42, "Form", TextStyle.WINDOW_ALT, { fontSize: "42px" });
-    this.pokemonFormText.setOrigin(0, 0);
-    this.starterSelectContainer.add(this.pokemonFormText);
-
-    this.pokemonCandyOverlayIcon = this.scene.add.sprite(4.5, 18, "candy_overlay");
+    this.pokemonCandyOverlayIcon = this.scene.add.sprite(0, 0, "candy_overlay");
     this.pokemonCandyOverlayIcon.setScale(0.5);
     this.pokemonCandyOverlayIcon.setOrigin(0, 0);
-    this.starterSelectContainer.add(this.pokemonCandyOverlayIcon);
+    this.pokemonCandyContainer.add(this.pokemonCandyOverlayIcon);
 
-    this.pokemonCandyDarknessOverlay = this.scene.add.sprite(4.5, 18, "candy");
+    this.pokemonCandyDarknessOverlay = this.scene.add.sprite(0, 0, "candy");
     this.pokemonCandyDarknessOverlay.setScale(0.5);
     this.pokemonCandyDarknessOverlay.setOrigin(0, 0);
     this.pokemonCandyDarknessOverlay.setTint(0x000000);
     this.pokemonCandyDarknessOverlay.setAlpha(0.50);
-    this.pokemonCandyDarknessOverlay.setInteractive(new Phaser.Geom.Rectangle(0, 0, 16, 16), Phaser.Geom.Rectangle.Contains);
-    this.starterSelectContainer.add(this.pokemonCandyDarknessOverlay);
+    this.pokemonCandyContainer.add(this.pokemonCandyDarknessOverlay);
 
-    this.pokemonCandyCountText = addTextObject(this.scene, 14, 18, "x0", TextStyle.WINDOW_ALT, { fontSize: "56px" });
+    this.pokemonCandyCountText = addTextObject(this.scene, 9.5, 0, "x0", TextStyle.WINDOW_ALT, { fontSize: "56px" });
     this.pokemonCandyCountText.setOrigin(0, 0);
-    this.starterSelectContainer.add(this.pokemonCandyCountText);
+    this.pokemonCandyContainer.add(this.pokemonCandyCountText);
+
+    this.pokemonCandyContainer.setInteractive(new Phaser.Geom.Rectangle(0, 0, 30, 20), Phaser.Geom.Rectangle.Contains);
+    this.starterSelectContainer.add(this.pokemonCandyContainer);
+
+    this.pokemonFormText = addTextObject(this.scene, 6, 42, "Form", TextStyle.WINDOW_ALT, { fontSize: "42px" });
+    this.pokemonFormText.setOrigin(0, 0);
+    this.starterSelectContainer.add(this.pokemonFormText);
 
     this.pokemonCaughtHatchedContainer = this.scene.add.container(2, 25);
     this.pokemonCaughtHatchedContainer.setScale(0.5);
@@ -2822,10 +2828,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
           this.pokemonShinyIcon.setY(135);
           this.pokemonShinyIcon.setFrame(getVariantIcon(variant));
           [
-            this.pokemonCandyIcon,
-            this.pokemonCandyOverlayIcon,
-            this.pokemonCandyDarknessOverlay,
-            this.pokemonCandyCountText,
+            this.pokemonCandyContainer,
             this.pokemonHatchedIcon,
             this.pokemonHatchedCountText
           ].map(c => c.setVisible(false));
@@ -2834,31 +2837,26 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
           this.pokemonCaughtHatchedContainer.setY(25);
           this.pokemonShinyIcon.setY(117);
           this.pokemonCandyIcon.setTint(argbFromRgba(rgbHexToRgba(colorScheme[0])));
-          this.pokemonCandyIcon.setVisible(true);
           this.pokemonCandyOverlayIcon.setTint(argbFromRgba(rgbHexToRgba(colorScheme[1])));
-          this.pokemonCandyOverlayIcon.setVisible(true);
-          this.pokemonCandyDarknessOverlay.setVisible(true);
           this.pokemonCandyCountText.setText(`x${this.scene.gameData.starterData[species.speciesId].candyCount}`);
-          this.pokemonCandyCountText.setVisible(true);
+          this.pokemonCandyContainer.setVisible(true);
           this.pokemonFormText.setY(42);
           this.pokemonHatchedIcon.setVisible(true);
           this.pokemonHatchedCountText.setVisible(true);
 
           const { currentFriendship, friendshipCap } = this.getFriendship(this.lastSpecies.speciesId);
           const candyCropY = 16 - (16 * (currentFriendship / friendshipCap));
-
-          if (this.pokemonCandyDarknessOverlay.visible) {
-            this.pokemonCandyDarknessOverlay.on("pointerover", () => {
-              this.scene.ui.showTooltip("", `${currentFriendship}/${friendshipCap}`, true);
-              this.activeTooltip = "CANDY";
-            });
-            this.pokemonCandyDarknessOverlay.on("pointerout", () => {
-              this.scene.ui.hideTooltip();
-              this.activeTooltip = undefined;
-            });
-          }
-
           this.pokemonCandyDarknessOverlay.setCrop(0, 0, 16, candyCropY);
+
+          this.pokemonCandyContainer.on("pointerover", () => {
+            this.scene.ui.showTooltip("", `${currentFriendship}/${friendshipCap}`, true);
+            this.activeTooltip = "CANDY";
+          });
+          this.pokemonCandyContainer.on("pointerout", () => {
+            this.scene.ui.hideTooltip();
+            this.activeTooltip = undefined;
+          });
+
         }
 
 
@@ -2934,10 +2932,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         this.pokemonPassiveLabelText.setVisible(false);
         this.pokemonNatureLabelText.setVisible(false);
         this.pokemonCaughtHatchedContainer.setVisible(false);
-        this.pokemonCandyIcon.setVisible(false);
-        this.pokemonCandyOverlayIcon.setVisible(false);
-        this.pokemonCandyDarknessOverlay.setVisible(false);
-        this.pokemonCandyCountText.setVisible(false);
+        this.pokemonCandyContainer.setVisible(false);
         this.pokemonFormText.setVisible(false);
 
         const defaultDexAttr = this.scene.gameData.getSpeciesDefaultDexAttr(species, true, true);
@@ -2971,10 +2966,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       this.pokemonPassiveLabelText.setVisible(false);
       this.pokemonNatureLabelText.setVisible(false);
       this.pokemonCaughtHatchedContainer.setVisible(false);
-      this.pokemonCandyIcon.setVisible(false);
-      this.pokemonCandyOverlayIcon.setVisible(false);
-      this.pokemonCandyDarknessOverlay.setVisible(false);
-      this.pokemonCandyCountText.setVisible(false);
+      this.pokemonCandyContainer.setVisible(false);
       this.pokemonFormText.setVisible(false);
 
       this.setSpeciesDetails(species!, { // TODO: is this bang correct?
@@ -3005,7 +2997,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
      || !isNullOrUndefined(formIndex) || !isNullOrUndefined(shiny) || !isNullOrUndefined(variant);
 
     if (this.activeTooltip === "CANDY") {
-      if (this.lastSpecies) {
+      if (this.lastSpecies && this.pokemonCandyContainer.visible) {
         const { currentFriendship, friendshipCap } = this.getFriendship(this.lastSpecies.speciesId);
         this.scene.ui.editTooltip("", `${currentFriendship}/${friendshipCap}`);
       } else {
@@ -3230,6 +3222,9 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
           this.pokemonPassiveLockedIcon.setVisible(!isUnlocked);
           this.pokemonPassiveLockedIcon.setPosition(iconPosition.x, iconPosition.y);
 
+        } else if (this.activeTooltip === "PASSIVE") {
+          // No passive and passive tooltip is active > hide it
+          this.scene.ui.hideTooltip();
         }
 
         this.pokemonNatureText.setText(getNatureName(natureIndex as unknown as Nature, true, true, false, this.scene.uiTheme));

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -184,7 +184,7 @@ export default class SummaryUiHandler extends UiHandler {
     this.candyShadow.setTint(0x000000);
     this.candyShadow.setAlpha(0.50);
     this.candyShadow.setScale(0.8);
-    this.candyShadow.setInteractive(new Phaser.Geom.Rectangle(0, 0, 16, 16), Phaser.Geom.Rectangle.Contains);
+    this.candyShadow.setInteractive(new Phaser.Geom.Rectangle(0, 0, 30, 16), Phaser.Geom.Rectangle.Contains);
     this.summaryContainer.add(this.candyShadow);
 
     this.candyCountText = addTextObject(this.scene, 20, -146, "x0", TextStyle.WINDOW_ALT, { fontSize: "76px" });
@@ -203,7 +203,7 @@ export default class SummaryUiHandler extends UiHandler {
     this.friendshipShadow.setTint(0x000000);
     this.friendshipShadow.setAlpha(0.50);
     this.friendshipShadow.setScale(0.8);
-    this.friendshipShadow.setInteractive(new Phaser.Geom.Rectangle(0, 0, 16, 16), Phaser.Geom.Rectangle.Contains);
+    this.friendshipShadow.setInteractive(new Phaser.Geom.Rectangle(0, 0, 50, 16), Phaser.Geom.Rectangle.Contains);
     this.summaryContainer.add(this.friendshipShadow);
 
     this.friendshipText = addTextObject(this.scene, 20, -66, "x0", TextStyle.WINDOW_ALT, { fontSize: "76px" });

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -391,6 +391,7 @@ export default class UI extends Phaser.GameObjects.Container {
     this.tooltipContent.y = title ? 16 : 4;
     this.tooltipBg.width = Math.min(Math.max(this.tooltipTitle.displayWidth, this.tooltipContent.displayWidth) + 12, 838);
     this.tooltipBg.height = (title ? 31 : 19) + 10.5 * (wrappedContent.split("\n").length - 1);
+    this.tooltipTitle.x = this.tooltipBg.width / 2;
   }
 
   hideTooltip(): void {
@@ -400,12 +401,34 @@ export default class UI extends Phaser.GameObjects.Container {
 
   update(): void {
     if (this.tooltipContainer.visible) {
-      const xReverse = this.scene.game.input.mousePointer && this.scene.game.input.mousePointer.x >= this.scene.game.canvas.width - this.tooltipBg.width * 6 - 12;
-      const yReverse = this.scene.game.input.mousePointer && this.scene.game.input.mousePointer.y >= this.scene.game.canvas.height - this.tooltipBg.height * 6 - 12;
-      this.tooltipContainer.setPosition(
-        !xReverse ? this.scene.game.input.mousePointer!.x / 6 + 2 : this.scene.game.input.mousePointer!.x / 6 - this.tooltipBg.width - 2,
-        !yReverse ? this.scene.game.input.mousePointer!.y / 6 + 2 : this.scene.game.input.mousePointer!.y / 6 - this.tooltipBg.height - 2,
-      );
+      const isTouch = (this.scene as BattleScene).inputMethod === "touch";
+      const pointerX = this.scene.game.input.activePointer.x;
+      const pointerY = this.scene.game.input.activePointer.y;
+      const tooltipWidth = this.tooltipBg.width;
+      const tooltipHeight = this.tooltipBg.height;
+      const padding = 2;
+
+      // Default placement is top left corner of the screen on mobile. Otherwise below the cursor, to the right
+      let x = isTouch ? padding : pointerX / 6 + padding;
+      let y = isTouch ? padding : pointerY / 6 + padding;
+
+      if (isTouch) {
+        // If we are in the top left quadrant on mobile, move the tooltip to the top right corner
+        if (pointerX <= this.scene.game.canvas.width / 2 && pointerY <= this.scene.game.canvas.height / 2) {
+          x = this.scene.game.canvas.width / 6 - tooltipWidth - padding;
+        }
+      } else {
+        // If the tooltip would go offscreen on the right, or is close to it, move to the left of the cursor
+        if (x + tooltipWidth + padding > this.scene.game.canvas.width / 6) {
+          x = Math.max(padding, pointerX / 6 - tooltipWidth - padding);
+        }
+        // If the tooltip would go offscreen at the bottom, or is close to it, move above the cursor
+        if (y + tooltipHeight + padding > this.scene.game.canvas.height / 6) {
+          y = Math.max(padding, pointerY / 6 - tooltipHeight - padding);
+        }
+      }
+
+      this.tooltipContainer.setPosition(x, y);
     }
   }
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
- (touch) Tooltips should no longer go offscreen
- (touch) Tooltips will show in the top right of the screen when interacting with an element in the top left
- Tooltip titles get centered properly in the tooltip window
- Tooltips for Candy Friendship and Frienship have a bigger hitbox
- Passive / Candy tooltip gets hidden for mons without passive / candy in starter select

<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?
Tooltips titles would sometimes show outside of their window

Tooltips are currently awful to use on mobile because:
- they show in the top left corner, so when trying to look at our items in battle they obscure the items.
And if we want to read the tooltip for something in the top left our thumb is in the way, for example when looking at Candy friendship in a Pokemon's summary 
- they actually don't stay properly in the top left and often disappear offscreen
- some of their hitboxes are too small to be able to hit properly on small screens

<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What are the changes from a developer perspective?
_ui.ts_:
- use `activePointer` instead of `mousePointer`, as per Phaser's [recommendation ](https://github.com/phaserjs/phaser/blob/580ff3074c9507be7f1a885e834f67d896be7acd/src/input/InputPlugin.js#L3254) for games that support touch and mouse. This was likely causing the out of screen tooltips on mobile, although I couldn't find a way to reproduce the bug consistently
- handle tooltip placement based on the scene's `inputMethod` attribute

_Starter Select UI_: 
- Place all candy related UI elements in their own container so that they can be shown/hidden more cleanly
- Hide the candy/passive tooltip if the Pokemon doesn't have these property (ie, Pokemon with baby forms)

<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos

<details><summary>Mobile tooltip placement</summary>

Before, out of screen tooltip:
![Screenshot_20241019-002256~2](https://github.com/user-attachments/assets/ebe8c918-a3e6-407b-88af-eaa99b3139f1)

Before, all tooltips in the top left:

https://github.com/user-attachments/assets/b7de2a3a-51f2-45f0-90a6-9039ef9e8dbe

After, pointer in the top left > tooltip in the top right:

https://github.com/user-attachments/assets/1e72b20c-81cf-452d-b82d-cbedfe5ce0c1

https://github.com/user-attachments/assets/ce40df8d-5f9c-4df0-90b7-11381e82936e


</details>

<details><summary>Tooltip title placement, Before/After:</summary>

![Screenshot_20241104-231815~2](https://github.com/user-attachments/assets/b81b1c95-3e00-472d-853f-8820571f3835)
![Screenshot_20241104-222329~2](https://github.com/user-attachments/assets/987e60af-0aa9-4d88-b19c-54ea7c8ec256)

</details>

<details><summary>Starter Select Candy/Passive Tooltip:</summary>

Before, Pikachu shows wrong tooltips:

https://github.com/user-attachments/assets/232a3925-8b07-4490-9e5a-944d76996c31

https://github.com/user-attachments/assets/ed198b6f-8d4b-41b4-807f-c15ee4ad7bc8

After, tooltips get hidden for Pikachu:

https://github.com/user-attachments/assets/84d22993-c01a-4938-aa28-2c918c2dd81e

</details>

<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
`npm run start:dev -- --host` to be able to access the game from another device on your network

Play around with tooltips on mobile and desktop.
Desktop should be the same for the most part.
Mobile should feel much better than before

<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs? i meaaan
- [X] Have I provided a clear explanation of the changes?
- ~~[ ] Have I considered writing automated tests for the issue?~~
- ~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
