### PR TITLE
[Bug] Fixing Incorrect Freeze Dry Interaction With Soaked Wonder Guard Target

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -7,7 +7,7 @@ import { Weather, WeatherType } from "./weather";
 import { BattlerTag, GroundedTag } from "./battler-tags";
 import { StatusEffect, getNonVolatileStatusEffects, getStatusEffectDescriptor, getStatusEffectHealText } from "./status-effect";
 import { Gender } from "./gender";
-import Move, { AttackMove, MoveCategory, MoveFlags, MoveTarget, FlinchAttr, OneHitKOAttr, HitHealAttr, allMoves, StatusMove, SelfStatusMove, VariablePowerAttr, applyMoveAttrs, IncrementMovePriorityAttr, VariableMoveTypeAttr, RandomMovesetMoveAttr, RandomMoveAttr, NaturePowerAttr, CopyMoveAttr, MoveAttr, MultiHitAttr, SacrificialAttr, SacrificialAttrOnHit, NeutralDamageAgainstFlyingTypeMultiplierAttr, FixedDamageAttr } from "./move";
+import Move, { AttackMove, MoveCategory, MoveFlags, MoveTarget, FlinchAttr, OneHitKOAttr, HitHealAttr, allMoves, StatusMove, SelfStatusMove, VariablePowerAttr, applyMoveAttrs, IncrementMovePriorityAttr, VariableMoveTypeAttr, RandomMovesetMoveAttr, RandomMoveAttr, NaturePowerAttr, CopyMoveAttr, MoveAttr, MultiHitAttr, SacrificialAttr, SacrificialAttrOnHit, NeutralDamageAgainstFlyingTypeMultiplierAttr, FixedDamageAttr, WaterSuperEffectTypeMultiplierAttr } from "./move";
 import { ArenaTagSide, ArenaTrapTag } from "./arena-tag";
 import { BerryModifier, HitHealModifier, PokemonHeldItemModifier } from "../modifier/modifier";
 import { TerrainType } from "./terrain";
@@ -512,6 +512,16 @@ export class NonSuperEffectiveImmunityAbAttr extends TypeImmunityAbAttr {
 
   applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): boolean {
     if (move instanceof AttackMove && pokemon.getAttackTypeEffectiveness(attacker.getMoveType(move), attacker) < 2) {
+      /**
+       * Forces supereffectiveness from moves with according move attributes {@linkcode WaterSuperEffectTypeMultiplierAttr}
+       *
+       * Note: edgeCase for NonSuperEffectiveImmunity interacting with forced supereffective moves.
+       * Future implementations of forced supereffective moves needs to be added here.
+       */
+      if (move.getAttrs(WaterSuperEffectTypeMultiplierAttr) && pokemon.getTypes().includes(Type.WATER)) {
+        return false;
+      }
+
       cancelled.value = true; // Suppresses "No Effect" message
       (args[0] as Utils.NumberHolder).value = 0;
       return true;

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -7,7 +7,7 @@ import { Weather, WeatherType } from "./weather";
 import { BattlerTag, GroundedTag } from "./battler-tags";
 import { StatusEffect, getNonVolatileStatusEffects, getStatusEffectDescriptor, getStatusEffectHealText } from "./status-effect";
 import { Gender } from "./gender";
-import Move, { AttackMove, MoveCategory, MoveFlags, MoveTarget, FlinchAttr, OneHitKOAttr, HitHealAttr, allMoves, StatusMove, SelfStatusMove, VariablePowerAttr, applyMoveAttrs, IncrementMovePriorityAttr, VariableMoveTypeAttr, RandomMovesetMoveAttr, RandomMoveAttr, NaturePowerAttr, CopyMoveAttr, MoveAttr, MultiHitAttr, SacrificialAttr, SacrificialAttrOnHit, NeutralDamageAgainstFlyingTypeMultiplierAttr, FixedDamageAttr, WaterSuperEffectTypeMultiplierAttr } from "./move";
+import Move, { AttackMove, MoveCategory, MoveFlags, MoveTarget, FlinchAttr, OneHitKOAttr, HitHealAttr, allMoves, StatusMove, SelfStatusMove, VariablePowerAttr, applyMoveAttrs, IncrementMovePriorityAttr, VariableMoveTypeAttr, RandomMovesetMoveAttr, RandomMoveAttr, NaturePowerAttr, CopyMoveAttr, MoveAttr, MultiHitAttr, SacrificialAttr, SacrificialAttrOnHit, NeutralDamageAgainstFlyingTypeMultiplierAttr, FixedDamageAttr } from "./move";
 import { ArenaTagSide, ArenaTrapTag } from "./arena-tag";
 import { BerryModifier, HitHealModifier, PokemonHeldItemModifier } from "../modifier/modifier";
 import { TerrainType } from "./terrain";
@@ -511,17 +511,11 @@ export class NonSuperEffectiveImmunityAbAttr extends TypeImmunityAbAttr {
   }
 
   applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): boolean {
-    if (move instanceof AttackMove && pokemon.getAttackTypeEffectiveness(attacker.getMoveType(move), attacker) < 2) {
-      /**
-       * Forces supereffectiveness from moves with according move attributes {@linkcode WaterSuperEffectTypeMultiplierAttr}
-       *
-       * Note: edgeCase for NonSuperEffectiveImmunity interacting with forced supereffective moves.
-       * Future implementations of forced supereffective moves needs to be added here.
-       */
-      if (move.getAttrs(WaterSuperEffectTypeMultiplierAttr) && pokemon.getTypes().includes(Type.WATER)) {
-        return false;
-      }
+    const modifierValue = args.length > 0
+      ? (args[0] as Utils.NumberHolder).value
+      : pokemon.getAttackTypeEffectiveness(attacker.getMoveType(move), attacker);
 
+    if (move instanceof AttackMove && modifierValue < 2) {
       cancelled.value = true; // Suppresses "No Effect" message
       (args[0] as Utils.NumberHolder).value = 0;
       return true;

--- a/src/test/moves/freeze_dry.test.ts
+++ b/src/test/moves/freeze_dry.test.ts
@@ -72,6 +72,31 @@ describe("Moves - Freeze-Dry", () => {
     expect(enemy.getMoveEffectiveness).toHaveReturnedWith(1);
   });
 
+  /**
+   * Freeze drys forced super effectiveness should overwrite wonder guard
+   */
+  it("should deal 2x dmg against soaked wonder guard target", async () => {
+    game.override
+      .enemySpecies(Species.SHEDINJA)
+      .enemyMoveset(Moves.SPLASH)
+      .starterSpecies(Species.MAGIKARP)
+      .moveset([ Moves.SOAK, Moves.FREEZE_DRY ]);
+    await game.classicMode.startBattle();
+
+    const enemy = game.scene.getEnemyPokemon()!;
+    vi.spyOn(enemy, "getMoveEffectiveness");
+
+    game.move.select(Moves.SOAK);
+    await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.ENEMY ]);
+    await game.toNextTurn();
+
+    game.move.select(Moves.FREEZE_DRY);
+    await game.phaseInterceptor.to("MoveEffectPhase");
+
+    expect(enemy.getMoveEffectiveness).toHaveReturnedWith(2);
+    expect(enemy.hp).toBeLessThan(enemy.getMaxHp());
+  });
+
   // enable if this is ever fixed (lol)
   it.todo("should deal 2x damage to water types under Normalize", async () => {
     game.override.ability(Abilities.NORMALIZE);


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
The Player was not able to damage a target with "Wonder Guard" even though the used move forced super effectiveness against the soaked target (forced water type). Now freeze dry damages the target correctly.

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
I saw the [Issue](https://github.com/pagefaultgames/pokerogue/issues/4744) (#4744 ) and wanted to fix it

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Should the Player Pokemon use Freeze Dry (which has the [`WaterSuperEffectTypeMultiplierAttr`](https://github.com/pagefaultgames/pokerogue/blob/13841765f177a2e6626683967457adcfc965b631/src/data/move.ts#L4889-L4903) on a target with the [`NonSuperEffectiveImmunityAbAttr`](https://github.com/pagefaultgames/pokerogue/blob/13841765f177a2e6626683967457adcfc965b631/src/data/ability.ts#L508-L529) it now checks if the target is of Type [Water](https://github.com/pagefaultgames/pokerogue/blob/13841765f177a2e6626683967457adcfc965b631/src/data/type.ts#L13). If that is the case then the move's super effective damage calculation is forced even if ice moves are usually not very effective against water type Pokemons.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
Before Fix:

https://github.com/user-attachments/assets/dd5fe1eb-35bd-4abd-8c48-88d3f3803d30

After Fix:

https://github.com/user-attachments/assets/13abffa2-ae5e-48d6-8c15-c0c5883a3616


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Manual tests:
```
const overrides = {
  OPP_SPECIES_OVERRIDE: Species.SHEDINJA,
  MOVESET_OVERRIDE: [ Moves.SOAK, Moves.FREEZE_DRY, Moves.EXTREME_SPEED ],
  OPP_MOVESET_OVERRIDE: Moves.SPLASH
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

Automated tests: [here](https://github.com/pagefaultgames/pokerogue/commit/42a1d5db06e77246d24b1838a5be8c9c64461c05)

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
