### PR TITLE
[P2][ME] Fix GTS not getting the correct tier when trading items

### DIFF
--- a/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
+++ b/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
@@ -367,10 +367,11 @@ export const GlobalTradeSystemEncounter: MysteryEncounter =
         })
         .withOptionPhase(async (scene: BattleScene) => {
           const encounter = scene.currentBattle.mysteryEncounter!;
-          const modifier = encounter.misc.chosenModifier;
+          const modifier = encounter.misc.chosenModifier as PokemonHeldItemModifier;
+          const party = scene.getPlayerParty();
 
           // Check tier of the traded item, the received item will be one tier up
-          const type = modifier.type.withTierFromPool();
+          const type = modifier.type.withTierFromPool(ModifierPoolType.PLAYER, party);
           let tier = type.tier ?? ModifierTier.GREAT;
           // Eggs and White Herb are not in the pool
           if (type.id === "WHITE_HERB") {
@@ -385,11 +386,11 @@ export const GlobalTradeSystemEncounter: MysteryEncounter =
             tier++;
           }
 
-          regenerateModifierPoolThresholds(scene.getPlayerParty(), ModifierPoolType.PLAYER, 0);
+          regenerateModifierPoolThresholds(party, ModifierPoolType.PLAYER, 0);
           let item: ModifierTypeOption | null = null;
           // TMs excluded from possible rewards
           while (!item || item.type.id.includes("TM_")) {
-            item = getPlayerModifierTypeOptions(1, scene.getPlayerParty(), [], { guaranteedModifierTiers: [ tier ], allowLuckUpgrades: false })[0];
+            item = getPlayerModifierTypeOptions(1, party, [], { guaranteedModifierTiers: [ tier ], allowLuckUpgrades: false })[0];
           }
 
           encounter.setDialogueToken("itemName", item.type.name);


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
When trading Soothe Bell with no event running, the ME will recognize it as Rogue Tier and give a Master Tier item in exchange
<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?
I missed that ME in PR #4775. [Discord bug report](https://discord.com/channels/1125469663833370665/1303136714172399727)
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What are the changes from a developer perspective?
Give the proper parameters to the `withTierFromPool` call
Missed that use of it initially because the modifier didn't have its proper typing so the IDE didn't recognize it as a reference to it. 😔 No more MEs should have this issue now
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos
Before, giving soothe bell would get you an Ultra Tier item:
![image](https://github.com/user-attachments/assets/cf9da1ac-fe55-4d4f-b925-42941b166e9b)

After, master tier:
![Screenshot 2024-11-05 at 13-38-48 PokéRogue](https://github.com/user-attachments/assets/6ea40432-8ab9-4035-bffa-f89ee42f5aea)

<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?

Overrides
```
MYSTERY_ENCOUNTER_OVERRIDE: MysteryEncounterType.GLOBAL_TRADE_SYSTEM,
  MYSTERY_ENCOUNTER_RATE_OVERRIDE: 255,
  STARTING_WAVE_OVERRIDE: 11,
  STARTING_BIOME_OVERRIDE: Biome.PLAINS,
  STARTING_HELD_ITEMS_OVERRIDE: [{ name: "BERRY", count: 2 }, { name: "QUICK_CLAW", count: 2 }, { name: "SOOTHE_BELL", count: 2 }]
``` 
trading an item should give you back an item one rarity tier higher

If you turn back on the event by changing the date in `timed-event-manager.ts` Soother Bell should give you an ultra item as reward. Without the event it should be master tier


<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
- ~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
