### PR TITLE
[Balance][Beta] Commander now increases double battle chance

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -6285,6 +6285,7 @@ export function initAbilities() {
       .bypassFaint(),
     new Ability(Abilities.COMMANDER, 9)
       .attr(CommanderAbAttr)
+      .attr(DoubleBattleChanceAbAttr)
       .attr(UncopiableAbilityAbAttr)
       .attr(UnswappableAbilityAbAttr)
       .edgeCase(), // Encore, Frenzy, and other non-`TURN_END` tags don't lapse correctly on the commanding Pokemon.


### PR DESCRIPTION
## What are the changes the user will see?
The ability [Commander](https://bulbapedia.bulbagarden.net/wiki/Commander_(Ability)) now quadruples the chance of encounters being double battles while the source is on the field in the same way as No Guard, Illuminate, and Arena Trap.

## Why am I making these changes?
Requested by Balance Team to offer more opportunities for Commander to activate.

## What are the changes from a developer perspective?
`data/ability`: Commander now has a `DoubleBattleChanceAbAttr`.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
Start a run with Commander Tatsugiri and pick up a lure from item rewards. The next Wild encounter should be guaranteed to be a double battle.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [n/a] Have I considered writing automated tests for the issue?
- [n/a] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [?] Are the changes visual?
  - [?] Have I provided screenshots/videos of the changes?
