### PR TITLE
[Bug] Fixing Encore's interactions with other Move Restriction moves 

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -969,14 +969,20 @@ export class EncoreTag extends MoveRestrictionBattlerTag {
     }
   }
 
-  public isMoveRestricted(move: Moves, user?: Pokemon): boolean {
+  /**
+   * Checks if the move matches the moveId stored within the tag and returns a boolean value
+   * @param move {@linkcode Moves} the move selected
+   * @param user {@linkcode Pokemon}
+   * @returns `true` if the move does not match with the moveId stored and as a result, restricted
+   */
+  override isMoveRestricted(move: Moves, _user?: Pokemon): boolean {
     if (move !== this.moveId) {
       return true;
     }
     return false;
   }
 
-  selectionDeniedText(pokemon: Pokemon, move: Moves): string {
+  override selectionDeniedText(_pokemon: Pokemon, move: Moves): string {
     return i18next.t("battle:moveDisabled", { moveName: allMoves[move].name });
   }
 

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -975,8 +975,6 @@ export class EncoreTag extends MoveRestrictionBattlerTag {
 
   /**
    * If the encored move has run out of PP, Encore ends early. Otherwise, Encore lapses based on the AFTER_MOVE battler tag lapse type.
-   * @param pokemon
-   * @param lapseType
    * @returns `true` to persist | `false` to end and be removed
    */
   override lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
@@ -994,7 +992,7 @@ export class EncoreTag extends MoveRestrictionBattlerTag {
   /**
    * Checks if the move matches the moveId stored within the tag and returns a boolean value
    * @param move {@linkcode Moves} the move selected
-   * @param user {@linkcode Pokemon}
+   * @param user N/A
    * @returns `true` if the move does not match with the moveId stored and as a result, restricted
    */
   override isMoveRestricted(move: Moves, _user?: Pokemon): boolean {

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -917,7 +917,7 @@ export class EncoreTag extends MoveRestrictionBattlerTag {
   public moveId: Moves;
 
   constructor(sourceId: number) {
-    super(BattlerTagType.ENCORE, [ BattlerTagLapseType.PRE_MOVE, BattlerTagLapseType.AFTER_MOVE ], 3, Moves.ENCORE, sourceId);
+    super(BattlerTagType.ENCORE, [ BattlerTagLapseType.CUSTOM, BattlerTagLapseType.AFTER_MOVE ], 3, Moves.ENCORE, sourceId);
   }
 
   /**
@@ -980,7 +980,7 @@ export class EncoreTag extends MoveRestrictionBattlerTag {
    * @returns `true` to persist | `false` to end and be removed
    */
   override lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
-    if (lapseType === BattlerTagLapseType.PRE_MOVE) {
+    if (lapseType === BattlerTagLapseType.CUSTOM) {
       const encoredMove = pokemon.getMoveset().find(m => m?.moveId === this.moveId);
       if (encoredMove && encoredMove?.getPpRatio() > 0) {
         return true;

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -917,7 +917,7 @@ export class EncoreTag extends MoveRestrictionBattlerTag {
   public moveId: Moves;
 
   constructor(sourceId: number) {
-    super(BattlerTagType.ENCORE, BattlerTagLapseType.AFTER_MOVE, 3, Moves.ENCORE, sourceId);
+    super(BattlerTagType.ENCORE, [ BattlerTagLapseType.PRE_MOVE, BattlerTagLapseType.AFTER_MOVE ], 3, Moves.ENCORE, sourceId);
   }
 
   /**
@@ -970,6 +970,24 @@ export class EncoreTag extends MoveRestrictionBattlerTag {
         pokemon.scene.tryReplacePhase((m => m instanceof MovePhase && m.pokemon === pokemon),
           new MovePhase(pokemon.scene, pokemon, lastMove.targets!, movesetMove)); // TODO: is this bang correct?
       }
+    }
+  }
+
+  /**
+   * If the encored move has run out of PP, Encore ends early. Otherwise, Encore lapses based on the AFTER_MOVE battler tag lapse type.
+   * @param pokemon
+   * @param lapseType
+   * @returns `true` to persist | `false` to end and be removed
+   */
+  override lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
+    if (lapseType === BattlerTagLapseType.PRE_MOVE) {
+      const encoredMove = pokemon.getMoveset().find(m => m?.moveId === this.moveId);
+      if (encoredMove && encoredMove?.getPpRatio() > 0) {
+        return true;
+      }
+      return false;
+    } else {
+      return super.lapse(pokemon, lapseType);
     }
   }
 

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -909,6 +909,10 @@ export class FrenzyTag extends BattlerTag {
   }
 }
 
+/**
+ * Applies the effects of the move Encore onto the target Pokemon
+ * Encore forces the target Pokemon to use its most-recent move for 3 turns
+ */
 export class EncoreTag extends MoveRestrictionBattlerTag {
   public moveId: Moves;
 

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -909,7 +909,7 @@ export class FrenzyTag extends BattlerTag {
   }
 }
 
-export class EncoreTag extends BattlerTag {
+export class EncoreTag extends MoveRestrictionBattlerTag {
   public moveId: Moves;
 
   constructor(sourceId: number) {
@@ -967,6 +967,17 @@ export class EncoreTag extends BattlerTag {
           new MovePhase(pokemon.scene, pokemon, lastMove.targets!, movesetMove)); // TODO: is this bang correct?
       }
     }
+  }
+
+  public isMoveRestricted(move: Moves, user?: Pokemon): boolean {
+    if (move !== this.moveId) {
+      return true;
+    }
+    return false;
+  }
+
+  selectionDeniedText(pokemon: Pokemon, move: Moves): string {
+    return i18next.t("battle:moveDisabled", { moveName: allMoves[move].name });
   }
 
   onRemove(pokemon: Pokemon): void {
@@ -2360,7 +2371,7 @@ export class HealBlockTag extends MoveRestrictionBattlerTag {
   }
 
   /**
-   * Uses DisabledTag's selectionDeniedText() message
+   * Uses its own unique selectionDeniedText() message
    */
   override selectionDeniedText(pokemon: Pokemon, move: Moves): string {
     return i18next.t("battle:moveDisabledHealBlock", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon), moveName: allMoves[move].name, healBlockName: allMoves[Moves.HEAL_BLOCK].name });

--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -1,6 +1,6 @@
 import BattleScene from "#app/battle-scene";
 import { TurnCommand, BattleType } from "#app/battle";
-import { BattlerTagLapseType, TrappedTag, EncoreTag } from "#app/data/battler-tags";
+import { TrappedTag, EncoreTag } from "#app/data/battler-tags";
 import { MoveTargetSet, getMoveTargets } from "#app/data/move";
 import { speciesStarterCosts } from "#app/data/balance/starters";
 import { Abilities } from "#app/enums/abilities";

--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -63,8 +63,8 @@ export class CommandPhase extends FieldPhase {
 
     // Checks if the Pokemon is under the effects of Encore. If so, Encore can end early if the encored move has no more PP.
     const encoreTag = this.getPokemon().getTag(BattlerTagType.ENCORE) as EncoreTag;
-    if (encoreTag && !encoreTag.lapse(this.getPokemon(), BattlerTagLapseType.CUSTOM)) {
-      this.getPokemon().removeTag(BattlerTagType.ENCORE);
+    if (encoreTag) {
+      this.getPokemon().lapseTag(BattlerTagType.ENCORE);
     }
 
     if (this.scene.currentBattle.turnCommands[this.fieldIndex]?.skip) {

--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -1,6 +1,6 @@
 import BattleScene from "#app/battle-scene";
 import { TurnCommand, BattleType } from "#app/battle";
-import { TrappedTag, EncoreTag } from "#app/data/battler-tags";
+import { TrappedTag } from "#app/data/battler-tags";
 import { MoveTargetSet, getMoveTargets } from "#app/data/move";
 import { speciesStarterCosts } from "#app/data/balance/starters";
 import { Abilities } from "#app/enums/abilities";
@@ -289,26 +289,6 @@ export class CommandPhase extends FieldPhase {
       this.scene.unshiftPhase(new CommandPhase(this.scene, 1));
       this.end();
     }
-  }
-
-  checkFightOverride(): boolean {
-    const pokemon = this.getPokemon();
-
-    const encoreTag = pokemon.getTag(EncoreTag) as EncoreTag;
-
-    if (!encoreTag) {
-      return false;
-    }
-
-    const moveIndex = pokemon.getMoveset().findIndex(m => m?.moveId === encoreTag.moveId);
-
-    if (moveIndex === -1 || !pokemon.getMoveset()[moveIndex]!.isUsable(pokemon)) { // TODO: is this bang correct?
-      return false;
-    }
-
-    this.handleCommand(Command.FIGHT, moveIndex, false);
-
-    return true;
   }
 
   getFieldIndex(): integer {

--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -1,6 +1,6 @@
 import BattleScene from "#app/battle-scene";
 import { TurnCommand, BattleType } from "#app/battle";
-import { TrappedTag } from "#app/data/battler-tags";
+import { BattlerTagLapseType, TrappedTag, EncoreTag } from "#app/data/battler-tags";
 import { MoveTargetSet, getMoveTargets } from "#app/data/move";
 import { speciesStarterCosts } from "#app/data/balance/starters";
 import { Abilities } from "#app/enums/abilities";
@@ -59,6 +59,12 @@ export class CommandPhase extends FieldPhase {
     // If the Pokemon has applied Commander's effects to its ally, skip this command
     if (this.scene.currentBattle?.double && this.getPokemon().getAlly()?.getTag(BattlerTagType.COMMANDED)?.getSourcePokemon(this.scene) === this.getPokemon()) {
       this.scene.currentBattle.turnCommands[this.fieldIndex] = { command: Command.FIGHT, move: { move: Moves.NONE, targets: []}, skip: true };
+    }
+
+    // Checks if the Pokemon is under the effects of Encore. If so, Encore can end early if the encored move has no more PP.
+    const encoreTag = this.getPokemon().getTag(BattlerTagType.ENCORE) as EncoreTag;
+    if (encoreTag && !encoreTag.lapse(this.getPokemon(), BattlerTagLapseType.CUSTOM)) {
+      this.getPokemon().removeTag(BattlerTagType.ENCORE);
     }
 
     if (this.scene.currentBattle.turnCommands[this.fieldIndex]?.skip) {

--- a/src/test/moves/encore.test.ts
+++ b/src/test/moves/encore.test.ts
@@ -1,0 +1,59 @@
+import { BattlerTagType } from "#app/enums/battler-tag-type";
+import { BattlerIndex } from "#app/battle";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Moves - Encore", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(Abilities.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH);
+  });
+
+  it("Pokemon under both Encore and Torment should alternate between Struggle and restricted move", async () => {
+    const turnOrder = [ BattlerIndex.ENEMY, BattlerIndex.PLAYER ];
+    game.override.moveset([ Moves.ENCORE, Moves.TORMENT, Moves.SPLASH ]);
+    await game.classicMode.startBattle([ Species.FEEBAS ]);
+
+    const enemyPokemon = game.scene.getEnemyPokemon();
+    game.move.select(Moves.ENCORE);
+    await game.setTurnOrder(turnOrder);
+    await game.phaseInterceptor.to("BerryPhase");
+    expect(enemyPokemon?.getTag(BattlerTagType.ENCORE)).toBeDefined();
+
+    await game.toNextTurn();
+    game.move.select(Moves.TORMENT);
+    await game.setTurnOrder(turnOrder);
+    await game.phaseInterceptor.to("BerryPhase");
+    expect(enemyPokemon?.getTag(BattlerTagType.TORMENT)).toBeDefined();
+
+    await game.toNextTurn();
+    game.move.select(Moves.SPLASH);
+    await game.setTurnOrder(turnOrder);
+    await game.phaseInterceptor.to("BerryPhase");
+    const lastMove = enemyPokemon?.getLastXMoves()[0];
+    expect(lastMove?.move).toBe(Moves.STRUGGLE);
+  });
+});

--- a/src/ui/command-ui-handler.ts
+++ b/src/ui/command-ui-handler.ts
@@ -90,9 +90,6 @@ export default class CommandUiHandler extends UiHandler {
         switch (cursor) {
         // Fight
           case Command.FIGHT:
-            if ((this.scene.getCurrentPhase() as CommandPhase).checkFightOverride()) {
-              return true;
-            }
             ui.setMode(Mode.FIGHT, (this.scene.getCurrentPhase() as CommandPhase).getFieldIndex());
             success = true;
             break;


### PR DESCRIPTION
## What are the changes the user will see?
Encore will interact correctly with other Move Restriction moves like Torment and Disable. Previously, it would override them and allow the use of restricted moves. 

## Why am I making these changes?
A bug a day keeps the shareholders and the triage team happy. 
See #4745 

## What are the changes from a developer perspective?
Because Encore was implemented before the introduction of the MoveRestrictionBattlerTag class, it had a separate implementation from other Move Restriction moves. Encore would override any other move restriction battler tags as result. This PR converts Encore into a MoveRestrictionBattlerTag and removes checkFightOverride() --> which was specifically only used to execute Encore's effects. Now, Encore uses the same 'scaffolding' as move restriction battler tags. 

A test was created for Encore's interactions with other tags of MoveRestrictionBattlerTag.

### Screenshots/Videos

https://github.com/user-attachments/assets/77a807f0-0296-4b09-9e42-6062da36bb11


## How to test the changes?
1. Apply Encore and a move-restriction move on a target with a single move. 
2. Target should use Struggle depending on the move + quality of the move-restriction  

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
