### PR TITLE
[Bug] Prevents crash from using Sketch against a lost turn 

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6748,7 +6748,7 @@ export class SketchAttr extends MoveEffectAttr {
       return false;
     }
 
-    const targetMove = target.getLastXMoves(target.battleSummonData.turnCount)
+    const targetMove = target.getLastXMoves(target.battleSummonData.turnCount).reverse()
       .find(m => m.move !== Moves.NONE && m.move !== Moves.STRUGGLE && !m.virtual);
     if (!targetMove) {
       return false;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6748,7 +6748,7 @@ export class SketchAttr extends MoveEffectAttr {
       return false;
     }
 
-    const targetMove = target.getLastXMoves()
+    const targetMove = target.getLastXMoves(target.battleSummonData.turnCount)
       .find(m => m.move !== Moves.NONE && m.move !== Moves.STRUGGLE && !m.virtual);
     if (!targetMove) {
       return false;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6748,7 +6748,7 @@ export class SketchAttr extends MoveEffectAttr {
       return false;
     }
 
-    const targetMove = target.getLastXMoves(target.battleSummonData.turnCount).reverse()
+    const targetMove = target.getLastXMoves(target.battleSummonData.turnCount)
       .find(m => m.move !== Moves.NONE && m.move !== Moves.STRUGGLE && !m.virtual);
     if (!targetMove) {
       return false;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6749,7 +6749,7 @@ export class SketchAttr extends MoveEffectAttr {
     }
 
     const targetMove = target.getMoveHistory().filter(m => !m.virtual).at(-1);
-    if (!targetMove || (targetMove.result === MoveResult.FAIL || targetMove.result === MoveResult.OTHER)) {
+    if (!targetMove || (targetMove.result === MoveResult.FAIL || targetMove.result === MoveResult.OTHER) || targetMove.move === Moves.STRUGGLE) {
       return false;
     }
 

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6748,8 +6748,9 @@ export class SketchAttr extends MoveEffectAttr {
       return false;
     }
 
-    const targetMove = target.getMoveHistory().filter(m => !m.virtual).at(-1);
-    if (!targetMove || (targetMove.result === MoveResult.FAIL || targetMove.result === MoveResult.OTHER) || targetMove.move === Moves.STRUGGLE) {
+    const targetMove = target.getLastXMoves()
+      .find(m => m.move !== Moves.NONE && m.move !== Moves.STRUGGLE && !m.virtual);
+    if (!targetMove) {
       return false;
     }
 

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6749,7 +6749,7 @@ export class SketchAttr extends MoveEffectAttr {
     }
 
     const targetMove = target.getMoveHistory().filter(m => !m.virtual).at(-1);
-    if (!targetMove) {
+    if (!targetMove || (targetMove.result === MoveResult.FAIL || targetMove.result === MoveResult.OTHER)) {
       return false;
     }
 


### PR DESCRIPTION
## What are the changes the user will see?
Sketch should no longer crash the game when it tries to copy a move from a lost turn. 

## Why am I making these changes?
A bug a day...
See #4610 

## What are the changes from a developer perspective?
Added some conditional checks to SketchAttr, but more research is needed to be done on what Sketch can copy and what it cannot. Throwing into draft.

Will write a test as well. 

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
