### PR TITLE
[Dev] Sessions will now sync with the server at the start of every wave

### DIFF
--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -226,7 +226,7 @@ export class EncounterPhase extends BattlePhase {
       this.scene.ui.setMode(Mode.MESSAGE).then(() => {
         if (!this.loaded) {
           this.trySetWeatherIfNewBiome(); // Set weather before session gets saved
-          this.scene.gameData.saveAll(this.scene, true, battle.waveIndex % 10 === 1 || (this.scene.lastSavePlayTime ?? 0) >= 300).then(success => {
+          this.scene.gameData.saveAll(this.scene, true, true).then(success => {
             this.scene.disableMenu = false;
             if (!success) {
               return this.scene.reset(true);


### PR DESCRIPTION
## What are the changes the user will see?
None, ideally. 

## Why am I making these changes?
Requested. 

## What are the changes from a developer perspective?
The updateAll function call found in encounter-phase had a conditional to determine whether the game should sync to the server or not. It has been replaced with a 'true'.

## How to test the changes?
1. Play a wave or 2. 
2. Change devices when starting a new wave.
3. New device should have that new wave. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
