### PR TITLE
[Move] Implement Ally Switch 

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6748,7 +6748,7 @@ export class SketchAttr extends MoveEffectAttr {
       return false;
     }
 
-    const targetMove = target.getLastXMoves(target.battleSummonData.turnCount)
+    const targetMove = target.getLastXMoves(target.battleSummonData.turnCount).reverse()
       .find(m => m.move !== Moves.NONE && m.move !== Moves.STRUGGLE && !m.virtual);
     if (!targetMove) {
       return false;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6748,7 +6748,7 @@ export class SketchAttr extends MoveEffectAttr {
       return false;
     }
 
-    const targetMove = target.getLastXMoves()
+    const targetMove = target.getLastXMoves(target.battleSummonData.turnCount)
       .find(m => m.move !== Moves.NONE && m.move !== Moves.STRUGGLE && !m.virtual);
     if (!targetMove) {
       return false;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6748,7 +6748,7 @@ export class SketchAttr extends MoveEffectAttr {
       return false;
     }
 
-    const targetMove = target.getLastXMoves(target.battleSummonData.turnCount).reverse()
+    const targetMove = target.getLastXMoves(target.battleSummonData.turnCount)
       .find(m => m.move !== Moves.NONE && m.move !== Moves.STRUGGLE && !m.virtual);
     if (!targetMove) {
       return false;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6749,7 +6749,7 @@ export class SketchAttr extends MoveEffectAttr {
     }
 
     const targetMove = target.getMoveHistory().filter(m => !m.virtual).at(-1);
-    if (!targetMove || (targetMove.result === MoveResult.FAIL || targetMove.result === MoveResult.OTHER)) {
+    if (!targetMove || (targetMove.result === MoveResult.FAIL || targetMove.result === MoveResult.OTHER) || targetMove.move === Moves.STRUGGLE) {
       return false;
     }
 

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6748,8 +6748,9 @@ export class SketchAttr extends MoveEffectAttr {
       return false;
     }
 
-    const targetMove = target.getMoveHistory().filter(m => !m.virtual).at(-1);
-    if (!targetMove || (targetMove.result === MoveResult.FAIL || targetMove.result === MoveResult.OTHER) || targetMove.move === Moves.STRUGGLE) {
+    const targetMove = target.getLastXMoves()
+      .find(m => m.move !== Moves.NONE && m.move !== Moves.STRUGGLE && !m.virtual);
+    if (!targetMove) {
       return false;
     }
 

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6749,7 +6749,7 @@ export class SketchAttr extends MoveEffectAttr {
     }
 
     const targetMove = target.getMoveHistory().filter(m => !m.virtual).at(-1);
-    if (!targetMove) {
+    if (!targetMove || (targetMove.result === MoveResult.FAIL || targetMove.result === MoveResult.OTHER)) {
       return false;
     }
 


### PR DESCRIPTION
## What are the changes the user will see?
The user can now use Ally Switch in battle. 

## Why am I making these changes?
Shareholder value up. 

## What are the changes from a developer perspective?
New AllySwitchAttr (child of MoveEffectAttr)
Will add a test. 

Localization PR here: https://github.com/pagefaultgames/pokerogue-locales/pull/46

### Screenshots/Videos

https://github.com/user-attachments/assets/2d4bea48-e642-49b7-8575-a239fac2161c


## How to test the changes?
1. Go into a doubles battle and use Ally Swap. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
