### PR TITLE
[Bug] Boss segments will no longer block healing

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -5079,26 +5079,6 @@ export class EnemyPokemon extends Pokemon {
     }
   }
 
-  heal(amount: integer): integer {
-    if (this.isBoss()) {
-      const amountRatio = amount / this.getMaxHp();
-      const segmentBypassCount = Math.floor(amountRatio / (1 / this.bossSegments));
-      const segmentSize = this.getMaxHp() / this.bossSegments;
-      for (let s = 1; s < this.bossSegments; s++) {
-        const hpThreshold = segmentSize * s;
-        if (this.hp <= Math.round(hpThreshold)) {
-          const healAmount = Math.min(amount, this.getMaxHp() - this.hp, Math.round(hpThreshold + (segmentSize * segmentBypassCount) - this.hp));
-          this.hp += healAmount;
-          return healAmount;
-        } else if (s >= this.bossSegmentIndex) {
-          return super.heal(amount);
-        }
-      }
-    }
-
-    return super.heal(amount);
-  }
-
   getFieldIndex(): integer {
     return this.scene.getEnemyField().indexOf(this);
   }


### PR DESCRIPTION
## What are the changes the user will see?
Boss pokemon will now heal the expected numerical value regardless of segments. (Grassy Terrain 1/16 * maxHp, Recover - 1/2 * maxHp, etc.)
Probably has a significant impact on difficulty.

## Why am I making these changes?
Fixes #1488
Corresponding discussion on discord: https://discord.com/channels/1125469663833370665/1176874654015684739/1304274351297659013

## What are the changes from a developer perspective?
Removed EnemyPokemon.heal() overload. Now defaulting to Pokemon.heal()

## How to test the changes?
- Set overrides
```js
const overrides = {
  OPP_HEALTH_SEGMENTS_OVERRIDE: 3,
  OPP_MOVESET_OVERRIDE: Moves.GRASSY_TERRAIN,
}
```

(Should probably get playtested in a normal run)

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
