### PR TITLE
[P2][Beta] Fix Sketch failing to sketch Metronome et al

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -6362,10 +6362,17 @@ export class RandomMovesetMoveAttr extends OverrideMoveEffectAttr {
 }
 
 export class RandomMoveAttr extends OverrideMoveEffectAttr {
+  /**
+   * This function exists solely to allow tests to override the randomly selected move by mocking this function.
+   */
+  public getMoveOverride(): Moves | null {
+    return null;
+  }
+
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): Promise<boolean> {
     return new Promise(resolve => {
       const moveIds = Utils.getEnumValues(Moves).filter(m => !allMoves[m].hasFlag(MoveFlags.IGNORE_VIRTUAL) && !allMoves[m].name.endsWith(" (N)"));
-      const moveId = moveIds[user.randSeedInt(moveIds.length)];
+      const moveId = this.getMoveOverride() ?? moveIds[user.randSeedInt(moveIds.length)];
 
       const moveTargets = getMoveTargets(user, moveId);
       if (!moveTargets.targets.length) {
@@ -6748,7 +6755,7 @@ export class SketchAttr extends MoveEffectAttr {
       return false;
     }
 
-    const targetMove = target.getLastXMoves(target.battleSummonData.turnCount)
+    const targetMove = target.getLastXMoves(-1)
       .find(m => m.move !== Moves.NONE && m.move !== Moves.STRUGGLE && !m.virtual);
     if (!targetMove) {
       return false;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3220,9 +3220,19 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     this.getMoveHistory().push(turnMove);
   }
 
-  getLastXMoves(turnCount: integer = 0): TurnMove[] {
+  /**
+   * Returns a list of the most recent move entries in this Pokemon's move history.
+   * The retrieved move entries are sorted in order from NEWEST to OLDEST.
+   * @param turnCount The number of move entries to retrieve. If `0`, retrieve exactly 1 move entry. If negative, retrieve the Pokemon's entire move history. Default is `1`.
+   * @returns A list of {@linkcode TurnMove}, as specified above.
+   */
+  getLastXMoves(turnCount: integer = 1): TurnMove[] {
     const moveHistory = this.getMoveHistory();
-    return moveHistory.slice(turnCount >= 0 ? Math.max(moveHistory.length - (turnCount || 1), 0) : 0, moveHistory.length).reverse();
+    if (turnCount >= 0) {
+      return moveHistory.slice(Math.max(moveHistory.length - (turnCount || 1), 0)).reverse();
+    } else {
+      return moveHistory.slice(0).reverse();
+    }
   }
 
   getMoveQueue(): QueuedMove[] {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3223,13 +3223,15 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Returns a list of the most recent move entries in this Pokemon's move history.
    * The retrieved move entries are sorted in order from NEWEST to OLDEST.
-   * @param turnCount The number of move entries to retrieve. If negative, retrieve the Pokemon's entire move history. Default is `1`.
+   * @param moveCount The number of move entries to retrieve.
+   *   If negative, retrieve the Pokemon's entire move history (equivalent to reversing the output of {@linkcode getMoveHistory()}).
+   *   Default is `1`.
    * @returns A list of {@linkcode TurnMove}, as specified above.
    */
-  getLastXMoves(turnCount: number = 1): TurnMove[] {
+  getLastXMoves(moveCount: number = 1): TurnMove[] {
     const moveHistory = this.getMoveHistory();
-    if (turnCount >= 0) {
-      return moveHistory.slice(Math.max(moveHistory.length - turnCount, 0)).reverse();
+    if (moveCount >= 0) {
+      return moveHistory.slice(Math.max(moveHistory.length - moveCount, 0)).reverse();
     } else {
       return moveHistory.slice(0).reverse();
     }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3223,13 +3223,13 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Returns a list of the most recent move entries in this Pokemon's move history.
    * The retrieved move entries are sorted in order from NEWEST to OLDEST.
-   * @param turnCount The number of move entries to retrieve. If `0`, retrieve exactly 1 move entry. If negative, retrieve the Pokemon's entire move history. Default is `1`.
+   * @param turnCount The number of move entries to retrieve. If negative, retrieve the Pokemon's entire move history. Default is `1`.
    * @returns A list of {@linkcode TurnMove}, as specified above.
    */
-  getLastXMoves(turnCount: integer = 1): TurnMove[] {
+  getLastXMoves(turnCount: number = 1): TurnMove[] {
     const moveHistory = this.getMoveHistory();
     if (turnCount >= 0) {
-      return moveHistory.slice(Math.max(moveHistory.length - (turnCount || 1), 0)).reverse();
+      return moveHistory.slice(Math.max(moveHistory.length - turnCount, 0)).reverse();
     } else {
       return moveHistory.slice(0).reverse();
     }

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -728,10 +728,10 @@ export abstract class PokemonHeldItemModifier extends PersistentModifier {
   //Applies to items with chance of activating secondary effects ie Kings Rock
   getSecondaryChanceMultiplier(pokemon: Pokemon): number {
     // Temporary quickfix to stop game from freezing when the opponet uses u-turn while holding on to king's rock
-    if (!pokemon.getLastXMoves(0)[0]) {
+    if (!pokemon.getLastXMoves()[0]) {
       return 1;
     }
-    const sheerForceAffected = allMoves[pokemon.getLastXMoves(0)[0].move].chance >= 0 && pokemon.hasAbility(Abilities.SHEER_FORCE);
+    const sheerForceAffected = allMoves[pokemon.getLastXMoves()[0].move].chance >= 0 && pokemon.hasAbility(Abilities.SHEER_FORCE);
 
     if (sheerForceAffected) {
       return 0;


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
Sketch can successfully sketch Metronome and some other moves that call other moves virtually.

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Fixing a bug newly introduced by #4806.

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
1. `SketchAttr` no longer places a limit on the number of moves retrieved by `getLastXMoves()`. The limit did not properly account for situations where a Pokemon's move history can receive multiple entries in 1 turn. For example, Metronome adds 1 move entry for Metronome itself, then another entry for the randomly selected move.
2. Made `getLastXMoves()` more readable.
3. Added a Sketch test.
    a. `RandomMoveAttr` can now have its randomly selected move overridden in tests.
    b. Enabled a Sap Sipper test that needed the ability to override `RandomMoveAttr`.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
<details>
<summary> Before the changes: Sketch fails (silently) when sketching Metronome </summary>

https://github.com/user-attachments/assets/eff39e03-9a3f-4741-b73c-a64b1c445dca

</details>
<details>
<summary> After the changes: Sketch properly sketches Metronome </summary>

https://github.com/user-attachments/assets/0c42ca44-4432-4290-86d7-332eebecf7f7

</details>
<details>
<summary> After the changes: Sketch still behaves properly if its target lost a turn (e.g., due to sleep) </summary>

https://github.com/user-attachments/assets/f19a0daf-a725-4af2-9239-8028c36a3df9

</details>


## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
`npm run test sketch`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~~[ ] Are the changes visual?~~
  - [x] Have I provided screenshots/videos of the changes?
