### PR TITLE
[Bug][Beta] Fix Commander implementation bugs

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -773,7 +773,7 @@ export default class BattleScene extends SceneBase {
 
   /**
    * @returns An array of {@linkcode PlayerPokemon} filtered from the player's party
-   * that are {@linkcode PlayerPokemon.isAllowedInBattle | allowed in battle}.
+   * that are {@linkcode Pokemon.isAllowedInBattle | allowed in battle}.
    */
   public getPokemonAllowedInBattle(): PlayerPokemon[] {
     return this.getPlayerParty().filter(p => p.isAllowedInBattle());
@@ -1242,14 +1242,20 @@ export default class BattleScene extends SceneBase {
 
     const lastBattle = this.currentBattle;
 
-    if (lastBattle?.double && !newDouble) {
-      this.tryRemovePhase(p => p instanceof SwitchPhase);
-    }
-
     const maxExpLevel = this.getMaxExpLevel();
 
     this.lastEnemyTrainer = lastBattle?.trainer ?? null;
     this.lastMysteryEncounter = lastBattle?.mysteryEncounter;
+
+    if (newBattleType === BattleType.MYSTERY_ENCOUNTER) {
+      // Disable double battle on mystery encounters (it may be re-enabled as part of encounter)
+      newDouble = false;
+    }
+
+    if (lastBattle?.double && !newDouble) {
+      this.tryRemovePhase(p => p instanceof SwitchPhase);
+      this.getPlayerField().forEach(p => p.lapseTag(BattlerTagType.COMMANDED));
+    }
 
     this.executeWithSeedOffset(() => {
       this.currentBattle = new Battle(this.gameMode, newWaveIndex, newBattleType, newTrainer, newDouble);
@@ -1257,8 +1263,6 @@ export default class BattleScene extends SceneBase {
     this.currentBattle.incrementTurn(this);
 
     if (newBattleType === BattleType.MYSTERY_ENCOUNTER) {
-      // Disable double battle on mystery encounters (it may be re-enabled as part of encounter)
-      this.currentBattle.double = false;
       // Will generate the actual Mystery Encounter during NextEncounterPhase, to ensure it uses proper biome
       this.currentBattle.mysteryEncounterType = mysteryEncounterType;
     }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -22,7 +22,7 @@ import { reverseCompatibleTms, tmSpecies, tmPoolTiers } from "#app/data/balance/
 import { BattlerTag, BattlerTagLapseType, EncoreTag, GroundedTag, HighestStatBoostTag, SubstituteTag, TypeImmuneTag, getBattlerTag, SemiInvulnerableTag, TypeBoostTag, MoveRestrictionBattlerTag, ExposedTag, DragonCheerTag, CritBoostTag, TrappedTag, TarShotTag, AutotomizedTag, PowerTrickTag } from "../data/battler-tags";
 import { WeatherType } from "#app/data/weather";
 import { ArenaTagSide, NoCritTag, WeakenMoveScreenTag } from "#app/data/arena-tag";
-import { Ability, AbAttr, StatMultiplierAbAttr, BlockCritAbAttr, BonusCritAbAttr, BypassBurnDamageReductionAbAttr, FieldPriorityMoveImmunityAbAttr, IgnoreOpponentStatStagesAbAttr, MoveImmunityAbAttr, PreDefendFullHpEndureAbAttr, ReceivedMoveDamageMultiplierAbAttr, StabBoostAbAttr, StatusEffectImmunityAbAttr, TypeImmunityAbAttr, WeightMultiplierAbAttr, allAbilities, applyAbAttrs, applyStatMultiplierAbAttrs, applyPreApplyBattlerTagAbAttrs, applyPreAttackAbAttrs, applyPreDefendAbAttrs, applyPreSetStatusAbAttrs, UnsuppressableAbilityAbAttr, SuppressFieldAbilitiesAbAttr, NoFusionAbilityAbAttr, MultCritAbAttr, IgnoreTypeImmunityAbAttr, DamageBoostAbAttr, IgnoreTypeStatusEffectImmunityAbAttr, ConditionalCritAbAttr, applyFieldStatMultiplierAbAttrs, FieldMultiplyStatAbAttr, AddSecondStrikeAbAttr, UserFieldStatusEffectImmunityAbAttr, UserFieldBattlerTagImmunityAbAttr, BattlerTagImmunityAbAttr, MoveTypeChangeAbAttr, FullHpResistTypeAbAttr, applyCheckTrappedAbAttrs, CheckTrappedAbAttr, PostSetStatusAbAttr, applyPostSetStatusAbAttrs, InfiltratorAbAttr, AlliedFieldDamageReductionAbAttr, PostDamageAbAttr, applyPostDamageAbAttrs, PostDamageForceSwitchAbAttr } from "#app/data/ability";
+import { Ability, AbAttr, StatMultiplierAbAttr, BlockCritAbAttr, BonusCritAbAttr, BypassBurnDamageReductionAbAttr, FieldPriorityMoveImmunityAbAttr, IgnoreOpponentStatStagesAbAttr, MoveImmunityAbAttr, PreDefendFullHpEndureAbAttr, ReceivedMoveDamageMultiplierAbAttr, StabBoostAbAttr, StatusEffectImmunityAbAttr, TypeImmunityAbAttr, WeightMultiplierAbAttr, allAbilities, applyAbAttrs, applyStatMultiplierAbAttrs, applyPreApplyBattlerTagAbAttrs, applyPreAttackAbAttrs, applyPreDefendAbAttrs, applyPreSetStatusAbAttrs, UnsuppressableAbilityAbAttr, SuppressFieldAbilitiesAbAttr, NoFusionAbilityAbAttr, MultCritAbAttr, IgnoreTypeImmunityAbAttr, DamageBoostAbAttr, IgnoreTypeStatusEffectImmunityAbAttr, ConditionalCritAbAttr, applyFieldStatMultiplierAbAttrs, FieldMultiplyStatAbAttr, AddSecondStrikeAbAttr, UserFieldStatusEffectImmunityAbAttr, UserFieldBattlerTagImmunityAbAttr, BattlerTagImmunityAbAttr, MoveTypeChangeAbAttr, FullHpResistTypeAbAttr, applyCheckTrappedAbAttrs, CheckTrappedAbAttr, PostSetStatusAbAttr, applyPostSetStatusAbAttrs, InfiltratorAbAttr, AlliedFieldDamageReductionAbAttr, PostDamageAbAttr, applyPostDamageAbAttrs, PostDamageForceSwitchAbAttr, CommanderAbAttr } from "#app/data/ability";
 import PokemonData from "#app/system/pokemon-data";
 import { BattlerIndex } from "#app/battle";
 import { Mode } from "#app/ui/ui";
@@ -3078,7 +3078,10 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   lapseTag(tagType: BattlerTagType): boolean {
-    const tags = this.summonData.tags;
+    const tags = this.summonData?.tags;
+    if (isNullOrUndefined(tags)) {
+      return false;
+    }
     const tag = tags.find(t => t.tagType === tagType);
     if (tag && !(tag.lapse(this, BattlerTagLapseType.CUSTOM))) {
       tag.onRemove(this);
@@ -3642,6 +3645,13 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       if (this.getTag(SubstituteTag)) {
         this.scene.triggerPokemonBattleAnim(this, PokemonAnimType.SUBSTITUTE_ADD);
         this.getTag(SubstituteTag)!.sourceInFocus = false;
+      }
+
+      // If this Pokemon has Commander and Dondozo as an active ally, hide this Pokemon's sprite.
+      if (this.hasAbilityWithAttr(CommanderAbAttr)
+          && this.scene.currentBattle.double
+          && this.getAlly()?.species.speciesId === Species.DONDOZO) {
+        this.setVisible(false);
       }
       this.summonDataPrimer = null;
     }

--- a/src/phases/check-switch-phase.ts
+++ b/src/phases/check-switch-phase.ts
@@ -26,25 +26,29 @@ export class CheckSwitchPhase extends BattlePhase {
 
     const pokemon = this.scene.getPlayerField()[this.fieldIndex];
 
+    // End this phase early...
+
+    // ...if the user is playing in Set Mode
     if (this.scene.battleStyle === BattleStyle.SET) {
-      super.end();
-      return;
+      return super.end();
     }
 
+    // ...if the checked Pokemon is somehow not on the field
     if (this.scene.field.getAll().indexOf(pokemon) === -1) {
       this.scene.unshiftPhase(new SummonMissingPhase(this.scene, this.fieldIndex));
-      super.end();
-      return;
+      return super.end();
     }
 
+    // ...if there are no other allowed Pokemon in the player's party to switch with
     if (!this.scene.getPlayerParty().slice(1).filter(p => p.isActive()).length) {
-      super.end();
-      return;
+      return super.end();
     }
 
-    if (pokemon.getTag(BattlerTagType.FRENZY)) {
-      super.end();
-      return;
+    // ...or if any player Pokemon has an effect that prevents the checked Pokemon from switching
+    if (pokemon.getTag(BattlerTagType.FRENZY)
+        || pokemon.isTrapped()
+        || this.scene.getPlayerField().some(p => p.getTag(BattlerTagType.COMMANDED))) {
+      return super.end();
     }
 
     this.scene.ui.showText(i18next.t("battle:switchQuestion", { pokemonName: this.useName ? getPokemonNameWithAffix(pokemon) : i18next.t("battle:pokemon") }), null, () => {

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -36,7 +36,6 @@ import { PlayerGender } from "#enums/player-gender";
 import { Species } from "#enums/species";
 import i18next from "i18next";
 import { WEIGHT_INCREMENT_ON_SPAWN_MISS } from "#app/data/mystery-encounters/mystery-encounters";
-import { BattlerTagType } from "#enums/battler-tag-type";
 
 export class EncounterPhase extends BattlePhase {
   private loaded: boolean;
@@ -483,7 +482,6 @@ export class EncounterPhase extends BattlePhase {
         }
       } else {
         if (availablePartyMembers.length > 1 && availablePartyMembers[1].isOnField()) {
-          this.scene.getPlayerField().forEach((pokemon) => pokemon.lapseTag(BattlerTagType.COMMANDED));
           this.scene.pushPhase(new ReturnPhase(this.scene, 1));
         }
         this.scene.pushPhase(new ToggleDoublePositionPhase(this.scene, false));


### PR DESCRIPTION
## What are the changes the user will see?
This fixes several bugs introduced with Commander's implementation:
- **(P1)** Fixed a bug where trying to remove Commander's effects at the end of some Mystery Encounters, even if Commander isn't present, would crash the game.
- (P2) Fixed a bug where self trapping effects including Commander, No Retreat, and Ingrain would not prevent the affected Pokemon from being given a prompt to switch out at the start of battle.
- (P3) Fixed some bugs with Tatsugiri's appearance in a few situations:
  - when reloading a game where Tatsugiri is commanding Dondozo at the start of a wave.
  - when transitioning from a double battle to a single battle.

## Why am I making these changes?
These bugs were reported after @damocleas did some stress testing on Commander's implementation. One of the reports is available on the Discord [here](https://discord.com/channels/1125469663833370665/1304502236138962974).

## What are the changes from a developer perspective?
- Moved a call to lapse `COMMANDED` tags from `EncounterPhase` to `BattleScene#newBattle`. Previously, the game would try to lapse tags based on the "current" wave's battle type when `currentBattle` was already adjusted for the next wave.
- `field/pokemon`:
  - `Pokemon.lapseTag` now does nothing if `summonData` is undefined instead of crashing the game.
  - `Pokemon.resetSummonData`, if given a primer, now makes Tatsugiri invisible if it has Commander and an ally Dondozo is on the field.
- `phases/check-switch-phase`: `CheckSwitchPhase` now ends before prompting a switch if the respective Pokemon is trapped (e.g. by No Retreat) or if any Pokemon on the Pokemon's side is being commanded.

### Screenshots/Videos

<details>
<summary>Game no longer crashes when exiting an ME </summary>

https://github.com/user-attachments/assets/0a0316f0-ebc7-4d88-9303-4ff92eac19f1

</details>

<details>
<summary>Visual fixes on loading the game with a commanding Tatsugiri</summary>

https://github.com/user-attachments/assets/b95d8b43-aac9-420b-8aaf-7d01493f2c06

</details>

<details>
<summary>Fixed missing animation in transition from double to single battle</summary>

https://github.com/user-attachments/assets/4ad1be2c-47c5-455f-baa7-4915a1748852

</details>

## How to test the changes?

- To test the ME bug, set the following overrides in `src/overrides.ts`:
  ```ts
  STARTING_WAVE_OVERRIDE: 11,
  STARTING_BIOME_OVERRIDE: Biome.PLAINS,
  MYSTERY_ENCOUNTER_RATE_OVERRIDE: 256,
  MYSTERY_ENCOUNTER_OVERRIDE: MysteryEncounterType.GLOBAL_TRADE_SYSTEM
  ```
  Start a Classic run and leave the GTS. The mystery encounter should end without crashing the game.
- To test other bugs, start a run with the following party (preferably in exact order):
  1. Tatsugiri with Commander
  2. Dondozo
  3. Any other Pokemon
  
  You should be able to observe the changes at different points in battle:
  - In the second consecutive double battle after Tatsugiri starts commanding Dondozo, neither Pokemon should be prompted to switch. When reloading the game at this point, Tatsugiri should be invisible when entering the field.
  - Tatsugiri's visibility should now be more consistent in transitions between single and double battles.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
