### PR TITLE
[P2] Removed incorrect calls to `resetBattleData` on switchout

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4029,8 +4029,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     this.resetTurnData();
     if (clearEffects) {
       this.destroySubstitute();
-      this.resetSummonData();
-      this.resetBattleData();
+      this.resetSummonData(); // this also calls `resetBattleSummonData`
     }
     if (hideInfo) {
       this.hideInfo();

--- a/src/phases/switch-summon-phase.ts
+++ b/src/phases/switch-summon-phase.ts
@@ -138,7 +138,6 @@ export class SwitchSummonPhase extends SummonPhase {
             switchedInPokemon.setAlpha(0.5);
           }
         } else {
-          switchedInPokemon.resetBattleData();
           switchedInPokemon.resetSummonData();
         }
         this.summon();


### PR DESCRIPTION
## What are the changes the user will see?
A few effects will now correctly persist when the Pokemon switches out, including:
- Rage Fist's power boost upon getting hit by an attack
- Belch's condition requiring the user to have eaten a berry
- A list of abilities applied during battle. This is relevant for Intrepid Sword and similar abilities, which will now only activate once per battle.

## Why am I making these changes?
`battleData` was being misused so that it was managed in basically the same way as `battleSummonData`. (closes #4708)

## What are the changes from a developer perspective?
Removed `Pokemon.resetBattleData` calls from `Pokemon.leaveField` and `SwitchSummonPhase.preSummon`

### Screenshots/Videos

## How to test the changes?

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [ ] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
