### PR TITLE
[Test] Fix flaky Wimp Out test

### DIFF
--- a/src/test/abilities/wimp_out.test.ts
+++ b/src/test/abilities/wimp_out.test.ts
@@ -296,7 +296,9 @@ describe("Abilities - Wimp Out", () => {
       Species.TYRUNT
     ]);
 
-    game.move.select(Moves.SPLASH);
+    game.scene.getPlayerPokemon()!.hp *= 0.51;
+
+    game.move.select(Moves.ENDURE);
     await game.phaseInterceptor.to("TurnEndPhase");
 
     confirmNoSwitch();


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Test was flaky.

## What are the changes from a developer perspective?
HP is now set within the test.

## How to test the changes?
`npm run test wimp_out`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
