### PR TITLE
[Telemetry][Misc] Client-Side changes to log run results at the end of runs

### DIFF
--- a/src/@types/PokerogueSessionSavedataApi.ts
+++ b/src/@types/PokerogueSessionSavedataApi.ts
@@ -8,8 +8,8 @@ export class UpdateSessionSavedataRequest {
 /** This is **NOT** similar to {@linkcode ClearSessionSavedataRequest}  */
 export interface NewClearSessionSavedataRequest {
   slot: number;
-  clientSessionId: string;
   result: boolean;
+  clientSessionId: string;
 }
 
 export interface GetSessionSavedataRequest {

--- a/src/@types/PokerogueSessionSavedataApi.ts
+++ b/src/@types/PokerogueSessionSavedataApi.ts
@@ -1,5 +1,3 @@
-import { GameModes } from "#app/game-mode";
-
 export class UpdateSessionSavedataRequest {
   slot: number;
   trainerId: number;
@@ -12,7 +10,6 @@ export interface NewClearSessionSavedataRequest {
   slot: number;
   clientSessionId: string;
   result: boolean;
-  gameMode: GameModes;
 }
 
 export interface GetSessionSavedataRequest {

--- a/src/@types/PokerogueSessionSavedataApi.ts
+++ b/src/@types/PokerogueSessionSavedataApi.ts
@@ -8,7 +8,7 @@ export class UpdateSessionSavedataRequest {
 /** This is **NOT** similar to {@linkcode ClearSessionSavedataRequest}  */
 export interface NewClearSessionSavedataRequest {
   slot: number;
-  result: boolean;
+  isVictory: boolean;
   clientSessionId: string;
 }
 

--- a/src/@types/PokerogueSessionSavedataApi.ts
+++ b/src/@types/PokerogueSessionSavedataApi.ts
@@ -1,3 +1,5 @@
+import { GameModes } from "#app/game-mode";
+
 export class UpdateSessionSavedataRequest {
   slot: number;
   trainerId: number;
@@ -9,6 +11,8 @@ export class UpdateSessionSavedataRequest {
 export interface NewClearSessionSavedataRequest {
   slot: number;
   clientSessionId: string;
+  result: boolean;
+  gameMode: GameModes;
 }
 
 export interface GetSessionSavedataRequest {

--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -178,7 +178,7 @@ export class GameOverPhase extends BattlePhase {
       If Offline, execute offlineNewClear(), a localStorage implementation of newClear daily run checks */
     if (this.victory) {
       if (!Utils.isLocal || Utils.isLocalServerConnected) {
-        pokerogueApi.savedata.session.newclear({ slot: this.scene.sessionSlotId, clientSessionId, result: this.victory, gameMode: this.scene.gameMode.modeId })
+        pokerogueApi.savedata.session.newclear({ slot: this.scene.sessionSlotId, clientSessionId, result: this.victory })
           .then((success) => doGameOver(!!success));
       } else {
         this.scene.gameData.offlineNewClear(this.scene).then(result => {

--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -29,10 +29,10 @@ export class GameOverPhase extends BattlePhase {
   private isVictory: boolean;
   private firstRibbons: PokemonSpecies[] = [];
 
-  constructor(scene: BattleScene, victory?: boolean) {
+  constructor(scene: BattleScene, victory: boolean = false) {
     super(scene);
 
-    this.isVictory = !!victory;
+    this.isVictory = victory;
   }
 
   start() {

--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -178,7 +178,7 @@ export class GameOverPhase extends BattlePhase {
       If Offline, execute offlineNewClear(), a localStorage implementation of newClear daily run checks */
     if (this.victory) {
       if (!Utils.isLocal || Utils.isLocalServerConnected) {
-        pokerogueApi.savedata.session.newclear({ slot: this.scene.sessionSlotId, clientSessionId })
+        pokerogueApi.savedata.session.newclear({ slot: this.scene.sessionSlotId, clientSessionId, result: this.victory, gameMode: this.scene.gameMode.modeId })
           .then((success) => doGameOver(!!success));
       } else {
         this.scene.gameData.offlineNewClear(this.scene).then(result => {

--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -179,12 +179,10 @@ export class GameOverPhase extends BattlePhase {
     if (!Utils.isLocal || Utils.isLocalServerConnected) {
       pokerogueApi.savedata.session.newclear({ slot: this.scene.sessionSlotId, isVictory: this.isVictory, clientSessionId: clientSessionId })
         .then((success) => doGameOver(!!success));
-    } else {
-      if (this.isVictory) {
-        this.scene.gameData.offlineNewClear(this.scene).then(result => {
-          doGameOver(result);
-        });
-      }
+    } else if (this.isVictory) {
+      this.scene.gameData.offlineNewClear(this.scene).then(result => {
+        doGameOver(result);
+      });
     }
   }
 

--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -176,17 +176,13 @@ export class GameOverPhase extends BattlePhase {
     /* Added a local check to see if the game is running offline on victory
       If Online, execute apiFetch as intended
       If Offline, execute offlineNewClear(), a localStorage implementation of newClear daily run checks */
-    if (this.victory) {
-      if (!Utils.isLocal || Utils.isLocalServerConnected) {
-        pokerogueApi.savedata.session.newclear({ slot: this.scene.sessionSlotId, clientSessionId, result: this.victory })
-          .then((success) => doGameOver(!!success));
-      } else {
-        this.scene.gameData.offlineNewClear(this.scene).then(result => {
-          doGameOver(result);
-        });
-      }
+    if (!Utils.isLocal || Utils.isLocalServerConnected) {
+      pokerogueApi.savedata.session.newclear({ slot: this.scene.sessionSlotId, result: this.victory, clientSessionId: clientSessionId })
+        .then((success) => doGameOver(!!success));
     } else {
-      doGameOver(false);
+      this.scene.gameData.offlineNewClear(this.scene).then(result => {
+        doGameOver(result);
+      });
     }
   }
 

--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -29,7 +29,7 @@ export class GameOverPhase extends BattlePhase {
   private isVictory: boolean;
   private firstRibbons: PokemonSpecies[] = [];
 
-  constructor(scene: BattleScene, victory: boolean = false) {
+  constructor(scene: BattleScene, isVictory: boolean = false) {
     super(scene);
 
     this.isVictory = victory;

--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -26,13 +26,13 @@ import i18next from "i18next";
 import { pokerogueApi } from "#app/plugins/api/pokerogue-api";
 
 export class GameOverPhase extends BattlePhase {
-  private victory: boolean;
+  private isVictory: boolean;
   private firstRibbons: PokemonSpecies[] = [];
 
   constructor(scene: BattleScene, victory?: boolean) {
     super(scene);
 
-    this.victory = !!victory;
+    this.isVictory = !!victory;
   }
 
   start() {
@@ -40,22 +40,22 @@ export class GameOverPhase extends BattlePhase {
 
     // Failsafe if players somehow skip floor 200 in classic mode
     if (this.scene.gameMode.isClassic && this.scene.currentBattle.waveIndex > 200) {
-      this.victory = true;
+      this.isVictory = true;
     }
 
     // Handle Mystery Encounter special Game Over cases
     // Situations such as when player lost a battle, but it isn't treated as full Game Over
-    if (!this.victory && this.scene.currentBattle.mysteryEncounter?.onGameOver && !this.scene.currentBattle.mysteryEncounter.onGameOver(this.scene)) {
+    if (!this.isVictory && this.scene.currentBattle.mysteryEncounter?.onGameOver && !this.scene.currentBattle.mysteryEncounter.onGameOver(this.scene)) {
       // Do not end the game
       return this.end();
     }
     // Otherwise, continue standard Game Over logic
 
-    if (this.victory && this.scene.gameMode.isEndless) {
+    if (this.isVictory && this.scene.gameMode.isEndless) {
       const genderIndex = this.scene.gameData.gender ?? PlayerGender.UNSET;
       const genderStr = PlayerGender[genderIndex].toLowerCase();
       this.scene.ui.showDialogue(i18next.t("miscDialogue:ending_endless", { context: genderStr }), i18next.t("miscDialogue:ending_name"), 0, () => this.handleGameOver());
-    } else if (this.victory || !this.scene.enableRetries) {
+    } else if (this.isVictory || !this.scene.enableRetries) {
       this.handleGameOver();
     } else {
       this.scene.ui.showText(i18next.t("battle:retryBattle"), null, () => {
@@ -93,7 +93,7 @@ export class GameOverPhase extends BattlePhase {
       this.scene.disableMenu = true;
       this.scene.time.delayedCall(1000, () => {
         let firstClear = false;
-        if (this.victory && newClear) {
+        if (this.isVictory && newClear) {
           if (this.scene.gameMode.isClassic) {
             firstClear = this.scene.validateAchv(achvs.CLASSIC_VICTORY);
             this.scene.validateAchv(achvs.UNEVOLVED_CLASSIC_VICTORY);
@@ -109,8 +109,8 @@ export class GameOverPhase extends BattlePhase {
             this.scene.gameData.gameStats.dailyRunSessionsWon++;
           }
         }
-        this.scene.gameData.saveRunHistory(this.scene, this.scene.gameData.getSessionSaveData(this.scene), this.victory);
-        const fadeDuration = this.victory ? 10000 : 5000;
+        this.scene.gameData.saveRunHistory(this.scene, this.scene.gameData.getSessionSaveData(this.scene), this.isVictory);
+        const fadeDuration = this.isVictory ? 10000 : 5000;
         this.scene.fadeOutBgm(fadeDuration, true);
         const activeBattlers = this.scene.getField().filter(p => p?.isActive(true));
         activeBattlers.map(p => p.hideInfo());
@@ -120,7 +120,7 @@ export class GameOverPhase extends BattlePhase {
           this.scene.clearPhaseQueue();
           this.scene.ui.clearText();
 
-          if (this.victory && this.scene.gameMode.isChallenge) {
+          if (this.isVictory && this.scene.gameMode.isChallenge) {
             this.scene.gameMode.challenges.forEach(c => this.scene.validateAchvs(ChallengeAchv, c));
           }
 
@@ -128,7 +128,7 @@ export class GameOverPhase extends BattlePhase {
             if (newClear) {
               this.handleUnlocks();
             }
-            if (this.victory && newClear) {
+            if (this.isVictory && newClear) {
               for (const species of this.firstRibbons) {
                 this.scene.unshiftPhase(new RibbonModifierRewardPhase(this.scene, modifierTypes.VOUCHER_PLUS, species));
               }
@@ -140,7 +140,7 @@ export class GameOverPhase extends BattlePhase {
             this.end();
           };
 
-          if (this.victory && this.scene.gameMode.isClassic) {
+          if (this.isVictory && this.scene.gameMode.isClassic) {
             const dialogueKey = "miscDialogue:ending";
 
             if (!this.scene.ui.shouldSkipDialogue(dialogueKey)) {
@@ -177,7 +177,7 @@ export class GameOverPhase extends BattlePhase {
       If Online, execute apiFetch as intended
       If Offline, execute offlineNewClear(), a localStorage implementation of newClear daily run checks */
     if (!Utils.isLocal || Utils.isLocalServerConnected) {
-      pokerogueApi.savedata.session.newclear({ slot: this.scene.sessionSlotId, result: this.victory, clientSessionId: clientSessionId })
+      pokerogueApi.savedata.session.newclear({ slot: this.scene.sessionSlotId, isVictory: this.isVictory, clientSessionId: clientSessionId })
         .then((success) => doGameOver(!!success));
     } else {
       this.scene.gameData.offlineNewClear(this.scene).then(result => {
@@ -187,7 +187,7 @@ export class GameOverPhase extends BattlePhase {
   }
 
   handleUnlocks(): void {
-    if (this.victory && this.scene.gameMode.isClassic) {
+    if (this.isVictory && this.scene.gameMode.isClassic) {
       if (!this.scene.gameData.unlocks[Unlockables.ENDLESS_MODE]) {
         this.scene.unshiftPhase(new UnlockPhase(this.scene, Unlockables.ENDLESS_MODE));
       }

--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -32,7 +32,7 @@ export class GameOverPhase extends BattlePhase {
   constructor(scene: BattleScene, isVictory: boolean = false) {
     super(scene);
 
-    this.isVictory = victory;
+    this.isVictory = isVictory;
   }
 
   start() {

--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -173,16 +173,18 @@ export class GameOverPhase extends BattlePhase {
       });
     };
 
-    /* Added a local check to see if the game is running offline on victory
+    /* Added a local check to see if the game is running offline
       If Online, execute apiFetch as intended
-      If Offline, execute offlineNewClear(), a localStorage implementation of newClear daily run checks */
+      If Offline, execute offlineNewClear() only for victory, a localStorage implementation of newClear daily run checks */
     if (!Utils.isLocal || Utils.isLocalServerConnected) {
       pokerogueApi.savedata.session.newclear({ slot: this.scene.sessionSlotId, isVictory: this.isVictory, clientSessionId: clientSessionId })
         .then((success) => doGameOver(!!success));
     } else {
-      this.scene.gameData.offlineNewClear(this.scene).then(result => {
-        doGameOver(result);
-      });
+      if (this.isVictory) {
+        this.scene.gameData.offlineNewClear(this.scene).then(result => {
+          doGameOver(result);
+        });
+      }
     }
   }
 

--- a/src/test/plugins/api/pokerogue-session-savedata-api.test.ts
+++ b/src/test/plugins/api/pokerogue-session-savedata-api.test.ts
@@ -6,7 +6,6 @@ import type {
   NewClearSessionSavedataRequest,
   UpdateSessionSavedataRequest,
 } from "#app/@types/PokerogueSessionSavedataApi";
-import { GameModes } from "#app/game-mode";
 import { PokerogueSessionSavedataApi } from "#app/plugins/api/pokerogue-session-savedata-api";
 import type { SessionSaveData } from "#app/system/game-data";
 import { getApiBaseUrl } from "#app/test/utils/testUtils";
@@ -30,8 +29,7 @@ describe("Pokerogue Session Savedata API", () => {
     const params: NewClearSessionSavedataRequest = {
       clientSessionId: "test-session-id",
       slot: 3,
-      result: true,
-      gameMode: GameModes.CLASSIC
+      result: true
     };
 
     it("should return true on SUCCESS", async () => {

--- a/src/test/plugins/api/pokerogue-session-savedata-api.test.ts
+++ b/src/test/plugins/api/pokerogue-session-savedata-api.test.ts
@@ -6,6 +6,7 @@ import type {
   NewClearSessionSavedataRequest,
   UpdateSessionSavedataRequest,
 } from "#app/@types/PokerogueSessionSavedataApi";
+import { GameModes } from "#app/game-mode";
 import { PokerogueSessionSavedataApi } from "#app/plugins/api/pokerogue-session-savedata-api";
 import type { SessionSaveData } from "#app/system/game-data";
 import { getApiBaseUrl } from "#app/test/utils/testUtils";
@@ -29,6 +30,8 @@ describe("Pokerogue Session Savedata API", () => {
     const params: NewClearSessionSavedataRequest = {
       clientSessionId: "test-session-id",
       slot: 3,
+      result: true,
+      gameMode: GameModes.CLASSIC
     };
 
     it("should return true on SUCCESS", async () => {

--- a/src/test/plugins/api/pokerogue-session-savedata-api.test.ts
+++ b/src/test/plugins/api/pokerogue-session-savedata-api.test.ts
@@ -28,7 +28,7 @@ describe("Pokerogue Session Savedata API", () => {
   describe("Newclear", () => {
     const params: NewClearSessionSavedataRequest = {
       clientSessionId: "test-session-id",
-      result: true,
+      isVictory: true,
       slot: 3
     };
 

--- a/src/test/plugins/api/pokerogue-session-savedata-api.test.ts
+++ b/src/test/plugins/api/pokerogue-session-savedata-api.test.ts
@@ -28,8 +28,8 @@ describe("Pokerogue Session Savedata API", () => {
   describe("Newclear", () => {
     const params: NewClearSessionSavedataRequest = {
       clientSessionId: "test-session-id",
-      slot: 3,
-      result: true
+      result: true,
+      slot: 3
     };
 
     it("should return true on SUCCESS", async () => {


### PR DESCRIPTION
## What are the changes the user will see?
None.

## Why am I making these changes?
Telemetry. 

## What are the changes from a developer perspective?
The /newclear request sent in game-over-phase now also sends the result and the game mode as part of the URL. 
See PR [4 ](https://github.com/f-fsantos/rogueserver/pull/4) for server side code. 

## How to test the changes?
Finish a run through winning or losing. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
