### PR TITLE
[P1] Fix crash when newly aquired Pokemon are used in battle

### DIFF
--- a/src/data/mystery-encounters/encounters/fun-and-games-encounter.ts
+++ b/src/data/mystery-encounters/encounters/fun-and-games-encounter.ts
@@ -305,7 +305,7 @@ async function showWobbuffetHealthBar(scene: BattleScene) {
   scene.field.add(wobbuffet);
 
   const playerPokemon = scene.getPlayerPokemon() as Pokemon;
-  if (playerPokemon?.visible) {
+  if (playerPokemon?.isOnField()) {
     scene.field.moveBelow(wobbuffet, playerPokemon);
   }
   // Show health bar and trigger cry

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -5113,7 +5113,7 @@ export class EnemyPokemon extends Pokemon {
 
   /**
    * Add a new pokemon to the player's party (at `slotIndex` if set).
-   * If the first slot is replaced, the new pokemon's visibility will be set to `false`.
+   * The new pokemon's visibility will be set to `false`.
    * @param pokeballType the type of pokeball the pokemon was caught with
    * @param slotIndex an optional index to place the pokemon in the party
    * @returns the pokemon that was added or null if the pokemon could not be added
@@ -5131,13 +5131,13 @@ export class EnemyPokemon extends Pokemon {
       const newPokemon = this.scene.addPlayerPokemon(this.species, this.level, this.abilityIndex, this.formIndex, this.gender, this.shiny, this.variant, this.ivs, this.nature, this);
 
       if (Utils.isBetween(slotIndex, 0, PLAYER_PARTY_MAX_SIZE - 1)) {
-        if (slotIndex === 0) {
-          newPokemon.setVisible(false); // Hide if replaced with first pokemon
-        }
         party.splice(slotIndex, 0, newPokemon);
       } else {
         party.push(newPokemon);
       }
+
+      // Hide the Pokemon since it is not on the field
+      newPokemon.setVisible(false);
 
       ret = newPokemon;
       this.scene.triggerPokemonFormChange(newPokemon, SpeciesFormChangeActiveTrigger, true);

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -202,7 +202,7 @@ export class EncounterPhase extends BattlePhase {
             this.scene.field.add(enemyPokemon);
             battle.seenEnemyPartyMemberIds.add(enemyPokemon.id);
             const playerPokemon = this.scene.getPlayerPokemon();
-            if (playerPokemon?.visible) {
+            if (playerPokemon?.isOnField()) {
               this.scene.field.moveBelow(enemyPokemon as Pokemon, playerPokemon);
             }
             enemyPokemon.tint(0, 0.5);

--- a/src/phases/summon-phase.ts
+++ b/src/phases/summon-phase.ts
@@ -140,7 +140,7 @@ export class SummonPhase extends PartyMemberPokemonPhase {
             this.scene.field.add(pokemon);
             if (!this.player) {
               const playerPokemon = this.scene.getPlayerPokemon() as Pokemon;
-              if (playerPokemon?.visible) {
+              if (playerPokemon?.isOnField()) {
                 this.scene.field.moveBelow(pokemon, playerPokemon);
               }
               this.scene.currentBattle.seenEnemyPartyMemberIds.add(pokemon.id);
@@ -193,7 +193,7 @@ export class SummonPhase extends PartyMemberPokemonPhase {
     this.scene.field.add(pokemon);
     if (!this.player) {
       const playerPokemon = this.scene.getPlayerPokemon() as Pokemon;
-      if (playerPokemon?.visible) {
+      if (playerPokemon?.isOnField()) {
         this.scene.field.moveBelow(pokemon, playerPokemon);
       }
       this.scene.currentBattle.seenEnemyPartyMemberIds.add(pokemon.id);


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
- No more crash at the start of the Expert Breeder ME when choosing a Pokemon that was caught during the run
- No more crash when trading your only Pokemon in Global Trade System ME
- In general should stop all similar crashes caused by Pokemon obtained during the current play session being sent in battle
<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?
Crashes not good, and this one has been reported a lot.
[Main discord thread](https://discord.com/channels/1125469663833370665/1289869659297812520/1300448219708522526). Shoutouts to PigeonBar for figuring out how to reproduce the bug
[Second thread](https://discord.com/channels/1125469663833370665/1303111425161433228/1304157578368122991) with more findings on this, in the context for the GTS ME this time
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What are the changes from a developer perspective?

<details><summary>Crash explanation:</summary>

The crash is caused by this bit of code that is used in a few places at the beginning of battles or encounters:
```
if (playerPokemon?.visible) {
   this.scene.field.moveBelow(enemyPokemon, playerPokemon);
} 
```
Its purpose is to make the enemyPokemon sprite's render below the player's one. For this both Pokemon Sprites must be in the same parent Container (the ui field Container).
The issue is that `playerPokemon?.visible` is not a good check for whether calling moveBelow is possible. It seems that Pokemon that were added to the team through `Pokemon.addToParty` have their visibility set to `true` at that point, even though they are not on the field and have no parent Container. This causes the following crash:
![image](https://github.com/user-attachments/assets/a1551236-0d19-41e6-bacd-0b3426cf04fb)

This issue was actually already encountered in the past when replacing the mon in first slot with a new Pokemon ( #762 ) and was fixed by making the new Pokemon invisible if it was added in slot 0 ( #4427 )

</details>

_Fix_:
- in pokemon.ts `addToParty`, generalize the fix mentioned above to make all new Pokemon invisible. They are made visible properly when added in the field in battle
- While this is enough to fix the crashes, I replaced all the `playerPokemon?.visible` checks by `playerPokemon?.isOnField()` checks, as it is more appropriate.

<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos

<details><summary>Expert Pokemon Breeder</summary>
Before, sending a Pokemon that was just caught:


https://github.com/user-attachments/assets/8e8cf281-6416-4c92-8dea-5e4649e07811

After, sending a Pokemon that was just caught:

https://github.com/user-attachments/assets/d798ef9b-6d2d-4b3d-9efc-a2cb0c21586d


</details>

<details><summary>Global Trade System</summary>

Before, trading your only Pokemon:

https://github.com/user-attachments/assets/fc8d9f01-28b7-401c-a0bb-bcfd66d7ca90



After, trading your only Pokemon:

https://github.com/user-attachments/assets/c6fca09f-d0e4-4170-8d32-97a5f1a2013b



</details>

<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
<details><summary>Expert Pokemon Breeder crash</summary>
Overrides:

```
  BATTLE_TYPE_OVERRIDE: "single",
  STARTING_WAVE_OVERRIDE: 11,
  STARTING_BIOME_OVERRIDE: Biome.VOLCANO,
  STARTING_LEVEL_OVERRIDE: 50,
  MYSTERY_ENCOUNTER_RATE_OVERRIDE: 100,
  MYSTERY_ENCOUNTER_OVERRIDE: MysteryEncounterType.GLOBAL_TRADE_SYSTEM,
  POKEBALL_OVERRIDE: {
    active: true,
    pokeballs: {
      [PokeballType.POKEBALL]: 5,
      [PokeballType.GREAT_BALL]: 0,
      [PokeballType.ULTRA_BALL]: 0,
      [PokeballType.ROGUE_BALL]: 0,
      [PokeballType.MASTER_BALL]: 99,
    },
  }
```

- Start with at least 3 Pokemon (the ME is not supposed to crash if you don't have 3 usable mons, so it will crash)
- When you encounter a wild Pokemon, catch it
- Don't use it in battle
- Play untiI the ME spawn, and pick the Pokemon you caught for it.
- The ME should play out as intended
</details>

<details><summary>Global Trade System crash</summary>
Overrides:

```
  STARTING_WAVE_OVERRIDE: 11,
  MYSTERY_ENCOUNTER_RATE_OVERRIDE: 150,
  MYSTERY_ENCOUNTER_OVERRIDE: MysteryEncounterType.GLOBAL_TRADE_SYSTEM
```
- Start with a single Pokemon
- Trade it away when you get the ME.
- Play untiI a non ME wave. It should not crash and send the Pokemon out
</details>

<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
- ~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
