### PR TITLE
[Test] Modernize the tests for the Zen Mode ability

### DIFF
--- a/src/test/abilities/zen_mode.test.ts
+++ b/src/test/abilities/zen_mode.test.ts
@@ -1,14 +1,8 @@
-import { BattlerIndex } from "#app/battle";
 import { Status } from "#app/data/status-effect";
-import { DamagePhase } from "#app/phases/damage-phase";
-import { SwitchSummonPhase } from "#app/phases/switch-summon-phase";
-import { Mode } from "#app/ui/ui";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
-import { Stat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
-import { SwitchType } from "#enums/switch-type";
 import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -34,78 +28,60 @@ describe("Abilities - ZEN MODE", () => {
     game = new GameManager(phaserGame);
     game.override
       .battleType("single")
-      .enemySpecies(Species.RATTATA)
-      .enemyAbility(Abilities.HYDRATION)
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyLevel(5)
       .ability(Abilities.ZEN_MODE)
-      .startingLevel(100)
       .moveset(Moves.SPLASH)
-      .enemyMoveset(Moves.TACKLE);
+      .enemyMoveset(Moves.SEISMIC_TOSS);
   });
 
   it("shouldn't change form when taking damage if not dropping below 50% HP", async () => {
     await game.classicMode.startBattle([ Species.DARMANITAN ]);
-    const player = game.scene.getPlayerPokemon()!;
-    player.stats[Stat.HP] = 100;
-    player.hp = 100;
-    expect(player.formIndex).toBe(baseForm);
+    const darmanitan = game.scene.getPlayerPokemon()!;
+    expect(darmanitan.formIndex).toBe(baseForm);
 
     game.move.select(Moves.SPLASH);
-    await game.setTurnOrder([ BattlerIndex.ENEMY, BattlerIndex.PLAYER ]);
-    await game.phaseInterceptor.to("BerryPhase");
+    await game.toNextTurn();
 
-    expect(player.hp).toBeLessThan(100);
-    expect(player.formIndex).toBe(baseForm);
+    expect(darmanitan.getHpRatio()).toBeLessThan(1);
+    expect(darmanitan.getHpRatio()).toBeGreaterThan(0.5);
+    expect(darmanitan.formIndex).toBe(baseForm);
   });
 
   it("should change form when falling below 50% HP", async () => {
     await game.classicMode.startBattle([ Species.DARMANITAN ]);
 
-    const player = game.scene.getPlayerPokemon()!;
-    player.stats[Stat.HP] = 1000;
-    player.hp = 100;
-    expect(player.formIndex).toBe(baseForm);
+    const darmanitan = game.scene.getPlayerPokemon()!;
+    darmanitan.hp = (darmanitan.getMaxHp() / 2) + 1;
+    expect(darmanitan.formIndex).toBe(baseForm);
 
     game.move.select(Moves.SPLASH);
+    await game.toNextTurn();
 
-    await game.setTurnOrder([ BattlerIndex.ENEMY, BattlerIndex.PLAYER ]);
-    await game.phaseInterceptor.to("QuietFormChangePhase");
-    await game.phaseInterceptor.to("TurnInitPhase", false);
-
-    expect(player.hp).not.toBe(100);
-    expect(player.formIndex).toBe(zenForm);
+    expect(darmanitan.getHpRatio()).toBeLessThan(0.5);
+    expect(darmanitan.formIndex).toBe(zenForm);
   });
 
   it("should stay zen mode when fainted", async () => {
     await game.classicMode.startBattle([ Species.DARMANITAN, Species.CHARIZARD ]);
-    const player = game.scene.getPlayerPokemon()!;
-    player.stats[Stat.HP] = 1000;
-    player.hp = 100;
-    expect(player.formIndex).toBe(baseForm);
+    const darmanitan = game.scene.getPlayerPokemon()!;
+    darmanitan.hp = (darmanitan.getMaxHp() / 2) + 1;
+    expect(darmanitan.formIndex).toBe(baseForm);
 
     game.move.select(Moves.SPLASH);
+    await game.toNextTurn();
 
-    await game.setTurnOrder([ BattlerIndex.ENEMY, BattlerIndex.PLAYER ]);
-    await game.phaseInterceptor.to(DamagePhase, false);
-    const damagePhase = game.scene.getCurrentPhase() as DamagePhase;
-    damagePhase.updateAmount(80);
-    await game.phaseInterceptor.to("QuietFormChangePhase");
+    expect(darmanitan.getHpRatio()).toBeLessThan(0.5);
+    expect(darmanitan.formIndex).toBe(zenForm);
 
-    expect(player.hp).not.toBe(100);
-    expect(player.formIndex).toBe(zenForm);
+    game.move.select(Moves.SPLASH);
+    await game.killPokemon(darmanitan);
+    game.doSelectPartyPokemon(1);
+    await game.toNextTurn();
 
-    await game.killPokemon(player);
-    expect(player.isFainted()).toBe(true);
-
-    await game.phaseInterceptor.to("TurnStartPhase");
-    game.onNextPrompt("SwitchPhase", Mode.PARTY, () => {
-      game.scene.unshiftPhase(new SwitchSummonPhase(game.scene, SwitchType.SWITCH, 0, 1, false));
-      game.scene.ui.setMode(Mode.MESSAGE);
-    });
-    game.onNextPrompt("SwitchPhase", Mode.MESSAGE, () => {
-      game.endPhase();
-    });
-    await game.phaseInterceptor.to("PostSummonPhase");
-
+    expect(darmanitan.isFainted()).toBe(true);
     expect(game.scene.getPlayerParty()[1].formIndex).toBe(zenForm);
   });
 
@@ -117,7 +93,8 @@ describe("Abilities - ZEN MODE", () => {
 
     await game.classicMode.startBattle([ Species.MAGIKARP, Species.DARMANITAN ]);
 
-    const darmanitan = game.scene.getPlayerParty().find((p) => p.species.speciesId === Species.DARMANITAN)!;
+    const darmanitan = game.scene.getPlayerParty()[1];
+    darmanitan.hp = 1;
     expect(darmanitan.formIndex).toBe(zenForm);
 
     darmanitan.hp = 0;
@@ -126,9 +103,7 @@ describe("Abilities - ZEN MODE", () => {
 
     game.move.select(Moves.SPLASH);
     await game.doKillOpponents();
-    await game.phaseInterceptor.to("TurnEndPhase");
-    game.doSelectModifier();
-    await game.phaseInterceptor.to("QuietFormChangePhase");
+    await game.toNextWave();
 
     expect(darmanitan.formIndex).toBe(baseForm);
   });


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
The test file is very outdated/questionable.

## What are the changes from a developer perspective?
The Zen Mode tests are more comprehensible (and more accurate?).

## How to test the changes?
`npm run test zen_mode`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- ~[ ] Have I tested the changes (manually)?~
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
