### PR TITLE
[UI] Make ME text legible when using the legacy UI theme

### DIFF
--- a/src/data/mystery-encounters/utils/encounter-dialogue-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-dialogue-utils.ts
@@ -7,22 +7,22 @@ import i18next from "i18next";
 /**
  * Will inject all relevant dialogue tokens that exist in the {@linkcode BattleScene.currentBattle.mysteryEncounter.dialogueTokens}, into i18n text.
  * Also adds BBCodeText fragments for colored text, if applicable
- * @param scene
  * @param keyOrString
  * @param primaryStyle Can define a text style to be applied to the entire string. Must be defined for BBCodeText styles to be applied correctly
- * @param uiTheme
  */
-export function getEncounterText(scene: BattleScene, keyOrString?: string, primaryStyle?: TextStyle, uiTheme: UiTheme = UiTheme.DEFAULT): string | null {
+export function getEncounterText(scene: BattleScene, keyOrString?: string, primaryStyle?: TextStyle): string | null {
   if (isNullOrUndefined(keyOrString)) {
     return null;
   }
+
+  const uiTheme = scene.uiTheme ?? UiTheme.DEFAULT;
 
   let textString: string | null = getTextWithDialogueTokens(scene, keyOrString);
 
   // Can only color the text if a Primary Style is defined
   // primaryStyle is applied to all text that does not have its own specified style
   if (primaryStyle && textString) {
-    textString = getTextWithColors(textString, primaryStyle, uiTheme);
+    textString = getTextWithColors(textString, primaryStyle, uiTheme, true);
   }
 
   return textString;

--- a/src/ui/mystery-encounter-ui-handler.ts
+++ b/src/ui/mystery-encounter-ui-handler.ts
@@ -369,9 +369,9 @@ export default class MysteryEncounterUiHandler extends UiHandler {
       let text: string | null;
       if (option.hasRequirements() && this.optionsMeetsReqs[i] && (option.optionMode === MysteryEncounterOptionMode.DEFAULT_OR_SPECIAL || option.optionMode === MysteryEncounterOptionMode.DISABLED_OR_SPECIAL)) {
         // Options with special requirements that are met are automatically colored green
-        text = getEncounterText(this.scene, label, TextStyle.SUMMARY_GREEN);
+        text = getEncounterText(this.scene, label, TextStyle.ME_OPTION_SPECIAL);
       } else {
-        text = getEncounterText(this.scene, label, optionDialogue.style ? optionDialogue.style : TextStyle.WINDOW);
+        text = getEncounterText(this.scene, label, optionDialogue.style ? optionDialogue.style : TextStyle.ME_OPTION_DEFAULT);
       }
 
       if (text) {

--- a/src/ui/run-info-ui-handler.ts
+++ b/src/ui/run-info-ui-handler.ts
@@ -518,7 +518,8 @@ export default class RunInfoUiHandler extends UiHandler {
     const runTime = Utils.getPlayTimeString(this.runInfo.playTime);
     runInfoText.appendText(`${i18next.t("runHistory:runLength")}: ${runTime}`, false);
     const runMoney = Utils.formatMoney(this.scene.moneyFormat, this.runInfo.money);
-    runInfoText.appendText(`[color=${getTextColor(TextStyle.MONEY)}]${i18next.t("battleScene:moneyOwned", { formattedMoney : runMoney })}[/color]`);
+    const moneyTextColor = getTextColor(TextStyle.MONEY_WINDOW, false, this.scene.uiTheme);
+    runInfoText.appendText(`[color=${moneyTextColor}]${i18next.t("battleScene:moneyOwned", { formattedMoney : runMoney })}[/color]`);
     runInfoText.setPosition(7, 70);
     runInfoTextContainer.add(runInfoText);
     // Luck

--- a/src/ui/text.ts
+++ b/src/ui/text.ts
@@ -22,7 +22,8 @@ export enum TextStyle {
   SUMMARY_GOLD,
   SUMMARY_GRAY,
   SUMMARY_GREEN,
-  MONEY,
+  MONEY, // Money default styling (pale yellow)
+  MONEY_WINDOW, // Money displayed in Windows (needs different colors based on theme)
   STATS_LABEL,
   STATS_VALUE,
   SETTINGS_VALUE,
@@ -38,7 +39,9 @@ export enum TextStyle {
   MOVE_PP_EMPTY,
   SMALLER_WINDOW_ALT,
   BGM_BAR,
-  PERFECT_IV
+  PERFECT_IV,
+  ME_OPTION_DEFAULT, // Default style for choices in ME
+  ME_OPTION_SPECIAL, // Style for choices with special requirements in ME
 }
 
 export interface TextStyleOptions {
@@ -139,6 +142,8 @@ export function getTextStyleOptions(style: TextStyle, uiTheme: UiTheme, extraSty
     case TextStyle.SUMMARY_GREEN:
     case TextStyle.WINDOW:
     case TextStyle.WINDOW_ALT:
+    case TextStyle.ME_OPTION_DEFAULT:
+    case TextStyle.ME_OPTION_SPECIAL:
       shadowXpos = 3;
       shadowYpos = 3;
       break;
@@ -177,6 +182,7 @@ export function getTextStyleOptions(style: TextStyle, uiTheme: UiTheme, extraSty
       break;
     case TextStyle.BATTLE_INFO:
     case TextStyle.MONEY:
+    case TextStyle.MONEY_WINDOW:
     case TextStyle.TOOLTIP_TITLE:
       styleOptions.fontSize = defaultFontSize - 24;
       shadowXpos = 3.5;
@@ -238,12 +244,21 @@ export function getBBCodeFrag(content: string, textStyle: TextStyle, uiTheme: Ui
  * - "red text" with TextStyle.SUMMARY_RED applied
  * @param content string with styling that need to be applied for BBCodeTextObject
  * @param primaryStyle Primary style is required in order to escape BBCode styling properly.
- * @param uiTheme
+ * @param uiTheme the {@linkcode UiTheme} to get TextStyle for
+ * @param forWindow set to `true` if the text is to be displayed in a window ({@linkcode BattleScene.addWindow})
+ *  it will replace all instances of the default MONEY TextStyle by {@linkcode TextStyle.MONEY_WINDOW}
  */
-export function getTextWithColors(content: string, primaryStyle: TextStyle, uiTheme: UiTheme = UiTheme.DEFAULT): string {
+export function getTextWithColors(content: string, primaryStyle: TextStyle, uiTheme: UiTheme, forWindow?: boolean): string {
   // Apply primary styling before anything else
   let text = getBBCodeFrag(content, primaryStyle, uiTheme) + "[/color][/shadow]";
   const primaryStyleString = [ ...text.match(new RegExp(/\[color=[^\[]*\]\[shadow=[^\[]*\]/i))! ][0];
+
+  /* For money text displayed in game windows, we can't use the default {@linkcode TextStyle.MONEY}
+   * or it will look wrong in legacy mode because of the different window background color
+   * So, for text to be displayed in windows replace all "@[MONEY]" with "@[MONEY_WINDOW]" */
+  if (forWindow) {
+    text = text.replace(/@\[MONEY\]/g, (_substring: string) => "@[MONEY_WINDOW]");
+  }
 
   // Set custom colors
   text = text.replace(/@\[([^{]*)\]{([^}]*)}/gi, (substring, textStyle: string, textToColor: string) => {
@@ -310,7 +325,12 @@ export function getTextColor(textStyle: TextStyle, shadow?: boolean, uiTheme: Ui
       return !shadow ? "#f89890" : "#984038";
     case TextStyle.SUMMARY_GOLD:
     case TextStyle.MONEY:
-      return !shadow ? "#e8e8a8" : "#a0a060";
+      return !shadow ? "#e8e8a8" : "#a0a060"; // Pale Yellow/Gold
+    case TextStyle.MONEY_WINDOW:
+      if (isLegacyTheme) {
+        return !shadow ? "#f8b050" : "#c07800"; // Gold
+      }
+      return !shadow ? "#e8e8a8" : "#a0a060"; // Pale Yellow/Gold
     case TextStyle.SETTINGS_LOCKED:
     case TextStyle.SUMMARY_GRAY:
       return !shadow ? "#a0a0a0" : "#636363";
@@ -332,6 +352,13 @@ export function getTextColor(textStyle: TextStyle, shadow?: boolean, uiTheme: Ui
       return !shadow ? "#484848" : "#d0d0c8";
     case TextStyle.BGM_BAR:
       return !shadow ? "#f8f8f8" : "#6b5a73";
+    case TextStyle.ME_OPTION_DEFAULT:
+      return !shadow ? "#f8f8f8" : "#6b5a73"; // White
+    case TextStyle.ME_OPTION_SPECIAL:
+      if (isLegacyTheme) {
+        return !shadow ? "#f8b050" : "#c07800"; // Gold
+      }
+      return !shadow ? "#78c850" : "#306850"; // Green
   }
 }
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->
## What are the changes the user will see?
Readable text in MEs when using legacy theme
<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?
Being able to read the game's text is good
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What are the changes from a developer perspective?
Default theme is unchanged
Legacy theme had the following changes, only affecting MEs:
- white text to black
- money text from pale yellow to gold
- option with fulfilled requirement from green to gold

Implementation:
- `encounter-dialogue-utils.getEncounterText` now properly uses the current ui theme when calling `getTextColor`
- `text.ts`:
  - added new TextStyles `ME_OPTION_DEFAULT` and `ME_OPTION_SPECIAL` for ME option colors
  - Added new TextStyle `MONEY_WINDOW`. Currently the default style for Money is a pale yellow in both themes. That doesn't work when the money has to be displayed in a game window since the themes have different colored windows (dark in default theme, white in legacy theme)
  - Currently the MONEY TextStyle is applied automatically by i18n based on the localized string. Changing the style of all money values in MEs would mean having to update a lot of locale strings, for something that will most likely need to change again with the future UI rework. The TextStyles are a mess, the scope of this PR is not to fix that but only to make MEs work in legacy theme. So, for now, `getTextColor` was changed to take a parameter of whether the text is to get displayed within a game window, in which case it replaces the MONEY textstyle with MONEY_WINDOW
- `run-info-ui-handler.ts` also displays money in a window, making it hard to read in legacy theme. It now uses the MONEY_WINDOW TextStyle as well

<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos

Before:
<img width="327" alt="before_legacy" src="https://github.com/user-attachments/assets/6a3bdae8-0786-432f-bc33-48898d26f9c0" > <img width="327" alt="before_default" src="https://github.com/user-attachments/assets/8257a69e-0561-48b5-b87d-475e850d4836" >

After:
<img width="327" alt="after_legacy" src="https://github.com/user-attachments/assets/cacd0095-e069-4113-850b-e4976d1889aa" > <img width="327" alt="after_default" src="https://github.com/user-attachments/assets/8257a69e-0561-48b5-b87d-475e850d4836" >


<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
Overrides:
Default Overrides to get MEs every wave
```
  STARTING_WAVE_OVERRIDE: 11,
  MYSTERY_ENCOUNTER_RATE_OVERRIDE: 255,
```

Example specific override for the one in the screenshots:
```
  ABILITY_OVERRIDE: Abilities.INTIMIDATE,
  MYSTERY_ENCOUNTER_OVERRIDE: MysteryEncounterType.AN_OFFER_YOU_CANT_REFUSE
```

<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- ~~[ ] Have I considered writing automated tests for the issue?~~
- ~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
