### PR TITLE
[Beta][Misc] Improved cursor memory for target selection in Doubles

### DIFF
--- a/src/ui/target-select-ui-handler.ts
+++ b/src/ui/target-select-ui-handler.ts
@@ -16,8 +16,8 @@ export default class TargetSelectUiHandler extends UiHandler {
   private fieldIndex: number;
   private move: Moves;
   private targetSelectCallback: TargetSelectCallback;
-  private cursor1: number;
-  private cursor2: number;
+  private cursor0: number; // associated with BattlerIndex.PLAYER
+  private cursor1: number; // associated with BattlerIndex.PLAYER_2
 
   private isMultipleTargets: boolean = false;
   private targets: BattlerIndex[];
@@ -57,13 +57,18 @@ export default class TargetSelectUiHandler extends UiHandler {
     this.enemyModifiers = this.scene.getModifierBar(true);
 
     if (this.fieldIndex === BattlerIndex.PLAYER) {
-      this.resetCursor(this.cursor1, user);
+      this.resetCursor(this.cursor0, user);
     } else if (this.fieldIndex === BattlerIndex.PLAYER_2) {
-      this.resetCursor(this.cursor2, user);
+      this.resetCursor(this.cursor1, user);
     }
     return true;
   }
 
+  /**
+   * Determines what value to assign the main cursor on previous history or the user's status
+   * @param cursorN the cursor associated with the user's field index
+   * @param user the Pokemon using the move
+   */
   resetCursor(cursorN: number, user: Pokemon): void {
     if (!Utils.isNullOrUndefined(cursorN)) {
       if ([ BattlerIndex.PLAYER, BattlerIndex.PLAYER_2 ].includes(cursorN) || user.battleSummonData.waveTurnCount === 1) {
@@ -85,12 +90,12 @@ export default class TargetSelectUiHandler extends UiHandler {
       this.targetSelectCallback(button === Button.ACTION ? targetIndexes : []);
       success = true;
       if (this.fieldIndex === BattlerIndex.PLAYER) {
-        if (Utils.isNullOrUndefined(this.cursor1) || this.cursor1 !== this.cursor) {
-          this.cursor1 = this.cursor;
+        if (Utils.isNullOrUndefined(this.cursor0) || this.cursor0 !== this.cursor) {
+          this.cursor0 = this.cursor;
         }
       } else if (this.fieldIndex === BattlerIndex.PLAYER_2) {
-        if (Utils.isNullOrUndefined(this.cursor1) || this.cursor2 !== this.cursor) {
-          this.cursor2 = this.cursor;
+        if (Utils.isNullOrUndefined(this.cursor0) || this.cursor1 !== this.cursor) {
+          this.cursor1 = this.cursor;
         }
       }
     } else if (this.isMultipleTargets) {

--- a/src/ui/target-select-ui-handler.ts
+++ b/src/ui/target-select-ui-handler.ts
@@ -94,7 +94,7 @@ export default class TargetSelectUiHandler extends UiHandler {
           this.cursor0 = this.cursor;
         }
       } else if (this.fieldIndex === BattlerIndex.PLAYER_2) {
-        if (Utils.isNullOrUndefined(this.cursor0) || this.cursor1 !== this.cursor) {
+        if (Utils.isNullOrUndefined(this.cursor1) || this.cursor1 !== this.cursor) {
           this.cursor1 = this.cursor;
         }
       }

--- a/src/ui/target-select-ui-handler.ts
+++ b/src/ui/target-select-ui-handler.ts
@@ -65,16 +65,15 @@ export default class TargetSelectUiHandler extends UiHandler {
   }
 
   /**
-   * Determines what value to assign the main cursor on previous history or the user's status
+   * Determines what value to assign the main cursor based on the previous turn's target or the user's status
    * @param cursorN the cursor associated with the user's field index
    * @param user the Pokemon using the move
    */
   resetCursor(cursorN: number, user: Pokemon): void {
     if (!Utils.isNullOrUndefined(cursorN)) {
       if ([ BattlerIndex.PLAYER, BattlerIndex.PLAYER_2 ].includes(cursorN) || user.battleSummonData.waveTurnCount === 1) {
-        this.cursor = cursorN = -1;
-      } else if (user.battleSummonData.waveTurnCount > 1) {
-        this.cursor = cursorN;
+        // Reset cursor on the first turn of a fight or if an ally was targeted last turn
+        cursorN = -1;
       }
     }
     this.setCursor(this.targets.includes(cursorN) ? cursorN : this.targets[0]);


### PR DESCRIPTION
## What are the changes the user will see?
The cursor will reset its position to the leftmost enemy when:
1) It is the first turn (of the wave) for the Pokemon involved. 
2) A new wave begins
3) The Pokemon used a move that targeted an ally or itself
It will remember its position if it targets an enemy though. 

## Why am I making these changes?
Changes requested by Beta testers. 

## What are the changes from a developer perspective?
Changes to show() and processInput()

### Screenshots/Videos

https://github.com/user-attachments/assets/623c9e26-ce07-4cfd-b91d-4df705e78af3


## How to test the changes?
1. Fight in a double battle and check how the user facing conditions are working. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
