### PR TITLE
[Balance][Beta] Revert Spread Move Restriction on Multi-Lens

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -1367,7 +1367,7 @@ export class AddSecondStrikeAbAttr extends PreAttackAbAttr {
     const hitCount = args[0] as Utils.NumberHolder;
     const multiplier = args[1] as Utils.NumberHolder;
 
-    if (move.canBeMultiStrikeEnhanced(pokemon)) {
+    if (move.canBeMultiStrikeEnhanced(pokemon, true)) {
       this.showAbility = !!hitCount?.value;
       if (hitCount?.value) {
         hitCount.value += 1;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -846,8 +846,11 @@ export default class Move implements Localizable {
    * by enhancing effects.
    * Currently used for {@link https://bulbapedia.bulbagarden.net/wiki/Parental_Bond_(Ability) | Parental Bond}
    * and {@linkcode PokemonMultiHitModifier | Multi-Lens}.
+   * @param user The {@linkcode Pokemon} using the move
+   * @param restrictSpread `true` if the enhancing effect
+   * should not affect multi-target moves (default `false`)
    */
-  canBeMultiStrikeEnhanced(user: Pokemon): boolean {
+  canBeMultiStrikeEnhanced(user: Pokemon, restrictSpread: boolean = false): boolean {
     // Multi-strike enhancers...
 
     // ...cannot enhance moves that hit multiple targets
@@ -870,7 +873,7 @@ export default class Move implements Localizable {
       Moves.ENDEAVOR
     ];
 
-    return !isMultiTarget
+    return (!restrictSpread || !isMultiTarget)
       && !this.isChargingMove()
       && !exceptAttrs.some(attr => this.hasAttr(attr))
       && !exceptMoves.some(id => this.id === id)

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -818,8 +818,6 @@ export default class Move implements Localizable {
 
     applyMoveAttrs(VariablePowerAttr, source, target, this, power);
 
-    source.scene.applyModifiers(PokemonMultiHitModifier, source.isPlayer(), source, this.id, null, power);
-
     if (!this.hasAttr(TypelessAttr)) {
       source.scene.arena.applyTags(WeakenMoveTypeTag, simulated, this.type, power);
       source.scene.applyModifiers(AttackTypeBoosterModifier, source.isPlayer(), source, this.type, power);

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -2715,7 +2715,7 @@ export class PokemonMultiHitModifier extends PokemonHeldItemModifier {
     if (!isNullOrUndefined(count)) {
       return this.applyHitCountBoost(count);
     } else if (!isNullOrUndefined(damageMultiplier)) {
-      return this.applyPowerModifier(pokemon, damageMultiplier);
+      return this.applyDamageModifier(pokemon, damageMultiplier);
     }
 
     return false;
@@ -2732,7 +2732,7 @@ export class PokemonMultiHitModifier extends PokemonHeldItemModifier {
    * equal to (1 - the number of stacked Multi-Lenses).
    * Additional strikes beyond that are given a 0.25x damage multiplier
    */
-  private applyPowerModifier(pokemon: Pokemon, damageMultiplier: NumberHolder): boolean {
+  private applyDamageModifier(pokemon: Pokemon, damageMultiplier: NumberHolder): boolean {
     damageMultiplier.value = (pokemon.turnData.hitsLeft === pokemon.turnData.hitCount)
       ? (1 - (0.25 * this.getStackCount()))
       : 0.25;

--- a/src/test/items/multi_lens.test.ts
+++ b/src/test/items/multi_lens.test.ts
@@ -95,4 +95,23 @@ describe("Items - Multi Lens", () => {
     await game.phaseInterceptor.to("BerryPhase", false);
     expect(playerPokemon.turnData.hitCount).toBe(2);
   });
+
+  it("should enhance multi-target moves", async () => {
+    game.override
+      .battleType("double")
+      .moveset([ Moves.SWIFT, Moves.SPLASH ]);
+
+    await game.classicMode.startBattle([ Species.MAGIKARP, Species.FEEBAS ]);
+
+    const [ magikarp, ] = game.scene.getPlayerField();
+
+    game.move.select(Moves.SWIFT, 0);
+    game.move.select(Moves.SPLASH, 1);
+
+    await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2 ]);
+
+    await game.phaseInterceptor.to("MoveEndPhase");
+
+    expect(magikarp.turnData.hitCount).toBe(2);
+  });
 });


### PR DESCRIPTION
## What are the changes the user will see?
This restores Multi-Lens' ability to enhance multi-target moves. Parental Bond is unaffected.

## Why am I making these changes?
Multi-Lens was changed recently with #4831 to function with the same restrictions as Parental Bond. However, the new restriction on multi-target attacks was deemed too detrimental to new and existing Endless runs by the Balance Team and other active community members.

## What are the changes from a developer perspective?
- `Move.canBeMultiStrikeEnhanced` now has a `restrictSpread` parameter which, if true, enforces a restriction on multi-target moves for the associated multi-strike enhancement. This is set to `true` for Parental Bond and `false` (by default) for Multi-Lens
- New test in `test/items/multi_lens.test` showing the item now enhances multi-target moves.

### Screenshots/Videos

## How to test the changes?
`npm run test multi_lens`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
