### PR TITLE
[Misc] Per-Session Biome Tracking

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -10,7 +10,7 @@ import { initCommonAnims, initMoveAnim, loadCommonAnimAssets, loadMoveAnimAssets
 import { Phase } from "#app/phase";
 import { initGameSpeed } from "#app/system/game-speed";
 import { Arena, ArenaBase } from "#app/field/arena";
-import { GameData } from "#app/system/game-data";
+import { GameData, BiomeSessionData } from "#app/system/game-data";
 import { addTextObject, getTextColor, TextStyle } from "#app/ui/text";
 import { allMoves } from "#app/data/move";
 import { MusicPreference } from "#app/system/settings/settings";
@@ -259,6 +259,7 @@ export default class BattleScene extends SceneBase {
   public pokeballCounts: PokeballCounts;
   public money: integer;
   public pokemonInfoContainer: PokemonInfoContainer;
+  public biomeTracker: BiomeSessionData;
   private party: PlayerPokemon[];
   /** Session save data that pertains to Mystery Encounters */
   public mysteryEncounterSaveData: MysteryEncounterSaveData = new MysteryEncounterSaveData();
@@ -1324,6 +1325,22 @@ export default class BattleScene extends SceneBase {
   }
 
   newArena(biome: Biome): Arena {
+    const biomeTrackerLimit = 22;
+    if (Utils.isNullOrUndefined(this.biomeTracker)) {
+      this.biomeTracker = {};
+    }
+    if (this.currentBattle) {
+      this.biomeTracker[this.currentBattle.waveIndex] = biome;
+    } else {
+      this.biomeTracker[1] = biome;
+    }
+    const biomeTrackerKeys = Object.keys(this.biomeTracker).map(Number);
+    console.log(this.biomeTracker);
+    // Arbitrary limit of 22 entries per session --> Can increase or decrease
+    while (biomeTrackerKeys.length >= biomeTrackerLimit ) {
+      const smallestWave = Math.min.apply(Math, biomeTrackerKeys);
+      delete this.biomeTracker[smallestWave];
+    }
     this.arena = new Arena(this, biome, Biome[biome].toLowerCase());
     this.eventTarget.dispatchEvent(new NewArenaEvent());
 

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1274,7 +1274,7 @@ export default class BattleScene extends SceneBase {
     if (!waveIndex && lastBattle) {
       const isWaveIndexMultipleOfTen = !(lastBattle.waveIndex % 10);
       const isEndlessOrDaily = this.gameMode.hasShortBiomes || this.gameMode.isDaily;
-      const isEndlessFifthWave = this.gameMode.hasShortBiomes && (lastBattle.waveIndex % 2) === 0;
+      const isEndlessFifthWave = this.gameMode.hasShortBiomes && (lastBattle.waveIndex % 5) === 0;
       const isWaveIndexMultipleOfFiftyMinusOne = (lastBattle.waveIndex % 50) === 49;
       const isNewBiome = isWaveIndexMultipleOfTen || isEndlessFifthWave || (isEndlessOrDaily && isWaveIndexMultipleOfFiftyMinusOne);
       const resetArenaState = isNewBiome || [ BattleType.TRAINER, BattleType.MYSTERY_ENCOUNTER ].includes(this.currentBattle.battleType) || this.currentBattle.battleSpec === BattleSpec.FINAL_BOSS;

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1108,7 +1108,7 @@ export default class BattleScene extends SceneBase {
 
     [ this.luckLabelText, this.luckText ].map(t => t.setVisible(false));
 
-    this.newArena(Overrides.STARTING_BIOME_OVERRIDE || Biome.TOWN);
+    this.newArena(Overrides.STARTING_BIOME_OVERRIDE || Biome.TOWN, false);
 
     this.field.setVisible(true);
 
@@ -1274,7 +1274,7 @@ export default class BattleScene extends SceneBase {
     if (!waveIndex && lastBattle) {
       const isWaveIndexMultipleOfTen = !(lastBattle.waveIndex % 10);
       const isEndlessOrDaily = this.gameMode.hasShortBiomes || this.gameMode.isDaily;
-      const isEndlessFifthWave = this.gameMode.hasShortBiomes && (lastBattle.waveIndex % 5) === 0;
+      const isEndlessFifthWave = this.gameMode.hasShortBiomes && (lastBattle.waveIndex % 2) === 0;
       const isWaveIndexMultipleOfFiftyMinusOne = (lastBattle.waveIndex % 50) === 49;
       const isNewBiome = isWaveIndexMultipleOfTen || isEndlessFifthWave || (isEndlessOrDaily && isWaveIndexMultipleOfFiftyMinusOne);
       const resetArenaState = isNewBiome || [ BattleType.TRAINER, BattleType.MYSTERY_ENCOUNTER ].includes(this.currentBattle.battleType) || this.currentBattle.battleSpec === BattleSpec.FINAL_BOSS;
@@ -1324,18 +1324,17 @@ export default class BattleScene extends SceneBase {
     return this.currentBattle;
   }
 
-  newArena(biome: Biome): Arena {
+  newArena(biome: Biome, isReset: boolean = true): Arena {
     const biomeTrackerLimit = 22;
     if (Utils.isNullOrUndefined(this.biomeTracker)) {
       this.biomeTracker = {};
     }
-    if (this.currentBattle) {
-      this.biomeTracker[this.currentBattle.waveIndex] = biome;
-    } else {
-      this.biomeTracker[1] = biome;
+    if (isReset) {
+      if (this.currentBattle) {
+        this.biomeTracker[this.currentBattle.waveIndex] = biome;
+      }
     }
     const biomeTrackerKeys = Object.keys(this.biomeTracker).map(Number);
-    console.log(this.biomeTracker);
     // Arbitrary limit of 22 entries per session --> Can increase or decrease
     while (biomeTrackerKeys.length >= biomeTrackerLimit ) {
       const smallestWave = Math.min.apply(Math, biomeTrackerKeys);

--- a/src/phases/title-phase.ts
+++ b/src/phases/title-phase.ts
@@ -233,8 +233,10 @@ export class TitlePhase extends Phase {
         Promise.all(loadPokemonAssets).then(() => {
           this.scene.time.delayedCall(500, () => this.scene.playBgm());
           this.scene.gameData.gameStats.dailyRunSessionsPlayed++;
-          this.scene.newArena(this.scene.gameMode.getStartingBiome(this.scene));
+          const startingBiome = this.scene.gameMode.getStartingBiome(this.scene);
+          this.scene.newArena(startingBiome);
           this.scene.newBattle();
+          this.scene.biomeTracker[this.scene.currentBattle.waveIndex] = startingBiome;
           this.scene.arena.init();
           this.scene.sessionPlayTime = 0;
           this.scene.lastSavePlayTime = 0;

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -39,6 +39,7 @@ import { Device } from "#enums/devices";
 import { GameDataType } from "#enums/game-data-type";
 import { Moves } from "#enums/moves";
 import { PlayerGender } from "#enums/player-gender";
+import { Biome } from "#enums/biome";
 import { Species } from "#enums/species";
 import { applyChallenges, ChallengeType } from "#app/data/challenge";
 import { WeatherType } from "#enums/weather-type";
@@ -136,10 +137,15 @@ export interface SessionSaveData {
   challenges: ChallengeData[];
   mysteryEncounterType: MysteryEncounterType | -1; // Only defined when current wave is ME,
   mysteryEncounterSaveData: MysteryEncounterSaveData;
+  biomeTracker: BiomeSessionData;
 }
 
 interface Unlocks {
   [key: integer]: boolean;
+}
+
+export interface BiomeSessionData {
+  [key: number]: Biome;
 }
 
 interface AchvUnlocks {
@@ -963,7 +969,8 @@ export class GameData {
       timestamp: new Date().getTime(),
       challenges: scene.gameMode.challenges.map(c => new ChallengeData(c)),
       mysteryEncounterType: scene.currentBattle.mysteryEncounter?.encounterType ?? -1,
-      mysteryEncounterSaveData: scene.mysteryEncounterSaveData
+      mysteryEncounterSaveData: scene.mysteryEncounterSaveData,
+      biomeTracker: scene.biomeTracker
     } as SessionSaveData;
   }
 
@@ -1023,6 +1030,7 @@ export class GameData {
 
           scene.sessionPlayTime = sessionData.playTime || 0;
           scene.lastSavePlayTime = 0;
+          scene.biomeTracker = sessionData.biomeTracker || {};
 
           const loadPokemonAssets: Promise<void>[] = [];
 


### PR DESCRIPTION
## What are the changes the user will see?
None, ideally.

## Why am I making these changes?
Necessary groundwork for Run History 2.0 and Biome Rework. 

## What are the changes from a developer perspective?
biomeTracker, an object, has been added to session data. 
It is appended onto from newArena() in battle-scene

Problem: Fails to grab this.scene.currentBattle when starting a run because it isn't initialized yet + leads to the game freezing on boot up. Temporary workaround for Daily Mode though. 

## How to test the changes?
Recommend logging the results on console and setting waves per biome change in Endless to 2 or 3. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?