### PR TITLE
[P3][Beta] Fix failed charge moves not displaying failed text

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -668,12 +668,12 @@ export default class Move implements Localizable {
   }
 
   /**
-   * Sees if, given the target pokemon, a move fails on it (by looking at each {@linkcode MoveAttr} of this move
+   * Sees if a move has a custom failure text (by looking at each {@linkcode MoveAttr} of this move)
    * @param user {@linkcode Pokemon} using the move
    * @param target {@linkcode Pokemon} receiving the move
    * @param move {@linkcode Move} using the move
    * @param cancelled {@linkcode Utils.BooleanHolder} to hold boolean value
-   * @returns string of the failed text, or null
+   * @returns string of the custom failure text, or `null` if it uses the default text ("But it failed!")
    */
   getFailedText(user: Pokemon, target: Pokemon, move: Move, cancelled: Utils.BooleanHolder): string | null {
     for (const attr of this.attrs) {

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -378,10 +378,8 @@ export class MovePhase extends BattlePhase {
       this.pokemon.pushMoveHistory({ move: this.move.moveId, targets: this.targets, result: MoveResult.FAIL, virtual: this.move.virtual });
 
       const failureMessage = move.getFailedText(this.pokemon, targets[0], move, new BooleanHolder(false));
-      if (failureMessage) {
-        this.showMoveText();
-        this.showFailedText(failureMessage);
-      }
+      this.showMoveText();
+      this.showFailedText(failureMessage ?? undefined);
 
       // Remove the user from its semi-invulnerable state (if applicable)
       this.pokemon.lapseTags(BattlerTagLapseType.MOVE_EFFECT);


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
If a charge move fails, the game will correctly display "But it failed!"

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
#4839 introduced more bugs than we expected.

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
Charge moves no longer check for `move.getFailedText()` to return a defined value in order to display the failure text. (My understanding is that `move.getFailedText()` is intended to check for custom failure text, and it returns `null` if the move should use the default failure text of "But it failed!".)

For reference, here is the code for `showFailedText()`:
https://github.com/pagefaultgames/pokerogue/blob/4802f512ff7925037ecb90bf4d19505d1831d2a4/src/phases/move-phase.ts#L550-L552

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
<details>
<summary> Before the changes: Charge move silently fails </summary>

https://github.com/user-attachments/assets/139ee999-4a3d-4038-a4b0-11d0c970ed09

</details>
<details>
<summary> After the changes: Charge move displays "But it failed!" </summary>

https://github.com/user-attachments/assets/6885a035-2a93-401d-a75c-813c5e5c0c34

</details>

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
Fail to use a charge move (e.g., use Sky Drop against a Pokemon with a Substitute, or use Fly while Gravity is active.)

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
