### PR TITLE
[Bug] Fix level up evolution delay

### DIFF
--- a/src/phases/level-up-phase.ts
+++ b/src/phases/level-up-phase.ts
@@ -1,59 +1,66 @@
-import BattleScene from "#app/battle-scene";
+import type BattleScene from "#app/battle-scene";
 import { ExpNotification } from "#app/enums/exp-notification";
-import { EvolutionPhase } from "#app/phases/evolution-phase";
-import { PlayerPokemon } from "#app/field/pokemon";
+import type { PlayerPokemon } from "#app/field/pokemon";
 import { getPokemonNameWithAffix } from "#app/messages";
+import { EvolutionPhase } from "#app/phases/evolution-phase";
+import { LearnMovePhase } from "#app/phases/learn-move-phase";
+import { PlayerPartyMemberPokemonPhase } from "#app/phases/player-party-member-pokemon-phase";
 import { LevelAchv } from "#app/system/achv";
+import { NumberHolder } from "#app/utils";
 import i18next from "i18next";
-import * as Utils from "#app/utils";
-import { PlayerPartyMemberPokemonPhase } from "./player-party-member-pokemon-phase";
-import { LearnMovePhase } from "./learn-move-phase";
 
 export class LevelUpPhase extends PlayerPartyMemberPokemonPhase {
-  private lastLevel: integer;
-  private level: integer;
+  protected lastLevel: number;
+  protected level: number;
+  protected pokemon: PlayerPokemon = this.getPlayerPokemon();
 
-  constructor(scene: BattleScene, partyMemberIndex: integer, lastLevel: integer, level: integer) {
+  constructor(scene: BattleScene, partyMemberIndex: number, lastLevel: number, level: number) {
     super(scene, partyMemberIndex);
 
     this.lastLevel = lastLevel;
     this.level = level;
-    this.scene = scene;
   }
 
-  start() {
+  public override start() {
     super.start();
 
     if (this.level > this.scene.gameData.gameStats.highestLevel) {
       this.scene.gameData.gameStats.highestLevel = this.level;
     }
 
-    this.scene.validateAchvs(LevelAchv, new Utils.NumberHolder(this.level));
+    this.scene.validateAchvs(LevelAchv, new NumberHolder(this.level));
 
-    const pokemon = this.getPokemon();
-    const prevStats = pokemon.stats.slice(0);
-    pokemon.calculateStats();
-    pokemon.updateInfo();
+    const prevStats = this.pokemon.stats.slice(0);
+    this.pokemon.calculateStats();
+    this.pokemon.updateInfo();
     if (this.scene.expParty === ExpNotification.DEFAULT) {
       this.scene.playSound("level_up_fanfare");
-      this.scene.ui.showText(i18next.t("battle:levelUp", { pokemonName: getPokemonNameWithAffix(this.getPokemon()), level: this.level }), null, () => this.scene.ui.getMessageHandler().promptLevelUpStats(this.partyMemberIndex, prevStats, false).then(() => this.end()), null, true);
+      this.scene.ui.showText(
+        i18next.t("battle:levelUp", { pokemonName: getPokemonNameWithAffix(this.pokemon), level: this.level }),
+        null,
+        () => this.scene.ui.getMessageHandler().promptLevelUpStats(this.partyMemberIndex, prevStats, false)
+          .then(() => this.end()), null, true);
     } else if (this.scene.expParty === ExpNotification.SKIP) {
       this.end();
     } else {
       // we still want to display the stats if activated
       this.scene.ui.getMessageHandler().promptLevelUpStats(this.partyMemberIndex, prevStats, false).then(() => this.end());
     }
+  }
+
+  public override end() {
     if (this.lastLevel < 100) { // this feels like an unnecessary optimization
       const levelMoves = this.getPokemon().getLevelMoves(this.lastLevel + 1);
       for (const lm of levelMoves) {
         this.scene.unshiftPhase(new LearnMovePhase(this.scene, this.partyMemberIndex, lm[1]));
       }
     }
-    if (!pokemon.pauseEvolutions) {
-      const evolution = pokemon.getEvolution();
+    if (!this.pokemon.pauseEvolutions) {
+      const evolution = this.pokemon.getEvolution();
       if (evolution) {
-        this.scene.unshiftPhase(new EvolutionPhase(this.scene, pokemon as PlayerPokemon, evolution, this.lastLevel));
+        this.scene.unshiftPhase(new EvolutionPhase(this.scene, this.pokemon, evolution, this.lastLevel));
       }
     }
+    return super.end();
   }
 }


### PR DESCRIPTION
## What are the changes the user will see?
Pokémon will now immediately evolve after leveling up, which will also prevent the bug causing evolutions to be rolled back when the player quits immediately after evolving their Pokémon.

## Why am I making these changes?
Fixes #4039 

## What are the changes from a developer perspective?
The code handling learning new moves and level up evolution is moved to a new `this.end()` function, which calls `super.end()` (which ultimately calls `scene.shiftPhase()`) at the appropriate time instead of in the middle of the phase before it's finished running.

### Screenshots/Videos

<details>
  <summary>Evolution Phase delayed until next wave (current behavior)</summary>

https://github.com/user-attachments/assets/49bf72c6-400e-49b1-acfb-3516ce807998

</details>
<details>
  <summary>Evolution Phase immediately after Level Up Phase (PR fix)</summary>

https://github.com/user-attachments/assets/0c90d3df-9efd-4632-8f5b-fce20e0e82bf

</details>

## How to test the changes?
Bring in a pokemon that evolves by level up (such as Squirtle) and use the following overrides:
```ts
const overrides = {
  STARTING_LEVEL_OVERRIDE: 50,
  ITEM_REWARD_OVERRIDE: [{ name: "RARER_CANDY" }]
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```
Beat the first wave and used the candy to force a level up, and check that the Pokémon evolves immediately instead of waiting until after the next encounter starts. Save and quit (or reload the page) after the start of the next encounter and reload the session, the Pokémon should still be evolved.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - [x] Have I provided screenshots/videos of the changes?
