### PR TITLE
[Bug] Moved code preventing MBH's transfer to post modifier generation 

### DIFF
--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -141,10 +141,6 @@ export class EncounterPhase extends BattlePhase {
         } else if (!(battle.waveIndex % 1000)) {
           enemyPokemon.formIndex = 1;
           enemyPokemon.updateScale();
-          const bossMBH = this.scene.findModifier(m => m instanceof TurnHeldItemTransferModifier && m.pokemonId === enemyPokemon.id, false) as TurnHeldItemTransferModifier;
-          this.scene.removeModifier(bossMBH!);
-          bossMBH?.setTransferrableFalse();
-          this.scene.addEnemyModifier(bossMBH!);
         }
       }
 
@@ -220,6 +216,18 @@ export class EncounterPhase extends BattlePhase {
       if (!this.loaded && battle.battleType !== BattleType.MYSTERY_ENCOUNTER) {
         regenerateModifierPoolThresholds(this.scene.getEnemyField(), battle.battleType === BattleType.TRAINER ? ModifierPoolType.TRAINER : ModifierPoolType.WILD);
         this.scene.generateEnemyModifiers();
+        // This checks if the current battle is an Endless E-Max battle/Classic final boss and sets the MBH held by the boss to untransferrable
+        if (this.scene.currentBattle.waveIndex % 1000 || battle.battleSpec === BattleSpec.FINAL_BOSS) {
+          const enemyPokemon = this.scene.getEnemyPokemon();
+          if (enemyPokemon) {
+            const bossMBH = this.scene.findModifier(m => m instanceof TurnHeldItemTransferModifier && m.pokemonId === enemyPokemon.id, false) as TurnHeldItemTransferModifier;
+            if (bossMBH) {
+              this.scene.removeModifier(bossMBH!);
+              bossMBH?.setTransferrableFalse();
+              this.scene.addEnemyModifier(bossMBH!);
+            }
+          }
+        }
       }
 
       this.scene.ui.setMode(Mode.MESSAGE).then(() => {


### PR DESCRIPTION
## What are the changes the user will see?
MBH will no longer be able to be stolen from the opponent. 

## Why am I making these changes?
Bug report https://discord.com/channels/1125469663833370665/1300228174151680040

## What are the changes from a developer perspective?
Code moved down to correct location. 

## How to test the changes?
Try to steal MBH when generated. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
