### PR TITLE
[Bug] Battles against wild Aegislash display a message after defeat, Gulp Missile activation freezes the game if both sides faint at the same time

### DIFF
--- a/src/phases/quiet-form-change-phase.ts
+++ b/src/phases/quiet-form-change-phase.ts
@@ -29,10 +29,14 @@ export class QuietFormChangePhase extends BattlePhase {
 
     const preName = getPokemonNameWithAffix(this.pokemon);
 
-    if (!this.pokemon.isOnField() || this.pokemon.getTag(SemiInvulnerableTag)) {
-      this.pokemon.changeForm(this.formChange).then(() => {
-        this.scene.ui.showText(getSpeciesFormChangeMessage(this.pokemon, this.formChange, preName), null, () => this.end(), 1500);
-      });
+    if (!this.pokemon.isOnField() || this.pokemon.getTag(SemiInvulnerableTag) || this.pokemon.isFainted()) {
+      if (this.pokemon.isPlayer() || this.pokemon.isActive()) {
+        this.pokemon.changeForm(this.formChange).then(() => {
+          this.scene.ui.showText(getSpeciesFormChangeMessage(this.pokemon, this.formChange, preName), null, () => this.end(), 1500);
+        });
+      } else {
+        this.end();
+      }
       return;
     }
 


### PR DESCRIPTION
## What are the changes the user will see?
- Wild Aegislash fainting will not display their form change message
- Fainting at the same time as a Gulp Missile'd Cram will not freeze the game

## Why am I making these changes?
Reported bugs
[Aegislash](https://github.com/pagefaultgames/pokerogue/issues/4774)
[Cramorant](https://github.com/pagefaultgames/pokerogue/issues/4552)
I combined the two since they are closely related

## What are the changes from a developer perspective?
- More checks in `QuietFormChangePhase`
- Fainted pokemon that are not the player's will not revert form

### Screenshots/Videos

<details>
  <summary>Aegislash</summary>

https://github.com/user-attachments/assets/7d5d9890-6c0c-4d6c-97b3-6762d0b23b5c

</details>
<details>
  <summary>Cramorant</summary>

https://github.com/user-attachments/assets/64804cfe-ccb6-4c22-a71f-56d8c709e645

</details>
<details>
  <summary>Cramorant (player)</summary>

https://github.com/user-attachments/assets/ca6125ca-3a06-462c-b3f2-5f81085084c4

</details>

## How to test the changes?
I mostly used the overrides to test this. Here are the overrides I used:
```
  // OPP_SPECIES_OVERRIDE:Species.AEGISLASH, 
  // OPP_MOVESET_OVERRIDE: Moves.EXPLOSION, 
  // STARTER_SPECIES_OVERRIDE: Species.AEGISLASH, 
  // MOVESET_OVERRIDE: Moves.EXPLOSION

  // MOVESET_OVERRIDE: [Moves.FALSE_SWIPE,Moves.SELF_DESTRUCT,Moves.SPLASH],
  // OPP_SPECIES_OVERRIDE: Species.CRAMORANT,
  // OPP_MOVESET_OVERRIDE: Moves.DIVE,
  // STARTING_LEVEL_OVERRIDE: 100,

  // OPP_MOVESET_OVERRIDE: [Moves.STEEL_BEAM],
  // STARTER_SPECIES_OVERRIDE: Species.CRAMORANT,
  // MOVESET_OVERRIDE: [Moves.DIVE, Moves.SPLASH],
  // OPP_LEVEL_OVERRIDE: 18
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
