### PR TITLE
[Balance] Disable King's Rock for moves that can already flinch

### DIFF
--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -26,6 +26,7 @@ import {
   applyMoveAttrs,
   AttackMove,
   DelayedAttackAttr,
+  FlinchAttr,
   HitsTagAttr,
   MissEffectAttr,
   MoveAttr,
@@ -502,6 +503,10 @@ export class MoveEffectPhase extends PokemonPhase {
    */
   protected applyHeldItemFlinchCheck(user: Pokemon, target: Pokemon, dealsDamage: boolean) : () => void {
     return () => {
+      if (this.move.getMove().hasAttr(FlinchAttr)) {
+        return;
+      }
+
       if (dealsDamage && !target.hasAbilityWithAttr(IgnoreMoveEffectsAbAttr) && !this.move.getMove().hitsSubstitute(user, target)) {
         const flinched = new BooleanHolder(false);
         user.scene.applyModifiers(FlinchChanceModifier, user.isPlayer(), user, flinched);


### PR DESCRIPTION
## What are the changes the user will see?
King's Rock should no longer activate when the holder uses a move with built-in flinch chance.

## Why am I making these changes?
Requested by Balance Team. King's Rock's ability to stack with flinch effects is inaccurate to mainline and leads to the enemy becoming unable to act for several consecutive turns way too consistently.

## What are the changes from a developer perspective?
`phases/move-effect-phase`: `MoveEffectPhase` now checks that the invoked move doesn't have a `FlinchAttr` before applying King's Rock's effects.

### Screenshots/Videos

## How to test the changes?
Finding a consistent test case may be difficult. If you try using Rock Slide/Iron Head with 3 King's Rocks, you might be able to observe that the target(s) flinch roughly 40% less often compared to before.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [?] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
