### PR TITLE
[Balance] Set the IVs of default starters to 15

### DIFF
--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -653,7 +653,7 @@ export class FreshStartChallenge extends Challenge {
     pokemon.shiny = false; // Not shiny
     pokemon.variant = 0; // Not shiny
     pokemon.formIndex = 0; // Froakie should be base form
-    pokemon.ivs = [ 10, 10, 10, 10, 10, 10 ]; // Default IVs of 10 for all stats
+    pokemon.ivs = [ 15, 15, 15, 15, 15, 15 ]; // Default IVs of 15 for all stats (Updated to 15 from 10 in 1.2.0)
     return true;
   }
 

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1540,7 +1540,7 @@ export class GameData {
       entry.caughtAttr = defaultStarterAttr;
       entry.natureAttr = 1 << (defaultStarterNatures[ds] + 1);
       for (const i in entry.ivs) {
-        entry.ivs[i] = 10;
+        entry.ivs[i] = 15;
       }
     }
 


### PR DESCRIPTION
## What are the changes the user will see?
The default starters will all start with IVs of 15. In addition, Fresh Start Challenge will also respect this change and starters will have IVs of 15. 

## Why am I making these changes?
Balance Team request. 

## What are the changes from a developer perspective?
game-data.ts and challenges.ts edited for this change. 

### Screenshots/Videos

https://github.com/user-attachments/assets/60a48ea3-5a30-4606-a20c-945f855c568f



## How to test the changes?
1. Start a new save file + Look at the IVs of the starters in starter-selection
2. Start a Fresh Start run -> IVs of the starters should be all set to 15

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
