### PR TITLE
[Bug][Beta] Fix crash when resetting Commanded Dondozo before Trainer battles

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2158,6 +2158,11 @@ export class CommandedTag extends BattlerTag {
       pokemon.scene.triggerPokemonBattleAnim(pokemon, PokemonAnimType.COMMANDER_REMOVE);
     }
   }
+
+  override loadTag(source: BattlerTag | any): void {
+    super.loadTag(source);
+    this._tatsugiriFormKey = source._tatsugiriFormKey;
+  }
 }
 
 /**

--- a/src/phases/pokemon-anim-phase.ts
+++ b/src/phases/pokemon-anim-phase.ts
@@ -312,6 +312,10 @@ export class PokemonAnimPhase extends BattlePhase {
     // Note: unlike the other Commander animation, this is played through the
     // Dondozo instead of the Tatsugiri.
     const tatsugiri = this.pokemon.getAlly();
+    if (isNullOrUndefined(tatsugiri)) {
+      console.warn("Aborting COMMANDER_REMOVE anim: Tatsugiri is undefined");
+      return this.end();
+    }
 
     const tatsuSprite = this.scene.addPokemonSprite(
       tatsugiri,


### PR DESCRIPTION
## What are the changes the user will see?
This fixes a couple of bugs in Commander's implementation:
- Fixed an issue where the game would crash when transitioning from a double battle to a Trainer battle while a commanded Dondozo is on the field.
- Fixed an issue where Tatsugiri's form was not stored correctly on reload, causing Order Up to raise the wrong stat.

## Why am I making these changes?
Commander animations are hard to manage :goomed:

## What are the changes from a developer perspective?
- `phases/pokemon-anim-phase`: Added a failsafe to Commander's remove animation to abort the animation if the Dondozo's ally isn't fetched correctly.
- `data/battler-tags`: Added a `loadTag` override to `CommandedTag` to load the stored Tatsugiri form.

### Screenshots/Videos

**Transition from Double Battle to Trainer Battle**

https://github.com/user-attachments/assets/0dd8388a-c17c-44eb-93f1-476a601b1a71


## How to test the changes?
1. Use the following overrides:
   ```ts
   const overrides = {
     BATTLE_TYPE_OVERRIDE: "double",
     STARTING_WAVE_OVERRIDE: 7
   } satisfies Partial<InstanceType<typeof DefaultOverrides>>;
   ```
2. Start a run with Dondozo and Tatsugiri (in that order) and clear the wave.
3. You should be able to progress to Wave 8 (a forced Trainer Battle) without crashing.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
