### PR TITLE
[Move][Beta] Freeze-dry Re-implementation

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -516,7 +516,7 @@ export class NonSuperEffectiveImmunityAbAttr extends TypeImmunityAbAttr {
   applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): boolean {
     const modifierValue = args.length > 0
       ? (args[0] as Utils.NumberHolder).value
-      : pokemon.getAttackTypeEffectiveness(attacker.getMoveType(move), attacker);
+      : pokemon.getAttackTypeEffectiveness(attacker.getMoveType(move), attacker, undefined, undefined, move);
 
     if (move instanceof AttackMove && modifierValue < 2) {
       cancelled.value = true; // Suppresses "No Effect" message
@@ -3180,7 +3180,7 @@ function getAnticipationCondition(): AbAttrCondition {
           continue;
         }
         // the move's base type (not accounting for variable type changes) is super effective
-        if (move.getMove() instanceof AttackMove && pokemon.getAttackTypeEffectiveness(move.getMove().type, opponent, true) >= 2) {
+        if (move.getMove() instanceof AttackMove && pokemon.getAttackTypeEffectiveness(move.getMove().type, opponent, true, undefined, move.getMove()) >= 2) {
           return true;
         }
         // move is a OHKO


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
1. Freeze-dry will correctly account for Terastallization.
2. Freeze-dry will correctly account for a third type added by Forest's Curse.

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
#4840 making `FreezeDryAttr` fully recalculate Freeze-dry's type effectiveness is not ideal. Moreover, that PR did not match the usual type effectiveness calculations exactly, leading to the bugs described above.

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
1. `FreezeDryAttr` now extends a new class `VariableMoveTypeChartAttr` that applies type chart changes to each of the target's individual types.
2. Removed an `.edgeCase()` tag regarding Freeze-Dry's interaction with Tera Shell, since this interaction works correctly. Also added a test for the Tera Shell interaction.
3. Added some more tests.

@geeilhan Sorry for undoing your hard work. You tried your best, and we truly appreciate your work.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
<details>
<summary> Before the changes: Freeze-dry is 1x effective against Empoleon affected by Forest's Curse </summary>

https://github.com/user-attachments/assets/9843ae98-009a-464b-96f9-8cf73119410d

</details>
<details>
<summary> After the changes: Freeze-dry is 2x effective against Empoleon affected by Forest's Curse </summary>

https://github.com/user-attachments/assets/98c1926a-333f-414a-8f26-ad0ec99eb610

</details>
<details>
<summary> Before the changes: Freeze-dry is 1x effective against Tera-Water Camerupt </summary>

https://github.com/user-attachments/assets/7eba7dd9-14cb-409e-98a8-f1a5e2c53d2f

</details>
<details>
<summary> After the changes: Freeze-dry is 2x effective against Tera-Water Camerupt </summary>

https://github.com/user-attachments/assets/aa013a5f-84e2-45ad-ba88-2ce121a0d434

</details>
<details>
<summary> After the changes: Freeze-dry is still 0.5x effective against Tera Shell </summary>

https://github.com/user-attachments/assets/96ef9a19-d54e-45d2-8129-2bbb7d7af1f2

</details>

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
`npm run test freeze_dry`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
