### PR TITLE
[Balance] Endure Tokens only endure one hit

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -1503,8 +1503,8 @@ export class ContactBurnProtectedTag extends DamageProtectedTag {
 }
 
 export class EnduringTag extends BattlerTag {
-  constructor(sourceMove: Moves) {
-    super(BattlerTagType.ENDURING, BattlerTagLapseType.TURN_END, 0, sourceMove);
+  constructor(tagType: BattlerTagType, lapseType: BattlerTagLapseType, sourceMove: Moves) {
+    super(tagType, lapseType, 0, sourceMove);
   }
 
   onAdd(pokemon: Pokemon): void {
@@ -3004,7 +3004,9 @@ export function getBattlerTag(tagType: BattlerTagType, turnCount: number, source
     case BattlerTagType.BURNING_BULWARK:
       return new ContactBurnProtectedTag(sourceMove);
     case BattlerTagType.ENDURING:
-      return new EnduringTag(sourceMove);
+      return new EnduringTag(tagType, BattlerTagLapseType.TURN_END, sourceMove);
+    case BattlerTagType.ENDURE_TOKEN:
+      return new EnduringTag(tagType, BattlerTagLapseType.AFTER_HIT, sourceMove);
     case BattlerTagType.STURDY:
       return new SturdyTag(sourceMove);
     case BattlerTagType.PERISH_SONG:

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -1502,6 +1502,11 @@ export class ContactBurnProtectedTag extends DamageProtectedTag {
   }
 }
 
+/**
+ * `BattlerTag` class for effects that cause the affected Pokemon to survive lethal attacks at 1 HP.
+ * Used for {@link https://bulbapedia.bulbagarden.net/wiki/Endure_(move) | Endure} and
+ * Endure Tokens.
+ */
 export class EnduringTag extends BattlerTag {
   constructor(tagType: BattlerTagType, lapseType: BattlerTagLapseType, sourceMove: Moves) {
     super(tagType, lapseType, 0, sourceMove);

--- a/src/enums/battler-tag-type.ts
+++ b/src/enums/battler-tag-type.ts
@@ -92,4 +92,5 @@ export enum BattlerTagType {
   COMMANDED = "COMMANDED",
   GRUDGE = "GRUDGE",
   PSYCHO_SHIFT = "PSYCHO_SHIFT",
+  ENDURE_TOKEN = "ENDURE_TOKEN",
 }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2955,6 +2955,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         surviveDamage.value = this.lapseTag(BattlerTagType.ENDURING);
       } else if (this.hp > 1 && this.getTag(BattlerTagType.STURDY)) {
         surviveDamage.value = this.lapseTag(BattlerTagType.STURDY);
+      } else if (this.hp >= 1 && this.getTag(BattlerTagType.ENDURE_TOKEN)) {
+        surviveDamage.value = this.lapseTag(BattlerTagType.ENDURE_TOKEN);
       }
       if (!surviveDamage.value) {
         this.scene.applyModifiers(SurviveDamageModifier, this.isPlayer(), this, surviveDamage);

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -3656,7 +3656,7 @@ export class EnemyEndureChanceModifier extends EnemyPersistentModifier {
       return false;
     }
 
-    target.addTag(BattlerTagType.ENDURING, 1);
+    target.addTag(BattlerTagType.ENDURE_TOKEN, 1);
 
     target.battleData.endured = true;
 

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -3647,8 +3647,8 @@ export class EnemyEndureChanceModifier extends EnemyPersistentModifier {
   }
 
   /**
-   * Applies {@linkcode EnemyEndureChanceModifier}
-   * @param target {@linkcode Pokemon} to apply the {@linkcode BattlerTagType.ENDURING} chance to
+   * Applies a chance of enduring a lethal hit of an attack
+   * @param target the {@linkcode Pokemon} to apply the {@linkcode BattlerTagType.ENDURING} chance to
    * @returns `true` if {@linkcode Pokemon} endured
    */
   override apply(target: Pokemon): boolean {

--- a/src/test/moves/endure.test.ts
+++ b/src/test/moves/endure.test.ts
@@ -1,0 +1,65 @@
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Moves - Endure", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([ Moves.THUNDER, Moves.BULLET_SEED, Moves.TOXIC ])
+      .ability(Abilities.SKILL_LINK)
+      .startingLevel(100)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.NO_GUARD)
+      .enemyMoveset(Moves.ENDURE);
+  });
+
+  it("should let the pokemon survive with 1 HP", async () => {
+    await game.classicMode.startBattle([ Species.ARCEUS ]);
+
+    game.move.select(Moves.THUNDER);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(game.scene.getEnemyPokemon()!.hp).toBe(1);
+  });
+
+  it("should let the pokemon survive with 1 HP when hit with a multihit move", async () => {
+    await game.classicMode.startBattle([ Species.ARCEUS ]);
+
+    game.move.select(Moves.BULLET_SEED);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(game.scene.getEnemyPokemon()!.hp).toBe(1);
+  });
+
+  it("shouldn't prevent fainting from indirect damage", async () => {
+    game.override.enemyLevel(100);
+    await game.classicMode.startBattle([ Species.ARCEUS ]);
+
+    const enemy = game.scene.getEnemyPokemon()!;
+    enemy.hp = 2;
+
+    game.move.select(Moves.TOXIC);
+    await game.phaseInterceptor.to("VictoryPhase");
+
+    expect(enemy.isFainted()).toBe(true);
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?
In Endless mode, the enemies' Endure Tokens will now only block a single hit when activated, rather than all instances of damage for the rest of the turn.

## Why am I making these changes?
Requested by Balance Team. Endure Tokens artificially stall the game in a way that is out of the player's control, and they contribute to making Endless an exhausting experience for some. This change should help alleviate players' frustration with the mode and make the mode more fast-paced in general.

## What are the changes from a developer perspective?
Endless Tokens now use an `ENDURE_TOKEN` battler tag type instead of the `ENDURING` type. Both types use the same `EnduringTag` class, but `ENDURE_TOKEN` is different in that it uses the `AFTER_HIT` lapse type. In turn, the enduring effect from Endure Tokens is removed immediately after the affected Pokemon is hit by an otherwise lethal attack.

### Screenshots/Videos

Enemy enduring the first hit of Tachyon Cutter, then fainting to the second:

https://github.com/user-attachments/assets/b07e3e38-958d-45e0-ba1c-320bfd95d163

## How to test the changes?

**To replicate the above video:**
1. Use the following overrides:
    ```ts
      STARTING_LEVEL_OVERRIDE: 1000,
      OPP_MODIFIER_OVERRIDE: [{name: "ENEMY_ENDURE_CHANCE", count: 46}],
      MOVESET_OVERRIDE: [ Moves.TACKLE, Moves.TACHYON_CUTTER, Moves.SALT_CURE ]
    ```
2. Start a new run in Endless mode and attack an enemy. When the enemy's Endure Tokens activate, the enemy should
  - Endure damage from Tackle completely.
  - Endure the first hit of Tachyon Cutter, then faint to the second hit.
  - Endure the hit from Salt Cure, then faint to the end-of-turn damage.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
  - I tried, but for some reason it's impossible to write working tests for persistent enemy modifiers :/
- [n/a] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
