### PR TITLE
[Move] Remove `.edgeCase()` from fully implemented moves

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -9876,11 +9876,9 @@ export function initMoves() {
       .ignoresSubstitute()
       .partial(), // Does not steal stats
     new AttackMove(Moves.SUNSTEEL_STRIKE, Type.STEEL, MoveCategory.PHYSICAL, 100, 100, 5, -1, 0, 7)
-      .ignoresAbilities()
-      .edgeCase(), // Should not ignore abilities when called virtually (metronome)
+      .ignoresAbilities(),
     new AttackMove(Moves.MOONGEIST_BEAM, Type.GHOST, MoveCategory.SPECIAL, 100, 100, 5, -1, 0, 7)
-      .ignoresAbilities()
-      .edgeCase(), // Should not ignore abilities when called virtually (metronome)
+      .ignoresAbilities(),
     new StatusMove(Moves.TEARFUL_LOOK, Type.NORMAL, -1, 20, -1, 0, 7)
       .attr(StatStageChangeAttr, [ Stat.ATK, Stat.SPATK ], -1),
     new AttackMove(Moves.ZING_ZAP, Type.ELECTRIC, MoveCategory.PHYSICAL, 80, 100, 10, 30, 0, 7)
@@ -9903,8 +9901,7 @@ export function initMoves() {
       .punchingMove(),
     new AttackMove(Moves.PHOTON_GEYSER, Type.PSYCHIC, MoveCategory.SPECIAL, 100, 100, 5, -1, 0, 7)
       .attr(PhotonGeyserCategoryAttr)
-      .ignoresAbilities()
-      .edgeCase(), // Should not ignore abilities when called virtually (metronome)
+      .ignoresAbilities(),
     /* Unused */
     new AttackMove(Moves.LIGHT_THAT_BURNS_THE_SKY, Type.PSYCHIC, MoveCategory.SPECIAL, 200, -1, 1, -1, 0, 7)
       .attr(PhotonGeyserCategoryAttr)

--- a/src/test/moves/moongeist_beam.test.ts
+++ b/src/test/moves/moongeist_beam.test.ts
@@ -1,0 +1,59 @@
+import { allMoves, RandomMoveAttr } from "#app/data/move";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Moves - Moongeist Beam", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([ Moves.MOONGEIST_BEAM, Moves.METRONOME ])
+      .ability(Abilities.BALL_FETCH)
+      .startingLevel(200)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.STURDY)
+      .enemyMoveset(Moves.SPLASH);
+  });
+
+  // Also covers Photon Geyser and Sunsteel Strike
+  it("should ignore enemy abilities", async () => {
+    await game.classicMode.startBattle([ Species.MILOTIC ]);
+
+    const enemy = game.scene.getEnemyPokemon()!;
+
+    game.move.select(Moves.MOONGEIST_BEAM);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(enemy.isFainted()).toBe(true);
+  });
+
+  // Also covers Photon Geyser and Sunsteel Strike
+  it("should not ignore enemy abilities when called by another move, such as metronome", async () => {
+    await game.classicMode.startBattle([ Species.MILOTIC ]);
+    vi.spyOn(allMoves[Moves.METRONOME].getAttrs(RandomMoveAttr)[0], "getMoveOverride").mockReturnValue(Moves.MOONGEIST_BEAM);
+
+    game.move.select(Moves.METRONOME);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(game.scene.getEnemyPokemon()!.isFainted()).toBe(false);
+    expect(game.scene.getPlayerPokemon()!.getLastXMoves()[0].move).toBe(Moves.MOONGEIST_BEAM);
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
The moves are complete. cf https://github.com/pagefaultgames/pokerogue/issues/3503#issuecomment-2478343286

## What are the changes from a developer perspective?
`.edgeCase()` is removed from some Sunsteel Strike, Moongeist Beam and Photon Geyser.

### Screenshots/Videos
`npm run test moongeist_beam`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- ~[ ] Have I tested the changes (manually)?~
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
