### PR TITLE
[Ability] Fully implement Sheer Force

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -5708,9 +5708,7 @@ export function initAbilities() {
       .condition(getSheerForceHitDisableAbCondition()),
     new Ability(Abilities.SHEER_FORCE, 5)
       .attr(MovePowerBoostAbAttr, (user, target, move) => move.chance >= 1, 5461 / 4096)
-      .attr(MoveEffectChanceMultiplierAbAttr, 0)
-      .edgeCase() // Should disable shell bell and Meloetta's relic song transformation
-      .edgeCase(), // Should disable life orb, eject button, red card, kee/maranga berry if they get implemented
+      .attr(MoveEffectChanceMultiplierAbAttr, 0), // Should disable life orb, eject button, red card, kee/maranga berry if they get implemented
     new Ability(Abilities.CONTRARY, 5)
       .attr(StatStageChangeMultiplierAbAttr, -1)
       .ignorable(),

--- a/src/data/pokemon-forms.ts
+++ b/src/data/pokemon-forms.ts
@@ -351,6 +351,10 @@ export class MeloettaFormChangePostMoveTrigger extends SpeciesFormChangePostMove
     if (pokemon.scene.gameMode.hasChallenge(Challenges.SINGLE_TYPE)) {
       return false;
     } else {
+      // Meloetta will not transform if it has the ability Sheer Force when using Relic Song
+      if (pokemon.hasAbility(Abilities.SHEER_FORCE, true)) {
+        return false;
+      }
       return super.canChange(pokemon);
     }
   }

--- a/src/data/pokemon-forms.ts
+++ b/src/data/pokemon-forms.ts
@@ -352,7 +352,7 @@ export class MeloettaFormChangePostMoveTrigger extends SpeciesFormChangePostMove
       return false;
     } else {
       // Meloetta will not transform if it has the ability Sheer Force when using Relic Song
-      if (pokemon.hasAbility(Abilities.SHEER_FORCE, true)) {
+      if (pokemon.hasAbility(Abilities.SHEER_FORCE)) {
         return false;
       }
       return super.canChange(pokemon);

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -1769,7 +1769,7 @@ export class HitHealModifier extends PokemonHeldItemModifier {
    * @returns `true` if the {@linkcode Pokemon} was healed
    */
   override apply(pokemon: Pokemon): boolean {
-    if (pokemon.turnData.totalDamageDealt && !pokemon.isFullHp()) {
+    if (pokemon.turnData.totalDamageDealt && !pokemon.isFullHp() && !pokemon.hasAbility(Abilities.SHEER_FORCE, true)) {
       const scene = pokemon.scene;
       scene.unshiftPhase(new PokemonHealPhase(scene, pokemon.getBattlerIndex(),
         toDmgValue(pokemon.turnData.totalDamageDealt / 8) * this.stackCount, i18next.t("modifier:hitHealApply", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon), typeName: this.type.name }), true));

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -756,6 +756,32 @@ export abstract class PokemonHeldItemModifier extends PersistentModifier {
   abstract getMaxHeldItemCount(pokemon?: Pokemon): number;
 }
 
+export class MoveEffectModifier extends PokemonHeldItemModifier {
+  constructor(type: ModifierType, pokemonId: number, stackCount?: number) {
+    super(type, pokemonId, stackCount);
+  }
+
+  matchType(modifier: Modifier): boolean {
+    return this.matchType(modifier);
+  }
+
+  shouldApply(pokemon?: Pokemon, ..._args: unknown[]): boolean {
+    return pokemon?.hasAbility(Abilities.SHEER_FORCE, true) ?? false;
+  }
+
+  apply(pokemon: Pokemon): boolean {
+    return this.apply(pokemon);
+  }
+
+  getMaxHeldItemCount(pokemon?: Pokemon): number {
+    return this.getMaxHeldItemCount(pokemon);
+  }
+
+  clone() {
+    return this.clone();
+  }
+}
+
 export abstract class LapsingPokemonHeldItemModifier extends PokemonHeldItemModifier {
   protected battlesLeft: number;
   public isTransferable: boolean = false;
@@ -1750,7 +1776,7 @@ export class TurnStatusEffectModifier extends PokemonHeldItemModifier {
   }
 }
 
-export class HitHealModifier extends PokemonHeldItemModifier {
+export class HitHealModifier extends MoveEffectModifier {
   constructor(type: ModifierType, pokemonId: number, stackCount?: number) {
     super(type, pokemonId, stackCount);
   }
@@ -1769,7 +1795,7 @@ export class HitHealModifier extends PokemonHeldItemModifier {
    * @returns `true` if the {@linkcode Pokemon} was healed
    */
   override apply(pokemon: Pokemon): boolean {
-    if (pokemon.turnData.totalDamageDealt && !pokemon.isFullHp() && !pokemon.hasAbility(Abilities.SHEER_FORCE, true)) {
+    if (pokemon.turnData.totalDamageDealt && !pokemon.isFullHp()) {
       const scene = pokemon.scene;
       scene.unshiftPhase(new PokemonHealPhase(scene, pokemon.getBattlerIndex(),
         toDmgValue(pokemon.turnData.totalDamageDealt / 8) * this.stackCount, i18next.t("modifier:hitHealApply", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon), typeName: this.type.name }), true));

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -1597,6 +1597,10 @@ export class BypassSpeedChanceModifier extends PokemonHeldItemModifier {
   }
 }
 
+/**
+ * Class for Pokemon held items like King's Rock
+ * Because King's Rock can be stacked in PokeRogue, unlike mainline, it does not receive a boost from Abilities.SERENE_GRACE
+ */
 export class FlinchChanceModifier extends PokemonHeldItemModifier {
   private chance: number;
   constructor(type: ModifierType, pokemonId: number, stackCount?: number) {

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -1631,7 +1631,7 @@ export class FlinchChanceModifier extends PokemonHeldItemModifier {
    */
   override apply(pokemon: Pokemon, flinched: BooleanHolder): boolean {
     // The check for pokemon.battleSummonData is to ensure that a crash doesn't occur when a Pokemon with King's Rock procs a flinch
-    if (!flinched.value && pokemon.randSeedInt(100) < (this.getStackCount() * this.chance)) {
+    if (pokemon.battleSummonData && !flinched.value && pokemon.randSeedInt(100) < (this.getStackCount() * this.chance)) {
       flinched.value = true;
       return true;
     }
@@ -1639,7 +1639,7 @@ export class FlinchChanceModifier extends PokemonHeldItemModifier {
     return false;
   }
 
-  getMaxHeldItemCount(pokemon: Pokemon): number {
+  getMaxHeldItemCount(_pokemon: Pokemon): number {
     return 3;
   }
 }

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -1405,7 +1405,7 @@ export class CritBoosterModifier extends PokemonHeldItemModifier {
    * @returns always `true`
    */
   override apply(pokemon: Pokemon, critStage: NumberHolder): boolean {
-    if (this.getSecondaryChanceMultiplier(pokemon) === 0) {
+    if (super.getSecondaryChanceMultiplier(pokemon) === 0) {
       return false;
     }
     critStage.value += this.stageIncrement;
@@ -1454,7 +1454,7 @@ export class SpeciesCritBoosterModifier extends CritBoosterModifier {
    * @returns `true` if the critical-hit level can be incremented, false otherwise
    */
   override shouldApply(pokemon: Pokemon, critStage: NumberHolder): boolean {
-    return super.shouldApply(pokemon, critStage) && this.getSecondaryChanceMultiplier(pokemon) !== 0 && (this.species.includes(pokemon.getSpeciesForm(true).speciesId) || (pokemon.isFusion() && this.species.includes(pokemon.getFusionSpeciesForm(true).speciesId)));
+    return super.shouldApply(pokemon, critStage) && super.getSecondaryChanceMultiplier(pokemon) !== 0 && (this.species.includes(pokemon.getSpeciesForm(true).speciesId) || (pokemon.isFusion() && this.species.includes(pokemon.getFusionSpeciesForm(true).speciesId)));
   }
 }
 
@@ -2671,7 +2671,7 @@ export class PokemonMoveAccuracyBoosterModifier extends PokemonHeldItemModifier 
    * @returns always `true`
    */
   override apply(pokemon: Pokemon, moveAccuracy: NumberHolder): boolean {
-    if (this.getSecondaryChanceMultiplier(pokemon)) {
+    if (super.getSecondaryChanceMultiplier(pokemon)) {
       return false;
     }
     moveAccuracy.value = Math.min(moveAccuracy.value + this.accuracyAmount * this.getStackCount(), 100);
@@ -2711,7 +2711,7 @@ export class PokemonMultiHitModifier extends PokemonHeldItemModifier {
    * @returns always `true`
    */
   override apply(pokemon: Pokemon, moveId: Moves, count: NumberHolder | null = null, damageMultiplier: NumberHolder | null = null): boolean {
-    if (this.getSecondaryChanceMultiplier(pokemon) === 0) {
+    if (super.getSecondaryChanceMultiplier(pokemon) === 0) {
       return false;
     }
     const move = allMoves[moveId];
@@ -2904,7 +2904,7 @@ export class DamageMoneyRewardModifier extends PokemonHeldItemModifier {
    * @returns always `true`
    */
   override apply(pokemon: Pokemon, multiplier: NumberHolder): boolean {
-    if (this.getSecondaryChanceMultiplier(pokemon) === 0) {
+    if (super.getSecondaryChanceMultiplier(pokemon) === 0) {
       return false;
     }
     const battleScene = pokemon.scene;

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -1368,6 +1368,7 @@ export class SpeciesStatBoosterModifier extends StatBoosterModifier {
 
 /**
  * Modifier used for held items that apply critical-hit stage boost(s).
+ * Example: Scope Lens
  * @extends PokemonHeldItemModifier
  * @see {@linkcode apply}
  */
@@ -1403,7 +1404,10 @@ export class CritBoosterModifier extends PokemonHeldItemModifier {
    * @param critStage {@linkcode NumberHolder} that holds the resulting critical-hit level
    * @returns always `true`
    */
-  override apply(_pokemon: Pokemon, critStage: NumberHolder): boolean {
+  override apply(pokemon: Pokemon, critStage: NumberHolder): boolean {
+    if (this.getSecondaryChanceMultiplier(pokemon) === 0) {
+      return false;
+    }
     critStage.value += this.stageIncrement;
     return true;
   }
@@ -1416,6 +1420,7 @@ export class CritBoosterModifier extends PokemonHeldItemModifier {
 /**
  * Modifier used for held items that apply critical-hit stage boost(s)
  * if the holder is of a specific {@linkcode Species}.
+ * Example: Leek-FarFetch'd line
  * @extends CritBoosterModifier
  * @see {@linkcode shouldApply}
  */
@@ -1449,7 +1454,7 @@ export class SpeciesCritBoosterModifier extends CritBoosterModifier {
    * @returns `true` if the critical-hit level can be incremented, false otherwise
    */
   override shouldApply(pokemon: Pokemon, critStage: NumberHolder): boolean {
-    return super.shouldApply(pokemon, critStage) && (this.species.includes(pokemon.getSpeciesForm(true).speciesId) || (pokemon.isFusion() && this.species.includes(pokemon.getFusionSpeciesForm(true).speciesId)));
+    return super.shouldApply(pokemon, critStage) && this.getSecondaryChanceMultiplier(pokemon) !== 0 && (this.species.includes(pokemon.getSpeciesForm(true).speciesId) || (pokemon.isFusion() && this.species.includes(pokemon.getFusionSpeciesForm(true).speciesId)));
   }
 }
 
@@ -1750,6 +1755,9 @@ export class TurnStatusEffectModifier extends PokemonHeldItemModifier {
   }
 }
 
+/**
+ * Modifier class associated with items like Shell Bell
+ */
 export class HitHealModifier extends PokemonHeldItemModifier {
   constructor(type: ModifierType, pokemonId: number, stackCount?: number) {
     super(type, pokemonId, stackCount);
@@ -1769,12 +1777,14 @@ export class HitHealModifier extends PokemonHeldItemModifier {
    * @returns `true` if the {@linkcode Pokemon} was healed
    */
   override apply(pokemon: Pokemon): boolean {
-    if (pokemon.turnData.totalDamageDealt && !pokemon.isFullHp() && !pokemon.hasAbility(Abilities.SHEER_FORCE, true)) {
+    if (this.getSecondaryChanceMultiplier(pokemon) === 0) {
+      return false;
+    }
+    if (pokemon.turnData.totalDamageDealt && !pokemon.isFullHp()) {
       const scene = pokemon.scene;
       scene.unshiftPhase(new PokemonHealPhase(scene, pokemon.getBattlerIndex(),
         toDmgValue(pokemon.turnData.totalDamageDealt / 8) * this.stackCount, i18next.t("modifier:hitHealApply", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon), typeName: this.type.name }), true));
     }
-
     return true;
   }
 
@@ -2616,6 +2626,9 @@ export class PokemonNatureWeightModifier extends PokemonHeldItemModifier {
   }
 }
 
+/**
+ * This class is associated with accuracy-boosting held items such as Wide Lens.
+ */
 export class PokemonMoveAccuracyBoosterModifier extends PokemonHeldItemModifier {
   public override type: PokemonMoveAccuracyBoosterModifierType;
   private accuracyAmount: number;
@@ -2657,7 +2670,10 @@ export class PokemonMoveAccuracyBoosterModifier extends PokemonHeldItemModifier 
    * @param moveAccuracy {@linkcode NumberHolder} holding the move accuracy boost
    * @returns always `true`
    */
-  override apply(_pokemon: Pokemon, moveAccuracy: NumberHolder): boolean {
+  override apply(pokemon: Pokemon, moveAccuracy: NumberHolder): boolean {
+    if (this.getSecondaryChanceMultiplier(pokemon)) {
+      return false;
+    }
     moveAccuracy.value = Math.min(moveAccuracy.value + this.accuracyAmount * this.getStackCount(), 100);
 
     return true;
@@ -2668,6 +2684,9 @@ export class PokemonMoveAccuracyBoosterModifier extends PokemonHeldItemModifier 
   }
 }
 
+/**
+ * This class is associated with items like Multi-Lens
+ */
 export class PokemonMultiHitModifier extends PokemonHeldItemModifier {
   public override type: PokemonMultiHitModifierType;
 
@@ -2692,6 +2711,9 @@ export class PokemonMultiHitModifier extends PokemonHeldItemModifier {
    * @returns always `true`
    */
   override apply(pokemon: Pokemon, moveId: Moves, count: NumberHolder | null = null, damageMultiplier: NumberHolder | null = null): boolean {
+    if (this.getSecondaryChanceMultiplier(pokemon) === 0) {
+      return false;
+    }
     const move = allMoves[moveId];
     /**
      * The move must meet Parental Bond's restrictions for this item
@@ -2859,6 +2881,9 @@ export class MoneyMultiplierModifier extends PersistentModifier {
   }
 }
 
+/**
+ * Class associated with items like Golden Punch
+ */
 export class DamageMoneyRewardModifier extends PokemonHeldItemModifier {
   constructor(type: ModifierType, pokemonId: number, stackCount?: number) {
     super(type, pokemonId, stackCount);
@@ -2879,6 +2904,9 @@ export class DamageMoneyRewardModifier extends PokemonHeldItemModifier {
    * @returns always `true`
    */
   override apply(pokemon: Pokemon, multiplier: NumberHolder): boolean {
+    if (this.getSecondaryChanceMultiplier(pokemon) === 0) {
+      return false;
+    }
     const battleScene = pokemon.scene;
     const moneyAmount = new NumberHolder(Math.floor(multiplier.value * (0.5 * this.getStackCount())));
     battleScene.applyModifiers(MoneyMultiplierModifier, true, moneyAmount);

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -756,32 +756,6 @@ export abstract class PokemonHeldItemModifier extends PersistentModifier {
   abstract getMaxHeldItemCount(pokemon?: Pokemon): number;
 }
 
-export class MoveEffectModifier extends PokemonHeldItemModifier {
-  constructor(type: ModifierType, pokemonId: number, stackCount?: number) {
-    super(type, pokemonId, stackCount);
-  }
-
-  matchType(modifier: Modifier): boolean {
-    return this.matchType(modifier);
-  }
-
-  shouldApply(pokemon?: Pokemon, ..._args: unknown[]): boolean {
-    return pokemon?.hasAbility(Abilities.SHEER_FORCE, true) ?? false;
-  }
-
-  apply(pokemon: Pokemon): boolean {
-    return this.apply(pokemon);
-  }
-
-  getMaxHeldItemCount(pokemon?: Pokemon): number {
-    return this.getMaxHeldItemCount(pokemon);
-  }
-
-  clone() {
-    return this.clone();
-  }
-}
-
 export abstract class LapsingPokemonHeldItemModifier extends PokemonHeldItemModifier {
   protected battlesLeft: number;
   public isTransferable: boolean = false;
@@ -1776,7 +1750,7 @@ export class TurnStatusEffectModifier extends PokemonHeldItemModifier {
   }
 }
 
-export class HitHealModifier extends MoveEffectModifier {
+export class HitHealModifier extends PokemonHeldItemModifier {
   constructor(type: ModifierType, pokemonId: number, stackCount?: number) {
     super(type, pokemonId, stackCount);
   }
@@ -1795,7 +1769,7 @@ export class HitHealModifier extends MoveEffectModifier {
    * @returns `true` if the {@linkcode Pokemon} was healed
    */
   override apply(pokemon: Pokemon): boolean {
-    if (pokemon.turnData.totalDamageDealt && !pokemon.isFullHp()) {
+    if (pokemon.turnData.totalDamageDealt && !pokemon.isFullHp() && !pokemon.hasAbility(Abilities.SHEER_FORCE, true)) {
       const scene = pokemon.scene;
       scene.unshiftPhase(new PokemonHealPhase(scene, pokemon.getBattlerIndex(),
         toDmgValue(pokemon.turnData.totalDamageDealt / 8) * this.stackCount, i18next.t("modifier:hitHealApply", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon), typeName: this.type.name }), true));

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -18,7 +18,6 @@ import type { VoucherType } from "#app/system/voucher";
 import { Command } from "#app/ui/command-ui-handler";
 import { addTextObject, TextStyle } from "#app/ui/text";
 import { BooleanHolder, hslToHex, isNullOrUndefined, NumberHolder, toDmgValue } from "#app/utils";
-import { Abilities } from "#enums/abilities";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { BerryType } from "#enums/berry-type";
 import { Moves } from "#enums/moves";
@@ -1625,18 +1624,6 @@ export class FlinchChanceModifier extends PokemonHeldItemModifier {
   }
 
   /**
-   * Checks for any chance modifying abilities
-   * @param pokemon
-   * @returns `2` if the pokemon involved has a Serene Grace-like ability | `1` if it does not
-   */
-  getSecondaryChanceMultiplier(pokemon: Pokemon): number {
-    if (pokemon.hasAbility(Abilities.SERENE_GRACE)) {
-      return 2;
-    }
-    return 1;
-  }
-
-  /**
    * Applies {@linkcode FlinchChanceModifier}
    * @param pokemon the {@linkcode Pokemon} that holds the item
    * @param flinched {@linkcode BooleanHolder} that is `true` if the pokemon flinched
@@ -1644,8 +1631,7 @@ export class FlinchChanceModifier extends PokemonHeldItemModifier {
    */
   override apply(pokemon: Pokemon, flinched: BooleanHolder): boolean {
     // The check for pokemon.battleSummonData is to ensure that a crash doesn't occur when a Pokemon with King's Rock procs a flinch
-    const secondaryChanceMultiplier = pokemon.battleSummonData ? this.getSecondaryChanceMultiplier(pokemon) : 1;
-    if (!flinched.value && pokemon.randSeedInt(100) < (this.getStackCount() * secondaryChanceMultiplier * this.chance)) {
+    if (!flinched.value && pokemon.randSeedInt(100) < (this.getStackCount() * this.chance)) {
       flinched.value = true;
       return true;
     }

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -766,11 +766,11 @@ export class MoveEffectModifier extends PokemonHeldItemModifier {
   }
 
   shouldApply(pokemon?: Pokemon, ..._args: unknown[]): boolean {
-    return pokemon?.hasAbility(Abilities.SHEER_FORCE, true) ?? false;
+    return !pokemon?.hasAbility(Abilities.SHEER_FORCE, true);
   }
 
-  apply(pokemon: Pokemon): boolean {
-    return this.apply(pokemon);
+  apply(pokemon: Pokemon, ...args: unknown[]): boolean {
+    return this.apply(pokemon, args);
   }
 
   getMaxHeldItemCount(pokemon?: Pokemon): number {
@@ -1787,6 +1787,10 @@ export class HitHealModifier extends MoveEffectModifier {
 
   clone() {
     return new HitHealModifier(this.type, this.pokemonId, this.stackCount);
+  }
+
+  override shouldApply(pokemon?: Pokemon, ...args: unknown[]): boolean {
+    return super.shouldApply(pokemon, ...args);
   }
 
   /**
@@ -2877,7 +2881,10 @@ export class MoneyMultiplierModifier extends PersistentModifier {
   }
 }
 
-export class DamageMoneyRewardModifier extends PokemonHeldItemModifier {
+/**
+ * Modifier class for items like Golden Punch
+ */
+export class DamageMoneyRewardModifier extends MoveEffectModifier {
   constructor(type: ModifierType, pokemonId: number, stackCount?: number) {
     super(type, pokemonId, stackCount);
   }
@@ -3311,6 +3318,10 @@ export class ContactHeldItemTransferChanceModifier extends HeldItemTransferModif
 
   getArgs(): any[] {
     return super.getArgs().concat(this.chance * 100);
+  }
+
+  shouldApply(pokemon?: Pokemon, ..._args: unknown[]): boolean {
+    return !pokemon?.hasAbility(Abilities.SHEER_FORCE, true);
   }
 
   getTransferredItemCount(): number {

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -766,11 +766,11 @@ export class MoveEffectModifier extends PokemonHeldItemModifier {
   }
 
   shouldApply(pokemon?: Pokemon, ..._args: unknown[]): boolean {
-    return !pokemon?.hasAbility(Abilities.SHEER_FORCE, true);
+    return pokemon?.hasAbility(Abilities.SHEER_FORCE, true) ?? false;
   }
 
-  apply(pokemon: Pokemon, ...args: unknown[]): boolean {
-    return this.apply(pokemon, args);
+  apply(pokemon: Pokemon): boolean {
+    return this.apply(pokemon);
   }
 
   getMaxHeldItemCount(pokemon?: Pokemon): number {
@@ -1787,10 +1787,6 @@ export class HitHealModifier extends MoveEffectModifier {
 
   clone() {
     return new HitHealModifier(this.type, this.pokemonId, this.stackCount);
-  }
-
-  override shouldApply(pokemon?: Pokemon, ...args: unknown[]): boolean {
-    return super.shouldApply(pokemon, ...args);
   }
 
   /**
@@ -2889,10 +2885,7 @@ export class MoneyMultiplierModifier extends PersistentModifier {
   }
 }
 
-/**
- * Modifier class for items like Golden Punch
- */
-export class DamageMoneyRewardModifier extends MoveEffectModifier {
+export class DamageMoneyRewardModifier extends PokemonHeldItemModifier {
   constructor(type: ModifierType, pokemonId: number, stackCount?: number) {
     super(type, pokemonId, stackCount);
   }
@@ -3326,10 +3319,6 @@ export class ContactHeldItemTransferChanceModifier extends HeldItemTransferModif
 
   getArgs(): any[] {
     return super.getArgs().concat(this.chance * 100);
-  }
-
-  shouldApply(pokemon?: Pokemon, ..._args: unknown[]): boolean {
-    return !pokemon?.hasAbility(Abilities.SHEER_FORCE, true);
   }
 
   getTransferredItemCount(): number {

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -732,11 +732,10 @@ export abstract class PokemonHeldItemModifier extends PersistentModifier {
     if (!pokemon.getLastXMoves()[0]) {
       return 1;
     }
-    const sheerForceAffected = allMoves[pokemon.getLastXMoves()[0].move].chance >= 0 && pokemon.hasAbility(Abilities.SHEER_FORCE);
-
+    const sheerForceAffected = pokemon.hasAbility(Abilities.SHEER_FORCE, true);
     if (sheerForceAffected) {
       return 0;
-    } else if (pokemon.hasAbility(Abilities.SERENE_GRACE)) {
+    } else if (pokemon.hasAbility(Abilities.SERENE_GRACE, true)) {
       return 2;
     }
     return 1;

--- a/src/test/abilities/serene_grace.test.ts
+++ b/src/test/abilities/serene_grace.test.ts
@@ -1,14 +1,13 @@
 import { BattlerIndex } from "#app/battle";
-import { applyAbAttrs, MoveEffectChanceMultiplierAbAttr } from "#app/data/ability";
-import { Stat } from "#enums/stat";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
-import * as Utils from "#app/utils";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
 import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { allMoves } from "#app/data/move";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { FlinchAttr } from "#app/data/move";
+import { FlinchChanceModifier } from "#app/modifier/modifier";
 
 
 describe("Abilities - Serene Grace", () => {
@@ -27,66 +26,42 @@ describe("Abilities - Serene Grace", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    const movesToUse = [ Moves.AIR_SLASH, Moves.TACKLE ];
-    game.override.battleType("single");
-    game.override.enemySpecies(Species.ONIX);
-    game.override.startingLevel(100);
-    game.override.moveset(movesToUse);
-    game.override.enemyMoveset([ Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE ]);
+    game.override
+      .ability(Abilities.SERENE_GRACE)
+      .moveset([ Moves.AIR_SLASH, Moves.TACKLE ])
+      .enemyLevel(10)
+      .enemyMoveset([ Moves.SPLASH ]);
   });
 
-  it("Move chance without Serene Grace", async () => {
-    const moveToUse = Moves.AIR_SLASH;
-    await game.startBattle([
-      Species.PIDGEOT
-    ]);
+  it("Serene Grace should double the secondary effect chance of a move", async () => {
+    await game.classicMode.startBattle([ Species.SHUCKLE ]);
 
+    const airSlashMove = allMoves[Moves.AIR_SLASH];
+    const airSlashFlinchAttr = airSlashMove.getAttrs(FlinchAttr)[0];
+    vi.spyOn(airSlashFlinchAttr, "getMoveChance");
 
-    game.scene.getEnemyParty()[0].stats[Stat.SPDEF] = 10000;
-    expect(game.scene.getPlayerParty()[0].formIndex).toBe(0);
-
-    game.move.select(moveToUse);
-
+    game.move.select(Moves.AIR_SLASH);
     await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.ENEMY ]);
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.move.forceHit();
+    await game.phaseInterceptor.to("BerryPhase");
 
-    // Check chance of Air Slash without Serene Grace
-    const phase = game.scene.getCurrentPhase() as MoveEffectPhase;
-    const move = phase.move.getMove();
-    expect(move.id).toBe(Moves.AIR_SLASH);
+    expect(airSlashFlinchAttr.getMoveChance).toHaveLastReturnedWith(60);
+  });
 
-    const chance = new Utils.IntegerHolder(move.chance);
-    console.log(move.chance + " Their ability is " + phase.getUserPokemon()!.getAbility().name);
-    applyAbAttrs(MoveEffectChanceMultiplierAbAttr, phase.getUserPokemon()!, null, false, chance, move, phase.getFirstTarget(), false);
-    expect(chance.value).toBe(30);
+  it("Serene Grace should double the chance of King Rock's activating", async () => {
+    game.override
+      .startingHeldItems([{ name: "KINGS_ROCK", count: 1 }]);
 
-  }, 20000);
+    await game.classicMode.startBattle([ Species.SHUCKLE ]);
 
-  it("Move chance with Serene Grace", async () => {
-    const moveToUse = Moves.AIR_SLASH;
-    game.override.ability(Abilities.SERENE_GRACE);
-    await game.startBattle([
-      Species.TOGEKISS
-    ]);
+    const kingsRockInstance = game.scene.findModifier(m => m instanceof FlinchChanceModifier) as FlinchChanceModifier;
+    vi.spyOn(kingsRockInstance, "getSecondaryChanceMultiplier");
 
-    game.scene.getEnemyParty()[0].stats[Stat.SPDEF] = 10000;
-    expect(game.scene.getPlayerParty()[0].formIndex).toBe(0);
-
-    game.move.select(moveToUse);
-
+    game.move.select(Moves.TACKLE);
     await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.ENEMY ]);
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.move.forceHit();
+    await game.phaseInterceptor.to("BerryPhase");
 
-    // Check chance of Air Slash with Serene Grace
-    const phase = game.scene.getCurrentPhase() as MoveEffectPhase;
-    const move = phase.move.getMove();
-    expect(move.id).toBe(Moves.AIR_SLASH);
-
-    const chance = new Utils.IntegerHolder(move.chance);
-    applyAbAttrs(MoveEffectChanceMultiplierAbAttr, phase.getUserPokemon()!, null, false, chance, move, phase.getFirstTarget(), false);
-    expect(chance.value).toBe(60);
-
-  }, 20000);
-
-  //TODO King's Rock Interaction Unit Test
+    expect(kingsRockInstance.getSecondaryChanceMultiplier).toHaveLastReturnedWith(2);
+  });
 });

--- a/src/test/abilities/serene_grace.test.ts
+++ b/src/test/abilities/serene_grace.test.ts
@@ -27,6 +27,7 @@ describe("Abilities - Serene Grace", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     game.override
+      .battleType("single")
       .ability(Abilities.SERENE_GRACE)
       .moveset([ Moves.AIR_SLASH, Moves.TACKLE ])
       .enemyLevel(10)

--- a/src/test/abilities/serene_grace.test.ts
+++ b/src/test/abilities/serene_grace.test.ts
@@ -7,8 +7,6 @@ import Phaser from "phaser";
 import { allMoves } from "#app/data/move";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { FlinchAttr } from "#app/data/move";
-import { FlinchChanceModifier } from "#app/modifier/modifier";
-
 
 describe("Abilities - Serene Grace", () => {
   let phaserGame: Phaser.Game;
@@ -47,22 +45,5 @@ describe("Abilities - Serene Grace", () => {
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(airSlashFlinchAttr.getMoveChance).toHaveLastReturnedWith(60);
-  });
-
-  it("Serene Grace should double the chance of King Rock's activating", async () => {
-    game.override
-      .startingHeldItems([{ name: "KINGS_ROCK", count: 1 }]);
-
-    await game.classicMode.startBattle([ Species.SHUCKLE ]);
-
-    const kingsRockInstance = game.scene.findModifier(m => m instanceof FlinchChanceModifier) as FlinchChanceModifier;
-    vi.spyOn(kingsRockInstance, "getSecondaryChanceMultiplier");
-
-    game.move.select(Moves.TACKLE);
-    await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.ENEMY ]);
-    await game.move.forceHit();
-    await game.phaseInterceptor.to("BerryPhase");
-
-    expect(kingsRockInstance.getSecondaryChanceMultiplier).toHaveLastReturnedWith(2);
   });
 });

--- a/src/test/abilities/sheer_force.test.ts
+++ b/src/test/abilities/sheer_force.test.ts
@@ -152,6 +152,4 @@ describe("Abilities - Sheer Force", () => {
     await game.phaseInterceptor.to("TurnEndPhase");
     expect(formKeyStart).toBe(playerPokemon?.getFormKey());
   });
-
-  //TODO King's Rock Interaction Unit Test
 });

--- a/src/test/abilities/sheer_force.test.ts
+++ b/src/test/abilities/sheer_force.test.ts
@@ -195,7 +195,8 @@ describe("Abilities - Sheer Force", () => {
     game.override
       .ability(Abilities.SHEER_FORCE)
       .moveset([ Moves.RELIC_SONG ])
-      .enemyMoveset([ Moves.SPLASH ]);
+      .enemyMoveset([ Moves.SPLASH ])
+      .enemyLevel(100);
     await game.classicMode.startBattle([ Species.MELOETTA ]);
 
     const playerPokemon = game.scene.getPlayerPokemon();
@@ -204,6 +205,25 @@ describe("Abilities - Sheer Force", () => {
     game.move.select(Moves.RELIC_SONG);
     await game.phaseInterceptor.to("TurnEndPhase");
     expect(formKeyStart).toBe(playerPokemon?.getFormKey());
+  });
+
+  it("Sheer Force should disable healing from Shell Bell", async () => {
+    game.override
+      .ability(Abilities.SHEER_FORCE)
+      .moveset([ Moves.TACKLE ])
+      .enemySpecies(Species.GEODUDE)
+      .enemyMoveset([ Moves.TACKLE ])
+      .enemyLevel(100)
+      .startingHeldItems([{ name: "SHELL_BELL", count: 1 }]);
+
+    await game.classicMode.startBattle([ Species.SHUCKLE ]);
+    const playerPokemon = game.scene.getPlayerPokemon();
+    game.move.select(Moves.TACKLE);
+    await game.setTurnOrder([ BattlerIndex.ENEMY, BattlerIndex.PLAYER ]);
+    await game.phaseInterceptor.to("MoveEndPhase");
+    const postAttackHp = playerPokemon?.hp;
+    await game.phaseInterceptor.to("TurnEndPhase");
+    expect(playerPokemon?.hp).toBe(postAttackHp);
   });
 
   //TODO King's Rock Interaction Unit Test

--- a/src/test/abilities/sheer_force.test.ts
+++ b/src/test/abilities/sheer_force.test.ts
@@ -191,5 +191,20 @@ describe("Abilities - Sheer Force", () => {
     expect(onix.getTypes()).toStrictEqual(expectedTypes);
   });
 
+  it("Sheer Force should disable Meloetta's transformation from Relic Song", async () => {
+    game.override
+      .ability(Abilities.SHEER_FORCE)
+      .moveset([ Moves.RELIC_SONG ])
+      .enemyMoveset([ Moves.SPLASH ]);
+    await game.classicMode.startBattle([ Species.MELOETTA ]);
+
+    const playerPokemon = game.scene.getPlayerPokemon();
+    const formKeyStart = playerPokemon?.getFormKey();
+
+    game.move.select(Moves.RELIC_SONG);
+    await game.phaseInterceptor.to("TurnEndPhase");
+    expect(formKeyStart).toBe(playerPokemon?.getFormKey());
+  });
+
   //TODO King's Rock Interaction Unit Test
 });

--- a/src/test/abilities/sheer_force.test.ts
+++ b/src/test/abilities/sheer_force.test.ts
@@ -153,23 +153,5 @@ describe("Abilities - Sheer Force", () => {
     expect(formKeyStart).toBe(playerPokemon?.getFormKey());
   });
 
-  it("Sheer Force should disable healing from Shell Bell", async () => {
-    game.override
-      .ability(Abilities.SHEER_FORCE)
-      .moveset([ Moves.TACKLE ])
-      .enemySpecies(Species.GEODUDE)
-      .enemyMoveset([ Moves.TACKLE ])
-      .startingHeldItems([{ name: "SHELL_BELL", count: 1 }]);
-
-    await game.classicMode.startBattle([ Species.SHUCKLE ]);
-    const playerPokemon = game.scene.getPlayerPokemon();
-    game.move.select(Moves.TACKLE);
-    await game.setTurnOrder([ BattlerIndex.ENEMY, BattlerIndex.PLAYER ]);
-    await game.phaseInterceptor.to("MoveEndPhase");
-    const postAttackHp = playerPokemon?.hp;
-    await game.phaseInterceptor.to("TurnEndPhase");
-    expect(playerPokemon?.hp).toBe(postAttackHp);
-  });
-
   //TODO King's Rock Interaction Unit Test
 });

--- a/src/test/abilities/sheer_force.test.ts
+++ b/src/test/abilities/sheer_force.test.ts
@@ -1,15 +1,13 @@
 import { BattlerIndex } from "#app/battle";
-import { applyAbAttrs, applyPostDefendAbAttrs, applyPreAttackAbAttrs, MoveEffectChanceMultiplierAbAttr, MovePowerBoostAbAttr, PostDefendTypeChangeAbAttr } from "#app/data/ability";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
-import { NumberHolder } from "#app/utils";
+import { Type } from "#app/enums/type";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
 import { Stat } from "#enums/stat";
 import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { allMoves } from "#app/data/move";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { allMoves, FlinchAttr } from "#app/data/move";
 
 describe("Abilities - Sheer Force", () => {
   let phaserGame: Phaser.Game;
@@ -27,143 +25,91 @@ describe("Abilities - Sheer Force", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    const movesToUse = [ Moves.AIR_SLASH, Moves.BIND, Moves.CRUSH_CLAW, Moves.TACKLE ];
-    game.override.battleType("single");
-    game.override.enemySpecies(Species.ONIX);
-    game.override.startingLevel(100);
-    game.override.moveset(movesToUse);
-    game.override.enemyMoveset([ Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE ]);
+    game.override
+      .battleType("single")
+      .ability(Abilities.SHEER_FORCE)
+      .enemySpecies(Species.ONIX)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset([ Moves.SPLASH ])
+      .disableCrits();
   });
 
-  it("Sheer Force", async () => {
-    const moveToUse = Moves.AIR_SLASH;
-    game.override.ability(Abilities.SHEER_FORCE);
+  const SHEER_FORCE_MULT = 5461 / 4096;
+
+  it("Sheer Force should boost the power of the move but disable secondary effects", async () => {
+    game.override.moveset([ Moves.AIR_SLASH ]);
+    await game.classicMode.startBattle([ Species.SHUCKLE ]);
+
+    const airSlashMove = allMoves[Moves.AIR_SLASH];
+    vi.spyOn(airSlashMove, "calculateBattlePower");
+    const airSlashFlinchAttr = airSlashMove.getAttrs(FlinchAttr)[0];
+    vi.spyOn(airSlashFlinchAttr, "getMoveChance");
+
+    game.move.select(Moves.AIR_SLASH);
+
+    await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.ENEMY ]);
+    await game.move.forceHit();
+    await game.phaseInterceptor.to("BerryPhase", false);
+
+    expect(airSlashMove.calculateBattlePower).toHaveLastReturnedWith(airSlashMove.power * SHEER_FORCE_MULT);
+    expect(airSlashFlinchAttr.getMoveChance).toHaveLastReturnedWith(0);
+  });
+
+  it("Sheer Force does not affect the base damage or secondary effects of binding moves", async () => {
+    game.override.moveset([ Moves.BIND ]);
+    await game.classicMode.startBattle([ Species.SHUCKLE ]);
+
+    const bindMove = allMoves[Moves.BIND];
+    vi.spyOn(bindMove, "calculateBattlePower");
+
+    game.move.select(Moves.BIND);
+
+    await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.ENEMY ]);
+    await game.move.forceHit();
+    await game.phaseInterceptor.to("BerryPhase", false);
+
+    expect(bindMove.calculateBattlePower).toHaveLastReturnedWith(bindMove.power);
+  }, 20000);
+
+  it("Sheer Force does not boost the base damage of moves with no secondary effect", async () => {
+    game.override.moveset([ Moves.TACKLE ]);
     await game.classicMode.startBattle([ Species.PIDGEOT ]);
 
-    game.scene.getEnemyPokemon()!.stats[Stat.SPDEF] = 10000;
-    expect(game.scene.getPlayerPokemon()!.formIndex).toBe(0);
+    const tackleMove = allMoves[Moves.TACKLE];
+    vi.spyOn(tackleMove, "calculateBattlePower");
 
-    game.move.select(moveToUse);
-
+    game.move.select(Moves.TACKLE);
     await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.ENEMY ]);
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.move.forceHit();
+    await game.phaseInterceptor.to("BerryPhase", false);
 
-    const phase = game.scene.getCurrentPhase() as MoveEffectPhase;
-    const move = phase.move.getMove();
-    expect(move.id).toBe(Moves.AIR_SLASH);
+    expect(tackleMove.calculateBattlePower).toHaveLastReturnedWith(tackleMove.power);
+  });
 
-    //Verify the move is boosted and has no chance of secondary effects
-    const power = new NumberHolder(move.power);
-    const chance = new NumberHolder(move.chance);
+  it("Sheer Force can disable the on-hit activation of specific abilities", async () => {
+    game.override
+      .moveset([ Moves.HEADBUTT ])
+      .enemySpecies(Species.SQUIRTLE)
+      .enemyLevel(10)
+      .enemyAbility(Abilities.COLOR_CHANGE);
 
-    applyAbAttrs(MoveEffectChanceMultiplierAbAttr, phase.getUserPokemon()!, null, false, chance, move, phase.getFirstTarget(), false);
-    applyPreAttackAbAttrs(MovePowerBoostAbAttr, phase.getUserPokemon()!, phase.getFirstTarget()!, move, false, power);
-
-    expect(chance.value).toBe(0);
-    expect(power.value).toBe(move.power * 5461 / 4096);
-
-
-  }, 20000);
-
-  it("Sheer Force with exceptions including binding moves", async () => {
-    const moveToUse = Moves.BIND;
-    game.override.ability(Abilities.SHEER_FORCE);
     await game.classicMode.startBattle([ Species.PIDGEOT ]);
+    const enemyPokemon = game.scene.getEnemyPokemon();
+    const headbuttMove = allMoves[Moves.HEADBUTT];
+    vi.spyOn(headbuttMove, "calculateBattlePower");
+    const headbuttFlinchAttr = headbuttMove.getAttrs(FlinchAttr)[0];
+    vi.spyOn(headbuttFlinchAttr, "getMoveChance");
 
-
-    game.scene.getEnemyPokemon()!.stats[Stat.DEF] = 10000;
-    expect(game.scene.getPlayerPokemon()!.formIndex).toBe(0);
-
-    game.move.select(moveToUse);
-
-    await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.ENEMY ]);
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
-
-    const phase = game.scene.getCurrentPhase() as MoveEffectPhase;
-    const move = phase.move.getMove();
-    expect(move.id).toBe(Moves.BIND);
-
-    //Binding moves and other exceptions are not affected by Sheer Force and have a chance.value of -1
-    const power = new NumberHolder(move.power);
-    const chance = new NumberHolder(move.chance);
-
-    applyAbAttrs(MoveEffectChanceMultiplierAbAttr, phase.getUserPokemon()!, null, false, chance, move, phase.getFirstTarget(), false);
-    applyPreAttackAbAttrs(MovePowerBoostAbAttr, phase.getUserPokemon()!, phase.getFirstTarget()!, move, false, power);
-
-    expect(chance.value).toBe(-1);
-    expect(power.value).toBe(move.power);
-
-
-  }, 20000);
-
-  it("Sheer Force with moves with no secondary effect", async () => {
-    const moveToUse = Moves.TACKLE;
-    game.override.ability(Abilities.SHEER_FORCE);
-    await game.classicMode.startBattle([ Species.PIDGEOT ]);
-
-
-    game.scene.getEnemyPokemon()!.stats[Stat.DEF] = 10000;
-    expect(game.scene.getPlayerPokemon()!.formIndex).toBe(0);
-
-    game.move.select(moveToUse);
+    game.move.select(Moves.HEADBUTT);
 
     await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.ENEMY ]);
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.move.forceHit();
+    await game.phaseInterceptor.to("BerryPhase", false);
 
-    const phase = game.scene.getCurrentPhase() as MoveEffectPhase;
-    const move = phase.move.getMove();
-    expect(move.id).toBe(Moves.TACKLE);
-
-    //Binding moves and other exceptions are not affected by Sheer Force and have a chance.value of -1
-    const power = new NumberHolder(move.power);
-    const chance = new NumberHolder(move.chance);
-
-    applyAbAttrs(MoveEffectChanceMultiplierAbAttr, phase.getUserPokemon()!, null, false, chance, move, phase.getFirstTarget(), false);
-    applyPreAttackAbAttrs(MovePowerBoostAbAttr, phase.getUserPokemon()!, phase.getFirstTarget()!, move, false, power);
-
-    expect(chance.value).toBe(-1);
-    expect(power.value).toBe(move.power);
-
-
-  }, 20000);
-
-  it("Sheer Force Disabling Specific Abilities", async () => {
-    const moveToUse = Moves.CRUSH_CLAW;
-    game.override.enemyAbility(Abilities.COLOR_CHANGE);
-    game.override.startingHeldItems([{ name: "KINGS_ROCK", count: 1 }]);
-    game.override.ability(Abilities.SHEER_FORCE);
-    await game.startBattle([ Species.PIDGEOT ]);
-
-
-    game.scene.getEnemyPokemon()!.stats[Stat.DEF] = 10000;
-    expect(game.scene.getPlayerPokemon()!.formIndex).toBe(0);
-
-    game.move.select(moveToUse);
-
-    await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.ENEMY ]);
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
-
-    const phase = game.scene.getCurrentPhase() as MoveEffectPhase;
-    const move = phase.move.getMove();
-    expect(move.id).toBe(Moves.CRUSH_CLAW);
-
-    //Disable color change due to being hit by Sheer Force
-    const power = new NumberHolder(move.power);
-    const chance = new NumberHolder(move.chance);
-    const user = phase.getUserPokemon()!;
-    const target = phase.getFirstTarget()!;
-    const opponentType = target.getTypes()[0];
-
-    applyAbAttrs(MoveEffectChanceMultiplierAbAttr, user, null, false, chance, move, target, false);
-    applyPreAttackAbAttrs(MovePowerBoostAbAttr, user, target, move, false, power);
-    applyPostDefendAbAttrs(PostDefendTypeChangeAbAttr, target, user, move, target.apply(user, move));
-
-    expect(chance.value).toBe(0);
-    expect(power.value).toBe(move.power * 5461 / 4096);
-    expect(target.getTypes().length).toBe(2);
-    expect(target.getTypes()[0]).toBe(opponentType);
-
-  }, 20000);
+    expect(enemyPokemon?.getTypes()[0]).toBe(Type.WATER);
+    expect(headbuttMove.calculateBattlePower).toHaveLastReturnedWith(headbuttMove.power * SHEER_FORCE_MULT);
+    expect(headbuttFlinchAttr.getMoveChance).toHaveLastReturnedWith(0);
+  });
 
   it("Two Pokemon with abilities disabled by Sheer Force hitting each other should not cause a crash", async () => {
     const moveToUse = Moves.CRUNCH;
@@ -213,7 +159,6 @@ describe("Abilities - Sheer Force", () => {
       .moveset([ Moves.TACKLE ])
       .enemySpecies(Species.GEODUDE)
       .enemyMoveset([ Moves.TACKLE ])
-      .enemyLevel(100)
       .startingHeldItems([{ name: "SHELL_BELL", count: 1 }]);
 
     await game.classicMode.startBattle([ Species.SHUCKLE ]);


### PR DESCRIPTION
## What are the changes the user will see?
If Meloetta happens to have the ability Sheer Force when using Relic Song, she does not transform.  
Serene Grace does not affect King's Rock proc chance anymore (Balance decision).

## Why am I making these changes?
Shareholder value up!

## What are the changes from a developer perspective?
Conditionals added to MeloettaFormChangePostMoveTrigger that check for Sheer Force. Tests also added. Serene Grace and Sheer Force tests modernized.

## How to test the changes?
1. Use Relic Song with a Meloetta that has the ability Sheer Force

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
