### PR TITLE
[Misc] Mark Rage Fist as partial in line with similar moves/abilities

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -10554,6 +10554,7 @@ export function initMoves() {
     new AttackMove(Moves.TWIN_BEAM, Type.PSYCHIC, MoveCategory.SPECIAL, 40, 100, 10, -1, 0, 9)
       .attr(MultiHitAttr, MultiHitType._2),
     new AttackMove(Moves.RAGE_FIST, Type.GHOST, MoveCategory.PHYSICAL, 50, 100, 10, -1, 0, 9)
+      .partial() // Counter resets every wave instead of on arena reset
       .attr(HitCountPowerAttr)
       .punchingMove(),
     new AttackMove(Moves.ARMOR_CANNON, Type.FIRE, MoveCategory.SPECIAL, 120, 100, 5, -1, 0, 9)


### PR DESCRIPTION
## What are the changes the user will see?
Rage Fist will now be marked "(P)".

## Why am I making these changes?
> Rage Fist should be marked P in accordance with Balance's Decision on Last Respects, Supreme Overlord, that it should not be resetting per wave as it does currently
- https://github.com/pagefaultgames/pokerogue/issues/3503#issuecomment-2480913593

## What are the changes from a developer perspective?
Added `.partial() // Counter resets every wave instead of on arena reset` to Rage Fist.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I considered writing automated tests for the issue?~
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - ~[ ] Have I provided screenshots/videos of the changes?~
