### PR TITLE
[Balance] Multi Lens damage reduction on fixed-damage moves

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2622,6 +2622,10 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     const fixedDamage = new Utils.IntegerHolder(0);
     applyMoveAttrs(FixedDamageAttr, source, this, move, fixedDamage);
     if (fixedDamage.value) {
+      const multiLensMultiplier = new Utils.NumberHolder(1);
+      source.scene.applyModifiers(PokemonMultiHitModifier, source.isPlayer(), source, move.id, null, multiLensMultiplier);
+      fixedDamage.value = Utils.toDmgValue(fixedDamage.value * multiLensMultiplier.value);
+
       return {
         cancelled: false,
         result: HitResult.EFFECTIVE,

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -2727,10 +2727,18 @@ export class PokemonMultiHitModifier extends PokemonHeldItemModifier {
    * Additional strikes beyond that are given a 0.25x damage multiplier
    */
   private applyDamageModifier(pokemon: Pokemon, damageMultiplier: NumberHolder): boolean {
-    damageMultiplier.value = (pokemon.turnData.hitsLeft === pokemon.turnData.hitCount)
-      ? (1 - (0.25 * this.getStackCount()))
-      : 0.25;
-    return true;
+    if (pokemon.turnData.hitsLeft === pokemon.turnData.hitCount) {
+      // Reduce first hit by 25% for each stack count
+      damageMultiplier.value *= 1 - 0.25 * this.getStackCount();
+      return true;
+    } else if (pokemon.turnData.hitCount - pokemon.turnData.hitsLeft !== this.getStackCount() + 1) {
+      // Deal 25% damage for each remaining Multi Lens hit
+      damageMultiplier.value *= 0.25;
+      return true;
+    } else {
+      // An extra hit not caused by Multi Lens -- assume it is Parental Bond
+      return false;
+    }
   }
 
   getMaxHeldItemCount(pokemon: Pokemon): number {

--- a/src/test/abilities/parental_bond.test.ts
+++ b/src/test/abilities/parental_bond.test.ts
@@ -313,7 +313,7 @@ describe("Abilities - Parental Bond", () => {
 
       await game.phaseInterceptor.to("MoveEndPhase", false);
 
-      expect(enemyPokemon.hp).toBe(enemyStartingHp - 300);
+      expect(enemyPokemon.hp).toBe(enemyStartingHp - 200);
     }
   );
 


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
Multi Lens will apply proper damage reduction to fixed-damage moves.
Affected moves: Sonic Boom, Dragon Rage, Super Fang, Nature's Madness, Ruination, Counter, Mirror Coat, Metal Burst, Comeuppance, Seismic Toss, Night Shade, Psywave.

**Note**: This implementation technically causes `TargetHalfHpDamageAttr` (e.g. Super Fang) to deal slightly less damage if used with Multi Lens.
With 1 Multi Lens, the damage dealt is around 45% (1 - 0.625 * 0.875) of the target's HP.
With 2 Multi Lens, the damage dealt is around 43% (1 - 0.75 * 0.875 * 0.875) of the target's HP.

## Why am I making these changes?
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->
Requested by balance, due to recent Multi Lens changes now allowing Multi Lens to activate on fixed-damage moves.

## What are the changes from a developer perspective?
<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->
1. `PokemonMultiHitModifier` now gets applied to fixed-damage moves.
2. Rewrote `PokemonMultiHitModifier` slightly to account for interaction with Parental Bond on fixed-damage moves.
3. Added a test.

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->
(Note: Cubone has 2 Multi Lens and Parental Bond in these videos. Hits 1-3 are Multi Lens, Hit 4 is Parental Bond. Ignore the critical hit on the first hit, it's a visual bug unrelated to Multi Lens: #4499)
<details>
<summary> Before the changes: Multi Lens does not apply damage reduction to Seismic Toss </summary>

https://github.com/user-attachments/assets/d5135e82-075a-4ced-ab1a-62a7a348cad1

</details>
<details>
<summary> After the changes: Multi Lens applies damage reduction to Seismic Toss </summary>

https://github.com/user-attachments/assets/54edaf02-18c2-40a2-a51f-040ec14d7aad

</details>

## How to test the changes?
<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->
`npm run test parental_bond`
`npm run test multi_lens`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- ~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
