### PR TITLE
[Bug][P1] Wave 10x Boss Pokemon can no longer flee battles with Wimp Out 

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -4953,7 +4953,7 @@ class ForceSwitchOutHelper {
      * For wild Pokémon battles, the Pokémon will flee if the conditions are met (waveIndex and double battles).
      */
     } else {
-      if (!pokemon.scene.currentBattle.waveIndex && pokemon.scene.currentBattle.waveIndex % 10 === 0) {
+      if (!pokemon.scene.currentBattle.waveIndex || pokemon.scene.currentBattle.waveIndex % 10 === 0) {
         return false;
       }
 


### PR DESCRIPTION
## Why am I making these changes?
Bug Reported by @PigeonBar 
Video Provided: 

https://github.com/user-attachments/assets/85dbe724-3b7a-4125-b020-e0eeae6c5c9b

## What are the changes from a developer perspective?
Conditional changed from AND to OR. 

## How to test the changes?
1. Fight a boss with Wimp Out/Wimp Out Sr. 
2. The boss should not flee when it hits the activation threshold for the ability. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
