### PR TITLE
[Balance] Make Intrepid Sword / Dauntless Shield their Generation 8 Implementation

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -6092,10 +6092,8 @@ export function initAbilities() {
       .attr(MovePowerBoostAbAttr, (user, target, move) => (target?.getMoveEffectiveness(user!, move) ?? 1) >= 2, 1.25),
     new Ability(Abilities.INTREPID_SWORD, 8)
       .attr(PostSummonStatStageChangeAbAttr, [ Stat.ATK ], 1, true)
-      .condition(getOncePerBattleCondition(Abilities.INTREPID_SWORD)),
     new Ability(Abilities.DAUNTLESS_SHIELD, 8)
       .attr(PostSummonStatStageChangeAbAttr, [ Stat.DEF ], 1, true)
-      .condition(getOncePerBattleCondition(Abilities.DAUNTLESS_SHIELD)),
     new Ability(Abilities.LIBERO, 8)
       .attr(PokemonTypeChangeAbAttr),
     //.condition((p) => !p.summonData?.abilitiesApplied.includes(Abilities.LIBERO)), //Gen 9 Implementation

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -6091,9 +6091,9 @@ export function initAbilities() {
     new Ability(Abilities.NEUROFORCE, 7)
       .attr(MovePowerBoostAbAttr, (user, target, move) => (target?.getMoveEffectiveness(user!, move) ?? 1) >= 2, 1.25),
     new Ability(Abilities.INTREPID_SWORD, 8)
-      .attr(PostSummonStatStageChangeAbAttr, [ Stat.ATK ], 1, true)
+      .attr(PostSummonStatStageChangeAbAttr, [ Stat.ATK ], 1, true),
     new Ability(Abilities.DAUNTLESS_SHIELD, 8)
-      .attr(PostSummonStatStageChangeAbAttr, [ Stat.DEF ], 1, true)
+      .attr(PostSummonStatStageChangeAbAttr, [ Stat.DEF ], 1, true),
     new Ability(Abilities.LIBERO, 8)
       .attr(PokemonTypeChangeAbAttr),
     //.condition((p) => !p.summonData?.abilitiesApplied.includes(Abilities.LIBERO)), //Gen 9 Implementation


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
Players should once again see Intrepid Sword / Dauntless shield activate multiple times in a battle

## Why am I making these changes?
The abilities were bugged to work as their Gen 8 variants until the Nov. 17th update that fixed the bug. With Zacian and Zamazenta receiving stat nerfs and multiple Pokemon having it as their passive, it was in an acceptable state to keep in the game so it was decided with Damo's approval to make them their Gen 8 variants as we did other abilities such as Protean. Another thing is the description of the abilities were using the Gen 8 description which does not align with their current implementation so it saves localization team the trouble!

## What are the changes from a developer perspective?
Removed getOncePerBattleCondition from both Intrepid Sword and Dauntless Shield

### Screenshots/Videos
![Untitled video - Made with Clipchamp (3)](https://github.com/user-attachments/assets/0347fd92-073a-4141-a151-f4093e3396d4)



## How to test the changes?
Overrides

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
