### PR TITLE
[Hotfix] Prevent crash if enemy Future Sight user is caught

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pokemon-rogue-battle",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pokemon-rogue-battle",
-			"version": "1.2.0",
+			"version": "1.2.1",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@material/material-color-utilities": "^0.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pokemon-rogue-battle",
 	"private": true,
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"type": "module",
 	"scripts": {
 		"start": "vite",

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3243,11 +3243,14 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     return null;
   }
 
-  getMoveHistory(): TurnMove[] {
+  public getMoveHistory(): TurnMove[] {
     return this.battleSummonData.moveHistory;
   }
 
-  pushMoveHistory(turnMove: TurnMove) {
+  public pushMoveHistory(turnMove: TurnMove): void {
+    if (!this.isOnField()) {
+      return;
+    }
     turnMove.turn = this.scene.currentBattle?.turn;
     this.getMoveHistory().push(turnMove);
   }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3101,10 +3101,10 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   lapseTag(tagType: BattlerTagType): boolean {
-    const tags = this.summonData?.tags;
-    if (isNullOrUndefined(tags)) {
+    if (!this.summonData) {
       return false;
     }
+    const tags = this.summonData.tags;
     const tag = tags.find(t => t.tagType === tagType);
     if (tag && !(tag.lapse(this, BattlerTagLapseType.CUSTOM))) {
       tag.onRemove(this);
@@ -3114,6 +3114,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   lapseTags(lapseType: BattlerTagLapseType): void {
+    if (!this.summonData) {
+      return;
+    }
     const tags = this.summonData.tags;
     tags.filter(t => lapseType === BattlerTagLapseType.FAINT || ((t.lapseTypes.some(lType => lType === lapseType)) && !(t.lapse(this, lapseType)))).forEach(t => {
       t.onRemove(this);
@@ -3122,6 +3125,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   removeTag(tagType: BattlerTagType): boolean {
+    if (!this.summonData) {
+      return false;
+    }
     const tags = this.summonData.tags;
     const tag = tags.find(t => t.tagType === tagType);
     if (tag) {

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -92,8 +92,12 @@ export class MoveEffectPhase extends PokemonPhase {
 
     const isDelayedAttack = this.move.getMove().hasAttr(DelayedAttackAttr);
     /** If the user was somehow removed from the field and it's not a delayed attack, end this phase */
-    if (!user.isOnField() && !isDelayedAttack) {
-      return super.end();
+    if (!user.isOnField()) {
+      if (!isDelayedAttack) {
+        return super.end();
+      } else {
+        user.resetTurnData();
+      }
     }
 
     /**
@@ -174,7 +178,7 @@ export class MoveEffectPhase extends PokemonPhase {
 
       const playOnEmptyField = this.scene.currentBattle?.mysteryEncounter?.hasBattleAnimationsWithoutTargets ?? false;
       // Move animation only needs one target
-      new MoveAnim(move.id as Moves, user, this.getFirstTarget()!.getBattlerIndex()!, playOnEmptyField).play(this.scene, move.hitsSubstitute(user, this.getFirstTarget()!), () => {
+      new MoveAnim(move.id as Moves, user, this.getFirstTarget()!.getBattlerIndex(), playOnEmptyField).play(this.scene, move.hitsSubstitute(user, this.getFirstTarget()!), () => {
         /** Has the move successfully hit a target (for damage) yet? */
         let hasHit: boolean = false;
         for (const target of targets) {


### PR DESCRIPTION
## What are the changes the user will see?
The game will no longer crash if a Pokémon that used Future Sight is caught.

## Why am I making these changes?
Bug report: https://discord.com/channels/1125469663833370665/1307871092261523567

## What are the changes from a developer perspective?
If the user of the move in `MoveEffectPhase` has no turn data and it's a delayed attack (ie: Future Sight), initialize it.
`Pokemon.pushMoveHistory()` checks if the Pokémon is on the field and returns early if it isn't.

### Screenshots/Videos

https://github.com/user-attachments/assets/c75e426f-fe86-4e02-9933-290f0a4253ac

## How to test the changes?
Use these overrides and start a new run. Stall the first turn so the enemy Pokémon uses Future Sight, then catch it the next turn. In the following turn, do whatever, and get hit by the Future Sight attack. At this point the game should continue on as normal instead of crashing.
```ts
const overrides = {
  OPP_MOVESET_OVERRIDE: Moves.FUTURE_SIGHT,
  POKEBALL_OVERRIDE: {
    active: true,
    pokeballs: {
      [PokeballType.POKEBALL]: 5,
      [PokeballType.GREAT_BALL]: 0,
      [PokeballType.ULTRA_BALL]: 0,
      [PokeballType.ROGUE_BALL]: 0,
      [PokeballType.MASTER_BALL]: 110,
    },
  }
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

## Checklist
- ~[ ] **I'm using `beta` as my base branch**~
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- ~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- ~[ ] Are the changes visual?~
  - [x] Have I provided screenshots/videos of the changes?
