### PR TITLE
[Balance][Ability] Remove Supersweet Syrup's once-per-battle condition

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -6343,8 +6343,7 @@ export function initAbilities() {
       .attr(IgnoreOpponentStatStagesAbAttr, [ Stat.EVA ])
       .ignorable(),
     new Ability(Abilities.SUPERSWEET_SYRUP, 9)
-      .attr(PostSummonStatStageChangeAbAttr, [ Stat.EVA ], -1)
-      .condition(getOncePerBattleCondition(Abilities.SUPERSWEET_SYRUP)),
+      .attr(PostSummonStatStageChangeAbAttr, [ Stat.EVA ], -1),
     new Ability(Abilities.HOSPITALITY, 9)
       .attr(PostSummonAllyHealAbAttr, 4, true),
     new Ability(Abilities.TOXIC_CHAIN, 9)


### PR DESCRIPTION
> [!IMPORTANT]
> This balance change requires adjustments to Supersweet Syrup's description and therefore requires Senior Translator approval. The corresponding locale changes are available at https://github.com/pagefaultgames/pokerogue-locales/pull/53

## What are the changes the user will see?
Supersweet Syrup should now activate whenever the source enters the field, not just on the first time in battle.

## Why am I making these changes?
This was discussed alongside reverting Intrepid Sword and Dauntless Shield to their Gen 8 implementations (see #4902). The once-per-battle condition on Supersweet Syrup is widely lamented even outside of this game, and the Hydrapple line deserves some love.

## What are the changes from a developer perspective?
- `data/ability`: Removed `getOncePerBattleCondition()` from Supersweet Syrup. 

### Screenshots/Videos
<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
1. Using overrides, give your Pokemon Supersweet Syrup.
2. In battle, switching your Pokemon with Supersweet Syrup out then back in should reactivate the ability.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
