### PR TITLE
[Hotfix] Prevent Future Sight crash with new catches, attempt 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pokemon-rogue-battle",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pokemon-rogue-battle",
-			"version": "1.2.1",
+			"version": "1.2.2",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@material/material-color-utilities": "^0.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pokemon-rogue-battle",
 	"private": true,
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"type": "module",
 	"scripts": {
 		"start": "vite",

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -96,6 +96,14 @@ export class MoveEffectPhase extends PokemonPhase {
       if (!isDelayedAttack) {
         return super.end();
       } else {
+        if (!user.scene) {
+          /**
+           * This happens if the Pokemon that used the delayed attack gets caught and released
+           * on the turn the attack would have triggered. Having access to the global scene
+           * in the future may solve this entirely, so for now we just cancel the hit
+           */
+          return super.end();
+        }
         user.resetTurnData();
       }
     }


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

## What are the changes the user will see?
Catching and releasing a Pokemon that used Future Sight on the turn FS was supposed to trigger will no longer freeze the game.

<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?
[Discord bug report](https://discord.com/channels/1125469663833370665/1307871092261523567/1308031755420434453)
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What are the changes from a developer perspective?
At the moment FS goes through a move effect phase so it expects the user Pokemon to be around to perform hit checks and other things. For a Pokemon that was caught and released the turn FS would hit a lot of its attributes are gone at this point, causing the checks to crash the game.
One of the undefined attributes is the Pokemon's scene reference, which should get solved in the future with PR #4766 
So hopefully this will just resolve itself with that in the future

As FS is still P and I'm not entirely sure that it should go through hit checks and everything in the first place, I don't really want to add null/undefined checks everywhere for this. So for now instead the Move Effect Phase is just ended and so FS will not hit in this specific scenario. Of note, FS already does not trigger if you catch and release the Pokemon one turn before FS is supposed to hit, so this makes the overall behavior a little more consistent.


<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos
Before: 
![image](https://github.com/user-attachments/assets/c8d4faec-d6ac-4af8-a358-77741cb9ae4b)

After:

https://github.com/user-attachments/assets/14feffea-7664-40e9-a187-c6dd97989db1

<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
<details><summary>Overrides:</summary>

```
  MOVESET_OVERRIDE: Moves.FALSE_SWIPE,
  OPP_MOVESET_OVERRIDE: Moves.FUTURE_SIGHT,
  STARTING_LEVEL_OVERRIDE: 50,
  STARTING_WAVE_OVERRIDE: 9,
  POKEBALL_OVERRIDE: {
    active: true,
    pokeballs: {
      [PokeballType.POKEBALL]: 5,
      [PokeballType.GREAT_BALL]: 0,
      [PokeballType.ULTRA_BALL]: 0,
      [PokeballType.ROGUE_BALL]: 0,
      [PokeballType.MASTER_BALL]: 99,
    }
  }
```
</details>

Start the run with a full team
- Turn 1: Stall so that the Pokemon uses Future Sight
- Turn 2: Stall
- Turn 3: Catch the Pokemon and release it. Game should continue as normal. FS will not hit 

<details><summary>Unchanged scenarios:</summary>

- Release - 1 turn before FS hit
  - Turn 1: Stall so that the Pokemon uses Future Sight
  - Turn 2: Catch it. Release it. Game should continue as normal. FS will not hit (was already the case before this PR)

- Keep - 1 turn before FS hit
  - Turn 1: Stall so that the Pokemon uses Future Sight
  - Turn 2: Catch it. Put in the team. Game should continue as normal and FS will hit the following turn

- Keep - turn of FS hit
  - Turn 1: Stall so that the Pokemon uses Future Sight
  - Turn 2: Stall
  - Turn 3: Catch it. Put in the team. Game should continue as normal and FS will hit
</details>

<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- ~~[ ] **I'm using `beta` as my base branch**~~
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I considered writing automated tests for the issue?
- ~~[ ] If I have text, did I make it translatable and add a key in the English locale file(s)?~~
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [X] Are the changes visual?
  - [X] Have I provided screenshots/videos of the changes?
