### PR TITLE
[Balance] 'Breeders in Space' cheevo unlocks for normal and expert breeders

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -3008,7 +3008,8 @@ export default class BattleScene extends SceneBase {
   }
 
   validateAchv(achv: Achv, args?: unknown[]): boolean {
-    if (!this.gameData.achvUnlocks.hasOwnProperty(achv.id) && achv.validate(this, args)) {
+    if ((!this.gameData.achvUnlocks.hasOwnProperty(achv.id) || Overrides.ACHIEVEMENTS_REUNLOCK_OVERRIDE)
+      && achv.validate(this, args)) {
       this.gameData.achvUnlocks[achv.id] = new Date().getTime();
       this.ui.achvBar.showAchv(achv);
       if (vouchers.hasOwnProperty(achv.id)) {

--- a/src/data/mystery-encounters/encounters/the-expert-pokemon-breeder-encounter.ts
+++ b/src/data/mystery-encounters/encounters/the-expert-pokemon-breeder-encounter.ts
@@ -21,7 +21,6 @@ import { EggSourceType } from "#enums/egg-source-types";
 import { EggTier } from "#enums/egg-type";
 import { MysteryEncounterOptionBuilder } from "#app/data/mystery-encounters/mystery-encounter-option";
 import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
-import { achvs } from "#app/system/achv";
 import { modifierTypes, PokemonHeldItemModifierType } from "#app/modifier/modifier-type";
 import { Type } from "#enums/type";
 import { getPokeballTintColor } from "#app/data/pokeball";
@@ -520,12 +519,6 @@ function removePokemonFromPartyAndStoreHeldItems(scene: BattleScene, encounter: 
   ];
 }
 
-function checkAchievement(scene: BattleScene) {
-  if (scene.arena.biomeType === Biome.SPACE) {
-    scene.validateAchv(achvs.BREEDERS_IN_SPACE);
-  }
-}
-
 function restorePartyAndHeldItems(scene: BattleScene) {
   const encounter = scene.currentBattle.mysteryEncounter!;
   // Restore original party
@@ -617,8 +610,6 @@ function onGameOver(scene: BattleScene) {
 function doPostEncounterCleanup(scene: BattleScene) {
   const encounter = scene.currentBattle.mysteryEncounter!;
   if (!encounter.misc.encounterFailed) {
-    // Give achievement if in Space biome
-    checkAchievement(scene);
     // Give 20 friendship to the chosen pokemon
     encounter.misc.chosenPokemon.addFriendship(FRIENDSHIP_ADDED);
     restorePartyAndHeldItems(scene);

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -86,6 +86,8 @@ class DefaultOverrides {
   readonly ITEM_UNLOCK_OVERRIDE: Unlockables[] = [];
   /** Set to `true` to show all tutorials */
   readonly BYPASS_TUTORIAL_SKIP_OVERRIDE: boolean = false;
+  /** Set to `true` to be able to re-earn already unlocked achievements */
+  readonly ACHIEVEMENTS_REUNLOCK_OVERRIDE: boolean = false;
   /** Set to `true` to force Paralysis and Freeze to always activate, or `false` to force them to not activate */
   readonly STATUS_ACTIVATION_OVERRIDE: boolean | null = null;
 

--- a/src/phases/trainer-victory-phase.ts
+++ b/src/phases/trainer-victory-phase.ts
@@ -9,6 +9,8 @@ import { BattlePhase } from "./battle-phase";
 import { ModifierRewardPhase } from "./modifier-reward-phase";
 import { MoneyRewardPhase } from "./money-reward-phase";
 import { TrainerSlot } from "#app/data/trainer-config";
+import { Biome } from "#app/enums/biome";
+import { achvs } from "#app/system/achv";
 
 export class TrainerVictoryPhase extends BattlePhase {
   constructor(scene: BattleScene) {
@@ -34,10 +36,16 @@ export class TrainerVictoryPhase extends BattlePhase {
     }
 
     const trainerType = this.scene.currentBattle.trainer?.config.trainerType!; // TODO: is this bang correct?
+    // Validate Voucher for boss trainers
     if (vouchers.hasOwnProperty(TrainerType[trainerType])) {
       if (!this.scene.validateVoucher(vouchers[TrainerType[trainerType]]) && this.scene.currentBattle.trainer?.config.isBoss) {
         this.scene.unshiftPhase(new ModifierRewardPhase(this.scene, [ modifierTypes.VOUCHER, modifierTypes.VOUCHER, modifierTypes.VOUCHER_PLUS, modifierTypes.VOUCHER_PREMIUM ][vouchers[TrainerType[trainerType]].voucherType]));
       }
+    }
+    // Breeders in Space achievement
+    if (this.scene.arena.biomeType === Biome.SPACE
+      && (trainerType === TrainerType.BREEDER || trainerType === TrainerType.EXPERT_POKEMON_BREEDER)) {
+      this.scene.validateAchv(achvs.BREEDERS_IN_SPACE);
     }
 
     this.scene.ui.showText(i18next.t("battle:trainerDefeated", { trainerName: this.scene.currentBattle.trainer?.getName(TrainerSlot.NONE, true) }), null, () => {

--- a/src/system/achv.ts
+++ b/src/system/achv.ts
@@ -358,7 +358,7 @@ export const achvs = {
   MONO_FAIRY: new ChallengeAchv("MONO_FAIRY", "", "MONO_FAIRY.description", "fairy_feather", 100, (c, scene) => c instanceof SingleTypeChallenge && c.value === 18 && !scene.gameMode.challenges.some(c => c.id === Challenges.INVERSE_BATTLE && c.value > 0)),
   FRESH_START: new ChallengeAchv("FRESH_START", "", "FRESH_START.description", "reviver_seed", 100, (c, scene) => c instanceof FreshStartChallenge && c.value > 0 && !scene.gameMode.challenges.some(c => c.id === Challenges.INVERSE_BATTLE && c.value > 0)),
   INVERSE_BATTLE: new ChallengeAchv("INVERSE_BATTLE", "", "INVERSE_BATTLE.description", "inverse", 100, c => c instanceof InverseBattleChallenge && c.value > 0),
-  BREEDERS_IN_SPACE: new Achv("BREEDERS_IN_SPACE", "", "BREEDERS_IN_SPACE.description", "moon_stone", 100).setSecret(),
+  BREEDERS_IN_SPACE: new Achv("BREEDERS_IN_SPACE", "", "BREEDERS_IN_SPACE.description", "moon_stone", 50).setSecret(),
 };
 
 export function initAchievements() {


### PR DESCRIPTION
<!-- Make sure the title includes categorization (i.e. [Bug], [QoL], [Localization]) -->
<!-- Make sure that this PR is not overlapping with someone else's work -->
<!-- Please try to keep the PR self-contained (and small) -->

> [!IMPORTANT]
> This PR introduces changes that require updates to existing locales, and therefore requires Senior Translator approval.

## What are the changes the user will see?
The "Breeders in Space" achievement will also unlock when beating normal breeders while in the Space biome
<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?
Asked by balance. The odds of encountering the Expert Pokemon Breeder while in space are too low and make the achievement unrewarding
<!-- Explain why you decided to introduce these changes -->
<!-- Does it come from an issue or another PR? Please link it -->
<!-- Explain why you believe this can enhance user experience -->

## What are the changes from a developer perspective?
Achievement description locale update PR: https://github.com/pagefaultgames/pokerogue-locales/pull/55

- Remove the achievement check from the Expert Breeder Encounter
- Put the check in `TrainerVictoryPhase` just after the Voucher checks for boss trainers
- Added an override to allow achievements to trigger even if they were already unlocked, for easier testing

<!-- Explicitly state what are the changes introduced by the PR -->
<!-- You can make use of a comparison between what was the state before and after your PR changes -->

### Screenshots/Videos
<details><summary>new english achievement description</summary>

![image](https://github.com/user-attachments/assets/4c5c9f34-4e74-4ce6-b037-c6637f77498d)
![image](https://github.com/user-attachments/assets/848b4193-f657-4b36-b5e7-dda9f948f7bb)

</details>

(all videos recorded with the old point value and description and using the override to re unlock achievements. If the achievement don't pop it means the condition wasn't met)

<details><summary>normal breeder space win</summary>

https://github.com/user-attachments/assets/5fc93973-5c5d-4e39-9648-57a4e27af0d7

</details>

<details><summary>expert breeder space win + defeat</summary>

https://github.com/user-attachments/assets/d915f8b1-e0d4-4793-aa50-9dbef006a847

</details>

<details><summary>expert breeder non space win</summary>

https://github.com/user-attachments/assets/64064742-7bd1-4167-affe-e4a65dcf21e7

</details>

<!-- If your change is changing anything on the user experience, please provide visual proofs of it -->
<!-- Please take screenshots/videos before and after your changes, to show what is brought by this PR -->

## How to test the changes?
Overrides:
```
  STARTING_BIOME_OVERRIDE: Biome.SPACE,
  MYSTERY_ENCOUNTER_OVERRIDE: MysteryEncounterType.THE_EXPERT_POKEMON_BREEDER,
  STARTING_WAVE_OVERRIDE: 11,
  STARTING_LEVEL_OVERRIDE: 25,
  MYSTERY_ENCOUNTER_RATE_OVERRIDE: 155,
  ACHIEVEMENTS_REUNLOCK_OVERRIDE: true
```
- Start a run with at least 3 Pokemon. Make sure to always have 3 alive mons or the Expert Breeder encounter will crash when overrides force it to spawn.
- Fight the Expert Pokemon Breeder
- Lose. The achievement should not trigger
- Win. It should trigger
- Hope for a normal breeder encounter
- Achievement should trigger in case of victory
- Do the same with another starting biome, the achievement should not trigger

<!-- How can a reviewer test your changes once they check out on your branch? -->
<!-- Did you just make use of the `src/overrides.ts` file? -->
<!-- Did you introduce any automated tests? -->
<!-- Do the reviewer need to do something special in order to test your change? -->

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [ ] Have I considered writing automated tests for the issue?
- [ ] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [X] Have I tested the changes (manually)?
    - [X] Are all unit tests still passing? (`npm run test`)
- [ ] Are the changes visual?
  - [ ] Have I provided screenshots/videos of the changes?
