### PR TITLE
[Bug] Analytic should only increase damage if the user moves last

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -5779,9 +5779,14 @@ export function initAbilities() {
       .attr(WonderSkinAbAttr)
       .ignorable(),
     new Ability(Abilities.ANALYTIC, 5)
-      .attr(MovePowerBoostAbAttr, (user, target, move) =>
-        !!target?.getLastXMoves(1).find(m => m.turn === target?.scene.currentBattle.turn)
-        || user?.scene.currentBattle.turnCommands[target?.getBattlerIndex() ?? BattlerIndex.ATTACKER]?.command !== Command.FIGHT, 1.3),
+      .attr(MovePowerBoostAbAttr, (user, target, move) => {
+        const movePhase = user?.scene.findPhase((phase) => phase instanceof MovePhase && phase.pokemon.id !== user.id);
+        if (movePhase) {
+          return false;
+        } else {
+          return true;
+        }
+      }, 1.3),
     new Ability(Abilities.ILLUSION, 5)
       .attr(UncopiableAbilityAbAttr)
       .attr(UnswappableAbilityAbAttr)

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -5781,11 +5781,7 @@ export function initAbilities() {
     new Ability(Abilities.ANALYTIC, 5)
       .attr(MovePowerBoostAbAttr, (user, target, move) => {
         const movePhase = user?.scene.findPhase((phase) => phase instanceof MovePhase && phase.pokemon.id !== user.id);
-        if (movePhase) {
-          return false;
-        } else {
-          return true;
-        }
+        return Utils.isNullOrUndefined(movePhase);
       }, 1.3),
     new Ability(Abilities.ILLUSION, 5)
       .attr(UncopiableAbilityAbAttr)

--- a/src/test/abilities/analytic.test.ts
+++ b/src/test/abilities/analytic.test.ts
@@ -1,0 +1,81 @@
+import { BattlerIndex } from "#app/battle";
+import { isBetween, toDmgValue } from "#app/utils";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Abilities - Analytic", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([ Moves.SPLASH, Moves.TACKLE ])
+      .ability(Abilities.ANALYTIC)
+      .battleType("single")
+      .disableCrits()
+      .startingLevel(200)
+      .enemyLevel(200)
+      .enemySpecies(Species.SNORLAX)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH);
+  });
+
+  it("should increase damage if the user moves last", async () => {
+    await game.classicMode.startBattle([ Species.ARCEUS ]);
+
+    const enemy = game.scene.getEnemyPokemon()!;
+
+    game.move.select(Moves.TACKLE);
+    await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.ENEMY ]);
+    await game.toNextTurn();
+    const damage1 = enemy.getInverseHp();
+    enemy.hp = enemy.getMaxHp();
+
+    game.move.select(Moves.TACKLE);
+    await game.setTurnOrder([ BattlerIndex.ENEMY, BattlerIndex.PLAYER ]);
+    await game.phaseInterceptor.to("BerryPhase");
+    expect(isBetween(enemy.getInverseHp(), toDmgValue(damage1 * 1.3) - 3, toDmgValue(damage1 * 1.3) + 3)).toBe(true);
+  });
+
+  it("should increase damage only if the user moves last in doubles", async () => {
+    game.override.battleType("double");
+    await game.classicMode.startBattle([ Species.GENGAR, Species.SHUCKLE ]);
+
+    const [ enemy, ] = game.scene.getEnemyField();
+
+    game.move.select(Moves.TACKLE, 0, BattlerIndex.ENEMY);
+    game.move.select(Moves.SPLASH, 1);
+    await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2 ]);
+    await game.toNextTurn();
+    const damage1 = enemy.getInverseHp();
+    enemy.hp = enemy.getMaxHp();
+
+    game.move.select(Moves.TACKLE, 0, BattlerIndex.ENEMY);
+    game.move.select(Moves.SPLASH, 1);
+    await game.setTurnOrder([ BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER ]);
+    await game.toNextTurn();
+    expect(isBetween(enemy.getInverseHp(), toDmgValue(damage1 * 1.3) - 3, toDmgValue(damage1 * 1.3) + 3)).toBe(true);
+    enemy.hp = enemy.getMaxHp();
+
+    game.move.select(Moves.TACKLE, 0, BattlerIndex.ENEMY);
+    game.move.select(Moves.SPLASH, 1);
+    await game.setTurnOrder([ BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.PLAYER, BattlerIndex.ENEMY_2 ]);
+    await game.phaseInterceptor.to("BerryPhase");
+    expect(enemy.getInverseHp()).toBe(damage1);
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?
In doubles, Analytic will no longer erroneously boost damage if the target moves before the user and the other Pokémon have not.

## Why am I making these changes?
Move is bugged, see https://github.com/pagefaultgames/pokerogue/issues/3503#issuecomment-2484728852

## What are the changes from a developer perspective?
The condition function for Analytic is changed.
Tests were added for Analytic.

## How to test the changes?
`npm run test analytic`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I tested the changes manually?~
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- ~[ ] Have I provided screenshots/videos of the changes (if applicable)?~
  - ~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~