### PR TITLE
[P1][Beta] Fix phazing moves forcing switches into fainted/ineligible Pokemon

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5976,7 +5976,7 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
       }
 
       // Find indices of off-field Pokemon that are eligible to be switched into
-      const eligibleNewIndices = [] as number[];
+      const eligibleNewIndices: number[] = [];
       switchOutTarget.scene.getPlayerParty().forEach((pokemon, index) => {
         if (pokemon.isAllowedInBattle() && !pokemon.isOnField()) {
           eligibleNewIndices.push(index);
@@ -6020,7 +6020,7 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
       return false;
     } else if (user.scene.currentBattle.battleType !== BattleType.WILD) { // Switch out logic for enemy trainers
       // Find indices of off-field Pokemon that are eligible to be switched into
-      const eligibleNewIndices = [] as number[];
+      const eligibleNewIndices: number[] = [];
       switchOutTarget.scene.getEnemyParty().forEach((pokemon, index) => {
         if (pokemon.isAllowedInBattle() && !pokemon.isOnField()) {
           eligibleNewIndices.push(index);

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5975,14 +5975,22 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
         }
       }
 
-      if (switchOutTarget.scene.getPlayerParty().filter((p) => p.isAllowedInBattle() && !p.isOnField()).length < 1) {
+      // Find indices of off-field Pokemon that are eligible to be switched into
+      const eligibleNewIndices = [] as number[];
+      switchOutTarget.scene.getPlayerParty().forEach((pokemon, index) => {
+        if (pokemon.isAllowedInBattle() && !pokemon.isOnField()) {
+          eligibleNewIndices.push(index);
+        }
+      });
+
+      if (eligibleNewIndices.length < 1) {
         return false;
       }
 
       if (switchOutTarget.hp > 0) {
         if (this.switchType === SwitchType.FORCE_SWITCH) {
           switchOutTarget.leaveField(true);
-          const slotIndex = Utils.randIntRange(user.scene.currentBattle.getBattlerCount(), user.scene.getPlayerParty().length);
+          const slotIndex = eligibleNewIndices[user.randSeedInt(eligibleNewIndices.length)];
           user.scene.prependToPhase(
             new SwitchSummonPhase(
               user.scene,
@@ -6011,14 +6019,22 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
       }
       return false;
     } else if (user.scene.currentBattle.battleType !== BattleType.WILD) { // Switch out logic for enemy trainers
-      if (switchOutTarget.scene.getEnemyParty().filter((p) => p.isAllowedInBattle() && !p.isOnField()).length < 1) {
+      // Find indices of off-field Pokemon that are eligible to be switched into
+      const eligibleNewIndices = [] as number[];
+      switchOutTarget.scene.getEnemyParty().forEach((pokemon, index) => {
+        if (pokemon.isAllowedInBattle() && !pokemon.isOnField()) {
+          eligibleNewIndices.push(index);
+        }
+      });
+
+      if (eligibleNewIndices.length < 1) {
         return false;
       }
 
       if (switchOutTarget.hp > 0) {
         if (this.switchType === SwitchType.FORCE_SWITCH) {
           switchOutTarget.leaveField(true);
-          const slotIndex = Utils.randIntRange(user.scene.currentBattle.getBattlerCount(), user.scene.getEnemyParty().length);
+          const slotIndex = eligibleNewIndices[user.randSeedInt(eligibleNewIndices.length)];
           user.scene.prependToPhase(
             new SwitchSummonPhase(
               user.scene,

--- a/src/test/moves/dragon_tail.test.ts
+++ b/src/test/moves/dragon_tail.test.ts
@@ -1,5 +1,9 @@
 import { BattlerIndex } from "#app/battle";
 import { allMoves } from "#app/data/move";
+import { Status } from "#app/data/status-effect";
+import { Challenges } from "#enums/challenges";
+import { StatusEffect } from "#enums/status-effect";
+import { Type } from "#enums/type";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
@@ -192,5 +196,123 @@ describe("Moves - Dragon Tail", () => {
     expect(dratini).toBeDefined();
     expect(dratini.hp).toBe(Math.floor(dratini.getMaxHp() / 2));
     expect(game.scene.getPlayerField().length).toBe(1);
+  });
+
+  it("should force switches randomly", async () => {
+    game.override.enemyMoveset(Moves.DRAGON_TAIL)
+      .startingLevel(100)
+      .enemyLevel(1);
+    await game.classicMode.startBattle([ Species.BULBASAUR, Species.CHARMANDER, Species.SQUIRTLE ]);
+
+    const [ bulbasaur, charmander, squirtle ] = game.scene.getPlayerParty();
+
+    // Turn 1: Mock an RNG call that calls for switching to 1st backup Pokemon (Charmander)
+    vi.spyOn(game.scene, "randBattleSeedInt").mockImplementation((range, min: number = 0) => {
+      return min;
+    });
+    game.move.select(Moves.SPLASH);
+    await game.forceEnemyMove(Moves.DRAGON_TAIL);
+    await game.toNextTurn();
+
+    expect(bulbasaur.isOnField()).toBe(false);
+    expect(charmander.isOnField()).toBe(true);
+    expect(squirtle.isOnField()).toBe(false);
+    expect(bulbasaur.getInverseHp()).toBeGreaterThan(0);
+
+    // Turn 2: Mock an RNG call that calls for switching to 2nd backup Pokemon (Squirtle)
+    vi.spyOn(game.scene, "randBattleSeedInt").mockImplementation((range, min: number = 0) => {
+      return min + 1;
+    });
+    game.move.select(Moves.SPLASH);
+    await game.toNextTurn();
+
+    expect(bulbasaur.isOnField()).toBe(false);
+    expect(charmander.isOnField()).toBe(false);
+    expect(squirtle.isOnField()).toBe(true);
+    expect(charmander.getInverseHp()).toBeGreaterThan(0);
+  });
+
+  it("should not force a switch to a challenge-ineligible Pokemon", async () => {
+    game.override.enemyMoveset(Moves.DRAGON_TAIL)
+      .startingLevel(100)
+      .enemyLevel(1);
+    // Mono-Water challenge, Eevee is ineligible
+    game.challengeMode.addChallenge(Challenges.SINGLE_TYPE, Type.WATER + 1, 0);
+    await game.challengeMode.startBattle([ Species.LAPRAS, Species.EEVEE, Species.TOXAPEX, Species.PRIMARINA ]);
+
+    const [ lapras, eevee, toxapex, primarina ] = game.scene.getPlayerParty();
+
+    // Turn 1: Mock an RNG call that would normally call for switching to Eevee, but it is ineligible
+    vi.spyOn(game.scene, "randBattleSeedInt").mockImplementation((range, min: number = 0) => {
+      return min;
+    });
+    game.move.select(Moves.SPLASH);
+    await game.toNextTurn();
+
+    expect(lapras.isOnField()).toBe(false);
+    expect(eevee.isOnField()).toBe(false);
+    expect(toxapex.isOnField()).toBe(true);
+    expect(primarina.isOnField()).toBe(false);
+    expect(lapras.getInverseHp()).toBeGreaterThan(0);
+  });
+
+  it("should not force a switch to a fainted Pokemon", async () => {
+    game.override.enemyMoveset([ Moves.SPLASH, Moves.DRAGON_TAIL ])
+      .startingLevel(100)
+      .enemyLevel(1);
+    await game.classicMode.startBattle([ Species.LAPRAS, Species.EEVEE, Species.TOXAPEX, Species.PRIMARINA ]);
+
+    const [ lapras, eevee, toxapex, primarina ] = game.scene.getPlayerParty();
+
+    // Turn 1: Eevee faints
+    eevee.hp = 0;
+    eevee.status = new Status(StatusEffect.FAINT);
+    expect(eevee.isFainted()).toBe(true);
+    game.move.select(Moves.SPLASH);
+    await game.forceEnemyMove(Moves.SPLASH);
+    await game.toNextTurn();
+
+    // Turn 2: Mock an RNG call that would normally call for switching to Eevee, but it is fainted
+    vi.spyOn(game.scene, "randBattleSeedInt").mockImplementation((range, min: number = 0) => {
+      return min;
+    });
+    game.move.select(Moves.SPLASH);
+    await game.forceEnemyMove(Moves.DRAGON_TAIL);
+    await game.toNextTurn();
+
+    expect(lapras.isOnField()).toBe(false);
+    expect(eevee.isOnField()).toBe(false);
+    expect(toxapex.isOnField()).toBe(true);
+    expect(primarina.isOnField()).toBe(false);
+    expect(lapras.getInverseHp()).toBeGreaterThan(0);
+  });
+
+  it("should not force a switch if there are no available Pokemon to switch into", async () => {
+    game.override.enemyMoveset([ Moves.SPLASH, Moves.DRAGON_TAIL ])
+      .startingLevel(100)
+      .enemyLevel(1);
+    await game.classicMode.startBattle([ Species.LAPRAS, Species.EEVEE ]);
+
+    const [ lapras, eevee ] = game.scene.getPlayerParty();
+
+    // Turn 1: Eevee faints
+    eevee.hp = 0;
+    eevee.status = new Status(StatusEffect.FAINT);
+    expect(eevee.isFainted()).toBe(true);
+    game.move.select(Moves.SPLASH);
+    await game.forceEnemyMove(Moves.SPLASH);
+    await game.toNextTurn();
+
+    // Turn 2: Mock an RNG call that would normally call for switching to Eevee, but it is fainted
+    vi.spyOn(game.scene, "randBattleSeedInt").mockImplementation((range, min: number = 0) => {
+      return min;
+    });
+    game.move.select(Moves.SPLASH);
+    await game.forceEnemyMove(Moves.DRAGON_TAIL);
+    await game.toNextTurn();
+
+    expect(lapras.isOnField()).toBe(true);
+    expect(eevee.isOnField()).toBe(false);
+    expect(lapras.getInverseHp()).toBeGreaterThan(0);
   });
 });

--- a/src/test/moves/whirlwind.test.ts
+++ b/src/test/moves/whirlwind.test.ts
@@ -1,11 +1,15 @@
-import { BattlerTagType } from "#app/enums/battler-tag-type";
+import { BattlerTagType } from "#enums/battler-tag-type";
+import { Challenges } from "#enums/challenges";
+import { Type } from "#enums/type";
 import { MoveResult } from "#app/field/pokemon";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
 import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { Status } from "#app/data/status-effect";
+import { StatusEffect } from "#enums/status-effect";
 
 describe("Moves - Whirlwind", () => {
   let phaserGame: Phaser.Game;
@@ -25,8 +29,9 @@ describe("Moves - Whirlwind", () => {
     game = new GameManager(phaserGame);
     game.override
       .battleType("single")
+      .moveset(Moves.SPLASH)
       .enemyAbility(Abilities.BALL_FETCH)
-      .enemyMoveset(Moves.WHIRLWIND)
+      .enemyMoveset([ Moves.SPLASH, Moves.WHIRLWIND ])
       .enemySpecies(Species.PIDGEY);
   });
 
@@ -41,10 +46,114 @@ describe("Moves - Whirlwind", () => {
     const staraptor = game.scene.getPlayerPokemon()!;
 
     game.move.select(move);
+    await game.forceEnemyMove(Moves.WHIRLWIND);
 
     await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(staraptor.findTag((t) => t.tagType === BattlerTagType.FLYING)).toBeDefined();
     expect(game.scene.getEnemyPokemon()!.getLastXMoves(1)[0].result).toBe(MoveResult.MISS);
+  });
+
+  it("should force switches randomly", async () => {
+    await game.classicMode.startBattle([ Species.BULBASAUR, Species.CHARMANDER, Species.SQUIRTLE ]);
+
+    const [ bulbasaur, charmander, squirtle ] = game.scene.getPlayerParty();
+
+    // Turn 1: Mock an RNG call that calls for switching to 1st backup Pokemon (Charmander)
+    vi.spyOn(game.scene, "randBattleSeedInt").mockImplementation((range, min: number = 0) => {
+      return min;
+    });
+    game.move.select(Moves.SPLASH);
+    await game.forceEnemyMove(Moves.WHIRLWIND);
+    await game.toNextTurn();
+
+    expect(bulbasaur.isOnField()).toBe(false);
+    expect(charmander.isOnField()).toBe(true);
+    expect(squirtle.isOnField()).toBe(false);
+
+    // Turn 2: Mock an RNG call that calls for switching to 2nd backup Pokemon (Squirtle)
+    vi.spyOn(game.scene, "randBattleSeedInt").mockImplementation((range, min: number = 0) => {
+      return min + 1;
+    });
+    game.move.select(Moves.SPLASH);
+    await game.forceEnemyMove(Moves.WHIRLWIND);
+    await game.toNextTurn();
+
+    expect(bulbasaur.isOnField()).toBe(false);
+    expect(charmander.isOnField()).toBe(false);
+    expect(squirtle.isOnField()).toBe(true);
+  });
+
+  it("should not force a switch to a challenge-ineligible Pokemon", async () => {
+    // Mono-Water challenge, Eevee is ineligible
+    game.challengeMode.addChallenge(Challenges.SINGLE_TYPE, Type.WATER + 1, 0);
+    await game.challengeMode.startBattle([ Species.LAPRAS, Species.EEVEE, Species.TOXAPEX, Species.PRIMARINA ]);
+
+    const [ lapras, eevee, toxapex, primarina ] = game.scene.getPlayerParty();
+
+    // Turn 1: Mock an RNG call that would normally call for switching to Eevee, but it is ineligible
+    vi.spyOn(game.scene, "randBattleSeedInt").mockImplementation((range, min: number = 0) => {
+      return min;
+    });
+    game.move.select(Moves.SPLASH);
+    await game.forceEnemyMove(Moves.WHIRLWIND);
+    await game.toNextTurn();
+
+    expect(lapras.isOnField()).toBe(false);
+    expect(eevee.isOnField()).toBe(false);
+    expect(toxapex.isOnField()).toBe(true);
+    expect(primarina.isOnField()).toBe(false);
+  });
+
+  it("should not force a switch to a fainted Pokemon", async () => {
+    await game.classicMode.startBattle([ Species.LAPRAS, Species.EEVEE, Species.TOXAPEX, Species.PRIMARINA ]);
+
+    const [ lapras, eevee, toxapex, primarina ] = game.scene.getPlayerParty();
+
+    // Turn 1: Eevee faints
+    eevee.hp = 0;
+    eevee.status = new Status(StatusEffect.FAINT);
+    expect(eevee.isFainted()).toBe(true);
+    game.move.select(Moves.SPLASH);
+    await game.forceEnemyMove(Moves.SPLASH);
+    await game.toNextTurn();
+
+    // Turn 2: Mock an RNG call that would normally call for switching to Eevee, but it is fainted
+    vi.spyOn(game.scene, "randBattleSeedInt").mockImplementation((range, min: number = 0) => {
+      return min;
+    });
+    game.move.select(Moves.SPLASH);
+    await game.forceEnemyMove(Moves.WHIRLWIND);
+    await game.toNextTurn();
+
+    expect(lapras.isOnField()).toBe(false);
+    expect(eevee.isOnField()).toBe(false);
+    expect(toxapex.isOnField()).toBe(true);
+    expect(primarina.isOnField()).toBe(false);
+  });
+
+  it("should not force a switch if there are no available Pokemon to switch into", async () => {
+    await game.classicMode.startBattle([ Species.LAPRAS, Species.EEVEE ]);
+
+    const [ lapras, eevee ] = game.scene.getPlayerParty();
+
+    // Turn 1: Eevee faints
+    eevee.hp = 0;
+    eevee.status = new Status(StatusEffect.FAINT);
+    expect(eevee.isFainted()).toBe(true);
+    game.move.select(Moves.SPLASH);
+    await game.forceEnemyMove(Moves.SPLASH);
+    await game.toNextTurn();
+
+    // Turn 2: Mock an RNG call that would normally call for switching to Eevee, but it is fainted
+    vi.spyOn(game.scene, "randBattleSeedInt").mockImplementation((range, min: number = 0) => {
+      return min;
+    });
+    game.move.select(Moves.SPLASH);
+    await game.forceEnemyMove(Moves.WHIRLWIND);
+    await game.toNextTurn();
+
+    expect(lapras.isOnField()).toBe(true);
+    expect(eevee.isOnField()).toBe(false);
   });
 });


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
Phazing moves can no longer randomly choose to force a switch into a fainted/ineligible Pokemon.
Also, phazing moves properly use seeded RNG instead of unseeded RNG.

## Why am I making these changes?
<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->
Bug report: [Discord](https://discord.com/channels/1125469663833370665/1176874654015684739/1312149844797685820)

## What are the changes from a developer perspective?
<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->
1. Phazing moves now generate a list of indices of eligible Pokemon to switch into, and then randomly pick an eligible index using seeded RNG.
2. Added tests for Whirlwind and Dragon Tail.

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->
<details>
<summary> Before the changes: Phazing moves can force a switch into a fainted Pokemon </summary>

https://github.com/user-attachments/assets/400bf42b-657b-44fc-ad84-ac7f7a96825f

</details>
<details>
<summary> After the changes: Phazing moves no longer force a switch into a fainted Pokemon </summary>

https://github.com/user-attachments/assets/18905718-2be9-49cc-b9d5-2ca9681ec77b

</details>

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->
1. Reach the floor 195 rival.
2. Defeat 4 of the rival's 6 Pokemon.
3. Use a phazing move.
4. The phazing move should always force the rival to switch to their only other unfainted Pokemon.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~

Are there any localization additions or changes? If so:
- ~~[ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?~~
  - ~~[ ] If so, please leave a link to it here:~~
- ~~[ ] Has the translation team been contacted for proofreading/translation?~~