### PR TITLE
[Test] Fix flaky Shell Side Arm test

### DIFF
--- a/src/test/moves/shell_side_arm.test.ts
+++ b/src/test/moves/shell_side_arm.test.ts
@@ -26,7 +26,7 @@ describe("Moves - Shell Side Arm", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     game.override
-      .moveset([ Moves.SHELL_SIDE_ARM ])
+      .moveset([ Moves.SHELL_SIDE_ARM, Moves.SPLASH ])
       .battleType("single")
       .startingLevel(100)
       .enemyLevel(100)
@@ -68,6 +68,9 @@ describe("Moves - Shell Side Arm", () => {
     await game.classicMode.startBattle([ Species.MANAPHY ]);
 
     vi.spyOn(shellSideArmAttr, "apply");
+
+    game.move.select(Moves.SPLASH);
+    await game.toNextTurn();
 
     game.move.select(Moves.SHELL_SIDE_ARM);
     await game.setTurnOrder([ BattlerIndex.ENEMY, BattlerIndex.PLAYER ]);


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
The test has a chance to fail.

## What are the changes from a developer perspective?
Added a second turn so the enemy Pokémon gets to +6 def, to guarantee that Def > SpDef.

## How to test the changes?
`npm run test shell_side_arm`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~[ ] Have I tested the changes manually?~
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- ~[ ] Have I provided screenshots/videos of the changes (if applicable)?~
  - ~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~