### PR TITLE
[Balance] Adjust Flame/Toxic Orb Weight Functions

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3496,6 +3496,15 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     return this.gender !== Gender.GENDERLESS && pokemon.gender === (this.gender === Gender.MALE ? Gender.FEMALE : Gender.MALE);
   }
 
+  /**
+   * Checks if a status effect can be applied to the Pokemon.
+   *
+   * @param effect The {@linkcode StatusEffect} whose applicability is being checked
+   * @param quiet Whether in-battle messages should trigger or not
+   * @param overrideStatus Whether the Pokemon's current status can be overriden
+   * @param sourcePokemon The Pokemon that is setting the status effect
+   * @param ignoreField Whether any field effects (weather, terrain, etc.) should be considered
+   */
   canSetStatus(effect: StatusEffect | undefined, quiet: boolean = false, overrideStatus: boolean = false, sourcePokemon: Pokemon | null = null, ignoreField: boolean = false): boolean {
     if (effect !== StatusEffect.FAINT) {
       if (overrideStatus ? this.status?.effect === effect : this.status) {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3496,12 +3496,12 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     return this.gender !== Gender.GENDERLESS && pokemon.gender === (this.gender === Gender.MALE ? Gender.FEMALE : Gender.MALE);
   }
 
-  canSetStatus(effect: StatusEffect | undefined, quiet: boolean = false, overrideStatus: boolean = false, sourcePokemon: Pokemon | null = null): boolean {
+  canSetStatus(effect: StatusEffect | undefined, quiet: boolean = false, overrideStatus: boolean = false, sourcePokemon: Pokemon | null = null, ignoreField: boolean = false): boolean {
     if (effect !== StatusEffect.FAINT) {
       if (overrideStatus ? this.status?.effect === effect : this.status) {
         return false;
       }
-      if (this.isGrounded() && this.scene.arena.terrain?.terrainType === TerrainType.MISTY) {
+      if (this.isGrounded() && (!ignoreField && this.scene.arena.terrain?.terrainType === TerrainType.MISTY)) {
         return false;
       }
     }
@@ -3551,7 +3551,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         }
         break;
       case StatusEffect.FREEZE:
-        if (this.isOfType(Type.ICE) || (this.scene?.arena?.weather?.weatherType && [ WeatherType.SUNNY, WeatherType.HARSH_SUN ].includes(this.scene.arena.weather.weatherType))) {
+        if (this.isOfType(Type.ICE) || (!ignoreField && (this.scene?.arena?.weather?.weatherType && [ WeatherType.SUNNY, WeatherType.HARSH_SUN ].includes(this.scene.arena.weather.weatherType)))) {
           return false;
         }
         break;

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1768,11 +1768,14 @@ const modifierPool: ModifierPool = {
         const hasRelevantAbilities = [ Abilities.QUICK_FEET, Abilities.GUTS, Abilities.MARVEL_SCALE, Abilities.TOXIC_BOOST, Abilities.POISON_HEAL, Abilities.MAGIC_GUARD ]
           .some(a => p.hasAbility(a, false, true));
 
-        if (canSetStatus) {
-          return !isHoldingOrb && (hasRelevantAbilities || hasStatusMoves);
-        } else {
-          return !isHoldingOrb && hasItemMoves;
+        if (!isHoldingOrb) {
+          if (canSetStatus) {
+            return hasRelevantAbilities || hasStatusMoves;
+          } else {
+            return hasItemMoves;
+          }
         }
+        return false;
       }) ? 10 : 0;
     }, 10),
     new WeightedModifierType(modifierTypes.FLAME_ORB, (party: Pokemon[]) => {
@@ -1792,11 +1795,14 @@ const modifierPool: ModifierPool = {
         const hasRelevantAbilities = [ Abilities.QUICK_FEET, Abilities.GUTS, Abilities.MARVEL_SCALE, Abilities.FLARE_BOOST, Abilities.MAGIC_GUARD ]
           .some(a => p.hasAbility(a, false, true));
 
-        if (canSetStatus) {
-          return !isHoldingOrb && (hasRelevantAbilities || hasStatusMoves);
-        } else {
-          return !isHoldingOrb && hasItemMoves;
+        if (!isHoldingOrb) {
+          if (canSetStatus) {
+            return hasRelevantAbilities || hasStatusMoves;
+          } else {
+            return hasItemMoves;
+          }
         }
+        return false;
       }) ? 10 : 0;
     }, 10),
     new WeightedModifierType(modifierTypes.WHITE_HERB, (party: Pokemon[]) => {

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1754,31 +1754,49 @@ const modifierPool: ModifierPool = {
       return party.some(p => {
         const moveset = p.getMoveset(true).filter(m => !isNullOrUndefined(m)).map(m => m.moveId);
 
-        const canSetStatus = !p.canSetStatus(StatusEffect.TOXIC, true, true, null, true);
+        const canSetStatus = p.canSetStatus(StatusEffect.TOXIC, true, true, null, true);
         const isHoldingOrb = p.getHeldItems().some(i => i.type.id === "FLAME_ORB" || i.type.id === "TOXIC_ORB");
 
-        // TODO: Take moves out of comment as they become implemented
-        const hasRelevantMoves = [ Moves.FACADE, Moves.PSYCHO_SHIFT, /* Moves.TRICK, Moves.FLING, Moves.SWITCHEROO */]
+        // Moves that take advantage of obtaining the actual status effect
+        const hasStatusMoves = [ Moves.FACADE, Moves.PSYCHO_SHIFT ]
           .some(m => moveset.includes(m));
+        // Moves that take advantage of being able to give the target a status orb
+        // TODO: Take moves from comment they are implemented
+        const hasItemMoves = [ /* Moves.TRICK, Moves.FLING, Moves.SWITCHEROO */ ]
+          .some(m => moveset.includes(m));
+        // Abilities that take advantage of obtaining the actual status effect
         const hasRelevantAbilities = [ Abilities.QUICK_FEET, Abilities.GUTS, Abilities.MARVEL_SCALE, Abilities.TOXIC_BOOST, Abilities.POISON_HEAL, Abilities.MAGIC_GUARD ]
           .some(a => p.hasAbility(a, false, true));
 
-        return !isHoldingOrb && (canSetStatus || hasRelevantMoves || hasRelevantAbilities);
+        if (canSetStatus) {
+          return !isHoldingOrb && (hasRelevantAbilities || hasStatusMoves);
+        } else {
+          return !isHoldingOrb && hasItemMoves;
+        }
       }) ? 10 : 0;
     }, 10),
     new WeightedModifierType(modifierTypes.FLAME_ORB, (party: Pokemon[]) => {
       return party.some(p => {
         const moveset = p.getMoveset(true).filter(m => !isNullOrUndefined(m)).map(m => m.moveId);
-        const canSetStatus = !p.canSetStatus(StatusEffect.BURN, true, true, null, true);
+        const canSetStatus = p.canSetStatus(StatusEffect.BURN, true, true, null, true);
         const isHoldingOrb = p.getHeldItems().some(i => i.type.id === "FLAME_ORB" || i.type.id === "TOXIC_ORB");
 
-        // TODO: Take moves out of comment as they become implemented
-        const hasRelevantMoves = [ Moves.FACADE, Moves.PSYCHO_SHIFT, /* Moves.TRICK, Moves.FLING, Moves.SWITCHEROO */]
+        // Moves that take advantage of obtaining the actual status effect
+        const hasStatusMoves = [ Moves.FACADE, Moves.PSYCHO_SHIFT ]
           .some(m => moveset.includes(m));
+        // Moves that take advantage of being able to give the target a status orb
+        // TODO: Take moves from comment they are implemented
+        const hasItemMoves = [ /* Moves.TRICK, Moves.FLING, Moves.SWITCHEROO */ ]
+          .some(m => moveset.includes(m));
+        // Abilities that take advantage of obtaining the actual status effect
         const hasRelevantAbilities = [ Abilities.QUICK_FEET, Abilities.GUTS, Abilities.MARVEL_SCALE, Abilities.FLARE_BOOST, Abilities.MAGIC_GUARD ]
           .some(a => p.hasAbility(a, false, true));
 
-        return !isHoldingOrb && (canSetStatus || hasRelevantMoves || hasRelevantAbilities);
+        if (canSetStatus) {
+          return !isHoldingOrb && (hasRelevantAbilities || hasStatusMoves);
+        } else {
+          return !isHoldingOrb && hasItemMoves;
+        }
       }) ? 10 : 0;
     }, 10),
     new WeightedModifierType(modifierTypes.WHITE_HERB, (party: Pokemon[]) => {

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1754,7 +1754,7 @@ const modifierPool: ModifierPool = {
       return party.some(p => {
         const moveset = p.getMoveset(true).filter(m => !isNullOrUndefined(m)).map(m => m.moveId);
 
-        const isImmune = !p.canSetStatus(StatusEffect.TOXIC, true, true, null, true);
+        const canSetStatus = !p.canSetStatus(StatusEffect.TOXIC, true, true, null, true);
         const isHoldingOrb = p.getHeldItems().some(i => i.type.id === "FLAME_ORB" || i.type.id === "TOXIC_ORB");
 
         // TODO: Take moves out of comment as they become implemented
@@ -1763,13 +1763,13 @@ const modifierPool: ModifierPool = {
         const hasRelevantAbilities = [ Abilities.QUICK_FEET, Abilities.GUTS, Abilities.MARVEL_SCALE, Abilities.TOXIC_BOOST, Abilities.POISON_HEAL, Abilities.MAGIC_GUARD ]
           .some(a => p.hasAbility(a, false, true));
 
-        return !isHoldingOrb && (!isImmune || hasRelevantMoves || hasRelevantAbilities);
+        return !isHoldingOrb && (canSetStatus || hasRelevantMoves || hasRelevantAbilities);
       }) ? 10 : 0;
     }, 10),
     new WeightedModifierType(modifierTypes.FLAME_ORB, (party: Pokemon[]) => {
       return party.some(p => {
         const moveset = p.getMoveset(true).filter(m => !isNullOrUndefined(m)).map(m => m.moveId);
-        const isImmune = !p.canSetStatus(StatusEffect.BURN, true, true, null, true);
+        const canSetStatus = !p.canSetStatus(StatusEffect.BURN, true, true, null, true);
         const isHoldingOrb = p.getHeldItems().some(i => i.type.id === "FLAME_ORB" || i.type.id === "TOXIC_ORB");
 
         // TODO: Take moves out of comment as they become implemented
@@ -1778,7 +1778,7 @@ const modifierPool: ModifierPool = {
         const hasRelevantAbilities = [ Abilities.QUICK_FEET, Abilities.GUTS, Abilities.MARVEL_SCALE, Abilities.FLARE_BOOST, Abilities.MAGIC_GUARD ]
           .some(a => p.hasAbility(a, false, true));
 
-        return !isHoldingOrb && (!isImmune || hasRelevantMoves || hasRelevantAbilities);
+        return !isHoldingOrb && (canSetStatus || hasRelevantMoves || hasRelevantAbilities);
       }) ? 10 : 0;
     }, 10),
     new WeightedModifierType(modifierTypes.WHITE_HERB, (party: Pokemon[]) => {

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1751,19 +1751,35 @@ const modifierPool: ModifierPool = {
         || (p.isFusion() && checkedSpecies.includes(p.getFusionSpeciesForm(true).speciesId)))) ? 12 : 0;
     }, 12),
     new WeightedModifierType(modifierTypes.TOXIC_ORB, (party: Pokemon[]) => {
-      const checkedAbilities = [ Abilities.QUICK_FEET, Abilities.GUTS, Abilities.MARVEL_SCALE, Abilities.TOXIC_BOOST, Abilities.POISON_HEAL, Abilities.MAGIC_GUARD ];
-      const checkedMoves = [ Moves.FACADE, Moves.TRICK, Moves.FLING, Moves.SWITCHEROO, Moves.PSYCHO_SHIFT ];
-      // If a party member doesn't already have one of these two orbs and has one of the above moves or abilities, the orb can appear
-      return party.some(p => !p.getHeldItems().some(i => i instanceof TurnStatusEffectModifier)
-        && (checkedAbilities.some(a => p.hasAbility(a, false, true))
-        || p.getMoveset(true).some(m => m && checkedMoves.includes(m.moveId)))) ? 10 : 0;
+      return party.some(p => {
+        const moveset = p.getMoveset(true).filter(m => !isNullOrUndefined(m)).map(m => m.moveId);
+
+        const isImmune = !p.canSetStatus(StatusEffect.TOXIC, true, true, null, true);
+        const isHoldingOrb = p.getHeldItems().some(i => i.type.id === "FLAME_ORB" || i.type.id === "TOXIC_ORB");
+
+        // TODO: Take moves out of comment as they become implemented
+        const hasRelevantMoves = [ Moves.FACADE, Moves.PSYCHO_SHIFT, /* Moves.TRICK, Moves.FLING, Moves.SWITCHEROO */]
+          .some(m => moveset.includes(m));
+        const hasRelevantAbilities = [ Abilities.QUICK_FEET, Abilities.GUTS, Abilities.MARVEL_SCALE, Abilities.TOXIC_BOOST, Abilities.POISON_HEAL, Abilities.MAGIC_GUARD ]
+          .some(a => p.hasAbility(a, false, true));
+
+        return !isHoldingOrb && (!isImmune || hasRelevantMoves || hasRelevantAbilities);
+      }) ? 10 : 0;
     }, 10),
     new WeightedModifierType(modifierTypes.FLAME_ORB, (party: Pokemon[]) => {
-      const checkedAbilities = [ Abilities.QUICK_FEET, Abilities.GUTS, Abilities.MARVEL_SCALE, Abilities.FLARE_BOOST, Abilities.MAGIC_GUARD ];
-      const checkedMoves = [ Moves.FACADE, Moves.TRICK, Moves.FLING, Moves.SWITCHEROO, Moves.PSYCHO_SHIFT ];
-      // If a party member doesn't already have one of these two orbs and has one of the above moves or abilities, the orb can appear
-      return party.some(p => !p.getHeldItems().some(i => i instanceof TurnStatusEffectModifier)
-        && (checkedAbilities.some(a => p.hasAbility(a, false, true)) || p.getMoveset(true).some(m => m && checkedMoves.includes(m.moveId)))) ? 10 : 0;
+      return party.some(p => {
+        const moveset = p.getMoveset(true).filter(m => !isNullOrUndefined(m)).map(m => m.moveId);
+        const isImmune = !p.canSetStatus(StatusEffect.BURN, true, true, null, true);
+        const isHoldingOrb = p.getHeldItems().some(i => i.type.id === "FLAME_ORB" || i.type.id === "TOXIC_ORB");
+
+        // TODO: Take moves out of comment as they become implemented
+        const hasRelevantMoves = [ Moves.FACADE, Moves.PSYCHO_SHIFT, /* Moves.TRICK, Moves.FLING, Moves.SWITCHEROO */]
+          .some(m => moveset.includes(m));
+        const hasRelevantAbilities = [ Abilities.QUICK_FEET, Abilities.GUTS, Abilities.MARVEL_SCALE, Abilities.FLARE_BOOST, Abilities.MAGIC_GUARD ]
+          .some(a => p.hasAbility(a, false, true));
+
+        return !isHoldingOrb && (!isImmune || hasRelevantMoves || hasRelevantAbilities);
+      }) ? 10 : 0;
     }, 10),
     new WeightedModifierType(modifierTypes.WHITE_HERB, (party: Pokemon[]) => {
       const checkedAbilities = [ Abilities.WEAK_ARMOR, Abilities.CONTRARY, Abilities.MOODY, Abilities.ANGER_SHELL, Abilities.COMPETITIVE, Abilities.DEFIANT ];


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->

`Flame Orb` and `Toxic Orb` have had their weight functions adjusted such that they only appear in item reward rolls under the following specific conditions:
- A Pokemon in the party does not already have either orb *AND*...
  -  Can be afflicted by the respective status effect *AND*...
     - Has any of the relevant abilities or moves that take advantage of obtaining either status effect
       - Moves: `Facade` and `Psycho Shift`
       - Abilities for `Toxic Orb`: `Quick Feet`, `Guts`, `Marvel Scale`, `Toxic Boost`, `Poison Heal`, and `Magic Guard`
       - Abilities for `Flame Orb`: `Quick Feet`, `Guts`, `Marvel Scale`, `Flare Boost`, and `Magic Guard`
  - Can not be afflicted by the respective status effect *AND*...
    - Has any of the relevant item-switching or -throwing moves that take advantage of holding either orb
      - Moves: `Fling`, `Switcheroo`, and `Trick`   

## Why am I making these changes?
<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

Both orbs were being weighted in item reward rolls in certain edge cases that were either counterintuitive or not productive (Fixes #1706), which are as follows but not limited to:
- Fire-type Pokemon with `Guts` causing `Flame Orb` to appear
- Poison-type Pokemon with `Guts` causing `Toxic Orb` to appear

Moreover, because certain moves were being grouped together that had different utilities (having a status effect from either orb and dealing with either orb itself) in addition to varying in actual implementation, each orb had a likelihood of appearing but effectively having no utility and therefore "taking" a spot for a more useful item during a run.

## What are the changes from a developer perspective?
<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

The weight functions for both orbs have been changed to reflect the new conditions that will cause them to be weighted during item reward rolls. Additionally, the code itself was refactored to be more readable and editable in the future. Note that, because all item-switching and -throwing moves are not implemented, they have been commented out with a `TODO` such that the respective boolean variable will always be `false` to save players from getting either orb and not being able to use the actual strategy the moves intend to provide.

An additional parameter `ignoreField` was added to the `canSetStatus` function to facilitate the reuse of determining whether a Pokemon can be afflicted with either status effect from their respective orbs but without being blocked by things like field terrain and weather. In particular, the original function would cause `Misty Terrain` to prevent either orb from spawning despite meeting the weight requirements since `Misty Terrain` blocks status conditions; with the new parameter, we can ignore this and reuse the logic for determining if a status effect can be afflicted.

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->
N/A

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

Testing can be done by using the `WAIVE_ROLL_FEE_OVERRIDE`, using a party that should or should not meet the requirements, and observing how either orb spawns in those contexts. In my own testing, I used the following lines towards the end of each weight function to observe how each boolean variable responded to each context:
```ts
console.log("ORB WEIGHT FUNCTION:");
console.log(p.name);
console.log(isHoldingOrb);
console.log(canSetStatus);
console.log(hasRelevantAbilities);
console.log(hasStatusMoves);
console.log(hasItemMoves);
console.log("RESULT");
console.log(!isHoldingOrb && (hasRelevantAbilities || hasStatusMoves));
console.log(!isHoldingOrb && hasItemMoves);
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - ~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~
- ~[ ] Have I provided screenshots/videos of the changes (if applicable)?~
  - ~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~

Are there any localization additions or changes? If so:
- ~[ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?~
  - ~[ ] If so, please leave a link to it here:~
- ~[ ] Has the translation team been contacted for proofreading/translation?~