### PR TITLE
[Test] Added additional safeguards to prevent Serene Grace test flakiness

### DIFF
--- a/src/test/abilities/serene_grace.test.ts
+++ b/src/test/abilities/serene_grace.test.ts
@@ -25,10 +25,13 @@ describe("Abilities - Serene Grace", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     game.override
+      .disableCrits()
       .battleType("single")
       .ability(Abilities.SERENE_GRACE)
-      .moveset([ Moves.AIR_SLASH, Moves.TACKLE ])
+      .moveset([ Moves.AIR_SLASH ])
+      .enemySpecies(Species.ALOLA_GEODUDE)
       .enemyLevel(10)
+      .enemyAbility(Abilities.BALL_FETCH)
       .enemyMoveset([ Moves.SPLASH ]);
   });
 


### PR DESCRIPTION
## What are the changes the user will see?
None.

## Why am I making these changes?
My fault. I did not think a Level 5 Shuckle could knock out a Level 10 Biome.TOWN pokemon.

## What are the changes from a developer perspective?
EnemySpecies given a neutral ability, a 4x resistant typing to Flying, and critical hits are disabled. 

## How to test the changes?
npm run test serene_Grace