### PR TITLE
[P1 Bug] Fix multi lens granting infinite Future Sight hits

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -8666,7 +8666,7 @@ export function initMoves() {
       .attr(StatStageChangeAttr, [ Stat.SPDEF ], -1)
       .ballBombMove(),
     new AttackMove(Moves.FUTURE_SIGHT, Type.PSYCHIC, MoveCategory.SPECIAL, 120, 100, 10, -1, 0, 2)
-      .partial() // cannot be used on multiple Pokemon on the same side in a double battle, hits immediately when called by Metronome/etc
+      .partial() // cannot be used on multiple Pokemon on the same side in a double battle, hits immediately when called by Metronome/etc, should not apply abilities or held items if user is off the field
       .ignoresProtect()
       .attr(DelayedAttackAttr, ArenaTagType.FUTURE_SIGHT, ChargeAnim.FUTURE_SIGHT_CHARGING, i18next.t("moveTriggers:foresawAnAttack", { pokemonName: "{USER}" })),
     new AttackMove(Moves.ROCK_SMASH, Type.FIGHTING, MoveCategory.PHYSICAL, 40, 100, 15, 50, 0, 2)
@@ -8976,7 +8976,7 @@ export function initMoves() {
       .attr(ConfuseAttr)
       .pulseMove(),
     new AttackMove(Moves.DOOM_DESIRE, Type.STEEL, MoveCategory.SPECIAL, 140, 100, 5, -1, 0, 3)
-      .partial() // cannot be used on multiple Pokemon on the same side in a double battle, hits immediately when called by Metronome/etc
+      .partial() // cannot be used on multiple Pokemon on the same side in a double battle, hits immediately when called by Metronome/etc, should not apply abilities or held items if user is off the field
       .ignoresProtect()
       .attr(DelayedAttackAttr, ArenaTagType.DOOM_DESIRE, ChargeAnim.DOOM_DESIRE_CHARGING, i18next.t("moveTriggers:choseDoomDesireAsDestiny", { pokemonName: "{USER}" })),
     new AttackMove(Moves.PSYCHO_BOOST, Type.PSYCHIC, MoveCategory.SPECIAL, 140, 90, 5, -1, 0, 3)

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -56,7 +56,7 @@ import {
   PokemonMultiHitModifier,
 } from "#app/modifier/modifier";
 import { PokemonPhase } from "#app/phases/pokemon-phase";
-import { BooleanHolder, executeIf, NumberHolder } from "#app/utils";
+import { BooleanHolder, executeIf, isNullOrUndefined, NumberHolder } from "#app/utils";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { Moves } from "#enums/moves";
 import i18next from "i18next";
@@ -106,7 +106,9 @@ export class MoveEffectPhase extends PokemonPhase {
            */
           return super.end();
         }
-        user.resetTurnData();
+        if (isNullOrUndefined(user.turnData)) {
+          user.resetTurnData();
+        }
       }
     }
 

--- a/src/test/abilities/parental_bond.test.ts
+++ b/src/test/abilities/parental_bond.test.ts
@@ -1,5 +1,5 @@
 import { Type } from "#enums/type";
-import { BattlerTagType } from "#app/enums/battler-tag-type";
+import { BattlerTagType } from "#enums/battler-tag-type";
 import { toDmgValue } from "#app/utils";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
@@ -8,7 +8,7 @@ import { Stat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
 import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 
 describe("Abilities - Parental Bond", () => {
@@ -470,4 +470,24 @@ describe("Abilities - Parental Bond", () => {
       expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(1);
     }
   );
+
+  it("should cause Future Sight to hit exactly twice if the user switches out", async () => {
+    game.override.enemyLevel(1000)
+      .moveset(Moves.FUTURE_SIGHT);
+    await game.classicMode.startBattle([ Species.BULBASAUR, Species.CHARMANDER, Species.SQUIRTLE ]);
+
+    const enemyPokemon = game.scene.getEnemyPokemon()!;
+    vi.spyOn(enemyPokemon, "damageAndUpdate");
+
+    game.move.select(Moves.FUTURE_SIGHT);
+    await game.toNextTurn();
+
+    game.doSwitchPokemon(1);
+    await game.toNextTurn();
+
+    game.doSwitchPokemon(2);
+    await game.toNextTurn();
+
+    expect(enemyPokemon.damageAndUpdate).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/test/abilities/parental_bond.test.ts
+++ b/src/test/abilities/parental_bond.test.ts
@@ -471,7 +471,7 @@ describe("Abilities - Parental Bond", () => {
     }
   );
 
-  it("should cause Future Sight to hit exactly twice if the user switches out", async () => {
+  it("should not allow Future Sight to hit infinitely many times if the user switches out", async () => {
     game.override.enemyLevel(1000)
       .moveset(Moves.FUTURE_SIGHT);
     await game.classicMode.startBattle([ Species.BULBASAUR, Species.CHARMANDER, Species.SQUIRTLE ]);
@@ -488,6 +488,7 @@ describe("Abilities - Parental Bond", () => {
     game.doSwitchPokemon(2);
     await game.toNextTurn();
 
+    // TODO: Update hit count to 1 once Future Sight is fixed to not activate abilities if user is off the field
     expect(enemyPokemon.damageAndUpdate).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/test/items/multi_lens.test.ts
+++ b/src/test/items/multi_lens.test.ts
@@ -24,7 +24,7 @@ describe("Items - Multi Lens", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     game.override
-      .moveset([ Moves.TACKLE, Moves.TRAILBLAZE, Moves.TACHYON_CUTTER ])
+      .moveset([ Moves.TACKLE, Moves.TRAILBLAZE, Moves.TACHYON_CUTTER, Moves.FUTURE_SIGHT ])
       .ability(Abilities.BALL_FETCH)
       .startingHeldItems([{ name: "MULTI_LENS" }])
       .battleType("single")
@@ -170,6 +170,7 @@ describe("Items - Multi Lens", () => {
     await game.phaseInterceptor.to("MoveEndPhase");
     expect(enemyPokemon.getHpRatio()).toBeCloseTo(0.5, 5);
   });
+
   it("should result in correct damage for hp% attacks with 2 lenses + Parental Bond", async () => {
     game.override.startingHeldItems([{ name: "MULTI_LENS", count: 2 }])
       .moveset(Moves.SUPER_FANG)
@@ -187,5 +188,24 @@ describe("Items - Multi Lens", () => {
     await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.ENEMY ]);
     await game.phaseInterceptor.to("MoveEndPhase");
     expect(enemyPokemon.getHpRatio()).toBeCloseTo(0.25, 5);
+  });
+
+  it("should cause Future Sight to hit exactly twice if the user switches out", async () => {
+    game.override.enemyLevel(1000);
+    await game.classicMode.startBattle([ Species.BULBASAUR, Species.CHARMANDER, Species.SQUIRTLE ]);
+
+    const enemyPokemon = game.scene.getEnemyPokemon()!;
+    vi.spyOn(enemyPokemon, "damageAndUpdate");
+
+    game.move.select(Moves.FUTURE_SIGHT);
+    await game.toNextTurn();
+
+    game.doSwitchPokemon(1);
+    await game.toNextTurn();
+
+    game.doSwitchPokemon(2);
+    await game.toNextTurn();
+
+    expect(enemyPokemon.damageAndUpdate).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/test/items/multi_lens.test.ts
+++ b/src/test/items/multi_lens.test.ts
@@ -190,7 +190,7 @@ describe("Items - Multi Lens", () => {
     expect(enemyPokemon.getHpRatio()).toBeCloseTo(0.25, 5);
   });
 
-  it("should cause Future Sight to hit exactly twice if the user switches out", async () => {
+  it("should not allow Future Sight to hit infinitely many times if the user switches out", async () => {
     game.override.enemyLevel(1000);
     await game.classicMode.startBattle([ Species.BULBASAUR, Species.CHARMANDER, Species.SQUIRTLE ]);
 
@@ -206,6 +206,7 @@ describe("Items - Multi Lens", () => {
     game.doSwitchPokemon(2);
     await game.toNextTurn();
 
+    // TODO: Update hit count to 1 once Future Sight is fixed to not activate held items if user is off the field
     expect(enemyPokemon.damageAndUpdate).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
If a Pokemon with Multi Lens and/or Parental Bond uses Future Sight and then switches out, Future Sight will no longer hit infinitely many times.

<sup>(Technically, according to Bulbapedia, held items and abilities should not be applying at all if the Future Sight user has switched out. But that's a fix for another day)</sup>

## Why am I making these changes?
<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->
Bug report: [Discord](https://discord.com/channels/1125469663833370665/1313094152585613312)

## What are the changes from a developer perspective?
<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->
1. `MoveEffectPhase` now resets the attacker`s turn data only if the turn data is undefined. This means that if Future Sight gets used as a multi-hit move, the attacker's turn data no longer gets reset during extra hits, so the game can properly keep track of the number of Future Sight hits.
2. Added unit tests.
3. Updated `.partial()` tags for Future Sight and Doom Desire, since abilities and held items should not be activating at all if the Future Sight user is off the field.

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->
<details>
<summary> Before the changes: Future Sight + Multi Lens hits inifinitely many times if the user switches out </summary>

https://github.com/user-attachments/assets/156b0b32-2ce4-4ce4-a6d6-4cf1d2b421ef

</details>
<details>
<summary> After the changes: Future Sight + Multi Lens hits exactly twice if the user switches out </summary>

https://github.com/user-attachments/assets/d86da756-2cd2-471c-8beb-964c1b37f1b8

</details>

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->
`npm run test [parental_bond | multi_lens]`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?