### PR TITLE
[Localization] Localizable Event Timer

### DIFF
--- a/src/timed-event-manager.ts
+++ b/src/timed-event-manager.ts
@@ -189,7 +189,7 @@ export class TimedEventDisplay extends Phaser.GameObjects.Container {
     const secs  = Math.round(diff % 6e4 / 1e3);
 
     // Return formatted string
-    return "Event Ends in : " + z(days) + "d " + z(hours) + "h " + z(mins) + "m " + z(secs) + "s";
+    return i18next.t("eventTimer", {days: z(days), hours: z(hours), mins: z(mins), secs: z(secs)});
   }
 
   updateCountdown() {

--- a/src/timed-event-manager.ts
+++ b/src/timed-event-manager.ts
@@ -189,7 +189,7 @@ export class TimedEventDisplay extends Phaser.GameObjects.Container {
     const secs  = Math.round(diff % 6e4 / 1e3);
 
     // Return formatted string
-    return i18next.t("eventTimer", { days: z(days), hours: z(hours), mins: z(mins), secs: z(secs) });
+    return i18next.t("menu:eventTimer", { days: z(days), hours: z(hours), mins: z(mins), secs: z(secs) });
   }
 
   updateCountdown() {

--- a/src/timed-event-manager.ts
+++ b/src/timed-event-manager.ts
@@ -189,7 +189,7 @@ export class TimedEventDisplay extends Phaser.GameObjects.Container {
     const secs  = Math.round(diff % 6e4 / 1e3);
 
     // Return formatted string
-    return i18next.t("eventTimer", {days: z(days), hours: z(hours), mins: z(mins), secs: z(secs)});
+    return i18next.t("eventTimer", { days: z(days), hours: z(hours), mins: z(mins), secs: z(secs) });
   }
 
   updateCountdown() {


### PR DESCRIPTION
## What are the changes the user will see?
If you not play in English and if a translation is available, so the event timer will display in the right language

## Why am I making these changes?
To have it opened to translation

## What are the changes from a developer perspective?
None

## Screenshots/Videos
Example in French:
![image](https://github.com/user-attachments/assets/70ae61bc-35b8-44e0-9bc5-50b387f0eefb)

## How to test the changes?
Set an Event in src/timed-event-manager covering you current date to display the timer and then play with the locales

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [X] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [X] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [X] If so, please leave a link to it here: https://github.com/pagefaultgames/pokerogue-locales/pull/77
- [X] Has the translation team been contacted for proofreading/translation?