### PR TITLE
[Localization] Missing localized "Able" & "Not able" in Transfer option

### DIFF
--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -362,12 +362,12 @@ export default class PartyUiHandler extends MessageUiHandler {
             if (p !== this.transferCursor) { // this skips adding the able/not able labels on the pokemon doing the transfer
               if (matchingModifier) { // if matchingModifier exists then the item exists on the new pokemon
                 if (matchingModifier.getMaxStackCount(this.scene) === matchingModifier.stackCount) { // checks to see if the stack of items is at max stack; if so, set the description label to "Not able"
-                  ableToTransfer = "Not able";
+                  ableToTransfer = i18next.t("partyUiHandler:notAble");
                 } else { // if the pokemon isn't at max stack, make the label "Able"
-                  ableToTransfer = "Able";
+                  ableToTransfer = i18next.t("partyUiHandler:able");
                 }
               } else { // if matchingModifier doesn't exist, that means the pokemon doesn't have any of the item, and we need to show "Able"
-                ableToTransfer = "Able";
+                ableToTransfer = i18next.t("partyUiHandler:able");
               }
             } else { // this else relates to the transfer pokemon. We set the text to be blank so there's no "Able"/"Not able" text
               ableToTransfer = "";


### PR DESCRIPTION
## What are the changes the user will see?
If not playing in English, so "Able" and "Not able" when Tranfering an item will be translated

## Why am I making these changes?
To have these texts translated

## What are the changes from a developer perspective?
None

## Screenshots/Videos
**Before (French)**
![image](https://github.com/user-attachments/assets/dbdc412a-c56b-44e2-94a3-662af04d6dac)

**After (French)**
![image](https://github.com/user-attachments/assets/3ca69f39-735b-49e1-b94f-84984870fd27)

## How to test the changes?
Play the game not in English an try to transfer an item between waves

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [X] Are all unit tests still passing? (`npm run test`)
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [X] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes?
- Already translated, was just missing in this context