### PR TITLE
[Misc] Update "Yda's Dex" credit (the tool is now gone)

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -615,6 +615,6 @@ In addition to the lists below, please check [the PokéRogue wiki](https://wiki.
 - roi
 
 ## External Tools
-- Ydarissep (RogueDex)
+- Ydarissep (creator of the now defunct "Yda's Dex")
 - Admiral-Billy (Offline App - Desktop)
 - Red aka StonedModder (iOS App)


### PR DESCRIPTION
```diff
diff --git "a/CREDITS.md" "b/CREDITS.md"
index 0fe0a8dc2..9a75020 100644
--- "a/CREDITS.md"
+++ "b/CREDITS.md"
@@ -615,6 +615,6 @@ In addition to the lists below, please check [the PokéRogue wiki](https://wiki.
 - roi
 
 ## External Tools
-- Ydarissep (RogueDex)
+- Ydarissep (creator of the now defunct "Yda's Dex")
 - Admiral-Billy (Offline App - Desktop)
 - Red aka StonedModder (iOS App)
```