### PR TITLE
[UI/UX] Refactor and enable seasonal splash messages

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,7 @@
 export const PLAYER_PARTY_MAX_SIZE: number = 6;
 
 /** Whether to use seasonal splash messages in general */
-export const USE_SEASONAL_SPLASH_MESSAGES: boolean = false;
+export const USE_SEASONAL_SPLASH_MESSAGES: boolean = true;
 
 /** Name of the session ID cookie */
 export const SESSION_ID_COOKIE_NAME: string = "pokerogue_sessionId";

--- a/src/data/splash-messages.ts
+++ b/src/data/splash-messages.ts
@@ -1,4 +1,5 @@
 import { USE_SEASONAL_SPLASH_MESSAGES } from "#app/constants";
+import i18next from "i18next";
 
 //#region Interfaces/Types
 
@@ -37,8 +38,6 @@ interface Season {
   start: `${Month}-${Day}`;
   /** The end day and month of the season. Format `MM-DD` */
   end: `${Month}-${Day}`;
-  /** Collection of the messages to display (without the `i18next.t()` call!) */
-  messages: string[];
 }
 
 //#region Constants
@@ -46,176 +45,53 @@ interface Season {
 /** The weight multiplier for the battles-won splash message */
 const BATTLES_WON_WEIGHT_MULTIPLIER = 10;
 /** The weight multiplier for the seasonal splash messages */
-const SEASONAL_WEIGHT_MULTIPLIER = 10;
-
-//#region Common Messages
-
-const commonSplashMessages = [
-  ...Array(BATTLES_WON_WEIGHT_MULTIPLIER).fill("battlesWon"),
-  "joinTheDiscord",
-  "infiniteLevels",
-  "everythingIsStackable",
-  "optionalSaveScumming",
-  "biomes",
-  "openSource",
-  "playWithSpeed",
-  "liveBugTesting",
-  "heavyInfluence",
-  "pokemonRiskAndPokemonRain",
-  "nowWithMoreSalt",
-  "infiniteFusionAtHome",
-  "brokenEggMoves",
-  "magnificent",
-  "doPeopleReadThis",
-  "thatsCrazy",
-  "gottaCatchEmAll",
-  "questionableBalancing",
-  "coolShaders",
-  "aiFree",
-  "suddenDifficultySpikes",
-  "basedOnAnUnfinishedFlashGame",
-  "moreAddictiveThanIntended",
-  "mostlyConsistentSeeds",
-  "achievementPointsDontDoAnything",
-  "nothingBeatsAJellyFilledDonut",
-  "dontTalkAboutTheTinkatonIncident",
-  "alsoTryPokengine",
-  "alsoTryEmeraldRogue",
-  "alsoTryRadicalRed",
-  "eeveeExpo",
-  "checkOutYnoproject",
-  "breedersInSpace",
-  "alsoTryPokemonUnbound",
-  "tryTheJohtoDragonChallenge",
-  "basicReadingAbilityRecommended",
-  "shoutoutsToTheArtists",
-  "gamblingNotEncouraged",
-  "dontForgetToTakeABreak",
-  "wEvent",
-  "ifItsNotAccurateItsAccurate",
-  "everyLossIsProgressMade",
-  "liveWoChienReaction",
-  "itsAFeatureNotABug",
-  "theEggsAreNotForEating",
-  "7.8outOf10TooManyWaterBiomes",
-  "butNothingHappened",
-  "thePowerOfScienceIsAmazing",
-  "freeToPlay",
-  "theresATimeAndPlaceForEverything",
-  "nowWithShinierShinies",
-  "smilesGoForMiles",
-  "certainlyNotDragonFree",
-  "haveANiceDay",
-  "redacted",
-  "hi",
-  "transRights",
-  "shinyOddsHigherThanYouThink",
-  "noFalseTrades",
-  "notForProfit",
-  "timeForYourDailyRun",
-  "moreEggsThanADaycare",
-  "disclaimerHarshSunDoesNotGiveVitaminD",
-  "whoNeedsAMap",
-  "luxrayIsNotADarkType",
-  "selfDestructiveEncounters",
-  "mostOptionsAreViable",
-  "pokerogueMorse",
-  "smiley",
-  "beAwareOfPassives",
-  "asSeenOnTheWorldWideWeb",
-  "vaultinVeluzas",
-  "tooManyStarters",
-  "checkTheWiki",
-  "winWithYourFavorites",
-  "alsoTryPokerogueWait",
-  "theWayISeeItKyogreIsSurrounded",
-  "tryOutHoneyGather",
-  "notForTheFaintOfHeart",
-  "p",
-  "flipYourDeviceToEvolveInkay",
-  "inArceusWeTrust",
-  "whyDidTheTorchicCrossTheRoad",
-  "goodLuck",
-  "fuseWisely",
-  "compensation",
-  "prepareForTroubleAndMakeItDouble",
-  "anEggForYourTroubles",
-  "regirock",
-  "hereForAGoodTime",
-  "getGoodOrDont",
-  "checkTheSubreddit",
-  "betterNerfGreninja",
-  "inCaseOfUpdateClearYourCache",
-  "insertTextHere",
-  "endingEndlessNotFound",
-  "iLikeMyEggsVouchered",
-  "YOU",
-  "noAddedSugar",
-  "notSponsored",
-  "notRated",
-  "justOneMoreWaveMom",
-  "saltCured",
-  "onlyOnPokerogueNet",
-  "pixelPerfection",
-  "openSource",
-  "probablyGood",
-  "itsAMonsterHouse",
-  "dontForgetYourPassword",
-  "tripleTripleTripleAxel",
-  "questionExclamation",
-  "clownEncounters",
-  "fullOfBerries",
-  "limitsAreMeantToBeBrokenSometimes",
-  "keepItCasual",
-  "serversProbablyWorking",
-  "mew",
-  "makeItRainAndYourProblemsGoAway",
-  "customMusicTracks",
-  "youAreValid",
-  "number591IsLookingOff",
-  "timeForYourDeliDelivery",
-  "goodFirstImpression",
-  "iPreferRarerCandies",
-];
+const SEASONAL_WEIGHT_MULTIPLIER = 20;
 
 //#region Seasonal Messages
 
 const seasonalSplashMessages: Season[] = [
   {
-    name: "Halloween",
-    start: "09-15",
-    end: "10-31",
-    messages: [ "halloween.pumpkabooAbout", "halloween.mayContainSpiders", "halloween.spookyScarySkeledirge", "halloween.gourgeistUsedTrickOrTreat", "halloween.letsSnuggleForever" ],
+    name: "halloween",
+    start: "10-15",
+    end: "10-31"
   },
   {
-    name: "XMAS",
-    start: "12-01",
-    end: "12-26",
-    messages: [ "xmas.happyHolidays", "xmas.unaffilicatedWithDelibirdServices", "xmas.delibirdSeason", "xmas.diamondsFromTheSky", "xmas.holidayStylePikachuNotIncluded" ],
+    name: "xmas",
+    start: "12-16",
+    end: "12-31"
   },
   {
-    name: "New Year's",
-    start: "01-01",
-    end: "01-31",
-    messages: [ "newYears.happyNewYear" ],
+    name: "newyears",
+    start: "12-31",
+    end: "01-14"
   },
 ];
 
 //#endregion
 
 export function getSplashMessages(): string[] {
-  const splashMessages: string[] = [ ...commonSplashMessages ];
+  const existingKeys = i18next.getResourceBundle(i18next.language, "splashMessages");
+  console.log(existingKeys);
+  const splashMessages: string[] = [ ...Object.keys(existingKeys["common"]) ].map((message) => `common.${message}`);
+  if (splashMessages.includes("common.battlesWon")) {
+    splashMessages.push(...Array(BATTLES_WON_WEIGHT_MULTIPLIER).fill("common.battlesWon"));
+  }
+
   console.log("use seasonal splash messages", USE_SEASONAL_SPLASH_MESSAGES);
   if (USE_SEASONAL_SPLASH_MESSAGES) {
     // add seasonal splash messages if the season is active
-    for (const { name, start, end, messages } of seasonalSplashMessages) {
+    for (const { name, start, end } of seasonalSplashMessages) {
       const now = new Date();
       const startDate = new Date(`${start}-${now.getFullYear()}`);
       const endDate = new Date(`${end}-${now.getFullYear()}`);
+      if (endDate < startDate) { // If the end date is earlier in the year, that means it's next year
+        endDate.setFullYear(endDate.getFullYear() + 1);
+      }
 
-      if (now >= startDate && now <= endDate) {
-        console.log(`Adding ${messages.length} ${name} splash messages (weight: x${SEASONAL_WEIGHT_MULTIPLIER})`);
-        messages.forEach((message) => {
+      if (existingKeys.hasOwnProperty(name) && now >= startDate && now <= endDate) {
+        const existingMessages: string[] = [ ...Object.keys(existingKeys[name]) ].map(m=>`${name}.${m}`);
+        console.log(`Adding ${existingMessages.length} ${name} splash messages from ${i18next.language} (weight: x${SEASONAL_WEIGHT_MULTIPLIER})`);
+        existingMessages.forEach((message) => {
           const weightedMessage = Array(SEASONAL_WEIGHT_MULTIPLIER).fill(message);
           splashMessages.push(...weightedMessage);
         });

--- a/src/data/splash-messages.ts
+++ b/src/data/splash-messages.ts
@@ -61,7 +61,7 @@ const seasonalSplashMessages: Season[] = [
     end: "12-31"
   },
   {
-    name: "newyears",
+    name: "newYears",
     start: "12-31",
     end: "01-14"
   },
@@ -71,10 +71,9 @@ const seasonalSplashMessages: Season[] = [
 
 export function getSplashMessages(): string[] {
   const existingKeys = i18next.getResourceBundle(i18next.language, "splashMessages");
-  console.log(existingKeys);
   const splashMessages: string[] = [ ...Object.keys(existingKeys["common"]) ].map((message) => `common.${message}`);
   if (splashMessages.includes("common.battlesWon")) {
-    splashMessages.push(...Array(BATTLES_WON_WEIGHT_MULTIPLIER).fill("common.battlesWon"));
+    splashMessages.push(...Array(Math.max(BATTLES_WON_WEIGHT_MULTIPLIER - 1, 1)).fill("common.battlesWon"));
   }
 
   console.log("use seasonal splash messages", USE_SEASONAL_SPLASH_MESSAGES);
@@ -85,8 +84,13 @@ export function getSplashMessages(): string[] {
       const startDate = new Date(`${start}-${now.getFullYear()}`);
       const endDate = new Date(`${end}-${now.getFullYear()}`);
       if (endDate < startDate) { // If the end date is earlier in the year, that means it's next year
-        endDate.setFullYear(endDate.getFullYear() + 1);
+        if (now >= startDate) {
+          endDate.setFullYear(endDate.getFullYear() + 1); //Ends next year
+        } else if (now <= endDate) {
+          startDate.setFullYear(startDate.getFullYear() - 1); //Started last year
+        }
       }
+      console.log(`${name} event starts ${startDate} and ends ${endDate}`);
 
       if (existingKeys.hasOwnProperty(name) && now >= startDate && now <= endDate) {
         const existingMessages: string[] = [ ...Object.keys(existingKeys[name]) ].map(m=>`${name}.${m}`);

--- a/src/test/data/splash_messages.test.ts
+++ b/src/test/data/splash_messages.test.ts
@@ -9,7 +9,7 @@ describe("Data - Splash Messages", () => {
 
   // make sure to adjust this test if the weight it changed!
   it("should add contain 10 `battlesWon` splash messages", () => {
-    const battlesWonMessages = getSplashMessages().filter((message) => message === "splashMessages:battlesWon");
+    const battlesWonMessages = getSplashMessages().filter((message) => message === "splashMessages:common.battlesWon");
     expect(battlesWonMessages).toHaveLength(10);
   });
 
@@ -22,16 +22,16 @@ describe("Data - Splash Messages", () => {
       vi.useRealTimers(); // reset system time
     });
 
-    it("should contain halloween messages from Sep 15 to Oct 31", () => {
-      testSeason(new Date("2024-09-15"), new Date("2024-10-31"), "halloween");
+    it("should contain halloween messages from Oct 15 to Oct 31", () => {
+      testSeason(new Date("2024-10-15"), new Date("2024-10-31"), "halloween");
     });
 
-    it("should contain xmas messages from Dec 1 to Dec 26", () => {
-      testSeason(new Date("2024-12-01"), new Date("2024-12-26"), "xmas");
+    it("should contain xmas messages from Dec 16 to Dec 31", () => {
+      testSeason(new Date("2024-12-16"), new Date("2024-12-31"), "xmas");
     });
 
-    it("should contain new years messages frm Jan 1 to Jan 31", () => {
-      testSeason(new Date("2024-01-01"), new Date("2024-01-31"), "newYears");
+    it("should contain new years messages from Dec 31 '24 to Jan 14 '25", () => {
+      testSeason(new Date("2024-12-31"), new Date("2025-01-14"), "newYears");
     });
   });
 });
@@ -60,7 +60,7 @@ function testSeason(startDate: Date, endDate: Date, prefix: string) {
   });
 
   expect(before).toBe(0);
-  expect(start).toBeGreaterThanOrEqual(10); // make sure to adjust if weight is changed!
-  expect(end).toBeGreaterThanOrEqual(10); // make sure to adjust if weight is changed!
+  expect(start).toBeGreaterThanOrEqual(20); // make sure to adjust if weight is changed!
+  expect(end).toBeGreaterThanOrEqual(20); // make sure to adjust if weight is changed!
   expect(after).toBe(0);
 }

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -83,7 +83,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
       .then(stats => {
         if (stats) {
           this.playerCountLabel.setText(`${stats.playerCount} ${i18next.t("menu:playersOnline")}`);
-          if (this.splashMessage === "splashMessages:battlesWon") {
+          if (this.splashMessage === "splashMessages:common.battlesWon") {
             this.splashMessageText.setText(i18next.t(this.splashMessage, { count: stats.battleCount }));
           }
         }
@@ -98,6 +98,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
 
     if (ret) {
       this.splashMessage = Utils.randItem(getSplashMessages());
+      console.log(this.splashMessage);
       this.splashMessageText.setText(i18next.t(this.splashMessage, { count: TitleUiHandler.BATTLES_WON_FALLBACK }));
 
       this.appVersionText.setText("v" + version);


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
- Seasonal splash messages will show up in the appropriate time period if splashes for that season exist for their language
- There are currently 3 "seasons" for splash messages:
  - Halloween from October 15 to October 31
  - Xmas from December 16 to December 31
  - NewYears from December 31 to the following year's January 14
- Seasonal splash message weights bumped from 10 to 20

## Why am I making these changes?
<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
- We can now be festive and jolly
- Makes it easier for each locale to have different splash messages without having to localize a reference which may not work
- Puts less pressure on translation team
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

## What are the changes from a developer perspective?
<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->
- Instead of returning a list of locale keys defined in `splash-messages.ts`, i18next is used to get all the splash texts for the user's language at once as a json object. Then, all the keys that exist in the "common" category are put in a list, and then if the time matches with a season, all the keys found in that season are pushed to the list. **THIS REQUIRES A CHANGE TO LOCALE FILES.** This way, the game will only choose splash texts that are defined in the language.
- Sets USE_SEASONAL_SPLASH_MESSAGES to true
- Updates `data/splash_messages` test to reflect these changes

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->
<img width="947" alt="Screenshot_991" src="https://github.com/user-attachments/assets/242c149f-870b-40c4-88ae-6e4e9ac6af3d" />


## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [X] Are all unit tests still passing? (`npm run test`)
  - [X] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [X] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?