### PR TITLE
Toggle cursor run

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -147,6 +147,7 @@ export default class BattleScene extends SceneBase {
   public damageNumbersMode: integer = 0;
   public reroll: boolean = false;
   public shopCursorTarget: number = ShopCursorTarget.REWARDS;
+  public commandCursorReset: boolean = true;
   public showMovesetFlyout: boolean = true;
   public showArenaFlyout: boolean = true;
   public showTimeOfDayWidget: boolean = true;

--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -35,8 +35,14 @@ export class CommandPhase extends FieldPhase {
     this.scene.updateGameInfo();
 
     const commandUiHandler = this.scene.ui.handlers[Mode.COMMAND];
+
+    // If one of these conditions is true, we always reset the cursor to Command.FIGHT
+    const cursorResetBattle = this.scene.currentBattle.battleType === BattleType.MYSTERY_ENCOUNTER ||
+                              this.scene.currentBattle.battleType === BattleType.TRAINER ||
+                              this.scene.arena.biomeType === Biome.END;
+
     if (commandUiHandler) {
-      if (this.scene.currentBattle.turn === 1 || commandUiHandler.getCursor() === Command.POKEMON) {
+      if ((this.scene.currentBattle.turn === 1 && (this.scene.commandCursorReset || cursorResetBattle)) || commandUiHandler.getCursor() === Command.POKEMON) {
         commandUiHandler.setCursor(Command.FIGHT);
       } else {
         commandUiHandler.setCursor(commandUiHandler.getCursor());

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -157,6 +157,7 @@ export const SettingKeys = {
   Move_Animations: "MOVE_ANIMATIONS",
   Show_Stats_on_Level_Up: "SHOW_LEVEL_UP_STATS",
   Shop_Cursor_Target: "SHOP_CURSOR_TARGET",
+  Command_Cursor_Reset: "COMMAND_CURSOR_RESET",
   Candy_Upgrade_Notification: "CANDY_UPGRADE_NOTIFICATION",
   Candy_Upgrade_Display: "CANDY_UPGRADE_DISPLAY",
   Move_Info: "MOVE_INFO",
@@ -682,6 +683,13 @@ export const Setting: Array<Setting> = [
     type: SettingType.DISPLAY
   },
   {
+    key: SettingKeys.Command_Cursor_Reset,
+    label: i18next.t("settings:commandCursorReset"),
+    options: OFF_ON,
+    default: 1,
+    type: SettingType.DISPLAY
+  },
+  {
     key: SettingKeys.Shop_Overlay_Opacity,
     label: i18next.t("settings:shopOverlayOpacity"),
     options: SHOP_OVERLAY_OPACITY_OPTIONS,
@@ -826,6 +834,9 @@ export function setSetting(scene: BattleScene, setting: string, value: integer):
     case SettingKeys.Shop_Cursor_Target:
       const selectedValue = shopCursorTargetIndexMap[value];
       scene.shopCursorTarget = selectedValue;
+      break;
+    case SettingKeys.Command_Cursor_Reset:
+      scene.commandCursorReset = Setting[index].options[value].value === "On";
       break;
     case SettingKeys.EXP_Gains_Speed:
       scene.expGainsSpeed = value;


### PR DESCRIPTION
## What are the changes the user will see?
A new on/off toggle is added to the Game Settings/Display menu, which is on by default corresponding to the current game behavior. 
Game behavior is only affected after a user switches the toggle off. The result is that the cursor does not reset after fleeing or catching a wild pokémon, unless the new battle is a trainer, mystery encounter, or is in the End.

## Why am I making these changes?
Several users have expressed that the ability to let the cursor not reset (not go back to "Fight" at the beginning of each battle) would positively affect their experience. Having this as a toggle allows to leave experience unchanged for all other users.

## What are the changes from a developer perspective?
A new variable commandCursorReset has been added to the BattleScene class in battle-scene.ts.
In command-phase.ts, at the beginning of each battle, this variable is checked to decide whether the cursor should reset.
A new toggle has been added in settings.ts.

## Screenshots/Videos
Screenshot of the new toggle in menu (without the changes to locales implemented yet).
![new_toggle](https://github.com/user-attachments/assets/04f6f2b7-9906-45ef-80ee-bb6a7ddf7499)
Screenshot of tests passing.
![tests_passing](https://github.com/user-attachments/assets/321fda9f-ebec-4c2b-a5d6-e559e74e74a3)

## How to test the changes?
I made use of overrides to increase the frequency of mystery encounters and make sure they did not lead to anomalous behaviour.
The most direct way to test the changes is start a new run, switch the toggle off, and start a new battle after running or catching a wild pokémon.

## Checklist
- [x ] **I'm using `beta` as my base branch**
- [x ] There is no overlap with another PR?
- [x ] The PR is self-contained and cannot be split into smaller PRs?
- [x ] Have I provided a clear explanation of the changes?
- [x ] Have I tested the changes manually?
- [x ] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [x ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [x ] If so, please leave a link to it here: https://github.com/pagefaultgames/pokerogue-locales/pull/87
- [x ] Has the translation team been contacted for proofreading/translation?
