### PR TITLE
[UI/UX] Change label for music settings

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -173,7 +173,7 @@ export default class BattleScene extends SceneBase {
   public uiTheme: UiTheme = UiTheme.DEFAULT;
   public windowType: integer = 0;
   public experimentalSprites: boolean = false;
-  public musicPreference: number = MusicPreference.MIXED;
+  public musicPreference: number = MusicPreference.ALLGENS;
   public moveAnimations: boolean = true;
   public expGainsSpeed: ExpGainsSpeed = ExpGainsSpeed.DEFAULT;
   public skipSeenDialogues: boolean = false;

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -222,7 +222,7 @@ export default class Battle {
       if (!this.started && this.trainer?.config.encounterBgm && this.trainer?.getEncounterMessages()?.length) {
         return `encounter_${this.trainer?.getEncounterBgm()}`;
       }
-      if (scene.musicPreference === MusicPreference.CONSISTENT) {
+      if (scene.musicPreference === MusicPreference.GENFIVE) {
         return this.trainer?.getBattleBgm() ?? null;
       } else {
         return this.trainer?.getMixedBattleBgm() ?? null;
@@ -239,7 +239,7 @@ export default class Battle {
         return "battle_final_encounter";
       }
       if (pokemon.species.legendary || pokemon.species.subLegendary || pokemon.species.mythical) {
-        if (scene.musicPreference === MusicPreference.CONSISTENT) {
+        if (scene.musicPreference === MusicPreference.GENFIVE) {
           switch (pokemon.species.speciesId) {
             case Species.REGIROCK:
             case Species.REGICE:
@@ -256,7 +256,7 @@ export default class Battle {
               }
               return "battle_legendary_unova";
           }
-        } else if (scene.musicPreference === MusicPreference.MIXED) {
+        } else if (scene.musicPreference === MusicPreference.ALLGENS) {
           switch (pokemon.species.speciesId) {
             case Species.ARTICUNO:
             case Species.ZAPDOS:

--- a/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
+++ b/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
@@ -107,7 +107,7 @@ export const GlobalTradeSystemEncounter: MysteryEncounter =
 
       // Load bgm
       let bgmKey: string;
-      if (scene.musicPreference === MusicPreference.CONSISTENT) {
+      if (scene.musicPreference === MusicPreference.GENFIVE) {
         bgmKey = "mystery_encounter_gen_5_gts";
         scene.loadBgm(bgmKey, `${bgmKey}.mp3`);
       } else {

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -663,11 +663,11 @@ export const Setting: Array<Setting> = [
     options: [
       {
         value: "Consistent",
-        label: i18next.t("settings:consistent")
+        label: i18next.t("settings:musicGenFive")
       },
       {
         value: "Mixed",
-        label: i18next.t("settings:mixed")
+        label: i18next.t("settings:musicAllGens")
       }
     ],
     default: MusicPreference.MIXED,

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -662,11 +662,11 @@ export const Setting: Array<Setting> = [
     label: i18next.t("settings:musicPreference"),
     options: [
       {
-        value: "Gen 5",
+        value: "Gen V + PMD",
         label: i18next.t("settings:musicGenFive")
       },
       {
-        value: "All Generations",
+        value: "All Gens",
         label: i18next.t("settings:musicAllGens")
       }
     ],

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -180,8 +180,8 @@ export const SettingKeys = {
 };
 
 export enum MusicPreference {
-  CONSISTENT,
-  MIXED
+  GENFIVE,
+  ALLGENS
 }
 
 /**
@@ -662,15 +662,15 @@ export const Setting: Array<Setting> = [
     label: i18next.t("settings:musicPreference"),
     options: [
       {
-        value: "Consistent",
+        value: "Gen 5",
         label: i18next.t("settings:musicGenFive")
       },
       {
-        value: "Mixed",
+        value: "All Generations",
         label: i18next.t("settings:musicAllGens")
       }
     ],
-    default: MusicPreference.MIXED,
+    default: MusicPreference.ALLGENS,
     type: SettingType.AUDIO,
     requireReload: true
   },


### PR DESCRIPTION
## What are the changes the user will see?
Music settings options changed from "Consistent/Mixed" to "Gen V + PMD/All Gens".

## Why am I making these changes?
The existing labels don't tell the user what they do, leading to confusion.

## What are the changes from a developer perspective?
New i18n keys created in `settings.json`: `musicGenFive` and `musicAllGens`.
Labels changed in `settings.ts` to use the new keys.

## Screenshots/Videos
![image](https://github.com/user-attachments/assets/7456fb08-fc22-4eaf-b303-4b8a41e2d4eb)

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Have I provided screenshots/videos of the changes (if applicable)?

Are there any localization additions or changes? If so:
- [x] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [x] If so, please leave a link to it here: https://github.com/pagefaultgames/pokerogue-locales/pull/90
- [x] Has the translation team been contacted for proofreading/translation?