### PR TITLE
[Hotfix] Prevent Keldeo from changing forms in Daily Run

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pokemon-rogue-battle",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pokemon-rogue-battle",
-			"version": "1.4.1",
+			"version": "1.4.2",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@material/material-color-utilities": "^0.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pokemon-rogue-battle",
 	"private": true,
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"type": "module",
 	"scripts": {
 		"start": "vite",

--- a/src/data/pokemon-forms.ts
+++ b/src/data/pokemon-forms.ts
@@ -770,8 +770,8 @@ export const pokemonFormChanges: PokemonFormChanges = {
     new SpeciesFormChange(Species.KYUREM, "", "white", new SpeciesFormChangeItemTrigger(FormChangeItem.LIGHT_STONE), false, getSpeciesDependentFormChangeCondition(Species.RESHIRAM))
   ],
   [Species.KELDEO]: [
-    new SpeciesFormChange(Species.KELDEO, "ordinary", "resolute", new SpeciesFormChangeMoveLearnedTrigger(Moves.SECRET_SWORD)),
-    new SpeciesFormChange(Species.KELDEO, "resolute", "ordinary", new SpeciesFormChangeMoveLearnedTrigger(Moves.SECRET_SWORD, false))
+    new SpeciesFormChange(Species.KELDEO, "ordinary", "resolute", new SpeciesFormChangeMoveLearnedTrigger(Moves.SECRET_SWORD), false, new SpeciesFormChangeCondition((p) => p.scene.gameMode.isDaily !== true)),
+    new SpeciesFormChange(Species.KELDEO, "resolute", "ordinary", new SpeciesFormChangeMoveLearnedTrigger(Moves.SECRET_SWORD, false), false, new SpeciesFormChangeCondition((p) => p.scene.gameMode.isDaily !== true))
   ],
   [Species.MELOETTA]: [
     new SpeciesFormChange(Species.MELOETTA, "aria", "pirouette", new MeloettaFormChangePostMoveTrigger(Moves.RELIC_SONG), true),


### PR DESCRIPTION
## What are the changes the user will see?
Keldeo will no longer be able to change forms in Daily Run mode, preventing a crash.

## Why am I making these changes?
The game crashes if the player has Keldeo in their starting party in Daily Run mode.

## What are the changes from a developer perspective?
A condition was added to Keldeo's form changes that checks if the mode is Daily Run and prevents the form change if so.

## Checklist
- ~[ ] **I'm using `beta` as my base branch**~
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?