### PR TITLE
[Bug] Gimmighoul and Eevee eggs will now properly randomize their forms

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1424,7 +1424,7 @@ export default class BattleScene extends SceneBase {
       return 0;
     }
 
-    const isEggPhase: boolean = this.getCurrentPhase()?.constructor.name === "EggLapsePhase";
+    const isEggPhase: boolean = [ "EggLapsePhase", "EggHatchPhase" ].includes(this.getCurrentPhase()?.constructor.name ?? "");
 
     switch (species.speciesId) {
       case Species.UNOWN:

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1424,6 +1424,8 @@ export default class BattleScene extends SceneBase {
       return 0;
     }
 
+    const isEggPhase: boolean = this.getCurrentPhase()?.constructor.name === "EggLapsePhase";
+
     switch (species.speciesId) {
       case Species.UNOWN:
       case Species.SHELLOS:
@@ -1455,7 +1457,7 @@ export default class BattleScene extends SceneBase {
         }
         return Utils.randSeedInt(8);
       case Species.EEVEE:
-        if (this.currentBattle?.battleType === BattleType.TRAINER && this.currentBattle?.waveIndex < 30) {
+        if (this.currentBattle?.battleType === BattleType.TRAINER && this.currentBattle?.waveIndex < 30 && !isEggPhase) {
           return 0; // No Partner Eevee for Wave 12 Preschoolers
         }
         return Utils.randSeedInt(2);
@@ -1483,7 +1485,7 @@ export default class BattleScene extends SceneBase {
         return 0;
       case Species.GIMMIGHOUL:
       // Chest form can only be found in Mysterious Chest Encounter, if this is a game mode with MEs
-        if (this.gameMode.hasMysteryEncounters) {
+        if (this.gameMode.hasMysteryEncounters && !isEggPhase) {
           return 1; // Wandering form
         } else {
           return Utils.randSeedInt(species.forms.length);


### PR DESCRIPTION
## What are the changes the user will see?
Gimmighoul and Eevee eggs will no longer hatch differently depending on what game mode you're playing in when they hatch.

## Why am I making these changes?
Fixes #5079 

## What are the changes from a developer perspective?
`BattleScene.getSpeciesFormIndex()` added checks for `EggLapsePhase` when selecting the form to generate for Gimmighoul and Eevee.

## Screenshots/Videos
<details>
  <summary>Fixed behavior</summary>

https://github.com/user-attachments/assets/0a2c3319-bff8-4da7-8bc9-f3c3cd4f346d

</details>

## How to test the changes?
Buy a bunch of Gimmighoul species eggs and hatch them during a Classic run. Some of them should be Chest form.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?