### PR TITLE
[Bug] Fixed defog not removing the target's Safeguard and Mist

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5814,60 +5814,6 @@ export class RemoveArenaTrapAttr extends MoveEffectAttr {
 }
 
 
-export class RemoveSafeguard extends MoveEffectAttr {
-
-  private targetBothSides: boolean;
-
-  constructor(targetBothSides: boolean = false) {
-    super(true, { trigger: MoveEffectTrigger.PRE_APPLY });
-    this.targetBothSides = targetBothSides;
-  }
-
-  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-
-    if (!super.apply(user, target, move, args)) {
-      return false;
-    }
-
-    if (this.targetBothSides) {
-      user.scene.arena.removeTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER);
-      user.scene.arena.removeTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY);
-
-    } else {
-      user.scene.arena.removeTagOnSide(ArenaTagType.SAFEGUARD, target.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY);
-    }
-
-    return true;
-  }
-}
-
-export class RemoveMist extends MoveEffectAttr {
-
-  private targetBothSides: boolean;
-
-  constructor(targetBothSides: boolean = false) {
-    super(true, { trigger: MoveEffectTrigger.PRE_APPLY });
-    this.targetBothSides = targetBothSides;
-  }
-
-  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-
-    if (!super.apply(user, target, move, args)) {
-      return false;
-    }
-
-    if (this.targetBothSides) {
-      user.scene.arena.removeTagOnSide(ArenaTagType.MIST, ArenaTagSide.PLAYER);
-      user.scene.arena.removeTagOnSide(ArenaTagType.MIST, ArenaTagSide.ENEMY);
-
-    } else {
-      user.scene.arena.removeTagOnSide(ArenaTagType.MIST, target.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY);
-    }
-
-    return true;
-  }
-}
-
 export class RemoveScreensAttr extends MoveEffectAttr {
 
   private targetBothSides: boolean;
@@ -9276,8 +9222,7 @@ export function initMoves() {
       .attr(ClearTerrainAttr)
       .attr(RemoveScreensAttr, false)
       .attr(RemoveArenaTrapAttr, true)
-      .attr(RemoveSafeguard, false)
-      .attr(RemoveMist, false),
+      .attr(RemoveArenaTagsAttr, [ ArenaTagType.MIST, ArenaTagType.SAFEGUARD ], false),
     new StatusMove(Moves.TRICK_ROOM, Type.PSYCHIC, -1, 5, -1, -7, 4)
       .attr(AddArenaTagAttr, ArenaTagType.TRICK_ROOM, 5)
       .ignoresProtect()

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5813,6 +5813,61 @@ export class RemoveArenaTrapAttr extends MoveEffectAttr {
   }
 }
 
+
+export class RemoveSafeguard extends MoveEffectAttr {
+
+  private targetBothSides: boolean;
+
+  constructor(targetBothSides: boolean = false) {
+    super(true, { trigger: MoveEffectTrigger.PRE_APPLY });
+    this.targetBothSides = targetBothSides;
+  }
+
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+
+    if (!super.apply(user, target, move, args)) {
+      return false;
+    }
+
+    if (this.targetBothSides) {
+      user.scene.arena.removeTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER);
+      user.scene.arena.removeTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY);
+
+    } else {
+      user.scene.arena.removeTagOnSide(ArenaTagType.SAFEGUARD, target.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY);
+    }
+
+    return true;
+  }
+}
+
+export class RemoveMist extends MoveEffectAttr {
+
+  private targetBothSides: boolean;
+
+  constructor(targetBothSides: boolean = false) {
+    super(true, { trigger: MoveEffectTrigger.PRE_APPLY });
+    this.targetBothSides = targetBothSides;
+  }
+
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+
+    if (!super.apply(user, target, move, args)) {
+      return false;
+    }
+
+    if (this.targetBothSides) {
+      user.scene.arena.removeTagOnSide(ArenaTagType.MIST, ArenaTagSide.PLAYER);
+      user.scene.arena.removeTagOnSide(ArenaTagType.MIST, ArenaTagSide.ENEMY);
+
+    } else {
+      user.scene.arena.removeTagOnSide(ArenaTagType.MIST, target.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY);
+    }
+
+    return true;
+  }
+}
+
 export class RemoveScreensAttr extends MoveEffectAttr {
 
   private targetBothSides: boolean;
@@ -9220,7 +9275,9 @@ export function initMoves() {
       .attr(ClearWeatherAttr, WeatherType.FOG)
       .attr(ClearTerrainAttr)
       .attr(RemoveScreensAttr, false)
-      .attr(RemoveArenaTrapAttr, true),
+      .attr(RemoveArenaTrapAttr, true)
+      .attr(RemoveSafeguard, false)
+      .attr(RemoveMist, false),
     new StatusMove(Moves.TRICK_ROOM, Type.PSYCHIC, -1, 5, -1, -7, 4)
       .attr(AddArenaTagAttr, ArenaTagType.TRICK_ROOM, 5)
       .ignoresProtect()

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -5813,7 +5813,6 @@ export class RemoveArenaTrapAttr extends MoveEffectAttr {
   }
 }
 
-
 export class RemoveScreensAttr extends MoveEffectAttr {
 
   private targetBothSides: boolean;

--- a/src/test/moves/defog.test.ts
+++ b/src/test/moves/defog.test.ts
@@ -1,0 +1,71 @@
+import { Stat } from "#enums/stat";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Moves - Defog", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([ Moves.MIST, Moves.SAFEGUARD, Moves.SPLASH ])
+      .ability(Abilities.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.SHUCKLE)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset([ Moves.DEFOG, Moves.GROWL ]);
+  });
+
+  it("should not allow Safeguard to be active", async () => {
+    await game.classicMode.startBattle([ Species.REGIELEKI ]);
+
+    const playerPokemon = game.scene.getPlayerField();
+    const enemyPokemon = game.scene.getEnemyField();
+
+    game.move.select(Moves.SAFEGUARD);
+    await game.forceEnemyMove(Moves.DEFOG);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(playerPokemon[0].isSafeguarded(enemyPokemon[0])).toBe(false);
+
+
+    expect(true).toBe(true);
+  });
+
+
+  it("should not allow Mist to be active", async () => {
+    await game.classicMode.startBattle([ Species.REGIELEKI ]);
+
+    const playerPokemon = game.scene.getPlayerField();
+
+    game.move.select(Moves.MIST);
+    await game.forceEnemyMove(Moves.DEFOG);
+
+    await game.toNextTurn();
+
+    game.move.select(Moves.SPLASH);
+    await game.forceEnemyMove(Moves.GROWL);
+
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(playerPokemon[0].getStatStage(Stat.ATK)).toBe(-1);
+
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?
Defog will now successfully remove the Safeguard and Mist from the target side.

## Why am I making these changes?
Fixes https://github.com/pagefaultgames/pokerogue/issues/5086.

## What are the changes from a developer perspective?
~~Added `RemoveSafeguard` and `RemoveMist` classes to `moves.ts`, and has them be called by Defog with both sides set to false.~~ Used `RemoveArenaTagsAttr` for Defog in `moves.ts`. Added `defog.test.ts` as well.

## How to test the changes?
Using defog on an enemy who has Safeguard or Mist active would verify the changes work.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?