### PR TITLE
[Balance] Multi-hit moves now use gen 5+ behavior

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -2231,14 +2231,14 @@ export class MultiHitAttr extends MoveAttr {
     switch (this.multiHitType) {
       case MultiHitType._2_TO_5:
       {
-        const rand = user.randSeedInt(16);
-        const hitValue = new Utils.IntegerHolder(rand);
+        const rand = user.randSeedInt(20);
+        const hitValue = new Utils.NumberHolder(rand);
         applyAbAttrs(MaxMultiHitAbAttr, user, null, false, hitValue);
-        if (hitValue.value >= 10) {
+        if (hitValue.value >= 13) {
           return 2;
-        } else if (hitValue.value >= 4) {
+        } else if (hitValue.value >= 6) {
           return 3;
-        } else if (hitValue.value >= 2) {
+        } else if (hitValue.value >= 3) {
           return 4;
         } else {
           return 5;


### PR DESCRIPTION
## What are the changes the user will see?
Changed behavior of multi-hit moves so that the odds are 35/35/15/15 for 2/3/4/5 hits (gen 5+) instead of 37.5/37.5/12.5/12.5 for 2/3/4/5 hits (gen 1-4).
cf https://bulbapedia.bulbagarden.net/wiki/Multistrike_move#Variable_number_of_strikes

## Why am I making these changes?
Multi-hit moves don't need to be that bad.

## What are the changes from a developer perspective?
The game now rolls a d20 and assigns the number of hits as follows:

| # rolled | # of hits |
| -------- | --------- |
| 0, 1, 2  | 5         |
| 3, 4, 5  | 4         |
| 6-12     | 3         |
| 13-19    | 2         |

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?