### PR TITLE
[Balance] Give Cosplay Pikachu Forms Custom Typings and Hidden Abilities.

### DIFF
--- a/src/data/balance/pokemon-level-moves.ts
+++ b/src/data/balance/pokemon-level-moves.ts
@@ -19033,7 +19033,7 @@ export const pokemonFormLevelMoves: PokemonSpeciesFormLevelMoves = {
       [ 48, Moves.PIKA_PAPOW ],
     ],
     5: [
-      [ 1, Moves.DRAINING_KISS ],
+      [ 1, Moves.DAZZLING_GLEAM ],
       [ 1, Moves.TAIL_WHIP ],
       [ 1, Moves.GROWL ],
       [ 1, Moves.THUNDER_SHOCK ],
@@ -19057,7 +19057,7 @@ export const pokemonFormLevelMoves: PokemonSpeciesFormLevelMoves = {
       [ 48, Moves.PIKA_PAPOW ],
     ],
     6: [
-      [ 1, Moves.ELECTRIC_TERRAIN ],
+      [ 1, Moves.PSYCHIC_NOISE ],
       [ 1, Moves.TAIL_WHIP ],
       [ 1, Moves.GROWL ],
       [ 1, Moves.THUNDER_SHOCK ],

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -1021,11 +1021,11 @@ export function initSpecies() {
       new PokemonForm("Normal", "", Type.ELECTRIC, null, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.LIGHTNING_ROD, 320, 35, 55, 40, 50, 50, 90, 190, 50, 112, true, null, true),
       new PokemonForm("Partner", "partner", Type.ELECTRIC, null, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.LIGHTNING_ROD, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true),
       new PokemonForm("Cosplay", "cosplay", Type.ELECTRIC, null, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.LIGHTNING_ROD, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true), //Custom
-      new PokemonForm("Cool Cosplay", "cool-cosplay", Type.ELECTRIC, null, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.LIGHTNING_ROD, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true), //Custom
-      new PokemonForm("Beauty Cosplay", "beauty-cosplay", Type.ELECTRIC, null, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.LIGHTNING_ROD, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true), //Custom
-      new PokemonForm("Cute Cosplay", "cute-cosplay", Type.ELECTRIC, null, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.LIGHTNING_ROD, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true), //Custom
-      new PokemonForm("Smart Cosplay", "smart-cosplay", Type.ELECTRIC, null, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.LIGHTNING_ROD, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true), //Custom
-      new PokemonForm("Tough Cosplay", "tough-cosplay", Type.ELECTRIC, null, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.LIGHTNING_ROD, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true), //Custom
+      new PokemonForm("Cool Cosplay", "cool-cosplay", Type.ELECTRIC, Type.STEEL, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.INNER_FOCUS, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true), //Custom
+      new PokemonForm("Beauty Cosplay", "beauty-cosplay", Type.ELECTRIC, Type.ICE, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.QUEENLY_MAJESTY, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true), //Custom
+      new PokemonForm("Cute Cosplay", "cute-cosplay", Type.ELECTRIC, Type.FAIRY, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.CUTE_CHARM, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true), //Custom
+      new PokemonForm("Smart Cosplay", "smart-cosplay", Type.ELECTRIC, Type.PSYCHIC, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.TINTED_LENS, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true), //Custom
+      new PokemonForm("Tough Cosplay", "tough-cosplay", Type.ELECTRIC, Type.FIGHTING, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.DEFIANT, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true), //Custom
       new PokemonForm("G-Max", SpeciesFormKey.GIGANTAMAX, Type.ELECTRIC, null, 21, 999.9, Abilities.LIGHTNING_ROD, Abilities.NONE, Abilities.LIGHTNING_ROD, 530, 125, 95, 60, 90, 70, 90, 190, 50, 112), //+100 BST from Partner Form
     ),
     new PokemonSpecies(Species.RAICHU, 1, false, false, false, "Mouse Pokémon", Type.ELECTRIC, null, 0.8, 30, Abilities.STATIC, Abilities.NONE, Abilities.LIGHTNING_ROD, 485, 60, 90, 55, 90, 80, 110, 75, 50, 243, GrowthRate.MEDIUM_FAST, 50, true),

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -1021,11 +1021,11 @@ export function initSpecies() {
       new PokemonForm("Normal", "", Type.ELECTRIC, null, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.LIGHTNING_ROD, 320, 35, 55, 40, 50, 50, 90, 190, 50, 112, true, null, true),
       new PokemonForm("Partner", "partner", Type.ELECTRIC, null, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.LIGHTNING_ROD, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true),
       new PokemonForm("Cosplay", "cosplay", Type.ELECTRIC, null, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.LIGHTNING_ROD, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true), //Custom
-      new PokemonForm("Cool Cosplay", "cool-cosplay", Type.ELECTRIC, Type.STEEL, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.INNER_FOCUS, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true), //Custom
+      new PokemonForm("Cool Cosplay", "cool-cosplay", Type.ELECTRIC, Type.STEEL, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.DEFIANT, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true), //Custom
       new PokemonForm("Beauty Cosplay", "beauty-cosplay", Type.ELECTRIC, Type.ICE, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.QUEENLY_MAJESTY, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true), //Custom
       new PokemonForm("Cute Cosplay", "cute-cosplay", Type.ELECTRIC, Type.FAIRY, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.CUTE_CHARM, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true), //Custom
-      new PokemonForm("Smart Cosplay", "smart-cosplay", Type.ELECTRIC, Type.PSYCHIC, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.TINTED_LENS, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true), //Custom
-      new PokemonForm("Tough Cosplay", "tough-cosplay", Type.ELECTRIC, Type.FIGHTING, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.DEFIANT, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true), //Custom
+      new PokemonForm("Smart Cosplay", "smart-cosplay", Type.ELECTRIC, Type.PSYCHIC, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.FRISK, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true), //Custom
+      new PokemonForm("Tough Cosplay", "tough-cosplay", Type.ELECTRIC, Type.FIGHTING, 0.4, 6, Abilities.STATIC, Abilities.NONE, Abilities.INNER_FOCUS, 430, 45, 80, 50, 75, 60, 120, 190, 50, 112, true, null, true), //Custom
       new PokemonForm("G-Max", SpeciesFormKey.GIGANTAMAX, Type.ELECTRIC, null, 21, 999.9, Abilities.LIGHTNING_ROD, Abilities.NONE, Abilities.LIGHTNING_ROD, 530, 125, 95, 60, 90, 70, 90, 190, 50, 112), //+100 BST from Partner Form
     ),
     new PokemonSpecies(Species.RAICHU, 1, false, false, false, "Mouse Pokémon", Type.ELECTRIC, null, 0.8, 30, Abilities.STATIC, Abilities.NONE, Abilities.LIGHTNING_ROD, 485, 60, 90, 55, 90, 80, 110, 75, 50, 243, GrowthRate.MEDIUM_FAST, 50, true),


### PR DESCRIPTION
## What are the changes the user will see?
Each Cosplay Pikachu receives a new type and hidden ability associated with its outfit.
Cute Cosplay loses Draining Kiss for Dazzling Gleam.
Clever Cosplay loses Electric Terrain for Psychic Noise.

Cool:
Electric -> Electric/Steel
Lightning Rod -> Defiant
Beauty:
Electric -> Electric/Ice
Lightning Rod -> Queenly Majesty
Cute:
Electric -> Electric/Fairy
Lightning Rod -> Cute Charm
Clever:
Electric -> Electric/Psychic
Lightning Rod -> Frisk
Tough:
Electric -> Electric/Fighting
Lightning Rod -> Inner Focus

## Why am I making these changes?
With https://github.com/pagefaultgames/pokerogue/pull/5125, Pikachu is the only remaining NFE starter due to having Partner/Cosplay forms locked to the starter. This puts a spotlight on the Cosplays, as they are mainly outclassed by Partner and starter Pichu due to being locked from evolving and lacking the G-Max capability of Partner Pikachu. Giving them a secondary typing gives them a boost to their signature moves, gives them flexibility in different comps or matchups, and puts them in line with the Starmobiles who also gained a secondary typing which detached them from mainline. Cute and Clever receive different signatures as after their release in ORAS, base Pikachu now gets access to both of those moves making their "exclusivity" redundant. Cute gets access to Dazzling Gleam now and Clever gets access to Psychic Noise, as Psychic moves tend to have the "Cleverness" attribute in Contests in mainline. Each form now also gets a new hidden ability for added flavor and originality, while adhering heavily to thematics. 

## What are the changes from a developer perspective?
Changes to pokemon-species.ts and pokemon-level-moves.ts

## Screenshots/Videos
Cute and Clever move changes
![image](https://github.com/user-attachments/assets/771e94f2-b01a-4a68-b4b4-3c717afc4a2c)
![image](https://github.com/user-attachments/assets/125672be-6bdd-4f84-bf22-a7b85481bfbe)

Hidden Ability + Type Changes
![image](https://github.com/user-attachments/assets/011ea45e-e43e-48ff-ba06-2e652501ef78)
![image](https://github.com/user-attachments/assets/08226c87-ee45-47e2-83a8-08a0a0be202d)
![image](https://github.com/user-attachments/assets/02cfa98f-884a-49b4-b4c3-6f074faa7aee)
![image](https://github.com/user-attachments/assets/4fafe893-3e0e-4298-9fc7-710589ecb8c5)
![image](https://github.com/user-attachments/assets/c19f017b-e1b3-4887-a34e-1ab84cde94a8)


## How to test the changes?
Overrides

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?