### PR TITLE
[Bug] Prevent pokemon with 0 HP from being statused

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3525,9 +3525,6 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    */
   canSetStatus(effect: StatusEffect | undefined, quiet: boolean = false, overrideStatus: boolean = false, sourcePokemon: Pokemon | null = null, ignoreField: boolean = false): boolean {
     if (effect !== StatusEffect.FAINT) {
-      if (this.isFainted()) {
-        return false;
-      }
       if (overrideStatus ? this.status?.effect === effect : this.status) {
         return false;
       }
@@ -3607,6 +3604,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   trySetStatus(effect?: StatusEffect, asPhase: boolean = false, sourcePokemon: Pokemon | null = null, turnsRemaining: number = 0, sourceText: string | null = null): boolean {
     if (!this.canSetStatus(effect, asPhase, false, sourcePokemon)) {
+      return false;
+    }
+    if (this.isFainted() && effect !== StatusEffect.FAINT) {
       return false;
     }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3525,6 +3525,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    */
   canSetStatus(effect: StatusEffect | undefined, quiet: boolean = false, overrideStatus: boolean = false, sourcePokemon: Pokemon | null = null, ignoreField: boolean = false): boolean {
     if (effect !== StatusEffect.FAINT) {
+      if (this.isFainted()) {
+        return false;
+      }
       if (overrideStatus ? this.status?.effect === effect : this.status) {
         return false;
       }

--- a/src/test/data/status_effect.test.ts
+++ b/src/test/data/status_effect.test.ts
@@ -434,7 +434,8 @@ describe("Status Effects", () => {
       const player = game.scene.getPlayerPokemon()!;
       player.hp = 0;
 
-      expect(player.canSetStatus(StatusEffect.BURN)).toBe(false);
+      expect(player.trySetStatus(StatusEffect.BURN)).toBe(false);
+      expect(player.status?.effect).not.toBe(StatusEffect.BURN);
     });
   });
 });

--- a/src/test/data/status_effect.test.ts
+++ b/src/test/data/status_effect.test.ts
@@ -400,4 +400,43 @@ describe("Status Effects", () => {
       expect(player.getLastXMoves(1)[0].result).toBe(MoveResult.SUCCESS);
     });
   });
+
+  describe("Behavior", () => {
+    let phaserGame: Phaser.Game;
+    let game: GameManager;
+
+    beforeAll(() => {
+      phaserGame = new Phaser.Game({
+        type: Phaser.HEADLESS,
+      });
+    });
+
+    afterEach(() => {
+      game.phaseInterceptor.restoreOg();
+    });
+
+    beforeEach(() => {
+      game = new GameManager(phaserGame);
+      game.override
+        .moveset([ Moves.SPLASH ])
+        .ability(Abilities.BALL_FETCH)
+        .battleType("single")
+        .disableCrits()
+        .enemySpecies(Species.MAGIKARP)
+        .enemyAbility(Abilities.BALL_FETCH)
+        .enemyMoveset(Moves.NUZZLE)
+        .enemyLevel(2000);
+    });
+
+    it("should not inflict a 0 HP mon with a status", async () => {
+      await game.classicMode.startBattle([ Species.FEEBAS, Species.MILOTIC ]);
+
+      const player = game.scene.getPlayerPokemon()!;
+
+      game.move.select(Moves.SPLASH);
+      await game.phaseInterceptor.to("FaintPhase", false);
+
+      expect(player.status?.effect).not.toBe(StatusEffect.PARALYSIS);
+    });
+  });
 });

--- a/src/test/data/status_effect.test.ts
+++ b/src/test/data/status_effect.test.ts
@@ -432,11 +432,9 @@ describe("Status Effects", () => {
       await game.classicMode.startBattle([ Species.FEEBAS, Species.MILOTIC ]);
 
       const player = game.scene.getPlayerPokemon()!;
+      player.hp = 0;
 
-      game.move.select(Moves.SPLASH);
-      await game.phaseInterceptor.to("FaintPhase", false);
-
-      expect(player.status?.effect).not.toBe(StatusEffect.PARALYSIS);
+      expect(player.canSetStatus(StatusEffect.BURN)).toBe(false);
     });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -349,14 +349,14 @@ export class IntegerHolder extends NumberHolder {
   }
 }
 
-/** @deprecated Use {@linkcode NumberHolder}*/
-export class FixedInt extends IntegerHolder {
-  constructor(value: integer) {
-    super(value);
+export class FixedInt {
+  public readonly value: number;
+
+  constructor(value: number) {
+    this.value = value;
   }
 }
 
-/** @deprecated */
 export function fixedInt(value: integer): integer {
   return new FixedInt(value) as unknown as integer;
 }


### PR DESCRIPTION
## What are the changes the user will see?
A Pokémon will no longer be able to be statused if it has 0 HP (aka: is fainted).

## Why am I making these changes?
Fixes #3585 

## What are the changes from a developer perspective?
`Pokemon.canSetStatus()` now returns `false` if the Pokémon has 0 HP.

## How to test the changes?
`npm run test status_effect`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?