### PR TITLE
[Misc] Disable enforced type-only imports in `overrides.ts`

### DIFF
--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -1,19 +1,20 @@
+/* eslint-disable @typescript-eslint/consistent-type-imports */
 import { type PokeballCounts } from "#app/battle-scene";
-import type { Gender } from "#app/data/gender";
-import type { Variant } from "#app/data/variant";
+import { Gender } from "#app/data/gender";
+import { Variant } from "#app/data/variant";
 import { type ModifierOverride } from "#app/modifier/modifier-type";
-import type { Unlockables } from "#app/system/unlockables";
+import { Unlockables } from "#app/system/unlockables";
 import { Abilities } from "#enums/abilities";
 import { Biome } from "#enums/biome";
-import type { EggTier } from "#enums/egg-type";
-import type { Moves } from "#enums/moves";
-import type { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
-import type { MysteryEncounterType } from "#enums/mystery-encounter-type";
+import { EggTier } from "#enums/egg-type";
+import { Moves } from "#enums/moves";
+import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { PokeballType } from "#enums/pokeball";
-import type { Species } from "#enums/species";
+import { Species } from "#enums/species";
 import { StatusEffect } from "#enums/status-effect";
-import type { TimeOfDay } from "#enums/time-of-day";
-import type { VariantTier } from "#enums/variant-tier";
+import { TimeOfDay } from "#enums/time-of-day";
+import { VariantTier } from "#enums/variant-tier";
 import { WeatherType } from "#enums/weather-type";
 
 /**


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Convenience for people testing with overrides.

## What are the changes from a developer perspective?
ESLint won't enforce type-only imports in `overrides.ts`.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?