### PR TITLE
[UI/UX] Allow viewing egg list from rewards screen

### DIFF
--- a/src/ui/menu-ui-handler.ts
+++ b/src/ui/menu-ui-handler.ts
@@ -111,7 +111,7 @@ export default class MenuUiHandler extends MessageUiHandler {
   render() {
     const ui = this.getUi();
     this.excludedMenus = () => [
-      { condition: globalScene.getCurrentPhase() instanceof SelectModifierPhase, options: [ MenuOptions.EGG_GACHA, MenuOptions.EGG_LIST ]},
+      { condition: globalScene.getCurrentPhase() instanceof SelectModifierPhase, options: [ MenuOptions.EGG_GACHA ]},
       { condition: bypassLogin, options: [ MenuOptions.LOG_OUT ]}
     ];
 


### PR DESCRIPTION
## What are the changes the user will see?
Users will be able to access the egg list screen from the post battle rewards screen

## Why am I making these changes?
See #5160 for rationale. I understand why the egg gacha was made inaccessible after an encounter ends, but I believe the egg list screen does not cause any of the same problems and we can safely let people look at their eggs from there.

## What are the changes from a developer perspective?
Excluded menu options for the post battle screen reduced by one.

## Screenshots/Videos
![image](https://github.com/user-attachments/assets/fb61956a-a3b8-4788-a3d7-24947b3cd8ce)

## How to test the changes?
Win a battle, open the menu.

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [X] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [X] Have I made sure that any UI change works for both UI themes (default and legacy)?