### PR TITLE
[Bug][Move] Opponent's Healing Wish/Lunar Dance now checks opponent's party

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1892,7 +1892,8 @@ export class SacrificialFullRestoreAttr extends SacrificialAttr {
     }
 
     // We don't know which party member will be chosen, so pick the highest max HP in the party
-    const maxPartyMemberHp = globalScene.getPlayerParty().map(p => p.getMaxHp()).reduce((maxHp: integer, hp: integer) => Math.max(hp, maxHp), 0);
+    const party = user.isPlayer() ? globalScene.getPlayerParty() : globalScene.getEnemyParty();
+    const maxPartyMemberHp = party.map(p => p.getMaxHp()).reduce((maxHp: integer, hp: integer) => Math.max(hp, maxHp), 0);
 
     globalScene.pushPhase(
       new PokemonHealPhase(


### PR DESCRIPTION
## What are the changes the user will see?
Healing Wish and Lunar Dance were only checking the player's party to decide how much HP should be healed. As a result, this could lead to very rare scenarios where the opponent using Healing Wish or Lunar Dance would not heal all of their HP. This PR fixes that.

## Why am I making these changes?
Bugfix.

## What are the changes from a developer perspective?
SacrificialFullRestoreAttr now checks which side is using Healing Wish/Lunar Dance before taking the max HP.

## Screenshots/Videos
<details><summary>Before</summary>
<p>

https://github.com/user-attachments/assets/b01ad5dd-3ba2-48d9-8b3d-3082530d8be7

</p>
</details>
<details><summary>After</summary>
<p>

https://github.com/user-attachments/assets/d1d95bd2-6294-442f-a0be-5599ca41fe0a

</p>
</details> 

## How to test the changes?
Due to the very specific circumstances this bug takes to occur, reproduction was difficult. Here's what I did:

- Set Rival 1's team to Blissey + random other mon.
- Alter this random other mon's levelup pool (in pokemon-level-moves.ts) to only have Healing Wish and Lunar Dance.
- Load up a classic run with low-HP mons (in my case, two Digletts and Wiglett)
- Bring the Blissey down to low HP
- Wait for the AI to switch to the other mon
- This other mon will immediately click either Healing Wish or Lunar Dance

Before the bug was fixed, this would then only heal part of the Blissey's maximum HP. After the bug was fixed, Blissey would get all of its HP back.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?

