### PR TITLE
[Test] Add eslint rule enforcing proper `await` usage in tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,7 +52,7 @@ export default [
     },
     {
         name: "eslint-tests",
-        files: ["src/test/**.test.ts"],
+        files: ["src/test/**/**.test.ts"],
         languageOptions: {
             parser: parser,
             parserOptions: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,7 @@ import importX from 'eslint-plugin-import-x';
 
 export default [ 
     {
+        name: "eslint-config",
         files: ["src/**/*.{ts,tsx,js,jsx}"],
         ignores: ["dist/*", "build/*", "coverage/*", "public/*", ".github/*", "node_modules/*", ".vscode/*"],
         languageOptions: {
@@ -47,6 +48,23 @@ export default [
             "space-infix-ops": ["error", { "int32Hint": false }], // Enforces spacing around infix operators
             "no-multiple-empty-lines": ["error", { "max": 2, "maxEOF": 1, "maxBOF": 0 }], // Disallows multiple empty lines
             "@typescript-eslint/consistent-type-imports": "error", // Enforces type-only imports wherever possible
+        }
+    },
+    {
+        name: "eslint-tests",
+        files: ["src/test/**.test.ts"],
+        languageOptions: {
+            parser: parser,
+            parserOptions: {
+                "project": ["./tsconfig.json"]
+            }
+        },
+        plugins: {
+            "@typescript-eslint": tseslint
+        },
+        rules: {
+            "@typescript-eslint/no-floating-promises": "error", // Require Promise-like statements to be handled appropriately. - https://typescript-eslint.io/rules/no-floating-promises/
+            "@typescript-eslint/no-misused-promises": "error", // Disallow Promises in places not designed to handle them. - https://typescript-eslint.io/rules/no-misused-promises/
         }
     }
 ]

--- a/src/test/abilities/shield_dust.test.ts
+++ b/src/test/abilities/shield_dust.test.ts
@@ -53,11 +53,11 @@ describe("Abilities - Shield Dust", () => {
     expect(move.id).toBe(Moves.AIR_SLASH);
 
     const chance = new NumberHolder(move.chance);
-    applyAbAttrs(MoveEffectChanceMultiplierAbAttr, phase.getUserPokemon()!, null, false, chance, move, phase.getFirstTarget(), false);
-    applyPreDefendAbAttrs(IgnoreMoveEffectsAbAttr, phase.getFirstTarget()!, phase.getUserPokemon()!, null, null, false, chance);
+    await applyAbAttrs(MoveEffectChanceMultiplierAbAttr, phase.getUserPokemon()!, null, false, chance, move, phase.getFirstTarget(), false);
+    await applyPreDefendAbAttrs(IgnoreMoveEffectsAbAttr, phase.getFirstTarget()!, phase.getUserPokemon()!, null, null, false, chance);
     expect(chance.value).toBe(0);
 
-  }, 20000);
+  });
 
   //TODO King's Rock Interaction Unit Test
 });

--- a/src/test/abilities/unseen_fist.test.ts
+++ b/src/test/abilities/unseen_fist.test.ts
@@ -45,9 +45,9 @@ describe("Abilities - Unseen Fist", () => {
 
   it(
     "should not apply if the source has Long Reach",
-    () => {
+    async () => {
       game.override.passiveAbility(Abilities.LONG_REACH);
-      testUnseenFistHitResult(game, Moves.QUICK_ATTACK, Moves.PROTECT, false);
+      await testUnseenFistHitResult(game, Moves.QUICK_ATTACK, Moves.PROTECT, false);
     }
   );
 
@@ -67,7 +67,7 @@ describe("Abilities - Unseen Fist", () => {
       game.override.enemyLevel(1);
       game.override.moveset([ Moves.TACKLE ]);
 
-      await game.startBattle();
+      await game.classicMode.startBattle();
 
       const enemyPokemon = game.scene.getEnemyPokemon()!;
       enemyPokemon.addTag(BattlerTagType.SUBSTITUTE, 0, Moves.NONE, enemyPokemon.id);
@@ -86,7 +86,7 @@ async function testUnseenFistHitResult(game: GameManager, attackMove: Moves, pro
   game.override.moveset([ attackMove ]);
   game.override.enemyMoveset([ protectMove, protectMove, protectMove, protectMove ]);
 
-  await game.startBattle();
+  await game.classicMode.startBattle();
 
   const leadPokemon = game.scene.getPlayerPokemon()!;
   expect(leadPokemon).not.toBe(undefined);

--- a/src/test/data/status_effect.test.ts
+++ b/src/test/data/status_effect.test.ts
@@ -20,8 +20,8 @@ const pokemonName = "PKM";
 const sourceText = "SOURCE";
 
 describe("Status Effect Messages", () => {
-  beforeAll(() => {
-    i18next.init();
+  beforeAll(async () => {
+    await i18next.init();
   });
 
   describe("NONE", () => {

--- a/src/test/evolution.test.ts
+++ b/src/test/evolution.test.ts
@@ -40,10 +40,10 @@ describe("Evolution", () => {
     eevee.abilityIndex = 2;
     trapinch.abilityIndex = 2;
 
-    eevee.evolve(pokemonEvolutions[Species.EEVEE][6], eevee.getSpeciesForm());
+    await eevee.evolve(pokemonEvolutions[Species.EEVEE][6], eevee.getSpeciesForm());
     expect(eevee.abilityIndex).toBe(2);
 
-    trapinch.evolve(pokemonEvolutions[Species.TRAPINCH][0], trapinch.getSpeciesForm());
+    await trapinch.evolve(pokemonEvolutions[Species.TRAPINCH][0], trapinch.getSpeciesForm());
     expect(trapinch.abilityIndex).toBe(1);
   });
 
@@ -55,10 +55,10 @@ describe("Evolution", () => {
     bulbasaur.abilityIndex = 0;
     charmander.abilityIndex = 1;
 
-    bulbasaur.evolve(pokemonEvolutions[Species.BULBASAUR][0], bulbasaur.getSpeciesForm());
+    await bulbasaur.evolve(pokemonEvolutions[Species.BULBASAUR][0], bulbasaur.getSpeciesForm());
     expect(bulbasaur.abilityIndex).toBe(0);
 
-    charmander.evolve(pokemonEvolutions[Species.CHARMANDER][0], charmander.getSpeciesForm());
+    await charmander.evolve(pokemonEvolutions[Species.CHARMANDER][0], charmander.getSpeciesForm());
     expect(charmander.abilityIndex).toBe(1);
   });
 
@@ -68,7 +68,7 @@ describe("Evolution", () => {
     const squirtle = game.scene.getPlayerPokemon()!;
     squirtle.abilityIndex = 5;
 
-    squirtle.evolve(pokemonEvolutions[Species.SQUIRTLE][0], squirtle.getSpeciesForm());
+    await squirtle.evolve(pokemonEvolutions[Species.SQUIRTLE][0], squirtle.getSpeciesForm());
     expect(squirtle.abilityIndex).toBe(0);
   });
 
@@ -80,7 +80,7 @@ describe("Evolution", () => {
     nincada.metBiome = -1;
     nincada.gender = 1;
 
-    nincada.evolve(pokemonEvolutions[Species.NINCADA][0], nincada.getSpeciesForm());
+    await nincada.evolve(pokemonEvolutions[Species.NINCADA][0], nincada.getSpeciesForm());
     const ninjask = game.scene.getPlayerParty()[0];
     const shedinja = game.scene.getPlayerParty()[1];
     expect(ninjask.abilityIndex).toBe(2);

--- a/src/test/items/light_ball.test.ts
+++ b/src/test/items/light_ball.test.ts
@@ -31,7 +31,7 @@ describe("Items - Light Ball", () => {
   it("LIGHT_BALL activates in battle correctly", async() => {
     game.override.startingHeldItems([{ name: "SPECIES_STAT_BOOSTER", type: "LIGHT_BALL" }]);
     const consoleSpy = vi.spyOn(console, "log");
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PIKACHU
     ]);
 
@@ -64,7 +64,7 @@ describe("Items - Light Ball", () => {
   });
 
   it("LIGHT_BALL held by PIKACHU", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PIKACHU
     ]);
 
@@ -83,7 +83,7 @@ describe("Items - Light Ball", () => {
     expect(spAtkValue.value / spAtkStat).toBe(1);
 
     // Giving Eviolite to party member and testing if it applies
-    game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "LIGHT_BALL" ])!.newModifier(partyMember), true);
+    await game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "LIGHT_BALL" ])!.newModifier(partyMember), true);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.ATK, atkValue);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.SPATK, spAtkValue);
 
@@ -92,7 +92,7 @@ describe("Items - Light Ball", () => {
   }, 20000);
 
   it("LIGHT_BALL held by fused PIKACHU (base)", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PIKACHU,
       Species.MAROWAK
     ]);
@@ -122,7 +122,7 @@ describe("Items - Light Ball", () => {
     expect(spAtkValue.value / spAtkStat).toBe(1);
 
     // Giving Eviolite to party member and testing if it applies
-    game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "LIGHT_BALL" ])!.newModifier(partyMember), true);
+    await game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "LIGHT_BALL" ])!.newModifier(partyMember), true);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.ATK, atkValue);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.SPATK, spAtkValue);
 
@@ -161,7 +161,7 @@ describe("Items - Light Ball", () => {
     expect(spAtkValue.value / spAtkStat).toBe(1);
 
     // Giving Eviolite to party member and testing if it applies
-    game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "LIGHT_BALL" ])!.newModifier(partyMember), true);
+    await game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "LIGHT_BALL" ])!.newModifier(partyMember), true);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.ATK, atkValue);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.SPATK, spAtkValue);
 
@@ -189,7 +189,7 @@ describe("Items - Light Ball", () => {
     expect(spAtkValue.value / spAtkStat).toBe(1);
 
     // Giving Eviolite to party member and testing if it applies
-    game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "LIGHT_BALL" ])!.newModifier(partyMember), true);
+    await game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "LIGHT_BALL" ])!.newModifier(partyMember), true);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.ATK, atkValue);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.SPATK, spAtkValue);
 

--- a/src/test/items/metal_powder.test.ts
+++ b/src/test/items/metal_powder.test.ts
@@ -31,7 +31,7 @@ describe("Items - Metal Powder", () => {
   it("METAL_POWDER activates in battle correctly", async() => {
     game.override.startingHeldItems([{ name: "SPECIES_STAT_BOOSTER", type: "METAL_POWDER" }]);
     const consoleSpy = vi.spyOn(console, "log");
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.DITTO
     ]);
 
@@ -79,7 +79,7 @@ describe("Items - Metal Powder", () => {
     expect(defValue.value / defStat).toBe(1);
 
     // Giving Eviolite to party member and testing if it applies
-    game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "METAL_POWDER" ])!.newModifier(partyMember), true);
+    await game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "METAL_POWDER" ])!.newModifier(partyMember), true);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.DEF, defValue);
 
     expect(defValue.value / defStat).toBe(2);
@@ -112,7 +112,7 @@ describe("Items - Metal Powder", () => {
     expect(defValue.value / defStat).toBe(1);
 
     // Giving Eviolite to party member and testing if it applies
-    game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "METAL_POWDER" ])!.newModifier(partyMember), true);
+    await game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "METAL_POWDER" ])!.newModifier(partyMember), true);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.DEF, defValue);
 
     expect(defValue.value / defStat).toBe(2);
@@ -145,7 +145,7 @@ describe("Items - Metal Powder", () => {
     expect(defValue.value / defStat).toBe(1);
 
     // Giving Eviolite to party member and testing if it applies
-    game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "METAL_POWDER" ])!.newModifier(partyMember), true);
+    await game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "METAL_POWDER" ])!.newModifier(partyMember), true);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.DEF, defValue);
 
     expect(defValue.value / defStat).toBe(2);
@@ -167,7 +167,7 @@ describe("Items - Metal Powder", () => {
     expect(defValue.value / defStat).toBe(1);
 
     // Giving Eviolite to party member and testing if it applies
-    game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "METAL_POWDER" ])!.newModifier(partyMember), true);
+    await game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "METAL_POWDER" ])!.newModifier(partyMember), true);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.DEF, defValue);
 
     expect(defValue.value / defStat).toBe(1);

--- a/src/test/items/quick_powder.test.ts
+++ b/src/test/items/quick_powder.test.ts
@@ -31,7 +31,7 @@ describe("Items - Quick Powder", () => {
   it("QUICK_POWDER activates in battle correctly", async() => {
     game.override.startingHeldItems([{ name: "SPECIES_STAT_BOOSTER", type: "QUICK_POWDER" }]);
     const consoleSpy = vi.spyOn(console, "log");
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.DITTO
     ]);
 
@@ -64,7 +64,7 @@ describe("Items - Quick Powder", () => {
   });
 
   it("QUICK_POWDER held by DITTO", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.DITTO
     ]);
 
@@ -79,14 +79,14 @@ describe("Items - Quick Powder", () => {
     expect(spdValue.value / spdStat).toBe(1);
 
     // Giving Eviolite to party member and testing if it applies
-    game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "QUICK_POWDER" ])!.newModifier(partyMember), true);
+    await game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "QUICK_POWDER" ])!.newModifier(partyMember), true);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.SPD, spdValue);
 
     expect(spdValue.value / spdStat).toBe(2);
-  }, 20000);
+  });
 
   it("QUICK_POWDER held by fused DITTO (base)", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.DITTO,
       Species.MAROWAK
     ]);
@@ -112,14 +112,14 @@ describe("Items - Quick Powder", () => {
     expect(spdValue.value / spdStat).toBe(1);
 
     // Giving Eviolite to party member and testing if it applies
-    game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "QUICK_POWDER" ])!.newModifier(partyMember), true);
+    await game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "QUICK_POWDER" ])!.newModifier(partyMember), true);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.SPD, spdValue);
 
     expect(spdValue.value / spdStat).toBe(2);
-  }, 20000);
+  });
 
   it("QUICK_POWDER held by fused DITTO (part)", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.MAROWAK,
       Species.DITTO
     ]);
@@ -145,14 +145,14 @@ describe("Items - Quick Powder", () => {
     expect(spdValue.value / spdStat).toBe(1);
 
     // Giving Eviolite to party member and testing if it applies
-    game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "QUICK_POWDER" ])!.newModifier(partyMember), true);
+    await game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "QUICK_POWDER" ])!.newModifier(partyMember), true);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.SPD, spdValue);
 
     expect(spdValue.value / spdStat).toBe(2);
-  }, 20000);
+  });
 
   it("QUICK_POWDER not held by DITTO", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.MAROWAK
     ]);
 
@@ -167,9 +167,9 @@ describe("Items - Quick Powder", () => {
     expect(spdValue.value / spdStat).toBe(1);
 
     // Giving Eviolite to party member and testing if it applies
-    game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "QUICK_POWDER" ])!.newModifier(partyMember), true);
+    await game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "QUICK_POWDER" ])!.newModifier(partyMember), true);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.SPD, spdValue);
 
     expect(spdValue.value / spdStat).toBe(1);
-  }, 20000);
+  });
 });

--- a/src/test/items/thick_club.test.ts
+++ b/src/test/items/thick_club.test.ts
@@ -31,7 +31,7 @@ describe("Items - Thick Club", () => {
   it("THICK_CLUB activates in battle correctly", async() => {
     game.override.startingHeldItems([{ name: "SPECIES_STAT_BOOSTER", type: "THICK_CLUB" }]);
     const consoleSpy = vi.spyOn(console, "log");
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.CUBONE
     ]);
 
@@ -64,7 +64,7 @@ describe("Items - Thick Club", () => {
   });
 
   it("THICK_CLUB held by CUBONE", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.CUBONE
     ]);
 
@@ -79,14 +79,14 @@ describe("Items - Thick Club", () => {
     expect(atkValue.value / atkStat).toBe(1);
 
     // Giving Eviolite to party member and testing if it applies
-    game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "THICK_CLUB" ])!.newModifier(partyMember), true);
+    await game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "THICK_CLUB" ])!.newModifier(partyMember), true);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.ATK, atkValue);
 
     expect(atkValue.value / atkStat).toBe(2);
-  }, 20000);
+  });
 
   it("THICK_CLUB held by MAROWAK", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.MAROWAK
     ]);
 
@@ -101,14 +101,14 @@ describe("Items - Thick Club", () => {
     expect(atkValue.value / atkStat).toBe(1);
 
     // Giving Eviolite to party member and testing if it applies
-    game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "THICK_CLUB" ])!.newModifier(partyMember), true);
+    await game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "THICK_CLUB" ])!.newModifier(partyMember), true);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.ATK, atkValue);
 
     expect(atkValue.value / atkStat).toBe(2);
-  }, 20000);
+  });
 
   it("THICK_CLUB held by ALOLA_MAROWAK", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.ALOLA_MAROWAK
     ]);
 
@@ -123,18 +123,18 @@ describe("Items - Thick Club", () => {
     expect(atkValue.value / atkStat).toBe(1);
 
     // Giving Eviolite to party member and testing if it applies
-    game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "THICK_CLUB" ])!.newModifier(partyMember), true);
+    await game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "THICK_CLUB" ])!.newModifier(partyMember), true);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.ATK, atkValue);
 
     expect(atkValue.value / atkStat).toBe(2);
-  }, 20000);
+  });
 
   it("THICK_CLUB held by fused CUBONE line (base)", async() => {
     // Randomly choose from the Cubone line
     const species = [ Species.CUBONE, Species.MAROWAK, Species.ALOLA_MAROWAK ];
     const randSpecies = Utils.randInt(species.length);
 
-    await game.startBattle([
+    await game.classicMode.startBattle([
       species[randSpecies],
       Species.PIKACHU
     ]);
@@ -160,18 +160,18 @@ describe("Items - Thick Club", () => {
     expect(atkValue.value / atkStat).toBe(1);
 
     // Giving Eviolite to party member and testing if it applies
-    game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "THICK_CLUB" ])!.newModifier(partyMember), true);
+    await game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "THICK_CLUB" ])!.newModifier(partyMember), true);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.ATK, atkValue);
 
     expect(atkValue.value / atkStat).toBe(2);
-  }, 20000);
+  });
 
   it("THICK_CLUB held by fused CUBONE line (part)", async() => {
     // Randomly choose from the Cubone line
     const species = [ Species.CUBONE, Species.MAROWAK, Species.ALOLA_MAROWAK ];
     const randSpecies = Utils.randInt(species.length);
 
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PIKACHU,
       species[randSpecies]
     ]);
@@ -197,14 +197,14 @@ describe("Items - Thick Club", () => {
     expect(atkValue.value / atkStat).toBe(1);
 
     // Giving Eviolite to party member and testing if it applies
-    game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "THICK_CLUB" ])!.newModifier(partyMember), true);
+    await game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "THICK_CLUB" ])!.newModifier(partyMember), true);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.ATK, atkValue);
 
     expect(atkValue.value / atkStat).toBe(2);
-  }, 20000);
+  });
 
   it("THICK_CLUB not held by CUBONE", async() => {
-    await game.startBattle([
+    await game.classicMode.startBattle([
       Species.PIKACHU
     ]);
 
@@ -219,9 +219,9 @@ describe("Items - Thick Club", () => {
     expect(atkValue.value / atkStat).toBe(1);
 
     // Giving Eviolite to party member and testing if it applies
-    game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "THICK_CLUB" ])!.newModifier(partyMember), true);
+    await game.scene.addModifier(modifierTypes.SPECIES_STAT_BOOSTER().generateType([], [ "THICK_CLUB" ])!.newModifier(partyMember), true);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.ATK, atkValue);
 
     expect(atkValue.value / atkStat).toBe(1);
-  }, 20000);
+  });
 });

--- a/src/test/moves/dragon_rage.test.ts
+++ b/src/test/moves/dragon_rage.test.ts
@@ -45,14 +45,10 @@ describe("Moves - Dragon Rage", () => {
     game.override.enemyPassiveAbility(Abilities.BALL_FETCH);
     game.override.enemyLevel(100);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     partyPokemon = game.scene.getPlayerParty()[0];
     enemyPokemon = game.scene.getEnemyPokemon()!;
-
-    // remove berries
-    game.scene.removePartyMemberModifiers(0);
-    game.scene.clearEnemyHeldItemModifiers();
   });
 
   it("ignores weaknesses", async () => {

--- a/src/test/moves/fissure.test.ts
+++ b/src/test/moves/fissure.test.ts
@@ -41,14 +41,10 @@ describe("Moves - Fissure", () => {
     game.override.enemyPassiveAbility(Abilities.BALL_FETCH);
     game.override.enemyLevel(100);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
 
     partyPokemon = game.scene.getPlayerParty()[0];
     enemyPokemon = game.scene.getEnemyPokemon()!;
-
-    // remove berries
-    game.scene.removePartyMemberModifiers(0);
-    game.scene.clearEnemyHeldItemModifiers();
   });
 
   it("ignores damage modification from abilities, for example FUR_COAT", async () => {

--- a/src/test/moves/toxic_spikes.test.ts
+++ b/src/test/moves/toxic_spikes.test.ts
@@ -132,7 +132,7 @@ describe("Moves - Toxic Spikes", () => {
     const sessionData : SessionSaveData = gameData["getSessionSaveData"]();
     localStorage.setItem("sessionTestData", encrypt(JSON.stringify(sessionData), true));
     const recoveredData : SessionSaveData = gameData.parseSessionData(decrypt(localStorage.getItem("sessionTestData")!, true));
-    gameData.loadSession(0, recoveredData);
+    await gameData.loadSession(0, recoveredData);
 
     expect(sessionData.arena.tags).toEqual(recoveredData.arena.tags);
     localStorage.removeItem("sessionTestData");

--- a/src/test/mystery-encounter/mystery-encounter-utils.test.ts
+++ b/src/test/mystery-encounter/mystery-encounter-utils.test.ts
@@ -48,12 +48,12 @@ describe("Mystery Encounter Utils", () => {
       expect(result.species.speciesId).toBe(Species.ARCEUS);
     });
 
-    it("gets a fainted pokemon from player party if isAllowedInBattle is false", () => {
+    it("gets a fainted pokemon from player party if isAllowedInBattle is false", async () => {
       // Both pokemon fainted
       scene.getPlayerParty().forEach(p => {
         p.hp = 0;
         p.trySetStatus(StatusEffect.FAINT);
-        p.updateInfo();
+        void p.updateInfo();
       });
 
       // Seeds are calculated to return index 0 first, 1 second (if both pokemon are legal)
@@ -68,12 +68,12 @@ describe("Mystery Encounter Utils", () => {
       expect(result.species.speciesId).toBe(Species.ARCEUS);
     });
 
-    it("gets an unfainted legal pokemon from player party if isAllowed is true and isFainted is false", () => {
+    it("gets an unfainted legal pokemon from player party if isAllowed is true and isFainted is false", async () => {
       // Only faint 1st pokemon
       const party = scene.getPlayerParty();
       party[0].hp = 0;
       party[0].trySetStatus(StatusEffect.FAINT);
-      party[0].updateInfo();
+      await party[0].updateInfo();
 
       // Seeds are calculated to return index 0 first, 1 second (if both pokemon are legal)
       game.override.seed("random");
@@ -87,12 +87,12 @@ describe("Mystery Encounter Utils", () => {
       expect(result.species.speciesId).toBe(Species.MANAPHY);
     });
 
-    it("returns last unfainted pokemon if doNotReturnLastAbleMon is false", () => {
+    it("returns last unfainted pokemon if doNotReturnLastAbleMon is false", async () => {
       // Only faint 1st pokemon
       const party = scene.getPlayerParty();
       party[0].hp = 0;
       party[0].trySetStatus(StatusEffect.FAINT);
-      party[0].updateInfo();
+      await party[0].updateInfo();
 
       // Seeds are calculated to return index 0 first, 1 second (if both pokemon are legal)
       game.override.seed("random");
@@ -106,12 +106,12 @@ describe("Mystery Encounter Utils", () => {
       expect(result.species.speciesId).toBe(Species.MANAPHY);
     });
 
-    it("never returns last unfainted pokemon if doNotReturnLastAbleMon is true", () => {
+    it("never returns last unfainted pokemon if doNotReturnLastAbleMon is true", async () => {
       // Only faint 1st pokemon
       const party = scene.getPlayerParty();
       party[0].hp = 0;
       party[0].trySetStatus(StatusEffect.FAINT);
-      party[0].updateInfo();
+      await party[0].updateInfo();
 
       // Seeds are calculated to return index 0 first, 1 second (if both pokemon are legal)
       game.override.seed("random");
@@ -152,12 +152,12 @@ describe("Mystery Encounter Utils", () => {
       expect(result.species.speciesId).toBe(Species.ARCEUS);
     });
 
-    it("returns highest level unfainted if unfainted is true", () => {
+    it("returns highest level unfainted if unfainted is true", async () => {
       const party = scene.getPlayerParty();
       party[0].level = 100;
       party[0].hp = 0;
       party[0].trySetStatus(StatusEffect.FAINT);
-      party[0].updateInfo();
+      await party[0].updateInfo();
       party[1].level = 10;
 
       const result = getHighestLevelPlayerPokemon(true);
@@ -191,12 +191,12 @@ describe("Mystery Encounter Utils", () => {
       expect(result.species.speciesId).toBe(Species.ARCEUS);
     });
 
-    it("returns lowest level unfainted if unfainted is true", () => {
+    it("returns lowest level unfainted if unfainted is true", async () => {
       const party = scene.getPlayerParty();
       party[0].level = 10;
       party[0].hp = 0;
       party[0].trySetStatus(StatusEffect.FAINT);
-      party[0].updateInfo();
+      await party[0].updateInfo();
       party[1].level = 100;
 
       const result = getLowestLevelPlayerPokemon(true);

--- a/src/test/ui/transfer-item.test.ts
+++ b/src/test/ui/transfer-item.test.ts
@@ -2,8 +2,6 @@ import { BerryType } from "#app/enums/berry-type";
 import { Button } from "#app/enums/buttons";
 import { Moves } from "#app/enums/moves";
 import { Species } from "#app/enums/species";
-import { BattleEndPhase } from "#app/phases/battle-end-phase";
-import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
 import ModifierSelectUiHandler from "#app/ui/modifier-select-ui-handler";
 import PartyUiHandler, { PartyUiMode } from "#app/ui/party-ui-handler";
 import { Mode } from "#app/ui/ui";
@@ -11,7 +9,6 @@ import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import type BBCodeText from "phaser3-rex-plugins/plugins/bbcodetext";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-
 
 describe("UI - Transfer Items", () => {
   let phaserGame: Phaser.Game;
@@ -41,7 +38,7 @@ describe("UI - Transfer Items", () => {
     game.override.enemySpecies(Species.MAGIKARP);
     game.override.enemyMoveset([ Moves.SPLASH ]);
 
-    await game.startBattle([ Species.RAYQUAZA, Species.RAYQUAZA, Species.RAYQUAZA ]);
+    await game.classicMode.startBattle([ Species.RAYQUAZA, Species.RAYQUAZA, Species.RAYQUAZA ]);
 
     game.move.select(Moves.DRAGON_CLAW);
 
@@ -52,10 +49,10 @@ describe("UI - Transfer Items", () => {
       handler.setCursor(1);
       handler.processInput(Button.ACTION);
 
-      game.scene.ui.setModeWithoutClear(Mode.PARTY, PartyUiMode.MODIFIER_TRANSFER);
+      void game.scene.ui.setModeWithoutClear(Mode.PARTY, PartyUiMode.MODIFIER_TRANSFER);
     });
 
-    await game.phaseInterceptor.to(BattleEndPhase);
+    await game.phaseInterceptor.to("BattleEndPhase");
   });
 
   it("check red tint for held item limit in transfer menu", async () => {
@@ -72,7 +69,7 @@ describe("UI - Transfer Items", () => {
       game.phaseInterceptor.unlock();
     });
 
-    await game.phaseInterceptor.to(SelectModifierPhase);
+    await game.phaseInterceptor.to("SelectModifierPhase");
   }, 20000);
 
   it("check transfer option for pokemon to transfer to", async () => {
@@ -91,6 +88,6 @@ describe("UI - Transfer Items", () => {
       game.phaseInterceptor.unlock();
     });
 
-    await game.phaseInterceptor.to(SelectModifierPhase);
+    await game.phaseInterceptor.to("SelectModifierPhase");
   }, 20000);
 });


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
To prevent mistakes in tests from forgotten `await`s.

## What are the changes from a developer perspective?
ESLint will display an error if a promise is misused (ie: an `await` is forgotten, such as someone writing `game.classicMode.startBattle();` instead of `await game.classicMode.startBattle();`). This will reduce mistakes in test writing.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?