### PR TITLE
[Bug] Fix softlock caused by shields down

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2861,7 +2861,7 @@ export class PreSetStatusEffectImmunityAbAttr extends PreSetStatusAbAttr {
    * @returns A boolean indicating the result of the status application.
    */
   applyPreSetStatus(pokemon: Pokemon, passive: boolean, simulated: boolean, effect: StatusEffect, cancelled: Utils.BooleanHolder, args: any[]): boolean {
-    if (this.immuneEffects.length < 1 || this.immuneEffects.includes(effect)) {
+    if (effect !== StatusEffect.FAINT && this.immuneEffects.length < 1 || this.immuneEffects.includes(effect)) {
       cancelled.value = true;
       return true;
     }

--- a/src/test/abilities/shields_down.test.ts
+++ b/src/test/abilities/shields_down.test.ts
@@ -189,4 +189,19 @@ describe("Abilities - SHIELDS DOWN", () => {
     }
   );
 
+  test("should not prevent minior from receiving the fainted status effect in trainer battles", async () => {
+    game.override.enemyMoveset([ Moves.TACKLE ]);
+    game.override.moveset([ Moves.THUNDERBOLT ]);
+    game.override.startingLevel(100);
+    game.override.startingWave(5);
+    game.override.enemySpecies(Species.MINIOR);
+    await game.classicMode.startBattle([ Species.REGIELEKI ]);
+    const minior = game.scene.getEnemyPokemon()!;
+
+    game.move.select(Moves.THUNDERBOLT);
+    await game.toNextTurn();
+    expect(minior.isFainted()).toBe(true);
+    expect(minior.status?.effect).toBe(StatusEffect.FAINT);
+  });
+
 });


### PR DESCRIPTION
## What are the changes the user will see?
Defeating an enemy trainer that has a minior will no longer cause the game to softlock.

## Why am I making these changes?
There was a bug report for it on the discord.  
Also it's embarassing for my first PR to have triggered a bug. <sup>Please merge quickly so we can hide the evidence 😅</sup>

## What are the changes from a developer perspective?
In`src/data/abilities.ts/`: added a condition inside `PreSetStatusEffectImmunityAbAttr` 's `applyPreSetStatus` method that prevents the status effect from being cancelled if it is `StatusEffect.FAINT`.

Added a unit test to detect this scenario in `src/test/abilities/shields_down.test.ts`.

## Screenshots/Videos

<details><summary>Current beta branch</summary>

https://github.com/user-attachments/assets/321ada4c-89f9-4e24-beed-5bd316bbbd4b
</details>

<details><summary>With this PR</summary>

https://github.com/user-attachments/assets/848cef8b-df64-49b7-8bfa-1c970637c185
</details>

## How to test the changes?
Set the overrides to this, and bring a starter mon that has a non-ground type damaging move.
```ts
const overrides = {
  OPP_SPECIES_OVERRIDE: Species.MINIOR,
  STARTING_LEVEL_OVERRIDE: 100,
  STARTING_WAVE_OVERRIDE: 5
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```
Defeat both miniors to end the trainer battle. Verify that the trainer battle is successful.

Can also run the automated test:
``npx vitest run src/test/abilities/shields_down.test.ts` -t "should not prevent minior from receiving the fainted status effect in trainer battles"``

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~

~~Are there any localization additions or changes? If so:~~
- ~~[ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?~~
  - ~~[ ] If so, please leave a link to it here: ~~
- ~~[ ] Has the translation team been contacted for proofreading/translation?~~