### PR TITLE
[Misc] Prevent auto-imports from appending `.js` to imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,11 +64,5 @@
 	},
 	"engines": {
 		"node": ">=20.0.0"
-	},
-	"imports": {
-		"#enums/*": "./enums/*",
-		"#app": "./src/main.js",
-		"#app/*": "./src/*",
-		"#test/*": "./src/test/*"
 	}
 }

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -44,7 +44,7 @@ import { SpeciesFormChangeRevertWeatherFormTrigger } from "./pokemon-forms";
 import type { GameMode } from "#app/game-mode";
 import { applyChallenges, ChallengeType } from "./challenge";
 import { SwitchType } from "#enums/switch-type";
-import { StatusEffect } from "enums/status-effect";
+import { StatusEffect } from "#enums/status-effect";
 import { globalScene } from "#app/global-scene";
 
 export enum MoveCategory {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
 		"paths": {
 			"#enums/*": ["./enums/*.ts"],
 			"#app/*": ["*.ts"],
-			"#app": ["."],
 			"#test/*": ["./test/*.ts"]
 		},
 		"outDir": "./build",


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Prevents annoyances with auto-imports.

## What are the changes from a developer perspective?
VSCode will no longer append `.js` to auto-imports.
`#enums` should now be recognized as a valid import shortcut by VSCode (instead of using `#app/enums`).

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?