### PR TITLE
[Bug][Ability] Fix wimp out and emergency exit skipping waves in double battles

### DIFF
--- a/src/phases/battle-end-phase.ts
+++ b/src/phases/battle-end-phase.ts
@@ -17,6 +17,23 @@ export class BattleEndPhase extends BattlePhase {
   start() {
     super.start();
 
+    // cull any extra `BattleEnd` phases from the queue.
+    globalScene.phaseQueue = globalScene.phaseQueue.filter(phase => {
+      if (phase instanceof BattleEndPhase) {
+        this.isVictory ||= phase.isVictory;
+        return false;
+      }
+      return true;
+    });
+    // `phaseQueuePrepend` is private, so we have to use this inefficient loop.
+    while (globalScene.tryRemoveUnshiftedPhase(phase => {
+      if (phase instanceof BattleEndPhase) {
+        this.isVictory ||= phase.isVictory;
+        return true;
+      }
+      return false;
+    })) {}
+
     globalScene.gameData.gameStats.battles++;
     if (
       globalScene.gameMode.isEndless &&

--- a/src/phases/new-battle-phase.ts
+++ b/src/phases/new-battle-phase.ts
@@ -5,6 +5,11 @@ export class NewBattlePhase extends BattlePhase {
   start() {
     super.start();
 
+    // cull any extra `NewBattle` phases from the queue.
+    globalScene.phaseQueue = globalScene.phaseQueue.filter(phase => !(phase instanceof NewBattlePhase));
+    // `phaseQueuePrepend` is private, so we have to use this inefficient loop.
+    while (globalScene.tryRemoveUnshiftedPhase(phase => phase instanceof NewBattlePhase)) {}
+
     globalScene.newBattle();
 
     this.end();


### PR DESCRIPTION
## What are the changes the user will see?
Emergency Exit and Wimp Out will no longer open an alternate dimension and skip waves when a pokemon with wimp out's ability triggers in response to a spread move that causes its teammates to faint.
## Why am I making these changes?
Fixes #5032 
![image](https://github.com/user-attachments/assets/1018ee00-e636-460b-b2b8-cd174d2df0c5)

## What are the changes from a developer perspective?
Inside the `start` method of `NewBattlePhase` and `EndBattlePhase`, the first thing that is done after the call to `super()` is to filter out the phase queue (and prependPhaseQueue) to clear out any extra phases that have been added.

This ends up being defensive programming. Rather than adding convoluted checks at the places where `NewBattlePhase` and `EndBattlePhase` occur to determine whether or not they *should* properly occur is 

## Screenshots/Videos
<details><summary>Fixed Wimp Out</summary>


https://github.com/user-attachments/assets/319e48b8-560f-4767-a967-a698362beee8
</details>


Old behavior on #5032 

## How to test the changes?
Go into a new battle with this override set:
```ts
  BATTLE_TYPE_OVERRIDE: "double",
  STARTING_LEVEL_OVERRIDE: 4,
  OPP_LEVEL_OVERRIDE: 3,
  MOVESET_OVERRIDE: [Moves.DRAGON_ENERGY, Moves.GASTRO_ACID, Moves.METAL_SOUND],
  OPP_SPECIES_OVERRIDE: Species.WIMPOD,
  OPP_MOVESET_OVERRIDE: [Moves.SPLASH]
```
Follow the steps in the video depicted in #5032

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~

~~Are there any localization additions or changes? If so:~~
- ~~[ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?~~
  - ~~[ ] If so, please leave a link to it here: ~~
- ~~[ ] Has the translation team been contacted for proofreading/translation?~~
