### PR TITLE
[Hotfix] Adding warning message for the maintenance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pokemon-rogue-battle",
-	"version": "1.5.2",
+	"version": "1.5.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pokemon-rogue-battle",
-			"version": "1.5.2",
+			"version": "1.5.3",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@material/material-color-utilities": "^0.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pokemon-rogue-battle",
 	"private": true,
-	"version": "1.5.2",
+	"version": "1.5.3",
 	"type": "module",
 	"scripts": {
 		"start": "vite",

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -85,7 +85,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
       "en": ` - INFORMATION - \nServer maintenance is scheduled for the following period:\n${startDate} until ${endDate}\nEnd date and hour are an estimate.\nMaintenance may end at an earlier or later time.`,
       "de": ` - INFORMATION - German translation goes here:\n${startDate} until ${endDate}`,
       "es-ES": ` - INFORMATION - Spanish translation goes here:\n${startDate} until ${endDate}`,
-      "fr": ` - INFORMATION - \nUne maintenance du serveur est prévue sur la période suivante :\n$Du {startDate} au ${endDate}\nL’heure de fin est une estimation et peut s’avérer plus en avance ou tardive qu’annoncé.`,
+      "fr": ` - INFORMATION - \nUne maintenance du serveur est prévue sur la période suivante :\nDu ${startDate} au ${endDate}\nL’heure de fin est une estimation et peut s’avérer plus en avance ou tardive qu’annoncé.`,
       "it": ` - INFORMATION - Italian translation goes here:\n${startDate} until ${endDate}`,
       "pt-BR": ` - INFORMATION - Portugese translation goes here:\n${startDate} until ${endDate}`,
       "zh-TW": ` - INFORMATION - Chinese-traditional translation goes here:\n${startDate} until ${endDate}`,

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -122,7 +122,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
       "ja": ` - 情報 -\nサーバーメンテナンスの予定は以下の期間:\n${startDateLocalized} から ${endDateLocalized} まで\n終了日・時間は推定です。\nメンテナンスはこの時期より早く終了する場合も遅く終了する場合もあります。`,
     };
     const announcementString = localizedAnnouncementString[Object.keys(localizedAnnouncementString).find(lang => currentLanguage.includes(lang)) ?? "en"];
-    this.announcementText = addTextObject(logo.x - 148, logo.y + logo.displayHeight + 116, announcementString, TextStyle.MONEY, { fontSize: "78px", wordWrap: { width: 200 * 6 }});
+    this.announcementText = addTextObject(logo.x - 148, logo.y + logo.displayHeight + 116, announcementString, TextStyle.MONEY, { fontSize: "76px", wordWrap: { width: 200 * 6 }});
     this.announcementText.setOrigin(0, 1);
     this.announcementText.setAngle(0);
     this.announcementBg = addWindow(this.announcementText.x - 8, this.announcementText.y + 6, this.announcementText.width / 6 + 14, this.announcementText.height / 6 + 12);

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -88,7 +88,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
       "fr": ` - INFORMATION - \nUne maintenance du serveur est prévue sur la période suivante :\nDu ${startDate} au ${endDate}\nL’heure de fin est une estimation et peut s’avérer plus en avance ou tardive qu’annoncé.`,
       "it": ` - INFORMATION - Italian translation goes here:\n${startDate} until ${endDate}`,
       "pt-BR": ` - INFORMATION - Portugese translation goes here:\n${startDate} until ${endDate}`,
-      "zh-TW": ` - INFORMATION - Chinese-traditional translation goes here:\n${startDate} until ${endDate}`,
+      "zh-TW": ` - 通知 - \n伺服器預計在以下時間維護：\n${startDate} 至 ${endDate}\n維護結束時間是預計時間\n維護可能稍早或稍晚結束。`,
       "zh-CN": ` - 通知 - \n服务器预计在以下时间维护：\n${startDate} 至 ${endDate}\n维护结束时间是预计时间\n维护可能稍早或稍晚结束。`,
       "ko": ` - INFORMATION - Korean translation goes here:\n${startDate} until ${endDate}`,
       "ja": ` - INFORMATION - Japanese translation goes here:\n${startDate} until ${endDate}`,

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -111,7 +111,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
     const endDateLocalized = new Intl.DateTimeFormat(currentLanguage, dateOptions).format(endDate);
     const localizedAnnouncementString: { [key: string]: string } = {
       "en": ` - INFORMATION - \nServer maintenance is scheduled for the following period:\n${startDateLocalized} until ${endDateLocalized}\nEnd date and hour are an estimate.\nMaintenance may end at an earlier or later time.`,
-      "de": ` - INFORMATION - German translation goes here:\n${startDateLocalized} until ${endDateLocalized}`,
+      "de": `- INFORMATION -\nServerwartung ist für den folgenden Zeitraum geplant:\n${startDateLocalized} bis ${endDateLocalized}\nEnddatum und Uhrzeit sind eine Schätzung.\nDie Wartung kann früher oder später beendet werden.`,
       "es-ES": ` - INFORMACIÓN -\nUn mantenimiento del servidor está programado para el siguiente período:\nDesde el ${startDateLocalized} hasta el ${endDateLocalized}.\nLa fecha y hora de finalización son aproximadas.\nEl mantenimiento podría finalizar antes o extenderse más de lo previsto.`,
       "fr": ` - INFORMATION - \nUne maintenance du serveur est prévue sur la période suivante :\nDu ${startDateLocalized} au ${endDateLocalized}\nL’heure de fin est une estimation et peut s’avérer plus en avance ou tardive qu’annoncé.`,
       "it": ` - INFORMATION - Italian translation goes here:\n${startDateLocalized} until ${endDateLocalized}`,

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -83,16 +83,15 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
     const endDate = new Date(1739167200000).toLocaleString();
     const localizedAnnouncementString: { [key: string]: string } = {
       "en": ` - INFORMATION - \nServer maintenance is scheduled for the following period:\n${startDate} until ${endDate}\nEnd date and hour are an estimate.\nMaintenance may end at an earlier or later time.`,
-      "de": ` - INFORMATION - German test:\n${startDate} until ${endDate}`,
-      "es-ES":"",
-      "fr":"",
-      "it":"",
-      "pt_BR":"",
-      "zh":"",
-      "pt":"",
-      "ko":"",
-      "ja":"",
-      "ca-ES":"",
+      "de": ` - INFORMATION - German translation goes here:\n${startDate} until ${endDate}`,
+      "es-ES": ` - INFORMATION - Spanish translation goes here:\n${startDate} until ${endDate}`,
+      "fr": ` - INFORMATION - French translation goes here:\n${startDate} until ${endDate}`,
+      "it": ` - INFORMATION - Italian translation goes here:\n${startDate} until ${endDate}`,
+      "pt-BR": ` - INFORMATION - Portugese translation goes here:\n${startDate} until ${endDate}`,
+      "zh-TW": ` - INFORMATION - Chinese-traditional translation goes here:\n${startDate} until ${endDate}`,
+      "zh-CN": ` - INFORMATION - Chinese-simplified translation goes here:\n${startDate} until ${endDate}`,
+      "ko": ` - INFORMATION - Korean translation goes here:\n${startDate} until ${endDate}`,
+      "ja": ` - INFORMATION - Japanese translation goes here:\n${startDate} until ${endDate}`,
     };
     const currentLanguage = i18next.resolvedLanguage ?? "en";
     const announcementString = localizedAnnouncementString[Object.keys(localizedAnnouncementString).find(lang => currentLanguage.includes(lang)) ?? "en"];

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -95,7 +95,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
         case "fr":
         case "it":
         case "ja":
-        case "pt-BR": // <-- in review
+        case "pt-BR":
         case "zh-CN":
           return false; // 24h
       }
@@ -115,7 +115,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
       "es-ES": ` - INFORMACIÓN -\nUn mantenimiento del servidor está programado para el siguiente período:\nDesde el ${startDateLocalized} hasta el ${endDateLocalized}.\nLa fecha y hora de finalización son aproximadas.\nEl mantenimiento podría finalizar antes o extenderse más de lo previsto.`,
       "fr": ` - INFORMATION -\nUne maintenance du serveur est prévue sur la période suivante :\nDu ${startDateLocalized} au ${endDateLocalized}\nL’heure de fin est une estimation et peut s’avérer plus en avance ou tardive qu’annoncé.`,
       "it": ` - ANNUNCIO -\nUna manutenzione del server avrà luogo nel periodo seguente:\nDal ${startDateLocalized} al ${endDateLocalized}\nData e ora di fine manutenzione sono una stima,\npotrebbe terminare in anticipo o più tardi.`,
-      "pt-BR": ` - INFORMATION - Portugese translation goes here:\n${startDateLocalized} until ${endDateLocalized}`,
+      "pt-BR": ` - INFORMATION -\nServer maintenance is scheduled for the following period:\n${startDateLocalized} until ${endDateLocalized}\nEnd date and hour are an estimate.\nMaintenance may end at an earlier or later time.`,
       "zh-TW": ` - 通知 -\n伺服器預計在以下時間維護：\n${startDateLocalized} 至 ${endDateLocalized}\n維護結束時間是預計時間\n維護可能稍早或稍晚結束。`,
       "zh-CN": ` - 通知 -\n服务器预计在以下时间维护：\n${startDateLocalized} 至 ${endDateLocalized}\n维护结束时间是预计时间\n维护可能稍早或稍晚结束。`,
       "ko": ` - 공지사항 -\n아래 기간동안 점검 예정입니다. :\n${startDateLocalized} ~ ${endDateLocalized}\n종료시각은 예상시간입니다.\n점검은 예상했던 것보다 빠르게 혹은 늦게  끝날 수 있습니다.`,

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -20,8 +20,10 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
   private splashMessageText: Phaser.GameObjects.Text;
   private eventDisplay: TimedEventDisplay;
   private appVersionText: Phaser.GameObjects.Text;
+  // -- start temporary maintenance announcement fields --
   private announcementText: Phaser.GameObjects.Text;
   private announcementBg: Phaser.GameObjects.NineSlice;
+  // -- end temporary maintenance announcement fields --
 
   private titleStatsTimer: NodeJS.Timeout | null;
 
@@ -79,6 +81,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
     this.appVersionText.setAngle(0);
     this.titleContainer.add(this.appVersionText);
 
+    // #region Temporary Maintenance Announcement
     const currentLanguage = i18next.resolvedLanguage ?? "en";
     const getTimeFormat = (): boolean => {
       switch (currentLanguage) {
@@ -128,6 +131,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
     this.titleContainer.add(this.announcementText);
     this.titleContainer.add(this.announcementBg);
     this.titleContainer.bringToTop(this.announcementText);
+    // #endregion
   }
 
   updateTitleStats(): void {

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -118,7 +118,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
       "pt-BR": ` - INFORMATION - Portugese translation goes here:\n${startDateLocalized} until ${endDateLocalized}`,
       "zh-TW": ` - 通知 - \n伺服器預計在以下時間維護：\n${startDateLocalized} 至 ${endDateLocalized}\n維護結束時間是預計時間\n維護可能稍早或稍晚結束。`,
       "zh-CN": ` - 通知 - \n服务器预计在以下时间维护：\n${startDateLocalized} 至 ${endDateLocalized}\n维护结束时间是预计时间\n维护可能稍早或稍晚结束。`,
-      "ko": ` - 공지사항 -\n 아래 기간동안 점검 예정입니다. :\n${startDateLocalized} ~ ${endDateLocalized}\n 종료시각은 예상시간입니다.\n 점검은 예상했던 것보다 빠르게 혹은 늦게  끝날 수 있습니다.`,
+      "ko": ` - 공지사항 -\n아래 기간동안 점검 예정입니다. :\n${startDateLocalized} ~ ${endDateLocalized}\n종료시각은 예상시간입니다.\n점검은 예상했던 것보다 빠르게 혹은 늦게  끝날 수 있습니다.`,
       "ja": ` - 情報 - \nサーバーメンテナンスの予定は以下の期間:\n${startDateLocalized} から ${endDateLocalized} まで\n終了日・時間は推定です。\nメンテナンスはこの時期より早く終了する場合も遅く終了する場合もあります。`,
     };
     const announcementString = localizedAnnouncementString[Object.keys(localizedAnnouncementString).find(lang => currentLanguage.includes(lang)) ?? "en"];

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -82,7 +82,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
     const startDate = new Date(1738994400000).toLocaleString();
     const endDate = new Date(1739167200000).toLocaleString();
     const localizedAnnouncementString: { [key: string]: string } = {
-      "en": ` - INFORMATION - \nA maintenance is scheduled for the following period:\n${startDate} until ${endDate}\nEnd date and hour are an estimate.\nMaintenance may end at an earlier or later time.`,
+      "en": ` - INFORMATION - \nServer maintenance is scheduled for the following period:\n${startDate} until ${endDate}\nEnd date and hour are an estimate.\nMaintenance may end at an earlier or later time.`,
       "de": ` - INFORMATION - German test:\n${startDate} until ${endDate}`,
       "es-ES":"",
       "fr":"",

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -85,7 +85,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
       "en": ` - INFORMATION - \nServer maintenance is scheduled for the following period:\n${startDate} until ${endDate}\nEnd date and hour are an estimate.\nMaintenance may end at an earlier or later time.`,
       "de": ` - INFORMATION - German translation goes here:\n${startDate} until ${endDate}`,
       "es-ES": ` - INFORMATION - Spanish translation goes here:\n${startDate} until ${endDate}`,
-      "fr": ` - INFORMATION - French translation goes here:\n${startDate} until ${endDate}`,
+      "fr": ` - INFORMATION - \nUne maintenance du serveur est prévue sur la période suivante :\n$Du {startDate} au ${endDate}\nL’heure de fin est une estimation et peut s’avérer plus en avance ou tardive qu’annoncé.`,
       "it": ` - INFORMATION - Italian translation goes here:\n${startDate} until ${endDate}`,
       "pt-BR": ` - INFORMATION - Portugese translation goes here:\n${startDate} until ${endDate}`,
       "zh-TW": ` - INFORMATION - Chinese-traditional translation goes here:\n${startDate} until ${endDate}`,

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -91,7 +91,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
       "zh-TW": ` - 通知 - \n伺服器預計在以下時間維護：\n${startDate} 至 ${endDate}\n維護結束時間是預計時間\n維護可能稍早或稍晚結束。`,
       "zh-CN": ` - 通知 - \n服务器预计在以下时间维护：\n${startDate} 至 ${endDate}\n维护结束时间是预计时间\n维护可能稍早或稍晚结束。`,
       "ko": ` - INFORMATION - Korean translation goes here:\n${startDate} until ${endDate}`,
-      "ja": ` - INFORMATION - Japanese translation goes here:\n${startDate} until ${endDate}`,
+      "ja": ` - 情報 - \nサーバーメンテナンスの予定は以下の期間:\n${startDate} から ${endDate} まで\n終了日・時間は推定です。\nメンテナンスはこの時期より早く終了する場合も遅く終了する場合もあります。`,
     };
     const currentLanguage = i18next.resolvedLanguage ?? "en";
     const announcementString = localizedAnnouncementString[Object.keys(localizedAnnouncementString).find(lang => currentLanguage.includes(lang)) ?? "en"];

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -80,12 +80,29 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
     this.titleContainer.add(this.appVersionText);
 
     const currentLanguage = i18next.resolvedLanguage ?? "en";
+    const getTimeFormat = (): boolean => {
+      switch (currentLanguage) {
+        case "en":
+        case "es-ES":
+        case "ko":
+        case "zh-TW":
+        default:
+          return true; // 12h
+        case "de":
+        case "fr":
+        case "it":
+        case "ja":
+        case "pt-BR": // <-- in review
+        case "zh-CN":
+          return false; // 24h
+      }
+    };
     const startDate = new Date(1738994400000);
     const endDate = new Date(1739167200000);
     const dateOptions: Intl.DateTimeFormatOptions = {
       dateStyle: "short",
       timeStyle: "short",
-      hour12: true,
+      hour12: getTimeFormat(),
     };
     const startDateLocalized = new Intl.DateTimeFormat(currentLanguage, dateOptions).format(startDate);
     const endDateLocalized = new Intl.DateTimeFormat(currentLanguage, dateOptions).format(endDate);

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -84,7 +84,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
     const localizedAnnouncementString: { [key: string]: string } = {
       "en": ` - INFORMATION - \nServer maintenance is scheduled for the following period:\n${startDate} until ${endDate}\nEnd date and hour are an estimate.\nMaintenance may end at an earlier or later time.`,
       "de": ` - INFORMATION - German translation goes here:\n${startDate} until ${endDate}`,
-      "es-ES": ` - INFORMATION - Spanish translation goes here:\n${startDate} until ${endDate}`,
+      "es-ES": ` - INFORMACIÓN -\nUn mantenimiento del servidor está programado para el siguiente período:\nDesde el ${startDate} hasta el ${endDate}.\nLa fecha y hora de finalización son aproximadas.\nEl mantenimiento podría finalizar antes o extenderse más de lo previsto.`,
       "fr": ` - INFORMATION - \nUne maintenance du serveur est prévue sur la période suivante :\nDu ${startDate} au ${endDate}\nL’heure de fin est une estimation et peut s’avérer plus en avance ou tardive qu’annoncé.`,
       "it": ` - INFORMATION - Italian translation goes here:\n${startDate} until ${endDate}`,
       "pt-BR": ` - INFORMATION - Portugese translation goes here:\n${startDate} until ${endDate}`,

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -8,6 +8,7 @@ import { TimedEventDisplay } from "#app/timed-event-manager";
 import { version } from "../../package.json";
 import { pokerogueApi } from "#app/plugins/api/pokerogue-api";
 import { globalScene } from "#app/global-scene";
+import { addWindow } from "./ui-theme";
 
 export default class TitleUiHandler extends OptionSelectUiHandler {
   /** If the stats can not be retrieved, use this fallback value */
@@ -19,6 +20,8 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
   private splashMessageText: Phaser.GameObjects.Text;
   private eventDisplay: TimedEventDisplay;
   private appVersionText: Phaser.GameObjects.Text;
+  private announcementText: Phaser.GameObjects.Text;
+  private announcementBg: Phaser.GameObjects.NineSlice;
 
   private titleStatsTimer: NodeJS.Timeout | null;
 
@@ -75,6 +78,33 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
     this.appVersionText.setOrigin(0.5, 0.5);
     this.appVersionText.setAngle(0);
     this.titleContainer.add(this.appVersionText);
+
+    const startDate = new Date(1738994400000).toLocaleString();
+    const endDate = new Date(1739167200000).toLocaleString();
+    const localizedAnnouncementString: { [key: string]: string } = {
+      "en": ` - INFORMATION - \nA maintenance is scheduled for the following period:\n${startDate} until ${endDate}\nEnd date and hour are an estimate.\nMaintenance may end at an earlier or later time.`,
+      "de": ` - INFORMATION - German test:\n${startDate} until ${endDate}`,
+      "es-ES":"",
+      "fr":"",
+      "it":"",
+      "pt_BR":"",
+      "zh":"",
+      "pt":"",
+      "ko":"",
+      "ja":"",
+      "ca-ES":"",
+    };
+    const currentLanguage = i18next.resolvedLanguage ?? "en";
+    const announcementString = localizedAnnouncementString[Object.keys(localizedAnnouncementString).find(lang => currentLanguage.includes(lang)) ?? "en"];
+    this.announcementText = addTextObject(logo.x - 138, logo.y + logo.displayHeight + 116, announcementString, TextStyle.MONEY, { fontSize: "78px", wordWrap: { width: 200 * 6 }});
+    this.announcementText.setOrigin(0, 1);
+    this.announcementText.setAngle(0);
+    this.announcementBg = addWindow(this.announcementText.x - 8, this.announcementText.y + 6, this.announcementText.width / 6 + 14, this.announcementText.height / 6 + 12);
+    this.announcementBg.setName("announcement-bg");
+    this.announcementBg.setOrigin(0, 1);
+    this.titleContainer.add(this.announcementText);
+    this.titleContainer.add(this.announcementBg);
+    this.titleContainer.bringToTop(this.announcementText);
   }
 
   updateTitleStats(): void {

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -122,7 +122,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
       "ja": ` - 情報 - \nサーバーメンテナンスの予定は以下の期間:\n${startDateLocalized} から ${endDateLocalized} まで\n終了日・時間は推定です。\nメンテナンスはこの時期より早く終了する場合も遅く終了する場合もあります。`,
     };
     const announcementString = localizedAnnouncementString[Object.keys(localizedAnnouncementString).find(lang => currentLanguage.includes(lang)) ?? "en"];
-    this.announcementText = addTextObject(logo.x - 138, logo.y + logo.displayHeight + 116, announcementString, TextStyle.MONEY, { fontSize: "78px", wordWrap: { width: 200 * 6 }});
+    this.announcementText = addTextObject(logo.x - 148, logo.y + logo.displayHeight + 116, announcementString, TextStyle.MONEY, { fontSize: "78px", wordWrap: { width: 200 * 6 }});
     this.announcementText.setOrigin(0, 1);
     this.announcementText.setAngle(0);
     this.announcementBg = addWindow(this.announcementText.x - 8, this.announcementText.y + 6, this.announcementText.width / 6 + 14, this.announcementText.height / 6 + 12);

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -89,7 +89,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
       "it": ` - INFORMATION - Italian translation goes here:\n${startDate} until ${endDate}`,
       "pt-BR": ` - INFORMATION - Portugese translation goes here:\n${startDate} until ${endDate}`,
       "zh-TW": ` - INFORMATION - Chinese-traditional translation goes here:\n${startDate} until ${endDate}`,
-      "zh-CN": ` - INFORMATION - Chinese-simplified translation goes here:\n${startDate} until ${endDate}`,
+      "zh-CN": ` - 通知 - \n服务器预计在以下时间维护：\n${startDate} 至 ${endDate}\n维护结束时间是预计时间\n维护可能稍早或稍晚结束。`,
       "ko": ` - INFORMATION - Korean translation goes here:\n${startDate} until ${endDate}`,
       "ja": ` - INFORMATION - Japanese translation goes here:\n${startDate} until ${endDate}`,
     };

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -114,18 +114,19 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
       "de": `- INFORMATION -\nServerwartung ist für den folgenden Zeitraum geplant:\n${startDateLocalized} bis ${endDateLocalized}\nEnddatum und Uhrzeit sind eine Schätzung.\nDie Wartung kann früher oder später beendet werden.`,
       "es-ES": ` - INFORMACIÓN -\nUn mantenimiento del servidor está programado para el siguiente período:\nDesde el ${startDateLocalized} hasta el ${endDateLocalized}.\nLa fecha y hora de finalización son aproximadas.\nEl mantenimiento podría finalizar antes o extenderse más de lo previsto.`,
       "fr": ` - INFORMATION -\nUne maintenance du serveur est prévue sur la période suivante :\nDu ${startDateLocalized} au ${endDateLocalized}\nL’heure de fin est une estimation et peut s’avérer plus en avance ou tardive qu’annoncé.`,
-      "it": ` - INFORMATION - Italian translation goes here:\n${startDateLocalized} until ${endDateLocalized}`,
+      "it": ` - ANNUNCIO -\nUna manutenzione del server avrà luogo nel periodo seguente:\nDal ${startDateLocalized} al ${endDateLocalized}\nData e ora di fine manutenzione sono una stima,\npotrebbe terminare in anticipo o più tardi.`,
       "pt-BR": ` - INFORMATION - Portugese translation goes here:\n${startDateLocalized} until ${endDateLocalized}`,
       "zh-TW": ` - 通知 -\n伺服器預計在以下時間維護：\n${startDateLocalized} 至 ${endDateLocalized}\n維護結束時間是預計時間\n維護可能稍早或稍晚結束。`,
       "zh-CN": ` - 通知 -\n服务器预计在以下时间维护：\n${startDateLocalized} 至 ${endDateLocalized}\n维护结束时间是预计时间\n维护可能稍早或稍晚结束。`,
       "ko": ` - 공지사항 -\n아래 기간동안 점검 예정입니다. :\n${startDateLocalized} ~ ${endDateLocalized}\n종료시각은 예상시간입니다.\n점검은 예상했던 것보다 빠르게 혹은 늦게  끝날 수 있습니다.`,
-      "ja": ` - 情報 -\nサーバーメンテナンスの予定は以下の期間:\n${startDateLocalized} から ${endDateLocalized} まで\n終了日・時間は推定です。\nメンテナンスはこの時期より早く終了する場合も遅く終了する場合もあります。`,
+      "ja": ` - 情報 -\nサーバーメンテナンスの予定は以下の期間:\n${startDateLocalized} から ${endDateLocalized} まで\n終了日・時間は推定です。\nメンテナンスはこの時期より早く終了する場合も\n遅く終了する場合もあります。`,
     };
     const announcementString = localizedAnnouncementString[Object.keys(localizedAnnouncementString).find(lang => currentLanguage.includes(lang)) ?? "en"];
     this.announcementText = addTextObject(logo.x - 148, logo.y + logo.displayHeight + 116, announcementString, TextStyle.MONEY, { fontSize: "76px", wordWrap: { width: 200 * 6 }});
     this.announcementText.setOrigin(0, 1);
     this.announcementText.setAngle(0);
-    this.announcementBg = addWindow(this.announcementText.x - 8, this.announcementText.y + 6, this.announcementText.width / 6 + 14, this.announcementText.height / 6 + 12);
+    const heightOffset = currentLanguage === "ja" ? -2 : 12;
+    this.announcementBg = addWindow(this.announcementText.x - 8, this.announcementText.y + 6, this.announcementText.width / 6 + 14, this.announcementText.height / 6 + heightOffset);
     this.announcementBg.setName("announcement-bg");
     this.announcementBg.setOrigin(0, 1);
     this.titleContainer.add(this.announcementText);

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -110,16 +110,16 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
     const startDateLocalized = new Intl.DateTimeFormat(currentLanguage, dateOptions).format(startDate);
     const endDateLocalized = new Intl.DateTimeFormat(currentLanguage, dateOptions).format(endDate);
     const localizedAnnouncementString: { [key: string]: string } = {
-      "en": ` - INFORMATION - \nServer maintenance is scheduled for the following period:\n${startDateLocalized} until ${endDateLocalized}\nEnd date and hour are an estimate.\nMaintenance may end at an earlier or later time.`,
+      "en": ` - INFORMATION -\nServer maintenance is scheduled for the following period:\n${startDateLocalized} until ${endDateLocalized}\nEnd date and hour are an estimate.\nMaintenance may end at an earlier or later time.`,
       "de": `- INFORMATION -\nServerwartung ist für den folgenden Zeitraum geplant:\n${startDateLocalized} bis ${endDateLocalized}\nEnddatum und Uhrzeit sind eine Schätzung.\nDie Wartung kann früher oder später beendet werden.`,
       "es-ES": ` - INFORMACIÓN -\nUn mantenimiento del servidor está programado para el siguiente período:\nDesde el ${startDateLocalized} hasta el ${endDateLocalized}.\nLa fecha y hora de finalización son aproximadas.\nEl mantenimiento podría finalizar antes o extenderse más de lo previsto.`,
-      "fr": ` - INFORMATION - \nUne maintenance du serveur est prévue sur la période suivante :\nDu ${startDateLocalized} au ${endDateLocalized}\nL’heure de fin est une estimation et peut s’avérer plus en avance ou tardive qu’annoncé.`,
+      "fr": ` - INFORMATION -\nUne maintenance du serveur est prévue sur la période suivante :\nDu ${startDateLocalized} au ${endDateLocalized}\nL’heure de fin est une estimation et peut s’avérer plus en avance ou tardive qu’annoncé.`,
       "it": ` - INFORMATION - Italian translation goes here:\n${startDateLocalized} until ${endDateLocalized}`,
       "pt-BR": ` - INFORMATION - Portugese translation goes here:\n${startDateLocalized} until ${endDateLocalized}`,
-      "zh-TW": ` - 通知 - \n伺服器預計在以下時間維護：\n${startDateLocalized} 至 ${endDateLocalized}\n維護結束時間是預計時間\n維護可能稍早或稍晚結束。`,
-      "zh-CN": ` - 通知 - \n服务器预计在以下时间维护：\n${startDateLocalized} 至 ${endDateLocalized}\n维护结束时间是预计时间\n维护可能稍早或稍晚结束。`,
+      "zh-TW": ` - 通知 -\n伺服器預計在以下時間維護：\n${startDateLocalized} 至 ${endDateLocalized}\n維護結束時間是預計時間\n維護可能稍早或稍晚結束。`,
+      "zh-CN": ` - 通知 -\n服务器预计在以下时间维护：\n${startDateLocalized} 至 ${endDateLocalized}\n维护结束时间是预计时间\n维护可能稍早或稍晚结束。`,
       "ko": ` - 공지사항 -\n아래 기간동안 점검 예정입니다. :\n${startDateLocalized} ~ ${endDateLocalized}\n종료시각은 예상시간입니다.\n점검은 예상했던 것보다 빠르게 혹은 늦게  끝날 수 있습니다.`,
-      "ja": ` - 情報 - \nサーバーメンテナンスの予定は以下の期間:\n${startDateLocalized} から ${endDateLocalized} まで\n終了日・時間は推定です。\nメンテナンスはこの時期より早く終了する場合も遅く終了する場合もあります。`,
+      "ja": ` - 情報 -\nサーバーメンテナンスの予定は以下の期間:\n${startDateLocalized} から ${endDateLocalized} まで\n終了日・時間は推定です。\nメンテナンスはこの時期より早く終了する場合も遅く終了する場合もあります。`,
     };
     const announcementString = localizedAnnouncementString[Object.keys(localizedAnnouncementString).find(lang => currentLanguage.includes(lang)) ?? "en"];
     this.announcementText = addTextObject(logo.x - 148, logo.y + logo.displayHeight + 116, announcementString, TextStyle.MONEY, { fontSize: "78px", wordWrap: { width: 200 * 6 }});

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -118,7 +118,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
       "pt-BR": ` - INFORMATION - Portugese translation goes here:\n${startDateLocalized} until ${endDateLocalized}`,
       "zh-TW": ` - 通知 - \n伺服器預計在以下時間維護：\n${startDateLocalized} 至 ${endDateLocalized}\n維護結束時間是預計時間\n維護可能稍早或稍晚結束。`,
       "zh-CN": ` - 通知 - \n服务器预计在以下时间维护：\n${startDateLocalized} 至 ${endDateLocalized}\n维护结束时间是预计时间\n维护可能稍早或稍晚结束。`,
-      "ko": ` - INFORMATION - Korean translation goes here:\n${startDateLocalized} until ${endDateLocalized}`,
+      "ko": ` - 공지사항 -\n 아래 기간동안 점검 예정입니다. :\n${startDateLocalized} ~ ${endDateLocalized}\n 종료시각은 예상시간입니다.\n 점검은 예상했던 것보다 빠르게 혹은 늦게  끝날 수 있습니다.`,
       "ja": ` - 情報 - \nサーバーメンテナンスの予定は以下の期間:\n${startDateLocalized} から ${endDateLocalized} まで\n終了日・時間は推定です。\nメンテナンスはこの時期より早く終了する場合も遅く終了する場合もあります。`,
     };
     const announcementString = localizedAnnouncementString[Object.keys(localizedAnnouncementString).find(lang => currentLanguage.includes(lang)) ?? "en"];

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -79,21 +79,28 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
     this.appVersionText.setAngle(0);
     this.titleContainer.add(this.appVersionText);
 
-    const startDate = new Date(1738994400000).toLocaleString();
-    const endDate = new Date(1739167200000).toLocaleString();
-    const localizedAnnouncementString: { [key: string]: string } = {
-      "en": ` - INFORMATION - \nServer maintenance is scheduled for the following period:\n${startDate} until ${endDate}\nEnd date and hour are an estimate.\nMaintenance may end at an earlier or later time.`,
-      "de": ` - INFORMATION - German translation goes here:\n${startDate} until ${endDate}`,
-      "es-ES": ` - INFORMACIÓN -\nUn mantenimiento del servidor está programado para el siguiente período:\nDesde el ${startDate} hasta el ${endDate}.\nLa fecha y hora de finalización son aproximadas.\nEl mantenimiento podría finalizar antes o extenderse más de lo previsto.`,
-      "fr": ` - INFORMATION - \nUne maintenance du serveur est prévue sur la période suivante :\nDu ${startDate} au ${endDate}\nL’heure de fin est une estimation et peut s’avérer plus en avance ou tardive qu’annoncé.`,
-      "it": ` - INFORMATION - Italian translation goes here:\n${startDate} until ${endDate}`,
-      "pt-BR": ` - INFORMATION - Portugese translation goes here:\n${startDate} until ${endDate}`,
-      "zh-TW": ` - 通知 - \n伺服器預計在以下時間維護：\n${startDate} 至 ${endDate}\n維護結束時間是預計時間\n維護可能稍早或稍晚結束。`,
-      "zh-CN": ` - 通知 - \n服务器预计在以下时间维护：\n${startDate} 至 ${endDate}\n维护结束时间是预计时间\n维护可能稍早或稍晚结束。`,
-      "ko": ` - INFORMATION - Korean translation goes here:\n${startDate} until ${endDate}`,
-      "ja": ` - 情報 - \nサーバーメンテナンスの予定は以下の期間:\n${startDate} から ${endDate} まで\n終了日・時間は推定です。\nメンテナンスはこの時期より早く終了する場合も遅く終了する場合もあります。`,
-    };
     const currentLanguage = i18next.resolvedLanguage ?? "en";
+    const startDate = new Date(1738994400000);
+    const endDate = new Date(1739167200000);
+    const dateOptions: Intl.DateTimeFormatOptions = {
+      dateStyle: "short",
+      timeStyle: "short",
+      hour12: true,
+    };
+    const startDateLocalized = new Intl.DateTimeFormat(currentLanguage, dateOptions).format(startDate);
+    const endDateLocalized = new Intl.DateTimeFormat(currentLanguage, dateOptions).format(endDate);
+    const localizedAnnouncementString: { [key: string]: string } = {
+      "en": ` - INFORMATION - \nServer maintenance is scheduled for the following period:\n${startDateLocalized} until ${endDateLocalized}\nEnd date and hour are an estimate.\nMaintenance may end at an earlier or later time.`,
+      "de": ` - INFORMATION - German translation goes here:\n${startDateLocalized} until ${endDateLocalized}`,
+      "es-ES": ` - INFORMACIÓN -\nUn mantenimiento del servidor está programado para el siguiente período:\nDesde el ${startDateLocalized} hasta el ${endDateLocalized}.\nLa fecha y hora de finalización son aproximadas.\nEl mantenimiento podría finalizar antes o extenderse más de lo previsto.`,
+      "fr": ` - INFORMATION - \nUne maintenance du serveur est prévue sur la période suivante :\nDu ${startDateLocalized} au ${endDateLocalized}\nL’heure de fin est une estimation et peut s’avérer plus en avance ou tardive qu’annoncé.`,
+      "it": ` - INFORMATION - Italian translation goes here:\n${startDateLocalized} until ${endDateLocalized}`,
+      "pt-BR": ` - INFORMATION - Portugese translation goes here:\n${startDateLocalized} until ${endDateLocalized}`,
+      "zh-TW": ` - 通知 - \n伺服器預計在以下時間維護：\n${startDateLocalized} 至 ${endDateLocalized}\n維護結束時間是預計時間\n維護可能稍早或稍晚結束。`,
+      "zh-CN": ` - 通知 - \n服务器预计在以下时间维护：\n${startDateLocalized} 至 ${endDateLocalized}\n维护结束时间是预计时间\n维护可能稍早或稍晚结束。`,
+      "ko": ` - INFORMATION - Korean translation goes here:\n${startDateLocalized} until ${endDateLocalized}`,
+      "ja": ` - 情報 - \nサーバーメンテナンスの予定は以下の期間:\n${startDateLocalized} から ${endDateLocalized} まで\n終了日・時間は推定です。\nメンテナンスはこの時期より早く終了する場合も遅く終了する場合もあります。`,
+    };
     const announcementString = localizedAnnouncementString[Object.keys(localizedAnnouncementString).find(lang => currentLanguage.includes(lang)) ?? "en"];
     this.announcementText = addTextObject(logo.x - 138, logo.y + logo.displayHeight + 116, announcementString, TextStyle.MONEY, { fontSize: "78px", wordWrap: { width: 200 * 6 }});
     this.announcementText.setOrigin(0, 1);


### PR DESCRIPTION
Displaying a message on the title page with starting and ending times (as dynamic dates) of the maintenance.

This is to warn users who don't have access or simply do not follow the discord.

Localization is needed. Localized strings will be directly added to `title-ui-handler.ts` without passing through locales.

Screenshots:
<details><summary>English</summary>
<p>

![image](https://github.com/user-attachments/assets/c1b192d7-1ab9-4ffc-9fdd-6f50e8ef38f9)

</p>
</details> 
<details><summary>Spanish</summary>
<p>

![image](https://github.com/user-attachments/assets/4de08aa0-c1a9-436a-b6ca-2e4c62a21a14)

</p>
</details> 
<details><summary>Italian</summary>
<p>

![image](https://github.com/user-attachments/assets/f6615c68-c406-416e-94be-5358717c92a3)

</p>
</details> 
<details><summary>French</summary>
<p>

![image](https://github.com/user-attachments/assets/71f0a1f1-380c-48d4-94f7-0a97cd08bca1)

</p>
</details> 
<details><summary>German</summary>
<p>

![image](https://github.com/user-attachments/assets/012c7052-cf69-4fa4-bc34-80e7d3f8de8d)

</p>
</details> 
<details><summary>Portugese (missing)</summary>
<p>



</p>
</details> 
<details><summary>Chinese - Simplified</summary>
<p>

![image](https://github.com/user-attachments/assets/9e123939-fe5f-48a6-a244-bae425f37180)

</p>
</details> 
<details><summary>Chinese - Traditional</summary>
<p>

![image](https://github.com/user-attachments/assets/1bcc35b2-377c-4fb3-9cf2-286d623ece9b)

</p>
</details> 
<details><summary>Korean</summary>
<p>

![image](https://github.com/user-attachments/assets/2012a26e-2b44-4756-a28d-5b4d296bfcf3)

</p>
</details> 
<details><summary>Japanese</summary>
<p>

![image](https://github.com/user-attachments/assets/64c3d36a-8c35-4974-906f-672b0d119e28)

</p>
</details> 

This is meant as a quick fix to go online as soon as possible before the maintenance, as such it is rather clunky. We can change it later on to be more modular and customizable.
 
