### PR TITLE
[Refactor] [Docs] Minor refactor of `move.checkFlags` into `move.doesFlagEffectApply`

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -998,7 +998,7 @@ export class PostDefendContactApplyStatusEffectAbAttr extends PostDefendAbAttr {
 
   override canApplyPostDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, hitResult: HitResult | null, args: any[]): boolean {
     const effect = this.effects.length === 1 ? this.effects[0] : this.effects[pokemon.randSeedInt(this.effects.length)];
-    return move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon) && !attacker.status
+    return move.doesFlagEffectApply({flag: MoveFlags.MAKES_CONTACT, user: attacker, target: pokemon}) && !attacker.status
       && (this.chance === -1 || pokemon.randSeedInt(100) < this.chance) && !move.hitsSubstitute(attacker, pokemon)
       && attacker.canSetStatus(effect, true, false, pokemon);
   }
@@ -1038,7 +1038,7 @@ export class PostDefendContactApplyTagChanceAbAttr extends PostDefendAbAttr {
   }
 
   override canApplyPostDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, hitResult: HitResult | null, args: any[]): boolean {
-    return move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon) && pokemon.randSeedInt(100) < this.chance
+    return move.doesFlagEffectApply({flag: MoveFlags.MAKES_CONTACT, user: attacker, target: pokemon}) && pokemon.randSeedInt(100) < this.chance
       && !move.hitsSubstitute(attacker, pokemon) && attacker.canAddTag(this.tagType);
   }
 
@@ -1085,7 +1085,7 @@ export class PostDefendContactDamageAbAttr extends PostDefendAbAttr {
   }
 
   override canApplyPostDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, hitResult: HitResult | null, args: any[]): boolean {
-    return !simulated && move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)
+    return !simulated && move.doesFlagEffectApply({flag: MoveFlags.MAKES_CONTACT, user: attacker, target: pokemon})
       && !attacker.hasAbilityWithAttr(BlockNonDirectDamageAbAttr) && !move.hitsSubstitute(attacker, pokemon);
   }
 
@@ -1118,8 +1118,8 @@ export class PostDefendPerishSongAbAttr extends PostDefendAbAttr {
   }
 
   override canApplyPostDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, hitResult: HitResult | null, args: any[]): boolean {
-    return (move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon) && !move.hitsSubstitute(attacker, pokemon))
-      && !attacker.getTag(BattlerTagType.PERISH_SONG);
+    return (move.doesFlagEffectApply({flag: MoveFlags.MAKES_CONTACT, user: attacker, target: pokemon}) && !move.hitsSubstitute(attacker, pokemon))
+      && !pokemon.getTag(BattlerTagType.PERISH_SONG) || attacker.getTag(BattlerTagType.PERISH_SONG);
   }
 
   override applyPostDefend(pokemon: Pokemon, _passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, _hitResult: HitResult, _args: any[]): void {
@@ -1163,7 +1163,7 @@ export class PostDefendAbilitySwapAbAttr extends PostDefendAbAttr {
   }
 
   override canApplyPostDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, hitResult: HitResult | null, args: any[]): boolean {
-    return move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)
+    return move.doesFlagEffectApply({flag: MoveFlags.MAKES_CONTACT, user: attacker, target: pokemon})
       && attacker.getAbility().isSwappable && !move.hitsSubstitute(attacker, pokemon);
   }
 
@@ -1189,7 +1189,7 @@ export class PostDefendAbilityGiveAbAttr extends PostDefendAbAttr {
   }
 
   override canApplyPostDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, hitResult: HitResult | null, args: any[]): boolean {
-    return move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon) && attacker.getAbility().isSuppressable
+    return move.doesFlagEffectApply({flag: MoveFlags.MAKES_CONTACT, user: attacker, target: pokemon}) && attacker.getAbility().isSuppressable
       && !attacker.getAbility().hasAttr(PostDefendAbilityGiveAbAttr) && !move.hitsSubstitute(attacker, pokemon);
   }
 
@@ -1220,7 +1220,7 @@ export class PostDefendMoveDisableAbAttr extends PostDefendAbAttr {
 
   override canApplyPostDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, hitResult: HitResult | null, args: any[]): boolean {
     return attacker.getTag(BattlerTagType.DISABLED) === null && !move.hitsSubstitute(attacker, pokemon)
-      && move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon) && (this.chance === -1 || pokemon.randSeedInt(100) < this.chance);
+      && move.doesFlagEffectApply({flag: MoveFlags.MAKES_CONTACT, user: attacker, target: pokemon}) && (this.chance === -1 || pokemon.randSeedInt(100) < this.chance);
   }
 
   override applyPostDefend(pokemon: Pokemon, _passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, _hitResult: HitResult, _args: any[]): void {
@@ -1925,7 +1925,7 @@ export class PostAttackApplyStatusEffectAbAttr extends PostAttackAbAttr {
       super.canApplyPostAttack(pokemon, passive, simulated, attacker, move, hitResult, args)
       && !(pokemon !== attacker && move.hitsSubstitute(attacker, pokemon))
       && (simulated || !attacker.hasAbilityWithAttr(IgnoreMoveEffectsAbAttr) && pokemon !== attacker
-      && (!this.contactRequired || move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)) && pokemon.randSeedInt(100) < this.chance && !pokemon.status)
+      && (!this.contactRequired || move.doesFlagEffectApply({flag: MoveFlags.MAKES_CONTACT, user: attacker, target: pokemon})) && pokemon.randSeedInt(100) < this.chance && !pokemon.status)
     ) {
       const effect = this.effects.length === 1 ? this.effects[0] : this.effects[pokemon.randSeedInt(this.effects.length)];
       return simulated || attacker.canSetStatus(effect, true, false, pokemon);
@@ -1964,7 +1964,7 @@ export class PostAttackApplyBattlerTagAbAttr extends PostAttackAbAttr {
     /**Battler tags inflicted by abilities post attacking are also considered additional effects.*/
     return super.canApplyPostAttack(pokemon, passive, simulated, attacker, move, hitResult, args) &&
       !attacker.hasAbilityWithAttr(IgnoreMoveEffectsAbAttr) && pokemon !== attacker &&
-      (!this.contactRequired || move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)) &&
+      (!this.contactRequired || move.doesFlagEffectApply({flag: MoveFlags.MAKES_CONTACT, user: attacker, target: pokemon})) &&
       pokemon.randSeedInt(100) < this.chance(attacker, pokemon, move) && !pokemon.status;
   }
 
@@ -4751,7 +4751,7 @@ export class PostFaintContactDamageAbAttr extends PostFaintAbAttr {
   }
 
   override canApplyPostFaint(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker?: Pokemon, move?: Move, hitResult?: HitResult, ...args: any[]): boolean {
-    const diedToDirectDamage = move !== undefined && attacker !== undefined && move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon);
+    const diedToDirectDamage = move !== undefined && attacker !== undefined && move.doesFlagEffectApply({flag: MoveFlags.MAKES_CONTACT, user: attacker, target: pokemon});
     const cancelled = new Utils.BooleanHolder(false);
     globalScene.getField(true).map(p => applyAbAttrs(FieldPreventExplosiveMovesAbAttr, p, cancelled, simulated));
     if (!diedToDirectDamage || cancelled.value || attacker!.hasAbilityWithAttr(BlockNonDirectDamageAbAttr)) {

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -1118,8 +1118,7 @@ export class PostDefendPerishSongAbAttr extends PostDefendAbAttr {
   }
 
   override canApplyPostDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, hitResult: HitResult | null, args: any[]): boolean {
-    return (move.doesFlagEffectApply({flag: MoveFlags.MAKES_CONTACT, user: attacker, target: pokemon}) && !move.hitsSubstitute(attacker, pokemon))
-      && !pokemon.getTag(BattlerTagType.PERISH_SONG) || attacker.getTag(BattlerTagType.PERISH_SONG);
+    return move.doesFlagEffectApply({flag: MoveFlags.MAKES_CONTACT, user: attacker, target: pokemon}) && !attacker.getTag(BattlerTagType.PERISH_SONG);
   }
 
   override applyPostDefend(pokemon: Pokemon, _passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, _hitResult: HitResult, _args: any[]): void {

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -660,7 +660,6 @@ export default class Move implements Localizable {
           // by another move, such as via metronome.
         }
         return this.hasFlag(MoveFlags.IGNORE_ABILITIES) && !isFollowUp;
-        break;
       case MoveFlags.IGNORE_PROTECT:
         if (user.hasAbilityWithAttr(IgnoreProtectOnContactAbAttr)
           && this.doesFlagEffectApply({ flag: MoveFlags.MAKES_CONTACT, user, target: null })) {

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -1,4 +1,4 @@
-import { ChargeAnim, initMoveAnim, loadMoveAnimAssets, MoveChargeAnim } from "../battle-anims";
+import { ChargeAnim, MoveChargeAnim } from "../battle-anims";
 import {
   CommandedTag,
   EncoreTag,

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -663,7 +663,7 @@ export default class Move implements Localizable {
         break;
       case MoveFlags.IGNORE_PROTECT:
         if (user.hasAbilityWithAttr(IgnoreProtectOnContactAbAttr)
-          && this.doesFlagEffectApply({ flag: MoveFlags.MAKES_CONTACT, user, target })) {
+          && this.doesFlagEffectApply({ flag: MoveFlags.MAKES_CONTACT, user, target: null })) {
           return true;
         }
         break;

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -623,6 +623,11 @@ export default class Move implements Localizable {
    * calling this method for {@linkcode MoveFlags.MAKES_CONTACT | MAKES_CONTACT}
    * will return `false` if the user has a {@linkcode Abilities.LONG_REACH} that is not being suppressed.
    *
+   * **Note:** This method only checks if the move should have effectively have the flag applied to its use.
+   * It does *not* check whether the flag will trigger related effects.
+   * For example using this method to check {@linkcode MoveFlags.WIND_MOVE}
+   * will not consider {@linkcode Abilities.WIND_RIDER | Wind Rider }.
+   *
    * To simply check whether the move has a flag, use {@linkcode hasFlag}.
    * @param flag {@linkcode MoveFlags} MoveFlag to check on user and/or target
    * @param user {@linkcode Pokemon} the Pokemon using the move

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -658,8 +658,8 @@ export default class Move implements Localizable {
           }
           // Sunsteel strike, Moongeist beam, and photon geyser will not ignore abilities if invoked
           // by another move, such as via metronome.
-          return this.hasFlag(MoveFlags.IGNORE_ABILITIES) && !isFollowUp;
         }
+        return this.hasFlag(MoveFlags.IGNORE_ABILITIES) && !isFollowUp;
         break;
       case MoveFlags.IGNORE_PROTECT:
         if (user.hasAbilityWithAttr(IgnoreProtectOnContactAbAttr)

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -346,7 +346,7 @@ export default class Move implements Localizable {
    * @param target The {@linkcode Pokemon} targeted by this move
    * @returns `true` if the move can bypass the target's Substitute; `false` otherwise.
    */
-  hitsSubstitute(user: Pokemon, target: Pokemon | null): boolean {
+  hitsSubstitute(user: Pokemon, target?: Pokemon): boolean {
     if ([ MoveTarget.USER, MoveTarget.USER_SIDE, MoveTarget.ENEMY_SIDE, MoveTarget.BOTH_SIDES ].includes(this.moveTarget)
         || !target?.getTag(BattlerTagType.SUBSTITUTE)) {
       return false;
@@ -632,14 +632,14 @@ export default class Move implements Localizable {
    * @param flag {@linkcode MoveFlags} MoveFlag to check on user and/or target
    * @param user {@linkcode Pokemon} the Pokemon using the move
    * @param target {@linkcode Pokemon} the Pokemon receiving the move
-   * @param isFollowUp (defaults to `false) `true` if the move was used as a follow up
+   * @param isFollowUp (defaults to `false`) `true` if the move was used as a follow up
    * @returns boolean
    * @see {@linkcode hasFlag}
    */
-  doesFlagEffectApply({ flag, user, target = null, isFollowUp = false }: {
+  doesFlagEffectApply({ flag, user, target, isFollowUp = false }: {
     flag: MoveFlags;
     user: Pokemon;
-    target?: Pokemon | null;
+    target?: Pokemon;
     isFollowUp?: boolean;
   }): boolean {
     // special cases below, eg: if the move flag is MAKES_CONTACT, and the user pokemon has an ability that ignores contact (like "Long Reach"), then overrides and move does not make contact
@@ -651,7 +651,7 @@ export default class Move implements Localizable {
         break;
       case MoveFlags.IGNORE_ABILITIES:
         if (user.hasAbilityWithAttr(MoveAbilityBypassAbAttr)) {
-          const abilityEffectsIgnored = new Utils.BooleanHolder(false);
+          const abilityEffectsIgnored = new Utils.BooleanHolder(false); 
           applyAbAttrs(MoveAbilityBypassAbAttr, user, abilityEffectsIgnored, false, this);
           if (abilityEffectsIgnored.value) {
             return true;
@@ -662,7 +662,7 @@ export default class Move implements Localizable {
         return this.hasFlag(MoveFlags.IGNORE_ABILITIES) && !isFollowUp;
       case MoveFlags.IGNORE_PROTECT:
         if (user.hasAbilityWithAttr(IgnoreProtectOnContactAbAttr)
-          && this.doesFlagEffectApply({ flag: MoveFlags.MAKES_CONTACT, user, target: null })) {
+          && this.doesFlagEffectApply({ flag: MoveFlags.MAKES_CONTACT, user })) {
           return true;
         }
         break;

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -308,7 +308,7 @@ export class MoveEffectPhase extends PokemonPhase {
           /** Is the target's magic bounce ability not ignored and able to reflect this move? */
           const canMagicBounce =
             !isReflecting &&
-            !move.checkFlag(MoveFlags.IGNORE_ABILITIES, user, target) &&
+            !move.doesFlagEffectApply({ flag: MoveFlags.IGNORE_ABILITIES, user, target }) &&
             target.hasAbilityWithAttr(ReflectStatusMoveAbAttr);
 
           const semiInvulnerableTag = target.getTag(SemiInvulnerableTag);

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -289,7 +289,8 @@ export class MoveEffectPhase extends PokemonPhase {
           /** Is the target protected by Protect, etc. or a relevant conditional protection effect? */
           const isProtected =
             ![MoveTarget.ENEMY_SIDE, MoveTarget.BOTH_SIDES].includes(this.move.getMove().moveTarget) &&
-            (bypassIgnoreProtect.value || !this.move.getMove().checkFlag(MoveFlags.IGNORE_PROTECT, user, target)) &&
+            (bypassIgnoreProtect.value ||
+              !this.move.getMove().doesFlagEffectApply({ flag: MoveFlags.IGNORE_PROTECT, user, target })) &&
             (hasConditionalProtectApplied.value ||
               (!target.findTags(t => t instanceof DamageProtectedTag).length &&
                 target.findTags(t => t instanceof ProtectedTag).find(t => target.lapseTag(t.tagType))) ||

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -168,7 +168,7 @@ export class MovePhase extends BattlePhase {
 
     // Check move to see if arena.ignoreAbilities should be true.
     if (!this.followUp || this.reflected) {
-      if (this.move.getMove().checkFlag(MoveFlags.IGNORE_ABILITIES, this.pokemon, null)) {
+      if (this.move.getMove().doesFlagEffectApply({ flag: MoveFlags.IGNORE_ABILITIES, user: this.pokemon, isFollowUp: this.followUp })) {
         globalScene.arena.setIgnoreAbilities(true, this.pokemon.getBattlerIndex());
       }
     }


### PR DESCRIPTION
## What are the changes the user will see?
Technically, this fixes an unreported bug where moves called by metronome would improperly not ignore abilities if the user had mold breaker.

## Why am I making these changes?
@Wlowscha and I had a long discussion in discord about the fact that the `checkFlags` method inside moves was confusing.
This class is the ideal place, adhering to the Separation of Concerns design principal, for moves to check whether a flag of theirs can be applied in a given situation (given that the existing structure of the code does not have move instances for moves that are in flight).

However, the name of the method is potentially confusing, and has likely contributed to the method not being used in cases where it probably should be (note, refactoring those uses is not in the scope of this PR). 

The signature of the method was also changed in a proactive effort to keep the function's signature from looking like
```ts
getBaseDamage(source: Pokemon,
  move: Move,
  moveCategory: MoveCategory,
  ignoreAbility: boolean = false,
  ignoreSourceAbility: boolean = false,
  ignoreAllyAbility: boolean = false,
  ignoreSourceAllyAbility: boolean = false,
  isCritical: boolean = false,
  simulated: boolean = true): number
```

which is very unwieldly to invoke in cases where you just want to override the default for a later parameter (e.g., in the above case, `simulated`).

There are likely circumstances where this method would want to be called with additional options to check. For example, in my implementation of Magic Bounce which would like to have its logic for checking the `reflectable` flag reside here, rather than in the body of the `move-effect` phase. Using the parameter destructuring pattern keeps code churn small and improves readability. It also has the added benefit of making the arguments at callsites more explicit w.r.t. the parameter they correspond to.

## What are the changes from a developer perspective?
`moves.checkFlags` has been renamed to `moves.doesFlagEffectApply`. Its signature has similarly been changed to use parameter destructring.
The check for `this.followUp` when determining whether or not to set the `ignoreAbilities` global in `move-phase` has been removed, as the check is now done inside this method. The check logic for `MoveFlags.IGNORE_ABILITIES` has been modified to return `false` if the source of the flag was from a move that was being used as a follow up.

## Screenshots/Videos
N/A
## How to test the changes?
N/A

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~~[ ] Have I tested the changes manually?~~
- [x] Are all unit tests still passing? (`npm run test`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~

~~Are there any localization additions or changes? If so:~~
- ~~[ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?~~
  - ~~[ ] If so, please leave a link to it here: ~~
- ~~[ ] Has the translation team been contacted for proofreading/translation?~~