### PR TITLE
[Bug][Ability] Fix mold breaker effect lingering if the user's move runs out of PP

### DIFF
--- a/src/phases/move-end-phase.ts
+++ b/src/phases/move-end-phase.ts
@@ -1,13 +1,20 @@
 import { globalScene } from "#app/global-scene";
 import { BattlerTagLapseType } from "#app/data/battler-tags";
 import { PokemonPhase } from "./pokemon-phase";
+import type { BattlerIndex } from "#app/battle";
 
 export class MoveEndPhase extends PokemonPhase {
+  private wasFollowUp: boolean;
+  constructor(battlerIndex: BattlerIndex, wasFollowUp: boolean = false) {
+    super(battlerIndex);
+    this.wasFollowUp = wasFollowUp;
+  }
+
   start() {
     super.start();
 
     const pokemon = this.getPokemon();
-    if (pokemon.isActive(true)) {
+    if (!this.wasFollowUp && pokemon.isActive(true)) {
       pokemon.lapseTags(BattlerTagLapseType.AFTER_MOVE);
     }
 

--- a/src/phases/move-end-phase.ts
+++ b/src/phases/move-end-phase.ts
@@ -14,7 +14,7 @@ export class MoveEndPhase extends PokemonPhase {
     super.start();
 
     const pokemon = this.getPokemon();
-    if (!this.wasFollowUp && pokemon.isActive(true)) {
+    if (!this.wasFollowUp && pokemon?.isActive(true)) {
       pokemon.lapseTags(BattlerTagLapseType.AFTER_MOVE);
     }
 

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -465,8 +465,7 @@ export class MovePhase extends BattlePhase {
   }
 
   /**
-   * Queues a {@linkcode MoveEndPhase} if the move wasn't a {@linkcode followUp} and {@linkcode canMove()} returns `true`,
-   * then ends the phase.
+   * Queues a {@linkcode MoveEndPhase} and then ends the phase
    */
   public end(): void {
     globalScene.unshiftPhase(new MoveEndPhase(this.pokemon.getBattlerIndex(), this.followUp));

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -469,9 +469,7 @@ export class MovePhase extends BattlePhase {
    * then ends the phase.
    */
   public end(): void {
-    if (!this.followUp && this.canMove()) {
-      globalScene.unshiftPhase(new MoveEndPhase(this.pokemon.getBattlerIndex()));
-    }
+    globalScene.unshiftPhase(new MoveEndPhase(this.pokemon.getBattlerIndex(), this.followUp));
 
     super.end();
   }

--- a/test/abilities/dancer.test.ts
+++ b/test/abilities/dancer.test.ts
@@ -39,20 +39,24 @@ describe("Abilities - Dancer", () => {
     game.move.select(Moves.SPLASH);
     game.move.select(Moves.SWORDS_DANCE, 1);
     await game.setTurnOrder([BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.PLAYER, BattlerIndex.ENEMY_2]);
-    await game.phaseInterceptor.to("MovePhase");
-    // immediately copies ally move
-    await game.phaseInterceptor.to("MovePhase", false);
+    await game.phaseInterceptor.to("MovePhase"); // feebas uses swords dance
+    await game.phaseInterceptor.to("MovePhase", false); // oricorio copies swords dance
+
     let currentPhase = game.scene.getCurrentPhase() as MovePhase;
     expect(currentPhase.pokemon).toBe(oricorio);
     expect(currentPhase.move.moveId).toBe(Moves.SWORDS_DANCE);
-    await game.phaseInterceptor.to("MoveEndPhase");
-    await game.phaseInterceptor.to("MovePhase");
-    // immediately copies enemy move
-    await game.phaseInterceptor.to("MovePhase", false);
+
+    await game.phaseInterceptor.to("MoveEndPhase"); // end oricorio's move
+    await game.phaseInterceptor.to("MovePhase"); // magikarp 1 copies swords dance
+    await game.phaseInterceptor.to("MovePhase"); // magikarp 2 copies swords dance
+    await game.phaseInterceptor.to("MovePhase"); // magikarp (left) uses victory dance
+    await game.phaseInterceptor.to("MovePhase", false); // oricorio copies magikarp's victory dance
+
     currentPhase = game.scene.getCurrentPhase() as MovePhase;
     expect(currentPhase.pokemon).toBe(oricorio);
     expect(currentPhase.move.moveId).toBe(Moves.VICTORY_DANCE);
-    await game.phaseInterceptor.to("BerryPhase");
+
+    await game.phaseInterceptor.to("BerryPhase"); // finish the turn
 
     // doesn't use PP if copied move is also in moveset
     expect(oricorio.moveset[0]?.ppUsed).toBe(0);

--- a/test/abilities/mold_breaker.test.ts
+++ b/test/abilities/mold_breaker.test.ts
@@ -1,0 +1,51 @@
+import { BattlerIndex } from "#app/battle";
+import { globalScene } from "#app/global-scene";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Abilities - Mold Breaker", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([ Moves.SPLASH ])
+      .ability(Abilities.MOLD_BREAKER)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH);
+  });
+
+  it("should turn off the ignore abilities arena variable after the user's move", async () => {
+    game.override.enemyMoveset(Moves.SPLASH)
+      .ability(Abilities.MOLD_BREAKER)
+      .moveset([ Moves.ERUPTION ])
+      .startingLevel(100)
+      .enemyLevel(2);
+    await game.classicMode.startBattle([ Species.MAGIKARP ]);
+    const enemy = game.scene.getEnemyPokemon()!;
+
+    expect(enemy.isFainted()).toBe(false);
+    game.move.select(Moves.SPLASH);
+    await game.setTurnOrder([ BattlerIndex.PLAYER, BattlerIndex.ENEMY ]);
+    await game.phaseInterceptor.to("MoveEndPhase", true);
+    expect(globalScene.arena.ignoreAbilities).toBe(false);
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?
Mold breaker will now no longer suppress abilities when its user uses a move with its last pp.

## Why am I making these changes?
I was asked to look into this odd interaction with mold breaker
![image](https://github.com/user-attachments/assets/72b39777-f627-40fc-8e5a-0faf5bb347a9)


## What are the changes from a developer perspective?
In `move-phase`'s `end` method, `MoveEndPhase` will *always* be unshifted, instead of only if the move was not called via a follow up and an erroneous check to the `canMove` call (which would previously return `false` after the move's pp had been deducted, as the `canMove` check also looks at the remaining pp).

Instead, `this.followUp` is now passed as an argument to the `MoveEndPhase` constructor which is called  unconditionally by `end`.
 
`MoveEndPhase` takes a new optional parameter - `wasFollowUp` that is checked before lapsing `BattlerTagLapseType.AFTER_MOVE`.
I don't know the interactions that would cause this lapse to need to not happen when a move is called via a follow up (something with Encore it looks like). This behavior, however, is consistent with what would happen prior to this PR.

## Screenshots/Videos
Note me highlighting the lack (or presence of, in the fixed version) of the MoveEndPhase in the console.
<details><summary>Before the fix</summary>


https://github.com/user-attachments/assets/61e02a15-cb15-4e35-9f5c-0bcaa5afcf6f
</details>

<details><summary>After the fix</summary>

https://github.com/user-attachments/assets/b70211d7-ea2b-46db-8035-77b74ad76213
</details>

## How to test the changes?
Boy oh boy is testing this complicated. We went through a lot of discussion in the `#endless-grinding` channel on discord to figure out exactly how to trigger this bug. (first message link here: https://discord.com/channels/1125469663833370665/1225619031156064317/1337131126992539725)

In short, I was able to reproduce this after a lot of effort with the following set up:

Alternatively, you can have an ally with the double-lure abilities/passive where one of them is ignorable (e.g. watchog with illuminate / no guard).

For the lure test (which the video depicts), you'll need to get yourself into a situation where you have run out of PP at the same time as you KO the last enemy pokemon in a double battle with your mold breaker user, AND make sure your watchog ally has used its move that turn already. (If a move is used after the PP drops, the ignoreAbilities arena flag will be cleared by that move's MoveEndPhase).
The wave that you do this on has to be before there will be a trainer or boss, as these will nullify the lures. I did my test on wave 109.
When you KO the last pokemon, without this bugfix, the `ignoreAbilities` modifier will be true. Since No Guard is an ignorable ability, when checking for abilities that have the lure effect, it will be ignored. When moving on to the next battle, if it isn't a double battle, that means that no guard's lure ability didn't trigger.

Alternatively, you may be able to whip up a scenario with a slightly easier way to test it, though I didn't end up testing it this way:
Get a pokemon to have mold breaker and an easily-confirmed ignorable passive, like earth eater / levitate. Make sure your ally pokemon does not have mold breaker or an intervening ability. Have your ally have a single-target ground type move, and have it go after your mold breaker ally. Have your mold breaker ally use a damaging move on its last PP, and then have its ally use a ground move on your mold breaker pokemon. This must happen before any enemy moves intervene, so it's best if you use a spread move and KO both opponents.

Before the change, mold breaker would have erroneously still been active, and so the ground move would go through levitate / earth eater.
With the change, this should not happen.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~

Are there any localization additions or changes? If so:
- ~~[ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?~~
  - ~~[ ] If so, please leave a link to it here:~~
- ~~[ ] Has the translation team been contacted for proofreading/translation?~~