### PR TITLE
[Move] [Bug] Fix super-niche edgecase with mega gengar and telekinesis

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2871,7 +2871,7 @@ export class SyrupBombTag extends BattlerTag {
 /**
  * Telekinesis raises the target into the air for three turns and causes all moves used against the target (aside from OHKO moves) to hit the target unless the target is in a semi-invulnerable state from Fly/Dig.
  * The first effect is provided by {@linkcode FloatingTag}, the accuracy-bypass effect is provided by TelekinesisTag
- * The effects of Telekinesis can be baton passed to a teammate. Unlike the mainline games, Telekinesis can be baton-passed to Mega Gengar.
+ * The effects of Telekinesis can be baton passed to a teammate.
  * @see {@link https://bulbapedia.bulbagarden.net/wiki/Telekinesis_(move) | Moves.TELEKINESIS}
  */
 export class TelekinesisTag extends BattlerTag {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3234,7 +3234,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     }
 
     for (const tag of source.summonData.tags) {
-      if (!tag.isBatonPassable) {
+      if (!tag.isBatonPassable || (tag.tagType === BattlerTagType.TELEKINESIS && this.species.speciesId === Species.GENGAR && this.getFormKey() === "mega")) {
         continue;
       }
 

--- a/src/test/moves/telekinesis.test.ts
+++ b/src/test/moves/telekinesis.test.ts
@@ -7,6 +7,7 @@ import { MoveResult } from "#app/field/pokemon";
 import GameManager from "#test/utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, it, expect, vi } from "vitest";
+import { BattlerIndex } from "#app/battle";
 
 describe("Moves - Telekinesis", () => {
   let phaserGame: Phaser.Game;
@@ -120,5 +121,18 @@ describe("Moves - Telekinesis", () => {
     expect(enemyOpponent.getTag(BattlerTagType.IGNORE_FLYING)).toBeDefined();
     expect(enemyOpponent.getTag(BattlerTagType.FLOATING)).toBeUndefined();
     expect(playerPokemon.getLastXMoves()[0].result).toBe(MoveResult.SUCCESS);
+  });
+
+  it("should not be baton passed onto a mega gengar", async () => {
+    game.override.moveset([ Moves.BATON_PASS ])
+      .enemyMoveset([ Moves.TELEKINESIS ])
+      .starterForms({ [Species.GENGAR]: 1 });
+
+    await game.classicMode.startBattle([ Species.MAGIKARP, Species.GENGAR ]);
+    game.move.select(Moves.BATON_PASS);
+    game.doSelectPartyPokemon(1);
+    await game.setTurnOrder([ BattlerIndex.ENEMY, BattlerIndex.PLAYER ]);
+    await game.phaseInterceptor.to("BerryPhase");
+    expect(game.scene.getPlayerPokemon()!.getTag(BattlerTagType.TELEKINESIS)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?
Most likely none at all. But mega gengar can no longer be baton passed the effect of telekinesis.

## Why am I making these changes?
Because I was reading code and saw a comment saying this interaction wasn't handled, and knew it would be a one-line fix.
Also because no matter how insignificant the change, I am obsessed with matching cartridge functionality.

## What are the changes from a developer perspective?
Added an automated test to telekinesis' unit tests for this interaction.
Inside of `pokemon`'s `transferSummon` method where it checks if a tag is baton passable, add a check if the tag is telekinesis and the pokemon is mega gengar.

## Screenshots/Videos
This is too niche. Just run the tests :)

## How to test the changes?
```
npx vitest run src/test/moves/telekinesis.test.ts -t "should not be baton passed onto a mega gengar"
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~

~~Are there any localization additions or changes? If so:~~
- ~~[ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?~~
  - ~~[ ] If so, please leave a link to it here: ~~
- ~~[ ] Has the translation team been contacted for proofreading/translation?~~