### PR TITLE
[Test] Update sprite test to give more useful error messages

### DIFF
--- a/src/test/sprites/pokemonSprite.test.ts
+++ b/src/test/sprites/pokemonSprite.test.ts
@@ -147,7 +147,7 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors", errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 
   it("check female variant files", () => {
@@ -156,7 +156,7 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors", errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 
   it("check back female variant files", () => {
@@ -165,7 +165,7 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors", errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 
   it("check back male back variant files", () => {
@@ -176,7 +176,7 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors", errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 
   it("check exp back variant files", () => {
@@ -185,7 +185,7 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors", errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 
   it("check exp female variant files", () => {
@@ -194,7 +194,7 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors", errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 
   it("check exp male variant files", () => {
@@ -206,7 +206,7 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors", errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 
   // check over every file if it's correctly set in the masterlist
@@ -217,7 +217,7 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors for ", dirPath, errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 
   it("look over every file in variant back female and check if present in masterlist", () => {
@@ -226,7 +226,7 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors for ", dirPath, errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 
   it("look over every file in variant back male and check if present in masterlist", () => {
@@ -236,7 +236,7 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors for ", dirPath, errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 
   it("look over every file in variant exp back and check if present in masterlist", () => {
@@ -245,7 +245,7 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors for ", dirPath, errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 
   it("look over every file in variant exp female and check if present in masterlist", () => {
@@ -254,7 +254,7 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors for ", dirPath, errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 
   it("look over every file in variant exp male and check if present in masterlist", () => {
@@ -263,7 +263,7 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors for ", dirPath, errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 
   it("look over every file in variant root and check if present in masterlist", () => {
@@ -272,6 +272,6 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors for ", dirPath, errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
The sprite check test didn't give helpful error messages when something was wrong, now it will.

## What are the changes from a developer perspective?
Changed the `expect()`s to go from checking the length of the error message array to checking that it equals an empty array, which makes it output the error message array to the console if it's not empty.

## How to test the changes?
`npm run test pokemonSprite` after breaking something

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?