### PR TITLE
[UI/UX] Show form name on main screen in dex

### DIFF
--- a/src/ui/pokedex-ui-handler.ts
+++ b/src/ui/pokedex-ui-handler.ts
@@ -150,6 +150,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
   private pokemonNumberText: Phaser.GameObjects.Text;
   private pokemonSprite: Phaser.GameObjects.Sprite;
   private pokemonNameText: Phaser.GameObjects.Text;
+  private pokemonFormText: Phaser.GameObjects.Text;
   private type1Icon: Phaser.GameObjects.Sprite;
   private type2Icon: Phaser.GameObjects.Sprite;
 
@@ -417,6 +418,10 @@ export default class PokedexUiHandler extends MessageUiHandler {
     this.pokemonNameText = addTextObject(6, 127, "", TextStyle.SUMMARY);
     this.pokemonNameText.setOrigin(0, 0);
     this.starterSelectContainer.add(this.pokemonNameText);
+
+    this.pokemonFormText = addTextObject(6, 122, "", TextStyle.PARTY, { fontSize: textSettings.instructionTextSize });
+    this.pokemonFormText.setOrigin(0, 0);
+    this.starterSelectContainer.add(this.pokemonFormText);
 
     const starterBoxContainer = globalScene.add.container(speciesContainerX + 6, 9); //115
 
@@ -1941,6 +1946,12 @@ export default class PokedexUiHandler extends MessageUiHandler {
         this.pokemonSprite.setTint(0x808080);
       } else {
         this.pokemonSprite.setTint(0);
+      }
+
+      if (isFormCaught || isFormSeen || globalScene.dexForDevs) {
+        this.pokemonFormText.setText("Form Text");
+      } else {
+        this.pokemonFormText.setText("");
       }
 
       if (isFormCaught || isFormSeen || globalScene.dexForDevs) {


### PR DESCRIPTION
## What are the changes the user will see?
When scrolling thorugh pokémon in the main page of the dex, or opening the form tray, the form label is shown over the name.

## Why am I making these changes?
This is a cosmetic change that makes the dex experience more pleasant by spelling out what form the user is looking at.

## What are the changes from a developer perspective?
Added one extra text element in pokedex-ui-handler.ts, leveraging the form label logic from #5294 .

## Screenshots/Videos
In the comments.

## How to test the changes?
Simply open the dex and scroll through.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?