### PR TITLE
[Bug][UI/UX] Dex bug fixes 12 feb

### DIFF
--- a/index.css
+++ b/index.css
@@ -164,13 +164,13 @@ input:-internal-autofill-selected {
 }
 
 /* Show cycle buttons only on STARTER_SELECT and on touch configuration panel */
-#touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT']) #apadOpenFilters,
-#touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT'], [data-ui-mode='RUN_INFO']) #apadCycleForm,
-#touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT'], [data-ui-mode='RUN_INFO']) #apadCycleShiny,
+#touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT'], [data-ui-mode='POKEDEX'], [data-ui-mode='POKEDEX_PAGE']) #apadOpenFilters,
+#touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT'], [data-ui-mode='POKEDEX'], [data-ui-mode='POKEDEX_PAGE'], [data-ui-mode='RUN_INFO']) #apadCycleForm,
+#touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT'], [data-ui-mode='POKEDEX'], [data-ui-mode='POKEDEX_PAGE'], [data-ui-mode='RUN_INFO']) #apadCycleShiny,
 #touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT']) #apadCycleNature,
-#touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT'], [data-ui-mode='RUN_INFO']) #apadCycleAbility,
-#touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT']) #apadCycleGender,
-#touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT']) #apadCycleVariant {
+#touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT'], [data-ui-mode='POKEDEX_PAGE'], [data-ui-mode='RUN_INFO']) #apadCycleAbility,
+#touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT'], [data-ui-mode='POKEDEX_PAGE']) #apadCycleGender,
+#touchControls:not(.config-mode):not([data-ui-mode='STARTER_SELECT'], [data-ui-mode='POKEDEX']) #apadCycleVariant {
  display: none;
 }
 

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -32,6 +32,37 @@ export enum Region {
   PALDEA
 }
 
+// TODO: this is horrible and will need to be removed once a refactor/cleanup of forms is executed.
+export const normalForm: Species[] = [
+  Species.PIKACHU,
+  Species.RAICHU,
+  Species.EEVEE,
+  Species.JOLTEON,
+  Species.FLAREON,
+  Species.VAPOREON,
+  Species.ESPEON,
+  Species.UMBREON,
+  Species.LEAFEON,
+  Species.GLACEON,
+  Species.SYLVEON,
+  Species.PICHU,
+  Species.ROTOM,
+  Species.DIALGA,
+  Species.PALKIA,
+  Species.KYUREM,
+  Species.GENESECT,
+  Species.FROAKIE,
+  Species.FROGADIER,
+  Species.GRENINJA,
+  Species.ROCKRUFF,
+  Species.NECROZMA,
+  Species.MAGEARNA,
+  Species.MARSHADOW,
+  Species.CRAMORANT,
+  Species.ZARUDE,
+  Species.CALYREX
+];
+
 /**
  * Gets the {@linkcode PokemonSpecies} object associated with the {@linkcode Species} enum given
  * @param species The species to fetch

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -7,7 +7,7 @@ import i18next from "i18next";
 import type { AnySound } from "#app/battle-scene";
 import { globalScene } from "#app/global-scene";
 import type { GameMode } from "#app/game-mode";
-import type { StarterMoveset } from "#app/system/game-data";
+import { DexAttr, type StarterMoveset } from "#app/system/game-data";
 import * as Utils from "#app/utils";
 import { uncatchableSpecies } from "#app/data/balance/biomes";
 import { speciesEggMoves } from "#app/data/balance/egg-moves";
@@ -1027,6 +1027,33 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
     return this.forms?.length
       ? this.forms[formIndex || 0].getFormSpriteKey()
       : "";
+  }
+
+  /**
+   * Generates a {@linkcode bigint} corresponding to the maximum unlocks possible for this species,
+   * taking into account if the species has a male/female gender, and which variants are implemented.
+   * @returns {@linkcode bigint} Maximum unlocks, can be compared with {@linkcode DexEntry.caughtAttr}.
+   */
+  getFullUnlocksData(): bigint {
+    let caughtAttr: bigint = 0n;
+    caughtAttr += DexAttr.NON_SHINY;
+    caughtAttr += DexAttr.SHINY;
+    if (this.malePercent !== null) {
+      if (this.malePercent > 0) {
+        caughtAttr += DexAttr.MALE;
+      }
+      if (this.malePercent < 100) {
+        caughtAttr += DexAttr.FEMALE;
+      }
+    }
+    caughtAttr += DexAttr.DEFAULT_VARIANT;
+    if (this.hasVariants()) {
+      caughtAttr += DexAttr.VARIANT_2;
+      caughtAttr += DexAttr.VARIANT_3;
+    }
+    caughtAttr += DexAttr.DEFAULT_FORM;
+
+    return caughtAttr;
   }
 }
 

--- a/src/ui/filter-text.ts
+++ b/src/ui/filter-text.ts
@@ -133,7 +133,7 @@ export class FilterText extends Phaser.GameObjects.Container {
         const handler = ui.getHandler() as AwaitableUiHandler;
         handler.tutorialActive = true;
         // Switch to the dialog test window
-        this.selections[index].setText(String(i18next.t(dialogueName)));
+        this.selections[index].setText( dialogueName === "" ? this.defaultText : String(i18next.t(dialogueName)));
         ui.revertMode();
         this.onChange();
       },

--- a/src/ui/pokedex-page-ui-handler.ts
+++ b/src/ui/pokedex-page-ui-handler.ts
@@ -1685,7 +1685,7 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
                     }
                     this.pokemonCandyCountText.setText(`x${starterData.candyCount}`);
 
-                    const egg = new Egg({ scene: globalScene, species: this.species.speciesId, sourceType: EggSourceType.SAME_SPECIES_EGG });
+                    const egg = new Egg({ scene: globalScene, species: this.starterId, sourceType: EggSourceType.SAME_SPECIES_EGG });
                     egg.addEggToGameData();
 
                     globalScene.gameData.saveSystem().then(success => {

--- a/src/ui/pokedex-page-ui-handler.ts
+++ b/src/ui/pokedex-page-ui-handler.ts
@@ -748,8 +748,9 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
 
     const species = otherSpecies ? otherSpecies : this.species;
     const dexEntry = globalScene.gameData.dexData[species.speciesId];
+    const starterDexEntry = globalScene.gameData.dexData[this.getStarterSpeciesId(species.speciesId)];
 
-    return (dexEntry?.caughtAttr ?? 0n) & species.getFullUnlocksData();
+    return (dexEntry?.caughtAttr ?? 0n) & (starterDexEntry?.caughtAttr ?? 0n) & species.getFullUnlocksData();
   }
   /**
    * Check whether a given form is caught for a given species.
@@ -2326,7 +2327,7 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
   getCurrentDexProps(speciesId: number): bigint {
     let props = 0n;
     const species = allSpecies.find(sp => sp.speciesId === speciesId);
-    const caughtAttr = globalScene.gameData.dexData[speciesId].caughtAttr & (species?.getFullUnlocksData() ?? 0n);
+    const caughtAttr = globalScene.gameData.dexData[speciesId].caughtAttr & globalScene.gameData.dexData[this.getStarterSpeciesId(speciesId)].caughtAttr & (species?.getFullUnlocksData() ?? 0n);
 
     /*  this checks the gender of the pokemon; this works by checking a) that the starter preferences for the species exist, and if so, is it female. If so, it'll add DexAttr.FEMALE to our temp props
      *  It then checks b) if the caughtAttr for the pokemon is female and NOT male - this means that the ONLY gender we've gotten is female, and we need to add DexAttr.FEMALE to our temp props

--- a/src/ui/pokedex-page-ui-handler.ts
+++ b/src/ui/pokedex-page-ui-handler.ts
@@ -16,7 +16,7 @@ import { pokemonFormChanges } from "#app/data/pokemon-forms";
 import type { LevelMoves } from "#app/data/balance/pokemon-level-moves";
 import { pokemonFormLevelMoves, pokemonSpeciesLevelMoves } from "#app/data/balance/pokemon-level-moves";
 import type PokemonSpecies from "#app/data/pokemon-species";
-import { allSpecies, getPokemonSpeciesForm } from "#app/data/pokemon-species";
+import { allSpecies, getPokemonSpeciesForm, normalForm } from "#app/data/pokemon-species";
 import { getStarterValueFriendshipCap, speciesStarterCosts } from "#app/data/balance/starters";
 import { starterPassiveAbilities } from "#app/data/balance/passives";
 import { Type } from "#enums/type";
@@ -2279,7 +2279,12 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
       if (isFormCaught || isFormSeen) {
         const speciesForm = getPokemonSpeciesForm(species.speciesId, formIndex!); // TODO: is the bang correct?
         this.setTypeIcons(speciesForm.type1, speciesForm.type2);
-        this.pokemonFormText.setText(species.getFormNameToDisplay(formIndex));
+        // TODO: change this once forms are refactored
+        if (normalForm.includes(species.speciesId) && !formIndex) {
+          this.pokemonFormText.setText("");
+        } else {
+          this.pokemonFormText.setText(species.getFormNameToDisplay(formIndex));
+        }
         this.pokemonFormText.setVisible(true);
         if (!isFormCaught) {
           this.pokemonFormText.setY(18);

--- a/src/ui/pokedex-page-ui-handler.ts
+++ b/src/ui/pokedex-page-ui-handler.ts
@@ -1532,6 +1532,7 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
                 this.pokemonShinyIcon.setVisible(true);
 
                 starterAttributes.shiny = true;
+                this.savedStarterAttributes.shiny = starterAttributes.shiny;
               } else {
                 let newVariant = props.variant;
                 do {

--- a/src/ui/pokedex-page-ui-handler.ts
+++ b/src/ui/pokedex-page-ui-handler.ts
@@ -383,7 +383,7 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
     this.pokemonHatchedIcon.setScale(0.8);
     this.pokemonCaughtHatchedContainer.add(this.pokemonHatchedIcon);
 
-    this.pokemonShinyIcon = globalScene.add.sprite(14, 76, "shiny_icons");
+    this.pokemonShinyIcon = globalScene.add.sprite(14, 117, "shiny_icons");
     this.pokemonShinyIcon.setOrigin(0.15, 0.2);
     this.pokemonShinyIcon.setScale(1);
     this.pokemonCaughtHatchedContainer.add(this.pokemonShinyIcon);
@@ -2240,13 +2240,11 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
         this.pokemonCandyContainer.setVisible(true);
 
         if (pokemonPrevolutions.hasOwnProperty(species.speciesId)) {
-          this.pokemonShinyIcon.setY(135);
           this.pokemonShinyIcon.setFrame(getVariantIcon(variant));
           this.pokemonHatchedIcon.setVisible(false);
           this.pokemonHatchedCountText.setVisible(false);
           this.pokemonFormText.setY(36);
         } else {
-          this.pokemonShinyIcon.setY(117);
           this.pokemonHatchedIcon.setVisible(true);
           this.pokemonHatchedCountText.setVisible(true);
           this.pokemonFormText.setY(42);

--- a/src/ui/pokedex-page-ui-handler.ts
+++ b/src/ui/pokedex-page-ui-handler.ts
@@ -601,7 +601,7 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
       const form = species.forms[formIndex];
 
       // If this form has a specific set of moves, we get them.
-      this.levelMoves = (formIndex > 0 && pokemonFormLevelMoves.hasOwnProperty(formIndex)) ? pokemonFormLevelMoves[species.speciesId][formIndex] : pokemonSpeciesLevelMoves[species.speciesId];
+      this.levelMoves = (formIndex > 0 && pokemonFormLevelMoves.hasOwnProperty(species.speciesId)) ? pokemonFormLevelMoves[species.speciesId][formIndex] : pokemonSpeciesLevelMoves[species.speciesId];
       this.ability1 = form.ability1;
       this.ability2 = (form.ability2 === form.ability1) ? undefined : form.ability2;
       this.abilityHidden = (form.abilityHidden === form.ability1) ? undefined : form.abilityHidden;

--- a/src/ui/pokedex-page-ui-handler.ts
+++ b/src/ui/pokedex-page-ui-handler.ts
@@ -601,7 +601,7 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
       const form = species.forms[formIndex];
 
       // If this form has a specific set of moves, we get them.
-      this.levelMoves = (formIndex > 0 && pokemonFormLevelMoves.hasOwnProperty(species.speciesId)) ? pokemonFormLevelMoves[species.speciesId][formIndex] : pokemonSpeciesLevelMoves[species.speciesId];
+      this.levelMoves = (formIndex > 0 && pokemonFormLevelMoves.hasOwnProperty(species.speciesId) && pokemonFormLevelMoves[species.speciesId].hasOwnProperty(formIndex)) ? pokemonFormLevelMoves[species.speciesId][formIndex] : pokemonSpeciesLevelMoves[species.speciesId];
       this.ability1 = form.ability1;
       this.ability2 = (form.ability2 === form.ability1) ? undefined : form.ability2;
       this.abilityHidden = (form.abilityHidden === form.ability1) ? undefined : form.abilityHidden;
@@ -1856,6 +1856,9 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
         if (this.canCycleGender) {
           this.updateButtonIcon(SettingKeyboard.Button_Cycle_Gender, gamepadType, this.genderIconElement, this.genderLabel);
         }
+      } else {
+        // Making space for "Uncaught" text
+        this.instructionRowY += 8;
       }
       if (this.canCycleForm) {
         this.updateButtonIcon(SettingKeyboard.Button_Cycle_Form, gamepadType, this.formIconElement, this.formLabel);

--- a/src/ui/pokedex-scan-ui-handler.ts
+++ b/src/ui/pokedex-scan-ui-handler.ts
@@ -169,7 +169,8 @@ export default class PokedexScanUiHandler extends FormModalUiHandler {
       this.submitAction = (_) => {
         if (ui.getMode() === Mode.POKEDEX_SCAN) {
           this.sanitizeInputs();
-          const sanitizedName = btoa(unescape(encodeURIComponent(this.inputs[0].text)));
+          const outputName = this.reducedKeys.includes(this.inputs[0].text) ? this.inputs[0].text : "";
+          const sanitizedName = btoa(unescape(encodeURIComponent(outputName)));
           config.buttonActions[0](sanitizedName);
           return true;
         }

--- a/src/ui/pokedex-scan-ui-handler.ts
+++ b/src/ui/pokedex-scan-ui-handler.ts
@@ -115,6 +115,10 @@ export default class PokedexScanUiHandler extends FormModalUiHandler {
 
     this.reduceKeys();
 
+    setTimeout(() => {
+      input.setFocus(); // Focus after a short delay to avoid unwanted input
+    }, 50);
+
     input.on("keydown", (inputObject, evt: KeyboardEvent) => {
       if ([ "escape", "space" ].some((v) => v === evt.key.toLowerCase() || v === evt.code.toLowerCase()) && ui.getMode() === Mode.AUTO_COMPLETE) {
         // Delete autocomplete list and recovery focus.

--- a/src/ui/pokedex-ui-handler.ts
+++ b/src/ui/pokedex-ui-handler.ts
@@ -1255,7 +1255,9 @@ export default class PokedexUiHandler extends MessageUiHandler {
 
       // First, ensure you have the caught attributes for the species else default to bigint 0
       // TODO: This might be removed depending on how accessible we want the pokedex function to be
-      const caughtAttr = (globalScene.gameData.dexData[container.species.speciesId]?.caughtAttr || BigInt(0)) & container.species.getFullUnlocksData();
+      const caughtAttr = (globalScene.gameData.dexData[container.species.speciesId]?.caughtAttr || BigInt(0)) &
+        (globalScene.gameData.dexData[this.getStarterSpeciesId(container.species.speciesId)]?.caughtAttr || BigInt(0)) &
+        container.species.getFullUnlocksData();
       const starterData = globalScene.gameData.starterData[starterId];
       const isStarterProgressable = speciesEggMoves.hasOwnProperty(starterId);
 
@@ -1580,7 +1582,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
           }
 
           const speciesId = container.species.speciesId;
-          const caughtAttr = globalScene.gameData.dexData[speciesId].caughtAttr & container.species.getFullUnlocksData();
+          const caughtAttr = globalScene.gameData.dexData[speciesId].caughtAttr & globalScene.gameData.dexData[this.getStarterSpeciesId(speciesId)].caughtAttr & container.species.getFullUnlocksData();
           this.updateStarterValueLabel(container);
 
           container.label.setVisible(true);
@@ -1901,7 +1903,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
 
     if (species) {
       const dexEntry = globalScene.gameData.dexData[species.speciesId];
-      const caughtAttr = dexEntry.caughtAttr & species.getFullUnlocksData();
+      const caughtAttr = dexEntry.caughtAttr & globalScene.gameData.dexData[this.getStarterSpeciesId(species.speciesId)].caughtAttr & species.getFullUnlocksData();
 
       if (!caughtAttr) {
         const props = this.getSanitizedProps(globalScene.gameData.getSpeciesDexAttrProps(species, this.getCurrentDexProps(species.speciesId)));
@@ -2063,7 +2065,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
   getCurrentDexProps(speciesId: number): bigint {
     let props = 0n;
     const species = allSpecies.find(sp => sp.speciesId === speciesId);
-    const caughtAttr = globalScene.gameData.dexData[speciesId].caughtAttr & (species?.getFullUnlocksData() ?? 0n);
+    const caughtAttr = globalScene.gameData.dexData[speciesId].caughtAttr & globalScene.gameData.dexData[this.getStarterSpeciesId(speciesId)].caughtAttr & (species?.getFullUnlocksData() ?? 0n);
 
     /*  this checks the gender of the pokemon; this works by checking a) that the starter preferences for the species exist, and if so, is it female. If so, it'll add DexAttr.FEMALE to our temp props
      *  It then checks b) if the caughtAttr for the pokemon is female and NOT male - this means that the ONLY gender we've gotten is female, and we need to add DexAttr.FEMALE to our temp props

--- a/src/ui/pokedex-ui-handler.ts
+++ b/src/ui/pokedex-ui-handler.ts
@@ -411,15 +411,15 @@ export default class PokedexUiHandler extends MessageUiHandler {
     this.iconAnimHandler = new PokemonIconAnimHandler();
     this.iconAnimHandler.setup();
 
-    this.pokemonNumberText = addTextObject(6, 140, "", TextStyle.SUMMARY);
+    this.pokemonNumberText = addTextObject(6, 141, "", TextStyle.SUMMARY);
     this.pokemonNumberText.setOrigin(0, 0);
     this.starterSelectContainer.add(this.pokemonNumberText);
 
-    this.pokemonNameText = addTextObject(6, 127, "", TextStyle.SUMMARY);
+    this.pokemonNameText = addTextObject(6, 128, "", TextStyle.SUMMARY);
     this.pokemonNameText.setOrigin(0, 0);
     this.starterSelectContainer.add(this.pokemonNameText);
 
-    this.pokemonFormText = addTextObject(6, 122, "", TextStyle.PARTY, { fontSize: textSettings.instructionTextSize });
+    this.pokemonFormText = addTextObject(6, 121, "", TextStyle.PARTY, { fontSize: textSettings.instructionTextSize });
     this.pokemonFormText.setOrigin(0, 0);
     this.starterSelectContainer.add(this.pokemonFormText);
 

--- a/src/ui/pokedex-ui-handler.ts
+++ b/src/ui/pokedex-ui-handler.ts
@@ -7,7 +7,7 @@ import { speciesEggMoves } from "#app/data/balance/egg-moves";
 import { pokemonFormLevelMoves, pokemonSpeciesLevelMoves } from "#app/data/balance/pokemon-level-moves";
 import type { PokemonForm } from "#app/data/pokemon-species";
 import type PokemonSpecies from "#app/data/pokemon-species";
-import { allSpecies, getPokemonSpeciesForm, getPokerusStarters } from "#app/data/pokemon-species";
+import { allSpecies, getPokemonSpeciesForm, getPokerusStarters, normalForm } from "#app/data/pokemon-species";
 import { getStarterValueFriendshipCap, speciesStarterCosts, POKERUS_STARTER_COUNT } from "#app/data/balance/starters";
 import { catchableSpecies } from "#app/data/balance/biomes";
 import { Type } from "#enums/type";
@@ -1950,7 +1950,12 @@ export default class PokedexUiHandler extends MessageUiHandler {
       }
 
       if (isFormCaught || isFormSeen || globalScene.dexForDevs) {
-        this.pokemonFormText.setText(species.getFormNameToDisplay(formIndex, false));
+        // TODO: change this once forms are refactored
+        if (normalForm.includes(species.speciesId) && !formIndex) {
+          this.pokemonFormText.setText("");
+        } else {
+          this.pokemonFormText.setText(species.getFormNameToDisplay(formIndex, false));
+        }
       } else {
         this.pokemonFormText.setText("");
       }

--- a/src/ui/pokedex-ui-handler.ts
+++ b/src/ui/pokedex-ui-handler.ts
@@ -1866,6 +1866,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
     } else {
       this.pokemonNumberText.setText(species ? i18next.t("pokedexUiHandler:pokemonNumber") + padInt(species.speciesId, 4) : "");
       this.pokemonNameText.setText(species ? "???" : "");
+      this.pokemonFormText.setText("");
       this.type1Icon.setVisible(false);
       this.type2Icon.setVisible(false);
       if (species) {

--- a/src/ui/pokedex-ui-handler.ts
+++ b/src/ui/pokedex-ui-handler.ts
@@ -1292,7 +1292,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
       if (fitsEggMove1 && !fitsLevelMove1) {
         container.eggMove1Icon.setVisible(true);
         const em1 = eggMoves.findIndex(name => name === selectedMove1);
-        if ((starterData[starterId].eggMoves & (1 << em1)) === 0) {
+        if ((starterData.eggMoves & (1 << em1)) === 0) {
           container.eggMove1Icon.setTint(0x808080);
         } else {
           container.eggMove1Icon.clearTint();
@@ -1303,7 +1303,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
       if (fitsEggMove2 && !fitsLevelMove2) {
         container.eggMove2Icon.setVisible(true);
         const em2 = eggMoves.findIndex(name => name === selectedMove2);
-        if ((starterData[starterId].eggMoves & (1 << em2)) === 0) {
+        if ((starterData.eggMoves & (1 << em2)) === 0) {
           container.eggMove2Icon.setTint(0x808080);
         } else {
           container.eggMove2Icon.clearTint();


### PR DESCRIPTION
## What are the changes the user will see?

Important bug fixes:
- A game-breaking bug that allowed to buy eggs of evolved species from the dex has been fixed.
- Move filters work properly, without crashing when finding egg moves
- Level up moves are displayed correctly for alternate forms
- In case that a save has unobtainable unlocks for evolutions, they are filtered out.

UI/UX fixes:
- The Pokédex buttons now show up as expected on the mobile touchpad
- The filter text now only allow values that can be selected (pokémon, move or ability names) and other selections simply return the default "---".
- When opening a filter text, the cursor goes to the input text without requiring a mouse click.
- Shinyness is maintained when turning pages (this had broken when changing the function of the shiny button).

Visual fixes:
- Fixed a visual bug where the "form cycle" button overlapped the "uncaught" button for uncaught form of a caught species
- The form text is now hidden when switching to filters
- Forms that are labeled "Normal" now don't show form text. This is especially relevant for evolutions (Raichu, Vaporeon...) and Marshadow who does not have an alternate form in the game.
- The form text, name text and number have been slightly displaced to avoid overlap in localized text.


## Changes from a developer perspective

Most fixes are only one or a few lines of code. The most extensive commit is the one which adds a `getFullUnlocksData()` method to `PokemonSpecies`: this returns what the `caughtAttr` bigint would be for that mon if it had all obtainable unlocks (shiny variants and genders). This is used in various places in the dex to ensure that illegal variants are not displayed even for old or corrupted savefiles.


## Screenshots/Videos

Filter working properly for egg moves:
![bouncy](https://github.com/user-attachments/assets/d4f7d014-94e9-4037-a589-95cfd3d03634)

Level up moves are correct for alternate forms:
![pika0](https://github.com/user-attachments/assets/04180b5f-7956-4fba-9451-1b37cb2aefec)
![pika1](https://github.com/user-attachments/assets/cb724531-4d4e-4844-bb91-addf96a85587)

No overlap between uncaught and form cycle button
![vivi](https://github.com/user-attachments/assets/482bbc57-fd35-4f6e-851f-843f00d322cf)


## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
- [x] Have I provided screenshots/videos of the changes (if applicable)?