### PR TITLE
[Ability][Bug] Remove `partial` designation from Quark Drive and Protosynthesis

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -6285,15 +6285,13 @@ export function initAbilities() {
       .attr(PostWeatherChangeAddBattlerTagAttr, BattlerTagType.PROTOSYNTHESIS, 0, WeatherType.SUNNY, WeatherType.HARSH_SUN)
       .attr(UncopiableAbilityAbAttr)
       .attr(UnswappableAbilityAbAttr)
-      .attr(NoTransformAbilityAbAttr)
-      .partial(), // While setting the tag, the getbattlestat should ignore all modifiers to stats except stat stages
+      .attr(NoTransformAbilityAbAttr),
     new Ability(Abilities.QUARK_DRIVE, 9)
       .conditionalAttr(getTerrainCondition(TerrainType.ELECTRIC), PostSummonAddBattlerTagAbAttr, BattlerTagType.QUARK_DRIVE, 0, true)
       .attr(PostTerrainChangeAddBattlerTagAttr, BattlerTagType.QUARK_DRIVE, 0, TerrainType.ELECTRIC)
       .attr(UncopiableAbilityAbAttr)
       .attr(UnswappableAbilityAbAttr)
-      .attr(NoTransformAbilityAbAttr)
-      .partial(), // While setting the tag, the getbattlestat should ignore all modifiers to stats except stat stages
+      .attr(NoTransformAbilityAbAttr),
     new Ability(Abilities.GOOD_AS_GOLD, 9)
       .attr(MoveImmunityAbAttr, (pokemon, attacker, move) => pokemon !== attacker && move.category === MoveCategory.STATUS && ![ MoveTarget.ENEMY_SIDE, MoveTarget.BOTH_SIDES, MoveTarget.USER_SIDE ].includes(move.moveTarget))
       .ignorable(),


### PR DESCRIPTION
## What are the changes the user will see?
The ( P ) designation is now removed from Quark Drive and Protosynthesis, as #5254 was merged.
There are no GitHub issues mentioning Quark Drive or Prosoynthesis to warrant the (P) designation staying.

## Why am I making these changes?
The more things without the (P)  and (N) designations, the better. It makes the game feel more complete.

## What are the changes from a developer perspective?
Remove `.partial()` in `src/data/moves.ts` from Quark Drive and Protosynthesis.

## Screenshots/Videos
<details><summary>before</summary>

![image](https://github.com/user-attachments/assets/7e6ac650-3f01-4985-a544-c7e1d3b8493f)
</details>
<details><summary>after</summary>

![image](https://github.com/user-attachments/assets/c52d2b0f-56ef-4e5c-a7ef-60b6cfd048f3)
</details>

## How to test the changes?
Look at a mon with quark drive and observe that it no longer has (P) on it.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~

~~Are there any localization additions or changes? If so:~~
- ~~[ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?~~
  - ~~[ ] If so, please leave a link to it here:~~
- ~~[ ] Has the translation team been contacted for proofreading/translation?~~