### PR TITLE
[Bug][UI/UX] Setting proper labels in cost reduction dropdown filter

### DIFF
--- a/src/ui/pokedex-ui-handler.ts
+++ b/src/ui/pokedex-ui-handler.ts
@@ -336,6 +336,8 @@ export default class PokedexUiHandler extends MessageUiHandler {
     const costReductionLabels = [
       new DropDownLabel(i18next.t("filterBar:costReduction"), undefined, DropDownState.OFF),
       new DropDownLabel(i18next.t("filterBar:costReductionUnlocked"), undefined, DropDownState.ON),
+      new DropDownLabel(i18next.t("filterBar:costReductionUnlockedOne"), undefined, DropDownState.ONE),
+      new DropDownLabel(i18next.t("filterBar:costReductionUnlockedTwo"), undefined, DropDownState.TWO),
       new DropDownLabel(i18next.t("filterBar:costReductionUnlockable"), undefined, DropDownState.UNLOCKABLE),
       new DropDownLabel(i18next.t("filterBar:costReductionLocked"), undefined, DropDownState.EXCLUDE),
     ];


### PR DESCRIPTION
## What are the changes the user will see?
Cost reduction filter in the dex works the same as in the starter selection screen.

## Why am I making these changes?
The filter had been implemented, but the labels in the dropdown had not been updated accordingly, meaning that two options could not be selected.

## What are the changes from a developer perspective?
Added missing label entried to the dropdown. The entries are already in the starter select screen so no locales changes are needed.

## Screenshots/Videos
https://github.com/user-attachments/assets/e29e2ba7-a663-4e5b-be64-cdbd0cc0d902



## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
- [x] Have I provided screenshots/videos of the changes (if applicable)?