### PR TITLE
[Bug][Hotfix] Display caught forms in dex as intended

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pokemon-rogue-battle",
-	"version": "1.6.0",
+	"version": "1.6.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pokemon-rogue-battle",
 	"private": true,
-	"version": "1.6.0",
+	"version": "1.6.1",
 	"type": "module",
 	"scripts": {
 		"start": "vite",

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -1051,7 +1051,11 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
       caughtAttr += DexAttr.VARIANT_2;
       caughtAttr += DexAttr.VARIANT_3;
     }
-    caughtAttr += DexAttr.DEFAULT_FORM;
+
+    // Summing successive bigints for each obtainable form
+    caughtAttr += this.forms
+      .map((f, index) => f.isUnobtainable ? 0n : 128n * 2n ** BigInt(index))
+      .reduce((acc, val) => acc + val, 0n);
 
     return caughtAttr;
   }


### PR DESCRIPTION
## What are the changes the user will see?
All caught forms are displayed and their data can be accessed.

## Why am I making these changes?
There was a bug where all forms except the default one would be marked as uncaught. This is now fixed.

## What are the changes from a developer perspective?
The `getFullUnlocksData` function (introduced to filter out impossible unlocks from old save data) was not taking into account the contribution to the `DexAttr.caughtData` bigint from caught forms. This is fixed by looping over forms and adding incremental contributions.

## Screenshots/Videos
Showing that forms are displayed properly with the hotfix:
![vivis](https://github.com/user-attachments/assets/0f80ed6e-bfbe-4dd1-a215-6b0dbdb2decf)
![unowns](https://github.com/user-attachments/assets/8c7fc21d-33e6-40f5-88df-9672c08efdd5)
![pikacool](https://github.com/user-attachments/assets/9809e8c3-4b78-4902-8a69-bfd87d0dd9e4)
![pikas](https://github.com/user-attachments/assets/3e2bf2df-17b8-4967-aafb-fd966e39ebcb)
