### PR TITLE
[Bug][Hotfix] Show caught pokemon correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pokemon-rogue-battle",
-	"version": "1.6.1",
+	"version": "1.6.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pokemon-rogue-battle",
 	"private": true,
-	"version": "1.6.1",
+	"version": "1.6.2",
 	"type": "module",
 	"scripts": {
 		"start": "vite",

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -1053,9 +1053,9 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
     }
 
     // Summing successive bigints for each obtainable form
-    caughtAttr += this.forms
-      .map((f, index) => f.isUnobtainable ? 0n : 128n * 2n ** BigInt(index))
-      .reduce((acc, val) => acc + val, 0n);
+    caughtAttr += this?.forms?.length > 1 ?
+      this.forms.map((f, index) => f.isUnobtainable ? 0n : 128n * 2n ** BigInt(index)).reduce((acc, val) => acc + val, 0n) :
+      DexAttr.DEFAULT_FORM;
 
     return caughtAttr;
   }


### PR DESCRIPTION
Previous hotfix accidentally made all Pokémon without forms show up as uncaught.

This is now fixed by adding the default form to `caughtAttr` again when there are no forms.

