### PR TITLE
[Bug][Hotfix] Fix fusion with dual type + monotype with shared primary type.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pokemon-rogue-battle",
-	"version": "1.6.2",
+	"version": "1.6.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pokemon-rogue-battle",
-			"version": "1.5.4",
+			"version": "1.6.3",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@material/material-color-utilities": "^0.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pokemon-rogue-battle",
 	"private": true,
-	"version": "1.6.2",
+	"version": "1.6.3",
 	"type": "module",
 	"scripts": {
 		"start": "vite",

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1322,6 +1322,12 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
           } else if (fusionType1 !== types[0]) {
             secondType = fusionType1;
           }
+
+
+          if (secondType === Type.UNKNOWN && Utils.isNullOrUndefined(fusionType2)) { // If second pokemon was monotype and shared its primary type
+            secondType = (customTypes && this.customPokemonData.types.length > 1 && this.customPokemonData.types[1] !== Type.UNKNOWN)
+              ? this.customPokemonData.types[1] : (speciesForm.type2 ?? Type.UNKNOWN);
+          }
         } else {
           // If not a fusion, just get the second type from the species, checking for permanent changes from ME
           secondType = (customTypes && this.customPokemonData.types.length > 1 && this.customPokemonData.types[1] !== Type.UNKNOWN)

--- a/src/test/field/pokemon.test.ts
+++ b/src/test/field/pokemon.test.ts
@@ -150,6 +150,17 @@ describe("Spec - Pokemon", () => {
       expect(types[1]).toBe(Type.DARK);
     });
 
+    it("Fusing mons with two and one types", async () => {
+      game.override.starterSpecies(Species.NUMEL);
+      game.override.starterFusionSpecies(Species.CHARMANDER);
+      await game.classicMode.startBattle();
+      const pokemon = scene.getPlayerParty()[0];
+
+      const types = pokemon.getTypes();
+      expect(types[0]).toBe(Type.FIRE);
+      expect(types[1]).toBe(Type.GROUND);
+    });
+
     it("Fusing two mons with two types", async () => {
       game.override.starterSpecies(Species.NATU);
       game.override.starterFusionSpecies(Species.HOUNDOUR);


### PR DESCRIPTION
## What are the changes the user will see?
Fusions work as normal again, allowing dual type + monotype with shared primary type to use the first pokemons dual typing.

## Why am I making these changes?
#5229 accidentally broke this.

## What are the changes from a developer perspective?

## Screenshots/Videos
![image](https://github.com/user-attachments/assets/405f79c1-758e-475e-a496-0a606b85781f)

## How to test the changes?
Fuse something like pidgey + rattata.

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?