### PR TITLE
[Ability] Flower Veil implementation

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -3204,6 +3204,7 @@ export class ConfusionOnStatusEffectAbAttr extends PostAttackAbAttr {
 }
 
 export class PreSetStatusAbAttr extends AbAttr {
+  /** Return whether the ability attribute can be applied */
   canApplyPreSetStatus(
     pokemon: Pokemon,
     passive: boolean,
@@ -3228,7 +3229,7 @@ export class PreSetStatusAbAttr extends AbAttr {
  * Provides immunity to status effects to specified targets.
  */
 export class PreSetStatusEffectImmunityAbAttr extends PreSetStatusAbAttr {
-  private immuneEffects: StatusEffect[];
+  protected immuneEffects: StatusEffect[];
 
   /**
    * @param immuneEffects - The status effects to which the Pokémon is immune.
@@ -3239,6 +3240,7 @@ export class PreSetStatusEffectImmunityAbAttr extends PreSetStatusAbAttr {
     this.immuneEffects = immuneEffects;
   }
 
+  /** Determine whether the  */
   override canApplyPreSetStatus(pokemon: Pokemon, passive: boolean, simulated: boolean, effect: StatusEffect, cancelled: Utils.BooleanHolder, args: any[]): boolean {
     return effect !== StatusEffect.FAINT && this.immuneEffects.length < 1 || this.immuneEffects.includes(effect);
   }
@@ -3290,20 +3292,80 @@ export class UserFieldStatusEffectImmunityAbAttr extends PreSetStatusEffectImmun
  *
  */
 export class ConditionalUserFieldStatusEffectImmunityAbAttr extends UserFieldStatusEffectImmunityAbAttr {
+  /**
+   * The condition for the field immunity to be applied.
+   * @param target The target of the status effect
+   * @param source The source of the status effect
+   */
   protected condition: (target: Pokemon, source: Pokemon | null) => boolean;
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): boolean {
-    if (cancelled.value || !this.condition(pokemon, args[1] as Pokemon)) {
-      return false;
-    }
-
-    return super.apply(pokemon, passive, simulated, cancelled, args);
+  /**
+   * Evaluate the condition to determine if the {@linkcode ConditionalUserFieldStatusEffectImmunityAbAttr} can be applied.
+   * @param pokemon The pokemon with the ability
+   * @param passive unused
+   * @param simulated Whether the ability is being simulated
+   * @param effect The status effect being applied
+   * @param cancelled Holds whether the status effect was cancelled by a prior effect
+   * @param args `Args[0]` is the target of the status effect, `Args[1]` is the source.
+   * @returns 
+   */
+  override canApplyPreSetStatus(pokemon: Pokemon, passive: boolean, simulated: boolean, effect: StatusEffect, cancelled: Utils.BooleanHolder, args: [Pokemon, Pokemon | null, ...any]): boolean {
+    return (!cancelled.value && effect !== StatusEffect.FAINT && this.immuneEffects.length < 1 || this.immuneEffects.includes(effect)) && this.condition(pokemon, args[1]);
   }
 
   constructor(condition: (target: Pokemon, source: Pokemon | null) => boolean, ...immuneEffects: StatusEffect[]) {
     super(...immuneEffects);
 
     this.condition = condition;
+  }
+}
+
+/**
+ * Conditionally provides immunity to stat drop effects to the user's field.
+ * 
+ * Used by {@linkcode Abilities.FLOWER_VEIL | Flower Veil}.
+ */
+export class ConditionalUserFieldProtectStatAbAttr extends PreStatStageChangeAbAttr {
+  /** {@linkcode BattleStat} to protect or `undefined` if **all** {@linkcode BattleStat} are protected */
+  protected protectedStat?: BattleStat;
+  
+  /** If the method evaluates to true, the stat will be protected. */
+  protected condition: (target: Pokemon) => boolean;
+
+  constructor(condition: (target: Pokemon) => boolean, protectedStat?: BattleStat) {
+    super();
+    this.condition = condition;
+  }
+
+  /**
+   * Determine whether the {@linkcode ConditionalUserFieldProtectStatAbAttr} can be applied.
+   * @param pokemon The pokemon with the ability
+   * @param passive unused
+   * @param simulated Unused
+   * @param stat The stat being affected
+   * @param cancelled Holds whether the stat change was already prevented.
+   * @param args Args[0] is the target pokemon of the stat change.
+   * @returns 
+   */
+  override canApplyPreStatStageChange(pokemon: Pokemon, passive: boolean, simulated: boolean, stat: BattleStat, cancelled: Utils.BooleanHolder, args: [Pokemon, ...any]): boolean {
+    const target = args[0];
+    if (!target) {
+      return false;
+    }
+    return !cancelled.value && (Utils.isNullOrUndefined(this.protectedStat) || stat === this.protectedStat) && this.condition(target);
+  }
+
+  /**
+   * Apply the {@linkcode ConditionalUserFieldStatusEffectImmunityAbAttr} to an interaction
+   * @param _pokemon The pokemon the stat change is affecting (unused)
+   * @param _passive unused
+   * @param _simulated unused
+   * @param stat The stat being affected
+   * @param cancelled Will be set to true if the stat change is prevented
+   * @param _args unused
+   */
+  override applyPreStatStageChange(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _stat: BattleStat, cancelled: Utils.BooleanHolder, _args: any[]): void {
+    cancelled.value = true;
   }
 }
 
@@ -3377,7 +3439,7 @@ export class UserFieldBattlerTagImmunityAbAttr extends PreApplyBattlerTagImmunit
 export class ConditionalUserFieldBattlerTagImmunityAbAttr extends UserFieldBattlerTagImmunityAbAttr {
   private condition: (target: Pokemon, source: Pokemon | null) => boolean;
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): boolean {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]) {
     if (cancelled.value || !this.condition(pokemon, args[1] as Pokemon)) {
       return false;
     }
@@ -5900,19 +5962,20 @@ export function applyPreLeaveFieldAbAttrs(
   );
 }
 
-export function applyPreStatStageChangeAbAttrs(
-  attrType: Constructor<PreStatStageChangeAbAttr>,
+export function applyPreStatStageChangeAbAttrs<T extends PreStatStageChangeAbAttr > (
+  attrType: Constructor<T>,
   pokemon: Pokemon | null,
   stat: BattleStat,
   cancelled: Utils.BooleanHolder,
   simulated = false,
   ...args: any[]
 ): void {
-  applyAbAttrsInternal<PreStatStageChangeAbAttr>(
+  applyAbAttrsInternal<T>(
     attrType,
     pokemon,
     (attr, passive) => attr.applyPreStatStageChange(pokemon, passive, simulated, stat, cancelled, args),
-    (attr, passive) => attr.canApplyPreStatStageChange(pokemon, passive, simulated, stat, cancelled, args), args,
+    (attr, passive) => attr.canApplyPreStatStageChange(pokemon, passive, simulated, stat, cancelled, args),
+    args,
     simulated,
   );
 }
@@ -6715,17 +6778,19 @@ export function initAbilities() {
       .ignorable(),
     new Ability(Abilities.FLOWER_VEIL, 6)
       .attr(ConditionalUserFieldStatusEffectImmunityAbAttr, (target: Pokemon, source: Pokemon | null) => {
-        return source ? target.getTypes().includes(Type.GRASS) && target.id !== source.id : false;
+        return source ? target.getTypes().includes(PokemonType.GRASS) && target.id !== source.id : false;
       })
       .attr(ConditionalUserFieldBattlerTagImmunityAbAttr,
         (target: Pokemon, source: Pokemon | null) => {
-          return source ? target.getTypes().includes(Type.GRASS) && target.id !== source.id : false;
+          return target.getTypes().includes(PokemonType.GRASS);
         },
         [ BattlerTagType.DROWSY ],
-
       )
-      .ignorable()
-      .unimplemented(),
+      .attr(ConditionalUserFieldProtectStatAbAttr, (target: Pokemon) => {
+        console.log(`target: ${target.name}`);
+        return target.getTypes().includes(PokemonType.GRASS);
+      })
+      .ignorable(),
     new Ability(Abilities.CHEEK_POUCH, 6)
       .attr(HealFromBerryUseAbAttr, 1 / 3),
     new Ability(Abilities.PROTEAN, 6)

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -3292,7 +3292,7 @@ export class UserFieldStatusEffectImmunityAbAttr extends PreSetStatusEffectImmun
 export class ConditionalUserFieldStatusEffectImmunityAbAttr extends UserFieldStatusEffectImmunityAbAttr {
   protected condition: (target: Pokemon, source: Pokemon | null) => boolean;
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): boolean | Promise<boolean> {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): boolean {
     if (cancelled.value || !this.condition(pokemon, args[1] as Pokemon)) {
       return false;
     }
@@ -3377,7 +3377,7 @@ export class UserFieldBattlerTagImmunityAbAttr extends PreApplyBattlerTagImmunit
 export class ConditionalUserFieldBattlerTagImmunityAbAttr extends UserFieldBattlerTagImmunityAbAttr {
   private condition: (target: Pokemon, source: Pokemon | null) => boolean;
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): boolean | Promise<boolean> {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): boolean {
     if (cancelled.value || !this.condition(pokemon, args[1] as Pokemon)) {
       return false;
     }

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -3240,7 +3240,6 @@ export class PreSetStatusEffectImmunityAbAttr extends PreSetStatusAbAttr {
     this.immuneEffects = immuneEffects;
   }
 
-  /** Determine whether the  */
   override canApplyPreSetStatus(pokemon: Pokemon, passive: boolean, simulated: boolean, effect: StatusEffect, cancelled: Utils.BooleanHolder, args: any[]): boolean {
     return effect !== StatusEffect.FAINT && this.immuneEffects.length < 1 || this.immuneEffects.includes(effect);
   }
@@ -3307,7 +3306,7 @@ export class ConditionalUserFieldStatusEffectImmunityAbAttr extends UserFieldSta
    * @param effect The status effect being applied
    * @param cancelled Holds whether the status effect was cancelled by a prior effect
    * @param args `Args[0]` is the target of the status effect, `Args[1]` is the source.
-   * @returns 
+   * @returns Whether the ability can be applied to cancel the status effect.
    */
   override canApplyPreSetStatus(pokemon: Pokemon, passive: boolean, simulated: boolean, effect: StatusEffect, cancelled: Utils.BooleanHolder, args: [Pokemon, Pokemon | null, ...any]): boolean {
     return (!cancelled.value && effect !== StatusEffect.FAINT && this.immuneEffects.length < 1 || this.immuneEffects.includes(effect)) && this.condition(args[0], args[1]);
@@ -3441,13 +3440,13 @@ export class ConditionalUserFieldBattlerTagImmunityAbAttr extends UserFieldBattl
 
   /**
    * Determine whether the {@linkcode ConditionalUserFieldBattlerTagImmunityAbAttr} can be applied by passing the target pokemon to the condition.
-   * @param pokemon 
-   * @param passive 
-   * @param simulated 
-   * @param tag 
-   * @param cancelled 
-   * @param args 
-   * @returns 
+   * @param pokemon The pokemon owning the ability
+   * @param passive unused
+   * @param simulated whether the ability is being simulated (unused)
+   * @param tag The {@linkcode BattlerTag} being applied
+   * @param cancelled Holds whether the tag was previously cancelled (unused)
+   * @param args Args[0] is the target that the tag is attempting to be applied to
+   * @returns Whether the ability can be used to cancel the battler tag
    */
   override canApplyPreApplyBattlerTag(pokemon: Pokemon, passive: boolean, simulated: boolean, tag: BattlerTag, cancelled: Utils.BooleanHolder, args: [Pokemon, ...any]): boolean {
     return super.canApplyPreApplyBattlerTag(pokemon, passive, simulated, tag, cancelled, args) && this.condition(args[0]);

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -3450,7 +3450,6 @@ export class ConditionalUserFieldBattlerTagImmunityAbAttr extends UserFieldBattl
    * @returns 
    */
   override canApplyPreApplyBattlerTag(pokemon: Pokemon, passive: boolean, simulated: boolean, tag: BattlerTag, cancelled: Utils.BooleanHolder, args: [Pokemon, ...any]): boolean {
-    console.log("==========Checking if we can apply the tag to " + args[0]?.name);
     return super.canApplyPreApplyBattlerTag(pokemon, passive, simulated, tag, cancelled, args) && this.condition(args[0]);
   }
 

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -12,7 +12,6 @@ import { StatusEffect } from "#enums/status-effect";
 import type { BattlerIndex } from "#app/battle";
 import {
   BlockNonDirectDamageAbAttr,
-  ConditionalUserFieldProtectStatAbAttr,
   InfiltratorAbAttr,
   PreLeaveFieldRemoveSuppressAbilitiesSourceAbAttr,
   ProtectStatAbAttr,

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -12,6 +12,7 @@ import { StatusEffect } from "#enums/status-effect";
 import type { BattlerIndex } from "#app/battle";
 import {
   BlockNonDirectDamageAbAttr,
+  ConditionalUserFieldProtectStatAbAttr,
   InfiltratorAbAttr,
   PreLeaveFieldRemoveSuppressAbilitiesSourceAbAttr,
   ProtectStatAbAttr,

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -5,6 +5,7 @@ import {
   BlockNonDirectDamageAbAttr,
   FlinchEffectAbAttr,
   ProtectStatAbAttr,
+  ConditionalUserFieldProtectStatAbAttr,
   ReverseDrainAbAttr,
 } from "#app/data/ability";
 import { ChargeAnim, CommonAnim, CommonBattleAnim, MoveChargeAnim } from "#app/data/battle-anims";
@@ -3024,6 +3025,7 @@ export class MysteryEncounterPostSummonTag extends BattlerTag {
     if (lapseType === BattlerTagLapseType.CUSTOM) {
       const cancelled = new BooleanHolder(false);
       applyAbAttrs(ProtectStatAbAttr, pokemon, cancelled);
+      applyAbAttrs(ConditionalUserFieldProtectStatAbAttr, pokemon, cancelled, false, pokemon);
       if (!cancelled.value) {
         if (pokemon.mysteryEncounterBattleEffects) {
           pokemon.mysteryEncounterBattleEffects(pokemon);

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -8692,7 +8692,7 @@ export function initMoves() {
     new SelfStatusMove(Moves.REST, PokemonType.PSYCHIC, -1, 5, -1, 0, 1)
       .attr(StatusEffectAttr, StatusEffect.SLEEP, true, 3, true)
       .attr(HealAttr, 1, true)
-      .condition((user, target, move) => !user.isFullHp() && user.canSetStatus(StatusEffect.SLEEP, true, true))
+      .condition((user, target, move) => !user.isFullHp() && user.canSetStatus(StatusEffect.SLEEP, true, true, user))
       .triageMove(),
     new AttackMove(Moves.ROCK_SLIDE, PokemonType.ROCK, MoveCategory.PHYSICAL, 75, 90, 10, 30, 0, 1)
       .attr(FlinchAttr)

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4766,6 +4766,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         stubTag,
         cancelled,
         true,
+        this,
       ),
     );
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4794,18 +4794,25 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       newTag,
       cancelled,
     );
+    if (cancelled.value) {
+      return false;
+    }
 
-    const userField = this.getAlliedField();
-    userField.forEach(pokemon =>
+    for (const pokemon of this.getAlliedField()) {
       applyPreApplyBattlerTagAbAttrs(
         UserFieldBattlerTagImmunityAbAttr,
         pokemon,
         newTag,
         cancelled,
-      ),
-    );
+        false,
+        this
+      );
+      if (cancelled.value) {
+        return false;
+      }
+    }
 
-    if (!cancelled.value && newTag.canAdd(this)) {
+    if (newTag.canAdd(this)) {
       this.summonData.tags.push(newTag);
       newTag.onAdd(this);
 
@@ -5449,17 +5456,22 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       cancelled,
       quiet,
     );
+    if (cancelled.value) {
+      return false;
+    }
 
-    const userField = this.getAlliedField();
-    userField.forEach(pokemon =>
+    for (const pokemon of this.getAlliedField()) {
       applyPreSetStatusAbAttrs(
         UserFieldStatusEffectImmunityAbAttr,
         pokemon,
         effect,
         cancelled,
         quiet, this, sourcePokemon,
-      ),
-    );
+      )
+      if (cancelled.value) {
+        break;
+      }
+    }
 
     if (cancelled.value) {
       return false;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -5456,7 +5456,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         pokemon,
         effect,
         cancelled,
-        quiet,
+        quiet, this, sourcePokemon,
       ),
     );
 

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -23,7 +23,6 @@ import { PokemonPhase } from "./pokemon-phase";
 import { Stat, type BattleStat, getStatKey, getStatStageChangeDescriptionKey } from "#enums/stat";
 import { OctolockTag } from "#app/data/battler-tags";
 import { ArenaTagType } from "#app/enums/arena-tag-type";
-import { pokemonFormChanges } from "#app/data/pokemon-forms";
 
 export type StatStageChangeCallback = (
   target: Pokemon | null,

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -4,6 +4,7 @@ import {
   applyAbAttrs,
   applyPostStatStageChangeAbAttrs,
   applyPreStatStageChangeAbAttrs,
+  ConditionalUserFieldProtectStatAbAttr,
   PostStatStageChangeAbAttr,
   ProtectStatAbAttr,
   ReflectStatStageChangeAbAttr,
@@ -22,6 +23,7 @@ import { PokemonPhase } from "./pokemon-phase";
 import { Stat, type BattleStat, getStatKey, getStatStageChangeDescriptionKey } from "#enums/stat";
 import { OctolockTag } from "#app/data/battler-tags";
 import { ArenaTagType } from "#app/enums/arena-tag-type";
+import { pokemonFormChanges } from "#app/data/pokemon-forms";
 
 export type StatStageChangeCallback = (
   target: Pokemon | null,
@@ -151,6 +153,25 @@ export class StatStageChangePhase extends PokemonPhase {
 
       if (!cancelled.value && !this.selfTarget && stages.value < 0) {
         applyPreStatStageChangeAbAttrs(ProtectStatAbAttr, pokemon, stat, cancelled, simulate);
+        applyPreStatStageChangeAbAttrs(
+          ConditionalUserFieldProtectStatAbAttr,
+          pokemon,
+          stat,
+          cancelled,
+          simulate,
+          pokemon,
+        );
+        const ally = pokemon.getAlly();
+        if (ally) {
+          applyPreStatStageChangeAbAttrs(
+            ConditionalUserFieldProtectStatAbAttr,
+            ally,
+            stat,
+            cancelled,
+            simulate,
+            pokemon,
+          );
+        }
 
         /** Potential stat reflection due to Mirror Armor, does not apply to Octolock end of turn effect */
         if (

--- a/test/abilities/flower_veil.test.ts
+++ b/test/abilities/flower_veil.test.ts
@@ -1,0 +1,86 @@
+import { BattlerIndex } from "#app/battle";
+import { modifierTypes } from "#app/modifier/modifier-type";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { Stat } from "#enums/stat";
+import { StatusEffect } from "#enums/status-effect";
+import GameManager from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Abilities - Flower Veil", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([ Moves.SPLASH ])
+      .enemySpecies(Species.BULBASAUR)
+      .ability(Abilities.FLOWER_VEIL)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH);
+  });
+
+  it("should not prevent any source of self-inflicted status conditions", async () => {
+    game.override.enemyMoveset([ Moves.TACKLE, Moves.SPLASH ])
+      .ability(Abilities.FLOWER_VEIL)
+      .moveset([ Moves.REST, Moves.SPLASH ]);
+    await game.classicMode.startBattle([ Species.BULBASAUR ]);
+    const user = game.scene.getPlayerPokemon()!;
+    game.move.select(Moves.REST);
+    await game.forceEnemyMove(Moves.TACKLE);
+    await game.setTurnOrder([ BattlerIndex.ENEMY, BattlerIndex.PLAYER ]);
+    await game.toNextTurn();
+    expect(user.status?.effect).toBe(StatusEffect.SLEEP);
+
+    game.scene.addModifier(modifierTypes.FLAME_ORB().newModifier(user));
+    game.scene.updateModifiers(true);
+    // remove sleep status
+    user.resetStatus();
+    game.move.select(Moves.SPLASH);
+    await game.forceEnemyMove(Moves.SPLASH);
+    await game.toNextTurn();
+    expect(user.status?.effect).toBe(StatusEffect.BURN);
+
+    game.scene.addModifier(modifierTypes.TOXIC_ORB().newModifier(user));
+    game.scene.updateModifiers(true);
+    user.resetStatus();
+
+  });
+
+  it("should prevent the drops while retaining the boosts from spicy extract", async () => {
+    game.override.enemyMoveset([ Moves.SPICY_EXTRACT ])
+      .moveset([ Moves.SPLASH ]);
+    await game.classicMode.startBattle([ Species.BULBASAUR ]);
+    const user = game.scene.getPlayerPokemon()!;
+    game.move.select(Moves.SPLASH);
+    await game.phaseInterceptor.to("BerryPhase");
+    expect(user.getStatStage(Stat.ATK)).toBe(2);
+    expect(user.getStatStage(Stat.DEF)).toBe(0);
+  });
+
+  it("should not prevent self-inflicted stat drops from moves like Close Combat", async () => {
+    game.override.moveset([ Moves.CLOSE_COMBAT ]);
+    await game.classicMode.startBattle([ Species.BULBASAUR ]);
+    const enemy = game.scene.getEnemyPokemon()!;
+    game.move.select(Moves.CLOSE_COMBAT);
+    await game.phaseInterceptor.to("BerryPhase");
+    expect(enemy.getStatStage(Stat.ATK)).toBe(-1);
+    expect(enemy.getStatStage(Stat.DEF)).toBe(-1);
+  });
+});

--- a/test/abilities/flower_veil.test.ts
+++ b/test/abilities/flower_veil.test.ts
@@ -76,8 +76,8 @@ describe("Abilities - Flower Veil", () => {
 
     await game.phaseInterceptor.to("BerryPhase");
     const user = game.scene.getPlayerPokemon()!;
-    expect(user.getTag(BattlerTagType.DROWSY)).toBeOneOf([false, undefined, null]);
-    expect(ally.getTag(BattlerTagType.DROWSY)).toBeOneOf([false, undefined, null]);
+    expect(user.getTag(BattlerTagType.DROWSY)).toBeFalsy();
+    expect(ally.getTag(BattlerTagType.DROWSY)).toBeFalsy();
   });
 
   it("should prevent status conditions from moves like Thunder Wave for a grass user and its grass allies", async () => {

--- a/test/abilities/flower_veil.test.ts
+++ b/test/abilities/flower_veil.test.ts
@@ -154,19 +154,6 @@ describe("Abilities - Flower Veil", () => {
     expect(ally.getStatStage(Stat.SPDEF)).toBe(-1);
   });
 
-  it("should not prevent status drops of a non-grass user or its non-grass allies", async () => {
-    game.override.enemyMoveset([Moves.GROWL]).moveset([Moves.SPLASH]).battleType("double");
-    await game.classicMode.startBattle([Species.MAGIKARP, Species.MAGIKARP]);
-    const [user, ally] = game.scene.getPlayerField();
-    // Clear the ally ability to isolate the test
-    vi.spyOn(ally, "getAbility").mockReturnValue(allAbilities[Abilities.BALL_FETCH]);
-    game.move.select(Moves.SPLASH);
-    game.move.select(Moves.SPLASH, 1);
-    await game.phaseInterceptor.to("BerryPhase");
-    expect(user.getStatStage(Stat.ATK)).toBe(-2);
-    expect(ally.getStatStage(Stat.ATK)).toBe(-2);
-  });
-
   it("should prevent the drops while retaining the boosts from spicy extract", async () => {
     game.override.enemyMoveset([Moves.SPICY_EXTRACT]).moveset([Moves.SPLASH]);
     await game.classicMode.startBattle([Species.BULBASAUR]);


### PR DESCRIPTION
## What are the changes the user will see?
Flower Veil works as it does on cartridge, and is no longer marked (N).

## Why am I making these changes?
I was commissioned by @Blitz425 

## What are the changes from a developer perspective?
Adds three new ability attributes:
`ConditionalUserFieldStatusEffectImmunityAbAttr `, `ConditionalUserFieldBattlerTagImmunityAbAttr `, and `ConditionalUserFieldProtectStatAbAttr`.

The first two ability attributes conditionally protect the user's field from status effects (or a battler tag), and are modeled off of the non-conditional methods of the same caliber (like UserFieldStatusEffectImmunityAbAttr for sweet veil).
They both take a condition function and, if the condition function returns true, will prevent the status effect immunity.

`ConditionalUserFieldProtectStatAbAttr` works much the same. The difference with this one is that the condition function can't take the source of the stat drop. For whatever reason, this logic is being handled by the stat drop, as it is always assuming that abilities that can prevent stat drops never work for self-targeted effects. ¯\_(ツ)_/¯

Adds several tests for the proper functionality.

## Screenshots/Videos

<details><summary>Status immunity, Stat drop immunity (and spicy extract boost still working) for a grass type user and its allies</summary>

https://github.com/user-attachments/assets/91d689ee-2f8b-4c91-bd6f-9d6f900e0b18
</details>

<details><summary>Properly not protecting non-grass types</summary>

https://github.com/user-attachments/assets/32244df3-b5d2-4768-9d62-b9af34badfd5
</details>

## How to test the changes?
npm run test:silent -- test/flower-veil.test.ts

For manual testing, this is the override set I use:

```ts
const overrides = {
  BATTLE_TYPE_OVERRIDE: "double",
  MOVESET_OVERRIDE: [Moves.SPLASH, Moves.THUNDER_WAVE, Moves.SPICY_EXTRACT, Moves.FORESTS_CURSE],
  OPP_ABILITY_OVERRIDE: Abilities.BALL_FETCH,
  OPP_MOVESET_OVERRIDE: [Moves.SPLASH]
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

I bring Comfey, and then I use forest's curse with the ally to set comfey to grass type (so you can see the ability working for _both_ the user and its ally.

### Extra Notes

There is an edge case with sticky web. See #5583 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~

~~Are there any localization additions or changes? If so:~~
- ~~[ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?~~
  - ~~[ ] If so, please leave a link to it here:~~
- ~~[ ] Has the translation team been contacted for proofreading/translation?~~