### PR TITLE
[Localization] Localizable Lv UP pop-up bar

### DIFF
--- a/src/ui/party-exp-bar.ts
+++ b/src/ui/party-exp-bar.ts
@@ -43,9 +43,9 @@ export default class PartyExpBar extends Phaser.GameObjects.Container {
       // if we want to only display the level in the small frame
       if (showOnlyLevelUp) {
         if (newLevel > 200) { // if the level is greater than 200, we only display Lv. UP
-          this.expText.setText("Lv. UP");
+          this.expText.setText(i18next.t("battleScene:levelUp"));
         } else { // otherwise we display Lv. Up and the new level
-          this.expText.setText(`Lv. UP: ${newLevel.toString()}`);
+          this.expText.setText(i18next.t("battleScene:levelUpWithLevel", { level: newLevel }));
         }
       } else {
         // if we want to display the exp


### PR DESCRIPTION
## What are the changes the user will see?
"Lv. UP" text in the pop-up bar when a Pokémon takes a level is now localizable

## Why am I making these changes?
To have this text localizable

## What are the changes from a developer perspective?
None

## Screenshots/Videos
BEFORE (French):
![image](https://github.com/user-attachments/assets/4c810cf4-24bc-45d0-b7d0-846ccb41d64a)

AFTER (French):
![image](https://github.com/user-attachments/assets/b3e65c91-4cd8-4659-b8fb-39d211269cd0)

## How to test the changes?
Have "Level Up Notification" enabled in the Game Settings and level up a de Pokémon

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [X] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [X] If so, please leave a link to it here: 
- [X] Has the translation team been contacted for proofreading/translation?