### PR TITLE
[Bug] Fix endless tokens allowing attacks to deal 0 damage

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -1416,7 +1416,7 @@ export class DamageBoostAbAttr extends PreAttackAbAttr {
   applyPreAttack(pokemon: Pokemon, passive: boolean, simulated: boolean, defender: Pokemon, move: Move, args: any[]): boolean {
     if (this.condition(pokemon, defender, move)) {
       const power = args[0] as Utils.NumberHolder;
-      power.value = Math.floor(power.value * this.damageMultiplier);
+      power.value = Utils.toDmgValue(power.value * this.damageMultiplier);
       return true;
     }
 

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -3426,7 +3426,7 @@ abstract class EnemyDamageMultiplierModifier extends EnemyPersistentModifier {
    * @returns always `true`
    */
   override apply(multiplier: NumberHolder): boolean {
-    multiplier.value = Math.floor(multiplier.value * Math.pow(this.damageMultiplier, this.getStackCount()));
+    multiplier.value = toDmgValue(multiplier.value * Math.pow(this.damageMultiplier, this.getStackCount()));
 
     return true;
   }

--- a/src/test/battle/damage_calculation.test.ts
+++ b/src/test/battle/damage_calculation.test.ts
@@ -1,4 +1,6 @@
 import { allMoves } from "#app/data/move";
+import type { EnemyPersistentModifier } from "#app/modifier/modifier";
+import { modifierTypes } from "#app/modifier/modifier-type";
 import { Abilities } from "#enums/abilities";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { Moves } from "#enums/moves";
@@ -62,6 +64,28 @@ describe("Battle Mechanics - Damage Calculation", () => {
     await game.phaseInterceptor.to("BerryPhase", false);
 
     // Lvl 1 0 Atk Magikarp Tackle vs. 0 HP / 0 Def Aggron: 1-1 (0.3 - 0.3%) -- possibly the worst move ever
+    expect(aggron.hp).toBe(aggron.getMaxHp() - 1);
+  });
+
+  it("Attacks deal 1 damage at minimum even with many tokens", async () => {
+    game.override
+      .startingLevel(1)
+      .enemySpecies(Species.AGGRON)
+      .enemyAbility(Abilities.STURDY)
+      .enemyLevel(10000);
+
+    await game.classicMode.startBattle([ Species.SHUCKLE ]);
+
+    const dmg_redux_modifier = modifierTypes.ENEMY_DAMAGE_REDUCTION().newModifier() as EnemyPersistentModifier;
+    dmg_redux_modifier.stackCount = 1000;
+    await game.scene.addEnemyModifier(modifierTypes.ENEMY_DAMAGE_REDUCTION().newModifier() as EnemyPersistentModifier);
+
+    const aggron = game.scene.getEnemyPokemon()!;
+
+    game.move.select(Moves.TACKLE);
+
+    await game.phaseInterceptor.to("BerryPhase", false);
+
     expect(aggron.hp).toBe(aggron.getMaxHp() - 1);
   });
 


### PR DESCRIPTION
## What are the changes the user will see?
Attacks can no longer deal 0 damage (unless they are specifically supposed to e.g. through endure).

## Why am I making these changes?
This has been requested, and balance team specifically said that tokens should not prevent attacks from doing at least 1 damage. This is also how it works in mainline games.

![image](https://github.com/user-attachments/assets/0b526de1-8da1-4346-88e0-7ab05bc94827)


**By the way** Most damage calculations actually *weren't* rounding to 0, as they were properly using the utils methd `toDmgValue` which computes the floor and min together. However, a few places were incorrectly *not* using this when they should have been, and were instead just calling `min`.

## What are the changes from a developer perspective?
In several places where damage multipliers were erroneously calculated using `Math.min`, they are now calculated using `Utils.toDmgValue`.

## Screenshots/Videos

<details><summary>Current live</summary>

https://github.com/user-attachments/assets/61935bb5-742c-4af2-a115-eb9ae10b38f0
</details>

<details><summary>With Fixes</summary>

https://github.com/user-attachments/assets/b7612270-2c48-4608-929e-5d60a92b196e
</details>

<details><summary>Endure still allows move to do 0 damage</summary>

https://github.com/user-attachments/assets/75217992-3e21-47de-bb07-b87e9bea545a
</details>

## How to test the changes?

Note, you want damage numbers to be on.

I used this configuration:
```ts
const overrides = {
  OPP_MODIFIER_OVERRIDE: [{ name: "ENEMY_DAMAGE_REDUCTION", count: 10000 }],
  BATTLE_TYPE_OVERRIDE: "single",
  STARTING_LEVEL_OVERRIDE: 1,
  OPP_LEVEL_OVERRIDE: 5,
  OPP_MOVESET_OVERRIDE: [ Moves.COTTON_GUARD ],
  MOVESET_OVERRIDE: [ Moves.TACKLE ],
  OPP_SPECIES_OVERRIDE: Species.WURMPLE
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

For the endure regression test, use this:
```ts
const overrides = {
  BATTLE_TYPE_OVERRIDE: "single",
  STARTING_LEVEL_OVERRIDE: 1000,
  OPP_LEVEL_OVERRIDE: 1,
  OPP_MOVESET_OVERRIDE: [ Moves.ENDURE ],
  MOVESET_OVERRIDE: [ Moves.TACKLE, Moves.SPLASH ],
  OPP_SPECIES_OVERRIDE: Species.WURMPLE,
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

On the first turn, just attack with tackle and let the enemy endure.
Then, use splash until the enemy endure fails (just so you don't waste time in case of a double success, in my test they did it 3 in a row lol).
Then use tackle again. Note that the enemy does not take any damage.


## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~

~~Are there any localization additions or changes? If so:~~
- ~~[ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?~~
  - ~~[ ] If so, please leave a link to it here:~~
- ~~[ ] Has the translation team been contacted for proofreading/translation?~~