### PR TITLE
[Localization] Move Touch controls Localization

### DIFF
--- a/src/ui/settings/move-touch-controls-handler.ts
+++ b/src/ui/settings/move-touch-controls-handler.ts
@@ -1,6 +1,7 @@
 import { globalScene } from "#app/global-scene";
 import type TouchControl from "#app/touch-controls";
 import type UI from "#app/ui/ui";
+import i18next from "i18next";
 
 export const TOUCH_CONTROL_POSITIONS_LANDSCAPE = "touchControlPositionsLandscape";
 export const TOUCH_CONTROL_POSITIONS_PORTRAIT = "touchControlPositionsPortrait";
@@ -71,7 +72,7 @@ export default class MoveTouchControlsHandler {
     if (this.inConfigurationMode) {
       const orientation = document.querySelector("#touchControls #orientation");
       if (orientation) {
-        orientation.textContent = this.isLandscapeMode ? "Landscape" : "Portrait";
+        orientation.textContent = this.isLandscapeMode ? i18next.t("settings:landscape") : i18next.t("settings:portrait");
       }
     }
     const positions = this.getSavedPositionsOfCurrentOrientation() ?? [];
@@ -87,24 +88,27 @@ export default class MoveTouchControlsHandler {
    * @returns A new div element that contains the toolbar for the configuration mode.
    */
   private createToolbarElement(): HTMLDivElement {
-    const toolbar = document.createElement("div");
-    toolbar.id = "configToolbar";
-    toolbar.innerHTML = `
-      <div class="column">
-        <div class="button-row">
-          <div id="resetButton" class="button">Reset</div>
-          <div id="saveButton" class="button">Save & close</div>
-          <div id="cancelButton" class="button">Cancel</div>
-        </div>
-        <div class="info-row">
-          <div class="orientation-label"> 
-            Orientation: <span id="orientation">${this.isLandscapeMode ? "Landscape" : "Portrait"}</span>
-          </div>
+  const toolbar = document.createElement("div");
+  toolbar.id = "configToolbar";
+  toolbar.innerHTML = `
+    <div class="column">
+      <div class="button-row">
+        <div id="resetButton" class="button">${i18next.t("settings:reset")}</div>
+        <div id="saveButton" class="button">${i18next.t("settings:saveClose")}</div>
+        <div id="cancelButton" class="button">${i18next.t("settings:cancel")}</div>
+      </div>
+      <div class="info-row">
+        <div class="orientation-label"> 
+          ${i18next.t("settings:orientation")}
+          <span id="orientation">
+            ${this.isLandscapeMode ? i18next.t("settings:landscape") : i18next.t("settings:portrait")}
+          </span>
         </div>
       </div>
-    `;
-    return toolbar;
-  }
+    </div>
+  `;
+  return toolbar;
+}
 
   /**
    * Initializes the toolbar of the configuration mode.

--- a/src/ui/settings/move-touch-controls-handler.ts
+++ b/src/ui/settings/move-touch-controls-handler.ts
@@ -88,9 +88,9 @@ export default class MoveTouchControlsHandler {
    * @returns A new div element that contains the toolbar for the configuration mode.
    */
   private createToolbarElement(): HTMLDivElement {
-  const toolbar = document.createElement("div");
-  toolbar.id = "configToolbar";
-  toolbar.innerHTML = `
+    const toolbar = document.createElement("div");
+    toolbar.id = "configToolbar";
+    toolbar.innerHTML = `
     <div class="column">
       <div class="button-row">
         <div id="resetButton" class="button">${i18next.t("settings:reset")}</div>
@@ -107,8 +107,8 @@ export default class MoveTouchControlsHandler {
       </div>
     </div>
   `;
-  return toolbar;
-}
+    return toolbar;
+  }
 
   /**
    * Initializes the toolbar of the configuration mode.


### PR DESCRIPTION
## What are the changes the user will see?
Touch controls configuration now translatable

## Why am I making these changes?
To have it translatable

## What are the changes from a developer perspective?
None

## Screenshots/Videos
BEFORE (French):
![IMG_20250216_211505](https://github.com/user-attachments/assets/a7610fe4-1e69-46b5-9925-98489c3bf8f3)

AFTER (French):
![IMG_20250216_211515](https://github.com/user-attachments/assets/09bb17e8-b33a-4da2-9827-2a8d958bf41e)

## How to test the changes?
Play on a device with a touch screen and try to reconfigure the position of the touch controls via the Game Settings

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [X] Are all unit tests still passing? (`npm run test`)
  - [X] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [X] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [X] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [X] If so, please leave a link to it here:  https://github.com/pagefaultgames/pokerogue-locales/pull/128
- [X] Has the translation team been contacted for proofreading/translation?