### PR TITLE
[UX/UI] Update Starter Select Screen Spanish text size

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -88,7 +88,7 @@ const languageSettings: { [key: string]: LanguageSetting } = {
     starterInfoXPos: 33,
   },
   "es-ES":{
-    starterInfoTextSize: "56px",
+    starterInfoTextSize: "52px",
     instructionTextSize: "35px",
   },
   "fr":{


### PR DESCRIPTION
## What are the changes the user will see?
No Nature informations text going out of the textbox on the starter select screen in Spanish

## Why am I making these changes?
To have something visually pleasing

## What are the changes from a developer perspective?
None

## Screenshots/Videos
BEFORE
![image](https://github.com/user-attachments/assets/03fe4161-7b04-46a7-ba5a-265a5534fa1a)

AFTER
![image](https://github.com/user-attachments/assets/4c23f744-9a1c-4eb4-a5a4-b3c3c80798dd)


## How to test the changes?
Go on the starter select screen in Spanish and cycle Natures

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [X] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?