### PR TITLE
[Bug] Fix tera type access

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2831,7 +2831,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       stabMultiplier.value += 0.5;
     }
 
-    if (source.isTerastallized && source.teraType === Type.STELLAR && (!source.stellarTypesBoosted.includes(moveType) || source.hasSpecies(Species.TERAPAGOS))) {
+    if (source.isTerastallized && source.getTeraType() === Type.STELLAR && (!source.stellarTypesBoosted.includes(moveType) || source.hasSpecies(Species.TERAPAGOS))) {
       if (matchesSourceType) {
         stabMultiplier.value += 0.5;
       } else {
@@ -4652,7 +4652,7 @@ export class PlayerPokemon extends Pokemon {
         newPokemon.fusionVariant = this.fusionVariant;
         newPokemon.fusionGender = this.fusionGender;
         newPokemon.fusionLuck = this.fusionLuck;
-        newPokemon.fusionTeraType = this.teraType;
+        newPokemon.fusionTeraType = this.fusionTeraType;
         newPokemon.usedTMs = this.usedTMs;
 
         globalScene.getPlayerParty().push(newPokemon);

--- a/src/phases/tera-phase.ts
+++ b/src/phases/tera-phase.ts
@@ -20,9 +20,7 @@ export class TeraPhase extends BattlePhase {
   start() {
     super.start();
 
-    console.log(this.pokemon.name, "terastallized to", Type[this.pokemon.teraType].toString());
-
-    globalScene.queueMessage(i18next.t("battle:pokemonTerastallized", { pokemonNameWithAffix: getPokemonNameWithAffix(this.pokemon), type: i18next.t(`pokemonInfo:Type.${Type[this.pokemon.teraType]}`) }));
+    globalScene.queueMessage(i18next.t("battle:pokemonTerastallized", { pokemonNameWithAffix: getPokemonNameWithAffix(this.pokemon), type: i18next.t(`pokemonInfo:Type.${Type[this.pokemon.getTeraType()]}`) }));
     new CommonBattleAnim(CommonAnim.TERASTALLIZE, this.pokemon).play(false, () => {
       this.end();
     });
@@ -41,7 +39,7 @@ export class TeraPhase extends BattlePhase {
 
     if (this.pokemon.isPlayer()) {
       globalScene.validateAchv(achvs.TERASTALLIZE);
-      if (this.pokemon.teraType === Type.STELLAR) {
+      if (this.pokemon.getTeraType() === Type.STELLAR) {
         globalScene.validateAchv(achvs.STELLAR_TERASTALLIZE);
       }
     }


### PR DESCRIPTION
## What are the changes the user will see?
Some parts of the code weren't correctly acknowleding tera type overrides, like terapagos was displaying as tera normal sometimes.

## Why am I making these changes?
The code accessed tera type directly instead of using getTeraType in a couple of places, this is now fixed.

## What are the changes from a developer perspective?
The code accessed tera type directly instead of using getTeraType in a couple of places, this is now fixed.

## Screenshots/Videos
![image](https://github.com/user-attachments/assets/e049e5cc-9ed2-4bbf-a08a-36bda1aae832)


## How to test the changes?
Terastallize terapagos. It should say tera stellar.

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [X] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?