### PR TITLE
[Localization] Corrections move-touch-controls-handler local key names

### DIFF
--- a/src/ui/settings/move-touch-controls-handler.ts
+++ b/src/ui/settings/move-touch-controls-handler.ts
@@ -93,9 +93,9 @@ export default class MoveTouchControlsHandler {
     toolbar.innerHTML = `
     <div class="column">
       <div class="button-row">
-        <div id="resetButton" class="button">${i18next.t("settings:reset")}</div>
-        <div id="saveButton" class="button">${i18next.t("settings:saveClose")}</div>
-        <div id="cancelButton" class="button">${i18next.t("settings:cancel")}</div>
+        <div id="resetButton" class="button">${i18next.t("settings:touchReset")}</div>
+        <div id="saveButton" class="button">${i18next.t("settings:touchSaveClose")}</div>
+        <div id="cancelButton" class="button">${i18next.t("settings:touchCancel")}</div>
       </div>
       <div class="info-row">
         <div class="orientation-label"> 


### PR DESCRIPTION
## What are the changes the user will see?
None

## Why am I making these changes?
Another key name "reset" already existed in the same locale file, so I renamed some keys related to touch controls

## What are the changes from a developer perspective?
None

## How to test the changes?
Play on a device with a touch screen and try to reconfigure the position of the touch controls via the Game Settings

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [X] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [X] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [X] If so, please leave a link to it here: https://github.com/pagefaultgames/pokerogue-locales/pull/132
- [X] Has the translation team been contacted for proofreading/translation?