### PR TITLE
[UI/UX] Pokedex - Page turning takes filters into account

### DIFF
--- a/src/ui/pokedex-page-ui-handler.ts
+++ b/src/ui/pokedex-page-ui-handler.ts
@@ -246,7 +246,7 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
   private menuOptions: MenuOptions[];
   protected scale: number = 0.1666666667;
   private menuDescriptions: string[];
-  filteredIndices: Species[] | null = null;
+  private filteredIndices: Species[] | null = null;
 
   constructor() {
     super(Mode.POKEDEX_PAGE);

--- a/src/ui/pokedex-page-ui-handler.ts
+++ b/src/ui/pokedex-page-ui-handler.ts
@@ -16,7 +16,7 @@ import { pokemonFormChanges } from "#app/data/pokemon-forms";
 import type { LevelMoves } from "#app/data/balance/pokemon-level-moves";
 import { pokemonFormLevelMoves, pokemonSpeciesLevelMoves } from "#app/data/balance/pokemon-level-moves";
 import type PokemonSpecies from "#app/data/pokemon-species";
-import { allSpecies, getPokemonSpeciesForm, normalForm } from "#app/data/pokemon-species";
+import { allSpecies, getPokemonSpecies, getPokemonSpeciesForm, normalForm } from "#app/data/pokemon-species";
 import { getStarterValueFriendshipCap, speciesStarterCosts } from "#app/data/balance/starters";
 import { starterPassiveAbilities } from "#app/data/balance/passives";
 import { Type } from "#enums/type";
@@ -246,6 +246,7 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
   private menuOptions: MenuOptions[];
   protected scale: number = 0.1666666667;
   private menuDescriptions: string[];
+  filteredIndices: Species[] | null = null;
 
   constructor() {
     super(Mode.POKEDEX_PAGE);
@@ -557,6 +558,7 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
       this.species = args[0];
       this.formIndex = args[1] ?? 0;
       this.savedStarterAttributes = args[2] ?? { shiny:false, female:true, variant:0, form:0 };
+      this.filteredIndices = args[3] ?? null;
       this.starterSetup();
     }
 
@@ -1432,7 +1434,7 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
                             this.savedStarterAttributes.form = newFormIndex;
                             this.moveInfoOverlay.clear();
                             this.clearText();
-                            ui.setMode(Mode.POKEDEX_PAGE, newSpecies, newFormIndex, this.savedStarterAttributes);
+                            ui.setMode(Mode.POKEDEX_PAGE, newSpecies, newFormIndex, this.savedStarterAttributes, this.filteredIndices);
                             return true;
                           },
                           onHover: () => this.showText(conditionText)
@@ -1747,31 +1749,45 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
           case Button.LEFT:
             this.blockInput = true;
             ui.setModeWithoutClear(Mode.OPTION_SELECT).then(() => {
-              const index = allSpecies.findIndex(species => species.speciesId === this.species.speciesId);
-              const newIndex = index <= 0 ? allSpecies.length - 1 : index - 1;
-              const newSpecies = allSpecies[newIndex];
+              let newSpecies: PokemonSpecies;
+              if (this.filteredIndices) {
+                const index = this.filteredIndices.findIndex(id => id === this.species.speciesId);
+                const newIndex = index <= 0 ? this.filteredIndices.length - 1 : index - 1;
+                newSpecies = getPokemonSpecies(this.filteredIndices[newIndex]);
+              } else {
+                const index = allSpecies.findIndex(species => species.speciesId === this.species.speciesId);
+                const newIndex = index <= 0 ? allSpecies.length - 1 : index - 1;
+                newSpecies = allSpecies[newIndex];
+              }
               const matchingForm = newSpecies?.forms.find(form => form.formKey === this.species?.forms[this.formIndex]?.formKey);
               const newFormIndex = matchingForm ? matchingForm.formIndex : 0;
               this.starterAttributes.form = newFormIndex;
               this.savedStarterAttributes.form = newFormIndex;
               this.moveInfoOverlay.clear();
               this.clearText();
-              ui.setModeForceTransition(Mode.POKEDEX_PAGE, newSpecies, newFormIndex, this.savedStarterAttributes);
+              ui.setModeForceTransition(Mode.POKEDEX_PAGE, newSpecies, newFormIndex, this.savedStarterAttributes, this.filteredIndices);
             });
             this.blockInput = false;
             break;
           case Button.RIGHT:
             ui.setModeWithoutClear(Mode.OPTION_SELECT).then(() => {
-              const index = allSpecies.findIndex(species => species.speciesId === this.species.speciesId);
-              const newIndex = index >= allSpecies.length - 1 ? 0 : index + 1;
-              const newSpecies = allSpecies[newIndex];
+              let newSpecies: PokemonSpecies;
+              if (this.filteredIndices) {
+                const index = this.filteredIndices.findIndex(id => id === this.species.speciesId);
+                const newIndex = index >= this.filteredIndices.length - 1 ? 0 : index + 1;
+                newSpecies = getPokemonSpecies(this.filteredIndices[newIndex]);
+              } else {
+                const index = allSpecies.findIndex(species => species.speciesId === this.species.speciesId);
+                const newIndex = index >= allSpecies.length - 1 ? 0 : index + 1;
+                newSpecies = allSpecies[newIndex];
+              }
               const matchingForm = newSpecies?.forms.find(form => form.formKey === this.species?.forms[this.formIndex]?.formKey);
               const newFormIndex = matchingForm ? matchingForm.formIndex : 0;
               this.starterAttributes.form = newFormIndex;
               this.savedStarterAttributes.form = newFormIndex;
               this.moveInfoOverlay.clear();
               this.clearText();
-              ui.setModeForceTransition(Mode.POKEDEX_PAGE, newSpecies, newFormIndex, this.savedStarterAttributes);
+              ui.setModeForceTransition(Mode.POKEDEX_PAGE, newSpecies, newFormIndex, this.savedStarterAttributes, this.filteredIndices);
             });
             break;
         }

--- a/src/ui/pokedex-ui-handler.ts
+++ b/src/ui/pokedex-ui-handler.ts
@@ -215,6 +215,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
   private showFormTrayIconElement: Phaser.GameObjects.Sprite;
   private showFormTrayLabel: Phaser.GameObjects.Text;
   private canShowFormTray: boolean;
+  private filteredIndices: Species[];
 
   constructor() {
     super(Mode.POKEDEX);
@@ -1037,7 +1038,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
     } else if (this.showingTray) {
       if (button === Button.ACTION) {
         const formIndex = this.trayForms[this.trayCursor].formIndex;
-        ui.setOverlayMode(Mode.POKEDEX_PAGE, this.lastSpecies, formIndex, { form: formIndex });
+        ui.setOverlayMode(Mode.POKEDEX_PAGE, this.lastSpecies, formIndex, { form: formIndex }, this.filteredIndices);
         success = true;
       } else {
         const numberOfForms = this.trayContainers.length;
@@ -1084,7 +1085,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
       }
     } else {
       if (button === Button.ACTION) {
-        ui.setOverlayMode(Mode.POKEDEX_PAGE, this.lastSpecies, 0);
+        ui.setOverlayMode(Mode.POKEDEX_PAGE, this.lastSpecies, 0, null, this.filteredIndices);
         success = true;
       } else {
         switch (button) {
@@ -1553,6 +1554,8 @@ export default class PokedexUiHandler extends MessageUiHandler {
       }
       return 0;
     });
+
+    this.filteredIndices = this.filteredPokemonContainers.map(c => c.species.speciesId);
 
     this.updateScroll();
   };


### PR DESCRIPTION
## What are the changes the user will see?
When using the left and right arrow on a Pokémon page to scroll to the previous or next mons, filters are now taken into account.

## Why am I making these changes?
This is a more intuitive behavior and has been requested on discord.

## What are the changes from a developer perspective?
When filtering, a list of species ids of the filtered mons is created. This is passed as an argument when selecting the Pokémon, and taken into account every time left or right is pressed.

## Screenshots/Videos
https://github.com/user-attachments/assets/361dccde-a205-433d-bca9-31f0ec2f4759

## How to test the changes?
Try different filters or combinations of filters.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?