### PR TITLE
[Bug/Item] Fix Flame Orb Weight Function

### DIFF
--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1822,7 +1822,7 @@ const modifierPool: ModifierPool = {
 
         if (!isHoldingOrb) {
           const moveset = p.getMoveset(true).filter(m => !isNullOrUndefined(m)).map(m => m.moveId);
-          const canSetStatus = p.canSetStatus(StatusEffect.TOXIC, true, true, null, true);
+          const canSetStatus = p.canSetStatus(StatusEffect.BURN, true, true, null, true);
 
           // Moves that take advantage of obtaining the actual status effect
           const hasStatusMoves = [ Moves.FACADE, Moves.PSYCHO_SHIFT ]


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->

`Flame Orb` should not longer get pushed if there is, for example, only a Pokémon who cannot get burned in the party.

## Why am I making these changes?
<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

This was a mistake introduced in #5070; it was not intended that `canSetStatus` within `Flame Orb`'s weight function would be determined on whether the current Pokémon could be inflicted with `Toxic`.

## What are the changes from a developer perspective?
<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

Switches `StatusEffect.TOXIC` in `Flame Orb`'s weight function to `StatusEffect.BURN`.

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

N/A

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

The same testing instructions from #5070 can be used here.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - ~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~
- ~[ ] Have I provided screenshots/videos of the changes (if applicable)?~
  - ~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~

Are there any localization additions or changes? If so:
- ~[ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?~
  - ~[ ] If so, please leave a link to it here:~
- ~[ ] Has the translation team been contacted for proofreading/translation?~