### PR TITLE
[UI/UX] Pokédex - Informative messages for level up moves

### DIFF
--- a/src/ui/pokedex-page-ui-handler.ts
+++ b/src/ui/pokedex-page-ui-handler.ts
@@ -983,13 +983,23 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
 
                   ui.setModeWithoutClear(Mode.OPTION_SELECT, {
                     options: this.levelMoves.map(m => {
+                      const levelNumber = m[0] > 0 ? String(m[0]) : "";
                       const option: OptionSelectItem = {
-                        label: String(m[0]).padEnd(4, " ") + allMoves[m[1]].name,
+                        label: levelNumber.padEnd(4, " ") + allMoves[m[1]].name,
                         handler: () => {
                           return false;
                         },
                         onHover: () => {
                           this.moveInfoOverlay.show(allMoves[m[1]]);
+                          if (m[0] === 0) {
+                            this.showText(i18next.t("pokedexUiHandler:onlyEvolutionMove"));
+                          } else if (m[0] === -1) {
+                            this.showText(i18next.t("pokedexUiHandler:onlyRecallMove"));
+                          } else if (m[0] <= 5) {
+                            this.showText(i18next.t("pokedexUiHandler:onStarterSelectMove"));
+                          } else {
+                            this.showText(i18next.t("pokedexUiHandler:byLevelUpMove"));
+                          }
                         },
                       };
                       return option;


### PR DESCRIPTION
## What are the changes the user will see?
When looking at level up moves in the Pokédex, messages give more information.

## Why am I making these changes?
Moves learnt on evolution ("lv 0") and only by recall ("lv -1") were not properly explained.

## Screenshots/Videos
![squirtle_2](https://github.com/user-attachments/assets/de802c60-d5f6-4aa7-bf1a-139d4e86ab22)
![squirtle_1](https://github.com/user-attachments/assets/58e503b2-a88b-4145-9d5b-01509dd30ef8)
![rightafter](https://github.com/user-attachments/assets/ab856d0f-d436-4b9f-8bca-ad13248cc7a5)
![canberecalled](https://github.com/user-attachments/assets/faeb7f60-86e7-4cbf-aa8d-191d08d82ac5)

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
- [x] Have I provided screenshots/videos of the changes (if applicable)?

Are there any localization additions or changes? If so:
- [x] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [x] If so, please leave a link to it here: https://github.com/pagefaultgames/pokerogue-locales/pull/136
- [x] Has the translation team been contacted for proofreading/translation?