### PR TITLE
[Misc] Update console logging of encounter pokemon on beta/local

### DIFF
--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -38,6 +38,7 @@ import { Species } from "#enums/species";
 import { overrideHeldItems, overrideModifiers } from "#app/modifier/modifier";
 import i18next from "i18next";
 import { WEIGHT_INCREMENT_ON_SPAWN_MISS } from "#app/data/mystery-encounters/mystery-encounters";
+import { Nature } from "#enums/nature";
 
 export class EncounterPhase extends BattlePhase {
   private loaded: boolean;
@@ -156,7 +157,31 @@ export class EncounterPhase extends BattlePhase {
 
       loadEnemyAssets.push(enemyPokemon.loadAssets());
 
-      console.log(`Pokemon: ${getPokemonNameWithAffix(enemyPokemon)}`, `Species ID: ${enemyPokemon.species.speciesId}`, `Stats: ${enemyPokemon.stats}`, `Ability: ${enemyPokemon.getAbility().name}`, `Passive Ability: ${enemyPokemon.getPassiveAbility().name}`);
+      const stats: string[] = [
+        `HP: ${enemyPokemon.stats[0]} (${enemyPokemon.ivs[0]})`,
+        ` Atk: ${enemyPokemon.stats[1]} (${enemyPokemon.ivs[1]})`,
+        ` Def: ${enemyPokemon.stats[2]} (${enemyPokemon.ivs[2]})`,
+        ` Spatk: ${enemyPokemon.stats[3]} (${enemyPokemon.ivs[3]})`,
+        ` Spdef: ${enemyPokemon.stats[4]} (${enemyPokemon.ivs[4]})`,
+        ` Spd: ${enemyPokemon.stats[5]} (${enemyPokemon.ivs[5]})`,
+      ];
+      const moveset: string[] = [];
+      enemyPokemon.getMoveset().forEach((move) => {
+        moveset.push(move!.getName());
+      });
+
+      console.log(
+        `Pokemon: ${getPokemonNameWithAffix(enemyPokemon)}`,
+        `| Species ID: ${enemyPokemon.species.speciesId}`,
+        `| Nature: ${Nature[enemyPokemon.getNature()]}`,
+      );
+      console.log(`Stats (IVs): ${stats}`);
+      console.log(
+        `Ability: ${enemyPokemon.getAbility().name}`,
+        `| Passive Ability${enemyPokemon.isBoss() ? "" : " (inactive)"}: ${enemyPokemon.getPassiveAbility().name}`,
+        `${enemyPokemon.isBoss() ? `| Boss Bars: ${enemyPokemon.bossSegments}` : ""}`
+      );
+      console.log("Moveset:", moveset);
       return true;
     });
 


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Additional logging when playing on beta or locally for use in development.

## What are the changes from a developer perspective?
At the start of an encounter, more of the enemy pokemon's information will be output to the console.

## Screenshots/Videos
<details><summary>An example team from wave 195</summary>
<p>

![image](https://github.com/user-attachments/assets/162836e4-4b2d-4103-83cc-1a196fed565e)

</p>
</details> 

## How to test the changes?
Start any wave and look at the console output.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)