### PR TITLE
[Bug][UI] Fix bgm bar

### DIFF
--- a/src/ui/pokedex-page-ui-handler.ts
+++ b/src/ui/pokedex-page-ui-handler.ts
@@ -45,7 +45,6 @@ import { EggSourceType } from "#enums/egg-source-types";
 import { getPassiveCandyCount, getValueReductionCandyCounts, getSameSpeciesEggCandyCounts } from "#app/data/balance/starters";
 import { BooleanHolder, getLocalizedSpriteKey, isNullOrUndefined, NumberHolder, padInt, rgbHexToRgba, toReadableString } from "#app/utils";
 import type { Nature } from "#enums/nature";
-import BgmBar from "./bgm-bar";
 import * as Utils from "../utils";
 import { speciesTmMoves } from "#app/data/balance/tms";
 import type { BiomeTierTod } from "#app/data/balance/biomes";
@@ -242,7 +241,6 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
   private menuContainer: Phaser.GameObjects.Container;
   private menuBg: Phaser.GameObjects.NineSlice;
   protected optionSelectText: Phaser.GameObjects.Text;
-  public bgmBar: BgmBar;
   private menuOptions: MenuOptions[];
   protected scale: number = 0.1666666667;
   private menuDescriptions: string[];
@@ -480,10 +478,6 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
     this.menuContainer.setName("menu");
     this.menuContainer.setInteractive(new Phaser.Geom.Rectangle(0, 0, globalScene.game.canvas.width / 6, globalScene.game.canvas.height / 6), Phaser.Geom.Rectangle.Contains);
 
-    this.bgmBar = new BgmBar();
-    this.bgmBar.setup();
-    ui.bgmBar = this.bgmBar;
-    this.menuContainer.add(this.bgmBar);
     this.menuContainer.setVisible(false);
 
     this.menuOptions = Utils.getEnumKeys(MenuOptions).map(m => parseInt(MenuOptions[m]) as MenuOptions);


### PR DESCRIPTION
## What are the changes the user will see?
BGM flyout will reappear in the menu. 

## Why am I making these changes?
It wasn't appearing.

## What are the changes from a developer perspective?
The pokedex had created a duplicate bgm bar that was never shown and was overriding the global ui handler to point to it. This was causing the actual bgm bar in the menu to never have its text updated, so it was never appearing.

## Screenshots/Videos
![image](https://github.com/user-attachments/assets/4985c84f-bf05-45f1-bc91-33bae00f46c5)

## How to test the changes?
Open the pause menu with and without this patch.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?