### PR TITLE
[Move] Add flavor text for Splash and Celebrate

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1541,10 +1541,6 @@ export class SurviveDamageAttr extends ModifiedDamageAttr {
 }
 
 export class SplashAttr extends MoveEffectAttr {
-  constructor() {
-    super();
-  }
-
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     globalScene.queueMessage(i18next.t("battlerTags:splashLapse"));
     return true;
@@ -1552,10 +1548,6 @@ export class SplashAttr extends MoveEffectAttr {
 }
 
 export class CelebrateAttr extends MoveEffectAttr {
-  constructor() {
-    super();
-  }
-
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     globalScene.queueMessage(i18next.t("moveTriggers:celebrate", { playerName: loggedInUser?.username }));
     return true;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -1542,7 +1542,7 @@ export class SurviveDamageAttr extends ModifiedDamageAttr {
 
 export class SplashAttr extends MoveEffectAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    globalScene.queueMessage(i18next.t("battlerTags:splashLapse"));
+    globalScene.queueMessage(i18next.t("moveTriggers:splash"));
     return true;
   }
 }

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -61,6 +61,7 @@ import { RevivalBlessingPhase } from "#app/phases/revival-blessing-phase";
 import { LoadMoveAnimPhase } from "#app/phases/load-move-anim-phase";
 import { PokemonTransformPhase } from "#app/phases/pokemon-transform-phase";
 import { MoveAnimPhase } from "#app/phases/move-anim-phase";
+import { loggedInUser } from "#app/account";
 
 export enum MoveCategory {
   PHYSICAL,
@@ -1536,6 +1537,28 @@ export class SurviveDamageAttr extends ModifiedDamageAttr {
 
   getUserBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
     return target.hp > 1 ? 0 : -20;
+  }
+}
+
+export class SplashAttr extends MoveEffectAttr {
+  constructor() {
+    super();
+  }
+
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    globalScene.queueMessage(i18next.t("battlerTags:splashLapse"));
+    return true;
+  }
+}
+
+export class CelebrateAttr extends MoveEffectAttr {
+  constructor() {
+    super();
+  }
+
+  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+    globalScene.queueMessage(i18next.t("moveTriggers:celebrate", { playerName: loggedInUser?.username }));
+    return true;
   }
 }
 
@@ -8802,6 +8825,7 @@ export function initMoves() {
     new AttackMove(Moves.PSYWAVE, Type.PSYCHIC, MoveCategory.SPECIAL, -1, 100, 15, -1, 0, 1)
       .attr(RandomLevelDamageAttr),
     new SelfStatusMove(Moves.SPLASH, Type.NORMAL, -1, 40, -1, 0, 1)
+      .attr(SplashAttr)
       .condition(failOnGravityCondition),
     new SelfStatusMove(Moves.ACID_ARMOR, Type.POISON, -1, 20, -1, 0, 1)
       .attr(StatStageChangeAttr, [ Stat.DEF ], 2, true),
@@ -10244,7 +10268,8 @@ export function initMoves() {
       .target(MoveTarget.BOTH_SIDES),
     new AttackMove(Moves.DAZZLING_GLEAM, Type.FAIRY, MoveCategory.SPECIAL, 80, 100, 10, -1, 0, 6)
       .target(MoveTarget.ALL_NEAR_ENEMIES),
-    new SelfStatusMove(Moves.CELEBRATE, Type.NORMAL, -1, 40, -1, 0, 6),
+    new SelfStatusMove(Moves.CELEBRATE, Type.NORMAL, -1, 40, -1, 0, 6)
+      .attr(CelebrateAttr),
     new StatusMove(Moves.HOLD_HANDS, Type.NORMAL, -1, 40, -1, 0, 6)
       .ignoresSubstitute()
       .target(MoveTarget.NEAR_ALLY),


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
Splash and Celebrate will now have their unique flavor text when used.

## Why am I making these changes?
<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->
I saw that another PR, #5340 , was trying to do the same thing with Splash, albeit through a much more unnecessarily complex method. So I simplified it, and included Celebrate as well, since they are both equally useless moves with unique text.

## What are the changes from a developer perspective?
<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->
Creates two attributes for Splash and Celebrate, which simply displays the relevant text. Relocates the existing localized Splash message from the battler tags to the move triggers. Celebrate uses your account name when congratulating the player.

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->
(Celebrate is still missing an attack animation, but works otherwise)

https://github.com/user-attachments/assets/06644f10-3e3a-4add-8a8c-6858184c8e8c

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->
Override the moveset to have Splash or Celebrate.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  ~- [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  ~- [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~

Are there any localization additions or changes? If so:
- [x] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [x] If so, please leave a link to it here: https://github.com/pagefaultgames/pokerogue-locales/pull/137
- [x] Has the translation team been contacted for proofreading/translation?