### PR TITLE
[UI/UX] Text is grey again in delay confirm option menu

### DIFF
--- a/src/ui/abstact-option-select-ui-handler.ts
+++ b/src/ui/abstact-option-select-ui-handler.ts
@@ -35,6 +35,7 @@ const scrollDownLabel = "↓";
 
 export default abstract class AbstractOptionSelectUiHandler extends UiHandler {
   protected optionSelectContainer: Phaser.GameObjects.Container;
+  protected optionSelectTextContainer: Phaser.GameObjects.Container;
   protected optionSelectBg: Phaser.GameObjects.NineSlice;
   protected optionSelectText: BBCodeText;
   protected optionSelectIcons: Phaser.GameObjects.Sprite[];
@@ -53,6 +54,7 @@ export default abstract class AbstractOptionSelectUiHandler extends UiHandler {
   protected unskippedIndices: number[] = [];
 
   protected defaultTextStyle: TextStyle = TextStyle.WINDOW;
+  protected textContent: string;
 
 
   constructor(mode: Mode | null) {
@@ -77,6 +79,9 @@ export default abstract class AbstractOptionSelectUiHandler extends UiHandler {
     this.optionSelectBg.setName("option-select-bg");
     this.optionSelectBg.setOrigin(1, 1);
     this.optionSelectContainer.add(this.optionSelectBg);
+
+    this.optionSelectTextContainer = globalScene.add.container(0, 0);
+    this.optionSelectContainer.add(this.optionSelectTextContainer);
 
     this.optionSelectIcons = [];
 
@@ -123,19 +128,18 @@ export default abstract class AbstractOptionSelectUiHandler extends UiHandler {
     );
     this.optionSelectText.setOrigin(0, 0);
     this.optionSelectText.setName("text-option-select");
-    this.optionSelectContainer.add(this.optionSelectText);
+    this.optionSelectTextContainer.add(this.optionSelectText);
     this.optionSelectContainer.setPosition((globalScene.game.canvas.width / 6) - 1 - (this.config?.xOffset || 0), -48 + (this.config?.yOffset || 0));
     this.optionSelectBg.width = Math.max(this.optionSelectText.displayWidth + 24, this.getWindowWidth());
     this.optionSelectBg.height = this.getWindowHeight();
-    this.optionSelectText.setPosition(this.optionSelectBg.x - this.optionSelectBg.width + 12 + 24 * this.scale, this.optionSelectBg.y - this.optionSelectBg.height + 2 + 42 * this.scale);
+    this.optionSelectTextContainer.setPosition(this.optionSelectBg.x - this.optionSelectBg.width + 12 + 24 * this.scale, this.optionSelectBg.y - this.optionSelectBg.height + 2 + 42 * this.scale);
 
     // Now that the container and background widths are established, we can set up the proper text restricted to visible options
-    this.optionSelectText.setText(optionsWithScroll.map(o => o.item
+    this.textContent = optionsWithScroll.map(o => o.item
       ? `[shadow=${getTextColor(o.style ?? this.defaultTextStyle, true, globalScene.uiTheme)}][color=${getTextColor(o.style ?? TextStyle.WINDOW, false, globalScene.uiTheme)}]    ${o.label}[/color][/shadow]`
       : `[shadow=${getTextColor(o.style ?? this.defaultTextStyle, true, globalScene.uiTheme)}][color=${getTextColor(o.style ?? TextStyle.WINDOW, false, globalScene.uiTheme)}]${o.label}[/color][/shadow]`
-    ).join("\n")
-
-    );
+    ).join("\n");
+    this.optionSelectText.setText(this.textContent);
 
     options.forEach((option: OptionSelectItem, i: number) => {
       if (option.item) {
@@ -184,7 +188,7 @@ export default abstract class AbstractOptionSelectUiHandler extends UiHandler {
 
     if (this.config.delay) {
       this.blockInput = true;
-      this.optionSelectText.setAlpha(0.5);
+      this.optionSelectTextContainer.setAlpha(0.5);
       this.cursorObj?.setAlpha(0.8);
       globalScene.time.delayedCall(Utils.fixedInt(this.config.delay), () => this.unblockInput());
     }
@@ -278,7 +282,7 @@ export default abstract class AbstractOptionSelectUiHandler extends UiHandler {
     }
 
     this.blockInput = false;
-    this.optionSelectText.setAlpha(1);
+    this.optionSelectTextContainer.setAlpha(1);
     this.cursorObj?.setAlpha(1);
   }
 


### PR DESCRIPTION
## What are the changes the user will see?
Confirm options with a delay show up as grey text for the duration of the delay, again.

## Why am I making these changes?
This was the behavior before #5083. The changes to the option select ui handler in that PR included a shift to BBCodeText objects. An unwanted consequence of this is that, since BBCodeText objects do not support a setAlpha() method, the method previously used to turn the text grey temporarily does not work anymore.

See bug report [here](https://discord.com/channels/1125469663833370665/1342697356331847802) and [here](https://discord.com/channels/1125469663833370665/1338544047597555772).

## What are the changes from a developer perspective?
The BBCodeText object is wrapped in a new container, and the setAlpha() method of the container is called instead.

## Screenshots/Videos
https://github.com/user-attachments/assets/70f6d4e3-e560-4f90-a3c1-0636626af648

## How to test the changes?
Start a new run, try to overwrite an existing save slot.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
- [x] Have I provided screenshots/videos of the changes (if applicable)?