### PR TITLE
[Misc] Copy Encounter Phase logging to MEs

### DIFF
--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -47,6 +47,8 @@ import { StatusEffect } from "#enums/status-effect";
 import { globalScene } from "#app/global-scene";
 import { getPokemonSpecies } from "#app/data/pokemon-species";
 import { Type } from "#app/enums/type";
+import { getNatureName } from "#app/data/nature";
+import { getPokemonNameWithAffix } from "#app/messages";
 
 /**
  * Animates exclamation sprite over trainer's head at start of encounter
@@ -357,7 +359,31 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
 
     loadEnemyAssets.push(enemyPokemon.loadAssets());
 
-    console.log(`Pokemon: ${enemyPokemon.name}`, `Species ID: ${enemyPokemon.species.speciesId}`, `Stats: ${enemyPokemon.stats}`, `Ability: ${enemyPokemon.getAbility().name}`, `Passive Ability: ${enemyPokemon.getPassiveAbility().name}`);
+    const stats: string[] = [
+      `HP: ${enemyPokemon.stats[0]} (${enemyPokemon.ivs[0]})`,
+      ` Atk: ${enemyPokemon.stats[1]} (${enemyPokemon.ivs[1]})`,
+      ` Def: ${enemyPokemon.stats[2]} (${enemyPokemon.ivs[2]})`,
+      ` Spatk: ${enemyPokemon.stats[3]} (${enemyPokemon.ivs[3]})`,
+      ` Spdef: ${enemyPokemon.stats[4]} (${enemyPokemon.ivs[4]})`,
+      ` Spd: ${enemyPokemon.stats[5]} (${enemyPokemon.ivs[5]})`,
+    ];
+    const moveset: string[] = [];
+    enemyPokemon.getMoveset().forEach((move) => {
+      moveset.push(move!.getName()); // TODO: remove `!` after moveset-null removal PR
+    });
+
+    console.log(
+      `Pokemon: ${getPokemonNameWithAffix(enemyPokemon)}`,
+      `| Species ID: ${enemyPokemon.species.speciesId}`,
+      `| Nature: ${getNatureName(enemyPokemon.nature, true, true, true)}`,
+    );
+    console.log(`Stats (IVs): ${stats}`);
+    console.log(
+      `Ability: ${enemyPokemon.getAbility().name}`,
+      `| Passive Ability${enemyPokemon.hasPassive() ? "" : " (inactive)"}: ${enemyPokemon.getPassiveAbility().name}`,
+      `${enemyPokemon.isBoss() ? `| Boss Bars: ${enemyPokemon.bossSegments}` : ""}`
+    );
+    console.log("Moveset:", moveset);
   });
 
   globalScene.pushPhase(new MysteryEncounterBattlePhase(partyConfig.disableSwitch));

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -167,7 +167,7 @@ export class EncounterPhase extends BattlePhase {
       ];
       const moveset: string[] = [];
       enemyPokemon.getMoveset().forEach((move) => {
-        moveset.push(move!.getName());
+        moveset.push(move!.getName()); // TODO: remove `!` after moveset-null removal PR
       });
 
       console.log(


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
MEs have their own encounter code that doesn't re-use existing encounter code, so the logging needs to be copied over manually.

## What are the changes from a developer perspective?
Logging from `EncounterPhase` copied over to MEs.

## Screenshots/Videos
<details><summary>Example of logging in Expert Pokemon Breeder ME</summary>
<p>

![image](https://github.com/user-attachments/assets/d9ecf2da-e3c1-45d6-9ee7-3a2b4987c3fc)

</p>
</details> 

## How to test the changes?
Start an ME battle, such as the Expert Pokemon Breeder ME (requires 3 pokemon on the player's team).

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?