### PR TITLE
[Move] Add Taunt Removal Message

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2752,6 +2752,12 @@ export class TauntTag extends MoveRestrictionBattlerTag {
     globalScene.queueMessage(i18next.t("battlerTags:tauntOnAdd", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }), 1500);
   }
 
+  public override onRemove(pokemon: Pokemon): void {
+    super.onRemove(pokemon);
+
+    globalScene.queueMessage(i18next.t("battlerTags:tauntOnRemove", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }));
+  }
+
   /**
    * Checks if a move is a status move and determines its restriction status on that basis
    * @param {Moves} move the move under investigation


### PR DESCRIPTION
## What are the changes the user will see?
Taunt now displays a message when it is removed.

## Why am I making these changes?
Was working on a different pr and noticed that the message is missing.
## What are the changes from a developer perspective?
TauntTag now overrides the `onRemove` method with a message, similar to most other tags.

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

https://github.com/user-attachments/assets/becbd7d2-3fa4-4542-ae6b-38762161818d


## How to test the changes?
look

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x ] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [x] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [x] If so, please leave a link to it here: https://github.com/pagefaultgames/pokerogue-locales/pull/139
- [ ] Has the translation team been contacted for proofreading/translation?