### PR TITLE
[Balance] [Bug] Set trainer mons to forms matching specialty type

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1865,6 +1865,58 @@ export default class BattleScene extends SceneBase {
       this.getCurrentPhase()?.constructor.name ?? "",
     );
 
+    if ( // Give trainers with specialty types an appropriately-typed form for Wormadam, Rotom, Arceus, Oricorio, Silvally, or Paldean Tauros.
+      !isEggPhase &&
+      this.currentBattle?.battleType === BattleType.TRAINER && !isNullOrUndefined(this.currentBattle.trainer) &&
+      this.currentBattle.trainer.config.hasSpecialtyType()
+    ) {
+      if (species.speciesId === Species.WORMADAM) {
+        switch (this.currentBattle.trainer.config.specialtyType) {
+          case Type.GROUND:
+            return 1; // Sandy Cloak
+          case Type.STEEL:
+            return 2; // Trash Cloak
+          case Type.GRASS:
+            return 0; // Plant Cloak
+        }
+      } else if (species.speciesId === Species.ROTOM) {
+        switch (this.currentBattle.trainer.config.specialtyType) {
+          case Type.FLYING:
+            return 4; // Fan Rotom
+          case Type.GHOST:
+            return 0; // Lightbulb Rotom
+          case Type.FIRE:
+            return 1; // Heat Rotom
+          case Type.GRASS:
+            return 5; // Mow Rotom
+          case Type.WATER:
+            return 2; // Wash Rotom
+          case Type.ICE:
+            return 3; // Frost Rotom
+        }
+      } else if (species.speciesId === Species.ORICORIO) {
+        switch (this.currentBattle.trainer.config.specialtyType) {
+          case Type.GHOST:
+            return 3; // Sensu Style
+          case Type.FIRE:
+            return 0; // Baile Style
+          case Type.ELECTRIC:
+            return 1; // Pom-Pom Style
+          case Type.PSYCHIC:
+            return 2; // Pa'u Style
+        }
+      } else if (species.speciesId === Species.PALDEA_TAUROS) {
+        switch (this.currentBattle.trainer.config.specialtyType) {
+          case Type.FIRE:
+            return 1; // Blaze Breed
+          case Type.WATER:
+            return 2; // Aqua Breed
+        }
+      } else if (species.speciesId === Species.SILVALLY || species.speciesId === Species.ARCEUS) { // Would probably never happen, but might as well
+        return this.currentBattle.trainer.config.specialtyType;
+      }
+    }
+
     switch (species.speciesId) {
       case Species.UNOWN:
       case Species.SHELLOS:
@@ -1872,8 +1924,6 @@ export default class BattleScene extends SceneBase {
       case Species.BASCULIN:
       case Species.DEERLING:
       case Species.SAWSBUCK:
-      case Species.FROAKIE:
-      case Species.FROGADIER:
       case Species.SCATTERBUG:
       case Species.SPEWPA:
       case Species.VIVILLON:
@@ -1907,9 +1957,14 @@ export default class BattleScene extends SceneBase {
           return 0; // No Partner Eevee for Wave 12 Preschoolers
         }
         return Utils.randSeedInt(2);
+      case Species.FROAKIE:
+      case Species.FROGADIER:
       case Species.GRENINJA:
-        if (this.currentBattle?.battleType === BattleType.TRAINER) {
-          return 0; // Don't give trainers Battle Bond Greninja
+        if (
+          this.currentBattle?.battleType === BattleType.TRAINER &&
+          !isEggPhase
+        ) {
+          return 0; // Don't give trainers Battle Bond Greninja, Froakie or Frogadier
         }
         return Utils.randSeedInt(2);
       case Species.URSHIFU:


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
- Trainers with a specialty type (E4, Gym Leaders etc) will have certain species set to a form matching their specialty type
- Affected mons are:
  - Rotom
    - Ghost, Fire, Water, Grass, Flying, and Ice specialists get the matching form.
  - Paldean Tauros
    - Fire or Water specialists get Blaze Breed or Aqua Breed respectively
  - Oricorio
    - Ghost, Fire, Electric, and Psychic specialists get the matching form.
  - Wormadam
    - Ground, Steel, and Grass specialists get the matching form
  - Silvally and Arceus
    - Trainers with a type specialty use the appropriate type. Not that this is planned to be used, just here for completeness sake.
  - These forms are only set if used by a trainer that specializes in the list of types. Otherwise, their forms are determined by the same method as usual, whether that be random, biome based etc.
- Trainers can no longer generate with Battle Bond Froakie or Frogadier
  - Battle Bond Froakie and Frogadier are identical to the regular forms but don't have a hidden ability, meaning Froakie and Frogadier used by trainers had a lower chance of spawning with Protean.

## Why am I making these changes?
<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->
- Split off from #5367, though it _does_ depend on it being merged so it can use the specialty type properly
- Expands variety of mons type specialists can use, for example Crispin's Rotom
- #4863 removed Battle Bond Greninja from trainers because Ash Greninja is OP. Froakie and Frogadier could still spawn as Battle Bond form, though. Since BB Froakie/Frogadier don't have their Hidden Ability, this meant chances of a trainer spawning with Protean Froakie or Frogadier were effectively halved.

## What are the changes from a developer perspective?
<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->
- Checks for trainer battle with type specialty in `getSpeciesFormIndex`

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->
Crispin's Rotom
![image](https://github.com/user-attachments/assets/192334f1-d566-4501-9146-5af2a397fdba)

Just to demonstrate the changes, Amarys uses Trash Cloak Wormadam, even in Plains where Plant Cloak usually spawns
![image](https://github.com/user-attachments/assets/73d22934-cf70-4c1e-8c49-c66627d322df)

Where did she get that
![image](https://github.com/user-attachments/assets/60a9c1c8-b9d7-437c-a9da-0a2f0683c04f)

Since Amarys doesn't have a matching Rotom form, its form is determined by biome like usual
![image](https://github.com/user-attachments/assets/a212d899-9fb3-4e69-9858-d01fb57b705d)

Same with Paldean Tauros, whose form is chosen randomly
![image](https://github.com/user-attachments/assets/ef566556-49d3-4850-8d9b-f0fcbef32b88)

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
  - Depends on #5367 
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?