### PR TITLE
[Bug] Fix canApplyAbility check

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -5073,6 +5073,10 @@ function applySingleAbAttrs<TAttr extends AbAttr>(
   showAbilityInstant: boolean = false,
   messages: string[] = []
 ) {
+  if (!pokemon?.canApplyAbility(passive) || (passive && (pokemon.getPassiveAbility().id === pokemon.getAbility().id))) {
+    return;
+  }
+
   const ability = passive ? pokemon.getPassiveAbility() : pokemon.getAbility();
   if (gainedMidTurn && ability.getAttrs(attrType).some(attr => attr instanceof PostSummonAbAttr && !attr.shouldActivateOnGain())) {
     return;
@@ -5366,12 +5370,10 @@ function applyAbAttrsInternal<TAttr extends AbAttr>(
   gainedMidTurn: boolean = false
 ) {
   for (const passive of [ false, true ]) {
-    if (!pokemon?.canApplyAbility(passive) || (passive && (pokemon.getPassiveAbility().id === pokemon.getAbility().id))) {
-      continue;
+    if (pokemon) {
+      applySingleAbAttrs(pokemon, passive, attrType, applyFunc, args, gainedMidTurn, simulated, showAbilityInstant, messages);
+      globalScene.clearPhaseQueueSplice();
     }
-
-    applySingleAbAttrs(pokemon, passive, attrType, applyFunc, args, gainedMidTurn, simulated, showAbilityInstant, messages);
-    globalScene.clearPhaseQueueSplice();
   }
 }
 


### PR DESCRIPTION
## What are the changes the user will see?
Unreported bug where onGain abilities could bypass checks, i.e. intimidate could activate under neutralizing gas.

## Why am I making these changes?
Fix a mistake I made

## What are the changes from a developer perspective?
In #5146 I split `applyAbAttrsInternal` into a second function, `applySingleAbAttrs`. I neglected to move the canApplyAbility check into the inner function. This isn't an issue most of the time, but onGain abilities call  `applySingleAbAttrs` directly (unlike other abilities, a pokemon will often only gain one ability at a time, so it can't loop over passive and normal like `applyAbAttrsInternal` does), so those abilities would skip the check. This fixes that

## How to test the changes?
```typescript
  BATTLE_TYPE_OVERRIDE: "double",
  ABILITY_OVERRIDE: Abilities.INTIMIDATE,
  OPP_ABILITY_OVERRIDE: Abilities.NEUTRALIZING_GAS,
  MOVESET_OVERRIDE: Moves.SKILL_SWAP
```
Use skill swap on yourself - on beta intimidate will activate when it shouldn't. Here it does not

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?