### PR TITLE
[UI/UX][Bug] Fixing obsolete reference in Pokédex to filteredPokemonContainers

### DIFF
--- a/src/ui/pokedex-ui-handler.ts
+++ b/src/ui/pokedex-ui-handler.ts
@@ -1538,7 +1538,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
       return 0;
     });
 
-    this.filteredIndices = this.filteredPokemonContainers.map(c => c.species.speciesId);
+    this.filteredIndices = this.filteredPokemonData.map(c => c.species.speciesId);
 
     this.updateScroll();
   };


### PR DESCRIPTION
## Why am I making these changes?
Hotfix due to a hidden conflict between #5400 and #5372.

## What are the changes from a developer perspective?
#5372 introduced a reference to filteredPokemonContainers, which have been removed in #5400 . Referencing filteredPokemonData instead.

## Screenshots/Videos
The Pokédex is not crashing anymore and filters are working as expected.
![not_crashing](https://github.com/user-attachments/assets/7efbb0a7-02d8-4a08-875d-706e5b1e8f14)

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?