### PR TITLE
[Bug][UI] Fix arena flyout

### DIFF
--- a/src/ui-inputs.ts
+++ b/src/ui-inputs.ts
@@ -109,7 +109,7 @@ export class UiInputs {
       [Button.CYCLE_GENDER]:    () => undefined,
       [Button.CYCLE_ABILITY]:   () => undefined,
       [Button.CYCLE_NATURE]:    () => undefined,
-      [Button.CYCLE_TERA]:      () => undefined,
+      [Button.CYCLE_TERA]:      () => this.buttonInfo(false),
       [Button.SPEED_UP]:        () => undefined,
       [Button.SLOW_DOWN]:       () => undefined,
     };


### PR DESCRIPTION
## What are the changes the user will see?
The arena flyout will go away when you let go of V.

## Why am I making these changes?
It wasn't going away.

## What are the changes from a developer perspective?
I accidentally removed a key up handler I shouldn't've in the tera update.

## Screenshots/Videos


## How to test the changes?
Go into a battle, hit the flyout key.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?