### PR TITLE
[Bug] Fix Neutralizing Gas not Deactivating on Faint and Capture

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -6877,7 +6877,8 @@ export function initAbilities() {
       .attr(PreLeaveFieldRemoveSuppressAbilitiesSourceAbAttr)
       .attr(UncopiableAbilityAbAttr)
       .attr(UnswappableAbilityAbAttr)
-      .attr(NoTransformAbilityAbAttr),
+      .attr(NoTransformAbilityAbAttr)
+      .bypassFaint(),
     new Ability(Abilities.PASTEL_VEIL, 8)
       .attr(PostSummonUserFieldRemoveStatusEffectAbAttr, StatusEffect.POISON, StatusEffect.TOXIC)
       .attr(UserFieldStatusEffectImmunityAbAttr, StatusEffect.POISON, StatusEffect.TOXIC)


### PR DESCRIPTION
## What are the changes the user will see?
NG now deactivates when its user faints or is captured, as it should.

## Why am I making these changes?
Helps with #5422 (not saying "fixes" so it doesn't auto close when this is merged 🙏)

The reason it doesn't fix it entirely is because _no_ PreLeaveField abilities (this and primal weather) correctly end when fleeing from a pokemon. This has been the case since before the NG changes.

## What are the changes from a developer perspective?
I was genuinely just unaware of the `bypassFaint()` addition to abilities. This is necessary because both faint and capture are treated as the pokemon having 0 hp, so this must be added for the ability's` PreLeaveFieldAbAttr` to not be ignored. So, it's my 100th one line change this week.

I also added automated tests to ensure that this doesn't happen again.

## Screenshots/Videos

https://github.com/user-attachments/assets/e49b0ec4-5d11-4989-8497-f0dd17f0aa65

Notice the removal messages after faint and capture
## How to test the changes?
tests

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?