### PR TITLE
[Refactor] Move playerFaints to arena data

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1794,8 +1794,8 @@ export default class BattleScene extends SceneBase {
     return this.currentBattle;
   }
 
-  newArena(biome: Biome, playerFaints?: number): Arena {
-    this.arena = new Arena(biome, Biome[biome].toLowerCase(), playerFaints);
+  newArena(biome: Biome): Arena {
+    this.arena = new Arena(biome, Biome[biome].toLowerCase());
     this.eventTarget.dispatchEvent(new NewArenaEvent());
 
     this.arenaBg.pipelineData = {

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -58,14 +58,14 @@ export class Arena {
 
   public readonly eventTarget: EventTarget = new EventTarget();
 
-  constructor(biome: Biome, bgm: string, playerFaints: number = 0) {
+  constructor(biome: Biome, bgm: string) {
     this.biomeType = biome;
     this.tags = [];
     this.bgm = bgm;
     this.trainerPool = biomeTrainerPools[biome];
     this.updatePoolsForTimeOfDay();
     this.playerTerasUsed = 0;
-    this.playerFaints = playerFaints;
+    this.playerFaints = 0;
   }
 
   init() {

--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -249,8 +249,7 @@ export class GameOverPhase extends BattlePhase {
       timestamp: new Date().getTime(),
       challenges: globalScene.gameMode.challenges.map(c => new ChallengeData(c)),
       mysteryEncounterType: globalScene.currentBattle.mysteryEncounter?.encounterType ?? -1,
-      mysteryEncounterSaveData: globalScene.mysteryEncounterSaveData,
-      playerFaints: globalScene.arena.playerFaints
+      mysteryEncounterSaveData: globalScene.mysteryEncounterSaveData
     } as SessionSaveData;
   }
 }

--- a/src/system/arena-data.ts
+++ b/src/system/arena-data.ts
@@ -11,6 +11,7 @@ export default class ArenaData {
   public terrain: Terrain | null;
   public tags: ArenaTag[];
   public playerTerasUsed: number;
+  public playerFaints: number;
 
   constructor(source: Arena | any) {
     const sourceArena = source instanceof Arena ? source as Arena : null;
@@ -18,6 +19,7 @@ export default class ArenaData {
     this.weather = sourceArena ? sourceArena.weather : source.weather ? new Weather(source.weather.weatherType, source.weather.turnsLeft) : null;
     this.terrain = sourceArena ? sourceArena.terrain : source.terrain ? new Terrain(source.terrain.terrainType, source.terrain.turnsLeft) : null;
     this.playerTerasUsed = (sourceArena ? sourceArena.playerTerasUsed : source.playerTerasUsed) ?? 0;
+    this.playerFaints = (sourceArena ? sourceArena.playerFaints : source.playerFaints ) ?? 0;
     this.tags = [];
 
     if (source.tags) {

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -143,10 +143,6 @@ export interface SessionSaveData {
   challenges: ChallengeData[];
   mysteryEncounterType: MysteryEncounterType | -1; // Only defined when current wave is ME,
   mysteryEncounterSaveData: MysteryEncounterSaveData;
-  /**
-   * Counts the amount of pokemon fainted in your party during the current arena encounter.
-   */
-  playerFaints: number;
 }
 
 interface Unlocks {
@@ -971,8 +967,7 @@ export class GameData {
       timestamp: new Date().getTime(),
       challenges: globalScene.gameMode.challenges.map(c => new ChallengeData(c)),
       mysteryEncounterType: globalScene.currentBattle.mysteryEncounter?.encounterType ?? -1,
-      mysteryEncounterSaveData: globalScene.mysteryEncounterSaveData,
-      playerFaints: globalScene.arena.playerFaints
+      mysteryEncounterSaveData: globalScene.mysteryEncounterSaveData
     } as SessionSaveData;
   }
 
@@ -1064,7 +1059,7 @@ export class GameData {
 
           globalScene.mysteryEncounterSaveData = new MysteryEncounterSaveData(sessionData.mysteryEncounterSaveData);
 
-          globalScene.newArena(sessionData.arena.biome, sessionData.playerFaints);
+          globalScene.newArena(sessionData.arena.biome);
 
           const battleType = sessionData.battleType || 0;
           const trainerConfig = sessionData.trainer ? trainerConfigs[sessionData.trainer.trainerType] : null;

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1087,6 +1087,8 @@ export class GameData {
 
           globalScene.arena.playerTerasUsed = sessionData.arena.playerTerasUsed;
 
+          globalScene.arena.playerFaints = sessionData.arena.playerFaints;
+
           globalScene.arena.tags = sessionData.arena.tags;
           if (globalScene.arena.tags) {
             for (const tag of globalScene.arena.tags) {


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
- None

## Why am I making these changes?
<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->
- In #5200, `playerFaints` was tracked oddly. It's stored by the `Arena` class but not by `ArenaData`. This meant it wouldn't save. So instead, `playerFaints` was added straight to `sessionSaveData`, and the `Arena` constructor as well as `BattleScene.newArena()` required an extra parameter just to pass `sessionSaveData.playerFaints`.

## What are the changes from a developer perspective?
<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->
- Puts player faint count in `ArenaData` class so it's saved and loaded from there instead of at the root of session data.
- Removes unnecessary parameter from `Arena` constructor and `BattleScene.newArena()`

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?