### PR TITLE
[Bug][Hotfix] Fix bug with transfering all items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pokemon-rogue-battle",
-	"version": "1.7.1",
+	"version": "1.7.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pokemon-rogue-battle",
-			"version": "1.7.1",
+			"version": "1.7.2",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@material/material-color-utilities": "^0.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pokemon-rogue-battle",
 	"private": true,
-	"version": "1.7.1",
+	"version": "1.7.2",
 	"type": "module",
 	"scripts": {
 		"start": "vite",

--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -422,7 +422,10 @@ export default class PartyUiHandler extends MessageUiHandler {
               if (option === PartyOption.TRANSFER) {
                 if (this.transferCursor !== this.cursor) {
                   if (this.transferAll) {
-                    getTransferrableItemsFromPokemon(globalScene.getPlayerParty()[this.transferCursor]).forEach((_, i) => (this.selectCallback as PartyModifierTransferSelectCallback)(this.transferCursor, i, this.transferQuantitiesMax[i], this.cursor));
+                    getTransferrableItemsFromPokemon(globalScene.getPlayerParty()[this.transferCursor]).forEach((_, i, array) => {
+                      const invertedIndex = array.length - 1 - i;
+                      (this.selectCallback as PartyModifierTransferSelectCallback)(this.transferCursor, invertedIndex, this.transferQuantitiesMax[invertedIndex], this.cursor);
+                    });
                   } else {
                     (this.selectCallback as PartyModifierTransferSelectCallback)(this.transferCursor, this.transferOptionCursor, this.transferQuantities[this.transferOptionCursor], this.cursor);
                   }
@@ -1187,7 +1190,6 @@ class PartySlot extends Phaser.GameObjects.Container {
   public slotHpText: Phaser.GameObjects.Text;
   public slotDescriptionLabel: Phaser.GameObjects.Text; // this is used to show text instead of the HP bar i.e. for showing "Able"/"Not Able" for TMs when you try to learn them
 
-
   private pokemonIcon: Phaser.GameObjects.Container;
   private iconAnimHandler: PokemonIconAnimHandler;
 
@@ -1208,6 +1210,10 @@ class PartySlot extends Phaser.GameObjects.Container {
   }
 
   setup(partyUiMode: PartyUiMode, tmMoveId: Moves) {
+
+    const currentLanguage = i18next.resolvedLanguage ?? "en";
+    const offsetJa = currentLanguage === "ja";
+
     const battlerCount = globalScene.currentBattle.getBattlerCount();
 
     const slotKey = `party_slot${this.slotIndex >= battlerCount ? "" : "_main"}`;
@@ -1246,15 +1252,15 @@ class PartySlot extends Phaser.GameObjects.Container {
     nameSizeTest.destroy();
 
     this.slotName = addTextObject(0, 0, displayName, TextStyle.PARTY);
-    this.slotName.setPositionRelative(slotBg, this.slotIndex >= battlerCount ? 21 : 24, this.slotIndex >= battlerCount ? 2 : 10);
+    this.slotName.setPositionRelative(slotBg, this.slotIndex >= battlerCount ? 21 : 24, (this.slotIndex >= battlerCount ? 2 : 10) + (offsetJa ? 2 : 0));
     this.slotName.setOrigin(0, 0);
 
     const slotLevelLabel = globalScene.add.image(0, 0, "party_slot_overlay_lv");
-    slotLevelLabel.setPositionRelative(this.slotName, 8, 12);
+    slotLevelLabel.setPositionRelative(slotBg, (this.slotIndex >= battlerCount ? 21 : 24) + 8, (this.slotIndex >= battlerCount ? 2 : 10) + 12);
     slotLevelLabel.setOrigin(0, 0);
 
     const slotLevelText = addTextObject(0, 0, this.pokemon.level.toString(), this.pokemon.level < globalScene.getMaxExpLevel() ? TextStyle.PARTY : TextStyle.PARTY_RED);
-    slotLevelText.setPositionRelative(slotLevelLabel, 9, 0);
+    slotLevelText.setPositionRelative(slotLevelLabel, 9, offsetJa ? 1.5 : 0);
     slotLevelText.setOrigin(0, 0.25);
 
     slotInfoContainer.add([ this.slotName, slotLevelLabel, slotLevelText ]);
@@ -1331,7 +1337,7 @@ class PartySlot extends Phaser.GameObjects.Container {
     this.slotHpOverlay.setVisible(false);
 
     this.slotHpText = addTextObject(0, 0, `${this.pokemon.hp}/${this.pokemon.getMaxHp()}`, TextStyle.PARTY);
-    this.slotHpText.setPositionRelative(this.slotHpBar, this.slotHpBar.width - 3, this.slotHpBar.height - 2);
+    this.slotHpText.setPositionRelative(this.slotHpBar, this.slotHpBar.width - 3, this.slotHpBar.height - 2 + (offsetJa ? 2 : 0));
     this.slotHpText.setOrigin(1, 0);
     this.slotHpText.setVisible(false);
 


### PR DESCRIPTION
## Why am I making these changes?
After 1.7.0 the "Transfer -> All" function is broken. The reason seemingly comes from #5283.

Bug report on discord (follow the links to find session data):
https://discord.com/channels/1125469663833370665/1344837990031167499

## What are the changes from a developer perspective?
When transfering all items, the game was checking the list of the items and moving up, with an index going from 0 to the length of the item array. This was fine before, probably due to the actual transfer happening asyncronously. However, with the Promise changes, the length of the array changes after each iteration and at some point the index goes over the length of the array of remaining items.

The solution is the oldest trick in the book, scan the array from the bottom.

## Screenshots/Videos

https://github.com/user-attachments/assets/1e07a1a7-f118-48d4-ab00-86c78160cc42

Also working when item does not get transferred:
https://github.com/user-attachments/assets/b673e110-84da-43ec-9c1e-8c5b3897bcda


## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?