### PR TITLE
[Bug] Fix mycelium might softlock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pokemon-rogue-battle",
-	"version": "1.7.2",
+	"version": "1.7.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pokemon-rogue-battle",
-			"version": "1.7.2",
+			"version": "1.7.3",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@material/material-color-utilities": "^0.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pokemon-rogue-battle",
 	"private": true,
-	"version": "1.7.2",
+	"version": "1.7.3",
 	"type": "module",
 	"scripts": {
 		"start": "vite",

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -5054,7 +5054,7 @@ export class PreventBypassSpeedChanceAbAttr extends AbAttr {
     const turnCommand = globalScene.currentBattle.turnCommands[pokemon.getBattlerIndex()];
     const isCommandFight = turnCommand?.command === Command.FIGHT;
     const move = turnCommand?.move?.move ? allMoves[turnCommand.move.move] : null;
-    if (this.condition(pokemon, move!) && isCommandFight) {
+    if (isCommandFight && this.condition(pokemon, move!)) {
       bypassSpeed.value = false;
       canCheckHeldItems.value = false;
       return false;


### PR DESCRIPTION
## What are the changes the user will see?
Mycelium Might crashes the game if the pokemon does anything except use a move.

## Why am I making these changes?
Game crashing.

## What are the changes from a developer perspective?
Something in the recent ability changes has caused mycelium might to start firing more, revealing a bug in its code. This fixes the broken conditional.

## Screenshots/Videos


## How to test the changes?
Use one of the sessions available on discord, it won't crash now when it did before.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?