### PR TITLE
[Bug][Hotfix] Restrict Use Candies option in the Pokédex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pokemon-rogue-battle",
-	"version": "1.7.4",
+	"version": "1.7.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pokemon-rogue-battle",
-			"version": "1.7.4",
+			"version": "1.7.5",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@material/material-color-utilities": "^0.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pokemon-rogue-battle",
 	"private": true,
-	"version": "1.7.4",
+	"version": "1.7.5",
 	"type": "module",
 	"scripts": {
 		"start": "vite",

--- a/src/ui/pokedex-page-ui-handler.ts
+++ b/src/ui/pokedex-page-ui-handler.ts
@@ -558,7 +558,8 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
 
   show(args: any[]): boolean {
 
-    this.canUseCandies = false;
+    // Allow the use of candies if we are in one of the whitelisted phases
+    this.canUseCandies = [ "TitlePhase", "SelectStarterPhase", "CommandPhase" ].includes(globalScene.getCurrentPhase()?.constructor.name ?? "");
 
     if (args.length >= 1 && args[0] === "refresh") {
       return false;

--- a/src/ui/pokedex-page-ui-handler.ts
+++ b/src/ui/pokedex-page-ui-handler.ts
@@ -250,6 +250,8 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
   private availableVariants: number;
   private unlockedVariants: boolean[];
 
+  private canUseCandies: boolean;
+
   constructor() {
     super(Mode.POKEDEX_PAGE);
   }
@@ -555,6 +557,8 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
   }
 
   show(args: any[]): boolean {
+
+    this.canUseCandies = false;
 
     if (args.length >= 1 && args[0] === "refresh") {
       return false;
@@ -1626,7 +1630,7 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
             }
             break;
           case Button.STATS:
-            if (!isCaught || !isFormCaught) {
+            if (!isCaught || !isFormCaught || !this.canUseCandies) {
               error = true;
             } else {
               const ui = this.getUi();
@@ -1888,7 +1892,9 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
 
     if (this.isCaught()) {
       if (isFormCaught) {
-        this.updateButtonIcon(SettingKeyboard.Button_Stats, gamepadType, this.candyUpgradeIconElement, this.candyUpgradeLabel);
+        if (this.canUseCandies) {
+          this.updateButtonIcon(SettingKeyboard.Button_Stats, gamepadType, this.candyUpgradeIconElement, this.candyUpgradeLabel);
+        }
         if (this.canCycleShiny) {
           this.updateButtonIcon(SettingKeyboard.Button_Cycle_Shiny, gamepadType, this.shinyIconElement, this.shinyLabel);
         }


### PR DESCRIPTION
## Why am I making these changes?
It was pointed out that using candies in the Pokédex during the shop phase can be exploited to dupe rewards for catching mons. #5444 

## What are the changes from a developer perspective?
Introducing a `canUseCandies `condition in the dex which is only `true` in whitelisted phases.

## Screenshots/Videos
The option does not show up anymore, even though Pidgey has more than enough candies:
![no-candies-for-pidgey](https://github.com/user-attachments/assets/5cc27717-64a6-4a08-a3ba-588d4240ee88)

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?