### PR TITLE
[Bug] Display Pokémon name in Focus Punch lost focus message

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -9384,7 +9384,7 @@ export function initMoves() {
       .attr(BypassBurnDamageReductionAttr),
     new AttackMove(Moves.FOCUS_PUNCH, Type.FIGHTING, MoveCategory.PHYSICAL, 150, 100, 20, -1, -3, 3)
       .attr(MessageHeaderAttr, (user, move) => i18next.t("moveTriggers:isTighteningFocus", { pokemonName: getPokemonNameWithAffix(user) }))
-      .attr(PreUseInterruptAttr, i18next.t("moveTriggers:lostFocus"), user => !!user.turnData.attacksReceived.find(r => r.damage))
+      .attr(PreUseInterruptAttr, (user, target, move) => i18next.t("moveTriggers:lostFocus", { pokemonName: getPokemonNameWithAffix(user) }), user => !!user.turnData.attacksReceived.find(r => r.damage))
       .punchingMove(),
     new AttackMove(Moves.SMELLING_SALTS, Type.NORMAL, MoveCategory.PHYSICAL, 70, 100, 10, -1, 0, 3)
       .attr(MovePowerMultiplierAttr, (user, target, move) => target.status?.effect === StatusEffect.PARALYSIS ? 2 : 1)

--- a/test/moves/focus_punch.test.ts
+++ b/test/moves/focus_punch.test.ts
@@ -140,6 +140,6 @@ describe("Moves - Focus Punch", () => {
     await game.phaseInterceptor.to("MessagePhase", false);
     const consoleSpy = vi.spyOn(console, "log");
     await game.phaseInterceptor.to("MoveEndPhase", true);
-    expect(consoleSpy).nthCalledWith(1, i18next.t("moveTriggers:lostFocus"));
+    expect(consoleSpy).nthCalledWith(1, i18next.t("moveTriggers:lostFocus", { pokemonName: "Charizard" }));
   });
 });


### PR DESCRIPTION
## Why am I making these changes?
Fixes #5442 , also reported [on Discord](https://discord.com/channels/1125469663833370665/1345085765440503920)

## What are the changes from a developer perspective?
After #5341 , the locales string was generated in the code without passing the pokemonName argument, this is now fixed.

## Screenshots/Videos

https://github.com/user-attachments/assets/8add358c-f674-4a7c-a6ea-61c97553e07d

![magikarplostfocus](https://github.com/user-attachments/assets/ce3437dc-33f5-4e03-aa05-9df434ac2aa6)

![best_focus_puncher](https://github.com/user-attachments/assets/da7d1e3b-9969-4f46-9ae7-bac5a1e8e8d9)


## How to test the changes?
E.g. with this override:
```
const overrides = {
  MOVESET_OVERRIDE: [ Moves.FOCUS_PUNCH ],
  OPP_MOVESET_OVERRIDE: [ Moves.QUICK_ATTACK ],
  OPP_SPECIES_OVERRIDE:  Species.MAGIKARP,
  ABILITY_OVERRIDE: Abilities.BALL_FETCH,
  OPP_ABILITY_OVERRIDE: Abilities.STURDY,
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?