### PR TITLE
[Bug][UI/UX] Never select invisible containers in Pokédex

### DIFF
--- a/src/ui/pokedex-ui-handler.ts
+++ b/src/ui/pokedex-ui-handler.ts
@@ -1108,7 +1108,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
             }
             break;
           case Button.DOWN:
-            if (currentRow < numOfRows - 1) { // not last row
+            if ((currentRow < numOfRows - 1) && (this.cursor + 9 < this.filteredPokemonData.length)) { // not last row
               if (currentRow - this.scrollCursor === 8) { // last row of visible pokemon
                 this.scrollCursor++;
                 this.updateScroll();

--- a/src/ui/pokedex-ui-handler.ts
+++ b/src/ui/pokedex-ui-handler.ts
@@ -986,7 +986,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
             this.updateScroll();
             const proportion = this.filterBarCursor / Math.max(1, this.filterBar.numFilters - 1);
             const targetCol = Math.min(8, proportion < 0.5 ? Math.floor(proportion * 8) : Math.ceil(proportion * 8));
-            this.setCursor(Math.min(targetCol, numberOfStarters));
+            this.setCursor(Math.min(targetCol, numberOfStarters - 1));
             success = true;
           }
           break;


### PR DESCRIPTION
## Why am I making these changes?
Fixes a bug reported on discord [here](https://discord.com/channels/1125469663833370665/1338291479449178223/1344979140163670067) which causes the cursor to move to a supposedly empty space and display the Pokémon in the respective container.
This happens in two cases:
1) Going down from the filter bar when only a few Pokémon are being shown, e.g. from the 2nd filter when only 1 Pokémon is shown
2) Going down from the second-to-last row of Pokémon

## What are the changes from a developer perspective?
Added a check to ensure that the cursor index doesn't go above the number of filtered Pokémon. Correctly setting the cursor index when going down from filter bar.

## Screenshots/Videos
https://github.com/user-attachments/assets/124e2887-27ce-491b-a391-e1c1700c0ff7

## How to test the changes?
Open the dex, select some filters.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?