### PR TITLE
[Bug][UI/UX] Restore egg/tm move and passive icons when using filters in Pokédex

### DIFF
--- a/src/ui/pokedex-ui-handler.ts
+++ b/src/ui/pokedex-ui-handler.ts
@@ -1577,6 +1577,37 @@ export default class PokedexUiHandler extends MessageUiHandler {
           container.icon.setTint(0);
         }
 
+        if (data.eggMove1) {
+          container.eggMove1Icon.setVisible(true);
+        } else {
+          container.eggMove1Icon.setVisible(false);
+        }
+        if (data.eggMove2) {
+          container.eggMove2Icon.setVisible(true);
+        } else {
+          container.eggMove2Icon.setVisible(false);
+        }
+        if (data.tmMove1) {
+          container.tmMove1Icon.setVisible(true);
+        } else {
+          container.tmMove1Icon.setVisible(false);
+        }
+        if (data.tmMove2) {
+          container.tmMove2Icon.setVisible(true);
+        } else {
+          container.tmMove2Icon.setVisible(false);
+        }
+        if (data.passive1) {
+          container.passive1Icon.setVisible(true);
+        } else {
+          container.passive1Icon.setVisible(false);
+        }
+        if (data.passive2) {
+          container.passive2Icon.setVisible(true);
+        } else {
+          container.passive2Icon.setVisible(false);
+        }
+
         if (this.showDecorations) {
 
           if (this.pokerusSpecies.includes(data.species)) {


### PR DESCRIPTION
## Why am I making these changes?
As reported [on Discord](https://discord.com/channels/1125469663833370665/1339431072152162395/1345177621314670599), icons that indicate egg or tm moves ir passives while filtering are not showing up.

## What are the changes from a developer perspective?
Code to turn the icons visible when needed had not been included after the refactoring in #5400, it is added now.

## Screenshots/Videos
![filter_2](https://github.com/user-attachments/assets/971affc1-c324-4283-95b1-f18b39cd8d8f)
![fliter_1](https://github.com/user-attachments/assets/2e13f583-e563-4592-8001-a4580ac14feb)

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?