### PR TITLE
[Bug][UI/UX] Make candy icons show up again in starter select screen

### DIFF
--- a/src/ui/abstact-option-select-ui-handler.ts
+++ b/src/ui/abstact-option-select-ui-handler.ts
@@ -147,7 +147,7 @@ export default abstract class AbstractOptionSelectUiHandler extends UiHandler {
         itemIcon.setScale(3 * this.scale);
         this.optionSelectIcons.push(itemIcon);
 
-        this.optionSelectContainer.add(itemIcon);
+        this.optionSelectTextContainer.add(itemIcon);
 
         itemIcon.setPositionRelative(this.optionSelectText, 36 * this.scale, 7 + i * (114 * this.scale - 3));
 
@@ -156,7 +156,7 @@ export default abstract class AbstractOptionSelectUiHandler extends UiHandler {
           itemOverlayIcon.setScale(3 * this.scale);
           this.optionSelectIcons.push(itemOverlayIcon);
 
-          this.optionSelectContainer.add(itemOverlayIcon);
+          this.optionSelectTextContainer.add(itemOverlayIcon);
 
           itemOverlayIcon.setPositionRelative(this.optionSelectText, 36 * this.scale, 7 + i * (114 * this.scale - 3));
 


### PR DESCRIPTION
## Why am I making these changes?
The changes to the option select ui handler in #5396 had accidentally made the icons invisible.

## What are the changes from a developer perspective?
The icons are moved to the container now used to manage visibility.

## Screenshots/Videos
![candy_icons](https://github.com/user-attachments/assets/1c5c9ac7-03e8-4b39-b285-367059c57cd4)

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?