### PR TITLE
[Bug] Unlocking correct base form of Zygarde when captured

### DIFF
--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1645,11 +1645,19 @@ export class GameData {
           } else if (formIndex === 3) {
             dexEntry.caughtAttr |= globalScene.gameData.getFormAttr(1);
           }
-        }
-        const allFormChanges = pokemonFormChanges.hasOwnProperty(species.speciesId) ? pokemonFormChanges[species.speciesId] : [];
-        const toCurrentFormChanges = allFormChanges.filter(f => (f.formKey === formKey));
-        if (toCurrentFormChanges.length > 0) {
-          dexEntry.caughtAttr |= globalScene.gameData.getFormAttr(0);
+        } else if (pokemon.species.speciesId === Species.ZYGARDE) {
+          if (formIndex === 4) {
+            dexEntry.caughtAttr |= globalScene.gameData.getFormAttr(2);
+          } else if (formIndex === 5) {
+            dexEntry.caughtAttr |= globalScene.gameData.getFormAttr(3);
+          }
+        } else {
+          const allFormChanges = pokemonFormChanges.hasOwnProperty(species.speciesId) ? pokemonFormChanges[species.speciesId] : [];
+          const toCurrentFormChanges = allFormChanges.filter(f => (f.formKey === formKey));
+          if (toCurrentFormChanges.length > 0) {
+            // Needs to do this or Castform can unlock the wrong form, etc.
+            dexEntry.caughtAttr |= globalScene.gameData.getFormAttr(0);
+          }
         }
       }
 


### PR DESCRIPTION
## Why am I making these changes?
An extension to #5385 which ensures that the correct base form of Zygarde is unlocked upon capturing it. Reported on Discord [here](https://discord.com/channels/1125469663833370665/1344848688610148522).

## What are the changes from a developer perspective?
More hard-coding. Yay!

## Screenshots/Videos

Before:
https://github.com/user-attachments/assets/a1b1d8ea-f4d3-4f9d-ac35-575b5e7d7c42

After:
https://github.com/user-attachments/assets/23b89a83-18a6-443a-bb0e-af0c3886346b
https://github.com/user-attachments/assets/53e737ba-5efa-4d9d-9b26-b3a435b4dfae


## How to test the changes?
The override is
```
const overrides = {
  STARTING_WAVE_OVERRIDE: 11,
  OPP_SPECIES_OVERRIDE: Species.ZYGARDE,
  OPP_FORM_OVERRIDES: {[Species.ZYGARDE]: 4},
  POKEBALL_OVERRIDE: {
    active: true,
    pokeballs: {
      [PokeballType.POKEBALL]: 0,
      [PokeballType.GREAT_BALL]: 0,
      [PokeballType.ULTRA_BALL]: 0,
      [PokeballType.ROGUE_BALL]: 0,
      [PokeballType.MASTER_BALL]: 99,
    },
  }
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?