### PR TITLE
[Bug][UI/UX] Starter select screen now looks for and displays form-specific abilities

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -8,6 +8,7 @@ import i18next from "i18next";
 import type BBCodeText from "phaser3-rex-plugins/plugins/bbcodetext";
 import { starterColors } from "#app/battle-scene";
 import { globalScene } from "#app/global-scene";
+import type { Ability } from "#app/data/ability";
 import { allAbilities } from "#app/data/ability";
 import { speciesEggMoves } from "#app/data/balance/egg-moves";
 import { GrowthRate, getGrowthRateColor } from "#app/data/exp";
@@ -3364,7 +3365,12 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       }
 
       if (dexEntry.caughtAttr) {
-        const ability = allAbilities[this.lastSpecies.getAbility(abilityIndex!)]; // TODO: is this bang correct?
+        let ability: Ability;
+        if (this.lastSpecies.forms?.length > 1) {
+          ability = allAbilities[this.lastSpecies.forms[formIndex ?? 0].getAbility(abilityIndex!)];
+        } else {
+          ability = allAbilities[this.lastSpecies.getAbility(abilityIndex!)]; // TODO: is this bang correct?
+        }
         this.pokemonAbilityText.setText(ability.name);
 
         const isHidden = abilityIndex === (this.lastSpecies.ability2 ? 2 : 1);


### PR DESCRIPTION
## Why am I making these changes?
As documented in this video, the starter select screen does not account for alternate forms having different abilities:

https://github.com/user-attachments/assets/f8d572e1-a8bd-4790-b71a-05dddeefe851

## What are the changes from a developer perspective?
Explicitly check for the ability of the form, rather than the species, whenever there is more than one form.

## Screenshots/Videos
After the changes:

https://github.com/user-attachments/assets/bb38efd5-cb05-4829-aa45-831350c534ce


## How to test the changes?
Load a save with all or many unlocks and look around the starter select screen.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?