### PR TITLE
[Bug][UI/UX] Shiny button can cycle variants even if non-shiny form is uncaught

### DIFF
--- a/src/ui/pokedex-page-ui-handler.ts
+++ b/src/ui/pokedex-page-ui-handler.ts
@@ -1575,15 +1575,14 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
 
                 starterAttributes.variant = newVariant; // store the selected variant
                 this.savedStarterAttributes.variant = starterAttributes.variant;
-                if (newVariant > props.variant) {
-                  this.setSpeciesDetails(this.species, { variant: newVariant as Variant });
-                  success = true;
-                } else {
+                if ((this.isCaught() & DexAttr.NON_SHINY) && (newVariant <= props.variant)) {
                   this.setSpeciesDetails(this.species, { shiny: false, variant: 0 });
                   success = true;
-
                   starterAttributes.shiny = false;
                   this.savedStarterAttributes.shiny = starterAttributes.shiny;
+                } else {
+                  this.setSpeciesDetails(this.species, { variant: newVariant as Variant });
+                  success = true;
                 }
               }
             }
@@ -2196,7 +2195,8 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
       const isNonShinyCaught = !!(caughtAttr & DexAttr.NON_SHINY);
       const isShinyCaught = !!(caughtAttr & DexAttr.SHINY);
 
-      this.canCycleShiny = isNonShinyCaught && isShinyCaught;
+      const caughtVariants = [ DexAttr.DEFAULT_VARIANT, DexAttr.VARIANT_2, DexAttr.VARIANT_3 ].filter(v => caughtAttr & v);
+      this.canCycleShiny = (isNonShinyCaught && isShinyCaught) || (isShinyCaught && caughtVariants.length > 1);
 
       const isMaleCaught = !!(caughtAttr & DexAttr.MALE);
       const isFemaleCaught = !!(caughtAttr & DexAttr.FEMALE);

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -2067,20 +2067,20 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
                   }
                 } while (newVariant !== props.variant);
                 starterAttributes.variant = newVariant; // store the selected variant
-                // If going to a higher variant, display that
-                if (newVariant > props.variant) {
+                if ((this.speciesStarterDexEntry!.caughtAttr & DexAttr.NON_SHINY) && (newVariant <= props.variant)) {
+                  // If we have run out of variants, go back to non shiny
+                  this.setSpeciesDetails(this.lastSpecies, { shiny: false, variant: 0 });
+                  this.pokemonShinyIcon.setVisible(false);
+                  success = true;
+                  starterAttributes.shiny = false;
+                } else {
+                  // If going to a higher variant, or only shiny forms are caught, go to next variant
                   this.setSpeciesDetails(this.lastSpecies, { variant: newVariant as Variant });
                   // Cycle tint based on current sprite tint
                   const tint = getVariantTint(newVariant as Variant);
                   this.pokemonShinyIcon.setFrame(getVariantIcon(newVariant as Variant));
                   this.pokemonShinyIcon.setTint(tint);
                   success = true;
-                // If we have run out of variants, go back to non shiny
-                } else {
-                  this.setSpeciesDetails(this.lastSpecies, { shiny: false, variant: 0 });
-                  this.pokemonShinyIcon.setVisible(false);
-                  success = true;
-                  starterAttributes.shiny = false;
                 }
               }
             }
@@ -3327,7 +3327,8 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         const isNonShinyCaught = !!(caughtAttr & DexAttr.NON_SHINY);
         const isShinyCaught = !!(caughtAttr & DexAttr.SHINY);
 
-        this.canCycleShiny = isNonShinyCaught && isShinyCaught;
+        const caughtVariants = [ DexAttr.DEFAULT_VARIANT, DexAttr.VARIANT_2, DexAttr.VARIANT_3 ].filter(v => caughtAttr & v);
+        this.canCycleShiny = (isNonShinyCaught && isShinyCaught) || (isShinyCaught && caughtVariants.length > 1);
 
         const isMaleCaught = !!(caughtAttr & DexAttr.MALE);
         const isFemaleCaught = !!(caughtAttr & DexAttr.FEMALE);


### PR DESCRIPTION
## Why am I making these changes?
When the variant button was removed by #5213, a minor bug was introduced which prevents the player from switching between variants if the non-shiny form is not caught. This has been reported on discord e.g. [here](https://discord.com/channels/1125469663833370665/1125894949020381285/1345114255833305181). See also these screenshots (from a save where all three variants of Miraidon are unlocked, but the non-shiny form is not): the "cycle shiny" button does not appear.
![mira_dex](https://github.com/user-attachments/assets/e1573f25-136b-48b1-8097-9fe840ef76e9)
![mira_ss](https://github.com/user-attachments/assets/8f8c35f4-da4d-4511-ba26-774326d8006f)

## What are the changes from a developer perspective?
`canCycleShiny` is now true if at least two variants are caught. The logic for cycling shiny has been reworked to loop correctly ig the non-shiny form is not caught.

## Screenshots/Videos

Shiny Miraidon cycling correctly:

https://github.com/user-attachments/assets/0af97659-b7a8-4f84-8eeb-dd4833141760


Proof that the button is still working properly when non-shiny forms are also caught:

https://github.com/user-attachments/assets/7143a191-39f8-46ba-8868-ace13c3d851e


## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?