### PR TITLE
[Bug][UI/UX] Fix bug in Pokédex for Mothim and other niche cases

### DIFF
--- a/src/ui/pokedex-page-ui-handler.ts
+++ b/src/ui/pokedex-page-ui-handler.ts
@@ -784,6 +784,10 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
     const formIndex = otherFormIndex !== undefined ? otherFormIndex : this.formIndex;
     const caughtAttr = this.isCaught(species);
 
+    if (caughtAttr && (!species.forms.length || species.forms.length === 1)) {
+      return true;
+    }
+
     const isFormCaught = (caughtAttr & globalScene.gameData.getFormAttr(formIndex ?? 0)) > 0n;
     return isFormCaught;
   }


### PR DESCRIPTION
## Why am I making these changes?
Discord bug report is [here](https://discord.com/channels/1125469663833370665/1345408533797146685)

This is a bit convoluted. The game keeps track of caught forms for every caught species. For species that have no forms, it still marks the "default form" as caught. Now, it turns out that if you evolve a Sand Cloak or Trash Cloak Burmy into Mothim, the "default form" on Mothim is _not_ marked as uncaught, probably because the game tries to unlock form 1 and 2, respectively, instead. A similar thing happens with Milcery when catching an Alcremie form with formIndex > 0, and there might be other niche cases as well.

This normally has no impact whatsoever, because these mons do not actually have a form to use anywhere in the code. The Pokédex, however, was checking `DexAttr.DEFAULT_FORM`, causing Mothim and Milcery to be shown as uncaught unless they had been obtained in a specific way. This can be easily fixed in the dex and is probably minor enough not to warrant other code changes and a save migration (although we can do that later on if it turns out to be necessary).

## What are the changes from a developer perspective?
This PR is focused solely on ensuring consistent behavior in the dex. The `isFormCaught()` function now always returns `true` if the species is caught and it only has a single form or no forms at all.

## Screenshots/Videos
Screenshots from a save where Mothim and Milcery both do not have `DexAttr.DEFAULT_FORM` (see that form 0 of Alcremie is not caught).
![alcreamie](https://github.com/user-attachments/assets/e2756076-3fea-420c-a88e-acbfd3169b48)
![milcery](https://github.com/user-attachments/assets/dc244f45-db80-4ccd-90b2-813950be60b0)
![mothim](https://github.com/user-attachments/assets/0a62aa7a-3d01-4b9a-8f22-7188bdea7897)

## How to test the changes?
A bit tricky, but one way is to start the game from a blank save file and catch Sand CLoak Burmy -> evolve it, or catch a random form of Alcremie, and checking that Mothim or Milcery are displayed correctly.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?