### PR TITLE
[GitHub] Update CODEOWNERS to have teams own the files they should

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,3 +17,6 @@
 *.wav @pagefaultgames/composer-team
 *.ogg @pagefaultgames/composer-team
 /public/audio @pagefaultgames/composer-team
+
+# Balance Files; contain actual code logic and must also be owned by dev team
+/src/data/balance @pagefaultgames/balance-team @pagefaultgames/junior-dev-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,10 @@
 * @pagefaultgames/junior-dev-team
 
 # github actions/templates etc. - Dev Leads
-/.github @pagefaultgames/dev-leads
+/.github @pagefaultgames/senior-dev-team
+
+# Art Team
+/public/**/*.png @pagefaultgames/art-team
+/public/**/*.json @pagefaultgames/art-team  
+/public/images @pagefaultgames/art-team
+/public/battle-anims @pagefaultgames/art-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,3 +11,9 @@
 /public/**/*.json @pagefaultgames/art-team  
 /public/images @pagefaultgames/art-team
 /public/battle-anims @pagefaultgames/art-team
+
+# Audio files
+*.mp3 @pagefaultgames/composer-team
+*.wav @pagefaultgames/composer-team
+*.ogg @pagefaultgames/composer-team
+/public/audio @pagefaultgames/composer-team


### PR DESCRIPTION
## What are the changes the user will see?
None

## Why am I making these changes?
Lots of requests for this to happen. Also it's annoying to be put on PRs that I don't really have much business reviewing.

## What are the changes from a developer perspective?
Added the following to `.github/CODEOWNERS` to make art-team and composer-team codeowners of their files.

This rightly means that junior-dev-team is no longer considered code owners for files matching these patterns

```
# Art Team
/public/**/*.png @pagefaultgames/art-team
/public/**/*.json @pagefaultgames/art-team  
/public/images @pagefaultgames/art-team
/public/battle-anims @pagefaultgames/art-team
```

```
# composer-team
*.mp3 @pagefaultgames/composer-team
*.wav @pagefaultgames/composer-team
*.ogg @pagefaultgames/composer-team
/public/audio @pagefaultgames/composer-team
```

Added balance-team to code owners of `src/data/balance`, keeping junior-dev-team as codeowners as it contains real code logic as well,

Also made senior-dev-team codeowners for /.github (it was previously dev-leads which does not exist).

## Screenshots/Videos
N/A

## How to test the changes?
N/A

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?