### PR TITLE
[Balance] Make megas/max player pokemon unable to tera

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1226,10 +1226,15 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Checks if the {@linkcode Pokemon} has is the specified {@linkcode Species} or is fused with it.
    * @param species the pokemon {@linkcode Species} to check
+   * @param formKey If provided, requires the species to be in that form
    * @returns `true` if the pokemon is the species or is fused with it, `false` otherwise
    */
-  hasSpecies(species: Species): boolean {
-    return this.species.speciesId === species || this.fusionSpecies?.speciesId === species;
+  hasSpecies(species: Species, formKey?: string): boolean {
+    if (Utils.isNullOrUndefined(formKey)) {
+      return this.species.speciesId === species || this.fusionSpecies?.speciesId === species;
+    }
+
+    return (this.species.speciesId === species && this.getFormKey() === formKey) || (this.fusionSpecies?.speciesId === species && this.getFusionFormKey() === formKey);
   }
 
   abstract isBoss(): boolean;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3204,6 +3204,11 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     return maxForms.includes(this.getFormKey()) || (!!this.getFusionFormKey() && maxForms.includes(this.getFusionFormKey()!));
   }
 
+  isMega(): boolean {
+    const megaForms = [ SpeciesFormKey.MEGA, SpeciesFormKey.MEGA_X, SpeciesFormKey.MEGA_Y, SpeciesFormKey.PRIMAL ] as string[];
+    return megaForms.includes(this.getFormKey()) || (!!this.getFusionFormKey() && megaForms.includes(this.getFusionFormKey()!));
+  }
+
   canAddTag(tagType: BattlerTagType): boolean {
     if (this.getTag(tagType)) {
       return false;

--- a/src/ui/command-ui-handler.ts
+++ b/src/ui/command-ui-handler.ts
@@ -180,9 +180,10 @@ export default class CommandUiHandler extends UiHandler {
 
   canTera(): boolean {
     const hasTeraMod = !!globalScene.getModifiers(TerastallizeAccessModifier).length;
+    const isBlockedForm = globalScene.getField()[this.fieldIndex].isMega() || globalScene.getField()[this.fieldIndex].isMax();
     const currentTeras = globalScene.arena.playerTerasUsed;
     const plannedTera = globalScene.currentBattle.preTurnCommands[0]?.command === Command.TERA && this.fieldIndex > 0 ? 1 : 0;
-    return hasTeraMod && (currentTeras + plannedTera) < 1;
+    return hasTeraMod && !isBlockedForm && (currentTeras + plannedTera) < 1;
   }
 
   toggleTeraButton() {

--- a/src/ui/command-ui-handler.ts
+++ b/src/ui/command-ui-handler.ts
@@ -10,6 +10,7 @@ import { globalScene } from "#app/global-scene";
 import { TerastallizeAccessModifier } from "#app/modifier/modifier";
 import { Type } from "#app/enums/type";
 import { getTypeRgb } from "#app/data/type";
+import { Species } from "#enums/species";
 
 export enum Command {
   FIGHT = 0,
@@ -180,7 +181,8 @@ export default class CommandUiHandler extends UiHandler {
 
   canTera(): boolean {
     const hasTeraMod = !!globalScene.getModifiers(TerastallizeAccessModifier).length;
-    const isBlockedForm = globalScene.getField()[this.fieldIndex].isMega() || globalScene.getField()[this.fieldIndex].isMax();
+    const activePokemon = globalScene.getField()[this.fieldIndex];
+    const isBlockedForm = activePokemon.isMega() || activePokemon.isMax() || activePokemon.hasSpecies(Species.NECROZMA, "ultra");
     const currentTeras = globalScene.arena.playerTerasUsed;
     const plannedTera = globalScene.currentBattle.preTurnCommands[0]?.command === Command.TERA && this.fieldIndex > 0 ? 1 : 0;
     return hasTeraMod && !isBlockedForm && (currentTeras + plannedTera) < 1;


### PR DESCRIPTION
## What are the changes the user will see?
The player's mega and dynamax pokemon will no longer be able to tera.

Note: This doesn't currently revert existing teras, that's being saved for 1.8.

## Why am I making these changes?
Damo asked.

## What are the changes from a developer perspective?
A new isMega function to go alongside isMax, and a slight tweak to the logic checking whether a pokemon can tera.

## Screenshots/Videos
![image](https://github.com/user-attachments/assets/1dbbc417-3491-495f-ab93-04ff3961e708)
![image](https://github.com/user-attachments/assets/526b06eb-0a3d-46d0-8199-3040cd043d81)

## How to test the changes?
Mega or gigantamax some pokemon.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?