### PR TITLE
[UI/UX] Make left button also go back to the run history screen from run info

### DIFF
--- a/src/ui/run-info-ui-handler.ts
+++ b/src/ui/run-info-ui-handler.ts
@@ -889,7 +889,7 @@ export default class RunInfoUiHandler extends UiHandler {
   /**
    * Takes input from the user to perform a desired action.
    * @param button - Button object to be processed
-   * Button.CANCEL - removes all containers related to RunInfo and returns the user to Run History
+   * Button.CANCEL, Button.LEFT - removes all containers related to RunInfo and returns the user to Run History
    * Button.CYCLE_FORM, Button.CYCLE_SHINY, Button.CYCLE_ABILITY - runs the function buttonCycleOption()
    */
  	override processInput(button: Button): boolean {
@@ -900,6 +900,7 @@ export default class RunInfoUiHandler extends UiHandler {
 
     switch (button) {
       case Button.CANCEL:
+      case Button.LEFT:
         success = true;
         if (this.pageMode === RunInfoUiMode.MAIN) {
           this.runInfoContainer.removeAll(true);


### PR DESCRIPTION
## What are the changes the user will see?
Hitting left will go back to the run history screen from the run info screen.

## Why am I making these changes?
I have to hit right to get to the run info screen, which makes me intuitively try to hit left to go back, but the left key doesn't go back.

## What are the changes from a developer perspective?
One line added to a switch case and a small comment added

## Screenshots/Videos
This isn't a very screenshottable change

## How to test the changes?
Go to run info for a run and hit the left key

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?