### PR TITLE
[Balance] Make Pickup and Honey Gather Unsuppressable

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -6186,7 +6186,8 @@ export function initAbilities() {
       .attr(ProtectStatAbAttr, Stat.ATK)
       .ignorable(),
     new Ability(Abilities.PICKUP, 3)
-      .attr(PostBattleLootAbAttr),
+      .attr(PostBattleLootAbAttr)
+      .attr(UnsuppressableAbilityAbAttr),
     new Ability(Abilities.TRUANT, 3)
       .attr(PostSummonAddBattlerTagAbAttr, BattlerTagType.TRUANT, 1, false),
     new Ability(Abilities.HUSTLE, 3)
@@ -6378,7 +6379,8 @@ export function initAbilities() {
       .attr(PostSummonWeatherChangeAbAttr, WeatherType.SNOW)
       .attr(PostBiomeChangeWeatherChangeAbAttr, WeatherType.SNOW),
     new Ability(Abilities.HONEY_GATHER, 4)
-      .attr(MoneyAbAttr),
+      .attr(MoneyAbAttr)
+      .attr(UnsuppressableAbilityAbAttr),
     new Ability(Abilities.FRISK, 4)
       .attr(FriskAbAttr),
     new Ability(Abilities.RECKLESS, 4)


### PR DESCRIPTION
## What are the changes the user will see?
Pickup and Honey Gather should no longer be suppressed from Ability Suppression Moves/Abilities like Gastro Acid, and Neutralizing Gas from an ally in a double battle.

## Why am I making these changes?
This was reported directly in the balance channels, and was not the first time I had heard of the issue, but was previously dismissed.

After testing it seems these do not get suppressed by the opposing pokemon at the end of battle correctly, but your ally can still suppress both in a double battle, making you keep (usually support pokemon) benched in the back of the party to get the effect out of it in double battles.

## What are the changes from a developer perspective?
Added the Unsuppressable tags to Pickup and Honey Gather.

These are notably now the only abilities with this tag that do NOT have the Uncopyable and Unswappable tags

## Screenshots/Videos

## How to test the changes?
- Set a Pokemon on your side of the field in a double battle to neutralizing gas and the other to Pickup or Honey Gather
- Make sure opposing pokemon has an item that can be picked up, no max stacks of anything on your pickup pokemon
- Get to the end of battle with the Pickup / Honey Gatherer still alive, should now activate

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [X] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?