### PR TITLE
[Bug][Hotfix] Fix migration crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pokemon-rogue-battle",
-	"version": "1.7.6",
+	"version": "1.7.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pokemon-rogue-battle",
-			"version": "1.7.6",
+			"version": "1.7.7",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@material/material-color-utilities": "^0.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pokemon-rogue-battle",
 	"private": true,
-	"version": "1.7.6",
+	"version": "1.7.7",
 	"type": "module",
 	"scripts": {
 		"start": "vite",

--- a/src/system/version_migration/versions/v1_7_0.ts
+++ b/src/system/version_migration/versions/v1_7_0.ts
@@ -13,7 +13,11 @@ export const systemMigrators = [
     if (data.starterData && data.dexData) {
       Object.keys(data.starterData).forEach(sd => {
         const caughtAttr = data.dexData[sd]?.caughtAttr;
-        const species = getPokemonSpecies(Number(sd));
+        const speciesNumber = Number(sd);
+        if (!speciesNumber) { // An unknown bug at some point in time caused some accounts to have starter data for pokedex number 0 which crashes
+          return;
+        }
+        const species = getPokemonSpecies(speciesNumber);
         if (caughtAttr && species.forms?.length > 1) {
           const selectableForms = species.forms.filter((form, formIndex) => form.isStarterSelectable && (caughtAttr & globalScene.gameData.getFormAttr(formIndex)));
           if (selectableForms.length === 0) {


### PR DESCRIPTION
## What are the changes the user will see?
The game will load.

## Why am I making these changes?
In some cases due to an unknown bug, something caused a player's account to have some unlock data for pokemon zero. Attempting to actually use that data crashed the save migrator rendering the game entirely unplayable for these accounts.

## What are the changes from a developer perspective?
A small tweak to the save migrator so it doesn't attempt to migrate pokemon zero.

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?
You will need a manually edited save file to introduce the bug or use the console and the debugger to inject the json of one of the faulty saves mid load.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?