### PR TITLE
[Bug] Fix #5159: Harsh Sun, Heavy Rain, Delta Stream Messages Incorrect

### DIFF
--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -205,6 +205,16 @@ export function getWeatherClearMessage(weatherType: WeatherType): string | null 
   return null;
 }
 
+export function getWeatherBlockMessage(weatherType: WeatherType): string {
+  switch (weatherType) {
+    case WeatherType.HARSH_SUN:
+      return i18next.t("weather:harshSunEffectMessage");
+    case WeatherType.HEAVY_RAIN:
+      return i18next.t("weather:heavyRainEffectMessage");
+  }
+  return i18next.t("weather:defaultEffectMessage");
+}
+
 export function getTerrainStartMessage(terrainType: TerrainType): string | null {
   switch (terrainType) {
     case TerrainType.MISTY:

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -358,6 +358,10 @@ export class Arena {
     return !!this.terrain && this.terrain.isMoveTerrainCancelled(user, targets, move);
   }
 
+  public getWeatherType(): WeatherType {
+    return this.weather?.weatherType ?? WeatherType.NONE;
+  }
+
   public getTerrainType(): TerrainType {
     return this.terrain?.terrainType ?? TerrainType.NONE;
   }

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -30,7 +30,7 @@ import {
 import { SpeciesFormChangePreMoveTrigger } from "#app/data/pokemon-forms";
 import { getStatusEffectActivationText, getStatusEffectHealText } from "#app/data/status-effect";
 import { Type } from "#enums/type";
-import { getTerrainBlockMessage } from "#app/data/weather";
+import { getTerrainBlockMessage, getWeatherBlockMessage } from "#app/data/weather";
 import { MoveUsedEvent } from "#app/events/battle-scene";
 import type { PokemonMove } from "#app/field/pokemon";
 import type Pokemon from "#app/field/pokemon";
@@ -342,9 +342,10 @@ export class MovePhase extends BattlePhase {
      * TODO: is this sustainable?
      */
     let failedDueToTerrain: boolean = false;
+    let failedDueToWeather: boolean = false;
     if (success) {
       const passesConditions = move.applyConditions(this.pokemon, targets[0], move);
-      const failedDueToWeather: boolean = globalScene.arena.isMoveWeatherCancelled(this.pokemon, move);
+      failedDueToWeather = globalScene.arena.isMoveWeatherCancelled(this.pokemon, move);
       failedDueToTerrain = globalScene.arena.isMoveTerrainCancelled(this.pokemon, this.targets, move);
       success = passesConditions && !failedDueToWeather && !failedDueToTerrain;
     }
@@ -381,6 +382,8 @@ export class MovePhase extends BattlePhase {
         failedText = failureMessage;
       } else if (failedDueToTerrain) {
         failedText = getTerrainBlockMessage(targets[0], globalScene.arena.getTerrainType());
+      } else if (failedDueToWeather) {
+        failedText = getWeatherBlockMessage(globalScene.arena.getWeatherType());
       }
 
       this.showFailedText(failedText);


### PR DESCRIPTION
The abilities Desolate Land, Primordial Sea and Delta Stream display the normal weather effect messages instead of special ones (e.g., "the sunlight got hot" instead of
"The sunlight turned extremely harsh!").

Another issue is that if one of these special weathers is active and the opponent uses a move that is ineffective in this weather, it doesn't display a special message but the normal one (e.g., using a Water-type move in Harsh Sunlight).


## What are the changes the user will see?
The message shown when a move has failed due to Desolate Land or Primordial Sea will be more appropriate instead of the default message ("But it failed")

## Why am I making these changes?


## What are the changes from a developer perspective?

- Added `getWeatherBlockMessage(WeatherType)` in `weather.ts` to return the correct message when a move fails due to Primordial Sea or Desolate Land.
- Called `getWeatherBlockMessage()` in `useMove()` (line 385) to update `failedText` using `failedDueToWeather`.
- Added `getWeatherType()` in `arena.ts` as a getter for `WeatherType`, since it wasn’t implemented yet.

## Screenshots/Videos


https://github.com/user-attachments/assets/337c5a8a-7474-4283-84d1-ff0e4ffb814d



## How to test the changes?
Testing Desolate Land:
  ABILITY_OVERRIDE: Abilities.DESOLATE_LAND,
  OPP_MOVESET_OVERRIDE: Moves.WATER_GUN
  
  Testing Primordial Sea:
   ABILITY_OVERRIDE: Abilities.PRIMORDIAL_SEA,
  OPP_MOVESET_OVERRIDE: Moves.EMBER

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [X] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [X] If so, please leave a link to it here:  https://github.com/pagefaultgames/pokerogue-locales/pull/145/files
- [x] Has the translation team been contacted for proofreading/translation?