### PR TITLE
[BUG] Exempt Struggle from Adaptability

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -6315,7 +6315,9 @@ export function initAbilities() {
       .attr(PostTurnStatusHealAbAttr, StatusEffect.TOXIC, StatusEffect.POISON)
       .attr(BlockStatusDamageAbAttr, StatusEffect.TOXIC, StatusEffect.POISON),
     new Ability(Abilities.ADAPTABILITY, 4)
-      .attr(StabBoostAbAttr),
+      .attr(StabBoostAbAttr, (user, target, move) => {
+        return ![ Moves.STRUGGLE ].includes(move.id);
+      }),
     new Ability(Abilities.SKILL_LINK, 4)
       .attr(MaxMultiHitAbAttr),
     new Ability(Abilities.HYDRATION, 4)


### PR DESCRIPTION
## What are the changes the user will see?
Struggle will not activate Adaptability

## Why am I making these changes?
Fix #5490

## What are the changes from a developer perspective?
Added the following to the adaptability call:

```
      .attr(StabBoostAbAttr, (user, target, move) => {
        return ![ Moves.STRUGGLE ].includes(move.id);
      }),
```

## Screenshots/Videos
N/A

## How to test the changes?
```
	STARTER_SPECIES_OVERRIDE: Species.RATTATA,
	MOVESET_OVERRIDE: [Moves.RAPID_SPIN],
	ABILITY_OVERRIDE: Abilities.ADAPTABILITY,

	OPP_LEVEL_OVERRIDE: 3,
	OPP_SPECIES_OVERRIDE: Species.SHROOMISH,
	OPP_MOVESET_OVERRIDE: [Moves.GRUDGE],
```

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?