### PR TITLE
[BUG] fixes #5472 - transform on reload

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -5575,7 +5575,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     }
     this.resetBattleSummonData();
     if (this.summonDataPrimer) {
-      for (const k of Object.keys(this.summonData)) {
+      for (const k of Object.keys(this.summonDataPrimer)) {
         if (this.summonDataPrimer[k]) {
           this.summonData[k] = this.summonDataPrimer[k];
         }

--- a/src/phases/summon-phase.ts
+++ b/src/phases/summon-phase.ts
@@ -197,7 +197,7 @@ export class SummonPhase extends PartyMemberPokemonPhase {
                 pokemon.resetSummonData();
                 // necessary to stay transformed during wild waves
                 if (pokemon.summonData?.speciesForm) {
-                  pokemon.loadAssets();
+                  pokemon.loadAssets(false);
                 }
                 globalScene.time.delayedCall(1000, () => this.end());
               },

--- a/src/phases/summon-phase.ts
+++ b/src/phases/summon-phase.ts
@@ -195,6 +195,10 @@ export class SummonPhase extends PartyMemberPokemonPhase {
                 pokemon.cry(pokemon.getHpRatio() > 0.25 ? undefined : { rate: 0.85 });
                 pokemon.getSprite().clearTint();
                 pokemon.resetSummonData();
+                // necessary to stay transformed during wild waves
+                if (pokemon.summonData?.speciesForm) {
+                  pokemon.loadAssets();
+                }
                 globalScene.time.delayedCall(1000, () => this.end());
               },
             });

--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -170,6 +170,7 @@ export default class PokemonData {
         this.summonData.ability = source.summonData.ability;
         this.summonData.moveset = source.summonData.moveset?.map(m => PokemonMove.loadMove(m));
         this.summonData.types = source.summonData.types;
+        this.summonData.speciesForm = source.summonData.speciesForm;
 
         if (source.summonData.tags) {
           this.summonData.tags = source.summonData.tags?.map(t => loadBattlerTag(t));
@@ -213,6 +214,11 @@ export default class PokemonData {
           this,
         );
     if (this.summonData) {
+      // when loading from saved session, recover summonData.speciesFrom species object
+      // used to stay transformed on reload session
+      if (this.summonData.speciesForm) {
+        this.summonData.speciesForm = getPokemonSpecies(this.summonData.speciesForm.speciesId);
+      }
       ret.primeSummonData(this.summonData);
     }
     return ret;

--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -3,7 +3,7 @@ import { globalScene } from "#app/global-scene";
 import type { Gender } from "../data/gender";
 import type { Nature } from "#enums/nature";
 import type { PokeballType } from "#enums/pokeball";
-import { getPokemonSpecies } from "../data/pokemon-species";
+import { getPokemonSpecies, getPokemonSpeciesForm } from "../data/pokemon-species";
 import { Status } from "../data/status-effect";
 import Pokemon, { EnemyPokemon, PokemonMove, PokemonSummonData } from "../field/pokemon";
 import { TrainerSlot } from "../data/trainer-config";
@@ -14,6 +14,7 @@ import { Moves } from "#enums/moves";
 import type { Species } from "#enums/species";
 import { CustomPokemonData } from "#app/data/custom-pokemon-data";
 import type { PokemonType } from "#enums/pokemon-type";
+import { getSpeciesFormChangeMessage } from "#app/data/pokemon-forms";
 
 export default class PokemonData {
   public id: number;
@@ -63,6 +64,7 @@ export default class PokemonData {
   public bossSegments?: number;
 
   public summonData: PokemonSummonData;
+  public summonDataSpeciesFormIndex: number;
 
   /** Data that can customize a Pokemon in non-standard ways from its Species */
   public customPokemonData: CustomPokemonData;
@@ -145,8 +147,9 @@ export default class PokemonData {
       this.moveset = sourcePokemon.moveset;
       if (!forHistory) {
         this.status = sourcePokemon.status;
-        if (this.player) {
+        if (this.player && sourcePokemon.summonData) {
           this.summonData = sourcePokemon.summonData;
+          this.summonDataSpeciesFormIndex = this.getSummonDataSpeciesFormIndex();
         }
       }
     } else {
@@ -171,6 +174,7 @@ export default class PokemonData {
         this.summonData.moveset = source.summonData.moveset?.map(m => PokemonMove.loadMove(m));
         this.summonData.types = source.summonData.types;
         this.summonData.speciesForm = source.summonData.speciesForm;
+        this.summonDataSpeciesFormIndex = source.summonDataSpeciesFormIndex;
 
         if (source.summonData.tags) {
           this.summonData.tags = source.summonData.tags?.map(t => loadBattlerTag(t));
@@ -214,13 +218,28 @@ export default class PokemonData {
           this,
         );
     if (this.summonData) {
-      // when loading from saved session, recover summonData.speciesFrom species object
+      // when loading from saved session, recover summonData.speciesFrom and form index species object
       // used to stay transformed on reload session
       if (this.summonData.speciesForm) {
-        this.summonData.speciesForm = getPokemonSpecies(this.summonData.speciesForm.speciesId);
+        this.summonData.speciesForm = getPokemonSpeciesForm(
+          this.summonData.speciesForm.speciesId,
+          this.summonDataSpeciesFormIndex,
+        );
       }
       ret.primeSummonData(this.summonData);
     }
     return ret;
+  }
+
+  /**
+   * Method to save summon data species form index
+   * Necessary in case the pokemon is transformed
+   * to reload the correct form
+   */
+  getSummonDataSpeciesFormIndex(): number {
+    if (this.summonData.speciesForm) {
+      return this.summonData.speciesForm.formIndex;
+    }
+    return 0;
   }
 }

--- a/test/abilities/imposter.test.ts
+++ b/test/abilities/imposter.test.ts
@@ -160,4 +160,30 @@ describe("Abilities - Imposter", () => {
     expect(playerMoveset.length).toEqual(1);
     expect(playerMoveset[0]?.moveId).toEqual(Moves.SPLASH);
   });
+
+  it("should stay transformed with the correct form after reload", async () => {
+    game.override.moveset([Moves.ABSORB]);
+    game.override.enemySpecies(Species.UNOWN);
+    await game.classicMode.startBattle([Species.DITTO]);
+
+    const enemy = game.scene.getEnemyPokemon()!;
+
+    // change form
+    enemy.species.forms[5];
+    enemy.species.formIndex = 5;
+
+    game.move.select(Moves.SPLASH);
+    await game.doKillOpponents();
+    await game.toNextWave();
+
+    expect(game.scene.getCurrentPhase()?.constructor.name).toBe("CommandPhase");
+    expect(game.scene.currentBattle.waveIndex).toBe(2);
+
+    await game.reload.reloadSession();
+
+    const playerReloaded = game.scene.getPlayerPokemon()!;
+
+    expect(playerReloaded.getSpeciesForm().speciesId).toBe(enemy.getSpeciesForm().speciesId);
+    expect(playerReloaded.getSpeciesForm().formIndex).toBe(enemy.getSpeciesForm().formIndex);
+  });
 });

--- a/test/abilities/imposter.test.ts
+++ b/test/abilities/imposter.test.ts
@@ -127,4 +127,37 @@ describe("Abilities - Imposter", () => {
 
     expect(game.scene.getEnemyPokemon()?.getStatStage(Stat.ATK)).toBe(-1);
   });
+
+  it("should persist transformed attributes across reloads", async () => {
+    game.override.moveset([Moves.ABSORB]);
+
+    await game.classicMode.startBattle([Species.DITTO]);
+
+    const player = game.scene.getPlayerPokemon()!;
+    const enemy = game.scene.getEnemyPokemon()!;
+
+    game.move.select(Moves.SPLASH);
+    await game.doKillOpponents();
+    await game.toNextWave();
+
+    expect(game.scene.getCurrentPhase()?.constructor.name).toBe("CommandPhase");
+    expect(game.scene.currentBattle.waveIndex).toBe(2);
+
+    await game.reload.reloadSession();
+
+    const playerReloaded = game.scene.getPlayerPokemon()!;
+    const playerMoveset = player.getMoveset();
+
+    expect(playerReloaded.getSpeciesForm().speciesId).toBe(enemy.getSpeciesForm().speciesId);
+    expect(playerReloaded.getAbility()).toBe(enemy.getAbility());
+    expect(playerReloaded.getGender()).toBe(enemy.getGender());
+
+    expect(playerReloaded.getStat(Stat.HP, false)).not.toBe(enemy.getStat(Stat.HP));
+    for (const s of EFFECTIVE_STATS) {
+      expect(playerReloaded.getStat(s, false)).toBe(enemy.getStat(s, false));
+    }
+
+    expect(playerMoveset.length).toEqual(1);
+    expect(playerMoveset[0]?.moveId).toEqual(Moves.SPLASH);
+  });
 });

--- a/test/moves/transform.test.ts
+++ b/test/moves/transform.test.ts
@@ -6,6 +6,7 @@ import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { Moves } from "#enums/moves";
 import { Stat, BATTLE_STATS, EFFECTIVE_STATS } from "#enums/stat";
 import { Abilities } from "#enums/abilities";
+import { BattlerIndex } from "#app/battle";
 
 // TODO: Add more tests once Transform is fully implemented
 describe("Moves - Transform", () => {
@@ -58,7 +59,7 @@ describe("Moves - Transform", () => {
     }
 
     const playerMoveset = player.getMoveset();
-    const enemyMoveset = player.getMoveset();
+    const enemyMoveset = enemy.getMoveset();
 
     expect(playerMoveset.length).toBe(enemyMoveset.length);
     for (let i = 0; i < playerMoveset.length && i < enemyMoveset.length; i++) {
@@ -126,5 +127,41 @@ describe("Moves - Transform", () => {
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(game.scene.getEnemyPokemon()?.getStatStage(Stat.ATK)).toBe(-1);
+  });
+
+  it("should persist transformed attributes across reloads", async () => {
+    game.override.enemyMoveset([]).moveset([]);
+
+    await game.classicMode.startBattle([Species.DITTO]);
+
+    const player = game.scene.getPlayerPokemon()!;
+    const enemy = game.scene.getEnemyPokemon()!;
+
+    game.move.changeMoveset(player, Moves.TRANSFORM);
+    game.move.changeMoveset(enemy, Moves.MEMENTO);
+
+    game.move.select(Moves.TRANSFORM);
+    await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+    await game.toNextWave();
+
+    expect(game.scene.getCurrentPhase()?.constructor.name).toBe("CommandPhase");
+    expect(game.scene.currentBattle.waveIndex).toBe(2);
+
+    await game.reload.reloadSession();
+
+    const playerReloaded = game.scene.getPlayerPokemon()!;
+    const playerMoveset = player.getMoveset();
+
+    expect(playerReloaded.getSpeciesForm().speciesId).toBe(enemy.getSpeciesForm().speciesId);
+    expect(playerReloaded.getAbility()).toBe(enemy.getAbility());
+    expect(playerReloaded.getGender()).toBe(enemy.getGender());
+
+    expect(playerReloaded.getStat(Stat.HP, false)).not.toBe(enemy.getStat(Stat.HP));
+    for (const s of EFFECTIVE_STATS) {
+      expect(playerReloaded.getStat(s, false)).toBe(enemy.getStat(s, false));
+    }
+
+    expect(playerMoveset.length).toEqual(1);
+    expect(playerMoveset[0]?.moveId).toEqual(Moves.MEMENTO);
   });
 });

--- a/test/moves/transform.test.ts
+++ b/test/moves/transform.test.ts
@@ -164,4 +164,35 @@ describe("Moves - Transform", () => {
     expect(playerMoveset.length).toEqual(1);
     expect(playerMoveset[0]?.moveId).toEqual(Moves.MEMENTO);
   });
+
+  it("should stay transformed with the correct form after reload", async () => {
+    game.override.enemyMoveset([]).moveset([]);
+    game.override.enemySpecies(Species.DARMANITAN);
+
+    await game.classicMode.startBattle([Species.DITTO]);
+
+    const player = game.scene.getPlayerPokemon()!;
+    const enemy = game.scene.getEnemyPokemon()!;
+
+    // change form
+    enemy.species.forms[1];
+    enemy.species.formIndex = 1;
+
+    game.move.changeMoveset(player, Moves.TRANSFORM);
+    game.move.changeMoveset(enemy, Moves.MEMENTO);
+
+    game.move.select(Moves.TRANSFORM);
+    await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+    await game.toNextWave();
+
+    expect(game.scene.getCurrentPhase()?.constructor.name).toBe("CommandPhase");
+    expect(game.scene.currentBattle.waveIndex).toBe(2);
+
+    await game.reload.reloadSession();
+
+    const playerReloaded = game.scene.getPlayerPokemon()!;
+
+    expect(playerReloaded.getSpeciesForm().speciesId).toBe(enemy.getSpeciesForm().speciesId);
+    expect(playerReloaded.getSpeciesForm().formIndex).toBe(enemy.getSpeciesForm().formIndex);
+  });
 });


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
Transformed pokémon, either via transform move or imposter ability now persists after reloading
## Why am I making these changes?
<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
To make sure any status changes on player pokémon during wild waves are consistent with the game roguelite behavior during wild battle waves. This Fixes #5472
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

## What are the changes from a developer perspective?
<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->
I changed 3 src files, `pokemon-data.ts`, `pokemon.ts` and `summon-phase.ts`. 
##### pokemon-data.ts
- when create a `pokemonData` object, it also copies the `speciesFrom` from the source pokemon object
- when creating a pokemon with `toPokemon()`, if there was a `speciesFrom`, runs `getPokemonSpecies(this.summonData.speciesForm.speciesId)`. This ensures that, once the JSON from the server was parsed, we create the `species` object again.

##### pokemon.ts
- on `resetSummonData()` now uses `Object.keys(this.summonDataPrimer)` to copy all attributes from the primer into `summonData` attribute. This way, `Object.keys()` is able to fetch all attributes that the primer has. For example, in the previous version, since we create a new `summonData` object in this method, and the `moveset` attribute can be null, I think `Object.Keys()` was missing it, hence the moveset of the transformed pokemon was not copied back.

##### summon-phase.ts
- if there was a `speciesForm` in the `summonData` after `resetSummonData()`, then we need to reload the assets of pokemon, to load the previously copied sprite. 

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->
https://github.com/user-attachments/assets/d529ae34-eac3-481e-8947-92a68ab92a63

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

On the overrides.ts file, insert these lines

```
  ABILITY_OVERRIDE: Abilities.IMPOSTER,

  STARTING_LEVEL_OVERRIDE: 20,
```
level 20 is to ensure you survive until the next wave. 

- New game
- select any pokemon as starter
- select a save slot
- win wave 1
- on wave 2, Save and Quit
- reload session on chosen save slot
- voilá, pokemon stayed transformed

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?