### PR TITLE
[Misc] `OPP_FORM_OVERRIDES` now accepts 0 as a valid form index

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -6916,10 +6916,10 @@ export class EnemyPokemon extends Pokemon {
 
     if (
       speciesId in Overrides.OPP_FORM_OVERRIDES &&
-      Overrides.OPP_FORM_OVERRIDES[speciesId] &&
+      !isNullOrUndefined(Overrides.OPP_FORM_OVERRIDES[speciesId]) &&
       this.species.forms[Overrides.OPP_FORM_OVERRIDES[speciesId]]
     ) {
-      this.formIndex = Overrides.OPP_FORM_OVERRIDES[speciesId] ?? 0;
+      this.formIndex = Overrides.OPP_FORM_OVERRIDES[speciesId];
     }
 
     if (!dataSource) {

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable @typescript-eslint/consistent-type-imports */
 import { type PokeballCounts } from "#app/battle-scene";
 import { EvolutionItem } from "#app/data/balance/pokemon-evolutions";
 import { Gender } from "#app/data/gender";

--- a/src/phases/select-starter-phase.ts
+++ b/src/phases/select-starter-phase.ts
@@ -53,6 +53,7 @@ export class SelectStarterPhase extends Phase {
       let starterFormIndex = Math.min(starterProps.formIndex, Math.max(starter.species.forms.length - 1, 0));
       if (
         starter.species.speciesId in Overrides.STARTER_FORM_OVERRIDES &&
+        !Utils.isNullOrUndefined(Overrides.STARTER_FORM_OVERRIDES[starter.species.speciesId]) &&
         starter.species.forms[Overrides.STARTER_FORM_OVERRIDES[starter.species.speciesId]!]
       ) {
         starterFormIndex = Overrides.STARTER_FORM_OVERRIDES[starter.species.speciesId]!;


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
`OPP_FORM_OVERRIDES` was broken and didn't allow setting form index 0.

## What are the changes from a developer perspective?
The check that `OPP_FORM_OVERRIDES` is not `undefined` now explicitly checks that it's not `undefined` instead of doing a falsy check which erroneously sees a value of `0` as not valid.

## How to test the changes?
Use the following overrides and observe that the opponent is always Unown-A.
```ts
const overrides = {
  OPP_SPECIES_OVERRIDE: Species.UNOWN,
  OPP_FORM_OVERRIDES: {[Species.UNOWN]: 0},
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?