### PR TITLE
[Bug] Fix Commander crash after 5267

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2783,8 +2783,8 @@ export class CommanderAbAttr extends AbAttr {
     // another Pokemon, this effect cannot apply.
 
     // TODO: Should this work with X + Dondozo fusions?
-    return !(pokemon.getAlly().isFainted() || pokemon.getAlly().getTag(BattlerTagType.COMMANDED))
-              && globalScene.currentBattle?.double && pokemon.getAlly()?.species.speciesId === Species.DONDOZO;
+    return globalScene.currentBattle?.double && pokemon.getAlly()?.species.speciesId === Species.DONDOZO
+           && !(pokemon.getAlly().isFainted() || pokemon.getAlly().getTag(BattlerTagType.COMMANDED));
   }
 
   override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: null, args: any[]): void {


### PR DESCRIPTION
## What are the changes the user will see?
No crash with a commander mon out

## What are the changes from a developer perspective?
I somehow reversed the checks when moving Commander stuff around for #5267, so the getAlly() dependent things were getting evaluated before checking if such ally existed

Discord: https://discord.com/channels/1125469663833370665/1350710951791562833

## Screenshots/Videos
Working again


https://github.com/user-attachments/assets/1c4091ec-2166-468f-9cee-742f749ab82f


## How to test the changes?
Use commander

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?