### PR TITLE
Fix #5082: Nicknames not properly sanitized

### DIFF
--- a/src/phases/message-phase.ts
+++ b/src/phases/message-phase.ts
@@ -28,8 +28,8 @@ export class MessagePhase extends Phase {
     super.start();
 
     if (this.text.indexOf("$") > -1) {
-      let pokename: string[] = [];
-      let repname = [ "#POKEMON1", "#POKEMON2" ];
+      const pokename: string[] = [];
+      const repname = [ "#POKEMON1", "#POKEMON2" ];
       for (let p = 0; p < globalScene.getPlayerField().length; p++) {
         pokename.push(globalScene.getPlayerField()[p].getNameToRender());
         this.text = this.text.split(pokename[p]).join(repname[p]);

--- a/src/phases/message-phase.ts
+++ b/src/phases/message-phase.ts
@@ -28,17 +28,28 @@ export class MessagePhase extends Phase {
     super.start();
 
     if (this.text.indexOf("$") > -1) {
+      let pokename: string[] = [];
+      let repname = [ "#POKEMON1", "#POKEMON2" ];
+      for (let p = 0; p < globalScene.getPlayerField().length; p++) {
+        pokename.push(globalScene.getPlayerField()[p].getNameToRender());
+        this.text = this.text.split(pokename[p]).join(repname[p]);
+      }
       const pageIndex = this.text.indexOf("$");
-      globalScene.unshiftPhase(
-        new MessagePhase(
-          this.text.slice(pageIndex + 1),
-          this.callbackDelay,
-          this.prompt,
-          this.promptDelay,
-          this.speaker,
-        ),
-      );
-      this.text = this.text.slice(0, pageIndex).trim();
+      for (let p = 0; p < globalScene.getPlayerField().length; p++) {
+        this.text = this.text.split(repname[p]).join(pokename[p]);
+      }
+      if (pageIndex !== -1) {
+        globalScene.unshiftPhase(
+          new MessagePhase(
+            this.text.slice(pageIndex + 1),
+            this.callbackDelay,
+            this.prompt,
+            this.promptDelay,
+            this.speaker,
+          ),
+        );
+        this.text = this.text.slice(0, pageIndex).trim();
+      }
     }
 
     if (this.speaker) {

--- a/src/ui/message-ui-handler.ts
+++ b/src/ui/message-ui-handler.ts
@@ -76,6 +76,12 @@ export default abstract class MessageUiHandler extends AwaitableUiHandler {
     const fadeMap = new Map<number, number>();
     const actionPattern = /@(c|d|s|f)\{(.*?)\}/;
     let actionMatch: RegExpExecArray | null;
+    let pokename: string[] = [];
+    let repname = [ "#POKEMON1", "#POKEMON2" ];
+    for (let p = 0; p < globalScene.getPlayerField().length; p++) {
+      pokename.push(globalScene.getPlayerField()[p].getNameToRender());
+      text = text.split(pokename[p]).join(repname[p]);
+    }
     while ((actionMatch = actionPattern.exec(text))) {
       switch (actionMatch[1]) {
         case "c":
@@ -94,6 +100,9 @@ export default abstract class MessageUiHandler extends AwaitableUiHandler {
       text = text.slice(0, actionMatch.index) + text.slice(actionMatch.index + actionMatch[2].length + 4);
     }
 
+    for (let p = 0; p < globalScene.getPlayerField().length; p++) {
+      text = text.split(repname[p]).join(pokename[p]);
+    }
     if (text) {
       // Predetermine overflow line breaks to avoid words breaking while displaying
       const textWords = text.split(" ");

--- a/src/ui/message-ui-handler.ts
+++ b/src/ui/message-ui-handler.ts
@@ -76,8 +76,8 @@ export default abstract class MessageUiHandler extends AwaitableUiHandler {
     const fadeMap = new Map<number, number>();
     const actionPattern = /@(c|d|s|f)\{(.*?)\}/;
     let actionMatch: RegExpExecArray | null;
-    let pokename: string[] = [];
-    let repname = [ "#POKEMON1", "#POKEMON2" ];
+    const pokename: string[] = [];
+    const repname = [ "#POKEMON1", "#POKEMON2" ];
     for (let p = 0; p < globalScene.getPlayerField().length; p++) {
       pokename.push(globalScene.getPlayerField()[p].getNameToRender());
       text = text.split(pokename[p]).join(repname[p]);

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -328,8 +328,8 @@ export default class UI extends Phaser.GameObjects.Container {
     prompt?: boolean | null,
     promptDelay?: number | null,
   ): void {
-    let pokename: string[] = [];
-    let repname = [ "#POKEMON1", "#POKEMON2" ];
+    const pokename: string[] = [];
+    const repname = [ "#POKEMON1", "#POKEMON2" ];
     for (let p = 0; p < globalScene.getPlayerField().length; p++) {
       pokename.push(globalScene.getPlayerField()[p].getNameToRender());
       text = text.split(pokename[p]).join(repname[p]);

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -328,17 +328,28 @@ export default class UI extends Phaser.GameObjects.Container {
     prompt?: boolean | null,
     promptDelay?: number | null,
   ): void {
+    let pokename: string[] = [];
+    let repname = [ "#POKEMON1", "#POKEMON2" ];
+    for (let p = 0; p < globalScene.getPlayerField().length; p++) {
+      pokename.push(globalScene.getPlayerField()[p].getNameToRender());
+      text = text.split(pokename[p]).join(repname[p]);
+    }
     if (prompt && text.indexOf("$") > -1) {
       const messagePages = text.split(/\$/g).map(m => m.trim());
       // biome-ignore lint/complexity/useOptionalChain: optional chain would change this to be null instead of undefined.
       let showMessageAndCallback = () => callback && callback();
       for (let p = messagePages.length - 1; p >= 0; p--) {
         const originalFunc = showMessageAndCallback;
+        messagePages[p] = messagePages[p].split(repname[0]).join(pokename[0]);
+        messagePages[p] = messagePages[p].split(repname[1]).join(pokename[1]);
         showMessageAndCallback = () => this.showText(messagePages[p], null, originalFunc, null, true);
       }
       showMessageAndCallback();
     } else {
       const handler = this.getHandler();
+      for (let p = 0; p < globalScene.getPlayerField().length; p++) {
+        text = text.split(repname[p]).join(pokename[p]);
+      }
       if (handler instanceof MessageUiHandler) {
         (handler as MessageUiHandler).showText(text, delay, callback, callbackDelay, prompt, promptDelay);
       } else {


### PR DESCRIPTION

<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?
When the player renames the pokemon to a nickname that contains the following symbols: "@c{}", "@s{}", "@d{}", "@f{}" and "$" the text will appear properly without causing abnormalities such as the name being cut or the game fading into black.


## Why am I making these changes?
To ensure all nicknames can be used without any abnormalities happening.
Fixes #5082

## What are the changes from a developer perspective?
- on message-ui-handler.ts file I updated the "showTextInternal" function to get the original name of the pokemon or pokemons (in case it's a double battle) saving it in a list named "pokename" and change it in the text for their  correspondent placeholder which is saved in the list "repname" (e.g "#POKEMON1" for the first pokemon and "#POKEMON2" for the second pokemon). After the text is properly modified because of the special characters ("@c{}", "@s{}", "@d{}", "@f{}")  the name of the pokemons is replaced to it's original value. 
- on message-phase.ts file I updated the "start" function to use a similar approach but only change the pokemon name to it's original form after the "pageIndex" (which checks the index of the "$") is updated, so the text is cut properly.
- on ui.ts file I updated the "showtext" function to use same approach of the previous files, ensuring that the pokemon names were only replaced back to their original values after all text processing on "$" was completed.

## Screenshots/Videos

https://github.com/user-attachments/assets/7a0b4618-5b14-4127-8a9c-27fc5aa13e64

## How to test the changes?
Add to the nickname of the pokemon any the following set of characters "@c{}", "@s{}", "@d{}", "@f{}" and "$".

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [X] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?