### PR TITLE
[Misc] Add `* -crlf` to `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+* -crlf


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
This should prevent issues with Biome seeming to change the line endings of files due to Git converting them to `crlf` locally for Windows users.

## What are the changes from a developer perspective?
Added `* -crlf` to `.gitattributes` below `* text=auto`.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?