### PR TITLE
[UI/UX] Icons for egg moves and passives show up even when not unlocked

### DIFF
--- a/src/ui/pokedex-ui-handler.ts
+++ b/src/ui/pokedex-ui-handler.ts
@@ -1742,36 +1742,26 @@ export default class PokedexUiHandler extends MessageUiHandler {
           container.icon.setTint(0);
         }
 
-        if (data.eggMove1) {
-          container.eggMove1Icon.setVisible(true);
-        } else {
-          container.eggMove1Icon.setVisible(false);
-        }
-        if (data.eggMove2) {
-          container.eggMove2Icon.setVisible(true);
-        } else {
-          container.eggMove2Icon.setVisible(false);
-        }
-        if (data.tmMove1) {
-          container.tmMove1Icon.setVisible(true);
-        } else {
-          container.tmMove1Icon.setVisible(false);
-        }
-        if (data.tmMove2) {
-          container.tmMove2Icon.setVisible(true);
-        } else {
-          container.tmMove2Icon.setVisible(false);
-        }
-        if (data.passive1) {
-          container.passive1Icon.setVisible(true);
-        } else {
-          container.passive1Icon.setVisible(false);
-        }
-        if (data.passive2) {
-          container.passive2Icon.setVisible(true);
-        } else {
-          container.passive2Icon.setVisible(false);
-        }
+        const pairs: [boolean | undefined, Phaser.GameObjects.Image][] = [
+          [data.eggMove1, container.eggMove1Icon],
+          [data.eggMove2, container.eggMove2Icon],
+          [data.tmMove1, container.tmMove1Icon],
+          [data.tmMove2, container.tmMove2Icon],
+          [data.passive1, container.passive1Icon],
+          [data.passive2, container.passive2Icon],
+        ];
+
+        pairs.forEach(([unlocked, icon]) => {
+          if (unlocked) {
+            icon.setVisible(true);
+            icon.clearTint();
+          } else if (unlocked === false) {
+            icon.setVisible(true);
+            icon.setTint(0x808080);
+          } else {
+            icon.setVisible(false);
+          }
+        });
 
         if (this.showDecorations) {
           if (this.pokerusSpecies.includes(data.species)) {


### PR DESCRIPTION
## Why am I making these changes?
This is the intended behavior and was broken accidentally by the container rework.

## What are the changes from a developer perspective?
Slightly reworked the code to make it more compact, now checking for false (has egg move/passive but is locked) vs undefined (no egg move/passive).

## Screenshots/Videos
![drizz](https://github.com/user-attachments/assets/2beaebb7-5fe4-4fe3-ab31-dabe31c0dbfe)
![mg](https://github.com/user-attachments/assets/a8feaf92-9f50-44b7-9703-4abadbf949d1)


## How to test the changes?
Open the dex and mess with filters.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?