### PR TITLE
[Test] Fix Chilly Reception Test Ability Overrides

### DIFF
--- a/test/moves/chilly_reception.test.ts
+++ b/test/moves/chilly_reception.test.ts
@@ -72,7 +72,6 @@ describe("Moves - Chilly Reception", () => {
     game.override
       .battleType("single")
       .enemyMoveset([Moves.CHILLY_RECEPTION, Moves.TACKLE])
-      .enemyAbility(Abilities.NONE)
       .moveset(Array(4).fill(Moves.SPLASH));
 
     await game.classicMode.startBattle([Species.SLOWKING, Species.MEOWTH]);
@@ -89,7 +88,6 @@ describe("Moves - Chilly Reception", () => {
       .battleType("single")
       .startingWave(8)
       .enemyMoveset(Array(4).fill(Moves.CHILLY_RECEPTION))
-      .enemyAbility(Abilities.NONE)
       .enemySpecies(Species.MAGIKARP)
       .moveset([Moves.SPLASH, Moves.THUNDERBOLT]);
 

--- a/test/moves/chilly_reception.test.ts
+++ b/test/moves/chilly_reception.test.ts
@@ -27,8 +27,8 @@ describe("Moves - Chilly Reception", () => {
       .battleType("single")
       .moveset([Moves.CHILLY_RECEPTION, Moves.SNOWSCAPE])
       .enemyMoveset(Array(4).fill(Moves.SPLASH))
-      .enemyAbility(Abilities.NONE)
-      .ability(Abilities.NONE);
+      .enemyAbility(Abilities.BALL_FETCH)
+      .ability(Abilities.BALL_FETCH);
   });
 
   it("should still change the weather if user can't switch out", async () => {


### PR DESCRIPTION
## What are the changes the user will see?
na

## Why am I making these changes?
Chilly Reception tests would randomly fail due to abilities not being overridden properly

## What are the changes from a developer perspective?
The abilities were overridden as `Abilities.NONE` (which is equivalent to not overriding at all). Switched them to Ball Fetch
## Screenshots/Videos

## How to test the changes?
test the test

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?