### PR TITLE
[Bug][UI/UX] Pokédex filters properly track TMs for evolutions

### DIFF
--- a/src/ui/pokedex-ui-handler.ts
+++ b/src/ui/pokedex-ui-handler.ts
@@ -1365,7 +1365,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
       const levelMoves = pokemonSpeciesLevelMoves[species.speciesId].map(m => allMoves[m[1]].name);
       // This always gets egg moves from the starter
       const eggMoves = speciesEggMoves[starterId]?.map(m => allMoves[m].name) ?? [];
-      const tmMoves = speciesTmMoves[starterId]?.map(m => allMoves[Array.isArray(m) ? m[1] : m].name) ?? [];
+      const tmMoves = speciesTmMoves[species.speciesId]?.map(m => allMoves[Array.isArray(m) ? m[1] : m].name) ?? [];
       const selectedMove1 = this.filterText.getValue(FilterTextRow.MOVE_1);
       const selectedMove2 = this.filterText.getValue(FilterTextRow.MOVE_2);
 


### PR DESCRIPTION
## Why am I making these changes?
The TM filter is currently bugged as it checks the starter Id instead of the species Id. This means that it misses TMs that are evolution exclusive.

## What are the changes from a developer perspective?
Changed the Id.

## Screenshots/Videos
![iron_head](https://github.com/user-attachments/assets/cae8c192-7829-4b8e-8a7c-36fb4403bbc3)
![fly](https://github.com/user-attachments/assets/61a95962-82d9-4983-8737-579ed3d66aaf)


## How to test the changes?
Try various moves in the filters.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?