### PR TITLE
[Bug] Fix Flash Fire has No Message

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2151,6 +2151,21 @@ export class TypeBoostTag extends BattlerTag {
   lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
     return lapseType !== BattlerTagLapseType.CUSTOM || super.lapse(pokemon, lapseType);
   }
+
+  override onAdd(pokemon: Pokemon): void {
+    globalScene.queueMessage(
+      i18next.t("abilityTriggers:typeImmunityPowerBoost", {
+        pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
+        typeName: i18next.t(`pokemonInfo:Type.${PokemonType[this.boostedType]}`),
+      }),
+    );
+  }
+
+  override onOverlap(pokemon: Pokemon): void {
+    globalScene.queueMessage(
+      i18next.t("abilityTriggers:moveImmunity", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
+    );
+  }
 }
 
 export class CritBoostTag extends BattlerTag {


### PR DESCRIPTION
## What are the changes the user will see?
Flash fire will display a message when activated

## Why am I making these changes?
Mirror of #4063 kinda
Fixes #4058 

## What are the changes from a developer perspective?
Queues messages from `onAdd` (type boost message) and `onOverlap` (immunity message) of `TypeBoostTag`

## Screenshots/Videos

https://github.com/user-attachments/assets/8cec498e-9a00-43c7-b318-e916bc734c8c



## How to test the changes?
```typescript
  ABILITY_OVERRIDE: Abilities.FLASH_FIRE,
  OPP_ABILITY_OVERRIDE: Abilities.FLASH_FIRE,
  MOVESET_OVERRIDE: Moves.EMBER,
  OPP_MOVESET_OVERRIDE: Moves.EMBER
```
lol

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? (Locales was merged long ago)