### PR TITLE
[Misc] Fallback `es-MX` to `es-ES` first

### DIFF
--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -170,7 +170,10 @@ export async function initI18n(): Promise<void> {
   i18next.use(processor);
   i18next.use(new KoreanPostpositionProcessor());
   await i18next.init({
-    fallbackLng: "en",
+    fallbackLng: {
+      "es-MX": ["es-ES", "en"],
+      default: ["en"],
+    },
     supportedLngs: ["en", "es-ES", "fr", "it", "de", "zh-CN", "zh-TW", "pt-BR", "ko", "ja", "ca-ES"],
     backend: {
       loadPath(lng: string, [ns]: string[]) {


### PR DESCRIPTION
## What are the changes the user will see?
LATAM Spanish doesn't exist yet, but when it is implemented it will automatically fallback to European Spanish and then back to English only if a key is missing from both.

## Why am I making these changes?
https://discord.com/channels/1125469663833370665/1176874654015684739/1355558755630186759

## What are the changes from a developer perspective?
`fallbackLng` in `i18next.init` is changed from a single string to an object with a default fallback list (`["en"]`) and a custom one for `es-MX`.

## Screenshots/Videos

## How to test the changes?
Once LATAM Spanish is implemented it's testable as is, otherwise you can test by switching `"es-MX"` to a language that does exist and seeing that it falls back properly to `es-ES` then `en`.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?