### PR TITLE
[Move] Add message for called moves failing due to no targets

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -6715,6 +6715,8 @@ class CallMoveAttr extends OverrideMoveEffectAttr {
     const replaceMoveTarget = move.moveTarget === MoveTarget.NEAR_OTHER ? MoveTarget.NEAR_ENEMY : undefined;
     const moveTargets = getMoveTargets(user, move.id, replaceMoveTarget);
     if (moveTargets.targets.length === 0) {
+      globalScene.queueMessage(i18next.t("battle:attackFailed"));
+      console.log("CallMoveAttr failed due to no targets.");
       return false;
     }
     const targets = moveTargets.multiple || moveTargets.targets.length === 1


### PR DESCRIPTION
## What are the changes the user will see?
If Metronome (or another move that calls other moves) fails due to there being no targets, a failure message will be displayed. This is a temporary change until the underlying issue can be fixed.

## Why am I making these changes?
Moves shouldn't fail with no feedback at all.

## What are the changes from a developer perspective?
If `CallMoveAttr` returns early due to there being no targets left, a failure message ("But it failed!") will be displayed to the player and a message logged to the console (on beta/local) explaining what happened.

## Screenshots/Videos
<details><summary>Fail message</summary>
<p>

https://github.com/user-attachments/assets/122634f7-a1d2-4718-b72a-08d01b468072

</p>
</details> 

## How to test the changes?
```ts
const overrides = {
  OPP_ABILITY_OVERRIDE: Abilities.PRANKSTER,
  MOVESET_OVERRIDE: Moves.METRONOME,
  OPP_MOVESET_OVERRIDE: Moves.MEMENTO,
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?