### PR TITLE
[Bug] Prevent `Mystical Rock` after Max Stack

### DIFF
--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -2823,37 +2823,48 @@ const modifierPool: ModifierPool = {
       modifierTypes.MYSTICAL_ROCK,
       (party: Pokemon[]) => {
         return party.some(p => {
-          const moveset = p.getMoveset(true).map(m => m.moveId);
+          let isHoldingMax = false;
+          for (const i of p.getHeldItems()) {
+            if (i.type.id === "MYSTICAL_ROCK") {
+              isHoldingMax = i.getStackCount() === i.getMaxStackCount();
+              break;
+            }
+          }
 
-          const hasAbility = [
-            Abilities.DRIZZLE,
-            Abilities.ORICHALCUM_PULSE,
-            Abilities.DRIZZLE,
-            Abilities.SAND_STREAM,
-            Abilities.SAND_SPIT,
-            Abilities.SNOW_WARNING,
-            Abilities.ELECTRIC_SURGE,
-            Abilities.HADRON_ENGINE,
-            Abilities.PSYCHIC_SURGE,
-            Abilities.GRASSY_SURGE,
-            Abilities.SEED_SOWER,
-            Abilities.MISTY_SURGE,
-          ].some(a => p.hasAbility(a, false, true));
+          if (!isHoldingMax) {
+            const moveset = p.getMoveset(true).map(m => m.moveId);
 
-          const hasMoves = [
-            Moves.SUNNY_DAY,
-            Moves.RAIN_DANCE,
-            Moves.SANDSTORM,
-            Moves.SNOWSCAPE,
-            Moves.HAIL,
-            Moves.CHILLY_RECEPTION,
-            Moves.ELECTRIC_TERRAIN,
-            Moves.PSYCHIC_TERRAIN,
-            Moves.GRASSY_TERRAIN,
-            Moves.MISTY_TERRAIN,
-          ].some(m => moveset.includes(m));
+            const hasAbility = [
+              Abilities.DRIZZLE,
+              Abilities.ORICHALCUM_PULSE,
+              Abilities.DRIZZLE,
+              Abilities.SAND_STREAM,
+              Abilities.SAND_SPIT,
+              Abilities.SNOW_WARNING,
+              Abilities.ELECTRIC_SURGE,
+              Abilities.HADRON_ENGINE,
+              Abilities.PSYCHIC_SURGE,
+              Abilities.GRASSY_SURGE,
+              Abilities.SEED_SOWER,
+              Abilities.MISTY_SURGE,
+            ].some(a => p.hasAbility(a, false, true));
 
-          return hasAbility || hasMoves;
+            const hasMoves = [
+              Moves.SUNNY_DAY,
+              Moves.RAIN_DANCE,
+              Moves.SANDSTORM,
+              Moves.SNOWSCAPE,
+              Moves.HAIL,
+              Moves.CHILLY_RECEPTION,
+              Moves.ELECTRIC_TERRAIN,
+              Moves.PSYCHIC_TERRAIN,
+              Moves.GRASSY_TERRAIN,
+              Moves.MISTY_TERRAIN,
+            ].some(m => moveset.includes(m));
+
+            return hasAbility || hasMoves;
+          }
+          return false;
         })
           ? 10
           : 0;


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->

Players should no longer get `Mystical Rock` from the rewards screen when any applicable Pokémon in the party already has the maximum stack count for the item.

## Why am I making these changes?
<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

The item should not be pushed when the applicable Pokémon already have the maximum stack count, which makes it "take up" an item reward slot.

## What are the changes from a developer perspective?
<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

A `for` loop is added to the weight function for `Mystical Rock` that goes through each held item of a given Pokémon, checks if it has `Mystical Rock`, and checks if the current stack count is equal to the max stack count. Only if this check is `false` will the weight function continue checking for relevant abilities and moves dictated previously.

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

N/A

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

Use the following override in `src/overrides.ts`
```ts
const overrides = {
  STARTING_HELD_ITEMS_OVERRIDE: [
    { name: "MYSTICAL_ROCK", count: 2 }
  ]
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```
and start a new Classic Mode run with a Pokémon who has a relevant ability or move listed in #4799 (i.e., Groudon). Using `console.log` statements with the weight function within and after the `isHoldingMax` `if` block can be used to see what the end result weight of the item in the rewards pool is (logging after the block means the weight is 0, logging within the block means the weight is 10).

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - ~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~
- ~[ ] Have I provided screenshots/videos of the changes (if applicable)?~
  - ~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~

Are there any localization additions or changes? If so:
- ~[ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?~
  - ~[ ] If so, please leave a link to it here:~ 
- ~[ ] Has the translation team been contacted for proofreading/translation?~