### PR TITLE
[Bug][Hotfix] Fix Parental bond + Pollen Puff softlock

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -912,7 +912,7 @@ export default class Move implements Localizable {
     ];
 
     // ...and cannot enhance Pollen Puff when targeting an ally.
-    const exceptPollenPuffAlly: boolean = this.id === Moves.POLLEN_PUFF && targets.includes(user.getAlly().getBattlerIndex())
+    const exceptPollenPuffAlly: boolean = this.id === Moves.POLLEN_PUFF && targets.includes(user.getAlly()?.getBattlerIndex())
 
     return (!restrictSpread || !isMultiTarget)
       && !this.isChargingMove()

--- a/test/abilities/parental_bond.test.ts
+++ b/test/abilities/parental_bond.test.ts
@@ -9,7 +9,6 @@ import { StatusEffect } from "#enums/status-effect";
 import GameManager from "#test/testUtils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { BattlerIndex } from "#app/battle";
 
 describe("Abilities - Parental Bond", () => {
   let phaserGame: Phaser.Game;
@@ -426,22 +425,5 @@ describe("Abilities - Parental Bond", () => {
 
     // TODO: Update hit count to 1 once Future Sight is fixed to not activate abilities if user is off the field
     expect(enemyPokemon.damageAndUpdate).toHaveBeenCalledTimes(2);
-  });
-
-  it("should not allow Pollen Puff to heal ally more than once", async () => {
-    game.override.battleType("double").moveset([Moves.POLLEN_PUFF, Moves.ENDURE]);
-    await game.classicMode.startBattle([Species.BULBASAUR, Species.OMANYTE]);
-
-    const [, rightPokemon] = game.scene.getPlayerField();
-
-    rightPokemon.damageAndUpdate(rightPokemon.hp - 1);
-
-    game.move.select(Moves.POLLEN_PUFF, 0, BattlerIndex.PLAYER_2);
-    game.move.select(Moves.ENDURE, 1);
-
-    await game.toNextTurn();
-
-    // Pollen Puff heals with a ratio of 0.5, as long as Pollen Puff triggers only once the pokemon will always be <= (0.5 * Max HP) + 1
-    expect(rightPokemon.hp).toBeLessThanOrEqual(0.5 * rightPokemon.getMaxHp() + 1);
   });
 });

--- a/test/moves/pollen_puff.test.ts
+++ b/test/moves/pollen_puff.test.ts
@@ -1,0 +1,64 @@
+import { BattlerIndex } from "#app/battle";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Moves - Pollen Puff", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([Moves.POLLEN_PUFF])
+      .ability(Abilities.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH);
+  });
+
+  it("should not heal more than once when the user has a source of multi-hit", async () => {
+    game.override.battleType("double").moveset([Moves.POLLEN_PUFF, Moves.ENDURE]).ability(Abilities.PARENTAL_BOND);
+    await game.classicMode.startBattle([Species.BULBASAUR, Species.OMANYTE]);
+
+    const [_, rightPokemon] = game.scene.getPlayerField();
+
+    rightPokemon.damageAndUpdate(rightPokemon.hp - 1);
+
+    game.move.select(Moves.POLLEN_PUFF, 0, BattlerIndex.PLAYER_2);
+    game.move.select(Moves.ENDURE, 1);
+
+    await game.phaseInterceptor.to("BerryPhase");
+
+    // Pollen Puff heals with a ratio of 0.5, as long as Pollen Puff triggers only once the pokemon will always be <= (0.5 * Max HP) + 1
+    expect(rightPokemon.hp).toBeLessThanOrEqual(0.5 * rightPokemon.getMaxHp() + 1);
+  });
+
+  it("should damage an enemy multiple times when the user has a source of multi-hit", async () => {
+    game.override.moveset([Moves.POLLEN_PUFF]).ability(Abilities.PARENTAL_BOND).enemyLevel(100);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
+
+    const target = game.scene.getEnemyPokemon()!;
+
+    game.move.select(Moves.POLLEN_PUFF);
+
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(target.battleData.hitCount).toBe(2);
+  });
+});


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?
Users of Pollen Puff with Parental Bond (namely, champion Kieran's Hydrapple) won't crash. This has always been an issue but wasn't possible to encounter until Hydrapple was given the ability

## Why am I making these changes?
<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

## What are the changes from a developer perspective?
Removing the assumption in `canBeMultiStrikeEnhanced` that `user.getAlly()` will be defined

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?