### PR TITLE
[Bug] Fix super luck implementation

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -3499,8 +3499,18 @@ export class BonusCritAbAttr extends AbAttr {
   constructor() {
     super(false);
   }
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
-    (args[0] as Utils.BooleanHolder).value = true;
+
+  /**
+   * Apply the bonus crit ability by increasing the value in the provided number holder by 1
+   * 
+   * @param pokemon The pokemon with the BonusCrit ability (unused)
+   * @param passive Unused
+   * @param simulated Unused
+   * @param cancelled Unused
+   * @param args Args[0] is a number holder containing the crit stage.
+   */
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: [Utils.NumberHolder, ...any]): void {
+    (args[0] as Utils.NumberHolder).value += 1;
   }
 }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1360,11 +1360,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       source.isPlayer(),
       critStage,
     );
-    const bonusCrit = new Utils.BooleanHolder(false);
-    applyAbAttrs(BonusCritAbAttr, source, null, false, bonusCrit)
-    if (bonusCrit.value) {
-      critStage.value += 1;
-    }
+    applyAbAttrs(BonusCritAbAttr, source, null, false, critStage)
     const critBoostTag = source.getTag(CritBoostTag);
     if (critBoostTag) {
       if (critBoostTag instanceof DragonCheerTag) {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1361,12 +1361,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       critStage,
     );
     const bonusCrit = new Utils.BooleanHolder(false);
-    //@ts-ignore
-    if (applyAbAttrs(BonusCritAbAttr, source, null, false, bonusCrit)) {
-      // TODO: resolve ts-ignore. This is a promise. Checking a promise is bogus.
-      if (bonusCrit.value) {
-        critStage.value += 1;
-      }
+    applyAbAttrs(BonusCritAbAttr, source, null, false, bonusCrit)
+    if (bonusCrit.value) {
+      critStage.value += 1;
     }
     const critBoostTag = source.getTag(CritBoostTag);
     if (critBoostTag) {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1340,8 +1340,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Retrieves the critical-hit stage considering the move used and the Pokemon
-   * who used it.
+   * Calculate the critical-hit stage of a move used against this pokemon by
+   * the given source
+   * 
    * @param source the {@linkcode Pokemon} who using the move
    * @param move the {@linkcode Move} being used
    * @returns the final critical-hit stage value

--- a/test/abilities/super_luck.test.ts
+++ b/test/abilities/super_luck.test.ts
@@ -1,0 +1,43 @@
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Abilities - Super Luck", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([Moves.TACKLE])
+      .ability(Abilities.SUPER_LUCK)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH);
+  });
+
+  it("should increase the crit stage of a user by 1", async () => {
+    await game.classicMode.startBattle([Species.MAGIKARP]);
+    const enemy = game.scene.getEnemyPokemon()!;
+    const fn = vi.spyOn(enemy, "getCritStage");
+    game.move.select(Moves.TACKLE);
+    await game.phaseInterceptor.to("BerryPhase");
+    expect(fn).toHaveReturnedWith(1);
+    fn.mockRestore();
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?
Super luck will now actually increase the crit stage

## Why am I making these changes?
The ability was effectively not even implemented.

Fixes #5480

## What are the changes from a developer perspective?
- Removes the erroneous guard for `applyAbAttr` inside the pokemon class's `getCritStage` 
- Replaces `BonusCritAbAttr`'s use of a boolean holder with a number holder, so applying the ability now directly increases the crit stage

## Screenshots/Videos
N/A

## How to test the changes?
``npm run test:silent -- test/abilities/super_luck.test.ts``

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~