### PR TITLE
[Bug] Fix beak blast: not applying if user faints and not respecting long reach

### DIFF
--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -6701,7 +6701,7 @@ export function initAbilities() {
     new Ability(Abilities.BAD_DREAMS, 4)
       .attr(PostTurnHurtIfSleepingAbAttr),
     new Ability(Abilities.PICKPOCKET, 5)
-      .attr(PostDefendStealHeldItemAbAttr, (target, user, move) => move.hasFlag(MoveFlags.MAKES_CONTACT))
+      .attr(PostDefendStealHeldItemAbAttr, (target, user, move) => move.doesFlagEffectApply({flag: MoveFlags.MAKES_CONTACT, user, target}))
       .condition(getSheerForceHitDisableAbCondition()),
     new Ability(Abilities.SHEER_FORCE, 5)
       .attr(MovePowerBoostAbAttr, (user, target, move) => move.chance >= 1, 1.3)
@@ -7051,7 +7051,7 @@ export function initAbilities() {
     new Ability(Abilities.BATTERY, 7)
       .attr(AllyMoveCategoryPowerBoostAbAttr, [ MoveCategory.SPECIAL ], 1.3),
     new Ability(Abilities.FLUFFY, 7)
-      .attr(ReceivedMoveDamageMultiplierAbAttr, (target, user, move) => move.hasFlag(MoveFlags.MAKES_CONTACT), 0.5)
+      .attr(ReceivedMoveDamageMultiplierAbAttr, (target, user, move) => move.doesFlagEffectApply({flag: MoveFlags.MAKES_CONTACT, user, target}), 0.5)
       .attr(ReceivedMoveDamageMultiplierAbAttr, (target, user, move) => user.getMoveType(move) === PokemonType.FIRE, 2)
       .ignorable(),
     new Ability(Abilities.DAZZLING, 7)
@@ -7060,7 +7060,7 @@ export function initAbilities() {
     new Ability(Abilities.SOUL_HEART, 7)
       .attr(PostKnockOutStatStageChangeAbAttr, Stat.SPATK, 1),
     new Ability(Abilities.TANGLING_HAIR, 7)
-      .attr(PostDefendStatStageChangeAbAttr, (target, user, move) => move.hasFlag(MoveFlags.MAKES_CONTACT), Stat.SPD, -1, false),
+      .attr(PostDefendStatStageChangeAbAttr, (target, user, move) => move.doesFlagEffectApply({flag: MoveFlags.MAKES_CONTACT, user, target}), Stat.SPD, -1, false),
     new Ability(Abilities.RECEIVER, 7)
       .attr(CopyFaintedAllyAbilityAbAttr)
       .uncopiable(),

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -52,6 +52,7 @@ export enum BattlerTagLapseType {
   MOVE_EFFECT,
   TURN_END,
   HIT,
+  /** Tag lapses AFTER_HIT, applying its effects even if the user faints */
   AFTER_HIT,
   CUSTOM,
 }
@@ -498,7 +499,13 @@ export class BeakBlastChargingTag extends BattlerTag {
   lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
     if (lapseType === BattlerTagLapseType.AFTER_HIT) {
       const phaseData = getMoveEffectPhaseData(pokemon);
-      if (phaseData?.move.hasFlag(MoveFlags.MAKES_CONTACT)) {
+      if (
+        phaseData?.move.doesFlagEffectApply({
+          flag: MoveFlags.MAKES_CONTACT,
+          user: phaseData.attacker,
+          target: pokemon,
+        })
+      ) {
         phaseData.attacker.trySetStatus(StatusEffect.BURN, true, pokemon);
       }
       return true;
@@ -1614,16 +1621,50 @@ export class ProtectedTag extends BattlerTag {
 /** Base class for `BattlerTag`s that block damaging moves but not status moves */
 export class DamageProtectedTag extends ProtectedTag {}
 
+/** Class for `BattlerTag`s that apply some effect when hit by a contact move */
+export class ContactProtectedTag extends ProtectedTag {
+  /**
+   * Function to call when a contact move hits the pokemon with this tag.
+   * @param _attacker - The pokemon using the contact move
+   * @param _user - The pokemon that is being attacked and has the tag
+   * @param _move - The move used by the attacker
+   */
+  onContact(_attacker: Pokemon, _user: Pokemon) {}
+
+  /**
+   * Lapse the tag and apply `onContact` if the move makes contact and
+   * `lapseType` is custom, respecting the move's flags and the pokemon's
+   * abilities, and whether the lapseType is custom.
+   *
+   * @param pokemon - The pokemon with the tag
+   * @param lapseType - The type of lapse to apply. If this is not {@linkcode BattlerTagLapseType.CUSTOM CUSTOM}, no effect will be applied.
+   * @returns Whether the tag continues to exist after the lapse.
+   */
+  lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
+    const ret = super.lapse(pokemon, lapseType);
+
+    const moveData = getMoveEffectPhaseData(pokemon);
+    if (
+      lapseType === BattlerTagLapseType.CUSTOM &&
+      moveData &&
+      moveData.move.doesFlagEffectApply({ flag: MoveFlags.MAKES_CONTACT, user: moveData.attacker, target: pokemon })
+    ) {
+      this.onContact(moveData.attacker, pokemon);
+    }
+
+    return ret;
+  }
+}
+
 /**
  * `BattlerTag` class for moves that block damaging moves damage the enemy if the enemy's move makes contact
  * Used by {@linkcode Moves.SPIKY_SHIELD}
  */
-export class ContactDamageProtectedTag extends ProtectedTag {
+export class ContactDamageProtectedTag extends ContactProtectedTag {
   private damageRatio: number;
 
   constructor(sourceMove: Moves, damageRatio: number) {
     super(sourceMove, BattlerTagType.SPIKY_SHIELD);
-
     this.damageRatio = damageRatio;
   }
 
@@ -1636,22 +1677,43 @@ export class ContactDamageProtectedTag extends ProtectedTag {
     this.damageRatio = source.damageRatio;
   }
 
-  lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
-    const ret = super.lapse(pokemon, lapseType);
-
-    if (lapseType === BattlerTagLapseType.CUSTOM) {
-      const effectPhase = globalScene.getCurrentPhase();
-      if (effectPhase instanceof MoveEffectPhase && effectPhase.move.getMove().hasFlag(MoveFlags.MAKES_CONTACT)) {
-        const attacker = effectPhase.getPokemon();
-        if (!attacker.hasAbilityWithAttr(BlockNonDirectDamageAbAttr)) {
-          attacker.damageAndUpdate(toDmgValue(attacker.getMaxHp() * (1 / this.damageRatio)), {
-            result: HitResult.INDIRECT,
-          });
-        }
-      }
+  /**
+   * Damage the attacker by `this.damageRatio` of the target's max HP
+   * @param attacker - The pokemon using the contact move
+   * @param user - The pokemon that is being attacked and has the tag
+   */
+  override onContact(attacker: Pokemon, user: Pokemon): void {
+    const cancelled = new BooleanHolder(false);
+    applyAbAttrs(BlockNonDirectDamageAbAttr, user, cancelled);
+    if (!cancelled.value) {
+      attacker.damageAndUpdate(toDmgValue(attacker.getMaxHp() * (1 / this.damageRatio)), {
+        result: HitResult.INDIRECT,
+      });
     }
+  }
+}
 
-    return ret;
+export class ContactSetStatusProtectedTag extends ContactProtectedTag {
+  /**
+   * @param sourceMove The move that caused the tag to be applied
+   * @param tagType The type of the tag
+   * @param statusEffect The status effect to apply to the attacker
+   */
+  constructor(
+    sourceMove: Moves,
+    tagType: BattlerTagType,
+    private statusEffect: StatusEffect,
+  ) {
+    super(sourceMove, tagType);
+  }
+
+  /**
+   * Set the status effect on the attacker
+   * @param attacker - The pokemon using the contact move
+   * @param user - The pokemon that is being attacked and has the tag
+   */
+  override onContact(attacker: Pokemon, user: Pokemon): void {
+    attacker.trySetStatus(this.statusEffect, true, user);
   }
 }
 
@@ -1659,7 +1721,7 @@ export class ContactDamageProtectedTag extends ProtectedTag {
  * `BattlerTag` class for moves that block damaging moves and lower enemy stats if the enemy's move makes contact
  * Used by {@linkcode Moves.KINGS_SHIELD}, {@linkcode Moves.OBSTRUCT}, {@linkcode Moves.SILK_TRAP}
  */
-export class ContactStatStageChangeProtectedTag extends DamageProtectedTag {
+export class ContactStatStageChangeProtectedTag extends ContactProtectedTag {
   private stat: BattleStat;
   private levels: number;
 
@@ -1674,68 +1736,19 @@ export class ContactStatStageChangeProtectedTag extends DamageProtectedTag {
    * When given a battler tag or json representing one, load the data for it.
    * @param {BattlerTag | any} source A battler tag
    */
-  loadTag(source: BattlerTag | any): void {
+  override loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
     this.stat = source.stat;
     this.levels = source.levels;
   }
 
-  lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
-    const ret = super.lapse(pokemon, lapseType);
-
-    if (lapseType === BattlerTagLapseType.CUSTOM) {
-      const effectPhase = globalScene.getCurrentPhase();
-      if (effectPhase instanceof MoveEffectPhase && effectPhase.move.getMove().hasFlag(MoveFlags.MAKES_CONTACT)) {
-        const attacker = effectPhase.getPokemon();
-        globalScene.unshiftPhase(new StatStageChangePhase(attacker.getBattlerIndex(), false, [this.stat], this.levels));
-      }
-    }
-
-    return ret;
-  }
-}
-
-export class ContactPoisonProtectedTag extends ProtectedTag {
-  constructor(sourceMove: Moves) {
-    super(sourceMove, BattlerTagType.BANEFUL_BUNKER);
-  }
-
-  lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
-    const ret = super.lapse(pokemon, lapseType);
-
-    if (lapseType === BattlerTagLapseType.CUSTOM) {
-      const effectPhase = globalScene.getCurrentPhase();
-      if (effectPhase instanceof MoveEffectPhase && effectPhase.move.getMove().hasFlag(MoveFlags.MAKES_CONTACT)) {
-        const attacker = effectPhase.getPokemon();
-        attacker.trySetStatus(StatusEffect.POISON, true, pokemon);
-      }
-    }
-
-    return ret;
-  }
-}
-
-/**
- * `BattlerTag` class for moves that block damaging moves and burn the enemy if the enemy's move makes contact
- * Used by {@linkcode Moves.BURNING_BULWARK}
- */
-export class ContactBurnProtectedTag extends DamageProtectedTag {
-  constructor(sourceMove: Moves) {
-    super(sourceMove, BattlerTagType.BURNING_BULWARK);
-  }
-
-  lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
-    const ret = super.lapse(pokemon, lapseType);
-
-    if (lapseType === BattlerTagLapseType.CUSTOM) {
-      const effectPhase = globalScene.getCurrentPhase();
-      if (effectPhase instanceof MoveEffectPhase && effectPhase.move.getMove().hasFlag(MoveFlags.MAKES_CONTACT)) {
-        const attacker = effectPhase.getPokemon();
-        attacker.trySetStatus(StatusEffect.BURN, true);
-      }
-    }
-
-    return ret;
+  /**
+   * Initiate the stat stage change on the attacker
+   * @param attacker - The pokemon using the contact move
+   * @param user - The pokemon that is being attacked and has the tag
+   */
+  override onContact(attacker: Pokemon, _user: Pokemon): void {
+    globalScene.unshiftPhase(new StatStageChangePhase(attacker.getBattlerIndex(), false, [this.stat], this.levels));
   }
 }
 
@@ -3518,9 +3531,9 @@ export function getBattlerTag(
     case BattlerTagType.SILK_TRAP:
       return new ContactStatStageChangeProtectedTag(sourceMove, tagType, Stat.SPD, -1);
     case BattlerTagType.BANEFUL_BUNKER:
-      return new ContactPoisonProtectedTag(sourceMove);
+      return new ContactSetStatusProtectedTag(sourceMove, tagType, StatusEffect.POISON);
     case BattlerTagType.BURNING_BULWARK:
-      return new ContactBurnProtectedTag(sourceMove);
+      return new ContactSetStatusProtectedTag(sourceMove, tagType, StatusEffect.BURN);
     case BattlerTagType.ENDURING:
       return new EnduringTag(tagType, BattlerTagLapseType.TURN_END, sourceMove);
     case BattlerTagType.ENDURE_TOKEN:

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -1618,9 +1618,6 @@ export class ProtectedTag extends BattlerTag {
   }
 }
 
-/** Base class for `BattlerTag`s that block damaging moves but not status moves */
-export class DamageProtectedTag extends ProtectedTag {}
-
 /** Class for `BattlerTag`s that apply some effect when hit by a contact move */
 export class ContactProtectedTag extends ProtectedTag {
   /**
@@ -1693,7 +1690,10 @@ export class ContactDamageProtectedTag extends ContactProtectedTag {
   }
 }
 
-export class ContactSetStatusProtectedTag extends ContactProtectedTag {
+/** Base class for `BattlerTag`s that block damaging moves but not status moves */
+export class DamageProtectedTag extends ContactProtectedTag {}
+
+export class ContactSetStatusProtectedTag extends DamageProtectedTag {
   /**
    * @param sourceMove The move that caused the tag to be applied
    * @param tagType The type of the tag
@@ -1721,7 +1721,7 @@ export class ContactSetStatusProtectedTag extends ContactProtectedTag {
  * `BattlerTag` class for moves that block damaging moves and lower enemy stats if the enemy's move makes contact
  * Used by {@linkcode Moves.KINGS_SHIELD}, {@linkcode Moves.OBSTRUCT}, {@linkcode Moves.SILK_TRAP}
  */
-export class ContactStatStageChangeProtectedTag extends ContactProtectedTag {
+export class ContactStatStageChangeProtectedTag extends DamageProtectedTag {
   private stat: BattleStat;
   private levels: number;
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4762,7 +4762,6 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
       this.destroySubstitute();
       this.lapseTag(BattlerTagType.COMMANDED);
-      this.resetSummonData();
     }
 
     return result;
@@ -4824,7 +4823,6 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       );
       this.destroySubstitute();
       this.lapseTag(BattlerTagType.COMMANDED);
-      this.resetSummonData();
     }
     return damage;
   }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -128,6 +128,7 @@ import {
   TarShotTag,
   AutotomizedTag,
   PowerTrickTag,
+  type GrudgeTag,
 } from "../data/battler-tags";
 import { WeatherType } from "#enums/weather-type";
 import {
@@ -4754,8 +4755,6 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         new FaintPhase(
           this.getBattlerIndex(),
           false,
-          destinyTag,
-          grudgeTag,
           source,
         ),
       );
@@ -4989,6 +4988,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
     return false;
   }
+
+  /**@overload */
+  getTag(tagType: BattlerTagType.GRUDGE): GrudgeTag | nil;
 
   /** @overload */
   getTag(tagType: BattlerTagType): BattlerTag | nil;

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -9,7 +9,6 @@ import {
   PostKnockOutAbAttr,
   PostVictoryAbAttr,
 } from "#app/data/abilities/ability";
-import type { DestinyBondTag, GrudgeTag } from "#app/data/battler-tags";
 import { BattlerTagLapseType } from "#app/data/battler-tags";
 import { battleSpecDialogue } from "#app/data/dialogue";
 import { allMoves, PostVictoryStatStageChangeAttr } from "#app/data/moves/move";
@@ -32,6 +31,7 @@ import { ToggleDoublePositionPhase } from "./toggle-double-position-phase";
 import { VictoryPhase } from "./victory-phase";
 import { isNullOrUndefined } from "#app/utils";
 import { FRIENDSHIP_LOSS_FROM_FAINT } from "#app/data/balance/starters";
+import { BattlerTagType } from "#enums/battler-tag-type";
 
 export class FaintPhase extends PokemonPhase {
   /**
@@ -40,32 +40,14 @@ export class FaintPhase extends PokemonPhase {
   private preventEndure: boolean;
 
   /**
-   * Destiny Bond tag belonging to the currently fainting Pokemon, if applicable
-   */
-  private destinyTag?: DestinyBondTag | null;
-
-  /**
-   * Grudge tag belonging to the currently fainting Pokemon, if applicable
-   */
-  private grudgeTag?: GrudgeTag | null;
-
-  /**
    * The source Pokemon that dealt fatal damage
    */
   private source?: Pokemon;
 
-  constructor(
-    battlerIndex: BattlerIndex,
-    preventEndure = false,
-    destinyTag?: DestinyBondTag | null,
-    grudgeTag?: GrudgeTag | null,
-    source?: Pokemon,
-  ) {
+  constructor(battlerIndex: BattlerIndex, preventEndure = false, source?: Pokemon) {
     super(battlerIndex);
 
     this.preventEndure = preventEndure;
-    this.destinyTag = destinyTag;
-    this.grudgeTag = grudgeTag;
     this.source = source;
   }
 
@@ -74,15 +56,12 @@ export class FaintPhase extends PokemonPhase {
 
     const faintPokemon = this.getPokemon();
 
+    if (this.source) {
+      faintPokemon.getTag(BattlerTagType.DESTINY_BOND)?.lapse(this.source, BattlerTagLapseType.CUSTOM);
+      faintPokemon.getTag(BattlerTagType.GRUDGE)?.lapse(faintPokemon, BattlerTagLapseType.CUSTOM, this.source);
+    }
+
     faintPokemon.resetSummonData();
-
-    if (!isNullOrUndefined(this.destinyTag) && !isNullOrUndefined(this.source)) {
-      this.destinyTag.lapse(this.source, BattlerTagLapseType.CUSTOM);
-    }
-
-    if (!isNullOrUndefined(this.grudgeTag) && !isNullOrUndefined(this.source)) {
-      this.grudgeTag.lapse(faintPokemon, BattlerTagLapseType.CUSTOM, this.source);
-    }
 
     if (!this.preventEndure) {
       const instantReviveModifier = globalScene.applyModifier(

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -74,6 +74,8 @@ export class FaintPhase extends PokemonPhase {
 
     const faintPokemon = this.getPokemon();
 
+    faintPokemon.resetSummonData();
+
     if (!isNullOrUndefined(this.destinyTag) && !isNullOrUndefined(this.source)) {
       this.destinyTag.lapse(this.source, BattlerTagLapseType.CUSTOM);
     }

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -628,16 +628,19 @@ export class MoveEffectPhase extends PokemonPhase {
    * @returns a `Promise` intended to be passed into a `then()` call.
    */
   protected applyOnGetHitAbEffects(user: Pokemon, target: Pokemon, hitResult: HitResult) {
+    const hitsSubstitute = this.move.getMove().hitsSubstitute(user, target);
     if (!target.isFainted() || target.canApplyAbility()) {
       applyPostDefendAbAttrs(PostDefendAbAttr, target, user, this.move.getMove(), hitResult);
 
-      if (!this.move.getMove().hitsSubstitute(user, target)) {
+      if (!hitsSubstitute) {
         if (!user.isPlayer() && this.move.getMove() instanceof AttackMove) {
           globalScene.applyShuffledModifiers(EnemyAttackStatusEffectChanceModifier, false, target);
         }
       }
     }
-    target.lapseTags(BattlerTagLapseType.AFTER_HIT);
+    if (!hitsSubstitute) {
+      target.lapseTags(BattlerTagLapseType.AFTER_HIT);
+    }
   }
 
   /**

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -627,7 +627,7 @@ export class MoveEffectPhase extends PokemonPhase {
    * @param hitResult - The {@linkcode HitResult} of the attempted move
    * @returns a `Promise` intended to be passed into a `then()` call.
    */
-  protected applyOnGetHitAbEffects(user: Pokemon, target: Pokemon, hitResult: HitResult): void {
+  protected applyOnGetHitAbEffects(user: Pokemon, target: Pokemon, hitResult: HitResult) {
     if (!target.isFainted() || target.canApplyAbility()) {
       applyPostDefendAbAttrs(PostDefendAbAttr, target, user, this.move.getMove(), hitResult);
 
@@ -635,10 +635,9 @@ export class MoveEffectPhase extends PokemonPhase {
         if (!user.isPlayer() && this.move.getMove() instanceof AttackMove) {
           globalScene.applyShuffledModifiers(EnemyAttackStatusEffectChanceModifier, false, target);
         }
-
-        target.lapseTags(BattlerTagLapseType.AFTER_HIT);
       }
     }
+    target.lapseTags(BattlerTagLapseType.AFTER_HIT);
   }
 
   /**

--- a/test/moves/beak_blast.test.ts
+++ b/test/moves/beak_blast.test.ts
@@ -127,4 +127,14 @@ describe("Moves - Beak Blast", () => {
     await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon.status?.effect).toBe(StatusEffect.BURN);
   });
+
+  it("should not burn a long reach enemy that hits the user with a contact move", async () => {
+    game.override.enemyAbility(Abilities.LONG_REACH);
+    game.override.enemyMoveset([Moves.FALSE_SWIPE]).enemyLevel(100);
+    await game.classicMode.startBattle([Species.MAGIKARP]);
+    game.move.select(Moves.BEAK_BLAST);
+    await game.phaseInterceptor.to("BerryPhase", false);
+    const enemyPokemon = game.scene.getEnemyPokemon()!;
+    expect(enemyPokemon.status?.effect).not.toBe(StatusEffect.BURN);
+  });
 });

--- a/test/moves/beak_blast.test.ts
+++ b/test/moves/beak_blast.test.ts
@@ -38,7 +38,7 @@ describe("Moves - Beak Blast", () => {
   });
 
   it("should add a charge effect that burns attackers on contact", async () => {
-    await game.startBattle([Species.BLASTOISE]);
+    await game.classicMode.startBattle([Species.BLASTOISE]);
 
     const leadPokemon = game.scene.getPlayerPokemon()!;
     const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -55,7 +55,7 @@ describe("Moves - Beak Blast", () => {
   it("should still charge and burn opponents if the user is sleeping", async () => {
     game.override.statusEffect(StatusEffect.SLEEP);
 
-    await game.startBattle([Species.BLASTOISE]);
+    await game.classicMode.startBattle([Species.BLASTOISE]);
 
     const leadPokemon = game.scene.getPlayerPokemon()!;
     const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -72,7 +72,7 @@ describe("Moves - Beak Blast", () => {
   it("should not burn attackers that don't make contact", async () => {
     game.override.enemyMoveset([Moves.WATER_GUN]);
 
-    await game.startBattle([Species.BLASTOISE]);
+    await game.classicMode.startBattle([Species.BLASTOISE]);
 
     const leadPokemon = game.scene.getPlayerPokemon()!;
     const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -89,7 +89,7 @@ describe("Moves - Beak Blast", () => {
   it("should only hit twice with Multi-Lens", async () => {
     game.override.startingHeldItems([{ name: "MULTI_LENS", count: 1 }]);
 
-    await game.startBattle([Species.BLASTOISE]);
+    await game.classicMode.startBattle([Species.BLASTOISE]);
 
     const leadPokemon = game.scene.getPlayerPokemon()!;
 
@@ -102,7 +102,7 @@ describe("Moves - Beak Blast", () => {
   it("should be blocked by Protect", async () => {
     game.override.enemyMoveset([Moves.PROTECT]);
 
-    await game.startBattle([Species.BLASTOISE]);
+    await game.classicMode.startBattle([Species.BLASTOISE]);
 
     const leadPokemon = game.scene.getPlayerPokemon()!;
     const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -115,5 +115,16 @@ describe("Moves - Beak Blast", () => {
     await game.phaseInterceptor.to(TurnEndPhase);
     expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
     expect(leadPokemon.getTag(BattlerTagType.BEAK_BLAST_CHARGING)).toBeUndefined();
+  });
+
+  it("should still burn the enemy if the user is knocked out", async () => {
+    game.override.ability(Abilities.BALL_FETCH);
+    await game.classicMode.startBattle([Species.MAGIKARP, Species.MAGIKARP]);
+    const enemyPokemon = game.scene.getEnemyPokemon()!;
+    const user = game.scene.getPlayerPokemon()!;
+    user.hp = 1;
+    game.move.select(Moves.BEAK_BLAST);
+    await game.phaseInterceptor.to("BerryPhase", false);
+    expect(enemyPokemon.status?.effect).toBe(StatusEffect.BURN);
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?

Beak Blast will now burn the attacker if the beak blast user faints.
Moves and abilities that proc an effect on contact damage will now consider things like long reach.

## Why am I making these changes?
Fixes #5518
Fixes #4974 

## What are the changes from a developer perspective?

Searched for all instances where the `move.hasFlag` method was being used to check for contact damage and replaced them with `move.doesFlagEffectApply`, so they will now properly consider whether long reach should apply.

Created a `ContactProtectedTag` class to deduplicate the logic applied by tags for baneful bunker, burning bulkwark, obstruct, etc., that apply some effect to an attacker that makes physical contact.

Removed the `ContactPoisonProtectedTag` and `ContactBurnProtectedTag` and replaced them with a `ContactSetStatusProtectedTag` that takes an argument specifying which status effect to apply.


Removed the call to `this.resetSummonData` inside the `apply` method of pokemon and instead moved it to occur in the faint phase _if_ the user actually fainted. This means that things like reviving from reviver seed, etc., will no longer improperly clear summon data. In turn, this means that the `faintPhase` no longer takes parameters for the grudge and destiny bond tags, as they are not cleared until the faint phase.
This is necessary, as the reason beak blast wasn't able to apply its effects if the user fainted is because it is the move effect phase that was applying the tags, but resetting summon data inside the apply method would clear all tags. This causes the tags to be removed.
The interaction between move effect phase and `pokemon.apply` needs to be scrutinized. That is outside the scope of this PR, however.

## Screenshots/Videos
<details><summary> Beak Blast properly burning after faint </summary>


https://github.com/user-attachments/assets/52bfad8c-ecff-4112-bbce-854990933b05
</details>

<details><summary> Beak Blast still burning even with no faint: </summary/>

https://github.com/user-attachments/assets/9a0edaac-f96d-4230-bf09-83a436d2fe08
</details>

<details><summary> Beak Blast not burning with long reach</summary/>

https://github.com/user-attachments/assets/b1a1e2d4-c869-490f-8ad9-127b02de133b
</details>


## How to test the changes?
For beak blast burning the attacker through faint (and not faint):

```ts
const overrides = {
  OPP_MOVESET_OVERRIDE: [Moves.BEAK_BLAST],
  OPP_HAS_PASSIVE_ABILITY_OVERRIDE: false,
  STARTING_LEVEL_OVERRIDE: 100,
  MOVESET_OVERRIDE: [ Moves.TACKLE, Moves.FALSE_SWIPE],
  ABILITY_OVERRIDE: Abilities.BALL_FETCH,
  OPP_SPECIES_OVERRIDE: Species.MAGIKARP,
  HAS_PASSIVE_ABILITY_OVERRIDE: false,
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

For beak blast and long reach interaction:

```ts
const overrides = {
  STARTING_LEVEL_OVERRIDE: 100,
  OPP_MOVESET_OVERRIDE: [Moves.BEAK_BLAST],
  ABILITY_OVERRIDE: Abilities.LONG_REACH,
  OPP_ABILITY_OVERRIDE: Abilities.BALL_FETCH,
  MOVESET_OVERRIDE: [ Moves.FALSE_SWIPE ]
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```


## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~