### PR TITLE
[Bug][Ability] Fix healer queueing its message when its ally is fainted

### DIFF
--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -4033,7 +4033,9 @@ export class PostTurnResetStatusAbAttr extends PostTurnAbAttr {
     } else {
       this.target = pokemon;
     }
-    return !isNullOrUndefined(this.target?.status);
+
+    const effect = this.target?.status?.effect;
+    return !!effect && effect !== StatusEffect.FAINT;
   }
 
   override applyPostTurn(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): void {

--- a/test/abilities/healer.test.ts
+++ b/test/abilities/healer.test.ts
@@ -5,8 +5,9 @@ import { StatusEffect } from "#enums/status-effect";
 import GameManager from "#test/testUtils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
-import * as Utils from "#app/utils";
-import { allAbilities, PostTurnResetStatusAbAttr } from "#app/data/ability";
+import { isNullOrUndefined } from "#app/utils";
+import { PostTurnResetStatusAbAttr } from "#app/data/abilities/ability";
+import { allAbilities } from "#app/data/data-lists";
 import type Pokemon from "#app/field/pokemon";
 
 describe("Abilities - Healer", () => {
@@ -40,7 +41,7 @@ describe("Abilities - Healer", () => {
     healerAttr = allAbilities[Abilities.HEALER].getAttrs(PostTurnResetStatusAbAttr)[0];
     healerAttrSpy = vi
       .spyOn(healerAttr, "getCondition")
-      .mockReturnValue((pokemon: Pokemon) => !Utils.isNullOrUndefined(pokemon.getAlly()));
+      .mockReturnValue((pokemon: Pokemon) => !isNullOrUndefined(pokemon.getAlly()));
   });
 
   it("should not queue a message phase for healing if the ally has fainted", async () => {

--- a/test/abilities/healer.test.ts
+++ b/test/abilities/healer.test.ts
@@ -71,9 +71,6 @@ describe("Abilities - Healer", () => {
     expect(ally.trySetStatus(StatusEffect.BURN)).toBe(true);
     game.move.select(Moves.SPLASH);
     game.move.select(Moves.SPLASH, 1);
-    await game.forceEnemyMove(Moves.SPLASH);
-    expect(ally.status?.effect).toBe(StatusEffect.BURN);
-    // Give the ally a status
     await game.toNextTurn();
 
     expect(ally.status?.effect, "status effect was not healed").toBeFalsy();
@@ -88,9 +85,6 @@ describe("Abilities - Healer", () => {
     expect(ally.trySetStatus(StatusEffect.BURN)).toBe(true);
     game.move.select(Moves.SPLASH);
     game.move.select(Moves.SPLASH, 1);
-    await game.forceEnemyMove(Moves.SPLASH);
-    expect(ally.status?.effect).toBe(StatusEffect.BURN);
-    // Give the ally a status
     await game.toNextTurn();
 
     expect(ally.status?.effect, "status effect was not healed").toBeFalsy();

--- a/test/abilities/healer.test.ts
+++ b/test/abilities/healer.test.ts
@@ -71,6 +71,8 @@ describe("Abilities - Healer", () => {
     expect(ally.trySetStatus(StatusEffect.BURN)).toBe(true);
     game.move.select(Moves.SPLASH);
     game.move.select(Moves.SPLASH, 1);
+
+    await game.phaseInterceptor.to("TurnEndPhase");
     await game.toNextTurn();
 
     expect(ally.status?.effect, "status effect was not healed").toBeFalsy();
@@ -85,6 +87,7 @@ describe("Abilities - Healer", () => {
     expect(ally.trySetStatus(StatusEffect.BURN)).toBe(true);
     game.move.select(Moves.SPLASH);
     game.move.select(Moves.SPLASH, 1);
+    await game.phaseInterceptor.to("TurnEndPhase");
     await game.toNextTurn();
 
     expect(ally.status?.effect, "status effect was not healed").toBeFalsy();

--- a/test/abilities/healer.test.ts
+++ b/test/abilities/healer.test.ts
@@ -1,0 +1,99 @@
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { StatusEffect } from "#enums/status-effect";
+import GameManager from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
+import * as Utils from "#app/utils";
+import { allAbilities, PostTurnResetStatusAbAttr } from "#app/data/ability";
+import type Pokemon from "#app/field/pokemon";
+
+describe("Abilities - Healer", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+  let healerAttrSpy: MockInstance;
+  let healerAttr: PostTurnResetStatusAbAttr;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+    healerAttrSpy.mockRestore();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([Moves.SPLASH])
+      .ability(Abilities.BALL_FETCH)
+      .battleType("double")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH);
+
+    healerAttr = allAbilities[Abilities.HEALER].getAttrs(PostTurnResetStatusAbAttr)[0];
+    healerAttrSpy = vi
+      .spyOn(healerAttr, "getCondition")
+      .mockReturnValue((pokemon: Pokemon) => !Utils.isNullOrUndefined(pokemon.getAlly()));
+  });
+
+  it("should not queue a message phase for healing if the ally has fainted", async () => {
+    game.override.moveset([Moves.SPLASH, Moves.LUNAR_DANCE]);
+    await game.classicMode.startBattle([Species.MAGIKARP, Species.MAGIKARP]);
+    const user = game.scene.getPlayerPokemon()!;
+    // Only want one magikarp to have the ability.
+    vi.spyOn(user, "getAbility").mockReturnValue(allAbilities[Abilities.HEALER]);
+    game.move.select(Moves.SPLASH);
+    // faint the ally
+    game.move.select(Moves.LUNAR_DANCE, 1);
+    const abSpy = vi.spyOn(healerAttr, "canApplyPostTurn");
+    await game.phaseInterceptor.to("TurnEndPhase");
+
+    // It's not enough to just test that the ally still has its status.
+    // We need to ensure that the ability failed to meet its condition
+    expect(abSpy).toHaveReturnedWith(false);
+
+    // Explicitly restore the mock to ensure pollution doesn't happen
+    abSpy.mockRestore();
+  });
+
+  it("should heal the status of an ally if the ally has a status", async () => {
+    await game.classicMode.startBattle([Species.MAGIKARP, Species.MAGIKARP]);
+    const [user, ally] = game.scene.getPlayerField();
+    // Only want one magikarp to have the ability.
+    vi.spyOn(user, "getAbility").mockReturnValue(allAbilities[Abilities.HEALER]);
+    expect(ally.trySetStatus(StatusEffect.BURN)).toBe(true);
+    game.move.select(Moves.SPLASH);
+    game.move.select(Moves.SPLASH, 1);
+    await game.forceEnemyMove(Moves.SPLASH);
+    expect(ally.status?.effect).toBe(StatusEffect.BURN);
+    // Give the ally a status
+    await game.toNextTurn();
+
+    expect(ally.status?.effect, "status effect was not healed").toBeFalsy();
+  });
+
+  // TODO: Healer is currently checked before the
+  it.todo("should heal a burn before its end of turn damage", async () => {
+    await game.classicMode.startBattle([Species.MAGIKARP, Species.MAGIKARP]);
+    const [user, ally] = game.scene.getPlayerField();
+    // Only want one magikarp to have the ability.
+    vi.spyOn(user, "getAbility").mockReturnValue(allAbilities[Abilities.HEALER]);
+    expect(ally.trySetStatus(StatusEffect.BURN)).toBe(true);
+    game.move.select(Moves.SPLASH);
+    game.move.select(Moves.SPLASH, 1);
+    await game.forceEnemyMove(Moves.SPLASH);
+    expect(ally.status?.effect).toBe(StatusEffect.BURN);
+    // Give the ally a status
+    await game.toNextTurn();
+
+    expect(ally.status?.effect, "status effect was not healed").toBeFalsy();
+    expect(ally.hp).toBe(ally.getMaxHp());
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?
The user will no longer see a message saying that healer attempted to heal a status effect of a fainted ally

## Why am I making these changes?
Fixes #4981 

## What are the changes from a developer perspective?
Adds the following check to the `canApplyPostTurn` of healer's attribute:
```ts
const effect = this.target?.status?.effect;
return !!effect && effect !== StatusEffect.FAINT;
 ```

Adds a test file for healer along with 3 tests, one of which is marked as TODO (healer healing the status before end of turn status damage).

## Screenshots/Videos
There's no way to upload a video for a negative, as it's a chance interaction anyway.

## How to test the changes?
`npm run test:silent test/abilities/healer.test.ts`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~~[ ] Have I tested the changes manually?~~ No way to do this
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~