### PR TITLE
[Bug][Move] Struggle no longer gets STAB

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4175,10 +4175,6 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       stabMultiplier.value += 0.5;
     }
 
-    if (!ignoreSourceAbility) {
-      applyAbAttrs(StabBoostAbAttr, source, null, simulated, stabMultiplier);
-    }
-
     applyMoveAttrs(
       CombinedPledgeStabBoostAttr,
       source,
@@ -4186,6 +4182,10 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       move,
       stabMultiplier,
     );
+
+    if (!ignoreSourceAbility) {
+      applyAbAttrs(StabBoostAbAttr, source, null, simulated, stabMultiplier);
+    }
 
     if (
       source.isTerastallized &&
@@ -4201,11 +4201,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       (!source.stellarTypesBoosted.includes(moveType) ||
         source.hasSpecies(Species.TERAPAGOS))
     ) {
-      if (matchesSourceType) {
-        stabMultiplier.value += 0.5;
-      } else {
-        stabMultiplier.value += 0.2;
-      }
+      stabMultiplier.value += matchesSourceType ? 0.5 : 0.2;
     }
 
     return Math.min(stabMultiplier.value, 2.25);
@@ -4395,7 +4391,6 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
 
     /** A damage multiplier for when the attack is of the attacker's type and/or Tera type. */
-
     const stabMultiplier = this.calculateStabMultiplier(source, move, ignoreSourceAbility, simulated);
 
     /** Halves damage if the attacker is using a physical attack while burned */

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4151,6 +4151,66 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     return baseDamage;
   }
 
+
+  /** Determine the STAB multiplier for a move used against this pokemon.
+   * 
+   * @param source - The attacking {@linkcode Pokemon}
+   * @param move - The {@linkcode Move} used in the attack
+   * @param ignoreSourceAbility - If `true`, ignores the attacking Pokemon's ability effects
+   * @param simulated - If `true`, suppresses changes to game state during the calculation
+   * 
+   * @returns The STAB multiplier for the move used against this Pokemon
+   */
+  calculateStabMultiplier(source: Pokemon, move: Move, ignoreSourceAbility: boolean, simulated: boolean): number {
+    // If the move has the Typeless attribute, it doesn't get STAB (e.g. struggle)
+    if (move.hasAttr(TypelessAttr)) {
+      return 1;
+    }
+    const sourceTypes = source.getTypes();
+    const sourceTeraType = source.getTeraType();
+    const moveType = source.getMoveType(move);
+    const matchesSourceType = sourceTypes.includes(source.getMoveType(move));
+    const stabMultiplier = new NumberHolder(1);
+    if (matchesSourceType && moveType !== PokemonType.STELLAR) {
+      stabMultiplier.value += 0.5;
+    }
+
+    if (!ignoreSourceAbility) {
+      applyAbAttrs(StabBoostAbAttr, source, null, simulated, stabMultiplier);
+    }
+
+    applyMoveAttrs(
+      CombinedPledgeStabBoostAttr,
+      source,
+      this,
+      move,
+      stabMultiplier,
+    );
+
+    if (
+      source.isTerastallized &&
+      sourceTeraType === moveType &&
+      moveType !== PokemonType.STELLAR
+    ) {
+      stabMultiplier.value += 0.5;
+    }
+
+    if (
+      source.isTerastallized &&
+      source.getTeraType() === PokemonType.STELLAR &&
+      (!source.stellarTypesBoosted.includes(moveType) ||
+        source.hasSpecies(Species.TERAPAGOS))
+    ) {
+      if (matchesSourceType) {
+        stabMultiplier.value += 0.5;
+      } else {
+        stabMultiplier.value += 0.2;
+      }
+    }
+
+    return Math.min(stabMultiplier.value, 2.25);
+  }
+
   /**
    * Calculates the damage of an attack made by another Pokemon against this Pokemon
    * @param source {@linkcode Pokemon} the attacking Pokemon
@@ -4333,70 +4393,30 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       ? 1
       : this.randSeedIntRange(85, 100) / 100;
 
-    const sourceTypes = source.getTypes();
-    const sourceTeraType = source.getTeraType();
-    const matchesSourceType = sourceTypes.includes(moveType);
+
     /** A damage multiplier for when the attack is of the attacker's type and/or Tera type. */
-    const stabMultiplier = new NumberHolder(1);
-    if (matchesSourceType && moveType !== PokemonType.STELLAR) {
-      stabMultiplier.value += 0.5;
-    }
 
-    if (!ignoreSourceAbility) {
-      applyAbAttrs(StabBoostAbAttr, source, null, simulated, stabMultiplier);
-    }
-
-    applyMoveAttrs(
-      CombinedPledgeStabBoostAttr,
-      source,
-      this,
-      move,
-      stabMultiplier,
-    );
-
-    if (
-      source.isTerastallized &&
-      sourceTeraType === moveType &&
-      moveType !== PokemonType.STELLAR
-    ) {
-      stabMultiplier.value += 0.5;
-    }
-
-    if (
-      source.isTerastallized &&
-      source.getTeraType() === PokemonType.STELLAR &&
-      (!source.stellarTypesBoosted.includes(moveType) ||
-        source.hasSpecies(Species.TERAPAGOS))
-    ) {
-      if (matchesSourceType) {
-        stabMultiplier.value += 0.5;
-      } else {
-        stabMultiplier.value += 0.2;
-      }
-    }
-
-    stabMultiplier.value = Math.min(stabMultiplier.value, 2.25);
+    const stabMultiplier = this.calculateStabMultiplier(source, move, ignoreSourceAbility, simulated);
 
     /** Halves damage if the attacker is using a physical attack while burned */
-    const burnMultiplier = new NumberHolder(1);
+    let burnMultiplier = 1;
     if (
       isPhysical &&
       source.status &&
-      source.status.effect === StatusEffect.BURN
+      source.status.effect === StatusEffect.BURN &&
+      !move.hasAttr(BypassBurnDamageReductionAttr)
     ) {
-      if (!move.hasAttr(BypassBurnDamageReductionAttr)) {
-        const burnDamageReductionCancelled = new BooleanHolder(false);
-        if (!ignoreSourceAbility) {
-          applyAbAttrs(
-            BypassBurnDamageReductionAbAttr,
-            source,
-            burnDamageReductionCancelled,
-            simulated,
-          );
-        }
-        if (!burnDamageReductionCancelled.value) {
-          burnMultiplier.value = 0.5;
-        }
+      const burnDamageReductionCancelled = new BooleanHolder(false);
+      if (!ignoreSourceAbility) {
+        applyAbAttrs(
+          BypassBurnDamageReductionAbAttr,
+          source,
+          burnDamageReductionCancelled,
+          simulated,
+        );
+      }
+      if (!burnDamageReductionCancelled.value) {
+        burnMultiplier = 0.5;
       }
     }
 
@@ -4447,9 +4467,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
         glaiveRushMultiplier.value *
         criticalMultiplier.value *
         randomMultiplier *
-        stabMultiplier.value *
+        stabMultiplier *
         typeMultiplier *
-        burnMultiplier.value *
+        burnMultiplier *
         screenMultiplier.value *
         hitsTagMultiplier.value *
         mistyTerrainMultiplier,

--- a/test/moves/struggle.test.ts
+++ b/test/moves/struggle.test.ts
@@ -1,0 +1,65 @@
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Moves - Struggle", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([Moves.SPLASH])
+      .ability(Abilities.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH);
+  });
+
+  it("should not have its power boosted by adaptability or stab", async () => {
+    game.override.moveset([Moves.STRUGGLE]).ability(Abilities.ADAPTABILITY);
+    await game.classicMode.startBattle([Species.RATTATA]);
+
+    const enemy = game.scene.getEnemyPokemon()!;
+    game.move.select(Moves.STRUGGLE);
+
+    const stabSpy = vi.spyOn(enemy, "calculateStabMultiplier");
+
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(stabSpy).toHaveReturnedWith(1);
+
+    stabSpy.mockRestore();
+  });
+
+  it("should ignore type effectiveness", async () => {
+    game.override.moveset([Moves.STRUGGLE]);
+    await game.classicMode.startBattle([Species.GASTLY]);
+
+    const enemy = game.scene.getEnemyPokemon()!;
+    game.move.select(Moves.STRUGGLE);
+
+    const moveEffectivenessSpy = vi.spyOn(enemy, "getMoveEffectiveness");
+
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(moveEffectivenessSpy).toHaveReturnedWith(1);
+
+    moveEffectivenessSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?
Struggle will no longer be impacted by stab.

## Why am I making these changes?
Fixes #5490

## What are the changes from a developer perspective?
Did some minor cleanup of ``pokemon.getAttackDamage`` while I was editing the file.
Extracted out the calculation of stab effectiveness into its own method that is called by `getAttackDamage`. The first thing the method does is check if the move has the typeless attribute. If it does, the method immediately returns with 1.

## Screenshots/Videos
There's not a good way of providing a screenshot for this.

## How to test the changes?
`npm run test:silent test/moves/struggle.test.ts`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~~[ ] Have I tested the changes manually?~~
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~