### PR TITLE
[Bug] Fix Biome selection RNG

### DIFF
--- a/src/phases/select-biome-phase.ts
+++ b/src/phases/select-biome-phase.ts
@@ -33,23 +33,19 @@ export class SelectBiomePhase extends BattlePhase {
     } else if (globalScene.gameMode.hasRandomBiomes) {
       setNextBiome(this.generateNextBiome());
     } else if (Array.isArray(biomeLinks[currentBiome])) {
-      let biomes: Biome[] = [];
-      globalScene.executeWithSeedOffset(() => {
-        biomes = (biomeLinks[currentBiome] as (Biome | [Biome, number])[])
-          .filter(b => !Array.isArray(b) || !randSeedInt(b[1]))
-          .map(b => (!Array.isArray(b) ? b : b[0]));
-      }, globalScene.currentBattle.waveIndex);
+      const biomes: Biome[] = (biomeLinks[currentBiome] as (Biome | [Biome, number])[])
+        .filter(b => !Array.isArray(b) || !randSeedInt(b[1]))
+        .map(b => (!Array.isArray(b) ? b : b[0]));
+
       if (biomes.length > 1 && globalScene.findModifier(m => m instanceof MapModifier)) {
-        let biomeChoices: Biome[] = [];
-        globalScene.executeWithSeedOffset(() => {
-          biomeChoices = (
-            !Array.isArray(biomeLinks[currentBiome])
-              ? [biomeLinks[currentBiome] as Biome]
-              : (biomeLinks[currentBiome] as (Biome | [Biome, number])[])
-          )
-            .filter(b => !Array.isArray(b) || !randSeedInt(b[1]))
-            .map(b => (Array.isArray(b) ? b[0] : b));
-        }, globalScene.currentBattle.waveIndex);
+        const biomeChoices: Biome[] = (
+          !Array.isArray(biomeLinks[currentBiome])
+            ? [biomeLinks[currentBiome] as Biome]
+            : (biomeLinks[currentBiome] as (Biome | [Biome, number])[])
+        )
+          .filter(b => !Array.isArray(b) || !randSeedInt(b[1]))
+          .map(b => (Array.isArray(b) ? b[0] : b));
+
         const biomeSelectItems = biomeChoices.map(b => {
           const ret: OptionSelectItem = {
             label: getBiomeName(b),


### PR DESCRIPTION
## What are the changes the user will see?
The chance of reaching certain biomes should no longer erroneously become 0 depending on the number of lures the player has.

## Why am I making these changes?
Fixes #5627 

## What are the changes from a developer perspective?
Removed the `executeWithSeedOffset` calls in `SelectBiomePhase`.

## How to test the changes?
<details><summary>Code to add in Title Phase</summary>
<p>

Add this to the `TitlePhase` class (L36):
```ts
  testRNG() {
    const results = {};

    const lures = [
      () => globalScene.RemoveLures(),
      () => globalScene.InsertLure(),
      () => globalScene.InsertSuperLure(),
      () => globalScene.InsertMaxLure(),
    ]
    const startingBiome = Biome.CAVE;
    for (let i = 0; i < 10000; i++) {
      globalScene.setSeed(`${i}averyrandomseed:)`);
      // console.log("Seed:", globalScene.seed)
      globalScene.resetSeed();
      globalScene.newArena(startingBiome);
      globalScene.newBattle(10);
      for (let j = 0; j < 4; j++) {
        globalScene.resetSeed();
        const fun = lures[j];
        fun();
        // console.log("Lures:", globalScene.modifiers.length)
        const doubleChance = globalScene.getDoubleBattleChance(11, globalScene.getPlayerField());
        // console.log("Double Chance:", doubleChance);
        randSeedInt(doubleChance);
        const biomePhase = new SelectBiomePhase();
        biomePhase.start();
        if (!results[Biome[nextChosenBiome]]) {
          results[Biome[nextChosenBiome]] = {};
        }
        if (!results[Biome[nextChosenBiome]][`lure ${globalScene.modifiers.length}`]) {
          results[Biome[nextChosenBiome]][`lure ${globalScene.modifiers.length}`] = 0;
        }
        results[Biome[nextChosenBiome]][`lure ${globalScene.modifiers.length}`]++
      }
      globalScene.currentBattle.waveIndex = 0;
    }

    console.log(Biome[startingBiome], results);
  }

  start(): void {
    super.start();

    this.testRNG();
```

</p>
</details> 
<details><summary>Code to add in BattleScene</summary>
<p>

Add this to the `BattleScene` class below the constructor (L405):
```ts
InsertLure() {
  const lure = modifierTypes
    .LURE()
    .withIdFromFunc(modifierTypes.LURE)
    .newModifier() as DoubleBattleChanceBoosterModifier;
  this.addModifier(lure, true, false, false, true);
}

InsertSuperLure() {
  const super_lure = modifierTypes
    .SUPER_LURE()
    .withIdFromFunc(modifierTypes.SUPER_LURE)
    .newModifier() as DoubleBattleChanceBoosterModifier;
  this.addModifier(super_lure, true, false, false, true);
}

InsertMaxLure() {
  const max_lure = modifierTypes
    .MAX_LURE()
    .withIdFromFunc(modifierTypes.MAX_LURE)
    .newModifier() as DoubleBattleChanceBoosterModifier;
  this.addModifier(max_lure, true, false, false, true);
}

RemoveLures() {
  const mods = this.modifiers.filter(m => m instanceof DoubleBattleChanceBoosterModifier);
  mods.forEach(m => {
    this.removeModifier(m);
  });
}
```

</p>
</details> 
<details><summary>Code to add in Select Biome Phase</summary>
<p>

Add this above the `SelectBiomePhase` class definition (L11):
```ts
export let nextChosenBiome: Biome = Biome.TOWN;
```

Add `nextChosenBiome = nextBiome` to the `setNextBiome()` function, like this (L18-19):
```ts
    const setNextBiome = (nextBiome: Biome) => {
      nextChosenBiome = nextBiome;
      if (globalScene.currentBattle.waveIndex % 10 === 1) {
```

</p>
</details> 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?