### PR TITLE
[Biome] Add and apply `lint/style/noNamespaceImport`

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -65,7 +65,8 @@
         "useDefaultParameterLast": "off", // TODO: Fix spots in the codebase where this flag would be triggered, and then enable
         "useSingleVarDeclarator": "off",
         "useNodejsImportProtocol": "off",
-        "useTemplate": "off" // string concatenation is faster: https://stackoverflow.com/questions/29055518/are-es6-template-literals-faster-than-string-concatenation
+        "useTemplate": "off", // string concatenation is faster: https://stackoverflow.com/questions/29055518/are-es6-template-literals-faster-than-string-concatenation
+        "noNamespaceImport": "error"
       },
       "suspicious": {
         "noDoubleEquals": "error",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -100,6 +100,9 @@
         "rules": {
           "performance": {
             "noDelete": "off"
+          },
+          "style": {
+            "noNamespaceImport": "off"
           }
         }
       }

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,11 +1,11 @@
 import { pokerogueApi } from "#app/plugins/api/pokerogue-api";
 import type { UserInfo } from "#app/@types/UserInfo";
-import { bypassLogin } from "./battle-scene";
-import * as Utils from "./utils";
+import { bypassLogin } from "#app/battle-scene";
+import { randomString } from "#app/utils";
 
 export let loggedInUser: UserInfo | null = null;
 // This is a random string that is used to identify the client session - unique per session (tab or window) so that the game will only save on the one that the server is expecting
-export const clientSessionId = Utils.randomString(32);
+export const clientSessionId = randomString(32);
 
 export function initLoggedInUser(): void {
   loggedInUser = {

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -5,9 +5,20 @@ import { EnemyPokemon, PlayerPokemon } from "#app/field/pokemon";
 import type { PokemonSpeciesFilter } from "#app/data/pokemon-species";
 import type PokemonSpecies from "#app/data/pokemon-species";
 import { allSpecies, getPokemonSpecies } from "#app/data/pokemon-species";
-import type { Constructor } from "#app/utils";
-import { isNullOrUndefined, randSeedInt } from "#app/utils";
-import * as Utils from "#app/utils";
+import {
+  fixedInt,
+  deepMergeObjects,
+  getIvsFromId,
+  randSeedInt,
+  getEnumValues,
+  randomString,
+  NumberHolder,
+  shiftCharCodes,
+  formatMoney,
+  isNullOrUndefined,
+  BooleanHolder,
+  type Constructor,
+} from "#app/utils";
 import type { Modifier, ModifierPredicate, TurnHeldItemTransferModifier } from "./modifier/modifier";
 import {
   ConsumableModifier,
@@ -733,7 +744,7 @@ export default class BattleScene extends SceneBase {
     }
 
     this.playTimeTimer = this.time.addEvent({
-      delay: Utils.fixedInt(1000),
+      delay: fixedInt(1000),
       repeat: -1,
       callback: () => {
         if (this.gameData) {
@@ -783,7 +794,7 @@ export default class BattleScene extends SceneBase {
       return;
     }
     const expVariantData = await this.cachedFetch("./images/pokemon/variant/_exp_masterlist.json").then(r => r.json());
-    Utils.deepMergeObjects(variantData, expVariantData);
+    deepMergeObjects(variantData, expVariantData);
   }
 
   cachedFetch(url: string, init?: RequestInit): Promise<Response> {
@@ -988,7 +999,7 @@ export default class BattleScene extends SceneBase {
     }
 
     if (boss && !dataSource) {
-      const secondaryIvs = Utils.getIvsFromId(Utils.randSeedInt(4294967296));
+      const secondaryIvs = getIvsFromId(randSeedInt(4294967296));
 
       for (let s = 0; s < pokemon.ivs.length; s++) {
         pokemon.ivs[s] = Math.round(
@@ -1147,7 +1158,7 @@ export default class BattleScene extends SceneBase {
    * Generates a random number using the current battle's seed
    *
    * This calls {@linkcode Battle.randSeedInt}({@linkcode range}, {@linkcode min}) in `src/battle.ts`
-   * which calls {@linkcode Utils.randSeedInt randSeedInt}({@linkcode range}, {@linkcode min}) in `src/utils.ts`
+   * which calls {@linkcode randSeedInt randSeedInt}({@linkcode range}, {@linkcode min}) in `src/utils.ts`
    *
    * @param range How large of a range of random numbers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
    * @param min The minimum integer to pick, default `0`
@@ -1172,7 +1183,7 @@ export default class BattleScene extends SceneBase {
     this.lockModifierTiers = false;
 
     this.pokeballCounts = Object.fromEntries(
-      Utils.getEnumValues(PokeballType)
+      getEnumValues(PokeballType)
         .filter(p => p <= PokeballType.MASTER_BALL)
         .map(t => [t, 0]),
     );
@@ -1204,7 +1215,7 @@ export default class BattleScene extends SceneBase {
 
     // Reset RNG after end of game or save & quit.
     // This needs to happen after clearing this.currentBattle or the seed will be affected by the last wave played
-    this.setSeed(Overrides.SEED_OVERRIDE || Utils.randomString(24));
+    this.setSeed(Overrides.SEED_OVERRIDE || randomString(24));
     console.log("Seed:", this.seed);
     this.resetSeed();
 
@@ -1245,7 +1256,7 @@ export default class BattleScene extends SceneBase {
         ...allSpecies,
         ...allMoves,
         ...allAbilities,
-        ...Utils.getEnumValues(ModifierPoolType)
+        ...getEnumValues(ModifierPoolType)
           .map(mpt => getModifierPoolForType(mpt))
           .flatMap(mp =>
             Object.values(mp)
@@ -1285,7 +1296,7 @@ export default class BattleScene extends SceneBase {
   }
 
   getDoubleBattleChance(newWaveIndex: number, playerField: PlayerPokemon[]) {
-    const doubleChance = new Utils.NumberHolder(newWaveIndex % 10 === 0 ? 32 : 8);
+    const doubleChance = new NumberHolder(newWaveIndex % 10 === 0 ? 32 : 8);
     this.applyModifiers(DoubleBattleChanceBoosterModifier, true, doubleChance);
     for (const p of playerField) {
       applyAbAttrs(DoubleBattleChanceAbAttr, p, null, false, doubleChance);
@@ -1342,7 +1353,7 @@ export default class BattleScene extends SceneBase {
         if (trainerConfigs[trainerType].doubleOnly) {
           doubleTrainer = true;
         } else if (trainerConfigs[trainerType].hasDouble) {
-          doubleTrainer = !Utils.randSeedInt(this.getDoubleBattleChance(newWaveIndex, playerField));
+          doubleTrainer = !randSeedInt(this.getDoubleBattleChance(newWaveIndex, playerField));
           // Add a check that special trainers can't be double except for tate and liza - they should use the normal double chance
           if (
             trainerConfigs[trainerType].trainerTypeDouble &&
@@ -1353,7 +1364,7 @@ export default class BattleScene extends SceneBase {
         }
         const variant = doubleTrainer
           ? TrainerVariant.DOUBLE
-          : Utils.randSeedInt(2)
+          : randSeedInt(2)
             ? TrainerVariant.FEMALE
             : TrainerVariant.DEFAULT;
         newTrainer = trainerData !== undefined ? trainerData.toTrainer() : new Trainer(trainerType, variant);
@@ -1371,7 +1382,7 @@ export default class BattleScene extends SceneBase {
 
     if (double === undefined && newWaveIndex > 1) {
       if (newBattleType === BattleType.WILD && !this.gameMode.isWaveFinal(newWaveIndex)) {
-        newDouble = !Utils.randSeedInt(this.getDoubleBattleChance(newWaveIndex, playerField));
+        newDouble = !randSeedInt(this.getDoubleBattleChance(newWaveIndex, playerField));
       } else if (newBattleType === BattleType.TRAINER) {
         newDouble = newTrainer?.variant === TrainerVariant.DOUBLE;
       }
@@ -1559,7 +1570,7 @@ export default class BattleScene extends SceneBase {
         scale: scale,
         x: (defaultWidth - scaledWidth) / 2,
         y: defaultHeight - scaledHeight,
-        duration: !instant ? Utils.fixedInt(Math.abs(this.field.scale - scale) * 200) : 0,
+        duration: !instant ? fixedInt(Math.abs(this.field.scale - scale) * 200) : 0,
         ease: "Sine.easeInOut",
         onComplete: () => resolve(),
       });
@@ -1656,12 +1667,12 @@ export default class BattleScene extends SceneBase {
       case Species.SQUAWKABILLY:
       case Species.TATSUGIRI:
       case Species.PALDEA_TAUROS:
-        return Utils.randSeedInt(species.forms.length);
+        return randSeedInt(species.forms.length);
       case Species.PIKACHU:
         if (this.currentBattle?.battleType === BattleType.TRAINER && this.currentBattle?.waveIndex < 30) {
           return 0; // Ban Cosplay and Partner Pika from Trainers before wave 30
         }
-        return Utils.randSeedInt(8);
+        return randSeedInt(8);
       case Species.EEVEE:
         if (
           this.currentBattle?.battleType === BattleType.TRAINER &&
@@ -1670,22 +1681,22 @@ export default class BattleScene extends SceneBase {
         ) {
           return 0; // No Partner Eevee for Wave 12 Preschoolers
         }
-        return Utils.randSeedInt(2);
+        return randSeedInt(2);
       case Species.FROAKIE:
       case Species.FROGADIER:
       case Species.GRENINJA:
         if (this.currentBattle?.battleType === BattleType.TRAINER && !isEggPhase) {
           return 0; // Don't give trainers Battle Bond Greninja, Froakie or Frogadier
         }
-        return Utils.randSeedInt(2);
+        return randSeedInt(2);
       case Species.URSHIFU:
-        return Utils.randSeedInt(2);
+        return randSeedInt(2);
       case Species.ZYGARDE:
-        return Utils.randSeedInt(4);
+        return randSeedInt(4);
       case Species.MINIOR:
-        return Utils.randSeedInt(7);
+        return randSeedInt(7);
       case Species.ALCREMIE:
-        return Utils.randSeedInt(9);
+        return randSeedInt(9);
       case Species.MEOWSTIC:
       case Species.INDEEDEE:
       case Species.BASCULEGION:
@@ -1716,7 +1727,7 @@ export default class BattleScene extends SceneBase {
         if (this.gameMode.hasMysteryEncounters && !isEggPhase) {
           return 1; // Wandering form
         }
-        return Utils.randSeedInt(species.forms.length);
+        return randSeedInt(species.forms.length);
     }
 
     if (ignoreArena) {
@@ -1725,7 +1736,7 @@ export default class BattleScene extends SceneBase {
         case Species.WORMADAM:
         case Species.ROTOM:
         case Species.LYCANROC:
-          return Utils.randSeedInt(species.forms.length);
+          return randSeedInt(species.forms.length);
       }
       return 0;
     }
@@ -1737,7 +1748,7 @@ export default class BattleScene extends SceneBase {
     let ret = false;
     this.executeWithSeedOffset(
       () => {
-        ret = !Utils.randSeedInt(2);
+        ret = !randSeedInt(2);
       },
       0,
       this.seed.toString(),
@@ -1749,7 +1760,7 @@ export default class BattleScene extends SceneBase {
     let ret = 0;
     this.executeWithSeedOffset(
       () => {
-        ret = Utils.randSeedInt(8) * 5;
+        ret = randSeedInt(8) * 5;
       },
       0,
       this.seed.toString(),
@@ -1778,7 +1789,7 @@ export default class BattleScene extends SceneBase {
         isBoss =
           waveIndex % 10 === 0 ||
           (this.gameMode.hasRandomBosses &&
-            Utils.randSeedInt(100) < Math.min(Math.max(Math.ceil((waveIndex - 250) / 50), 0) * 2, 30));
+            randSeedInt(100) < Math.min(Math.max(Math.ceil((waveIndex - 250) / 50), 0) * 2, 30));
       }, waveIndex << 2);
     }
     if (!isBoss) {
@@ -1805,7 +1816,7 @@ export default class BattleScene extends SceneBase {
     const infectedIndexes: number[] = [];
     const spread = (index: number, spreadTo: number) => {
       const partyMember = party[index + spreadTo];
-      if (!partyMember.pokerus && !Utils.randSeedInt(10)) {
+      if (!partyMember.pokerus && !randSeedInt(10)) {
         partyMember.pokerus = true;
         infectedIndexes.push(index + spreadTo);
       }
@@ -1831,7 +1842,7 @@ export default class BattleScene extends SceneBase {
 
   resetSeed(waveIndex?: number): void {
     const wave = waveIndex || this.currentBattle?.waveIndex || 0;
-    this.waveSeed = Utils.shiftCharCodes(this.seed, wave);
+    this.waveSeed = shiftCharCodes(this.seed, wave);
     Phaser.Math.RND.sow([this.waveSeed]);
     console.log("Wave Seed:", this.waveSeed, wave);
     this.rngCounter = 0;
@@ -1850,7 +1861,7 @@ export default class BattleScene extends SceneBase {
     const tempRngOffset = this.rngOffset;
     const tempRngSeedOverride = this.rngSeedOverride;
     const state = Phaser.Math.RND.state();
-    Phaser.Math.RND.sow([Utils.shiftCharCodes(seedOverride || this.seed, offset)]);
+    Phaser.Math.RND.sow([shiftCharCodes(seedOverride || this.seed, offset)]);
     this.rngCounter = 0;
     this.rngOffset = offset;
     this.rngSeedOverride = seedOverride || "";
@@ -1995,7 +2006,7 @@ export default class BattleScene extends SceneBase {
     if (this.money === undefined) {
       return;
     }
-    const formattedMoney = Utils.formatMoney(this.moneyFormat, this.money);
+    const formattedMoney = formatMoney(this.moneyFormat, this.money);
     this.moneyText.setText(i18next.t("battleScene:moneyOwned", { formattedMoney }));
     this.fieldUI.moveAbove(this.moneyText, this.luckText);
     if (forceVisible) {
@@ -2152,12 +2163,12 @@ export default class BattleScene extends SceneBase {
           ),
         ]
       : allSpecies.filter(s => s.isCatchable());
-    return filteredSpecies[Utils.randSeedInt(filteredSpecies.length)];
+    return filteredSpecies[randSeedInt(filteredSpecies.length)];
   }
 
   generateRandomBiome(waveIndex: number): Biome {
     const relWave = waveIndex % 250;
-    const biomes = Utils.getEnumValues(Biome).filter(b => b !== Biome.TOWN && b !== Biome.END);
+    const biomes = getEnumValues(Biome).filter(b => b !== Biome.TOWN && b !== Biome.END);
     const maxDepth = biomeDepths[Biome.END][0] - 2;
     const depthWeights = new Array(maxDepth + 1)
       .fill(null)
@@ -2169,7 +2180,7 @@ export default class BattleScene extends SceneBase {
       biomeThresholds.push(totalWeight);
     }
 
-    const randInt = Utils.randSeedInt(totalWeight);
+    const randInt = randSeedInt(totalWeight);
 
     for (let i = 0; i < biomes.length; i++) {
       if (randInt < biomeThresholds[i]) {
@@ -2177,7 +2188,7 @@ export default class BattleScene extends SceneBase {
       }
     }
 
-    return biomes[Utils.randSeedInt(biomes.length)];
+    return biomes[randSeedInt(biomes.length)];
   }
 
   isBgmPlaying(): boolean {
@@ -2362,7 +2373,7 @@ export default class BattleScene extends SceneBase {
       this.bgmResumeTimer.destroy();
     }
     if (resumeBgm) {
-      this.bgmResumeTimer = this.time.delayedCall(pauseDuration || Utils.fixedInt(sound.totalDuration * 1000), () => {
+      this.bgmResumeTimer = this.time.delayedCall(pauseDuration || fixedInt(sound.totalDuration * 1000), () => {
         this.resumeBgm();
         this.bgmResumeTimer = null;
       });
@@ -2955,7 +2966,7 @@ export default class BattleScene extends SceneBase {
           const args: unknown[] = [];
           if (modifier instanceof PokemonHpRestoreModifier) {
             if (!(modifier as PokemonHpRestoreModifier).fainted) {
-              const hpRestoreMultiplier = new Utils.NumberHolder(1);
+              const hpRestoreMultiplier = new NumberHolder(1);
               this.applyModifiers(HealingBoosterModifier, true, hpRestoreMultiplier);
               args.push(hpRestoreMultiplier.value);
             } else {
@@ -2963,7 +2974,7 @@ export default class BattleScene extends SceneBase {
             }
           } else if (modifier instanceof FusePokemonModifier) {
             args.push(this.getPokemonById(modifier.fusePokemonId) as PlayerPokemon);
-          } else if (modifier instanceof RememberMoveModifier && !Utils.isNullOrUndefined(cost)) {
+          } else if (modifier instanceof RememberMoveModifier && !isNullOrUndefined(cost)) {
             args.push(cost);
           }
 
@@ -3032,7 +3043,7 @@ export default class BattleScene extends SceneBase {
     itemLost = true,
   ): boolean {
     const source = itemModifier.pokemonId ? itemModifier.getPokemon() : null;
-    const cancelled = new Utils.BooleanHolder(false);
+    const cancelled = new BooleanHolder(false);
 
     if (source && source.isPlayer() !== target.isPlayer()) {
       applyAbAttrs(BlockItemTheftAbAttr, source, cancelled);
@@ -3101,7 +3112,7 @@ export default class BattleScene extends SceneBase {
   canTransferHeldItemModifier(itemModifier: PokemonHeldItemModifier, target: Pokemon, transferQuantity = 1): boolean {
     const mod = itemModifier.clone() as PokemonHeldItemModifier;
     const source = mod.pokemonId ? mod.getPokemon() : null;
-    const cancelled = new Utils.BooleanHolder(false);
+    const cancelled = new BooleanHolder(false);
 
     if (source && source.isPlayer() !== target.isPlayer()) {
       applyAbAttrs(BlockItemTheftAbAttr, source, cancelled);
@@ -3195,7 +3206,7 @@ export default class BattleScene extends SceneBase {
           }
           let count = 0;
           for (let c = 0; c < chances; c++) {
-            if (!Utils.randSeedInt(this.gameMode.getEnemyModifierChance(isBoss))) {
+            if (!randSeedInt(this.gameMode.getEnemyModifierChance(isBoss))) {
               count++;
             }
           }
@@ -3371,7 +3382,7 @@ export default class BattleScene extends SceneBase {
           if (mods.length < 1) {
             return mods;
           }
-          const rand = Utils.randSeedInt(mods.length);
+          const rand = randSeedInt(mods.length);
           return [mods[rand], ...shuffleModifiers(mods.filter((_, i) => i !== rand))];
         };
         modifiers = shuffleModifiers(modifiers);
@@ -3597,7 +3608,7 @@ export default class BattleScene extends SceneBase {
    */
   initFinalBossPhaseTwo(pokemon: Pokemon): void {
     if (pokemon instanceof EnemyPokemon && pokemon.isBoss() && !pokemon.formIndex && pokemon.bossSegmentIndex < 1) {
-      this.fadeOutBgm(Utils.fixedInt(2000), false);
+      this.fadeOutBgm(fixedInt(2000), false);
       this.ui.showDialogue(
         battleSpecDialogue[BattleSpec.FINAL_BOSS].firstStageWin,
         pokemon.species.name,
@@ -3700,7 +3711,7 @@ export default class BattleScene extends SceneBase {
         if (Overrides.XP_MULTIPLIER_OVERRIDE !== null) {
           expMultiplier = Overrides.XP_MULTIPLIER_OVERRIDE;
         }
-        const pokemonExp = new Utils.NumberHolder(expValue * expMultiplier);
+        const pokemonExp = new NumberHolder(expValue * expMultiplier);
         this.applyModifiers(PokemonExpBoosterModifier, true, partyMember, pokemonExp);
         partyMemberExp.push(Math.floor(pokemonExp.value));
       }
@@ -3849,7 +3860,7 @@ export default class BattleScene extends SceneBase {
       while (i < this.mysteryEncounterSaveData.queuedEncounters.length && !!encounter) {
         const candidate = this.mysteryEncounterSaveData.queuedEncounters[i];
         const forcedChance = candidate.spawnPercent;
-        if (Utils.randSeedInt(100) < forcedChance) {
+        if (randSeedInt(100) < forcedChance) {
           encounter = allMysteryEncounters[candidate.type];
         }
 
@@ -3882,7 +3893,7 @@ export default class BattleScene extends SceneBase {
     }
 
     const totalWeight = tierWeights.reduce((a, b) => a + b);
-    const tierValue = Utils.randSeedInt(totalWeight);
+    const tierValue = randSeedInt(totalWeight);
     const commonThreshold = totalWeight - tierWeights[0];
     const greatThreshold = totalWeight - tierWeights[0] - tierWeights[1];
     const ultraThreshold = totalWeight - tierWeights[0] - tierWeights[1] - tierWeights[2];
@@ -3974,7 +3985,7 @@ export default class BattleScene extends SceneBase {
       console.log("No Mystery Encounters found, falling back to Mysterious Challengers.");
       return allMysteryEncounters[MysteryEncounterType.MYSTERIOUS_CHALLENGERS];
     }
-    encounter = availableEncounters[Utils.randSeedInt(availableEncounters.length)];
+    encounter = availableEncounters[randSeedInt(availableEncounters.length)];
     // New encounter object to not dirty flags
     encounter = new MysteryEncounter(encounter);
     encounter.populateDialogueTokensFromRequirements();

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1,6 +1,14 @@
 import { globalScene } from "#app/global-scene";
 import type { Command } from "./ui/command-ui-handler";
-import * as Utils from "./utils";
+import {
+  randomString,
+  getEnumValues,
+  NumberHolder,
+  randSeedInt,
+  shiftCharCodes,
+  randSeedItem,
+  randInt,
+} from "#app/utils";
 import Trainer, { TrainerVariant } from "./field/trainer";
 import type { GameMode } from "./game-mode";
 import { MoneyMultiplierModifier, PokemonHeldItemModifier } from "./modifier/modifier";
@@ -99,7 +107,7 @@ export default class Battle {
   public postBattleLoot: PokemonHeldItemModifier[] = [];
   public escapeAttempts = 0;
   public lastMove: Moves;
-  public battleSeed: string = Utils.randomString(16, true);
+  public battleSeed: string = randomString(16, true);
   private battleSeedState: string | null = null;
   public moneyScattered = 0;
   /** Primarily for double battles, keeps track of last enemy and player pokemon that triggered its ability or used a move */
@@ -181,8 +189,8 @@ export default class Battle {
 
   incrementTurn(): void {
     this.turn++;
-    this.turnCommands = Object.fromEntries(Utils.getEnumValues(BattlerIndex).map(bt => [bt, null]));
-    this.preTurnCommands = Object.fromEntries(Utils.getEnumValues(BattlerIndex).map(bt => [bt, null]));
+    this.turnCommands = Object.fromEntries(getEnumValues(BattlerIndex).map(bt => [bt, null]));
+    this.preTurnCommands = Object.fromEntries(getEnumValues(BattlerIndex).map(bt => [bt, null]));
     this.battleSeedState = null;
   }
 
@@ -211,7 +219,7 @@ export default class Battle {
   }
 
   pickUpScatteredMoney(): void {
-    const moneyAmount = new Utils.NumberHolder(globalScene.currentBattle.moneyScattered);
+    const moneyAmount = new NumberHolder(globalScene.currentBattle.moneyScattered);
     globalScene.applyModifiers(MoneyMultiplierModifier, true, moneyAmount);
 
     if (globalScene.arena.getTag(ArenaTagType.HAPPY_HOUR)) {
@@ -448,7 +456,7 @@ export default class Battle {
   }
 
   /**
-   * Generates a random number using the current battle's seed. Calls {@linkcode Utils.randSeedInt}
+   * Generates a random number using the current battle's seed. Calls {@linkcode randSeedInt}
    * @param range How large of a range of random numbers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
    * @param min The minimum integer to pick, default `0`
    * @returns A random integer between {@linkcode min} and ({@linkcode min} + {@linkcode range} - 1)
@@ -463,12 +471,12 @@ export default class Battle {
     if (this.battleSeedState) {
       Phaser.Math.RND.state(this.battleSeedState);
     } else {
-      Phaser.Math.RND.sow([Utils.shiftCharCodes(this.battleSeed, this.turn << 6)]);
+      Phaser.Math.RND.sow([shiftCharCodes(this.battleSeed, this.turn << 6)]);
       console.log("Battle Seed:", this.battleSeed);
     }
     globalScene.rngCounter = this.rngCounter++;
     globalScene.rngSeedOverride = this.battleSeed;
-    const ret = Utils.randSeedInt(range, min);
+    const ret = randSeedInt(range, min);
     this.battleSeedState = Phaser.Math.RND.state();
     Phaser.Math.RND.state(state);
     globalScene.rngCounter = tempRngCounter;
@@ -554,19 +562,19 @@ export function getRandomTrainerFunc(
   seedOffset = 0,
 ): GetTrainerFunc {
   return () => {
-    const rand = Utils.randSeedInt(trainerPool.length);
+    const rand = randSeedInt(trainerPool.length);
     const trainerTypes: TrainerType[] = [];
 
     globalScene.executeWithSeedOffset(() => {
       for (const trainerPoolEntry of trainerPool) {
-        const trainerType = Array.isArray(trainerPoolEntry) ? Utils.randSeedItem(trainerPoolEntry) : trainerPoolEntry;
+        const trainerType = Array.isArray(trainerPoolEntry) ? randSeedItem(trainerPoolEntry) : trainerPoolEntry;
         trainerTypes.push(trainerType);
       }
     }, seedOffset);
 
     let trainerGender = TrainerVariant.DEFAULT;
     if (randomGender) {
-      trainerGender = Utils.randInt(2) === 0 ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT;
+      trainerGender = randInt(2) === 0 ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT;
     }
 
     /* 1/3 chance for evil team grunts to be double battles */
@@ -585,7 +593,7 @@ export function getRandomTrainerFunc(
     const isEvilTeamGrunt = evilTeamGrunts.includes(trainerTypes[rand]);
 
     if (trainerConfigs[trainerTypes[rand]].hasDouble && isEvilTeamGrunt) {
-      return new Trainer(trainerTypes[rand], Utils.randInt(3) === 0 ? TrainerVariant.DOUBLE : trainerGender);
+      return new Trainer(trainerTypes[rand], randInt(3) === 0 ? TrainerVariant.DOUBLE : trainerGender);
     }
 
     return new Trainer(trainerTypes[rand], trainerGender);
@@ -608,7 +616,7 @@ export const classicFixedBattles: FixedBattleConfigs = {
   [ClassicFixedBossWaves.TOWN_YOUNGSTER]: new FixedBattleConfig()
     .setBattleType(BattleType.TRAINER)
     .setGetTrainerFunc(
-      () => new Trainer(TrainerType.YOUNGSTER, Utils.randSeedInt(2) ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT),
+      () => new Trainer(TrainerType.YOUNGSTER, randSeedInt(2) ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT),
     ),
   [ClassicFixedBossWaves.RIVAL_1]: new FixedBattleConfig()
     .setBattleType(BattleType.TRAINER)

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -2,8 +2,7 @@ import type { EnemyPokemon, PokemonMove } from "../field/pokemon";
 import type Pokemon from "../field/pokemon";
 import { HitResult, MoveResult, PlayerPokemon } from "../field/pokemon";
 import { PokemonType } from "#enums/pokemon-type";
-import type { Constructor } from "#app/utils";
-import * as Utils from "../utils";
+import { BooleanHolder, NumberHolder, toDmgValue, isNullOrUndefined, randSeedItem, randSeedInt, type Constructor } from "#app/utils";
 import { getPokemonNameWithAffix } from "../messages";
 import type { Weather } from "#app/data/weather";
 import type { BattlerTag } from "./battler-tags";
@@ -196,7 +195,7 @@ export abstract class AbAttr {
    * @param args - Extra args passed to the function. Handled by child classes.
    * @see {@linkcode canApply}
    */
-  apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder | null, args: any[]): void {}
+  apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder | null, args: any[]): void {}
 
   getTriggerMessage(_pokemon: Pokemon, _abilityName: string, ..._args: any[]): string | null {
     return null;
@@ -230,7 +229,7 @@ export class BlockRecoilDamageAttr extends AbAttr {
     super(false);
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
     cancelled.value = true;
   }
 
@@ -251,10 +250,10 @@ export class DoubleBattleChanceAbAttr extends AbAttr {
 
   /**
    * Increases the chance of a double battle occurring
-   * @param args [0] {@linkcode Utils.NumberHolder} for double battle chance
+   * @param args [0] {@linkcode NumberHolder} for double battle chance
    */
-  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _cancelled: Utils.BooleanHolder, args: any[]): void {
-    const doubleBattleChance = args[0] as Utils.NumberHolder;
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _cancelled: BooleanHolder, args: any[]): void {
+    const doubleBattleChance = args[0] as NumberHolder;
     // This is divided because the chance is generated as a number from 0 to doubleBattleChance.value using Utils.randSeedInt
     // A double battle will initiate if the generated number is 0
     doubleBattleChance.value = doubleBattleChance.value / 4;
@@ -299,7 +298,7 @@ export class PostTeraFormChangeStatChangeAbAttr extends AbAttr {
     this.stages = stages;
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder | null, args: any[]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder | null, args: any[]): void {
     const statStageChangePhases: StatStageChangePhase[] = [];
 
     if (!simulated) {
@@ -331,7 +330,7 @@ export class ClearWeatherAbAttr extends AbAttr {
     return globalScene.arena.canSetWeather(WeatherType.NONE);
   }
 
-  public override apply(pokemon: Pokemon, passive: boolean, simulated:boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
+  public override apply(pokemon: Pokemon, passive: boolean, simulated:boolean, cancelled: BooleanHolder, args: any[]): void {
     if (!simulated) {
       globalScene.arena.trySetWeather(WeatherType.NONE, pokemon);
     }
@@ -357,7 +356,7 @@ export class ClearTerrainAbAttr extends AbAttr {
     return globalScene.arena.canSetTerrain(TerrainType.NONE);
   }
 
-  public override apply(pokemon: Pokemon, passive: boolean, simulated:boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
+  public override apply(pokemon: Pokemon, passive: boolean, simulated:boolean, cancelled: BooleanHolder, args: any[]): void {
     if (!simulated) {
       globalScene.arena.trySetTerrain(TerrainType.NONE, true, pokemon);
     }
@@ -373,7 +372,7 @@ export class PreDefendAbAttr extends AbAttr {
     simulated: boolean,
     attacker: Pokemon,
     move: Move | null,
-    cancelled: Utils.BooleanHolder | null,
+    cancelled: BooleanHolder | null,
     args: any[]): boolean {
     return true;
   }
@@ -384,19 +383,19 @@ export class PreDefendAbAttr extends AbAttr {
     simulated: boolean,
     attacker: Pokemon,
     move: Move | null,
-    cancelled: Utils.BooleanHolder | null,
+    cancelled: BooleanHolder | null,
     args: any[],
   ): void {}
 }
 
 export class PreDefendFullHpEndureAbAttr extends PreDefendAbAttr {
-  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move | null, cancelled: Utils.BooleanHolder | null, args: any[]): boolean {
+  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move | null, cancelled: BooleanHolder | null, args: any[]): boolean {
     return pokemon.isFullHp()
     && pokemon.getMaxHp() > 1 //Checks if pokemon has wonder_guard (which forces 1hp)
-    && (args[0] as Utils.NumberHolder).value >= pokemon.hp; //Damage >= hp
+    && (args[0] as NumberHolder).value >= pokemon.hp; //Damage >= hp
   }
 
-  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: any[]): void {
     if (!simulated) {
       pokemon.addTag(BattlerTagType.STURDY, 1);
     }
@@ -404,7 +403,7 @@ export class PreDefendFullHpEndureAbAttr extends PreDefendAbAttr {
 }
 
 export class BlockItemTheftAbAttr extends AbAttr {
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
     cancelled.value = true;
   }
 
@@ -422,11 +421,11 @@ export class StabBoostAbAttr extends AbAttr {
   }
 
   override canApply(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): boolean {
-    return (args[0] as Utils.NumberHolder).value > 1;
+    return (args[0] as NumberHolder).value > 1;
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
-    (args[0] as Utils.NumberHolder).value += 0.5;
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
+    (args[0] as NumberHolder).value += 0.5;
   }
 }
 
@@ -441,12 +440,12 @@ export class ReceivedMoveDamageMultiplierAbAttr extends PreDefendAbAttr {
     this.damageMultiplier = damageMultiplier;
   }
 
-  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder | null, args: any[]): boolean {
+  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder | null, args: any[]): boolean {
     return this.condition(pokemon, attacker, move);
   }
 
-  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): void {
-    (args[0] as Utils.NumberHolder).value = Utils.toDmgValue((args[0] as Utils.NumberHolder).value * this.damageMultiplier);
+  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: any[]): void {
+    (args[0] as NumberHolder).value = toDmgValue((args[0] as NumberHolder).value * this.damageMultiplier);
   }
 }
 
@@ -465,11 +464,11 @@ export class AlliedFieldDamageReductionAbAttr extends PreDefendAbAttr {
   /**
    * Handles the damage reduction
    * @param args
-   * - `[0]` {@linkcode Utils.NumberHolder} - The damage being dealt
+   * - `[0]` {@linkcode NumberHolder} - The damage being dealt
    */
-  override applyPreDefend(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _attacker: Pokemon, _move: Move, _cancelled: Utils.BooleanHolder, args: any[]): void {
-    const damage = args[0] as Utils.NumberHolder;
-    damage.value = Utils.toDmgValue(damage.value * this.damageMultiplier);
+  override applyPreDefend(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _attacker: Pokemon, _move: Move, _cancelled: BooleanHolder, args: any[]): void {
+    const damage = args[0] as NumberHolder;
+    damage.value = toDmgValue(damage.value * this.damageMultiplier);
   }
 }
 
@@ -496,7 +495,7 @@ export class TypeImmunityAbAttr extends PreDefendAbAttr {
     this.condition = condition ?? null;
   }
 
-  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder | null, args: any[]): boolean {
+  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder | null, args: any[]): boolean {
     return ![ MoveTarget.BOTH_SIDES, MoveTarget.ENEMY_SIDE, MoveTarget.USER_SIDE ].includes(move.moveTarget) && attacker !== pokemon && attacker.getMoveType(move) === this.immuneType;
   }
 
@@ -506,12 +505,12 @@ export class TypeImmunityAbAttr extends PreDefendAbAttr {
    * @param passive - Whether the ability is passive.
    * @param attacker {@linkcode Pokemon} The attacking Pokemon.
    * @param move {@linkcode Move} The attacking move.
-   * @param cancelled {@linkcode Utils.BooleanHolder} - A holder for a boolean value indicating if the move was cancelled.
-   * @param args [0] {@linkcode Utils.NumberHolder} gets set to 0 if move is immuned by an ability.
+   * @param cancelled {@linkcode BooleanHolder} - A holder for a boolean value indicating if the move was cancelled.
+   * @param args [0] {@linkcode NumberHolder} gets set to 0 if move is immuned by an ability.
    * @param args [1] - Whether the move is simulated.
    */
-  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): void {
-    (args[0] as Utils.NumberHolder).value = 0;
+  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: any[]): void {
+    (args[0] as NumberHolder).value = 0;
   }
 
   getImmuneType(): PokemonType | null {
@@ -528,7 +527,7 @@ export class AttackTypeImmunityAbAttr extends TypeImmunityAbAttr {
     super(immuneType, condition);
   }
 
-  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder | null, args: any[]): boolean {
+  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder | null, args: any[]): boolean {
     return move.category !== MoveCategory.STATUS && !move.hasAttr(NeutralDamageAgainstFlyingTypeMultiplierAttr)
             && super.canApplyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
   }
@@ -538,7 +537,7 @@ export class AttackTypeImmunityAbAttr extends TypeImmunityAbAttr {
    * Type immunity abilities that do not give additional benefits (HP recovery, stat boosts, etc) are not immune to status moves of the type
    * Example: Levitate
    */
-  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: any[]): void {
     // this is a hacky way to fix the Levitate/Thousand Arrows interaction, but it works for now...
     super.applyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
   }
@@ -549,16 +548,16 @@ export class TypeImmunityHealAbAttr extends TypeImmunityAbAttr {
     super(immuneType);
   }
 
-  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder | null, args: any[]): boolean {
+  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder | null, args: any[]): boolean {
     return super.canApplyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
   }
 
-  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: any[]): void {
     super.applyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
     if (!pokemon.isFullHp() && !simulated) {
       const abilityName = (!passive ? pokemon.getAbility() : pokemon.getPassiveAbility()).name;
       globalScene.unshiftPhase(new PokemonHealPhase(pokemon.getBattlerIndex(),
-        Utils.toDmgValue(pokemon.getMaxHp() / 4), i18next.t("abilityTriggers:typeImmunityHeal", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon), abilityName }), true));
+        toDmgValue(pokemon.getMaxHp() / 4), i18next.t("abilityTriggers:typeImmunityHeal", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon), abilityName }), true));
       cancelled.value = true; // Suppresses "No Effect" message
     }
   }
@@ -575,11 +574,11 @@ class TypeImmunityStatStageChangeAbAttr extends TypeImmunityAbAttr {
     this.stages = stages;
   }
 
-  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder | null, args: any[]): boolean {
+  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder | null, args: any[]): boolean {
     return super.canApplyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
   }
 
-  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: any[]): void {
     super.applyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
     cancelled.value = true; // Suppresses "No Effect" message
     if (!simulated) {
@@ -599,11 +598,11 @@ class TypeImmunityAddBattlerTagAbAttr extends TypeImmunityAbAttr {
     this.turnCount = turnCount;
   }
 
-  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder | null, args: any[]): boolean {
+  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder | null, args: any[]): boolean {
     return super.canApplyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
   }
 
-  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: any[]): void {
     super.applyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
     cancelled.value = true; // Suppresses "No Effect" message
     if (!simulated) {
@@ -617,16 +616,16 @@ export class NonSuperEffectiveImmunityAbAttr extends TypeImmunityAbAttr {
     super(null, condition);
   }
 
-  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder | null, args: any[]): boolean {
+  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder | null, args: any[]): boolean {
     const modifierValue = args.length > 0
-      ? (args[0] as Utils.NumberHolder).value
+      ? (args[0] as NumberHolder).value
       : pokemon.getAttackTypeEffectiveness(attacker.getMoveType(move), attacker, undefined, undefined, move);
     return move instanceof AttackMove && modifierValue < 2;
   }
 
-  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: any[]): void {
     cancelled.value = true; // Suppresses "No Effect" message
-    (args[0] as Utils.NumberHolder).value = 0;
+    (args[0] as NumberHolder).value = 0;
   }
 
   getTriggerMessage(pokemon: Pokemon, abilityName: string, ...args: any[]): string {
@@ -644,9 +643,9 @@ export class NonSuperEffectiveImmunityAbAttr extends TypeImmunityAbAttr {
  */
 export class FullHpResistTypeAbAttr extends PreDefendAbAttr {
 
-  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move | null, cancelled: Utils.BooleanHolder | null, args: any[]): boolean {
+  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move | null, cancelled: BooleanHolder | null, args: any[]): boolean {
     const typeMultiplier = args[0];
-    return (typeMultiplier && typeMultiplier instanceof Utils.NumberHolder) && !(move && move.hasAttr(FixedDamageAttr)) && pokemon.isFullHp() && typeMultiplier.value > 0.5;
+    return (typeMultiplier && typeMultiplier instanceof NumberHolder) && !(move && move.hasAttr(FixedDamageAttr)) && pokemon.isFullHp() && typeMultiplier.value > 0.5;
   }
 
   /**
@@ -665,7 +664,7 @@ export class FullHpResistTypeAbAttr extends PreDefendAbAttr {
     simulated: boolean,
     attacker: Pokemon,
     move: Move | null,
-    cancelled: Utils.BooleanHolder | null,
+    cancelled: BooleanHolder | null,
     args: any[]): void {
     const typeMultiplier = args[0];
     typeMultiplier.value = 0.5;
@@ -704,11 +703,11 @@ export class PostDefendAbAttr extends AbAttr {
 
 export class FieldPriorityMoveImmunityAbAttr extends PreDefendAbAttr {
 
-  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder | null, args: any[]): boolean {
+  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder | null, args: any[]): boolean {
     return !(move.moveTarget === MoveTarget.USER || move.moveTarget === MoveTarget.NEAR_ALLY) && move.getPriority(attacker) > 0 && !move.isMultiTarget();
   }
 
-  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: any[]): void {
     cancelled.value = true;
   }
 }
@@ -743,11 +742,11 @@ export class MoveImmunityAbAttr extends PreDefendAbAttr {
     this.immuneCondition = immuneCondition;
   }
 
-  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder | null, args: any[]): boolean {
+  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder | null, args: any[]): boolean {
     return this.immuneCondition(pokemon, attacker, move);
   }
 
-  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: any[]): void {
     cancelled.value = true;
   }
 
@@ -768,13 +767,13 @@ export class WonderSkinAbAttr extends PreDefendAbAttr {
     super(false);
   }
 
-  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder | null, args: any[]): boolean {
-    const moveAccuracy = args[0] as Utils.NumberHolder;
+  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder | null, args: any[]): boolean {
+    const moveAccuracy = args[0] as NumberHolder;
     return move.category === MoveCategory.STATUS && moveAccuracy.value >= 50;
   }
 
-  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): void {
-    const moveAccuracy = args[0] as Utils.NumberHolder;
+  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: any[]): void {
+    const moveAccuracy = args[0] as NumberHolder;
     moveAccuracy.value = 50;
   }
 }
@@ -789,11 +788,11 @@ export class MoveImmunityStatStageChangeAbAttr extends MoveImmunityAbAttr {
     this.stages = stages;
   }
 
-  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder | null, args: any[]): boolean {
+  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder | null, args: any[]): boolean {
     return !simulated && super.canApplyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
   }
 
-  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: any[]): void {
     super.applyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
     globalScene.unshiftPhase(new StatStageChangePhase(pokemon.getBattlerIndex(), true, [ this.stat ], this.stages));
   }
@@ -855,7 +854,7 @@ export class PostDefendStatStageChangeAbAttr extends PostDefendAbAttr {
 
     if (this.allOthers) {
       const ally = pokemon.getAlly();
-      const otherPokemon = !Utils.isNullOrUndefined(ally) ? pokemon.getOpponents().concat([ ally ]) : pokemon.getOpponents();
+      const otherPokemon = !isNullOrUndefined(ally) ? pokemon.getOpponents().concat([ ally ]) : pokemon.getOpponents();
       for (const other of otherPokemon) {
         globalScene.unshiftPhase(new StatStageChangePhase((other).getBattlerIndex(), false, [ this.stat ], this.stages));
       }
@@ -1090,8 +1089,8 @@ export class PostDefendContactDamageAbAttr extends PostDefendAbAttr {
   }
 
   override applyPostDefend(pokemon: Pokemon, _passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, _hitResult: HitResult, _args: any[]): void {
-    attacker.damageAndUpdate(Utils.toDmgValue(attacker.getMaxHp() * (1 / this.damageRatio)), { result: HitResult.INDIRECT });
-    attacker.turnData.damageTaken += Utils.toDmgValue(attacker.getMaxHp() * (1 / this.damageRatio));
+    attacker.damageAndUpdate(toDmgValue(attacker.getMaxHp() * (1 / this.damageRatio)), { result: HitResult.INDIRECT });
+    attacker.turnData.damageTaken += toDmgValue(attacker.getMaxHp() * (1 / this.damageRatio));
   }
 
   override getTriggerMessage(pokemon: Pokemon, abilityName: string, ..._args: any[]): string {
@@ -1291,16 +1290,16 @@ export class MoveEffectChanceMultiplierAbAttr extends AbAttr {
 
   override canApply(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): boolean {
     const exceptMoves = [ Moves.ORDER_UP, Moves.ELECTRO_SHOT ];
-    return !((args[0] as Utils.NumberHolder).value <= 0 || exceptMoves.includes((args[1] as Move).id));
+    return !((args[0] as NumberHolder).value <= 0 || exceptMoves.includes((args[1] as Move).id));
   }
 
   /**
-   * @param args [0]: {@linkcode Utils.NumberHolder} Move additional effect chance. Has to be higher than or equal to 0.
+   * @param args [0]: {@linkcode NumberHolder} Move additional effect chance. Has to be higher than or equal to 0.
    *             [1]: {@linkcode Moves } Move used by the ability user.
    */
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
-    (args[0] as Utils.NumberHolder).value *= this.chanceMultiplier;
-    (args[0] as Utils.NumberHolder).value = Math.min((args[0] as Utils.NumberHolder).value, 100);
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
+    (args[0] as NumberHolder).value *= this.chanceMultiplier;
+    (args[0] as NumberHolder).value = Math.min((args[0] as NumberHolder).value, 100);
   }
 }
 
@@ -1314,15 +1313,15 @@ export class IgnoreMoveEffectsAbAttr extends PreDefendAbAttr {
     super(showAbility);
   }
 
-  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move | null, cancelled: Utils.BooleanHolder | null, args: any[]): boolean {
-    return (args[0] as Utils.NumberHolder).value > 0;
+  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move | null, cancelled: BooleanHolder | null, args: any[]): boolean {
+    return (args[0] as NumberHolder).value > 0;
   }
 
   /**
-   * @param args [0]: {@linkcode Utils.NumberHolder} Move additional effect chance.
+   * @param args [0]: {@linkcode NumberHolder} Move additional effect chance.
    */
-  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder, args: any[]): void {
-    (args[0] as Utils.NumberHolder).value = 0;
+  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: any[]): void {
+    (args[0] as NumberHolder).value = 0;
   }
 }
 
@@ -1337,7 +1336,7 @@ export class FieldPreventExplosiveMovesAbAttr extends AbAttr {
     pokemon: Pokemon,
     passive: boolean,
     simulated: boolean,
-    cancelled: Utils.BooleanHolder,
+    cancelled: BooleanHolder,
     args: any[],
   ): void {
     cancelled.value = true;
@@ -1349,7 +1348,7 @@ export class FieldPreventExplosiveMovesAbAttr extends AbAttr {
  * If this ability cannot stack, a BooleanHolder can be used to prevent this from stacking.
  * @see {@link applyFieldStatMultiplierAbAttrs}
  * @see {@link applyFieldStat}
- * @see {@link Utils.BooleanHolder}
+ * @see {@link BooleanHolder}
  */
 export class FieldMultiplyStatAbAttr extends AbAttr {
   private stat: Stat;
@@ -1364,7 +1363,7 @@ export class FieldMultiplyStatAbAttr extends AbAttr {
     this.canStack = canStack;
   }
 
-  canApplyFieldStat(pokemon: Pokemon, passive: boolean, simulated: boolean, stat: Stat, statValue: Utils.NumberHolder, checkedPokemon: Pokemon, hasApplied: Utils.BooleanHolder, args: any[]): boolean {
+  canApplyFieldStat(pokemon: Pokemon, passive: boolean, simulated: boolean, stat: Stat, statValue: NumberHolder, checkedPokemon: Pokemon, hasApplied: BooleanHolder, args: any[]): boolean {
     return this.canStack || !hasApplied.value
       && this.stat === stat && checkedPokemon.getAbilityAttrs(FieldMultiplyStatAbAttr).every(attr => (attr as FieldMultiplyStatAbAttr).stat !== stat);
   }
@@ -1374,12 +1373,12 @@ export class FieldMultiplyStatAbAttr extends AbAttr {
    * @param pokemon {@linkcode Pokemon} the Pokemon using this ability
    * @param passive {@linkcode boolean} unused
    * @param stat {@linkcode Stat} the type of the checked stat
-   * @param statValue {@linkcode Utils.NumberHolder} the value of the checked stat
+   * @param statValue {@linkcode NumberHolder} the value of the checked stat
    * @param checkedPokemon {@linkcode Pokemon} the Pokemon this ability is targeting
-   * @param hasApplied {@linkcode Utils.BooleanHolder} whether or not another multiplier has been applied to this stat
+   * @param hasApplied {@linkcode BooleanHolder} whether or not another multiplier has been applied to this stat
    * @param args {any[]} unused
    */
-  applyFieldStat(pokemon: Pokemon, passive: boolean, simulated: boolean, stat: Stat, statValue: Utils.NumberHolder, checkedPokemon: Pokemon, hasApplied: Utils.BooleanHolder, args: any[]): void {
+  applyFieldStat(pokemon: Pokemon, passive: boolean, simulated: boolean, stat: Stat, statValue: NumberHolder, checkedPokemon: Pokemon, hasApplied: BooleanHolder, args: any[]): void {
     statValue.value *= this.multiplier;
     hasApplied.value = true;
   }
@@ -1401,10 +1400,10 @@ export class MoveTypeChangeAbAttr extends PreAttackAbAttr {
 
   // TODO: Decouple this into two attributes (type change / power boost)
   override applyPreAttack(pokemon: Pokemon, passive: boolean, simulated: boolean, defender: Pokemon, move: Move, args: any[]): void {
-    if (args[0] && args[0] instanceof Utils.NumberHolder) {
+    if (args[0] && args[0] instanceof NumberHolder) {
       args[0].value = this.newType;
     }
-    if (args[1] && args[1] instanceof Utils.NumberHolder) {
+    if (args[1] && args[1] instanceof NumberHolder) {
       args[1].value *= this.powerMultiplier;
     }
   }
@@ -1482,12 +1481,12 @@ export class AddSecondStrikeAbAttr extends PreAttackAbAttr {
    * @param defender n/a
    * @param move the {@linkcode Move} used by the ability source
    * @param args Additional arguments:
-   * - `[0]` the number of strikes this move currently has ({@linkcode Utils.NumberHolder})
-   * - `[1]` the damage multiplier for the current strike ({@linkcode Utils.NumberHolder})
+   * - `[0]` the number of strikes this move currently has ({@linkcode NumberHolder})
+   * - `[1]` the damage multiplier for the current strike ({@linkcode NumberHolder})
    */
   override applyPreAttack(pokemon: Pokemon, passive: boolean, simulated: boolean, defender: Pokemon, move: Move, args: any[]): void {
-    const hitCount = args[0] as Utils.NumberHolder;
-    const multiplier = args[1] as Utils.NumberHolder;
+    const hitCount = args[0] as NumberHolder;
+    const multiplier = args[1] as NumberHolder;
     if (hitCount?.value) {
       hitCount.value += 1;
     }
@@ -1527,8 +1526,8 @@ export class DamageBoostAbAttr extends PreAttackAbAttr {
    * @param args Utils.NumberHolder as damage
    */
   override applyPreAttack(pokemon: Pokemon, passive: boolean, simulated: boolean, defender: Pokemon, move: Move, args: any[]): void {
-    const power = args[0] as Utils.NumberHolder;
-    power.value = Utils.toDmgValue(power.value * this.damageMultiplier);
+    const power = args[0] as NumberHolder;
+    power.value = toDmgValue(power.value * this.damageMultiplier);
   }
 }
 
@@ -1547,7 +1546,7 @@ export class MovePowerBoostAbAttr extends VariableMovePowerAbAttr {
   }
 
   override applyPreAttack(pokemon: Pokemon, passive: boolean, simulated: boolean, defender: Pokemon, move: Move, args: any[]): void {
-    (args[0] as Utils.NumberHolder).value *= this.powerMultiplier;
+    (args[0] as NumberHolder).value *= this.powerMultiplier;
   }
 }
 
@@ -1590,7 +1589,7 @@ export class VariableMovePowerBoostAbAttr extends VariableMovePowerAbAttr {
 
   override applyPreAttack(pokemon: Pokemon, passive: boolean, simulated: boolean, defender: Pokemon, move: Move, args: any[]): void {
     const multiplier = this.mult(pokemon, defender, move);
-    (args[0] as Utils.NumberHolder).value *= multiplier;
+    (args[0] as NumberHolder).value *= multiplier;
   }
 }
 
@@ -1619,7 +1618,7 @@ export class FieldMovePowerBoostAbAttr extends AbAttr {
 
   applyPreAttack(pokemon: Pokemon | null, passive: boolean | null, simulated: boolean, defender: Pokemon | null, move: Move, args: any[]): void {
     if (this.condition(pokemon, defender, move)) {
-      (args[0] as Utils.NumberHolder).value *= this.powerMultiplier;
+      (args[0] as NumberHolder).value *= this.powerMultiplier;
     }
   }
 }
@@ -1682,7 +1681,7 @@ export class StatMultiplierAbAttr extends AbAttr {
     _passive: boolean,
     simulated: boolean,
     stat: BattleStat,
-    statValue: Utils.NumberHolder,
+    statValue: NumberHolder,
     args: any[]): boolean {
     const move = (args[0] as Move);
     return stat === this.stat && (!this.condition || this.condition(pokemon, null, move));
@@ -1693,7 +1692,7 @@ export class StatMultiplierAbAttr extends AbAttr {
     _passive: boolean,
     simulated: boolean,
     stat: BattleStat,
-    statValue: Utils.NumberHolder,
+    statValue: NumberHolder,
     args: any[]): void {
     statValue.value *= this.multiplier;
   }
@@ -1766,13 +1765,13 @@ export class AllyStatMultiplierAbAttr extends AbAttr {
    * @param passive - unused
    * @param _simulated - Whether the ability is being simulated (unused)
    * @param _stat - The type of the checked {@linkcode Stat} (unused)
-   * @param statValue - {@linkcode Utils.NumberHolder} containing the value of the checked stat
+   * @param statValue - {@linkcode NumberHolder} containing the value of the checked stat
    * @param _checkedPokemon - The {@linkcode Pokemon} this ability is targeting (unused)
    * @param _ignoreAbility - Whether the ability should be ignored if possible
    * @param _args - unused
    * @returns `true` if this changed the checked stat, `false` otherwise.
    */
-  applyAllyStat(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _stat: BattleStat, statValue: Utils.NumberHolder, _checkedPokemon: Pokemon, _ignoreAbility: boolean, _args: any[]) {
+  applyAllyStat(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _stat: BattleStat, statValue: NumberHolder, _checkedPokemon: Pokemon, _ignoreAbility: boolean, _args: any[]) {
     statValue.value *= this.multiplier;
   }
 
@@ -1782,13 +1781,13 @@ export class AllyStatMultiplierAbAttr extends AbAttr {
    * @param passive - unused
    * @param simulated - Whether the ability is being simulated (unused)
    * @param stat - The type of the checked {@linkcode Stat}
-   * @param statValue - {@linkcode Utils.NumberHolder} containing the value of the checked stat
+   * @param statValue - {@linkcode NumberHolder} containing the value of the checked stat
    * @param checkedPokemon - The {@linkcode Pokemon} this ability is targeting (unused)
    * @param ignoreAbility - Whether the ability should be ignored if possible
    * @param args - unused
    * @returns `true` if this can apply to the checked stat, `false` otherwise.
    */
-  canApplyAllyStat(pokemon: Pokemon, _passive: boolean, simulated: boolean, stat: BattleStat, statValue: Utils.NumberHolder, checkedPokemon: Pokemon, ignoreAbility: boolean, args: any[]): boolean {
+  canApplyAllyStat(pokemon: Pokemon, _passive: boolean, simulated: boolean, stat: BattleStat, statValue: NumberHolder, checkedPokemon: Pokemon, ignoreAbility: boolean, args: any[]): boolean {
     return stat === this.stat && !(ignoreAbility && this.ignorable);
   }
 }
@@ -2220,8 +2219,8 @@ export class IgnoreOpponentStatStagesAbAttr extends AbAttr {
    * @param _cancelled n/a
    * @param args A BooleanHolder that represents whether or not to ignore a stat's stat changes
    */
-  override apply(_pokemon: Pokemon, _passive: boolean, simulated: boolean, _cancelled: Utils.BooleanHolder, args: any[]): void {
-    (args[1] as Utils.BooleanHolder).value = true;
+  override apply(_pokemon: Pokemon, _passive: boolean, simulated: boolean, _cancelled: BooleanHolder, args: any[]): void {
+    (args[1] as BooleanHolder).value = true;
   }
 }
 
@@ -2230,7 +2229,7 @@ export class IntimidateImmunityAbAttr extends AbAttr {
     super(false);
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
     cancelled.value = true;
   }
 
@@ -2254,7 +2253,7 @@ export class PostIntimidateStatStageChangeAbAttr extends AbAttr {
     this.overwrites = !!overwrites;
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated:boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated:boolean, cancelled: BooleanHolder, args: any[]): void {
     if (!simulated) {
       globalScene.pushPhase(new StatStageChangePhase(pokemon.getBattlerIndex(), false, this.stats, this.stages));
     }
@@ -2461,7 +2460,7 @@ export class PostSummonStatStageChangeAbAttr extends PostSummonAbAttr {
       globalScene.unshiftPhase(new StatStageChangePhase(pokemon.getBattlerIndex(), true, this.stats, this.stages));
     } else {
       for (const opponent of pokemon.getOpponents()) {
-        const cancelled = new Utils.BooleanHolder(false);
+        const cancelled = new BooleanHolder(false);
         if (this.intimidate) {
           applyAbAttrs(IntimidateImmunityAbAttr, opponent, cancelled, simulated);
           applyAbAttrs(PostIntimidateStatStageChangeAbAttr, opponent, cancelled, simulated);
@@ -2495,9 +2494,9 @@ export class PostSummonAllyHealAbAttr extends PostSummonAbAttr {
 
   override applyPostSummon(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): void {
     const target = pokemon.getAlly();
-    if (!simulated && !Utils.isNullOrUndefined(target)) {
+    if (!simulated && !isNullOrUndefined(target)) {
       globalScene.unshiftPhase(new PokemonHealPhase(target.getBattlerIndex(),
-        Utils.toDmgValue(pokemon.getMaxHp() / this.healRatio), i18next.t("abilityTriggers:postSummonAllyHeal", { pokemonNameWithAffix: getPokemonNameWithAffix(target), pokemonName: pokemon.name }), true, !this.showAnim));
+        toDmgValue(pokemon.getMaxHp() / this.healRatio), i18next.t("abilityTriggers:postSummonAllyHeal", { pokemonNameWithAffix: getPokemonNameWithAffix(target), pokemonName: pokemon.name }), true, !this.showAnim));
     }
   }
 }
@@ -2521,7 +2520,7 @@ export class PostSummonClearAllyStatStagesAbAttr extends PostSummonAbAttr {
 
   override applyPostSummon(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): void {
     const target = pokemon.getAlly();
-    if (!simulated && !Utils.isNullOrUndefined(target)) {
+    if (!simulated && !isNullOrUndefined(target)) {
       for (const s of BATTLE_STATS) {
         target.setStatStage(s, 0);
       }
@@ -2639,12 +2638,12 @@ export class PostSummonHealStatusAbAttr extends PostSummonRemoveEffectAbAttr {
 
   public override canApplyPostSummon(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): boolean {
     const status = pokemon.status?.effect;
-    return !Utils.isNullOrUndefined(status) && (this.immuneEffects.length < 1 || this.immuneEffects.includes(status))
+    return !isNullOrUndefined(status) && (this.immuneEffects.length < 1 || this.immuneEffects.includes(status))
   }
 
   public override applyPostSummon(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): void {
     const status = pokemon.status?.effect;
-    if (!Utils.isNullOrUndefined(status)) {
+    if (!isNullOrUndefined(status)) {
       this.statusHealed = status;
       pokemon.resetStatus(false);
       pokemon.updateInfo();
@@ -2692,7 +2691,7 @@ export class PostSummonCopyAbilityAbAttr extends PostSummonAbAttr {
 
     let target: Pokemon;
     if (targets.length > 1) {
-      globalScene.executeWithSeedOffset(() => target = Utils.randSeedItem(targets), globalScene.currentBattle.waveIndex);
+      globalScene.executeWithSeedOffset(() => target = randSeedItem(targets), globalScene.currentBattle.waveIndex);
     } else {
       target = targets[0];
     }
@@ -2779,7 +2778,7 @@ export class PostSummonCopyAllyStatsAbAttr extends PostSummonAbAttr {
     }
 
     const ally = pokemon.getAlly();
-    if (Utils.isNullOrUndefined(ally) || ally.getStatStages().every(s => s === 0)) {
+    if (isNullOrUndefined(ally) || ally.getStatStages().every(s => s === 0)) {
       return false;
     }
 
@@ -2788,7 +2787,7 @@ export class PostSummonCopyAllyStatsAbAttr extends PostSummonAbAttr {
 
   override applyPostSummon(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): void {
     const ally = pokemon.getAlly();
-    if (!simulated && !Utils.isNullOrUndefined(ally)) {
+    if (!simulated && !isNullOrUndefined(ally)) {
       for (const s of BATTLE_STATS) {
         pokemon.setStatStage(s, ally.getStatStage(s));
       }
@@ -2825,7 +2824,7 @@ export class PostSummonTransformAbAttr extends PostSummonAbAttr {
           target = targets[0];
           return;
         }
-        target = Utils.randSeedItem(targets);
+        target = randSeedItem(targets);
       }, globalScene.currentBattle.waveIndex);
     } else {
       target = targets[0];
@@ -2934,7 +2933,7 @@ export class CommanderAbAttr extends AbAttr {
 
     // TODO: Should this work with X + Dondozo fusions?
     const ally = pokemon.getAlly();
-    return globalScene.currentBattle?.double && !Utils.isNullOrUndefined(ally) && ally.species.speciesId === Species.DONDOZO
+    return globalScene.currentBattle?.double && !isNullOrUndefined(ally) && ally.species.speciesId === Species.DONDOZO
            && !(ally.isFainted() || ally.getTag(BattlerTagType.COMMANDED));
   }
 
@@ -2970,7 +2969,7 @@ export class PreSwitchOutResetStatusAbAttr extends PreSwitchOutAbAttr {
   }
 
   override canApplyPreSwitchOut(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): boolean {
-    return !Utils.isNullOrUndefined(pokemon.status);
+    return !isNullOrUndefined(pokemon.status);
   }
 
   override applyPreSwitchOut(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): void {
@@ -3052,7 +3051,7 @@ export class PreSwitchOutHealAbAttr extends PreSwitchOutAbAttr {
 
   override applyPreSwitchOut(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): void {
     if (!simulated) {
-      const healAmount = Utils.toDmgValue(pokemon.getMaxHp() * 0.33);
+      const healAmount = toDmgValue(pokemon.getMaxHp() * 0.33);
       pokemon.heal(healAmount);
       pokemon.updateInfo();
     }
@@ -3166,7 +3165,7 @@ export class PreStatStageChangeAbAttr extends AbAttr {
     passive: boolean,
     simulated: boolean,
     stat: BattleStat,
-    cancelled: Utils.BooleanHolder,
+    cancelled: BooleanHolder,
     args: any[]): boolean {
     return true;
   }
@@ -3176,7 +3175,7 @@ export class PreStatStageChangeAbAttr extends AbAttr {
     passive: boolean,
     simulated: boolean,
     stat: BattleStat,
-    cancelled: Utils.BooleanHolder,
+    cancelled: BooleanHolder,
     args: any[],
   ): void {}
 }
@@ -3195,10 +3194,10 @@ export class ReflectStatStageChangeAbAttr extends PreStatStageChangeAbAttr {
    * @param _passive N/A
    * @param simulated `true` if the ability is being simulated by the AI
    * @param stat the {@linkcode BattleStat} being affected
-   * @param cancelled The {@linkcode Utils.BooleanHolder} that will be set to true due to reflection
+   * @param cancelled The {@linkcode BooleanHolder} that will be set to true due to reflection
    * @param args
    */
-  override applyPreStatStageChange(_pokemon: Pokemon, _passive: boolean, simulated: boolean, stat: BattleStat, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override applyPreStatStageChange(_pokemon: Pokemon, _passive: boolean, simulated: boolean, stat: BattleStat, cancelled: BooleanHolder, args: any[]): void {
     const attacker: Pokemon = args[0];
     const stages = args[1];
     this.reflectedStat = stat;
@@ -3230,8 +3229,8 @@ export class ProtectStatAbAttr extends PreStatStageChangeAbAttr {
     this.protectedStat = protectedStat;
   }
 
-  override canApplyPreStatStageChange(pokemon: Pokemon | null, passive: boolean, simulated: boolean, stat: BattleStat, cancelled: Utils.BooleanHolder, args: any[]): boolean {
-    return Utils.isNullOrUndefined(this.protectedStat) || stat === this.protectedStat;
+  override canApplyPreStatStageChange(pokemon: Pokemon | null, passive: boolean, simulated: boolean, stat: BattleStat, cancelled: BooleanHolder, args: any[]): boolean {
+    return isNullOrUndefined(this.protectedStat) || stat === this.protectedStat;
   }
 
   /**
@@ -3240,10 +3239,10 @@ export class ProtectStatAbAttr extends PreStatStageChangeAbAttr {
    * @param _passive
    * @param simulated
    * @param stat the {@linkcode BattleStat} being affected
-   * @param cancelled The {@linkcode Utils.BooleanHolder} that will be set to true if the stat is protected
+   * @param cancelled The {@linkcode BooleanHolder} that will be set to true if the stat is protected
    * @param _args
    */
-  override applyPreStatStageChange(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, stat: BattleStat, cancelled: Utils.BooleanHolder, _args: any[]): void {
+  override applyPreStatStageChange(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, stat: BattleStat, cancelled: BooleanHolder, _args: any[]): void {
     cancelled.value = true;
   }
 
@@ -3302,7 +3301,7 @@ export class PreSetStatusAbAttr extends AbAttr {
     passive: boolean,
     simulated: boolean,
     effect: StatusEffect | undefined,
-    cancelled: Utils.BooleanHolder,
+    cancelled: BooleanHolder,
     args: any[]): boolean {
     return true;
   }
@@ -3312,7 +3311,7 @@ export class PreSetStatusAbAttr extends AbAttr {
     passive: boolean,
     simulated: boolean,
     effect: StatusEffect | undefined,
-    cancelled: Utils.BooleanHolder,
+    cancelled: BooleanHolder,
     args: any[],
   ): void {}
 }
@@ -3332,7 +3331,7 @@ export class PreSetStatusEffectImmunityAbAttr extends PreSetStatusAbAttr {
     this.immuneEffects = immuneEffects;
   }
 
-  override canApplyPreSetStatus(pokemon: Pokemon, passive: boolean, simulated: boolean, effect: StatusEffect, cancelled: Utils.BooleanHolder, args: any[]): boolean {
+  override canApplyPreSetStatus(pokemon: Pokemon, passive: boolean, simulated: boolean, effect: StatusEffect, cancelled: BooleanHolder, args: any[]): boolean {
     return effect !== StatusEffect.FAINT && this.immuneEffects.length < 1 || this.immuneEffects.includes(effect);
   }
 
@@ -3345,7 +3344,7 @@ export class PreSetStatusEffectImmunityAbAttr extends PreSetStatusAbAttr {
    * @param cancelled - A holder for a boolean value indicating if the status application was cancelled.
    * @param args - n/a
    */
-  override applyPreSetStatus(pokemon: Pokemon, passive: boolean, simulated: boolean, effect: StatusEffect, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override applyPreSetStatus(pokemon: Pokemon, passive: boolean, simulated: boolean, effect: StatusEffect, cancelled: BooleanHolder, args: any[]): void {
     cancelled.value = true;
   }
 
@@ -3400,7 +3399,7 @@ export class ConditionalUserFieldStatusEffectImmunityAbAttr extends UserFieldSta
    * @param args `Args[0]` is the target of the status effect, `Args[1]` is the source.
    * @returns Whether the ability can be applied to cancel the status effect.
    */
-  override canApplyPreSetStatus(pokemon: Pokemon, passive: boolean, simulated: boolean, effect: StatusEffect, cancelled: Utils.BooleanHolder, args: [Pokemon, Pokemon | null, ...any]): boolean {
+  override canApplyPreSetStatus(pokemon: Pokemon, passive: boolean, simulated: boolean, effect: StatusEffect, cancelled: BooleanHolder, args: [Pokemon, Pokemon | null, ...any]): boolean {
     return (!cancelled.value && effect !== StatusEffect.FAINT && this.immuneEffects.length < 1 || this.immuneEffects.includes(effect)) && this.condition(args[0], args[1]);
   }
 
@@ -3438,12 +3437,12 @@ export class ConditionalUserFieldProtectStatAbAttr extends PreStatStageChangeAbA
    * @param args Args[0] is the target pokemon of the stat change.
    * @returns 
    */
-  override canApplyPreStatStageChange(pokemon: Pokemon, passive: boolean, simulated: boolean, stat: BattleStat, cancelled: Utils.BooleanHolder, args: [Pokemon, ...any]): boolean {
+  override canApplyPreStatStageChange(pokemon: Pokemon, passive: boolean, simulated: boolean, stat: BattleStat, cancelled: BooleanHolder, args: [Pokemon, ...any]): boolean {
     const target = args[0];
     if (!target) {
       return false;
     }
-    return !cancelled.value && (Utils.isNullOrUndefined(this.protectedStat) || stat === this.protectedStat) && this.condition(target);
+    return !cancelled.value && (isNullOrUndefined(this.protectedStat) || stat === this.protectedStat) && this.condition(target);
   }
 
   /**
@@ -3455,7 +3454,7 @@ export class ConditionalUserFieldProtectStatAbAttr extends PreStatStageChangeAbA
    * @param cancelled Will be set to true if the stat change is prevented
    * @param _args unused
    */
-  override applyPreStatStageChange(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _stat: BattleStat, cancelled: Utils.BooleanHolder, _args: any[]): void {
+  override applyPreStatStageChange(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _stat: BattleStat, cancelled: BooleanHolder, _args: any[]): void {
     cancelled.value = true;
   }
 }
@@ -3467,7 +3466,7 @@ export class PreApplyBattlerTagAbAttr extends AbAttr {
     passive: boolean,
     simulated: boolean,
     tag: BattlerTag,
-    cancelled: Utils.BooleanHolder,
+    cancelled: BooleanHolder,
     args: any[],
   ): boolean {
     return true;
@@ -3478,7 +3477,7 @@ export class PreApplyBattlerTagAbAttr extends AbAttr {
     passive: boolean,
     simulated: boolean,
     tag: BattlerTag,
-    cancelled: Utils.BooleanHolder,
+    cancelled: BooleanHolder,
     args: any[],
   ): void {}
 }
@@ -3496,13 +3495,13 @@ export class PreApplyBattlerTagImmunityAbAttr extends PreApplyBattlerTagAbAttr {
     this.immuneTagTypes = Array.isArray(immuneTagTypes) ? immuneTagTypes : [ immuneTagTypes ];
   }
 
-  override canApplyPreApplyBattlerTag(pokemon: Pokemon, passive: boolean, simulated: boolean, tag: BattlerTag, cancelled: Utils.BooleanHolder, args: any[]): boolean {
+  override canApplyPreApplyBattlerTag(pokemon: Pokemon, passive: boolean, simulated: boolean, tag: BattlerTag, cancelled: BooleanHolder, args: any[]): boolean {
     this.battlerTag = tag;
 
     return !cancelled.value && this.immuneTagTypes.includes(tag.tagType);
   }
 
-  override applyPreApplyBattlerTag(pokemon: Pokemon, passive: boolean, simulated: boolean, tag: BattlerTag, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override applyPreApplyBattlerTag(pokemon: Pokemon, passive: boolean, simulated: boolean, tag: BattlerTag, cancelled: BooleanHolder, args: any[]): void {
     cancelled.value = true;
   }
 
@@ -3540,7 +3539,7 @@ export class ConditionalUserFieldBattlerTagImmunityAbAttr extends UserFieldBattl
    * @param args Args[0] is the target that the tag is attempting to be applied to
    * @returns Whether the ability can be used to cancel the battler tag
    */
-  override canApplyPreApplyBattlerTag(pokemon: Pokemon, passive: boolean, simulated: boolean, tag: BattlerTag, cancelled: Utils.BooleanHolder, args: [Pokemon, ...any]): boolean {
+  override canApplyPreApplyBattlerTag(pokemon: Pokemon, passive: boolean, simulated: boolean, tag: BattlerTag, cancelled: BooleanHolder, args: [Pokemon, ...any]): boolean {
     return super.canApplyPreApplyBattlerTag(pokemon, passive, simulated, tag, cancelled, args) && this.condition(args[0]);
   }
 
@@ -3556,8 +3555,8 @@ export class BlockCritAbAttr extends AbAttr {
     super(false);
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
-    (args[0] as Utils.BooleanHolder).value = true;
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
+    (args[0] as BooleanHolder).value = true;
   }
 }
 
@@ -3575,8 +3574,8 @@ export class BonusCritAbAttr extends AbAttr {
    * @param cancelled Unused
    * @param args Args[0] is a number holder containing the crit stage.
    */
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: [Utils.NumberHolder, ...any]): void {
-    (args[0] as Utils.NumberHolder).value += 1;
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: [NumberHolder, ...any]): void {
+    (args[0] as NumberHolder).value += 1;
   }
 }
 
@@ -3590,12 +3589,12 @@ export class MultCritAbAttr extends AbAttr {
   }
 
   override canApply(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): boolean {
-    const critMult = args[0] as Utils.NumberHolder;
+    const critMult = args[0] as NumberHolder;
     return critMult.value > 1;
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
-    const critMult = args[0] as Utils.NumberHolder;
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
+    const critMult = args[0] as NumberHolder;
     critMult.value *= this.multAmount;
   }
 }
@@ -3622,12 +3621,12 @@ export class ConditionalCritAbAttr extends AbAttr {
 
   /**
    * @param pokemon {@linkcode Pokemon} user.
-   * @param args [0] {@linkcode Utils.BooleanHolder} If true critical hit is guaranteed.
+   * @param args [0] {@linkcode BooleanHolder} If true critical hit is guaranteed.
    *             [1] {@linkcode Pokemon} Target.
    *             [2] {@linkcode Move} used by ability user.
    */
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
-    (args[0] as Utils.BooleanHolder).value = true;
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
+    (args[0] as BooleanHolder).value = true;
   }
 }
 
@@ -3636,7 +3635,7 @@ export class BlockNonDirectDamageAbAttr extends AbAttr {
     super(false);
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
     cancelled.value = true;
   }
 }
@@ -3666,16 +3665,16 @@ export class BlockStatusDamageAbAttr extends AbAttr {
   /**
    * @param {Pokemon} pokemon The pokemon with the ability
    * @param {boolean} passive N/A
-   * @param {Utils.BooleanHolder} cancelled Whether to cancel the status damage
+   * @param {BooleanHolder} cancelled Whether to cancel the status damage
    * @param {any[]} args N/A
    */
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
     cancelled.value = true;
   }
 }
 
 export class BlockOneHitKOAbAttr extends AbAttr {
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
     cancelled.value = true;
   }
 }
@@ -3704,8 +3703,8 @@ export class ChangeMovePriorityAbAttr extends AbAttr {
     return this.moveFunc(pokemon, args[0] as Move);
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
-    (args[1] as Utils.NumberHolder).value += this.changeAmount;
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
+    (args[1] as NumberHolder).value += this.changeAmount;
   }
 }
 
@@ -3717,7 +3716,7 @@ export class PreWeatherEffectAbAttr extends AbAttr {
     passive: Boolean,
     simulated: boolean,
     weather: Weather | null,
-    cancelled: Utils.BooleanHolder,
+    cancelled: BooleanHolder,
     args: any[]): boolean {
     return true;
   }
@@ -3727,7 +3726,7 @@ export class PreWeatherEffectAbAttr extends AbAttr {
     passive: boolean,
     simulated: boolean,
     weather: Weather | null,
-    cancelled: Utils.BooleanHolder,
+    cancelled: BooleanHolder,
     args: any[],
   ): void {}
 }
@@ -3743,11 +3742,11 @@ export class BlockWeatherDamageAttr extends PreWeatherDamageAbAttr {
     this.weatherTypes = weatherTypes;
   }
 
-  override canApplyPreWeatherEffect(pokemon: Pokemon, passive: Boolean, simulated: boolean, weather: Weather, cancelled: Utils.BooleanHolder, args: any[]): boolean {
+  override canApplyPreWeatherEffect(pokemon: Pokemon, passive: Boolean, simulated: boolean, weather: Weather, cancelled: BooleanHolder, args: any[]): boolean {
     return !this.weatherTypes.length || this.weatherTypes.indexOf(weather?.weatherType) > -1;
   }
 
-  override applyPreWeatherEffect(pokemon: Pokemon, passive: boolean, simulated: boolean, weather: Weather, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override applyPreWeatherEffect(pokemon: Pokemon, passive: boolean, simulated: boolean, weather: Weather, cancelled: BooleanHolder, args: any[]): void {
     cancelled.value = true;
   }
 }
@@ -3761,11 +3760,11 @@ export class SuppressWeatherEffectAbAttr extends PreWeatherEffectAbAttr {
     this.affectsImmutable = !!affectsImmutable;
   }
 
-  override canApplyPreWeatherEffect(pokemon: Pokemon, passive: Boolean, simulated: boolean, weather: Weather, cancelled: Utils.BooleanHolder, args: any[]): boolean {
+  override canApplyPreWeatherEffect(pokemon: Pokemon, passive: Boolean, simulated: boolean, weather: Weather, cancelled: BooleanHolder, args: any[]): boolean {
     return this.affectsImmutable || weather.isImmutable();
   }
 
-  override applyPreWeatherEffect(pokemon: Pokemon, passive: boolean, simulated: boolean, weather: Weather, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override applyPreWeatherEffect(pokemon: Pokemon, passive: boolean, simulated: boolean, weather: Weather, cancelled: BooleanHolder, args: any[]): void {
     cancelled.value = true;
   }
 }
@@ -4042,7 +4041,7 @@ export class PostWeatherLapseHealAbAttr extends PostWeatherLapseAbAttr {
     const abilityName = (!passive ? pokemon.getAbility() : pokemon.getPassiveAbility()).name;
     if (!simulated) {
       globalScene.unshiftPhase(new PokemonHealPhase(pokemon.getBattlerIndex(),
-        Utils.toDmgValue(pokemon.getMaxHp() / (16 / this.healFactor)), i18next.t("abilityTriggers:postWeatherLapseHeal", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon), abilityName }), true));
+        toDmgValue(pokemon.getMaxHp() / (16 / this.healFactor)), i18next.t("abilityTriggers:postWeatherLapseHeal", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon), abilityName }), true));
     }
   }
 }
@@ -4064,7 +4063,7 @@ export class PostWeatherLapseDamageAbAttr extends PostWeatherLapseAbAttr {
     if (!simulated) {
       const abilityName = (!passive ? pokemon.getAbility() : pokemon.getPassiveAbility()).name;
       globalScene.queueMessage(i18next.t("abilityTriggers:postWeatherLapseDamage", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon), abilityName }));
-      pokemon.damageAndUpdate(Utils.toDmgValue(pokemon.getMaxHp() / (16 / this.damageFactor)), { result: HitResult.INDIRECT });
+      pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() / (16 / this.damageFactor)), { result: HitResult.INDIRECT });
     }
   }
 }
@@ -4132,7 +4131,7 @@ export class PostTurnStatusHealAbAttr extends PostTurnAbAttr {
   }
 
   override canApplyPostTurn(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): boolean {
-    return !Utils.isNullOrUndefined(pokemon.status) && this.effects.includes(pokemon.status.effect) && !pokemon.isFullHp();
+    return !isNullOrUndefined(pokemon.status) && this.effects.includes(pokemon.status.effect) && !pokemon.isFullHp();
   }
 
   /**
@@ -4144,7 +4143,7 @@ export class PostTurnStatusHealAbAttr extends PostTurnAbAttr {
     if (!simulated) {
       const abilityName = (!passive ? pokemon.getAbility() : pokemon.getPassiveAbility()).name;
       globalScene.unshiftPhase(new PokemonHealPhase(pokemon.getBattlerIndex(),
-        Utils.toDmgValue(pokemon.getMaxHp() / 8), i18next.t("abilityTriggers:poisonHeal", { pokemonName: getPokemonNameWithAffix(pokemon), abilityName }), true));
+        toDmgValue(pokemon.getMaxHp() / 8), i18next.t("abilityTriggers:poisonHeal", { pokemonName: getPokemonNameWithAffix(pokemon), abilityName }), true));
     }
   }
 }
@@ -4168,7 +4167,7 @@ export class PostTurnResetStatusAbAttr extends PostTurnAbAttr {
     } else {
       this.target = pokemon;
     }
-    return !Utils.isNullOrUndefined(this.target?.status);
+    return !isNullOrUndefined(this.target?.status);
   }
 
   override applyPostTurn(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): void {
@@ -4224,7 +4223,7 @@ export class PostTurnLootAbAttr extends PostTurnAbAttr {
       return true;
     }
 
-    const randomIdx = Utils.randSeedInt(berriesEaten.length);
+    const randomIdx = randSeedInt(berriesEaten.length);
     const chosenBerryType = berriesEaten[randomIdx];
     const chosenBerry = new BerryModifierType(chosenBerryType);
     berriesEaten.splice(randomIdx); // Remove berry from memory
@@ -4312,7 +4311,7 @@ export class PostTurnHealAbAttr extends PostTurnAbAttr {
     if (!simulated) {
       const abilityName = (!passive ? pokemon.getAbility() : pokemon.getPassiveAbility()).name;
       globalScene.unshiftPhase(new PokemonHealPhase(pokemon.getBattlerIndex(),
-        Utils.toDmgValue(pokemon.getMaxHp() / 16), i18next.t("abilityTriggers:postTurnHeal", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon), abilityName }), true));
+        toDmgValue(pokemon.getMaxHp() / 16), i18next.t("abilityTriggers:postTurnHeal", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon), abilityName }), true));
     }
   }
 }
@@ -4356,7 +4355,7 @@ export class PostTurnHurtIfSleepingAbAttr extends PostTurnAbAttr {
     for (const opp of pokemon.getOpponents()) {
       if ((opp.status?.effect === StatusEffect.SLEEP || opp.hasAbility(Abilities.COMATOSE)) && !opp.hasAbilityWithAttr(BlockNonDirectDamageAbAttr) && !opp.switchOutStatus) {
         if (!simulated) {
-          opp.damageAndUpdate(Utils.toDmgValue(opp.getMaxHp() / 8), { result: HitResult.INDIRECT });
+          opp.damageAndUpdate(toDmgValue(opp.getMaxHp() / 8), { result: HitResult.INDIRECT });
           globalScene.queueMessage(i18next.t("abilityTriggers:badDreams", { pokemonName: getPokemonNameWithAffix(opp) }));
         }
       }
@@ -4375,7 +4374,7 @@ export class FetchBallAbAttr extends PostTurnAbAttr {
   }
 
   override canApplyPostTurn(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): boolean {
-    return !simulated && !Utils.isNullOrUndefined(globalScene.currentBattle.lastUsedPokeball) && !!pokemon.isPlayer;
+    return !simulated && !isNullOrUndefined(globalScene.currentBattle.lastUsedPokeball) && !!pokemon.isPlayer;
   }
 
   /**
@@ -4407,7 +4406,7 @@ export class PostBiomeChangeWeatherChangeAbAttr extends PostBiomeChangeAbAttr {
     return ((globalScene.arena.weather?.isImmutable() ?? false) && globalScene.arena.canSetWeather(this.weatherType));
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
     if (!simulated) {
       globalScene.arena.trySetWeather(this.weatherType, pokemon);
     }
@@ -4427,7 +4426,7 @@ export class PostBiomeChangeTerrainChangeAbAttr extends PostBiomeChangeAbAttr {
     return globalScene.arena.canSetTerrain(this.terrainType);
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
     if (!simulated) {
       globalScene.arena.trySetTerrain(this.terrainType, false, pokemon);
     }
@@ -4562,8 +4561,8 @@ export class StatStageChangeMultiplierAbAttr extends AbAttr {
     this.multiplier = multiplier;
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
-    (args[0] as Utils.NumberHolder).value *= this.multiplier;
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
+    (args[0] as NumberHolder).value *= this.multiplier;
   }
 }
 
@@ -4572,7 +4571,7 @@ export class StatStageChangeCopyAbAttr extends AbAttr {
     pokemon: Pokemon,
     passive: boolean,
     simulated: boolean,
-    cancelled: Utils.BooleanHolder,
+    cancelled: BooleanHolder,
     args: any[],
   ): void {
     if (!simulated) {
@@ -4586,7 +4585,7 @@ export class BypassBurnDamageReductionAbAttr extends AbAttr {
     super(false);
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
     cancelled.value = true;
   }
 }
@@ -4605,21 +4604,21 @@ export class ReduceBurnDamageAbAttr extends AbAttr {
    * @param pokemon N/A
    * @param passive N/A
    * @param cancelled N/A
-   * @param args `[0]` {@linkcode Utils.NumberHolder} The damage value being modified
+   * @param args `[0]` {@linkcode NumberHolder} The damage value being modified
    */
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
-    (args[0] as Utils.NumberHolder).value = Utils.toDmgValue((args[0] as Utils.NumberHolder).value * this.multiplier);
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
+    (args[0] as NumberHolder).value = toDmgValue((args[0] as NumberHolder).value * this.multiplier);
   }
 }
 
 export class DoubleBerryEffectAbAttr extends AbAttr {
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
-    (args[0] as Utils.NumberHolder).value *= 2;
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
+    (args[0] as NumberHolder).value *= 2;
   }
 }
 
 export class PreventBerryUseAbAttr extends AbAttr {
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
     cancelled.value = true;
   }
 }
@@ -4640,13 +4639,13 @@ export class HealFromBerryUseAbAttr extends AbAttr {
     this.healPercent = Math.max(Math.min(healPercent, 1), 0);
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, ...args: [Utils.BooleanHolder, any[]]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, ...args: [BooleanHolder, any[]]): void {
     const { name: abilityName } = passive ? pokemon.getPassiveAbility() : pokemon.getAbility();
     if (!simulated) {
       globalScene.unshiftPhase(
         new PokemonHealPhase(
           pokemon.getBattlerIndex(),
-          Utils.toDmgValue(pokemon.getMaxHp() * this.healPercent),
+          toDmgValue(pokemon.getMaxHp() * this.healPercent),
           i18next.t("abilityTriggers:healFromBerryUse", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon), abilityName }),
           true
         )
@@ -4656,8 +4655,8 @@ export class HealFromBerryUseAbAttr extends AbAttr {
 }
 
 export class RunSuccessAbAttr extends AbAttr {
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
-    (args[0] as Utils.NumberHolder).value = 256;
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
+    (args[0] as NumberHolder).value = 256;
   }
 }
 
@@ -4681,7 +4680,7 @@ export class CheckTrappedAbAttr extends AbAttr {
     pokemon: Pokemon,
     passive: boolean,
     simulated: boolean,
-    trapped: Utils.BooleanHolder,
+    trapped: BooleanHolder,
     otherPokemon: Pokemon,
     args: any[]): boolean {
     return true;
@@ -4691,7 +4690,7 @@ export class CheckTrappedAbAttr extends AbAttr {
     pokemon: Pokemon,
     passive: boolean,
     simulated: boolean,
-    trapped: Utils.BooleanHolder,
+    trapped: BooleanHolder,
     otherPokemon: Pokemon,
     args: any[],
   ): void {}
@@ -4704,7 +4703,7 @@ export class CheckTrappedAbAttr extends AbAttr {
  * @see {@linkcode applyCheckTrapped}
  */
 export class ArenaTrapAbAttr extends CheckTrappedAbAttr {
-  override canApplyCheckTrapped(pokemon: Pokemon, passive: boolean, simulated: boolean, trapped: Utils.BooleanHolder, otherPokemon: Pokemon, args: any[]): boolean {
+  override canApplyCheckTrapped(pokemon: Pokemon, passive: boolean, simulated: boolean, trapped: BooleanHolder, otherPokemon: Pokemon, args: any[]): boolean {
     return this.arenaTrapCondition(pokemon, otherPokemon)
     && !(otherPokemon.getTypes(true).includes(PokemonType.GHOST) || (otherPokemon.getTypes(true).includes(PokemonType.STELLAR) && otherPokemon.getTypes().includes(PokemonType.GHOST)))
     && !otherPokemon.hasAbility(Abilities.RUN_AWAY);
@@ -4718,11 +4717,11 @@ export class ArenaTrapAbAttr extends CheckTrappedAbAttr {
    * If the user has Arena Trap and the enemy is not grounded, it is not trapped.
    * @param pokemon The {@link Pokemon} with this {@link AbAttr}
    * @param passive N/A
-   * @param trapped {@link Utils.BooleanHolder} indicating whether the other Pokemon is trapped or not
+   * @param trapped {@link BooleanHolder} indicating whether the other Pokemon is trapped or not
    * @param otherPokemon The {@link Pokemon} that is affected by an Arena Trap ability
    * @param args N/A
    */
-  override applyCheckTrapped(pokemon: Pokemon, passive: boolean, simulated: boolean, trapped: Utils.BooleanHolder, otherPokemon: Pokemon, args: any[]): void {
+  override applyCheckTrapped(pokemon: Pokemon, passive: boolean, simulated: boolean, trapped: BooleanHolder, otherPokemon: Pokemon, args: any[]): void {
     trapped.value = true;
   }
 
@@ -4736,8 +4735,8 @@ export class MaxMultiHitAbAttr extends AbAttr {
     super(false);
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
-    (args[0] as Utils.NumberHolder).value = 0;
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
+    (args[0] as NumberHolder).value = 0;
   }
 }
 
@@ -4759,7 +4758,7 @@ export class PostBattleLootAbAttr extends PostBattleAbAttr {
   override canApplyPostBattle(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): boolean {
     const postBattleLoot = globalScene.currentBattle.postBattleLoot;
     if (!simulated && postBattleLoot.length && args[0]) {
-      this.randItem = Utils.randSeedItem(postBattleLoot);
+      this.randItem = randSeedItem(postBattleLoot);
       return globalScene.canTransferHeldItemModifier(this.randItem, pokemon, 1);
     }
     return false;
@@ -4771,7 +4770,7 @@ export class PostBattleLootAbAttr extends PostBattleAbAttr {
   override applyPostBattle(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): void {
     const postBattleLoot = globalScene.currentBattle.postBattleLoot;
     if (!this.randItem) {
-      this.randItem = Utils.randSeedItem(postBattleLoot);
+      this.randItem = randSeedItem(postBattleLoot);
     }
 
     if (globalScene.tryTransferHeldItemModifier(this.randItem, pokemon, true, 1, true, undefined, false)) {
@@ -4828,7 +4827,7 @@ export class PostFaintContactDamageAbAttr extends PostFaintAbAttr {
 
   override canApplyPostFaint(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker?: Pokemon, move?: Move, hitResult?: HitResult, ...args: any[]): boolean {
     const diedToDirectDamage = move !== undefined && attacker !== undefined && move.doesFlagEffectApply({flag: MoveFlags.MAKES_CONTACT, user: attacker, target: pokemon});
-    const cancelled = new Utils.BooleanHolder(false);
+    const cancelled = new BooleanHolder(false);
     globalScene.getField(true).map(p => applyAbAttrs(FieldPreventExplosiveMovesAbAttr, p, cancelled, simulated));
     if (!diedToDirectDamage || cancelled.value || attacker!.hasAbilityWithAttr(BlockNonDirectDamageAbAttr)) {
       return false;
@@ -4839,8 +4838,8 @@ export class PostFaintContactDamageAbAttr extends PostFaintAbAttr {
 
   override applyPostFaint(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker?: Pokemon, move?: Move, hitResult?: HitResult, ...args: any[]): void {
     if (!simulated) {
-      attacker!.damageAndUpdate(Utils.toDmgValue(attacker!.getMaxHp() * (1 / this.damageRatio)), { result: HitResult.INDIRECT });
-      attacker!.turnData.damageTaken += Utils.toDmgValue(attacker!.getMaxHp() * (1 / this.damageRatio));
+      attacker!.damageAndUpdate(toDmgValue(attacker!.getMaxHp() * (1 / this.damageRatio)), { result: HitResult.INDIRECT });
+      attacker!.turnData.damageTaken += toDmgValue(attacker!.getMaxHp() * (1 / this.damageRatio));
     }
   }
 
@@ -4886,13 +4885,13 @@ export class RedirectMoveAbAttr extends AbAttr {
     if (!this.canRedirect(args[0] as Moves, args[2] as Pokemon)) {
       return false;
     }
-    const target = args[1] as Utils.NumberHolder;
+    const target = args[1] as NumberHolder;
     const newTarget = pokemon.getBattlerIndex();
     return target.value !== newTarget;
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
-    const target = args[1] as Utils.NumberHolder;
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
+    const target = args[1] as NumberHolder;
     const newTarget = pokemon.getBattlerIndex();
     target.value = newTarget;
   }
@@ -4933,7 +4932,7 @@ export class ReduceStatusEffectDurationAbAttr extends AbAttr {
   }
 
   override canApply(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): boolean {
-    return args[1] instanceof Utils.NumberHolder && args[0] === this.statusEffect;
+    return args[1] instanceof NumberHolder && args[0] === this.statusEffect;
   }
 
   /**
@@ -4942,7 +4941,7 @@ export class ReduceStatusEffectDurationAbAttr extends AbAttr {
    * - `[0]` - The {@linkcode StatusEffect} of the Pokemon
    * - `[1]` - The number of turns remaining until the status is healed
    */
-  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _cancelled: Utils.BooleanHolder, args: any[]): void {
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _cancelled: BooleanHolder, args: any[]): void {
     args[1].value -= 1;
   }
 }
@@ -4966,7 +4965,7 @@ export class FlinchStatStageChangeAbAttr extends FlinchEffectAbAttr {
     this.stages = stages;
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
     if (!simulated) {
       globalScene.unshiftPhase(new StatStageChangePhase(pokemon.getBattlerIndex(), true, this.stats, this.stages));
     }
@@ -4976,7 +4975,7 @@ export class FlinchStatStageChangeAbAttr extends FlinchEffectAbAttr {
 export class IncreasePpAbAttr extends AbAttr { }
 
 export class ForceSwitchOutImmunityAbAttr extends AbAttr {
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
     cancelled.value = true;
   }
 }
@@ -4991,7 +4990,7 @@ export class ReduceBerryUseThresholdAbAttr extends AbAttr {
     return args[0].value < hpRatio;
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
     args[0].value *= 2;
   }
 }
@@ -5009,8 +5008,8 @@ export class WeightMultiplierAbAttr extends AbAttr {
     this.multiplier = multiplier;
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
-    (args[0] as Utils.NumberHolder).value *= this.multiplier;
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
+    (args[0] as NumberHolder).value *= this.multiplier;
   }
 }
 
@@ -5019,7 +5018,7 @@ export class SyncEncounterNatureAbAttr extends AbAttr {
     super(false);
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
     (args[0] as Pokemon).setNature(pokemon.getNature());
   }
 }
@@ -5037,7 +5036,7 @@ export class MoveAbilityBypassAbAttr extends AbAttr {
     return this.moveIgnoreFunc(pokemon, (args[0] as Move));
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
     cancelled.value = true;
   }
 }
@@ -5057,7 +5056,7 @@ export class InfiltratorAbAttr extends AbAttr {
   }
 
   override canApply(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): boolean {
-    return args[0] instanceof Utils.BooleanHolder;
+    return args[0] instanceof BooleanHolder;
   }
 
   /**
@@ -5066,7 +5065,7 @@ export class InfiltratorAbAttr extends AbAttr {
    * @param passive n/a
    * @param simulated n/a
    * @param cancelled n/a
-   * @param args `[0]` a {@linkcode Utils.BooleanHolder | BooleanHolder} containing the flag
+   * @param args `[0]` a {@linkcode BooleanHolder | BooleanHolder} containing the flag
    */
   override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: null, args: any[]): void {
     const bypassed = args[0];
@@ -5107,7 +5106,7 @@ export class IgnoreTypeImmunityAbAttr extends AbAttr {
     return this.defenderType === (args[1] as PokemonType) && this.allowedMoveTypes.includes(args[0] as PokemonType);
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
     cancelled.value = true;
   }
 }
@@ -5130,7 +5129,7 @@ export class IgnoreTypeStatusEffectImmunityAbAttr extends AbAttr {
     return this.statusEffect.includes(args[0] as StatusEffect) && this.defenderType.includes(args[1] as PokemonType);
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
     cancelled.value = true;
   }
 }
@@ -5223,7 +5222,7 @@ export class FormBlockDamageAbAttr extends ReceivedMoveDamageMultiplierAbAttr {
     this.triggerMessageFunc = triggerMessageFunc;
   }
 
-  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: Utils.BooleanHolder | null, args: any[]): boolean {
+  override canApplyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder | null, args: any[]): boolean {
     return this.condition(pokemon, attacker, move) && !move.hitsSubstitute(attacker, pokemon);
   }
 
@@ -5238,9 +5237,9 @@ export class FormBlockDamageAbAttr extends ReceivedMoveDamageMultiplierAbAttr {
    * @param _cancelled n/a
    * @param args Additional arguments.
    */
-  override applyPreDefend(pokemon: Pokemon, _passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, _cancelled: Utils.BooleanHolder, args: any[]): void {
+  override applyPreDefend(pokemon: Pokemon, _passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, _cancelled: BooleanHolder, args: any[]): void {
     if (!simulated) {
-      (args[0] as Utils.NumberHolder).value = this.multiplier;
+      (args[0] as NumberHolder).value = this.multiplier;
       pokemon.removeTag(this.tagType);
       if (this.recoilDamageFunc) {
         pokemon.damageAndUpdate(this.recoilDamageFunc(pokemon), { result: HitResult.INDIRECT, ignoreSegments: true, ignoreFaintPhase: true });
@@ -5277,7 +5276,7 @@ export class BypassSpeedChanceAbAttr extends AbAttr {
   }
 
   override canApply(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): boolean {
-    const bypassSpeed = args[0] as Utils.BooleanHolder;
+    const bypassSpeed = args[0] as BooleanHolder;
     const turnCommand = globalScene.currentBattle.turnCommands[pokemon.getBattlerIndex()];
     const isCommandFight = turnCommand?.command === Command.FIGHT;
     const move = turnCommand?.move?.move ? allMoves[turnCommand.move.move] : null;
@@ -5289,11 +5288,11 @@ export class BypassSpeedChanceAbAttr extends AbAttr {
    * bypass move order in their priority bracket when pokemon choose damaging move
    * @param {Pokemon} pokemon {@linkcode Pokemon}  the Pokemon applying this ability
    * @param {boolean} passive N/A
-   * @param {Utils.BooleanHolder} cancelled N/A
-   * @param {any[]} args [0] {@linkcode Utils.BooleanHolder} set to true when the ability activated
+   * @param {BooleanHolder} cancelled N/A
+   * @param {any[]} args [0] {@linkcode BooleanHolder} set to true when the ability activated
    */
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
-    const bypassSpeed = args[0] as Utils.BooleanHolder;
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
+    const bypassSpeed = args[0] as BooleanHolder;
     bypassSpeed.value = true;
   }
 
@@ -5328,9 +5327,9 @@ export class PreventBypassSpeedChanceAbAttr extends AbAttr {
    * @argument {boolean} bypassSpeed - determines if a Pokemon is able to bypass speed at the moment
    * @argument {boolean} canCheckHeldItems - determines if a Pokemon has access to Quick Claw's effects or not
    */
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: Utils.BooleanHolder, args: any[]): void {
-    const bypassSpeed = args[0] as Utils.BooleanHolder;
-    const canCheckHeldItems = args[1] as Utils.BooleanHolder;
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
+    const bypassSpeed = args[0] as BooleanHolder;
+    const canCheckHeldItems = args[1] as BooleanHolder;
     bypassSpeed.value = false;
     canCheckHeldItems.value = false;
   }
@@ -5349,7 +5348,7 @@ export class TerrainEventTypeChangeAbAttr extends PostSummonAbAttr {
     return !pokemon.isTerastallized;
   }
 
-  override apply(pokemon: Pokemon, _passive: boolean, _simulated: boolean, _cancelled: Utils.BooleanHolder, _args: any[]): void {
+  override apply(pokemon: Pokemon, _passive: boolean, _simulated: boolean, _cancelled: BooleanHolder, _args: any[]): void {
     const currentTerrain = globalScene.arena.getTerrainType();
     const typeChange: PokemonType[] = this.determineTypeChange(pokemon, currentTerrain);
     if (typeChange.length !== 0) {
@@ -5400,7 +5399,7 @@ export class TerrainEventTypeChangeAbAttr extends PostSummonAbAttr {
    * Checks if the Pokemon should change types if summoned into an active terrain
    */
   override applyPostSummon(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): void {
-    this.apply(pokemon, passive, simulated, new Utils.BooleanHolder(false), []);
+    this.apply(pokemon, passive, simulated, new BooleanHolder(false), []);
   }
 
   override getTriggerMessage(pokemon: Pokemon, abilityName: string, ...args: any[]) {
@@ -5527,7 +5526,7 @@ class ForceSwitchOutHelper {
       if (switchOutTarget.hp > 0) {
         switchOutTarget.leaveField(false);
         globalScene.queueMessage(i18next.t("moveTriggers:fled", { pokemonName: getPokemonNameWithAffix(switchOutTarget) }), null, true, 500);
-        if (globalScene.currentBattle.double && !Utils.isNullOrUndefined(allyPokemon)) {
+        if (globalScene.currentBattle.double && !isNullOrUndefined(allyPokemon)) {
           globalScene.redirectPokemonMoves(switchOutTarget, allyPokemon);
         }
       }
@@ -5556,7 +5555,7 @@ class ForceSwitchOutHelper {
     const player = switchOutTarget instanceof PlayerPokemon;
 
     if (player) {
-      const blockedByAbility = new Utils.BooleanHolder(false);
+      const blockedByAbility = new BooleanHolder(false);
       applyAbAttrs(ForceSwitchOutImmunityAbAttr, opponent, blockedByAbility);
       return !blockedByAbility.value;
     }
@@ -5584,7 +5583,7 @@ class ForceSwitchOutHelper {
    * @returns The failure message, or `null` if no failure.
    */
   public getFailedText(target: Pokemon): string | null {
-    const blockedByAbility = new Utils.BooleanHolder(false);
+    const blockedByAbility = new BooleanHolder(false);
     applyAbAttrs(ForceSwitchOutImmunityAbAttr, target, blockedByAbility);
     return blockedByAbility.value ? i18next.t("moveTriggers:cannotBeSwitchedOut", { pokemonName: getPokemonNameWithAffix(target) }) : null;
   }
@@ -5603,7 +5602,7 @@ class ForceSwitchOutHelper {
 function calculateShellBellRecovery(pokemon: Pokemon): number {
   const shellBellModifier = pokemon.getHeldItems().find(m => m instanceof HitHealModifier);
   if (shellBellModifier) {
-    return Utils.toDmgValue(pokemon.turnData.totalDamageDealt / 8) * shellBellModifier.stackCount;
+    return toDmgValue(pokemon.turnData.totalDamageDealt / 8) * shellBellModifier.stackCount;
   }
   return 0;
 }
@@ -5743,7 +5742,7 @@ function applyAbAttrsInternal<TAttr extends AbAttr>(
 export function applyAbAttrs(
   attrType: Constructor<AbAttr>,
   pokemon: Pokemon,
-  cancelled: Utils.BooleanHolder | null,
+  cancelled: BooleanHolder | null,
   simulated = false,
   ...args: any[]
 ): void {
@@ -5778,7 +5777,7 @@ export function applyPreDefendAbAttrs(
   pokemon: Pokemon,
   attacker: Pokemon,
   move: Move | null,
-  cancelled: Utils.BooleanHolder | null,
+  cancelled: BooleanHolder | null,
   simulated = false,
   ...args: any[]
 ): void {
@@ -5833,7 +5832,7 @@ export function applyStatMultiplierAbAttrs(
   attrType: Constructor<StatMultiplierAbAttr>,
   pokemon: Pokemon,
   stat: BattleStat,
-  statValue: Utils.NumberHolder,
+  statValue: NumberHolder,
   simulated = false,
   ...args: any[]
 ): void {
@@ -5851,13 +5850,13 @@ export function applyStatMultiplierAbAttrs(
  * @param attrType - {@linkcode AllyStatMultiplierAbAttr} should always be AllyStatMultiplierAbAttr for the time being
  * @param pokemon - The {@linkcode Pokemon} with the ability
  * @param stat - The type of the checked {@linkcode Stat}
- * @param statValue - {@linkcode Utils.NumberHolder} containing the value of the checked stat
+ * @param statValue - {@linkcode NumberHolder} containing the value of the checked stat
  * @param checkedPokemon - The {@linkcode Pokemon} with the checked stat
  * @param ignoreAbility - Whether or not the ability should be ignored by the pokemon or its move.
  * @param args - unused
  */
 export function applyAllyStatMultiplierAbAttrs(attrType: Constructor<AllyStatMultiplierAbAttr>,
-  pokemon: Pokemon, stat: BattleStat, statValue: Utils.NumberHolder, simulated: boolean = false, checkedPokemon: Pokemon, ignoreAbility: boolean, ...args: any[]
+  pokemon: Pokemon, stat: BattleStat, statValue: NumberHolder, simulated: boolean = false, checkedPokemon: Pokemon, ignoreAbility: boolean, ...args: any[]
 ): void {
   return applyAbAttrsInternal<AllyStatMultiplierAbAttr>(
     attrType,
@@ -5910,18 +5909,18 @@ export function applyPostDamageAbAttrs(
  * @param attrType {@linkcode FieldMultiplyStatAbAttr} should always be FieldMultiplyBattleStatAbAttr for the time being
  * @param pokemon {@linkcode Pokemon} the Pokemon applying this ability
  * @param stat {@linkcode Stat} the type of the checked stat
- * @param statValue {@linkcode Utils.NumberHolder} the value of the checked stat
+ * @param statValue {@linkcode NumberHolder} the value of the checked stat
  * @param checkedPokemon {@linkcode Pokemon} the Pokemon with the checked stat
- * @param hasApplied {@linkcode Utils.BooleanHolder} whether or not a FieldMultiplyBattleStatAbAttr has already affected this stat
+ * @param hasApplied {@linkcode BooleanHolder} whether or not a FieldMultiplyBattleStatAbAttr has already affected this stat
  * @param args unused
  */
 export function applyFieldStatMultiplierAbAttrs(
   attrType: Constructor<FieldMultiplyStatAbAttr>,
   pokemon: Pokemon,
   stat: Stat,
-  statValue: Utils.NumberHolder,
+  statValue: NumberHolder,
   checkedPokemon: Pokemon,
-  hasApplied: Utils.BooleanHolder,
+  hasApplied: BooleanHolder,
   simulated = false,
   ...args: any[]
 ): void {
@@ -6055,7 +6054,7 @@ export function applyPreStatStageChangeAbAttrs<T extends PreStatStageChangeAbAtt
   attrType: Constructor<T>,
   pokemon: Pokemon | null,
   stat: BattleStat,
-  cancelled: Utils.BooleanHolder,
+  cancelled: BooleanHolder,
   simulated = false,
   ...args: any[]
 ): void {
@@ -6091,7 +6090,7 @@ export function applyPreSetStatusAbAttrs(
   attrType: Constructor<PreSetStatusAbAttr>,
   pokemon: Pokemon,
   effect: StatusEffect | undefined,
-  cancelled: Utils.BooleanHolder,
+  cancelled: BooleanHolder,
   simulated = false,
   ...args: any[]
 ): void {
@@ -6109,7 +6108,7 @@ export function applyPreApplyBattlerTagAbAttrs(
   attrType: Constructor<PreApplyBattlerTagAbAttr>,
   pokemon: Pokemon,
   tag: BattlerTag,
-  cancelled: Utils.BooleanHolder,
+  cancelled: BooleanHolder,
   simulated = false,
   ...args: any[]
 ): void {
@@ -6127,7 +6126,7 @@ export function applyPreWeatherEffectAbAttrs(
   attrType: Constructor<PreWeatherEffectAbAttr>,
   pokemon: Pokemon,
   weather: Weather | null,
-  cancelled: Utils.BooleanHolder,
+  cancelled: BooleanHolder,
   simulated = false,
   ...args: any[]
 ): void {
@@ -6211,7 +6210,7 @@ export function applyPostTerrainChangeAbAttrs(
 export function applyCheckTrappedAbAttrs(
   attrType: Constructor<CheckTrappedAbAttr>,
   pokemon: Pokemon,
-  trapped: Utils.BooleanHolder,
+  trapped: BooleanHolder,
   otherPokemon: Pokemon,
   messages: string[],
   simulated = false,
@@ -6539,7 +6538,7 @@ export function initAbilities() {
       .bypassFaint()
       .ignorable(),
     new Ability(Abilities.SHED_SKIN, 3)
-      .conditionalAttr(pokemon => !Utils.randSeedInt(3), PostTurnResetStatusAbAttr),
+      .conditionalAttr(pokemon => !randSeedInt(3), PostTurnResetStatusAbAttr),
     new Ability(Abilities.GUTS, 3)
       .attr(BypassBurnDamageReductionAbAttr)
       .conditionalAttr(pokemon => !!pokemon.status || pokemon.hasAbility(Abilities.COMATOSE), StatMultiplierAbAttr, Stat.ATK, 1.5),
@@ -6661,7 +6660,7 @@ export function initAbilities() {
       .attr(ChangeMovePriorityAbAttr, (pokemon, move: Move) => true, -0.2),
     new Ability(Abilities.TECHNICIAN, 4)
       .attr(MovePowerBoostAbAttr, (user, target, move) => {
-        const power = new Utils.NumberHolder(move.power);
+        const power = new NumberHolder(move.power);
         applyMoveAttrs(VariablePowerAttr, user, target, move, power);
         return power.value <= 60;
       }, 1.5),
@@ -6755,7 +6754,7 @@ export function initAbilities() {
       .attr(PostDefendMoveDisableAbAttr, 30)
       .bypassFaint(),
     new Ability(Abilities.HEALER, 5)
-      .conditionalAttr(pokemon => !Utils.isNullOrUndefined(pokemon.getAlly()) && Utils.randSeedInt(10) < 3, PostTurnResetStatusAbAttr, true),
+      .conditionalAttr(pokemon => !isNullOrUndefined(pokemon.getAlly()) && randSeedInt(10) < 3, PostTurnResetStatusAbAttr, true),
     new Ability(Abilities.FRIEND_GUARD, 5)
       .attr(AlliedFieldDamageReductionAbAttr, 0.75)
       .ignorable(),
@@ -6809,7 +6808,7 @@ export function initAbilities() {
     new Ability(Abilities.ANALYTIC, 5)
       .attr(MovePowerBoostAbAttr, (user, target, move) => {
         const movePhase = globalScene.findPhase((phase) => phase instanceof MovePhase && phase.pokemon.id !== user?.id);
-        return Utils.isNullOrUndefined(movePhase);
+        return isNullOrUndefined(movePhase);
       }, 1.3),
     new Ability(Abilities.ILLUSION, 5)
       .uncopiable()
@@ -7032,7 +7031,7 @@ export function initAbilities() {
       .attr(FormBlockDamageAbAttr,
         (target, user, move) => !!target.getTag(BattlerTagType.DISGUISE) && target.getMoveEffectiveness(user, move) > 0, 0, BattlerTagType.DISGUISE,
         (pokemon, abilityName) => i18next.t("abilityTriggers:disguiseAvoidedDamage", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon), abilityName: abilityName }),
-        (pokemon) => Utils.toDmgValue(pokemon.getMaxHp() / 8))
+        (pokemon) => toDmgValue(pokemon.getMaxHp() / 8))
       .attr(PostBattleInitFormChangeAbAttr, () => 0)
       .uncopiable()
       .unreplaceable()

--- a/src/data/balance/biomes.ts
+++ b/src/data/balance/biomes.ts
@@ -1,5 +1,5 @@
 import { PokemonType } from "#enums/pokemon-type";
-import * as Utils from "#app/utils";
+import { randSeedInt, getEnumValues } from "#app/utils";
 import type { SpeciesFormEvolution } from "#app/data/balance/pokemon-evolutions";
 import { pokemonEvolutions } from "#app/data/balance/pokemon-evolutions";
 import i18next from "i18next";
@@ -7710,7 +7710,7 @@ export function initBiomes() {
     if (biome === Biome.END) {
       const biomeList = Object.keys(Biome).filter(key => !Number.isNaN(Number(key)));
       biomeList.pop(); // Removes Biome.END from the list
-      const randIndex = Utils.randSeedInt(biomeList.length, 1); // Will never be Biome.TOWN
+      const randIndex = randSeedInt(biomeList.length, 1); // Will never be Biome.TOWN
       biome = Biome[biomeList[randIndex]];
     }
     const linkedBiomes: (Biome | [ Biome, number ])[] = Array.isArray(biomeLinks[biome])
@@ -7733,15 +7733,15 @@ export function initBiomes() {
   traverseBiome(Biome.TOWN, 0);
   biomeDepths[Biome.END] = [ Object.values(biomeDepths).map(d => d[0]).reduce((max: number, value: number) => Math.max(max, value), 0) + 1, 1 ];
 
-  for (const biome of Utils.getEnumValues(Biome)) {
+  for (const biome of getEnumValues(Biome)) {
     biomePokemonPools[biome] = {};
     biomeTrainerPools[biome] = {};
 
-    for (const tier of Utils.getEnumValues(BiomePoolTier)) {
+    for (const tier of getEnumValues(BiomePoolTier)) {
       biomePokemonPools[biome][tier] = {};
       biomeTrainerPools[biome][tier] = [];
 
-      for (const tod of Utils.getEnumValues(TimeOfDay)) {
+      for (const tod of getEnumValues(TimeOfDay)) {
         biomePokemonPools[biome][tier][tod] = [];
       }
     }

--- a/src/data/balance/egg-moves.ts
+++ b/src/data/balance/egg-moves.ts
@@ -1,5 +1,5 @@
 import { allMoves } from "#app/data/moves/move";
-import * as Utils from "#app/utils";
+import { getEnumKeys, getEnumValues } from "#app/utils";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
 
@@ -587,8 +587,8 @@ export const speciesEggMoves = {
 function parseEggMoves(content: string): void {
   let output = "";
 
-  const speciesNames = Utils.getEnumKeys(Species);
-  const speciesValues = Utils.getEnumValues(Species);
+  const speciesNames = getEnumKeys(Species);
+  const speciesValues = getEnumValues(Species);
   const lines = content.split(/\n/g);
 
   for (const line of lines) {

--- a/src/data/balance/pokemon-evolutions.ts
+++ b/src/data/balance/pokemon-evolutions.ts
@@ -3,7 +3,7 @@ import { Gender } from "#app/data/gender";
 import { PokeballType } from "#enums/pokeball";
 import type Pokemon from "#app/field/pokemon";
 import { PokemonType } from "#enums/pokemon-type";
-import * as Utils from "#app/utils";
+import { randSeedInt } from "#app/utils";
 import { WeatherType } from "#enums/weather-type";
 import { Nature } from "#enums/nature";
 import { Biome } from "#enums/biome";
@@ -333,7 +333,7 @@ class DunsparceEvolutionCondition extends SpeciesEvolutionCondition {
     super(p => {
       let ret = false;
       if (p.moveset.filter(m => m.moveId === Moves.HYPER_DRILL).length > 0) {
-        globalScene.executeWithSeedOffset(() => ret = !Utils.randSeedInt(4), p.id);
+        globalScene.executeWithSeedOffset(() => ret = !randSeedInt(4), p.id);
       }
       return ret;
     });
@@ -346,7 +346,7 @@ class TandemausEvolutionCondition extends SpeciesEvolutionCondition {
   constructor() {
     super(p => {
       let ret = false;
-      globalScene.executeWithSeedOffset(() => ret = !Utils.randSeedInt(4), p.id);
+      globalScene.executeWithSeedOffset(() => ret = !randSeedInt(4), p.id);
       return ret;
     });
   }

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -42,7 +42,7 @@ import { Species } from "#enums/species";
 import { EFFECTIVE_STATS, getStatKey, Stat, type BattleStat, type EffectiveStat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
 import { WeatherType } from "#enums/weather-type";
-import * as Utils from "../utils";
+import { isNullOrUndefined } from "#app/utils";
 
 export enum BattlerTagLapseType {
   FAINT,
@@ -302,7 +302,7 @@ export class DisabledTag extends MoveRestrictionBattlerTag {
     super.onAdd(pokemon);
 
     const move = pokemon.getLastXMoves(-1).find(m => !m.virtual);
-    if (Utils.isNullOrUndefined(move) || move.move === Moves.STRUGGLE || move.move === Moves.NONE) {
+    if (isNullOrUndefined(move) || move.move === Moves.STRUGGLE || move.move === Moves.NONE) {
       return;
     }
 

--- a/src/data/berry.ts
+++ b/src/data/berry.ts
@@ -2,7 +2,7 @@ import { getPokemonNameWithAffix } from "../messages";
 import type Pokemon from "../field/pokemon";
 import { HitResult } from "../field/pokemon";
 import { getStatusEffectHealText } from "./status-effect";
-import * as Utils from "../utils";
+import { NumberHolder, toDmgValue, randSeedInt } from "#app/utils";
 import {
   DoubleBerryEffectAbAttr,
   PostItemLostAbAttr,
@@ -43,7 +43,7 @@ export function getBerryPredicate(berryType: BerryType): BerryPredicate {
     case BerryType.APICOT:
     case BerryType.SALAC:
       return (pokemon: Pokemon) => {
-        const threshold = new Utils.NumberHolder(0.25);
+        const threshold = new NumberHolder(0.25);
         // Offset BerryType such that LIECHI -> Stat.ATK = 1, GANLON -> Stat.DEF = 2, so on and so forth
         const stat: BattleStat = berryType - BerryType.ENIGMA;
         applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, null, false, threshold);
@@ -51,19 +51,19 @@ export function getBerryPredicate(berryType: BerryType): BerryPredicate {
       };
     case BerryType.LANSAT:
       return (pokemon: Pokemon) => {
-        const threshold = new Utils.NumberHolder(0.25);
+        const threshold = new NumberHolder(0.25);
         applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, null, false, threshold);
         return pokemon.getHpRatio() < 0.25 && !pokemon.getTag(BattlerTagType.CRIT_BOOST);
       };
     case BerryType.STARF:
       return (pokemon: Pokemon) => {
-        const threshold = new Utils.NumberHolder(0.25);
+        const threshold = new NumberHolder(0.25);
         applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, null, false, threshold);
         return pokemon.getHpRatio() < 0.25;
       };
     case BerryType.LEPPA:
       return (pokemon: Pokemon) => {
-        const threshold = new Utils.NumberHolder(0.25);
+        const threshold = new NumberHolder(0.25);
         applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, null, false, threshold);
         return !!pokemon.getMoveset().find(m => !m.getPpRatio());
       };
@@ -80,7 +80,7 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
         if (pokemon.battleData) {
           pokemon.battleData.berriesEaten.push(berryType);
         }
-        const hpHealed = new Utils.NumberHolder(Utils.toDmgValue(pokemon.getMaxHp() / 4));
+        const hpHealed = new NumberHolder(toDmgValue(pokemon.getMaxHp() / 4));
         applyAbAttrs(DoubleBerryEffectAbAttr, pokemon, null, false, hpHealed);
         globalScene.unshiftPhase(
           new PokemonHealPhase(
@@ -118,7 +118,7 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
         }
         // Offset BerryType such that LIECHI -> Stat.ATK = 1, GANLON -> Stat.DEF = 2, so on and so forth
         const stat: BattleStat = berryType - BerryType.ENIGMA;
-        const statStages = new Utils.NumberHolder(1);
+        const statStages = new NumberHolder(1);
         applyAbAttrs(DoubleBerryEffectAbAttr, pokemon, null, false, statStages);
         globalScene.unshiftPhase(new StatStageChangePhase(pokemon.getBattlerIndex(), true, [stat], statStages.value));
         applyPostItemLostAbAttrs(PostItemLostAbAttr, berryOwner ?? pokemon, false);
@@ -136,8 +136,8 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
         if (pokemon.battleData) {
           pokemon.battleData.berriesEaten.push(berryType);
         }
-        const randStat = Utils.randSeedInt(Stat.SPD, Stat.ATK);
-        const stages = new Utils.NumberHolder(2);
+        const randStat = randSeedInt(Stat.SPD, Stat.ATK);
+        const stages = new NumberHolder(2);
         applyAbAttrs(DoubleBerryEffectAbAttr, pokemon, null, false, stages);
         globalScene.unshiftPhase(new StatStageChangePhase(pokemon.getBattlerIndex(), true, [randStat], stages.value));
         applyPostItemLostAbAttrs(PostItemLostAbAttr, berryOwner ?? pokemon, false);

--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -1,4 +1,4 @@
-import * as Utils from "#app/utils";
+import { BooleanHolder, type NumberHolder, randSeedItem, deepCopy } from "#app/utils";
 import i18next from "i18next";
 import type { DexAttrProps, GameData } from "#app/system/game-data";
 import { defaultStarterSpecies } from "#app/system/game-data";
@@ -283,30 +283,30 @@ export abstract class Challenge {
   /**
    * An apply function for STARTER_CHOICE challenges. Derived classes should alter this.
    * @param _pokemon {@link PokemonSpecies} The pokemon to check the validity of.
-   * @param _valid {@link Utils.BooleanHolder} A BooleanHolder, the value gets set to false if the pokemon isn't allowed.
+   * @param _valid {@link BooleanHolder} A BooleanHolder, the value gets set to false if the pokemon isn't allowed.
    * @param _dexAttr {@link DexAttrProps} The dex attributes of the pokemon.
    * @returns {@link boolean} Whether this function did anything.
    */
-  applyStarterChoice(_pokemon: PokemonSpecies, _valid: Utils.BooleanHolder, _dexAttr: DexAttrProps): boolean {
+  applyStarterChoice(_pokemon: PokemonSpecies, _valid: BooleanHolder, _dexAttr: DexAttrProps): boolean {
     return false;
   }
 
   /**
    * An apply function for STARTER_POINTS challenges. Derived classes should alter this.
-   * @param _points {@link Utils.NumberHolder} The amount of points you have available.
+   * @param _points {@link NumberHolder} The amount of points you have available.
    * @returns {@link boolean} Whether this function did anything.
    */
-  applyStarterPoints(_points: Utils.NumberHolder): boolean {
+  applyStarterPoints(_points: NumberHolder): boolean {
     return false;
   }
 
   /**
    * An apply function for STARTER_COST challenges. Derived classes should alter this.
    * @param _species {@link Species} The pokemon to change the cost of.
-   * @param _cost {@link Utils.NumberHolder} The cost of the starter.
+   * @param _cost {@link NumberHolder} The cost of the starter.
    * @returns {@link boolean} Whether this function did anything.
    */
-  applyStarterCost(_species: Species, _cost: Utils.NumberHolder): boolean {
+  applyStarterCost(_species: Species, _cost: NumberHolder): boolean {
     return false;
   }
 
@@ -322,10 +322,10 @@ export abstract class Challenge {
   /**
    * An apply function for POKEMON_IN_BATTLE challenges. Derived classes should alter this.
    * @param _pokemon {@link Pokemon} The pokemon to check the validity of.
-   * @param _valid {@link Utils.BooleanHolder} A BooleanHolder, the value gets set to false if the pokemon isn't allowed.
+   * @param _valid {@link BooleanHolder} A BooleanHolder, the value gets set to false if the pokemon isn't allowed.
    * @returns {@link boolean} Whether this function did anything.
    */
-  applyPokemonInBattle(_pokemon: Pokemon, _valid: Utils.BooleanHolder): boolean {
+  applyPokemonInBattle(_pokemon: Pokemon, _valid: BooleanHolder): boolean {
     return false;
   }
 
@@ -341,42 +341,42 @@ export abstract class Challenge {
 
   /**
    * An apply function for TYPE_EFFECTIVENESS challenges. Derived classes should alter this.
-   * @param _effectiveness {@linkcode Utils.NumberHolder} The current effectiveness of the move.
+   * @param _effectiveness {@linkcode NumberHolder} The current effectiveness of the move.
    * @returns Whether this function did anything.
    */
-  applyTypeEffectiveness(_effectiveness: Utils.NumberHolder): boolean {
+  applyTypeEffectiveness(_effectiveness: NumberHolder): boolean {
     return false;
   }
 
   /**
    * An apply function for AI_LEVEL challenges. Derived classes should alter this.
-   * @param _level {@link Utils.NumberHolder} The generated level.
+   * @param _level {@link NumberHolder} The generated level.
    * @param _levelCap {@link Number} The current level cap.
    * @param _isTrainer {@link Boolean} Whether this is a trainer pokemon.
    * @param _isBoss {@link Boolean} Whether this is a non-trainer boss pokemon.
    * @returns {@link boolean} Whether this function did anything.
    */
-  applyLevelChange(_level: Utils.NumberHolder, _levelCap: number, _isTrainer: boolean, _isBoss: boolean): boolean {
+  applyLevelChange(_level: NumberHolder, _levelCap: number, _isTrainer: boolean, _isBoss: boolean): boolean {
     return false;
   }
 
   /**
    * An apply function for AI_MOVE_SLOTS challenges. Derived classes should alter this.
    * @param pokemon {@link Pokemon} The pokemon that is being considered.
-   * @param moveSlots {@link Utils.NumberHolder} The amount of move slots.
+   * @param moveSlots {@link NumberHolder} The amount of move slots.
    * @returns {@link boolean} Whether this function did anything.
    */
-  applyMoveSlot(_pokemon: Pokemon, _moveSlots: Utils.NumberHolder): boolean {
+  applyMoveSlot(_pokemon: Pokemon, _moveSlots: NumberHolder): boolean {
     return false;
   }
 
   /**
    * An apply function for PASSIVE_ACCESS challenges. Derived classes should alter this.
    * @param pokemon {@link Pokemon} The pokemon to change.
-   * @param hasPassive {@link Utils.BooleanHolder} Whether it should have its passive.
+   * @param hasPassive {@link BooleanHolder} Whether it should have its passive.
    * @returns {@link boolean} Whether this function did anything.
    */
-  applyPassiveAccess(_pokemon: Pokemon, _hasPassive: Utils.BooleanHolder): boolean {
+  applyPassiveAccess(_pokemon: Pokemon, _hasPassive: BooleanHolder): boolean {
     return false;
   }
 
@@ -393,15 +393,10 @@ export abstract class Challenge {
    * @param _pokemon {@link Pokemon} What pokemon would learn the move.
    * @param _moveSource {@link MoveSourceType} What source the pokemon would get the move from.
    * @param _move {@link Moves} The move in question.
-   * @param _level {@link Utils.NumberHolder} The level threshold for access.
+   * @param _level {@link NumberHolder} The level threshold for access.
    * @returns {@link boolean} Whether this function did anything.
    */
-  applyMoveAccessLevel(
-    _pokemon: Pokemon,
-    _moveSource: MoveSourceType,
-    _move: Moves,
-    _level: Utils.NumberHolder,
-  ): boolean {
+  applyMoveAccessLevel(_pokemon: Pokemon, _moveSource: MoveSourceType, _move: Moves, _level: NumberHolder): boolean {
     return false;
   }
 
@@ -410,10 +405,10 @@ export abstract class Challenge {
    * @param _pokemon {@link Pokemon} What pokemon would learn the move.
    * @param _moveSource {@link MoveSourceType} What source the pokemon would get the move from.
    * @param _move {@link Moves} The move in question.
-   * @param _weight {@link Utils.NumberHolder} The base weight of the move
+   * @param _weight {@link NumberHolder} The base weight of the move
    * @returns {@link boolean} Whether this function did anything.
    */
-  applyMoveWeight(_pokemon: Pokemon, _moveSource: MoveSourceType, _move: Moves, _level: Utils.NumberHolder): boolean {
+  applyMoveWeight(_pokemon: Pokemon, _moveSource: MoveSourceType, _move: Moves, _level: NumberHolder): boolean {
     return false;
   }
 
@@ -438,7 +433,7 @@ export class SingleGenerationChallenge extends Challenge {
     super(Challenges.SINGLE_GENERATION, 9);
   }
 
-  applyStarterChoice(pokemon: PokemonSpecies, valid: Utils.BooleanHolder): boolean {
+  applyStarterChoice(pokemon: PokemonSpecies, valid: BooleanHolder): boolean {
     if (pokemon.generation !== this.value) {
       valid.value = false;
       return true;
@@ -446,7 +441,7 @@ export class SingleGenerationChallenge extends Challenge {
     return false;
   }
 
-  applyPokemonInBattle(pokemon: Pokemon, valid: Utils.BooleanHolder): boolean {
+  applyPokemonInBattle(pokemon: Pokemon, valid: BooleanHolder): boolean {
     const baseGeneration = getPokemonSpecies(pokemon.species.speciesId).generation;
     const fusionGeneration = pokemon.isFusion() ? getPokemonSpecies(pokemon.fusionSpecies!.speciesId).generation : 0;
     if (
@@ -575,7 +570,7 @@ export class SingleGenerationChallenge extends Challenge {
           TrainerType.AARON,
           TrainerType.SHAUNTAL,
           TrainerType.MALVA,
-          Utils.randSeedItem([TrainerType.HALA, TrainerType.MOLAYNE]),
+          randSeedItem([TrainerType.HALA, TrainerType.MOLAYNE]),
           TrainerType.MARNIE_ELITE,
           TrainerType.RIKA,
         ];
@@ -602,7 +597,7 @@ export class SingleGenerationChallenge extends Challenge {
           TrainerType.GRIMSLEY,
           TrainerType.WIKSTROM,
           TrainerType.ACEROLA,
-          Utils.randSeedItem([TrainerType.BEA_ELITE, TrainerType.ALLISTER_ELITE]),
+          randSeedItem([TrainerType.BEA_ELITE, TrainerType.ALLISTER_ELITE]),
           TrainerType.LARRY_ELITE,
         ];
         break;
@@ -622,14 +617,14 @@ export class SingleGenerationChallenge extends Challenge {
       case ClassicFixedBossWaves.CHAMPION:
         trainerTypes = [
           TrainerType.BLUE,
-          Utils.randSeedItem([TrainerType.RED, TrainerType.LANCE_CHAMPION]),
-          Utils.randSeedItem([TrainerType.STEVEN, TrainerType.WALLACE]),
+          randSeedItem([TrainerType.RED, TrainerType.LANCE_CHAMPION]),
+          randSeedItem([TrainerType.STEVEN, TrainerType.WALLACE]),
           TrainerType.CYNTHIA,
-          Utils.randSeedItem([TrainerType.ALDER, TrainerType.IRIS]),
+          randSeedItem([TrainerType.ALDER, TrainerType.IRIS]),
           TrainerType.DIANTHA,
-          Utils.randSeedItem([TrainerType.KUKUI, TrainerType.HAU]),
-          Utils.randSeedItem([TrainerType.LEON, TrainerType.MUSTARD]),
-          Utils.randSeedItem([TrainerType.GEETA, TrainerType.NEMONA]),
+          randSeedItem([TrainerType.KUKUI, TrainerType.HAU]),
+          randSeedItem([TrainerType.LEON, TrainerType.MUSTARD]),
+          randSeedItem([TrainerType.GEETA, TrainerType.NEMONA]),
         ];
         break;
     }
@@ -718,7 +713,7 @@ export class SingleTypeChallenge extends Challenge {
     super(Challenges.SINGLE_TYPE, 18);
   }
 
-  override applyStarterChoice(pokemon: PokemonSpecies, valid: Utils.BooleanHolder, dexAttr: DexAttrProps): boolean {
+  override applyStarterChoice(pokemon: PokemonSpecies, valid: BooleanHolder, dexAttr: DexAttrProps): boolean {
     const speciesForm = getPokemonSpeciesForm(pokemon.speciesId, dexAttr.formIndex);
     const types = [speciesForm.type1, speciesForm.type2];
     if (!types.includes(this.value - 1)) {
@@ -728,7 +723,7 @@ export class SingleTypeChallenge extends Challenge {
     return false;
   }
 
-  applyPokemonInBattle(pokemon: Pokemon, valid: Utils.BooleanHolder): boolean {
+  applyPokemonInBattle(pokemon: Pokemon, valid: BooleanHolder): boolean {
     if (
       pokemon.isPlayer() &&
       !pokemon.isOfType(this.value - 1, false, false, true) &&
@@ -798,7 +793,7 @@ export class FreshStartChallenge extends Challenge {
     super(Challenges.FRESH_START, 1);
   }
 
-  applyStarterChoice(pokemon: PokemonSpecies, valid: Utils.BooleanHolder): boolean {
+  applyStarterChoice(pokemon: PokemonSpecies, valid: BooleanHolder): boolean {
     if (!defaultStarterSpecies.includes(pokemon.speciesId)) {
       valid.value = false;
       return true;
@@ -806,7 +801,7 @@ export class FreshStartChallenge extends Challenge {
     return false;
   }
 
-  applyStarterCost(species: Species, cost: Utils.NumberHolder): boolean {
+  applyStarterCost(species: Species, cost: NumberHolder): boolean {
     if (defaultStarterSpecies.includes(species)) {
       cost.value = speciesStarterCosts[species];
       return true;
@@ -864,7 +859,7 @@ export class InverseBattleChallenge extends Challenge {
     return 0;
   }
 
-  applyTypeEffectiveness(effectiveness: Utils.NumberHolder): boolean {
+  applyTypeEffectiveness(effectiveness: NumberHolder): boolean {
     if (effectiveness.value < 1) {
       effectiveness.value = 2;
       return true;
@@ -887,7 +882,7 @@ export class FlipStatChallenge extends Challenge {
   }
 
   override applyFlipStat(_pokemon: Pokemon, baseStats: number[]) {
-    const origStats = Utils.deepCopy(baseStats);
+    const origStats = deepCopy(baseStats);
     baseStats[0] = origStats[5];
     baseStats[1] = origStats[4];
     baseStats[2] = origStats[3];
@@ -923,7 +918,7 @@ export class LowerStarterMaxCostChallenge extends Challenge {
     return (DEFAULT_PARTY_MAX_COST - overrideValue).toString();
   }
 
-  applyStarterChoice(pokemon: PokemonSpecies, valid: Utils.BooleanHolder): boolean {
+  applyStarterChoice(pokemon: PokemonSpecies, valid: BooleanHolder): boolean {
     if (speciesStarterCosts[pokemon.speciesId] > DEFAULT_PARTY_MAX_COST - this.value) {
       valid.value = false;
       return true;
@@ -957,7 +952,7 @@ export class LowerStarterPointsChallenge extends Challenge {
     return (DEFAULT_PARTY_MAX_COST - overrideValue).toString();
   }
 
-  applyStarterPoints(points: Utils.NumberHolder): boolean {
+  applyStarterPoints(points: NumberHolder): boolean {
     points.value -= this.value;
     return true;
   }
@@ -974,34 +969,34 @@ export class LowerStarterPointsChallenge extends Challenge {
  * Apply all challenges that modify starter choice.
  * @param challengeType {@link ChallengeType} ChallengeType.STARTER_CHOICE
  * @param pokemon {@link PokemonSpecies} The pokemon to check the validity of.
- * @param valid {@link Utils.BooleanHolder} A BooleanHolder, the value gets set to false if the pokemon isn't allowed.
+ * @param valid {@link BooleanHolder} A BooleanHolder, the value gets set to false if the pokemon isn't allowed.
  * @param dexAttr {@link DexAttrProps} The dex attributes of the pokemon.
  * @returns True if any challenge was successfully applied.
  */
 export function applyChallenges(
   challengeType: ChallengeType.STARTER_CHOICE,
   pokemon: PokemonSpecies,
-  valid: Utils.BooleanHolder,
+  valid: BooleanHolder,
   dexAttr: DexAttrProps,
 ): boolean;
 /**
  * Apply all challenges that modify available total starter points.
  * @param challengeType {@link ChallengeType} ChallengeType.STARTER_POINTS
- * @param points {@link Utils.NumberHolder} The amount of points you have available.
+ * @param points {@link NumberHolder} The amount of points you have available.
  * @returns True if any challenge was successfully applied.
  */
-export function applyChallenges(challengeType: ChallengeType.STARTER_POINTS, points: Utils.NumberHolder): boolean;
+export function applyChallenges(challengeType: ChallengeType.STARTER_POINTS, points: NumberHolder): boolean;
 /**
  * Apply all challenges that modify the cost of a starter.
  * @param challengeType {@link ChallengeType} ChallengeType.STARTER_COST
  * @param species {@link Species} The pokemon to change the cost of.
- * @param points {@link Utils.NumberHolder} The cost of the pokemon.
+ * @param points {@link NumberHolder} The cost of the pokemon.
  * @returns True if any challenge was successfully applied.
  */
 export function applyChallenges(
   challengeType: ChallengeType.STARTER_COST,
   species: Species,
-  cost: Utils.NumberHolder,
+  cost: NumberHolder,
 ): boolean;
 /**
  * Apply all challenges that modify a starter after selection.
@@ -1014,13 +1009,13 @@ export function applyChallenges(challengeType: ChallengeType.STARTER_MODIFY, pok
  * Apply all challenges that what pokemon you can have in battle.
  * @param challengeType {@link ChallengeType} ChallengeType.POKEMON_IN_BATTLE
  * @param pokemon {@link Pokemon} The pokemon to check the validity of.
- * @param valid {@link Utils.BooleanHolder} A BooleanHolder, the value gets set to false if the pokemon isn't allowed.
+ * @param valid {@link BooleanHolder} A BooleanHolder, the value gets set to false if the pokemon isn't allowed.
  * @returns True if any challenge was successfully applied.
  */
 export function applyChallenges(
   challengeType: ChallengeType.POKEMON_IN_BATTLE,
   pokemon: Pokemon,
-  valid: Utils.BooleanHolder,
+  valid: BooleanHolder,
 ): boolean;
 /**
  * Apply all challenges that modify what fixed battles there are.
@@ -1037,17 +1032,14 @@ export function applyChallenges(
 /**
  * Apply all challenges that modify type effectiveness.
  * @param challengeType {@linkcode ChallengeType} ChallengeType.TYPE_EFFECTIVENESS
- * @param effectiveness {@linkcode Utils.NumberHolder} The current effectiveness of the move.
+ * @param effectiveness {@linkcode NumberHolder} The current effectiveness of the move.
  * @returns True if any challenge was successfully applied.
  */
-export function applyChallenges(
-  challengeType: ChallengeType.TYPE_EFFECTIVENESS,
-  effectiveness: Utils.NumberHolder,
-): boolean;
+export function applyChallenges(challengeType: ChallengeType.TYPE_EFFECTIVENESS, effectiveness: NumberHolder): boolean;
 /**
  * Apply all challenges that modify what level AI are.
  * @param challengeType {@link ChallengeType} ChallengeType.AI_LEVEL
- * @param level {@link Utils.NumberHolder} The generated level of the pokemon.
+ * @param level {@link NumberHolder} The generated level of the pokemon.
  * @param levelCap {@link Number} The maximum level cap for the current wave.
  * @param isTrainer {@link Boolean} Whether this is a trainer pokemon.
  * @param isBoss {@link Boolean} Whether this is a non-trainer boss pokemon.
@@ -1055,7 +1047,7 @@ export function applyChallenges(
  */
 export function applyChallenges(
   challengeType: ChallengeType.AI_LEVEL,
-  level: Utils.NumberHolder,
+  level: NumberHolder,
   levelCap: number,
   isTrainer: boolean,
   isBoss: boolean,
@@ -1064,25 +1056,25 @@ export function applyChallenges(
  * Apply all challenges that modify how many move slots the AI has.
  * @param challengeType {@link ChallengeType} ChallengeType.AI_MOVE_SLOTS
  * @param pokemon {@link Pokemon} The pokemon being considered.
- * @param moveSlots {@link Utils.NumberHolder} The amount of move slots.
+ * @param moveSlots {@link NumberHolder} The amount of move slots.
  * @returns True if any challenge was successfully applied.
  */
 export function applyChallenges(
   challengeType: ChallengeType.AI_MOVE_SLOTS,
   pokemon: Pokemon,
-  moveSlots: Utils.NumberHolder,
+  moveSlots: NumberHolder,
 ): boolean;
 /**
  * Apply all challenges that modify whether a pokemon has its passive.
  * @param challengeType {@link ChallengeType} ChallengeType.PASSIVE_ACCESS
  * @param pokemon {@link Pokemon} The pokemon to modify.
- * @param hasPassive {@link Utils.BooleanHolder} Whether it has its passive.
+ * @param hasPassive {@link BooleanHolder} Whether it has its passive.
  * @returns True if any challenge was successfully applied.
  */
 export function applyChallenges(
   challengeType: ChallengeType.PASSIVE_ACCESS,
   pokemon: Pokemon,
-  hasPassive: Utils.BooleanHolder,
+  hasPassive: BooleanHolder,
 ): boolean;
 /**
  * Apply all challenges that modify the game modes settings.
@@ -1096,7 +1088,7 @@ export function applyChallenges(challengeType: ChallengeType.GAME_MODE_MODIFY): 
  * @param pokemon {@link Pokemon} What pokemon would learn the move.
  * @param moveSource {@link MoveSourceType} What source the pokemon would get the move from.
  * @param move {@link Moves} The move in question.
- * @param level {@link Utils.NumberHolder} The level threshold for access.
+ * @param level {@link NumberHolder} The level threshold for access.
  * @returns True if any challenge was successfully applied.
  */
 export function applyChallenges(
@@ -1104,7 +1096,7 @@ export function applyChallenges(
   pokemon: Pokemon,
   moveSource: MoveSourceType,
   move: Moves,
-  level: Utils.NumberHolder,
+  level: NumberHolder,
 ): boolean;
 /**
  * Apply all challenges that modify what weight a pokemon gives to move generation
@@ -1112,7 +1104,7 @@ export function applyChallenges(
  * @param pokemon {@link Pokemon} What pokemon would learn the move.
  * @param moveSource {@link MoveSourceType} What source the pokemon would get the move from.
  * @param move {@link Moves} The move in question.
- * @param weight {@link Utils.NumberHolder} The weight of the move.
+ * @param weight {@link NumberHolder} The weight of the move.
  * @returns True if any challenge was successfully applied.
  */
 export function applyChallenges(
@@ -1120,7 +1112,7 @@ export function applyChallenges(
   pokemon: Pokemon,
   moveSource: MoveSourceType,
   move: Moves,
-  weight: Utils.NumberHolder,
+  weight: NumberHolder,
 ): boolean;
 
 export function applyChallenges(challengeType: ChallengeType.FLIP_STAT, pokemon: Pokemon, baseStats: number[]): boolean;
@@ -1225,7 +1217,7 @@ export function initChallenges() {
  */
 export function checkStarterValidForChallenge(species: PokemonSpecies, props: DexAttrProps, soft: boolean) {
   if (!soft) {
-    const isValidForChallenge = new Utils.BooleanHolder(true);
+    const isValidForChallenge = new BooleanHolder(true);
     applyChallenges(ChallengeType.STARTER_CHOICE, species, isValidForChallenge, props);
     return isValidForChallenge.value;
   }
@@ -1263,7 +1255,7 @@ export function checkStarterValidForChallenge(species: PokemonSpecies, props: De
  * @returns `true` if the species is considered valid.
  */
 function checkSpeciesValidForChallenge(species: PokemonSpecies, props: DexAttrProps, soft: boolean) {
-  const isValidForChallenge = new Utils.BooleanHolder(true);
+  const isValidForChallenge = new BooleanHolder(true);
   applyChallenges(ChallengeType.STARTER_CHOICE, species, isValidForChallenge, props);
   if (!soft || !pokemonFormChanges.hasOwnProperty(species.speciesId)) {
     return isValidForChallenge.value;
@@ -1282,7 +1274,7 @@ function checkSpeciesValidForChallenge(species: PokemonSpecies, props: DexAttrPr
     return species.forms.some((f2, formIndex) => {
       if (f1.formKey === f2.formKey) {
         const formProps = { ...props, formIndex };
-        const isFormValidForChallenge = new Utils.BooleanHolder(true);
+        const isFormValidForChallenge = new BooleanHolder(true);
         applyChallenges(ChallengeType.STARTER_CHOICE, species, isFormValidForChallenge, formProps);
         return isFormValidForChallenge.value;
       }

--- a/src/data/daily-run.ts
+++ b/src/data/daily-run.ts
@@ -3,7 +3,7 @@ import type { Species } from "#enums/species";
 import { globalScene } from "#app/global-scene";
 import { PlayerPokemon } from "#app/field/pokemon";
 import type { Starter } from "#app/ui/starter-select-ui-handler";
-import * as Utils from "#app/utils";
+import { randSeedGauss, randSeedInt, randSeedItem, getEnumValues } from "#app/utils";
 import type { PokemonSpeciesForm } from "#app/data/pokemon-species";
 import PokemonSpecies, { getPokemonSpecies, getPokemonSpeciesForm } from "#app/data/pokemon-species";
 import { speciesStarterCosts } from "#app/data/balance/starters";
@@ -43,8 +43,8 @@ export function getDailyRunStarters(seed: string): Starter[] {
       }
 
       const starterCosts: number[] = [];
-      starterCosts.push(Math.min(Math.round(3.5 + Math.abs(Utils.randSeedGauss(1))), 8));
-      starterCosts.push(Utils.randSeedInt(9 - starterCosts[0], 1));
+      starterCosts.push(Math.min(Math.round(3.5 + Math.abs(randSeedGauss(1))), 8));
+      starterCosts.push(randSeedInt(9 - starterCosts[0], 1));
       starterCosts.push(10 - (starterCosts[0] + starterCosts[1]));
 
       for (let c = 0; c < starterCosts.length; c++) {
@@ -52,7 +52,7 @@ export function getDailyRunStarters(seed: string): Starter[] {
         const costSpecies = Object.keys(speciesStarterCosts)
           .map(s => Number.parseInt(s) as Species)
           .filter(s => speciesStarterCosts[s] === cost);
-        const randPkmSpecies = getPokemonSpecies(Utils.randSeedItem(costSpecies));
+        const randPkmSpecies = getPokemonSpecies(randSeedItem(costSpecies));
         const starterSpecies = getPokemonSpecies(
           randPkmSpecies.getTrainerSpeciesForLevel(startingLevel, true, PartyMemberStrength.STRONGER),
         );
@@ -143,7 +143,7 @@ const dailyBiomeWeights: BiomeWeights = {
 };
 
 export function getDailyStartingBiome(): Biome {
-  const biomes = Utils.getEnumValues(Biome).filter(b => b !== Biome.TOWN && b !== Biome.END);
+  const biomes = getEnumValues(Biome).filter(b => b !== Biome.TOWN && b !== Biome.END);
 
   let totalWeight = 0;
   const biomeThresholds: number[] = [];
@@ -155,7 +155,7 @@ export function getDailyStartingBiome(): Biome {
     biomeThresholds.push(totalWeight);
   }
 
-  const randInt = Utils.randSeedInt(totalWeight);
+  const randInt = randSeedInt(totalWeight);
 
   for (let i = 0; i < biomes.length; i++) {
     if (randInt < biomeThresholds[i]) {
@@ -164,5 +164,5 @@ export function getDailyStartingBiome(): Biome {
   }
 
   // Fallback in case something went wrong
-  return biomes[Utils.randSeedInt(biomes.length)];
+  return biomes[randSeedInt(biomes.length)];
 }

--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -4,7 +4,7 @@ import type PokemonSpecies from "#app/data/pokemon-species";
 import { getPokemonSpecies } from "#app/data/pokemon-species";
 import { speciesStarterCosts } from "#app/data/balance/starters";
 import { VariantTier } from "#enums/variant-tier";
-import * as Utils from "#app/utils";
+import { randInt, randomString, randSeedInt, getIvsFromId } from "#app/utils";
 import Overrides from "#app/overrides";
 import { pokemonPrevolutions } from "#app/data/balance/pokemon-evolutions";
 import type { PlayerPokemon } from "#app/field/pokemon";
@@ -171,7 +171,7 @@ export class Egg {
         this.checkForPityTierOverrides();
       }
 
-      this._id = eggOptions?.id ?? Utils.randInt(EGG_SEED, EGG_SEED * this._tier);
+      this._id = eggOptions?.id ?? randInt(EGG_SEED, EGG_SEED * this._tier);
 
       this._sourceType = eggOptions?.sourceType ?? undefined;
       this._hatchWaves = eggOptions?.hatchWaves ?? this.getEggTierDefaultHatchWaves();
@@ -203,7 +203,7 @@ export class Egg {
       }
     };
 
-    const seedOverride = Utils.randomString(24);
+    const seedOverride = randomString(24);
     globalScene.executeWithSeedOffset(
       () => {
         generateEggProperties(eggOptions);
@@ -248,18 +248,15 @@ export class Egg {
       let pokemonSpecies = getPokemonSpecies(this._species);
       // Special condition to have Phione eggs also have a chance of generating Manaphy
       if (this._species === Species.PHIONE && this._sourceType === EggSourceType.SAME_SPECIES_EGG) {
-        pokemonSpecies = getPokemonSpecies(
-          Utils.randSeedInt(MANAPHY_EGG_MANAPHY_RATE) ? Species.PHIONE : Species.MANAPHY,
-        );
+        pokemonSpecies = getPokemonSpecies(randSeedInt(MANAPHY_EGG_MANAPHY_RATE) ? Species.PHIONE : Species.MANAPHY);
       }
 
       // Sets the hidden ability if a hidden ability exists and
       // the override is set or the egg hits the chance
       let abilityIndex: number | undefined = undefined;
       const sameSpeciesEggHACheck =
-        this._sourceType === EggSourceType.SAME_SPECIES_EGG && !Utils.randSeedInt(SAME_SPECIES_EGG_HA_RATE);
-      const gachaEggHACheck =
-        !(this._sourceType === EggSourceType.SAME_SPECIES_EGG) && !Utils.randSeedInt(GACHA_EGG_HA_RATE);
+        this._sourceType === EggSourceType.SAME_SPECIES_EGG && !randSeedInt(SAME_SPECIES_EGG_HA_RATE);
+      const gachaEggHACheck = !(this._sourceType === EggSourceType.SAME_SPECIES_EGG) && !randSeedInt(GACHA_EGG_HA_RATE);
       if (pokemonSpecies.abilityHidden && (this._overrideHiddenAbility || sameSpeciesEggHACheck || gachaEggHACheck)) {
         abilityIndex = 2;
       }
@@ -269,7 +266,7 @@ export class Egg {
       ret.shiny = this._isShiny;
       ret.variant = this._variantTier;
 
-      const secondaryIvs = Utils.getIvsFromId(Utils.randSeedInt(4294967295));
+      const secondaryIvs = getIvsFromId(randSeedInt(4294967295));
 
       for (let s = 0; s < ret.ivs.length; s++) {
         ret.ivs[s] = Math.max(ret.ivs[s], secondaryIvs[s]);
@@ -370,7 +367,7 @@ export class Egg {
     }
 
     const tierMultiplier = this.isManaphyEgg() ? 2 : Math.pow(2, 3 - this.tier);
-    return Utils.randSeedInt(baseChance * tierMultiplier) ? Utils.randSeedInt(3) : 3;
+    return randSeedInt(baseChance * tierMultiplier) ? randSeedInt(3) : 3;
   }
 
   private getEggTierDefaultHatchWaves(eggTier?: EggTier): number {
@@ -392,7 +389,7 @@ export class Egg {
   private rollEggTier(): EggTier {
     const tierValueOffset =
       this._sourceType === EggSourceType.GACHA_LEGENDARY ? GACHA_LEGENDARY_UP_THRESHOLD_OFFSET : 0;
-    const tierValue = Utils.randInt(256);
+    const tierValue = randInt(256);
     return tierValue >= GACHA_DEFAULT_COMMON_EGG_THRESHOLD + tierValueOffset
       ? EggTier.COMMON
       : tierValue >= GACHA_DEFAULT_RARE_EGG_THRESHOLD + tierValueOffset
@@ -417,11 +414,11 @@ export class Egg {
        * when Utils.randSeedInt(8) = 1, and by making the generatePlayerPokemon() species
        * check pass when Utils.randSeedInt(8) = 0, we can tell them apart during tests.
        */
-      const rand = Utils.randSeedInt(MANAPHY_EGG_MANAPHY_RATE) !== 1;
+      const rand = randSeedInt(MANAPHY_EGG_MANAPHY_RATE) !== 1;
       return rand ? Species.PHIONE : Species.MANAPHY;
     }
     if (this.tier === EggTier.LEGENDARY && this._sourceType === EggSourceType.GACHA_LEGENDARY) {
-      if (!Utils.randSeedInt(2)) {
+      if (!randSeedInt(2)) {
         return getLegendaryGachaSpeciesForTimestamp(this.timestamp);
       }
     }
@@ -501,7 +498,7 @@ export class Egg {
 
     let species: Species;
 
-    const rand = Utils.randSeedInt(totalWeight);
+    const rand = randSeedInt(totalWeight);
     for (let s = 0; s < speciesWeights.length; s++) {
       if (rand < speciesWeights[s]) {
         species = speciesPool[s];
@@ -539,7 +536,7 @@ export class Egg {
         break;
     }
 
-    return !Utils.randSeedInt(shinyChance);
+    return !randSeedInt(shinyChance);
   }
 
   // Uses the same logic as pokemon.generateVariant(). I would like to only have this logic in one
@@ -550,7 +547,7 @@ export class Egg {
       return VariantTier.STANDARD;
     }
 
-    const rand = Utils.randSeedInt(10);
+    const rand = randSeedInt(10);
     if (rand >= SHINY_VARIANT_CHANCE) {
       return VariantTier.STANDARD; // 6/10
     }

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -29,9 +29,7 @@ import {
 } from "../status-effect";
 import { getTypeDamageMultiplier } from "../type";
 import { PokemonType } from "#enums/pokemon-type";
-import type { Constructor } from "#app/utils";
-import { NumberHolder } from "#app/utils";
-import * as Utils from "../../utils";
+import { BooleanHolder, NumberHolder, isNullOrUndefined, toDmgValue, randSeedItem, randSeedInt, getEnumValues, toReadableString, type Constructor } from "#app/utils";
 import { WeatherType } from "#enums/weather-type";
 import type { ArenaTrapTag } from "../arena-tag";
 import { ArenaTagSide, WeakenMoveTypeTag } from "../arena-tag";
@@ -352,7 +350,7 @@ export default class Move implements Localizable {
       return false;
     }
 
-    const bypassed = new Utils.BooleanHolder(false);
+    const bypassed = new BooleanHolder(false);
     // TODO: Allow this to be simulated
     applyAbAttrs(InfiltratorAbAttr, user, null, false, bypassed);
 
@@ -651,7 +649,7 @@ export default class Move implements Localizable {
         break;
       case MoveFlags.IGNORE_ABILITIES:
         if (user.hasAbilityWithAttr(MoveAbilityBypassAbAttr)) {
-          const abilityEffectsIgnored = new Utils.BooleanHolder(false); 
+          const abilityEffectsIgnored = new BooleanHolder(false); 
           applyAbAttrs(MoveAbilityBypassAbAttr, user, abilityEffectsIgnored, false, this);
           if (abilityEffectsIgnored.value) {
             return true;
@@ -755,7 +753,7 @@ export default class Move implements Localizable {
    * @returns The calculated accuracy of the move.
    */
   calculateBattleAccuracy(user: Pokemon, target: Pokemon, simulated: boolean = false) {
-    const moveAccuracy = new Utils.NumberHolder(this.accuracy);
+    const moveAccuracy = new NumberHolder(this.accuracy);
 
     applyMoveAttrs(VariableAccuracyAttr, user, target, this, moveAccuracy);
     applyPreDefendAbAttrs(WonderSkinAbAttr, target, user, this, { value: false }, simulated, moveAccuracy);
@@ -797,8 +795,8 @@ export default class Move implements Localizable {
       return -1;
     }
 
-    const power = new Utils.NumberHolder(this.power);
-    const typeChangeMovePowerMultiplier = new Utils.NumberHolder(1);
+    const power = new NumberHolder(this.power);
+    const typeChangeMovePowerMultiplier = new NumberHolder(1);
 
     applyPreAttackAbAttrs(MoveTypeChangeAbAttr, source, target, this, true, null, typeChangeMovePowerMultiplier);
 
@@ -809,7 +807,7 @@ export default class Move implements Localizable {
 
     applyPreAttackAbAttrs(VariableMovePowerAbAttr, source, target, this, simulated, power);
     const ally = source.getAlly();
-    if (!Utils.isNullOrUndefined(ally)) {
+    if (!isNullOrUndefined(ally)) {
       applyPreAttackAbAttrs(AllyMoveCategoryPowerBoostAbAttr, ally, target, this, simulated, power);
     }
 
@@ -850,7 +848,7 @@ export default class Move implements Localizable {
   }
 
   getPriority(user: Pokemon, simulated: boolean = true) {
-    const priority = new Utils.NumberHolder(this.priority);
+    const priority = new NumberHolder(this.priority);
 
     applyMoveAttrs(IncrementMovePriorityAttr, user, null, this, priority);
     applyAbAttrs(ChangeMovePriorityAbAttr, user, null, simulated, this, priority);
@@ -932,7 +930,7 @@ export default class Move implements Localizable {
 
     // ...and cannot enhance Pollen Puff when targeting an ally.
     const ally = user.getAlly();
-    const exceptPollenPuffAlly: boolean = this.id === Moves.POLLEN_PUFF && !Utils.isNullOrUndefined(ally) && targets.includes(ally.getBattlerIndex())
+    const exceptPollenPuffAlly: boolean = this.id === Moves.POLLEN_PUFF && !isNullOrUndefined(ally) && targets.includes(ally.getBattlerIndex())
 
     return (!restrictSpread || !isMultiTarget)
       && !this.isChargingMove()
@@ -971,7 +969,7 @@ export class AttackMove extends Move {
     const effectiveness = target.getAttackTypeEffectiveness(this.type, user, undefined, undefined, this);
     attackScore = Math.pow(effectiveness - 1, 2) * (effectiveness < 1 ? -2 : 2);
     const [ thisStat, offStat ]: EffectiveStat[] = this.category === MoveCategory.PHYSICAL ? [ Stat.ATK, Stat.SPATK ] : [ Stat.SPATK, Stat.ATK ];
-    const statHolder = new Utils.NumberHolder(user.getEffectiveStat(thisStat, target));
+    const statHolder = new NumberHolder(user.getEffectiveStat(thisStat, target));
     const offStatValue = user.getEffectiveStat(offStat, target);
     applyMoveAttrs(VariableAtkAttr, user, target, move, statHolder);
     const statRatio = offStatValue / statHolder.value;
@@ -981,7 +979,7 @@ export class AttackMove extends Move {
       attackScore *= 1.5;
     }
 
-    const power = new Utils.NumberHolder(this.calculateEffectivePower());
+    const power = new NumberHolder(this.calculateEffectivePower());
     applyMoveAttrs(VariablePowerAttr, user, target, move, power);
 
     attackScore += Math.floor(power.value / 5);
@@ -1252,7 +1250,7 @@ export class MoveEffectAttr extends MoveAttr {
    * @returns Move effect chance value.
    */
   getMoveChance(user: Pokemon, target: Pokemon, move: Move, selfEffect?: Boolean, showAbility?: Boolean): number {
-    const moveChance = new Utils.NumberHolder(this.effectChanceOverride ?? move.chance);
+    const moveChance = new NumberHolder(this.effectChanceOverride ?? move.chance);
 
     applyAbAttrs(MoveEffectChanceMultiplierAbAttr, user, null, !showAbility, moveChance, move);
 
@@ -1415,7 +1413,7 @@ export class RespectAttackTypeImmunityAttr extends MoveAttr { }
 
 export class IgnoreOpponentStatStagesAttr extends MoveAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    (args[0] as Utils.BooleanHolder).value = true;
+    (args[0] as BooleanHolder).value = true;
 
     return true;
   }
@@ -1423,7 +1421,7 @@ export class IgnoreOpponentStatStagesAttr extends MoveAttr {
 
 export class HighCritAttr extends MoveAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    (args[0] as Utils.NumberHolder).value++;
+    (args[0] as NumberHolder).value++;
 
     return true;
   }
@@ -1435,7 +1433,7 @@ export class HighCritAttr extends MoveAttr {
 
 export class CritOnlyAttr extends MoveAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    (args[0] as Utils.BooleanHolder).value = true;
+    (args[0] as BooleanHolder).value = true;
 
     return true;
   }
@@ -1455,7 +1453,7 @@ export class FixedDamageAttr extends MoveAttr {
   }
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    (args[0] as Utils.NumberHolder).value = this.getDamage(user, target, move);
+    (args[0] as NumberHolder).value = this.getDamage(user, target, move);
 
     return true;
   }
@@ -1471,7 +1469,7 @@ export class UserHpDamageAttr extends FixedDamageAttr {
   }
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    (args[0] as Utils.NumberHolder).value = user.hp;
+    (args[0] as NumberHolder).value = user.hp;
 
     return true;
   }
@@ -1492,7 +1490,7 @@ export class TargetHalfHpDamageAttr extends FixedDamageAttr {
     const lensCount = user.getHeldItems().find(i => i instanceof PokemonMultiHitModifier)?.getStackCount() ?? 0;
     if (lensCount <= 0) {
       // no multi lenses; we can just halve the target's hp and call it a day
-      (args[0] as Utils.NumberHolder).value = Utils.toDmgValue(target.hp / 2);
+      (args[0] as NumberHolder).value = toDmgValue(target.hp / 2);
       return true;
     }
 
@@ -1503,11 +1501,11 @@ export class TargetHalfHpDamageAttr extends FixedDamageAttr {
         this.initialHp = target.hp;
       default:
         // multi lens added hit; use initialHp tracker to ensure correct damage
-        (args[0] as Utils.NumberHolder).value = Utils.toDmgValue(this.initialHp / 2);
+        (args[0] as NumberHolder).value = toDmgValue(this.initialHp / 2);
         return true;
       case lensCount + 1:
         // parental bond added hit; calc damage as normal
-        (args[0] as Utils.NumberHolder).value = Utils.toDmgValue(target.hp / 2);
+        (args[0] as NumberHolder).value = toDmgValue(target.hp / 2);
         return true;
     }
   }
@@ -1523,7 +1521,7 @@ export class MatchHpAttr extends FixedDamageAttr {
   }
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    (args[0] as Utils.NumberHolder).value = target.hp - user.hp;
+    (args[0] as NumberHolder).value = target.hp - user.hp;
 
     return true;
   }
@@ -1553,7 +1551,7 @@ export class CounterDamageAttr extends FixedDamageAttr {
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const damage = user.turnData.attacksReceived.filter(ar => this.moveFilter(allMoves[ar.move])).reduce((total: number, ar: AttackMoveResult) => total + ar.damage, 0);
-    (args[0] as Utils.NumberHolder).value = Utils.toDmgValue(damage * this.multiplier);
+    (args[0] as NumberHolder).value = toDmgValue(damage * this.multiplier);
 
     return true;
   }
@@ -1579,13 +1577,13 @@ export class RandomLevelDamageAttr extends FixedDamageAttr {
   }
 
   getDamage(user: Pokemon, target: Pokemon, move: Move): number {
-    return Utils.toDmgValue(user.level * (user.randSeedIntRange(50, 150) * 0.01));
+    return toDmgValue(user.level * (user.randSeedIntRange(50, 150) * 0.01));
   }
 }
 
 export class ModifiedDamageAttr extends MoveAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const initialDamage = args[0] as Utils.NumberHolder;
+    const initialDamage = args[0] as NumberHolder;
     initialDamage.value = this.getModifiedDamage(user, target, move, initialDamage.value);
 
     return true;
@@ -1638,7 +1636,7 @@ export class RecoilAttr extends MoveEffectAttr {
       return false;
     }
 
-    const cancelled = new Utils.BooleanHolder(false);
+    const cancelled = new BooleanHolder(false);
     if (!this.unblockable) {
       applyAbAttrs(BlockRecoilDamageAttr, user, cancelled);
       applyAbAttrs(BlockNonDirectDamageAbAttr, user, cancelled);
@@ -1655,7 +1653,7 @@ export class RecoilAttr extends MoveEffectAttr {
 
     const damageValue = (!this.useHp ? user.turnData.totalDamageDealt : user.getMaxHp()) * this.damageRatio;
     const minValue = user.turnData.totalDamageDealt ? 1 : 0;
-    const recoilDamage = Utils.toDmgValue(damageValue, minValue);
+    const recoilDamage = toDmgValue(damageValue, minValue);
     if (!recoilDamage) {
       return false;
     }
@@ -1772,11 +1770,11 @@ export class HalfSacrificialAttr extends MoveEffectAttr {
       return false;
     }
 
-    const cancelled = new Utils.BooleanHolder(false);
+    const cancelled = new BooleanHolder(false);
     // Check to see if the Pokemon has an ability that blocks non-direct damage
     applyAbAttrs(BlockNonDirectDamageAbAttr, user, cancelled);
     if (!cancelled.value) {
-      user.damageAndUpdate(Utils.toDmgValue(user.getMaxHp() / 2), { result: HitResult.INDIRECT, ignoreSegments: true });
+      user.damageAndUpdate(toDmgValue(user.getMaxHp() / 2), { result: HitResult.INDIRECT, ignoreSegments: true });
       globalScene.queueMessage(i18next.t("moveTriggers:cutHpPowerUpMove", { pokemonName: getPokemonNameWithAffix(user) })); // Queue recoil message
     }
     return true;
@@ -1882,7 +1880,7 @@ export class HealAttr extends MoveEffectAttr {
    */
   addHealPhase(target: Pokemon, healRatio: number) {
     globalScene.unshiftPhase(new PokemonHealPhase(target.getBattlerIndex(),
-      Utils.toDmgValue(target.getMaxHp() * healRatio), i18next.t("moveTriggers:healHp", { pokemonName: getPokemonNameWithAffix(target) }), true, !this.showAnim));
+      toDmgValue(target.getMaxHp() * healRatio), i18next.t("moveTriggers:healHp", { pokemonName: getPokemonNameWithAffix(target) }), true, !this.showAnim));
   }
 
   getTargetBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
@@ -1965,9 +1963,9 @@ export class FlameBurstAttr extends MoveEffectAttr {
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const targetAlly = target.getAlly();
-    const cancelled = new Utils.BooleanHolder(false);
+    const cancelled = new BooleanHolder(false);
 
-    if (!Utils.isNullOrUndefined(targetAlly)) {
+    if (!isNullOrUndefined(targetAlly)) {
       applyAbAttrs(BlockNonDirectDamageAbAttr, targetAlly, cancelled);
     }
 
@@ -1980,7 +1978,7 @@ export class FlameBurstAttr extends MoveEffectAttr {
   }
 
   getTargetBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
-    return !Utils.isNullOrUndefined(target.getAlly()) ? -5 : 0;
+    return !isNullOrUndefined(target.getAlly()) ? -5 : 0;
   }
 }
 
@@ -2048,11 +2046,11 @@ export class IgnoreWeatherTypeDebuffAttr extends MoveAttr {
    * @param user {@linkcode Pokemon} that used the move
    * @param target N/A
    * @param move {@linkcode Move} with this attribute
-   * @param args [0] {@linkcode Utils.NumberHolder} for arenaAttackTypeMultiplier
+   * @param args [0] {@linkcode NumberHolder} for arenaAttackTypeMultiplier
    * @returns true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const weatherModifier = args[0] as Utils.NumberHolder;
+    const weatherModifier = args[0] as NumberHolder;
     //If the type-based attack power modifier due to weather (e.g. Water moves in Sun) is below 1, set it to 1
     if (globalScene.arena.weather?.weatherType === this.weather) {
       weatherModifier.value = Math.max(weatherModifier.value, 1);
@@ -2203,7 +2201,7 @@ export class HitHealAttr extends MoveEffectAttr {
       message = i18next.t("battle:drainMessage", { pokemonName: getPokemonNameWithAffix(target) });
     } else {
       // Default healing formula used by draining moves like Absorb, Draining Kiss, Bitter Blade, etc.
-      healAmount = Utils.toDmgValue(user.turnData.singleHitDamageDealt * this.healRatio);
+      healAmount = toDmgValue(user.turnData.singleHitDamageDealt * this.healRatio);
       message = i18next.t("battle:regainHealth", { pokemonName: getPokemonNameWithAffix(user) });
     }
     if (reverseDrain) {
@@ -2261,7 +2259,7 @@ export class IncrementMovePriorityAttr extends MoveAttr {
    * @param user {@linkcode Pokemon} using this move
    * @param target {@linkcode Pokemon} target of this move
    * @param move {@linkcode Move} being used
-   * @param args [0] {@linkcode Utils.NumberHolder} for move priority.
+   * @param args [0] {@linkcode NumberHolder} for move priority.
    * @returns true if function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -2269,7 +2267,7 @@ export class IncrementMovePriorityAttr extends MoveAttr {
       return false;
     }
 
-    (args[0] as Utils.NumberHolder).value += this.increaseAmount;
+    (args[0] as NumberHolder).value += this.increaseAmount;
     return true;
   }
 }
@@ -2307,15 +2305,15 @@ export class MultiHitAttr extends MoveAttr {
    * @param user {@linkcode Pokemon} that used the attack
    * @param target {@linkcode Pokemon} targeted by the attack
    * @param move {@linkcode Move} being used
-   * @param args [0] {@linkcode Utils.NumberHolder} storing the hit count of the attack
+   * @param args [0] {@linkcode NumberHolder} storing the hit count of the attack
    * @returns True
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const hitType = new Utils.NumberHolder(this.intrinsicMultiHitType);
+    const hitType = new NumberHolder(this.intrinsicMultiHitType);
     applyMoveAttrs(ChangeMultiHitTypeAttr, user, target, move, hitType);
     this.multiHitType = hitType.value;
 
-    (args[0] as Utils.NumberHolder).value = this.getHitCount(user, target);
+    (args[0] as NumberHolder).value = this.getHitCount(user, target);
     return true;
   }
 
@@ -2336,7 +2334,7 @@ export class MultiHitAttr extends MoveAttr {
       case MultiHitType._2_TO_5:
       {
         const rand = user.randSeedInt(20);
-        const hitValue = new Utils.NumberHolder(rand);
+        const hitValue = new NumberHolder(rand);
         applyAbAttrs(MaxMultiHitAbAttr, user, null, false, hitValue);
         if (hitValue.value >= 13) {
           return 2;
@@ -2414,7 +2412,7 @@ export class ChangeMultiHitTypeAttr extends MoveAttr {
 export class WaterShurikenMultiHitTypeAttr extends ChangeMultiHitTypeAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     if (user.species.speciesId === Species.GRENINJA && user.hasAbility(Abilities.BATTLE_BOND) && user.formIndex === 2) {
-      (args[0] as Utils.NumberHolder).value = MultiHitType._3;
+      (args[0] as NumberHolder).value = MultiHitType._3;
       return true;
     }
     return false;
@@ -2480,7 +2478,7 @@ export class MultiStatusEffectAttr extends StatusEffectAttr {
   }
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    this.effect = Utils.randSeedItem(this.effects);
+    this.effect = randSeedItem(this.effects);
     const result = super.apply(user, target, move, args);
     return result;
   }
@@ -2612,7 +2610,7 @@ export class RemoveHeldItemAttr extends MoveEffectAttr {
       return false;
     }
 
-    const cancelled = new Utils.BooleanHolder(false);
+    const cancelled = new BooleanHolder(false);
     applyAbAttrs(BlockItemTheftAbAttr, target, cancelled); // Check for abilities that block item theft
 
     if (cancelled.value === true) {
@@ -2686,7 +2684,7 @@ export class EatBerryAttr extends MoveEffectAttr {
       return false;
     }
     this.chosenBerry = heldBerries[user.randSeedInt(heldBerries.length)];
-    const preserve = new Utils.BooleanHolder(false);
+    const preserve = new BooleanHolder(false);
     globalScene.applyModifiers(PreserveBerryModifier, target.isPlayer(), target, preserve); // check for berry pouch preservation
     if (!preserve.value) {
       this.reduceBerryModifier(target);
@@ -2709,7 +2707,7 @@ export class EatBerryAttr extends MoveEffectAttr {
 
   eatBerry(consumer: Pokemon, berryOwner?: Pokemon) {
     getBerryEffectFunc(this.chosenBerry!.berryType)(consumer, berryOwner); // consumer eats the berry
-    applyAbAttrs(HealFromBerryUseAbAttr, consumer, new Utils.BooleanHolder(false));
+    applyAbAttrs(HealFromBerryUseAbAttr, consumer, new BooleanHolder(false));
   }
 }
 
@@ -2733,7 +2731,7 @@ export class StealEatBerryAttr extends EatBerryAttr {
     if (move.hitsSubstitute(user, target)) {
       return false;
     }
-    const cancelled = new Utils.BooleanHolder(false);
+    const cancelled = new BooleanHolder(false);
     applyAbAttrs(BlockItemTheftAbAttr, target, cancelled); // check for abilities that block item theft
     if (cancelled.value === true) {
       return false;
@@ -2846,11 +2844,11 @@ export class BypassBurnDamageReductionAttr extends MoveAttr {
    * @param user N/A
    * @param target N/A
    * @param move {@linkcode Move} with this attribute
-   * @param args [0] {@linkcode Utils.BooleanHolder} for burnDamageReductionCancelled
+   * @param args [0] {@linkcode BooleanHolder} for burnDamageReductionCancelled
    * @returns true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    (args[0] as Utils.BooleanHolder).value = true;
+    (args[0] as BooleanHolder).value = true;
 
     return true;
   }
@@ -2931,14 +2929,14 @@ export class OneHitKOAttr extends MoveAttr {
       return false;
     }
 
-    (args[0] as Utils.BooleanHolder).value = true;
+    (args[0] as BooleanHolder).value = true;
 
     return true;
   }
 
   getCondition(): MoveConditionFunc {
     return (user, target, move) => {
-      const cancelled = new Utils.BooleanHolder(false);
+      const cancelled = new BooleanHolder(false);
       applyAbAttrs(BlockOneHitKOAbAttr, target, cancelled);
       return !cancelled.value && user.level >= target.level;
     };
@@ -2965,12 +2963,12 @@ export class InstantChargeAttr extends MoveAttr {
    * @param target n/a
    * @param move the {@linkcode Move} associated with this attribute
    * @param args
-   *  - `[0]` a {@linkcode Utils.BooleanHolder | BooleanHolder} for the "instant charge" flag
+   *  - `[0]` a {@linkcode BooleanHolder | BooleanHolder} for the "instant charge" flag
    * @returns `true` if the instant charge condition is met; `false` otherwise.
    */
   override apply(user: Pokemon, target: Pokemon | null, move: Move, args: any[]): boolean {
     const instantCharge = args[0];
-    if (!(instantCharge instanceof Utils.BooleanHolder)) {
+    if (!(instantCharge instanceof BooleanHolder)) {
       return false;
     }
 
@@ -2992,7 +2990,7 @@ export class WeatherInstantChargeAttr extends InstantChargeAttr {
     super((user, move) => {
       const currentWeather = globalScene.arena.weather;
 
-      if (Utils.isNullOrUndefined(currentWeather?.weatherType)) {
+      if (isNullOrUndefined(currentWeather?.weatherType)) {
         return false;
       } else {
         return !currentWeather?.isEffectSuppressed()
@@ -3035,7 +3033,7 @@ export class DelayedAttackAttr extends OverrideMoveEffectAttr {
       return true;
     }
 
-    const overridden = args[0] as Utils.BooleanHolder;
+    const overridden = args[0] as BooleanHolder;
     const virtual = args[1] as boolean;
 
     if (!virtual) {
@@ -3069,7 +3067,7 @@ export class AwaitCombinedPledgeAttr extends OverrideMoveEffectAttr {
    * @param target n/a
    * @param move the {@linkcode Move} being used
    * @param args
-   * - [0] a {@linkcode Utils.BooleanHolder} indicating whether the move's base
+   * - [0] a {@linkcode BooleanHolder} indicating whether the move's base
    * effects should be overridden this turn.
    * @returns `true` if base move effects were overridden; `false` otherwise
    */
@@ -3080,7 +3078,7 @@ export class AwaitCombinedPledgeAttr extends OverrideMoveEffectAttr {
       return false;
     }
 
-    const overridden = args[0] as Utils.BooleanHolder;
+    const overridden = args[0] as BooleanHolder;
 
     const allyMovePhase = globalScene.findPhase<MovePhase>((phase) => phase instanceof MovePhase && phase.pokemon.isPlayer() === user.isPlayer());
     if (allyMovePhase) {
@@ -3451,7 +3449,7 @@ export class CutHpStatStageBoostAttr extends StatStageChangeAttr {
     this.messageCallback = messageCallback;
   }
   override apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    user.damageAndUpdate(Utils.toDmgValue(user.getMaxHp() / this.cutRatio), { result: HitResult.INDIRECT });
+    user.damageAndUpdate(toDmgValue(user.getMaxHp() / this.cutRatio), { result: HitResult.INDIRECT });
     user.updateInfo();
     const ret = super.apply(user, target, move, args);
     if (this.messageCallback) {
@@ -3663,7 +3661,7 @@ export class LessPPMorePowerAttr extends VariablePowerAttr {
    * @param user {@linkcode Pokemon} using this move
    * @param target {@linkcode Pokemon} target of this move
    * @param move {@linkcode Move} being used
-   * @param args [0] {@linkcode Utils.NumberHolder} of power
+   * @param args [0] {@linkcode NumberHolder} of power
    * @returns true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -3676,7 +3674,7 @@ export class LessPPMorePowerAttr extends VariablePowerAttr {
       ppRemains = 0;
     }
 
-    const power = args[0] as Utils.NumberHolder;
+    const power = args[0] as NumberHolder;
 
     switch (ppRemains) {
       case 0:
@@ -3709,7 +3707,7 @@ export class MovePowerMultiplierAttr extends VariablePowerAttr {
   }
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const power = args[0] as Utils.NumberHolder;
+    const power = args[0] as NumberHolder;
     power.value *= this.powerMultiplierFunc(user, target, move);
 
     return true;
@@ -3749,7 +3747,7 @@ export class BeatUpAttr extends VariablePowerAttr {
    * @returns true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const power = args[0] as Utils.NumberHolder;
+    const power = args[0] as NumberHolder;
 
     const party = user.isPlayer() ? globalScene.getPlayerParty() : globalScene.getEnemyParty();
     const allyCount = party.filter(pokemon => {
@@ -3764,7 +3762,7 @@ export class BeatUpAttr extends VariablePowerAttr {
 const doublePowerChanceMessageFunc = (user: Pokemon, target: Pokemon, move: Move) => {
   let message: string = "";
   globalScene.executeWithSeedOffset(() => {
-    const rand = Utils.randSeedInt(100);
+    const rand = randSeedInt(100);
     if (rand < move.chance) {
       message = i18next.t("moveTriggers:goingAllOutForAttack", { pokemonName: getPokemonNameWithAffix(user) });
     }
@@ -3775,9 +3773,9 @@ const doublePowerChanceMessageFunc = (user: Pokemon, target: Pokemon, move: Move
 export class DoublePowerChanceAttr extends VariablePowerAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     let rand: number;
-    globalScene.executeWithSeedOffset(() => rand = Utils.randSeedInt(100), globalScene.currentBattle.turn << 6, globalScene.waveSeed);
+    globalScene.executeWithSeedOffset(() => rand = randSeedInt(100), globalScene.currentBattle.turn << 6, globalScene.waveSeed);
     if (rand! < move.chance) {
-      const power = args[0] as Utils.NumberHolder;
+      const power = args[0] as NumberHolder;
       power.value *= 2;
       return true;
     }
@@ -3831,7 +3829,7 @@ export class ConsecutiveUseMultiBasePowerAttr extends ConsecutiveUsePowerMultipl
 
 export class WeightPowerAttr extends VariablePowerAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const power = args[0] as Utils.NumberHolder;
+    const power = args[0] as NumberHolder;
 
     const targetWeight = target.getWeight();
     const weightThresholds = [ 10, 25, 50, 100, 200 ];
@@ -3865,7 +3863,7 @@ export class ElectroBallPowerAttr extends VariablePowerAttr {
    * @returns true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const power = args[0] as Utils.NumberHolder;
+    const power = args[0] as NumberHolder;
 
     const statRatio = target.getEffectiveStat(Stat.SPD) / user.getEffectiveStat(Stat.SPD);
     const statThresholds = [ 0.25, 1 / 3, 0.5, 1, -1 ];
@@ -3900,7 +3898,7 @@ export class GyroBallPowerAttr extends VariablePowerAttr {
    * @returns true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const power = args[0] as Utils.NumberHolder;
+    const power = args[0] as NumberHolder;
     const userSpeed = user.getEffectiveStat(Stat.SPD);
     if (userSpeed < 1) {
       // Gen 6+ always have 1 base power
@@ -3915,7 +3913,7 @@ export class GyroBallPowerAttr extends VariablePowerAttr {
 
 export class LowHpPowerAttr extends VariablePowerAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const power = args[0] as Utils.NumberHolder;
+    const power = args[0] as NumberHolder;
     const hpRatio = user.getHpRatio();
 
     switch (true) {
@@ -3945,7 +3943,7 @@ export class LowHpPowerAttr extends VariablePowerAttr {
 
 export class CompareWeightPowerAttr extends VariablePowerAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const power = args[0] as Utils.NumberHolder;
+    const power = args[0] as NumberHolder;
     const userWeight = user.getWeight();
     const targetWeight = target.getWeight();
 
@@ -3979,7 +3977,7 @@ export class CompareWeightPowerAttr extends VariablePowerAttr {
 
 export class HpPowerAttr extends VariablePowerAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    (args[0] as Utils.NumberHolder).value = Utils.toDmgValue(150 * user.getHpRatio());
+    (args[0] as NumberHolder).value = toDmgValue(150 * user.getHpRatio());
 
     return true;
   }
@@ -4007,7 +4005,7 @@ export class OpponentHighHpPowerAttr extends VariablePowerAttr {
    * @returns true
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    (args[0] as Utils.NumberHolder).value = Utils.toDmgValue(this.maxBasePower * target.getHpRatio());
+    (args[0] as NumberHolder).value = toDmgValue(this.maxBasePower * target.getHpRatio());
 
     return true;
   }
@@ -4017,7 +4015,7 @@ export class FirstAttackDoublePowerAttr extends VariablePowerAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     console.log(target.getLastXMoves(1), globalScene.currentBattle.turn);
     if (!target.getLastXMoves(1).find(m => m.turn === globalScene.currentBattle.turn)) {
-      (args[0] as Utils.NumberHolder).value *= 2;
+      (args[0] as NumberHolder).value *= 2;
       return true;
     }
 
@@ -4029,7 +4027,7 @@ export class FirstAttackDoublePowerAttr extends VariablePowerAttr {
 export class TurnDamagedDoublePowerAttr extends VariablePowerAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     if (user.turnData.attacksReceived.find(r => r.damage && r.sourceId === target.id)) {
-      (args[0] as Utils.NumberHolder).value *= 2;
+      (args[0] as NumberHolder).value *= 2;
       return true;
     }
 
@@ -4042,7 +4040,7 @@ const magnitudeMessageFunc = (user: Pokemon, target: Pokemon, move: Move) => {
   globalScene.executeWithSeedOffset(() => {
     const magnitudeThresholds = [ 5, 15, 35, 65, 75, 95 ];
 
-    const rand = Utils.randSeedInt(100);
+    const rand = randSeedInt(100);
 
     let m = 0;
     for (; m < magnitudeThresholds.length; m++) {
@@ -4058,14 +4056,14 @@ const magnitudeMessageFunc = (user: Pokemon, target: Pokemon, move: Move) => {
 
 export class MagnitudePowerAttr extends VariablePowerAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const power = args[0] as Utils.NumberHolder;
+    const power = args[0] as NumberHolder;
 
     const magnitudeThresholds = [ 5, 15, 35, 65, 75, 95 ];
     const magnitudePowers = [ 10, 30, 50, 70, 90, 100, 110, 150 ];
 
     let rand: number;
 
-    globalScene.executeWithSeedOffset(() => rand = Utils.randSeedInt(100), globalScene.currentBattle.turn << 6, globalScene.waveSeed);
+    globalScene.executeWithSeedOffset(() => rand = randSeedInt(100), globalScene.currentBattle.turn << 6, globalScene.waveSeed);
 
     let m = 0;
     for (; m < magnitudeThresholds.length; m++) {
@@ -4083,7 +4081,7 @@ export class MagnitudePowerAttr extends VariablePowerAttr {
 export class AntiSunlightPowerDecreaseAttr extends VariablePowerAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     if (!globalScene.arena.weather?.isEffectSuppressed()) {
-      const power = args[0] as Utils.NumberHolder;
+      const power = args[0] as NumberHolder;
       const weatherType = globalScene.arena.weather?.weatherType || WeatherType.NONE;
       switch (weatherType) {
         case WeatherType.RAIN:
@@ -4110,7 +4108,7 @@ export class FriendshipPowerAttr extends VariablePowerAttr {
   }
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const power = args[0] as Utils.NumberHolder;
+    const power = args[0] as NumberHolder;
 
     const friendshipPower = Math.floor(Math.min(user instanceof PlayerPokemon ? user.friendship : user.species.baseFriendship, 255) / 2.5);
     power.value = Math.max(!this.invert ? friendshipPower : 102 - friendshipPower, 1);
@@ -4126,7 +4124,7 @@ export class FriendshipPowerAttr extends VariablePowerAttr {
 export class RageFistPowerAttr extends VariablePowerAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const { hitCount, prevHitCount } = user.battleData;
-    const basePower: Utils.NumberHolder = args[0];
+    const basePower: NumberHolder = args[0];
 
     this.updateHitReceivedCount(user, hitCount, prevHitCount);
 
@@ -4171,7 +4169,7 @@ export class PositiveStatStagePowerAttr extends VariablePowerAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const positiveStatStages: number = countPositiveStatStages(user);
 
-    (args[0] as Utils.NumberHolder).value += positiveStatStages * 20;
+    (args[0] as NumberHolder).value += positiveStatStages * 20;
     return true;
   }
 }
@@ -4194,7 +4192,7 @@ export class PunishmentPowerAttr extends VariablePowerAttr {
      */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const positiveStatStages: number = countPositiveStatStages(target);
-    (args[0] as Utils.NumberHolder).value = Math.min(
+    (args[0] as NumberHolder).value = Math.min(
       this.PUNISHMENT_MAX_BASE_POWER,
       this.PUNISHMENT_MIN_BASE_POWER + positiveStatStages * 20
     );
@@ -4210,18 +4208,18 @@ export class PresentPowerAttr extends VariablePowerAttr {
      */
     const firstHit = (user.turnData.hitCount === user.turnData.hitsLeft);
 
-    const powerSeed = Utils.randSeedInt(firstHit ? 100 : 80);
+    const powerSeed = randSeedInt(firstHit ? 100 : 80);
     if (powerSeed <= 40) {
-      (args[0] as Utils.NumberHolder).value = 40;
+      (args[0] as NumberHolder).value = 40;
     } else if (40 < powerSeed && powerSeed <= 70) {
-      (args[0] as Utils.NumberHolder).value = 80;
+      (args[0] as NumberHolder).value = 80;
     } else if (70 < powerSeed && powerSeed <= 80) {
-      (args[0] as Utils.NumberHolder).value = 120;
+      (args[0] as NumberHolder).value = 120;
     } else if (80 < powerSeed && powerSeed <= 100) {
       // If this move is multi-hit, disable all other hits
       user.stopMultiHit();
       globalScene.unshiftPhase(new PokemonHealPhase(target.getBattlerIndex(),
-        Utils.toDmgValue(target.getMaxHp() / 4), i18next.t("moveTriggers:regainedHealth", { pokemonName: getPokemonNameWithAffix(target) }), true));
+        toDmgValue(target.getMaxHp() / 4), i18next.t("moveTriggers:regainedHealth", { pokemonName: getPokemonNameWithAffix(target) }), true));
     }
 
     return true;
@@ -4231,7 +4229,7 @@ export class PresentPowerAttr extends VariablePowerAttr {
 export class WaterShurikenPowerAttr extends VariablePowerAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     if (user.species.speciesId === Species.GRENINJA && user.hasAbility(Abilities.BATTLE_BOND) && user.formIndex === 2) {
-      (args[0] as Utils.NumberHolder).value = 20;
+      (args[0] as NumberHolder).value = 20;
       return true;
     }
     return false;
@@ -4253,7 +4251,7 @@ export class SpitUpPowerAttr extends VariablePowerAttr {
     const stockpilingTag = user.getTag(StockpilingTag);
 
     if (stockpilingTag && stockpilingTag.stockpiledCount > 0) {
-      const power = args[0] as Utils.NumberHolder;
+      const power = args[0] as NumberHolder;
       power.value = this.multiplier * stockpilingTag.stockpiledCount;
       return true;
     }
@@ -4321,12 +4319,12 @@ export class MultiHitPowerIncrementAttr extends VariablePowerAttr {
    * @param user {@linkcode Pokemon} that used the move
    * @param target {@linkcode Pokemon} that the move was used on
    * @param move {@linkcode Move} with this attribute
-   * @param args [0] {@linkcode Utils.NumberHolder} for final calculated power of move
+   * @param args [0] {@linkcode NumberHolder} for final calculated power of move
    * @returns true if attribute application succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const hitsTotal = user.turnData.hitCount - Math.max(user.turnData.hitsLeft, 0);
-    const power = args[0] as Utils.NumberHolder;
+    const power = args[0] as NumberHolder;
 
     power.value = move.power * (1 + hitsTotal % this.maxHits);
 
@@ -4358,11 +4356,11 @@ export class LastMoveDoublePowerAttr extends VariablePowerAttr {
    * @param user {@linkcode Pokemon} that used the move
    * @param target N/A
    * @param move N/A
-   * @param args [0] {@linkcode Utils.NumberHolder} that holds the resulting power of the move
+   * @param args [0] {@linkcode NumberHolder} that holds the resulting power of the move
    * @returns true if attribute application succeeds, false otherwise
    */
   apply(user: Pokemon, _target: Pokemon, _move: Move, args: any[]): boolean {
-    const power = args[0] as Utils.NumberHolder;
+    const power = args[0] as NumberHolder;
     const enemy = user.getOpponent(0);
     const pokemonActed: Pokemon[] = [];
 
@@ -4374,10 +4372,10 @@ export class LastMoveDoublePowerAttr extends VariablePowerAttr {
       const userAlly = user.getAlly();
       const enemyAlly = enemy?.getAlly();
 
-      if (!Utils.isNullOrUndefined(userAlly) && userAlly.turnData.acted) {
+      if (!isNullOrUndefined(userAlly) && userAlly.turnData.acted) {
         pokemonActed.push(userAlly);
       }
-      if (!Utils.isNullOrUndefined(enemyAlly) && enemyAlly.turnData.acted) {
+      if (!isNullOrUndefined(enemyAlly) && enemyAlly.turnData.acted) {
         pokemonActed.push(enemyAlly);
       }
     }
@@ -4407,7 +4405,7 @@ export class LastMoveDoublePowerAttr extends VariablePowerAttr {
 export class CombinedPledgePowerAttr extends VariablePowerAttr {
   override apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const power = args[0];
-    if (!(power instanceof Utils.NumberHolder)) {
+    if (!(power instanceof NumberHolder)) {
       return false;
     }
     const combinedPledgeMove = user.turnData.combiningPledge;
@@ -4426,7 +4424,7 @@ export class CombinedPledgePowerAttr extends VariablePowerAttr {
 export class CombinedPledgeStabBoostAttr extends MoveAttr {
   override apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const stabMultiplier = args[0];
-    if (!(stabMultiplier instanceof Utils.NumberHolder)) {
+    if (!(stabMultiplier instanceof NumberHolder)) {
       return false;
     }
     const combinedPledgeMove = user.turnData.combiningPledge;
@@ -4447,7 +4445,7 @@ export class CombinedPledgeStabBoostAttr extends MoveAttr {
 export class RoundPowerAttr extends VariablePowerAttr {
   override apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const power = args[0];
-    if (!(power instanceof Utils.NumberHolder)) {
+    if (!(power instanceof NumberHolder)) {
       return false;
     }
 
@@ -4572,7 +4570,7 @@ export class TargetAtkUserAtkAttr extends VariableAtkAttr {
     super();
   }
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    (args[0] as Utils.NumberHolder).value = target.getEffectiveStat(Stat.ATK, target);
+    (args[0] as NumberHolder).value = target.getEffectiveStat(Stat.ATK, target);
     return true;
   }
 }
@@ -4583,7 +4581,7 @@ export class DefAtkAttr extends VariableAtkAttr {
   }
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    (args[0] as Utils.NumberHolder).value = user.getEffectiveStat(Stat.DEF, target);
+    (args[0] as NumberHolder).value = user.getEffectiveStat(Stat.DEF, target);
     return true;
   }
 }
@@ -4605,7 +4603,7 @@ export class DefDefAttr extends VariableDefAttr {
   }
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    (args[0] as Utils.NumberHolder).value = target.getEffectiveStat(Stat.DEF, user);
+    (args[0] as NumberHolder).value = target.getEffectiveStat(Stat.DEF, user);
     return true;
   }
 }
@@ -4623,7 +4621,7 @@ export class VariableAccuracyAttr extends MoveAttr {
 export class ThunderAccuracyAttr extends VariableAccuracyAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     if (!globalScene.arena.weather?.isEffectSuppressed()) {
-      const accuracy = args[0] as Utils.NumberHolder;
+      const accuracy = args[0] as NumberHolder;
       const weatherType = globalScene.arena.weather?.weatherType || WeatherType.NONE;
       switch (weatherType) {
         case WeatherType.SUNNY:
@@ -4649,7 +4647,7 @@ export class ThunderAccuracyAttr extends VariableAccuracyAttr {
 export class StormAccuracyAttr extends VariableAccuracyAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     if (!globalScene.arena.weather?.isEffectSuppressed()) {
-      const accuracy = args[0] as Utils.NumberHolder;
+      const accuracy = args[0] as NumberHolder;
       const weatherType = globalScene.arena.weather?.weatherType || WeatherType.NONE;
       switch (weatherType) {
         case WeatherType.RAIN:
@@ -4680,7 +4678,7 @@ export class AlwaysHitMinimizeAttr extends VariableAccuracyAttr {
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     if (target.getTag(BattlerTagType.MINIMIZED)) {
-      const accuracy = args[0] as Utils.NumberHolder;
+      const accuracy = args[0] as NumberHolder;
       accuracy.value = -1;
 
       return true;
@@ -4693,7 +4691,7 @@ export class AlwaysHitMinimizeAttr extends VariableAccuracyAttr {
 export class ToxicAccuracyAttr extends VariableAccuracyAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     if (user.isOfType(PokemonType.POISON)) {
-      const accuracy = args[0] as Utils.NumberHolder;
+      const accuracy = args[0] as NumberHolder;
       accuracy.value = -1;
       return true;
     }
@@ -4705,7 +4703,7 @@ export class ToxicAccuracyAttr extends VariableAccuracyAttr {
 export class BlizzardAccuracyAttr extends VariableAccuracyAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     if (!globalScene.arena.weather?.isEffectSuppressed()) {
-      const accuracy = args[0] as Utils.NumberHolder;
+      const accuracy = args[0] as NumberHolder;
       const weatherType = globalScene.arena.weather?.weatherType || WeatherType.NONE;
       if (weatherType === WeatherType.HAIL || weatherType === WeatherType.SNOW) {
         accuracy.value = -1;
@@ -4725,7 +4723,7 @@ export class VariableMoveCategoryAttr extends MoveAttr {
 
 export class PhotonGeyserCategoryAttr extends VariableMoveCategoryAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const category = (args[0] as Utils.NumberHolder);
+    const category = (args[0] as NumberHolder);
 
     if (user.getEffectiveStat(Stat.ATK, target, move) > user.getEffectiveStat(Stat.SPATK, target, move)) {
       category.value = MoveCategory.PHYSICAL;
@@ -4745,7 +4743,7 @@ export class PhotonGeyserCategoryAttr extends VariableMoveCategoryAttr {
  */
 export class TeraMoveCategoryAttr extends VariableMoveCategoryAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const category = (args[0] as Utils.NumberHolder);
+    const category = (args[0] as NumberHolder);
 
     if (user.isTerastallized && user.getEffectiveStat(Stat.ATK, target, move, true, true, false, false, true) >
     user.getEffectiveStat(Stat.SPATK, target, move, true, true, false, false, true)) {
@@ -4769,12 +4767,12 @@ export class TeraBlastPowerAttr extends VariablePowerAttr {
    * @param target n/a
    * @param move {@linkcode Move} the Move with this attribute (i.e. Tera Blast)
    * @param args
-   *   - [0] {@linkcode Utils.NumberHolder} the applied move's power, factoring in
+   *   - [0] {@linkcode NumberHolder} the applied move's power, factoring in
    *       previously applied power modifiers.
    * @returns
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const power = args[0] as Utils.NumberHolder;
+    const power = args[0] as NumberHolder;
     if (user.isTerastallized && user.getTeraType() === PokemonType.STELLAR) {
       power.value = 100;
       return true;
@@ -4794,11 +4792,11 @@ export class StatusCategoryOnAllyAttr extends VariableMoveCategoryAttr {
    * @param user {@linkcode Pokemon} using the move
    * @param target {@linkcode Pokemon} target of the move
    * @param move {@linkcode Move} with this attribute
-   * @param args [0] {@linkcode Utils.NumberHolder} The category of the move
+   * @param args [0] {@linkcode NumberHolder} The category of the move
    * @returns true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const category = (args[0] as Utils.NumberHolder);
+    const category = (args[0] as NumberHolder);
 
     if (user.getAlly() === target) {
       category.value = MoveCategory.STATUS;
@@ -4811,7 +4809,7 @@ export class StatusCategoryOnAllyAttr extends VariableMoveCategoryAttr {
 
 export class ShellSideArmCategoryAttr extends VariableMoveCategoryAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const category = (args[0] as Utils.NumberHolder);
+    const category = (args[0] as NumberHolder);
 
     const predictedPhysDmg = target.getBaseDamage(user, move, MoveCategory.PHYSICAL, true, true, true, true);
     const predictedSpecDmg = target.getBaseDamage(user, move, MoveCategory.SPECIAL, true, true, true, true);
@@ -4836,7 +4834,7 @@ export class VariableMoveTypeAttr extends MoveAttr {
 export class FormChangeItemTypeAttr extends VariableMoveTypeAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const moveType = args[0];
-    if (!(moveType instanceof Utils.NumberHolder)) {
+    if (!(moveType instanceof NumberHolder)) {
       return false;
     }
 
@@ -4854,7 +4852,7 @@ export class FormChangeItemTypeAttr extends VariableMoveTypeAttr {
 export class TechnoBlastTypeAttr extends VariableMoveTypeAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const moveType = args[0];
-    if (!(moveType instanceof Utils.NumberHolder)) {
+    if (!(moveType instanceof NumberHolder)) {
       return false;
     }
 
@@ -4888,7 +4886,7 @@ export class TechnoBlastTypeAttr extends VariableMoveTypeAttr {
 export class AuraWheelTypeAttr extends VariableMoveTypeAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const moveType = args[0];
-    if (!(moveType instanceof Utils.NumberHolder)) {
+    if (!(moveType instanceof NumberHolder)) {
       return false;
     }
 
@@ -4913,7 +4911,7 @@ export class AuraWheelTypeAttr extends VariableMoveTypeAttr {
 export class RagingBullTypeAttr extends VariableMoveTypeAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const moveType = args[0];
-    if (!(moveType instanceof Utils.NumberHolder)) {
+    if (!(moveType instanceof NumberHolder)) {
       return false;
     }
 
@@ -4941,7 +4939,7 @@ export class RagingBullTypeAttr extends VariableMoveTypeAttr {
 export class IvyCudgelTypeAttr extends VariableMoveTypeAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const moveType = args[0];
-    if (!(moveType instanceof Utils.NumberHolder)) {
+    if (!(moveType instanceof NumberHolder)) {
       return false;
     }
 
@@ -4976,7 +4974,7 @@ export class IvyCudgelTypeAttr extends VariableMoveTypeAttr {
 export class WeatherBallTypeAttr extends VariableMoveTypeAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const moveType = args[0];
-    if (!(moveType instanceof Utils.NumberHolder)) {
+    if (!(moveType instanceof NumberHolder)) {
       return false;
     }
 
@@ -5018,12 +5016,12 @@ export class TerrainPulseTypeAttr extends VariableMoveTypeAttr {
    * @param user {@linkcode Pokemon} using this move
    * @param target N/A
    * @param move N/A
-   * @param args [0] {@linkcode Utils.NumberHolder} The move's type to be modified
+   * @param args [0] {@linkcode NumberHolder} The move's type to be modified
    * @returns true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const moveType = args[0];
-    if (!(moveType instanceof Utils.NumberHolder)) {
+    if (!(moveType instanceof NumberHolder)) {
       return false;
     }
 
@@ -5059,7 +5057,7 @@ export class TerrainPulseTypeAttr extends VariableMoveTypeAttr {
 export class HiddenPowerTypeAttr extends VariableMoveTypeAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const moveType = args[0];
-    if (!(moveType instanceof Utils.NumberHolder)) {
+    if (!(moveType instanceof NumberHolder)) {
       return false;
     }
 
@@ -5094,7 +5092,7 @@ export class TeraBlastTypeAttr extends VariableMoveTypeAttr {
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const moveType = args[0];
-    if (!(moveType instanceof Utils.NumberHolder)) {
+    if (!(moveType instanceof NumberHolder)) {
       return false;
     }
 
@@ -5117,12 +5115,12 @@ export class TeraStarstormTypeAttr extends VariableMoveTypeAttr {
    * @param user the {@linkcode Pokemon} using the move
    * @param target n/a
    * @param move n/a
-   * @param args[0] {@linkcode Utils.NumberHolder} the move type
+   * @param args[0] {@linkcode NumberHolder} the move type
    * @returns `true` if the move type is changed to {@linkcode PokemonType.STELLAR}, `false` otherwise
    */
   override apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     if (user.isTerastallized && user.hasSpecies(Species.TERAPAGOS)) {
-      const moveType = args[0] as Utils.NumberHolder;
+      const moveType = args[0] as NumberHolder;
 
       moveType.value = PokemonType.STELLAR;
       return true;
@@ -5134,7 +5132,7 @@ export class TeraStarstormTypeAttr extends VariableMoveTypeAttr {
 export class MatchUserTypeAttr extends VariableMoveTypeAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const moveType = args[0];
-    if (!(moveType instanceof Utils.NumberHolder)) {
+    if (!(moveType instanceof NumberHolder)) {
       return false;
     }
     const userTypes = user.getTypes(true);
@@ -5160,7 +5158,7 @@ export class MatchUserTypeAttr extends VariableMoveTypeAttr {
 export class CombinedPledgeTypeAttr extends VariableMoveTypeAttr {
   override apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const moveType = args[0];
-    if (!(moveType instanceof Utils.NumberHolder)) {
+    if (!(moveType instanceof NumberHolder)) {
       return false;
     }
 
@@ -5203,7 +5201,7 @@ export class VariableMoveTypeMultiplierAttr extends MoveAttr {
 export class NeutralDamageAgainstFlyingTypeMultiplierAttr extends VariableMoveTypeMultiplierAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     if (!target.getTag(BattlerTagType.IGNORE_FLYING)) {
-      const multiplier = args[0] as Utils.NumberHolder;
+      const multiplier = args[0] as NumberHolder;
       //When a flying type is hit, the first hit is always 1x multiplier.
       if (target.isOfType(PokemonType.FLYING)) {
         multiplier.value = 1;
@@ -5221,11 +5219,11 @@ export class IceNoEffectTypeAttr extends VariableMoveTypeMultiplierAttr {
    * @param user n/a
    * @param target The {@linkcode Pokemon} targeted by the move
    * @param move n/a
-   * @param args `[0]` a {@linkcode Utils.NumberHolder | NumberHolder} containing a type effectiveness multiplier
+   * @param args `[0]` a {@linkcode NumberHolder | NumberHolder} containing a type effectiveness multiplier
    * @returns `true` if this Ice-type immunity applies; `false` otherwise
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const multiplier = args[0] as Utils.NumberHolder;
+    const multiplier = args[0] as NumberHolder;
     if (target.isOfType(PokemonType.ICE)) {
       multiplier.value = 0;
       return true;
@@ -5236,7 +5234,7 @@ export class IceNoEffectTypeAttr extends VariableMoveTypeMultiplierAttr {
 
 export class FlyingTypeMultiplierAttr extends VariableMoveTypeMultiplierAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const multiplier = args[0] as Utils.NumberHolder;
+    const multiplier = args[0] as NumberHolder;
     multiplier.value *= target.getAttackTypeEffectiveness(PokemonType.FLYING, user);
     return true;
   }
@@ -5265,7 +5263,7 @@ export class VariableMoveTypeChartAttr extends MoveAttr {
  */
 export class FreezeDryAttr extends VariableMoveTypeChartAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const multiplier = args[0] as Utils.NumberHolder;
+    const multiplier = args[0] as NumberHolder;
     const defType = args[1] as PokemonType;
 
     if (defType === PokemonType.WATER) {
@@ -5279,7 +5277,7 @@ export class FreezeDryAttr extends VariableMoveTypeChartAttr {
 
 export class OneHitKOAccuracyAttr extends VariableAccuracyAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const accuracy = args[0] as Utils.NumberHolder;
+    const accuracy = args[0] as NumberHolder;
     if (user.level < target.level) {
       accuracy.value = 0;
     } else {
@@ -5301,7 +5299,7 @@ export class SheerColdAccuracyAttr extends OneHitKOAccuracyAttr {
    * @returns Returns true if move is successful, false if misses.
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const accuracy = args[0] as Utils.NumberHolder;
+    const accuracy = args[0] as NumberHolder;
     if (user.level < target.level) {
       accuracy.value = 0;
     } else {
@@ -5343,15 +5341,15 @@ export class NoEffectAttr extends MoveAttr {
 }
 
 const crashDamageFunc = (user: Pokemon, move: Move) => {
-  const cancelled = new Utils.BooleanHolder(false);
+  const cancelled = new BooleanHolder(false);
   applyAbAttrs(BlockNonDirectDamageAbAttr, user, cancelled);
   if (cancelled.value) {
     return false;
   }
 
-  user.damageAndUpdate(Utils.toDmgValue(user.getMaxHp() / 2), { result: HitResult.INDIRECT });
+  user.damageAndUpdate(toDmgValue(user.getMaxHp() / 2), { result: HitResult.INDIRECT });
   globalScene.queueMessage(i18next.t("moveTriggers:keptGoingAndCrashed", { pokemonName: getPokemonNameWithAffix(user) }));
-  user.turnData.damageTaken += Utils.toDmgValue(user.getMaxHp() / 2);
+  user.turnData.damageTaken += toDmgValue(user.getMaxHp() / 2);
 
   return true;
 };
@@ -6177,10 +6175,10 @@ export class RevivalBlessingAttr extends MoveEffectAttr {
       const pokemon = faintedPokemon[user.randSeedInt(faintedPokemon.length)];
       const slotIndex = globalScene.getEnemyParty().findIndex((p) => pokemon.id === p.id);
       pokemon.resetStatus();
-      pokemon.heal(Math.min(Utils.toDmgValue(0.5 * pokemon.getMaxHp()), pokemon.getMaxHp()));
+      pokemon.heal(Math.min(toDmgValue(0.5 * pokemon.getMaxHp()), pokemon.getMaxHp()));
       globalScene.queueMessage(i18next.t("moveTriggers:revivalBlessing", { pokemonName: getPokemonNameWithAffix(pokemon) }), 0, true);
       const allyPokemon = user.getAlly();
-      if (globalScene.currentBattle.double && globalScene.getEnemyParty().length > 1 && !Utils.isNullOrUndefined(allyPokemon)) {
+      if (globalScene.currentBattle.double && globalScene.getEnemyParty().length > 1 && !isNullOrUndefined(allyPokemon)) {
         // Handle cases where revived pokemon needs to get switched in on same turn
         if (allyPokemon.isFainted() || allyPokemon === pokemon) {
           // Enemy switch phase should be removed and replaced with the revived pkmn switching in
@@ -6366,7 +6364,7 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
         globalScene.queueMessage(i18next.t("moveTriggers:fled", { pokemonName: getPokemonNameWithAffix(switchOutTarget) }), null, true, 500);
 
         // in double battles redirect potential moves off fled pokemon
-        if (globalScene.currentBattle.double && !Utils.isNullOrUndefined(allyPokemon)) {
+        if (globalScene.currentBattle.double && !isNullOrUndefined(allyPokemon)) {
           globalScene.redirectPokemonMoves(switchOutTarget, allyPokemon);
         }
       }
@@ -6389,7 +6387,7 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
   }
 
   getFailedText(_user: Pokemon, target: Pokemon, _move: Move): string | undefined {
-    const blockedByAbility = new Utils.BooleanHolder(false);
+    const blockedByAbility = new BooleanHolder(false);
     applyAbAttrs(ForceSwitchOutImmunityAbAttr, target, blockedByAbility);
     if (blockedByAbility.value) {
       return i18next.t("moveTriggers:cannotBeSwitchedOut", { pokemonName: getPokemonNameWithAffix(target) });
@@ -6417,7 +6415,7 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
           return false;
         }
 
-        const blockedByAbility = new Utils.BooleanHolder(false);
+        const blockedByAbility = new BooleanHolder(false);
         applyAbAttrs(ForceSwitchOutImmunityAbAttr, target, blockedByAbility);
         return !blockedByAbility.value;
       }
@@ -6776,7 +6774,7 @@ export class RandomMoveAttr extends CallMoveAttr {
    * @param args Unused
    */
   override apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const moveIds = Utils.getEnumValues(Moves).map(m => !this.invalidMoves.has(m) && !allMoves[m].name.endsWith(" (N)") ? m : Moves.NONE);
+    const moveIds = getEnumValues(Moves).map(m => !this.invalidMoves.has(m) && !allMoves[m].name.endsWith(" (N)") ? m : Moves.NONE);
     let moveId: Moves = Moves.NONE;
     do {
       moveId = this.getMoveOverride() ?? moveIds[user.randSeedInt(moveIds.length)];
@@ -7047,7 +7045,7 @@ export class RepeatMoveAttr extends MoveEffectAttr {
     const firstTarget = globalScene.getField()[moveTargets[0]];
     if (globalScene.currentBattle.double && moveTargets.length === 1 && firstTarget.isFainted() && firstTarget !== target.getAlly()) {
       const ally = firstTarget.getAlly();
-      if (!Utils.isNullOrUndefined(ally) && ally.isActive()) { // ally exists, is not dead and can sponge the blast
+      if (!isNullOrUndefined(ally) && ally.isActive()) { // ally exists, is not dead and can sponge the blast
         moveTargets = [ ally.getBattlerIndex() ];
       }
     }
@@ -7423,7 +7421,7 @@ export class AbilityCopyAttr extends MoveEffectAttr {
     user.setTempAbility(target.getAbility());
     const ally = user.getAlly();
 
-    if (this.copyToPartner && globalScene.currentBattle?.double && !Utils.isNullOrUndefined(ally) && ally.hp) { // TODO is this the best way to check that the ally is active?
+    if (this.copyToPartner && globalScene.currentBattle?.double && !isNullOrUndefined(ally) && ally.hp) { // TODO is this the best way to check that the ally is active?
       globalScene.queueMessage(i18next.t("moveTriggers:copiedTargetAbility", { pokemonName: getPokemonNameWithAffix(ally), targetName: getPokemonNameWithAffix(target), abilityName: allAbilities[target.getAbility().id].name }));
       ally.setTempAbility(target.getAbility());
     }
@@ -7839,7 +7837,7 @@ export class VariableTargetAttr extends MoveAttr {
   }
 
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const targetVal = args[0] as Utils.NumberHolder;
+    const targetVal = args[0] as NumberHolder;
     targetVal.value = this.targetChangeFunc(user, target, move);
     return true;
   }
@@ -7930,7 +7928,7 @@ const failOnBossCondition: MoveConditionFunc = (user, target, move) => !target.i
 const failIfSingleBattle: MoveConditionFunc = (user, target, move) => globalScene.currentBattle.double;
 
 const failIfDampCondition: MoveConditionFunc = (user, target, move) => {
-  const cancelled = new Utils.BooleanHolder(false);
+  const cancelled = new BooleanHolder(false);
   globalScene.getField(true).map(p=>applyAbAttrs(FieldPreventExplosiveMovesAbAttr, p, cancelled));
   // Queue a message if an ability prevented usage of the move
   if (cancelled.value) {
@@ -8065,7 +8063,7 @@ export class UpperHandCondition extends MoveCondition {
 
 export class hitsSameTypeAttr extends VariableMoveTypeMultiplierAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
-    const multiplier = args[0] as Utils.NumberHolder;
+    const multiplier = args[0] as NumberHolder;
     if (!user.getTypes().some(type => target.getTypes().includes(type))) {
       multiplier.value = 0;
       return true;
@@ -8116,7 +8114,7 @@ export class ResistLastMoveTypeAttr extends MoveEffectAttr {
     }
     const type = validTypes[user.randSeedInt(validTypes.length)];
     user.summonData.types = [ type ];
-    globalScene.queueMessage(i18next.t("battle:transformedIntoType", { pokemonName: getPokemonNameWithAffix(user), type: Utils.toReadableString(PokemonType[type]) }));
+    globalScene.queueMessage(i18next.t("battle:transformedIntoType", { pokemonName: getPokemonNameWithAffix(user), type: toReadableString(PokemonType[type]) }));
     user.updateInfo();
 
     return true;
@@ -8190,7 +8188,7 @@ export type MoveTargetSet = {
 };
 
 export function getMoveTargets(user: Pokemon, move: Moves, replaceTarget?: MoveTarget): MoveTargetSet {
-  const variableTarget = new Utils.NumberHolder(0);
+  const variableTarget = new NumberHolder(0);
   user.getOpponents().forEach(p => applyMoveAttrs(VariableTargetAttr, user, p, allMoves[move], variableTarget));
 
   let moveTarget: MoveTarget | undefined;
@@ -8218,7 +8216,7 @@ export function getMoveTargets(user: Pokemon, move: Moves, replaceTarget?: MoveT
     case MoveTarget.OTHER:
     case MoveTarget.ALL_NEAR_OTHERS:
     case MoveTarget.ALL_OTHERS:
-      set = !Utils.isNullOrUndefined(ally) ? (opponents.concat([ ally ])) : opponents;
+      set = !isNullOrUndefined(ally) ? (opponents.concat([ ally ])) : opponents;
       multiple = moveTarget === MoveTarget.ALL_NEAR_OTHERS || moveTarget === MoveTarget.ALL_OTHERS;
       break;
     case MoveTarget.NEAR_ENEMY:
@@ -8235,21 +8233,21 @@ export function getMoveTargets(user: Pokemon, move: Moves, replaceTarget?: MoveT
       return { targets: [ -1 as BattlerIndex ], multiple: false };
     case MoveTarget.NEAR_ALLY:
     case MoveTarget.ALLY:
-      set = !Utils.isNullOrUndefined(ally) ? [ ally ] : [];
+      set = !isNullOrUndefined(ally) ? [ ally ] : [];
       break;
     case MoveTarget.USER_OR_NEAR_ALLY:
     case MoveTarget.USER_AND_ALLIES:
     case MoveTarget.USER_SIDE:
-      set = !Utils.isNullOrUndefined(ally) ? [ user, ally ] : [ user ];
+      set = !isNullOrUndefined(ally) ? [ user, ally ] : [ user ];
       multiple = moveTarget !== MoveTarget.USER_OR_NEAR_ALLY;
       break;
     case MoveTarget.ALL:
     case MoveTarget.BOTH_SIDES:
-      set = (!Utils.isNullOrUndefined(ally) ? [ user, ally ] : [ user ]).concat(opponents);
+      set = (!isNullOrUndefined(ally) ? [ user, ally ] : [ user ]).concat(opponents);
       multiple = true;
       break;
     case MoveTarget.CURSE:
-      const extraTargets = !Utils.isNullOrUndefined(ally) ? [ ally ] : [];
+      const extraTargets = !isNullOrUndefined(ally) ? [ ally ] : [];
       set = user.getTypes(true).includes(PokemonType.GHOST) ? (opponents.concat(extraTargets)) : [ user ];
       break;
   }
@@ -8408,7 +8406,7 @@ export function initMoves() {
       .attr(AddBattlerTagAttr, BattlerTagType.DISABLED, false, true)
       .condition((user, target, move) => {
         const lastRealMove = target.getLastXMoves(-1).find(m => !m.virtual);
-        return !Utils.isNullOrUndefined(lastRealMove) && lastRealMove.move !== Moves.NONE && lastRealMove.move !== Moves.STRUGGLE;
+        return !isNullOrUndefined(lastRealMove) && lastRealMove.move !== Moves.NONE && lastRealMove.move !== Moves.STRUGGLE;
       })
       .ignoresSubstitute()
       .reflectable(),
@@ -9716,7 +9714,7 @@ export function initMoves() {
       .condition(failOnGravityCondition)
       .condition((_user, target, _move) => ![ Species.DIGLETT, Species.DUGTRIO, Species.ALOLA_DIGLETT, Species.ALOLA_DUGTRIO, Species.SANDYGAST, Species.PALOSSAND, Species.WIGLETT, Species.WUGTRIO ].includes(target.species.speciesId))
       .condition((_user, target, _move) => !(target.species.speciesId === Species.GENGAR && target.getFormKey() === "mega"))
-      .condition((_user, target, _move) => Utils.isNullOrUndefined(target.getTag(BattlerTagType.INGRAIN)) && Utils.isNullOrUndefined(target.getTag(BattlerTagType.IGNORE_FLYING)))
+      .condition((_user, target, _move) => isNullOrUndefined(target.getTag(BattlerTagType.INGRAIN)) && isNullOrUndefined(target.getTag(BattlerTagType.IGNORE_FLYING)))
       .attr(AddBattlerTagAttr, BattlerTagType.TELEKINESIS, false, true, 3)
       .attr(AddBattlerTagAttr, BattlerTagType.FLOATING, false, true, 3)
       .reflectable(),

--- a/src/data/mystery-encounters/encounters/mysterious-challengers-encounter.ts
+++ b/src/data/mystery-encounters/encounters/mysterious-challengers-encounter.ts
@@ -12,7 +12,7 @@ import { modifierTypes } from "#app/modifier/modifier-type";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { PartyMemberStrength } from "#enums/party-member-strength";
 import { globalScene } from "#app/global-scene";
-import * as Utils from "#app/utils";
+import { randSeedInt } from "#app/utils";
 import type MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
 import { MysteryEncounterBuilder } from "#app/data/mystery-encounters/mystery-encounter";
 import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
@@ -46,7 +46,7 @@ export const MysteriousChallengersEncounter: MysteryEncounter = MysteryEncounter
     const normalConfig = trainerConfigs[normalTrainerType].clone();
     let female = false;
     if (normalConfig.hasGenders) {
-      female = !!Utils.randSeedInt(2);
+      female = !!randSeedInt(2);
     }
     const normalSpriteKey = normalConfig.getSpriteKey(female, normalConfig.doubleOnly);
     encounter.enemyPartyConfigs.push({
@@ -76,7 +76,7 @@ export const MysteriousChallengersEncounter: MysteryEncounter = MysteryEncounter
     hardConfig.setPartyTemplates(hardTemplate);
     female = false;
     if (hardConfig.hasGenders) {
-      female = !!Utils.randSeedInt(2);
+      female = !!randSeedInt(2);
     }
     const hardSpriteKey = hardConfig.getSpriteKey(female, hardConfig.doubleOnly);
     encounter.enemyPartyConfigs.push({
@@ -96,7 +96,7 @@ export const MysteriousChallengersEncounter: MysteryEncounter = MysteryEncounter
     brutalConfig.partyTemplateFunc = null; // Overrides gym leader party template func
     female = false;
     if (brutalConfig.hasGenders) {
-      female = !!Utils.randSeedInt(2);
+      female = !!randSeedInt(2);
     }
     const brutalSpriteKey = brutalConfig.getSpriteKey(female, brutalConfig.doubleOnly);
     encounter.enemyPartyConfigs.push({

--- a/src/data/mystery-encounters/mystery-encounter.ts
+++ b/src/data/mystery-encounters/mystery-encounter.ts
@@ -5,7 +5,7 @@ import { capitalizeFirstLetter, isNullOrUndefined } from "#app/utils";
 import type { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import type { MysteryEncounterSpriteConfig } from "#app/field/mystery-encounter-intro";
 import MysteryEncounterIntroVisuals from "#app/field/mystery-encounter-intro";
-import * as Utils from "#app/utils";
+import { randSeedInt } from "#app/utils";
 import type { StatusEffect } from "#enums/status-effect";
 import type { OptionTextDisplay } from "./mystery-encounter-dialogue";
 import type MysteryEncounterDialogue from "./mystery-encounter-dialogue";
@@ -378,13 +378,13 @@ export default class MysteryEncounter implements IMysteryEncounter {
       }
       if (truePrimaryPool.length > 0) {
         // Always choose from the non-overlapping pokemon first
-        this.primaryPokemon = truePrimaryPool[Utils.randSeedInt(truePrimaryPool.length, 0)];
+        this.primaryPokemon = truePrimaryPool[randSeedInt(truePrimaryPool.length, 0)];
         return true;
       }
       // If there are multiple overlapping pokemon, we're okay - just choose one and take it out of the primary pokemon pool
       if (overlap.length > 1 || this.secondaryPokemon.length - overlap.length >= 1) {
         // is this working?
-        this.primaryPokemon = overlap[Utils.randSeedInt(overlap.length, 0)];
+        this.primaryPokemon = overlap[randSeedInt(overlap.length, 0)];
         this.secondaryPokemon = this.secondaryPokemon.filter(supp => supp !== this.primaryPokemon);
         return true;
       }
@@ -394,7 +394,7 @@ export default class MysteryEncounter implements IMysteryEncounter {
       return false;
     }
     // this means we CAN have the same pokemon be a primary and secondary pokemon, so just choose any qualifying one randomly.
-    this.primaryPokemon = qualified[Utils.randSeedInt(qualified.length, 0)];
+    this.primaryPokemon = qualified[randSeedInt(qualified.length, 0)];
     return true;
   }
 

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -30,8 +30,7 @@ import type { OptionSelectConfig, OptionSelectItem } from "#app/ui/abstact-optio
 import type { PartyOption, PokemonSelectFilter } from "#app/ui/party-ui-handler";
 import { PartyUiMode } from "#app/ui/party-ui-handler";
 import { Mode } from "#app/ui/ui";
-import * as Utils from "#app/utils";
-import { isNullOrUndefined, randSeedInt, randSeedItem } from "#app/utils";
+import { isNullOrUndefined, randSeedInt, randomString, randSeedItem } from "#app/utils";
 import type { BattlerTagType } from "#enums/battler-tag-type";
 import { Biome } from "#enums/biome";
 import type { TrainerType } from "#enums/trainer-type";
@@ -168,7 +167,7 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
 
     const doubleTrainer = trainerConfig.doubleOnly || (trainerConfig.hasDouble && !!partyConfig.doubleBattle);
     doubleBattle = doubleTrainer;
-    const trainerFemale = isNullOrUndefined(partyConfig.female) ? !!Utils.randSeedInt(2) : partyConfig.female;
+    const trainerFemale = isNullOrUndefined(partyConfig.female) ? !!randSeedInt(2) : partyConfig.female;
     const newTrainer = new Trainer(
       trainerConfig.trainerType,
       doubleTrainer ? TrainerVariant.DOUBLE : trainerFemale ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT,
@@ -286,7 +285,7 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
 
       // Generate new id, reset status and HP in case using data source
       if (config.dataSource) {
-        enemyPokemon.id = Utils.randSeedInt(4294967296);
+        enemyPokemon.id = randSeedInt(4294967296);
       }
 
       // Set form
@@ -1115,7 +1114,7 @@ export function calculateMEAggregateStats(baseSpawnWeight: number) {
     const validMEfloorsByBiome = new Map<string, number>(biomes.map(b => [b, 0]));
     let currentBiome = Biome.TOWN;
     let currentArena = globalScene.newArena(currentBiome);
-    globalScene.setSeed(Utils.randomString(24));
+    globalScene.setSeed(randomString(24));
     globalScene.resetSeed();
     for (let i = 10; i < 180; i++) {
       // Boss
@@ -1130,16 +1129,16 @@ export function calculateMEAggregateStats(baseSpawnWeight: number) {
           globalScene.executeWithSeedOffset(() => {
             biomes = (biomeLinks[currentBiome] as (Biome | [Biome, number])[])
               .filter(b => {
-                return !Array.isArray(b) || !Utils.randSeedInt(b[1]);
+                return !Array.isArray(b) || !randSeedInt(b[1]);
               })
               .map(b => (!Array.isArray(b) ? b : b[0]));
           }, i * 100);
           if (biomes! && biomes.length > 0) {
             const specialBiomes = biomes.filter(b => alwaysPickTheseBiomes.includes(b));
             if (specialBiomes.length > 0) {
-              currentBiome = specialBiomes[Utils.randSeedInt(specialBiomes.length)];
+              currentBiome = specialBiomes[randSeedInt(specialBiomes.length)];
             } else {
-              currentBiome = biomes[Utils.randSeedInt(biomes.length)];
+              currentBiome = biomes[randSeedInt(biomes.length)];
             }
           }
         } else if (biomeLinks.hasOwnProperty(currentBiome)) {
@@ -1167,7 +1166,7 @@ export function calculateMEAggregateStats(baseSpawnWeight: number) {
 
       // Otherwise, roll encounter
 
-      const roll = Utils.randSeedInt(256);
+      const roll = randSeedInt(256);
       validMEfloorsByBiome.set(Biome[currentBiome], (validMEfloorsByBiome.get(Biome[currentBiome]) ?? 0) + 1);
 
       // If total number of encounters is lower than expected for the run, slightly favor a new encounter
@@ -1192,7 +1191,7 @@ export function calculateMEAggregateStats(baseSpawnWeight: number) {
         tierWeights[1] = tierWeights[1] - 4 * numEncounters[1];
 
         const totalWeight = tierWeights.reduce((a, b) => a + b);
-        const tierValue = Utils.randSeedInt(totalWeight);
+        const tierValue = randSeedInt(totalWeight);
         const commonThreshold = totalWeight - tierWeights[0]; // 64 - 32 = 32
         const uncommonThreshold = totalWeight - tierWeights[0] - tierWeights[1]; // 64 - 32 - 16 = 16
         const rareThreshold = totalWeight - tierWeights[0] - tierWeights[1] - tierWeights[2]; // 64 - 32 - 16 - 10 = 6
@@ -1281,7 +1280,7 @@ export function calculateRareSpawnAggregateStats(luckValue: number) {
 
   const calculateNumRareEncounters = (): any[] => {
     const bossEncountersByRarity = [0, 0, 0, 0];
-    globalScene.setSeed(Utils.randomString(24));
+    globalScene.setSeed(randomString(24));
     globalScene.resetSeed();
     // There are 12 wild boss floors
     for (let i = 0; i < 12; i++) {
@@ -1291,7 +1290,7 @@ export function calculateRareSpawnAggregateStats(luckValue: number) {
       if (!Number.isNaN(luckValue)) {
         luckModifier = luckValue * 0.5;
       }
-      const tierValue = Utils.randSeedInt(64 - luckModifier);
+      const tierValue = randSeedInt(64 - luckModifier);
       const tier =
         tierValue >= 20
           ? BiomePoolTier.BOSS

--- a/src/data/nature.ts
+++ b/src/data/nature.ts
@@ -1,4 +1,4 @@
-import * as Utils from "../utils";
+import { toReadableString } from "#app/utils";
 import { TextStyle, getBBCodeFrag } from "../ui/text";
 import { Nature } from "#enums/nature";
 import { UiTheme } from "#enums/ui-theme";
@@ -12,7 +12,7 @@ export function getNatureName(
   ignoreBBCode = false,
   uiTheme: UiTheme = UiTheme.DEFAULT,
 ): string {
-  let ret = Utils.toReadableString(Nature[nature]);
+  let ret = toReadableString(Nature[nature]);
   //Translating nature
   if (i18next.exists(`nature:${ret}`)) {
     ret = i18next.t(`nature:${ret}` as any);

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -8,7 +8,7 @@ import type { AnySound } from "#app/battle-scene";
 import { globalScene } from "#app/global-scene";
 import type { GameMode } from "#app/game-mode";
 import { DexAttr, type StarterMoveset } from "#app/system/game-data";
-import * as Utils from "#app/utils";
+import { isNullOrUndefined, capitalizeString, randSeedInt, randSeedGauss, randSeedItem } from "#app/utils";
 import { uncatchableSpecies } from "#app/data/balance/biomes";
 import { speciesEggMoves } from "#app/data/balance/egg-moves";
 import { GrowthRate } from "#app/data/exp";
@@ -290,7 +290,7 @@ export abstract class PokemonSpeciesForm {
    * @returns The id of the ability
    */
   getPassiveAbility(formIndex?: number): Abilities {
-    if (Utils.isNullOrUndefined(formIndex)) {
+    if (isNullOrUndefined(formIndex)) {
       formIndex = this.formIndex;
     }
     let starterSpeciesId = this.speciesId;
@@ -626,7 +626,7 @@ export abstract class PokemonSpeciesForm {
         const spritePath = this.getSpriteAtlasPath(female, formIndex, shiny, variant, back)
           .replace("variant/", "")
           .replace(/_[1-3]$/, "");
-        if (!Utils.isNullOrUndefined(variant)) {
+        if (!isNullOrUndefined(variant)) {
           loadPokemonVariantAssets(spriteKey, spritePath, variant).then(() => resolve());
         }
       });
@@ -852,8 +852,8 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
    */
   getFormNameToDisplay(formIndex = 0, append = false): string {
     const formKey = this.forms?.[formIndex!]?.formKey;
-    const formText = Utils.capitalizeString(formKey, "-", false, false) || "";
-    const speciesName = Utils.capitalizeString(Species[this.speciesId], "_", true, false);
+    const formText = capitalizeString(formKey, "-", false, false) || "";
+    const speciesName = capitalizeString(Species[this.speciesId], "_", true, false);
     let ret = "";
 
     const region = this.getRegion();
@@ -884,7 +884,7 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
       if (i18next.exists(i18key)) {
         ret = i18next.t(i18key);
       } else {
-        const rootSpeciesName = Utils.capitalizeString(Species[this.getRootSpeciesId()], "_", true, false);
+        const rootSpeciesName = capitalizeString(Species[this.getRootSpeciesId()], "_", true, false);
         const i18RootKey = `pokemonForm:${rootSpeciesName}${formText}`;
         ret = i18next.exists(i18RootKey) ? i18next.t(i18RootKey) : formText;
       }
@@ -1079,7 +1079,7 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
       return this.speciesId;
     }
 
-    const randValue = evolutionPool.size === 1 ? 0 : Utils.randSeedInt(totalWeight);
+    const randValue = evolutionPool.size === 1 ? 0 : randSeedInt(totalWeight);
 
     for (const weight of evolutionPool.keys()) {
       if (randValue < weight) {
@@ -1164,7 +1164,7 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
           Math.min(
             Math.max(
               evolution?.level! +
-                Math.round(Utils.randSeedGauss(0.5, 1 + levelDiff * 0.2) * Math.max(evolution?.wildDelay!, 0.5) * 5) -
+                Math.round(randSeedGauss(0.5, 1 + levelDiff * 0.2) * Math.max(evolution?.wildDelay!, 0.5) * 5) -
                 1,
               2,
               evolution?.level!,
@@ -1182,7 +1182,7 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
         Math.min(
           Math.max(
             lastPrevolutionLevel +
-              Math.round(Utils.randSeedGauss(0.5, 1 + levelDiff * 0.2) * Math.max(evolution?.wildDelay!, 0.5) * 5),
+              Math.round(randSeedGauss(0.5, 1 + levelDiff * 0.2) * Math.max(evolution?.wildDelay!, 0.5) * 5),
             lastPrevolutionLevel + 1,
             evolution?.level!,
           ),
@@ -1367,7 +1367,7 @@ export function getPokerusStarters(): PokemonSpecies[] {
   globalScene.executeWithSeedOffset(
     () => {
       while (pokerusStarters.length < POKERUS_STARTER_COUNT) {
-        const randomSpeciesId = Number.parseInt(Utils.randSeedItem(Object.keys(speciesStarterCosts)), 10);
+        const randomSpeciesId = Number.parseInt(randSeedItem(Object.keys(speciesStarterCosts)), 10);
         const species = getPokemonSpecies(randomSpeciesId);
         if (!pokerusStarters.includes(species)) {
           pokerusStarters.push(species);

--- a/src/data/trainer-names.ts
+++ b/src/data/trainer-names.ts
@@ -1,12 +1,12 @@
 import { TrainerType } from "#enums/trainer-type";
-import * as Utils from "../utils";
+import { toReadableString } from "#app/utils";
 
 class TrainerNameConfig {
   public urls: string[];
   public femaleUrls: string[] | null;
 
   constructor(type: TrainerType, ...urls: string[]) {
-    this.urls = urls.length ? urls : [Utils.toReadableString(TrainerType[type]).replace(/ /g, "_")];
+    this.urls = urls.length ? urls : [toReadableString(TrainerType[type]).replace(/ /g, "_")];
   }
 
   hasGenderVariant(...femaleUrls: string[]): TrainerNameConfig {

--- a/src/data/trainers/trainer-config.ts
+++ b/src/data/trainers/trainer-config.ts
@@ -1,7 +1,7 @@
 import { globalScene } from "#app/global-scene";
 import { modifierTypes } from "#app/modifier/modifier-type";
 import { PokemonMove } from "#app/field/pokemon";
-import * as Utils from "#app/utils";
+import { toReadableString, isNullOrUndefined, randSeedItem, randSeedInt } from "#app/utils";
 import { pokemonEvolutions, pokemonPrevolutions } from "#app/data/balance/pokemon-evolutions";
 import { getPokemonSpecies } from "#app/data/pokemon-species";
 import { tmSpecies } from "#app/data/balance/tms";
@@ -139,7 +139,7 @@ export class TrainerConfig {
   constructor(trainerType: TrainerType, allowLegendaries?: boolean) {
     this.trainerType = trainerType;
     this.trainerAI = new TrainerAI();
-    this.name = Utils.toReadableString(TrainerType[this.getDerivedType()]);
+    this.name = toReadableString(TrainerType[this.getDerivedType()]);
     this.battleBgm = "battle_trainer";
     this.mixedBattleBgm = "battle_trainer";
     this.victoryBgm = "victory_trainer";
@@ -482,10 +482,10 @@ export class TrainerConfig {
         .fill(null)
         .map((_, i) => i)
         .filter(i => shedinjaCanTera || party[i].species.speciesId !== Species.SHEDINJA); // Shedinja can only Tera on Bug specialty type (or no specialty type)
-      const setPartySlot = !Utils.isNullOrUndefined(slot) ? Phaser.Math.Wrap(slot, 0, party.length) : -1; // If we have a tera slot defined, wrap it to party size.
+      const setPartySlot = !isNullOrUndefined(slot) ? Phaser.Math.Wrap(slot, 0, party.length) : -1; // If we have a tera slot defined, wrap it to party size.
       for (let t = 0; t < Math.min(count(), party.length); t++) {
         const randomIndex =
-          partyMemberIndexes.indexOf(setPartySlot) > -1 ? setPartySlot : Utils.randSeedItem(partyMemberIndexes);
+          partyMemberIndexes.indexOf(setPartySlot) > -1 ? setPartySlot : randSeedItem(partyMemberIndexes);
         partyMemberIndexes.splice(partyMemberIndexes.indexOf(randomIndex), 1);
         if (this.hasSpecialtyType()) {
           party[randomIndex].teraType = this.specialtyType;
@@ -555,7 +555,7 @@ export class TrainerConfig {
       initI18n();
     }
 
-    if (!Utils.isNullOrUndefined(specialtyType)) {
+    if (!isNullOrUndefined(specialtyType)) {
       this.setSpecialtyType(specialtyType);
     }
 
@@ -636,7 +636,7 @@ export class TrainerConfig {
       }
       this.setPartyMemberFunc(-(s + 1), getRandomPartyMemberFunc(speciesPool));
     });
-    if (!Utils.isNullOrUndefined(specialtyType)) {
+    if (!isNullOrUndefined(specialtyType)) {
       this.setSpeciesFilter(p => p.isOfType(specialtyType));
       this.setSpecialtyType(specialtyType);
     }
@@ -749,7 +749,7 @@ export class TrainerConfig {
     });
 
     // Set species filter and specialty type if provided, otherwise filter by base total.
-    if (!Utils.isNullOrUndefined(specialtyType)) {
+    if (!isNullOrUndefined(specialtyType)) {
       this.setSpeciesFilter(p => p.isOfType(specialtyType) && p.baseTotal >= ELITE_FOUR_MINIMUM_BST);
       this.setSpecialtyType(specialtyType);
     } else {
@@ -927,7 +927,7 @@ export class TrainerConfig {
    * @returns true if specialtyType is defined and not Type.UNKNOWN
    */
   hasSpecialtyType(): boolean {
-    return !Utils.isNullOrUndefined(this.specialtyType) && this.specialtyType !== PokemonType.UNKNOWN;
+    return !isNullOrUndefined(this.specialtyType) && this.specialtyType !== PokemonType.UNKNOWN;
   }
 
   /**
@@ -1006,7 +1006,7 @@ export function getRandomPartyMemberFunc(
   postProcess?: (enemyPokemon: EnemyPokemon) => void,
 ) {
   return (level: number, strength: PartyMemberStrength) => {
-    let species = Utils.randSeedItem(speciesPool);
+    let species = randSeedItem(speciesPool);
     if (!ignoreEvolution) {
       species = getPokemonSpecies(species).getTrainerSpeciesForLevel(
         level,
@@ -3549,7 +3549,7 @@ export const trainerConfigs: TrainerConfigs = {
     .setPartyMemberFunc(
       5,
       getRandomPartyMemberFunc([Species.URSHIFU], TrainerSlot.TRAINER, true, p => {
-        p.formIndex = Utils.randSeedInt(2, 2); // Random G-Max Urshifu
+        p.formIndex = randSeedInt(2, 2); // Random G-Max Urshifu
         p.generateAndPopulateMoveset();
         p.generateName();
         p.gender = Gender.MALE;
@@ -3659,10 +3659,10 @@ export const trainerConfigs: TrainerConfigs = {
     .setPartyMemberFunc(
       4,
       getRandomPartyMemberFunc([Species.OGERPON], TrainerSlot.TRAINER, true, p => {
-        p.formIndex = Utils.randSeedInt(4); // Random Ogerpon Tera Mask
+        p.formIndex = randSeedInt(4); // Random Ogerpon Tera Mask
         p.generateAndPopulateMoveset();
         p.pokeball = PokeballType.ULTRA_BALL;
-        if (!p.moveset.some(move => !Utils.isNullOrUndefined(move) && move.moveId === Moves.IVY_CUDGEL)) {
+        if (!p.moveset.some(move => !isNullOrUndefined(move) && move.moveId === Moves.IVY_CUDGEL)) {
           // Check if Ivy Cudgel is in the moveset, if not, replace the first move with Ivy Cudgel.
           p.moveset[0] = new PokemonMove(Moves.IVY_CUDGEL);
         }
@@ -4713,10 +4713,10 @@ export const trainerConfigs: TrainerConfigs = {
     .setPartyMemberFunc(
       2,
       getRandomPartyMemberFunc([Species.SILVALLY], TrainerSlot.TRAINER, true, p => {
-        p.formIndex = Utils.randSeedInt(18); // Random Silvally Form
+        p.formIndex = randSeedInt(18); // Random Silvally Form
         p.generateAndPopulateMoveset();
         p.pokeball = PokeballType.ROGUE_BALL;
-        if (!p.moveset.some(move => !Utils.isNullOrUndefined(move) && move.moveId === Moves.MULTI_ATTACK)) {
+        if (!p.moveset.some(move => !isNullOrUndefined(move) && move.moveId === Moves.MULTI_ATTACK)) {
           // Check if Multi Attack is in the moveset, if not, replace the first move with Multi Attack.
           p.moveset[0] = new PokemonMove(Moves.MULTI_ATTACK);
         }
@@ -4833,8 +4833,8 @@ export const trainerConfigs: TrainerConfigs = {
         p.setBoss(true, 2);
         p.generateAndPopulateMoveset();
         p.pokeball = PokeballType.ULTRA_BALL;
-        p.formIndex = Utils.randSeedInt(4, 1); // Shock, Burn, Chill, or Douse Drive
-        if (!p.moveset.some(move => !Utils.isNullOrUndefined(move) && move.moveId === Moves.TECHNO_BLAST)) {
+        p.formIndex = randSeedInt(4, 1); // Shock, Burn, Chill, or Douse Drive
+        if (!p.moveset.some(move => !isNullOrUndefined(move) && move.moveId === Moves.TECHNO_BLAST)) {
           // Check if Techno Blast is in the moveset, if not, replace the first move with Techno Blast.
           p.moveset[2] = new PokemonMove(Moves.TECHNO_BLAST);
         }
@@ -5006,7 +5006,7 @@ export const trainerConfigs: TrainerConfigs = {
       1,
       getRandomPartyMemberFunc([Species.ROTOM], TrainerSlot.TRAINER, true, p => {
         p.generateAndPopulateMoveset();
-        p.formIndex = Utils.randSeedInt(5, 1); // Heat, Wash, Frost, Fan, or Mow
+        p.formIndex = randSeedInt(5, 1); // Heat, Wash, Frost, Fan, or Mow
       }),
     )
     .setPartyMemberFunc(
@@ -5019,7 +5019,7 @@ export const trainerConfigs: TrainerConfigs = {
     .setPartyMemberFunc(
       3,
       getRandomPartyMemberFunc([Species.REVAVROOM], TrainerSlot.TRAINER, true, p => {
-        p.formIndex = Utils.randSeedInt(5, 1); // Random Starmobile form
+        p.formIndex = randSeedInt(5, 1); // Random Starmobile form
         p.generateAndPopulateMoveset();
         p.pokeball = PokeballType.ROGUE_BALL;
       }),

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -5,7 +5,7 @@ import type Pokemon from "../field/pokemon";
 import { PokemonType } from "#enums/pokemon-type";
 import type Move from "./moves/move";
 import { AttackMove } from "./moves/move";
-import * as Utils from "../utils";
+import { randSeedInt } from "#app/utils";
 import { SuppressWeatherEffectAbAttr } from "./ability";
 import { TerrainType, getTerrainName } from "./terrain";
 import i18next from "i18next";
@@ -416,7 +416,7 @@ export function getRandomWeatherType(arena: Arena): WeatherType {
       totalWeight += w.weight;
     }
 
-    const rand = Utils.randSeedInt(totalWeight);
+    const rand = randSeedInt(totalWeight);
     let w = 0;
     for (const weather of weatherPool) {
       w += weather.weight;

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -1,8 +1,7 @@
 import { globalScene } from "#app/global-scene";
 import type { BiomeTierTrainerPools, PokemonPools } from "#app/data/balance/biomes";
 import { biomePokemonPools, BiomePoolTier, biomeTrainerPools } from "#app/data/balance/biomes";
-import type { Constructor } from "#app/utils";
-import * as Utils from "#app/utils";
+import { randSeedInt, NumberHolder, isNullOrUndefined, type Constructor } from "#app/utils";
 import type PokemonSpecies from "#app/data/pokemon-species";
 import { getPokemonSpecies } from "#app/data/pokemon-species";
 import {
@@ -124,7 +123,7 @@ export class Arena {
     if (typeof luckValue !== "undefined") {
       luckModifier = luckValue * (isBossSpecies ? 0.5 : 2);
     }
-    const tierValue = Utils.randSeedInt(randVal - luckModifier);
+    const tierValue = randSeedInt(randVal - luckModifier);
     let tier = !isBossSpecies
       ? tierValue >= 156
         ? BiomePoolTier.COMMON
@@ -153,7 +152,7 @@ export class Arena {
     if (!tierPool.length) {
       ret = globalScene.randomSpecies(waveIndex, level);
     } else {
-      const entry = tierPool[Utils.randSeedInt(tierPool.length)];
+      const entry = tierPool[randSeedInt(tierPool.length)];
       let species: Species;
       if (typeof entry === "number") {
         species = entry as Species;
@@ -164,7 +163,7 @@ export class Arena {
           if (level >= levelThreshold) {
             const speciesIds = entry[levelThreshold];
             if (speciesIds.length > 1) {
-              species = speciesIds[Utils.randSeedInt(speciesIds.length)];
+              species = speciesIds[randSeedInt(speciesIds.length)];
             } else {
               species = speciesIds[0];
             }
@@ -211,7 +210,7 @@ export class Arena {
       !!this.trainerPool[BiomePoolTier.BOSS].length &&
       (globalScene.gameMode.isTrainerBoss(waveIndex, this.biomeType, globalScene.offsetGym) || isBoss);
     console.log(isBoss, this.trainerPool);
-    const tierValue = Utils.randSeedInt(!isTrainerBoss ? 512 : 64);
+    const tierValue = randSeedInt(!isTrainerBoss ? 512 : 64);
     let tier = !isTrainerBoss
       ? tierValue >= 156
         ? BiomePoolTier.COMMON
@@ -235,7 +234,7 @@ export class Arena {
       tier--;
     }
     const tierPool = this.trainerPool[tier] || [];
-    return !tierPool.length ? TrainerType.BREEDER : tierPool[Utils.randSeedInt(tierPool.length)];
+    return !tierPool.length ? TrainerType.BREEDER : tierPool[randSeedInt(tierPool.length)];
   }
 
   getSpeciesFormIndex(species: PokemonSpecies): number {
@@ -336,9 +335,9 @@ export class Arena {
       return false;
     }
 
-    const weatherDuration = new Utils.NumberHolder(0);
+    const weatherDuration = new NumberHolder(0);
 
-    if (!Utils.isNullOrUndefined(user)) {
+    if (!isNullOrUndefined(user)) {
       weatherDuration.value = 5;
       globalScene.applyModifier(FieldEffectModifier, user.isPlayer(), user, weatherDuration);
     }
@@ -417,9 +416,9 @@ export class Arena {
 
     const oldTerrainType = this.terrain?.terrainType || TerrainType.NONE;
 
-    const terrainDuration = new Utils.NumberHolder(0);
+    const terrainDuration = new NumberHolder(0);
 
-    if (!Utils.isNullOrUndefined(user)) {
+    if (!isNullOrUndefined(user)) {
       terrainDuration.value = 5;
       globalScene.applyModifier(FieldEffectModifier, user.isPlayer(), user, terrainDuration);
     }
@@ -1013,7 +1012,7 @@ export class ArenaBase extends Phaser.GameObjects.Container {
     if (!this.player) {
       globalScene.executeWithSeedOffset(
         () => {
-          this.propValue = propValue === undefined ? (hasProps ? Utils.randSeedInt(8) : 0) : propValue;
+          this.propValue = propValue === undefined ? (hasProps ? randSeedInt(8) : 0) : propValue;
           this.props.forEach((prop, p) => {
             const propKey = `${biomeKey}_b${hasProps ? `_${p + 1}` : ""}`;
             prop.setTexture(propKey);

--- a/src/field/damage-number-handler.ts
+++ b/src/field/damage-number-handler.ts
@@ -2,7 +2,7 @@ import { TextStyle, addTextObject } from "../ui/text";
 import type { DamageResult } from "./pokemon";
 import type Pokemon from "./pokemon";
 import { HitResult } from "./pokemon";
-import * as Utils from "../utils";
+import { formatStat, fixedInt } from "#app/utils";
 import type { BattlerIndex } from "../battle";
 import { globalScene } from "#app/global-scene";
 
@@ -30,7 +30,7 @@ export default class DamageNumberHandler {
     const damageNumber = addTextObject(
       target.x,
       -(globalScene.game.canvas.height / 6) + target.y - target.getSprite().height / 2,
-      Utils.formatStat(amount, true),
+      formatStat(amount, true),
       TextStyle.SUMMARY,
     );
     damageNumber.setName("text-damage-number");
@@ -86,14 +86,14 @@ export default class DamageNumberHandler {
     if (globalScene.damageNumbersMode === 1) {
       globalScene.tweens.add({
         targets: damageNumber,
-        duration: Utils.fixedInt(750),
+        duration: fixedInt(750),
         alpha: 1,
         y: "-=32",
       });
       globalScene.tweens.add({
         delay: 375,
         targets: damageNumber,
-        duration: Utils.fixedInt(625),
+        duration: fixedInt(625),
         alpha: 0,
         ease: "Sine.easeIn",
         onComplete: () => {
@@ -110,7 +110,7 @@ export default class DamageNumberHandler {
       targets: damageNumber,
       tweens: [
         {
-          duration: Utils.fixedInt(250),
+          duration: fixedInt(250),
           alpha: 1,
           scaleX: 0.75 * baseScale,
           scaleY: 1.25 * baseScale,
@@ -118,7 +118,7 @@ export default class DamageNumberHandler {
           ease: "Cubic.easeOut",
         },
         {
-          duration: Utils.fixedInt(175),
+          duration: fixedInt(175),
           alpha: 1,
           scaleX: 0.875 * baseScale,
           scaleY: 1.125 * baseScale,
@@ -126,59 +126,59 @@ export default class DamageNumberHandler {
           ease: "Cubic.easeIn",
         },
         {
-          duration: Utils.fixedInt(100),
+          duration: fixedInt(100),
           scaleX: 1.25 * baseScale,
           scaleY: 0.75 * baseScale,
           ease: "Cubic.easeOut",
         },
         {
-          duration: Utils.fixedInt(175),
+          duration: fixedInt(175),
           scaleX: 0.875 * baseScale,
           scaleY: 1.125 * baseScale,
           y: "-=8",
           ease: "Cubic.easeOut",
         },
         {
-          duration: Utils.fixedInt(50),
+          duration: fixedInt(50),
           scaleX: 0.925 * baseScale,
           scaleY: 1.075 * baseScale,
           y: "+=8",
           ease: "Cubic.easeIn",
         },
         {
-          duration: Utils.fixedInt(100),
+          duration: fixedInt(100),
           scaleX: 1.125 * baseScale,
           scaleY: 0.875 * baseScale,
           ease: "Cubic.easeOut",
         },
         {
-          duration: Utils.fixedInt(175),
+          duration: fixedInt(175),
           scaleX: 0.925 * baseScale,
           scaleY: 1.075 * baseScale,
           y: "-=4",
           ease: "Cubic.easeOut",
         },
         {
-          duration: Utils.fixedInt(50),
+          duration: fixedInt(50),
           scaleX: 0.975 * baseScale,
           scaleY: 1.025 * baseScale,
           y: "+=4",
           ease: "Cubic.easeIn",
         },
         {
-          duration: Utils.fixedInt(100),
+          duration: fixedInt(100),
           scaleX: 1.075 * baseScale,
           scaleY: 0.925 * baseScale,
           ease: "Cubic.easeOut",
         },
         {
-          duration: Utils.fixedInt(25),
+          duration: fixedInt(25),
           scaleX: baseScale,
           scaleY: baseScale,
           ease: "Cubic.easeOut",
         },
         {
-          delay: Utils.fixedInt(500),
+          delay: fixedInt(500),
           alpha: 0,
           onComplete: () => {
             this.damageNumbers

--- a/src/field/pokemon-sprite-sparkle-handler.ts
+++ b/src/field/pokemon-sprite-sparkle-handler.ts
@@ -1,6 +1,6 @@
 import { globalScene } from "#app/global-scene";
 import Pokemon from "./pokemon";
-import * as Utils from "../utils";
+import { fixedInt, randInt } from "#app/utils";
 
 export default class PokemonSpriteSparkleHandler {
   private sprites: Set<Phaser.GameObjects.Sprite>;
@@ -9,7 +9,7 @@ export default class PokemonSpriteSparkleHandler {
     this.sprites = new Set();
 
     globalScene.tweens.addCounter({
-      duration: Utils.fixedInt(200),
+      duration: fixedInt(200),
       from: 0,
       to: 1,
       yoyo: true,
@@ -36,7 +36,7 @@ export default class PokemonSpriteSparkleHandler {
       const parent = (pokemon || s).parentContainer;
       const texture = s.texture;
       const [width, height] = [texture.source[0].width, texture.source[0].height];
-      const [pixelX, pixelY] = [Utils.randInt(width), Utils.randInt(height)];
+      const [pixelX, pixelY] = [randInt(width), randInt(height)];
       const ratioX = s.width / width;
       const ratioY = s.height / height;
       const pixel = texture.manager.getPixel(pixelX, pixelY, texture.key, "__BASE");
@@ -51,7 +51,7 @@ export default class PokemonSpriteSparkleHandler {
         sparkle.setName("sprite-tera-sparkle");
         sparkle.play("tera_sparkle");
         parent.add(sparkle);
-        s.scene.time.delayedCall(Utils.fixedInt(Math.floor((1000 / 12) * 13)), () => sparkle.destroy());
+        s.scene.time.delayedCall(fixedInt(Math.floor((1000 / 12) * 13)), () => sparkle.destroy());
       }
     }
   }

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -11,7 +11,7 @@ import { TrainerSlot } from "#enums/trainer-slot";
 import { TrainerPoolTier } from "#enums/trainer-pool-tier";
 import { TeraAIMode } from "#enums/tera-ai-mode";
 import type { EnemyPokemon } from "#app/field/pokemon";
-import * as Utils from "#app/utils";
+import { randSeedWeightedItem, randSeedItem, randSeedInt } from "#app/utils";
 import type { PersistentModifier } from "#app/modifier/modifier";
 import { ArenaTagSide, ArenaTrapTag } from "#app/data/arena-tag";
 import { getIsInitialized, initI18n } from "#app/plugins/i18n";
@@ -58,7 +58,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
     this.partyTemplateIndex = Math.min(
       partyTemplateIndex !== undefined
         ? partyTemplateIndex
-        : Utils.randSeedWeightedItem(this.config.partyTemplates.map((_, i) => i)),
+        : randSeedWeightedItem(this.config.partyTemplates.map((_, i) => i)),
       this.config.partyTemplates.length - 1,
     );
     const classKey = `trainersCommon:${TrainerType[trainerType]}`;
@@ -71,9 +71,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
             ? ".FEMALE"
             : ".MALE"
           : "";
-        const trainerKey = Utils.randSeedItem(
-          Object.keys(i18next.t(`${classKey}${genderKey}`, { returnObjects: true })),
-        );
+        const trainerKey = randSeedItem(Object.keys(i18next.t(`${classKey}${genderKey}`, { returnObjects: true })));
         this.nameKey = `${classKey}${genderKey}.${trainerKey}`;
       }
       this.name = i18next.t(this.nameKey);
@@ -87,7 +85,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
           }
         } else {
           const partnerGenderKey = i18next.exists(`${classKey}.FEMALE`) ? ".FEMALE" : "";
-          const partnerTrainerKey = Utils.randSeedItem(
+          const partnerTrainerKey = randSeedItem(
             Object.keys(
               i18next.t(`${classKey}${partnerGenderKey}`, {
                 returnObjects: true,
@@ -420,7 +418,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
 
         // If useNewSpeciesPool is true, we need to generate a new species from the new species pool, otherwise we generate a random species
         let species = useNewSpeciesPool
-          ? getPokemonSpecies(newSpeciesPool[Math.floor(Utils.randSeedInt(newSpeciesPool.length))])
+          ? getPokemonSpecies(newSpeciesPool[Math.floor(randSeedInt(newSpeciesPool.length))])
           : template.isSameSpecies(index) && index > offset
             ? getPokemonSpecies(
                 battle.enemyParty[offset].species.getTrainerSpeciesForLevel(
@@ -461,7 +459,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
 
     let baseSpecies: PokemonSpecies;
     if (this.config.speciesPools) {
-      const tierValue = Utils.randSeedInt(512);
+      const tierValue = randSeedInt(512);
       let tier =
         tierValue >= 156
           ? TrainerPoolTier.COMMON
@@ -480,7 +478,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
         tier--;
       }
       const tierPool = this.config.speciesPools[tier];
-      baseSpecies = getPokemonSpecies(Utils.randSeedItem(tierPool));
+      baseSpecies = getPokemonSpecies(randSeedItem(tierPool));
     } else {
       baseSpecies = globalScene.randomSpecies(battle.waveIndex, level, false, this.config.speciesFilter);
     }
@@ -619,7 +617,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
     if (maxScorePartyMemberIndexes.length > 1) {
       let rand: number;
       globalScene.executeWithSeedOffset(
-        () => (rand = Utils.randSeedInt(maxScorePartyMemberIndexes.length)),
+        () => (rand = randSeedInt(maxScorePartyMemberIndexes.length)),
         globalScene.currentBattle.turn << 2,
       );
       return maxScorePartyMemberIndexes[rand!];

--- a/src/game-mode.ts
+++ b/src/game-mode.ts
@@ -7,7 +7,7 @@ import type PokemonSpecies from "./data/pokemon-species";
 import { allSpecies } from "./data/pokemon-species";
 import type { Arena } from "./field/arena";
 import Overrides from "#app/overrides";
-import * as Utils from "./utils";
+import { randSeedInt, randSeedItem } from "#app/utils";
 import { Biome } from "#enums/biome";
 import { Species } from "#enums/species";
 import { Challenges } from "./enums/challenges";
@@ -186,7 +186,7 @@ export class GameMode implements GameModeConfig {
           if (w < waveIndex) {
             globalScene.executeWithSeedOffset(() => {
               const waveTrainerChance = arena.getTrainerChance();
-              if (!Utils.randSeedInt(waveTrainerChance)) {
+              if (!randSeedInt(waveTrainerChance)) {
                 allowTrainerBattle = false;
               }
             }, w);
@@ -196,7 +196,7 @@ export class GameMode implements GameModeConfig {
           }
         }
       }
-      return Boolean(allowTrainerBattle && trainerChance && !Utils.randSeedInt(trainerChance));
+      return Boolean(allowTrainerBattle && trainerChance && !randSeedInt(trainerChance));
     }
     return false;
   }
@@ -222,7 +222,7 @@ export class GameMode implements GameModeConfig {
           s.speciesId !== Species.ETERNATUS &&
           s.speciesId !== Species.ARCEUS,
       );
-      return Utils.randSeedItem(allFinalBossSpecies);
+      return randSeedItem(allFinalBossSpecies);
     }
 
     return null;

--- a/src/inputs-controller.ts
+++ b/src/inputs-controller.ts
@@ -1,6 +1,5 @@
 import Phaser from "phaser";
-import * as Utils from "./utils";
-import { deepCopy } from "./utils";
+import { deepCopy, getEnumValues } from "#app/utils";
 import pad_generic from "./configs/inputs/pad_generic";
 import pad_unlicensedSNES from "./configs/inputs/pad_unlicensedSNES";
 import pad_xbox360 from "./configs/inputs/pad_xbox360";
@@ -102,7 +101,7 @@ export class InputsController {
       [Device.KEYBOARD]: "default",
     };
 
-    for (const b of Utils.getEnumValues(Button)) {
+    for (const b of getEnumValues(Button)) {
       this.interactions[b] = {
         pressTime: false,
         isPressed: false,

--- a/src/loading-scene.ts
+++ b/src/loading-scene.ts
@@ -4,7 +4,7 @@ import CacheBustedLoaderPlugin from "#app/plugins/cache-busted-loader-plugin";
 import { SceneBase } from "#app/scene-base";
 import { WindowVariant, getWindowVariantSuffix } from "#app/ui/ui-theme";
 import { isMobile } from "#app/touch-controls";
-import * as Utils from "#app/utils";
+import { localPing, getEnumValues, hasAllLocalizedSprites, getEnumKeys } from "#app/utils";
 import { initPokemonPrevolutions, initPokemonStarters } from "#app/data/balance/pokemon-evolutions";
 import { initBiomes } from "#app/data/balance/biomes";
 import { initEggMoves } from "#app/data/balance/egg-moves";
@@ -34,7 +34,7 @@ export class LoadingScene extends SceneBase {
   }
 
   preload() {
-    Utils.localPing();
+    localPing();
     this.load["manifest"] = this.game["manifest"];
 
     this.loadImage("loading_bg", "arenas");
@@ -49,7 +49,7 @@ export class LoadingScene extends SceneBase {
     this.loadImage("friendship_overlay", "ui");
     this.loadImage("cursor", "ui");
     this.loadImage("cursor_reverse", "ui");
-    for (const wv of Utils.getEnumValues(WindowVariant)) {
+    for (const wv of getEnumValues(WindowVariant)) {
       for (let w = 1; w <= 5; w++) {
         this.loadImage(`window_${w}${getWindowVariantSuffix(wv)}`, "ui/windows");
       }
@@ -177,7 +177,7 @@ export class LoadingScene extends SceneBase {
 
     this.loadImage("default_bg", "arenas");
     // Load arena images
-    Utils.getEnumValues(Biome).map(bt => {
+    getEnumValues(Biome).map(bt => {
       const btKey = Biome[bt].toLowerCase();
       const isBaseAnimated = btKey === "end";
       const baseAKey = `${btKey}_a`;
@@ -239,7 +239,7 @@ export class LoadingScene extends SceneBase {
     // Get current lang and load the types atlas for it. English will only load types while all other languages will load types and types_<lang>
     const lang = i18next.resolvedLanguage;
     if (lang !== "en") {
-      if (Utils.hasAllLocalizedSprites(lang)) {
+      if (hasAllLocalizedSprites(lang)) {
         this.loadAtlas(`statuses_${lang}`, "");
         this.loadAtlas(`types_${lang}`, "");
       } else {
@@ -268,7 +268,7 @@ export class LoadingScene extends SceneBase {
     this.loadAtlas("egg_icons", "egg");
     this.loadAtlas("egg_shard", "egg");
     this.loadAtlas("egg_lightrays", "egg");
-    for (const gt of Utils.getEnumKeys(GachaType)) {
+    for (const gt of getEnumKeys(GachaType)) {
       const key = gt.toLowerCase();
       this.loadImage(`gacha_${key}`, "egg");
       this.loadAtlas(`gacha_underlay_${key}`, "egg");

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -297,16 +297,16 @@ export class MoveEffectPhase extends PokemonPhase {
           );
         }
 
-          /** Is the target protected by Protect, etc. or a relevant conditional protection effect? */
-          const isProtected =
-            ![MoveTarget.ENEMY_SIDE, MoveTarget.BOTH_SIDES].includes(this.move.getMove().moveTarget) &&
-            (bypassIgnoreProtect.value ||
-              !this.move.getMove().doesFlagEffectApply({ flag: MoveFlags.IGNORE_PROTECT, user, target })) &&
-            (hasConditionalProtectApplied.value ||
-              (!target.findTags(t => t instanceof DamageProtectedTag).length &&
-                target.findTags(t => t instanceof ProtectedTag).find(t => target.lapseTag(t.tagType))) ||
-              (this.move.getMove().category !== MoveCategory.STATUS &&
-                target.findTags(t => t instanceof DamageProtectedTag).find(t => target.lapseTag(t.tagType))));
+        /** Is the target protected by Protect, etc. or a relevant conditional protection effect? */
+        const isProtected =
+          ![MoveTarget.ENEMY_SIDE, MoveTarget.BOTH_SIDES].includes(this.move.getMove().moveTarget) &&
+          (bypassIgnoreProtect.value ||
+            !this.move.getMove().doesFlagEffectApply({ flag: MoveFlags.IGNORE_PROTECT, user, target })) &&
+          (hasConditionalProtectApplied.value ||
+            (!target.findTags(t => t instanceof DamageProtectedTag).length &&
+              target.findTags(t => t instanceof ProtectedTag).find(t => target.lapseTag(t.tagType))) ||
+            (this.move.getMove().category !== MoveCategory.STATUS &&
+              target.findTags(t => t instanceof DamageProtectedTag).find(t => target.lapseTag(t.tagType))));
 
         /** Is the target hidden by the effects of its Commander ability? */
         const isCommanding =
@@ -316,11 +316,11 @@ export class MoveEffectPhase extends PokemonPhase {
         /** Is the target reflecting status moves from the magic coat move? */
         const isReflecting = !!target.getTag(BattlerTagType.MAGIC_COAT);
 
-          /** Is the target's magic bounce ability not ignored and able to reflect this move? */
-          const canMagicBounce =
-            !isReflecting &&
-            !move.doesFlagEffectApply({ flag: MoveFlags.IGNORE_ABILITIES, user, target }) &&
-            target.hasAbilityWithAttr(ReflectStatusMoveAbAttr);
+        /** Is the target's magic bounce ability not ignored and able to reflect this move? */
+        const canMagicBounce =
+          !isReflecting &&
+          !move.doesFlagEffectApply({ flag: MoveFlags.IGNORE_ABILITIES, user, target }) &&
+          target.hasAbilityWithAttr(ReflectStatusMoveAbAttr);
 
         const semiInvulnerableTag = target.getTag(SemiInvulnerableTag);
 
@@ -333,21 +333,19 @@ export class MoveEffectPhase extends PokemonPhase {
           (isReflecting || canMagicBounce) &&
           !semiInvulnerableTag;
 
-          // If the move will bounce, then queue the bounce and move on to the next target
-          if (!target.switchOutStatus && willBounce) {
-            const newTargets = move.isMultiTarget()
-              ? getMoveTargets(target, move.id).targets
-              : [user.getBattlerIndex()];
-            if (!isReflecting) {
-              // TODO: Ability displays should be handled by the ability
-              queuedPhases.push(
-                new ShowAbilityPhase(
-                  target.getBattlerIndex(),
-                  target.getPassiveAbility().hasAttr(ReflectStatusMoveAbAttr),
-                ),
-              );
-              queuedPhases.push(new HideAbilityPhase());
-            }
+        // If the move will bounce, then queue the bounce and move on to the next target
+        if (!target.switchOutStatus && willBounce) {
+          const newTargets = move.isMultiTarget() ? getMoveTargets(target, move.id).targets : [user.getBattlerIndex()];
+          if (!isReflecting) {
+            // TODO: Ability displays should be handled by the ability
+            queuedPhases.push(
+              new ShowAbilityPhase(
+                target.getBattlerIndex(),
+                target.getPassiveAbility().hasAttr(ReflectStatusMoveAbAttr),
+              ),
+            );
+            queuedPhases.push(new HideAbilityPhase());
+          }
 
           queuedPhases.push(new MovePhase(target, newTargets, new PokemonMove(move.id, 0, 0, true), true, true, true));
           continue;

--- a/src/phases/revival-blessing-phase.ts
+++ b/src/phases/revival-blessing-phase.ts
@@ -4,7 +4,7 @@ import type { PartyOption } from "#app/ui/party-ui-handler";
 import PartyUiHandler, { PartyUiMode } from "#app/ui/party-ui-handler";
 import { Mode } from "#app/ui/ui";
 import i18next from "i18next";
-import * as Utils from "#app/utils";
+import { toDmgValue, isNullOrUndefined } from "#app/utils";
 import { BattlePhase } from "#app/phases/battle-phase";
 import { SwitchSummonPhase } from "#app/phases/switch-summon-phase";
 import { ToggleDoublePositionPhase } from "#app/phases/toggle-double-position-phase";
@@ -33,7 +33,7 @@ export class RevivalBlessingPhase extends BattlePhase {
 
           pokemon.resetTurnData();
           pokemon.resetStatus();
-          pokemon.heal(Math.min(Utils.toDmgValue(0.5 * pokemon.getMaxHp()), pokemon.getMaxHp()));
+          pokemon.heal(Math.min(toDmgValue(0.5 * pokemon.getMaxHp()), pokemon.getMaxHp()));
           globalScene.queueMessage(
             i18next.t("moveTriggers:revivalBlessing", {
               pokemonName: pokemon.name,
@@ -46,7 +46,7 @@ export class RevivalBlessingPhase extends BattlePhase {
           if (
             globalScene.currentBattle.double &&
             globalScene.getPlayerParty().length > 1 &&
-            !Utils.isNullOrUndefined(allyPokemon)
+            !isNullOrUndefined(allyPokemon)
           ) {
             if (slotIndex <= 1) {
               // Revived ally pokemon

--- a/src/phases/select-starter-phase.ts
+++ b/src/phases/select-starter-phase.ts
@@ -12,7 +12,7 @@ import type { Starter } from "#app/ui/starter-select-ui-handler";
 import { Mode } from "#app/ui/ui";
 import type { Species } from "#enums/species";
 import SoundFade from "phaser3-rex-plugins/plugins/soundfade";
-import * as Utils from "../utils";
+import { isNullOrUndefined } from "#app/utils";
 
 export class SelectStarterPhase extends Phase {
   start() {
@@ -49,7 +49,7 @@ export class SelectStarterPhase extends Phase {
       let starterFormIndex = Math.min(starterProps.formIndex, Math.max(starter.species.forms.length - 1, 0));
       if (
         starter.species.speciesId in Overrides.STARTER_FORM_OVERRIDES &&
-        !Utils.isNullOrUndefined(Overrides.STARTER_FORM_OVERRIDES[starter.species.speciesId]) &&
+        !isNullOrUndefined(Overrides.STARTER_FORM_OVERRIDES[starter.species.speciesId]) &&
         starter.species.forms[Overrides.STARTER_FORM_OVERRIDES[starter.species.speciesId]!]
       ) {
         starterFormIndex = Overrides.STARTER_FORM_OVERRIDES[starter.species.speciesId]!;
@@ -87,7 +87,7 @@ export class SelectStarterPhase extends Phase {
         starterPokemon.nickname = starter.nickname;
       }
 
-      if (!Utils.isNullOrUndefined(starter.teraType)) {
+      if (!isNullOrUndefined(starter.teraType)) {
         starterPokemon.teraType = starter.teraType;
       } else {
         starterPokemon.teraType = starterPokemon.species.type1;

--- a/src/pipelines/field-sprite.ts
+++ b/src/pipelines/field-sprite.ts
@@ -1,6 +1,6 @@
 import { globalScene } from "#app/global-scene";
 import { TerrainType, getTerrainColor } from "../data/terrain";
-import * as Utils from "../utils";
+import { getCurrentTime } from "#app/utils";
 import fieldSpriteFragShader from "./glsl/fieldSpriteFragShader.frag?raw";
 import spriteVertShader from "./glsl/spriteShader.vert?raw";
 
@@ -34,7 +34,7 @@ export default class FieldSpritePipeline extends Phaser.Renderer.WebGL.Pipelines
 
     const time = globalScene.currentBattle?.waveIndex
       ? ((globalScene.currentBattle.waveIndex + globalScene.waveCycleOffset) % 40) / 40 // ((new Date().getSeconds() * 1000 + new Date().getMilliseconds()) % 10000) / 10000
-      : Utils.getCurrentTime();
+      : getCurrentTime();
     this.set1f("time", time);
     this.set1i("ignoreTimeTint", ignoreTimeTint ? 1 : 0);
     this.set1i("isOutside", globalScene.arena.isOutside() ? 1 : 0);

--- a/src/pipelines/sprite.ts
+++ b/src/pipelines/sprite.ts
@@ -3,7 +3,7 @@ import MysteryEncounterIntroVisuals from "#app/field/mystery-encounter-intro";
 import Pokemon from "#app/field/pokemon";
 import Trainer from "#app/field/trainer";
 import { globalScene } from "#app/global-scene";
-import * as Utils from "#app/utils";
+import { rgbHexToRgba } from "#app/utils";
 import FieldSpritePipeline from "./field-sprite";
 import spriteFragShader from "./glsl/spriteFragShader.frag?raw";
 import spriteVertShader from "./glsl/spriteShader.vert?raw";
@@ -144,8 +144,8 @@ export default class SpritePipeline extends FieldSpritePipeline {
         const baseColors = Object.keys(variantColors[variant]);
         for (let c = 0; c < 32; c++) {
           if (c < baseColors.length) {
-            const baseColor = Array.from(Object.values(Utils.rgbHexToRgba(baseColors[c])));
-            const variantColor = Array.from(Object.values(Utils.rgbHexToRgba(variantColors[variant][baseColors[c]])));
+            const baseColor = Array.from(Object.values(rgbHexToRgba(baseColors[c])));
+            const variantColor = Array.from(Object.values(rgbHexToRgba(variantColors[variant][baseColors[c]])));
             flatBaseColors.splice(flatBaseColors.length, 0, ...baseColor);
             flatVariantColors.splice(flatVariantColors.length, 0, ...variantColor.map(c => c / 255.0));
           } else {

--- a/src/system/achv.ts
+++ b/src/system/achv.ts
@@ -2,7 +2,7 @@ import type { Modifier } from "typescript";
 import { TurnHeldItemTransferModifier } from "../modifier/modifier";
 import { pokemonEvolutions } from "#app/data/balance/pokemon-evolutions";
 import i18next from "i18next";
-import * as Utils from "../utils";
+import { NumberHolder } from "#app/utils";
 import { PlayerGender } from "#enums/player-gender";
 import type { Challenge } from "#app/data/challenge";
 import {
@@ -138,7 +138,7 @@ export class DamageAchv extends Achv {
       "",
       iconImage,
       score,
-      (args: any[]) => (args[0] instanceof Utils.NumberHolder ? args[0].value : args[0]) >= this.damageAmount,
+      (args: any[]) => (args[0] instanceof NumberHolder ? args[0].value : args[0]) >= this.damageAmount,
     );
     this.damageAmount = damageAmount;
   }
@@ -154,7 +154,7 @@ export class HealAchv extends Achv {
       "",
       iconImage,
       score,
-      (args: any[]) => (args[0] instanceof Utils.NumberHolder ? args[0].value : args[0]) >= this.healAmount,
+      (args: any[]) => (args[0] instanceof NumberHolder ? args[0].value : args[0]) >= this.healAmount,
     );
     this.healAmount = healAmount;
   }
@@ -170,7 +170,7 @@ export class LevelAchv extends Achv {
       "",
       iconImage,
       score,
-      (args: any[]) => (args[0] instanceof Utils.NumberHolder ? args[0].value : args[0]) >= this.level,
+      (args: any[]) => (args[0] instanceof NumberHolder ? args[0].value : args[0]) >= this.level,
     );
     this.level = level;
   }

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -8,7 +8,7 @@ import { pokemonPrevolutions } from "#app/data/balance/pokemon-evolutions";
 import type PokemonSpecies from "#app/data/pokemon-species";
 import { allSpecies, getPokemonSpecies } from "#app/data/pokemon-species";
 import { speciesStarterCosts } from "#app/data/balance/starters";
-import * as Utils from "#app/utils";
+import { randInt, getEnumKeys, isLocal, executeIf, fixedInt, randSeedItem, NumberHolder } from "#app/utils";
 import Overrides from "#app/overrides";
 import PokemonData from "#app/system/pokemon-data";
 import PersistentModifierData from "#app/system/modifier-data";
@@ -37,6 +37,7 @@ import { setSettingGamepad, SettingGamepad, settingGamepadDefaults } from "#app/
 import type { SettingKeyboard } from "#app/system/settings/settings-keyboard";
 import { setSettingKeyboard } from "#app/system/settings/settings-keyboard";
 import { TagAddedEvent, TerrainChangedEvent, WeatherChangedEvent } from "#app/events/arena";
+// biome-ignore lint/style/noNamespaceImport: Something weird is going on here and I don't want to touch it
 import * as Modifier from "#app/modifier/modifier";
 import { StatusEffect } from "#enums/status-effect";
 import ChallengeData from "#app/system/challenge-data";
@@ -360,8 +361,8 @@ export class GameData {
     this.loadSettings();
     this.loadGamepadSettings();
     this.loadMappingConfigs();
-    this.trainerId = Utils.randInt(65536);
-    this.secretId = Utils.randInt(65536);
+    this.trainerId = randInt(65536);
+    this.secretId = randInt(65536);
     this.starterData = {};
     this.gameStats = new GameStats();
     this.runHistory = {};
@@ -589,7 +590,7 @@ export class GameData {
         }
 
         if (systemData.voucherCounts) {
-          Utils.getEnumKeys(VoucherType).forEach(key => {
+          getEnumKeys(VoucherType).forEach(key => {
             const index = VoucherType[key];
             this.voucherCounts[index] = systemData.voucherCounts[index] || 0;
           });
@@ -617,7 +618,7 @@ export class GameData {
    * At the moment, only retrievable from locale cache
    */
   async getRunHistoryData(): Promise<RunHistoryData> {
-    if (!Utils.isLocal) {
+    if (!isLocal) {
       /**
        * Networking Code DO NOT DELETE!
        * Note: Might have to be migrated to `pokerogue-api.ts`
@@ -1035,6 +1036,7 @@ export class GameData {
   }
 
   getSession(slotId: number): Promise<SessionSaveData | null> {
+    // biome-ignore lint/suspicious/noAsyncPromiseExecutor: <explanation>
     return new Promise(async (resolve, reject) => {
       if (slotId < 0) {
         return resolve(null);
@@ -1075,6 +1077,7 @@ export class GameData {
   }
 
   loadSession(slotId: number, sessionData?: SessionSaveData): Promise<boolean> {
+    // biome-ignore lint/suspicious/noAsyncPromiseExecutor: <explanation>
     return new Promise(async (resolve, reject) => {
       try {
         const initSessionFromData = async (sessionData: SessionSaveData) => {
@@ -1406,7 +1409,7 @@ export class GameData {
 
   saveAll(skipVerification = false, sync = false, useCachedSession = false, useCachedSystem = false): Promise<boolean> {
     return new Promise<boolean>(resolve => {
-      Utils.executeIf(!skipVerification, updateUserInfo).then(success => {
+      executeIf(!skipVerification, updateUserInfo).then(success => {
         if (success !== null && !success) {
           return resolve(false);
         }
@@ -1586,7 +1589,7 @@ export class GameData {
           }
 
           const displayError = (error: string) =>
-            globalScene.ui.showText(error, null, () => globalScene.ui.showText("", 0), Utils.fixedInt(1500));
+            globalScene.ui.showText(error, null, () => globalScene.ui.showText("", 0), fixedInt(1500));
           dataName = dataName!; // tell TS compiler that dataName is defined!
 
           if (!valid) {
@@ -1594,7 +1597,7 @@ export class GameData {
               `Your ${dataName} data could not be loaded. It may be corrupted.`,
               null,
               () => globalScene.ui.showText("", 0),
-              Utils.fixedInt(1500),
+              fixedInt(1500),
             );
           }
 
@@ -1687,7 +1690,7 @@ export class GameData {
       () => {
         const neutralNatures = [Nature.HARDY, Nature.DOCILE, Nature.SERIOUS, Nature.BASHFUL, Nature.QUIRKY];
         for (let s = 0; s < defaultStarterSpecies.length; s++) {
-          defaultStarterNatures.push(Utils.randSeedItem(neutralNatures));
+          defaultStarterNatures.push(randSeedItem(neutralNatures));
         }
       },
       0,
@@ -2188,7 +2191,7 @@ export class GameData {
       value = decrementValue(value);
     }
 
-    const cost = new Utils.NumberHolder(value);
+    const cost = new NumberHolder(value);
     applyChallenges(ChallengeType.STARTER_COST, speciesId, cost);
 
     return cost.value;
@@ -2216,7 +2219,7 @@ export class GameData {
         entry.hatchedCount = 0;
       }
       if (!entry.hasOwnProperty("natureAttr") || (entry.caughtAttr && !entry.natureAttr)) {
-        entry.natureAttr = this.defaultDexData?.[k].natureAttr || 1 << Utils.randInt(25, 1);
+        entry.natureAttr = this.defaultDexData?.[k].natureAttr || 1 << randInt(25, 1);
       }
     }
   }

--- a/src/system/game-speed.ts
+++ b/src/system/game-speed.ts
@@ -3,7 +3,7 @@ import type FadeIn from "phaser3-rex-plugins/plugins/audio/fade/FadeIn";
 import type FadeOut from "phaser3-rex-plugins/plugins/audio/fade/FadeOut";
 import type BattleScene from "#app/battle-scene";
 import { globalScene } from "#app/global-scene";
-import * as Utils from "../utils";
+import { FixedInt } from "#app/utils";
 
 type FadeInType = typeof FadeIn;
 type FadeOutType = typeof FadeOut;
@@ -11,9 +11,9 @@ type FadeOutType = typeof FadeOut;
 export function initGameSpeed() {
   const thisArg = this as BattleScene;
 
-  const transformValue = (value: number | Utils.FixedInt): number => {
-    if (value instanceof Utils.FixedInt) {
-      return (value as Utils.FixedInt).value;
+  const transformValue = (value: number | FixedInt): number => {
+    if (value instanceof FixedInt) {
+      return (value as FixedInt).value;
     }
     return thisArg.gameSpeed === 1 ? value : Math.ceil((value /= thisArg.gameSpeed));
   };

--- a/src/system/version_migration/version_converter.ts
+++ b/src/system/version_migration/version_converter.ts
@@ -48,12 +48,15 @@ export const settingsMigrators: Readonly<SettingsSaveMigrator[]> = [settingsMigr
 // import * as vA_B_C from "./versions/vA_B_C";
 
 // --- v1.0.4 (and below) PATCHES --- //
+// biome-ignore lint/style/noNamespaceImport: Convenience (TODO: make this a file-wide ignore when Biome supports those)
 import * as v1_0_4 from "./versions/v1_0_4";
 
 // --- v1.7.0 PATCHES --- //
+// biome-ignore lint/style/noNamespaceImport: Convenience
 import * as v1_7_0 from "./versions/v1_7_0";
 
 // --- v1.8.3 PATCHES --- //
+// biome-ignore lint/style/noNamespaceImport: Convenience
 import * as v1_8_3 from "./versions/v1_8_3";
 
 /** Current game version */

--- a/src/ui/abstact-option-select-ui-handler.ts
+++ b/src/ui/abstact-option-select-ui-handler.ts
@@ -3,7 +3,7 @@ import { TextStyle, addBBCodeTextObject, getTextColor, getTextStyleOptions } fro
 import { Mode } from "./ui";
 import UiHandler from "./ui-handler";
 import { addWindow } from "./ui-theme";
-import * as Utils from "../utils";
+import { rgbHexToRgba, fixedInt } from "#app/utils";
 import { argbFromRgba } from "@material/material-color-utilities";
 import { Button } from "#enums/buttons";
 import BBCodeText from "phaser3-rex-plugins/plugins/gameobjects/tagtext/bbcodetext/BBCodeText";
@@ -178,8 +178,8 @@ export default abstract class AbstractOptionSelectUiHandler extends UiHandler {
           itemOverlayIcon.setPositionRelative(this.optionSelectText, 36 * this.scale, 7 + i * (114 * this.scale - 3));
 
           if (option.itemArgs) {
-            itemIcon.setTint(argbFromRgba(Utils.rgbHexToRgba(option.itemArgs[0])));
-            itemOverlayIcon.setTint(argbFromRgba(Utils.rgbHexToRgba(option.itemArgs[1])));
+            itemIcon.setTint(argbFromRgba(rgbHexToRgba(option.itemArgs[0])));
+            itemOverlayIcon.setTint(argbFromRgba(rgbHexToRgba(option.itemArgs[1])));
           }
         }
       }
@@ -207,7 +207,7 @@ export default abstract class AbstractOptionSelectUiHandler extends UiHandler {
       this.blockInput = true;
       this.optionSelectTextContainer.setAlpha(0.5);
       this.cursorObj?.setAlpha(0.8);
-      globalScene.time.delayedCall(Utils.fixedInt(this.config.delay), () => this.unblockInput());
+      globalScene.time.delayedCall(fixedInt(this.config.delay), () => this.unblockInput());
     }
 
     if (this.config?.supportHover) {

--- a/src/ui/arena-flyout.ts
+++ b/src/ui/arena-flyout.ts
@@ -16,7 +16,7 @@ import type { TurnEndEvent } from "../events/battle-scene";
 import { BattleSceneEventType } from "../events/battle-scene";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import TimeOfDayWidget from "./time-of-day-widget";
-import * as Utils from "../utils";
+import { toCamelCaseString, formatText, fixedInt } from "#app/utils";
 import type { ParseKeys } from "i18next";
 import i18next from "i18next";
 
@@ -47,10 +47,10 @@ export function getFieldEffectText(arenaTagType: string): string {
   if (!arenaTagType || arenaTagType === ArenaTagType.NONE) {
     return arenaTagType;
   }
-  const effectName = Utils.toCamelCaseString(arenaTagType);
+  const effectName = toCamelCaseString(arenaTagType);
   const i18nKey = `arenaFlyout:${effectName}` as ParseKeys;
   const resultName = i18next.t(i18nKey);
-  return !resultName || resultName === i18nKey ? Utils.formatText(arenaTagType) : resultName;
+  return !resultName || resultName === i18nKey ? formatText(arenaTagType) : resultName;
 }
 
 export class ArenaFlyout extends Phaser.GameObjects.Container {
@@ -411,7 +411,7 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
     globalScene.tweens.add({
       targets: this.flyoutParent,
       x: visible ? this.anchorX : this.anchorX - this.translationX,
-      duration: Utils.fixedInt(125),
+      duration: fixedInt(125),
       ease: "Sine.easeInOut",
       alpha: visible ? 1 : 0,
       onComplete: () => (this.timeOfDayWidget.parentVisible = visible),

--- a/src/ui/base-stats-overlay.ts
+++ b/src/ui/base-stats-overlay.ts
@@ -1,7 +1,7 @@
 import type { InfoToggle } from "../battle-scene";
 import { TextStyle, addTextObject } from "./text";
 import { addWindow } from "./ui-theme";
-import * as Utils from "../utils";
+import { fixedInt } from "#app/utils";
 import i18next from "i18next";
 import { globalScene } from "#app/global-scene";
 
@@ -93,7 +93,7 @@ export class BaseStatsOverlay extends Phaser.GameObjects.Container implements In
     }
     globalScene.tweens.add({
       targets: this.statsLabels,
-      duration: Utils.fixedInt(125),
+      duration: fixedInt(125),
       ease: "Sine.easeInOut",
       alpha: visible ? 1 : 0,
     });

--- a/src/ui/battle-flyout.ts
+++ b/src/ui/battle-flyout.ts
@@ -1,6 +1,6 @@
 import type { default as Pokemon } from "../field/pokemon";
 import { addTextObject, TextStyle } from "./text";
-import * as Utils from "../utils";
+import { fixedInt } from "#app/utils";
 import { globalScene } from "#app/global-scene";
 import type Move from "#app/data/moves/move";
 import type { BerryUsedEvent, MoveUsedEvent } from "../events/battle-scene";
@@ -201,7 +201,7 @@ export default class BattleFlyout extends Phaser.GameObjects.Container {
     globalScene.tweens.add({
       targets: this.flyoutParent,
       x: visible ? this.anchorX : this.anchorX - this.translationX,
-      duration: Utils.fixedInt(125),
+      duration: fixedInt(125),
       ease: "Sine.easeInOut",
       alpha: visible ? 1 : 0,
     });

--- a/src/ui/battle-info.ts
+++ b/src/ui/battle-info.ts
@@ -1,6 +1,6 @@
 import type { EnemyPokemon, default as Pokemon } from "../field/pokemon";
 import { getLevelTotalExp, getLevelRelExp } from "../data/exp";
-import * as Utils from "../utils";
+import { getLocalizedSpriteKey, fixedInt } from "#app/utils";
 import { addTextObject, TextStyle } from "./text";
 import { getGenderSymbol, getGenderColor, Gender } from "../data/gender";
 import { StatusEffect } from "#enums/status-effect";
@@ -163,7 +163,7 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
     this.splicedIcon.setInteractive(new Phaser.Geom.Rectangle(0, 0, 12, 15), Phaser.Geom.Rectangle.Contains);
     this.add(this.splicedIcon);
 
-    this.statusIndicator = globalScene.add.sprite(0, 0, Utils.getLocalizedSpriteKey("statuses"));
+    this.statusIndicator = globalScene.add.sprite(0, 0, getLocalizedSpriteKey("statuses"));
     this.statusIndicator.setName("icon_status");
     this.statusIndicator.setVisible(false);
     this.statusIndicator.setOrigin(0, 0);
@@ -536,7 +536,7 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
   toggleStats(visible: boolean): void {
     globalScene.tweens.add({
       targets: this.statsContainer,
-      duration: Utils.fixedInt(125),
+      duration: fixedInt(125),
       ease: "Sine.easeInOut",
       alpha: visible ? 1 : 0,
     });

--- a/src/ui/bgm-bar.ts
+++ b/src/ui/bgm-bar.ts
@@ -1,6 +1,6 @@
 import { addTextObject, TextStyle } from "./text";
 import i18next from "i18next";
-import * as Utils from "#app/utils";
+import { formatText } from "#app/utils";
 import { globalScene } from "#app/global-scene";
 
 const hiddenX = -150;
@@ -100,7 +100,7 @@ export default class BgmBar extends Phaser.GameObjects.Container {
 
   getRealBgmName(bgmName: string): string {
     return i18next.t([`bgmName:${bgmName}`, "bgmName:missing_entries"], {
-      name: Utils.formatText(bgmName),
+      name: formatText(bgmName),
     });
   }
 }

--- a/src/ui/candy-bar.ts
+++ b/src/ui/candy-bar.ts
@@ -2,7 +2,7 @@ import { starterColors } from "#app/battle-scene";
 import { globalScene } from "#app/global-scene";
 import { TextStyle, addTextObject } from "./text";
 import { argbFromRgba } from "@material/material-color-utilities";
-import * as Utils from "../utils";
+import { rgbHexToRgba } from "#app/utils";
 import type { Species } from "#enums/species";
 
 export default class CandyBar extends Phaser.GameObjects.Container {
@@ -60,8 +60,8 @@ export default class CandyBar extends Phaser.GameObjects.Container {
 
       const colorScheme = starterColors[starterSpeciesId];
 
-      this.candyIcon.setTint(argbFromRgba(Utils.rgbHexToRgba(colorScheme[0])));
-      this.candyOverlayIcon.setTint(argbFromRgba(Utils.rgbHexToRgba(colorScheme[1])));
+      this.candyIcon.setTint(argbFromRgba(rgbHexToRgba(colorScheme[0])));
+      this.candyOverlayIcon.setTint(argbFromRgba(rgbHexToRgba(colorScheme[1])));
 
       this.countText.setText(
         `${globalScene.gameData.starterData[starterSpeciesId].candyCount + count} (+${count.toString()})`,

--- a/src/ui/challenges-select-ui-handler.ts
+++ b/src/ui/challenges-select-ui-handler.ts
@@ -5,7 +5,7 @@ import { addWindow } from "./ui-theme";
 import { Button } from "#enums/buttons";
 import i18next from "i18next";
 import type { Challenge } from "#app/data/challenge";
-import * as Utils from "../utils";
+import { getLocalizedSpriteKey } from "#app/utils";
 import { Challenges } from "#app/enums/challenges";
 import BBCodeText from "phaser3-rex-plugins/plugins/bbcodetext";
 import { Color, ShadowColor } from "#app/enums/color";
@@ -193,7 +193,7 @@ export default class GameChallengesUiHandler extends UiHandler {
       };
     }
 
-    this.monoTypeValue = globalScene.add.sprite(8, 98, Utils.getLocalizedSpriteKey("types"));
+    this.monoTypeValue = globalScene.add.sprite(8, 98, getLocalizedSpriteKey("types"));
     this.monoTypeValue.setName("challenge-value-monotype-sprite");
     this.monoTypeValue.setScale(0.86);
     this.monoTypeValue.setVisible(false);

--- a/src/ui/char-sprite.ts
+++ b/src/ui/char-sprite.ts
@@ -1,5 +1,5 @@
 import { globalScene } from "#app/global-scene";
-import * as Utils from "../utils";
+import { MissingTextureKey } from "#app/utils";
 
 export default class CharSprite extends Phaser.GameObjects.Container {
   private sprite: Phaser.GameObjects.Sprite;
@@ -57,7 +57,7 @@ export default class CharSprite extends Phaser.GameObjects.Container {
         },
       });
 
-      this.setVisible(globalScene.textures.get(key).key !== Utils.MissingTextureKey);
+      this.setVisible(globalScene.textures.get(key).key !== MissingTextureKey);
       this.shown = true;
 
       this.key = key;

--- a/src/ui/daily-run-scoreboard.ts
+++ b/src/ui/daily-run-scoreboard.ts
@@ -1,6 +1,6 @@
 import i18next from "i18next";
 import { globalScene } from "#app/global-scene";
-import * as Utils from "../utils";
+import { getEnumKeys, executeIf } from "#app/utils";
 import { TextStyle, addTextObject } from "./text";
 import { WindowVariant, addWindow } from "./ui-theme";
 import { pokerogueApi } from "#app/plugins/api/pokerogue-api";
@@ -89,7 +89,7 @@ export class DailyRunScoreboard extends Phaser.GameObjects.Container {
 
     this.prevCategoryButton.setInteractive(new Phaser.Geom.Rectangle(0, 0, 6, 10), Phaser.Geom.Rectangle.Contains);
     this.prevCategoryButton.on("pointerup", () => {
-      this.update(this.category ? this.category - 1 : Utils.getEnumKeys(ScoreboardCategory).length - 1);
+      this.update(this.category ? this.category - 1 : getEnumKeys(ScoreboardCategory).length - 1);
     });
 
     this.nextCategoryButton = globalScene.add.sprite(window.displayWidth - 4, 4, "cursor");
@@ -98,7 +98,7 @@ export class DailyRunScoreboard extends Phaser.GameObjects.Container {
 
     this.nextCategoryButton.setInteractive(new Phaser.Geom.Rectangle(0, 0, 6, 10), Phaser.Geom.Rectangle.Contains);
     this.nextCategoryButton.on("pointerup", () => {
-      this.update(this.category < Utils.getEnumKeys(ScoreboardCategory).length - 1 ? this.category + 1 : 0);
+      this.update(this.category < getEnumKeys(ScoreboardCategory).length - 1 ? this.category + 1 : 0);
     });
 
     this.prevPageButton = globalScene.add.sprite(
@@ -226,7 +226,7 @@ export class DailyRunScoreboard extends Phaser.GameObjects.Container {
       this.page = page = 1;
     }
 
-    Utils.executeIf(category !== this.category || this.pageCount === undefined, () =>
+    executeIf(category !== this.category || this.pageCount === undefined, () =>
       pokerogueApi.daily.getRankingsPageCount({ category }).then(count => (this.pageCount = count)),
     )
       .then(() => {

--- a/src/ui/egg-gacha-ui-handler.ts
+++ b/src/ui/egg-gacha-ui-handler.ts
@@ -1,7 +1,7 @@
 import { Mode } from "./ui";
 import { TextStyle, addTextObject, getEggTierTextTint, getTextStyleOptions } from "./text";
 import MessageUiHandler from "./message-ui-handler";
-import * as Utils from "../utils";
+import { getEnumValues, getEnumKeys, fixedInt, randSeedShuffle } from "#app/utils";
 import type { IEggOptions } from "../data/egg";
 import { Egg, getLegendaryGachaSpeciesForTimestamp } from "../data/egg";
 import { VoucherType, getVoucherTypeIcon } from "../system/voucher";
@@ -83,7 +83,7 @@ export default class EggGachaUiHandler extends MessageUiHandler {
       });
     }
 
-    Utils.getEnumValues(GachaType).forEach((gachaType, g) => {
+    getEnumValues(GachaType).forEach((gachaType, g) => {
       const gachaTypeKey = GachaType[gachaType].toString().toLowerCase();
       const gachaContainer = globalScene.add.container(180 * g, 18);
 
@@ -272,7 +272,7 @@ export default class EggGachaUiHandler extends MessageUiHandler {
 
     this.eggGachaContainer.add(this.eggGachaOptionsContainer);
 
-    new Array(Utils.getEnumKeys(VoucherType).length).fill(null).map((_, i) => {
+    new Array(getEnumKeys(VoucherType).length).fill(null).map((_, i) => {
       const container = globalScene.add.container(globalScene.game.canvas.width / 6 - 56 * i, 0);
 
       const bg = addWindow(0, 0, 56, 22);
@@ -355,7 +355,7 @@ export default class EggGachaUiHandler extends MessageUiHandler {
     if (this.transitioning && this.transitionCancelled) {
       delay = Math.ceil(delay / 5);
     }
-    return Utils.fixedInt(delay);
+    return fixedInt(delay);
   }
 
   pull(pullCount = 0, count = 0, eggs?: Egg[]): void {
@@ -476,7 +476,7 @@ export default class EggGachaUiHandler extends MessageUiHandler {
         eggs.push(egg);
       }
       // Shuffle the eggs in case the guaranteed one got added as last egg
-      eggs = Utils.randSeedShuffle<Egg>(eggs);
+      eggs = randSeedShuffle<Egg>(eggs);
 
       (globalScene.currentBattle
         ? globalScene.gameData.saveAll(true, true, true)
@@ -643,7 +643,7 @@ export default class EggGachaUiHandler extends MessageUiHandler {
   }
 
   showError(text: string): void {
-    this.showText(text, undefined, () => this.showText(this.defaultText), Utils.fixedInt(1500));
+    this.showText(text, undefined, () => this.showText(this.defaultText), fixedInt(1500));
   }
 
   setTransitioning(transitioning: boolean): void {
@@ -783,7 +783,7 @@ export default class EggGachaUiHandler extends MessageUiHandler {
             }
             break;
           case Button.RIGHT:
-            if (this.gachaCursor < Utils.getEnumKeys(GachaType).length - 1) {
+            if (this.gachaCursor < getEnumKeys(GachaType).length - 1) {
               success = this.setGachaCursor(this.gachaCursor + 1);
             }
             break;

--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -6,7 +6,7 @@ import { PokemonType } from "#enums/pokemon-type";
 import { Command } from "./command-ui-handler";
 import { Mode } from "./ui";
 import UiHandler from "./ui-handler";
-import * as Utils from "../utils";
+import { getLocalizedSpriteKey, fixedInt, padInt } from "#app/utils";
 import { MoveCategory } from "#enums/MoveCategory";
 import i18next from "i18next";
 import { Button } from "#enums/buttons";
@@ -54,7 +54,7 @@ export default class FightUiHandler extends UiHandler implements InfoToggle {
     this.typeIcon = globalScene.add.sprite(
       globalScene.scaledCanvas.width - 57,
       -36,
-      Utils.getLocalizedSpriteKey("types"),
+      getLocalizedSpriteKey("types"),
       "unknown",
     );
     this.typeIcon.setVisible(false);
@@ -199,7 +199,7 @@ export default class FightUiHandler extends UiHandler implements InfoToggle {
     }
     globalScene.tweens.add({
       targets: [this.movesContainer, this.cursorObj],
-      duration: Utils.fixedInt(125),
+      duration: fixedInt(125),
       ease: "Sine.easeInOut",
       alpha: visible ? 0 : 1,
     });
@@ -245,7 +245,7 @@ export default class FightUiHandler extends UiHandler implements InfoToggle {
     if (hasMove) {
       const pokemonMove = moveset[cursor];
       const moveType = pokemon.getMoveType(pokemonMove.getMove());
-      const textureKey = Utils.getLocalizedSpriteKey("types");
+      const textureKey = getLocalizedSpriteKey("types");
       this.typeIcon.setTexture(textureKey, PokemonType[moveType].toLowerCase()).setScale(0.8);
 
       const moveCategory = pokemonMove.getMove().category;
@@ -255,8 +255,8 @@ export default class FightUiHandler extends UiHandler implements InfoToggle {
       const maxPP = pokemonMove.getMovePp();
       const pp = maxPP - pokemonMove.ppUsed;
 
-      const ppLeftStr = Utils.padInt(pp, 2, "  ");
-      const ppMaxStr = Utils.padInt(maxPP, 2, "  ");
+      const ppLeftStr = padInt(pp, 2, "  ");
+      const ppMaxStr = padInt(maxPP, 2, "  ");
       this.ppText.setText(`${ppLeftStr}/${ppMaxStr}`);
       this.powerText.setText(`${power >= 0 ? power : "---"}`);
       this.accuracyText.setText(`${accuracy >= 0 ? accuracy : "---"}`);

--- a/src/ui/form-modal-ui-handler.ts
+++ b/src/ui/form-modal-ui-handler.ts
@@ -4,7 +4,7 @@ import type { Mode } from "./ui";
 import { TextStyle, addTextInputObject, addTextObject } from "./text";
 import { WindowVariant, addWindow } from "./ui-theme";
 import type InputText from "phaser3-rex-plugins/plugins/inputtext";
-import * as Utils from "../utils";
+import { fixedInt } from "#app/utils";
 import { Button } from "#enums/buttons";
 import { globalScene } from "#app/global-scene";
 
@@ -135,7 +135,7 @@ export abstract class FormModalUiHandler extends ModalUiHandler {
 
       this.tween = globalScene.tweens.add({
         targets: this.modalContainer,
-        duration: Utils.fixedInt(1000),
+        duration: fixedInt(1000),
         ease: "Sine.easeInOut",
         y: "-=24",
         alpha: 1,

--- a/src/ui/game-stats-ui-handler.ts
+++ b/src/ui/game-stats-ui-handler.ts
@@ -3,7 +3,7 @@ import { TextStyle, addTextObject } from "#app/ui/text";
 import type { Mode } from "#app/ui/ui";
 import UiHandler from "#app/ui/ui-handler";
 import { addWindow } from "#app/ui/ui-theme";
-import * as Utils from "#app/utils";
+import { getPlayTimeString, formatFancyLargeNumber, toReadableString } from "#app/utils";
 import type { GameData } from "#app/system/game-data";
 import { DexAttr } from "#app/system/game-data";
 import { speciesStarterCosts } from "#app/data/balance/starters";
@@ -25,7 +25,7 @@ interface DisplayStats {
 const displayStats: DisplayStats = {
   playTime: {
     label_key: "playTime",
-    sourceFunc: gameData => Utils.getPlayTimeString(gameData.gameStats.playTime),
+    sourceFunc: gameData => getPlayTimeString(gameData.gameStats.playTime),
   },
   battles: {
     label_key: "totalBattles",
@@ -91,7 +91,7 @@ const displayStats: DisplayStats = {
   },
   highestMoney: {
     label_key: "highestMoney",
-    sourceFunc: gameData => Utils.formatFancyLargeNumber(gameData.gameStats.highestMoney),
+    sourceFunc: gameData => formatFancyLargeNumber(gameData.gameStats.highestMoney),
   },
   highestDamage: {
     label_key: "highestDamage",
@@ -435,7 +435,7 @@ export function initStatsKeys() {
     }
     if (!(displayStats[key] as DisplayStat).label_key) {
       const splittableKey = key.replace(/([a-z]{2,})([A-Z]{1}(?:[^A-Z]|$))/g, "$1_$2");
-      (displayStats[key] as DisplayStat).label_key = Utils.toReadableString(
+      (displayStats[key] as DisplayStat).label_key = toReadableString(
         `${splittableKey[0].toUpperCase()}${splittableKey.slice(1)}`,
       );
     }

--- a/src/ui/login-form-ui-handler.ts
+++ b/src/ui/login-form-ui-handler.ts
@@ -1,7 +1,7 @@
 import type { InputFieldConfig } from "./form-modal-ui-handler";
 import { FormModalUiHandler } from "./form-modal-ui-handler";
 import type { ModalConfig } from "./modal-ui-handler";
-import * as Utils from "../utils";
+import { fixedInt } from "#app/utils";
 import { Mode } from "./ui";
 import i18next from "i18next";
 import { addTextObject, TextStyle } from "./text";
@@ -283,7 +283,7 @@ export default class LoginFormUiHandler extends FormModalUiHandler {
     this.externalPartyContainer.setAlpha(0);
     globalScene.tweens.add({
       targets: this.externalPartyContainer,
-      duration: Utils.fixedInt(1000),
+      duration: fixedInt(1000),
       ease: "Sine.easeInOut",
       y: "-=24",
       alpha: 1,
@@ -292,7 +292,7 @@ export default class LoginFormUiHandler extends FormModalUiHandler {
     this.infoContainer.setAlpha(0);
     globalScene.tweens.add({
       targets: this.infoContainer,
-      duration: Utils.fixedInt(1000),
+      duration: fixedInt(1000),
       ease: "Sine.easeInOut",
       y: "-=24",
       alpha: 1,

--- a/src/ui/menu-ui-handler.ts
+++ b/src/ui/menu-ui-handler.ts
@@ -2,7 +2,7 @@ import { bypassLogin } from "#app/battle-scene";
 import { globalScene } from "#app/global-scene";
 import { TextStyle, addTextObject, getTextStyleOptions } from "./text";
 import { Mode } from "./ui";
-import * as Utils from "../utils";
+import { getEnumKeys, isLocal, isBeta, fixedInt, getCookie, sessionIdKey } from "#app/utils";
 import { addWindow, WindowVariant } from "./ui-theme";
 import MessageUiHandler from "./message-ui-handler";
 import type { OptionSelectConfig, OptionSelectItem } from "./abstact-option-select-ui-handler";
@@ -75,7 +75,7 @@ export default class MenuUiHandler extends MessageUiHandler {
       { condition: bypassLogin, options: [MenuOptions.LOG_OUT] },
     ];
 
-    this.menuOptions = Utils.getEnumKeys(MenuOptions)
+    this.menuOptions = getEnumKeys(MenuOptions)
       .map(m => Number.parseInt(MenuOptions[m]) as MenuOptions)
       .filter(m => {
         return !this.excludedMenus().some(exclusion => exclusion.condition && exclusion.options.includes(m));
@@ -130,7 +130,7 @@ export default class MenuUiHandler extends MessageUiHandler {
       { condition: bypassLogin, options: [MenuOptions.LOG_OUT] },
     ];
 
-    this.menuOptions = Utils.getEnumKeys(MenuOptions)
+    this.menuOptions = getEnumKeys(MenuOptions)
       .map(m => Number.parseInt(MenuOptions[m]) as MenuOptions)
       .filter(m => {
         return !this.excludedMenus().some(exclusion => exclusion.condition && exclusion.options.includes(m));
@@ -238,7 +238,7 @@ export default class MenuUiHandler extends MessageUiHandler {
       });
     };
 
-    if (Utils.isLocal || Utils.isBeta) {
+    if (isLocal || isBeta) {
       manageDataOptions.push({
         label: i18next.t("menuUiHandler:importSession"),
         handler: () => {
@@ -292,7 +292,7 @@ export default class MenuUiHandler extends MessageUiHandler {
       },
       keepOpen: true,
     });
-    if (Utils.isLocal || Utils.isBeta) {
+    if (isLocal || isBeta) {
       manageDataOptions.push({
         label: i18next.t("menuUiHandler:importData"),
         handler: () => {
@@ -328,7 +328,7 @@ export default class MenuUiHandler extends MessageUiHandler {
         keepOpen: true,
       },
     );
-    if (Utils.isLocal || Utils.isBeta) {
+    if (isLocal || isBeta) {
       // this should make sure we don't have this option in live
       manageDataOptions.push({
         label: "Test Dialogue",
@@ -510,7 +510,7 @@ export default class MenuUiHandler extends MessageUiHandler {
     this.render();
     super.show(args);
 
-    this.menuOptions = Utils.getEnumKeys(MenuOptions)
+    this.menuOptions = getEnumKeys(MenuOptions)
       .map(m => Number.parseInt(MenuOptions[m]) as MenuOptions)
       .filter(m => {
         return !this.excludedMenus().some(exclusion => exclusion.condition && exclusion.options.includes(m));
@@ -574,7 +574,7 @@ export default class MenuUiHandler extends MessageUiHandler {
             ui.setOverlayMode(Mode.EGG_LIST);
             success = true;
           } else {
-            ui.showText(i18next.t("menuUiHandler:noEggs"), null, () => ui.showText(""), Utils.fixedInt(1500));
+            ui.showText(i18next.t("menuUiHandler:noEggs"), null, () => ui.showText(""), fixedInt(1500));
             error = true;
           }
           break;
@@ -607,7 +607,7 @@ export default class MenuUiHandler extends MessageUiHandler {
                     : i18next.t("menuUiHandler:unlinkDiscord"),
                 handler: () => {
                   if (loggedInUser?.discordId === "") {
-                    const token = Utils.getCookie(Utils.sessionIdKey);
+                    const token = getCookie(sessionIdKey);
                     const redirectUri = encodeURIComponent(`${import.meta.env.VITE_SERVER_URL}/auth/discord/callback`);
                     const discordId = import.meta.env.VITE_DISCORD_CLIENT_ID;
                     const discordUrl = `https://discord.com/api/oauth2/authorize?client_id=${discordId}&redirect_uri=${redirectUri}&response_type=code&scope=identify&state=${token}&prompt=none`;
@@ -627,7 +627,7 @@ export default class MenuUiHandler extends MessageUiHandler {
                     : i18next.t("menuUiHandler:unlinkGoogle"),
                 handler: () => {
                   if (loggedInUser?.googleId === "") {
-                    const token = Utils.getCookie(Utils.sessionIdKey);
+                    const token = getCookie(sessionIdKey);
                     const redirectUri = encodeURIComponent(`${import.meta.env.VITE_SERVER_URL}/auth/google/callback`);
                     const googleId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
                     const googleUrl = `https://accounts.google.com/o/oauth2/auth?client_id=${googleId}&response_type=code&redirect_uri=${redirectUri}&scope=openid&state=${token}`;

--- a/src/ui/message-ui-handler.ts
+++ b/src/ui/message-ui-handler.ts
@@ -1,6 +1,6 @@
 import AwaitableUiHandler from "./awaitable-ui-handler";
 import type { Mode } from "./ui";
-import * as Utils from "../utils";
+import { getFrameMs } from "#app/utils";
 import { globalScene } from "#app/global-scene";
 
 export default abstract class MessageUiHandler extends AwaitableUiHandler {
@@ -183,7 +183,7 @@ export default abstract class MessageUiHandler extends AwaitableUiHandler {
           if (charDelay) {
             this.textTimer!.paused = true; // TODO: is the bang correct?
             globalScene.tweens.addCounter({
-              duration: Utils.getFrameMs(charDelay),
+              duration: getFrameMs(charDelay),
               onComplete: () => {
                 this.textTimer!.paused = false; // TODO: is the bang correct?
                 advance();
@@ -193,7 +193,7 @@ export default abstract class MessageUiHandler extends AwaitableUiHandler {
             this.textTimer!.paused = true;
             globalScene.time.delayedCall(150, () => {
               globalScene.ui.fadeOut(750).then(() => {
-                const delay = Utils.getFrameMs(charFade);
+                const delay = getFrameMs(charFade);
                 globalScene.time.delayedCall(delay, () => {
                   globalScene.ui.fadeIn(500).then(() => {
                     this.textTimer!.paused = false;

--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -10,11 +10,10 @@ import { handleTutorial, Tutorial } from "../tutorial";
 import { Button } from "#enums/buttons";
 import MoveInfoOverlay from "./move-info-overlay";
 import { allMoves } from "../data/moves/move";
-import * as Utils from "./../utils";
+import { formatMoney, NumberHolder } from "#app/utils";
 import Overrides from "#app/overrides";
 import i18next from "i18next";
 import { ShopCursorTarget } from "#app/enums/shop-cursor-target";
-import { NumberHolder } from "./../utils";
 import Phaser from "phaser";
 import type { PokeballType } from "#enums/pokeball";
 
@@ -645,7 +644,7 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
     this.rerollCostText.setVisible(true);
     const canReroll = globalScene.money >= this.rerollCost;
 
-    const formattedMoney = Utils.formatMoney(globalScene.moneyFormat, this.rerollCost);
+    const formattedMoney = formatMoney(globalScene.moneyFormat, this.rerollCost);
 
     this.rerollCostText.setText(i18next.t("modifierSelectUiHandler:rerollCost", { formattedMoney }));
     this.rerollCostText.setColor(this.getTextColor(canReroll ? TextStyle.MONEY : TextStyle.PARTY_RED));
@@ -933,7 +932,7 @@ class ModifierOption extends Phaser.GameObjects.Container {
     const cost = Overrides.WAIVE_ROLL_FEE_OVERRIDE ? 0 : this.modifierTypeOption.cost;
     const textStyle = cost <= globalScene.money ? TextStyle.MONEY : TextStyle.PARTY_RED;
 
-    const formattedMoney = Utils.formatMoney(globalScene.moneyFormat, cost);
+    const formattedMoney = formatMoney(globalScene.moneyFormat, cost);
 
     this.itemCostText.setText(i18next.t("modifierSelectUiHandler:itemCost", { formattedMoney }));
     this.itemCostText.setColor(getTextColor(textStyle, false, globalScene.uiTheme));

--- a/src/ui/move-info-overlay.ts
+++ b/src/ui/move-info-overlay.ts
@@ -2,7 +2,7 @@ import type { InfoToggle } from "#app/battle-scene";
 import { globalScene } from "#app/global-scene";
 import { TextStyle, addTextObject } from "./text";
 import { addWindow } from "./ui-theme";
-import * as Utils from "../utils";
+import { getLocalizedSpriteKey, fixedInt } from "#app/utils";
 import type Move from "../data/moves/move";
 import { MoveCategory } from "#enums/MoveCategory";
 import { PokemonType } from "#enums/pokemon-type";
@@ -120,7 +120,7 @@ export default class MoveInfoOverlay extends Phaser.GameObjects.Container implem
     valuesBg.setOrigin(0, 0);
     this.val.add(valuesBg);
 
-    this.typ = globalScene.add.sprite(25, EFF_HEIGHT - 35, Utils.getLocalizedSpriteKey("types"), "unknown");
+    this.typ = globalScene.add.sprite(25, EFF_HEIGHT - 35, getLocalizedSpriteKey("types"), "unknown");
     this.typ.setScale(0.8);
     this.val.add(this.typ);
 
@@ -175,7 +175,7 @@ export default class MoveInfoOverlay extends Phaser.GameObjects.Container implem
     this.pow.setText(move.power >= 0 ? move.power.toString() : "---");
     this.acc.setText(move.accuracy >= 0 ? move.accuracy.toString() : "---");
     this.pp.setText(move.pp >= 0 ? move.pp.toString() : "---");
-    this.typ.setTexture(Utils.getLocalizedSpriteKey("types"), PokemonType[move.type].toLowerCase());
+    this.typ.setTexture(getLocalizedSpriteKey("types"), PokemonType[move.type].toLowerCase());
     this.cat.setFrame(MoveCategory[move.category].toLowerCase());
 
     this.desc.setText(move?.effect || "");
@@ -193,10 +193,10 @@ export default class MoveInfoOverlay extends Phaser.GameObjects.Container implem
       // generate scrolling effects
       this.descScroll = globalScene.tweens.add({
         targets: this.desc,
-        delay: Utils.fixedInt(2000),
+        delay: fixedInt(2000),
         loop: -1,
-        hold: Utils.fixedInt(2000),
-        duration: Utils.fixedInt((moveDescriptionLineCount - 3) * 2000),
+        hold: fixedInt(2000),
+        duration: fixedInt((moveDescriptionLineCount - 3) * 2000),
         y: `-=${14.83 * (72 / 96) * (moveDescriptionLineCount - 3)}`,
       });
     }
@@ -219,7 +219,7 @@ export default class MoveInfoOverlay extends Phaser.GameObjects.Container implem
     }
     globalScene.tweens.add({
       targets: this.desc,
-      duration: Utils.fixedInt(125),
+      duration: fixedInt(125),
       ease: "Sine.easeInOut",
       alpha: visible ? 1 : 0,
     });

--- a/src/ui/mystery-encounter-ui-handler.ts
+++ b/src/ui/mystery-encounter-ui-handler.ts
@@ -6,8 +6,7 @@ import { addWindow, WindowVariant } from "./ui-theme";
 import type { MysteryEncounterPhase } from "../phases/mystery-encounter-phases";
 import { PartyUiMode } from "./party-ui-handler";
 import type MysteryEncounterOption from "#app/data/mystery-encounters/mystery-encounter-option";
-import * as Utils from "../utils";
-import { isNullOrUndefined } from "../utils";
+import { fixedInt, isNullOrUndefined } from "#app/utils";
 import { getPokeballAtlasKey } from "../data/pokeball";
 import type { OptionSelectSettings } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
 import { getEncounterText } from "#app/data/mystery-encounters/utils/encounter-dialogue-utils";
@@ -456,10 +455,10 @@ export default class MysteryEncounterUiHandler extends UiHandler {
       if (optionTextWidth > nonScrollWidth) {
         this.optionScrollTweens[i] = globalScene.tweens.add({
           targets: optionText,
-          delay: Utils.fixedInt(2000),
+          delay: fixedInt(2000),
           loop: -1,
-          hold: Utils.fixedInt(2000),
-          duration: Utils.fixedInt(((optionTextWidth - nonScrollWidth) / 15) * 2000),
+          hold: fixedInt(2000),
+          duration: fixedInt(((optionTextWidth - nonScrollWidth) / 15) * 2000),
           x: `-=${optionTextWidth - nonScrollWidth}`,
         });
       }
@@ -527,10 +526,10 @@ export default class MysteryEncounterUiHandler extends UiHandler {
     if (descriptionLineCount > 6) {
       this.descriptionScrollTween = globalScene.tweens.add({
         targets: descriptionTextObject,
-        delay: Utils.fixedInt(2000),
+        delay: fixedInt(2000),
         loop: -1,
-        hold: Utils.fixedInt(2000),
-        duration: Utils.fixedInt((descriptionLineCount - 6) * 2000),
+        hold: fixedInt(2000),
+        duration: fixedInt((descriptionLineCount - 6) * 2000),
         y: `-=${10 * (descriptionLineCount - 6)}`,
       });
     }
@@ -637,10 +636,10 @@ export default class MysteryEncounterUiHandler extends UiHandler {
       if (tooltipLineCount > 3) {
         this.tooltipScrollTween = globalScene.tweens.add({
           targets: tooltipTextObject,
-          delay: Utils.fixedInt(1200),
+          delay: fixedInt(1200),
           loop: -1,
-          hold: Utils.fixedInt(1200),
-          duration: Utils.fixedInt((tooltipLineCount - 3) * 1200),
+          hold: fixedInt(1200),
+          duration: fixedInt((tooltipLineCount - 3) * 1200),
           y: `-=${11.2 * (tooltipLineCount - 3)}`,
         });
       }

--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -5,7 +5,7 @@ import { addBBCodeTextObject, addTextObject, getTextColor, TextStyle } from "#ap
 import { Command } from "#app/ui/command-ui-handler";
 import MessageUiHandler from "#app/ui/message-ui-handler";
 import { Mode } from "#app/ui/ui";
-import * as Utils from "#app/utils";
+import { BooleanHolder, toReadableString, randInt, getLocalizedSpriteKey } from "#app/utils";
 import {
   PokemonFormChangeItemModifier,
   PokemonHeldItemModifier,
@@ -215,7 +215,7 @@ export default class PartyUiHandler extends MessageUiHandler {
    * @returns
    */
   private FilterChallengeLegal = (pokemon: PlayerPokemon) => {
-    const challengeAllowed = new Utils.BooleanHolder(true);
+    const challengeAllowed = new BooleanHolder(true);
     applyChallenges(ChallengeType.POKEMON_IN_BATTLE, pokemon, challengeAllowed);
     if (!challengeAllowed.value) {
       return i18next.t("partyUiHandler:cantBeUsed", {
@@ -1201,7 +1201,7 @@ export default class PartyUiHandler extends MessageUiHandler {
               if (this.localizedOptions.includes(option)) {
                 optionName = i18next.t(`partyUiHandler:${PartyOption[option]}`);
               } else {
-                optionName = Utils.toReadableString(PartyOption[option]);
+                optionName = toReadableString(PartyOption[option]);
               }
             }
             break;
@@ -1309,7 +1309,7 @@ export default class PartyUiHandler extends MessageUiHandler {
   }
 
   getReleaseMessage(pokemonName: string): string {
-    const rand = Utils.randInt(128);
+    const rand = randInt(128);
     if (rand < 20) {
       return i18next.t("partyUiHandler:goodbye", { pokemonName: pokemonName });
     }
@@ -1566,7 +1566,7 @@ class PartySlot extends Phaser.GameObjects.Container {
     }
 
     if (this.pokemon.status) {
-      const statusIndicator = globalScene.add.sprite(0, 0, Utils.getLocalizedSpriteKey("statuses"));
+      const statusIndicator = globalScene.add.sprite(0, 0, getLocalizedSpriteKey("statuses"));
       statusIndicator.setFrame(StatusEffect[this.pokemon.status?.effect].toLowerCase());
       statusIndicator.setOrigin(0, 0);
       statusIndicator.setPositionRelative(slotLevelLabel, this.slotIndex >= battlerCount ? 43 : 55, 0);

--- a/src/ui/pokedex-info-overlay.ts
+++ b/src/ui/pokedex-info-overlay.ts
@@ -1,7 +1,7 @@
 import type { InfoToggle } from "../battle-scene";
 import { TextStyle, addTextObject } from "./text";
 import { addWindow } from "./ui-theme";
-import * as Utils from "../utils";
+import { fixedInt } from "#app/utils";
 import i18next from "i18next";
 import { globalScene } from "#app/global-scene";
 
@@ -128,10 +128,10 @@ export default class PokedexInfoOverlay extends Phaser.GameObjects.Container imp
       // generate scrolling effects
       this.descScroll = globalScene.tweens.add({
         targets: this.desc,
-        delay: Utils.fixedInt(2000),
+        delay: fixedInt(2000),
         loop: -1,
-        hold: Utils.fixedInt(2000),
-        duration: Utils.fixedInt((lineCount - 3) * 2000),
+        hold: fixedInt(2000),
+        duration: fixedInt((lineCount - 3) * 2000),
         y: `-=${14.83 * (72 / 96) * (lineCount - 3)}`,
       });
     }
@@ -154,7 +154,7 @@ export default class PokedexInfoOverlay extends Phaser.GameObjects.Container imp
     }
     globalScene.tweens.add({
       targets: this.desc,
-      duration: Utils.fixedInt(125),
+      duration: fixedInt(125),
       ease: "Sine.easeInOut",
       alpha: visible ? 1 : 0,
     });

--- a/src/ui/pokedex-page-ui-handler.ts
+++ b/src/ui/pokedex-page-ui-handler.ts
@@ -54,7 +54,7 @@ import {
   toReadableString,
 } from "#app/utils";
 import type { Nature } from "#enums/nature";
-import * as Utils from "../utils";
+import { getEnumKeys } from "#app/utils";
 import { speciesTmMoves } from "#app/data/balance/tms";
 import type { BiomeTierTod } from "#app/data/balance/biomes";
 import { BiomePoolTier, catchableSpecies } from "#app/data/balance/biomes";
@@ -592,7 +592,7 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
 
     this.menuContainer.setVisible(false);
 
-    this.menuOptions = Utils.getEnumKeys(MenuOptions).map(m => Number.parseInt(MenuOptions[m]) as MenuOptions);
+    this.menuOptions = getEnumKeys(MenuOptions).map(m => Number.parseInt(MenuOptions[m]) as MenuOptions);
 
     this.optionSelectText = addBBCodeTextObject(
       0,
@@ -696,7 +696,7 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
 
     this.starterAttributes = this.initStarterPrefs();
 
-    this.menuOptions = Utils.getEnumKeys(MenuOptions).map(m => Number.parseInt(MenuOptions[m]) as MenuOptions);
+    this.menuOptions = getEnumKeys(MenuOptions).map(m => Number.parseInt(MenuOptions[m]) as MenuOptions);
 
     this.menuContainer.setVisible(true);
 

--- a/src/ui/pokemon-hatch-info-container.ts
+++ b/src/ui/pokemon-hatch-info-container.ts
@@ -1,7 +1,7 @@
 import PokemonInfoContainer from "#app/ui/pokemon-info-container";
 import { Gender } from "#app/data/gender";
 import { PokemonType } from "#enums/pokemon-type";
-import * as Utils from "#app/utils";
+import { rgbHexToRgba, padInt } from "#app/utils";
 import { TextStyle, addTextObject } from "#app/ui/text";
 import { speciesEggMoves } from "#app/data/balance/egg-moves";
 import { allMoves } from "#app/data/moves/move";
@@ -154,14 +154,14 @@ export default class PokemonHatchInfoContainer extends PokemonInfoContainer {
     super.show(pokemon, false, 1, hatchInfo.getDex(), hatchInfo.getStarterEntry(), true);
     const colorScheme = starterColors[species.speciesId];
 
-    this.pokemonCandyIcon.setTint(argbFromRgba(Utils.rgbHexToRgba(colorScheme[0])));
+    this.pokemonCandyIcon.setTint(argbFromRgba(rgbHexToRgba(colorScheme[0])));
     this.pokemonCandyIcon.setVisible(true);
-    this.pokemonCandyOverlayIcon.setTint(argbFromRgba(Utils.rgbHexToRgba(colorScheme[1])));
+    this.pokemonCandyOverlayIcon.setTint(argbFromRgba(rgbHexToRgba(colorScheme[1])));
     this.pokemonCandyOverlayIcon.setVisible(true);
     this.pokemonCandyCountText.setText(`x${globalScene.gameData.starterData[species.speciesId].candyCount}`);
     this.pokemonCandyCountText.setVisible(true);
 
-    this.pokemonNumberText.setText(Utils.padInt(species.speciesId, 4));
+    this.pokemonNumberText.setText(padInt(species.speciesId, 4));
     this.pokemonNameText.setText(species.name);
 
     const hasEggMoves = species && speciesEggMoves.hasOwnProperty(species.speciesId);

--- a/src/ui/pokemon-icon-anim-handler.ts
+++ b/src/ui/pokemon-icon-anim-handler.ts
@@ -1,5 +1,5 @@
 import { globalScene } from "#app/global-scene";
-import * as Utils from "../utils";
+import { fixedInt } from "#app/utils";
 
 export enum PokemonIconAnimMode {
   NONE,
@@ -27,7 +27,7 @@ export default class PokemonIconAnimHandler {
       }
     };
     globalScene.tweens.addCounter({
-      duration: Utils.fixedInt(200),
+      duration: fixedInt(200),
       from: 0,
       to: 1,
       yoyo: true,

--- a/src/ui/pokemon-info-container.ts
+++ b/src/ui/pokemon-info-container.ts
@@ -8,7 +8,7 @@ import type Pokemon from "../field/pokemon";
 import i18next from "i18next";
 import type { DexEntry, StarterDataEntry } from "../system/game-data";
 import { DexAttr } from "../system/game-data";
-import * as Utils from "../utils";
+import { fixedInt } from "#app/utils";
 import ConfirmUiHandler from "./confirm-ui-handler";
 import { StatsContainer } from "./stats-container";
 import { TextStyle, addBBCodeTextObject, addTextObject, getTextColor } from "./text";
@@ -393,7 +393,7 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
       if (!eggInfo) {
         globalScene.tweens.add({
           targets: this,
-          duration: Utils.fixedInt(Math.floor(750 / speedMultiplier)),
+          duration: fixedInt(Math.floor(750 / speedMultiplier)),
           ease: "Cubic.easeInOut",
           x: this.initialX - this.infoWindowWidth,
           onComplete: () => {
@@ -403,9 +403,9 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
 
         if (showMoves) {
           globalScene.tweens.add({
-            delay: Utils.fixedInt(Math.floor(325 / speedMultiplier)),
+            delay: fixedInt(Math.floor(325 / speedMultiplier)),
             targets: this.pokemonMovesContainer,
-            duration: Utils.fixedInt(Math.floor(325 / speedMultiplier)),
+            duration: fixedInt(Math.floor(325 / speedMultiplier)),
             ease: "Cubic.easeInOut",
             x: this.movesContainerInitialX - 57,
             onComplete: () => resolve(),
@@ -463,7 +463,7 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
     return new Promise<void>(resolve => {
       globalScene.tweens.add({
         targets: this,
-        duration: Utils.fixedInt(Math.floor(150 / speedMultiplier)),
+        duration: fixedInt(Math.floor(150 / speedMultiplier)),
         ease: "Cubic.easeInOut",
         x: xPosition,
         onComplete: () => {
@@ -482,14 +482,14 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
 
       globalScene.tweens.add({
         targets: this.pokemonMovesContainer,
-        duration: Utils.fixedInt(Math.floor(750 / speedMultiplier)),
+        duration: fixedInt(Math.floor(750 / speedMultiplier)),
         ease: "Cubic.easeInOut",
         x: this.movesContainerInitialX,
       });
 
       globalScene.tweens.add({
         targets: this,
-        duration: Utils.fixedInt(Math.floor(750 / speedMultiplier)),
+        duration: fixedInt(Math.floor(750 / speedMultiplier)),
         ease: "Cubic.easeInOut",
         x: this.initialX,
         onComplete: () => {

--- a/src/ui/run-history-ui-handler.ts
+++ b/src/ui/run-history-ui-handler.ts
@@ -3,7 +3,7 @@ import { GameModes } from "../game-mode";
 import { TextStyle, addTextObject } from "./text";
 import { Mode } from "./ui";
 import { addWindow } from "./ui-theme";
-import * as Utils from "../utils";
+import { fixedInt, formatLargeNumber } from "#app/utils";
 import type PokemonData from "../system/pokemon-data";
 import MessageUiHandler from "./message-ui-handler";
 import i18next from "i18next";
@@ -218,7 +218,7 @@ export default class RunHistoryUiHandler extends MessageUiHandler {
       globalScene.tweens.add({
         targets: this.runsContainer,
         y: this.runContainerInitialY - 56 * scrollCursor,
-        duration: Utils.fixedInt(325),
+        duration: fixedInt(325),
         ease: "Sine.easeInOut",
       });
     }
@@ -314,7 +314,7 @@ class RunEntryContainer extends Phaser.GameObjects.Container {
           const enemyLevel = addTextObject(
             32,
             20,
-            `${i18next.t("saveSlotSelectUiHandler:lv")}${Utils.formatLargeNumber(enemy.level, 1000)}`,
+            `${i18next.t("saveSlotSelectUiHandler:lv")}${formatLargeNumber(enemy.level, 1000)}`,
             TextStyle.PARTY,
             { fontSize: "54px", color: "#f8f8f8" },
           );
@@ -408,7 +408,7 @@ class RunEntryContainer extends Phaser.GameObjects.Container {
       const text = addTextObject(
         32,
         20,
-        `${i18next.t("saveSlotSelectUiHandler:lv")}${Utils.formatLargeNumber(pokemon.level, 1000)}`,
+        `${i18next.t("saveSlotSelectUiHandler:lv")}${formatLargeNumber(pokemon.level, 1000)}`,
         TextStyle.PARTY,
         { fontSize: "54px", color: "#f8f8f8" },
       );

--- a/src/ui/run-info-ui-handler.ts
+++ b/src/ui/run-info-ui-handler.ts
@@ -5,7 +5,7 @@ import { TextStyle, addTextObject, addBBCodeTextObject, getTextColor } from "./t
 import { Mode } from "./ui";
 import { addWindow } from "./ui-theme";
 import { getPokeballAtlasKey } from "#app/data/pokeball";
-import * as Utils from "../utils";
+import { formatLargeNumber, getPlayTimeString, formatMoney, formatFancyLargeNumber } from "#app/utils";
 import type PokemonData from "../system/pokemon-data";
 import i18next from "i18next";
 import { Button } from "../enums/buttons";
@@ -19,7 +19,8 @@ import { PokemonType } from "#enums/pokemon-type";
 import { TypeColor, TypeShadow } from "#app/enums/color";
 import { getNatureStatMultiplier, getNatureName } from "../data/nature";
 import { getVariantTint } from "#app/sprites/variant";
-import * as Modifier from "../modifier/modifier";
+// biome-ignore lint/style/noNamespaceImport: See `src/system/game-data.ts`
+import * as Modifier from "#app/modifier/modifier";
 import type { Species } from "#enums/species";
 import { PlayerGender } from "#enums/player-gender";
 import { SettingKeyboard } from "#app/system/settings/settings-keyboard";
@@ -411,7 +412,7 @@ export default class RunInfoUiHandler extends UiHandler {
     const enemyLevel = addTextObject(
       36,
       26,
-      `${i18next.t("saveSlotSelectUiHandler:lv")}${Utils.formatLargeNumber(enemy.level, 1000)}`,
+      `${i18next.t("saveSlotSelectUiHandler:lv")}${formatLargeNumber(enemy.level, 1000)}`,
       enemyLevelStyle,
       { fontSize: "44px", color: "#f8f8f8" },
     );
@@ -441,7 +442,7 @@ export default class RunInfoUiHandler extends UiHandler {
       const enemyLevel = addTextObject(
         36,
         26,
-        `${i18next.t("saveSlotSelectUiHandler:lv")}${Utils.formatLargeNumber(enemy.level, 1000)}`,
+        `${i18next.t("saveSlotSelectUiHandler:lv")}${formatLargeNumber(enemy.level, 1000)}`,
         bossStatus ? TextStyle.PARTY_RED : TextStyle.PARTY,
         { fontSize: "44px", color: "#f8f8f8" },
       );
@@ -527,7 +528,7 @@ export default class RunInfoUiHandler extends UiHandler {
       const enemyLevel = addTextObject(
         43 * (e % 3),
         27 * (pokemonRowHeight + 1),
-        `${i18next.t("saveSlotSelectUiHandler:lv")}${Utils.formatLargeNumber(enemy.level, 1000)}`,
+        `${i18next.t("saveSlotSelectUiHandler:lv")}${formatLargeNumber(enemy.level, 1000)}`,
         isBoss ? TextStyle.PARTY_RED : TextStyle.PARTY,
         { fontSize: "54px" },
       );
@@ -606,9 +607,9 @@ export default class RunInfoUiHandler extends UiHandler {
       fontSize: "50px",
       lineSpacing: lineSpacing,
     });
-    const runTime = Utils.getPlayTimeString(this.runInfo.playTime);
+    const runTime = getPlayTimeString(this.runInfo.playTime);
     runInfoText.appendText(`${i18next.t("runHistory:runLength")}: ${runTime}`, false);
-    const runMoney = Utils.formatMoney(globalScene.moneyFormat, this.runInfo.money);
+    const runMoney = formatMoney(globalScene.moneyFormat, this.runInfo.money);
     const moneyTextColor = getTextColor(TextStyle.MONEY_WINDOW, false, globalScene.uiTheme);
     runInfoText.appendText(
       `[color=${moneyTextColor}]${i18next.t("battleScene:moneyOwned", { formattedMoney: runMoney })}[/color]`,
@@ -770,7 +771,7 @@ export default class RunInfoUiHandler extends UiHandler {
         lineSpacing: lineSpacing,
       });
       pokeInfoText.appendText(
-        `${i18next.t("saveSlotSelectUiHandler:lv")}${Utils.formatFancyLargeNumber(pokemon.level, 1)} - ${pNatureName}`,
+        `${i18next.t("saveSlotSelectUiHandler:lv")}${formatFancyLargeNumber(pokemon.level, 1)} - ${pNatureName}`,
       );
       pokeInfoText.appendText(pAbilityInfo);
       pokeInfoText.appendText(pPassiveInfo);
@@ -780,7 +781,7 @@ export default class RunInfoUiHandler extends UiHandler {
       // Colored Arrows (Red/Blue) are placed by stats that are boosted from natures
       const pokeStatTextContainer = globalScene.add.container(-35, 6);
       const pStats: string[] = [];
-      pokemon.stats.forEach(element => pStats.push(Utils.formatFancyLargeNumber(element, 1)));
+      pokemon.stats.forEach(element => pStats.push(formatFancyLargeNumber(element, 1)));
       for (let i = 0; i < pStats.length; i++) {
         const isMult = getNatureStatMultiplier(pNature, i);
         pStats[i] = isMult < 1 ? pStats[i] + "[color=#40c8f8]↓[/color]" : pStats[i];

--- a/src/ui/save-slot-select-ui-handler.ts
+++ b/src/ui/save-slot-select-ui-handler.ts
@@ -2,10 +2,11 @@ import i18next from "i18next";
 import { globalScene } from "#app/global-scene";
 import { Button } from "#enums/buttons";
 import { GameMode } from "../game-mode";
-import * as Modifier from "../modifier/modifier";
+// biome-ignore lint/style/noNamespaceImport: See `src/system/game-data.ts`
+import * as Modifier from "#app/modifier/modifier";
 import type { SessionSaveData } from "../system/game-data";
 import type PokemonData from "../system/pokemon-data";
-import * as Utils from "../utils";
+import { isNullOrUndefined, fixedInt, getPlayTimeString, formatLargeNumber } from "#app/utils";
 import MessageUiHandler from "./message-ui-handler";
 import { TextStyle, addTextObject } from "./text";
 import { Mode } from "./ui";
@@ -296,7 +297,7 @@ export default class SaveSlotSelectUiHandler extends MessageUiHandler {
       }
       this.setArrowVisibility(hasData);
     }
-    if (!Utils.isNullOrUndefined(prevSlotIndex)) {
+    if (!isNullOrUndefined(prevSlotIndex)) {
       this.revertSessionSlot(prevSlotIndex);
     }
 
@@ -339,7 +340,7 @@ export default class SaveSlotSelectUiHandler extends MessageUiHandler {
       globalScene.tweens.add({
         targets: this.sessionSlotsContainer,
         y: this.sessionSlotsContainerInitialY - 56 * scrollCursor,
-        duration: Utils.fixedInt(325),
+        duration: fixedInt(325),
         ease: "Sine.easeInOut",
       });
     }
@@ -407,7 +408,7 @@ class SessionSlot extends Phaser.GameObjects.Container {
     const timestampLabel = addTextObject(8, 19, new Date(data.timestamp).toLocaleString(), TextStyle.WINDOW);
     this.add(timestampLabel);
 
-    const playTimeLabel = addTextObject(8, 33, Utils.getPlayTimeString(data.playTime), TextStyle.WINDOW);
+    const playTimeLabel = addTextObject(8, 33, getPlayTimeString(data.playTime), TextStyle.WINDOW);
     this.add(playTimeLabel);
 
     const pokemonIconsContainer = globalScene.add.container(144, 4);
@@ -421,7 +422,7 @@ class SessionSlot extends Phaser.GameObjects.Container {
       const text = addTextObject(
         32,
         20,
-        `${i18next.t("saveSlotSelectUiHandler:lv")}${Utils.formatLargeNumber(pokemon.level, 1000)}`,
+        `${i18next.t("saveSlotSelectUiHandler:lv")}${formatLargeNumber(pokemon.level, 1000)}`,
         TextStyle.PARTY,
         { fontSize: "54px", color: "#f8f8f8" },
       );

--- a/src/ui/saving-icon-handler.ts
+++ b/src/ui/saving-icon-handler.ts
@@ -1,5 +1,5 @@
 import { globalScene } from "#app/global-scene";
-import * as Utils from "../utils";
+import { fixedInt } from "#app/utils";
 
 export default class SavingIconHandler extends Phaser.GameObjects.Container {
   private icon: Phaser.GameObjects.Sprite;
@@ -36,10 +36,10 @@ export default class SavingIconHandler extends Phaser.GameObjects.Container {
     globalScene.tweens.add({
       targets: this,
       alpha: 1,
-      duration: Utils.fixedInt(250),
+      duration: fixedInt(250),
       ease: "Sine.easeInOut",
       onComplete: () => {
-        globalScene.time.delayedCall(Utils.fixedInt(500), () => {
+        globalScene.time.delayedCall(fixedInt(500), () => {
           this.animActive = false;
           if (!this.shown) {
             this.hide();
@@ -64,7 +64,7 @@ export default class SavingIconHandler extends Phaser.GameObjects.Container {
     globalScene.tweens.add({
       targets: this,
       alpha: 0,
-      duration: Utils.fixedInt(250),
+      duration: fixedInt(250),
       ease: "Sine.easeInOut",
       onComplete: () => {
         this.animActive = false;

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -43,7 +43,7 @@ import { Egg } from "#app/data/egg";
 import Overrides from "#app/overrides";
 import { SettingKeyboard } from "#app/system/settings/settings-keyboard";
 import { Passive as PassiveAttr } from "#enums/passive";
-import * as Challenge from "#app/data/challenge";
+import { applyChallenges, ChallengeType } from "#app/data/challenge";
 import MoveInfoOverlay from "#app/ui/move-info-overlay";
 import { getEggTierForSpecies } from "#app/data/egg";
 import { Device } from "#enums/devices";
@@ -78,7 +78,6 @@ import {
 import type { Nature } from "#enums/nature";
 import { PLAYER_PARTY_MAX_SIZE } from "#app/constants";
 import { achvs } from "#app/system/achv";
-import * as Utils from "../utils";
 import type { GameObjects } from "phaser";
 import { checkStarterValidForChallenge } from "#app/data/challenge";
 
@@ -2518,7 +2517,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
           case Button.CYCLE_TERA:
             if (this.canCycleTera) {
               const speciesForm = getPokemonSpeciesForm(this.lastSpecies.speciesId, starterAttributes.form ?? 0);
-              if (speciesForm.type1 === this.teraCursor && !Utils.isNullOrUndefined(speciesForm.type2)) {
+              if (speciesForm.type1 === this.teraCursor && !isNullOrUndefined(speciesForm.type2)) {
                 starterAttributes.tera = speciesForm.type2!;
                 this.setSpeciesDetails(this.lastSpecies, {
                   teraType: speciesForm.type2!,
@@ -2960,7 +2959,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         valueLimit.value = 10;
     }
 
-    Challenge.applyChallenges(Challenge.ChallengeType.STARTER_POINTS, valueLimit);
+    applyChallenges(ChallengeType.STARTER_POINTS, valueLimit);
 
     return valueLimit.value;
   }
@@ -3748,7 +3747,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       ); // TODO: is this bang correct?
       this.abilityCursor = abilityIndex !== undefined ? abilityIndex : (abilityIndex = oldAbilityIndex);
       this.natureCursor = natureIndex !== undefined ? natureIndex : (natureIndex = oldNatureIndex);
-      this.teraCursor = !Utils.isNullOrUndefined(teraType) ? teraType : (teraType = species.type1);
+      this.teraCursor = !isNullOrUndefined(teraType) ? teraType : (teraType = species.type1);
       const [isInParty, partyIndex]: [boolean, number] = this.isInParty(species); // we use this to firstly check if the pokemon is in the party, and if so, to get the party index in order to update the icon image
       if (isInParty) {
         this.updatePartyIcon(species, partyIndex);
@@ -3886,7 +3885,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         this.canCycleTera =
           !this.statsMode &&
           globalScene.gameData.achvUnlocks.hasOwnProperty(achvs.TERASTALLIZE.id) &&
-          !Utils.isNullOrUndefined(getPokemonSpeciesForm(species.speciesId, formIndex ?? 0).type2);
+          !isNullOrUndefined(getPokemonSpeciesForm(species.speciesId, formIndex ?? 0).type2);
       }
 
       if (dexEntry.caughtAttr && species.malePercent !== null) {
@@ -4483,7 +4482,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       this.canCycleTera =
         !this.statsMode &&
         globalScene.gameData.achvUnlocks.hasOwnProperty(achvs.TERASTALLIZE.id) &&
-        !Utils.isNullOrUndefined(getPokemonSpeciesForm(this.lastSpecies.speciesId, formIndex ?? 0).type2);
+        !isNullOrUndefined(getPokemonSpeciesForm(this.lastSpecies.speciesId, formIndex ?? 0).type2);
       this.updateInstructions();
     }
   }

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -2,7 +2,16 @@ import { starterColors } from "#app/battle-scene";
 import { globalScene } from "#app/global-scene";
 import { Mode } from "#app/ui/ui";
 import UiHandler from "#app/ui/ui-handler";
-import * as Utils from "#app/utils";
+import {
+  getLocalizedSpriteKey,
+  rgbHexToRgba,
+  padInt,
+  getEnumValues,
+  fixedInt,
+  isNullOrUndefined,
+  toReadableString,
+  formatStat,
+} from "#app/utils";
 import type { PlayerPokemon, PokemonMove } from "#app/field/pokemon";
 import { getStarterValueFriendshipCap, speciesStarterCosts } from "#app/data/balance/starters";
 import { argbFromRgba } from "@material/material-color-utilities";
@@ -255,7 +264,7 @@ export default class SummaryUiHandler extends UiHandler {
 
     this.statusContainer.add(statusLabel);
 
-    this.status = globalScene.add.sprite(91, 4, Utils.getLocalizedSpriteKey("statuses"));
+    this.status = globalScene.add.sprite(91, 4, getLocalizedSpriteKey("statuses"));
     this.status.setOrigin(0.5, 0);
 
     this.statusContainer.add(this.status);
@@ -330,10 +339,10 @@ export default class SummaryUiHandler extends UiHandler {
     this.shinyOverlay.setVisible(this.pokemon.isShiny());
 
     const colorScheme = starterColors[this.pokemon.species.getRootSpeciesId()];
-    this.candyIcon.setTint(argbFromRgba(Utils.rgbHexToRgba(colorScheme[0])));
-    this.candyOverlay.setTint(argbFromRgba(Utils.rgbHexToRgba(colorScheme[1])));
+    this.candyIcon.setTint(argbFromRgba(rgbHexToRgba(colorScheme[0])));
+    this.candyOverlay.setTint(argbFromRgba(rgbHexToRgba(colorScheme[1])));
 
-    this.numberText.setText(Utils.padInt(this.pokemon.species.speciesId, 4));
+    this.numberText.setText(padInt(this.pokemon.species.speciesId, 4));
     this.numberText.setColor(this.getTextColor(!this.pokemon.isShiny() ? TextStyle.SUMMARY : TextStyle.SUMMARY_GOLD));
     this.numberText.setShadowColor(
       this.getTextColor(!this.pokemon.isShiny() ? TextStyle.SUMMARY : TextStyle.SUMMARY_GOLD, true),
@@ -600,7 +609,7 @@ export default class SummaryUiHandler extends UiHandler {
         }
         success = true;
       } else {
-        const pages = Utils.getEnumValues(Page);
+        const pages = getEnumValues(Page);
         switch (button) {
           case Button.UP:
           case Button.DOWN: {
@@ -675,10 +684,10 @@ export default class SummaryUiHandler extends UiHandler {
       if (moveDescriptionLineCount > 3) {
         this.descriptionScrollTween = globalScene.tweens.add({
           targets: this.moveDescriptionText,
-          delay: Utils.fixedInt(2000),
+          delay: fixedInt(2000),
           loop: -1,
-          hold: Utils.fixedInt(2000),
-          duration: Utils.fixedInt((moveDescriptionLineCount - 3) * 2000),
+          hold: fixedInt(2000),
+          duration: fixedInt((moveDescriptionLineCount - 3) * 2000),
           y: `-=${14.83 * (moveDescriptionLineCount - 3)}`,
         });
       }
@@ -697,10 +706,10 @@ export default class SummaryUiHandler extends UiHandler {
       this.moveCursorObj.setVisible(true);
       this.moveCursorBlinkTimer = globalScene.time.addEvent({
         loop: true,
-        delay: Utils.fixedInt(600),
+        delay: fixedInt(600),
         callback: () => {
           this.moveCursorObj?.setVisible(false);
-          globalScene.time.delayedCall(Utils.fixedInt(100), () => {
+          globalScene.time.delayedCall(fixedInt(100), () => {
             if (!this.moveCursorObj) {
               return;
             }
@@ -818,7 +827,7 @@ export default class SummaryUiHandler extends UiHandler {
         const getTypeIcon = (index: number, type: PokemonType, tera = false) => {
           const xCoord = typeLabel.width * typeLabel.scale + 9 + 34 * index;
           const typeIcon = !tera
-            ? globalScene.add.sprite(xCoord, 42, Utils.getLocalizedSpriteKey("types"), PokemonType[type].toLowerCase())
+            ? globalScene.add.sprite(xCoord, 42, getLocalizedSpriteKey("types"), PokemonType[type].toLowerCase())
             : globalScene.add.sprite(xCoord, 42, "type_tera");
           if (tera) {
             typeIcon.setScale(0.5);
@@ -853,7 +862,7 @@ export default class SummaryUiHandler extends UiHandler {
 
         if (
           globalScene.gameData.achvUnlocks.hasOwnProperty(achvs.TERASTALLIZE.id) &&
-          !Utils.isNullOrUndefined(this.pokemon)
+          !isNullOrUndefined(this.pokemon)
         ) {
           const teraIcon = globalScene.add.sprite(123, 26, "button_tera");
           teraIcon.setName("terrastallize-icon");
@@ -925,10 +934,10 @@ export default class SummaryUiHandler extends UiHandler {
             abilityInfo.descriptionText.setY(69);
             this.descriptionScrollTween = globalScene.tweens.add({
               targets: abilityInfo.descriptionText,
-              delay: Utils.fixedInt(2000),
+              delay: fixedInt(2000),
               loop: -1,
-              hold: Utils.fixedInt(2000),
-              duration: Utils.fixedInt((abilityDescriptionLineCount - 2) * 2000),
+              hold: fixedInt(2000),
+              duration: fixedInt((abilityDescriptionLineCount - 2) * 2000),
               y: `-=${14.83 * (abilityDescriptionLineCount - 2)}`,
             });
           }
@@ -939,8 +948,8 @@ export default class SummaryUiHandler extends UiHandler {
         this.passiveContainer?.descriptionText?.setVisible(false);
 
         const closeFragment = getBBCodeFrag("", TextStyle.WINDOW_ALT);
-        const rawNature = Utils.toReadableString(Nature[this.pokemon?.getNature()!]); // TODO: is this bang correct?
-        const nature = `${getBBCodeFrag(Utils.toReadableString(getNatureName(this.pokemon?.getNature()!)), TextStyle.SUMMARY_RED)}${closeFragment}`; // TODO: is this bang correct?
+        const rawNature = toReadableString(Nature[this.pokemon?.getNature()!]); // TODO: is this bang correct?
+        const nature = `${getBBCodeFrag(toReadableString(getNatureName(this.pokemon?.getNature()!)), TextStyle.SUMMARY_RED)}${closeFragment}`; // TODO: is this bang correct?
 
         const memoString = i18next.t("pokemonSummary:memoString", {
           metFragment: i18next.t(
@@ -999,8 +1008,8 @@ export default class SummaryUiHandler extends UiHandler {
 
           const statValueText =
             stat !== Stat.HP
-              ? Utils.formatStat(this.pokemon?.getStat(stat)!) // TODO: is this bang correct?
-              : `${Utils.formatStat(this.pokemon?.hp!, true)}/${Utils.formatStat(this.pokemon?.getMaxHp()!, true)}`; // TODO: are those bangs correct?
+              ? formatStat(this.pokemon?.getStat(stat)!) // TODO: is this bang correct?
+              : `${formatStat(this.pokemon?.hp!, true)}/${formatStat(this.pokemon?.getMaxHp()!, true)}`; // TODO: are those bangs correct?
           const ivText = `${this.pokemon?.ivs[stat]}/31`;
 
           const statValue = addTextObject(93 + 88 * colIndex, 16 * rowIndex, statValueText, TextStyle.WINDOW_ALT);
@@ -1106,7 +1115,7 @@ export default class SummaryUiHandler extends UiHandler {
           this.extraMoveRowContainer.setVisible(true);
 
           if (this.newMove && this.pokemon) {
-            const spriteKey = Utils.getLocalizedSpriteKey("types");
+            const spriteKey = getLocalizedSpriteKey("types");
             const moveType = this.pokemon.getMoveType(this.newMove);
             const newMoveTypeIcon = globalScene.add.sprite(0, 0, spriteKey, PokemonType[moveType].toLowerCase());
             newMoveTypeIcon.setOrigin(0, 1);
@@ -1116,7 +1125,7 @@ export default class SummaryUiHandler extends UiHandler {
           ppOverlay.setOrigin(0, 1);
           this.extraMoveRowContainer.add(ppOverlay);
 
-          const pp = Utils.padInt(this.newMove?.pp!, 2, "  "); // TODO: is this bang correct?
+          const pp = padInt(this.newMove?.pp!, 2, "  "); // TODO: is this bang correct?
           const ppText = addTextObject(173, 1, `${pp}/${pp}`, TextStyle.WINDOW);
           ppText.setOrigin(0, 1);
           this.extraMoveRowContainer.add(ppText);
@@ -1132,7 +1141,7 @@ export default class SummaryUiHandler extends UiHandler {
           this.moveRowsContainer.add(moveRowContainer);
 
           if (move && this.pokemon) {
-            const spriteKey = Utils.getLocalizedSpriteKey("types");
+            const spriteKey = getLocalizedSpriteKey("types");
             const moveType = this.pokemon.getMoveType(move.getMove());
             const typeIcon = globalScene.add.sprite(0, 0, spriteKey, PokemonType[moveType].toLowerCase());
             typeIcon.setOrigin(0, 1);
@@ -1153,7 +1162,7 @@ export default class SummaryUiHandler extends UiHandler {
           if (move) {
             const maxPP = move.getMovePp();
             const pp = maxPP - move.ppUsed;
-            ppText.setText(`${Utils.padInt(pp, 2, "  ")}/${Utils.padInt(maxPP, 2, "  ")}`);
+            ppText.setText(`${padInt(pp, 2, "  ")}/${padInt(maxPP, 2, "  ")}`);
           }
 
           moveRowContainer.add(ppText);

--- a/src/ui/target-select-ui-handler.ts
+++ b/src/ui/target-select-ui-handler.ts
@@ -1,7 +1,7 @@
 import { BattlerIndex } from "../battle";
 import { Mode } from "./ui";
 import UiHandler from "./ui-handler";
-import * as Utils from "../utils";
+import { isNullOrUndefined, fixedInt } from "#app/utils";
 import { getMoveTargets } from "../data/moves/move";
 import { Button } from "#enums/buttons";
 import type { Moves } from "#enums/moves";
@@ -70,7 +70,7 @@ export default class TargetSelectUiHandler extends UiHandler {
    * @param user the Pokemon using the move
    */
   resetCursor(cursorN: number, user: Pokemon): void {
-    if (!Utils.isNullOrUndefined(cursorN)) {
+    if (!isNullOrUndefined(cursorN)) {
       if ([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2].includes(cursorN) || user.battleSummonData.waveTurnCount === 1) {
         // Reset cursor on the first turn of a fight or if an ally was targeted last turn
         cursorN = -1;
@@ -89,11 +89,11 @@ export default class TargetSelectUiHandler extends UiHandler {
       this.targetSelectCallback(button === Button.ACTION ? targetIndexes : []);
       success = true;
       if (this.fieldIndex === BattlerIndex.PLAYER) {
-        if (Utils.isNullOrUndefined(this.cursor0) || this.cursor0 !== this.cursor) {
+        if (isNullOrUndefined(this.cursor0) || this.cursor0 !== this.cursor) {
           this.cursor0 = this.cursor;
         }
       } else if (this.fieldIndex === BattlerIndex.PLAYER_2) {
-        if (Utils.isNullOrUndefined(this.cursor1) || this.cursor1 !== this.cursor) {
+        if (isNullOrUndefined(this.cursor1) || this.cursor1 !== this.cursor) {
           this.cursor1 = this.cursor;
         }
       }
@@ -152,7 +152,7 @@ export default class TargetSelectUiHandler extends UiHandler {
       key: { start: 1, to: 0.25 },
       loop: -1,
       loopDelay: 150,
-      duration: Utils.fixedInt(450),
+      duration: fixedInt(450),
       ease: "Sine.easeInOut",
       yoyo: true,
       onUpdate: t => {
@@ -178,7 +178,7 @@ export default class TargetSelectUiHandler extends UiHandler {
           targets: [info],
           y: { start: info.getBaseY(), to: info.getBaseY() + 1 },
           loop: -1,
-          duration: Utils.fixedInt(250),
+          duration: fixedInt(250),
           ease: "Linear",
           yoyo: true,
         }),

--- a/src/ui/time-of-day-widget.ts
+++ b/src/ui/time-of-day-widget.ts
@@ -1,4 +1,4 @@
-import * as Utils from "../utils";
+import { fixedInt } from "#app/utils";
 import { globalScene } from "#app/global-scene";
 import { BattleSceneEventType } from "../events/battle-scene";
 import { EaseType } from "#enums/ease-type";
@@ -75,14 +75,14 @@ export default class TimeOfDayWidget extends Phaser.GameObjects.Container {
     const rotate = {
       targets: [this.timeOfDayIconMgs[0], this.timeOfDayIconMgs[1]],
       angle: "+=90",
-      duration: Utils.fixedInt(1500),
+      duration: fixedInt(1500),
       ease: "Back.easeOut",
       paused: !this.parentVisible,
     };
     const fade = {
       targets: [this.timeOfDayIconBgs[1], this.timeOfDayIconMgs[1], this.timeOfDayIconFgs[1]],
       alpha: 0,
-      duration: Utils.fixedInt(500),
+      duration: fixedInt(500),
       ease: "Linear",
       paused: !this.parentVisible,
     };
@@ -98,14 +98,14 @@ export default class TimeOfDayWidget extends Phaser.GameObjects.Container {
     const bounce = {
       targets: [this.timeOfDayIconMgs[0], this.timeOfDayIconMgs[1]],
       angle: "+=90",
-      duration: Utils.fixedInt(2000),
+      duration: fixedInt(2000),
       ease: "Bounce.easeOut",
       paused: !this.parentVisible,
     };
     const fade = {
       targets: [this.timeOfDayIconBgs[1], this.timeOfDayIconMgs[1], this.timeOfDayIconFgs[1]],
       alpha: 0,
-      duration: Utils.fixedInt(800),
+      duration: fixedInt(800),
       ease: "Linear",
       paused: !this.parentVisible,
     };

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -1,6 +1,6 @@
 import OptionSelectUiHandler from "./settings/option-select-ui-handler";
 import { Mode } from "./ui";
-import * as Utils from "../utils";
+import { fixedInt, randInt, randItem } from "#app/utils";
 import { TextStyle, addTextObject } from "./text";
 import { getSplashMessages } from "../data/splash-messages";
 import i18next from "i18next";
@@ -72,7 +72,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
 
     globalScene.tweens.add({
       targets: this.splashMessageText,
-      duration: Utils.fixedInt(350),
+      duration: fixedInt(350),
       scale: originalSplashMessageScale * 1.25,
       loop: -1,
       yoyo: true,
@@ -104,7 +104,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
 
   /** Used solely to display a random Pokémon name in a splash message. */
   randomPokemon(): void {
-    const rand = Utils.randInt(1025, 1);
+    const rand = randInt(1025, 1);
     const pokemon = getPokemonSpecies(rand as Species);
     if (
       this.splashMessage === "splashMessages:underratedPokemon" ||
@@ -132,7 +132,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
       // Moving player count to top of the menu
       this.playerCountLabel.setY(globalScene.game.canvas.height / 6 - 13 - this.getWindowHeight());
 
-      this.splashMessage = Utils.randItem(getSplashMessages());
+      this.splashMessage = randItem(getSplashMessages());
       this.splashMessageText.setText(
         i18next.t(this.splashMessage, {
           count: TitleUiHandler.BATTLES_WON_FALLBACK,
@@ -159,7 +159,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
 
       globalScene.tweens.add({
         targets: [this.titleContainer, ui.getMessageHandler().bg],
-        duration: Utils.fixedInt(325),
+        duration: fixedInt(325),
         alpha: (target: any) => (target === this.titleContainer ? 1 : 0),
         ease: "Sine.easeInOut",
       });
@@ -180,7 +180,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
 
     globalScene.tweens.add({
       targets: [this.titleContainer, ui.getMessageHandler().bg],
-      duration: Utils.fixedInt(325),
+      duration: fixedInt(325),
       alpha: (target: any) => (target === this.titleContainer ? 0 : 1),
       ease: "Sine.easeInOut",
     });

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -28,7 +28,7 @@ import { addWindow } from "./ui-theme";
 import LoginFormUiHandler from "./login-form-ui-handler";
 import RegistrationFormUiHandler from "./registration-form-ui-handler";
 import LoadingModalUiHandler from "./loading-modal-ui-handler";
-import * as Utils from "../utils";
+import { executeIf } from "#app/utils";
 import GameStatsUiHandler from "./game-stats-ui-handler";
 import AwaitableUiHandler from "./awaitable-ui-handler";
 import SaveSlotSelectUiHandler from "./save-slot-select-ui-handler";
@@ -674,7 +674,7 @@ export default class UI extends Phaser.GameObjects.Container {
       if (!this?.modeChain?.length) {
         return resolve();
       }
-      this.revertMode().then(success => Utils.executeIf(success, this.revertModes).then(() => resolve()));
+      this.revertMode().then(success => executeIf(success, this.revertModes).then(() => resolve()));
     });
   }
 

--- a/src/ui/unavailable-modal-ui-handler.ts
+++ b/src/ui/unavailable-modal-ui-handler.ts
@@ -3,7 +3,7 @@ import { ModalUiHandler } from "./modal-ui-handler";
 import { addTextObject, TextStyle } from "./text";
 import type { Mode } from "./ui";
 import { updateUserInfo } from "#app/account";
-import * as Utils from "#app/utils";
+import { removeCookie, sessionIdKey } from "#app/utils";
 import i18next from "i18next";
 import { globalScene } from "#app/global-scene";
 
@@ -65,7 +65,7 @@ export default class UnavailableModalUiHandler extends ModalUiHandler {
         globalScene.playSound("se/pb_bounce_1");
         this.reconnectCallback();
       } else if (response[1] === 401) {
-        Utils.removeCookie(Utils.sessionIdKey);
+        removeCookie(sessionIdKey);
         globalScene.reset(true, true);
       } else {
         this.reconnectDuration = Math.min(this.reconnectDuration * 2, this.maxTime); // Set a max delay so it isn't infinite

--- a/test/escape-calculations.test.ts
+++ b/test/escape-calculations.test.ts
@@ -1,7 +1,7 @@
 import { AttemptRunPhase } from "#app/phases/attempt-run-phase";
 import type { CommandPhase } from "#app/phases/command-phase";
 import { Command } from "#app/ui/command-ui-handler";
-import * as Utils from "#app/utils";
+import { NumberHolder } from "#app/utils";
 import { Abilities } from "#enums/abilities";
 import { Species } from "#enums/species";
 import GameManager from "#test/testUtils/gameManager";
@@ -45,7 +45,7 @@ describe("Escape chance calculations", () => {
 
     await game.phaseInterceptor.to(AttemptRunPhase, false);
     const phase = game.scene.getCurrentPhase() as AttemptRunPhase;
-    const escapePercentage = new Utils.NumberHolder(0);
+    const escapePercentage = new NumberHolder(0);
 
     // this sets up an object for multiple attempts. The pokemonSpeedRatio is your speed divided by the enemy speed, the escapeAttempts are the number of escape attempts and the expectedEscapeChance is the chance it should be escaping
     const escapeChances: {
@@ -118,7 +118,7 @@ describe("Escape chance calculations", () => {
 
     await game.phaseInterceptor.to(AttemptRunPhase, false);
     const phase = game.scene.getCurrentPhase() as AttemptRunPhase;
-    const escapePercentage = new Utils.NumberHolder(0);
+    const escapePercentage = new NumberHolder(0);
 
     // this sets up an object for multiple attempts. The pokemonSpeedRatio is your speed divided by the enemy speed, the escapeAttempts are the number of escape attempts and the expectedEscapeChance is the chance it should be escaping
     const escapeChances: {
@@ -197,7 +197,7 @@ describe("Escape chance calculations", () => {
 
     await game.phaseInterceptor.to(AttemptRunPhase, false);
     const phase = game.scene.getCurrentPhase() as AttemptRunPhase;
-    const escapePercentage = new Utils.NumberHolder(0);
+    const escapePercentage = new NumberHolder(0);
 
     // this sets up an object for multiple attempts. The pokemonSpeedRatio is your speed divided by the enemy speed, the escapeAttempts are the number of escape attempts and the expectedEscapeChance is the chance it should be escaping
     const escapeChances: {
@@ -284,7 +284,7 @@ describe("Escape chance calculations", () => {
 
     await game.phaseInterceptor.to(AttemptRunPhase, false);
     const phase = game.scene.getCurrentPhase() as AttemptRunPhase;
-    const escapePercentage = new Utils.NumberHolder(0);
+    const escapePercentage = new NumberHolder(0);
 
     // this sets up an object for multiple attempts. The pokemonSpeedRatio is your speed divided by the enemy speed, the escapeAttempts are the number of escape attempts and the expectedEscapeChance is the chance it should be escaping
     const escapeChances: {

--- a/test/items/exp_booster.test.ts
+++ b/test/items/exp_booster.test.ts
@@ -1,6 +1,6 @@
 import { Abilities } from "#app/enums/abilities";
 import { PokemonExpBoosterModifier } from "#app/modifier/modifier";
-import * as Utils from "#app/utils";
+import { NumberHolder } from "#app/utils";
 import GameManager from "#test/testUtils/gameManager";
 import Phase from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -33,7 +33,7 @@ describe("EXP Modifier Items", () => {
 
     const partyMember = game.scene.getPlayerPokemon()!;
     partyMember.exp = 100;
-    const expHolder = new Utils.NumberHolder(partyMember.exp);
+    const expHolder = new NumberHolder(partyMember.exp);
     game.scene.applyModifiers(PokemonExpBoosterModifier, true, partyMember, expHolder);
     expect(expHolder.value).toBe(440);
   }, 20000);

--- a/test/items/leek.test.ts
+++ b/test/items/leek.test.ts
@@ -1,5 +1,5 @@
 import { TurnEndPhase } from "#app/phases/turn-end-phase";
-import * as Utils from "#app/utils";
+import { randInt } from "#app/utils";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
 import GameManager from "#test/testUtils/gameManager";
@@ -78,7 +78,7 @@ describe("Items - Leek", () => {
     // Randomly choose from the Farfetch'd line
     const species = [Species.FARFETCHD, Species.GALAR_FARFETCHD, Species.SIRFETCHD];
 
-    await game.startBattle([species[Utils.randInt(species.length)], Species.PIKACHU]);
+    await game.startBattle([species[randInt(species.length)], Species.PIKACHU]);
 
     const [partyMember, ally] = game.scene.getPlayerParty();
 
@@ -106,7 +106,7 @@ describe("Items - Leek", () => {
     // Randomly choose from the Farfetch'd line
     const species = [Species.FARFETCHD, Species.GALAR_FARFETCHD, Species.SIRFETCHD];
 
-    await game.startBattle([Species.PIKACHU, species[Utils.randInt(species.length)]]);
+    await game.startBattle([Species.PIKACHU, species[randInt(species.length)]]);
 
     const [partyMember, ally] = game.scene.getPlayerParty();
 

--- a/test/items/light_ball.test.ts
+++ b/test/items/light_ball.test.ts
@@ -2,7 +2,7 @@ import { Stat } from "#enums/stat";
 import { SpeciesStatBoosterModifier } from "#app/modifier/modifier";
 import { modifierTypes } from "#app/modifier/modifier-type";
 import i18next from "#app/plugins/i18n";
-import * as Utils from "#app/utils";
+import { NumberHolder } from "#app/utils";
 import { Species } from "#enums/species";
 import GameManager from "#test/testUtils/gameManager";
 import Phase from "phaser";
@@ -90,9 +90,9 @@ describe("Items - Light Ball", () => {
     const spAtkStat = partyMember.getStat(Stat.SPATK);
 
     // Making sure modifier is not applied without holding item
-    const atkValue = new Utils.NumberHolder(atkStat);
+    const atkValue = new NumberHolder(atkStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.DEF, atkValue);
-    const spAtkValue = new Utils.NumberHolder(spAtkStat);
+    const spAtkValue = new NumberHolder(spAtkStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.SPDEF, spAtkValue);
 
     expect(atkValue.value / atkStat).toBe(1);
@@ -129,9 +129,9 @@ describe("Items - Light Ball", () => {
     const spAtkStat = partyMember.getStat(Stat.SPATK);
 
     // Making sure modifier is not applied without holding item
-    const atkValue = new Utils.NumberHolder(atkStat);
+    const atkValue = new NumberHolder(atkStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.DEF, atkValue);
-    const spAtkValue = new Utils.NumberHolder(spAtkStat);
+    const spAtkValue = new NumberHolder(spAtkStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.SPDEF, spAtkValue);
 
     expect(atkValue.value / atkStat).toBe(1);
@@ -168,9 +168,9 @@ describe("Items - Light Ball", () => {
     const spAtkStat = partyMember.getStat(Stat.SPATK);
 
     // Making sure modifier is not applied without holding item
-    const atkValue = new Utils.NumberHolder(atkStat);
+    const atkValue = new NumberHolder(atkStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.DEF, atkValue);
-    const spAtkValue = new Utils.NumberHolder(spAtkStat);
+    const spAtkValue = new NumberHolder(spAtkStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.SPDEF, spAtkValue);
 
     expect(atkValue.value / atkStat).toBe(1);
@@ -197,9 +197,9 @@ describe("Items - Light Ball", () => {
     const spAtkStat = partyMember.getStat(Stat.SPATK);
 
     // Making sure modifier is not applied without holding item
-    const atkValue = new Utils.NumberHolder(atkStat);
+    const atkValue = new NumberHolder(atkStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.DEF, atkValue);
-    const spAtkValue = new Utils.NumberHolder(spAtkStat);
+    const spAtkValue = new NumberHolder(spAtkStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.SPDEF, spAtkValue);
 
     expect(atkValue.value / atkStat).toBe(1);

--- a/test/items/metal_powder.test.ts
+++ b/test/items/metal_powder.test.ts
@@ -2,7 +2,7 @@ import { Stat } from "#enums/stat";
 import { SpeciesStatBoosterModifier } from "#app/modifier/modifier";
 import { modifierTypes } from "#app/modifier/modifier-type";
 import i18next from "#app/plugins/i18n";
-import * as Utils from "#app/utils";
+import { NumberHolder } from "#app/utils";
 import { Species } from "#enums/species";
 import GameManager from "#test/testUtils/gameManager";
 import Phase from "phaser";
@@ -89,7 +89,7 @@ describe("Items - Metal Powder", () => {
     const defStat = partyMember.getStat(Stat.DEF);
 
     // Making sure modifier is not applied without holding item
-    const defValue = new Utils.NumberHolder(defStat);
+    const defValue = new NumberHolder(defStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.DEF, defValue);
 
     expect(defValue.value / defStat).toBe(1);
@@ -122,7 +122,7 @@ describe("Items - Metal Powder", () => {
     const defStat = partyMember.getStat(Stat.DEF);
 
     // Making sure modifier is not applied without holding item
-    const defValue = new Utils.NumberHolder(defStat);
+    const defValue = new NumberHolder(defStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.DEF, defValue);
 
     expect(defValue.value / defStat).toBe(1);
@@ -155,7 +155,7 @@ describe("Items - Metal Powder", () => {
     const defStat = partyMember.getStat(Stat.DEF);
 
     // Making sure modifier is not applied without holding item
-    const defValue = new Utils.NumberHolder(defStat);
+    const defValue = new NumberHolder(defStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.DEF, defValue);
 
     expect(defValue.value / defStat).toBe(1);
@@ -178,7 +178,7 @@ describe("Items - Metal Powder", () => {
     const defStat = partyMember.getStat(Stat.DEF);
 
     // Making sure modifier is not applied without holding item
-    const defValue = new Utils.NumberHolder(defStat);
+    const defValue = new NumberHolder(defStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.DEF, defValue);
 
     expect(defValue.value / defStat).toBe(1);

--- a/test/items/quick_powder.test.ts
+++ b/test/items/quick_powder.test.ts
@@ -2,7 +2,7 @@ import { Stat } from "#enums/stat";
 import { SpeciesStatBoosterModifier } from "#app/modifier/modifier";
 import { modifierTypes } from "#app/modifier/modifier-type";
 import i18next from "#app/plugins/i18n";
-import * as Utils from "#app/utils";
+import { NumberHolder } from "#app/utils";
 import { Species } from "#enums/species";
 import GameManager from "#test/testUtils/gameManager";
 import Phase from "phaser";
@@ -89,7 +89,7 @@ describe("Items - Quick Powder", () => {
     const spdStat = partyMember.getStat(Stat.SPD);
 
     // Making sure modifier is not applied without holding item
-    const spdValue = new Utils.NumberHolder(spdStat);
+    const spdValue = new NumberHolder(spdStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.SPD, spdValue);
 
     expect(spdValue.value / spdStat).toBe(1);
@@ -122,7 +122,7 @@ describe("Items - Quick Powder", () => {
     const spdStat = partyMember.getStat(Stat.SPD);
 
     // Making sure modifier is not applied without holding item
-    const spdValue = new Utils.NumberHolder(spdStat);
+    const spdValue = new NumberHolder(spdStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.SPD, spdValue);
 
     expect(spdValue.value / spdStat).toBe(1);
@@ -155,7 +155,7 @@ describe("Items - Quick Powder", () => {
     const spdStat = partyMember.getStat(Stat.SPD);
 
     // Making sure modifier is not applied without holding item
-    const spdValue = new Utils.NumberHolder(spdStat);
+    const spdValue = new NumberHolder(spdStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.SPD, spdValue);
 
     expect(spdValue.value / spdStat).toBe(1);
@@ -178,7 +178,7 @@ describe("Items - Quick Powder", () => {
     const spdStat = partyMember.getStat(Stat.SPD);
 
     // Making sure modifier is not applied without holding item
-    const spdValue = new Utils.NumberHolder(spdStat);
+    const spdValue = new NumberHolder(spdStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.SPD, spdValue);
 
     expect(spdValue.value / spdStat).toBe(1);

--- a/test/items/thick_club.test.ts
+++ b/test/items/thick_club.test.ts
@@ -2,7 +2,7 @@ import { Stat } from "#enums/stat";
 import { SpeciesStatBoosterModifier } from "#app/modifier/modifier";
 import { modifierTypes } from "#app/modifier/modifier-type";
 import i18next from "#app/plugins/i18n";
-import * as Utils from "#app/utils";
+import { NumberHolder, randInt } from "#app/utils";
 import { Species } from "#enums/species";
 import GameManager from "#test/testUtils/gameManager";
 import Phase from "phaser";
@@ -89,7 +89,7 @@ describe("Items - Thick Club", () => {
     const atkStat = partyMember.getStat(Stat.ATK);
 
     // Making sure modifier is not applied without holding item
-    const atkValue = new Utils.NumberHolder(atkStat);
+    const atkValue = new NumberHolder(atkStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.ATK, atkValue);
 
     expect(atkValue.value / atkStat).toBe(1);
@@ -112,7 +112,7 @@ describe("Items - Thick Club", () => {
     const atkStat = partyMember.getStat(Stat.ATK);
 
     // Making sure modifier is not applied without holding item
-    const atkValue = new Utils.NumberHolder(atkStat);
+    const atkValue = new NumberHolder(atkStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.ATK, atkValue);
 
     expect(atkValue.value / atkStat).toBe(1);
@@ -135,7 +135,7 @@ describe("Items - Thick Club", () => {
     const atkStat = partyMember.getStat(Stat.ATK);
 
     // Making sure modifier is not applied without holding item
-    const atkValue = new Utils.NumberHolder(atkStat);
+    const atkValue = new NumberHolder(atkStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.ATK, atkValue);
 
     expect(atkValue.value / atkStat).toBe(1);
@@ -153,7 +153,7 @@ describe("Items - Thick Club", () => {
   it("THICK_CLUB held by fused CUBONE line (base)", async () => {
     // Randomly choose from the Cubone line
     const species = [Species.CUBONE, Species.MAROWAK, Species.ALOLA_MAROWAK];
-    const randSpecies = Utils.randInt(species.length);
+    const randSpecies = randInt(species.length);
 
     await game.classicMode.startBattle([species[randSpecies], Species.PIKACHU]);
 
@@ -172,7 +172,7 @@ describe("Items - Thick Club", () => {
     const atkStat = partyMember.getStat(Stat.ATK);
 
     // Making sure modifier is not applied without holding item
-    const atkValue = new Utils.NumberHolder(atkStat);
+    const atkValue = new NumberHolder(atkStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.ATK, atkValue);
 
     expect(atkValue.value / atkStat).toBe(1);
@@ -190,7 +190,7 @@ describe("Items - Thick Club", () => {
   it("THICK_CLUB held by fused CUBONE line (part)", async () => {
     // Randomly choose from the Cubone line
     const species = [Species.CUBONE, Species.MAROWAK, Species.ALOLA_MAROWAK];
-    const randSpecies = Utils.randInt(species.length);
+    const randSpecies = randInt(species.length);
 
     await game.classicMode.startBattle([Species.PIKACHU, species[randSpecies]]);
 
@@ -209,7 +209,7 @@ describe("Items - Thick Club", () => {
     const atkStat = partyMember.getStat(Stat.ATK);
 
     // Making sure modifier is not applied without holding item
-    const atkValue = new Utils.NumberHolder(atkStat);
+    const atkValue = new NumberHolder(atkStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.ATK, atkValue);
 
     expect(atkValue.value / atkStat).toBe(1);
@@ -232,7 +232,7 @@ describe("Items - Thick Club", () => {
     const atkStat = partyMember.getStat(Stat.ATK);
 
     // Making sure modifier is not applied without holding item
-    const atkValue = new Utils.NumberHolder(atkStat);
+    const atkValue = new NumberHolder(atkStat);
     game.scene.applyModifiers(SpeciesStatBoosterModifier, true, partyMember, Stat.ATK, atkValue);
 
     expect(atkValue.value / atkStat).toBe(1);

--- a/test/moves/multi_target.test.ts
+++ b/test/moves/multi_target.test.ts
@@ -1,7 +1,7 @@
 import { BattlerIndex } from "#app/battle";
 import { Abilities } from "#app/enums/abilities";
 import { Species } from "#app/enums/species";
-import * as Utils from "#app/utils";
+import { toDmgValue } from "#app/utils";
 import { Moves } from "#enums/moves";
 import GameManager from "#test/testUtils/gameManager";
 import Phaser from "phaser";
@@ -71,8 +71,8 @@ describe("Multi-target damage reduction", () => {
     // Single target moves don't get reduced
     expect(tackle1).toBe(tackle2);
     // Moves that target all enemies get reduced if there's more than one enemy
-    expect(gleam1).toBeLessThanOrEqual(Utils.toDmgValue(gleam2 * 0.75) + 1);
-    expect(gleam1).toBeGreaterThanOrEqual(Utils.toDmgValue(gleam2 * 0.75) - 1);
+    expect(gleam1).toBeLessThanOrEqual(toDmgValue(gleam2 * 0.75) + 1);
+    expect(gleam1).toBeGreaterThanOrEqual(toDmgValue(gleam2 * 0.75) - 1);
   });
 
   it("should reduce earthquake when more than one pokemon other than user is not fainted", async () => {
@@ -122,7 +122,7 @@ describe("Multi-target damage reduction", () => {
 
     const damageEnemy1Turn3 = enemy1.getMaxHp() - enemy1.hp;
     // Turn 3: 1 target, should be no damage reduction
-    expect(damageEnemy1Turn1).toBeLessThanOrEqual(Utils.toDmgValue(damageEnemy1Turn3 * 0.75) + 1);
-    expect(damageEnemy1Turn1).toBeGreaterThanOrEqual(Utils.toDmgValue(damageEnemy1Turn3 * 0.75) - 1);
+    expect(damageEnemy1Turn1).toBeLessThanOrEqual(toDmgValue(damageEnemy1Turn3 * 0.75) + 1);
+    expect(damageEnemy1Turn1).toBeGreaterThanOrEqual(toDmgValue(damageEnemy1Turn3 * 0.75) - 1);
   });
 });

--- a/test/mystery-encounter/encounter-test-utils.ts
+++ b/test/mystery-encounter/encounter-test-utils.ts
@@ -1,3 +1,4 @@
+// biome-ignore lint/style/noNamespaceImport: Necessary for mocks
 import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
 import { Status } from "#app/data/status-effect";
 import { CommandPhase } from "#app/phases/command-phase";

--- a/test/testUtils/gameWrapper.ts
+++ b/test/testUtils/gameWrapper.ts
@@ -2,7 +2,7 @@
 import BattleScene, * as battleScene from "#app/battle-scene";
 import { MoveAnim } from "#app/data/battle-anims";
 import Pokemon from "#app/field/pokemon";
-import * as Utils from "#app/utils";
+import { setCookie, sessionIdKey } from "#app/utils";
 import { blobToString } from "#test/testUtils/gameManagerUtils";
 import { MockClock } from "#test/testUtils/mocks/mockClock";
 import { MockFetch } from "#test/testUtils/mocks/mockFetch";
@@ -29,7 +29,7 @@ window.URL.createObjectURL = (blob: Blob) => {
 };
 navigator.getGamepads = () => [];
 global.fetch = vi.fn(MockFetch);
-Utils.setCookie(Utils.sessionIdKey, "fake_token");
+setCookie(sessionIdKey, "fake_token");
 
 window.matchMedia = () => ({
   matches: false,


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
It can cause issues with a plugin we're adding. Also, from the [rule page](https://biomejs.dev/linter/rules/no-namespace-import/):
> Namespace imports might impact the efficiency of tree shaking, a process that removes unused code from bundles. The effectiveness of tree shaking largely depends on the bundler (e.g., Webpack, Rollup) and its configuration. Modern bundlers are generally capable of handling namespace imports effectively, but using named imports is recommended for optimal tree shaking and minimizing bundle size.

## What are the changes from a developer perspective?
Imports in the style of `import * as Utils from "#app/utils";` will no longer be valid.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?