### PR TITLE
[Balance] Biome Encounter Redistribution and Rarity Adjustments

### DIFF
--- a/src/data/balance/biomes.ts
+++ b/src/data/balance/biomes.ts
@@ -313,13 +313,13 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.DAY]: [{ 1: [ Species.TANDEMAUS ], 25: [ Species.MAUSHOLD ]}],
       [TimeOfDay.DUSK]: [ Species.MORPEKO ],
       [TimeOfDay.NIGHT]: [ Species.MORPEKO ],
-      [TimeOfDay.ALL]: [{ 1: [ Species.VAROOM ], 40: [ Species.REVAVROOM ]}]
+      [TimeOfDay.ALL]: [ Species.CASTFORM, { 1: [ Species.VAROOM ], 40: [ Species.REVAVROOM ]}]
     },
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.DITTO, Species.EEVEE, Species.SMEARGLE ]},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.CASTFORM ]},
-    [BiomePoolTier.BOSS]: { [TimeOfDay.DAWN]: [ Species.BOLTUND ], [TimeOfDay.DAY]: [ Species.BOLTUND ], [TimeOfDay.DUSK]: [ Species.MEOWSTIC ], [TimeOfDay.NIGHT]: [ Species.MEOWSTIC ], [TimeOfDay.ALL]: [ Species.STOUTLAND, Species.FURFROU, Species.DACHSBUN ]},
-    [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [ Species.MAUSHOLD ], [TimeOfDay.DAY]: [ Species.MAUSHOLD ], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.CASTFORM, Species.REVAVROOM ]},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: []},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.POIPOLE, Species.ZERAORA ]},
+    [BiomePoolTier.BOSS]: { [TimeOfDay.DAWN]: [ Species.BOLTUND ], [TimeOfDay.DAY]: [ Species.BOLTUND ], [TimeOfDay.DUSK]: [ Species.MEOWSTIC ], [TimeOfDay.NIGHT]: [ Species.MEOWSTIC ], [TimeOfDay.ALL]: [ Species.CASTFORM, Species.STOUTLAND, Species.FURFROU, Species.DACHSBUN ]},
+    [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [ Species.MAUSHOLD ], [TimeOfDay.DAY]: [ Species.MAUSHOLD ], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.REVAVROOM ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.NAGANADEL, Species.ZERAORA ]},
     [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: []}
   },
   [Biome.FOREST]: {
@@ -390,7 +390,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       ]
     },
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [ Species.BLOODMOON_URSALUNA ], [TimeOfDay.ALL]: [ Species.DURANT ]},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.KARTANA, Species.WO_CHIEN ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.CELEBI, Species.KARTANA, Species.WO_CHIEN ]},
     [BiomePoolTier.BOSS]: {
       [TimeOfDay.DAWN]: [ Species.VICTREEBEL, Species.MOTHIM, Species.VESPIQUEN, Species.LILLIGANT, Species.SAWSBUCK ],
       [TimeOfDay.DAY]: [ Species.VICTREEBEL, Species.BEAUTIFLY, Species.MOTHIM, Species.VESPIQUEN, Species.LILLIGANT, Species.SAWSBUCK ],
@@ -405,7 +405,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.NIGHT]: [ Species.LYCANROC, Species.BLOODMOON_URSALUNA ],
       [TimeOfDay.ALL]: [ Species.HERACROSS, Species.SCEPTILE, Species.ESCAVALIER, Species.ACCELGOR, Species.DURANT, Species.CHESNAUGHT, Species.DECIDUEYE, Species.TOEDSCRUEL ]
     },
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.KARTANA, Species.WO_CHIEN ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.CELEBI, Species.KARTANA, Species.WO_CHIEN ]},
     [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.CALYREX ]}
   },
   [Biome.SEA]: {
@@ -490,7 +490,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.NIGHT]: [],
       [TimeOfDay.ALL]: [ Species.POLITOED, Species.GALAR_STUNFISK ]
     },
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.AZELF, Species.POIPOLE ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.AZELF, Species.PECHARUNT ]},
     [BiomePoolTier.BOSS]: {
       [TimeOfDay.DAWN]: [ Species.QUAGSIRE, Species.LUDICOLO ],
       [TimeOfDay.DAY]: [ Species.QUAGSIRE, Species.LUDICOLO ],
@@ -505,7 +505,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.NIGHT]: [],
       [TimeOfDay.ALL]: [ Species.FERALIGATR, Species.POLITOED, Species.SWAMPERT, Species.GALAR_STUNFISK ]
     },
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.AZELF, Species.NAGANADEL ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.AZELF, Species.PECHARUNT ]},
     [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: []}
   },
   [Biome.BEACH]: {
@@ -732,7 +732,7 @@ export const biomePokemonPools: BiomePokemonPools = {
         { 1: [ Species.AXEW ], 38: [ Species.FRAXURE ]}
       ]
     },
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.TORNADUS, Species.TING_LU, Species.OGERPON ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.JIRACHI, Species.TORNADUS, Species.TING_LU, Species.OGERPON ]},
     [BiomePoolTier.BOSS]: {
       [TimeOfDay.DAWN]: [ Species.SWELLOW, Species.ALTARIA, Species.STARAPTOR, Species.UNFEZANT, Species.BRAVIARY, Species.TALONFLAME, Species.CORVIKNIGHT, Species.ESPATHRA ],
       [TimeOfDay.DAY]: [ Species.SWELLOW, Species.ALTARIA, Species.STARAPTOR, Species.UNFEZANT, Species.BRAVIARY, Species.TALONFLAME, Species.CORVIKNIGHT, Species.ESPATHRA ],
@@ -740,8 +740,8 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.NIGHT]: [ Species.MANDIBUZZ ],
       [TimeOfDay.ALL]: [ Species.PIDGEOT, Species.FEAROW, Species.SKARMORY, Species.AGGRON, Species.GOGOAT, Species.GARGANACL ]
     },
-    [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [ Species.HISUI_BRAVIARY ], [TimeOfDay.DAY]: [ Species.HISUI_BRAVIARY ], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.BLAZIKEN, Species.RAMPARDOS, Species.BASTIODON, Species.HAWLUCHA ]},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ROTOM, Species.TORNADUS, Species.TING_LU, Species.OGERPON ]},
+    [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [ Species.HISUI_BRAVIARY ], [TimeOfDay.DAY]: [ Species.HISUI_BRAVIARY ], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.BLAZIKEN, Species.RAMPARDOS, Species.BASTIODON, Species.ROTOM, Species.HAWLUCHA ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.JIRACHI, Species.TORNADUS, Species.TING_LU, Species.OGERPON ]},
     [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.HO_OH ]}
   },
   [Biome.BADLANDS]: {
@@ -832,7 +832,7 @@ export const biomePokemonPools: BiomePokemonPools = {
     },
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [ Species.LYCANROC ], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.SHUCKLE, Species.FERROTHORN, Species.GLIMMORA ]},
     [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.UXIE ]},
-    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.TERAPAGOS ]}
+    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ZYGARDE ]}
   },
   [Biome.DESERT]: {
     [BiomePoolTier.COMMON]: {
@@ -900,7 +900,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       ]
     },
     [BiomePoolTier.RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.JYNX, Species.LAPRAS, Species.FROSLASS, Species.CRYOGONAL ]},
-    [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.DELIBIRD, Species.ROTOM, { 1: [ Species.AMAURA ], 59: [ Species.AURORUS ]}]},
+    [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.DELIBIRD, Species.GLACEON, Species.ROTOM, { 1: [ Species.AMAURA ], 59: [ Species.AURORUS ]}]},
     [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ARTICUNO, Species.REGICE ]},
     [BiomePoolTier.BOSS]: {
       [TimeOfDay.DAWN]: [],
@@ -909,8 +909,8 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.NIGHT]: [],
       [TimeOfDay.ALL]: [ Species.DEWGONG, Species.GLALIE, Species.WALREIN, Species.WEAVILE, Species.MAMOSWINE, Species.FROSLASS, Species.VANILLUXE, Species.BEARTIC, Species.CRYOGONAL, Species.AVALUGG, Species.CRABOMINABLE, Species.CETITAN ]
     },
-    [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.JYNX, Species.LAPRAS, Species.GLACEON, Species.AURORUS ]},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ARTICUNO, Species.REGICE, Species.ROTOM ]},
+    [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.JYNX, Species.LAPRAS, Species.GLACEON, Species.ROTOM, Species.AURORUS ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ARTICUNO, Species.REGICE ]},
     [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.KYUREM ]}
   },
   [Biome.MEADOW]: {
@@ -960,7 +960,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.ALL]: [ Species.TAUROS, Species.EEVEE, Species.MILTANK, Species.SPINDA, { 1: [ Species.APPLIN ], 30: [ Species.DIPPLIN ]}, { 1: [ Species.SPRIGATITO ], 16: [ Species.FLORAGATO ], 36: [ Species.MEOWSCARADA ]}]
     },
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.CHANSEY, Species.SYLVEON ]},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MELOETTA ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MELOETTA, Species.SHAYMIN, Species.VICTINI ]},
     [BiomePoolTier.BOSS]: {
       [TimeOfDay.DAWN]: [ Species.LEDIAN, Species.GRANBULL, Species.DELCATTY, Species.ROSERADE, Species.CINCCINO, Species.BOUFFALANT, Species.ARBOLIVA ],
       [TimeOfDay.DAY]: [ Species.GRANBULL, Species.DELCATTY, Species.ROSERADE, Species.CINCCINO, Species.BOUFFALANT, Species.ARBOLIVA ],
@@ -969,8 +969,8 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.ALL]: [ Species.TAUROS, Species.MILTANK, Species.GARDEVOIR, Species.PURUGLY, Species.ZEBSTRIKA, Species.FLORGES, Species.RIBOMBEE, Species.DUBWOOL ]
     },
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [ Species.HISUI_LILLIGANT ], [TimeOfDay.DAY]: [ Species.HISUI_LILLIGANT ], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.BLISSEY, Species.SYLVEON, Species.FLAPPLE, Species.APPLETUN, Species.MEOWSCARADA, Species.HYDRAPPLE ]},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MELOETTA ]},
-    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.SHAYMIN ]}
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MELOETTA, Species.SHAYMIN, Species.VICTINI ]},
+    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.XERNEAS ]}
   },
   [Biome.POWER_PLANT]: {
     [BiomePoolTier.COMMON]: {
@@ -993,7 +993,7 @@ export const biomePokemonPools: BiomePokemonPools = {
     [BiomePoolTier.UNCOMMON]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ELECTABUZZ, Species.PLUSLE, Species.MINUN, Species.PACHIRISU, Species.EMOLGA, Species.TOGEDEMARU ]},
     [BiomePoolTier.RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [{ 1: [ Species.MAREEP ], 15: [ Species.FLAAFFY ]}]},
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.JOLTEON, Species.HISUI_VOLTORB ]},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.RAIKOU, Species.THUNDURUS, Species.XURKITREE, Species.ZERAORA, Species.REGIELEKI ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ZAPDOS, Species.RAIKOU, Species.THUNDURUS, Species.XURKITREE, Species.REGIELEKI ]},
     [BiomePoolTier.BOSS]: {
       [TimeOfDay.DAWN]: [],
       [TimeOfDay.DAY]: [],
@@ -1002,7 +1002,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.ALL]: [ Species.RAICHU, Species.MANECTRIC, Species.LUXRAY, Species.MAGNEZONE, Species.ELECTIVIRE, Species.DEDENNE, Species.VIKAVOLT, Species.TOGEDEMARU, Species.PAWMOT, Species.BELLIBOLT ]
     },
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.JOLTEON, Species.AMPHAROS, Species.HISUI_ELECTRODE ]},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ZAPDOS, Species.RAIKOU, Species.THUNDURUS, Species.XURKITREE, Species.ZERAORA, Species.REGIELEKI ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ZAPDOS, Species.RAIKOU, Species.THUNDURUS, Species.XURKITREE, Species.REGIELEKI ]},
     [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ZEKROM ]}
   },
   [Biome.VOLCANO]: {
@@ -1039,7 +1039,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       ]
     },
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.FLAREON, Species.ROTOM, { 1: [ Species.LARVESTA ], 59: [ Species.VOLCARONA ]}, Species.HISUI_GROWLITHE ]},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ENTEI, Species.HEATRAN, Species.VOLCANION, Species.CHI_YU ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MOLTRES, Species.ENTEI, Species.HEATRAN, Species.VOLCANION, Species.CHI_YU ]},
     [BiomePoolTier.BOSS]: {
       [TimeOfDay.DAWN]: [],
       [TimeOfDay.DAY]: [],
@@ -1052,9 +1052,9 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.DAY]: [],
       [TimeOfDay.DUSK]: [],
       [TimeOfDay.NIGHT]: [],
-      [TimeOfDay.ALL]: [ Species.CHARIZARD, Species.FLAREON, Species.TYPHLOSION, Species.INFERNAPE, Species.EMBOAR, Species.VOLCARONA, Species.DELPHOX, Species.INCINEROAR, Species.CINDERACE, Species.ARMAROUGE, Species.HISUI_ARCANINE ]
+      [TimeOfDay.ALL]: [ Species.CHARIZARD, Species.FLAREON, Species.TYPHLOSION, Species.INFERNAPE, Species.ROTOM, Species.EMBOAR, Species.VOLCARONA, Species.DELPHOX, Species.INCINEROAR, Species.CINDERACE, Species.ARMAROUGE, Species.HISUI_ARCANINE ]
     },
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MOLTRES, Species.ENTEI, Species.ROTOM, Species.HEATRAN, Species.VOLCANION, Species.CHI_YU ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MOLTRES, Species.ENTEI, Species.HEATRAN, Species.VOLCANION, Species.CHI_YU ]},
     [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.RESHIRAM ]}
   },
   [Biome.GRAVEYARD]: {
@@ -1127,8 +1127,8 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.ALL]: [ Species.HITMONLEE, Species.HITMONCHAN, Species.HARIYAMA, Species.MEDICHAM, Species.LUCARIO, Species.TOXICROAK, Species.THROH, Species.SAWK, Species.SCRAFTY, Species.MIENSHAO, Species.BEWEAR, Species.GRAPPLOCT, Species.ANNIHILAPE ]
     },
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.HITMONTOP, Species.GALLADE, Species.PANGORO, Species.SIRFETCHD, Species.HISUI_DECIDUEYE ]},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.TERRAKION, Species.URSHIFU ]},
-    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ZAMAZENTA, Species.GALAR_ZAPDOS ]}
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.TERRAKION, Species.URSHIFU, Species.GALAR_ZAPDOS ]},
+    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ZAMAZENTA ]}
   },
   [Biome.FACTORY]: {
     [BiomePoolTier.COMMON]: {
@@ -1145,13 +1145,13 @@ export const biomePokemonPools: BiomePokemonPools = {
       ]
     },
     [BiomePoolTier.UNCOMMON]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [{ 1: [ Species.BRONZOR ], 33: [ Species.BRONZONG ]}, Species.KLEFKI ]},
-    [BiomePoolTier.RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [{ 1: [ Species.PORYGON ], 30: [ Species.PORYGON2 ]}]},
+    [BiomePoolTier.RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [{ 1: [ Species.PORYGON ], 30: [ Species.PORYGON2 ]}, { 1: [ Species.VAROOM ], 40: [ Species.REVAVROOM ]}]},
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [{ 1: [ Species.BELDUM ], 20: [ Species.METANG ], 45: [ Species.METAGROSS ]}]},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.GENESECT, Species.MAGEARNA ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MAGEARNA, Species.MELTAN ]},
     [BiomePoolTier.BOSS]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.KLINKLANG, Species.KLEFKI ]},
-    [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: []},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.GENESECT, Species.MAGEARNA ]},
-    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: []}
+    [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.REVAVROOM ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MAGEARNA, Species.MELMETAL ]},
+    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MIRAIDON ]}
   },
   [Biome.RUINS]: {
     [BiomePoolTier.COMMON]: {
@@ -1187,7 +1187,7 @@ export const biomePokemonPools: BiomePokemonPools = {
     [BiomePoolTier.BOSS]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ALAKAZAM, Species.HYPNO, Species.XATU, Species.GRUMPIG, Species.CLAYDOL, Species.SIGILYPH, Species.GOTHITELLE, Species.BEHEEYEM, Species.TINKATON ]},
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [ Species.ESPEON ], [TimeOfDay.DUSK]: [ Species.RUNERIGUS ], [TimeOfDay.NIGHT]: [ Species.RUNERIGUS ], [TimeOfDay.ALL]: [ Species.MR_MIME, Species.WOBBUFFET, Species.ARCHEOPS ]},
     [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.REGISTEEL, Species.FEZANDIPITI ]},
-    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.KORAIDON ]}
+    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.DIALGA, Species.PALKIA ]}
   },
   [Biome.WASTELAND]: {
     [BiomePoolTier.COMMON]: {
@@ -1234,7 +1234,7 @@ export const biomePokemonPools: BiomePokemonPools = {
     },
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.AERODACTYL, Species.DRUDDIGON, Species.TYRANTRUM, Species.DRACOZOLT, Species.DRACOVISH ]},
     [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.REGIDRAGO ]},
-    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.DIALGA ]}
+    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.KORAIDON ]}
   },
   [Biome.ABYSS]: {
     [BiomePoolTier.COMMON]: {
@@ -1271,8 +1271,8 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.ALL]: [ Species.HOUNDOOM, Species.SABLEYE, Species.ABSOL, Species.HONCHKROW, Species.SPIRITOMB, Species.LIEPARD, Species.ZOROARK, Species.HYDREIGON, Species.THIEVUL, Species.GRIMMSNARL, Species.MABOSSTIFF, Species.KINGAMBIT ]
     },
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.UMBREON, Species.HISUI_SAMUROTT ]},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.DARKRAI ]},
-    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.PALKIA, Species.YVELTAL, Species.GALAR_MOLTRES ]}
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.DARKRAI, Species.GALAR_MOLTRES ]},
+    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.YVELTAL ]}
   },
   [Biome.SPACE]: {
     [BiomePoolTier.COMMON]: {
@@ -1295,7 +1295,7 @@ export const biomePokemonPools: BiomePokemonPools = {
     [BiomePoolTier.BOSS]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [ Species.SOLROCK ], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [ Species.LUNATONE ], [TimeOfDay.ALL]: [ Species.CLEFABLE, Species.BRONZONG, Species.MUSHARNA, Species.REUNICLUS, Species.MINIOR ]},
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.METAGROSS, Species.PORYGON_Z ]},
     [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.CELESTEELA ]},
-    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [ Species.SOLGALEO ], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [ Species.LUNALA ], [TimeOfDay.ALL]: [ Species.RAYQUAZA, Species.NECROZMA ]}
+    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.RAYQUAZA, Species.DEOXYS ]}
   },
   [Biome.CONSTRUCTION_SITE]: {
     [BiomePoolTier.COMMON]: {
@@ -1354,8 +1354,8 @@ export const biomePokemonPools: BiomePokemonPools = {
       ]
     },
     [BiomePoolTier.RARE]: {
-      [TimeOfDay.DAWN]: [{ 1: [ Species.FOONGUS ], 39: [ Species.AMOONGUSS ]}, Species.PASSIMIAN, { 1: [ Species.GALAR_PONYTA ], 40: [ Species.GALAR_RAPIDASH ]}],
-      [TimeOfDay.DAY]: [{ 1: [ Species.FOONGUS ], 39: [ Species.AMOONGUSS ]}, Species.PASSIMIAN ],
+      [TimeOfDay.DAWN]: [ Species.CHATOT, { 1: [ Species.FOONGUS ], 39: [ Species.AMOONGUSS ]}, Species.PASSIMIAN, { 1: [ Species.GALAR_PONYTA ], 40: [ Species.GALAR_RAPIDASH ]}],
+      [TimeOfDay.DAY]: [ Species.CHATOT, { 1: [ Species.FOONGUS ], 39: [ Species.AMOONGUSS ]}, Species.PASSIMIAN ],
       [TimeOfDay.DUSK]: [ Species.ORANGURU ],
       [TimeOfDay.NIGHT]: [ Species.ORANGURU ],
       [TimeOfDay.ALL]: [
@@ -1368,8 +1368,8 @@ export const biomePokemonPools: BiomePokemonPools = {
         { 1: [ Species.GROOKEY ], 16: [ Species.THWACKEY ], 35: [ Species.RILLABOOM ]}
       ]
     },
-    [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.KANGASKHAN, Species.CHATOT, Species.KLEAVOR ]},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.TAPU_LELE, Species.BUZZWOLE, Species.ZARUDE, Species.MUNKIDORI ]},
+    [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.KANGASKHAN, Species.SCIZOR, Species.LEAFEON, Species.KLEAVOR ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MEW, Species.TAPU_LELE, Species.BUZZWOLE, Species.ZARUDE, Species.MUNKIDORI ]},
     [BiomePoolTier.BOSS]: {
       [TimeOfDay.DAWN]: [ Species.EXEGGUTOR, Species.TROPIUS, Species.CHERRIM, Species.LEAVANNY, Species.KOMALA ],
       [TimeOfDay.DAY]: [ Species.EXEGGUTOR, Species.TROPIUS, Species.CHERRIM, Species.LEAVANNY, Species.KOMALA ],
@@ -1382,10 +1382,10 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.DAY]: [ Species.AMOONGUSS ],
       [TimeOfDay.DUSK]: [],
       [TimeOfDay.NIGHT]: [],
-      [TimeOfDay.ALL]: [ Species.KANGASKHAN, Species.SCIZOR, Species.SLAKING, Species.LEAFEON, Species.SERPERIOR, Species.RILLABOOM ]
+      [TimeOfDay.ALL]: [ Species.KANGASKHAN, Species.SCIZOR, Species.SLAKING, Species.LEAFEON, Species.SERPERIOR, Species.RILLABOOM, Species.KLEAVOR ]
     },
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.TAPU_LELE, Species.BUZZWOLE, Species.ZARUDE, Species.MUNKIDORI ]},
-    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.KLEAVOR ]}
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MEW, Species.TAPU_LELE, Species.BUZZWOLE, Species.ZARUDE, Species.MUNKIDORI ]},
+    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: []}
   },
   [Biome.FAIRY_CAVE]: {
     [BiomePoolTier.COMMON]: {
@@ -1430,7 +1430,7 @@ export const biomePokemonPools: BiomePokemonPools = {
     },
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ETERNAL_FLOETTE ]},
     [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.DIANCIE, Species.ENAMORUS ]},
-    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.XERNEAS ]}
+    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.TERAPAGOS ]}
   },
   [Biome.TEMPLE]: {
     [BiomePoolTier.COMMON]: {
@@ -1491,8 +1491,8 @@ export const biomePokemonPools: BiomePokemonPools = {
     [BiomePoolTier.RARE]: {
       [TimeOfDay.DAWN]: [],
       [TimeOfDay.DAY]: [],
-      [TimeOfDay.DUSK]: [ Species.TOXTRICITY, { 1: [ Species.GALAR_LINOONE ], 65: [ Species.OBSTAGOON ]}, Species.GALAR_ZIGZAGOON ],
-      [TimeOfDay.NIGHT]: [ Species.TOXTRICITY, { 1: [ Species.GALAR_LINOONE ], 65: [ Species.OBSTAGOON ]}, Species.GALAR_ZIGZAGOON ],
+      [TimeOfDay.DUSK]: [ Species.TOXTRICITY, { 1: [ Species.GALAR_ZIGZAGOON ], 20: [ Species.GALAR_LINOONE ], 35: [ Species.OBSTAGOON ]} ],
+      [TimeOfDay.NIGHT]: [ Species.TOXTRICITY, { 1: [ Species.GALAR_ZIGZAGOON ], 20: [ Species.GALAR_LINOONE ], 35: [ Species.OBSTAGOON ]} ],
       [TimeOfDay.ALL]: [{ 1: [ Species.VAROOM ], 40: [ Species.REVAVROOM ]}]
     },
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: []},
@@ -1540,8 +1540,8 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.NIGHT]: [ Species.HISUI_ZOROARK ],
       [TimeOfDay.ALL]: [ Species.MR_RIME, Species.ARCTOZOLT, Species.ALOLA_SANDSLASH, Species.ALOLA_NINETALES ]
     },
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.GLASTRIER, Species.CHIEN_PAO ]},
-    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ZACIAN, Species.GALAR_ARTICUNO ]}
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.GLASTRIER, Species.CHIEN_PAO, Species.GALAR_ARTICUNO ]},
+    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ZACIAN ]}
   },
   [Biome.ISLAND]: {
     [BiomePoolTier.COMMON]: {
@@ -1577,7 +1577,7 @@ export const biomePokemonPools: BiomePokemonPools = {
     },
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: []},
     [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.BLACEPHALON ]},
-    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: []}
+    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [ Species.SOLGALEO ], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [ Species.LUNALA ], [TimeOfDay.ALL]: [ Species.NECROZMA ]}
   },
   [Biome.LABORATORY]: {
     [BiomePoolTier.COMMON]: {
@@ -1593,14 +1593,14 @@ export const biomePokemonPools: BiomePokemonPools = {
         { 1: [ Species.KLINK ], 38: [ Species.KLANG ], 49: [ Species.KLINKLANG ]}
       ]
     },
-    [BiomePoolTier.UNCOMMON]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [{ 1: [ Species.SOLOSIS ], 32: [ Species.DUOSION ], 41: [ Species.REUNICLUS ]}]},
+    [BiomePoolTier.UNCOMMON]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [Species.CASTFORM, { 1: [ Species.SOLOSIS ], 32: [ Species.DUOSION ], 41: [ Species.REUNICLUS ]}]},
     [BiomePoolTier.RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.DITTO, { 1: [ Species.PORYGON ], 30: [ Species.PORYGON2 ]}]},
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ROTOM ]},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.TYPE_NULL ]},
-    [BiomePoolTier.BOSS]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MUK, Species.ELECTRODE, Species.BRONZONG, Species.MAGNEZONE, Species.PORYGON_Z, Species.REUNICLUS, Species.KLINKLANG ]},
-    [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: []},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ROTOM, Species.ZYGARDE, Species.SILVALLY ]},
-    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MEWTWO, Species.MIRAIDON ]}
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.GENESECT, Species.TYPE_NULL ]},
+    [BiomePoolTier.BOSS]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MUK, Species.ELECTRODE, Species.CASTFORM, Species.BRONZONG, Species.MAGNEZONE, Species.PORYGON_Z, Species.REUNICLUS, Species.KLINKLANG ]},
+    [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ROTOM ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.GENESECT, Species.SILVALLY ]},
+    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MEWTWO ]}
   },
   [Biome.END]: {
     [BiomePoolTier.COMMON]: {
@@ -2765,10 +2765,12 @@ export function initBiomes() {
     ]
     ],
     [ Species.ZAPDOS, PokemonType.ELECTRIC, PokemonType.FLYING, [
+      [ Biome.POWER_PLANT, BiomePoolTier.ULTRA_RARE ],
       [ Biome.POWER_PLANT, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
     [ Species.MOLTRES, PokemonType.FIRE, PokemonType.FLYING, [
+      [ Biome.VOLCANO, BiomePoolTier.ULTRA_RARE ],
       [ Biome.VOLCANO, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
@@ -2789,7 +2791,10 @@ export function initBiomes() {
       [ Biome.LABORATORY, BiomePoolTier.BOSS_ULTRA_RARE ]
     ]
     ],
-    [ Species.MEW, PokemonType.PSYCHIC, -1, [ ]
+    [ Species.MEW, PokemonType.PSYCHIC, -1, [
+      [ Biome.JUNGLE, BiomePoolTier.ULTRA_RARE ]
+      [ Biome.JUNGLE, BiomePoolTier.BOSS_SUPER_RARE ]
+    ]
     ],
     [ Species.CHIKORITA, PokemonType.GRASS, -1, [
       [ Biome.TALL_GRASS, BiomePoolTier.RARE ]
@@ -3073,6 +3078,7 @@ export function initBiomes() {
     ]
     ],
     [ Species.SCIZOR, PokemonType.BUG, PokemonType.STEEL, [
+      [ Biome.JUNGLE, BiomePoolTier.SUPER_RARE ],
       [ Biome.JUNGLE, BiomePoolTier.BOSS_RARE ]
     ]
     ],
@@ -3259,7 +3265,10 @@ export function initBiomes() {
       [ Biome.MOUNTAIN, BiomePoolTier.BOSS_ULTRA_RARE ]
     ]
     ],
-    [ Species.CELEBI, PokemonType.PSYCHIC, PokemonType.GRASS, [ ]
+    [ Species.CELEBI, PokemonType.PSYCHIC, PokemonType.GRASS, [
+      [ Biome.FOREST, BiomePoolTier.ULTRA_RARE ]
+      [ Biome.FOREST, BiomePoolTier.BOSS_SUPER_RARE ]
+    ]
     ],
     [ Species.TREECKO, PokemonType.GRASS, -1, [
       [ Biome.FOREST, BiomePoolTier.RARE ]
@@ -3743,8 +3752,10 @@ export function initBiomes() {
     ]
     ],
     [ Species.CASTFORM, PokemonType.NORMAL, -1, [
-      [ Biome.METROPOLIS, BiomePoolTier.ULTRA_RARE ],
-      [ Biome.METROPOLIS, BiomePoolTier.BOSS_RARE ]
+      [ Biome.METROPOLIS, BiomePoolTier.RARE ],
+      [ Biome.METROPOLIS, BiomePoolTier.BOSS ]
+      [ Biome.LABORATORY, BiomePoolTier.RARE ],
+      [ Biome.LABORATORY, BiomePoolTier.BOSS ]
     ]
     ],
     [ Species.KECLEON, PokemonType.NORMAL, -1, [
@@ -3900,9 +3911,14 @@ export function initBiomes() {
       [ Biome.SPACE, BiomePoolTier.BOSS_ULTRA_RARE ]
     ]
     ],
-    [ Species.JIRACHI, PokemonType.STEEL, PokemonType.PSYCHIC, [ ]
+    [ Species.JIRACHI, PokemonType.STEEL, PokemonType.PSYCHIC, [
+      [ Biome.MOUNTAIN, BiomePoolTier.ULTRA_RARE ]
+      [ Biome.MOUNTAIN, BiomePoolTier.BOSS_SUPER_RARE ]
+    ]
     ],
-    [ Species.DEOXYS, PokemonType.PSYCHIC, -1, [ ]
+    [ Species.DEOXYS, PokemonType.PSYCHIC, -1, [
+      [ Biome.SPACE, BiomePoolTier.BOSS_ULTRA_RARE ]
+    ]
     ],
     [ Species.TURTWIG, PokemonType.GRASS, -1, [
       [ Biome.GRASS, BiomePoolTier.RARE ]
@@ -4165,7 +4181,7 @@ export function initBiomes() {
     [ Species.HAPPINY, PokemonType.NORMAL, -1, [ ]
     ],
     [ Species.CHATOT, PokemonType.NORMAL, PokemonType.FLYING, [
-      [ Biome.JUNGLE, BiomePoolTier.SUPER_RARE ]
+      [ Biome.JUNGLE, BiomePoolTier.RARE, [ TimeOfDay.DAWN, TimeOfDay.DAY ]],
     ]
     ],
     [ Species.SPIRITOMB, PokemonType.GHOST, PokemonType.DARK, [
@@ -4299,10 +4315,12 @@ export function initBiomes() {
     ]
     ],
     [ Species.LEAFEON, PokemonType.GRASS, -1, [
+      [ Biome.JUNGLE, BiomePoolTier.SUPER_RARE ]
       [ Biome.JUNGLE, BiomePoolTier.BOSS_RARE ]
     ]
     ],
     [ Species.GLACEON, PokemonType.ICE, -1, [
+      [ Biome.ICE_CAVE, BiomePoolTier.SUPER_RARE ]
       [ Biome.ICE_CAVE, BiomePoolTier.BOSS_RARE ]
     ]
     ],
@@ -4339,15 +4357,15 @@ export function initBiomes() {
     ],
     [ Species.ROTOM, PokemonType.ELECTRIC, PokemonType.GHOST, [
       [ Biome.LABORATORY, BiomePoolTier.SUPER_RARE ],
-      [ Biome.LABORATORY, BiomePoolTier.BOSS_SUPER_RARE ],
+      [ Biome.LABORATORY, BiomePoolTier.BOSS_RARE ],
       [ Biome.VOLCANO, BiomePoolTier.SUPER_RARE ],
-      [ Biome.VOLCANO, BiomePoolTier.BOSS_SUPER_RARE ],
+      [ Biome.VOLCANO, BiomePoolTier.BOSS_RARE ],
       [ Biome.SEA, BiomePoolTier.SUPER_RARE ],
       [ Biome.SEA, BiomePoolTier.BOSS_SUPER_RARE ],
       [ Biome.ICE_CAVE, BiomePoolTier.SUPER_RARE ],
-      [ Biome.ICE_CAVE, BiomePoolTier.BOSS_SUPER_RARE ],
+      [ Biome.ICE_CAVE, BiomePoolTier.BOSS_RARE ],
       [ Biome.MOUNTAIN, BiomePoolTier.SUPER_RARE ],
-      [ Biome.MOUNTAIN, BiomePoolTier.BOSS_SUPER_RARE ],
+      [ Biome.MOUNTAIN, BiomePoolTier.BOSS_RARE ],
       [ Biome.TALL_GRASS, BiomePoolTier.SUPER_RARE ],
       [ Biome.TALL_GRASS, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
@@ -4368,11 +4386,11 @@ export function initBiomes() {
     ]
     ],
     [ Species.DIALGA, PokemonType.STEEL, PokemonType.DRAGON, [
-      [ Biome.WASTELAND, BiomePoolTier.BOSS_ULTRA_RARE ]
+      [ Biome.RUINS, BiomePoolTier.BOSS_ULTRA_RARE ]
     ]
     ],
     [ Species.PALKIA, PokemonType.WATER, PokemonType.DRAGON, [
-      [ Biome.ABYSS, BiomePoolTier.BOSS_ULTRA_RARE ]
+      [ Biome.RUINS, BiomePoolTier.BOSS_ULTRA_RARE ]
     ]
     ],
     [ Species.HEATRAN, PokemonType.FIRE, PokemonType.STEEL, [
@@ -4403,12 +4421,16 @@ export function initBiomes() {
     ]
     ],
     [ Species.SHAYMIN, PokemonType.GRASS, -1, [
-      [ Biome.MEADOW, BiomePoolTier.BOSS_ULTRA_RARE ]
+      [ Biome.MEADOW, BiomePoolTier.ULTRA_RARE ]
+      [ Biome.MEADOW, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
     [ Species.ARCEUS, PokemonType.NORMAL, -1, [ ]
     ],
-    [ Species.VICTINI, PokemonType.PSYCHIC, PokemonType.FIRE, [ ]
+    [ Species.VICTINI, PokemonType.PSYCHIC, PokemonType.FIRE, [
+      [ Biome.MEADOW, BiomePoolTier.ULTRA_RARE ]
+      [ Biome.MEADOW, BiomePoolTier.BOSS_SUPER_RARE ]
+    ]
     ],
     [ Species.SNIVY, PokemonType.GRASS, -1, [
       [ Biome.JUNGLE, BiomePoolTier.RARE ]
@@ -5165,8 +5187,8 @@ export function initBiomes() {
     ]
     ],
     [ Species.GENESECT, PokemonType.BUG, PokemonType.STEEL, [
-      [ Biome.FACTORY, BiomePoolTier.ULTRA_RARE ],
-      [ Biome.FACTORY, BiomePoolTier.BOSS_SUPER_RARE ]
+      [ Biome.LABORATORY, BiomePoolTier.ULTRA_RARE ],
+      [ Biome.LABORATORY, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
     [ Species.CHESPIN, PokemonType.GRASS, -1, [
@@ -5468,7 +5490,7 @@ export function initBiomes() {
     ]
     ],
     [ Species.XERNEAS, PokemonType.FAIRY, -1, [
-      [ Biome.FAIRY_CAVE, BiomePoolTier.BOSS_ULTRA_RARE ]
+      [ Biome.MEADOW, BiomePoolTier.BOSS_ULTRA_RARE ]
     ]
     ],
     [ Species.YVELTAL, PokemonType.DARK, PokemonType.FLYING, [
@@ -5476,7 +5498,7 @@ export function initBiomes() {
     ]
     ],
     [ Species.ZYGARDE, PokemonType.DRAGON, PokemonType.GROUND, [
-      [ Biome.LABORATORY, BiomePoolTier.BOSS_SUPER_RARE ]
+      [ Biome.CAVE, BiomePoolTier.BOSS_ULTRA_RARE ]
     ]
     ],
     [ Species.DIANCIE, PokemonType.ROCK, PokemonType.FAIRY, [
@@ -5822,11 +5844,11 @@ export function initBiomes() {
     ]
     ],
     [ Species.SOLGALEO, PokemonType.PSYCHIC, PokemonType.STEEL, [
-      [ Biome.SPACE, BiomePoolTier.BOSS_ULTRA_RARE, TimeOfDay.DAY ]
+      [ Biome.ISLAND, BiomePoolTier.BOSS_ULTRA_RARE, TimeOfDay.DAY ]
     ]
     ],
     [ Species.LUNALA, PokemonType.PSYCHIC, PokemonType.GHOST, [
-      [ Biome.SPACE, BiomePoolTier.BOSS_ULTRA_RARE, TimeOfDay.NIGHT ]
+      [ Biome.ISLAND, BiomePoolTier.BOSS_ULTRA_RARE, TimeOfDay.NIGHT ]
     ]
     ],
     [ Species.NIHILEGO, PokemonType.ROCK, PokemonType.POISON, [
@@ -5865,7 +5887,7 @@ export function initBiomes() {
     ]
     ],
     [ Species.NECROZMA, PokemonType.PSYCHIC, -1, [
-      [ Biome.SPACE, BiomePoolTier.BOSS_ULTRA_RARE ]
+      [ Biome.ISLAND, BiomePoolTier.BOSS_ULTRA_RARE ]
     ]
     ],
     [ Species.MAGEARNA, PokemonType.STEEL, PokemonType.FAIRY, [
@@ -5879,11 +5901,11 @@ export function initBiomes() {
     ]
     ],
     [ Species.POIPOLE, PokemonType.POISON, -1, [
-      [ Biome.SWAMP, BiomePoolTier.ULTRA_RARE ]
+      [ Biome.METROPOLIS, BiomePoolTier.ULTRA_RARE ]
     ]
     ],
     [ Species.NAGANADEL, PokemonType.POISON, PokemonType.DRAGON, [
-      [ Biome.SWAMP, BiomePoolTier.BOSS_SUPER_RARE ]
+      [ Biome.METROPOLIS, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
     [ Species.STAKATAKA, PokemonType.ROCK, PokemonType.STEEL, [
@@ -5897,13 +5919,17 @@ export function initBiomes() {
     ]
     ],
     [ Species.ZERAORA, PokemonType.ELECTRIC, -1, [
-      [ Biome.POWER_PLANT, BiomePoolTier.ULTRA_RARE ],
-      [ Biome.POWER_PLANT, BiomePoolTier.BOSS_SUPER_RARE ]
+      [ Biome.METROPOLIS, BiomePoolTier.ULTRA_RARE ],
+      [ Biome.METROPOLIS, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
-    [ Species.MELTAN, PokemonType.STEEL, -1, [ ]
+    [ Species.MELTAN, PokemonType.STEEL, -1, [
+      [ Biome.FACTORY, BiomePoolTier.ULTRA_RARE ],
+    ]
     ],
-    [ Species.MELMETAL, PokemonType.STEEL, -1, [ ]
+    [ Species.MELMETAL, PokemonType.STEEL, -1, [
+      [ Biome.FACTORY, BiomePoolTier.BOSS_SUPER_RARE ]
+    ]
     ],
     [ Species.GROOKEY, PokemonType.GRASS, -1, [
       [ Biome.JUNGLE, BiomePoolTier.RARE ]
@@ -6313,7 +6339,7 @@ export function initBiomes() {
     ],
     [ Species.KLEAVOR, PokemonType.BUG, PokemonType.ROCK, [
       [ Biome.JUNGLE, BiomePoolTier.SUPER_RARE ],
-      [ Biome.JUNGLE, BiomePoolTier.BOSS_ULTRA_RARE ]
+      [ Biome.JUNGLE, BiomePoolTier.BOSS_RARE ]
     ]
     ],
     [ Species.URSALUNA, PokemonType.GROUND, PokemonType.NORMAL, [
@@ -6616,6 +6642,7 @@ export function initBiomes() {
     [ Species.VAROOM, PokemonType.STEEL, PokemonType.POISON, [
       [ Biome.METROPOLIS, BiomePoolTier.RARE ],
       [ Biome.SLUM, BiomePoolTier.RARE ]
+      [ Biome.FACTORY, BiomePoolTier.RARE ]
     ]
     ],
     [ Species.REVAVROOM, PokemonType.STEEL, PokemonType.POISON, [
@@ -6623,6 +6650,8 @@ export function initBiomes() {
       [ Biome.METROPOLIS, BiomePoolTier.BOSS_RARE ],
       [ Biome.SLUM, BiomePoolTier.RARE ],
       [ Biome.SLUM, BiomePoolTier.BOSS_RARE ]
+      [ Biome.FACTORY, BiomePoolTier.RARE ],
+      [ Biome.FACTORY, BiomePoolTier.BOSS_RARE ]
     ]
     ],
     [ Species.CYCLIZAR, PokemonType.DRAGON, PokemonType.NORMAL, [
@@ -6802,11 +6831,11 @@ export function initBiomes() {
     ]
     ],
     [ Species.KORAIDON, PokemonType.FIGHTING, PokemonType.DRAGON, [
-      [ Biome.RUINS, BiomePoolTier.BOSS_ULTRA_RARE ]
+      [ Biome.WASTELAND, BiomePoolTier.BOSS_ULTRA_RARE ]
     ]
     ],
     [ Species.MIRAIDON, PokemonType.ELECTRIC, PokemonType.DRAGON, [
-      [ Biome.LABORATORY, BiomePoolTier.BOSS_ULTRA_RARE ]
+      [ Biome.FACTORY, BiomePoolTier.BOSS_ULTRA_RARE ]
     ]
     ],
     [ Species.WALKING_WAKE, PokemonType.WATER, PokemonType.DRAGON, [
@@ -6875,10 +6904,13 @@ export function initBiomes() {
     ]
     ],
     [ Species.TERAPAGOS, PokemonType.NORMAL, -1, [
-      [ Biome.CAVE, BiomePoolTier.BOSS_ULTRA_RARE ]
+      [ Biome.FAIRY_CAVE, BiomePoolTier.BOSS_ULTRA_RARE ]
     ]
     ],
-    [ Species.PECHARUNT, PokemonType.POISON, PokemonType.GHOST, [ ]
+    [ Species.PECHARUNT, PokemonType.POISON, PokemonType.GHOST, [
+      [ Biome.SWAMP, BiomePoolTier.ULTRA_RARE ]
+      [ Biome.SWAMP, BiomePoolTier.BOSS_SUPER_RARE ]
+    ]
     ],
     [ Species.ALOLA_RATTATA, PokemonType.DARK, PokemonType.NORMAL, [
       [ Biome.ISLAND, BiomePoolTier.COMMON, [ TimeOfDay.DUSK, TimeOfDay.NIGHT ]]
@@ -7009,17 +7041,17 @@ export function initBiomes() {
     ],
     [ Species.GALAR_ARTICUNO, PokemonType.PSYCHIC, PokemonType.FLYING, [
       [ Biome.SNOWY_FOREST, BiomePoolTier.ULTRA_RARE ],
-      [ Biome.SNOWY_FOREST, BiomePoolTier.BOSS_ULTRA_RARE ]
+      [ Biome.SNOWY_FOREST, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
     [ Species.GALAR_ZAPDOS, PokemonType.FIGHTING, PokemonType.FLYING, [
       [ Biome.DOJO, BiomePoolTier.ULTRA_RARE ],
-      [ Biome.DOJO, BiomePoolTier.BOSS_ULTRA_RARE ]
+      [ Biome.DOJO, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
     [ Species.GALAR_MOLTRES, PokemonType.DARK, PokemonType.FLYING, [
       [ Biome.ABYSS, BiomePoolTier.ULTRA_RARE ],
-      [ Biome.ABYSS, BiomePoolTier.BOSS_ULTRA_RARE ]
+      [ Biome.ABYSS, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
     [ Species.GALAR_SLOWKING, PokemonType.POISON, PokemonType.PSYCHIC, [

--- a/src/data/balance/biomes.ts
+++ b/src/data/balance/biomes.ts
@@ -532,7 +532,7 @@ export const biomePokemonPools: BiomePokemonPools = {
     },
     [BiomePoolTier.RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [{ 1: [ Species.QUAXLY ], 16: [ Species.QUAXWELL ], 36: [ Species.QUAQUAVAL ]}, Species.TATSUGIRI ]},
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [{ 1: [ Species.TIRTOUGA ], 37: [ Species.CARRACOSTA ]}]},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.PHIONE, Species.KELDEO, Species.TAPU_FINI ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.PHIONE, Species.VICTINI, Species.TAPU_FINI ]},
     [BiomePoolTier.BOSS]: {
       [TimeOfDay.DAWN]: [ Species.STARMIE ],
       [TimeOfDay.DAY]: [ Species.STARMIE ],
@@ -541,7 +541,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.ALL]: [ Species.KINGLER, Species.CRAWDAUNT, Species.WORMADAM, Species.CRUSTLE, Species.BARBARACLE, Species.CLAWITZER, Species.TOXAPEX, Species.PALOSSAND ]
     },
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.CARRACOSTA, Species.QUAQUAVAL ]},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.PHIONE, Species.KELDEO, Species.TAPU_FINI ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.PHIONE, Species.VICTINI, Species.TAPU_FINI ]},
     [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MANAPHY ]}
   },
   [Biome.LAKE]: {
@@ -577,7 +577,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       ]
     },
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.VAPOREON, Species.SLOWKING ]},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.SUICUNE, Species.MESPRIT ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.SUICUNE, Species.MESPRIT, Species.KELDEO ]},
     [BiomePoolTier.BOSS]: {
       [TimeOfDay.DAWN]: [ Species.SWANNA, Species.ARAQUANID ],
       [TimeOfDay.DAY]: [ Species.SWANNA, Species.ARAQUANID ],
@@ -586,7 +586,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.ALL]: [ Species.GOLDUCK, Species.SLOWBRO, Species.SEAKING, Species.GYARADOS, Species.MASQUERAIN, Species.WISHIWASHI, Species.DREDNAW ]
     },
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.BLASTOISE, Species.VAPOREON, Species.SLOWKING, Species.SAMUROTT, Species.GRENINJA, Species.INTELEON ]},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.SUICUNE, Species.MESPRIT ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.SUICUNE, Species.MESPRIT, Species.KELDEO ]},
     [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: []}
   },
   [Biome.SEABED]: {
@@ -822,7 +822,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.ALL]: [ Species.ONIX, { 1: [ Species.FERROSEED ], 40: [ Species.FERROTHORN ]}, Species.CARBINK, { 1: [ Species.GLIMMET ], 35: [ Species.GLIMMORA ]}]
     },
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.SHUCKLE ]},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.UXIE ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.UXIE, Species.TERRAKION ]},
     [BiomePoolTier.BOSS]: {
       [TimeOfDay.DAWN]: [],
       [TimeOfDay.DAY]: [],
@@ -831,7 +831,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.ALL]: [ Species.PARASECT, Species.ONIX, Species.CROBAT, Species.URSARING, Species.EXPLOUD, Species.PROBOPASS, Species.GIGALITH, Species.SWOOBAT, Species.DIGGERSBY, Species.NOIVERN, Species.GOLISOPOD, Species.GARGANACL ]
     },
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [ Species.LYCANROC ], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.SHUCKLE, Species.FERROTHORN, Species.GLIMMORA ]},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.UXIE ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.UXIE, Species.TERRAKION ]},
     [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ZYGARDE ]}
   },
   [Biome.DESERT]: {
@@ -960,7 +960,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.ALL]: [ Species.TAUROS, Species.EEVEE, Species.MILTANK, Species.SPINDA, { 1: [ Species.APPLIN ], 30: [ Species.DIPPLIN ]}, { 1: [ Species.SPRIGATITO ], 16: [ Species.FLORAGATO ], 36: [ Species.MEOWSCARADA ]}]
     },
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.CHANSEY, Species.SYLVEON ]},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MELOETTA, Species.SHAYMIN, Species.VICTINI ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MELOETTA, Species.SHAYMIN ]},
     [BiomePoolTier.BOSS]: {
       [TimeOfDay.DAWN]: [ Species.LEDIAN, Species.GRANBULL, Species.DELCATTY, Species.ROSERADE, Species.CINCCINO, Species.BOUFFALANT, Species.ARBOLIVA ],
       [TimeOfDay.DAY]: [ Species.GRANBULL, Species.DELCATTY, Species.ROSERADE, Species.CINCCINO, Species.BOUFFALANT, Species.ARBOLIVA ],
@@ -969,7 +969,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.ALL]: [ Species.TAUROS, Species.MILTANK, Species.GARDEVOIR, Species.PURUGLY, Species.ZEBSTRIKA, Species.FLORGES, Species.RIBOMBEE, Species.DUBWOOL ]
     },
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [ Species.HISUI_LILLIGANT ], [TimeOfDay.DAY]: [ Species.HISUI_LILLIGANT ], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.BLISSEY, Species.SYLVEON, Species.FLAPPLE, Species.APPLETUN, Species.MEOWSCARADA, Species.HYDRAPPLE ]},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MELOETTA, Species.SHAYMIN, Species.VICTINI ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MELOETTA, Species.SHAYMIN ]},
     [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.XERNEAS ]}
   },
   [Biome.POWER_PLANT]: {
@@ -1118,7 +1118,7 @@ export const biomePokemonPools: BiomePokemonPools = {
     },
     [BiomePoolTier.RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.HITMONLEE, Species.HITMONCHAN, Species.LUCARIO, Species.THROH, Species.SAWK, { 1: [ Species.PANCHAM ], 52: [ Species.PANGORO ]}]},
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.HITMONTOP, Species.GALLADE, Species.GALAR_FARFETCHD ]},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.TERRAKION, Species.KUBFU, Species.GALAR_ZAPDOS ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.KUBFU, Species.GALAR_ZAPDOS ]},
     [BiomePoolTier.BOSS]: {
       [TimeOfDay.DAWN]: [],
       [TimeOfDay.DAY]: [],
@@ -1127,7 +1127,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.ALL]: [ Species.HITMONLEE, Species.HITMONCHAN, Species.HARIYAMA, Species.MEDICHAM, Species.LUCARIO, Species.TOXICROAK, Species.THROH, Species.SAWK, Species.SCRAFTY, Species.MIENSHAO, Species.BEWEAR, Species.GRAPPLOCT, Species.ANNIHILAPE ]
     },
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.HITMONTOP, Species.GALLADE, Species.PANGORO, Species.SIRFETCHD, Species.HISUI_DECIDUEYE ]},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.TERRAKION, Species.URSHIFU, Species.GALAR_ZAPDOS ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.URSHIFU, Species.GALAR_ZAPDOS ]},
     [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ZAMAZENTA ]}
   },
   [Biome.FACTORY]: {
@@ -1147,10 +1147,10 @@ export const biomePokemonPools: BiomePokemonPools = {
     [BiomePoolTier.UNCOMMON]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [{ 1: [ Species.BRONZOR ], 33: [ Species.BRONZONG ]}, Species.KLEFKI ]},
     [BiomePoolTier.RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [{ 1: [ Species.PORYGON ], 30: [ Species.PORYGON2 ]}, { 1: [ Species.VAROOM ], 40: [ Species.REVAVROOM ]}]},
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [{ 1: [ Species.BELDUM ], 20: [ Species.METANG ], 45: [ Species.METAGROSS ]}]},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MAGEARNA, Species.MELTAN ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MAGEARNA ]},
     [BiomePoolTier.BOSS]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.KLINKLANG, Species.KLEFKI ]},
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.REVAVROOM ]},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MAGEARNA, Species.MELMETAL ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MAGEARNA ]},
     [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MIRAIDON ]}
   },
   [Biome.RUINS]: {
@@ -1324,10 +1324,10 @@ export const biomePokemonPools: BiomePokemonPools = {
     },
     [BiomePoolTier.RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [{ 1: [ Species.GALAR_MEOWTH ], 28: [ Species.PERRSERKER ]}], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ONIX, Species.HITMONLEE, Species.HITMONCHAN, Species.DURALUDON ]},
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.DITTO, Species.HITMONTOP ]},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.COBALION, Species.STAKATAKA ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.COBALION, Species.MELTAN ]},
     [BiomePoolTier.BOSS]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MACHAMP, Species.CONKELDURR ]},
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [ Species.PERRSERKER ], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ARCHALUDON ]},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.COBALION, Species.STAKATAKA ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.COBALION, Species.MELMETAL ]},
     [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: []}
   },
   [Biome.JUNGLE]: {
@@ -1577,7 +1577,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       ]
     },
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: []},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ { 1: [ Species.COSMOG ], 43: [ Species.COSMOEM ]}, Species.BLACEPHALON ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ { 1: [ Species.COSMOG ], 43: [ Species.COSMOEM ]}, Species.STAKATAKA, Species.BLACEPHALON ]},
     [BiomePoolTier.BOSS]: {
       [TimeOfDay.DAWN]: [ Species.ALOLA_RAICHU, Species.ALOLA_EXEGGUTOR ],
       [TimeOfDay.DAY]: [ Species.ALOLA_RAICHU, Species.ALOLA_EXEGGUTOR ],
@@ -1586,7 +1586,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.ALL]: [ Species.ORICORIO, Species.BRUXISH, Species.ALOLA_SANDSLASH, Species.ALOLA_NINETALES, Species.ALOLA_DUGTRIO, Species.ALOLA_GOLEM, Species.ALOLA_MUK ]
     },
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.DECIDUEYE, Species.INCINEROAR, Species.PRIMARINA ]},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.BLACEPHALON ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.STAKATAKA, Species.BLACEPHALON ]},
     [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [ Species.SOLGALEO ], [TimeOfDay.DAY]: [ Species.SOLGALEO ], [TimeOfDay.DUSK]: [ Species.LUNALA ], [TimeOfDay.NIGHT]: [ Species.LUNALA ], [TimeOfDay.ALL]: []}
   },
   [Biome.LABORATORY]: {
@@ -4443,8 +4443,8 @@ export function initBiomes() {
     [ Species.ARCEUS, PokemonType.NORMAL, -1, [ ]
     ],
     [ Species.VICTINI, PokemonType.PSYCHIC, PokemonType.FIRE, [
-      [ Biome.MEADOW, BiomePoolTier.ULTRA_RARE ]
-      [ Biome.MEADOW, BiomePoolTier.BOSS_SUPER_RARE ]
+      [ Biome.BEACH, BiomePoolTier.ULTRA_RARE ]
+      [ Biome.BEACH, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
     [ Species.SNIVY, PokemonType.GRASS, -1, [
@@ -5155,8 +5155,8 @@ export function initBiomes() {
     ]
     ],
     [ Species.TERRAKION, PokemonType.ROCK, PokemonType.FIGHTING, [
-      [ Biome.DOJO, BiomePoolTier.ULTRA_RARE ],
-      [ Biome.DOJO, BiomePoolTier.BOSS_SUPER_RARE ]
+      [ Biome.CAVE, BiomePoolTier.ULTRA_RARE ],
+      [ Biome.CAVE, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
     [ Species.VIRIZION, PokemonType.GRASS, PokemonType.FIGHTING, [
@@ -5192,8 +5192,8 @@ export function initBiomes() {
     ]
     ],
     [ Species.KELDEO, PokemonType.WATER, PokemonType.FIGHTING, [
-      [ Biome.BEACH, BiomePoolTier.ULTRA_RARE ],
-      [ Biome.BEACH, BiomePoolTier.BOSS_SUPER_RARE ]
+      [ Biome.LAKE, BiomePoolTier.ULTRA_RARE ],
+      [ Biome.LAKE, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
     [ Species.MELOETTA, PokemonType.NORMAL, PokemonType.PSYCHIC, [
@@ -5936,8 +5936,8 @@ export function initBiomes() {
     ]
     ],
     [ Species.STAKATAKA, PokemonType.ROCK, PokemonType.STEEL, [
-      [ Biome.CONSTRUCTION_SITE, BiomePoolTier.ULTRA_RARE ],
-      [ Biome.CONSTRUCTION_SITE, BiomePoolTier.BOSS_SUPER_RARE ]
+      [ Biome.ISLAND, BiomePoolTier.ULTRA_RARE ],
+      [ Biome.ISLAND, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
     [ Species.BLACEPHALON, PokemonType.FIRE, PokemonType.GHOST, [
@@ -5951,11 +5951,11 @@ export function initBiomes() {
     ]
     ],
     [ Species.MELTAN, PokemonType.STEEL, -1, [
-      [ Biome.FACTORY, BiomePoolTier.ULTRA_RARE ],
+      [ Biome.CONSTRUCTION_SITE, BiomePoolTier.ULTRA_RARE ],
     ]
     ],
     [ Species.MELMETAL, PokemonType.STEEL, -1, [
-      [ Biome.FACTORY, BiomePoolTier.BOSS_SUPER_RARE ]
+      [ Biome.CONSTRUCTION_SITE, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
     [ Species.GROOKEY, PokemonType.GRASS, -1, [

--- a/src/data/balance/biomes.ts
+++ b/src/data/balance/biomes.ts
@@ -320,7 +320,7 @@ export const biomePokemonPools: BiomePokemonPools = {
     [BiomePoolTier.BOSS]: { [TimeOfDay.DAWN]: [ Species.BOLTUND ], [TimeOfDay.DAY]: [ Species.BOLTUND ], [TimeOfDay.DUSK]: [ Species.MEOWSTIC ], [TimeOfDay.NIGHT]: [ Species.MEOWSTIC ], [TimeOfDay.ALL]: [ Species.CASTFORM, Species.STOUTLAND, Species.FURFROU, Species.DACHSBUN ]},
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [ Species.MAUSHOLD ], [TimeOfDay.DAY]: [ Species.MAUSHOLD ], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.REVAVROOM ]},
     [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.NAGANADEL, Species.ZERAORA ]},
-    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: []}
+    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.NECROZMA ]}
   },
   [Biome.FOREST]: {
     [BiomePoolTier.COMMON]: {
@@ -532,7 +532,7 @@ export const biomePokemonPools: BiomePokemonPools = {
     },
     [BiomePoolTier.RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [{ 1: [ Species.QUAXLY ], 16: [ Species.QUAXWELL ], 36: [ Species.QUAQUAVAL ]}, Species.TATSUGIRI ]},
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [{ 1: [ Species.TIRTOUGA ], 37: [ Species.CARRACOSTA ]}]},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.CRESSELIA, Species.KELDEO, Species.TAPU_FINI ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.PHIONE, Species.KELDEO, Species.TAPU_FINI ]},
     [BiomePoolTier.BOSS]: {
       [TimeOfDay.DAWN]: [ Species.STARMIE ],
       [TimeOfDay.DAY]: [ Species.STARMIE ],
@@ -541,8 +541,8 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.ALL]: [ Species.KINGLER, Species.CRAWDAUNT, Species.WORMADAM, Species.CRUSTLE, Species.BARBARACLE, Species.CLAWITZER, Species.TOXAPEX, Species.PALOSSAND ]
     },
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.CARRACOSTA, Species.QUAQUAVAL ]},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.CRESSELIA, Species.KELDEO, Species.TAPU_FINI ]},
-    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: []}
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.PHIONE, Species.KELDEO, Species.TAPU_FINI ]},
+    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MANAPHY ]}
   },
   [Biome.LAKE]: {
     [BiomePoolTier.COMMON]: {
@@ -1224,7 +1224,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.ALL]: [{ 1: [ Species.DRATINI ], 30: [ Species.DRAGONAIR ], 55: [ Species.DRAGONITE ]}, { 1: [ Species.FRIGIBAX ], 35: [ Species.ARCTIBAX ], 54: [ Species.BAXCALIBUR ]}]
     },
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.AERODACTYL, Species.DRUDDIGON, { 1: [ Species.TYRUNT ], 59: [ Species.TYRANTRUM ]}, Species.DRACOZOLT, Species.DRACOVISH ]},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.REGIDRAGO ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.CELESTEELA, Species.REGIDRAGO ]},
     [BiomePoolTier.BOSS]: {
       [TimeOfDay.DAWN]: [ Species.SALAMENCE, Species.GOODRA, Species.KOMMO_O ],
       [TimeOfDay.DAY]: [ Species.SALAMENCE, Species.GOODRA, Species.KOMMO_O ],
@@ -1233,7 +1233,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.ALL]: [ Species.DRAGONITE, Species.FLYGON, Species.GARCHOMP, Species.HAXORUS, Species.DRAMPA, Species.BAXCALIBUR ]
     },
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.AERODACTYL, Species.DRUDDIGON, Species.TYRANTRUM, Species.DRACOZOLT, Species.DRACOVISH ]},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.REGIDRAGO ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.CELESTEELA, Species.REGIDRAGO ]},
     [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.KORAIDON ]}
   },
   [Biome.ABYSS]: {
@@ -1291,10 +1291,10 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.ALL]: [{ 1: [ Species.BELDUM ], 20: [ Species.METANG ], 45: [ Species.METAGROSS ]}, Species.SIGILYPH, { 1: [ Species.SOLOSIS ], 32: [ Species.DUOSION ], 41: [ Species.REUNICLUS ]}]
     },
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [{ 1: [ Species.PORYGON ], 30: [ Species.PORYGON2 ]}]},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [{ 1: [ Species.COSMOG ], 43: [ Species.COSMOEM ]}, Species.CELESTEELA ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.CRESSELIA ]},
     [BiomePoolTier.BOSS]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [ Species.SOLROCK ], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [ Species.LUNATONE ], [TimeOfDay.ALL]: [ Species.CLEFABLE, Species.BRONZONG, Species.MUSHARNA, Species.REUNICLUS, Species.MINIOR ]},
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.METAGROSS, Species.PORYGON_Z ]},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.CELESTEELA ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.CRESSELIA ]},
     [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.RAYQUAZA, Species.DEOXYS ]}
   },
   [Biome.CONSTRUCTION_SITE]: {
@@ -1565,9 +1565,19 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.NIGHT]: [ Species.ALOLA_MAROWAK ],
       [TimeOfDay.ALL]: [ Species.BRUXISH ]
     },
-    [BiomePoolTier.RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: []},
+    [BiomePoolTier.RARE]: {
+      [TimeOfDay.DAWN]: [],
+      [TimeOfDay.DAY]: [],
+      [TimeOfDay.DUSK]: [],
+      [TimeOfDay.NIGHT]: [],
+      [TimeOfDay.ALL]: [
+        { 1: [ Species.ROWLET ], 17: [ Species.DARTRIX ], 34: [ Species.DECIDUEYE ]},
+        { 1: [ Species.LITTEN ], 17: [ Species.TORRACAT ], 34: [ Species.INCINEROAR ]},
+        { 1: [ Species.POPPLIO ], 17: [ Species.BRIONNE ], 34: [ Species.PRIMARINA ]}
+      ]
+    },
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: []},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.BLACEPHALON ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ { 1: [ Species.COSMOG ], 43: [ Species.COSMOEM ]}, Species.BLACEPHALON ]},
     [BiomePoolTier.BOSS]: {
       [TimeOfDay.DAWN]: [ Species.ALOLA_RAICHU, Species.ALOLA_EXEGGUTOR ],
       [TimeOfDay.DAY]: [ Species.ALOLA_RAICHU, Species.ALOLA_EXEGGUTOR ],
@@ -1575,9 +1585,9 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.NIGHT]: [ Species.ALOLA_RATICATE, Species.ALOLA_PERSIAN, Species.ALOLA_MAROWAK ],
       [TimeOfDay.ALL]: [ Species.ORICORIO, Species.BRUXISH, Species.ALOLA_SANDSLASH, Species.ALOLA_NINETALES, Species.ALOLA_DUGTRIO, Species.ALOLA_GOLEM, Species.ALOLA_MUK ]
     },
-    [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: []},
+    [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.DECIDUEYE, Species.INCINEROAR, Species.PRIMARINA ]},
     [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.BLACEPHALON ]},
-    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [ Species.SOLGALEO ], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [ Species.LUNALA ], [TimeOfDay.ALL]: [ Species.NECROZMA ]}
+    [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [ Species.SOLGALEO ], [TimeOfDay.DAY]: [ Species.SOLGALEO ], [TimeOfDay.DUSK]: [ Species.LUNALA ], [TimeOfDay.NIGHT]: [ Species.LUNALA ], [TimeOfDay.ALL]: []}
   },
   [Biome.LABORATORY]: {
     [BiomePoolTier.COMMON]: {
@@ -4407,13 +4417,18 @@ export function initBiomes() {
     ]
     ],
     [ Species.CRESSELIA, PokemonType.PSYCHIC, -1, [
+      [ Biome.SPACE, BiomePoolTier.ULTRA_RARE ],
+      [ Biome.SPACE, BiomePoolTier.BOSS_SUPER_RARE ]
+    ]
+    ],
+    [ Species.PHIONE, PokemonType.WATER, -1, [
       [ Biome.BEACH, BiomePoolTier.ULTRA_RARE ],
       [ Biome.BEACH, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
-    [ Species.PHIONE, PokemonType.WATER, -1, [ ]
-    ],
-    [ Species.MANAPHY, PokemonType.WATER, -1, [ ]
+    [ Species.MANAPHY, PokemonType.WATER, -1, [
+      [ Biome.BEACH, BiomePoolTier.BOSS_ULTRA_RARE ]
+    ]
     ],
     [ Species.DARKRAI, PokemonType.DARK, -1, [
       [ Biome.ABYSS, BiomePoolTier.ULTRA_RARE ],
@@ -5518,41 +5533,53 @@ export function initBiomes() {
     ],
     [ Species.ROWLET, PokemonType.GRASS, PokemonType.FLYING, [
       [ Biome.FOREST, BiomePoolTier.RARE ]
+      [ Biome.ISLAND, BiomePoolTier.RARE ]
     ]
     ],
     [ Species.DARTRIX, PokemonType.GRASS, PokemonType.FLYING, [
       [ Biome.FOREST, BiomePoolTier.RARE ]
+      [ Biome.ISLAND, BiomePoolTier.RARE ]
     ]
     ],
     [ Species.DECIDUEYE, PokemonType.GRASS, PokemonType.GHOST, [
       [ Biome.FOREST, BiomePoolTier.RARE ],
       [ Biome.FOREST, BiomePoolTier.BOSS_RARE ]
+      [ Biome.ISLAND, BiomePoolTier.RARE ],
+      [ Biome.ISLAND, BiomePoolTier.BOSS_RARE ]
     ]
     ],
     [ Species.LITTEN, PokemonType.FIRE, -1, [
       [ Biome.VOLCANO, BiomePoolTier.RARE ]
+      [ Biome.ISLAND, BiomePoolTier.RARE ]
     ]
     ],
     [ Species.TORRACAT, PokemonType.FIRE, -1, [
       [ Biome.VOLCANO, BiomePoolTier.RARE ]
+      [ Biome.ISLAND, BiomePoolTier.RARE ]
     ]
     ],
     [ Species.INCINEROAR, PokemonType.FIRE, PokemonType.DARK, [
       [ Biome.VOLCANO, BiomePoolTier.RARE ],
       [ Biome.VOLCANO, BiomePoolTier.BOSS_RARE ]
+      [ Biome.ISLAND, BiomePoolTier.RARE ],
+      [ Biome.ISLAND, BiomePoolTier.BOSS_RARE ]
     ]
     ],
     [ Species.POPPLIO, PokemonType.WATER, -1, [
       [ Biome.SEA, BiomePoolTier.RARE ]
+      [ Biome.ISLAND, BiomePoolTier.RARE ]
     ]
     ],
     [ Species.BRIONNE, PokemonType.WATER, -1, [
       [ Biome.SEA, BiomePoolTier.RARE ]
+      [ Biome.ISLAND, BiomePoolTier.RARE ]
     ]
     ],
     [ Species.PRIMARINA, PokemonType.WATER, PokemonType.FAIRY, [
       [ Biome.SEA, BiomePoolTier.RARE ],
       [ Biome.SEA, BiomePoolTier.BOSS_RARE ]
+      [ Biome.ISLAND, BiomePoolTier.RARE ],
+      [ Biome.ISLAND, BiomePoolTier.BOSS_RARE ]
     ]
     ],
     [ Species.PIKIPEK, PokemonType.NORMAL, PokemonType.FLYING, [
@@ -5836,19 +5863,19 @@ export function initBiomes() {
     ]
     ],
     [ Species.COSMOG, PokemonType.PSYCHIC, -1, [
-      [ Biome.SPACE, BiomePoolTier.ULTRA_RARE ]
+      [ Biome.ISLAND, BiomePoolTier.ULTRA_RARE ]
     ]
     ],
     [ Species.COSMOEM, PokemonType.PSYCHIC, -1, [
-      [ Biome.SPACE, BiomePoolTier.ULTRA_RARE ]
+      [ Biome.ISLAND, BiomePoolTier.ULTRA_RARE ]
     ]
     ],
     [ Species.SOLGALEO, PokemonType.PSYCHIC, PokemonType.STEEL, [
-      [ Biome.ISLAND, BiomePoolTier.BOSS_ULTRA_RARE, TimeOfDay.DAY ]
+      [ Biome.ISLAND, BiomePoolTier.BOSS_ULTRA_RARE, [ TimeOfDay.DAWN, TimeOfDay.DAY ]]
     ]
     ],
     [ Species.LUNALA, PokemonType.PSYCHIC, PokemonType.GHOST, [
-      [ Biome.ISLAND, BiomePoolTier.BOSS_ULTRA_RARE, TimeOfDay.NIGHT ]
+      [ Biome.ISLAND, BiomePoolTier.BOSS_ULTRA_RARE, [ TimeOfDay.DUSK, TimeOfDay.NIGHT ]]
     ]
     ],
     [ Species.NIHILEGO, PokemonType.ROCK, PokemonType.POISON, [
@@ -5872,8 +5899,8 @@ export function initBiomes() {
     ]
     ],
     [ Species.CELESTEELA, PokemonType.STEEL, PokemonType.FLYING, [
-      [ Biome.SPACE, BiomePoolTier.ULTRA_RARE ],
-      [ Biome.SPACE, BiomePoolTier.BOSS_SUPER_RARE ]
+      [ Biome.WASTELAND, BiomePoolTier.ULTRA_RARE ],
+      [ Biome.WASTELAND, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
     [ Species.KARTANA, PokemonType.GRASS, PokemonType.STEEL, [
@@ -5887,7 +5914,7 @@ export function initBiomes() {
     ]
     ],
     [ Species.NECROZMA, PokemonType.PSYCHIC, -1, [
-      [ Biome.ISLAND, BiomePoolTier.BOSS_ULTRA_RARE ]
+      [ Biome.METROPOLIS, BiomePoolTier.BOSS_ULTRA_RARE ]
     ]
     ],
     [ Species.MAGEARNA, PokemonType.STEEL, PokemonType.FAIRY, [

--- a/src/data/balance/biomes.ts
+++ b/src/data/balance/biomes.ts
@@ -1147,10 +1147,10 @@ export const biomePokemonPools: BiomePokemonPools = {
     [BiomePoolTier.UNCOMMON]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [{ 1: [ Species.BRONZOR ], 33: [ Species.BRONZONG ]}, Species.KLEFKI ]},
     [BiomePoolTier.RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [{ 1: [ Species.PORYGON ], 30: [ Species.PORYGON2 ]}, { 1: [ Species.VAROOM ], 40: [ Species.REVAVROOM ]}]},
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [{ 1: [ Species.BELDUM ], 20: [ Species.METANG ], 45: [ Species.METAGROSS ]}]},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MAGEARNA ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MAGEARNA, Species.MELTAN ]},
     [BiomePoolTier.BOSS]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.KLINKLANG, Species.KLEFKI ]},
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.REVAVROOM ]},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MAGEARNA ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MAGEARNA, Species.MELMETAL ]},
     [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MIRAIDON ]}
   },
   [Biome.RUINS]: {
@@ -1324,10 +1324,10 @@ export const biomePokemonPools: BiomePokemonPools = {
     },
     [BiomePoolTier.RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [{ 1: [ Species.GALAR_MEOWTH ], 28: [ Species.PERRSERKER ]}], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ONIX, Species.HITMONLEE, Species.HITMONCHAN, Species.DURALUDON ]},
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.DITTO, Species.HITMONTOP ]},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.COBALION, Species.MELTAN ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.COBALION, Species.STAKATAKA ]},
     [BiomePoolTier.BOSS]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.MACHAMP, Species.CONKELDURR ]},
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [ Species.PERRSERKER ], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.ARCHALUDON ]},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.COBALION, Species.MELMETAL ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.COBALION, Species.STAKATAKA ]},
     [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: []}
   },
   [Biome.JUNGLE]: {
@@ -1577,7 +1577,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       ]
     },
     [BiomePoolTier.SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: []},
-    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ { 1: [ Species.COSMOG ], 43: [ Species.COSMOEM ]}, Species.STAKATAKA, Species.BLACEPHALON ]},
+    [BiomePoolTier.ULTRA_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ { 1: [ Species.COSMOG ], 43: [ Species.COSMOEM ]}, Species.BLACEPHALON ]},
     [BiomePoolTier.BOSS]: {
       [TimeOfDay.DAWN]: [ Species.ALOLA_RAICHU, Species.ALOLA_EXEGGUTOR ],
       [TimeOfDay.DAY]: [ Species.ALOLA_RAICHU, Species.ALOLA_EXEGGUTOR ],
@@ -1586,7 +1586,7 @@ export const biomePokemonPools: BiomePokemonPools = {
       [TimeOfDay.ALL]: [ Species.ORICORIO, Species.BRUXISH, Species.ALOLA_SANDSLASH, Species.ALOLA_NINETALES, Species.ALOLA_DUGTRIO, Species.ALOLA_GOLEM, Species.ALOLA_MUK ]
     },
     [BiomePoolTier.BOSS_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.DECIDUEYE, Species.INCINEROAR, Species.PRIMARINA ]},
-    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.STAKATAKA, Species.BLACEPHALON ]},
+    [BiomePoolTier.BOSS_SUPER_RARE]: { [TimeOfDay.DAWN]: [], [TimeOfDay.DAY]: [], [TimeOfDay.DUSK]: [], [TimeOfDay.NIGHT]: [], [TimeOfDay.ALL]: [ Species.BLACEPHALON ]},
     [BiomePoolTier.BOSS_ULTRA_RARE]: { [TimeOfDay.DAWN]: [ Species.SOLGALEO ], [TimeOfDay.DAY]: [ Species.SOLGALEO ], [TimeOfDay.DUSK]: [ Species.LUNALA ], [TimeOfDay.NIGHT]: [ Species.LUNALA ], [TimeOfDay.ALL]: []}
   },
   [Biome.LABORATORY]: {
@@ -5936,8 +5936,8 @@ export function initBiomes() {
     ]
     ],
     [ Species.STAKATAKA, PokemonType.ROCK, PokemonType.STEEL, [
-      [ Biome.ISLAND, BiomePoolTier.ULTRA_RARE ],
-      [ Biome.ISLAND, BiomePoolTier.BOSS_SUPER_RARE ]
+      [ Biome.CONSTRUCTION_SITE, BiomePoolTier.ULTRA_RARE ],
+      [ Biome.CONSTRUCTION_SITE, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
     [ Species.BLACEPHALON, PokemonType.FIRE, PokemonType.GHOST, [
@@ -5951,11 +5951,11 @@ export function initBiomes() {
     ]
     ],
     [ Species.MELTAN, PokemonType.STEEL, -1, [
-      [ Biome.CONSTRUCTION_SITE, BiomePoolTier.ULTRA_RARE ],
+      [ Biome.FACTORY, BiomePoolTier.ULTRA_RARE ],
     ]
     ],
     [ Species.MELMETAL, PokemonType.STEEL, -1, [
-      [ Biome.CONSTRUCTION_SITE, BiomePoolTier.BOSS_SUPER_RARE ]
+      [ Biome.FACTORY, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
     [ Species.GROOKEY, PokemonType.GRASS, -1, [

--- a/src/data/balance/biomes.ts
+++ b/src/data/balance/biomes.ts
@@ -2802,7 +2802,7 @@ export function initBiomes() {
     ]
     ],
     [ Species.MEW, PokemonType.PSYCHIC, -1, [
-      [ Biome.JUNGLE, BiomePoolTier.ULTRA_RARE ]
+      [ Biome.JUNGLE, BiomePoolTier.ULTRA_RARE ],
       [ Biome.JUNGLE, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
@@ -3276,7 +3276,7 @@ export function initBiomes() {
     ]
     ],
     [ Species.CELEBI, PokemonType.PSYCHIC, PokemonType.GRASS, [
-      [ Biome.FOREST, BiomePoolTier.ULTRA_RARE ]
+      [ Biome.FOREST, BiomePoolTier.ULTRA_RARE ],
       [ Biome.FOREST, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
@@ -3763,9 +3763,9 @@ export function initBiomes() {
     ],
     [ Species.CASTFORM, PokemonType.NORMAL, -1, [
       [ Biome.METROPOLIS, BiomePoolTier.RARE ],
-      [ Biome.METROPOLIS, BiomePoolTier.BOSS ]
+      [ Biome.METROPOLIS, BiomePoolTier.BOSS ],
       [ Biome.LABORATORY, BiomePoolTier.RARE ],
-      [ Biome.LABORATORY, BiomePoolTier.BOSS ]
+      [ Biome.LABORATORY, BiomePoolTier.BOSS ],
     ]
     ],
     [ Species.KECLEON, PokemonType.NORMAL, -1, [
@@ -3922,7 +3922,7 @@ export function initBiomes() {
     ]
     ],
     [ Species.JIRACHI, PokemonType.STEEL, PokemonType.PSYCHIC, [
-      [ Biome.MOUNTAIN, BiomePoolTier.ULTRA_RARE ]
+      [ Biome.MOUNTAIN, BiomePoolTier.ULTRA_RARE ],
       [ Biome.MOUNTAIN, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
@@ -4325,12 +4325,12 @@ export function initBiomes() {
     ]
     ],
     [ Species.LEAFEON, PokemonType.GRASS, -1, [
-      [ Biome.JUNGLE, BiomePoolTier.SUPER_RARE ]
+      [ Biome.JUNGLE, BiomePoolTier.SUPER_RARE ],
       [ Biome.JUNGLE, BiomePoolTier.BOSS_RARE ]
     ]
     ],
     [ Species.GLACEON, PokemonType.ICE, -1, [
-      [ Biome.ICE_CAVE, BiomePoolTier.SUPER_RARE ]
+      [ Biome.ICE_CAVE, BiomePoolTier.SUPER_RARE ],
       [ Biome.ICE_CAVE, BiomePoolTier.BOSS_RARE ]
     ]
     ],
@@ -4436,14 +4436,14 @@ export function initBiomes() {
     ]
     ],
     [ Species.SHAYMIN, PokemonType.GRASS, -1, [
-      [ Biome.MEADOW, BiomePoolTier.ULTRA_RARE ]
+      [ Biome.MEADOW, BiomePoolTier.ULTRA_RARE ],
       [ Biome.MEADOW, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
     [ Species.ARCEUS, PokemonType.NORMAL, -1, [ ]
     ],
     [ Species.VICTINI, PokemonType.PSYCHIC, PokemonType.FIRE, [
-      [ Biome.BEACH, BiomePoolTier.ULTRA_RARE ]
+      [ Biome.BEACH, BiomePoolTier.ULTRA_RARE ],
       [ Biome.BEACH, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],
@@ -5532,52 +5532,52 @@ export function initBiomes() {
     ]
     ],
     [ Species.ROWLET, PokemonType.GRASS, PokemonType.FLYING, [
-      [ Biome.FOREST, BiomePoolTier.RARE ]
+      [ Biome.FOREST, BiomePoolTier.RARE ],
       [ Biome.ISLAND, BiomePoolTier.RARE ]
     ]
     ],
     [ Species.DARTRIX, PokemonType.GRASS, PokemonType.FLYING, [
-      [ Biome.FOREST, BiomePoolTier.RARE ]
+      [ Biome.FOREST, BiomePoolTier.RARE ],
       [ Biome.ISLAND, BiomePoolTier.RARE ]
     ]
     ],
     [ Species.DECIDUEYE, PokemonType.GRASS, PokemonType.GHOST, [
       [ Biome.FOREST, BiomePoolTier.RARE ],
-      [ Biome.FOREST, BiomePoolTier.BOSS_RARE ]
+      [ Biome.FOREST, BiomePoolTier.BOSS_RARE ],
       [ Biome.ISLAND, BiomePoolTier.RARE ],
       [ Biome.ISLAND, BiomePoolTier.BOSS_RARE ]
     ]
     ],
     [ Species.LITTEN, PokemonType.FIRE, -1, [
-      [ Biome.VOLCANO, BiomePoolTier.RARE ]
+      [ Biome.VOLCANO, BiomePoolTier.RARE ],
       [ Biome.ISLAND, BiomePoolTier.RARE ]
     ]
     ],
     [ Species.TORRACAT, PokemonType.FIRE, -1, [
-      [ Biome.VOLCANO, BiomePoolTier.RARE ]
+      [ Biome.VOLCANO, BiomePoolTier.RARE ],
       [ Biome.ISLAND, BiomePoolTier.RARE ]
     ]
     ],
     [ Species.INCINEROAR, PokemonType.FIRE, PokemonType.DARK, [
       [ Biome.VOLCANO, BiomePoolTier.RARE ],
-      [ Biome.VOLCANO, BiomePoolTier.BOSS_RARE ]
+      [ Biome.VOLCANO, BiomePoolTier.BOSS_RARE ],
       [ Biome.ISLAND, BiomePoolTier.RARE ],
       [ Biome.ISLAND, BiomePoolTier.BOSS_RARE ]
     ]
     ],
     [ Species.POPPLIO, PokemonType.WATER, -1, [
-      [ Biome.SEA, BiomePoolTier.RARE ]
+      [ Biome.SEA, BiomePoolTier.RARE ],
       [ Biome.ISLAND, BiomePoolTier.RARE ]
     ]
     ],
     [ Species.BRIONNE, PokemonType.WATER, -1, [
-      [ Biome.SEA, BiomePoolTier.RARE ]
+      [ Biome.SEA, BiomePoolTier.RARE ],
       [ Biome.ISLAND, BiomePoolTier.RARE ]
     ]
     ],
     [ Species.PRIMARINA, PokemonType.WATER, PokemonType.FAIRY, [
       [ Biome.SEA, BiomePoolTier.RARE ],
-      [ Biome.SEA, BiomePoolTier.BOSS_RARE ]
+      [ Biome.SEA, BiomePoolTier.BOSS_RARE ],
       [ Biome.ISLAND, BiomePoolTier.RARE ],
       [ Biome.ISLAND, BiomePoolTier.BOSS_RARE ]
     ]
@@ -6668,7 +6668,7 @@ export function initBiomes() {
     ],
     [ Species.VAROOM, PokemonType.STEEL, PokemonType.POISON, [
       [ Biome.METROPOLIS, BiomePoolTier.RARE ],
-      [ Biome.SLUM, BiomePoolTier.RARE ]
+      [ Biome.SLUM, BiomePoolTier.RARE ],
       [ Biome.FACTORY, BiomePoolTier.RARE ]
     ]
     ],
@@ -6676,7 +6676,7 @@ export function initBiomes() {
       [ Biome.METROPOLIS, BiomePoolTier.RARE ],
       [ Biome.METROPOLIS, BiomePoolTier.BOSS_RARE ],
       [ Biome.SLUM, BiomePoolTier.RARE ],
-      [ Biome.SLUM, BiomePoolTier.BOSS_RARE ]
+      [ Biome.SLUM, BiomePoolTier.BOSS_RARE ],
       [ Biome.FACTORY, BiomePoolTier.RARE ],
       [ Biome.FACTORY, BiomePoolTier.BOSS_RARE ]
     ]
@@ -6935,7 +6935,7 @@ export function initBiomes() {
     ]
     ],
     [ Species.PECHARUNT, PokemonType.POISON, PokemonType.GHOST, [
-      [ Biome.SWAMP, BiomePoolTier.ULTRA_RARE ]
+      [ Biome.SWAMP, BiomePoolTier.ULTRA_RARE ],
       [ Biome.SWAMP, BiomePoolTier.BOSS_SUPER_RARE ]
     ]
     ],


### PR DESCRIPTION
This is my first PR. I have no idea of how to test anything, so I may need a little help with that. Feedback and questions are appreciated.

## What are the changes the user will see?
The player will be able to see these changes in the PokéDex.

## Why am I making these changes?
To give all the remaining egg-only mythical Pokémon a biome, while also redistributing super rare and ultra rare encounters to be spread more evenly among biomes.

## What are the changes from a developer perspective?

List of biome changes: 
- Celebi: N/A -> Forest
   Reason: Celebi is the guardian of Ilex Forest.
- Celesteela: Space -> Wasteland
   Reason: Wasteland resembles its home dimension of Ultra Crater.
- Cosmog/Cosmoem: Space -> Island
   Reason: Cosmog and its evolutions come from another dimension, not outer space, and their close ties to the Alola region justify moving them to Island to make space for Deoxys.
- Deoxys: N/A -> Space
   Reason: Deoxys used to be encountered in Space, until it was removed because Space had too many ultra rare encounters. If the Light Trio is moved to other biomes, that leaves only Deoxys and Rayquaza.
- Dialga: Wasteland -> Ancient Ruins
   Reason: Dialga is traditionally encountered at the Spear Pillar.
- Genesect: Factory -> Laboratory
   Reason: Genesect is a Pokémon altered by science. It has nothing to do with industry.
- Jirachi: N/A -> Mountain
   Reason: Jirachi is said to be found in the mountains.
- Koraidon: Ancient Ruins -> Wasteland
   Reason: Swapped with Dialga. Koraidon has no particular association with ruins in Scarlet and Violet.
- Lunala: Space (Night) -> Island (Dusk/Night)
   Reason: See Cosmog/Cosmoem.
- Manaphy: N/A -> Sea Bed
- Meltan/Melmetal: N/A -> Factory
   Reason: Factory seems like a good fit for this Pokémon. Fills the slot left by Genesect.
- Mew: N/A -> Jungle
   Reason: Mew was first discovered in the jungle.
- Miraidon: Laboratory -> Factory
   Reason: Moved so that Factory has an Ultra Rare boss encounter. This placement is somewhat arbitrary. Power Plant would be more apt, but Power Plant already has Zekrom as an ultra rare boss encounter, and I'd rather it go to a biome that doesn't already have one.
- Necrozma: Space -> Metropolis
   Reason: In the story of Sun and Moon, Necrozma was imprisoned in the alternate universe city of Ultra Megalopolis.
- Palkia: Abyss -> Ancient Ruins
   Reason: Palkia is traditionally encountered at the Spear Pillar.
- Pecharunt: N/A -> Swamp
   Reason: Placed in Swamp for type reasons, filling the the gap left by Poipole/Naganadel.
- Phione: N/A -> Sea Bed
- Poipole/Naganadel: Swamp -> Metropolis
   Reason: Metropolis resembles their home dimension of Ultra Megalopolis.
- Solgaleo: Space (Day) -> Island (Dawn/Day)
   Reason: See Cosmog/Cosmoem.
- Victini: N/A -> Island
   Reason: Victini is found on Liberty Garden Island in Black and White. Island is closely associated with Alola, so Beach is the second-best choice.
- Terapagos: Cave -> Fairy Cave
   Reason: Fills the encounter slot formerly occupied by Xerneas. Though Terapagos isn't Fairy type, Fairy Cave is somewhat reminiscient of the Area Zero Underdepths.
- Terrakion: Dojo -> Cave
   Reason: Terrakion is found on Victory Road in Black and White. This balances the ratio of super rare boss encounters between Dojo and Cave from 3-1 to 2-2 (factoring in the Galarian Zapdos boss encounter being demoted from ultra rare to super rare).
- Victini: N/A -> Beach
   Reason: Victini is found on Liberty Garden Island in Black and White.
- Xerneas: Fairy Cave -> Meadow
   Reason: Moved so that Meadow has an Ultra Rare boss encounter. Also, Xerneas doesn't seem like it would be found in a cave.
- Zeraora: Power Plant -> Metropolis
   Reason: Though Zeraora prefers to live in the wilderness, I selected Metropolis for its encounter because of Zeraora's history with Fula City. There may be a better place to put it.
- Zygarde: Laboratory -> Cave
   Reason: Zygarde is encountered in Terminus Cave in X and Y. Moved so that Mewtwo is the only Ultra Rare Laboratory boss encounter.

Other changes:
- Galarian Articuno, Zapdos, and Moltres boss encounter rarity reduced from ultra rare to super rare.
- Kleavor boss encounter rarity reduced from ultra rare to rare.
- Rotom boss encounter rarities reduced from super rare to rare in most biomes.
- Varoom/Revavroom encounters added to Factory.
- Castform encounters added to Laboratory.
- Leafeon and Glaceon given non-boss encounters to be consistent with other Eeveelutions.
- Chatot encounter rarity reduced from super rare (any time) to rare (dawn/day).

## How to test the changes?
- [N] Did you make use of the `src/overrides.ts` file?
- [N] Did you introduce any automated tests?
- [N] Do the reviewers need to do something special in order to test your changes?

## Checklist
- [Y] **I'm using `beta` as my base branch**
- [Y] There is no overlap with another PR?
- [Y] The PR is self-contained and cannot be split into smaller PRs?
- [Y] Have I provided a clear explanation of the changes?
- [N] Have I tested the changes manually?
- [N] Are all unit tests still passing? (`npm run test`)
- [N] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [N/A] Have I provided screenshots/videos of the changes (if applicable)?
- [N/A] Have I made sure that any UI change works for both UI themes (default and legacy)?