### PR TITLE
[GitHub] Use `.nvmrc` for pages workflow

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node 22.14.1
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: "pokerogue_docs/.nvmrc"
 
       - name: Checkout repository for Github Pages
         if: github.event_name == 'push'


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
The pages workflow was the only one not using the `.nvmrc` file.

## What are the changes from a developer perspective?
```diff
-         node-version: 22
+         node-version-file: "pokerogue_docs/.nvmrc"
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?