### PR TITLE
[Bug] Prevent game from hanging when loading in a new battle

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -838,9 +838,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       }
     }
 
-    console.log("Before awaiting line 842");
     await Promise.allSettled(loadPromises);
-    console.log("After awaiting line 842");
 
     // This must be initiated before we queue loading, otherwise the load could have finished before
     // we reach the line of code that adds the listener, causing a deadlock.

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -844,12 +844,11 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     // we reach the line of code that adds the listener, causing a deadlock.
     const waitOnLoadPromise = new Promise<void>(resolve => globalScene.load.once(Phaser.Loader.Events.COMPLETE, resolve));
 
-    // Wait for the assets we queued to load to finish loading, then...
     if (!globalScene.load.isLoading()) {
-      // push an event that will resolve when the load is complete
       globalScene.load.start();
-
     }
+
+    // Wait for the assets we queued to load to finish loading, then...
     // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises#creating_a_promise_around_an_old_callback_api
     await waitOnLoadPromise;
 
@@ -880,7 +879,6 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     if (this.summonData?.speciesForm) {
       this.updateFusionPalette(true);
     }
-    console.log("Line 881");
   }
 
   /**


### PR DESCRIPTION
## What are the changes the user will see?
Game will no longer hang due to a race condition when loading some battles

## Why am I making these changes?

I can't launch the game with certain overrides set.

## What are the changes from a developer perspective?
In `pokemon#loadAssets`, the `globalScene.load.once` call that resolves the promise is now created _before_ calling `globalScene.load.start()`.  Essentially, what was happening before was the await statement that awaits that promise was creating the call to start the loading. This ended up causing a race condition, where the asynchronous execution of the load might have finished before the event listener that allows the promise to resolve was added.

## Screenshots/Videos
N/A

## How to test the changes?
Use the following override set with the everything save, and ensure the game starts when selecting bulbasaur and charmander.

```ts
const overrides = {
  OPP_SPECIES_OVERRIDE: Species.ABRA,
  BATTLE_TYPE_OVERRIDE: "double",
  MOVESET_OVERRIDE: [Moves.SOAK, Moves.FAKE_OUT, Moves.SHADOW_BALL, Moves.THUNDERBOLT],
  OPP_MOVESET_OVERRIDE: [Moves.TELEPORT],
  OPP_ABILITY_OVERRIDE: Abilities.BALL_FETCH,
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~ Requires actually loading assets, so can't be tested
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~