### PR TITLE
[Bug] [Move] Supercell Slam now hits Minimized targets for double damage and can't miss

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -11231,6 +11231,8 @@ export function initMoves() {
     new AttackMove(Moves.TEMPER_FLARE, PokemonType.FIRE, MoveCategory.PHYSICAL, 75, 100, 10, -1, 0, 9)
       .attr(MovePowerMultiplierAttr, (user, target, move) => user.getLastXMoves(2)[1]?.result === MoveResult.MISS || user.getLastXMoves(2)[1]?.result === MoveResult.FAIL ? 2 : 1),
     new AttackMove(Moves.SUPERCELL_SLAM, PokemonType.ELECTRIC, MoveCategory.PHYSICAL, 100, 95, 15, -1, 0, 9)
+      .attr(AlwaysHitMinimizeAttr)
+      .attr(HitsTagForDoubleDamageAttr, BattlerTagType.MINIMIZED)
       .attr(MissEffectAttr, crashDamageFunc)
       .attr(NoEffectAttr, crashDamageFunc)
       .recklessMove(),


### PR DESCRIPTION
## What are the changes the user will see?
Supercell Slam now
- Does double damage to targets who have used Minmize
- Cannot miss against targets who have used Minimize

## Why am I making these changes?
Was missing attributes
https://bulbapedia.bulbagarden.net/wiki/Minimize_(move)#Vulnerability_to_moves

## What are the changes from a developer perspective?
Two attributes added to Supercell Slam that are applied to all moves that Minimize is vulnerable to

## Screenshots/Videos

## How to test the changes?
Overrides, use Supercell Slam against a Minimize target

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [X] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?