### PR TITLE
[Refactor][Docs] Cleanup tsdoc comments and remove invalid syntax

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -271,7 +271,7 @@ export default class BattleScene extends SceneBase {
    * - `2` - Skip: No level up frame nor message.
    *
    * Modes `1` and `2` are still compatible with stats display, level up, new move, etc.
-   * @default 0 - Uses the default normal experience gain display.
+   * @defaultValue 0
    */
   public expParty: ExpNotification = 0;
   public hpBarSpeed = 0;

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -830,7 +830,7 @@ export default class BattleScene extends SceneBase {
    * and {@linkcode PlayerPokemon.isActive is active}
    * (aka {@linkcode PlayerPokemon.isAllowedInBattle is allowed in battle}),
    * or `undefined` if there are no valid pokemon
-   * @param includeSwitching Whether a pokemon that is currently switching out is valid, default `true`
+   * @param includeSwitching - Whether a pokemon that is currently switching out is valid, default `true`
    */
   public getPlayerPokemon(includeSwitching = true): PlayerPokemon | undefined {
     return this.getPlayerField().find(p => p.isActive() && (includeSwitching || p.switchOutStatus === false));
@@ -855,7 +855,7 @@ export default class BattleScene extends SceneBase {
    * and {@linkcode EnemyPokemon.isActive is active}
    * (aka {@linkcode EnemyPokemon.isAllowedInBattle is allowed in battle}),
    * or `undefined` if there are no valid pokemon
-   * @param includeSwitching Whether a pokemon that is currently switching out is valid, default `true`
+   * @param includeSwitching - Whether a pokemon that is currently switching out is valid, default `true`
    */
   public getEnemyPokemon(includeSwitching = true): EnemyPokemon | undefined {
     return this.getEnemyField().find(p => p.isActive() && (includeSwitching || p.switchOutStatus === false));
@@ -874,7 +874,7 @@ export default class BattleScene extends SceneBase {
   /**
    * Returns an array of Pokemon on both sides of the battle - player first, then enemy.
    * Does not actually check if the pokemon are on the field or not, and always has length 4 regardless of battle type.
-   * @param activeOnly Whether to consider only active pokemon
+   * @param activeOnly - Whether to consider only active pokemon
    * @returns array of {@linkcode Pokemon}
    */
   public getField(activeOnly = false): Pokemon[] {
@@ -888,8 +888,8 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Used in doubles battles to redirect moves from one pokemon to another when one faints or is removed from the field
-   * @param removedPokemon {@linkcode Pokemon} the pokemon that is being removed from the field (flee, faint), moves to be redirected FROM
-   * @param allyPokemon {@linkcode Pokemon} the pokemon that will have the moves be redirected TO
+   * @param removedPokemon - The pokemon that is being removed from the field (flee, faint), moves to be redirected FROM
+   * @param allyPokemon - The pokemon that will have the moves be redirected TO
    */
   redirectPokemonMoves(removedPokemon: Pokemon, allyPokemon: Pokemon): void {
     // failsafe: if not a double battle just return
@@ -915,8 +915,7 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Returns the ModifierBar of this scene, which is declared private and therefore not accessible elsewhere
-   * @param isEnemy Whether to return the enemy's modifier bar
-   * @returns {ModifierBar}
+   * @param isEnemy - Whether to return the enemy's modifier bar
    */
   getModifierBar(isEnemy?: boolean): ModifierBar {
     return isEnemy ? this.enemyModifierBar : this.modifierBar;
@@ -1023,7 +1022,7 @@ export default class BattleScene extends SceneBase {
    * Removes a {@linkcode PlayerPokemon} from the party, and clears modifiers for that Pokemon's id
    * Useful for MEs/Challenges that remove Pokemon from the player party temporarily or permanently
    * @param pokemon
-   * @param destroy Default true. If true, will destroy the {@linkcode PlayerPokemon} after removing
+   * @param destroy - Default true. If true, will destroy the {@linkcode PlayerPokemon} after removing
    */
   removePokemonFromPlayerParty(pokemon: PlayerPokemon, destroy = true) {
     if (!pokemon) {
@@ -1154,8 +1153,8 @@ export default class BattleScene extends SceneBase {
    * This calls {@linkcode Battle.randSeedInt}({@linkcode range}, {@linkcode min}) in `src/battle.ts`
    * which calls {@linkcode randSeedInt randSeedInt}({@linkcode range}, {@linkcode min}) in `src/utils.ts`
    *
-   * @param range How large of a range of random numbers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
-   * @param min The minimum integer to pick, default `0`
+   * @param range - How large of a range of random numbers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
+   * @param min - The minimum integer to pick, default `0`
    * @returns A random integer between {@linkcode min} and ({@linkcode min} + {@linkcode range} - 1)
    */
   randBattleSeedInt(range: number, min = 0): number {
@@ -2039,7 +2038,7 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Displays the current luck value.
-   * @param duration The time for this label to fade in, if it is not already visible.
+   * @param duration - The time for this label to fade in, if it is not already visible.
    */
   updateAndShowText(duration: number): void {
     const labels = [this.luckLabelText, this.luckText];
@@ -2628,8 +2627,8 @@ export default class BattleScene extends SceneBase {
    * This method allows deferring the execution of a phase until certain conditions are met, which is useful for handling
    * situations like abilities and entry hazards that depend on specific game states.
    *
-   * @param {Phase} phase - The phase to be added to the conditional queue.
-   * @param {() => boolean} condition - A function that returns a boolean indicating whether the phase should be executed.
+   * @param phase - The phase to be added to the conditional queue.
+   * @param condition - A function that returns a boolean indicating whether the phase should be executed.
    *
    */
   pushConditionalPhase(phase: Phase, condition: () => boolean): void {
@@ -2638,8 +2637,8 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Adds a phase to nextCommandPhaseQueue, as long as boolean passed in is false
-   * @param phase {@linkcode Phase} the phase to add
-   * @param defer boolean on which queue to add to, defaults to false, and adds to phaseQueue
+   * @param phase - The phase to add
+   * @param defer - boolean on which queue to add to, defaults to false, and adds to phaseQueue
    */
   pushPhase(phase: Phase, defer = false): void {
     (!defer ? this.phaseQueue : this.nextCommandPhaseQueue).push(phase);
@@ -2647,7 +2646,7 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Adds Phase(s) to the end of phaseQueuePrepend, or at phaseQueuePrependSpliceIndex
-   * @param phases {@linkcode Phase} the phase(s) to add
+   * @param phases - The phase(s) to add
    */
   unshiftPhase(...phases: Phase[]): void {
     if (this.phaseQueuePrependSpliceIndex === -1) {
@@ -2759,7 +2758,7 @@ export default class BattleScene extends SceneBase {
   /**
    * Find a specific {@linkcode Phase} in the phase queue.
    *
-   * @param phaseFilter filter function to use to find the wanted phase
+   * @param phaseFilter - filter function to use to find the wanted phase
    * @returns the found phase or undefined if none found
    */
   findPhase<P extends Phase = Phase>(phaseFilter: (phase: P) => boolean): P | undefined {
@@ -2786,7 +2785,7 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Will search for a specific phase in {@linkcode phaseQueuePrepend} via filter, and remove the first result if a match is found.
-   * @param phaseFilter filter function
+   * @param phaseFilter - filter function
    */
   tryRemoveUnshiftedPhase(phaseFilter: (phase: Phase) => boolean): boolean {
     const phaseIndex = this.phaseQueuePrepend.findIndex(phaseFilter);
@@ -2799,8 +2798,8 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Tries to add the input phase to index before target phase in the phaseQueue, else simply calls unshiftPhase()
-   * @param phase {@linkcode Phase} the phase to be added
-   * @param targetPhase {@linkcode Phase} the type of phase to search for in phaseQueue
+   * @param phase - The phase to be added
+   * @param targetPhase - The type of phase to search for in phaseQueue
    * @returns boolean if a targetPhase was found and added
    */
   prependToPhase(phase: Phase | Phase[], targetPhase: Constructor<Phase>): boolean {
@@ -2819,8 +2818,8 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Tries to add the input phase(s) to index after target phase in the {@linkcode phaseQueue}, else simply calls {@linkcode unshiftPhase()}
-   * @param phase {@linkcode Phase} the phase(s) to be added
-   * @param targetPhase {@linkcode Phase} the type of phase to search for in {@linkcode phaseQueue}
+   * @param phase - The phase(s) to be added
+   * @param targetPhase - The type of phase to search for in {@linkcode phaseQueue}
    * @returns `true` if a `targetPhase` was found to append to
    */
   appendToPhase(phase: Phase | Phase[], targetPhase: Constructor<Phase>): boolean {
@@ -2839,11 +2838,11 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Adds a MessagePhase, either to PhaseQueuePrepend or nextCommandPhaseQueue
-   * @param message string for MessagePhase
-   * @param callbackDelay optional param for MessagePhase constructor
-   * @param prompt optional param for MessagePhase constructor
-   * @param promptDelay optional param for MessagePhase constructor
-   * @param defer boolean for which queue to add it to, false -> add to PhaseQueuePrepend, true -> nextCommandPhaseQueue
+   * @param message - string for MessagePhase
+   * @param callbackDelay - optional param for MessagePhase constructor
+   * @param prompt - optional param for MessagePhase constructor
+   * @param promptDelay - optional param for MessagePhase constructor
+   * @param defer - boolean for which queue to add it to, false -> add to PhaseQueuePrepend, true -> nextCommandPhaseQueue
    */
   queueMessage(
     message: string,
@@ -2864,9 +2863,9 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Queues an ability bar flyout phase
-   * @param pokemon The pokemon who has the ability
-   * @param passive Whether the ability is a passive
-   * @param show Whether to show or hide the bar
+   * @param pokemon - The pokemon who has the ability
+   * @param passive - Whether the ability is a passive
+   * @param show - Whether to show or hide the bar
    */
   public queueAbilityDisplay(pokemon: Pokemon, passive: boolean, show: boolean): void {
     this.unshiftPhase(show ? new ShowAbilityPhase(pokemon.getBattlerIndex(), passive) : new HideAbilityPhase());
@@ -3026,13 +3025,13 @@ export default class BattleScene extends SceneBase {
    * If the recepient already has the maximum amount allowed for this item, the transfer is cancelled.
    * The quantity to transfer is automatically capped at how much the recepient can take before reaching the maximum stack size for the item.
    * A transfer that moves a quantity smaller than what is specified in the transferQuantity parameter is still considered successful.
-   * @param itemModifier {@linkcode PokemonHeldItemModifier} item to transfer (represents the whole stack)
-   * @param target {@linkcode Pokemon} recepient in this transfer
-   * @param playSound `true` to play a sound when transferring the item
-   * @param transferQuantity How many items of the stack to transfer. Optional, defaults to `1`
-   * @param instant ??? (Optional)
-   * @param ignoreUpdate ??? (Optional)
-   * @param itemLost If `true`, treat the item's current holder as losing the item (for now, this simply enables Unburden). Default is `true`.
+   * @param itemModifier - The item to transfer (represents the whole stack)
+   * @param target - The pokemon receiving the item in this transfer
+   * @param playSound - `true` to play a sound when transferring the item
+   * @param transferQuantity - How many items of the stack to transfer. Optional, defaults to `1`
+   * @param instant - If an item changes a display, such as the HP bar, whether changes will be animated or move instantly (Optional, defaults to false)
+   * @param ignoreUpdate - ??? (Optional)
+   * @param itemLost - If `true`, treat the item's current holder as losing the item (for now, this simply enables Unburden). Default is `true`.
    * @returns `true` if the transfer was successful
    */
   tryTransferHeldItemModifier(
@@ -3312,8 +3311,8 @@ export default class BattleScene extends SceneBase {
    * Removes a currently owned item. If the item is stacked, the entire item stack
    * gets removed. This function does NOT apply in-battle effects, such as Unburden.
    * If in-battle effects are needed, use {@linkcode Pokemon.loseHeldItem} instead.
-   * @param modifier The item to be removed.
-   * @param enemy If `true`, remove an item owned by the enemy. If `false`, remove an item owned by the player. Default is `false`.
+   * @param modifier - The item to be removed.
+   * @param enemy - If `true`, remove an item owned by the enemy. If `false`, remove an item owned by the player. Default is `false`.
    * @returns `true` if the item exists and was successfully removed, `false` otherwise.
    */
   removeModifier(modifier: PersistentModifier, enemy = false): boolean {
@@ -3335,8 +3334,8 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Get all of the modifiers that match `modifierType`
-   * @param modifierType The type of modifier to apply; must extend {@linkcode PersistentModifier}
-   * @param player Whether to search the player (`true`) or the enemy (`false`); Defaults to `true`
+   * @param modifierType - The type of modifier to apply; must extend {@linkcode PersistentModifier}
+   * @param player - Whether to search the player (`true`) or the enemy (`false`); Defaults to `true`
    * @returns the list of all modifiers that matched `modifierType`.
    */
   getModifiers<T extends PersistentModifier>(modifierType: Constructor<T>, player = true): T[] {
@@ -3345,8 +3344,8 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Get all of the modifiers that pass the `modifierFilter` function
-   * @param modifierFilter The function used to filter a target's modifiers
-   * @param isPlayer Whether to search the player (`true`) or the enemy (`false`); Defaults to `true`
+   * @param modifierFilter - The function used to filter a target's modifiers
+   * @param isPlayer - Whether to search the player (`true`) or the enemy (`false`); Defaults to `true`
    * @returns the list of all modifiers that passed the `modifierFilter` function
    */
   findModifiers(modifierFilter: ModifierPredicate, isPlayer = true): PersistentModifier[] {
@@ -3355,8 +3354,8 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Find the first modifier that pass the `modifierFilter` function
-   * @param modifierFilter The function used to filter a target's modifiers
-   * @param player Whether to search the player (`true`) or the enemy (`false`); Defaults to `true`
+   * @param modifierFilter - The function used to filter a target's modifiers
+   * @param player - Whether to search the player (`true`) or the enemy (`false`); Defaults to `true`
    * @returns the first modifier that passed the `modifierFilter` function; `undefined` if none passed
    */
   findModifier(modifierFilter: ModifierPredicate, player = true): PersistentModifier | undefined {
@@ -3365,9 +3364,9 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Apply all modifiers that match `modifierType` in a random order
-   * @param modifierType The type of modifier to apply; must extend {@linkcode PersistentModifier}
-   * @param player Whether to search the player (`true`) or the enemy (`false`); Defaults to `true`
-   * @param ...args The list of arguments needed to invoke `modifierType.apply`
+   * @param modifierType - The type of modifier to apply; must extend {@linkcode PersistentModifier}
+   * @param player - Whether to search the player (`true`) or the enemy (`false`); Defaults to `true`
+   * @param ...args - The list of arguments needed to invoke `modifierType.apply`
    * @returns the list of all modifiers that matched `modifierType` and were applied.
    */
   applyShuffledModifiers<T extends PersistentModifier>(
@@ -3397,9 +3396,9 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Apply all modifiers that match `modifierType`
-   * @param modifierType The type of modifier to apply; must extend {@linkcode PersistentModifier}
-   * @param player Whether to search the player (`true`) or the enemy (`false`); Defaults to `true`
-   * @param ...args The list of arguments needed to invoke `modifierType.apply`
+   * @param modifierType - The type of modifier to apply; must extend {@linkcode PersistentModifier}
+   * @param player - Whether to search the player (`true`) or the enemy (`false`); Defaults to `true`
+   * @param ...args - The list of arguments needed to invoke `modifierType.apply`
    * @returns the list of all modifiers that matched `modifierType` and were applied.
    */
   applyModifiers<T extends PersistentModifier>(
@@ -3432,9 +3431,9 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Apply the first modifier that matches `modifierType`
-   * @param modifierType The type of modifier to apply; must extend {@linkcode PersistentModifier}
-   * @param player Whether to search the player (`true`) or the enemy (`false`); Defaults to `true`
-   * @param ...args The list of arguments needed to invoke `modifierType.apply`
+   * @param modifierType - The type of modifier to apply; must extend {@linkcode PersistentModifier}
+   * @param player - Whether to search the player (`true`) or the enemy (`false`); Defaults to `true`
+   * @param ...args - The list of arguments needed to invoke `modifierType.apply`
    * @returns the first modifier that matches `modifierType` and was applied; return `null` if none matched
    */
   applyModifier<T extends PersistentModifier>(
@@ -3606,7 +3605,7 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Initialized the 2nd phase of the final boss (e.g. form-change for Eternatus)
-   * @param pokemon The (enemy) pokemon
+   * @param pokemon - The (enemy) pokemon
    */
   initFinalBossPhaseTwo(pokemon: Pokemon): void {
     if (pokemon instanceof EnemyPokemon && pokemon.isBoss() && !pokemon.formIndex && pokemon.bossSegmentIndex < 1) {
@@ -3644,10 +3643,10 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Updates Exp and level values for Player's party, adding new level up phases as required
-   * @param expValue raw value of exp to split among participants, OR the base multiplier to use with waveIndex
-   * @param pokemonDefeated If true, will increment Macho Brace stacks and give the party Pokemon friendship increases
-   * @param useWaveIndexMultiplier Default false. If true, will multiply expValue by a scaling waveIndex multiplier. Not needed if expValue is already scaled by level/wave
-   * @param pokemonParticipantIds Participants. If none are defined, no exp will be given. To spread evenly among the party, should pass all ids of party members.
+   * @param expValue - raw value of exp to split among participants, OR the base multiplier to use with waveIndex
+   * @param pokemonDefeated - If true, will increment Macho Brace stacks and give the party Pokemon friendship increases
+   * @param useWaveIndexMultiplier - Default false. If true, will multiply expValue by a scaling waveIndex multiplier. Not needed if expValue is already scaled by level/wave
+   * @param pokemonParticipantIds - Participants. If none are defined, no exp will be given. To spread evenly among the party, should pass all ids of party members.
    */
   applyPartyExp(
     expValue: number,
@@ -3830,8 +3829,8 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Loads or generates a mystery encounter
-   * @param encounterType used to load session encounter when restarting game, etc.
-   * @param canBypass optional boolean to indicate that the request is coming from a function that needs to access a Mystery Encounter outside of gameplay requirements
+   * @param encounterType - used to load session encounter when restarting game, etc.
+   * @param canBypass - optional boolean to indicate that the request is coming from a function that needs to access a Mystery Encounter outside of gameplay requirements
    * @returns
    */
   getMysteryEncounter(encounterType?: MysteryEncounterType, canBypass?: boolean): MysteryEncounter {

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -451,8 +451,8 @@ export default class Battle {
 
   /**
    * Generates a random number using the current battle's seed. Calls {@linkcode randSeedInt}
-   * @param range How large of a range of random numbers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
-   * @param min The minimum integer to pick, default `0`
+   * @param range - How large of a range of random numbers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
+   * @param min - The minimum integer to pick, default `0`
    * @returns A random integer between {@linkcode min} and ({@linkcode min} + {@linkcode range} - 1)
    */
   randSeedInt(range: number, min = 0): number {
@@ -545,9 +545,9 @@ export class FixedBattleConfig {
 
 /**
  * Helper function to generate a random trainer for evil team trainers and the elite 4/champion
- * @param trainerPool The TrainerType or list of TrainerTypes that can possibly be generated
- * @param randomGender whether or not to randomly (50%) generate a female trainer (for use with evil team grunts)
- * @param seedOffset the seed offset to use for the random generation of the trainer
+ * @param trainerPool - The TrainerType or list of TrainerTypes that can possibly be generated
+ * @param randomGender - whether or not to randomly (50%) generate a female trainer (for use with evil team grunts)
+ * @param seedOffset - the seed offset to use for the random generation of the trainer
  * @returns the generated trainer
  */
 export function getRandomTrainerFunc(

--- a/src/data/abilities/ability-class.ts
+++ b/src/data/abilities/ability-class.ts
@@ -51,7 +51,7 @@ export class Ability implements Localizable {
 
   /**
    * Get all ability attributes that match `attrType`
-   * @param attrType any attribute that extends {@linkcode AbAttr}
+   * @param attrType - any attribute that extends {@linkcode AbAttr}
    * @returns Array of attributes that match `attrType`, Empty Array if none match.
    */
   getAttrs<T extends AbAttr>(attrType: Constructor<T>): T[] {
@@ -60,7 +60,7 @@ export class Ability implements Localizable {
 
   /**
    * Check if an ability has an attribute that matches `attrType`
-   * @param attrType any attribute that extends {@linkcode AbAttr}
+   * @param attrType - any attribute that extends {@linkcode AbAttr}
    * @returns true if the ability has attribute `attrType`
    */
   hasAttr<T extends AbAttr>(attrType: Constructor<T>): boolean {

--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -99,9 +99,9 @@ export class DoubleBattleChanceAbAttr extends AbAttr {
 
   /**
    * Increases the chance of a double battle occurring
-   * @param args [0] {@linkcode NumberHolder} for double battle chance
+   * @param args - [0] {@linkcode NumberHolder} for double battle chance
    */
-  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _cancelled: BooleanHolder, args: any[]): void {
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _cancelled: BooleanHolder, args: [NumberHolder, ...any]): void {
     const doubleBattleChance = args[0] as NumberHolder;
     // This is divided because the chance is generated as a number from 0 to doubleBattleChance.value using Utils.randSeedInt
     // A double battle will initiate if the generated number is 0
@@ -167,7 +167,7 @@ export class ClearWeatherAbAttr extends AbAttr {
   private weather: WeatherType[];
 
   /**
-   * @param weather {@linkcode WeatherType[]} - the weather to be removed
+   * @param weather - the weather to be removed
    */
   constructor(weather: WeatherType[]) {
     super(true);
@@ -193,7 +193,7 @@ export class ClearTerrainAbAttr extends AbAttr {
   private terrain: TerrainType[];
 
   /**
-   * @param terrain {@linkcode TerrainType[]} - the terrain to be removed
+   * @param terrain - the terrain to be removed
    */
   constructor(terrain: TerrainType[]) {
     super(true);
@@ -329,7 +329,6 @@ export class ReceivedTypeDamageMultiplierAbAttr extends ReceivedMoveDamageMultip
 
 /**
  * Determines whether a Pokemon is immune to a move because of an ability.
- * @extends PreDefendAbAttr
  * @see {@linkcode applyPreDefend}
  * @see {@linkcode getCondition}
  */
@@ -349,16 +348,15 @@ export class TypeImmunityAbAttr extends PreDefendAbAttr {
   }
 
   /**
-   * Applies immunity if this ability grants immunity to the type of the given move.
-   * @param pokemon {@linkcode Pokemon} The defending Pokemon.
-   * @param passive - Whether the ability is passive.
-   * @param attacker {@linkcode Pokemon} The attacking Pokemon.
-   * @param move {@linkcode Move} The attacking move.
-   * @param cancelled {@linkcode BooleanHolder} - A holder for a boolean value indicating if the move was cancelled.
-   * @param args [0] {@linkcode NumberHolder} gets set to 0 if move is immuned by an ability.
-   * @param args [1] - Whether the move is simulated.
+   * Applies immunity if this ability grants immunity to the type of the given move
+   * @param pokemon - The defending Pokemon
+   * @param passive - Whether the ability is passive
+   * @param attacker - The attacking Pokemon
+   * @param move -  The attacking move
+   * @param cancelled - A holder for a boolean value indicating if the move was cancelled.
+   * @param args - args[0] is a {@linkcode NumberHolder} that is set to 0 if the ability makes the target immune to the move.
    */
-  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: any[]): void {
+  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: [NumberHolder, ...any]): void {
     (args[0] as NumberHolder).value = 0;
   }
 
@@ -488,7 +486,6 @@ export class NonSuperEffectiveImmunityAbAttr extends TypeImmunityAbAttr {
 /**
  * Attribute implementing the effects of {@link https://bulbapedia.bulbagarden.net/wiki/Tera_Shell_(Ability) | Tera Shell}
  * When the source is at full HP, incoming attacks will have a maximum 0.5x type effectiveness multiplier.
- * @extends PreDefendAbAttr
  */
 export class FullHpResistTypeAbAttr extends PreDefendAbAttr {
 
@@ -499,13 +496,13 @@ export class FullHpResistTypeAbAttr extends PreDefendAbAttr {
 
   /**
    * Reduces a type multiplier to 0.5 if the source is at full HP.
-   * @param pokemon {@linkcode Pokemon} the Pokemon with this ability
-   * @param passive n/a
-   * @param simulated n/a (this doesn't change game state)
-   * @param attacker n/a
-   * @param move {@linkcode Move} the move being used on the source
-   * @param cancelled n/a
-   * @param args `[0]` a container for the move's current type effectiveness multiplier
+   * @param pokemon - the Pokemon with this ability
+   * @param passive - n/a
+   * @param simulated - n/a (this doesn't change game state)
+   * @param attacker - n/a
+   * @param move - the move being used on the source
+   * @param cancelled - n/a
+   * @param args - `[0]` a container for the move's current type effectiveness multiplier
    */
   override applyPreDefend(
     pokemon: Pokemon,
@@ -608,7 +605,6 @@ export class MoveImmunityAbAttr extends PreDefendAbAttr {
  * Reduces the accuracy of status moves used against the Pokémon with this ability to 50%.
  * Used by Wonder Skin.
  *
- * @extends PreDefendAbAttr
  */
 export class WonderSkinAbAttr extends PreDefendAbAttr {
 
@@ -648,7 +644,6 @@ export class MoveImmunityStatStageChangeAbAttr extends MoveImmunityAbAttr {
 }
 /**
  * Class for abilities that make drain moves deal damage to user instead of healing them.
- * @extends PostDefendAbAttr
  * @see {@linkcode applyPostDefend}
  */
 export class ReverseDrainAbAttr extends PostDefendAbAttr {
@@ -661,12 +656,12 @@ export class ReverseDrainAbAttr extends PostDefendAbAttr {
    * Determines if a damage and draining move was used to check if this ability should stop the healing.
    * Examples include: Absorb, Draining Kiss, Bitter Blade, etc.
    * Also displays a message to show this ability was activated.
-   * @param pokemon {@linkcode Pokemon} with this ability
-   * @param _passive N/A
-   * @param attacker {@linkcode Pokemon} that is attacking this Pokemon
-   * @param move {@linkcode PokemonMove} that is being used
-   * @param _hitResult N/A
-   * @param _args N/A
+   * @param pokemon - with this ability
+   * @param _passive - N/A
+   * @param attacker - that is attacking this Pokemon
+   * @param move - that is being used
+   * @param _hitResult - N/A
+   * @param _args - N/A
    */
   override applyPostDefend(pokemon: Pokemon, _passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, _hitResult: HitResult, _args: any[]): void {
     if (!simulated) {
@@ -954,7 +949,6 @@ export class PostDefendContactDamageAbAttr extends PostDefendAbAttr {
  * and the defending pokemon if the move makes physical contact and neither pokemon
  * already has the Perish Song tag.
  * @class PostDefendPerishSongAbAttr
- * @extends {PostDefendAbAttr}
  */
 export class PostDefendPerishSongAbAttr extends PostDefendAbAttr {
   private turns: number;
@@ -1126,7 +1120,6 @@ export class PreAttackAbAttr extends AbAttr {
 
 /**
  * Modifies moves additional effects with multipliers, ie. Sheer Force, Serene Grace.
- * @extends AbAttr
  * @see {@linkcode apply}
  */
 export class MoveEffectChanceMultiplierAbAttr extends AbAttr {
@@ -1143,10 +1136,10 @@ export class MoveEffectChanceMultiplierAbAttr extends AbAttr {
   }
 
   /**
-   * @param args [0]: {@linkcode NumberHolder} Move additional effect chance. Has to be higher than or equal to 0.
+   * @param args - [0]: {@linkcode NumberHolder} Move additional effect chance. Has to be higher than or equal to 0.
    *             [1]: {@linkcode Moves } Move used by the ability user.
    */
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: [NumberHolder, NumberHolder, ...any]): void {
     (args[0] as NumberHolder).value *= this.chanceMultiplier;
     (args[0] as NumberHolder).value = Math.min((args[0] as NumberHolder).value, 100);
   }
@@ -1154,7 +1147,6 @@ export class MoveEffectChanceMultiplierAbAttr extends AbAttr {
 
 /**
  * Sets incoming moves additional effect chance to zero, ignoring all effects from moves. ie. Shield Dust.
- * @extends PreDefendAbAttr
  * @see {@linkcode applyPreDefend}
  */
 export class IgnoreMoveEffectsAbAttr extends PreDefendAbAttr {
@@ -1167,9 +1159,9 @@ export class IgnoreMoveEffectsAbAttr extends PreDefendAbAttr {
   }
 
   /**
-   * @param args [0]: {@linkcode NumberHolder} Move additional effect chance.
+   * @param args - args[0] Holds the additional effect chance
    */
-  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: any[]): void {
+  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: [NumberHolder, ...any]): void {
     (args[0] as NumberHolder).value = 0;
   }
 }
@@ -1219,13 +1211,13 @@ export class FieldMultiplyStatAbAttr extends AbAttr {
 
   /**
    * applyFieldStat: Tries to multiply a Pokemon's Stat
-   * @param pokemon {@linkcode Pokemon} the Pokemon using this ability
-   * @param passive {@linkcode boolean} unused
-   * @param stat {@linkcode Stat} the type of the checked stat
-   * @param statValue {@linkcode NumberHolder} the value of the checked stat
-   * @param checkedPokemon {@linkcode Pokemon} the Pokemon this ability is targeting
-   * @param hasApplied {@linkcode BooleanHolder} whether or not another multiplier has been applied to this stat
-   * @param args {any[]} unused
+   * @param pokemon - the Pokemon using this ability
+   * @param passive - unused
+   * @param stat - The type of the checked stat
+   * @param statValue - The value of the checked stat
+   * @param checkedPokemon - The Pokemon this ability is targeting
+   * @param hasApplied - Whether or not another multiplier has been applied to this stat
+   * @param args - unused
    */
   applyFieldStat(pokemon: Pokemon, passive: boolean, simulated: boolean, stat: Stat, statValue: NumberHolder, checkedPokemon: Pokemon, hasApplied: BooleanHolder, args: any[]): void {
     statValue.value *= this.multiplier;
@@ -1307,7 +1299,7 @@ export class PokemonTypeChangeAbAttr extends PreAttackAbAttr {
 
 /**
  * Class for abilities that convert single-strike moves to two-strike moves (i.e. Parental Bond).
- * @param damageMultiplier the damage multiplier for the second strike, relative to the first.
+ * @param damageMultiplier - the damage multiplier for the second strike, relative to the first.
  */
 export class AddSecondStrikeAbAttr extends PreAttackAbAttr {
   private damageMultiplier: number;
@@ -1325,11 +1317,11 @@ export class AddSecondStrikeAbAttr extends PreAttackAbAttr {
   /**
    * If conditions are met, this doubles the move's hit count (via args[1])
    * or multiplies the damage of secondary strikes (via args[2])
-   * @param pokemon the {@linkcode Pokemon} using the move
-   * @param passive n/a
-   * @param defender n/a
-   * @param move the {@linkcode Move} used by the ability source
-   * @param args Additional arguments:
+   * @param pokemon - the {@linkcode Pokemon} using the move
+   * @param passive - n/a
+   * @param defender - n/a
+   * @param move - the {@linkcode Move} used by the ability source
+   * @param args - Additional arguments:
    * - `[0]` the number of strikes this move currently has ({@linkcode NumberHolder})
    * - `[1]` the damage multiplier for the current strike ({@linkcode NumberHolder})
    */
@@ -1349,8 +1341,8 @@ export class AddSecondStrikeAbAttr extends PreAttackAbAttr {
 /**
  * Class for abilities that boost the damage of moves
  * For abilities that boost the base power of moves, see VariableMovePowerAbAttr
- * @param damageMultiplier the amount to multiply the damage by
- * @param condition the condition for this ability to be applied
+ * @param damageMultiplier - the amount to multiply the damage by
+ * @param condition - the condition for this ability to be applied
  */
 export class DamageBoostAbAttr extends PreAttackAbAttr {
   private damageMultiplier: number;
@@ -1368,11 +1360,11 @@ export class DamageBoostAbAttr extends PreAttackAbAttr {
 
   /**
    *
-   * @param pokemon the attacker pokemon
-   * @param passive N/A
-   * @param defender the target pokemon
-   * @param move the move used by the attacker pokemon
-   * @param args Utils.NumberHolder as damage
+   * @param pokemon - the attacker pokemon
+   * @param passive - N/A
+   * @param defender - the target pokemon
+   * @param move - the move used by the attacker pokemon
+   * @param args - Utils.NumberHolder as damage
    */
   override applyPreAttack(pokemon: Pokemon, passive: boolean, simulated: boolean, defender: Pokemon, move: Move, args: any[]): void {
     const power = args[0] as NumberHolder;
@@ -1417,15 +1409,14 @@ export class LowHpMoveTypePowerBoostAbAttr extends MoveTypePowerBoostAbAttr {
 
 /**
  * Abilities which cause a variable amount of power increase.
- * @extends VariableMovePowerAbAttr
  * @see {@link applyPreAttack}
  */
 export class VariableMovePowerBoostAbAttr extends VariableMovePowerAbAttr {
   private mult: (user: Pokemon, target: Pokemon, move: Move) => number;
 
   /**
-   * @param mult A function which takes the user, target, and move, and returns the power multiplier. 1 means no multiplier.
-   * @param {boolean} showAbility Whether to show the ability when it activates.
+   * @param mult - A function which takes the user, target, and move, and returns the power multiplier. 1 means no multiplier.
+   * @param showAbility - Whether to show the ability when it activates.
    */
   constructor(mult: (user: Pokemon, target: Pokemon, move: Move) => number, showAbility = true) {
     super(showAbility);
@@ -1444,7 +1435,6 @@ export class VariableMovePowerBoostAbAttr extends VariableMovePowerAbAttr {
 
 /**
  * Boosts the power of a Pokémon's move under certain conditions.
- * @extends AbAttr
  */
 export class FieldMovePowerBoostAbAttr extends AbAttr {
   // TODO: Refactor this class? It extends from base AbAttr but has preAttack methods and gets called directly instead of going through applyAbAttrsInternal
@@ -1474,7 +1464,6 @@ export class FieldMovePowerBoostAbAttr extends AbAttr {
 
 /**
  * Boosts the power of a specific type of move.
- * @extends FieldMovePowerBoostAbAttr
  */
 export class PreAttackFieldMoveTypePowerBoostAbAttr extends FieldMovePowerBoostAbAttr {
   /**
@@ -1488,19 +1477,16 @@ export class PreAttackFieldMoveTypePowerBoostAbAttr extends FieldMovePowerBoostA
 
 /**
  * Boosts the power of a specific type of move for all Pokemon in the field.
- * @extends PreAttackFieldMoveTypePowerBoostAbAttr
  */
 export class FieldMoveTypePowerBoostAbAttr extends PreAttackFieldMoveTypePowerBoostAbAttr { }
 
 /**
  * Boosts the power of a specific type of move for the user and its allies.
- * @extends PreAttackFieldMoveTypePowerBoostAbAttr
  */
 export class UserFieldMoveTypePowerBoostAbAttr extends PreAttackFieldMoveTypePowerBoostAbAttr { }
 
 /**
  * Boosts the power of moves in specified categories.
- * @extends FieldMovePowerBoostAbAttr
  */
 export class AllyMoveCategoryPowerBoostAbAttr extends FieldMovePowerBoostAbAttr {
   /**
@@ -1643,7 +1629,6 @@ export class AllyStatMultiplierAbAttr extends AbAttr {
 
 /**
  * Ability attribute for Gorilla Tactics
- * @extends PostAttackAbAttr
  */
 export class GorillaTacticsAbAttr extends PostAttackAbAttr {
   constructor() {
@@ -1664,13 +1649,13 @@ export class GorillaTacticsAbAttr extends PostAttackAbAttr {
 
   /**
    *
-   * @param {Pokemon} pokemon the {@linkcode Pokemon} with this ability
-   * @param passive n/a
-   * @param simulated whether the ability is being simulated
-   * @param defender n/a
-   * @param move n/a
-   * @param hitResult n/a
-   * @param args n/a
+   * @param pokemon - the {@linkcode Pokemon} with this ability
+   * @param passive - n/a
+   * @param simulated - whether the ability is being simulated
+   * @param defender - n/a
+   * @param move - n/a
+   * @param hitResult - n/a
+   * @param args - n/a
    */
   override applyPostAttack(
     pokemon: Pokemon,
@@ -1900,11 +1885,11 @@ export class PostSetStatusAbAttr extends AbAttr {
 
   /**
    * Does nothing after a status condition is set.
-   * @param pokemon {@linkcode Pokemon} that status condition was set on.
-   * @param sourcePokemon {@linkcode Pokemon} that that set the status condition. Is `null` if status was not set by a Pokemon.
-   * @param passive Whether this ability is a passive.
-   * @param effect {@linkcode StatusEffect} that was set.
-   * @param args Set of unique arguments needed by this attribute.
+   * @param pokemon - that status condition was set on.
+   * @param sourcePokemon - that that set the status condition. Is `null` if status was not set by a Pokemon.
+   * @param passive - Whether this ability is a passive.
+   * @param effect - that was set.
+   * @param args - Set of unique arguments needed by this attribute.
    */
   applyPostSetStatus(
     pokemon: Pokemon,
@@ -1938,11 +1923,11 @@ export class SynchronizeStatusAbAttr extends PostSetStatusAbAttr {
   /**
    * If the `StatusEffect` that was set is Burn, Paralysis, Poison, or Toxic, and the status
    * was set by a source Pokemon, set the source Pokemon's status to the same `StatusEffect`.
-   * @param pokemon {@linkcode Pokemon} that status condition was set on.
-   * @param sourcePokemon {@linkcode Pokemon} that that set the status condition. Is null if status was not set by a Pokemon.
-   * @param passive Whether this ability is a passive.
-   * @param effect {@linkcode StatusEffect} that was set.
-   * @param args Set of unique arguments needed by this attribute.
+   * @param pokemon - that status condition was set on.
+   * @param sourcePokemon - that that set the status condition. Is null if status was not set by a Pokemon.
+   * @param passive - Whether this ability is a passive.
+   * @param effect - that was set.
+   * @param args - Set of unique arguments needed by this attribute.
    */
   override applyPostSetStatus(pokemon: Pokemon, sourcePokemon: Pokemon | null = null, passive: boolean, effect: StatusEffect, simulated: boolean, args: any[]): void {
     if (!simulated && sourcePokemon) {
@@ -2045,7 +2030,7 @@ export class CopyFaintedAllyAbilityAbAttr extends PostKnockOutAbAttr {
 
 /**
  * Ability attribute for ignoring the opponent's stat changes
- * @param stats the stats that should be ignored
+ * @param stats - the stats that should be ignored
  */
 export class IgnoreOpponentStatStagesAbAttr extends AbAttr {
   private stats: readonly BattleStat[];
@@ -2062,11 +2047,11 @@ export class IgnoreOpponentStatStagesAbAttr extends AbAttr {
 
   /**
    * Modifies a BooleanHolder and returns the result to see if a stat is ignored or not
-   * @param _pokemon n/a
-   * @param _passive n/a
-   * @param simulated n/a
-   * @param _cancelled n/a
-   * @param args A BooleanHolder that represents whether or not to ignore a stat's stat changes
+   * @param _pokemon - n/a
+   * @param _passive - n/a
+   * @param simulated - n/a
+   * @param _cancelled - n/a
+   * @param args - A BooleanHolder that represents whether or not to ignore a stat's stat changes
    */
   override apply(_pokemon: Pokemon, _passive: boolean, simulated: boolean, _cancelled: BooleanHolder, args: any[]): void {
     (args[1] as BooleanHolder).value = true;
@@ -2136,9 +2121,9 @@ export class PostSummonAbAttr extends AbAttr {
 
   /**
    * Applies ability post summon (after switching in)
-   * @param pokemon {@linkcode Pokemon} with this ability
-   * @param passive Whether this ability is a passive
-   * @param args Set of unique arguments needed by this attribute
+   * @param pokemon - with this ability
+   * @param passive - Whether this ability is a passive
+   * @param args - Set of unique arguments needed by this attribute
    */
   applyPostSummon(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): void {}
 }
@@ -2155,7 +2140,7 @@ export class PostSummonRemoveArenaTagAbAttr extends PostSummonAbAttr {
   private arenaTags: ArenaTagType[];
 
   /**
-   * @param arenaTags {@linkcode ArenaTagType[]} - the arena tags to be removed
+   * @param arenaTags - the arena tags to be removed
    */
   constructor(arenaTags: ArenaTagType[]) {
     super(true);
@@ -2365,9 +2350,9 @@ export class PostSummonAllyHealAbAttr extends PostSummonAbAttr {
 /**
  * Resets an ally's temporary stat boots to zero with no regard to
  * whether this is a positive or negative change
- * @param pokemon The {@link Pokemon} with this {@link AbAttr}
- * @param passive N/A
- * @param args N/A
+ * @param pokemon - The {@link Pokemon} with this {@link AbAttr}
+ * @param passive - N/A
+ * @param args - N/A
  * @returns if the move was successful
  */
 export class PostSummonClearAllyStatStagesAbAttr extends PostSummonAbAttr {
@@ -2395,7 +2380,6 @@ export class PostSummonClearAllyStatStagesAbAttr extends PostSummonAbAttr {
  * Download raises either the Attack stat or Special Attack stat by one stage depending on the foe's currently lowest defensive stat:
  * it will raise Attack if the foe's current Defense is lower than its current Special Defense stat;
  * otherwise, it will raise Special Attack.
- * @extends PostSummonAbAttr
  * @see {applyPostSummon}
  */
 export class DownloadAbAttr extends PostSummonAbAttr {
@@ -2422,9 +2406,9 @@ export class DownloadAbAttr extends PostSummonAbAttr {
   /**
    * Checks to see if it is the opening turn (starting a new game), if so, Download won't work. This is because Download takes into account
    * vitamins and items, so it needs to use the Stat and the stat alone.
-   * @param {Pokemon} pokemon Pokemon that is using the move, as well as seeing the opposing pokemon.
-   * @param {boolean} passive N/A
-   * @param {any[]} args N/A
+   * @param pokemon - Pokemon that is using the move, as well as seeing the opposing pokemon.
+   * @param passive - N/A
+   * @param args - N/A
    */
   override applyPostSummon(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): void {
     if (this.enemyDef < this.enemySpDef) {
@@ -2727,7 +2711,6 @@ export class PostSummonTransformAbAttr extends PostSummonAbAttr {
 /**
  * Reverts weather-based forms to their normal forms when the user is summoned.
  * Used by Cloud Nine and Air Lock.
- * @extends PostSummonAbAttr
  */
 export class PostSummonWeatherSuppressedFormChangeAbAttr extends PostSummonAbAttr {
   override canApplyPostSummon(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): boolean {
@@ -2736,9 +2719,9 @@ export class PostSummonWeatherSuppressedFormChangeAbAttr extends PostSummonAbAtt
 
   /**
    * Triggers {@linkcode Arena.triggerWeatherBasedFormChangesToNormal | triggerWeatherBasedFormChangesToNormal}
-   * @param {Pokemon} pokemon the Pokemon with this ability
-   * @param passive n/a
-   * @param args n/a
+   * @param pokemon - the Pokemon with this ability
+   * @param passive - n/a
+   * @param args - n/a
    */
   override applyPostSummon(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): void {
     if (!simulated) {
@@ -2750,7 +2733,6 @@ export class PostSummonWeatherSuppressedFormChangeAbAttr extends PostSummonAbAtt
 /**
  * Triggers weather-based form change when summoned into an active weather.
  * Used by Forecast and Flower Gift.
- * @extends PostSummonAbAttr
  */
 export class PostSummonFormChangeByWeatherAbAttr extends PostSummonAbAttr {
   private ability: Abilities;
@@ -2772,9 +2754,9 @@ export class PostSummonFormChangeByWeatherAbAttr extends PostSummonAbAttr {
    * {@linkcode SpeciesFormChange.SpeciesFormChangeWeatherTrigger | SpeciesFormChangeWeatherTrigger} and
    * {@linkcode SpeciesFormChange.SpeciesFormChangeWeatherTrigger | SpeciesFormChangeRevertWeatherFormTrigger} if it
    * is the specific Pokemon and ability
-   * @param {Pokemon} pokemon the Pokemon with this ability
-   * @param passive n/a
-   * @param args n/a
+   * @param pokemon - the Pokemon with this ability
+   * @param passive - n/a
+   * @param args - n/a
    */
   override applyPostSummon(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): void {
     if (!simulated) {
@@ -2853,9 +2835,9 @@ export class PreSwitchOutResetStatusAbAttr extends PreSwitchOutAbAttr {
  */
 export class PreSwitchOutClearWeatherAbAttr extends PreSwitchOutAbAttr {
   /**
-   * @param pokemon The {@linkcode Pokemon} with the ability
-   * @param passive N/A
-   * @param args N/A
+   * @param pokemon - The {@linkcode Pokemon} with the ability
+   * @param passive - N/A
+   * @param args - N/A
    * @returns {boolean} Returns true if the weather clears, otherwise false.
    */
   override applyPreSwitchOut(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): boolean {
@@ -2928,7 +2910,6 @@ export class PreSwitchOutHealAbAttr extends PreSwitchOutAbAttr {
 
 /**
  * Attribute for form changes that occur on switching out
- * @extends PreSwitchOutAbAttr
  * @see {@linkcode applyPreSwitchOut}
  */
 export class PreSwitchOutFormChangeAbAttr extends PreSwitchOutAbAttr {
@@ -2946,9 +2927,9 @@ export class PreSwitchOutFormChangeAbAttr extends PreSwitchOutAbAttr {
 
   /**
    * On switch out, trigger the form change to the one defined in the ability
-   * @param pokemon The pokemon switching out and changing form {@linkcode Pokemon}
-   * @param passive N/A
-   * @param args N/A
+   * @param pokemon - The pokemon switching out and changing form {@linkcode Pokemon}
+   * @param passive - N/A
+   * @param args - N/A
    */
   override applyPreSwitchOut(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): void {
     if (!simulated) {
@@ -2998,9 +2979,9 @@ export class PreLeaveFieldClearWeatherAbAttr extends PreLeaveFieldAbAttr {
   }
 
   /**
-   * @param pokemon The {@linkcode Pokemon} with the ability
-   * @param passive N/A
-   * @param args N/A
+   * @param pokemon - The {@linkcode Pokemon} with the ability
+   * @param passive - N/A
+   * @param args - N/A
    */
   override applyPreLeaveField(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): void {
     if (!simulated) {
@@ -3058,11 +3039,11 @@ export class ReflectStatStageChangeAbAttr extends PreStatStageChangeAbAttr {
 
   /**
    * Apply the {@linkcode ReflectStatStageChangeAbAttr} to an interaction
-   * @param _pokemon The user pokemon
-   * @param _passive N/A
-   * @param simulated `true` if the ability is being simulated by the AI
-   * @param stat the {@linkcode BattleStat} being affected
-   * @param cancelled The {@linkcode BooleanHolder} that will be set to true due to reflection
+   * @param _pokemon - The user pokemon
+   * @param _passive - N/A
+   * @param simulated - `true` if the ability is being simulated by the AI
+   * @param stat - the {@linkcode BattleStat} being affected
+   * @param cancelled - The {@linkcode BooleanHolder} that will be set to true due to reflection
    * @param args
    */
   override applyPreStatStageChange(_pokemon: Pokemon, _passive: boolean, simulated: boolean, stat: BattleStat, cancelled: BooleanHolder, args: any[]): void {
@@ -3106,8 +3087,8 @@ export class ProtectStatAbAttr extends PreStatStageChangeAbAttr {
    * @param _pokemon
    * @param _passive
    * @param simulated
-   * @param stat the {@linkcode BattleStat} being affected
-   * @param cancelled The {@linkcode BooleanHolder} that will be set to true if the stat is protected
+   * @param stat - the {@linkcode BattleStat} being affected
+   * @param cancelled - The {@linkcode BooleanHolder} that will be set to true if the stat is protected
    * @param _args
    */
   override applyPreStatStageChange(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, stat: BattleStat, cancelled: BooleanHolder, _args: any[]): void {
@@ -3127,7 +3108,6 @@ export class ProtectStatAbAttr extends PreStatStageChangeAbAttr {
  * This attribute applies confusion to the target whenever the user
  * directly poisons them with a move, e.g. Poison Puppeteer.
  * Called in {@linkcode StatusEffectAttr}.
- * @extends PostAttackAbAttr
  * @see {@linkcode applyPostAttack}
  */
 export class ConfusionOnStatusEffectAbAttr extends PostAttackAbAttr {
@@ -3148,12 +3128,12 @@ export class ConfusionOnStatusEffectAbAttr extends PostAttackAbAttr {
 
   /**
    * Applies confusion to the target pokemon.
-   * @param pokemon {@link Pokemon} attacking
-   * @param passive N/A
-   * @param defender {@link Pokemon} defending
-   * @param move {@link Move} used to apply status effect and confusion
-   * @param hitResult N/A
-   * @param args [0] {@linkcode StatusEffect} applied by move
+   * @param pokemon - attacking
+   * @param passive - N/A
+   * @param defender - defending
+   * @param move - used to apply status effect and confusion
+   * @param hitResult - N/A
+   * @param args - [0] {@linkcode StatusEffect} applied by move
    */
   override applyPostAttack(pokemon: Pokemon, passive: boolean, simulated: boolean, defender: Pokemon, move: Move, hitResult: HitResult, args: any[]): void {
     if (!simulated) {
@@ -3232,13 +3212,11 @@ export class PreSetStatusEffectImmunityAbAttr extends PreSetStatusAbAttr {
 
 /**
  * Provides immunity to status effects to the user.
- * @extends PreSetStatusEffectImmunityAbAttr
  */
 export class StatusEffectImmunityAbAttr extends PreSetStatusEffectImmunityAbAttr { }
 
 /**
  * Provides immunity to status effects to the user's field.
- * @extends PreSetStatusEffectImmunityAbAttr
  */
 export class UserFieldStatusEffectImmunityAbAttr extends PreSetStatusEffectImmunityAbAttr { }
 
@@ -3246,25 +3224,24 @@ export class UserFieldStatusEffectImmunityAbAttr extends PreSetStatusEffectImmun
  * Conditionally provides immunity to status effects to the user's field.
  *
  * Used by {@linkcode Abilities.FLOWER_VEIL | Flower Veil}.
- * @extends UserFieldStatusEffectImmunityAbAttr
  *
  */
 export class ConditionalUserFieldStatusEffectImmunityAbAttr extends UserFieldStatusEffectImmunityAbAttr {
   /**
    * The condition for the field immunity to be applied.
-   * @param target The target of the status effect
-   * @param source The source of the status effect
+   * @param target - The target of the status effect
+   * @param source - The source of the status effect
    */
   protected condition: (target: Pokemon, source: Pokemon | null) => boolean;
 
   /**
    * Evaluate the condition to determine if the {@linkcode ConditionalUserFieldStatusEffectImmunityAbAttr} can be applied.
-   * @param pokemon The pokemon with the ability
-   * @param passive unused
-   * @param simulated Whether the ability is being simulated
-   * @param effect The status effect being applied
-   * @param cancelled Holds whether the status effect was cancelled by a prior effect
-   * @param args `Args[0]` is the target of the status effect, `Args[1]` is the source.
+   * @param pokemon - The pokemon with the ability
+   * @param passive - unused
+   * @param simulated - Whether the ability is being simulated
+   * @param effect - The status effect being applied
+   * @param cancelled - Holds whether the status effect was cancelled by a prior effect
+   * @param args - `Args[0]` is the target of the status effect, `Args[1]` is the source.
    * @returns Whether the ability can be applied to cancel the status effect.
    */
   override canApplyPreSetStatus(pokemon: Pokemon, passive: boolean, simulated: boolean, effect: StatusEffect, cancelled: BooleanHolder, args: [Pokemon, Pokemon | null, ...any]): boolean {
@@ -3297,12 +3274,12 @@ export class ConditionalUserFieldProtectStatAbAttr extends PreStatStageChangeAbA
 
   /**
    * Determine whether the {@linkcode ConditionalUserFieldProtectStatAbAttr} can be applied.
-   * @param pokemon The pokemon with the ability
-   * @param passive unused
-   * @param simulated Unused
-   * @param stat The stat being affected
-   * @param cancelled Holds whether the stat change was already prevented.
-   * @param args Args[0] is the target pokemon of the stat change.
+   * @param pokemon - The pokemon with the ability
+   * @param passive - unused
+   * @param simulated - Unused
+   * @param stat - The stat being affected
+   * @param cancelled - Holds whether the stat change was already prevented.
+   * @param args - Args[0] is the target pokemon of the stat change.
    * @returns 
    */
   override canApplyPreStatStageChange(pokemon: Pokemon, passive: boolean, simulated: boolean, stat: BattleStat, cancelled: BooleanHolder, args: [Pokemon, ...any]): boolean {
@@ -3315,12 +3292,12 @@ export class ConditionalUserFieldProtectStatAbAttr extends PreStatStageChangeAbA
 
   /**
    * Apply the {@linkcode ConditionalUserFieldStatusEffectImmunityAbAttr} to an interaction
-   * @param _pokemon The pokemon the stat change is affecting (unused)
-   * @param _passive unused
-   * @param _simulated unused
-   * @param stat The stat being affected
-   * @param cancelled Will be set to true if the stat change is prevented
-   * @param _args unused
+   * @param _pokemon - The pokemon the stat change is affecting (unused)
+   * @param _passive - unused
+   * @param _simulated - unused
+   * @param stat - The stat being affected
+   * @param cancelled - Will be set to true if the stat change is prevented
+   * @param _args - unused
    */
   override applyPreStatStageChange(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _stat: BattleStat, cancelled: BooleanHolder, _args: any[]): void {
     cancelled.value = true;
@@ -3384,13 +3361,11 @@ export class PreApplyBattlerTagImmunityAbAttr extends PreApplyBattlerTagAbAttr {
 
 /**
  * Provides immunity to BattlerTags {@linkcode BattlerTag} to the user.
- * @extends PreApplyBattlerTagImmunityAbAttr
  */
 export class BattlerTagImmunityAbAttr extends PreApplyBattlerTagImmunityAbAttr { }
 
 /**
  * Provides immunity to BattlerTags {@linkcode BattlerTag} to the user's field.
- * @extends PreApplyBattlerTagImmunityAbAttr
  */
 export class UserFieldBattlerTagImmunityAbAttr extends PreApplyBattlerTagImmunityAbAttr { }
 
@@ -3399,12 +3374,12 @@ export class ConditionalUserFieldBattlerTagImmunityAbAttr extends UserFieldBattl
 
   /**
    * Determine whether the {@linkcode ConditionalUserFieldBattlerTagImmunityAbAttr} can be applied by passing the target pokemon to the condition.
-   * @param pokemon The pokemon owning the ability
-   * @param passive unused
-   * @param simulated whether the ability is being simulated (unused)
-   * @param tag The {@linkcode BattlerTag} being applied
-   * @param cancelled Holds whether the tag was previously cancelled (unused)
-   * @param args Args[0] is the target that the tag is attempting to be applied to
+   * @param pokemon - The pokemon owning the ability
+   * @param passive - unused
+   * @param simulated - whether the ability is being simulated (unused)
+   * @param tag - The {@linkcode BattlerTag} being applied
+   * @param cancelled - Holds whether the tag was previously cancelled (unused)
+   * @param args - Args[0] is the target that the tag is attempting to be applied to
    * @returns Whether the ability can be used to cancel the battler tag
    */
   override canApplyPreApplyBattlerTag(pokemon: Pokemon, passive: boolean, simulated: boolean, tag: BattlerTag, cancelled: BooleanHolder, args: [Pokemon, ...any]): boolean {
@@ -3436,11 +3411,11 @@ export class BonusCritAbAttr extends AbAttr {
   /**
    * Apply the bonus crit ability by increasing the value in the provided number holder by 1
    * 
-   * @param pokemon The pokemon with the BonusCrit ability (unused)
-   * @param passive Unused
-   * @param simulated Unused
-   * @param cancelled Unused
-   * @param args Args[0] is a number holder containing the crit stage.
+   * @param pokemon - The pokemon with the BonusCrit ability (unused)
+   * @param passive - Unused
+   * @param simulated - Unused
+   * @param cancelled - Unused
+   * @param args - Args[0] is a number holder containing the crit stage.
    */
   override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: [NumberHolder, ...any]): void {
     (args[0] as NumberHolder).value += 1;
@@ -3469,7 +3444,6 @@ export class MultCritAbAttr extends AbAttr {
 
 /**
  * Guarantees a critical hit according to the given condition, except if target prevents critical hits. ie. Merciless
- * @extends AbAttr
  * @see {@linkcode apply}
  */
 export class ConditionalCritAbAttr extends AbAttr {
@@ -3488,8 +3462,8 @@ export class ConditionalCritAbAttr extends AbAttr {
   }
 
   /**
-   * @param pokemon {@linkcode Pokemon} user.
-   * @param args [0] {@linkcode BooleanHolder} If true critical hit is guaranteed.
+   * @param pokemon - user.
+   * @param args - [0] {@linkcode BooleanHolder} If true critical hit is guaranteed.
    *             [1] {@linkcode Pokemon} Target.
    *             [2] {@linkcode Move} used by ability user.
    */
@@ -3515,7 +3489,7 @@ export class BlockStatusDamageAbAttr extends AbAttr {
   private effects: StatusEffect[];
 
   /**
-   * @param {StatusEffect[]} effects The status effect(s) that will be blocked from damaging the ability pokemon
+   * @param effects - The status effect(s) that will be blocked from damaging the ability pokemon
    */
   constructor(...effects: StatusEffect[]) {
     super(false);
@@ -3531,10 +3505,10 @@ export class BlockStatusDamageAbAttr extends AbAttr {
   }
 
   /**
-   * @param {Pokemon} pokemon The pokemon with the ability
-   * @param {boolean} passive N/A
-   * @param {BooleanHolder} cancelled Whether to cancel the status damage
-   * @param {any[]} args N/A
+   * @param pokemon - The pokemon with the ability
+   * @param passive - N/A
+   * @param cancelled - Whether to cancel the status damage
+   * @param args - N/A
    */
   override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
     cancelled.value = true;
@@ -3557,8 +3531,8 @@ export class ChangeMovePriorityAbAttr extends AbAttr {
   private changeAmount: number;
 
   /**
-   * @param {(pokemon, move) => boolean} moveFunc applies priority-change to moves within a provided category
-   * @param {number} changeAmount the amount of priority added or subtracted
+   * @param moveFunc - applies priority-change to moves within a provided category
+   * @param changeAmount - the amount of priority added or subtracted
    */
   constructor(moveFunc: (pokemon: Pokemon, move: Move) => boolean, changeAmount: number) {
     super(false);
@@ -3724,7 +3698,7 @@ function getAnticipationCondition(): AbAttrCondition {
  * Creates an ability condition that causes the ability to fail if that ability
  * has already been used by that pokemon that battle. It requires an ability to
  * be specified due to current limitations in how conditions on abilities work.
- * @param {Abilities} ability The ability to check if it's already been applied
+ * @param ability - The ability to check if it's already been applied
  * @returns {AbAttrCondition} The condition
  */
 function getOncePerBattleCondition(ability: Abilities): AbAttrCondition {
@@ -3794,7 +3768,6 @@ export class PostWeatherChangeAbAttr extends AbAttr {
 /**
  * Triggers weather-based form change when weather changes.
  * Used by Forecast and Flower Gift.
- * @extends PostWeatherChangeAbAttr
  */
 export class PostWeatherChangeFormChangeAbAttr extends PostWeatherChangeAbAttr {
   private ability: Abilities;
@@ -3817,10 +3790,10 @@ export class PostWeatherChangeFormChangeAbAttr extends PostWeatherChangeAbAttr {
   /**
    * Calls {@linkcode Arena.triggerWeatherBasedFormChangesToNormal | triggerWeatherBasedFormChangesToNormal} when the
    * weather changed to form-reverting weather, otherwise calls {@linkcode Arena.triggerWeatherBasedFormChanges | triggerWeatherBasedFormChanges}
-   * @param {Pokemon} pokemon the Pokemon with this ability
-   * @param passive n/a
-   * @param weather n/a
-   * @param args n/a
+   * @param pokemon - the Pokemon with this ability
+   * @param passive - n/a
+   * @param weather - n/a
+   * @param args - n/a
    */
   override applyPostWeatherChange(pokemon: Pokemon, passive: boolean, simulated: boolean, weather: WeatherType, args: any[]): void {
     if (simulated) {
@@ -3990,7 +3963,7 @@ export class PostTurnStatusHealAbAttr extends PostTurnAbAttr {
   private effects: StatusEffect[];
 
   /**
-   * @param {StatusEffect[]} effects The status effect(s) that will qualify healing the ability pokemon
+   * @param effects - The status effect(s) that will qualify healing the ability pokemon
    */
   constructor(...effects: StatusEffect[]) {
     super(false);
@@ -4003,9 +3976,9 @@ export class PostTurnStatusHealAbAttr extends PostTurnAbAttr {
   }
 
   /**
-   * @param {Pokemon} pokemon The pokemon with the ability that will receive the healing
-   * @param {Boolean} passive N/A
-   * @param {any[]} args N/A
+   * @param pokemon - The pokemon with the ability that will receive the healing
+   * @param passive - N/A
+   * @param args - N/A
    */
   override applyPostTurn(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): void {
     if (!simulated) {
@@ -4018,7 +3991,7 @@ export class PostTurnStatusHealAbAttr extends PostTurnAbAttr {
 
 /**
  * After the turn ends, resets the status of either the ability holder or their ally
- * @param {boolean} allyTarget Whether to target ally, defaults to false (self-target)
+ * @param allyTarget - Whether to target ally, defaults to false (self-target)
  */
 export class PostTurnResetStatusAbAttr extends PostTurnAbAttr {
   private allyTarget: boolean;
@@ -4078,8 +4051,8 @@ export class PostTurnLootAbAttr extends PostTurnAbAttr {
 
   /**
    * Create a new berry chosen randomly from the berries the pokemon ate this battle
-   * @param pokemon The pokemon with this ability
-   * @param simulated whether the associated ability call is simulated
+   * @param pokemon - The pokemon with this ability
+   * @param simulated - whether the associated ability call is simulated
    * @returns whether a new berry was created
    */
   createEatenBerry(pokemon: Pokemon, simulated: boolean): boolean {
@@ -4130,10 +4103,10 @@ export class MoodyAbAttr extends PostTurnAbAttr {
   }
   /**
    * Randomly increases one stat stage by 2 and decreases a different stat stage by 1
-   * @param {Pokemon} pokemon Pokemon that has this ability
-   * @param passive N/A
-   * @param simulated true if applying in a simulated call.
-   * @param args N/A
+   * @param pokemon - Pokemon that has this ability
+   * @param passive - N/A
+   * @param simulated - true if applying in a simulated call.
+   * @param args - N/A
    *
    * Any stat stages at +6 or -6 are excluded from being increased or decreased, respectively
    * If the pokemon already has all stat stages raised to 6, it will only decrease one stat stage by 1
@@ -4216,10 +4189,10 @@ export class PostTurnHurtIfSleepingAbAttr extends PostTurnAbAttr {
   }
   /**
    * Deals damage to all sleeping opponents equal to 1/8 of their max hp (min 1)
-   * @param pokemon Pokemon that has this ability
-   * @param passive N/A
-   * @param simulated `true` if applying in a simulated call.
-   * @param args N/A
+   * @param pokemon - Pokemon that has this ability
+   * @param passive - N/A
+   * @param simulated - `true` if applying in a simulated call.
+   * @param args - N/A
    */
   override applyPostTurn(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): void {
     for (const opp of pokemon.getOpponents()) {
@@ -4236,7 +4209,6 @@ export class PostTurnHurtIfSleepingAbAttr extends PostTurnAbAttr {
 
 /**
  * Grabs the last failed Pokeball used
- * @extends PostTurnAbAttr
  * @see {@linkcode applyPostTurn} */
 export class FetchBallAbAttr extends PostTurnAbAttr {
   constructor() {
@@ -4249,9 +4221,9 @@ export class FetchBallAbAttr extends PostTurnAbAttr {
 
   /**
    * Adds the last used Pokeball back into the player's inventory
-   * @param pokemon {@linkcode Pokemon} with this ability
-   * @param passive N/A
-   * @param args N/A
+   * @param pokemon - with this ability
+   * @param passive - N/A
+   * @param args - N/A
    */
   override applyPostTurn(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): void {
     const lastUsed = globalScene.currentBattle.lastUsedPokeball;
@@ -4305,7 +4277,6 @@ export class PostBiomeChangeTerrainChangeAbAttr extends PostBiomeChangeAbAttr {
 
 /**
  * Triggers just after a move is used either by the opponent or the player
- * @extends AbAttr
  */
 export class PostMoveUsedAbAttr extends AbAttr {
   canApplyPostMoveUsed(
@@ -4330,7 +4301,6 @@ export class PostMoveUsedAbAttr extends AbAttr {
 
 /**
  * Triggers after a dance move is used either by the opponent or the player
- * @extends PostMoveUsedAbAttr
  */
 export class PostDancingMoveAbAttr extends PostMoveUsedAbAttr {
   override canApplyPostMoveUsed(dancer: Pokemon, move: PokemonMove, source: Pokemon, targets: BattlerIndex[], simulated: boolean, args: any[]): boolean {
@@ -4345,11 +4315,11 @@ export class PostDancingMoveAbAttr extends PostMoveUsedAbAttr {
   /**
    * Resolves the Dancer ability by replicating the move used by the source of the dance
    * either on the source itself or on the target of the dance
-   * @param dancer {@linkcode Pokemon} with Dancer ability
-   * @param move {@linkcode PokemonMove} Dancing move used by the source
-   * @param source {@linkcode Pokemon} that used the dancing move
-   * @param targets {@linkcode BattlerIndex}Targets of the dancing move
-   * @param args N/A
+   * @param dancer - with Dancer ability
+   * @param move - Dancing move used by the source
+   * @param source - that used the dancing move
+   * @param targetsTargets - of the dancing move
+   * @param args - N/A
    */
   override applyPostMoveUsed(
     dancer: Pokemon,
@@ -4373,9 +4343,9 @@ export class PostDancingMoveAbAttr extends PostMoveUsedAbAttr {
   /**
    * Get the correct targets of Dancer ability
    *
-   * @param dancer {@linkcode Pokemon} Pokemon with Dancer ability
-   * @param source {@linkcode Pokemon} Source of the dancing move
-   * @param targets {@linkcode BattlerIndex} Targets of the dancing move
+   * @param dancer - Pokemon with Dancer ability
+   * @param source - Source of the dancing move
+   * @param targets - Targets of the dancing move
    */
   getTarget(dancer: Pokemon, source: Pokemon, targets: BattlerIndex[]) : BattlerIndex[] {
     if (dancer.isPlayer()) {
@@ -4387,7 +4357,6 @@ export class PostDancingMoveAbAttr extends PostMoveUsedAbAttr {
 
 /**
  * Triggers after the Pokemon loses or consumes an item
- * @extends AbAttr
  */
 export class PostItemLostAbAttr extends AbAttr {
   canApplyPostItemLost(pokemon: Pokemon, simulated: boolean, args: any[]): boolean {
@@ -4399,7 +4368,6 @@ export class PostItemLostAbAttr extends AbAttr {
 
 /**
  * Applies a Battler Tag to the Pokemon after it loses or consumes item
- * @extends PostItemLostAbAttr
  */
 export class PostItemLostApplyBattlerTagAbAttr extends PostItemLostAbAttr {
   private tagType: BattlerTagType;
@@ -4414,8 +4382,8 @@ export class PostItemLostApplyBattlerTagAbAttr extends PostItemLostAbAttr {
 
   /**
    * Adds the last used Pokeball back into the player's inventory
-   * @param pokemon {@linkcode Pokemon} with this ability
-   * @param args N/A
+   * @param pokemon - with this ability
+   * @param args - N/A
    */
   override applyPostItemLost(pokemon: Pokemon, simulated: boolean, args: any[]): void {
     pokemon.addTag(this.tagType);
@@ -4462,7 +4430,7 @@ export class BypassBurnDamageReductionAbAttr extends AbAttr {
 
 /**
  * Causes Pokemon to take reduced damage from the {@linkcode StatusEffect.BURN | Burn} status
- * @param multiplier Multiplied with the damage taken
+ * @param multiplier - Multiplied with the damage taken
 */
 export class ReduceBurnDamageAbAttr extends AbAttr {
   constructor(protected multiplier: number) {
@@ -4471,10 +4439,10 @@ export class ReduceBurnDamageAbAttr extends AbAttr {
 
   /**
    * Applies the damage reduction
-   * @param pokemon N/A
-   * @param passive N/A
-   * @param cancelled N/A
-   * @param args `[0]` {@linkcode NumberHolder} The damage value being modified
+   * @param pokemon - N/A
+   * @param passive - N/A
+   * @param cancelled - N/A
+   * @param args - `[0]` {@linkcode NumberHolder} The damage value being modified
    */
   override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
     (args[0] as NumberHolder).value = toDmgValue((args[0] as NumberHolder).value * this.multiplier);
@@ -4534,7 +4502,6 @@ type ArenaTrapCondition = (user: Pokemon, target: Pokemon) => boolean;
 
 /**
  * Base class for checking if a Pokemon is trapped by arena trap
- * @extends AbAttr
  * @field {@linkcode arenaTrapCondition} Conditional for trapping abilities.
  * For example, Magnet Pull will only activate if opponent is Steel type.
  * @see {@linkcode applyCheckTrapped}
@@ -4569,7 +4536,6 @@ export class CheckTrappedAbAttr extends AbAttr {
 /**
  * Determines whether a Pokemon is blocked from switching/running away
  * because of a trapping ability or move.
- * @extends CheckTrappedAbAttr
  * @see {@linkcode applyCheckTrapped}
  */
 export class ArenaTrapAbAttr extends CheckTrappedAbAttr {
@@ -4585,11 +4551,11 @@ export class ArenaTrapAbAttr extends CheckTrappedAbAttr {
    * If the enemy has the ability Run Away, it is not trapped.
    * If the user has Magnet Pull and the enemy is not a Steel type, it is not trapped.
    * If the user has Arena Trap and the enemy is not grounded, it is not trapped.
-   * @param pokemon The {@link Pokemon} with this {@link AbAttr}
-   * @param passive N/A
-   * @param trapped {@link BooleanHolder} indicating whether the other Pokemon is trapped or not
-   * @param otherPokemon The {@link Pokemon} that is affected by an Arena Trap ability
-   * @param args N/A
+   * @param pokemon - The {@link Pokemon} with this {@link AbAttr}
+   * @param passive - N/A
+   * @param trapped - indicating whether the other Pokemon is trapped or not
+   * @param otherPokemon - The {@link Pokemon} that is affected by an Arena Trap ability
+   * @param args - N/A
    */
   override applyCheckTrapped(pokemon: Pokemon, passive: boolean, simulated: boolean, trapped: BooleanHolder, otherPokemon: Pokemon, args: any[]): void {
     trapped.value = true;
@@ -4662,7 +4628,6 @@ export class PostFaintAbAttr extends AbAttr {
 /**
  * Used for weather suppressing abilities to trigger weather-based form changes upon being fainted.
  * Used by Cloud Nine and Air Lock.
- * @extends PostFaintAbAttr
  */
 export class PostFaintUnsuppressedWeatherFormChangeAbAttr extends PostFaintAbAttr {
   override canApplyPostFaint(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker?: Pokemon, move?: Move, hitResult?: HitResult, ...args: any[]): boolean {
@@ -4672,12 +4637,12 @@ export class PostFaintUnsuppressedWeatherFormChangeAbAttr extends PostFaintAbAtt
   /**
    * Triggers {@linkcode Arena.triggerWeatherBasedFormChanges | triggerWeatherBasedFormChanges}
    * when the user of the ability faints
-   * @param {Pokemon} pokemon the fainted Pokemon
-   * @param passive n/a
-   * @param attacker n/a
-   * @param move n/a
-   * @param hitResult n/a
-   * @param args n/a
+   * @param pokemon - the fainted Pokemon
+   * @param passive - n/a
+   * @param attacker - n/a
+   * @param move - n/a
+   * @param hitResult - n/a
+   * @param args - n/a
    */
   override applyPostFaint(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, hitResult: HitResult, args: any[]): void {
     if (!simulated) {
@@ -4931,11 +4896,11 @@ export class InfiltratorAbAttr extends AbAttr {
 
   /**
    * Sets a flag to bypass screens, Substitute, Safeguard, and Mist
-   * @param pokemon n/a
-   * @param passive n/a
-   * @param simulated n/a
-   * @param cancelled n/a
-   * @param args `[0]` a {@linkcode BooleanHolder | BooleanHolder} containing the flag
+   * @param pokemon - n/a
+   * @param passive - n/a
+   * @param simulated - n/a
+   * @param cancelled - n/a
+   * @param args - `[0]` a {@linkcode BooleanHolder | BooleanHolder} containing the flag
    */
   override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: null, args: any[]): void {
     const bypassed = args[0];
@@ -5007,7 +4972,6 @@ export class IgnoreTypeStatusEffectImmunityAbAttr extends AbAttr {
 /**
  * Gives money to the user after the battle.
  *
- * @extends PostBattleAbAttr
  * @see {@linkcode applyPostBattle}
  */
 export class MoneyAbAttr extends PostBattleAbAttr {
@@ -5020,8 +4984,8 @@ export class MoneyAbAttr extends PostBattleAbAttr {
   }
 
   /**
-   * @param pokemon {@linkcode Pokemon} that is the user of this ability.
-   * @param passive N/A
+   * @param pokemon - that is the user of this ability.
+   * @param passive - N/A
    * @param args - `[0]`: boolean for if the battle ended in a victory
    */
   override applyPostBattle(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): void {
@@ -5033,7 +4997,6 @@ export class MoneyAbAttr extends PostBattleAbAttr {
  * Applies a stat change after a Pokémon is summoned,
  * conditioned on the presence of a specific arena tag.
  *
- * @extends PostSummonStatStageChangeAbAttr
  */
 export class PostSummonStatStageChangeOnArenaAbAttr extends PostSummonStatStageChangeAbAttr {
   /**
@@ -5046,7 +5009,7 @@ export class PostSummonStatStageChangeOnArenaAbAttr extends PostSummonStatStageC
    * Creates an instance of PostSummonStatStageChangeOnArenaAbAttr.
    * Initializes the stat change to increase Attack by 1 stage if the specified arena tag is present.
    *
-   * @param {ArenaTagType} tagType - The type of arena tag to check for.
+   * @param tagType - The type of arena tag to check for.
    */
   constructor(tagType: ArenaTagType) {
     super([ Stat.ATK ], 1, true, false);
@@ -5063,9 +5026,9 @@ export class PostSummonStatStageChangeOnArenaAbAttr extends PostSummonStatStageC
    * Applies the post-summon stat change if the specified arena tag is present on pokemon's side.
    * This is used in Wind Rider ability.
    *
-   * @param {Pokemon} pokemon - The Pokémon being summoned.
-   * @param {boolean} passive - Whether the effect is passive.
-   * @param {any[]} args - Additional arguments.
+   * @param pokemon - The Pokémon being summoned.
+   * @param passive - Whether the effect is passive.
+   * @param args - Additional arguments.
    */
   override applyPostSummon(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): void {
     super.applyPostSummon(pokemon, passive, simulated, args);
@@ -5075,7 +5038,6 @@ export class PostSummonStatStageChangeOnArenaAbAttr extends PostSummonStatStageC
 /**
  * Takes no damage from the first hit of a damaging move.
  * This is used in the Disguise and Ice Face abilities.
- * @extends ReceivedMoveDamageMultiplierAbAttr
  */
 export class FormBlockDamageAbAttr extends ReceivedMoveDamageMultiplierAbAttr {
   private multiplier: number;
@@ -5100,12 +5062,12 @@ export class FormBlockDamageAbAttr extends ReceivedMoveDamageMultiplierAbAttr {
    * Applies the pre-defense ability to the Pokémon.
    * Removes the appropriate `BattlerTagType` when hit by an attack and is in its defense form.
    *
-   * @param pokemon The Pokémon with the ability.
-   * @param _passive n/a
-   * @param attacker The attacking Pokémon.
-   * @param move The move being used.
-   * @param _cancelled n/a
-   * @param args Additional arguments.
+   * @param pokemon - The Pokémon with the ability.
+   * @param _passive - n/a
+   * @param attacker - The attacking Pokémon.
+   * @param move - The move being used.
+   * @param _cancelled - n/a
+   * @param args - Additional arguments.
    */
   override applyPreDefend(pokemon: Pokemon, _passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, _cancelled: BooleanHolder, args: any[]): void {
     if (!simulated) {
@@ -5119,9 +5081,9 @@ export class FormBlockDamageAbAttr extends ReceivedMoveDamageMultiplierAbAttr {
 
   /**
    * Gets the message triggered when the Pokémon avoids damage using the form-changing ability.
-   * @param pokemon The Pokémon with the ability.
-   * @param abilityName The name of the ability.
-   * @param _args n/a
+   * @param pokemon - The Pokémon with the ability.
+   * @param abilityName - The name of the ability.
+   * @param _args - n/a
    * @returns The trigger message.
    */
   getTriggerMessage(pokemon: Pokemon, abilityName: string, ..._args: any[]): string {
@@ -5218,13 +5180,12 @@ export class IllusionPostBattleAbAttr extends PostBattleAbAttr {
 /**
  * If a Pokémon with this Ability selects a damaging move, it has a 30% chance of going first in its priority bracket. If the Ability activates, this is announced at the start of the turn (after move selection).
  *
- * @extends AbAttr
  */
 export class BypassSpeedChanceAbAttr extends AbAttr {
   public chance: number;
 
   /**
-   * @param {number} chance probability of ability being active.
+   * @param chance - probability of ability being active.
    */
   constructor(chance: number) {
     super(true);
@@ -5242,10 +5203,10 @@ export class BypassSpeedChanceAbAttr extends AbAttr {
 
   /**
    * bypass move order in their priority bracket when pokemon choose damaging move
-   * @param {Pokemon} pokemon {@linkcode Pokemon}  the Pokemon applying this ability
-   * @param {boolean} passive N/A
-   * @param {BooleanHolder} cancelled N/A
-   * @param {any[]} args [0] {@linkcode BooleanHolder} set to true when the ability activated
+   * @param pokemon - the Pokemon applying this ability
+   * @param passive - N/A
+   * @param cancelled - N/A
+   * @param args - [0] {@linkcode BooleanHolder} set to true when the ability activated
    */
   override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
     const bypassSpeed = args[0] as BooleanHolder;
@@ -5265,7 +5226,7 @@ export class PreventBypassSpeedChanceAbAttr extends AbAttr {
   private condition: ((pokemon: Pokemon, move: Move) => boolean);
 
   /**
-   * @param {function} condition - checks if a move meets certain conditions
+   * @param condition - checks if a move meets certain conditions
    */
   constructor(condition: (pokemon: Pokemon, move: Move) => boolean) {
     super(true);
@@ -5319,7 +5280,7 @@ export class TerrainEventTypeChangeAbAttr extends PostSummonAbAttr {
   /**
    * Retrieves the type(s) the Pokemon should change to in response to a terrain
    * @param pokemon
-   * @param currentTerrain {@linkcode TerrainType}
+   * @param currentTerrain
    * @returns a list of type(s)
    */
   private determineTypeChange(pokemon: Pokemon, currentTerrain: TerrainType): PokemonType[] {
@@ -5434,7 +5395,7 @@ class ForceSwitchOutHelper {
   /**
    * Handles the logic for switching out a Pokémon based on battle conditions, HP, and the switch type.
    *
-   * @param pokemon The {@linkcode Pokemon} attempting to switch out.
+   * @param pokemon - The {@linkcode Pokemon} attempting to switch out.
    * @returns `true` if the switch is successful
    */
   public switchOutLogic(pokemon: Pokemon): boolean {
@@ -5502,8 +5463,8 @@ class ForceSwitchOutHelper {
   /**
    * Determines if a Pokémon can switch out based on its status, the opponent's status, and battle conditions.
    *
-   * @param pokemon The Pokémon attempting to switch out.
-   * @param opponent The opponent Pokémon.
+   * @param pokemon - The Pokémon attempting to switch out.
+   * @param opponent - The opponent Pokémon.
    * @returns `true` if the switch-out condition is met
    */
   public getSwitchOutCondition(pokemon: Pokemon, opponent: Pokemon): boolean {
@@ -5535,7 +5496,7 @@ class ForceSwitchOutHelper {
   /**
    * Returns a message if the switch-out attempt fails due to ability effects.
    *
-   * @param target The target Pokémon.
+   * @param target - The target Pokémon.
    * @returns The failure message, or `null` if no failure.
    */
   public getFailedText(target: Pokemon): string | null {
@@ -5565,7 +5526,6 @@ function calculateShellBellRecovery(pokemon: Pokemon): number {
 
 /**
  * Triggers after the Pokemon takes any damage
- * @extends AbAttr
  */
 export class PostDamageAbAttr extends AbAttr {
   public canApplyPostDamage(
@@ -5595,7 +5555,6 @@ export class PostDamageAbAttr extends AbAttr {
  *
  * Used by Wimp Out and Emergency Exit
  *
- * @extends PostDamageAbAttr
  * @see {@linkcode applyPostDamage}
  */
 export class PostDamageForceSwitchAbAttr extends PostDamageAbAttr {
@@ -5666,12 +5625,12 @@ export class PostDamageForceSwitchAbAttr extends PostDamageAbAttr {
    * Checks various conditions based on the moves used by the Pokémon, the opponents' moves, and
    * the Pokémon's health after damage to determine whether the switch-out should occur.
    *
-   * @param pokemon The Pokémon that took damage.
-   * @param damage N/A
-   * @param passive N/A
-   * @param simulated Whether the ability is being simulated.
-   * @param args N/A
-   * @param source N/A
+   * @param pokemon - The Pokémon that took damage.
+   * @param damage - N/A
+   * @param passive - N/A
+   * @param simulated - Whether the ability is being simulated.
+   * @param args - N/A
+   * @param source - N/A
    */
   public override applyPostDamage(pokemon: Pokemon, damage: number, passive: boolean, simulated: boolean, args: any[], source?: Pokemon): void {
     this.helper.switchOutLogic(pokemon);
@@ -5862,13 +5821,13 @@ export function applyPostDamageAbAttrs(
 
 /**
  * Applies a field Stat multiplier attribute
- * @param attrType {@linkcode FieldMultiplyStatAbAttr} should always be FieldMultiplyBattleStatAbAttr for the time being
- * @param pokemon {@linkcode Pokemon} the Pokemon applying this ability
- * @param stat {@linkcode Stat} the type of the checked stat
- * @param statValue {@linkcode NumberHolder} the value of the checked stat
- * @param checkedPokemon {@linkcode Pokemon} the Pokemon with the checked stat
- * @param hasApplied {@linkcode BooleanHolder} whether or not a FieldMultiplyBattleStatAbAttr has already affected this stat
- * @param args unused
+ * @param attrType - should always be FieldMultiplyBattleStatAbAttr for the time being
+ * @param pokemon - the Pokemon applying this ability
+ * @param stat - the type of the checked stat
+ * @param statValue - the value of the checked stat
+ * @param checkedPokemon - the Pokemon with the checked stat
+ * @param hasApplied - whether or not a FieldMultiplyBattleStatAbAttr has already affected this stat
+ * @param args - unused
  */
 export function applyFieldStatMultiplierAbAttrs(
   attrType: Constructor<FieldMultiplyStatAbAttr>,

--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -384,7 +384,7 @@ export class AttackTypeImmunityAbAttr extends TypeImmunityAbAttr {
    * Type immunity abilities that do not give additional benefits (HP recovery, stat boosts, etc) are not immune to status moves of the type
    * Example: Levitate
    */
-  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: any[]): void {
+  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: [NumberHolder, ...any]): void {
     // this is a hacky way to fix the Levitate/Thousand Arrows interaction, but it works for now...
     super.applyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
   }
@@ -399,7 +399,7 @@ export class TypeImmunityHealAbAttr extends TypeImmunityAbAttr {
     return super.canApplyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
   }
 
-  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: any[]): void {
+  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: [NumberHolder, ...any]): void {
     super.applyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
     if (!pokemon.isFullHp() && !simulated) {
       const abilityName = (!passive ? pokemon.getAbility() : pokemon.getPassiveAbility()).name;
@@ -425,7 +425,7 @@ class TypeImmunityStatStageChangeAbAttr extends TypeImmunityAbAttr {
     return super.canApplyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
   }
 
-  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: any[]): void {
+  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: [NumberHolder, ...any]): void {
     super.applyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
     cancelled.value = true; // Suppresses "No Effect" message
     if (!simulated) {
@@ -449,7 +449,7 @@ class TypeImmunityAddBattlerTagAbAttr extends TypeImmunityAbAttr {
     return super.canApplyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
   }
 
-  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: any[]): void {
+  override applyPreDefend(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker: Pokemon, move: Move, cancelled: BooleanHolder, args: [NumberHolder, ...any]): void {
     super.applyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
     cancelled.value = true; // Suppresses "No Effect" message
     if (!simulated) {
@@ -5241,10 +5241,10 @@ export class PreventBypassSpeedChanceAbAttr extends AbAttr {
   }
 
   /**
-   * @argument {boolean} bypassSpeed - determines if a Pokemon is able to bypass speed at the moment
-   * @argument {boolean} canCheckHeldItems - determines if a Pokemon has access to Quick Claw's effects or not
+   * @param Args args[0] bypassSpeed - determines if a Pokemon is able to bypass speed at the moment
+   * @param canCheckHeldItems - determines if a Pokemon has access to Quick Claw's effects or not
    */
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: [BooleanHolder, BooleanHolder, ...any]): void {
     const bypassSpeed = args[0] as BooleanHolder;
     const canCheckHeldItems = args[1] as BooleanHolder;
     bypassSpeed.value = false;

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -76,7 +76,7 @@ export abstract class ArenaTag {
   /**
    * When given a arena tag or json representing one, load the data for it.
    * This is meant to be inherited from by any arena tag with custom attributes
-   * @param {ArenaTag | any} source An arena tag
+   * @param source - An arena tag
    */
   loadTag(source: ArenaTag | any): void {
     this.turnCount = source.turnCount;
@@ -139,10 +139,10 @@ export class MistTag extends ArenaTag {
 
   /**
    * Cancels the lowering of stats
-   * @param _arena the {@linkcode Arena} containing this effect
-   * @param simulated `true` if the effect should be applied quietly
-   * @param attacker the {@linkcode Pokemon} using a move into this effect.
-   * @param cancelled a {@linkcode BooleanHolder} whose value is set to `true`
+   * @param _arena - the {@linkcode Arena} containing this effect
+   * @param simulated - `true` if the effect should be applied quietly
+   * @param attacker - the {@linkcode Pokemon} using a move into this effect.
+   * @param cancelled - a {@linkcode BooleanHolder} whose value is set to `true`
    * to flag the stat reduction as cancelled
    * @returns `true` if a stat reduction was cancelled; `false` otherwise
    */
@@ -170,7 +170,6 @@ export class MistTag extends ArenaTag {
 
 /**
  * Reduces the damage of specific move categories in the arena.
- * @extends ArenaTag
  */
 export class WeakenMoveScreenTag extends ArenaTag {
   protected weakenedCategories: MoveCategory[];
@@ -201,11 +200,11 @@ export class WeakenMoveScreenTag extends ArenaTag {
   /**
    * Applies the weakening effect to the move.
    *
-   * @param _arena the {@linkcode Arena} where the move is applied.
-   * @param _simulated n/a
-   * @param attacker the attacking {@linkcode Pokemon}
-   * @param moveCategory the attacking move's {@linkcode MoveCategory}.
-   * @param damageMultiplier A {@linkcode NumberHolder} containing the damage multiplier
+   * @param _arena - the {@linkcode Arena} where the move is applied.
+   * @param _simulated - n/a
+   * @param attacker - the attacking {@linkcode Pokemon}
+   * @param moveCategory - the attacking move's {@linkcode MoveCategory}.
+   * @param damageMultiplier - A {@linkcode NumberHolder} containing the damage multiplier
    * @returns `true` if the attacking move was weakened; `false` otherwise.
    */
   override apply(
@@ -332,13 +331,13 @@ export class ConditionalProtectTag extends ArenaTag {
   /**
    * Checks incoming moves against the condition function
    * and protects the target if conditions are met
-   * @param arena the {@linkcode Arena} containing this tag
-   * @param simulated `true` if the tag is applied quietly; `false` otherwise.
-   * @param isProtected a {@linkcode BooleanHolder} used to flag if the move is protected against
-   * @param attacker the attacking {@linkcode Pokemon}
-   * @param defender the defending {@linkcode Pokemon}
-   * @param moveId the {@linkcode Moves | identifier} for the move being used
-   * @param ignoresProtectBypass a {@linkcode BooleanHolder} used to flag if a protection effect supercedes effects that ignore protection
+   * @param arena - the {@linkcode Arena} containing this tag
+   * @param simulated - `true` if the tag is applied quietly; `false` otherwise.
+   * @param isProtected - a {@linkcode BooleanHolder} used to flag if the move is protected against
+   * @param attacker - the attacking {@linkcode Pokemon}
+   * @param defender - the defending {@linkcode Pokemon}
+   * @param moveId - the {@linkcode Moves | identifier} for the move being used
+   * @param ignoresProtectBypass - a {@linkcode BooleanHolder} used to flag if a protection effect supercedes effects that ignore protection
    * @returns `true` if this tag protected against the attack; `false` otherwise
    */
   override apply(
@@ -376,8 +375,8 @@ export class ConditionalProtectTag extends ArenaTag {
 /**
  * Condition function for {@link https://bulbapedia.bulbagarden.net/wiki/Quick_Guard_(move) Quick Guard's}
  * protection effect.
- * @param _arena {@linkcode Arena} The arena containing the protection effect
- * @param moveId {@linkcode Moves} The move to check against this condition
+ * @param _arena - The arena containing the protection effect
+ * @param moveId - The move to check against this condition
  * @returns `true` if the incoming move's priority is greater than 0.
  *   This includes moves with modified priorities from abilities (e.g. Prankster)
  */
@@ -407,8 +406,8 @@ class QuickGuardTag extends ConditionalProtectTag {
 /**
  * Condition function for {@link https://bulbapedia.bulbagarden.net/wiki/Wide_Guard_(move) Wide Guard's}
  * protection effect.
- * @param _arena {@linkcode Arena} The arena containing the protection effect
- * @param moveId {@linkcode Moves} The move to check against this condition
+ * @param _arena - The arena containing the protection effect
+ * @param moveId - The move to check against this condition
  * @returns `true` if the incoming move is multi-targeted (even if it's only used against one Pokemon).
  */
 const WideGuardConditionFunc: ProtectConditionFunc = (_arena, moveId): boolean => {
@@ -438,8 +437,8 @@ class WideGuardTag extends ConditionalProtectTag {
 /**
  * Condition function for {@link https://bulbapedia.bulbagarden.net/wiki/Mat_Block_(move) Mat Block's}
  * protection effect.
- * @param _arena {@linkcode Arena} The arena containing the protection effect.
- * @param moveId {@linkcode Moves} The move to check against this condition.
+ * @param _arena - The arena containing the protection effect.
+ * @param moveId - The move to check against this condition.
  * @returns `true` if the incoming move is not a Status move.
  */
 const MatBlockConditionFunc: ProtectConditionFunc = (_arena, moveId): boolean => {
@@ -475,8 +474,8 @@ class MatBlockTag extends ConditionalProtectTag {
 /**
  * Condition function for {@link https://bulbapedia.bulbagarden.net/wiki/Crafty_Shield_(move) Crafty Shield's}
  * protection effect.
- * @param _arena {@linkcode Arena} The arena containing the protection effect
- * @param moveId {@linkcode Moves} The move to check against this condition
+ * @param _arena - The arena containing the protection effect
+ * @param moveId - The move to check against this condition
  * @returns `true` if the incoming move is a Status move, is not a hazard, and does not target all
  * Pokemon or sides of the field.
  */
@@ -508,10 +507,10 @@ class CraftyShieldTag extends ConditionalProtectTag {
 export class NoCritTag extends ArenaTag {
   /**
    * Constructor method for the NoCritTag class
-   * @param turnCount `number` the number of turns this effect lasts
-   * @param sourceMove {@linkcode Moves} the move that created this effect
-   * @param sourceId `number` the ID of the {@linkcode Pokemon} that created this effect
-   * @param side {@linkcode ArenaTagSide} the side to which this effect belongs
+   * @param turnCount - `number` the number of turns this effect lasts
+   * @param sourceMove - the move that created this effect
+   * @param sourceId - `number` the ID of the {@linkcode Pokemon} that created this effect
+   * @param side - the side to which this effect belongs
    */
   constructor(turnCount: number, sourceMove: Moves, sourceId: number, side: ArenaTagSide) {
     super(ArenaTagType.NO_CRIT, turnCount, sourceMove, sourceId, side);
@@ -598,10 +597,10 @@ export class WeakenMoveTypeTag extends ArenaTag {
 
   /**
    * Reduces an attack's power by 0.33x if it matches this tag's weakened type.
-   * @param _arena n/a
-   * @param _simulated n/a
-   * @param type the attack's {@linkcode PokemonType}
-   * @param power a {@linkcode NumberHolder} containing the attack's power
+   * @param _arena - n/a
+   * @param _simulated - n/a
+   * @param type - the attack's {@linkcode PokemonType}
+   * @param power - a {@linkcode NumberHolder} containing the attack's power
    * @returns `true` if the attack's power was reduced; `false` otherwise.
    */
   override apply(_arena: Arena, _simulated: boolean, type: PokemonType, power: NumberHolder): boolean {
@@ -668,9 +667,9 @@ export class IonDelugeTag extends ArenaTag {
 
   /**
    * Converts Normal-type moves to Electric type
-   * @param _arena n/a
-   * @param _simulated n/a
-   * @param moveType a {@linkcode NumberHolder} containing a move's {@linkcode PokemonType}
+   * @param _arena - n/a
+   * @param _simulated - n/a
+   * @param moveType - a {@linkcode NumberHolder} containing a move's {@linkcode PokemonType}
    * @returns `true` if the given move type changed; `false` otherwise.
    */
   override apply(_arena: Arena, _simulated: boolean, moveType: NumberHolder): boolean {
@@ -715,9 +714,9 @@ export class ArenaTrapTag extends ArenaTag {
 
   /**
    * Activates the hazard effect onto a Pokemon when it enters the field
-   * @param _arena the {@linkcode Arena} containing this tag
-   * @param simulated if `true`, only checks if the hazard would activate.
-   * @param pokemon the {@linkcode Pokemon} triggering this hazard
+   * @param _arena - the {@linkcode Arena} containing this tag
+   * @param simulated - if `true`, only checks if the hazard would activate.
+   * @param pokemon - the {@linkcode Pokemon} triggering this hazard
    * @returns `true` if this hazard affects the given Pokemon; `false` otherwise.
    */
   override apply(_arena: Arena, simulated: boolean, pokemon: Pokemon): boolean {
@@ -1070,9 +1069,9 @@ export class TrickRoomTag extends ArenaTag {
 
   /**
    * Reverses Speed-based turn order for all Pokemon on the field
-   * @param _arena n/a
-   * @param _simulated n/a
-   * @param speedReversed a {@linkcode BooleanHolder} used to flag if Speed-based
+   * @param _arena - n/a
+   * @param _simulated - n/a
+   * @param speedReversed - a {@linkcode BooleanHolder} used to flag if Speed-based
    * turn order should be reversed.
    * @returns `true` if turn order is successfully reversed; `false` otherwise
    */
@@ -1267,7 +1266,7 @@ class ImprisonTag extends ArenaTrapTag {
 
   /**
    * This applies the effects of Imprison to any opposing Pokemon that switch into the field while the source Pokemon is still active
-   * @param {Pokemon} pokemon the Pokemon Imprison is applied to
+   * @param pokemon - the Pokemon Imprison is applied to
    * @returns `true`
    */
   override activateTrap(pokemon: Pokemon): boolean {
@@ -1358,9 +1357,9 @@ class WaterFirePledgeTag extends ArenaTag {
 
   /**
    * Doubles the chance for the given move's secondary effect(s) to trigger
-   * @param _arena the {@linkcode Arena} containing this tag
-   * @param _simulated n/a
-   * @param moveChance a {@linkcode NumberHolder} containing
+   * @param _arena - the {@linkcode Arena} containing this tag
+   * @param _simulated - n/a
+   * @param moveChance - a {@linkcode NumberHolder} containing
    * the move's current effect chance
    * @returns `true` if the move's effect chance was doubled (currently always `true`)
    */
@@ -1567,7 +1566,7 @@ export function getArenaTag(
 
 /**
  * When given a battler tag or json representing one, creates an actual ArenaTag object with the same data.
- * @param {ArenaTag | any} source An arena tag
+ * @param source - An arena tag
  * @return {ArenaTag} The valid arena tag
  */
 export function loadArenaTag(source: ArenaTag | any): ArenaTag {

--- a/src/data/balance/starters.ts
+++ b/src/data/balance/starters.ts
@@ -10,7 +10,7 @@ export const FRIENDSHIP_LOSS_FROM_FAINT = 5;
 
 /**
  * Function to get the cumulative friendship threshold at which a candy is earned
- * @param starterCost The cost of the starter, found in {@linkcode speciesStarterCosts}
+ * @param starterCost - The cost of the starter, found in {@linkcode speciesStarterCosts}
  * @returns aforementioned threshold
  */
 export function getStarterValueFriendshipCap(starterCost: number): number {
@@ -633,7 +633,7 @@ const starterCandyCosts: { passive: number; costReduction: [number, number]; egg
 
 /**
  * Getter for {@linkcode starterCandyCosts} for passive unlock candy cost based on initial point cost
- * @param starterCost the default point cost of the starter found in {@linkcode speciesStarterCosts}
+ * @param starterCost - the default point cost of the starter found in {@linkcode speciesStarterCosts}
  * @returns the candy cost for passive unlock
  */
 export function getPassiveCandyCount(starterCost: number): number {
@@ -642,7 +642,7 @@ export function getPassiveCandyCount(starterCost: number): number {
 
 /**
  * Getter for {@linkcode starterCandyCosts} for value reduction unlock candy cost based on initial point cost
- * @param starterCost the default point cost of the starter found in {@linkcode speciesStarterCosts}
+ * @param starterCost - the default point cost of the starter found in {@linkcode speciesStarterCosts}
  * @returns respective candy cost for the two cost reductions as an array 2 numbers
  */
 export function getValueReductionCandyCounts(starterCost: number): [number, number] {
@@ -651,7 +651,7 @@ export function getValueReductionCandyCounts(starterCost: number): [number, numb
 
 /**
  * Getter for {@linkcode starterCandyCosts} for egg purchase candy cost based on initial point cost
- * @param starterCost the default point cost of the starter found in {@linkcode speciesStarterCosts}
+ * @param starterCost - the default point cost of the starter found in {@linkcode speciesStarterCosts}
  * @returns the candy cost for the purchasable egg
  */
 export function getSameSpeciesEggCandyCounts(starterCost: number): number {

--- a/src/data/battle-anims.ts
+++ b/src/data/battle-anims.ts
@@ -590,8 +590,8 @@ export function initMoveAnim(move: Moves): Promise<void> {
 /**
  * Populates the default animation for the given move.
  *
- * @param move the move to populate an animation for
- * @param defaultMoveAnim the move to use as the default animation
+ * @param move - the move to populate an animation for
+ * @param defaultMoveAnim - the move to use as the default animation
  */
 function useDefaultAnim(move: Moves, defaultMoveAnim: Moves) {
   populateMoveAnim(move, moveAnims.get(defaultMoveAnim));
@@ -600,8 +600,8 @@ function useDefaultAnim(move: Moves, defaultMoveAnim: Moves) {
 /**
  * Helper method for printing a warning to the console when a move animation is missing.
  *
- * @param move the move to populate an animation for
- * @param optionalParams parameters to add to the error logging
+ * @param move - the move to populate an animation for
+ * @param optionalParams - parameters to add to the error logging
  *
  * @remarks use {@linkcode useDefaultAnim} to use a default animation
  */
@@ -612,7 +612,7 @@ function logMissingMoveAnim(move: Moves, ...optionalParams: any[]) {
 
 /**
  * Fetches animation configs to be used in a Mystery Encounter
- * @param encounterAnim one or more animations to fetch
+ * @param encounterAnim - one or more animations to fetch
  */
 export async function initEncounterAnims(encounterAnim: EncounterAnim | EncounterAnim[]): Promise<void> {
   const anims = Array.isArray(encounterAnim) ? encounterAnim : [encounterAnim];
@@ -1114,7 +1114,7 @@ export abstract class BattleAnim {
             if (spritePriorities[graphicIndex] !== frame.priority) {
               spritePriorities[graphicIndex] = frame.priority;
               /** Move the position that the moveSprite is rendered in based on the priority.
-               * @param priority The priority level to draw the sprite.
+               * @param priority - The priority level to draw the sprite.
                * - 0: Draw the sprite in front of the pokemon on the field.
                * - 1: Draw the sprite in front of the user pokemon.
                * - 2: Draw the sprite in front of its `bgSprite` (if it has one), or its

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -110,7 +110,7 @@ export class BattlerTag {
   /**
    * When given a battler tag or json representing one, load the data for it.
    * This is meant to be inherited from by any battler tag with custom attributes
-   * @param {BattlerTag | any} source A battler tag
+   * @param source - A battler tag
    */
   loadTag(source: BattlerTag | any): void {
     this.turnCount = source.turnCount;
@@ -186,9 +186,9 @@ export abstract class MoveRestrictionBattlerTag extends BattlerTag {
   /**
    * Checks if this tag is restricting a move based on a user's decisions during the target selection phase
    *
-   * @param {Moves} _move {@linkcode Moves} move ID to check restriction for
-   * @param {Pokemon} _user {@linkcode Pokemon} the user of the above move
-   * @param {Pokemon} _target {@linkcode Pokemon} the target of the above move
+   * @param _move - move ID to check restriction for
+   * @param _user - the user of the above move
+   * @param _target - the target of the above move
    * @returns {boolean} `false` unless overridden by the child tag
    */
   isMoveTargetRestricted(_move: Moves, _user: Pokemon, _target: Pokemon): boolean {
@@ -198,8 +198,8 @@ export abstract class MoveRestrictionBattlerTag extends BattlerTag {
   /**
    * Gets the text to display when the player attempts to select a move that is restricted by this tag.
    *
-   * @param {Pokemon} pokemon {@linkcode Pokemon} for which the player is attempting to select the restricted move
-   * @param {Moves} move {@linkcode Moves} ID of the move that is having its selection denied
+   * @param pokemon - for which the player is attempting to select the restricted move
+   * @param move - ID of the move that is having its selection denied
    * @returns {string} text to display when the player attempts to select the restricted move
    */
   abstract selectionDeniedText(pokemon: Pokemon, move: Moves): string;
@@ -209,8 +209,8 @@ export abstract class MoveRestrictionBattlerTag extends BattlerTag {
    * Because restriction effects also prevent selection of the move, this situation can only arise if a
    * pokemon first selects a move, then gets outsped by a pokemon using a move that restricts the selected move.
    *
-   * @param {Pokemon} _pokemon {@linkcode Pokemon} attempting to use the restricted move
-   * @param {Moves} _move {@linkcode Moves} ID of the move being interrupted
+   * @param _pokemon - attempting to use the restricted move
+   * @param _move - ID of the move being interrupted
    * @returns {string} text to display when the move is interrupted
    */
   interruptedText(_pokemon: Pokemon, _move: Moves): string {
@@ -221,7 +221,6 @@ export abstract class MoveRestrictionBattlerTag extends BattlerTag {
 /**
  * Tag representing the "Throat Chop" effect. Pokemon with this tag cannot use sound-based moves.
  * @see {@link https://bulbapedia.bulbagarden.net/wiki/Throat_Chop_(move) | Throat Chop}
- * @extends MoveRestrictionBattlerTag
  */
 export class ThroatChoppedTag extends MoveRestrictionBattlerTag {
   constructor() {
@@ -236,7 +235,7 @@ export class ThroatChoppedTag extends MoveRestrictionBattlerTag {
   /**
    * Checks if a {@linkcode Moves | move} is restricted by Throat Chop.
    * @override
-   * @param {Moves} move the {@linkcode Moves | move} to check for sound-based restriction
+   * @param move - the {@linkcode Moves | move} to check for sound-based restriction
    * @returns true if the move is sound-based
    */
   override isMoveRestricted(move: Moves): boolean {
@@ -246,8 +245,8 @@ export class ThroatChoppedTag extends MoveRestrictionBattlerTag {
   /**
    * Shows a message when the player attempts to select a move that is restricted by Throat Chop.
    * @override
-   * @param {Pokemon} _pokemon the {@linkcode Pokemon} that is attempting to select the restricted move
-   * @param {Moves} move the {@linkcode Moves | move} that is being restricted
+   * @param _pokemon - the {@linkcode Pokemon} that is attempting to select the restricted move
+   * @param move - the {@linkcode Moves | move} that is being restricted
    * @returns the message to display when the player attempts to select the restricted move
    */
   override selectionDeniedText(_pokemon: Pokemon, move: Moves): string {
@@ -259,8 +258,8 @@ export class ThroatChoppedTag extends MoveRestrictionBattlerTag {
   /**
    * Shows a message when a move is interrupted by Throat Chop.
    * @override
-   * @param {Pokemon} pokemon the interrupted {@linkcode Pokemon}
-   * @param {Moves} _move the {@linkcode Moves | move} that was interrupted
+   * @param pokemon - the interrupted {@linkcode Pokemon}
+   * @param _move - the {@linkcode Moves | move} that was interrupted
    * @returns the message to display when the move is interrupted
    */
   override interruptedText(pokemon: Pokemon, _move: Moves): string {
@@ -336,8 +335,8 @@ export class DisabledTag extends MoveRestrictionBattlerTag {
 
   /**
    * @override
-   * @param {Pokemon} pokemon {@linkcode Pokemon} attempting to use the restricted move
-   * @param {Moves} move {@linkcode Moves} ID of the move being interrupted
+   * @param pokemon - attempting to use the restricted move
+   * @param move - ID of the move being interrupted
    * @returns {string} text to display when the move is interrupted
    */
   override interruptedText(pokemon: Pokemon, move: Moves): string {
@@ -356,7 +355,6 @@ export class DisabledTag extends MoveRestrictionBattlerTag {
 
 /**
  * Tag used by Gorilla Tactics to restrict the user to using only one move.
- * @extends MoveRestrictionBattlerTag
  */
 export class GorillaTacticsTag extends MoveRestrictionBattlerTag {
   private moveId = Moves.NONE;
@@ -372,7 +370,7 @@ export class GorillaTacticsTag extends MoveRestrictionBattlerTag {
 
   /**
    * @override
-   * @param {Pokemon} pokemon the {@linkcode Pokemon} to check if the tag can be added
+   * @param pokemon - the {@linkcode Pokemon} to check if the tag can be added
    * @returns `true` if the pokemon has a valid move and no existing {@linkcode GorillaTacticsTag}; `false` otherwise
    */
   override canAdd(pokemon: Pokemon): boolean {
@@ -383,7 +381,7 @@ export class GorillaTacticsTag extends MoveRestrictionBattlerTag {
    * Ensures that move history exists on {@linkcode Pokemon} and has a valid move.
    * If so, sets the {@linkcode moveId} and increases the user's Attack by 50%.
    * @override
-   * @param {Pokemon} pokemon the {@linkcode Pokemon} to add the tag to
+   * @param pokemon - the {@linkcode Pokemon} to add the tag to
    */
   override onAdd(pokemon: Pokemon): void {
     const lastValidMove = this.getLastValidMove(pokemon);
@@ -399,7 +397,7 @@ export class GorillaTacticsTag extends MoveRestrictionBattlerTag {
   /**
    * Loads the Gorilla Tactics Battler Tag along with its unique class variable moveId
    * @override
-   * @param source Gorilla Tactics' {@linkcode BattlerTag} information
+   * @param source - Gorilla Tactics' {@linkcode BattlerTag} information
    */
   public override loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
@@ -409,8 +407,8 @@ export class GorillaTacticsTag extends MoveRestrictionBattlerTag {
   /**
    *
    * @override
-   * @param {Pokemon} pokemon n/a
-   * @param {Moves} _move {@linkcode Moves} ID of the move being denied
+   * @param pokemon - n/a
+   * @param _move - ID of the move being denied
    * @returns {string} text to display when the move is denied
    */
   override selectionDeniedText(pokemon: Pokemon, _move: Moves): string {
@@ -422,7 +420,7 @@ export class GorillaTacticsTag extends MoveRestrictionBattlerTag {
 
   /**
    * Gets the last valid move from the pokemon's move history.
-   * @param {Pokemon} pokemon {@linkcode Pokemon} to get the last valid move from
+   * @param pokemon - to get the last valid move from
    * @returns {Moves | undefined} the last valid move from the pokemon's move history
    */
   getLastValidMove(pokemon: Pokemon): Moves | undefined {
@@ -492,8 +490,8 @@ export class BeakBlastChargingTag extends BattlerTag {
   /**
    * Inflicts `BURN` status on attackers that make contact, and causes this tag
    * to be removed after the source makes a move (or the turn ends, whichever comes first)
-   * @param pokemon {@linkcode Pokemon} the owner of this tag
-   * @param lapseType {@linkcode BattlerTagLapseType} the type of functionality invoked in battle
+   * @param pokemon - the owner of this tag
+   * @param lapseType - the type of functionality invoked in battle
    * @returns `true` if invoked with the `AFTER_HIT` lapse type
    */
   lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
@@ -536,8 +534,8 @@ export class ShellTrapTag extends BattlerTag {
 
   /**
    * "Activates" the shell trap, causing the tag owner to move next.
-   * @param pokemon {@linkcode Pokemon} the owner of this tag
-   * @param lapseType {@linkcode BattlerTagLapseType} the type of functionality invoked in battle
+   * @param pokemon - the owner of this tag
+   * @param lapseType - the type of functionality invoked in battle
    * @returns `true` if invoked with the `AFTER_HIT` lapse type
    */
   lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
@@ -625,7 +623,6 @@ export class TrappedTag extends BattlerTag {
  * BattlerTag implementing No Retreat's trapping effect.
  * This is treated separately from other trapping effects to prevent
  * Ghost-type Pokemon from being able to reuse the move.
- * @extends TrappedTag
  */
 class NoRetreatTag extends TrappedTag {
   constructor(sourceId: number) {
@@ -654,8 +651,8 @@ export class FlinchedTag extends BattlerTag {
 
   /**
    * Cancels the Pokemon's next Move on the turn this tag is applied
-   * @param pokemon The {@linkcode Pokemon} with this tag
-   * @param lapseType The {@linkcode BattlerTagLapseType lapse type} used for this function call
+   * @param pokemon - The {@linkcode Pokemon} with this tag
+   * @param lapseType - The {@linkcode BattlerTagLapseType lapse type} used for this function call
    * @returns `false` (This tag is always removed after applying its effects)
    */
   lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
@@ -780,7 +777,6 @@ export class ConfusedTag extends BattlerTag {
 
 /**
  * Tag applied to the {@linkcode Move.DESTINY_BOND} user.
- * @extends BattlerTag
  * @see {@linkcode apply}
  */
 export class DestinyBondTag extends BattlerTag {
@@ -793,8 +789,8 @@ export class DestinyBondTag extends BattlerTag {
    * or after receiving fatal damage. When the damage is fatal,
    * the attacking Pokemon is taken down as well, unless it's a boss.
    *
-   * @param {Pokemon} pokemon Pokemon that is attacking the Destiny Bond user.
-   * @param {BattlerTagLapseType} lapseType CUSTOM or PRE_MOVE
+   * @param pokemon - Pokemon that is attacking the Destiny Bond user.
+   * @param lapseType - CUSTOM or PRE_MOVE
    * @returns false if the tag source fainted or one turn has passed since the application
    */
   lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
@@ -923,7 +919,7 @@ export class SeedTag extends BattlerTag {
 
   /**
    * When given a battler tag or json representing one, load the data for it.
-   * @param {BattlerTag | any} source A battler tag
+   * @param source - A battler tag
    */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
@@ -1012,8 +1008,8 @@ export class PowderTag extends BattlerTag {
   /**
    * Applies Powder's effects before the tag owner uses a Fire-type move.
    * Also causes the tag to expire at the end of turn.
-   * @param pokemon {@linkcode Pokemon} the owner of this tag
-   * @param lapseType {@linkcode BattlerTagLapseType} the type of lapse functionality to carry out
+   * @param pokemon - the owner of this tag
+   * @param lapseType - the type of lapse functionality to carry out
    * @returns `true` if the tag should not expire after this lapse; `false` otherwise.
    */
   lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
@@ -1135,7 +1131,7 @@ export class EncoreTag extends MoveRestrictionBattlerTag {
 
   /**
    * When given a battler tag or json representing one, load the data for it.
-   * @param {BattlerTag | any} source A battler tag
+   * @param source - A battler tag
    */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
@@ -1209,8 +1205,8 @@ export class EncoreTag extends MoveRestrictionBattlerTag {
 
   /**
    * Checks if the move matches the moveId stored within the tag and returns a boolean value
-   * @param move {@linkcode Moves} the move selected
-   * @param user N/A
+   * @param move - the move selected
+   * @param user - N/A
    * @returns `true` if the move does not match with the moveId stored and as a result, restricted
    */
   override isMoveRestricted(move: Moves, _user?: Pokemon): boolean {
@@ -1252,7 +1248,6 @@ export class HelpingHandTag extends BattlerTag {
 
 /**
  * Applies the Ingrain tag to a pokemon
- * @extends TrappedTag
  */
 export class IngrainTag extends TrappedTag {
   constructor(sourceId: number) {
@@ -1261,7 +1256,7 @@ export class IngrainTag extends TrappedTag {
 
   /**
    * Check if the Ingrain tag can be added to the pokemon
-   * @param pokemon {@linkcode Pokemon} The pokemon to check if the tag can be added to
+   * @param pokemon - The pokemon to check if the tag can be added to
    * @returns boolean True if the tag can be added, false otherwise
    */
   canAdd(pokemon: Pokemon): boolean {
@@ -1420,7 +1415,7 @@ export abstract class DamagingTrapTag extends TrappedTag {
 
   /**
    * When given a battler tag or json representing one, load the data for it.
-   * @param {BattlerTag | any} source A battler tag
+   * @param source - A battler tag
    */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
@@ -1667,7 +1662,7 @@ export class ContactDamageProtectedTag extends ContactProtectedTag {
 
   /**
    * When given a battler tag or json representing one, load the data for it.
-   * @param {BattlerTag | any} source A battler tag
+   * @param source - A battler tag
    */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
@@ -1695,9 +1690,9 @@ export class DamageProtectedTag extends ContactProtectedTag {}
 
 export class ContactSetStatusProtectedTag extends DamageProtectedTag {
   /**
-   * @param sourceMove The move that caused the tag to be applied
-   * @param tagType The type of the tag
-   * @param statusEffect The status effect to apply to the attacker
+   * @param sourceMove - The move that caused the tag to be applied
+   * @param tagType - The type of the tag
+   * @param statusEffect - The status effect to apply to the attacker
    */
   constructor(
     sourceMove: Moves,
@@ -1734,7 +1729,7 @@ export class ContactStatStageChangeProtectedTag extends DamageProtectedTag {
 
   /**
    * When given a battler tag or json representing one, load the data for it.
-   * @param {BattlerTag | any} source A battler tag
+   * @param source - A battler tag
    */
   override loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
@@ -1874,7 +1869,7 @@ export class AbilityBattlerTag extends BattlerTag {
 
   /**
    * When given a battler tag or json representing one, load the data for it.
-   * @param {BattlerTag | any} source A battler tag
+   * @param source - A battler tag
    */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
@@ -1884,7 +1879,6 @@ export class AbilityBattlerTag extends BattlerTag {
 
 /**
  * Tag used by Unburden to double speed
- * @extends AbilityBattlerTag
  */
 export class UnburdenTag extends AbilityBattlerTag {
   constructor() {
@@ -1974,7 +1968,7 @@ export class HighestStatBoostTag extends AbilityBattlerTag {
 
   /**
    * When given a battler tag or json representing one, load the data for it.
-   * @param {BattlerTag | any} source A battler tag
+   * @param source - A battler tag
    */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
@@ -2034,7 +2028,7 @@ export class WeatherHighestStatBoostTag extends HighestStatBoostTag implements W
 
   /**
    * When given a battler tag or json representing one, load the data for it.
-   * @param {BattlerTag | any} source A battler tag
+   * @param source - A battler tag
    */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
@@ -2052,7 +2046,7 @@ export class TerrainHighestStatBoostTag extends HighestStatBoostTag implements T
 
   /**
    * When given a battler tag or json representing one, load the data for it.
-   * @param {BattlerTag | any} source A battler tag
+   * @param source - A battler tag
    */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
@@ -2091,7 +2085,7 @@ export class TypeImmuneTag extends BattlerTag {
 
   /**
    * When given a battler tag or json representing one, load the data for it.
-   * @param {BattlerTag | any} source A battler tag
+   * @param source - A battler tag
    */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
@@ -2154,7 +2148,7 @@ export class TypeBoostTag extends BattlerTag {
 
   /**
    * When given a battler tag or json representing one, load the data for it.
-   * @param {BattlerTag | any} source A battler tag
+   * @param source - A battler tag
    */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
@@ -2215,7 +2209,6 @@ export class CritBoostTag extends BattlerTag {
 
 /**
  * Tag for the effects of Dragon Cheer, which boosts the critical hit ratio of the user's allies.
- * @extends {CritBoostTag}
  */
 export class DragonCheerTag extends CritBoostTag {
   /** The types of the user's ally when the tag is added */
@@ -2241,7 +2234,7 @@ export class SaltCuredTag extends BattlerTag {
 
   /**
    * When given a battler tag or json representing one, load the data for it.
-   * @param {BattlerTag | any} source A battler tag
+   * @param source - A battler tag
    */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
@@ -2298,7 +2291,7 @@ export class CursedTag extends BattlerTag {
 
   /**
    * When given a battler tag or json representing one, load the data for it.
-   * @param {BattlerTag | any} source A battler tag
+   * @param source - A battler tag
    */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
@@ -2427,7 +2420,7 @@ export class FormBlockDamageTag extends BattlerTag {
 
   /**
    * Determines if the tag can be added to the Pokémon.
-   * @param {Pokemon} pokemon The Pokémon to which the tag might be added.
+   * @param pokemon - The Pokémon to which the tag might be added.
    * @returns {boolean} True if the tag can be added, false otherwise.
    */
   canAdd(pokemon: Pokemon): boolean {
@@ -2437,7 +2430,7 @@ export class FormBlockDamageTag extends BattlerTag {
   /**
    * Applies the tag to the Pokémon.
    * Triggers a form change if the Pokémon is not in its defense form.
-   * @param {Pokemon} pokemon The Pokémon to which the tag is added.
+   * @param pokemon - The Pokémon to which the tag is added.
    */
   onAdd(pokemon: Pokemon): void {
     super.onAdd(pokemon);
@@ -2450,7 +2443,7 @@ export class FormBlockDamageTag extends BattlerTag {
   /**
    * Removes the tag from the Pokémon.
    * Triggers a form change when the tag is removed.
-   * @param {Pokemon} pokemon The Pokémon from which the tag is removed.
+   * @param pokemon - The Pokémon from which the tag is removed.
    */
   onRemove(pokemon: Pokemon): void {
     super.onRemove(pokemon);
@@ -2462,7 +2455,7 @@ export class FormBlockDamageTag extends BattlerTag {
 export class IceFaceBlockDamageTag extends FormBlockDamageTag {
   /**
    * Determines if the tag can be added to the Pokémon.
-   * @param {Pokemon} pokemon The Pokémon to which the tag might be added.
+   * @param pokemon - The Pokémon to which the tag might be added.
    * @returns {boolean} True if the tag can be added, false otherwise.
    */
   canAdd(pokemon: Pokemon): boolean {
@@ -2617,7 +2610,6 @@ export class StockpilingTag extends BattlerTag {
 
 /**
  * Battler tag for Gulp Missile used by Cramorant.
- * @extends BattlerTag
  */
 export class GulpMissileTag extends BattlerTag {
   constructor(tagType: BattlerTagType, sourceMove: Moves) {
@@ -2659,7 +2651,7 @@ export class GulpMissileTag extends BattlerTag {
 
   /**
    * Gulp Missile's initial form changes are triggered by using Surf and Dive.
-   * @param {Pokemon} pokemon The Pokemon with Gulp Missile ability.
+   * @param pokemon - The Pokemon with Gulp Missile ability.
    * @returns Whether the BattlerTag can be added.
    */
   canAdd(pokemon: Pokemon): boolean {
@@ -2691,7 +2683,6 @@ export class GulpMissileTag extends BattlerTag {
  * Applied by moves: {@linkcode Moves.ODOR_SLEUTH | Odor Sleuth},
  * {@linkcode Moves.MIRACLE_EYE | Miracle Eye} and {@linkcode Moves.FORESIGHT | Foresight}.
  *
- * @extends BattlerTag
  * @see {@linkcode ignoreImmunity}
  */
 export class ExposedTag extends BattlerTag {
@@ -2706,7 +2697,7 @@ export class ExposedTag extends BattlerTag {
 
   /**
    * When given a battler tag or json representing one, load the data for it.
-   * @param {BattlerTag | any} source A battler tag
+   * @param source - A battler tag
    */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
@@ -2715,8 +2706,8 @@ export class ExposedTag extends BattlerTag {
   }
 
   /**
-   * @param types {@linkcode PokemonType} of the defending Pokemon
-   * @param moveType {@linkcode PokemonType} of the move targetting it
+   * @param types - of the defending Pokemon
+   * @param moveType - of the move targetting it
    * @returns `true` if the move should be allowed to target the defender.
    */
   ignoreImmunity(type: PokemonType, moveType: PokemonType): boolean {
@@ -2728,7 +2719,6 @@ export class ExposedTag extends BattlerTag {
  * Tag that prevents HP recovery from held items and move effects. It also blocks the usage of recovery moves.
  * Applied by moves:  {@linkcode Moves.HEAL_BLOCK | Heal Block (5 turns)}, {@linkcode Moves.PSYCHIC_NOISE | Psychic Noise (2 turns)}
  *
- * @extends MoveRestrictionBattlerTag
  */
 export class HealBlockTag extends MoveRestrictionBattlerTag {
   constructor(turnCount: number, sourceMove: Moves) {
@@ -2748,7 +2738,7 @@ export class HealBlockTag extends MoveRestrictionBattlerTag {
 
   /**
    * Checks if a move is disabled under Heal Block
-   * @param {Moves} move {@linkcode Moves} the move ID
+   * @param move - The move ID
    * @returns `true` if the move has a TRIAGE_MOVE flag and is a status move
    */
   override isMoveRestricted(move: Moves): boolean {
@@ -2761,9 +2751,9 @@ export class HealBlockTag extends MoveRestrictionBattlerTag {
   /**
    * Checks if a move is disabled under Heal Block because of its choice of target
    * Implemented b/c of Pollen Puff
-   * @param {Moves} move {@linkcode Moves} the move ID
-   * @param {Pokemon} user {@linkcode Pokemon} the move user
-   * @param {Pokemon} target {@linkcode Pokemon} the target of the move
+   * @param move - The move ID
+   * @param user - The move user
+   * @param target - The target of the move
    * @returns `true` if the move cannot be used because the target is an ally
    */
   override isMoveTargetRestricted(move: Moves, user: Pokemon, target: Pokemon) {
@@ -2788,8 +2778,8 @@ export class HealBlockTag extends MoveRestrictionBattlerTag {
 
   /**
    * @override
-   * @param {Pokemon} pokemon {@linkcode Pokemon} attempting to use the restricted move
-   * @param {Moves} move {@linkcode Moves} ID of the move being interrupted
+   * @param pokemon - attempting to use the restricted move
+   * @param move - ID of the move being interrupted
    * @returns {string} text to display when the move is interrupted
    */
   override interruptedText(pokemon: Pokemon, move: Moves): string {
@@ -2816,7 +2806,6 @@ export class HealBlockTag extends MoveRestrictionBattlerTag {
 
 /**
  * Tag that doubles the type effectiveness of Fire-type moves.
- * @extends BattlerTag
  */
 export class TarShotTag extends BattlerTag {
   constructor() {
@@ -2825,7 +2814,7 @@ export class TarShotTag extends BattlerTag {
 
   /**
    * If the Pokemon is terastallized, the tag cannot be added.
-   * @param {Pokemon} pokemon the {@linkcode Pokemon} to which the tag is added
+   * @param pokemon - the {@linkcode Pokemon} to which the tag is added
    * @returns whether the tag is applied
    */
   override canAdd(pokemon: Pokemon): boolean {
@@ -2873,7 +2862,7 @@ export class AutotomizedTag extends BattlerTag {
   /**
    * Adds an autotomize count to the Pokemon. Each stack reduces weight by 100kg
    * If the Pokemon is over 0.1kg it also displays a message.
-   * @param pokemon The Pokemon that is being autotomized
+   * @param pokemon - The Pokemon that is being autotomized
    */
   onAdd(pokemon: Pokemon): void {
     const minWeight = 0.1;
@@ -3008,7 +2997,7 @@ export class SubstituteTag extends BattlerTag {
 
   /**
    * When given a battler tag or json representing one, load the data for it.
-   * @param {BattlerTag | any} source A battler tag
+   * @param source - A battler tag
    */
   loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
@@ -3070,7 +3059,7 @@ export class TormentTag extends MoveRestrictionBattlerTag {
   /**
    * Adds the battler tag to the target Pokemon and defines the private class variable 'target'
    * 'Target' is used to track the Pokemon's current status
-   * @param {Pokemon} pokemon the Pokemon tormented
+   * @param pokemon - the Pokemon tormented
    */
   override onAdd(pokemon: Pokemon) {
     super.onAdd(pokemon);
@@ -3084,7 +3073,7 @@ export class TormentTag extends MoveRestrictionBattlerTag {
 
   /**
    * Torment only ends when the affected Pokemon leaves the battle field
-   * @param {Pokemon} pokemon the Pokemon under the effects of Torment
+   * @param pokemon - the Pokemon under the effects of Torment
    * @param _tagType
    * @returns `true` if still present | `false` if not
    */
@@ -3094,7 +3083,7 @@ export class TormentTag extends MoveRestrictionBattlerTag {
 
   /**
    * This checks if the current move used is identical to the last used move with a {@linkcode MoveResult} of `SUCCESS`/`MISS`
-   * @param {Moves} move the move under investigation
+   * @param move - the move under investigation
    * @returns `true` if there is valid consecutive usage | `false` if the moves are different from each other
    */
   public override isMoveRestricted(move: Moves, user: Pokemon): boolean {
@@ -3155,7 +3144,7 @@ export class TauntTag extends MoveRestrictionBattlerTag {
 
   /**
    * Checks if a move is a status move and determines its restriction status on that basis
-   * @param {Moves} move the move under investigation
+   * @param move - the move under investigation
    * @returns `true` if the move is a status move
    */
   override isMoveRestricted(move: Moves): boolean {
@@ -3196,7 +3185,7 @@ export class ImprisonTag extends MoveRestrictionBattlerTag {
   /**
    * Checks if the source of Imprison is still active
    * @override
-   * @param pokemon The pokemon this tag is attached to
+   * @param pokemon - The pokemon this tag is attached to
    * @returns `true` if the source is still active
    */
   public override lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
@@ -3213,7 +3202,7 @@ export class ImprisonTag extends MoveRestrictionBattlerTag {
   /**
    * Checks if the source of the tag has the parameter move in its moveset and that the source is still active
    * @override
-   * @param {Moves} move the move under investigation
+   * @param move - the move under investigation
    * @returns `false` if either condition is not met
    */
   public override isMoveRestricted(move: Moves, _user: Pokemon): boolean {
@@ -3315,7 +3304,6 @@ export class TelekinesisTag extends BattlerTag {
 
 /**
  * Tag that swaps the user's base ATK stat with its base DEF stat.
- * @extends BattlerTag
  */
 export class PowerTrickTag extends BattlerTag {
   constructor(sourceMove: Moves, sourceId: number) {
@@ -3342,7 +3330,7 @@ export class PowerTrickTag extends BattlerTag {
 
   /**
    * Removes the Power Trick tag and reverts any stat changes if the tag is already applied.
-   * @param {Pokemon} pokemon The {@linkcode Pokemon} that already has the Power Trick tag.
+   * @param pokemon - The {@linkcode Pokemon} that already has the Power Trick tag.
    */
   onOverlap(pokemon: Pokemon): void {
     pokemon.removeTag(this.tagType);
@@ -3350,7 +3338,7 @@ export class PowerTrickTag extends BattlerTag {
 
   /**
    * Swaps the user's base ATK stat with its base DEF stat.
-   * @param {Pokemon} pokemon The {@linkcode Pokemon} whose stats will be swapped.
+   * @param pokemon - The {@linkcode Pokemon} whose stats will be swapped.
    */
   swapStat(pokemon: Pokemon): void {
     const temp = pokemon.getStat(Stat.ATK, false);
@@ -3382,7 +3370,7 @@ export class GrudgeTag extends BattlerTag {
    * Activates Grudge's special effect on the attacking Pokemon and lapses the tag.
    * @param pokemon
    * @param lapseType
-   * @param sourcePokemon {@linkcode Pokemon} the source of the move that fainted the tag's bearer
+   * @param sourcePokemon - the source of the move that fainted the tag's bearer
    * @returns `false` if Grudge activates its effect or lapses
    */
   override lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType, sourcePokemon?: Pokemon): boolean {
@@ -3659,7 +3647,7 @@ export function getBattlerTag(
 
 /**
  * When given a battler tag or json representing one, creates an actual BattlerTag object with the same data.
- * @param {BattlerTag | any} source A battler tag
+ * @param source - A battler tag
  * @return {BattlerTag} The valid battler tag
  */
 export function loadBattlerTag(source: BattlerTag | any): BattlerTag {
@@ -3671,7 +3659,7 @@ export function loadBattlerTag(source: BattlerTag | any): BattlerTag {
 /**
  * Helper function to verify that the current phase is a MoveEffectPhase and provide quick access to commonly used fields
  *
- * @param _pokemon {@linkcode Pokemon} The Pokémon used to access the current phase
+ * @param _pokemon - The Pokémon used to access the current phase
  * @returns null if current phase is not MoveEffectPhase, otherwise Object containing the {@linkcode MoveEffectPhase}, and its
  * corresponding {@linkcode Move} and user {@linkcode Pokemon}
  */

--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -115,15 +115,19 @@ export enum MoveSourceType {
 export abstract class Challenge {
   public id: Challenges; // The id of the challenge
 
-  public value: number; // The "strength" of the challenge, all challenges have a numerical value.
-  public maxValue: number; // The maximum strength of the challenge.
-  public severity: number; // The current severity of the challenge. Some challenges have multiple severities in addition to strength.
-  public maxSeverity: number; // The maximum severity of the challenge.
+  /** The "strength" of the challenge; all challenges have a numerical value */
+  public value: number;
+  /** The maximum strength of the challenge */
+  public maxValue: number;
+  /** The current severity of the challenge. Some challenges have multiple severities in addition to strength. */
+  public severity: number;
+  public maxSeverity: number;
 
   public conditions: ChallengeCondition[];
 
   /**
-   * @param id {@link Challenges} The enum value for the challenge
+   * @param id - The enum value for the challenge
+   * @param maxValue - The maximum strength of the challenge
    */
   constructor(id: Challenges, maxValue: number = Number.MAX_SAFE_INTEGER) {
     this.id = id;
@@ -136,7 +140,7 @@ export abstract class Challenge {
   }
 
   /**
-   * Reset the challenge to a base state.
+   * Reset the challenge to a base state
    */
   reset(): void {
     this.value = 0;
@@ -144,8 +148,8 @@ export abstract class Challenge {
   }
 
   /**
-   * Gets the localisation key for the challenge
-   * @returns {@link string} The i18n key for this challenge
+   * Get the localisation key for the challenge
+   * @returns The i18n key for this challenge
    */
   geti18nKey(): string {
     return Challenges[this.id]
@@ -155,18 +159,18 @@ export abstract class Challenge {
   }
 
   /**
-   * Used for unlockable challenges to check if they're unlocked.
-   * @param data {@link GameData} The save data.
-   * @returns {@link boolean} Whether this challenge is unlocked.
+   * Check whether the challenge has been unlocked
+   * @param data - The save data to check
+   * @returns Whether this challenge is unlocked
    */
   isUnlocked(data: GameData): boolean {
     return this.conditions.every(f => f(data));
   }
 
   /**
-   * Adds an unlock condition to this challenge.
-   * @param condition {@link ChallengeCondition} The condition to add.
-   * @returns {@link Challenge} This challenge
+   * Add an unlock condition to this challenge
+   * @param condition - The condition to add
+   * @returns This challenge
    */
   condition(condition: ChallengeCondition): Challenge {
     this.conditions.push(condition);
@@ -175,16 +179,16 @@ export abstract class Challenge {
   }
 
   /**
-   * @returns {@link string} The localised name of this challenge.
+   * @returns The localised name of this challenge.
    */
   getName(): string {
     return i18next.t(`challenges:${this.geti18nKey()}.name`);
   }
 
   /**
-   * Returns the textual representation of a challenge's current value.
-   * @param overrideValue {@link number} The value to check for. If undefined, gets the current value.
-   * @returns {@link string} The localised name for the current value.
+   * Return the textual representation of a challenge's current value.
+   * @param overrideValue - The value to check for. If undefined, gets the current value.
+   * @returns The localised name for the current value.
    */
   getValue(overrideValue?: number): string {
     const value = overrideValue ?? this.value;
@@ -193,8 +197,8 @@ export abstract class Challenge {
 
   /**
    * Returns the description of a challenge's current value.
-   * @param overrideValue {@link number} The value to check for. If undefined, gets the current value.
-   * @returns {@link string} The localised description for the current value.
+   * @param overrideValue - The value to check for. If undefined, gets the current value.
+   * @returns The localised description for the current value.
    */
   getDescription(overrideValue?: number): string {
     const value = overrideValue ?? this.value;
@@ -203,7 +207,7 @@ export abstract class Challenge {
 
   /**
    * Increase the value of the challenge
-   * @returns {@link boolean} Returns true if the value changed
+   * @returns whether the value changed
    */
   increaseValue(): boolean {
     if (this.value < this.maxValue) {
@@ -215,7 +219,7 @@ export abstract class Challenge {
 
   /**
    * Decrease the value of the challenge
-   * @returns {@link boolean} Returns true if the value changed
+   * @returns whether the value changed
    */
   decreaseValue(): boolean {
     if (this.value > 0) {
@@ -234,7 +238,7 @@ export abstract class Challenge {
 
   /**
    * Decrease the severity of the challenge
-   * @returns {@link boolean} Returns true if the value changed
+   * @returns whether the value changed
    */
   decreaseSeverity(): boolean {
     if (this.severity > 0) {
@@ -246,7 +250,7 @@ export abstract class Challenge {
 
   /**
    * Increase the severity of the challenge
-   * @returns {@link boolean} Returns true if the value changed
+   * @returns whether the value changed
    */
   increaseSeverity(): boolean {
     if (this.severity < this.maxSeverity) {
@@ -257,16 +261,14 @@ export abstract class Challenge {
   }
 
   /**
-   * Gets the "difficulty" value of this challenge.
-   * @returns {@link integer} The difficulty value.
+   * Get the "difficulty" value of this challenge
    */
   getDifficulty(): number {
     return this.value;
   }
 
   /**
-   * Gets the minimum difficulty added by this challenge.
-   * @returns {@link integer} The difficulty value.
+   * Gets the minimum difficulty added by this challenge
    */
   getMinDifficulty(): number {
     return 0;
@@ -274,8 +276,8 @@ export abstract class Challenge {
 
   /**
    * Clones a challenge, either from another challenge or json. Chainable.
-   * @param source The source challenge or json.
-   * @returns This challenge.
+   * @param source - The source challenge or json
+   * @returns This challenge
    */
   static loadChallenge(_source: Challenge | any): Challenge {
     throw new Error("Method not implemented! Use derived class");
@@ -283,10 +285,10 @@ export abstract class Challenge {
 
   /**
    * An apply function for STARTER_CHOICE challenges. Derived classes should alter this.
-   * @param _pokemon {@link PokemonSpecies} The pokemon to check the validity of.
-   * @param _valid {@link BooleanHolder} A BooleanHolder, the value gets set to false if the pokemon isn't allowed.
-   * @param _dexAttr {@link DexAttrProps} The dex attributes of the pokemon.
-   * @returns {@link boolean} Whether this function did anything.
+   * @param _pokemon - The pokemon to check the validity of
+   * @param _valid - A BooleanHolder, the value gets set to false if the pokemon isn't allowed
+   * @param _dexAttr - The dex attributes of the pokemon
+   * @returns - Whether this function did anything
    */
   applyStarterChoice(_pokemon: PokemonSpecies, _valid: BooleanHolder, _dexAttr: DexAttrProps): boolean {
     return false;
@@ -294,7 +296,7 @@ export abstract class Challenge {
 
   /**
    * An apply function for STARTER_POINTS challenges. Derived classes should alter this.
-   * @param _points {@link NumberHolder} The amount of points you have available.
+   * @param _points - The amount of points you have available.
    * @returns {@link boolean} Whether this function did anything.
    */
   applyStarterPoints(_points: NumberHolder): boolean {
@@ -303,9 +305,9 @@ export abstract class Challenge {
 
   /**
    * An apply function for STARTER_COST challenges. Derived classes should alter this.
-   * @param _species {@link Species} The pokemon to change the cost of.
-   * @param _cost {@link NumberHolder} The cost of the starter.
-   * @returns {@link boolean} Whether this function did anything.
+   * @param _species - The pokemon to change the cost of
+   * @param _cost - The cost of the starter
+   * @returns - Whether this function did anything
    */
   applyStarterCost(_species: Species, _cost: NumberHolder): boolean {
     return false;
@@ -313,8 +315,8 @@ export abstract class Challenge {
 
   /**
    * An apply function for STARTER_MODIFY challenges. Derived classes should alter this.
-   * @param _pokemon {@link Pokemon} The starter pokemon to modify.
-   * @returns {@link boolean} Whether this function did anything.
+   * @param _pokemon - The starter pokemon to modify.
+   * @returns - Whether this function did anything.
    */
   applyStarterModify(_pokemon: Pokemon): boolean {
     return false;
@@ -322,8 +324,8 @@ export abstract class Challenge {
 
   /**
    * An apply function for POKEMON_IN_BATTLE challenges. Derived classes should alter this.
-   * @param _pokemon {@link Pokemon} The pokemon to check the validity of.
-   * @param _valid {@link BooleanHolder} A BooleanHolder, the value gets set to false if the pokemon isn't allowed.
+   * @param _pokemon - The pokemon to check the validity of.
+   * @param _valid - Holder for the validity of the pokemon
    * @returns {@link boolean} Whether this function did anything.
    */
   applyPokemonInBattle(_pokemon: Pokemon, _valid: BooleanHolder): boolean {
@@ -332,9 +334,9 @@ export abstract class Challenge {
 
   /**
    * An apply function for FIXED_BATTLE challenges. Derived classes should alter this.
-   * @param _waveIndex {@link Number} The current wave index.
-   * @param _battleConfig {@link FixedBattleConfig} The battle config to modify.
-   * @returns {@link boolean} Whether this function did anything.
+   * @param _waveIndex - The current wave index.
+   * @param _battleConfig - The battle config to modify.
+   * @returns Whether this function did anything.
    */
   applyFixedBattle(_waveIndex: number, _battleConfig: FixedBattleConfig): boolean {
     return false;
@@ -342,7 +344,7 @@ export abstract class Challenge {
 
   /**
    * An apply function for TYPE_EFFECTIVENESS challenges. Derived classes should alter this.
-   * @param _effectiveness {@linkcode NumberHolder} The current effectiveness of the move.
+   * @param _effectiveness - The current effectiveness of the move.
    * @returns Whether this function did anything.
    */
   applyTypeEffectiveness(_effectiveness: NumberHolder): boolean {
@@ -351,11 +353,11 @@ export abstract class Challenge {
 
   /**
    * An apply function for AI_LEVEL challenges. Derived classes should alter this.
-   * @param _level {@link NumberHolder} The generated level.
-   * @param _levelCap {@link Number} The current level cap.
-   * @param _isTrainer {@link Boolean} Whether this is a trainer pokemon.
-   * @param _isBoss {@link Boolean} Whether this is a non-trainer boss pokemon.
-   * @returns {@link boolean} Whether this function did anything.
+   * @param _level - The generated level
+   * @param _levelCap - The current level cap
+   * @param _isTrainer - Whether this is a trainer pokemon
+   * @param _isBoss - Whether this is a non-trainer boss pokemon
+   * @returns Whether this function did anything
    */
   applyLevelChange(_level: NumberHolder, _levelCap: number, _isTrainer: boolean, _isBoss: boolean): boolean {
     return false;
@@ -363,9 +365,9 @@ export abstract class Challenge {
 
   /**
    * An apply function for AI_MOVE_SLOTS challenges. Derived classes should alter this.
-   * @param pokemon {@link Pokemon} The pokemon that is being considered.
-   * @param moveSlots {@link NumberHolder} The amount of move slots.
-   * @returns {@link boolean} Whether this function did anything.
+   * @param pokemon - The pokemon that is being considered
+   * @param moveSlots - The amount of move slots
+   * @returns Whether this function did anything.
    */
   applyMoveSlot(_pokemon: Pokemon, _moveSlots: NumberHolder): boolean {
     return false;
@@ -373,8 +375,8 @@ export abstract class Challenge {
 
   /**
    * An apply function for PASSIVE_ACCESS challenges. Derived classes should alter this.
-   * @param pokemon {@link Pokemon} The pokemon to change.
-   * @param hasPassive {@link BooleanHolder} Whether it should have its passive.
+   * @param pokemon - The pokemon to change
+   * @param hasPassive - Whether it should have its passive
    * @returns {@link boolean} Whether this function did anything.
    */
   applyPassiveAccess(_pokemon: Pokemon, _hasPassive: BooleanHolder): boolean {
@@ -383,7 +385,7 @@ export abstract class Challenge {
 
   /**
    * An apply function for GAME_MODE_MODIFY challenges. Derived classes should alter this.
-   * @returns {@link boolean} Whether this function did anything.
+   * @returns Whether this function did anything.
    */
   applyGameModeModify(): boolean {
     return false;
@@ -391,11 +393,11 @@ export abstract class Challenge {
 
   /**
    * An apply function for MOVE_ACCESS. Derived classes should alter this.
-   * @param _pokemon {@link Pokemon} What pokemon would learn the move.
-   * @param _moveSource {@link MoveSourceType} What source the pokemon would get the move from.
-   * @param _move {@link Moves} The move in question.
-   * @param _level {@link NumberHolder} The level threshold for access.
-   * @returns {@link boolean} Whether this function did anything.
+   * @param _pokemon - What pokemon would learn the move
+   * @param _moveSource - What source the pokemon would get the move from
+   * @param _move - The move in question
+   * @param _level - The level threshold for access
+   * @returns Whether this function did anything
    */
   applyMoveAccessLevel(_pokemon: Pokemon, _moveSource: MoveSourceType, _move: Moves, _level: NumberHolder): boolean {
     return false;
@@ -403,11 +405,11 @@ export abstract class Challenge {
 
   /**
    * An apply function for MOVE_WEIGHT. Derived classes should alter this.
-   * @param _pokemon {@link Pokemon} What pokemon would learn the move.
-   * @param _moveSource {@link MoveSourceType} What source the pokemon would get the move from.
-   * @param _move {@link Moves} The move in question.
-   * @param _weight {@link NumberHolder} The base weight of the move
-   * @returns {@link boolean} Whether this function did anything.
+   * @param _pokemon - What pokemon would learn the move
+   * @param _moveSource - What source the pokemon would get the move from
+   * @param _move - The move in question
+   * @param _weight - The base weight of the move
+   * @returns Whether this function did anything
    */
   applyMoveWeight(_pokemon: Pokemon, _moveSource: MoveSourceType, _move: Moves, _level: NumberHolder): boolean {
     return false;
@@ -415,9 +417,9 @@ export abstract class Challenge {
 
   /**
    * An apply function for FlipStats. Derived classes should alter this.
-   * @param _pokemon {@link Pokemon} What pokemon would learn the move.
-   * @param _baseStats  What are the stats to flip.
-   * @returns {@link boolean} Whether this function did anything.
+   * @param _pokemon - What pokemon would learn the move
+   * @param _baseStats -  - What are the stats to flip
+   * @returns Whether this function did anything
    */
   applyFlipStat(_pokemon: Pokemon, _baseStats: number[]) {
     return false;
@@ -658,7 +660,7 @@ export class SingleGenerationChallenge extends Challenge {
 
   /**
    * Returns the textual representation of a challenge's current value.
-   * @param {value} overrideValue The value to check for. If undefined, gets the current value.
+   * @param overrideValue - The value to check for. If undefined, gets the current value.
    * @returns {string} The localised name for the current value.
    */
   getValue(overrideValue?: number): string {
@@ -671,7 +673,7 @@ export class SingleGenerationChallenge extends Challenge {
 
   /**
    * Returns the description of a challenge's current value.
-   * @param {value} overrideValue The value to check for. If undefined, gets the current value.
+   * @param overrideValue - The value to check for. If undefined, gets the current value.
    * @returns {string} The localised description for the current value.
    */
   getDescription(overrideValue?: number): string {
@@ -750,7 +752,7 @@ export class SingleTypeChallenge extends Challenge {
 
   /**
    * Returns the textual representation of a challenge's current value.
-   * @param {value} overrideValue The value to check for. If undefined, gets the current value.
+   * @param overrideValue - The value to check for. If undefined, gets the current value.
    * @returns {string} The localised name for the current value.
    */
   getValue(overrideValue?: number): string {
@@ -762,8 +764,8 @@ export class SingleTypeChallenge extends Challenge {
 
   /**
    * Returns the description of a challenge's current value.
-   * @param {value} overrideValue The value to check for. If undefined, gets the current value.
-   * @returns {string} The localised description for the current value.
+   * @param overrideValue - The value to check for. If undefined, gets the current value.
+   * @returns The localised description for the current value.
    */
   getDescription(overrideValue?: number): string {
     if (overrideValue === undefined) {
@@ -968,12 +970,13 @@ export class LowerStarterPointsChallenge extends Challenge {
 
 /**
  * Apply all challenges that modify starter choice.
- * @param challengeType {@link ChallengeType} ChallengeType.STARTER_CHOICE
- * @param pokemon {@link PokemonSpecies} The pokemon to check the validity of.
- * @param valid {@link BooleanHolder} A BooleanHolder, the value gets set to false if the pokemon isn't allowed.
- * @param dexAttr {@link DexAttrProps} The dex attributes of the pokemon.
+ * @param challengeType - ChallengeType.STARTER_CHOICE
+ * @param pokemon - The pokemon to check the validity of.
+ * @param valid - A BooleanHolder, the value gets set to false if the pokemon isn't allowed.
+ * @param dexAttr - The dex attributes of the pokemon.
  * @returns True if any challenge was successfully applied.
  */
+
 export function applyChallenges(
   challengeType: ChallengeType.STARTER_CHOICE,
   pokemon: PokemonSpecies,
@@ -982,16 +985,16 @@ export function applyChallenges(
 ): boolean;
 /**
  * Apply all challenges that modify available total starter points.
- * @param challengeType {@link ChallengeType} ChallengeType.STARTER_POINTS
- * @param points {@link NumberHolder} The amount of points you have available.
+ * @param challengeType - ChallengeType.STARTER_POINTS
+ * @param points - The amount of points you have available.
  * @returns True if any challenge was successfully applied.
  */
 export function applyChallenges(challengeType: ChallengeType.STARTER_POINTS, points: NumberHolder): boolean;
 /**
  * Apply all challenges that modify the cost of a starter.
- * @param challengeType {@link ChallengeType} ChallengeType.STARTER_COST
- * @param species {@link Species} The pokemon to change the cost of.
- * @param points {@link NumberHolder} The cost of the pokemon.
+ * @param challengeType - ChallengeType.STARTER_COST
+ * @param species - The pokemon to change the cost of.
+ * @param points - The cost of the pokemon.
  * @returns True if any challenge was successfully applied.
  */
 export function applyChallenges(
@@ -1001,16 +1004,16 @@ export function applyChallenges(
 ): boolean;
 /**
  * Apply all challenges that modify a starter after selection.
- * @param challengeType {@link ChallengeType} ChallengeType.STARTER_MODIFY
- * @param pokemon {@link Pokemon} The starter pokemon to modify.
+ * @param challengeType - ChallengeType.STARTER_MODIFY
+ * @param pokemon - The starter pokemon to modify.
  * @returns True if any challenge was successfully applied.
  */
 export function applyChallenges(challengeType: ChallengeType.STARTER_MODIFY, pokemon: Pokemon): boolean;
 /**
  * Apply all challenges that what pokemon you can have in battle.
- * @param challengeType {@link ChallengeType} ChallengeType.POKEMON_IN_BATTLE
- * @param pokemon {@link Pokemon} The pokemon to check the validity of.
- * @param valid {@link BooleanHolder} A BooleanHolder, the value gets set to false if the pokemon isn't allowed.
+ * @param challengeType - ChallengeType.POKEMON_IN_BATTLE
+ * @param pokemon - The pokemon to check the validity of.
+ * @param valid - A BooleanHolder, the value gets set to false if the pokemon isn't allowed.
  * @returns True if any challenge was successfully applied.
  */
 export function applyChallenges(
@@ -1020,9 +1023,9 @@ export function applyChallenges(
 ): boolean;
 /**
  * Apply all challenges that modify what fixed battles there are.
- * @param challengeType {@link ChallengeType} ChallengeType.FIXED_BATTLES
- * @param waveIndex {@link Number} The current wave index.
- * @param battleConfig {@link FixedBattleConfig} The battle config to modify.
+ * @param challengeType - ChallengeType.FIXED_BATTLES
+ * @param waveIndex - The current wave index.
+ * @param battleConfig - The battle config to modify.
  * @returns True if any challenge was successfully applied.
  */
 export function applyChallenges(
@@ -1032,19 +1035,19 @@ export function applyChallenges(
 ): boolean;
 /**
  * Apply all challenges that modify type effectiveness.
- * @param challengeType {@linkcode ChallengeType} ChallengeType.TYPE_EFFECTIVENESS
- * @param effectiveness {@linkcode NumberHolder} The current effectiveness of the move.
+ * @param challengeType - ChallengeType.TYPE_EFFECTIVENESS
+ * @param effectiveness - The current effectiveness of the move.
  * @returns True if any challenge was successfully applied.
  */
 export function applyChallenges(challengeType: ChallengeType.TYPE_EFFECTIVENESS, effectiveness: NumberHolder): boolean;
 /**
  * Apply all challenges that modify what level AI are.
- * @param challengeType {@link ChallengeType} ChallengeType.AI_LEVEL
- * @param level {@link NumberHolder} The generated level of the pokemon.
- * @param levelCap {@link Number} The maximum level cap for the current wave.
- * @param isTrainer {@link Boolean} Whether this is a trainer pokemon.
- * @param isBoss {@link Boolean} Whether this is a non-trainer boss pokemon.
- * @returns True if any challenge was successfully applied.
+ * @param challengeType - ChallengeType.AI_LEVEL
+ * @param level - The generated level of the pokemon
+ * @param levelCap - The maximum level cap for the current wave
+ * @param isTrainer - Whether this is a trainer pokemon
+ * @param isBoss - Whether this is a non-trainer boss pokemon
+ * @returns True if any challenge was successfully applied
  */
 export function applyChallenges(
   challengeType: ChallengeType.AI_LEVEL,
@@ -1055,10 +1058,10 @@ export function applyChallenges(
 ): boolean;
 /**
  * Apply all challenges that modify how many move slots the AI has.
- * @param challengeType {@link ChallengeType} ChallengeType.AI_MOVE_SLOTS
- * @param pokemon {@link Pokemon} The pokemon being considered.
- * @param moveSlots {@link NumberHolder} The amount of move slots.
- * @returns True if any challenge was successfully applied.
+ * @param challengeType - ChallengeType.AI_MOVE_SLOTS
+ * @param pokemon - The pokemon being considered
+ * @param moveSlots - The amount of move slots
+ * @returns True if any challenge was successfully applied
  */
 export function applyChallenges(
   challengeType: ChallengeType.AI_MOVE_SLOTS,
@@ -1067,10 +1070,10 @@ export function applyChallenges(
 ): boolean;
 /**
  * Apply all challenges that modify whether a pokemon has its passive.
- * @param challengeType {@link ChallengeType} ChallengeType.PASSIVE_ACCESS
- * @param pokemon {@link Pokemon} The pokemon to modify.
- * @param hasPassive {@link BooleanHolder} Whether it has its passive.
- * @returns True if any challenge was successfully applied.
+ * @param challengeType - ChallengeType.PASSIVE_ACCESS
+ * @param pokemon - The pokemon to modify
+ * @param hasPassive - Whether it has its passive
+ * @returns True if any challenge was successfully applied
  */
 export function applyChallenges(
   challengeType: ChallengeType.PASSIVE_ACCESS,
@@ -1079,17 +1082,17 @@ export function applyChallenges(
 ): boolean;
 /**
  * Apply all challenges that modify the game modes settings.
- * @param challengeType {@link ChallengeType} ChallengeType.GAME_MODE_MODIFY
- * @returns True if any challenge was successfully applied.
+ * @param challengeType - The type of the challenge to apply
+ * @returns whether any challenge was successfully applied
  */
 export function applyChallenges(challengeType: ChallengeType.GAME_MODE_MODIFY): boolean;
 /**
  * Apply all challenges that modify what level a pokemon can access a move.
- * @param challengeType {@link ChallengeType} ChallengeType.MOVE_ACCESS
- * @param pokemon {@link Pokemon} What pokemon would learn the move.
- * @param moveSource {@link MoveSourceType} What source the pokemon would get the move from.
- * @param move {@link Moves} The move in question.
- * @param level {@link NumberHolder} The level threshold for access.
+ * @param challengeType - The type of the challenge to apply
+ * @param pokemon - What pokemon would learn the move
+ * @param moveSource - What source the pokemon would get the move from
+ * @param move - The move in question
+ * @param level - The level threshold for access
  * @returns True if any challenge was successfully applied.
  */
 export function applyChallenges(
@@ -1101,11 +1104,11 @@ export function applyChallenges(
 ): boolean;
 /**
  * Apply all challenges that modify what weight a pokemon gives to move generation
- * @param challengeType {@link ChallengeType} ChallengeType.MOVE_WEIGHT
- * @param pokemon {@link Pokemon} What pokemon would learn the move.
- * @param moveSource {@link MoveSourceType} What source the pokemon would get the move from.
- * @param move {@link Moves} The move in question.
- * @param weight {@link NumberHolder} The weight of the move.
+ * @param challengeType - ChallengeType.MOVE_WEIGHT
+ * @param pokemon - What pokemon would learn the move.
+ * @param moveSource - What source the pokemon would get the move from.
+ * @param move - The move in question.
+ * @param weight - The weight of the move.
  * @returns True if any challenge was successfully applied.
  */
 export function applyChallenges(
@@ -1173,7 +1176,7 @@ export function applyChallenges(challengeType: ChallengeType, ...args: any[]): b
 
 /**
  *
- * @param source A challenge to copy, or an object of a challenge's properties. Missing values are treated as defaults.
+ * @param source - A challenge to copy, or an object of a challenge's properties. Missing values are treated as defaults.
  * @returns The challenge in question.
  */
 export function copyChallenge(source: Challenge | any): Challenge {
@@ -1210,11 +1213,11 @@ export function initChallenges() {
 
 /**
  * Apply all challenges to the given starter (and form) to check its validity.
- * Differs from {@linkcode checkSpeciesValidForChallenge} which only checks form changes.
- * @param species - The {@linkcode PokemonSpecies} to check the validity of.
- * @param dexAttr - The {@linkcode DexAttrProps | dex attributes} of the species, including its form index.
- * @param soft - If `true`, allow it if it could become valid through evolution or form change.
- * @returns `true` if the species is considered valid.
+ * Differs from {@linkcode checkSpeciesValidForChallenge} which only checks form changes
+ * @param species - The {@linkcode PokemonSpecies} to check the validity of
+ * @param dexAttr - The {@linkcode DexAttrProps | dex attributes} of the species, including its form index
+ * @param soft - If `true`, allow it if it could become valid through evolution or form change
+ * @returns `true` if the species is considered valid
  */
 export function checkStarterValidForChallenge(species: PokemonSpecies, props: DexAttrProps, soft: boolean) {
   if (!soft) {
@@ -1249,11 +1252,11 @@ export function checkStarterValidForChallenge(species: PokemonSpecies, props: De
 
 /**
  * Apply all challenges to the given species (and form) to check its validity.
- * Differs from {@linkcode checkStarterValidForChallenge} which also checks evolutions.
- * @param species - The {@linkcode PokemonSpecies} to check the validity of.
- * @param dexAttr - The {@linkcode DexAttrProps | dex attributes} of the species, including its form index.
- * @param soft - If `true`, allow it if it could become valid through a form change.
- * @returns `true` if the species is considered valid.
+ * Differs from {@linkcode checkStarterValidForChallenge} which also checks evolutions
+ * @param species - The {@linkcode PokemonSpecies} to check the validity of
+ * @param dexAttr - The {@linkcode DexAttrProps | dex attributes} of the species, including its form index
+ * @param soft - If `true`, allow it if it could become valid through a form change
+ * @returns `true` if the species is considered valid
  */
 function checkSpeciesValidForChallenge(species: PokemonSpecies, props: DexAttrProps, soft: boolean) {
   const isValidForChallenge = new BooleanHolder(true);

--- a/src/data/egg-hatch-data.ts
+++ b/src/data/egg-hatch-data.ts
@@ -25,7 +25,7 @@ export class EggHatchData {
 
   /**
    * Sets the boolean for if the egg move for the hatch is a new unlock
-   * @param unlocked True if the EM is new
+   * @param unlocked - True if the EM is new
    */
   setEggMoveUnlocked(unlocked: boolean) {
     this.eggMoveUnlocked = unlocked;
@@ -78,7 +78,7 @@ export class EggHatchData {
   /**
    * Update the pokedex data corresponding with the new hatch's pokemon data
    * Also sets whether the egg move is a new unlock or not
-   * @param showMessage boolean to show messages for the new catches and egg moves (false by default)
+   * @param showMessage - boolean to show messages for the new catches and egg moves (false by default)
    * @returns
    */
   updatePokemon(showMessage = false) {

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -184,7 +184,7 @@ export default class Move implements Localizable {
 
   /**
    * Get all move attributes that match `attrType`
-   * @param attrType any attribute that extends {@linkcode MoveAttr}
+   * @param attrType - any attribute that extends {@linkcode MoveAttr}
    * @returns Array of attributes that match `attrType`, Empty Array if none match.
    */
   getAttrs<T extends MoveAttr>(attrType: Constructor<T>): T[] {
@@ -193,7 +193,7 @@ export default class Move implements Localizable {
 
   /**
    * Check if a move has an attribute that matches `attrType`
-   * @param attrType any attribute that extends {@linkcode MoveAttr}
+   * @param attrType - any attribute that extends {@linkcode MoveAttr}
    * @returns true if the move has attribute `attrType`
    */
   hasAttr<T extends MoveAttr>(attrType: Constructor<T>): boolean {
@@ -212,8 +212,8 @@ export default class Move implements Localizable {
   /**
    * Adds a new MoveAttr to the move (appends to the attr array)
    * if the MoveAttr also comes with a condition, also adds that to the conditions array: {@linkcode MoveCondition}
-   * @param AttrType {@linkcode MoveAttr} the constructor of a MoveAttr class
-   * @param args the args needed to instantiate a the given class
+   * @param AttrType - The constructor of a MoveAttr class
+   * @param args - The args needed to instantiate a the given class
    * @returns the called object {@linkcode Move}
    */
   attr<T extends Constructor<MoveAttr>>(AttrType: T, ...args: ConstructorParameters<T>): this {
@@ -234,7 +234,7 @@ export default class Move implements Localizable {
    * Adds a new MoveAttr to the move (appends to the attr array)
    * if the MoveAttr also comes with a condition, also adds that to the conditions array: {@linkcode MoveCondition}
    * Almost identical to {@link attr}, except you are passing in a MoveAttr object, instead of a constructor and it's arguments
-   * @param attrAdd {@linkcode MoveAttr} the attribute to add
+   * @param attrAdd - The attribute to add
    * @returns the called object {@linkcode Move}
    */
   addAttr(attrAdd: MoveAttr): this {
@@ -252,8 +252,8 @@ export default class Move implements Localizable {
 
   /**
    * Sets the move target of this move
-   * @param moveTarget {@linkcode MoveTarget} the move target to set
-   * @returns the called object {@linkcode Move}
+   * @param moveTarget - the move target to set
+   * @returns `this`
    */
   target(moveTarget: MoveTarget): this {
     this.moveTarget = moveTarget;
@@ -261,9 +261,8 @@ export default class Move implements Localizable {
   }
 
   /**
-   * Getter function that returns if this Move has a MoveFlag
-   * @param flag {@linkcode MoveFlags} to check
-   * @returns boolean
+   * Return whether this Move has a MoveFlag
+   * @param flag - The flag to check
    */
   hasFlag(flag: MoveFlags): boolean {
     // internally it is taking the bitwise AND (MoveFlags are represented as bit-shifts) and returning False if result is 0 and true otherwise
@@ -271,8 +270,7 @@ export default class Move implements Localizable {
   }
 
   /**
-   * Getter function that returns if the move hits multiple targets
-   * @returns boolean
+   * Return whether the move hits multiple targets
    */
   isMultiTarget(): boolean {
     switch (this.moveTarget) {
@@ -291,8 +289,7 @@ export default class Move implements Localizable {
   }
 
   /**
-   * Getter function that returns if the move targets the user or its ally
-   * @returns boolean
+   * Return whether the move targets the user or its ally
    */
   isAllyTarget(): boolean {
     switch (this.moveTarget) {
@@ -312,12 +309,11 @@ export default class Move implements Localizable {
   }
 
   /**
-   * Checks if the move is immune to certain types.
+   * Check whether if a type is immune to the move
    * Currently looks at cases of Grass types with powder moves and Dark types with moves affected by Prankster.
-   * @param {Pokemon} user the source of this move
-   * @param {Pokemon} target the target of this move
-   * @param {PokemonType} type the type of the move's target
-   * @returns boolean
+   * @param user - The source of this move
+   * @param target - The target of this move
+   * @param type - The type of the move's target
    */
   isTypeImmune(user: Pokemon, target: Pokemon, type: PokemonType): boolean {
     if (this.moveTarget === MoveTarget.USER) {
@@ -341,9 +337,9 @@ export default class Move implements Localizable {
 
   /**
    * Checks if the move would hit its target's Substitute instead of the target itself.
-   * @param user The {@linkcode Pokemon} using this move
-   * @param target The {@linkcode Pokemon} targeted by this move
-   * @returns `true` if the move can bypass the target's Substitute; `false` otherwise.
+   * @param user - The {@linkcode Pokemon} using this move
+   * @param target - The {@linkcode Pokemon} targeted by this move
+   * @returns whether the move can bypass the target's Substitute
    */
   hitsSubstitute(user: Pokemon, target?: Pokemon): boolean {
     if ([ MoveTarget.USER, MoveTarget.USER_SIDE, MoveTarget.ENEMY_SIDE, MoveTarget.BOTH_SIDES ].includes(this.moveTarget)
@@ -362,8 +358,7 @@ export default class Move implements Localizable {
 
   /**
    * Adds a move condition to the move
-   * @param condition {@linkcode MoveCondition} or {@linkcode MoveConditionFunc}, appends to conditions array a new MoveCondition object
-   * @returns the called object {@linkcode Move}
+   * @param condition - The condition to append to the condition array
    */
   condition(condition: MoveCondition | MoveConditionFunc): this {
     if (typeof condition === "function") {
@@ -402,8 +397,8 @@ export default class Move implements Localizable {
 
   /**
    * Sets the flags of the move
-   * @param flag {@linkcode MoveFlags}
-   * @param on a boolean, if True, then "ORs" the flag onto existing ones, if False then "XORs" the flag onto existing ones
+   * @param flag - The Flag to set
+   * @param on - a boolean, if True, then "ORs" the flag onto existing ones, if False then "XORs" the flag onto existing ones
    */
   private setFlag(flag: MoveFlags, on: boolean): void {
     // bitwise OR and bitwise XOR respectively
@@ -416,7 +411,7 @@ export default class Move implements Localizable {
 
   /**
    * Sets the {@linkcode MoveFlags.MAKES_CONTACT} flag for the calling Move
-   * @param setFlag Default `true`, set to `false` if the move doesn't make contact
+   * @param setFlag - Default `true`, set to `false` if the move doesn't make contact
    * @see {@linkcode Abilities.STATIC}
    * @returns The {@linkcode Move} that called this function
    */
@@ -628,10 +623,10 @@ export default class Move implements Localizable {
    * will not consider {@linkcode Abilities.WIND_RIDER | Wind Rider }.
    *
    * To simply check whether the move has a flag, use {@linkcode hasFlag}.
-   * @param flag {@linkcode MoveFlags} MoveFlag to check on user and/or target
-   * @param user {@linkcode Pokemon} the Pokemon using the move
-   * @param target {@linkcode Pokemon} the Pokemon receiving the move
-   * @param isFollowUp (defaults to `false`) `true` if the move was used as a follow up
+   * @param flag - MoveFlag to check on user and/or target
+   * @param user - the Pokemon using the move
+   * @param target - the Pokemon receiving the move
+   * @param isFollowUp - (defaults to `false`) `true` if the move was used as a follow up
    * @returns boolean
    * @see {@linkcode hasFlag}
    */
@@ -672,9 +667,9 @@ export default class Move implements Localizable {
 
   /**
    * Applies each {@linkcode MoveCondition} function of this move to the params, determines if the move can be used prior to calling each attribute's apply()
-   * @param user {@linkcode Pokemon} to apply conditions to
-   * @param target {@linkcode Pokemon} to apply conditions to
-   * @param move {@linkcode Move} to apply conditions to
+   * @param user - to apply conditions to
+   * @param target - to apply conditions to
+   * @param move - to apply conditions to
    * @returns boolean: false if any of the apply()'s return false, else true
    */
   applyConditions(user: Pokemon, target: Pokemon, move: Move): boolean {
@@ -689,9 +684,9 @@ export default class Move implements Localizable {
 
   /**
    * Sees if a move has a custom failure text (by looking at each {@linkcode MoveAttr} of this move)
-   * @param user {@linkcode Pokemon} using the move
-   * @param target {@linkcode Pokemon} target of the move
-   * @param move {@linkcode Move} with this attribute
+   * @param user - using the move
+   * @param target - target of the move
+   * @param move - with this attribute
    * @returns string of the custom failure text, or `null` if it uses the default text ("But it failed!")
    */
   getFailedText(user: Pokemon, target: Pokemon, move: Move): string | undefined {
@@ -705,9 +700,9 @@ export default class Move implements Localizable {
 
   /**
    * Calculates the userBenefitScore across all the attributes and conditions
-   * @param user {@linkcode Pokemon} using the move
-   * @param target {@linkcode Pokemon} receiving the move
-   * @param move {@linkcode Move} using the move
+   * @param user - using the move
+   * @param target - receiving the move
+   * @param move - using the move
    * @returns integer representing the total benefitScore
    */
   getUserBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
@@ -726,9 +721,9 @@ export default class Move implements Localizable {
 
   /**
    * Calculates the targetBenefitScore across all the attributes
-   * @param user {@linkcode Pokemon} using the move
-   * @param target {@linkcode Pokemon} receiving the move
-   * @param move {@linkcode Move} using the move
+   * @param user - using the move
+   * @param target - receiving the move
+   * @param move - using the move
    * @returns integer representing the total benefitScore
    */
   getTargetBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
@@ -749,8 +744,8 @@ export default class Move implements Localizable {
   /**
    * Calculates the accuracy of a move in battle based on various conditions and attributes.
    *
-   * @param user {@linkcode Pokemon} The Pokémon using the move.
-   * @param target {@linkcode Pokemon} The Pokémon being targeted by the move.
+   * @param user - The Pokémon using the move.
+   * @param target - The Pokémon being targeted by the move.
    * @returns The calculated accuracy of the move.
    */
   calculateBattleAccuracy(user: Pokemon, target: Pokemon, simulated: boolean = false) {
@@ -787,8 +782,8 @@ export default class Move implements Localizable {
   /**
    * Calculates the power of a move in battle based on various conditions and attributes.
    *
-   * @param source {@linkcode Pokemon} The Pokémon using the move.
-   * @param target {@linkcode Pokemon} The Pokémon being targeted by the move.
+   * @param source - The Pokémon using the move.
+   * @param target - The Pokémon being targeted by the move.
    * @returns The calculated power of the move.
    */
   calculateBattlePower(source: Pokemon, target: Pokemon, simulated: boolean = false): number {
@@ -902,8 +897,8 @@ export default class Move implements Localizable {
    * by enhancing effects.
    * Currently used for {@link https://bulbapedia.bulbagarden.net/wiki/Parental_Bond_(Ability) | Parental Bond}
    * and {@linkcode PokemonMultiHitModifier | Multi-Lens}.
-   * @param user The {@linkcode Pokemon} using the move
-   * @param restrictSpread `true` if the enhancing effect
+   * @param user - The {@linkcode Pokemon} using the move
+   * @param restrictSpread - `true` if the enhancing effect
    * should not affect multi-target moves (default `false`)
    */
   canBeMultiStrikeEnhanced(user: Pokemon, restrictSpread: boolean = false): boolean {
@@ -957,9 +952,9 @@ export class AttackMove extends Move {
 
   /**
    * Compute the benefit score of this move based on the offensive stat used and the move's power.
-   * @param user The Pokemon using the move
-   * @param target The Pokemon targeted by the move
-   * @param move The move being used
+   * @param user - The Pokemon using the move
+   * @param target - The Pokemon targeted by the move
+   * @param move - The move being used
    * @returns The benefit score of using this move
    */
   getTargetBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
@@ -1021,8 +1016,7 @@ function ChargeMove<TBase extends SubMove>(Base: TBase) {
      * Sets the text to be displayed during this move's charging phase.
      * References to the user Pokemon should be written as "{USER}", and
      * references to the target Pokemon should be written as "{TARGET}".
-     * @param chargeText the text to set
-     * @returns this {@linkcode Move} (for chaining API purposes)
+     * @param chargeText - the text to set
      */
     chargeText(chargeText: string): this {
       this._chargeText = chargeText;
@@ -1031,8 +1025,8 @@ function ChargeMove<TBase extends SubMove>(Base: TBase) {
 
     /**
      * Queues the charge text to display to the player
-     * @param user the {@linkcode Pokemon} using this move
-     * @param target the {@linkcode Pokemon} targeted by this move (optional)
+     * @param user - the {@linkcode Pokemon} using this move
+     * @param target - the {@linkcode Pokemon} targeted by this move (optional)
      */
     showChargeText(user: Pokemon, target?: Pokemon): void {
       globalScene.queueMessage(this._chargeText
@@ -1042,8 +1036,8 @@ function ChargeMove<TBase extends SubMove>(Base: TBase) {
     }
 
     /**
-     * Gets all charge attributes of the given attribute type.
-     * @param attrType any attribute that extends {@linkcode MoveAttr}
+     * Get all charge attributes of the given attribute type.
+     * @param attrType - An attribute to check against
      * @returns Array of attributes that match `attrType`, or an empty array if
      * no matches are found.
      */
@@ -1052,9 +1046,9 @@ function ChargeMove<TBase extends SubMove>(Base: TBase) {
     }
 
     /**
-     * Checks if this move has an attribute of the given type.
-     * @param attrType any attribute that extends {@linkcode MoveAttr}
-     * @returns `true` if a matching attribute is found; `false` otherwise
+     * Check whether this move has an attribute of the given type.
+     * @param attrType - any attribute that extends {@linkcode MoveAttr}
+     * @returns whether the matching attribute is found
      */
     hasChargeAttr<T extends MoveAttr>(attrType: Constructor<T>): boolean {
       return this.chargeAttrs.some((attr) => attr instanceof attrType);
@@ -1062,9 +1056,8 @@ function ChargeMove<TBase extends SubMove>(Base: TBase) {
 
     /**
      * Adds an attribute to this move to be applied during the move's charging phase
-     * @param ChargeAttrType the type of {@linkcode MoveAttr} being added
-     * @param args the parameters to construct the given {@linkcode MoveAttr} with
-     * @returns this {@linkcode Move} (for chaining API purposes)
+     * @param ChargeAttrType - The type of {@linkcode MoveAttr} being added
+     * @param args - The parameters to construct the given {@linkcode MoveAttr} with
      */
     chargeAttr<T extends Constructor<MoveAttr>>(ChargeAttrType: T, ...args: ConstructorParameters<T>): this {
       const chargeAttr = new ChargeAttrType(...args);
@@ -1082,7 +1075,6 @@ export type ChargingMove = ChargingAttackMove | ChargingSelfStatusMove;
 
 /**
  * Base class defining all {@linkcode Move} Attributes
- * @abstract
  * @see {@linkcode apply}
  */
 export abstract class MoveAttr {
@@ -1097,10 +1089,10 @@ export abstract class MoveAttr {
    * Applies move attributes
    * @see {@linkcode applyMoveAttrsInternal}
    * @virtual
-   * @param user {@linkcode Pokemon} using the move
-   * @param target {@linkcode Pokemon} target of the move
-   * @param move {@linkcode Move} with this attribute
-   * @param args Set of unique arguments needed by this attribute
+   * @param user - using the move
+   * @param target - target of the move
+   * @param move - with this attribute
+   * @param args - Set of unique arguments needed by this attribute
    * @returns true if application of the ability succeeds
    */
   apply(user: Pokemon | null, target: Pokemon | null, move: Move, args: any[]): boolean {
@@ -1117,9 +1109,9 @@ export abstract class MoveAttr {
 
   /**
    * @virtual
-   * @param user {@linkcode Pokemon} using the move
-   * @param target {@linkcode Pokemon} target of the move
-   * @param move {@linkcode Move} with this attribute
+   * @param user - using the move
+   * @param target - target of the move
+   * @param move - with this attribute
    * @returns the string representing failure of this {@linkcode Move}
    */
   getFailedText(user: Pokemon, target: Pokemon, move: Move): string | undefined {
@@ -1162,7 +1154,6 @@ interface MoveEffectAttrOptions {
 }
 
 /** Base class defining all Move Effect Attributes
- * @extends MoveAttr
  * @see {@linkcode apply}
  */
 export class MoveEffectAttr extends MoveAttr {
@@ -1224,10 +1215,10 @@ export class MoveEffectAttr extends MoveAttr {
   /**
    * Determines whether the {@linkcode Move}'s effects are valid to {@linkcode apply}
    * @virtual
-   * @param user {@linkcode Pokemon} using the move
-   * @param target {@linkcode Pokemon} target of the move
-   * @param move {@linkcode Move} with this attribute
-   * @param args Set of unique arguments needed by this attribute
+   * @param user - using the move
+   * @param target - target of the move
+   * @param move - with this attribute
+   * @param args - Set of unique arguments needed by this attribute
    * @returns true if basic application of the ability attribute should be possible
    */
   canApply(user: Pokemon, target: Pokemon, move: Move, args?: any[]) {
@@ -1244,10 +1235,10 @@ export class MoveEffectAttr extends MoveAttr {
   /**
    * Gets the used move's additional effect chance.
    * Chance is modified by {@linkcode MoveEffectChanceMultiplierAbAttr} and {@linkcode IgnoreMoveEffectsAbAttr}.
-   * @param user {@linkcode Pokemon} using this move
-   * @param target {@linkcode Pokemon | Target} of this move
-   * @param move {@linkcode Move} being used
-   * @param selfEffect `true` if move targets user.
+   * @param user - using this move
+   * @param target - of this move
+   * @param move - being used
+   * @param selfEffect - `true` if move targets user.
    * @returns Move effect chance value.
    */
   getMoveChance(user: Pokemon, target: Pokemon, move: Move, selfEffect?: Boolean, showAbility?: Boolean): number {
@@ -1361,7 +1352,6 @@ export class PreMoveMessageAttr extends MoveAttr {
  * Attribute for moves that can be conditionally interrupted to be considered to
  * have failed before their "useMove" message is displayed. Currently used by
  * Focus Punch.
- * @extends MoveAttr
  */
 export class PreUseInterruptAttr extends MoveAttr {
   protected message?: string | ((user: Pokemon, target: Pokemon, move: Move) => string);
@@ -1370,7 +1360,7 @@ export class PreUseInterruptAttr extends MoveAttr {
 
   /**
    * Create a new MoveInterruptedMessageAttr.
-   * @param message The message to display when the move is interrupted, or a function that formats the message based on the user, target, and move.
+   * @param message - The message to display when the move is interrupted, or a function that formats the message based on the user, target, and move.
    */
   constructor(message?: string | ((user: Pokemon, target: Pokemon, move: Move) => string), conditionFunc?: MoveConditionFunc) {
     super();
@@ -1380,9 +1370,9 @@ export class PreUseInterruptAttr extends MoveAttr {
 
   /**
    * Message to display when a move is interrupted.
-   * @param user {@linkcode Pokemon} using the move
-   * @param target {@linkcode Pokemon} target of the move
-   * @param move {@linkcode Move} with this attribute
+   * @param user - using the move
+   * @param target - target of the move
+   * @param move - with this attribute
    */
   override apply(user: Pokemon, target: Pokemon, move: Move): boolean {
     return this.conditionFunc(user, target, move);
@@ -1390,9 +1380,9 @@ export class PreUseInterruptAttr extends MoveAttr {
 
   /**
    * Message to display when a move is interrupted.
-   * @param user {@linkcode Pokemon} using the move
-   * @param target {@linkcode Pokemon} target of the move
-   * @param move {@linkcode Move} with this attribute
+   * @param user - using the move
+   * @param target - target of the move
+   * @param move - with this attribute
    */
   override getFailedText(user: Pokemon, target: Pokemon, move: Move): string | undefined {
     if (this.message && this.conditionFunc(user, target, move)) {
@@ -1408,7 +1398,6 @@ export class PreUseInterruptAttr extends MoveAttr {
 /**
  * Attribute for Status moves that take attack type effectiveness
  * into consideration (i.e. {@linkcode https://bulbapedia.bulbagarden.net/wiki/Thunder_Wave_(move) | Thunder Wave})
- * @extends MoveAttr
  */
 export class RespectAttackTypeImmunityAttr extends MoveAttr { }
 
@@ -1678,7 +1667,6 @@ export class RecoilAttr extends MoveEffectAttr {
 
 /**
  * Attribute used for moves which self KO the user regardless if the move hits a target
- * @extends MoveEffectAttr
  * @see {@linkcode apply}
  **/
 export class SacrificialAttr extends MoveEffectAttr {
@@ -1688,11 +1676,11 @@ export class SacrificialAttr extends MoveEffectAttr {
 
   /**
    * Deals damage to the user equal to their current hp
-   * @param user {@linkcode Pokemon} that used the move
-   * @param target {@linkcode Pokemon} target of the move
-   * @param move {@linkcode Move} with this attribute
-   * @param args N/A
-   * @returns true if the function succeeds
+   * @param user - The pokemon using the move
+   * @param target - The target of the move (unused)
+   * @param move - The move with the attribute
+   * @param args - unused
+   * @returns whether the attribute was successfully applied
    **/
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     user.damageAndUpdate(user.hp, { result: HitResult.INDIRECT, ignoreSegments: true });
@@ -1711,7 +1699,6 @@ export class SacrificialAttr extends MoveEffectAttr {
 
 /**
  * Attribute used for moves which self KO the user but only if the move hits a target
- * @extends MoveEffectAttr
  * @see {@linkcode apply}
  **/
 export class SacrificialAttrOnHit extends MoveEffectAttr {
@@ -1721,10 +1708,10 @@ export class SacrificialAttrOnHit extends MoveEffectAttr {
 
   /**
    * Deals damage to the user equal to their current hp if the move lands
-   * @param user {@linkcode Pokemon} that used the move
-   * @param target {@linkcode Pokemon} target of the move
-   * @param move {@linkcode Move} with this attribute
-   * @param args N/A
+   * @param user - that used the move
+   * @param target - target of the move
+   * @param move - with this attribute
+   * @param args - N/A
    * @returns true if the function succeeds
    **/
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -1750,7 +1737,6 @@ export class SacrificialAttrOnHit extends MoveEffectAttr {
 /**
  * Attribute used for moves which cut the user's Max HP in half.
  * Triggers using {@linkcode MoveEffectTrigger.POST_TARGET}.
- * @extends MoveEffectAttr
  * @see {@linkcode apply}
  */
 export class HalfSacrificialAttr extends MoveEffectAttr {
@@ -1760,10 +1746,10 @@ export class HalfSacrificialAttr extends MoveEffectAttr {
 
   /**
    * Cut's the user's Max HP in half and displays the appropriate recoil message
-   * @param user {@linkcode Pokemon} that used the move
-   * @param target N/A
-   * @param move {@linkcode Move} with this attribute
-   * @param args N/A
+   * @param user - that used the move
+   * @param target - N/A
+   * @param move - with this attribute
+   * @param args - N/A
    * @returns true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -1792,7 +1778,6 @@ export class HalfSacrificialAttr extends MoveEffectAttr {
 /**
  * Attribute to put in a {@link https://bulbapedia.bulbagarden.net/wiki/Substitute_(doll) | Substitute Doll}
  * for the user.
- * @extends MoveEffectAttr
  * @see {@linkcode apply}
  */
 export class AddSubstituteAttr extends MoveEffectAttr {
@@ -1810,10 +1795,10 @@ export class AddSubstituteAttr extends MoveEffectAttr {
 
   /**
    * Removes 1/4 of the user's maximum HP (rounded down) to create a substitute for the user
-   * @param user the {@linkcode Pokemon} that used the move.
-   * @param target n/a
-   * @param move the {@linkcode Move} with this attribute.
-   * @param args n/a
+   * @param user - the {@linkcode Pokemon} that used the move.
+   * @param target - n/a
+   * @param move - the {@linkcode Move} with this attribute.
+   * @param args - n/a
    * @returns true if the attribute successfully applies, false otherwise
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -1840,7 +1825,7 @@ export class AddSubstituteAttr extends MoveEffectAttr {
 
   /**
    * Get the substitute-specific failure message if one should be displayed.
-   * @param user The pokemon using the move.
+   * @param user - The pokemon using the move.
    * @returns The substitute-specific failure message if the conditions apply, otherwise `undefined`
    */
   getFailedText(user: Pokemon, _target: Pokemon, _move: Move): string | undefined {
@@ -1854,7 +1839,6 @@ export class AddSubstituteAttr extends MoveEffectAttr {
 
 /**
  * Heals the user or target by {@linkcode healRatio} depending on the value of {@linkcode selfTarget}
- * @extends MoveEffectAttr
  * @see {@linkcode apply}
  */
 export class HealAttr extends MoveEffectAttr {
@@ -1892,7 +1876,6 @@ export class HealAttr extends MoveEffectAttr {
 
 /**
  * Cures the user's party of non-volatile status conditions, ie. Heal Bell, Aromatherapy
- * @extends MoveEffectAttr
  * @see {@linkcode apply}
  */
 export class PartyStatusCureAttr extends MoveEffectAttr {
@@ -1932,8 +1915,8 @@ export class PartyStatusCureAttr extends MoveEffectAttr {
 
   /**
    * Tries to cure the status of the given {@linkcode Pokemon}
-   * @param pokemon The {@linkcode Pokemon} to cure.
-   * @param userId The ID of the (move) {@linkcode Pokemon | user}.
+   * @param pokemon - The {@linkcode Pokemon} to cure.
+   * @param userId - The ID of the (move) {@linkcode Pokemon | user}.
    */
   public cureStatus(pokemon: Pokemon, userId: number) {
     if (!pokemon.isOnField() || pokemon.id === userId) { // user always cures its own status, regardless of ability
@@ -1952,7 +1935,6 @@ export class PartyStatusCureAttr extends MoveEffectAttr {
 
 /**
  * Applies damage to the target's ally equal to 1/16 of that ally's max HP.
- * @extends MoveEffectAttr
  */
 export class FlameBurstAttr extends MoveEffectAttr {
   /**
@@ -2031,7 +2013,6 @@ export class SacrificialFullRestoreAttr extends SacrificialAttr {
 /**
  * Attribute used for moves which ignore type-based debuffs from weather, namely Hydro Steam.
  * Called during damage calculation after getting said debuff from getAttackTypeMultiplier in the Pokemon class.
- * @extends MoveAttr
  * @see {@linkcode apply}
  */
 export class IgnoreWeatherTypeDebuffAttr extends MoveAttr {
@@ -2044,10 +2025,10 @@ export class IgnoreWeatherTypeDebuffAttr extends MoveAttr {
   }
   /**
    * Changes the type-based weather modifier if this move's power would be reduced by it
-   * @param user {@linkcode Pokemon} that used the move
-   * @param target N/A
-   * @param move {@linkcode Move} with this attribute
-   * @param args [0] {@linkcode NumberHolder} for arenaAttackTypeMultiplier
+   * @param user - that used the move
+   * @param target - N/A
+   * @param move - with this attribute
+   * @param args - [0] {@linkcode NumberHolder} for arenaAttackTypeMultiplier
    * @returns true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -2110,7 +2091,6 @@ export class SandHealAttr extends WeatherHealAttr {
 /**
  * Heals the target or the user by either {@linkcode normalHealRatio} or {@linkcode boostedHealRatio}
  * depending on the evaluation of {@linkcode condition}
- * @extends HealAttr
  * @see {@linkcode apply}
  */
 export class BoostHealAttr extends HealAttr {
@@ -2129,10 +2109,10 @@ export class BoostHealAttr extends HealAttr {
   }
 
   /**
-   * @param user {@linkcode Pokemon} using the move
-   * @param target {@linkcode Pokemon} target of the move
-   * @param move {@linkcode Move} with this attribute
-   * @param args N/A
+   * @param user - using the move
+   * @param target - target of the move
+   * @param move - with this attribute
+   * @param args - N/A
    * @returns true if the move was successful
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -2144,15 +2124,14 @@ export class BoostHealAttr extends HealAttr {
 
 /**
  * Heals the target only if it is the ally
- * @extends HealAttr
  * @see {@linkcode apply}
  */
 export class HealOnAllyAttr extends HealAttr {
   /**
-   * @param user {@linkcode Pokemon} using the move
-   * @param target {@linkcode Pokemon} target of the move
-   * @param move {@linkcode Move} with this attribute
-   * @param args N/A
+   * @param user - using the move
+   * @param target - target of the move
+   * @param move - with this attribute
+   * @param args - N/A
    * @returns true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -2168,7 +2147,6 @@ export class HealOnAllyAttr extends HealAttr {
 /**
  * Heals user as a side effect of a move that hits a target.
  * Healing is based on {@linkcode healRatio} * the amount of damage dealt or a stat of the target.
- * @extends MoveEffectAttr
  * @see {@linkcode apply}
  * @see {@linkcode getUserBenefitScore}
  */
@@ -2186,10 +2164,10 @@ export class HitHealAttr extends MoveEffectAttr {
    * Heals the user the determined amount and possibly displays a message about regaining health.
    * If the target has the {@linkcode ReverseDrainAbAttr}, all healing is instead converted
    * to damage to the user.
-   * @param user {@linkcode Pokemon} using this move
-   * @param target {@linkcode Pokemon} target of this move
-   * @param move {@linkcode Move} being used
-   * @param args N/A
+   * @param user - using this move
+   * @param target - target of this move
+   * @param move - being used
+   * @param args - N/A
    * @returns true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -2221,9 +2199,9 @@ export class HitHealAttr extends MoveEffectAttr {
 
   /**
    * Used by the Enemy AI to rank an attack based on a given user
-   * @param user {@linkcode Pokemon} using this move
-   * @param target {@linkcode Pokemon} target of this move
-   * @param move {@linkcode Move} being used
+   * @param user - using this move
+   * @param target - target of this move
+   * @param move - being used
    * @returns an integer. Higher means enemy is more likely to use that move.
    */
   getUserBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
@@ -2239,7 +2217,6 @@ export class HitHealAttr extends MoveEffectAttr {
  * Attribute used for moves that change priority in a turn given a condition,
  * e.g. Grassy Glide
  * Called when move order is calculated in {@linkcode TurnStartPhase}.
- * @extends MoveAttr
  * @see {@linkcode apply}
  */
 export class IncrementMovePriorityAttr extends MoveAttr {
@@ -2257,10 +2234,10 @@ export class IncrementMovePriorityAttr extends MoveAttr {
 
   /**
    * Increments move priority by set amount if condition passes
-   * @param user {@linkcode Pokemon} using this move
-   * @param target {@linkcode Pokemon} target of this move
-   * @param move {@linkcode Move} being used
-   * @param args [0] {@linkcode NumberHolder} for move priority.
+   * @param user - using this move
+   * @param target - target of this move
+   * @param move - being used
+   * @param args - [0] {@linkcode NumberHolder} for move priority.
    * @returns true if function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -2278,7 +2255,6 @@ export class IncrementMovePriorityAttr extends MoveAttr {
  *
  * Applied at the beginning of {@linkcode MoveEffectPhase}.
  *
- * @extends MoveAttr
  * @see {@linkcode apply}
  */
 export class MultiHitAttr extends MoveAttr {
@@ -2303,10 +2279,10 @@ export class MultiHitAttr extends MoveAttr {
    * Set the hit count of an attack based on this attribute instance's {@linkcode MultiHitType}.
    * If the target has an immunity to this attack's types, the hit count will always be 1.
    *
-   * @param user {@linkcode Pokemon} that used the attack
-   * @param target {@linkcode Pokemon} targeted by the attack
-   * @param move {@linkcode Move} being used
-   * @param args [0] {@linkcode NumberHolder} storing the hit count of the attack
+   * @param user - that used the attack
+   * @param target - targeted by the attack
+   * @param move - being used
+   * @param args - [0] {@linkcode NumberHolder} storing the hit count of the attack
    * @returns True
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -2326,8 +2302,8 @@ export class MultiHitAttr extends MoveAttr {
    * Calculate the number of hits that an attack should have given this attribute's
    * {@linkcode MultiHitType}.
    *
-   * @param user {@linkcode Pokemon} using the attack
-   * @param target {@linkcode Pokemon} targeted by the attack
+   * @param user - using the attack
+   * @param target - targeted by the attack
    * @returns The number of hits this attack should deal
    */
   getHitCount(user: Pokemon, target: Pokemon): number {
@@ -2596,10 +2572,10 @@ export class RemoveHeldItemAttr extends MoveEffectAttr {
 
   /**
    *
-   * @param user {@linkcode Pokemon} that used the move
-   * @param target Target {@linkcode Pokemon} that the moves applies to
-   * @param move {@linkcode Move} that is used
-   * @param args N/A
+   * @param user - that used the move
+   * @param target - Target {@linkcode Pokemon} that the moves applies to
+   * @param move - that is used
+   * @param args - N/A
    * @returns {boolean} True if an item was removed
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -2669,10 +2645,10 @@ export class EatBerryAttr extends MoveEffectAttr {
   }
   /**
    * Causes the target to eat a berry.
-   * @param user {@linkcode Pokemon} Pokemon that used the move
-   * @param target {@linkcode Pokemon} Pokemon that will eat a berry
-   * @param move {@linkcode Move} The move being used
-   * @param args Unused
+   * @param user - Pokemon that used the move
+   * @param target - Pokemon that will eat a berry
+   * @param move - The move being used
+   * @param args - Unused
    * @returns {boolean} true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -2722,10 +2698,10 @@ export class StealEatBerryAttr extends EatBerryAttr {
   }
   /**
    * User steals a random berry from the target and then eats it.
-   * @param {Pokemon} user Pokemon that used the move and will eat the stolen berry
-   * @param {Pokemon} target Pokemon that will have its berry stolen
-   * @param {Move} move Move being used
-   * @param {any[]} args Unused
+   * @param user - Pokemon that used the move and will eat the stolen berry
+   * @param target - Pokemon that will have its berry stolen
+   * @param move - Move being used
+   * @param args - Unused
    * @returns {boolean} true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -2755,7 +2731,6 @@ export class StealEatBerryAttr extends EatBerryAttr {
 
 /**
  * Move attribute that signals that the move should cure a status effect
- * @extends MoveEffectAttr
  * @see {@linkcode apply()}
  */
 export class HealStatusEffectAttr extends MoveEffectAttr {
@@ -2772,9 +2747,9 @@ export class HealStatusEffectAttr extends MoveEffectAttr {
   }
 
   /**
-   * @param user {@linkcode Pokemon} source of the move
-   * @param target {@linkcode Pokemon} target of the move
-   * @param move the {@linkcode Move} being used
+   * @param user - source of the move
+   * @param target - target of the move
+   * @param move - the {@linkcode Move} being used
    * @returns true if the status is cured
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -2837,15 +2812,14 @@ export class BypassSleepAttr extends MoveAttr {
 /**
  * Attribute used for moves that bypass the burn damage reduction of physical moves, currently only facade
  * Called during damage calculation
- * @extends MoveAttr
  * @see {@linkcode apply}
  */
 export class BypassBurnDamageReductionAttr extends MoveAttr {
   /** Prevents the move's damage from being reduced by burn
-   * @param user N/A
-   * @param target N/A
-   * @param move {@linkcode Move} with this attribute
-   * @param args [0] {@linkcode BooleanHolder} for burnDamageReductionCancelled
+   * @param user - N/A
+   * @param target - N/A
+   * @param move - with this attribute
+   * @param args - [0] {@linkcode BooleanHolder} for burnDamageReductionCancelled
    * @returns true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -2947,7 +2921,6 @@ export class OneHitKOAttr extends MoveAttr {
 /**
  * Attribute that allows charge moves to resolve in 1 turn under a given condition.
  * Should only be used for {@linkcode ChargingMove | ChargingMoves} as a `chargeAttr`.
- * @extends MoveAttr
  */
 export class InstantChargeAttr extends MoveAttr {
   /** The condition in which the move with this attribute instantly charges */
@@ -2960,9 +2933,9 @@ export class InstantChargeAttr extends MoveAttr {
 
   /**
    * Flags the move with this attribute as instantly charged if this attribute's condition is met.
-   * @param user the {@linkcode Pokemon} using the move
-   * @param target n/a
-   * @param move the {@linkcode Move} associated with this attribute
+   * @param user - the {@linkcode Pokemon} using the move
+   * @param target - n/a
+   * @param move - the {@linkcode Move} associated with this attribute
    * @param args
    *  - `[0]` a {@linkcode BooleanHolder | BooleanHolder} for the "instant charge" flag
    * @returns `true` if the instant charge condition is met; `false` otherwise.
@@ -2984,7 +2957,6 @@ export class InstantChargeAttr extends MoveAttr {
 /**
  * Attribute that allows charge moves to resolve in 1 turn while specific {@linkcode WeatherType | Weather}
  * is active. Should only be used for {@linkcode ChargingMove | ChargingMoves} as a `chargeAttr`.
- * @extends InstantChargeAttr
  */
 export class WeatherInstantChargeAttr extends InstantChargeAttr {
   constructor(weatherTypes: WeatherType[]) {
@@ -3010,10 +2982,9 @@ export class OverrideMoveEffectAttr extends MoveAttr {
 /**
  * Attack Move that doesn't hit the turn it is played and doesn't allow for multiple
  * uses on the same target. Examples are Future Sight or Doom Desire.
- * @extends OverrideMoveEffectAttr
- * @param tagType The {@linkcode ArenaTagType} that will be placed on the field when the move is used
- * @param chargeAnim The {@linkcode ChargeAnim | Charging Animation} used for the move
- * @param chargeText The text to display when the move is used
+ * @param tagType - The {@linkcode ArenaTagType} that will be placed on the field when the move is used
+ * @param chargeAnim - The {@linkcode ChargeAnim | Charging Animation} used for the move
+ * @param chargeText - The text to display when the move is used
  */
 export class DelayedAttackAttr extends OverrideMoveEffectAttr {
   public tagType: ArenaTagType;
@@ -3055,7 +3026,6 @@ export class DelayedAttackAttr extends OverrideMoveEffectAttr {
 /**
  * Attribute that cancels the associated move's effects when set to be combined with the user's ally's
  * subsequent move this turn. Used for Grass Pledge, Water Pledge, and Fire Pledge.
- * @extends OverrideMoveEffectAttr
  */
 export class AwaitCombinedPledgeAttr extends OverrideMoveEffectAttr {
   constructor() {
@@ -3064,9 +3034,9 @@ export class AwaitCombinedPledgeAttr extends OverrideMoveEffectAttr {
   /**
    * If the user's ally is set to use a different move with this attribute,
    * defer this move's effects for a combined move on the ally's turn.
-   * @param user the {@linkcode Pokemon} using this move
-   * @param target n/a
-   * @param move the {@linkcode Move} being used
+   * @param user - the {@linkcode Pokemon} using this move
+   * @param target - n/a
+   * @param move - the {@linkcode Move} being used
    * @param args
    * - [0] a {@linkcode BooleanHolder} indicating whether the move's base
    * effects should be overridden this turn.
@@ -3110,7 +3080,6 @@ export class AwaitCombinedPledgeAttr extends OverrideMoveEffectAttr {
 
 /**
  * Set of optional parameters that may be applied to stat stage changing effects
- * @extends MoveEffectAttrOptions
  * @see {@linkcode StatStageChangeAttr}
  */
 interface StatStageChangeAttrOptions extends MoveEffectAttrOptions {
@@ -3123,12 +3092,11 @@ interface StatStageChangeAttrOptions extends MoveEffectAttrOptions {
 /**
  * Attribute used for moves that change stat stages
  *
- * @param stats {@linkcode BattleStat} Array of stat(s) to change
- * @param stages How many stages to change the stat(s) by, [-6, 6]
- * @param selfTarget `true` if the move is self-targetting
- * @param options {@linkcode StatStageChangeAttrOptions} Container for any optional parameters for this attribute.
+ * @param stats - Array of stat(s) to change
+ * @param stages - How many stages to change the stat(s) by, [-6, 6]
+ * @param selfTarget - `true` if the move is self-targetting
+ * @param options - Container for any optional parameters for this attribute.
  *
- * @extends MoveEffectAttr
  * @see {@linkcode apply}
  */
 export class StatStageChangeAttr extends MoveEffectAttr {
@@ -3173,10 +3141,10 @@ export class StatStageChangeAttr extends MoveEffectAttr {
 
   /**
    * Attempts to change stats of the user or target (depending on value of selfTarget) if conditions are met
-   * @param user {@linkcode Pokemon} the user of the move
-   * @param target {@linkcode Pokemon} the target of the move
-   * @param move {@linkcode Move} the move
-   * @param args unused
+   * @param user - the user of the move
+   * @param target - the target of the move
+   * @param move - the move
+   * @param args - unused
    * @returns whether stat stages were changed
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args?: any[]): boolean {
@@ -3574,7 +3542,6 @@ export class ResetStatsAttr extends MoveEffectAttr {
 /**
  * Attribute used for status moves, specifically Heart, Guard, and Power Swap,
  * that swaps the user's and target's corresponding stat stages.
- * @extends MoveEffectAttr
  * @see {@linkcode apply}
  */
 export class SwapStatStagesAttr extends MoveEffectAttr {
@@ -3590,10 +3557,10 @@ export class SwapStatStagesAttr extends MoveEffectAttr {
   /**
    * For all {@linkcode stats}, swaps the user's and target's corresponding stat
    * stage.
-   * @param user the {@linkcode Pokemon} that used the move
-   * @param target the {@linkcode Pokemon} that the move was used on
-   * @param move N/A
-   * @param args N/A
+   * @param user - the {@linkcode Pokemon} that used the move
+   * @param target - the {@linkcode Pokemon} that the move was used on
+   * @param move - N/A
+   * @param args - N/A
    * @returns true if attribute application succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any []): boolean {
@@ -3658,10 +3625,10 @@ export class VariablePowerAttr extends MoveAttr {
 export class LessPPMorePowerAttr extends VariablePowerAttr {
   /**
    * Power up moves when less PP user has
-   * @param user {@linkcode Pokemon} using this move
-   * @param target {@linkcode Pokemon} target of this move
-   * @param move {@linkcode Move} being used
-   * @param args [0] {@linkcode NumberHolder} of power
+   * @param user - using this move
+   * @param target - target of this move
+   * @param move - being used
+   * @param args - [0] {@linkcode NumberHolder} of power
    * @returns true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -3716,8 +3683,8 @@ export class MovePowerMultiplierAttr extends VariablePowerAttr {
 
 /**
  * Helper function to calculate the the base power of an ally's hit when using Beat Up.
- * @param user The Pokemon that used Beat Up.
- * @param allyIndex The party position of the ally contributing to Beat Up.
+ * @param user - The Pokemon that used Beat Up.
+ * @param allyIndex - The party position of the ally contributing to Beat Up.
  * @returns The base power of the Beat Up hit.
  */
 const beatUpFunc = (user: Pokemon, allyIndex: number): number => {
@@ -3740,10 +3707,10 @@ export class BeatUpAttr extends VariablePowerAttr {
 
   /**
    * Gets the next party member to contribute to a Beat Up hit, and calculates the base power for it.
-   * @param user Pokemon that used the move
-   * @param _target N/A
-   * @param _move Move with this attribute
-   * @param args N/A
+   * @param user - Pokemon that used the move
+   * @param _target - N/A
+   * @param _move - Move with this attribute
+   * @param args - N/A
    * @returns true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -3849,17 +3816,16 @@ export class WeightPowerAttr extends VariablePowerAttr {
 
 /**
  * Attribute used for Electro Ball move.
- * @extends VariablePowerAttr
  * @see {@linkcode apply}
  **/
 export class ElectroBallPowerAttr extends VariablePowerAttr {
   /**
    * Move that deals more damage the faster {@linkcode Stat.SPD}
    * the user is compared to the target.
-   * @param user Pokemon that used the move
-   * @param target The target of the move
-   * @param move Move with this attribute
-   * @param args N/A
+   * @param user - Pokemon that used the move
+   * @param target - The target of the move
+   * @param move - Move with this attribute
+   * @param args - N/A
    * @returns true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -3884,17 +3850,16 @@ export class ElectroBallPowerAttr extends VariablePowerAttr {
 
 /**
  * Attribute used for Gyro Ball move.
- * @extends VariablePowerAttr
  * @see {@linkcode apply}
  **/
 export class GyroBallPowerAttr extends VariablePowerAttr {
   /**
    * Move that deals more damage the slower {@linkcode Stat.SPD}
    * the user is compared to the target.
-   * @param user Pokemon that used the move
-   * @param target The target of the move
-   * @param move Move with this attribute
-   * @param args N/A
+   * @param user - Pokemon that used the move
+   * @param target - The target of the move
+   * @param move - Move with this attribute
+   * @param args - N/A
    * @returns true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -3998,10 +3963,10 @@ export class OpponentHighHpPowerAttr extends VariablePowerAttr {
 
   /**
    * Changes the base power of the move to be the target's HP ratio times the maxBasePower with a min value of 1
-   * @param user n/a
-   * @param target the Pokemon being attacked
-   * @param move n/a
-   * @param args holds the base power of the move at args[0]
+   * @param user - n/a
+   * @param target - the Pokemon being attacked
+   * @param move - n/a
+   * @param args - holds the base power of the move at args[0]
    * @returns true
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -4135,9 +4100,9 @@ export class RageFistPowerAttr extends VariablePowerAttr {
 
   /**
    * Updates the number of hits the Pokemon has taken in battle
-   * @param user Pokemon calling Rage Fist
-   * @param hitCount The number of received hits this battle
-   * @param previousHitCount The number of received hits this battle since last time Rage Fist was used
+   * @param user - Pokemon calling Rage Fist
+   * @param hitCount - The number of received hits this battle
+   * @param previousHitCount - The number of received hits this battle since last time Rage Fist was used
    */
   protected updateHitReceivedCount(user: Pokemon, hitCount: number, previousHitCount: number): void {
     user.customPokemonData.hitsRecCount += (hitCount - previousHitCount);
@@ -4147,7 +4112,7 @@ export class RageFistPowerAttr extends VariablePowerAttr {
 
 /**
  * Tallies the number of positive stages for a given {@linkcode Pokemon}.
- * @param pokemon The {@linkcode Pokemon} that is being used to calculate the count of positive stats
+ * @param pokemon - The {@linkcode Pokemon} that is being used to calculate the count of positive stats
  * @returns the amount of positive stats
  */
 const countPositiveStatStages = (pokemon: Pokemon): number => {
@@ -4160,10 +4125,10 @@ const countPositiveStatStages = (pokemon: Pokemon): number => {
 export class PositiveStatStagePowerAttr extends VariablePowerAttr {
 
   /**
-   * @param {Pokemon} user The pokemon that is being used to calculate the amount of positive stats
-   * @param {Pokemon} target N/A
-   * @param {Move} move N/A
-   * @param {any[]} args The argument for VariablePowerAttr, accumulates and sets the amount of power multiplied by stats
+   * @param user - The pokemon that is being used to calculate the amount of positive stats
+   * @param target - N/A
+   * @param move - N/A
+   * @param args - The argument for VariablePowerAttr, accumulates and sets the amount of power multiplied by stats
    * @returns {boolean} Returns true if attribute is applied
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -4184,10 +4149,10 @@ export class PunishmentPowerAttr extends VariablePowerAttr {
   private PUNISHMENT_MAX_BASE_POWER = 200;
 
   /**
-     * @param {Pokemon} user N/A
-     * @param {Pokemon} target The pokemon that the move is being used against, as well as calculating the stats for the min/max base power
-     * @param {Move} move N/A
-     * @param {any[]} args The value that is being changed due to VariablePowerAttr
+     * @param user - N/A
+     * @param target - The pokemon that the move is being used against, as well as calculating the stats for the min/max base power
+     * @param move - N/A
+     * @param args - The value that is being changed due to VariablePowerAttr
      * @returns Returns true if attribute is applied
      */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -4298,7 +4263,6 @@ const hasStockpileStacksCondition: MoveConditionFunc = (user) => {
 /**
  * Attribute used for multi-hit moves that increase power in increments of the
  * move's base power for each hit, namely Triple Kick and Triple Axel.
- * @extends VariablePowerAttr
  * @see {@linkcode apply}
  */
 export class MultiHitPowerIncrementAttr extends VariablePowerAttr {
@@ -4316,10 +4280,10 @@ export class MultiHitPowerIncrementAttr extends VariablePowerAttr {
    * the move hit. In the case that the move is extended, it will circle back to the
    * original base power of the move after incrementing past the maximum amount of
    * hits.
-   * @param user {@linkcode Pokemon} that used the move
-   * @param target {@linkcode Pokemon} that the move was used on
-   * @param move {@linkcode Move} with this attribute
-   * @param args [0] {@linkcode NumberHolder} for final calculated power of move
+   * @param user - that used the move
+   * @param target - that the move was used on
+   * @param move - with this attribute
+   * @param args - [0] {@linkcode NumberHolder} for final calculated power of move
    * @returns true if attribute application succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -4336,7 +4300,6 @@ export class MultiHitPowerIncrementAttr extends VariablePowerAttr {
  * Attribute used for moves that double in power if the given move immediately
  * preceded the move applying the attribute, namely Fusion Flare and
  * Fusion Bolt.
- * @extends VariablePowerAttr
  * @see {@linkcode apply}
  */
 export class LastMoveDoublePowerAttr extends VariablePowerAttr {
@@ -4353,10 +4316,10 @@ export class LastMoveDoublePowerAttr extends VariablePowerAttr {
    * Doubles power of move if the given move is found to precede the current
    * move with no other moves being executed in between, only ignoring failed
    * moves if any.
-   * @param user {@linkcode Pokemon} that used the move
-   * @param target N/A
-   * @param move N/A
-   * @param args [0] {@linkcode NumberHolder} that holds the resulting power of the move
+   * @param user - that used the move
+   * @param target - N/A
+   * @param move - N/A
+   * @param args - [0] {@linkcode NumberHolder} that holds the resulting power of the move
    * @returns true if attribute application succeeds, false otherwise
    */
   apply(user: Pokemon, _target: Pokemon, _move: Move, args: any[]): boolean {
@@ -4440,7 +4403,6 @@ export class CombinedPledgeStabBoostAttr extends MoveAttr {
 /**
  * Variable Power attribute for {@link https://bulbapedia.bulbagarden.net/wiki/Round_(move) | Round}.
  * Doubles power if another Pokemon has previously selected Round this turn.
- * @extends VariablePowerAttr
  */
 export class RoundPowerAttr extends VariablePowerAttr {
   override apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -4461,7 +4423,6 @@ export class RoundPowerAttr extends VariablePowerAttr {
  * Attribute for the "combo" effect of {@link https://bulbapedia.bulbagarden.net/wiki/Round_(move) | Round}.
  * Preempts the next move in the turn order with the first instance of any Pokemon
  * using Round. Also marks the Pokemon using the cued Round to double the move's power.
- * @extends MoveEffectAttr
  * @see {@linkcode RoundPowerAttr}
  */
 export class CueNextRoundAttr extends MoveEffectAttr {
@@ -4498,10 +4459,10 @@ export class StatChangeBeforeDmgCalcAttr extends MoveAttr {
   /**
    * Applies Stat Changes before damage is calculated
    *
-   * @param user {@linkcode Pokemon} that called {@linkcode move}
-   * @param target {@linkcode Pokemon} that is the target of {@linkcode move}
-   * @param move {@linkcode Move} called by {@linkcode user}
-   * @param args N/A
+   * @param user - that called {@linkcode move}
+   * @param target - that is the target of {@linkcode move}
+   * @param move - called by {@linkcode user}
+   * @param args - N/A
    *
    * @returns true if stat stages where correctly applied
    */
@@ -4519,10 +4480,10 @@ export class SpectralThiefAttr extends StatChangeBeforeDmgCalcAttr {
   /**
    * steals max amount of positive stats of the target while not exceeding the limit of max 6 stat stages
    *
-   * @param user {@linkcode Pokemon} that called {@linkcode move}
-   * @param target {@linkcode Pokemon} that is the target of {@linkcode move}
-   * @param move {@linkcode Move} called by {@linkcode user}
-   * @param args N/A
+   * @param user - that called {@linkcode move}
+   * @param target - that is the target of {@linkcode move}
+   * @param move - called by {@linkcode user}
+   * @param args - N/A
    *
    * @returns true if stat stages where correctly stolen
    */
@@ -4664,16 +4625,15 @@ export class StormAccuracyAttr extends VariableAccuracyAttr {
 /**
  * Attribute used for moves which never miss
  * against Pokemon with the {@linkcode BattlerTagType.MINIMIZED}
- * @extends VariableAccuracyAttr
  * @see {@linkcode apply}
  */
 export class AlwaysHitMinimizeAttr extends VariableAccuracyAttr {
   /**
    * @see {@linkcode apply}
-   * @param user N/A
-   * @param target {@linkcode Pokemon} target of the move
-   * @param move N/A
-   * @param args [0] Accuracy of the move to be modified
+   * @param user - N/A
+   * @param target - target of the move
+   * @param move - N/A
+   * @param args - [0] Accuracy of the move to be modified
    * @returns true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -4739,7 +4699,6 @@ export class PhotonGeyserCategoryAttr extends VariableMoveCategoryAttr {
  * Note: Currently, `getEffectiveStat` does not ignore all abilities that affect stats except those
  * with the attribute of `StatMultiplierAbAttr`
  * TODO: Remove the `.partial()` tag from Tera Blast and Tera Starstorm when the above issue is resolved
- * @extends VariableMoveCategoryAttr
  */
 export class TeraMoveCategoryAttr extends VariableMoveCategoryAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -4757,15 +4716,14 @@ export class TeraMoveCategoryAttr extends VariableMoveCategoryAttr {
 
 /**
  * Increases the power of Tera Blast if the user is Terastallized into Stellar type
- * @extends VariablePowerAttr
  */
 export class TeraBlastPowerAttr extends VariablePowerAttr {
   /**
    * Sets Tera Blast's power to 100 if the user is terastallized with
    * the Stellar tera type.
-   * @param user {@linkcode Pokemon} the Pokemon using this move
-   * @param target n/a
-   * @param move {@linkcode Move} the Move with this attribute (i.e. Tera Blast)
+   * @param user - the Pokemon using this move
+   * @param target - n/a
+   * @param move - the Move with this attribute (i.e. Tera Blast)
    * @param args
    *   - [0] {@linkcode NumberHolder} the applied move's power, factoring in
    *       previously applied power modifiers.
@@ -4784,15 +4742,14 @@ export class TeraBlastPowerAttr extends VariablePowerAttr {
 
 /**
  * Change the move category to status when used on the ally
- * @extends VariableMoveCategoryAttr
  * @see {@linkcode apply}
  */
 export class StatusCategoryOnAllyAttr extends VariableMoveCategoryAttr {
   /**
-   * @param user {@linkcode Pokemon} using the move
-   * @param target {@linkcode Pokemon} target of the move
-   * @param move {@linkcode Move} with this attribute
-   * @param args [0] {@linkcode NumberHolder} The category of the move
+   * @param user - using the move
+   * @param target - target of the move
+   * @param move - with this attribute
+   * @param args - [0] {@linkcode NumberHolder} The category of the move
    * @returns true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -5008,15 +4965,14 @@ export class WeatherBallTypeAttr extends VariableMoveTypeAttr {
 /**
  * Changes the move's type to match the current terrain.
  * Has no effect if the user is not grounded.
- * @extends VariableMoveTypeAttr
  * @see {@linkcode apply}
  */
 export class TerrainPulseTypeAttr extends VariableMoveTypeAttr {
   /**
-   * @param user {@linkcode Pokemon} using this move
-   * @param target N/A
-   * @param move N/A
-   * @param args [0] {@linkcode NumberHolder} The move's type to be modified
+   * @param user - using this move
+   * @param target - N/A
+   * @param move - N/A
+   * @param args - [0] {@linkcode NumberHolder} The move's type to be modified
    * @returns true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -5052,7 +5008,6 @@ export class TerrainPulseTypeAttr extends VariableMoveTypeAttr {
 
 /**
  * Changes type based on the user's IVs
- * @extends VariableMoveTypeAttr
  */
 export class HiddenPowerTypeAttr extends VariableMoveTypeAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -5080,14 +5035,13 @@ export class HiddenPowerTypeAttr extends VariableMoveTypeAttr {
 
 /**
  * Changes the type of Tera Blast to match the user's tera type
- * @extends VariableMoveTypeAttr
  */
 export class TeraBlastTypeAttr extends VariableMoveTypeAttr {
   /**
-   * @param user {@linkcode Pokemon} the user of the move
-   * @param target {@linkcode Pokemon} N/A
-   * @param move {@linkcode Move} the move with this attribute
-   * @param args `[0]` the move's type to be modified
+   * @param user - the user of the move
+   * @param target - N/A
+   * @param move - the move with this attribute
+   * @param args - `[0]` the move's type to be modified
    * @returns `true` if the move's type was modified; `false` otherwise
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -5107,15 +5061,14 @@ export class TeraBlastTypeAttr extends VariableMoveTypeAttr {
 
 /**
  * Attribute used for Tera Starstorm that changes the move type to Stellar
- * @extends VariableMoveTypeAttr
  */
 export class TeraStarstormTypeAttr extends VariableMoveTypeAttr {
   /**
    *
-   * @param user the {@linkcode Pokemon} using the move
-   * @param target n/a
-   * @param move n/a
-   * @param args[0] {@linkcode NumberHolder} the move type
+   * @param user - the {@linkcode Pokemon} using the move
+   * @param target - n/a
+   * @param move - n/a
+   * @param args[0] - the move type
    * @returns `true` if the move type is changed to {@linkcode PokemonType.STELLAR}, `false` otherwise
    */
   override apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -5153,7 +5106,6 @@ export class MatchUserTypeAttr extends VariableMoveTypeAttr {
 
 /**
  * Changes the type of a Pledge move based on the Pledge move combined with it.
- * @extends VariableMoveTypeAttr
  */
 export class CombinedPledgeTypeAttr extends VariableMoveTypeAttr {
   override apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -5216,10 +5168,10 @@ export class NeutralDamageAgainstFlyingTypeMultiplierAttr extends VariableMoveTy
 export class IceNoEffectTypeAttr extends VariableMoveTypeMultiplierAttr {
   /**
    * Checks to see if the Target is Ice-Type or not. If so, the move will have no effect.
-   * @param user n/a
-   * @param target The {@linkcode Pokemon} targeted by the move
-   * @param move n/a
-   * @param args `[0]` a {@linkcode NumberHolder | NumberHolder} containing a type effectiveness multiplier
+   * @param user - n/a
+   * @param target - The {@linkcode Pokemon} targeted by the move
+   * @param move - n/a
+   * @param args - `[0]` a {@linkcode NumberHolder | NumberHolder} containing a type effectiveness multiplier
    * @returns `true` if this Ice-type immunity applies; `false` otherwise
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -5245,11 +5197,11 @@ export class FlyingTypeMultiplierAttr extends VariableMoveTypeMultiplierAttr {
  */
 export class VariableMoveTypeChartAttr extends MoveAttr {
   /**
-   * @param user {@linkcode Pokemon} using the move
-   * @param target {@linkcode Pokemon} target of the move
-   * @param move {@linkcode Move} with this attribute
-   * @param args [0] {@linkcode NumberHolder} holding the type effectiveness
-   * @param args [1] A single defensive type of the target
+   * @param user - using the move
+   * @param target - target of the move
+   * @param move - with this attribute
+   * @param args - [0] {@linkcode NumberHolder} holding the type effectiveness
+   * @param args - [1] A single defensive type of the target
    *
    * @returns true if application of the attribute succeeds
    */
@@ -5291,10 +5243,10 @@ export class SheerColdAccuracyAttr extends OneHitKOAccuracyAttr {
   /**
    * Changes the normal One Hit KO Accuracy Attr to implement the Gen VII changes,
    * where if the user is Ice-Type, it has more accuracy.
-   * @param {Pokemon} user Pokemon that is using the move; checks the Pokemon's level.
-   * @param {Pokemon} target Pokemon that is receiving the move; checks the Pokemon's level.
-   * @param {Move} move N/A
-   * @param {any[]} args Uses the accuracy argument, allowing to change it from either 0 if it doesn't pass
+   * @param user - Pokemon that is using the move; checks the Pokemon's level.
+   * @param target - Pokemon that is receiving the move; checks the Pokemon's level.
+   * @param move - N/A
+   * @param args - Uses the accuracy argument, allowing to change it from either 0 if it doesn't pass
    * the first if/else, or 30/20 depending on the type of the user Pokemon.
    * @returns Returns true if move is successful, false if misses.
    */
@@ -5408,7 +5360,6 @@ export const frenzyMissFunc: UserMoveConditionFunc = (user: Pokemon, move: Move)
 /**
  * Attribute that grants {@link https://bulbapedia.bulbagarden.net/wiki/Semi-invulnerable_turn | semi-invulnerability} to the user during
  * the associated move's charging phase. Should only be used for {@linkcode ChargingMove | ChargingMoves} as a `chargeAttr`.
- * @extends MoveEffectAttr
  */
 export class SemiInvulnerableAttr extends MoveEffectAttr {
   /** The type of {@linkcode SemiInvulnerableTag} to grant to the user */
@@ -5421,10 +5372,10 @@ export class SemiInvulnerableAttr extends MoveEffectAttr {
 
   /**
    * Grants a {@linkcode SemiInvulnerableTag} to the associated move's user.
-   * @param user the {@linkcode Pokemon} using the move
-   * @param target n/a
-   * @param move the {@linkcode Move} being used
-   * @param args n/a
+   * @param user - the {@linkcode Pokemon} using the move
+   * @param target - n/a
+   * @param move - the {@linkcode Move} being used
+   * @param args - n/a
    * @returns `true` if semi-invulnerability was successfully granted; `false` otherwise.
    */
   override apply(user: Pokemon, target: Pokemon, move: Move, args?: any[]): boolean {
@@ -5543,7 +5494,6 @@ export class AddBattlerTagAttr extends MoveEffectAttr {
 /**
  * Adds a {@link https://bulbapedia.bulbagarden.net/wiki/Seeding | Seeding} effect to the target
  * as seen with Leech Seed and Sappy Seed.
- * @extends AddBattlerTagAttr
  */
 export class LeechSeedAttr extends AddBattlerTagAttr {
   constructor() {
@@ -5552,10 +5502,10 @@ export class LeechSeedAttr extends AddBattlerTagAttr {
 
   /**
    * Adds a Seeding effect to the target if the target does not have an active Substitute.
-   * @param user the {@linkcode Pokemon} using the move
-   * @param target the {@linkcode Pokemon} targeted by the move
-   * @param move the {@linkcode Move} invoking this effect
-   * @param args n/a
+   * @param user - the {@linkcode Pokemon} using the move
+   * @param target - the {@linkcode Pokemon} targeted by the move
+   * @param move - the {@linkcode Move} invoking this effect
+   * @param args - n/a
    * @returns `true` if the effect successfully applies; `false` otherwise
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -5566,7 +5516,6 @@ export class LeechSeedAttr extends AddBattlerTagAttr {
 
 /**
  * Adds the appropriate battler tag for Smack Down and Thousand arrows
- * @extends AddBattlerTagAttr
  */
 export class FallDownAttr extends AddBattlerTagAttr {
   constructor() {
@@ -5575,10 +5524,10 @@ export class FallDownAttr extends AddBattlerTagAttr {
 
   /**
    * Adds Grounded Tag to the target and checks if fallDown message should be displayed
-   * @param user the {@linkcode Pokemon} using the move
-   * @param target the {@linkcode Pokemon} targeted by the move
-   * @param move the {@linkcode Move} invoking this effect
-   * @param args n/a
+   * @param user - the {@linkcode Pokemon} using the move
+   * @param target - the {@linkcode Pokemon} targeted by the move
+   * @param move - the {@linkcode Move} invoking this effect
+   * @param args - n/a
    * @returns `true` if the effect successfully applies; `false` otherwise
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -5591,7 +5540,6 @@ export class FallDownAttr extends AddBattlerTagAttr {
 
 /**
  * Adds the appropriate battler tag for Gulp Missile when Surf or Dive is used.
- * @extends MoveEffectAttr
  */
 export class GulpMissileTagAttr extends MoveEffectAttr {
   constructor() {
@@ -5600,10 +5548,10 @@ export class GulpMissileTagAttr extends MoveEffectAttr {
 
   /**
    * Adds BattlerTagType from GulpMissileTag based on the Pokemon's HP ratio.
-   * @param user The Pokemon using the move.
-   * @param _target N/A
-   * @param move The move being used.
-   * @param _args N/A
+   * @param user - The Pokemon using the move.
+   * @param _target - N/A
+   * @param move - The move being used.
+   * @param _args - N/A
    * @returns Whether the BattlerTag is applied.
    */
   apply(user: Pokemon, _target: Pokemon, move: Move, _args: any[]): boolean {
@@ -5631,7 +5579,6 @@ export class GulpMissileTagAttr extends MoveEffectAttr {
 
 /**
  * Attribute to implement Jaw Lock's linked trapping effect between the user and target
- * @extends AddBattlerTagAttr
  */
 export class JawLockAttr extends AddBattlerTagAttr {
   constructor() {
@@ -5838,7 +5785,6 @@ export class FaintCountdownAttr extends AddBattlerTagAttr {
 
 /**
  * Attribute to remove all Substitutes from the field.
- * @extends MoveEffectAttr
  * @see {@link https://bulbapedia.bulbagarden.net/wiki/Tidy_Up_(move) | Tidy Up}
  * @see {@linkcode SubstituteTag}
  */
@@ -5849,10 +5795,10 @@ export class RemoveAllSubstitutesAttr extends MoveEffectAttr {
 
   /**
    * Remove's the Substitute Doll effect from all active Pokemon on the field
-   * @param user {@linkcode Pokemon} the Pokemon using this move
-   * @param target n/a
-   * @param move {@linkcode Move} the move applying this effect
-   * @param args n/a
+   * @param user - the Pokemon using this move
+   * @param target - n/a
+   * @param move - the move applying this effect
+   * @param args - n/a
    * @returns `true` if the effect successfully applies
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -5870,7 +5816,6 @@ export class RemoveAllSubstitutesAttr extends MoveEffectAttr {
  * Attribute used when a move can deal damage to {@linkcode BattlerTagType}
  * Moves that always hit but do not deal double damage: Thunder, Fissure, Sky Uppercut,
  * Smack Down, Hurricane, Thousand Arrows
- * @extends MoveAttr
 */
 export class HitsTagAttr extends MoveAttr {
   /** The {@linkcode BattlerTagType} this move hits */
@@ -5939,8 +5884,8 @@ export class AddArenaTagAttr extends MoveEffectAttr {
 
 /**
  * Generic class for removing arena tags
- * @param tagTypes: The types of tags that can be removed
- * @param selfSideTarget: Is the user removing tags from its own side?
+ * @param tagTypes: - The types of tags that can be removed
+ * @param selfSideTarget: - Is the user removing tags from its own side?
  */
 export class RemoveArenaTagsAttr extends MoveEffectAttr {
   public tagTypes: ArenaTagType[];
@@ -5984,14 +5929,13 @@ export class AddArenaTrapTagAttr extends AddArenaTagAttr {
 /**
  * Attribute used for Stone Axe and Ceaseless Edge.
  * Applies the given ArenaTrapTag when move is used.
- * @extends AddArenaTagAttr
  * @see {@linkcode apply}
  */
 export class AddArenaTrapTagHitAttr extends AddArenaTagAttr {
   /**
-   * @param user {@linkcode Pokemon} using this move
-   * @param target {@linkcode Pokemon} target of this move
-   * @param move {@linkcode Move} being used
+   * @param user - using this move
+   * @param target - target of this move
+   * @param move - being used
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const moveChance = this.getMoveChance(user, target, move, this.selfTarget, true);
@@ -6079,7 +6023,6 @@ export class RemoveScreensAttr extends MoveEffectAttr {
 }
 
 /*Swaps arena effects between the player and enemy side
-  * @extends MoveEffectAttr
   * @see {@linkcode apply}
 */
 export class SwapArenaTagsAttr extends MoveEffectAttr {
@@ -6147,7 +6090,6 @@ export class AddPledgeEffectAttr extends AddArenaTagAttr {
 
 /**
  * Attribute used for Revival Blessing.
- * @extends MoveEffectAttr
  * @see {@linkcode apply}
  */
 export class RevivalBlessingAttr extends MoveEffectAttr {
@@ -6157,10 +6099,10 @@ export class RevivalBlessingAttr extends MoveEffectAttr {
 
   /**
    *
-   * @param user {@linkcode Pokemon} using this move
-   * @param target {@linkcode Pokemon} target of this move
-   * @param move {@linkcode Move} being used
-   * @param args N/A
+   * @param user - using this move
+   * @param target - target of this move
+   * @param move - being used
+   * @param args - N/A
    * @returns Promise, true if function succeeds.
    */
   override apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -6561,7 +6503,7 @@ export class CopyBiomeTypeAttr extends MoveEffectAttr {
 
   /**
    * Retrieves a type from the current terrain
-   * @param terrainType {@linkcode TerrainType}
+   * @param terrainType
    * @returns {@linkcode Type}
    */
   private getTypeForTerrain(terrainType: TerrainType): PokemonType {
@@ -6582,7 +6524,7 @@ export class CopyBiomeTypeAttr extends MoveEffectAttr {
 
   /**
    * Retrieves a type from the current biome
-   * @param biomeType {@linkcode Biome}
+   * @param biomeType
    * @returns {@linkcode Type}
    */
   private getTypeForBiome(biomeType: Biome): PokemonType {
@@ -6714,7 +6656,6 @@ export class FirstMoveTypeAttr extends MoveEffectAttr {
  * Attribute used to call a move.
  * Used by other move attributes: {@linkcode RandomMoveAttr}, {@linkcode RandomMovesetMoveAttr}, {@linkcode CopyMoveAttr}
  * @see {@linkcode apply} for move call
- * @extends OverrideMoveEffectAttr
  */
 class CallMoveAttr extends OverrideMoveEffectAttr {
   protected invalidMoves: ReadonlySet<Moves>;
@@ -6741,7 +6682,6 @@ class CallMoveAttr extends OverrideMoveEffectAttr {
  * Attribute used to call a random move.
  * Used for {@linkcode Moves.METRONOME}
  * @see {@linkcode apply} for move selection and move call
- * @extends CallMoveAttr to call a selected move
  */
 export class RandomMoveAttr extends CallMoveAttr {
   constructor(invalidMoves: ReadonlySet<Moves>) {
@@ -6760,10 +6700,10 @@ export class RandomMoveAttr extends CallMoveAttr {
    * User calls a random moveId.
    *
    * Invalid moves are indicated by what is passed in to invalidMoves: {@linkcode invalidMetronomeMoves}
-   * @param user Pokemon that used the move and will call a random move
-   * @param target Pokemon that will be targeted by the random move (if single target)
-   * @param move Move being used
-   * @param args Unused
+   * @param user - Pokemon that used the move and will call a random move
+   * @param target - Pokemon that will be targeted by the random move (if single target)
+   * @param move - Move being used
+   * @param args - Unused
    */
   override apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const moveIds = getEnumValues(Moves).map(m => !this.invalidMoves.has(m) && !allMoves[m].name.endsWith(" (N)") ? m : Moves.NONE);
@@ -6783,7 +6723,6 @@ export class RandomMoveAttr extends CallMoveAttr {
  * Fails if the user has no callable moves.
  *
  * Invalid moves are indicated by what is passed in to invalidMoves: {@linkcode invalidAssistMoves} or {@linkcode invalidSleepTalkMoves}
- * @extends RandomMoveAttr to use the callMove function on a moveId
  * @see {@linkcode getCondition} for move selection
  */
 export class RandomMovesetMoveAttr extends CallMoveAttr {
@@ -6797,10 +6736,10 @@ export class RandomMovesetMoveAttr extends CallMoveAttr {
 
   /**
    * User calls a random moveId selected in {@linkcode getCondition}
-   * @param user Pokemon that used the move and will call a random move
-   * @param target Pokemon that will be targeted by the random move (if single target)
-   * @param move Move being used
-   * @param args Unused
+   * @param user - Pokemon that used the move and will call a random move
+   * @param target - Pokemon that will be targeted by the random move (if single target)
+   * @param move - Move being used
+   * @param args - Unused
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     return super.apply(user, target, allMoves[this.moveId], args);
@@ -6970,7 +6909,6 @@ export class NaturePowerAttr extends OverrideMoveEffectAttr {
  * Attribute used to copy a previously-used move.
  * Used for {@linkcode Moves.COPYCAT} and {@linkcode Moves.MIRROR_MOVE}
  * @see {@linkcode apply} for move selection and move call
- * @extends CallMoveAttr to call a selected move
  */
 export class CopyMoveAttr extends CallMoveAttr {
   private mirrorMove: boolean;
@@ -7012,10 +6950,10 @@ export class RepeatMoveAttr extends MoveEffectAttr {
   /**
    * Forces the target to re-use their last used move again
    *
-   * @param user {@linkcode Pokemon} that used the attack
-   * @param target {@linkcode Pokemon} targeted by the attack
-   * @param move N/A
-   * @param args N/A
+   * @param user - that used the attack
+   * @param target - targeted by the attack
+   * @param move - N/A
+   * @param args - N/A
    * @returns `true` if the move succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -7148,10 +7086,10 @@ export class ReducePpMoveAttr extends MoveEffectAttr {
   /**
    * Reduces the PP of the target's last-used move by an amount based on this attribute instance's {@linkcode reduction}.
    *
-   * @param user {@linkcode Pokemon} that used the attack
-   * @param target {@linkcode Pokemon} targeted by the attack
-   * @param move N/A
-   * @param args N/A
+   * @param user - that used the attack
+   * @param target - targeted by the attack
+   * @param move - N/A
+   * @param args - N/A
    * @returns `true`
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -7210,10 +7148,10 @@ export class AttackReducePpMoveAttr extends ReducePpMoveAttr {
   /**
    * Checks if the target has used a move prior to the attack. PP-reduction is applied through the super class if so.
    *
-   * @param user {@linkcode Pokemon} that used the attack
-   * @param target {@linkcode Pokemon} targeted by the attack
-   * @param move {@linkcode Move} being used
-   * @param args N/A
+   * @param user - that used the attack
+   * @param target - targeted by the attack
+   * @param move - being used
+   * @param args - N/A
    * @returns {boolean} true
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -7298,10 +7236,10 @@ export class SketchAttr extends MoveEffectAttr {
   }
   /**
    * User copies the opponent's last used move, if possible
-   * @param {Pokemon} user Pokemon that used the move and will replace Sketch with the copied move
-   * @param {Pokemon} target Pokemon that the user wants to copy a move from
-   * @param {Move} move Move being used
-   * @param {any[]} args Unused
+   * @param user - Pokemon that used the move and will replace Sketch with the copied move
+   * @param target - Pokemon that the user wants to copy a move from
+   * @param move - Move being used
+   * @param args - Unused
    * @returns {boolean} true if the function succeeds, otherwise false
    */
 
@@ -7488,7 +7426,6 @@ export class SwitchAbilitiesAttr extends MoveEffectAttr {
  * Attribute used for moves that suppress abilities like {@linkcode Moves.GASTRO_ACID}.
  * A suppressed ability cannot be activated.
  *
- * @extends MoveEffectAttr
  * @see {@linkcode apply}
  * @see {@linkcode getCondition}
  */
@@ -7516,7 +7453,6 @@ export class SuppressAbilitiesAttr extends MoveEffectAttr {
 
 /**
  * Applies the effects of {@linkcode SuppressAbilitiesAttr} if the target has already moved this turn.
- * @extends MoveEffectAttr
  * @see {@linkcode Moves.CORE_ENFORCER} (the move which uses this effect)
  */
 export class SuppressAbilitiesIfActedAttr extends MoveEffectAttr {
@@ -7563,7 +7499,6 @@ export class TransformAttr extends MoveEffectAttr {
 /**
  * Attribute used for status moves, namely Speed Swap,
  * that swaps the user's and target's corresponding stats.
- * @extends MoveEffectAttr
  * @see {@linkcode apply}
  */
 export class SwapStatAttr extends MoveEffectAttr {
@@ -7579,10 +7514,10 @@ export class SwapStatAttr extends MoveEffectAttr {
   /**
    * Swaps the user's and target's corresponding current
    * {@linkcode EffectiveStat | stat} values
-   * @param user the {@linkcode Pokemon} that used the move
-   * @param target the {@linkcode Pokemon} that the move was used on
-   * @param move N/A
-   * @param args N/A
+   * @param user - the {@linkcode Pokemon} that used the move
+   * @param target - the {@linkcode Pokemon} that the move was used on
+   * @param move - N/A
+   * @param args - N/A
    * @returns true if attribute application succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -7605,7 +7540,6 @@ export class SwapStatAttr extends MoveEffectAttr {
 /**
  * Attribute used to switch the user's own stats.
  * Used by Power Shift.
- * @extends MoveEffectAttr
  */
 export class ShiftStatAttr extends MoveEffectAttr {
   private statToSwitch: EffectiveStat;
@@ -7620,10 +7554,10 @@ export class ShiftStatAttr extends MoveEffectAttr {
 
   /**
    * Switches the user's stats based on the {@linkcode statToSwitch} and {@linkcode statToSwitchWith} attributes.
-   * @param {Pokemon} user the {@linkcode Pokemon} that used the move
-   * @param target n/a
-   * @param move n/a
-   * @param args n/a
+   * @param user - the {@linkcode Pokemon} that used the move
+   * @param target - n/a
+   * @param move - n/a
+   * @param args - n/a
    * @returns whether the effect was applied
    */
   override apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -7648,9 +7582,9 @@ export class ShiftStatAttr extends MoveEffectAttr {
 
   /**
    * Encourages the user to use the move if the stat to switch with is greater than the stat to switch.
-   * @param {Pokemon} user the {@linkcode Pokemon} that used the move
-   * @param target n/a
-   * @param move n/a
+   * @param user - the {@linkcode Pokemon} that used the move
+   * @param target - n/a
+   * @param move - n/a
    * @returns number of points to add to the user's benefit score
    */
   override getUserBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
@@ -7662,7 +7596,6 @@ export class ShiftStatAttr extends MoveEffectAttr {
  * Attribute used for status moves, namely Power Split and Guard Split,
  * that take the average of a user's and target's corresponding
  * stats and assign that average back to each corresponding stat.
- * @extends MoveEffectAttr
  * @see {@linkcode apply}
  */
 export class AverageStatsAttr extends MoveEffectAttr {
@@ -7681,10 +7614,10 @@ export class AverageStatsAttr extends MoveEffectAttr {
    * Takes the average of the user's and target's corresponding {@linkcode stat}
    * values and sets those stats to the corresponding average for both
    * temporarily.
-   * @param user the {@linkcode Pokemon} that used the move
-   * @param target the {@linkcode Pokemon} that the move was used on
-   * @param move N/A
-   * @param args N/A
+   * @param user - the {@linkcode Pokemon} that used the move
+   * @param target - the {@linkcode Pokemon} that the move was used on
+   * @param move - N/A
+   * @param args - N/A
    * @returns true if attribute application succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -7733,7 +7666,6 @@ export class MoneyAttr extends MoveEffectAttr {
 /**
  * Applies {@linkcode BattlerTagType.DESTINY_BOND} to the user.
  *
- * @extends MoveEffectAttr
  */
 export class DestinyBondAttr extends MoveEffectAttr {
   constructor() {
@@ -7742,10 +7674,10 @@ export class DestinyBondAttr extends MoveEffectAttr {
 
   /**
    * Applies {@linkcode BattlerTagType.DESTINY_BOND} to the user.
-   * @param user {@linkcode Pokemon} that is having the tag applied to.
-   * @param target {@linkcode Pokemon} N/A
-   * @param move {@linkcode Move} {@linkcode Move.DESTINY_BOND}
-   * @param {any[]} args N/A
+   * @param user - that is having the tag applied to.
+   * @param target - N/A
+   * @param move - {@linkcode Move.DESTINY_BOND}
+   * @param args - N/A
    * @returns true
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -7757,7 +7689,6 @@ export class DestinyBondAttr extends MoveEffectAttr {
 
 /**
  * Attribute to apply a battler tag to the target if they have had their stats boosted this turn.
- * @extends AddBattlerTagAttr
  */
 export class AddBattlerTagIfBoostedAttr extends AddBattlerTagAttr {
   constructor(tag: BattlerTagType) {
@@ -7765,10 +7696,10 @@ export class AddBattlerTagIfBoostedAttr extends AddBattlerTagAttr {
   }
 
   /**
-   * @param user {@linkcode Pokemon} using this move
-   * @param target {@linkcode Pokemon} target of this move
-   * @param move {@linkcode Move} being used
-   * @param {any[]} args N/A
+   * @param user - using this move
+   * @param target - target of this move
+   * @param move - being used
+   * @param args - N/A
    * @returns true
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -7781,7 +7712,6 @@ export class AddBattlerTagIfBoostedAttr extends AddBattlerTagAttr {
 
 /**
  * Attribute to apply a status effect to the target if they have had their stats boosted this turn.
- * @extends MoveEffectAttr
  */
 export class StatusIfBoostedAttr extends MoveEffectAttr {
   public effect: StatusEffect;
@@ -7792,10 +7722,10 @@ export class StatusIfBoostedAttr extends MoveEffectAttr {
   }
 
   /**
-   * @param user {@linkcode Pokemon} using this move
-   * @param target {@linkcode Pokemon} target of this move
-   * @param move {@linkcode Move} N/A
-   * @param {any[]} args N/A
+   * @param user - using this move
+   * @param target - target of this move
+   * @param move - N/A
+   * @param args - N/A
    * @returns true
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -7846,10 +7776,10 @@ export class AfterYouAttr extends MoveEffectAttr {
   /**
    * Allows the target of this move to act right after the user.
    *
-   * @param user {@linkcode Pokemon} that is using the move.
-   * @param target {@linkcode Pokemon} that will move right after this move is used.
-   * @param move {@linkcode Move} {@linkcode Moves.AFTER_YOU}
-   * @param _args N/A
+   * @param user - that is using the move.
+   * @param target - that will move right after this move is used.
+   * @param move - {@linkcode Moves.AFTER_YOU}
+   * @param _args - N/A
    * @returns true
    */
   override apply(user: Pokemon, target: Pokemon, _move: Move, _args: any[]): boolean {
@@ -7868,16 +7798,15 @@ export class AfterYouAttr extends MoveEffectAttr {
 /**
  * Move effect to force the target to move last, ignoring priority.
  * If applied to multiple targets, they move in speed order after all other moves.
- * @extends MoveEffectAttr
  */
 export class ForceLastAttr extends MoveEffectAttr {
   /**
    * Forces the target of this move to move last.
    *
-   * @param user {@linkcode Pokemon} that is using the move.
-   * @param target {@linkcode Pokemon} that will be forced to move last.
-   * @param move {@linkcode Move} {@linkcode Moves.QUASH}
-   * @param _args N/A
+   * @param user - that is using the move.
+   * @param target - that will be forced to move last.
+   * @param move - {@linkcode Moves.QUASH}
+   * @param _args - N/A
    * @returns true
    */
   override apply(user: Pokemon, target: Pokemon, _move: Move, _args: any[]): boolean {
@@ -8081,10 +8010,10 @@ export class ResistLastMoveTypeAttr extends MoveEffectAttr {
   }
   /**
    * User changes its type to a random type that resists the target's last used move
-   * @param {Pokemon} user Pokemon that used the move and will change types
-   * @param {Pokemon} target Opposing pokemon that recently used a move
-   * @param {Move} move Move being used
-   * @param {any[]} args Unused
+   * @param user - Pokemon that used the move and will change types
+   * @param target - Opposing pokemon that recently used a move
+   * @param move - Move being used
+   * @param args - Unused
    * @returns {boolean} true if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
@@ -8146,7 +8075,6 @@ export class ResistLastMoveTypeAttr extends MoveEffectAttr {
  * and makes its evasiveness be ignored during accuracy
  * checks. Used by: {@linkcode Moves.ODOR_SLEUTH | Odor Sleuth}, {@linkcode Moves.MIRACLE_EYE | Miracle Eye} and {@linkcode Moves.FORESIGHT | Foresight}
  *
- * @extends AddBattlerTagAttr
  * @see {@linkcode apply}
  */
 export class ExposedMoveAttr extends AddBattlerTagAttr {
@@ -8156,10 +8084,10 @@ export class ExposedMoveAttr extends AddBattlerTagAttr {
 
   /**
    * Applies {@linkcode ExposedTag} to the target.
-   * @param user {@linkcode Pokemon} using this move
-   * @param target {@linkcode Pokemon} target of this move
-   * @param move {@linkcode Move} being used
-   * @param args N/A
+   * @param user - using this move
+   * @param target - target of this move
+   * @param move - being used
+   * @param args - N/A
    * @returns `true` if the function succeeds
    */
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {

--- a/src/data/mystery-encounters/encounters/absolute-avarice-encounter.ts
+++ b/src/data/mystery-encounters/encounters/absolute-avarice-encounter.ts
@@ -500,7 +500,7 @@ function doGreedentEatBerries() {
 }
 
 /**
- * @param isEat Default false. Will "create" pile when false, and remove pile when true.
+ * @param isEat - Default false. Will "create" pile when false, and remove pile when true.
  */
 function doBerrySpritePile(isEat = false) {
   const berryAddDelay = 150;

--- a/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
+++ b/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
@@ -496,7 +496,7 @@ async function doNewTeamPostProcess(transformations: PokemonTransformation[]) {
  * @param previousPokemon
  * @param newPokemon
  * @param speciesRootForm
- * @param forBattle Default `false`. If false, will perform achievements and dex unlocks for the player.
+ * @param forBattle - Default `false`. If false, will perform achievements and dex unlocks for the player.
  */
 async function postProcessTransformedPokemon(
   previousPokemon: PlayerPokemon,

--- a/src/data/mystery-encounters/mystery-encounter-option.ts
+++ b/src/data/mystery-encounters/mystery-encounter-option.ts
@@ -276,9 +276,9 @@ export class MysteryEncounterOptionBuilder implements Partial<IMysteryEncounterO
   /**
    * Player is required to have certain type/s of pokemon in his party (with optional min number of pokemons with that type)
    *
-   * @param type the required type/s
-   * @param excludeFainted whether to exclude fainted pokemon
-   * @param minNumberOfPokemon number of pokemons to have that type
+   * @param type - the required type/s
+   * @param excludeFainted - whether to exclude fainted pokemon
+   * @param minNumberOfPokemon - number of pokemons to have that type
    * @param invertQuery
    * @returns
    */
@@ -296,8 +296,8 @@ export class MysteryEncounterOptionBuilder implements Partial<IMysteryEncounterO
   /**
    * Player is required to have a pokemon that can learn a certain move/moveset
    *
-   * @param move the required move/moves
-   * @param options see {@linkcode CanLearnMoveRequirementOptions}
+   * @param move - the required move/moves
+   * @param options - see {@linkcode CanLearnMoveRequirementOptions}
    * @returns
    */
   withPokemonCanLearnMoveRequirement(move: Moves | Moves[], options?: CanLearnMoveRequirementOptions) {
@@ -327,7 +327,7 @@ export class MysteryEncounterOptionBuilder implements Partial<IMysteryEncounterO
   /**
    * Set the full dialogue object to the option. Will override anything already set
    *
-   * @param dialogue see {@linkcode OptionTextDisplay}
+   * @param dialogue - see {@linkcode OptionTextDisplay}
    * @returns
    */
   withDialogue(dialogue: OptionTextDisplay) {

--- a/src/data/mystery-encounters/mystery-encounter-requirements.ts
+++ b/src/data/mystery-encounters/mystery-encounter-requirements.ts
@@ -69,7 +69,7 @@ export class CombinationSceneRequirement extends EncounterSceneRequirement {
 
   /**
    * Retrieves a dialogue token key/value pair for the given {@linkcode EncounterSceneRequirement | requirements}.
-   * @param pokemon The {@linkcode PlayerPokemon} to check against
+   * @param pokemon - The {@linkcode PlayerPokemon} to check against
    * @returns A dialogue token key/value pair
    * @throws An {@linkcode Error} if {@linkcode isAnd} is `true` (not supported)
    */
@@ -146,7 +146,7 @@ export class CombinationPokemonRequirement extends EncounterPokemonRequirement {
 
   /**
    * Queries the players party for all party members that are compatible with all/any requirements (depends on {@linkcode isAnd})
-   * @param partyPokemon The party of {@linkcode PlayerPokemon}
+   * @param partyPokemon - The party of {@linkcode PlayerPokemon}
    * @returns All party members that are compatible with all/any requirements (depends on {@linkcode isAnd})
    */
   override queryParty(partyPokemon: PlayerPokemon[]): PlayerPokemon[] {
@@ -159,7 +159,7 @@ export class CombinationPokemonRequirement extends EncounterPokemonRequirement {
 
   /**
    * Retrieves a dialogue token key/value pair for the given {@linkcode EncounterPokemonRequirement | requirements}.
-   * @param pokemon The {@linkcode PlayerPokemon} to check against
+   * @param pokemon - The {@linkcode PlayerPokemon} to check against
    * @returns A dialogue token key/value pair
    * @throws An {@linkcode Error} if {@linkcode isAnd} is `true` (not supported)
    */
@@ -211,7 +211,7 @@ export class WaveRangeRequirement extends EncounterSceneRequirement {
   /**
    * Used for specifying a unique wave or wave range requirement
    * If minWaveIndex and maxWaveIndex are equivalent, will check for exact wave number
-   * @param waveRange [min, max]
+   * @param waveRange - [min, max]
    */
   constructor(waveRange: [number, number]) {
     super();
@@ -243,8 +243,8 @@ export class WaveModulusRequirement extends EncounterSceneRequirement {
   /**
    * Used for specifying a modulus requirement on the wave index
    * For example, can be used to require the wave index to end with 1, 2, or 3
-   * @param waveModuli The allowed modulus results
-   * @param modulusValue The modulus calculation value
+   * @param waveModuli - The allowed modulus results
+   * @param modulusValue - The modulus calculation value
    *
    * Example:
    * new WaveModulusRequirement([1, 2, 3], 10) will check for 1st/2nd/3rd waves that are immediately after a multiple of 10 wave

--- a/src/data/mystery-encounters/mystery-encounter.ts
+++ b/src/data/mystery-encounters/mystery-encounter.ts
@@ -592,7 +592,7 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
    * Use for complex options.
    * There should be at least 2 options defined and no more than 4.
    *
-   * @param option MysteryEncounterOption to add, can use MysteryEncounterOptionBuilder to create instance
+   * @param option - MysteryEncounterOption to add, can use MysteryEncounterOptionBuilder to create instance
    * @returns
    */
   withOption(option: MysteryEncounterOption): this & Pick<IMysteryEncounter, "options"> {
@@ -610,8 +610,8 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
    * There should be at least 2 options defined and no more than 4.
    * If complex use {@linkcode MysteryEncounterBuilder.withOption}
    *
-   * @param dialogue {@linkcode OptionTextDisplay}
-   * @param callback {@linkcode OptionPhaseCallback}
+   * @param dialogue
+   * @param callback
    * @returns
    */
   withSimpleOption(
@@ -632,8 +632,8 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
    * There should be at least 2 options defined and no more than 4.
    * If complex use {@linkcode MysteryEncounterBuilder.withOption}
    *
-   * @param dialogue {@linkcode OptionTextDisplay}
-   * @param callback {@linkcode OptionPhaseCallback}
+   * @param dialogue
+   * @param callback
    * @returns
    */
   withSimpleDexProgressOption(
@@ -678,7 +678,7 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
 
   /**
    * Sets the localization key used by the encounter
-   * @param localizationKey the string used as the key
+   * @param localizationKey - the string used as the key
    * @returns `this`
    */
   setLocalizationKey(localizationKey: string): this {
@@ -830,8 +830,8 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
   /**
    * Specifies a wave range requirement for an encounter.
    *
-   * @param min min wave (or exact wave if only min is given)
-   * @param max optional max wave. If not given, defaults to min => exact wave
+   * @param min - min wave (or exact wave if only min is given)
+   * @param max - optional max wave. If not given, defaults to min => exact wave
    * @returns
    */
   withSceneWaveRangeRequirement(min: number, max?: number): this & Required<Pick<IMysteryEncounter, "requirements">> {
@@ -841,9 +841,9 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
   /**
    * Specifies a party size requirement for an encounter.
    *
-   * @param min min wave (or exact size if only min is given)
-   * @param max optional max size. If not given, defaults to min => exact wave
-   * @param excludeDisallowedPokemon if true, only counts allowed (legal in Challenge/unfainted) mons
+   * @param min - min wave (or exact size if only min is given)
+   * @param max - optional max size. If not given, defaults to min => exact wave
+   * @param excludeDisallowedPokemon - if true, only counts allowed (legal in Challenge/unfainted) mons
    * @returns
    */
   withScenePartySizeRequirement(
@@ -857,7 +857,7 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
   /**
    * Add a primary pokemon requirement
    *
-   * @param requirement {@linkcode EncounterPokemonRequirement}
+   * @param requirement
    * @returns
    */
   withPrimaryPokemonRequirement(
@@ -876,9 +876,9 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
   /**
    * Add a primary pokemon status effect requirement
    *
-   * @param statusEffect the status effect/s to check
-   * @param minNumberOfPokemon minimum number of pokemon to have the effect
-   * @param invertQuery if true will invert the query
+   * @param statusEffect - the status effect/s to check
+   * @param minNumberOfPokemon - minimum number of pokemon to have the effect
+   * @param invertQuery - if true will invert the query
    * @returns
    */
   withPrimaryPokemonStatusEffectRequirement(
@@ -894,9 +894,9 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
   /**
    * Add a primary pokemon health ratio requirement
    *
-   * @param requiredHealthRange the health range to check
-   * @param minNumberOfPokemon minimum number of pokemon to have the health range
-   * @param invertQuery if true will invert the query
+   * @param requiredHealthRange - the health range to check
+   * @param minNumberOfPokemon - minimum number of pokemon to have the health range
+   * @param invertQuery - if true will invert the query
    * @returns
    */
   withPrimaryPokemonHealthRatioRequirement(
@@ -935,7 +935,7 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
    * NOTE: If rewards are dependent on options selected, runtime data, etc.,
    * It may be better to programmatically set doEncounterRewards elsewhere.
    * There is a helper function in mystery-encounter utils, setEncounterRewards(), which can be called programmatically to set rewards
-   * @param doEncounterRewards Synchronous callback function to perform during rewards phase of the encounter
+   * @param doEncounterRewards - Synchronous callback function to perform during rewards phase of the encounter
    * @returns
    */
   withRewards(doEncounterRewards: () => boolean): this & Required<Pick<IMysteryEncounter, "doEncounterRewards">> {
@@ -949,7 +949,7 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
    * NOTE: If rewards are dependent on options selected, runtime data, etc.,
    * It may be better to programmatically set doEncounterExp elsewhere.
    * There is a helper function in mystery-encounter utils, setEncounterExp(), which can be called programmatically to set rewards
-   * @param doEncounterExp Synchronous callback function to perform during rewards phase of the encounter
+   * @param doEncounterExp - Synchronous callback function to perform during rewards phase of the encounter
    * @returns
    */
   withExp(doEncounterExp: () => boolean): this & Required<Pick<IMysteryEncounter, "doEncounterExp">> {
@@ -960,7 +960,7 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
    * Can be used to perform init logic before intro visuals are shown and before the MysteryEncounterPhase begins
    * Useful for performing things like procedural generation of intro sprites, etc.
    *
-   * @param onInit Synchronous callback function to perform as soon as the encounter is selected for the next phase
+   * @param onInit - Synchronous callback function to perform as soon as the encounter is selected for the next phase
    * @returns
    */
   withOnInit(onInit: () => boolean): this & Required<Pick<IMysteryEncounter, "onInit">> {
@@ -970,7 +970,7 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
   /**
    * Can be used to perform some extra logic (usually animations) when the enemy field is finished sliding in
    *
-   * @param onVisualsStart Synchronous callback function to perform as soon as the enemy field finishes sliding in
+   * @param onVisualsStart - Synchronous callback function to perform as soon as the enemy field finishes sliding in
    * @returns
    */
   withOnVisualsStart(onVisualsStart: () => boolean): this & Required<Pick<IMysteryEncounter, "onVisualsStart">> {
@@ -980,7 +980,7 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
   /**
    * Can set whether catching is allowed or not on the encounter
    * This flag can also be programmatically set inside option event functions or elsewhere
-   * @param catchAllowed If `true`, allows enemy pokemon to be caught during the encounter
+   * @param catchAllowed - If `true`, allows enemy pokemon to be caught during the encounter
    * @returns
    */
   withCatchAllowed(catchAllowed: boolean): this & Required<Pick<IMysteryEncounter, "catchAllowed">> {
@@ -989,7 +989,7 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
 
   /**
    * Can set whether fleeing is allowed or not on the encounter
-   * @param fleeAllowed If `false`, prevents fleeing from a wild battle (trainer battle MEs already have flee disabled)
+   * @param fleeAllowed - If `false`, prevents fleeing from a wild battle (trainer battle MEs already have flee disabled)
    * @returns
    */
   withFleeAllowed(fleeAllowed: boolean): this & Required<Pick<IMysteryEncounter, "fleeAllowed">> {
@@ -997,7 +997,7 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
   }
 
   /**
-   * @param hideBattleIntroMessage If `true`, will not show the trainerAppeared/wildAppeared/bossAppeared message for an encounter
+   * @param hideBattleIntroMessage - If `true`, will not show the trainerAppeared/wildAppeared/bossAppeared message for an encounter
    * @returns
    */
   withHideWildIntroMessage(
@@ -1009,7 +1009,7 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
   }
 
   /**
-   * @param autoHideIntroVisuals If `false`, will not hide the intro visuals that are displayed at the beginning of encounter
+   * @param autoHideIntroVisuals - If `false`, will not hide the intro visuals that are displayed at the beginning of encounter
    * @returns
    */
   withAutoHideIntroVisuals(
@@ -1019,7 +1019,7 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
   }
 
   /**
-   * @param enterIntroVisualsFromRight If `true`, will slide in intro visuals from the right side of the screen. If false, slides in from left, as normal
+   * @param enterIntroVisualsFromRight - If `true`, will slide in intro visuals from the right side of the screen. If false, slides in from left, as normal
    * Default false
    * @returns
    */
@@ -1034,7 +1034,7 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
   /**
    * Add a title for the encounter
    *
-   * @param title Title of the encounter
+   * @param title - Title of the encounter
    * @returns
    */
   withTitle(title: string): this {
@@ -1054,7 +1054,7 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
   /**
    * Add a description of the encounter
    *
-   * @param description Description of the encounter
+   * @param description - Description of the encounter
    * @returns
    */
   withDescription(description: string): this {
@@ -1074,7 +1074,7 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
   /**
    * Add a query for the encounter
    *
-   * @param query Query to use for the encounter
+   * @param query - Query to use for the encounter
    * @returns
    */
   withQuery(query: string): this {
@@ -1094,7 +1094,7 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
   /**
    * Add outro dialogue/s for the encounter
    *
-   * @param dialogue Outro dialogue(s)
+   * @param dialogue - Outro dialogue(s)
    * @returns
    */
   withOutroDialogue(dialogue: MysteryEncounterDialogue["outro"] = []): this {

--- a/src/data/mystery-encounters/utils/encounter-dialogue-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-dialogue-utils.ts
@@ -9,7 +9,7 @@ import i18next from "i18next";
  * Will inject all relevant dialogue tokens that exist in the {@linkcode BattlegScene.currentBattle.mysteryEncounter.dialogueTokens}, into i18n text.
  * Also adds BBCodeText fragments for colored text, if applicable
  * @param keyOrString
- * @param primaryStyle Can define a text style to be applied to the entire string. Must be defined for BBCodeText styles to be applied correctly
+ * @param primaryStyle - Can define a text style to be applied to the entire string. Must be defined for BBCodeText styles to be applied correctly
  */
 export function getEncounterText(keyOrString?: string, primaryStyle?: TextStyle): string | null {
   if (isNullOrUndefined(keyOrString)) {

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -143,7 +143,7 @@ export interface EnemyPartyConfig {
  * Generates an enemy party for a mystery encounter battle
  * This will override and replace any standard encounter generation logic
  * Useful for tailoring specific battles to mystery encounters
- * @param partyConfig Can pass various customizable attributes for the enemy party, see EnemyPartyConfig
+ * @param partyConfig - Can pass various customizable attributes for the enemy party, see EnemyPartyConfig
  */
 export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): Promise<void> {
   const loaded: boolean = false;
@@ -509,7 +509,7 @@ export function updatePlayerMoney(changeValue: number, playSound = true, showMes
 /**
  * Converts modifier bullshit to an actual item
  * @param modifier
- * @param pregenArgs Can specify BerryType for berries, TM for TMs, AttackBoostType for item, etc.
+ * @param pregenArgs - Can specify BerryType for berries, TM for TMs, AttackBoostType for item, etc.
  */
 export function generateModifierType(modifier: () => ModifierType, pregenArgs?: any[]): ModifierType | null {
   const modifierId = Object.keys(modifierTypes).find(k => modifierTypes[k] === modifier);
@@ -1039,9 +1039,9 @@ export function handleMysteryEncounterTurnStartEffects(): boolean {
 /**
  * Helper function for encounters such as {@linkcode UncommonBreedEncounter} which call for a random species including event encounters.
  * If the mon is from the event encounter list, it will do an extra shiny roll.
- * @param level the level of the mon, which differs between MEs
- * @param isBoss whether the mon should be a Boss
- * @param rerollHidden whether the mon should get an extra roll for Hidden Ability
+ * @param level - the level of the mon, which differs between MEs
+ * @param isBoss - whether the mon should be a Boss
+ * @param rerollHidden - whether the mon should get an extra roll for Hidden Ability
  * @returns {@linkcode EnemyPokemon} for the requested encounter
  */
 export function getRandomEncounterSpecies(level: number, isBoss = false, rerollHidden = false): EnemyPokemon {

--- a/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
@@ -92,9 +92,9 @@ export function getSpriteKeysFromPokemon(pokemon: Pokemon): {
 /**
  * Will never remove the player's last non-fainted Pokemon (if they only have 1).
  * Otherwise, picks a Pokemon completely at random and removes from the party
- * @param isAllowed Default `false`. If `true`, only picks from legal mons. If no legal mons are found (or there is 1, with `doNotReturnLastAllowedMon = true`), will return a mon that is not allowed.
- * @param isFainted Default `false`. If `true`, includes fainted mons.
- * @param doNotReturnLastAllowedMon Default `false`. If `true`, will never return the last unfainted pokemon in the party. Useful when this function is being used to determine what Pokemon to remove from the party (Don't want to remove last unfainted)
+ * @param isAllowed - Default `false`. If `true`, only picks from legal mons. If no legal mons are found (or there is 1, with `doNotReturnLastAllowedMon = true`), will return a mon that is not allowed.
+ * @param isFainted - Default `false`. If `true`, includes fainted mons.
+ * @param doNotReturnLastAllowedMon - Default `false`. If `true`, will never return the last unfainted pokemon in the party. Useful when this function is being used to determine what Pokemon to remove from the party (Don't want to remove last unfainted)
  * @returns
  */
 export function getRandomPlayerPokemon(
@@ -136,8 +136,8 @@ export function getRandomPlayerPokemon(
 /**
  * Ties are broken by whatever mon is closer to the front of the party
  * @param scene
- * @param isAllowed Default false. If true, only picks from legal mons.
- * @param isFainted Default false. If true, includes fainted mons.
+ * @param isAllowed - Default false. If true, only picks from legal mons.
+ * @param isFainted - Default false. If true, includes fainted mons.
  * @returns
  */
 export function getHighestLevelPlayerPokemon(isAllowed = false, isFainted = false): PlayerPokemon {
@@ -161,9 +161,9 @@ export function getHighestLevelPlayerPokemon(isAllowed = false, isFainted = fals
 /**
  * Ties are broken by whatever mon is closer to the front of the party
  * @param scene
- * @param stat Stat to search for
- * @param isAllowed Default false. If true, only picks from legal mons.
- * @param isFainted Default false. If true, includes fainted mons.
+ * @param stat - Stat to search for
+ * @param isAllowed - Default false. If true, only picks from legal mons.
+ * @param isFainted - Default false. If true, includes fainted mons.
  * @returns
  */
 export function getHighestStatPlayerPokemon(stat: PermanentStat, isAllowed = false, isFainted = false): PlayerPokemon {
@@ -187,8 +187,8 @@ export function getHighestStatPlayerPokemon(stat: PermanentStat, isAllowed = fal
 /**
  * Ties are broken by whatever mon is closer to the front of the party
  * @param scene
- * @param isAllowed Default false. If true, only picks from legal mons.
- * @param isFainted Default false. If true, includes fainted mons.
+ * @param isAllowed - Default false. If true, only picks from legal mons.
+ * @param isFainted - Default false. If true, includes fainted mons.
  * @returns
  */
 export function getLowestLevelPlayerPokemon(isAllowed = false, isFainted = false): PlayerPokemon {
@@ -212,8 +212,8 @@ export function getLowestLevelPlayerPokemon(isAllowed = false, isFainted = false
 /**
  * Ties are broken by whatever mon is closer to the front of the party
  * @param scene
- * @param isAllowed Default false. If true, only picks from legal mons.
- * @param isFainted Default false. If true, includes fainted mons.
+ * @param isAllowed - Default false. If true, only picks from legal mons.
+ * @param isFainted - Default false. If true, includes fainted mons.
  * @returns
  */
 export function getHighestStatTotalPlayerPokemon(isAllowed = false, isFainted = false): PlayerPokemon {
@@ -300,8 +300,8 @@ export function getRandomSpeciesByStarterCost(
 /**
  * Takes care of handling player pokemon KO (with all its side effects)
  *
- * @param scene the battle scene
- * @param pokemon the player pokemon to KO
+ * @param scene - the battle scene
+ * @param pokemon - the player pokemon to KO
  */
 export function koPlayerPokemon(pokemon: PlayerPokemon) {
   pokemon.hp = 0;
@@ -318,9 +318,9 @@ export function koPlayerPokemon(pokemon: PlayerPokemon) {
  * Handles applying hp changes to a player pokemon.
  * Takes care of not going below `0`, above max-hp, adding `FNT` status correctly and updating the pokemon info.
  * TODO: should we handle special cases like wonder-guard/shedinja?
- * @param scene the battle scene
- * @param pokemon the player pokemon to apply the hp change to
- * @param value the hp change amount. Positive for heal. Negative for damage
+ * @param scene - the battle scene
+ * @param pokemon - the player pokemon to apply the hp change to
+ * @param value - the hp change amount. Positive for heal. Negative for damage
  *
  */
 function applyHpChangeToPokemon(pokemon: PlayerPokemon, value: number) {
@@ -335,9 +335,9 @@ function applyHpChangeToPokemon(pokemon: PlayerPokemon, value: number) {
 
 /**
  * Handles applying damage to a player pokemon
- * @param scene the battle scene
- * @param pokemon the player pokemon to apply damage to
- * @param damage the amount of damage to apply
+ * @param scene - the battle scene
+ * @param pokemon - the player pokemon to apply damage to
+ * @param damage - the amount of damage to apply
  * @see {@linkcode applyHpChangeToPokemon}
  */
 export function applyDamageToPokemon(pokemon: PlayerPokemon, damage: number) {
@@ -355,9 +355,9 @@ export function applyDamageToPokemon(pokemon: PlayerPokemon, damage: number) {
 
 /**
  * Handles applying heal to a player pokemon
- * @param scene the battle scene
- * @param pokemon the player pokemon to apply heal to
- * @param heal the amount of heal to apply
+ * @param scene - the battle scene
+ * @param pokemon - the player pokemon to apply heal to
+ * @param heal - the amount of heal to apply
  * @see {@linkcode applyHpChangeToPokemon}
  */
 export function applyHealToPokemon(pokemon: PlayerPokemon, heal: number) {
@@ -957,7 +957,7 @@ export function getGoldenBugNetSpecies(level: number): PokemonSpecies {
 /**
  * Generates a Pokemon level for a given wave, with an option to increase/decrease by a scaling modifier
  * @param scene
- * @param levelAdditiveModifier Default 0. will add +(1 level / 10 waves * levelAdditiveModifier) to the level calculation
+ * @param levelAdditiveModifier - Default 0. will add +(1 level / 10 waves * levelAdditiveModifier) to the level calculation
  */
 export function getEncounterPokemonLevelForWave(levelAdditiveModifier = 0) {
   const currentBattle = globalScene.currentBattle;

--- a/src/data/pokeball.ts
+++ b/src/data/pokeball.ts
@@ -85,7 +85,7 @@ export function getPokeballTintColor(type: PokeballType): number {
 /**
  * Gets the critical capture chance based on number of mons registered in Dex and modified {@link https://bulbapedia.bulbagarden.net/wiki/Catch_rate Catch rate}
  * Formula from {@link https://www.dragonflycave.com/mechanics/gen-vi-vii-capturing Dragonfly Cave Gen 6 Capture Mechanics page}
- * @param modifiedCatchRate the modified catch rate as calculated in {@linkcode AttemptCapturePhase}
+ * @param modifiedCatchRate - the modified catch rate as calculated in {@linkcode AttemptCapturePhase}
  * @returns the chance of getting a critical capture, out of 256
  */
 export function getCriticalCaptureChance(modifiedCatchRate: number): number {

--- a/src/data/pokemon-forms.ts
+++ b/src/data/pokemon-forms.ts
@@ -431,7 +431,6 @@ export class SpeciesDefaultFormMatchTrigger extends SpeciesFormChangeTrigger {
 /**
  * Class used for triggering form changes based on the user's Tera type.
  * Used by Ogerpon and Terapagos.
- * @extends SpeciesFormChangeTrigger
  */
 export class SpeciesFormChangeTeraTrigger extends SpeciesFormChangeTrigger {
   description = i18next.t("pokemonEvolutions:Forms.tera");
@@ -440,7 +439,6 @@ export class SpeciesFormChangeTeraTrigger extends SpeciesFormChangeTrigger {
 /**
  * Class used for triggering form changes based on the user's lapsed Tera type.
  * Used by Ogerpon and Terapagos.
- * @extends SpeciesFormChangeTrigger
  */
 export class SpeciesFormChangeLapseTeraTrigger extends SpeciesFormChangeTrigger {
   description = i18next.t("pokemonEvolutions:Forms.teraLapse");
@@ -449,7 +447,6 @@ export class SpeciesFormChangeLapseTeraTrigger extends SpeciesFormChangeTrigger 
 /**
  * Class used for triggering form changes based on weather.
  * Used by Castform and Cherrim.
- * @extends SpeciesFormChangeTrigger
  */
 export class SpeciesFormChangeWeatherTrigger extends SpeciesFormChangeTrigger {
   /** The ability that  triggers the form change */
@@ -465,10 +462,10 @@ export class SpeciesFormChangeWeatherTrigger extends SpeciesFormChangeTrigger {
   }
 
   /**
-   * Checks if the Pokemon has the required ability and is in the correct weather while
+   * Check if the Pokemon has the required ability and is in the correct weather while
    * the weather or ability is also not suppressed.
-   * @param {Pokemon} pokemon the pokemon that is trying to do the form change
-   * @returns `true` if the Pokemon can change forms, `false` otherwise
+   * @param pokemon - The pokemon that is trying to do the form change
+   * @returns whether the Pokemon can change forms
    */
   canChange(pokemon: Pokemon): boolean {
     const currentWeather = globalScene.arena.weather?.weatherType ?? WeatherType.NONE;
@@ -488,7 +485,6 @@ export class SpeciesFormChangeWeatherTrigger extends SpeciesFormChangeTrigger {
  * Class used for reverting to the original form when the weather runs out
  * or when the user loses the ability/is suppressed.
  * Used by Castform and Cherrim.
- * @extends SpeciesFormChangeTrigger
  */
 export class SpeciesFormChangeRevertWeatherFormTrigger extends SpeciesFormChangeTrigger {
   /** The ability that triggers the form change*/
@@ -506,7 +502,7 @@ export class SpeciesFormChangeRevertWeatherFormTrigger extends SpeciesFormChange
   /**
    * Checks if the Pokemon has the required ability and the weather is one that will revert
    * the Pokemon to its original form or the weather or ability is suppressed
-   * @param {Pokemon} pokemon the pokemon that is trying to do the form change
+   * @param pokemon - the pokemon that is trying to do the form change
    * @returns `true` if the Pokemon will revert to its original form, `false` otherwise
    */
   canChange(pokemon: Pokemon): boolean {
@@ -562,7 +558,7 @@ export function getSpeciesFormChangeMessage(pokemon: Pokemon, formChange: Specie
 /**
  * Gives a condition for form changing checking if a species is registered as caught in the player's dex data.
  * Used for fusion forms such as Kyurem and Necrozma.
- * @param species {@linkcode Species}
+ * @param species
  * @returns A {@linkcode SpeciesFormChangeCondition} checking if that species is registered as caught
  */
 function getSpeciesDependentFormChangeCondition(species: Species): SpeciesFormChangeCondition {

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -75,7 +75,7 @@ export const normalForm: Species[] = [
 
 /**
  * Gets the {@linkcode PokemonSpecies} object associated with the {@linkcode Species} enum given
- * @param species The species to fetch
+ * @param species - The species to fetch
  * @returns The associated {@linkcode PokemonSpecies} object
  */
 export function getPokemonSpecies(species: Species | Species[]): PokemonSpecies {
@@ -229,7 +229,7 @@ export abstract class PokemonSpeciesForm {
    * Method to get the root species id of a Pokemon.
    * Magmortar.getRootSpeciesId(true) => Magmar
    * Magmortar.getRootSpeciesId(false) => Magby
-   * @param forStarter boolean to get the nonbaby form of a starter
+   * @param forStarter - boolean to get the nonbaby form of a starter
    * @returns The species
    */
   getRootSpeciesId(forStarter = false): Species {
@@ -270,7 +270,7 @@ export abstract class PokemonSpeciesForm {
 
   /**
    * Method to get the ability of a Pokemon species.
-   * @param abilityIndex Which ability to get (should only be 0-2)
+   * @param abilityIndex - Which ability to get (should only be 0-2)
    * @returns The id of the Ability
    */
   getAbility(abilityIndex: number): Abilities {
@@ -287,7 +287,7 @@ export abstract class PokemonSpeciesForm {
 
   /**
    * Method to get the passive ability of a Pokemon species
-   * @param formIndex The form index to use, defaults to form for this species instance
+   * @param formIndex - The form index to use, defaults to form for this species instance
    * @returns The id of the ability
    */
   getPassiveAbility(formIndex?: number): Abilities {
@@ -362,7 +362,7 @@ export abstract class PokemonSpeciesForm {
 
   /**
    * Gets the species' base stat amount for the given stat.
-   * @param stat  The desired stat.
+   * @param stat - The desired stat.
    * @returns The species' base stat amount.
    */
   getBaseStat(stat: Stat): number {
@@ -422,7 +422,7 @@ export abstract class PokemonSpeciesForm {
 
   /**
    * Variant Data key/index is either species id or species id followed by -formkey
-   * @param formIndex optional form index for pokemon with different forms
+   * @param formIndex - optional form index for pokemon with different forms
    * @returns species id if no additional forms, index with formkey if a pokemon with a form
    */
   getVariantDataIndex(formIndex?: number) {
@@ -860,8 +860,8 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
 
   /**
    * Find the form name for species with just one form (regional variants, Floette, Ursaluna)
-   * @param formIndex The form index to check (defaults to 0)
-   * @param append Whether to append the species name to the end (defaults to false)
+   * @param formIndex - The form index to check (defaults to 0)
+   * @param append - Whether to append the species name to the end (defaults to false)
    * @returns the pokemon-form locale key for the single form name ("Alolan Form", "Eternal Flower" etc)
    */
   getFormNameToDisplay(formIndex = 0, append = false): string {
@@ -960,7 +960,7 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
    * It's also used for preferredMinLevel, which is used when an evolution delay exists.
    * The calculation with evolution delay is a weighted average of the easeIn and easeOut functions where preferredMinLevel is the denominator.
    * This also means a lower value of x will lead to a higher evolution chance.
-   * @param strength {@linkcode PartyMemberStrength} The strength of the party member in question
+   * @param strength - The strength of the party member in question
    * @returns {@linkcode number} The level difference from expected evolution level tolerated for a mon to be unevolved. Lower value = higher evolution chance.
    */
   private getStrengthLevelDiff(strength: PartyMemberStrength): number {

--- a/src/data/status-effect.ts
+++ b/src/data/status-effect.ts
@@ -124,8 +124,8 @@ export function generateRandomStatusEffect(): StatusEffect {
 
 /**
  * Returns a random non-volatile StatusEffect between the two provided
- * @param statusEffectA The first StatusEffect
- * @param statusEffectA The second StatusEffect
+ * @param statusEffectA - The first StatusEffect
+ * @param statusEffectA - The second StatusEffect
  */
 export function getRandomStatusEffect(statusEffectA: StatusEffect, statusEffectB: StatusEffect): StatusEffect {
   if (statusEffectA === StatusEffect.NONE || statusEffectA === StatusEffect.FAINT) {
@@ -140,8 +140,8 @@ export function getRandomStatusEffect(statusEffectA: StatusEffect, statusEffectB
 
 /**
  * Returns a random non-volatile StatusEffect between the two provided
- * @param statusA The first Status
- * @param statusB The second Status
+ * @param statusA - The first Status
+ * @param statusB - The second Status
  */
 export function getRandomStatus(statusA: Status | null, statusB: Status | null): Status | null {
   if (!statusA || statusA.effect === StatusEffect.NONE || statusA.effect === StatusEffect.FAINT) {
@@ -172,7 +172,7 @@ export function getNonVolatileStatusEffects(): Array<StatusEffect> {
 /**
  * Returns whether a status effect is non volatile.
  * Non-volatile status condition is a status that remains after being switched out.
- * @param status The status to check
+ * @param status - The status to check
  */
 export function isNonVolatileStatusEffect(status: StatusEffect): boolean {
   return getNonVolatileStatusEffects().includes(status);

--- a/src/data/trainers/trainer-config.ts
+++ b/src/data/trainers/trainer-config.ts
@@ -64,7 +64,7 @@ export class TrainerAI {
   public instantTeras: number[];
 
   /**
-   * @param canTerastallize Whether this trainer is allowed to tera
+   * @param canTerastallize - Whether this trainer is allowed to tera
    */
   constructor(teraMode: TeraAIMode = TeraAIMode.NO_TERA) {
     this.teraMode = teraMode;
@@ -81,7 +81,7 @@ export class TrainerAI {
 
   /**
    * Sets a pokemon on this AI to just instantly Tera on first move used
-   * @param index The index of the pokemon to instantly tera.
+   * @param index - The index of the pokemon to instantly tera.
    */
   public setInstantTera(index: number) {
     this.teraMode = TeraAIMode.INSTANT_TERA;
@@ -280,8 +280,8 @@ export class TrainerConfig {
 
   /**
    * Sets the configuration for trainers with genders, including the female name and encounter background music (BGM).
-   * @param {string} [nameFemale] The name of the female trainer. If 'Ivy', a localized name will be assigned.
-   * @param {TrainerType | string} [femaleEncounterBgm] The encounter BGM for the female trainer, which can be a TrainerType or a string.
+   * @param [nameFemale] - The name of the female trainer. If 'Ivy', a localized name will be assigned.
+   * @param [femaleEncounterBgm] - The encounter BGM for the female trainer, which can be a TrainerType or a string.
    * @returns {TrainerConfig} The updated TrainerConfig instance.
    **/
   setHasGenders(nameFemale?: string, femaleEncounterBgm?: TrainerType | string): TrainerConfig {
@@ -318,8 +318,8 @@ export class TrainerConfig {
 
   /**
    * Sets the configuration for trainers with double battles, including the name of the double trainer and the encounter BGM.
-   * @param nameDouble The name of the double trainer (e.g., "Ace Duo" for Trainer Class Doubles or "red_blue_double" for NAMED trainer doubles).
-   * @param doubleEncounterBgm The encounter BGM for the double trainer, which can be a TrainerType or a string.
+   * @param nameDouble - The name of the double trainer (e.g., "Ace Duo" for Trainer Class Doubles or "red_blue_double" for NAMED trainer doubles).
+   * @param doubleEncounterBgm - The encounter BGM for the double trainer, which can be a TrainerType or a string.
    * @returns {TrainerConfig} The updated TrainerConfig instance.
    */
   setHasDouble(nameDouble: string, doubleEncounterBgm?: TrainerType | string): TrainerConfig {
@@ -336,7 +336,7 @@ export class TrainerConfig {
 
   /**
    * Sets the trainer type for double battles.
-   * @param trainerTypeDouble The TrainerType of the partner in a double battle.
+   * @param trainerTypeDouble - The TrainerType of the partner in a double battle.
    * @returns {TrainerConfig} The updated TrainerConfig instance.
    */
   setDoubleTrainerType(trainerTypeDouble: TrainerType): TrainerConfig {
@@ -361,7 +361,7 @@ export class TrainerConfig {
 
   /**
    * Sets the title for double trainers
-   * @param titleDouble The key for the title in the i18n file. (e.g., "champion_double").
+   * @param titleDouble - The key for the title in the i18n file. (e.g., "champion_double").
    * @returns {TrainerConfig} The updated TrainerConfig instance.
    */
   setDoubleTitle(titleDouble: string): TrainerConfig {
@@ -470,8 +470,8 @@ export class TrainerConfig {
 
   /**
    * Sets random pokemon from the trainer's team to instant tera. Also sets Tera type to specialty type and checks for Shedinja as appropriate.
-   * @param count A callback (yucky) to see how many teras should be used
-   * @param slot Optional, a specified slot that should be terastallized. Wraps to match party size (-1 will get the last slot and so on).
+   * @param count - A callback (yucky) to see how many teras should be used
+   * @param slot - Optional, a specified slot that should be terastallized. Wraps to match party size (-1 will get the last slot and so on).
    * @returns this
    */
   setRandomTeraModifiers(count: () => number, slot?: number): TrainerConfig {
@@ -497,7 +497,7 @@ export class TrainerConfig {
 
   /**
    * Sets a specific pokemon to instantly Tera
-   * @param index The index within the team to have instant Tera.
+   * @param index - The index within the team to have instant Tera.
    * @returns this
    */
   setInstantTera(index: number): TrainerConfig {
@@ -528,10 +528,10 @@ export class TrainerConfig {
 
   /**
    * Initializes the trainer configuration for an evil team admin.
-   * @param title The title of the evil team admin.
-   * @param poolName The evil team the admin belongs to.
-   * @param {Species | Species[]} signatureSpecies The signature species for the evil team leader.
-   * @param specialtyType The specialty Type of the admin, if they have one
+   * @param title - The title of the evil team admin.
+   * @param poolName - The evil team the admin belongs to.
+   * @param signatureSpecies - The signature species for the evil team leader.
+   * @param specialtyType - The specialty Type of the admin, if they have one
    * @returns {TrainerConfig} The updated TrainerConfig instance.
    * **/
   initForEvilTeamAdmin(
@@ -575,7 +575,7 @@ export class TrainerConfig {
 
   /**
    * Initializes the trainer configuration for a Stat Trainer, as part of the Trainer's Test Mystery Encounter.
-   * @param _isMale Whether the stat trainer is Male or Female (for localization of the title).
+   * @param _isMale - Whether the stat trainer is Male or Female (for localization of the title).
    * @returns {TrainerConfig} The updated TrainerConfig instance.
    **/
   initForStatTrainer(_isMale = false): TrainerConfig {
@@ -600,9 +600,9 @@ export class TrainerConfig {
 
   /**
    * Initializes the trainer configuration for an evil team leader. Temporarily hardcoding evil leader teams though.
-   * @param {Species | Species[]} signatureSpecies The signature species for the evil team leader.
-   * @param {PokemonType} specialtyType The specialty type for the evil team Leader.
-   * @param boolean Whether or not this is the rematch fight
+   * @param signatureSpecies - The signature species for the evil team leader.
+   * @param specialtyType - The specialty type for the evil team Leader.
+   * @param boolean - Whether or not this is the rematch fight
    * @returns {TrainerConfig} The updated TrainerConfig instance.
    * **/
   initForEvilTeamLeader(
@@ -644,11 +644,11 @@ export class TrainerConfig {
 
   /**
    * Initializes the trainer configuration for a Gym Leader.
-   * @param {Species | Species[]} signatureSpecies The signature species for the Gym Leader. Added to party in reverse order.
-   * @param isMale Whether the Gym Leader is Male or Not (for localization of the title).
-   * @param {PokemonType} specialtyType The specialty type for the Gym Leader.
-   * @param ignoreMinTeraWave Whether the Gym Leader always uses Tera (true), or only Teras after {@linkcode GYM_LEADER_TERA_WAVE} (false). Defaults to false.
-   * @param teraSlot Optional, sets the party member in this slot to Terastallize. Wraps based on party size.
+   * @param signatureSpecies - The signature species for the Gym Leader. Added to party in reverse order.
+   * @param isMale - Whether the Gym Leader is Male or Not (for localization of the title).
+   * @param specialtyType - The specialty type for the Gym Leader.
+   * @param ignoreMinTeraWave - Whether the Gym Leader always uses Tera (true), or only Teras after {@linkcode GYM_LEADER_TERA_WAVE} (false). Defaults to false.
+   * @param teraSlot - Optional, sets the party member in this slot to Terastallize. Wraps based on party size.
    * @returns {TrainerConfig} The updated TrainerConfig instance.
    * **/
   initForGymLeader(
@@ -707,11 +707,11 @@ export class TrainerConfig {
 
   /**
    * Initializes the trainer configuration for an Elite Four member.
-   * @param {Species | Species[]} signatureSpecies The signature species for the Elite Four member.
-   * @param isMale Whether the Elite Four Member is Male or Female (for localization of the title).
-   * @param specialtyType {PokemonType} The specialty type for the Elite Four member.
-   * @param teraSlot Optional, sets the party member in this slot to Terastallize.
-   * @returns {TrainerConfig} The updated TrainerConfig instance.
+   * @param signatureSpecies - The signature species for the Elite Four member
+   * @param isMale - Whether the Elite Four Member is Male or Female (for localization of the title)
+   * @param specialtyType - The specialty type for the Elite Four member
+   * @param teraSlot - Optional, sets the party member in this slot to Terastallize
+   * @returns The updated TrainerConfig instance.
    **/
   initForEliteFour(
     signatureSpecies: (Species | Species[])[],
@@ -769,8 +769,8 @@ export class TrainerConfig {
 
   /**
    * Initializes the trainer configuration for a Champion.
-   * @param {Species | Species[]} signatureSpecies The signature species for the Champion.
-   * @param isMale Whether the Champion is Male or Female (for localization of the title).
+   * @param signatureSpecies - The signature species for the Champion.
+   * @param isMale - Whether the Champion is Male or Female (for localization of the title).
    * @returns {TrainerConfig} The updated TrainerConfig instance.
    **/
   initForChampion(isMale: boolean): TrainerConfig {
@@ -819,8 +819,8 @@ export class TrainerConfig {
 
   /**
    * Retrieves the title for the trainer based on the provided trainer slot and variant.
-   * @param {TrainerSlot} trainerSlot - The slot to determine which title to use. Defaults to TrainerSlot.NONE.
-   * @param {TrainerVariant} variant - The variant of the trainer to determine the specific title.
+   * @param trainerSlot - The slot to determine which title to use. Defaults to TrainerSlot.NONE.
+   * @param variant - The variant of the trainer to determine the specific title.
    * @returns {string} - The title of the trainer.
    **/
   getTitle(trainerSlot: TrainerSlot = TrainerSlot.NONE, variant: TrainerVariant): string {

--- a/src/enums/stat.ts
+++ b/src/enums/stat.ts
@@ -41,8 +41,8 @@ export type TempBattleStat = typeof TEMP_BATTLE_STATS[number];
 /**
  * Provides the translation key corresponding to the amount of stat stages and whether those stat stages
  * are positive or negative.
- * @param stages the amount of stages
- * @param isIncrease dictates a negative (`false`) or a positive (`true`) stat stage change
+ * @param stages - the amount of stages
+ * @param isIncrease - dictates a negative (`false`) or a positive (`true`) stat stage change
  * @returns the translation key fitting the conditions described by {@linkcode stages} and {@linkcode isIncrease}
  */
 export function getStatStageChangeDescriptionKey(stages: number, isIncrease: boolean) {
@@ -60,7 +60,7 @@ export function getStatStageChangeDescriptionKey(stages: number, isIncrease: boo
 
 /**
  * Provides the translation key corresponding to a given stat which can be translated into its full name.
- * @param stat the {@linkcode Stat} to be translated
+ * @param stat - the {@linkcode Stat} to be translated
  * @returns the translation key corresponding to the given {@linkcode Stat}
  */
 export function getStatKey(stat: Stat) {
@@ -69,7 +69,7 @@ export function getStatKey(stat: Stat) {
 
 /**
  * Provides the translation key corresponding to a given stat which can be translated into its shortened name.
- * @param stat the {@linkcode Stat} to be translated
+ * @param stat - the {@linkcode Stat} to be translated
  * @returns the translation key corresponding to the given {@linkcode Stat}
  */
 export function getShortenedStatKey(stat: PermanentStat) {

--- a/src/events/arena.ts
+++ b/src/events/arena.ts
@@ -18,7 +18,6 @@ export enum ArenaEventType {
 
 /**
  * Base container class for all {@linkcode ArenaEventType} events
- * @extends Event
  */
 export class ArenaEvent extends Event {
   /** The total duration of the {@linkcode ArenaEventType} */
@@ -31,7 +30,6 @@ export class ArenaEvent extends Event {
 }
 /**
  * Container class for {@linkcode ArenaEventType.WEATHER_CHANGED} events
- * @extends ArenaEvent
  */
 export class WeatherChangedEvent extends ArenaEvent {
   /** The {@linkcode WeatherType} being overridden */
@@ -47,7 +45,6 @@ export class WeatherChangedEvent extends ArenaEvent {
 }
 /**
  * Container class for {@linkcode ArenaEventType.TERRAIN_CHANGED} events
- * @extends ArenaEvent
  */
 export class TerrainChangedEvent extends ArenaEvent {
   /** The {@linkcode TerrainType} being overridden */
@@ -64,7 +61,6 @@ export class TerrainChangedEvent extends ArenaEvent {
 
 /**
  * Container class for {@linkcode ArenaEventType.TAG_ADDED} events
- * @extends ArenaEvent
  */
 export class TagAddedEvent extends ArenaEvent {
   /** The {@linkcode ArenaTagType} being added */
@@ -93,7 +89,6 @@ export class TagAddedEvent extends ArenaEvent {
 }
 /**
  * Container class for {@linkcode ArenaEventType.TAG_REMOVED} events
- * @extends ArenaEvent
  */
 export class TagRemovedEvent extends ArenaEvent {
   /** The {@linkcode ArenaTagType} being removed */

--- a/src/events/battle-scene.ts
+++ b/src/events/battle-scene.ts
@@ -45,7 +45,6 @@ export enum BattleSceneEventType {
 
 /**
  * Container class for {@linkcode BattleSceneEventType.CANDY_UPGRADE_NOTIFICATION_CHANGED} events
- * @extends Event
  */
 export class CandyUpgradeNotificationChangedEvent extends Event {
   /** The new value the setting was changed to */
@@ -59,7 +58,6 @@ export class CandyUpgradeNotificationChangedEvent extends Event {
 
 /**
  * Container class for {@linkcode BattleSceneEventType.MOVE_USED} events
- * @extends Event
  */
 export class MoveUsedEvent extends Event {
   /** The ID of the {@linkcode Pokemon} that used the {@linkcode Move} */
@@ -78,7 +76,6 @@ export class MoveUsedEvent extends Event {
 }
 /**
  * Container class for {@linkcode BattleSceneEventType.BERRY_USED} events
- * @extends Event
  */
 export class BerryUsedEvent extends Event {
   /** The {@linkcode BerryModifier} being used */
@@ -92,7 +89,6 @@ export class BerryUsedEvent extends Event {
 
 /**
  * Container class for {@linkcode BattleSceneEventType.ENCOUNTER_PHASE} events
- * @extends Event
  */
 export class EncounterPhaseEvent extends Event {
   constructor() {
@@ -101,7 +97,6 @@ export class EncounterPhaseEvent extends Event {
 }
 /**
  * Container class for {@linkcode BattleSceneEventType.TURN_INIT} events
- * @extends Event
  */
 export class TurnInitEvent extends Event {
   constructor() {
@@ -110,7 +105,6 @@ export class TurnInitEvent extends Event {
 }
 /**
  * Container class for {@linkcode BattleSceneEventType.TURN_END} events
- * @extends Event
  */
 export class TurnEndEvent extends Event {
   /** The amount of turns in the current battle */
@@ -123,7 +117,6 @@ export class TurnEndEvent extends Event {
 }
 /**
  * Container class for {@linkcode BattleSceneEventType.NEW_ARENA} events
- * @extends Event
  */
 export class NewArenaEvent extends Event {
   constructor() {

--- a/src/events/egg.ts
+++ b/src/events/egg.ts
@@ -8,7 +8,6 @@ export enum EggEventType {
 
 /**
  * Container class for {@linkcode EggEventType.EGG_COUNT_CHANGED} events
- * @extends Event
  */
 export class EggCountChangedEvent extends Event {
   /** The updated egg count. */

--- a/src/field/anims.ts
+++ b/src/field/anims.ts
@@ -202,8 +202,8 @@ export function cos(index: number, amplitude: number): number {
 /**
  * Play the shiny sparkle animation and sound effect for the given sprite
  * First ensures that the animation has been properly initialized
- * @param sparkleSprite the Sprite to play the animation on
- * @param variant which shiny {@linkcode variant} to play the animation for
+ * @param sparkleSprite - the Sprite to play the animation on
+ * @param variant - which shiny {@linkcode variant} to play the animation for
  */
 export function doShinySparkleAnim(sparkleSprite: Phaser.GameObjects.Sprite, variant: Variant) {
   const keySuffix = variant ? `_${variant + 1}` : "";

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -292,7 +292,7 @@ export class Arena {
 
   /**
    * Sets weather to the override specified in overrides.ts
-   * @param weather new {@linkcode WeatherType} to set
+   * @param weather - new {@linkcode WeatherType} to set
    * @returns true to force trySetWeather to return true
    */
   trySetWeatherOverride(weather: WeatherType): boolean {
@@ -309,8 +309,8 @@ export class Arena {
 
   /**
    * Attempts to set a new weather to the battle
-   * @param weather {@linkcode WeatherType} new {@linkcode WeatherType} to set
-   * @param user {@linkcode Pokemon} that caused the weather effect
+   * @param weather - new {@linkcode WeatherType} to set
+   * @param user - that caused the weather effect
    * @returns true if new weather set, false if no weather provided or attempting to set the same weather as currently in use
    */
   trySetWeather(weather: WeatherType, user?: Pokemon): boolean {
@@ -404,9 +404,9 @@ export class Arena {
 
   /**
    * Attempts to set a new terrain effect to the battle
-   * @param terrain {@linkcode TerrainType} new {@linkcode TerrainType} to set
-   * @param ignoreAnim boolean if the terrain animation should be ignored
-   * @param user {@linkcode Pokemon} that caused the terrain effect
+   * @param terrain - new {@linkcode TerrainType} to set
+   * @param ignoreAnim - boolean if the terrain animation should be ignored
+   * @param user - that caused the terrain effect
    * @returns true if new terrain set, false if no terrain provided or attempting to set the same terrain as currently in use
    */
   trySetTerrain(terrain: TerrainType, ignoreAnim = false, user?: Pokemon): boolean {
@@ -638,10 +638,10 @@ export class Arena {
 
   /**
    * Applies each `ArenaTag` in this Arena, based on which side (self, enemy, or both) is passed in as a parameter
-   * @param tagType Either an {@linkcode ArenaTagType} string, or an actual {@linkcode ArenaTag} class to filter which ones to apply
-   * @param side {@linkcode ArenaTagSide} which side's arena tags to apply
-   * @param simulated if `true`, this applies arena tags without changing game state
-   * @param args array of parameters that the called upon tags may need
+   * @param tagType - Either an {@linkcode ArenaTagType} string, or an actual {@linkcode ArenaTag} class to filter which ones to apply
+   * @param side - which side's arena tags to apply
+   * @param simulated - if `true`, this applies arena tags without changing game state
+   * @param args - array of parameters that the called upon tags may need
    */
   applyTagsForSide(
     tagType: ArenaTagType | Constructor<ArenaTag>,
@@ -662,9 +662,9 @@ export class Arena {
   /**
    * Applies the specified tag to both sides (ie: both user and trainer's tag that match the Tag specified)
    * by calling {@linkcode applyTagsForSide()}
-   * @param tagType Either an {@linkcode ArenaTagType} string, or an actual {@linkcode ArenaTag} class to filter which ones to apply
-   * @param simulated if `true`, this applies arena tags without changing game state
-   * @param args array of parameters that the called upon tags may need
+   * @param tagType - Either an {@linkcode ArenaTagType} string, or an actual {@linkcode ArenaTag} class to filter which ones to apply
+   * @param simulated - if `true`, this applies arena tags without changing game state
+   * @param args - array of parameters that the called upon tags may need
    */
   applyTags(tagType: ArenaTagType | Constructor<ArenaTag>, simulated: boolean, ...args: unknown[]): void {
     this.applyTagsForSide(tagType, ArenaTagSide.BOTH, simulated, ...args);
@@ -672,13 +672,13 @@ export class Arena {
 
   /**
    * Adds a new tag to the arena
-   * @param tagType {@linkcode ArenaTagType} the tag being added
-   * @param turnCount How many turns the tag lasts
-   * @param sourceMove {@linkcode Moves} the move the tag came from, or `undefined` if not from a move
-   * @param sourceId The ID of the pokemon in play the tag came from (see {@linkcode BattleScene.getPokemonById})
-   * @param side {@linkcode ArenaTagSide} which side(s) the tag applies to
-   * @param quiet If a message should be queued on screen to announce the tag being added
-   * @param targetIndex The {@linkcode BattlerIndex} of the target pokemon
+   * @param tagType - the tag being added
+   * @param turnCount - How many turns the tag lasts
+   * @param sourceMove - the move the tag came from, or `undefined` if not from a move
+   * @param sourceId - The ID of the pokemon in play the tag came from (see {@linkcode BattleScene.getPokemonById})
+   * @param side - which side(s) the tag applies to
+   * @param quiet - If a message should be queued on screen to announce the tag being added
+   * @param targetIndex - The {@linkcode BattlerIndex} of the target pokemon
    * @returns `false` if there already exists a tag of this type in the Arena
    */
   addTag(
@@ -720,7 +720,7 @@ export class Arena {
 
   /**
    * Attempts to get a tag from the Arena via {@linkcode getTagOnSide} that applies to both sides
-   * @param tagType The {@linkcode ArenaTagType} or {@linkcode ArenaTag} to get
+   * @param tagType - The {@linkcode ArenaTagType} or {@linkcode ArenaTag} to get
    * @returns either the {@linkcode ArenaTag}, or `undefined` if it isn't there
    */
   getTag(tagType: ArenaTagType | Constructor<ArenaTag>): ArenaTag | undefined {
@@ -735,8 +735,8 @@ export class Arena {
    * Attempts to get a tag from the Arena from a specific side (the tag passed in has to either apply to both sides, or the specific side only)
    *
    * eg: `MIST` only applies to the user's side, while `MUD_SPORT` applies to both user and enemy side
-   * @param tagType The {@linkcode ArenaTagType} or {@linkcode ArenaTag} to get
-   * @param side The {@linkcode ArenaTagSide} to look at
+   * @param tagType - The {@linkcode ArenaTagType} or {@linkcode ArenaTag} to get
+   * @param side - The {@linkcode ArenaTagSide} to look at
    * @returns either the {@linkcode ArenaTag}, or `undefined` if it isn't there
    */
   getTagOnSide(tagType: ArenaTagType | Constructor<ArenaTag>, side: ArenaTagSide): ArenaTag | undefined {
@@ -751,7 +751,7 @@ export class Arena {
 
   /**
    * Uses {@linkcode findTagsOnSide} to filter (using the parameter function) for specific tags that apply to both sides
-   * @param tagPredicate a function mapping {@linkcode ArenaTag}s to `boolean`s
+   * @param tagPredicate - a function mapping {@linkcode ArenaTag}s to `boolean`s
    * @returns array of {@linkcode ArenaTag}s from which the Arena's tags return true and apply to both sides
    */
   findTags(tagPredicate: (t: ArenaTag) => boolean): ArenaTag[] {
@@ -760,8 +760,8 @@ export class Arena {
 
   /**
    * Returns specific tags from the arena that pass the `tagPredicate` function passed in as a parameter, and apply to the given side
-   * @param tagPredicate a function mapping {@linkcode ArenaTag}s to `boolean`s
-   * @param side The {@linkcode ArenaTagSide} to look at
+   * @param tagPredicate - a function mapping {@linkcode ArenaTag}s to `boolean`s
+   * @param side - The {@linkcode ArenaTagSide} to look at
    * @returns array of {@linkcode ArenaTag}s from which the Arena's tags return `true` and apply to the given side
    */
   findTagsOnSide(tagPredicate: (t: ArenaTag) => boolean, side: ArenaTagSide): ArenaTag[] {

--- a/src/field/mystery-encounter-intro.ts
+++ b/src/field/mystery-encounter-intro.ts
@@ -327,9 +327,9 @@ export default class MysteryEncounterIntroVisuals extends Phaser.GameObjects.Con
   /**
    * Attempts to animate a given set of {@linkcode Phaser.GameObjects.Sprite}
    * @see {@linkcode Phaser.GameObjects.Sprite.play}
-   * @param sprite {@linkcode Phaser.GameObjects.Sprite} to animate
-   * @param tintSprite {@linkcode Phaser.GameObjects.Sprite} placed on top of the sprite to add a color tint
-   * @param animConfig {@linkcode Phaser.Types.Animations.PlayAnimationConfig} to pass to {@linkcode Phaser.GameObjects.Sprite.play}
+   * @param sprite - to animate
+   * @param tintSprite - placed on top of the sprite to add a color tint
+   * @param animConfig - to pass to {@linkcode Phaser.GameObjects.Sprite.play}
    * @returns true if the sprite was able to be animated
    */
   tryPlaySprite(

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -539,7 +539,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * @param {boolean} useIllusion - Whether we want the fake name or the real name of the Pokemon (for Illusion ability).
+   * @param useIllusion - Whether we want the fake name or the real name of the Pokemon (for Illusion ability).
    */
   getNameToRender(useIllusion: boolean = true) {
     const name: string = (!useIllusion && !!this.summonData?.illusion) ? this.summonData?.illusion.basePokemon!.name : this.name;
@@ -618,7 +618,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Checks if a pokemon is fainted (ie: its `hp <= 0`).
    * It's usually better to call {@linkcode isAllowedInBattle()}
-   * @param checkStatus `true` to also check that the pokemon's status is {@linkcode StatusEffect.FAINT}
+   * @param checkStatus - `true` to also check that the pokemon's status is {@linkcode StatusEffect.FAINT}
    * @returns `true` if the pokemon is fainted
    */
   public isFainted(checkStatus = false): boolean {
@@ -653,7 +653,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Checks if the pokemon is allowed in battle (ie: not fainted, and allowed under any active challenges).
-   * @param onField `true` to also check if the pokemon is currently on the field, defaults to `false`
+   * @param onField - `true` to also check if the pokemon is currently on the field, defaults to `false`
    * @returns `true` if the pokemon is "active". Returns `false` if there is no active {@linkcode BattleScene}
    */
   public isActive(onField = false): boolean {
@@ -886,11 +886,11 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * Gracefully handle errors loading a variant sprite. Log if it fails and attempt to fall back on
    * non-experimental sprites before giving up.
    *
-   * @param cacheKey the cache key for the variant color sprite
-   * @param attemptedSpritePath the sprite path that failed to load
-   * @param useExpSprite was the attempted sprite experimental
-   * @param battleSpritePath the filename of the sprite
-   * @param optionalParams any additional params to log
+   * @param cacheKey - the cache key for the variant color sprite
+   * @param attemptedSpritePath - the sprite path that failed to load
+   * @param useExpSprite - was the attempted sprite experimental
+   * @param battleSpritePath - the filename of the sprite
+   * @param optionalParams - any additional params to log
    */
   async fallbackVariantColor(
     cacheKey: string,
@@ -908,9 +908,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Attempt to process variant sprite.
    *
-   * @param cacheKey the cache key for the variant color sprite
-   * @param useExpSprite should the experimental sprite be used
-   * @param battleSpritePath the filename of the sprite
+   * @param cacheKey - the cache key for the variant color sprite
+   * @param useExpSprite - should the experimental sprite be used
+   * @param battleSpritePath - the filename of the sprite
    */
   async populateVariantColorCache(
     cacheKey: string,
@@ -1103,7 +1103,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * @param {boolean} useIllusion - Whether we want the speciesForm of the illusion or not.
+   * @param useIllusion - Whether we want the speciesForm of the illusion or not.
    */
   getSpeciesForm(ignoreOverride?: boolean, useIllusion: boolean = false): PokemonSpeciesForm {
     const species: PokemonSpecies = useIllusion && !!this.summonData?.illusion ? getPokemonSpecies(this.summonData?.illusion.species) : this.species;
@@ -1120,7 +1120,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * @param {boolean} useIllusion - Whether we want the fusionSpeciesForm of the illusion or not.
+   * @param useIllusion - Whether we want the fusionSpeciesForm of the illusion or not.
    */
   getFusionSpeciesForm(ignoreOverride?: boolean, useIllusion: boolean = false): PokemonSpeciesForm {
     const fusionSpecies: PokemonSpecies = useIllusion && !!this.summonData?.illusion ? this.summonData?.illusion.fusionSpecies! : this.fusionSpecies!;
@@ -1218,9 +1218,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Attempts to animate a given {@linkcode Phaser.GameObjects.Sprite}
    * @see {@linkcode Phaser.GameObjects.Sprite.play}
-   * @param sprite {@linkcode Phaser.GameObjects.Sprite} to animate
-   * @param tintSprite {@linkcode Phaser.GameObjects.Sprite} placed on top of the sprite to add a color tint
-   * @param animConfig {@linkcode String} to pass to {@linkcode Phaser.GameObjects.Sprite.play}
+   * @param sprite - to animate
+   * @param tintSprite - placed on top of the sprite to add a color tint
+   * @param animConfig - to pass to {@linkcode Phaser.GameObjects.Sprite.play}
    * @returns true if the sprite was able to be animated
    */
   tryPlaySprite(
@@ -1358,7 +1358,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Retrieves the entire set of stats of the {@linkcode Pokemon}.
-   * @param bypassSummonData prefer actual stats (`true` by default) or in-battle overriden stats (`false`)
+   * @param bypassSummonData - prefer actual stats (`true` by default) or in-battle overriden stats (`false`)
    * @returns the numeric values of the {@linkcode Pokemon}'s stats
    */
   getStats(bypassSummonData = true): number[] {
@@ -1370,8 +1370,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Retrieves the corresponding {@linkcode PermanentStat} of the {@linkcode Pokemon}.
-   * @param stat the desired {@linkcode PermanentStat}
-   * @param bypassSummonData prefer actual stats (`true` by default) or in-battle overridden stats (`false`)
+   * @param stat - the desired {@linkcode PermanentStat}
+   * @param bypassSummonData - prefer actual stats (`true` by default) or in-battle overridden stats (`false`)
    * @returns the numeric value of the desired {@linkcode Stat}
    */
   getStat(stat: PermanentStat, bypassSummonData = true): number {
@@ -1389,9 +1389,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * Writes the value to the corrseponding {@linkcode PermanentStat} of the {@linkcode Pokemon}.
    *
    * Note that this does nothing if {@linkcode value} is less than 0.
-   * @param stat the desired {@linkcode PermanentStat} to be overwritten
-   * @param value the desired numeric value
-   * @param bypassSummonData write to actual stats (`true` by default) or in-battle overridden stats (`false`)
+   * @param stat - the desired {@linkcode PermanentStat} to be overwritten
+   * @param value - the desired numeric value
+   * @param bypassSummonData - write to actual stats (`true` by default) or in-battle overridden stats (`false`)
    */
   setStat(stat: PermanentStat, value: number, bypassSummonData = true): void {
     if (value >= 0) {
@@ -1413,7 +1413,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Retrieves the in-battle stage of the specified {@linkcode BattleStat}.
-   * @param stat the {@linkcode BattleStat} whose stage is desired
+   * @param stat - the {@linkcode BattleStat} whose stage is desired
    * @returns the stage of the desired {@linkcode BattleStat} if available, 0 otherwise
    */
   getStatStage(stat: BattleStat): number {
@@ -1424,8 +1424,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * Writes the value to the in-battle stage of the corresponding {@linkcode BattleStat} of the {@linkcode Pokemon}.
    *
    * Note that, if the value is not within a range of [-6, 6], it will be forced to the closest range bound.
-   * @param stat the {@linkcode BattleStat} whose stage is to be overwritten
-   * @param value the desired numeric value
+   * @param stat - the {@linkcode BattleStat} whose stage is to be overwritten
+   * @param value - the desired numeric value
    */
   setStatStage(stat: BattleStat, value: number): void {
     if (this.summonData) {
@@ -1441,8 +1441,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * Calculate the critical-hit stage of a move used against this pokemon by
    * the given source
    * 
-   * @param source the {@linkcode Pokemon} who using the move
-   * @param move the {@linkcode Move} being used
+   * @param source - the {@linkcode Pokemon} who using the move
+   * @param move - the {@linkcode Move} being used
    * @returns the final critical-hit stage value
    */
   getCritStage(source: Pokemon, move: Move): number {
@@ -1479,15 +1479,15 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * Calculates and retrieves the final value of a stat considering any held
    * items, move effects, opponent abilities, and whether there was a critical
    * hit.
-   * @param stat the desired {@linkcode EffectiveStat}
-   * @param opponent the target {@linkcode Pokemon}
-   * @param move the {@linkcode Move} being used
-   * @param ignoreAbility determines whether this Pokemon's abilities should be ignored during the stat calculation
-   * @param ignoreOppAbility during an attack, determines whether the opposing Pokemon's abilities should be ignored during the stat calculation.
-   * @param ignoreAllyAbility during an attack, determines whether the ally Pokemon's abilities should be ignored during the stat calculation.
-   * @param isCritical determines whether a critical hit has occurred or not (`false` by default)
-   * @param simulated if `true`, nullifies any effects that produce any changes to game state from triggering
-   * @param ignoreHeldItems determines whether this Pokemon's held items should be ignored during the stat calculation, default `false`
+   * @param stat - the desired {@linkcode EffectiveStat}
+   * @param opponent - the target {@linkcode Pokemon}
+   * @param move - the {@linkcode Move} being used
+   * @param ignoreAbility - determines whether this Pokemon's abilities should be ignored during the stat calculation
+   * @param ignoreOppAbility - during an attack, determines whether the opposing Pokemon's abilities should be ignored during the stat calculation.
+   * @param ignoreAllyAbility - during an attack, determines whether the ally Pokemon's abilities should be ignored during the stat calculation.
+   * @param isCritical - determines whether a critical hit has occurred or not (`false` by default)
+   * @param simulated - if `true`, nullifies any effects that produce any changes to game state from triggering
+   * @param ignoreHeldItems - determines whether this Pokemon's held items should be ignored during the stat calculation, default `false`
    * @returns the final in-battle value of a stat
    */
   getEffectiveStat(
@@ -1792,7 +1792,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * @param {boolean} useIllusion - Whether we want the fake or real gender (illusion ability).
+   * @param useIllusion - Whether we want the fake or real gender (illusion ability).
    */
   getGender(ignoreOverride?: boolean, useIllusion: boolean = false): Gender {
     if (useIllusion && !!this.summonData?.illusion) {
@@ -1804,7 +1804,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * @param {boolean} useIllusion - Whether we want the fake or real gender (illusion ability).
+   * @param useIllusion - Whether we want the fake or real gender (illusion ability).
    */
   getFusionGender(ignoreOverride?: boolean, useIllusion: boolean = false): Gender {
     if (useIllusion && !!this.summonData?.illusion) {
@@ -1816,7 +1816,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * @param {boolean} useIllusion - Whether we want the fake or real shininess (illusion ability).
+   * @param useIllusion - Whether we want the fake or real shininess (illusion ability).
    */
   isShiny(useIllusion: boolean = false): boolean {
     if (!useIllusion && !!this.summonData?.illusion) {
@@ -1840,7 +1840,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * @param {boolean} useIllusion - Whether we want the fake or real variant (illusion ability).
+   * @param useIllusion - Whether we want the fake or real variant (illusion ability).
    */
   getVariant(useIllusion: boolean = false): Variant {
     if (!useIllusion && !!this.summonData?.illusion) {
@@ -1877,7 +1877,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * @param {boolean} useIllusion - Whether we want the fake name or the real name of the Pokemon (for Illusion ability).
+   * @param useIllusion - Whether we want the fake name or the real name of the Pokemon (for Illusion ability).
    */
   getName(useIllusion: boolean = false): string {
     return (!useIllusion && !!this.summonData?.illusion && this.summonData?.illusion.basePokemon) 
@@ -1887,7 +1887,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Checks if the {@linkcode Pokemon} has a fusion with the specified {@linkcode Species}.
-   * @param species the pokemon {@linkcode Species} to check
+   * @param species - the pokemon {@linkcode Species} to check
    * @returns `true` if the {@linkcode Pokemon} has a fusion with the specified {@linkcode Species}, `false` otherwise
    */
   hasFusionSpecies(species: Species): boolean {
@@ -1896,8 +1896,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Checks if the {@linkcode Pokemon} has is the specified {@linkcode Species} or is fused with it.
-   * @param species the pokemon {@linkcode Species} to check
-   * @param formKey If provided, requires the species to be in that form
+   * @param species - the pokemon {@linkcode Species} to check
+   * @param formKey - If provided, requires the species to be in that form
    * @returns `true` if the pokemon is the species or is fused with it, `false` otherwise
    */
   hasSpecies(species: Species, formKey?: string): boolean {
@@ -2246,7 +2246,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * Sets the {@linkcode Pokemon}'s ability and activates it if it normally activates on summon
    *
    * Also clears primal weather if it is from the ability being changed
-   * @param ability New Ability
+   * @param ability - New Ability
    */
   public setTempAbility(ability: Ability, passive = false): void {
     applyOnLoseAbAttrs(this, passive);
@@ -2311,7 +2311,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * Checks whether an ability of a pokemon can be currently applied. This should rarely be
    * directly called, as {@linkcode hasAbility} and {@linkcode hasAbilityWithAttr} already call this.
    * @see {@linkcode hasAbility} {@linkcode hasAbilityWithAttr} Intended ways to check abilities in most cases
-   * @param passive If true, check if passive can be applied instead of non-passive
+   * @param passive - If true, check if passive can be applied instead of non-passive
    * @returns `true` if the ability can be applied
    */
   public canApplyAbility(passive = false): boolean {
@@ -2372,9 +2372,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * Checks whether a pokemon has the specified ability and it's in effect. Accounts for all the various
    * effects which can affect whether an ability will be present or in effect, and both passive and
    * non-passive. This is the primary way to check whether a pokemon has a particular ability.
-   * @param {Abilities} ability The ability to check for
-   * @param {boolean} canApply If false, it doesn't check whether the ability is currently active
-   * @param {boolean} ignoreOverride If true, it ignores ability changing effects
+   * @param ability - The ability to check for
+   * @param canApply - If false, it doesn't check whether the ability is currently active
+   * @param ignoreOverride - If true, it ignores ability changing effects
    * @returns {boolean} Whether the ability is present and active
    */
   public hasAbility(
@@ -2403,9 +2403,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * Accounts for all the various effects which can affect whether an ability will be present or
    * in effect, and both passive and non-passive. This is one of the two primary ways to check
    * whether a pokemon has a particular ability.
-   * @param {AbAttr} attrType The ability attribute to check for
-   * @param {boolean} canApply If false, it doesn't check whether the ability is currently active
-   * @param {boolean} ignoreOverride If true, it ignores ability changing effects
+   * @param attrType - The ability attribute to check for
+   * @param canApply - If false, it doesn't check whether the ability is currently active
+   * @param ignoreOverride - If true, it ignores ability changing effects
    * @returns {boolean} Whether an ability with that attribute is present and active
    */
   public hasAbilityWithAttr(
@@ -2578,11 +2578,11 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Calculates the effectiveness of a move against the Pokémon.
    * This includes modifiers from move and ability attributes.
-   * @param source {@linkcode Pokemon} The attacking Pokémon.
-   * @param move {@linkcode Move} The move being used by the attacking Pokémon.
-   * @param ignoreAbility Whether to ignore abilities that might affect type effectiveness or immunity (defaults to `false`).
-   * @param simulated Whether to apply abilities via simulated calls (defaults to `true`)
-   * @param cancelled {@linkcode BooleanHolder} Stores whether the move was cancelled by a non-type-based immunity.
+   * @param source - The attacking Pokémon.
+   * @param move - The move being used by the attacking Pokémon.
+   * @param ignoreAbility - Whether to ignore abilities that might affect type effectiveness or immunity (defaults to `false`).
+   * @param simulated - Whether to apply abilities via simulated calls (defaults to `true`)
+   * @param cancelled - Stores whether the move was cancelled by a non-type-based immunity.
    * @param useIllusion - Whether we want the attack move effectiveness on the illusion or not
    * Currently only used by {@linkcode Pokemon.apply} to determine whether a "No effect" message should be shown.
    * @returns The type damage multiplier, indicating the effectiveness of the move
@@ -2714,11 +2714,11 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Calculates the move's type effectiveness multiplier based on the target's type/s.
-   * @param moveType {@linkcode PokemonType} the type of the move being used
-   * @param source {@linkcode Pokemon} the Pokemon using the move
-   * @param ignoreStrongWinds whether or not this ignores strong winds (anticipation, forewarn, stealth rocks)
-   * @param simulated tag to only apply the strong winds effect message when the move is used
-   * @param move (optional) the move whose type effectiveness is to be checked. Used for applying {@linkcode VariableMoveTypeChartAttr}
+   * @param moveType - the type of the move being used
+   * @param source - the Pokemon using the move
+   * @param ignoreStrongWinds - whether or not this ignores strong winds (anticipation, forewarn, stealth rocks)
+   * @param simulated - tag to only apply the strong winds effect message when the move is used
+   * @param move - (optional) the move whose type effectiveness is to be checked. Used for applying {@linkcode VariableMoveTypeChartAttr}
    * @param useIllusion - Whether we want the attack type effectiveness on the illusion or not
    * @returns a multiplier for the type effectiveness
    */
@@ -2827,7 +2827,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Computes the given Pokemon's matchup score against this Pokemon.
    * In most cases, this score ranges from near-zero to 16, but the maximum possible matchup score is 64.
-   * @param opponent {@linkcode Pokemon} The Pokemon to compare this Pokemon against
+   * @param opponent - The Pokemon to compare this Pokemon against
    * @returns A score value based on how favorable this Pokemon is when fighting the given Pokemon
    */
   getMatchupScore(opponent: Pokemon): number {
@@ -2920,10 +2920,10 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Gets all level up moves in a given range for a particular pokemon.
-   * @param {number} startingLevel Don't include moves below this level
-   * @param {boolean} includeEvolutionMoves Whether to include evolution moves
-   * @param {boolean} simulateEvolutionChain Whether to include moves from prior evolutions
-   * @param {boolean} includeRelearnerMoves Whether to include moves that would require a relearner. Note the move relearner inherently allows evolution moves
+   * @param startingLevel - Don't include moves below this level
+   * @param includeEvolutionMoves - Whether to include evolution moves
+   * @param simulateEvolutionChain - Whether to include moves from prior evolutions
+   * @param includeRelearnerMoves - Whether to include moves that would require a relearner. Note the move relearner inherently allows evolution moves
    * @returns {LevelMoves} A list of moves and the levels they can be learned at
    */
   getLevelMoves(
@@ -3079,8 +3079,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * Finds all non-duplicate items from the input, and pushes them into the output.
    * Two items count as duplicate if they have the same Move, regardless of level.
    *
-   * @param levelMoves the input array to search for non-duplicates from
-   * @param ret the output array to be pushed into.
+   * @param levelMoves - the input array to search for non-duplicates from
+   * @param ret - the output array to be pushed into.
    */
   private getUniqueMoves(levelMoves: LevelMoves, ret: LevelMoves): void {
     const uniqueMoves: Moves[] = [];
@@ -3120,7 +3120,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * F is calculated as the XOR of the first 16 bits of the Pokemon's ID with the last 16 bits.
    * The XOR of E and F are then compared to the {@linkcode shinyThreshold} (or {@linkcode thresholdOverride} if set) to see whether or not to generate a shiny.
    * The base shiny odds are {@linkcode BASE_SHINY_CHANCE} / 65536
-   * @param thresholdOverride number that is divided by 2^16 (65536) to get the shiny chance, overrides {@linkcode shinyThreshold} if set (bypassing shiny rate modifiers such as Shiny Charm)
+   * @param thresholdOverride - number that is divided by 2^16 (65536) to get the shiny chance, overrides {@linkcode shinyThreshold} if set (bypassing shiny rate modifiers such as Shiny Charm)
    * @returns true if the Pokemon has been set as a shiny, false otherwise
    */
   trySetShiny(thresholdOverride?: number): boolean {
@@ -3173,8 +3173,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * If it rolls shiny, also sets a random variant and give the Pokemon the associated luck.
    *
    * The base shiny odds are {@linkcode BASE_SHINY_CHANCE} / `65536`
-   * @param thresholdOverride number that is divided by `2^16` (`65536`) to get the shiny chance, overrides {@linkcode shinyThreshold} if set (bypassing shiny rate modifiers such as Shiny Charm)
-   * @param applyModifiersToOverride If {@linkcode thresholdOverride} is set and this is true, will apply Shiny Charm and event modifiers to {@linkcode thresholdOverride}
+   * @param thresholdOverride - number that is divided by `2^16` (`65536`) to get the shiny chance, overrides {@linkcode shinyThreshold} if set (bypassing shiny rate modifiers such as Shiny Charm)
+   * @param applyModifiersToOverride - If {@linkcode thresholdOverride} is set and this is true, will apply Shiny Charm and event modifiers to {@linkcode thresholdOverride}
    * @returns `true` if the Pokemon has been set as a shiny, `false` otherwise
    */
   public trySetShinySeed(
@@ -3258,8 +3258,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * For manual use only, usually to roll a Pokemon's hidden ability chance a second time.
    *
    * The base hidden ability odds are {@linkcode BASE_HIDDEN_ABILITY_CHANCE} / `65536`
-   * @param thresholdOverride number that is divided by `2^16` (`65536`) to get the HA chance, overrides {@linkcode haThreshold} if set (bypassing HA rate modifiers such as Ability Charm)
-   * @param applyModifiersToOverride If {@linkcode thresholdOverride} is set and this is true, will apply Ability Charm to {@linkcode thresholdOverride}
+   * @param thresholdOverride - number that is divided by `2^16` (`65536`) to get the HA chance, overrides {@linkcode haThreshold} if set (bypassing HA rate modifiers such as Ability Charm)
+   * @param applyModifiersToOverride - If {@linkcode thresholdOverride} is set and this is true, will apply Ability Charm to {@linkcode thresholdOverride}
    * @returns `true` if the Pokemon has been set to have its hidden ability, `false` otherwise
    */
   public tryRerollHiddenAbilitySeed(
@@ -3807,8 +3807,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Adds experience to this PlayerPokemon, subject to wave based level caps.
-   * @param exp The amount of experience to add
-   * @param ignoreLevelCap Whether to ignore level caps when adding experience (defaults to false)
+   * @param exp - The amount of experience to add
+   * @param ignoreLevelCap - Whether to ignore level caps when adding experience (defaults to false)
    */
   addExp(exp: number, ignoreLevelCap = false) {
     const maxExpLevel = globalScene.getMaxExpLevel(ignoreLevelCap);
@@ -3837,7 +3837,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Compares if `this` and {@linkcode target} are on the same team.
-   * @param target the {@linkcode Pokemon} to compare against.
+   * @param target - the {@linkcode Pokemon} to compare against.
    * @returns `true` if the two pokemon are allies, `false` otherwise
    */
   public isOpponent(target: Pokemon): boolean {
@@ -3899,13 +3899,13 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    *
    * Note that this does not apply to evasion or accuracy
    * @see {@linkcode getAccuracyMultiplier}
-   * @param stat the desired {@linkcode EffectiveStat}
-   * @param opponent the target {@linkcode Pokemon}
-   * @param move the {@linkcode Move} being used
-   * @param ignoreOppAbility determines whether the effects of the opponent's abilities (i.e. Unaware) should be ignored (`false` by default)
-   * @param isCritical determines whether a critical hit has occurred or not (`false` by default)
-   * @param simulated determines whether effects are applied without altering game state (`true` by default)
-   * @param ignoreHeldItems determines whether this Pokemon's held items should be ignored during the stat calculation, default `false`
+   * @param stat - the desired {@linkcode EffectiveStat}
+   * @param opponent - the target {@linkcode Pokemon}
+   * @param move - the {@linkcode Move} being used
+   * @param ignoreOppAbility - determines whether the effects of the opponent's abilities (i.e. Unaware) should be ignored (`false` by default)
+   * @param isCritical - determines whether a critical hit has occurred or not (`false` by default)
+   * @param simulated - determines whether effects are applied without altering game state (`true` by default)
+   * @param ignoreHeldItems - determines whether this Pokemon's held items should be ignored during the stat calculation, default `false`
    * @return the stat stage multiplier to be used for effective stat calculation
    */
   getStatStageMultiplier(
@@ -3977,8 +3977,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * This method considers various factors such as the user's accuracy level, the target's evasion level,
    * abilities, and modifiers to compute the final accuracy multiplier.
    *
-   * @param target {@linkcode Pokemon} - The target Pokémon against which the move is used.
-   * @param sourceMove {@linkcode Move}  - The move being used by the user.
+   * @param target - The target Pokémon against which the move is used.
+   * @param sourceMove -  - The move being used by the user.
    * @returns The calculated accuracy multiplier.
    */
   getAccuracyMultiplier(target: Pokemon, sourceMove: Move): number {
@@ -4073,15 +4073,15 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Calculates the base damage of the given move against this Pokemon when attacked by the given source.
    * Used during damage calculation and for Shell Side Arm's forecasting effect.
-   * @param source the attacking {@linkcode Pokemon}.
-   * @param move the {@linkcode Move} used in the attack.
-   * @param moveCategory the move's {@linkcode MoveCategory} after variable-category effects are applied.
-   * @param ignoreAbility if `true`, ignores this Pokemon's defensive ability effects (defaults to `false`).
-   * @param ignoreSourceAbility if `true`, ignore's the attacking Pokemon's ability effects (defaults to `false`).
-   * @param ignoreAllyAbility if `true`, ignores the ally Pokemon's ability effects (defaults to `false`).
-   * @param ignoreSourceAllyAbility if `true`, ignores the attacking Pokemon's ally's ability effects (defaults to `false`).
-   * @param isCritical if `true`, calculates effective stats as if the hit were critical (defaults to `false`).
-   * @param simulated if `true`, suppresses changes to game state during calculation (defaults to `true`).
+   * @param source - the attacking {@linkcode Pokemon}.
+   * @param move - the {@linkcode Move} used in the attack.
+   * @param moveCategory - the move's {@linkcode MoveCategory} after variable-category effects are applied.
+   * @param ignoreAbility - if `true`, ignores this Pokemon's defensive ability effects (defaults to `false`).
+   * @param ignoreSourceAbility - if `true`, ignore's the attacking Pokemon's ability effects (defaults to `false`).
+   * @param ignoreAllyAbility - if `true`, ignores the ally Pokemon's ability effects (defaults to `false`).
+   * @param ignoreSourceAllyAbility - if `true`, ignores the attacking Pokemon's ally's ability effects (defaults to `false`).
+   * @param isCritical - if `true`, calculates effective stats as if the hit were critical (defaults to `false`).
+   * @param simulated - if `true`, suppresses changes to game state during calculation (defaults to `true`).
    * @returns The move's base damage against this Pokemon when used by the source Pokemon.
    */
   getBaseDamage(
@@ -4219,14 +4219,14 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Calculates the damage of an attack made by another Pokemon against this Pokemon
-   * @param source {@linkcode Pokemon} the attacking Pokemon
-   * @param move {@linkcode Pokemon} the move used in the attack
-   * @param ignoreAbility If `true`, ignores this Pokemon's defensive ability effects
-   * @param ignoreSourceAbility If `true`, ignores the attacking Pokemon's ability effects
-   * @param ignoreAllyAbility If `true`, ignores the ally Pokemon's ability effects
-   * @param ignoreSourceAllyAbility If `true`, ignores the ability effects of the attacking pokemon's ally
-   * @param isCritical If `true`, calculates damage for a critical hit.
-   * @param simulated If `true`, suppresses changes to game state during the calculation.
+   * @param source - the attacking Pokemon
+   * @param move - the move used in the attack
+   * @param ignoreAbility - If `true`, ignores this Pokemon's defensive ability effects
+   * @param ignoreSourceAbility - If `true`, ignores the attacking Pokemon's ability effects
+   * @param ignoreAllyAbility - If `true`, ignores the ally Pokemon's ability effects
+   * @param ignoreSourceAllyAbility - If `true`, ignores the ability effects of the attacking pokemon's ally
+   * @param isCritical - If `true`, calculates damage for a critical hit.
+   * @param simulated - If `true`, suppresses changes to game state during the calculation.
    * @returns a {@linkcode DamageCalculationResult} object with three fields:
    * - `cancelled`: `true` if the move was cancelled by another effect.
    * - `result`: {@linkcode HitResult} indicates the attack's type effectiveness.
@@ -4565,8 +4565,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Applies the results of a move to this pokemon
-   * @param source The {@linkcode Pokemon} using the move
-   * @param move The {@linkcode Move} being used
+   * @param source - The {@linkcode Pokemon} using the move
+   * @param move - The {@linkcode Move} being used
    * @returns The {@linkcode HitResult} of the attack
    */
   apply(source: Pokemon, move: Move): HitResult {
@@ -4772,10 +4772,10 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Called by damageAndUpdate()
-   * @param damage integer
-   * @param ignoreSegments boolean, not currently used
-   * @param preventEndure  used to update damage if endure or sturdy
-   * @param ignoreFaintPhase  flag on wheter to add FaintPhase if pokemon after applying damage faints
+   * @param damage - integer
+   * @param ignoreSegments - boolean, not currently used
+   * @param preventEndure - used to update damage if endure or sturdy
+   * @param ignoreFaintPhase - flag on wheter to add FaintPhase if pokemon after applying damage faints
    * @returns integer representing damage
    */
   damage(
@@ -4833,12 +4833,12 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Called by apply(), given the damage, adds a new DamagePhase and actually updates HP values, etc.
    * Checks for 'Indirect' HitResults to account for Endure/Reviver Seed applying correctly
-   * @param damage integer - passed to damage()
-   * @param result an enum if it's super effective, not very, etc.
-   * @param isCritical boolean if move is a critical hit
-   * @param ignoreSegments boolean, passed to damage() and not used currently
-   * @param preventEndure boolean, ignore endure properties of pokemon, passed to damage()
-   * @param ignoreFaintPhase boolean to ignore adding a FaintPhase, passsed to damage()
+   * @param damage - integer - passed to damage()
+   * @param result - an enum if it's super effective, not very, etc.
+   * @param isCritical - boolean if move is a critical hit
+   * @param ignoreSegments - boolean, passed to damage() and not used currently
+   * @param preventEndure - boolean, ignore endure properties of pokemon, passed to damage()
+   * @param ignoreFaintPhase - boolean to ignore adding a FaintPhase, passsed to damage()
    * @returns integer of damage done
    */
   damageAndUpdate(damage: number,
@@ -5099,7 +5099,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Transferring stat changes and Tags
-   * @param source {@linkcode Pokemon} the pokemon whose stats/Tags are to be passed on from, ie: the Pokemon using Baton Pass
+   * @param source - the pokemon whose stats/Tags are to be passed on from, ie: the Pokemon using Baton Pass
    */
   transferSummon(source: Pokemon): void {
     // Copy all stat stages
@@ -5134,7 +5134,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Gets whether the given move is currently disabled for this Pokemon.
    *
-   * @param {Moves} moveId {@linkcode Moves} ID of the move to check
+   * @param moveId - ID of the move to check
    * @returns {boolean} `true` if the move is disabled for this Pokemon, otherwise `false`
    *
    * @see {@linkcode MoveRestrictionBattlerTag}
@@ -5146,9 +5146,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Gets whether the given move is currently disabled for the user based on the player's target selection
    *
-   * @param {Moves} moveId {@linkcode Moves} ID of the move to check
-   * @param {Pokemon} user {@linkcode Pokemon} the move user
-   * @param {Pokemon} target {@linkcode Pokemon} the target of the move
+   * @param moveId - ID of the move to check
+   * @param user - the move user
+   * @param target - the target of the move
    *
    * @returns {boolean} `true` if the move is disabled for this Pokemon due to the player's target selection
    *
@@ -5178,9 +5178,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Gets the {@link MoveRestrictionBattlerTag} that is restricting a move, if it exists.
    *
-   * @param {Moves} moveId {@linkcode Moves} ID of the move to check
-   * @param {Pokemon} user {@linkcode Pokemon} the move user, optional and used when the target is a factor in the move's restricted status
-   * @param {Pokemon} target {@linkcode Pokemon} the target of the move, optional and used when the target is a factor in the move's restricted status
+   * @param moveId - ID of the move to check
+   * @param user - the move user, optional and used when the target is a factor in the move's restricted status
+   * @param target - the target of the move, optional and used when the target is a factor in the move's restricted status
    * @returns {MoveRestrictionBattlerTag | null} the first tag on this Pokemon that restricts the move, or `null` if the move is not restricted.
    */
   getRestrictingTag(
@@ -5224,7 +5224,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Returns a list of the most recent move entries in this Pokemon's move history.
    * The retrieved move entries are sorted in order from NEWEST to OLDEST.
-   * @param moveCount The number of move entries to retrieve.
+   * @param moveCount - The number of move entries to retrieve.
    *   If negative, retrieve the Pokemon's entire move history (equivalent to reversing the output of {@linkcode getMoveHistory()}).
    *   Default is `1`.
    * @returns A list of {@linkcode TurnMove}, as specified above.
@@ -5245,7 +5245,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * If this Pokemon is using a multi-hit move, cancels all subsequent strikes
-   * @param {Pokemon} target If specified, this only cancels subsequent strikes against the given target
+   * @param target - If specified, this only cancels subsequent strikes against the given target
    */
   stopMultiHit(target?: Pokemon): void {
     const effectPhase = globalScene.getCurrentPhase();
@@ -5519,11 +5519,11 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Checks if a status effect can be applied to the Pokemon.
    *
-   * @param effect The {@linkcode StatusEffect} whose applicability is being checked
-   * @param quiet Whether in-battle messages should trigger or not
-   * @param overrideStatus Whether the Pokemon's current status can be overriden
-   * @param sourcePokemon The Pokemon that is setting the status effect
-   * @param ignoreField Whether any field effects (weather, terrain, etc.) should be considered
+   * @param effect - The {@linkcode StatusEffect} whose applicability is being checked
+   * @param quiet - Whether in-battle messages should trigger or not
+   * @param overrideStatus - Whether the Pokemon's current status can be overriden
+   * @param sourcePokemon - The Pokemon that is setting the status effect
+   * @param ignoreField - Whether any field effects (weather, terrain, etc.) should be considered
    */
   canSetStatus(
     effect: StatusEffect | undefined,
@@ -5725,9 +5725,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Resets the status of a pokemon.
-   * @param revive Whether revive should be cured; defaults to true.
-   * @param confusion Whether resetStatus should include confusion or not; defaults to false.
-   * @param reloadAssets Whether to reload the assets or not; defaults to false.
+   * @param revive - Whether revive should be cured; defaults to true.
+   * @param confusion - Whether resetStatus should include confusion or not; defaults to false.
+   * @param reloadAssets - Whether to reload the assets or not; defaults to false.
    */
   resetStatus(revive = true, confusion = false, reloadAssets = false): void {
     const lastStatus = this.status?.effect;
@@ -5739,7 +5739,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Checks if this Pokemon is protected by Safeguard
-   * @param attacker the {@linkcode Pokemon} inflicting status on this Pokemon
+   * @param attacker - the {@linkcode Pokemon} inflicting status on this Pokemon
    * @returns `true` if this Pokemon is protected by Safeguard; `false` otherwise.
    */
   isSafeguarded(attacker: Pokemon): boolean {
@@ -6321,8 +6321,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * which calls {@linkcode randSeedInt randSeedInt}({@linkcode range}, {@linkcode min}) in `src/utils.ts`,
    * or it directly calls {@linkcode randSeedInt randSeedInt}({@linkcode range}, {@linkcode min}) in `src/utils.ts` if there is no current battle
    *
-   * @param range How large of a range of random numbers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
-   * @param min The minimum integer to pick, default `0`
+   * @param range - How large of a range of random numbers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
+   * @param min - The minimum integer to pick, default `0`
    * @returns A random integer between {@linkcode min} and ({@linkcode min} + {@linkcode range} - 1)
    */
   randSeedInt(range: number, min = 0): number {
@@ -6333,8 +6333,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Generates a random number using the current battle's seed, or the global seed if `globalScene.currentBattle` is falsy
-   * @param min The minimum integer to generate
-   * @param max The maximum integer to generate
+   * @param min - The minimum integer to generate
+   * @param max - The maximum integer to generate
    * @returns a random integer between {@linkcode min} and {@linkcode max} inclusive
    */
   randSeedIntRange(min: number, max: number): number {
@@ -6343,9 +6343,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Causes a Pokemon to leave the field (such as in preparation for a switch out/escape).
-   * @param clearEffects Indicates if effects should be cleared (true) or passed
+   * @param clearEffects - Indicates if effects should be cleared (true) or passed
    * to the next pokemon, such as during a baton pass (false)
-   * @param hideInfo Indicates if this should also play the animation to hide the Pokemon's
+   * @param hideInfo - Indicates if this should also play the animation to hide the Pokemon's
    * info container.
    */
   leaveField(clearEffects = true, hideInfo = true, destroy = false) {
@@ -6386,7 +6386,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Checks whether or not the Pokemon's root form has the same ability
-   * @param abilityIndex the given ability index we are checking
+   * @param abilityIndex - the given ability index we are checking
    * @returns true if the abilities are the same
    */
   hasSameAbilityInRootForm(abilityIndex: number): boolean {
@@ -6401,7 +6401,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Helper function to check if the player already owns the starter data of the Pokemon's
    * current ability
-   * @param ownedAbilityAttrs the owned abilityAttr of this Pokemon's root form
+   * @param ownedAbilityAttrs - the owned abilityAttr of this Pokemon's root form
    * @returns true if the player already has it, false otherwise
    */
   checkIfPlayerHasAbilityOfStarter(ownedAbilityAttrs: number): boolean {
@@ -6420,8 +6420,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Reduces one of this Pokemon's held item stacks by 1, and removes the item if applicable.
    * Does nothing if this Pokemon is somehow not the owner of the held item.
-   * @param heldItem The item stack to be reduced by 1.
-   * @param forBattle If `false`, do not trigger in-battle effects (such as Unburden) from losing the item. For example, set this to `false` if the Pokemon is giving away the held item for a Mystery Encounter. Default is `true`.
+   * @param heldItem - The item stack to be reduced by 1.
+   * @param forBattle - If `false`, do not trigger in-battle effects (such as Unburden) from losing the item. For example, set this to `false` if the Pokemon is giving away the held item for a Mystery Encounter. Default is `true`.
    * @returns `true` if the item was removed successfully, `false` otherwise.
    */
   public loseHeldItem(
@@ -6577,7 +6577,7 @@ export class PlayerPokemon extends Pokemon {
   /**
    * Causes this mon to leave the field (via {@linkcode leaveField}) and then
    * opens the party switcher UI to switch a new mon in
-   * @param switchType the {@linkcode SwitchType} for this switch-out. If this is
+   * @param switchType - the {@linkcode SwitchType} for this switch-out. If this is
    * `BATON_PASS` or `SHED_TAIL`, this Pokemon's effects are not cleared upon leaving
    * the field.
    */
@@ -6962,7 +6962,7 @@ export class PlayerPokemon extends Pokemon {
 
   /**
    * Returns a Promise to fuse two PlayerPokemon together
-   * @param pokemon The PlayerPokemon to fuse to this one
+   * @param pokemon - The PlayerPokemon to fuse to this one
    */
   fuse(pokemon: PlayerPokemon): void {
     this.fusionSpecies = pokemon.species;
@@ -7173,8 +7173,8 @@ export class EnemyPokemon extends Pokemon {
    * Sets the pokemons boss status. If true initializes the boss segments either from the arguments
    * or through the the Scene.getEncounterBossSegments function
    *
-   * @param boss if the pokemon is a boss
-   * @param bossSegments amount of boss segments (health-bar segments)
+   * @param boss - if the pokemon is a boss
+   * @param bossSegments - amount of boss segments (health-bar segments)
    */
   setBoss(boss = true, bossSegments = 0): void {
     if (boss) {
@@ -7453,7 +7453,7 @@ export class EnemyPokemon extends Pokemon {
 
   /**
    * Determines the Pokemon the given move would target if used by this Pokemon
-   * @param moveId {@linkcode Moves} The move to be used
+   * @param moveId - The move to be used
    * @returns The indexes of the Pokemon the given move would target
    */
   getNextTargets(moveId: Moves): BattlerIndex[] {
@@ -7651,7 +7651,7 @@ export class EnemyPokemon extends Pokemon {
    * The base boost is 1 to a random stat that's not already maxed out per broken shield
    * For Pokemon with 3 health segments or more, breaking the last shield gives +2 instead
    * For Pokemon with 5 health segments or more, breaking the last two shields give +2 each
-   * @param segmentIndex index of the segment to get down to (0 = no shield left, 1 = 1 shield left, etc.)
+   * @param segmentIndex - index of the segment to get down to (0 = no shield left, 1 = 1 shield left, etc.)
    */
   handleBossSegmentCleared(segmentIndex: number): void {
     while (
@@ -7720,8 +7720,8 @@ export class EnemyPokemon extends Pokemon {
   /**
    * Add a new pokemon to the player's party (at `slotIndex` if set).
    * The new pokemon's visibility will be set to `false`.
-   * @param pokeballType the type of pokeball the pokemon was caught with
-   * @param slotIndex an optional index to place the pokemon in the party
+   * @param pokeballType - the type of pokeball the pokemon was caught with
+   * @param slotIndex - an optional index to place the pokemon in the party
    * @returns the pokemon that was added or null if the pokemon could not be added
    */
   addToParty(pokeballType: PokeballType, slotIndex = -1) {
@@ -7986,9 +7986,9 @@ export class PokemonMove {
    * Checks whether the move can be selected or performed by a Pokemon, without consideration for the move's targets.
    * The move is unusable if it is out of PP, restricted by an effect, or unimplemented.
    *
-   * @param {Pokemon} pokemon {@linkcode Pokemon} that would be using this move
-   * @param {boolean} ignorePp If `true`, skips the PP check
-   * @param {boolean} ignoreRestrictionTags If `true`, skips the check for move restriction tags (see {@link MoveRestrictionBattlerTag})
+   * @param pokemon - that would be using this move
+   * @param ignorePp - If `true`, skips the PP check
+   * @param ignoreRestrictionTags - If `true`, skips the check for move restriction tags (see {@link MoveRestrictionBattlerTag})
    * @returns `true` if the move can be selected and used by the Pokemon, otherwise `false`.
    */
   isUsable(
@@ -8019,7 +8019,7 @@ export class PokemonMove {
 
   /**
    * Sets {@link ppUsed} for this move and ensures the value does not exceed {@link getMovePp}
-   * @param {number} count Amount of PP to use
+   * @param count - Amount of PP to use
    */
   usePp(count = 1) {
     this.ppUsed = Math.min(this.ppUsed + count, this.getMovePp());
@@ -8042,7 +8042,7 @@ export class PokemonMove {
 
   /**
    * Copies an existing move or creates a valid PokemonMove object from json representing one
-   * @param {PokemonMove | any} source The data for the move to copy
+   * @param source - The data for the move to copy
    * @return {PokemonMove} A valid pokemonmove object
    */
   static loadMove(source: PokemonMove | any): PokemonMove {

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -159,8 +159,8 @@ export default class Trainer extends Phaser.GameObjects.Container {
 
   /**
    * Returns the name of the trainer based on the provided trainer slot and the option to include a title.
-   * @param {TrainerSlot} trainerSlot - The slot to determine which name to use. Defaults to TrainerSlot.NONE.
-   * @param {boolean} includeTitle - Whether to include the title in the returned name. Defaults to false.
+   * @param trainerSlot - The slot to determine which name to use. Defaults to TrainerSlot.NONE.
+   * @param includeTitle - Whether to include the title in the returned name. Defaults to false.
    * @returns {string} - The formatted name of the trainer.
    **/
   getName(trainerSlot: TrainerSlot = TrainerSlot.NONE, includeTitle = false): string {
@@ -677,9 +677,9 @@ export default class Trainer extends Phaser.GameObjects.Container {
   /**
    * Attempts to animate a given set of {@linkcode Phaser.GameObjects.Sprite}
    * @see {@linkcode Phaser.GameObjects.Sprite.play}
-   * @param sprite {@linkcode Phaser.GameObjects.Sprite} to animate
-   * @param tintSprite {@linkcode Phaser.GameObjects.Sprite} placed on top of the sprite to add a color tint
-   * @param animConfig {@linkcode Phaser.Types.Animations.PlayAnimationConfig} to pass to {@linkcode Phaser.GameObjects.Sprite.play}
+   * @param sprite - to animate
+   * @param tintSprite - placed on top of the sprite to add a color tint
+   * @param animConfig - to pass to {@linkcode Phaser.GameObjects.Sprite.play}
    * @returns true if the sprite was able to be animated
    */
   tryPlaySprite(
@@ -789,7 +789,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
 
   /**
    * Determines whether a Trainer should Terastallize their Pokemon
-   * @param pokemon {@linkcode EnemyPokemon} Trainer Pokemon in question
+   * @param pokemon - Trainer Pokemon in question
    * @returns boolean Whether the EnemyPokemon should Terastalize this turn
    */
   shouldTera(pokemon: EnemyPokemon): boolean {

--- a/src/game-mode.ts
+++ b/src/game-mode.ts
@@ -70,8 +70,8 @@ export class GameMode implements GameModeConfig {
 
   /**
    * Enables challenges if they are disabled and sets the specified challenge's value
-   * @param challenge The challenge to set
-   * @param value The value to give the challenge. Impact depends on the specific challenge
+   * @param challenge - The challenge to set
+   * @param value - The value to give the challenge. Impact depends on the specific challenge
    */
   setChallengeValue(challenge: Challenges, value: number) {
     if (!this.isChallenge) {
@@ -83,7 +83,7 @@ export class GameMode implements GameModeConfig {
 
   /**
    * Helper function to see if a GameMode has a specific challenge type
-   * @param challenge the Challenges it looks for
+   * @param challenge - the Challenges it looks for
    * @returns true if the game mode has that challenge
    */
   hasChallenge(challenge: Challenges): boolean {
@@ -150,9 +150,9 @@ export class GameMode implements GameModeConfig {
   }
 
   /**
-   * Determines whether or not to generate a trainer
-   * @param waveIndex the current floor the player is on (trainer sprites fail to generate on X1 floors)
-   * @param arena the current {@linkcode Arena}
+   * Determine whether or not to generate a trainer
+   * @param waveIndex - The current floor the player is on (trainer sprites fail to generate on X1 floors)
+   * @param arena - The current {@linkcode Arena}
    * @returns `true` if a trainer should be generated, `false` otherwise
    */
   isWaveTrainer(waveIndex: number, arena: Arena): boolean {
@@ -231,7 +231,7 @@ export class GameMode implements GameModeConfig {
   /**
    * Checks if wave provided is the final for current or specified game mode
    * @param waveIndex
-   * @param modeId game mode
+   * @param modeId - game mode
    * @returns if the current wave is final for classic or daily OR a minor boss in endless
    */
   isWaveFinal(waveIndex: number, modeId: GameModes = this.modeId): boolean {
@@ -291,7 +291,7 @@ export class GameMode implements GameModeConfig {
 
   /**
    * Checks whether there is a fixed battle on this gamemode on a given wave.
-   * @param {number} waveIndex The wave to check.
+   * @param waveIndex - The wave to check.
    * @returns {boolean} If this game mode has a fixed battle on this wave
    */
   isFixedBattle(waveIndex: number): boolean {
@@ -304,7 +304,7 @@ export class GameMode implements GameModeConfig {
 
   /**
    * Returns the config for the fixed battle for a particular wave.
-   * @param {number} waveIndex The wave to check.
+   * @param waveIndex - The wave to check.
    * @returns {boolean} The fixed battle for this wave.
    */
   getFixedBattle(waveIndex: number): FixedBattleConfig {

--- a/src/inputs-controller.ts
+++ b/src/inputs-controller.ts
@@ -229,7 +229,7 @@ export class InputsController {
   /**
    * Initializes the chosen gamepad by setting its identifier in the local storage and updating the UI to reflect the chosen gamepad.
    * If a gamepad name is provided, it uses that as the chosen gamepad; otherwise, it defaults to the currently chosen gamepad.
-   * @param gamepadName Optional parameter to specify the name of the gamepad to initialize as chosen.
+   * @param gamepadName - Optional parameter to specify the name of the gamepad to initialize as chosen.
    */
   initChosenGamepad(gamepadName?: string): void {
     if (gamepadName) {
@@ -242,7 +242,7 @@ export class InputsController {
   /**
    * Initializes the chosen keyboard layout by setting its identifier in the local storage and updating the UI to reflect the chosen layout.
    * If a layout name is provided, it uses that as the chosen layout; otherwise, it defaults to the currently chosen layout.
-   * @param layoutKeyboard Optional parameter to specify the name of the keyboard layout to initialize as chosen.
+   * @param layoutKeyboard - Optional parameter to specify the name of the keyboard layout to initialize as chosen.
    */
   initChosenLayoutKeyboard(layoutKeyboard?: string): void {
     if (layoutKeyboard) {
@@ -258,7 +258,7 @@ export class InputsController {
    * disconnections, it would be impossible to determine the connection status of gamepads. This method ensures
    * that disconnected gamepads are recognized and can be appropriately hidden in the gamepad selection menu.
    *
-   * @param thisGamepad The gamepad that has been disconnected.
+   * @param thisGamepad - The gamepad that has been disconnected.
    */
   onDisconnect(thisGamepad: Phaser.Input.Gamepad.Gamepad): void {
     this.disconnectedGamepads.push(thisGamepad.id);
@@ -269,7 +269,7 @@ export class InputsController {
    * It removes the reconnected gamepad's identifier from the `disconnectedGamepads` array,
    * effectively updating its status to connected.
    *
-   * @param thisGamepad The gamepad that has been reconnected.
+   * @param thisGamepad - The gamepad that has been reconnected.
    */
   onReconnect(thisGamepad: Phaser.Input.Gamepad.Gamepad): void {
     this.disconnectedGamepads = this.disconnectedGamepads.filter(g => g !== thisGamepad.id);
@@ -281,7 +281,7 @@ export class InputsController {
    * and ensures these configurations are saved. If the connected gamepad is the currently chosen one,
    * it reinitializes the chosen gamepad settings.
    *
-   * @param thisGamepad The gamepad that is being set up.
+   * @param thisGamepad - The gamepad that is being set up.
    */
   setupGamepad(_thisGamepad: Phaser.Input.Gamepad.Gamepad): void {
     const allGamepads = this.getGamepadsName();
@@ -343,7 +343,7 @@ export class InputsController {
   /**
    * Handles the keydown event for the keyboard.
    *
-   * @param event The keyboard event.
+   * @param event - The keyboard event.
    */
   keyboardKeyDown(event): void {
     this.lastSource = "keyboard";
@@ -371,7 +371,7 @@ export class InputsController {
   /**
    * Handles the keyup event for the keyboard.
    *
-   * @param event The keyboard event.
+   * @param event - The keyboard event.
    */
   keyboardKeyUp(event): void {
     this.lastSource = "keyboard";
@@ -392,9 +392,9 @@ export class InputsController {
    * It checks if gamepad support is enabled and if the event comes from the chosen gamepad. If so, it maps the button press to a specific
    * action using a custom configuration, emits an event for the button press, and records the time of the action.
    *
-   * @param pad The gamepad on which the button was pressed.
-   * @param button The specific button that was pressed.
-   * @param value The intensity or value of the button press, if applicable.
+   * @param pad - The gamepad on which the button was pressed.
+   * @param button - The specific button that was pressed.
+   * @param value - The intensity or value of the button press, if applicable.
    */
   gamepadButtonDown(pad: Phaser.Input.Gamepad.Gamepad, button: Phaser.Input.Gamepad.Button, _value: number): void {
     if (!this.configs[this.selectedDevice[Device.KEYBOARD]]?.padID) {
@@ -444,9 +444,9 @@ export class InputsController {
    * If conditions are met, it identifies the configured action for the button, emits an event signaling the button release,
    * and clears the record of the button.
    *
-   * @param pad The gamepad from which the button was released.
-   * @param button The specific button that was released.
-   * @param value The intensity or value of the button release, if applicable.
+   * @param pad - The gamepad from which the button was released.
+   * @param button - The specific button that was released.
+   * @param value - The intensity or value of the button release, if applicable.
    */
   gamepadButtonUp(pad: Phaser.Input.Gamepad.Gamepad, button: Phaser.Input.Gamepad.Button, _value: number): void {
     if (!pad) {
@@ -473,7 +473,7 @@ export class InputsController {
    * based on substrings in the identifier and returns predefined configurations for recognized models.
    * If no specific configuration matches, it defaults to a generic gamepad configuration.
    *
-   * @param id The identifier string of the gamepad.
+   * @param id - The identifier string of the gamepad.
    * @returns InterfaceConfig The configuration object corresponding to the identified gamepad type.
    */
   getConfig(id: string): InterfaceConfig {
@@ -498,7 +498,7 @@ export class InputsController {
   /**
    * Retrieves the configuration object for a keyboard layout based on its identifier.
    *
-   * @param id The identifier string of the keyboard layout.
+   * @param id - The identifier string of the keyboard layout.
    * @returns InterfaceConfig The configuration object corresponding to the identified keyboard layout.
    */
   getConfigKeyboard(id: string): InterfaceConfig {
@@ -563,8 +563,8 @@ export class InputsController {
    * Injects a custom mapping configuration into the configuration for a specific gamepad.
    * If the device does not have an existing configuration, it initializes one first.
    *
-   * @param selectedDevice The identifier of the device to configure.
-   * @param mappingConfigs The mapping configuration to apply to the device.
+   * @param selectedDevice - The identifier of the device to configure.
+   * @param mappingConfigs - The mapping configuration to apply to the device.
    */
   injectConfig(selectedDevice: string, mappingConfigs): void {
     if (!this.configs[selectedDevice]) {
@@ -593,9 +593,9 @@ export class InputsController {
   /**
    * Swaps a binding in the configuration.
    *
-   * @param config The configuration object.
-   * @param settingName The name of the setting to swap.
-   * @param pressedButton The button that was pressed.
+   * @param config - The configuration object.
+   * @param settingName - The name of the setting to swap.
+   * @param pressedButton - The button that was pressed.
    */
   assignBinding(config, settingName, pressedButton): boolean {
     this.deactivatePressedKey();

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -5,8 +5,8 @@ import i18next from "i18next";
 
 /**
  * Retrieves the Pokemon's name, potentially with an affix indicating its role (wild or foe) in the current battle context, translated
- * @param pokemon {@linkcode Pokemon} name and battle context will be retrieved from this instance
- * @param {boolean} useIllusion - Whether we want the name of the illusion or not. Default value : true
+ * @param pokemon - name and battle context will be retrieved from this instance
+ * @param useIllusion - Whether we want the name of the illusion or not. Default value : true
  * @returns {string} ex: "Wild Gengar", "Ectoplasma sauvage"
  */
 export function getPokemonNameWithAffix(pokemon: Pokemon | undefined, useIllusion = true): string {

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -230,10 +230,10 @@ export class ModifierType {
    * It checks the weight of the item and will use the first tier for which the weight is greater than 0
    * This is to allow items to be in multiple item pools depending on the conditions, for example for events
    * If all tiers have a weight of 0 for the item, the first tier where the item was found is used
-   * @param poolType Default 'ModifierPoolType.PLAYER'. Which pool to lookup item tier from
-   * @param party optional. Needed to check the weight of modifiers with conditional weight (see {@linkcode WeightedModifierTypeWeightFunc})
+   * @param poolType - Default 'ModifierPoolType.PLAYER'. Which pool to lookup item tier from
+   * @param party - optional. Needed to check the weight of modifiers with conditional weight (see {@linkcode WeightedModifierTypeWeightFunc})
    *  if not provided or empty, the weight check will be ignored
-   * @param rerollCount Default `0`. Used to check the weight of modifiers with conditional weight (see {@linkcode WeightedModifierTypeWeightFunc})
+   * @param rerollCount - Default `0`. Used to check the weight of modifiers with conditional weight (see {@linkcode WeightedModifierTypeWeightFunc})
    */
   withTierFromPool(
     poolType: ModifierPoolType = ModifierPoolType.PLAYER,
@@ -863,7 +863,6 @@ export type SpeciesStatBoosterItem = keyof typeof SpeciesStatBoosterModifierType
 
 /**
  * Modifier type for {@linkcode SpeciesStatBoosterModifier}
- * @extends PokemonHeldItemModifierType
  * @implements GeneratedPersistentModifierType
  */
 export class SpeciesStatBoosterModifierType
@@ -1428,7 +1427,6 @@ class TempStatStageBoosterModifierTypeGenerator extends ModifierTypeGenerator {
  * Modifier type generator for {@linkcode SpeciesStatBoosterModifierType}, which
  * encapsulates the logic for weighting the most useful held item from
  * the current list of {@linkcode items}.
- * @extends ModifierTypeGenerator
  */
 class SpeciesStatBoosterModifierTypeGenerator extends ModifierTypeGenerator {
   /** Object comprised of the currently available species-based stat boosting held items */
@@ -1788,7 +1786,7 @@ function skipInClassicAfterWave(wave: number, defaultWeight: number): WeightedMo
 /**
  * High order function that returns a WeightedModifierTypeWeightFunc that will only be applied on
  * classic and it will skip a ModifierType if it is the last wave pull.
- * @param defaultWeight ModifierType default weight
+ * @param defaultWeight - ModifierType default weight
  * @returns A WeightedModifierTypeWeightFunc
  */
 function skipInLastClassicWaveOrDefault(defaultWeight: number): WeightedModifierTypeWeightFunc {
@@ -1798,8 +1796,8 @@ function skipInLastClassicWaveOrDefault(defaultWeight: number): WeightedModifier
 /**
  * High order function that returns a WeightedModifierTypeWeightFunc to ensure Lures don't spawn on Classic 199
  * or if the lure still has over 60% of its duration left
- * @param maxBattles The max battles the lure type in question lasts. 10 for green, 15 for Super, 30 for Max
- * @param weight The desired weight for the lure when it does spawn
+ * @param maxBattles - The max battles the lure type in question lasts. 10 for green, 15 for Super, 30 for Max
+ * @param weight - The desired weight for the lure when it does spawn
  * @returns A WeightedModifierTypeWeightFunc
  */
 function lureWeightFunc(maxBattles: number, weight: number): WeightedModifierTypeWeightFunc {
@@ -2399,7 +2397,7 @@ interface ModifierPool {
 
 /**
  * Used to check if the player has max of a given ball type in Classic
- * @param ballType The {@linkcode PokeballType} being checked
+ * @param ballType - The {@linkcode PokeballType} being checked
  * @returns boolean: true if the player has the maximum of a given ball type
  */
 function hasMaximumBalls(ballType: PokeballType): boolean {
@@ -3287,10 +3285,10 @@ export function getModifierTypeFuncById(id: string): ModifierTypeFunc {
 
 /**
  * Generates modifier options for a {@linkcode SelectModifierPhase}
- * @param count Determines the number of items to generate
- * @param party Party is required for generating proper modifier pools
- * @param modifierTiers (Optional) If specified, rolls items in the specified tiers. Commonly used for tier-locking with Lock Capsule.
- * @param customModifierSettings (Optional) If specified, can customize the item shop rewards further.
+ * @param count - Determines the number of items to generate
+ * @param party - Party is required for generating proper modifier pools
+ * @param modifierTiers - (Optional) If specified, rolls items in the specified tiers. Commonly used for tier-locking with Lock Capsule.
+ * @param customModifierSettings - (Optional) If specified, can customize the item shop rewards further.
  *  - `guaranteedModifierTypeOptions?: ModifierTypeOption[]` If specified, will override the first X items to be specific modifier options (these should be pre-genned).
  *  - `guaranteedModifierTypeFuncs?: ModifierTypeFunc[]` If specified, will override the next X items to be auto-generated from specific modifier functions (these don't have to be pre-genned).
  *  - `guaranteedModifierTiers?: ModifierTier[]` If specified, will override the next X items to be the specified tier. These can upgrade with luck.
@@ -3375,11 +3373,11 @@ export function getPlayerModifierTypeOptions(
 
 /**
  * Will generate a {@linkcode ModifierType} from the {@linkcode ModifierPoolType.PLAYER} pool, attempting to retry duplicated items up to retryCount
- * @param existingOptions Currently generated options
- * @param retryCount How many times to retry before allowing a dupe item
- * @param party Current player party, used to calculate items in the pool
- * @param tier If specified will generate item of tier
- * @param allowLuckUpgrades `true` to allow items to upgrade tiers (the little animation that plays and is affected by luck)
+ * @param existingOptions - Currently generated options
+ * @param retryCount - How many times to retry before allowing a dupe item
+ * @param party - Current player party, used to calculate items in the pool
+ * @param tier - If specified will generate item of tier
+ * @param allowLuckUpgrades - `true` to allow items to upgrade tiers (the little animation that plays and is affected by luck)
  */
 function getModifierTypeOptionWithRetry(
   existingOptions: ModifierTypeOption[],
@@ -3412,8 +3410,8 @@ function getModifierTypeOptionWithRetry(
  * Replaces the {@linkcode ModifierType} of the entries within {@linkcode options} with any
  * {@linkcode ModifierOverride} entries listed in {@linkcode Overrides.ITEM_REWARD_OVERRIDE}
  * up to the smallest amount of entries between {@linkcode options} and the override array.
- * @param options Array of naturally rolled {@linkcode ModifierTypeOption}s
- * @param party Array of the player's current party
+ * @param options - Array of naturally rolled {@linkcode ModifierTypeOption}s
+ * @param party - Array of the player's current party
  */
 export function overridePlayerModifierTypeOptions(options: ModifierTypeOption[], party: PlayerPokemon[]) {
   const minLength = Math.min(options.length, Overrides.ITEM_REWARD_OVERRIDE.length);
@@ -3553,12 +3551,12 @@ export function getDailyRunStarterModifiers(party: PlayerPokemon[]): PokemonHeld
 
 /**
  * Generates a ModifierType from the specified pool
- * @param party party of the trainer using the item
- * @param poolType PLAYER/WILD/TRAINER
- * @param tier If specified, will override the initial tier of an item (can still upgrade with luck)
- * @param upgradeCount If defined, means that this is a new ModifierType being generated to override another via luck upgrade. Used for recursive logic
- * @param retryCount Max allowed tries before the next tier down is checked for a valid ModifierType
- * @param allowLuckUpgrades Default true. If false, will not allow ModifierType to randomly upgrade to next tier
+ * @param party - party of the trainer using the item
+ * @param poolType - PLAYER/WILD/TRAINER
+ * @param tier - If specified, will override the initial tier of an item (can still upgrade with luck)
+ * @param upgradeCount - If defined, means that this is a new ModifierType being generated to override another via luck upgrade. Used for recursive logic
+ * @param retryCount - Max allowed tries before the next tier down is checked for a valid ModifierType
+ * @param allowLuckUpgrades - Default true. If false, will not allow ModifierType to randomly upgrade to next tier
  */
 function getNewModifierTypeOption(
   party: Pokemon[],
@@ -3700,7 +3698,7 @@ export class ModifierTypeOption {
 
 /**
  * Calculates the team's luck value.
- * @param party The player's party.
+ * @param party - The player's party.
  * @returns A number between 0 and 14 based on the party's total luck value, or a random number between 0 and 14 if the player is in Daily Run mode.
  */
 export function getPartyLuckValue(party: Pokemon[]): number {

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -91,8 +91,8 @@ export class ModifierBar extends Phaser.GameObjects.Container {
 
   /**
    * Method to update content displayed in {@linkcode ModifierBar}
-   * @param {PersistentModifier[]} modifiers - The list of modifiers to be displayed in the {@linkcode ModifierBar}
-   * @param {boolean} hideHeldItems - If set to "true", only modifiers not assigned to a Pokémon are displayed
+   * @param modifiers - The list of modifiers to be displayed in the {@linkcode ModifierBar}
+   * @param hideHeldItems - If set to "true", only modifiers not assigned to a Pokémon are displayed
    */
   updateModifiers(modifiers: PersistentModifier[], hideHeldItems = false) {
     this.removeAll(true);
@@ -168,7 +168,7 @@ export abstract class Modifier {
 
   /**
    * Checks if {@linkcode Modifier} should be applied
-   * @param _args parameters passed to {@linkcode Modifier.apply}
+   * @param _args - parameters passed to {@linkcode Modifier.apply}
    * @returns always `true` by default
    */
   shouldApply(..._args: Parameters<this["apply"]>): boolean {
@@ -177,7 +177,7 @@ export abstract class Modifier {
 
   /**
    * Handles applying of {@linkcode Modifier}
-   * @param args collection of all passed parameters
+   * @param args - collection of all passed parameters
    */
   abstract apply(...args: unknown[]): boolean;
 }
@@ -292,7 +292,7 @@ export class AddPokeballModifier extends ConsumableModifier {
 
   /**
    * Applies {@linkcode AddPokeballModifier}
-   * @param battleScene {@linkcode BattleScene}
+   * @param battleScene
    * @returns always `true`
    */
   override apply(): boolean {
@@ -319,7 +319,7 @@ export class AddVoucherModifier extends ConsumableModifier {
 
   /**
    * Applies {@linkcode AddVoucherModifier}
-   * @param battleScene {@linkcode BattleScene}
+   * @param battleScene
    * @returns always `true`
    */
   override apply(): boolean {
@@ -337,8 +337,6 @@ export class AddVoucherModifier extends ConsumableModifier {
  * modifier will be removed. If a modifier of the same type is to be added, it
  * will reset {@linkcode battleCount} back to {@linkcode maxBattles} of the
  * existing modifier instead of adding that modifier directly.
- * @extends PersistentModifier
- * @abstract
  * @see {@linkcode add}
  */
 export abstract class LapsingPersistentModifier extends PersistentModifier {
@@ -358,9 +356,9 @@ export abstract class LapsingPersistentModifier extends PersistentModifier {
    * Goes through existing modifiers for any that match the selected modifier,
    * which will then either add it to the existing modifiers if none were found
    * or, if one was found, it will refresh {@linkcode battleCount}.
-   * @param modifiers {@linkcode PersistentModifier} array of the player's modifiers
-   * @param _virtual N/A
-   * @param _scene N/A
+   * @param modifiers - array of the player's modifiers
+   * @param _virtual - N/A
+   * @param _scene - N/A
    * @returns `true` if the modifier was successfully added or applied, false otherwise
    */
   add(modifiers: PersistentModifier[], _virtual: boolean): boolean {
@@ -383,7 +381,7 @@ export abstract class LapsingPersistentModifier extends PersistentModifier {
 
   /**
    * Lapses the {@linkcode battleCount} by 1.
-   * @param _args passed arguments (not in use here)
+   * @param _args - passed arguments (not in use here)
    * @returns `true` if the {@linkcode battleCount} is greater than 0
    */
   public lapse(..._args: unknown[]): boolean {
@@ -450,7 +448,6 @@ export abstract class LapsingPersistentModifier extends PersistentModifier {
 /**
  * Modifier used for passive items, specifically lures, that
  * temporarily increases the chance of a double battle.
- * @extends LapsingPersistentModifier
  * @see {@linkcode apply}
  */
 export class DoubleBattleChanceBoosterModifier extends LapsingPersistentModifier {
@@ -471,7 +468,7 @@ export class DoubleBattleChanceBoosterModifier extends LapsingPersistentModifier
 
   /**
    * Increases the chance of a double battle occurring
-   * @param doubleBattleChance {@linkcode NumberHolder} for double battle chance
+   * @param doubleBattleChance - for double battle chance
    * @returns true
    */
   override apply(doubleBattleChance: NumberHolder): boolean {
@@ -487,7 +484,6 @@ export class DoubleBattleChanceBoosterModifier extends LapsingPersistentModifier
  * Modifier used for party-wide items, specifically the X items, that
  * temporarily increases the stat stage multiplier of the corresponding
  * {@linkcode TempBattleStat}.
- * @extends LapsingPersistentModifier
  * @see {@linkcode apply}
  */
 export class TempStatStageBoosterModifier extends LapsingPersistentModifier {
@@ -530,8 +526,8 @@ export class TempStatStageBoosterModifier extends LapsingPersistentModifier {
   /**
    * Checks if {@linkcode args} contains the necessary elements and if the
    * incoming stat is matches {@linkcode stat}.
-   * @param tempBattleStat {@linkcode TempBattleStat} being affected
-   * @param statLevel {@linkcode NumberHolder} that holds the resulting value of the stat stage multiplier
+   * @param tempBattleStat - being affected
+   * @param statLevel - that holds the resulting value of the stat stage multiplier
    * @returns `true` if the modifier can be applied, false otherwise
    */
   override shouldApply(tempBattleStat?: TempBattleStat, statLevel?: NumberHolder): boolean {
@@ -542,8 +538,8 @@ export class TempStatStageBoosterModifier extends LapsingPersistentModifier {
 
   /**
    * Increases the incoming stat stage matching {@linkcode stat} by {@linkcode boost}.
-   * @param _tempBattleStat {@linkcode TempBattleStat} N/A
-   * @param statLevel {@linkcode NumberHolder} that holds the resulting value of the stat stage multiplier
+   * @param _tempBattleStat - N/A
+   * @param statLevel - that holds the resulting value of the stat stage multiplier
    */
   override apply(_tempBattleStat: TempBattleStat, statLevel: NumberHolder): boolean {
     statLevel.value += this.boost;
@@ -554,7 +550,6 @@ export class TempStatStageBoosterModifier extends LapsingPersistentModifier {
 /**
  * Modifier used for party-wide items, namely Dire Hit, that
  * temporarily increments the critical-hit stage
- * @extends LapsingPersistentModifier
  * @see {@linkcode apply}
  */
 export class TempCritBoosterModifier extends LapsingPersistentModifier {
@@ -568,7 +563,7 @@ export class TempCritBoosterModifier extends LapsingPersistentModifier {
 
   /**
    * Checks if {@linkcode args} contains the necessary elements.
-   * @param critLevel {@linkcode NumberHolder} that holds the resulting critical-hit level
+   * @param critLevel - that holds the resulting critical-hit level
    * @returns `true` if the critical-hit stage boost applies successfully
    */
   override shouldApply(critLevel?: NumberHolder): boolean {
@@ -577,7 +572,7 @@ export class TempCritBoosterModifier extends LapsingPersistentModifier {
 
   /**
    * Increases the current critical-hit stage value by 1.
-   * @param critLevel {@linkcode NumberHolder} that holds the resulting critical-hit level
+   * @param critLevel - that holds the resulting critical-hit level
    * @returns `true` if the critical-hit stage boost applies successfully
    */
   override apply(critLevel: NumberHolder): boolean {
@@ -621,7 +616,7 @@ export class GigantamaxAccessModifier extends PersistentModifier {
 
   /**
    * Applies {@linkcode GigantamaxAccessModifier}
-   * @param _args N/A
+   * @param _args - N/A
    * @returns always `true`
    */
   apply(..._args: unknown[]): boolean {
@@ -640,7 +635,7 @@ export class TerastallizeAccessModifier extends PersistentModifier {
 
   /**
    * Applies {@linkcode TerastallizeAccessModifier}
-   * @param _args N/A
+   * @param _args - N/A
    * @returns always `true`
    */
   override apply(..._args: unknown[]): boolean {
@@ -674,15 +669,15 @@ export abstract class PokemonHeldItemModifier extends PersistentModifier {
 
   /**
    * Applies the {@linkcode PokemonHeldItemModifier} to the given {@linkcode Pokemon}.
-   * @param pokemon The {@linkcode Pokemon} that holds the held item
-   * @param args additional parameters
+   * @param pokemon - The {@linkcode Pokemon} that holds the held item
+   * @param args - additional parameters
    */
   abstract override apply(pokemon: Pokemon, ...args: unknown[]): boolean;
 
   /**
    * Checks if {@linkcode PokemonHeldItemModifier} should be applied.
-   * @param pokemon The {@linkcode Pokemon} that holds the item
-   * @param _args N/A
+   * @param pokemon - The {@linkcode Pokemon} that holds the item
+   * @param _args - N/A
    * @returns if {@linkcode PokemonHeldItemModifier} should be applied
    */
   override shouldApply(pokemon?: Pokemon, ..._args: unknown[]): boolean {
@@ -763,7 +758,7 @@ export abstract class LapsingPokemonHeldItemModifier extends PokemonHeldItemModi
 
   /**
    * Lapse the {@linkcode battlesLeft} counter (reduce it by 1)
-   * @param _args arguments passed (not used here)
+   * @param _args - arguments passed (not used here)
    * @returns `true` if {@linkcode battlesLeft} is not null
    */
   public lapse(..._args: unknown[]): boolean {
@@ -772,7 +767,7 @@ export abstract class LapsingPokemonHeldItemModifier extends PokemonHeldItemModi
 
   /**
    * Retrieve the {@linkcode Modifier | Modifiers} icon as a {@linkcode Phaser.GameObjects.Container | Container}
-   * @param forSummary `true` if the icon is for the summary screen
+   * @param forSummary - `true` if the icon is for the summary screen
    * @returns the icon as a {@linkcode Phaser.GameObjects.Container | Container}
    */
   public getIcon(forSummary?: boolean): Phaser.GameObjects.Container {
@@ -804,7 +799,6 @@ export abstract class LapsingPokemonHeldItemModifier extends PokemonHeldItemModi
 /**
  * Modifier used for held items, specifically vitamins like Carbos, Hp Up, etc., that
  * increase the value of a given {@linkcode PermanentStat}.
- * @extends PokemonHeldItemModifier
  * @see {@linkcode apply}
  */
 export class BaseStatModifier extends PokemonHeldItemModifier {
@@ -833,8 +827,8 @@ export class BaseStatModifier extends PokemonHeldItemModifier {
 
   /**
    * Checks if {@linkcode BaseStatModifier} should be applied to the specified {@linkcode Pokemon}.
-   * @param _pokemon the {@linkcode Pokemon} to be modified
-   * @param baseStats the base stats of the {@linkcode Pokemon}
+   * @param _pokemon - the {@linkcode Pokemon} to be modified
+   * @param baseStats - the base stats of the {@linkcode Pokemon}
    * @returns `true` if the {@linkcode Pokemon} should be modified
    */
   override shouldApply(_pokemon?: Pokemon, baseStats?: number[]): boolean {
@@ -843,8 +837,8 @@ export class BaseStatModifier extends PokemonHeldItemModifier {
 
   /**
    * Applies the {@linkcode BaseStatModifier} to the specified {@linkcode Pokemon}.
-   * @param _pokemon the {@linkcode Pokemon} to be modified
-   * @param baseStats the base stats of the {@linkcode Pokemon}
+   * @param _pokemon - the {@linkcode Pokemon} to be modified
+   * @param baseStats - the base stats of the {@linkcode Pokemon}
    * @returns always `true`
    */
   override apply(_pokemon: Pokemon, baseStats: number[]): boolean {
@@ -964,8 +958,8 @@ export class PokemonBaseStatTotalModifier extends PokemonHeldItemModifier {
 
   /**
    * Checks if {@linkcode PokemonBaseStatTotalModifier} should be applied to the specified {@linkcode Pokemon}.
-   * @param pokemon the {@linkcode Pokemon} to be modified
-   * @param baseStats the base stats of the {@linkcode Pokemon}
+   * @param pokemon - the {@linkcode Pokemon} to be modified
+   * @param baseStats - the base stats of the {@linkcode Pokemon}
    * @returns `true` if the {@linkcode Pokemon} should be modified
    */
   override shouldApply(pokemon?: Pokemon, baseStats?: number[]): boolean {
@@ -974,8 +968,8 @@ export class PokemonBaseStatTotalModifier extends PokemonHeldItemModifier {
 
   /**
    * Applies the {@linkcode PokemonBaseStatTotalModifier}
-   * @param _pokemon the {@linkcode Pokemon} to be modified
-   * @param baseStats the base stats of the {@linkcode Pokemon}
+   * @param _pokemon - the {@linkcode Pokemon} to be modified
+   * @param baseStats - the base stats of the {@linkcode Pokemon}
    * @returns always `true`
    */
   override apply(_pokemon: Pokemon, baseStats: number[]): boolean {
@@ -1031,8 +1025,8 @@ export class PokemonBaseStatFlatModifier extends PokemonHeldItemModifier {
 
   /**
    * Checks if the {@linkcode PokemonBaseStatFlatModifier} should be applied to the {@linkcode Pokemon}.
-   * @param pokemon The {@linkcode Pokemon} that holds the item
-   * @param baseStats The base stats of the {@linkcode Pokemon}
+   * @param pokemon - The {@linkcode Pokemon} that holds the item
+   * @param baseStats - The base stats of the {@linkcode Pokemon}
    * @returns `true` if the {@linkcode PokemonBaseStatFlatModifier} should be applied
    */
   override shouldApply(pokemon?: Pokemon, baseStats?: number[]): boolean {
@@ -1041,8 +1035,8 @@ export class PokemonBaseStatFlatModifier extends PokemonHeldItemModifier {
 
   /**
    * Applies the {@linkcode PokemonBaseStatFlatModifier}
-   * @param _pokemon The {@linkcode Pokemon} that holds the item
-   * @param baseStats The base stats of the {@linkcode Pokemon}
+   * @param _pokemon - The {@linkcode Pokemon} that holds the item
+   * @param baseStats - The base stats of the {@linkcode Pokemon}
    * @returns always `true`
    */
   override apply(_pokemon: Pokemon, baseStats: number[]): boolean {
@@ -1086,9 +1080,9 @@ export class PokemonIncrementingStatModifier extends PokemonHeldItemModifier {
 
   /**
    * Checks if the {@linkcode PokemonIncrementingStatModifier} should be applied to the {@linkcode Pokemon}.
-   * @param pokemon The {@linkcode Pokemon} that holds the item
-   * @param stat The affected {@linkcode Stat}
-   * @param statHolder The {@linkcode NumberHolder} that holds the stat
+   * @param pokemon - The {@linkcode Pokemon} that holds the item
+   * @param stat - The affected {@linkcode Stat}
+   * @param statHolder - The {@linkcode NumberHolder} that holds the stat
    * @returns `true` if the {@linkcode PokemonBaseStatFlatModifier} should be applied
    */
   override shouldApply(pokemon?: Pokemon, stat?: Stat, statHolder?: NumberHolder): boolean {
@@ -1097,9 +1091,9 @@ export class PokemonIncrementingStatModifier extends PokemonHeldItemModifier {
 
   /**
    * Applies the {@linkcode PokemonIncrementingStatModifier}
-   * @param _pokemon The {@linkcode Pokemon} that holds the item
-   * @param stat The affected {@linkcode Stat}
-   * @param statHolder The {@linkcode NumberHolder} that holds the stat
+   * @param _pokemon - The {@linkcode Pokemon} that holds the item
+   * @param stat - The affected {@linkcode Stat}
+   * @param statHolder - The {@linkcode NumberHolder} that holds the stat
    * @returns always `true`
    */
   override apply(_pokemon: Pokemon, stat: Stat, statHolder: NumberHolder): boolean {
@@ -1134,7 +1128,6 @@ export class PokemonIncrementingStatModifier extends PokemonHeldItemModifier {
 /**
  * Modifier used for held items that Applies {@linkcode Stat} boost(s)
  * using a multiplier.
- * @extends PokemonHeldItemModifier
  * @see {@linkcode apply}
  */
 export class StatBoosterModifier extends PokemonHeldItemModifier {
@@ -1171,9 +1164,9 @@ export class StatBoosterModifier extends PokemonHeldItemModifier {
 
   /**
    * Checks if the incoming stat is listed in {@linkcode stats}
-   * @param _pokemon the {@linkcode Pokemon} that holds the item
-   * @param _stat the {@linkcode Stat} to be boosted
-   * @param statValue {@linkcode NumberHolder} that holds the resulting value of the stat
+   * @param _pokemon - the {@linkcode Pokemon} that holds the item
+   * @param _stat - the {@linkcode Stat} to be boosted
+   * @param statValue - that holds the resulting value of the stat
    * @returns `true` if the stat could be boosted, false otherwise
    */
   override shouldApply(pokemon: Pokemon, stat: Stat, statValue: NumberHolder): boolean {
@@ -1183,9 +1176,9 @@ export class StatBoosterModifier extends PokemonHeldItemModifier {
   /**
    * Boosts the incoming stat by a {@linkcode multiplier} if the stat is listed
    * in {@linkcode stats}.
-   * @param _pokemon the {@linkcode Pokemon} that holds the item
-   * @param _stat the {@linkcode Stat} to be boosted
-   * @param statValue {@linkcode NumberHolder} that holds the resulting value of the stat
+   * @param _pokemon - the {@linkcode Pokemon} that holds the item
+   * @param _stat - the {@linkcode Stat} to be boosted
+   * @param statValue - that holds the resulting value of the stat
    * @returns `true` if the stat boost applies successfully, false otherwise
    * @see shouldApply
    */
@@ -1202,7 +1195,6 @@ export class StatBoosterModifier extends PokemonHeldItemModifier {
 /**
  * Modifier used for held items, specifically Eviolite, that apply
  * {@linkcode Stat} boost(s) using a multiplier if the holder can evolve.
- * @extends StatBoosterModifier
  * @see {@linkcode apply}
  */
 export class EvolutionStatBoosterModifier extends StatBoosterModifier {
@@ -1217,9 +1209,9 @@ export class EvolutionStatBoosterModifier extends StatBoosterModifier {
   /**
    * Checks if the stat boosts can apply and if the holder is not currently
    * Gigantamax'd.
-   * @param pokemon {@linkcode Pokemon} that holds the held item
-   * @param stat {@linkcode Stat} The {@linkcode Stat} to be boosted
-   * @param statValue {@linkcode NumberHolder} that holds the resulting value of the stat
+   * @param pokemon - that holds the held item
+   * @param stat - The {@linkcode Stat} to be boosted
+   * @param statValue - that holds the resulting value of the stat
    * @returns `true` if the stat boosts can be applied, false otherwise
    */
   override shouldApply(pokemon: Pokemon, stat: Stat, statValue: NumberHolder): boolean {
@@ -1232,9 +1224,9 @@ export class EvolutionStatBoosterModifier extends StatBoosterModifier {
    * only half of the boost if either of the fused members are fully
    * evolved. However, if they are both unevolved, the full boost
    * will apply.
-   * @param pokemon {@linkcode Pokemon} that holds the item
-   * @param _stat {@linkcode Stat} The {@linkcode Stat} to be boosted
-   * @param statValue{@linkcode NumberHolder} that holds the resulting value of the stat
+   * @param pokemon - that holds the item
+   * @param _stat - The {@linkcode Stat} to be boosted
+   * @param statValue{@linkcode - NumberHolder} that holds the resulting value of the stat
    * @returns `true` if the stat boost applies successfully, false otherwise
    * @see shouldApply
    */
@@ -1258,7 +1250,6 @@ export class EvolutionStatBoosterModifier extends StatBoosterModifier {
 /**
  * Modifier used for held items that Applies {@linkcode Stat} boost(s) using a
  * multiplier if the holder is of a specific {@linkcode Species}.
- * @extends StatBoosterModifier
  * @see {@linkcode apply}
  */
 export class SpeciesStatBoosterModifier extends StatBoosterModifier {
@@ -1307,9 +1298,9 @@ export class SpeciesStatBoosterModifier extends StatBoosterModifier {
   /**
    * Checks if the incoming stat is listed in {@linkcode stats} and if the holder's {@linkcode Species}
    * (or its fused species) is listed in {@linkcode species}.
-   * @param pokemon {@linkcode Pokemon} that holds the item
-   * @param stat {@linkcode Stat} being checked at the time
-   * @param statValue {@linkcode NumberHolder} that holds the resulting value of the stat
+   * @param pokemon - that holds the item
+   * @param stat - being checked at the time
+   * @param statValue - that holds the resulting value of the stat
    * @returns `true` if the stat could be boosted, false otherwise
    */
   override shouldApply(pokemon: Pokemon, stat: Stat, statValue: NumberHolder): boolean {
@@ -1322,8 +1313,8 @@ export class SpeciesStatBoosterModifier extends StatBoosterModifier {
 
   /**
    * Checks if either parameter is included in the corresponding lists
-   * @param speciesId {@linkcode Species} being checked
-   * @param stat {@linkcode Stat} being checked
+   * @param speciesId - being checked
+   * @param stat - being checked
    * @returns `true` if both parameters are in {@linkcode species} and {@linkcode stats} respectively, false otherwise
    */
   contains(speciesId: Species, stat: Stat): boolean {
@@ -1333,7 +1324,6 @@ export class SpeciesStatBoosterModifier extends StatBoosterModifier {
 
 /**
  * Modifier used for held items that apply critical-hit stage boost(s).
- * @extends PokemonHeldItemModifier
  * @see {@linkcode apply}
  */
 export class CritBoosterModifier extends PokemonHeldItemModifier {
@@ -1364,8 +1354,8 @@ export class CritBoosterModifier extends PokemonHeldItemModifier {
 
   /**
    * Increases the current critical-hit stage value by {@linkcode stageIncrement}.
-   * @param _pokemon {@linkcode Pokemon} N/A
-   * @param critStage {@linkcode NumberHolder} that holds the resulting critical-hit level
+   * @param _pokemon - N/A
+   * @param critStage - that holds the resulting critical-hit level
    * @returns always `true`
    */
   override apply(_pokemon: Pokemon, critStage: NumberHolder): boolean {
@@ -1381,7 +1371,6 @@ export class CritBoosterModifier extends PokemonHeldItemModifier {
 /**
  * Modifier used for held items that apply critical-hit stage boost(s)
  * if the holder is of a specific {@linkcode Species}.
- * @extends CritBoosterModifier
  * @see {@linkcode shouldApply}
  */
 export class SpeciesCritBoosterModifier extends CritBoosterModifier {
@@ -1415,8 +1404,8 @@ export class SpeciesCritBoosterModifier extends CritBoosterModifier {
   /**
    * Checks if the holder's {@linkcode Species} (or its fused species) is listed
    * in {@linkcode species}.
-   * @param pokemon {@linkcode Pokemon} that holds the held item
-   * @param critStage {@linkcode NumberHolder} that holds the resulting critical-hit level
+   * @param pokemon - that holds the held item
+   * @param critStage - that holds the resulting critical-hit level
    * @returns `true` if the critical-hit level can be incremented, false otherwise
    */
   override shouldApply(pokemon: Pokemon, critStage: NumberHolder): boolean {
@@ -1470,9 +1459,9 @@ export class AttackTypeBoosterModifier extends PokemonHeldItemModifier {
 
   /**
    * Checks if {@linkcode AttackTypeBoosterModifier} should be applied
-   * @param pokemon the {@linkcode Pokemon} that holds the held item
-   * @param moveType the {@linkcode PokemonType} of the move being used
-   * @param movePower the {@linkcode NumberHolder} that holds the power of the move
+   * @param pokemon - the {@linkcode Pokemon} that holds the held item
+   * @param moveType - the {@linkcode PokemonType} of the move being used
+   * @param movePower - the {@linkcode NumberHolder} that holds the power of the move
    * @returns `true` if boosts should be applied to the move.
    */
   override shouldApply(pokemon?: Pokemon, moveType?: PokemonType, movePower?: NumberHolder): boolean {
@@ -1485,9 +1474,9 @@ export class AttackTypeBoosterModifier extends PokemonHeldItemModifier {
 
   /**
    * Applies {@linkcode AttackTypeBoosterModifier}
-   * @param pokemon {@linkcode Pokemon} that holds the held item
-   * @param moveType {@linkcode PokemonType} of the move being used
-   * @param movePower {@linkcode NumberHolder} that holds the power of the move
+   * @param pokemon - that holds the held item
+   * @param moveType - of the move being used
+   * @param movePower - that holds the power of the move
    * @returns `true` if boosts have been applied to the move.
    */
   override apply(_pokemon: Pokemon, moveType: PokemonType, movePower: NumberHolder): boolean {
@@ -1521,8 +1510,8 @@ export class SurviveDamageModifier extends PokemonHeldItemModifier {
 
   /**
    * Checks if the {@linkcode SurviveDamageModifier} should be applied
-   * @param pokemon the {@linkcode Pokemon} that holds the item
-   * @param surviveDamage {@linkcode BooleanHolder} that holds the survive damage
+   * @param pokemon - the {@linkcode Pokemon} that holds the item
+   * @param surviveDamage - that holds the survive damage
    * @returns `true` if the {@linkcode SurviveDamageModifier} should be applied
    */
   override shouldApply(pokemon?: Pokemon, surviveDamage?: BooleanHolder): boolean {
@@ -1531,8 +1520,8 @@ export class SurviveDamageModifier extends PokemonHeldItemModifier {
 
   /**
    * Applies {@linkcode SurviveDamageModifier}
-   * @param pokemon the {@linkcode Pokemon} that holds the item
-   * @param surviveDamage {@linkcode BooleanHolder} that holds the survive damage
+   * @param pokemon - the {@linkcode Pokemon} that holds the item
+   * @param surviveDamage - that holds the survive damage
    * @returns `true` if the survive damage has been applied
    */
   override apply(pokemon: Pokemon, surviveDamage: BooleanHolder): boolean {
@@ -1567,8 +1556,8 @@ export class BypassSpeedChanceModifier extends PokemonHeldItemModifier {
 
   /**
    * Checks if {@linkcode BypassSpeedChanceModifier} should be applied
-   * @param pokemon the {@linkcode Pokemon} that holds the item
-   * @param doBypassSpeed {@linkcode BooleanHolder} that is `true` if speed should be bypassed
+   * @param pokemon - the {@linkcode Pokemon} that holds the item
+   * @param doBypassSpeed - that is `true` if speed should be bypassed
    * @returns `true` if {@linkcode BypassSpeedChanceModifier} should be applied
    */
   override shouldApply(pokemon?: Pokemon, doBypassSpeed?: BooleanHolder): boolean {
@@ -1577,8 +1566,8 @@ export class BypassSpeedChanceModifier extends PokemonHeldItemModifier {
 
   /**
    * Applies {@linkcode BypassSpeedChanceModifier}
-   * @param pokemon the {@linkcode Pokemon} that holds the item
-   * @param doBypassSpeed {@linkcode BooleanHolder} that is `true` if speed should be bypassed
+   * @param pokemon - the {@linkcode Pokemon} that holds the item
+   * @param doBypassSpeed - that is `true` if speed should be bypassed
    * @returns `true` if {@linkcode BypassSpeedChanceModifier} has been applied
    */
   override apply(pokemon: Pokemon, doBypassSpeed: BooleanHolder): boolean {
@@ -1629,8 +1618,8 @@ export class FlinchChanceModifier extends PokemonHeldItemModifier {
 
   /**
    * Checks if {@linkcode FlinchChanceModifier} should be applied
-   * @param pokemon the {@linkcode Pokemon} that holds the item
-   * @param flinched {@linkcode BooleanHolder} that is `true` if the pokemon flinched
+   * @param pokemon - the {@linkcode Pokemon} that holds the item
+   * @param flinched - that is `true` if the pokemon flinched
    * @returns `true` if {@linkcode FlinchChanceModifier} should be applied
    */
   override shouldApply(pokemon?: Pokemon, flinched?: BooleanHolder): boolean {
@@ -1639,8 +1628,8 @@ export class FlinchChanceModifier extends PokemonHeldItemModifier {
 
   /**
    * Applies {@linkcode FlinchChanceModifier}
-   * @param pokemon the {@linkcode Pokemon} that holds the item
-   * @param flinched {@linkcode BooleanHolder} that is `true` if the pokemon flinched
+   * @param pokemon - the {@linkcode Pokemon} that holds the item
+   * @param flinched - that is `true` if the pokemon flinched
    * @returns `true` if {@linkcode FlinchChanceModifier} has been applied
    */
   override apply(pokemon: Pokemon, flinched: BooleanHolder): boolean {
@@ -1669,7 +1658,7 @@ export class TurnHealModifier extends PokemonHeldItemModifier {
 
   /**
    * Applies {@linkcode TurnHealModifier}
-   * @param pokemon The {@linkcode Pokemon} that holds the item
+   * @param pokemon - The {@linkcode Pokemon} that holds the item
    * @returns `true` if the {@linkcode Pokemon} was healed
    */
   override apply(pokemon: Pokemon): boolean {
@@ -1699,7 +1688,6 @@ export class TurnHealModifier extends PokemonHeldItemModifier {
 /**
  * Modifier used for held items, namely Toxic Orb and Flame Orb, that apply a
  * set {@linkcode StatusEffect} at the end of a turn.
- * @extends PokemonHeldItemModifier
  * @see {@linkcode apply}
  */
 export class TurnStatusEffectModifier extends PokemonHeldItemModifier {
@@ -1725,7 +1713,7 @@ export class TurnStatusEffectModifier extends PokemonHeldItemModifier {
    * to prevent held item stockpiling since the item obtained first
    * would be the only item able to {@linkcode apply} successfully.
    * @override
-   * @param modifier {@linkcode Modifier} being type tested
+   * @param modifier - being type tested
    * @return `true` if {@linkcode modifier} is an instance of
    * TurnStatusEffectModifier, false otherwise
    */
@@ -1739,7 +1727,7 @@ export class TurnStatusEffectModifier extends PokemonHeldItemModifier {
 
   /**
    * Tries to inflicts the holder with the associated {@linkcode StatusEffect}.
-   * @param pokemon {@linkcode Pokemon} that holds the held item
+   * @param pokemon - that holds the held item
    * @returns `true` if the status effect was applied successfully
    */
   override apply(pokemon: Pokemon): boolean {
@@ -1766,7 +1754,7 @@ export class HitHealModifier extends PokemonHeldItemModifier {
 
   /**
    * Applies {@linkcode HitHealModifier}
-   * @param pokemon The {@linkcode Pokemon} that holds the item
+   * @param pokemon - The {@linkcode Pokemon} that holds the item
    * @returns `true` if the {@linkcode Pokemon} was healed
    */
   override apply(pokemon: Pokemon): boolean {
@@ -1803,7 +1791,7 @@ export class LevelIncrementBoosterModifier extends PersistentModifier {
 
   /**
    * Checks if {@linkcode LevelIncrementBoosterModifier} should be applied
-   * @param count {@linkcode NumberHolder} holding the level increment count
+   * @param count - holding the level increment count
    * @returns `true` if {@linkcode LevelIncrementBoosterModifier} should be applied
    */
   override shouldApply(count: NumberHolder): boolean {
@@ -1812,7 +1800,7 @@ export class LevelIncrementBoosterModifier extends PersistentModifier {
 
   /**
    * Applies {@linkcode LevelIncrementBoosterModifier}
-   * @param count {@linkcode NumberHolder} holding the level increment count
+   * @param count - holding the level increment count
    * @returns always `true`
    */
   override apply(count: NumberHolder): boolean {
@@ -1851,7 +1839,7 @@ export class BerryModifier extends PokemonHeldItemModifier {
 
   /**
    * Checks if {@linkcode BerryModifier} should be applied
-   * @param pokemon The {@linkcode Pokemon} that holds the berry
+   * @param pokemon - The {@linkcode Pokemon} that holds the berry
    * @returns `true` if {@linkcode BerryModifier} should be applied
    */
   override shouldApply(pokemon: Pokemon): boolean {
@@ -1860,7 +1848,7 @@ export class BerryModifier extends PokemonHeldItemModifier {
 
   /**
    * Applies {@linkcode BerryModifier}
-   * @param pokemon The {@linkcode Pokemon} that holds the berry
+   * @param pokemon - The {@linkcode Pokemon} that holds the berry
    * @returns always `true`
    */
   override apply(pokemon: Pokemon): boolean {
@@ -1894,8 +1882,8 @@ export class PreserveBerryModifier extends PersistentModifier {
 
   /**
    * Checks if all prequired conditions are met to apply {@linkcode PreserveBerryModifier}
-   * @param pokemon {@linkcode Pokemon} that holds the berry
-   * @param doPreserve {@linkcode BooleanHolder} that is `true` if the berry should be preserved
+   * @param pokemon - that holds the berry
+   * @param doPreserve - that is `true` if the berry should be preserved
    * @returns `true` if {@linkcode PreserveBerryModifier} should be applied
    */
   override shouldApply(pokemon?: Pokemon, doPreserve?: BooleanHolder): boolean {
@@ -1904,8 +1892,8 @@ export class PreserveBerryModifier extends PersistentModifier {
 
   /**
    * Applies {@linkcode PreserveBerryModifier}
-   * @param pokemon The {@linkcode Pokemon} that holds the berry
-   * @param doPreserve {@linkcode BooleanHolder} that is `true` if the berry should be preserved
+   * @param pokemon - The {@linkcode Pokemon} that holds the berry
+   * @param doPreserve - that is `true` if the berry should be preserved
    * @returns always `true`
    */
   override apply(pokemon: Pokemon, doPreserve: BooleanHolder): boolean {
@@ -1932,7 +1920,7 @@ export class PokemonInstantReviveModifier extends PokemonHeldItemModifier {
 
   /**
    * Applies {@linkcode PokemonInstantReviveModifier}
-   * @param pokemon The {@linkcode Pokemon} that holds the item
+   * @param pokemon - The {@linkcode Pokemon} that holds the item
    * @returns always `true`
    */
   override apply(pokemon: Pokemon): boolean {
@@ -1970,7 +1958,6 @@ export class PokemonInstantReviveModifier extends PokemonHeldItemModifier {
 /**
  * Modifier used for held items, namely White Herb, that restore adverse stat
  * stages in battle.
- * @extends PokemonHeldItemModifier
  * @see {@linkcode apply}
  */
 export class ResetNegativeStatStageModifier extends PokemonHeldItemModifier {
@@ -1985,7 +1972,7 @@ export class ResetNegativeStatStageModifier extends PokemonHeldItemModifier {
   /**
    * Goes through the holder's stat stages and, if any are negative, resets that
    * stat stage back to 0.
-   * @param pokemon {@linkcode Pokemon} that holds the item
+   * @param pokemon - that holds the item
    * @returns `true` if any stat stages were reset, false otherwise
    */
   override apply(pokemon: Pokemon): boolean {
@@ -2017,15 +2004,14 @@ export class ResetNegativeStatStageModifier extends PokemonHeldItemModifier {
 /**
  * Modifier used for held items, namely Mystical Rock, that extend the
  * duration of weather and terrain effects.
- * @extends PokemonHeldItemModifier
  * @see {@linkcode apply}
  */
 export class FieldEffectModifier extends PokemonHeldItemModifier {
   /**
    * Provides two more turns per stack to any weather or terrain effect caused
    * by the holder.
-   * @param pokemon {@linkcode Pokemon} that holds the held item
-   * @param fieldDuration {@linkcode NumberHolder} that stores the current field effect duration
+   * @param pokemon - that holds the held item
+   * @param fieldDuration - that stores the current field effect duration
    * @returns `true` if the field effect extension was applied successfully
    */
   override apply(_pokemon: Pokemon, fieldDuration: NumberHolder): boolean {
@@ -2057,8 +2043,8 @@ export abstract class ConsumablePokemonModifier extends ConsumableModifier {
 
   /**
    * Checks if {@linkcode ConsumablePokemonModifier} should be applied
-   * @param playerPokemon The {@linkcode PlayerPokemon} that consumes the item
-   * @param _args N/A
+   * @param playerPokemon - The {@linkcode PlayerPokemon} that consumes the item
+   * @param _args - N/A
    * @returns `true` if {@linkcode ConsumablePokemonModifier} should be applied
    */
   override shouldApply(playerPokemon?: PlayerPokemon, ..._args: unknown[]): boolean {
@@ -2067,8 +2053,8 @@ export abstract class ConsumablePokemonModifier extends ConsumableModifier {
 
   /**
    * Applies {@linkcode ConsumablePokemonModifier}
-   * @param playerPokemon The {@linkcode PlayerPokemon} that consumes the item
-   * @param args Additional arguments passed to {@linkcode ConsumablePokemonModifier.apply}
+   * @param playerPokemon - The {@linkcode PlayerPokemon} that consumes the item
+   * @param args - Additional arguments passed to {@linkcode ConsumablePokemonModifier.apply}
    */
   abstract override apply(playerPokemon: PlayerPokemon, ...args: unknown[]): boolean;
 
@@ -2089,7 +2075,7 @@ export class TerrastalizeModifier extends ConsumablePokemonModifier {
 
   /**
    * Checks if {@linkcode TerrastalizeModifier} should be applied
-   * @param playerPokemon The {@linkcode PlayerPokemon} that consumes the item
+   * @param playerPokemon - The {@linkcode PlayerPokemon} that consumes the item
    * @returns `true` if the {@linkcode TerrastalizeModifier} should be applied
    */
   override shouldApply(playerPokemon?: PlayerPokemon): boolean {
@@ -2103,7 +2089,7 @@ export class TerrastalizeModifier extends ConsumablePokemonModifier {
 
   /**
    * Applies {@linkcode TerrastalizeModifier}
-   * @param pokemon The {@linkcode PlayerPokemon} that consumes the item
+   * @param pokemon - The {@linkcode PlayerPokemon} that consumes the item
    * @returns `true` if hp was restored
    */
   override apply(pokemon: Pokemon): boolean {
@@ -2136,8 +2122,8 @@ export class PokemonHpRestoreModifier extends ConsumablePokemonModifier {
 
   /**
    * Checks if {@linkcode PokemonHpRestoreModifier} should be applied
-   * @param playerPokemon The {@linkcode PlayerPokemon} that consumes the item
-   * @param multiplier The multiplier of the hp restore
+   * @param playerPokemon - The {@linkcode PlayerPokemon} that consumes the item
+   * @param multiplier - The multiplier of the hp restore
    * @returns `true` if the {@linkcode PokemonHpRestoreModifier} should be applied
    */
   override shouldApply(playerPokemon?: PlayerPokemon, multiplier?: number): boolean {
@@ -2149,8 +2135,8 @@ export class PokemonHpRestoreModifier extends ConsumablePokemonModifier {
 
   /**
    * Applies {@linkcode PokemonHpRestoreModifier}
-   * @param pokemon The {@linkcode PlayerPokemon} that consumes the item
-   * @param multiplier The multiplier of the hp restore
+   * @param pokemon - The {@linkcode PlayerPokemon} that consumes the item
+   * @param multiplier - The multiplier of the hp restore
    * @returns `true` if hp was restored
    */
   override apply(pokemon: Pokemon, multiplier: number): boolean {
@@ -2176,7 +2162,7 @@ export class PokemonHpRestoreModifier extends ConsumablePokemonModifier {
 export class PokemonStatusHealModifier extends ConsumablePokemonModifier {
   /**
    * Applies {@linkcode PokemonStatusHealModifier}
-   * @param playerPokemon The {@linkcode PlayerPokemon} that gets healed from the status
+   * @param playerPokemon - The {@linkcode PlayerPokemon} that gets healed from the status
    * @returns always `true`
    */
   override apply(playerPokemon: PlayerPokemon): boolean {
@@ -2206,7 +2192,7 @@ export class PokemonPpRestoreModifier extends ConsumablePokemonMoveModifier {
 
   /**
    * Applies {@linkcode PokemonPpRestoreModifier}
-   * @param playerPokemon The {@linkcode PlayerPokemon} that should get move pp restored
+   * @param playerPokemon - The {@linkcode PlayerPokemon} that should get move pp restored
    * @returns always `true`
    */
   override apply(playerPokemon: PlayerPokemon): boolean {
@@ -2231,7 +2217,7 @@ export class PokemonAllMovePpRestoreModifier extends ConsumablePokemonModifier {
 
   /**
    * Applies {@linkcode PokemonAllMovePpRestoreModifier}
-   * @param playerPokemon The {@linkcode PlayerPokemon} that should get all move pp restored
+   * @param playerPokemon - The {@linkcode PlayerPokemon} that should get all move pp restored
    * @returns always `true`
    */
   override apply(playerPokemon: PlayerPokemon): boolean {
@@ -2256,7 +2242,7 @@ export class PokemonPpUpModifier extends ConsumablePokemonMoveModifier {
 
   /**
    * Applies {@linkcode PokemonPpUpModifier}
-   * @param playerPokemon The {@linkcode PlayerPokemon} that gets a pp up on move-slot {@linkcode moveIndex}
+   * @param playerPokemon - The {@linkcode PlayerPokemon} that gets a pp up on move-slot {@linkcode moveIndex}
    * @returns
    */
   override apply(playerPokemon: PlayerPokemon): boolean {
@@ -2281,7 +2267,7 @@ export class PokemonNatureChangeModifier extends ConsumablePokemonModifier {
 
   /**
    * Applies {@linkcode PokemonNatureChangeModifier}
-   * @param playerPokemon {@linkcode PlayerPokemon} to apply the {@linkcode Nature} change to
+   * @param playerPokemon - to apply the {@linkcode Nature} change to
    * @returns
    */
   override apply(playerPokemon: PlayerPokemon): boolean {
@@ -2295,8 +2281,8 @@ export class PokemonNatureChangeModifier extends ConsumablePokemonModifier {
 export class PokemonLevelIncrementModifier extends ConsumablePokemonModifier {
   /**
    * Applies {@linkcode PokemonLevelIncrementModifier}
-   * @param playerPokemon The {@linkcode PlayerPokemon} that should get levels incremented
-   * @param levelCount The amount of levels to increment
+   * @param playerPokemon - The {@linkcode PlayerPokemon} that should get levels incremented
+   * @param levelCount - The amount of levels to increment
    * @returns always `true`
    */
   override apply(playerPokemon: PlayerPokemon, levelCount: NumberHolder = new NumberHolder(1)): boolean {
@@ -2327,7 +2313,7 @@ export class TmModifier extends ConsumablePokemonModifier {
 
   /**
    * Applies {@linkcode TmModifier}
-   * @param playerPokemon The {@linkcode PlayerPokemon} that should learn the TM
+   * @param playerPokemon - The {@linkcode PlayerPokemon} that should learn the TM
    * @returns always `true`
    */
   override apply(playerPokemon: PlayerPokemon): boolean {
@@ -2350,7 +2336,7 @@ export class RememberMoveModifier extends ConsumablePokemonModifier {
 
   /**
    * Applies {@linkcode RememberMoveModifier}
-   * @param playerPokemon The {@linkcode PlayerPokemon} that should remember the move
+   * @param playerPokemon - The {@linkcode PlayerPokemon} that should remember the move
    * @returns always `true`
    */
   override apply(playerPokemon: PlayerPokemon, cost?: number): boolean {
@@ -2371,7 +2357,7 @@ export class EvolutionItemModifier extends ConsumablePokemonModifier {
   public override type: EvolutionItemModifierType;
   /**
    * Applies {@linkcode EvolutionItemModifier}
-   * @param playerPokemon The {@linkcode PlayerPokemon} that should evolve via item
+   * @param playerPokemon - The {@linkcode PlayerPokemon} that should evolve via item
    * @returns `true` if the evolution was successful
    */
   override apply(playerPokemon: PlayerPokemon): boolean {
@@ -2416,8 +2402,8 @@ export class FusePokemonModifier extends ConsumablePokemonModifier {
 
   /**
    * Checks if {@linkcode FusePokemonModifier} should be applied
-   * @param playerPokemon {@linkcode PlayerPokemon} that should be fused
-   * @param playerPokemon2 {@linkcode PlayerPokemon} that should be fused with {@linkcode playerPokemon}
+   * @param playerPokemon - that should be fused
+   * @param playerPokemon2 - that should be fused with {@linkcode playerPokemon}
    * @returns `true` if {@linkcode FusePokemonModifier} should be applied
    */
   override shouldApply(playerPokemon?: PlayerPokemon, playerPokemon2?: PlayerPokemon): boolean {
@@ -2428,8 +2414,8 @@ export class FusePokemonModifier extends ConsumablePokemonModifier {
 
   /**
    * Applies {@linkcode FusePokemonModifier}
-   * @param playerPokemon {@linkcode PlayerPokemon} that should be fused
-   * @param playerPokemon2 {@linkcode PlayerPokemon} that should be fused with {@linkcode playerPokemon}
+   * @param playerPokemon - that should be fused
+   * @param playerPokemon2 - that should be fused with {@linkcode playerPokemon}
    * @returns always Promise<true>
    */
   override apply(playerPokemon: PlayerPokemon, playerPokemon2: PlayerPokemon): boolean {
@@ -2483,7 +2469,7 @@ export class HealingBoosterModifier extends PersistentModifier {
 
   /**
    * Applies {@linkcode HealingBoosterModifier}
-   * @param healingMultiplier the multiplier to apply to the healing
+   * @param healingMultiplier - the multiplier to apply to the healing
    * @returns always `true`
    */
   override apply(healingMultiplier: NumberHolder): boolean {
@@ -2524,7 +2510,7 @@ export class ExpBoosterModifier extends PersistentModifier {
 
   /**
    * Applies {@linkcode ExpBoosterModifier}
-   * @param boost {@linkcode NumberHolder} holding the boost value
+   * @param boost - holding the boost value
    * @returns always `true`
    */
   override apply(boost: NumberHolder): boolean {
@@ -2566,8 +2552,8 @@ export class PokemonExpBoosterModifier extends PokemonHeldItemModifier {
 
   /**
    * Checks if {@linkcode PokemonExpBoosterModifier} should be applied
-   * @param pokemon The {@linkcode Pokemon} to apply the exp boost to
-   * @param boost {@linkcode NumberHolder} holding the exp boost value
+   * @param pokemon - The {@linkcode Pokemon} to apply the exp boost to
+   * @param boost - holding the exp boost value
    * @returns `true` if {@linkcode PokemonExpBoosterModifier} should be applied
    */
   override shouldApply(pokemon: Pokemon, boost: NumberHolder): boolean {
@@ -2576,8 +2562,8 @@ export class PokemonExpBoosterModifier extends PokemonHeldItemModifier {
 
   /**
    * Applies {@linkcode PokemonExpBoosterModifier}
-   * @param _pokemon The {@linkcode Pokemon} to apply the exp boost to
-   * @param boost {@linkcode NumberHolder} holding the exp boost value
+   * @param _pokemon - The {@linkcode Pokemon} to apply the exp boost to
+   * @param boost - holding the exp boost value
    * @returns always `true`
    */
   override apply(_pokemon: Pokemon, boost: NumberHolder): boolean {
@@ -2648,8 +2634,8 @@ export class PokemonFriendshipBoosterModifier extends PokemonHeldItemModifier {
 
   /**
    * Applies {@linkcode PokemonFriendshipBoosterModifier}
-   * @param _pokemon The {@linkcode Pokemon} to apply the friendship boost to
-   * @param friendship {@linkcode NumberHolder} holding the friendship boost value
+   * @param _pokemon - The {@linkcode Pokemon} to apply the friendship boost to
+   * @param friendship - holding the friendship boost value
    * @returns always `true`
    */
   override apply(_pokemon: Pokemon, friendship: NumberHolder): boolean {
@@ -2674,8 +2660,8 @@ export class PokemonNatureWeightModifier extends PokemonHeldItemModifier {
 
   /**
    * Applies {@linkcode PokemonNatureWeightModifier}
-   * @param _pokemon The {@linkcode Pokemon} to apply the nature weight to
-   * @param multiplier {@linkcode NumberHolder} holding the nature weight
+   * @param _pokemon - The {@linkcode Pokemon} to apply the nature weight to
+   * @param multiplier - holding the nature weight
    * @returns `true` if multiplier was applied
    */
   override apply(_pokemon: Pokemon, multiplier: NumberHolder): boolean {
@@ -2719,8 +2705,8 @@ export class PokemonMoveAccuracyBoosterModifier extends PokemonHeldItemModifier 
 
   /**
    * Checks if {@linkcode PokemonMoveAccuracyBoosterModifier} should be applied
-   * @param pokemon The {@linkcode Pokemon} to apply the move accuracy boost to
-   * @param moveAccuracy {@linkcode NumberHolder} holding the move accuracy boost
+   * @param pokemon - The {@linkcode Pokemon} to apply the move accuracy boost to
+   * @param moveAccuracy - holding the move accuracy boost
    * @returns `true` if {@linkcode PokemonMoveAccuracyBoosterModifier} should be applied
    */
   override shouldApply(pokemon?: Pokemon, moveAccuracy?: NumberHolder): boolean {
@@ -2729,8 +2715,8 @@ export class PokemonMoveAccuracyBoosterModifier extends PokemonHeldItemModifier 
 
   /**
    * Applies {@linkcode PokemonMoveAccuracyBoosterModifier}
-   * @param _pokemon The {@linkcode Pokemon} to apply the move accuracy boost to
-   * @param moveAccuracy {@linkcode NumberHolder} holding the move accuracy boost
+   * @param _pokemon - The {@linkcode Pokemon} to apply the move accuracy boost to
+   * @param moveAccuracy - holding the move accuracy boost
    * @returns always `true`
    */
   override apply(_pokemon: Pokemon, moveAccuracy: NumberHolder): boolean {
@@ -2757,10 +2743,10 @@ export class PokemonMultiHitModifier extends PokemonHeldItemModifier {
 
   /**
    * For each stack, converts 25 percent of attack damage into an additional strike.
-   * @param pokemon The {@linkcode Pokemon} using the move
-   * @param moveId The {@linkcode Moves | identifier} for the move being used
-   * @param count {@linkcode NumberHolder} holding the move's hit count for this turn
-   * @param damageMultiplier {@linkcode NumberHolder} holding a damage multiplier applied to a strike of this move
+   * @param pokemon - The {@linkcode Pokemon} using the move
+   * @param moveId - The {@linkcode Moves | identifier} for the move being used
+   * @param count - holding the move's hit count for this turn
+   * @param damageMultiplier - holding a damage multiplier applied to a strike of this move
    * @returns always `true`
    */
   override apply(
@@ -2862,8 +2848,8 @@ export class PokemonFormChangeItemModifier extends PokemonHeldItemModifier {
 
   /**
    * Applies {@linkcode PokemonFormChangeItemModifier}
-   * @param pokemon The {@linkcode Pokemon} to apply the form change item to
-   * @param active `true` if the form change item is active
+   * @param pokemon - The {@linkcode Pokemon} to apply the form change item to
+   * @param active - `true` if the form change item is active
    * @returns `true` if the form change item was applied
    */
   override apply(pokemon: Pokemon, active: boolean): boolean {
@@ -2934,7 +2920,7 @@ export class MoneyMultiplierModifier extends PersistentModifier {
 
   /**
    * Applies {@linkcode MoneyMultiplierModifier}
-   * @param multiplier {@linkcode NumberHolder} holding the money multiplier value
+   * @param multiplier - holding the money multiplier value
    * @returns always `true`
    */
   override apply(multiplier: NumberHolder): boolean {
@@ -2959,8 +2945,8 @@ export class DamageMoneyRewardModifier extends PokemonHeldItemModifier {
 
   /**
    * Applies {@linkcode DamageMoneyRewardModifier}
-   * @param pokemon The {@linkcode Pokemon} attacking
-   * @param multiplier {@linkcode NumberHolder} holding the multiplier value
+   * @param pokemon - The {@linkcode Pokemon} attacking
+   * @param multiplier - holding the multiplier value
    * @returns always `true`
    */
   override apply(_pokemon: Pokemon, multiplier: NumberHolder): boolean {
@@ -3020,7 +3006,7 @@ export class HiddenAbilityRateBoosterModifier extends PersistentModifier {
 
   /**
    * Applies {@linkcode HiddenAbilityRateBoosterModifier}
-   * @param boost {@linkcode NumberHolder} holding the boost value
+   * @param boost - holding the boost value
    * @returns always `true`
    */
   override apply(boost: NumberHolder): boolean {
@@ -3045,7 +3031,7 @@ export class ShinyRateBoosterModifier extends PersistentModifier {
 
   /**
    * Applies {@linkcode ShinyRateBoosterModifier}
-   * @param boost {@linkcode NumberHolder} holding the boost value
+   * @param boost - holding the boost value
    * @returns always `true`
    */
   override apply(boost: NumberHolder): boolean {
@@ -3070,7 +3056,7 @@ export class CriticalCatchChanceBoosterModifier extends PersistentModifier {
 
   /**
    * Applies {@linkcode CriticalCatchChanceBoosterModifier}
-   * @param boost {@linkcode NumberHolder} holding the boost value
+   * @param boost - holding the boost value
    * @returns always `true`
    */
   override apply(boost: NumberHolder): boolean {
@@ -3131,7 +3117,7 @@ export class HealShopCostModifier extends PersistentModifier {
 
   /**
    * Applies {@linkcode HealShopCostModifier}
-   * @param cost {@linkcode NumberHolder} holding the heal shop cost
+   * @param cost - holding the heal shop cost
    * @returns always `true`
    */
   apply(moneyCost: NumberHolder): boolean {
@@ -3201,8 +3187,8 @@ export class SwitchEffectTransferModifier extends PokemonHeldItemModifier {
 export abstract class HeldItemTransferModifier extends PokemonHeldItemModifier {
   /**
    * Determines the targets to transfer items from when this applies.
-   * @param pokemon the {@linkcode Pokemon} holding this item
-   * @param _args N/A
+   * @param pokemon - the {@linkcode Pokemon} holding this item
+   * @param _args - N/A
    * @returns the opponents of the source {@linkcode Pokemon}
    */
   getTargets(pokemon?: Pokemon, ..._args: unknown[]): Pokemon[] {
@@ -3212,9 +3198,9 @@ export abstract class HeldItemTransferModifier extends PokemonHeldItemModifier {
   /**
    * Steals an item from a set of target Pokemon.
    * This prioritizes high-tier held items when selecting the item to steal.
-   * @param pokemon The {@linkcode Pokemon} holding this item
-   * @param target The {@linkcode Pokemon} to steal from (optional)
-   * @param _args N/A
+   * @param pokemon - The {@linkcode Pokemon} holding this item
+   * @param target - The {@linkcode Pokemon} to steal from (optional)
+   * @param _args - N/A
    * @returns `true` if an item was stolen; false otherwise.
    */
   override apply(pokemon: Pokemon, target?: Pokemon, ..._args: unknown[]): boolean {
@@ -3331,8 +3317,8 @@ export class ContactHeldItemTransferChanceModifier extends HeldItemTransferModif
 
   /**
    * Determines the target to steal items from when this applies.
-   * @param _holderPokemon The {@linkcode Pokemon} holding this item
-   * @param targetPokemon The {@linkcode Pokemon} the holder is targeting with an attack
+   * @param _holderPokemon - The {@linkcode Pokemon} holding this item
+   * @param targetPokemon - The {@linkcode Pokemon} the holder is targeting with an attack
    * @returns The target {@linkcode Pokemon} as array for further use in `apply` implementations
    */
   override getTargets(_holderPokemon: Pokemon, targetPokemon: Pokemon): Pokemon[] {
@@ -3406,7 +3392,7 @@ export class ExtraModifierModifier extends PersistentModifier {
 
   /**
    * Applies {@linkcode ExtraModifierModifier}
-   * @param count {NumberHolder} holding the count value
+   * @param count - holding the count value
    * @returns always `true`
    */
   override apply(count: NumberHolder): boolean {
@@ -3422,7 +3408,6 @@ export class ExtraModifierModifier extends PersistentModifier {
 
 /**
  * Modifier used for timed boosts to the player's shop item rewards.
- * @extends LapsingPersistentModifier
  * @see {@linkcode apply}
  */
 export class TempExtraModifierModifier extends LapsingPersistentModifier {
@@ -3430,8 +3415,8 @@ export class TempExtraModifierModifier extends LapsingPersistentModifier {
    * Goes through existing modifiers for any that match Silver Pokeball,
    * which will then add the max count of the new item to the existing count of the current item.
    * If no existing Silver Pokeballs are found, will add a new one.
-   * @param modifiers {@linkcode PersistentModifier} array of the player's modifiers
-   * @param _virtual N/A
+   * @param modifiers - array of the player's modifiers
+   * @param _virtual - N/A
    * @returns true if the modifier was successfully added or applied, false otherwise
    */
   add(modifiers: PersistentModifier[], _virtual: boolean): boolean {
@@ -3461,7 +3446,7 @@ export class TempExtraModifierModifier extends LapsingPersistentModifier {
   /**
    * Increases the current rewards in the battle by the `stackCount`.
    * @returns `true` if the shop reward number modifier applies successfully
-   * @param count {@linkcode NumberHolder} that holds the resulting shop item reward count
+   * @param count - that holds the resulting shop item reward count
    */
   apply(count: NumberHolder): boolean {
     count.value += this.getStackCount();
@@ -3486,7 +3471,7 @@ abstract class EnemyDamageMultiplierModifier extends EnemyPersistentModifier {
 
   /**
    * Applies {@linkcode EnemyDamageMultiplierModifier}
-   * @param multiplier {NumberHolder} holding the multiplier value
+   * @param multiplier - holding the multiplier value
    * @returns always `true`
    */
   override apply(multiplier: NumberHolder): boolean {
@@ -3570,7 +3555,7 @@ export class EnemyTurnHealModifier extends EnemyPersistentModifier {
 
   /**
    * Applies {@linkcode EnemyTurnHealModifier}
-   * @param enemyPokemon The {@linkcode Pokemon} to heal
+   * @param enemyPokemon - The {@linkcode Pokemon} to heal
    * @returns `true` if the {@linkcode Pokemon} was healed
    */
   override apply(enemyPokemon: Pokemon): boolean {
@@ -3626,7 +3611,7 @@ export class EnemyAttackStatusEffectChanceModifier extends EnemyPersistentModifi
 
   /**
    * Applies {@linkcode EnemyAttackStatusEffectChanceModifier}
-   * @param enemyPokemon {@linkcode Pokemon} to apply the status effect to
+   * @param enemyPokemon - to apply the status effect to
    * @returns `true` if the {@linkcode Pokemon} was affected
    */
   override apply(enemyPokemon: Pokemon): boolean {
@@ -3666,7 +3651,7 @@ export class EnemyStatusEffectHealChanceModifier extends EnemyPersistentModifier
 
   /**
    * Applies {@linkcode EnemyStatusEffectHealChanceModifier}
-   * @param enemyPokemon The {@linkcode Pokemon} to heal
+   * @param enemyPokemon - The {@linkcode Pokemon} to heal
    * @returns `true` if the {@linkcode Pokemon} was healed
    */
   override apply(enemyPokemon: Pokemon): boolean {
@@ -3711,7 +3696,7 @@ export class EnemyEndureChanceModifier extends EnemyPersistentModifier {
 
   /**
    * Applies a chance of enduring a lethal hit of an attack
-   * @param target the {@linkcode Pokemon} to apply the {@linkcode BattlerTagType.ENDURING} chance to
+   * @param target - the {@linkcode Pokemon} to apply the {@linkcode BattlerTagType.ENDURING} chance to
    * @returns `true` if {@linkcode Pokemon} endured
    */
   override apply(target: Pokemon): boolean {
@@ -3754,7 +3739,7 @@ export class EnemyFusionChanceModifier extends EnemyPersistentModifier {
 
   /**
    * Applies {@linkcode EnemyFusionChanceModifier}
-   * @param isFusion {@linkcode BooleanHolder} that will be set to `true` if the {@linkcode EnemyPokemon} is a fusion
+   * @param isFusion - that will be set to `true` if the {@linkcode EnemyPokemon} is a fusion
    * @returns `true` if the {@linkcode EnemyPokemon} is a fusion
    */
   override apply(isFusion: BooleanHolder): boolean {
@@ -3776,7 +3761,7 @@ export class EnemyFusionChanceModifier extends EnemyPersistentModifier {
  * Uses either `MODIFIER_OVERRIDE` in overrides.ts to set {@linkcode PersistentModifier}s for either:
  *  - The player
  *  - The enemy
- * @param isPlayer {@linkcode boolean} for whether the player (`true`) or enemy (`false`) is being overridden
+ * @param isPlayer - for whether the player (`true`) or enemy (`false`) is being overridden
  */
 export function overrideModifiers(isPlayer = true): void {
   const modifiersOverride: ModifierOverride[] = isPlayer
@@ -3817,8 +3802,8 @@ export function overrideModifiers(isPlayer = true): void {
  * Uses either `HELD_ITEMS_OVERRIDE` in overrides.ts to set {@linkcode PokemonHeldItemModifier}s for either:
  *  - The first member of the player's team when starting a new game
  *  - An enemy {@linkcode Pokemon} being spawned in
- * @param pokemon {@linkcode Pokemon} whose held items are being overridden
- * @param isPlayer {@linkcode boolean} for whether the {@linkcode pokemon} is the player's (`true`) or an enemy (`false`)
+ * @param pokemon - whose held items are being overridden
+ * @param isPlayer - for whether the {@linkcode pokemon} is the player's (`true`) or an enemy (`false`)
  */
 export function overrideHeldItems(pokemon: Pokemon, isPlayer = true): void {
   const heldItemsOverride: ModifierOverride[] = isPlayer

--- a/src/phases/egg-hatch-phase.ts
+++ b/src/phases/egg-hatch-phase.ts
@@ -234,9 +234,9 @@ export class EggHatchPhase extends Phase {
 
   /**
    * Function that animates egg shaking
-   * @param intensity of horizontal shaking. Doubled on the first call (where count is 0)
-   * @param repeatCount the number of times this function should be called (asynchronous recursion?!?)
-   * @param count the current number of times this function has been called.
+   * @param intensity - of horizontal shaking. Doubled on the first call (where count is 0)
+   * @param repeatCount - the number of times this function should be called (asynchronous recursion?!?)
+   * @param count - the current number of times this function has been called.
    * @returns nothing since it's a Promise<void>
    */
   doEggShake(intensity: number, repeatCount?: number, count?: number): Promise<void> {
@@ -408,8 +408,8 @@ export class EggHatchPhase extends Phase {
 
   /**
    * Helper function to generate sine. (Why is this not a Utils?!?)
-   * @param index random number from 0-7 being passed in to scale pi/128
-   * @param amplitude Scaling
+   * @param index - random number from 0-7 being passed in to scale pi/128
+   * @param amplitude - Scaling
    * @returns a number
    */
   sin(index: number, amplitude: number): number {
@@ -418,8 +418,8 @@ export class EggHatchPhase extends Phase {
 
   /**
    * Animates spraying
-   * @param intensity number of times this is repeated (this is a badly named variable)
-   * @param offsetY how much to offset the Y coordinates
+   * @param intensity - number of times this is repeated (this is a badly named variable)
+   * @param offsetY - how much to offset the Y coordinates
    */
   doSpray(intensity: number, offsetY?: number) {
     globalScene.tweens.addCounter({
@@ -433,8 +433,8 @@ export class EggHatchPhase extends Phase {
 
   /**
    * Animates a particle used in the spray animation
-   * @param trigIndex Used to modify the particle's vertical speed, is a random number from 0-7
-   * @param offsetY how much to offset the Y coordinate
+   * @param trigIndex - Used to modify the particle's vertical speed, is a random number from 0-7
+   * @param offsetY - how much to offset the Y coordinate
    */
   doSprayParticle(trigIndex: number, offsetY: number) {
     const initialX = this.eggHatchBg.displayWidth / 2;

--- a/src/phases/egg-lapse-phase.ts
+++ b/src/phases/egg-lapse-phase.ts
@@ -77,7 +77,7 @@ export class EggLapsePhase extends Phase {
 
   /**
    * Hatches eggs normally one by one, showing animations
-   * @param eggsToHatch list of eggs to hatch
+   * @param eggsToHatch - list of eggs to hatch
    */
   hatchEggsRegular(eggsToHatch: Egg[]) {
     let eggsToHatchCount: number = eggsToHatch.length;
@@ -89,7 +89,7 @@ export class EggLapsePhase extends Phase {
 
   /**
    * Hatches eggs with no animations
-   * @param eggsToHatch list of eggs to hatch
+   * @param eggsToHatch - list of eggs to hatch
    */
   hatchEggsSkipped(eggsToHatch: Egg[]) {
     for (const egg of eggsToHatch) {
@@ -105,7 +105,7 @@ export class EggLapsePhase extends Phase {
   /**
    * Hatches an egg and stores it in the local EggHatchData array without animations
    * Also validates the achievements for the hatched pokemon and removes the egg
-   * @param egg egg to hatch
+   * @param egg - egg to hatch
    */
   hatchEggSilently(egg: Egg) {
     const eggIndex = globalScene.gameData.eggs.findIndex(e => e.id === egg.id);
@@ -136,7 +136,7 @@ export class EggLapsePhase extends Phase {
 
   /**
    * Generates a Pokemon and creates a new EggHatchData instance for the given egg
-   * @param egg the egg to hatch
+   * @param egg - the egg to hatch
    * @returns the hatched PlayerPokemon
    */
   generatePokemon(egg: Egg): EggHatchData {

--- a/src/phases/learn-move-phase.ts
+++ b/src/phases/learn-move-phase.ts
@@ -72,8 +72,8 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
    * > [Pokemon] wants to learn the move [MoveName]
    * > However, [Pokemon] already knows four moves.
    * > Should a move be forgotten and replaced with [MoveName]? --> `Mode.CONFIRM` -> Yes: Go to `this.forgetMoveProcess()`, No: Go to `this.rejectMoveAndEnd()`
-   * @param move The Move to be learned
-   * @param Pokemon The Pokemon learning the move
+   * @param move - The Move to be learned
+   * @param Pokemon - The Pokemon learning the move
    */
   async replaceMoveCheck(move: Move, pokemon: Pokemon) {
     const learnMovePrompt = i18next.t("battle:learnMovePrompt", {
@@ -108,8 +108,8 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
    * The game then goes `Mode.SUMMARY` to select a move to be forgotten.
    * If a player does not select a move or chooses the new move (`moveIndex === 4`), the game goes to `this.rejectMoveAndEnd()`.
    * If an old move is selected, the function then passes the `moveIndex` to `this.learnMove()`
-   * @param move The Move to be learned
-   * @param Pokemon The Pokemon learning the move
+   * @param move - The Move to be learned
+   * @param Pokemon - The Pokemon learning the move
    */
   async forgetMoveProcess(move: Move, pokemon: Pokemon) {
     globalScene.ui.setMode(this.messageMode);
@@ -143,8 +143,8 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
    *
    * If the player wishes to not teach the Pokemon the move, it displays a message and ends the phase.
    * If the player reconsiders, it repeats the process for a Pokemon with a full moveset once again.
-   * @param move The Move to be learned
-   * @param Pokemon The Pokemon learning the move
+   * @param move - The Move to be learned
+   * @param Pokemon - The Pokemon learning the move
    */
   async rejectMoveAndEnd(move: Move, pokemon: Pokemon) {
     await globalScene.ui.showTextPromise(
@@ -186,8 +186,8 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
    * > [Pokemon] forgot how to use [MoveName]
    * > And...
    * > [Pokemon] learned [MoveName]!
-   * @param move The Move to be learned
-   * @param Pokemon The Pokemon learning the move
+   * @param move - The Move to be learned
+   * @param Pokemon - The Pokemon learning the move
    */
   async learnMove(index: number, move: Move, pokemon: Pokemon, textMessage?: string) {
     if (this.learnMoveType === LearnMoveType.TM) {

--- a/src/phases/move-charge-phase.ts
+++ b/src/phases/move-charge-phase.ts
@@ -13,7 +13,6 @@ import { MoveEndPhase } from "#app/phases/move-end-phase";
 
 /**
  * Phase for the "charging turn" of two-turn moves (e.g. Dig).
- * @extends {@linkcode PokemonPhase}
  */
 export class MoveChargePhase extends PokemonPhase {
   /** The move instance that this phase applies */

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -78,7 +78,7 @@ export class MoveEffectPhase extends PokemonPhase {
   protected reflected = false;
 
   /**
-   * @param reflected Indicates that the move was reflected by the user due to magic coat or magic bounce
+   * @param reflected - Indicates that the move was reflected by the user due to magic coat or magic bounce
    */
   constructor(battlerIndex: BattlerIndex, targets: BattlerIndex[], move: PokemonMove, reflected = false) {
     super(battlerIndex);

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -87,9 +87,9 @@ export class MovePhase extends BattlePhase {
   }
 
   /**
-   * @param followUp Indicates that the move being used is a "follow-up" - for example, a move being used by Metronome or Dancer.
+   * @param followUp - Indicates that the move being used is a "follow-up" - for example, a move being used by Metronome or Dancer.
    *                 Follow-ups bypass a few failure conditions, including flinches, sleep/paralysis/freeze and volatile status checks, etc.
-   * @param reflected Indicates that the move was reflected by Magic Coat or Magic Bounce.
+   * @param reflected - Indicates that the move was reflected by Magic Coat or Magic Bounce.
    *                  Reflected moves cannot be reflected again and will not trigger Dancer.
    */
 
@@ -115,7 +115,7 @@ export class MovePhase extends BattlePhase {
 
   /**
    * Checks if the pokemon is active, if the move is usable, and that the move is targetting something.
-   * @param ignoreDisableTags `true` to not check if the move is disabled
+   * @param ignoreDisableTags - `true` to not check if the move is disabled
    * @returns `true` if all the checks pass
    */
   public canMove(ignoreDisableTags = false): boolean {

--- a/src/phases/mystery-encounter-phases.ts
+++ b/src/phases/mystery-encounter-phases.ts
@@ -43,7 +43,7 @@ export class MysteryEncounterPhase extends Phase {
 
   /**
    * Mostly useful for having repeated queries during a single encounter, where the queries and options may differ each time
-   * @param optionSelectSettings allows overriding the typical options of an encounter with new ones
+   * @param optionSelectSettings - allows overriding the typical options of an encounter with new ones
    */
   constructor(optionSelectSettings?: OptionSelectSettings) {
     super();

--- a/src/phases/select-starter-phase.ts
+++ b/src/phases/select-starter-phase.ts
@@ -36,7 +36,7 @@ export class SelectStarterPhase extends Phase {
 
   /**
    * Initialize starters before starting the first battle
-   * @param starters {@linkcode Pokemon} with which to start the first battle
+   * @param starters - with which to start the first battle
    */
   initBattle(starters: Starter[]) {
     const party = globalScene.getPlayerParty();

--- a/src/phases/switch-phase.ts
+++ b/src/phases/switch-phase.ts
@@ -18,11 +18,11 @@ export class SwitchPhase extends BattlePhase {
 
   /**
    * Creates a new SwitchPhase
-   * @param switchType {@linkcode SwitchType} The type of switch logic this phase implements
-   * @param fieldIndex Field index to switch out
-   * @param isModal Indicates if the switch should be forced (true) or is
+   * @param switchType - The type of switch logic this phase implements
+   * @param fieldIndex - Field index to switch out
+   * @param isModal - Indicates if the switch should be forced (true) or is
    * optional (false).
-   * @param doReturn Indicates if the party member on the field should be
+   * @param doReturn - Indicates if the party member on the field should be
    * recalled to ball or has already left the field. Passed to {@linkcode SwitchSummonPhase}.
    */
   constructor(switchType: SwitchType, fieldIndex: number, isModal: boolean, doReturn: boolean) {

--- a/src/plugins/api/api-base.ts
+++ b/src/plugins/api/api-base.ts
@@ -20,7 +20,7 @@ export abstract class ApiBase {
 
   /**
    * Send a GET request.
-   * @param path The path to send the request to.
+   * @param path - The path to send the request to.
    */
   protected async doGet(path: string) {
     return this.doFetch(path, { method: "GET" });
@@ -28,9 +28,9 @@ export abstract class ApiBase {
 
   /**
    * Send a POST request.
-   * @param path THe path to send the request to.
-   * @param bodyData The body-data to send.
-   * @param dataType The data-type of the {@linkcode bodyData}.
+   * @param path - THe path to send the request to.
+   * @param bodyData - The body-data to send.
+   * @param dataType - The data-type of the {@linkcode bodyData}.
    */
   protected async doPost<D = undefined>(path: string, bodyData?: D, dataType: DataType = "json") {
     let body: string | undefined = undefined;
@@ -59,8 +59,8 @@ export abstract class ApiBase {
 
   /**
    * A generic request helper.
-   * @param path The path to send the request to.
-   * @param config The request {@linkcode RequestInit | Configuration}.
+   * @param path - The path to send the request to.
+   * @param config - The request {@linkcode RequestInit | Configuration}.
    */
   protected async doFetch(path: string, config: RequestInit): Promise<Response> {
     config.headers = {
@@ -80,7 +80,7 @@ export abstract class ApiBase {
    * Helper to transform data to {@linkcode URLSearchParams}
    * Any key with a value of `undefined` will be ignored.
    * Any key with a value of `null` will be included.
-   * @param data the data to transform to {@linkcode URLSearchParams}
+   * @param data - the data to transform to {@linkcode URLSearchParams}
    * @returns a {@linkcode URLSearchParams} representaton of {@linkcode data}
    */
   protected toUrlSearchParams<D extends Record<string, any>>(data: D) {

--- a/src/plugins/api/pokerogue-account-api.ts
+++ b/src/plugins/api/pokerogue-account-api.ts
@@ -36,7 +36,7 @@ export class PokerogueAccountApi extends ApiBase {
 
   /**
    * Register a new account.
-   * @param registerData The {@linkcode AccountRegisterRequest} to send
+   * @param registerData - The {@linkcode AccountRegisterRequest} to send
    * @returns An error message if something went wrong
    */
   public async register(registerData: AccountRegisterRequest) {
@@ -57,7 +57,7 @@ export class PokerogueAccountApi extends ApiBase {
   /**
    * Send a login request.
    * Sets the session cookie on success.
-   * @param loginData The {@linkcode AccountLoginRequest} to send
+   * @param loginData - The {@linkcode AccountLoginRequest} to send
    * @returns An error message if something went wrong
    */
   public async login(loginData: AccountLoginRequest) {

--- a/src/plugins/api/pokerogue-admin-api.ts
+++ b/src/plugins/api/pokerogue-admin-api.ts
@@ -13,7 +13,7 @@ export class PokerogueAdminApi extends ApiBase {
 
   /**
    * Links an account to a discord id.
-   * @param params The {@linkcode LinkAccountToDiscordIdRequest} to send
+   * @param params - The {@linkcode LinkAccountToDiscordIdRequest} to send
    * @returns `null` if successful, error message if not
    */
   public async linkAccountToDiscord(params: LinkAccountToDiscordIdRequest) {
@@ -37,7 +37,7 @@ export class PokerogueAdminApi extends ApiBase {
 
   /**
    * Unlinks an account from a discord id.
-   * @param params The {@linkcode UnlinkAccountFromDiscordIdRequest} to send
+   * @param params - The {@linkcode UnlinkAccountFromDiscordIdRequest} to send
    * @returns `null` if successful, error message if not
    */
   public async unlinkAccountFromDiscord(params: UnlinkAccountFromDiscordIdRequest) {
@@ -61,7 +61,7 @@ export class PokerogueAdminApi extends ApiBase {
 
   /**
    * Links an account to a google id.
-   * @param params The {@linkcode LinkAccountToGoogledIdRequest} to send
+   * @param params - The {@linkcode LinkAccountToGoogledIdRequest} to send
    * @returns `null` if successful, error message if not
    */
   public async linkAccountToGoogleId(params: LinkAccountToGoogledIdRequest) {
@@ -85,7 +85,7 @@ export class PokerogueAdminApi extends ApiBase {
 
   /**
    * Unlinks an account from a google id.
-   * @param params The {@linkcode UnlinkAccountFromGoogledIdRequest} to send
+   * @param params - The {@linkcode UnlinkAccountFromGoogledIdRequest} to send
    * @returns `null` if successful, error message if not
    */
   public async unlinkAccountFromGoogleId(params: UnlinkAccountFromGoogledIdRequest) {
@@ -109,7 +109,7 @@ export class PokerogueAdminApi extends ApiBase {
 
   /**
    * Search an account.
-   * @param params The {@linkcode SearchAccountRequest} to send
+   * @param params - The {@linkcode SearchAccountRequest} to send
    * @returns an array of {@linkcode SearchAccountResponse} and error. Both can be `undefined`
    */
   public async searchAccount(params: SearchAccountRequest): Promise<[data?: SearchAccountResponse, error?: string]> {

--- a/src/plugins/api/pokerogue-daily-api.ts
+++ b/src/plugins/api/pokerogue-daily-api.ts
@@ -24,7 +24,7 @@ export class PokerogueDailyApi extends ApiBase {
 
   /**
    * Get the daily rankings for a {@linkcode ScoreboardCategory}.
-   * @param params The {@linkcode GetDailyRankingsRequest} to send
+   * @param params - The {@linkcode GetDailyRankingsRequest} to send
    */
   public async getRankings(params: GetDailyRankingsRequest) {
     try {
@@ -40,7 +40,7 @@ export class PokerogueDailyApi extends ApiBase {
 
   /**
    * Get the page count of the daily rankings for a {@linkcode ScoreboardCategory}.
-   * @param params The {@linkcode GetDailyRankingsPageCountRequest} to send.
+   * @param params - The {@linkcode GetDailyRankingsPageCountRequest} to send.
    */
   public async getRankingsPageCount(params: GetDailyRankingsPageCountRequest) {
     try {

--- a/src/plugins/api/pokerogue-savedata-api.ts
+++ b/src/plugins/api/pokerogue-savedata-api.ts
@@ -23,7 +23,7 @@ export class PokerogueSavedataApi extends ApiBase {
 
   /**
    * Update all savedata
-   * @param bodyData The {@linkcode UpdateAllSavedataRequest | request data} to send
+   * @param bodyData - The {@linkcode UpdateAllSavedataRequest | request data} to send
    * @returns An error message if something went wrong
    */
   public async updateAll(bodyData: UpdateAllSavedataRequest) {

--- a/src/plugins/api/pokerogue-session-savedata-api.ts
+++ b/src/plugins/api/pokerogue-session-savedata-api.ts
@@ -18,7 +18,7 @@ export class PokerogueSessionSavedataApi extends ApiBase {
   /**
    * Mark a session as cleared aka "newclear".\
    * *This is **NOT** the same as {@linkcode clear | clear()}.*
-   * @param params The {@linkcode NewClearSessionSavedataRequest} to send
+   * @param params - The {@linkcode NewClearSessionSavedataRequest} to send
    * @returns The raw savedata as `string`.
    */
   public async newclear(params: NewClearSessionSavedataRequest) {
@@ -36,7 +36,7 @@ export class PokerogueSessionSavedataApi extends ApiBase {
 
   /**
    * Get a session savedata.
-   * @param params The {@linkcode GetSessionSavedataRequest} to send
+   * @param params - The {@linkcode GetSessionSavedataRequest} to send
    * @returns The session as `string`
    */
   public async get(params: GetSessionSavedataRequest) {
@@ -53,8 +53,8 @@ export class PokerogueSessionSavedataApi extends ApiBase {
 
   /**
    * Update a session savedata.
-   * @param params The {@linkcode UpdateSessionSavedataRequest} to send
-   * @param rawSavedata The raw savedata (as `string`)
+   * @param params - The {@linkcode UpdateSessionSavedataRequest} to send
+   * @param rawSavedata - The raw savedata (as `string`)
    * @returns An error message if something went wrong
    */
   public async update(params: UpdateSessionSavedataRequest, rawSavedata: string) {
@@ -72,7 +72,7 @@ export class PokerogueSessionSavedataApi extends ApiBase {
 
   /**
    * Delete a session savedata slot.
-   * @param params The {@linkcode DeleteSessionSavedataRequest} to send
+   * @param params - The {@linkcode DeleteSessionSavedataRequest} to send
    * @returns An error message if something went wrong
    */
   public async delete(params: DeleteSessionSavedataRequest) {
@@ -93,8 +93,8 @@ export class PokerogueSessionSavedataApi extends ApiBase {
   /**
    * Clears the session savedata of the given slot.\
    * *This is **NOT** the same as {@linkcode newclear | newclear()}.*
-   * @param params The {@linkcode ClearSessionSavedataRequest} to send
-   * @param sessionData The {@linkcode SessionSaveData} object
+   * @param params - The {@linkcode ClearSessionSavedataRequest} to send
+   * @param sessionData - The {@linkcode SessionSaveData} object
    */
   public async clear(params: ClearSessionSavedataRequest, sessionData: SessionSaveData) {
     try {

--- a/src/plugins/api/pokerogue-system-savedata-api.ts
+++ b/src/plugins/api/pokerogue-system-savedata-api.ts
@@ -14,7 +14,7 @@ export class PokerogueSystemSavedataApi extends ApiBase {
 
   /**
    * Get a system savedata.
-   * @param params The {@linkcode GetSystemSavedataRequest} to send
+   * @param params - The {@linkcode GetSystemSavedataRequest} to send
    * @returns The system savedata as `string` or `null` on error
    */
   public async get(params: GetSystemSavedataRequest) {
@@ -33,7 +33,7 @@ export class PokerogueSystemSavedataApi extends ApiBase {
   /**
    * Verify if the session is valid.
    * If not the {@linkcode SystemSaveData} is returned.
-   * @param params The {@linkcode VerifySystemSavedataRequest} to send
+   * @param params - The {@linkcode VerifySystemSavedataRequest} to send
    * @returns A {@linkcode SystemSaveData} if **NOT** valid, otherwise `null`.
    *
    * TODO: add handling for errors
@@ -58,8 +58,8 @@ export class PokerogueSystemSavedataApi extends ApiBase {
 
   /**
    * Update a system savedata.
-   * @param params The {@linkcode UpdateSystemSavedataRequest} to send
-   * @param rawSystemData The raw {@linkcode SystemSaveData}
+   * @param params - The {@linkcode UpdateSystemSavedataRequest} to send
+   * @param rawSystemData - The raw {@linkcode SystemSaveData}
    * @returns An error message if something went wrong
    */
   public async update(params: UpdateSystemSavedataRequest, rawSystemData: string) {

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -125,7 +125,7 @@ async function initFonts(language: string | undefined) {
  * *If you don't want the BBCode tag applied, just use 'number' formatter*
  * @example Input: `{{myMoneyValue, money}}`
  *          Output: `@[MONEY]{₽100,000,000}`
- * @param amount the money amount
+ * @param amount - the money amount
  * @returns a money formatted string
  */
 function i18nMoneyFormatter(amount: any): string {

--- a/src/plugins/vite/vite-minify-json-plugin.ts
+++ b/src/plugins/vite/vite-minify-json-plugin.ts
@@ -4,8 +4,8 @@ import type { Plugin as VitePlugin } from "vite";
 
 /**
  * Crawl a directory (recursively if wanted) for json files and minifies found ones.
- * @param dir the directory to crawl
- * @param recursive if true, will crawl subdirectories
+ * @param dir - the directory to crawl
+ * @param recursive - if true, will crawl subdirectories
  */
 function applyToDir(dir: string, recursive?: boolean) {
   const files = fs.readdirSync(dir).filter(file => !/^\..*/.test(file));
@@ -27,8 +27,8 @@ function applyToDir(dir: string, recursive?: boolean) {
 
 /**
  * Plugin to mnify json files in the build folder after the bundling is done.
- * @param basePath base path/es starting inside the build dir (e.g. will always start with "/dist" if dist is the build dir)
- * @param recursive if true, will crawl subdirectories
+ * @param basePath - base path/es starting inside the build dir (e.g. will always start with "/dist" if dist is the build dir)
+ * @param recursive - if true, will crawl subdirectories
  */
 export function minifyJsonPlugin(basePath: string | string[], recursive?: boolean): VitePlugin {
   let buildDir = "dist"; // Default build dir

--- a/src/system/achv.ts
+++ b/src/system/achv.ts
@@ -204,7 +204,7 @@ export class ChallengeAchv extends Achv {
 
 /**
  * Get the description of an achievement from the localization file with all the necessary variables filled in
- * @param localizationKey The localization key of the achievement
+ * @param localizationKey - The localization key of the achievement
  * @returns The description of the achievement
  */
 export function getAchievementDescription(localizationKey: string): string {

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -409,7 +409,7 @@ export class GameData {
 
   /**
    * Checks if an `Unlockable` has been unlocked.
-   * @param unlockable The Unlockable to check
+   * @param unlockable - The Unlockable to check
    * @returns `true` if the player has unlocked this `Unlockable` or an override has enabled it
    */
   public isUnlocked(unlockable: Unlockables): boolean {
@@ -663,8 +663,8 @@ export class GameData {
 
   /**
    * Saves a new entry to Run History
-   * @param runEntry: most recent SessionSaveData of the run
-   * @param isVictory: result of the run
+   * @param runEntry: - most recent SessionSaveData of the run
+   * @param isVictory: - result of the run
    * Arbitrary limit of 25 runs per player - Will delete runs, starting with the oldest one, if needed
    */
   async saveRunHistory(runEntry: SessionSaveData, isVictory: boolean): Promise<boolean> {
@@ -773,8 +773,8 @@ export class GameData {
 
   /**
    * Saves a setting to localStorage
-   * @param setting string ideally of SettingKeys
-   * @param valueIndex index of the setting's option
+   * @param setting - string ideally of SettingKeys
+   * @param valueIndex - index of the setting's option
    * @returns true
    */
   public saveSetting(setting: string, valueIndex: number): boolean {
@@ -1234,7 +1234,7 @@ export class GameData {
   /**
    * Delete the session data at the given slot when overwriting a save file
    * For deleting the session of a finished run, use {@linkcode tryClearSession}
-   * @param slotId the slot to clear
+   * @param slotId - the slot to clear
    * @returns Promise with result `true` if the session was deleted successfully, `false` otherwise
    */
   deleteSession(slotId: number): Promise<boolean> {
@@ -1971,8 +1971,8 @@ export class GameData {
    *
    * @param species
    * @param eggMoveIndex
-   * @param showMessage Default true. If true, will display message for unlocked egg move
-   * @param prependSpeciesToMessage Default false. If true, will change message from "X Egg Move Unlocked!" to "Bulbasaur X Egg Move Unlocked!"
+   * @param showMessage - Default true. If true, will display message for unlocked egg move
+   * @param prependSpeciesToMessage - Default false. If true, will change message from "X Egg Move Unlocked!" to "Bulbasaur X Egg Move Unlocked!"
    */
   setEggMoveUnlocked(
     species: PokemonSpecies,

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -709,7 +709,7 @@ if (isLocal) {
 
 /**
  * Return the index of a Setting
- * @param key SettingKey
+ * @param key - SettingKey
  * @returns index or -1 if doesn't exist
  */
 export function settingIndex(key: string) {
@@ -727,8 +727,8 @@ export function resetSettings() {
 
 /**
  * Updates a setting
- * @param setting string ideally from SettingKeys
- * @param value value to update setting with
+ * @param setting - string ideally from SettingKeys
+ * @param value - value to update setting with
  * @returns true if successful, false if not
  */
 export function setSetting(setting: string, value: number): boolean {

--- a/src/system/version_migration/version_converter.ts
+++ b/src/system/version_migration/version_converter.ts
@@ -110,7 +110,7 @@ const applyMigrators = (migrators: readonly SaveMigrator[], data: SaveData, save
  * Note that no transforms act on the {@linkcode data} if its version matches
  * the current version or if there are no migrations made between its version up
  * to the current version.
- * @param data {@linkcode SystemSaveData}
+ * @param data
  * @see {@link SystemVersionConverter}
  */
 export function applySystemVersionMigration(data: SystemSaveData) {
@@ -130,7 +130,7 @@ export function applySystemVersionMigration(data: SystemSaveData) {
  * Note that no transforms act on the {@linkcode data} if its version matches
  * the current version or if there are no migrations made between its version up
  * to the current version.
- * @param data {@linkcode SessionSaveData}
+ * @param data
  * @see {@link SessionVersionConverter}
  */
 export function applySessionVersionMigration(data: SessionSaveData) {
@@ -153,7 +153,7 @@ export function applySessionVersionMigration(data: SessionSaveData) {
  * Note that no transforms act on the {@linkcode data} if its version matches
  * the current version or if there are no migrations made between its version up
  * to the current version.
- * @param data Settings data object
+ * @param data - Settings data object
  * @see {@link SettingsVersionConverter}
  */
 // biome-ignore lint/complexity/noBannedTypes: TODO - refactor settings

--- a/src/timed-event-manager.ts
+++ b/src/timed-event-manager.ts
@@ -488,7 +488,7 @@ export class TimedEventManager {
   /**
    * Gets all the modifier types associated with a certain wave during an event
    * @see EventWaveReward
-   * @param wave the wave to check for associated rewards
+   * @param wave - the wave to check for associated rewards
    * @returns array of strings of the event modifier reward types
    */
   getFixedBattleEventRewards(wave: number): string[] {

--- a/src/touch-controls.ts
+++ b/src/touch-controls.ts
@@ -143,7 +143,7 @@ export default class TouchControl {
    * {@link https://stackoverflow.com/a/39778831/4622620|Source}
    *
    * Prevent zoom on specified element
-   * @param {HTMLElement} element
+   * @param element
    */
   preventElementZoom(element: HTMLElement | null): void {
     if (!element) {

--- a/src/tutorial.ts
+++ b/src/tutorial.ts
@@ -123,7 +123,7 @@ const tutorialHandlers = {
  * Run through the specified tutorial if it hasn't been seen before and mark it as seen once done
  * This will show a tutorial overlay if defined in the current {@linkcode AwaitableUiHandler}
  * The main menu will also get disabled while the tutorial is running
- * @param tutorial the {@linkcode Tutorial} to play
+ * @param tutorial - the {@linkcode Tutorial} to play
  * @returns a promise with result `true` if the tutorial was run and finished, `false` otherwise
  */
 export async function handleTutorial(tutorial: Tutorial): Promise<boolean> {
@@ -160,7 +160,7 @@ export async function handleTutorial(tutorial: Tutorial): Promise<boolean> {
 
 /**
  * Show the tutorial overlay if there is one
- * @param handler the current UiHandler
+ * @param handler - the current UiHandler
  * @returns `true` once the overlay has finished appearing, or if there is no overlay
  */
 async function showTutorialOverlay(handler: UiHandler) {
@@ -181,7 +181,7 @@ async function showTutorialOverlay(handler: UiHandler) {
 
 /**
  * Hide the tutorial overlay if there is one
- * @param handler the current UiHandler
+ * @param handler - the current UiHandler
  * @returns `true` once the overlay has finished disappearing, or if there is no overlay
  */
 async function hideTutorialOverlay(handler: UiHandler) {

--- a/src/ui/achvs-ui-handler.ts
+++ b/src/ui/achvs-ui-handler.ts
@@ -368,7 +368,7 @@ export default class AchvsUiHandler extends MessageUiHandler {
   /**
    * setScrollCursor(scrollCursor: number) : boolean
    * scrollCursor refers to the page's position within the entire sum of the data, unlike cursor, which refers to a user's position within displayed data
-   * @param scrollCursor takes a value that has been updated based on user behavior
+   * @param scrollCursor - takes a value that has been updated based on user behavior
    * @returns returns a boolean that indicates whether the updated scrollCursor led to an update in the data displayed.
    */
   setScrollCursor(scrollCursor: number): boolean {

--- a/src/ui/arena-flyout.ts
+++ b/src/ui/arena-flyout.ts
@@ -272,7 +272,7 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
 
   /**
    * Parses the {@linkcode Event} being passed and updates the state of the fieldEffectInfo array
-   * @param event {@linkcode Event} being sent
+   * @param event - being sent
    */
   private onFieldEffectChanged(event: Event) {
     const arenaEffectChangedEvent = event as ArenaEvent;
@@ -375,7 +375,7 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
 
   /**
    * Iterates through the fieldEffectInfo array and decrements the duration of each item
-   * @param event {@linkcode Event} being sent
+   * @param event - being sent
    */
   private onTurnEnd(event: Event) {
     const turnEndEvent = event as TurnEndEvent;
@@ -405,7 +405,7 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
 
   /**
    * Animates the flyout to either show or hide it by applying a fade and translation
-   * @param visible Should the flyout be shown?
+   * @param visible - Should the flyout be shown?
    */
   public toggleFlyout(visible: boolean): void {
     globalScene.tweens.add({

--- a/src/ui/awaitable-ui-handler.ts
+++ b/src/ui/awaitable-ui-handler.ts
@@ -28,7 +28,7 @@ export default abstract class AwaitableUiHandler extends UiHandler {
 
   /**
    * Create a semi transparent overlay that will get shown during tutorials
-   * @param container the container to add the overlay to
+   * @param container - the container to add the overlay to
    */
   initTutorialOverlay(container: Phaser.GameObjects.Container) {
     if (!this.tutorialOverlay) {

--- a/src/ui/battle-flyout.ts
+++ b/src/ui/battle-flyout.ts
@@ -124,7 +124,7 @@ export default class BattleFlyout extends Phaser.GameObjects.Container {
 
   /**
    * Links the given {@linkcode Pokemon} and subscribes to the {@linkcode BattleSceneEventType.MOVE_USED} event
-   * @param pokemon {@linkcode Pokemon} to link to this flyout
+   * @param pokemon - to link to this flyout
    */
   initInfo(pokemon: Pokemon) {
     this.pokemon = pokemon;

--- a/src/ui/bgm-bar.ts
+++ b/src/ui/bgm-bar.ts
@@ -52,7 +52,7 @@ export default class BgmBar extends Phaser.GameObjects.Container {
 
   /*
    * Set the BGM Name to the BGM bar.
-   * @param {string} bgmName The name of the BGM to set.
+   * @param bgmName - The name of the BGM to set.
    */
   setBgmToBgmBar(bgmName: string): void {
     this.musicText.setText(`${i18next.t("bgmName:music")}${this.getRealBgmName(bgmName)}`);
@@ -70,7 +70,7 @@ export default class BgmBar extends Phaser.GameObjects.Container {
 
   /*
     Show or hide the BGM bar.
-    @param {boolean} visible Whether to show or hide the BGM bar.
+    @param visible Whether to show or hide the BGM bar.
    */
   public toggleBgmBar(visible: boolean): void {
     /*

--- a/src/ui/challenges-select-ui-handler.ts
+++ b/src/ui/challenges-select-ui-handler.ts
@@ -222,7 +222,7 @@ export default class GameChallengesUiHandler extends UiHandler {
 
   /**
    * Adds the default text color to the description text
-   * @param text text to set to the BBCode description
+   * @param text - text to set to the BBCode description
    */
   setDescription(text: string): void {
     this.descriptionText.setText(`[color=${Color.ORANGE}][shadow=${ShadowColor.ORANGE}]${text}`);

--- a/src/ui/daily-run-scoreboard.ts
+++ b/src/ui/daily-run-scoreboard.ts
@@ -44,7 +44,7 @@ export class DailyRunScoreboard extends Phaser.GameObjects.Container {
   /**
    * Sets the updating state and updates button states accordingly.
    * If value is true (updating), disables the buttons; if false, enables the buttons.
-   * @param {boolean} value - The new updating state.
+   * @param value - The new updating state.
    */
   set isUpdating(value) {
     this._isUpdating = value;
@@ -208,8 +208,8 @@ export class DailyRunScoreboard extends Phaser.GameObjects.Container {
    * The method fetches the total page count if necessary, followed by fetching the rankings for the specified category
    * and page. It updates the UI with the fetched rankings or shows an appropriate message if no rankings are found.
    *
-   * @param {ScoreboardCategory} [category=this.category] - The category to fetch rankings for. Defaults to the current category.
-   * @param {number} [page=this.page] - The page number to fetch. Defaults to the current page.
+   * @param [category=this.category] - The category to fetch rankings for. Defaults to the current category.
+   * @param [page=this.page] - The page number to fetch. Defaults to the current page.
    */
   update(category: ScoreboardCategory = this.category, page: number = this.page) {
     if (this.isUpdating) {
@@ -255,7 +255,7 @@ export class DailyRunScoreboard extends Phaser.GameObjects.Container {
 
   /**
    * Sets the state of the navigation buttons.
-   * @param {boolean} [enabled=true] - Whether the buttons should be enabled or disabled.
+   * @param [enabled=true] - Whether the buttons should be enabled or disabled.
    */
   setButtonsState(enabled = true) {
     const buttons = [

--- a/src/ui/dropdown.ts
+++ b/src/ui/dropdown.ts
@@ -96,8 +96,8 @@ export class DropDownOption extends Phaser.GameObjects.Container {
    * Initialize the toggle icon based on the provided DropDownType
    * For DropDownType.SINGLE: uses a cursor arrow icon
    * For other types: uses a candy icon
-   * @param type the DropDownType to use
-   * @param visible whether the icon should be visible or not
+   * @param type - the DropDownType to use
+   * @param visible - whether the icon should be visible or not
    */
   setupToggleIcon(type: DropDownType, visible: boolean): void {
     if (type === DropDownType.SINGLE) {
@@ -157,7 +157,7 @@ export class DropDownOption extends Phaser.GameObjects.Container {
 
   /**
    * Set the option to the given state and update visuals
-   * @param newState the state to switch to
+   * @param newState - the state to switch to
    * @returns the new DropDownState
    */
   public setOptionState(newState: DropDownState): DropDownState {
@@ -173,7 +173,7 @@ export class DropDownOption extends Phaser.GameObjects.Container {
 
   /**
    * Change the option state to the one at the given index and update visuals
-   * @param index index of the state to switch to
+   * @param index - index of the state to switch to
    * @returns the new DropDownState
    */
   private setCurrentLabel(index: number): DropDownState {
@@ -205,7 +205,7 @@ export class DropDownOption extends Phaser.GameObjects.Container {
 
   /**
    * Set the current SortDirection to the provided value and update icon accordingly
-   * @param SortDirection the new SortDirection to use
+   * @param SortDirection - the new SortDirection to use
    */
   public setDirection(dir: SortDirection): void {
     this.dir = dir;
@@ -221,8 +221,8 @@ export class DropDownOption extends Phaser.GameObjects.Container {
 
   /**
    * Place the label elements (text and sprite if there is one) to the provided x and y position
-   * @param x the horizontal position
-   * @param y the vertical position
+   * @param x - the horizontal position
+   * @param y - the vertical position
    */
   setLabelPosition(x: number, y: number) {
     let textX = x;
@@ -244,8 +244,8 @@ export class DropDownOption extends Phaser.GameObjects.Container {
 
   /**
    * Place the toggle icon at the provided position
-   * @param x the horizontal position
-   * @param y the vertical position
+   * @param x - the horizontal position
+   * @param y - the vertical position
    */
   setTogglePosition(x: number, y: number) {
     if (this.toggle) {
@@ -494,7 +494,7 @@ export class DropDown extends Phaser.GameObjects.Container {
    * Update accordingly the other options if needed:
    *  - if "all" is toggled, also update all other options
    *  - for DropDownType.SINGLE, unselect the previously selected option if applicable
-   * @param index the index of the option for which to update the state
+   * @param index - the index of the option for which to update the state
    */
   toggleOptionState(index: number = this.cursor): void {
     const option: DropDownOption = this.options[index];
@@ -665,7 +665,7 @@ export class DropDown extends Phaser.GameObjects.Container {
 
   /**
    * Set all options to a specific state
-   * @param state the DropDownState to assign to each option
+   * @param state - the DropDownState to assign to each option
    */
   private setAllOptions(state: DropDownState): void {
     // For single type dropdown, setting all options is not relevant

--- a/src/ui/egg-counter-container.ts
+++ b/src/ui/egg-counter-container.ts
@@ -7,7 +7,6 @@ import type EggHatchSceneHandler from "./egg-hatch-scene-handler";
 
 /**
  * A container that displays the count of hatching eggs.
- * @extends Phaser.GameObjects.Container
  */
 export default class EggCounterContainer extends Phaser.GameObjects.Container {
   private readonly WINDOW_DEFAULT_WIDTH = 37;
@@ -63,7 +62,7 @@ export default class EggCounterContainer extends Phaser.GameObjects.Container {
   /**
    * Handles window size, the egg count to show, and whether it should be displayed.
    *
-   * @param event {@linkcode Event} being sent
+   * @param event - being sent
    */
   private onEggCountChanged(event: Event): void {
     const eggCountChangedEvent = event as EggCountChangedEvent;

--- a/src/ui/egg-list-ui-handler.ts
+++ b/src/ui/egg-list-ui-handler.ts
@@ -165,7 +165,7 @@ export default class EggListUiHandler extends MessageUiHandler {
 
   /**
    * Update the information panel with the information of the given egg
-   * @param index which egg in the list to display the info for
+   * @param index - which egg in the list to display the info for
    */
   private setEggDetails(index: number): void {
     const egg = globalScene.gameData.eggs[index];

--- a/src/ui/egg-summary-ui-handler.ts
+++ b/src/ui/egg-summary-ui-handler.ts
@@ -140,7 +140,7 @@ export default class EggSummaryUiHandler extends MessageUiHandler {
   }
 
   /**
-   * @param args EggHatchData[][]
+   * @param args - EggHatchData[][]
    * args[0]: list of EggHatchData for each egg/pokemon hatched
    */
   show(args: EggHatchData[][]): boolean {

--- a/src/ui/filter-bar.ts
+++ b/src/ui/filter-bar.ts
@@ -60,9 +60,9 @@ export class FilterBar extends Phaser.GameObjects.Container {
 
   /**
    * Add a new filter to the FilterBar, as long that a unique DropDownColumn is provided
-   * @param column  the DropDownColumn that will be used to access the filter values
-   * @param title   the string that will get displayed in the filter bar
-   * @param dropDown the DropDown with all options for this filter
+   * @param column - the DropDownColumn that will be used to access the filter values
+   * @param title  - the string that will get displayed in the filter bar
+   * @param dropDown - the DropDown with all options for this filter
    * @returns true if successful, false if the provided column was already in use for another filter
    */
   addFilter(column: DropDownColumn, title: string, dropDown: DropDown): boolean {
@@ -87,7 +87,7 @@ export class FilterBar extends Phaser.GameObjects.Container {
 
   /**
    * Get the DropDown associated to a given filter
-   * @param col the DropDownColumn used to register the filter to retrieve
+   * @param col - the DropDownColumn used to register the filter to retrieve
    * @returns the associated DropDown if it exists, undefined otherwise
    */
   getFilter(col: DropDownColumn): DropDown {
@@ -96,7 +96,7 @@ export class FilterBar extends Phaser.GameObjects.Container {
 
   /**
    * Get the DropDownColumn associated to a given index
-   * @param index the index of the column to retrieve
+   * @param index - the index of the column to retrieve
    * @returns the associated DropDownColumn if it exists, undefined otherwise
    */
   public getColumn(index: number): DropDownColumn {
@@ -214,7 +214,7 @@ export class FilterBar extends Phaser.GameObjects.Container {
 
   /**
    * Find the nearest filter to the provided container
-   * @param container the StarterContainer to compare position against
+   * @param container - the StarterContainer to compare position against
    * @returns the index of the closest filter
    */
   getNearestFilter(container: StarterContainer): number {

--- a/src/ui/filter-text.ts
+++ b/src/ui/filter-text.ts
@@ -83,9 +83,9 @@ export class FilterText extends Phaser.GameObjects.Container {
 
   /**
    * Add a new filter to the FilterBar, as long that a unique DropDownColumn is provided
-   * @param column  the DropDownColumn that will be used to access the filter values
-   * @param title   the string that will get displayed in the filter bar
-   * @param dropDown the DropDown with all options for this filter
+   * @param column - the DropDownColumn that will be used to access the filter values
+   * @param title  - the string that will get displayed in the filter bar
+   * @param dropDown - the DropDown with all options for this filter
    * @returns true if successful, false if the provided column was already in use for another filter
    */
   addFilter(row: FilterTextRow, title: string): boolean {
@@ -206,7 +206,7 @@ export class FilterText extends Phaser.GameObjects.Container {
 
   /**
    * Find the nearest filter to the provided container on the y-axis
-   * @param container the StarterContainer to compare position against
+   * @param container - the StarterContainer to compare position against
    * @returns the index of the closest filter
    */
   getNearestFilter(container: StarterContainer): number {

--- a/src/ui/hatched-pokemon-container.ts
+++ b/src/ui/hatched-pokemon-container.ts
@@ -21,9 +21,9 @@ export class HatchedPokemonContainer extends Phaser.GameObjects.Container {
   public eggMoveIcon: Phaser.GameObjects.Image;
 
   /**
-   * @param x x position
-   * @param y y position
-   * @param hatchData the {@linkcode EggHatchData} to load the icons and sprites for
+   * @param x - x position
+   * @param y - y position
+   * @param hatchData - the {@linkcode EggHatchData} to load the icons and sprites for
    */
   constructor(x: number, y: number, hatchData: EggHatchData) {
     super(globalScene, x, y);
@@ -80,8 +80,8 @@ export class HatchedPokemonContainer extends Phaser.GameObjects.Container {
    * Update the Pokemon's sprite and icons based on new hatch data
    * Animates the pokemon icon if it has a new form or shiny variant
    *
-   * @param hatchData the {@linkcode EggHatchData} to base the icons on
-   * @param iconAnimHandler the {@linkcode PokemonIconAnimHandler} to use to animate the sprites
+   * @param hatchData - the {@linkcode EggHatchData} to base the icons on
+   * @param iconAnimHandler - the {@linkcode PokemonIconAnimHandler} to use to animate the sprites
    */
   updateAndAnimate(hatchData: EggHatchData, iconAnimHandler: PokemonIconAnimHandler) {
     const displayPokemon = hatchData.pokemon;
@@ -120,10 +120,10 @@ export class HatchedPokemonContainer extends Phaser.GameObjects.Container {
 
   /**
    * Check if the given Pokemon icon exists, otherwise replace it with a default one
-   * @param female `true` to get the female icon
-   * @param formIndex the form index
-   * @param shiny whether the Pokemon is shiny
-   * @param variant the shiny variant
+   * @param female - `true` to get the female icon
+   * @param formIndex - the form index
+   * @param shiny - whether the Pokemon is shiny
+   * @param variant - the shiny variant
    */
   private checkIconId(female: boolean, formIndex: number, shiny: boolean, variant: number) {
     if (this.icon.frame.name !== this.species.getIconId(female, formIndex, shiny, variant)) {

--- a/src/ui/menu-ui-handler.ts
+++ b/src/ui/menu-ui-handler.ts
@@ -759,7 +759,7 @@ export default class MenuUiHandler extends MessageUiHandler {
    * Switch the message window style and size when we are replaying dialog for debug purposes
    * In "dialog test mode", the window takes the whole width of the screen and the text
    * is set up to wrap around the same way as the dialogue during the game
-   * @param isDialogMode whether to use the dialog test
+   * @param isDialogMode - whether to use the dialog test
    */
   setDialogTestMode(isDialogMode: boolean) {
     this.menuMessageBox.setVisible(!isDialogMode);

--- a/src/ui/message-ui-handler.ts
+++ b/src/ui/message-ui-handler.ts
@@ -19,7 +19,7 @@ export default abstract class MessageUiHandler extends AwaitableUiHandler {
 
   /**
    * Add the sprite to be displayed at the end of messages with prompts
-   * @param container the container to add the sprite to
+   * @param container - the container to add the sprite to
    */
   initPromptSprite(container: Phaser.GameObjects.Container) {
     if (!this.prompt) {

--- a/src/ui/modal-ui-handler.ts
+++ b/src/ui/modal-ui-handler.ts
@@ -181,7 +181,7 @@ export abstract class ModalUiHandler extends UiHandler {
 
   /**
    * Adds a hover effect to a game object which changes the cursor to a `pointer` and tints it slighly
-   * @param gameObject the game object to add hover events/effects to
+   * @param gameObject - the game object to add hover events/effects to
    */
   protected addInteractionHoverEffect(
     gameObject: Phaser.GameObjects.Image | Phaser.GameObjects.NineSlice | Phaser.GameObjects.Sprite,

--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -207,7 +207,7 @@ export default class PartyUiHandler extends MessageUiHandler {
 
   /**
    * For consistency reasons, this looks like the above filters. However this is used only internally and is always enforced for switching.
-   * @param pokemon The pokemon to check.
+   * @param pokemon - The pokemon to check.
    * @returns
    */
   private FilterChallengeLegal = (pokemon: PlayerPokemon) => {

--- a/src/ui/pokedex-page-ui-handler.ts
+++ b/src/ui/pokedex-page-ui-handler.ts
@@ -937,8 +937,8 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
    * Check whether a given form is caught for a given species.
    * All forms that can be reached through a form change during battle are considered caught and show up in the dex as such.
    *
-   * @param otherSpecies The species to check; defaults to current species
-   * @param otherFormIndex The form index of the form to check; defaults to current form
+   * @param otherSpecies - The species to check; defaults to current species
+   * @param otherFormIndex - The form index of the form to check; defaults to current form
    * @returns StarterAttributes for the species
    */
   isFormCaught(otherSpecies?: PokemonSpecies, otherFormIndex?: number | undefined): boolean {
@@ -970,7 +970,7 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
    * If somehow a preference is set for a form, variant, gender, ability or nature
    * that wasn't actually unlocked or is invalid it will be cleared here
    *
-   * @param species The species to get Starter Preferences for
+   * @param species - The species to get Starter Preferences for
    * @returns StarterAttributes for the species
    */
   initStarterPrefs(): StarterAttributes {
@@ -1078,7 +1078,7 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
 
   /**
    * If the pokemon is an evolution, find speciesId of its starter.
-   * @param speciesId the id of the species to check
+   * @param speciesId - the id of the species to check
    * @returns the id of the corresponding starter
    */
   getStarterSpeciesId(speciesId): number {
@@ -2691,7 +2691,7 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
   /**
    * Creates a temporary dex attr props that will be used to display the correct shiny, variant, and form based on this.starterAttributes
    *
-   * @param speciesId the id of the species to get props for
+   * @param speciesId - the id of the species to get props for
    * @returns the dex props
    */
   getCurrentDexProps(speciesId: number): bigint {

--- a/src/ui/pokedex-ui-handler.ts
+++ b/src/ui/pokedex-ui-handler.ts
@@ -131,7 +131,7 @@ const speciesContainerX = 143;
 
 /**
  * Calculates the starter position for a Pokemon of a given UI index
- * @param index UI index to calculate the starter position of
+ * @param index - UI index to calculate the starter position of
  * @returns An interface with an x and y property
  */
 function calcStarterPosition(index: number): { x: number; y: number } {
@@ -655,7 +655,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
    * If somehow a preference is set for a form, variant, gender, ability or nature
    * that wasn't actually unlocked or is invalid it will be cleared here
    *
-   * @param species The species to get Starter Preferences for
+   * @param species - The species to get Starter Preferences for
    * @returns StarterAttributes for the species
    */
   initStarterPrefs(species: PokemonSpecies): StarterAttributes {
@@ -814,7 +814,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
 
   /**
    * Determines if a passive upgrade is available for the given species ID
-   * @param speciesId The ID of the species to check the passive of
+   * @param speciesId - The ID of the species to check the passive of
    * @returns true if the user has enough candies and a passive has not been unlocked already
    */
   isPassiveAvailable(speciesId: number): boolean {
@@ -829,7 +829,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
 
   /**
    * Determines if a value reduction upgrade is available for the given species ID
-   * @param speciesId The ID of the species to check the value reduction of
+   * @param speciesId - The ID of the species to check the value reduction of
    * @returns true if the user has enough candies and all value reductions have not been unlocked already
    */
   isValueReductionAvailable(speciesId: number): boolean {
@@ -846,7 +846,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
 
   /**
    * Determines if an same species egg can be bought for the given species ID
-   * @param speciesId The ID of the species to check the value reduction of
+   * @param speciesId - The ID of the species to check the value reduction of
    * @returns true if the user has enough candies
    */
   isSameSpeciesEggAvailable(speciesId: number): boolean {
@@ -860,9 +860,9 @@ export default class PokedexUiHandler extends MessageUiHandler {
 
   /**
    * Sets a bounce animation if enabled and the Pokemon has an upgrade
-   * @param icon {@linkcode Phaser.GameObjects.GameObject} to animate
-   * @param species {@linkcode PokemonSpecies} of the icon used to check for upgrades
-   * @param startPaused Should this animation be paused after it is added?
+   * @param icon - to animate
+   * @param species - of the icon used to check for upgrades
+   * @param startPaused - Should this animation be paused after it is added?
    */
   setUpgradeAnimation(icon: Phaser.GameObjects.Sprite, species: PokemonSpecies, startPaused = false): void {
     globalScene.tweens.killTweensOf(icon);
@@ -951,7 +951,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
 
   /**
    * Update the display of candy upgrade icons or animations for the given PokedexMonContainer
-   * @param pokemonContainer the container for the Pokemon to update
+   * @param pokemonContainer - the container for the Pokemon to update
    */
   updateCandyUpgradeDisplay(pokemonContainer: PokedexMonContainer) {
     if (this.isUpgradeIconEnabled()) {
@@ -2295,7 +2295,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
    * Creates a temporary dex attr props that will be used to
    * display the correct shiny, variant, and form based on the StarterPreferences
    *
-   * @param speciesId the id of the species to get props for
+   * @param speciesId - the id of the species to get props for
    * @returns the dex props
    */
   getCurrentDexProps(speciesId: number): bigint {

--- a/src/ui/pokemon-hatch-info-container.ts
+++ b/src/ui/pokemon-hatch-info-container.ts
@@ -142,7 +142,7 @@ export default class PokemonHatchInfoContainer extends PokemonInfoContainer {
   /**
    * Updates the info container with the appropriate dex data and starter entry from the hatchInfo
    * Also updates the displayed name, number, egg moves and main animated sprite for the pokemon
-   * @param hatchInfo The EggHatchData of the pokemon / new hatch to show
+   * @param hatchInfo - The EggHatchData of the pokemon / new hatch to show
    */
   showHatchInfo(hatchInfo: EggHatchData) {
     this.pokemonEggMovesContainer.setVisible(true);

--- a/src/ui/run-info-ui-handler.ts
+++ b/src/ui/run-info-ui-handler.ts
@@ -82,7 +82,7 @@ export default class RunInfoUiHandler extends UiHandler {
 
   /**
    * This takes a run's RunEntry and uses the information provided to display essential information about the player's run.
-   * @param args[0] : a RunEntry object
+   * @param args[0] - : a RunEntry object
    *
    * show() creates these UI objects in order -
    * A solid-color background used to hide RunHistoryUiHandler
@@ -461,7 +461,7 @@ export default class RunInfoUiHandler extends UiHandler {
   /**
    * This loads the enemy sprites, positions, and scales them according to the current display mode of the RunInfo UI and then adds them to the container parameter.
    * Used by {@linkcode parseRunStatus} and {@linkcode parseTrainerDefeat}
-   * @param enemyContainer a Phaser Container that should hold enemy sprites
+   * @param enemyContainer - a Phaser Container that should hold enemy sprites
    */
   private showTrainerSprites(enemyContainer: Phaser.GameObjects.Container) {
     // Creating the trainer sprite and adding it to enemyContainer
@@ -549,7 +549,7 @@ export default class RunInfoUiHandler extends UiHandler {
    * Shows information about the run like the run's mode, duration, luck, money, and player held items
    * The values for luck and money are from the end of the run, not the player's luck at the start of the run.
    * @param windowX
-   * @param windowY These two params are the coordinates of the window's bottom right corner. This is used to dynamically position Luck based on its length, creating a nice layout regardless of language / luck value.
+   * @param windowY - These two params are the coordinates of the window's bottom right corner. This is used to dynamically position Luck based on its length, creating a nice layout regardless of language / luck value.
    */
   private async parseRunInfo(windowX: number, windowY: number) {
     // Parsing and displaying the mode.
@@ -940,7 +940,7 @@ export default class RunInfoUiHandler extends UiHandler {
 
   /**
    * Changes what is displayed of the Pokemon's held items
-   * @param partyVisible {boolean}
+   * @param partyVisible
    * True -> Shows the Pokemon's default information and hides held items
    * False -> Shows the Pokemon's held items and hides default information
    */

--- a/src/ui/save-slot-select-ui-handler.ts
+++ b/src/ui/save-slot-select-ui-handler.ts
@@ -255,8 +255,8 @@ export default class SaveSlotSelectUiHandler extends MessageUiHandler {
 
   /**
    * Move the cursor to a new position and update the view accordingly
-   * @param cursor the new cursor position, between `0` and `SLOTS_ON_SCREEN - 1`
-   * @param prevSlotIndex index of the previous session occupied by the cursor, between `0` and `SESSION_SLOTS_COUNT - 1` - optional
+   * @param cursor - the new cursor position, between `0` and `SLOTS_ON_SCREEN - 1`
+   * @param prevSlotIndex - index of the previous session occupied by the cursor, between `0` and `SESSION_SLOTS_COUNT - 1` - optional
    * @returns `true` if the cursor position has changed | `false` if it has not
    */
   override setCursor(cursor: number, prevSlotIndex?: number): boolean {
@@ -316,7 +316,7 @@ export default class SaveSlotSelectUiHandler extends MessageUiHandler {
 
   /**
    * Helper function that checks if the session slot involved holds data or not
-   * @param hasData `true` if session slot contains data | 'false' if not
+   * @param hasData - `true` if session slot contains data | 'false' if not
    */
   setArrowVisibility(hasData: boolean): void {
     if (this.cursorObj) {
@@ -327,8 +327,8 @@ export default class SaveSlotSelectUiHandler extends MessageUiHandler {
 
   /**
    * Move the scrolling cursor to a new position and update the view accordingly
-   * @param scrollCursor the new cursor position, between `0` and `SESSION_SLOTS_COUNT - SLOTS_ON_SCREEN`
-   * @param prevSlotIndex index of the previous slot occupied by the cursor, between `0` and `SESSION_SLOTS_COUNT-1` - optional
+   * @param scrollCursor - the new cursor position, between `0` and `SESSION_SLOTS_COUNT - SLOTS_ON_SCREEN`
+   * @param prevSlotIndex - index of the previous slot occupied by the cursor, between `0` and `SESSION_SLOTS_COUNT-1` - optional
    * @returns `true` if the cursor position has changed | `false` if it has not
    */
   setScrollCursor(scrollCursor: number, prevSlotIndex?: number): boolean {

--- a/src/ui/scroll-bar.ts
+++ b/src/ui/scroll-bar.ts
@@ -13,11 +13,11 @@ export class ScrollBar extends Phaser.GameObjects.Container {
   private maxRows: number;
 
   /**
-   * @param x the scrollbar's x position (origin: top left)
-   * @param y the scrollbar's y position (origin: top left)
-   * @param width the scrollbar's width
-   * @param height the scrollbar's height
-   * @param maxRows the maximum number of rows that can be shown at once
+   * @param x - the scrollbar's x position (origin: top left)
+   * @param y - the scrollbar's y position (origin: top left)
+   * @param width - the scrollbar's width
+   * @param height - the scrollbar's height
+   * @param maxRows - the maximum number of rows that can be shown at once
    */
   constructor(x: number, y: number, width: number, height: number, maxRows: number) {
     super(globalScene, x, y);
@@ -56,7 +56,7 @@ export class ScrollBar extends Phaser.GameObjects.Container {
   /**
    * Set the current row that is displayed
    * Moves the bar handle up or down accordingly
-   * @param scrollCursor how many times the view was scrolled down
+   * @param scrollCursor - how many times the view was scrolled down
    */
   setScrollCursor(scrollCursor: number): void {
     this.currentRow = scrollCursor;
@@ -67,7 +67,7 @@ export class ScrollBar extends Phaser.GameObjects.Container {
    * Set the total number of rows to display
    * If it's smaller than the maximum number of rows on screen the bar will get hidden
    * Otherwise the scrollbar handle gets resized based on the ratio to the maximum number of rows
-   * @param rows how many rows of data there are in total
+   * @param rows - how many rows of data there are in total
    */
   setTotalRows(rows: number): void {
     this.totalRows = rows;

--- a/src/ui/scrollable-grid-handler.ts
+++ b/src/ui/scrollable-grid-handler.ts
@@ -30,8 +30,8 @@ export default class ScrollableGridUiHandler {
   private updateDetailsCallback?: UpdateDetailsCallbackFunction;
 
   /**
-   * @param rows the maximum number of rows shown at once
-   * @param columns the maximum number of columns shown at once
+   * @param rows - the maximum number of rows shown at once
+   * @param columns - the maximum number of columns shown at once
    */
   constructor(handler: UiHandler, rows: number, columns: number) {
     this.handler = handler;
@@ -44,7 +44,7 @@ export default class ScrollableGridUiHandler {
 
   /**
    * Set a scrollBar to get updated with the scrolling
-   * @param scrollBar {@linkcode ScrollBar}
+   * @param scrollBar
    * @returns this
    */
   withScrollBar(scrollBar: ScrollBar): ScrollableGridUiHandler {
@@ -55,7 +55,7 @@ export default class ScrollableGridUiHandler {
 
   /**
    * Set function that will get called if the whole grid needs to get updated
-   * @param callback {@linkcode UpdateGridCallbackFunction}
+   * @param callback
    * @returns this
    */
   withUpdateGridCallBack(callback: UpdateGridCallbackFunction): ScrollableGridUiHandler {
@@ -65,7 +65,7 @@ export default class ScrollableGridUiHandler {
 
   /**
    * Set function that will get called if a single element in the grid needs to get updated
-   * @param callback {@linkcode UpdateDetailsCallbackFunction}
+   * @param callback
    * @returns this
    */
   withUpdateSingleElementCallback(callback: UpdateDetailsCallbackFunction): ScrollableGridUiHandler {
@@ -74,7 +74,7 @@ export default class ScrollableGridUiHandler {
   }
 
   /**
-   * @param totalElements the total number of elements that the grid needs to display
+   * @param totalElements - the total number of elements that the grid needs to display
    */
   setTotalElements(totalElements: number) {
     this.totalElements = totalElements;
@@ -93,7 +93,7 @@ export default class ScrollableGridUiHandler {
 
   /**
    * Update the cursor and scrollCursor based on user input
-   * @param button the button that was pressed
+   * @param button - the button that was pressed
    * @returns `true` if either the cursor or scrollCursor was updated
    */
   processInput(button: Button): boolean {

--- a/src/ui/settings/abstract-settings-ui-handler.ts
+++ b/src/ui/settings/abstract-settings-ui-handler.ts
@@ -341,7 +341,7 @@ export default class AbstractSettingsUiHandler extends MessageUiHandler {
 
   /**
    * Activate the specified setting if it is activatable.
-   * @param setting The setting to activate.
+   * @param setting - The setting to activate.
    * @returns Whether the setting was successfully activated.
    */
   activateSetting(setting: Setting): boolean {

--- a/src/ui/settings/move-touch-controls-handler.ts
+++ b/src/ui/settings/move-touch-controls-handler.ts
@@ -63,7 +63,7 @@ export default class MoveTouchControlsHandler {
 
   /**
    * Changes the state of the touch controls to the given orientation.
-   * @param isLandscapeMode Whether the screen is in landscape mode.
+   * @param isLandscapeMode - Whether the screen is in landscape mode.
    */
   private async changeOrientation(isLandscapeMode: boolean) {
     this.isLandscapeMode = isLandscapeMode;
@@ -157,15 +157,15 @@ export default class MoveTouchControlsHandler {
   /**
    * Elements that are inside the left div are anchored to the left boundary of the screen.
    * The x value of the positions are considered offsets to their respective boundaries.
-   * @param element Either an element in the left div or the right div.
+   * @param element - Either an element in the left div or the right div.
    * @returns Whether the given element is inside the left div.
    */
   private isLeft = (element: HTMLElement) => document.querySelector("#touchControls .left")?.contains(element);
 
   /**
    * Start dragging the given button.
-   * @param controlGroup The button that is being dragged.
-   * @param touch The touch event that started the drag.
+   * @param controlGroup - The button that is being dragged.
+   * @param touch - The touch event that started the drag.
    */
   private startDrag = (controlGroup: HTMLElement): void => {
     this.draggingElement = controlGroup;
@@ -173,8 +173,8 @@ export default class MoveTouchControlsHandler {
 
   /**
    * Drags the currently dragged element to the given touch position.
-   * @param touch The touch event that is currently happening.
-   * @param isLeft Whether the dragged element is a left button.
+   * @param touch - The touch event that is currently happening.
+   * @param isLeft - Whether the dragged element is a left button.
    */
   private drag = (touch: Touch): void => {
     if (!this.draggingElement) {
@@ -242,7 +242,7 @@ export default class MoveTouchControlsHandler {
 
   /**
    * Updates the positions of the touch controls.
-   * @param positions The new positions of the touch controls.
+   * @param positions - The new positions of the touch controls.
    */
   private setPositions(positions: ControlPosition[]) {
     this.resetPositions();
@@ -258,8 +258,8 @@ export default class MoveTouchControlsHandler {
    * E.g. For left elements, (0, 0) is the bottom left corner of the screen and
    * for right elements, (0, 0) is the bottom right corner of the screen.
    * @param controlElement
-   * @param x Either an offset to the left or right boundary of the screen.
-   * @param y An offset to the bottom boundary of the screen.
+   * @param x - Either an offset to the left or right boundary of the screen.
+   * @param y - An offset to the bottom boundary of the screen.
    */
   private setPosition(controlElement: HTMLElement, x: number, y: number) {
     const rect = controlElement.getBoundingClientRect();
@@ -298,7 +298,7 @@ export default class MoveTouchControlsHandler {
 
   /**
    * Creates the event listeners for the configuration mode.
-   * @param controlGroups The elements that can be dragged around the screen.
+   * @param controlGroups - The elements that can be dragged around the screen.
    * @returns The event listeners for the configuration mode.
    */
   private createConfigurationEventListeners(controlGroups: HTMLDivElement[]): ConfigurationEventListeners {
@@ -324,7 +324,7 @@ export default class MoveTouchControlsHandler {
   /**
    * Creates an overlay that covers the screen and allows the user to drag the touch controls around.
    * Also enables the toolbar for saving, resetting, and canceling the changes.
-   * @param ui The UI of the game.
+   * @param ui - The UI of the game.
    */
   private createOverlay(ui: UI) {
     const container = new Phaser.GameObjects.Container(globalScene, 0, 0);
@@ -348,7 +348,7 @@ export default class MoveTouchControlsHandler {
 
   /**
    * Allows the user to configure the touch controls by dragging buttons around the screen.
-   * @param ui The UI of the game.
+   * @param ui - The UI of the game.
    */
   public enableConfigurationMode(ui: UI) {
     if (this.inConfigurationMode) {

--- a/src/ui/settings/navigationMenu.ts
+++ b/src/ui/settings/navigationMenu.ts
@@ -60,7 +60,7 @@ export class NavigationManager {
 
   /**
    * Navigates modes based on given direction
-   * @param direction LEFT or RIGHT
+   * @param direction - LEFT or RIGHT
    */
   public navigate(direction) {
     const pos = this.modes.indexOf(this.selectedMode);
@@ -109,8 +109,8 @@ export default class NavigationMenu extends Phaser.GameObjects.Container {
 
   /**
    * Creates an instance of NavigationMenu.
-   * @param x The x position of the NavigationMenu.
-   * @param y The y position of the NavigationMenu.
+   * @param x - The x position of the NavigationMenu.
+   * @param y - The y position of the NavigationMenu.
    */
   constructor(x: number, y: number) {
     super(globalScene, x, y);
@@ -200,7 +200,7 @@ export default class NavigationMenu extends Phaser.GameObjects.Container {
 
   /**
    * Handles navigation based on the button pressed.
-   * @param button The button pressed for navigation.
+   * @param button - The button pressed for navigation.
    * @returns A boolean indicating if the navigation was handled.
    */
   navigate(button: Button): boolean {

--- a/src/ui/settings/settings-gamepad-ui-handler.ts
+++ b/src/ui/settings/settings-gamepad-ui-handler.ts
@@ -20,7 +20,6 @@ import { globalScene } from "#app/global-scene";
 /**
  * Class representing the settings UI handler for gamepads.
  *
- * @extends AbstractControlSettingsUiHandler
  */
 
 export default class SettingsGamepadUiHandler extends AbstractControlSettingsUiHandler {

--- a/src/ui/settings/settings-keyboard-ui-handler.ts
+++ b/src/ui/settings/settings-keyboard-ui-handler.ts
@@ -20,7 +20,6 @@ import { globalScene } from "#app/global-scene";
 /**
  * Class representing the settings UI handler for keyboards.
  *
- * @extends AbstractControlSettingsUiHandler
  */
 export default class SettingsKeyboardUiHandler extends AbstractControlSettingsUiHandler {
   /**

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -171,7 +171,7 @@ const randomSelectionWindowHeight = 20;
 
 /**
  * Calculates the starter position for a Pokemon of a given UI index
- * @param index UI index to calculate the starter position of
+ * @param index - UI index to calculate the starter position of
  * @returns An interface with an x and y property
  */
 function calcStarterPosition(index: number, scrollCursor = 0): { x: number; y: number } {
@@ -185,7 +185,7 @@ function calcStarterPosition(index: number, scrollCursor = 0): { x: number; y: n
 
 /**
  * Calculates the y position for the icon of stater pokemon selected for the team
- * @param index index of the Pokemon in the team (0-5)
+ * @param index - index of the Pokemon in the team (0-5)
  * @returns the y position to use for the icon
  */
 function calcStarterIconY(index: number) {
@@ -196,8 +196,8 @@ function calcStarterIconY(index: number) {
 
 /**
  * Finds the index of the team Pokemon closest vertically to the given y position
- * @param y the y position to find closest starter Pokemon
- * @param teamSize how many Pokemon are in the team (0-6)
+ * @param y - the y position to find closest starter Pokemon
+ * @param teamSize - how many Pokemon are in the team (0-6)
  * @returns index of the closest Pokemon in the team container
  */
 function findClosestStarterIndex(y: number, teamSize = 6): number {
@@ -215,8 +215,8 @@ function findClosestStarterIndex(y: number, teamSize = 6): number {
 
 /**
  * Finds the row of the filtered Pokemon closest vertically to the given Pokemon in the team
- * @param index index of the Pokemon in the team (0-5)
- * @param numberOfRows the number of rows to check against
+ * @param index - index of the Pokemon in the team (0-5)
+ * @param numberOfRows - the number of rows to check against
  * @returns index of the row closest vertically to the given Pokemon
  */
 function findClosestStarterRow(index: number, numberOfRows: number) {
@@ -1227,7 +1227,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
    * If somehow a preference is set for a form, variant, gender, ability or nature
    * that wasn't actually unlocked or is invalid it will be cleared here
    *
-   * @param species The species to get Starter Preferences for
+   * @param species - The species to get Starter Preferences for
    * @returns StarterAttributes for the species
    */
   initStarterPrefs(species: PokemonSpecies): StarterAttributes {
@@ -1386,7 +1386,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
   /**
    * Determines if a passive upgrade is available for the given species ID
-   * @param speciesId The ID of the species to check the passive of
+   * @param speciesId - The ID of the species to check the passive of
    * @returns true if the user has enough candies and a passive has not been unlocked already
    */
   isPassiveAvailable(speciesId: number): boolean {
@@ -1401,7 +1401,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
   /**
    * Determines if a value reduction upgrade is available for the given species ID
-   * @param speciesId The ID of the species to check the value reduction of
+   * @param speciesId - The ID of the species to check the value reduction of
    * @returns true if the user has enough candies and all value reductions have not been unlocked already
    */
   isValueReductionAvailable(speciesId: number): boolean {
@@ -1417,7 +1417,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
   /**
    * Determines if an same species egg can be bought for the given species ID
-   * @param speciesId The ID of the species to check the value reduction of
+   * @param speciesId - The ID of the species to check the value reduction of
    * @returns true if the user has enough candies
    */
   isSameSpeciesEggAvailable(speciesId: number): boolean {
@@ -1429,9 +1429,9 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
   /**
    * Sets a bounce animation if enabled and the Pokemon has an upgrade
-   * @param icon {@linkcode Phaser.GameObjects.GameObject} to animate
-   * @param species {@linkcode PokemonSpecies} of the icon used to check for upgrades
-   * @param startPaused Should this animation be paused after it is added?
+   * @param icon - to animate
+   * @param species - of the icon used to check for upgrades
+   * @param startPaused - Should this animation be paused after it is added?
    */
   setUpgradeAnimation(icon: Phaser.GameObjects.Sprite, species: PokemonSpecies, startPaused = false): void {
     globalScene.tweens.killTweensOf(icon);
@@ -1520,7 +1520,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
   /**
    * Update the display of candy upgrade icons or animations for the given StarterContainer
-   * @param starterContainer the container for the Pokemon to update
+   * @param starterContainer - the container for the Pokemon to update
    */
   updateCandyUpgradeDisplay(starterContainer: StarterContainer) {
     if (this.isUpgradeIconEnabled()) {
@@ -1533,7 +1533,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
   /**
    * Processes an {@linkcode CandyUpgradeNotificationChangedEvent} sent when the corresponding setting changes
-   * @param event {@linkcode Event} sent by the callback
+   * @param event - sent by the callback
    */
   onCandyUpgradeDisplayChanged(event: Event): void {
     const candyUpgradeDisplayEvent = event as CandyUpgradeNotificationChangedEvent;
@@ -4400,7 +4400,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
    * Creates a temporary dex attr props that will be used to check whether a pokemon is valid for a challenge
    * and to display the correct shiny, variant, and form based on the StarterPreferences
    *
-   * @param speciesId the id of the species to get props for
+   * @param speciesId - the id of the species to get props for
    * @returns the dex props
    */
   getCurrentDexProps(speciesId: number): bigint {

--- a/src/ui/target-select-ui-handler.ts
+++ b/src/ui/target-select-ui-handler.ts
@@ -66,8 +66,8 @@ export default class TargetSelectUiHandler extends UiHandler {
 
   /**
    * Determines what value to assign the main cursor based on the previous turn's target or the user's status
-   * @param cursorN the cursor associated with the user's field index
-   * @param user the Pokemon using the move
+   * @param cursorN - the cursor associated with the user's field index
+   * @param user - the Pokemon using the move
    */
   resetCursor(cursorN: number, user: Pokemon): void {
     if (!isNullOrUndefined(cursorN)) {

--- a/src/ui/text.ts
+++ b/src/ui/text.ts
@@ -286,10 +286,10 @@ export function getBBCodeFrag(content: string, textStyle: TextStyle, uiTheme: Ui
  * - "blue text" with TextStyle.SUMMARY_BLUE applied
  * - " primaryStyle text " with primaryStyle TextStyle applied
  * - "red text" with TextStyle.SUMMARY_RED applied
- * @param content string with styling that need to be applied for BBCodeTextObject
- * @param primaryStyle Primary style is required in order to escape BBCode styling properly.
- * @param uiTheme the {@linkcode UiTheme} to get TextStyle for
- * @param forWindow set to `true` if the text is to be displayed in a window ({@linkcode BattleScene.addWindow})
+ * @param content - string with styling that need to be applied for BBCodeTextObject
+ * @param primaryStyle - Primary style is required in order to escape BBCode styling properly.
+ * @param uiTheme - the {@linkcode UiTheme} to get TextStyle for
+ * @param forWindow - set to `true` if the text is to be displayed in a window ({@linkcode BattleScene.addWindow})
  *  it will replace all instances of the default MONEY TextStyle by {@linkcode TextStyle.MONEY_WINDOW}
  */
 export function getTextWithColors(

--- a/src/ui/time-of-day-widget.ts
+++ b/src/ui/time-of-day-widget.ts
@@ -149,7 +149,7 @@ export default class TimeOfDayWidget extends Phaser.GameObjects.Container {
 
   /**
    * Grabs the current time of day from the arena and calls {@linkcode tweenTimeOfDayIcon}
-   * @param _event {@linkcode Event} being sent
+   * @param _event - being sent
    */
   private onEncounterPhase(_event: Event) {
     const newTime = globalScene.arena.getTimeOfDay();

--- a/src/ui/ui-handler.ts
+++ b/src/ui/ui-handler.ts
@@ -13,7 +13,7 @@ export default abstract class UiHandler {
   public active = false;
 
   /**
-   * @param mode The mode of the UI element. These should be unique.
+   * @param mode - The mode of the UI element. These should be unique.
    */
   constructor(mode: UiMode | null = null) {
     this.mode = mode;
@@ -53,7 +53,7 @@ export default abstract class UiHandler {
   /**
    * Changes the style of the mouse cursor.
    * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/cursor}
-   * @param cursorStyle cursor style to apply
+   * @param cursorStyle - cursor style to apply
    */
   protected setMouseCursorStyle(cursorStyle: "pointer" | "default") {
     globalScene.input.manager.canvas.style.cursor = cursorStyle;

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -250,7 +250,7 @@ export default class UI extends Phaser.GameObjects.Container {
 
   /**
    * Process a player input of a button (delivering it to the current UI handler for processing)
-   * @param button The {@linkcode Button} being inputted
+   * @param button - The {@linkcode Button} being inputted
    * @returns true if the input attempt succeeds
    */
   processInput(button: Button): boolean {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -76,8 +76,8 @@ export function padInt(value: number, length: number, padWith?: string): string 
 
 /**
  * Returns a random integer between min and min + range
- * @param range The amount of possible numbers
- * @param min The starting number
+ * @param range - The amount of possible numbers
+ * @param min - The starting number
  */
 export function randInt(range: number, min = 0): number {
   if (range === 1) {
@@ -88,8 +88,8 @@ export function randInt(range: number, min = 0): number {
 
 /**
  * Generates a random number using the global seed, or the current battle's seed if called via `Battle.randSeedInt`
- * @param range How large of a range of random numbers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
- * @param min The minimum integer to pick, default `0`
+ * @param range - How large of a range of random numbers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
+ * @param min - The minimum integer to pick, default `0`
  * @returns A random integer between {@linkcode min} and ({@linkcode min} + {@linkcode range} - 1)
  */
 export function randSeedInt(range: number, min = 0): number {
@@ -101,8 +101,8 @@ export function randSeedInt(range: number, min = 0): number {
 
 /**
  * Returns a random integer between min and max (non-inclusive)
- * @param min The lowest number
- * @param max The highest number
+ * @param min - The lowest number
+ * @param max - The highest number
  */
 export function randIntRange(min: number, max: number): number {
   return randInt(max - min, min);
@@ -122,7 +122,7 @@ export function randSeedWeightedItem<T>(items: T[]): T {
 
 /**
  * Shuffle a list using the seeded rng. Utilises the Fisher-Yates algorithm.
- * @param {Array} items An array of items.
+ * @param items - An array of items.
  * @returns {Array} A new shuffled array of items.
  */
 export function randSeedShuffle<T>(items: T[]): T[] {
@@ -160,7 +160,7 @@ export function getPlayTimeString(totalSeconds: number): string {
 /**
  * Generates IVs from a given {@linkcode id} by extracting 5 bits at a time
  * starting from the least significant bit up to the 30th most significant bit.
- * @param id 32-bit number
+ * @param id - 32-bit number
  * @returns An array of six numbers corresponding to 5-bit chunks from {@linkcode id}
  */
 export function getIvsFromId(id: number): number[] {
@@ -322,7 +322,7 @@ export function fixedInt(value: number): number {
 
 /**
  * Formats a string to title case
- * @param unformattedText Text to be formatted
+ * @param unformattedText - Text to be formatted
  * @returns the formatted string
  */
 export function formatText(unformattedText: string): string {
@@ -354,8 +354,8 @@ export function rgbToHsv(r: number, g: number, b: number) {
 
 /**
  * Compare color difference in RGB
- * @param {Array} rgb1 First RGB color in array
- * @param {Array} rgb2 Second RGB color in array
+ * @param rgb1 - First RGB color in array
+ * @param rgb2 - Second RGB color in array
  */
 export function deltaRgb(rgb1: number[], rgb2: number[]): number {
   const [r1, g1, b1] = rgb1;
@@ -390,9 +390,9 @@ export function rgbaToInt(rgba: number[]): number {
  * HSV color's corresponding hex code.
  *
  * Sourced from {@link https://stackoverflow.com/a/44134328}.
- * @param h Hue in degrees, must be in a range of [0, 360]
- * @param s Saturation percentage, must be in a range of [0, 1]
- * @param l Ligthness percentage, must be in a range of [0, 1]
+ * @param h - Hue in degrees, must be in a range of [0, 360]
+ * @param s - Saturation percentage, must be in a range of [0, 1]
+ * @param l - Ligthness percentage, must be in a range of [0, 1]
  * @returns a string of the corresponding color hex code with a "#" prefix
  */
 export function hslToHex(h: number, s: number, l: number): string {
@@ -440,7 +440,7 @@ export function hasAllLocalizedSprites(lang?: string): boolean {
 
 /**
  * Prints the type and name of all game objects in a container for debugging purposes
- * @param container container with game objects inside it
+ * @param container - container with game objects inside it
  */
 export function printContainerList(container: Phaser.GameObjects.Container): void {
   console.log(
@@ -542,7 +542,7 @@ export function toDmgValue(value: number, minValue = 1) {
 
 /**
  * Helper method to localize a sprite key (e.g. for types)
- * @param baseKey the base key of the sprite (e.g. `type`)
+ * @param baseKey - the base key of the sprite (e.g. `type`)
  * @returns the localized sprite key
  */
 export function getLocalizedSpriteKey(baseKey: string) {
@@ -551,9 +551,9 @@ export function getLocalizedSpriteKey(baseKey: string) {
 
 /**
  * Check if a number is **inclusive** between two numbers
- * @param num the number to check
- * @param min the minimum value (included)
- * @param max the maximum value (included)
+ * @param num - the number to check
+ * @param min - the minimum value (included)
+ * @param max - the maximum value (included)
  * @returns `true` if number is **inclusive** between min and max
  */
 export function isBetween(num: number, min: number, max: number): boolean {
@@ -563,7 +563,7 @@ export function isBetween(num: number, min: number, max: number): boolean {
 /**
  * Helper method to return the animation filename for a given move
  *
- * @param move the move for which the animation filename is needed
+ * @param move - the move for which the animation filename is needed
  */
 export function animationFileName(move: Moves): string {
   return Moves[move].toLowerCase().replace(/\_/g, "-");
@@ -571,7 +571,7 @@ export function animationFileName(move: Moves): string {
 
 /**
  * Transforms a camelCase string into a kebab-case string
- * @param str The camelCase string
+ * @param str - The camelCase string
  * @returns A kebab-case string
  *
  * @source {@link https://stackoverflow.com/a/67243723/}


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
@DayKev pointed out that `-` is required after the parameter name in tsdoc. I hadn't actually looked at the tsdoc specification. I found that there were many instances in our codebase where we were using invalid tsdoc syntax. tsdoc is not jsdoc.

## What are the changes from a developer perspective?
Removed all jsdoc type annotations from doc comments.
Added necessary hyphens after method names
Did some cleanup and minor consistency rewrites for doc comments, but quickly grew weary and there is still more to do. But this PR is already quite large and I don't want it to conflict.

## Screenshots/Videos
N/A

## How to test the changes?
N/A
## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~~[ ] Have I tested the changes manually?~~
- [x] Are all unit tests still passing? (`npm run test`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~