### PR TITLE
[Dev] Fix imports in `overrides.ts` and `illusion.test.ts`

### DIFF
--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -2,10 +2,11 @@ import { type PokeballCounts } from "#app/battle-scene";
 import { EvolutionItem } from "#app/data/balance/pokemon-evolutions";
 import { Gender } from "#app/data/gender";
 import { FormChangeItem } from "#app/data/pokemon-forms";
-import { Variant } from "#app/sprites/variant";
 import { type ModifierOverride } from "#app/modifier/modifier-type";
+import { Variant } from "#app/sprites/variant";
 import { Unlockables } from "#app/system/unlockables";
 import { Abilities } from "#enums/abilities";
+import { BattleType } from "#enums/battle-type";
 import { BerryType } from "#enums/berry-type";
 import { Biome } from "#enums/biome";
 import { EggTier } from "#enums/egg-type";
@@ -15,13 +16,12 @@ import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { PokeballType } from "#enums/pokeball";
 import { PokemonType } from "#enums/pokemon-type";
 import { Species } from "#enums/species";
-import { BATTLE_STATS, Stat } from "#enums/stat";
+import { Stat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
 import { TimeOfDay } from "#enums/time-of-day";
+import { TrainerType } from "#enums/trainer-type";
 import { VariantTier } from "#enums/variant-tier";
 import { WeatherType } from "#enums/weather-type";
-import { TrainerType } from "#enums/trainer-type";
-import { BattleType } from "#enums/battle-type";
 
 /**
  * This comment block exists to prevent IDEs from automatically removing unused imports

--- a/test/abilities/illusion.test.ts
+++ b/test/abilities/illusion.test.ts
@@ -1,13 +1,11 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import Phaser from "phaser";
-import GameManager from "#test/testUtils/gameManager";
-import { Species } from "#enums/species";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
-import { Moves } from "#enums/moves";
-import { Abilities } from "#enums/abilities";
-import { PokeballType } from "#app/enums/pokeball";
 import { Gender } from "#app/data/gender";
-import { BerryPhase } from "#app/phases/berry-phase";
+import { PokeballType } from "#app/enums/pokeball";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import GameManager from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Abilities - Illusion", () => {
   let phaserGame: Phaser.Game;
@@ -48,7 +46,7 @@ describe("Abilities - Illusion", () => {
     await game.classicMode.startBattle([Species.AXEW]);
     game.move.select(Moves.TACKLE);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     const zorua = game.scene.getEnemyPokemon()!;
 
@@ -60,7 +58,7 @@ describe("Abilities - Illusion", () => {
     await game.classicMode.startBattle([Species.AXEW]);
     game.move.select(Moves.WORRY_SEED);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     const zorua = game.scene.getEnemyPokemon()!;
 
@@ -114,7 +112,7 @@ describe("Abilities - Illusion", () => {
 
     game.move.select(Moves.FLARE_BLITZ);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     const zoroark = game.scene.getPlayerPokemon()!;
 
@@ -132,7 +130,7 @@ describe("Abilities - Illusion", () => {
 
     game.doSwitchPokemon(1);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     const zoroark = game.scene.getPlayerPokemon()!;
 
@@ -151,7 +149,7 @@ describe("Abilities - Illusion", () => {
     expect(!!zorua.summonData?.illusion).toBe(true);
 
     game.move.select(Moves.GASTRO_ACID);
-    await game.phaseInterceptor.to(BerryPhase);
+    await game.phaseInterceptor.to("BerryPhase");
 
     expect(zorua.isFullHp()).toBe(true);
     expect(!!zorua.summonData?.illusion).toBe(false);


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
An extra import was accidentally committed to the `overrides.ts` file.

## What are the changes from a developer perspective?
Unused import removed from `overrides.ts` and "organize imports" applied.
Unnecessary imports removed from `illusion.test.ts` and "organize imports" applied.

## How to test the changes?
`npm run test:silent`
Start the game and see if it boots up.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?