### PR TITLE
[Bug][Sprite] Fix variants not using recolors for back sprite

### DIFF
--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -404,7 +404,7 @@ export abstract class PokemonSpeciesForm {
   }
 
   /** Compute the sprite ID of the pokemon form. */
-  getSpriteId(female: boolean, formIndex?: number, shiny?: boolean, variant = 0, back?: boolean): string {
+  getSpriteId(female: boolean, formIndex?: number, shiny?: boolean, variant = 0, back = false): string {
     const baseSpriteKey = this.getBaseSpriteKey(female, formIndex);
 
     let config = variantData;
@@ -598,11 +598,21 @@ export abstract class PokemonSpeciesForm {
    * Load the variant colors for the species into the variant color cache
    *
    * @param spriteKey - The sprite key to use
-   * @param female - Whether to get
+   * @param female - Whether to load female instead of male
+   * @param back - Whether the back sprite is being loaded
    *
    */
-  async loadVariantColors(spriteKey: string, female: boolean, variant: Variant, formIndex?: number): Promise<void> {
-    const baseSpriteKey = this.getBaseSpriteKey(female, formIndex);
+  async loadVariantColors(
+    spriteKey: string,
+    female: boolean,
+    variant: Variant,
+    back = false,
+    formIndex?: number,
+  ): Promise<void> {
+    let baseSpriteKey = this.getBaseSpriteKey(female, formIndex);
+    if (back) {
+      baseSpriteKey = "back__" + baseSpriteKey;
+    }
 
     if (variantColorCache.hasOwnProperty(baseSpriteKey)) {
       // Variant colors have already been loaded
@@ -618,7 +628,7 @@ export abstract class PokemonSpeciesForm {
     await populateVariantColorCache(
       "pkmn__" + baseSpriteKey,
       globalScene.experimentalSprites && hasExpSprite(spriteKey),
-      baseSpriteKey,
+      baseSpriteKey.replace("__", "/"),
     );
   }
 
@@ -635,7 +645,7 @@ export abstract class PokemonSpeciesForm {
     globalScene.loadPokemonAtlas(spriteKey, this.getSpriteAtlasPath(female, formIndex, shiny, variant, back));
     globalScene.load.audio(this.getCryKey(formIndex), `audio/${this.getCryKey(formIndex)}.m4a`);
     if (!isNullOrUndefined(variant)) {
-      await this.loadVariantColors(spriteKey, female, variant, formIndex);
+      await this.loadVariantColors(spriteKey, female, variant, back, formIndex);
     }
     return new Promise<void>(resolve => {
       globalScene.load.once(Phaser.Loader.Events.COMPLETE, () => {


### PR DESCRIPTION
## What are the changes the user will see?
In the pokedex, back sprites will now show the recolors

## Why am I making these changes?
The fix for #5664 was not being applied to back sprites, as it would always assume the front sprite was loaded. This applies the same fix that #5664 did to show variant colors.

## What are the changes from a developer perspective?
Added `back` as a parameter to specify that back sprites will be loaded to `PokemonSpecies#loadVariantColors`

## Screenshots/Videos
Too lazy

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~