### PR TITLE
[Bug][Misc][Beta] Moved SelectBiomePhase in front of NewBattlePhase

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -151,7 +151,6 @@ import { NextEncounterPhase } from "#app/phases/next-encounter-phase";
 import { PokemonAnimPhase } from "#app/phases/pokemon-anim-phase";
 import { QuietFormChangePhase } from "#app/phases/quiet-form-change-phase";
 import { ReturnPhase } from "#app/phases/return-phase";
-import { SelectBiomePhase } from "#app/phases/select-biome-phase";
 import { ShowTrainerPhase } from "#app/phases/show-trainer-phase";
 import { SummonPhase } from "#app/phases/summon-phase";
 import { SwitchPhase } from "#app/phases/switch-phase";
@@ -1298,6 +1297,16 @@ export default class BattleScene extends SceneBase {
     return Math.max(doubleChance.value, 1);
   }
 
+  isNewBiome(currentBattle = this.currentBattle) {
+    const isWaveIndexMultipleOfTen = !(currentBattle.waveIndex % 10);
+    const isEndlessOrDaily = this.gameMode.hasShortBiomes || this.gameMode.isDaily;
+    const isEndlessFifthWave = this.gameMode.hasShortBiomes && currentBattle.waveIndex % 5 === 0;
+    const isWaveIndexMultipleOfFiftyMinusOne = currentBattle.waveIndex % 50 === 49;
+    const isNewBiome =
+      isWaveIndexMultipleOfTen || isEndlessFifthWave || (isEndlessOrDaily && isWaveIndexMultipleOfFiftyMinusOne);
+    return isNewBiome;
+  }
+
   // TODO: ...this never actually returns `null`, right?
   newBattle(
     waveIndex?: number,
@@ -1461,12 +1470,7 @@ export default class BattleScene extends SceneBase {
     }
 
     if (!waveIndex && lastBattle) {
-      const isWaveIndexMultipleOfTen = !(lastBattle.waveIndex % 10);
-      const isEndlessOrDaily = this.gameMode.hasShortBiomes || this.gameMode.isDaily;
-      const isEndlessFifthWave = this.gameMode.hasShortBiomes && lastBattle.waveIndex % 5 === 0;
-      const isWaveIndexMultipleOfFiftyMinusOne = lastBattle.waveIndex % 50 === 49;
-      const isNewBiome =
-        isWaveIndexMultipleOfTen || isEndlessFifthWave || (isEndlessOrDaily && isWaveIndexMultipleOfFiftyMinusOne);
+      const isNewBiome = this.isNewBiome(lastBattle);
       const resetArenaState =
         isNewBiome ||
         [BattleType.TRAINER, BattleType.MYSTERY_ENCOUNTER].includes(this.currentBattle.battleType) ||
@@ -1515,7 +1519,6 @@ export default class BattleScene extends SceneBase {
       if (!this.gameMode.hasRandomBiomes && !isNewBiome) {
         this.pushPhase(new NextEncounterPhase());
       } else {
-        this.pushPhase(new SelectBiomePhase());
         this.pushPhase(new NewBiomeEncounterPhase());
 
         const newMaxExpLevel = this.getMaxExpLevel();

--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -72,6 +72,7 @@ import type { AbAttrCondition, PokemonDefendCondition, PokemonStatStageChangeCon
 import type { BattlerIndex } from "#app/battle";
 import type Move from "#app/data/moves/move";
 import type { ArenaTrapTag, SuppressAbilitiesTag } from "#app/data/arena-tag";
+import { SelectBiomePhase } from "#app/phases/select-biome-phase";
 
 export class BlockRecoilDamageAttr extends AbAttr {
   constructor() {
@@ -5483,6 +5484,11 @@ class ForceSwitchOutHelper {
 
         if (switchOutTarget.hp) {
           globalScene.pushPhase(new BattleEndPhase(false));
+
+          if (globalScene.gameMode.hasRandomBiomes || globalScene.isNewBiome()) {
+            globalScene.pushPhase(new SelectBiomePhase());
+          }
+
           globalScene.pushPhase(new NewBattlePhase());
         }
       }

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -123,6 +123,7 @@ import { MoveEffectTrigger } from "#enums/MoveEffectTrigger";
 import { MultiHitType } from "#enums/MultiHitType";
 import { invalidAssistMoves, invalidCopycatMoves, invalidMetronomeMoves, invalidMirrorMoveMoves, invalidSleepTalkMoves } from "./invalid-moves";
 import { TrainerVariant } from "#app/field/trainer";
+import { SelectBiomePhase } from "#app/phases/select-biome-phase";
 
 type MoveConditionFunc = (user: Pokemon, target: Pokemon, move: Move) => boolean;
 type UserMoveConditionFunc = (user: Pokemon, move: Move) => boolean;
@@ -6332,6 +6333,11 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
 
       if (!allyPokemon?.isActive(true) && switchOutTarget.hp) {
           globalScene.pushPhase(new BattleEndPhase(false));
+                    
+          if (globalScene.gameMode.hasRandomBiomes || globalScene.isNewBiome()) {
+            globalScene.pushPhase(new SelectBiomePhase());
+          }
+          
           globalScene.pushPhase(new NewBattlePhase());
       }
     }

--- a/src/phases/attempt-run-phase.ts
+++ b/src/phases/attempt-run-phase.ts
@@ -14,6 +14,7 @@ import { BattleEndPhase } from "./battle-end-phase";
 import { NewBattlePhase } from "./new-battle-phase";
 import { PokemonPhase } from "./pokemon-phase";
 import { globalScene } from "#app/global-scene";
+import { SelectBiomePhase } from "./select-biome-phase";
 
 export class AttemptRunPhase extends PokemonPhase {
   /** For testing purposes: this is to force the pokemon to fail and escape */
@@ -59,6 +60,11 @@ export class AttemptRunPhase extends PokemonPhase {
       });
 
       globalScene.pushPhase(new BattleEndPhase(false));
+
+      if (globalScene.gameMode.hasRandomBiomes || globalScene.isNewBiome()) {
+        globalScene.pushPhase(new SelectBiomePhase());
+      }
+
       globalScene.pushPhase(new NewBattlePhase());
     } else {
       playerPokemon.turnData.failedRunAway = true;

--- a/src/phases/mystery-encounter-phases.ts
+++ b/src/phases/mystery-encounter-phases.ts
@@ -27,6 +27,7 @@ import { IvScannerModifier } from "../modifier/modifier";
 import { Phase } from "../phase";
 import { UiMode } from "#enums/ui-mode";
 import { isNullOrUndefined, randSeedItem } from "#app/utils/common";
+import { SelectBiomePhase } from "./select-biome-phase";
 
 /**
  * Will handle (in order):
@@ -612,6 +613,10 @@ export class PostMysteryEncounterPhase extends Phase {
    */
   continueEncounter() {
     const endPhase = () => {
+      if (globalScene.gameMode.hasRandomBiomes || globalScene.isNewBiome()) {
+        globalScene.pushPhase(new SelectBiomePhase());
+      }
+
       globalScene.pushPhase(new NewBattlePhase());
       this.end();
     };

--- a/src/phases/select-biome-phase.ts
+++ b/src/phases/select-biome-phase.ts
@@ -14,9 +14,10 @@ export class SelectBiomePhase extends BattlePhase {
     super.start();
 
     const currentBiome = globalScene.arena.biomeType;
+    const nextWaveIndex = globalScene.currentBattle.waveIndex + 1;
 
     const setNextBiome = (nextBiome: Biome) => {
-      if (globalScene.currentBattle.waveIndex % 10 === 1) {
+      if (nextWaveIndex % 10 === 1) {
         globalScene.applyModifiers(MoneyInterestModifier, true);
         globalScene.unshiftPhase(new PartyHealPhase(false));
       }
@@ -25,13 +26,13 @@ export class SelectBiomePhase extends BattlePhase {
     };
 
     if (
-      (globalScene.gameMode.isClassic && globalScene.gameMode.isWaveFinal(globalScene.currentBattle.waveIndex + 9)) ||
-      (globalScene.gameMode.isDaily && globalScene.gameMode.isWaveFinal(globalScene.currentBattle.waveIndex)) ||
-      (globalScene.gameMode.hasShortBiomes && !(globalScene.currentBattle.waveIndex % 50))
+      (globalScene.gameMode.isClassic && globalScene.gameMode.isWaveFinal(nextWaveIndex + 9)) ||
+      (globalScene.gameMode.isDaily && globalScene.gameMode.isWaveFinal(nextWaveIndex)) ||
+      (globalScene.gameMode.hasShortBiomes && !(nextWaveIndex % 50))
     ) {
       setNextBiome(Biome.END);
     } else if (globalScene.gameMode.hasRandomBiomes) {
-      setNextBiome(this.generateNextBiome());
+      setNextBiome(this.generateNextBiome(nextWaveIndex));
     } else if (Array.isArray(biomeLinks[currentBiome])) {
       const biomes: Biome[] = (biomeLinks[currentBiome] as (Biome | [Biome, number])[])
         .filter(b => !Array.isArray(b) || !randSeedInt(b[1]))
@@ -59,14 +60,14 @@ export class SelectBiomePhase extends BattlePhase {
     } else if (biomeLinks.hasOwnProperty(currentBiome)) {
       setNextBiome(biomeLinks[currentBiome] as Biome);
     } else {
-      setNextBiome(this.generateNextBiome());
+      setNextBiome(this.generateNextBiome(nextWaveIndex));
     }
   }
 
-  generateNextBiome(): Biome {
-    if (!(globalScene.currentBattle.waveIndex % 50)) {
+  generateNextBiome(waveIndex: number): Biome {
+    if (!(waveIndex % 50)) {
       return Biome.END;
     }
-    return globalScene.generateRandomBiome(globalScene.currentBattle.waveIndex);
+    return globalScene.generateRandomBiome(waveIndex);
   }
 }

--- a/src/phases/switch-biome-phase.ts
+++ b/src/phases/switch-biome-phase.ts
@@ -19,6 +19,10 @@ export class SwitchBiomePhase extends BattlePhase {
       return this.end();
     }
 
+    // Before switching biomes, make sure to set the last encounter for other phases that need it too.
+    globalScene.lastEnemyTrainer = globalScene.currentBattle?.trainer ?? null;
+    globalScene.lastMysteryEncounter = globalScene.currentBattle?.mysteryEncounter;
+
     globalScene.tweens.add({
       targets: [globalScene.arenaEnemy, globalScene.lastEnemyTrainer],
       x: "+=300",

--- a/src/phases/victory-phase.ts
+++ b/src/phases/victory-phase.ts
@@ -15,6 +15,7 @@ import { TrainerVictoryPhase } from "./trainer-victory-phase";
 import { handleMysteryEncounterVictory } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
 import { globalScene } from "#app/global-scene";
 import { timedEventManager } from "#app/global-event-manager";
+import { SelectBiomePhase } from "./select-biome-phase";
 
 export class VictoryPhase extends PokemonPhase {
   /** If true, indicates that the phase is intended for EXP purposes only, and not to continue a battle to next phase */
@@ -111,6 +112,11 @@ export class VictoryPhase extends PokemonPhase {
             globalScene.pushPhase(new AddEnemyBuffModifierPhase());
           }
         }
+
+        if (globalScene.gameMode.hasRandomBiomes || globalScene.isNewBiome()) {
+          globalScene.pushPhase(new SelectBiomePhase());
+        }
+
         globalScene.pushPhase(new NewBattlePhase());
       } else {
         globalScene.currentBattle.battleType = BattleType.CLEAR;

--- a/test/abilities/disguise.test.ts
+++ b/test/abilities/disguise.test.ts
@@ -186,7 +186,7 @@ describe("Abilities - Disguise", () => {
     await game.toNextTurn();
     game.move.select(Moves.SPLASH);
     await game.doKillOpponents();
-    await game.phaseInterceptor.to("PartyHealPhase");
+    await game.phaseInterceptor.to("QuietFormChangePhase");
 
     expect(mimikyu1.formIndex).toBe(disguisedForm);
   });


### PR DESCRIPTION
## What are the changes the user will see?
Lures now have no effect on which Biomes are offered.

## Why am I making these changes?
PRs #5645 and #5648 were aimed at removing the RNG issues that biome selection had. However this opened up an old buried issue where the amount of Lures (for the double battle rng roll) influence what biomes you will travel to or get as map options.

The only solution I could find, was to make sure the biome selection happens before the double battle roll. It is not possible to seed offset the double battle roll, as that will completely change how 2 lure encounters are generated and would be an even worse solution.

This is only a minor issue in Classic (you could redo the last wave and end with/without a lure ability mon to see if the map options are now more favourable). But it is a huge issue in Daily mode. Since it uses the same seed all day long, you would lock certainly biomes behind needing x lures and then a biome later lock one behind needing y lures.. Lures last a long time, sometimes the interesting/rare spawns require a certain amount of lures. This would cause a lot of frustration. Frustration that was already fixed/buried by Daily mode finally getting the Map as a starting item.

Also, logically it makes sense to me that you choose a biome before you start a new battle for wave x1.

## What are the changes from a developer perspective?
SelectBiomePhase is now called (when appropriate) before the NewBattlePhase. This only caused a few variables that were set in NewBattlePhase to happen too late and only one test that now failed due to waiting on the wrong phase. These have been fixed and overall it was a very minor change.

## Screenshots/Videos
No longer any changes to which biomes were selected based on lure counts.
![image](https://github.com/user-attachments/assets/62a58eaf-dba9-4d2f-bb79-9379022e0265)
![image](https://github.com/user-attachments/assets/bed49105-e9b9-43ef-b26b-634604a9bfa8)


## How to test the changes?
Manually went through Classic/Endless/Daily to see that nothing breaks. Ran all tests and those are running fine too.

And with something like this you can test that on the same seed you will get the same Map options when you add/remove the 2 lures there. (change the seed per set of tests of course). 
```ts
const overrides = {
  STARTING_HELD_ITEMS_OVERRIDE: [{name: "LURE", count: 1}, {name: "SUPER_LURE", count: 1}, {name: "MAP", count: 1}],
  STARTING_WAVE_OVERRIDE: 10,
  STARTING_BIOME_OVERRIDE: Biome.ABYSS,
  MOVESET_OVERRIDE: [Moves.BOOMBURST],
  STARTING_LEVEL_OVERRIDE: 1000,
  SEED_OVERRIDE: "sameseedpertest"
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?