### PR TITLE
[Refactor][UI/UX] Cleanup battle-info ui code

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -5,7 +5,7 @@ import { globalScene } from "#app/global-scene";
 import type { Variant } from "#app/sprites/variant";
 import { populateVariantColors, variantColorCache } from "#app/sprites/variant";
 import { variantData } from "#app/sprites/variant";
-import BattleInfo, { PlayerBattleInfo, EnemyBattleInfo } from "#app/ui/battle-info";
+import BattleInfo, { PlayerBattleInfo, EnemyBattleInfo } from "#app/ui/battle-info/battle-info";
 import type Move from "#app/data/moves/move";
 import {
   HighCritAttr,

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -5,7 +5,9 @@ import { globalScene } from "#app/global-scene";
 import type { Variant } from "#app/sprites/variant";
 import { populateVariantColors, variantColorCache } from "#app/sprites/variant";
 import { variantData } from "#app/sprites/variant";
-import BattleInfo, { PlayerBattleInfo, EnemyBattleInfo } from "#app/ui/battle-info/battle-info";
+import BattleInfo from "#app/ui/battle-info/battle-info";
+import { EnemyBattleInfo } from "#app/ui/battle-info/enemy-battle-info";
+import { PlayerBattleInfo } from "#app/ui/battle-info/player-battle-info";
 import type Move from "#app/data/moves/move";
 import {
   HighCritAttr,

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -5508,6 +5508,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 }
 
 export class PlayerPokemon extends Pokemon {
+  protected battleInfo: PlayerBattleInfo;
   public compatibleTms: Moves[];
 
   constructor(

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3349,20 +3349,8 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     return this.battleInfo.updateInfo(this, instant);
   }
 
-  /**
-   * Show or hide the type effectiveness multiplier window
-   * Passing undefined will hide the window
-   */
-  updateEffectiveness(effectiveness?: string) {
-    this.battleInfo.updateEffectiveness(effectiveness);
-  }
-
   toggleStats(visible: boolean): void {
     this.battleInfo.toggleStats(visible);
-  }
-
-  toggleFlyout(visible: boolean): void {
-    this.battleInfo.toggleFlyout(visible);
   }
 
   /**
@@ -6040,6 +6028,7 @@ export class PlayerPokemon extends Pokemon {
 }
 
 export class EnemyPokemon extends Pokemon {
+  protected battleInfo: EnemyBattleInfo;
   public trainerSlot: TrainerSlot;
   public aiType: AiType;
   public bossSegments: number;
@@ -6710,6 +6699,19 @@ export class EnemyPokemon extends Pokemon {
     }
 
     return ret;
+  }
+
+  
+  /**
+   * Show or hide the type effectiveness multiplier window
+   * Passing undefined will hide the window
+   */
+  updateEffectiveness(effectiveness?: string) {
+    this.battleInfo.updateEffectiveness(effectiveness);
+  }
+
+  toggleFlyout(visible: boolean): void {
+    this.battleInfo.toggleFlyout(visible);
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,7 @@ window.addEventListener("unhandledrejection", event => {
 const setPositionRelative = function (guideObject: Phaser.GameObjects.GameObject, x: number, y: number) {
   const offsetX = guideObject.width * (-0.5 + (0.5 - guideObject.originX));
   const offsetY = guideObject.height * (-0.5 + (0.5 - guideObject.originY));
-  this.setPosition(guideObject.x + offsetX + x, guideObject.y + offsetY + y);
+  return this.setPosition(guideObject.x + offsetX + x, guideObject.y + offsetY + y);
 };
 
 Phaser.GameObjects.Container.prototype.setPositionRelative = setPositionRelative;

--- a/src/typings/phaser/index.d.ts
+++ b/src/typings/phaser/index.d.ts
@@ -20,37 +20,37 @@ declare module "phaser" {
       /**
        * Sets this object's position relative to another object with a given offset
        */
-			setPositionRelative(guideObject: any, x: number, y: number): self;
+			setPositionRelative(guideObject: any, x: number, y: number): this;
 		}
 		interface Sprite {
       /**
        * Sets this object's position relative to another object with a given offset
        */
-			setPositionRelative(guideObject: any, x: number, y: number): self;
+			setPositionRelative(guideObject: any, x: number, y: number): this;
 		}
 		interface Image {
       /**
        * Sets this object's position relative to another object with a given offset
        */
-			setPositionRelative(guideObject: any, x: number, y: number): self;
+			setPositionRelative(guideObject: any, x: number, y: number): this;
 		}
 		interface NineSlice {
       /**
        * Sets this object's position relative to another object with a given offset
        */
-			setPositionRelative(guideObject: any, x: number, y: number): self;
+			setPositionRelative(guideObject: any, x: number, y: number): this;
 		}
 		interface Text {
       /**
        * Sets this object's position relative to another object with a given offset
        */
-			setPositionRelative(guideObject: any, x: number, y: number): self;
+			setPositionRelative(guideObject: any, x: number, y: number): this;
 		}
 		interface Rectangle {
       /**
        * Sets this object's position relative to another object with a given offset
        */
-			setPositionRelative(guideObject: any, x: number, y: number): self;
+			setPositionRelative(guideObject: any, x: number, y: number): this;
 		}
 	}
 

--- a/src/typings/phaser/index.d.ts
+++ b/src/typings/phaser/index.d.ts
@@ -20,37 +20,37 @@ declare module "phaser" {
       /**
        * Sets this object's position relative to another object with a given offset
        */
-			setPositionRelative(guideObject: any, x: number, y: number): void;
+			setPositionRelative(guideObject: any, x: number, y: number): self;
 		}
 		interface Sprite {
       /**
        * Sets this object's position relative to another object with a given offset
        */
-			setPositionRelative(guideObject: any, x: number, y: number): void;
+			setPositionRelative(guideObject: any, x: number, y: number): self;
 		}
 		interface Image {
       /**
        * Sets this object's position relative to another object with a given offset
        */
-			setPositionRelative(guideObject: any, x: number, y: number): void;
+			setPositionRelative(guideObject: any, x: number, y: number): self;
 		}
 		interface NineSlice {
       /**
        * Sets this object's position relative to another object with a given offset
        */
-			setPositionRelative(guideObject: any, x: number, y: number): void;
+			setPositionRelative(guideObject: any, x: number, y: number): self;
 		}
 		interface Text {
       /**
        * Sets this object's position relative to another object with a given offset
        */
-			setPositionRelative(guideObject: any, x: number, y: number): void;
+			setPositionRelative(guideObject: any, x: number, y: number): self;
 		}
 		interface Rectangle {
       /**
        * Sets this object's position relative to another object with a given offset
        */
-			setPositionRelative(guideObject: any, x: number, y: number): void;
+			setPositionRelative(guideObject: any, x: number, y: number): self;
 		}
 	}
 

--- a/src/ui-inputs.ts
+++ b/src/ui-inputs.ts
@@ -161,7 +161,7 @@ export class UiInputs {
 
   buttonInfo(pressed = true): void {
     if (globalScene.showMovesetFlyout) {
-      for (const p of globalScene.getField().filter(p => p?.isActive(true))) {
+      for (const p of globalScene.getEnemyField().filter(p => p?.isActive(true))) {
         p.toggleFlyout(pressed);
       }
     }

--- a/src/ui/battle-flyout.ts
+++ b/src/ui/battle-flyout.ts
@@ -1,4 +1,4 @@
-import type { default as Pokemon } from "../field/pokemon";
+import type { EnemyPokemon, default as Pokemon } from "../field/pokemon";
 import { addTextObject, TextStyle } from "./text";
 import { fixedInt } from "#app/utils/common";
 import { globalScene } from "#app/global-scene";
@@ -126,7 +126,7 @@ export default class BattleFlyout extends Phaser.GameObjects.Container {
    * Links the given {@linkcode Pokemon} and subscribes to the {@linkcode BattleSceneEventType.MOVE_USED} event
    * @param pokemon {@linkcode Pokemon} to link to this flyout
    */
-  initInfo(pokemon: Pokemon) {
+  initInfo(pokemon: EnemyPokemon) {
     this.pokemon = pokemon;
 
     this.name = `Flyout ${getPokemonNameWithAffix(this.pokemon)}`;

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -75,6 +75,49 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
     return [];
   }
 
+  /** Helper method used by the constructor to create the tera and shiny icons next to the name */
+  private constructIcons() {
+    const hitArea = new Phaser.Geom.Rectangle(0, 0, 12, 15);
+    const hitCallback = Phaser.Geom.Rectangle.Contains;
+
+    this.teraIcon = globalScene.add
+      .sprite(0, 0, "icon_tera")
+      .setName("icon_tera")
+      .setVisible(false)
+      .setOrigin(0, 0)
+      .setScale(0.5)
+      .setInteractive(hitArea, hitCallback);
+    this.teraIcon.setPositionRelative(this.nameText, 0, 2);
+
+    this.shinyIcon = globalScene.add
+      .sprite(0, 0, "shiny_star")
+      .setName("icon_shiny")
+      .setVisible(false)
+      .setOrigin(0, 0)
+      .setScale(0.5)
+      .setInteractive(hitArea, hitCallback);
+    this.shinyIcon.setPositionRelative(this.nameText, 0, 2);
+
+    this.fusionShinyIcon = globalScene.add
+      .sprite(0, 0, "shiny_star_2")
+      .setName("icon_fusion_shiny")
+      .setVisible(false)
+      .setOrigin(0, 0)
+      .setScale(0.5)
+      .copyPosition(this.shinyIcon);
+
+    this.splicedIcon = globalScene.add
+      .sprite(0, 0, "icon_spliced")
+      .setName("icon_spliced")
+      .setVisible(false)
+      .setOrigin(0, 0)
+      .setScale(0.5)
+      .setInteractive(hitArea, hitCallback);
+    this.splicedIcon.setPositionRelative(this.nameText, 0, 2);
+
+    this.add([this.teraIcon, this.shinyIcon, this.fusionShinyIcon, this.splicedIcon]);
+  }
+
   constructor(x: number, y: number, player: boolean) {
     super(globalScene, x, y);
     this.baseY = y;
@@ -111,40 +154,7 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
     this.genderText.setPositionRelative(this.nameText, 0, 2);
     this.add(this.genderText);
 
-    this.teraIcon = globalScene.add.sprite(0, 0, "icon_tera");
-    this.teraIcon.setName("icon_tera");
-    this.teraIcon.setVisible(false);
-    this.teraIcon.setOrigin(0, 0);
-    this.teraIcon.setScale(0.5);
-    this.teraIcon.setPositionRelative(this.nameText, 0, 2);
-    this.teraIcon.setInteractive(new Phaser.Geom.Rectangle(0, 0, 12, 15), Phaser.Geom.Rectangle.Contains);
-    this.add(this.teraIcon);
-
-    this.shinyIcon = globalScene.add.sprite(0, 0, "shiny_star");
-    this.shinyIcon.setName("icon_shiny");
-    this.shinyIcon.setVisible(false);
-    this.shinyIcon.setOrigin(0, 0);
-    this.shinyIcon.setScale(0.5);
-    this.shinyIcon.setPositionRelative(this.nameText, 0, 2);
-    this.shinyIcon.setInteractive(new Phaser.Geom.Rectangle(0, 0, 12, 15), Phaser.Geom.Rectangle.Contains);
-    this.add(this.shinyIcon);
-
-    this.fusionShinyIcon = globalScene.add.sprite(0, 0, "shiny_star_2");
-    this.fusionShinyIcon.setName("icon_fusion_shiny");
-    this.fusionShinyIcon.setVisible(false);
-    this.fusionShinyIcon.setOrigin(0, 0);
-    this.fusionShinyIcon.setScale(0.5);
-    this.fusionShinyIcon.setPosition(this.shinyIcon.x, this.shinyIcon.y);
-    this.add(this.fusionShinyIcon);
-
-    this.splicedIcon = globalScene.add.sprite(0, 0, "icon_spliced");
-    this.splicedIcon.setName("icon_spliced");
-    this.splicedIcon.setVisible(false);
-    this.splicedIcon.setOrigin(0, 0);
-    this.splicedIcon.setScale(0.5);
-    this.splicedIcon.setPositionRelative(this.nameText, 0, 2);
-    this.splicedIcon.setInteractive(new Phaser.Geom.Rectangle(0, 0, 12, 15), Phaser.Geom.Rectangle.Contains);
-    this.add(this.splicedIcon);
+    this.constructIcons();
 
     this.statusIndicator = globalScene.add.sprite(0, 0, getLocalizedSpriteKey("statuses"));
     this.statusIndicator.setName("icon_status");

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -68,7 +68,7 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
       .sprite(0, 0, "icon_tera")
       .setName("icon_tera")
       .setVisible(false)
-      .setOrigin(0, 0)
+      .setOrigin(0)
       .setScale(0.5)
       .setInteractive(hitArea, hitCallback);
     this.teraIcon.setPositionRelative(this.nameText, 0, 2);
@@ -77,7 +77,7 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
       .sprite(0, 0, "shiny_star")
       .setName("icon_shiny")
       .setVisible(false)
-      .setOrigin(0, 0)
+      .setOrigin(0)
       .setScale(0.5)
       .setInteractive(hitArea, hitCallback);
     this.shinyIcon.setPositionRelative(this.nameText, 0, 2);
@@ -86,7 +86,7 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
       .sprite(0, 0, "shiny_star_2")
       .setName("icon_fusion_shiny")
       .setVisible(false)
-      .setOrigin(0, 0)
+      .setOrigin(0)
       .setScale(0.5)
       .copyPosition(this.shinyIcon);
 
@@ -94,7 +94,7 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
       .sprite(0, 0, "icon_spliced")
       .setName("icon_spliced")
       .setVisible(false)
-      .setOrigin(0, 0)
+      .setOrigin(0)
       .setScale(0.5)
       .setInteractive(hitArea, hitCallback);
     this.splicedIcon.setPositionRelative(this.nameText, 0, 2);
@@ -122,55 +122,52 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
     // Initially invisible and shown via Pokemon.showInfo
     this.setVisible(false);
 
-    this.box = globalScene.add.sprite(0, 0, this.getTextureName());
-    this.box.setName("box");
-    this.box.setOrigin(1, 0.5);
+    this.box = globalScene.add.sprite(0, 0, this.getTextureName()).setName("box").setOrigin(1, 0.5);
     this.add(this.box);
 
-    this.nameText = addTextObject(player ? -115 : -124, player ? -15.2 : -11.2, "", TextStyle.BATTLE_INFO);
-    this.nameText.setName("text_name");
-    this.nameText.setOrigin(0, 0);
+    this.nameText = addTextObject(player ? -115 : -124, player ? -15.2 : -11.2, "", TextStyle.BATTLE_INFO)
+      .setName("text_name")
+      .setOrigin(0);
     this.add(this.nameText);
 
-    this.genderText = addTextObject(0, 0, "", TextStyle.BATTLE_INFO);
-    this.genderText.setName("text_gender");
-    this.genderText.setOrigin(0, 0);
+    this.genderText = addTextObject(0, 0, "", TextStyle.BATTLE_INFO).setName("text_gender").setOrigin(0);
     this.genderText.setPositionRelative(this.nameText, 0, 2);
     this.add(this.genderText);
 
     this.constructIcons();
 
-    this.statusIndicator = globalScene.add.sprite(0, 0, getLocalizedSpriteKey("statuses"));
-    this.statusIndicator.setName("icon_status");
-    this.statusIndicator.setVisible(false);
-    this.statusIndicator.setOrigin(0, 0);
+    this.statusIndicator = globalScene.add
+      .sprite(0, 0, getLocalizedSpriteKey("statuses"))
+      .setName("icon_status")
+      .setVisible(false)
+      .setOrigin(0);
     this.statusIndicator.setPositionRelative(this.nameText, 0, 11.5);
     this.add(this.statusIndicator);
 
-    this.levelContainer = globalScene.add.container(player ? -41 : -50, player ? -10 : -5);
-    this.levelContainer.setName("container_level");
+    this.levelContainer = globalScene.add.container(player ? -41 : -50, player ? -10 : -5).setName("container_level");
     this.add(this.levelContainer);
 
     const levelOverlay = globalScene.add.image(0, 0, "overlay_lv");
     this.levelContainer.add(levelOverlay);
 
-    this.hpBar = globalScene.add.image(player ? -61 : -71, player ? -1 : 4.5, "overlay_hp");
-    this.hpBar.setName("hp_bar");
-    this.hpBar.setOrigin(0);
+    this.hpBar = globalScene.add
+      .image(player ? -61 : -71, player ? -1 : 4.5, "overlay_hp")
+      .setName("hp_bar")
+      .setOrigin(0);
     this.add(this.hpBar);
 
-    this.levelNumbersContainer = globalScene.add.container(9.5, globalScene.uiTheme ? 0 : -0.5);
-    this.levelNumbersContainer.setName("container_level");
+    this.levelNumbersContainer = globalScene.add
+      .container(9.5, globalScene.uiTheme ? 0 : -0.5)
+      .setName("container_level");
     this.levelContainer.add(this.levelNumbersContainer);
 
-    this.statsContainer = globalScene.add.container(0, 0);
-    this.statsContainer.setName("container_stats");
-    this.statsContainer.setAlpha(0);
+    this.statsContainer = globalScene.add.container(0, 0).setName("container_stats").setAlpha(0);
     this.add(this.statsContainer);
 
-    this.statsBox = globalScene.add.sprite(0, 0, `${this.getTextureName()}_stats`);
-    this.statsBox.setName("box_stats");
-    this.statsBox.setOrigin(1, 0.5);
+    this.statsBox = globalScene.add
+      .sprite(0, 0, `${this.getTextureName()}_stats`)
+      .setName("box_stats")
+      .setOrigin(1, 0.5);
     this.statsContainer.add(this.statsBox);
 
     const statLabels: Phaser.GameObjects.Sprite[] = [];
@@ -202,20 +199,17 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
         statY = baseY + (!!(i % 2) === this.player ? 10 : 0); // we compare i % 2 against this.player to tell us where to place the label; because this.battleStatOrder for enemies has HP, this.battleStatOrder[1]=ATK, but for players this.battleStatOrder[0]=ATK, so this comparing i % 2 to this.player fixes this issue for us
       }
 
-      const statLabel = globalScene.add.sprite(statX, statY, "pbinfo_stat", Stat[s]);
-      statLabel.setName("icon_stat_label_" + i.toString());
-      statLabel.setOrigin(0, 0);
+      const statLabel = globalScene.add
+        .sprite(statX, statY, "pbinfo_stat", Stat[s])
+        .setName("icon_stat_label_" + i.toString())
+        .setOrigin(0);
       statLabels.push(statLabel);
       this.statValuesContainer.add(statLabel);
 
-      const statNumber = globalScene.add.sprite(
-        statX + statLabel.width,
-        statY,
-        "pbinfo_stat_numbers",
-        this.statOrder[i] !== Stat.HP ? "3" : "empty",
-      );
-      statNumber.setName("icon_stat_number_" + i.toString());
-      statNumber.setOrigin(0, 0);
+      const statNumber = globalScene.add
+        .sprite(statX + statLabel.width, statY, "pbinfo_stat_numbers", this.statOrder[i] !== Stat.HP ? "3" : "empty")
+        .setName("icon_stat_number_" + i.toString())
+        .setOrigin(0);
       this.statNumbers.push(statNumber);
       this.statValuesContainer.add(statNumber);
 
@@ -225,31 +219,22 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
       }
     }
 
-    this.type1Icon = globalScene.add.sprite(
-      player ? -139 : -15,
-      player ? -17 : -15.5,
-      `pbinfo_${player ? "player" : "enemy"}_type1`,
-    );
-    this.type1Icon.setName("icon_type_1");
-    this.type1Icon.setOrigin(0, 0);
+    this.type1Icon = globalScene.add
+      .sprite(player ? -139 : -15, player ? -17 : -15.5, `pbinfo_${player ? "player" : "enemy"}_type1`)
+      .setName("icon_type_1")
+      .setOrigin(0);
     this.add(this.type1Icon);
 
-    this.type2Icon = globalScene.add.sprite(
-      player ? -139 : -15,
-      player ? -1 : -2.5,
-      `pbinfo_${player ? "player" : "enemy"}_type2`,
-    );
-    this.type2Icon.setName("icon_type_2");
-    this.type2Icon.setOrigin(0, 0);
+    this.type2Icon = globalScene.add
+      .sprite(player ? -139 : -15, player ? -1 : -2.5, `pbinfo_${player ? "player" : "enemy"}_type2`)
+      .setName("icon_type_2")
+      .setOrigin(0);
     this.add(this.type2Icon);
 
-    this.type3Icon = globalScene.add.sprite(
-      player ? -154 : 0,
-      player ? -17 : -15.5,
-      `pbinfo_${player ? "player" : "enemy"}_type`,
-    );
-    this.type3Icon.setName("icon_type_3");
-    this.type3Icon.setOrigin(0, 0);
+    this.type3Icon = globalScene.add
+      .sprite(player ? -154 : 0, player ? -17 : -15.5, `pbinfo_${player ? "player" : "enemy"}_type`)
+      .setName("icon_type_3")
+      .setOrigin(0);
     this.add(this.type3Icon);
   }
 
@@ -423,6 +408,10 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
 
   //#region Update methods and helpers
 
+  /** Update the status icon to match the pokemon's current status
+   * @param pokemon - The pokemon object attached to this battle info
+   * @param xOffset - The offset from the name text
+   */
   updateStatusIcon(pokemon: Pokemon, xOffset = 0) {
     if (this.lastStatus !== (pokemon.status?.effect || StatusEffect.NONE)) {
       this.lastStatus = pokemon.status?.effect || StatusEffect.NONE;
@@ -434,6 +423,7 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
       this.statusIndicator.setVisible(!!this.lastStatus).setPositionRelative(this.nameText, xOffset, 11.5);
     }
   }
+
   /** Update the pokemon name inside the container ,*/
   protected updateName(name: string): boolean {
     if (this.lastName === name) {
@@ -555,8 +545,7 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
 
     const gender: Gender = pokemon.summonData?.illusion?.gender ?? pokemon.gender;
 
-    this.genderText.setText(getGenderSymbol(gender));
-    this.genderText.setColor(getGenderColor(gender));
+    this.genderText.setText(getGenderSymbol(gender)).setColor(getGenderColor(gender));
 
     const nameUpdated = this.updateName(pokemon.getNameToRender());
 
@@ -634,10 +623,6 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
         Phaser.Geom.Rectangle.Contains,
       );
     }
-  }
-
-  async updatePokemonExp(_pokemon: Pokemon, _instant: boolean, _levelDurationMultiplier): Promise<void> {
-    return;
   }
 
   setLevel(level: number): void {

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -1,5 +1,4 @@
 import type { default as Pokemon } from "../../field/pokemon";
-import { getLevelRelExp } from "../../data/exp";
 import { getLocalizedSpriteKey, fixedInt, getShinyDescriptor } from "#app/utils/common";
 import { addTextObject, TextStyle } from "../text";
 import { getGenderSymbol, getGenderColor, Gender } from "../../data/gender";
@@ -10,7 +9,6 @@ import { PokemonType } from "#enums/pokemon-type";
 import { getVariantTint } from "#app/sprites/variant";
 import { Stat } from "#enums/stat";
 import i18next from "i18next";
-import { ExpGainsSpeed } from "#app/enums/exp-gains-speed";
 
 export default abstract class BattleInfo extends Phaser.GameObjects.Container {
   public static readonly EXP_GAINS_DURATION_BASE = 1650;
@@ -403,43 +401,7 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
     return `pbinfo_${this.player ? "player" : "enemy"}${!this.player && this.boss ? "_boss" : this.mini ? "_mini" : ""}`;
   }
 
-  setMini(mini: boolean): void {
-    if (this.mini === mini) {
-      return;
-    }
-
-    this.mini = mini;
-
-    this.box.setTexture(this.getTextureName());
-    this.statsBox.setTexture(`${this.getTextureName()}_stats`);
-
-    if (this.player) {
-      this.y -= 12 * (mini ? 1 : -1);
-      this.baseY = this.y;
-    }
-
-    const offsetElements = [
-      this.nameText,
-      this.genderText,
-      this.teraIcon,
-      this.splicedIcon,
-      this.shinyIcon,
-      this.statusIndicator,
-      this.levelContainer,
-    ];
-    offsetElements.forEach(el => (el.y += 1.5 * (mini ? -1 : 1)));
-
-    [this.type1Icon, this.type2Icon, this.type3Icon].forEach(el => {
-      el.x += 4 * (mini ? 1 : -1);
-      el.y += -8 * (mini ? 1 : -1);
-    });
-
-    this.statValuesContainer.x += 2 * (mini ? 1 : -1);
-    this.statValuesContainer.y += -7 * (mini ? 1 : -1);
-
-    const toggledElements = [this.hpNumbersContainer, this.expBar];
-    toggledElements.forEach(el => el.setVisible(!mini));
-  }
+  setMini(_mini: boolean): void {}
 
   toggleStats(visible: boolean): void {
     globalScene.tweens.add({
@@ -678,69 +640,8 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
     }
   }
 
-  updatePokemonExp(pokemon: Pokemon, instant?: boolean, levelDurationMultiplier = 1): Promise<void> {
-    return new Promise(resolve => {
-      const levelUp = this.lastLevel < pokemon.level;
-      const relLevelExp = getLevelRelExp(this.lastLevel + 1, pokemon.species.growthRate);
-      const levelExp = levelUp ? relLevelExp : pokemon.levelExp;
-      let ratio = relLevelExp ? levelExp / relLevelExp : 0;
-      if (this.lastLevel >= globalScene.getMaxExpLevel(true)) {
-        if (levelUp) {
-          ratio = 1;
-        } else {
-          ratio = 0;
-        }
-        instant = true;
-      }
-      const durationMultiplier = Phaser.Tweens.Builders.GetEaseFunction("Sine.easeIn")(
-        1 - Math.max(this.lastLevel - 100, 0) / 150,
-      );
-      let duration =
-        this.visible && !instant
-          ? ((levelExp - this.lastLevelExp) / relLevelExp) *
-            BattleInfo.EXP_GAINS_DURATION_BASE *
-            durationMultiplier *
-            levelDurationMultiplier
-          : 0;
-      const speed = globalScene.expGainsSpeed;
-      if (speed && speed >= ExpGainsSpeed.DEFAULT) {
-        duration = speed >= ExpGainsSpeed.SKIP ? ExpGainsSpeed.DEFAULT : duration / Math.pow(2, speed);
-      }
-      if (ratio === 1) {
-        this.lastLevelExp = 0;
-        this.lastLevel++;
-      } else {
-        this.lastExp = pokemon.exp;
-        this.lastLevelExp = pokemon.levelExp;
-      }
-      if (duration) {
-        globalScene.playSound("se/exp");
-      }
-      globalScene.tweens.add({
-        targets: this.expMaskRect,
-        ease: "Sine.easeIn",
-        x: ratio * 510,
-        duration: duration,
-        onComplete: () => {
-          if (!globalScene) {
-            return resolve();
-          }
-          if (duration) {
-            globalScene.sound.stopByKey("se/exp");
-          }
-          if (ratio === 1) {
-            globalScene.playSound("se/level_up");
-            this.setLevel(this.lastLevel);
-            globalScene.time.delayedCall(500 * levelDurationMultiplier, () => {
-              this.expMaskRect.x = 0;
-              this.updateInfo(pokemon, instant).then(() => resolve());
-            });
-            return;
-          }
-          resolve();
-        },
-      });
-    });
+  async updatePokemonExp(_pokemon: Pokemon, _instant: boolean, _levelDurationMultiplier): Promise<void> {
+    return;
   }
 
   setLevel(level: number): void {
@@ -773,11 +674,11 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
   }
 
   updateStats(stats: number[]): void {
-    this.statOrder.map((s, i) => {
+    for (const [i, s] of this.statOrder.entries()) {
       if (s !== Stat.HP) {
         this.statNumbers[i].setFrame(stats[s - 1].toString());
       }
-    });
+    }
   }
 
   getBaseY(): number {

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -410,7 +410,8 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
 
   //#region Update methods and helpers
 
-  /** Update the status icon to match the pokemon's current status
+  /**
+   * Update the status icon to match the pokemon's current status
    * @param pokemon - The pokemon object attached to this battle info
    * @param xOffset - The offset from the name text
    */

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -46,7 +46,6 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
   protected statusIndicator: Phaser.GameObjects.Sprite;
   protected levelContainer: Phaser.GameObjects.Container;
   protected hpBar: Phaser.GameObjects.Image;
-  protected hpBarSegmentDividers: Phaser.GameObjects.Rectangle[];
   protected levelNumbersContainer: Phaser.GameObjects.Container;
   protected hpNumbersContainer: Phaser.GameObjects.Container;
   protected type1Icon: Phaser.GameObjects.Sprite;
@@ -164,8 +163,6 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
     this.hpBar.setName("hp_bar");
     this.hpBar.setOrigin(0);
     this.add(this.hpBar);
-
-    this.hpBarSegmentDividers = [];
 
     this.levelNumbersContainer = globalScene.add.container(9.5, globalScene.uiTheme ? 0 : -0.5);
     this.levelNumbersContainer.setName("container_level");

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -970,17 +970,3 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
     this.y = this.baseY;
   }
 }
-
-export class PlayerBattleInfo extends BattleInfo {
-  constructor() {
-    super(Math.floor(globalScene.game.canvas.width / 6) - 10, -72, true);
-  }
-}
-
-export class EnemyBattleInfo extends BattleInfo {
-  constructor() {
-    super(140, -141, false);
-  }
-
-  setMini(_mini: boolean): void {} // Always mini
-}

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -9,7 +9,6 @@ import { getTypeRgb } from "#app/data/type";
 import { PokemonType } from "#enums/pokemon-type";
 import { getVariantTint } from "#app/sprites/variant";
 import { Stat } from "#enums/stat";
-import type BattleFlyout from "../battle-flyout";
 import i18next from "i18next";
 import { ExpGainsSpeed } from "#app/enums/exp-gains-speed";
 
@@ -55,21 +54,12 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
   protected type3Icon: Phaser.GameObjects.Sprite;
   protected expBar: Phaser.GameObjects.Image;
 
-  // #region Type effectiveness hint objects
-  protected effectivenessContainer: Phaser.GameObjects.Container;
-  protected effectivenessWindow: Phaser.GameObjects.NineSlice;
-  protected effectivenessText: Phaser.GameObjects.Text;
-  protected currentEffectiveness?: string;
-  // #endregion
-
   public expMaskRect: Phaser.GameObjects.Graphics;
 
   protected statsContainer: Phaser.GameObjects.Container;
   protected statsBox: Phaser.GameObjects.Sprite;
   protected statValuesContainer: Phaser.GameObjects.Container;
   protected statNumbers: Phaser.GameObjects.Sprite[];
-
-  public flyoutMenu?: BattleFlyout;
 
   get statOrder(): Stat[] {
     return [];
@@ -281,8 +271,6 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
 
     this.name = pokemon.getNameToRender();
     this.box.name = pokemon.getNameToRender();
-
-    this.flyoutMenu?.initInfo(pokemon);
 
     this.genderText.setText(getGenderSymbol(pokemon.gender));
     this.genderText.setColor(getGenderColor(pokemon.gender));
@@ -875,39 +863,6 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
         this.statNumbers[i].setFrame(stats[s - 1].toString());
       }
     });
-  }
-
-  /**
-   * Request the flyoutMenu to toggle if available and hides or shows the effectiveness window where necessary
-   */
-  toggleFlyout(visible: boolean): void {
-    this.flyoutMenu?.toggleFlyout(visible);
-
-    if (visible) {
-      this.effectivenessContainer?.setVisible(false);
-    } else {
-      this.updateEffectiveness(this.currentEffectiveness);
-    }
-  }
-
-  /**
-   * Show or hide the type effectiveness multiplier window
-   * Passing undefined will hide the window
-   */
-  updateEffectiveness(effectiveness?: string) {
-    if (this.player) {
-      return;
-    }
-    this.currentEffectiveness = effectiveness;
-
-    if (!globalScene.typeHints || effectiveness === undefined || this.flyoutMenu?.flyoutVisible) {
-      this.effectivenessContainer.setVisible(false);
-      return;
-    }
-
-    this.effectivenessText.setText(effectiveness);
-    this.effectivenessWindow.width = 10 + this.effectivenessText.displayWidth;
-    this.effectivenessContainer.setVisible(true);
   }
 
   getBaseY(): number {

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -264,7 +264,8 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
       .on("pointerout", () => globalScene.ui.hideTooltip());
   }
 
-  /** Called by {@linkcode initInfo} to initialize the shiny icon
+  /**
+   * Called by {@linkcode initInfo} to initialize the shiny icon
    * @param pokemon - The pokemon object attached to this battle info
    * @param baseXOffset - The x offset to use for the shiny icon
    * @param doubleShiny - Whether the pokemon is shiny and its fusion species is also shiny
@@ -379,9 +380,10 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
   }
   //#endregion
 
-  getTextureName(): string {
-    return `pbinfo_${this.player ? "player" : "enemy"}${!this.player && this.boss ? "_boss" : this.mini ? "_mini" : ""}`;
-  }
+  /**
+   * Return the texture name of the battle info box
+   */
+  abstract getTextureName(): string;
 
   setMini(_mini: boolean): void {}
 
@@ -424,7 +426,7 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
     }
   }
 
-  /** Update the pokemon name inside the container ,*/
+  /** Update the pokemon name inside the container */
   protected updateName(name: string): boolean {
     if (this.lastName === name) {
       return false;

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -30,7 +30,7 @@ export type BattleInfoParamList = {
   statBox: {
     /** The starting offset from the left of the label for the entries in the stat box */
     xOffset: number;
-    /** The X between each number */
+    /** The X padding between each number column */
     paddingX: number;
     /** The index of the stat entries at which paddingX is used instead of startingX */
     statOverflow: number;

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -98,8 +98,8 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
       .setVisible(false)
       .setOrigin(0)
       .setScale(0.5)
-      .setInteractive(hitArea, hitCallback);
-    this.teraIcon.setPositionRelative(this.nameText, 0, 2);
+      .setInteractive(hitArea, hitCallback)
+      .setPositionRelative(this.nameText, 0, 2);
 
     this.shinyIcon = globalScene.add
       .sprite(0, 0, "shiny_star")
@@ -107,8 +107,8 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
       .setVisible(false)
       .setOrigin(0)
       .setScale(0.5)
-      .setInteractive(hitArea, hitCallback);
-    this.shinyIcon.setPositionRelative(this.nameText, 0, 2);
+      .setInteractive(hitArea, hitCallback)
+      .setPositionRelative(this.nameText, 0, 2);
 
     this.fusionShinyIcon = globalScene.add
       .sprite(0, 0, "shiny_star_2")
@@ -124,8 +124,8 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
       .setVisible(false)
       .setOrigin(0)
       .setScale(0.5)
-      .setInteractive(hitArea, hitCallback);
-    this.splicedIcon.setPositionRelative(this.nameText, 0, 2);
+      .setInteractive(hitArea, hitCallback)
+      .setPositionRelative(this.nameText, 0, 2);
 
     this.add([this.teraIcon, this.shinyIcon, this.fusionShinyIcon, this.splicedIcon]);
   }
@@ -235,8 +235,10 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
       .setOrigin(0);
     this.add(this.nameText);
 
-    this.genderText = addTextObject(0, 0, "", TextStyle.BATTLE_INFO).setName("text_gender").setOrigin(0);
-    this.genderText.setPositionRelative(this.nameText, 0, 2);
+    this.genderText = addTextObject(0, 0, "", TextStyle.BATTLE_INFO)
+      .setName("text_gender")
+      .setOrigin(0)
+      .setPositionRelative(this.nameText, 0, 2);
     this.add(this.genderText);
 
     this.constructIcons();
@@ -245,8 +247,8 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
       .sprite(0, 0, getLocalizedSpriteKey("statuses"))
       .setName("icon_status")
       .setVisible(false)
-      .setOrigin(0);
-    this.statusIndicator.setPositionRelative(this.nameText, 0, 11.5);
+      .setOrigin(0)
+      .setPositionRelative(this.nameText, 0, 11.5);
     this.add(this.statusIndicator);
 
     this.levelContainer = globalScene.add

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -13,7 +13,7 @@ import type BattleFlyout from "../battle-flyout";
 import i18next from "i18next";
 import { ExpGainsSpeed } from "#app/enums/exp-gains-speed";
 
-export default class BattleInfo extends Phaser.GameObjects.Container {
+export default abstract class BattleInfo extends Phaser.GameObjects.Container {
   public static readonly EXP_GAINS_DURATION_BASE = 1650;
 
   protected baseY: number;
@@ -71,18 +71,9 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
 
   public flyoutMenu?: BattleFlyout;
 
-  protected statOrder: Stat[];
-  protected readonly statOrderPlayer = [Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.ACC, Stat.EVA, Stat.SPD];
-  protected readonly statOrderEnemy = [
-    Stat.HP,
-    Stat.ATK,
-    Stat.DEF,
-    Stat.SPATK,
-    Stat.SPDEF,
-    Stat.ACC,
-    Stat.EVA,
-    Stat.SPD,
-  ];
+  get statOrder(): Stat[] {
+    return [];
+  }
 
   constructor(x: number, y: number, player: boolean) {
     super(globalScene, x, y);
@@ -201,9 +192,8 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
     const startingX = this.player ? -this.statsBox.width + 8 : -this.statsBox.width + 5;
     const paddingX = this.player ? 4 : 2;
     const statOverflow = this.player ? 1 : 0;
-    this.statOrder = this.player ? this.statOrderPlayer : this.statOrderEnemy; // this tells us whether or not to use the player or enemy battle stat order
 
-    this.statOrder.map((s, i) => {
+    for (const [i, s] of this.statOrder.entries()) {
       // we do a check for i > statOverflow to see when the stat labels go onto the next column
       // For enemies, we have HP (i=0) by itself then a new column, so we check for i > 0
       // For players, we don't have HP, so we start with i = 0 and i = 1 for our first column, and so need to check for i > 1
@@ -241,7 +231,7 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
         statLabel.setVisible(false);
         statNumber.setVisible(false);
       }
-    });
+    }
 
     this.type1Icon = globalScene.add.sprite(
       player ? -139 : -15,

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -1,16 +1,16 @@
-import type { EnemyPokemon, default as Pokemon } from "../field/pokemon";
-import { getLevelTotalExp, getLevelRelExp } from "../data/exp";
+import type { EnemyPokemon, default as Pokemon } from "../../field/pokemon";
+import { getLevelTotalExp, getLevelRelExp } from "../../data/exp";
 import { getLocalizedSpriteKey, fixedInt } from "#app/utils/common";
-import { addTextObject, TextStyle } from "./text";
-import { getGenderSymbol, getGenderColor, Gender } from "../data/gender";
+import { addTextObject, TextStyle } from "../text";
+import { getGenderSymbol, getGenderColor, Gender } from "../../data/gender";
 import { StatusEffect } from "#enums/status-effect";
 import { globalScene } from "#app/global-scene";
 import { getTypeRgb } from "#app/data/type";
 import { PokemonType } from "#enums/pokemon-type";
 import { getVariantTint } from "#app/sprites/variant";
 import { Stat } from "#enums/stat";
-import BattleFlyout from "./battle-flyout";
-import { WindowVariant, addWindow } from "./ui-theme";
+import BattleFlyout from "../battle-flyout";
+import { WindowVariant, addWindow } from "../ui-theme";
 import i18next from "i18next";
 import { ExpGainsSpeed } from "#app/enums/exp-gains-speed";
 

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -1,4 +1,4 @@
-import type { EnemyPokemon, default as Pokemon } from "../../field/pokemon";
+import type { default as Pokemon } from "../../field/pokemon";
 import { getLevelTotalExp, getLevelRelExp } from "../../data/exp";
 import { getLocalizedSpriteKey, fixedInt } from "#app/utils/common";
 import { addTextObject, TextStyle } from "../text";
@@ -345,48 +345,6 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
       this.fusionShinyIcon.setTint(getVariantTint(pokemon.fusionVariant));
     }
 
-    if (!this.player) {
-      if (this.nameText.visible) {
-        this.nameText.on("pointerover", () =>
-          globalScene.ui.showTooltip(
-            "",
-            i18next.t("battleInfo:generation", {
-              generation: i18next.t(`starterSelectUiHandler:gen${pokemon.species.generation}`),
-            }),
-          ),
-        );
-        this.nameText.on("pointerout", () => globalScene.ui.hideTooltip());
-      }
-
-      const dexEntry = globalScene.gameData.dexData[pokemon.species.speciesId];
-      this.ownedIcon.setVisible(!!dexEntry.caughtAttr);
-      const opponentPokemonDexAttr = pokemon.getDexAttr();
-      if (globalScene.gameMode.isClassic) {
-        if (
-          globalScene.gameData.starterData[pokemon.species.getRootSpeciesId()].classicWinCount > 0 &&
-          globalScene.gameData.starterData[pokemon.species.getRootSpeciesId(true)].classicWinCount > 0
-        ) {
-          this.championRibbon.setVisible(true);
-        }
-      }
-
-      // Check if Player owns all genders and forms of the Pokemon
-      const missingDexAttrs = (dexEntry.caughtAttr & opponentPokemonDexAttr) < opponentPokemonDexAttr;
-
-      const ownedAbilityAttrs = globalScene.gameData.starterData[pokemon.species.getRootSpeciesId()].abilityAttr;
-
-      // Check if the player owns ability for the root form
-      const playerOwnsThisAbility = pokemon.checkIfPlayerHasAbilityOfStarter(ownedAbilityAttrs);
-
-      if (missingDexAttrs || !playerOwnsThisAbility) {
-        this.ownedIcon.setTint(0x808080);
-      }
-
-      if (this.boss) {
-        this.updateBossSegmentDividers(pokemon as EnemyPokemon);
-      }
-    }
-
     this.hpBar.setScale(pokemon.getHpRatio(true), 1);
     this.lastHpFrame = this.hpBar.scaleX > 0.5 ? "high" : this.hpBar.scaleX > 0.25 ? "medium" : "low";
     this.hpBar.setFrame(this.lastHpFrame);
@@ -476,63 +434,6 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
       ease: "Sine.easeInOut",
       alpha: visible ? 1 : 0,
     });
-  }
-
-  updateBossSegments(pokemon: EnemyPokemon): void {
-    const boss = !!pokemon.bossSegments;
-
-    if (boss !== this.boss) {
-      this.boss = boss;
-
-      [
-        this.nameText,
-        this.genderText,
-        this.teraIcon,
-        this.splicedIcon,
-        this.shinyIcon,
-        this.ownedIcon,
-        this.championRibbon,
-        this.statusIndicator,
-        this.statValuesContainer,
-      ].map(e => (e.x += 48 * (boss ? -1 : 1)));
-      this.hpBar.x += 38 * (boss ? -1 : 1);
-      this.hpBar.y += 2 * (this.boss ? -1 : 1);
-      this.levelContainer.x += 2 * (boss ? -1 : 1);
-      this.hpBar.setTexture(`overlay_hp${boss ? "_boss" : ""}`);
-      this.box.setTexture(this.getTextureName());
-      this.statsBox.setTexture(`${this.getTextureName()}_stats`);
-    }
-
-    this.bossSegments = boss ? pokemon.bossSegments : 0;
-    this.updateBossSegmentDividers(pokemon);
-  }
-
-  updateBossSegmentDividers(pokemon: EnemyPokemon): void {
-    while (this.hpBarSegmentDividers.length) {
-      this.hpBarSegmentDividers.pop()?.destroy();
-    }
-
-    if (this.boss && this.bossSegments > 1) {
-      const uiTheme = globalScene.uiTheme;
-      const maxHp = pokemon.getMaxHp();
-      for (let s = 1; s < this.bossSegments; s++) {
-        const dividerX = (Math.round((maxHp / this.bossSegments) * s) / maxHp) * this.hpBar.width;
-        const divider = globalScene.add.rectangle(
-          0,
-          0,
-          1,
-          this.hpBar.height - (uiTheme ? 0 : 1),
-          pokemon.bossSegmentIndex >= s ? 0xffffff : 0x404040,
-        );
-        divider.setOrigin(0.5, 0);
-        divider.setName("hpBar_divider_" + s.toString());
-        this.add(divider);
-        this.moveBelow(divider as Phaser.GameObjects.GameObject, this.statsContainer);
-
-        divider.setPositionRelative(this.hpBar, dividerX, uiTheme ? 0 : 1);
-        this.hpBarSegmentDividers.push(divider);
-      }
-    }
   }
 
   setOffset(offset: boolean): void {

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -9,72 +9,80 @@ import { getTypeRgb } from "#app/data/type";
 import { PokemonType } from "#enums/pokemon-type";
 import { getVariantTint } from "#app/sprites/variant";
 import { Stat } from "#enums/stat";
-import BattleFlyout from "../battle-flyout";
-import { WindowVariant, addWindow } from "../ui-theme";
+import type BattleFlyout from "../battle-flyout";
 import i18next from "i18next";
 import { ExpGainsSpeed } from "#app/enums/exp-gains-speed";
 
 export default class BattleInfo extends Phaser.GameObjects.Container {
   public static readonly EXP_GAINS_DURATION_BASE = 1650;
 
-  private baseY: number;
+  protected baseY: number;
 
-  private player: boolean;
-  private mini: boolean;
-  private boss: boolean;
-  private bossSegments: number;
-  private offset: boolean;
-  private lastName: string | null;
-  private lastTeraType: PokemonType;
-  private lastStatus: StatusEffect;
-  private lastHp: number;
-  private lastMaxHp: number;
-  private lastHpFrame: string | null;
-  private lastExp: number;
-  private lastLevelExp: number;
-  private lastLevel: number;
-  private lastLevelCapped: boolean;
-  private lastStats: string;
+  protected player: boolean;
+  protected mini: boolean;
+  protected boss: boolean;
+  protected bossSegments: number;
+  protected offset: boolean;
+  protected lastName: string | null;
+  protected lastTeraType: PokemonType;
+  protected lastStatus: StatusEffect;
+  protected lastHp: number;
+  protected lastMaxHp: number;
+  protected lastHpFrame: string | null;
+  protected lastExp: number;
+  protected lastLevelExp: number;
+  protected lastLevel: number;
+  protected lastLevelCapped: boolean;
+  protected lastStats: string;
 
-  private box: Phaser.GameObjects.Sprite;
-  private nameText: Phaser.GameObjects.Text;
-  private genderText: Phaser.GameObjects.Text;
-  private ownedIcon: Phaser.GameObjects.Sprite;
-  private championRibbon: Phaser.GameObjects.Sprite;
-  private teraIcon: Phaser.GameObjects.Sprite;
-  private shinyIcon: Phaser.GameObjects.Sprite;
-  private fusionShinyIcon: Phaser.GameObjects.Sprite;
-  private splicedIcon: Phaser.GameObjects.Sprite;
-  private statusIndicator: Phaser.GameObjects.Sprite;
-  private levelContainer: Phaser.GameObjects.Container;
-  private hpBar: Phaser.GameObjects.Image;
-  private hpBarSegmentDividers: Phaser.GameObjects.Rectangle[];
-  private levelNumbersContainer: Phaser.GameObjects.Container;
-  private hpNumbersContainer: Phaser.GameObjects.Container;
-  private type1Icon: Phaser.GameObjects.Sprite;
-  private type2Icon: Phaser.GameObjects.Sprite;
-  private type3Icon: Phaser.GameObjects.Sprite;
-  private expBar: Phaser.GameObjects.Image;
+  protected box: Phaser.GameObjects.Sprite;
+  protected nameText: Phaser.GameObjects.Text;
+  protected genderText: Phaser.GameObjects.Text;
+  protected ownedIcon: Phaser.GameObjects.Sprite;
+  protected championRibbon: Phaser.GameObjects.Sprite;
+  protected teraIcon: Phaser.GameObjects.Sprite;
+  protected shinyIcon: Phaser.GameObjects.Sprite;
+  protected fusionShinyIcon: Phaser.GameObjects.Sprite;
+  protected splicedIcon: Phaser.GameObjects.Sprite;
+  protected statusIndicator: Phaser.GameObjects.Sprite;
+  protected levelContainer: Phaser.GameObjects.Container;
+  protected hpBar: Phaser.GameObjects.Image;
+  protected hpBarSegmentDividers: Phaser.GameObjects.Rectangle[];
+  protected levelNumbersContainer: Phaser.GameObjects.Container;
+  protected hpNumbersContainer: Phaser.GameObjects.Container;
+  protected type1Icon: Phaser.GameObjects.Sprite;
+  protected type2Icon: Phaser.GameObjects.Sprite;
+  protected type3Icon: Phaser.GameObjects.Sprite;
+  protected expBar: Phaser.GameObjects.Image;
 
   // #region Type effectiveness hint objects
-  private effectivenessContainer: Phaser.GameObjects.Container;
-  private effectivenessWindow: Phaser.GameObjects.NineSlice;
-  private effectivenessText: Phaser.GameObjects.Text;
-  private currentEffectiveness?: string;
+  protected effectivenessContainer: Phaser.GameObjects.Container;
+  protected effectivenessWindow: Phaser.GameObjects.NineSlice;
+  protected effectivenessText: Phaser.GameObjects.Text;
+  protected currentEffectiveness?: string;
   // #endregion
 
   public expMaskRect: Phaser.GameObjects.Graphics;
 
-  private statsContainer: Phaser.GameObjects.Container;
-  private statsBox: Phaser.GameObjects.Sprite;
-  private statValuesContainer: Phaser.GameObjects.Container;
-  private statNumbers: Phaser.GameObjects.Sprite[];
+  protected statsContainer: Phaser.GameObjects.Container;
+  protected statsBox: Phaser.GameObjects.Sprite;
+  protected statValuesContainer: Phaser.GameObjects.Container;
+  protected statNumbers: Phaser.GameObjects.Sprite[];
 
   public flyoutMenu?: BattleFlyout;
 
-  private statOrder: Stat[];
-  private readonly statOrderPlayer = [Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.ACC, Stat.EVA, Stat.SPD];
-  private readonly statOrderEnemy = [Stat.HP, Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.ACC, Stat.EVA, Stat.SPD];
+  protected statOrder: Stat[];
+  protected readonly statOrderPlayer = [Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.ACC, Stat.EVA, Stat.SPD];
+  protected readonly statOrderEnemy = [
+    Stat.HP,
+    Stat.ATK,
+    Stat.DEF,
+    Stat.SPATK,
+    Stat.SPDEF,
+    Stat.ACC,
+    Stat.EVA,
+    Stat.SPD,
+  ];
 
   constructor(x: number, y: number, player: boolean) {
     super(globalScene, x, y);
@@ -111,22 +119,6 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
     this.genderText.setOrigin(0, 0);
     this.genderText.setPositionRelative(this.nameText, 0, 2);
     this.add(this.genderText);
-
-    if (!this.player) {
-      this.ownedIcon = globalScene.add.sprite(0, 0, "icon_owned");
-      this.ownedIcon.setName("icon_owned");
-      this.ownedIcon.setVisible(false);
-      this.ownedIcon.setOrigin(0, 0);
-      this.ownedIcon.setPositionRelative(this.nameText, 0, 11.75);
-      this.add(this.ownedIcon);
-
-      this.championRibbon = globalScene.add.sprite(0, 0, "champion_ribbon");
-      this.championRibbon.setName("icon_champion_ribbon");
-      this.championRibbon.setVisible(false);
-      this.championRibbon.setOrigin(0, 0);
-      this.championRibbon.setPositionRelative(this.nameText, 8, 11.75);
-      this.add(this.championRibbon);
-    }
 
     this.teraIcon = globalScene.add.sprite(0, 0, "icon_tera");
     this.teraIcon.setName("icon_tera");
@@ -187,30 +179,6 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
     this.levelNumbersContainer = globalScene.add.container(9.5, globalScene.uiTheme ? 0 : -0.5);
     this.levelNumbersContainer.setName("container_level");
     this.levelContainer.add(this.levelNumbersContainer);
-
-    if (this.player) {
-      this.hpNumbersContainer = globalScene.add.container(-15, 10);
-      this.hpNumbersContainer.setName("container_hp");
-      this.add(this.hpNumbersContainer);
-
-      const expBar = globalScene.add.image(-98, 18, "overlay_exp");
-      expBar.setName("overlay_exp");
-      expBar.setOrigin(0);
-      this.add(expBar);
-
-      const expMaskRect = globalScene.make.graphics({});
-      expMaskRect.setScale(6);
-      expMaskRect.fillStyle(0xffffff);
-      expMaskRect.beginPath();
-      expMaskRect.fillRect(127, 126, 85, 2);
-
-      const expMask = expMaskRect.createGeometryMask();
-
-      expBar.setMask(expMask);
-
-      this.expBar = expBar;
-      this.expMaskRect = expMaskRect;
-    }
 
     this.statsContainer = globalScene.add.container(0, 0);
     this.statsContainer.setName("container_stats");
@@ -275,13 +243,6 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
       }
     });
 
-    if (!this.player) {
-      this.flyoutMenu = new BattleFlyout(this.player);
-      this.add(this.flyoutMenu);
-
-      this.moveBelow<Phaser.GameObjects.GameObject>(this.flyoutMenu, this.box);
-    }
-
     this.type1Icon = globalScene.add.sprite(
       player ? -139 : -15,
       player ? -17 : -15.5,
@@ -308,19 +269,6 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
     this.type3Icon.setName("icon_type_3");
     this.type3Icon.setOrigin(0, 0);
     this.add(this.type3Icon);
-
-    if (!this.player) {
-      this.effectivenessContainer = globalScene.add.container(0, 0);
-      this.effectivenessContainer.setPositionRelative(this.type1Icon, 22, 4);
-      this.effectivenessContainer.setVisible(false);
-      this.add(this.effectivenessContainer);
-
-      this.effectivenessText = addTextObject(5, 4.5, "", TextStyle.BATTLE_INFO);
-      this.effectivenessWindow = addWindow(0, 0, 0, 20, undefined, false, undefined, undefined, WindowVariant.XTHIN);
-
-      this.effectivenessContainer.add(this.effectivenessWindow);
-      this.effectivenessContainer.add(this.effectivenessText);
-    }
   }
 
   getStatsValueContainer(): Phaser.GameObjects.Container {

--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -188,4 +188,8 @@ export class EnemyBattleInfo extends BattleInfo {
       }
     }
   }
+
+  override updateStatusIcon(pokemon: EnemyPokemon): void {
+    super.updateStatusIcon(pokemon, (this.ownedIcon.visible ? 8 : 0) + (this.championRibbon.visible ? 8 : 0));
+  }
 }

--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -178,8 +178,7 @@ export class EnemyBattleInfo extends BattleInfo {
           this.hpBar.height - (uiTheme ? 0 : 1),
           pokemon.bossSegmentIndex >= s ? 0xffffff : 0x404040,
         );
-        divider.setOrigin(0.5, 0);
-        divider.setName("hpBar_divider_" + s.toString());
+        divider.setOrigin(0.5, 0).setName("hpBar_divider_" + s.toString());
         this.add(divider);
         this.moveBelow(divider as Phaser.GameObjects.GameObject, this.statsContainer);
 

--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -4,14 +4,17 @@ import BattleFlyout from "../battle-flyout";
 import { addTextObject, TextStyle } from "#app/ui/text";
 import { addWindow, WindowVariant } from "#app/ui/ui-theme";
 import { Stat } from "#enums/stat";
-import type { EnemyPokemon } from "#app/field/pokemon";
 import i18next from "i18next";
+import type { EnemyPokemon } from "#app/field/pokemon";
+import type { GameObjects } from "phaser";
 
 export class EnemyBattleInfo extends BattleInfo {
   protected player: false = false;
   protected championRibbon: Phaser.GameObjects.Sprite;
   protected ownedIcon: Phaser.GameObjects.Sprite;
   protected flyoutMenu: BattleFlyout;
+
+  protected hpBarSegmentDividers: GameObjects.Rectangle[] = [];
 
   // #region Type effectiveness hint objects
   protected effectivenessContainer: Phaser.GameObjects.Container;

--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -126,7 +126,7 @@ export class EnemyBattleInfo extends BattleInfo {
     this.flyoutMenu.toggleFlyout(visible);
 
     if (visible) {
-      this.effectivenessContainer?.setVisible(false);
+      this.effectivenessContainer.setVisible(false);
     } else {
       this.updateEffectiveness(this.currentEffectiveness);
     }

--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -1,0 +1,9 @@
+import BattleInfo from "./battle-info";
+
+export class EnemyBattleInfo extends BattleInfo {
+  constructor() {
+    super(140, -141, false);
+  }
+
+  setMini(_mini: boolean): void {} // Always mini
+}

--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -56,15 +56,19 @@ export class EnemyBattleInfo extends BattleInfo {
 
     super(140, -141, false, posParams);
 
-    this.ownedIcon = globalScene.add.sprite(0, 0, "icon_owned").setName("icon_owned").setVisible(false).setOrigin(0, 0);
-    this.ownedIcon.setPositionRelative(this.nameText, 0, 11.75);
+    this.ownedIcon = globalScene.add
+      .sprite(0, 0, "icon_owned")
+      .setName("icon_owned")
+      .setVisible(false)
+      .setOrigin(0, 0)
+      .setPositionRelative(this.nameText, 0, 11.75);
 
     this.championRibbon = globalScene.add
       .sprite(0, 0, "champion_ribbon")
       .setName("icon_champion_ribbon")
       .setVisible(false)
-      .setOrigin(0, 0);
-    this.championRibbon.setPositionRelative(this.nameText, 8, 11.75);
+      .setOrigin(0, 0)
+      .setPositionRelative(this.nameText, 8, 11.75);
     // Ensure these two icons are positioned below the stats container
     this.addAt([this.ownedIcon, this.championRibbon], this.getIndex(this.statsContainer));
 
@@ -73,8 +77,10 @@ export class EnemyBattleInfo extends BattleInfo {
 
     this.moveBelow<Phaser.GameObjects.GameObject>(this.flyoutMenu, this.box);
 
-    this.effectivenessContainer = globalScene.add.container(0, 0).setVisible(false);
-    this.effectivenessContainer.setPositionRelative(this.type1Icon, 22, 4);
+    this.effectivenessContainer = globalScene.add
+      .container(0, 0)
+      .setVisible(false)
+      .setPositionRelative(this.type1Icon, 22, 4);
     this.add(this.effectivenessContainer);
 
     this.effectivenessText = addTextObject(5, 4.5, "", TextStyle.BATTLE_INFO);

--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -188,6 +188,4 @@ export class EnemyBattleInfo extends BattleInfo {
       }
     }
   }
-
-  setMini(_mini: boolean): void {} // Always mini
 }

--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -1,8 +1,42 @@
 import BattleInfo from "./battle-info";
+import { globalScene } from "#app/global-scene";
+import BattleFlyout from "../battle-flyout";
+import { addTextObject, TextStyle } from "#app/ui/text";
+import { addWindow, WindowVariant } from "#app/ui/ui-theme";
 
 export class EnemyBattleInfo extends BattleInfo {
   constructor() {
     super(140, -141, false);
+
+    this.ownedIcon = globalScene.add.sprite(0, 0, "icon_owned");
+    this.ownedIcon.setName("icon_owned");
+    this.ownedIcon.setVisible(false);
+    this.ownedIcon.setOrigin(0, 0);
+    this.ownedIcon.setPositionRelative(this.nameText, 0, 11.75);
+    this.add(this.ownedIcon);
+
+    this.championRibbon = globalScene.add.sprite(0, 0, "champion_ribbon");
+    this.championRibbon.setName("icon_champion_ribbon");
+    this.championRibbon.setVisible(false);
+    this.championRibbon.setOrigin(0, 0);
+    this.championRibbon.setPositionRelative(this.nameText, 8, 11.75);
+    this.add(this.championRibbon);
+
+    this.flyoutMenu = new BattleFlyout(this.player);
+    this.add(this.flyoutMenu);
+
+    this.moveBelow<Phaser.GameObjects.GameObject>(this.flyoutMenu, this.box);
+
+    this.effectivenessContainer = globalScene.add.container(0, 0);
+    this.effectivenessContainer.setPositionRelative(this.type1Icon, 22, 4);
+    this.effectivenessContainer.setVisible(false);
+    this.add(this.effectivenessContainer);
+
+    this.effectivenessText = addTextObject(5, 4.5, "", TextStyle.BATTLE_INFO);
+    this.effectivenessWindow = addWindow(0, 0, 0, 20, undefined, false, undefined, undefined, WindowVariant.XTHIN);
+
+    this.effectivenessContainer.add(this.effectivenessWindow);
+    this.effectivenessContainer.add(this.effectivenessText);
   }
 
   setMini(_mini: boolean): void {} // Always mini

--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -25,17 +25,15 @@ export class EnemyBattleInfo extends BattleInfo {
   constructor() {
     super(140, -141, false);
 
-    this.ownedIcon = globalScene.add.sprite(0, 0, "icon_owned");
-    this.ownedIcon.setName("icon_owned");
-    this.ownedIcon.setVisible(false);
-    this.ownedIcon.setOrigin(0, 0);
+    this.ownedIcon = globalScene.add.sprite(0, 0, "icon_owned").setName("icon_owned").setVisible(false).setOrigin(0, 0);
     this.ownedIcon.setPositionRelative(this.nameText, 0, 11.75);
     this.add(this.ownedIcon);
 
-    this.championRibbon = globalScene.add.sprite(0, 0, "champion_ribbon");
-    this.championRibbon.setName("icon_champion_ribbon");
-    this.championRibbon.setVisible(false);
-    this.championRibbon.setOrigin(0, 0);
+    this.championRibbon = globalScene.add
+      .sprite(0, 0, "champion_ribbon")
+      .setName("icon_champion_ribbon")
+      .setVisible(false)
+      .setOrigin(0, 0);
     this.championRibbon.setPositionRelative(this.nameText, 8, 11.75);
     this.add(this.championRibbon);
 
@@ -44,16 +42,14 @@ export class EnemyBattleInfo extends BattleInfo {
 
     this.moveBelow<Phaser.GameObjects.GameObject>(this.flyoutMenu, this.box);
 
-    this.effectivenessContainer = globalScene.add.container(0, 0);
+    this.effectivenessContainer = globalScene.add.container(0, 0).setVisible(false);
     this.effectivenessContainer.setPositionRelative(this.type1Icon, 22, 4);
-    this.effectivenessContainer.setVisible(false);
     this.add(this.effectivenessContainer);
 
     this.effectivenessText = addTextObject(5, 4.5, "", TextStyle.BATTLE_INFO);
     this.effectivenessWindow = addWindow(0, 0, 0, 20, undefined, false, undefined, undefined, WindowVariant.XTHIN);
 
-    this.effectivenessContainer.add(this.effectivenessWindow);
-    this.effectivenessContainer.add(this.effectivenessText);
+    this.effectivenessContainer.add([this.effectivenessWindow, this.effectivenessText]);
   }
 
   setMini(_mini: boolean): void {} // Always mini

--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -192,4 +192,13 @@ export class EnemyBattleInfo extends BattleInfo {
   override updateStatusIcon(pokemon: EnemyPokemon): void {
     super.updateStatusIcon(pokemon, (this.ownedIcon.visible ? 8 : 0) + (this.championRibbon.visible ? 8 : 0));
   }
+
+  protected override updatePokemonHp(
+    pokemon: EnemyPokemon,
+    resolve: (r: void | PromiseLike<void>) => void,
+    instant?: boolean,
+  ): void {
+    super.updatePokemonHp(pokemon, resolve, instant);
+    this.lastHp = pokemon.hp;
+  }
 }

--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -1,4 +1,3 @@
-import BattleInfo from "./battle-info";
 import { globalScene } from "#app/global-scene";
 import BattleFlyout from "../battle-flyout";
 import { addTextObject, TextStyle } from "#app/ui/text";
@@ -7,6 +6,8 @@ import { Stat } from "#enums/stat";
 import i18next from "i18next";
 import type { EnemyPokemon } from "#app/field/pokemon";
 import type { GameObjects } from "phaser";
+import BattleInfo from "./battle-info";
+import type { BattleInfoParamList } from "./battle-info";
 
 export class EnemyBattleInfo extends BattleInfo {
   protected player: false = false;
@@ -31,8 +32,29 @@ export class EnemyBattleInfo extends BattleInfo {
     return this.boss ? "pbinfo_enemy_boss_mini" : "pbinfo_enemy_mini";
   }
 
+  override constructTypeIcons(): void {
+    this.type1Icon = globalScene.add.sprite(-15, -15.5, "pbinfo_enemy_type1").setName("icon_type_1").setOrigin(0);
+    this.type2Icon = globalScene.add.sprite(-15, -2.5, "pbinfo_enemy_type2").setName("icon_type_2").setOrigin(0);
+    this.type3Icon = globalScene.add.sprite(0, 15.5, "pbinfo_enemy_type3").setName("icon_type_3").setOrigin(0);
+    this.add([this.type1Icon, this.type2Icon, this.type3Icon]);
+  }
+
   constructor() {
-    super(140, -141, false);
+    const posParams: BattleInfoParamList = {
+      nameTextX: -124,
+      nameTextY: -11.2,
+      levelContainerX: -50,
+      levelContainerY: -5,
+      hpBarX: -71,
+      hpBarY: 4.5,
+      statBox: {
+        xOffset: 5,
+        paddingX: 2,
+        statOverflow: 0,
+      },
+    };
+
+    super(140, -141, false, posParams);
 
     this.ownedIcon = globalScene.add.sprite(0, 0, "icon_owned").setName("icon_owned").setVisible(false).setOrigin(0, 0);
     this.ownedIcon.setPositionRelative(this.nameText, 0, 11.75);

--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -36,7 +36,6 @@ export class EnemyBattleInfo extends BattleInfo {
 
     this.ownedIcon = globalScene.add.sprite(0, 0, "icon_owned").setName("icon_owned").setVisible(false).setOrigin(0, 0);
     this.ownedIcon.setPositionRelative(this.nameText, 0, 11.75);
-    this.add(this.ownedIcon);
 
     this.championRibbon = globalScene.add
       .sprite(0, 0, "champion_ribbon")
@@ -44,7 +43,8 @@ export class EnemyBattleInfo extends BattleInfo {
       .setVisible(false)
       .setOrigin(0, 0);
     this.championRibbon.setPositionRelative(this.nameText, 8, 11.75);
-    this.add(this.championRibbon);
+    // Ensure these two icons are positioned below the stats container
+    this.addAt([this.ownedIcon, this.championRibbon], this.getIndex(this.statsContainer));
 
     this.flyoutMenu = new BattleFlyout(this.player);
     this.add(this.flyoutMenu);

--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -27,6 +27,10 @@ export class EnemyBattleInfo extends BattleInfo {
     return [Stat.HP, Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.ACC, Stat.EVA, Stat.SPD];
   }
 
+  override getTextureName(): string {
+    return this.boss ? "pbinfo_enemy_boss_mini" : "pbinfo_enemy_mini";
+  }
+
   constructor() {
     super(140, -141, false);
 

--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -3,8 +3,25 @@ import { globalScene } from "#app/global-scene";
 import BattleFlyout from "../battle-flyout";
 import { addTextObject, TextStyle } from "#app/ui/text";
 import { addWindow, WindowVariant } from "#app/ui/ui-theme";
+import { Stat } from "#enums/stat";
 
 export class EnemyBattleInfo extends BattleInfo {
+  protected player: false = false;
+  protected championRibbon: Phaser.GameObjects.Sprite;
+  protected ownedIcon: Phaser.GameObjects.Sprite;
+  public flyoutMenu: BattleFlyout;
+
+  // #region Type effectiveness hint objects
+  protected effectivenessContainer: Phaser.GameObjects.Container;
+  protected effectivenessWindow: Phaser.GameObjects.NineSlice;
+  protected effectivenessText: Phaser.GameObjects.Text;
+  protected currentEffectiveness?: string;
+  // #endregion
+
+  override get statOrder(): Stat[] {
+    return [Stat.HP, Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.ACC, Stat.EVA, Stat.SPD];
+  }
+
   constructor() {
     super(140, -141, false);
 

--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -4,12 +4,13 @@ import BattleFlyout from "../battle-flyout";
 import { addTextObject, TextStyle } from "#app/ui/text";
 import { addWindow, WindowVariant } from "#app/ui/ui-theme";
 import { Stat } from "#enums/stat";
+import type { EnemyPokemon } from "#app/field/pokemon";
 
 export class EnemyBattleInfo extends BattleInfo {
   protected player: false = false;
   protected championRibbon: Phaser.GameObjects.Sprite;
   protected ownedIcon: Phaser.GameObjects.Sprite;
-  public flyoutMenu: BattleFlyout;
+  protected flyoutMenu: BattleFlyout;
 
   // #region Type effectiveness hint objects
   protected effectivenessContainer: Phaser.GameObjects.Container;
@@ -50,6 +51,41 @@ export class EnemyBattleInfo extends BattleInfo {
     this.effectivenessWindow = addWindow(0, 0, 0, 20, undefined, false, undefined, undefined, WindowVariant.XTHIN);
 
     this.effectivenessContainer.add([this.effectivenessWindow, this.effectivenessText]);
+  }
+
+  override initInfo(pokemon: EnemyPokemon): void {
+    this.flyoutMenu.initInfo(pokemon);
+    super.initInfo(pokemon);
+  }
+
+  /**
+   * Show or hide the type effectiveness multiplier window
+   * Passing undefined will hide the window
+   */
+  updateEffectiveness(effectiveness?: string) {
+    this.currentEffectiveness = effectiveness;
+
+    if (!globalScene.typeHints || effectiveness === undefined || this.flyoutMenu.flyoutVisible) {
+      this.effectivenessContainer.setVisible(false);
+      return;
+    }
+
+    this.effectivenessText.setText(effectiveness);
+    this.effectivenessWindow.width = 10 + this.effectivenessText.displayWidth;
+    this.effectivenessContainer.setVisible(true);
+  }
+
+  /**
+   * Request the flyoutMenu to toggle if available and hides or shows the effectiveness window where necessary
+   */
+  toggleFlyout(visible: boolean): void {
+    this.flyoutMenu.toggleFlyout(visible);
+
+    if (visible) {
+      this.effectivenessContainer?.setVisible(false);
+    } else {
+      this.updateEffectiveness(this.currentEffectiveness);
+    }
   }
 
   setMini(_mini: boolean): void {} // Always mini

--- a/src/ui/battle-info/player-battle-info.ts
+++ b/src/ui/battle-info/player-battle-info.ts
@@ -90,11 +90,7 @@ export class PlayerBattleInfo extends BattleInfo {
     this.updateHpFrame();
   }
 
-  override async updatePokemonExp(
-    pokemon: PlayerPokemon,
-    instant?: boolean,
-    levelDurationMultiplier = 1,
-  ): Promise<void> {
+  async updatePokemonExp(pokemon: PlayerPokemon, instant?: boolean, levelDurationMultiplier = 1): Promise<void> {
     const levelUp = this.lastLevel < pokemon.level;
     const relLevelExp = getLevelRelExp(this.lastLevel + 1, pokemon.species.growthRate);
     const levelExp = levelUp ? relLevelExp : pokemon.levelExp;

--- a/src/ui/battle-info/player-battle-info.ts
+++ b/src/ui/battle-info/player-battle-info.ts
@@ -4,5 +4,27 @@ import BattleInfo from "./battle-info";
 export class PlayerBattleInfo extends BattleInfo {
   constructor() {
     super(Math.floor(globalScene.game.canvas.width / 6) - 10, -72, true);
+
+    this.hpNumbersContainer = globalScene.add.container(-15, 10);
+    this.hpNumbersContainer.setName("container_hp");
+    this.add(this.hpNumbersContainer);
+
+    const expBar = globalScene.add.image(-98, 18, "overlay_exp");
+    expBar.setName("overlay_exp");
+    expBar.setOrigin(0);
+    this.add(expBar);
+
+    const expMaskRect = globalScene.make.graphics({});
+    expMaskRect.setScale(6);
+    expMaskRect.fillStyle(0xffffff);
+    expMaskRect.beginPath();
+    expMaskRect.fillRect(127, 126, 85, 2);
+
+    const expMask = expMaskRect.createGeometryMask();
+
+    expBar.setMask(expMask);
+
+    this.expBar = expBar;
+    this.expMaskRect = expMaskRect;
   }
 }

--- a/src/ui/battle-info/player-battle-info.ts
+++ b/src/ui/battle-info/player-battle-info.ts
@@ -4,6 +4,7 @@ import { globalScene } from "#app/global-scene";
 import { ExpGainsSpeed } from "#enums/exp-gains-speed";
 import { Stat } from "#enums/stat";
 import BattleInfo from "./battle-info";
+import type { BattleInfoParamList } from "./battle-info";
 
 export class PlayerBattleInfo extends BattleInfo {
   protected player: true = true;
@@ -17,8 +18,28 @@ export class PlayerBattleInfo extends BattleInfo {
     return this.mini ? "pbinfo_player_mini" : "pbinfo_player";
   }
 
+  override constructTypeIcons(): void {
+    this.type1Icon = globalScene.add.sprite(-139, -17, "pbinfo_player_type1").setName("icon_type_1").setOrigin(0);
+    this.type2Icon = globalScene.add.sprite(-139, -1, "pbinfo_player_type2").setName("icon_type_2").setOrigin(0);
+    this.type3Icon = globalScene.add.sprite(-154, -17, "pbinfo_player_type3").setName("icon_type_3").setOrigin(0);
+    this.add([this.type1Icon, this.type2Icon, this.type3Icon]);
+  }
+
   constructor() {
-    super(Math.floor(globalScene.game.canvas.width / 6) - 10, -72, true);
+    const posParams: BattleInfoParamList = {
+      nameTextX: -115,
+      nameTextY: -15.2,
+      levelContainerX: -41,
+      levelContainerY: -10,
+      hpBarX: -61,
+      hpBarY: -1,
+      statBox: {
+        xOffset: 8,
+        paddingX: 4,
+        statOverflow: 1,
+      },
+    };
+    super(Math.floor(globalScene.game.canvas.width / 6) - 10, -72, true, posParams);
 
     this.hpNumbersContainer = globalScene.add.container(-15, 10).setName("container_hp");
 
@@ -207,5 +228,15 @@ export class PlayerBattleInfo extends BattleInfo {
     for (let i = hpStr.length - 1; i >= 0; i--) {
       this.hpNumbersContainer.add(globalScene.add.image(offset++ * -8, 0, "numbers", hpStr[i]));
     }
+  }
+
+  /**
+   * Set the level numbers container to display the provided level
+   *
+   * Overrides the default implementation to handle displaying level capped numbers in red.
+   * @param level - The level to display
+   */
+  override setLevel(level: number): void {
+    super.setLevel(level, level >= globalScene.getMaxExpLevel() ? "numbers_red" : "numbers");
   }
 }

--- a/src/ui/battle-info/player-battle-info.ts
+++ b/src/ui/battle-info/player-battle-info.ts
@@ -95,17 +95,13 @@ export class PlayerBattleInfo extends BattleInfo {
     this.updateHpFrame();
   }
 
-  async updatePokemonExp(pokemon: PlayerPokemon, instant?: boolean, levelDurationMultiplier = 1): Promise<void> {
+  updatePokemonExp(pokemon: PlayerPokemon, instant?: boolean, levelDurationMultiplier = 1): Promise<void> {
     const levelUp = this.lastLevel < pokemon.level;
     const relLevelExp = getLevelRelExp(this.lastLevel + 1, pokemon.species.growthRate);
     const levelExp = levelUp ? relLevelExp : pokemon.levelExp;
     let ratio = relLevelExp ? levelExp / relLevelExp : 0;
     if (this.lastLevel >= globalScene.getMaxExpLevel(true)) {
-      if (levelUp) {
-        ratio = 1;
-      } else {
-        ratio = 0;
-      }
+      ratio = levelUp ? 1 : 0;
       instant = true;
     }
     const durationMultiplier = Phaser.Tweens.Builders.GetEaseFunction("Sine.easeIn")(

--- a/src/ui/battle-info/player-battle-info.ts
+++ b/src/ui/battle-info/player-battle-info.ts
@@ -83,6 +83,11 @@ export class PlayerBattleInfo extends BattleInfo {
     toggledElements.forEach(el => el.setVisible(!mini));
   }
 
+  /**
+   * Updates the Hp Number text (that is the "HP/Max HP" text that appears below the player's health bar)
+   * while the health bar is tweening.
+   * @param pokemon - The Pokemon the health bar belongs to.
+   */
   protected override onHpTweenUpdate(pokemon: PlayerPokemon): void {
     const tweenHp = Math.ceil(this.hpBar.scaleX * pokemon.getMaxHp());
     this.setHpNumbers(tweenHp, pokemon.getMaxHp());
@@ -155,6 +160,10 @@ export class PlayerBattleInfo extends BattleInfo {
     });
   }
 
+  /** Updates the info on the info bar.
+   * In addition to performing all the steps of {@linkcode BattleInfo.updateInfo},
+   * it also updates the EXP Bar
+   */
   override async updateInfo(pokemon: PlayerPokemon, instant?: boolean): Promise<void> {
     await super.updateInfo(pokemon, instant);
     const isLevelCapped = pokemon.level >= globalScene.getMaxExpLevel();

--- a/src/ui/battle-info/player-battle-info.ts
+++ b/src/ui/battle-info/player-battle-info.ts
@@ -12,6 +12,11 @@ export class PlayerBattleInfo extends BattleInfo {
   override get statOrder(): Stat[] {
     return [Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.ACC, Stat.EVA, Stat.SPD];
   }
+
+  override getTextureName(): string {
+    return this.mini ? "pbinfo_player_mini" : "pbinfo_player";
+  }
+
   constructor() {
     super(Math.floor(globalScene.game.canvas.width / 6) - 10, -72, true);
 
@@ -55,6 +60,7 @@ export class PlayerBattleInfo extends BattleInfo {
 
     this.statValuesContainer.setPosition(8, 7);
   }
+
   override setMini(mini: boolean): void {
     if (this.mini === mini) {
       return;
@@ -166,7 +172,9 @@ export class PlayerBattleInfo extends BattleInfo {
     });
   }
 
-  /** Updates the info on the info bar.
+  /**
+   * Updates the info on the info bar.
+   *
    * In addition to performing all the steps of {@linkcode BattleInfo.updateInfo},
    * it also updates the EXP Bar
    */

--- a/src/ui/battle-info/player-battle-info.ts
+++ b/src/ui/battle-info/player-battle-info.ts
@@ -1,8 +1,12 @@
+import { getLevelTotalExp } from "#app/data/exp";
+import type { PlayerPokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { Stat } from "#enums/stat";
 import BattleInfo from "./battle-info";
 
 export class PlayerBattleInfo extends BattleInfo {
+  protected player: true = true;
+
   override get statOrder(): Stat[] {
     return [Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.ACC, Stat.EVA, Stat.SPD];
   }
@@ -28,5 +32,15 @@ export class PlayerBattleInfo extends BattleInfo {
 
     this.expBar = expBar;
     this.expMaskRect = expMaskRect;
+  }
+
+  override initInfo(pokemon: PlayerPokemon): void {
+    super.initInfo(pokemon);
+    this.setHpNumbers(pokemon.hp, pokemon.getMaxHp());
+    this.expMaskRect.x = (pokemon.levelExp / getLevelTotalExp(pokemon.level, pokemon.species.growthRate)) * 510;
+    this.lastExp = pokemon.exp;
+    this.lastLevelExp = pokemon.levelExp;
+
+    this.statValuesContainer.setPosition(8, 7);
   }
 }

--- a/src/ui/battle-info/player-battle-info.ts
+++ b/src/ui/battle-info/player-battle-info.ts
@@ -14,11 +14,12 @@ export class PlayerBattleInfo extends BattleInfo {
     expBar.setOrigin(0);
     this.add(expBar);
 
-    const expMaskRect = globalScene.make.graphics({});
-    expMaskRect.setScale(6);
-    expMaskRect.fillStyle(0xffffff);
-    expMaskRect.beginPath();
-    expMaskRect.fillRect(127, 126, 85, 2);
+    const expMaskRect = globalScene.make
+      .graphics({})
+      .setScale(6)
+      .fillStyle(0xffffff)
+      .beginPath()
+      .fillRect(127, 126, 85, 2);
 
     const expMask = expMaskRect.createGeometryMask();
 

--- a/src/ui/battle-info/player-battle-info.ts
+++ b/src/ui/battle-info/player-battle-info.ts
@@ -1,17 +1,18 @@
 import { globalScene } from "#app/global-scene";
+import { Stat } from "#enums/stat";
 import BattleInfo from "./battle-info";
 
 export class PlayerBattleInfo extends BattleInfo {
+  override get statOrder(): Stat[] {
+    return [Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.ACC, Stat.EVA, Stat.SPD];
+  }
   constructor() {
     super(Math.floor(globalScene.game.canvas.width / 6) - 10, -72, true);
 
-    this.hpNumbersContainer = globalScene.add.container(-15, 10);
-    this.hpNumbersContainer.setName("container_hp");
+    this.hpNumbersContainer = globalScene.add.container(-15, 10).setName("container_hp");
     this.add(this.hpNumbersContainer);
 
-    const expBar = globalScene.add.image(-98, 18, "overlay_exp");
-    expBar.setName("overlay_exp");
-    expBar.setOrigin(0);
+    const expBar = globalScene.add.image(-98, 18, "overlay_exp").setName("overlay_exp").setOrigin(0);
     this.add(expBar);
 
     const expMaskRect = globalScene.make

--- a/src/ui/battle-info/player-battle-info.ts
+++ b/src/ui/battle-info/player-battle-info.ts
@@ -1,0 +1,8 @@
+import { globalScene } from "#app/global-scene";
+import BattleInfo from "./battle-info";
+
+export class PlayerBattleInfo extends BattleInfo {
+  constructor() {
+    super(Math.floor(globalScene.game.canvas.width / 6) - 10, -72, true);
+  }
+}

--- a/src/ui/battle-info/player-battle-info.ts
+++ b/src/ui/battle-info/player-battle-info.ts
@@ -36,6 +36,16 @@ export class PlayerBattleInfo extends BattleInfo {
     this.expMaskRect = expMaskRect;
   }
 
+  /**
+   * Toggle the stat overlay, ensuring that the hp numbers container is hidden while the stats are visible.
+   * @param visible - Whether the stats should be visible or not.
+   */
+  override toggleStats(visible: boolean): void {
+    // Need to make the hp numbers container invisible
+    this.hpNumbersContainer.setVisible(!visible);
+    super.toggleStats(visible);
+  }
+
   override initInfo(pokemon: PlayerPokemon): void {
     super.initInfo(pokemon);
     this.setHpNumbers(pokemon.hp, pokemon.getMaxHp());

--- a/src/ui/battle-info/player-battle-info.ts
+++ b/src/ui/battle-info/player-battle-info.ts
@@ -21,7 +21,9 @@ export class PlayerBattleInfo extends BattleInfo {
     super(Math.floor(globalScene.game.canvas.width / 6) - 10, -72, true);
 
     this.hpNumbersContainer = globalScene.add.container(-15, 10).setName("container_hp");
-    this.add(this.hpNumbersContainer);
+
+    // hp number container must be beneath the stat container for overlay to display properly
+    this.addAt(this.hpNumbersContainer, this.getIndex(this.statsContainer));
 
     const expBar = globalScene.add.image(-98, 18, "overlay_exp").setName("overlay_exp").setOrigin(0);
     this.add(expBar);
@@ -39,16 +41,6 @@ export class PlayerBattleInfo extends BattleInfo {
 
     this.expBar = expBar;
     this.expMaskRect = expMaskRect;
-  }
-
-  /**
-   * Toggle the stat overlay, ensuring that the hp numbers container is hidden while the stats are visible.
-   * @param visible - Whether the stats should be visible or not.
-   */
-  override toggleStats(visible: boolean): void {
-    // Need to make the hp numbers container invisible
-    this.hpNumbersContainer.setVisible(!visible);
-    super.toggleStats(visible);
   }
 
   override initInfo(pokemon: PlayerPokemon): void {

--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -10,7 +10,7 @@ import { getLocalizedSpriteKey, fixedInt, padInt } from "#app/utils/common";
 import { MoveCategory } from "#enums/MoveCategory";
 import i18next from "i18next";
 import { Button } from "#enums/buttons";
-import type { PokemonMove } from "#app/field/pokemon";
+import type { EnemyPokemon, PokemonMove } from "#app/field/pokemon";
 import type Pokemon from "#app/field/pokemon";
 import type { CommandPhase } from "#app/phases/command-phase";
 import MoveInfoOverlay from "./move-info-overlay";
@@ -279,7 +279,7 @@ export default class FightUiHandler extends UiHandler implements InfoToggle {
       this.moveInfoOverlay.show(pokemonMove.getMove());
 
       pokemon.getOpponents().forEach(opponent => {
-        opponent.updateEffectiveness(this.getEffectivenessText(pokemon, opponent, pokemonMove));
+        (opponent as EnemyPokemon).updateEffectiveness(this.getEffectivenessText(pokemon, opponent, pokemonMove));
       });
     }
 
@@ -391,7 +391,7 @@ export default class FightUiHandler extends UiHandler implements InfoToggle {
 
     const opponents = (globalScene.getCurrentPhase() as CommandPhase).getPokemon().getOpponents();
     opponents.forEach(opponent => {
-      opponent.updateEffectiveness(undefined);
+      (opponent as EnemyPokemon).updateEffectiveness(undefined);
     });
   }
 

--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -391,7 +391,7 @@ export default class FightUiHandler extends UiHandler implements InfoToggle {
 
     const opponents = (globalScene.getCurrentPhase() as CommandPhase).getPokemon().getOpponents();
     opponents.forEach(opponent => {
-      (opponent as EnemyPokemon).updateEffectiveness(undefined);
+      (opponent as EnemyPokemon).updateEffectiveness();
     });
   }
 

--- a/src/ui/pokemon-info-container.ts
+++ b/src/ui/pokemon-info-container.ts
@@ -8,7 +8,7 @@ import type Pokemon from "../field/pokemon";
 import i18next from "i18next";
 import type { DexEntry, StarterDataEntry } from "../system/game-data";
 import { DexAttr } from "../system/game-data";
-import { fixedInt } from "#app/utils/common";
+import { fixedInt, getShinyDescriptor } from "#app/utils/common";
 import ConfirmUiHandler from "./confirm-ui-handler";
 import { StatsContainer } from "./stats-container";
 import { TextStyle, addBBCodeTextObject, addTextObject, getTextColor } from "./text";
@@ -343,18 +343,19 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
       this.pokemonShinyIcon.setVisible(pokemon.isShiny());
       this.pokemonShinyIcon.setTint(getVariantTint(baseVariant));
       if (this.pokemonShinyIcon.visible) {
-        const shinyDescriptor =
-          doubleShiny || baseVariant
-            ? `${baseVariant === 2 ? i18next.t("common:epicShiny") : baseVariant === 1 ? i18next.t("common:rareShiny") : i18next.t("common:commonShiny")}${doubleShiny ? `/${pokemon.fusionVariant === 2 ? i18next.t("common:epicShiny") : pokemon.fusionVariant === 1 ? i18next.t("common:rareShiny") : i18next.t("common:commonShiny")}` : ""}`
-            : "";
-        this.pokemonShinyIcon.on("pointerover", () =>
-          globalScene.ui.showTooltip(
-            "",
-            `${i18next.t("common:shinyOnHover")}${shinyDescriptor ? ` (${shinyDescriptor})` : ""}`,
-            true,
-          ),
-        );
-        this.pokemonShinyIcon.on("pointerout", () => globalScene.ui.hideTooltip());
+        let shinyDescriptor = "";
+        if (doubleShiny || baseVariant) {
+          shinyDescriptor = " (" + getShinyDescriptor(baseVariant);
+          if (doubleShiny) {
+            shinyDescriptor += "/" + getShinyDescriptor(pokemon.fusionVariant);
+          }
+          shinyDescriptor += ")";
+        }
+        this.pokemonShinyIcon
+          .on("pointerover", () =>
+            globalScene.ui.showTooltip("", i18next.t("common:shinyOnHover") + shinyDescriptor, true),
+          )
+          .on("pointerout", () => globalScene.ui.hideTooltip());
 
         const newShiny = BigInt(1 << (pokemon.shiny ? 1 : 0));
         const newVariant = BigInt(1 << (pokemon.variant + 4));

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -11,6 +11,7 @@ import {
   isNullOrUndefined,
   toReadableString,
   formatStat,
+  getShinyDescriptor,
 } from "#app/utils/common";
 import type { PlayerPokemon, PokemonMove } from "#app/field/pokemon";
 import { getStarterValueFriendshipCap, speciesStarterCosts } from "#app/data/balance/starters";
@@ -444,18 +445,19 @@ export default class SummaryUiHandler extends UiHandler {
     this.shinyIcon.setVisible(this.pokemon.isShiny(false));
     this.shinyIcon.setTint(getVariantTint(baseVariant));
     if (this.shinyIcon.visible) {
-      const shinyDescriptor =
-        doubleShiny || baseVariant
-          ? `${baseVariant === 2 ? i18next.t("common:epicShiny") : baseVariant === 1 ? i18next.t("common:rareShiny") : i18next.t("common:commonShiny")}${doubleShiny ? `/${this.pokemon.fusionVariant === 2 ? i18next.t("common:epicShiny") : this.pokemon.fusionVariant === 1 ? i18next.t("common:rareShiny") : i18next.t("common:commonShiny")}` : ""}`
-          : "";
-      this.shinyIcon.on("pointerover", () =>
-        globalScene.ui.showTooltip(
-          "",
-          `${i18next.t("common:shinyOnHover")}${shinyDescriptor ? ` (${shinyDescriptor})` : ""}`,
-          true,
-        ),
-      );
-      this.shinyIcon.on("pointerout", () => globalScene.ui.hideTooltip());
+      let shinyDescriptor = "";
+      if (doubleShiny || baseVariant) {
+        shinyDescriptor = " (" + getShinyDescriptor(baseVariant);
+        if (doubleShiny) {
+          shinyDescriptor += "/" + getShinyDescriptor(this.pokemon.fusionVariant);
+        }
+        shinyDescriptor += ")";
+      }
+      this.shinyIcon
+        .on("pointerover", () =>
+          globalScene.ui.showTooltip("", i18next.t("common:shinyOnHover") + shinyDescriptor, true),
+        )
+        .on("pointerout", () => globalScene.ui.hideTooltip());
     }
 
     this.fusionShinyIcon.setPosition(this.shinyIcon.x, this.shinyIcon.y);

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -587,8 +587,8 @@ export function getShinyDescriptor(variant: Variant): string {
     case 2:
       return i18next.t("common:epicShiny");
     case 1:
-      return i18next.t("common:shiny");
+      return i18next.t("common:rareShiny");
     case 0:
-      return i18next.t("common:normal");
+      return i18next.t("common:commonShiny");
   }
 }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -2,6 +2,7 @@ import { MoneyFormat } from "#enums/money-format";
 import { Moves } from "#enums/moves";
 import i18next from "i18next";
 import { pokerogueApi } from "#app/plugins/api/pokerogue-api";
+import type { Variant } from "#app/sprites/variant";
 
 export type nil = null | undefined;
 
@@ -575,4 +576,19 @@ export function animationFileName(move: Moves): string {
  */
 export function camelCaseToKebabCase(str: string): string {
   return str.replace(/[A-Z]+(?![a-z])|[A-Z]/g, (s, o) => (o ? "-" : "") + s.toLowerCase());
+}
+
+/** Get the localized shiny descriptor for the provided variant
+ * @param variant - The variant to get the shiny descriptor for
+ * @returns The localized shiny descriptor
+ */
+export function getShinyDescriptor(variant: Variant): string {
+  switch (variant) {
+    case 2:
+      return i18next.t("common:epicShiny");
+    case 1:
+      return i18next.t("common:shiny");
+    case 0:
+      return i18next.t("common:normal");
+  }
 }

--- a/test/testUtils/mocks/mockGameObject.ts
+++ b/test/testUtils/mocks/mockGameObject.ts
@@ -1,3 +1,4 @@
 export interface MockGameObject {
   name: string;
+  destroy?(): void;
 }

--- a/test/testUtils/mocks/mocksContainer/mockContainer.ts
+++ b/test/testUtils/mocks/mocksContainer/mockContainer.ts
@@ -2,199 +2,252 @@ import type MockTextureManager from "#test/testUtils/mocks/mockTextureManager";
 import type { MockGameObject } from "../mockGameObject";
 
 export default class MockContainer implements MockGameObject {
-  protected x;
-  protected y;
+  protected x: number;
+  protected y: number;
   protected scene;
-  protected width;
-  protected height;
-  protected visible;
-  private alpha;
+  protected width: number;
+  protected height: number;
+  protected visible: boolean;
+  private alpha: number;
   private style;
   public frame;
   protected textureManager;
   public list: MockGameObject[] = [];
   public name: string;
 
-  constructor(textureManager: MockTextureManager, x, y) {
+  constructor(textureManager: MockTextureManager, x: number, y: number) {
     this.x = x;
     this.y = y;
     this.frame = {};
     this.textureManager = textureManager;
   }
-  setVisible(visible) {
+  setVisible(visible: boolean): this {
     this.visible = visible;
+    return this;
   }
 
-  once(_event, _callback, _source) {}
+  once(_event, _callback, _source): this {
+    return this;
+  }
 
-  off(_event, _callback, _source) {}
+  off(_event, _callback, _source): this {
+    return this;
+  }
 
-  removeFromDisplayList() {
+  removeFromDisplayList(): this {
     // same as remove or destroy
+    return this;
   }
 
-  removeBetween(_startIndex, _endIndex, _destroyChild) {
+  removeBetween(_startIndex, _endIndex, _destroyChild): this {
     // Removes multiple children across an index range
+    return this;
   }
 
   addedToScene() {
     // This callback is invoked when this Game Object is added to a Scene.
   }
 
-  setSize(_width, _height) {
+  setSize(_width: number, _height: number): this {
     // Sets the size of this Game Object.
+    return this;
   }
 
-  setMask() {
+  setMask(): this {
     /// Sets the mask that this Game Object will use to render with.
+    return this;
   }
 
   setPositionRelative(_source, _x, _y) {
     /// Sets the position of this Game Object to be a relative position from the source Game Object.
   }
 
-  setInteractive = () => null;
-
-  setOrigin(x, y) {
-    this.x = x;
-    this.y = y;
+  setInteractive(): this {
+    return this;
   }
 
-  setAlpha(alpha) {
+  setOrigin(x = 0.5, y = x): this {
+    this.x = x;
+    this.y = y;
+    return this;
+  }
+
+  setAlpha(alpha = 1): this {
     this.alpha = alpha;
+    return this;
   }
 
-  setFrame(_frame, _updateSize?: boolean, _updateOrigin?: boolean) {
+  setFrame(_frame, _updateSize?: boolean, _updateOrigin?: boolean): this {
     // Sets the frame this Game Object will use to render with.
+    return this;
   }
 
-  setScale(_scale) {
+  setScale(_x = 1, _y = _x): this {
     // Sets the scale of this Game Object.
+    return this;
   }
 
-  setPosition(x, y) {
+  setPosition(x = 0, y = x, _z = 0, _w = 0): this {
     this.x = x;
     this.y = y;
+    return this;
   }
 
-  setX(x) {
+  setX(x = 0): this {
     this.x = x;
+    return this;
   }
 
-  setY(y) {
+  setY(y = 0): this {
     this.y = y;
+    return this;
   }
 
   destroy() {
     this.list = [];
   }
 
-  setShadow(_shadowXpos, _shadowYpos, _shadowColor) {
+  setShadow(_shadowXpos, _shadowYpos, _shadowColor): this {
     // Sets the shadow settings for this Game Object.
+    return this;
   }
 
-  setLineSpacing(_lineSpacing) {
+  setLineSpacing(_lineSpacing): this {
     // Sets the line spacing value of this Game Object.
+    return this;
   }
 
-  setText(_text) {
+  setText(_text): this {
     // Sets the text this Game Object will display.
+    return this;
   }
 
-  setAngle(_angle) {
+  setAngle(_angle): this {
     // Sets the angle of this Game Object.
+    return this;
   }
 
-  setShadowOffset(_offsetX, _offsetY) {
+  setShadowOffset(_offsetX, _offsetY): this {
     // Sets the shadow offset values.
+    return this;
   }
 
   setWordWrapWidth(_width) {
     // Sets the width (in pixels) to use for wrapping lines.
   }
 
-  setFontSize(_fontSize) {
+  setFontSize(_fontSize): this {
     // Sets the font size of this Game Object.
+    return this;
   }
   getBounds() {
     return { width: this.width, height: this.height };
   }
 
-  setColor(_color) {
+  setColor(_color): this {
     // Sets the tint of this Game Object.
+    return this;
   }
 
-  setShadowColor(_color) {
+  setShadowColor(_color): this {
     // Sets the shadow color.
+    return this;
   }
 
-  setTint(_color) {
+  setTint(_color: this) {
     // Sets the tint of this Game Object.
+    return this;
   }
 
-  setStrokeStyle(_thickness, _color) {
+  setStrokeStyle(_thickness, _color): this {
     // Sets the stroke style for the graphics.
     return this;
   }
 
-  setDepth(_depth) {
-    // Sets the depth of this Game Object.
+  setDepth(_depth): this {
+    // Sets the depth of this Game Object.\
+    return this;
   }
 
-  setTexture(_texture) {
-    // Sets the texture this Game Object will use to render with.
+  setTexture(_texture): this {
+    // Sets the texture this Game Object will use to render with.\
+    return this;
   }
 
-  clearTint() {
-    // Clears any previously set tint.
+  clearTint(): this {
+    // Clears any previously set tint.\
+    return this;
   }
 
-  sendToBack() {
-    // Sends this Game Object to the back of its parent's display list.
+  sendToBack(): this {
+    // Sends this Game Object to the back of its parent's display list.\
+    return this;
   }
 
-  moveTo(_obj) {
-    // Moves this Game Object to the given index in the list.
+  moveTo(_obj): this {
+    // Moves this Game Object to the given index in the list.\
+    return this;
   }
 
-  moveAbove(_obj) {
+  moveAbove(_obj): this {
     // Moves this Game Object to be above the given Game Object in the display list.
+    return this;
   }
 
-  moveBelow(_obj) {
+  moveBelow(_obj): this {
     // Moves this Game Object to be below the given Game Object in the display list.
+    return this;
   }
 
-  setName(name: string) {
+  setName(name: string): this {
     this.name = name;
+    return this;
   }
 
-  bringToTop(_obj) {
+  bringToTop(_obj): this {
     // Brings this Game Object to the top of its parents display list.
+    return this;
   }
 
-  on(_event, _callback, _source) {}
+  on(_event, _callback, _source): this {
+    return this;
+  }
 
-  add(obj) {
+  add(...obj: MockGameObject[]): this {
     // Adds a child to this Game Object.
-    this.list.push(obj);
+    this.list.push(...obj);
+    return this;
   }
 
-  removeAll() {
+  removeAll(): this {
     // Removes all Game Objects from this Container.
     this.list = [];
+    return this;
   }
 
-  addAt(obj, index) {
+  addAt(obj: MockGameObject | MockGameObject[], index = 0): this {
     // Adds a Game Object to this Container at the given index.
-    this.list.splice(index, 0, obj);
+    if (!Array.isArray(obj)) {
+      obj = [obj];
+    }
+    this.list.splice(index, 0, ...obj);
+    return this;
   }
 
-  remove(obj) {
-    const index = this.list.indexOf(obj);
-    if (index !== -1) {
-      this.list.splice(index, 1);
+  remove(obj: MockGameObject | MockGameObject[], destroyChild = false): this {
+    if (!Array.isArray(obj)) {
+      obj = [obj];
     }
+    for (const item of obj) {
+      const index = this.list.indexOf(item);
+      if (index !== -1) {
+        this.list.splice(index, 1);
+      }
+      if (destroyChild) {
+        item.destroy?.();
+      }
+    }
+    return this;
   }
 
   getIndex(obj) {
@@ -210,15 +263,28 @@ export default class MockContainer implements MockGameObject {
     return this.list;
   }
 
-  getByName(key: string) {
+  getByName(key: string): MockGameObject | null {
     return this.list.find(v => v.name === key) ?? new MockContainer(this.textureManager, 0, 0);
   }
 
-  disableInteractive = () => null;
+  disableInteractive(): this {
+    return this;
+  }
 
-  each(method) {
+  each(method): this {
     for (const item of this.list) {
       method(item);
     }
+    return this;
+  }
+
+  copyPosition(source: { x?: number; y?: number }): this {
+    if (source.x !== undefined) {
+      this.x = source.x;
+    }
+    if (source.y !== undefined) {
+      this.y = source.y;
+    }
+    return this;
   }
 }

--- a/test/testUtils/mocks/mocksContainer/mockContainer.ts
+++ b/test/testUtils/mocks/mocksContainer/mockContainer.ts
@@ -58,8 +58,9 @@ export default class MockContainer implements MockGameObject {
     return this;
   }
 
-  setPositionRelative(_source, _x, _y) {
+  setPositionRelative(_source, _x, _y): this {
     /// Sets the position of this Game Object to be a relative position from the source Game Object.
+    return this;
   }
 
   setInteractive(): this {

--- a/test/testUtils/mocks/mocksContainer/mockGraphics.ts
+++ b/test/testUtils/mocks/mocksContainer/mockGraphics.ts
@@ -8,34 +8,49 @@ export default class MockGraphics implements MockGameObject {
     this.scene = textureManager.scene;
   }
 
-  fillStyle(_color) {
+  fillStyle(_color): this {
     // Sets the fill style to be used by the fill methods.
+    return this;
   }
 
-  beginPath() {
+  beginPath(): this {
     // Starts a new path by emptying the list of sub-paths. Call this method when you want to create a new path.
+    return this;
   }
 
-  fillRect(_x, _y, _width, _height) {
+  fillRect(_x, _y, _width, _height): this {
     // Adds a rectangle shape to the path which is filled when you call fill().
+    return this;
   }
 
-  createGeometryMask() {
+  createGeometryMask(): this {
     // Creates a geometry mask.
+    return this;
   }
 
-  setOrigin(_x, _y) {}
+  setOrigin(_x, _y): this {
+    return this;
+  }
 
-  setAlpha(_alpha) {}
+  setAlpha(_alpha): this {
+    return this;
+  }
 
-  setVisible(_visible) {}
+  setVisible(_visible): this {
+    return this;
+  }
 
-  setName(_name) {}
+  setName(_name) {
+    return this;
+  }
 
-  once(_event, _callback, _source) {}
+  once(_event, _callback, _source) {
+    return this;
+  }
 
-  removeFromDisplayList() {
+  removeFromDisplayList(): this {
     // same as remove or destroy
+    return this;
   }
 
   addedToScene() {
@@ -50,15 +65,18 @@ export default class MockGraphics implements MockGameObject {
     this.list = [];
   }
 
-  setScale(_scale) {
-    // Sets the scale of this Game Object.
+  setScale(_scale): this {
+    return this;
   }
 
-  off(_event, _callback, _source) {}
+  off(_event, _callback, _source): this {
+    return this;
+  }
 
-  add(obj) {
+  add(obj): this {
     // Adds a child to this Game Object.
     this.list.push(obj);
+    return this;
   }
 
   removeAll() {
@@ -89,5 +107,9 @@ export default class MockGraphics implements MockGameObject {
 
   getAll() {
     return this.list;
+  }
+
+  copyPosition(_source): this {
+    return this;
   }
 }

--- a/test/testUtils/mocks/mocksContainer/mockGraphics.ts
+++ b/test/testUtils/mocks/mocksContainer/mockGraphics.ts
@@ -57,8 +57,9 @@ export default class MockGraphics implements MockGameObject {
     // This callback is invoked when this Game Object is added to a Scene.
   }
 
-  setPositionRelative(_source, _x, _y) {
+  setPositionRelative(_source, _x, _y): this {
     /// Sets the position of this Game Object to be a relative position from the source Game Object.
+    return this;
   }
 
   destroy() {

--- a/test/testUtils/mocks/mocksContainer/mockRectangle.ts
+++ b/test/testUtils/mocks/mocksContainer/mockRectangle.ts
@@ -10,17 +10,28 @@ export default class MockRectangle implements MockGameObject {
     this.fillColor = fillColor;
     this.scene = textureManager.scene;
   }
-  setOrigin(_x, _y) {}
+  setOrigin(_x, _y): this {
+    return this;
+  }
 
-  setAlpha(_alpha) {}
-  setVisible(_visible) {}
+  setAlpha(_alpha): this {
+    return this;
+  }
+  setVisible(_visible): this {
+    return this;
+  }
 
-  setName(_name) {}
+  setName(_name): this {
+    return this;
+  }
 
-  once(_event, _callback, _source) {}
+  once(_event, _callback, _source): this {
+    return this;
+  }
 
-  removeFromDisplayList() {
+  removeFromDisplayList(): this {
     // same as remove or destroy
+    return this;
   }
 
   addedToScene() {
@@ -35,9 +46,10 @@ export default class MockRectangle implements MockGameObject {
     this.list = [];
   }
 
-  add(obj) {
+  add(obj): this {
     // Adds a child to this Game Object.
     this.list.push(obj);
+    return this;
   }
 
   removeAll() {
@@ -45,16 +57,18 @@ export default class MockRectangle implements MockGameObject {
     this.list = [];
   }
 
-  addAt(obj, index) {
+  addAt(obj, index): this {
     // Adds a Game Object to this Container at the given index.
     this.list.splice(index, 0, obj);
+    return this;
   }
 
-  remove(obj) {
+  remove(obj): this {
     const index = this.list.indexOf(obj);
     if (index !== -1) {
       this.list.splice(index, 1);
     }
+    return this;
   }
 
   getIndex(obj) {
@@ -69,9 +83,12 @@ export default class MockRectangle implements MockGameObject {
   getAll() {
     return this.list;
   }
-  setScale(_scale) {
+  setScale(_scale): this {
     // return this.phaserText.setScale(scale);
+    return this;
   }
 
-  off() {}
+  off(): this {
+    return this;
+  }
 }

--- a/test/testUtils/mocks/mocksContainer/mockRectangle.ts
+++ b/test/testUtils/mocks/mocksContainer/mockRectangle.ts
@@ -38,8 +38,9 @@ export default class MockRectangle implements MockGameObject {
     // This callback is invoked when this Game Object is added to a Scene.
   }
 
-  setPositionRelative(_source, _x, _y) {
+  setPositionRelative(_source, _x, _y): this {
     /// Sets the position of this Game Object to be a relative position from the source Game Object.
+    return this;
   }
 
   destroy() {

--- a/test/testUtils/mocks/mocksContainer/mockSprite.ts
+++ b/test/testUtils/mocks/mocksContainer/mockSprite.ts
@@ -142,7 +142,8 @@ export default class MockSprite implements MockGameObject {
 
   setPositionRelative(source, x, y): this {
     /// Sets the position of this Game Object to be a relative position from the source Game Object.
-    return this.phaserSprite.setPositionRelative(source, x, y);
+    this.phaserSprite.setPositionRelative(source, x, y);
+    return this;
   }
 
   setY(y: number): this {

--- a/test/testUtils/mocks/mocksContainer/mockSprite.ts
+++ b/test/testUtils/mocks/mocksContainer/mockSprite.ts
@@ -22,6 +22,7 @@ export default class MockSprite implements MockGameObject {
     // @ts-ignore
     Phaser.GameObjects.Sprite.prototype.setTexture = this.setTexture;
     Phaser.GameObjects.Sprite.prototype.setSizeToFrame = this.setSizeToFrame;
+    // @ts-ignore
     Phaser.GameObjects.Sprite.prototype.setFrame = this.setFrame;
     // Phaser.GameObjects.Sprite.prototype.disable = this.disable;
 
@@ -37,7 +38,7 @@ export default class MockSprite implements MockGameObject {
     };
   }
 
-  setTexture(_key: string, _frame?: string | number) {
+  setTexture(_key: string, _frame?: string | number): this {
     return this;
   }
 
@@ -45,38 +46,47 @@ export default class MockSprite implements MockGameObject {
     return {} as Sprite;
   }
 
-  setPipeline(obj) {
+  setPipeline(obj): this {
     // Sets the pipeline of this Game Object.
-    return this.phaserSprite.setPipeline(obj);
+    this.phaserSprite.setPipeline(obj);
+    return this;
   }
 
-  off(_event, _callback, _source) {}
+  off(_event, _callback, _source): this {
+    return this;
+  }
 
-  setTintFill(color) {
+  setTintFill(color): this {
     // Sets the tint fill color.
-    return this.phaserSprite.setTintFill(color);
+    this.phaserSprite.setTintFill(color);
+    return this;
   }
 
-  setScale(scale) {
-    return this.phaserSprite.setScale(scale);
+  setScale(scale): this {
+    this.phaserSprite.setScale(scale);
+    return this;
   }
 
-  setOrigin(x, y) {
-    return this.phaserSprite.setOrigin(x, y);
+  setOrigin(x, y): this {
+    this.phaserSprite.setOrigin(x, y);
+    return this;
   }
 
-  setSize(width, height) {
+  setSize(width, height): this {
     // Sets the size of this Game Object.
-    return this.phaserSprite.setSize(width, height);
+    this.phaserSprite.setSize(width, height);
+    return this;
   }
 
-  once(event, callback, source) {
-    return this.phaserSprite.once(event, callback, source);
+  once(event, callback, source): this {
+    this.phaserSprite.once(event, callback, source);
+    return this;
   }
 
-  removeFromDisplayList() {
+  removeFromDisplayList(): this {
     // same as remove or destroy
-    return this.phaserSprite.removeFromDisplayList();
+    this.phaserSprite.removeFromDisplayList();
+    return this;
   }
 
   addedToScene() {
@@ -84,97 +94,116 @@ export default class MockSprite implements MockGameObject {
     return this.phaserSprite.addedToScene();
   }
 
-  setVisible(visible) {
-    return this.phaserSprite.setVisible(visible);
+  setVisible(visible): this {
+    this.phaserSprite.setVisible(visible);
+    return this;
   }
 
-  setPosition(x, y) {
-    return this.phaserSprite.setPosition(x, y);
+  setPosition(x, y): this {
+    this.phaserSprite.setPosition(x, y);
+    return this;
   }
 
-  setRotation(radians) {
-    return this.phaserSprite.setRotation(radians);
+  setRotation(radians): this {
+    this.phaserSprite.setRotation(radians);
+    return this;
   }
 
-  stop() {
-    return this.phaserSprite.stop();
+  stop(): this {
+    this.phaserSprite.stop();
+    return this;
   }
 
-  setInteractive = () => null;
-
-  on(event, callback, source) {
-    return this.phaserSprite.on(event, callback, source);
+  setInteractive(): this {
+    return this;
   }
 
-  setAlpha(alpha) {
-    return this.phaserSprite.setAlpha(alpha);
+  on(event, callback, source): this {
+    this.phaserSprite.on(event, callback, source);
+    return this;
   }
 
-  setTint(color) {
+  setAlpha(alpha): this {
+    this.phaserSprite.setAlpha(alpha);
+    return this;
+  }
+
+  setTint(color): this {
     // Sets the tint of this Game Object.
-    return this.phaserSprite.setTint(color);
+    this.phaserSprite.setTint(color);
+    return this;
   }
 
-  setFrame(frame, _updateSize?: boolean, _updateOrigin?: boolean) {
+  setFrame(frame, _updateSize?: boolean, _updateOrigin?: boolean): this {
     // Sets the frame this Game Object will use to render with.
     this.frame = frame;
-    return frame;
+    return this;
   }
 
   setPositionRelative(source, x, y) {
     /// Sets the position of this Game Object to be a relative position from the source Game Object.
-    return this.phaserSprite.setPositionRelative(source, x, y);
+    this.phaserSprite.setPositionRelative(source, x, y);
   }
 
-  setY(y) {
-    return this.phaserSprite.setY(y);
+  setY(y: number): this {
+    this.phaserSprite.setY(y);
+    return this;
   }
 
-  setCrop(x, y, width, height) {
+  setCrop(x: number, y: number, width: number, height: number): this {
     // Sets the crop size of this Game Object.
-    return this.phaserSprite.setCrop(x, y, width, height);
+    this.phaserSprite.setCrop(x, y, width, height);
+    return this;
   }
 
-  clearTint() {
+  clearTint(): this {
     // Clears any previously set tint.
-    return this.phaserSprite.clearTint();
+    this.phaserSprite.clearTint();
+    return this;
   }
 
-  disableInteractive() {
+  disableInteractive(): this {
     // Disables Interactive features of this Game Object.
-    return null;
+    return this;
   }
 
   apply() {
-    return this.phaserSprite.apply();
+    this.phaserSprite.apply();
+    return this;
   }
 
-  play() {
+  play(): this {
     // return this.phaserSprite.play();
     return this;
   }
 
-  setPipelineData(key, value) {
+  setPipelineData(key: string, value: any): this {
     this.pipelineData[key] = value;
+    return this;
   }
 
   destroy() {
     return this.phaserSprite.destroy();
   }
 
-  setName(name) {
-    return this.phaserSprite.setName(name);
+  setName(name: string): this {
+    this.phaserSprite.setName(name);
+    return this;
   }
 
-  setAngle(angle) {
-    return this.phaserSprite.setAngle(angle);
+  setAngle(angle): this {
+    this.phaserSprite.setAngle(angle);
+    return this;
   }
 
-  setMask() {}
+  setMask(): this {
+    return this;
+  }
 
-  add(obj) {
+  add(obj): this {
     // Adds a child to this Game Object.
     this.list.push(obj);
+    return this;
   }
 
   removeAll() {
@@ -182,16 +211,18 @@ export default class MockSprite implements MockGameObject {
     this.list = [];
   }
 
-  addAt(obj, index) {
+  addAt(obj, index): this {
     // Adds a Game Object to this Container at the given index.
     this.list.splice(index, 0, obj);
+    return this;
   }
 
-  remove(obj) {
+  remove(obj): this {
     const index = this.list.indexOf(obj);
     if (index !== -1) {
       this.list.splice(index, 1);
     }
+    return this;
   }
 
   getIndex(obj) {
@@ -205,5 +236,10 @@ export default class MockSprite implements MockGameObject {
 
   getAll() {
     return this.list;
+  }
+
+  copyPosition(obj): this {
+    this.phaserSprite.copyPosition(obj);
+    return this;
   }
 }

--- a/test/testUtils/mocks/mocksContainer/mockSprite.ts
+++ b/test/testUtils/mocks/mocksContainer/mockSprite.ts
@@ -140,9 +140,9 @@ export default class MockSprite implements MockGameObject {
     return this;
   }
 
-  setPositionRelative(source, x, y) {
+  setPositionRelative(source, x, y): this {
     /// Sets the position of this Game Object to be a relative position from the source Game Object.
-    this.phaserSprite.setPositionRelative(source, x, y);
+    return this.phaserSprite.setPositionRelative(source, x, y);
   }
 
   setY(y: number): this {

--- a/test/testUtils/mocks/mocksContainer/mockSprite.ts
+++ b/test/testUtils/mocks/mocksContainer/mockSprite.ts
@@ -1,6 +1,5 @@
 import Phaser from "phaser";
 import type { MockGameObject } from "../mockGameObject";
-import Sprite = Phaser.GameObjects.Sprite;
 import Frame = Phaser.Textures.Frame;
 
 export default class MockSprite implements MockGameObject {
@@ -21,6 +20,7 @@ export default class MockSprite implements MockGameObject {
     Phaser.GameObjects.Sprite.prototype.setInteractive = this.setInteractive;
     // @ts-ignore
     Phaser.GameObjects.Sprite.prototype.setTexture = this.setTexture;
+    // @ts-ignore
     Phaser.GameObjects.Sprite.prototype.setSizeToFrame = this.setSizeToFrame;
     // @ts-ignore
     Phaser.GameObjects.Sprite.prototype.setFrame = this.setFrame;
@@ -42,8 +42,8 @@ export default class MockSprite implements MockGameObject {
     return this;
   }
 
-  setSizeToFrame(_frame?: boolean | Frame): Sprite {
-    return {} as Sprite;
+  setSizeToFrame(_frame?: boolean | Frame): this {
+    return this;
   }
 
   setPipeline(obj): this {
@@ -62,12 +62,12 @@ export default class MockSprite implements MockGameObject {
     return this;
   }
 
-  setScale(scale): this {
+  setScale(scale = 1): this {
     this.phaserSprite.setScale(scale);
     return this;
   }
 
-  setOrigin(x, y): this {
+  setOrigin(x = 0.5, y = x): this {
     this.phaserSprite.setOrigin(x, y);
     return this;
   }

--- a/test/testUtils/mocks/mocksContainer/mockText.ts
+++ b/test/testUtils/mocks/mocksContainer/mockText.ts
@@ -197,9 +197,10 @@ export default class MockText implements MockGameObject {
     return this;
   }
 
-  setPositionRelative(_source, _x, _y) {
+  setPositionRelative(_source, _x, _y): this {
     /// Sets the position of this Game Object to be a relative position from the source Game Object.
     // return this.phaserText.setPositionRelative(source, x, y);
+    return this;
   }
 
   setShadowOffset(_offsetX, _offsetY): this {

--- a/test/testUtils/mocks/mocksContainer/mockText.ts
+++ b/test/testUtils/mocks/mocksContainer/mockText.ts
@@ -107,42 +107,51 @@ export default class MockText implements MockGameObject {
     }
   }
 
-  setScale(_scale) {
+  setScale(_scale): this {
     // return this.phaserText.setScale(scale);
+    return this;
   }
 
-  setShadow(_shadowXpos, _shadowYpos, _shadowColor) {
+  setShadow(_shadowXpos, _shadowYpos, _shadowColor): this {
     // Sets the shadow settings for this Game Object.
     // return this.phaserText.setShadow(shadowXpos, shadowYpos, shadowColor);
+    return this;
   }
 
-  setLineSpacing(_lineSpacing) {
+  setLineSpacing(_lineSpacing): this {
     // Sets the line spacing value of this Game Object.
     // return this.phaserText.setLineSpacing(lineSpacing);
+    return this;
   }
 
-  setOrigin(_x, _y) {
+  setOrigin(_x, _y): this {
     // return this.phaserText.setOrigin(x, y);
+    return this;
   }
 
-  once(_event, _callback, _source) {
+  once(_event, _callback, _source): this {
     // return this.phaserText.once(event, callback, source);
+    return this;
   }
 
   off(_event, _callback, _obj) {}
 
   removedFromScene() {}
 
-  addToDisplayList() {}
-
-  setStroke(_color, _thickness) {
-    // Sets the stroke color and thickness.
-    // return this.phaserText.setStroke(color, thickness);
+  addToDisplayList(): this {
+    return this;
   }
 
-  removeFromDisplayList() {
+  setStroke(_color, _thickness): this {
+    // Sets the stroke color and thickness.
+    // return this.phaserText.setStroke(color, thickness);
+    return this;
+  }
+
+  removeFromDisplayList(): this {
     // same as remove or destroy
     // return this.phaserText.removeFromDisplayList();
+    return this;
   }
 
   addedToScene() {
@@ -154,12 +163,14 @@ export default class MockText implements MockGameObject {
     // return this.phaserText.setVisible(visible);
   }
 
-  setY(_y) {
+  setY(_y): this {
     // return this.phaserText.setY(y);
+    return this;
   }
 
-  setX(_x) {
+  setX(_x): this {
     // return this.phaserText.setX(x);
+    return this;
   }
 
   /**
@@ -169,17 +180,21 @@ export default class MockText implements MockGameObject {
    * @param z The z position of this Game Object. Default 0.
    * @param w The w position of this Game Object. Default 0.
    */
-  setPosition(_x?: number, _y?: number, _z?: number, _w?: number) {}
+  setPosition(_x?: number, _y?: number, _z?: number, _w?: number): this {
+    return this;
+  }
 
-  setText(text) {
+  setText(text): this {
     // Sets the text this Game Object will display.
     // return this.phaserText.setText\(text);
     this.text = text;
+    return this;
   }
 
-  setAngle(_angle) {
+  setAngle(_angle): this {
     // Sets the angle of this Game Object.
     // return this.phaserText.setAngle(angle);
+    return this;
   }
 
   setPositionRelative(_source, _x, _y) {
@@ -187,9 +202,10 @@ export default class MockText implements MockGameObject {
     // return this.phaserText.setPositionRelative(source, x, y);
   }
 
-  setShadowOffset(_offsetX, _offsetY) {
+  setShadowOffset(_offsetX, _offsetY): this {
     // Sets the shadow offset values.
     // return this.phaserText.setShadowOffset(offsetX, offsetY);
+    return this;
   }
 
   setWordWrapWidth(width) {
@@ -197,9 +213,10 @@ export default class MockText implements MockGameObject {
     this.wordWrapWidth = width;
   }
 
-  setFontSize(_fontSize) {
+  setFontSize(_fontSize): this {
     // Sets the font size of this Game Object.
     // return this.phaserText.setFontSize(fontSize);
+    return this;
   }
 
   getBounds() {
@@ -209,25 +226,31 @@ export default class MockText implements MockGameObject {
     };
   }
 
-  setColor(color: string) {
+  setColor(color: string): this {
     this.color = color;
+    return this;
   }
 
-  setInteractive = () => null;
+  setInteractive(): this {
+    return this;
+  }
 
-  setShadowColor(_color) {
+  setShadowColor(_color): this {
     // Sets the shadow color.
     // return this.phaserText.setShadowColor(color);
+    return this;
   }
 
-  setTint(_color) {
+  setTint(_color): this {
     // Sets the tint of this Game Object.
     // return this.phaserText.setTint(color);
+    return this;
   }
 
-  setStrokeStyle(_thickness, _color) {
+  setStrokeStyle(_thickness, _color): this {
     // Sets the stroke style for the graphics.
     // return this.phaserText.setStrokeStyle(thickness, color);
+    return this;
   }
 
   destroy() {
@@ -235,20 +258,24 @@ export default class MockText implements MockGameObject {
     this.list = [];
   }
 
-  setAlpha(_alpha) {
+  setAlpha(_alpha): this {
     // return this.phaserText.setAlpha(alpha);
+    return this;
   }
 
-  setName(name: string) {
+  setName(name: string): this {
     this.name = name;
+    return this;
   }
 
-  setAlign(_align) {
+  setAlign(_align): this {
     // return this.phaserText.setAlign(align);
+    return this;
   }
 
-  setMask() {
+  setMask(): this {
     /// Sets the mask that this Game Object will use to render with.
+    return this;
   }
 
   getBottomLeft() {
@@ -265,37 +292,43 @@ export default class MockText implements MockGameObject {
     };
   }
 
-  disableInteractive() {
+  disableInteractive(): this {
     // Disables interaction with this Game Object.
+    return this;
   }
 
-  clearTint() {
+  clearTint(): this {
     // Clears tint on this Game Object.
+    return this;
   }
 
-  add(obj) {
+  add(obj): this {
     // Adds a child to this Game Object.
     this.list.push(obj);
+    return this;
   }
 
-  removeAll() {
+  removeAll(): this {
     // Removes all Game Objects from this Container.
     this.list = [];
+    return this;
   }
 
-  addAt(obj, index) {
+  addAt(obj, index): this {
     // Adds a Game Object to this Container at the given index.
     this.list.splice(index, 0, obj);
+    return this;
   }
 
-  remove(obj) {
+  remove(obj): this {
     const index = this.list.indexOf(obj);
     if (index !== -1) {
       this.list.splice(index, 1);
     }
+    return this;
   }
 
-  getIndex(obj) {
+  getIndex(obj): number {
     const index = this.list.indexOf(obj);
     return index || -1;
   }

--- a/test/testUtils/testFileInitialization.ts
+++ b/test/testUtils/testFileInitialization.ts
@@ -70,10 +70,10 @@ export function initTestFile() {
    * @param x The relative x position
    * @param y The relative y position
    */
-  const setPositionRelative = function (guideObject: any, x: number, y: number) {
+  const setPositionRelative = function (guideObject: any, x: number, y: number): any {
     const offsetX = guideObject.width * (-0.5 + (0.5 - guideObject.originX));
     const offsetY = guideObject.height * (-0.5 + (0.5 - guideObject.originY));
-    this.setPosition(guideObject.x + offsetX + x, guideObject.y + offsetY + y);
+    return this.setPosition(guideObject.x + offsetX + x, guideObject.y + offsetY + y);
   };
 
   Phaser.GameObjects.Container.prototype.setPositionRelative = setPositionRelative;


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
There are mumblings of wanting to change parts of the battle ui. I took a look at the ui file to try to get an understanding of what is going on there, and it's in quite poor shape.

## What are the changes from a developer perspective?
Created a new directroy, `src/ui/battle-info`.
Moved the old `battle-info.ts` file into it.
Converted `BattleInfo` into an abstract class, as it should never be instantiated itself.

I did not change any code logic. This was entirely just moving things around and cleaning up poor syntax to replace with equivalent code:

I didn't even clean up suspicious logic, such as this:
```ts
const baseVariant = !doubleShiny ? pokemon.getVariant(true) : pokemon.variant;
```
As that is not the point of this PR

- Made it so all methods now pass the `cognitiveComplexity` biome lint, by splitting up methods into smaller methods.

- Made it so that all of the phaser methods that return `this` for chaining actually use chaining. This shortens the code and makes it clearer what is going on.

- Moved methods into the `PlayerBattleInfo` and `EnemyBattleInfo` class into their own files.
  - Any method of `BattleInfo` class that had functionality surrounded by ``(if !playerInfo)`` (or not negated) had that logic moved to an overridden method in the respective class that calls the base class's method before doing that logic.

- Removed `updateEffectiveness` from `Pokemon` and only into `EnemyPokemon` class, as we never look at effectiveness for the player pokemon.

- Created a new function in `utils/common.ts` (I didn't know a better spot to put this) for getting the shiny descriptor for a variant.
- Modified all of the `GameObject` mocks in `test/testUtils/mocksContainer` to properly return the `this` parameter as required for certain methods. Also added a few mocked methods that were missing and necessary.

Previously, there was this nasty method contributing ~12 points of cognitive complexity:
```ts
doubleShiny || baseVariant ? `${baseVariant === 2 ? i18next.t("common:epicShiny") : baseVariant === 1 ? i18next.t("common:rareShiny") : i18next.t("common:commonShiny")}${doubleShiny ? `/${pokemon.fusionVariant === 2 ? i18next.t("common:epicShiny") : pokemon.fusionVariant === 1 ? i18next.t("common:rareShiny") : i18next.t("common:commonShiny")}` : ""}`
```

I updated `pokemon-info-container`, which also had the exact same pattern, to use this method. That's why that file was touched here as well.

Instead of that long ternary chain, I just made a short and sweet method that resolves to the i18n key for the variant.
## Screenshots/Videos
N/A

## How to test the changes?
N/A

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?