### PR TITLE
[Bug] Fix doubles trainers not initializing properly

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1394,9 +1394,9 @@ export default class BattleScene extends SceneBase {
     if (double === undefined && newWaveIndex > 1) {
       if (newBattleType === BattleType.WILD && !this.gameMode.isWaveFinal(newWaveIndex)) {
         newDouble = !randSeedInt(this.getDoubleBattleChance(newWaveIndex, playerField));
+      } else if (newBattleType === BattleType.TRAINER) {
+        newDouble = newTrainer?.variant === TrainerVariant.DOUBLE;
       }
-    } else if (double === undefined && newBattleType === BattleType.TRAINER) {
-      newDouble = newTrainer?.variant === TrainerVariant.DOUBLE;
     } else if (!battleConfig) {
       newDouble = !!double;
     }


### PR DESCRIPTION
## What are the changes the user will see?
Doubles trainer battles will no longer require a reload for the battle to start correctly.

## Why am I making these changes?
Issue caused by #5644 

## What are the changes from a developer perspective?
Reverted the change to the `newDouble` logic in `BattleScene#newBattle`.

## How to test the changes?
Add this to L1354 in `BattleScene#newBattle`:
```ts
      if (newWaveIndex === 2) {
        newBattleType = BattleType.TRAINER;
      }
```
Use this override:
```ts
const overrides = {
  RANDOM_TRAINER_OVERRIDE: {
    trainerType: TrainerType.TWINS,
  }
} satisfies Partial<InstanceType<OverridesType>>;
```
Then start a new classic run and beat wave 1. Wave 2 should be a Twins fight and the bug will occur if the fix is not implemented.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?