### PR TITLE
[Bug] Fix improper critical hit key in move effect phase

### DIFF
--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -859,7 +859,7 @@ export class MoveEffectPhase extends PokemonPhase {
         });
 
     if (isCritical) {
-      globalScene.queueMessage(i18next.t("battle:criticalHit"));
+      globalScene.queueMessage(i18next.t("battle:hitResultCriticalHit"));
     }
 
     if (damage <= 0) {


### PR DESCRIPTION
## What are the changes the user will see?
When critically hitting, the user will now see proper `A critical hit!` message (or associated locale) instead of the `criticalHit` key.

## Why am I making these changes?
A regression introduced in #4887 due to a changed i18nkey

## What are the changes from a developer perspective?

Replaced the `battle:criticalHit` key with the proper `battle:hitResultCriticalHit`

## Screenshots/Videos

<details><summary>Proper critical hit message</summary>

https://github.com/user-attachments/assets/2b28871c-30ee-4d37-bb33-bd0da525044c
</details>

## How to test the changes?
I use frost breath in the overrides

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~