### PR TITLE
[Bug] Hotfix 1.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pokemon-rogue-battle",
   "private": true,
-  "version": "1.8.4",
+  "version": "1.8.5",
   "type": "module",
   "scripts": {
     "start": "vite",

--- a/src/plugins/api/pokerogue-system-savedata-api.ts
+++ b/src/plugins/api/pokerogue-system-savedata-api.ts
@@ -15,14 +15,17 @@ export class PokerogueSystemSavedataApi extends ApiBase {
   /**
    * Get a system savedata.
    * @param params The {@linkcode GetSystemSavedataRequest} to send
-   * @returns The system savedata as `string` or `null` on error
+   * @returns The system savedata as `string` or either the status code or `null` on error
    */
-  public async get(params: GetSystemSavedataRequest) {
+  public async get(params: GetSystemSavedataRequest): Promise<string | number | null> {
     try {
       const urlSearchParams = this.toUrlSearchParams(params);
       const response = await this.doGet(`/savedata/system/get?${urlSearchParams}`);
       const rawSavedata = await response.text();
-
+      if (!response.ok) {
+        console.warn("Could not get system savedata!", response.status, rawSavedata);
+        return response.status;
+      }
       return rawSavedata;
     } catch (err) {
       console.warn("Could not get system savedata!", err);

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -461,8 +461,13 @@ export class GameData {
 
       if (!bypassLogin) {
         pokerogueApi.savedata.system.get({ clientSessionId }).then(saveDataOrErr => {
-          if (!saveDataOrErr || saveDataOrErr.length === 0 || saveDataOrErr[0] !== "{") {
-            if (saveDataOrErr?.startsWith("sql: no rows in result set")) {
+          if (
+            typeof saveDataOrErr === "number" ||
+            !saveDataOrErr ||
+            saveDataOrErr.length === 0 ||
+            saveDataOrErr[0] !== "{"
+          ) {
+            if (saveDataOrErr === 404) {
               globalScene.queueMessage(
                 "Save data could not be found. If this is a new account, you can safely ignore this message.",
                 null,
@@ -470,7 +475,7 @@ export class GameData {
               );
               return resolve(true);
             }
-            if (saveDataOrErr?.includes("Too many connections")) {
+            if (typeof saveDataOrErr === "string" && saveDataOrErr?.includes("Too many connections")) {
               globalScene.queueMessage(
                 "Too many people are trying to connect and the server is overloaded. Please try again later.",
                 null,
@@ -478,7 +483,6 @@ export class GameData {
               );
               return resolve(false);
             }
-            console.error(saveDataOrErr);
             return resolve(false);
           }
 
@@ -1499,7 +1503,7 @@ export class GameData {
         link.remove();
       };
       if (!bypassLogin && dataType < GameDataType.SETTINGS) {
-        let promise: Promise<string | null> = Promise.resolve(null);
+        let promise: Promise<string | null | number> = Promise.resolve(null);
 
         if (dataType === GameDataType.SYSTEM) {
           promise = pokerogueApi.savedata.system.get({ clientSessionId });
@@ -1511,7 +1515,7 @@ export class GameData {
         }
 
         promise.then(response => {
-          if (!response?.length || response[0] !== "{") {
+          if (typeof response === "number" || !response?.length || response[0] !== "{") {
             console.error(response);
             resolve(false);
             return;


### PR DESCRIPTION
## What are the changes the user will see?
When trying to load system data from the server and it returns an error `404` status code, the user will now be able to continue.  This reflects a change on the server side the error message changed from a string. We are now instead relying on the number.

## Why am I making these changes?
This fixes an urgent error related to new users being unable to login.

## What are the changes from a developer perspective?
`pokerogue-system-save-data-api#get` can now return a number in the case that the response did not send an `ok`. If this happens, then the error message logged to the console.

In the `game-data` method, we now check against the return type being a number. If it is a number, then we check if it is 404. A 404 error is benign, meaning that no save data exists on the server, which is expected for new accounts. Before, we were relying on the message string. However, the message string has changed, and we should be relying on response codes.
