### PR TITLE
[Dev] Add enemy pokemon level to encounter logging

### DIFF
--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -424,6 +424,7 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
     console.log(
       `Pokemon: ${getPokemonNameWithAffix(enemyPokemon)}`,
       `| Species ID: ${enemyPokemon.species.speciesId}`,
+      `| Level: ${enemyPokemon.level}`,
       `| Nature: ${getNatureName(enemyPokemon.nature, true, true, true)}`,
     );
     console.log(`Stats (IVs): ${stats}`);

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -2,7 +2,12 @@ import { BattlerIndex } from "#app/battle";
 import { BattleType } from "#enums/battle-type";
 import { globalScene } from "#app/global-scene";
 import { PLAYER_PARTY_MAX_SIZE } from "#app/constants";
-import { applyAbAttrs, SyncEncounterNatureAbAttr, applyPreSummonAbAttrs, PreSummonAbAttr } from "#app/data/abilities/ability";
+import {
+  applyAbAttrs,
+  SyncEncounterNatureAbAttr,
+  applyPreSummonAbAttrs,
+  PreSummonAbAttr,
+} from "#app/data/abilities/ability";
 import { initEncounterAnims, loadEncounterAnimAssets } from "#app/data/battle-anims";
 import { getCharVariantFromDialogue } from "#app/data/dialogue";
 import { getEncounterText } from "#app/data/mystery-encounters/utils/encounter-dialogue-utils";
@@ -196,6 +201,7 @@ export class EncounterPhase extends BattlePhase {
       console.log(
         `Pokemon: ${getPokemonNameWithAffix(enemyPokemon)}`,
         `| Species ID: ${enemyPokemon.species.speciesId}`,
+        `| Level: ${enemyPokemon.level}`,
         `| Nature: ${getNatureName(enemyPokemon.nature, true, true, true)}`,
       );
       console.log(`Stats (IVs): ${stats}`);


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
To aid in development of battles.

## What are the changes from a developer perspective?
Added logging of enemy Pokémon levels in `EncounterPhase` and `encounter-phase-utils.ts`.

## Screenshots/Videos
![image](https://github.com/user-attachments/assets/9576dfe3-8dda-4d38-a5b9-f8062699a1ba)

## How to test the changes?
Open the browser devtools and observe the console log when starting a new wave.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?