### PR TITLE
[Balance] Trainer pokemon now have minimum IVs of `wave/10`

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -12,7 +12,6 @@ import BattleInfo, {
 import type Move from "#app/data/moves/move";
 import {
   HighCritAttr,
-  StatChangeBeforeDmgCalcAttr,
   HitsTagAttr,
   applyMoveAttrs,
   FixedDamageAttr,
@@ -70,10 +69,8 @@ import {
   EFFECTIVE_STATS,
 } from "#enums/stat";
 import {
-  DamageMoneyRewardModifier,
   EnemyDamageBoosterModifier,
   EnemyDamageReducerModifier,
-  EnemyEndureChanceModifier,
   EnemyFusionChanceModifier,
   HiddenAbilityRateBoosterModifier,
   BaseStatModifier,
@@ -119,7 +116,6 @@ import {
   TypeImmuneTag,
   getBattlerTag,
   SemiInvulnerableTag,
-  TypeBoostTag,
   MoveRestrictionBattlerTag,
   ExposedTag,
   DragonCheerTag,
@@ -188,7 +184,7 @@ import {
   PreLeaveFieldRemoveSuppressAbilitiesSourceAbAttr,
   applyAllyStatMultiplierAbAttrs,
   AllyStatMultiplierAbAttr,
-  MoveAbilityBypassAbAttr
+  MoveAbilityBypassAbAttr,
 } from "#app/data/abilities/ability";
 import { allAbilities } from "#app/data/data-lists";
 import type PokemonData from "#app/system/pokemon-data";
@@ -202,7 +198,7 @@ import {
   EVOLVE_MOVE,
   RELEARN_MOVE,
 } from "#app/data/balance/pokemon-level-moves";
-import { DamageAchv, achvs } from "#app/system/achv";
+import { achvs } from "#app/system/achv";
 import type { StarterDataEntry, StarterMoveset } from "#app/system/game-data";
 import { DexAttr } from "#app/system/game-data";
 import {
@@ -248,7 +244,7 @@ import { PLAYER_PARTY_MAX_SIZE } from "#app/constants";
 import { CustomPokemonData } from "#app/data/custom-pokemon-data";
 import { SwitchType } from "#enums/switch-type";
 import { SpeciesFormKey } from "#enums/species-form-key";
-import {getStatusEffectOverlapText } from "#app/data/status-effect";
+import { getStatusEffectOverlapText } from "#app/data/status-effect";
 import {
   BASE_HIDDEN_ABILITY_CHANCE,
   BASE_SHINY_CHANCE,
@@ -7029,6 +7025,12 @@ export class EnemyPokemon extends Pokemon {
           evolution.condition.enforceFunc(this);
         }
         speciesId = prevolution;
+      }
+
+      if (this.hasTrainer() && globalScene.currentBattle) {
+        for (const index in this.ivs) {
+          this.ivs[index] = Math.max(this.ivs[index], Math.floor(globalScene.currentBattle.waveIndex / 10));
+        }
       }
     }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -7028,9 +7028,12 @@ export class EnemyPokemon extends Pokemon {
       }
 
       if (this.hasTrainer() && globalScene.currentBattle) {
-        for (const index in this.ivs) {
-          this.ivs[index] = Math.max(this.ivs[index], Math.floor(globalScene.currentBattle.waveIndex / 10));
+        const { waveIndex } = globalScene.currentBattle;
+        const ivs: number[] = [];
+        while (ivs.length < 6) {
+          ivs.push(this.randSeedIntRange(Math.floor(waveIndex / 10), 31));
         }
+        this.ivs = ivs;
       }
     }
 

--- a/test/field/pokemon.test.ts
+++ b/test/field/pokemon.test.ts
@@ -209,4 +209,19 @@ describe("Spec - Pokemon", () => {
       expect(types[1]).toBe(PokemonType.DARK);
     });
   });
+
+  it.each([5, 25, 55, 95, 145, 195])(
+    "should set minimum IVs for enemy trainer pokemon based on wave (%i)",
+    async wave => {
+      game.override.startingWave(wave);
+      await game.classicMode.startBattle([Species.FEEBAS]);
+      const { waveIndex } = game.scene.currentBattle;
+
+      for (const pokemon of game.scene.getEnemyParty()) {
+        for (const index in pokemon.ivs) {
+          expect(pokemon.ivs[index]).toBeGreaterThanOrEqual(Math.floor(waveIndex / 10));
+        }
+      }
+    },
+  );
 });


### PR DESCRIPTION
## What are the changes the user will see?
Trainer pokemon will all have minimum IVs based on the current wave (`floor(wave/10)`).

## Why am I making these changes?
Request from balance team.

## What are the changes from a developer perspective?
In the `EnemyPokemon` constructor, a new set of IVs are generated using `floor(wave/10)` as the minimum value and the existing IVs array is overwritten with the new array.

## Screenshots/Videos
<details><summary>Rival 195 fight</summary>
<p>

![image](https://github.com/user-attachments/assets/5b4a29ae-13e1-48d1-a74b-77ec08041f58)

</p>
</details> 
<details><summary>Wild pokemon wave 194</summary>
<p>

![image](https://github.com/user-attachments/assets/4b1e6d63-7c0d-46d7-9c81-4b63acd8aadc)

</p>
</details> 

## How to test the changes?
Check the console logs that show the enemy pokemon on various waves and encounter types.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?