### PR TITLE
[Bug][Item] Only moves will now show the explicit status immunity effect.

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -2463,7 +2463,7 @@ export class StatusEffectAttr extends MoveEffectAttr {
         return false;
       }
       if (((!pokemon.status || this.overrideStatus) || (pokemon.status.effect === this.effect && moveChance < 0))
-        && pokemon.trySetStatus(this.effect, true, user, this.turnsRemaining, null, this.overrideStatus)) {
+        && pokemon.trySetStatus(this.effect, true, user, this.turnsRemaining, null, this.overrideStatus, false)) {
         applyPostAttackAbAttrs(ConfusionOnStatusEffectAbAttr, user, target, move, null, false, this.effect);
         return true;
       }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -5529,9 +5529,10 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     sourcePokemon: Pokemon | null = null,
     turnsRemaining = 0,
     sourceText: string | null = null,
-    overrideStatus?: boolean
+    overrideStatus?: boolean,
+    quiet = false,
   ): boolean {
-    if (!this.canSetStatus(effect, false, overrideStatus, sourcePokemon)) {
+    if (!this.canSetStatus(effect, quiet, overrideStatus, sourcePokemon)) {
       return false;
     }
     if (this.isFainted() && effect !== StatusEffect.FAINT) {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -5530,7 +5530,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     turnsRemaining = 0,
     sourceText: string | null = null,
     overrideStatus?: boolean,
-    quiet = false,
+    quiet = true,
   ): boolean {
     if (!this.canSetStatus(effect, quiet, overrideStatus, sourcePokemon)) {
       return false;

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -1743,7 +1743,7 @@ export class TurnStatusEffectModifier extends PokemonHeldItemModifier {
    * @returns `true` if the status effect was applied successfully
    */
   override apply(pokemon: Pokemon): boolean {
-    return pokemon.trySetStatus(this.effect, true, undefined, undefined, this.type.name);
+    return pokemon.trySetStatus(this.effect, true, undefined, undefined, this.type.name, undefined, true);
   }
 
   getMaxHeldItemCount(_pokemon: Pokemon): number {

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -1743,7 +1743,7 @@ export class TurnStatusEffectModifier extends PokemonHeldItemModifier {
    * @returns `true` if the status effect was applied successfully
    */
   override apply(pokemon: Pokemon): boolean {
-    return pokemon.trySetStatus(this.effect, true, undefined, undefined, this.type.name, undefined, true);
+    return pokemon.trySetStatus(this.effect, true, undefined, undefined, this.type.name);
   }
 
   getMaxHeldItemCount(_pokemon: Pokemon): number {


### PR DESCRIPTION
# What are the changes the user will see?
User will no longer be spammed with the "you are already burned" message and similar.

## Why am I making these changes?
Fixes a bug introduced in #5533.

## What are the changes from a developer perspective?
Adds a new parameter, `quiet`, to `pokemon#trySetStatus`, that defaults to true. The only instance where this called with `false` is in the move attribute that sets a status: `StatusEffectAttr`. Effects that are not moves should not show the messages for status immunities.

This prevents, for instance, flame orb from constantly showing the "But ... is already burned!" message or w/e it shows.

## Screenshots/Videos

<details><summary>Gen 9 interaction</summary>

https://github.com/user-attachments/assets/3bf32ee6-8a1a-4695-a629-012dd6ab720d
</details>

## How to test the changes?
Use the override to give your mon a flame orb, and then have it apply, and then use it.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~


## Additional Notes

Damo tested what happens when a pokemon with immunity attacks a pokemon using baneful bunker. I wanted to know if the ability flyout would show up. It doesn't!
I extrapolated this to assume that immunity messages, also, should never show up.
