### PR TITLE
[GitHub] Update pull request template to say test:silent instead of just test

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -65,7 +65,7 @@ Do the reviewers need to do something special in order to test your changes?
 - [ ] The PR is self-contained and cannot be split into smaller PRs?
 - [ ] Have I provided a clear explanation of the changes?
 - [ ] Have I tested the changes manually?
-- [ ] Are all unit tests still passing? (`npm run test`)
+- [ ] Are all unit tests still passing? (`npm run test:silent`)
   - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
 - [ ] Have I provided screenshots/videos of the changes (if applicable)?
   - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?


### PR DESCRIPTION
## What are the changes the user will see?
None

## Why am I making these changes?
Ever since #5566, we have been using `--no-isolate`. The recommended way to test is therefore to run `--no-isolate`.

## What are the changes from a developer perspective?
Makes the pr template instruct the author to use `npm run test:silent` instead of just `npm run test`

## Screenshots/Videos
N/A

## How to test the changes?
N/A

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~~[ ] Have I tested the changes manually?~~
- [x] Are all unit tests still passing? (`npm run test`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~