### PR TITLE
[Refactor] Refactor evo phase

### DIFF
--- a/src/phases/evolution-phase.ts
+++ b/src/phases/evolution-phase.ts
@@ -94,7 +94,7 @@ export class EvolutionPhase extends Phase {
       .rectangle(0, 0, globalScene.game.canvas.width / 6, globalScene.game.canvas.height / 6, 0x262626)
       .setOrigin(0)
       .setAlpha(0);
-    this.evolutionContainer.add([this.evolutionBaseBg, this.evolutionBg, this.evolutionBgOverlay]);
+    this.evolutionContainer.add([this.evolutionBaseBg, this.evolutionBgOverlay, this.evolutionBg]);
 
     this.evolutionOverlay = globalScene.add.rectangle(
       0,
@@ -224,11 +224,6 @@ export class EvolutionPhase extends Phase {
         ease: "Sine.easeOut",
         onComplete: () => {
           globalScene.time.delayedCall(1000, () => {
-            globalScene.tweens.add({
-              targets: this.evolutionBgOverlay,
-              alpha: 0,
-              duration: 250,
-            });
             this.evolutionBg.setVisible(true);
             this.evolutionBg.play();
           });

--- a/src/phases/evolution-phase.ts
+++ b/src/phases/evolution-phase.ts
@@ -411,11 +411,7 @@ export class EvolutionPhase extends Phase {
       .getLevelMoves(this.lastLevel + 1, true, false, false, learnSituation)
       .filter(lm => lm[0] === EVOLVE_MOVE);
     for (const lm of levelMoves) {
-      globalScene.phaseManager.unshiftNew(
-            "LearnMovePhase",
-            globalScene.getPlayerParty().indexOf(this.pokemon),
-            lm[1],
-          );
+      globalScene.phaseManager.unshiftNew("LearnMovePhase", globalScene.getPlayerParty().indexOf(this.pokemon), lm[1]);
     }
     globalScene.phaseManager.unshiftNew("EndEvolutionPhase");
 

--- a/src/phases/evolution-phase.ts
+++ b/src/phases/evolution-phase.ts
@@ -40,13 +40,23 @@ export class EvolutionPhase extends Phase {
   protected pokemonEvoSprite: Phaser.GameObjects.Sprite;
   protected pokemonEvoTintSprite: Phaser.GameObjects.Sprite;
 
-  constructor(pokemon: PlayerPokemon, evolution: SpeciesFormEvolution | null, lastLevel: number) {
+  /** Whether the evolution can be cancelled by the player */
+  protected canCancel: boolean;
+
+  /**
+   * @param pokemon - The Pokemon that is evolving
+   * @param evolution - The form being evolved into
+   * @param lastLevel - The level at which the Pokemon is evolving
+   * @param canCancel - Whether the evolution can be cancelled by the player
+   */
+  constructor(pokemon: PlayerPokemon, evolution: SpeciesFormEvolution | null, lastLevel: number, canCancel = false) {
     super();
 
     this.pokemon = pokemon;
     this.evolution = evolution;
     this.lastLevel = lastLevel;
     this.fusionSpeciesEvolved = evolution instanceof FusionSpeciesFormEvolution;
+    this.canCancel = canCancel;
   }
 
   validate(): boolean {
@@ -57,198 +67,233 @@ export class EvolutionPhase extends Phase {
     return globalScene.ui.setModeForceTransition(UiMode.EVOLUTION_SCENE);
   }
 
-  start() {
-    super.start();
+  /**
+   * Set up the following evolution assets
+   * - {@linkcode evolutionContainer}
+   * - {@linkcode evolutionBaseBg}
+   * - {@linkcode evolutionBg}
+   * - {@linkcode evolutionBgOverlay}
+   * - {@linkcode evolutionOverlay}
+   *
+   */
+  private setupEvolutionAssets(): void {
+    this.evolutionHandler = globalScene.ui.getHandler() as EvolutionSceneHandler;
+    this.evolutionContainer = this.evolutionHandler.evolutionContainer;
+    this.evolutionBaseBg = globalScene.add.image(0, 0, "default_bg").setOrigin(0);
 
-    this.setMode().then(() => {
-      if (!this.validate()) {
-        return this.end();
-      }
+    this.evolutionBg = globalScene.add
+      .video(0, 0, "evo_bg")
+      .stop()
+      .setOrigin(0)
+      .setScale(0.4359673025)
+      .setVisible(false);
 
-      globalScene.fadeOutBgm(undefined, false);
+    this.evolutionBgOverlay = globalScene.add
+      .rectangle(0, 0, globalScene.game.canvas.width / 6, globalScene.game.canvas.height / 6, 0x262626)
+      .setOrigin(0)
+      .setAlpha(0);
+    this.evolutionContainer.add([this.evolutionBaseBg, this.evolutionBg, this.evolutionBgOverlay]);
 
-      this.evolutionHandler = globalScene.ui.getHandler() as EvolutionSceneHandler;
+    this.evolutionOverlay = globalScene.add.rectangle(
+      0,
+      -globalScene.game.canvas.height / 6,
+      globalScene.game.canvas.width / 6,
+      globalScene.game.canvas.height / 6 - 48,
+      0xffffff,
+    );
+    this.evolutionOverlay.setOrigin(0).setAlpha(0);
+    globalScene.ui.add(this.evolutionOverlay);
+  }
 
-      this.evolutionContainer = this.evolutionHandler.evolutionContainer;
+  /**
+   * Configure the sprite, setting its pipeline data
+   * @param pokemon - The pokemon object that the sprite information is configured from
+   * @param sprite - The sprite object to configure
+   * @param setPipeline - Whether to also set the pipeline; should be false
+   *  if the sprite is only being updated with new sprite assets
+   *
+   *
+   * @returns The sprite object that was passed in
+   */
+  private configureSprite(pokemon: Pokemon, sprite: Phaser.GameObjects.Sprite, setPipeline = true): typeof sprite {
+    const spriteKey = this.pokemon.getSpriteKey(true);
+    try {
+      sprite.play(spriteKey);
+    } catch (err: unknown) {
+      console.error(`Failed to play animation for ${spriteKey}`, err);
+    }
 
-      this.evolutionBaseBg = globalScene.add.image(0, 0, "default_bg");
-      this.evolutionBaseBg.setOrigin(0, 0);
-      this.evolutionContainer.add(this.evolutionBaseBg);
-
-      this.evolutionBg = globalScene.add.video(0, 0, "evo_bg").stop();
-      this.evolutionBg.setOrigin(0, 0);
-      this.evolutionBg.setScale(0.4359673025);
-      this.evolutionBg.setVisible(false);
-      this.evolutionContainer.add(this.evolutionBg);
-
-      this.evolutionBgOverlay = globalScene.add.rectangle(
-        0,
-        0,
-        globalScene.game.canvas.width / 6,
-        globalScene.game.canvas.height / 6,
-        0x262626,
-      );
-      this.evolutionBgOverlay.setOrigin(0, 0);
-      this.evolutionBgOverlay.setAlpha(0);
-      this.evolutionContainer.add(this.evolutionBgOverlay);
-
-      const getPokemonSprite = () => {
-        const ret = globalScene.addPokemonSprite(
-          this.pokemon,
-          this.evolutionBaseBg.displayWidth / 2,
-          this.evolutionBaseBg.displayHeight / 2,
-          "pkmn__sub",
-        );
-        ret.setPipeline(globalScene.spritePipeline, {
-          tone: [0.0, 0.0, 0.0, 0.0],
-          ignoreTimeTint: true,
-        });
-        return ret;
-      };
-
-      this.evolutionContainer.add((this.pokemonSprite = getPokemonSprite()));
-      this.evolutionContainer.add((this.pokemonTintSprite = getPokemonSprite()));
-      this.evolutionContainer.add((this.pokemonEvoSprite = getPokemonSprite()));
-      this.evolutionContainer.add((this.pokemonEvoTintSprite = getPokemonSprite()));
-
-      this.pokemonTintSprite.setAlpha(0);
-      this.pokemonTintSprite.setTintFill(0xffffff);
-      this.pokemonEvoSprite.setVisible(false);
-      this.pokemonEvoTintSprite.setVisible(false);
-      this.pokemonEvoTintSprite.setTintFill(0xffffff);
-
-      this.evolutionOverlay = globalScene.add.rectangle(
-        0,
-        -globalScene.game.canvas.height / 6,
-        globalScene.game.canvas.width / 6,
-        globalScene.game.canvas.height / 6 - 48,
-        0xffffff,
-      );
-      this.evolutionOverlay.setOrigin(0, 0);
-      this.evolutionOverlay.setAlpha(0);
-      globalScene.ui.add(this.evolutionOverlay);
-
-      [this.pokemonSprite, this.pokemonTintSprite, this.pokemonEvoSprite, this.pokemonEvoTintSprite].map(sprite => {
-        const spriteKey = this.pokemon.getSpriteKey(true);
-        try {
-          sprite.play(spriteKey);
-        } catch (err: unknown) {
-          console.error(`Failed to play animation for ${spriteKey}`, err);
-        }
-
-        sprite.setPipeline(globalScene.spritePipeline, {
-          tone: [0.0, 0.0, 0.0, 0.0],
-          hasShadow: false,
-          teraColor: getTypeRgb(this.pokemon.getTeraType()),
-          isTerastallized: this.pokemon.isTerastallized,
-        });
-        sprite.setPipelineData("ignoreTimeTint", true);
-        sprite.setPipelineData("spriteKey", this.pokemon.getSpriteKey());
-        sprite.setPipelineData("shiny", this.pokemon.shiny);
-        sprite.setPipelineData("variant", this.pokemon.variant);
-        ["spriteColors", "fusionSpriteColors"].map(k => {
-          if (this.pokemon.summonData.speciesForm) {
-            k += "Base";
-          }
-          sprite.pipelineData[k] = this.pokemon.getSprite().pipelineData[k];
-        });
+    if (setPipeline) {
+      sprite.setPipeline(globalScene.spritePipeline, {
+        tone: [0.0, 0.0, 0.0, 0.0],
+        hasShadow: false,
+        teraColor: getTypeRgb(pokemon.getTeraType()),
+        isTerastallized: pokemon.isTerastallized,
       });
-      this.preEvolvedPokemonName = getPokemonNameWithAffix(this.pokemon);
-      this.doEvolution();
+    }
+
+    sprite
+      .setPipelineData("ignoreTimeTint", true)
+      .setPipelineData("spriteKey", pokemon.getSpriteKey())
+      .setPipelineData("shiny", pokemon.shiny)
+      .setPipelineData("variant", pokemon.variant);
+
+    for (let k of ["spriteColors", "fusionSpriteColors"]) {
+      if (pokemon.summonData.speciesForm) {
+        k += "Base";
+      }
+      sprite.pipelineData[k] = pokemon.getSprite().pipelineData[k];
+    }
+
+    return sprite;
+  }
+
+  private getPokemonSprite(): Phaser.GameObjects.Sprite {
+    const sprite = globalScene.addPokemonSprite(
+      this.pokemon,
+      this.evolutionBaseBg.displayWidth / 2,
+      this.evolutionBaseBg.displayHeight / 2,
+      "pkmn__sub",
+    );
+    sprite.setPipeline(globalScene.spritePipeline, {
+      tone: [0.0, 0.0, 0.0, 0.0],
+      ignoreTimeTint: true,
+    });
+    return sprite;
+  }
+
+  /**
+   * Initialize {@linkcode pokemonSprite}, {@linkcode pokemonTintSprite}, {@linkcode pokemonEvoSprite}, and {@linkcode pokemonEvoTintSprite}
+   * and add them to the {@linkcode evolutionContainer}
+   */
+  private setupPokemonSprites(): void {
+    this.pokemonSprite = this.configureSprite(this.pokemon, this.getPokemonSprite());
+    this.pokemonTintSprite = this.configureSprite(
+      this.pokemon,
+      this.getPokemonSprite().setAlpha(0).setTintFill(0xffffff),
+    );
+    this.pokemonEvoSprite = this.configureSprite(this.pokemon, this.getPokemonSprite().setVisible(false));
+    this.pokemonEvoTintSprite = this.configureSprite(
+      this.pokemon,
+      this.getPokemonSprite().setVisible(false).setTintFill(0xffffff),
+    );
+
+    this.evolutionContainer.add([
+      this.pokemonSprite,
+      this.pokemonTintSprite,
+      this.pokemonEvoSprite,
+      this.pokemonEvoTintSprite,
+    ]);
+  }
+
+  async start() {
+    super.start();
+    await this.setMode();
+
+    if (!this.validate()) {
+      return this.end();
+    }
+    this.setupEvolutionAssets();
+    this.setupPokemonSprites();
+    this.preEvolvedPokemonName = getPokemonNameWithAffix(this.pokemon);
+    this.doEvolution();
+  }
+
+  /**
+   * Update the sprites depicting the evolved Pokemon
+   * @param evolvedPokemon - The evolved Pokemon
+   */
+  private updateEvolvedPokemonSprites(evolvedPokemon: Pokemon): void {
+    this.configureSprite(evolvedPokemon, this.pokemonEvoSprite, false);
+    this.configureSprite(evolvedPokemon, this.pokemonEvoTintSprite, false);
+  }
+
+  /**
+   * Adds the evolution tween and begins playing it
+   */
+  private playEvolutionAnimation(evolvedPokemon: Pokemon): void {
+    globalScene.time.delayedCall(1000, () => {
+      this.evolutionBgm = globalScene.playSoundWithoutBgm("evolution");
+      globalScene.tweens.add({
+        targets: this.evolutionBgOverlay,
+        alpha: 1,
+        delay: 500,
+        duration: 1500,
+        ease: "Sine.easeOut",
+        onComplete: () => {
+          globalScene.time.delayedCall(1000, () => {
+            globalScene.tweens.add({
+              targets: this.evolutionBgOverlay,
+              alpha: 0,
+              duration: 250,
+            });
+            this.evolutionBg.setVisible(true);
+            this.evolutionBg.play();
+          });
+          globalScene.playSound("se/charge");
+          this.doSpiralUpward();
+          this.fadeOutPokemonSprite(evolvedPokemon);
+        },
+      });
     });
   }
 
+  private fadeOutPokemonSprite(evolvedPokemon: Pokemon): void {
+    globalScene.tweens.addCounter({
+      from: 0,
+      to: 1,
+      duration: 2000,
+      onUpdate: t => {
+        this.pokemonTintSprite.setAlpha(t.getValue());
+      },
+      onComplete: () => {
+        this.pokemonSprite.setVisible(false);
+        globalScene.time.delayedCall(1100, () => {
+          globalScene.playSound("se/beam");
+          this.doArcDownward();
+          this.prepareForCycle(evolvedPokemon);
+        });
+      },
+    });
+  }
+
+  /**
+   * Prepares the evolution cycle by setting up the tint sprites and starting the cycle
+   */
+  private prepareForCycle(evolvedPokemon: Pokemon): void {
+    globalScene.time.delayedCall(1500, () => {
+      this.pokemonEvoTintSprite.setScale(0.25).setVisible(true);
+      this.evolutionHandler.canCancel = true;
+      this.doCycle(1).then(success => {
+        if (success) {
+          this.handleSuccessEvolution(evolvedPokemon);
+        } else {
+          this.handleFailedEvolution(evolvedPokemon);
+        }
+      });
+    });
+  }
+
+  /**
+   * Show the evolution text and then commence the evolution animation
+   */
   doEvolution(): void {
     globalScene.ui.showText(
       i18next.t("menu:evolving", { pokemonName: this.preEvolvedPokemonName }),
       null,
       () => {
         this.pokemon.cry();
-
         this.pokemon.getPossibleEvolution(this.evolution).then(evolvedPokemon => {
-          [this.pokemonEvoSprite, this.pokemonEvoTintSprite].map(sprite => {
-            const spriteKey = evolvedPokemon.getSpriteKey(true);
-            try {
-              sprite.play(spriteKey);
-            } catch (err: unknown) {
-              console.error(`Failed to play animation for ${spriteKey}`, err);
-            }
-
-            sprite.setPipelineData("ignoreTimeTint", true);
-            sprite.setPipelineData("spriteKey", evolvedPokemon.getSpriteKey());
-            sprite.setPipelineData("shiny", evolvedPokemon.shiny);
-            sprite.setPipelineData("variant", evolvedPokemon.variant);
-            ["spriteColors", "fusionSpriteColors"].map(k => {
-              if (evolvedPokemon.summonData.speciesForm) {
-                k += "Base";
-              }
-              sprite.pipelineData[k] = evolvedPokemon.getSprite().pipelineData[k];
-            });
-          });
-
-          globalScene.time.delayedCall(1000, () => {
-            this.evolutionBgm = globalScene.playSoundWithoutBgm("evolution");
-            globalScene.tweens.add({
-              targets: this.evolutionBgOverlay,
-              alpha: 1,
-              delay: 500,
-              duration: 1500,
-              ease: "Sine.easeOut",
-              onComplete: () => {
-                globalScene.time.delayedCall(1000, () => {
-                  globalScene.tweens.add({
-                    targets: this.evolutionBgOverlay,
-                    alpha: 0,
-                    duration: 250,
-                  });
-                  this.evolutionBg.setVisible(true);
-                  this.evolutionBg.play();
-                });
-                globalScene.playSound("se/charge");
-                this.doSpiralUpward();
-                globalScene.tweens.addCounter({
-                  from: 0,
-                  to: 1,
-                  duration: 2000,
-                  onUpdate: t => {
-                    this.pokemonTintSprite.setAlpha(t.getValue());
-                  },
-                  onComplete: () => {
-                    this.pokemonSprite.setVisible(false);
-                    globalScene.time.delayedCall(1100, () => {
-                      globalScene.playSound("se/beam");
-                      this.doArcDownward();
-                      globalScene.time.delayedCall(1500, () => {
-                        this.pokemonEvoTintSprite.setScale(0.25);
-                        this.pokemonEvoTintSprite.setVisible(true);
-                        this.evolutionHandler.canCancel = true;
-                        this.doCycle(1).then(success => {
-                          if (success) {
-                            this.handleSuccessEvolution(evolvedPokemon);
-                          } else {
-                            this.handleFailedEvolution(evolvedPokemon);
-                          }
-                        });
-                      });
-                    });
-                  },
-                });
-              },
-            });
-          });
+          this.updateEvolvedPokemonSprites(evolvedPokemon);
+          this.playEvolutionAnimation(evolvedPokemon);
         });
       },
       1000,
     );
   }
 
-  /**
-   * Handles a failed/stopped evolution
-   * @param evolvedPokemon - The evolved Pokemon
-   */
-  private handleFailedEvolution(evolvedPokemon: Pokemon): void {
-    this.pokemonSprite.setVisible(true);
-    this.pokemonTintSprite.setScale(1);
+  /** Used exclusively by {@linkcode handleFailedEvolution} to fade out the evolution sprites and music */
+  private fadeOutEvolutionAssets(): void {
     globalScene.tweens.add({
       targets: [this.evolutionBg, this.pokemonTintSprite, this.pokemonEvoSprite, this.pokemonEvoTintSprite],
       alpha: 0,
@@ -257,9 +302,40 @@ export class EvolutionPhase extends Phase {
         this.evolutionBg.setVisible(false);
       },
     });
-
     SoundFade.fadeOut(globalScene, this.evolutionBgm, 100);
+  }
 
+  /**
+   * Show the confirmation prompt for pausing evolutions
+   * @param endCallback - The callback to call after either option is selected.
+   *  This should end the evolution phase
+   */
+  private showPauseEvolutionConfirmation(endCallback: () => void): void {
+    globalScene.ui.setOverlayMode(
+      UiMode.CONFIRM,
+      () => {
+        globalScene.ui.revertMode();
+        this.pokemon.pauseEvolutions = true;
+        globalScene.ui.showText(
+          i18next.t("menu:evolutionsPaused", {
+            pokemonName: this.preEvolvedPokemonName,
+          }),
+          null,
+          endCallback,
+          3000,
+        );
+      },
+      () => {
+        globalScene.ui.revertMode();
+        globalScene.time.delayedCall(3000, endCallback);
+      },
+    );
+  }
+
+  /**
+   * Used exclusively by {@linkcode handleFailedEvolution} to show the failed evolution UI messages
+   */
+  private showFailedEvolutionUI(evolvedPokemon: Pokemon): void {
     globalScene.phaseManager.unshiftNew("EndEvolutionPhase");
 
     globalScene.ui.showText(
@@ -280,31 +356,104 @@ export class EvolutionPhase extends Phase {
               evolvedPokemon.destroy();
               this.end();
             };
-            globalScene.ui.setOverlayMode(
-              UiMode.CONFIRM,
-              () => {
-                globalScene.ui.revertMode();
-                this.pokemon.pauseEvolutions = true;
-                globalScene.ui.showText(
-                  i18next.t("menu:evolutionsPaused", {
-                    pokemonName: this.preEvolvedPokemonName,
-                  }),
-                  null,
-                  end,
-                  3000,
-                );
-              },
-              () => {
-                globalScene.ui.revertMode();
-                globalScene.time.delayedCall(3000, end);
-              },
-            );
+            this.showPauseEvolutionConfirmation(end);
           },
         );
       },
       null,
       true,
     );
+  }
+
+  /**
+   * Fade out the evolution assets, show the failed evolution UI messages, and enqueue the EndEvolutionPhase
+   * @param evolvedPokemon - The evolved Pokemon
+   */
+  private handleFailedEvolution(evolvedPokemon: Pokemon): void {
+    this.pokemonSprite.setVisible(true);
+    this.pokemonTintSprite.setScale(1);
+    this.fadeOutEvolutionAssets();
+
+    globalScene.phaseManager.unshiftNew("EndEvolutionPhase");
+    this.showFailedEvolutionUI(evolvedPokemon);
+  }
+
+  /**
+   * Fadeout evolution music, play the cry, show the evolution completed text, and end the phase
+   */
+  private onEvolutionComplete(evolvedPokemon: Pokemon) {
+    SoundFade.fadeOut(globalScene, this.evolutionBgm, 100);
+    globalScene.time.delayedCall(250, () => {
+      this.pokemon.cry();
+      globalScene.time.delayedCall(1250, () => {
+        globalScene.playSoundWithoutBgm("evolution_fanfare");
+
+        evolvedPokemon.destroy();
+        globalScene.ui.showText(
+          i18next.t("menu:evolutionDone", {
+            pokemonName: this.preEvolvedPokemonName,
+            evolvedPokemonName: this.pokemon.species.getExpandedSpeciesName(),
+          }),
+          null,
+          () => this.end(),
+          null,
+          true,
+          fixedInt(4000),
+        );
+        globalScene.time.delayedCall(fixedInt(4250), () => globalScene.playBgm());
+      });
+    });
+  }
+
+  private postEvolve(evolvedPokemon: Pokemon): void {
+    const learnSituation: LearnMoveSituation = this.fusionSpeciesEvolved
+      ? LearnMoveSituation.EVOLUTION_FUSED
+      : this.pokemon.fusionSpecies
+        ? LearnMoveSituation.EVOLUTION_FUSED_BASE
+        : LearnMoveSituation.EVOLUTION;
+    const levelMoves = this.pokemon
+      .getLevelMoves(this.lastLevel + 1, true, false, false, learnSituation)
+      .filter(lm => lm[0] === EVOLVE_MOVE);
+    for (const lm of levelMoves) {
+      globalScene.phaseManager.unshiftNew(
+            "LearnMovePhase",
+            globalScene.getPlayerParty().indexOf(this.pokemon),
+            lm[1],
+          );
+    }
+    globalScene.phaseManager.unshiftNew("EndEvolutionPhase");
+
+    globalScene.playSound("se/shine");
+    this.doSpray();
+
+    globalScene.tweens.chain({
+      targets: null,
+      tweens: [
+        {
+          targets: this.evolutionOverlay,
+          alpha: 1,
+          duration: 250,
+          easing: "Sine.easeIn",
+          onComplete: () => {
+            this.evolutionBgOverlay.setAlpha(1);
+            this.evolutionBg.setVisible(false);
+          },
+        },
+        {
+          targets: [this.evolutionOverlay, this.pokemonEvoTintSprite],
+          alpha: 0,
+          duration: 2000,
+          delay: 150,
+          easing: "Sine.easeIn",
+        },
+        {
+          targets: this.evolutionBgOverlay,
+          alpha: 0,
+          duration: 250,
+          onComplete: () => this.onEvolutionComplete(evolvedPokemon),
+        },
+      ],
+    });
   }
 
   /**
@@ -316,79 +465,10 @@ export class EvolutionPhase extends Phase {
     this.pokemonEvoSprite.setVisible(true);
     this.doCircleInward();
 
-    const onEvolutionComplete = () => {
-      SoundFade.fadeOut(globalScene, this.evolutionBgm, 100);
-      globalScene.time.delayedCall(250, () => {
-        this.pokemon.cry();
-        globalScene.time.delayedCall(1250, () => {
-          globalScene.playSoundWithoutBgm("evolution_fanfare");
-
-          evolvedPokemon.destroy();
-          globalScene.ui.showText(
-            i18next.t("menu:evolutionDone", {
-              pokemonName: this.preEvolvedPokemonName,
-              evolvedPokemonName: this.pokemon.species.getExpandedSpeciesName(),
-            }),
-            null,
-            () => this.end(),
-            null,
-            true,
-            fixedInt(4000),
-          );
-          globalScene.time.delayedCall(fixedInt(4250), () => globalScene.playBgm());
-        });
-      });
-    };
-
     globalScene.time.delayedCall(900, () => {
-      this.evolutionHandler.canCancel = false;
+      this.evolutionHandler.canCancel = this.canCancel;
 
-      this.pokemon.evolve(this.evolution, this.pokemon.species).then(() => {
-        const learnSituation: LearnMoveSituation = this.fusionSpeciesEvolved
-          ? LearnMoveSituation.EVOLUTION_FUSED
-          : this.pokemon.fusionSpecies
-            ? LearnMoveSituation.EVOLUTION_FUSED_BASE
-            : LearnMoveSituation.EVOLUTION;
-        const levelMoves = this.pokemon
-          .getLevelMoves(this.lastLevel + 1, true, false, false, learnSituation)
-          .filter(lm => lm[0] === EVOLVE_MOVE);
-        for (const lm of levelMoves) {
-          globalScene.phaseManager.unshiftNew(
-            "LearnMovePhase",
-            globalScene.getPlayerParty().indexOf(this.pokemon),
-            lm[1],
-          );
-        }
-        globalScene.phaseManager.unshiftNew("EndEvolutionPhase");
-
-        globalScene.playSound("se/shine");
-        this.doSpray();
-        globalScene.tweens.add({
-          targets: this.evolutionOverlay,
-          alpha: 1,
-          duration: 250,
-          easing: "Sine.easeIn",
-          onComplete: () => {
-            this.evolutionBgOverlay.setAlpha(1);
-            this.evolutionBg.setVisible(false);
-            globalScene.tweens.add({
-              targets: [this.evolutionOverlay, this.pokemonEvoTintSprite],
-              alpha: 0,
-              duration: 2000,
-              delay: 150,
-              easing: "Sine.easeIn",
-              onComplete: () => {
-                globalScene.tweens.add({
-                  targets: this.evolutionBgOverlay,
-                  alpha: 0,
-                  duration: 250,
-                  onComplete: onEvolutionComplete,
-                });
-              },
-            });
-          },
-        });
-      });
+      this.pokemon.evolve(this.evolution, this.pokemon.species).then(() => this.postEvolve(evolvedPokemon));
     });
   }
 

--- a/src/phases/evolution-phase.ts
+++ b/src/phases/evolution-phase.ts
@@ -224,8 +224,7 @@ export class EvolutionPhase extends Phase {
         ease: "Sine.easeOut",
         onComplete: () => {
           globalScene.time.delayedCall(1000, () => {
-            this.evolutionBg.setVisible(true);
-            this.evolutionBg.play();
+            this.evolutionBg.setVisible(true).play();
           });
           globalScene.playSound("se/charge");
           this.doSpiralUpward();

--- a/src/phases/form-change-phase.ts
+++ b/src/phases/form-change-phase.ts
@@ -1,9 +1,9 @@
 import { globalScene } from "#app/global-scene";
-import { fixedInt } from "#app/utils/common";
+import { FixedInt, fixedInt } from "#app/utils/common";
 import { achvs } from "../system/achv";
 import type { SpeciesFormChange } from "../data/pokemon-forms";
 import { getSpeciesFormChangeMessage } from "#app/data/pokemon-forms/form-change-triggers";
-import type { PlayerPokemon } from "../field/pokemon";
+import type { default as Pokemon, PlayerPokemon } from "../field/pokemon";
 import { UiMode } from "#enums/ui-mode";
 import type PartyUiHandler from "../ui/party-ui-handler";
 import { getPokemonNameWithAffix } from "../messages";
@@ -34,146 +34,158 @@ export class FormChangePhase extends EvolutionPhase {
     return globalScene.ui.setOverlayMode(UiMode.EVOLUTION_SCENE);
   }
 
-  doEvolution(): void {
-    const preName = getPokemonNameWithAffix(this.pokemon);
-
-    this.pokemon.getPossibleForm(this.formChange).then(transformedPokemon => {
-      [this.pokemonEvoSprite, this.pokemonEvoTintSprite].map(sprite => {
-        const spriteKey = transformedPokemon.getSpriteKey(true);
-        try {
-          sprite.play(spriteKey);
-        } catch (err: unknown) {
-          console.error(`Failed to play animation for ${spriteKey}`, err);
+  /**
+   * Commence the tweens that play after the form change animation finishes
+   * @param transformedPokemon - The Pokemon after the evolution
+   * @param preName - The name of the Pokemon before the evolution
+   */
+  private postFormChangeTweens(transformedPokemon: Pokemon, preName: string): void {
+    globalScene.tweens.chain({
+      targets: null,
+      tweens: [
+        {
+          targets: this.evolutionOverlay,
+          alpha: 1,
+          duration: 250,
+          easing: "Sine.easeIn",
+          onComplete: () => {
+            this.evolutionBgOverlay.setAlpha(1);
+            this.evolutionBg.setVisible(false);
+          },
+        },
+        {
+          targets: [this.evolutionOverlay, this.pokemonEvoTintSprite],
+          alpha: 0,
+          duration: 2000,
+          delay: 150,
+          easing: "Sine.easeIn",
+        },
+        {
+          targets: this.evolutionBgOverlay,
+          alpha: 0,
+          duration: 250,
+          completeDelay: 250,
+          onComplete: () => this.pokemon.cry(),
+        },
+      ],
+      // 1.25 seconds after the pokemon cry
+      completeDelay: 1250,
+      onComplete: () => {
+        let playEvolutionFanfare = false;
+        if (this.formChange.formKey.indexOf(SpeciesFormKey.MEGA) > -1) {
+          globalScene.validateAchv(achvs.MEGA_EVOLVE);
+          playEvolutionFanfare = true;
+        } else if (
+          this.formChange.formKey.indexOf(SpeciesFormKey.GIGANTAMAX) > -1 ||
+          this.formChange.formKey.indexOf(SpeciesFormKey.ETERNAMAX) > -1
+        ) {
+          globalScene.validateAchv(achvs.GIGANTAMAX);
+          playEvolutionFanfare = true;
         }
 
-        sprite.setPipelineData("ignoreTimeTint", true);
-        sprite.setPipelineData("spriteKey", transformedPokemon.getSpriteKey());
-        sprite.setPipelineData("shiny", transformedPokemon.shiny);
-        sprite.setPipelineData("variant", transformedPokemon.variant);
-        ["spriteColors", "fusionSpriteColors"].map(k => {
-          if (transformedPokemon.summonData.speciesForm) {
-            k += "Base";
-          }
-          sprite.pipelineData[k] = transformedPokemon.getSprite().pipelineData[k];
-        });
-      });
+        const delay = playEvolutionFanfare ? 4000 : 1750;
+        globalScene.playSoundWithoutBgm(playEvolutionFanfare ? "evolution_fanfare" : "minor_fanfare");
+        transformedPokemon.destroy();
+        globalScene.ui.showText(
+          getSpeciesFormChangeMessage(this.pokemon, this.formChange, preName),
+          null,
+          () => this.end(),
+          null,
+          true,
+          fixedInt(delay),
+        );
+        globalScene.time.delayedCall(fixedInt(delay + 250), () => globalScene.playBgm());
+      },
+    });
+  }
 
-      globalScene.time.delayedCall(250, () => {
-        globalScene.tweens.add({
+  /**
+   * Commence the animations that occur once the form change evolution cycle ({@linkcode doCycle}) is complete
+   *
+   * @privateRemarks
+   * This would prefer {@linkcode doCycle} to be refactored and de-promisified so this can be moved into {@linkcode beginTweens}
+   * @param preName - The name of the Pokemon before the evolution
+   * @param transformedPokemon - The Pokemon being transformed into
+   */
+  private afterCycle(preName: string, transformedPokemon: Pokemon): void {
+    globalScene.playSound("se/sparkle");
+    this.pokemonEvoSprite.setVisible(true);
+    this.doCircleInward();
+    globalScene.time.delayedCall(900, () => {
+      this.pokemon.changeForm(this.formChange).then(() => {
+        if (!this.modal) {
+          globalScene.phaseManager.unshiftNew("EndEvolutionPhase");
+        }
+        globalScene.playSound("se/shine");
+        this.doSpray();
+        this.postFormChangeTweens(transformedPokemon, preName);
+      });
+    });
+  }
+
+  /**
+   * Commence the sequence of tweens and events that occur during the evolution animation
+   * @param preName The name of the Pokemon before the evolution
+   * @param transformedPokemon The Pokemon after the evolution
+   */
+  private beginTweens(preName: string, transformedPokemon: Pokemon): void {
+    globalScene.tweens.chain({
+      // Starts 250ms after sprites have been configured
+      delay: 250,
+      targets: null,
+      tweens: [
+        // Step 1: Fade in the background overlay
+        {
           targets: this.evolutionBgOverlay,
           alpha: 1,
-          delay: 500,
           duration: 1500,
           ease: "Sine.easeOut",
+          // We want the backkground overlay to fade out after it fades in
           onComplete: () => {
-            globalScene.time.delayedCall(1000, () => {
-              globalScene.tweens.add({
-                targets: this.evolutionBgOverlay,
-                alpha: 0,
-                duration: 250,
-              });
-              this.evolutionBg.setVisible(true);
-              this.evolutionBg.play();
+            globalScene.tweens.add({
+              targets: this.evolutionBgOverlay,
+              alpha: 0,
+              duration: 250,
+              delay: fixedInt(1000),
             });
+            this.evolutionBg.setVisible(true).play();
+          },
+        },
+        // Step 2: Play the sounds and fade in the tint sprite
+        {
+          targets: this.pokemonTintSprite,
+          alpha: { from: 0, to: 1 },
+          duration: 2000,
+          onStart: () => {
             globalScene.playSound("se/charge");
             this.doSpiralUpward();
-            globalScene.tweens.addCounter({
-              from: 0,
-              to: 1,
-              duration: 2000,
-              onUpdate: t => {
-                this.pokemonTintSprite.setAlpha(t.getValue());
-              },
-              onComplete: () => {
-                this.pokemonSprite.setVisible(false);
-                globalScene.time.delayedCall(1100, () => {
-                  globalScene.playSound("se/beam");
-                  this.doArcDownward();
-                  globalScene.time.delayedCall(1000, () => {
-                    this.pokemonEvoTintSprite.setScale(0.25);
-                    this.pokemonEvoTintSprite.setVisible(true);
-                    this.doCycle(1, 1).then(_success => {
-                      globalScene.playSound("se/sparkle");
-                      this.pokemonEvoSprite.setVisible(true);
-                      this.doCircleInward();
-                      globalScene.time.delayedCall(900, () => {
-                        this.pokemon.changeForm(this.formChange).then(() => {
-                          if (!this.modal) {
-                            globalScene.phaseManager.unshiftNew("EndEvolutionPhase");
-                          }
-
-                          globalScene.playSound("se/shine");
-                          this.doSpray();
-                          globalScene.tweens.add({
-                            targets: this.evolutionOverlay,
-                            alpha: 1,
-                            duration: 250,
-                            easing: "Sine.easeIn",
-                            onComplete: () => {
-                              this.evolutionBgOverlay.setAlpha(1);
-                              this.evolutionBg.setVisible(false);
-                              globalScene.tweens.add({
-                                targets: [this.evolutionOverlay, this.pokemonEvoTintSprite],
-                                alpha: 0,
-                                duration: 2000,
-                                delay: 150,
-                                easing: "Sine.easeIn",
-                                onComplete: () => {
-                                  globalScene.tweens.add({
-                                    targets: this.evolutionBgOverlay,
-                                    alpha: 0,
-                                    duration: 250,
-                                    onComplete: () => {
-                                      globalScene.time.delayedCall(250, () => {
-                                        this.pokemon.cry();
-                                        globalScene.time.delayedCall(1250, () => {
-                                          let playEvolutionFanfare = false;
-                                          if (this.formChange.formKey.indexOf(SpeciesFormKey.MEGA) > -1) {
-                                            globalScene.validateAchv(achvs.MEGA_EVOLVE);
-                                            playEvolutionFanfare = true;
-                                          } else if (
-                                            this.formChange.formKey.indexOf(SpeciesFormKey.GIGANTAMAX) > -1 ||
-                                            this.formChange.formKey.indexOf(SpeciesFormKey.ETERNAMAX) > -1
-                                          ) {
-                                            globalScene.validateAchv(achvs.GIGANTAMAX);
-                                            playEvolutionFanfare = true;
-                                          }
-
-                                          const delay = playEvolutionFanfare ? 4000 : 1750;
-                                          globalScene.playSoundWithoutBgm(
-                                            playEvolutionFanfare ? "evolution_fanfare" : "minor_fanfare",
-                                          );
-
-                                          transformedPokemon.destroy();
-                                          globalScene.ui.showText(
-                                            getSpeciesFormChangeMessage(this.pokemon, this.formChange, preName),
-                                            null,
-                                            () => this.end(),
-                                            null,
-                                            true,
-                                            fixedInt(delay),
-                                          );
-                                          globalScene.time.delayedCall(fixedInt(delay + 250), () =>
-                                            globalScene.playBgm(),
-                                          );
-                                        });
-                                      });
-                                    },
-                                  });
-                                },
-                              });
-                            },
-                          });
-                        });
-                      });
-                    });
-                  });
-                });
-              },
-            });
           },
+          onComplete: () => {
+            this.pokemonSprite.setVisible(false);
+          },
+        },
+      ],
+
+      // Step 3: Commence the form change animation via doCycle then continue the animation chain with afterCycle
+      completeDelay: new FixedInt(1100),
+      onComplete: () => {
+        globalScene.playSound("se/beam");
+        this.doArcDownward();
+        globalScene.time.delayedCall(1000, () => {
+          this.pokemonEvoTintSprite.setScale(0.25).setVisible(true);
+          this.doCycle(1, 1).then(() => this.afterCycle(preName, transformedPokemon));
         });
-      });
+      },
+    });
+  }
+
+  doEvolution(): void {
+    const preName = getPokemonNameWithAffix(this.pokemon, false);
+
+    this.pokemon.getPossibleForm(this.formChange).then(transformedPokemon => {
+      this.configureSprite(transformedPokemon, this.pokemonEvoSprite, false);
+      this.configureSprite(transformedPokemon, this.pokemonEvoTintSprite, false);
+      this.beginTweens(preName, transformedPokemon);
     });
   }
 

--- a/src/phases/form-change-phase.ts
+++ b/src/phases/form-change-phase.ts
@@ -1,5 +1,5 @@
 import { globalScene } from "#app/global-scene";
-import { FixedInt, fixedInt } from "#app/utils/common";
+import { fixedInt } from "#app/utils/common";
 import { achvs } from "../system/achv";
 import type { SpeciesFormChange } from "../data/pokemon-forms";
 import { getSpeciesFormChangeMessage } from "#app/data/pokemon-forms/form-change-triggers";
@@ -146,7 +146,7 @@ export class FormChangePhase extends EvolutionPhase {
               targets: this.evolutionBgOverlay,
               alpha: 0,
               duration: 250,
-              delay: fixedInt(1000),
+              delay: 1000,
             });
             this.evolutionBg.setVisible(true).play();
           },
@@ -167,13 +167,13 @@ export class FormChangePhase extends EvolutionPhase {
       ],
 
       // Step 3: Commence the form change animation via doCycle then continue the animation chain with afterCycle
-      completeDelay: new FixedInt(1100),
+      completeDelay: 1100,
       onComplete: () => {
         globalScene.playSound("se/beam");
         this.doArcDownward();
         globalScene.time.delayedCall(1000, () => {
           this.pokemonEvoTintSprite.setScale(0.25).setVisible(true);
-          this.doCycle(1, 1).then(() => this.afterCycle(preName, transformedPokemon));
+          this.doCycle(1, 1, () => this.afterCycle(preName, transformedPokemon));
         });
       },
     });

--- a/src/phases/form-change-phase.ts
+++ b/src/phases/form-change-phase.ts
@@ -131,11 +131,11 @@ export class FormChangePhase extends EvolutionPhase {
   private beginTweens(preName: string, transformedPokemon: Pokemon): void {
     globalScene.tweens.chain({
       // Starts 250ms after sprites have been configured
-      delay: 250,
       targets: null,
       tweens: [
         // Step 1: Fade in the background overlay
         {
+          delay: 250,
           targets: this.evolutionBgOverlay,
           alpha: 1,
           duration: 1500,

--- a/src/system/game-speed.ts
+++ b/src/system/game-speed.ts
@@ -24,7 +24,7 @@ export function initGameSpeed() {
 
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Complexity is necessary here
   const mutateProperties = (obj: any, allowArray = false) => {
-    // We do not mutate Tweens or TweenChains
+    // We do not mutate Tweens or TweenChain objects themselves.
     if (obj instanceof Phaser.Tweens.Tween || obj instanceof Phaser.Tweens.TweenChain) {
       return;
     }
@@ -42,9 +42,9 @@ export function initGameSpeed() {
         obj[prop] = transformValue(objProp);
       }
     }
-    // If the object has a 'tweens' property, then it is a tween chain
+    // If the object has a 'tweens' property that is an array, then it is a tween chain
     // and we need to mutate its properties as well
-    if (obj.tweens) {
+    if (obj.tweens && Array.isArray(obj.tweens)) {
       for (const tween of obj.tweens) {
         mutateProperties(tween);
       }
@@ -83,11 +83,11 @@ export function initGameSpeed() {
     return originalAddCounter.apply(this, [config]);
   } as typeof originalAddCounter;
 
-  // const originalCreate: TweenManager["create"] = this.tweens.create;
-  // this.tweens.create = function (config: Phaser.Types.Tweens.TweenBuilderConfig) {
-  //   mutateProperties(config, true);
-  //   return originalCreate.apply(this, [config]);
-  // } as typeof originalCreate;
+  const originalCreate: TweenManager["create"] = this.tweens.create;
+  this.tweens.create = function (config: Phaser.Types.Tweens.TweenBuilderConfig) {
+    mutateProperties(config, true);
+    return originalCreate.apply(this, [config]);
+  } as typeof originalCreate;
 
   const originalAddMultiple: TweenManager["addMultiple"] = this.tweens.addMultiple;
   this.tweens.addMultiple = function (config: Phaser.Types.Tweens.TweenBuilderConfig[]) {

--- a/src/system/game-speed.ts
+++ b/src/system/game-speed.ts
@@ -26,6 +26,8 @@ export function initGameSpeed() {
     return originalAddEvent.apply(this, [config]);
   };
   const originalTweensAdd = this.tweens.add;
+
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: This isn't bad
   this.tweens.add = function (
     config:
       | Phaser.Types.Tweens.TweenBuilderConfig
@@ -33,8 +35,11 @@ export function initGameSpeed() {
       | Phaser.Tweens.Tween
       | Phaser.Tweens.TweenChain,
   ) {
+    if (config.completeDelay) {
+      config.completeDelay = transformValue(config.completeDelay as number | FixedInt);
+    }
     if (config.loopDelay) {
-      config.loopDelay = transformValue(config.loopDelay as number);
+      config.loopDelay = transformValue(config.loopDelay as number | FixedInt);
     }
 
     if (!(config instanceof Phaser.Tweens.TweenChain)) {
@@ -44,7 +49,7 @@ export function initGameSpeed() {
 
       if (!(config instanceof Phaser.Tweens.Tween)) {
         if (config.delay) {
-          config.delay = transformValue(config.delay as number);
+          config.delay = transformValue(config.delay as number | FixedInt);
         }
         if (config.repeatDelay) {
           config.repeatDelay = transformValue(config.repeatDelay);
@@ -52,11 +57,13 @@ export function initGameSpeed() {
         if (config.hold) {
           config.hold = transformValue(config.hold);
         }
+        1;
       }
     }
     return originalTweensAdd.apply(this, [config]);
   };
   const originalTweensChain = this.tweens.chain;
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: This isn't bad
   this.tweens.chain = function (config: Phaser.Types.Tweens.TweenChainBuilderConfig): Phaser.Tweens.TweenChain {
     if (config.tweens) {
       for (const t of config.tweens) {
@@ -64,16 +71,19 @@ export function initGameSpeed() {
           t.duration = transformValue(t.duration);
         }
         if (t.delay) {
-          t.delay = transformValue(t.delay as number);
+          t.delay = transformValue(t.delay);
         }
         if (t.repeatDelay) {
           t.repeatDelay = transformValue(t.repeatDelay);
         }
         if (t.loopDelay) {
-          t.loopDelay = transformValue(t.loopDelay as number);
+          t.loopDelay = transformValue(t.loopDelay);
         }
         if (t.hold) {
           t.hold = transformValue(t.hold);
+        }
+        if (t.completeDelay) {
+          t.completeDelay = transformValue(t.completeDelay);
         }
       }
     }
@@ -91,10 +101,13 @@ export function initGameSpeed() {
       config.repeatDelay = transformValue(config.repeatDelay);
     }
     if (config.loopDelay) {
-      config.loopDelay = transformValue(config.loopDelay as number);
+      config.loopDelay = transformValue(config.loopDelay);
     }
     if (config.hold) {
       config.hold = transformValue(config.hold);
+    }
+    if (config.completeDelay) {
+      config.completeDelay = transformValue(config.completeDelay as number | FixedInt);
     }
     return originalAddCounter.apply(this, [config]);
   };

--- a/src/system/game-speed.ts
+++ b/src/system/game-speed.ts
@@ -5,9 +5,13 @@ import type BattleScene from "#app/battle-scene";
 import { globalScene } from "#app/global-scene";
 import { FixedInt } from "#app/utils/common";
 
+type TweenManager = typeof Phaser.Tweens.TweenManager.prototype;
+
+/** The set of properties to mutate */
+const PROPERTIES = ["delay", "completeDelay", "loopDelay", "duration", "repeatDelay", "hold", "startDelay"];
+
 type FadeInType = typeof FadeIn;
 type FadeOutType = typeof FadeOut;
-
 export function initGameSpeed() {
   const thisArg = this as BattleScene;
 
@@ -18,16 +22,44 @@ export function initGameSpeed() {
     return thisArg.gameSpeed === 1 ? value : Math.ceil((value /= thisArg.gameSpeed));
   };
 
-  const originalAddEvent = this.time.addEvent;
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Complexity is necessary here
+  const mutateProperties = (obj: any, allowArray = false) => {
+    // We do not mutate Tweens or TweenChains
+    if (obj instanceof Phaser.Tweens.Tween || obj instanceof Phaser.Tweens.TweenChain) {
+      return;
+    }
+    // If allowArray is true then check if first obj is an array and if so, mutate the tweens inside
+    if (allowArray && Array.isArray(obj)) {
+      for (const tween of obj) {
+        mutateProperties(tween);
+      }
+      return;
+    }
+
+    for (const prop of PROPERTIES) {
+      const objProp = obj[prop];
+      if (typeof objProp === "number" || objProp instanceof FixedInt) {
+        obj[prop] = transformValue(objProp);
+      }
+    }
+    // If the object has a 'tweens' property, then it is a tween chain
+    // and we need to mutate its properties as well
+    if (obj.tweens) {
+      for (const tween of obj.tweens) {
+        mutateProperties(tween);
+      }
+    }
+  };
+
+  const originalAddEvent: typeof Phaser.Time.Clock.prototype.addEvent = this.time.addEvent;
   this.time.addEvent = function (config: Phaser.Time.TimerEvent | Phaser.Types.Time.TimerEventConfig) {
     if (!(config instanceof Phaser.Time.TimerEvent) && config.delay) {
       config.delay = transformValue(config.delay);
     }
     return originalAddEvent.apply(this, [config]);
   };
-  const originalTweensAdd = this.tweens.add;
+  const originalTweensAdd: TweenManager["add"] = this.tweens.add;
 
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: This isn't bad
   this.tweens.add = function (
     config:
       | Phaser.Types.Tweens.TweenBuilderConfig
@@ -35,82 +67,33 @@ export function initGameSpeed() {
       | Phaser.Tweens.Tween
       | Phaser.Tweens.TweenChain,
   ) {
-    if (config.completeDelay) {
-      config.completeDelay = transformValue(config.completeDelay as number | FixedInt);
-    }
-    if (config.loopDelay) {
-      config.loopDelay = transformValue(config.loopDelay as number | FixedInt);
-    }
-
-    if (!(config instanceof Phaser.Tweens.TweenChain)) {
-      if (config.duration) {
-        config.duration = transformValue(config.duration);
-      }
-
-      if (!(config instanceof Phaser.Tweens.Tween)) {
-        if (config.delay) {
-          config.delay = transformValue(config.delay as number | FixedInt);
-        }
-        if (config.repeatDelay) {
-          config.repeatDelay = transformValue(config.repeatDelay);
-        }
-        if (config.hold) {
-          config.hold = transformValue(config.hold);
-        }
-        1;
-      }
-    }
+    mutateProperties(config);
     return originalTweensAdd.apply(this, [config]);
-  };
-  const originalTweensChain = this.tweens.chain;
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: This isn't bad
+  } as typeof originalTweensAdd;
+
+  const originalTweensChain: TweenManager["chain"] = this.tweens.chain;
   this.tweens.chain = function (config: Phaser.Types.Tweens.TweenChainBuilderConfig): Phaser.Tweens.TweenChain {
-    if (config.tweens) {
-      for (const t of config.tweens) {
-        if (t.duration) {
-          t.duration = transformValue(t.duration);
-        }
-        if (t.delay) {
-          t.delay = transformValue(t.delay);
-        }
-        if (t.repeatDelay) {
-          t.repeatDelay = transformValue(t.repeatDelay);
-        }
-        if (t.loopDelay) {
-          t.loopDelay = transformValue(t.loopDelay);
-        }
-        if (t.hold) {
-          t.hold = transformValue(t.hold);
-        }
-        if (t.completeDelay) {
-          t.completeDelay = transformValue(t.completeDelay);
-        }
-      }
-    }
+    mutateProperties(config);
     return originalTweensChain.apply(this, [config]);
-  };
-  const originalAddCounter = this.tweens.addCounter;
+  } as typeof originalTweensChain;
+  const originalAddCounter: TweenManager["addCounter"] = this.tweens.addCounter;
+
   this.tweens.addCounter = function (config: Phaser.Types.Tweens.NumberTweenBuilderConfig) {
-    if (config.duration) {
-      config.duration = transformValue(config.duration);
-    }
-    if (config.delay) {
-      config.delay = transformValue(config.delay);
-    }
-    if (config.repeatDelay) {
-      config.repeatDelay = transformValue(config.repeatDelay);
-    }
-    if (config.loopDelay) {
-      config.loopDelay = transformValue(config.loopDelay);
-    }
-    if (config.hold) {
-      config.hold = transformValue(config.hold);
-    }
-    if (config.completeDelay) {
-      config.completeDelay = transformValue(config.completeDelay as number | FixedInt);
-    }
+    mutateProperties(config);
     return originalAddCounter.apply(this, [config]);
-  };
+  } as typeof originalAddCounter;
+
+  // const originalCreate: TweenManager["create"] = this.tweens.create;
+  // this.tweens.create = function (config: Phaser.Types.Tweens.TweenBuilderConfig) {
+  //   mutateProperties(config, true);
+  //   return originalCreate.apply(this, [config]);
+  // } as typeof originalCreate;
+
+  const originalAddMultiple: TweenManager["addMultiple"] = this.tweens.addMultiple;
+  this.tweens.addMultiple = function (config: Phaser.Types.Tweens.TweenBuilderConfig[]) {
+    mutateProperties(config, true);
+    return originalAddMultiple.apply(this, [config]);
+  } as typeof originalAddMultiple;
 
   const originalFadeOut = SoundFade.fadeOut;
   SoundFade.fadeOut = ((_scene: Phaser.Scene, sound: Phaser.Sound.BaseSound, duration: number, destroy?: boolean) =>

--- a/test/testUtils/gameWrapper.ts
+++ b/test/testUtils/gameWrapper.ts
@@ -122,6 +122,7 @@ export default class GameWrapper {
       },
     };
 
+    // TODO: Replace this with a proper mock of phaser's TweenManager.
     this.scene.tweens = {
       add: data => {
         // TODO: our mock of `add` should have the same signature as the real one, which returns the tween

--- a/test/testUtils/gameWrapper.ts
+++ b/test/testUtils/gameWrapper.ts
@@ -124,13 +124,17 @@ export default class GameWrapper {
 
     this.scene.tweens = {
       add: data => {
-        if (data.onComplete) {
-          data.onComplete();
-        }
+        // TODO: our mock of `add` should have the same signature as the real one, which returns the tween
+        data.onComplete?.();
       },
       getTweensOf: () => [],
       killTweensOf: () => [],
-      chain: () => null,
+
+      chain: data => {
+        // TODO: our mock of `chain` should have the same signature as the real one, which returns the chain
+        data?.tweens?.forEach(tween => tween.onComplete?.());
+        data.onComplete?.();
+      },
       addCounter: data => {
         if (data.onComplete) {
           data.onComplete();

--- a/test/testUtils/mocks/mockVideoGameObject.ts
+++ b/test/testUtils/mocks/mockVideoGameObject.ts
@@ -5,7 +5,7 @@ export class MockVideoGameObject implements MockGameObject {
   public name: string;
   public active = true;
 
-  public play = () => null;
+  public play = () => this;
   public stop = () => this;
   public setOrigin = () => this;
   public setScale = () => this;


### PR DESCRIPTION
## What are the changes the user will see?
If I did everything right, none. Maybe a slightly smoother evolution sequence (idk if it's the video quality in the examples below but the original looks choppier).

## Why am I making these changes?
I was trying to find the source of the memory leak that causes evolution assets to stick around (or whatever causes the slew of errors that sometimes happen after vigoroth evolves). I came across the evo-phase file and it is in poor shape and need of a refactor.

<details><summary>Also to avoid this that happens due to callback hell</summary>

![image](https://github.com/user-attachments/assets/22bf1d4a-899b-43cf-8296-c9c6a60f93d6)
</details>

## What are the changes from a developer perspective?
Cleanup of the evolution phase and form-change-phase, primarily making proper use of phaser's `tweenChain` instead of adding the next tween after the previous one's `onComplete` method.

Note that I did not change the behavior of anything, other than to add a `canCancel` parameter to the form change and evolution constructor that can be used to prevent the sequence from being cancelled. I intend to use this in a PR that will follow this to prevent evolution items from allowing the evolution to be cancelled (as they cannot be on cartridge; using an evolution stone for example, does not let you cancel the evolution by pressing b).

Modified the overrides in `src/game-speed.ts` to also shorten the `completeDelay` along with the other delays as I am making use of this parameter in the refactor (although it was not used in our codebase beforehand). I also refactored the methods inside to apply the overrides to all properties within, creating a method `mutateProperties` that does that.

Thanks to #5696, I also am making use of the builder pattern allowed by phaser's object constructors.


## Screenshots/Videos

<details><summary>Original evolution phase (for comparison)</summary>

https://github.com/user-attachments/assets/c88b5686-b8bb-40e5-8cdb-0dcce2676646
</details>

<details><summary>Post refactor evolution phase</summary>

https://github.com/user-attachments/assets/d4827234-0b5c-4687-bb26-dfb77230bda9
</details>

<details><summary>Cancelling evolution continues to work</summary>

https://github.com/user-attachments/assets/72ac67f2-7b34-4df1-a969-35e3f026f8f0
</details>

<details><summary>Form change after refactor</summary>

https://github.com/user-attachments/assets/cc4f96b0-4d73-438b-ac0e-05367aee2d1b
</details>


## How to test the changes?
Start up a run and evolve a pokemon, and make sure the animation works as expected, particularly on different game speeds.
Do the same with the form change animation that happens when you initiate the form change for a pokemon from the items (NOT the form change that appears in battle).


The overrides I used for normal evolution:
```ts
const overrides = {
  STARTING_LEVEL_OVERRIDE: 18,
  STARTER_SPECIES_OVERRIDE: Species.BULBASAUR,
  MOVESET_OVERRIDE: [Moves.ENERGY_BALL],
  ITEM_REWARD_OVERRIDE: [
    {
      name: "RARE_CANDY"
    }
  ],
  OPP_SPECIES_OVERRIDE: Species.MAGIKARP,
} satisfies Partial<InstanceType<OverridesType>>;
```

Here are the overrides I used for form change:

```ts
const overrides = {
  STARTER_SPECIES_OVERRIDE: Species.VENUSAUR,
  MOVESET_OVERRIDE: [Moves.ENERGY_BALL],
  ITEM_REWARD_OVERRIDE: [
    { name: "RARE_FORM_CHANGE_ITEM"}
  ],
  STARTING_MODIFIER_OVERRIDE: [
    { name: "DYNAMAX_BAND"}
  ],
  OPP_SPECIES_OVERRIDE: Species.MAGIKARP,
} satisfies Partial<InstanceType<OverridesType>>;
```

In either case, just startup a battle, ko the mon. Use the rare candy or the max mushroom to commence the evolution.
To test the proper behavior when cancelling the evo, have to press backspace or whatever button you have bound.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~