### PR TITLE
[Bug][Ability] Fix shell armor not blocking crits

### DIFF
--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -3408,8 +3408,12 @@ export class BlockCritAbAttr extends AbAttr {
     super(false);
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, cancelled: BooleanHolder, args: any[]): void {
-    (args[0] as BooleanHolder).value = true;
+  /**
+   * Apply the block crit ability by setting the value in the provided boolean holder to false
+   * @param args - [0] is a boolean holder representing whether the attack can crit
+   */
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _cancelled: BooleanHolder, args: [BooleanHolder, ...any]): void {
+    (args[0]).value = false;
   }
 }
 


### PR DESCRIPTION
## What are the changes the user will see?
Shell armor and battle armor will now prevent crits instead of guaranteeing them.

## Why am I making these changes?
Fixes a bug introduced in #5678 where shell armor and battle armor always caused crits instead of preventing them.

## What are the changes from a developer perspective?
`blockCritAttr`'s apply method now uses the boolean holder for `isCritical` consistently with the other crit attributes rather than using it to cancel the crit.

Will wait for #5684 to add the test, as we would like the crit override to have a good test file for this.

## Screenshots/Videos

## How to test the changes?
I used these overrides:

```ts
const overrides = {
  ABILITY_OVERRIDE: Abilities.SHELL_ARMOR,
  MOVESET_OVERRIDE: [Moves.SPLASH],
  OPP_MOVESET_OVERRIDE: [Moves.FLOWER_TRICK],
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - ~~[ ]~~ Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes? Waiting on #5684
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~