### PR TITLE
[Move] [Beta] Undo Order Up Sheer Force change

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -3482,7 +3482,8 @@ export class CutHpStatStageBoostAttr extends StatStageChangeAttr {
 /**
  * Attribute implementing the stat boosting effect of {@link https://bulbapedia.bulbagarden.net/wiki/Order_Up_(move) | Order Up}.
  * If the user has a Pokemon with {@link https://bulbapedia.bulbagarden.net/wiki/Commander_(Ability) | Commander} in their mouth,
- * one of the user's stats are increased by 1 stage, depending on the "commanding" Pokemon's form.
+ * one of the user's stats are increased by 1 stage, depending on the "commanding" Pokemon's form. This effect does not respect
+ * effect chance, but Order Up itself may be boosted by Sheer Force.
  */
 export class OrderUpStatBoostAttr extends MoveEffectAttr {
   constructor() {
@@ -11024,7 +11025,7 @@ export function initMoves() {
       .makesContact(false),
     new AttackMove(Moves.LUMINA_CRASH, PokemonType.PSYCHIC, MoveCategory.SPECIAL, 80, 100, 10, 100, 0, 9)
       .attr(StatStageChangeAttr, [ Stat.SPDEF ], -2),
-    new AttackMove(Moves.ORDER_UP, PokemonType.DRAGON, MoveCategory.PHYSICAL, 80, 100, 10, -1, 0, 9)
+    new AttackMove(Moves.ORDER_UP, PokemonType.DRAGON, MoveCategory.PHYSICAL, 80, 100, 10, 100, 0, 9)
       .attr(OrderUpStatBoostAttr)
       .makesContact(false),
     new AttackMove(Moves.JET_PUNCH, PokemonType.WATER, MoveCategory.PHYSICAL, 60, 100, 15, -1, 1, 9)

--- a/test/moves/order_up.test.ts
+++ b/test/moves/order_up.test.ts
@@ -81,7 +81,7 @@ describe("Moves - Order Up", () => {
 
     await game.phaseInterceptor.to("BerryPhase", false);
 
-    expect(dondozo.battleData.abilitiesApplied.has(Abilities.SHEER_FORCE)).toBeTruthy();
+    expect(dondozo.waveData.abilitiesApplied.has(Abilities.SHEER_FORCE)).toBeTruthy();
     expect(dondozo.getStatStage(Stat.ATK)).toBe(3);
   });
 });

--- a/test/moves/order_up.test.ts
+++ b/test/moves/order_up.test.ts
@@ -65,4 +65,23 @@ describe("Moves - Order Up", () => {
       affectedStats.forEach(st => expect(dondozo.getStatStage(st)).toBe(st === stat ? 3 : 2));
     },
   );
+
+  it("should be boosted by Sheer Force while still applying a stat boost", async () => {
+    game.override.passiveAbility(Abilities.SHEER_FORCE).starterForms({ [Species.TATSUGIRI]: 0 });
+
+    await game.classicMode.startBattle([Species.TATSUGIRI, Species.DONDOZO]);
+
+    const [tatsugiri, dondozo] = game.scene.getPlayerField();
+
+    expect(game.scene.triggerPokemonBattleAnim).toHaveBeenLastCalledWith(tatsugiri, PokemonAnimType.COMMANDER_APPLY);
+    expect(dondozo.getTag(BattlerTagType.COMMANDED)).toBeDefined();
+
+    game.move.select(Moves.ORDER_UP, 1, BattlerIndex.ENEMY);
+    expect(game.scene.currentBattle.turnCommands[0]?.skip).toBeTruthy();
+
+    await game.phaseInterceptor.to("BerryPhase", false);
+
+    expect(dondozo.battleData.abilitiesApplied.includes(Abilities.SHEER_FORCE)).toBeTruthy();
+    expect(dondozo.getStatStage(Stat.ATK)).toBe(3);
+  });
 });

--- a/test/moves/order_up.test.ts
+++ b/test/moves/order_up.test.ts
@@ -81,7 +81,7 @@ describe("Moves - Order Up", () => {
 
     await game.phaseInterceptor.to("BerryPhase", false);
 
-    expect(dondozo.battleData.abilitiesApplied.includes(Abilities.SHEER_FORCE)).toBeTruthy();
+    expect(dondozo.battleData.abilitiesApplied.has(Abilities.SHEER_FORCE)).toBeTruthy();
     expect(dondozo.getStatStage(Stat.ATK)).toBe(3);
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?
Order Up is now boosted by Sheer Force again, this is an extremely specific interaction that you probably will never see.

## Why am I making these changes?
Followup to #5515 

## What are the changes from a developer perspective?
Revert removal of a part of the Order Up test

## Screenshots/Videos

## How to test the changes?
Overrides

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [X] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?