### PR TITLE
[Bug] Disable Illusion in Fusions

### DIFF
--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -6907,6 +6907,8 @@ export function initAbilities() {
       .attr(IllusionBreakAbAttr)
       // The Pokemon loses its illusion when damaged by a move
       .attr(PostDefendIllusionBreakAbAttr, true)
+      // Disable Illusion in fusions
+      .attr(NoFusionAbilityAbAttr)
       // Illusion is available again after a battle
       .conditionalAttr((pokemon) => pokemon.isAllowedInBattle(), IllusionPostBattleAbAttr, false)
       .uncopiable()


### PR DESCRIPTION


## What are the changes the user will see?
Illusion no longer works (crashes) on a fused Pokemon.

## Why am I making these changes?
The game hard locks when trying to switch in an Illusioned fused Pokemon.

## What are the changes from a developer perspective?
Added .attr(NoFusionAbilityAbAttr) to Illusion


## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?
Overrides

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?