### PR TITLE
[Bug] Fix crash when loading a save with a statused Pokemon

### DIFF
--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -4,7 +4,7 @@ import type { Gender } from "../data/gender";
 import { Nature } from "#enums/nature";
 import { PokeballType } from "#enums/pokeball";
 import { getPokemonSpecies, getPokemonSpeciesForm } from "../data/pokemon-species";
-import type { Status } from "../data/status-effect";
+import { Status } from "../data/status-effect";
 import Pokemon, { EnemyPokemon, PokemonBattleData, PokemonMove, PokemonSummonData } from "../field/pokemon";
 import { TrainerSlot } from "#enums/trainer-slot";
 import type { Variant } from "#app/sprites/variant";
@@ -105,7 +105,9 @@ export default class PokemonData {
     // TODO: Can't we move some of this verification stuff to an upgrade script?
     this.nature = source.nature ?? Nature.HARDY;
     this.moveset = source.moveset.map((m: any) => PokemonMove.loadMove(m));
-    this.status = source.status ?? null;
+    this.status = source.status
+      ? new Status(source.status.effect, source.status.toxicTurnCount, source.status.sleepTurnsRemaining)
+      : null;
     this.friendship = source.friendship ?? getPokemonSpecies(this.species).baseFriendship;
     this.metLevel = source.metLevel || 5;
     this.metBiome = source.metBiome ?? -1;


### PR DESCRIPTION
## What are the changes the user will see?
The game will no longer crash if you load a save with a statused Pokémon and take a turn with that Pokémon.

## Why am I making these changes?
https://discord.com/channels/1125469663833370665/1367989572813979648

## What are the changes from a developer perspective?
Save data loading code for statuses reverted to pre-#5655

## Screenshots/Videos
<details><summary>Video of fix</summary>
<p>

https://github.com/user-attachments/assets/63482366-f86f-4516-9184-a70522c6066e

</p>
</details> 

## How to test the changes?
Have a Pokémon that's afflicted with a status effect (like Poison) do something and pass the turn.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?