### PR TITLE
[Bug][Hotfix] Secondary effects no longer trigger status immunity messages

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -2454,13 +2454,14 @@ export class StatusEffectAttr extends MoveEffectAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const moveChance = this.getMoveChance(user, target, move, this.selfTarget, true);
     const statusCheck = moveChance < 0 || moveChance === 100 || user.randSeedInt(100) < moveChance;
+    const quiet = move.category !== MoveCategory.STATUS;
     if (statusCheck) {
       const pokemon = this.selfTarget ? user : target;
-      if (user !== target && move.category === MoveCategory.STATUS && !target.canSetStatus(this.effect, false, false, user, true)) {
+      if (user !== target && move.category === MoveCategory.STATUS && !target.canSetStatus(this.effect, quiet, false, user, true)) {
         return false;
       }
       if (((!pokemon.status || this.overrideStatus) || (pokemon.status.effect === this.effect && moveChance < 0))
-        && pokemon.trySetStatus(this.effect, true, user, this.turnsRemaining, null, this.overrideStatus, false)) {
+        && pokemon.trySetStatus(this.effect, true, user, this.turnsRemaining, null, this.overrideStatus, quiet)) {
         applyPostAttackAbAttrs(ConfusionOnStatusEffectAbAttr, user, target, move, null, false, this.effect);
         return true;
       }


### PR DESCRIPTION
## What are the changes the user will see?
Something like Zap Cannon into an electric type will no longer play "It doesn't effect ...".

## Why am I making these changes?
Mainline behavior

## What are the changes from a developer perspective?
The `quiet` argument for `can/trySetStatus` calls from `StatusEffectAttr` is now `move.category !== MoveCategory.Status` instead of always false. This makes the assumption that all status moves should play the messages and all non-status moves should not. This seems to generally be correct, but edge cases can be ironed out later.

## Screenshots/Videos
<details><summary>Before</summary>
<p>

https://github.com/user-attachments/assets/06d28560-8194-49d8-8f5c-c8cba737de29

</p>
</details> 

<details><summary>After</summary>
<p>

https://github.com/user-attachments/assets/5739c84b-1371-437d-b5eb-58ca11533835

</p>
</details> 

## How to test the changes?
My overrides file is:

```ts
const overrides = {
  ABILITY_OVERRIDE: Abilities.NO_GUARD,
  OPP_MOVESET_OVERRIDE: Moves.ZAP_CANNON,
  STARTING_LEVEL_OVERRIDE: 100,
  OPP_SPECIES_OVERRIDE: Species.CHARMANDER,
  MOVESET_OVERRIDE: Moves.WILL_O_WISP
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?