### PR TITLE
[Bug][Hotfix] Always show hit result message

### DIFF
--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -944,7 +944,7 @@ export class MoveEffectPhase extends PokemonPhase {
 
     const result = this.applyMoveDamage(user, target, effectiveness);
 
-    if (user.turnData.hitsLeft === 1 && target.isFainted()) {
+    if (user.turnData.hitsLeft === 1 || target.isFainted()) {
       this.queueHitResultMessage(result);
     }
 


### PR DESCRIPTION
## What are the changes the user will see?
Moves that don't cause a faint will properly play hit result messages

## Why am I making these changes?
https://discord.com/channels/1125469663833370665/1368485009492676729
https://discord.com/channels/1125469663833370665/1368639571910328471\

## What are the changes from a developer perspective?
This block
```ts
   if (user.turnData.hitsLeft === 1 && target.isFainted()) {
      this.queueHitResultMessage(result);
    }
```
was changed to or instead of and

## Screenshots/Videos
<details><summary>Before</summary>
<p>

https://github.com/user-attachments/assets/ef2ccbfe-8df7-44cd-ae0f-e524abad59e8

</p>
</details> 

<details><summary>After</summary>
<p>

https://github.com/user-attachments/assets/e32a3be1-1df4-4bb3-923f-34b1f29cc7e3

</p>
</details> 

## How to test the changes?
Use any move that does not faint the opponent and does not do neutral damage

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?