### PR TITLE
[Bug] Fix item icons not displaying correctly in shop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "lefthook": "^1.11.5",
         "msw": "^2.7.3",
         "phaser3spectorjs": "^0.0.8",
-        "rollup": "^4.40.1",
         "typedoc": "^0.28.1",
         "typescript": "^5.8.2",
         "typescript-eslint": "^8.28.0",

--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -763,7 +763,26 @@ class ModifierOption extends Phaser.GameObjects.Container {
     this.add(this.itemContainer);
 
     const getItem = () => {
-      const item = globalScene.add.sprite(0, 0, "items", this.modifierTypeOption.type?.iconImage);
+      const iconKey = this.modifierTypeOption.type?.iconImage;
+      const item = globalScene.add.sprite(0, 0, "items", iconKey);
+      item.setVisible(false);
+
+      const showItemSprite = () => {
+        if (globalScene.textures.get("items").has(iconKey)) {
+          item.setFrame(iconKey);
+        } else {
+          item.setTexture("default_icon");
+        }
+        item.setVisible(true);
+      };
+
+      if (globalScene.textures.get("items").has(iconKey)) {
+        showItemSprite();
+      } else {
+        globalScene.load.once("complete", showItemSprite);
+        globalScene.load.start();
+      }
+
       return item;
     };
 


### PR DESCRIPTION
## What are the changes the user will see?
- Icons for shop items will now properly display, instead of occasionally appearing empty or invisible.

## Why am I making these changes?
- Previously, shop item icons sometimes didn't appear because their sprites were used before being fully loaded.
- This fix ensures that sprites are fully loaded before displaying the icon, significantly enhancing the user experience.

## What are the changes from a developer perspective?
- Modified the `getItem()` function in `modifier-select-ui-handler.ts` to explicitly handle asynchronous loading of item sprites:
  - Checks if the sprite atlas (`items`) is loaded.
  - If not yet loaded, waits for loading completion before displaying the sprite.
  - Uses a default fallback icon if the sprite fails to load.

## How to test the changes?
- Open the shop multiple times rapidly or under heavy load conditions.
- Confirm that all item icons are consistently displayed without disappearing or defaulting incorrectly.
- You can go nuts with this code to force the broken display

```
    /*
    const getItem = () => {
        const item = globalScene.add.sprite(0, 0, "items", this.modifierTypeOption.type?.iconImage);
        return item;
    };
  */

    const getItem = () => {
      const iconKey = this.modifierTypeOption.type?.iconImage;
      const item = globalScene.add.sprite(0, 0, "items", iconKey);
  
      // Set this to true to artificially simulate loading delay
      const simulateLoadingDelay = false; // <-- SET TO true TO SIMULATE DELAY
  
      item.setVisible(false);
  
      const showItemSprite = () => {
          if (globalScene.textures.get('items').has(iconKey)) {
              item.setFrame(iconKey);
              item.setVisible(true);
          } else {
              item.setTexture('default_icon');
              item.setVisible(true);
          }
      };
  
      if (simulateLoadingDelay) {
          // Simulate an artificial delay of 2 seconds
          setTimeout(showItemSprite, 2000);
      } else {
          if (globalScene.textures.get('items').has(iconKey)) {
              showItemSprite();
          } else {
              // Wait until the atlas is fully loaded
              globalScene.load.once('complete', showItemSprite);
              globalScene.load.start();
          }
      }
  
      return item;
  };  
```


## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually? It's not really testable but on my side I wasn't able to reproduce the issue
- [] Are all unit tests still passing? (`npm run test:silent`)
(A thousands unrelated things are broken but i don't think it's my fault I guess?)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes? *(not applicable)*
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)? *(not applicable)*
