### PR TITLE
[Bug] Fix shiny save bug

### DIFF
--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -91,8 +91,8 @@ export default class PokemonData {
     this.formIndex = Math.max(Math.min(source.formIndex, getPokemonSpecies(this.species).forms.length - 1), 0);
     this.abilityIndex = source.abilityIndex;
     this.passive = source.passive;
-    this.shiny = sourcePokemon?.isShiny() ?? source.shiny;
-    this.variant = sourcePokemon?.getVariant() ?? source.variant;
+    this.shiny = source.shiny;
+    this.variant = source.variant;
     this.pokeball = source.pokeball ?? PokeballType.POKEBALL;
     this.level = source.level;
     this.exp = source.exp;


### PR DESCRIPTION
## What are the changes the user will see?
Whether a fusion is shiny and what variant it is are saved correctly.

## Why am I making these changes?
In some circumstances, fusions were incorrectly saving as the wrong variant.

## What are the changes from a developer perspective?
This is really just reverting some of the changes the illusion implementation made to the save/load code.

## Screenshots/Videos


## How to test the changes?


## Checklist
- [ ] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?