### PR TITLE
[Bug][UI/UX] Ensure pokemon hop when animations are selected

### DIFF
--- a/src/ui/pokedex-ui-handler.ts
+++ b/src/ui/pokedex-ui-handler.ts
@@ -873,6 +873,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
     const tweenChain: Phaser.Types.Tweens.TweenChainBuilderConfig = {
       targets: icon,
       loop: -1,
+      paused: startPaused,
       // Make the initial bounce a little randomly delayed
       delay: randIntRange(0, 50) * 5,
       loopDelay: 1000,
@@ -894,19 +895,14 @@ export default class PokedexUiHandler extends MessageUiHandler {
       ],
     };
 
-    const isPassiveAvailable = this.isPassiveAvailable(species.speciesId);
-    const isValueReductionAvailable = this.isValueReductionAvailable(species.speciesId);
-    const isSameSpeciesEggAvailable = this.isSameSpeciesEggAvailable(species.speciesId);
-
-    // 'Passives Only' mode
-    if (globalScene.candyUpgradeNotification === 1) {
-      if (isPassiveAvailable) {
-        globalScene.tweens.chain(tweenChain).paused = startPaused;
-      }
-      // 'On' mode
-    } else if (globalScene.candyUpgradeNotification === 2) {
-      if (isPassiveAvailable || isValueReductionAvailable || isSameSpeciesEggAvailable) {
-        globalScene.tweens.chain(tweenChain).paused = startPaused;
+    if (
+      this.isPassiveAvailable(species.speciesId) ||
+      (globalScene.candyUpgradeNotification === 2 &&
+        (this.isValueReductionAvailable(species.speciesId) || this.isSameSpeciesEggAvailable(species.speciesId)))
+    ) {
+      const chain = globalScene.tweens.chain(tweenChain);
+      if (!startPaused) {
+        chain.play();
       }
     }
   }
@@ -2040,7 +2036,7 @@ export default class PokedexUiHandler extends MessageUiHandler {
       this.checkIconId(lastSpeciesIcon, container.species, props.female, props.formIndex, props.shiny, props.variant);
       this.iconAnimHandler.addOrUpdate(lastSpeciesIcon, PokemonIconAnimMode.NONE);
       // Resume the animation for the previously selected species
-      globalScene.tweens.getTweensOf(lastSpeciesIcon).forEach(tween => tween.resume());
+      globalScene.tweens.getTweensOf(lastSpeciesIcon).forEach(tween => tween.play());
     }
   }
 

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1444,6 +1444,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
     const tweenChain: Phaser.Types.Tweens.TweenChainBuilderConfig = {
       targets: icon,
+      paused: startPaused,
       loop: -1,
       // Make the initial bounce a little randomly delayed
       delay: randIntRange(0, 50) * 5,
@@ -1451,14 +1452,14 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       tweens: [
         {
           targets: icon,
-          y: 2 - 5,
+          y: "-=5",
           duration: fixedInt(125),
           ease: "Cubic.easeOut",
           yoyo: true,
         },
         {
           targets: icon,
-          y: 2 - 3,
+          y: "-=3",
           duration: fixedInt(150),
           ease: "Cubic.easeOut",
           yoyo: true,
@@ -1466,19 +1467,14 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       ],
     };
 
-    const isPassiveAvailable = this.isPassiveAvailable(species.speciesId);
-    const isValueReductionAvailable = this.isValueReductionAvailable(species.speciesId);
-    const isSameSpeciesEggAvailable = this.isSameSpeciesEggAvailable(species.speciesId);
-
-    // 'Passives Only' mode
-    if (globalScene.candyUpgradeNotification === 1) {
-      if (isPassiveAvailable) {
-        globalScene.tweens.chain(tweenChain).paused = startPaused;
-      }
-      // 'On' mode
-    } else if (globalScene.candyUpgradeNotification === 2) {
-      if (isPassiveAvailable || isValueReductionAvailable || isSameSpeciesEggAvailable) {
-        globalScene.tweens.chain(tweenChain).paused = startPaused;
+    if (
+      this.isPassiveAvailable(species.speciesId) ||
+      (globalScene.candyUpgradeNotification === 2 &&
+        (this.isValueReductionAvailable(species.speciesId) || this.isSameSpeciesEggAvailable(species.speciesId)))
+    ) {
+      const chain = globalScene.tweens.chain(tweenChain);
+      if (!startPaused) {
+        chain.play();
       }
     }
   }
@@ -3478,7 +3474,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
       // Resume the animation for the previously selected species
       const icon = this.starterContainers[speciesIndex].icon;
-      globalScene.tweens.getTweensOf(icon).forEach(tween => tween.resume());
+      globalScene.tweens.getTweensOf(icon).forEach(tween => tween.play());
     }
 
     this.lastSpecies = species!; // TODO: is this bang correct?


### PR DESCRIPTION
## What are the changes the user will see?
Pokemon will now consistently play their hop animation in starter select / pokedex when candy upgrade is set to `animation`.

## Why am I making these changes?
Fixes a bug reported in: https://discord.com/channels/1125469663833370665/1368563798088355850/1368563798088355850

## What are the changes from a developer perspective?
Inside `pokedex-ui-handler` and `starter-select-ui-handler`, after creating the tween that causes the pokemon to hop, we forcibly call the `.play()` method on said tween. It is unclear to me precisely why the tweens required this to be set, even in the case that the tweens were not starting paused.

I also changed the call to `.resume()` to a .`play()` because this will ensure the tween that was created in a paused state will start. Calling `resume` will not do this.

## Screenshots/Videos

<details><summary>Proper candy hopping in starter select</summary>

https://github.com/user-attachments/assets/4d96af1d-d73c-47aa-ade8-a8f330d78814
</details>


## How to test the changes?
Load up a save that has enough candies to unlock passives and/or upgrades on some mons.
Go into settings and make sure the candy upgrade notifications is set to `animation`.
Then, go into starter select or pokedex and observe.

## Checklist
- ~~[ ] **I'm using `beta` as my base branch**~~ Hotfix
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~