### PR TITLE
[Bug] Ensure shiny and variant status respects illusion properly

### DIFF
--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -91,8 +91,8 @@ export default class PokemonData {
     this.formIndex = Math.max(Math.min(source.formIndex, getPokemonSpecies(this.species).forms.length - 1), 0);
     this.abilityIndex = source.abilityIndex;
     this.passive = source.passive;
-    this.shiny = source.shiny;
-    this.variant = source.variant;
+    this.shiny = sourcePokemon?.summonData.illusion?.basePokemon.shiny ?? source.shiny;
+    this.variant = sourcePokemon?.summonData.illusion?.basePokemon.variant ?? source.variant;
     this.pokeball = source.pokeball ?? PokeballType.POKEBALL;
     this.level = source.level;
     this.exp = source.exp;


### PR DESCRIPTION
## What are the changes the user will see?
Saving pokemon data will now ignore the pokemon's illusion

## Why am I making these changes?
Fixes a bug during serialization of a pokemon not properly respecting illusion.

#5780 did not actually fix this issue.

## What are the changes from a developer perspective?
Respect the true shiny / variant result.

## Screenshots/Videos
N/A

## How to test the changes?


## Checklist
- ~~[ ] **I'm using `beta` as my base branch**~~ Hotfix
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?