### PR TITLE
[Bug] Prevent some corrupt eggs from crashing the game

### DIFF
--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -598,7 +598,7 @@ export class Egg {
   }
 
   private getEggTier(): EggTier {
-    return speciesEggTiers[this.species];
+    return speciesEggTiers[this.species] ?? EggTier.COMMON;
   }
 
   ////


### PR DESCRIPTION
## What are the changes the user will see?
Certain types of corrupt eggs (those with species who don't have an associated `EggTier` because they're not supposed to be in eggs) will no longer crash the game.

## Why am I making these changes?
Fixing a P0 bug.

## What are the changes from a developer perspective?
If an egg is somehow a species that doesn't have an associated egg tier (such as Pikachu), `Egg#getEggTier` now falls back to `EggTier.COMMON`

## Screenshots/Videos
<details><summary>Pikachu Egg</summary>
<p>

![image](https://github.com/user-attachments/assets/52274c06-2758-4bb5-bc1d-785c81a0f15b)

</p>
</details> 

## How to test the changes?
Load this save data and look at the egg list, the first egg should be a Pikachu egg. Without the fix, the game should crash; with the fix, it should show in the egg list as a common egg.
[data_DemoCinderace98 - egg bug.prsv.txt](https://github.com/user-attachments/files/20061165/data_DemoCinderace98.-.egg.bug.prsv.txt)

## Checklist
- ~[ ] **I'm using `beta` as my base branch**~
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?