### PR TITLE
[Bug] Fix seed not being reset now that Select Biome Phase goes before New Battle

### DIFF
--- a/src/phases/select-biome-phase.ts
+++ b/src/phases/select-biome-phase.ts
@@ -13,6 +13,8 @@ export class SelectBiomePhase extends BattlePhase {
   start() {
     super.start();
 
+    globalScene.resetSeed();
+
     const currentBiome = globalScene.arena.biomeType;
     const nextWaveIndex = globalScene.currentBattle.waveIndex + 1;
 


### PR DESCRIPTION
## What are the changes the user will see?
Depending on the last actions on every wave x0, it would change the biome options rng roll. Now the seed is reset, which means the biome options are independent of your actions on the last wave.

## Why am I making these changes?
This messes up Daily Mode a lot, since everyone is on the same seed but they cant go to the same biomes if they have a slightly different action. It would also allow a player to sit on the last wave and keep trying different actions until the Map shows the biome that they want.
Generally not a good thing. 
ResetSeed used to be done by the NewBattlePhase, but that is now happening after the SelectBiomePhase, so the latter now has to reset it themselves.

## What are the changes from a developer perspective?


## Screenshots/Videos
Attacking vs Running video
Override:
```ts
const overrides = {
  SEED_OVERRIDE: "lokaisdhjfklhj",
  STARTING_WAVE_OVERRIDE: 10,
  STARTING_LEVEL_OVERRIDE: 10000,
  STARTING_BIOME_OVERRIDE: Biome.TEMPLE,
  STARTING_MODIFIER_OVERRIDE: [{name: "MAP", count:1}]
} satisfies Partial<InstanceType<OverridesType>>;
```
Before:

https://github.com/user-attachments/assets/a2ab4268-8f83-4225-b4a4-5383796c874e

After:

https://github.com/user-attachments/assets/e358828b-6aa3-4502-86b3-3fc8b00d4dac

--------------

Attacking vs Catching video
Override:
```ts
const overrides = {
  SEED_OVERRIDE: "regu4nw5iugn45iu9n",
  STARTING_WAVE_OVERRIDE: 10,
  STARTING_LEVEL_OVERRIDE: 15,
  STARTING_BIOME_OVERRIDE: Biome.TEMPLE,
  STARTING_MODIFIER_OVERRIDE: [{name: "MAP", count:1}, {name: "MASTER_BALL", count:1}]
} satisfies Partial<InstanceType<OverridesType>>;
```
Before:

https://github.com/user-attachments/assets/b1b969ef-61df-4627-b391-81f27a3dde66

After:

https://github.com/user-attachments/assets/6b139cd8-33b9-4795-b25a-5f956ee28ffe

--------------

And one last one showing After 3 times:
```ts
const overrides = {
  SEED_OVERRIDE: "lkjsd234Z8z7hg8.q345t2=-",
  STARTING_WAVE_OVERRIDE: 10,
  STARTING_LEVEL_OVERRIDE: 10000,
  STARTING_BIOME_OVERRIDE: Biome.TEMPLE,
  STARTING_MODIFIER_OVERRIDE: [{name: "MAP", count:1}, {name: "MASTER_BALL", count:1}]
} satisfies Partial<InstanceType<OverridesType>>;
```
https://github.com/user-attachments/assets/f6c309bf-4cba-41df-a4d4-d4cdf4f225d4






## How to test the changes?
Override to w10, different actions like moves, turns, poke ball or running on the same seed could give different map options.

## Checklist
- [x] **I'm using `main` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
