### PR TITLE
[Bug][Hotfix] Suppress Illusion if NG is already active

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -186,6 +186,7 @@ import {
   applyAllyStatMultiplierAbAttrs,
   AllyStatMultiplierAbAttr,
   MoveAbilityBypassAbAttr,
+  PreSummonAbAttr,
 } from "#app/data/abilities/ability";
 import { allAbilities } from "#app/data/data-lists";
 import type PokemonData from "#app/system/pokemon-data";
@@ -2414,8 +2415,9 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
     const suppressAbilitiesTag = arena.getTag(
       ArenaTagType.NEUTRALIZING_GAS,
     ) as SuppressAbilitiesTag;
+    const suppressOffField = ability.hasAttr(PreSummonAbAttr);
     if (
-      this.isOnField() &&
+      (this.isOnField() || suppressOffField) &&
       suppressAbilitiesTag &&
       !suppressAbilitiesTag.isBeingRemoved()
     ) {

--- a/test/abilities/illusion.test.ts
+++ b/test/abilities/illusion.test.ts
@@ -65,13 +65,27 @@ describe("Abilities - Illusion", () => {
     expect(!!zorua.summonData.illusion).equals(false);
   });
 
-  it("break with neutralizing gas", async () => {
+  it("breaks with neutralizing gas", async () => {
     game.override.enemyAbility(Abilities.NEUTRALIZING_GAS);
     await game.classicMode.startBattle([Species.KOFFING]);
 
     const zorua = game.scene.getEnemyPokemon()!;
 
     expect(!!zorua.summonData.illusion).equals(false);
+  });
+
+  it("does not activate if neutralizing gas is active", async () => {
+    game.override
+      .enemyAbility(Abilities.NEUTRALIZING_GAS)
+      .ability(Abilities.ILLUSION)
+      .moveset(Moves.SPLASH)
+      .enemyMoveset(Moves.SPLASH);
+    await game.classicMode.startBattle([Species.MAGIKARP, Species.FEEBAS, Species.MAGIKARP]);
+
+    game.doSwitchPokemon(1);
+    await game.toNextTurn();
+
+    expect(game.scene.getPlayerPokemon()!.summonData.illusion).toBeFalsy();
   });
 
   it("causes enemy AI to consider the illusion's type instead of the actual type when considering move effectiveness", async () => {


### PR DESCRIPTION
## What are the changes the user will see?
Sending out an illusion Pokemon with neutralizing gas active will result in the illusion not being activated

## Why am I making these changes?
https://discord.com/channels/1125469663833370665/1369015872424775720

## What are the changes from a developer perspective?
`canApplyAbility` checks if an ability is PreSummon, and if so ignores the check that the pokemon must be on the field for neutralizing gas to apply (because PreSummon abilities are still suppressible even though they activate before being sent out - it's the equivalent of activating the ability then immediately suppressing it on summon, without the overhead). 

It's likely that the `isOnField()` check as a whole is unnecessary, but that's not a can of worms to open for a hotfix

## Screenshots/Videos
<details><summary>Before</summary>
<p>

https://github.com/user-attachments/assets/621a3f10-c002-4e48-a654-cb646f31dfb5

</p>
</details> 

<details><summary>After</summary>
<p>

https://github.com/user-attachments/assets/68148cfb-cf31-4e75-a733-12c2711e2993

</p>
</details> 

## How to test the changes?
Switch a pokemon with illusion in while NG is already active

## Checklist
- [x] **I'm using `hotfix-1.9.2` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?