### PR TITLE
[Bug][Hotfix] Fix Transformed Sprites not loading properly

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -909,7 +909,6 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       const originalWarn = console.warn;
       // Ignore warnings for missing frames, because there will be a lot
       console.warn = () => {};
-      // NEED REVIEW: is `this.isPlayer()` always the correct check for whether to get the front of back sprite?
       const battleSpriteKey = this.getBattleSpriteKey(this.isPlayer(), ignoreOverride);
       const battleFrameNames = globalScene.anims.generateFrameNames(battleSpriteKey, {
         zeroPad: 4,

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -909,19 +909,23 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       const originalWarn = console.warn;
       // Ignore warnings for missing frames, because there will be a lot
       console.warn = () => {};
-      const battleFrameNames = globalScene.anims.generateFrameNames(this.getBattleSpriteKey(), {
+      // NEED REVIEW: is `this.isPlayer()` always the correct check for whether to get the front of back sprite?
+      const battleSpriteKey = this.getBattleSpriteKey(this.isPlayer(), ignoreOverride);
+      const battleFrameNames = globalScene.anims.generateFrameNames(battleSpriteKey, {
         zeroPad: 4,
         suffix: ".png",
         start: 1,
         end: 400,
       });
       console.warn = originalWarn;
-      globalScene.anims.create({
-        key: this.getBattleSpriteKey(),
-        frames: battleFrameNames,
-        frameRate: 10,
-        repeat: -1,
-      });
+      if (!globalScene.anims.exists(battleSpriteKey)) {
+        globalScene.anims.create({
+          key: battleSpriteKey,
+          frames: battleFrameNames,
+          frameRate: 10,
+          repeat: -1,
+        });
+      }
     }
     // With everything loaded, now begin playing the animation.
     this.playAnim();

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1110,7 +1110,7 @@ export class GameData {
           for (const p of sessionData.party) {
             const pokemon = p.toPokemon() as PlayerPokemon;
             pokemon.setVisible(false);
-            loadPokemonAssets.push(pokemon.loadAssets());
+            loadPokemonAssets.push(pokemon.loadAssets(false));
             party.push(pokemon);
           }
 


### PR DESCRIPTION
## What are the changes the user will see?
A transformed pokemon at the lead of the party will display the correct sprite when loading a save. Hopefully also prevents a related phaser crash

## Why am I making these changes?
Should fix https://discord.com/channels/1125469663833370665/1368847213224132618

## What are the changes from a developer perspective?
Similarly to icons, the code for grabbing the atlas and the code for grabbing the sprite key weren't synced in terms of their use of `ignoreOverride`, so one would grab the transformed species and the other would grab the base species (i.e. ditto), leading to mixups. No idea how it ever worked correctly, in all honesty.

As an example, `loadAssets()` is called when generating pokemon from save data with no arguments, and `ignoreOverride` defaults to true in that method. `ignoreOverride` is then passed (as `true`) when getting the atlas, but *not* passed (defaulting to false) when getting the actual sprite key. Genuinely, no idea

I changed the call to `getBattleSpriteKey()` to actually use the `ignoreOverride` parameter, as well as changed the relevant `loadAssets()` call to pass `false` to `ignoreOverride`

## Screenshots/Videos
<details><summary>Before</summary>
<p>

https://github.com/user-attachments/assets/7ed1ee19-a0b0-4499-b4da-214e1d936483

</p>
</details> 

<details><summary>After</summary>
<p>

https://github.com/user-attachments/assets/c8832579-ed1a-46be-999d-3ba8e1ae899e

</p>
</details> 

## How to test the changes?
Grab a broken ditto save and see if the sprite loads in correctly

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?