### PR TITLE
[Bug] [Move] Fix KO causing effects to occur twice

### DIFF
--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -206,11 +206,13 @@ export class MoveEffectPhase extends PokemonPhase {
    * @throws Error if there was an unexpected hit check result
    */
   private applyToTargets(user: Pokemon, targets: Pokemon[]): void {
+    let firstHit = true;
     for (const [i, target] of targets.entries()) {
       const [hitCheckResult, effectiveness] = this.hitChecks[i];
       switch (hitCheckResult) {
         case HitCheckResult.HIT:
-          this.applyMoveEffects(target, effectiveness);
+          this.applyMoveEffects(target, effectiveness, firstHit);
+          firstHit = false;
           if (isFieldTargeted(this.move)) {
             // Stop processing other targets if the move is a field move
             return;
@@ -763,15 +765,12 @@ export class MoveEffectPhase extends PokemonPhase {
    * - Invoking {@linkcode applyOnTargetEffects} if the move does not hit a substitute
    * - Triggering form changes and emergency exit / wimp out if this is the last hit
    *
-   * @param target the {@linkcode Pokemon} hit by this phase's move.
-   * @param effectiveness the effectiveness of the move (as previously evaluated in {@linkcode hitCheck})
+   * @param target - the {@linkcode Pokemon} hit by this phase's move.
+   * @param effectiveness - The effectiveness of the move (as previously evaluated in {@linkcode hitCheck})
+   * @param firstTarget - Whether this is the first target successfully struck by the move
    */
-  protected applyMoveEffects(target: Pokemon, effectiveness: TypeDamageMultiplier): void {
+  protected applyMoveEffects(target: Pokemon, effectiveness: TypeDamageMultiplier, firstTarget): void {
     const user = this.getUserPokemon();
-
-    /** The first target hit by the move */
-    const firstTarget = target === this.getTargets().find((_, i) => this.hitChecks[i][1] > 0);
-
     if (isNullOrUndefined(user)) {
       return;
     }

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -769,7 +769,7 @@ export class MoveEffectPhase extends PokemonPhase {
    * @param effectiveness - The effectiveness of the move (as previously evaluated in {@linkcode hitCheck})
    * @param firstTarget - Whether this is the first target successfully struck by the move
    */
-  protected applyMoveEffects(target: Pokemon, effectiveness: TypeDamageMultiplier, firstTarget): void {
+  protected applyMoveEffects(target: Pokemon, effectiveness: TypeDamageMultiplier, firstTarget: boolean): void {
     const user = this.getUserPokemon();
     if (isNullOrUndefined(user)) {
       return;


### PR DESCRIPTION
## What are the changes the user will see?
Using a move like Make it Rain in doubles will no longer cause effects to happen once per target.

## Why am I making these changes?
Fixes https://discord.com/channels/1125469663833370665/1370729720035016775/1370729720035016775

## What are the changes from a developer perspective?
Add a `firstTarget` parameter to the `applyMoveEffect` in the move effect phase.
Added a boolean to `applyToTargets` that starts true and is set to false after the first successful hit against a pokemon.

## Screenshots/Videos

Go to the linked discord bug report to see the "before" behavior.

<details><summary>Fixed Make it Rain</summary>

https://github.com/user-attachments/assets/c7bfd862-f7f1-46e0-8cd8-7c0897853ea9
</details>

## How to test the changes?
```ts
const overrides = {
  MOVESET_OVERRIDE: [
    Moves.MAKE_IT_RAIN,
  ],
  OPP_SPECIES_OVERRIDE: Species.CACNEA,
  STARTING_LEVEL_OVERRIDE: 100,
  BATTLE_STYLE_OVERRIDE: "double",
} satisfies Partial<InstanceType<OverridesType>>;
```

Use Make it Rain and notice that the stats do not drop twice.

## Checklist
- ~~[ ] **I'm using `beta` as my base branch**~~ Hotfix
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~