### PR TITLE
[Bug][Move] Fix move effects not applying with multi-lens

### DIFF
--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -905,6 +905,14 @@ export class MoveEffectPhase extends PokemonPhase {
 
     target.destroySubstitute();
     target.lapseTag(BattlerTagType.COMMANDED);
+
+    // Force `lastHit` to be true if this is a multi hit move with hits left
+    // `hitsLeft` must be left as-is in order for the message displaying the number of hits
+    // to display the proper number.
+    // Note: When Dragon Darts' smart targeting is implemented, this logic may need to be adjusted.
+    if (!this.lastHit && user.turnData.hitsLeft > 1) {
+      this.lastHit = true;
+    }
   }
 
   /**


### PR DESCRIPTION
## What are the changes the user will see?
Move effects like hyper beam's recharge will now

## Why am I making these changes?
Fixes a bug: https://discord.com/channels/1125469663833370665/1369623154900734012/1369623154900734012

## What are the changes from a developer perspective?
Inside the `onFaintTarget` method, if the move was multi hit and the phase's `lastHit` method was not already marked as true, then force `lastHit` to be true. This will allow the POST_TARGET effects responsible for adding the tags from outrage, hyper beam, etc., to continue.

## Screenshots/Videos
<details><summary>Proper hyper beam recharge</summary>

https://github.com/user-attachments/assets/39167837-eb31-4fac-ab88-c83d3d279f29
</details>

## How to test the changes?
Here are the overrides I used:

```ts
const overrides = {
  MOVESET_OVERRIDE: [
    Moves.HYPER_BEAM,
    Moves.DAZZLING_GLEAM
  ],
  ITEM_REWARD_OVERRIDE: [
    { name: "MULTI_LENS"},
  ],
  OPP_SPECIES_OVERRIDE: Species.MAGIKARP,
  OPP_LEVEL_OVERRIDE: 1,
  OPP_MOVESET_OVERRIDE: [Moves.SPLASH],
  STARTING_LEVEL_OVERRIDE: 100,
  BATTLE_STYLE_OVERRIDE: "double",
} satisfies Partial<InstanceType<OverridesType>>;
```

Beat the first wave by using dazzling gleam, and choose multi-lens.
Proceed to the next battle and use hyper beam. Notice that you now recharge, where as you did not before.

## Checklist
- ~~[ ] **I'm using `beta` as my base branch**~~ Hotfix
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~