### PR TITLE
[Bug] Fix old session load modifier crash

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2921,7 +2921,10 @@ export default class BattleScene extends SceneBase {
     instant?: boolean,
     cost?: number,
   ): boolean {
-    if (!modifier) {
+    // We check against modifier.type to stop a bug related to loading in a pokemon that has a form change item, which prior to some patch
+    // that changed form change modifiers worked, had previously set the `type` field to null.
+    // TODO: This is not the right place to check for this; it should ideally go in a session migrator.
+    if (!modifier || !modifier.type) {
       return false;
     }
     let success = false;


### PR DESCRIPTION
## What are the changes the user will see?
Users with saves from before the form change modifier items were split will now be able to load in their saves.
Also, any saves that somehow had corrupted their modifier type will now be able to load in.

## Why am I making these changes?
Fixes one of the issues preventing sessions from being loaded.

## What are the changes from a developer perspective?
Add a check to `modifier.type` being null inside of `battle-scene#addModifer`

Note that if the user tries to examine the run data by pressing right arrow key, the game will error, though this will be fixed as soon as they save the run after having loaded it in.

## Screenshots/Videos

<details><summary>Attempting to load in save prior to bugfix</summary>

https://github.com/user-attachments/assets/e2df2c45-89fb-427c-9eb0-5aa83fd36e25
</details>

<details><summary>Successfully loading in previously-corrupted save post bug</summary>

https://github.com/user-attachments/assets/a4ad41b4-64b7-420d-bbd4-c6688f2f7ced
</details>


## How to test the changes?
Use this save:
(change the file extension back to .prsv, I had to change it to .txt to get github to let me upload it)
[sessionData_IceEnd.prsv.txt](https://github.com/user-attachments/files/20153974/sessionData_IceEnd.prsv.txt)


## Checklist
- ~~[ ] **I'm using `beta` as my base branch**~~ Hotfix
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~