### PR TITLE
[BUG] Fix #5288 Clowning Around doesn’t check if Pokemon already has that Ability Before Granting It 

### DIFF
--- a/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
@@ -1023,14 +1023,22 @@ export function isPokemonValidForEncounterOptionSelection(
 /**
  * Permanently overrides the ability (not passive) of a pokemon.
  * If the pokemon is a fusion, instead overrides the fused pokemon's ability.
+ * @param ability
+ * @param pokemon
+ * @param flagAcceptAbility
  */
-export function applyAbilityOverrideToPokemon(pokemon: Pokemon, ability: Abilities) {
-  if (pokemon.isFusion()) {
-    if (!pokemon.fusionCustomPokemonData) {
-      pokemon.fusionCustomPokemonData = new CustomPokemonData();
-    }
-    pokemon.fusionCustomPokemonData.ability = ability;
-  } else {
-    pokemon.customPokemonData.ability = ability;
+export function applyAbilityOverrideToPokemon(pokemon: Pokemon, ability: Abilities, flagAcceptAbility: boolean) {
+  const isFusion = pokemon.isFusion();
+  const data = isFusion
+    ? (pokemon.fusionCustomPokemonData ??= new CustomPokemonData())
+    : (pokemon.customPokemonData ??= new CustomPokemonData());
+
+  const shouldOverride = data.ability !== ability || flagAcceptAbility;
+
+  if (shouldOverride) {
+    data.ability = ability;
+    return true;
   }
+
+  return false;
 }


### PR DESCRIPTION
## What are the changes the user will see?

When attempting to assign an ability that the selected Pokémon already possesses, a confirmation message is now displayed:

    "Your Pokémon already has this ability. Are you sure you want to apply it?"

The player is then given two options:
 - "Yes" – Confirms the action. The ability remains unchanged and the new (duplicate) ability is discarded.
- "No" – Cancels the action and returns to the selection menu, allowing the player to choose a different Pokémon to receive the ability.

## Why am I making these changes?

Adds a confirmation step to inform the player when attempting to assign an ability that the Pokémon already has, and allows them to choose a different Pokémon instead. This improves overall gameplay clarity and user experience.
Fixes  #5288


## What are the changes from a developer perspective?

To implement the fix, 2 source files were changed,  accompained by the addition of a test on another file. The test is detailed in the corresponding section.

- Refactored `applyAbilityOverrideToPokemon` to accept a new boolean parameter `flagAcceptAbility`, allowing reapplication of the same ability when explicitly confirmed by the user.
- Improved code readability and eliminated duplication using a ternary expression for selecting fusion or standard Pokémon data.
- Added `handleRepeatedAbility` function that shows a menu if the selected Pokémon already has the target ability.
- Integrated new OptionSelectConfig with yes/no handlers:

    "Yes" → Forces ability reapplication.

    "No" → Returns to Pokémon selection via `onYesAbilitySwap`


## Screenshots/Videos

https://github.com/user-attachments/assets/1e55e802-4507-4f6d-b5eb-4d5164552844


## How to test the changes?


To manually test and observe the behavior demonstrated in the video, follow these steps:

   1. In the `src/overrides.ts` file, set the following values:

```
	STARTING_WAVE_OVERRIDE: 11,

	MYSTERY_ENCOUNTER_RATE_OVERRIDE: 255,

	MYSTERY_ENCOUNTER_OVERRIDE: MysteryEncounterType.CLOWNING_AROUND,
```

   2. In the `src/data/mystery-encounters/encounters/clowning-around-encounter.ts` file, comment out line 504 and replace it with a hardcoded ability:

```
	// const randomAbility = encounter.misc.ability;
	
	const randomAbility = Abilities.PRANKSTER;
```

   3. After that, launch a new save with any two starting Pokémons. Give the selected ability (e.g., PRANKSTER) to one of your Pokémon and attempt to give the same ability to the same Pokémon again.

Also added an automated test, in the file `test/mystery-encounter/encounters/clowning-around-encounter.test.ts` to verify the behavior when giving an ability to a Pokémon that already has it: it displays a confirmation message, shows the menu to confirm overwriting with the same ability, and then accepts it.

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [X] Are all unit tests still passing? (`npm run test:silent`)
  - [X] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?