### PR TITLE
[Bug][UI/UX] Fix faint phase order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokemon-rogue-battle",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pokemon-rogue-battle",
-      "version": "1.9.2",
+      "version": "1.9.3",
       "hasInstallScript": true,
       "dependencies": {
         "@material/material-color-utilities": "^0.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pokemon-rogue-battle",
   "private": true,
-  "version": "1.9.2",
+  "version": "1.9.3",
   "type": "module",
   "scripts": {
     "start": "vite",

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1045,7 +1045,7 @@ export default class BattleScene extends SceneBase {
     y: number,
     originX = 0.5,
     originY = 0.5,
-    ignoreOverride = false,
+    ignoreOverride = true,
     useIllusion = false,
   ): Phaser.GameObjects.Container {
     const container = this.add.container(x, y);
@@ -1053,9 +1053,9 @@ export default class BattleScene extends SceneBase {
 
     const icon = this.add.sprite(0, 0, pokemon.getIconAtlasKey(ignoreOverride, useIllusion));
     icon.setName(`sprite-${pokemon.name}-icon`);
-    icon.setFrame(pokemon.getIconId(true, useIllusion));
+    icon.setFrame(pokemon.getIconId(ignoreOverride, useIllusion));
     // Temporary fix to show pokemon's default icon if variant icon doesn't exist
-    if (icon.frame.name !== pokemon.getIconId(true, useIllusion)) {
+    if (icon.frame.name !== pokemon.getIconId(ignoreOverride, useIllusion)) {
       console.log(`${pokemon.name}'s variant icon does not exist. Replacing with default.`);
       const temp = pokemon.shiny;
       pokemon.shiny = false;
@@ -1071,7 +1071,7 @@ export default class BattleScene extends SceneBase {
       const fusionIcon = this.add.sprite(0, 0, pokemon.getFusionIconAtlasKey(ignoreOverride, useIllusion));
       fusionIcon.setName("sprite-fusion-icon");
       fusionIcon.setOrigin(0.5, 0);
-      fusionIcon.setFrame(pokemon.getFusionIconId(true, useIllusion));
+      fusionIcon.setFrame(pokemon.getFusionIconId(ignoreOverride, useIllusion));
 
       const originalWidth = icon.width;
       const originalHeight = icon.height;

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2921,7 +2921,10 @@ export default class BattleScene extends SceneBase {
     instant?: boolean,
     cost?: number,
   ): boolean {
-    if (!modifier) {
+    // We check against modifier.type to stop a bug related to loading in a pokemon that has a form change item, which prior to some patch
+    // that changed form change modifiers worked, had previously set the `type` field to null.
+    // TODO: This is not the right place to check for this; it should ideally go in a session migrator.
+    if (!modifier || !modifier.type) {
       return false;
     }
     let success = false;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -909,19 +909,22 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       const originalWarn = console.warn;
       // Ignore warnings for missing frames, because there will be a lot
       console.warn = () => {};
-      const battleFrameNames = globalScene.anims.generateFrameNames(this.getBattleSpriteKey(), {
+      const battleSpriteKey = this.getBattleSpriteKey(this.isPlayer(), ignoreOverride);
+      const battleFrameNames = globalScene.anims.generateFrameNames(battleSpriteKey, {
         zeroPad: 4,
         suffix: ".png",
         start: 1,
         end: 400,
       });
       console.warn = originalWarn;
-      globalScene.anims.create({
-        key: this.getBattleSpriteKey(),
-        frames: battleFrameNames,
-        frameRate: 10,
-        repeat: -1,
-      });
+      if (!globalScene.anims.exists(battleSpriteKey)) {
+        globalScene.anims.create({
+          key: battleSpriteKey,
+          frames: battleFrameNames,
+          frameRate: 10,
+          repeat: -1,
+        });
+      }
     }
     // With everything loaded, now begin playing the animation.
     this.playAnim();

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -7862,7 +7862,7 @@ export class PokemonSummonData {
       }
 
       if (key === "moveset") {
-        this.moveset = value.map((m: any) => PokemonMove.loadMove(m));
+        this.moveset = value?.map((m: any) => PokemonMove.loadMove(m));
         continue;
       }
 

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -905,6 +905,14 @@ export class MoveEffectPhase extends PokemonPhase {
 
     target.destroySubstitute();
     target.lapseTag(BattlerTagType.COMMANDED);
+
+    // Force `lastHit` to be true if this is a multi hit move with hits left
+    // `hitsLeft` must be left as-is in order for the message displaying the number of hits
+    // to display the proper number.
+    // Note: When Dragon Darts' smart targeting is implemented, this logic may need to be adjusted.
+    if (!this.lastHit && user.turnData.hitsLeft > 1) {
+      this.lastHit = true;
+    }
   }
 
   /**

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -98,6 +98,8 @@ export class MoveEffectPhase extends PokemonPhase {
   /** Is this the last strike of a move? */
   private lastHit: boolean;
 
+  private faintPhases: FaintPhase[] = [];
+
   /** Phases queued during moves */
   private queuedPhases: Phase[] = [];
 
@@ -242,6 +244,11 @@ export class MoveEffectPhase extends PokemonPhase {
         case HitCheckResult.ERROR:
           throw new Error("Unexpected hit check result");
       }
+    }
+
+    // Append the faint phases after resolving all move effects so that the faint phase happens after any message phases
+    if (this.faintPhases.length) {
+      globalScene.unshiftPhase(...this.faintPhases);
     }
   }
 
@@ -900,7 +907,7 @@ export class MoveEffectPhase extends PokemonPhase {
     // set splice index here, so future scene queues happen before FaintedPhase
     globalScene.setPhaseQueueSplice();
 
-    globalScene.unshiftPhase(new FaintPhase(target.getBattlerIndex(), false, user));
+    this.faintPhases.push(new FaintPhase(target.getBattlerIndex(), false, user));
 
     target.destroySubstitute();
     target.lapseTag(BattlerTagType.COMMANDED);

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -246,7 +246,10 @@ export class MoveEffectPhase extends PokemonPhase {
       }
     }
 
-    // Append the faint phases after resolving all move effects so that the faint phase happens after any message phases
+    // Faint phases are unshifted after applying the move effects to all targets in order
+    // to ensure that all move effect messages and related phases occur _before_ the faint phase
+    // Note that this must occur before POST_TARGET effects are triggered in order for the faint phase to correctly
+    // occur before the user of self-destruct faints
     if (this.faintPhases.length) {
       globalScene.unshiftPhase(...this.faintPhases);
     }

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -206,11 +206,13 @@ export class MoveEffectPhase extends PokemonPhase {
    * @throws Error if there was an unexpected hit check result
    */
   private applyToTargets(user: Pokemon, targets: Pokemon[]): void {
+    let firstHit = true;
     for (const [i, target] of targets.entries()) {
       const [hitCheckResult, effectiveness] = this.hitChecks[i];
       switch (hitCheckResult) {
         case HitCheckResult.HIT:
-          this.applyMoveEffects(target, effectiveness);
+          this.applyMoveEffects(target, effectiveness, firstHit);
+          firstHit = false;
           if (isFieldTargeted(this.move)) {
             // Stop processing other targets if the move is a field move
             return;
@@ -763,15 +765,12 @@ export class MoveEffectPhase extends PokemonPhase {
    * - Invoking {@linkcode applyOnTargetEffects} if the move does not hit a substitute
    * - Triggering form changes and emergency exit / wimp out if this is the last hit
    *
-   * @param target the {@linkcode Pokemon} hit by this phase's move.
-   * @param effectiveness the effectiveness of the move (as previously evaluated in {@linkcode hitCheck})
+   * @param target - the {@linkcode Pokemon} hit by this phase's move.
+   * @param effectiveness - The effectiveness of the move (as previously evaluated in {@linkcode hitCheck})
+   * @param firstTarget - Whether this is the first target successfully struck by the move
    */
-  protected applyMoveEffects(target: Pokemon, effectiveness: TypeDamageMultiplier): void {
+  protected applyMoveEffects(target: Pokemon, effectiveness: TypeDamageMultiplier, firstTarget: boolean): void {
     const user = this.getUserPokemon();
-
-    /** The first target hit by the move */
-    const firstTarget = target === this.getTargets().find((_, i) => this.hitChecks[i][1] > 0);
-
     if (isNullOrUndefined(user)) {
       return;
     }

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1110,7 +1110,7 @@ export class GameData {
           for (const p of sessionData.party) {
             const pokemon = p.toPokemon() as PlayerPokemon;
             pokemon.setVisible(false);
-            loadPokemonAssets.push(pokemon.loadAssets());
+            loadPokemonAssets.push(pokemon.loadAssets(false));
             party.push(pokemon);
           }
 

--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -188,7 +188,7 @@ export default class PokemonData {
     // when loading from saved session, recover summonData.speciesFrom and form index species object
     // used to stay transformed on reload session
     if (this.summonData.speciesForm) {
-      this.summonData.speciesForm = getPokemonSpeciesForm(
+      ret.summonData.speciesForm = getPokemonSpeciesForm(
         this.summonData.speciesForm.speciesId,
         this.summonDataSpeciesFormIndex,
       );


### PR DESCRIPTION
## What are the changes the user will see?
A move that causes a target to faint will no longer have the target faint before other messages related to the move are displayed.

## Why am I making these changes?
~~Fixes a bug caused by #5678~~
Was not actually caused by that PR.

## What are the changes from a developer perspective?
Added a new private field to the move effect phase, `faintPhases`, that stores the faint phases that will be added by the move.
Instead of immediately unshifting the faint phase when the target faints, the faint phase is pushed to this array. Then, each of the faint phases are unshifted after all of the move effects could occur, inside of the `applyToTargets` method.

This ensures that the faint phases are unshifted _after_ all of the phases that are enqueued from a move's use (like the self-stat increase). Note that this must happen before POST_TARGET effects to ensure that self-destruct's self-faint occurs after the targets hit by the move faint. This is why the unshifting is done in the `applyToTargets` method.

## Screenshots/Videos

<details><summary>Current hotfix branch</summary>

https://github.com/user-attachments/assets/0d36b1bd-66c9-43d3-8003-5834c5ce4ea7
</details>

<details><summary>After fix</summary>

https://github.com/user-attachments/assets/502e1d6e-9d8a-46e6-bb5d-7f1e847e149b
</details>


## How to test the changes?
I use these overrides:
```ts
const overrides = {
  MOVESET_OVERRIDE: Moves.MYSTICAL_POWER,
  STARTING_LEVEL_OVERRIDE: 100
} satisfies Partial<InstanceType<OverridesType>>;
```

Just go into battle and use mystical power, and note that the stat boost message now properly appears before the target's faint animation has played.

## Checklist
- ~~[ ] **I'm using `beta` as my base branch**~~ Hotfix
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~