### PR TITLE
[Bug] Fix field moves always playing their animations

### DIFF
--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -354,8 +354,8 @@ export class MoveEffectPhase extends PokemonPhase {
         move.id as Moves,
         user,
         firstTarget?.getBattlerIndex() ?? BattlerIndex.ATTACKER,
-        // Field moves and some moves used in mystery encounters should be played even on an empty field
-        fieldMove || (globalScene.currentBattle?.mysteryEncounter?.hasBattleAnimationsWithoutTargets ?? false),
+        // Some moves used in mystery encounters should be played even on an empty field
+        globalScene.currentBattle?.mysteryEncounter?.hasBattleAnimationsWithoutTargets ?? false,
       ).play(move.hitsSubstitute(user, firstTarget), () => this.postAnimCallback(user, targets));
 
       return;


### PR DESCRIPTION
## What are the changes the user will see?
Field moves will now no longer forcibly play the animation

## Why am I making these changes?
Fixes a bug introduced by the MEP refactor.
Discord post: https://discord.com/channels/1125469663833370665/1368305137424007239/1368305137424007239

## What are the changes from a developer perspective?
I had misunderstood the `playOnEmptyField` argument of the "play" method responsible for animations. This parameter actually forces an animation to _always_ play. I removed the modifications I did to the play animation to skip this.

## Screenshots/Videos

<details><summary>Properly not displaying field move animation</summary>

https://github.com/user-attachments/assets/58cd3975-95f4-452f-8d45-b7b08b714229
</details>


## How to test the changes?
Load up a save and use a field move with the animations disabled.

## Checklist
- ~~[ ] **I'm using `beta` as my base branch**~~ Hotfix 1.9.4
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~