### PR TITLE
[Bug][UI/UX] Fix fiery fallout message bug

### DIFF
--- a/src/phases/message-phase.ts
+++ b/src/phases/message-phase.ts
@@ -35,20 +35,18 @@ export class MessagePhase extends Phase {
         this.text = this.text.split(pokename[p]).join(repname[p]);
       }
       const pageIndex = this.text.indexOf("$");
-      for (let p = 0; p < globalScene.getPlayerField().length; p++) {
-        this.text = this.text.split(repname[p]).join(pokename[p]);
-      }
       if (pageIndex !== -1) {
+        let page0 = this.text.slice(0, pageIndex);
+        let page1 = this.text.slice(pageIndex + 1);
+        // Pokemon names must be re-inserted _after_ the split, otherwise the index will be wrong
+        for (let p = 0; p < globalScene.getPlayerField().length; p++) {
+          page0 = page0.split(repname[p]).join(pokename[p]);
+          page1 = page1.split(repname[p]).join(pokename[p]);
+        }
         globalScene.unshiftPhase(
-          new MessagePhase(
-            this.text.slice(pageIndex + 1),
-            this.callbackDelay,
-            this.prompt,
-            this.promptDelay,
-            this.speaker,
-          ),
+          new MessagePhase(page1, this.callbackDelay, this.prompt, this.promptDelay, this.speaker),
         );
-        this.text = this.text.slice(0, pageIndex).trim();
+        this.text = page0.trim();
       }
     }
 

--- a/src/phases/message-phase.ts
+++ b/src/phases/message-phase.ts
@@ -47,6 +47,10 @@ export class MessagePhase extends Phase {
           new MessagePhase(page1, this.callbackDelay, this.prompt, this.promptDelay, this.speaker),
         );
         this.text = page0.trim();
+      } else {
+        for (let p = 0; p < globalScene.getPlayerField().length; p++) {
+          this.text = this.text.split(repname[p]).join(pokename[p]);
+        }
       }
     }
 


### PR DESCRIPTION
## What are the changes the user will see?
Messages like those in fiery fallout will no longer display `s{item_fanfare}` improperly.

## Why am I making these changes?
Fixes https://discord.com/channels/1125469663833370665/1357159700130566185/1357159700130566185, a bug that was caused by an oversight in #5537 

## What are the changes from a developer perspective?

The bug was caused by the `#POKEMON` placeholder being inserted before finding the index of the `$` character, and then re-inserting the pokemon _before_ actually splitting the string. This caused issues where the index that the page was supposed to be split at would be different, if the pokemon's actual name was not 9 characters.

To remedy this:

Right after finding the page separator, I create the two pages with the text (page0 and page1), splitting the text as it was done already.
After it is split, _then_ we re-insert the pokemon names. We do this on both pages, as we don't know which page had the pokemon name. The strings are very small, so the impact of doing 2 insertions is minimal.

## Screenshots/Videos

<details><summary>Fixed text replacement</summary>

https://github.com/user-attachments/assets/12f093fd-245f-44e6-a1d6-84f3bb19715c
</details>


## How to test the changes?
I use these overrides (courtesy of @DayKev)
```ts
const overrides = {
  MYSTERY_ENCOUNTER_OVERRIDE: MysteryEncounterType.FIERY_FALLOUT,
  MYSTERY_ENCOUNTER_RATE_OVERRIDE: 256,
  STARTING_WAVE_OVERRIDE: 11,
  STARTER_SPECIES_OVERRIDE: Species.SNEASLER,
  MOVESET_OVERRIDE: [
    Moves.ROCK_SLIDE,
  ],
  STARTING_HELD_ITEMS_OVERRIDE: [
    {name: "WIDE_LENS", "count": 5 },
  ],
  STARTING_LEVEL_OVERRIDE: 100
} satisfies Partial<InstanceType<OverridesType>>;
```
Do the first option to fight the volcaronas.
I just use rock slide and then look at the message that displays. The message should have the normal text and play the item fanfare music track.

## Checklist
- ~~[ ] **I'm using `beta` as my base branch**~~ Hotfix
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~