### PR TITLE
[Localization] Localizable "Cancel" text in Ball selection menu

### DIFF
--- a/src/ui/ball-ui-handler.ts
+++ b/src/ui/ball-ui-handler.ts
@@ -7,6 +7,7 @@ import { addWindow } from "./ui-theme";
 import { Button } from "#enums/buttons";
 import type { CommandPhase } from "#app/phases/command-phase";
 import { globalScene } from "#app/global-scene";
+import i18next from "i18next";
 
 export default class BallUiHandler extends UiHandler {
   private pokeballSelectContainer: Phaser.GameObjects.Container;
@@ -31,7 +32,7 @@ export default class BallUiHandler extends UiHandler {
     for (let pb = 0; pb < Object.keys(globalScene.pokeballCounts).length; pb++) {
       optionsTextContent += `${getPokeballName(pb)}\n`;
     }
-    optionsTextContent += "Cancel";
+    optionsTextContent += i18next.t("pokeball:cancel");
     const optionsText = addTextObject(0, 0, optionsTextContent, TextStyle.WINDOW, { align: "right", maxLines: 6 });
     const optionsTextWidth = optionsText.displayWidth;
     this.pokeballSelectContainer = globalScene.add.container(


### PR DESCRIPTION
## What are the changes the user will see?
"Cancel" button in Poké Ball selection menu is now localizable

## Why am I making these changes?
To have it translatable

## What are the changes from a developer perspective?
None

## Screenshots/Videos
BEFORE (French)
![image](https://github.com/user-attachments/assets/cda57c98-57f9-4866-8a7f-0a5c62f24dd9)

AFTER (French)
![image](https://github.com/user-attachments/assets/103b3f18-ea1b-42c7-8c39-47194a1f3386)

## How to test the changes?
Play the game in a language where it is translated (ideally in French, to be sure) and open the Ball menu during a battle

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [X] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [X] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [X] If so, please leave a link to it here: https://github.com/pagefaultgames/pokerogue-locales/pull/167
- [X] Has the translation team been contacted for proofreading/translation?