### PR TITLE
[UI/UX] [Localization] Text ratio adjustment for es-MX Egg Gatcha

### DIFF
--- a/src/ui/egg-gacha-ui-handler.ts
+++ b/src/ui/egg-gacha-ui-handler.ts
@@ -108,7 +108,7 @@ export default class EggGachaUiHandler extends MessageUiHandler {
       let pokemonIconX = -20;
       let pokemonIconY = 6;
 
-      if (["de", "es-ES", "fr", "ko", "pt-BR"].includes(currentLanguage)) {
+      if (["de", "es-ES", "es-MX", "fr", "ko", "pt-BR"].includes(currentLanguage)) {
         gachaTextStyle = TextStyle.SMALLER_WINDOW_ALT;
         gachaX = 2;
         gachaY = 2;
@@ -116,7 +116,7 @@ export default class EggGachaUiHandler extends MessageUiHandler {
 
       let legendaryLabelX = gachaX;
       let legendaryLabelY = gachaY;
-      if (["de", "es-ES"].includes(currentLanguage)) {
+      if (["de", "es-ES", "es-MX"].includes(currentLanguage)) {
         pokemonIconX = -25;
         pokemonIconY = 10;
         legendaryLabelX = -6;


### PR DESCRIPTION
## What are the changes the user will see?
Latam Spanish Egg Gatcha texts adjusted

## Why am I making these changes?
To have these texts properly sized

## What are the changes from a developer perspective?
None

## Screenshots/Videos
BEFORE
![image](https://github.com/user-attachments/assets/cad2db30-f9d4-44b1-8ec5-ebbacce03bf4)
![image](https://github.com/user-attachments/assets/a7ce9fb6-dbe5-4385-9c46-ccc7651705ab)
![image](https://github.com/user-attachments/assets/3548ae15-cd1b-463d-af8a-267c1e4d9f2f)


AFTER
![image](https://github.com/user-attachments/assets/477079f1-4240-4dce-b71b-ad46f6235b9f)
![image](https://github.com/user-attachments/assets/9dc608d6-d7e2-4cd1-80fd-7b9a42490bdb)
![image](https://github.com/user-attachments/assets/dfff3c10-0c36-498f-b640-9e6be4c06069)

## How to test the changes?
Play the game in LATAM Spanish

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [X] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?