### PR TITLE
[UI/UX] [Localization] Update Korean starterInfoText

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -145,8 +145,10 @@ const languageSettings: { [key: string]: LanguageSetting } = {
     starterInfoXPos: 33,
   },
   ko: {
-    starterInfoTextSize: "52px",
+    starterInfoTextSize: "60px",
     instructionTextSize: "38px",
+    starterInfoYOffset: -0.5,
+    starterInfoXPos: 30,
   },
   ja: {
     starterInfoTextSize: "51px",


### PR DESCRIPTION
## What are the changes the user will see?
Korean players will have a bigger starter information text

## Why am I making these changes?
Text optimization for a better readability and an optimal use of the available text area in Korean

## What are the changes from a developer perspective?
None

## Screenshots/Videos
BEFORE
![image](https://github.com/user-attachments/assets/89a4b82f-7683-42f1-b771-b7de9d785e8f)

AFTER
![image](https://github.com/user-attachments/assets/c3fb00e3-fac7-4ef8-828f-e67bc782afcc)

## How to test the changes?
Go to the starter select screen while playing in Korean

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [X] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?