### PR TITLE
[Bug] Libero now triggers if move is stopped by Psychic Terrain

### DIFF
--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -48,7 +48,7 @@ import { MoveTarget } from "#enums/MoveTarget";
 import { MoveCategory } from "#enums/MoveCategory";
 import { SpeciesFormChangePostMoveTrigger } from "#app/data/pokemon-forms";
 import { PokemonType } from "#enums/pokemon-type";
-import { DamageResult, PokemonMove, type TurnMove } from "#app/field/pokemon";
+import { type DamageResult, PokemonMove, type TurnMove } from "#app/field/pokemon";
 import type Pokemon from "#app/field/pokemon";
 import { HitResult, MoveResult } from "#app/field/pokemon";
 import { getPokemonNameWithAffix } from "#app/messages";
@@ -72,7 +72,7 @@ import { ShowAbilityPhase } from "./show-ability-phase";
 import { MovePhase } from "./move-phase";
 import { MoveEndPhase } from "./move-end-phase";
 import { HideAbilityPhase } from "#app/phases/hide-ability-phase";
-import { TypeDamageMultiplier } from "#app/data/type";
+import type { TypeDamageMultiplier } from "#app/data/type";
 import { HitCheckResult } from "#enums/hit-check-result";
 import type Move from "#app/data/moves/move";
 import { isFieldTargeted } from "#app/data/moves/move-utils";
@@ -547,6 +547,12 @@ export class MoveEffectPhase extends PokemonPhase {
       return [HitCheckResult.MISS, 0];
     }
 
+    // Protection from Psychic Terrain applies before Magic Bounce/Coat and Protect/etc
+    if (globalScene.arena.isMoveTerrainCancelled(user, this.targets, move)) {
+      // getTerrainBlockMessage(targets[0], globalScene.arena.getTerrainType());
+      return [HitCheckResult.NO_EFFECT, 0];
+    }
+
     if (!fieldTargeted && this.protectedCheck(user, target)) {
       return [HitCheckResult.PROTECTED, 0];
     }
@@ -809,7 +815,7 @@ export class MoveEffectPhase extends PokemonPhase {
      */
     applyMoveAttrs(StatChangeBeforeDmgCalcAttr, user, target, this.move);
 
-    const { result: result, damage: dmg } = target.getAttackDamage({
+    const { result, damage: dmg } = target.getAttackDamage({
       source: user,
       move: this.move,
       ignoreAbility: false,

--- a/test/abilities/libero.test.ts
+++ b/test/abilities/libero.test.ts
@@ -11,8 +11,9 @@ import { Species } from "#enums/species";
 import { WeatherType } from "#enums/weather-type";
 import GameManager from "#test/testUtils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, test } from "vitest";
 
+// TODO: use `describe.each` to combine the Libero and Protean tests
 describe("Abilities - Libero", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
@@ -289,6 +290,18 @@ describe("Abilities - Libero", () => {
 
     testPokemonTypeMatchesDefaultMoveType(leadPokemon, Moves.CURSE);
     expect(leadPokemon.getTag(BattlerTagType.CURSED)).not.toBe(undefined);
+  });
+
+  it("activates even if the move is stopped by Psychic Terrain", async () => {
+    game.override.enemyAbility(Abilities.PSYCHIC_SURGE).moveset(Moves.QUICK_ATTACK);
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    const feebas = game.scene.getPlayerPokemon()!;
+
+    game.move.select(Moves.QUICK_ATTACK);
+    await game.phaseInterceptor.to("TurnEndPhase");
+
+    testPokemonTypeMatchesDefaultMoveType(feebas, Moves.QUICK_ATTACK);
   });
 });
 

--- a/test/moves/instruct.test.ts
+++ b/test/moves/instruct.test.ts
@@ -200,6 +200,7 @@ describe("Moves - Instruct", () => {
     expect(karp1.isFainted()).toBe(true);
     expect(karp2.isFainted()).toBe(true);
   });
+
   it("should allow for dancer copying of instructed dance move", async () => {
     game.override.battleStyle("double").enemyMoveset([Moves.INSTRUCT, Moves.SPLASH]).enemyLevel(1000);
     await game.classicMode.startBattle([Species.ORICORIO, Species.VOLCARONA]);
@@ -377,7 +378,7 @@ describe("Moves - Instruct", () => {
       .enemyMoveset([Moves.SPLASH, Moves.PSYCHIC_TERRAIN]);
     await game.classicMode.startBattle([Species.BANETTE, Species.KLEFKI]);
 
-    game.move.select(Moves.QUICK_ATTACK, BattlerIndex.PLAYER, BattlerIndex.ENEMY); // succeeds due to terrain no
+    game.move.select(Moves.QUICK_ATTACK, BattlerIndex.PLAYER, BattlerIndex.ENEMY);
     game.move.select(Moves.SPLASH, BattlerIndex.PLAYER_2);
     await game.forceEnemyMove(Moves.SPLASH);
     await game.forceEnemyMove(Moves.PSYCHIC_TERRAIN);
@@ -388,10 +389,9 @@ describe("Moves - Instruct", () => {
     await game.setTurnOrder([BattlerIndex.PLAYER_2, BattlerIndex.PLAYER, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
     await game.phaseInterceptor.to("TurnEndPhase", false);
 
-    // quick attack failed when instructed
     const banette = game.scene.getPlayerPokemon()!;
     expect(banette.getLastXMoves(-1)[1].move).toBe(Moves.QUICK_ATTACK);
-    expect(banette.getLastXMoves(-1)[1].result).toBe(MoveResult.FAIL);
+    expect(banette.getLastXMoves(-1)[1].result).toBe(MoveResult.MISS);
   });
 
   it("should still work w/ prankster in psychic terrain", async () => {


### PR DESCRIPTION
## What are the changes the user will see?
Libero and Protean will now activate if the user's move is blocked by Psychic Terrain.

## Why am I making these changes?
Fixes #5849

## What are the changes from a developer perspective?
Handling of move failure due to Psychic Terrain moved from Move Phase to Move Effect Phase.

## How to test the changes?
`npm run test:silent libero`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?