### PR TITLE
[Misc] Move allMoves to data-lists.ts

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -51,7 +51,7 @@ import { initGameSpeed } from "#app/system/game-speed";
 import { Arena, ArenaBase } from "#app/field/arena";
 import { GameData } from "#app/system/game-data";
 import { addTextObject, getTextColor, TextStyle } from "#app/ui/text";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "./data/data-lists";
 import { MusicPreference } from "#app/system/settings/settings";
 import {
   getDefaultModifierTypeForTier,

--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -9,7 +9,6 @@ import {
   FlinchAttr,
   OneHitKOAttr,
   HitHealAttr,
-  allMoves,
   StatusMove,
   SelfStatusMove,
   VariablePowerAttr,
@@ -21,6 +20,7 @@ import {
   NeutralDamageAgainstFlyingTypeMultiplierAttr,
   FixedDamageAttr,
 } from "#app/data/moves/move";
+import { allMoves } from "../data-lists";
 import { ArenaTagSide } from "#app/data/arena-tag";
 import { BerryModifier, HitHealModifier, PokemonHeldItemModifier } from "#app/modifier/modifier";
 import { TerrainType } from "#app/data/terrain";

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -2,7 +2,7 @@ import { globalScene } from "#app/global-scene";
 import type { Arena } from "#app/field/arena";
 import { PokemonType } from "#enums/pokemon-type";
 import { BooleanHolder, NumberHolder, toDmgValue } from "#app/utils/common";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "./data-lists";
 import { MoveTarget } from "#enums/MoveTarget";
 import { MoveCategory } from "#enums/MoveCategory";
 import { getPokemonNameWithAffix } from "#app/messages";

--- a/src/data/balance/egg-moves.ts
+++ b/src/data/balance/egg-moves.ts
@@ -1,4 +1,4 @@
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "../data-lists";
 import { getEnumKeys, getEnumValues } from "#app/utils/common";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";

--- a/src/data/battle-anims.ts
+++ b/src/data/battle-anims.ts
@@ -1,5 +1,6 @@
 import { globalScene } from "#app/global-scene";
-import { AttackMove, BeakBlastHeaderAttr, DelayedAttackAttr, SelfStatusMove, allMoves } from "./moves/move";
+import { AttackMove, BeakBlastHeaderAttr, DelayedAttackAttr, SelfStatusMove } from "./moves/move";
+import { allMoves } from "./data-lists";
 import { MoveFlags } from "#enums/MoveFlags";
 import type Pokemon from "../field/pokemon";
 import { type nil, getFrameMs, getEnumKeys, getEnumValues, animationFileName } from "../utils/common";

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -12,12 +12,12 @@ import { allAbilities } from "./data-lists";
 import { ChargeAnim, CommonAnim, CommonBattleAnim, MoveChargeAnim } from "#app/data/battle-anims";
 import type Move from "#app/data/moves/move";
 import {
-  allMoves,
   applyMoveAttrs,
   ConsecutiveUseDoublePowerAttr,
   HealOnAllyAttr,
   StatusCategoryOnAllyAttr,
 } from "#app/data/moves/move";
+import { allMoves } from "./data-lists";
 import { MoveFlags } from "#enums/MoveFlags";
 import { MoveCategory } from "#enums/MoveCategory";
 import { SpeciesFormChangeAbilityTrigger } from "#app/data/pokemon-forms";

--- a/src/data/data-lists.ts
+++ b/src/data/data-lists.ts
@@ -1,3 +1,5 @@
 import type { Ability } from "./abilities/ability-class";
+import type Move from "./moves/move";
 
 export const allAbilities: Ability[] = [];
+export const allMoves: Move[] = [];

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -66,7 +66,7 @@ import {
   VariableMovePowerAbAttr,
   WonderSkinAbAttr,
 } from "../abilities/ability";
-import { allAbilities } from "../data-lists";
+import { allAbilities, allMoves } from "../data-lists";
 import {
   AttackTypeBoosterModifier,
   BerryModifier,
@@ -8261,14 +8261,11 @@ export function getMoveTargets(user: Pokemon, move: Moves, replaceTarget?: MoveT
   return { targets: set.filter(p => p?.isActive(true)).map(p => p.getBattlerIndex()).filter(t => t !== undefined), multiple };
 }
 
-export const allMoves: Move[] = [
-  new SelfStatusMove(Moves.NONE, PokemonType.NORMAL, MoveCategory.STATUS, -1, -1, 0, 1),
-];
-
 export const selfStatLowerMoves: Moves[] = [];
 
 export function initMoves() {
   allMoves.push(
+    new SelfStatusMove(Moves.NONE, PokemonType.NORMAL, MoveCategory.STATUS, -1, -1, 0, 1),
     new AttackMove(Moves.POUND, PokemonType.NORMAL, MoveCategory.PHYSICAL, 40, 100, 35, -1, 0, 1),
     new AttackMove(Moves.KARATE_CHOP, PokemonType.FIGHTING, MoveCategory.PHYSICAL, 50, 100, 25, -1, 0, 1)
       .attr(HighCritAttr),

--- a/src/data/mystery-encounters/encounters/bug-type-superfan-encounter.ts
+++ b/src/data/mystery-encounters/encounters/bug-type-superfan-encounter.ts
@@ -50,7 +50,7 @@ import {
 } from "#app/modifier/modifier";
 import i18next from "i18next";
 import MoveInfoOverlay from "#app/ui/move-info-overlay";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { ModifierTier } from "#app/modifier/modifier-tier";
 import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants";
 import { getSpriteKeysFromSpecies } from "#app/data/mystery-encounters/utils/encounter-pokemon-utils";
@@ -144,20 +144,14 @@ const POOL_3_POKEMON: { species: Species; formIndex?: number }[] = [
 
 const POOL_4_POKEMON = [Species.GENESECT, Species.SLITHER_WING, Species.BUZZWOLE, Species.PHEROMOSA];
 
-const PHYSICAL_TUTOR_MOVES = [
-  Moves.MEGAHORN,
-  Moves.ATTACK_ORDER,
-  Moves.BUG_BITE,
-  Moves.FIRST_IMPRESSION,
-  Moves.LUNGE
-];
+const PHYSICAL_TUTOR_MOVES = [Moves.MEGAHORN, Moves.ATTACK_ORDER, Moves.BUG_BITE, Moves.FIRST_IMPRESSION, Moves.LUNGE];
 
 const SPECIAL_TUTOR_MOVES = [
   Moves.SILVER_WIND,
   Moves.SIGNAL_BEAM,
   Moves.BUG_BUZZ,
   Moves.POLLEN_PUFF,
-  Moves.STRUGGLE_BUG
+  Moves.STRUGGLE_BUG,
 ];
 
 const STATUS_TUTOR_MOVES = [
@@ -165,16 +159,10 @@ const STATUS_TUTOR_MOVES = [
   Moves.DEFEND_ORDER,
   Moves.RAGE_POWDER,
   Moves.STICKY_WEB,
-  Moves.SILK_TRAP
+  Moves.SILK_TRAP,
 ];
 
-const MISC_TUTOR_MOVES = [
-  Moves.LEECH_LIFE,
-  Moves.U_TURN,
-  Moves.HEAL_ORDER,
-  Moves.QUIVER_DANCE,
-  Moves.INFESTATION,
-];
+const MISC_TUTOR_MOVES = [Moves.LEECH_LIFE, Moves.U_TURN, Moves.HEAL_ORDER, Moves.QUIVER_DANCE, Moves.INFESTATION];
 
 /**
  * Wave breakpoints that determine how strong to make the Bug-Type Superfan's team

--- a/src/data/pokemon-forms.ts
+++ b/src/data/pokemon-forms.ts
@@ -1,7 +1,7 @@
 import { PokemonFormChangeItemModifier } from "../modifier/modifier";
 import type Pokemon from "../field/pokemon";
 import { StatusEffect } from "#enums/status-effect";
-import { allMoves } from "./moves/move";
+import { allMoves } from "./data-lists";
 import { MoveCategory } from "#enums/MoveCategory";
 import type { Constructor, nil } from "#app/utils/common";
 import { Abilities } from "#enums/abilities";

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -16,7 +16,6 @@ import {
   applyMoveAttrs,
   FixedDamageAttr,
   VariableAtkAttr,
-  allMoves,
   TypelessAttr,
   CritOnlyAttr,
   getMoveTargets,
@@ -41,6 +40,7 @@ import {
   VariableMoveTypeChartAttr,
   HpSplitAttr,
 } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { MoveTarget } from "#enums/MoveTarget";
 import { MoveCategory } from "#enums/MoveCategory";
 import type { PokemonSpeciesForm } from "#app/data/pokemon-species";

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -2,7 +2,8 @@ import { globalScene } from "#app/global-scene";
 import { EvolutionItem, pokemonEvolutions } from "#app/data/balance/pokemon-evolutions";
 import { tmPoolTiers, tmSpecies } from "#app/data/balance/tms";
 import { getBerryEffectDescription, getBerryName } from "#app/data/berry";
-import { allMoves, AttackMove } from "#app/data/moves/move";
+import { AttackMove } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { getNatureName, getNatureStatMultiplier } from "#app/data/nature";
 import { getPokeballCatchMultiplier, getPokeballName, MAX_PER_TYPE_POKEBALLS } from "#app/data/pokeball";
 import {

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -1,7 +1,7 @@
 import { FusionSpeciesFormEvolution, pokemonEvolutions } from "#app/data/balance/pokemon-evolutions";
 import { getBerryEffectFunc, getBerryPredicate } from "#app/data/berry";
 import { getLevelTotalExp } from "#app/data/exp";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { MAX_PER_TYPE_POKEBALLS } from "#app/data/pokeball";
 import { type FormChangeItem, SpeciesFormChangeItemTrigger } from "#app/data/pokemon-forms";
 import { getStatusEffectHealText } from "#app/data/status-effect";

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -11,7 +11,8 @@ import {
 } from "#app/data/abilities/ability";
 import { BattlerTagLapseType } from "#app/data/battler-tags";
 import { battleSpecDialogue } from "#app/data/dialogue";
-import { allMoves, PostVictoryStatStageChangeAttr } from "#app/data/moves/move";
+import { PostVictoryStatStageChangeAttr } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { SpeciesFormChangeActiveTrigger } from "#app/data/pokemon-forms";
 import { BattleSpec } from "#app/enums/battle-spec";
 import { StatusEffect } from "#app/enums/status-effect";

--- a/src/phases/learn-move-phase.ts
+++ b/src/phases/learn-move-phase.ts
@@ -1,7 +1,7 @@
 import { globalScene } from "#app/global-scene";
 import { initMoveAnim, loadMoveAnimAssets } from "#app/data/battle-anims";
 import type Move from "#app/data/moves/move";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { SpeciesFormChangeMoveLearnedTrigger } from "#app/data/pokemon-forms";
 import { Moves } from "#enums/moves";
 import { getPokemonNameWithAffix } from "#app/messages";

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -16,7 +16,6 @@ import { CommonAnim } from "#app/data/battle-anims";
 import { BattlerTagLapseType, CenterOfAttentionTag } from "#app/data/battler-tags";
 import {
   AddArenaTrapTagAttr,
-  allMoves,
   applyMoveAttrs,
   BypassRedirectAttr,
   BypassSleepAttr,
@@ -27,6 +26,7 @@ import {
   PreMoveMessageAttr,
   PreUseInterruptAttr,
 } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { MoveFlags } from "#enums/MoveFlags";
 import { SpeciesFormChangePreMoveTrigger } from "#app/data/pokemon-forms";
 import { getStatusEffectActivationText, getStatusEffectHealText } from "#app/data/status-effect";

--- a/src/phases/select-target-phase.ts
+++ b/src/phases/select-target-phase.ts
@@ -5,7 +5,7 @@ import { UiMode } from "#enums/ui-mode";
 import { CommandPhase } from "./command-phase";
 import { PokemonPhase } from "./pokemon-phase";
 import i18next from "#app/plugins/i18n";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 
 export class SelectTargetPhase extends PokemonPhase {
   // biome-ignore lint/complexity/noUselessConstructor: This makes `fieldIndex` required

--- a/src/phases/switch-summon-phase.ts
+++ b/src/phases/switch-summon-phase.ts
@@ -6,7 +6,8 @@ import {
   PreSummonAbAttr,
   PreSwitchOutAbAttr,
 } from "#app/data/abilities/ability";
-import { allMoves, ForceSwitchOutAttr } from "#app/data/moves/move";
+import { ForceSwitchOutAttr } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { getPokeballTintColor } from "#app/data/pokeball";
 import { SpeciesFormChangeActiveTrigger } from "#app/data/pokemon-forms";
 import { TrainerSlot } from "#enums/trainer-slot";

--- a/src/phases/turn-start-phase.ts
+++ b/src/phases/turn-start-phase.ts
@@ -1,5 +1,6 @@
 import { applyAbAttrs, BypassSpeedChanceAbAttr, PreventBypassSpeedChanceAbAttr } from "#app/data/abilities/ability";
-import { allMoves, MoveHeaderAttr } from "#app/data/moves/move";
+import { MoveHeaderAttr } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#app/enums/abilities";
 import { Stat } from "#app/enums/stat";
 import type Pokemon from "#app/field/pokemon";

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -30,7 +30,7 @@ import { Nature } from "#enums/nature";
 import { GameStats } from "#app/system/game-stats";
 import { Tutorial } from "#app/tutorial";
 import { speciesEggMoves } from "#app/data/balance/egg-moves";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { TrainerVariant } from "#app/field/trainer";
 import type { Variant } from "#app/sprites/variant";
 import { setSettingGamepad, SettingGamepad, settingGamepadDefaults } from "#app/system/settings/settings-gamepad";

--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -9,7 +9,7 @@ import { LockModifierTiersModifier, PokemonHeldItemModifier, HealShopCostModifie
 import { handleTutorial, Tutorial } from "../tutorial";
 import { Button } from "#enums/buttons";
 import MoveInfoOverlay from "./move-info-overlay";
-import { allMoves } from "../data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { formatMoney, NumberHolder } from "#app/utils/common";
 import Overrides from "#app/overrides";
 import i18next from "i18next";

--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -11,7 +11,8 @@ import {
   PokemonHeldItemModifier,
   SwitchEffectTransferModifier,
 } from "#app/modifier/modifier";
-import { allMoves, ForceSwitchOutAttr } from "#app/data/moves/move";
+import { ForceSwitchOutAttr } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Gender, getGenderColor, getGenderSymbol } from "#app/data/gender";
 import { StatusEffect } from "#enums/status-effect";
 import PokemonIconAnimHandler, { PokemonIconAnimMode } from "#app/ui/pokemon-icon-anim-handler";

--- a/src/ui/pokedex-page-ui-handler.ts
+++ b/src/ui/pokedex-page-ui-handler.ts
@@ -9,7 +9,7 @@ import { allAbilities } from "#app/data/data-lists";
 import { speciesEggMoves } from "#app/data/balance/egg-moves";
 import { GrowthRate, getGrowthRateColor } from "#app/data/exp";
 import { Gender, getGenderColor, getGenderSymbol } from "#app/data/gender";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { getNatureName } from "#app/data/nature";
 import type { SpeciesFormChange } from "#app/data/pokemon-forms";
 import { pokemonFormChanges } from "#app/data/pokemon-forms";

--- a/src/ui/pokedex-scan-ui-handler.ts
+++ b/src/ui/pokedex-scan-ui-handler.ts
@@ -7,7 +7,7 @@ import { isNullOrUndefined } from "#app/utils/common";
 import { UiMode } from "#enums/ui-mode";
 import { FilterTextRow } from "./filter-text";
 import { allAbilities } from "#app/data/data-lists";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { allSpecies } from "#app/data/pokemon-species";
 import i18next from "i18next";
 

--- a/src/ui/pokedex-ui-handler.ts
+++ b/src/ui/pokedex-ui-handler.ts
@@ -37,7 +37,7 @@ import { addWindow } from "./ui-theme";
 import type { OptionSelectConfig } from "./abstact-option-select-ui-handler";
 import { FilterText, FilterTextRow } from "./filter-text";
 import { allAbilities } from "#app/data/data-lists";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { speciesTmMoves } from "#app/data/balance/tms";
 import { pokemonStarters } from "#app/data/balance/pokemon-evolutions";
 import { Biome } from "#enums/biome";

--- a/src/ui/pokemon-hatch-info-container.ts
+++ b/src/ui/pokemon-hatch-info-container.ts
@@ -4,7 +4,7 @@ import { PokemonType } from "#enums/pokemon-type";
 import { rgbHexToRgba, padInt } from "#app/utils/common";
 import { TextStyle, addTextObject } from "#app/ui/text";
 import { speciesEggMoves } from "#app/data/balance/egg-moves";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Species } from "#enums/species";
 import { getEggTierForSpecies } from "#app/data/egg";
 import { starterColors } from "#app/global-vars/starter-colors";

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -13,7 +13,7 @@ import { allAbilities } from "#app/data/data-lists";
 import { speciesEggMoves } from "#app/data/balance/egg-moves";
 import { GrowthRate, getGrowthRateColor } from "#app/data/exp";
 import { Gender, getGenderColor, getGenderSymbol } from "#app/data/gender";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { getNatureName } from "#app/data/nature";
 import { pokemonFormChanges } from "#app/data/pokemon-forms";
 import type { LevelMoves } from "#app/data/balance/pokemon-level-moves";

--- a/test/abilities/aura_break.test.ts
+++ b/test/abilities/aura_break.test.ts
@@ -1,4 +1,4 @@
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";

--- a/test/abilities/battery.test.ts
+++ b/test/abilities/battery.test.ts
@@ -1,4 +1,4 @@
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#app/enums/abilities";
 import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { TurnEndPhase } from "#app/phases/turn-end-phase";

--- a/test/abilities/battle_bond.test.ts
+++ b/test/abilities/battle_bond.test.ts
@@ -1,4 +1,5 @@
-import { allMoves, MultiHitAttr } from "#app/data/moves/move";
+import { MultiHitAttr } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { MultiHitType } from "#enums/MultiHitType";
 import { Status } from "#app/data/status-effect";
 import { Abilities } from "#enums/abilities";

--- a/test/abilities/flower_veil.test.ts
+++ b/test/abilities/flower_veil.test.ts
@@ -7,7 +7,7 @@ import { StatusEffect } from "#enums/status-effect";
 import GameManager from "#test/testUtils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { allAbilities } from "#app/data/data-lists";
 

--- a/test/abilities/friend_guard.test.ts
+++ b/test/abilities/friend_guard.test.ts
@@ -6,7 +6,7 @@ import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { BattlerIndex } from "#app/battle";
 import { allAbilities } from "#app/data/data-lists";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { MoveCategory } from "#enums/MoveCategory";
 
 describe("Moves - Friend Guard", () => {

--- a/test/abilities/hustle.test.ts
+++ b/test/abilities/hustle.test.ts
@@ -1,4 +1,4 @@
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#app/enums/abilities";
 import { Stat } from "#app/enums/stat";
 import { Moves } from "#enums/moves";

--- a/test/abilities/infiltrator.test.ts
+++ b/test/abilities/infiltrator.test.ts
@@ -1,5 +1,5 @@
 import { ArenaTagSide } from "#app/data/arena-tag";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { Stat } from "#enums/stat";

--- a/test/abilities/libero.test.ts
+++ b/test/abilities/libero.test.ts
@@ -1,4 +1,4 @@
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { PokemonType } from "#enums/pokemon-type";
 import { Weather } from "#app/data/weather";
 import type { PlayerPokemon } from "#app/field/pokemon";

--- a/test/abilities/magic_bounce.test.ts
+++ b/test/abilities/magic_bounce.test.ts
@@ -1,7 +1,7 @@
 import { BattlerIndex } from "#app/battle";
 import { allAbilities } from "#app/data/data-lists";
 import { ArenaTagSide } from "#app/data/arena-tag";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { ArenaTagType } from "#app/enums/arena-tag-type";
 import { BattlerTagType } from "#app/enums/battler-tag-type";
 import { Stat } from "#app/enums/stat";

--- a/test/abilities/normal-move-type-change.test.ts
+++ b/test/abilities/normal-move-type-change.test.ts
@@ -1,5 +1,5 @@
 import { BattlerIndex } from "#app/battle";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { PokemonType } from "#enums/pokemon-type";
 import { Abilities } from "#app/enums/abilities";
 import { Moves } from "#app/enums/moves";

--- a/test/abilities/normalize.test.ts
+++ b/test/abilities/normalize.test.ts
@@ -1,5 +1,5 @@
 import { TYPE_BOOST_ITEM_BOOST_PERCENT } from "#app/constants";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { toDmgValue } from "#app/utils/common";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";

--- a/test/abilities/power_spot.test.ts
+++ b/test/abilities/power_spot.test.ts
@@ -1,4 +1,4 @@
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#app/enums/abilities";
 import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { TurnEndPhase } from "#app/phases/turn-end-phase";

--- a/test/abilities/protean.test.ts
+++ b/test/abilities/protean.test.ts
@@ -1,4 +1,4 @@
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { PokemonType } from "#enums/pokemon-type";
 import { Weather } from "#app/data/weather";
 import type { PlayerPokemon } from "#app/field/pokemon";

--- a/test/abilities/sap_sipper.test.ts
+++ b/test/abilities/sap_sipper.test.ts
@@ -9,7 +9,8 @@ import { Species } from "#enums/species";
 import GameManager from "#test/testUtils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { allMoves, RandomMoveAttr } from "#app/data/moves/move";
+import { RandomMoveAttr } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 
 // See also: TypeImmunityAbAttr
 describe("Abilities - Sap Sipper", () => {

--- a/test/abilities/serene_grace.test.ts
+++ b/test/abilities/serene_grace.test.ts
@@ -4,7 +4,7 @@ import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
 import GameManager from "#test/testUtils/gameManager";
 import Phaser from "phaser";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { FlinchAttr } from "#app/data/moves/move";
 

--- a/test/abilities/sheer_force.test.ts
+++ b/test/abilities/sheer_force.test.ts
@@ -7,7 +7,8 @@ import { Stat } from "#enums/stat";
 import GameManager from "#test/testUtils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { allMoves, FlinchAttr } from "#app/data/moves/move";
+import { FlinchAttr } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 
 describe("Abilities - Sheer Force", () => {
   let phaserGame: Phaser.Game;

--- a/test/abilities/steely_spirit.test.ts
+++ b/test/abilities/steely_spirit.test.ts
@@ -1,5 +1,5 @@
 import { allAbilities } from "#app/data/data-lists";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#app/enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";

--- a/test/abilities/supreme_overlord.test.ts
+++ b/test/abilities/supreme_overlord.test.ts
@@ -7,7 +7,7 @@ import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import GameManager from "#test/testUtils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 
 describe("Abilities - Supreme Overlord", () => {
   let phaserGame: Phaser.Game;

--- a/test/abilities/unburden.test.ts
+++ b/test/abilities/unburden.test.ts
@@ -1,6 +1,7 @@
 import { BattlerIndex } from "#app/battle";
 import { PostItemLostAbAttr } from "#app/data/abilities/ability";
-import { allMoves, StealHeldItemChanceAttr } from "#app/data/moves/move";
+import { StealHeldItemChanceAttr } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import type Pokemon from "#app/field/pokemon";
 import type { ContactHeldItemTransferChanceModifier } from "#app/modifier/modifier";
 import { Abilities } from "#enums/abilities";

--- a/test/abilities/wimp_out.test.ts
+++ b/test/abilities/wimp_out.test.ts
@@ -1,6 +1,6 @@
 import { BattlerIndex } from "#app/battle";
 import { ArenaTagSide } from "#app/data/arena-tag";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import GameManager from "#test/testUtils/gameManager";
 import { toDmgValue } from "#app/utils/common";
 import { Abilities } from "#enums/abilities";

--- a/test/abilities/wonder_skin.test.ts
+++ b/test/abilities/wonder_skin.test.ts
@@ -1,4 +1,4 @@
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";

--- a/test/arena/arena_gravity.test.ts
+++ b/test/arena/arena_gravity.test.ts
@@ -1,5 +1,5 @@
 import { BattlerIndex } from "#app/battle";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#enums/abilities";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { BattlerTagType } from "#enums/battler-tag-type";

--- a/test/arena/grassy_terrain.test.ts
+++ b/test/arena/grassy_terrain.test.ts
@@ -1,4 +1,4 @@
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";

--- a/test/arena/weather_fog.test.ts
+++ b/test/arena/weather_fog.test.ts
@@ -1,4 +1,4 @@
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#app/enums/abilities";
 import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { Moves } from "#enums/moves";

--- a/test/arena/weather_strong_winds.test.ts
+++ b/test/arena/weather_strong_winds.test.ts
@@ -1,4 +1,4 @@
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { StatusEffect } from "#app/enums/status-effect";
 import { TurnStartPhase } from "#app/phases/turn-start-phase";
 import { Abilities } from "#enums/abilities";

--- a/test/battle/damage_calculation.test.ts
+++ b/test/battle/damage_calculation.test.ts
@@ -1,4 +1,4 @@
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import type { EnemyPersistentModifier } from "#app/modifier/modifier";
 import { modifierTypes } from "#app/modifier/modifier-type";
 import { Abilities } from "#enums/abilities";

--- a/test/battlerTags/substitute.test.ts
+++ b/test/battlerTags/substitute.test.ts
@@ -7,7 +7,7 @@ import { BattlerTagLapseType, BindTag, SubstituteTag } from "#app/data/battler-t
 import { Moves } from "#app/enums/moves";
 import { PokemonAnimType } from "#app/enums/pokemon-anim-type";
 import * as messages from "#app/messages";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import type { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import GameManager from "#test/testUtils/gameManager";
 

--- a/test/enemy_command.test.ts
+++ b/test/enemy_command.test.ts
@@ -1,5 +1,5 @@
 import type BattleScene from "#app/battle-scene";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { MoveCategory } from "#enums/MoveCategory";
 import { Abilities } from "#app/enums/abilities";
 import { Moves } from "#app/enums/moves";

--- a/test/items/reviver_seed.test.ts
+++ b/test/items/reviver_seed.test.ts
@@ -1,5 +1,5 @@
 import { BattlerIndex } from "#app/battle";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { BattlerTagType } from "#app/enums/battler-tag-type";
 import type { PokemonInstantReviveModifier } from "#app/modifier/modifier";
 import { Abilities } from "#enums/abilities";

--- a/test/moves/astonish.test.ts
+++ b/test/moves/astonish.test.ts
@@ -1,4 +1,4 @@
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { BattlerTagType } from "#app/enums/battler-tag-type";
 import { BerryPhase } from "#app/phases/berry-phase";
 import { CommandPhase } from "#app/phases/command-phase";

--- a/test/moves/aurora_veil.test.ts
+++ b/test/moves/aurora_veil.test.ts
@@ -1,7 +1,8 @@
 import type BattleScene from "#app/battle-scene";
 import { ArenaTagSide } from "#app/data/arena-tag";
 import type Move from "#app/data/moves/move";
-import { allMoves, CritOnlyAttr } from "#app/data/moves/move";
+import { CritOnlyAttr } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { ArenaTagType } from "#app/enums/arena-tag-type";
 import type Pokemon from "#app/field/pokemon";
 import { TurnEndPhase } from "#app/phases/turn-end-phase";

--- a/test/moves/burning_jealousy.test.ts
+++ b/test/moves/burning_jealousy.test.ts
@@ -1,5 +1,5 @@
 import { BattlerIndex } from "#app/battle";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#app/enums/abilities";
 import { StatusEffect } from "#app/enums/status-effect";
 import { Moves } from "#enums/moves";

--- a/test/moves/ceaseless_edge.test.ts
+++ b/test/moves/ceaseless_edge.test.ts
@@ -1,5 +1,5 @@
 import { ArenaTagSide, ArenaTrapTag } from "#app/data/arena-tag";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#app/enums/abilities";
 import { ArenaTagType } from "#app/enums/arena-tag-type";
 import { MoveEffectPhase } from "#app/phases/move-effect-phase";

--- a/test/moves/copycat.test.ts
+++ b/test/moves/copycat.test.ts
@@ -1,5 +1,6 @@
 import { BattlerIndex } from "#app/battle";
-import { allMoves, RandomMoveAttr } from "#app/data/moves/move";
+import { RandomMoveAttr } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Stat } from "#app/enums/stat";
 import { MoveResult } from "#app/field/pokemon";
 import { Abilities } from "#enums/abilities";

--- a/test/moves/destiny_bond.test.ts
+++ b/test/moves/destiny_bond.test.ts
@@ -1,6 +1,6 @@
 import type { ArenaTrapTag } from "#app/data/arena-tag";
 import { ArenaTagSide } from "#app/data/arena-tag";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#enums/abilities";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { Moves } from "#enums/moves";

--- a/test/moves/diamond_storm.test.ts
+++ b/test/moves/diamond_storm.test.ts
@@ -1,4 +1,4 @@
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";

--- a/test/moves/dig.test.ts
+++ b/test/moves/dig.test.ts
@@ -1,5 +1,5 @@
 import { BattlerIndex } from "#app/battle";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#enums/abilities";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { Moves } from "#enums/moves";

--- a/test/moves/dragon_tail.test.ts
+++ b/test/moves/dragon_tail.test.ts
@@ -1,5 +1,5 @@
 import { BattlerIndex } from "#app/battle";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Status } from "#app/data/status-effect";
 import { Challenges } from "#enums/challenges";
 import { StatusEffect } from "#enums/status-effect";

--- a/test/moves/dynamax_cannon.test.ts
+++ b/test/moves/dynamax_cannon.test.ts
@@ -1,5 +1,5 @@
 import { BattlerIndex } from "#app/battle";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { DamageAnimPhase } from "#app/phases/damage-anim-phase";
 import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { Moves } from "#enums/moves";

--- a/test/moves/effectiveness.test.ts
+++ b/test/moves/effectiveness.test.ts
@@ -1,4 +1,4 @@
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { getPokemonSpecies } from "#app/data/pokemon-species";
 import { TrainerSlot } from "#enums/trainer-slot";
 import { PokemonType } from "#enums/pokemon-type";

--- a/test/moves/fell_stinger.test.ts
+++ b/test/moves/fell_stinger.test.ts
@@ -7,7 +7,7 @@ import { Moves } from "#enums/moves";
 import { Stat } from "#enums/stat";
 import { StatusEffect } from "#app/enums/status-effect";
 import { WeatherType } from "#app/enums/weather-type";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 
 describe("Moves - Fell Stinger", () => {
   let phaserGame: Phaser.Game;

--- a/test/moves/fly.test.ts
+++ b/test/moves/fly.test.ts
@@ -8,7 +8,7 @@ import GameManager from "#test/testUtils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, it, expect, vi } from "vitest";
 import { BattlerIndex } from "#app/battle";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 
 describe("Moves - Fly", () => {
   let phaserGame: Phaser.Game;

--- a/test/moves/freezy_frost.test.ts
+++ b/test/moves/freezy_frost.test.ts
@@ -5,7 +5,7 @@ import { Species } from "#enums/species";
 import GameManager from "#test/testUtils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { CommandPhase } from "#app/phases/command-phase";
 
 describe("Moves - Freezy Frost", () => {

--- a/test/moves/fusion_flare_bolt.test.ts
+++ b/test/moves/fusion_flare_bolt.test.ts
@@ -1,6 +1,6 @@
 import { Stat } from "#enums/stat";
 import { BattlerIndex } from "#app/battle";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import type Move from "#app/data/moves/move";
 import { DamageAnimPhase } from "#app/phases/damage-anim-phase";
 import { MoveEffectPhase } from "#app/phases/move-effect-phase";

--- a/test/moves/glaive_rush.test.ts
+++ b/test/moves/glaive_rush.test.ts
@@ -1,4 +1,4 @@
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#app/enums/abilities";
 import { Moves } from "#app/enums/moves";
 import { Species } from "#app/enums/species";

--- a/test/moves/hard_press.test.ts
+++ b/test/moves/hard_press.test.ts
@@ -1,4 +1,4 @@
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";

--- a/test/moves/hyper_beam.test.ts
+++ b/test/moves/hyper_beam.test.ts
@@ -1,4 +1,4 @@
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#app/enums/abilities";
 import { BattlerTagType } from "#app/enums/battler-tag-type";
 import { Moves } from "#app/enums/moves";

--- a/test/moves/lash_out.test.ts
+++ b/test/moves/lash_out.test.ts
@@ -1,5 +1,5 @@
 import { BattlerIndex } from "#app/battle";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#app/enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";

--- a/test/moves/last_respects.test.ts
+++ b/test/moves/last_respects.test.ts
@@ -3,7 +3,7 @@ import { BattlerIndex } from "#app/battle";
 import { Species } from "#enums/species";
 import { Abilities } from "#enums/abilities";
 import GameManager from "#test/testUtils/gameManager";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import type Move from "#app/data/moves/move";
 import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import Phaser from "phaser";

--- a/test/moves/light_screen.test.ts
+++ b/test/moves/light_screen.test.ts
@@ -1,7 +1,8 @@
 import type BattleScene from "#app/battle-scene";
 import { ArenaTagSide } from "#app/data/arena-tag";
 import type Move from "#app/data/moves/move";
-import { allMoves, CritOnlyAttr } from "#app/data/moves/move";
+import { CritOnlyAttr } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#app/enums/abilities";
 import { ArenaTagType } from "#app/enums/arena-tag-type";
 import type Pokemon from "#app/field/pokemon";

--- a/test/moves/magic_coat.test.ts
+++ b/test/moves/magic_coat.test.ts
@@ -1,6 +1,6 @@
 import { BattlerIndex } from "#app/battle";
 import { ArenaTagSide } from "#app/data/arena-tag";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { ArenaTagType } from "#app/enums/arena-tag-type";
 import { BattlerTagType } from "#app/enums/battler-tag-type";
 import { Stat } from "#app/enums/stat";

--- a/test/moves/metronome.test.ts
+++ b/test/moves/metronome.test.ts
@@ -1,5 +1,6 @@
 import { RechargingTag, SemiInvulnerableTag } from "#app/data/battler-tags";
-import { allMoves, RandomMoveAttr } from "#app/data/moves/move";
+import { RandomMoveAttr } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#app/enums/abilities";
 import { Stat } from "#app/enums/stat";
 import { CommandPhase } from "#app/phases/command-phase";

--- a/test/moves/moongeist_beam.test.ts
+++ b/test/moves/moongeist_beam.test.ts
@@ -1,4 +1,5 @@
-import { allMoves, RandomMoveAttr } from "#app/data/moves/move";
+import { RandomMoveAttr } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";

--- a/test/moves/pledge_moves.test.ts
+++ b/test/moves/pledge_moves.test.ts
@@ -1,7 +1,8 @@
 import { BattlerIndex } from "#app/battle";
 import { allAbilities } from "#app/data/data-lists";
 import { ArenaTagSide } from "#app/data/arena-tag";
-import { allMoves, FlinchAttr } from "#app/data/moves/move";
+import { FlinchAttr } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { PokemonType } from "#enums/pokemon-type";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { Stat } from "#enums/stat";

--- a/test/moves/protect.test.ts
+++ b/test/moves/protect.test.ts
@@ -5,7 +5,7 @@ import { Species } from "#enums/species";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Stat } from "#enums/stat";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { ArenaTagSide, ArenaTrapTag } from "#app/data/arena-tag";
 import { BattlerIndex } from "#app/battle";
 import { MoveResult } from "#app/field/pokemon";

--- a/test/moves/rage_fist.test.ts
+++ b/test/moves/rage_fist.test.ts
@@ -2,7 +2,7 @@ import { BattlerIndex } from "#app/battle";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import type Move from "#app/data/moves/move";
 import GameManager from "#test/testUtils/gameManager";
 import Phaser from "phaser";

--- a/test/moves/reflect.test.ts
+++ b/test/moves/reflect.test.ts
@@ -1,7 +1,8 @@
 import type BattleScene from "#app/battle-scene";
 import { ArenaTagSide } from "#app/data/arena-tag";
 import type Move from "#app/data/moves/move";
-import { allMoves, CritOnlyAttr } from "#app/data/moves/move";
+import { CritOnlyAttr } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#app/enums/abilities";
 import { ArenaTagType } from "#app/enums/arena-tag-type";
 import type Pokemon from "#app/field/pokemon";

--- a/test/moves/retaliate.test.ts
+++ b/test/moves/retaliate.test.ts
@@ -3,7 +3,7 @@ import Phaser from "phaser";
 import GameManager from "#test/testUtils/gameManager";
 import { Species } from "#enums/species";
 import { Moves } from "#enums/moves";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import type Move from "#app/data/moves/move";
 
 describe("Moves - Retaliate", () => {

--- a/test/moves/rollout.test.ts
+++ b/test/moves/rollout.test.ts
@@ -1,4 +1,4 @@
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { CommandPhase } from "#app/phases/command-phase";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";

--- a/test/moves/round.test.ts
+++ b/test/moves/round.test.ts
@@ -1,5 +1,5 @@
 import { BattlerIndex } from "#app/battle";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import type { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";

--- a/test/moves/scale_shot.test.ts
+++ b/test/moves/scale_shot.test.ts
@@ -1,5 +1,5 @@
 import { BattlerIndex } from "#app/battle";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { DamageAnimPhase } from "#app/phases/damage-anim-phase";
 import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { MoveEndPhase } from "#app/phases/move-end-phase";

--- a/test/moves/secret_power.test.ts
+++ b/test/moves/secret_power.test.ts
@@ -2,7 +2,7 @@ import { Abilities } from "#enums/abilities";
 import { Biome } from "#enums/biome";
 import { Moves } from "#enums/moves";
 import { Stat } from "#enums/stat";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Species } from "#enums/species";
 import GameManager from "#test/testUtils/gameManager";
 import Phaser from "phaser";

--- a/test/moves/shell_side_arm.test.ts
+++ b/test/moves/shell_side_arm.test.ts
@@ -1,5 +1,6 @@
 import { BattlerIndex } from "#app/battle";
-import { allMoves, ShellSideArmCategoryAttr } from "#app/data/moves/move";
+import { ShellSideArmCategoryAttr } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import type Move from "#app/data/moves/move";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";

--- a/test/moves/shell_trap.test.ts
+++ b/test/moves/shell_trap.test.ts
@@ -1,5 +1,5 @@
 import { BattlerIndex } from "#app/battle";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Moves } from "#app/enums/moves";
 import { Species } from "#app/enums/species";
 import { MoveResult } from "#app/field/pokemon";

--- a/test/moves/sketch.test.ts
+++ b/test/moves/sketch.test.ts
@@ -7,7 +7,8 @@ import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { StatusEffect } from "#app/enums/status-effect";
 import { BattlerIndex } from "#app/battle";
-import { allMoves, RandomMoveAttr } from "#app/data/moves/move";
+import { RandomMoveAttr } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 
 describe("Moves - Sketch", () => {
   let phaserGame: Phaser.Game;

--- a/test/moves/solar_beam.test.ts
+++ b/test/moves/solar_beam.test.ts
@@ -1,4 +1,4 @@
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { WeatherType } from "#enums/weather-type";
 import { MoveResult } from "#app/field/pokemon";

--- a/test/moves/sparkly_swirl.test.ts
+++ b/test/moves/sparkly_swirl.test.ts
@@ -1,4 +1,4 @@
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { StatusEffect } from "#app/enums/status-effect";
 import { CommandPhase } from "#app/phases/command-phase";
 import { Abilities } from "#enums/abilities";

--- a/test/moves/spectral_thief.test.ts
+++ b/test/moves/spectral_thief.test.ts
@@ -1,7 +1,7 @@
 import { Abilities } from "#enums/abilities";
 import { BattlerIndex } from "#app/battle";
 import { Stat } from "#enums/stat";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
 import { TurnEndPhase } from "#app/phases/turn-end-phase";

--- a/test/moves/spit_up.test.ts
+++ b/test/moves/spit_up.test.ts
@@ -1,6 +1,6 @@
 import { Stat } from "#enums/stat";
 import { StockpilingTag } from "#app/data/battler-tags";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { BattlerTagType } from "#app/enums/battler-tag-type";
 import type { TurnMove } from "#app/field/pokemon";
 import { MoveResult } from "#app/field/pokemon";

--- a/test/moves/steamroller.test.ts
+++ b/test/moves/steamroller.test.ts
@@ -1,5 +1,5 @@
 import { BattlerIndex } from "#app/battle";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { BattlerTagType } from "#app/enums/battler-tag-type";
 import type { DamageCalculationResult } from "#app/field/pokemon";
 import { Abilities } from "#enums/abilities";

--- a/test/moves/substitute.test.ts
+++ b/test/moves/substitute.test.ts
@@ -1,7 +1,8 @@
 import { BattlerIndex } from "#app/battle";
 import { ArenaTagSide } from "#app/data/arena-tag";
 import { SubstituteTag, TrappedTag } from "#app/data/battler-tags";
-import { allMoves, StealHeldItemChanceAttr } from "#app/data/moves/move";
+import { StealHeldItemChanceAttr } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { MoveResult } from "#app/field/pokemon";
 import type { CommandPhase } from "#app/phases/command-phase";
 import GameManager from "#test/testUtils/gameManager";

--- a/test/moves/telekinesis.test.ts
+++ b/test/moves/telekinesis.test.ts
@@ -1,5 +1,5 @@
 import { BattlerTagType } from "#enums/battler-tag-type";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";

--- a/test/moves/tera_blast.test.ts
+++ b/test/moves/tera_blast.test.ts
@@ -1,6 +1,7 @@
 import { BattlerIndex } from "#app/battle";
 import { Stat } from "#enums/stat";
-import { allMoves, TeraMoveCategoryAttr } from "#app/data/moves/move";
+import { TeraMoveCategoryAttr } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import type Move from "#app/data/moves/move";
 import { PokemonType } from "#enums/pokemon-type";
 import { Abilities } from "#app/enums/abilities";

--- a/test/moves/toxic.test.ts
+++ b/test/moves/toxic.test.ts
@@ -5,7 +5,7 @@ import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { StatusEffect } from "#enums/status-effect";
 import { BattlerIndex } from "#app/battle";
-import { allMoves } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 
 describe("Moves - Toxic", () => {
   let phaserGame: Phaser.Game;

--- a/test/moves/triple_arrows.test.ts
+++ b/test/moves/triple_arrows.test.ts
@@ -1,4 +1,5 @@
-import { allMoves, FlinchAttr, StatStageChangeAttr } from "#app/data/moves/move";
+import { FlinchAttr, StatStageChangeAttr } from "#app/data/moves/move";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import type Move from "#app/data/moves/move";


### PR DESCRIPTION
## What are the changes the user will see?
None

## Why am I making these changes?
Much like for abilities and the global scene, moving all-moves out of `moves.ts` helps reduce cicular imports.

Lots of files need to access `allMoves`, but not nearly as many need to access any of the other things inside.

## What are the changes from a developer perspective?
Move `allMoves` to `data-lists.ts`

## Screenshots/Videos
N/A

## How to test the changes?
N/A

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually? I did a few waves and nothing broke
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~