### PR TITLE
[Bug] Fix crash caused by switching in a transformed pokemon

### DIFF
--- a/src/phases/switch-summon-phase.ts
+++ b/src/phases/switch-summon-phase.ts
@@ -138,7 +138,6 @@ export class SwitchSummonPhase extends SummonPhase {
       return;
     }
 
-    // await globalScene.time.delayedCall(2000 () => )
 
     if (this.switchType === SwitchType.BATON_PASS) {
       // If switching via baton pass, update opposing tags coming from the prior pokemon


### PR DESCRIPTION
## What are the changes the user will see?
Switching in a ditto that somehow already has summon data will now no longer cause a crash when it faints.
The ditto will now come in un-transformed (as it should)

## Why am I making these changes?
Fixes a p1 crash.


## What are the changes from a developer perspective?

The root cause is that somehow, summon data is not being cleared in some cases.
I could not find exactly what causes this. However, as a workaround, I modify the switch phase so that before the new mon switches in, its summon data is cleared and the assets are forcibly loaded. This fixes the bug, which is caused by the cry key asset not being loaded.

## Screenshots/Videos

<details><summary>No crash post bugfix</summary>

https://github.com/user-attachments/assets/56500161-f8bd-432a-b2fd-eadaa0618322
</details>

## How to test the changes?

Use this save file (remove the .txt extension after downloading and import).
Switch in ditto, and check if the game crashes after it faints.

[sessionData_quillceepkm.prsv.txt](https://github.com/user-attachments/files/20397553/sessionData_quillceepkm.prsv.txt)

## Checklist
- ~~[ ] **I'm using `beta` as my base branch**~~ Hotfix
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?