### PR TITLE
Moved Ball "Cancel" label to a different locale file

### DIFF
--- a/src/ui/ball-ui-handler.ts
+++ b/src/ui/ball-ui-handler.ts
@@ -32,7 +32,7 @@ export default class BallUiHandler extends UiHandler {
     for (let pb = 0; pb < Object.keys(globalScene.pokeballCounts).length; pb++) {
       optionsTextContent += `${getPokeballName(pb)}\n`;
     }
-    optionsTextContent += i18next.t("pokeball:cancel");
+    optionsTextContent += i18next.t("commandUiHandler:ballCancel");
     const optionsText = addTextObject(0, 0, optionsTextContent, TextStyle.WINDOW, { align: "right", maxLines: 6 });
     const optionsTextWidth = optionsText.displayWidth;
     this.pokeballSelectContainer = globalScene.add.container(


### PR DESCRIPTION
## What are the changes the user will see?
None

## Why am I making these changes?
Moved the location of the "Cancel" in a more logical locale file

## What are the changes from a developer perspective?
None

## Screenshots/Videos
No visual change

## How to test the changes?
Just play the game and check if the "Cancel" button in Ball menu is properly displayed

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [X] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [X] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [X] If so, please leave a link to it here: https://github.com/pagefaultgames/pokerogue-locales/pull/168
- [X] Has the translation team been contacted for proofreading/translation?