### PR TITLE
[Misc] Add `phase#is` method to help reduce circular imports

### DIFF
--- a/src/@types/phase-types.ts
+++ b/src/@types/phase-types.ts
@@ -1,0 +1,180 @@
+import type { AttemptRunPhase } from "#app/phases/attempt-run-phase";
+import type { BattleEndPhase } from "#app/phases/battle-end-phase";
+import type { BerryPhase } from "#app/phases/berry-phase";
+import type { CheckSwitchPhase } from "#app/phases/check-switch-phase";
+import type { CommandPhase } from "#app/phases/command-phase";
+import type { DamageAnimPhase } from "#app/phases/damage-anim-phase";
+import type { EggLapsePhase } from "#app/phases/egg-lapse-phase";
+import type { EncounterPhase } from "#app/phases/encounter-phase";
+import type { EndEvolutionPhase } from "#app/phases/end-evolution-phase";
+import type { EnemyCommandPhase } from "#app/phases/enemy-command-phase";
+import type { EvolutionPhase } from "#app/phases/evolution-phase";
+import type { ExpPhase } from "#app/phases/exp-phase";
+import type { FaintPhase } from "#app/phases/faint-phase";
+import type { FormChangePhase } from "#app/phases/form-change-phase";
+import type { GameOverModifierRewardPhase } from "#app/phases/game-over-modifier-reward-phase";
+import type { GameOverPhase } from "#app/phases/game-over-phase";
+import type { LearnMovePhase } from "#app/phases/learn-move-phase";
+import type { LevelCapPhase } from "#app/phases/level-cap-phase";
+import type { LoginPhase } from "#app/phases/login-phase";
+import type { MessagePhase } from "#app/phases/message-phase";
+import type { ModifierRewardPhase } from "#app/phases/modifier-reward-phase";
+import type { MoveEffectPhase } from "#app/phases/move-effect-phase";
+import type { MoveEndPhase } from "#app/phases/move-end-phase";
+import type { MovePhase } from "#app/phases/move-phase";
+import type {
+  MysteryEncounterPhase,
+  MysteryEncounterOptionSelectedPhase,
+  MysteryEncounterBattlePhase,
+  MysteryEncounterRewardsPhase,
+  PostMysteryEncounterPhase,
+} from "#app/phases/mystery-encounter-phases";
+import type { NewBattlePhase } from "#app/phases/new-battle-phase";
+import type { NewBiomeEncounterPhase } from "#app/phases/new-biome-encounter-phase";
+import type { NextEncounterPhase } from "#app/phases/next-encounter-phase";
+import type { PartyExpPhase } from "#app/phases/party-exp-phase";
+import type { PartyHealPhase } from "#app/phases/party-heal-phase";
+import type { PostGameOverPhase } from "#app/phases/post-game-over-phase";
+import type { PostSummonPhase } from "#app/phases/post-summon-phase";
+import type { QuietFormChangePhase } from "#app/phases/quiet-form-change-phase";
+import type { RevivalBlessingPhase } from "#app/phases/revival-blessing-phase";
+import type { RibbonModifierRewardPhase } from "#app/phases/ribbon-modifier-reward-phase";
+import type { SelectBiomePhase } from "#app/phases/select-biome-phase";
+import type { SelectGenderPhase } from "#app/phases/select-gender-phase";
+import type { SelectModifierPhase } from "#app/phases/select-modifier-phase";
+import type { SelectStarterPhase } from "#app/phases/select-starter-phase";
+import type { SelectTargetPhase } from "#app/phases/select-target-phase";
+import type { ShinySparklePhase } from "#app/phases/shiny-sparkle-phase";
+import type { ShowAbilityPhase } from "#app/phases/show-ability-phase";
+import type { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
+import type { SummonPhase } from "#app/phases/summon-phase";
+import type { SwitchPhase } from "#app/phases/switch-phase";
+import type { SwitchSummonPhase } from "#app/phases/switch-summon-phase";
+import type { TitlePhase } from "#app/phases/title-phase";
+import type { ToggleDoublePositionPhase } from "#app/phases/toggle-double-position-phase";
+import type { TurnEndPhase } from "#app/phases/turn-end-phase";
+import type { TurnInitPhase } from "#app/phases/turn-init-phase";
+import type { TurnStartPhase } from "#app/phases/turn-start-phase";
+import type { UnavailablePhase } from "#app/phases/unavailable-phase";
+import type { UnlockPhase } from "#app/phases/unlock-phase";
+import type { VictoryPhase } from "#app/phases/victory-phase";
+
+export type PhaseKind = "";
+export type PhaseClass =
+  | typeof LoginPhase
+  | typeof TitlePhase
+  | typeof SelectGenderPhase
+  | typeof NewBiomeEncounterPhase
+  | typeof SelectStarterPhase
+  | typeof PostSummonPhase
+  | typeof SummonPhase
+  | typeof ToggleDoublePositionPhase
+  | typeof CheckSwitchPhase
+  | typeof ShowAbilityPhase
+  | typeof MessagePhase
+  | typeof TurnInitPhase
+  | typeof CommandPhase
+  | typeof EnemyCommandPhase
+  | typeof TurnStartPhase
+  | typeof MovePhase
+  | typeof MoveEffectPhase
+  | typeof DamageAnimPhase
+  | typeof FaintPhase
+  | typeof BerryPhase
+  | typeof TurnEndPhase
+  | typeof BattleEndPhase
+  | typeof EggLapsePhase
+  | typeof SelectModifierPhase
+  | typeof NextEncounterPhase
+  | typeof NewBattlePhase
+  | typeof VictoryPhase
+  | typeof LearnMovePhase
+  | typeof MoveEndPhase
+  | typeof StatStageChangePhase
+  | typeof ShinySparklePhase
+  | typeof SelectTargetPhase
+  | typeof UnavailablePhase
+  | typeof QuietFormChangePhase
+  | typeof SwitchPhase
+  | typeof SwitchSummonPhase
+  | typeof PartyHealPhase
+  | typeof FormChangePhase
+  | typeof EvolutionPhase
+  | typeof EndEvolutionPhase
+  | typeof LevelCapPhase
+  | typeof AttemptRunPhase
+  | typeof SelectBiomePhase
+  | typeof MysteryEncounterPhase
+  | typeof MysteryEncounterOptionSelectedPhase
+  | typeof MysteryEncounterBattlePhase
+  | typeof MysteryEncounterRewardsPhase
+  | typeof PostMysteryEncounterPhase
+  | typeof RibbonModifierRewardPhase
+  | typeof GameOverModifierRewardPhase
+  | typeof ModifierRewardPhase
+  | typeof PartyExpPhase
+  | typeof ExpPhase
+  | typeof EncounterPhase
+  | typeof GameOverPhase
+  | typeof UnlockPhase
+  | typeof PostGameOverPhase
+  | typeof RevivalBlessingPhase;
+export type PhaseString =
+  | "LoginPhase"
+  | "TitlePhase"
+  | "SelectGenderPhase"
+  | "NewBiomeEncounterPhase"
+  | "SelectStarterPhase"
+  | "PostSummonPhase"
+  | "SummonPhase"
+  | "ToggleDoublePositionPhase"
+  | "CheckSwitchPhase"
+  | "ShowAbilityPhase"
+  | "MessagePhase"
+  | "TurnInitPhase"
+  | "CommandPhase"
+  | "EnemyCommandPhase"
+  | "TurnStartPhase"
+  | "MovePhase"
+  | "MoveEffectPhase"
+  | "DamageAnimPhase"
+  | "FaintPhase"
+  | "BerryPhase"
+  | "TurnEndPhase"
+  | "BattleEndPhase"
+  | "EggLapsePhase"
+  | "SelectModifierPhase"
+  | "NextEncounterPhase"
+  | "NewBattlePhase"
+  | "VictoryPhase"
+  | "LearnMovePhase"
+  | "MoveEndPhase"
+  | "StatStageChangePhase"
+  | "ShinySparklePhase"
+  | "SelectTargetPhase"
+  | "UnavailablePhase"
+  | "QuietFormChangePhase"
+  | "SwitchPhase"
+  | "SwitchSummonPhase"
+  | "PartyHealPhase"
+  | "FormChangePhase"
+  | "EvolutionPhase"
+  | "EndEvolutionPhase"
+  | "LevelCapPhase"
+  | "AttemptRunPhase"
+  | "SelectBiomePhase"
+  | "MysteryEncounterPhase"
+  | "MysteryEncounterOptionSelectedPhase"
+  | "MysteryEncounterBattlePhase"
+  | "MysteryEncounterRewardsPhase"
+  | "PostMysteryEncounterPhase"
+  | "RibbonModifierRewardPhase"
+  | "GameOverModifierRewardPhase"
+  | "ModifierRewardPhase"
+  | "PartyExpPhase"
+  | "ExpPhase"
+  | "EncounterPhase"
+  | "GameOverPhase"
+  | "UnlockPhase"
+  | "PostGameOverPhase"
+  | "RevivalBlessingPhase";

--- a/src/@types/phase-types.ts
+++ b/src/@types/phase-types.ts
@@ -1,11 +1,19 @@
+import type { MoveAnim } from "#app/data/battle-anims";
+import type { AddEnemyBuffModifierPhase } from "#app/phases/add-enemy-buff-modifier-phase";
+import type { AttemptCapturePhase } from "#app/phases/attempt-capture-phase";
 import type { AttemptRunPhase } from "#app/phases/attempt-run-phase";
 import type { BattleEndPhase } from "#app/phases/battle-end-phase";
 import type { BerryPhase } from "#app/phases/berry-phase";
+import type { CheckStatusEffectPhase } from "#app/phases/check-status-effect-phase";
 import type { CheckSwitchPhase } from "#app/phases/check-switch-phase";
 import type { CommandPhase } from "#app/phases/command-phase";
+import type { CommonAnimPhase } from "#app/phases/common-anim-phase";
 import type { DamageAnimPhase } from "#app/phases/damage-anim-phase";
+import type { EggHatchPhase } from "#app/phases/egg-hatch-phase";
 import type { EggLapsePhase } from "#app/phases/egg-lapse-phase";
+import type { EggSummaryPhase } from "#app/phases/egg-summary-phase";
 import type { EncounterPhase } from "#app/phases/encounter-phase";
+import type { EndCardPhase } from "#app/phases/end-card-phase";
 import type { EndEvolutionPhase } from "#app/phases/end-evolution-phase";
 import type { EnemyCommandPhase } from "#app/phases/enemy-command-phase";
 import type { EvolutionPhase } from "#app/phases/evolution-phase";
@@ -14,13 +22,21 @@ import type { FaintPhase } from "#app/phases/faint-phase";
 import type { FormChangePhase } from "#app/phases/form-change-phase";
 import type { GameOverModifierRewardPhase } from "#app/phases/game-over-modifier-reward-phase";
 import type { GameOverPhase } from "#app/phases/game-over-phase";
+import type { HideAbilityPhase } from "#app/phases/hide-ability-phase";
+import type { HidePartyExpBarPhase } from "#app/phases/hide-party-exp-bar-phase";
 import type { LearnMovePhase } from "#app/phases/learn-move-phase";
 import type { LevelCapPhase } from "#app/phases/level-cap-phase";
+import type { LevelUpPhase } from "#app/phases/level-up-phase";
+import type { LoadMoveAnimPhase } from "#app/phases/load-move-anim-phase";
 import type { LoginPhase } from "#app/phases/login-phase";
 import type { MessagePhase } from "#app/phases/message-phase";
 import type { ModifierRewardPhase } from "#app/phases/modifier-reward-phase";
+import type { MoneyRewardPhase } from "#app/phases/money-reward-phase";
+import type { MoveAnimPhase } from "#app/phases/move-anim-phase";
+import type { MoveChargePhase } from "#app/phases/move-charge-phase";
 import type { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import type { MoveEndPhase } from "#app/phases/move-end-phase";
+import type { MoveHeaderPhase } from "#app/phases/move-header-phase";
 import type { MovePhase } from "#app/phases/move-phase";
 import type {
   MysteryEncounterPhase,
@@ -28,153 +44,243 @@ import type {
   MysteryEncounterBattlePhase,
   MysteryEncounterRewardsPhase,
   PostMysteryEncounterPhase,
+  MysteryEncounterBattleStartCleanupPhase,
 } from "#app/phases/mystery-encounter-phases";
 import type { NewBattlePhase } from "#app/phases/new-battle-phase";
 import type { NewBiomeEncounterPhase } from "#app/phases/new-biome-encounter-phase";
 import type { NextEncounterPhase } from "#app/phases/next-encounter-phase";
+import type { ObtainStatusEffectPhase } from "#app/phases/obtain-status-effect-phase";
 import type { PartyExpPhase } from "#app/phases/party-exp-phase";
 import type { PartyHealPhase } from "#app/phases/party-heal-phase";
+import type { PokemonAnimPhase } from "#app/phases/pokemon-anim-phase";
+import type { PokemonHealPhase } from "#app/phases/pokemon-heal-phase";
+import type { PokemonTransformPhase } from "#app/phases/pokemon-transform-phase";
 import type { PostGameOverPhase } from "#app/phases/post-game-over-phase";
 import type { PostSummonPhase } from "#app/phases/post-summon-phase";
+import type { PostTurnStatusEffectPhase } from "#app/phases/post-turn-status-effect-phase";
 import type { QuietFormChangePhase } from "#app/phases/quiet-form-change-phase";
+import type { ReloadSessionPhase } from "#app/phases/reload-session-phase";
+import type { ResetStatusPhase } from "#app/phases/reset-status-phase";
+import type { ReturnPhase } from "#app/phases/return-phase";
 import type { RevivalBlessingPhase } from "#app/phases/revival-blessing-phase";
 import type { RibbonModifierRewardPhase } from "#app/phases/ribbon-modifier-reward-phase";
+import type { ScanIvsPhase } from "#app/phases/scan-ivs-phase";
 import type { SelectBiomePhase } from "#app/phases/select-biome-phase";
+import type { SelectChallengePhase } from "#app/phases/select-challenge-phase";
 import type { SelectGenderPhase } from "#app/phases/select-gender-phase";
 import type { SelectModifierPhase } from "#app/phases/select-modifier-phase";
 import type { SelectStarterPhase } from "#app/phases/select-starter-phase";
 import type { SelectTargetPhase } from "#app/phases/select-target-phase";
 import type { ShinySparklePhase } from "#app/phases/shiny-sparkle-phase";
 import type { ShowAbilityPhase } from "#app/phases/show-ability-phase";
+import type { ShowPartyExpBarPhase } from "#app/phases/show-party-exp-bar-phase";
+import type { ShowTrainerPhase } from "#app/phases/show-trainer-phase";
 import type { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
+import type { SummonMissingPhase } from "#app/phases/summon-missing-phase";
 import type { SummonPhase } from "#app/phases/summon-phase";
+import type { SwitchBiomePhase } from "#app/phases/switch-biome-phase";
 import type { SwitchPhase } from "#app/phases/switch-phase";
 import type { SwitchSummonPhase } from "#app/phases/switch-summon-phase";
+import type { TeraPhase } from "#app/phases/tera-phase";
 import type { TitlePhase } from "#app/phases/title-phase";
 import type { ToggleDoublePositionPhase } from "#app/phases/toggle-double-position-phase";
+import type { TrainerVictoryPhase } from "#app/phases/trainer-victory-phase";
 import type { TurnEndPhase } from "#app/phases/turn-end-phase";
 import type { TurnInitPhase } from "#app/phases/turn-init-phase";
 import type { TurnStartPhase } from "#app/phases/turn-start-phase";
 import type { UnavailablePhase } from "#app/phases/unavailable-phase";
 import type { UnlockPhase } from "#app/phases/unlock-phase";
 import type { VictoryPhase } from "#app/phases/victory-phase";
+import type { WeatherEffectPhase } from "#app/phases/weather-effect-phase";
 
-export type PhaseKind = "";
 export type PhaseClass =
-  | typeof LoginPhase
-  | typeof TitlePhase
-  | typeof SelectGenderPhase
-  | typeof NewBiomeEncounterPhase
-  | typeof SelectStarterPhase
-  | typeof PostSummonPhase
-  | typeof SummonPhase
-  | typeof ToggleDoublePositionPhase
-  | typeof CheckSwitchPhase
-  | typeof ShowAbilityPhase
-  | typeof MessagePhase
-  | typeof TurnInitPhase
-  | typeof CommandPhase
-  | typeof EnemyCommandPhase
-  | typeof TurnStartPhase
-  | typeof MovePhase
-  | typeof MoveEffectPhase
-  | typeof DamageAnimPhase
-  | typeof FaintPhase
-  | typeof BerryPhase
-  | typeof TurnEndPhase
-  | typeof BattleEndPhase
-  | typeof EggLapsePhase
-  | typeof SelectModifierPhase
-  | typeof NextEncounterPhase
-  | typeof NewBattlePhase
-  | typeof VictoryPhase
-  | typeof LearnMovePhase
-  | typeof MoveEndPhase
-  | typeof StatStageChangePhase
-  | typeof ShinySparklePhase
-  | typeof SelectTargetPhase
-  | typeof UnavailablePhase
-  | typeof QuietFormChangePhase
-  | typeof SwitchPhase
-  | typeof SwitchSummonPhase
-  | typeof PartyHealPhase
-  | typeof FormChangePhase
-  | typeof EvolutionPhase
-  | typeof EndEvolutionPhase
-  | typeof LevelCapPhase
+  | typeof AddEnemyBuffModifierPhase
+  | typeof AttemptCapturePhase
   | typeof AttemptRunPhase
-  | typeof SelectBiomePhase
+  | typeof BattleEndPhase
+  | typeof BerryPhase
+  | typeof CheckStatusEffectPhase
+  | typeof CheckSwitchPhase
+  | typeof CommandPhase
+  | typeof CommonAnimPhase
+  | typeof DamageAnimPhase
+  | typeof EggHatchPhase
+  | typeof EggLapsePhase
+  | typeof EggSummaryPhase
+  | typeof EncounterPhase
+  | typeof EndCardPhase
+  | typeof EndEvolutionPhase
+  | typeof EnemyCommandPhase
+  | typeof EvolutionPhase
+  | typeof FormChangePhase
+  | typeof ExpPhase
+  | typeof FaintPhase
+  | typeof FormChangePhase
+  | typeof GameOverPhase
+  | typeof GameOverModifierRewardPhase
+  | typeof HideAbilityPhase
+  | typeof HidePartyExpBarPhase
+  | typeof LearnMovePhase
+  | typeof LevelUpPhase
+  | typeof LevelCapPhase
+  | typeof LoadMoveAnimPhase
+  | typeof LoginPhase
+  | typeof MessagePhase
+  | typeof ModifierRewardPhase
+  | typeof MoneyRewardPhase
+  | typeof MoveAnimPhase
+  | typeof MoveChargePhase
+  | typeof MoveEffectPhase
+  | typeof MoveEndPhase
+  | typeof MoveHeaderPhase
+  | typeof MovePhase
   | typeof MysteryEncounterPhase
   | typeof MysteryEncounterOptionSelectedPhase
   | typeof MysteryEncounterBattlePhase
   | typeof MysteryEncounterRewardsPhase
+  | typeof MysteryEncounterBattleStartCleanupPhase
+  | typeof MysteryEncounterRewardsPhase
   | typeof PostMysteryEncounterPhase
-  | typeof RibbonModifierRewardPhase
-  | typeof GameOverModifierRewardPhase
-  | typeof ModifierRewardPhase
+  | typeof NewBattlePhase
+  | typeof NewBiomeEncounterPhase
+  | typeof NextEncounterPhase
+  | typeof ObtainStatusEffectPhase
   | typeof PartyExpPhase
-  | typeof ExpPhase
-  | typeof EncounterPhase
-  | typeof GameOverPhase
-  | typeof UnlockPhase
+  | typeof PartyHealPhase
+  | typeof PokemonAnimPhase
+  | typeof PokemonHealPhase
+  | typeof PokemonTransformPhase
   | typeof PostGameOverPhase
-  | typeof RevivalBlessingPhase;
-export type PhaseString =
-  | "LoginPhase"
-  | "TitlePhase"
-  | "SelectGenderPhase"
-  | "NewBiomeEncounterPhase"
-  | "SelectStarterPhase"
-  | "PostSummonPhase"
-  | "SummonPhase"
-  | "ToggleDoublePositionPhase"
-  | "CheckSwitchPhase"
-  | "ShowAbilityPhase"
-  | "MessagePhase"
-  | "TurnInitPhase"
-  | "CommandPhase"
-  | "EnemyCommandPhase"
-  | "TurnStartPhase"
-  | "MovePhase"
-  | "MoveEffectPhase"
-  | "DamageAnimPhase"
-  | "FaintPhase"
-  | "BerryPhase"
-  | "TurnEndPhase"
-  | "BattleEndPhase"
-  | "EggLapsePhase"
-  | "SelectModifierPhase"
-  | "NextEncounterPhase"
-  | "NewBattlePhase"
-  | "VictoryPhase"
-  | "LearnMovePhase"
-  | "MoveEndPhase"
-  | "StatStageChangePhase"
-  | "ShinySparklePhase"
-  | "SelectTargetPhase"
-  | "UnavailablePhase"
-  | "QuietFormChangePhase"
-  | "SwitchPhase"
-  | "SwitchSummonPhase"
-  | "PartyHealPhase"
-  | "FormChangePhase"
-  | "EvolutionPhase"
-  | "EndEvolutionPhase"
-  | "LevelCapPhase"
-  | "AttemptRunPhase"
-  | "SelectBiomePhase"
-  | "MysteryEncounterPhase"
-  | "MysteryEncounterOptionSelectedPhase"
-  | "MysteryEncounterBattlePhase"
-  | "MysteryEncounterRewardsPhase"
-  | "PostMysteryEncounterPhase"
-  | "RibbonModifierRewardPhase"
-  | "GameOverModifierRewardPhase"
-  | "ModifierRewardPhase"
-  | "PartyExpPhase"
-  | "ExpPhase"
-  | "EncounterPhase"
-  | "GameOverPhase"
-  | "UnlockPhase"
-  | "PostGameOverPhase"
-  | "RevivalBlessingPhase";
+  | typeof PostSummonPhase
+  | typeof PostTurnStatusEffectPhase
+  | typeof QuietFormChangePhase
+  | typeof ReloadSessionPhase
+  | typeof ResetStatusPhase
+  | typeof ReturnPhase
+  | typeof RevivalBlessingPhase
+  | typeof RibbonModifierRewardPhase
+  | typeof ScanIvsPhase
+  | typeof SelectBiomePhase
+  | typeof SelectChallengePhase
+  | typeof SelectGenderPhase
+  | typeof SelectModifierPhase
+  | typeof SelectStarterPhase
+  | typeof SelectTargetPhase
+  | typeof ShinySparklePhase
+  | typeof ShowAbilityPhase
+  | typeof ShowTrainerPhase
+  | typeof ShowPartyExpBarPhase
+  | typeof StatStageChangePhase
+  | typeof SummonMissingPhase
+  | typeof SummonPhase
+  | typeof SwitchBiomePhase
+  | typeof SwitchPhase
+  | typeof SwitchSummonPhase
+  | typeof TeraPhase
+  | typeof TitlePhase
+  | typeof ToggleDoublePositionPhase
+  | typeof TrainerVictoryPhase
+  | typeof TurnEndPhase
+  | typeof TurnInitPhase
+  | typeof TurnStartPhase
+  | typeof UnavailablePhase
+  | typeof UnlockPhase
+  | typeof VictoryPhase
+  | typeof WeatherEffectPhase;
+
+/** Typescript map used to map a string phase to the actual phase type */
+export type PhaseMap = {
+  AddEnemyBuffModifierPhase: AddEnemyBuffModifierPhase;
+  AttemptCapturePhase: AttemptCapturePhase;
+  AttemptRunPhase: AttemptRunPhase;
+  BattleEndPhase: BattleEndPhase;
+  BerryPhase: BerryPhase;
+  CheckStatusEffectPhase: CheckStatusEffectPhase;
+  CheckSwitchPhase: CheckSwitchPhase;
+  CommandPhase: CommandPhase;
+  CommonAnimPhase: CommonAnimPhase;
+  DamageAnimPhase: DamageAnimPhase;
+  EggHatchPhase: EggHatchPhase;
+  EggLapsePhase: EggLapsePhase;
+  EggSummaryPhase: EggSummaryPhase;
+  EncounterPhase: EncounterPhase;
+  EndCardPhase: EndCardPhase;
+  EndEvolutionPhase: EndEvolutionPhase;
+  EnemyCommandPhase: EnemyCommandPhase;
+  EvolutionPhase: EvolutionPhase;
+  ExpPhase: ExpPhase;
+  FaintPhase: FaintPhase;
+  FormChangePhase: FormChangePhase;
+  GameOverPhase: GameOverPhase;
+  GameOverModifierRewardPhase: GameOverModifierRewardPhase;
+  HideAbilityPhase: HideAbilityPhase;
+  HidePartyExpBarPhase: HidePartyExpBarPhase;
+  LearnMovePhase: LearnMovePhase;
+  LevelCapPhase: LevelCapPhase;
+  LevelUpPhase: LevelUpPhase;
+  LoadMoveAnimPhase: LoadMoveAnimPhase;
+  LoginPhase: LoginPhase;
+  MessagePhase: MessagePhase;
+  ModifierRewardPhase: ModifierRewardPhase;
+  MoneyRewardPhase: MoneyRewardPhase;
+  MoveAnimPhase: MoveAnimPhase<MoveAnim>;
+  MoveChargePhase: MoveChargePhase;
+  MoveEffectPhase: MoveEffectPhase;
+  MoveEndPhase: MoveEndPhase;
+  MoveHeaderPhase: MoveHeaderPhase;
+  MovePhase: MovePhase;
+  MysteryEncounterPhase: MysteryEncounterPhase;
+  MysteryEncounterOptionSelectedPhase: MysteryEncounterOptionSelectedPhase;
+  MysteryEncounterBattlePhase: MysteryEncounterBattlePhase;
+  MysteryEncounterBattleStartCleanupPhase: MysteryEncounterBattleStartCleanupPhase;
+  MysteryEncounterRewardsPhase: MysteryEncounterRewardsPhase;
+  PostMysteryEncounterPhase: PostMysteryEncounterPhase;
+  NewBattlePhase: NewBattlePhase;
+  NewBiomeEncounterPhase: NewBiomeEncounterPhase;
+  NextEncounterPhase: NextEncounterPhase;
+  ObtainStatusEffectPhase: ObtainStatusEffectPhase;
+  PartyExpPhase: PartyExpPhase;
+  PartyHealPhase: PartyHealPhase;
+  PokemonAnimPhase: PokemonAnimPhase;
+  PokemonHealPhase: PokemonHealPhase;
+  PokemonTransformPhase: PokemonTransformPhase;
+  PostGameOverPhase: PostGameOverPhase;
+  PostSummonPhase: PostSummonPhase;
+  PostTurnStatusEffectPhase: PostTurnStatusEffectPhase;
+  QuietFormChangePhase: QuietFormChangePhase;
+  ReloadSessionPhase: ReloadSessionPhase;
+  ResetStatusPhase: ResetStatusPhase;
+  ReturnPhase: ReturnPhase;
+  RevivalBlessingPhase: RevivalBlessingPhase;
+  RibbonModifierRewardPhase: RibbonModifierRewardPhase;
+  ScanIvsPhase: ScanIvsPhase;
+  SelectBiomePhase: SelectBiomePhase;
+  SelectChallengePhase: SelectChallengePhase;
+  SelectGenderPhase: SelectGenderPhase;
+  SelectModifierPhase: SelectModifierPhase;
+  SelectStarterPhase: SelectStarterPhase;
+  SelectTargetPhase: SelectTargetPhase;
+  ShinySparklePhase: ShinySparklePhase;
+  ShowAbilityPhase: ShowAbilityPhase;
+  ShowPartyExpBarPhase: ShowPartyExpBarPhase;
+  ShowTrainerPhase: ShowTrainerPhase;
+  StatStageChangePhase: StatStageChangePhase;
+  SummonMissingPhase: SummonMissingPhase;
+  SummonPhase: SummonPhase;
+  SwitchBiomePhase: SwitchBiomePhase;
+  SwitchPhase: SwitchPhase;
+  SwitchSummonPhase: SwitchSummonPhase;
+  TeraPhase: TeraPhase;
+  TitlePhase: TitlePhase;
+  ToggleDoublePositionPhase: ToggleDoublePositionPhase;
+  TrainerVictoryPhase: TrainerVictoryPhase;
+  TurnEndPhase: TurnEndPhase;
+  TurnInitPhase: TurnInitPhase;
+  TurnStartPhase: TurnStartPhase;
+  UnavailablePhase: UnavailablePhase;
+  UnlockPhase: UnlockPhase;
+  VictoryPhase: VictoryPhase;
+  WeatherEffectPhase: WeatherEffectPhase;
+};
+
+export type PhaseString = keyof PhaseMap;

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1587,9 +1587,7 @@ export default class BattleScene extends SceneBase {
       return 0;
     }
 
-    const isEggPhase: boolean = ["EggLapsePhase", "EggHatchPhase"].includes(
-      this.getCurrentPhase()?.constructor.name ?? "",
-    );
+    const isEggPhase: boolean = ["EggLapsePhase", "EggHatchPhase"].includes(this.getCurrentPhase()?.phaseName ?? "");
 
     if (
       // Give trainers with specialty types an appropriately-typed form for Wormadam, Rotom, Arceus, Oricorio, Silvally, or Paldean Tauros.

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -900,7 +900,7 @@ export default class BattleScene extends SceneBase {
       do {
         targetingMovePhase = this.findPhase(
           mp =>
-            mp.isXPhase("MovePhase") &&
+            mp.is("MovePhase") &&
             mp.targets.length === 1 &&
             mp.targets[0] === removedPokemon.getBattlerIndex() &&
             mp.pokemon.isPlayer() !== allyPokemon.isPlayer(),
@@ -1449,7 +1449,7 @@ export default class BattleScene extends SceneBase {
     }
 
     if (lastBattle?.double && !newDouble) {
-      this.tryRemovePhase((p: Phase) => p.isXPhase("SwitchPhase"));
+      this.tryRemovePhase((p: Phase) => p.is("SwitchPhase"));
       for (const p of this.getPlayerField()) {
         p.lapseTag(BattlerTagType.COMMANDED);
       }

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -145,7 +145,7 @@ import { LoadingScene } from "#app/loading-scene";
 import { LevelCapPhase } from "#app/phases/level-cap-phase";
 import { LoginPhase } from "#app/phases/login-phase";
 import { MessagePhase } from "#app/phases/message-phase";
-import { MovePhase } from "#app/phases/move-phase";
+import type { MovePhase } from "#app/phases/move-phase";
 import { NewBiomeEncounterPhase } from "#app/phases/new-biome-encounter-phase";
 import { NextEncounterPhase } from "#app/phases/next-encounter-phase";
 import { PokemonAnimPhase } from "#app/phases/pokemon-anim-phase";
@@ -153,7 +153,6 @@ import { QuietFormChangePhase } from "#app/phases/quiet-form-change-phase";
 import { ReturnPhase } from "#app/phases/return-phase";
 import { ShowTrainerPhase } from "#app/phases/show-trainer-phase";
 import { SummonPhase } from "#app/phases/summon-phase";
-import { SwitchPhase } from "#app/phases/switch-phase";
 import { TitlePhase } from "#app/phases/title-phase";
 import { ToggleDoublePositionPhase } from "#app/phases/toggle-double-position-phase";
 import { TurnInitPhase } from "#app/phases/turn-init-phase";
@@ -901,7 +900,7 @@ export default class BattleScene extends SceneBase {
       do {
         targetingMovePhase = this.findPhase(
           mp =>
-            mp instanceof MovePhase &&
+            mp.isXPhase("MovePhase") &&
             mp.targets.length === 1 &&
             mp.targets[0] === removedPokemon.getBattlerIndex() &&
             mp.pokemon.isPlayer() !== allyPokemon.isPlayer(),
@@ -1450,7 +1449,7 @@ export default class BattleScene extends SceneBase {
     }
 
     if (lastBattle?.double && !newDouble) {
-      this.tryRemovePhase(p => p instanceof SwitchPhase);
+      this.tryRemovePhase((p: Phase) => p.isXPhase("SwitchPhase"));
       for (const p of this.getPlayerField()) {
         p.lapseTag(BattlerTagType.COMMANDED);
       }

--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -2828,7 +2828,7 @@ export class CommanderAbAttr extends AbAttr {
       // Apply boosts from this effect to the ally Dondozo
       pokemon.getAlly()?.addTag(BattlerTagType.COMMANDED, 0, MoveId.NONE, pokemon.id);
       // Cancel the source Pokemon's next move (if a move is queued)
-      globalScene.tryRemovePhase((phase) => phase.isXPhase("MovePhase") && phase.pokemon === pokemon);
+      globalScene.tryRemovePhase((phase) => phase.is("MovePhase") && phase.pokemon === pokemon);
     }
   }
 }
@@ -6897,7 +6897,7 @@ export function initAbilities() {
       .ignorable(),
     new Ability(AbilityId.ANALYTIC, 5)
       .attr(MovePowerBoostAbAttr, (user, target, move) => {
-        const movePhase = globalScene.findPhase((phase) => phase.isXPhase("MovePhase") && phase.pokemon.id !== user?.id);
+        const movePhase = globalScene.findPhase((phase) => phase.is("MovePhase") && phase.pokemon.id !== user?.id);
         return isNullOrUndefined(movePhase);
       }, 1.3),
     new Ability(AbilityId.ILLUSION, 5)

--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -2828,7 +2828,7 @@ export class CommanderAbAttr extends AbAttr {
       // Apply boosts from this effect to the ally Dondozo
       pokemon.getAlly()?.addTag(BattlerTagType.COMMANDED, 0, MoveId.NONE, pokemon.id);
       // Cancel the source Pokemon's next move (if a move is queued)
-      globalScene.tryRemovePhase((phase) => phase instanceof MovePhase && phase.pokemon === pokemon);
+      globalScene.tryRemovePhase((phase) => phase.isXPhase("MovePhase") && phase.pokemon === pokemon);
     }
   }
 }
@@ -6897,7 +6897,7 @@ export function initAbilities() {
       .ignorable(),
     new Ability(AbilityId.ANALYTIC, 5)
       .attr(MovePowerBoostAbAttr, (user, target, move) => {
-        const movePhase = globalScene.findPhase((phase) => phase instanceof MovePhase && phase.pokemon.id !== user?.id);
+        const movePhase = globalScene.findPhase((phase) => phase.isXPhase("MovePhase") && phase.pokemon.id !== user?.id);
         return isNullOrUndefined(movePhase);
       }, 1.3),
     new Ability(AbilityId.ILLUSION, 5)

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -383,7 +383,7 @@ const QuickGuardConditionFunc: ProtectConditionFunc = (_arena, moveId) => {
   const move = allMoves[moveId];
   const effectPhase = globalScene.getCurrentPhase();
 
-  if (effectPhase?.isXPhase("MoveEffectPhase")) {
+  if (effectPhase?.is("MoveEffectPhase")) {
     const attacker = effectPhase.getUserPokemon();
     if (attacker) {
       return move.getPriority(attacker) > 0;

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -383,7 +383,7 @@ const QuickGuardConditionFunc: ProtectConditionFunc = (_arena, moveId) => {
   const move = allMoves[moveId];
   const effectPhase = globalScene.getCurrentPhase();
 
-  if (effectPhase instanceof MoveEffectPhase) {
+  if (effectPhase?.isXPhase("MoveEffectPhase")) {
     const attacker = effectPhase.getUserPokemon();
     if (attacker) {
       return move.getPriority(attacker) > 0;

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -553,9 +553,9 @@ export class ShellTrapTag extends BattlerTag {
       // Trap should only be triggered by opponent's Physical moves
       if (phaseData?.move.category === MoveCategory.PHYSICAL && pokemon.isOpponent(phaseData.attacker)) {
         const shellTrapPhaseIndex = globalScene.phaseQueue.findIndex(
-          phase => phase.isXPhase("MovePhase") && phase.pokemon === pokemon,
+          phase => phase.is("MovePhase") && phase.pokemon === pokemon,
         );
-        const firstMovePhaseIndex = globalScene.phaseQueue.findIndex(phase => phase.isXPhase("MovePhase"));
+        const firstMovePhaseIndex = globalScene.phaseQueue.findIndex(phase => phase.is("MovePhase"));
 
         // Only shift MovePhase timing if it's not already next up
         if (shellTrapPhaseIndex !== -1 && shellTrapPhaseIndex !== firstMovePhaseIndex) {
@@ -1027,7 +1027,7 @@ export class PowderTag extends BattlerTag {
   lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
     if (lapseType === BattlerTagLapseType.PRE_MOVE) {
       const movePhase = globalScene.getCurrentPhase();
-      if (movePhase?.isXPhase("MovePhase")) {
+      if (movePhase?.is("MovePhase")) {
         const move = movePhase.move.getMove();
         const weather = globalScene.arena.weather;
         if (
@@ -1183,13 +1183,13 @@ export class EncoreTag extends MoveRestrictionBattlerTag {
       }),
     );
 
-    const movePhase = globalScene.findPhase(m => m.isXPhase("MovePhase") && m.pokemon === pokemon);
+    const movePhase = globalScene.findPhase(m => m.is("MovePhase") && m.pokemon === pokemon);
     if (movePhase) {
       const movesetMove = pokemon.getMoveset().find(m => m.moveId === this.moveId);
       if (movesetMove) {
         const lastMove = pokemon.getLastXMoves(1)[0];
         globalScene.tryReplacePhase(
-          m => m.isXPhase("MovePhase") && m.pokemon === pokemon,
+          m => m.is("MovePhase") && m.pokemon === pokemon,
           new MovePhase(pokemon, lastMove.targets ?? [], movesetMove),
         );
       }
@@ -1624,7 +1624,7 @@ export class ProtectedTag extends BattlerTag {
 
       // Stop multi-hit moves early
       const effectPhase = globalScene.getCurrentPhase();
-      if (effectPhase?.isXPhase("MoveEffectPhase")) {
+      if (effectPhase?.is("MoveEffectPhase")) {
         effectPhase.stopMultiHit(pokemon);
       }
       return true;
@@ -2646,7 +2646,7 @@ export class GulpMissileTag extends BattlerTag {
     }
 
     const moveEffectPhase = globalScene.getCurrentPhase();
-    if (moveEffectPhase?.isXPhase("MoveEffectPhase")) {
+    if (moveEffectPhase?.is("MoveEffectPhase")) {
       const attacker = moveEffectPhase.getUserPokemon();
 
       if (!attacker) {
@@ -3004,7 +3004,7 @@ export class SubstituteTag extends BattlerTag {
   /** If the Substitute redirects damage, queue a message to indicate it. */
   onHit(pokemon: Pokemon): void {
     const moveEffectPhase = globalScene.getCurrentPhase();
-    if (moveEffectPhase?.isXPhase("MoveEffectPhase")) {
+    if (moveEffectPhase?.is("MoveEffectPhase")) {
       const attacker = moveEffectPhase.getUserPokemon();
       if (!attacker) {
         return;
@@ -3693,7 +3693,7 @@ export function loadBattlerTag(source: BattlerTag | any): BattlerTag {
  */
 function getMoveEffectPhaseData(_pokemon: Pokemon): { phase: MoveEffectPhase; attacker: Pokemon; move: Move } | null {
   const phase = globalScene.getCurrentPhase();
-  if (phase?.isXPhase("MoveEffectPhase")) {
+  if (phase?.is("MoveEffectPhase")) {
     return {
       phase: phase,
       attacker: phase.getPokemon(),

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -28,7 +28,7 @@ import type Pokemon from "#app/field/pokemon";
 import { HitResult, MoveResult } from "#app/field/pokemon";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { CommonAnimPhase } from "#app/phases/common-anim-phase";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
+import type { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { MovePhase } from "#app/phases/move-phase";
 import { PokemonHealPhase } from "#app/phases/pokemon-heal-phase";
 import type { StatStageChangeCallback } from "#app/phases/stat-stage-change-phase";
@@ -553,9 +553,9 @@ export class ShellTrapTag extends BattlerTag {
       // Trap should only be triggered by opponent's Physical moves
       if (phaseData?.move.category === MoveCategory.PHYSICAL && pokemon.isOpponent(phaseData.attacker)) {
         const shellTrapPhaseIndex = globalScene.phaseQueue.findIndex(
-          phase => phase instanceof MovePhase && phase.pokemon === pokemon,
+          phase => phase.isXPhase("MovePhase") && phase.pokemon === pokemon,
         );
-        const firstMovePhaseIndex = globalScene.phaseQueue.findIndex(phase => phase instanceof MovePhase);
+        const firstMovePhaseIndex = globalScene.phaseQueue.findIndex(phase => phase.isXPhase("MovePhase"));
 
         // Only shift MovePhase timing if it's not already next up
         if (shellTrapPhaseIndex !== -1 && shellTrapPhaseIndex !== firstMovePhaseIndex) {
@@ -1027,7 +1027,7 @@ export class PowderTag extends BattlerTag {
   lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
     if (lapseType === BattlerTagLapseType.PRE_MOVE) {
       const movePhase = globalScene.getCurrentPhase();
-      if (movePhase instanceof MovePhase) {
+      if (movePhase?.isXPhase("MovePhase")) {
         const move = movePhase.move.getMove();
         const weather = globalScene.arena.weather;
         if (
@@ -1183,13 +1183,13 @@ export class EncoreTag extends MoveRestrictionBattlerTag {
       }),
     );
 
-    const movePhase = globalScene.findPhase(m => m instanceof MovePhase && m.pokemon === pokemon);
+    const movePhase = globalScene.findPhase(m => m.isXPhase("MovePhase") && m.pokemon === pokemon);
     if (movePhase) {
       const movesetMove = pokemon.getMoveset().find(m => m.moveId === this.moveId);
       if (movesetMove) {
         const lastMove = pokemon.getLastXMoves(1)[0];
         globalScene.tryReplacePhase(
-          m => m instanceof MovePhase && m.pokemon === pokemon,
+          m => m.isXPhase("MovePhase") && m.pokemon === pokemon,
           new MovePhase(pokemon, lastMove.targets ?? [], movesetMove),
         );
       }
@@ -1624,7 +1624,7 @@ export class ProtectedTag extends BattlerTag {
 
       // Stop multi-hit moves early
       const effectPhase = globalScene.getCurrentPhase();
-      if (effectPhase instanceof MoveEffectPhase) {
+      if (effectPhase?.isXPhase("MoveEffectPhase")) {
         effectPhase.stopMultiHit(pokemon);
       }
       return true;
@@ -2646,7 +2646,7 @@ export class GulpMissileTag extends BattlerTag {
     }
 
     const moveEffectPhase = globalScene.getCurrentPhase();
-    if (moveEffectPhase instanceof MoveEffectPhase) {
+    if (moveEffectPhase?.isXPhase("MoveEffectPhase")) {
       const attacker = moveEffectPhase.getUserPokemon();
 
       if (!attacker) {
@@ -3004,7 +3004,7 @@ export class SubstituteTag extends BattlerTag {
   /** If the Substitute redirects damage, queue a message to indicate it. */
   onHit(pokemon: Pokemon): void {
     const moveEffectPhase = globalScene.getCurrentPhase();
-    if (moveEffectPhase instanceof MoveEffectPhase) {
+    if (moveEffectPhase?.isXPhase("MoveEffectPhase")) {
       const attacker = moveEffectPhase.getUserPokemon();
       if (!attacker) {
         return;
@@ -3693,7 +3693,7 @@ export function loadBattlerTag(source: BattlerTag | any): BattlerTag {
  */
 function getMoveEffectPhaseData(_pokemon: Pokemon): { phase: MoveEffectPhase; attacker: Pokemon; move: Move } | null {
   const phase = globalScene.getCurrentPhase();
-  if (phase instanceof MoveEffectPhase) {
+  if (phase?.isXPhase("MoveEffectPhase")) {
     return {
       phase: phase,
       attacker: phase.getPokemon(),

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -3109,7 +3109,7 @@ export class AwaitCombinedPledgeAttr extends OverrideMoveEffectAttr {
 
     const overridden = args[0] as BooleanHolder;
 
-    const allyMovePhase = globalScene.findPhase<MovePhase>((phase) => phase instanceof MovePhase && phase.pokemon.isPlayer() === user.isPlayer());
+    const allyMovePhase = globalScene.findPhase<MovePhase>((phase) => phase.isXPhase("MovePhase") && phase.pokemon.isPlayer() === user.isPlayer());
     if (allyMovePhase) {
       const allyMove = allyMovePhase.move.getMove();
       if (allyMove !== move && allyMove.hasAttr(AwaitCombinedPledgeAttr)) {
@@ -3123,7 +3123,7 @@ export class AwaitCombinedPledgeAttr extends OverrideMoveEffectAttr {
 
         // Move the ally's MovePhase (if needed) so that the ally moves next
         const allyMovePhaseIndex = globalScene.phaseQueue.indexOf(allyMovePhase);
-        const firstMovePhaseIndex = globalScene.phaseQueue.findIndex((phase) => phase instanceof MovePhase);
+        const firstMovePhaseIndex = globalScene.phaseQueue.findIndex((phase) => phase.isXPhase("MovePhase"));
         if (allyMovePhaseIndex !== firstMovePhaseIndex) {
           globalScene.prependToPhase(globalScene.phaseQueue.splice(allyMovePhaseIndex, 1)[0], MovePhase);
         }
@@ -4477,7 +4477,7 @@ export class CueNextRoundAttr extends MoveEffectAttr {
 
   override apply(user: Pokemon, target: Pokemon, move: Move, args?: any[]): boolean {
     const nextRoundPhase = globalScene.findPhase<MovePhase>(phase =>
-      phase instanceof MovePhase && phase.move.moveId === MoveId.ROUND
+      phase.isXPhase("MovePhase") && phase.move.moveId === MoveId.ROUND
     );
 
     if (!nextRoundPhase) {
@@ -4486,7 +4486,7 @@ export class CueNextRoundAttr extends MoveEffectAttr {
 
     // Update the phase queue so that the next Pokemon using Round moves next
     const nextRoundIndex = globalScene.phaseQueue.indexOf(nextRoundPhase);
-    const nextMoveIndex = globalScene.phaseQueue.findIndex(phase => phase instanceof MovePhase);
+    const nextMoveIndex = globalScene.phaseQueue.findIndex(phase => phase.isXPhase("MovePhase"));
     if (nextRoundIndex !== nextMoveIndex) {
       globalScene.prependToPhase(globalScene.phaseQueue.splice(nextRoundIndex, 1)[0], MovePhase);
     }
@@ -6177,7 +6177,7 @@ export class RevivalBlessingAttr extends MoveEffectAttr {
         // Handle cases where revived pokemon needs to get switched in on same turn
         if (allyPokemon.isFainted() || allyPokemon === pokemon) {
           // Enemy switch phase should be removed and replaced with the revived pkmn switching in
-          globalScene.tryRemovePhase((phase: SwitchSummonPhase) => phase instanceof SwitchSummonPhase && phase.getPokemon() === pokemon);
+          globalScene.tryRemovePhase((phase: SwitchSummonPhase) => phase.isXPhase("SwitchSummonPhase") && phase.getPokemon() === pokemon);
           // If the pokemon being revived was alive earlier in the turn, cancel its move
           // (revived pokemon can't move in the turn they're brought back)
           globalScene.findPhase((phase: MovePhase) => phase.pokemon === pokemon)?.cancel();
@@ -7896,7 +7896,7 @@ export class ForceLastAttr extends MoveEffectAttr {
       // Either the end of the turn or in front of another, slower move which has also been forced last
       const prependPhase = globalScene.findPhase((phase) =>
         [ MovePhase, MoveEndPhase ].every(cls => !(phase instanceof cls))
-        || (phase instanceof MovePhase) && phaseForcedSlower(phase, target, !!globalScene.arena.getTag(ArenaTagType.TRICK_ROOM))
+        || (phase.isXPhase("MovePhase")) && phaseForcedSlower(phase, target, !!globalScene.arena.getTag(ArenaTagType.TRICK_ROOM))
       );
       if (prependPhase) {
         globalScene.phaseQueue.splice(
@@ -7942,7 +7942,7 @@ const userSleptOrComatoseCondition: MoveConditionFunc = (user: Pokemon, target: 
 
 const targetSleptOrComatoseCondition: MoveConditionFunc = (user: Pokemon, target: Pokemon, move: Move) =>  target.status?.effect === StatusEffect.SLEEP || target.hasAbility(AbilityId.COMATOSE);
 
-const failIfLastCondition: MoveConditionFunc = (user: Pokemon, target: Pokemon, move: Move) => globalScene.phaseQueue.find(phase => phase instanceof MovePhase) !== undefined;
+const failIfLastCondition: MoveConditionFunc = (user: Pokemon, target: Pokemon, move: Move) => globalScene.phaseQueue.find(phase => phase.isXPhase("MovePhase")) !== undefined;
 
 const failIfLastInPartyCondition: MoveConditionFunc = (user: Pokemon, target: Pokemon, move: Move) => {
   const party: Pokemon[] = user.isPlayer() ? globalScene.getPlayerParty() : globalScene.getEnemyParty();

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -3109,7 +3109,7 @@ export class AwaitCombinedPledgeAttr extends OverrideMoveEffectAttr {
 
     const overridden = args[0] as BooleanHolder;
 
-    const allyMovePhase = globalScene.findPhase<MovePhase>((phase) => phase.isXPhase("MovePhase") && phase.pokemon.isPlayer() === user.isPlayer());
+    const allyMovePhase = globalScene.findPhase<MovePhase>((phase) => phase.is("MovePhase") && phase.pokemon.isPlayer() === user.isPlayer());
     if (allyMovePhase) {
       const allyMove = allyMovePhase.move.getMove();
       if (allyMove !== move && allyMove.hasAttr(AwaitCombinedPledgeAttr)) {
@@ -3123,7 +3123,7 @@ export class AwaitCombinedPledgeAttr extends OverrideMoveEffectAttr {
 
         // Move the ally's MovePhase (if needed) so that the ally moves next
         const allyMovePhaseIndex = globalScene.phaseQueue.indexOf(allyMovePhase);
-        const firstMovePhaseIndex = globalScene.phaseQueue.findIndex((phase) => phase.isXPhase("MovePhase"));
+        const firstMovePhaseIndex = globalScene.phaseQueue.findIndex((phase) => phase.is("MovePhase"));
         if (allyMovePhaseIndex !== firstMovePhaseIndex) {
           globalScene.prependToPhase(globalScene.phaseQueue.splice(allyMovePhaseIndex, 1)[0], MovePhase);
         }
@@ -4477,7 +4477,7 @@ export class CueNextRoundAttr extends MoveEffectAttr {
 
   override apply(user: Pokemon, target: Pokemon, move: Move, args?: any[]): boolean {
     const nextRoundPhase = globalScene.findPhase<MovePhase>(phase =>
-      phase.isXPhase("MovePhase") && phase.move.moveId === MoveId.ROUND
+      phase.is("MovePhase") && phase.move.moveId === MoveId.ROUND
     );
 
     if (!nextRoundPhase) {
@@ -4486,7 +4486,7 @@ export class CueNextRoundAttr extends MoveEffectAttr {
 
     // Update the phase queue so that the next Pokemon using Round moves next
     const nextRoundIndex = globalScene.phaseQueue.indexOf(nextRoundPhase);
-    const nextMoveIndex = globalScene.phaseQueue.findIndex(phase => phase.isXPhase("MovePhase"));
+    const nextMoveIndex = globalScene.phaseQueue.findIndex(phase => phase.is("MovePhase"));
     if (nextRoundIndex !== nextMoveIndex) {
       globalScene.prependToPhase(globalScene.phaseQueue.splice(nextRoundIndex, 1)[0], MovePhase);
     }
@@ -6177,7 +6177,7 @@ export class RevivalBlessingAttr extends MoveEffectAttr {
         // Handle cases where revived pokemon needs to get switched in on same turn
         if (allyPokemon.isFainted() || allyPokemon === pokemon) {
           // Enemy switch phase should be removed and replaced with the revived pkmn switching in
-          globalScene.tryRemovePhase((phase: SwitchSummonPhase) => phase.isXPhase("SwitchSummonPhase") && phase.getPokemon() === pokemon);
+          globalScene.tryRemovePhase((phase: SwitchSummonPhase) => phase.is("SwitchSummonPhase") && phase.getPokemon() === pokemon);
           // If the pokemon being revived was alive earlier in the turn, cancel its move
           // (revived pokemon can't move in the turn they're brought back)
           globalScene.findPhase((phase: MovePhase) => phase.pokemon === pokemon)?.cancel();
@@ -7896,7 +7896,7 @@ export class ForceLastAttr extends MoveEffectAttr {
       // Either the end of the turn or in front of another, slower move which has also been forced last
       const prependPhase = globalScene.findPhase((phase) =>
         [ MovePhase, MoveEndPhase ].every(cls => !(phase instanceof cls))
-        || (phase.isXPhase("MovePhase")) && phaseForcedSlower(phase, target, !!globalScene.arena.getTag(ArenaTagType.TRICK_ROOM))
+        || (phase.is("MovePhase")) && phaseForcedSlower(phase, target, !!globalScene.arena.getTag(ArenaTagType.TRICK_ROOM))
       );
       if (prependPhase) {
         globalScene.phaseQueue.splice(
@@ -7942,7 +7942,7 @@ const userSleptOrComatoseCondition: MoveConditionFunc = (user: Pokemon, target: 
 
 const targetSleptOrComatoseCondition: MoveConditionFunc = (user: Pokemon, target: Pokemon, move: Move) =>  target.status?.effect === StatusEffect.SLEEP || target.hasAbility(AbilityId.COMATOSE);
 
-const failIfLastCondition: MoveConditionFunc = (user: Pokemon, target: Pokemon, move: Move) => globalScene.phaseQueue.find(phase => phase.isXPhase("MovePhase")) !== undefined;
+const failIfLastCondition: MoveConditionFunc = (user: Pokemon, target: Pokemon, move: Move) => globalScene.phaseQueue.find(phase => phase.is("MovePhase")) !== undefined;
 
 const failIfLastInPartyCondition: MoveConditionFunc = (user: Pokemon, target: Pokemon, move: Move) => {
   const party: Pokemon[] = user.isPlayer() ? globalScene.getPlayerParty() : globalScene.getEnemyParty();

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -769,7 +769,7 @@ export function setEncounterRewards(
     if (customShopRewards) {
       globalScene.unshiftPhase(new SelectModifierPhase(0, undefined, customShopRewards));
     } else {
-      globalScene.tryRemovePhase(p => p instanceof SelectModifierPhase);
+      globalScene.tryRemovePhase(p => p.isXPhase("MysteryEncounterRewardsPhase"));
     }
 
     if (eggRewards) {

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -769,7 +769,7 @@ export function setEncounterRewards(
     if (customShopRewards) {
       globalScene.unshiftPhase(new SelectModifierPhase(0, undefined, customShopRewards));
     } else {
-      globalScene.tryRemovePhase(p => p.isXPhase("MysteryEncounterRewardsPhase"));
+      globalScene.tryRemovePhase(p => p.is("MysteryEncounterRewardsPhase"));
     }
 
     if (eggRewards) {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1300,7 +1300,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
       // During the Pokemon's MoveEffect phase, the offset is removed to put the Pokemon "in focus"
       const currentPhase = globalScene.getCurrentPhase();
-      if (currentPhase instanceof MoveEffectPhase && currentPhase.getPokemon() === this) {
+      if (currentPhase?.isXPhase("MoveEffectPhase") && currentPhase.getPokemon() === this) {
         return false;
       }
       return true;
@@ -4775,7 +4775,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
      */
     if (effect === StatusEffect.SLEEP || effect === StatusEffect.FREEZE) {
       const currentPhase = globalScene.getCurrentPhase();
-      if (currentPhase instanceof MoveEffectPhase && currentPhase.getUserPokemon() === this) {
+      if (currentPhase?.isXPhase("MoveEffectPhase") && currentPhase.getUserPokemon() === this) {
         this.turnData.hitCount = 1;
         this.turnData.hitsLeft = 1;
       }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -232,7 +232,6 @@ import { getPokemonNameWithAffix } from "#app/messages";
 import { DamageAnimPhase } from "#app/phases/damage-anim-phase";
 import { FaintPhase } from "#app/phases/faint-phase";
 import { LearnMovePhase } from "#app/phases/learn-move-phase";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { MoveEndPhase } from "#app/phases/move-end-phase";
 import { ObtainStatusEffectPhase } from "#app/phases/obtain-status-effect-phase";
 import { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
@@ -1300,7 +1299,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
       // During the Pokemon's MoveEffect phase, the offset is removed to put the Pokemon "in focus"
       const currentPhase = globalScene.getCurrentPhase();
-      if (currentPhase?.isXPhase("MoveEffectPhase") && currentPhase.getPokemon() === this) {
+      if (currentPhase?.is("MoveEffectPhase") && currentPhase.getPokemon() === this) {
         return false;
       }
       return true;
@@ -4775,7 +4774,7 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
      */
     if (effect === StatusEffect.SLEEP || effect === StatusEffect.FREEZE) {
       const currentPhase = globalScene.getCurrentPhase();
-      if (currentPhase?.isXPhase("MoveEffectPhase") && currentPhase.getUserPokemon() === this) {
+      if (currentPhase?.is("MoveEffectPhase") && currentPhase.getUserPokemon() === this) {
         this.turnData.hitCount = 1;
         this.turnData.hitsLeft = 1;
       }

--- a/src/phase.ts
+++ b/src/phase.ts
@@ -21,7 +21,7 @@ export abstract class Phase {
    * Check if the phase is of the given type without requiring `instanceof`.
    *
    * @param phase - The string name of the phase to check.
-   * @returns `true` if this phase is of the given type, `false` otherwise.
+   * @returns Whether this phase is of the provided type.
    *
    * @remarks
    * This does not check for subclasses! It only checks if the phase is *exactly* the given type.

--- a/src/phase.ts
+++ b/src/phase.ts
@@ -9,7 +9,7 @@ export abstract class Phase {
   }
 
   /**
-   * The string name of the phase, used to identify the phase type for {@linkcode isXPhase}
+   * The string name of the phase, used to identify the phase type for {@linkcode is}
    *
    * @privateremarks
    *
@@ -27,7 +27,7 @@ export abstract class Phase {
    * This does not check for subclasses! It only checks if the phase is *exactly* the given type.
    * This method exists to avoid circular import issues, as using `instanceof` would require importing each phase.
    */
-  isXPhase<K extends keyof PhaseMap>(phase: K): this is PhaseMap[K] {
+  is<K extends keyof PhaseMap>(phase: K): this is PhaseMap[K] {
     return this.phaseName === phase;
   }
 }

--- a/src/phase.ts
+++ b/src/phase.ts
@@ -15,7 +15,7 @@ export abstract class Phase {
    *
    * When implementing a phase, you must set the `phaseName` property to the name of the phase.
    */
-  protected abstract readonly phaseName: PhaseString;
+  public abstract readonly phaseName: PhaseString;
 
   /**
    * Check if the phase is of the given type without requiring `instanceof`.

--- a/src/phase.ts
+++ b/src/phase.ts
@@ -1,9 +1,33 @@
 import { globalScene } from "#app/global-scene";
+import type { PhaseMap, PhaseString } from "./@types/phase-types";
 
-export class Phase {
+export abstract class Phase {
   start() {}
 
   end() {
     globalScene.shiftPhase();
+  }
+
+  /**
+   * The string name of the phase, used to identify the phase type for {@linkcode isXPhase}
+   *
+   * @privateremarks
+   *
+   * When implementing a phase, you must set the `phaseName` property to the name of the phase.
+   */
+  protected abstract readonly phaseName: PhaseString;
+
+  /**
+   * Check if the phase is of the given type without requiring `instanceof`.
+   *
+   * @param phase - The string name of the phase to check.
+   * @returns `true` if this phase is of the given type, `false` otherwise.
+   *
+   * @remarks
+   * This does not check for subclasses! It only checks if the phase is *exactly* the given type.
+   * This method exists to avoid circular import issues, as using `instanceof` would require importing each phase.
+   */
+  isXPhase<K extends keyof PhaseMap>(phase: K): this is PhaseMap[K] {
+    return this.phaseName === phase;
   }
 }

--- a/src/phases/add-enemy-buff-modifier-phase.ts
+++ b/src/phases/add-enemy-buff-modifier-phase.ts
@@ -9,6 +9,7 @@ import { Phase } from "#app/phase";
 import { globalScene } from "#app/global-scene";
 
 export class AddEnemyBuffModifierPhase extends Phase {
+  protected readonly phaseName = "AddEnemyBuffModifierPhase";
   start() {
     super.start();
 

--- a/src/phases/add-enemy-buff-modifier-phase.ts
+++ b/src/phases/add-enemy-buff-modifier-phase.ts
@@ -9,7 +9,7 @@ import { Phase } from "#app/phase";
 import { globalScene } from "#app/global-scene";
 
 export class AddEnemyBuffModifierPhase extends Phase {
-  protected readonly phaseName = "AddEnemyBuffModifierPhase";
+  public readonly phaseName = "AddEnemyBuffModifierPhase";
   start() {
     super.start();
 

--- a/src/phases/attempt-capture-phase.ts
+++ b/src/phases/attempt-capture-phase.ts
@@ -27,6 +27,7 @@ import { globalScene } from "#app/global-scene";
 import { Gender } from "#app/data/gender";
 
 export class AttemptCapturePhase extends PokemonPhase {
+  protected readonly phaseName = "AttemptCapturePhase";
   private pokeballType: PokeballType;
   private pokeball: Phaser.GameObjects.Sprite;
   private originalY: number;

--- a/src/phases/attempt-capture-phase.ts
+++ b/src/phases/attempt-capture-phase.ts
@@ -27,7 +27,7 @@ import { globalScene } from "#app/global-scene";
 import { Gender } from "#app/data/gender";
 
 export class AttemptCapturePhase extends PokemonPhase {
-  protected readonly phaseName = "AttemptCapturePhase";
+  public readonly phaseName = "AttemptCapturePhase";
   private pokeballType: PokeballType;
   private pokeball: Phaser.GameObjects.Sprite;
   private originalY: number;

--- a/src/phases/attempt-run-phase.ts
+++ b/src/phases/attempt-run-phase.ts
@@ -17,6 +17,7 @@ import { globalScene } from "#app/global-scene";
 import { SelectBiomePhase } from "./select-biome-phase";
 
 export class AttemptRunPhase extends PokemonPhase {
+  protected readonly phaseName = "AttemptRunPhase";
   /** For testing purposes: this is to force the pokemon to fail and escape */
   public forceFailEscape = false;
 

--- a/src/phases/attempt-run-phase.ts
+++ b/src/phases/attempt-run-phase.ts
@@ -17,7 +17,7 @@ import { globalScene } from "#app/global-scene";
 import { SelectBiomePhase } from "./select-biome-phase";
 
 export class AttemptRunPhase extends PokemonPhase {
-  protected readonly phaseName = "AttemptRunPhase";
+  public readonly phaseName = "AttemptRunPhase";
   /** For testing purposes: this is to force the pokemon to fail and escape */
   public forceFailEscape = false;
 

--- a/src/phases/battle-end-phase.ts
+++ b/src/phases/battle-end-phase.ts
@@ -5,6 +5,7 @@ import { BattlePhase } from "./battle-phase";
 import { GameOverPhase } from "./game-over-phase";
 
 export class BattleEndPhase extends BattlePhase {
+  protected readonly phaseName = "BattleEndPhase";
   /** If true, will increment battles won */
   isVictory: boolean;
 

--- a/src/phases/battle-end-phase.ts
+++ b/src/phases/battle-end-phase.ts
@@ -20,7 +20,7 @@ export class BattleEndPhase extends BattlePhase {
 
     // cull any extra `BattleEnd` phases from the queue.
     globalScene.phaseQueue = globalScene.phaseQueue.filter(phase => {
-      if (phase instanceof BattleEndPhase) {
+      if (phase.isXPhase("BattleEndPhase")) {
         this.isVictory ||= phase.isVictory;
         return false;
       }
@@ -29,7 +29,7 @@ export class BattleEndPhase extends BattlePhase {
     // `phaseQueuePrepend` is private, so we have to use this inefficient loop.
     while (
       globalScene.tryRemoveUnshiftedPhase(phase => {
-        if (phase instanceof BattleEndPhase) {
+        if (phase.isXPhase("BattleEndPhase")) {
           this.isVictory ||= phase.isVictory;
           return true;
         }

--- a/src/phases/battle-end-phase.ts
+++ b/src/phases/battle-end-phase.ts
@@ -20,7 +20,7 @@ export class BattleEndPhase extends BattlePhase {
 
     // cull any extra `BattleEnd` phases from the queue.
     globalScene.phaseQueue = globalScene.phaseQueue.filter(phase => {
-      if (phase.isXPhase("BattleEndPhase")) {
+      if (phase.is("BattleEndPhase")) {
         this.isVictory ||= phase.isVictory;
         return false;
       }
@@ -29,7 +29,7 @@ export class BattleEndPhase extends BattlePhase {
     // `phaseQueuePrepend` is private, so we have to use this inefficient loop.
     while (
       globalScene.tryRemoveUnshiftedPhase(phase => {
-        if (phase.isXPhase("BattleEndPhase")) {
+        if (phase.is("BattleEndPhase")) {
           this.isVictory ||= phase.isVictory;
           return true;
         }

--- a/src/phases/battle-end-phase.ts
+++ b/src/phases/battle-end-phase.ts
@@ -5,7 +5,7 @@ import { BattlePhase } from "./battle-phase";
 import { GameOverPhase } from "./game-over-phase";
 
 export class BattleEndPhase extends BattlePhase {
-  protected readonly phaseName = "BattleEndPhase";
+  public readonly phaseName = "BattleEndPhase";
   /** If true, will increment battles won */
   isVictory: boolean;
 

--- a/src/phases/battle-phase.ts
+++ b/src/phases/battle-phase.ts
@@ -2,7 +2,7 @@ import { globalScene } from "#app/global-scene";
 import { TrainerSlot } from "#enums/trainer-slot";
 import { Phase } from "#app/phase";
 
-export class BattlePhase extends Phase {
+export abstract class BattlePhase extends Phase {
   showEnemyTrainer(trainerSlot: TrainerSlot = TrainerSlot.NONE): void {
     if (!globalScene.currentBattle.trainer) {
       console.warn("Enemy trainer is missing!");

--- a/src/phases/berry-phase.ts
+++ b/src/phases/berry-phase.ts
@@ -20,7 +20,7 @@ import type Pokemon from "#app/field/pokemon";
  * Also triggers Cud Chew's "repeat berry use" effects
  */
 export class BerryPhase extends FieldPhase {
-  protected readonly phaseName = "BerryPhase";
+  public readonly phaseName = "BerryPhase";
   start() {
     super.start();
 

--- a/src/phases/berry-phase.ts
+++ b/src/phases/berry-phase.ts
@@ -20,6 +20,7 @@ import type Pokemon from "#app/field/pokemon";
  * Also triggers Cud Chew's "repeat berry use" effects
  */
 export class BerryPhase extends FieldPhase {
+  protected readonly phaseName = "BerryPhase";
   start() {
     super.start();
 

--- a/src/phases/check-status-effect-phase.ts
+++ b/src/phases/check-status-effect-phase.ts
@@ -4,6 +4,7 @@ import type { BattlerIndex } from "#app/battle";
 import { globalScene } from "#app/global-scene";
 
 export class CheckStatusEffectPhase extends Phase {
+  protected readonly phaseName = "CheckStatusEffectPhase";
   private order: BattlerIndex[];
   constructor(order: BattlerIndex[]) {
     super();

--- a/src/phases/check-status-effect-phase.ts
+++ b/src/phases/check-status-effect-phase.ts
@@ -4,7 +4,7 @@ import type { BattlerIndex } from "#app/battle";
 import { globalScene } from "#app/global-scene";
 
 export class CheckStatusEffectPhase extends Phase {
-  protected readonly phaseName = "CheckStatusEffectPhase";
+  public readonly phaseName = "CheckStatusEffectPhase";
   private order: BattlerIndex[];
   constructor(order: BattlerIndex[]) {
     super();

--- a/src/phases/check-switch-phase.ts
+++ b/src/phases/check-switch-phase.ts
@@ -10,6 +10,7 @@ import { SwitchPhase } from "./switch-phase";
 import { SwitchType } from "#enums/switch-type";
 
 export class CheckSwitchPhase extends BattlePhase {
+  protected readonly phaseName = "CheckSwitchPhase";
   protected fieldIndex: number;
   protected useName: boolean;
 

--- a/src/phases/check-switch-phase.ts
+++ b/src/phases/check-switch-phase.ts
@@ -10,7 +10,7 @@ import { SwitchPhase } from "./switch-phase";
 import { SwitchType } from "#enums/switch-type";
 
 export class CheckSwitchPhase extends BattlePhase {
-  protected readonly phaseName = "CheckSwitchPhase";
+  public readonly phaseName = "CheckSwitchPhase";
   protected fieldIndex: number;
   protected useName: boolean;
 

--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -25,6 +25,7 @@ import { ArenaTagSide } from "#app/data/arena-tag";
 import { ArenaTagType } from "#app/enums/arena-tag-type";
 
 export class CommandPhase extends FieldPhase {
+  protected readonly phaseName = "CommandPhase";
   protected fieldIndex: number;
 
   constructor(fieldIndex: number) {

--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -25,7 +25,7 @@ import { ArenaTagSide } from "#app/data/arena-tag";
 import { ArenaTagType } from "#app/enums/arena-tag-type";
 
 export class CommandPhase extends FieldPhase {
-  protected readonly phaseName = "CommandPhase";
+  public readonly phaseName = "CommandPhase";
   protected fieldIndex: number;
 
   constructor(fieldIndex: number) {

--- a/src/phases/common-anim-phase.ts
+++ b/src/phases/common-anim-phase.ts
@@ -7,7 +7,7 @@ import { PokemonPhase } from "./pokemon-phase";
 export class CommonAnimPhase extends PokemonPhase {
   // PokemonHealPhase extends CommonAnimPhase, and to make typescript happy,
   // we need to allow phaseName to be a union of the two
-  protected readonly phaseName: "CommonAnimPhase" | "PokemonHealPhase" | "WeatherEffectPhase" = "CommonAnimPhase";
+  public readonly phaseName: "CommonAnimPhase" | "PokemonHealPhase" | "WeatherEffectPhase" = "CommonAnimPhase";
   private anim: CommonAnim | null;
   private targetIndex?: BattlerIndex;
   private playOnEmptyField: boolean;

--- a/src/phases/common-anim-phase.ts
+++ b/src/phases/common-anim-phase.ts
@@ -5,6 +5,9 @@ import { CommonBattleAnim } from "#app/data/battle-anims";
 import { PokemonPhase } from "./pokemon-phase";
 
 export class CommonAnimPhase extends PokemonPhase {
+  // PokemonHealPhase extends CommonAnimPhase, and to make typescript happy,
+  // we need to allow phaseName to be a union of the two
+  protected readonly phaseName: "CommonAnimPhase" | "PokemonHealPhase" | "WeatherEffectPhase" = "CommonAnimPhase";
   private anim: CommonAnim | null;
   private targetIndex?: BattlerIndex;
   private playOnEmptyField: boolean;

--- a/src/phases/damage-anim-phase.ts
+++ b/src/phases/damage-anim-phase.ts
@@ -6,6 +6,7 @@ import { fixedInt } from "#app/utils/common";
 import { PokemonPhase } from "#app/phases/pokemon-phase";
 
 export class DamageAnimPhase extends PokemonPhase {
+  protected readonly phaseName = "DamageAnimPhase";
   private amount: number;
   private damageResult: DamageResult;
   private critical: boolean;

--- a/src/phases/damage-anim-phase.ts
+++ b/src/phases/damage-anim-phase.ts
@@ -6,7 +6,7 @@ import { fixedInt } from "#app/utils/common";
 import { PokemonPhase } from "#app/phases/pokemon-phase";
 
 export class DamageAnimPhase extends PokemonPhase {
-  protected readonly phaseName = "DamageAnimPhase";
+  public readonly phaseName = "DamageAnimPhase";
   private amount: number;
   private damageResult: DamageResult;
   private critical: boolean;

--- a/src/phases/egg-hatch-phase.ts
+++ b/src/phases/egg-hatch-phase.ts
@@ -20,6 +20,7 @@ import { doShinySparkleAnim } from "#app/field/anims";
  * Class that represents egg hatching
  */
 export class EggHatchPhase extends Phase {
+  protected readonly phaseName = "EggHatchPhase";
   /** The egg that is hatching */
   private egg: Egg;
   /** The new EggHatchData for the egg/pokemon that hatches */

--- a/src/phases/egg-hatch-phase.ts
+++ b/src/phases/egg-hatch-phase.ts
@@ -225,7 +225,7 @@ export class EggHatchPhase extends Phase {
   }
 
   end() {
-    if (globalScene.findPhase(p => p instanceof EggHatchPhase)) {
+    if (globalScene.findPhase(p => p.isXPhase("EggHatchPhase"))) {
       this.eggHatchHandler.clear();
     } else {
       globalScene.time.delayedCall(250, () => globalScene.setModifiersVisible(true));

--- a/src/phases/egg-hatch-phase.ts
+++ b/src/phases/egg-hatch-phase.ts
@@ -20,7 +20,7 @@ import { doShinySparkleAnim } from "#app/field/anims";
  * Class that represents egg hatching
  */
 export class EggHatchPhase extends Phase {
-  protected readonly phaseName = "EggHatchPhase";
+  public readonly phaseName = "EggHatchPhase";
   /** The egg that is hatching */
   private egg: Egg;
   /** The new EggHatchData for the egg/pokemon that hatches */

--- a/src/phases/egg-hatch-phase.ts
+++ b/src/phases/egg-hatch-phase.ts
@@ -225,7 +225,7 @@ export class EggHatchPhase extends Phase {
   }
 
   end() {
-    if (globalScene.findPhase(p => p.isXPhase("EggHatchPhase"))) {
+    if (globalScene.findPhase(p => p.is("EggHatchPhase"))) {
       this.eggHatchHandler.clear();
     } else {
       globalScene.time.delayedCall(250, () => globalScene.setModifiersVisible(true));

--- a/src/phases/egg-lapse-phase.ts
+++ b/src/phases/egg-lapse-phase.ts
@@ -16,7 +16,7 @@ import { EggHatchData } from "#app/data/egg-hatch-data";
  * Also handles prompts for skipping animation, and calling the egg summary phase
  */
 export class EggLapsePhase extends Phase {
-  protected readonly phaseName = "EggLapsePhase";
+  public readonly phaseName = "EggLapsePhase";
   private eggHatchData: EggHatchData[] = [];
   private readonly minEggsToSkip: number = 2;
 

--- a/src/phases/egg-lapse-phase.ts
+++ b/src/phases/egg-lapse-phase.ts
@@ -16,6 +16,7 @@ import { EggHatchData } from "#app/data/egg-hatch-data";
  * Also handles prompts for skipping animation, and calling the egg summary phase
  */
 export class EggLapsePhase extends Phase {
+  protected readonly phaseName = "EggLapsePhase";
   private eggHatchData: EggHatchData[] = [];
   private readonly minEggsToSkip: number = 2;
 

--- a/src/phases/egg-summary-phase.ts
+++ b/src/phases/egg-summary-phase.ts
@@ -9,7 +9,7 @@ import type { EggHatchData } from "#app/data/egg-hatch-data";
  * Phase is handled mostly by the egg-hatch-scene-handler UI
  */
 export class EggSummaryPhase extends Phase {
-  protected readonly phaseName = "EggSummaryPhase";
+  public readonly phaseName = "EggSummaryPhase";
   private eggHatchData: EggHatchData[];
 
   constructor(eggHatchData: EggHatchData[]) {

--- a/src/phases/egg-summary-phase.ts
+++ b/src/phases/egg-summary-phase.ts
@@ -9,6 +9,7 @@ import type { EggHatchData } from "#app/data/egg-hatch-data";
  * Phase is handled mostly by the egg-hatch-scene-handler UI
  */
 export class EggSummaryPhase extends Phase {
+  protected readonly phaseName = "EggSummaryPhase";
   private eggHatchData: EggHatchData[];
 
   constructor(eggHatchData: EggHatchData[]) {

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -47,6 +47,7 @@ import { WEIGHT_INCREMENT_ON_SPAWN_MISS } from "#app/data/mystery-encounters/mys
 import { getNatureName } from "#app/data/nature";
 
 export class EncounterPhase extends BattlePhase {
+  protected readonly phaseName = "EncounterPhase";
   private loaded: boolean;
 
   constructor(loaded = false) {

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -47,7 +47,7 @@ import { WEIGHT_INCREMENT_ON_SPAWN_MISS } from "#app/data/mystery-encounters/mys
 import { getNatureName } from "#app/data/nature";
 
 export class EncounterPhase extends BattlePhase {
-  // Union type is necessary as these
+  // Union type is necessary as this is subclassed, and typescript will otherwise complain
   protected readonly phaseName: "EncounterPhase" | "NextEncounterPhase" | "NewBiomeEncounterPhase" = "EncounterPhase";
   private loaded: boolean;
 

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -48,7 +48,7 @@ import { getNatureName } from "#app/data/nature";
 
 export class EncounterPhase extends BattlePhase {
   // Union type is necessary as this is subclassed, and typescript will otherwise complain
-  protected readonly phaseName: "EncounterPhase" | "NextEncounterPhase" | "NewBiomeEncounterPhase" = "EncounterPhase";
+  public readonly phaseName: "EncounterPhase" | "NextEncounterPhase" | "NewBiomeEncounterPhase" = "EncounterPhase";
   private loaded: boolean;
 
   constructor(loaded = false) {

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -47,7 +47,8 @@ import { WEIGHT_INCREMENT_ON_SPAWN_MISS } from "#app/data/mystery-encounters/mys
 import { getNatureName } from "#app/data/nature";
 
 export class EncounterPhase extends BattlePhase {
-  protected readonly phaseName = "EncounterPhase";
+  // Union type is necessary as these
+  protected readonly phaseName: "EncounterPhase" | "NextEncounterPhase" | "NewBiomeEncounterPhase" = "EncounterPhase";
   private loaded: boolean;
 
   constructor(loaded = false) {

--- a/src/phases/end-card-phase.ts
+++ b/src/phases/end-card-phase.ts
@@ -5,6 +5,7 @@ import { addTextObject, TextStyle } from "#app/ui/text";
 import i18next from "i18next";
 
 export class EndCardPhase extends Phase {
+  protected readonly phaseName = "EndCardPhase";
   public endCard: Phaser.GameObjects.Image;
   public text: Phaser.GameObjects.Text;
   start(): void {

--- a/src/phases/end-card-phase.ts
+++ b/src/phases/end-card-phase.ts
@@ -5,7 +5,7 @@ import { addTextObject, TextStyle } from "#app/ui/text";
 import i18next from "i18next";
 
 export class EndCardPhase extends Phase {
-  protected readonly phaseName = "EndCardPhase";
+  public readonly phaseName = "EndCardPhase";
   public endCard: Phaser.GameObjects.Image;
   public text: Phaser.GameObjects.Text;
   start(): void {

--- a/src/phases/end-evolution-phase.ts
+++ b/src/phases/end-evolution-phase.ts
@@ -3,7 +3,7 @@ import { Phase } from "#app/phase";
 import { UiMode } from "#enums/ui-mode";
 
 export class EndEvolutionPhase extends Phase {
-  protected readonly phaseName = "EndEvolutionPhase";
+  public readonly phaseName = "EndEvolutionPhase";
   start() {
     super.start();
 

--- a/src/phases/end-evolution-phase.ts
+++ b/src/phases/end-evolution-phase.ts
@@ -3,6 +3,7 @@ import { Phase } from "#app/phase";
 import { UiMode } from "#enums/ui-mode";
 
 export class EndEvolutionPhase extends Phase {
+  protected readonly phaseName = "EndEvolutionPhase";
   start() {
     super.start();
 

--- a/src/phases/enemy-command-phase.ts
+++ b/src/phases/enemy-command-phase.ts
@@ -15,7 +15,7 @@ import { BattlerTagType } from "#enums/battler-tag-type";
  * @see {@linkcode EnemyPokemon.getNextMove}
  */
 export class EnemyCommandPhase extends FieldPhase {
-  protected readonly phaseName = "EnemyCommandPhase";
+  public readonly phaseName = "EnemyCommandPhase";
   protected fieldIndex: number;
   protected skipTurn = false;
 

--- a/src/phases/enemy-command-phase.ts
+++ b/src/phases/enemy-command-phase.ts
@@ -15,6 +15,7 @@ import { BattlerTagType } from "#enums/battler-tag-type";
  * @see {@linkcode EnemyPokemon.getNextMove}
  */
 export class EnemyCommandPhase extends FieldPhase {
+  protected readonly phaseName = "EnemyCommandPhase";
   protected fieldIndex: number;
   protected skipTurn = false;
 

--- a/src/phases/evolution-phase.ts
+++ b/src/phases/evolution-phase.ts
@@ -19,6 +19,9 @@ import { EndEvolutionPhase } from "#app/phases/end-evolution-phase";
 import { EVOLVE_MOVE } from "#app/data/balance/pokemon-level-moves";
 
 export class EvolutionPhase extends Phase {
+  // FormChangePhase inherits from this, but EvolutionPhase is not abstract.
+  // We have to use the union here
+  protected readonly phaseName: "EvolutionPhase" | "FormChangePhase" = "EvolutionPhase";
   protected pokemon: PlayerPokemon;
   protected lastLevel: number;
 

--- a/src/phases/evolution-phase.ts
+++ b/src/phases/evolution-phase.ts
@@ -21,7 +21,7 @@ import { EVOLVE_MOVE } from "#app/data/balance/pokemon-level-moves";
 export class EvolutionPhase extends Phase {
   // FormChangePhase inherits from this, but EvolutionPhase is not abstract.
   // We have to use the union here
-  protected readonly phaseName: "EvolutionPhase" | "FormChangePhase" = "EvolutionPhase";
+  public readonly phaseName: "EvolutionPhase" | "FormChangePhase" = "EvolutionPhase";
   protected pokemon: PlayerPokemon;
   protected lastLevel: number;
 

--- a/src/phases/exp-phase.ts
+++ b/src/phases/exp-phase.ts
@@ -7,6 +7,7 @@ import { PlayerPartyMemberPokemonPhase } from "./player-party-member-pokemon-pha
 import { LevelUpPhase } from "./level-up-phase";
 
 export class ExpPhase extends PlayerPartyMemberPokemonPhase {
+  protected readonly phaseName = "ExpPhase";
   private expValue: number;
 
   constructor(partyMemberIndex: number, expValue: number) {

--- a/src/phases/exp-phase.ts
+++ b/src/phases/exp-phase.ts
@@ -7,7 +7,7 @@ import { PlayerPartyMemberPokemonPhase } from "./player-party-member-pokemon-pha
 import { LevelUpPhase } from "./level-up-phase";
 
 export class ExpPhase extends PlayerPartyMemberPokemonPhase {
-  protected readonly phaseName = "ExpPhase";
+  public readonly phaseName = "ExpPhase";
   private expValue: number;
 
   constructor(partyMemberIndex: number, expValue: number) {

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -35,6 +35,7 @@ import { FRIENDSHIP_LOSS_FROM_FAINT } from "#app/data/balance/starters";
 import { BattlerTagType } from "#enums/battler-tag-type";
 
 export class FaintPhase extends PokemonPhase {
+  protected readonly phaseName = "FaintPhase";
   /**
    * Whether or not instant revive should be prevented
    */

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -35,7 +35,7 @@ import { FRIENDSHIP_LOSS_FROM_FAINT } from "#app/data/balance/starters";
 import { BattlerTagType } from "#enums/battler-tag-type";
 
 export class FaintPhase extends PokemonPhase {
-  protected readonly phaseName = "FaintPhase";
+  public readonly phaseName = "FaintPhase";
   /**
    * Whether or not instant revive should be prevented
    */

--- a/src/phases/form-change-phase.ts
+++ b/src/phases/form-change-phase.ts
@@ -13,7 +13,7 @@ import { BattlerTagType } from "#enums/battler-tag-type";
 import { SpeciesFormKey } from "#enums/species-form-key";
 
 export class FormChangePhase extends EvolutionPhase {
-  protected readonly phaseName = "FormChangePhase";
+  public readonly phaseName = "FormChangePhase";
   private formChange: SpeciesFormChange;
   private modal: boolean;
 

--- a/src/phases/form-change-phase.ts
+++ b/src/phases/form-change-phase.ts
@@ -13,6 +13,7 @@ import { BattlerTagType } from "#enums/battler-tag-type";
 import { SpeciesFormKey } from "#enums/species-form-key";
 
 export class FormChangePhase extends EvolutionPhase {
+  protected readonly phaseName = "FormChangePhase";
   private formChange: SpeciesFormChange;
   private modal: boolean;
 

--- a/src/phases/game-over-modifier-reward-phase.ts
+++ b/src/phases/game-over-modifier-reward-phase.ts
@@ -4,7 +4,7 @@ import i18next from "i18next";
 import { ModifierRewardPhase } from "./modifier-reward-phase";
 
 export class GameOverModifierRewardPhase extends ModifierRewardPhase {
-  protected readonly phaseName = "GameOverModifierRewardPhase";
+  public readonly phaseName = "GameOverModifierRewardPhase";
   doReward(): Promise<void> {
     return new Promise<void>(resolve => {
       const newModifier = this.modifierType.newModifier();

--- a/src/phases/game-over-modifier-reward-phase.ts
+++ b/src/phases/game-over-modifier-reward-phase.ts
@@ -4,6 +4,7 @@ import i18next from "i18next";
 import { ModifierRewardPhase } from "./modifier-reward-phase";
 
 export class GameOverModifierRewardPhase extends ModifierRewardPhase {
+  protected readonly phaseName = "GameOverModifierRewardPhase";
   doReward(): Promise<void> {
     return new Promise<void>(resolve => {
       const newModifier = this.modifierType.newModifier();

--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -34,7 +34,7 @@ import { pokerogueApi } from "#app/plugins/api/pokerogue-api";
 import { MessagePhase } from "./message-phase";
 
 export class GameOverPhase extends BattlePhase {
-  protected readonly phaseName = "GameOverPhase";
+  public readonly phaseName = "GameOverPhase";
   private isVictory: boolean;
   private firstRibbons: PokemonSpecies[] = [];
 

--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -34,6 +34,7 @@ import { pokerogueApi } from "#app/plugins/api/pokerogue-api";
 import { MessagePhase } from "./message-phase";
 
 export class GameOverPhase extends BattlePhase {
+  protected readonly phaseName = "GameOverPhase";
   private isVictory: boolean;
   private firstRibbons: PokemonSpecies[] = [];
 

--- a/src/phases/hide-ability-phase.ts
+++ b/src/phases/hide-ability-phase.ts
@@ -2,6 +2,7 @@ import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
 
 export class HideAbilityPhase extends Phase {
+  protected readonly phaseName = "HideAbilityPhase";
   start() {
     super.start();
 

--- a/src/phases/hide-ability-phase.ts
+++ b/src/phases/hide-ability-phase.ts
@@ -2,7 +2,7 @@ import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
 
 export class HideAbilityPhase extends Phase {
-  protected readonly phaseName = "HideAbilityPhase";
+  public readonly phaseName = "HideAbilityPhase";
   start() {
     super.start();
 

--- a/src/phases/hide-party-exp-bar-phase.ts
+++ b/src/phases/hide-party-exp-bar-phase.ts
@@ -2,7 +2,7 @@ import { globalScene } from "#app/global-scene";
 import { BattlePhase } from "./battle-phase";
 
 export class HidePartyExpBarPhase extends BattlePhase {
-  protected readonly phaseName = "HidePartyExpBarPhase";
+  public readonly phaseName = "HidePartyExpBarPhase";
   start() {
     super.start();
 

--- a/src/phases/hide-party-exp-bar-phase.ts
+++ b/src/phases/hide-party-exp-bar-phase.ts
@@ -2,6 +2,7 @@ import { globalScene } from "#app/global-scene";
 import { BattlePhase } from "./battle-phase";
 
 export class HidePartyExpBarPhase extends BattlePhase {
+  protected readonly phaseName = "HidePartyExpBarPhase";
   start() {
     super.start();
 

--- a/src/phases/learn-move-phase.ts
+++ b/src/phases/learn-move-phase.ts
@@ -12,7 +12,6 @@ import { UiMode } from "#enums/ui-mode";
 import i18next from "i18next";
 import { PlayerPartyMemberPokemonPhase } from "#app/phases/player-party-member-pokemon-phase";
 import type Pokemon from "#app/field/pokemon";
-import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
 
 export enum LearnMoveType {
   /** For learning a move via level-up, evolution, or other non-item-based event */
@@ -196,7 +195,7 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
         pokemon.usedTMs = [];
       }
       pokemon.usedTMs.push(this.moveId);
-      globalScene.tryRemovePhase(phase => phase instanceof SelectModifierPhase);
+      globalScene.tryRemovePhase(phase => phase.isXPhase("SelectModifierPhase"));
     } else if (this.learnMoveType === LearnMoveType.MEMORY) {
       if (this.cost !== -1) {
         if (!Overrides.WAIVE_ROLL_FEE_OVERRIDE) {
@@ -206,7 +205,7 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
         }
         globalScene.playSound("se/buy");
       } else {
-        globalScene.tryRemovePhase(phase => phase instanceof SelectModifierPhase);
+        globalScene.tryRemovePhase(phase => phase.isXPhase("SelectModifierPhase"));
       }
     }
     pokemon.setMove(index, this.moveId);

--- a/src/phases/learn-move-phase.ts
+++ b/src/phases/learn-move-phase.ts
@@ -24,6 +24,7 @@ export enum LearnMoveType {
 }
 
 export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
+  protected readonly phaseName = "LearnMovePhase";
   private moveId: MoveId;
   private messageMode: UiMode;
   private learnMoveType: LearnMoveType;

--- a/src/phases/learn-move-phase.ts
+++ b/src/phases/learn-move-phase.ts
@@ -195,7 +195,7 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
         pokemon.usedTMs = [];
       }
       pokemon.usedTMs.push(this.moveId);
-      globalScene.tryRemovePhase(phase => phase.isXPhase("SelectModifierPhase"));
+      globalScene.tryRemovePhase(phase => phase.is("SelectModifierPhase"));
     } else if (this.learnMoveType === LearnMoveType.MEMORY) {
       if (this.cost !== -1) {
         if (!Overrides.WAIVE_ROLL_FEE_OVERRIDE) {
@@ -205,7 +205,7 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
         }
         globalScene.playSound("se/buy");
       } else {
-        globalScene.tryRemovePhase(phase => phase.isXPhase("SelectModifierPhase"));
+        globalScene.tryRemovePhase(phase => phase.is("SelectModifierPhase"));
       }
     }
     pokemon.setMove(index, this.moveId);

--- a/src/phases/learn-move-phase.ts
+++ b/src/phases/learn-move-phase.ts
@@ -23,7 +23,7 @@ export enum LearnMoveType {
 }
 
 export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
-  protected readonly phaseName = "LearnMovePhase";
+  public readonly phaseName = "LearnMovePhase";
   private moveId: MoveId;
   private messageMode: UiMode;
   private learnMoveType: LearnMoveType;

--- a/src/phases/level-cap-phase.ts
+++ b/src/phases/level-cap-phase.ts
@@ -4,6 +4,7 @@ import i18next from "i18next";
 import { FieldPhase } from "./field-phase";
 
 export class LevelCapPhase extends FieldPhase {
+  protected readonly phaseName = "LevelCapPhase";
   start(): void {
     super.start();
 

--- a/src/phases/level-cap-phase.ts
+++ b/src/phases/level-cap-phase.ts
@@ -4,7 +4,7 @@ import i18next from "i18next";
 import { FieldPhase } from "./field-phase";
 
 export class LevelCapPhase extends FieldPhase {
-  protected readonly phaseName = "LevelCapPhase";
+  public readonly phaseName = "LevelCapPhase";
   start(): void {
     super.start();
 

--- a/src/phases/level-up-phase.ts
+++ b/src/phases/level-up-phase.ts
@@ -10,6 +10,7 @@ import { NumberHolder } from "#app/utils/common";
 import i18next from "i18next";
 
 export class LevelUpPhase extends PlayerPartyMemberPokemonPhase {
+  protected readonly phaseName = "LevelUpPhase";
   protected lastLevel: number;
   protected level: number;
   protected pokemon: PlayerPokemon = this.getPlayerPokemon();

--- a/src/phases/level-up-phase.ts
+++ b/src/phases/level-up-phase.ts
@@ -10,7 +10,7 @@ import { NumberHolder } from "#app/utils/common";
 import i18next from "i18next";
 
 export class LevelUpPhase extends PlayerPartyMemberPokemonPhase {
-  protected readonly phaseName = "LevelUpPhase";
+  public readonly phaseName = "LevelUpPhase";
   protected lastLevel: number;
   protected level: number;
   protected pokemon: PlayerPokemon = this.getPlayerPokemon();

--- a/src/phases/load-move-anim-phase.ts
+++ b/src/phases/load-move-anim-phase.ts
@@ -8,6 +8,7 @@ import { Phase } from "#app/phase";
  * isn't already loaded (e.g. for Metronome)
  */
 export class LoadMoveAnimPhase extends Phase {
+  protected readonly phaseName = "LoadMoveAnimPhase";
   constructor(protected moveId: MoveId) {
     super();
   }

--- a/src/phases/load-move-anim-phase.ts
+++ b/src/phases/load-move-anim-phase.ts
@@ -8,7 +8,7 @@ import { Phase } from "#app/phase";
  * isn't already loaded (e.g. for Metronome)
  */
 export class LoadMoveAnimPhase extends Phase {
-  protected readonly phaseName = "LoadMoveAnimPhase";
+  public readonly phaseName = "LoadMoveAnimPhase";
   constructor(protected moveId: MoveId) {
     super();
   }

--- a/src/phases/login-phase.ts
+++ b/src/phases/login-phase.ts
@@ -11,6 +11,7 @@ import { SelectGenderPhase } from "./select-gender-phase";
 import { UnavailablePhase } from "./unavailable-phase";
 
 export class LoginPhase extends Phase {
+  protected readonly phaseName = "LoginPhase";
   private showText: boolean;
 
   constructor(showText = true) {

--- a/src/phases/login-phase.ts
+++ b/src/phases/login-phase.ts
@@ -11,7 +11,7 @@ import { SelectGenderPhase } from "./select-gender-phase";
 import { UnavailablePhase } from "./unavailable-phase";
 
 export class LoginPhase extends Phase {
-  protected readonly phaseName = "LoginPhase";
+  public readonly phaseName = "LoginPhase";
   private showText: boolean;
 
   constructor(showText = true) {

--- a/src/phases/message-phase.ts
+++ b/src/phases/message-phase.ts
@@ -2,6 +2,7 @@ import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
 
 export class MessagePhase extends Phase {
+  protected readonly phaseName = "MessagePhase";
   private text: string;
   private callbackDelay?: number | null;
   private prompt?: boolean | null;

--- a/src/phases/message-phase.ts
+++ b/src/phases/message-phase.ts
@@ -2,7 +2,7 @@ import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
 
 export class MessagePhase extends Phase {
-  protected readonly phaseName = "MessagePhase";
+  public readonly phaseName = "MessagePhase";
   private text: string;
   private callbackDelay?: number | null;
   private prompt?: boolean | null;

--- a/src/phases/modifier-reward-phase.ts
+++ b/src/phases/modifier-reward-phase.ts
@@ -5,6 +5,9 @@ import i18next from "i18next";
 import { BattlePhase } from "./battle-phase";
 
 export class ModifierRewardPhase extends BattlePhase {
+  // RibbonModifierRewardPhase extends ModifierRewardPhase and to make typescript happy
+  // we need to use a union type here
+  protected readonly phaseName: "ModifierRewardPhase" | "RibbonModifierRewardPhase" = "ModifierRewardPhase";
   protected modifierType: ModifierType;
 
   constructor(modifierTypeFunc: ModifierTypeFunc) {

--- a/src/phases/modifier-reward-phase.ts
+++ b/src/phases/modifier-reward-phase.ts
@@ -7,7 +7,7 @@ import { BattlePhase } from "./battle-phase";
 export class ModifierRewardPhase extends BattlePhase {
   // RibbonModifierRewardPhase extends ModifierRewardPhase and to make typescript happy
   // we need to use a union type here
-  protected readonly phaseName: "ModifierRewardPhase" | "RibbonModifierRewardPhase" | "GameOverModifierRewardPhase" =
+  public readonly phaseName: "ModifierRewardPhase" | "RibbonModifierRewardPhase" | "GameOverModifierRewardPhase" =
     "ModifierRewardPhase";
   protected modifierType: ModifierType;
 

--- a/src/phases/modifier-reward-phase.ts
+++ b/src/phases/modifier-reward-phase.ts
@@ -7,7 +7,8 @@ import { BattlePhase } from "./battle-phase";
 export class ModifierRewardPhase extends BattlePhase {
   // RibbonModifierRewardPhase extends ModifierRewardPhase and to make typescript happy
   // we need to use a union type here
-  protected readonly phaseName: "ModifierRewardPhase" | "RibbonModifierRewardPhase" = "ModifierRewardPhase";
+  protected readonly phaseName: "ModifierRewardPhase" | "RibbonModifierRewardPhase" | "GameOverModifierRewardPhase" =
+    "ModifierRewardPhase";
   protected modifierType: ModifierType;
 
   constructor(modifierTypeFunc: ModifierTypeFunc) {

--- a/src/phases/money-reward-phase.ts
+++ b/src/phases/money-reward-phase.ts
@@ -6,7 +6,7 @@ import { NumberHolder } from "#app/utils/common";
 import { BattlePhase } from "./battle-phase";
 
 export class MoneyRewardPhase extends BattlePhase {
-  protected readonly phaseName = "MoneyRewardPhase";
+  public readonly phaseName = "MoneyRewardPhase";
   private moneyMultiplier: number;
 
   constructor(moneyMultiplier: number) {

--- a/src/phases/money-reward-phase.ts
+++ b/src/phases/money-reward-phase.ts
@@ -6,6 +6,7 @@ import { NumberHolder } from "#app/utils/common";
 import { BattlePhase } from "./battle-phase";
 
 export class MoneyRewardPhase extends BattlePhase {
+  protected readonly phaseName = "MoneyRewardPhase";
   private moneyMultiplier: number;
 
   constructor(moneyMultiplier: number) {

--- a/src/phases/move-anim-phase.ts
+++ b/src/phases/move-anim-phase.ts
@@ -5,14 +5,14 @@ import { Phase } from "#app/phase";
  * Plays the given {@linkcode MoveAnim} sequentially.
  */
 export class MoveAnimPhase<Anim extends MoveAnim> extends Phase {
+  public readonly phaseName = "MoveAnimPhase";
+
   constructor(
     protected anim: Anim,
     protected onSubstitute = false,
   ) {
     super();
   }
-
-  public readonly phaseName = "MoveAnimPhase";
 
   public override start(): void {
     super.start();

--- a/src/phases/move-anim-phase.ts
+++ b/src/phases/move-anim-phase.ts
@@ -12,7 +12,7 @@ export class MoveAnimPhase<Anim extends MoveAnim> extends Phase {
     super();
   }
 
-  protected readonly phaseName = "MoveAnimPhase";
+  public readonly phaseName = "MoveAnimPhase";
 
   public override start(): void {
     super.start();

--- a/src/phases/move-anim-phase.ts
+++ b/src/phases/move-anim-phase.ts
@@ -12,6 +12,8 @@ export class MoveAnimPhase<Anim extends MoveAnim> extends Phase {
     super();
   }
 
+  protected readonly phaseName = "MoveAnimPhase";
+
   public override start(): void {
     super.start();
 

--- a/src/phases/move-charge-phase.ts
+++ b/src/phases/move-charge-phase.ts
@@ -16,6 +16,7 @@ import { MoveEndPhase } from "#app/phases/move-end-phase";
  * @extends {@linkcode PokemonPhase}
  */
 export class MoveChargePhase extends PokemonPhase {
+  protected readonly phaseName = "MoveChargePhase";
   /** The move instance that this phase applies */
   public move: PokemonMove;
   /** The field index targeted by the move (Charging moves assume single target) */

--- a/src/phases/move-charge-phase.ts
+++ b/src/phases/move-charge-phase.ts
@@ -62,7 +62,7 @@ export class MoveChargePhase extends PokemonPhase {
 
       if (instantCharge.value) {
         // this MoveEndPhase will be duplicated by the queued MovePhase if not removed
-        globalScene.tryRemovePhase(phase => phase.isXPhase("MoveEndPhase") && phase.getPokemon() === user);
+        globalScene.tryRemovePhase(phase => phase.is("MoveEndPhase") && phase.getPokemon() === user);
         // queue a new MovePhase for this move's attack phase
         globalScene.unshiftPhase(new MovePhase(user, [this.targetIndex], this.move, false));
       } else {

--- a/src/phases/move-charge-phase.ts
+++ b/src/phases/move-charge-phase.ts
@@ -15,7 +15,7 @@ import { BattlerTagType } from "#enums/battler-tag-type";
  * @extends {@linkcode PokemonPhase}
  */
 export class MoveChargePhase extends PokemonPhase {
-  protected readonly phaseName = "MoveChargePhase";
+  public readonly phaseName = "MoveChargePhase";
   /** The move instance that this phase applies */
   public move: PokemonMove;
   /** The field index targeted by the move (Charging moves assume single target) */

--- a/src/phases/move-charge-phase.ts
+++ b/src/phases/move-charge-phase.ts
@@ -9,7 +9,6 @@ import { BooleanHolder } from "#app/utils/common";
 import { MovePhase } from "#app/phases/move-phase";
 import { PokemonPhase } from "#app/phases/pokemon-phase";
 import { BattlerTagType } from "#enums/battler-tag-type";
-import { MoveEndPhase } from "#app/phases/move-end-phase";
 
 /**
  * Phase for the "charging turn" of two-turn moves (e.g. Dig).
@@ -63,7 +62,7 @@ export class MoveChargePhase extends PokemonPhase {
 
       if (instantCharge.value) {
         // this MoveEndPhase will be duplicated by the queued MovePhase if not removed
-        globalScene.tryRemovePhase(phase => phase instanceof MoveEndPhase && phase.getPokemon() === user);
+        globalScene.tryRemovePhase(phase => phase.isXPhase("MoveEndPhase") && phase.getPokemon() === user);
         // queue a new MovePhase for this move's attack phase
         globalScene.unshiftPhase(new MovePhase(user, [this.targetIndex], this.move, false));
       } else {

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -82,7 +82,7 @@ import { DamageAchv } from "#app/system/achv";
 type HitCheckEntry = [HitCheckResult, TypeDamageMultiplier];
 
 export class MoveEffectPhase extends PokemonPhase {
-  protected readonly phaseName = "MoveEffectPhase";
+  public readonly phaseName = "MoveEffectPhase";
   public move: Move;
   private virtual = false;
   protected targets: BattlerIndex[];

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -82,6 +82,7 @@ import { DamageAchv } from "#app/system/achv";
 type HitCheckEntry = [HitCheckResult, TypeDamageMultiplier];
 
 export class MoveEffectPhase extends PokemonPhase {
+  protected readonly phaseName = "MoveEffectPhase";
   public move: Move;
   private virtual = false;
   protected targets: BattlerIndex[];

--- a/src/phases/move-end-phase.ts
+++ b/src/phases/move-end-phase.ts
@@ -6,7 +6,7 @@ import { applyPostSummonAbAttrs, PostSummonRemoveEffectAbAttr } from "#app/data/
 import type Pokemon from "#app/field/pokemon";
 
 export class MoveEndPhase extends PokemonPhase {
-  protected readonly phaseName = "MoveEndPhase";
+  public readonly phaseName = "MoveEndPhase";
   private wasFollowUp: boolean;
 
   /** Targets from the preceding MovePhase */

--- a/src/phases/move-end-phase.ts
+++ b/src/phases/move-end-phase.ts
@@ -6,6 +6,7 @@ import { applyPostSummonAbAttrs, PostSummonRemoveEffectAbAttr } from "#app/data/
 import type Pokemon from "#app/field/pokemon";
 
 export class MoveEndPhase extends PokemonPhase {
+  protected readonly phaseName = "MoveEndPhase";
   private wasFollowUp: boolean;
 
   /** Targets from the preceding MovePhase */

--- a/src/phases/move-header-phase.ts
+++ b/src/phases/move-header-phase.ts
@@ -4,7 +4,7 @@ import type Pokemon from "#app/field/pokemon";
 import { BattlePhase } from "./battle-phase";
 
 export class MoveHeaderPhase extends BattlePhase {
-  protected readonly phaseName = "MoveHeaderPhase";
+  public readonly phaseName = "MoveHeaderPhase";
   public pokemon: Pokemon;
   public move: PokemonMove;
 

--- a/src/phases/move-header-phase.ts
+++ b/src/phases/move-header-phase.ts
@@ -4,6 +4,7 @@ import type Pokemon from "#app/field/pokemon";
 import { BattlePhase } from "./battle-phase";
 
 export class MoveHeaderPhase extends BattlePhase {
+  protected readonly phaseName = "MoveHeaderPhase";
   public pokemon: Pokemon;
   public move: PokemonMove;
 

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -52,6 +52,7 @@ import { StatusEffect } from "#enums/status-effect";
 import i18next from "i18next";
 
 export class MovePhase extends BattlePhase {
+  protected readonly phaseName = "MovePhase";
   protected _pokemon: Pokemon;
   protected _move: PokemonMove;
   protected _targets: BattlerIndex[];

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -52,7 +52,7 @@ import { StatusEffect } from "#enums/status-effect";
 import i18next from "i18next";
 
 export class MovePhase extends BattlePhase {
-  protected readonly phaseName = "MovePhase";
+  public readonly phaseName = "MovePhase";
   protected _pokemon: Pokemon;
   protected _move: PokemonMove;
   protected _targets: BattlerIndex[];

--- a/src/phases/mystery-encounter-phases.ts
+++ b/src/phases/mystery-encounter-phases.ts
@@ -6,7 +6,6 @@ import { getEncounterText } from "#app/data/mystery-encounters/utils/encounter-d
 import { CheckSwitchPhase } from "#app/phases/check-switch-phase";
 import { GameOverPhase } from "#app/phases/game-over-phase";
 import { NewBattlePhase } from "#app/phases/new-battle-phase";
-import { PostTurnStatusEffectPhase } from "#app/phases/post-turn-status-effect-phase";
 import { ReturnPhase } from "#app/phases/return-phase";
 import { ScanIvsPhase } from "#app/phases/scan-ivs-phase";
 import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
@@ -248,8 +247,8 @@ export class MysteryEncounterBattleStartCleanupPhase extends Phase {
     });
 
     // Remove any status tick phases
-    while (globalScene.findPhase(p => p instanceof PostTurnStatusEffectPhase)) {
-      globalScene.tryRemovePhase(p => p instanceof PostTurnStatusEffectPhase);
+    while (globalScene.findPhase(p => p.isXPhase("PostTurnStatusEffectPhase"))) {
+      globalScene.tryRemovePhase(p => p.isXPhase("PostTurnStatusEffectPhase"));
     }
 
     // The total number of Pokemon in the player's party that can legally fight
@@ -563,7 +562,7 @@ export class MysteryEncounterRewardsPhase extends Phase {
     if (encounter.doEncounterRewards) {
       encounter.doEncounterRewards();
     } else if (this.addHealPhase) {
-      globalScene.tryRemovePhase(p => p instanceof SelectModifierPhase);
+      globalScene.tryRemovePhase(p => p.isXPhase("SelectModifierPhase"));
       globalScene.unshiftPhase(
         new SelectModifierPhase(0, undefined, {
           fillRemaining: false,

--- a/src/phases/mystery-encounter-phases.ts
+++ b/src/phases/mystery-encounter-phases.ts
@@ -247,8 +247,8 @@ export class MysteryEncounterBattleStartCleanupPhase extends Phase {
     });
 
     // Remove any status tick phases
-    while (globalScene.findPhase(p => p.isXPhase("PostTurnStatusEffectPhase"))) {
-      globalScene.tryRemovePhase(p => p.isXPhase("PostTurnStatusEffectPhase"));
+    while (globalScene.findPhase(p => p.is("PostTurnStatusEffectPhase"))) {
+      globalScene.tryRemovePhase(p => p.is("PostTurnStatusEffectPhase"));
     }
 
     // The total number of Pokemon in the player's party that can legally fight
@@ -562,7 +562,7 @@ export class MysteryEncounterRewardsPhase extends Phase {
     if (encounter.doEncounterRewards) {
       encounter.doEncounterRewards();
     } else if (this.addHealPhase) {
-      globalScene.tryRemovePhase(p => p.isXPhase("SelectModifierPhase"));
+      globalScene.tryRemovePhase(p => p.is("SelectModifierPhase"));
       globalScene.unshiftPhase(
         new SelectModifierPhase(0, undefined, {
           fillRemaining: false,

--- a/src/phases/mystery-encounter-phases.ts
+++ b/src/phases/mystery-encounter-phases.ts
@@ -39,6 +39,7 @@ import { SelectBiomePhase } from "./select-biome-phase";
  * - Queuing of the {@linkcode MysteryEncounterOptionSelectedPhase}
  */
 export class MysteryEncounterPhase extends Phase {
+  protected readonly phaseName = "MysteryEncounterPhase";
   private readonly FIRST_DIALOGUE_PROMPT_DELAY = 300;
   optionSelectSettings?: OptionSelectSettings;
 
@@ -180,6 +181,7 @@ export class MysteryEncounterPhase extends Phase {
  * Any phase that is meant to follow this one MUST be queued via the onOptionSelect() logic of the selected option
  */
 export class MysteryEncounterOptionSelectedPhase extends Phase {
+  protected readonly phaseName = "MysteryEncounterOptionSelectedPhase";
   onOptionSelect: OptionPhaseCallback;
 
   constructor() {
@@ -221,6 +223,7 @@ export class MysteryEncounterOptionSelectedPhase extends Phase {
  * See {@linkcode TurnEndPhase} for more details
  */
 export class MysteryEncounterBattleStartCleanupPhase extends Phase {
+  protected readonly phaseName = "MysteryEncounterBattleStartCleanupPhase";
   /**
    * Cleans up `TURN_END` tags, any {@linkcode PostTurnStatusEffectPhase}s, checks for Pokemon switches, then continues
    */
@@ -284,6 +287,7 @@ export class MysteryEncounterBattleStartCleanupPhase extends Phase {
  * - Queue the {@linkcode SummonPhase}s, {@linkcode PostSummonPhase}s, etc., required to initialize the phase queue for a battle
  */
 export class MysteryEncounterBattlePhase extends Phase {
+  protected readonly phaseName = "MysteryEncounterBattlePhase";
   disableSwitch: boolean;
 
   constructor(disableSwitch = false) {
@@ -513,6 +517,7 @@ export class MysteryEncounterBattlePhase extends Phase {
  * - Queuing of the {@linkcode PostMysteryEncounterPhase}
  */
 export class MysteryEncounterRewardsPhase extends Phase {
+  protected readonly phaseName = "MysteryEncounterRewardsPhase";
   addHealPhase: boolean;
 
   constructor(addHealPhase = false) {
@@ -580,6 +585,7 @@ export class MysteryEncounterRewardsPhase extends Phase {
  * - Queuing of the next wave
  */
 export class PostMysteryEncounterPhase extends Phase {
+  protected readonly phaseName = "PostMysteryEncounterPhase";
   private readonly FIRST_DIALOGUE_PROMPT_DELAY = 750;
   onPostOptionSelect?: OptionPhaseCallback;
 

--- a/src/phases/mystery-encounter-phases.ts
+++ b/src/phases/mystery-encounter-phases.ts
@@ -38,7 +38,7 @@ import { SelectBiomePhase } from "./select-biome-phase";
  * - Queuing of the {@linkcode MysteryEncounterOptionSelectedPhase}
  */
 export class MysteryEncounterPhase extends Phase {
-  protected readonly phaseName = "MysteryEncounterPhase";
+  public readonly phaseName = "MysteryEncounterPhase";
   private readonly FIRST_DIALOGUE_PROMPT_DELAY = 300;
   optionSelectSettings?: OptionSelectSettings;
 
@@ -180,7 +180,7 @@ export class MysteryEncounterPhase extends Phase {
  * Any phase that is meant to follow this one MUST be queued via the onOptionSelect() logic of the selected option
  */
 export class MysteryEncounterOptionSelectedPhase extends Phase {
-  protected readonly phaseName = "MysteryEncounterOptionSelectedPhase";
+  public readonly phaseName = "MysteryEncounterOptionSelectedPhase";
   onOptionSelect: OptionPhaseCallback;
 
   constructor() {
@@ -222,7 +222,7 @@ export class MysteryEncounterOptionSelectedPhase extends Phase {
  * See {@linkcode TurnEndPhase} for more details
  */
 export class MysteryEncounterBattleStartCleanupPhase extends Phase {
-  protected readonly phaseName = "MysteryEncounterBattleStartCleanupPhase";
+  public readonly phaseName = "MysteryEncounterBattleStartCleanupPhase";
   /**
    * Cleans up `TURN_END` tags, any {@linkcode PostTurnStatusEffectPhase}s, checks for Pokemon switches, then continues
    */
@@ -286,7 +286,7 @@ export class MysteryEncounterBattleStartCleanupPhase extends Phase {
  * - Queue the {@linkcode SummonPhase}s, {@linkcode PostSummonPhase}s, etc., required to initialize the phase queue for a battle
  */
 export class MysteryEncounterBattlePhase extends Phase {
-  protected readonly phaseName = "MysteryEncounterBattlePhase";
+  public readonly phaseName = "MysteryEncounterBattlePhase";
   disableSwitch: boolean;
 
   constructor(disableSwitch = false) {
@@ -516,7 +516,7 @@ export class MysteryEncounterBattlePhase extends Phase {
  * - Queuing of the {@linkcode PostMysteryEncounterPhase}
  */
 export class MysteryEncounterRewardsPhase extends Phase {
-  protected readonly phaseName = "MysteryEncounterRewardsPhase";
+  public readonly phaseName = "MysteryEncounterRewardsPhase";
   addHealPhase: boolean;
 
   constructor(addHealPhase = false) {
@@ -584,7 +584,7 @@ export class MysteryEncounterRewardsPhase extends Phase {
  * - Queuing of the next wave
  */
 export class PostMysteryEncounterPhase extends Phase {
-  protected readonly phaseName = "PostMysteryEncounterPhase";
+  public readonly phaseName = "PostMysteryEncounterPhase";
   private readonly FIRST_DIALOGUE_PROMPT_DELAY = 750;
   onPostOptionSelect?: OptionPhaseCallback;
 

--- a/src/phases/new-battle-phase.ts
+++ b/src/phases/new-battle-phase.ts
@@ -2,7 +2,7 @@ import { globalScene } from "#app/global-scene";
 import { BattlePhase } from "./battle-phase";
 
 export class NewBattlePhase extends BattlePhase {
-  protected readonly phaseName = "NewBattlePhase";
+  public readonly phaseName = "NewBattlePhase";
   start() {
     super.start();
 

--- a/src/phases/new-battle-phase.ts
+++ b/src/phases/new-battle-phase.ts
@@ -7,9 +7,9 @@ export class NewBattlePhase extends BattlePhase {
     super.start();
 
     // cull any extra `NewBattle` phases from the queue.
-    globalScene.phaseQueue = globalScene.phaseQueue.filter(phase => !phase.isXPhase("NewBattlePhase"));
+    globalScene.phaseQueue = globalScene.phaseQueue.filter(phase => !phase.is("NewBattlePhase"));
     // `phaseQueuePrepend` is private, so we have to use this inefficient loop.
-    while (globalScene.tryRemoveUnshiftedPhase(phase => phase.isXPhase("NewBattlePhase"))) {}
+    while (globalScene.tryRemoveUnshiftedPhase(phase => phase.is("NewBattlePhase"))) {}
 
     globalScene.newBattle();
 

--- a/src/phases/new-battle-phase.ts
+++ b/src/phases/new-battle-phase.ts
@@ -7,9 +7,9 @@ export class NewBattlePhase extends BattlePhase {
     super.start();
 
     // cull any extra `NewBattle` phases from the queue.
-    globalScene.phaseQueue = globalScene.phaseQueue.filter(phase => !(phase instanceof NewBattlePhase));
+    globalScene.phaseQueue = globalScene.phaseQueue.filter(phase => !phase.isXPhase("NewBattlePhase"));
     // `phaseQueuePrepend` is private, so we have to use this inefficient loop.
-    while (globalScene.tryRemoveUnshiftedPhase(phase => phase instanceof NewBattlePhase)) {}
+    while (globalScene.tryRemoveUnshiftedPhase(phase => phase.isXPhase("NewBattlePhase"))) {}
 
     globalScene.newBattle();
 

--- a/src/phases/new-battle-phase.ts
+++ b/src/phases/new-battle-phase.ts
@@ -2,6 +2,7 @@ import { globalScene } from "#app/global-scene";
 import { BattlePhase } from "./battle-phase";
 
 export class NewBattlePhase extends BattlePhase {
+  protected readonly phaseName = "NewBattlePhase";
   start() {
     super.start();
 

--- a/src/phases/new-biome-encounter-phase.ts
+++ b/src/phases/new-biome-encounter-phase.ts
@@ -4,7 +4,7 @@ import { getRandomWeatherType } from "#app/data/weather";
 import { NextEncounterPhase } from "./next-encounter-phase";
 
 export class NewBiomeEncounterPhase extends NextEncounterPhase {
-  protected readonly phaseName = "NewBiomeEncounterPhase";
+  public readonly phaseName = "NewBiomeEncounterPhase";
   doEncounter(): void {
     globalScene.playBgm(undefined, true);
 

--- a/src/phases/new-biome-encounter-phase.ts
+++ b/src/phases/new-biome-encounter-phase.ts
@@ -4,6 +4,7 @@ import { getRandomWeatherType } from "#app/data/weather";
 import { NextEncounterPhase } from "./next-encounter-phase";
 
 export class NewBiomeEncounterPhase extends NextEncounterPhase {
+  protected readonly phaseName = "NewBiomeEncounterPhase";
   doEncounter(): void {
     globalScene.playBgm(undefined, true);
 

--- a/src/phases/next-encounter-phase.ts
+++ b/src/phases/next-encounter-phase.ts
@@ -6,7 +6,7 @@ import { EncounterPhase } from "./encounter-phase";
  * Handles generating, loading and preparing for it.
  */
 export class NextEncounterPhase extends EncounterPhase {
-  protected readonly phaseName = "NextEncounterPhase";
+  protected readonly phaseName: "NextEncounterPhase" | "NewBiomeEncounterPhase" = "NextEncounterPhase";
   start() {
     super.start();
   }

--- a/src/phases/next-encounter-phase.ts
+++ b/src/phases/next-encounter-phase.ts
@@ -6,7 +6,7 @@ import { EncounterPhase } from "./encounter-phase";
  * Handles generating, loading and preparing for it.
  */
 export class NextEncounterPhase extends EncounterPhase {
-  protected readonly phaseName: "NextEncounterPhase" | "NewBiomeEncounterPhase" = "NextEncounterPhase";
+  public readonly phaseName: "NextEncounterPhase" | "NewBiomeEncounterPhase" = "NextEncounterPhase";
   start() {
     super.start();
   }

--- a/src/phases/next-encounter-phase.ts
+++ b/src/phases/next-encounter-phase.ts
@@ -6,6 +6,7 @@ import { EncounterPhase } from "./encounter-phase";
  * Handles generating, loading and preparing for it.
  */
 export class NextEncounterPhase extends EncounterPhase {
+  protected readonly phaseName = "NextEncounterPhase";
   start() {
     super.start();
   }

--- a/src/phases/obtain-status-effect-phase.ts
+++ b/src/phases/obtain-status-effect-phase.ts
@@ -11,7 +11,7 @@ import { applyPostSetStatusAbAttrs, PostSetStatusAbAttr } from "#app/data/abilit
 import { isNullOrUndefined } from "#app/utils/common";
 
 export class ObtainStatusEffectPhase extends PokemonPhase {
-  protected readonly phaseName = "ObtainStatusEffectPhase";
+  public readonly phaseName = "ObtainStatusEffectPhase";
   private statusEffect?: StatusEffect;
   private turnsRemaining?: number;
   private sourceText?: string | null;

--- a/src/phases/obtain-status-effect-phase.ts
+++ b/src/phases/obtain-status-effect-phase.ts
@@ -11,6 +11,7 @@ import { applyPostSetStatusAbAttrs, PostSetStatusAbAttr } from "#app/data/abilit
 import { isNullOrUndefined } from "#app/utils/common";
 
 export class ObtainStatusEffectPhase extends PokemonPhase {
+  protected readonly phaseName = "ObtainStatusEffectPhase";
   private statusEffect?: StatusEffect;
   private turnsRemaining?: number;
   private sourceText?: string | null;

--- a/src/phases/party-exp-phase.ts
+++ b/src/phases/party-exp-phase.ts
@@ -6,7 +6,7 @@ import { Phase } from "#app/phase";
  * Intended to be used as a more 1-off phase to provide exp to the party (such as during MEs), rather than cleanup a battle entirely
  */
 export class PartyExpPhase extends Phase {
-  protected readonly phaseName = "PartyExpPhase";
+  public readonly phaseName = "PartyExpPhase";
   expValue: number;
   useWaveIndexMultiplier?: boolean;
   pokemonParticipantIds?: Set<number>;

--- a/src/phases/party-exp-phase.ts
+++ b/src/phases/party-exp-phase.ts
@@ -6,6 +6,7 @@ import { Phase } from "#app/phase";
  * Intended to be used as a more 1-off phase to provide exp to the party (such as during MEs), rather than cleanup a battle entirely
  */
 export class PartyExpPhase extends Phase {
+  protected readonly phaseName = "PartyExpPhase";
   expValue: number;
   useWaveIndexMultiplier?: boolean;
   pokemonParticipantIds?: Set<number>;

--- a/src/phases/party-heal-phase.ts
+++ b/src/phases/party-heal-phase.ts
@@ -3,7 +3,7 @@ import { fixedInt } from "#app/utils/common";
 import { BattlePhase } from "./battle-phase";
 
 export class PartyHealPhase extends BattlePhase {
-  protected readonly phaseName = "PartyHealPhase";
+  public readonly phaseName = "PartyHealPhase";
   private resumeBgm: boolean;
 
   constructor(resumeBgm: boolean) {

--- a/src/phases/party-heal-phase.ts
+++ b/src/phases/party-heal-phase.ts
@@ -3,6 +3,7 @@ import { fixedInt } from "#app/utils/common";
 import { BattlePhase } from "./battle-phase";
 
 export class PartyHealPhase extends BattlePhase {
+  protected readonly phaseName = "PartyHealPhase";
   private resumeBgm: boolean;
 
   constructor(resumeBgm: boolean) {

--- a/src/phases/pokemon-anim-phase.ts
+++ b/src/phases/pokemon-anim-phase.ts
@@ -7,6 +7,7 @@ import { PokemonAnimType } from "#enums/pokemon-anim-type";
 import { SpeciesId } from "#enums/species-id";
 
 export class PokemonAnimPhase extends BattlePhase {
+  protected readonly phaseName = "PokemonAnimPhase";
   /** The type of animation to play in this phase */
   protected key: PokemonAnimType;
   /** The Pokemon to which this animation applies */

--- a/src/phases/pokemon-anim-phase.ts
+++ b/src/phases/pokemon-anim-phase.ts
@@ -7,7 +7,7 @@ import { PokemonAnimType } from "#enums/pokemon-anim-type";
 import { SpeciesId } from "#enums/species-id";
 
 export class PokemonAnimPhase extends BattlePhase {
-  protected readonly phaseName = "PokemonAnimPhase";
+  public readonly phaseName = "PokemonAnimPhase";
   /** The type of animation to play in this phase */
   protected key: PokemonAnimType;
   /** The Pokemon to which this animation applies */

--- a/src/phases/pokemon-heal-phase.ts
+++ b/src/phases/pokemon-heal-phase.ts
@@ -14,6 +14,7 @@ import { BattlerTagType } from "#app/enums/battler-tag-type";
 import type { HealBlockTag } from "#app/data/battler-tags";
 
 export class PokemonHealPhase extends CommonAnimPhase {
+  protected readonly phaseName = "PokemonHealPhase";
   private hpHealed: number;
   private message: string | null;
   private showFullHpMessage: boolean;

--- a/src/phases/pokemon-heal-phase.ts
+++ b/src/phases/pokemon-heal-phase.ts
@@ -14,7 +14,7 @@ import { BattlerTagType } from "#app/enums/battler-tag-type";
 import type { HealBlockTag } from "#app/data/battler-tags";
 
 export class PokemonHealPhase extends CommonAnimPhase {
-  protected readonly phaseName = "PokemonHealPhase";
+  public readonly phaseName = "PokemonHealPhase";
   private hpHealed: number;
   private message: string | null;
   private showFullHpMessage: boolean;

--- a/src/phases/pokemon-transform-phase.ts
+++ b/src/phases/pokemon-transform-phase.ts
@@ -13,7 +13,7 @@ import i18next from "i18next";
  * Used for Transform (move) and Imposter (ability)
  */
 export class PokemonTransformPhase extends PokemonPhase {
-  protected readonly phaseName = "PokemonTransformPhase";
+  public readonly phaseName = "PokemonTransformPhase";
   protected targetIndex: BattlerIndex;
   private playSound: boolean;
 

--- a/src/phases/pokemon-transform-phase.ts
+++ b/src/phases/pokemon-transform-phase.ts
@@ -13,6 +13,7 @@ import i18next from "i18next";
  * Used for Transform (move) and Imposter (ability)
  */
 export class PokemonTransformPhase extends PokemonPhase {
+  protected readonly phaseName = "PokemonTransformPhase";
   protected targetIndex: BattlerIndex;
   private playSound: boolean;
 

--- a/src/phases/post-game-over-phase.ts
+++ b/src/phases/post-game-over-phase.ts
@@ -4,7 +4,7 @@ import type { EndCardPhase } from "./end-card-phase";
 import { TitlePhase } from "./title-phase";
 
 export class PostGameOverPhase extends Phase {
-  protected readonly phaseName = "PostGameOverPhase";
+  public readonly phaseName = "PostGameOverPhase";
   private endCardPhase?: EndCardPhase;
 
   constructor(endCardPhase?: EndCardPhase) {

--- a/src/phases/post-game-over-phase.ts
+++ b/src/phases/post-game-over-phase.ts
@@ -4,6 +4,7 @@ import type { EndCardPhase } from "./end-card-phase";
 import { TitlePhase } from "./title-phase";
 
 export class PostGameOverPhase extends Phase {
+  protected readonly phaseName = "PostGameOverPhase";
   private endCardPhase?: EndCardPhase;
 
   constructor(endCardPhase?: EndCardPhase) {

--- a/src/phases/post-summon-phase.ts
+++ b/src/phases/post-summon-phase.ts
@@ -7,6 +7,7 @@ import { MysteryEncounterPostSummonTag } from "#app/data/battler-tags";
 import { BattlerTagType } from "#enums/battler-tag-type";
 
 export class PostSummonPhase extends PokemonPhase {
+  protected readonly phaseName = "PostSummonPhase";
   start() {
     super.start();
 

--- a/src/phases/post-summon-phase.ts
+++ b/src/phases/post-summon-phase.ts
@@ -7,7 +7,7 @@ import { MysteryEncounterPostSummonTag } from "#app/data/battler-tags";
 import { BattlerTagType } from "#enums/battler-tag-type";
 
 export class PostSummonPhase extends PokemonPhase {
-  protected readonly phaseName = "PostSummonPhase";
+  public readonly phaseName = "PostSummonPhase";
   start() {
     super.start();
 

--- a/src/phases/post-turn-status-effect-phase.ts
+++ b/src/phases/post-turn-status-effect-phase.ts
@@ -17,6 +17,7 @@ import { BooleanHolder, NumberHolder } from "#app/utils/common";
 import { PokemonPhase } from "./pokemon-phase";
 
 export class PostTurnStatusEffectPhase extends PokemonPhase {
+  protected readonly phaseName = "PostTurnStatusEffectPhase";
   // biome-ignore lint/complexity/noUselessConstructor: Not unnecessary as it makes battlerIndex required
   constructor(battlerIndex: BattlerIndex) {
     super(battlerIndex);

--- a/src/phases/post-turn-status-effect-phase.ts
+++ b/src/phases/post-turn-status-effect-phase.ts
@@ -17,7 +17,7 @@ import { BooleanHolder, NumberHolder } from "#app/utils/common";
 import { PokemonPhase } from "./pokemon-phase";
 
 export class PostTurnStatusEffectPhase extends PokemonPhase {
-  protected readonly phaseName = "PostTurnStatusEffectPhase";
+  public readonly phaseName = "PostTurnStatusEffectPhase";
   // biome-ignore lint/complexity/noUselessConstructor: Not unnecessary as it makes battlerIndex required
   constructor(battlerIndex: BattlerIndex) {
     super(battlerIndex);

--- a/src/phases/quiet-form-change-phase.ts
+++ b/src/phases/quiet-form-change-phase.ts
@@ -9,7 +9,7 @@ import type Pokemon from "#app/field/pokemon";
 import { EnemyPokemon } from "#app/field/pokemon";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { BattlePhase } from "./battle-phase";
-import { MovePhase } from "./move-phase";
+import type { MovePhase } from "./move-phase";
 import { PokemonHealPhase } from "./pokemon-heal-phase";
 import {
   applyAbAttrs,
@@ -169,7 +169,7 @@ export class QuietFormChangePhase extends BattlePhase {
       this.pokemon.initBattleInfo();
       this.pokemon.cry();
 
-      const movePhase = globalScene.findPhase(p => p instanceof MovePhase && p.pokemon === this.pokemon) as MovePhase;
+      const movePhase = globalScene.findPhase(p => p.isXPhase("MovePhase") && p.pokemon === this.pokemon) as MovePhase;
       if (movePhase) {
         movePhase.cancel();
       }

--- a/src/phases/quiet-form-change-phase.ts
+++ b/src/phases/quiet-form-change-phase.ts
@@ -19,7 +19,7 @@ import {
 } from "#app/data/abilities/ability";
 
 export class QuietFormChangePhase extends BattlePhase {
-  protected readonly phaseName = "QuietFormChangePhase";
+  public readonly phaseName = "QuietFormChangePhase";
   protected pokemon: Pokemon;
   protected formChange: SpeciesFormChange;
 

--- a/src/phases/quiet-form-change-phase.ts
+++ b/src/phases/quiet-form-change-phase.ts
@@ -19,6 +19,7 @@ import {
 } from "#app/data/abilities/ability";
 
 export class QuietFormChangePhase extends BattlePhase {
+  protected readonly phaseName = "QuietFormChangePhase";
   protected pokemon: Pokemon;
   protected formChange: SpeciesFormChange;
 

--- a/src/phases/quiet-form-change-phase.ts
+++ b/src/phases/quiet-form-change-phase.ts
@@ -169,7 +169,7 @@ export class QuietFormChangePhase extends BattlePhase {
       this.pokemon.initBattleInfo();
       this.pokemon.cry();
 
-      const movePhase = globalScene.findPhase(p => p.isXPhase("MovePhase") && p.pokemon === this.pokemon) as MovePhase;
+      const movePhase = globalScene.findPhase(p => p.is("MovePhase") && p.pokemon === this.pokemon) as MovePhase;
       if (movePhase) {
         movePhase.cancel();
       }

--- a/src/phases/reload-session-phase.ts
+++ b/src/phases/reload-session-phase.ts
@@ -4,7 +4,7 @@ import { UiMode } from "#enums/ui-mode";
 import { fixedInt } from "#app/utils/common";
 
 export class ReloadSessionPhase extends Phase {
-  protected readonly phaseName = "ReloadSessionPhase";
+  public readonly phaseName = "ReloadSessionPhase";
   private systemDataStr?: string;
 
   constructor(systemDataStr?: string) {

--- a/src/phases/reload-session-phase.ts
+++ b/src/phases/reload-session-phase.ts
@@ -4,6 +4,7 @@ import { UiMode } from "#enums/ui-mode";
 import { fixedInt } from "#app/utils/common";
 
 export class ReloadSessionPhase extends Phase {
+  protected readonly phaseName = "ReloadSessionPhase";
   private systemDataStr?: string;
 
   constructor(systemDataStr?: string) {

--- a/src/phases/reset-status-phase.ts
+++ b/src/phases/reset-status-phase.ts
@@ -7,6 +7,7 @@ import { BattlePhase } from "#app/phases/battle-phase";
  * This is necessary to perform in a phase primarly to ensure that the status icon disappears at the correct time in the battle
  */
 export class ResetStatusPhase extends BattlePhase {
+  protected readonly phaseName = "ResetStatusPhase";
   private readonly pokemon: Pokemon;
   private readonly affectConfusion: boolean;
   private readonly reloadAssets: boolean;

--- a/src/phases/reset-status-phase.ts
+++ b/src/phases/reset-status-phase.ts
@@ -7,7 +7,7 @@ import { BattlePhase } from "#app/phases/battle-phase";
  * This is necessary to perform in a phase primarly to ensure that the status icon disappears at the correct time in the battle
  */
 export class ResetStatusPhase extends BattlePhase {
-  protected readonly phaseName = "ResetStatusPhase";
+  public readonly phaseName = "ResetStatusPhase";
   private readonly pokemon: Pokemon;
   private readonly affectConfusion: boolean;
   private readonly reloadAssets: boolean;

--- a/src/phases/return-phase.ts
+++ b/src/phases/return-phase.ts
@@ -4,6 +4,7 @@ import { SwitchType } from "#enums/switch-type";
 import { SwitchSummonPhase } from "./switch-summon-phase";
 
 export class ReturnPhase extends SwitchSummonPhase {
+  protected readonly phaseName = "ReturnPhase";
   constructor(fieldIndex: number) {
     super(SwitchType.SWITCH, fieldIndex, -1, true);
   }

--- a/src/phases/return-phase.ts
+++ b/src/phases/return-phase.ts
@@ -4,7 +4,7 @@ import { SwitchType } from "#enums/switch-type";
 import { SwitchSummonPhase } from "./switch-summon-phase";
 
 export class ReturnPhase extends SwitchSummonPhase {
-  protected readonly phaseName = "ReturnPhase";
+  public readonly phaseName = "ReturnPhase";
   constructor(fieldIndex: number) {
     super(SwitchType.SWITCH, fieldIndex, -1, true);
   }

--- a/src/phases/revival-blessing-phase.ts
+++ b/src/phases/revival-blessing-phase.ts
@@ -15,6 +15,7 @@ import type { PlayerPokemon } from "#app/field/pokemon";
  * when used by one of the player's Pokemon.
  */
 export class RevivalBlessingPhase extends BattlePhase {
+  protected readonly phaseName = "RevivalBlessingPhase";
   constructor(protected user: PlayerPokemon) {
     super();
   }

--- a/src/phases/revival-blessing-phase.ts
+++ b/src/phases/revival-blessing-phase.ts
@@ -15,7 +15,7 @@ import type { PlayerPokemon } from "#app/field/pokemon";
  * when used by one of the player's Pokemon.
  */
 export class RevivalBlessingPhase extends BattlePhase {
-  protected readonly phaseName = "RevivalBlessingPhase";
+  public readonly phaseName = "RevivalBlessingPhase";
   constructor(protected user: PlayerPokemon) {
     super();
   }

--- a/src/phases/ribbon-modifier-reward-phase.ts
+++ b/src/phases/ribbon-modifier-reward-phase.ts
@@ -6,6 +6,7 @@ import i18next from "i18next";
 import { ModifierRewardPhase } from "./modifier-reward-phase";
 
 export class RibbonModifierRewardPhase extends ModifierRewardPhase {
+  protected readonly phaseName = "RibbonModifierRewardPhase";
   private species: PokemonSpecies;
 
   constructor(modifierTypeFunc: ModifierTypeFunc, species: PokemonSpecies) {

--- a/src/phases/ribbon-modifier-reward-phase.ts
+++ b/src/phases/ribbon-modifier-reward-phase.ts
@@ -6,7 +6,7 @@ import i18next from "i18next";
 import { ModifierRewardPhase } from "./modifier-reward-phase";
 
 export class RibbonModifierRewardPhase extends ModifierRewardPhase {
-  protected readonly phaseName = "RibbonModifierRewardPhase";
+  public readonly phaseName = "RibbonModifierRewardPhase";
   private species: PokemonSpecies;
 
   constructor(modifierTypeFunc: ModifierTypeFunc, species: PokemonSpecies) {

--- a/src/phases/scan-ivs-phase.ts
+++ b/src/phases/scan-ivs-phase.ts
@@ -8,6 +8,7 @@ import i18next from "i18next";
 import { PokemonPhase } from "./pokemon-phase";
 
 export class ScanIvsPhase extends PokemonPhase {
+  protected readonly phaseName = "ScanIvsPhase";
   // biome-ignore lint/complexity/noUselessConstructor: This changes `battlerIndex` to be required
   constructor(battlerIndex: BattlerIndex) {
     super(battlerIndex);

--- a/src/phases/scan-ivs-phase.ts
+++ b/src/phases/scan-ivs-phase.ts
@@ -8,7 +8,7 @@ import i18next from "i18next";
 import { PokemonPhase } from "./pokemon-phase";
 
 export class ScanIvsPhase extends PokemonPhase {
-  protected readonly phaseName = "ScanIvsPhase";
+  public readonly phaseName = "ScanIvsPhase";
   // biome-ignore lint/complexity/noUselessConstructor: This changes `battlerIndex` to be required
   constructor(battlerIndex: BattlerIndex) {
     super(battlerIndex);

--- a/src/phases/select-biome-phase.ts
+++ b/src/phases/select-biome-phase.ts
@@ -10,6 +10,7 @@ import { PartyHealPhase } from "./party-heal-phase";
 import { SwitchBiomePhase } from "./switch-biome-phase";
 
 export class SelectBiomePhase extends BattlePhase {
+  protected readonly phaseName = "SelectBiomePhase";
   start() {
     super.start();
 

--- a/src/phases/select-biome-phase.ts
+++ b/src/phases/select-biome-phase.ts
@@ -10,7 +10,7 @@ import { PartyHealPhase } from "./party-heal-phase";
 import { SwitchBiomePhase } from "./switch-biome-phase";
 
 export class SelectBiomePhase extends BattlePhase {
-  protected readonly phaseName = "SelectBiomePhase";
+  public readonly phaseName = "SelectBiomePhase";
   start() {
     super.start();
 

--- a/src/phases/select-challenge-phase.ts
+++ b/src/phases/select-challenge-phase.ts
@@ -3,7 +3,7 @@ import { Phase } from "#app/phase";
 import { UiMode } from "#enums/ui-mode";
 
 export class SelectChallengePhase extends Phase {
-  protected readonly phaseName = "SelectChallengePhase";
+  public readonly phaseName = "SelectChallengePhase";
   start() {
     super.start();
 

--- a/src/phases/select-challenge-phase.ts
+++ b/src/phases/select-challenge-phase.ts
@@ -3,6 +3,7 @@ import { Phase } from "#app/phase";
 import { UiMode } from "#enums/ui-mode";
 
 export class SelectChallengePhase extends Phase {
+  protected readonly phaseName = "SelectChallengePhase";
   start() {
     super.start();
 

--- a/src/phases/select-gender-phase.ts
+++ b/src/phases/select-gender-phase.ts
@@ -6,6 +6,7 @@ import { UiMode } from "#enums/ui-mode";
 import i18next from "i18next";
 
 export class SelectGenderPhase extends Phase {
+  protected readonly phaseName = "SelectGenderPhase";
   start(): void {
     super.start();
 

--- a/src/phases/select-gender-phase.ts
+++ b/src/phases/select-gender-phase.ts
@@ -6,7 +6,7 @@ import { UiMode } from "#enums/ui-mode";
 import i18next from "i18next";
 
 export class SelectGenderPhase extends Phase {
-  protected readonly phaseName = "SelectGenderPhase";
+  public readonly phaseName = "SelectGenderPhase";
   start(): void {
     super.start();
 

--- a/src/phases/select-modifier-phase.ts
+++ b/src/phases/select-modifier-phase.ts
@@ -32,7 +32,7 @@ import type { CustomModifierSettings } from "#app/modifier/modifier-type";
 import { isNullOrUndefined, NumberHolder } from "#app/utils/common";
 
 export class SelectModifierPhase extends BattlePhase {
-  protected readonly phaseName = "SelectModifierPhase";
+  public readonly phaseName = "SelectModifierPhase";
   private rerollCount: number;
   private modifierTiers?: ModifierTier[];
   private customModifierSettings?: CustomModifierSettings;

--- a/src/phases/select-modifier-phase.ts
+++ b/src/phases/select-modifier-phase.ts
@@ -32,6 +32,7 @@ import type { CustomModifierSettings } from "#app/modifier/modifier-type";
 import { isNullOrUndefined, NumberHolder } from "#app/utils/common";
 
 export class SelectModifierPhase extends BattlePhase {
+  protected readonly phaseName = "SelectModifierPhase";
   private rerollCount: number;
   private modifierTiers?: ModifierTier[];
   private customModifierSettings?: CustomModifierSettings;

--- a/src/phases/select-starter-phase.ts
+++ b/src/phases/select-starter-phase.ts
@@ -15,6 +15,7 @@ import SoundFade from "phaser3-rex-plugins/plugins/soundfade";
 import { isNullOrUndefined } from "#app/utils/common";
 
 export class SelectStarterPhase extends Phase {
+  protected readonly phaseName = "SelectStarterPhase";
   start() {
     super.start();
 

--- a/src/phases/select-starter-phase.ts
+++ b/src/phases/select-starter-phase.ts
@@ -15,7 +15,7 @@ import SoundFade from "phaser3-rex-plugins/plugins/soundfade";
 import { isNullOrUndefined } from "#app/utils/common";
 
 export class SelectStarterPhase extends Phase {
-  protected readonly phaseName = "SelectStarterPhase";
+  public readonly phaseName = "SelectStarterPhase";
   start() {
     super.start();
 

--- a/src/phases/select-target-phase.ts
+++ b/src/phases/select-target-phase.ts
@@ -8,7 +8,7 @@ import i18next from "#app/plugins/i18n";
 import { allMoves } from "#app/data/data-lists";
 
 export class SelectTargetPhase extends PokemonPhase {
-  protected readonly phaseName = "SelectTargetPhase";
+  public readonly phaseName = "SelectTargetPhase";
   // biome-ignore lint/complexity/noUselessConstructor: This makes `fieldIndex` required
   constructor(fieldIndex: number) {
     super(fieldIndex);

--- a/src/phases/select-target-phase.ts
+++ b/src/phases/select-target-phase.ts
@@ -8,6 +8,7 @@ import i18next from "#app/plugins/i18n";
 import { allMoves } from "#app/data/data-lists";
 
 export class SelectTargetPhase extends PokemonPhase {
+  protected readonly phaseName = "SelectTargetPhase";
   // biome-ignore lint/complexity/noUselessConstructor: This makes `fieldIndex` required
   constructor(fieldIndex: number) {
     super(fieldIndex);

--- a/src/phases/shiny-sparkle-phase.ts
+++ b/src/phases/shiny-sparkle-phase.ts
@@ -3,6 +3,7 @@ import type { BattlerIndex } from "#app/battle";
 import { PokemonPhase } from "./pokemon-phase";
 
 export class ShinySparklePhase extends PokemonPhase {
+  protected readonly phaseName = "ShinySparklePhase";
   // biome-ignore lint/complexity/noUselessConstructor: This makes `battlerIndex` required
   constructor(battlerIndex: BattlerIndex) {
     super(battlerIndex);

--- a/src/phases/shiny-sparkle-phase.ts
+++ b/src/phases/shiny-sparkle-phase.ts
@@ -3,7 +3,7 @@ import type { BattlerIndex } from "#app/battle";
 import { PokemonPhase } from "./pokemon-phase";
 
 export class ShinySparklePhase extends PokemonPhase {
-  protected readonly phaseName = "ShinySparklePhase";
+  public readonly phaseName = "ShinySparklePhase";
   // biome-ignore lint/complexity/noUselessConstructor: This makes `battlerIndex` required
   constructor(battlerIndex: BattlerIndex) {
     super(battlerIndex);

--- a/src/phases/show-ability-phase.ts
+++ b/src/phases/show-ability-phase.ts
@@ -5,7 +5,7 @@ import { getPokemonNameWithAffix } from "#app/messages";
 import { HideAbilityPhase } from "#app/phases/hide-ability-phase";
 
 export class ShowAbilityPhase extends PokemonPhase {
-  protected readonly phaseName = "ShowAbilityPhase";
+  public readonly phaseName = "ShowAbilityPhase";
   private passive: boolean;
   private pokemonName: string;
   private abilityName: string;

--- a/src/phases/show-ability-phase.ts
+++ b/src/phases/show-ability-phase.ts
@@ -5,6 +5,7 @@ import { getPokemonNameWithAffix } from "#app/messages";
 import { HideAbilityPhase } from "#app/phases/hide-ability-phase";
 
 export class ShowAbilityPhase extends PokemonPhase {
+  protected readonly phaseName = "ShowAbilityPhase";
   private passive: boolean;
   private pokemonName: string;
   private abilityName: string;

--- a/src/phases/show-party-exp-bar-phase.ts
+++ b/src/phases/show-party-exp-bar-phase.ts
@@ -8,7 +8,7 @@ import { LevelUpPhase } from "./level-up-phase";
 import { PlayerPartyMemberPokemonPhase } from "./player-party-member-pokemon-phase";
 
 export class ShowPartyExpBarPhase extends PlayerPartyMemberPokemonPhase {
-  protected readonly phaseName = "ShowPartyExpBarPhase";
+  public readonly phaseName = "ShowPartyExpBarPhase";
   private expValue: number;
 
   constructor(partyMemberIndex: number, expValue: number) {

--- a/src/phases/show-party-exp-bar-phase.ts
+++ b/src/phases/show-party-exp-bar-phase.ts
@@ -8,6 +8,7 @@ import { LevelUpPhase } from "./level-up-phase";
 import { PlayerPartyMemberPokemonPhase } from "./player-party-member-pokemon-phase";
 
 export class ShowPartyExpBarPhase extends PlayerPartyMemberPokemonPhase {
+  protected readonly phaseName = "ShowPartyExpBarPhase";
   private expValue: number;
 
   constructor(partyMemberIndex: number, expValue: number) {

--- a/src/phases/show-trainer-phase.ts
+++ b/src/phases/show-trainer-phase.ts
@@ -3,6 +3,7 @@ import { PlayerGender } from "#app/enums/player-gender";
 import { BattlePhase } from "./battle-phase";
 
 export class ShowTrainerPhase extends BattlePhase {
+  protected readonly phaseName = "ShowTrainerPhase";
   start() {
     super.start();
 

--- a/src/phases/show-trainer-phase.ts
+++ b/src/phases/show-trainer-phase.ts
@@ -3,7 +3,7 @@ import { PlayerGender } from "#app/enums/player-gender";
 import { BattlePhase } from "./battle-phase";
 
 export class ShowTrainerPhase extends BattlePhase {
-  protected readonly phaseName = "ShowTrainerPhase";
+  public readonly phaseName = "ShowTrainerPhase";
   start() {
     super.start();
 

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -236,9 +236,9 @@ export class StatStageChangePhase extends PokemonPhase {
 
       // Look for any other stat change phases; if this is the last one, do White Herb check
       const existingPhase = globalScene.findPhase(
-        p => p.isXPhase("StatStageChangePhase") && p.battlerIndex === this.battlerIndex,
+        p => p.is("StatStageChangePhase") && p.battlerIndex === this.battlerIndex,
       );
-      if (!existingPhase?.isXPhase("StatStageChangePhase")) {
+      if (!existingPhase?.is("StatStageChangePhase")) {
         // Apply White Herb if needed
         const whiteHerb = globalScene.applyModifier(
           ResetNegativeStatStageModifier,
@@ -317,7 +317,7 @@ export class StatStageChangePhase extends PokemonPhase {
       while (
         (existingPhase = globalScene.findPhase(
           p =>
-            p.isXPhase("StatStageChangePhase") &&
+            p.is("StatStageChangePhase") &&
             p.battlerIndex === this.battlerIndex &&
             p.stats.length === 1 &&
             p.stats[0] === this.stats[0] &&
@@ -336,7 +336,7 @@ export class StatStageChangePhase extends PokemonPhase {
     while (
       (existingPhase = globalScene.findPhase(
         p =>
-          p.isXPhase("StatStageChangePhase") &&
+          p.is("StatStageChangePhase") &&
           p.battlerIndex === this.battlerIndex &&
           p.selfTarget === this.selfTarget &&
           accEva.some(s => p.stats.includes(s)) === isAccEva &&

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -236,9 +236,9 @@ export class StatStageChangePhase extends PokemonPhase {
 
       // Look for any other stat change phases; if this is the last one, do White Herb check
       const existingPhase = globalScene.findPhase(
-        p => p instanceof StatStageChangePhase && p.battlerIndex === this.battlerIndex,
+        p => p.isXPhase("StatStageChangePhase") && p.battlerIndex === this.battlerIndex,
       );
-      if (!(existingPhase instanceof StatStageChangePhase)) {
+      if (!existingPhase?.isXPhase("StatStageChangePhase")) {
         // Apply White Herb if needed
         const whiteHerb = globalScene.applyModifier(
           ResetNegativeStatStageModifier,
@@ -317,7 +317,7 @@ export class StatStageChangePhase extends PokemonPhase {
       while (
         (existingPhase = globalScene.findPhase(
           p =>
-            p instanceof StatStageChangePhase &&
+            p.isXPhase("StatStageChangePhase") &&
             p.battlerIndex === this.battlerIndex &&
             p.stats.length === 1 &&
             p.stats[0] === this.stats[0] &&
@@ -336,7 +336,7 @@ export class StatStageChangePhase extends PokemonPhase {
     while (
       (existingPhase = globalScene.findPhase(
         p =>
-          p instanceof StatStageChangePhase &&
+          p.isXPhase("StatStageChangePhase") &&
           p.battlerIndex === this.battlerIndex &&
           p.selfTarget === this.selfTarget &&
           accEva.some(s => p.stats.includes(s)) === isAccEva &&

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -31,7 +31,7 @@ export type StatStageChangeCallback = (
 ) => void;
 
 export class StatStageChangePhase extends PokemonPhase {
-  protected readonly phaseName = "StatStageChangePhase";
+  public readonly phaseName = "StatStageChangePhase";
   private stats: BattleStat[];
   private selfTarget: boolean;
   private stages: number;

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -31,6 +31,7 @@ export type StatStageChangeCallback = (
 ) => void;
 
 export class StatStageChangePhase extends PokemonPhase {
+  protected readonly phaseName = "StatStageChangePhase";
   private stats: BattleStat[];
   private selfTarget: boolean;
   private stages: number;

--- a/src/phases/summon-missing-phase.ts
+++ b/src/phases/summon-missing-phase.ts
@@ -4,6 +4,7 @@ import { SummonPhase } from "./summon-phase";
 import { globalScene } from "#app/global-scene";
 
 export class SummonMissingPhase extends SummonPhase {
+  protected readonly phaseName = "SummonMissingPhase";
   preSummon(): void {
     globalScene.ui.showText(
       i18next.t("battle:sendOutPokemon", {

--- a/src/phases/summon-missing-phase.ts
+++ b/src/phases/summon-missing-phase.ts
@@ -4,7 +4,7 @@ import { SummonPhase } from "./summon-phase";
 import { globalScene } from "#app/global-scene";
 
 export class SummonMissingPhase extends SummonPhase {
-  protected readonly phaseName = "SummonMissingPhase";
+  public readonly phaseName = "SummonMissingPhase";
   preSummon(): void {
     globalScene.ui.showText(
       i18next.t("battle:sendOutPokemon", {

--- a/src/phases/summon-phase.ts
+++ b/src/phases/summon-phase.ts
@@ -17,9 +17,9 @@ import { applyPreSummonAbAttrs, PreSummonAbAttr } from "#app/data/abilities/abil
 import { globalScene } from "#app/global-scene";
 
 export class SummonPhase extends PartyMemberPokemonPhase {
-  // Both SwitchSummonPhase and SummonMissingPhase extend this class and so we must use a
-  // union type to make typescript happy.
-  protected readonly phaseName: "SummonPhase" | "SummonMissingPhase" | "SwitchSummonPhase" = "SummonPhase";
+  // The union type is needed to keep typescript happy as these phases extend from SummonPhase
+  protected readonly phaseName: "SummonPhase" | "SummonMissingPhase" | "SwitchSummonPhase" | "ReturnPhase" =
+    "SummonPhase";
   private loaded: boolean;
 
   constructor(fieldIndex: number, player = true, loaded = false) {

--- a/src/phases/summon-phase.ts
+++ b/src/phases/summon-phase.ts
@@ -18,8 +18,7 @@ import { globalScene } from "#app/global-scene";
 
 export class SummonPhase extends PartyMemberPokemonPhase {
   // The union type is needed to keep typescript happy as these phases extend from SummonPhase
-  protected readonly phaseName: "SummonPhase" | "SummonMissingPhase" | "SwitchSummonPhase" | "ReturnPhase" =
-    "SummonPhase";
+  public readonly phaseName: "SummonPhase" | "SummonMissingPhase" | "SwitchSummonPhase" | "ReturnPhase" = "SummonPhase";
   private loaded: boolean;
 
   constructor(fieldIndex: number, player = true, loaded = false) {

--- a/src/phases/summon-phase.ts
+++ b/src/phases/summon-phase.ts
@@ -17,6 +17,9 @@ import { applyPreSummonAbAttrs, PreSummonAbAttr } from "#app/data/abilities/abil
 import { globalScene } from "#app/global-scene";
 
 export class SummonPhase extends PartyMemberPokemonPhase {
+  // Both SwitchSummonPhase and SummonMissingPhase extend this class and so we must use a
+  // union type to make typescript happy.
+  protected readonly phaseName: "SummonPhase" | "SummonMissingPhase" | "SwitchSummonPhase" = "SummonPhase";
   private loaded: boolean;
 
   constructor(fieldIndex: number, player = true, loaded = false) {

--- a/src/phases/switch-biome-phase.ts
+++ b/src/phases/switch-biome-phase.ts
@@ -4,6 +4,7 @@ import { getBiomeKey } from "#app/field/arena";
 import { BattlePhase } from "./battle-phase";
 
 export class SwitchBiomePhase extends BattlePhase {
+  protected readonly phaseName = "SwitchBiomePhase";
   private nextBiome: BiomeId;
 
   constructor(nextBiome: BiomeId) {

--- a/src/phases/switch-biome-phase.ts
+++ b/src/phases/switch-biome-phase.ts
@@ -4,7 +4,7 @@ import { getBiomeKey } from "#app/field/arena";
 import { BattlePhase } from "./battle-phase";
 
 export class SwitchBiomePhase extends BattlePhase {
-  protected readonly phaseName = "SwitchBiomePhase";
+  public readonly phaseName = "SwitchBiomePhase";
   private nextBiome: BiomeId;
 
   constructor(nextBiome: BiomeId) {

--- a/src/phases/switch-phase.ts
+++ b/src/phases/switch-phase.ts
@@ -76,9 +76,7 @@ export class SwitchPhase extends BattlePhase {
         if (slotIndex >= globalScene.currentBattle.getBattlerCount() && slotIndex < 6) {
           // Remove any pre-existing PostSummonPhase under the same field index.
           // Pre-existing PostSummonPhases may occur when this phase is invoked during a prompt to switch at the start of a wave.
-          globalScene.tryRemovePhase(
-            p => p.isXPhase("PostSummonPhase") && p.player && p.fieldIndex === this.fieldIndex,
-          );
+          globalScene.tryRemovePhase(p => p.is("PostSummonPhase") && p.player && p.fieldIndex === this.fieldIndex);
           const switchType = option === PartyOption.PASS_BATON ? SwitchType.BATON_PASS : this.switchType;
           globalScene.unshiftPhase(new SwitchSummonPhase(switchType, fieldIndex, slotIndex, this.doReturn));
         }

--- a/src/phases/switch-phase.ts
+++ b/src/phases/switch-phase.ts
@@ -10,7 +10,7 @@ import { SwitchSummonPhase } from "./switch-summon-phase";
  * for the player (if a switch would be valid for the current battle state).
  */
 export class SwitchPhase extends BattlePhase {
-  protected readonly phaseName = "SwitchPhase";
+  public readonly phaseName = "SwitchPhase";
   protected readonly fieldIndex: number;
   private readonly switchType: SwitchType;
   private readonly isModal: boolean;

--- a/src/phases/switch-phase.ts
+++ b/src/phases/switch-phase.ts
@@ -11,6 +11,7 @@ import { SwitchSummonPhase } from "./switch-summon-phase";
  * for the player (if a switch would be valid for the current battle state).
  */
 export class SwitchPhase extends BattlePhase {
+  protected readonly phaseName = "SwitchPhase";
   protected readonly fieldIndex: number;
   private readonly switchType: SwitchType;
   private readonly isModal: boolean;

--- a/src/phases/switch-phase.ts
+++ b/src/phases/switch-phase.ts
@@ -3,7 +3,6 @@ import PartyUiHandler, { PartyOption, PartyUiMode } from "#app/ui/party-ui-handl
 import { UiMode } from "#enums/ui-mode";
 import { SwitchType } from "#enums/switch-type";
 import { BattlePhase } from "./battle-phase";
-import { PostSummonPhase } from "./post-summon-phase";
 import { SwitchSummonPhase } from "./switch-summon-phase";
 
 /**
@@ -77,7 +76,9 @@ export class SwitchPhase extends BattlePhase {
         if (slotIndex >= globalScene.currentBattle.getBattlerCount() && slotIndex < 6) {
           // Remove any pre-existing PostSummonPhase under the same field index.
           // Pre-existing PostSummonPhases may occur when this phase is invoked during a prompt to switch at the start of a wave.
-          globalScene.tryRemovePhase(p => p instanceof PostSummonPhase && p.player && p.fieldIndex === this.fieldIndex);
+          globalScene.tryRemovePhase(
+            p => p.isXPhase("PostSummonPhase") && p.player && p.fieldIndex === this.fieldIndex,
+          );
           const switchType = option === PartyOption.PASS_BATON ? SwitchType.BATON_PASS : this.switchType;
           globalScene.unshiftPhase(new SwitchSummonPhase(switchType, fieldIndex, slotIndex, this.doReturn));
         }

--- a/src/phases/switch-summon-phase.ts
+++ b/src/phases/switch-summon-phase.ts
@@ -22,7 +22,7 @@ import { SubstituteTag } from "#app/data/battler-tags";
 import { SwitchType } from "#enums/switch-type";
 
 export class SwitchSummonPhase extends SummonPhase {
-  protected readonly phaseName = "SwitchSummonPhase";
+  protected readonly phaseName: "SwitchSummonPhase" | "ReturnPhase" = "SwitchSummonPhase";
   private readonly switchType: SwitchType;
   private readonly slotIndex: number;
   private readonly doReturn: boolean;

--- a/src/phases/switch-summon-phase.ts
+++ b/src/phases/switch-summon-phase.ts
@@ -22,6 +22,7 @@ import { SubstituteTag } from "#app/data/battler-tags";
 import { SwitchType } from "#enums/switch-type";
 
 export class SwitchSummonPhase extends SummonPhase {
+  protected readonly phaseName = "SwitchSummonPhase";
   private readonly switchType: SwitchType;
   private readonly slotIndex: number;
   private readonly doReturn: boolean;

--- a/src/phases/switch-summon-phase.ts
+++ b/src/phases/switch-summon-phase.ts
@@ -22,7 +22,7 @@ import { SubstituteTag } from "#app/data/battler-tags";
 import { SwitchType } from "#enums/switch-type";
 
 export class SwitchSummonPhase extends SummonPhase {
-  protected readonly phaseName: "SwitchSummonPhase" | "ReturnPhase" = "SwitchSummonPhase";
+  public readonly phaseName: "SwitchSummonPhase" | "ReturnPhase" = "SwitchSummonPhase";
   private readonly switchType: SwitchType;
   private readonly slotIndex: number;
   private readonly doReturn: boolean;

--- a/src/phases/tera-phase.ts
+++ b/src/phases/tera-phase.ts
@@ -9,7 +9,7 @@ import { SpeciesFormChangeTeraTrigger } from "#app/data/pokemon-forms";
 import { CommonAnim, CommonBattleAnim } from "#app/data/battle-anims";
 
 export class TeraPhase extends BattlePhase {
-  protected readonly phaseName = "TeraPhase";
+  public readonly phaseName = "TeraPhase";
   public pokemon: Pokemon;
 
   constructor(pokemon: Pokemon) {

--- a/src/phases/tera-phase.ts
+++ b/src/phases/tera-phase.ts
@@ -9,6 +9,7 @@ import { SpeciesFormChangeTeraTrigger } from "#app/data/pokemon-forms";
 import { CommonAnim, CommonBattleAnim } from "#app/data/battle-anims";
 
 export class TeraPhase extends BattlePhase {
+  protected readonly phaseName = "TeraPhase";
   public pokemon: Pokemon;
 
   constructor(pokemon: Pokemon) {

--- a/src/phases/title-phase.ts
+++ b/src/phases/title-phase.ts
@@ -29,7 +29,7 @@ import { globalScene } from "#app/global-scene";
 import Overrides from "#app/overrides";
 
 export class TitlePhase extends Phase {
-  protected readonly phaseName = "TitlePhase";
+  public readonly phaseName = "TitlePhase";
   private loaded = false;
   private lastSessionData: SessionSaveData;
   public gameMode: GameModes;

--- a/src/phases/title-phase.ts
+++ b/src/phases/title-phase.ts
@@ -29,6 +29,7 @@ import { globalScene } from "#app/global-scene";
 import Overrides from "#app/overrides";
 
 export class TitlePhase extends Phase {
+  protected readonly phaseName = "TitlePhase";
   private loaded = false;
   private lastSessionData: SessionSaveData;
   public gameMode: GameModes;

--- a/src/phases/toggle-double-position-phase.ts
+++ b/src/phases/toggle-double-position-phase.ts
@@ -3,6 +3,7 @@ import { FieldPosition } from "#app/field/pokemon";
 import { BattlePhase } from "./battle-phase";
 
 export class ToggleDoublePositionPhase extends BattlePhase {
+  protected readonly phaseName = "ToggleDoublePositionPhase";
   private double: boolean;
 
   constructor(double: boolean) {

--- a/src/phases/toggle-double-position-phase.ts
+++ b/src/phases/toggle-double-position-phase.ts
@@ -3,7 +3,7 @@ import { FieldPosition } from "#app/field/pokemon";
 import { BattlePhase } from "./battle-phase";
 
 export class ToggleDoublePositionPhase extends BattlePhase {
-  protected readonly phaseName = "ToggleDoublePositionPhase";
+  public readonly phaseName = "ToggleDoublePositionPhase";
   private double: boolean;
 
   constructor(double: boolean) {

--- a/src/phases/trainer-victory-phase.ts
+++ b/src/phases/trainer-victory-phase.ts
@@ -14,7 +14,7 @@ import { achvs } from "#app/system/achv";
 import { timedEventManager } from "#app/global-event-manager";
 
 export class TrainerVictoryPhase extends BattlePhase {
-  protected readonly phaseName = "TrainerVictoryPhase";
+  public readonly phaseName = "TrainerVictoryPhase";
   start() {
     globalScene.disableMenu = true;
 

--- a/src/phases/trainer-victory-phase.ts
+++ b/src/phases/trainer-victory-phase.ts
@@ -14,6 +14,7 @@ import { achvs } from "#app/system/achv";
 import { timedEventManager } from "#app/global-event-manager";
 
 export class TrainerVictoryPhase extends BattlePhase {
+  protected readonly phaseName = "TrainerVictoryPhase";
   start() {
     globalScene.disableMenu = true;
 

--- a/src/phases/turn-end-phase.ts
+++ b/src/phases/turn-end-phase.ts
@@ -18,7 +18,7 @@ import { PokemonHealPhase } from "./pokemon-heal-phase";
 import { globalScene } from "#app/global-scene";
 
 export class TurnEndPhase extends FieldPhase {
-  protected readonly phaseName = "TurnEndPhase";
+  public readonly phaseName = "TurnEndPhase";
   start() {
     super.start();
 

--- a/src/phases/turn-end-phase.ts
+++ b/src/phases/turn-end-phase.ts
@@ -18,6 +18,7 @@ import { PokemonHealPhase } from "./pokemon-heal-phase";
 import { globalScene } from "#app/global-scene";
 
 export class TurnEndPhase extends FieldPhase {
+  protected readonly phaseName = "TurnEndPhase";
   start() {
     super.start();
 

--- a/src/phases/turn-init-phase.ts
+++ b/src/phases/turn-init-phase.ts
@@ -15,6 +15,7 @@ import { TurnStartPhase } from "./turn-start-phase";
 import { globalScene } from "#app/global-scene";
 
 export class TurnInitPhase extends FieldPhase {
+  protected readonly phaseName = "TurnInitPhase";
   start() {
     super.start();
 

--- a/src/phases/turn-init-phase.ts
+++ b/src/phases/turn-init-phase.ts
@@ -15,7 +15,7 @@ import { TurnStartPhase } from "./turn-start-phase";
 import { globalScene } from "#app/global-scene";
 
 export class TurnInitPhase extends FieldPhase {
-  protected readonly phaseName = "TurnInitPhase";
+  public readonly phaseName = "TurnInitPhase";
   start() {
     super.start();
 

--- a/src/phases/turn-start-phase.ts
+++ b/src/phases/turn-start-phase.ts
@@ -25,7 +25,7 @@ import { globalScene } from "#app/global-scene";
 import { TeraPhase } from "./tera-phase";
 
 export class TurnStartPhase extends FieldPhase {
-  protected readonly phaseName = "TurnStartPhase";
+  public readonly phaseName = "TurnStartPhase";
   /**
    * This orders the active Pokemon on the field by speed into an BattlerIndex array and returns that array.
    * It also checks for Trick Room and reverses the array if it is present.

--- a/src/phases/turn-start-phase.ts
+++ b/src/phases/turn-start-phase.ts
@@ -25,6 +25,7 @@ import { globalScene } from "#app/global-scene";
 import { TeraPhase } from "./tera-phase";
 
 export class TurnStartPhase extends FieldPhase {
+  protected readonly phaseName = "TurnStartPhase";
   /**
    * This orders the active Pokemon on the field by speed into an BattlerIndex array and returns that array.
    * It also checks for Trick Room and reverses the array if it is present.

--- a/src/phases/unavailable-phase.ts
+++ b/src/phases/unavailable-phase.ts
@@ -4,7 +4,7 @@ import { UiMode } from "#enums/ui-mode";
 import { LoginPhase } from "./login-phase";
 
 export class UnavailablePhase extends Phase {
-  protected readonly phaseName = "UnavailablePhase";
+  public readonly phaseName = "UnavailablePhase";
   start(): void {
     globalScene.ui.setMode(UiMode.UNAVAILABLE, () => {
       globalScene.unshiftPhase(new LoginPhase(true));

--- a/src/phases/unavailable-phase.ts
+++ b/src/phases/unavailable-phase.ts
@@ -4,6 +4,7 @@ import { UiMode } from "#enums/ui-mode";
 import { LoginPhase } from "./login-phase";
 
 export class UnavailablePhase extends Phase {
+  protected readonly phaseName = "UnavailablePhase";
   start(): void {
     globalScene.ui.setMode(UiMode.UNAVAILABLE, () => {
       globalScene.unshiftPhase(new LoginPhase(true));

--- a/src/phases/unlock-phase.ts
+++ b/src/phases/unlock-phase.ts
@@ -6,6 +6,7 @@ import { UiMode } from "#enums/ui-mode";
 import i18next from "i18next";
 
 export class UnlockPhase extends Phase {
+  protected readonly phaseName = "UnlockPhase";
   private unlockable: Unlockables;
 
   constructor(unlockable: Unlockables) {

--- a/src/phases/unlock-phase.ts
+++ b/src/phases/unlock-phase.ts
@@ -6,7 +6,7 @@ import { UiMode } from "#enums/ui-mode";
 import i18next from "i18next";
 
 export class UnlockPhase extends Phase {
-  protected readonly phaseName = "UnlockPhase";
+  public readonly phaseName = "UnlockPhase";
   private unlockable: Unlockables;
 
   constructor(unlockable: Unlockables) {

--- a/src/phases/victory-phase.ts
+++ b/src/phases/victory-phase.ts
@@ -18,6 +18,7 @@ import { timedEventManager } from "#app/global-event-manager";
 import { SelectBiomePhase } from "./select-biome-phase";
 
 export class VictoryPhase extends PokemonPhase {
+  protected readonly phaseName = "VictoryPhase";
   /** If true, indicates that the phase is intended for EXP purposes only, and not to continue a battle to next phase */
   isExpOnly: boolean;
 

--- a/src/phases/victory-phase.ts
+++ b/src/phases/victory-phase.ts
@@ -18,7 +18,7 @@ import { timedEventManager } from "#app/global-event-manager";
 import { SelectBiomePhase } from "./select-biome-phase";
 
 export class VictoryPhase extends PokemonPhase {
-  protected readonly phaseName = "VictoryPhase";
+  public readonly phaseName = "VictoryPhase";
   /** If true, indicates that the phase is intended for EXP purposes only, and not to continue a battle to next phase */
   isExpOnly: boolean;
 

--- a/src/phases/weather-effect-phase.ts
+++ b/src/phases/weather-effect-phase.ts
@@ -19,7 +19,7 @@ import { BooleanHolder, toDmgValue } from "#app/utils/common";
 import { CommonAnimPhase } from "./common-anim-phase";
 
 export class WeatherEffectPhase extends CommonAnimPhase {
-  protected readonly phaseName = "WeatherEffectPhase";
+  public readonly phaseName = "WeatherEffectPhase";
   public weather: Weather | null;
 
   constructor() {

--- a/src/phases/weather-effect-phase.ts
+++ b/src/phases/weather-effect-phase.ts
@@ -19,6 +19,7 @@ import { BooleanHolder, toDmgValue } from "#app/utils/common";
 import { CommonAnimPhase } from "./common-anim-phase";
 
 export class WeatherEffectPhase extends CommonAnimPhase {
+  protected readonly phaseName = "WeatherEffectPhase";
   public weather: Weather | null;
 
   constructor() {

--- a/src/ui/command-ui-handler.ts
+++ b/src/ui/command-ui-handler.ts
@@ -75,7 +75,7 @@ export default class CommandUiHandler extends UiHandler {
 
     let commandPhase: CommandPhase;
     const currentPhase = globalScene.getCurrentPhase();
-    if (currentPhase?.isXPhase("CommandPhase")) {
+    if (currentPhase?.is("CommandPhase")) {
       commandPhase = currentPhase;
     } else {
       commandPhase = globalScene.getStandbyPhase() as CommandPhase;

--- a/src/ui/command-ui-handler.ts
+++ b/src/ui/command-ui-handler.ts
@@ -5,7 +5,7 @@ import UiHandler from "./ui-handler";
 import i18next from "i18next";
 import { Button } from "#enums/buttons";
 import { getPokemonNameWithAffix } from "#app/messages";
-import { CommandPhase } from "#app/phases/command-phase";
+import type { CommandPhase } from "#app/phases/command-phase";
 import { globalScene } from "#app/global-scene";
 import { TerastallizeAccessModifier } from "#app/modifier/modifier";
 import { PokemonType } from "#enums/pokemon-type";
@@ -75,7 +75,7 @@ export default class CommandUiHandler extends UiHandler {
 
     let commandPhase: CommandPhase;
     const currentPhase = globalScene.getCurrentPhase();
-    if (currentPhase instanceof CommandPhase) {
+    if (currentPhase?.isXPhase("CommandPhase")) {
       commandPhase = currentPhase;
     } else {
       commandPhase = globalScene.getStandbyPhase() as CommandPhase;

--- a/src/ui/egg-hatch-scene-handler.ts
+++ b/src/ui/egg-hatch-scene-handler.ts
@@ -1,7 +1,6 @@
 import { UiMode } from "#enums/ui-mode";
 import UiHandler from "./ui-handler";
 import { Button } from "#enums/buttons";
-import { EggHatchPhase } from "#app/phases/egg-hatch-phase";
 import { globalScene } from "#app/global-scene";
 
 export default class EggHatchSceneHandler extends UiHandler {
@@ -46,7 +45,7 @@ export default class EggHatchSceneHandler extends UiHandler {
   processInput(button: Button): boolean {
     if (button === Button.ACTION || button === Button.CANCEL) {
       const phase = globalScene.getCurrentPhase();
-      if (phase instanceof EggHatchPhase && phase.trySkip()) {
+      if (phase?.isXPhase("EggHatchPhase") && phase.trySkip()) {
         return true;
       }
     }

--- a/src/ui/egg-hatch-scene-handler.ts
+++ b/src/ui/egg-hatch-scene-handler.ts
@@ -45,7 +45,7 @@ export default class EggHatchSceneHandler extends UiHandler {
   processInput(button: Button): boolean {
     if (button === Button.ACTION || button === Button.CANCEL) {
       const phase = globalScene.getCurrentPhase();
-      if (phase?.isXPhase("EggHatchPhase") && phase.trySkip()) {
+      if (phase?.is("EggHatchPhase") && phase.trySkip()) {
         return true;
       }
     }

--- a/src/ui/egg-summary-ui-handler.ts
+++ b/src/ui/egg-summary-ui-handler.ts
@@ -4,7 +4,6 @@ import MessageUiHandler from "./message-ui-handler";
 import { getEggTierForSpecies } from "../data/egg";
 import { Button } from "#enums/buttons";
 import PokemonHatchInfoContainer from "./pokemon-hatch-info-container";
-import { EggSummaryPhase } from "#app/phases/egg-summary-phase";
 import type { EggHatchData } from "#app/data/egg-hatch-data";
 import ScrollableGridUiHandler from "./scrollable-grid-handler";
 import { HatchedPokemonContainer } from "./hatched-pokemon-container";
@@ -223,7 +222,7 @@ export default class EggSummaryUiHandler extends MessageUiHandler {
     if (button === Button.CANCEL) {
       if (!this.blockExit) {
         const phase = globalScene.getCurrentPhase();
-        if (phase instanceof EggSummaryPhase) {
+        if (phase?.isXPhase("EggSummaryPhase")) {
           phase.end();
         }
         success = true;

--- a/src/ui/egg-summary-ui-handler.ts
+++ b/src/ui/egg-summary-ui-handler.ts
@@ -222,7 +222,7 @@ export default class EggSummaryUiHandler extends MessageUiHandler {
     if (button === Button.CANCEL) {
       if (!this.blockExit) {
         const phase = globalScene.getCurrentPhase();
-        if (phase?.isXPhase("EggSummaryPhase")) {
+        if (phase?.is("EggSummaryPhase")) {
           phase.end();
         }
         success = true;

--- a/src/ui/menu-ui-handler.ts
+++ b/src/ui/menu-ui-handler.ts
@@ -15,7 +15,6 @@ import { Button } from "#enums/buttons";
 import { GameDataType } from "#enums/game-data-type";
 import BgmBar from "#app/ui/bgm-bar";
 import type AwaitableUiHandler from "./awaitable-ui-handler";
-import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
 import { AdminMode, getAdminModeName } from "./admin-ui-handler";
 import { pokerogueApi } from "#app/plugins/api/pokerogue-api";
 
@@ -126,7 +125,7 @@ export default class MenuUiHandler extends MessageUiHandler {
     const ui = this.getUi();
     this.excludedMenus = () => [
       {
-        condition: globalScene.getCurrentPhase() instanceof SelectModifierPhase,
+        condition: !!globalScene.getCurrentPhase()?.isXPhase("SelectModifierPhase"),
         options: [MenuOptions.EGG_GACHA],
       },
       { condition: bypassLogin, options: [MenuOptions.LOG_OUT] },

--- a/src/ui/menu-ui-handler.ts
+++ b/src/ui/menu-ui-handler.ts
@@ -125,7 +125,7 @@ export default class MenuUiHandler extends MessageUiHandler {
     const ui = this.getUi();
     this.excludedMenus = () => [
       {
-        condition: !!globalScene.getCurrentPhase()?.isXPhase("SelectModifierPhase"),
+        condition: !!globalScene.getCurrentPhase()?.is("SelectModifierPhase"),
         options: [MenuOptions.EGG_GACHA],
       },
       { condition: bypassLogin, options: [MenuOptions.LOG_OUT] },

--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -750,7 +750,7 @@ export default class PartyUiHandler extends MessageUiHandler {
     // TODO: This risks hitting the other options (.MOVE_i and ALL) so does it? Do we need an extra check?
     if (
       option >= PartyOption.FORM_CHANGE_ITEM &&
-      globalScene.getCurrentPhase()?.isXPhase("SelectModifierPhase") &&
+      globalScene.getCurrentPhase()?.is("SelectModifierPhase") &&
       this.partyUiMode === PartyUiMode.CHECK
     ) {
       const formChangeItemModifiers = this.getFormChangeItemsModifiers(pokemon);
@@ -1337,7 +1337,7 @@ export default class PartyUiHandler extends MessageUiHandler {
         this.addCommonOptions(pokemon);
         break;
       case PartyUiMode.CHECK:
-        if (globalScene.getCurrentPhase()?.isXPhase("SelectModifierPhase")) {
+        if (globalScene.getCurrentPhase()?.is("SelectModifierPhase")) {
           const formChangeItemModifiers = this.getFormChangeItemsModifiers(pokemon);
           for (let i = 0; i < formChangeItemModifiers.length; i++) {
             this.options.push(PartyOption.FORM_CHANGE_ITEM + i);

--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -29,7 +29,6 @@ import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { getPokemonNameWithAffix } from "#app/messages";
 import type { CommandPhase } from "#app/phases/command-phase";
-import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
 import { globalScene } from "#app/global-scene";
 
 const defaultMessage = i18next.t("partyUiHandler:choosePokemon");
@@ -751,7 +750,7 @@ export default class PartyUiHandler extends MessageUiHandler {
     // TODO: This risks hitting the other options (.MOVE_i and ALL) so does it? Do we need an extra check?
     if (
       option >= PartyOption.FORM_CHANGE_ITEM &&
-      globalScene.getCurrentPhase() instanceof SelectModifierPhase &&
+      globalScene.getCurrentPhase()?.isXPhase("SelectModifierPhase") &&
       this.partyUiMode === PartyUiMode.CHECK
     ) {
       const formChangeItemModifiers = this.getFormChangeItemsModifiers(pokemon);
@@ -1338,7 +1337,7 @@ export default class PartyUiHandler extends MessageUiHandler {
         this.addCommonOptions(pokemon);
         break;
       case PartyUiMode.CHECK:
-        if (globalScene.getCurrentPhase() instanceof SelectModifierPhase) {
+        if (globalScene.getCurrentPhase()?.isXPhase("SelectModifierPhase")) {
           const formChangeItemModifiers = this.getFormChangeItemsModifiers(pokemon);
           for (let i = 0; i < formChangeItemModifiers.length; i++) {
             this.options.push(PartyOption.FORM_CHANGE_ITEM + i);

--- a/src/ui/pokedex-page-ui-handler.ts
+++ b/src/ui/pokedex-page-ui-handler.ts
@@ -665,7 +665,7 @@ export default class PokedexPageUiHandler extends MessageUiHandler {
   show(args: any[]): boolean {
     // Allow the use of candies if we are in one of the whitelisted phases
     this.canUseCandies = ["TitlePhase", "SelectStarterPhase", "CommandPhase"].includes(
-      globalScene.getCurrentPhase()?.constructor.name ?? "",
+      globalScene.getCurrentPhase()?.phaseName ?? "",
     );
 
     if (args.length >= 1 && args[0] === "refresh") {

--- a/test/testUtils/phaseInterceptor.ts
+++ b/test/testUtils/phaseInterceptor.ts
@@ -63,6 +63,8 @@ import { UnlockPhase } from "#app/phases/unlock-phase";
 import { PostGameOverPhase } from "#app/phases/post-game-over-phase";
 import { RevivalBlessingPhase } from "#app/phases/revival-blessing-phase";
 
+import type { PhaseClass, PhaseString } from "#app/@types/phase-types";
+
 export interface PromptHandler {
   phaseTarget?: string;
   mode?: UiMode;
@@ -70,126 +72,6 @@ export interface PromptHandler {
   expireFn?: () => void;
   awaitingActionInput?: boolean;
 }
-
-type PhaseClass =
-  | typeof LoginPhase
-  | typeof TitlePhase
-  | typeof SelectGenderPhase
-  | typeof NewBiomeEncounterPhase
-  | typeof SelectStarterPhase
-  | typeof PostSummonPhase
-  | typeof SummonPhase
-  | typeof ToggleDoublePositionPhase
-  | typeof CheckSwitchPhase
-  | typeof ShowAbilityPhase
-  | typeof MessagePhase
-  | typeof TurnInitPhase
-  | typeof CommandPhase
-  | typeof EnemyCommandPhase
-  | typeof TurnStartPhase
-  | typeof MovePhase
-  | typeof MoveEffectPhase
-  | typeof DamageAnimPhase
-  | typeof FaintPhase
-  | typeof BerryPhase
-  | typeof TurnEndPhase
-  | typeof BattleEndPhase
-  | typeof EggLapsePhase
-  | typeof SelectModifierPhase
-  | typeof NextEncounterPhase
-  | typeof NewBattlePhase
-  | typeof VictoryPhase
-  | typeof LearnMovePhase
-  | typeof MoveEndPhase
-  | typeof StatStageChangePhase
-  | typeof ShinySparklePhase
-  | typeof SelectTargetPhase
-  | typeof UnavailablePhase
-  | typeof QuietFormChangePhase
-  | typeof SwitchPhase
-  | typeof SwitchSummonPhase
-  | typeof PartyHealPhase
-  | typeof FormChangePhase
-  | typeof EvolutionPhase
-  | typeof EndEvolutionPhase
-  | typeof LevelCapPhase
-  | typeof AttemptRunPhase
-  | typeof SelectBiomePhase
-  | typeof MysteryEncounterPhase
-  | typeof MysteryEncounterOptionSelectedPhase
-  | typeof MysteryEncounterBattlePhase
-  | typeof MysteryEncounterRewardsPhase
-  | typeof PostMysteryEncounterPhase
-  | typeof RibbonModifierRewardPhase
-  | typeof GameOverModifierRewardPhase
-  | typeof ModifierRewardPhase
-  | typeof PartyExpPhase
-  | typeof ExpPhase
-  | typeof EncounterPhase
-  | typeof GameOverPhase
-  | typeof UnlockPhase
-  | typeof PostGameOverPhase
-  | typeof RevivalBlessingPhase;
-
-type PhaseString =
-  | "LoginPhase"
-  | "TitlePhase"
-  | "SelectGenderPhase"
-  | "NewBiomeEncounterPhase"
-  | "SelectStarterPhase"
-  | "PostSummonPhase"
-  | "SummonPhase"
-  | "ToggleDoublePositionPhase"
-  | "CheckSwitchPhase"
-  | "ShowAbilityPhase"
-  | "MessagePhase"
-  | "TurnInitPhase"
-  | "CommandPhase"
-  | "EnemyCommandPhase"
-  | "TurnStartPhase"
-  | "MovePhase"
-  | "MoveEffectPhase"
-  | "DamageAnimPhase"
-  | "FaintPhase"
-  | "BerryPhase"
-  | "TurnEndPhase"
-  | "BattleEndPhase"
-  | "EggLapsePhase"
-  | "SelectModifierPhase"
-  | "NextEncounterPhase"
-  | "NewBattlePhase"
-  | "VictoryPhase"
-  | "LearnMovePhase"
-  | "MoveEndPhase"
-  | "StatStageChangePhase"
-  | "ShinySparklePhase"
-  | "SelectTargetPhase"
-  | "UnavailablePhase"
-  | "QuietFormChangePhase"
-  | "SwitchPhase"
-  | "SwitchSummonPhase"
-  | "PartyHealPhase"
-  | "FormChangePhase"
-  | "EvolutionPhase"
-  | "EndEvolutionPhase"
-  | "LevelCapPhase"
-  | "AttemptRunPhase"
-  | "SelectBiomePhase"
-  | "MysteryEncounterPhase"
-  | "MysteryEncounterOptionSelectedPhase"
-  | "MysteryEncounterBattlePhase"
-  | "MysteryEncounterRewardsPhase"
-  | "PostMysteryEncounterPhase"
-  | "RibbonModifierRewardPhase"
-  | "GameOverModifierRewardPhase"
-  | "ModifierRewardPhase"
-  | "PartyExpPhase"
-  | "ExpPhase"
-  | "EncounterPhase"
-  | "GameOverPhase"
-  | "UnlockPhase"
-  | "PostGameOverPhase"
-  | "RevivalBlessingPhase";
 
 type PhaseInterceptorPhase = PhaseClass | PhaseString;
 


### PR DESCRIPTION
## What are the changes the user will see?
None

## Why am I making these changes?
Many circular import cycles occur due to phases importing each other in some way. In many cases, this is entirely due to `instanceof` checks.

## What are the changes from a developer perspective?

First, I moved the phase utility types out of `PhaseInterceptor` and into `phase-types.ts` so that they can be reused.

Adds a new method to `Phase`, called `is` that allows for files to check if a phase is a specific phase without having to import the phase itself to use the `instanceof` check.

I also converted a few phase classes into abstract classes that should have already been marked as such.

I added a new property, `phaseName` to each phase that is just the string name of the phase.

I then replaced all of the instances of `instanceof <specificPhase>` with a call to this method.

Note that this is _not_ the exact same as an `instanceof` check in the case that a phase is subclassed, as it checks the *exact* match of the phase name. This is OK for all of the existing uses of `instanceof` as they were never checking for a phase that could be subclassed.

This reduces circular imports from 585 to 574.

Note that the method also works as a type predicate to narrow the type of the var passed in in the same way that an instanceof check did.

## Screenshots/Videos
N/A

## How to test the changes?
N/A

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually? I did about 50 waves on super speed. Nothing out of the ordinary happened.
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~