### PR TITLE
[Bug] Protect rng now resets on new waves and fixed to look at all turns in the same wave.

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -5780,20 +5780,35 @@ export class ProtectAttr extends AddBattlerTagAttr {
 
   getCondition(): MoveConditionFunc {
     return ((user, target, move): boolean => {
+      // Protect rng resets on new waves, it always succeeds.
+      if (user.tempSummonData.waveTurnCount === 1) {
+        return true;
+      }
+
       let timesUsed = 0;
-      const moveHistory = user.getLastXMoves();
+      const moveHistory = user.getLastXMoves(-1);
       let turnMove: TurnMove | undefined;
 
       while (moveHistory.length) {
         turnMove = moveHistory.shift();
+
         if (!allMoves[turnMove?.move ?? Moves.NONE].hasAttr(ProtectAttr) || turnMove?.result !== MoveResult.SUCCESS) {
           break;
         }
+
         timesUsed++;
+
+        // Break after first move used this wave.
+        // If no move was used on turn 1, then it would have broken in the attr check already.
+        if (turnMove?.turn === 1) {
+          break;
+        }
       }
+
       if (timesUsed) {
         return !user.randBattleSeedInt(Math.pow(3, timesUsed));
       }
+
       return true;
     });
   }


### PR DESCRIPTION
## What are the changes the user will see?
Protect is no longer stuck at maximum 1 in 3 odds. So chaining multiple protects in a row will be far less likely.
Protect is now also guaranteed to succeed on the first turn the pokemon is out. It properly resets the rng on each new wave.

## Why am I making these changes?
Protect was stuck on maximum 1 in 3 odds instead of becoming 3 times less likely on each subsequent protect. And in discussion with balance team, protect rng should reset on each new wave.

## What are the changes from a developer perspective?
-

## Screenshots/Videos


## How to test the changes?
```ts
const overrides = {
  SEED_OVERRIDE: "eUv9ArUWreKyj4MbtnNR8gmI",
  BATTLE_STYLE_OVERRIDE: "double",
  STARTING_LEVEL_OVERRIDE: 1000,
  OPP_MOVESET_OVERRIDE: [Moves.TACKLE],
  MOVESET_OVERRIDE: [Moves.PROTECT, Moves.DETECT, Moves.CORE_ENFORCER],
  STARTING_WAVE_OVERRIDE: 2,
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?