### PR TITLE
[Misc] Prohibit same species fusions

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -5498,6 +5498,38 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
       globalScene.findModifiers(m => m.is("MoneyMultiplierModifier") || m.is("ExtraModifierModifier")).length
     );
   }
+
+  /**
+   * Determine whether this pokemon is one of the prevolutions of the other pokemon (including stage 1 to stage 3)
+   * @param other - The pokemon to check prevolution against
+   * @returns Whether this Pokemon is a prevolution of the other Pokemon
+   */
+  public isPrevolutionOf(other: Pokemon): boolean {
+    let prevolution: SpeciesId | undefined;
+    while ((prevolution = pokemonPrevolutions[other.species.speciesId])) {
+      if (prevolution === this.species.speciesId) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Determine whether this pokemon can fuse with the other pokemon
+   *
+   * @remarks
+   *
+   * This checks if the two Pokemon are the same species, or if one is a prevolution of the other.
+   * Does not check if one of the pokemon is already a fusion.
+   *
+   * @param other - The pokemon to check fusion compatibility with
+   * @returns Whether this Pokemon can fuse with the other Pokemon.
+   */
+  public isFusionForbidden(other: Pokemon): boolean {
+    return (
+      this.species.speciesId === other.species.speciesId || other.isPrevolutionOf(this) || this.isPrevolutionOf(other)
+    );
+  }
 }
 
 export class PlayerPokemon extends Pokemon {

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -100,7 +100,7 @@ import {
 import { ModifierTier } from "#enums/modifier-tier";
 import Overrides from "#app/overrides";
 import { getVoucherTypeIcon, getVoucherTypeName, VoucherType } from "#app/system/voucher";
-import type { PokemonMoveSelectFilter, PokemonSelectFilter } from "#app/ui/party-ui-handler";
+import type { PokemonFuseSelectFilter, PokemonMoveSelectFilter, PokemonSelectFilter } from "#app/ui/party-ui-handler";
 import PartyUiHandler from "#app/ui/party-ui-handler";
 import { getModifierTierTextTint } from "#app/ui/text";
 import {
@@ -1304,18 +1304,24 @@ export class FormChangeItemModifierType extends PokemonModifierType implements G
 }
 
 export class FusePokemonModifierType extends PokemonModifierType {
+  public selectFilter: PokemonFuseSelectFilter;
   constructor(localeKey: string, iconImage: string) {
     super(
       localeKey,
       iconImage,
       (_type, args) => new FusePokemonModifier(this, (args[0] as PlayerPokemon).id, (args[1] as PlayerPokemon).id),
-      (pokemon: PlayerPokemon) => {
-        if (pokemon.isFusion()) {
-          return PartyUiHandler.NoEffectMessage;
-        }
-        return null;
-      },
     );
+
+    this.selectFilter = (pokemon: PlayerPokemon, first?: PlayerPokemon) => {
+      if (pokemon.isFusion()) {
+        return PartyUiHandler.NoEffectMessage;
+      }
+      if (first?.isFusionForbidden(pokemon)) {
+        return PartyUiHandler.FusionForbiddenMessage;
+      }
+
+      return null;
+    };
   }
 
   getDescription(): string {


### PR DESCRIPTION
## What are the changes the user will see?
Pokemon that are the same species will no longer be able to be fused with one another.

TODO: Existing sessions that have same-species fusions will have the second pokemon dropped from the fusion

## Why am I making these changes?
This is desired to make it easier to handle form changes.

## What are the changes from a developer perspective?
Adds two new methods to `Pokemon`, one that checks for fusion legality, and another that checks for pokemon prevolutions.
A minor refactor of the `PartySelectUi#getFilterResult` method to make it easier to reason about, and also have it invoke the new `PokemonFuseSelectfilter`

Modifies the existing `selectFilter` method used by the dna splicer. A new optional parameter is added, `firstPokemon`, that, if provided, rejects the pokemon from being selected if it is unable to fuse with the `firstPokemon` (by checking the new method I added to the pokemon class). If the fusion is denied, returns the new locale key.

TODO:
Need to make a save migrator for version 1.10 that drops the second species from same-species fusions of earlier sessions.
I haven't messed with save migrators before. Will probably want @Xavion3 to look at it.

## Screenshots/Videos

<details><summary>Preventing same species line fusion</summary>

https://github.com/user-attachments/assets/52f509fe-edbd-4df0-9275-0c7f39f18666
</details>

## How to test the changes?
I use these overrides:
```ts
const overrides = {
  OPP_SPECIES_OVERRIDE: Species.BULBASAUR,
  OPP_LEVEL_OVERRIDE: 36,
  STARTER_SPECIES_OVERRIDE: Species.BULBASAUR,
  ITEM_REWARD_OVERRIDE: [{name: "DNA_SPLICERS"}, { name: "RARE_CANDY" }],
  MOVESET_OVERRIDE: [ Moves.FLAMETHROWER ],
  STARTING_LEVEL_OVERRIDE: 100,
  POKEBALL_OVERRIDE: {
    active: true,
    pokeballs: {
      [PokeballType.POKEBALL]: 5,
      [PokeballType.GREAT_BALL]: 0,
      [PokeballType.ULTRA_BALL]: 0,
      [PokeballType.ROGUE_BALL]: 0,
      [PokeballType.MASTER_BALL]: 10,
    }
  }
} satisfies Partial<InstanceType<OverridesType>>;
```

Start with any 3 pokemon, one of them as bulbasaur, and ensure that the first slot is NOT bulbasaur (otherwise you have to catch an extra bulbasaur).

I use Charmander, Squirtle, Bulbasaur. (The override will force charmander into a bulbasaur, and then we use squirtle to show normal fusion is still allowed).

First wave, catch the bulbasaur and choose rare candy to evolve one into ivysaur.
Next wave, KO opponent and use dna splicer to confirm that fusions are denied / allowed as expected.


## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes? No, I'd rather not make unit tests for modifiers until after the modifier rework
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~

Are there any localization additions or changes? If so:
- [x] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: https://github.com/pagefaultgames/pokerogue-locales/pull/169
- [x] Has the translation team been contacted for proofreading/translation?