### PR TITLE
[Test] Fix mock text to make it compatible with method chaining

### DIFF
--- a/test/testUtils/mocks/mocksContainer/mockText.ts
+++ b/test/testUtils/mocks/mocksContainer/mockText.ts
@@ -159,8 +159,8 @@ export default class MockText implements MockGameObject {
     // return this.phaserText.addedToScene();
   }
 
-  setVisible(_visible) {
-    // return this.phaserText.setVisible(visible);
+  setVisible(_visible): this {
+    return this;
   }
 
   setY(_y): this {
@@ -209,9 +209,10 @@ export default class MockText implements MockGameObject {
     return this;
   }
 
-  setWordWrapWidth(width) {
+  setWordWrapWidth(width): this {
     // Sets the width (in pixels) to use for wrapping lines.
     this.wordWrapWidth = width;
+    return this;
   }
 
   setFontSize(_fontSize): this {
@@ -351,5 +352,6 @@ export default class MockText implements MockGameObject {
     return this.runWordWrap(this.text).split("\n");
   }
 
+  // biome-ignore lint/complexity/noBannedTypes: This matches the signature of the class this mocks
   on(_event: string | symbol, _fn: Function, _context?: any) {}
 }


### PR DESCRIPTION
## What are the changes the user will see?
None

## Why am I making these changes?
Fixes the signature and implementation of a few methods of the mock text object to reflect the actual signature of phaser's text object.
This is needed because I am using the method chaining functionality of Phaser to cleanup our ui files.

## What are the changes from a developer perspective?
Makes mock text's `setVisible` and `setWordWrapWidth` return `this`, same as the method that they mock.

## Screenshots/Videos
N/A

## How to test the changes?
N/A

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~