### PR TITLE
[Test] Fix mocks' add method to match phaser signature

### DIFF
--- a/test/testUtils/mocks/mocksContainer/mockContainer.ts
+++ b/test/testUtils/mocks/mocksContainer/mockContainer.ts
@@ -214,9 +214,12 @@ export default class MockContainer implements MockGameObject {
     return this;
   }
 
-  add(...obj: MockGameObject[]): this {
-    // Adds a child to this Game Object.
-    this.list.push(...obj);
+  add(obj: MockGameObject | MockGameObject[]): this {
+    if (Array.isArray(obj)) {
+      this.list.push(...obj);
+    } else {
+      this.list.push(obj);
+    }
     return this;
   }
 

--- a/test/testUtils/mocks/mocksContainer/mockRectangle.ts
+++ b/test/testUtils/mocks/mocksContainer/mockRectangle.ts
@@ -47,9 +47,13 @@ export default class MockRectangle implements MockGameObject {
     this.list = [];
   }
 
-  add(obj): this {
+  add(obj: MockGameObject | MockGameObject[]): this {
     // Adds a child to this Game Object.
-    this.list.push(obj);
+    if (Array.isArray(obj)) {
+      this.list.push(...obj);
+    } else {
+      this.list.push(obj);
+    }
     return this;
   }
 

--- a/test/testUtils/mocks/mocksContainer/mockSprite.ts
+++ b/test/testUtils/mocks/mocksContainer/mockSprite.ts
@@ -201,9 +201,13 @@ export default class MockSprite implements MockGameObject {
     return this;
   }
 
-  add(obj): this {
+  add(obj: MockGameObject | MockGameObject[]): this {
     // Adds a child to this Game Object.
-    this.list.push(obj);
+    if (Array.isArray(obj)) {
+      this.list.push(...obj);
+    } else {
+      this.list.push(obj);
+    }
     return this;
   }
 


### PR DESCRIPTION
## What are the changes the user will see?
None

## Why am I making these changes?
The add method of mock container (and friends) was erroneously using the rest parameter list instead of taking a single object or an array of objects.

## What are the changes from a developer perspective?
Fixes the afformentioned issue

## Screenshots/Videos
N/A

## How to test the changes?
N/A

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~~[ ] Have I tested the changes manually?~~
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~