### PR TITLE
[Bug] Fix improperly named sprite key for enemy boss' battle info bar

### DIFF
--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -230,7 +230,7 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
     this.box = globalScene.add.sprite(0, 0, this.getTextureName()).setName("box").setOrigin(1, 0.5);
     this.add(this.box);
 
-    this.nameText = addTextObject(player ? -115 : -124, player ? -15.2 : -11.2, "", TextStyle.BATTLE_INFO)
+    this.nameText = addTextObject(posParams.nameTextX, posParams.nameTextY, "", TextStyle.BATTLE_INFO)
       .setName("text_name")
       .setOrigin(0);
     this.add(this.nameText);

--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -29,7 +29,7 @@ export class EnemyBattleInfo extends BattleInfo {
   }
 
   override getTextureName(): string {
-    return this.boss ? "pbinfo_enemy_boss_mini" : "pbinfo_enemy_mini";
+    return this.boss ? "pbinfo_enemy_boss" : "pbinfo_enemy_mini";
   }
 
   override constructTypeIcons(): void {


### PR DESCRIPTION
## What are the changes the user will see?
Fixes missing texture images for enemy boss battle bars

## Why am I making these changes?
Fixes an oversight from #5696 

## What are the changes from a developer perspective?
Fixes the improper images caused by the wrong key name being used.
Also fixes a missed use of posParams in the constructor.


## Screenshots/Videos
The buggy image
![image](https://github.com/user-attachments/assets/100dcdc4-fde1-4569-abb3-c70ad0330cba)

## How to test the changes?
Start up a run and get to a boss wave, and ensure that the boss hp bar renders properly.


## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~