### PR TITLE
[Test] Add missing methods to many mocks

### DIFF
--- a/test/testUtils/mocks/mockGameObject.ts
+++ b/test/testUtils/mocks/mockGameObject.ts
@@ -1,4 +1,7 @@
 export interface MockGameObject {
   name: string;
+  active: boolean;
   destroy?(): void;
+  setActive(active: boolean): this;
+  setName(name: string): this;
 }

--- a/test/testUtils/mocks/mockVideoGameObject.ts
+++ b/test/testUtils/mocks/mockVideoGameObject.ts
@@ -3,11 +3,20 @@ import type { MockGameObject } from "./mockGameObject";
 /** Mocks video-related stuff */
 export class MockVideoGameObject implements MockGameObject {
   public name: string;
+  public active = true;
 
   public play = () => null;
   public stop = () => this;
-  public setOrigin = () => null;
-  public setScale = () => null;
-  public setVisible = () => null;
-  public setLoop = () => null;
+  public setOrigin = () => this;
+  public setScale = () => this;
+  public setVisible = () => this;
+  public setLoop = () => this;
+  public setName = (name: string) => {
+    this.name = name;
+    return this;
+  };
+  public setActive = (active: boolean) => {
+    this.active = active;
+    return this;
+  };
 }

--- a/test/testUtils/mocks/mocksContainer/mockContainer.ts
+++ b/test/testUtils/mocks/mocksContainer/mockContainer.ts
@@ -14,6 +14,7 @@ export default class MockContainer implements MockGameObject {
   protected textureManager;
   public list: MockGameObject[] = [];
   public name: string;
+  public active = true;
 
   constructor(textureManager: MockTextureManager, x: number, y: number) {
     this.x = x;
@@ -304,6 +305,11 @@ export default class MockContainer implements MockGameObject {
     if (source.y !== undefined) {
       this.y = source.y;
     }
+    return this;
+  }
+
+  setActive(active: boolean): this {
+    this.active = active;
     return this;
   }
 }

--- a/test/testUtils/mocks/mocksContainer/mockGraphics.ts
+++ b/test/testUtils/mocks/mocksContainer/mockGraphics.ts
@@ -4,6 +4,7 @@ export default class MockGraphics implements MockGameObject {
   private scene;
   public list: MockGameObject[] = [];
   public name: string;
+  public active = true;
   constructor(textureManager, _config) {
     this.scene = textureManager.scene;
   }
@@ -111,6 +112,11 @@ export default class MockGraphics implements MockGameObject {
   }
 
   copyPosition(_source): this {
+    return this;
+  }
+
+  setActive(active: boolean): this {
+    this.active = active;
     return this;
   }
 }

--- a/test/testUtils/mocks/mocksContainer/mockRectangle.ts
+++ b/test/testUtils/mocks/mocksContainer/mockRectangle.ts
@@ -5,6 +5,7 @@ export default class MockRectangle implements MockGameObject {
   private scene;
   public list: MockGameObject[] = [];
   public name: string;
+  public active = true;
 
   constructor(textureManager, _x, _y, _width, _height, fillColor) {
     this.fillColor = fillColor;
@@ -94,6 +95,11 @@ export default class MockRectangle implements MockGameObject {
   }
 
   off(): this {
+    return this;
+  }
+
+  setActive(active: boolean): this {
+    this.active = active;
     return this;
   }
 }

--- a/test/testUtils/mocks/mocksContainer/mockSprite.ts
+++ b/test/testUtils/mocks/mocksContainer/mockSprite.ts
@@ -13,6 +13,7 @@ export default class MockSprite implements MockGameObject {
   public anims;
   public list: MockGameObject[] = [];
   public name: string;
+  public active = true;
   constructor(textureManager, x, y, texture) {
     this.textureManager = textureManager;
     this.scene = textureManager.scene;
@@ -245,6 +246,11 @@ export default class MockSprite implements MockGameObject {
 
   copyPosition(obj): this {
     this.phaserSprite.copyPosition(obj);
+    return this;
+  }
+
+  setActive(active: boolean): this {
+    this.phaserSprite.setActive(active);
     return this;
   }
 }

--- a/test/testUtils/mocks/mocksContainer/mockText.ts
+++ b/test/testUtils/mocks/mocksContainer/mockText.ts
@@ -12,6 +12,7 @@ export default class MockText implements MockGameObject {
   public text = "";
   public name: string;
   public color?: string;
+  public active = true;
 
   constructor(textureManager, _x, _y, _content, _styleOptions) {
     this.scene = textureManager.scene;
@@ -354,4 +355,8 @@ export default class MockText implements MockGameObject {
 
   // biome-ignore lint/complexity/noBannedTypes: This matches the signature of the class this mocks
   on(_event: string | symbol, _fn: Function, _context?: any) {}
+
+  setActive(_active: boolean): this {
+    return this;
+  }
 }

--- a/test/testUtils/mocks/mocksContainer/mockTexture.ts
+++ b/test/testUtils/mocks/mocksContainer/mockTexture.ts
@@ -12,6 +12,7 @@ export default class MockTexture implements MockGameObject {
   public frames: object;
   public firstFrame: string;
   public name: string;
+  public active: boolean;
 
   constructor(manager, key: string, source) {
     this.manager = manager;
@@ -38,5 +39,15 @@ export default class MockTexture implements MockGameObject {
   /** Mocks the function call that gets an HTMLImageElement, see {@link Pokemon.updateFusionPalette} */
   getSourceImage() {
     return null;
+  }
+
+  setActive(active: boolean): this {
+    this.active = active;
+    return this;
+  }
+
+  setName(name: string): this {
+    this.name = name;
+    return this;
   }
 }


### PR DESCRIPTION
## What are the changes the user will see?
Fixes several instances of mocks methods that are missing.

## Why am I making these changes?
I am refactoring UI and I keep running into issues where tests fail because methods aren't defined. This fixes yet another set of them. 

## What are the changes from a developer perspective?
Ensures that `setName` and `setActive` are defined for all mock game objects.

## Screenshots/Videos
N/A

## How to test the changes?
N/A

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~