### PR TITLE
[GitHub] Fix gh action path filter

### DIFF
--- a/.github/test-filters.yml
+++ b/.github/test-filters.yml
@@ -1,7 +1,8 @@
 all:
-  - "src/**"
-  - "test/**"
-  - "public/**"
+  # Negations syntax from https://github.com/dorny/paths-filter/issues/184#issuecomment-2786521554
+  - "src/**/!(*.{md,py,sh,gitkeep,gitignore})"
+  - "test/**/!(*.md,*.py,*.sh,*.gitkeep,*.gitignore)"
+  - "public/**/!(*.{md,py,sh,gitkeep,gitignore})"
   # Workflows that can impact tests
   - ".github/workflows/test*.yml"
   - ".github/test-filters.yml"
@@ -12,8 +13,3 @@ all:
   - "tsconfig*.json" # tsconfig.json tweaking can impact compilation
   - "global.d.ts"
   - ".env*"
-  # Blanket negations for files that cannot impact tests
-  - "!**/*.py" # No .py files
-  - "!**/*.sh" # No .sh files
-  - "!**/*.md" # No .md files
-  - "!**/.git*" # .gitkeep and family

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+        id: filter
         with:
           filters: .github/test-filters.yml
 
@@ -39,4 +40,4 @@ jobs:
       project: main
       shard: ${{ matrix.shard }}
       totalShards: 10
-      skip: ${{ needs.check-path-change-filter.outputs.all == 'false'}}
+      skip: ${{ needs.check-path-change-filter.outputs.all != 'true'}}


### PR DESCRIPTION
# What are the changes the user will see?
None

## Why am I making these changes?
Previously, #5744 attempted to do this. However, the implementation relied on a misunderstanding of the syntax used by paths filter related to file negation.
See, by default, path filters must match any rule.  It does _not_ use git ignore style filtering. That means that when we wrote

```
  - "!**/*.py" # No .py files
  - "!**/*.sh" # No .sh files
  - "!**/*.md" # No .md files
  - "!**/.git*" # .gitkeep and family
```
in an attempt to negate these file endings, it would end up matching these for _every file_.
This meant that changes would always be detected, and so tests were _never_ being skipped.

Also, there was an oversight where the `id` field for the job was not filled out, and so the output variable was not even being set properly.

I fixed all of this.

Should be a simple change.

## What are the changes from a developer perspective?
Described above

## Screenshots/Videos
Idk how to screenshot or video this

## How to test the changes?
This is the tricky thing. You'd have to make a new github repository and set up actions properly.

I did this over on a private repo. If you have questions, then let me know.

https://github.com/SirzBenjie/test-path-filter

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- ~~[ ] Are all unit tests still passing? (`npm run test:silent`)~~
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~