### PR TITLE
[Bug][UI/UX] Fix name position and types not being updated in battle info

### DIFF
--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -447,12 +447,14 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
   }
 
   /** Update the pokemon name inside the container */
-  protected updateName(name: string): boolean {
+  protected updateName(pokemon: Pokemon): boolean {
+    const name = pokemon.getNameToRender();
     if (this.lastName === name) {
       return false;
     }
-    this.nameText.setText(name).setPositionRelative(this.box, -this.nameText.displayWidth, 0);
-    this.lastName = name;
+
+    this.updateNameText(pokemon);
+    this.genderText.setPositionRelative(this.nameText, this.nameText.displayWidth, 0);
 
     return true;
   }
@@ -572,7 +574,7 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
 
     this.genderText.setText(getGenderSymbol(gender)).setColor(getGenderColor(gender));
 
-    const nameUpdated = this.updateName(pokemon.getNameToRender());
+    const nameUpdated = this.updateName(pokemon);
 
     const teraTypeUpdated = this.updateTeraType(pokemon.isTerastallized ? pokemon.getTeraType() : PokemonType.UNKNOWN);
 
@@ -583,6 +585,8 @@ export default abstract class BattleInfo extends Phaser.GameObjects.Container {
     }
 
     this.updateStatusIcon(pokemon);
+
+    this.setTypes(pokemon.getTypes(true, false, undefined, true));
 
     if (this.lastHp !== pokemon.hp || this.lastMaxHp !== pokemon.getMaxHp()) {
       return this.updatePokemonHp(pokemon, resolve, instant);


### PR DESCRIPTION
## What are the changes the user will see?
#5693 Cleaned up methods and refactored out common logic to their own methods. However, it forgot to call the methods properly in the init info

## Why am I making these changes?
Fixes a regression caused by #5693 

## What are the changes from a developer perspective?
Ensures that the `setTypes` is called in battle info's `updateInfo`, and fixes the call to `updateName` to actually call `updateNameText`

## Screenshots/Videos
<details><summary>Current behavior on beta</summary>

https://github.com/user-attachments/assets/ef8a9fd8-f5fe-412d-b082-357354aa1b1d
</details>

<details><summary>Proper type and name position</summary>

https://github.com/user-attachments/assets/29b509b3-b4f8-4a0a-a22a-858da6081971
</details>

## How to test the changes?
I don't use any overrides, I just make sure to take zoroark / zoroark hisui as the second pokemon in the run.
At the start, you just switch to that pokemon. Notice that the types are now displaying the illusion types properly, and the name is no longer weirdly offset.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~