### PR TITLE
[Test] `MoveHelper#changeMoveset` disables moveset overrides

### DIFF
--- a/test/moves/assist.test.ts
+++ b/test/moves/assist.test.ts
@@ -86,12 +86,11 @@ describe("Moves - Assist", () => {
   });
 
   it("should apply secondary effects of a move", async () => {
-    game.override.moveset([MoveId.ASSIST, MoveId.WOOD_HAMMER, MoveId.WOOD_HAMMER, MoveId.WOOD_HAMMER]);
     await game.classicMode.startBattle([SpeciesId.FEEBAS, SpeciesId.SHUCKLE]);
 
     const [feebas, shuckle] = game.scene.getPlayerField();
-    game.move.changeMoveset(feebas, [MoveId.ASSIST, MoveId.SKETCH, MoveId.PROTECT, MoveId.DRAGON_TAIL]);
-    game.move.changeMoveset(shuckle, [MoveId.ASSIST, MoveId.SKETCH, MoveId.PROTECT, MoveId.DRAGON_TAIL]);
+    game.move.changeMoveset(feebas, [MoveId.ASSIST, MoveId.WOOD_HAMMER]);
+    game.move.changeMoveset(shuckle, [MoveId.ASSIST, MoveId.WOOD_HAMMER]);
 
     game.move.select(MoveId.ASSIST, 0);
     game.move.select(MoveId.ASSIST, 1);

--- a/test/test-utils/helpers/move-helper.ts
+++ b/test/test-utils/helpers/move-helper.ts
@@ -209,12 +209,27 @@ export class MoveHelper extends GameManagerHelper {
 
   /**
    * Changes a pokemon's moveset to the given move(s).
+   *
    * Used when the normal moveset override can't be used (such as when it's necessary to check or update properties of the moveset).
+   *
+   * **Note**: Will disable the moveset override matching the pokemon's party.
    * @param pokemon - The {@linkcode Pokemon} being modified
    * @param moveset - The {@linkcode MoveId} (single or array) to change the Pokemon's moveset to.
    */
   public changeMoveset(pokemon: Pokemon, moveset: MoveId | MoveId[]): void {
+    if (pokemon.isPlayer()) {
+      if (coerceArray(Overrides.MOVESET_OVERRIDE).length > 0) {
+        vi.spyOn(Overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([]);
+        console.warn("Player moveset override disabled due to use of `game.move.changeMoveset`!");
+      }
+    } else {
+      if (coerceArray(Overrides.OPP_MOVESET_OVERRIDE).length > 0) {
+        vi.spyOn(Overrides, "OPP_MOVESET_OVERRIDE", "get").mockReturnValue([]);
+        console.warn("Enemy moveset override disabled due to use of `game.move.changeMoveset`!");
+      }
+    }
     moveset = coerceArray(moveset);
+    expect(moveset.length, "Cannot assign more than 4 moves to a moveset!").toBeLessThanOrEqual(4);
     pokemon.moveset = [];
     moveset.forEach(move => {
       pokemon.moveset.push(new PokemonMove(move));


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
To prevent mistakes when writing tests.

## What are the changes from a developer perspective?
The helper function used to manually modify a Pokémon's moveset in tests will now disable the matching override.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?