### PR TITLE
Translatable Game Speed values

### DIFF
--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -193,35 +193,35 @@ export const Setting: Array<Setting> = [
     options: [
       {
         value: "1",
-        label: "1x",
+        label: i18next.t("settings:gameSpeed1x"),
       },
       {
         value: "1.25",
-        label: "1.25x",
+        label: i18next.t("settings:gameSpeed1_25x"),
       },
       {
         value: "1.5",
-        label: "1.5x",
+        label: i18next.t("settings:gameSpeed1_5x"),
       },
       {
         value: "2",
-        label: "2x",
+        label: i18next.t("settings:gameSpeed2x"),
       },
       {
         value: "2.5",
-        label: "2.5x",
+        label: i18next.t("settings:gameSpeed2_5x"),
       },
       {
         value: "3",
-        label: "3x",
+        label: i18next.t("settings:gameSpeed3x"),
       },
       {
         value: "4",
-        label: "4x",
+        label: i18next.t("settings:gameSpeed4x"),
       },
       {
         value: "5",
-        label: "5x",
+        label: i18next.t("settings:gameSpeed5x"),
       },
     ],
     default: 3,


### PR DESCRIPTION
## What are the changes the user will see?
If applicable, the Game Speed values in a number format more suited to their language (if not playing in English)

## Why am I making these changes?
To allow to adapt values of Game Speed to the format of each language

## What are the changes from a developer perspective?
None

## Screenshots/Videos
BEFORE (French):
![image](https://github.com/user-attachments/assets/551d56f3-2d98-42cd-8ae0-e5b2c10f0e2c)

AFTER (French):
![image](https://github.com/user-attachments/assets/1633bc2f-1bd7-4eb7-b735-2284b4ca3c21)

## How to test the changes?
Play the game in another language, (currently preferably in French) and check the Game Speed values

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [X] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [X] If so, please leave a link to it here: https://github.com/pagefaultgames/pokerogue-locales/pull/171
- [X] Has the translation team been contacted for proofreading/translation?