### PR TITLE
[UI/UX] Moves menu position adjustments

### DIFF
--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -292,7 +292,7 @@ export default class FightUiHandler extends UiHandler implements InfoToggle {
     this.accuracyText.setVisible(hasMove);
     this.moveCategoryIcon.setVisible(hasMove);
 
-    this.cursorObj.setPosition(13 + (cursor % 2 === 1 ? 100 : 0), -31 + (cursor >= 2 ? 15 : 0));
+    this.cursorObj.setPosition(13 + (cursor % 2 === 1 ? 114 : 0), -31 + (cursor >= 2 ? 15 : 0));
 
     return changed;
   }
@@ -322,7 +322,7 @@ export default class FightUiHandler extends UiHandler implements InfoToggle {
     const moveset = pokemon.getMoveset();
 
     for (let moveIndex = 0; moveIndex < 4; moveIndex++) {
-      const moveText = addTextObject(moveIndex % 2 === 0 ? 0 : 100, moveIndex < 2 ? 0 : 16, "-", TextStyle.WINDOW);
+      const moveText = addTextObject(moveIndex % 2 === 0 ? 0 : 114, moveIndex < 2 ? 0 : 16, "-", TextStyle.WINDOW);
       moveText.setName("text-empty-move");
 
       if (moveIndex < moveset.length) {


### PR DESCRIPTION
## What are the changes the user will see?
Moves in the move selection menu during a battle are a bit more spaced (by the equivalent of 2 characters)

## Why am I making these changes?
To equilibrate the space on both sides, and allow newly added languages to better fit when displayed on the left column. (because some have names way longer than any existing languages)

## What are the changes from a developer perspective?
None

## Screenshots/Videos
BEFORE
![image](https://github.com/user-attachments/assets/03d06dd5-ee5c-4495-944d-a6c4663cc38b)

AFTER
![image](https://github.com/user-attachments/assets/05dd131b-a381-4cd0-ae9a-8047929b947a)

## How to test the changes?
Play the game and go the move selection menu during a battle

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?