### PR TITLE
[Test] Condensed all `game.override` calls into 1 chained line where possible

### DIFF
--- a/test/abilities/battery.test.ts
+++ b/test/abilities/battery.test.ts
@@ -26,11 +26,12 @@ describe("Abilities - Battery", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("double");
-    game.override.enemySpecies(Species.SHUCKLE);
-    game.override.enemyAbility(Abilities.BALL_FETCH);
-    game.override.moveset([Moves.TACKLE, Moves.BREAKING_SWIPE, Moves.SPLASH, Moves.DAZZLING_GLEAM]);
-    game.override.enemyMoveset(Moves.SPLASH);
+    game.override
+      .battleStyle("double")
+      .enemySpecies(Species.SHUCKLE)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .moveset([Moves.TACKLE, Moves.BREAKING_SWIPE, Moves.SPLASH, Moves.DAZZLING_GLEAM])
+      .enemyMoveset(Moves.SPLASH);
   });
 
   it("raises the power of allies' special moves by 30%", async () => {

--- a/test/abilities/costar.test.ts
+++ b/test/abilities/costar.test.ts
@@ -24,10 +24,11 @@ describe("Abilities - COSTAR", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("double");
-    game.override.ability(Abilities.COSTAR);
-    game.override.moveset([Moves.SPLASH, Moves.NASTY_PLOT]);
-    game.override.enemyMoveset(Moves.SPLASH);
+    game.override
+      .battleStyle("double")
+      .ability(Abilities.COSTAR)
+      .moveset([Moves.SPLASH, Moves.NASTY_PLOT])
+      .enemyMoveset(Moves.SPLASH);
   });
 
   test("ability copies positive stat stages", async () => {

--- a/test/abilities/disguise.test.ts
+++ b/test/abilities/disguise.test.ts
@@ -66,8 +66,7 @@ describe("Abilities - Disguise", () => {
   });
 
   it("takes no damage from the first hit of a multihit move and transforms to Busted form, then takes damage from the second hit", async () => {
-    game.override.moveset([Moves.SURGING_STRIKES]);
-    game.override.enemyLevel(5);
+    game.override.moveset([Moves.SURGING_STRIKES]).enemyLevel(5);
     await game.classicMode.startBattle();
 
     const mimikyu = game.scene.getEnemyPokemon()!;
@@ -106,8 +105,7 @@ describe("Abilities - Disguise", () => {
   });
 
   it("persists form change when switched out", async () => {
-    game.override.enemyMoveset([Moves.SHADOW_SNEAK]);
-    game.override.starterSpecies(0);
+    game.override.enemyMoveset([Moves.SHADOW_SNEAK]).starterSpecies(0);
 
     await game.classicMode.startBattle([Species.MIMIKYU, Species.FURRET]);
 
@@ -131,8 +129,7 @@ describe("Abilities - Disguise", () => {
   });
 
   it("persists form change when wave changes with no arena reset", async () => {
-    game.override.starterSpecies(0);
-    game.override.starterForms({
+    game.override.starterSpecies(0).starterForms({
       [Species.MIMIKYU]: bustedForm,
     });
     await game.classicMode.startBattle([Species.FURRET, Species.MIMIKYU]);
@@ -148,11 +145,12 @@ describe("Abilities - Disguise", () => {
   });
 
   it("reverts to Disguised form on arena reset", async () => {
-    game.override.startingWave(4);
-    game.override.starterSpecies(Species.MIMIKYU);
-    game.override.starterForms({
-      [Species.MIMIKYU]: bustedForm,
-    });
+    game.override
+      .startingWave(4)
+      .starterSpecies(Species.MIMIKYU)
+      .starterForms({
+        [Species.MIMIKYU]: bustedForm,
+      });
 
     await game.classicMode.startBattle();
 
@@ -168,11 +166,12 @@ describe("Abilities - Disguise", () => {
   });
 
   it("reverts to Disguised form on biome change when fainted", async () => {
-    game.override.startingWave(10);
-    game.override.starterSpecies(0);
-    game.override.starterForms({
-      [Species.MIMIKYU]: bustedForm,
-    });
+    game.override
+      .startingWave(10)
+      .starterSpecies(0)
+      .starterForms({
+        [Species.MIMIKYU]: bustedForm,
+      });
 
     await game.classicMode.startBattle([Species.MIMIKYU, Species.FURRET]);
 
@@ -206,8 +205,7 @@ describe("Abilities - Disguise", () => {
   });
 
   it("activates when Aerilate circumvents immunity to the move's base type", async () => {
-    game.override.ability(Abilities.AERILATE);
-    game.override.moveset([Moves.TACKLE]);
+    game.override.ability(Abilities.AERILATE).moveset([Moves.TACKLE]);
 
     await game.classicMode.startBattle();
 

--- a/test/abilities/flash_fire.test.ts
+++ b/test/abilities/flash_fire.test.ts
@@ -73,8 +73,7 @@ describe("Abilities - Flash Fire", () => {
   }, 20000);
 
   it("activated after being frozen", async () => {
-    game.override.enemyMoveset([Moves.EMBER]).moveset(Moves.SPLASH);
-    game.override.statusEffect(StatusEffect.FREEZE);
+    game.override.enemyMoveset([Moves.EMBER]).moveset(Moves.SPLASH).statusEffect(StatusEffect.FREEZE);
     await game.classicMode.startBattle([Species.BLISSEY]);
 
     const blissey = game.scene.getPlayerPokemon()!;
@@ -102,8 +101,11 @@ describe("Abilities - Flash Fire", () => {
   }, 20000);
 
   it("boosts Fire-type move when the ability is activated", async () => {
-    game.override.enemyMoveset([Moves.FIRE_PLEDGE]).moveset([Moves.EMBER, Moves.SPLASH]);
-    game.override.enemyAbility(Abilities.FLASH_FIRE).ability(Abilities.NONE);
+    game.override
+      .enemyMoveset([Moves.FIRE_PLEDGE])
+      .moveset([Moves.EMBER, Moves.SPLASH])
+      .enemyAbility(Abilities.FLASH_FIRE)
+      .ability(Abilities.NONE);
     await game.classicMode.startBattle([Species.BLISSEY]);
     const blissey = game.scene.getPlayerPokemon()!;
     const initialHP = 1000;
@@ -127,9 +129,12 @@ describe("Abilities - Flash Fire", () => {
   }, 20000);
 
   it("still activates regardless of accuracy check", async () => {
-    game.override.moveset(Moves.FIRE_PLEDGE).enemyMoveset(Moves.EMBER);
-    game.override.enemyAbility(Abilities.NONE).ability(Abilities.FLASH_FIRE);
-    game.override.enemySpecies(Species.BLISSEY);
+    game.override
+      .moveset(Moves.FIRE_PLEDGE)
+      .enemyMoveset(Moves.EMBER)
+      .enemyAbility(Abilities.NONE)
+      .ability(Abilities.FLASH_FIRE)
+      .enemySpecies(Species.BLISSEY);
     await game.classicMode.startBattle([Species.RATTATA]);
 
     const blissey = game.scene.getEnemyPokemon()!;

--- a/test/abilities/flower_gift.test.ts
+++ b/test/abilities/flower_gift.test.ts
@@ -47,9 +47,10 @@ describe("Abilities - Flower Gift", () => {
     allyAbility = Abilities.BALL_FETCH,
     enemyAbility = Abilities.BALL_FETCH,
   ): Promise<[number, number]> => {
-    game.override.battleStyle("double");
-    game.override.moveset([Moves.SPLASH, Moves.SUNNY_DAY, move, Moves.HEAL_PULSE]);
-    game.override.enemyMoveset([Moves.SPLASH, Moves.HEAL_PULSE]);
+    game.override
+      .battleStyle("double")
+      .moveset([Moves.SPLASH, Moves.SUNNY_DAY, move, Moves.HEAL_PULSE])
+      .enemyMoveset([Moves.SPLASH, Moves.HEAL_PULSE]);
     const target_index = allyAttacker ? BattlerIndex.ENEMY : BattlerIndex.PLAYER_2;
     const attacker_index = allyAttacker ? BattlerIndex.PLAYER_2 : BattlerIndex.ENEMY;
     const ally_move = allyAttacker ? move : Moves.SPLASH;

--- a/test/abilities/good_as_gold.test.ts
+++ b/test/abilities/good_as_gold.test.ts
@@ -63,9 +63,10 @@ describe("Abilities - Good As Gold", () => {
   });
 
   it("should not block any status moves that target the field, one side, or all pokemon", async () => {
-    game.override.battleStyle("double");
-    game.override.enemyMoveset([Moves.STEALTH_ROCK, Moves.HAZE]);
-    game.override.moveset([Moves.SWORDS_DANCE, Moves.SAFEGUARD]);
+    game.override
+      .battleStyle("double")
+      .enemyMoveset([Moves.STEALTH_ROCK, Moves.HAZE])
+      .moveset([Moves.SWORDS_DANCE, Moves.SAFEGUARD]);
     await game.classicMode.startBattle([Species.MAGIKARP, Species.FEEBAS]);
     const [good_as_gold, ball_fetch] = game.scene.getPlayerField();
 
@@ -85,8 +86,7 @@ describe("Abilities - Good As Gold", () => {
   });
 
   it("should not block field targeted effects in singles", async () => {
-    game.override.battleStyle("single");
-    game.override.enemyMoveset([Moves.SPIKES]);
+    game.override.battleStyle("single").enemyMoveset([Moves.SPIKES]);
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
     game.move.select(Moves.SPLASH, 0);
@@ -96,8 +96,7 @@ describe("Abilities - Good As Gold", () => {
   });
 
   it("should block the ally's helping hand", async () => {
-    game.override.battleStyle("double");
-    game.override.moveset([Moves.HELPING_HAND, Moves.TACKLE]);
+    game.override.battleStyle("double").moveset([Moves.HELPING_HAND, Moves.TACKLE]);
     await game.classicMode.startBattle([Species.MAGIKARP, Species.FEEBAS]);
 
     game.move.select(Moves.HELPING_HAND, 0);
@@ -129,8 +128,7 @@ describe("Abilities - Good As Gold", () => {
   });
 
   it("should not block field targeted effects like rain dance", async () => {
-    game.override.battleStyle("single");
-    game.override.enemyMoveset([Moves.RAIN_DANCE]);
+    game.override.battleStyle("single").enemyMoveset([Moves.RAIN_DANCE]);
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
     game.move.use(Moves.SPLASH, 0);

--- a/test/abilities/hustle.test.ts
+++ b/test/abilities/hustle.test.ts
@@ -75,8 +75,7 @@ describe("Abilities - Hustle", () => {
   });
 
   it("does not affect OHKO moves", async () => {
-    game.override.startingLevel(100);
-    game.override.enemyLevel(30);
+    game.override.startingLevel(100).enemyLevel(30);
 
     await game.classicMode.startBattle([Species.PIKACHU]);
     const pikachu = game.scene.getPlayerPokemon()!;

--- a/test/abilities/ice_face.test.ts
+++ b/test/abilities/ice_face.test.ts
@@ -30,10 +30,11 @@ describe("Abilities - Ice Face", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-    game.override.enemySpecies(Species.EISCUE);
-    game.override.enemyAbility(Abilities.ICE_FACE);
-    game.override.moveset([Moves.TACKLE, Moves.ICE_BEAM, Moves.TOXIC_THREAD, Moves.HAIL]);
+    game.override
+      .battleStyle("single")
+      .enemySpecies(Species.EISCUE)
+      .enemyAbility(Abilities.ICE_FACE)
+      .moveset([Moves.TACKLE, Moves.ICE_BEAM, Moves.TOXIC_THREAD, Moves.HAIL]);
   });
 
   it("takes no damage from physical move and transforms to Noice", async () => {
@@ -51,8 +52,7 @@ describe("Abilities - Ice Face", () => {
   });
 
   it("takes no damage from the first hit of multihit physical move and transforms to Noice", async () => {
-    game.override.moveset([Moves.SURGING_STRIKES]);
-    game.override.enemyLevel(1);
+    game.override.moveset([Moves.SURGING_STRIKES]).enemyLevel(1);
     await game.classicMode.startBattle([Species.HITMONLEE]);
 
     game.move.select(Moves.SURGING_STRIKES);
@@ -196,12 +196,13 @@ describe("Abilities - Ice Face", () => {
   });
 
   it("reverts to Ice Face on arena reset", async () => {
-    game.override.startingWave(4);
-    game.override.startingLevel(4);
-    game.override.enemySpecies(Species.MAGIKARP);
-    game.override.starterForms({
-      [Species.EISCUE]: noiceForm,
-    });
+    game.override
+      .startingWave(4)
+      .startingLevel(4)
+      .enemySpecies(Species.MAGIKARP)
+      .starterForms({
+        [Species.EISCUE]: noiceForm,
+      });
 
     await game.classicMode.startBattle([Species.EISCUE]);
 

--- a/test/abilities/illusion.test.ts
+++ b/test/abilities/illusion.test.ts
@@ -117,25 +117,20 @@ describe("Abilities - Illusion", () => {
   });
 
   it("does not break from indirect damage", async () => {
-    game.override.enemySpecies(Species.GIGALITH);
-    game.override.enemyAbility(Abilities.SAND_STREAM);
-    game.override.enemyMoveset(Moves.WILL_O_WISP);
-    game.override.moveset([Moves.FLARE_BLITZ]);
-
+    game.override.enemySpecies(Species.GIGALITH).enemyAbility(Abilities.SAND_STREAM);
     await game.classicMode.startBattle([Species.ZOROARK, Species.AZUMARILL]);
 
-    game.move.select(Moves.FLARE_BLITZ);
-
+    game.move.use(Moves.FLARE_BLITZ);
     await game.phaseInterceptor.to("TurnEndPhase");
 
     const zoroark = game.scene.getPlayerPokemon()!;
-
     expect(!!zoroark.summonData.illusion).equals(true);
   });
 
   it("copies the the name, nickname, gender, shininess, and pokeball from the illusion source", async () => {
     game.override.enemyMoveset(Moves.SPLASH);
     await game.classicMode.startBattle([Species.ABRA, Species.ZOROARK, Species.AXEW]);
+
     const axew = game.scene.getPlayerParty().at(2)!;
     axew.shiny = true;
     axew.nickname = btoa(unescape(encodeURIComponent("axew nickname")));

--- a/test/abilities/imposter.test.ts
+++ b/test/abilities/imposter.test.ts
@@ -162,8 +162,7 @@ describe("Abilities - Imposter", () => {
   });
 
   it("should stay transformed with the correct form after reload", async () => {
-    game.override.moveset([Moves.ABSORB]);
-    game.override.enemySpecies(Species.UNOWN);
+    game.override.moveset([Moves.ABSORB]).enemySpecies(Species.UNOWN);
     await game.classicMode.startBattle([Species.DITTO]);
 
     const enemy = game.scene.getEnemyPokemon()!;

--- a/test/abilities/intimidate.test.ts
+++ b/test/abilities/intimidate.test.ts
@@ -88,8 +88,7 @@ describe("Abilities - Intimidate", () => {
   }, 20000);
 
   it("should not activate again if there is no switch or new entry", async () => {
-    game.override.startingWave(2);
-    game.override.moveset([Moves.SPLASH]);
+    game.override.startingWave(2).moveset([Moves.SPLASH]);
     await game.classicMode.startBattle([Species.MIGHTYENA, Species.POOCHYENA]);
 
     const playerPokemon = game.scene.getPlayerPokemon()!;

--- a/test/abilities/intrepid_sword.test.ts
+++ b/test/abilities/intrepid_sword.test.ts
@@ -22,10 +22,11 @@ describe("Abilities - Intrepid Sword", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-    game.override.enemySpecies(Species.ZACIAN);
-    game.override.enemyAbility(Abilities.INTREPID_SWORD);
-    game.override.ability(Abilities.INTREPID_SWORD);
+    game.override
+      .battleStyle("single")
+      .enemySpecies(Species.ZACIAN)
+      .enemyAbility(Abilities.INTREPID_SWORD)
+      .ability(Abilities.INTREPID_SWORD);
   });
 
   it("should raise ATK stat stage by 1 on entry", async () => {

--- a/test/abilities/libero.test.ts
+++ b/test/abilities/libero.test.ts
@@ -108,8 +108,7 @@ describe("Abilities - Libero", () => {
   });
 
   test("ability applies correctly even if the type has changed by another ability", async () => {
-    game.override.moveset([Moves.TACKLE]);
-    game.override.passiveAbility(Abilities.REFRIGERATE);
+    game.override.moveset([Moves.TACKLE]).passiveAbility(Abilities.REFRIGERATE);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
@@ -156,8 +155,7 @@ describe("Abilities - Libero", () => {
   });
 
   test("ability applies correctly even if the pokemon's move misses", async () => {
-    game.override.moveset([Moves.TACKLE]);
-    game.override.enemyMoveset(Moves.SPLASH);
+    game.override.moveset([Moves.TACKLE]).enemyMoveset(Moves.SPLASH);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
@@ -188,8 +186,7 @@ describe("Abilities - Libero", () => {
   });
 
   test("ability applies correctly even if the pokemon's move fails because of type immunity", async () => {
-    game.override.moveset([Moves.TACKLE]);
-    game.override.enemySpecies(Species.GASTLY);
+    game.override.moveset([Moves.TACKLE]).enemySpecies(Species.GASTLY);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
@@ -262,8 +259,7 @@ describe("Abilities - Libero", () => {
   });
 
   test("ability applies correctly even if the pokemon's Trick-or-Treat fails", async () => {
-    game.override.moveset([Moves.TRICK_OR_TREAT]);
-    game.override.enemySpecies(Species.GASTLY);
+    game.override.moveset([Moves.TRICK_OR_TREAT]).enemySpecies(Species.GASTLY);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 

--- a/test/abilities/magic_bounce.test.ts
+++ b/test/abilities/magic_bounce.test.ts
@@ -41,18 +41,16 @@ describe("Abilities - Magic Bounce", () => {
   it("should reflect basic status moves", async () => {
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
-    game.move.select(Moves.GROWL);
+    game.move.use(Moves.GROWL);
     await game.phaseInterceptor.to("BerryPhase");
     expect(game.scene.getPlayerPokemon()!.getStatStage(Stat.ATK)).toBe(-1);
   });
 
   it("should not bounce moves while the target is in the semi-invulnerable state", async () => {
     await game.classicMode.startBattle([Species.MAGIKARP]);
-    game.override.moveset([Moves.GROWL]);
-    game.override.enemyMoveset([Moves.FLY]);
 
-    game.move.select(Moves.GROWL);
-    await game.move.selectEnemyMove(Moves.FLY);
+    game.move.use(Moves.GROWL);
+    await game.move.forceEnemyMove(Moves.FLY);
     await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.phaseInterceptor.to("BerryPhase");
 
@@ -61,11 +59,10 @@ describe("Abilities - Magic Bounce", () => {
 
   it("should individually bounce back multi-target moves", async () => {
     game.override.battleStyle("double");
-    game.override.moveset([Moves.GROWL, Moves.SPLASH]);
     await game.classicMode.startBattle([Species.MAGIKARP, Species.MAGIKARP]);
 
-    game.move.select(Moves.GROWL, 0);
-    game.move.select(Moves.SPLASH, 1);
+    game.move.use(Moves.GROWL, 0);
+    game.move.use(Moves.SPLASH, 1);
     await game.phaseInterceptor.to("BerryPhase");
 
     const user = game.scene.getPlayerField()[0];
@@ -75,9 +72,8 @@ describe("Abilities - Magic Bounce", () => {
   it("should still bounce back a move that would otherwise fail", async () => {
     await game.classicMode.startBattle([Species.MAGIKARP]);
     game.scene.getEnemyPokemon()?.setStatStage(Stat.ATK, -6);
-    game.override.moveset([Moves.GROWL]);
 
-    game.move.select(Moves.GROWL);
+    game.move.use(Moves.GROWL);
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(game.scene.getPlayerPokemon()!.getStatStage(Stat.ATK)).toBe(-1);
@@ -107,29 +103,26 @@ describe("Abilities - Magic Bounce", () => {
     game.override.ability(Abilities.MOLD_BREAKER);
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
-    game.move.select(Moves.GROWL);
+    game.move.use(Moves.GROWL);
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(game.scene.getEnemyPokemon()!.getStatStage(Stat.ATK)).toBe(-1);
   });
 
   it("should bounce back a spread status move against both pokemon", async () => {
-    game.override.battleStyle("double");
-    game.override.moveset([Moves.GROWL, Moves.SPLASH]);
-    game.override.enemyMoveset([Moves.SPLASH]);
+    game.override.battleStyle("double").enemyMoveset([Moves.SPLASH]);
     await game.classicMode.startBattle([Species.MAGIKARP, Species.MAGIKARP]);
 
-    game.move.select(Moves.GROWL, 0);
-    game.move.select(Moves.SPLASH, 1);
+    game.move.use(Moves.GROWL, 0);
+    game.move.use(Moves.SPLASH, 1);
 
     await game.phaseInterceptor.to("BerryPhase");
     expect(game.scene.getPlayerField().every(p => p.getStatStage(Stat.ATK) === -2)).toBeTruthy();
   });
 
   it("should only bounce spikes back once in doubles when both targets have magic bounce", async () => {
-    game.override.battleStyle("double");
+    game.override.battleStyle("double").moveset([Moves.SPIKES]);
     await game.classicMode.startBattle([Species.MAGIKARP]);
-    game.override.moveset([Moves.SPIKES]);
 
     game.move.select(Moves.SPIKES);
     await game.phaseInterceptor.to("BerryPhase");
@@ -139,8 +132,7 @@ describe("Abilities - Magic Bounce", () => {
   });
 
   it("should bounce spikes even when the target is protected", async () => {
-    game.override.moveset([Moves.SPIKES]);
-    game.override.enemyMoveset([Moves.PROTECT]);
+    game.override.moveset([Moves.SPIKES]).enemyMoveset([Moves.PROTECT]);
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
     game.move.select(Moves.SPIKES);
@@ -149,8 +141,7 @@ describe("Abilities - Magic Bounce", () => {
   });
 
   it("should not bounce spikes when the target is in the semi-invulnerable state", async () => {
-    game.override.moveset([Moves.SPIKES]);
-    game.override.enemyMoveset([Moves.FLY]);
+    game.override.moveset([Moves.SPIKES]).enemyMoveset([Moves.FLY]);
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
     game.move.select(Moves.SPIKES);
@@ -160,9 +151,8 @@ describe("Abilities - Magic Bounce", () => {
   });
 
   it("should not bounce back curse", async () => {
-    game.override.starterSpecies(Species.GASTLY);
-    await game.classicMode.startBattle([Species.GASTLY]);
     game.override.moveset([Moves.CURSE]);
+    await game.classicMode.startBattle([Species.GASTLY]);
 
     game.move.select(Moves.CURSE);
     await game.phaseInterceptor.to("BerryPhase");
@@ -171,8 +161,7 @@ describe("Abilities - Magic Bounce", () => {
   });
 
   it("should not cause encore to be interrupted after bouncing", async () => {
-    game.override.moveset([Moves.SPLASH, Moves.GROWL, Moves.ENCORE]);
-    game.override.enemyMoveset([Moves.TACKLE, Moves.GROWL]);
+    game.override.moveset([Moves.SPLASH, Moves.GROWL, Moves.ENCORE]).enemyMoveset([Moves.TACKLE, Moves.GROWL]);
     // game.override.ability(Abilities.MOLD_BREAKER);
     await game.classicMode.startBattle([Species.MAGIKARP]);
     const playerPokemon = game.scene.getPlayerPokemon()!;
@@ -199,9 +188,10 @@ describe("Abilities - Magic Bounce", () => {
 
   // TODO: encore is failing if the last move was virtual.
   it.todo("should not cause the bounced move to count for encore", async () => {
-    game.override.moveset([Moves.SPLASH, Moves.GROWL, Moves.ENCORE]);
-    game.override.enemyMoveset([Moves.GROWL, Moves.TACKLE]);
-    game.override.enemyAbility(Abilities.MAGIC_BOUNCE);
+    game.override
+      .moveset([Moves.SPLASH, Moves.GROWL, Moves.ENCORE])
+      .enemyMoveset([Moves.GROWL, Moves.TACKLE])
+      .enemyAbility(Abilities.MAGIC_BOUNCE);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
     const playerPokemon = game.scene.getPlayerPokemon()!;
@@ -227,9 +217,8 @@ describe("Abilities - Magic Bounce", () => {
 
   // TODO: stomping tantrum should consider moves that were bounced.
   it.todo("should cause stomping tantrum to double in power when the last move was bounced", async () => {
-    game.override.battleStyle("single");
+    game.override.battleStyle("single").moveset([Moves.STOMPING_TANTRUM, Moves.CHARM]);
     await game.classicMode.startBattle([Species.MAGIKARP]);
-    game.override.moveset([Moves.STOMPING_TANTRUM, Moves.CHARM]);
 
     const stomping_tantrum = allMoves[Moves.STOMPING_TANTRUM];
     vi.spyOn(stomping_tantrum, "calculateBattlePower");
@@ -242,36 +231,30 @@ describe("Abilities - Magic Bounce", () => {
     expect(stomping_tantrum.calculateBattlePower).toHaveReturnedWith(150);
   });
 
-  // TODO: stomping tantrum should consider moves that were bounced.
-  it.todo(
-    "should properly cause the enemy's stomping tantrum to be doubled in power after bouncing and failing",
-    async () => {
-      game.override.enemyMoveset([Moves.STOMPING_TANTRUM, Moves.SPLASH, Moves.CHARM]);
-      await game.classicMode.startBattle([Species.BULBASAUR]);
+  // TODO: stomping tantrum should consider moves that were bounced
+  it.todo("should boost enemy's stomping tantrum after failed bounce", async () => {
+    game.override.enemyMoveset([Moves.STOMPING_TANTRUM, Moves.SPLASH, Moves.CHARM]);
+    await game.classicMode.startBattle([Species.BULBASAUR]);
 
-      const stomping_tantrum = allMoves[Moves.STOMPING_TANTRUM];
-      const enemy = game.scene.getEnemyPokemon()!;
-      vi.spyOn(stomping_tantrum, "calculateBattlePower");
+    const stomping_tantrum = allMoves[Moves.STOMPING_TANTRUM];
+    const enemy = game.scene.getEnemyPokemon()!;
+    vi.spyOn(stomping_tantrum, "calculateBattlePower");
 
-      game.move.select(Moves.SPORE);
-      await game.move.selectEnemyMove(Moves.CHARM);
-      await game.phaseInterceptor.to("TurnEndPhase");
-      expect(enemy.getLastXMoves(1)[0].result).toBe("success");
+    // Spore gets reflected back onto us
+    game.move.select(Moves.SPORE);
+    await game.move.selectEnemyMove(Moves.CHARM);
+    await game.toNextTurn();
+    expect(enemy.getLastXMoves(1)[0].result).toBe("success");
 
-      await game.phaseInterceptor.to("BerryPhase");
-      expect(stomping_tantrum.calculateBattlePower).toHaveReturnedWith(75);
-
-      await game.toNextTurn();
-      game.move.select(Moves.GROWL);
-      await game.phaseInterceptor.to("BerryPhase");
-      expect(stomping_tantrum.calculateBattlePower).toHaveReturnedWith(75);
-    },
-  );
+    game.move.select(Moves.SPORE);
+    await game.move.selectEnemyMove(Moves.STOMPING_TANTRUM);
+    await game.toNextTurn();
+    expect(stomping_tantrum.calculateBattlePower).toHaveReturnedWith(150);
+  });
 
   it("should respect immunities when bouncing a move", async () => {
     vi.spyOn(allMoves[Moves.THUNDER_WAVE], "accuracy", "get").mockReturnValue(100);
-    game.override.moveset([Moves.THUNDER_WAVE, Moves.GROWL]);
-    game.override.ability(Abilities.SOUNDPROOF);
+    game.override.moveset([Moves.THUNDER_WAVE, Moves.GROWL]).ability(Abilities.SOUNDPROOF);
     await game.classicMode.startBattle([Species.PHANPY]);
 
     // Turn 1 - thunder wave immunity test
@@ -309,8 +292,7 @@ describe("Abilities - Magic Bounce", () => {
   });
 
   it("should always apply the leftmost available target's magic bounce when bouncing moves like sticky webs in doubles", async () => {
-    game.override.battleStyle("double");
-    game.override.moveset([Moves.STICKY_WEB, Moves.SPLASH, Moves.TRICK_ROOM]);
+    game.override.battleStyle("double").moveset([Moves.STICKY_WEB, Moves.SPLASH, Moves.TRICK_ROOM]);
 
     await game.classicMode.startBattle([Species.MAGIKARP, Species.MAGIKARP]);
     const [enemy_1, enemy_2] = game.scene.getEnemyField();
@@ -345,6 +327,7 @@ describe("Abilities - Magic Bounce", () => {
   it("should not bounce back status moves that hit through semi-invulnerable states", async () => {
     game.override.moveset([Moves.TOXIC, Moves.CHARM]);
     await game.classicMode.startBattle([Species.BULBASAUR]);
+
     game.move.select(Moves.TOXIC);
     await game.move.selectEnemyMove(Moves.FLY);
     await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);

--- a/test/abilities/magic_guard.test.ts
+++ b/test/abilities/magic_guard.test.ts
@@ -29,16 +29,16 @@ describe("Abilities - Magic Guard", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
 
-    /** Player Pokemon overrides */
-    game.override.ability(Abilities.MAGIC_GUARD);
-    game.override.moveset([Moves.SPLASH]);
-    game.override.startingLevel(100);
-
-    /** Enemy Pokemon overrides */
-    game.override.enemySpecies(Species.SNORLAX);
-    game.override.enemyAbility(Abilities.INSOMNIA);
-    game.override.enemyMoveset(Moves.SPLASH);
-    game.override.enemyLevel(100);
+    game.override
+      /** Player Pokemon overrides */
+      .ability(Abilities.MAGIC_GUARD)
+      .moveset([Moves.SPLASH])
+      .startingLevel(100)
+      /** Enemy Pokemon overrides */
+      .enemySpecies(Species.SNORLAX)
+      .enemyAbility(Abilities.INSOMNIA)
+      .enemyMoveset(Moves.SPLASH)
+      .enemyLevel(100);
   });
 
   //Bulbapedia Reference: https://bulbapedia.bulbagarden.net/wiki/Magic_Guard_(Ability)
@@ -88,8 +88,9 @@ describe("Abilities - Magic Guard", () => {
   });
 
   it("ability effect should not persist when the ability is replaced", async () => {
-    game.override.enemyMoveset([Moves.WORRY_SEED, Moves.WORRY_SEED, Moves.WORRY_SEED, Moves.WORRY_SEED]);
-    game.override.statusEffect(StatusEffect.POISON);
+    game.override
+      .enemyMoveset([Moves.WORRY_SEED, Moves.WORRY_SEED, Moves.WORRY_SEED, Moves.WORRY_SEED])
+      .statusEffect(StatusEffect.POISON);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
@@ -107,8 +108,7 @@ describe("Abilities - Magic Guard", () => {
   });
 
   it("Magic Guard prevents damage caused by burn but other non-damaging effects are still applied", async () => {
-    game.override.enemyStatusEffect(StatusEffect.BURN);
-    game.override.enemyAbility(Abilities.MAGIC_GUARD);
+    game.override.enemyStatusEffect(StatusEffect.BURN).enemyAbility(Abilities.MAGIC_GUARD);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
@@ -129,8 +129,7 @@ describe("Abilities - Magic Guard", () => {
   });
 
   it("Magic Guard prevents damage caused by toxic but other non-damaging effects are still applied", async () => {
-    game.override.enemyStatusEffect(StatusEffect.TOXIC);
-    game.override.enemyAbility(Abilities.MAGIC_GUARD);
+    game.override.enemyStatusEffect(StatusEffect.TOXIC).enemyAbility(Abilities.MAGIC_GUARD);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
@@ -207,8 +206,7 @@ describe("Abilities - Magic Guard", () => {
 
   it("Magic Guard prevents against damage from volatile status effects", async () => {
     await game.classicMode.startBattle([Species.DUSKULL]);
-    game.override.moveset([Moves.CURSE]);
-    game.override.enemyAbility(Abilities.MAGIC_GUARD);
+    game.override.moveset([Moves.CURSE]).enemyAbility(Abilities.MAGIC_GUARD);
 
     const leadPokemon = game.scene.getPlayerPokemon()!;
 
@@ -330,8 +328,7 @@ describe("Abilities - Magic Guard", () => {
     //Tests the ability Bad Dreams
     game.override.statusEffect(StatusEffect.SLEEP);
     //enemy pokemon is given Spore just in case player pokemon somehow awakens during test
-    game.override.enemyMoveset([Moves.SPORE, Moves.SPORE, Moves.SPORE, Moves.SPORE]);
-    game.override.enemyAbility(Abilities.BAD_DREAMS);
+    game.override.enemyMoveset([Moves.SPORE, Moves.SPORE, Moves.SPORE, Moves.SPORE]).enemyAbility(Abilities.BAD_DREAMS);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
@@ -352,8 +349,7 @@ describe("Abilities - Magic Guard", () => {
 
   it("Magic Guard prevents damage from abilities with PostFaintContactDamageAbAttr", async () => {
     //Tests the abilities Innards Out/Aftermath
-    game.override.moveset([Moves.TACKLE]);
-    game.override.enemyAbility(Abilities.AFTERMATH);
+    game.override.moveset([Moves.TACKLE]).enemyAbility(Abilities.AFTERMATH);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
@@ -376,8 +372,7 @@ describe("Abilities - Magic Guard", () => {
 
   it("Magic Guard prevents damage from abilities with PostDefendContactDamageAbAttr", async () => {
     //Tests the abilities Iron Barbs/Rough Skin
-    game.override.moveset([Moves.TACKLE]);
-    game.override.enemyAbility(Abilities.IRON_BARBS);
+    game.override.moveset([Moves.TACKLE]).enemyAbility(Abilities.IRON_BARBS);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
@@ -399,8 +394,7 @@ describe("Abilities - Magic Guard", () => {
 
   it("Magic Guard prevents damage from abilities with ReverseDrainAbAttr", async () => {
     //Tests the ability Liquid Ooze
-    game.override.moveset([Moves.ABSORB]);
-    game.override.enemyAbility(Abilities.LIQUID_OOZE);
+    game.override.moveset([Moves.ABSORB]).enemyAbility(Abilities.LIQUID_OOZE);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
@@ -421,9 +415,7 @@ describe("Abilities - Magic Guard", () => {
   });
 
   it("Magic Guard prevents HP loss from abilities with PostWeatherLapseDamageAbAttr", async () => {
-    //Tests the abilities Solar Power/Dry Skin
-    game.override.passiveAbility(Abilities.SOLAR_POWER);
-    game.override.weather(WeatherType.SUNNY);
+    game.override.passiveAbility(Abilities.SOLAR_POWER).weather(WeatherType.SUNNY);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
     const leadPokemon = game.scene.getPlayerPokemon()!;

--- a/test/abilities/mirror_armor.test.ts
+++ b/test/abilities/mirror_armor.test.ts
@@ -37,8 +37,7 @@ describe("Ability - Mirror Armor", () => {
   });
 
   it("Player side + single battle Intimidate - opponent loses stats", async () => {
-    game.override.ability(Abilities.MIRROR_ARMOR);
-    game.override.enemyAbility(Abilities.INTIMIDATE);
+    game.override.ability(Abilities.MIRROR_ARMOR).enemyAbility(Abilities.INTIMIDATE);
     await game.classicMode.startBattle([Species.BULBASAUR]);
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -54,8 +53,7 @@ describe("Ability - Mirror Armor", () => {
   });
 
   it("Enemy side + single battle Intimidate - player loses stats", async () => {
-    game.override.enemyAbility(Abilities.MIRROR_ARMOR);
-    game.override.ability(Abilities.INTIMIDATE);
+    game.override.enemyAbility(Abilities.MIRROR_ARMOR).ability(Abilities.INTIMIDATE);
     await game.classicMode.startBattle([Species.BULBASAUR]);
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -71,9 +69,7 @@ describe("Ability - Mirror Armor", () => {
   });
 
   it("Player side + double battle Intimidate - opponents each lose -2 atk", async () => {
-    game.override.battleStyle("double");
-    game.override.ability(Abilities.MIRROR_ARMOR);
-    game.override.enemyAbility(Abilities.INTIMIDATE);
+    game.override.battleStyle("double").ability(Abilities.MIRROR_ARMOR).enemyAbility(Abilities.INTIMIDATE);
     await game.classicMode.startBattle([Species.BULBASAUR, Species.CHARMANDER]);
 
     const [enemy1, enemy2] = game.scene.getEnemyField();
@@ -93,9 +89,7 @@ describe("Ability - Mirror Armor", () => {
   });
 
   it("Enemy side + double battle Intimidate - players each lose -2 atk", async () => {
-    game.override.battleStyle("double");
-    game.override.enemyAbility(Abilities.MIRROR_ARMOR);
-    game.override.ability(Abilities.INTIMIDATE);
+    game.override.battleStyle("double").enemyAbility(Abilities.MIRROR_ARMOR).ability(Abilities.INTIMIDATE);
     await game.classicMode.startBattle([Species.BULBASAUR, Species.CHARMANDER]);
 
     const [enemy1, enemy2] = game.scene.getEnemyField();
@@ -115,8 +109,7 @@ describe("Ability - Mirror Armor", () => {
   });
 
   it("Player side + single battle Intimidate + Tickle - opponent loses stats", async () => {
-    game.override.ability(Abilities.MIRROR_ARMOR);
-    game.override.enemyAbility(Abilities.INTIMIDATE);
+    game.override.ability(Abilities.MIRROR_ARMOR).enemyAbility(Abilities.INTIMIDATE);
     await game.classicMode.startBattle([Species.BULBASAUR]);
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -134,9 +127,7 @@ describe("Ability - Mirror Armor", () => {
   });
 
   it("Player side + double battle Intimidate + Tickle - opponents each lose -3 atk, -1 def", async () => {
-    game.override.battleStyle("double");
-    game.override.ability(Abilities.MIRROR_ARMOR);
-    game.override.enemyAbility(Abilities.INTIMIDATE);
+    game.override.battleStyle("double").ability(Abilities.MIRROR_ARMOR).enemyAbility(Abilities.INTIMIDATE);
     await game.classicMode.startBattle([Species.BULBASAUR, Species.CHARMANDER]);
 
     const [enemy1, enemy2] = game.scene.getEnemyField();
@@ -159,8 +150,7 @@ describe("Ability - Mirror Armor", () => {
   });
 
   it("Enemy side + single battle Intimidate + Tickle - player loses stats", async () => {
-    game.override.enemyAbility(Abilities.MIRROR_ARMOR);
-    game.override.ability(Abilities.INTIMIDATE);
+    game.override.enemyAbility(Abilities.MIRROR_ARMOR).ability(Abilities.INTIMIDATE);
     await game.classicMode.startBattle([Species.BULBASAUR]);
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -178,8 +168,7 @@ describe("Ability - Mirror Armor", () => {
   });
 
   it("Player side + single battle Intimidate + oppoenent has white smoke - no one loses stats", async () => {
-    game.override.enemyAbility(Abilities.WHITE_SMOKE);
-    game.override.ability(Abilities.MIRROR_ARMOR);
+    game.override.enemyAbility(Abilities.WHITE_SMOKE).ability(Abilities.MIRROR_ARMOR);
     await game.classicMode.startBattle([Species.BULBASAUR]);
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -197,8 +186,7 @@ describe("Ability - Mirror Armor", () => {
   });
 
   it("Enemy side + single battle Intimidate + player has white smoke - no one loses stats", async () => {
-    game.override.ability(Abilities.WHITE_SMOKE);
-    game.override.enemyAbility(Abilities.MIRROR_ARMOR);
+    game.override.ability(Abilities.WHITE_SMOKE).enemyAbility(Abilities.MIRROR_ARMOR);
     await game.classicMode.startBattle([Species.BULBASAUR]);
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -252,9 +240,7 @@ describe("Ability - Mirror Armor", () => {
   });
 
   it("Both sides have mirror armor - does not loop, player loses attack", async () => {
-    game.override.enemyAbility(Abilities.MIRROR_ARMOR);
-    game.override.ability(Abilities.MIRROR_ARMOR);
-    game.override.ability(Abilities.INTIMIDATE);
+    game.override.enemyAbility(Abilities.MIRROR_ARMOR).ability(Abilities.MIRROR_ARMOR).ability(Abilities.INTIMIDATE);
     await game.classicMode.startBattle([Species.BULBASAUR]);
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -288,8 +274,7 @@ describe("Ability - Mirror Armor", () => {
   });
 
   it("Double battle + sticky web applied player side - player switches out and enemy 1 should lose -1 speed", async () => {
-    game.override.battleStyle("double");
-    game.override.ability(Abilities.MIRROR_ARMOR);
+    game.override.battleStyle("double").ability(Abilities.MIRROR_ARMOR);
     await game.classicMode.startBattle([Species.BULBASAUR, Species.CHARMANDER, Species.SQUIRTLE]);
 
     const [enemy1, enemy2] = game.scene.getEnemyField();

--- a/test/abilities/moxie.test.ts
+++ b/test/abilities/moxie.test.ts
@@ -27,13 +27,14 @@ describe("Abilities - Moxie", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     const moveToUse = Moves.AERIAL_ACE;
-    game.override.battleStyle("single");
-    game.override.enemySpecies(Species.RATTATA);
-    game.override.enemyAbility(Abilities.MOXIE);
-    game.override.ability(Abilities.MOXIE);
-    game.override.startingLevel(2000);
-    game.override.moveset([moveToUse]);
-    game.override.enemyMoveset(Moves.SPLASH);
+    game.override
+      .battleStyle("single")
+      .enemySpecies(Species.RATTATA)
+      .enemyAbility(Abilities.MOXIE)
+      .ability(Abilities.MOXIE)
+      .startingLevel(2000)
+      .moveset([moveToUse])
+      .enemyMoveset(Moves.SPLASH);
   });
 
   it("should raise ATK stat stage by 1 when winning a battle", async () => {

--- a/test/abilities/normalize.test.ts
+++ b/test/abilities/normalize.test.ts
@@ -45,8 +45,9 @@ describe("Abilities - Normalize", () => {
   });
 
   it("should not apply the old type boost item after changing a move's type", async () => {
-    game.override.startingHeldItems([{ name: "ATTACK_TYPE_BOOSTER", count: 1, type: PokemonType.GRASS }]);
-    game.override.moveset([Moves.LEAFAGE]);
+    game.override
+      .startingHeldItems([{ name: "ATTACK_TYPE_BOOSTER", count: 1, type: PokemonType.GRASS }])
+      .moveset([Moves.LEAFAGE]);
 
     const powerSpy = vi.spyOn(allMoves[Moves.LEAFAGE], "calculateBattlePower");
     await game.classicMode.startBattle([Species.MAGIKARP]);
@@ -58,8 +59,9 @@ describe("Abilities - Normalize", () => {
   });
 
   it("should apply silk scarf's power boost after changing a move's type", async () => {
-    game.override.startingHeldItems([{ name: "ATTACK_TYPE_BOOSTER", count: 1, type: PokemonType.NORMAL }]);
-    game.override.moveset([Moves.LEAFAGE]);
+    game.override
+      .startingHeldItems([{ name: "ATTACK_TYPE_BOOSTER", count: 1, type: PokemonType.NORMAL }])
+      .moveset([Moves.LEAFAGE]);
 
     const powerSpy = vi.spyOn(allMoves[Moves.LEAFAGE], "calculateBattlePower");
     await game.classicMode.startBattle([Species.MAGIKARP]);

--- a/test/abilities/parental_bond.test.ts
+++ b/test/abilities/parental_bond.test.ts
@@ -26,14 +26,15 @@ describe("Abilities - Parental Bond", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-    game.override.disableCrits();
-    game.override.ability(Abilities.PARENTAL_BOND);
-    game.override.enemySpecies(Species.SNORLAX);
-    game.override.enemyAbility(Abilities.FUR_COAT);
-    game.override.enemyMoveset(Moves.SPLASH);
-    game.override.startingLevel(100);
-    game.override.enemyLevel(100);
+    game.override
+      .battleStyle("single")
+      .disableCrits()
+      .ability(Abilities.PARENTAL_BOND)
+      .enemySpecies(Species.SNORLAX)
+      .enemyAbility(Abilities.FUR_COAT)
+      .enemyMoveset(Moves.SPLASH)
+      .startingLevel(100)
+      .enemyLevel(100);
   });
 
   it("should add second strike to attack move", async () => {
@@ -61,8 +62,7 @@ describe("Abilities - Parental Bond", () => {
   });
 
   it("should apply secondary effects to both strikes", async () => {
-    game.override.moveset([Moves.POWER_UP_PUNCH]);
-    game.override.enemySpecies(Species.AMOONGUSS);
+    game.override.moveset([Moves.POWER_UP_PUNCH]).enemySpecies(Species.AMOONGUSS);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
@@ -148,8 +148,7 @@ describe("Abilities - Parental Bond", () => {
   });
 
   it("should not apply multiplier to counter moves", async () => {
-    game.override.moveset([Moves.COUNTER]);
-    game.override.enemyMoveset([Moves.TACKLE]);
+    game.override.moveset([Moves.COUNTER]).enemyMoveset([Moves.TACKLE]);
 
     await game.classicMode.startBattle([Species.SHUCKLE]);
 
@@ -167,9 +166,7 @@ describe("Abilities - Parental Bond", () => {
   });
 
   it("should not apply to multi-target moves", async () => {
-    game.override.battleStyle("double");
-    game.override.moveset([Moves.EARTHQUAKE]);
-    game.override.passiveAbility(Abilities.LEVITATE);
+    game.override.battleStyle("double").moveset([Moves.EARTHQUAKE]).passiveAbility(Abilities.LEVITATE);
 
     await game.classicMode.startBattle([Species.MAGIKARP, Species.FEEBAS]);
 
@@ -237,8 +234,7 @@ describe("Abilities - Parental Bond", () => {
   });
 
   it("Moves boosted by this ability and Multi-Lens should strike 3 times", async () => {
-    game.override.moveset([Moves.TACKLE]);
-    game.override.startingHeldItems([{ name: "MULTI_LENS", count: 1 }]);
+    game.override.moveset([Moves.TACKLE]).startingHeldItems([{ name: "MULTI_LENS", count: 1 }]);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
@@ -252,8 +248,7 @@ describe("Abilities - Parental Bond", () => {
   });
 
   it("Seismic Toss boosted by this ability and Multi-Lens should strike 3 times", async () => {
-    game.override.moveset([Moves.SEISMIC_TOSS]);
-    game.override.startingHeldItems([{ name: "MULTI_LENS", count: 1 }]);
+    game.override.moveset([Moves.SEISMIC_TOSS]).startingHeldItems([{ name: "MULTI_LENS", count: 1 }]);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
@@ -378,8 +373,7 @@ describe("Abilities - Parental Bond", () => {
   });
 
   it("should not cause user to hit into King's Shield more than once", async () => {
-    game.override.moveset([Moves.TACKLE]);
-    game.override.enemyMoveset([Moves.KINGS_SHIELD]);
+    game.override.moveset([Moves.TACKLE]).enemyMoveset([Moves.KINGS_SHIELD]);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
@@ -393,8 +387,7 @@ describe("Abilities - Parental Bond", () => {
   });
 
   it("should not cause user to hit into Storm Drain more than once", async () => {
-    game.override.moveset([Moves.WATER_GUN]);
-    game.override.enemyAbility(Abilities.STORM_DRAIN);
+    game.override.moveset([Moves.WATER_GUN]).enemyAbility(Abilities.STORM_DRAIN);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 

--- a/test/abilities/perish_body.test.ts
+++ b/test/abilities/perish_body.test.ts
@@ -21,19 +21,18 @@ describe("Abilities - Perish Song", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-    game.override.disableCrits();
-
-    game.override.enemySpecies(Species.MAGIKARP);
-    game.override.enemyAbility(Abilities.BALL_FETCH);
-
-    game.override.starterSpecies(Species.CURSOLA);
-    game.override.ability(Abilities.PERISH_BODY);
-    game.override.moveset([Moves.SPLASH]);
+    game.override
+      .battleStyle("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .starterSpecies(Species.CURSOLA)
+      .ability(Abilities.PERISH_BODY)
+      .moveset([Moves.SPLASH])
+      .enemyMoveset([Moves.AQUA_JET]);
   });
 
   it("should trigger when hit with damaging move", async () => {
-    game.override.enemyMoveset([Moves.AQUA_JET]);
     await game.classicMode.startBattle();
     const cursola = game.scene.getPlayerPokemon();
     const magikarp = game.scene.getEnemyPokemon();
@@ -46,7 +45,7 @@ describe("Abilities - Perish Song", () => {
   });
 
   it("should trigger even when fainting", async () => {
-    game.override.enemyMoveset([Moves.AQUA_JET]).enemyLevel(100).startingLevel(1);
+    game.override.enemyLevel(100).startingLevel(1);
     await game.classicMode.startBattle([Species.CURSOLA, Species.FEEBAS]);
     const magikarp = game.scene.getEnemyPokemon();
 
@@ -87,9 +86,10 @@ describe("Abilities - Perish Song", () => {
   });
 
   it("should activate if cursola already has perish song, but not reset its counter", async () => {
-    game.override.enemyMoveset([Moves.PERISH_SONG, Moves.AQUA_JET, Moves.SPLASH]);
-    game.override.moveset([Moves.WHIRLWIND, Moves.SPLASH]);
-    game.override.startingWave(5);
+    game.override
+      .enemyMoveset([Moves.PERISH_SONG, Moves.AQUA_JET, Moves.SPLASH])
+      .moveset([Moves.WHIRLWIND, Moves.SPLASH])
+      .startingWave(5);
     await game.classicMode.startBattle([Species.CURSOLA]);
     const cursola = game.scene.getPlayerPokemon();
 

--- a/test/abilities/power_construct.test.ts
+++ b/test/abilities/power_construct.test.ts
@@ -35,8 +35,7 @@ describe("Abilities - POWER CONSTRUCT", () => {
   test("check if fainted 50% Power Construct Pokemon switches to base form on arena reset", async () => {
     const baseForm = 2,
       completeForm = 4;
-    game.override.startingWave(4);
-    game.override.starterForms({
+    game.override.startingWave(4).starterForms({
       [Species.ZYGARDE]: completeForm,
     });
 
@@ -62,8 +61,7 @@ describe("Abilities - POWER CONSTRUCT", () => {
   test("check if fainted 10% Power Construct Pokemon switches to base form on arena reset", async () => {
     const baseForm = 3,
       completeForm = 5;
-    game.override.startingWave(4);
-    game.override.starterForms({
+    game.override.startingWave(4).starterForms({
       [Species.ZYGARDE]: completeForm,
     });
 

--- a/test/abilities/power_spot.test.ts
+++ b/test/abilities/power_spot.test.ts
@@ -26,11 +26,12 @@ describe("Abilities - Power Spot", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("double");
-    game.override.moveset([Moves.TACKLE, Moves.BREAKING_SWIPE, Moves.SPLASH, Moves.DAZZLING_GLEAM]);
-    game.override.enemyMoveset(Moves.SPLASH);
-    game.override.enemySpecies(Species.SHUCKLE);
-    game.override.enemyAbility(Abilities.BALL_FETCH);
+    game.override
+      .battleStyle("double")
+      .moveset([Moves.TACKLE, Moves.BREAKING_SWIPE, Moves.SPLASH, Moves.DAZZLING_GLEAM])
+      .enemyMoveset(Moves.SPLASH)
+      .enemySpecies(Species.SHUCKLE)
+      .enemyAbility(Abilities.BALL_FETCH);
   });
 
   it("raises the power of allies' special moves by 30%", async () => {

--- a/test/abilities/protean.test.ts
+++ b/test/abilities/protean.test.ts
@@ -108,8 +108,7 @@ describe("Abilities - Protean", () => {
   });
 
   test("ability applies correctly even if the type has changed by another ability", async () => {
-    game.override.moveset([Moves.TACKLE]);
-    game.override.passiveAbility(Abilities.REFRIGERATE);
+    game.override.moveset([Moves.TACKLE]).passiveAbility(Abilities.REFRIGERATE);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
@@ -156,8 +155,7 @@ describe("Abilities - Protean", () => {
   });
 
   test("ability applies correctly even if the pokemon's move misses", async () => {
-    game.override.moveset([Moves.TACKLE]);
-    game.override.enemyMoveset(Moves.SPLASH);
+    game.override.moveset([Moves.TACKLE]).enemyMoveset(Moves.SPLASH);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
@@ -188,8 +186,7 @@ describe("Abilities - Protean", () => {
   });
 
   test("ability applies correctly even if the pokemon's move fails because of type immunity", async () => {
-    game.override.moveset([Moves.TACKLE]);
-    game.override.enemySpecies(Species.GASTLY);
+    game.override.moveset([Moves.TACKLE]).enemySpecies(Species.GASTLY);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
@@ -262,8 +259,7 @@ describe("Abilities - Protean", () => {
   });
 
   test("ability applies correctly even if the pokemon's Trick-or-Treat fails", async () => {
-    game.override.moveset([Moves.TRICK_OR_TREAT]);
-    game.override.enemySpecies(Species.GASTLY);
+    game.override.moveset([Moves.TRICK_OR_TREAT]).enemySpecies(Species.GASTLY);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 

--- a/test/abilities/quick_draw.test.ts
+++ b/test/abilities/quick_draw.test.ts
@@ -24,16 +24,15 @@ describe("Abilities - Quick Draw", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-
-    game.override.starterSpecies(Species.MAGIKARP);
-    game.override.ability(Abilities.QUICK_DRAW);
-    game.override.moveset([Moves.TACKLE, Moves.TAIL_WHIP]);
-
-    game.override.enemyLevel(100);
-    game.override.enemySpecies(Species.MAGIKARP);
-    game.override.enemyAbility(Abilities.BALL_FETCH);
-    game.override.enemyMoveset([Moves.TACKLE]);
+    game.override
+      .battleStyle("single")
+      .starterSpecies(Species.MAGIKARP)
+      .ability(Abilities.QUICK_DRAW)
+      .moveset([Moves.TACKLE, Moves.TAIL_WHIP])
+      .enemyLevel(100)
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset([Moves.TACKLE]);
 
     vi.spyOn(allAbilities[Abilities.QUICK_DRAW].getAttrs(BypassSpeedChanceAbAttr)[0], "chance", "get").mockReturnValue(
       100,

--- a/test/abilities/sand_spit.test.ts
+++ b/test/abilities/sand_spit.test.ts
@@ -22,15 +22,14 @@ describe("Abilities - Sand Spit", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-    game.override.disableCrits();
-
-    game.override.enemySpecies(Species.MAGIKARP);
-    game.override.enemyAbility(Abilities.BALL_FETCH);
-
-    game.override.starterSpecies(Species.SILICOBRA);
-    game.override.ability(Abilities.SAND_SPIT);
-    game.override.moveset([Moves.SPLASH, Moves.COIL]);
+    game.override
+      .battleStyle("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .starterSpecies(Species.SILICOBRA)
+      .ability(Abilities.SAND_SPIT)
+      .moveset([Moves.SPLASH, Moves.COIL]);
   });
 
   it("should trigger when hit with damaging move", async () => {

--- a/test/abilities/schooling.test.ts
+++ b/test/abilities/schooling.test.ts
@@ -31,8 +31,7 @@ describe("Abilities - SCHOOLING", () => {
   test("check if fainted pokemon switches to base form on arena reset", async () => {
     const soloForm = 0,
       schoolForm = 1;
-    game.override.startingWave(4);
-    game.override.starterForms({
+    game.override.startingWave(4).starterForms({
       [Species.WISHIWASHI]: schoolForm,
     });
 

--- a/test/abilities/screen_cleaner.test.ts
+++ b/test/abilities/screen_cleaner.test.ts
@@ -24,9 +24,7 @@ describe("Abilities - Screen Cleaner", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-    game.override.ability(Abilities.SCREEN_CLEANER);
-    game.override.enemySpecies(Species.SHUCKLE);
+    game.override.battleStyle("single").ability(Abilities.SCREEN_CLEANER).enemySpecies(Species.SHUCKLE);
   });
 
   it("removes Aurora Veil", async () => {

--- a/test/abilities/seed_sower.test.ts
+++ b/test/abilities/seed_sower.test.ts
@@ -22,15 +22,14 @@ describe("Abilities - Seed Sower", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-    game.override.disableCrits();
-
-    game.override.enemySpecies(Species.MAGIKARP);
-    game.override.enemyAbility(Abilities.BALL_FETCH);
-
-    game.override.starterSpecies(Species.ARBOLIVA);
-    game.override.ability(Abilities.SEED_SOWER);
-    game.override.moveset([Moves.SPLASH]);
+    game.override
+      .battleStyle("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .starterSpecies(Species.ARBOLIVA)
+      .ability(Abilities.SEED_SOWER)
+      .moveset([Moves.SPLASH]);
   });
 
   it("should trigger when hit with damaging move", async () => {

--- a/test/abilities/shield_dust.test.ts
+++ b/test/abilities/shield_dust.test.ts
@@ -31,12 +31,13 @@ describe("Abilities - Shield Dust", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-    game.override.enemySpecies(Species.ONIX);
-    game.override.enemyAbility(Abilities.SHIELD_DUST);
-    game.override.startingLevel(100);
-    game.override.moveset(Moves.AIR_SLASH);
-    game.override.enemyMoveset(Moves.TACKLE);
+    game.override
+      .battleStyle("single")
+      .enemySpecies(Species.ONIX)
+      .enemyAbility(Abilities.SHIELD_DUST)
+      .startingLevel(100)
+      .moveset(Moves.AIR_SLASH)
+      .enemyMoveset(Moves.TACKLE);
   });
 
   it("Shield Dust", async () => {

--- a/test/abilities/shields_down.test.ts
+++ b/test/abilities/shields_down.test.ts
@@ -26,17 +26,17 @@ describe("Abilities - SHIELDS DOWN", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     const moveToUse = Moves.SPLASH;
-    game.override.battleStyle("single");
-    game.override.ability(Abilities.SHIELDS_DOWN);
-    game.override.moveset([moveToUse]);
-    game.override.enemyMoveset([Moves.TACKLE]);
+    game.override
+      .battleStyle("single")
+      .ability(Abilities.SHIELDS_DOWN)
+      .moveset([moveToUse])
+      .enemyMoveset([Moves.TACKLE]);
   });
 
   test("check if fainted pokemon switched to base form on arena reset", async () => {
     const meteorForm = 0,
       coreForm = 7;
-    game.override.startingWave(4);
-    game.override.starterForms({
+    game.override.startingWave(4).starterForms({
       [Species.MINIOR]: coreForm,
     });
 
@@ -70,8 +70,7 @@ describe("Abilities - SHIELDS DOWN", () => {
   });
 
   test("should still ignore non-volatile status moves used by a pokemon with mold breaker", async () => {
-    game.override.enemyAbility(Abilities.MOLD_BREAKER);
-    game.override.enemyMoveset([Moves.SPORE]);
+    game.override.enemyAbility(Abilities.MOLD_BREAKER).enemyMoveset([Moves.SPORE]);
 
     await game.classicMode.startBattle([Species.MINIOR]);
 
@@ -94,8 +93,7 @@ describe("Abilities - SHIELDS DOWN", () => {
   });
 
   test("should ignore status moves even through mold breaker", async () => {
-    game.override.enemyMoveset([Moves.SPORE]);
-    game.override.enemyAbility(Abilities.MOLD_BREAKER);
+    game.override.enemyMoveset([Moves.SPORE]).enemyAbility(Abilities.MOLD_BREAKER);
 
     await game.classicMode.startBattle([Species.MINIOR]);
 
@@ -108,8 +106,9 @@ describe("Abilities - SHIELDS DOWN", () => {
 
   // toxic spikes currently does not poison flying types when gravity is in effect
   test.todo("should become poisoned by toxic spikes when grounded", async () => {
-    game.override.enemyMoveset([Moves.GRAVITY, Moves.TOXIC_SPIKES, Moves.SPLASH]);
-    game.override.moveset([Moves.GRAVITY, Moves.SPLASH]);
+    game.override
+      .enemyMoveset([Moves.GRAVITY, Moves.TOXIC_SPIKES, Moves.SPLASH])
+      .moveset([Moves.GRAVITY, Moves.SPLASH]);
 
     await game.classicMode.startBattle([Species.MAGIKARP, Species.MINIOR]);
 
@@ -155,9 +154,7 @@ describe("Abilities - SHIELDS DOWN", () => {
 
   // the `NoTransformAbilityAbAttr` attribute is not checked anywhere, so this test cannot pass.
   test.todo("ditto should not be immune to status after transforming", async () => {
-    game.override.enemySpecies(Species.DITTO);
-    game.override.enemyAbility(Abilities.IMPOSTER);
-    game.override.moveset([Moves.SPLASH, Moves.SPORE]);
+    game.override.enemySpecies(Species.DITTO).enemyAbility(Abilities.IMPOSTER).moveset([Moves.SPLASH, Moves.SPORE]);
 
     await game.classicMode.startBattle([Species.MINIOR]);
 
@@ -169,11 +166,12 @@ describe("Abilities - SHIELDS DOWN", () => {
   });
 
   test("should not prevent minior from receiving the fainted status effect in trainer battles", async () => {
-    game.override.enemyMoveset([Moves.TACKLE]);
-    game.override.moveset([Moves.THUNDERBOLT]);
-    game.override.startingLevel(100);
-    game.override.startingWave(5);
-    game.override.enemySpecies(Species.MINIOR);
+    game.override
+      .enemyMoveset([Moves.TACKLE])
+      .moveset([Moves.THUNDERBOLT])
+      .startingLevel(100)
+      .startingWave(5)
+      .enemySpecies(Species.MINIOR);
     await game.classicMode.startBattle([Species.REGIELEKI]);
     const minior = game.scene.getEnemyPokemon()!;
 

--- a/test/abilities/steely_spirit.test.ts
+++ b/test/abilities/steely_spirit.test.ts
@@ -28,11 +28,12 @@ describe("Abilities - Steely Spirit", () => {
   beforeEach(() => {
     ironHeadPower = allMoves[moveToCheck].power;
     game = new GameManager(phaserGame);
-    game.override.battleStyle("double");
-    game.override.enemySpecies(Species.SHUCKLE);
-    game.override.enemyAbility(Abilities.BALL_FETCH);
-    game.override.moveset([Moves.IRON_HEAD, Moves.SPLASH]);
-    game.override.enemyMoveset(Moves.SPLASH);
+    game.override
+      .battleStyle("double")
+      .enemySpecies(Species.SHUCKLE)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .moveset([Moves.IRON_HEAD, Moves.SPLASH])
+      .enemyMoveset(Moves.SPLASH);
     vi.spyOn(allMoves[moveToCheck], "calculateBattlePower");
   });
 

--- a/test/abilities/sturdy.test.ts
+++ b/test/abilities/sturdy.test.ts
@@ -24,15 +24,14 @@ describe("Abilities - Sturdy", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-
-    game.override.starterSpecies(Species.LUCARIO);
-    game.override.startingLevel(100);
-    game.override.moveset([Moves.CLOSE_COMBAT, Moves.FISSURE]);
-
-    game.override.enemySpecies(Species.ARON);
-    game.override.enemyLevel(5);
-    game.override.enemyAbility(Abilities.STURDY);
+    game.override
+      .battleStyle("single")
+      .starterSpecies(Species.LUCARIO)
+      .startingLevel(100)
+      .moveset([Moves.CLOSE_COMBAT, Moves.FISSURE])
+      .enemySpecies(Species.ARON)
+      .enemyLevel(5)
+      .enemyAbility(Abilities.STURDY);
   });
 
   test("Sturdy activates when user is at full HP", async () => {

--- a/test/abilities/sweet_veil.test.ts
+++ b/test/abilities/sweet_veil.test.ts
@@ -69,10 +69,7 @@ describe("Abilities - Sweet Veil", () => {
   });
 
   it("prevents the user and its allies already drowsy due to Yawn from falling asleep.", async () => {
-    game.override.enemySpecies(Species.PIKACHU);
-    game.override.enemyLevel(5);
-    game.override.startingLevel(5);
-    game.override.enemyMoveset(Moves.SPLASH);
+    game.override.enemySpecies(Species.PIKACHU).enemyLevel(5).startingLevel(5).enemyMoveset(Moves.SPLASH);
 
     await game.classicMode.startBattle([Species.SHUCKLE, Species.SHUCKLE, Species.SWIRLIX]);
 

--- a/test/abilities/unseen_fist.test.ts
+++ b/test/abilities/unseen_fist.test.ts
@@ -51,8 +51,7 @@ describe("Abilities - Unseen Fist", () => {
     await testUnseenFistHitResult(game, Moves.BULLDOZE, Moves.WIDE_GUARD, false));
 
   it("should cause a contact move to ignore Protect, but not Substitute", async () => {
-    game.override.enemyLevel(1);
-    game.override.moveset([Moves.TACKLE]);
+    game.override.enemyLevel(1).moveset([Moves.TACKLE]);
 
     await game.classicMode.startBattle();
 

--- a/test/abilities/volt_absorb.test.ts
+++ b/test/abilities/volt_absorb.test.ts
@@ -26,19 +26,19 @@ describe("Abilities - Volt Absorb", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-    game.override.disableCrits();
+    game.override.battleStyle("single").disableCrits();
   });
 
   it("does not activate when CHARGE is used", async () => {
     const moveToUse = Moves.CHARGE;
     const ability = Abilities.VOLT_ABSORB;
 
-    game.override.moveset([moveToUse]);
-    game.override.ability(ability);
-    game.override.enemyMoveset([Moves.SPLASH, Moves.NONE, Moves.NONE, Moves.NONE]);
-    game.override.enemySpecies(Species.DUSKULL);
-    game.override.enemyAbility(Abilities.BALL_FETCH);
+    game.override
+      .moveset([moveToUse])
+      .ability(ability)
+      .enemyMoveset([Moves.SPLASH, Moves.NONE, Moves.NONE, Moves.NONE])
+      .enemySpecies(Species.DUSKULL)
+      .enemyAbility(Abilities.BALL_FETCH);
 
     await game.classicMode.startBattle();
 
@@ -54,10 +54,11 @@ describe("Abilities - Volt Absorb", () => {
   });
 
   it("should activate regardless of accuracy checks", async () => {
-    game.override.moveset(Moves.THUNDERBOLT);
-    game.override.enemyMoveset(Moves.SPLASH);
-    game.override.enemySpecies(Species.MAGIKARP);
-    game.override.enemyAbility(Abilities.VOLT_ABSORB);
+    game.override
+      .moveset(Moves.THUNDERBOLT)
+      .enemyMoveset(Moves.SPLASH)
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.VOLT_ABSORB);
 
     await game.classicMode.startBattle();
 
@@ -74,10 +75,11 @@ describe("Abilities - Volt Absorb", () => {
   });
 
   it("regardless of accuracy should not trigger on pokemon in semi invulnerable state", async () => {
-    game.override.moveset(Moves.THUNDERBOLT);
-    game.override.enemyMoveset(Moves.DIVE);
-    game.override.enemySpecies(Species.MAGIKARP);
-    game.override.enemyAbility(Abilities.VOLT_ABSORB);
+    game.override
+      .moveset(Moves.THUNDERBOLT)
+      .enemyMoveset(Moves.DIVE)
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.VOLT_ABSORB);
 
     await game.classicMode.startBattle();
 

--- a/test/abilities/wind_power.test.ts
+++ b/test/abilities/wind_power.test.ts
@@ -23,14 +23,15 @@ describe("Abilities - Wind Power", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-    game.override.enemySpecies(Species.SHIFTRY);
-    game.override.enemyAbility(Abilities.WIND_POWER);
-    game.override.moveset([Moves.TAILWIND, Moves.SPLASH, Moves.PETAL_BLIZZARD, Moves.SANDSTORM]);
-    game.override.enemyMoveset(Moves.SPLASH);
+    game.override
+      .battleStyle("single")
+      .enemySpecies(Species.SHIFTRY)
+      .enemyAbility(Abilities.WIND_POWER)
+      .moveset([Moves.TAILWIND, Moves.SPLASH, Moves.PETAL_BLIZZARD, Moves.SANDSTORM])
+      .enemyMoveset(Moves.SPLASH);
   });
 
-  it("it becomes charged when hit by wind moves", async () => {
+  it("becomes charged when hit by wind moves", async () => {
     await game.classicMode.startBattle([Species.MAGIKARP]);
     const shiftry = game.scene.getEnemyPokemon()!;
 
@@ -42,9 +43,8 @@ describe("Abilities - Wind Power", () => {
     expect(shiftry.getTag(BattlerTagType.CHARGED)).toBeDefined();
   });
 
-  it("it becomes charged when Tailwind takes effect on its side", async () => {
-    game.override.ability(Abilities.WIND_POWER);
-    game.override.enemySpecies(Species.MAGIKARP);
+  it("becomes charged when Tailwind takes effect on its side", async () => {
+    game.override.ability(Abilities.WIND_POWER).enemySpecies(Species.MAGIKARP);
 
     await game.classicMode.startBattle([Species.SHIFTRY]);
     const shiftry = game.scene.getPlayerPokemon()!;
@@ -58,8 +58,7 @@ describe("Abilities - Wind Power", () => {
   });
 
   it("does not become charged when Tailwind takes effect on opposing side", async () => {
-    game.override.enemySpecies(Species.MAGIKARP);
-    game.override.ability(Abilities.WIND_POWER);
+    game.override.enemySpecies(Species.MAGIKARP).ability(Abilities.WIND_POWER);
 
     await game.classicMode.startBattle([Species.SHIFTRY]);
     const magikarp = game.scene.getEnemyPokemon()!;

--- a/test/abilities/wonder_skin.test.ts
+++ b/test/abilities/wonder_skin.test.ts
@@ -23,12 +23,13 @@ describe("Abilities - Wonder Skin", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-    game.override.moveset([Moves.TACKLE, Moves.CHARM]);
-    game.override.ability(Abilities.BALL_FETCH);
-    game.override.enemySpecies(Species.SHUCKLE);
-    game.override.enemyAbility(Abilities.WONDER_SKIN);
-    game.override.enemyMoveset(Moves.SPLASH);
+    game.override
+      .battleStyle("single")
+      .moveset([Moves.TACKLE, Moves.CHARM])
+      .ability(Abilities.BALL_FETCH)
+      .enemySpecies(Species.SHUCKLE)
+      .enemyAbility(Abilities.WONDER_SKIN)
+      .enemyMoveset(Moves.SPLASH);
   });
 
   it("lowers accuracy of status moves to 50%", async () => {

--- a/test/abilities/zen_mode.test.ts
+++ b/test/abilities/zen_mode.test.ts
@@ -85,8 +85,7 @@ describe("Abilities - ZEN MODE", () => {
   });
 
   it("should switch to base form on arena reset", async () => {
-    game.override.startingWave(4);
-    game.override.starterForms({
+    game.override.startingWave(4).starterForms({
       [Species.DARMANITAN]: zenForm,
     });
 

--- a/test/abilities/zero_to_hero.test.ts
+++ b/test/abilities/zero_to_hero.test.ts
@@ -34,8 +34,7 @@ describe("Abilities - ZERO TO HERO", () => {
   });
 
   it("should swap to base form on arena reset", async () => {
-    game.override.startingWave(4);
-    game.override.starterForms({
+    game.override.startingWave(4).starterForms({
       [Species.PALAFIN]: heroForm,
     });
 

--- a/test/achievements/achievement.test.ts
+++ b/test/achievements/achievement.test.ts
@@ -130,12 +130,7 @@ describe("RibbonAchv", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.moveset([]);
-    game.override.startingLevel(0);
-    game.override.starterSpecies(0);
-    game.override.enemyMoveset([]);
-    game.override.enemySpecies(0);
-    game.override.startingWave(0);
+    game.override.moveset([]).startingLevel(0).starterSpecies(0).enemyMoveset([]).enemySpecies(0).startingWave(0);
     scene = game.scene;
   });
 

--- a/test/arena/weather_fog.test.ts
+++ b/test/arena/weather_fog.test.ts
@@ -24,12 +24,14 @@ describe("Weather - Fog", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.weather(WeatherType.FOG).battleStyle("single");
-    game.override.moveset([Moves.TACKLE]);
-    game.override.ability(Abilities.BALL_FETCH);
-    game.override.enemyAbility(Abilities.BALL_FETCH);
-    game.override.enemySpecies(Species.MAGIKARP);
-    game.override.enemyMoveset([Moves.SPLASH]);
+    game.override
+      .weather(WeatherType.FOG)
+      .battleStyle("single")
+      .moveset([Moves.TACKLE])
+      .ability(Abilities.BALL_FETCH)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemySpecies(Species.MAGIKARP)
+      .enemyMoveset([Moves.SPLASH]);
   });
 
   it("move accuracy is multiplied by 90%", async () => {

--- a/test/arena/weather_strong_winds.test.ts
+++ b/test/arena/weather_strong_winds.test.ts
@@ -24,11 +24,12 @@ describe("Weather - Strong Winds", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-    game.override.startingLevel(10);
-    game.override.enemySpecies(Species.TAILLOW);
-    game.override.enemyAbility(Abilities.DELTA_STREAM);
-    game.override.moveset([Moves.THUNDERBOLT, Moves.ICE_BEAM, Moves.ROCK_SLIDE]);
+    game.override
+      .battleStyle("single")
+      .startingLevel(10)
+      .enemySpecies(Species.TAILLOW)
+      .enemyAbility(Abilities.DELTA_STREAM)
+      .moveset([Moves.THUNDERBOLT, Moves.ICE_BEAM, Moves.ROCK_SLIDE]);
   });
 
   it("electric type move is not very effective on Rayquaza", async () => {

--- a/test/battle/battle-order.test.ts
+++ b/test/battle/battle-order.test.ts
@@ -24,11 +24,12 @@ describe("Battle order", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-    game.override.enemySpecies(Species.MEWTWO);
-    game.override.enemyAbility(Abilities.INSOMNIA);
-    game.override.ability(Abilities.INSOMNIA);
-    game.override.moveset([Moves.TACKLE]);
+    game.override
+      .battleStyle("single")
+      .enemySpecies(Species.MEWTWO)
+      .enemyAbility(Abilities.INSOMNIA)
+      .ability(Abilities.INSOMNIA)
+      .moveset([Moves.TACKLE]);
   });
 
   it("opponent faster than player 50 vs 150", async () => {

--- a/test/battle/battle.test.ts
+++ b/test/battle/battle.test.ts
@@ -15,7 +15,6 @@ import { SummonPhase } from "#app/phases/summon-phase";
 import { SwitchPhase } from "#app/phases/switch-phase";
 import { TitlePhase } from "#app/phases/title-phase";
 import { TurnInitPhase } from "#app/phases/turn-init-phase";
-import { VictoryPhase } from "#app/phases/victory-phase";
 import GameManager from "#test/testUtils/gameManager";
 import { generateStarter } from "#test/testUtils/gameManagerUtils";
 import { UiMode } from "#enums/ui-mode";
@@ -91,28 +90,27 @@ describe("Test Battle Phase", () => {
   }, 20000);
 
   it("do attack wave 3 - single battle - regular - OHKO", async () => {
-    game.override.starterSpecies(Species.MEWTWO);
-    game.override.enemySpecies(Species.RATTATA);
-    game.override.startingLevel(2000);
-    game.override.startingWave(3).battleStyle("single");
-    game.override.moveset([Moves.TACKLE]);
-    game.override.enemyAbility(Abilities.HYDRATION);
-    game.override.enemyMoveset([Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE]);
-    await game.classicMode.startBattle();
+    game.override
+      .enemySpecies(Species.RATTATA)
+      .startingLevel(2000)
+      .startingWave(3)
+      .battleStyle("single")
+      .enemyMoveset([Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE]);
+    await game.classicMode.startBattle([Species.MEWTWO]);
     game.move.select(Moves.TACKLE);
     await game.phaseInterceptor.runFrom(EnemyCommandPhase).to(SelectModifierPhase, false);
   }, 20000);
 
   it("do attack wave 3 - single battle - regular - NO OHKO with opponent using non damage attack", async () => {
-    game.override.starterSpecies(Species.MEWTWO);
-    game.override.enemySpecies(Species.RATTATA);
-    game.override.startingLevel(5);
-    game.override.startingWave(3);
-    game.override.moveset([Moves.TACKLE]);
-    game.override.enemyAbility(Abilities.HYDRATION);
-    game.override.enemyMoveset([Moves.TAIL_WHIP, Moves.TAIL_WHIP, Moves.TAIL_WHIP, Moves.TAIL_WHIP]);
-    game.override.battleStyle("single");
-    await game.classicMode.startBattle();
+    game.override
+      .enemySpecies(Species.RATTATA)
+      .startingLevel(5)
+      .startingWave(3)
+      .moveset([Moves.TACKLE])
+      .enemyAbility(Abilities.HYDRATION)
+      .enemyMoveset([Moves.TAIL_WHIP, Moves.TAIL_WHIP, Moves.TAIL_WHIP, Moves.TAIL_WHIP])
+      .battleStyle("single");
+    await game.classicMode.startBattle([Species.MEWTWO]);
     game.move.select(Moves.TACKLE);
     await game.phaseInterceptor.runFrom(EnemyCommandPhase).to(TurnInitPhase, false);
   }, 20000);
@@ -246,36 +244,37 @@ describe("Test Battle Phase", () => {
 
   it("kill opponent pokemon", async () => {
     const moveToUse = Moves.SPLASH;
-    game.override.battleStyle("single");
-    game.override.starterSpecies(Species.MEWTWO);
-    game.override.enemySpecies(Species.RATTATA);
-    game.override.enemyAbility(Abilities.HYDRATION);
-    game.override.ability(Abilities.ZEN_MODE);
-    game.override.startingLevel(2000);
-    game.override.startingWave(3);
-    game.override.moveset([moveToUse]);
-    game.override.enemyMoveset([Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE]);
+    game.override
+      .battleStyle("single")
+      .starterSpecies(Species.MEWTWO)
+      .enemySpecies(Species.RATTATA)
+      .enemyAbility(Abilities.HYDRATION)
+      .ability(Abilities.ZEN_MODE)
+      .startingLevel(2000)
+      .startingWave(3)
+      .moveset([moveToUse])
+      .enemyMoveset([Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE]);
     await game.classicMode.startBattle([Species.DARMANITAN, Species.CHARIZARD]);
 
     game.move.select(moveToUse);
     await game.phaseInterceptor.to(DamageAnimPhase, false);
     await game.killPokemon(game.scene.currentBattle.enemyParty[0]);
     expect(game.scene.currentBattle.enemyParty[0].isFainted()).toBe(true);
-    await game.phaseInterceptor.to(VictoryPhase, false);
-  }, 200000);
+    await game.phaseInterceptor.to("VictoryPhase");
+  });
 
   it("to next turn", async () => {
     const moveToUse = Moves.SPLASH;
-    game.override.battleStyle("single");
-    game.override.starterSpecies(Species.MEWTWO);
-    game.override.enemySpecies(Species.RATTATA);
-    game.override.enemyAbility(Abilities.HYDRATION);
-    game.override.ability(Abilities.ZEN_MODE);
-    game.override.startingLevel(2000);
-    game.override.startingWave(3);
-    game.override.moveset([moveToUse]);
-    game.override.enemyMoveset([Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE]);
-    await game.classicMode.startBattle();
+    game.override
+      .battleStyle("single")
+      .enemySpecies(Species.RATTATA)
+      .enemyAbility(Abilities.HYDRATION)
+      .ability(Abilities.ZEN_MODE)
+      .startingLevel(2000)
+      .startingWave(3)
+      .moveset([moveToUse])
+      .enemyMoveset([Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE]);
+    await game.classicMode.startBattle([Species.MEWTWO]);
     const turn = game.scene.currentBattle.turn;
     game.move.select(moveToUse);
     await game.toNextTurn();
@@ -293,8 +292,8 @@ describe("Test Battle Phase", () => {
       .startingLevel(2000)
       .startingWave(3)
       .startingBiome(Biome.LAKE)
-      .moveset([moveToUse]);
-    game.override.enemyMoveset([Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE]);
+      .moveset([moveToUse])
+      .enemyMoveset([Moves.TACKLE, Moves.TACKLE, Moves.TACKLE, Moves.TACKLE]);
     await game.classicMode.startBattle();
     const waveIndex = game.scene.currentBattle.waveIndex;
     game.move.select(moveToUse);

--- a/test/escape-calculations.test.ts
+++ b/test/escape-calculations.test.ts
@@ -262,8 +262,7 @@ describe("Escape chance calculations", () => {
   }, 20000);
 
   it("double boss opponent", async () => {
-    game.override.battleStyle("double");
-    game.override.startingWave(10);
+    game.override.battleStyle("double").startingWave(10);
     await game.classicMode.startBattle([Species.BULBASAUR, Species.ABOMASNOW]);
 
     const playerPokemon = game.scene.getPlayerField();

--- a/test/evolution.test.ts
+++ b/test/evolution.test.ts
@@ -28,12 +28,11 @@ describe("Evolution", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
 
-    game.override.battleStyle("single");
-
-    game.override.enemySpecies(Species.MAGIKARP);
-    game.override.enemyAbility(Abilities.BALL_FETCH);
-
-    game.override.startingLevel(60);
+    game.override
+      .battleStyle("single")
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .startingLevel(60);
   });
 
   it("should keep hidden ability after evolving", async () => {

--- a/test/field/pokemon.test.ts
+++ b/test/field/pokemon.test.ts
@@ -82,9 +82,7 @@ describe("Spec - Pokemon", () => {
     let scene: BattleScene;
 
     beforeEach(async () => {
-      game.override.enemySpecies(Species.ZUBAT);
-      game.override.starterSpecies(Species.ABRA);
-      game.override.enableStarterFusion();
+      game.override.enemySpecies(Species.ZUBAT).starterSpecies(Species.ABRA).enableStarterFusion();
       scene = game.scene;
     });
 
@@ -140,8 +138,7 @@ describe("Spec - Pokemon", () => {
     });
 
     it("Fusing mons with one and two types", async () => {
-      game.override.starterSpecies(Species.CHARMANDER);
-      game.override.starterFusionSpecies(Species.HOUNDOUR);
+      game.override.starterSpecies(Species.CHARMANDER).starterFusionSpecies(Species.HOUNDOUR);
       await game.classicMode.startBattle();
       const pokemon = scene.getPlayerParty()[0];
 
@@ -151,8 +148,7 @@ describe("Spec - Pokemon", () => {
     });
 
     it("Fusing mons with two and one types", async () => {
-      game.override.starterSpecies(Species.NUMEL);
-      game.override.starterFusionSpecies(Species.CHARMANDER);
+      game.override.starterSpecies(Species.NUMEL).starterFusionSpecies(Species.CHARMANDER);
       await game.classicMode.startBattle();
       const pokemon = scene.getPlayerParty()[0];
 
@@ -162,8 +158,7 @@ describe("Spec - Pokemon", () => {
     });
 
     it("Fusing two mons with two types", async () => {
-      game.override.starterSpecies(Species.NATU);
-      game.override.starterFusionSpecies(Species.HOUNDOUR);
+      game.override.starterSpecies(Species.NATU).starterFusionSpecies(Species.HOUNDOUR);
       await game.classicMode.startBattle();
       const pokemon = scene.getPlayerParty()[0];
 

--- a/test/items/exp_booster.test.ts
+++ b/test/items/exp_booster.test.ts
@@ -22,9 +22,7 @@ describe("EXP Modifier Items", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
 
-    game.override.enemyAbility(Abilities.BALL_FETCH);
-    game.override.ability(Abilities.BALL_FETCH);
-    game.override.battleStyle("single");
+    game.override.enemyAbility(Abilities.BALL_FETCH).ability(Abilities.BALL_FETCH).battleStyle("single");
   });
 
   it("EXP booster items stack multiplicatively", async () => {

--- a/test/moves/baneful_bunker.test.ts
+++ b/test/moves/baneful_bunker.test.ts
@@ -24,16 +24,14 @@ describe("Moves - Baneful Bunker", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
 
-    game.override.battleStyle("single");
-
-    game.override.moveset(Moves.SLASH);
-
-    game.override.enemySpecies(Species.SNORLAX);
-    game.override.enemyAbility(Abilities.INSOMNIA);
-    game.override.enemyMoveset(Moves.BANEFUL_BUNKER);
-
-    game.override.startingLevel(100);
-    game.override.enemyLevel(100);
+    game.override
+      .battleStyle("single")
+      .moveset(Moves.SLASH)
+      .enemySpecies(Species.SNORLAX)
+      .enemyAbility(Abilities.INSOMNIA)
+      .enemyMoveset(Moves.BANEFUL_BUNKER)
+      .startingLevel(100)
+      .enemyLevel(100);
   });
   test("should protect the user and poison attackers that make contact", async () => {
     await game.classicMode.startBattle([Species.CHARIZARD]);

--- a/test/moves/baton_pass.test.ts
+++ b/test/moves/baton_pass.test.ts
@@ -59,28 +59,23 @@ describe("Moves - Baton Pass", () => {
 
   it("passes stat stage buffs when AI uses it", async () => {
     // arrange
-    game.override.startingWave(5).enemyMoveset(new Array(4).fill([Moves.NASTY_PLOT]));
+    game.override.startingWave(5).enemyMoveset([Moves.NASTY_PLOT, Moves.BATON_PASS]);
     await game.classicMode.startBattle([Species.RAICHU, Species.SHUCKLE]);
 
     // round 1 - ai buffs
     game.move.select(Moves.SPLASH);
+    await game.forceEnemyMove(Moves.NASTY_PLOT);
     await game.toNextTurn();
 
     // round 2 - baton pass
-    game.scene.getEnemyPokemon()!.hp = 100;
-    game.override.enemyMoveset([Moves.BATON_PASS]);
-    // Force moveset to update mid-battle
-    // TODO: replace with enemy ai control function when it's added
-    game.scene.getEnemyParty()[0].getMoveset();
     game.move.select(Moves.SPLASH);
+    await game.forceEnemyMove(Moves.BATON_PASS);
     await game.phaseInterceptor.to("PostSummonPhase", false);
 
-    // assert
     // check buffs are still there
-    expect(game.scene.getEnemyPokemon()!.getStatStage(Stat.SPATK)).toEqual(2);
+    expect(game.scene.getEnemyPokemon()?.getStatStage(Stat.SPATK)).toEqual(2);
     // confirm that a switch actually happened. can't use species because I
     // can't find a way to override trainer parties with more than 1 pokemon species
-    expect(game.scene.getEnemyPokemon()!.hp).not.toEqual(100);
     expect(game.phaseInterceptor.log.slice(-4)).toEqual([
       "MoveEffectPhase",
       "SwitchSummonPhase",

--- a/test/moves/beak_blast.test.ts
+++ b/test/moves/beak_blast.test.ts
@@ -129,8 +129,7 @@ describe("Moves - Beak Blast", () => {
   });
 
   it("should not burn a long reach enemy that hits the user with a contact move", async () => {
-    game.override.enemyAbility(Abilities.LONG_REACH);
-    game.override.enemyMoveset([Moves.FALSE_SWIPE]).enemyLevel(100);
+    game.override.enemyAbility(Abilities.LONG_REACH).enemyMoveset([Moves.FALSE_SWIPE]).enemyLevel(100);
     await game.classicMode.startBattle([Species.MAGIKARP]);
     game.move.select(Moves.BEAK_BLAST);
     await game.phaseInterceptor.to("BerryPhase", false);

--- a/test/moves/beat_up.test.ts
+++ b/test/moves/beat_up.test.ts
@@ -23,15 +23,14 @@ describe("Moves - Beat Up", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-
-    game.override.enemySpecies(Species.SNORLAX);
-    game.override.enemyLevel(100);
-    game.override.enemyMoveset([Moves.SPLASH]);
-    game.override.enemyAbility(Abilities.INSOMNIA);
-
-    game.override.startingLevel(100);
-    game.override.moveset([Moves.BEAT_UP]);
+    game.override
+      .battleStyle("single")
+      .enemySpecies(Species.SNORLAX)
+      .enemyLevel(100)
+      .enemyMoveset([Moves.SPLASH])
+      .enemyAbility(Abilities.INSOMNIA)
+      .startingLevel(100)
+      .moveset([Moves.BEAT_UP]);
   });
 
   it("should hit once for each healthy player Pokemon", async () => {

--- a/test/moves/ceaseless_edge.test.ts
+++ b/test/moves/ceaseless_edge.test.ts
@@ -26,14 +26,15 @@ describe("Moves - Ceaseless Edge", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-    game.override.enemySpecies(Species.RATTATA);
-    game.override.enemyAbility(Abilities.RUN_AWAY);
-    game.override.enemyPassiveAbility(Abilities.RUN_AWAY);
-    game.override.startingLevel(100);
-    game.override.enemyLevel(100);
-    game.override.moveset([Moves.CEASELESS_EDGE, Moves.SPLASH, Moves.ROAR]);
-    game.override.enemyMoveset(Moves.SPLASH);
+    game.override
+      .battleStyle("single")
+      .enemySpecies(Species.RATTATA)
+      .enemyAbility(Abilities.RUN_AWAY)
+      .enemyPassiveAbility(Abilities.RUN_AWAY)
+      .startingLevel(100)
+      .enemyLevel(100)
+      .moveset([Moves.CEASELESS_EDGE, Moves.SPLASH, Moves.ROAR])
+      .enemyMoveset(Moves.SPLASH);
     vi.spyOn(allMoves[Moves.CEASELESS_EDGE], "accuracy", "get").mockReturnValue(100);
   });
 
@@ -81,8 +82,7 @@ describe("Moves - Ceaseless Edge", () => {
   });
 
   test("trainer - move should hit twice, apply two layers of spikes, force switch opponent - opponent takes damage", async () => {
-    game.override.startingHeldItems([{ name: "MULTI_LENS" }]);
-    game.override.startingWave(25);
+    game.override.startingHeldItems([{ name: "MULTI_LENS" }]).startingWave(25);
 
     await game.classicMode.startBattle([Species.ILLUMISE]);
 

--- a/test/moves/clangorous_soul.test.ts
+++ b/test/moves/clangorous_soul.test.ts
@@ -27,12 +27,13 @@ describe("Moves - Clangorous Soul", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.starterSpecies(Species.MAGIKARP);
-    game.override.enemySpecies(Species.SNORLAX);
-    game.override.startingLevel(100);
-    game.override.enemyLevel(100);
-    game.override.moveset([Moves.CLANGOROUS_SOUL]);
-    game.override.enemyMoveset(Moves.SPLASH);
+    game.override
+      .starterSpecies(Species.MAGIKARP)
+      .enemySpecies(Species.SNORLAX)
+      .startingLevel(100)
+      .enemyLevel(100)
+      .moveset([Moves.CLANGOROUS_SOUL])
+      .enemyMoveset(Moves.SPLASH);
   });
 
   //Bulbapedia Reference: https://bulbapedia.bulbagarden.net/wiki/Clangorous_Soul_(move)

--- a/test/moves/crafty_shield.test.ts
+++ b/test/moves/crafty_shield.test.ts
@@ -26,16 +26,14 @@ describe("Moves - Crafty Shield", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
 
-    game.override.battleStyle("double");
-
-    game.override.moveset([Moves.CRAFTY_SHIELD, Moves.SPLASH, Moves.SWORDS_DANCE]);
-
-    game.override.enemySpecies(Species.SNORLAX);
-    game.override.enemyMoveset([Moves.GROWL]);
-    game.override.enemyAbility(Abilities.INSOMNIA);
-
-    game.override.startingLevel(100);
-    game.override.enemyLevel(100);
+    game.override
+      .battleStyle("double")
+      .moveset([Moves.CRAFTY_SHIELD, Moves.SPLASH, Moves.SWORDS_DANCE])
+      .enemySpecies(Species.SNORLAX)
+      .enemyMoveset([Moves.GROWL])
+      .enemyAbility(Abilities.INSOMNIA)
+      .startingLevel(100)
+      .enemyLevel(100);
   });
 
   test("should protect the user and allies from status moves", async () => {
@@ -73,8 +71,7 @@ describe("Moves - Crafty Shield", () => {
   });
 
   test("should protect the user and allies from moves that ignore other protection", async () => {
-    game.override.enemySpecies(Species.DUSCLOPS);
-    game.override.enemyMoveset([Moves.CURSE]);
+    game.override.enemySpecies(Species.DUSCLOPS).enemyMoveset([Moves.CURSE]);
 
     await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
 

--- a/test/moves/dragon_rage.test.ts
+++ b/test/moves/dragon_rage.test.ts
@@ -31,19 +31,18 @@ describe("Moves - Dragon Rage", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
 
-    game.override.battleStyle("single");
-
-    game.override.starterSpecies(Species.SNORLAX);
-    game.override.moveset([Moves.DRAGON_RAGE]);
-    game.override.ability(Abilities.BALL_FETCH);
-    game.override.passiveAbility(Abilities.BALL_FETCH);
-    game.override.startingLevel(100);
-
-    game.override.enemySpecies(Species.SNORLAX);
-    game.override.enemyMoveset(Moves.SPLASH);
-    game.override.enemyAbility(Abilities.BALL_FETCH);
-    game.override.enemyPassiveAbility(Abilities.BALL_FETCH);
-    game.override.enemyLevel(100);
+    game.override
+      .battleStyle("single")
+      .starterSpecies(Species.SNORLAX)
+      .moveset([Moves.DRAGON_RAGE])
+      .ability(Abilities.BALL_FETCH)
+      .passiveAbility(Abilities.BALL_FETCH)
+      .startingLevel(100)
+      .enemySpecies(Species.SNORLAX)
+      .enemyMoveset(Moves.SPLASH)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyPassiveAbility(Abilities.BALL_FETCH)
+      .enemyLevel(100);
 
     await game.classicMode.startBattle();
 
@@ -101,8 +100,7 @@ describe("Moves - Dragon Rage", () => {
   });
 
   it("ignores damage modification from abilities, for example ICE_SCALES", async () => {
-    game.override.disableCrits();
-    game.override.enemyAbility(Abilities.ICE_SCALES);
+    game.override.disableCrits().enemyAbility(Abilities.ICE_SCALES);
 
     game.move.select(Moves.DRAGON_RAGE);
     await game.phaseInterceptor.to(TurnEndPhase);

--- a/test/moves/dynamax_cannon.test.ts
+++ b/test/moves/dynamax_cannon.test.ts
@@ -38,15 +38,7 @@ describe("Moves - Dynamax Cannon", () => {
       .enemySpecies(Species.MAGIKARP)
       .enemyMoveset(Moves.SPLASH);
 
-    // Note that, for Waves 1-10, the level cap is 10
-    game.override.startingWave(1);
-    game.override.battleStyle("single");
-    game.override.disableCrits();
-
-    game.override.enemySpecies(Species.MAGIKARP);
-    game.override.enemyMoveset([Moves.SPLASH, Moves.SPLASH, Moves.SPLASH, Moves.SPLASH]);
-
-    vi.spyOn(dynamaxCannon, "calculateBattlePower");
+    vi.spyOn(allMoves[Moves.DYNAMAX_CANNON], "calculateBattlePower");
   });
 
   it("should return 100 power against an enemy below level cap", async () => {

--- a/test/moves/fillet_away.test.ts
+++ b/test/moves/fillet_away.test.ts
@@ -28,12 +28,13 @@ describe("Moves - FILLET AWAY", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.starterSpecies(Species.MAGIKARP);
-    game.override.enemySpecies(Species.SNORLAX);
-    game.override.startingLevel(100);
-    game.override.enemyLevel(100);
-    game.override.moveset([Moves.FILLET_AWAY]);
-    game.override.enemyMoveset(Moves.SPLASH);
+    game.override
+      .starterSpecies(Species.MAGIKARP)
+      .enemySpecies(Species.SNORLAX)
+      .startingLevel(100)
+      .enemyLevel(100)
+      .moveset([Moves.FILLET_AWAY])
+      .enemyMoveset(Moves.SPLASH);
   });
 
   //Bulbapedia Reference: https://bulbapedia.bulbagarden.net/wiki/fillet_away_(move)

--- a/test/moves/fissure.test.ts
+++ b/test/moves/fissure.test.ts
@@ -28,18 +28,17 @@ describe("Moves - Fissure", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
 
-    game.override.battleStyle("single");
-    game.override.disableCrits();
-
-    game.override.starterSpecies(Species.SNORLAX);
-    game.override.moveset([Moves.FISSURE]);
-    game.override.passiveAbility(Abilities.BALL_FETCH);
-    game.override.startingLevel(100);
-
-    game.override.enemySpecies(Species.SNORLAX);
-    game.override.enemyMoveset(Moves.SPLASH);
-    game.override.enemyPassiveAbility(Abilities.BALL_FETCH);
-    game.override.enemyLevel(100);
+    game.override
+      .battleStyle("single")
+      .disableCrits()
+      .starterSpecies(Species.SNORLAX)
+      .moveset([Moves.FISSURE])
+      .passiveAbility(Abilities.BALL_FETCH)
+      .startingLevel(100)
+      .enemySpecies(Species.SNORLAX)
+      .enemyMoveset(Moves.SPLASH)
+      .enemyPassiveAbility(Abilities.BALL_FETCH)
+      .enemyLevel(100);
 
     await game.classicMode.startBattle();
 
@@ -48,8 +47,7 @@ describe("Moves - Fissure", () => {
   });
 
   it("ignores damage modification from abilities, for example FUR_COAT", async () => {
-    game.override.ability(Abilities.NO_GUARD);
-    game.override.enemyAbility(Abilities.FUR_COAT);
+    game.override.ability(Abilities.NO_GUARD).enemyAbility(Abilities.FUR_COAT);
 
     game.move.select(Moves.FISSURE);
     await game.phaseInterceptor.to(DamageAnimPhase, true);

--- a/test/moves/flame_burst.test.ts
+++ b/test/moves/flame_burst.test.ts
@@ -35,14 +35,15 @@ describe("Moves - Flame Burst", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("double");
-    game.override.moveset([Moves.FLAME_BURST, Moves.SPLASH]);
-    game.override.disableCrits();
-    game.override.ability(Abilities.UNNERVE);
-    game.override.startingWave(4);
-    game.override.enemySpecies(Species.SHUCKLE);
-    game.override.enemyAbility(Abilities.BALL_FETCH);
-    game.override.enemyMoveset([Moves.SPLASH]);
+    game.override
+      .battleStyle("double")
+      .moveset([Moves.FLAME_BURST, Moves.SPLASH])
+      .disableCrits()
+      .ability(Abilities.UNNERVE)
+      .startingWave(4)
+      .enemySpecies(Species.SHUCKLE)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset([Moves.SPLASH]);
   });
 
   it("inflicts damage to the target's ally equal to 1/16 of its max HP", async () => {

--- a/test/moves/flower_shield.test.ts
+++ b/test/moves/flower_shield.test.ts
@@ -26,11 +26,12 @@ describe("Moves - Flower Shield", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.ability(Abilities.NONE);
-    game.override.enemyAbility(Abilities.NONE);
-    game.override.battleStyle("single");
-    game.override.moveset([Moves.FLOWER_SHIELD, Moves.SPLASH]);
-    game.override.enemyMoveset(Moves.SPLASH);
+    game.override
+      .ability(Abilities.NONE)
+      .enemyAbility(Abilities.NONE)
+      .battleStyle("single")
+      .moveset([Moves.FLOWER_SHIELD, Moves.SPLASH])
+      .enemyMoveset(Moves.SPLASH);
   });
 
   it("raises DEF stat stage by 1 for all Grass-type Pokemon on the field by one stage - single battle", async () => {

--- a/test/moves/follow_me.test.ts
+++ b/test/moves/follow_me.test.ts
@@ -24,14 +24,15 @@ describe("Moves - Follow Me", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("double");
-    game.override.starterSpecies(Species.AMOONGUSS);
-    game.override.ability(Abilities.BALL_FETCH);
-    game.override.enemySpecies(Species.SNORLAX);
-    game.override.startingLevel(100);
-    game.override.enemyLevel(100);
-    game.override.moveset([Moves.FOLLOW_ME, Moves.RAGE_POWDER, Moves.SPOTLIGHT, Moves.QUICK_ATTACK]);
-    game.override.enemyMoveset([Moves.TACKLE, Moves.FOLLOW_ME, Moves.SPLASH]);
+    game.override
+      .battleStyle("double")
+      .starterSpecies(Species.AMOONGUSS)
+      .ability(Abilities.BALL_FETCH)
+      .enemySpecies(Species.SNORLAX)
+      .startingLevel(100)
+      .enemyLevel(100)
+      .moveset([Moves.FOLLOW_ME, Moves.RAGE_POWDER, Moves.SPOTLIGHT, Moves.QUICK_ATTACK])
+      .enemyMoveset([Moves.TACKLE, Moves.FOLLOW_ME, Moves.SPLASH]);
   });
 
   test("move should redirect enemy attacks to the user", async () => {
@@ -73,8 +74,7 @@ describe("Moves - Follow Me", () => {
   });
 
   test("move effect should be bypassed by Stalwart", async () => {
-    game.override.ability(Abilities.STALWART);
-    game.override.moveset([Moves.QUICK_ATTACK]);
+    game.override.ability(Abilities.STALWART).moveset([Moves.QUICK_ATTACK]);
 
     await game.classicMode.startBattle([Species.AMOONGUSS, Species.CHARIZARD]);
 

--- a/test/moves/gastro_acid.test.ts
+++ b/test/moves/gastro_acid.test.ts
@@ -22,14 +22,15 @@ describe("Moves - Gastro Acid", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("double");
-    game.override.startingLevel(1);
-    game.override.enemyLevel(100);
-    game.override.ability(Abilities.BALL_FETCH);
-    game.override.moveset([Moves.GASTRO_ACID, Moves.WATER_GUN, Moves.SPLASH, Moves.CORE_ENFORCER]);
-    game.override.enemySpecies(Species.BIDOOF);
-    game.override.enemyMoveset(Moves.SPLASH);
-    game.override.enemyAbility(Abilities.WATER_ABSORB);
+    game.override
+      .battleStyle("double")
+      .startingLevel(1)
+      .enemyLevel(100)
+      .ability(Abilities.NONE)
+      .moveset([Moves.GASTRO_ACID, Moves.WATER_GUN, Moves.SPLASH, Moves.CORE_ENFORCER])
+      .enemySpecies(Species.BIDOOF)
+      .enemyMoveset(Moves.SPLASH)
+      .enemyAbility(Abilities.WATER_ABSORB);
   });
 
   it("suppresses effect of ability", async () => {

--- a/test/moves/glaive_rush.test.ts
+++ b/test/moves/glaive_rush.test.ts
@@ -28,13 +28,12 @@ describe("Moves - Glaive Rush", () => {
       .enemySpecies(Species.MAGIKARP)
       .enemyAbility(Abilities.BALL_FETCH)
       .enemyMoveset([Moves.GLAIVE_RUSH])
-      .starterSpecies(Species.KLINK)
       .ability(Abilities.BALL_FETCH)
       .moveset([Moves.SHADOW_SNEAK, Moves.AVALANCHE, Moves.SPLASH, Moves.GLAIVE_RUSH]);
   });
 
   it("takes double damage from attacks", async () => {
-    await game.classicMode.startBattle();
+    await game.classicMode.startBattle([Species.KLINK]);
 
     const enemy = game.scene.getEnemyPokemon()!;
     enemy.hp = 1000;
@@ -49,7 +48,7 @@ describe("Moves - Glaive Rush", () => {
   });
 
   it("always gets hit by attacks", async () => {
-    await game.classicMode.startBattle();
+    await game.classicMode.startBattle([Species.KLINK]);
 
     const enemy = game.scene.getEnemyPokemon()!;
     enemy.hp = 1000;
@@ -62,7 +61,7 @@ describe("Moves - Glaive Rush", () => {
 
   it("interacts properly with multi-lens", async () => {
     game.override.startingHeldItems([{ name: "MULTI_LENS", count: 2 }]).enemyMoveset([Moves.AVALANCHE]);
-    await game.classicMode.startBattle();
+    await game.classicMode.startBattle([Species.KLINK]);
 
     const player = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;
@@ -82,7 +81,7 @@ describe("Moves - Glaive Rush", () => {
 
   it("secondary effects only last until next move", async () => {
     game.override.enemyMoveset([Moves.SHADOW_SNEAK]);
-    await game.classicMode.startBattle();
+    await game.classicMode.startBattle([Species.KLINK]);
 
     const player = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;
@@ -106,7 +105,7 @@ describe("Moves - Glaive Rush", () => {
   });
 
   it("secondary effects are removed upon switching", async () => {
-    game.override.enemyMoveset([Moves.SHADOW_SNEAK]).starterSpecies(0);
+    game.override.enemyMoveset([Moves.SHADOW_SNEAK]);
     await game.classicMode.startBattle([Species.KLINK, Species.FEEBAS]);
 
     const player = game.scene.getPlayerPokemon()!;
@@ -127,8 +126,10 @@ describe("Moves - Glaive Rush", () => {
   });
 
   it("secondary effects don't activate if move fails", async () => {
-    game.override.moveset([Moves.SHADOW_SNEAK, Moves.PROTECT, Moves.SPLASH, Moves.GLAIVE_RUSH]);
-    await game.classicMode.startBattle();
+    game.override
+      .moveset([Moves.SHADOW_SNEAK, Moves.PROTECT, Moves.SPLASH, Moves.GLAIVE_RUSH])
+      .enemyMoveset([Moves.GLAIVE_RUSH, Moves.SPLASH]);
+    await game.classicMode.startBattle([Species.KLINK]);
 
     const player = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;
@@ -137,15 +138,17 @@ describe("Moves - Glaive Rush", () => {
     player.hp = 1000;
 
     game.move.select(Moves.PROTECT);
+    await game.forceEnemyMove(Moves.GLAIVE_RUSH);
     await game.phaseInterceptor.to("TurnEndPhase");
 
     game.move.select(Moves.SHADOW_SNEAK);
+    await game.forceEnemyMove(Moves.GLAIVE_RUSH);
     await game.phaseInterceptor.to("TurnEndPhase");
-    game.override.enemyMoveset([Moves.SPLASH]);
     const damagedHP1 = 1000 - enemy.hp;
     enemy.hp = 1000;
 
     game.move.select(Moves.SHADOW_SNEAK);
+    await game.forceEnemyMove(Moves.SPLASH);
     await game.phaseInterceptor.to("TurnEndPhase");
     const damagedHP2 = 1000 - enemy.hp;
 

--- a/test/moves/growth.test.ts
+++ b/test/moves/growth.test.ts
@@ -24,11 +24,12 @@ describe("Moves - Growth", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-    game.override.enemyAbility(Abilities.MOXIE);
-    game.override.ability(Abilities.INSOMNIA);
-    game.override.moveset([Moves.GROWTH]);
-    game.override.enemyMoveset(Moves.SPLASH);
+    game.override
+      .battleStyle("single")
+      .enemyAbility(Abilities.MOXIE)
+      .ability(Abilities.INSOMNIA)
+      .moveset([Moves.GROWTH])
+      .enemyMoveset(Moves.SPLASH);
   });
 
   it("should raise SPATK stat stage by 1", async () => {

--- a/test/moves/hard_press.test.ts
+++ b/test/moves/hard_press.test.ts
@@ -27,12 +27,13 @@ describe("Moves - Hard Press", () => {
   beforeEach(() => {
     moveToCheck = allMoves[Moves.HARD_PRESS];
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-    game.override.ability(Abilities.BALL_FETCH);
-    game.override.enemySpecies(Species.MUNCHLAX);
-    game.override.enemyAbility(Abilities.BALL_FETCH);
-    game.override.enemyMoveset(Moves.SPLASH);
-    game.override.moveset([Moves.HARD_PRESS]);
+    game.override
+      .battleStyle("single")
+      .ability(Abilities.BALL_FETCH)
+      .enemySpecies(Species.MUNCHLAX)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH)
+      .moveset([Moves.HARD_PRESS]);
     vi.spyOn(moveToCheck, "calculateBattlePower");
   });
 

--- a/test/moves/haze.test.ts
+++ b/test/moves/haze.test.ts
@@ -23,16 +23,15 @@ describe("Moves - Haze", () => {
     beforeEach(() => {
       game = new GameManager(phaserGame);
 
-      game.override.battleStyle("single");
-
-      game.override.enemySpecies(Species.RATTATA);
-      game.override.enemyLevel(100);
-      game.override.enemyMoveset(Moves.SPLASH);
-      game.override.enemyAbility(Abilities.NONE);
-
-      game.override.startingLevel(100);
-      game.override.moveset([Moves.HAZE, Moves.SWORDS_DANCE, Moves.CHARM, Moves.SPLASH]);
-      game.override.ability(Abilities.NONE);
+      game.override
+        .battleStyle("single")
+        .enemySpecies(Species.RATTATA)
+        .enemyLevel(100)
+        .enemyMoveset(Moves.SPLASH)
+        .enemyAbility(Abilities.BALL_FETCH)
+        .startingLevel(100)
+        .moveset([Moves.HAZE, Moves.SWORDS_DANCE, Moves.CHARM, Moves.SPLASH])
+        .ability(Abilities.BALL_FETCH);
     });
 
     it("should reset all stat changes of all Pokemon on field", async () => {

--- a/test/moves/hyper_beam.test.ts
+++ b/test/moves/hyper_beam.test.ts
@@ -26,14 +26,14 @@ describe("Moves - Hyper Beam", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
 
-    game.override.battleStyle("single");
-    game.override.ability(Abilities.BALL_FETCH);
-    game.override.enemySpecies(Species.SNORLAX);
-    game.override.enemyAbility(Abilities.BALL_FETCH);
-    game.override.enemyMoveset([Moves.SPLASH]);
-    game.override.enemyLevel(100);
-
-    game.override.moveset([Moves.HYPER_BEAM, Moves.TACKLE]);
+    game.override
+      .battleStyle("single")
+      .ability(Abilities.BALL_FETCH)
+      .enemySpecies(Species.SNORLAX)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset([Moves.SPLASH])
+      .enemyLevel(100)
+      .moveset([Moves.HYPER_BEAM, Moves.TACKLE]);
     vi.spyOn(allMoves[Moves.HYPER_BEAM], "accuracy", "get").mockReturnValue(100);
   });
 

--- a/test/moves/lunar_blessing.test.ts
+++ b/test/moves/lunar_blessing.test.ts
@@ -22,14 +22,13 @@ describe("Moves - Lunar Blessing", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
 
-    game.override.battleStyle("double");
-
-    game.override.enemySpecies(Species.SHUCKLE);
-    game.override.enemyMoveset(Moves.SPLASH);
-    game.override.enemyAbility(Abilities.BALL_FETCH);
-
-    game.override.moveset([Moves.LUNAR_BLESSING, Moves.SPLASH]);
-    game.override.ability(Abilities.BALL_FETCH);
+    game.override
+      .battleStyle("double")
+      .enemySpecies(Species.SHUCKLE)
+      .enemyMoveset(Moves.SPLASH)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .moveset([Moves.LUNAR_BLESSING, Moves.SPLASH])
+      .ability(Abilities.BALL_FETCH);
   });
 
   it("should restore 25% HP of the user and its ally", async () => {

--- a/test/moves/magic_coat.test.ts
+++ b/test/moves/magic_coat.test.ts
@@ -56,8 +56,7 @@ describe("Moves - Magic Coat", () => {
   });
 
   it("should not reflect moves used on the next turn", async () => {
-    game.override.moveset([Moves.GROWL, Moves.SPLASH]);
-    game.override.enemyMoveset([Moves.MAGIC_COAT, Moves.SPLASH]);
+    game.override.moveset([Moves.GROWL, Moves.SPLASH]).enemyMoveset([Moves.MAGIC_COAT, Moves.SPLASH]);
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
     // turn 1
@@ -82,8 +81,7 @@ describe("Moves - Magic Coat", () => {
   });
 
   it("should individually bounce back multi-target moves when used by both targets in doubles", async () => {
-    game.override.battleStyle("double");
-    game.override.moveset([Moves.GROWL, Moves.SPLASH]);
+    game.override.battleStyle("double").moveset([Moves.GROWL, Moves.SPLASH]);
     await game.classicMode.startBattle([Species.MAGIKARP, Species.MAGIKARP]);
 
     game.move.select(Moves.GROWL, 0);
@@ -95,9 +93,10 @@ describe("Moves - Magic Coat", () => {
   });
 
   it("should bounce back a spread status move against both pokemon", async () => {
-    game.override.battleStyle("double");
-    game.override.moveset([Moves.GROWL, Moves.SPLASH]);
-    game.override.enemyMoveset([Moves.SPLASH, Moves.MAGIC_COAT]);
+    game.override
+      .battleStyle("double")
+      .moveset([Moves.GROWL, Moves.SPLASH])
+      .enemyMoveset([Moves.SPLASH, Moves.MAGIC_COAT]);
     await game.classicMode.startBattle([Species.MAGIKARP, Species.MAGIKARP]);
 
     game.move.select(Moves.GROWL, 0);
@@ -121,10 +120,11 @@ describe("Moves - Magic Coat", () => {
   });
 
   it("should not bounce back a move that was just bounced", async () => {
-    game.override.battleStyle("double");
-    game.override.ability(Abilities.MAGIC_BOUNCE);
-    game.override.moveset([Moves.GROWL, Moves.MAGIC_COAT]);
-    game.override.enemyMoveset([Moves.SPLASH, Moves.MAGIC_COAT]);
+    game.override
+      .battleStyle("double")
+      .ability(Abilities.MAGIC_BOUNCE)
+      .moveset([Moves.GROWL, Moves.MAGIC_COAT])
+      .enemyMoveset([Moves.SPLASH, Moves.MAGIC_COAT]);
     await game.classicMode.startBattle([Species.MAGIKARP, Species.MAGIKARP]);
 
     game.move.select(Moves.MAGIC_COAT, 0);
@@ -147,8 +147,7 @@ describe("Moves - Magic Coat", () => {
   });
 
   it("should still bounce back a move from a mold breaker user", async () => {
-    game.override.ability(Abilities.MOLD_BREAKER);
-    game.override.moveset([Moves.GROWL]);
+    game.override.ability(Abilities.MOLD_BREAKER).moveset([Moves.GROWL]);
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
     game.move.select(Moves.GROWL);
@@ -159,9 +158,8 @@ describe("Moves - Magic Coat", () => {
   });
 
   it("should only bounce spikes back once when both targets use magic coat in doubles", async () => {
-    game.override.battleStyle("double");
+    game.override.battleStyle("double").moveset([Moves.SPIKES]);
     await game.classicMode.startBattle([Species.MAGIKARP]);
-    game.override.moveset([Moves.SPIKES]);
 
     game.move.select(Moves.SPIKES);
     await game.phaseInterceptor.to("BerryPhase");
@@ -171,9 +169,8 @@ describe("Moves - Magic Coat", () => {
   });
 
   it("should not bounce back curse", async () => {
-    game.override.starterSpecies(Species.GASTLY);
-    await game.classicMode.startBattle([Species.GASTLY]);
     game.override.moveset([Moves.CURSE]);
+    await game.classicMode.startBattle([Species.GASTLY]);
 
     game.move.select(Moves.CURSE);
     await game.phaseInterceptor.to("BerryPhase");
@@ -183,9 +180,10 @@ describe("Moves - Magic Coat", () => {
 
   // TODO: encore is failing if the last move was virtual.
   it.todo("should not cause the bounced move to count for encore", async () => {
-    game.override.moveset([Moves.GROWL, Moves.ENCORE]);
-    game.override.enemyMoveset([Moves.MAGIC_COAT, Moves.TACKLE]);
-    game.override.enemyAbility(Abilities.MAGIC_BOUNCE);
+    game.override
+      .moveset([Moves.GROWL, Moves.ENCORE])
+      .enemyMoveset([Moves.MAGIC_COAT, Moves.TACKLE])
+      .enemyAbility(Abilities.MAGIC_BOUNCE);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
     const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -206,9 +204,8 @@ describe("Moves - Magic Coat", () => {
 
   // TODO: stomping tantrum should consider moves that were bounced.
   it.todo("should cause stomping tantrum to double in power when the last move was bounced", async () => {
-    game.override.battleStyle("single");
+    game.override.battleStyle("single").moveset([Moves.STOMPING_TANTRUM, Moves.CHARM]);
     await game.classicMode.startBattle([Species.MAGIKARP]);
-    game.override.moveset([Moves.STOMPING_TANTRUM, Moves.CHARM]);
 
     const stomping_tantrum = allMoves[Moves.STOMPING_TANTRUM];
     vi.spyOn(stomping_tantrum, "calculateBattlePower");
@@ -249,8 +246,7 @@ describe("Moves - Magic Coat", () => {
 
   it("should respect immunities when bouncing a move", async () => {
     vi.spyOn(allMoves[Moves.THUNDER_WAVE], "accuracy", "get").mockReturnValue(100);
-    game.override.moveset([Moves.THUNDER_WAVE, Moves.GROWL]);
-    game.override.ability(Abilities.SOUNDPROOF);
+    game.override.moveset([Moves.THUNDER_WAVE, Moves.GROWL]).ability(Abilities.SOUNDPROOF);
     await game.classicMode.startBattle([Species.PHANPY]);
 
     // Turn 1 - thunder wave immunity test

--- a/test/moves/make_it_rain.test.ts
+++ b/test/moves/make_it_rain.test.ts
@@ -24,13 +24,14 @@ describe("Moves - Make It Rain", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("double");
-    game.override.moveset([Moves.MAKE_IT_RAIN, Moves.SPLASH]);
-    game.override.enemySpecies(Species.SNORLAX);
-    game.override.enemyAbility(Abilities.INSOMNIA);
-    game.override.enemyMoveset(Moves.SPLASH);
-    game.override.startingLevel(100);
-    game.override.enemyLevel(100);
+    game.override
+      .battleStyle("double")
+      .moveset([Moves.MAKE_IT_RAIN, Moves.SPLASH])
+      .enemySpecies(Species.SNORLAX)
+      .enemyAbility(Abilities.INSOMNIA)
+      .enemyMoveset(Moves.SPLASH)
+      .startingLevel(100)
+      .enemyLevel(100);
   });
 
   it("should only lower SPATK stat stage by 1 once in a double battle", async () => {
@@ -47,8 +48,9 @@ describe("Moves - Make It Rain", () => {
   });
 
   it("should apply effects even if the target faints", async () => {
-    game.override.enemyLevel(1); // ensures the enemy will faint
-    game.override.battleStyle("single");
+    game.override
+      .enemyLevel(1) // ensures the enemy will faint
+      .battleStyle("single");
 
     await game.classicMode.startBattle([Species.CHARIZARD]);
 

--- a/test/moves/mat_block.test.ts
+++ b/test/moves/mat_block.test.ts
@@ -26,16 +26,14 @@ describe("Moves - Mat Block", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
 
-    game.override.battleStyle("double");
-
-    game.override.moveset([Moves.MAT_BLOCK, Moves.SPLASH]);
-
-    game.override.enemySpecies(Species.SNORLAX);
-    game.override.enemyMoveset([Moves.TACKLE]);
-    game.override.enemyAbility(Abilities.INSOMNIA);
-
-    game.override.startingLevel(100);
-    game.override.enemyLevel(100);
+    game.override
+      .battleStyle("double")
+      .moveset([Moves.MAT_BLOCK, Moves.SPLASH])
+      .enemySpecies(Species.SNORLAX)
+      .enemyMoveset([Moves.TACKLE])
+      .enemyAbility(Abilities.INSOMNIA)
+      .startingLevel(100)
+      .enemyLevel(100);
   });
 
   test("should protect the user and allies from attack moves", async () => {

--- a/test/moves/parting_shot.test.ts
+++ b/test/moves/parting_shot.test.ts
@@ -26,11 +26,12 @@ describe("Moves - Parting Shot", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-    game.override.moveset([Moves.PARTING_SHOT, Moves.SPLASH]);
-    game.override.enemyMoveset(Moves.SPLASH);
-    game.override.startingLevel(5);
-    game.override.enemyLevel(5);
+    game.override
+      .battleStyle("single")
+      .moveset([Moves.PARTING_SHOT, Moves.SPLASH])
+      .enemyMoveset(Moves.SPLASH)
+      .startingLevel(5)
+      .enemyLevel(5);
   });
 
   test("Parting Shot when buffed by prankster should fail against dark types", async () => {

--- a/test/moves/powder.test.ts
+++ b/test/moves/powder.test.ts
@@ -27,9 +27,8 @@ describe("Moves - Powder", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-
     game.override
+      .battleStyle("single")
       .enemySpecies(Species.SNORLAX)
       .enemyLevel(100)
       .enemyMoveset(Moves.EMBER)

--- a/test/moves/protect.test.ts
+++ b/test/moves/protect.test.ts
@@ -27,16 +27,14 @@ describe("Moves - Protect", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
 
-    game.override.battleStyle("single");
-
-    game.override.moveset([Moves.PROTECT]);
-    game.override.enemySpecies(Species.SNORLAX);
-
-    game.override.enemyAbility(Abilities.INSOMNIA);
-    game.override.enemyMoveset([Moves.TACKLE]);
-
-    game.override.startingLevel(100);
-    game.override.enemyLevel(100);
+    game.override
+      .battleStyle("single")
+      .moveset([Moves.PROTECT])
+      .enemySpecies(Species.SNORLAX)
+      .enemyAbility(Abilities.INSOMNIA)
+      .enemyMoveset([Moves.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
   });
 
   test("should protect the user from attacks", async () => {

--- a/test/moves/purify.test.ts
+++ b/test/moves/purify.test.ts
@@ -25,15 +25,14 @@ describe("Moves - Purify", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-
-    game.override.starterSpecies(Species.PYUKUMUKU);
-    game.override.startingLevel(10);
-    game.override.moveset([Moves.PURIFY, Moves.SIZZLY_SLIDE]);
-
-    game.override.enemySpecies(Species.MAGIKARP);
-    game.override.enemyLevel(10);
-    game.override.enemyMoveset([Moves.SPLASH, Moves.NONE, Moves.NONE, Moves.NONE]);
+    game.override
+      .battleStyle("single")
+      .starterSpecies(Species.PYUKUMUKU)
+      .startingLevel(10)
+      .moveset([Moves.PURIFY, Moves.SIZZLY_SLIDE])
+      .enemySpecies(Species.MAGIKARP)
+      .enemyLevel(10)
+      .enemyMoveset([Moves.SPLASH, Moves.NONE, Moves.NONE, Moves.NONE]);
   });
 
   test("Purify heals opponent status effect and restores user hp", async () => {

--- a/test/moves/quick_guard.test.ts
+++ b/test/moves/quick_guard.test.ts
@@ -25,16 +25,14 @@ describe("Moves - Quick Guard", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
 
-    game.override.battleStyle("double");
-
-    game.override.moveset([Moves.QUICK_GUARD, Moves.SPLASH, Moves.FOLLOW_ME]);
-
-    game.override.enemySpecies(Species.SNORLAX);
-    game.override.enemyMoveset([Moves.QUICK_ATTACK]);
-    game.override.enemyAbility(Abilities.INSOMNIA);
-
-    game.override.startingLevel(100);
-    game.override.enemyLevel(100);
+    game.override
+      .battleStyle("double")
+      .moveset([Moves.QUICK_GUARD, Moves.SPLASH, Moves.FOLLOW_ME])
+      .enemySpecies(Species.SNORLAX)
+      .enemyMoveset([Moves.QUICK_ATTACK])
+      .enemyAbility(Abilities.INSOMNIA)
+      .startingLevel(100)
+      .enemyLevel(100);
   });
 
   test("should protect the user and allies from priority moves", async () => {
@@ -51,8 +49,7 @@ describe("Moves - Quick Guard", () => {
   });
 
   test("should protect the user and allies from Prankster-boosted moves", async () => {
-    game.override.enemyAbility(Abilities.PRANKSTER);
-    game.override.enemyMoveset([Moves.GROWL]);
+    game.override.enemyAbility(Abilities.PRANKSTER).enemyMoveset([Moves.GROWL]);
 
     await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
 
@@ -84,8 +81,7 @@ describe("Moves - Quick Guard", () => {
   });
 
   test("should fail if the user is the last to move in the turn", async () => {
-    game.override.battleStyle("single");
-    game.override.enemyMoveset([Moves.QUICK_GUARD]);
+    game.override.battleStyle("single").enemyMoveset([Moves.QUICK_GUARD]);
 
     await game.classicMode.startBattle([Species.CHARIZARD]);
 

--- a/test/moves/rage_powder.test.ts
+++ b/test/moves/rage_powder.test.ts
@@ -22,12 +22,13 @@ describe("Moves - Rage Powder", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("double");
-    game.override.enemySpecies(Species.SNORLAX);
-    game.override.startingLevel(100);
-    game.override.enemyLevel(100);
-    game.override.moveset([Moves.FOLLOW_ME, Moves.RAGE_POWDER, Moves.SPOTLIGHT, Moves.QUICK_ATTACK]);
-    game.override.enemyMoveset([Moves.RAGE_POWDER, Moves.TACKLE, Moves.SPLASH]);
+    game.override
+      .battleStyle("double")
+      .enemySpecies(Species.SNORLAX)
+      .startingLevel(100)
+      .enemyLevel(100)
+      .moveset([Moves.FOLLOW_ME, Moves.RAGE_POWDER, Moves.SPOTLIGHT, Moves.QUICK_ATTACK])
+      .enemyMoveset([Moves.RAGE_POWDER, Moves.TACKLE, Moves.SPLASH]);
   });
 
   test("move effect should be bypassed by Grass type", async () => {

--- a/test/moves/rollout.test.ts
+++ b/test/moves/rollout.test.ts
@@ -23,18 +23,19 @@ describe("Moves - Rollout", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.disableCrits();
-    game.override.battleStyle("single");
-    game.override.starterSpecies(Species.RATTATA);
-    game.override.ability(Abilities.BALL_FETCH);
-    game.override.enemySpecies(Species.BIDOOF);
-    game.override.enemyAbility(Abilities.BALL_FETCH);
-    game.override.startingLevel(100);
-    game.override.enemyLevel(100);
-    game.override.enemyMoveset(Moves.SPLASH);
+    game.override
+      .disableCrits()
+      .battleStyle("single")
+      .starterSpecies(Species.RATTATA)
+      .ability(Abilities.BALL_FETCH)
+      .enemySpecies(Species.BIDOOF)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .startingLevel(100)
+      .enemyLevel(100)
+      .enemyMoveset(Moves.SPLASH);
   });
 
-  it("should double it's dmg on sequential uses but reset after 5", async () => {
+  it("should double its dmg on sequential uses but reset after 5", async () => {
     game.override.moveset([Moves.ROLLOUT]);
     vi.spyOn(allMoves[Moves.ROLLOUT], "accuracy", "get").mockReturnValue(100); //always hit
 

--- a/test/moves/roost.test.ts
+++ b/test/moves/roost.test.ts
@@ -25,12 +25,13 @@ describe("Moves - Roost", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-    game.override.enemySpecies(Species.RELICANTH);
-    game.override.startingLevel(100);
-    game.override.enemyLevel(100);
-    game.override.enemyMoveset(Moves.EARTHQUAKE);
-    game.override.moveset([Moves.ROOST, Moves.BURN_UP, Moves.DOUBLE_SHOCK]);
+    game.override
+      .battleStyle("single")
+      .enemySpecies(Species.RELICANTH)
+      .startingLevel(100)
+      .enemyLevel(100)
+      .enemyMoveset(Moves.EARTHQUAKE)
+      .moveset([Moves.ROOST, Moves.BURN_UP, Moves.DOUBLE_SHOCK]);
   });
 
   /**

--- a/test/moves/spikes.test.ts
+++ b/test/moves/spikes.test.ts
@@ -80,9 +80,7 @@ describe("Moves - Spikes", () => {
   }, 20000);
 
   it("should work when all targets fainted", async () => {
-    game.override.enemySpecies(Species.DIGLETT);
-    game.override.battleStyle("double");
-    game.override.startingLevel(50);
+    game.override.enemySpecies(Species.DIGLETT).battleStyle("double").startingLevel(50);
     await game.classicMode.startBattle([Species.RAYQUAZA, Species.ROWLET]);
 
     game.move.select(Moves.EARTHQUAKE);

--- a/test/moves/spit_up.test.ts
+++ b/test/moves/spit_up.test.ts
@@ -32,15 +32,14 @@ describe("Moves - Spit Up", () => {
     spitUp = allMoves[Moves.SPIT_UP];
     game = new GameManager(phaserGame);
 
-    game.override.battleStyle("single");
-
-    game.override.enemySpecies(Species.RATTATA);
-    game.override.enemyMoveset(Moves.SPLASH);
-    game.override.enemyAbility(Abilities.NONE);
-    game.override.enemyLevel(2000);
-
-    game.override.moveset(new Array(4).fill(spitUp.id));
-    game.override.ability(Abilities.NONE);
+    game.override
+      .battleStyle("single")
+      .enemySpecies(Species.RATTATA)
+      .enemyMoveset(Moves.SPLASH)
+      .enemyAbility(Abilities.NONE)
+      .enemyLevel(2000)
+      .moveset(Moves.SPIT_UP)
+      .ability(Abilities.NONE);
 
     vi.spyOn(spitUp, "calculateBattlePower");
   });

--- a/test/moves/spotlight.test.ts
+++ b/test/moves/spotlight.test.ts
@@ -22,13 +22,14 @@ describe("Moves - Spotlight", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("double");
-    game.override.starterSpecies(Species.AMOONGUSS);
-    game.override.enemySpecies(Species.SNORLAX);
-    game.override.startingLevel(100);
-    game.override.enemyLevel(100);
-    game.override.moveset([Moves.FOLLOW_ME, Moves.RAGE_POWDER, Moves.SPOTLIGHT, Moves.QUICK_ATTACK]);
-    game.override.enemyMoveset([Moves.FOLLOW_ME, Moves.SPLASH]);
+    game.override
+      .battleStyle("double")
+      .starterSpecies(Species.AMOONGUSS)
+      .enemySpecies(Species.SNORLAX)
+      .startingLevel(100)
+      .enemyLevel(100)
+      .moveset([Moves.FOLLOW_ME, Moves.RAGE_POWDER, Moves.SPOTLIGHT, Moves.QUICK_ATTACK])
+      .enemyMoveset([Moves.FOLLOW_ME, Moves.SPLASH]);
   });
 
   test("move should redirect attacks to the target", async () => {

--- a/test/moves/stockpile.test.ts
+++ b/test/moves/stockpile.test.ts
@@ -27,15 +27,14 @@ describe("Moves - Stockpile", () => {
     beforeEach(() => {
       game = new GameManager(phaserGame);
 
-      game.override.battleStyle("single");
-
-      game.override.enemySpecies(Species.RATTATA);
-      game.override.enemyMoveset(Moves.SPLASH);
-      game.override.enemyAbility(Abilities.NONE);
-
-      game.override.startingLevel(2000);
-      game.override.moveset([Moves.STOCKPILE, Moves.SPLASH]);
-      game.override.ability(Abilities.NONE);
+      game.override
+        .battleStyle("single")
+        .enemySpecies(Species.RATTATA)
+        .enemyMoveset(Moves.SPLASH)
+        .enemyAbility(Abilities.NONE)
+        .startingLevel(2000)
+        .moveset([Moves.STOCKPILE, Moves.SPLASH])
+        .ability(Abilities.NONE);
     });
 
     it("gains a stockpile stack and raises user's DEF and SPDEF stat stages by 1 on each use, fails at max stacks (3)", async () => {

--- a/test/moves/substitute.test.ts
+++ b/test/moves/substitute.test.ts
@@ -138,8 +138,7 @@ describe("Moves - Substitute", () => {
   });
 
   it("should be bypassed by attackers with Infiltrator", async () => {
-    game.override.enemyMoveset(Moves.TACKLE);
-    game.override.enemyAbility(Abilities.INFILTRATOR);
+    game.override.enemyMoveset(Moves.TACKLE).enemyAbility(Abilities.INFILTRATOR);
 
     await game.classicMode.startBattle([Species.BLASTOISE]);
 
@@ -230,8 +229,7 @@ describe("Moves - Substitute", () => {
   });
 
   it("should protect the user from flinching", async () => {
-    game.override.enemyMoveset(Moves.FAKE_OUT);
-    game.override.startingLevel(1); // Ensures the Substitute will break
+    game.override.enemyMoveset(Moves.FAKE_OUT).startingLevel(1); // Ensures the Substitute will break
 
     await game.classicMode.startBattle([Species.BLASTOISE]);
 
@@ -298,9 +296,8 @@ describe("Moves - Substitute", () => {
   });
 
   it("should prevent the user's items from being stolen", async () => {
-    game.override.enemyMoveset(Moves.THIEF);
+    game.override.enemyMoveset(Moves.THIEF).startingHeldItems([{ name: "BERRY", type: BerryType.SITRUS }]);
     vi.spyOn(allMoves[Moves.THIEF], "attrs", "get").mockReturnValue([new StealHeldItemChanceAttr(1.0)]); // give Thief 100% steal rate
-    game.override.startingHeldItems([{ name: "BERRY", type: BerryType.SITRUS }]);
 
     await game.classicMode.startBattle([Species.BLASTOISE]);
 
@@ -316,8 +313,7 @@ describe("Moves - Substitute", () => {
   });
 
   it("should prevent the user's items from being removed", async () => {
-    game.override.moveset([Moves.KNOCK_OFF]);
-    game.override.enemyHeldItems([{ name: "BERRY", type: BerryType.SITRUS }]);
+    game.override.moveset([Moves.KNOCK_OFF]).enemyHeldItems([{ name: "BERRY", type: BerryType.SITRUS }]);
 
     await game.classicMode.startBattle([Species.BLASTOISE]);
 
@@ -334,8 +330,7 @@ describe("Moves - Substitute", () => {
   });
 
   it("move effect should prevent the user's berries from being stolen and eaten", async () => {
-    game.override.enemyMoveset(Moves.BUG_BITE);
-    game.override.startingHeldItems([{ name: "BERRY", type: BerryType.SITRUS }]);
+    game.override.enemyMoveset(Moves.BUG_BITE).startingHeldItems([{ name: "BERRY", type: BerryType.SITRUS }]);
 
     await game.classicMode.startBattle([Species.BLASTOISE]);
 
@@ -412,8 +407,7 @@ describe("Moves - Substitute", () => {
   });
 
   it("should prevent the source's Rough Skin from activating when hit", async () => {
-    game.override.enemyMoveset(Moves.TACKLE);
-    game.override.ability(Abilities.ROUGH_SKIN);
+    game.override.enemyMoveset(Moves.TACKLE).ability(Abilities.ROUGH_SKIN);
 
     await game.classicMode.startBattle([Species.BLASTOISE]);
 
@@ -427,8 +421,7 @@ describe("Moves - Substitute", () => {
   });
 
   it("should prevent the source's Focus Punch from failing when hit", async () => {
-    game.override.enemyMoveset(Moves.TACKLE);
-    game.override.moveset([Moves.FOCUS_PUNCH]);
+    game.override.enemyMoveset(Moves.TACKLE).moveset([Moves.FOCUS_PUNCH]);
 
     // Make Focus Punch 40 power to avoid a KO
     vi.spyOn(allMoves[Moves.FOCUS_PUNCH], "calculateBattlePower").mockReturnValue(40);
@@ -449,8 +442,7 @@ describe("Moves - Substitute", () => {
   });
 
   it("should not allow Shell Trap to activate when attacked", async () => {
-    game.override.enemyMoveset(Moves.TACKLE);
-    game.override.moveset([Moves.SHELL_TRAP]);
+    game.override.enemyMoveset(Moves.TACKLE).moveset([Moves.SHELL_TRAP]);
 
     await game.classicMode.startBattle([Species.BLASTOISE]);
 
@@ -466,8 +458,7 @@ describe("Moves - Substitute", () => {
   });
 
   it("should not allow Beak Blast to burn opponents when hit", async () => {
-    game.override.enemyMoveset(Moves.TACKLE);
-    game.override.moveset([Moves.BEAK_BLAST]);
+    game.override.enemyMoveset(Moves.TACKLE).moveset([Moves.BEAK_BLAST]);
 
     await game.classicMode.startBattle([Species.BLASTOISE]);
 
@@ -484,8 +475,7 @@ describe("Moves - Substitute", () => {
   });
 
   it("should cause incoming attacks to not activate Counter", async () => {
-    game.override.enemyMoveset(Moves.TACKLE);
-    game.override.moveset([Moves.COUNTER]);
+    game.override.enemyMoveset(Moves.TACKLE).moveset([Moves.COUNTER]);
 
     await game.classicMode.startBattle([Species.BLASTOISE]);
 

--- a/test/moves/tackle.test.ts
+++ b/test/moves/tackle.test.ts
@@ -37,6 +37,7 @@ describe("Moves - Tackle", () => {
   it("TACKLE against ghost", async () => {
     const moveToUse = Moves.TACKLE;
     game.override.enemySpecies(Species.GENGAR);
+
     await game.classicMode.startBattle([Species.MIGHTYENA]);
     const hpOpponent = game.scene.currentBattle.enemyParty[0].hp;
     game.move.select(moveToUse);

--- a/test/moves/tail_whip.test.ts
+++ b/test/moves/tail_whip.test.ts
@@ -25,13 +25,14 @@ describe("Moves - Tail whip", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     const moveToUse = Moves.TAIL_WHIP;
-    game.override.battleStyle("single");
-    game.override.enemySpecies(Species.RATTATA);
-    game.override.enemyAbility(Abilities.INSOMNIA);
-    game.override.ability(Abilities.INSOMNIA);
-    game.override.startingLevel(2000);
-    game.override.moveset([moveToUse]);
-    game.override.enemyMoveset(Moves.SPLASH);
+    game.override
+      .battleStyle("single")
+      .enemySpecies(Species.RATTATA)
+      .enemyAbility(Abilities.INSOMNIA)
+      .ability(Abilities.INSOMNIA)
+      .startingLevel(2000)
+      .moveset([moveToUse])
+      .enemyMoveset(Moves.SPLASH);
   });
 
   it("should lower DEF stat stage by 1", async () => {

--- a/test/moves/thousand_arrows.test.ts
+++ b/test/moves/thousand_arrows.test.ts
@@ -24,12 +24,13 @@ describe("Moves - Thousand Arrows", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-    game.override.enemySpecies(Species.TOGETIC);
-    game.override.startingLevel(100);
-    game.override.enemyLevel(100);
-    game.override.moveset([Moves.THOUSAND_ARROWS]);
-    game.override.enemyMoveset([Moves.SPLASH, Moves.SPLASH, Moves.SPLASH, Moves.SPLASH]);
+    game.override
+      .battleStyle("single")
+      .enemySpecies(Species.TOGETIC)
+      .startingLevel(100)
+      .enemyLevel(100)
+      .moveset([Moves.THOUSAND_ARROWS])
+      .enemyMoveset(Moves.SPLASH);
   });
 
   it("move should hit and ground Flying-type targets", async () => {
@@ -50,8 +51,7 @@ describe("Moves - Thousand Arrows", () => {
   });
 
   it("move should hit and ground targets with Levitate", async () => {
-    game.override.enemySpecies(Species.SNORLAX);
-    game.override.enemyAbility(Abilities.LEVITATE);
+    game.override.enemySpecies(Species.SNORLAX).enemyAbility(Abilities.LEVITATE);
 
     await game.classicMode.startBattle([Species.ILLUMISE]);
 

--- a/test/moves/tidy_up.test.ts
+++ b/test/moves/tidy_up.test.ts
@@ -26,14 +26,15 @@ describe("Moves - Tidy Up", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-    game.override.enemySpecies(Species.MAGIKARP);
-    game.override.enemyAbility(Abilities.BALL_FETCH);
-    game.override.enemyMoveset(Moves.SPLASH);
-    game.override.starterSpecies(Species.FEEBAS);
-    game.override.ability(Abilities.BALL_FETCH);
-    game.override.moveset([Moves.TIDY_UP]);
-    game.override.startingLevel(50);
+    game.override
+      .battleStyle("single")
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH)
+      .starterSpecies(Species.FEEBAS)
+      .ability(Abilities.BALL_FETCH)
+      .moveset([Moves.TIDY_UP])
+      .startingLevel(50);
   });
 
   it("spikes are cleared", async () => {

--- a/test/moves/toxic.test.ts
+++ b/test/moves/toxic.test.ts
@@ -71,8 +71,7 @@ describe("Moves - Toxic", () => {
   });
 
   it("moves other than Toxic should not hit semi-invulnerable targets even if user is Poison-type", async () => {
-    game.override.moveset(Moves.SWIFT);
-    game.override.enemyMoveset(Moves.FLY);
+    game.override.moveset(Moves.SWIFT).enemyMoveset(Moves.FLY);
     await game.classicMode.startBattle([Species.TOXAPEX]);
 
     game.move.select(Moves.SWIFT);

--- a/test/moves/transform.test.ts
+++ b/test/moves/transform.test.ts
@@ -154,8 +154,7 @@ describe("Moves - Transform", () => {
   });
 
   it("should stay transformed with the correct form after reload", async () => {
-    game.override.enemyMoveset([]).moveset([]);
-    game.override.enemySpecies(Species.DARMANITAN);
+    game.override.enemyMoveset([]).moveset([]).enemySpecies(Species.DARMANITAN);
 
     await game.classicMode.startBattle([Species.DITTO]);
 

--- a/test/moves/wide_guard.test.ts
+++ b/test/moves/wide_guard.test.ts
@@ -25,16 +25,14 @@ describe("Moves - Wide Guard", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
 
-    game.override.battleStyle("double");
-
-    game.override.moveset([Moves.WIDE_GUARD, Moves.SPLASH, Moves.SURF]);
-
-    game.override.enemySpecies(Species.SNORLAX);
-    game.override.enemyMoveset([Moves.SWIFT]);
-    game.override.enemyAbility(Abilities.INSOMNIA);
-
-    game.override.startingLevel(100);
-    game.override.enemyLevel(100);
+    game.override
+      .battleStyle("double")
+      .moveset([Moves.WIDE_GUARD, Moves.SPLASH, Moves.SURF])
+      .enemySpecies(Species.SNORLAX)
+      .enemyMoveset(Moves.SWIFT)
+      .enemyAbility(Abilities.INSOMNIA)
+      .startingLevel(100)
+      .enemyLevel(100);
   });
 
   test("should protect the user and allies from multi-target attack moves", async () => {

--- a/test/mystery-encounter/encounters/a-trainers-test-encounter.test.ts
+++ b/test/mystery-encounter/encounters/a-trainers-test-encounter.test.ts
@@ -38,10 +38,11 @@ describe("A Trainer's Test - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves();
 
     const biomeMap = new Map<Biome, MysteryEncounterType[]>([
       [Biome.VOLCANO, [MysteryEncounterType.MYSTERIOUS_CHALLENGERS]],

--- a/test/mystery-encounter/encounters/absolute-avarice-encounter.test.ts
+++ b/test/mystery-encounter/encounters/absolute-avarice-encounter.test.ts
@@ -38,10 +38,11 @@ describe("Absolute Avarice - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves();
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<Biome, MysteryEncounterType[]>([
@@ -71,8 +72,7 @@ describe("Absolute Avarice - Mystery Encounter", () => {
   });
 
   it("should not spawn outside of proper biomes", async () => {
-    game.override.mysteryEncounterTier(MysteryEncounterTier.GREAT);
-    game.override.startingBiome(Biome.VOLCANO);
+    game.override.mysteryEncounterTier(MysteryEncounterTier.GREAT).startingBiome(Biome.VOLCANO);
     await game.runToMysteryEncounter();
 
     expect(game.scene.currentBattle.mysteryEncounter?.encounterType).not.toBe(MysteryEncounterType.ABSOLUTE_AVARICE);
@@ -87,8 +87,7 @@ describe("Absolute Avarice - Mystery Encounter", () => {
   });
 
   it("should spawn if player has enough berries", async () => {
-    game.override.mysteryEncounterTier(MysteryEncounterTier.GREAT);
-    game.override.startingHeldItems([
+    game.override.mysteryEncounterTier(MysteryEncounterTier.GREAT).startingHeldItems([
       { name: "BERRY", count: 2, type: BerryType.SITRUS },
       { name: "BERRY", count: 3, type: BerryType.GANLON },
       { name: "BERRY", count: 2, type: BerryType.APICOT },

--- a/test/mystery-encounter/encounters/an-offer-you-cant-refuse-encounter.test.ts
+++ b/test/mystery-encounter/encounters/an-offer-you-cant-refuse-encounter.test.ts
@@ -79,8 +79,7 @@ describe("An Offer You Can't Refuse - Mystery Encounter", () => {
   });
 
   it("should not spawn outside of HUMAN_TRANSITABLE_BIOMES", async () => {
-    game.override.mysteryEncounterTier(MysteryEncounterTier.GREAT);
-    game.override.startingBiome(Biome.VOLCANO);
+    game.override.mysteryEncounterTier(MysteryEncounterTier.GREAT).startingBiome(Biome.VOLCANO);
     await game.runToMysteryEncounter();
 
     expect(scene.currentBattle?.mysteryEncounter?.encounterType).not.toBe(

--- a/test/mystery-encounter/encounters/bug-type-superfan-encounter.test.ts
+++ b/test/mystery-encounter/encounters/bug-type-superfan-encounter.test.ts
@@ -116,20 +116,14 @@ const POOL_3_POKEMON: { species: Species; formIndex?: number }[] = [
 
 const POOL_4_POKEMON = [Species.GENESECT, Species.SLITHER_WING, Species.BUZZWOLE, Species.PHEROMOSA];
 
-const PHYSICAL_TUTOR_MOVES = [
-  Moves.MEGAHORN,
-  Moves.ATTACK_ORDER,
-  Moves.BUG_BITE,
-  Moves.FIRST_IMPRESSION,
-  Moves.LUNGE
-];
+const PHYSICAL_TUTOR_MOVES = [Moves.MEGAHORN, Moves.ATTACK_ORDER, Moves.BUG_BITE, Moves.FIRST_IMPRESSION, Moves.LUNGE];
 
 const SPECIAL_TUTOR_MOVES = [
   Moves.SILVER_WIND,
   Moves.SIGNAL_BEAM,
   Moves.BUG_BUZZ,
   Moves.POLLEN_PUFF,
-  Moves.STRUGGLE_BUG
+  Moves.STRUGGLE_BUG,
 ];
 
 const STATUS_TUTOR_MOVES = [
@@ -137,16 +131,10 @@ const STATUS_TUTOR_MOVES = [
   Moves.DEFEND_ORDER,
   Moves.RAGE_POWDER,
   Moves.STICKY_WEB,
-  Moves.SILK_TRAP
+  Moves.SILK_TRAP,
 ];
 
-const MISC_TUTOR_MOVES = [
-  Moves.LEECH_LIFE,
-  Moves.U_TURN,
-  Moves.HEAL_ORDER,
-  Moves.QUIVER_DANCE,
-  Moves.INFESTATION,
-];
+const MISC_TUTOR_MOVES = [Moves.LEECH_LIFE, Moves.U_TURN, Moves.HEAL_ORDER, Moves.QUIVER_DANCE, Moves.INFESTATION];
 
 describe("Bug-Type Superfan - Mystery Encounter", () => {
   let phaserGame: Phaser.Game;
@@ -160,10 +148,11 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves();
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<Biome, MysteryEncounterType[]>([[Biome.CAVE, [MysteryEncounterType.BUG_TYPE_SUPERFAN]]]),

--- a/test/mystery-encounter/encounters/clowning-around-encounter.test.ts
+++ b/test/mystery-encounter/encounters/clowning-around-encounter.test.ts
@@ -55,10 +55,11 @@ describe("Clowning Around - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves();
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<Biome, MysteryEncounterType[]>([[Biome.CAVE, [MysteryEncounterType.CLOWNING_AROUND]]]),

--- a/test/mystery-encounter/encounters/dancing-lessons-encounter.test.ts
+++ b/test/mystery-encounter/encounters/dancing-lessons-encounter.test.ts
@@ -41,10 +41,11 @@ describe("Dancing Lessons - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves();
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<Biome, MysteryEncounterType[]>([
@@ -74,8 +75,7 @@ describe("Dancing Lessons - Mystery Encounter", () => {
   });
 
   it("should not spawn outside of proper biomes", async () => {
-    game.override.mysteryEncounterTier(MysteryEncounterTier.GREAT);
-    game.override.startingBiome(Biome.SPACE);
+    game.override.mysteryEncounterTier(MysteryEncounterTier.GREAT).startingBiome(Biome.SPACE);
     await game.runToMysteryEncounter();
 
     expect(game.scene.currentBattle.mysteryEncounter?.encounterType).not.toBe(MysteryEncounterType.DANCING_LESSONS);

--- a/test/mystery-encounter/encounters/delibirdy-encounter.test.ts
+++ b/test/mystery-encounter/encounters/delibirdy-encounter.test.ts
@@ -46,10 +46,11 @@ describe("Delibird-y - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves();
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<Biome, MysteryEncounterType[]>([[Biome.CAVE, [MysteryEncounterType.DELIBIRDY]]]),

--- a/test/mystery-encounter/encounters/department-store-sale-encounter.test.ts
+++ b/test/mystery-encounter/encounters/department-store-sale-encounter.test.ts
@@ -32,10 +32,11 @@ describe("Department Store Sale - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves();
 
     const biomeMap = new Map<Biome, MysteryEncounterType[]>([
       [Biome.VOLCANO, [MysteryEncounterType.MYSTERIOUS_CHALLENGERS]],
@@ -74,8 +75,7 @@ describe("Department Store Sale - Mystery Encounter", () => {
   });
 
   it("should not spawn outside of CIVILIZATION_ENCOUNTER_BIOMES", async () => {
-    game.override.mysteryEncounterTier(MysteryEncounterTier.COMMON);
-    game.override.startingBiome(Biome.VOLCANO);
+    game.override.mysteryEncounterTier(MysteryEncounterTier.COMMON).startingBiome(Biome.VOLCANO);
     await game.runToMysteryEncounter();
 
     expect(scene.currentBattle?.mysteryEncounter?.encounterType).not.toBe(MysteryEncounterType.DEPARTMENT_STORE_SALE);

--- a/test/mystery-encounter/encounters/field-trip-encounter.test.ts
+++ b/test/mystery-encounter/encounters/field-trip-encounter.test.ts
@@ -33,11 +33,12 @@ describe("Field Trip - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
-    game.override.moveset([Moves.TACKLE, Moves.UPROAR, Moves.SWORDS_DANCE]);
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves()
+      .moveset([Moves.TACKLE, Moves.UPROAR, Moves.SWORDS_DANCE]);
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<Biome, MysteryEncounterType[]>([[Biome.CAVE, [MysteryEncounterType.FIELD_TRIP]]]),

--- a/test/mystery-encounter/encounters/fight-or-flight-encounter.test.ts
+++ b/test/mystery-encounter/encounters/fight-or-flight-encounter.test.ts
@@ -40,10 +40,11 @@ describe("Fight or Flight - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves();
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<Biome, MysteryEncounterType[]>([[Biome.CAVE, [MysteryEncounterType.FIGHT_OR_FLIGHT]]]),

--- a/test/mystery-encounter/encounters/fun-and-games-encounter.test.ts
+++ b/test/mystery-encounter/encounters/fun-and-games-encounter.test.ts
@@ -42,10 +42,11 @@ describe("Fun And Games! - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves();
 
     const biomeMap = new Map<Biome, MysteryEncounterType[]>([[Biome.VOLCANO, [MysteryEncounterType.FIGHT_OR_FLIGHT]]]);
     HUMAN_TRANSITABLE_BIOMES.forEach(biome => {
@@ -79,8 +80,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
   });
 
   it("should not spawn outside of CIVILIZATIONN biomes", async () => {
-    game.override.mysteryEncounterTier(MysteryEncounterTier.GREAT);
-    game.override.startingBiome(Biome.VOLCANO);
+    game.override.mysteryEncounterTier(MysteryEncounterTier.GREAT).startingBiome(Biome.VOLCANO);
     await game.runToMysteryEncounter();
 
     expect(scene.currentBattle?.mysteryEncounter?.encounterType).not.toBe(MysteryEncounterType.FUN_AND_GAMES);

--- a/test/mystery-encounter/encounters/global-trade-system-encounter.test.ts
+++ b/test/mystery-encounter/encounters/global-trade-system-encounter.test.ts
@@ -37,10 +37,11 @@ describe("Global Trade System - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves();
 
     const biomeMap = new Map<Biome, MysteryEncounterType[]>([
       [Biome.VOLCANO, [MysteryEncounterType.MYSTERIOUS_CHALLENGERS]],
@@ -85,8 +86,7 @@ describe("Global Trade System - Mystery Encounter", () => {
   });
 
   it("should not spawn outside of CIVILIZATION_ENCOUNTER_BIOMES", async () => {
-    game.override.mysteryEncounterTier(MysteryEncounterTier.COMMON);
-    game.override.startingBiome(Biome.VOLCANO);
+    game.override.mysteryEncounterTier(MysteryEncounterTier.COMMON).startingBiome(Biome.VOLCANO);
     await game.runToMysteryEncounter();
 
     expect(scene.currentBattle?.mysteryEncounter?.encounterType).not.toBe(MysteryEncounterType.GLOBAL_TRADE_SYSTEM);

--- a/test/mystery-encounter/encounters/lost-at-sea-encounter.test.ts
+++ b/test/mystery-encounter/encounters/lost-at-sea-encounter.test.ts
@@ -34,10 +34,11 @@ describe("Lost at Sea - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves();
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<Biome, MysteryEncounterType[]>([
@@ -67,8 +68,7 @@ describe("Lost at Sea - Mystery Encounter", () => {
   });
 
   it("should not spawn outside of sea biome", async () => {
-    game.override.mysteryEncounterTier(MysteryEncounterTier.COMMON);
-    game.override.startingBiome(Biome.MOUNTAIN);
+    game.override.mysteryEncounterTier(MysteryEncounterTier.COMMON).startingBiome(Biome.MOUNTAIN);
     await game.runToMysteryEncounter();
 
     expect(game.scene.currentBattle.mysteryEncounter?.encounterType).not.toBe(MysteryEncounterType.LOST_AT_SEA);

--- a/test/mystery-encounter/encounters/mysterious-challengers-encounter.test.ts
+++ b/test/mystery-encounter/encounters/mysterious-challengers-encounter.test.ts
@@ -43,10 +43,11 @@ describe("Mysterious Challengers - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves();
 
     const biomeMap = new Map<Biome, MysteryEncounterType[]>([[Biome.VOLCANO, [MysteryEncounterType.FIGHT_OR_FLIGHT]]]);
     HUMAN_TRANSITABLE_BIOMES.forEach(biome => {
@@ -77,8 +78,7 @@ describe("Mysterious Challengers - Mystery Encounter", () => {
   });
 
   it("should not spawn outside of HUMAN_TRANSITABLE_BIOMES", async () => {
-    game.override.mysteryEncounterTier(MysteryEncounterTier.GREAT);
-    game.override.startingBiome(Biome.VOLCANO);
+    game.override.mysteryEncounterTier(MysteryEncounterTier.GREAT).startingBiome(Biome.VOLCANO);
     await game.runToMysteryEncounter();
 
     expect(scene.currentBattle?.mysteryEncounter?.encounterType).not.toBe(MysteryEncounterType.MYSTERIOUS_CHALLENGERS);

--- a/test/mystery-encounter/encounters/part-timer-encounter.test.ts
+++ b/test/mystery-encounter/encounters/part-timer-encounter.test.ts
@@ -36,10 +36,11 @@ describe("Part-Timer - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves();
 
     const biomeMap = new Map<Biome, MysteryEncounterType[]>([
       [Biome.VOLCANO, [MysteryEncounterType.MYSTERIOUS_CHALLENGERS]],
@@ -76,8 +77,7 @@ describe("Part-Timer - Mystery Encounter", () => {
   });
 
   it("should not spawn outside of CIVILIZATION_ENCOUNTER_BIOMES", async () => {
-    game.override.mysteryEncounterTier(MysteryEncounterTier.COMMON);
-    game.override.startingBiome(Biome.VOLCANO);
+    game.override.mysteryEncounterTier(MysteryEncounterTier.COMMON).startingBiome(Biome.VOLCANO);
     await game.runToMysteryEncounter();
 
     expect(scene.currentBattle?.mysteryEncounter?.encounterType).not.toBe(MysteryEncounterType.PART_TIMER);

--- a/test/mystery-encounter/encounters/safari-zone.test.ts
+++ b/test/mystery-encounter/encounters/safari-zone.test.ts
@@ -38,10 +38,11 @@ describe("Safari Zone - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves();
 
     const biomeMap = new Map<Biome, MysteryEncounterType[]>([
       [Biome.VOLCANO, [MysteryEncounterType.FIGHT_OR_FLIGHT]],
@@ -72,8 +73,7 @@ describe("Safari Zone - Mystery Encounter", () => {
   });
 
   it("should not spawn outside of the forest, swamp, or jungle biomes", async () => {
-    game.override.mysteryEncounterTier(MysteryEncounterTier.GREAT);
-    game.override.startingBiome(Biome.VOLCANO);
+    game.override.mysteryEncounterTier(MysteryEncounterTier.GREAT).startingBiome(Biome.VOLCANO);
     await game.runToMysteryEncounter();
 
     expect(scene.currentBattle?.mysteryEncounter?.encounterType).not.toBe(MysteryEncounterType.SAFARI_ZONE);

--- a/test/mystery-encounter/encounters/teleporting-hijinks-encounter.test.ts
+++ b/test/mystery-encounter/encounters/teleporting-hijinks-encounter.test.ts
@@ -75,8 +75,7 @@ describe("Teleporting Hijinks - Mystery Encounter", () => {
   });
 
   it("should run in waves that are X1", async () => {
-    game.override.startingWave(11);
-    game.override.mysteryEncounterTier(MysteryEncounterTier.COMMON);
+    game.override.startingWave(11).mysteryEncounterTier(MysteryEncounterTier.COMMON);
 
     await game.runToMysteryEncounter();
 
@@ -84,8 +83,7 @@ describe("Teleporting Hijinks - Mystery Encounter", () => {
   });
 
   it("should run in waves that are X2", async () => {
-    game.override.startingWave(32);
-    game.override.mysteryEncounterTier(MysteryEncounterTier.COMMON);
+    game.override.startingWave(32).mysteryEncounterTier(MysteryEncounterTier.COMMON);
 
     await game.runToMysteryEncounter();
 
@@ -93,8 +91,7 @@ describe("Teleporting Hijinks - Mystery Encounter", () => {
   });
 
   it("should run in waves that are X3", async () => {
-    game.override.startingWave(23);
-    game.override.mysteryEncounterTier(MysteryEncounterTier.COMMON);
+    game.override.startingWave(23).mysteryEncounterTier(MysteryEncounterTier.COMMON);
 
     await game.runToMysteryEncounter();
 

--- a/test/mystery-encounter/encounters/the-expert-breeder-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-expert-breeder-encounter.test.ts
@@ -40,10 +40,11 @@ describe("The Expert Pokémon Breeder - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves();
 
     const biomeMap = new Map<Biome, MysteryEncounterType[]>([[Biome.VOLCANO, [MysteryEncounterType.FIGHT_OR_FLIGHT]]]);
     HUMAN_TRANSITABLE_BIOMES.forEach(biome => {
@@ -82,8 +83,7 @@ describe("The Expert Pokémon Breeder - Mystery Encounter", () => {
   });
 
   it("should not spawn outside of HUMAN_TRANSITABLE_BIOMES", async () => {
-    game.override.mysteryEncounterTier(MysteryEncounterTier.GREAT);
-    game.override.startingBiome(Biome.VOLCANO);
+    game.override.mysteryEncounterTier(MysteryEncounterTier.GREAT).startingBiome(Biome.VOLCANO);
     await game.runToMysteryEncounter();
 
     expect(scene.currentBattle?.mysteryEncounter?.encounterType).not.toBe(

--- a/test/mystery-encounter/encounters/the-pokemon-salesman-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-pokemon-salesman-encounter.test.ts
@@ -39,10 +39,11 @@ describe("The Pokemon Salesman - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves();
 
     const biomeMap = new Map<Biome, MysteryEncounterType[]>([
       [Biome.VOLCANO, [MysteryEncounterType.MYSTERIOUS_CHALLENGERS]],
@@ -79,8 +80,7 @@ describe("The Pokemon Salesman - Mystery Encounter", () => {
   });
 
   it("should not spawn outside of HUMAN_TRANSITABLE_BIOMES", async () => {
-    game.override.mysteryEncounterTier(MysteryEncounterTier.ULTRA);
-    game.override.startingBiome(Biome.VOLCANO);
+    game.override.mysteryEncounterTier(MysteryEncounterTier.ULTRA).startingBiome(Biome.VOLCANO);
     await game.runToMysteryEncounter();
 
     expect(scene.currentBattle?.mysteryEncounter?.encounterType).not.toBe(MysteryEncounterType.THE_POKEMON_SALESMAN);

--- a/test/mystery-encounter/encounters/the-strong-stuff-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-strong-stuff-encounter.test.ts
@@ -83,8 +83,7 @@ describe("The Strong Stuff - Mystery Encounter", () => {
   });
 
   it("should not spawn outside of CAVE biome", async () => {
-    game.override.mysteryEncounterTier(MysteryEncounterTier.COMMON);
-    game.override.startingBiome(Biome.MOUNTAIN);
+    game.override.mysteryEncounterTier(MysteryEncounterTier.COMMON).startingBiome(Biome.MOUNTAIN);
     await game.runToMysteryEncounter();
 
     expect(scene.currentBattle?.mysteryEncounter?.encounterType).not.toBe(MysteryEncounterType.THE_STRONG_STUFF);

--- a/test/mystery-encounter/encounters/the-winstrate-challenge-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-winstrate-challenge-encounter.test.ts
@@ -44,10 +44,11 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves();
 
     const biomeMap = new Map<Biome, MysteryEncounterType[]>([[Biome.VOLCANO, [MysteryEncounterType.FIGHT_OR_FLIGHT]]]);
     HUMAN_TRANSITABLE_BIOMES.forEach(biome => {
@@ -84,8 +85,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
   });
 
   it("should not spawn outside of HUMAN_TRANSITABLE_BIOMES", async () => {
-    game.override.mysteryEncounterTier(MysteryEncounterTier.GREAT);
-    game.override.startingBiome(Biome.VOLCANO);
+    game.override.mysteryEncounterTier(MysteryEncounterTier.GREAT).startingBiome(Biome.VOLCANO);
     await game.runToMysteryEncounter();
 
     expect(scene.currentBattle?.mysteryEncounter?.encounterType).not.toBe(MysteryEncounterType.THE_WINSTRATE_CHALLENGE);

--- a/test/mystery-encounter/encounters/trash-to-treasure-encounter.test.ts
+++ b/test/mystery-encounter/encounters/trash-to-treasure-encounter.test.ts
@@ -50,10 +50,11 @@ describe("Trash to Treasure - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves();
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<Biome, MysteryEncounterType[]>([[Biome.CAVE, [MysteryEncounterType.TRASH_TO_TREASURE]]]),

--- a/test/mystery-encounter/encounters/weird-dream-encounter.test.ts
+++ b/test/mystery-encounter/encounters/weird-dream-encounter.test.ts
@@ -38,10 +38,11 @@ describe("Weird Dream - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .disableTrainerWaves();
     vi.spyOn(EncounterTransformationSequence, "doPokemonTransformationSequence").mockImplementation(
       () => new Promise<void>(resolve => resolve()),
     );

--- a/test/mystery-encounter/mystery-encounter-utils.test.ts
+++ b/test/mystery-encounter/mystery-encounter-utils.test.ts
@@ -51,9 +51,7 @@ describe("Mystery Encounter Utils", () => {
       game.override.seed("random");
 
       let result = getRandomPlayerPokemon();
-      expect(result.species.speciesId).toBe(Species.MANAPHY);
-
-      game.override.seed("random2");
+      expect(result.species.speciesId).toBe(Species.MANAPHY).seed("random2");
 
       result = getRandomPlayerPokemon();
       expect(result.species.speciesId).toBe(Species.ARCEUS);
@@ -71,9 +69,7 @@ describe("Mystery Encounter Utils", () => {
       game.override.seed("random");
 
       let result = getRandomPlayerPokemon();
-      expect(result.species.speciesId).toBe(Species.MANAPHY);
-
-      game.override.seed("random2");
+      expect(result.species.speciesId).toBe(Species.MANAPHY).seed("random2");
 
       result = getRandomPlayerPokemon();
       expect(result.species.speciesId).toBe(Species.ARCEUS);
@@ -90,9 +86,7 @@ describe("Mystery Encounter Utils", () => {
       game.override.seed("random");
 
       let result = getRandomPlayerPokemon(true);
-      expect(result.species.speciesId).toBe(Species.MANAPHY);
-
-      game.override.seed("random2");
+      expect(result.species.speciesId).toBe(Species.MANAPHY).seed("random2");
 
       result = getRandomPlayerPokemon(true);
       expect(result.species.speciesId).toBe(Species.MANAPHY);
@@ -109,9 +103,7 @@ describe("Mystery Encounter Utils", () => {
       game.override.seed("random");
 
       let result = getRandomPlayerPokemon(true, false);
-      expect(result.species.speciesId).toBe(Species.MANAPHY);
-
-      game.override.seed("random2");
+      expect(result.species.speciesId).toBe(Species.MANAPHY).seed("random2");
 
       result = getRandomPlayerPokemon(true, false);
       expect(result.species.speciesId).toBe(Species.MANAPHY);
@@ -128,9 +120,7 @@ describe("Mystery Encounter Utils", () => {
       game.override.seed("random");
 
       let result = getRandomPlayerPokemon(true, false, true);
-      expect(result.species.speciesId).toBe(Species.ARCEUS);
-
-      game.override.seed("random2");
+      expect(result.species.speciesId).toBe(Species.ARCEUS).seed("random2");
 
       result = getRandomPlayerPokemon(true, false, true);
       expect(result.species.speciesId).toBe(Species.ARCEUS);

--- a/test/mystery-encounter/mystery-encounter.test.ts
+++ b/test/mystery-encounter/mystery-encounter.test.ts
@@ -24,8 +24,7 @@ describe("Mystery Encounters", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.startingWave(11);
-    game.override.mysteryEncounterChance(100);
+    game.override.startingWave(11).mysteryEncounterChance(100);
   });
 
   it("Spawns a mystery encounter", async () => {

--- a/test/phases/mystery-encounter-phase.test.ts
+++ b/test/phases/mystery-encounter-phase.test.ts
@@ -27,10 +27,7 @@ describe("Mystery Encounter Phases", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.startingWave(11);
-    game.override.mysteryEncounterChance(100);
-    // Seed guarantees wild encounter to be replaced by ME
-    game.override.seed("test");
+    game.override.startingWave(11).mysteryEncounterChance(100).seed("test"); // Seed guarantees wild encounter to be replaced by ME
   });
 
   describe("MysteryEncounterPhase", () => {

--- a/test/ui/transfer-item.test.ts
+++ b/test/ui/transfer-item.test.ts
@@ -26,17 +26,18 @@ describe("UI - Transfer Items", () => {
 
   beforeEach(async () => {
     game = new GameManager(phaserGame);
-    game.override.battleStyle("single");
-    game.override.startingLevel(100);
-    game.override.startingWave(1);
-    game.override.startingHeldItems([
-      { name: "BERRY", count: 1, type: BerryType.SITRUS },
-      { name: "BERRY", count: 2, type: BerryType.APICOT },
-      { name: "BERRY", count: 2, type: BerryType.LUM },
-    ]);
-    game.override.moveset([Moves.DRAGON_CLAW]);
-    game.override.enemySpecies(Species.MAGIKARP);
-    game.override.enemyMoveset([Moves.SPLASH]);
+    game.override
+      .battleStyle("single")
+      .startingLevel(100)
+      .startingWave(1)
+      .startingHeldItems([
+        { name: "BERRY", count: 1, type: BerryType.SITRUS },
+        { name: "BERRY", count: 2, type: BerryType.APICOT },
+        { name: "BERRY", count: 2, type: BerryType.LUM },
+      ])
+      .moveset([Moves.DRAGON_CLAW])
+      .enemySpecies(Species.MAGIKARP)
+      .enemyMoveset([Moves.SPLASH]);
 
     await game.classicMode.startBattle([Species.RAYQUAZA, Species.RAYQUAZA, Species.RAYQUAZA]);
 


### PR DESCRIPTION
I hope I got them all...

## What are the changes the user will see?
N/A
## Why am I making these changes?
```ts
    game.override.starterSpecies(Species.MAGIKARP);
    game.override.enemySpecies(Species.SNORLAX);
    game.override.startingLevel(100);
    game.override.enemyLevel(100);

    game.override.moveset([Moves.FILLET_AWAY]);
    game.override.enemyMoveset(Moves.SPLASH);
```
This looks bad and _really_ needn't exist anymore since we have chaining on all `game.override` statements

## What are the changes from a developer perspective?
Removed above pattern in place of using optional chaining
regex go brrr

## Screenshots/Videos
N/A
## How to test the changes?
`npm run test:silent` (all i did was change overrides using regex)

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?