### PR TITLE
[UI/UX] Move Reload Required text to bottom of settings

### DIFF
--- a/src/ui/settings/abstract-settings-ui-handler.ts
+++ b/src/ui/settings/abstract-settings-ui-handler.ts
@@ -19,8 +19,6 @@ export default class AbstractSettingsUiHandler extends MessageUiHandler {
   private optionsContainer: Phaser.GameObjects.Container;
   private messageBoxContainer: Phaser.GameObjects.Container;
   private navigationContainer: NavigationMenu;
-  /** Text object displaying "*Reload Required" */
-  protected reloadRequiredText: Phaser.GameObjects.Text;
 
   private scrollCursor: number;
   private scrollBar: ScrollBar;

--- a/src/ui/settings/abstract-settings-ui-handler.ts
+++ b/src/ui/settings/abstract-settings-ui-handler.ts
@@ -19,6 +19,8 @@ export default class AbstractSettingsUiHandler extends MessageUiHandler {
   private optionsContainer: Phaser.GameObjects.Container;
   private messageBoxContainer: Phaser.GameObjects.Container;
   private navigationContainer: NavigationMenu;
+  /** Text object displaying "*Reload Required" */
+  protected reloadRequiredText: Phaser.GameObjects.Text;
 
   private scrollCursor: number;
   private scrollBar: ScrollBar;
@@ -108,10 +110,12 @@ export default class AbstractSettingsUiHandler extends MessageUiHandler {
 
     this.reloadSettings = this.settings.filter(s => s?.requireReload);
 
+    let anyReloadRequired = false;
     this.settings.forEach((setting, s) => {
       let settingName = setting.label;
       if (setting?.requireReload) {
-        settingName += ` (${i18next.t("settings:requireReload")})`;
+        settingName += "*";
+        anyReloadRequired = true;
       }
 
       this.settingLabels[s] = addTextObject(8, 28 + s * 16, settingName, TextStyle.SETTINGS_LABEL);
@@ -187,6 +191,14 @@ export default class AbstractSettingsUiHandler extends MessageUiHandler {
     this.settingsContainer.add(iconAction);
     this.settingsContainer.add(iconCancel);
     this.settingsContainer.add(actionText);
+    // Only add the ReloadRequired text on pages that have settings that require a reload.
+    if (anyReloadRequired) {
+      const reloadRequired = addTextObject(0, 0, `*${i18next.t("settings:requireReload")}`, TextStyle.SETTINGS_LABEL)
+        .setOrigin(0, 0.15)
+        .setPositionRelative(actionsBg, 6, 0)
+        .setY(actionText.y);
+      this.settingsContainer.add(reloadRequired);
+    }
     this.settingsContainer.add(cancelText);
     this.settingsContainer.add(this.messageBoxContainer);
 


### PR DESCRIPTION
# What are the changes the user will see?
See the Screenshots/Videos section.

## Why am I making these changes?
Requested by @Adri1 

## What are the changes from a developer perspective?
In `abstract-settings-ui-handler`, we replace the concatenation of the i18nkey with the "Reload Required" localization with an asterisk, and set a variable indicating whether any setting requires reload.
Then, when adding items to the container, if any setting had reload required, then we add the text object to the page.

## Screenshots/Videos

<details><summary>Before</summary>

![image](https://github.com/user-attachments/assets/108a0f26-d6c2-4362-a4cd-69c0be27462b)
</details>
<details><summary>After</summary>

![image](https://github.com/user-attachments/assets/de88066c-3700-4e91-8490-41ffb86bee2f)
</details>

<details><summary>Before (Legacy)</summary>

![image](https://github.com/user-attachments/assets/e8afbc21-e90d-4db7-81d4-9b4c3eda1a13)
</details>

<details><summary>After (Legacy)</summary>

![image](https://github.com/user-attachments/assets/45e734bb-cb75-4e85-894b-5e578f05b08a)
</details>

## How to test the changes?
Open up the settings page, and navigate to the display / audio pages.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - ~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?