### PR TITLE
grey caught indicator for genderless pokemon

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -657,7 +657,12 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
 
   getDexAttr(): bigint {
     let ret = 0n;
-    ret |= this.gender !== Gender.FEMALE ? DexAttr.MALE : DexAttr.FEMALE;
+    ret |= ret |=
+      this.gender === Gender.GENDERLESS
+        ? DexAttr.GENDERLESS
+        : this.gender !== Gender.FEMALE
+          ? DexAttr.MALE
+          : DexAttr.FEMALE;
     ret |= !this.shiny ? DexAttr.NON_SHINY : DexAttr.SHINY;
     ret |= this.variant >= 2 ? DexAttr.VARIANT_3 : this.variant === 1 ? DexAttr.VARIANT_2 : DexAttr.DEFAULT_VARIANT;
     ret |= globalScene.gameData.getFormAttr(this.formIndex);
@@ -6702,7 +6707,6 @@ export class EnemyPokemon extends Pokemon {
     return ret;
   }
 
-  
   /**
    * Show or hide the type effectiveness multiplier window
    * Passing undefined will hide the window

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -248,6 +248,7 @@ export interface RunEntry {
 }
 
 export const DexAttr = {
+  GENDERLESS: 0n,
   NON_SHINY: 1n,
   SHINY: 2n,
   MALE: 4n,


### PR DESCRIPTION
## What are the changes the user will see?

The caught indicator will no longer be greyed out for genderless pokemon, regardless of anything missing in the Pokédex

## Why am I making these changes?

Fixes #5757

## What are the changes from a developer perspective?

Adds `GENDERLESS: 0n` to the `DexAttr`

Checks if the Pokemon is genderless in `getDexAttr`, instead of treating it as a male

## Screenshots/Videos

Before
![before](image.png)

After
![after](image-1.png)

## How to test the changes?

Start a new run and in `overrides.ts` specify a genderless pokemon. (Easier to test with Pokemons, which only have one ability)

These are the overrides I used:

```ts
OPP_SPECIES_OVERRIDE: Species.MAGNEMITE,
POKEBALL_OVERRIDE: {
  active: true,
  pokeballs: {
    [PokeballType.POKEBALL]: 0,
    [PokeballType.GREAT_BALL]: 0,
    [PokeballType.ULTRA_BALL]: 0,
    [PokeballType.ROGUE_BALL]: 0,
    [PokeballType.MASTER_BALL]: 99,
  },
}
```

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?