### PR TITLE
[Bug] Fix Rattled Speed Stat Increase Delayed until End of Turn

### DIFF
--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -2130,7 +2130,12 @@ export class PostIntimidateStatStageChangeAbAttr extends AbAttr {
 
   override apply(pokemon: Pokemon, passive: boolean, simulated:boolean, cancelled: BooleanHolder, args: any[]): void {
     if (!simulated) {
-      globalScene.pushPhase(new StatStageChangePhase(pokemon.getBattlerIndex(), false, this.stats, this.stages));
+      const newStatStageChangePhase = new StatStageChangePhase(pokemon.getBattlerIndex(), false, this.stats, this.stages)
+      if(globalScene.findPhase(m => m instanceof MovePhase)){
+        globalScene.prependToPhase(newStatStageChangePhase, MovePhase)
+      }else {
+        globalScene.pushPhase(newStatStageChangePhase);
+      }
     }
     cancelled.value = this.overwrites;
   }

--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -2133,6 +2133,8 @@ export class PostIntimidateStatStageChangeAbAttr extends AbAttr {
       const newStatStageChangePhase = new StatStageChangePhase(pokemon.getBattlerIndex(), false, this.stats, this.stages)
       if(globalScene.findPhase(m => m instanceof MovePhase)){
         globalScene.prependToPhase(newStatStageChangePhase, MovePhase)
+      } else if(globalScene.findPhase(m => m instanceof SwitchSummonPhase)){
+        globalScene.prependToPhase(newStatStageChangePhase, SwitchSummonPhase)
       }else {
         globalScene.pushPhase(newStatStageChangePhase);
       }


### PR DESCRIPTION
## What are the changes the user will see?
<!--현재 상대가 포켓몬을 변경하고 위협 효과로 Rattle가 발동될 시 공격력이 낮아진 다음 바로 스피드가 높아지지 않습니다. 이 PR은 이 문제를 해결하는 것이 목표입니다.-->
Currently, when the opponent changes their Pokémon and Rattle is activated, the attack power is lowered and then the speed does not increase right away. This PR aims to fix this issue.

## Why am I making these changes?
<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->
Fixes #5516 

## What are the changes from a developer perspective?
<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->
- ability.ts
<!--pushPhase 하던 곳에서 if 분기를 합니다.
findPhase를 사용하여 MovePhase 또는 SwitchSummonPhase 가 있을 시 찾은 Phase를 기준으로 prepend를 하고
없을 시 기존과 같이 pushPhase를 합니다.-->

In the place where `pushPhase` was done, use `globalScene.findPhase`.
If there is a `MovePhase` or `SwitchSummonPhase` in the `phaseQueue`, `prependToPhase`is done based on the found phase,
and if there is none, `pushPhase` is done as before.

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->
1. Set overrides in src/overrides.ts
```ts
const overrides = {
  STARTING_WAVE_OVERRIDE: 25,

  STARTING_LEVEL_OVERRIDE: 100,

  MOVESET_OVERRIDE: [MoveId.FALSE_SWIPE, MoveId.TRICK_ROOM],

  OPP_ABILITY_OVERRIDE: AbilityId.INTIMIDATE,

  OPP_MOVESET_OVERRIDE: [MoveId.PIN_MISSILE] // Bug type move (optional)

} satisfies Partial<InstanceType<OverridesType>>;
```
2. Start battle

3. Check speed raise after attack falls

4. Use False Swipe against an Opponent, and then use Trick Room.

5. When the opponent switches, switch out Gimmighoul as well


## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test:silent`)
~~[ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?~~
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

~~Are there any localization additions or changes? If so:
[ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  [ ] If so, please leave a link to it here: 
 [ ] Has the translation team been contacted for proofreading/translation?~~