### PR TITLE
[Misc] Added overloads for `battleScene` modifier functions & cleaned up usages

### DIFF
--- a/src/@types/modifier-predicate.ts
+++ b/src/@types/modifier-predicate.ts
@@ -1,0 +1,4 @@
+import type { Modifier } from "../modifier/modifier";
+
+export type ModifierPredicate = (modifier: Modifier) => boolean;
+export type ModifierIdentityPredicate<T extends Modifier> = (modifier: Modifier) => modifier is T;

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -19,7 +19,12 @@ import {
   type Constructor,
 } from "#app/utils/common";
 import { deepMergeSpriteData } from "#app/utils/data";
-import type { Modifier, ModifierPredicate, TurnHeldItemTransferModifier } from "./modifier/modifier";
+import type {
+  Modifier,
+  ModifierIdentityPredicate,
+  ModifierPredicate,
+  TurnHeldItemTransferModifier,
+} from "./modifier/modifier";
 import {
   ConsumableModifier,
   ConsumablePokemonModifier,
@@ -3361,6 +3366,11 @@ export default class BattleScene extends SceneBase {
     return (isPlayer ? this.modifiers : this.enemyModifiers).filter(modifierFilter);
   }
 
+  findModifier<T extends PersistentModifier>(
+    modifierFilter: ModifierIdentityPredicate<T>,
+    player?: boolean,
+  ): T | undefined;
+  findModifier(modifierFilter: ModifierPredicate, player?: boolean): PersistentModifier | undefined;
   /**
    * Find the first modifier that pass the `modifierFilter` function
    * @param modifierFilter The function used to filter a target's modifiers

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -3316,9 +3316,23 @@ export default class BattleScene extends SceneBase {
     });
   }
 
-  hasModifier(modifier: PersistentModifier, enemy = false): boolean {
-    const modifiers = !enemy ? this.modifiers : this.enemyModifiers;
-    return modifiers.indexOf(modifier) > -1;
+  /**
+   * Check whether a given predicate function returns `true` for any of a given side's modifiers.
+   * @param predicate - The {@linkcode ModifierPredicate} to check against.
+   * THe predicate function will be called once for each of the given side's modifiers until it returns `true`,
+   * or the end of the array.
+   * @param enemy - Whether to search the enemy (`true`) or player (`false`) side of the field; default `false`
+   */
+  hasModifier(modifier: ModifierPredicate, enemy?: boolean): boolean;
+  /**
+   * Check whether a given PersistentModifier exists on the given side of the field.
+   * @param modifier - The {@linkcode PersistentModifier} to check against.
+   * @param enemy - Whether to search the enemy (`true`) or player (`false`) side of the field; default `false`
+   */
+  hasModifier(modifier: PersistentModifier, enemy?: boolean): boolean;
+  hasModifier(modifier: ModifierPredicate | PersistentModifier, enemy = false): boolean {
+    const modifiers = enemy ? this.enemyModifiers : this.modifiers;
+    return typeof modifier === "function" ? modifiers.some(modifier) : modifiers.indexOf(modifier) > -1;
   }
 
   /**
@@ -3358,24 +3372,26 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Get all of the modifiers that pass the `modifierFilter` function
-   * @param modifierFilter The function used to filter a target's modifiers
-   * @param isPlayer Whether to search the player (`true`) or the enemy (`false`); Defaults to `true`
-   * @returns the list of all modifiers that passed the `modifierFilter` function
+   * @param modifierFilter - The function used to filter a target's modifiers
+   * @param isPlayer - Whether to search the player (`true`) or the enemy (`false`) party; default `true`.
+   * @returns - An array containing all modifiers that passed the `modifierFilter` function.
    */
+  findModifiers(modifierFilter: ModifierPredicate, isPlayer?: boolean): PersistentModifier[];
+  findModifiers<T extends PersistentModifier>(modifierFilter: ModifierIdentityPredicate<T>, isPlayer?: boolean): T[];
   findModifiers(modifierFilter: ModifierPredicate, isPlayer = true): PersistentModifier[] {
     return (isPlayer ? this.modifiers : this.enemyModifiers).filter(modifierFilter);
   }
 
+  findModifier(modifierFilter: ModifierPredicate, player?: boolean): PersistentModifier | undefined;
   findModifier<T extends PersistentModifier>(
     modifierFilter: ModifierIdentityPredicate<T>,
     player?: boolean,
   ): T | undefined;
-  findModifier(modifierFilter: ModifierPredicate, player?: boolean): PersistentModifier | undefined;
   /**
-   * Find the first modifier that pass the `modifierFilter` function
-   * @param modifierFilter The function used to filter a target's modifiers
-   * @param player Whether to search the player (`true`) or the enemy (`false`); Defaults to `true`
-   * @returns the first modifier that passed the `modifierFilter` function; `undefined` if none passed
+   * Get the first modifier that passes the `modifierFilter` function.
+   * @param modifierFilter - The function used to filter a target's modifiers.
+   * @param isPlayer - Whether to search the player (`true`) or the enemy (`false`) party; default `true`.
+   * @returns - The first modifier that passed the `modifierFilter` function, or `undefined` if none are found.
    */
   findModifier(modifierFilter: ModifierPredicate, player = true): PersistentModifier | undefined {
     return (player ? this.modifiers : this.enemyModifiers).find(modifierFilter);

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -178,14 +178,14 @@ export default class Battle {
     this.postBattleLoot.push(
       ...globalScene
         .findModifiers(
-          m => m instanceof PokemonHeldItemModifier && m.pokemonId === enemyPokemon.id && m.isTransferable,
+          (m): m is PokemonHeldItemModifier =>
+            m instanceof PokemonHeldItemModifier && m.pokemonId === enemyPokemon.id && m.isTransferable,
           false,
         )
         .map(i => {
-          const ret = i as PokemonHeldItemModifier;
-          //@ts-ignore - this is awful to fix/change
-          ret.pokemonId = null;
-          return ret;
+          // @ts-ignore - this is awful to fix/change
+          i.pokemonId = null;
+          return i;
         }),
     );
   }

--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -1246,7 +1246,7 @@ export class MoveTypeChangeAbAttr extends PreAttackAbAttr {
 
   /**
    * Determine if the move type change attribute can be applied
-   * 
+   *
    * Can be applied if:
    * - The ability's condition is met, e.g. pixilate only boosts normal moves,
    * - The move is not forbidden from having its type changed by an ability, e.g. {@linkcode MoveId.MULTI_ATTACK}
@@ -1262,7 +1262,7 @@ export class MoveTypeChangeAbAttr extends PreAttackAbAttr {
    */
   override canApplyPreAttack(pokemon: Pokemon, _passive: boolean, _simulated: boolean, _defender: Pokemon | null, move: Move, _args: [NumberHolder?, NumberHolder?, ...any]): boolean {
     return (!this.condition || this.condition(pokemon, _defender, move)) &&
-            !noAbilityTypeOverrideMoves.has(move.id) && 
+            !noAbilityTypeOverrideMoves.has(move.id) &&
             (!pokemon.isTerastallized ||
               (move.id !== MoveId.TERA_BLAST &&
               (move.id !== MoveId.TERA_STARSTORM || pokemon.getTeraType() !== PokemonType.STELLAR || !pokemon.hasSpecies(SpeciesId.TERAPAGOS))));
@@ -1777,8 +1777,10 @@ export class PostAttackStealHeldItemAbAttr extends PostAttackAbAttr {
   }
 
   getTargetHeldItems(target: Pokemon): PokemonHeldItemModifier[] {
-    return globalScene.findModifiers(m => m instanceof PokemonHeldItemModifier
-      && m.pokemonId === target.id, target.isPlayer()) as PokemonHeldItemModifier[];
+    return globalScene.findModifiers((m): m is PokemonHeldItemModifier =>
+      m instanceof PokemonHeldItemModifier
+      && m.pokemonId === target.id, target.isPlayer()
+    );
   }
 }
 
@@ -1904,8 +1906,10 @@ export class PostDefendStealHeldItemAbAttr extends PostDefendAbAttr {
   }
 
   getTargetHeldItems(target: Pokemon): PokemonHeldItemModifier[] {
-    return globalScene.findModifiers(m => m instanceof PokemonHeldItemModifier
-      && m.pokemonId === target.id, target.isPlayer()) as PokemonHeldItemModifier[];
+    return globalScene.findModifiers((m): m is PokemonHeldItemModifier =>
+      m instanceof PokemonHeldItemModifier
+      && m.pokemonId === target.id, target.isPlayer()
+    );
   }
 }
 

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -815,7 +815,7 @@ export default class Move implements Localizable {
     applyPreAttackAbAttrs(MoveTypeChangeAbAttr, source, target, this, true, typeChangeHolder, typeChangeMovePowerMultiplier);
 
     const sourceTeraType = source.getTeraType();
-    if (source.isTerastallized && sourceTeraType === this.type && power.value < 60 && this.priority <= 0 && !this.hasAttr(MultiHitAttr) && !globalScene.findModifier(m => m instanceof PokemonMultiHitModifier && m.pokemonId === source.id)) {
+    if (source.isTerastallized && sourceTeraType === this.type && power.value < 60 && this.priority <= 0 && !this.hasAttr(MultiHitAttr) && !globalScene.hasModifier(m => m instanceof PokemonMultiHitModifier && m.pokemonId === source.id)) {
       power.value = 60;
     }
 
@@ -2570,8 +2570,10 @@ export class StealHeldItemChanceAttr extends MoveEffectAttr {
   }
 
   getTargetHeldItems(target: Pokemon): PokemonHeldItemModifier[] {
-    return globalScene.findModifiers(m => m instanceof PokemonHeldItemModifier
-      && m.pokemonId === target.id, target.isPlayer()) as PokemonHeldItemModifier[];
+    return globalScene.findModifiers((m): m is PokemonHeldItemModifier =>
+      m instanceof PokemonHeldItemModifier
+      && m.pokemonId === target.id, target.isPlayer()
+    );
   }
 
   getUserBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
@@ -2652,8 +2654,10 @@ export class RemoveHeldItemAttr extends MoveEffectAttr {
   }
 
   getTargetHeldItems(target: Pokemon): PokemonHeldItemModifier[] {
-    return globalScene.findModifiers(m => m instanceof PokemonHeldItemModifier
-      && m.pokemonId === target.id, target.isPlayer()) as PokemonHeldItemModifier[];
+    return globalScene.findModifiers((m): m is PokemonHeldItemModifier =>
+      m instanceof PokemonHeldItemModifier
+      && m.pokemonId === target.id, target.isPlayer()
+    );
   }
 
   getUserBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
@@ -2712,8 +2716,10 @@ export class EatBerryAttr extends MoveEffectAttr {
   }
 
   getTargetHeldBerries(target: Pokemon): BerryModifier[] {
-    return globalScene.findModifiers(m => m instanceof BerryModifier
-      && (m as BerryModifier).pokemonId === target.id, target.isPlayer()) as BerryModifier[];
+    return globalScene.findModifiers((m): m is BerryModifier =>
+      m instanceof BerryModifier
+      && m.pokemonId === target.id, target.isPlayer()
+    );
   }
 
   reduceBerryModifier(target: Pokemon) {

--- a/src/data/mystery-encounters/encounters/absolute-avarice-encounter.ts
+++ b/src/data/mystery-encounters/encounters/absolute-avarice-encounter.ts
@@ -191,7 +191,7 @@ export const AbsoluteAvariceEncounter: MysteryEncounter = MysteryEncounterBuilde
     globalScene.loadSe("Follow Me", "battle_anims", "Follow Me.mp3");
 
     // Get all player berry items, remove from party, and store reference
-    const berryItems = globalScene.findModifiers(m => m instanceof BerryModifier) as BerryModifier[];
+    const berryItems = globalScene.findModifiers(m => m instanceof BerryModifier);
 
     // Sort berries by party member ID to more easily re-add later if necessary
     const berryItemsMap = new Map<number, BerryModifier[]>();
@@ -256,7 +256,7 @@ export const AbsoluteAvariceEncounter: MysteryEncounter = MysteryEncounterBuilde
 
     // Remove the berries from the party
     // Session has been safely saved at this point, so data won't be lost
-    const berryItems = globalScene.findModifiers(m => m instanceof BerryModifier) as BerryModifier[];
+    const berryItems = globalScene.findModifiers(m => m instanceof BerryModifier);
     berryItems.forEach(berryMod => {
       globalScene.removeModifier(berryMod);
     });

--- a/src/data/mystery-encounters/encounters/berries-abound-encounter.ts
+++ b/src/data/mystery-encounters/encounters/berries-abound-encounter.ts
@@ -314,12 +314,10 @@ function tryGiveBerry(prioritizedPokemon?: PlayerPokemon) {
   // Will try to apply to prioritized pokemon first, then do normal application method if it fails
   if (prioritizedPokemon) {
     const heldBerriesOfType = globalScene.findModifier(
-      m =>
-        m instanceof BerryModifier &&
-        m.pokemonId === prioritizedPokemon.id &&
-        (m as BerryModifier).berryType === berryType,
+      (m): m is BerryModifier =>
+        m instanceof BerryModifier && m.pokemonId === prioritizedPokemon.id && m.berryType === berryType,
       true,
-    ) as BerryModifier;
+    );
 
     if (!heldBerriesOfType || heldBerriesOfType.getStackCount() < heldBerriesOfType.getMaxStackCount()) {
       applyModifierTypeToPlayerPokemon(prioritizedPokemon, berry);
@@ -330,9 +328,10 @@ function tryGiveBerry(prioritizedPokemon?: PlayerPokemon) {
   // Iterate over the party until berry was successfully given
   for (const pokemon of party) {
     const heldBerriesOfType = globalScene.findModifier(
-      m => m instanceof BerryModifier && m.pokemonId === pokemon.id && (m as BerryModifier).berryType === berryType,
+      (m): m is BerryModifier =>
+        m instanceof BerryModifier && m.pokemonId === pokemon.id && (m as BerryModifier).berryType === berryType,
       true,
-    ) as BerryModifier;
+    );
 
     if (!heldBerriesOfType || heldBerriesOfType.getStackCount() < heldBerriesOfType.getMaxStackCount()) {
       applyModifierTypeToPlayerPokemon(pokemon, berry);

--- a/src/data/mystery-encounters/encounters/bug-type-superfan-encounter.ts
+++ b/src/data/mystery-encounters/encounters/bug-type-superfan-encounter.ts
@@ -367,10 +367,10 @@ export const BugTypeSuperfanEncounter: MysteryEncounter = MysteryEncounterBuilde
           const modifierOptions: ModifierTypeOption[] = [generateModifierTypeOption(modifierTypes.MASTER_BALL)!];
           const specialOptions: ModifierTypeOption[] = [];
 
-          if (!globalScene.findModifier(m => m instanceof MegaEvolutionAccessModifier)) {
+          if (!globalScene.hasModifier(m => m instanceof MegaEvolutionAccessModifier)) {
             modifierOptions.push(generateModifierTypeOption(modifierTypes.MEGA_BRACELET)!);
           }
-          if (!globalScene.findModifier(m => m instanceof GigantamaxAccessModifier)) {
+          if (!globalScene.hasModifier(m => m instanceof GigantamaxAccessModifier)) {
             modifierOptions.push(generateModifierTypeOption(modifierTypes.DYNAMAX_BAND)!);
           }
           const nonRareEvolutionModifier = generateModifierTypeOption(modifierTypes.EVOLUTION_ITEM);

--- a/src/data/mystery-encounters/encounters/delibirdy-encounter.ts
+++ b/src/data/mystery-encounters/encounters/delibirdy-encounter.ts
@@ -166,7 +166,7 @@ export const DelibirdyEncounter: MysteryEncounter = MysteryEncounterBuilder.with
       .withOptionPhase(async () => {
         // Give the player an Amulet Coin
         // Check if the player has max stacks of that item already
-        const existing = globalScene.findModifier(m => m instanceof MoneyMultiplierModifier) as MoneyMultiplierModifier;
+        const existing = globalScene.findModifier(m => m instanceof MoneyMultiplierModifier);
 
         if (existing && existing.getStackCount() >= existing.getMaxStackCount()) {
           // At max stacks, give the first party pokemon a Shell Bell instead
@@ -247,9 +247,7 @@ export const DelibirdyEncounter: MysteryEncounter = MysteryEncounterBuilder.with
         // Give the player a Candy Jar if they gave a Berry, and a Berry Pouch for Reviver Seed
         if (modifier instanceof BerryModifier) {
           // Check if the player has max stacks of that Candy Jar already
-          const existing = globalScene.findModifier(
-            m => m instanceof LevelIncrementBoosterModifier,
-          ) as LevelIncrementBoosterModifier;
+          const existing = globalScene.findModifier(m => m instanceof LevelIncrementBoosterModifier);
 
           if (existing && existing.getStackCount() >= existing.getMaxStackCount()) {
             // At max stacks, give the first party pokemon a Shell Bell instead
@@ -271,7 +269,7 @@ export const DelibirdyEncounter: MysteryEncounter = MysteryEncounterBuilder.with
           }
         } else {
           // Check if the player has max stacks of that Berry Pouch already
-          const existing = globalScene.findModifier(m => m instanceof PreserveBerryModifier) as PreserveBerryModifier;
+          const existing = globalScene.findModifier(m => m instanceof PreserveBerryModifier);
 
           if (existing && existing.getStackCount() >= existing.getMaxStackCount()) {
             // At max stacks, give the first party pokemon a Shell Bell instead
@@ -357,7 +355,7 @@ export const DelibirdyEncounter: MysteryEncounter = MysteryEncounterBuilder.with
         const chosenPokemon: PlayerPokemon = encounter.misc.chosenPokemon;
 
         // Check if the player has max stacks of Healing Charm already
-        const existing = globalScene.findModifier(m => m instanceof HealingBoosterModifier) as HealingBoosterModifier;
+        const existing = globalScene.findModifier(m => m instanceof HealingBoosterModifier);
 
         if (existing && existing.getStackCount() >= existing.getMaxStackCount()) {
           // At max stacks, give the first party pokemon a Shell Bell instead

--- a/src/data/mystery-encounters/encounters/trash-to-treasure-encounter.ts
+++ b/src/data/mystery-encounters/encounters/trash-to-treasure-encounter.ts
@@ -17,7 +17,8 @@ import { MysteryEncounterOptionBuilder } from "#app/data/mystery-encounters/myst
 import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
 import { SpeciesId } from "#enums/species-id";
-import { HitHealModifier, PokemonHeldItemModifier, TurnHealModifier } from "#app/modifier/modifier";
+import { PokemonHeldItemModifier, TurnHealModifier } from "#app/modifier/modifier";
+import type { HitHealModifier } from "#app/modifier/modifier";
 import { applyModifierTypeToPlayerPokemon } from "#app/data/mystery-encounters/utils/encounter-pokemon-utils";
 import { showEncounterText } from "#app/data/mystery-encounters/utils/encounter-dialogue-utils";
 import i18next from "#app/plugins/i18n";
@@ -231,12 +232,10 @@ async function tryApplyDigRewardItems() {
   // Iterate over the party until an item was successfully given
   // First leftovers
   for (const pokemon of party) {
-    const heldItems = globalScene.findModifiers(
-      m => m instanceof PokemonHeldItemModifier && m.pokemonId === pokemon.id,
+    const existingLeftovers = globalScene.findModifier(
+      (m): m is TurnHealModifier => m instanceof TurnHealModifier && m.pokemonId === pokemon.id,
       true,
-    ) as PokemonHeldItemModifier[];
-    const existingLeftovers = heldItems.find(m => m instanceof TurnHealModifier) as TurnHealModifier;
-
+    );
     if (!existingLeftovers || existingLeftovers.getStackCount() < existingLeftovers.getMaxStackCount()) {
       await applyModifierTypeToPlayerPokemon(pokemon, leftovers);
       break;
@@ -245,12 +244,10 @@ async function tryApplyDigRewardItems() {
 
   // Second leftovers
   for (const pokemon of party) {
-    const heldItems = globalScene.findModifiers(
-      m => m instanceof PokemonHeldItemModifier && m.pokemonId === pokemon.id,
+    const existingLeftovers = globalScene.findModifier(
+      (m): m is TurnHealModifier => m instanceof TurnHealModifier && m.pokemonId === pokemon.id,
       true,
-    ) as PokemonHeldItemModifier[];
-    const existingLeftovers = heldItems.find(m => m instanceof TurnHealModifier) as TurnHealModifier;
-
+    );
     if (!existingLeftovers || existingLeftovers.getStackCount() < existingLeftovers.getMaxStackCount()) {
       await applyModifierTypeToPlayerPokemon(pokemon, leftovers);
       break;
@@ -270,12 +267,10 @@ async function tryApplyDigRewardItems() {
 
   // Only Shell bell
   for (const pokemon of party) {
-    const heldItems = globalScene.findModifiers(
-      m => m instanceof PokemonHeldItemModifier && m.pokemonId === pokemon.id,
+    const existingShellBell = globalScene.findModifier(
+      (m): m is HitHealModifier => m instanceof PokemonHeldItemModifier && m.pokemonId === pokemon.id,
       true,
-    ) as PokemonHeldItemModifier[];
-    const existingShellBell = heldItems.find(m => m instanceof HitHealModifier) as HitHealModifier;
-
+    );
     if (!existingShellBell || existingShellBell.getStackCount() < existingShellBell.getMaxStackCount()) {
       await applyModifierTypeToPlayerPokemon(pokemon, shellBell);
       break;

--- a/src/data/mystery-encounters/encounters/uncommon-breed-encounter.ts
+++ b/src/data/mystery-encounters/encounters/uncommon-breed-encounter.ts
@@ -204,9 +204,7 @@ export const UncommonBreedEncounter: MysteryEncounter = MysteryEncounterBuilder.
 
         // Remove 4 random berries from player's party
         // Get all player berry items, remove from party, and store reference
-        const berryItems: BerryModifier[] = globalScene.findModifiers(
-          m => m instanceof BerryModifier,
-        ) as BerryModifier[];
+        const berryItems = globalScene.findModifiers(m => m instanceof BerryModifier);
         for (let i = 0; i < 4; i++) {
           const index = randSeedInt(berryItems.length);
           const randBerry = berryItems[index];

--- a/src/data/mystery-encounters/mystery-encounter-requirements.ts
+++ b/src/data/mystery-encounters/mystery-encounter-requirements.ts
@@ -377,10 +377,8 @@ export class PersistentModifierRequirement extends EncounterSceneRequirement {
     let modifierCount = 0;
     for (const modifier of this.requiredHeldItemModifiers) {
       const matchingMods = globalScene.findModifiers(m => m.constructor.name === modifier);
-      if (matchingMods?.length > 0) {
-        for (const matchingMod of matchingMods) {
-          modifierCount += matchingMod.stackCount;
-        }
+      for (const matchingMod of matchingMods) {
+        modifierCount += matchingMod.stackCount;
       }
     }
 

--- a/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
@@ -404,12 +404,12 @@ export async function applyModifierTypeToPlayerPokemon(
   // Check if the Pokemon has max stacks of that item already
   const modifier = modType.newModifier(pokemon);
   const existing = globalScene.findModifier(
-    m =>
+    (m): m is PokemonHeldItemModifier =>
       m instanceof PokemonHeldItemModifier &&
       m.type.id === modType.id &&
       m.pokemonId === pokemon.id &&
       m.matchType(modifier),
-  ) as PokemonHeldItemModifier;
+  );
 
   // At max stacks
   if (existing && existing.getStackCount() >= existing.getMaxStackCount()) {

--- a/src/data/pokemon-forms.ts
+++ b/src/data/pokemon-forms.ts
@@ -281,7 +281,7 @@ export class SpeciesFormChangeItemTrigger extends SpeciesFormChangeTrigger {
   }
 
   canChange(pokemon: Pokemon): boolean {
-    return !!globalScene.findModifier(
+    return globalScene.hasModifier(
       m =>
         m instanceof PokemonFormChangeItemModifier &&
         m.pokemonId === pokemon.id &&

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1211,13 +1211,13 @@ export default abstract class Pokemon extends Phaser.GameObjects.Container {
    * @param transferrableOnly - Whether to only consider transferrable held items; default `false`
    * @returns An array of all {@linkcode PokemonHeldItemModifier}s held by this Pokemon.
    */
-  getHeldItems(transferrableOnly = this.getFusionIconAtlasKey): PokemonHeldItemModifier[] {
+  getHeldItems(transferrableOnly = false): PokemonHeldItemModifier[] {
     if (!globalScene) {
       return [];
     }
     return globalScene.findModifiers(
       (m): m is PokemonHeldItemModifier =>
-        m instanceof PokemonHeldItemModifier && m.pokemonId === this.id && !(transferrableOnly && !m.isTransferable()),
+        m instanceof PokemonHeldItemModifier && m.pokemonId === this.id && (!transferrableOnly || m.isTransferable),
       this.isPlayer(),
     );
   }

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -394,8 +394,9 @@ export class PokemonHeldItemModifierType extends PokemonModifierType {
       (pokemon: PlayerPokemon) => {
         const dummyModifier = this.newModifier(pokemon);
         const matchingModifier = globalScene.findModifier(
-          m => m instanceof PokemonHeldItemModifier && m.pokemonId === pokemon.id && m.matchType(dummyModifier),
-        ) as PokemonHeldItemModifier;
+          (m): m is PokemonHeldItemModifier =>
+            m instanceof PokemonHeldItemModifier && m.pokemonId === pokemon.id && m.matchType(dummyModifier),
+        );
         const maxStackCount = dummyModifier.getMaxStackCount();
         if (!maxStackCount) {
           return i18next.t("modifierType:ModifierType.PokemonHeldItemModifierType.extra.inoperable", {

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -54,9 +54,6 @@ import {
 } from "#app/data/abilities/ability";
 import { globalScene } from "#app/global-scene";
 
-export type ModifierPredicate = (modifier: Modifier) => boolean;
-export type ModifierIdentityPredicate<T extends Modifier> = (modifier: Modifier) => modifier is T;
-
 const iconOverflowIndex = 24;
 
 export const modifierSortFunc = (a: Modifier, b: Modifier): number => {
@@ -3253,10 +3250,7 @@ export abstract class HeldItemTransferModifier extends PokemonHeldItemModifier {
     }
 
     const transferredModifierTypes: ModifierType[] = [];
-    const itemModifiers = globalScene.findModifiers(
-      m => m instanceof PokemonHeldItemModifier && m.pokemonId === targetPokemon.id && m.isTransferable,
-      targetPokemon.isPlayer(),
-    ) as PokemonHeldItemModifier[];
+    const itemModifiers = targetPokemon.getHeldItems();
 
     for (let i = 0; i < transferredItemCount; i++) {
       if (!itemModifiers.length) {

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -55,6 +55,7 @@ import {
 import { globalScene } from "#app/global-scene";
 
 export type ModifierPredicate = (modifier: Modifier) => boolean;
+export type ModifierIdentityPredicate<T extends Modifier> = (modifier: Modifier) => modifier is T;
 
 const iconOverflowIndex = 24;
 

--- a/src/phases/battle-end-phase.ts
+++ b/src/phases/battle-end-phase.ts
@@ -82,8 +82,9 @@ export class BattleEndPhase extends BattlePhase {
     }
 
     const lapsingModifiers = globalScene.findModifiers(
-      m => m instanceof LapsingPersistentModifier || m instanceof LapsingPokemonHeldItemModifier,
-    ) as (LapsingPersistentModifier | LapsingPokemonHeldItemModifier)[];
+      (m): m is LapsingPersistentModifier | LapsingPokemonHeldItemModifier =>
+        m instanceof LapsingPersistentModifier || m instanceof LapsingPokemonHeldItemModifier,
+    );
     for (const m of lapsingModifiers) {
       const args: any[] = [];
       if (m instanceof LapsingPokemonHeldItemModifier) {

--- a/src/phases/berry-phase.ts
+++ b/src/phases/berry-phase.ts
@@ -36,7 +36,7 @@ export class BerryPhase extends FieldPhase {
    * @param pokemon - The {@linkcode Pokemon} to check
    */
   eatBerries(pokemon: Pokemon): void {
-    const hasUsableBerry = !!globalScene.findModifier(
+    const hasUsableBerry = globalScene.hasModifier(
       m => m instanceof BerryModifier && m.shouldApply(pokemon),
       pokemon.isPlayer(),
     );

--- a/src/phases/select-biome-phase.ts
+++ b/src/phases/select-biome-phase.ts
@@ -40,7 +40,7 @@ export class SelectBiomePhase extends BattlePhase {
         .filter(b => !Array.isArray(b) || !randSeedInt(b[1]))
         .map(b => (!Array.isArray(b) ? b : b[0]));
 
-      if (biomes.length > 1 && globalScene.findModifier(m => m instanceof MapModifier)) {
+      if (biomes.length > 1 && globalScene.hasModifier(m => m instanceof MapModifier)) {
         const biomeSelectItems = biomes.map(b => {
           const ret: OptionSelectItem = {
             label: getBiomeName(b),

--- a/src/phases/select-modifier-phase.ts
+++ b/src/phases/select-modifier-phase.ts
@@ -15,12 +15,7 @@ import {
   getPlayerModifierTypeOptions,
 } from "#app/modifier/modifier-type";
 import type { Modifier } from "#app/modifier/modifier";
-import {
-  ExtraModifierModifier,
-  HealShopCostModifier,
-  PokemonHeldItemModifier,
-  TempExtraModifierModifier,
-} from "#app/modifier/modifier";
+import { ExtraModifierModifier, HealShopCostModifier, TempExtraModifierModifier } from "#app/modifier/modifier";
 import type ModifierSelectUiHandler from "#app/ui/modifier-select-ui-handler";
 import { SHOP_OPTIONS_ROW_LIMIT } from "#app/ui/modifier-select-ui-handler";
 import PartyUiHandler, { PartyUiMode, PartyOption } from "#app/ui/party-ui-handler";
@@ -150,12 +145,7 @@ export class SelectModifierPhase extends BattlePhase {
                     fromSlotIndex !== toSlotIndex &&
                     itemIndex > -1
                   ) {
-                    const itemModifiers = globalScene.findModifiers(
-                      m =>
-                        m instanceof PokemonHeldItemModifier &&
-                        m.isTransferable &&
-                        m.pokemonId === party[fromSlotIndex].id,
-                    ) as PokemonHeldItemModifier[];
+                    const itemModifiers = party[toSlotIndex].getHeldItems(true);
                     const itemModifier = itemModifiers[itemIndex];
                     globalScene.tryTransferHeldItemModifier(
                       itemModifier,

--- a/src/phases/switch-summon-phase.ts
+++ b/src/phases/switch-summon-phase.ts
@@ -138,7 +138,6 @@ export class SwitchSummonPhase extends SummonPhase {
       return;
     }
 
-
     if (this.switchType === SwitchType.BATON_PASS) {
       // If switching via baton pass, update opposing tags coming from the prior pokemon
       (this.player ? globalScene.getEnemyField() : globalScene.getPlayerField()).forEach((enemyPokemon: Pokemon) =>
@@ -147,17 +146,17 @@ export class SwitchSummonPhase extends SummonPhase {
 
       // If the recipient pokemon lacks a baton, give our baton to it during the swap
       if (
-        !globalScene.findModifier(
+        !globalScene.hasModifier(
           m =>
             m instanceof SwitchEffectTransferModifier &&
             (m as SwitchEffectTransferModifier).pokemonId === switchedInPokemon.id,
         )
       ) {
         const batonPassModifier = globalScene.findModifier(
-          m =>
+          (m): m is SwitchEffectTransferModifier =>
             m instanceof SwitchEffectTransferModifier &&
             (m as SwitchEffectTransferModifier).pokemonId === this.lastPokemon.id,
-        ) as SwitchEffectTransferModifier;
+        );
 
         if (batonPassModifier) {
           globalScene.tryTransferHeldItemModifier(

--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -183,8 +183,8 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
     this.player = args[0];
 
     const partyHasHeldItem =
-      this.player && !!globalScene.findModifiers(m => m instanceof PokemonHeldItemModifier && m.isTransferable).length;
-    const canLockRarities = !!globalScene.findModifier(m => m instanceof LockModifierTiersModifier);
+      this.player && globalScene.hasModifier(m => m instanceof PokemonHeldItemModifier && m.isTransferable);
+    const canLockRarities = globalScene.hasModifier(m => m instanceof LockModifierTiersModifier);
 
     this.transferButtonContainer.setVisible(false);
     this.transferButtonContainer.setAlpha(0);

--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -225,8 +225,9 @@ export default class PartyUiHandler extends MessageUiHandler {
 
   public static FilterItemMaxStacks = (pokemon: PlayerPokemon, modifier: PokemonHeldItemModifier) => {
     const matchingModifier = globalScene.findModifier(
-      m => m instanceof PokemonHeldItemModifier && m.pokemonId === pokemon.id && m.matchType(modifier),
-    ) as PokemonHeldItemModifier;
+      (m): m is PokemonHeldItemModifier =>
+        m instanceof PokemonHeldItemModifier && m.pokemonId === pokemon.id && m.matchType(modifier),
+    );
     if (matchingModifier && matchingModifier.stackCount === matchingModifier.getMaxStackCount()) {
       return i18next.t("partyUiHandler:tooManyItems", { pokemonName: getPokemonNameWithAffix(pokemon, false) });
     }
@@ -552,11 +553,11 @@ export default class PartyUiHandler extends MessageUiHandler {
         // this next bit checks to see if the the selected item from the original transfer pokemon exists on the new pokemon `p`
         // this returns `undefined` if the new pokemon doesn't have the item at all, otherwise it returns the `pokemonHeldItemModifier` for that item
         const matchingModifier = globalScene.findModifier(
-          m =>
+          (m): m is PokemonHeldItemModifier =>
             m instanceof PokemonHeldItemModifier &&
             m.pokemonId === newPokemon.id &&
             m.matchType(this.getTransferrableItemsFromPokemon(pokemon)[this.transferOptionCursor]),
-        ) as PokemonHeldItemModifier;
+        );
         const partySlot = this.partySlots.filter(m => m.getPokemon() === newPokemon)[0]; // this gets pokemon [p] for us
         if (p !== this.transferCursor) {
           // this skips adding the able/not able labels on the pokemon doing the transfer
@@ -1161,9 +1162,9 @@ export default class PartyUiHandler extends MessageUiHandler {
   }
 
   private allowBatonModifierSwitch(): boolean {
-    return !!(
+    return (
       this.partyUiMode !== PartyUiMode.FAINT_SWITCH &&
-      globalScene.findModifier(
+      globalScene.hasModifier(
         m =>
           m instanceof SwitchEffectTransferModifier && m.pokemonId === globalScene.getPlayerField()[this.fieldIndex].id,
       )

--- a/test/abilities/harvest.test.ts
+++ b/test/abilities/harvest.test.ts
@@ -19,7 +19,9 @@ describe("Abilities - Harvest", () => {
   let game: GameManager;
 
   const getPlayerBerries = () =>
-    game.scene.getModifiers(BerryModifier, true).filter(b => b.pokemonId === game.scene.getPlayerPokemon()?.id);
+    game.scene.findModifiers(
+      (b): b is BerryModifier => b instanceof BerryModifier && b.pokemonId === game.scene.getPlayerPokemon()!.id,
+    );
 
   /** Check whether the player's Modifiers contains the specified berries and nothing else. */
   function expectBerriesContaining(...berries: ModifierOverride[]): void {

--- a/test/items/dire_hit.test.ts
+++ b/test/items/dire_hit.test.ts
@@ -64,8 +64,8 @@ describe("Items - Dire Hit", () => {
 
     await game.phaseInterceptor.to(BattleEndPhase);
 
-    const modifier = game.scene.findModifier(m => m instanceof TempCritBoosterModifier) as TempCritBoosterModifier;
-    expect(modifier.getBattleCount()).toBe(4);
+    const modifier = game.scene.findModifier(m => m instanceof TempCritBoosterModifier);
+    expect(modifier?.getBattleCount()).toBe(4);
 
     // Forced DIRE_HIT to spawn in the first slot with override
     game.onNextPrompt(

--- a/test/mystery-encounter/encounters/absolute-avarice-encounter.test.ts
+++ b/test/mystery-encounter/encounters/absolute-avarice-encounter.test.ts
@@ -157,9 +157,10 @@ describe("Absolute Avarice - Mystery Encounter", () => {
       for (const partyPokemon of scene.getPlayerParty()) {
         const pokemonId = partyPokemon.id;
         const pokemonItems = scene.findModifiers(
-          m => m instanceof PokemonHeldItemModifier && (m as PokemonHeldItemModifier).pokemonId === pokemonId,
+          (m): m is PokemonHeldItemModifier =>
+            m instanceof PokemonHeldItemModifier && (m as PokemonHeldItemModifier).pokemonId === pokemonId,
           true,
-        ) as PokemonHeldItemModifier[];
+        );
         const revSeed = pokemonItems.find(
           i => i.type.name === i18next.t("modifierType:ModifierType.REVIVER_SEED.name"),
         );


### PR DESCRIPTION

- **Revert "Revert predicate stuff for now"**
- **Added modifier predicate overload to `hasModifier`**
- **Added overloads to modifier functions, cleaned up existing uses theroef**

## What are the changes the user will see?
N/A

## Why am I making these changes?
I really dislike assertions like this hiding info:
![Scary modifier code 1](image.png)
![Scary modifier assertion 2](image-1.png)

## What are the changes from a developer perspective?
Added overloads for several functions and tweaked existing usages to better use them.
(Yes, I dislike `!!findModifier`. Fight me.)

## Screenshots/Videos
N/A
## How to test the changes?
Run tests ig?

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?