### PR TITLE
[Dev] Enable Biome linting of `move-effect-phase.ts`

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -42,9 +42,6 @@
   // TODO: Remove if we ever get down to 0 circular imports
   "organizeImports": { "enabled": false },
   "linter": {
-    "ignore": [
-      "src/phases/move-effect-phase.ts" // TODO: unignore after move-effect-phase refactor
-    ],
     "enabled": true,
     "rules": {
       "recommended": true,

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -219,6 +219,7 @@ export class MoveEffectPhase extends PokemonPhase {
             return;
           }
           break;
+        // biome-ignore lint/suspicious/noFallthroughSwitchClause: The fallthrough is intentional
         case HitCheckResult.NO_EFFECT:
           globalScene.queueMessage(
             i18next.t(this.move.id === MoveId.SHEER_COLD ? "battle:hitResultImmune" : "battle:hitResultNoEffect", {
@@ -294,7 +295,8 @@ export class MoveEffectPhase extends PokemonPhase {
 
     // If other effects were overriden, stop this phase before they can be applied
     if (overridden.value) {
-      return this.end();
+      this.end();
+      return;
     }
 
     // Lapse `MOVE_EFFECT` effects (i.e. semi-invulnerability) when applicable
@@ -743,7 +745,7 @@ export class MoveEffectPhase extends PokemonPhase {
     firstTarget?: boolean | null,
     selfTarget?: boolean,
   ): void {
-    return applyFilteredMoveAttrs(
+    applyFilteredMoveAttrs(
       (attr: MoveAttr) =>
         attr instanceof MoveEffectAttr &&
         attr.trigger === triggerType &&


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
The ignore was forgotten to be removed.

## What are the changes from a developer perspective?
Biome will now lint `src/phases/move-effect-phase.ts`.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?