### PR TITLE
Added lefthook to enforce no non-type export in `src/@types`

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -2,6 +2,18 @@
 module.exports = {
   forbidden: [
     {
+      name: "no-non-type-@type-exports",
+      severity: "error",
+      comment:
+        "Files in @types should not export anything but types and interfaces. " +
+        "The folder is intended to house imports that are removed at runtime, " +
+        "and thus should not contain anything with a bearing on runtime code.",
+      to: {
+        path: "(^|/)src/@types",
+        dependencyTypesNot: ["type-only"],
+      },
+    },
+    {
       name: "only-type-imports",
       severity: "error",
       comment: "Files in enums and @types may only use type imports.",
@@ -218,7 +230,7 @@ module.exports = {
        module systems it knows of. It's the default because it's the safe option
        It might come at a performance penalty, though.
        moduleSystems: ['amd', 'cjs', 'es6', 'tsd']
-      
+
        As in practice only commonjs ('cjs') and ecmascript modules ('es6')
        are widely used, you can limit the moduleSystems to those.
      */
@@ -226,7 +238,7 @@ module.exports = {
     // moduleSystems: ['cjs', 'es6'],
 
     /* prefix for links in html and svg output (e.g. 'https://github.com/you/yourrepo/blob/main/'
-       to open it on your online repo or `vscode://file/${process.cwd()}/` to 
+       to open it on your online repo or `vscode://file/${process.cwd()}/` to
        open it in visual studio code),
      */
     // prefix: `vscode://file/${process.cwd()}/`,
@@ -271,7 +283,7 @@ module.exports = {
        to './webpack.conf.js'.
 
        The (optional) `env` and `arguments` attributes contain the parameters
-       to be passed if your webpack config is a function and takes them (see 
+       to be passed if your webpack config is a function and takes them (see
         webpack documentation for details)
      */
     // webpackConfig: {
@@ -322,8 +334,8 @@ module.exports = {
          A list of alias fields in package.jsons
          See [this specification](https://github.com/defunctzombie/package-browser-field-spec) and
          the webpack [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealiasfields)
-         documentation 
-         
+         documentation
+
          Defaults to an empty array (= don't use alias fields).
        */
       // aliasFields: ["browser"],


### PR DESCRIPTION
## What are the changes the user will see?
N/A
## Why am I making these changes?
`@types` is conventionally an interface dump, not a class dump

## What are the changes from a developer perspective?
Added lefthook to ensure no classes are inside `@types`
## Screenshots/Videos
N/A
## How to test the changes?
N/A
## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?