### PR TITLE
[Nit] Remove extra newline in test-boilerplate.ts

### DIFF
--- a/scripts/create-test/test-boilerplate.ts
+++ b/scripts/create-test/test-boilerplate.ts
@@ -34,7 +34,6 @@ describe("{{description}}", () => {
 
   it("should do XYZ", async () => {
     await game.classicMode.startBattle([SpeciesId.FEEBAS]);
-    
     game.move.use(MoveId.SPLASH);
     await game.toEndOfTurn();
 

--- a/scripts/create-test/test-boilerplate.ts
+++ b/scripts/create-test/test-boilerplate.ts
@@ -32,11 +32,10 @@ describe("{{description}}", () => {
       .enemyLevel(100);
   });
 
-  it("should do X", async () => {
+  it("should do XYZ", async () => {
     await game.classicMode.startBattle([SpeciesId.FEEBAS]);
-
+    
     game.move.use(MoveId.SPLASH);
-
     await game.toEndOfTurn();
 
     expect(true).toBe(true);

--- a/scripts/create-test/test-boilerplate.ts
+++ b/scripts/create-test/test-boilerplate.ts
@@ -34,6 +34,7 @@ describe("{{description}}", () => {
 
   it("should do XYZ", async () => {
     await game.classicMode.startBattle([SpeciesId.FEEBAS]);
+
     game.move.use(MoveId.SPLASH);
     await game.toEndOfTurn();
 


### PR DESCRIPTION
=## What are the changes the user will see?

## Why am I making these changes?
the newline in the test boilerplate script bothered me and @DayKev agreed

## What are the changes from a developer perspective?
removed the demon within our ranks - the hideous extra newline has been vanquished

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)