### PR TITLE
[Balance] Add wild encounter chance to Maushold and Dudunsparce forms

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1635,6 +1635,9 @@ export default class BattleScene extends SceneBase {
       case SpeciesId.TATSUGIRI:
       case SpeciesId.PALDEA_TAUROS:
         return randSeedInt(species.forms.length);
+      case SpeciesId.MAUSHOLD:
+      case SpeciesId.DUDUNSPARCE:
+        return !randSeedInt(4) ? 1 : 0;
       case SpeciesId.PIKACHU:
         if (this.currentBattle?.battleType === BattleType.TRAINER && this.currentBattle?.waveIndex < 30) {
           return 0; // Ban Cosplay and Partner Pika from Trainers before wave 30


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?
Family of three Maushold and three-segment Dudunsparce will be available in the wild and on trainers.

## Why am I making these changes?
Maushold and Dudunsparce forms were never available in the wild, while being available in mainline. This is probably an oversight due to their forms being added later in development. 

The forms were still available to the player evolving their Tandemaus and Dunsparce. 

The chance of 1/4 matches current evolve chance. 

## What are the changes from a developer perspective?

Just two new form species data in battle-scene.ts

## Screenshots/Videos

![image](https://github.com/user-attachments/assets/69d6280e-36de-49f9-90d8-90a59048f7b1)
Both Maushold forms in the wild

![image](https://github.com/user-attachments/assets/9b3e1ee8-9c20-4c21-8b8c-de24328fb722)
Both Dudunsparce forms in the wild
## How to test the changes?

```
const overrides = {
  OPP_SPECIES_OVERRIDE: SpeciesId.DUDUNSPARCE,
  STARTING_LEVEL_OVERRIDE: 1000
} satisfies Partial<InstanceType<OverridesType>>;
```

Replace Dudunsparce with Maushold. Play the game and encounter both forms. 

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [X] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?