### PR TITLE
[Bug] Fix Fog interactions with Morning Sun/Synthesis/Moonlight and Solar Beam/Blade

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -2156,6 +2156,7 @@ export class PlantHealAttr extends WeatherHealAttr {
       case WeatherType.SANDSTORM:
       case WeatherType.HAIL:
       case WeatherType.SNOW:
+      case WeatherType.FOG:
       case WeatherType.HEAVY_RAIN:
         return 0.25;
       default:
@@ -4157,6 +4158,7 @@ export class AntiSunlightPowerDecreaseAttr extends VariablePowerAttr {
         case WeatherType.SANDSTORM:
         case WeatherType.HAIL:
         case WeatherType.SNOW:
+        case WeatherType.FOG:
         case WeatherType.HEAVY_RAIN:
           power.value *= 0.5;
           return true;


### PR DESCRIPTION
## What are the changes the user will see?
Fog will now properly decrease the healing of Morning Sun/Synthesis/Moonlight and half the power of Solar Blade/Beam

## Why am I making these changes?
Incorrect behavior.
https://bulbapedia.bulbagarden.net/wiki/Fog

## What are the changes from a developer perspective?
Added Fog to two weather lists

## Screenshots/Videos

## How to test the changes?
Overrides

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?