### PR TITLE
[BUG] Removed empty modifierPool

### DIFF
--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -2393,8 +2393,6 @@ export interface ModifierPool {
   [tier: string]: WeightedModifierType[];
 }
 
-const modifierPool: ModifierPool = {};
-
 let modifierPoolThresholds = {};
 let ignoredPoolIndexes = {};
 
@@ -2859,7 +2857,7 @@ function getNewModifierTypeOption(
     }
 
     tier += upgradeCount;
-    while (tier && (!modifierPool.hasOwnProperty(tier) || !modifierPool[tier].length)) {
+    while (tier && (!pool.hasOwnProperty(tier) || !pool[tier].length)) {
       tier--;
       if (upgradeCount) {
         upgradeCount--;
@@ -2870,7 +2868,7 @@ function getNewModifierTypeOption(
     if (tier < ModifierTier.MASTER && allowLuckUpgrades) {
       const partyLuckValue = getPartyLuckValue(party);
       const upgradeOdds = Math.floor(128 / ((partyLuckValue + 4) / 4));
-      while (modifierPool.hasOwnProperty(tier + upgradeCount + 1) && modifierPool[tier + upgradeCount + 1].length) {
+      while (pool.hasOwnProperty(tier + upgradeCount + 1) && pool[tier + upgradeCount + 1].length) {
         if (randSeedInt(upgradeOdds) < 4) {
           upgradeCount++;
         } else {
@@ -2920,6 +2918,7 @@ function getNewModifierTypeOption(
 }
 
 export function getDefaultModifierTypeForTier(tier: ModifierTier): ModifierType {
+  const modifierPool = getModifierPoolForType(ModifierPoolType.PLAYER);
   let modifierType: ModifierType | WeightedModifierType = modifierPool[tier || ModifierTier.COMMON][0];
   if (modifierType instanceof WeightedModifierType) {
     modifierType = (modifierType as WeightedModifierType).modifierType;


### PR DESCRIPTION
## Why am I making these changes?
The last refactor #5964 has moved around some modifier code and inadvertently caused modifier rewards to never be ugraded due to luck. This PR fixes that.

## What are the changes from a developer perspective?
The code for modifier pools has been moved away from modifier-types.ts, but a definition of an empty `const modifierPool: ModifierPool = {};` was left. It is now removed.

The function `getNewModifierTypeOption` correctly used `const pool = getModifierPoolForType(poolType);` to get the pool, but then referenced `modifierPool` instead of `pool`. This caused the function to look at the now empty pool, and checks failing.

The function `getDefaultModifierTypeForTier` did something similar and has been replaced accordingly.


## Screenshots/Videos
![upgrades](https://github.com/user-attachments/assets/3722318b-d1c5-411c-8ff9-8b29223c9270)

Upgrades showing up again in endless



## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?