### PR TITLE
[Bug] Fix zombie pokemon in Fun+Games ME

### DIFF
--- a/src/data/mystery-encounters/encounters/fun-and-games-encounter.ts
+++ b/src/data/mystery-encounters/encounters/fun-and-games-encounter.ts
@@ -408,7 +408,7 @@ function summonPlayerPokemonAnimation(pokemon: PlayerPokemon): Promise<void> {
               onComplete: () => {
                 pokemon.cry(pokemon.getHpRatio() > 0.25 ? undefined : { rate: 0.85 });
                 pokemon.getSprite().clearTint();
-                pokemon.resetSummonData();
+                pokemon.fieldSetup(true);
                 globalScene.time.delayedCall(1000, () => {
                   if (pokemon.isShiny()) {
                     globalScene.unshiftPhase(new ShinySparklePhase(pokemon.getBattlerIndex()));


### PR DESCRIPTION
## What are the changes the user will see?
User pokemon will no longer be stuck unable to move during the Wobuffet ME

## Why am I making these changes?
Fixes https://discord.com/channels/1125469663833370665/1373765846458962083

## What are the changes from a developer perspective?
In #5829 `resetSummonData` was split into two functions because of issues revealed by the Cud Chew PR. Because of code duplication, F+G had a `resetSummonData` call left over which needed to be `fieldSetup`. The actual reason for the zombie behavior is that `switchOutStatus` was not reset

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?
Override to wave 10 with the Fun and Games encounter; ensure that after clearing the wave and advancing to the ME that it works as expected

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?
