### PR TITLE
[Bug] Fix infinite memory mushrooms

### DIFF
--- a/src/phases/select-modifier-phase.ts
+++ b/src/phases/select-modifier-phase.ts
@@ -134,7 +134,7 @@ export class SelectModifierPhase extends BattlePhase {
       return true;
     }
     const modifierType = this.typeOptions[cursor].type;
-    return this.applyChosenModifier(modifierType, 0, modifierSelectCallback);
+    return this.applyChosenModifier(modifierType, -1, modifierSelectCallback);
   }
 
   // Pick a modifier from the shop and apply it
@@ -260,8 +260,13 @@ export class SelectModifierPhase extends BattlePhase {
     return false;
   }
 
-  // Applies the effects of the chosen modifier
-  private applyModifier(modifier: Modifier, cost = 0, playSound = false): void {
+  /**
+   * Apply the effects of the chosen modifier
+   * @param modifier - The modifier to apply
+   * @param cost - The cost of the modifier if it was purchased, or -1 if selected as the modifier reward
+   * @param playSound - Whether the 'obtain modifier' sound should be played when adding the modifier.
+   */
+  private applyModifier(modifier: Modifier, cost = -1, playSound = false): void {
     const result = globalScene.addModifier(modifier, false, playSound, undefined, undefined, cost);
     // Queue a copy of this phase when applying a TM or Memory Mushroom.
     // If the player selects either of these, then escapes out of consuming them,

--- a/src/phases/select-modifier-phase.ts
+++ b/src/phases/select-modifier-phase.ts
@@ -275,7 +275,7 @@ export class SelectModifierPhase extends BattlePhase {
       globalScene.phaseManager.unshiftPhase(this.copy());
     }
 
-    if (cost && !(modifier.type instanceof RememberMoveModifierType)) {
+    if (cost !== -1 && !(modifier.type instanceof RememberMoveModifierType)) {
       if (result) {
         if (!Overrides.WAIVE_ROLL_FEE_OVERRIDE) {
           globalScene.money -= cost;


### PR DESCRIPTION
## What are the changes the user will see?
Users will no longer be able to infinitely select memory mushrooms in the modifier select screen.

## Why am I making these changes?
Fixes https://discord.com/channels/1125469663833370665/1383787265729495110/1383787265729495110

## What are the changes from a developer perspective?
#5886 introduced an oversight where the `cost` for the selected modifiers (versus purchased modifiers) was set to 0.
The memory mushroom was using a comparison against `-1` to discern whether the modifier was purchased or selected in order to decide whether to progress to the next phase (if a move was forgotten) or to return to the modifier select screen.

Actually, while it was using a -1 check for cost, to discern it, in reality what was happening is that `undefined` was being assigned to cost for modifiers that were selected and not purchased. This caused an issue elsewhere in the `if` condition to apply modifiers when I set it back to -1, as -1 is truthy. So I had to adjust the conditional there to check against >0.

## Screenshots/Videos

<details><summary>Selecting memory mushroom now continues to next phase</summary>

https://github.com/user-attachments/assets/3907e58b-e595-4959-bbb4-3b65c89678d6
</details>


## How to test the changes?
Use these overrides, and choose a mon that can have moves to re-learn. (This is why I set starting level to 100).
Defeat the opponent and select the memory mushroom. Verify that re-learning a move does not take you back to the select-modifier-phase and instead continues to the next wave.

```ts
const overrides = {
  STARTING_LEVEL_OVERRIDE: 100,
  ITEM_REWARD_OVERRIDE: [
    {name: "MEMORY_MUSHROOM"}
  ]
} satisfies Partial<InstanceType<OverridesType>>;
```



## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes? I don't want to write tests for modifiers while there's a pending rework.
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~