### PR TITLE
[i18n] Map "biome" namespace to the filename change to "biomes"

### DIFF
--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -101,6 +101,7 @@ const namespaceMap = {
   doubleBattleDialogue: "dialogue-double-battle",
   splashMessages: "splash-texts",
   mysteryEncounterMessages: "mystery-encounter-texts",
+  biome: "biomes",
 };
 
 //#region Functions


### PR DESCRIPTION
## What are the changes the user will see?
An update to the locales submodule is included as it is necessary.

## Why am I making these changes?
Our code linter + formatter (Biome) expects that any file named "biome.json" is a config file, but our locales had files named "biome.json" that were not config files for Biome. They have been renamed "biomes.json" to prevent them from being erroneously considered as config files.

## What are the changes from a developer perspective?
There should be no change to the development experience, "biome" should still be a valid locales namespace as it has been mapped to the file rename to prevent the need for any change from developers.

## Screenshots/Videos
![image](https://github.com/user-attachments/assets/1fabbcf2-9543-4cec-be8e-f6c56b549ed7)

## How to test the changes?
Load up any run to ensure the biome name is still properly localized.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?

Are there any localization additions or changes? If so:
- [x] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [x] If so, please leave a link to it here: https://github.com/pagefaultgames/pokerogue-locales/pull/186
- [x] Has the translation team been contacted for proofreading/translation?
