### PR TITLE
[UI/UX] Fix button and input field overlaps

### DIFF
--- a/src/ui/form-modal-ui-handler.ts
+++ b/src/ui/form-modal-ui-handler.ts
@@ -71,6 +71,10 @@ export abstract class FormModalUiHandler extends ModalUiHandler {
       (hasTitle ? 31 : 5) + 20 * (config.length - 1) + 16 + this.getButtonTopMargin(),
       "",
       TextStyle.TOOLTIP_CONTENT,
+      {
+        fontSize: "42px",
+        wordWrap: { width: 850 },
+      },
     );
     this.errorMessage.setColor(this.getTextColor(TextStyle.SUMMARY_PINK));
     this.errorMessage.setShadowColor(this.getTextColor(TextStyle.SUMMARY_PINK, true));
@@ -83,20 +87,29 @@ export abstract class FormModalUiHandler extends ModalUiHandler {
     this.inputs = [];
     this.formLabels = [];
     fieldsConfig.forEach((config, f) => {
-      const label = addTextObject(10, (hasTitle ? 31 : 5) + 20 * f, config.label, TextStyle.TOOLTIP_CONTENT);
+      // The Pokédex Scan Window has a much bigger width, so there is currently no need to shorten the label
+      const label = addTextObject(
+        10,
+        (hasTitle ? 31 : 5) + 20 * f,
+        config.label.length > 25 && this.constructor.name !== "PokedexScanUiHandler"
+          ? config.label.slice(0, 20) + "..."
+          : config.label,
+        TextStyle.TOOLTIP_CONTENT,
+      );
       label.name = "formLabel" + f;
 
       this.formLabels.push(label);
       this.modalContainer.add(this.formLabels[this.formLabels.length - 1]);
 
-      const inputContainer = globalScene.add.container(70, (hasTitle ? 28 : 2) + 20 * f);
+      const inputWidth = label.width < 320 ? 80 : 80 - (label.width - 320) / 5.5;
+      const inputContainer = globalScene.add.container(70 + (80 - inputWidth), (hasTitle ? 28 : 2) + 20 * f);
       inputContainer.setVisible(false);
 
-      const inputBg = addWindow(0, 0, 80, 16, false, false, 0, 0, WindowVariant.XTHIN);
+      const inputBg = addWindow(0, 0, inputWidth, 16, false, false, 0, 0, WindowVariant.XTHIN);
 
       const isPassword = config?.isPassword;
       const isReadOnly = config?.isReadOnly;
-      const input = addTextInputObject(4, -2, 440, 116, TextStyle.TOOLTIP_CONTENT, {
+      const input = addTextInputObject(4, -2, inputWidth * 5.5, 116, TextStyle.TOOLTIP_CONTENT, {
         type: isPassword ? "password" : "text",
         maxLength: isPassword ? 64 : 20,
         readOnly: isReadOnly,

--- a/src/ui/modal-ui-handler.ts
+++ b/src/ui/modal-ui-handler.ts
@@ -151,7 +151,12 @@ export abstract class ModalUiHandler extends UiHandler {
   updateContainer(config?: ModalConfig): void {
     const [marginTop, marginRight, marginBottom, marginLeft] = this.getMargin(config);
 
-    const [width, height] = [this.getWidth(config), this.getHeight(config)];
+    /**
+     * If the total amount of characters for the 2 buttons exceeds ~30 characters,
+     * the width in `registration-form-ui-handler.ts` and `login-form-ui-handler.ts` needs to be increased.
+     */
+    const width = this.getWidth(config);
+    const height = this.getHeight(config);
     this.modalContainer.setPosition(
       (globalScene.game.canvas.width / 6 - (width + (marginRight - marginLeft))) / 2,
       (-globalScene.game.canvas.height / 6 - (height + (marginBottom - marginTop))) / 2,
@@ -165,10 +170,14 @@ export abstract class ModalUiHandler extends UiHandler {
     this.titleText.setX(width / 2);
     this.titleText.setVisible(!!title);
 
-    for (let b = 0; b < this.buttonContainers.length; b++) {
-      const sliceWidth = width / (this.buttonContainers.length + 1);
-
-      this.buttonContainers[b].setPosition(sliceWidth * (b + 1), this.modalBg.height - (this.buttonBgs[b].height + 8));
+    if (this.buttonContainers.length > 0) {
+      const spacing = 12;
+      const totalWidth = this.buttonBgs.reduce((sum, bg) => sum + bg.width, 0) + spacing * (this.buttonBgs.length - 1);
+      let x = (this.modalBg.width - totalWidth) / 2;
+      this.buttonContainers.forEach((container, i) => {
+        container.setPosition(x + this.buttonBgs[i].width / 2, this.modalBg.height - (this.buttonBgs[i].height + 8));
+        x += this.buttonBgs[i].width + spacing;
+      });
     }
   }
 

--- a/src/ui/pokedex-scan-ui-handler.ts
+++ b/src/ui/pokedex-scan-ui-handler.ts
@@ -160,8 +160,11 @@ export default class PokedexScanUiHandler extends FormModalUiHandler {
 
     if (super.show(args)) {
       const config = args[0] as ModalConfig;
-      this.inputs[0].resize(1150, 116);
-      this.inputContainers[0].list[0].width = 200;
+      const label = this.formLabels[0];
+
+      const inputWidth = label.width < 420 ? 200 : 200 - (label.width - 420) / 5.75;
+      this.inputs[0].resize(inputWidth * 5.75, 116);
+      this.inputContainers[0].list[0].width = inputWidth;
       if (args[1] && typeof (args[1] as PlayerPokemon).getNameToRender === "function") {
         this.inputs[0].text = (args[1] as PlayerPokemon).getNameToRender();
       } else {

--- a/src/ui/registration-form-ui-handler.ts
+++ b/src/ui/registration-form-ui-handler.ts
@@ -7,19 +7,6 @@ import i18next from "i18next";
 import { pokerogueApi } from "#app/plugins/api/pokerogue-api";
 import { globalScene } from "#app/global-scene";
 
-interface LanguageSetting {
-  inputFieldFontSize?: string;
-  warningMessageFontSize?: string;
-  errorMessageFontSize?: string;
-}
-
-const languageSettings: { [key: string]: LanguageSetting } = {
-  "es-ES": {
-    inputFieldFontSize: "50px",
-    errorMessageFontSize: "40px",
-  },
-};
-
 export default class RegistrationFormUiHandler extends FormModalUiHandler {
   getModalTitle(_config?: ModalConfig): string {
     return i18next.t("menu:register");
@@ -34,7 +21,7 @@ export default class RegistrationFormUiHandler extends FormModalUiHandler {
   }
 
   getButtonTopMargin(): number {
-    return 8;
+    return 12;
   }
 
   getButtonLabels(_config?: ModalConfig): string[] {
@@ -75,18 +62,9 @@ export default class RegistrationFormUiHandler extends FormModalUiHandler {
   setup(): void {
     super.setup();
 
-    this.modalContainer.list.forEach((child: Phaser.GameObjects.GameObject) => {
-      if (child instanceof Phaser.GameObjects.Text && child !== this.titleText) {
-        const inputFieldFontSize = languageSettings[i18next.resolvedLanguage!]?.inputFieldFontSize;
-        if (inputFieldFontSize) {
-          child.setFontSize(inputFieldFontSize);
-        }
-      }
-    });
-
-    const warningMessageFontSize = languageSettings[i18next.resolvedLanguage!]?.warningMessageFontSize ?? "42px";
     const label = addTextObject(10, 87, i18next.t("menu:registrationAgeWarning"), TextStyle.TOOLTIP_CONTENT, {
-      fontSize: warningMessageFontSize,
+      fontSize: "42px",
+      wordWrap: { width: 850 },
     });
 
     this.modalContainer.add(label);
@@ -106,10 +84,6 @@ export default class RegistrationFormUiHandler extends FormModalUiHandler {
           const onFail = error => {
             globalScene.ui.setMode(UiMode.REGISTRATION_FORM, Object.assign(config, { errorMessage: error?.trim() }));
             globalScene.ui.playError();
-            const errorMessageFontSize = languageSettings[i18next.resolvedLanguage!]?.errorMessageFontSize;
-            if (errorMessageFontSize) {
-              this.errorMessage.setFontSize(errorMessageFontSize);
-            }
           };
           if (!this.inputs[0].text) {
             return onFail(i18next.t("menu:emptyUsername"));


### PR DESCRIPTION
## What are the changes the user will see?

- There won't be any overlaps involving input fields in some languages
- There won't be any button overlaps in the registration screen anymore
- Age warning has a word wrap now instead of going over window

### These Languages were impacted:
Registration screen:
- ca
- de
- en (slightly)
- es-MX
- it
- pt-BR (slightly)
- ru

Pokedex scan:
name: es-ES, es-MX,
move: es-ES, es-MX, de (slightly)
ability: es-ES, es-MX, de, ru
passive: es-ES, es-MX, de (slightly)

## Why am I making these changes?

When I wanted to create a Beta account i noticed, the button in the registration screen where overlaping in german

## What are the changes from a developer perspective?

- Input fields don't have a hardcoded width anymore
- Login/Registration buttons have a fixed sapcing to prevent overlaps
- es-ES doesn't need a custom fontsize in the registration screen anymore

## Screenshots/Videos

### Registration Screen examples
<details><summary>ca</summary><details><summary>before</summary>

![ca-reg-before](https://github.com/user-attachments/assets/566b8de1-cd5c-440e-a85a-6df13cb24fc0)

</details><details><summary>after</summary>

![ca-reg-after](https://github.com/user-attachments/assets/6cecd06a-a582-472f-9637-4b8957eaaf0c)

</details></details><details><summary>de</summary><details><summary>before</summary>

![de-reg-before](https://github.com/user-attachments/assets/17cf30ba-2a8f-4085-9434-095bf6feacd6)

</details><details><summary>after</summary>

![de-reg-after](https://github.com/user-attachments/assets/494a9ebc-8a6a-4e94-8f68-12aafcb0d5c3)

</details></details>

### Pokédex scan examples

<details><summary>es-ES</summary><details><summary>before</summary>

![es-ES-move-before](https://github.com/user-attachments/assets/78684d95-f875-4d28-989e-5c89ed9e9c60)

</details><details><summary>after</summary>

![es-ES-move-after](https://github.com/user-attachments/assets/506d6b51-5bad-48ab-a7ad-dd1fb49885c5)

</details></details>

## How to test the changes?

load any of the languages mentioned above

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  ~~- [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?
