### PR TITLE
[Bug] Remove message for Rock Head activation

### DIFF
--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -306,13 +306,6 @@ export class BlockRecoilDamageAttr extends AbAttr {
   ): void {
     cancelled.value = true;
   }
-
-  getTriggerMessage(pokemon: Pokemon, abilityName: string, ..._args: any[]) {
-    return i18next.t("abilityTriggers:blockRecoilDamage", {
-      pokemonName: getPokemonNameWithAffix(pokemon),
-      abilityName: abilityName,
-    });
-  }
 }
 
 /**


### PR DESCRIPTION
## What are the changes the user will see?
Rock Head will no longer have a message.

## Why am I making these changes?
Rock Head should not have a message (it doesn't in mainline) and it's annoying for players.

## What are the changes from a developer perspective?
Removed `BlockRecoilDamageAttr#getTriggerMessage`.

## How to test the changes?
Use a recoil move with a pokemon with Rock Head.
```ts
const overrides = {
  ABILITY_OVERRIDE: AbilityId.ROCK_HEAD,
  MOVESET_OVERRIDE: MoveId.FLARE_BLITZ,
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?