### PR TITLE
[i18n] Large Numbers Abbreviations Translation

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -201,7 +201,7 @@ export function formatLargeNumber(count: number, threshold: number): string {
   let suffix = "";
   switch (Math.ceil(ret.length / 3) - 1) {
     case 1:
-      suffix = i18next.t("common:abrK");
+      suffix = i18next.t("common:abrThousand");
       break;
     case 2:
       suffix = i18next.t("common:abrMillion");
@@ -230,7 +230,7 @@ export function formatLargeNumber(count: number, threshold: number): string {
 function getAbbreviationsLargeNumber(): string[] {
   return [
     "",
-    i18next.t("common:abrK"),
+    i18next.t("common:abrThousand"),
     i18next.t("common:abrMillion"),
     i18next.t("common:abrBillion"),
     i18next.t("common:abrTrillion"),

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -201,19 +201,19 @@ export function formatLargeNumber(count: number, threshold: number): string {
   let suffix = "";
   switch (Math.ceil(ret.length / 3) - 1) {
     case 1:
-      suffix = "K";
+      suffix = i18next.t("common:abrK");
       break;
     case 2:
-      suffix = "M";
+      suffix = i18next.t("common:abrMillion");
       break;
     case 3:
-      suffix = "B";
+      suffix = i18next.t("common:abrBillion");
       break;
     case 4:
-      suffix = "T";
+      suffix = i18next.t("common:abrTrillion");
       break;
     case 5:
-      suffix = "q";
+      suffix = i18next.t("common:abrQuadrillion");
       break;
     default:
       return "?";
@@ -227,15 +227,31 @@ export function formatLargeNumber(count: number, threshold: number): string {
 }
 
 // Abbreviations from 10^0 to 10^33
-const AbbreviationsLargeNumber: string[] = ["", "K", "M", "B", "t", "q", "Q", "s", "S", "o", "n", "d"];
+function getAbbreviationsLargeNumber(): string[] {
+  return [
+    "",
+    i18next.t("common:abrK"),
+    i18next.t("common:abrMillion"),
+    i18next.t("common:abrBillion"),
+    i18next.t("common:abrTrillion"),
+    i18next.t("common:abrQuadrillion"),
+    i18next.t("common:abrQuintillion"),
+    i18next.t("common:abrSextillion"),
+    i18next.t("common:abrSeptillion"),
+    i18next.t("common:abrOctillion"),
+    i18next.t("common:abrNonillion"),
+    i18next.t("common:abrDecillion"),
+  ];
+}
 
 export function formatFancyLargeNumber(number: number, rounded = 3): string {
+  const abbreviations = getAbbreviationsLargeNumber();
   let exponent: number;
 
   if (number < 1000) {
     exponent = 0;
   } else {
-    const maxExp = AbbreviationsLargeNumber.length - 1;
+    const maxExp = abbreviations.length - 1;
 
     exponent = Math.floor(Math.log(number) / Math.log(1000));
     exponent = Math.min(exponent, maxExp);
@@ -243,7 +259,7 @@ export function formatFancyLargeNumber(number: number, rounded = 3): string {
     number /= Math.pow(1000, exponent);
   }
 
-  return `${(exponent === 0) || number % 1 === 0 ? number : number.toFixed(rounded)}${AbbreviationsLargeNumber[exponent]}`;
+  return `${(exponent === 0 || number % 1 === 0) ? number : number.toFixed(rounded)}${abbreviations[exponent]}`;
 }
 
 export function formatMoney(format: MoneyFormat, amount: number) {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -259,7 +259,7 @@ export function formatFancyLargeNumber(number: number, rounded = 3): string {
     number /= Math.pow(1000, exponent);
   }
 
-  return `${(exponent === 0 || number % 1 === 0) ? number : number.toFixed(rounded)}${abbreviations[exponent]}`;
+  return `${exponent === 0 || number % 1 === 0 ? number : number.toFixed(rounded)}${abbreviations[exponent]}`;
 }
 
 export function formatMoney(format: MoneyFormat, amount: number) {


### PR DESCRIPTION
## What are the changes the user will see?
See abbreviations transalated

## Why am I making these changes?
To have these translatable

## What are the changes from a developer perspective?
None

## Screenshots/Videos
BEFORE (French)
![image](https://github.com/user-attachments/assets/19b3b5ef-0394-4064-b633-63920fb22c83)

AFTER (French)
![image](https://github.com/user-attachments/assets/4728449e-f75d-49a6-8148-51653d06c499)

## How to test the changes?
```
  readonly STARTING_MONEY_OVERRIDE: number = 1520000000;
```

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [X] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [X] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [X] If so, please leave a link to it here: https://github.com/pagefaultgames/pokerogue-locales/pull/190
- [X] Has the translation team been contacted for proofreading/translation?
