### PR TITLE
[Dev] Mark the fixer for Biome's `useBlockStatements` as "safe"

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -70,7 +70,10 @@
       },
       "style": {
         "useEnumInitializers": "off", // large enums like Moves/Species would make this cumbersome
-        "useBlockStatements": "error",
+        "useBlockStatements": {
+          "level": "error",
+          "fix": "safe"
+        },
         "useConst": "error",
         "useImportType": "error",
         "noNonNullAssertion": "off", // TODO: Turn this on ASAP and fix all non-null assertions in non-test files


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Improved developer experience.

## What are the changes from a developer perspective?
Biome's `lint/style/useBlockStatements` rule will automatically be applied without the developer needing to manually apply the fix (either in the IDE or by adding the `--unsafe` flag when running Biome from the command line).

## How to test the changes?
Put `if (globalScene) console.log("test");` in some file and run `pnpm biome` (or `pnpm exec biome check --write path/to/file.ts`). If you have your IDE configured to automatically apply Biome on saving a file then it should automatically be modified without you needing to run Biome from the command line.
```ts
// this
if (globalScene) console.log("test");

// should become this
if (globalScene) {
  console.log("test");
}
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?