### PR TITLE
[i18n] [Localization] Translatable Manaphy Egg Tier

### DIFF
--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -294,7 +294,7 @@ export class Egg {
 
   public getEggDescriptor(): string {
     if (this.isManaphyEgg()) {
-      return "Manaphy";
+      return i18next.t("egg:manaphyTier");
     }
     switch (this.tier) {
       case EggTier.RARE:


### PR DESCRIPTION
## What are the changes the user will see?
"Manaphy" Egg Tier translated in their own languages (visible only in non-latin alphabet languages)

## Why am I making these changes?
To have it translated

## What are the changes from a developer perspective?
None

## Screenshots/Videos
BEFORE (Japanese)
![image](https://github.com/user-attachments/assets/3464a7df-7f52-4d74-b9e4-45ef9acda6c5)

AFTER (Japanese)
![image](https://github.com/user-attachments/assets/52b9199e-982c-4005-8773-6deda009a9af)

## How to test the changes?
Play in a non-latin alphabet language and grab a Manaphy Egg

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [X] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [X] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [X] If so, please leave a link to it here: https://github.com/pagefaultgames/pokerogue-locales/pull/191
- [X] Has the translation team been contacted for proofreading/translation?
