### PR TITLE
[Bug] Fix Shields Down blocking status in Core Form, unnecessarily resetting before battle

### DIFF
--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -7334,7 +7334,7 @@ export function initAbilities() {
       .unreplaceable()
       .unsuppressable()
       .bypassFaint(),
-    new Ability(AbilityId.POWER_CONSTRUCT,
+    new Ability(AbilityId.POWER_CONSTRUCT, 7)
       // Change to 10% complete or 50% complete on switchout/turn end if at <50% HP;
       // revert to 10% PC or 50% PC before a new battle starts
       // TODO: Should this revert the form change even if it would re-activate on summon?

--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -7263,12 +7263,13 @@ export function initAbilities() {
     new Ability(AbilityId.MERCILESS, 7)
       .attr(ConditionalCritAbAttr, (_user, target, _move) => target?.status?.effect === StatusEffect.TOXIC || target?.status?.effect === StatusEffect.POISON),
     new Ability(AbilityId.SHIELDS_DOWN, 7, -1)
-      // Change into Meteor Form on switch-in or turn end with HP >= 50%,
-      // or Core Form with HP <= 50%.
+      // Change into Meteor Form on switch-in or turn end if HP >= 50%,
+      // or Core Form if HP <= 50%.
       .attr(PostSummonFormChangeAbAttr, p => p.formIndex % 7 + (p.getHpRatio() <= 0.5 ? 7 : 0))
       .attr(PostTurnFormChangeAbAttr, p => p.formIndex % 7 + (p.getHpRatio() <= 0.5 ? 7 : 0))
-      .conditionalAttr(p => p.formIndex !== 7, StatusEffectImmunityAbAttr)
-      .conditionalAttr(p => p.formIndex !== 7, BattlerTagImmunityAbAttr, BattlerTagType.DROWSY)
+      // All variants of Meteor Form are immune to status effects & Yawn
+      .conditionalAttr(p => p.formIndex < 7, StatusEffectImmunityAbAttr)
+      .conditionalAttr(p => p.formIndex < 7, BattlerTagImmunityAbAttr, BattlerTagType.DROWSY)
       .attr(NoFusionAbilityAbAttr)
       .attr(NoTransformAbilityAbAttr)
       .uncopiable()

--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -7265,6 +7265,7 @@ export function initAbilities() {
     new Ability(AbilityId.SHIELDS_DOWN, 7, -1)
       // Change into Meteor Form on switch-in or turn end if HP >= 50%,
       // or Core Form if HP <= 50%.
+      .attr(PostBattleInitFormChangeAbAttr, p => p.formIndex % 7)
       .attr(PostSummonFormChangeAbAttr, p => p.formIndex % 7 + (p.getHpRatio() <= 0.5 ? 7 : 0))
       .attr(PostTurnFormChangeAbAttr, p => p.formIndex % 7 + (p.getHpRatio() <= 0.5 ? 7 : 0))
       // All variants of Meteor Form are immune to status effects & Yawn
@@ -7337,7 +7338,6 @@ export function initAbilities() {
     new Ability(AbilityId.POWER_CONSTRUCT, 7)
       // Change to 10% complete or 50% complete on switchout/turn end if at <50% HP;
       // revert to 10% PC or 50% PC before a new battle starts
-      // TODO: Should this revert the form change even if it would re-activate on summon?
       .conditionalAttr(p => p.formIndex === 4 || p.formIndex === 5, PostBattleInitFormChangeAbAttr, p => p.formIndex - 2)
       .conditionalAttr(p => p.getHpRatio() <= 0.5 && (p.formIndex === 2 || p.formIndex === 3), PostSummonFormChangeAbAttr, p => p.formIndex + 2)
       .conditionalAttr(p => p.getHpRatio() <= 0.5 && (p.formIndex === 2 || p.formIndex === 3), PostTurnFormChangeAbAttr, p => p.formIndex + 2)

--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -7263,7 +7263,8 @@ export function initAbilities() {
     new Ability(AbilityId.MERCILESS, 7)
       .attr(ConditionalCritAbAttr, (_user, target, _move) => target?.status?.effect === StatusEffect.TOXIC || target?.status?.effect === StatusEffect.POISON),
     new Ability(AbilityId.SHIELDS_DOWN, 7, -1)
-      .attr(PostBattleInitFormChangeAbAttr, () => 0)
+      // Change into Meteor Form on switch-in or turn end with HP >= 50%,
+      // or Core Form with HP <= 50%.
       .attr(PostSummonFormChangeAbAttr, p => p.formIndex % 7 + (p.getHpRatio() <= 0.5 ? 7 : 0))
       .attr(PostTurnFormChangeAbAttr, p => p.formIndex % 7 + (p.getHpRatio() <= 0.5 ? 7 : 0))
       .conditionalAttr(p => p.formIndex !== 7, StatusEffectImmunityAbAttr)
@@ -7333,6 +7334,9 @@ export function initAbilities() {
       .unsuppressable()
       .bypassFaint(),
     new Ability(AbilityId.POWER_CONSTRUCT, 7)
+      // Change to 10% PC or 50% PC after battle ends,
+      // change to 10% complete or 50% complete on switchout/turn end if at <50% HP
+      // TODO: change condition functions to remove duplicate changes
       .conditionalAttr(pokemon => pokemon.formIndex === 2 || pokemon.formIndex === 4, PostBattleInitFormChangeAbAttr, () => 2)
       .conditionalAttr(pokemon => pokemon.formIndex === 3 || pokemon.formIndex === 5, PostBattleInitFormChangeAbAttr, () => 3)
       .conditionalAttr(pokemon => pokemon.formIndex === 2 || pokemon.formIndex === 4, PostSummonFormChangeAbAttr, p => p.getHpRatio() <= 0.5 || p.getFormKey() === "complete" ? 4 : 2)

--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -7334,16 +7334,13 @@ export function initAbilities() {
       .unreplaceable()
       .unsuppressable()
       .bypassFaint(),
-    new Ability(AbilityId.POWER_CONSTRUCT, 7)
-      // Change to 10% PC or 50% PC after battle ends,
-      // change to 10% complete or 50% complete on switchout/turn end if at <50% HP
-      // TODO: change condition functions to remove duplicate changes
-      .conditionalAttr(pokemon => pokemon.formIndex === 2 || pokemon.formIndex === 4, PostBattleInitFormChangeAbAttr, () => 2)
-      .conditionalAttr(pokemon => pokemon.formIndex === 3 || pokemon.formIndex === 5, PostBattleInitFormChangeAbAttr, () => 3)
-      .conditionalAttr(pokemon => pokemon.formIndex === 2 || pokemon.formIndex === 4, PostSummonFormChangeAbAttr, p => p.getHpRatio() <= 0.5 || p.getFormKey() === "complete" ? 4 : 2)
-      .conditionalAttr(pokemon => pokemon.formIndex === 2 || pokemon.formIndex === 4, PostTurnFormChangeAbAttr, p => p.getHpRatio() <= 0.5 || p.getFormKey() === "complete" ? 4 : 2)
-      .conditionalAttr(pokemon => pokemon.formIndex === 3 || pokemon.formIndex === 5, PostSummonFormChangeAbAttr, p => p.getHpRatio() <= 0.5 || p.getFormKey() === "10-complete" ? 5 : 3)
-      .conditionalAttr(pokemon => pokemon.formIndex === 3 || pokemon.formIndex === 5, PostTurnFormChangeAbAttr, p => p.getHpRatio() <= 0.5 || p.getFormKey() === "10-complete" ? 5 : 3)
+    new Ability(AbilityId.POWER_CONSTRUCT,
+      // Change to 10% complete or 50% complete on switchout/turn end if at <50% HP;
+      // revert to 10% PC or 50% PC before a new battle starts
+      // TODO: Should this revert the form change even if it would re-activate on summon?
+      .conditionalAttr(p => p.formIndex === 4 || p.formIndex === 5, PostBattleInitFormChangeAbAttr, p => p.formIndex - 2)
+      .conditionalAttr(p => p.getHpRatio() <= 0.5 && (p.formIndex === 2 || p.formIndex === 3), PostSummonFormChangeAbAttr, p => p.formIndex + 2)
+      .conditionalAttr(p => p.getHpRatio() <= 0.5 && (p.formIndex === 2 || p.formIndex === 3), PostTurnFormChangeAbAttr, p => p.formIndex + 2)
       .attr(NoFusionAbilityAbAttr)
       .uncopiable()
       .unreplaceable()


### PR DESCRIPTION
## What are the changes the user will see?
Shields down no longer blocks status setting in non-Red Core Forms
Shields Down no longer shows reset popup when it shouldn't 

## Why am I making these changes?
Bugfix

## What are the changes from a developer perspective?
Fixed conditionla to be less jank
Also cleaned up power construct `conditionalAttr`s (dw, it's around 4 locs)

## Screenshots/Videos
DAMO PLS HALP IM ON MOBILE 

## How to test the changes?
HALP I'M ON MOBILE

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated  tests related to the PR's changes?
