### PR TITLE
[Bug] Fix anger point procing on every hit if first hit in multi hit was a crit

### DIFF
--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -1198,12 +1198,12 @@ export class PostDefendContactApplyTagChanceAbAttr extends PostDefendAbAttr {
  * Set stat stages when the user gets hit by a critical hit
  *
  * @privateremarks
- * It is the responsibility of the caller to ensure that this ability is only applied
+ * It is the responsibility of the caller to ensure that this ability attribute is only applied
  * when the user has been hit by a critical hit; such an event is not checked here.
  *
  * @sealed
  */
-export class PostDefendCritStatStageChangeAbAttr extends AbAttr {
+export class PostReceiveCritStatStageChangeAbAttr extends AbAttr {
   private stat: BattleStat;
   private stages: number;
 
@@ -6420,7 +6420,7 @@ const AbilityAttrs = Object.freeze({
   PostDefendContactApplyStatusEffectAbAttr,
   EffectSporeAbAttr,
   PostDefendContactApplyTagChanceAbAttr,
-  PostDefendCritStatStageChangeAbAttr,
+  PostReceiveCritStatStageChangeAbAttr,
   PostDefendContactDamageAbAttr,
   PostDefendPerishSongAbAttr,
   PostDefendWeatherChangeAbAttr,
@@ -6889,7 +6889,7 @@ export function initAbilities() {
     new Ability(AbilityId.GLUTTONY, 4)
       .attr(ReduceBerryUseThresholdAbAttr),
     new Ability(AbilityId.ANGER_POINT, 4)
-      .attr(PostDefendCritStatStageChangeAbAttr, Stat.ATK, 12),
+      .attr(PostReceiveCritStatStageChangeAbAttr, Stat.ATK, 12),
     new Ability(AbilityId.UNBURDEN, 4)
       .attr(PostItemLostApplyBattlerTagAbAttr, BattlerTagType.UNBURDEN)
       .bypassFaint() // Allows reviver seed to activate Unburden

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -439,7 +439,7 @@ export class MoveEffectPhase extends PokemonPhase {
     applyAbAttrs("PostDefendAbAttr", params);
 
     if (wasCritical) {
-      applyAbAttrs("PostDefendCritStatStageChangeAbAttr", params);
+      applyAbAttrs("PostReceiveCritStatStageChangeAbAttr", params);
     }
     target.lapseTags(BattlerTagLapseType.AFTER_HIT);
   }

--- a/test/abilities/anger-point.test.ts
+++ b/test/abilities/anger-point.test.ts
@@ -1,4 +1,4 @@
-import { PostDefendCritStatStageChangeAbAttr } from "#app/data/abilities/ability";
+import { PostReceiveCritStatStageChangeAbAttr } from "#app/data/abilities/ability";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -55,7 +55,7 @@ describe("Ability - Anger Point", () => {
     await game.classicMode.startBattle([SpeciesId.FEEBAS]);
     const enemy = game.scene.getEnemyPokemon()!;
     vi.spyOn(enemy, "getCriticalHitResult").mockReturnValueOnce(true);
-    const angerPointSpy = vi.spyOn(PostDefendCritStatStageChangeAbAttr.prototype, "apply");
+    const angerPointSpy = vi.spyOn(PostReceiveCritStatStageChangeAbAttr.prototype, "apply");
     game.move.select(MoveId.BULLET_SEED);
     await game.phaseInterceptor.to("BerryPhase");
     expect(angerPointSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## What are the changes the user will see?
Fixes 2 bugs related to anger point:

1. Anger point will no longer constantly emit its application message when the first strike of a multi-hit move is a critical hit
2. Anger point will now correctly maximize the user's attack (previously only added +6)

## Why am I making these changes?
Fixes a bug related to anger point: https://discord.com/channels/1125469663833370665/1370628941060243466/1370628941060243466.

## What are the changes from a developer perspective?
Made `PostDefendCritStatStageAbAttr` no longer subclass `PostDefendAbAttr` so that it could be applied separately from the other `PostDefend` abilities in the move effect phase, particularly, conditioned on the attack being a critical hit.
This allowed me to remove the janky check that was going on in the ability.

I also adjusted the ability attribute to give a +12 boost (from +6).

Also added tests for anger point.

## Screenshots/Videos
Trigger circumstances are too annoying to force. Also why I haven't manually tested.


## How to test the changes?
``pnpm test:silent tests/abilities/anger-point.test.ts``

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~
