### PR TITLE
[Bug] [Move] Court Change now swaps Safeguard and Pledge Effects

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -10822,7 +10822,7 @@ export function initMoves() {
       .attr(FirstAttackDoublePowerAttr)
       .bitingMove(),
     new StatusMove(MoveId.COURT_CHANGE, PokemonType.NORMAL, 100, 10, -1, 0, 8)
-      .attr(SwapArenaTagsAttr, [ ArenaTagType.AURORA_VEIL, ArenaTagType.LIGHT_SCREEN, ArenaTagType.MIST, ArenaTagType.REFLECT, ArenaTagType.SPIKES, ArenaTagType.STEALTH_ROCK, ArenaTagType.STICKY_WEB, ArenaTagType.TAILWIND, ArenaTagType.TOXIC_SPIKES ]),
+      .attr(SwapArenaTagsAttr, [ ArenaTagType.AURORA_VEIL, ArenaTagType.LIGHT_SCREEN, ArenaTagType.MIST, ArenaTagType.REFLECT, ArenaTagType.SPIKES, ArenaTagType.STEALTH_ROCK, ArenaTagType.STICKY_WEB, ArenaTagType.TAILWIND, ArenaTagType.TOXIC_SPIKES, ArenaTagType.SAFEGUARD, ArenaTagType.FIRE_GRASS_PLEDGE, ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagType.GRASS_WATER_PLEDGE ]),
     /* Unused */
     new AttackMove(MoveId.MAX_FLARE, PokemonType.FIRE, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .target(MoveTarget.NEAR_ENEMY)

--- a/test/moves/court-change.test.ts
+++ b/test/moves/court-change.test.ts
@@ -1,0 +1,76 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import GameManager from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { Stat } from "#enums/stat";
+import { StatusEffect } from "#enums/status-effect";
+
+describe("Move - Court Change", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .criticalHits(false)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .startingLevel(100)
+      .battleStyle("double")
+      .enemyLevel(100);
+  });
+
+  it("Court Change should swap the swamp from the enemy to the own teams side ", async () => {
+    await game.classicMode.startBattle([SpeciesId.REGIELEKI, SpeciesId.SHUCKLE]);
+    const [regieleki, shuckle] = game.scene.getPlayerParty();
+    game.move.changeMoveset(regieleki, [MoveId.WATER_PLEDGE, MoveId.COURT_CHANGE, MoveId.SPLASH]);
+    game.move.changeMoveset(shuckle, [MoveId.GRASS_PLEDGE, MoveId.COURT_CHANGE, MoveId.SPLASH]);
+    const enemyPokemon = game.scene.getEnemyPokemon()!;
+
+    game.move.use(MoveId.WATER_PLEDGE, 0);
+    game.move.use(MoveId.GRASS_PLEDGE, 1);
+    await game.toEndOfTurn();
+
+    //enemy team will be in the swamp and slowed
+    expect(enemyPokemon.getEffectiveStat(Stat.SPD)).toBe(enemyPokemon.getStat(Stat.SPD) >> 2);
+
+    game.move.use(MoveId.COURT_CHANGE, 0);
+    game.move.use(MoveId.SPLASH, 1);
+    await game.toEndOfTurn();
+
+    //own team should now be in the swamp and slowed
+
+    expect(regieleki.getEffectiveStat(Stat.SPD)).toBe(regieleki.getStat(Stat.SPD) >> 2);
+  });
+
+  it("Court Change should swap safeguard to the enemy side ", async () => {
+    game.override.battleStyle("single").enemySpecies(SpeciesId.GRIMER).enemyMoveset(MoveId.TOXIC_THREAD);
+    await game.classicMode.startBattle([SpeciesId.NINJASK]);
+    const [ninjask] = game.scene.getPlayerParty();
+    game.move.changeMoveset(ninjask, [MoveId.SAFEGUARD, MoveId.COURT_CHANGE, MoveId.NUZZLE, MoveId.SPLASH]);
+
+    game.move.use(MoveId.SAFEGUARD, 0);
+    await game.toEndOfTurn();
+
+    //Ninjask will not be poisoned because of Safeguard
+    expect(ninjask.status?.effect).not.toBe(StatusEffect.POISON);
+
+    game.move.use(MoveId.COURT_CHANGE);
+    await game.toEndOfTurn();
+
+    //Ninjask should now be poisoned
+    expect(ninjask.status?.effect).toBe(StatusEffect.POISON);
+  });
+});


### PR DESCRIPTION



## What are the changes the user will see?
Court Change will now correctly swap Safeguard and Pledge Effects.

## Why am I making these changes?
This is a fix to this issue: #5047 

## What are the changes from a developer perspective?
Added the pledge and safeguard arena tags to the Court Change move.

## Screenshots/Videos
-

## How to test the changes?
Added a Unit test.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?
