### PR TITLE
[Bug] Prevent save corruption when loading a pokemonData that has no moves

### DIFF
--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -105,7 +105,7 @@ export default class PokemonData {
 
     // TODO: Can't we move some of this verification stuff to an upgrade script?
     this.nature = source.nature ?? Nature.HARDY;
-    this.moveset = source.moveset.map((m: any) => PokemonMove.loadMove(m));
+    this.moveset = source.moveset?.map((m: any) => PokemonMove.loadMove(m)) ?? [];
     this.status = source.status
       ? new Status(source.status.effect, source.status.toxicTurnCount, source.status.sleepTurnsRemaining)
       : null;


### PR DESCRIPTION
## What are the changes the user will see?
Some saves that were stuck on "loading" are now able to be loaded.

## Why am I making these changes?
Partially addresses #6037; saves where a pokemon has no moves will no longer cause the run to be corrupted.

## What are the changes from a developer perspective?

When the bug in #6037 is triggered, during serialization, the pokemon's moveset is written as null/undefined, causing it to be omitted from the json output.
To fix, all we have to do is add nullish coalescing and a default when loading from pokemon data. Specifically, in `src/system/pokemon-data.ts`:
```diff
-    this.moveset = source.moveset.map((m: any) => PokemonMove.loadMove(m));
+    this.moveset = source.moveset?.map((m: any) => PokemonMove.loadMove(m)) ?? [];
```

## Screenshots/Videos

<details><summary>Successfully loading a previously broken save</summary>

https://github.com/user-attachments/assets/61026d88-1c7e-4546-b080-269de60baecd
</details>

## How to test the changes?
You'll need to be running rogueserver. Follow the reproduction steps in #6037, and get a corrupted save. Then, try to load the save after refresh. Notice how with these changes, the save can be loaded from.


## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes? We don't have a system that allows creating automated tests that require rogueserver to be running.
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~
