### PR TITLE
[Misc] Make FixedInt support coercion to number primitive

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -341,6 +341,10 @@ export class NumberHolder {
   constructor(value: number) {
     this.value = value;
   }
+
+  valueOf(): number {
+    return this.value;
+  }
 }
 
 export class FixedInt {
@@ -348,6 +352,10 @@ export class FixedInt {
 
   constructor(value: number) {
     this.value = value;
+  }
+
+  [Symbol.toPrimitive](_hint: string): number {
+    return this.value;
   }
 }
 


### PR DESCRIPTION
## What are the changes the user will see?
None

## Why am I making these changes?
`FixedInt` is working in dangerous territory. The creator method for it, `fixedInt()`, does a type assertion to tell typescript that the value it returns as a number. This typing behavior is done to avoid headaches when using FixedInt in our intercepted phaser methods.
However, if care is not taken, the fact that fixedInt appears to typescript to return a number can cause unintended bugs.
If, somehow, a FixedInt is passed to phaser in a place where it expects a number, then bad things can happen (crashes).

Really, FixedInt is just a wrapper around `number` that is only used to prevent a number from being modified by game speed. If something goes wrong and a `FixedInt` is somehow passed to phaser, really bad stuff can happen.
We can mitigate this by allowing for `FixedInt` to be coerced into the number it wraps. This means that if phaser attempts to use the FixedInt in a situation where it can be coerced, then we avoid the bad stuff and it works as we would expect.

## What are the changes from a developer perspective?
Define [`Symbol.toPrimitive`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive) for the `FixedInt` class.

For QoL, I also define `valueOf` for `NumberHolder`, which opens the door for it to be coerced to a number.

## Screenshots/Videos
N/A

## How to test the changes?
N/A

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~~[ ] Have I tested the changes manually?~~
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - ~~[ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~
