### PR TITLE
[Bug][Performance] Plug memory leak related to enemy pokemon lingering around

### DIFF
--- a/src/data/battle-anims.ts
+++ b/src/data/battle-anims.ts
@@ -880,6 +880,10 @@ export abstract class BattleAnim {
       targetSprite.pipelineData["tone"] = [0.0, 0.0, 0.0, 0.0];
       targetSprite.setAngle(0);
 
+      // Remove animation event listeners to enable sprites to be freed.
+      userSprite.off("animationupdate");
+      targetSprite.off("animationupdate");
+
       /**
        * This and `targetSpriteToShow` are used to restore context lost
        * from the `isOppAnim` swap. Using these references instead of `this.user`


### PR DESCRIPTION
## What are the changes the user will see?
Less memory usage over time as waves progress

## Why am I making these changes?
Memory leaks are a huge problem, and cause players, particularly on mobile devices, to crash after progressing through waves.
Plugging memory leaks will reduce the memory footprint of the game and reduce the frequency of these crashes.
Hopefully, this leak fixes most of the 

## What are the changes from a developer perspective?
The `animationUpdate` event listeners are now removed from sprites during the `cleanUpAndComplete` method defined in the sprite's `play` method.

The listeners for `animationUpdate` were keeping references to several parts of the `EnemyPokemon`. This meant that an `EnemyPokemon` and all elements related to it would linger around in memory and not be garbage collected.
Every single enemy pokemon that was created (or player pokemon that were since released) would linger around in memory. This included not only their sprite, but also their battle-info-ui!

This is definitely NOT the only memory leak related to waves, as the memory footprint continues to grow with each wave.

I'm continuing to investigate.

## Screenshots/Videos
Not useful.

## How to test the changes?
Start a game. Open devtools and go to memory. Click on "take heap snapshot"
In the `filter by class`, search `EnemyPokemon`.
Look at how many references there are.

Progress a few waves. Then, take another snapshot and look at its enemy pokemon.
Notice how there are fewer.
## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - ~~[ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~ Not easy to do with our testing infra.

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?
