### PR TITLE
[UI/UX] HEADER_LABEL TextStyle Fix

### DIFF
--- a/src/ui/text.ts
+++ b/src/ui/text.ts
@@ -320,7 +320,6 @@ export function getTextStyleOptions(
       styleOptions.fontSize = defaultFontSize;
       break;
     case TextStyle.HEADER_LABEL: {
-      let fontSizeValue = "96px";
       switch (lang) {
         case "ja":
           styleOptions.padding = { top: 6 };

--- a/src/ui/text.ts
+++ b/src/ui/text.ts
@@ -319,10 +319,15 @@ export function getTextStyleOptions(
     case TextStyle.MESSAGE:
       styleOptions.fontSize = defaultFontSize;
       break;
-    case TextStyle.HEADER_LABEL:
-      styleOptions.fontSize = defaultFontSize;
-      styleOptions.padding = { top: 6 };
+    case TextStyle.HEADER_LABEL: {
+      let fontSizeValue = "96px";
+      switch (lang) {
+        case "ja":
+          styleOptions.padding = { top: 6 };
+          break;
+      }
       break;
+    }
     case TextStyle.SETTINGS_VALUE:
     case TextStyle.SETTINGS_LABEL: {
       shadowXpos = 3;


### PR DESCRIPTION
## What are the changes the user will see?
Text positon for header texts adjusted

## Why am I making these changes?
[Japanese Text edits PR](https://github.com/pagefaultgames/pokerogue/pull/6026) introduced a padding for header texts in all languages while it was meant only for Japanese, it is now fixed

## What are the changes from a developer perspective?
None

## Screenshots/Videos
Aimed result (as it is still currently in main repo) :
<img width="483" height="149" alt="image" src="https://github.com/user-attachments/assets/a581fec4-c5ba-474d-b3ee-ba0e25ad1b22" />

Current state in beta:
<img width="477" height="147" alt="image" src="https://github.com/user-attachments/assets/2d809726-a4e5-47c2-9ffc-8a90427e9646" />

Result after fix:
<img width="483" height="157" alt="image" src="https://github.com/user-attachments/assets/0a50c3b9-303b-4082-92ed-0abfaf0fda49" />

## How to test the changes?
Check the game sections headers while visually comparing it to the current beta

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [X] Have I made sure that any UI change works for both UI themes (default and legacy)?