### PR TITLE
Revert "[Bug] Genderless Pokemon no longer grey out the caught icon"

### DIFF
--- a/src/enums/dex-attr.ts
+++ b/src/enums/dex-attr.ts
@@ -1,5 +1,4 @@
 export const DexAttr = Object.freeze({
-  GENDERLESS: 0n,
   NON_SHINY: 1n,
   SHINY: 2n,
   MALE: 4n,

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -558,13 +558,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   getDexAttr(): bigint {
     let ret = 0n;
-    ret |=
-      this.gender === Gender.GENDERLESS
-        ? DexAttr.GENDERLESS
-        : this.gender === Gender.FEMALE
-          ? DexAttr.FEMALE
-          : DexAttr.MALE;
-
+    ret |= this.gender !== Gender.FEMALE ? DexAttr.MALE : DexAttr.FEMALE;
     ret |= !this.shiny ? DexAttr.NON_SHINY : DexAttr.SHINY;
     ret |= this.variant >= 2 ? DexAttr.VARIANT_3 : this.variant === 1 ? DexAttr.VARIANT_2 : DexAttr.DEFAULT_VARIANT;
     ret |= globalScene.gameData.getFormAttr(this.formIndex);


### PR DESCRIPTION
Reverts pagefaultgames/pokerogue#5935

I shouldn't have accepted the PR. We shouldn't add a new DexAttr for genderless. Especially not one with 0n considering it's a bitfield.