### PR TITLE
[Bug] Fix grey caught indicator for genderless pokemon

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -558,7 +558,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   getDexAttr(): bigint {
     let ret = 0n;
-    ret |= this.gender !== Gender.FEMALE ? DexAttr.MALE : DexAttr.FEMALE;
+    if (this.gender !== Gender.GENDERLESS) {
+      ret |= this.gender !== Gender.FEMALE ? DexAttr.MALE : DexAttr.FEMALE;
+    }
     ret |= !this.shiny ? DexAttr.NON_SHINY : DexAttr.SHINY;
     ret |= this.variant >= 2 ? DexAttr.VARIANT_3 : this.variant === 1 ? DexAttr.VARIANT_2 : DexAttr.DEFAULT_VARIANT;
     ret |= globalScene.gameData.getFormAttr(this.formIndex);


### PR DESCRIPTION
## What are the changes the user will see?
The caught indicator will no longer be greyed out for genderless pokemon, regardless of anything missing in the Pokédex

## Why am I making these changes?
Fixes https://github.com/pagefaultgames/pokerogue/issues/5757 without introducing a new `DexAttr` field.

See #5935

## What are the changes from a developer perspective?

Guard the `|=` for the `getDexAttr` to not incorrectly set `DexAttr.MALE`.
Previously, this was just checking if the solely if the mon was Female. If it wasn't, then it would set the bit flag for `Gender.MALE`. When checking against `dexAttr` to determine pokeball tint, it would check against the pokemon's gender. If genderless, this would never match.
```diff
-    ret |= this.gender !== Gender.FEMALE ? DexAttr.MALE : DexAttr.FEMALE;
+    if (this.gender !== Gender.GENDERLESS) {
+     ret |= this.gender !== Gender.FEMALE ? DexAttr.MALE : DexAttr.FEMALE;
+    }
```

## Screenshots/Videos
See #5935

## How to test the changes?
See #5935 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - ~~[ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~
,.