### PR TITLE
[Bug][UI/UX] Ensure setCursor is called if not first turn

### DIFF
--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -134,6 +134,8 @@ export class FightUiHandler extends UiHandler implements InfoToggle {
     const pokemon = (globalScene.phaseManager.getCurrentPhase() as CommandPhase).getPokemon();
     if (pokemon.tempSummonData.turnCount <= 1) {
       this.setCursor(0);
+    } else {
+      this.setCursor(this.fieldIndex ? this.cursor2 : this.cursor);
     }
     this.displayMoves();
     this.toggleInfo(false); // in case cancel was pressed while info toggle is active


### PR DESCRIPTION
## What are the changes the user will see?
Fight cursor will now show up when selecting a move on the next turn.

## Why am I making these changes?
Fixes https://discord.com/channels/1125469663833370665/1394365674901737642/1394365674901737642
An oversight in #5883 cleaned up the cursor, but didn't adjust the logic to re-create the cursor in all cases during the show method.

## What are the changes from a developer perspective?
During the `show` method, we now always call `setCursor`, even if it's not the pokemon's first turn out since summon.
The cursor is cleared in the `clear` method. During the `show` method, there was a conditional for not calling `setCursor` (which creates the cursor if it doesn't exist) conditioned on the pokemon.
This addresses this.

## Screenshots/Videos

<details><summary>Proper fight ui cursor showing up</summary>

https://github.com/user-attachments/assets/4df282dd-e42a-4cd3-8538-191fcedf6b92
</details>

## How to test the changes?
Go into fight. Select a move. Go to next wave, press fight again. Notice how cursor is visible when it wasn't before

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - ~~[ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~
