### PR TITLE
[AI] Minor fixup of matchup score

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2562,8 +2562,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     // Get average attack score of all damaging moves (|| 1 prevents division by zero))
     // TODO: Averaging the attack score is excessively simplistic, and doesn't reflect the AI's move selection logic
     // e.g. if the mon has one 4x effective move and three 0.5x effective moves, this score would be ~1.375
-    // instead of
-    // That is, this atkScore logic does not reflect the AI's move selection logic.
+    // which does not seem fair, given that if the AI were to switch, in all likelihood it would use the 4x move.
+    // We could consider a weighted average...
     atkScore /= moveAtkScoreLength || 1;
     /**
      * Based on this Pokemon's HP ratio compared to that of the opponent.

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2560,6 +2560,10 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       moveAtkScoreLength++;
     }
     // Get average attack score of all damaging moves (|| 1 prevents division by zero))
+    // TODO: Averaging the attack score is excessively simplistic, and doesn't reflect the AI's move selection logic
+    // e.g. if the mon has one 4x effective move and three 0.5x effective moves, this score would be ~1.375
+    // instead of
+    // That is, this atkScore logic does not reflect the AI's move selection logic.
     atkScore /= moveAtkScoreLength || 1;
     /**
      * Based on this Pokemon's HP ratio compared to that of the opponent.
@@ -2568,6 +2572,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
      */
     const hpRatio = this.getHpRatio();
     const oppHpRatio = opponent.getHpRatio();
+    // TODO: use better logic for predicting whether the pokemon "is dying"
+    // E.g., perhaps check if it would faint if the opponent were to use the same move it just used
+    // (twice if the user is slower)
     const isDying = hpRatio <= 0.2;
     let hpDiffRatio = hpRatio + (1 - oppHpRatio);
     if (isDying && this.isActive(true)) {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2537,7 +2537,6 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }
 
     const moveset = this.moveset;
-    // Start at 1 to prevent division by zero later on
     let moveAtkScoreLength = 0;
     let atkScore = 0;
     // TODO: this calculation needs to consider more factors; it's currently very simplistic
@@ -2552,7 +2551,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
       // Add STAB multiplier for attack type effectiveness.
       // For now, simply don't apply STAB to moves that may change type
-      if (this.getTypes(true).includes(moveType) && move.getMove().hasAttr("VariableMoveTypeAttr")) {
+      if (this.getTypes(true).includes(moveType) && !move.getMove().hasAttr("VariableMoveTypeAttr")) {
         thisScore *= 1.5;
       }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2520,41 +2520,47 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @returns A score value based on how favorable this Pokemon is when fighting the given Pokemon
    */
   getMatchupScore(opponent: Pokemon): number {
-    const types = this.getTypes(true);
-
-    const enemyTypes = opponent.getTypes(true, true, false, true);
+    const enemyTypes = opponent.getTypes(true, false, false, true);
     /** Is this Pokemon faster than the opponent? */
     const outspeed =
       (this.isActive(true) ? this.getEffectiveStat(Stat.SPD, opponent) : this.getStat(Stat.SPD, false)) >=
       opponent.getEffectiveStat(Stat.SPD, this);
-    /**
-     * Based on how effective this Pokemon's types are offensively against the opponent's types.
-     * This score is increased by 25 percent if this Pokemon is faster than the opponent.
-     */
-    let atkScore =
-      opponent.getAttackTypeEffectiveness(types[0], this, false, true, undefined, true) * (outspeed ? 1.25 : 1);
+
     /**
      * Based on how effectively this Pokemon defends against the opponent's types.
      * This score cannot be higher than 4.
      */
     let defScore = 1 / Math.max(this.getAttackTypeEffectiveness(enemyTypes[0], opponent), 0.25);
-    if (types.length > 1) {
-      atkScore *= opponent.getAttackTypeEffectiveness(types[1], this);
-    }
     if (enemyTypes.length > 1) {
       defScore *=
         1 / Math.max(this.getAttackTypeEffectiveness(enemyTypes[1], opponent, false, false, undefined, true), 0.25);
     }
-    atkScore *= 1.25; //give more value for the pokemon's typing
+
     const moveset = this.moveset;
+    // Start at 1 to prevent division by zero later on
     let moveAtkScoreLength = 0;
+    let atkScore = 0;
+    // TODO: this calculation needs to consider more factors; it's currently very simplistic
     for (const move of moveset) {
-      if (move.getMove().category === MoveCategory.SPECIAL || move.getMove().category === MoveCategory.PHYSICAL) {
-        atkScore += opponent.getAttackTypeEffectiveness(move.getMove().type, this, false, true, undefined, true);
-        moveAtkScoreLength++;
+      const resolvedMove = move.getMove();
+      // NOTE: Counter and Mirror Coat are considered as attack moves here
+      if (resolvedMove.category === MoveCategory.STATUS || move.getPpRatio() <= 0) {
+        continue;
       }
+      const moveType = resolvedMove.type;
+      let thisScore = opponent.getAttackTypeEffectiveness(moveType, this, false, true, undefined, true);
+
+      // Add STAB multiplier for attack type effectiveness.
+      // For now, simply don't apply STAB to moves that may change type
+      if (this.getTypes(true).includes(moveType) && move.getMove().hasAttr("VariableMoveTypeAttr")) {
+        thisScore *= 1.5;
+      }
+
+      atkScore += thisScore;
+      moveAtkScoreLength++;
     }
-    atkScore = atkScore / (moveAtkScoreLength + 1); //calculate the median for the attack score
+    // Get average attack score of all damaging moves (|| 1 prevents division by zero))
+    atkScore /= moveAtkScoreLength || 1;
     /**
      * Based on this Pokemon's HP ratio compared to that of the opponent.
      * This ratio is multiplied by 1.5 if this Pokemon outspeeds the opponent;
@@ -2571,15 +2577,15 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         //It might not be a worthy sacrifice if it doesn't outspeed or doesn't do enough damage
         hpDiffRatio *= 0.85;
       } else {
-        hpDiffRatio = Math.min(1 - hpRatio + (outspeed ? 0.2 : 0.1), 1);
+        hpDiffRatio = 1 - hpRatio + (outspeed ? 0.2 : 0.1);
       }
     } else if (outspeed) {
-      hpDiffRatio = Math.min(hpDiffRatio * 1.25, 1);
+      hpDiffRatio = hpDiffRatio * 1.25;
     } else if (hpRatio > 0.2 && hpRatio <= 0.4) {
-      //Might be considered to be switched because it's not in low enough health
-      hpDiffRatio = Math.min(hpDiffRatio * 0.5, 1);
+      // Might be considered to be switched because it's not in low enough health
+      hpDiffRatio = hpDiffRatio * 0.5;
     }
-    return (atkScore + defScore) * hpDiffRatio;
+    return (atkScore + defScore) * Math.min(hpDiffRatio, 1);
   }
 
   getEvolution(): SpeciesFormEvolution | null {


### PR DESCRIPTION
## What are the changes the user will see?
Smarter enemy AI when considering switches

## Why am I making these changes?
It was pointed out to me that the prior PR, #5981 had a few oversights in its logic. This addresses such oversights.

## What are the changes from a developer perspective?
- If the enemy is tera'd, its original types as well as its tera type are considered, instead of just the tera type (by changing the `forDefend` parameter to `false`)
- The pokemon's offensive types are no longer counted in its attack score, as the procedure added by #5981 which considers the attack score on a per-move basis
- Ensure that `hpDiffRatio` caps at 1, as its comment indicates, by moving the `Math.min()` calculations to the return statement

Added comments discussing some of the deficiencies in the logic.
## Screenshots/Videos
N/A

## How to test the changes?
Play waves?

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - ~~[ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~
