### PR TITLE
[Dev] Move typedoc settings out of `tsconfig.json` and into `typedoc.json`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,11 +47,5 @@
     "outDir": "./build",
     "noEmit": true
   },
-  "typedocOptions": {
-    "entryPoints": ["./src"],
-    "entryPointStrategy": "expand",
-    "exclude": "**/*+.test.ts",
-    "out": "typedoc"
-  },
   "exclude": ["node_modules", "dist", "vite.config.ts", "vitest.config.ts", "vitest.workspace.ts"]
 }


### PR DESCRIPTION
## What are the changes the user will see?
None

## Why am I making these changes?
Makes it easier to edit tsdoc settings + add plugins