### PR TITLE
[UI/UX] Added "Hide Username" Setting

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -236,6 +236,7 @@ export class BattleScene extends SceneBase {
   public enableTouchControls = false;
   public enableVibration = false;
   public showBgmBar = true;
+  public hideUsername = false;
   /** Determines the selected battle style. */
   public battleStyle: BattleStyle = BattleStyle.SWITCH;
   /**

--- a/src/system/settings/settings.ts
+++ b/src/system/settings/settings.ts
@@ -171,6 +171,7 @@ export const SettingKeys = {
   UI_Volume: "UI_SOUND_EFFECTS",
   Battle_Music: "BATTLE_MUSIC",
   Show_BGM_Bar: "SHOW_BGM_BAR",
+  Hide_Username: "HIDE_USERNAME",
   Move_Touch_Controls: "MOVE_TOUCH_CONTROLS",
   Shop_Overlay_Opacity: "SHOP_OVERLAY_OPACITY",
 };
@@ -626,6 +627,13 @@ export const Setting: Array<Setting> = [
     type: SettingType.DISPLAY,
   },
   {
+    key: SettingKeys.Hide_Username,
+    label: i18next.t("settings:hideUsername"),
+    options: OFF_ON,
+    default: 0,
+    type: SettingType.DISPLAY,
+  },
+  {
     key: SettingKeys.Master_Volume,
     label: i18next.t("settings:masterVolume"),
     options: VOLUME_OPTIONS,
@@ -791,6 +799,9 @@ export function setSetting(setting: string, value: number): boolean {
       break;
     case SettingKeys.Show_BGM_Bar:
       globalScene.showBgmBar = Setting[index].options[value].value === "On";
+      break;
+    case SettingKeys.Hide_Username:
+      globalScene.hideUsername = Setting[index].options[value].value === "On";
       break;
     case SettingKeys.Candy_Upgrade_Notification:
       if (globalScene.candyUpgradeNotification === value) {

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -810,12 +810,23 @@ export class SummaryUiHandler extends UiHandler {
       case Page.PROFILE: {
         const profileContainer = globalScene.add.container(0, -pageBg.height);
         pageContainer.add(profileContainer);
+        const otColor =
+          globalScene.gameData.gender === PlayerGender.FEMALE ? TextStyle.SUMMARY_PINK : TextStyle.SUMMARY_BLUE;
+        const usernameReplacement =
+          globalScene.gameData.gender === PlayerGender.FEMALE
+            ? i18next.t("trainerNames:player_f")
+            : i18next.t("trainerNames:player_m");
 
         // TODO: should add field for original trainer name to Pokemon object, to support gift/traded Pokemon from MEs
         const trainerText = addBBCodeTextObject(
           7,
           12,
-          `${i18next.t("pokemonSummary:ot")}/${getBBCodeFrag(loggedInUser?.username || i18next.t("pokemonSummary:unknown"), globalScene.gameData.gender === PlayerGender.FEMALE ? TextStyle.SUMMARY_PINK : TextStyle.SUMMARY_BLUE)}`,
+          `${i18next.t("pokemonSummary:ot")}/${getBBCodeFrag(
+            !globalScene.hideUsername
+              ? loggedInUser?.username || i18next.t("pokemonSummary:unknown")
+              : usernameReplacement,
+            otColor,
+          )}`,
           TextStyle.SUMMARY_ALT,
         );
         trainerText.setOrigin(0, 0);
@@ -824,7 +835,9 @@ export class SummaryUiHandler extends UiHandler {
         const trainerIdText = addTextObject(
           141,
           12,
-          `${i18next.t("pokemonSummary:idNo")}${globalScene.gameData.trainerId.toString()}`,
+          !globalScene.hideUsername
+            ? `${i18next.t("pokemonSummary:idNo")}${globalScene.gameData.trainerId.toString()}`
+            : "",
           TextStyle.SUMMARY_ALT,
         );
         trainerIdText.setOrigin(0, 0);

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -828,19 +828,16 @@ export class SummaryUiHandler extends UiHandler {
             otColor,
           )}`,
           TextStyle.SUMMARY_ALT,
-        );
-        trainerText.setOrigin(0, 0);
+        ).setOrigin(0);
         profileContainer.add(trainerText);
 
+        const idToDisplay = globalScene.hideUsername ? "*****" : globalScene.gameData.trainerId.toString();
         const trainerIdText = addTextObject(
           141,
           12,
-          !globalScene.hideUsername
-            ? `${i18next.t("pokemonSummary:idNo")}${globalScene.gameData.trainerId.toString()}`
-            : "",
+          `${i18next.t("pokemonSummary:idNo")}${idToDisplay}`,
           TextStyle.SUMMARY_ALT,
-        );
-        trainerIdText.setOrigin(0, 0);
+        ).setOrigin(0);
         profileContainer.add(trainerIdText);
 
         const typeLabel = addTextObject(7, 28, `${i18next.t("pokemonSummary:type")}/`, TextStyle.WINDOW_ALT);


### PR DESCRIPTION
## What are the changes the user will see?
New setting inside the Display section "Hide Username" that will change the username shown in the Pokémon summary next to "OT" from your real username to the name of the character you're playing (Amber / Kayle), as well as removing the ID No.

## Why am I making these changes?
Pokérogue was designed to be accessible. Accounts can be created with just a username and password. Because of this simplicity, many players use insecure usernames and passwords. Additionally, usernames are displayed on the summary screen of your Pokémon under “OT.”

This often leads to people unintentionally “doxing” themselves when sharing screenshots of their Pokémon, posting videos, or streaming gameplay.

While some users choose a username unrelated to their real identity, others may use their regular online handle. Every year, numerous data breaches occur, flooding the internet with leaked usernames linked to passwords. It’s likely that many Pokérogue usernames are among them. And even though it's a single-player game with little incentive to hack accounts, malicious actors still exist—especially those targeting streamers.

To make matters worse, it’s currently not possible to change your username or password on Pokérogue. This should be a simple and aesthetic solution.

## What are the changes from a developer perspective?
New setting added on `settings.ts`: "HIDE_USERNAME"
`summary-ui-handler.ts` now checks if "hideUsername" is enabled before showing the username next to "OT" while on Pokémon Summary, also it only shows ID No. if "hideUsername" is not enabled.


## Screenshots/Videos
**Default / Hide Username off:**
![](https://i.imgur.com/lWO1bK2.png)
**Hide Username on, Amber:**
![](https://i.imgur.com/Xq50Qzj.png)
**Hide Username on, Kayle:**
![](https://i.imgur.com/XWGt7Xz.png)
**Hide Username on, Legacy:**
![](https://i.imgur.com/CyZno2l.png)
**Settings:**
![](https://i.imgur.com/ztClRUu.png)

## How to test the changes?
Go into Settings, Display, Scroll all the way down.
Enable "Hide Username".
Go into a run.
Go into the team menu.
Select a Pokémon and go into Summary.
It shouldn't show your username or Guest if you're on local and it shouldn't show your ID No.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  ~- [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [x] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [x] If so, please leave a link to it here: [#200](https://github.com/pagefaultgames/pokerogue-locales/pull/200)
  - [ ] Has the translation team been contacted for proofreading/translation?
