### PR TITLE
[Bug][Refactor] Fix loading arena tags

### DIFF
--- a/src/@types/arena-tags.ts
+++ b/src/@types/arena-tags.ts
@@ -1,0 +1,65 @@
+import type { ArenaTagTypeMap } from "#data/arena-tag";
+import type { ArenaTagType } from "#enums/arena-tag-type";
+import type { NonFunctionProperties } from "./type-helpers";
+
+/** Subset of {@linkcode ArenaTagType}s that are considered traps */
+export type ArenaTrapTagType =
+  | ArenaTagType.STICKY_WEB
+  | ArenaTagType.SPIKES
+  | ArenaTagType.TOXIC_SPIKES
+  | ArenaTagType.STEALTH_ROCK
+  | ArenaTagType.IMPRISON;
+
+/** Subset of {@linkcode ArenaTagType}s that are considered delayed attacks */
+export type ArenaDelayedAttackTagType = ArenaTagType.FUTURE_SIGHT | ArenaTagType.DOOM_DESIRE;
+
+/** Subset of {@linkcode ArenaTagType}s that work like screens */
+export type ArenaScreenTagType = ArenaTagType.REFLECT | ArenaTagType.LIGHT_SCREEN | ArenaTagType.AURORA_VEIL;
+
+/** Subset of {@linkcode ArenaTagType}s for moves that add protection */
+export type TurnProtectArenaTagType =
+  | ArenaTagType.QUICK_GUARD
+  | ArenaTagType.WIDE_GUARD
+  | ArenaTagType.MAT_BLOCK
+  | ArenaTagType.CRAFTY_SHIELD;
+
+/** Subset of {@linkcode ArenaTagType}s that may persist across turns, and thus may be serialized in `SessionSaveData` */
+export type SerializableArenaTagType =
+  | ArenaDelayedAttackTagType
+  | ArenaScreenTagType
+  | ArenaTrapTagType
+  | ArenaTagType.MUD_SPORT
+  | ArenaTagType.WATER_SPORT
+  | ArenaTagType.MIST
+  | ArenaTagType.WISH
+  | ArenaTagType.GRAVITY
+  | ArenaTagType.TRICK_ROOM
+  | ArenaTagType.SAFEGUARD
+  | ArenaTagType.TAILWIND
+  | ArenaTagType.HAPPY_HOUR
+  | ArenaTagType.FIRE_GRASS_PLEDGE
+  | ArenaTagType.WATER_FIRE_PLEDGE
+  | ArenaTagType.GRASS_WATER_PLEDGE
+  | ArenaTagType.FAIRY_LOCK
+  | ArenaTagType.NEUTRALIZING_GAS
+  | ArenaTagType.NO_CRIT
+  | ArenaTagType.IMPRISON;
+
+/** Subset of {@linkcode ArenaTagType}s that cannot persist across turns, and thus should not be serialized in `SessionSaveData`. */
+export type NonSerializableArenaTagType = ArenaTagType.NONE | TurnProtectArenaTagType | ArenaTagType.ION_DELUGE;
+
+/**
+ * Type-safe representation of the serializable data of an ArenaTag
+ */
+export type ArenaTagTypeData = NonFunctionProperties<
+  ArenaTagTypeMap[keyof {
+    [K in keyof ArenaTagTypeMap as K extends SerializableArenaTagType ? K : never]: ArenaTagTypeMap[K];
+  }]
+>;
+
+/** Dummy, typescript-only declaration to ensure that
+ * {@linkcode ArenaTagTypeMap} has a map for all ArenaTagTypes.
+ *
+ * ⚠️ Does not actually exist at runtime, so it must not be used!
+ */
+declare const EnsureAllArenaTagTypesAreMapped: ArenaTagTypeMap[ArenaTagType] & never;

--- a/src/@types/arena-tags.ts
+++ b/src/@types/arena-tags.ts
@@ -23,30 +23,11 @@ export type TurnProtectArenaTagType =
   | ArenaTagType.MAT_BLOCK
   | ArenaTagType.CRAFTY_SHIELD;
 
-/** Subset of {@linkcode ArenaTagType}s that may persist across turns, and thus may be serialized in `SessionSaveData` */
-export type SerializableArenaTagType =
-  | ArenaDelayedAttackTagType
-  | ArenaScreenTagType
-  | ArenaTrapTagType
-  | ArenaTagType.MUD_SPORT
-  | ArenaTagType.WATER_SPORT
-  | ArenaTagType.MIST
-  | ArenaTagType.WISH
-  | ArenaTagType.GRAVITY
-  | ArenaTagType.TRICK_ROOM
-  | ArenaTagType.SAFEGUARD
-  | ArenaTagType.TAILWIND
-  | ArenaTagType.HAPPY_HOUR
-  | ArenaTagType.FIRE_GRASS_PLEDGE
-  | ArenaTagType.WATER_FIRE_PLEDGE
-  | ArenaTagType.GRASS_WATER_PLEDGE
-  | ArenaTagType.FAIRY_LOCK
-  | ArenaTagType.NEUTRALIZING_GAS
-  | ArenaTagType.NO_CRIT
-  | ArenaTagType.IMPRISON;
-
 /** Subset of {@linkcode ArenaTagType}s that cannot persist across turns, and thus should not be serialized in `SessionSaveData`. */
 export type NonSerializableArenaTagType = ArenaTagType.NONE | TurnProtectArenaTagType | ArenaTagType.ION_DELUGE;
+
+/** Subset of {@linkcode ArenaTagType}s that may persist across turns, and thus may be serialized in `SessionSaveData` */
+export type SerializableArenaTagType = Exclude<ArenaTagType, NonSerializableArenaTagType>;
 
 /**
  * Type-safe representation of the serializable data of an ArenaTag
@@ -59,6 +40,8 @@ export type ArenaTagTypeData = NonFunctionProperties<
 
 /** Dummy, typescript-only declaration to ensure that
  * {@linkcode ArenaTagTypeMap} has a map for all ArenaTagTypes.
+ *
+ * If an arena tag is missing from the map, typescript will throw an error on this statement.
  *
  * ⚠️ Does not actually exist at runtime, so it must not be used!
  */

--- a/src/@types/arena-tags.ts
+++ b/src/@types/arena-tags.ts
@@ -2,7 +2,7 @@ import type { ArenaTagTypeMap } from "#data/arena-tag";
 import type { ArenaTagType } from "#enums/arena-tag-type";
 import type { NonFunctionProperties } from "./type-helpers";
 
-/** Subset of {@linkcode ArenaTagType}s that are considered traps */
+/** Subset of {@linkcode ArenaTagType}s that apply some negative effect to pokemon that switch in ({@link https://bulbapedia.bulbagarden.net/wiki/List_of_moves_that_cause_entry_hazards#List_of_traps | entry hazards} and Imprison. */
 export type ArenaTrapTagType =
   | ArenaTagType.STICKY_WEB
   | ArenaTagType.SPIKES
@@ -13,7 +13,7 @@ export type ArenaTrapTagType =
 /** Subset of {@linkcode ArenaTagType}s that are considered delayed attacks */
 export type ArenaDelayedAttackTagType = ArenaTagType.FUTURE_SIGHT | ArenaTagType.DOOM_DESIRE;
 
-/** Subset of {@linkcode ArenaTagType}s that work like screens */
+/** Subset of {@linkcode ArenaTagType}s that create {@link https://bulbapedia.bulbagarden.net/wiki/Category:Screen-creating_moves | screens}. */
 export type ArenaScreenTagType = ArenaTagType.REFLECT | ArenaTagType.LIGHT_SCREEN | ArenaTagType.AURORA_VEIL;
 
 /** Subset of {@linkcode ArenaTagType}s for moves that add protection */
@@ -23,10 +23,10 @@ export type TurnProtectArenaTagType =
   | ArenaTagType.MAT_BLOCK
   | ArenaTagType.CRAFTY_SHIELD;
 
-/** Subset of {@linkcode ArenaTagType}s that cannot persist across turns, and thus should not be serialized in `SessionSaveData`. */
+/** Subset of {@linkcode ArenaTagType}s that cannot persist across turns, and thus should not be serialized in {@linkcode SessionSaveData}. */
 export type NonSerializableArenaTagType = ArenaTagType.NONE | TurnProtectArenaTagType | ArenaTagType.ION_DELUGE;
 
-/** Subset of {@linkcode ArenaTagType}s that may persist across turns, and thus may be serialized in `SessionSaveData` */
+/** Subset of {@linkcode ArenaTagType}s that may persist across turns, and thus must be serialized in {@linkcode SessionSaveData}. */
 export type SerializableArenaTagType = Exclude<ArenaTagType, NonSerializableArenaTagType>;
 
 /**

--- a/src/@types/type-helpers.ts
+++ b/src/@types/type-helpers.ts
@@ -46,7 +46,7 @@ export type InferKeys<O extends Record<keyof any, unknown>, V extends EnumValues
 }[keyof O];
 
 /**
- * Type helper for `Function` types. Equivalent to `Function`, but will not raise a warning in TypeScript.
+ * Type helper that matches any `Function` type. Equivalent to `Function`, but will not raise a warning from Biome.
  */
 export type AnyFn = (...args: any[]) => any;
 

--- a/src/@types/type-helpers.ts
+++ b/src/@types/type-helpers.ts
@@ -64,7 +64,6 @@ export type NonFunctionProperties<T> = {
 
 /**
  * Type helper to extract out non-function properties from a type, recursively applying to nested properties.
- *
  */
 export type NonFunctionPropertiesRecursive<Class> = {
   [K in keyof Class as Class[K] extends AnyFn ? never : K]: Class[K] extends Array<infer U>

--- a/src/@types/type-helpers.ts
+++ b/src/@types/type-helpers.ts
@@ -57,7 +57,6 @@ export type AnyFn = (...args: any[]) => any;
  * Useful to produce a type that is roughly the same as the type of `{... obj}`, where `obj` is an instance of `T`.
  * A couple of differences:
  * - Private and protected properties are not included.
- * -
  */
 export type NonFunctionProperties<T> = {
   [K in keyof T as T[K] extends AnyFn ? never : K]: T[K];

--- a/src/@types/type-helpers.ts
+++ b/src/@types/type-helpers.ts
@@ -44,3 +44,33 @@ export type Mutable<T> = {
 export type InferKeys<O extends Record<keyof any, unknown>, V extends EnumValues<O>> = {
   [K in keyof O]: O[K] extends V ? K : never;
 }[keyof O];
+
+/**
+ * Type helper for `Function` types. Equivalent to `Function`, but will not raise a warning in TypeScript.
+ */
+export type AnyFn = (...args: any[]) => any;
+
+/**
+ * Type helper to extract non-function properties from a type.
+ *
+ * @remarks
+ * Useful to produce a type that is roughly the same as the type of `{... obj}`, where `obj` is an instance of `T`.
+ * A couple of differences:
+ * - Private and protected properties are not included.
+ * -
+ */
+export type NonFunctionProperties<T> = {
+  [K in keyof T as T[K] extends AnyFn ? never : K]: T[K];
+};
+
+/**
+ * Type helper to extract out non-function properties from a type, recursively applying to nested properties.
+ *
+ */
+export type NonFunctionPropertiesRecursive<Class> = {
+  [K in keyof Class as Class[K] extends AnyFn ? never : K]: Class[K] extends Array<infer U>
+    ? NonFunctionPropertiesRecursive<U>[]
+    : Class[K] extends object
+      ? NonFunctionPropertiesRecursive<Class[K]>
+      : Class[K];
+};

--- a/src/@types/type-helpers.ts
+++ b/src/@types/type-helpers.ts
@@ -57,6 +57,7 @@ export type AnyFn = (...args: any[]) => any;
  * Useful to produce a type that is roughly the same as the type of `{... obj}`, where `obj` is an instance of `T`.
  * A couple of differences:
  * - Private and protected properties are not included.
+ * - Nested properties are not recursively extracted. For this, use {@linkcode NonFunctionPropertiesRecursive}
  */
 export type NonFunctionProperties<T> = {
   [K in keyof T as T[K] extends AnyFn ? never : K]: T[K];
@@ -72,3 +73,5 @@ export type NonFunctionPropertiesRecursive<Class> = {
       ? NonFunctionPropertiesRecursive<Class[K]>
       : Class[K];
 };
+
+export type AbstractConstructor<T> = abstract new (...args: any[]) => T;

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -61,9 +61,13 @@ If the field should be accessible outside of the class, then a public getter sho
 
 /** Interface of the serializable fields of ArenaTagData */
 interface BaseArenaTag {
-  /** The turns that have passed since the tag was added */
+  /** 
+   * The tag's remaining duration. Setting to any number `<=0` will make the tag's duration effectively infinite.
+   */
   turnCount: number;
-  /** The id of the move that set the tag, or undefined if not set by a move */
+  /** 
+   * The {@linkcode MoveId} that created this tag, or `undefined` if not set by a move.
+   */
   sourceMove?: MoveId;
   /** The source pokemon of the move, or undefined if not set by a pokemon */
   // Note: Intentionally not using `?`, as the property should always exist, but just be undefined if not present.
@@ -625,6 +629,7 @@ class WishTag extends SerializableArenaTag {
     const target = globalScene.getField()[this.battlerIndex];
     if (target?.isActive(true)) {
       globalScene.phaseManager.queueMessage(
+        // TODO: Rename key as it triggers on activation
         i18next.t("arenaTag:wishTagOnAdd", {
           pokemonNameWithAffix: this.sourceName,
         }),
@@ -671,7 +676,7 @@ export abstract class WeakenMoveTypeTag extends SerializableArenaTag {
  */
 class MudSportTag extends WeakenMoveTypeTag {
   public readonly tagType = ArenaTagType.MUD_SPORT;
-  override get weakenedType(): PokemonType {
+  override get weakenedType(): PokemonType.ELECTRIC {
     return PokemonType.ELECTRIC;
   }
   constructor(turnCount: number, sourceId?: number) {
@@ -693,7 +698,7 @@ class MudSportTag extends WeakenMoveTypeTag {
  */
 class WaterSportTag extends WeakenMoveTypeTag {
   public readonly tagType = ArenaTagType.WATER_SPORT;
-  override get weakenedType(): PokemonType {
+  override get weakenedType(): PokemonType.FIRE {
     return PokemonType.FIRE;
   }
   constructor(turnCount: number, sourceId?: number) {

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -366,7 +366,10 @@ type ProtectConditionFunc = (arena: Arena, moveId: MoveId) => boolean;
 export abstract class ConditionalProtectTag extends ArenaTag {
   /** The condition function to determine which moves are negated */
   protected protectConditionFunc: ProtectConditionFunc;
-  /** Does this apply to all moves, including those that ignore other forms of protection? */
+  /**
+   * Whether this protection effect should apply to _all_ moves, including ones that ignore other forms of protection.
+   * @defaultValue `false`
+   */
   protected ignoresBypass: boolean;
 
   constructor(

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -50,8 +50,9 @@ A static property is also acceptable, though static properties are less ergonomi
 
 If the data is mutable (i.e. it can change over the course of the tag's lifetime), then it *must*
 be defined as a field, and it must be set in the `loadTag` method.
-Such fields cannot be marked as `private/protected`, as if they were, typescript would complain
-that the class does not properly implement the `SerializedTag` interface.
+Such fields cannot be marked as `private/protected`, as if they were, typescript would omit them from
+types that are based off of the class, namely, `ArenaTagTypeData`. It is preferrable to trade the
+type-safety of private/protected fields for the type safety when deserializing arena tags from save data.
 
 For data that is mutable only within a turn (e.g. SuppressAbilitiesTag's beingRemoved field),
 where it does not make sense to be serialized, the field should use ES2020's private field syntax (a `#` prepended to the field name).
@@ -596,9 +597,11 @@ export class NoCritTag extends SerializableArenaTag {
  * Heals the Pokémon in the user's position the turn after Wish is used.
  */
 class WishTag extends SerializableArenaTag {
+  // The following fields are meant to be inwardly mutable, but outwardly immutable.
   readonly battlerIndex: BattlerIndex;
   readonly healHp: number;
   readonly sourceName: string;
+  // End inwardly mutable fields
 
   public readonly tagType = ArenaTagType.WISH;
 
@@ -1548,6 +1551,7 @@ export class FairyLockTag extends SerializableArenaTag {
  * @sealed
  */
 export class SuppressAbilitiesTag extends SerializableArenaTag {
+  // Source count is allowed to be inwardly mutable, but outwardly immutable
   public readonly sourceCount: number;
   public readonly tagType = ArenaTagType.NEUTRALIZING_GAS;
   // Private field prevents field from appearing during serialization

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -61,15 +61,15 @@ If the field should be accessible outside of the class, then a public getter sho
 
 /** Interface containing the serializable fields of ArenaTagData. */
 interface BaseArenaTag {
-  /** 
+  /**
    * The tag's remaining duration. Setting to any number `<=0` will make the tag's duration effectively infinite.
    */
   turnCount: number;
-  /** 
+  /**
    * The {@linkcode MoveId} that created this tag, or `undefined` if not set by a move.
    */
   sourceMove?: MoveId;
-  /** 
+  /**
    * The {@linkcode Pokemon.id | PID} of the {@linkcode Pokemon} having created the tag, or `undefined` if not set by a Pokemon.
    * @todo Implement handling for `ArenaTag`s created by non-pokemon sources (most tags will throw errors without a source)
    */

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -49,7 +49,7 @@ instead be defined as a getter.
 A static property is also acceptable, though static properties are less ergonomic with inheritance.
 
 If the data is mutable (i.e. it can change over the course of the tag's lifetime), then it *must*
-be defined as a field, *must* be part of the accompanying `SerializedTag` interface.
+be defined as a field, and it must be set in the `loadTag` method.
 Such fields cannot be marked as `private/protected`, as if they were, typescript would complain
 that the class does not properly implement the `SerializedTag` interface.
 

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -37,7 +37,7 @@ Examples include (but are not limited to)
 - Effects that are applied to a specific side of the field, such as Crafty Shield, Reflect, and Spikes
 - Field-Effects, like Gravity and Trick Room
 
-Any arena tag that persists across turns *must* extend from `SerializableArenaTag` to the class definition signature.
+Any arena tag that persists across turns *must* extend from `SerializableArenaTag` in the class definition signature.
 
 Serializable ArenaTags have strict rules for their fields.
 These rules ensure that only the data necessary to reconstruct the tag is serialized, and that the

--- a/src/data/terrain.ts
+++ b/src/data/terrain.ts
@@ -13,6 +13,10 @@ export enum TerrainType {
   PSYCHIC,
 }
 
+export interface SerializedTerrain {
+  terrainType: TerrainType;
+  turnsLeft: number;
+}
 export class Terrain {
   public terrainType: TerrainType;
   public turnsLeft: number;

--- a/src/data/terrain.ts
+++ b/src/data/terrain.ts
@@ -17,6 +17,7 @@ export interface SerializedTerrain {
   terrainType: TerrainType;
   turnsLeft: number;
 }
+
 export class Terrain {
   public terrainType: TerrainType;
   public turnsLeft: number;

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -11,6 +11,11 @@ import type { Move } from "#moves/move";
 import { randSeedInt } from "#utils/common";
 import i18next from "i18next";
 
+export interface SerializedWeather {
+  weatherType: WeatherType;
+  turnsLeft: number;
+}
+
 export class Weather {
   public weatherType: WeatherType;
   public turnsLeft: number;

--- a/src/enums/arena-tag-type.ts
+++ b/src/enums/arena-tag-type.ts
@@ -2,7 +2,8 @@ import type { ArenaTagTypeMap } from "#data/arena-tag";
 import type { NonSerializableArenaTagType, SerializableArenaTagType } from "#types/arena-tags";
 
 /**
- * @privateremarks
+ * Enum representing all different types of {@linkcode ArenaTag}s.
+ * @privateRemarks
  * ⚠️ When modifying the fields in this enum, ensure that:
  * - The entry is added to / removed from {@linkcode ArenaTagTypeMap} 
  * - The tag is added to / removed from {@linkcode NonSerializableArenaTagType} or {@linkcode SerializableArenaTagType}

--- a/src/enums/arena-tag-type.ts
+++ b/src/enums/arena-tag-type.ts
@@ -1,3 +1,12 @@
+import type { ArenaTagTypeMap } from "#data/arena-tag";
+import type { NonSerializableArenaTagType, SerializableArenaTagType } from "#types/arena-tags";
+
+/**
+ * @privateremarks
+ * ⚠️ When modifying the fields in this enum, ensure that:
+ * - The entry is added to / removed from {@linkcode ArenaTagTypeMap} 
+ * - The tag is added to / removed from {@linkcode NonSerializableArenaTagType} or {@linkcode SerializableArenaTagType}
+*/
 export enum ArenaTagType {
   NONE = "NONE",
   MUD_SPORT = "MUD_SPORT",

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -3,7 +3,7 @@ import { globalScene } from "#app/global-scene";
 import Overrides from "#app/overrides";
 import type { BiomeTierTrainerPools, PokemonPools } from "#balance/biomes";
 import { BiomePoolTier, biomePokemonPools, biomeTrainerPools } from "#balance/biomes";
-import type { ArenaTag, WeakenMoveScreenTag } from "#data/arena-tag";
+import type { ArenaTag } from "#data/arena-tag";
 import { ArenaTrapTag, getArenaTag } from "#data/arena-tag";
 import { SpeciesFormChangeRevertWeatherFormTrigger, SpeciesFormChangeWeatherTrigger } from "#data/form-change-triggers";
 import type { PokemonSpecies } from "#data/pokemon-species";
@@ -30,6 +30,7 @@ import { TagAddedEvent, TagRemovedEvent, TerrainChangedEvent, WeatherChangedEven
 import type { Pokemon } from "#field/pokemon";
 import { FieldEffectModifier } from "#modifiers/modifier";
 import type { Move } from "#moves/move";
+import type { AbstractConstructor } from "#types/type-helpers";
 import { type Constructor, isNullOrUndefined, NumberHolder, randSeedInt } from "#utils/common";
 import { getPokemonSpecies } from "#utils/pokemon-utils";
 
@@ -644,7 +645,7 @@ export class Arena {
    * @param args array of parameters that the called upon tags may need
    */
   applyTagsForSide(
-    tagType: ArenaTagType | Constructor<ArenaTag> | typeof WeakenMoveScreenTag,
+    tagType: ArenaTagType | Constructor<ArenaTag> | AbstractConstructor<ArenaTag>,
     side: ArenaTagSide,
     simulated: boolean,
     ...args: unknown[]
@@ -666,7 +667,11 @@ export class Arena {
    * @param simulated if `true`, this applies arena tags without changing game state
    * @param args array of parameters that the called upon tags may need
    */
-  applyTags(tagType: ArenaTagType | Constructor<ArenaTag>, simulated: boolean, ...args: unknown[]): void {
+  applyTags(
+    tagType: ArenaTagType | Constructor<ArenaTag> | AbstractConstructor<ArenaTag>,
+    simulated: boolean,
+    ...args: unknown[]
+  ): void {
     this.applyTagsForSide(tagType, ArenaTagSide.BOTH, simulated, ...args);
   }
 
@@ -723,7 +728,7 @@ export class Arena {
    * @param tagType The {@linkcode ArenaTagType} or {@linkcode ArenaTag} to get
    * @returns either the {@linkcode ArenaTag}, or `undefined` if it isn't there
    */
-  getTag(tagType: ArenaTagType | Constructor<ArenaTag>): ArenaTag | undefined {
+  getTag(tagType: ArenaTagType | Constructor<ArenaTag> | AbstractConstructor<ArenaTag>): ArenaTag | undefined {
     return this.getTagOnSide(tagType, ArenaTagSide.BOTH);
   }
 
@@ -739,7 +744,10 @@ export class Arena {
    * @param side The {@linkcode ArenaTagSide} to look at
    * @returns either the {@linkcode ArenaTag}, or `undefined` if it isn't there
    */
-  getTagOnSide(tagType: ArenaTagType | Constructor<ArenaTag>, side: ArenaTagSide): ArenaTag | undefined {
+  getTagOnSide(
+    tagType: ArenaTagType | Constructor<ArenaTag> | AbstractConstructor<ArenaTag>,
+    side: ArenaTagSide,
+  ): ArenaTag | undefined {
     return typeof tagType === "string"
       ? this.tags.find(
           t => t.tagType === tagType && (side === ArenaTagSide.BOTH || t.side === ArenaTagSide.BOTH || t.side === side),

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -3,7 +3,7 @@ import { globalScene } from "#app/global-scene";
 import Overrides from "#app/overrides";
 import type { BiomeTierTrainerPools, PokemonPools } from "#balance/biomes";
 import { BiomePoolTier, biomePokemonPools, biomeTrainerPools } from "#balance/biomes";
-import type { ArenaTag } from "#data/arena-tag";
+import type { ArenaTag, WeakenMoveScreenTag } from "#data/arena-tag";
 import { ArenaTrapTag, getArenaTag } from "#data/arena-tag";
 import { SpeciesFormChangeRevertWeatherFormTrigger, SpeciesFormChangeWeatherTrigger } from "#data/form-change-triggers";
 import type { PokemonSpecies } from "#data/pokemon-species";
@@ -644,7 +644,7 @@ export class Arena {
    * @param args array of parameters that the called upon tags may need
    */
   applyTagsForSide(
-    tagType: ArenaTagType | Constructor<ArenaTag>,
+    tagType: ArenaTagType | Constructor<ArenaTag> | typeof WeakenMoveScreenTag,
     side: ArenaTagSide,
     simulated: boolean,
     ...args: unknown[]

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2192,7 +2192,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }
     const suppressAbilitiesTag = arena.getTag(ArenaTagType.NEUTRALIZING_GAS) as SuppressAbilitiesTag;
     const suppressOffField = ability.hasAttr("PreSummonAbAttr");
-    if ((this.isOnField() || suppressOffField) && suppressAbilitiesTag && !suppressAbilitiesTag.isBeingRemoved()) {
+    if ((this.isOnField() || suppressOffField) && suppressAbilitiesTag && !suppressAbilitiesTag.beingRemoved) {
       const thisAbilitySuppressing = ability.hasAttr("PreLeaveFieldRemoveSuppressAbilitiesSourceAbAttr");
       const hasSuppressingAbility = this.hasAbilityWithAttr("PreLeaveFieldRemoveSuppressAbilitiesSourceAbAttr", false);
       // Neutralizing gas is up - suppress abilities unless they are unsuppressable or this pokemon is responsible for the gas

--- a/src/system/arena-data.ts
+++ b/src/system/arena-data.ts
@@ -1,9 +1,19 @@
 import type { ArenaTag } from "#data/arena-tag";
-import { loadArenaTag } from "#data/arena-tag";
+import { loadArenaTag, SerializableArenaTag } from "#data/arena-tag";
 import { Terrain } from "#data/terrain";
 import { Weather } from "#data/weather";
 import type { BiomeId } from "#enums/biome-id";
 import { Arena } from "#field/arena";
+import type { ArenaTagTypeData } from "#types/arena-tags";
+import type { NonFunctionProperties } from "#types/type-helpers";
+
+export interface SerializedArenaData {
+  biome: BiomeId;
+  weather: NonFunctionProperties<Weather> | null;
+  terrain: NonFunctionProperties<Terrain> | null;
+  tags?: ArenaTagTypeData[];
+  playerTerasUsed?: number;
+}
 
 export class ArenaData {
   public biome: BiomeId;
@@ -12,24 +22,27 @@ export class ArenaData {
   public tags: ArenaTag[];
   public playerTerasUsed: number;
 
-  constructor(source: Arena | any) {
-    const sourceArena = source instanceof Arena ? (source as Arena) : null;
-    this.biome = sourceArena ? sourceArena.biomeType : source.biome;
-    this.weather = sourceArena
-      ? sourceArena.weather
-      : source.weather
-        ? new Weather(source.weather.weatherType, source.weather.turnsLeft)
-        : null;
-    this.terrain = sourceArena
-      ? sourceArena.terrain
-      : source.terrain
-        ? new Terrain(source.terrain.terrainType, source.terrain.turnsLeft)
-        : null;
-    this.playerTerasUsed = (sourceArena ? sourceArena.playerTerasUsed : source.playerTerasUsed) ?? 0;
-    this.tags = [];
-
+  constructor(source: Arena | SerializedArenaData) {
     if (source.tags) {
-      this.tags = source.tags.map(t => loadArenaTag(t));
+      // NOTE: The filter has to be done _after_ map, data loaded from `ArenaTagTypeData`
+      // is not yet an instance of `ArenaTag`
+      this.tags = source.tags
+        .map((t: ArenaTag | ArenaTagTypeData) => loadArenaTag(t))
+        .filter((tag): tag is SerializableArenaTag => tag instanceof SerializableArenaTag);
+    } else {
+      this.tags = [];
     }
+
+    if (source instanceof Arena) {
+      this.biome = source.biomeType;
+      this.weather = source.weather;
+      this.terrain = source.terrain;
+      this.playerTerasUsed = source.playerTerasUsed ?? 0;
+      return;
+    }
+
+    this.biome = source.biome;
+    this.weather = source.weather ? new Weather(source.weather.weatherType, source.weather.turnsLeft) : null;
+    this.terrain = source.terrain ? new Terrain(source.terrain.terrainType, source.terrain.turnsLeft) : null;
   }
 }

--- a/src/system/arena-data.ts
+++ b/src/system/arena-data.ts
@@ -23,22 +23,20 @@ export class ArenaData {
   public playerTerasUsed: number;
 
   constructor(source: Arena | SerializedArenaData) {
-    if (source.tags) {
-      // Exclude any unserializable tags from the serialized data (such as ones only lasting 1 turn).
-      // NOTE: The filter has to be done _after_ map, data loaded from `ArenaTagTypeData`
-      // is not yet an instance of `ArenaTag`
-      this.tags = source.tags
-        .map((t: ArenaTag | ArenaTagTypeData) => loadArenaTag(t))
-        .filter((tag): tag is SerializableArenaTag => tag instanceof SerializableArenaTag);
-    } else {
-      this.tags = [];
-    }
+    // Exclude any unserializable tags from the serialized data (such as ones only lasting 1 turn).
+    // NOTE: The filter has to be done _after_ map, data loaded from `ArenaTagTypeData`
+    // is not yet an instance of `ArenaTag`
+    this.tags =
+      source.tags
+        ?.map((t: ArenaTag | ArenaTagTypeData) => loadArenaTag(t))
+        ?.filter((tag): tag is SerializableArenaTag => tag instanceof SerializableArenaTag) ?? [];
+
+    this.playerTerasUsed = source.playerTerasUsed ?? 0;
 
     if (source instanceof Arena) {
       this.biome = source.biomeType;
       this.weather = source.weather;
       this.terrain = source.terrain;
-      this.playerTerasUsed = source.playerTerasUsed ?? 0;
       return;
     }
 

--- a/src/system/arena-data.ts
+++ b/src/system/arena-data.ts
@@ -24,6 +24,7 @@ export class ArenaData {
 
   constructor(source: Arena | SerializedArenaData) {
     if (source.tags) {
+      // Exclude any unserializable tags from the serialized data (such as ones only lasting 1 turn).
       // NOTE: The filter has to be done _after_ map, data loaded from `ArenaTagTypeData`
       // is not yet an instance of `ArenaTag`
       this.tags = source.tags

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -42,7 +42,7 @@ import * as Modifier from "#modifiers/modifier";
 import { MysteryEncounterSaveData } from "#mystery-encounters/mystery-encounter-save-data";
 import type { Variant } from "#sprites/variant";
 import { achvs } from "#system/achv";
-import { ArenaData } from "#system/arena-data";
+import { ArenaData, type SerializedArenaData } from "#system/arena-data";
 import { ChallengeData } from "#system/challenge-data";
 import { EggData } from "#system/egg-data";
 import { GameStats } from "#system/game-stats";
@@ -1286,7 +1286,7 @@ export class GameData {
         }
 
         case "arena":
-          return new ArenaData(v);
+          return new ArenaData(v as SerializedArenaData);
 
         case "challenges": {
           const ret: ChallengeData[] = [];


### PR DESCRIPTION
## What are the changes the user will see?
Wish is now usable, and persists across session saves.

## Why am I making these changes?
#5932 broke wish due to a minor oversight.
This PR fixes that.
Fixes https://discord.com/channels/1125469663833370665/1348446393261621299/1348446393261621299

It also allows, for the first time, wish to work properly across saves.
Also lets neutralizing gas work properly across saves.

## What are the changes from a developer perspective?
- Added missing implementations for `loadTag` to the SuppressAbilitiesTag and WishTag.
- Added many new types and type helpers for the purposes of type-safe parsing of arena data.
- Added a lengthy description at the top of `ArenaTags` that discusses changes
- Added a new abstract class, `SerializableArenaTag` to mark arena tags that should persist in save data.
- Simplified the body of `ArenaData`'s constructor to be more readable.
  -  When creating an Arena, tags that are not Serializable are now ignored when constructing this data.


## Screenshots/Videos

<details><summary>Demonstration of wish fix, and wish working across saves</summary>

https://github.com/user-attachments/assets/b31124c2-ad03-4b68-8b35-f472cadfd15d
</details>


## How to test the changes?
Load up some old saves and ensure everything works.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - ~~[ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~ Not doing this.
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~