### PR TITLE
[Bug] Fix Tera Steller interaction with Imposter and Transform

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1071,7 +1071,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         // Neither pokemon can be behind an illusion
         target.summonData.illusion ||
         this.summonData.illusion ||
-        // The user cannot be tera-steller
+        // The user cannot be Terastallized into Tera Stellar
         this.isOfType(PokemonType.STELLAR) ||
         // The target cannot be behind a substitute
         target.getTag(BattlerTagType.SUBSTITUTE) ||

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1071,6 +1071,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         // Neither pokemon can be behind an illusion
         target.summonData.illusion ||
         this.summonData.illusion ||
+        // The user cannot be tera-steller
+        this.isOfType(PokemonType.STELLAR) ||
         // The target cannot be behind a substitute
         target.getTag(BattlerTagType.SUBSTITUTE) ||
         // Transforming to/from fusion pokemon causes various problems (crashes, etc.)

--- a/test/moves/transform-imposter.test.ts
+++ b/test/moves/transform-imposter.test.ts
@@ -291,7 +291,7 @@ describe("Transforming Effects", () => {
         player: false,
       },
       {
-        cause: "user is tera-steller",
+        cause: "user is currently Tera Steller",
         callback: p => game.field.forceTera(p, PokemonType.STELLAR),
       },
     ])("should fail if $cause", async ({ callback, player = true }) => {
@@ -380,13 +380,13 @@ describe("Transforming Effects", () => {
       expect(game.phaseInterceptor.log).not.toContain("PokemonTransformPhase");
     });
 
-    it("should not activate if currently tera-steller", async () => {
-      game.override.battleStyle("single");
+    it("should not activate if currently Tera Steller", async () => {
       await game.classicMode.startBattle([SpeciesId.GYARADOS, SpeciesId.DITTO]);
 
-      const [, ditto] = game.scene.getPlayerParty();
-      const enemy1 = game.scene.getEnemyParty()[0];
+      const ditto = game.scene.getPlayerParty()[1];
+      const enemy1 = game.field.getEnemyPokemon();
 
+      // Override Ditto to be Tera Stellar
       game.field.forceTera(ditto, PokemonType.STELLAR);
       expect(ditto.canTransformInto(enemy1)).toBe(false);
 


### PR DESCRIPTION

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
Pokémon that are Tera Steller will no longer be able to use Transform. The ability Imposter will not activate on switch in if the Pokémon is Tera Steller.
## Why am I making these changes?
<!--
-->
Fixes #6077 
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

## What are the changes from a developer perspective?
<!--


Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->
Added one line to the function in `pokemon.ts` that checks if Imposter and Transform can be applied.
Added two tests to `transform-imposter.test.ts` to check that Tera Steller Pokémon cannot use Imposter and Transform.

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->
Before

https://github.com/user-attachments/assets/f454e1ca-77da-4e49-84b5-6e8f4c133f28


https://github.com/user-attachments/assets/408faa1d-305c-4249-9a8c-4228fa60f1b2

After

https://github.com/user-attachments/assets/df941e56-a046-4d2b-9cb5-9f388065b206


https://github.com/user-attachments/assets/2db270bf-4e88-4123-96e2-bb62947fb8ef



## How to test the changes?
<!--
-->
Use overrides 
`const overrides = {
  STARTER_SPECIES_OVERRIDE: SpeciesId.DITTO,
  STARTING_LEVEL_OVERRIDE: 1000,
  ABILITY_OVERRIDE: AbilityId.IMPOSTER,
  OPP_MOVESET_OVERRIDE: [MoveId.TRANSFORM, MoveId.WATER_SPOUT],
  MOVESET_OVERRIDE: [MoveId.TRANSFORM],
  STARTING_HELD_ITEMS_OVERRIDE: [{name:"TERA_ORB"},{name: "TERA_SHARD", type: PokemonType.STELLAR},{name: "BERRY", type: BerryType.SITRUS}]
} satisfies Partial<InstanceType<OverridesType>>;`
Start a run with two Pokémon. Tera Steller the Ditto, and attempt to use transform. Switch out Ditto, and then switch back in. Imposter should not activate.
## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?
