### PR TITLE
[Dev] Fixed lefthook to no longer reset submodules on file checkouts

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -15,4 +15,6 @@ post-merge:
 post-checkout:
   commands:
     update-submodules:
-      run: git submodule update --init --recursive
+      # cf https://git-scm.com/docs/githooks#_post_checkout:
+      # The 3rd argument is 1 for branch checkouts and 0 for file checkouts.
+      run: if test {3} -eq "1"; then git submodule update --init --recursive; fi


### PR DESCRIPTION
## What are the changes the user will see?
N/A
## Why am I making these changes?
Lefthook checking out locales on using `git checkout` to revert files made using `git submodule update --remote --recursive` really annoying

## What are the changes from a developer perspective?
Post checkout script amended to not trigger on file checkouts (only branch ones)

## How to test the changes?
```bash
git submodule update --remote --recursive # or anything else that updates them, like `cd public/locales; git checkout HEAD~5`
git checkout upstream/beta -- package.json
# Notice locales stays updated
git switch `branch-name`
# Locales should reset
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?