### PR TITLE
[Dev] Turned on `js-check` in TSConfig; fixed script type errors

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -177,9 +177,10 @@
       }
     },
 
-    // Overrides to prevent unused import removal inside `overrides.ts` and enums files (for TSDoc linkcodes)
+    // Overrides to prevent unused import removal inside `overrides.ts` and enums files (for TSDoc linkcodes),
+    // as well as in all TS files in `scripts/` (which are assumed to be boilerplate templates).
     {
-      "includes": ["**/src/overrides.ts", "**/src/enums/**/*"],
+      "includes": ["**/src/overrides.ts", "**/src/enums/**/*", "**/scripts/**/*.ts"],
       "linter": {
         "rules": {
           "correctness": {
@@ -189,7 +190,7 @@
       }
     },
     {
-      "includes": ["**/src/overrides.ts"],
+      "includes": ["**/src/overrides.ts", "**/scripts/**/*.ts"],
       "linter": {
         "rules": {
           "style": {

--- a/scripts/create-test/create-test.js
+++ b/scripts/create-test/create-test.js
@@ -44,20 +44,22 @@ function getTestFolderPath(...folders) {
  * @returns {Promise<{selectedOption: {label: string, dir: string}}>} the selected type
  */
 async function promptTestType() {
-  const typeAnswer = await inquirer.prompt([
-    {
-      type: "list",
-      name: "selectedOption",
-      message: "What type of test would you like to create?",
-      choices: [...choices.map(choice => ({ name: choice.label, value: choice })), "EXIT"],
-    },
-  ]);
+  const typeAnswer = await inquirer
+    .prompt([
+      {
+        type: "list",
+        name: "selectedOption",
+        message: "What type of test would you like to create?",
+        choices: [...choices.map(choice => ({ name: choice.label, value: choice })), { name: "EXIT", value: "N/A" }],
+      },
+    ])
+    .then(ans => ans.selectedOption);
 
-  if (typeAnswer.selectedOption === "EXIT") {
+  if (typeAnswer.name === "EXIT") {
     console.log("Exiting...");
-    return process.exit();
+    return process.exit(0);
   }
-  if (!choices.some(choice => choice.dir === typeAnswer.selectedOption.dir)) {
+  if (!choices.some(choice => choice.dir === typeAnswer.dir)) {
     console.error(`Please provide a valid type: (${choices.map(choice => choice.label).join(", ")})!`);
     return await promptTestType();
   }

--- a/scripts/decrypt-save.js
+++ b/scripts/decrypt-save.js
@@ -144,7 +144,7 @@ function main() {
     process.exit(0);
   }
 
-  writeToFile(destPath, decrypt);
+  writeToFile(args[1], decrypt);
 }
 
 main();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "esModuleInterop": true,
     "strictNullChecks": true,
     "sourceMap": false,
+    "checkJs": true,
     "strict": false, // TODO: Enable this eventually
     "rootDir": ".",
     "baseUrl": "./src",


### PR DESCRIPTION
## What are the changes the user will see?
The decrypt save util actually works.

## Why am I making these changes?
I wanted type checking for my egg scripts.
Along the way, I noticed our existing ones were breaking typescript.

## What are the changes from a developer perspective?
Added `checkJs` in ts config
fixed type errors

## How to test the changes?
run ze scripts

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)