### PR TITLE
[UI] Status moves only show 1x or 0x for effectiveness hints

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -305,10 +305,11 @@ export abstract class Move implements Localizable {
 
   /**
    * Checks if the move is immune to certain types.
+   * 
    * Currently looks at cases of Grass types with powder moves and Dark types with moves affected by Prankster.
-   * @param {Pokemon} user the source of this move
-   * @param {Pokemon} target the target of this move
-   * @param {PokemonType} type the type of the move's target
+   * @param user - The source of this move
+   * @param target - The target of this move
+   * @param type - The type of the move's target
    * @returns boolean
    */
   isTypeImmune(user: Pokemon, target: Pokemon, type: PokemonType): boolean {

--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -322,7 +322,6 @@ export class FightUiHandler extends UiHandler implements InfoToggle {
 
   /**
    * Gets multiplier text for a pokemon's move against a specific opponent
-   * Returns undefined if it's a status move
    */
   private getEffectivenessText(pokemon: Pokemon, opponent: Pokemon, pokemonMove: PokemonMove): string | undefined {
     const effectiveness = opponent.getMoveEffectiveness(
@@ -333,8 +332,11 @@ export class FightUiHandler extends UiHandler implements InfoToggle {
       undefined,
       true,
     );
-    if (effectiveness === undefined) {
-      return undefined;
+    if (pokemonMove.getMove().category === MoveCategory.STATUS) {
+      if (effectiveness === 0) {
+        return "0x";
+      }
+      return "1x";
     }
 
     return `${effectiveness}x`;
@@ -391,7 +393,12 @@ export class FightUiHandler extends UiHandler implements InfoToggle {
         ),
       )
       .sort((a, b) => b - a)
-      .map(effectiveness => getTypeDamageMultiplierColor(effectiveness ?? 0, "offense"));
+      .map(effectiveness => {
+        if (pokemonMove.getMove().category === MoveCategory.STATUS && effectiveness !== 0) {
+          return undefined;
+        }
+        return getTypeDamageMultiplierColor(effectiveness ?? 0, "offense");
+      });
 
     return moveColors[0];
   }


### PR DESCRIPTION
## What are the changes the user will see?
Status moves like Thunder Wave will no longer show multipliers other than 1x and 0x (including coloring).
This is still not 100% accurate (Poison Powder won't show 0x vs Steel types, for example).

## Why am I making these changes?
The type hints were incorrect.
Fixes #4304
Note that #6058 is a different issue and is not fixed by this PR.

## What are the changes from a developer perspective?
Added checks to the type hint color and text displays for status moves which set nonzero values to the 1x effectiveness value.
Some situations, such as Poison Powder vs Steel types, are still not fully accurate (should show 0x), but that would be a more involved change.

## Screenshots/Videos
Moves: Will-O-Wisp, Thunder Wave, Poison Powder
<details><summary>vs Grass</summary>
<p>

Will-O-Wisp:
<img width="1225" height="683" alt="image" src="https://github.com/user-attachments/assets/111e375a-23e7-41cb-aef4-7ac7617c9255" />
Thunder Wave:
<img width="1223" height="686" alt="image" src="https://github.com/user-attachments/assets/56bf91fd-776c-4266-9a1a-25129b452b48" />
Poison Powder:
<img width="1219" height="686" alt="image" src="https://github.com/user-attachments/assets/1e08a6a2-8e76-4b03-8eda-e374c6e0223e" />

</p>
</details> 
<details><summary>vs Ground</summary>
<p>

<img width="1222" height="688" alt="image" src="https://github.com/user-attachments/assets/a5508db2-7498-4b28-9c17-17c2758e8401" />

</p>
</details> 
<details><summary>vs Steel</summary>
<p>

<img width="1225" height="682" alt="image" src="https://github.com/user-attachments/assets/8eec9382-6493-4b3d-884f-cf86a5086d8a" />

</p>
</details> 
<details><summary>vs Water</summary>
<p>

Will-O-Wisp:
<img width="1222" height="686" alt="image" src="https://github.com/user-attachments/assets/fc8e4717-f5d9-4196-9f4e-7118f99e0915" />
Thunder Wave:
<img width="1223" height="684" alt="image" src="https://github.com/user-attachments/assets/fd24d5a2-c548-4c2f-9356-edd7883a1735" />

</p>
</details> 

## How to test the changes?
```ts
const overrides = {
  MOVESET_OVERRIDE: [MoveId.WILL_O_WISP, MoveId.THUNDER_WAVE, MoveId.POISON_POWDER, MoveId.THUNDER_SHOCK],
  OPP_SPECIES_OVERRIDE: SpeciesId.SNIVY, // replace with various pokemon of different types
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Have I provided screenshots/videos of the changes (if applicable)?