### PR TITLE
[Dev] Disabled biome `noAwaitInLoop` rule

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -139,7 +139,7 @@
         "useAdjacentGetterSetter": "error",
         "noConstantBinaryExpression": "error",
         "noTsIgnore": "error",
-        "noAwaitInLoop": "warn",
+        "noAwaitInLoop": "off",
         "useJsonImportAttribute": "off", // "Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'nodenext', or 'preserve'. ts(2823)"
         "useIndexOf": "error",
         "useObjectSpread": "error",


### PR DESCRIPTION
## What are the changes the user will see?
N/A
## Why am I making these changes?
Benjie mentioned wanting to disable the rule.
We use promises sparingly enough that the places where we _do_ use await in a for loop, there's usually a pretty good reason.
Also it becomes an especially large nuisance in tests (since advancing to phases is asynchronous)

## What are the changes from a developer perspective?
Disabled rule

## Screenshots/Videos
N/A

## How to test the changes?
N/A

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?x