### PR TITLE
[Bug] Appropriately load future sight / doom desire when target index was player

### DIFF
--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -27,7 +27,7 @@ import type {
   SerializableArenaTagType,
 } from "#types/arena-tags";
 import type { Mutable, NonFunctionProperties } from "#types/type-helpers";
-import { BooleanHolder, NumberHolder, toDmgValue } from "#utils/common";
+import { BooleanHolder, isNullOrUndefined, NumberHolder, toDmgValue } from "#utils/common";
 import i18next from "i18next";
 
 /*
@@ -1691,7 +1691,7 @@ export function getArenaTag(
       return new ToxicSpikesTag(sourceId, side);
     case ArenaTagType.FUTURE_SIGHT:
     case ArenaTagType.DOOM_DESIRE:
-      if (!targetIndex) {
+      if (isNullOrUndefined(targetIndex)) {
         return null; // If missing target index, no tag is created
       }
       return new DelayedAttackTag(tagType, sourceMove, sourceId, targetIndex, side);


### PR DESCRIPTION
Really quick PR, fixes a minor oversight from #6110 where `!targetIndex` was being used instead of `isNullOrUndefined`, meaning tags aimed at the player would be dropped. Mostly benign, but should still be fixed.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- ~~[ ] Have I tested the changes manually?~~
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - ~~[ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~
