### PR TITLE
[Dev] test:silent now passes --silent='passed-only' to Vitest

### DIFF
--- a/.github/workflows/test-shard-template.yml
+++ b/.github/workflows/test-shard-template.yml
@@ -44,4 +44,4 @@ jobs:
         run: pnpm i
 
       - name: Run tests
-        run: pnpm test:silent --project=${{ inputs.project }} --shard=${{ inputs.shard }}/${{ inputs.totalShards }}
+        run: pnpm test:silent --shard=${{ inputs.shard }}/${{ inputs.totalShards }}

--- a/.github/workflows/test-shard-template.yml
+++ b/.github/workflows/test-shard-template.yml
@@ -44,4 +44,4 @@ jobs:
         run: pnpm i
 
       - name: Run tests
-        run: pnpm exec vitest --project ${{ inputs.project }} --no-isolate --shard=${{ inputs.shard }}/${{ inputs.totalShards }} ${{ !runner.debug && '--silent' || '' }}
+        run: pnpm test:silent --project=${{ inputs.project }} --shard=${{ inputs.shard }}/${{ inputs.totalShards }}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run --no-isolate",
     "test:cov": "vitest run --coverage --no-isolate",
     "test:watch": "vitest watch --coverage --no-isolate",
-    "test:silent": "vitest run --silent --no-isolate",
+    "test:silent": "vitest run --silent='passed-only' --no-isolate",
     "test:create": "node scripts/create-test/create-test.js",
     "typecheck": "tsc --noEmit",
     "eslint": "eslint --fix .",


### PR DESCRIPTION
> [!NOTE]
> Copied from https://github.com/Despair-Games/poketernity/pull/1296/

## What are the changes the user will see?
N/A

## Why am I making these changes?
Better testing - failed tests will now output console logs

Value is somewhat minimal with our GODAWFUL logging system ATM, but this at least paves the way for future improvements.

## What are the changes from a developer perspective?
Changed package json to add command

## Screenshots/Videos
N/A

## How to test the changes?
Run tests and CI?

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?