### PR TITLE
[Dev] Remove `sanitizeOverrides`, consolidate initialization code into 1 file

### DIFF
--- a/src/data/balance/biomes.ts
+++ b/src/data/balance/biomes.ts
@@ -86,7 +86,7 @@ export enum BiomePoolTier {
 
 export const uncatchableSpecies: SpeciesId[] = [];
 
-export interface SpeciesTree {
+interface SpeciesTree {
   [key: number]: SpeciesId[]
 }
 
@@ -94,11 +94,11 @@ export interface PokemonPools {
   [key: number]: (SpeciesId | SpeciesTree)[]
 }
 
-export interface BiomeTierPokemonPools {
+interface BiomeTierPokemonPools {
   [key: number]: PokemonPools
 }
 
-export interface BiomePokemonPools {
+interface BiomePokemonPools {
   [key: number]: BiomeTierPokemonPools
 }
 
@@ -2022,7 +2022,6 @@ export const biomeTrainerPools: BiomeTrainerPools = {
   }
 };
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: init methods are expected to have many lines.
 export function initBiomes() {
   const pokemonBiomes = [
     [ SpeciesId.BULBASAUR, PokemonType.GRASS, PokemonType.POISON, [

--- a/src/init/init.ts
+++ b/src/init/init.ts
@@ -1,0 +1,35 @@
+import { initAbilities } from "#abilities/ability";
+import { initBiomes } from "#balance/biomes";
+import { initEggMoves } from "#balance/egg-moves";
+import { initPokemonPrevolutions, initPokemonStarters } from "#balance/pokemon-evolutions";
+import { initChallenges } from "#data/challenge";
+import { initTrainerTypeDialogue } from "#data/dialogue";
+import { initPokemonForms } from "#data/pokemon-forms";
+import { initSpecies } from "#data/pokemon-species";
+import { initModifierPools } from "#modifiers/init-modifier-pools";
+import { initModifierTypes } from "#modifiers/modifier-type";
+import { initMoves } from "#moves/move";
+import { initMysteryEncounters } from "#mystery-encounters/mystery-encounters";
+import { initAchievements } from "#system/achv";
+import { initVouchers } from "#system/voucher";
+import { initStatsKeys } from "#ui/game-stats-ui-handler";
+
+/** Initialize the game. */
+export function initializeGame() {
+  initModifierTypes();
+  initModifierPools();
+  initAchievements();
+  initVouchers();
+  initStatsKeys();
+  initPokemonPrevolutions();
+  initPokemonStarters();
+  initBiomes();
+  initEggMoves();
+  initPokemonForms();
+  initTrainerTypeDialogue();
+  initSpecies();
+  initMoves();
+  initAbilities();
+  initChallenges();
+  initMysteryEncounters();
+}

--- a/src/loading-scene.ts
+++ b/src/loading-scene.ts
@@ -1,29 +1,16 @@
-import { initAbilities } from "#abilities/ability";
 import { timedEventManager } from "#app/global-event-manager";
+import { initializeGame } from "#app/init/init";
 import { SceneBase } from "#app/scene-base";
 import { isMobile } from "#app/touch-controls";
-import { initBiomes } from "#balance/biomes";
-import { initEggMoves } from "#balance/egg-moves";
-import { initPokemonPrevolutions, initPokemonStarters } from "#balance/pokemon-evolutions";
-import { initChallenges } from "#data/challenge";
-import { initTrainerTypeDialogue } from "#data/dialogue";
-import { initPokemonForms } from "#data/pokemon-forms";
-import { initSpecies } from "#data/pokemon-species";
 import { BiomeId } from "#enums/biome-id";
 import { GachaType } from "#enums/gacha-types";
 import { getBiomeHasProps } from "#field/arena";
-import { initModifierPools } from "#modifiers/init-modifier-pools";
-import { initModifierTypes } from "#modifiers/modifier-type";
-import { initMoves } from "#moves/move";
-import { initMysteryEncounters } from "#mystery-encounters/mystery-encounters";
 import { CacheBustedLoaderPlugin } from "#plugins/cache-busted-loader-plugin";
-import { initAchievements } from "#system/achv";
-import { initVouchers } from "#system/voucher";
-import { initStatsKeys } from "#ui/game-stats-ui-handler";
 import { getWindowVariantSuffix, WindowVariant } from "#ui/ui-theme";
 import { hasAllLocalizedSprites, localPing } from "#utils/common";
 import { getEnumValues } from "#utils/enums";
 import i18next from "i18next";
+import type { GameObjects } from "phaser";
 
 export class LoadingScene extends SceneBase {
   public static readonly KEY = "loading";
@@ -366,29 +353,11 @@ export class LoadingScene extends SceneBase {
 
     this.loadLoadingScreen();
 
-    initModifierTypes();
-    initModifierPools();
-
-    initAchievements();
-    initVouchers();
-    initStatsKeys();
-    initPokemonPrevolutions();
-    initPokemonStarters();
-    initBiomes();
-    initEggMoves();
-    initPokemonForms();
-    initTrainerTypeDialogue();
-    initSpecies();
-    initMoves();
-    initAbilities();
-    initChallenges();
-    initMysteryEncounters();
+    initializeGame();
   }
 
   loadLoadingScreen() {
     const mobile = isMobile();
-
-    const loadingGraphics: any[] = [];
 
     const bg = this.add.image(0, 0, "");
     bg.setOrigin(0, 0);
@@ -460,6 +429,7 @@ export class LoadingScene extends SceneBase {
     });
     disclaimerDescriptionText.setOrigin(0.5, 0.5);
 
+    const loadingGraphics: (GameObjects.Image | GameObjects.Graphics | GameObjects.Text)[] = [];
     loadingGraphics.push(
       bg,
       graphics,

--- a/test/test-utils/game-manager.ts
+++ b/test/test-utils/game-manager.ts
@@ -124,7 +124,6 @@ export class GameManager {
     this.reload = new ReloadHelper(this);
     this.modifiers = new ModifierHelper(this);
     this.field = new FieldHelper(this);
-    this.override.sanitizeOverrides();
 
     // Disables Mystery Encounters on all tests (can be overridden at test level)
     this.override.mysteryEncounterChance(0);

--- a/test/test-utils/helpers/overrides-helper.ts
+++ b/test/test-utils/helpers/overrides-helper.ts
@@ -3,7 +3,7 @@ import type { NewArenaEvent } from "#events/battle-scene";
 /** biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 
 import type { BattleStyle, RandomTrainerOverride } from "#app/overrides";
-import Overrides, { defaultOverrides } from "#app/overrides";
+import Overrides from "#app/overrides";
 import { AbilityId } from "#enums/ability-id";
 import type { BattleType } from "#enums/battle-type";
 import { BiomeId } from "#enums/biome-id";
@@ -19,7 +19,7 @@ import type { ModifierOverride } from "#modifiers/modifier-type";
 import type { Variant } from "#sprites/variant";
 import { GameManagerHelper } from "#test/test-utils/helpers/game-manager-helper";
 import { coerceArray, shiftCharCodes } from "#utils/common";
-import { expect, vi } from "vitest";
+import { vi } from "vitest";
 
 /**
  * Helper to handle overrides in tests
@@ -666,15 +666,5 @@ export class OverridesHelper extends GameManagerHelper {
 
   private log(...params: any[]) {
     console.log("Overrides:", ...params);
-  }
-
-  public sanitizeOverrides(): void {
-    for (const key of Object.keys(defaultOverrides)) {
-      if (Overrides[key] !== defaultOverrides[key]) {
-        vi.spyOn(Overrides, key as any, "get").mockReturnValue(defaultOverrides[key]);
-      }
-    }
-    expect(Overrides).toEqual(defaultOverrides);
-    this.log("Sanitizing all overrides!");
   }
 }

--- a/test/test-utils/test-file-initialization.ts
+++ b/test/test-utils/test-file-initialization.ts
@@ -30,7 +30,7 @@ export function initTests(): void {
 /**
  * Initialize various values at the beginning of each testing instance.
  */
-export function initTestFile(): void {
+function initTestFile(): void {
   initI18n();
   initializeGame();
 }

--- a/test/test-utils/test-file-initialization.ts
+++ b/test/test-utils/test-file-initialization.ts
@@ -1,35 +1,21 @@
-import { initAbilities } from "#abilities/ability";
-import { initLoggedInUser } from "#app/account";
 import { SESSION_ID_COOKIE_NAME } from "#app/constants";
-import { initBiomes } from "#balance/biomes";
-import { initEggMoves } from "#balance/egg-moves";
-import { initPokemonPrevolutions, initPokemonStarters } from "#balance/pokemon-evolutions";
-import { initPokemonForms } from "#data/pokemon-forms";
-import { initSpecies } from "#data/pokemon-species";
-import { initModifierPools } from "#modifiers/init-modifier-pools";
-import { initModifierTypes } from "#modifiers/modifier-type";
-import { initMoves } from "#moves/move";
-import { initMysteryEncounters } from "#mystery-encounters/mystery-encounters";
+import { initializeGame } from "#app/init/init";
 import { initI18n } from "#plugins/i18n";
-import { initAchievements } from "#system/achv";
-import { initVouchers } from "#system/voucher";
 import { blobToString } from "#test/test-utils/game-manager-utils";
 import { manageListeners } from "#test/test-utils/listeners-manager";
 import { MockConsoleLog } from "#test/test-utils/mocks/mock-console-log";
 import { mockContext } from "#test/test-utils/mocks/mock-context-canvas";
 import { mockLocalStorage } from "#test/test-utils/mocks/mock-local-storage";
 import { MockImage } from "#test/test-utils/mocks/mocks-container/mock-image";
-import { initStatsKeys } from "#ui/game-stats-ui-handler";
 import { setCookie } from "#utils/cookies";
 import Phaser from "phaser";
 import BBCodeText from "phaser3-rex-plugins/plugins/bbcodetext";
 import InputText from "phaser3-rex-plugins/plugins/inputtext";
 
-let wasInitialized = false;
 /**
  * An initialization function that is run at the beginning of every test file (via `beforeAll()`).
  */
-export function initTestFile() {
+export async function initTestFile() {
   // Set the timezone to UTC for tests.
   process.env.TZ = "UTC";
 
@@ -87,26 +73,8 @@ export function initTestFile() {
   HTMLCanvasElement.prototype.getContext = () => mockContext;
 
   // Initialize all of these things if and only if they have not been initialized yet
-  if (!wasInitialized) {
-    wasInitialized = true;
-    initI18n();
-    initModifierTypes();
-    initModifierPools();
-    initVouchers();
-    initAchievements();
-    initStatsKeys();
-    initPokemonPrevolutions();
-    initBiomes();
-    initEggMoves();
-    initPokemonForms();
-    initSpecies();
-    initMoves();
-    initAbilities();
-    initLoggedInUser();
-    initMysteryEncounters();
-    // init the pokemon starters for the pokedex
-    initPokemonStarters();
-  }
+  await initI18n();
+  initializeGame();
 
   manageListeners();
 }

--- a/test/test-utils/test-file-initialization.ts
+++ b/test/test-utils/test-file-initialization.ts
@@ -18,6 +18,7 @@ let wasInitialized = false;
  * Run initialization code upon starting a new file, both per-suite and per-instance oncess.
  */
 export function initTests(): void {
+  setupStubs();
   if (!wasInitialized) {
     initTestFile();
     wasInitialized = true;
@@ -30,7 +31,6 @@ export function initTests(): void {
  * Initialize various values at the beginning of each testing instance.
  */
 export function initTestFile(): void {
-  setupStubs();
   initI18n();
   initializeGame();
 }
@@ -38,6 +38,7 @@ export function initTestFile(): void {
 /**
  * Setup various stubs for testing.
  * @todo Move this into a dedicated stub file instead of running it once per test instance
+ * @todo Investigate why this resets on new test suite start
  */
 function setupStubs(): void {
   Object.defineProperty(window, "localStorage", {

--- a/test/test-utils/test-file-initialization.ts
+++ b/test/test-utils/test-file-initialization.ts
@@ -2,6 +2,7 @@ import { SESSION_ID_COOKIE_NAME } from "#app/constants";
 import { initializeGame } from "#app/init/init";
 import { initI18n } from "#plugins/i18n";
 import { blobToString } from "#test/test-utils/game-manager-utils";
+import { manageListeners } from "#test/test-utils/listeners-manager";
 import { MockConsoleLog } from "#test/test-utils/mocks/mock-console-log";
 import { mockContext } from "#test/test-utils/mocks/mock-context-canvas";
 import { mockLocalStorage } from "#test/test-utils/mocks/mock-local-storage";
@@ -11,8 +12,22 @@ import Phaser from "phaser";
 import BBCodeText from "phaser3-rex-plugins/plugins/bbcodetext";
 import InputText from "phaser3-rex-plugins/plugins/inputtext";
 
+let wasInitialized = false;
+
 /**
- * A initialization function that is run at the beginning of every testing instance (via `beforeAll()`).
+ * Run initialization code upon starting a new file, both per-suite and per-instance oncess.
+ */
+export function initTests(): void {
+  if (!wasInitialized) {
+    initTestFile();
+    wasInitialized = true;
+  }
+
+  manageListeners();
+}
+
+/**
+ * Initialize various values at the beginning of each testing instance.
  */
 export function initTestFile(): void {
   setupStubs();

--- a/test/test-utils/test-file-initialization.ts
+++ b/test/test-utils/test-file-initialization.ts
@@ -12,20 +12,17 @@ import BBCodeText from "phaser3-rex-plugins/plugins/bbcodetext";
 import InputText from "phaser3-rex-plugins/plugins/inputtext";
 
 /**
- * An initialization function that is run at the beginning of every _test file_ (via `beforeAll()`).
+ * A initialization function that is run at the beginning of every testing instance (via `beforeAll()`).
  */
 export function initTestFile(): void {
   setupStubs();
-
-  // Initialize all of these things if and only if they have not been initialized yet.
   initI18n();
   initializeGame();
-  console.log("Game initialized!");
 }
 
 /**
  * Setup various stubs for testing.
- * @todo Move this into a dedicated stub file instead of running it once per test file init
+ * @todo Move this into a dedicated stub file instead of running it once per test instance
  */
 function setupStubs(): void {
   Object.defineProperty(window, "localStorage", {

--- a/test/test-utils/test-file-initialization.ts
+++ b/test/test-utils/test-file-initialization.ts
@@ -2,7 +2,6 @@ import { SESSION_ID_COOKIE_NAME } from "#app/constants";
 import { initializeGame } from "#app/init/init";
 import { initI18n } from "#plugins/i18n";
 import { blobToString } from "#test/test-utils/game-manager-utils";
-import { manageListeners } from "#test/test-utils/listeners-manager";
 import { MockConsoleLog } from "#test/test-utils/mocks/mock-console-log";
 import { mockContext } from "#test/test-utils/mocks/mock-context-canvas";
 import { mockLocalStorage } from "#test/test-utils/mocks/mock-local-storage";
@@ -13,12 +12,22 @@ import BBCodeText from "phaser3-rex-plugins/plugins/bbcodetext";
 import InputText from "phaser3-rex-plugins/plugins/inputtext";
 
 /**
- * An initialization function that is run at the beginning of every test file (via `beforeAll()`).
+ * An initialization function that is run at the beginning of every _test file_ (via `beforeAll()`).
  */
-export async function initTestFile() {
-  // Set the timezone to UTC for tests.
-  process.env.TZ = "UTC";
+export function initTestFile(): void {
+  setupStubs();
 
+  // Initialize all of these things if and only if they have not been initialized yet.
+  initI18n();
+  initializeGame();
+  console.log("Game initialized!");
+}
+
+/**
+ * Setup various stubs for testing.
+ * @todo Move this into a dedicated stub file instead of running it once per test file init
+ */
+function setupStubs(): void {
   Object.defineProperty(window, "localStorage", {
     value: mockLocalStorage(),
   });
@@ -54,9 +63,9 @@ export async function initTestFile() {
 
   /**
    * Sets this object's position relative to another object with a given offset
-   * @param guideObject {@linkcode Phaser.GameObjects.GameObject} to base the position off of
-   * @param x The relative x position
-   * @param y The relative y position
+   * @param guideObject - The {@linkcode Phaser.GameObjects.GameObject} to base the position off of
+   * @param x - The relative x position
+   * @param y - The relative y position
    */
   const setPositionRelative = function (guideObject: any, x: number, y: number): any {
     const offsetX = guideObject.width * (-0.5 + (0.5 - guideObject.originX));
@@ -71,12 +80,6 @@ export async function initTestFile() {
   Phaser.GameObjects.Text.prototype.setPositionRelative = setPositionRelative;
   Phaser.GameObjects.Rectangle.prototype.setPositionRelative = setPositionRelative;
   HTMLCanvasElement.prototype.getContext = () => mockContext;
-
-  // Initialize all of these things if and only if they have not been initialized yet
-  await initI18n();
-  initializeGame();
-
-  manageListeners();
 }
 
 /**

--- a/test/vitest.setup.ts
+++ b/test/vitest.setup.ts
@@ -51,9 +51,15 @@ vi.mock("i18next", async importOriginal => {
 
 global.testFailed = false;
 
-initTestFile();
+let wasInitialized = false;
 
 beforeAll(() => {
+  // Run the init code once per thread, and manage listeners once per file
+  if (!wasInitialized) {
+    initTestFile();
+    wasInitialized = true;
+  }
+
   manageListeners();
 });
 

--- a/test/vitest.setup.ts
+++ b/test/vitest.setup.ts
@@ -50,8 +50,9 @@ vi.mock("i18next", async importOriginal => {
 
 global.testFailed = false;
 
-beforeAll(() => {
-  initTestFile();
+beforeAll(async () => {
+  await initTestFile();
+  console.log("Test file initialized!");
 });
 
 afterAll(() => {

--- a/test/vitest.setup.ts
+++ b/test/vitest.setup.ts
@@ -1,6 +1,5 @@
 import "vitest-canvas-mock";
-import { manageListeners } from "#test/test-utils/listeners-manager";
-import { initTestFile } from "#test/test-utils/test-file-initialization";
+import { initTests } from "#test/test-utils/test-file-initialization";
 import { afterAll, beforeAll, vi } from "vitest";
 
 /** Set the timezone to UTC for tests. */
@@ -51,16 +50,8 @@ vi.mock("i18next", async importOriginal => {
 
 global.testFailed = false;
 
-let wasInitialized = false;
-
 beforeAll(() => {
-  // Run the init code once per thread, and manage listeners once per file
-  if (!wasInitialized) {
-    initTestFile();
-    wasInitialized = true;
-  }
-
-  manageListeners();
+  initTests();
 });
 
 afterAll(() => {

--- a/test/vitest.setup.ts
+++ b/test/vitest.setup.ts
@@ -1,4 +1,5 @@
 import "vitest-canvas-mock";
+import { manageListeners } from "#test/test-utils/listeners-manager";
 import { initTestFile } from "#test/test-utils/test-file-initialization";
 import { afterAll, beforeAll, vi } from "vitest";
 
@@ -50,9 +51,10 @@ vi.mock("i18next", async importOriginal => {
 
 global.testFailed = false;
 
-beforeAll(async () => {
-  await initTestFile();
-  console.log("Test file initialized!");
+initTestFile();
+
+beforeAll(() => {
+  manageListeners();
 });
 
 afterAll(() => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,9 @@ import { defaultConfig } from "./vite.config";
 export default defineProject(({ mode }) => ({
   ...defaultConfig,
   test: {
+    env: {
+      TZ: "UTC",
+    },
     testTimeout: 20000,
     setupFiles: ["./test/font-face.setup.ts", "./test/vitest.setup.ts"],
     sequence: {


### PR DESCRIPTION
- **Removed `sanitizeOverrides`**
- **Moved initialization code to its own file**

## What are the changes the user will see?
N/A

## Why am I making these changes?
It is nice to have all our init code in 1 place.
Also `sanitizeOverrides` did nothing as we mocked the module via vitest

## What are the changes from a developer perspective?
Removed santize overrides
Moved init code to new file

Made a few internal interfaces in biomes.ts internal for reasons

## Screenshots/Videos
N/A
## How to test the changes?
Test the game?

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
