### PR TITLE
[UI/UX] [Localization] Apply single-column Game Stats to more languages

### DIFF
--- a/src/ui/game-stats-ui-handler.ts
+++ b/src/ui/game-stats-ui-handler.ts
@@ -230,7 +230,7 @@ export class GameStatsUiHandler extends UiHandler {
     const resolvedLang = i18next.resolvedLanguage ?? "en";
     // NOTE TO TRANSLATION TEAM: Add more languages that want to display
     // in a single-column inside of the `[]` (e.g. `["ru", "fr"]`)
-    return ["ru"].includes(resolvedLang);
+    return ["fr", "es-ES", "es-MX", "it", "ja", "pt-BR", "ru"].includes(resolvedLang);
   }
   /** The number of columns used by this menu in the resolved language */
   private get columnCount(): 1 | 2 {


### PR DESCRIPTION
## What are the changes the user will see?
French, both Spanish, Italian, Japanese et Brazilian Portuguese players will also have a Game Stats menu as a single column on top of Russian, already having it.

## Why am I making these changes?
Two columns makes things too tight for these languages

## What are the changes from a developer perspective?
None

## How to test the changes?
Play the game in these languages and check the Game Stats

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [X] Have I made sure that any UI change works for both UI themes (default and legacy)?
