### PR TITLE
[Bug] Fix Thrash continuing on caught Pokemon

### DIFF
--- a/src/phases/attempt-capture-phase.ts
+++ b/src/phases/attempt-capture-phase.ts
@@ -279,6 +279,7 @@ export class AttemptCapturePhase extends PokemonPhase {
             globalScene.updateModifiers(true);
             removePokemon();
             if (newPokemon) {
+              newPokemon.leaveField(true, true, false);
               newPokemon.loadAssets().then(end);
             } else {
               end();

--- a/test/phases/capture-phase.test.ts
+++ b/test/phases/capture-phase.test.ts
@@ -1,0 +1,37 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, it } from "vitest";
+
+describe("Capture Phase", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleStyle("single")
+      .criticalHits(false)
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset(MoveId.SPLASH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  // TODO: write test and enable once the phase's logic has been refactored
+  it.todo("should reset the captured Pokemon's temporary data");
+});


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-  [Bug]: If the PR is primarily a bug fix
-  [Move]: If a move has new or changed functionality
-  [Ability]: If an ability has new or changed functionality
-  [Item]: For new or modified items
-  [Mystery]: For new or modified Mystery Encounters
-  [Test]: If the PR is primarily adding or modifying tests
-  [UI/UX]: If the PR is changing UI/UX elements
-  [Audio]: If the PR is adding or changing music/sfx
-  [Sprite]: If the PR is adding or changing sprites
-  [Balance]: If the PR is related to game balance
-  [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-  [Dev]: If the PR is primarily changing something pertaining to development (lefthook hooks, linter rules, etc.)
-  [i18n]: If the PR is primarily adding/changing locale keys or key usage (may come with an associated locales PR)
-  [Docs]: If the PR is adding or modifying documentation (such as tsdocs/code comments)
-  [GitHub]: For changes to GitHub workflows/templates/etc
-  [Misc]: If no other category fits the PR
-->

<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small!)
-->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
After catching a wild Pokemon that is using Thrash, the Pokemon will no longer be using Thrash when sent out immediately in a double battle. 
## Why am I making these changes?
<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->
Fixes #5956
## What are the changes from a developer perspective?
<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->
In `attempt-capture-phase.test.ts`, both addToParty and removePokemon will now call leaveField, when previously only removePokemon did.
A dummy test file has been created for the Capture Phase.

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->
Before:

https://github.com/user-attachments/assets/605a6307-d795-4938-8a72-6539474bbcf2

After:

https://github.com/user-attachments/assets/f73d9328-cf37-468a-936c-2d0b41c7826e


## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->
```typescript
const overrides = {
  STARTER_SPECIES_OVERRIDE: SpeciesId.DITTO,
  STARTING_LEVEL_OVERRIDE: 1000,
  OPP_MOVESET_OVERRIDE: [MoveId.THRASH],
  POKEBALL_OVERRIDE: {
  active: true,
    pokeballs: {
      [PokeballType.POKEBALL]: 5,
      [PokeballType.GREAT_BALL]: 0,
      [PokeballType.ULTRA_BALL]: 0,
      [PokeballType.ROGUE_BALL]: 0,
      [PokeballType.MASTER_BALL]: 1,
    }
  },
  BATTLE_STYLE_OVERRIDE: "double",
  MOVESET_OVERRIDE:  [MoveId.THRASH, MoveId.AIR_SLASH, MoveId.SPLASH]
} satisfies Partial<InstanceType<OverridesType>>;
```

In first double battle, knock out one Pokemon and catch the other. In the next turn, you should be able to select moves for both Ditto and the newly caught Pokemon.


## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [] ~~Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] ~~Have I made sure that any UI change works for both UI themes (default and legacy)?~~