### PR TITLE
[Refactor] Prevent serialization of entire species form in pokemon summon data

### DIFF
--- a/src/@types/type-helpers.ts
+++ b/src/@types/type-helpers.ts
@@ -75,3 +75,14 @@ export type NonFunctionPropertiesRecursive<Class> = {
 };
 
 export type AbstractConstructor<T> = abstract new (...args: any[]) => T;
+
+/**
+ * Type helper that iterates through the fields of the type and coerces any `null` properties to `undefined` (including in union types).
+ *
+ * @remarks
+ * This is primarily useful when an object with nullable properties wants to be serialized and have its `null`
+ * properties coerced to `undefined`.
+ */
+export type CoerceNullPropertiesToUndefined<T extends object> = {
+  [K in keyof T]: null extends T[K] ? Exclude<T[K], null> | undefined : T[K];
+};

--- a/src/data/pokemon/pokemon-data.ts
+++ b/src/data/pokemon/pokemon-data.ts
@@ -75,7 +75,7 @@ function deserializePokemonSpeciesForm(value: SerializedSpeciesForm | PokemonSpe
 }
 
 interface SerializedIllusionData extends Omit<IllusionData, "fusionSpecies"> {
-  /** The id of the illusioned fusion species, or undefined if not a fusion */
+  /** The id of the illusioned fusion species, or `undefined` if not a fusion */
   fusionSpecies?: SpeciesId;
 }
 
@@ -168,7 +168,6 @@ export class PokemonSummonData {
           ...value,
         };
         if (!isNullOrUndefined(illusionData.fusionSpecies)) {
-          6;
           switch (typeof illusionData.fusionSpecies) {
             case "object":
               illusionData.fusionSpecies = allSpecies[illusionData.fusionSpecies.speciesId];

--- a/src/data/pokemon/pokemon-data.ts
+++ b/src/data/pokemon/pokemon-data.ts
@@ -1,17 +1,28 @@
 import { type BattlerTag, loadBattlerTag } from "#data/battler-tags";
+import { allSpecies } from "#data/data-lists";
 import type { Gender } from "#data/gender";
 import { PokemonMove } from "#data/moves/pokemon-move";
-import type { PokemonSpeciesForm } from "#data/pokemon-species";
+import { getPokemonSpeciesForm, type PokemonSpeciesForm } from "#data/pokemon-species";
 import type { TypeDamageMultiplier } from "#data/type";
 import type { AbilityId } from "#enums/ability-id";
 import type { BerryType } from "#enums/berry-type";
 import type { MoveId } from "#enums/move-id";
 import type { Nature } from "#enums/nature";
 import type { PokemonType } from "#enums/pokemon-type";
+import type { SpeciesId } from "#enums/species-id";
 import type { AttackMoveResult } from "#types/attack-move-result";
 import type { IllusionData } from "#types/illusion-data";
 import type { TurnMove } from "#types/turn-move";
+import type { CoerceNullPropertiesToUndefined } from "#types/type-helpers";
 import { isNullOrUndefined } from "#utils/common";
+
+/**
+ * The type that {@linkcode PokemonSpeciesForm} is converted to when an object containing it serializes it.
+ */
+type SerializedSpeciesForm = {
+  id: SpeciesId;
+  formIdx: number;
+};
 
 /**
  * Permanent data that can customize a Pokemon in non-standard ways from its Species.
@@ -42,8 +53,58 @@ export class CustomPokemonData {
 }
 
 /**
+ * Deserialize a pokemon species form from an object containing `id` and `formIdx` properties.
+ * @param value - The value to deserialize
+ * @returns The `PokemonSpeciesForm` or `null` if the fields could not be properly discerned
+ */
+function deserializePokemonSpeciesForm(value: SerializedSpeciesForm | PokemonSpeciesForm): PokemonSpeciesForm | null {
+  // @ts-expect-error: We may be deserializing a PokemonSpeciesForm, but we catch later on
+  let { id, formIdx } = value;
+
+  if (isNullOrUndefined(id) || isNullOrUndefined(formIdx)) {
+    // @ts-expect-error: Typescript doesn't know that in block, `value` must be a PokemonSpeciesForm
+    id = value.speciesId;
+    // @ts-expect-error: Same as above (plus we are accessing a protected property)
+    formIdx = value._formIndex;
+  }
+  // If for some reason either of these fields are null/undefined, we cannot reconstruct the species form
+  if (isNullOrUndefined(id) || isNullOrUndefined(formIdx)) {
+    return null;
+  }
+  return getPokemonSpeciesForm(id, formIdx);
+}
+
+interface SerializedIllusionData extends Omit<IllusionData, "fusionSpecies"> {
+  /** The id of the illusioned fusion species, or undefined if not a fusion */
+  fusionSpecies?: SpeciesId;
+}
+
+interface SerializedPokemonSummonData {
+  statStages: number[];
+  moveQueue: TurnMove[];
+  tags: BattlerTag[];
+  abilitySuppressed: boolean;
+  speciesForm?: SerializedSpeciesForm;
+  fusionSpeciesForm?: SerializedSpeciesForm;
+  ability?: AbilityId;
+  passiveAbility?: AbilityId;
+  gender?: Gender;
+  fusionGender?: Gender;
+  stats: number[];
+  moveset?: PokemonMove[];
+  types: PokemonType[];
+  addedType?: PokemonType;
+  illusion?: SerializedIllusionData;
+  illusionBroken: boolean;
+  berriesEatenLast: BerryType[];
+  moveHistory: TurnMove[];
+}
+
+/**
  * Persistent in-battle data for a {@linkcode Pokemon}.
  * Resets on switch or new battle.
+ *
+ * @sealed
  */
 export class PokemonSummonData {
   /** [Atk, Def, SpAtk, SpDef, Spd, Acc, Eva] */
@@ -86,7 +147,7 @@ export class PokemonSummonData {
    */
   public moveHistory: TurnMove[] = [];
 
-  constructor(source?: PokemonSummonData | Partial<PokemonSummonData>) {
+  constructor(source?: PokemonSummonData | SerializedPokemonSummonData) {
     if (isNullOrUndefined(source)) {
       return;
     }
@@ -95,6 +156,31 @@ export class PokemonSummonData {
     for (const [key, value] of Object.entries(source)) {
       if (isNullOrUndefined(value) && this.hasOwnProperty(key)) {
         continue;
+      }
+
+      if (key === "speciesForm" || key === "fusionSpeciesForm") {
+        this[key] = deserializePokemonSpeciesForm(value);
+      }
+
+      if (key === "illusion" && typeof value === "object") {
+        // Make a copy so as not to mutate provided value
+        const illusionData = {
+          ...value,
+        };
+        if (!isNullOrUndefined(illusionData.fusionSpecies)) {
+          6;
+          switch (typeof illusionData.fusionSpecies) {
+            case "object":
+              illusionData.fusionSpecies = allSpecies[illusionData.fusionSpecies.speciesId];
+              break;
+            case "number":
+              illusionData.fusionSpecies = allSpecies[illusionData.fusionSpecies];
+              break;
+            default:
+              illusionData.fusionSpecies = undefined;
+          }
+        }
+        this[key] = illusionData as IllusionData;
       }
 
       if (key === "moveset") {
@@ -109,6 +195,49 @@ export class PokemonSummonData {
       }
       this[key] = value;
     }
+  }
+
+  /**
+   * Serialize this PokemonSummonData to JSON, converting {@linkcode PokemonSpeciesForm} and {@linkcode IllusionData.fusionSpecies}
+   * into simpler types instead of serializing all of their fields.
+   *
+   * @remarks
+   * - `IllusionData.fusionSpecies` is serialized as just the species ID
+   * - `PokemonSpeciesForm` and `PokemonSpeciesForm.fusionSpeciesForm` are converted into {@linkcode SerializedSpeciesForm} objects
+   */
+  public toJSON(): SerializedPokemonSummonData {
+    // Pokemon species forms are never saved, only the species ID.
+    const illusion = this.illusion;
+    const speciesForm = this.speciesForm;
+    const fusionSpeciesForm = this.fusionSpeciesForm;
+    const illusionSpeciesForm = illusion?.fusionSpecies;
+    const t = {
+      // the "as omit" is required to avoid TS resolving the overwritten properties to "never"
+      // We coerce null to undefined in the type, as the for loop below replaces `null` with `undefined`
+      ...(this as Omit<
+        CoerceNullPropertiesToUndefined<PokemonSummonData>,
+        "speciesForm" | "fusionSpeciesForm" | "illusion"
+      >),
+      speciesForm: isNullOrUndefined(speciesForm)
+        ? undefined
+        : { id: speciesForm?.speciesId, formIdx: speciesForm?.formIndex },
+      fusionSpeciesForm: isNullOrUndefined(fusionSpeciesForm)
+        ? undefined
+        : { id: fusionSpeciesForm?.speciesId, formIdx: fusionSpeciesForm?.formIndex },
+      illusion: isNullOrUndefined(illusion)
+        ? undefined
+        : {
+            ...(this.illusion as Omit<typeof illusion, "fusionSpecies">),
+            fusionSpecies: illusionSpeciesForm?.speciesId,
+          },
+    };
+    // Replace `null` with `undefined`, as `undefined` never gets serialized
+    for (const [key, value] of Object.entries(t)) {
+      if (value === null) {
+        t[key] = undefined;
+      }
+    }
+    return t;
   }
 }
 

--- a/src/data/pokemon/pokemon-data.ts
+++ b/src/data/pokemon/pokemon-data.ts
@@ -219,10 +219,10 @@ export class PokemonSummonData {
       >),
       speciesForm: isNullOrUndefined(speciesForm)
         ? undefined
-        : { id: speciesForm?.speciesId, formIdx: speciesForm?.formIndex },
+        : { id: speciesForm.speciesId, formIdx: speciesForm.formIndex },
       fusionSpeciesForm: isNullOrUndefined(fusionSpeciesForm)
         ? undefined
-        : { id: fusionSpeciesForm?.speciesId, formIdx: fusionSpeciesForm?.formIndex },
+        : { id: fusionSpeciesForm.speciesId, formIdx: fusionSpeciesForm.formIndex },
       illusion: isNullOrUndefined(illusion)
         ? undefined
         : {


### PR DESCRIPTION
## What are the changes the user will see?
Smaller sizes of saved session data.

## Why am I making these changes?
Writing the entire structure of `pokemonSpecies` when serializing data is completely unnecessary, as the data for a species is static. All we need are enough fields to reconstruct.
Also, this simplifies the zod schemas for the save migrator rewrite.

## What are the changes from a developer perspective?
Added a `toJSON` method to `PokemonSummonData` that does a few things
- Null fields are replaced with undefined
- Fields that used `PokemonSpeciesForm` instead serialize an object containing the species ID and the particular form index.
- Fields (specifically `illusionData.fusionSpecies` serializes to just the speciesID.
- A new type helper, `CoerceNullProperitesToUndefined` was added.

## Screenshots/Videos
No UI changes, and a video for this is sorta cumbersome.


## How to test the changes?
Load up an old save that had a pokemon that would have serialized a pokemon species in its summon data. Usually, ditto.
Use ditto to transform, go to next wave, then save and quit. Ensure that loading in keeps fields as expected.
It did for me.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - ~~[ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?