### PR TITLE
[Test] Added `timeoutManager` to reset lingering timeouts on test end

### DIFF
--- a/test/test-utils/listeners-manager.ts
+++ b/test/test-utils/listeners-manager.ts
@@ -19,8 +19,10 @@ let currentListener: NodeJS.MessageListener | null;
 
 export function manageListeners() {
   if (firstTime) {
+    console.log("First Time");
     initialListeners.push(...process.listeners("message"));
   } else {
+    console.log("Not first time");
     expect(process.listeners("message").length).toBeLessThan(7);
 
     // Remove the listener that was used during the previous test file

--- a/test/test-utils/listeners-manager.ts
+++ b/test/test-utils/listeners-manager.ts
@@ -19,10 +19,8 @@ let currentListener: NodeJS.MessageListener | null;
 
 export function manageListeners() {
   if (firstTime) {
-    console.log("First Time");
     initialListeners.push(...process.listeners("message"));
   } else {
-    console.log("Not first time");
     expect(process.listeners("message").length).toBeLessThan(7);
 
     // Remove the listener that was used during the previous test file

--- a/test/test-utils/test-file-initialization.ts
+++ b/test/test-utils/test-file-initialization.ts
@@ -20,13 +20,13 @@ let wasInitialized = false;
  */
 export function initTests(): void {
   setupStubs();
-  manageTimeouts();
   if (!wasInitialized) {
     initTestFile();
     wasInitialized = true;
   }
 
   manageListeners();
+  manageTimeouts();
 }
 
 /**

--- a/test/test-utils/test-file-initialization.ts
+++ b/test/test-utils/test-file-initialization.ts
@@ -20,9 +20,9 @@ let wasInitialized = false;
  */
 export function initTests(): void {
   setupStubs();
+  manageTimeouts();
   if (!wasInitialized) {
     initTestFile();
-    manageTimeouts();
     wasInitialized = true;
   }
 

--- a/test/test-utils/test-file-initialization.ts
+++ b/test/test-utils/test-file-initialization.ts
@@ -7,6 +7,7 @@ import { MockConsoleLog } from "#test/test-utils/mocks/mock-console-log";
 import { mockContext } from "#test/test-utils/mocks/mock-context-canvas";
 import { mockLocalStorage } from "#test/test-utils/mocks/mock-local-storage";
 import { MockImage } from "#test/test-utils/mocks/mocks-container/mock-image";
+import { manageTimeouts } from "#test/test-utils/timeout-manager";
 import { setCookie } from "#utils/cookies";
 import Phaser from "phaser";
 import BBCodeText from "phaser3-rex-plugins/plugins/bbcodetext";
@@ -21,6 +22,7 @@ export function initTests(): void {
   setupStubs();
   if (!wasInitialized) {
     initTestFile();
+    manageTimeouts();
     wasInitialized = true;
   }
 

--- a/test/test-utils/tests/timeout-reset.test.ts
+++ b/test/test-utils/tests/timeout-reset.test.ts
@@ -19,6 +19,6 @@ describe("Timeout resets", () => {
     const initCounter = counter;
     await setTimeout(500);
     // Were the interval active, the counter would have increased by now
-    expect(counter).toBe(initCounter);
+    expect(counter, "Timeout was not reset between test runs!").toBe(initCounter);
   });
 });

--- a/test/test-utils/tests/timeout-reset.test.ts
+++ b/test/test-utils/tests/timeout-reset.test.ts
@@ -1,0 +1,24 @@
+import { setTimeout } from "timers/promises";
+import { describe, expect, it, vi } from "vitest";
+
+describe("Timeout resets", () => {
+  let counter = 1;
+
+  it.sequential("should not reset intervals during test", async () => {
+    vi.spyOn(global, "clearInterval");
+    setInterval(() => {
+      console.log("interval called");
+      counter++;
+      expect(counter).toBeLessThan(200);
+    }, 50);
+    await vi.waitUntil(() => counter > 2);
+    expect(clearInterval).not.toHaveBeenCalled();
+  });
+
+  it.sequential("should reset intervals after test end", async () => {
+    const initCounter = counter;
+    await setTimeout(500);
+    // Were the interval active, the counter would have increased by now
+    expect(counter).toBe(initCounter);
+  });
+});

--- a/test/test-utils/timeout-manager.ts
+++ b/test/test-utils/timeout-manager.ts
@@ -83,6 +83,7 @@ export function manageTimeouts() {
 }
 
 beforeEach(() => {
+  console.log("Clearing prior timeouts on new test start");
   allTimeouts.splice(0);
   allImmediates.splice(0);
 });

--- a/test/test-utils/timeout-manager.ts
+++ b/test/test-utils/timeout-manager.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach } from "vitest";
+import { afterEach } from "vitest";
 
 /** An array of pending timeouts and intervals to clear on test end. */
 const allTimeouts: NodeJS.Timeout[] = [];
@@ -32,7 +32,6 @@ export function manageTimeouts() {
   global.setInterval = ((...args: Parameters<typeof globalThis.setInterval>) => {
     const interval = origInterval(...args);
     allTimeouts.push(interval);
-    console.log("Interval added!!");
     return interval;
   }) as typeof global.setInterval;
 
@@ -83,15 +82,9 @@ export function manageTimeouts() {
   };
 }
 
-beforeEach(() => {
-  console.log("Clearing prior timeouts on new test start", allTimeouts.length);
-  allTimeouts.splice(0);
-  allImmediates.splice(0);
-});
-
 // Clear all lingering timeouts on test end.
 afterEach(() => {
-  console.log("Clearing timeouts on test end", allTimeouts.length);
+  console.log("Clearing %d timeouts on test end", allTimeouts.length + allImmediates.length);
   // NB: The absolute WORST CASE SCENARIO for this is us clearing a timeout twice in a row
   // (behavior which MDN web docs has certified to be a no-op)
   for (const timeout of allTimeouts) {
@@ -101,4 +94,6 @@ afterEach(() => {
   for (const immediate of allImmediates) {
     origClearImmediate(immediate);
   }
+  allTimeouts.splice(0);
+  allImmediates.splice(0);
 });

--- a/test/test-utils/timeout-manager.ts
+++ b/test/test-utils/timeout-manager.ts
@@ -32,6 +32,7 @@ export function manageTimeouts() {
   global.setInterval = ((...args: Parameters<typeof globalThis.setInterval>) => {
     const interval = origInterval(...args);
     allTimeouts.push(interval);
+    console.log("Interval added!!");
     return interval;
   }) as typeof global.setInterval;
 
@@ -83,13 +84,14 @@ export function manageTimeouts() {
 }
 
 beforeEach(() => {
-  console.log("Clearing prior timeouts on new test start");
+  console.log("Clearing prior timeouts on new test start", allTimeouts.length);
   allTimeouts.splice(0);
   allImmediates.splice(0);
 });
 
 // Clear all lingering timeouts on test end.
 afterEach(() => {
+  console.log("Clearing timeouts on test end", allTimeouts.length);
   // NB: The absolute WORST CASE SCENARIO for this is us clearing a timeout twice in a row
   // (behavior which MDN web docs has certified to be a no-op)
   for (const timeout of allTimeouts) {

--- a/test/test-utils/timeout-manager.ts
+++ b/test/test-utils/timeout-manager.ts
@@ -1,5 +1,3 @@
-import { afterEach } from "vitest";
-
 /** An array of pending timeouts and intervals to clear on test end. */
 const allTimeouts: NodeJS.Timeout[] = [];
 /** An array of pending Immediates to clear on test end. */
@@ -17,7 +15,7 @@ const origClearImmediate = global.clearImmediate;
  * We add all timeouts to a global array on creation, remove them upon being cleared, and remove all stray intervals
  * on test end.
  */
-export function manageTimeouts() {
+export function manageTimeouts(): void {
   const origTimeout = global.setTimeout;
   global.setTimeout = Object.assign(
     (...args: Parameters<typeof globalThis.setTimeout>) => {
@@ -83,7 +81,7 @@ export function manageTimeouts() {
 }
 
 // Clear all lingering timeouts on test end.
-afterEach(() => {
+export function clearIntervals() {
   console.log("Clearing %d timeouts on test end", allTimeouts.length + allImmediates.length);
   // NB: The absolute WORST CASE SCENARIO for this is us clearing a timeout twice in a row
   // (behavior which MDN web docs has certified to be a no-op)
@@ -96,4 +94,4 @@ afterEach(() => {
   }
   allTimeouts.splice(0);
   allImmediates.splice(0);
-});
+}

--- a/test/test-utils/timeout-manager.ts
+++ b/test/test-utils/timeout-manager.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach } from "vitest";
+
+/** An array of pending timeouts and intervals to clear on test end. */
+const allTimeouts: NodeJS.Timeout[] = [];
+/** An array of pending Immediates to clear on test end. */
+const allImmediates: NodeJS.Immediate[] = [];
+
+// Original clear functions
+
+const origClearTimeout = global.clearTimeout;
+const origClearInterval = global.clearInterval;
+const origClearImmediate = global.clearImmediate;
+
+/**
+ * Wrap NodeJS global timeout functions to allow clearing stray intervals on test end.
+ *
+ * We add all timeouts to a global array on creation, remove them upon being cleared, and remove all stray intervals
+ * on test end.
+ */
+export function manageTimeouts() {
+  const origTimeout = global.setTimeout;
+  global.setTimeout = Object.assign(
+    (...args: Parameters<typeof globalThis.setTimeout>) => {
+      const timeout = origTimeout(...args);
+      allTimeouts.push(timeout);
+      return timeout;
+    },
+    { __promisify__: global.setTimeout.__promisify__ },
+  ) as typeof global.setTimeout;
+
+  const origInterval = global.setInterval;
+  global.setInterval = ((...args: Parameters<typeof globalThis.setInterval>) => {
+    const interval = origInterval(...args);
+    allTimeouts.push(interval);
+    return interval;
+  }) as typeof global.setInterval;
+
+  const origImmediate = global.setImmediate;
+  global.setImmediate = Object.assign(
+    (...args: Parameters<typeof globalThis.setImmediate>) => {
+      const immediate = origImmediate(...args);
+      allImmediates.push(immediate);
+      return immediate;
+    },
+    { __promisify__: global.setImmediate.__promisify__ },
+  ) as typeof global.setImmediate;
+
+  global.clearTimeout = (...args: Parameters<typeof globalThis.clearTimeout>) => {
+    const timeout = args[0];
+    if (typeof timeout === "object") {
+      const index = allTimeouts.indexOf(timeout);
+      if (index !== -1) {
+        // Remove the timeout from the list of all unresolved timeouts
+        allTimeouts.splice(index, 1);
+      }
+    }
+    return origClearTimeout(...args);
+  };
+
+  global.clearInterval = (...args: Parameters<typeof globalThis.clearInterval>) => {
+    const interval = args[0];
+    if (typeof interval === "object") {
+      const index = allTimeouts.indexOf(interval);
+      if (index !== -1) {
+        // Remove the interval from the list of all unresolved timeouts
+        allTimeouts.splice(index, 1);
+      }
+    }
+    return origClearInterval(...args);
+  };
+
+  global.clearImmediate = (...args: Parameters<typeof globalThis.clearImmediate>) => {
+    const immediate = args[0];
+    if (typeof immediate === "object") {
+      const index = allImmediates.indexOf(immediate);
+      if (index !== -1) {
+        // Remove the immediate from the list of all unresolved immediates
+        allImmediates.splice(index, 1);
+      }
+    }
+    return origClearImmediate(...args);
+  };
+}
+
+beforeEach(() => {
+  allTimeouts.splice(0);
+  allImmediates.splice(0);
+});
+
+// Clear all lingering timeouts on test end.
+afterEach(() => {
+  // NB: The absolute WORST CASE SCENARIO for this is us clearing a timeout twice in a row
+  // (behavior which MDN web docs has certified to be a no-op)
+  for (const timeout of allTimeouts) {
+    // clearTimeout works on both intervals and timeouts
+    origClearTimeout(timeout);
+  }
+  for (const immediate of allImmediates) {
+    origClearImmediate(immediate);
+  }
+});

--- a/test/vitest.setup.ts
+++ b/test/vitest.setup.ts
@@ -1,6 +1,7 @@
 import "vitest-canvas-mock";
 import { initTests } from "#test/test-utils/test-file-initialization";
-import { afterAll, beforeAll, vi } from "vitest";
+import { clearIntervals } from "#test/test-utils/timeout-manager";
+import { afterAll, afterEach, beforeAll, vi } from "vitest";
 
 /** Set the timezone to UTC for tests. */
 
@@ -58,3 +59,5 @@ afterAll(() => {
   global.server.close();
   console.log("Closing i18n MSW server!");
 });
+
+afterEach(() => clearIntervals());


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Lingering uncleared timeouts are bad and can cause test pollution.

> [!IMPORTANT]
> This is effectively the only important reason `ErrorHandler` and `PhaseInterceptor` exist.
> We can likely remove them in a future PR.

## What are the changes from a developer perspective?
Added a new file, `timeout-manager.ts` to manage wrapping the global timeouts.

In essence, we shove everything in a big array and remove any remaining timeouts or intervals on test end.

## Screenshots/Videos
N/A
## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
