### PR TITLE
[Misc] Fix import in decrypt-save.js

### DIFF
--- a/scripts/decrypt-save.js
+++ b/scripts/decrypt-save.js
@@ -2,7 +2,9 @@
 
 // biome-ignore lint/performance/noNamespaceImport: This is how you import fs from node
 import * as fs from "node:fs";
-import { AES, enc } from "crypto-js";
+import crypto_js from "crypto-js";
+
+const { AES, enc } = crypto_js;
 
 const SAVE_KEY = "x0i2O7WRiANTqPmZ";
 
@@ -144,7 +146,7 @@ function main() {
     process.exit(0);
   }
 
-  writeToFile(destPath, decrypt);
+  writeToFile(args[1], decrypt);
 }
 
 main();


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
So `decrypt-save` can one again be used (#6052 messed it up due to an oversight).

## What are the changes from a developer perspective?
Restored the `import _ from 'crypto-js'` cjs syntax that is necessary when importing via node.
Also fixed the undefined error.