### PR TITLE
[Beta] [Bug] Fix shiny display issues

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1694,12 +1694,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @returns Whether this Pokemon is shiny
    */
   isShiny(useIllusion = false): boolean {
-    if (useIllusion) {
-      const illusion = this.summonData.illusion;
-      return illusion?.shiny || (!!illusion?.fusionSpecies && !!illusion.fusionShiny);
-    }
-
-    return this.shiny || (this.isFusion(useIllusion) && this.fusionShiny);
+    return this.isBaseShiny(useIllusion) || this.isFusionShiny(useIllusion);
   }
 
   isBaseShiny(useIllusion = false) {


### PR DESCRIPTION
## What are the changes the user will see?
Shiny pokemon now display as shiny

## Why am I making these changes?
Fixes https://discord.com/channels/1125469663833370665/1398807184208298096/1398807184208298096
## What are the changes from a developer perspective?
An oversight from #6140 caused the `isShiny` method to always return false if the method was called with `useIllusion(true)` but the pokemon wasn't in an illusion.
I just updated the method to call the other two methods that do work correctly.

## Screenshots/Videos
<img width="1649" height="919" alt="image" src="https://github.com/user-attachments/assets/3aee9fa2-0357-46a8-9bc0-c431b78a4f96" />

## How to test the changes?
Start a game with some shinies and ensure that they display properly.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - ~~[ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~