### PR TITLE
[Bug] Make bounce delay use fixed int

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1476,7 +1476,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
       loop: -1,
       // Make the initial bounce a little randomly delayed
       delay: randIntRange(0, 50) * 5,
-      loopDelay: 1000,
+      loopDelay: fixedInt(1000),
       tweens: [
         {
           targets: icon,


### PR DESCRIPTION
## What are the changes the user will see?
The loop delay for the bounce animation in starter select is now unaffected by game speed.

## Why am I making these changes?
Fixes a bug pointed out by @damocleas 

## What are the changes from a developer perspective?
Make the `loopDelay` parameter used `fixedInt` instead of a raw 1000s

## Screenshots/Videos

<details><summary>Live vs Beta (before this PR)</summary>

https://github.com/user-attachments/assets/2f13c97c-f881-4ef8-a6a3-05d077d1470f
</summary>

<details><summary>Beta (after this PR)</summary>

https://github.com/user-attachments/assets/d6d6a84d-3c8a-4747-a90a-30045fb77d19
</details> 

## How to test the changes?
Go into starter select UI on a save that has candies and upgrade animations turned on. Notice the delay between bounces is now appropriate.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - ~~[ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~