### PR TITLE
[Test] Added custom equality matchers

### DIFF
--- a/test/@types/vitest.d.ts
+++ b/test/@types/vitest.d.ts
@@ -1,0 +1,26 @@
+import type { Pokemon } from "#field/pokemon";
+import type { PokemonType } from "#enums/pokemon-type";
+import type { expect } from "vitest";
+import { toHaveTypesOptions } from "#test/test-utils/matchers/to-have-types";
+
+declare module "vitest" {
+  interface Assertion {
+    /**
+     * Matcher to check if an array contains EXACTLY the given items (in any order).
+     *
+     * Different from {@linkcode expect.arrayContaining} as the latter only requires the array contain
+     * _at least_ the listed items.
+     *
+     * @param expected - The expected contents of the array, in any order.
+     * @see {@linkcode expect.arrayContaining}
+     */
+    toEqualArrayUnsorted<E>(expected: E[]): void;
+    /**
+     * Matcher to check if a {@linkcode Pokemon}'s current typing includes the given types.
+     *
+     * @param expected - The expected types (in any order).
+     * @param options - The options passed to the matcher.
+     */
+    toHaveTypes(expected: PokemonType[], options?: toHaveTypesOptions): void;
+  }
+}

--- a/test/matchers.setup.ts
+++ b/test/matchers.setup.ts
@@ -1,0 +1,14 @@
+import { toEqualArrayUnsorted } from "#test/test-utils/matchers/to-equal-array-unsorted";
+import { toHaveTypes } from "#test/test-utils/matchers/to-have-types";
+import { expect } from "vitest";
+
+/**
+ * @module
+ * Setup file for custom matchers.
+ * Make sure to define the call signatures in `test/@types/vitest.d.ts` too!
+ */
+
+expect.extend({
+  toEqualArrayUnsorted,
+  toHaveTypes,
+});

--- a/test/test-utils/matchers/to-equal-array-unsorted.ts
+++ b/test/test-utils/matchers/to-equal-array-unsorted.ts
@@ -1,0 +1,43 @@
+import type { MatcherState, SyncExpectationResult } from "@vitest/expect";
+
+/**
+ * Matcher to check if an array contains exactly the given items, disregarding order.
+ * @param received - The object to check. Should be an array of elements.
+ * @returns The result of the matching
+ */
+export function toEqualArrayUnsorted(this: MatcherState, received: unknown, expected: unknown): SyncExpectationResult {
+  if (!Array.isArray(received)) {
+    return {
+      pass: this.isNot,
+      message: () => `Expected an array, but got ${this.utils.stringify(received)}!`,
+    };
+  }
+
+  if (!Array.isArray(expected)) {
+    return {
+      pass: this.isNot,
+      message: () => `Expected to recieve an array, but got ${this.utils.stringify(expected)}!`,
+    };
+  }
+
+  if (received.length !== expected.length) {
+    return {
+      pass: this.isNot,
+      message: () => `Expected to recieve array of length ${received.length}, but got ${expected.length}!`,
+      actual: received,
+      expected,
+    };
+  }
+
+  const gotSorted = received.slice().sort();
+  const wantSorted = expected.slice().sort();
+  const pass = this.equals(gotSorted, wantSorted, [...this.customTesters, this.utils.iterableEquality]);
+
+  return {
+    pass: this.isNot !== pass,
+    message: () =>
+      `Expected ${this.utils.stringify(received)} to exactly equal ${this.utils.stringify(expected)} without order!`,
+    actual: gotSorted,
+    expected: wantSorted,
+  };
+}

--- a/test/test-utils/matchers/to-have-types.ts
+++ b/test/test-utils/matchers/to-have-types.ts
@@ -1,0 +1,64 @@
+import { PokemonType } from "#enums/pokemon-type";
+import { Pokemon } from "#field/pokemon";
+import type { MatcherState, SyncExpectationResult } from "@vitest/expect";
+
+export interface toHaveTypesOptions {
+  /**
+   * Whether to enforce exact matches (`true`) or superset matches (`false`).
+   * @defaultValue `true`
+   */
+  exact?: boolean;
+  /**
+   * Optional arguments to pass to {@linkcode Pokemon.getTypes}.
+   */
+  args?: Parameters<(typeof Pokemon.prototype)["getTypes"]>;
+}
+
+/**
+ * Matcher to check if an array contains exactly the given items, disregarding order.
+ * @param received - The object to check. Should be an array of one or more {@linkcode PokemonType}s.
+ * @param options - The {@linkcode toHaveTypesOptions | options} for this matcher
+ * @returns The result of the matching
+ */
+export function toHaveTypes(
+  this: MatcherState,
+  received: unknown,
+  expected: unknown,
+  options: toHaveTypesOptions = {},
+): SyncExpectationResult {
+  if (!(received instanceof Pokemon)) {
+    return {
+      pass: this.isNot,
+      message: () => `Expected a Pokemon, but got ${this.utils.stringify(received)}!`,
+    };
+  }
+
+  if (!Array.isArray(expected) || expected.length === 0) {
+    return {
+      pass: this.isNot,
+      message: () => `Expected to recieve an array with length >=1, but got ${this.utils.stringify(expected)}!`,
+    };
+  }
+
+  if (!expected.every((t): t is PokemonType => t in PokemonType)) {
+    return {
+      pass: this.isNot,
+      message: () => `Expected to recieve array of PokemonTypes but got ${this.utils.stringify(expected)}!`,
+    };
+  }
+
+  const gotSorted = pkmnTypeToStr(received.getTypes(...(options.args ?? [])));
+  const wantSorted = pkmnTypeToStr(expected.slice());
+  const pass = this.equals(gotSorted, wantSorted, [...this.customTesters, this.utils.iterableEquality]);
+
+  return {
+    pass: this.isNot !== pass,
+    message: () => `Expected ${received.name} to have types ${this.utils.stringify(wantSorted)}, but got ${gotSorted}!`,
+    actual: gotSorted,
+    expected: wantSorted,
+  };
+}
+
+function pkmnTypeToStr(p: PokemonType[]): string[] {
+  return p.sort().map(type => PokemonType[type]);
+}


### PR DESCRIPTION
## What are the changes the user will see?
N/A
## Why am I making these changes?
Test matchers good

## What are the changes from a developer perspective?
Added test matchers for unsorted equality and for pokemon having types

## Screenshots/Videos
TODO

## How to test the changes?
Write tests
## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?