### PR TITLE
[Bug] Fix camel case bug in strings.ts

### DIFF
--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -98,7 +98,7 @@ export function toTitleCase(str: string): string {
  */
 export function toCamelCase(str: string) {
   return splitWords(str)
-    .map((word, index) => (index === 0 ? word.toLowerCase() : capitalizeFirstLetter(word)))
+    .map((word, index) => (index === 0 ? word.toLowerCase() : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()))
     .join("");
 }
 

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -98,7 +98,9 @@ export function toTitleCase(str: string): string {
  */
 export function toCamelCase(str: string) {
   return splitWords(str)
-    .map((word, index) => (index === 0 ? word.toLowerCase() : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()))
+    .map((word, index) =>
+      index === 0 ? word.toLowerCase() : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
+    )
     .join("");
 }
 


### PR DESCRIPTION
## What are the changes the user will see?
Challenge keys will look ok again

## Why am I making these changes?
I did an oopsie with camel case-ing strings

## What are the changes from a developer perspective?
Fixed the bug

## Screenshots/Videos
TODO
## How to test the changes?
go onto beta?

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?
