### PR TITLE
[Balance] End of turn triggers won't occur when you end a biome

### DIFF
--- a/src/phase-manager.ts
+++ b/src/phase-manager.ts
@@ -675,7 +675,7 @@ export class PhaseManager {
 
     const turnEndPhase = this.findPhase<TurnEndPhase>(p => p.phaseName === "TurnEndPhase");
     if (turnEndPhase) {
-      turnEndPhase.endOfBiome = true;
+      turnEndPhase.upcomingInterlude = true;
     }
   }
 }

--- a/src/phase-manager.ts
+++ b/src/phase-manager.ts
@@ -9,7 +9,7 @@ import { AttemptCapturePhase } from "#phases/attempt-capture-phase";
 import { AttemptRunPhase } from "#phases/attempt-run-phase";
 import { BattleEndPhase } from "#phases/battle-end-phase";
 import { BerryPhase } from "#phases/berry-phase";
-import { CheckBiomeEndPhase } from "#phases/check-biome-end-phase";
+import { CheckInterludePhase } from "#phases/check-interlude-phase";
 import { CheckStatusEffectPhase } from "#phases/check-status-effect-phase";
 import { CheckSwitchPhase } from "#phases/check-switch-phase";
 import { CommandPhase } from "#phases/command-phase";
@@ -122,7 +122,7 @@ const PHASES = Object.freeze({
   AttemptRunPhase,
   BattleEndPhase,
   BerryPhase,
-  CheckBiomeEndPhase,
+  CheckInterludePhase,
   CheckStatusEffectPhase,
   CheckSwitchPhase,
   CommandPhase,
@@ -669,7 +669,7 @@ export class PhaseManager {
   }
 
   /** Prevents end of turn effects from triggering when transitioning to a new biome on a X0 wave */
-  public onBiomeEnd(): void {
+  public onInterlude(): void {
     const phasesToRemove = ["WeatherEffectPhase", "BerryPhase", "CheckStatusEffectPhase"];
     this.phaseQueue = this.phaseQueue.filter(p => !phasesToRemove.includes(p.phaseName));
 

--- a/src/phase-manager.ts
+++ b/src/phase-manager.ts
@@ -9,6 +9,7 @@ import { AttemptCapturePhase } from "#phases/attempt-capture-phase";
 import { AttemptRunPhase } from "#phases/attempt-run-phase";
 import { BattleEndPhase } from "#phases/battle-end-phase";
 import { BerryPhase } from "#phases/berry-phase";
+import { CheckBiomeEndPhase } from "#phases/check-biome-end-phase";
 import { CheckStatusEffectPhase } from "#phases/check-status-effect-phase";
 import { CheckSwitchPhase } from "#phases/check-switch-phase";
 import { CommandPhase } from "#phases/command-phase";
@@ -121,6 +122,7 @@ const PHASES = Object.freeze({
   AttemptRunPhase,
   BattleEndPhase,
   BerryPhase,
+  CheckBiomeEndPhase,
   CheckStatusEffectPhase,
   CheckSwitchPhase,
   CommandPhase,

--- a/src/phase-manager.ts
+++ b/src/phase-manager.ts
@@ -667,4 +667,15 @@ export class PhaseManager {
   ): void {
     this.startDynamicPhase(this.create(phase, ...args));
   }
+
+  /** Prevents end of turn effects from triggering when transitioning to a new biome on a X0 wave */
+  public onBiomeEnd(): void {
+    const phasesToRemove = ["WeatherEffectPhase", "BerryPhase", "CheckStatusEffectPhase"];
+    this.phaseQueue = this.phaseQueue.filter(p => !phasesToRemove.includes(p.phaseName));
+
+    const turnEndPhase = this.findPhase<TurnEndPhase>(p => p.phaseName === "TurnEndPhase");
+    if (turnEndPhase) {
+      turnEndPhase.endOfBiome = true;
+    }
+  }
 }

--- a/src/phases/check-biome-end-phase.ts
+++ b/src/phases/check-biome-end-phase.ts
@@ -1,6 +1,5 @@
 import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
-import type { TurnEndPhase } from "#phases/turn-end-phase";
 
 export class CheckBiomeEndPhase extends Phase {
   public override readonly phaseName = "CheckBiomeEndPhase";
@@ -11,15 +10,7 @@ export class CheckBiomeEndPhase extends Phase {
     const { waveIndex } = globalScene.currentBattle;
 
     if (waveIndex % 10 === 0 && globalScene.getEnemyParty().every(p => p.isFainted())) {
-      const phasesToRemove = ["WeatherEffectPhase", "BerryPhase", "CheckStatusEffectPhase"];
-      while (phaseManager.tryRemovePhase(p => phasesToRemove.includes(p.phaseName))) {
-        // do nothing, this loop just exists to remove all the relevant phases from the queue
-      }
-
-      const turnEndPhase = phaseManager.findPhase<TurnEndPhase>(p => p.phaseName === "TurnEndPhase");
-      if (turnEndPhase) {
-        turnEndPhase.endOfBiome = true;
-      }
+      phaseManager.onBiomeEnd();
     }
 
     this.end();

--- a/src/phases/check-biome-end-phase.ts
+++ b/src/phases/check-biome-end-phase.ts
@@ -1,0 +1,27 @@
+import { globalScene } from "#app/global-scene";
+import { Phase } from "#app/phase";
+import type { TurnEndPhase } from "#phases/turn-end-phase";
+
+export class CheckBiomeEndPhase extends Phase {
+  public override readonly phaseName = "CheckBiomeEndPhase";
+
+  public override start(): void {
+    super.start();
+    const { phaseManager } = globalScene;
+    const { waveIndex } = globalScene.currentBattle;
+
+    if (waveIndex % 10 === 0 && globalScene.getEnemyParty().every(p => p.isFainted())) {
+      const phasesToRemove = ["WeatherEffectPhase", "BerryPhase", "CheckStatusEffectPhase"];
+      while (phaseManager.tryRemovePhase(p => phasesToRemove.includes(p.phaseName))) {
+        // do nothing, this loop just exists to remove all the relevant phases from the queue
+      }
+
+      const turnEndPhase = phaseManager.findPhase<TurnEndPhase>(p => p.phaseName === "TurnEndPhase");
+      if (turnEndPhase) {
+        turnEndPhase.endOfBiome = true;
+      }
+    }
+
+    this.end();
+  }
+}

--- a/src/phases/check-interlude-phase.ts
+++ b/src/phases/check-interlude-phase.ts
@@ -1,8 +1,8 @@
 import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
 
-export class CheckBiomeEndPhase extends Phase {
-  public override readonly phaseName = "CheckBiomeEndPhase";
+export class CheckInterludePhase extends Phase {
+  public override readonly phaseName = "CheckInterludePhase";
 
   public override start(): void {
     super.start();
@@ -10,7 +10,7 @@ export class CheckBiomeEndPhase extends Phase {
     const { waveIndex } = globalScene.currentBattle;
 
     if (waveIndex % 10 === 0 && globalScene.getEnemyParty().every(p => p.isFainted())) {
-      phaseManager.onBiomeEnd();
+      phaseManager.onInterlude();
     }
 
     this.end();

--- a/src/phases/turn-end-phase.ts
+++ b/src/phases/turn-end-phase.ts
@@ -18,7 +18,7 @@ import i18next from "i18next";
 
 export class TurnEndPhase extends FieldPhase {
   public readonly phaseName = "TurnEndPhase";
-  public endOfBiome = false;
+  public upcomingInterlude = false;
 
   start() {
     super.start();
@@ -61,7 +61,7 @@ export class TurnEndPhase extends FieldPhase {
       pokemon.tempSummonData.waveTurnCount++;
     };
 
-    if (!this.endOfBiome) {
+    if (!this.upcomingInterlude) {
       this.executeForAll(handlePokemon);
 
       globalScene.arena.lapseTags();

--- a/src/phases/turn-end-phase.ts
+++ b/src/phases/turn-end-phase.ts
@@ -18,6 +18,8 @@ import i18next from "i18next";
 
 export class TurnEndPhase extends FieldPhase {
   public readonly phaseName = "TurnEndPhase";
+  public endOfBiome = false;
+
   start() {
     super.start();
 
@@ -59,9 +61,11 @@ export class TurnEndPhase extends FieldPhase {
       pokemon.tempSummonData.waveTurnCount++;
     };
 
-    this.executeForAll(handlePokemon);
+    if (!this.endOfBiome) {
+      this.executeForAll(handlePokemon);
 
-    globalScene.arena.lapseTags();
+      globalScene.arena.lapseTags();
+    }
 
     if (globalScene.arena.weather && !globalScene.arena.weather.lapse()) {
       globalScene.arena.trySetWeather(WeatherType.NONE);

--- a/src/phases/turn-start-phase.ts
+++ b/src/phases/turn-start-phase.ts
@@ -218,7 +218,7 @@ export class TurnStartPhase extends FieldPhase {
           break;
       }
     }
-    phaseManager.pushNew("CheckBiomeEndPhase");
+    phaseManager.pushNew("CheckInterludePhase");
 
     phaseManager.pushNew("WeatherEffectPhase");
     phaseManager.pushNew("BerryPhase");

--- a/src/phases/turn-start-phase.ts
+++ b/src/phases/turn-start-phase.ts
@@ -218,6 +218,7 @@ export class TurnStartPhase extends FieldPhase {
           break;
       }
     }
+    phaseManager.pushNew("CheckBiomeEndPhase");
 
     phaseManager.pushNew("WeatherEffectPhase");
     phaseManager.pushNew("BerryPhase");
@@ -227,10 +228,10 @@ export class TurnStartPhase extends FieldPhase {
 
     phaseManager.pushNew("TurnEndPhase");
 
-    /**
-     * this.end() will call shiftPhase(), which dumps everything from PrependQueue (aka everything that is unshifted()) to the front
-     * of the queue and dequeues to start the next phase
-     * this is important since stuff like SwitchSummon, AttemptRun, AttemptCapture Phases break the "flow" and should take precedence
+    /*
+     * `this.end()` will call `PhaseManager#shiftPhase()`, which dumps everything from `phaseQueuePrepend`
+     * (aka everything that is queued via `unshift()`) to the front of the queue and dequeues to start the next phase.
+     * This is important since stuff like `SwitchSummonPhase`, `AttemptRunPhase`, and `AttemptCapturePhase` break the "flow" and should take precedence
      */
     this.end();
   }

--- a/test/phases/check-biome-end-phase.test.ts
+++ b/test/phases/check-biome-end-phase.test.ts
@@ -1,0 +1,62 @@
+import { AbilityId } from "#enums/ability-id";
+import { BerryType } from "#enums/berry-type";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { WeatherType } from "#enums/weather-type";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Check Biome End Phase", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyMoveset(MoveId.SPLASH)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .ability(AbilityId.BALL_FETCH)
+      .startingLevel(100);
+  });
+
+  it("should not trigger end of turn effects when defeating the final pokemon of a biome in classic", async () => {
+    game.override
+      .startingWave(10)
+      .weather(WeatherType.SANDSTORM)
+      .startingHeldItems([{ name: "BERRY", type: BerryType.SITRUS }]);
+    await game.classicMode.startBattle([SpeciesId.FEEBAS]);
+
+    const player = game.field.getPlayerPokemon();
+
+    player.hp = 1;
+
+    game.move.use(MoveId.EXTREME_SPEED);
+    await game.toEndOfTurn();
+
+    expect(player.hp).toBe(1);
+  });
+
+  it("should not prevent end of turn effects when transitioning waves within a biome", async () => {
+    game.override.weather(WeatherType.SANDSTORM);
+    await game.classicMode.startBattle([SpeciesId.FEEBAS]);
+
+    const player = game.field.getPlayerPokemon();
+
+    game.move.use(MoveId.EXTREME_SPEED);
+    await game.toEndOfTurn();
+
+    expect(player.hp).toBeLessThan(player.getMaxHp());
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?
When you defeat the final Pokémon at the end of a biome (waves 10, 20, ...), the battle will end immediately, meaning end of turn triggers (weather damage, berries, etc) won't occur. This prevents berries from being wasted when your party is about to be automatically healed anyway.

## Why am I making these changes?
Requested by balance team.

## What are the changes from a developer perspective?
A new phase (`CheckBiomeEndPhase`) is queued along with the other "end of turn" phases from within `TurnStartPhase` which removes the end of turn effect phases and sets a new field `TurnEndPhase#endOfBiome` to `true` on the currently queued `TurnEndPhase`, which causes most of the triggers to be skipped in that phase.

## How to test the changes?
Defeat the last Pokémon of a biome (wave X0) with end of turn triggers that should occur (opponent's Future Sight, weather damage, Aqua Ring, etc) and observe that they do not occur.

You can also run the automated test with `pnpm test:silent check-biome-end-phase`.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?