### PR TITLE
[Test] Cleaned up tests to use updated test utils; part 1

### DIFF
--- a/test/abilities/disguise.test.ts
+++ b/test/abilities/disguise.test.ts
@@ -134,7 +134,7 @@ describe("Abilities - Disguise", () => {
     });
     await game.classicMode.startBattle([SpeciesId.FURRET, SpeciesId.MIMIKYU]);
 
-    const mimikyu = game.scene.getPlayerParty()[1]!;
+    const mimikyu = game.scene.getPlayerParty()[1];
     expect(mimikyu.formIndex).toBe(bustedForm);
 
     game.move.select(MoveId.SPLASH);

--- a/test/abilities/sheer-force.test.ts
+++ b/test/abilities/sheer-force.test.ts
@@ -121,8 +121,8 @@ describe("Abilities - Sheer Force", () => {
 
     await game.classicMode.startBattle([SpeciesId.PIDGEOT]);
 
-    const pidgeot = game.scene.getPlayerParty()[0];
-    const onix = game.scene.getEnemyParty()[0];
+    const pidgeot = game.field.getPlayerPokemon();
+    const onix = game.field.getEnemyPokemon();
 
     pidgeot.stats[Stat.DEF] = 10000;
     onix.stats[Stat.DEF] = 10000;

--- a/test/abilities/sturdy.test.ts
+++ b/test/abilities/sturdy.test.ts
@@ -1,7 +1,6 @@
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import type { EnemyPokemon } from "#field/pokemon";
 import { DamageAnimPhase } from "#phases/damage-anim-phase";
 import { MoveEndPhase } from "#phases/move-end-phase";
 import { GameManager } from "#test/test-utils/game-manager";
@@ -38,13 +37,13 @@ describe("Abilities - Sturdy", () => {
     await game.classicMode.startBattle();
     game.move.select(MoveId.CLOSE_COMBAT);
     await game.phaseInterceptor.to(MoveEndPhase);
-    expect(game.scene.getEnemyParty()[0].hp).toBe(1);
+    expect(game.field.getEnemyPokemon().hp).toBe(1);
   });
 
   test("Sturdy doesn't activate when user is not at full HP", async () => {
     await game.classicMode.startBattle();
 
-    const enemyPokemon: EnemyPokemon = game.scene.getEnemyParty()[0];
+    const enemyPokemon = game.field.getEnemyPokemon();
     enemyPokemon.hp = enemyPokemon.getMaxHp() - 1;
 
     game.move.select(MoveId.CLOSE_COMBAT);
@@ -59,7 +58,7 @@ describe("Abilities - Sturdy", () => {
     game.move.select(MoveId.FISSURE);
     await game.phaseInterceptor.to(MoveEndPhase);
 
-    const enemyPokemon: EnemyPokemon = game.scene.getEnemyParty()[0];
+    const enemyPokemon = game.field.getEnemyPokemon();
     expect(enemyPokemon.isFullHp()).toBe(true);
   });
 
@@ -70,7 +69,7 @@ describe("Abilities - Sturdy", () => {
     game.move.select(MoveId.CLOSE_COMBAT);
     await game.phaseInterceptor.to(DamageAnimPhase);
 
-    const enemyPokemon: EnemyPokemon = game.scene.getEnemyParty()[0];
+    const enemyPokemon = game.field.getEnemyPokemon();
     expect(enemyPokemon.hp).toBe(0);
     expect(enemyPokemon.isFainted()).toBe(true);
   });

--- a/test/abilities/wimp-out.test.ts
+++ b/test/abilities/wimp-out.test.ts
@@ -336,7 +336,7 @@ describe("Abilities - Wimp Out", () => {
     game.move.select(MoveId.SPLASH);
     await game.phaseInterceptor.to("TurnEndPhase");
 
-    expect(game.scene.getPlayerParty()[0].getHpRatio()).toEqual(0.51);
+    expect(game.field.getPlayerPokemon().getHpRatio()).toEqual(0.51);
     expect(game.phaseInterceptor.log).not.toContain("SwitchSummonPhase");
     expect(game.scene.getPlayerPokemon()!.species.speciesId).toBe(SpeciesId.WIMPOD);
   });

--- a/test/abilities/wimp-out.test.ts
+++ b/test/abilities/wimp-out.test.ts
@@ -344,8 +344,7 @@ describe("Abilities - Wimp Out", () => {
   it("Wimp Out activating should not cancel a double battle", async () => {
     game.override.battleStyle("double").enemyAbility(AbilityId.WIMP_OUT).enemyMoveset([MoveId.SPLASH]).enemyLevel(1);
     await game.classicMode.startBattle([SpeciesId.WIMPOD, SpeciesId.TYRUNT]);
-    const enemyLeadPokemon = game.scene.getEnemyParty()[0];
-    const enemySecPokemon = game.scene.getEnemyParty()[1];
+    const [enemyLeadPokemon, enemySecPokemon] = game.scene.getEnemyParty();
 
     game.move.select(MoveId.FALSE_SWIPE, 0, BattlerIndex.ENEMY);
     game.move.select(MoveId.SPLASH, 1);

--- a/test/abilities/zero-to-hero.test.ts
+++ b/test/abilities/zero-to-hero.test.ts
@@ -40,8 +40,7 @@ describe("Abilities - ZERO TO HERO", () => {
 
     await game.classicMode.startBattle([SpeciesId.FEEBAS, SpeciesId.PALAFIN, SpeciesId.PALAFIN]);
 
-    const palafin1 = game.scene.getPlayerParty()[1];
-    const palafin2 = game.scene.getPlayerParty()[2];
+    const [, palafin1, palafin2] = game.scene.getPlayerParty();
     expect(palafin1.formIndex).toBe(heroForm);
     expect(palafin2.formIndex).toBe(heroForm);
     palafin2.hp = 0;

--- a/test/boss-pokemon.test.ts
+++ b/test/boss-pokemon.test.ts
@@ -64,11 +64,9 @@ describe("Boss Pokemon / Shields", () => {
 
   it("should reduce the number of shields if we are in a double battle", async () => {
     game.override.battleStyle("double").startingWave(150); // Floor 150 > 2 shields / 3 health segments
-
     await game.classicMode.startBattle([SpeciesId.MEWTWO]);
 
-    const boss1: EnemyPokemon = game.scene.getEnemyParty()[0]!;
-    const boss2: EnemyPokemon = game.scene.getEnemyParty()[1]!;
+    const [boss1, boss2] = game.scene.getEnemyParty();
     expect(boss1.isBoss()).toBe(true);
     expect(boss1.bossSegments).toBe(2);
     expect(boss2.isBoss()).toBe(true);
@@ -112,7 +110,7 @@ describe("Boss Pokemon / Shields", () => {
     // In this test we want to break through 3 shields at once
     const brokenShields = 3;
 
-    const boss1: EnemyPokemon = game.scene.getEnemyParty()[0]!;
+    const boss1: EnemyPokemon = game.scene.getEnemyParty()[0];
     const boss1SegmentHp = boss1.getMaxHp() / boss1.bossSegments;
     const requiredDamageBoss1 = boss1SegmentHp * (1 + Math.pow(2, brokenShields));
     expect(boss1.isBoss()).toBe(true);
@@ -124,7 +122,7 @@ describe("Boss Pokemon / Shields", () => {
     expect(boss1.bossSegmentIndex).toBe(1);
     expect(boss1.hp).toBe(boss1.getMaxHp() - toDmgValue(boss1SegmentHp * 3));
 
-    const boss2: EnemyPokemon = game.scene.getEnemyParty()[1]!;
+    const boss2: EnemyPokemon = game.scene.getEnemyParty()[1];
     const boss2SegmentHp = boss2.getMaxHp() / boss2.bossSegments;
     const requiredDamageBoss2 = boss2SegmentHp * (1 + Math.pow(2, brokenShields));
 
@@ -144,7 +142,7 @@ describe("Boss Pokemon / Shields", () => {
 
     await game.classicMode.startBattle([SpeciesId.MEWTWO]);
 
-    const boss1: EnemyPokemon = game.scene.getEnemyParty()[0]!;
+    const boss1: EnemyPokemon = game.scene.getEnemyParty()[0];
     const boss1SegmentHp = boss1.getMaxHp() / boss1.bossSegments;
     const singleShieldDamage = Math.ceil(boss1SegmentHp);
     expect(boss1.isBoss()).toBe(true);
@@ -167,7 +165,7 @@ describe("Boss Pokemon / Shields", () => {
       expect(getTotalStatStageBoosts(boss1)).toBe(totalStatStages);
     }
 
-    const boss2: EnemyPokemon = game.scene.getEnemyParty()[1]!;
+    const boss2: EnemyPokemon = game.scene.getEnemyParty()[1];
     const boss2SegmentHp = boss2.getMaxHp() / boss2.bossSegments;
     const requiredDamage = boss2SegmentHp * (1 + Math.pow(2, shieldsToBreak - 1));
 

--- a/test/boss-pokemon.test.ts
+++ b/test/boss-pokemon.test.ts
@@ -110,7 +110,7 @@ describe("Boss Pokemon / Shields", () => {
     // In this test we want to break through 3 shields at once
     const brokenShields = 3;
 
-    const boss1: EnemyPokemon = game.scene.getEnemyParty()[0];
+    const boss1 = game.field.getEnemyPokemon();
     const boss1SegmentHp = boss1.getMaxHp() / boss1.bossSegments;
     const requiredDamageBoss1 = boss1SegmentHp * (1 + Math.pow(2, brokenShields));
     expect(boss1.isBoss()).toBe(true);
@@ -122,7 +122,7 @@ describe("Boss Pokemon / Shields", () => {
     expect(boss1.bossSegmentIndex).toBe(1);
     expect(boss1.hp).toBe(boss1.getMaxHp() - toDmgValue(boss1SegmentHp * 3));
 
-    const boss2: EnemyPokemon = game.scene.getEnemyParty()[1];
+    const boss2 = game.scene.getEnemyParty()[1];
     const boss2SegmentHp = boss2.getMaxHp() / boss2.bossSegments;
     const requiredDamageBoss2 = boss2SegmentHp * (1 + Math.pow(2, brokenShields));
 
@@ -142,7 +142,7 @@ describe("Boss Pokemon / Shields", () => {
 
     await game.classicMode.startBattle([SpeciesId.MEWTWO]);
 
-    const boss1: EnemyPokemon = game.scene.getEnemyParty()[0];
+    const boss1 = game.field.getEnemyPokemon();
     const boss1SegmentHp = boss1.getMaxHp() / boss1.bossSegments;
     const singleShieldDamage = Math.ceil(boss1SegmentHp);
     expect(boss1.isBoss()).toBe(true);
@@ -165,7 +165,7 @@ describe("Boss Pokemon / Shields", () => {
       expect(getTotalStatStageBoosts(boss1)).toBe(totalStatStages);
     }
 
-    const boss2: EnemyPokemon = game.scene.getEnemyParty()[1];
+    const boss2 = game.scene.getEnemyParty()[1];
     const boss2SegmentHp = boss2.getMaxHp() / boss2.bossSegments;
     const requiredDamage = boss2SegmentHp * (1 + Math.pow(2, shieldsToBreak - 1));
 

--- a/test/evolution.test.ts
+++ b/test/evolution.test.ts
@@ -34,8 +34,7 @@ describe("Evolution", () => {
   it("should keep hidden ability after evolving", async () => {
     await game.classicMode.runToSummon([SpeciesId.EEVEE, SpeciesId.TRAPINCH]);
 
-    const eevee = game.scene.getPlayerParty()[0];
-    const trapinch = game.scene.getPlayerParty()[1];
+    const [eevee, trapinch] = game.scene.getPlayerParty();
     eevee.abilityIndex = 2;
     trapinch.abilityIndex = 2;
 
@@ -49,8 +48,7 @@ describe("Evolution", () => {
   it("should keep same ability slot after evolving", async () => {
     await game.classicMode.runToSummon([SpeciesId.BULBASAUR, SpeciesId.CHARMANDER]);
 
-    const bulbasaur = game.scene.getPlayerParty()[0];
-    const charmander = game.scene.getPlayerParty()[1];
+    const [bulbasaur, charmander] = game.scene.getPlayerParty();
     bulbasaur.abilityIndex = 0;
     charmander.abilityIndex = 1;
 
@@ -80,8 +78,7 @@ describe("Evolution", () => {
     nincada.gender = 1;
 
     await nincada.evolve(pokemonEvolutions[SpeciesId.NINCADA][0], nincada.getSpeciesForm());
-    const ninjask = game.scene.getPlayerParty()[0];
-    const shedinja = game.scene.getPlayerParty()[1];
+    const [ninjask, shedinja] = game.scene.getPlayerParty();
     expect(ninjask.abilityIndex).toBe(2);
     expect(shedinja.abilityIndex).toBe(1);
     expect(ninjask.gender).toBe(1);

--- a/test/field/pokemon.test.ts
+++ b/test/field/pokemon.test.ts
@@ -85,17 +85,14 @@ describe("Spec - Pokemon", () => {
   });
 
   describe("Get correct fusion type", () => {
-    let scene: BattleScene;
-
     beforeEach(async () => {
       game.override.enemySpecies(SpeciesId.ZUBAT).starterSpecies(SpeciesId.ABRA).enableStarterFusion();
-      scene = game.scene;
     });
 
     it("Fusing two mons with a single type", async () => {
       game.override.starterFusionSpecies(SpeciesId.CHARMANDER);
       await game.classicMode.startBattle();
-      const pokemon = scene.getPlayerParty()[0];
+      const pokemon = game.field.getPlayerPokemon();
 
       let types = pokemon.getTypes();
       expect(types[0]).toBe(PokemonType.PSYCHIC);
@@ -136,7 +133,7 @@ describe("Spec - Pokemon", () => {
     it("Fusing two mons with same single type", async () => {
       game.override.starterFusionSpecies(SpeciesId.DROWZEE);
       await game.classicMode.startBattle();
-      const pokemon = scene.getPlayerParty()[0];
+      const pokemon = game.field.getPlayerPokemon();
 
       const types = pokemon.getTypes();
       expect(types[0]).toBe(PokemonType.PSYCHIC);
@@ -146,7 +143,7 @@ describe("Spec - Pokemon", () => {
     it("Fusing mons with one and two types", async () => {
       game.override.starterSpecies(SpeciesId.CHARMANDER).starterFusionSpecies(SpeciesId.HOUNDOUR);
       await game.classicMode.startBattle();
-      const pokemon = scene.getPlayerParty()[0];
+      const pokemon = game.field.getPlayerPokemon();
 
       const types = pokemon.getTypes();
       expect(types[0]).toBe(PokemonType.FIRE);
@@ -156,7 +153,7 @@ describe("Spec - Pokemon", () => {
     it("Fusing mons with two and one types", async () => {
       game.override.starterSpecies(SpeciesId.NUMEL).starterFusionSpecies(SpeciesId.CHARMANDER);
       await game.classicMode.startBattle();
-      const pokemon = scene.getPlayerParty()[0];
+      const pokemon = game.field.getPlayerPokemon();
 
       const types = pokemon.getTypes();
       expect(types[0]).toBe(PokemonType.FIRE);
@@ -166,7 +163,7 @@ describe("Spec - Pokemon", () => {
     it("Fusing two mons with two types", async () => {
       game.override.starterSpecies(SpeciesId.NATU).starterFusionSpecies(SpeciesId.HOUNDOUR);
       await game.classicMode.startBattle();
-      const pokemon = scene.getPlayerParty()[0];
+      const pokemon = game.field.getPlayerPokemon();
 
       let types = pokemon.getTypes();
       expect(types[0]).toBe(PokemonType.PSYCHIC);

--- a/test/items/light-ball.test.ts
+++ b/test/items/light-ball.test.ts
@@ -113,8 +113,7 @@ describe("Items - Light Ball", () => {
   it("LIGHT_BALL held by fused PIKACHU (base)", async () => {
     await game.classicMode.startBattle([SpeciesId.PIKACHU, SpeciesId.MAROWAK]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
-    const ally = game.scene.getPlayerParty()[1];
+    const [partyMember, ally] = game.scene.getPlayerParty();
 
     // Fuse party members (taken from PlayerPokemon.fuse(...) function)
     partyMember.fusionSpecies = ally.species;
@@ -152,8 +151,7 @@ describe("Items - Light Ball", () => {
   it("LIGHT_BALL held by fused PIKACHU (part)", async () => {
     await game.classicMode.startBattle([SpeciesId.MAROWAK, SpeciesId.PIKACHU]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
-    const ally = game.scene.getPlayerParty()[1];
+    const [partyMember, ally] = game.scene.getPlayerParty();
 
     // Fuse party members (taken from PlayerPokemon.fuse(...) function)
     partyMember.fusionSpecies = ally.species;

--- a/test/items/light-ball.test.ts
+++ b/test/items/light-ball.test.ts
@@ -33,7 +33,7 @@ describe("Items - Light Ball", () => {
     const consoleSpy = vi.spyOn(console, "log");
     await game.classicMode.startBattle([SpeciesId.PIKACHU]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
+    const partyMember = game.field.getPlayerPokemon();
 
     // Checking console log to make sure Light Ball is applied when getEffectiveStat (with the appropriate stat) is called
     partyMember.getEffectiveStat(Stat.DEF);
@@ -84,7 +84,7 @@ describe("Items - Light Ball", () => {
   it("LIGHT_BALL held by PIKACHU", async () => {
     await game.classicMode.startBattle([SpeciesId.PIKACHU]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
+    const partyMember = game.field.getPlayerPokemon();
 
     const atkStat = partyMember.getStat(Stat.ATK);
     const spAtkStat = partyMember.getStat(Stat.SPATK);
@@ -189,7 +189,7 @@ describe("Items - Light Ball", () => {
   it("LIGHT_BALL not held by PIKACHU", async () => {
     await game.classicMode.startBattle([SpeciesId.MAROWAK]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
+    const partyMember = game.field.getPlayerPokemon();
 
     const atkStat = partyMember.getStat(Stat.ATK);
     const spAtkStat = partyMember.getStat(Stat.SPATK);

--- a/test/items/metal-powder.test.ts
+++ b/test/items/metal-powder.test.ts
@@ -33,7 +33,7 @@ describe("Items - Metal Powder", () => {
     const consoleSpy = vi.spyOn(console, "log");
     await game.classicMode.startBattle([SpeciesId.DITTO]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
+    const partyMember = game.field.getPlayerPokemon();
 
     // Checking console log to make sure Metal Powder is applied when getEffectiveStat (with the appropriate stat) is called
     partyMember.getEffectiveStat(Stat.DEF);
@@ -84,7 +84,7 @@ describe("Items - Metal Powder", () => {
   it("METAL_POWDER held by DITTO", async () => {
     await game.classicMode.startBattle([SpeciesId.DITTO]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
+    const partyMember = game.field.getPlayerPokemon();
 
     const defStat = partyMember.getStat(Stat.DEF);
 
@@ -171,7 +171,7 @@ describe("Items - Metal Powder", () => {
   it("METAL_POWDER not held by DITTO", async () => {
     await game.classicMode.startBattle([SpeciesId.MAROWAK]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
+    const partyMember = game.field.getPlayerPokemon();
 
     const defStat = partyMember.getStat(Stat.DEF);
 

--- a/test/items/metal-powder.test.ts
+++ b/test/items/metal-powder.test.ts
@@ -107,8 +107,7 @@ describe("Items - Metal Powder", () => {
   it("METAL_POWDER held by fused DITTO (base)", async () => {
     await game.classicMode.startBattle([SpeciesId.DITTO, SpeciesId.MAROWAK]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
-    const ally = game.scene.getPlayerParty()[1];
+    const [partyMember, ally] = game.scene.getPlayerParty();
 
     // Fuse party members (taken from PlayerPokemon.fuse(...) function)
     partyMember.fusionSpecies = ally.species;
@@ -140,8 +139,7 @@ describe("Items - Metal Powder", () => {
   it("METAL_POWDER held by fused DITTO (part)", async () => {
     await game.classicMode.startBattle([SpeciesId.MAROWAK, SpeciesId.DITTO]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
-    const ally = game.scene.getPlayerParty()[1];
+    const [partyMember, ally] = game.scene.getPlayerParty();
 
     // Fuse party members (taken from PlayerPokemon.fuse(...) function)
     partyMember.fusionSpecies = ally.species;

--- a/test/items/quick-powder.test.ts
+++ b/test/items/quick-powder.test.ts
@@ -33,7 +33,7 @@ describe("Items - Quick Powder", () => {
     const consoleSpy = vi.spyOn(console, "log");
     await game.classicMode.startBattle([SpeciesId.DITTO]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
+    const partyMember = game.field.getPlayerPokemon();
 
     // Checking console log to make sure Quick Powder is applied when getEffectiveStat (with the appropriate stat) is called
     partyMember.getEffectiveStat(Stat.DEF);
@@ -84,7 +84,7 @@ describe("Items - Quick Powder", () => {
   it("QUICK_POWDER held by DITTO", async () => {
     await game.classicMode.startBattle([SpeciesId.DITTO]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
+    const partyMember = game.field.getPlayerPokemon();
 
     const spdStat = partyMember.getStat(Stat.SPD);
 
@@ -171,7 +171,7 @@ describe("Items - Quick Powder", () => {
   it("QUICK_POWDER not held by DITTO", async () => {
     await game.classicMode.startBattle([SpeciesId.MAROWAK]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
+    const partyMember = game.field.getPlayerPokemon();
 
     const spdStat = partyMember.getStat(Stat.SPD);
 

--- a/test/items/quick-powder.test.ts
+++ b/test/items/quick-powder.test.ts
@@ -107,8 +107,7 @@ describe("Items - Quick Powder", () => {
   it("QUICK_POWDER held by fused DITTO (base)", async () => {
     await game.classicMode.startBattle([SpeciesId.DITTO, SpeciesId.MAROWAK]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
-    const ally = game.scene.getPlayerParty()[1];
+    const [partyMember, ally] = game.scene.getPlayerParty();
 
     // Fuse party members (taken from PlayerPokemon.fuse(...) function)
     partyMember.fusionSpecies = ally.species;
@@ -140,8 +139,7 @@ describe("Items - Quick Powder", () => {
   it("QUICK_POWDER held by fused DITTO (part)", async () => {
     await game.classicMode.startBattle([SpeciesId.MAROWAK, SpeciesId.DITTO]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
-    const ally = game.scene.getPlayerParty()[1];
+    const [partyMember, ally] = game.scene.getPlayerParty();
 
     // Fuse party members (taken from PlayerPokemon.fuse(...) function)
     partyMember.fusionSpecies = ally.species;

--- a/test/items/thick-club.test.ts
+++ b/test/items/thick-club.test.ts
@@ -33,7 +33,7 @@ describe("Items - Thick Club", () => {
     const consoleSpy = vi.spyOn(console, "log");
     await game.classicMode.startBattle([SpeciesId.CUBONE]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
+    const partyMember = game.field.getPlayerPokemon();
 
     // Checking console log to make sure Thick Club is applied when getEffectiveStat (with the appropriate stat) is called
     partyMember.getEffectiveStat(Stat.DEF);
@@ -84,7 +84,7 @@ describe("Items - Thick Club", () => {
   it("THICK_CLUB held by CUBONE", async () => {
     await game.classicMode.startBattle([SpeciesId.CUBONE]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
+    const partyMember = game.field.getPlayerPokemon();
 
     const atkStat = partyMember.getStat(Stat.ATK);
 
@@ -107,7 +107,7 @@ describe("Items - Thick Club", () => {
   it("THICK_CLUB held by MAROWAK", async () => {
     await game.classicMode.startBattle([SpeciesId.MAROWAK]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
+    const partyMember = game.field.getPlayerPokemon();
 
     const atkStat = partyMember.getStat(Stat.ATK);
 
@@ -130,7 +130,7 @@ describe("Items - Thick Club", () => {
   it("THICK_CLUB held by ALOLA_MAROWAK", async () => {
     await game.classicMode.startBattle([SpeciesId.ALOLA_MAROWAK]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
+    const partyMember = game.field.getPlayerPokemon();
 
     const atkStat = partyMember.getStat(Stat.ATK);
 
@@ -225,7 +225,7 @@ describe("Items - Thick Club", () => {
   it("THICK_CLUB not held by CUBONE", async () => {
     await game.classicMode.startBattle([SpeciesId.PIKACHU]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
+    const partyMember = game.field.getPlayerPokemon();
 
     const atkStat = partyMember.getStat(Stat.ATK);
 

--- a/test/items/thick-club.test.ts
+++ b/test/items/thick-club.test.ts
@@ -157,8 +157,7 @@ describe("Items - Thick Club", () => {
 
     await game.classicMode.startBattle([species[randSpecies], SpeciesId.PIKACHU]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
-    const ally = game.scene.getPlayerParty()[1];
+    const [partyMember, ally] = game.scene.getPlayerParty();
 
     // Fuse party members (taken from PlayerPokemon.fuse(...) function)
     partyMember.fusionSpecies = ally.species;
@@ -194,8 +193,7 @@ describe("Items - Thick Club", () => {
 
     await game.classicMode.startBattle([SpeciesId.PIKACHU, species[randSpecies]]);
 
-    const partyMember = game.scene.getPlayerParty()[0];
-    const ally = game.scene.getPlayerParty()[1];
+    const [partyMember, ally] = game.scene.getPlayerParty();
 
     // Fuse party members (taken from PlayerPokemon.fuse(...) function)
     partyMember.fusionSpecies = ally.species;

--- a/test/moves/dragon-rage.test.ts
+++ b/test/moves/dragon-rage.test.ts
@@ -46,7 +46,7 @@ describe("Moves - Dragon Rage", () => {
 
     await game.classicMode.startBattle();
 
-    partyPokemon = game.scene.getPlayerParty()[0];
+    partyPokemon = game.field.getPlayerPokemon();
     enemyPokemon = game.scene.getEnemyPokemon()!;
   });
 

--- a/test/moves/dragon-tail.test.ts
+++ b/test/moves/dragon-tail.test.ts
@@ -76,10 +76,10 @@ describe("Moves - Dragon Tail", () => {
     game.override.battleStyle("double").enemyMoveset(MoveId.SPLASH).enemyAbility(AbilityId.ROUGH_SKIN);
     await game.classicMode.startBattle([SpeciesId.DRATINI, SpeciesId.DRATINI, SpeciesId.WAILORD, SpeciesId.WAILORD]);
 
-    const leadPokemon = game.scene.getPlayerParty()[0]!;
+    const leadPokemon = game.scene.getPlayerParty()[0];
 
-    const enemyLeadPokemon = game.scene.getEnemyParty()[0]!;
-    const enemySecPokemon = game.scene.getEnemyParty()[1]!;
+    const enemyLeadPokemon = game.scene.getEnemyParty()[0];
+    const enemySecPokemon = game.scene.getEnemyParty()[1];
 
     game.move.select(MoveId.DRAGON_TAIL, 0, BattlerIndex.ENEMY);
     game.move.select(MoveId.SPLASH, 1);
@@ -105,11 +105,11 @@ describe("Moves - Dragon Tail", () => {
     game.override.battleStyle("double").enemyMoveset(MoveId.SPLASH).enemyAbility(AbilityId.ROUGH_SKIN);
     await game.classicMode.startBattle([SpeciesId.DRATINI, SpeciesId.DRATINI, SpeciesId.WAILORD, SpeciesId.WAILORD]);
 
-    const leadPokemon = game.scene.getPlayerParty()[0]!;
-    const secPokemon = game.scene.getPlayerParty()[1]!;
+    const leadPokemon = game.scene.getPlayerParty()[0];
+    const secPokemon = game.scene.getPlayerParty()[1];
 
-    const enemyLeadPokemon = game.scene.getEnemyParty()[0]!;
-    const enemySecPokemon = game.scene.getEnemyParty()[1]!;
+    const enemyLeadPokemon = game.scene.getEnemyParty()[0];
+    const enemySecPokemon = game.scene.getEnemyParty()[1];
 
     game.move.select(MoveId.DRAGON_TAIL, 0, BattlerIndex.ENEMY);
     // target the same pokemon, second move should be redirected after first flees

--- a/test/moves/dragon-tail.test.ts
+++ b/test/moves/dragon-tail.test.ts
@@ -78,8 +78,7 @@ describe("Moves - Dragon Tail", () => {
 
     const leadPokemon = game.scene.getPlayerParty()[0];
 
-    const enemyLeadPokemon = game.scene.getEnemyParty()[0];
-    const enemySecPokemon = game.scene.getEnemyParty()[1];
+    const [enemyLeadPokemon, enemySecPokemon] = game.scene.getEnemyParty();
 
     game.move.select(MoveId.DRAGON_TAIL, 0, BattlerIndex.ENEMY);
     game.move.select(MoveId.SPLASH, 1);
@@ -105,11 +104,9 @@ describe("Moves - Dragon Tail", () => {
     game.override.battleStyle("double").enemyMoveset(MoveId.SPLASH).enemyAbility(AbilityId.ROUGH_SKIN);
     await game.classicMode.startBattle([SpeciesId.DRATINI, SpeciesId.DRATINI, SpeciesId.WAILORD, SpeciesId.WAILORD]);
 
-    const leadPokemon = game.scene.getPlayerParty()[0];
-    const secPokemon = game.scene.getPlayerParty()[1];
+    const [leadPokemon, secPokemon] = game.scene.getPlayerParty();
 
-    const enemyLeadPokemon = game.scene.getEnemyParty()[0];
-    const enemySecPokemon = game.scene.getEnemyParty()[1];
+    const [enemyLeadPokemon, enemySecPokemon] = game.scene.getEnemyParty();
 
     game.move.select(MoveId.DRAGON_TAIL, 0, BattlerIndex.ENEMY);
     // target the same pokemon, second move should be redirected after first flees

--- a/test/moves/dragon-tail.test.ts
+++ b/test/moves/dragon-tail.test.ts
@@ -76,7 +76,7 @@ describe("Moves - Dragon Tail", () => {
     game.override.battleStyle("double").enemyMoveset(MoveId.SPLASH).enemyAbility(AbilityId.ROUGH_SKIN);
     await game.classicMode.startBattle([SpeciesId.DRATINI, SpeciesId.DRATINI, SpeciesId.WAILORD, SpeciesId.WAILORD]);
 
-    const leadPokemon = game.scene.getPlayerParty()[0];
+    const leadPokemon = game.field.getPlayerPokemon();
 
     const [enemyLeadPokemon, enemySecPokemon] = game.scene.getEnemyParty();
 

--- a/test/moves/fissure.test.ts
+++ b/test/moves/fissure.test.ts
@@ -42,7 +42,7 @@ describe("Moves - Fissure", () => {
 
     await game.classicMode.startBattle();
 
-    partyPokemon = game.scene.getPlayerParty()[0];
+    partyPokemon = game.field.getPlayerPokemon();
     enemyPokemon = game.scene.getEnemyPokemon()!;
   });
 

--- a/test/moves/parting-shot.test.ts
+++ b/test/moves/parting-shot.test.ts
@@ -80,19 +80,19 @@ describe("Moves - Parting Shot", () => {
       // use Memento 3 times to debuff enemy
       game.move.select(MoveId.MEMENTO);
       await game.phaseInterceptor.to(FaintPhase);
-      expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
+      expect(game.field.getPlayerPokemon().isFainted()).toBe(true);
       game.doSelectPartyPokemon(1);
 
       await game.phaseInterceptor.to(TurnInitPhase, false);
       game.move.select(MoveId.MEMENTO);
       await game.phaseInterceptor.to(FaintPhase);
-      expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
+      expect(game.field.getPlayerPokemon().isFainted()).toBe(true);
       game.doSelectPartyPokemon(2);
 
       await game.phaseInterceptor.to(TurnInitPhase, false);
       game.move.select(MoveId.MEMENTO);
       await game.phaseInterceptor.to(FaintPhase);
-      expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
+      expect(game.field.getPlayerPokemon().isFainted()).toBe(true);
       game.doSelectPartyPokemon(3);
 
       // set up done
@@ -177,8 +177,8 @@ describe("Moves - Parting Shot", () => {
       game.move.select(MoveId.SPLASH);
 
       // intentionally kill party pokemon, switch to second slot (now 1 party mon is fainted)
-      await game.killPokemon(game.scene.getPlayerParty()[0]);
-      expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
+      await game.killPokemon(game.field.getPlayerPokemon());
+      expect(game.field.getPlayerPokemon().isFainted()).toBe(true);
       await game.phaseInterceptor.run(MessagePhase);
       game.doSelectPartyPokemon(1);
 

--- a/test/moves/revival-blessing.test.ts
+++ b/test/moves/revival-blessing.test.ts
@@ -133,6 +133,6 @@ describe("Moves - Revival Blessing", () => {
     await game.toNextTurn();
     // If there are incorrectly two switch phases into this slot, the fainted pokemon will end up in slot 3
     // Make sure it's still in slot 1
-    expect(game.scene.getEnemyParty()[0]).toBe(enemyFainting);
+    expect(game.field.getEnemyPokemon()).toBe(enemyFainting);
   });
 });

--- a/test/moves/rollout.test.ts
+++ b/test/moves/rollout.test.ts
@@ -44,10 +44,10 @@ describe("Moves - Rollout", () => {
 
     await game.classicMode.startBattle();
 
-    const playerPkm = game.scene.getPlayerParty()[0];
+    const playerPkm = game.field.getPlayerPokemon();
     vi.spyOn(playerPkm, "stats", "get").mockReturnValue([500000, 1, 1, 1, 1, 1]); // HP, ATK, DEF, SPATK, SPDEF, SPD
 
-    const enemyPkm = game.scene.getEnemyParty()[0];
+    const enemyPkm = game.field.getEnemyPokemon();
     vi.spyOn(enemyPkm, "stats", "get").mockReturnValue([500000, 1, 1, 1, 1, 1]); // HP, ATK, DEF, SPATK, SPDEF, SPD
     vi.spyOn(enemyPkm, "getHeldItems").mockReturnValue([]); //no berries
 

--- a/test/moves/spikes.test.ts
+++ b/test/moves/spikes.test.ts
@@ -48,7 +48,7 @@ describe("Moves - Spikes", () => {
     game.doSwitchPokemon(1);
     await game.toNextTurn();
 
-    const player = game.scene.getPlayerParty()[0];
+    const player = game.field.getPlayerPokemon();
     expect(player.hp).toBe(player.getMaxHp());
   });
 
@@ -62,7 +62,7 @@ describe("Moves - Spikes", () => {
     game.move.select(MoveId.ROAR);
     await game.toNextTurn();
 
-    const enemy = game.scene.getEnemyParty()[0];
+    const enemy = game.field.getEnemyPokemon();
     expect(enemy.hp).toBeLessThan(enemy.getMaxHp());
   });
 
@@ -77,7 +77,7 @@ describe("Moves - Spikes", () => {
     game.forceEnemyToSwitch();
     await game.toNextTurn();
 
-    const enemy = game.scene.getEnemyParty()[0];
+    const enemy = game.field.getEnemyPokemon();
     expect(enemy.hp).toBeLessThan(enemy.getMaxHp());
   });
 

--- a/test/moves/tackle.test.ts
+++ b/test/moves/tackle.test.ts
@@ -50,7 +50,7 @@ describe("Moves - Tackle", () => {
     const moveToUse = MoveId.TACKLE;
     await game.classicMode.startBattle([SpeciesId.MIGHTYENA]);
     game.scene.currentBattle.enemyParty[0].stats[Stat.DEF] = 50;
-    game.scene.getPlayerParty()[0].stats[Stat.ATK] = 50;
+    game.field.getPlayerPokemon().stats[Stat.ATK] = 50;
 
     const hpOpponent = game.scene.currentBattle.enemyParty[0].hp;
 

--- a/test/moves/tera-starstorm.test.ts
+++ b/test/moves/tera-starstorm.test.ts
@@ -72,7 +72,7 @@ describe("Moves - Tera Starstorm", () => {
   it("targets both opponents in a double battle when used by Terapagos immediately after terastallizing", async () => {
     await game.classicMode.startBattle([SpeciesId.TERAPAGOS]);
 
-    const terapagos = game.scene.getPlayerParty()[0];
+    const terapagos = game.field.getPlayerPokemon();
     terapagos.isTerastallized = false;
 
     game.move.selectWithTera(MoveId.TERA_STARSTORM, 0);
@@ -89,7 +89,7 @@ describe("Moves - Tera Starstorm", () => {
   it("targets only one opponent in a double battle when used by Terapagos without terastallizing", async () => {
     await game.classicMode.startBattle([SpeciesId.TERAPAGOS]);
 
-    const terapagos = game.scene.getPlayerParty()[0];
+    const terapagos = game.field.getPlayerPokemon();
     terapagos.isTerastallized = false;
 
     game.move.select(MoveId.TERA_STARSTORM, 0, BattlerIndex.ENEMY);

--- a/test/moves/tera-starstorm.test.ts
+++ b/test/moves/tera-starstorm.test.ts
@@ -106,8 +106,7 @@ describe("Moves - Tera Starstorm", () => {
   it("applies the effects when Terapagos in Stellar Form is fused with another Pokemon", async () => {
     await game.classicMode.startBattle([SpeciesId.TERAPAGOS, SpeciesId.CHARMANDER, SpeciesId.MAGIKARP]);
 
-    const fusionedMon = game.scene.getPlayerParty()[0];
-    const magikarp = game.scene.getPlayerParty()[2];
+    const [fusionedMon, , magikarp] = game.scene.getPlayerParty();
 
     // Fuse party members (taken from PlayerPokemon.fuse(...) function)
     fusionedMon.fusionSpecies = magikarp.species;

--- a/test/mystery-encounter/encounters/clowning-around-encounter.test.ts
+++ b/test/mystery-encounter/encounters/clowning-around-encounter.test.ts
@@ -230,7 +230,7 @@ describe("Clowning Around - Mystery Encounter", () => {
       // Stop next battle before it runs
       await game.phaseInterceptor.to(NewBattlePhase, false);
 
-      const leadPokemon = scene.getPlayerParty()[0];
+      const leadPokemon = field.getPlayerPokemon();
       expect(leadPokemon.customPokemonData?.ability).toBe(abilityToTrain);
     });
   });
@@ -263,30 +263,30 @@ describe("Clowning Around - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.CLOWNING_AROUND, defaultParty);
 
       // Set some moves on party for attack type booster generation
-      scene.getPlayerParty()[0].moveset = [new PokemonMove(MoveId.TACKLE), new PokemonMove(MoveId.THIEF)];
+      field.getPlayerPokemon().moveset = [new PokemonMove(MoveId.TACKLE), new PokemonMove(MoveId.THIEF)];
 
       // 2 Sitrus Berries on lead
       scene.modifiers = [];
       let itemType = generateModifierType(modifierTypes.BERRY, [BerryType.SITRUS]) as PokemonHeldItemModifierType;
-      await addItemToPokemon(scene, scene.getPlayerParty()[0], 2, itemType);
+      await addItemToPokemon(scene, field.getPlayerPokemon(), 2, itemType);
       // 2 Ganlon Berries on lead
       itemType = generateModifierType(modifierTypes.BERRY, [BerryType.GANLON]) as PokemonHeldItemModifierType;
-      await addItemToPokemon(scene, scene.getPlayerParty()[0], 2, itemType);
+      await addItemToPokemon(scene, field.getPlayerPokemon(), 2, itemType);
       // 5 Golden Punch on lead (ultra)
       itemType = generateModifierType(modifierTypes.GOLDEN_PUNCH) as PokemonHeldItemModifierType;
-      await addItemToPokemon(scene, scene.getPlayerParty()[0], 5, itemType);
+      await addItemToPokemon(scene, field.getPlayerPokemon(), 5, itemType);
       // 5 Lucky Egg on lead (ultra)
       itemType = generateModifierType(modifierTypes.LUCKY_EGG) as PokemonHeldItemModifierType;
-      await addItemToPokemon(scene, scene.getPlayerParty()[0], 5, itemType);
+      await addItemToPokemon(scene, field.getPlayerPokemon(), 5, itemType);
       // 3 Soothe Bell on lead (great tier, but counted as ultra by this ME)
       itemType = generateModifierType(modifierTypes.SOOTHE_BELL) as PokemonHeldItemModifierType;
-      await addItemToPokemon(scene, scene.getPlayerParty()[0], 3, itemType);
+      await addItemToPokemon(scene, field.getPlayerPokemon(), 3, itemType);
       // 5 Soul Dew on lead (rogue)
       itemType = generateModifierType(modifierTypes.SOUL_DEW) as PokemonHeldItemModifierType;
-      await addItemToPokemon(scene, scene.getPlayerParty()[0], 5, itemType);
+      await addItemToPokemon(scene, field.getPlayerPokemon(), 5, itemType);
       // 2 Golden Egg on lead (rogue)
       itemType = generateModifierType(modifierTypes.GOLDEN_EGG) as PokemonHeldItemModifierType;
-      await addItemToPokemon(scene, scene.getPlayerParty()[0], 2, itemType);
+      await addItemToPokemon(scene, field.getPlayerPokemon(), 2, itemType);
 
       // 5 Soul Dew on second party pokemon (these should not change)
       itemType = generateModifierType(modifierTypes.SOUL_DEW) as PokemonHeldItemModifierType;
@@ -294,7 +294,7 @@ describe("Clowning Around - Mystery Encounter", () => {
 
       await runMysteryEncounterToEnd(game, 2);
 
-      const leadItemsAfter = scene.getPlayerParty()[0].getHeldItems();
+      const leadItemsAfter = field.getPlayerPokemon().getHeldItems();
       const ultraCountAfter = leadItemsAfter
         .filter(m => m.type.tier === ModifierTier.ULTRA)
         .reduce((a, b) => a + b.stackCount, 0);
@@ -348,14 +348,14 @@ describe("Clowning Around - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.CLOWNING_AROUND, defaultParty);
 
       // Same type moves on lead
-      scene.getPlayerParty()[0].moveset = [new PokemonMove(MoveId.ICE_BEAM), new PokemonMove(MoveId.SURF)];
+      field.getPlayerPokemon().moveset = [new PokemonMove(MoveId.ICE_BEAM), new PokemonMove(MoveId.SURF)];
       // Different type moves on second
       scene.getPlayerParty()[1].moveset = [new PokemonMove(MoveId.GRASS_KNOT), new PokemonMove(MoveId.ELECTRO_BALL)];
       // No moves on third
       scene.getPlayerParty()[2].moveset = [];
       await runMysteryEncounterToEnd(game, 3);
 
-      const leadTypesAfter = scene.getPlayerParty()[0].getTypes();
+      const leadTypesAfter = field.getPlayerPokemon().getTypes();
       const secondaryTypesAfter = scene.getPlayerParty()[1].getTypes();
       const thirdTypesAfter = scene.getPlayerParty()[2].getTypes();
 

--- a/test/mystery-encounter/encounters/dancing-lessons-encounter.test.ts
+++ b/test/mystery-encounter/encounters/dancing-lessons-encounter.test.ts
@@ -100,7 +100,7 @@ describe("Dancing Lessons - Mystery Encounter", () => {
 
       await game.runToMysteryEncounter(MysteryEncounterType.DANCING_LESSONS, defaultParty);
       // Make party lead's level arbitrarily high to not get KOed by move
-      const partyLead = scene.getPlayerParty()[0];
+      const partyLead = field.getPlayerPokemon();
       partyLead.level = 1000;
       partyLead.calculateStats();
       await runMysteryEncounterToEnd(game, 1, undefined, true);
@@ -121,7 +121,7 @@ describe("Dancing Lessons - Mystery Encounter", () => {
     it("should have a Baton in the rewards after battle", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.DANCING_LESSONS, defaultParty);
       // Make party lead's level arbitrarily high to not get KOed by move
-      const partyLead = scene.getPlayerParty()[0];
+      const partyLead = field.getPlayerPokemon();
       partyLead.level = 1000;
       partyLead.calculateStats();
       await runMysteryEncounterToEnd(game, 1, undefined, true);
@@ -159,7 +159,7 @@ describe("Dancing Lessons - Mystery Encounter", () => {
       const phaseSpy = vi.spyOn(scene.phaseManager, "unshiftPhase");
 
       await game.runToMysteryEncounter(MysteryEncounterType.DANCING_LESSONS, defaultParty);
-      scene.getPlayerParty()[0].moveset = [];
+      field.getPlayerPokemon().moveset = [];
       await runMysteryEncounterToEnd(game, 2, { pokemonNo: 1 });
 
       const movePhases = phaseSpy.mock.calls.filter(p => p[0] instanceof LearnMovePhase).map(p => p[0]);
@@ -171,7 +171,7 @@ describe("Dancing Lessons - Mystery Encounter", () => {
       const leaveEncounterWithoutBattleSpy = vi.spyOn(EncounterPhaseUtils, "leaveEncounterWithoutBattle");
 
       await game.runToMysteryEncounter(MysteryEncounterType.DANCING_LESSONS, defaultParty);
-      scene.getPlayerParty()[0].moveset = [];
+      field.getPlayerPokemon().moveset = [];
       await runMysteryEncounterToEnd(game, 2, { pokemonNo: 1 });
 
       expect(leaveEncounterWithoutBattleSpy).toBeCalled();
@@ -199,7 +199,7 @@ describe("Dancing Lessons - Mystery Encounter", () => {
     it("should add Oricorio to the party", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.DANCING_LESSONS, defaultParty);
       const partyCountBefore = scene.getPlayerParty().length;
-      scene.getPlayerParty()[0].moveset = [new PokemonMove(MoveId.DRAGON_DANCE)];
+      field.getPlayerPokemon().moveset = [new PokemonMove(MoveId.DRAGON_DANCE)];
       await runMysteryEncounterToEnd(game, 3, { pokemonNo: 1, optionNo: 1 });
       const partyCountAfter = scene.getPlayerParty().length;
 
@@ -238,7 +238,7 @@ describe("Dancing Lessons - Mystery Encounter", () => {
       const leaveEncounterWithoutBattleSpy = vi.spyOn(EncounterPhaseUtils, "leaveEncounterWithoutBattle");
 
       await game.runToMysteryEncounter(MysteryEncounterType.DANCING_LESSONS, defaultParty);
-      scene.getPlayerParty()[0].moveset = [new PokemonMove(MoveId.DRAGON_DANCE)];
+      field.getPlayerPokemon().moveset = [new PokemonMove(MoveId.DRAGON_DANCE)];
       await runMysteryEncounterToEnd(game, 3, { pokemonNo: 1, optionNo: 1 });
 
       expect(leaveEncounterWithoutBattleSpy).toBeCalled();

--- a/test/mystery-encounter/encounters/delibirdy-encounter.test.ts
+++ b/test/mystery-encounter/encounters/delibirdy-encounter.test.ts
@@ -201,7 +201,7 @@ describe("Delibird-y - Mystery Encounter", () => {
       // Set 2 Sitrus berries on party lead
       scene.modifiers = [];
       const sitrus = generateModifierType(modifierTypes.BERRY, [BerryType.SITRUS])!;
-      const sitrusMod = sitrus.newModifier(scene.getPlayerParty()[0]) as BerryModifier;
+      const sitrusMod = sitrus.newModifier(field.getPlayerPokemon()) as BerryModifier;
       sitrusMod.stackCount = 2;
       scene.addModifier(sitrusMod, true, false, false, true);
       await scene.updateModifiers(true);
@@ -222,7 +222,7 @@ describe("Delibird-y - Mystery Encounter", () => {
       // Set 1 Reviver Seed on party lead
       scene.modifiers = [];
       const revSeed = generateModifierType(modifierTypes.REVIVER_SEED)!;
-      const modifier = revSeed.newModifier(scene.getPlayerParty()[0]) as PokemonInstantReviveModifier;
+      const modifier = revSeed.newModifier(field.getPlayerPokemon()) as PokemonInstantReviveModifier;
       modifier.stackCount = 1;
       scene.addModifier(modifier, true, false, false, true);
       await scene.updateModifiers(true);
@@ -248,7 +248,7 @@ describe("Delibird-y - Mystery Encounter", () => {
       const sitrus = generateModifierType(modifierTypes.BERRY, [BerryType.SITRUS])!;
 
       // Sitrus berries on party
-      const sitrusMod = sitrus.newModifier(scene.getPlayerParty()[0]) as BerryModifier;
+      const sitrusMod = sitrus.newModifier(field.getPlayerPokemon()) as BerryModifier;
       sitrusMod.stackCount = 2;
       scene.addModifier(sitrusMod, true, false, false, true);
       await scene.updateModifiers(true);
@@ -277,7 +277,7 @@ describe("Delibird-y - Mystery Encounter", () => {
 
       // Set 1 Reviver Seed on party lead
       const revSeed = generateModifierType(modifierTypes.REVIVER_SEED)!;
-      const modifier = revSeed.newModifier(scene.getPlayerParty()[0]) as PokemonInstantReviveModifier;
+      const modifier = revSeed.newModifier(field.getPlayerPokemon()) as PokemonInstantReviveModifier;
       modifier.stackCount = 1;
       scene.addModifier(modifier, true, false, false, true);
       await scene.updateModifiers(true);
@@ -301,7 +301,7 @@ describe("Delibird-y - Mystery Encounter", () => {
       // Set 1 Soul Dew on party lead
       scene.modifiers = [];
       const soulDew = generateModifierType(modifierTypes.SOUL_DEW)!;
-      const modifier = soulDew.newModifier(scene.getPlayerParty()[0]);
+      const modifier = soulDew.newModifier(field.getPlayerPokemon());
       scene.addModifier(modifier, true, false, false, true);
       await scene.updateModifiers(true);
 
@@ -329,7 +329,7 @@ describe("Delibird-y - Mystery Encounter", () => {
 
       // Set 1 Reviver Seed on party lead
       const revSeed = generateModifierType(modifierTypes.REVIVER_SEED)!;
-      const modifier = revSeed.newModifier(scene.getPlayerParty()[0]) as PokemonInstantReviveModifier;
+      const modifier = revSeed.newModifier(field.getPlayerPokemon()) as PokemonInstantReviveModifier;
       modifier.stackCount = 1;
       scene.addModifier(modifier, true, false, false, true);
       await scene.updateModifiers(true);
@@ -363,7 +363,7 @@ describe("Delibird-y - Mystery Encounter", () => {
       // Set 2 Soul Dew on party lead
       scene.modifiers = [];
       const soulDew = generateModifierType(modifierTypes.SOUL_DEW)!;
-      const modifier = soulDew.newModifier(scene.getPlayerParty()[0]) as PokemonNatureWeightModifier;
+      const modifier = soulDew.newModifier(field.getPlayerPokemon()) as PokemonNatureWeightModifier;
       modifier.stackCount = 2;
       scene.addModifier(modifier, true, false, false, true);
       await scene.updateModifiers(true);
@@ -384,7 +384,7 @@ describe("Delibird-y - Mystery Encounter", () => {
       // Set 1 Soul Dew on party lead
       scene.modifiers = [];
       const soulDew = generateModifierType(modifierTypes.SOUL_DEW)!;
-      const modifier = soulDew.newModifier(scene.getPlayerParty()[0]) as PokemonNatureWeightModifier;
+      const modifier = soulDew.newModifier(field.getPlayerPokemon()) as PokemonNatureWeightModifier;
       modifier.stackCount = 1;
       scene.addModifier(modifier, true, false, false, true);
       await scene.updateModifiers(true);
@@ -410,7 +410,7 @@ describe("Delibird-y - Mystery Encounter", () => {
 
       // Set 1 Soul Dew on party lead
       const soulDew = generateModifierType(modifierTypes.SOUL_DEW)!;
-      const modifier = soulDew.newModifier(scene.getPlayerParty()[0]) as PokemonNatureWeightModifier;
+      const modifier = soulDew.newModifier(field.getPlayerPokemon()) as PokemonNatureWeightModifier;
       modifier.stackCount = 1;
       scene.addModifier(modifier, true, false, false, true);
       await scene.updateModifiers(true);
@@ -434,7 +434,7 @@ describe("Delibird-y - Mystery Encounter", () => {
       // Set 1 Reviver Seed on party lead
       scene.modifiers = [];
       const revSeed = generateModifierType(modifierTypes.REVIVER_SEED)!;
-      const modifier = revSeed.newModifier(scene.getPlayerParty()[0]);
+      const modifier = revSeed.newModifier(field.getPlayerPokemon());
       scene.addModifier(modifier, true, false, false, true);
       await scene.updateModifiers(true);
 
@@ -463,7 +463,7 @@ describe("Delibird-y - Mystery Encounter", () => {
       // Set 1 Soul Dew on party lead
       scene.modifiers = [];
       const soulDew = generateModifierType(modifierTypes.SOUL_DEW)!;
-      const modifier = soulDew.newModifier(scene.getPlayerParty()[0]) as PokemonNatureWeightModifier;
+      const modifier = soulDew.newModifier(field.getPlayerPokemon()) as PokemonNatureWeightModifier;
       modifier.stackCount = 1;
       scene.addModifier(modifier, true, false, false, true);
       await scene.updateModifiers(true);

--- a/test/mystery-encounter/encounters/fight-or-flight-encounter.test.ts
+++ b/test/mystery-encounter/encounters/fight-or-flight-encounter.test.ts
@@ -178,7 +178,7 @@ describe("Fight or Flight - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.FIGHT_OR_FLIGHT, defaultParty);
 
       // Mock moveset
-      scene.getPlayerParty()[0].moveset = [new PokemonMove(MoveId.KNOCK_OFF)];
+      field.getPlayerPokemon().moveset = [new PokemonMove(MoveId.KNOCK_OFF)];
       const item = game.scene.currentBattle.mysteryEncounter!.misc;
 
       await runMysteryEncounterToEnd(game, 2);

--- a/test/mystery-encounter/encounters/global-trade-system-encounter.test.ts
+++ b/test/mystery-encounter/encounters/global-trade-system-encounter.test.ts
@@ -105,7 +105,7 @@ describe("Global Trade System - Mystery Encounter", () => {
     it("Should trade a Pokemon from the player's party for the first of 3 Pokemon options", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.GLOBAL_TRADE_SYSTEM, defaultParty);
 
-      const speciesBefore = scene.getPlayerParty()[0].species.speciesId;
+      const speciesBefore = field.getPlayerPokemon().species.speciesId;
       await runMysteryEncounterToEnd(game, 1, { pokemonNo: 1, optionNo: 1 });
 
       const speciesAfter = scene.getPlayerParty().at(-1)?.species.speciesId;
@@ -220,7 +220,7 @@ describe("Global Trade System - Mystery Encounter", () => {
       // Set 2 Soul Dew on party lead
       scene.modifiers = [];
       const soulDew = generateModifierType(modifierTypes.SOUL_DEW)!;
-      const modifier = soulDew.newModifier(scene.getPlayerParty()[0]) as PokemonNatureWeightModifier;
+      const modifier = soulDew.newModifier(field.getPlayerPokemon()) as PokemonNatureWeightModifier;
       modifier.stackCount = 2;
       scene.addModifier(modifier, true, false, false, true);
       await scene.updateModifiers(true);
@@ -247,7 +247,7 @@ describe("Global Trade System - Mystery Encounter", () => {
       // Set 1 Soul Dew on party lead
       scene.modifiers = [];
       const soulDew = generateModifierType(modifierTypes.SOUL_DEW)!;
-      const modifier = soulDew.newModifier(scene.getPlayerParty()[0]) as PokemonNatureWeightModifier;
+      const modifier = soulDew.newModifier(field.getPlayerPokemon()) as PokemonNatureWeightModifier;
       modifier.stackCount = 1;
       scene.addModifier(modifier, true, false, false, true);
       await scene.updateModifiers(true);

--- a/test/mystery-encounter/encounters/part-timer-encounter.test.ts
+++ b/test/mystery-encounter/encounters/part-timer-encounter.test.ts
@@ -110,7 +110,7 @@ describe("Part-Timer - Mystery Encounter", () => {
 
       expect(EncounterPhaseUtils.updatePlayerMoney).toHaveBeenCalledWith(scene.getWaveMoneyAmount(1), true, false);
       // Expect PP of mon's moves to have been reduced to 2
-      const moves = scene.getPlayerParty()[0].moveset;
+      const moves = field.getPlayerPokemon().moveset;
       for (const move of moves) {
         expect((move?.getMovePp() ?? 0) - (move?.ppUsed ?? 0)).toBe(2);
       }
@@ -257,12 +257,12 @@ describe("Part-Timer - Mystery Encounter", () => {
 
       await game.runToMysteryEncounter(MysteryEncounterType.PART_TIMER, defaultParty);
       // Mock moveset
-      scene.getPlayerParty()[0].moveset = [new PokemonMove(MoveId.ATTRACT)];
+      field.getPlayerPokemon().moveset = [new PokemonMove(MoveId.ATTRACT)];
       await runMysteryEncounterToEnd(game, 3);
 
       expect(EncounterPhaseUtils.updatePlayerMoney).toHaveBeenCalledWith(scene.getWaveMoneyAmount(2.5), true, false);
       // Expect PP of mon's moves to have been reduced to 2
-      const moves = scene.getPlayerParty()[0].moveset;
+      const moves = field.getPlayerPokemon().moveset;
       for (const move of moves) {
         expect((move?.getMovePp() ?? 0) - (move?.ppUsed ?? 0)).toBe(2);
       }

--- a/test/mystery-encounter/encounters/uncommon-breed-encounter.test.ts
+++ b/test/mystery-encounter/encounters/uncommon-breed-encounter.test.ts
@@ -214,11 +214,11 @@ describe("Uncommon Breed - Mystery Encounter", () => {
 
       // Berries on party lead
       const sitrus = generateModifierType(modifierTypes.BERRY, [BerryType.SITRUS])!;
-      const sitrusMod = sitrus.newModifier(scene.getPlayerParty()[0]) as BerryModifier;
+      const sitrusMod = sitrus.newModifier(field.getPlayerPokemon()) as BerryModifier;
       sitrusMod.stackCount = 2;
       scene.addModifier(sitrusMod, true, false, false, true);
       const ganlon = generateModifierType(modifierTypes.BERRY, [BerryType.GANLON])!;
-      const ganlonMod = ganlon.newModifier(scene.getPlayerParty()[0]) as BerryModifier;
+      const ganlonMod = ganlon.newModifier(field.getPlayerPokemon()) as BerryModifier;
       ganlonMod.stackCount = 3;
       scene.addModifier(ganlonMod, true, false, false, true);
       await scene.updateModifiers(true);
@@ -270,7 +270,7 @@ describe("Uncommon Breed - Mystery Encounter", () => {
       const leaveEncounterWithoutBattleSpy = vi.spyOn(EncounterPhaseUtils, "leaveEncounterWithoutBattle");
       await game.runToMysteryEncounter(MysteryEncounterType.UNCOMMON_BREED, defaultParty);
       // Mock moveset
-      scene.getPlayerParty()[0].moveset = [new PokemonMove(MoveId.CHARM)];
+      field.getPlayerPokemon().moveset = [new PokemonMove(MoveId.CHARM)];
       await runMysteryEncounterToEnd(game, 3);
 
       expect(leaveEncounterWithoutBattleSpy).toBeCalled();

--- a/test/phases/form-change-phase.test.ts
+++ b/test/phases/form-change-phase.test.ts
@@ -38,7 +38,7 @@ describe("Form Change Phase", () => {
     await game.classicMode.startBattle([SpeciesId.ZACIAN]);
 
     // Before the form change: Should be Hero form
-    const zacian = game.scene.getPlayerParty()[0];
+    const zacian = game.field.getPlayerPokemon();
     expect(zacian.getFormKey()).toBe("hero-of-many-battles");
     expect(zacian.getTypes()).toStrictEqual([PokemonType.FAIRY]);
     expect(zacian.calculateBaseStats()).toStrictEqual([92, 120, 115, 80, 115, 138]);

--- a/test/ui/starter-select.test.ts
+++ b/test/ui/starter-select.test.ts
@@ -90,10 +90,10 @@ describe("UI - Starter select", () => {
     });
     await game.phaseInterceptor.whenAboutToRun(EncounterPhase);
 
-    expect(game.scene.getPlayerParty()[0].species.speciesId).toBe(SpeciesId.BULBASAUR);
-    expect(game.scene.getPlayerParty()[0].shiny).toBe(true);
-    expect(game.scene.getPlayerParty()[0].variant).toBe(2);
-    expect(game.scene.getPlayerParty()[0].gender).toBe(Gender.MALE);
+    expect(game.field.getPlayerPokemon().species.speciesId).toBe(SpeciesId.BULBASAUR);
+    expect(game.field.getPlayerPokemon().shiny).toBe(true);
+    expect(game.field.getPlayerPokemon().variant).toBe(2);
+    expect(game.field.getPlayerPokemon().gender).toBe(Gender.MALE);
   });
 
   it("Bulbasaur - shiny - variant 2 female hardy overgrow", async () => {
@@ -151,11 +151,11 @@ describe("UI - Starter select", () => {
     });
     await game.phaseInterceptor.whenAboutToRun(EncounterPhase);
 
-    expect(game.scene.getPlayerParty()[0].species.speciesId).toBe(SpeciesId.BULBASAUR);
-    expect(game.scene.getPlayerParty()[0].shiny).toBe(true);
-    expect(game.scene.getPlayerParty()[0].variant).toBe(2);
-    expect(game.scene.getPlayerParty()[0].nature).toBe(Nature.HARDY);
-    expect(game.scene.getPlayerParty()[0].getAbility().id).toBe(AbilityId.OVERGROW);
+    expect(game.field.getPlayerPokemon().species.speciesId).toBe(SpeciesId.BULBASAUR);
+    expect(game.field.getPlayerPokemon().shiny).toBe(true);
+    expect(game.field.getPlayerPokemon().variant).toBe(2);
+    expect(game.field.getPlayerPokemon().nature).toBe(Nature.HARDY);
+    expect(game.field.getPlayerPokemon().getAbility().id).toBe(AbilityId.OVERGROW);
   });
 
   it("Bulbasaur - shiny - variant 2 female lonely chlorophyl", async () => {
@@ -215,12 +215,12 @@ describe("UI - Starter select", () => {
     });
     await game.phaseInterceptor.whenAboutToRun(EncounterPhase);
 
-    expect(game.scene.getPlayerParty()[0].species.speciesId).toBe(SpeciesId.BULBASAUR);
-    expect(game.scene.getPlayerParty()[0].shiny).toBe(true);
-    expect(game.scene.getPlayerParty()[0].variant).toBe(2);
-    expect(game.scene.getPlayerParty()[0].gender).toBe(Gender.FEMALE);
-    expect(game.scene.getPlayerParty()[0].nature).toBe(Nature.LONELY);
-    expect(game.scene.getPlayerParty()[0].getAbility().id).toBe(AbilityId.CHLOROPHYLL);
+    expect(game.field.getPlayerPokemon().species.speciesId).toBe(SpeciesId.BULBASAUR);
+    expect(game.field.getPlayerPokemon().shiny).toBe(true);
+    expect(game.field.getPlayerPokemon().variant).toBe(2);
+    expect(game.field.getPlayerPokemon().gender).toBe(Gender.FEMALE);
+    expect(game.field.getPlayerPokemon().nature).toBe(Nature.LONELY);
+    expect(game.field.getPlayerPokemon().getAbility().id).toBe(AbilityId.CHLOROPHYLL);
   });
 
   it("Bulbasaur - shiny - variant 2 female", async () => {
@@ -278,10 +278,10 @@ describe("UI - Starter select", () => {
     });
     await game.phaseInterceptor.whenAboutToRun(EncounterPhase);
 
-    expect(game.scene.getPlayerParty()[0].species.speciesId).toBe(SpeciesId.BULBASAUR);
-    expect(game.scene.getPlayerParty()[0].shiny).toBe(true);
-    expect(game.scene.getPlayerParty()[0].variant).toBe(2);
-    expect(game.scene.getPlayerParty()[0].gender).toBe(Gender.FEMALE);
+    expect(game.field.getPlayerPokemon().species.speciesId).toBe(SpeciesId.BULBASAUR);
+    expect(game.field.getPlayerPokemon().shiny).toBe(true);
+    expect(game.field.getPlayerPokemon().variant).toBe(2);
+    expect(game.field.getPlayerPokemon().gender).toBe(Gender.FEMALE);
   });
 
   it("Bulbasaur - not shiny", async () => {
@@ -339,9 +339,9 @@ describe("UI - Starter select", () => {
     });
     await game.phaseInterceptor.whenAboutToRun(EncounterPhase);
 
-    expect(game.scene.getPlayerParty()[0].species.speciesId).toBe(SpeciesId.BULBASAUR);
-    expect(game.scene.getPlayerParty()[0].shiny).toBe(false);
-    expect(game.scene.getPlayerParty()[0].variant).toBe(0);
+    expect(game.field.getPlayerPokemon().species.speciesId).toBe(SpeciesId.BULBASAUR);
+    expect(game.field.getPlayerPokemon().shiny).toBe(false);
+    expect(game.field.getPlayerPokemon().variant).toBe(0);
   });
 
   it("Bulbasaur - shiny - variant 1", async () => {
@@ -401,9 +401,9 @@ describe("UI - Starter select", () => {
     });
     await game.phaseInterceptor.whenAboutToRun(EncounterPhase);
 
-    expect(game.scene.getPlayerParty()[0].species.speciesId).toBe(SpeciesId.BULBASAUR);
-    expect(game.scene.getPlayerParty()[0].shiny).toBe(true);
-    expect(game.scene.getPlayerParty()[0].variant).toBe(1);
+    expect(game.field.getPlayerPokemon().species.speciesId).toBe(SpeciesId.BULBASAUR);
+    expect(game.field.getPlayerPokemon().shiny).toBe(true);
+    expect(game.field.getPlayerPokemon().variant).toBe(1);
   });
 
   it("Bulbasaur - shiny - variant 0", async () => {
@@ -462,9 +462,9 @@ describe("UI - Starter select", () => {
     });
     await game.phaseInterceptor.whenAboutToRun(EncounterPhase);
 
-    expect(game.scene.getPlayerParty()[0].species.speciesId).toBe(SpeciesId.BULBASAUR);
-    expect(game.scene.getPlayerParty()[0].shiny).toBe(true);
-    expect(game.scene.getPlayerParty()[0].variant).toBe(0);
+    expect(game.field.getPlayerPokemon().species.speciesId).toBe(SpeciesId.BULBASAUR);
+    expect(game.field.getPlayerPokemon().shiny).toBe(true);
+    expect(game.field.getPlayerPokemon().variant).toBe(0);
   });
 
   it("Check if first pokemon in party is caterpie from gen 1 and 1rd row, 3rd column", async () => {
@@ -528,7 +528,7 @@ describe("UI - Starter select", () => {
       saveSlotSelectUiHandler.processInput(Button.ACTION);
     });
     await game.phaseInterceptor.whenAboutToRun(EncounterPhase);
-    expect(game.scene.getPlayerParty()[0].species.speciesId).toBe(SpeciesId.CATERPIE);
+    expect(game.field.getPlayerPokemon().species.speciesId).toBe(SpeciesId.CATERPIE);
   });
 
   it("Check if first pokemon in party is nidoran_m from gen 1 and 2nd row, 4th column (cursor (9+4)-1)", async () => {
@@ -594,6 +594,6 @@ describe("UI - Starter select", () => {
       saveSlotSelectUiHandler.processInput(Button.ACTION);
     });
     await game.phaseInterceptor.whenAboutToRun(EncounterPhase);
-    expect(game.scene.getPlayerParty()[0].species.speciesId).toBe(SpeciesId.NIDORAN_M);
+    expect(game.field.getPlayerPokemon().species.speciesId).toBe(SpeciesId.NIDORAN_M);
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?
N/A
## Why am I making these changes?
```ts
const pkm1 = game.field.getPlayerField()[0];
const pkm2 = game.field.getPlayerField()[1];
```

is dumb.

So is 
```ts
const pkm1 = game.field.getPlayerField()[0]!;
```

## What are the changes from a developer perspective?
Regex-ed away these two anti-patterns to use destructuring or the updated `game.field.getXYZPokemon()`

## Screenshots/Videos
N/A
## How to test the changes?
run tests ig

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)