### PR TITLE
[Bug] [Beta] Fix serializable battler tags

### DIFF
--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -1659,7 +1659,10 @@ export function getArenaTag(
  * @param source - An arena tag
  * @returns The valid arena tag
  */
-export function loadArenaTag(source: ArenaTag | ArenaTagTypeData): ArenaTag {
+export function loadArenaTag(source: ArenaTag | ArenaTagTypeData | { tagType: ArenaTagType.NONE }): ArenaTag {
+  if (source.tagType === ArenaTagType.NONE) {
+    return new NoneTag();
+  }
   const tag =
     getArenaTag(source.tagType, source.turnCount, source.sourceMove, source.sourceId, source.side) ?? new NoneTag();
   tag.loadTag(source);

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -201,7 +201,7 @@ export class BattlerTag implements BaseBattlerTag {
   }
 }
 
-export abstract class SerializableBattlerTag extends BattlerTag {
+export class SerializableBattlerTag extends BattlerTag {
   /** Nonexistent, dummy field to allow typescript to distinguish this class from `BattlerTag` */
   private declare __SerializableBattlerTag: never;
 }
@@ -3641,7 +3641,7 @@ export function getBattlerTag(
     case BattlerTagType.FRENZY:
       return new FrenzyTag(turnCount, sourceMove, sourceId);
     case BattlerTagType.CHARGING:
-      return new BattlerTag(tagType, BattlerTagLapseType.CUSTOM, 1, sourceMove, sourceId);
+      return new SerializableBattlerTag(tagType, BattlerTagLapseType.CUSTOM, 1, sourceMove, sourceId);
     case BattlerTagType.ENCORE:
       return new EncoreTag(sourceId);
     case BattlerTagType.HELPING_HAND:
@@ -3726,10 +3726,10 @@ export function getBattlerTag(
       return new DragonCheerTag();
     case BattlerTagType.ALWAYS_CRIT:
     case BattlerTagType.IGNORE_ACCURACY:
-      return new BattlerTag(tagType, BattlerTagLapseType.TURN_END, 2, sourceMove);
+      return new SerializableBattlerTag(tagType, BattlerTagLapseType.TURN_END, 2, sourceMove);
     case BattlerTagType.ALWAYS_GET_HIT:
     case BattlerTagType.RECEIVE_DOUBLE_DAMAGE:
-      return new BattlerTag(tagType, BattlerTagLapseType.PRE_MOVE, 1, sourceMove);
+      return new SerializableBattlerTag(tagType, BattlerTagLapseType.PRE_MOVE, 1, sourceMove);
     case BattlerTagType.BYPASS_SLEEP:
       return new BattlerTag(tagType, BattlerTagLapseType.TURN_END, turnCount, sourceMove);
     case BattlerTagType.IGNORE_FLYING:


### PR DESCRIPTION
## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?
An oversight in #6129 made it so that certain battler tags which were being instantiated with the base `BattlerTag` class would not be persist across save and quit (as they were not marked as serializable).

## What are the changes from a developer perspective?
- Removes the `abstract` marker from `SerializableBattlerTag` 
- Changes the construction of most battler tags that were being instantiated with the base `BattlerTag` to use `SerializableBattlerTag`. This applied to all such battler tags other than Snore's `BYPASS_SLEEP`.
- Allows for `loadArenaTag` to permit an arena tag of type `NONE`


## Screenshots/Videos
N/A

## How to test the changes?
Make sure a battler tag such as Glaive Rush persists after save and load.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - ~~[ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~