### PR TITLE
[Misc] Disallow using NonFunctionProperties in loadTag methods

### DIFF
--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -71,13 +71,10 @@ import i18next from "i18next";
  *   // Then we must also define a loadTag method with one of the following signatures
  *   public override loadTag(source: BaseArenaTag & Pick<ExampleTag, "tagType" | "a" | "b"): void;
  *   public override loadTag<const T extends this>(source: BaseArenaTag & Pick<T, "tagType" | "a" | "b">): void;
- *   public override loadTag(source: NonFunctionProperties<ExampleTag>): void;
  * }
  * ```
  * Notes
  * - If the class has any subclasses, then the second form of `loadTag` *must* be used.
- * - The third form *must not* be used if the class has any getters, as typescript would expect such fields to be
- *   present in `source`.
  */
 
 /** Interface containing the serializable fields of ArenaTagData. */

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -44,7 +44,7 @@ import type {
   SemiInvulnerableTagType,
   TrappingBattlerTagType,
 } from "#types/battler-tags";
-import type { Mutable, NonFunctionProperties } from "#types/type-helpers";
+import type { Mutable } from "#types/type-helpers";
 import { BooleanHolder, coerceArray, getFrameMs, isNullOrUndefined, NumberHolder, toDmgValue } from "#utils/common";
 
 /**
@@ -80,13 +80,10 @@ import { BooleanHolder, coerceArray, getFrameMs, isNullOrUndefined, NumberHolder
  *   // Then we must also define a loadTag method with one of the following signatures
  *   public override loadTag(source: BaseBattlerTag & Pick<ExampleTag, "tagType" | "a" | "b"): void;
  *   public override loadTag<const T extends this>(source: BaseBattlerTag & Pick<T, "tagType" | "a" | "b">): void;
- *   public override loadTag(source: NonFunctionProperties<ExampleTag>): void;
  * }
  * ```
  * Notes
  * - If the class has any subclasses, then the second form of `loadTag` *must* be used.
- * - The third form *must not* be used if the class has any getters, as typescript would expect such fields to be
- *   present in `source`.
  */
 
 /** Interface containing the serializable fields of BattlerTag */
@@ -419,7 +416,6 @@ export class GorillaTacticsTag extends MoveRestrictionBattlerTag {
   public override readonly tagType = BattlerTagType.GORILLA_TACTICS;
   /** ID of the move that the user is locked into using*/
   public readonly moveId: MoveId = MoveId.NONE;
-
   constructor() {
     super(BattlerTagType.GORILLA_TACTICS, BattlerTagLapseType.CUSTOM, 0);
   }
@@ -1235,7 +1231,7 @@ export class EncoreTag extends MoveRestrictionBattlerTag {
     );
   }
 
-  public override loadTag(source: NonFunctionProperties<EncoreTag>): void {
+  public override loadTag(source: BaseBattlerTag & Pick<EncoreTag, "tagType" | "moveId">): void {
     super.loadTag(source);
     this.moveId = source.moveId;
   }
@@ -2618,7 +2614,7 @@ export class CommandedTag extends SerializableBattlerTag {
     }
   }
 
-  override loadTag(source: NonFunctionProperties<CommandedTag>): void {
+  override loadTag(source: BaseBattlerTag & Pick<CommandedTag, "tagType" | "tatsugiriFormKey">): void {
     super.loadTag(source);
     (this as Mutable<this>).tatsugiriFormKey = source.tatsugiriFormKey;
   }
@@ -2659,7 +2655,9 @@ export class StockpilingTag extends SerializableBattlerTag {
     }
   };
 
-  public override loadTag(source: NonFunctionProperties<StockpilingTag>): void {
+  public override loadTag(
+    source: BaseBattlerTag & Pick<StockpilingTag, "tagType" | "stockpiledCount" | "statChangeCounts">,
+  ): void {
     super.loadTag(source);
     this.stockpiledCount = source.stockpiledCount || 0;
     this.statChangeCounts = {
@@ -3006,7 +3004,7 @@ export class AutotomizedTag extends SerializableBattlerTag {
     this.onAdd(pokemon);
   }
 
-  public override loadTag(source: NonFunctionProperties<AutotomizedTag>): void {
+  public override loadTag(source: BaseBattlerTag & Pick<AutotomizedTag, "tagType" | "autotomizeCount">): void {
     super.loadTag(source);
     this.autotomizeCount = source.autotomizeCount;
   }


### PR DESCRIPTION
## What are the changes the user will see?
None

## Why am I making these changes?
When working on Zod schemas, I found that permitting the `NonFunctionProperties` shorthand in `loadtag` methods messes with type inference (even though, in theory, it shouldn't. Thanks typescript).


## What are the changes from a developer perspective?
Remove mentions of the third form of `loadTag` in the arena-tag and battler-tag comments.
Replace `NonFunctionProperties` in the signatures of `BattlerTags` with the other, "Pick" format.

## Screenshots/Videos
N/A

## How to test the changes?
N/A

## Checklist
- [X] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - ~~[ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~