### PR TITLE
[Dev] `pnpm biome` will now only display errors by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typecheck": "tsc --noEmit",
     "eslint": "eslint --fix .",
     "eslint-ci": "eslint .",
-    "biome": "biome check --write --changed --no-errors-on-unmatched",
+    "biome": "biome check --write --changed --no-errors-on-unmatched --diagnostic-level=error",
     "biome-ci": "biome ci --diagnostic-level=error --reporter=github --no-errors-on-unmatched",
     "docs": "typedoc",
     "depcruise": "depcruise src test",


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
To make it easier to find and fix linting errors that can't be autofixed.

## What are the changes from a developer perspective?
`--diagnostic-level=error` added to the `biome` command in `package.json`.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?