### PR TITLE
[Bug] [Beta] Remove setting currentPhase to null in clearAllPhases

### DIFF
--- a/src/phase-manager.ts
+++ b/src/phase-manager.ts
@@ -322,7 +322,6 @@ export class PhaseManager {
       queue.splice(0, queue.length);
     }
     this.dynamicPhaseQueues.forEach(queue => queue.clear());
-    this.currentPhase = null;
     this.standbyPhase = null;
     this.clearPhaseQueueSplice();
   }


### PR DESCRIPTION
## What are the changes the user will see?
Exiting out of starter select screen will no longer hang the game.

## Why am I making these changes?
Bugfix

## What are the changes from a developer perspective?
Remove setting currentPhase to null

## Screenshots/Videos
Trust

## How to test the changes?
Open starter select, then try to leave it.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?
