### PR TITLE
[Misc] More battler tag fixups

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2722,7 +2722,7 @@ export class StockpilingTag extends SerializableBattlerTag {
         true,
         false,
         true,
-        this.onStatStagesChanged,
+        this.onStatStagesChanged.bind(this),
       );
     }
   }


### PR DESCRIPTION
## What are the changes the user will see?
Quark Drive and protosynthesis will no longer consider abilities like pure power or an ally's flower gift when determining the stat to boost.
Session saves with the stockpiling battler tag will no longer have a serialized function in them.

## Why am I making these changes?
Cleaning up battler tags.
Removing the serialized function from stockpiling tag is necessary for zod schemas.

## What are the changes from a developer perspective?
- Added default values to fields in various battler tags
- Cleaned up the calculation of highest effective stat in the `HighestStatBoostTag`
- Made is to that `StockpilingTag`'s `onStatStagesChanged` is defined as a method instead of a function property so that it wouldn't be serialized
  - It appears to have used the function property so that there could be parity with the type of `StatStageChangeCallback`
  - I kept this type safety check with a dummy statement that gets removed during bundling.

## Screenshots/Videos
N/A

## How to test the changes?
Start game with a quark drive / protosynthsis mon and ensure

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - ~~[ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~