### PR TITLE
[Bug/Ability] Fixed bugs with Intimidate triggers after reload/initial switch 

### DIFF
--- a/src/data/phase-priority-queue.ts
+++ b/src/data/phase-priority-queue.ts
@@ -44,6 +44,30 @@ export abstract class PhasePriorityQueue {
   public clear(): void {
     this.queue.splice(0, this.queue.length);
   }
+
+  /**
+   * Attempt to remove one or more Phases from the current queue.
+   * @param phaseFilter - The function to select phases for removal
+   * @param removeCount - The maximum number of phases to remove, or `all` to remove all matching phases;
+   * default `1`
+   * @returns The number of successfully removed phases
+   * @todo Remove this eventually once the patchwork bug this is used for is fixed
+   */
+  public tryRemovePhase(phaseFilter: (phase: Phase) => boolean, removeCount: number | "all" = 1): number {
+    if (typeof removeCount === "string") {
+      removeCount = Number.MAX_SAFE_INTEGER; // For the lulz
+    }
+    let numRemoved = 0;
+    let phaseIndex = this.queue.findIndex(phaseFilter);
+    if (phaseIndex === -1) {
+      return 0;
+    }
+    do {
+      this.queue.splice(phaseIndex, 1);
+      numRemoved++;
+    } while (numRemoved < removeCount || (phaseIndex = this.queue.findIndex(phaseFilter)) !== -1);
+    return removeCount;
+  }
 }
 
 /**
@@ -79,6 +103,7 @@ export class PostSummonPhasePriorityQueue extends PhasePriorityQueue {
   private queueAbilityPhase(phase: PostSummonPhase): void {
     const phasePokemon = phase.getPokemon();
 
+    console.log(phasePokemon.getNameToRender());
     phasePokemon.getAbilityPriorities().forEach((priority, idx) => {
       this.queue.push(new PostSummonActivateAbilityPhase(phasePokemon.getBattlerIndex(), priority, !!idx));
       globalScene.phaseManager.appendToPhase(

--- a/src/data/phase-priority-queue.ts
+++ b/src/data/phase-priority-queue.ts
@@ -55,20 +55,21 @@ export abstract class PhasePriorityQueue {
    */
   public tryRemovePhase(phaseFilter: (phase: Phase) => boolean, removeCount: number | "all" = 1): number {
     if (removeCount === "all") {
-      removeCount = Number.MAX_SAFE_INTEGER;
+      removeCount = this.queue.length;
     } else if (removeCount < 1) {
       return 0;
     }
     let numRemoved = 0;
-    let phaseIndex = this.queue.findIndex(phaseFilter);
-    if (phaseIndex === -1) {
-      return 0;
-    }
-    while (numRemoved < removeCount && phaseIndex !== -1) {
+
+    do {
+      const phaseIndex = this.queue.findIndex(phaseFilter);
+      if (phaseIndex === -1) {
+        break;
+      }
       this.queue.splice(phaseIndex, 1);
       numRemoved++;
-      phaseIndex = this.queue.findIndex(phaseFilter);
-    }
+    } while (numRemoved < removeCount && this.queue.length > 0);
+
     return numRemoved;
   }
 }

--- a/src/data/phase-priority-queue.ts
+++ b/src/data/phase-priority-queue.ts
@@ -54,8 +54,10 @@ export abstract class PhasePriorityQueue {
    * @todo Remove this eventually once the patchwork bug this is used for is fixed
    */
   public tryRemovePhase(phaseFilter: (phase: Phase) => boolean, removeCount: number | "all" = 1): number {
-    if (typeof removeCount === "string") {
-      removeCount = Number.MAX_SAFE_INTEGER; // For the lulz
+    if (removeCount === "all") {
+      removeCount = Number.MAX_SAFE_INTEGER;
+    } else if (removeCount < 1) {
+      return 0;
     }
     let numRemoved = 0;
     let phaseIndex = this.queue.findIndex(phaseFilter);

--- a/src/data/phase-priority-queue.ts
+++ b/src/data/phase-priority-queue.ts
@@ -64,11 +64,12 @@ export abstract class PhasePriorityQueue {
     if (phaseIndex === -1) {
       return 0;
     }
-    do {
+    while (numRemoved < removeCount && phaseIndex !== -1) {
       this.queue.splice(phaseIndex, 1);
       numRemoved++;
-    } while (numRemoved < removeCount || (phaseIndex = this.queue.findIndex(phaseFilter)) !== -1);
-    return removeCount;
+      phaseIndex = this.queue.findIndex(phaseFilter);
+    }
+    return numRemoved;
   }
 }
 

--- a/src/data/phase-priority-queue.ts
+++ b/src/data/phase-priority-queue.ts
@@ -107,7 +107,6 @@ export class PostSummonPhasePriorityQueue extends PhasePriorityQueue {
   private queueAbilityPhase(phase: PostSummonPhase): void {
     const phasePokemon = phase.getPokemon();
 
-    console.log(phasePokemon.getNameToRender());
     phasePokemon.getAbilityPriorities().forEach((priority, idx) => {
       this.queue.push(new PostSummonActivateAbilityPhase(phasePokemon.getBattlerIndex(), priority, !!idx));
       globalScene.phaseManager.appendToPhase(

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2234,8 +2234,16 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return this.hasPassive() && (!canApply || this.canApplyAbility(true)) && this.getPassiveAbility().hasAttr(attrType);
   }
 
-  public getAbilityPriorities(): [number, number] {
-    return [this.getAbility().postSummonPriority, this.getPassiveAbility().postSummonPriority];
+  /**
+   * Return the ability priorities of the pokemon's ability and, if enabled, its passive ability
+   * @returns A tuple containing the ability priorities of the pokemon
+   */
+  public getAbilityPriorities(): [number] | [activePriority: number, passivePriority: number] {
+    const abilityPriority = this.getAbility().postSummonPriority;
+    if (this.hasPassive()) {
+      return [abilityPriority, this.getPassiveAbility().postSummonPriority];
+    }
+    return [abilityPriority];
   }
 
   /**

--- a/src/phase-manager.ts
+++ b/src/phase-manager.ts
@@ -355,14 +355,23 @@ export class PhaseManager {
     if (this.phaseQueuePrependSpliceIndex > -1) {
       this.clearPhaseQueueSplice();
     }
-    if (this.phaseQueuePrepend.length) {
-      while (this.phaseQueuePrepend.length) {
-        const poppedPhase = this.phaseQueuePrepend.pop();
-        if (poppedPhase) {
-          this.phaseQueue.unshift(poppedPhase);
-        }
+    this.phaseQueue.unshift(...this.phaseQueuePrepend);
+    this.phaseQueuePrepend.splice(0);
+
+    const unactivatedConditionalPhases: [() => boolean, Phase][] = [];
+    // Check if there are any conditional phases queued
+    for (const [condition, phase] of this.conditionalQueue) {
+      // Evaluate the condition associated with the phase
+      if (condition()) {
+        // If the condition is met, add the phase to the phase queue
+        this.pushPhase(phase);
+      } else {
+        // If the condition is not met, re-add the phase back to the end of the conditional queue
+        unactivatedConditionalPhases.push([condition, phase]);
       }
     }
+    this.conditionalQueue = unactivatedConditionalPhases;
+
     if (!this.phaseQueue.length) {
       this.populatePhaseQueue();
       // Clear the conditionalQueue if there are no phases left in the phaseQueue
@@ -370,24 +379,6 @@ export class PhaseManager {
     }
 
     this.currentPhase = this.phaseQueue.shift() ?? null;
-
-    const unactivatedConditionalPhases: [() => boolean, Phase][] = [];
-    // Check if there are any conditional phases queued
-    while (this.conditionalQueue?.length) {
-      // Retrieve the first conditional phase from the queue
-      const conditionalPhase = this.conditionalQueue.shift();
-      // Evaluate the condition associated with the phase
-      if (conditionalPhase?.[0]()) {
-        // If the condition is met, add the phase to the phase queue
-        this.pushPhase(conditionalPhase[1]);
-      } else if (conditionalPhase) {
-        // If the condition is not met, re-add the phase back to the front of the conditional queue
-        unactivatedConditionalPhases.push(conditionalPhase);
-      } else {
-        console.warn("condition phase is undefined/null!", conditionalPhase);
-      }
-    }
-    this.conditionalQueue.push(...unactivatedConditionalPhases);
 
     if (this.currentPhase) {
       console.log(`%cStart Phase ${this.currentPhase.constructor.name}`, "color:green;");
@@ -518,6 +509,25 @@ export class PhaseManager {
 
     this.pushPhase(new ActivatePriorityQueuePhase(type));
     this.dynamicPhaseQueues[type].push(phase);
+  }
+
+  /**
+   * Attempt to remove one or more Phases from the given DynamicPhaseQueue, removing the equivalent amount of {@linkcode ActivatePriorityQueuePhase}s from the queue.
+   * @param type - The {@linkcode DynamicPhaseType} to check
+   * @param phaseFilter - The function to select phases for removal
+   * @param removeCount - The maximum number of phases to remove, or `all` to remove all matching phases;
+   * default `1`
+   * @todo Remove this eventually once the patchwork bug this is used for is fixed
+   */
+  public tryRemoveDynamicPhase(
+    type: DynamicPhaseType,
+    phaseFilter: (phase: Phase) => boolean,
+    removeCount: number | "all" = 1,
+  ): void {
+    const numRemoved = this.dynamicPhaseQueues[type].tryRemovePhase(phaseFilter, removeCount);
+    for (let x = 0; x < numRemoved; x++) {
+      this.tryRemovePhase(p => p.is("ActivatePriorityQueuePhase"));
+    }
   }
 
   /**

--- a/src/phases/check-switch-phase.ts
+++ b/src/phases/check-switch-phase.ts
@@ -2,7 +2,6 @@ import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { BattleStyle } from "#enums/battle-style";
 import { BattlerTagType } from "#enums/battler-tag-type";
-import { DynamicPhaseType } from "#enums/dynamic-phase-type";
 import { SwitchType } from "#enums/switch-type";
 import { UiMode } from "#enums/ui-mode";
 import { BattlePhase } from "#phases/battle-phase";
@@ -67,17 +66,6 @@ export class CheckSwitchPhase extends BattlePhase {
           UiMode.CONFIRM,
           () => {
             globalScene.ui.setMode(UiMode.MESSAGE);
-            /*
-            Remove any pending `ActivatePriorityQueuePhase`s for the currently leaving Pokemon produced by the prior `SwitchSummonPhase`.
-            This is required to avoid triggering on-switch abilities twice on initial entrance.
-            TODO: Separate the animations from `SwitchSummonPhase` to another phase and call that on initial switch - this is a band-aid fix
-            TODO: Confirm with @emdeann what the maximum number of these things that gets unshifted can be
-            */
-            globalScene.phaseManager.tryRemoveDynamicPhase(
-              DynamicPhaseType.POST_SUMMON,
-              p => p.is("PostSummonPhase") && p.getPokemon() === pokemon,
-              4,
-            );
             globalScene.phaseManager.unshiftNew("SwitchPhase", SwitchType.INITIAL_SWITCH, this.fieldIndex, false, true);
             this.end();
           },

--- a/src/phases/switch-phase.ts
+++ b/src/phases/switch-phase.ts
@@ -76,6 +76,7 @@ export class SwitchPhase extends BattlePhase {
         if (slotIndex >= globalScene.currentBattle.getBattlerCount() && slotIndex < 6) {
           // Remove any pre-existing PostSummonPhase under the same field index.
           // Pre-existing PostSummonPhases may occur when this phase is invoked during a prompt to switch at the start of a wave.
+          // TODO: Separate the animations from `SwitchSummonPhase` and co. into another phase and use that on initial switch - this is a band-aid fix
           globalScene.phaseManager.tryRemoveDynamicPhase(
             DynamicPhaseType.POST_SUMMON,
             p => p.is("PostSummonPhase") && p.player && p.fieldIndex === this.fieldIndex,

--- a/src/phases/switch-phase.ts
+++ b/src/phases/switch-phase.ts
@@ -1,4 +1,5 @@
 import { globalScene } from "#app/global-scene";
+import { DynamicPhaseType } from "#enums/dynamic-phase-type";
 import { SwitchType } from "#enums/switch-type";
 import { UiMode } from "#enums/ui-mode";
 import { BattlePhase } from "#phases/battle-phase";
@@ -75,8 +76,10 @@ export class SwitchPhase extends BattlePhase {
         if (slotIndex >= globalScene.currentBattle.getBattlerCount() && slotIndex < 6) {
           // Remove any pre-existing PostSummonPhase under the same field index.
           // Pre-existing PostSummonPhases may occur when this phase is invoked during a prompt to switch at the start of a wave.
-          globalScene.phaseManager.tryRemovePhase(
+          globalScene.phaseManager.tryRemoveDynamicPhase(
+            DynamicPhaseType.POST_SUMMON,
             p => p.is("PostSummonPhase") && p.player && p.fieldIndex === this.fieldIndex,
+            "all",
           );
           const switchType = option === PartyOption.PASS_BATON ? SwitchType.BATON_PASS : this.switchType;
           globalScene.phaseManager.unshiftNew("SwitchSummonPhase", switchType, fieldIndex, slotIndex, this.doReturn);

--- a/test/abilities/intimidate.test.ts
+++ b/test/abilities/intimidate.test.ts
@@ -44,6 +44,22 @@ describe("Abilities - Intimidate", () => {
     expect(enemy.getStatStage(Stat.ATK)).toBe(-2);
   });
 
+  // TODO: This fails due to a limitation in our switching logic - the animations and field entry occur concurrently
+  // inside `SummonPhase`, unshifting 2 `PostSummmonPhase`s and proccing intimidate twice
+  it.todo("should lower all opponents' ATK by 1 stage on initial switch prompt", async () => {
+    await game.classicMode.runToSummon([SpeciesId.MIGHTYENA, SpeciesId.POOCHYENA]);
+    await game.classicMode.startBattleWithSwitch(1);
+
+    const [poochyena, mightyena] = game.scene.getPlayerField();
+    expect(poochyena.species.speciesId).toBe(SpeciesId.POOCHYENA);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toHaveStatStage(Stat.ATK, -1);
+
+    expect(poochyena).toHaveAbilityApplied(AbilityId.INTIMIDATE);
+    expect(mightyena).not.toHaveAbilityApplied(AbilityId.INTIMIDATE);
+  });
+
   it("should lower ATK of all opponents in a double battle", async () => {
     game.override.battleStyle("double");
     await game.classicMode.startBattle([SpeciesId.MIGHTYENA]);

--- a/test/abilities/intimidate.test.ts
+++ b/test/abilities/intimidate.test.ts
@@ -35,29 +35,43 @@ describe("Abilities - Intimidate", () => {
   it("should lower all opponents' ATK by 1 stage on entry and switch", async () => {
     await game.classicMode.startBattle([SpeciesId.MIGHTYENA, SpeciesId.POOCHYENA]);
 
+    const [mightyena, poochyena] = game.scene.getPlayerParty();
+
     const enemy = game.field.getEnemyPokemon();
     expect(enemy.getStatStage(Stat.ATK)).toBe(-1);
+    expect(mightyena).toHaveAbilityApplied(AbilityId.INTIMIDATE);
 
     game.doSwitchPokemon(1);
     await game.toNextTurn();
 
+    expect(poochyena.isActive()).toBe(true);
     expect(enemy.getStatStage(Stat.ATK)).toBe(-2);
+    expect(poochyena).toHaveAbilityApplied(AbilityId.INTIMIDATE);
   });
 
-  // TODO: This fails due to a limitation in our switching logic - the animations and field entry occur concurrently
-  // inside `SummonPhase`, unshifting 2 `PostSummmonPhase`s and proccing intimidate twice
-  it.todo("should lower all opponents' ATK by 1 stage on initial switch prompt", async () => {
+  it("should trigger once on initial switch prompt without cancelling opposing abilities", async () => {
     await game.classicMode.runToSummon([SpeciesId.MIGHTYENA, SpeciesId.POOCHYENA]);
     await game.classicMode.startBattleWithSwitch(1);
 
-    const [poochyena, mightyena] = game.scene.getPlayerField();
+    const [poochyena, mightyena] = game.scene.getPlayerParty();
     expect(poochyena.species.speciesId).toBe(SpeciesId.POOCHYENA);
 
     const enemy = game.field.getEnemyPokemon();
     expect(enemy).toHaveStatStage(Stat.ATK, -1);
+    expect(poochyena).toHaveStatStage(Stat.ATK, -1);
 
     expect(poochyena).toHaveAbilityApplied(AbilityId.INTIMIDATE);
     expect(mightyena).not.toHaveAbilityApplied(AbilityId.INTIMIDATE);
+  });
+
+  it("should activate on reload with single party", async () => {
+    await game.classicMode.startBattle([SpeciesId.MIGHTYENA]);
+
+    expect(game.field.getEnemyPokemon()).toHaveStatStage(Stat.ATK, -1);
+
+    await game.reload.reloadSession();
+
+    expect(game.field.getEnemyPokemon()).toHaveStatStage(Stat.ATK, -1);
   });
 
   it("should lower ATK of all opponents in a double battle", async () => {

--- a/test/test-utils/helpers/classic-mode-helper.ts
+++ b/test/test-utils/helpers/classic-mode-helper.ts
@@ -111,7 +111,7 @@ export class ClassicModeHelper extends GameManagerHelper {
    * @example
    * ```ts
    * await game.classicMode.runToSummon([SpeciesId.MIGHTYENA, SpeciesId.POOCHYENA])
-   * await game.queueStartOfBattleSwitch(1);
+   * await game.startBattleWithSwitch(1);
    * ```
    */
   public async startBattleWithSwitch(pokemonIndex: number): Promise<void> {

--- a/test/test-utils/helpers/classic-mode-helper.ts
+++ b/test/test-utils/helpers/classic-mode-helper.ts
@@ -1,6 +1,7 @@
 import { getGameMode } from "#app/game-mode";
 import overrides from "#app/overrides";
 import { BattleStyle } from "#enums/battle-style";
+import { Button } from "#enums/buttons";
 import { GameModes } from "#enums/game-modes";
 import { Nature } from "#enums/nature";
 import type { SpeciesId } from "#enums/species-id";
@@ -99,5 +100,34 @@ export class ClassicModeHelper extends GameManagerHelper {
 
     await this.game.phaseInterceptor.to(CommandPhase);
     console.log("==================[New Turn]==================");
+  }
+
+  /**
+   * Queue inputs to switch at the start of the next battle, and then start it.
+   * @param pokemonIndex - The 0-indexed position of the party pokemon to switch to.
+   * Should never be called with 0 as that will select the currently active pokemon and freeze
+   * @returns A Promise that resolves once the battle has been started and the switch prompt resolved
+   * @todo Make this work for double battles
+   * @example
+   * ```ts
+   * await game.classicMode.runToSummon([SpeciesId.MIGHTYENA, SpeciesId.POOCHYENA])
+   * await game.queueStartOfBattleSwitch(1);
+   * ```
+   */
+  public async startBattleWithSwitch(pokemonIndex: number): Promise<void> {
+    this.game.scene.battleStyle = BattleStyle.SWITCH;
+    this.game.onNextPrompt(
+      "CheckSwitchPhase",
+      UiMode.CONFIRM,
+      () => {
+        this.game.scene.ui.getHandler().setCursor(0);
+        this.game.scene.ui.getHandler().processInput(Button.ACTION);
+      },
+      () => this.game.isCurrentPhase("CommandPhase") || this.game.isCurrentPhase("TurnInitPhase"),
+    );
+    this.game.doSelectPartyPokemon(pokemonIndex);
+
+    await this.game.phaseInterceptor.to("CommandPhase");
+    console.log("==================[New Battle (Initial Switch)]==================");
   }
 }


### PR DESCRIPTION
## What are the changes the user will see?

Intimidate and simlar abilities now trigger exactly once during an initial switch or page refresh with 1 party member. 

Not twice, not 0 times, ONCE.

## Why am I making these changes?
Helping fix bugs

Fixes #6219 
Fixes #6249

The implementation is not clean at all, but our switch system really needs to be reworked eventually.

## What are the changes from a developer perspective?
Added helper to start battle with initial switch

Added some emergency code to remove extra `PostSummonPhase`s and `ActivatePriorityQueuePhase`s upon confirming a force switch. \
Is it jank? Maybe. \
Does it work? Yeah

Added intimidate test that mirrors the found information


## Screenshots/Videos
N/A
## How to test the changes?
Enable the intimidate test and see that it does indeed fail instead of timing out

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)