### PR TITLE
[Bug] Release Fainted Pokémon in Switch Menu

### DIFF
--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -827,6 +827,10 @@ export class PartyUiHandler extends MessageUiHandler {
       globalScene.triggerPokemonFormChange(pokemon, SpeciesFormChangeItemTrigger, false, true);
     }
 
+    if (option === PartyOption.RELEASE) {
+      return this.processReleaseOption(pokemon);
+    }
+
     // If the pokemon is filtered out for this option, we cannot continue
     const filterResult = this.getFilterResult(option, pokemon);
     if (filterResult) {
@@ -837,7 +841,6 @@ export class PartyUiHandler extends MessageUiHandler {
 
     // For what modes is a selectCallback needed?
     // PartyUiMode.SELECT (SELECT)
-    // PartyUiMode.RELEASE (RELEASE)
     // PartyUiMode.FAINT_SWITCH (SEND_OUT or PASS_BATON (?))
     // PartyUiMode.REVIVAL_BLESSING (REVIVE)
     // PartyUiMode.MODIFIER_TRANSFER (held items, and ALL)
@@ -850,10 +853,6 @@ export class PartyUiHandler extends MessageUiHandler {
     // PartyUiMode.POST_BATTLE_SWITCH (SEND_OUT)
 
     // These are the options that need a callback
-    if (option === PartyOption.RELEASE) {
-      return this.processReleaseOption(pokemon);
-    }
-
     if (this.partyUiMode === PartyUiMode.SPLICE) {
       if (option === PartyOption.SPLICE) {
         (this.selectCallback as PartyModifierSpliceSelectCallback)(this.transferCursor, this.cursor);

--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -827,6 +827,7 @@ export class PartyUiHandler extends MessageUiHandler {
       globalScene.triggerPokemonFormChange(pokemon, SpeciesFormChangeItemTrigger, false, true);
     }
 
+    // This is processed before the filter result since releasing does not depend on status.
     if (option === PartyOption.RELEASE) {
       return this.processReleaseOption(pokemon);
     }
@@ -841,6 +842,7 @@ export class PartyUiHandler extends MessageUiHandler {
 
     // For what modes is a selectCallback needed?
     // PartyUiMode.SELECT (SELECT)
+    // PartyUiMode.RELEASE (RELEASE)
     // PartyUiMode.FAINT_SWITCH (SEND_OUT or PASS_BATON (?))
     // PartyUiMode.REVIVAL_BLESSING (REVIVE)
     // PartyUiMode.MODIFIER_TRANSFER (held items, and ALL)


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-  [Bug]: If the PR is primarily a bug fix
-  [Move]: If a move has new or changed functionality
-  [Ability]: If an ability has new or changed functionality
-  [Item]: For new or modified items
-  [Mystery]: For new or modified Mystery Encounters
-  [Test]: If the PR is primarily adding or modifying tests
-  [UI/UX]: If the PR is changing UI/UX elements
-  [Audio]: If the PR is adding or changing music/sfx
-  [Sprite]: If the PR is adding or changing sprites
-  [Balance]: If the PR is related to game balance
-  [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-  [Dev]: If the PR is primarily changing something pertaining to development (lefthook hooks, linter rules, etc.)
-  [i18n]: If the PR is primarily adding/changing locale keys or key usage (may come with an associated locales PR)
-  [Docs]: If the PR is adding or modifying documentation (such as tsdocs/code comments)
-  [GitHub]: For changes to GitHub workflows/templates/etc
-  [Misc]: If no other category fits the PR
-->

<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small!)
-->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->

Players should now be able to release any fainted Pokémon in the "POKÉMON" party menu during a battle.

## Why am I making these changes?
<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

While testing https://github.com/pagefaultgames/pokerogue/pull/6186, @Blitz425 found out that fainted Pokémon couldn't be released from the in-battle party menu, which is cumbersome in a mode like Permanent Faint centered around having fainted Pokémon. The text that displays ("X has no energy left to battle!") also implies that this isn't intended behavior and only meant for trying to switch fainted Pokémon in.

## What are the changes from a developer perspective?
<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

The `if` block handling the release behavior was moved above the filtering code, which was using the `FilterNonFainted` callback preventing fainted Pokémon from being released.

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

### Before (on Beta)

https://github.com/user-attachments/assets/be2cdf91-d20a-43d7-9531-eb9578c59b50

### After


https://github.com/user-attachments/assets/d9f3c329-02f7-4d1b-b046-33e16d6df429



## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

Start a Classic run with two Pokémon (or catch one), let one faint, and upon switching the next Pokémon in, immediately go to party and try releasing the fainted Pokémon.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - ~[ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~

Are there any localization additions or changes? If so:
- ~[ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?~
  - ~[ ] If so, please leave a link to it here:~ 
- ~[ ] Has the translation team been contacted for proofreading/translation?~
