### PR TITLE
[Refactor/Test] Cleaned up `getAttackTypeEffectiveness` and removed `VariableMoveTypeMultiplierAttr`

### DIFF
--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -730,9 +730,7 @@ export class AttackTypeImmunityAbAttr extends TypeImmunityAbAttr {
   override canApply(params: TypeMultiplierAbAttrParams): boolean {
     const { move } = params;
     return (
-      move.category !== MoveCategory.STATUS &&
-      !move.hasAttr("NeutralDamageAgainstFlyingTypeMultiplierAttr") &&
-      super.canApply(params)
+      move.category !== MoveCategory.STATUS && !move.hasAttr("VariableMoveTypeChartAttr") && super.canApply(params)
     );
   }
 }

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -958,7 +958,7 @@ class StealthRockTag extends ArenaTrapTag {
   }
 
   getDamageHpRatio(pokemon: Pokemon): number {
-    const effectiveness = pokemon.getAttackTypeEffectiveness(PokemonType.ROCK, undefined, true);
+    const effectiveness = pokemon.getAttackTypeEffectiveness(PokemonType.ROCK, { ignoreStrongWinds: true });
 
     let damageHpRatio = 0;
 

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -999,7 +999,7 @@ export class AttackMove extends Move {
     const ret = super.getTargetBenefitScore(user, target, move);
     let attackScore = 0;
 
-    const effectiveness = target.getAttackTypeEffectiveness(this.type, user, undefined, undefined, this);
+    const effectiveness = target.getAttackTypeEffectiveness(this.type, {source: user, move: this});
     attackScore = Math.pow(effectiveness - 1, 2) * (effectiveness < 1 ? -2 : 2);
     const [ thisStat, offStat ]: EffectiveStat[] = this.category === MoveCategory.PHYSICAL ? [ Stat.ATK, Stat.SPATK ] : [ Stat.SPATK, Stat.ATK ];
     const statHolder = new NumberHolder(user.getEffectiveStat(thisStat, target));
@@ -1795,7 +1795,7 @@ export class SacrificialAttr extends MoveEffectAttr {
     if (user.isBoss()) {
       return -20;
     }
-    return Math.ceil(((1 - user.getHpRatio()) * 10 - 10) * (target.getAttackTypeEffectiveness(move.type, user) - 0.5));
+    return Math.ceil(((1 - user.getHpRatio()) * 10 - 10) * (target.getAttackTypeEffectiveness(move.type, {source: user}) - 0.5));
   }
 }
 
@@ -1833,7 +1833,7 @@ export class SacrificialAttrOnHit extends MoveEffectAttr {
     if (user.isBoss()) {
       return -20;
     }
-    return Math.ceil(((1 - user.getHpRatio()) * 10 - 10) * (target.getAttackTypeEffectiveness(move.type, user) - 0.5));
+    return Math.ceil(((1 - user.getHpRatio()) * 10 - 10) * (target.getAttackTypeEffectiveness(move.type, {source: user}) - 0.5));
   }
 }
 
@@ -1875,7 +1875,7 @@ export class HalfSacrificialAttr extends MoveEffectAttr {
     if (user.isBoss()) {
       return -10;
     }
-    return Math.ceil(((1 - user.getHpRatio() / 2) * 10 - 10) * (target.getAttackTypeEffectiveness(move.type, user) - 0.5));
+    return Math.ceil(((1 - user.getHpRatio() / 2) * 10 - 10) * (target.getAttackTypeEffectiveness(move.type, {source: user}) - 0.5));
   }
 }
 
@@ -5402,9 +5402,9 @@ export class NeutralDamageAgainstFlyingTypeAttr extends VariableMoveTypeChartAtt
  * Attribute used by {@linkcode MoveId.FLYING_PRESS} to add the Flying Type to its type effectiveness.
  */
 export class FlyingTypeMultiplierAttr extends VariableMoveTypeChartAttr {
-  apply(user: Pokemon, target: Pokemon, move: Move, args: [multiplier: NumberHolder, types: PokemonType[]]): boolean {
-    const multiplier = args[0] as NumberHolder;
-    multiplier.value *= target.getAttackTypeEffectiveness(PokemonType.FLYING, user);
+  apply(user: Pokemon, target: Pokemon, _move: Move, args: [multiplier: NumberHolder, types: PokemonType[]]): boolean {
+    const multiplier = args[0];
+    multiplier.value *= target.getAttackTypeEffectiveness(PokemonType.FLYING, {source: user});
     return true;
   }
 }
@@ -11383,9 +11383,10 @@ export function initMoves() {
     new AttackMove(MoveId.RUINATION, PokemonType.DARK, MoveCategory.SPECIAL, -1, 90, 10, -1, 0, 9)
       .attr(TargetHalfHpDamageAttr),
     new AttackMove(MoveId.COLLISION_COURSE, PokemonType.FIGHTING, MoveCategory.PHYSICAL, 100, 100, 5, -1, 0, 9)
-      .attr(MovePowerMultiplierAttr, (user, target, move) => target.getAttackTypeEffectiveness(move.type, user) >= 2 ? 5461 / 4096 : 1),
+      // TODO: Do we want to change this to 4/3?
+      .attr(MovePowerMultiplierAttr, (user, target, move) => target.getAttackTypeEffectiveness(move.type, {source: user}) >= 2 ? 5461 / 4096 : 1),
     new AttackMove(MoveId.ELECTRO_DRIFT, PokemonType.ELECTRIC, MoveCategory.SPECIAL, 100, 100, 5, -1, 0, 9)
-      .attr(MovePowerMultiplierAttr, (user, target, move) => target.getAttackTypeEffectiveness(move.type, user) >= 2 ? 5461 / 4096 : 1)
+      .attr(MovePowerMultiplierAttr, (user, target, move) => target.getAttackTypeEffectiveness(move.type, {source: user}) >= 2 ? 5461 / 4096 : 1)
       .makesContact(),
     new SelfStatusMove(MoveId.SHED_TAIL, PokemonType.NORMAL, -1, 10, -1, 0, 9)
       .attr(AddSubstituteAttr, 0.5, true)

--- a/src/data/type.ts
+++ b/src/data/type.ts
@@ -2,6 +2,13 @@ import { PokemonType } from "#enums/pokemon-type";
 
 export type TypeDamageMultiplier = 0 | 0.125 | 0.25 | 0.5 | 1 | 2 | 4 | 8;
 
+/**
+ * Get the type effectiveness multiplier of one PokemonType against another.
+ * @param attackType - The {@linkcode PokemonType} of the attacker
+ * @param defType - The {@linkcode PokemonType} of the defender
+ * @returns The type damage multiplier between the two types;
+ * will be either `0`, `0.5`, `1` or `2`.
+ */
 export function getTypeDamageMultiplier(attackType: PokemonType, defType: PokemonType): TypeDamageMultiplier {
   if (attackType === PokemonType.UNKNOWN || defType === PokemonType.UNKNOWN) {
     return 1;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2400,7 +2400,6 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         : 1,
     );
 
-    applyMoveAttrs("VariableMoveTypeMultiplierAttr", source, this, move, typeMultiplier);
     if (this.getTypes(true, true).find(t => move.isTypeImmune(source, this, t))) {
       typeMultiplier.value = 0;
     }

--- a/test/abilities/illusion.test.ts
+++ b/test/abilities/illusion.test.ts
@@ -88,6 +88,7 @@ describe("Abilities - Illusion", () => {
     expect(game.field.getPlayerPokemon().summonData.illusion).toBeFalsy();
   });
 
+  // TODO: This doesn't actually check that the ai calls the function this way... useless test
   it("causes enemy AI to consider the illusion's type instead of the actual type when considering move effectiveness", async () => {
     game.override.enemyMoveset([MoveId.FLAMETHROWER, MoveId.PSYCHIC, MoveId.TACKLE]);
     await game.classicMode.startBattle([SpeciesId.ZOROARK, SpeciesId.FEEBAS]);
@@ -97,22 +98,16 @@ describe("Abilities - Illusion", () => {
 
     const flameThrower = enemy.getMoveset()[0]!.getMove();
     const psychic = enemy.getMoveset()[1]!.getMove();
-    const flameThrowerEffectiveness = zoroark.getAttackTypeEffectiveness(
-      flameThrower.type,
-      enemy,
-      undefined,
-      undefined,
-      flameThrower,
-      true,
-    );
-    const psychicEffectiveness = zoroark.getAttackTypeEffectiveness(
-      psychic.type,
-      enemy,
-      undefined,
-      undefined,
-      psychic,
-      true,
-    );
+    const flameThrowerEffectiveness = zoroark.getAttackTypeEffectiveness(flameThrower.type, {
+      source: enemy,
+      move: flameThrower,
+      useIllusion: true,
+    });
+    const psychicEffectiveness = zoroark.getAttackTypeEffectiveness(psychic.type, {
+      source: enemy,
+      move: psychic,
+      useIllusion: true,
+    });
     expect(psychicEffectiveness).above(flameThrowerEffectiveness);
   });
 

--- a/test/arena/weather-strong-winds.test.ts
+++ b/test/arena/weather-strong-winds.test.ts
@@ -42,7 +42,7 @@ describe("Weather - Strong Winds", () => {
     game.move.select(MoveId.THUNDERBOLT);
 
     await game.phaseInterceptor.to(TurnStartPhase);
-    expect(enemy.getAttackTypeEffectiveness(allMoves[MoveId.THUNDERBOLT].type, pikachu)).toBe(0.5);
+    expect(enemy.getAttackTypeEffectiveness(allMoves[MoveId.THUNDERBOLT].type, { source: pikachu })).toBe(0.5);
   });
 
   it("electric type move is neutral for flying type pokemon", async () => {
@@ -53,7 +53,7 @@ describe("Weather - Strong Winds", () => {
     game.move.select(MoveId.THUNDERBOLT);
 
     await game.phaseInterceptor.to(TurnStartPhase);
-    expect(enemy.getAttackTypeEffectiveness(allMoves[MoveId.THUNDERBOLT].type, pikachu)).toBe(1);
+    expect(enemy.getAttackTypeEffectiveness(allMoves[MoveId.THUNDERBOLT].type, { source: pikachu })).toBe(1);
   });
 
   it("ice type move is neutral for flying type pokemon", async () => {
@@ -64,7 +64,7 @@ describe("Weather - Strong Winds", () => {
     game.move.select(MoveId.ICE_BEAM);
 
     await game.phaseInterceptor.to(TurnStartPhase);
-    expect(enemy.getAttackTypeEffectiveness(allMoves[MoveId.ICE_BEAM].type, pikachu)).toBe(1);
+    expect(enemy.getAttackTypeEffectiveness(allMoves[MoveId.ICE_BEAM].type, { source: pikachu })).toBe(1);
   });
 
   it("rock type move is neutral for flying type pokemon", async () => {
@@ -75,7 +75,7 @@ describe("Weather - Strong Winds", () => {
     game.move.select(MoveId.ROCK_SLIDE);
 
     await game.phaseInterceptor.to(TurnStartPhase);
-    expect(enemy.getAttackTypeEffectiveness(allMoves[MoveId.ROCK_SLIDE].type, pikachu)).toBe(1);
+    expect(enemy.getAttackTypeEffectiveness(allMoves[MoveId.ROCK_SLIDE].type, { source: pikachu })).toBe(1);
   });
 
   it("weather goes away when last trainer pokemon dies to indirect damage", async () => {

--- a/test/moves/flying-press.test.ts
+++ b/test/moves/flying-press.test.ts
@@ -1,0 +1,109 @@
+import { allAbilities, allMoves } from "#data/data-lists";
+import { AbilityId } from "#enums/ability-id";
+import { BattlerTagType } from "#enums/battler-tag-type";
+import { Challenges } from "#enums/challenges";
+import { MoveId } from "#enums/move-id";
+import { PokemonType } from "#enums/pokemon-type";
+import { SpeciesId } from "#enums/species-id";
+import type { PlayerPokemon } from "#field/pokemon";
+import { GameManager } from "#test/test-utils/game-manager";
+import { getEnumValues } from "#utils/enums";
+import { toTitleCase } from "#utils/strings";
+import Phaser from "phaser";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+describe.sequential("Move - Flying Press", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+  let hawlucha: PlayerPokemon;
+
+  beforeAll(async () => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleStyle("single")
+      .criticalHits(false)
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset(MoveId.SPLASH)
+      .startingLevel(100)
+      .enemyLevel(100);
+
+    await game.classicMode.startBattle([SpeciesId.HAWLUCHA]);
+    hawlucha = game.field.getPlayerPokemon();
+  });
+
+  afterAll(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  // Reset temporary summon data overrides to reset effects
+  afterEach(() => {
+    console.log("Apple");
+    hawlucha.resetSummonData();
+    expect(hawlucha).not.toHaveBattlerTag(BattlerTagType.ELECTRIFIED);
+    expect(hawlucha.hasAbility(AbilityId.NORMALIZE)).toBe(false);
+  });
+
+  const pokemonTypes = getEnumValues(PokemonType);
+
+  function checkEffForAllTypes(primaryType: PokemonType) {
+    const enemy = game.field.getEnemyPokemon();
+    for (const type of pokemonTypes) {
+      enemy.summonData.types = [type];
+      const primaryEff = enemy.getAttackTypeEffectiveness(primaryType, { source: hawlucha });
+      const flyingEff = enemy.getAttackTypeEffectiveness(PokemonType.FLYING, { source: hawlucha });
+      const flyingPressEff = enemy.getAttackTypeEffectiveness(hawlucha.getMoveType(allMoves[MoveId.FLYING_PRESS]), {
+        source: hawlucha,
+        move: allMoves[MoveId.FLYING_PRESS],
+      });
+      expect
+        .soft(
+          flyingPressEff,
+          `Flying Press effectiveness against ${toTitleCase(PokemonType[type])} was incorrect!` +
+            `\nExpected: ${flyingPressEff},` +
+            `\nActual: ${primaryEff * flyingEff} (=${primaryEff} * ${flyingEff})`,
+        )
+        .toBe(primaryEff * flyingEff);
+    }
+  }
+
+  describe("Normal", () => {
+    it("should deal damage as a Fighting/Flying type move by default", async () => {
+      checkEffForAllTypes(PokemonType.FIGHTING);
+    });
+
+    it("should deal damage as an Electric/Flying type move when Electrify is active", async () => {
+      hawlucha.addTag(BattlerTagType.ELECTRIFIED);
+      checkEffForAllTypes(PokemonType.ELECTRIC);
+    });
+
+    it("should deal damage as a Normal/Flying type move when Normalize is active", async () => {
+      hawlucha.setTempAbility(allAbilities[AbilityId.NORMALIZE]);
+      checkEffForAllTypes(PokemonType.NORMAL);
+    });
+  });
+
+  describe("Inverse", () => {
+    beforeAll(() => {
+      game.challengeMode.addChallenge(Challenges.INVERSE_BATTLE, 1, 1);
+    });
+    it("should deal damage as a Fighting/Flying type move by default", async () => {
+      checkEffForAllTypes(PokemonType.FIGHTING);
+    });
+
+    it("should deal damage as an Electric/Flying type move when Electrify is active", async () => {
+      hawlucha.addTag(BattlerTagType.ELECTRIFIED);
+      checkEffForAllTypes(PokemonType.ELECTRIC);
+    });
+
+    it("should deal damage as a Normal/Flying type move when Normalize is active", async () => {
+      hawlucha.setTempAbility(allAbilities[AbilityId.NORMALIZE]);
+      checkEffForAllTypes(PokemonType.NORMAL);
+    });
+  });
+});


### PR DESCRIPTION
- **Cleaned up flying press/etc moves; removed `VariableMoveTypeMultiplierAttr`**
- **Made `getAttackTypeEffectiveness` take an object for parameters; added FP tests**

## What are the changes the user will see?
N/A

## Why am I making these changes?
`VariableMoveTypeMultiplierAttr` and `VariableMoveTypeChartAttr` were used in extremely overlapping ways.

The only difference was the former operated on all types, while the latter operated on each individual type.

Also big function with many args usually like to have object literal

## What are the changes from a developer perspective?
The aforementioned 2 attributes have been combined into 1 attribute that is used for all the prior moves (Freeze-Dry, Flying Press, Sheer Cold, Thousand Arrows and Synchronoise)

Moved params into an object and updated callsites

stopped anticipation from hardcoding Hidden Power's type check

## Screenshots/Videos
N/A
## How to test the changes?
`pnpm test flying-press.test.ts`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?