### PR TITLE
[UI/UX][Bug] Removed extra division by 6 in starter-select-ui-handler.ts

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1053,7 +1053,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
     this.moveInfoOverlay = new MoveInfoOverlay({
       top: true,
       x: 1,
-      y: globalScene.scaledCanvas.height / 6 - MoveInfoOverlay.getHeight() - 29,
+      y: globalScene.scaledCanvas.height - MoveInfoOverlay.getHeight() - 29,
     });
 
     this.starterSelectContainer.add([


### PR DESCRIPTION
One-liner PR to remove an extra `/ 6` which had been mistakenly added while merging conflicts for #6165 .