### PR TITLE
[Bug] [UI/UX] [Beta] Fix icons not showing in save slot selection

### DIFF
--- a/src/ui/save-slot-select-ui-handler.ts
+++ b/src/ui/save-slot-select-ui-handler.ts
@@ -594,13 +594,9 @@ class SessionSlot extends Phaser.GameObjects.Container {
         TextStyle.PARTY,
         { fontSize: "54px", color: "#f8f8f8" },
       );
-      text.setShadow(0, 0, undefined);
-      text.setStroke("#424242", 14);
-      text.setOrigin(1, 0);
+      text.setShadow(0, 0, undefined).setStroke("#424242", 14).setOrigin(1, 0);
 
-      iconContainer.add(icon);
-      iconContainer.add(text);
-
+      iconContainer.add([icon, text]);
       pokemonIconsContainer.add(iconContainer);
 
       pokemon.destroy();
@@ -645,6 +641,7 @@ class SessionSlot extends Phaser.GameObjects.Container {
             return;
           }
           this.saveData = sessionData;
+          this.setupWithData(sessionData);
           resolve(true);
         })
         .catch(e => {


### PR DESCRIPTION
## What are the changes the user will see?
Sessions in the session slot selection will once again show the pokemon icons.

## Why am I making these changes?
Fixes a minor oversight.

## What are the changes from a developer perspective?
Restore the accidentally deleted call to `setupWithData`

## Screenshots/Videos
<img width="1032" height="582" alt="image" src="https://github.com/user-attachments/assets/8bd889d1-022c-4eb3-afac-533c115c52e1" />

## How to test the changes?
Go to load game and observe the team preview for the slot

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - ~~[ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~