### PR TITLE
[i18n] rename cancel to cancelButton

### DIFF
--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -2142,7 +2142,12 @@ class PartyCancelButton extends Phaser.GameObjects.Container {
 
     this.partyCancelPb = partyCancelPb;
 
-    const partyCancelText = addTextObject(-10, -7, i18next.t("partyUiHandler:cancel"), TextStyle.PARTY_CANCEL_BUTTON);
+    const partyCancelText = addTextObject(
+      -10,
+      -7,
+      i18next.t("partyUiHandler:cancelButton"),
+      TextStyle.PARTY_CANCEL_BUTTON,
+    );
     this.add(partyCancelText);
   }
 


### PR DESCRIPTION
## What are the changes the user will see?

N/A

## Why am I making these changes?

There are 2 locale `cancel` keys in `party-ui-handler.json` and [[i18n] Change i18n keys to be camel case](https://github.com/pagefaultgames/pokerogue/pull/6237) would make them overlap

## What are the changes from a developer perspective?

The key used for the cancel button (see screenshots) now uses `cancelButton` instead of `cancel`

## Screenshots/Videos



## How to test the changes?

Open the party menu

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?
