### PR TITLE
[Bug] [Beta] Fix renaming runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.0.0",
     "@ls-lint/ls-lint": "2.3.1",
+    "@types/crypto-js": "^4.2.0",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^22.16.5",
     "@vitest/coverage-istanbul": "^3.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@ls-lint/ls-lint':
         specifier: 2.3.1
         version: 2.3.1
+      '@types/crypto-js':
+        specifier: ^4.2.0
+        version: 4.2.2
       '@types/jsdom':
         specifier: ^21.1.7
         version: 21.1.7
@@ -717,6 +720,9 @@ packages:
 
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
+  '@types/crypto-js@4.2.2':
+    resolution: {integrity: sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -2524,6 +2530,8 @@ snapshots:
       '@types/deep-eql': 4.0.2
 
   '@types/cookie@0.6.0': {}
+
+  '@types/crypto-js@4.2.2': {}
 
   '@types/deep-eql@4.0.2': {}
 

--- a/src/account.ts
+++ b/src/account.ts
@@ -17,45 +17,42 @@ export function initLoggedInUser(): void {
   };
 }
 
-export function updateUserInfo(): Promise<[boolean, number]> {
-  return new Promise<[boolean, number]>(resolve => {
-    if (bypassLogin) {
-      loggedInUser = {
-        username: "Guest",
-        lastSessionSlot: -1,
-        discordId: "",
-        googleId: "",
-        hasAdminRole: false,
-      };
-      let lastSessionSlot = -1;
-      for (let s = 0; s < 5; s++) {
-        if (localStorage.getItem(`sessionData${s ? s : ""}_${loggedInUser.username}`)) {
-          lastSessionSlot = s;
-          break;
-        }
+export async function updateUserInfo(): Promise<[boolean, number]> {
+  if (bypassLogin) {
+    loggedInUser = {
+      username: "Guest",
+      lastSessionSlot: -1,
+      discordId: "",
+      googleId: "",
+      hasAdminRole: false,
+    };
+    let lastSessionSlot = -1;
+    for (let s = 0; s < 5; s++) {
+      if (localStorage.getItem(`sessionData${s ? s : ""}_${loggedInUser.username}`)) {
+        lastSessionSlot = s;
+        break;
       }
-      loggedInUser.lastSessionSlot = lastSessionSlot;
-      // Migrate old data from before the username was appended
-      ["data", "sessionData", "sessionData1", "sessionData2", "sessionData3", "sessionData4"].map(d => {
-        const lsItem = localStorage.getItem(d);
-        if (lsItem && !!loggedInUser?.username) {
-          const lsUserItem = localStorage.getItem(`${d}_${loggedInUser.username}`);
-          if (lsUserItem) {
-            localStorage.setItem(`${d}_${loggedInUser.username}_bak`, lsUserItem);
-          }
-          localStorage.setItem(`${d}_${loggedInUser.username}`, lsItem);
-          localStorage.removeItem(d);
-        }
-      });
-      return resolve([true, 200]);
     }
-    pokerogueApi.account.getInfo().then(([accountInfo, status]) => {
-      if (!accountInfo) {
-        resolve([false, status]);
-        return;
+    loggedInUser.lastSessionSlot = lastSessionSlot;
+    // Migrate old data from before the username was appended
+    ["data", "sessionData", "sessionData1", "sessionData2", "sessionData3", "sessionData4"].forEach(d => {
+      const lsItem = localStorage.getItem(d);
+      if (lsItem && !!loggedInUser?.username) {
+        const lsUserItem = localStorage.getItem(`${d}_${loggedInUser.username}`);
+        if (lsUserItem) {
+          localStorage.setItem(`${d}_${loggedInUser.username}_bak`, lsUserItem);
+        }
+        localStorage.setItem(`${d}_${loggedInUser.username}`, lsItem);
+        localStorage.removeItem(d);
       }
-      loggedInUser = accountInfo;
-      resolve([true, 200]);
     });
-  });
+    return [true, 200];
+  }
+
+  const [accountInfo, status] = await pokerogueApi.account.getInfo();
+  if (!accountInfo) {
+    return [false, status];
+  }
+  loggedInUser = accountInfo;
+  return [true, 200];
 }

--- a/src/plugins/api/pokerogue-session-savedata-api.ts
+++ b/src/plugins/api/pokerogue-session-savedata-api.ts
@@ -56,15 +56,15 @@ export class PokerogueSessionSavedataApi extends ApiBase {
 
   /**
    * Update a session savedata.
-   * @param params The {@linkcode UpdateSessionSavedataRequest} to send
-   * @param rawSavedata The raw savedata (as `string`)
+   * @param params - The request to send
+   * @param rawSavedata - The raw, unencrypted savedata
    * @returns An error message if something went wrong
    */
-  public async update(params: UpdateSessionSavedataRequest, rawSavedata: string) {
+  public async update(params: UpdateSessionSavedataRequest, rawSavedata: string): Promise<string> {
     try {
       const urlSearchParams = this.toUrlSearchParams(params);
-      const response = await this.doPost(`/savedata/session/update?${urlSearchParams}`, rawSavedata);
 
+      const response = await this.doPost(`/savedata/session/update?${urlSearchParams}`, rawSavedata);
       return await response.text();
     } catch (err) {
       console.warn("Could not update session savedata!", err);

--- a/src/ui/run-info-ui-handler.ts
+++ b/src/ui/run-info-ui-handler.ts
@@ -208,7 +208,7 @@ export class RunInfoUiHandler extends UiHandler {
     headerText.setOrigin(0, 0);
     headerText.setPositionRelative(headerBg, 8, 4);
     this.runContainer.add(headerText);
-    const runName = addTextObject(0, 0, this.runInfo.runNameText, TextStyle.WINDOW);
+    const runName = addTextObject(0, 0, this.runInfo.name, TextStyle.WINDOW);
     runName.setOrigin(0, 0);
     runName.setPositionRelative(headerBg, 60, 4);
     this.runContainer.add(runName);

--- a/src/ui/save-slot-select-ui-handler.ts
+++ b/src/ui/save-slot-select-ui-handler.ts
@@ -377,7 +377,7 @@ export class SaveSlotSelectUiHandler extends MessageUiHandler {
         "select_cursor_highlight_thick",
         undefined,
         294,
-        this.sessionSlots[prevSlotIndex ?? 0]?.saveData?.runNameText ? 50 : 60,
+        this.sessionSlots[prevSlotIndex ?? 0]?.saveData?.name ? 50 : 60,
         6,
         6,
         6,
@@ -553,10 +553,10 @@ class SessionSlot extends Phaser.GameObjects.Container {
   }
 
   async setupWithData(data: SessionSaveData) {
-    const hasName = data?.runNameText;
+    const hasName = data?.name;
     this.remove(this.loadingLabel, true);
     if (hasName) {
-      const nameLabel = addTextObject(8, 5, data.runNameText, TextStyle.WINDOW);
+      const nameLabel = addTextObject(8, 5, data.name, TextStyle.WINDOW);
       this.add(nameLabel);
     } else {
       const fallbackName = this.decideFallback(data);

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -45,17 +45,17 @@ export function deepMergeSpriteData(dest: object, source: object) {
 }
 
 export function encrypt(data: string, bypassLogin: boolean): string {
-  return (bypassLogin
-    ? (data: string) => btoa(encodeURIComponent(data))
-    : (data: string) => AES.encrypt(data, saveKey))(data) as unknown as string; // TODO: is this correct?
+  if (bypassLogin) {
+    return btoa(encodeURIComponent(data));
+  }
+  return AES.encrypt(data, saveKey).toString();
 }
 
 export function decrypt(data: string, bypassLogin: boolean): string {
-  return (
-    bypassLogin
-      ? (data: string) => decodeURIComponent(atob(data))
-      : (data: string) => AES.decrypt(data, saveKey).toString(enc.Utf8)
-  )(data);
+  if (bypassLogin) {
+    return decodeURIComponent(atob(data));
+  }
+  return AES.decrypt(data, saveKey).toString(enc.Utf8);
 }
 
 // the latest data saved/loaded for the Starter Preferences. Required to reduce read/writes. Initialize as "{}", since this is the default value and no data needs to be stored if present.


### PR DESCRIPTION
## What are the changes the user will see?
Renaming a run will now work properly.

## Why am I making these changes?
Fixes a bug in #5978 that prevented runs from being renamed when running on rogueserver (bug does not appear during local testing).

This actually *did* need changes to rogueserver: https://github.com/pagefaultgames/rogueserver/pull/63

## What are the changes from a developer perspective?
- Added the `@types/crypto-js` package as a dev dependency to give proper typescript hints for the crypto-js dependency
- Cleaned up the `encrypt` and `decrypt` methods' bespoke logic.
   - Fixed the `encrypt` function to call `toString` on the returned data. Before, it was not doing this, and the method was actually returning an object. Before #5978, the existing uses of this method were always being passed directly to `localStorage#setItem`, which calls `toString` on its argument anyway, bypassing this bug.
- De-nested a few promises in related methods that I was exploring
- Updated the documentation of `gameData#update` to convey that the session data should *not* be encrypted.
- Made the server call to the rename session _not_ pass the encrypted session, as the server wants the raw json.
- Renamed the `runNameText` field to just `name` to keep session data lightweight

## Screenshots/Videos
<details><summary>Demonstration of fix</summary>

https://github.com/user-attachments/assets/b6776af6-feee-4b91-aafc-e99184b8accb
</details> 

## How to test the changes?
You'll need a copy of rogueserver built and running.
Rename a run, and then see that it persists across logout.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes? **No**: Need a better way of testing things that require server responses.
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~