### PR TITLE
[Bug][UI/UX] Bringing mon icon overlays on top correctly

### DIFF
--- a/src/ui/pokedex-mon-container.ts
+++ b/src/ui/pokedex-mon-container.ts
@@ -208,6 +208,26 @@ export class PokedexMonContainer extends Phaser.GameObjects.Container {
     );
     this.checkIconId(defaultProps.female, defaultProps.formIndex, defaultProps.shiny, defaultProps.variant);
     this.add(this.icon);
+
+    [
+      this.hiddenAbilityIcon,
+      this.favoriteIcon,
+      this.classicWinIcon,
+      this.candyUpgradeIcon,
+      this.candyUpgradeOverlayIcon,
+      this.eggMove1Icon,
+      this.tmMove1Icon,
+      this.eggMove2Icon,
+      this.tmMove2Icon,
+      this.passive1Icon,
+      this.passive2Icon,
+      this.passive1OverlayIcon,
+      this.passive2OverlayIcon,
+    ].forEach(icon => {
+      if (icon) {
+        this.bringToTop(icon);
+      }
+    });
   }
 
   checkIconId(female, formIndex, shiny, variant) {


### PR DESCRIPTION
## What are the changes the user will see?
Overlay decorations in the Pokédex now show above the pokémon icons, as intended.

## Why am I making these changes?
The Pokédex refactor to curb the number of containers #5400 had introduced dynamical updates for the icon in the Pokémon containers. This caused the icon to go on top of everything else.

Was reported by @damocleas [on discord](https://discord.com/channels/1125469663833370665/1176874654015684739/1405935511507439666)

## What are the changes from a developer perspective?
Updating the elements that need to be on top when the new icon is added.

## Screenshots/Videos

After the changes, the decorations look correct.

<img width="502" height="435" alt="overlay_correct" src="https://github.com/user-attachments/assets/cd0a36ae-0013-42c4-b64d-d106843e03a9" />


## How to test the changes?
Open the Pokédex, scroll, change a few filters.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?