### PR TITLE
[Beta][Bug] Fixing Ribbons that do not work because of integer overflow

### DIFF
--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -49,7 +49,7 @@ export abstract class Challenge {
    * @defaultValue 0
    */
   public get ribbonAwarded(): RibbonFlag {
-    return 0 as RibbonFlag;
+    return 0n as RibbonFlag;
   }
 
   /**
@@ -436,7 +436,7 @@ export class SingleGenerationChallenge extends Challenge {
   public override get ribbonAwarded(): RibbonFlag {
     // NOTE: This logic will not work for the eventual mono gen 10 ribbon, as
     // as its flag will not be in sequence with the other mono gen ribbons.
-    return this.value ? ((RibbonData.MONO_GEN_1 << (this.value - 1)) as RibbonFlag) : 0;
+    return this.value ? ((RibbonData.MONO_GEN_1 << (BigInt(this.value) - 1n)) as RibbonFlag) : 0n;
   }
 
   constructor() {
@@ -706,7 +706,7 @@ export class SingleTypeChallenge extends Challenge {
     // `this.value` represents the 1-based index of pokemon type
     // `RibbonData.MONO_NORMAL` starts the flag position for the types,
     // and we shift it by 1 for the specific type.
-    return this.value ? ((RibbonData.MONO_NORMAL << (this.value - 1)) as RibbonFlag) : 0;
+    return this.value ? ((RibbonData.MONO_NORMAL << (BigInt(this.value) - 1n)) as RibbonFlag) : 0n;
   }
   private static TYPE_OVERRIDES: monotypeOverride[] = [
     { species: SpeciesId.CASTFORM, type: PokemonType.NORMAL, fusion: false },
@@ -778,7 +778,7 @@ export class SingleTypeChallenge extends Challenge {
  */
 export class FreshStartChallenge extends Challenge {
   public override get ribbonAwarded(): RibbonFlag {
-    return this.value ? RibbonData.FRESH_START : 0;
+    return this.value ? RibbonData.FRESH_START : 0n;
   }
   constructor() {
     super(Challenges.FRESH_START, 2);
@@ -854,7 +854,7 @@ export class FreshStartChallenge extends Challenge {
  */
 export class InverseBattleChallenge extends Challenge {
   public override get ribbonAwarded(): RibbonFlag {
-    return this.value ? RibbonData.INVERSE : 0;
+    return this.value ? RibbonData.INVERSE : 0n;
   }
   constructor() {
     super(Challenges.INVERSE_BATTLE, 1);
@@ -890,7 +890,7 @@ export class InverseBattleChallenge extends Challenge {
  */
 export class FlipStatChallenge extends Challenge {
   public override get ribbonAwarded(): RibbonFlag {
-    return this.value ? RibbonData.FLIP_STATS : 0;
+    return this.value ? RibbonData.FLIP_STATS : 0n;
   }
   constructor() {
     super(Challenges.FLIP_STAT, 1);
@@ -973,7 +973,7 @@ export class LowerStarterPointsChallenge extends Challenge {
  */
 export class LimitedSupportChallenge extends Challenge {
   public override get ribbonAwarded(): RibbonFlag {
-    return this.value ? ((RibbonData.NO_HEAL << (this.value - 1)) as RibbonFlag) : 0;
+    return this.value ? ((RibbonData.NO_HEAL << (BigInt(this.value) - 1n)) as RibbonFlag) : 0n;
   }
   constructor() {
     super(Challenges.LIMITED_SUPPORT, 3);
@@ -1008,7 +1008,7 @@ export class LimitedSupportChallenge extends Challenge {
  */
 export class LimitedCatchChallenge extends Challenge {
   public override get ribbonAwarded(): RibbonFlag {
-    return this.value ? RibbonData.LIMITED_CATCH : 0;
+    return this.value ? RibbonData.LIMITED_CATCH : 0n;
   }
   constructor() {
     super(Challenges.LIMITED_CATCH, 1);
@@ -1035,7 +1035,7 @@ export class LimitedCatchChallenge extends Challenge {
  */
 export class HardcoreChallenge extends Challenge {
   public override get ribbonAwarded(): RibbonFlag {
-    return this.value ? RibbonData.HARDCORE : 0;
+    return this.value ? RibbonData.HARDCORE : 0n;
   }
   constructor() {
     super(Challenges.HARDCORE, 1);

--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -119,7 +119,7 @@ export class GameOverPhase extends BattlePhase {
    * game mode and challenges.
    */
   private awardRibbons(): void {
-    let ribbonFlags = 0;
+    let ribbonFlags = 0n;
     if (globalScene.gameMode.isClassic) {
       ribbonFlags |= RibbonData.CLASSIC;
     }

--- a/src/system/ribbons/ribbon-data.ts
+++ b/src/system/ribbons/ribbon-data.ts
@@ -1,6 +1,6 @@
 import type { Brander } from "#types/type-helpers";
 
-export type RibbonFlag = (number & Brander<"RibbonFlag">) | 0;
+export type RibbonFlag = (bigint & Brander<"RibbonFlag">) | 0n;
 
 /**
  * Class for ribbon data management. Usually constructed via the {@linkcode fromJSON} method.
@@ -10,91 +10,91 @@ export type RibbonFlag = (number & Brander<"RibbonFlag">) | 0;
  */
 export class RibbonData {
   /** Internal bitfield storing the unlock state for each ribbon */
-  private payload: number;
+  private payload: bigint;
 
   //#region Ribbons
   //#region Monotype challenge ribbons
   /** Ribbon for winning the normal monotype challenge */
-  public static readonly MONO_NORMAL = 0x1 as RibbonFlag;
+  public static readonly MONO_NORMAL = 0x1n as RibbonFlag;
   /** Ribbon for winning the fighting monotype challenge */
-  public static readonly MONO_FIGHTING = 0x2 as RibbonFlag;
+  public static readonly MONO_FIGHTING = 0x2n as RibbonFlag;
   /** Ribbon for winning the flying monotype challenge */
-  public static readonly MONO_FLYING = 0x4 as RibbonFlag;
+  public static readonly MONO_FLYING = 0x4n as RibbonFlag;
   /** Ribbon for winning the poision monotype challenge */
-  public static readonly MONO_POISON = 0x8 as RibbonFlag;
+  public static readonly MONO_POISON = 0x8n as RibbonFlag;
   /** Ribbon for winning the ground monotype challenge */
-  public static readonly MONO_GROUND = 0x10 as RibbonFlag;
+  public static readonly MONO_GROUND = 0x10n as RibbonFlag;
   /** Ribbon for winning the rock monotype challenge */
-  public static readonly MONO_ROCK = 0x20 as RibbonFlag;
+  public static readonly MONO_ROCK = 0x20n as RibbonFlag;
   /** Ribbon for winning the bug monotype challenge */
-  public static readonly MONO_BUG = 0x40 as RibbonFlag;
+  public static readonly MONO_BUG = 0x40n as RibbonFlag;
   /** Ribbon for winning the ghost monotype challenge */
-  public static readonly MONO_GHOST = 0x80 as RibbonFlag;
+  public static readonly MONO_GHOST = 0x80n as RibbonFlag;
   /** Ribbon for winning the steel monotype challenge */
-  public static readonly MONO_STEEL = 0x100 as RibbonFlag;
+  public static readonly MONO_STEEL = 0x100n as RibbonFlag;
   /** Ribbon for winning the fire monotype challenge */
-  public static readonly MONO_FIRE = 0x200 as RibbonFlag;
+  public static readonly MONO_FIRE = 0x200n as RibbonFlag;
   /** Ribbon for winning the water monotype challenge */
-  public static readonly MONO_WATER = 0x400 as RibbonFlag;
+  public static readonly MONO_WATER = 0x400n as RibbonFlag;
   /** Ribbon for winning the grass monotype challenge */
-  public static readonly MONO_GRASS = 0x800 as RibbonFlag;
+  public static readonly MONO_GRASS = 0x800n as RibbonFlag;
   /** Ribbon for winning the electric monotype challenge */
-  public static readonly MONO_ELECTRIC = 0x1000 as RibbonFlag;
+  public static readonly MONO_ELECTRIC = 0x1000n as RibbonFlag;
   /** Ribbon for winning the psychic monotype challenge */
-  public static readonly MONO_PSYCHIC = 0x2000 as RibbonFlag;
+  public static readonly MONO_PSYCHIC = 0x2000n as RibbonFlag;
   /** Ribbon for winning the ice monotype challenge */
-  public static readonly MONO_ICE = 0x4000 as RibbonFlag;
+  public static readonly MONO_ICE = 0x4000n as RibbonFlag;
   /** Ribbon for winning the dragon monotype challenge */
-  public static readonly MONO_DRAGON = 0x8000 as RibbonFlag;
+  public static readonly MONO_DRAGON = 0x8000n as RibbonFlag;
   /** Ribbon for winning the dark monotype challenge */
-  public static readonly MONO_DARK = 0x10000 as RibbonFlag;
+  public static readonly MONO_DARK = 0x10000n as RibbonFlag;
   /** Ribbon for winning the fairy monotype challenge */
-  public static readonly MONO_FAIRY = 0x20000 as RibbonFlag;
+  public static readonly MONO_FAIRY = 0x20000n as RibbonFlag;
   //#endregion Monotype ribbons
 
   //#region Monogen ribbons
   /** Ribbon for winning the the mono gen 1 challenge */
-  public static readonly MONO_GEN_1 = 0x40000 as RibbonFlag;
+  public static readonly MONO_GEN_1 = 0x40000n as RibbonFlag;
   /** Ribbon for winning the the mono gen 2 challenge */
-  public static readonly MONO_GEN_2 = 0x80000 as RibbonFlag;
+  public static readonly MONO_GEN_2 = 0x80000n as RibbonFlag;
   /** Ribbon for winning the mono gen 3 challenge */
-  public static readonly MONO_GEN_3 = 0x100000 as RibbonFlag;
+  public static readonly MONO_GEN_3 = 0x100000n as RibbonFlag;
   /** Ribbon for winning the mono gen 4 challenge */
-  public static readonly MONO_GEN_4 = 0x200000 as RibbonFlag;
+  public static readonly MONO_GEN_4 = 0x200000n as RibbonFlag;
   /** Ribbon for winning the mono gen 5 challenge */
-  public static readonly MONO_GEN_5 = 0x400000 as RibbonFlag;
+  public static readonly MONO_GEN_5 = 0x400000n as RibbonFlag;
   /** Ribbon for winning the mono gen 6 challenge */
-  public static readonly MONO_GEN_6 = 0x800000 as RibbonFlag;
+  public static readonly MONO_GEN_6 = 0x800000n as RibbonFlag;
   /** Ribbon for winning the mono gen 7 challenge */
-  public static readonly MONO_GEN_7 = 0x1000000 as RibbonFlag;
+  public static readonly MONO_GEN_7 = 0x1000000n as RibbonFlag;
   /** Ribbon for winning the mono gen 8 challenge */
-  public static readonly MONO_GEN_8 = 0x2000000 as RibbonFlag;
+  public static readonly MONO_GEN_8 = 0x2000000n as RibbonFlag;
   /** Ribbon for winning the mono gen 9 challenge */
-  public static readonly MONO_GEN_9 = 0x4000000 as RibbonFlag;
+  public static readonly MONO_GEN_9 = 0x4000000n as RibbonFlag;
   //#endregion Monogen ribbons
 
   /** Ribbon for winning classic */
-  public static readonly CLASSIC = 0x8000000 as RibbonFlag;
+  public static readonly CLASSIC = 0x8000000n as RibbonFlag;
   /** Ribbon for winning the nuzzlocke challenge */
-  public static readonly NUZLOCKE = 0x10000000 as RibbonFlag;
+  public static readonly NUZLOCKE = 0x10000000n as RibbonFlag;
   /** Ribbon for reaching max friendship */
-  public static readonly FRIENDSHIP = 0x20000000 as RibbonFlag;
+  public static readonly FRIENDSHIP = 0x20000000n as RibbonFlag;
   /** Ribbon for winning the flip stats challenge */
-  public static readonly FLIP_STATS = 0x40000000 as RibbonFlag;
+  public static readonly FLIP_STATS = 0x40000000n as RibbonFlag;
   /** Ribbon for winning the inverse challenge */
-  public static readonly INVERSE = 0x80000000 as RibbonFlag;
+  public static readonly INVERSE = 0x80000000n as RibbonFlag;
   /** Ribbon for winning the fresh start challenge */
-  public static readonly FRESH_START = 0x100000000 as RibbonFlag;
+  public static readonly FRESH_START = 0x100000000n as RibbonFlag;
   /** Ribbon for winning the hardcore challenge */
-  public static readonly HARDCORE = 0x200000000 as RibbonFlag;
+  public static readonly HARDCORE = 0x200000000n as RibbonFlag;
   /** Ribbon for winning the limited catch challenge */
-  public static readonly LIMITED_CATCH = 0x400000000 as RibbonFlag;
+  public static readonly LIMITED_CATCH = 0x400000000n as RibbonFlag;
   /** Ribbon for winning the limited support challenge set to no heal */
-  public static readonly NO_HEAL = 0x800000000 as RibbonFlag;
+  public static readonly NO_HEAL = 0x800000000n as RibbonFlag;
   /** Ribbon for winning the limited uspport challenge set to no shop */
-  public static readonly NO_SHOP = 0x1000000000 as RibbonFlag;
+  public static readonly NO_SHOP = 0x1000000000n as RibbonFlag;
   /** Ribbon for winning the limited support challenge set to both*/
-  public static readonly NO_SUPPORT = 0x2000000000 as RibbonFlag;
+  public static readonly NO_SUPPORT = 0x2000000000n as RibbonFlag;
 
   // NOTE: max possible ribbon flag is 0x20000000000000 (53 total ribbons)
   // Once this is exceeded, bitfield needs to be changed to a bigint or even a uint array
@@ -104,7 +104,7 @@ export class RibbonData {
 
   /** Create a new instance of RibbonData. Generally, {@linkcode fromJSON} is used instead. */
   constructor(value: number) {
-    this.payload = value;
+    this.payload = BigInt(value);
   }
 
   /** Serialize the bitfield payload as a hex encoded string */


### PR DESCRIPTION
## What are the changes the user will see?
The last few ribbons actually working. Though these are not yet visible to the player, they are being tracked in the save file already.

## Why am I making these changes?
Some RibbonFlags had numbers bigger than max int, which overflowed the flag and never actually awarded them to the species.

## What are the changes from a developer perspective?
RibbonData is now entirely using BigInt.

## Screenshots/Videos
New challenge with all challenges active:
<img width="1190" height="664" alt="image" src="https://github.com/user-attachments/assets/aa01a772-7cba-4b67-8275-b73bcd127e87" />

Before on Beta:
<img width="492" height="155" alt="image" src="https://github.com/user-attachments/assets/5fe89e55-58ba-441d-a62a-181a35ced224" />
Everything after inverse is larger than max int and thus overflows the function to award it.

After on this PR:
<img width="824" height="159" alt="image" src="https://github.com/user-attachments/assets/a066c048-7fa2-4156-bbb0-b33cff8671d8" />
Now even the largest value `NO_SUPPORT` is able to be awarded.

## How to test the changes?
Using the following overrides and starting a new challenge will instantly trigger a classic win:
```ts
const overrides = {
  STARTER_SPECIES_OVERRIDE: SpeciesId.CHARIZARD,
  STARTING_WAVE_OVERRIDE: 201,
} satisfies Partial<InstanceType<OverridesType>>;
```

I made a helper function that prints the before and after of the dexdata ribbons to the console during the gameoverphase. The ribbondata payload is just a large number and kind of annoying to read. This function simplifies that for testing.
In `ribbon-methods.ts` I replaced the `awardRibbonsToSpeciesLine` function with the following code:
```ts
export function awardRibbonsToSpeciesLine(id: SpeciesId, ribbons: RibbonFlag): void {
  const dexData = globalScene.gameData.dexData;
  console.log(id, "before", tempRibbonList(id));
  dexData[id].ribbons.award(ribbons);
  console.log(id, "after", tempRibbonList(id));
  // Mark all pre-evolutions of the Pokémon with the same ribbon flags.
  for (let prevoId = pokemonPrevolutions[id]; !isNullOrUndefined(prevoId); prevoId = pokemonPrevolutions[prevoId]) {
    console.log(prevoId, "before", tempRibbonList(prevoId));
    dexData[prevoId].ribbons.award(ribbons);
    console.log(prevoId, "after", tempRibbonList(prevoId));
  }
}

function tempRibbonList(id): string {
  let list: string[] = [];
  const ribbons = globalScene.gameData.dexData[id].ribbons;
  ribbons.has(RibbonData.MONO_NORMAL) ? list.push("MONO_NORMAL") : "";
  ribbons.has(RibbonData.MONO_NORMAL) ? list.push("MONO_NORMAL") : "";
  ribbons.has(RibbonData.MONO_FIGHTING) ? list.push("MONO_FIGHTING") : "";
  ribbons.has(RibbonData.MONO_FLYING) ? list.push("MONO_FLYING") : "";
  ribbons.has(RibbonData.MONO_POISON) ? list.push("MONO_POISON") : "";
  ribbons.has(RibbonData.MONO_GROUND) ? list.push("MONO_GROUND") : "";
  ribbons.has(RibbonData.MONO_ROCK) ? list.push("MONO_ROCK") : "";
  ribbons.has(RibbonData.MONO_BUG) ? list.push("MONO_BUG") : "";
  ribbons.has(RibbonData.MONO_GHOST) ? list.push("MONO_GHOST") : "";
  ribbons.has(RibbonData.MONO_STEEL) ? list.push("MONO_STEEL") : "";
  ribbons.has(RibbonData.MONO_FIRE) ? list.push("MONO_FIRE") : "";
  ribbons.has(RibbonData.MONO_WATER) ? list.push("MONO_WATER") : "";
  ribbons.has(RibbonData.MONO_GRASS) ? list.push("MONO_GRASS") : "";
  ribbons.has(RibbonData.MONO_ELECTRIC) ? list.push("MONO_ELECTRIC") : "";
  ribbons.has(RibbonData.MONO_PSYCHIC) ? list.push("MONO_PSYCHIC") : "";
  ribbons.has(RibbonData.MONO_ICE) ? list.push("MONO_ICE") : "";
  ribbons.has(RibbonData.MONO_DRAGON) ? list.push("MONO_DRAGON") : "";
  ribbons.has(RibbonData.MONO_DARK) ? list.push("MONO_DARK") : "";
  ribbons.has(RibbonData.MONO_FAIRY) ? list.push("MONO_FAIRY") : "";
  ribbons.has(RibbonData.MONO_GEN_1) ? list.push("MONO_GEN_1") : "";
  ribbons.has(RibbonData.MONO_GEN_2) ? list.push("MONO_GEN_2") : "";
  ribbons.has(RibbonData.MONO_GEN_3) ? list.push("MONO_GEN_3") : "";
  ribbons.has(RibbonData.MONO_GEN_4) ? list.push("MONO_GEN_4") : "";
  ribbons.has(RibbonData.MONO_GEN_5) ? list.push("MONO_GEN_5") : "";
  ribbons.has(RibbonData.MONO_GEN_6) ? list.push("MONO_GEN_6") : "";
  ribbons.has(RibbonData.MONO_GEN_7) ? list.push("MONO_GEN_7") : "";
  ribbons.has(RibbonData.MONO_GEN_8) ? list.push("MONO_GEN_8") : "";
  ribbons.has(RibbonData.MONO_GEN_9) ? list.push("MONO_GEN_9") : "";
  ribbons.has(RibbonData.CLASSIC) ? list.push("CLASSIC") : "";
  ribbons.has(RibbonData.NUZLOCKE) ? list.push("NUZLOCKE") : "";
  ribbons.has(RibbonData.FRIENDSHIP) ? list.push("FRIENDSHIP") : "";
  ribbons.has(RibbonData.FLIP_STATS) ? list.push("FLIP_STATS") : "";
  ribbons.has(RibbonData.INVERSE) ? list.push("INVERSE") : "";
  ribbons.has(RibbonData.FRESH_START) ? list.push("FRESH_START") : "";
  ribbons.has(RibbonData.HARDCORE) ? list.push("HARDCORE") : "";
  ribbons.has(RibbonData.LIMITED_CATCH) ? list.push("LIMITED_CATCH") : "";
  ribbons.has(RibbonData.NO_HEAL) ? list.push("NO_HEAL") : "";
  ribbons.has(RibbonData.NO_SHOP) ? list.push("NO_SHOP") : "";
  ribbons.has(RibbonData.NO_SUPPORT) ? list.push("NO_SUPPORT") : "";
  return list.join(", ");
}
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?
