### PR TITLE
[Bug] [Beta] Prevent crash when attempting to select a move not in the user's moveset

### DIFF
--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -208,7 +208,7 @@ export class CommandPhase extends FieldPhase {
    * Submethod of {@linkcode handleFightCommand} responsible for queuing the appropriate
    * error message when a move cannot be used.
    * @param user - The pokemon using the move
-   * @param Move - The move that cannot be used
+   * @param move - The move that cannot be used
    */
   private queueFightErrorMessage(user: PlayerPokemon, move: PokemonMove) {
     globalScene.ui.setMode(UiMode.MESSAGE);

--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -20,6 +20,7 @@ import { UiMode } from "#enums/ui-mode";
 import type { PlayerPokemon } from "#field/pokemon";
 import type { MoveTargetSet } from "#moves/move";
 import { getMoveTargets } from "#moves/move-utils";
+import type { PokemonMove } from "#moves/pokemon-move";
 import { FieldPhase } from "#phases/field-phase";
 import type { TurnMove } from "#types/turn-move";
 import { applyChallenges } from "#utils/challenge-utils";
@@ -207,10 +208,9 @@ export class CommandPhase extends FieldPhase {
    * Submethod of {@linkcode handleFightCommand} responsible for queuing the appropriate
    * error message when a move cannot be used.
    * @param user - The pokemon using the move
-   * @param cursor - The index of the move in the moveset
+   * @param Move - The move that cannot be used
    */
-  private queueFightErrorMessage(user: PlayerPokemon, cursor: number) {
-    const move = user.getMoveset()[cursor];
+  private queueFightErrorMessage(user: PlayerPokemon, move: PokemonMove) {
     globalScene.ui.setMode(UiMode.MESSAGE);
 
     // Set the translation key for why the move cannot be selected
@@ -277,15 +277,19 @@ export class CommandPhase extends FieldPhase {
 
     let canUse = cursor === -1 || playerPokemon.trySelectMove(cursor, ignorePP);
 
+    const moveset = playerPokemon.getMoveset();
+
     // Ternary here ensures we don't compute struggle conditions unless necessary
-    const useStruggle = canUse
-      ? false
-      : cursor > -1 && !playerPokemon.getMoveset().some(m => m.isUsable(playerPokemon));
+    const useStruggle = canUse ? false : cursor > -1 && !moveset.some(m => m.isUsable(playerPokemon));
 
     canUse ||= useStruggle;
 
     if (!canUse) {
-      this.queueFightErrorMessage(playerPokemon, cursor);
+      // Selected move *may* be undefined if the cursor is over a position that the mon does not have
+      const selectedMove: PokemonMove | undefined = moveset[cursor];
+      if (selectedMove) {
+        this.queueFightErrorMessage(playerPokemon, moveset[cursor]);
+      }
       return false;
     }
 


### PR DESCRIPTION
## What are the changes the user will see?
Pressing "Action" while the cursor is over a moveslot that does not have an occupied move in the moveset will no longer cause the game to hang indefinitely.

## Why am I making these changes?
Fixes P1 Bug

## What are the changes from a developer perspective?
Modify `queueFightErrorMessage` to take the move instead of computing it.

## Screenshots/Videos

<details><summary>No more crash</summary>

https://github.com/user-attachments/assets/450052fb-8c42-4b43-a130-650299f461f4
</details>

## How to test the changes?
Go into a game with a starter that has fewer moves available than 4. Probably on a fresh save.
Click fight, then try to press `ACTION` on one of the moves not in the user's moveset.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?