### PR TITLE
[Bug] [Beta] Fix trick room message

### DIFF
--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -1205,7 +1205,7 @@ export class TrickRoomTag extends RoomArenaTag {
 
     globalScene.phaseManager.queueMessage(
       i18next.t("arenaTag:trickRoomOnAdd", {
-        moveName: this.getMoveName(),
+        pokemonNameWithAffix: getPokemonNameWithAffix(source),
       }),
     );
   }


### PR DESCRIPTION
## What are the changes the user will see?
Trick room will display it's proper message

## Why am I making these changes?
Fix a bug related 

## What are the changes from a developer perspective?
Pass the proper key to i18n

## Screenshots/Videos
<details><summary>Before</summary>
<img width="1237" height="687" alt="image" src="https://github.com/user-attachments/assets/be5ca48f-b623-454c-8a16-1f6bd631424f" />
</details>

<details><summary>After</summary>
<img width="1234" height="696" alt="image" src="https://github.com/user-attachments/assets/8e347d23-558b-4c3d-88b4-0ca7e53f804f" />
</details> 

## How to test the changes?

```ts
const overrides = {
  MOVESET_OVERRIDE: [MoveId.TRICK_ROOM],
  ENEMY_MOVESET_OVERRIDE: [MoveId.SPLASH],
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- [x] **I'm using `release` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~