### PR TITLE
[GitHub] Workflows will now run on `release` branch

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - beta
+      - release
   pull_request:
     branches:
       - main
       - beta
+      - release
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - beta
+      - release
   pull_request:
     branches:
       - main
       - beta
+      - release
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - beta
+      - release
   pull_request:
     branches:
       - main
       - beta
+      - release
   merge_group:
     types: [checks_requested]
   workflow_dispatch:


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Some workflows that should be running on PRs to the `release` branch weren't running.

## What are the changes from a developer perspective?
Updated GitHub workflow files to run on `release` branch and PRs to `release` branch as appropriate.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?