### PR TITLE
[Bug] Fresh start does _not_ override iv unlocks

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -3741,7 +3741,9 @@ export class StarterSelectUiHandler extends MessageUiHandler {
     const dexEntry = globalScene.gameData.dexData[speciesId];
     const starterDataEntry = globalScene.gameData.starterData[speciesId];
 
+    // Unpacking to make a copy by values, not references
     const copiedDexEntry = { ...dexEntry };
+    copiedDexEntry.ivs = [...dexEntry.ivs];
     const copiedStarterDataEntry = { ...starterDataEntry };
     if (applyChallenge) {
       applyChallenges(ChallengeType.STARTER_SELECT_MODIFY, speciesId, copiedDexEntry, copiedStarterDataEntry);


### PR DESCRIPTION
This fixes a bug due to #6277 . The bug causes all iv unlocks to be permanently capped at 15 when opening starter select in fresh start and saving the game.

In this PR, a copy of `dexData` is made and overridden with the fresh start limitations.
When unpacking `dexEntry`, ivs are still being passed as a reference due to being an array, so they need to be unpacked individually. Not doing so caused the bug.



```ts
export interface DexEntry {
  seenAttr: bigint;
  caughtAttr: bigint;
  natureAttr: number;
  seenCount: number;
  caughtCount: number;
  hatchedCount: number;
  ivs: number[];
  ribbons: RibbonData;
}
```

```ts
export interface StarterDataEntry {
  moveset: StarterMoveset | StarterFormMoveData | null;
  eggMoves: number;
  candyCount: number;
  friendship: number;
  abilityAttr: number;
  passiveAttr: number;
  valueReduction: number;
  classicWinCount: number;
}
```

Everything else should be fine, ivs is the only array in there.
