### PR TITLE
[UI/UX] Always show starter's natures and ivs in evolution's dex entry

### DIFF
--- a/src/ui/pokedex-page-ui-handler.ts
+++ b/src/ui/pokedex-page-ui-handler.ts
@@ -1777,7 +1777,9 @@ export class PokedexPageUiHandler extends MessageUiHandler {
               this.blockInput = true;
               ui.setMode(UiMode.POKEDEX_PAGE, "refresh").then(() => {
                 ui.showText(i18next.t("pokedexUiHandler:showNature"), null, () => {
-                  const natures = globalScene.gameData.getNaturesForAttr(this.speciesStarterDexEntry?.natureAttr);
+                  const starterDexEntry =
+                    globalScene.gameData.dexData[this.getStarterSpeciesId(this.species.speciesId)];
+                  const natures = globalScene.gameData.getNaturesForAttr(starterDexEntry.natureAttr);
                   ui.setModeWithoutClear(UiMode.OPTION_SELECT, {
                     options: natures
                       .map((n: Nature, _i: number) => {
@@ -2829,7 +2831,8 @@ export class PokedexPageUiHandler extends MessageUiHandler {
 
     this.statsContainer.setVisible(true);
 
-    this.statsContainer.updateIvs(this.speciesStarterDexEntry.ivs);
+    const ivs = globalScene.gameData.dexData[this.getStarterSpeciesId(this.species.speciesId)].ivs;
+    this.statsContainer.updateIvs(ivs);
   }
 
   clearText() {


### PR DESCRIPTION
In our data, evolutions have their own stored ivs and natures. These are unlocked by catching them in the wild, or evolving a starter with those ivs and natures---in other words, they are completely irrelevant, see #6311 .

Making sure that the dex doesn't show inconsistent ivs and natures for evolutions can be done without refactoring save data. This is arguably a visual bug fix.