### PR TITLE
Restricted party options for fainted mons in hardcore

### DIFF
--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -6,6 +6,7 @@ import { SpeciesFormChangeItemTrigger } from "#data/form-change-triggers";
 import { Gender, getGenderColor, getGenderSymbol } from "#data/gender";
 import { Button } from "#enums/buttons";
 import { ChallengeType } from "#enums/challenge-type";
+import { Challenges } from "#enums/challenges";
 import { Command } from "#enums/command";
 import { FormChangeItem } from "#enums/form-change-item";
 import { MoveId } from "#enums/move-id";
@@ -1427,6 +1428,11 @@ export class PartyUiHandler extends MessageUiHandler {
       this.eraseOptionsCursor();
     }
 
+    if (pokemon.isFainted() && globalScene.gameMode.hasChallenge(Challenges.HARDCORE)) {
+      this.updateOptionsHardcore();
+      return;
+    }
+
     switch (this.partyUiMode) {
       case PartyUiMode.MOVE_MODIFIER:
         this.updateOptionsWithMoveModifierMode(pokemon);
@@ -1523,6 +1529,34 @@ export class PartyUiHandler extends MessageUiHandler {
     // Generic, these are applied to all Modes
     this.addCancelAndScrollOptions();
 
+    this.updateOptionsWindow();
+  }
+
+  updateOptionsHardcore(): void {
+    const pokemon = globalScene.getPlayerParty()[this.cursor];
+
+    switch (this.partyUiMode) {
+      case PartyUiMode.MODIFIER_TRANSFER:
+        if (!this.transferMode) {
+          this.updateOptionsWithModifierTransferMode(pokemon);
+        } else {
+          this.options.push(PartyOption.TRANSFER);
+          this.addCommonOptions(pokemon);
+        }
+        break;
+      case PartyUiMode.DISCARD:
+        this.updateOptionsWithModifierTransferMode(pokemon);
+        break;
+      case PartyUiMode.SWITCH:
+        this.options.push(PartyOption.RELEASE);
+        break;
+      case PartyUiMode.RELEASE:
+        this.options.push(PartyOption.RELEASE);
+        break;
+    }
+
+    // Generic, these are applied to all Modes
+    this.addCancelAndScrollOptions();
     this.updateOptionsWindow();
   }
 


### PR DESCRIPTION
Fainted pokemon in hardcore mode cannot be revived, but we keep them around so their items can be transfered to other party members.

However, other party options can still be selected, which makes for some odd cases. For example, it is possible to give candies to a fainted pokemon, have it level up and learn new moves.

This PR removes all options except for Release and Item Transfer/Discard.

The video exemplifies common cases. Edge instances (e.g. switching with U-Turn or selecting a fainted mon in MEs) have not been tested directly yet, but should follow the same logic.


https://github.com/user-attachments/assets/7583505a-f531-4f5b-a1b0-02400d3f247b

