### PR TITLE
[Bug] [UI/UX] [Beta] Fix visibility of egg moves in ssui

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1171,17 +1171,17 @@ export class StarterSelectUiHandler extends MessageUiHandler {
         this.setUpgradeAnimation(icon, species);
       });
 
-      if (globalScene.gameMode.hasChallenge(Challenges.FRESH_START)) {
-        for (const container of this.pokemonEggMoveContainers) {
-          container.setVisible(false);
-        }
-        this.eggMovesLabel.setVisible(false);
-        // This is not enough, we need individual checks in setStarterSpecies too! :)
-        this.pokemonPassiveDisabledIcon.setVisible(false);
-        this.pokemonPassiveLabelText.setVisible(false);
-        this.pokemonPassiveLockedIcon.setVisible(false);
-        this.pokemonPassiveText.setVisible(false);
+      const notFreshStart = !globalScene.gameMode.hasChallenge(Challenges.FRESH_START);
+
+      for (const container of this.pokemonEggMoveContainers) {
+        container.setVisible(notFreshStart);
       }
+      this.eggMovesLabel.setVisible(notFreshStart);
+      // This is not enough, we need individual checks in setStarterSpecies too! :)
+      this.pokemonPassiveDisabledIcon.setVisible(notFreshStart);
+      this.pokemonPassiveLabelText.setVisible(notFreshStart);
+      this.pokemonPassiveLockedIcon.setVisible(notFreshStart);
+      this.pokemonPassiveText.setVisible(notFreshStart);
 
       this.resetFilters();
       this.updateStarters();


### PR DESCRIPTION
## What are the changes the user will see?
Backing out of starter select from a fresh start challenge mode and then entering normal mode will no longer hide the egg move containers

## Why am I making these changes?
Minor visual bug

## What are the changes from a developer perspective?
Set the visibility value based on the challenge inside the show method instead of only hiding their visibility when showing in fresh start.

## Screenshots/Videos
<details><summary>Details</summary>

https://github.com/user-attachments/assets/2bcbde97-b98f-4d1a-8741-99585a2b7b01
</details>

## How to test the changes?
Open starter select UI in a challenge mode with fresh start. Close challenge mode, then open normal new game.
Ensure that the egg moves are shown.

## Checklist
- [x] **I'm using `release` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~