### PR TITLE
[Bug] Fix egg gacha 10x pull option working with just one voucher

### DIFF
--- a/src/ui/egg-gacha-ui-handler.ts
+++ b/src/ui/egg-gacha-ui-handler.ts
@@ -743,7 +743,7 @@ export class EggGachaUiHandler extends MessageUiHandler {
 
     if (!freePulls && globalScene.gameData.eggs.length + pulls > 99) {
       errorKey = "egg:tooManyEggs";
-    } else if (!freePulls && !globalScene.gameData.voucherCounts[voucherType]) {
+    } else if (!freePulls && globalScene.gameData.voucherCounts[voucherType] < vouchersConsumed) {
       errorKey = "egg:notEnoughVouchers";
     }
 


### PR DESCRIPTION
## What are the changes the user will see?
Users will no longer be able to use the 10x pull option with just 1 voucher.

## Why am I making these changes?
This is a huge exploit introduced by #5889 (sorry folks!)

## What are the changes from a developer perspective?
Added the proper check against vouchersConsumed.

## Screenshots/Videos


## How to test the changes?
Use egg gacha's 10x pull option while having only one voucher

## Checklist
- [x] **I'm using `hotfix-1.10.1` as my base branch**
- [x] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - ~~[ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~