### PR TITLE
[Bug] Fix typo in i18n key for second Berries Abound ME option

### DIFF
--- a/src/data/mystery-encounters/encounters/berries-abound-encounter.ts
+++ b/src/data/mystery-encounters/encounters/berries-abound-encounter.ts
@@ -237,7 +237,7 @@ export const BerriesAboundEncounter: MysteryEncounter = MysteryEncounterBuilder.
           const config = globalScene.currentBattle.mysteryEncounter!.enemyPartyConfigs[0];
           config.pokemonConfigs![0].tags = [BattlerTagType.MYSTERY_ENCOUNTER_POST_SUMMON];
           config.pokemonConfigs![0].mysteryEncounterBattleEffects = (pokemon: Pokemon) => {
-            queueEncounterMessage(`${namespace}:option.2.boss_enraged`);
+            queueEncounterMessage(`${namespace}:option.2.bossEnraged`);
             globalScene.phaseManager.unshiftNew(
               "StatStageChangePhase",
               pokemon.getBattlerIndex(),


### PR DESCRIPTION
## What are the changes the user will see?
Working text.

## Why am I making these changes?
The key was missed when converting i18n keys.

## What are the changes from a developer perspective?
Fixed i18n key in Berries Abound ME, second option when attempting and failing to steal the berries.

## Screenshots/Videos
<details><summary>Screenshot</summary>
<p>

<img width="1222" height="684" alt="image" src="https://github.com/user-attachments/assets/23cd2f37-c24b-4adc-9750-9c075453c3cf" />

</p>
</details> 

## How to test the changes?
Pick the second option in the Berries Abound ME with a slow/underleveled Pokémon.

## Checklist
- ~[ ] **I'm using `beta` as my base branch**~
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Have I provided screenshots/videos of the changes (if applicable)?