### PR TITLE
[Bug][Item] Items can be transfered from 6th item slot again.

### DIFF
--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -567,12 +567,9 @@ export class PartyUiHandler extends MessageUiHandler {
       return this.processTransferOption();
     }
 
-    console.log("HERE");
-
     // TODO: Revise this condition
     if (!this.transferMode) {
       this.startTransfer();
-      console.log("AND HERE");
 
       let ableToTransferText: string;
       for (let p = 0; p < globalScene.getPlayerParty().length; p++) {
@@ -788,12 +785,9 @@ export class PartyUiHandler extends MessageUiHandler {
     // If the input has been already processed we are done, otherwise move on until the correct option is found
     const pokemon = globalScene.getPlayerParty()[this.cursor];
 
-    console.log("Processing action", pokemon);
-
     // TODO: Careful about using success for the return values here. Find a better way
     // PartyOption.ALL, and options specific to the mode (held items)
     if (this.partyUiMode === PartyUiMode.MODIFIER_TRANSFER) {
-      console.log("Transfer time");
       return this.processModifierTransferModeInput(pokemon);
     }
 


### PR DESCRIPTION
## Why am I making these changes?
The function responsible for handling item transfer was checking against `option === PartyOption.TRANSFER`. However, the check was happening even if an item had not currently been selected, meaning that it caused the wrong behavior when choosing the sixth item in the list, since `PartyOption.TRANSFER` is 5.

## What are the changes from a developer perspective?
The condition now also checks that an item transfer is already underway.

## Screenshots/Videos
Fixed behavior:

https://github.com/user-attachments/assets/a579f010-8671-4455-90bc-e107f7194aaa



## How to test the changes?
I used this override:
const overrides = {
  STARTING_WAVE_OVERRIDE: 31,
  STARTING_LEVEL_OVERRIDE: 1000,
  STARTING_MONEY_OVERRIDE: 999999,
  STARTING_HELD_ITEMS_OVERRIDE: [
    {name: "BERRY", type: BerryType.SITRUS},
    {name: "BERRY", type: BerryType.LEPPA},
    {name: "BERRY", type: BerryType.GANLON},
    {name: "BERRY", type: BerryType.PETAYA},
    {name: "BERRY", type: BerryType.LUM},
    {name: "BERRY", type: BerryType.APICOT},
    {name: "BERRY", type: BerryType.ENIGMA},
    {name: "BERRY", type: BerryType.LIECHI},
  ]
} satisfies Partial<InstanceType<OverridesType>>;
