### PR TITLE
[Misc] Fix circular dep

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,3 @@
-import { pokemonEvolutions } from "#balance/pokemon-evolutions";
 import { SpeciesId } from "#enums/species-id";
 
 /** The maximum size of the player's party */
@@ -53,15 +52,6 @@ export const defaultStarterSpecies: SpeciesId[] = [
   SpeciesId.FUECOCO,
   SpeciesId.QUAXLY,
 ];
-
-/**
- * The default species and all their evolutions
- */
-export const defaultStarterSpeciesAndEvolutions: SpeciesId[] = defaultStarterSpecies.flatMap(id => {
-  const stage2ids = pokemonEvolutions[id]?.map(e => e.speciesId) ?? [];
-  const stage3ids = stage2ids.flatMap(s2id => pokemonEvolutions[s2id]?.map(e => e.speciesId) ?? []);
-  return [id, ...stage2ids, ...stage3ids];
-});
 
 export const saveKey = "x0i2O7WRiANTqPmZ"; // Temporary; secure encryption is not yet necessary
 

--- a/src/data/balance/pokemon-evolutions.ts
+++ b/src/data/balance/pokemon-evolutions.ts
@@ -1,3 +1,4 @@
+import { defaultStarterSpecies } from "#app/constants";
 import { globalScene } from "#app/global-scene";
 import { speciesStarterCosts } from "#balance/starters";
 import { allMoves } from "#data/data-lists";
@@ -1882,6 +1883,15 @@ export function initPokemonPrevolutions(): void {
 
 // TODO: This may cause funny business for double starters such as Pichu/Pikachu
 export const pokemonStarters: PokemonPrevolutions = {};
+
+/**
+ * The default species and all their evolutions
+ */
+export const defaultStarterSpeciesAndEvolutions: SpeciesId[] = defaultStarterSpecies.flatMap(id => {
+  const stage2ids = pokemonEvolutions[id]?.map(e => e.speciesId) ?? [];
+  const stage3ids = stage2ids.flatMap(s2id => pokemonEvolutions[s2id]?.map(e => e.speciesId) ?? []);
+  return [id, ...stage2ids, ...stage3ids];
+});
 
 export function initPokemonStarters(): void {
   const starterKeys = Object.keys(pokemonPrevolutions);

--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -1,6 +1,6 @@
 import type { FixedBattleConfig } from "#app/battle";
 import { getRandomTrainerFunc } from "#app/battle";
-import { defaultStarterSpeciesAndEvolutions } from "#app/constants";
+import { defaultStarterSpeciesAndEvolutions } from "#balance/pokemon-evolutions";
 import { speciesStarterCosts } from "#balance/starters";
 import type { PokemonSpecies } from "#data/pokemon-species";
 import { AbilityAttr } from "#enums/ability-attr";


### PR DESCRIPTION
## What are the changes the user will see?
None

## Why am I making these changes?
Can't have circular deps.

## What are the changes from a developer perspective?
Moved `defaultStarterSpeciesAndEvolutions` to `src/data/balance/pokemon-evolutilns.ts`

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?
`pnpm depcruise`

## Checklist
- [x] **I'm using `hotfix-1.10.2` as my base branch**
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - ~~[ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~