### PR TITLE
[Bug] Fix ssui passives

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -2095,27 +2095,21 @@ export class StarterSelectUiHandler extends MessageUiHandler {
           const passiveAttr = starterData.passiveAttr;
           if (passiveAttr & PassiveAttr.UNLOCKED) {
             // this is for enabling and disabling the passive
-            if (!(passiveAttr & PassiveAttr.ENABLED)) {
-              options.push({
-                label: i18next.t("starterSelectUiHandler:enablePassive"),
-                handler: () => {
-                  starterData.passiveAttr |= PassiveAttr.ENABLED;
-                  ui.setMode(UiMode.STARTER_SELECT);
-                  this.setSpeciesDetails(this.lastSpecies);
-                  return true;
-                },
-              });
-            } else {
-              options.push({
-                label: i18next.t("starterSelectUiHandler:disablePassive"),
-                handler: () => {
-                  starterData.passiveAttr ^= PassiveAttr.ENABLED;
-                  ui.setMode(UiMode.STARTER_SELECT);
-                  this.setSpeciesDetails(this.lastSpecies);
-                  return true;
-                },
-              });
-            }
+            const label = i18next.t(
+              passiveAttr & PassiveAttr.ENABLED
+                ? "starterSelectUiHandler:disablePassive"
+                : "starterSelectUiHandler:enablePassive",
+            );
+            options.push({
+              label,
+              handler: () => {
+                starterData.passiveAttr ^= PassiveAttr.ENABLED;
+                persistentStarterData.passiveAttr ^= PassiveAttr.ENABLED;
+                ui.setMode(UiMode.STARTER_SELECT);
+                this.setSpeciesDetails(this.lastSpecies);
+                return true;
+              },
+            });
           }
           // if container.favorite is false, show the favorite option
           const isFavorite = starterAttributes?.favorite ?? false;


### PR DESCRIPTION
## What are the changes the user will see?
Enabling / Disabling a passive from starter select will once again 

## Why am I making these changes?
Bugfix

## What are the changes from a developer perspective?
Before:
```ts
const passiveAttr = starterData.passiveAttr;
if (passiveAttr & PassiveAttr.UNLOCKED) {
  // this is for enabling and disabling the passive
  if (!(passiveAttr & PassiveAttr.ENABLED)) {
    options.push({
      label: i18next.t("starterSelectUiHandler:enablePassive"),
      handler: () => {
        starterData.passiveAttr |= PassiveAttr.ENABLED;
        ui.setMode(UiMode.STARTER_SELECT);
        this.setSpeciesDetails(this.lastSpecies);
        return true;
      },
    });
  } else {
    options.push({
      label: i18next.t("starterSelectUiHandler:disablePassive"),
      handler: () => {
        starterData.passiveAttr ^= PassiveAttr.ENABLED;
        ui.setMode(UiMode.STARTER_SELECT);
        this.setSpeciesDetails(this.lastSpecies);
        return true;
      },
    });
  }
}
```
After
```ts
const passiveAttr = starterData.passiveAttr;
if (passiveAttr & PassiveAttr.UNLOCKED) {
  // this is for enabling and disabling the passive
  const label = i18next.t(
    passiveAttr & PassiveAttr.ENABLED
      ? "starterSelectUiHandler:disablePassive"
      : "starterSelectUiHandler:enablePassive",
  );
  options.push({
    label,
    handler: () => {
      starterData.passiveAttr ^= PassiveAttr.ENABLED;
      persistentStarterData.passiveAttr ^= PassiveAttr.ENABLED;
      ui.setMode(UiMode.STARTER_SELECT);
      this.setSpeciesDetails(this.lastSpecies);
      return true;
    },
  });
}
```


## Screenshots/Videos
<details><summary>Disabling an enabled passive</summary>

https://github.com/user-attachments/assets/457a908e-d932-41a7-8850-e24b522d0fed
</details> 
<details><summary>Enabling a disabled passive</summary>

https://github.com/user-attachments/assets/1efdb361-9b87-4d7e-a47e-8b5f544315e3
</details> 

## How to test the changes?
Go into starter select with a passive that can be easily observed, toggle a starter's passive and add it to your team. Start the run, and observe whether the passive is active.

## Checklist
- [x] **I'm using `hotfix-1.10.2` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~