### PR TITLE
[Bug] [Move] Fix pollen puff

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -2325,6 +2325,13 @@ export class HealOnAllyAttr extends HealAttr {
     // Don't trigger if not targeting an ally
     return target === user.getAlly() && super.canApply(user, target, _move, _args);
   }
+
+  override apply(user: Pokemon, target: Pokemon, _move: Move, _args: any[]): boolean {
+    if (user.isOpponent(target)) {
+      return false;
+    }
+    return super.apply(user, target, _move, _args);
+  }
 }
 
 /**

--- a/test/moves/pollen-puff.test.ts
+++ b/test/moves/pollen-puff.test.ts
@@ -61,4 +61,16 @@ describe("Moves - Pollen Puff", () => {
 
     expect(target.battleData.hitCount).toBe(2);
   });
+
+  // Regression test for pollen puff healing an enemy after dealing damage
+  it("should not heal an enemy after dealing damage", async () => {
+    await game.classicMode.startBattle([SpeciesId.FEEBAS]);
+    const target = game.field.getEnemyPokemon();
+    game.move.use(MoveId.POLLEN_PUFF);
+
+    await game.phaseInterceptor.to("BerryPhase", false);
+
+    expect(target.hp).not.toBe(target.getMaxHp());
+    expect(game.phaseInterceptor.log).not.toContain("PokemonHealPhase");
+  });
 });

--- a/test/test-utils/phase-interceptor.ts
+++ b/test/test-utils/phase-interceptor.ts
@@ -37,6 +37,7 @@ import { NewBiomeEncounterPhase } from "#phases/new-biome-encounter-phase";
 import { NextEncounterPhase } from "#phases/next-encounter-phase";
 import { PartyExpPhase } from "#phases/party-exp-phase";
 import { PartyHealPhase } from "#phases/party-heal-phase";
+import { PokemonHealPhase } from "#phases/pokemon-heal-phase";
 import { PokemonTransformPhase } from "#phases/pokemon-transform-phase";
 import { PositionalTagPhase } from "#phases/positional-tag-phase";
 import { PostGameOverPhase } from "#phases/post-game-over-phase";
@@ -181,6 +182,7 @@ export class PhaseInterceptor {
     UnlockPhase,
     PostGameOverPhase,
     RevivalBlessingPhase,
+    PokemonHealPhase,
   ];
 
   private endBySetMode = [


### PR DESCRIPTION
## What are the changes the user will see?
Pollen Puff will no longer heal an enemy after dealing damage

## Why am I making these changes?
Bugfix

## What are the changes from a developer perspective?
Added an `apply` override to pollen puff's move attribute that will check if the target is an enemy before allowing the attribute to apply its effects.

## Screenshots/Videos
<details><summary>Post bugfix</summary>

https://github.com/user-attachments/assets/8e2b8e89-2248-4bb3-a4bf-7b85e7189924
</details>

## How to test the changes?
```
const overrides = {
  MOVESET_OVERRIDE: [MoveId.POLLEN_PUFF],
  ENEMY_LEVEL_OVERRIDE: 10,
  ENEMY_MOVESET_OVERRIDE: [MoveId.SPLASH],
} satisfies Partial<InstanceType<OverridesType>>;
```

Select pollen puff against the enemy

## Checklist
- [x] **I'm using `hotfix-1.10.2` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~
