### PR TITLE
[Test] Fix leftovers test not running heal phase

### DIFF
--- a/test/items/leftovers.test.ts
+++ b/test/items/leftovers.test.ts
@@ -2,7 +2,6 @@ import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { DamageAnimPhase } from "#phases/damage-anim-phase";
-import { TurnEndPhase } from "#phases/turn-end-phase";
 import { GameManager } from "#test/test-utils/game-manager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -54,7 +53,7 @@ describe("Items - Leftovers", () => {
     const leadHpAfterDamage = leadPokemon.hp;
 
     // Check if leftovers heal us
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("PokemonHealPhase");
     expect(leadPokemon.hp).toBeGreaterThan(leadHpAfterDamage);
   });
 });


### PR DESCRIPTION
## What are the changes from a developer perspective?
After `PokemonHealPhase` was added to the phase manager's internal array, it was not being automatically run with `.to(TurnEndPhase)`. Changed to instead go to and run the heal phase itself

## How to test the changes?
`pnpm test:silent leftovers`

## Checklist
- [x] **I'm using `hotfix-1.10.2` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - `item-manage-button.test.ts` is flaky, this is unrelated to the PR
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?
