### PR TITLE
[Bug] Fixed delayed attacks pushing to move history twice on charging turn

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -3278,7 +3278,6 @@ export class DelayedAttackAttr extends OverrideMoveEffectAttr {
     )
 
     user.pushMoveHistory({move: move.id, targets: [target.getBattlerIndex()], result: MoveResult.OTHER, useMode, turn: globalScene.currentBattle.turn})
-    user.pushMoveHistory({move: move.id, targets: [target.getBattlerIndex()], result: MoveResult.OTHER, useMode, turn: globalScene.currentBattle.turn})
     // Queue up an attack on the given slot.
     globalScene.arena.positionalTagManager.addTag<PositionalTagType.DELAYED_ATTACK>({
       tagType: PositionalTagType.DELAYED_ATTACK,


### PR DESCRIPTION
## What are the changes the user will see?
Not much, but this does reduce save size growth from having more useless entries.

## Why am I making these changes?
very minor oopsie

## What are the changes from a developer perspective?
Fixed duplicate `pushMoveHistory` call

## Screenshots/Videos
N/A

## How to test the changes?
don't?

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)