### PR TITLE
[UI/UX][Bug] Saving preferences when leaving ssui

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -4612,6 +4612,8 @@ export class StarterSelectUiHandler extends MessageUiHandler {
   clear(): void {
     super.clear();
 
+    saveStarterPreferences(this.originalStarterPreferences);
+
     this.clearStarterPreferences();
     this.cursor = -1;
     this.hideInstructions();


### PR DESCRIPTION
During the ssui changes for fresh start, the function that saves starter preferences was moved to `setSpeciesDetails()`. However, this function is not always called when changing preferences, particularly not when leaving the screen, meaning that some preferences may end up not being saved.

Note anyway that `setSpeciesDetails()` is called every time the cursor moves to a new pokémon, so the missing preferences are in any case restricted to the last selected mon.