### PR TITLE
[bug/i18n] Fix stealth rock message

### DIFF
--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -937,7 +937,7 @@ class StealthRockTag extends DamagingTrapTag {
 
   protected override getTriggerMessage(pokemon: Pokemon): string {
     return i18next.t("arenaTag:stealthRockActivateTrap", {
-      pokemonName: getPokemonNameWithAffix(pokemon),
+      pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
     });
   }
 

--- a/test/moves/entry-hazards.test.ts
+++ b/test/moves/entry-hazards.test.ts
@@ -200,7 +200,7 @@ describe("Moves - Entry Hazards", () => {
       expect(enemy).toHaveTakenDamage(enemy.getMaxHp() * 0.125 * multi);
       expect(game.textInterceptor.logs).toContain(
         i18next.t("arenaTag:stealthRockActivateTrap", {
-          pokemonName: getPokemonNameWithAffix(enemy),
+          pokemonNameWithAffix: getPokemonNameWithAffix(enemy),
         }),
       );
     });


### PR DESCRIPTION
## What are the changes the user will see?

stealth rock activation message will show correctly

## Why am I making these changes?

[Discord report](https://discord.com/channels/1125469663833370665/1125894949020381285/1408931173710692463)

## What are the changes from a developer perspective?

replaced `pokemonName` with `pokemonNameWithAffix`

## Screenshots/Videos

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/be6fc697-b83b-4f1a-bab7-4cee2e573fc0" />

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist
- [x] **I'm using `hotfix-1.10.2` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?
