### PR TITLE
[Bug] Fix nicknames not showing up in battle

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -454,7 +454,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   getNameToRender(useIllusion = true) {
     const illusion = this.summonData.illusion;
     const name = useIllusion ? (illusion?.name ?? this.name) : this.name;
-    const nickname: string | undefined = useIllusion ? illusion?.nickname : this.nickname;
+    const nickname: string | undefined = useIllusion ? (illusion?.nickname ?? this.nickname) : this.nickname;
     try {
       if (nickname) {
         return decodeURIComponent(escape(atob(nickname))); // TODO: Remove `atob` and `escape`... eventually...


### PR DESCRIPTION
## What are the changes the user will see?
Players will now see the nicknames of their and their enemy's pokemon

## Why am I making these changes?
Fixes bug

## What are the changes from a developer perspective?
Fixed the nullish coalescing in the case where `useIllusion` is true in `pokemon#getNameToRender`

## Screenshots/Videos
<details><summary>Details</summary>

https://github.com/user-attachments/assets/828b6ffb-1415-410c-9e27-e72cc28d205b
</details>

## How to test the changes?
```ts
const overrides = {
  MYSTERY_ENCOUNTER_OVERRIDE: MysteryEncounterType.THE_EXPERT_POKEMON_BREEDER,
  MYSTERY_ENCOUNTER_RATE_OVERRIDE: 256,
  STARTING_BIOME_OVERRIDE: BiomeId.SPACE,
  STARTING_LEVEL_OVERRIDE: 100,
  STARTING_WAVE_OVERRIDE: 54,
} satisfies Partial<InstanceType<OverridesType>>;
```

Expert pokemon breeder has pokemon known to use nicknames, so this is the easiest way to test in a way that doesn't conflate the issue with nicknames potentially not being saved properly.

## Checklist
- [x] **I'm using `hotfix-1.10.2` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - ~~[ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~