### PR TITLE
[Bug/i18n] Fix unpause evolution option in party ui

### DIFF
--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -1610,7 +1610,7 @@ export class PartyUiHandler extends MessageUiHandler {
               const modifier = formChangeItemModifiers[option - PartyOption.FORM_CHANGE_ITEM];
               optionName = `${modifier.active ? i18next.t("partyUiHandler:deactivate") : i18next.t("partyUiHandler:activate")} ${modifier.type.name}`;
             } else if (option === PartyOption.UNPAUSE_EVOLUTION) {
-              optionName = `${pokemon.pauseEvolutions ? i18next.t("partyUiHandler:unpausedEvolutions") : i18next.t("partyUiHandler:pauseEvolution")}`;
+              optionName = `${pokemon.pauseEvolutions ? i18next.t("partyUiHandler:unpauseEvolution") : i18next.t("partyUiHandler:pauseEvolution")}`;
             } else {
               if (this.localizedOptions.includes(option)) {
                 optionName = i18next.t(`partyUiHandler:${toCamelCase(PartyOption[option])}`);


### PR DESCRIPTION
## What are the changes the user will see?

Correctly display `unpause evolution` option locale

## Why am I making these changes?

[Discord report](https://discord.com/channels/1125469663833370665/1225619031156064317/1408943268816879686)

## What are the changes from a developer perspective?

Use the correct locales key

## Screenshots/Videos

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7d7bfb3c-8496-40e9-b0ee-b26f1ac1a2df" />

## How to test the changes?

Pause an evolution and then open the menu again

## Checklist
- [x] **I'm using `Hotfix-1.10.2` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?
