### PR TITLE
[Bug] Fix saveslot deletion

### DIFF
--- a/src/ui/save-slot-select-ui-handler.ts
+++ b/src/ui/save-slot-select-ui-handler.ts
@@ -181,7 +181,7 @@ export class SaveSlotSelectUiHandler extends MessageUiHandler {
                     ui.setOverlayMode(
                       UiMode.CONFIRM,
                       () => {
-                        globalScene.gameData.tryClearSession(cursor).then(response => {
+                        globalScene.gameData.deleteSession(cursor).then(response => {
                           if (response[0] === false) {
                             globalScene.reset(true);
                           } else {


### PR DESCRIPTION
## What are the changes the user will see?
Deleting a run will no longer freeze the game, and will also successfully delete the run

## Why am I making these changes?
Fix P1 bug.

## What are the changes from a developer perspective?
Change the call to use the `deleteSession` instead of `tryClearSession`.

## Screenshots/Videos
<details><summary>Details</summary>

https://github.com/user-attachments/assets/9904ad13-3614-4851-b00a-2886bb0f1981
</details> 

## How to test the changes?
Need rogueserver to be running and for the game to use it (change `VITE_BYPASS_LOGIN=0` in `.env.development`. Go into the load run screen, click on a run, and press delete. Ensure the game does not hang, and that the session is deleted

## Checklist
- [x] **I'm using `hotfix-1.10.2` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?