### PR TITLE
[Bug] Fix missing fusion icon

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1781,7 +1781,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @returns Whether this Pokemon is currently fused with another species.
    */
   isFusion(useIllusion = false): boolean {
-    return useIllusion ? !!this.summonData.illusion?.fusionSpecies : !!this.fusionSpecies;
+    return !!(useIllusion ? (this.summonData.illusion?.fusionSpecies ?? this.fusionSpecies) : this.fusionSpecies);
   }
 
   /**


### PR DESCRIPTION
## What are the changes the user will see?
Fusion icon will now properly display.

## Why am I making these changes?
Fixes bug

## What are the changes from a developer perspective?
Fix improper nullish coalescing in `pokemon#isFusion` (same fix as #6378).

## Screenshots/Videos
<details><summary>Post fix</summary>
<img width="1584" height="889" alt="image" src="https://github.com/user-attachments/assets/6b337a2d-c0f8-4a8a-8c02-9f63d5e80655" />
</details> 


## How to test the changes?
```ts
const overrides = {
  ENEMY_FUSION_OVERRIDE: true,
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- [x] **I'm using `hotfix-1.10.2` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?