### PR TITLE
[Hotfix] Leech Seed does not get cleared when user faints

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -1058,8 +1058,7 @@ export class SeedTag extends SerializableBattlerTag {
     // Check which opponent to restore HP to
     const source = pokemon.getOpponents().find(o => o.getBattlerIndex() === this.sourceIndex);
     if (!source) {
-      console.warn(`Failed to get source Pokemon for SeedTag lapse; id: ${this.sourceId}`);
-      return false;
+      return true;
     }
 
     const cancelled = new BooleanHolder(false);


### PR DESCRIPTION
When the leech seed user faints, the check to lapse the leech seed tag happens before the new user switches in---therefore, `source` does not exist at that time. Returning `false` causes the tag to be removed, we need to return `true` instead.

Example override to test:

const overrides = {
  STARTING_LEVEL_OVERRIDE: 1000,
  MOVESET_OVERRIDE: [MoveId.LEECH_SEED, MoveId.MEMENTO],
} satisfies Partial<InstanceType<OverridesType>>;


Not sure if there are any edge cases where we would want to return false; the tag should stick there until the seeded pokemon leaves the field anyway, or some other effects removes it.