### PR TITLE
[Dev] Allow forcing all trainer variants in trainer override

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1330,13 +1330,12 @@ export class BattleScene extends SceneBase {
       if (newBattleType === BattleType.TRAINER) {
         const trainerType =
           Overrides.RANDOM_TRAINER_OVERRIDE?.trainerType ?? this.arena.randomTrainerType(newWaveIndex);
+        const hasDouble = trainerConfigs[trainerType].hasDouble;
         let doubleTrainer = false;
         if (trainerConfigs[trainerType].doubleOnly) {
           doubleTrainer = true;
-        } else if (trainerConfigs[trainerType].hasDouble) {
-          doubleTrainer =
-            Overrides.RANDOM_TRAINER_OVERRIDE?.alwaysDouble ||
-            !randSeedInt(this.getDoubleBattleChance(newWaveIndex, playerField));
+        } else if (hasDouble) {
+          doubleTrainer = !randSeedInt(this.getDoubleBattleChance(newWaveIndex, playerField));
           // Add a check that special trainers can't be double except for tate and liza - they should use the normal double chance
           if (
             trainerConfigs[trainerType].trainerTypeDouble &&
@@ -1345,11 +1344,18 @@ export class BattleScene extends SceneBase {
             doubleTrainer = false;
           }
         }
-        const variant = doubleTrainer
-          ? TrainerVariant.DOUBLE
-          : randSeedInt(2)
-            ? TrainerVariant.FEMALE
-            : TrainerVariant.DEFAULT;
+
+        // Forcing a double battle on wave 1 causes a bug, where only one enemy is sent out, making it impossible to complete the fight without a reload
+        const overrideVariant =
+          (Overrides.RANDOM_TRAINER_OVERRIDE?.trainerVariant === TrainerVariant.DOUBLE && !hasDouble) ||
+          newWaveIndex <= 1
+            ? TrainerVariant.DEFAULT
+            : Overrides.RANDOM_TRAINER_OVERRIDE?.trainerVariant;
+
+        const variant =
+          overrideVariant ??
+          (doubleTrainer ? TrainerVariant.DOUBLE : randSeedInt(2) ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT);
+
         newTrainer = trainerData !== undefined ? trainerData.toTrainer() : new Trainer(trainerType, variant);
         this.field.add(newTrainer);
       }

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -18,6 +18,7 @@ import { Stat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
 import { TimeOfDay } from "#enums/time-of-day";
 import { TrainerType } from "#enums/trainer-type";
+import { TrainerVariant } from "#enums/trainer-variant";
 import { Unlockables } from "#enums/unlockables";
 import { VariantTier } from "#enums/variant-tier";
 import { WeatherType } from "#enums/weather-type";
@@ -311,8 +312,8 @@ export type BattleStyle = "double" | "single" | "even-doubles" | "odd-doubles";
 export type RandomTrainerOverride = {
   /** The Type of trainer to force */
   trainerType: Exclude<TrainerType, TrainerType.UNKNOWN>;
-  /* If the selected trainer type has a double version, it will always use its double version. */
-  alwaysDouble?: boolean;
+  /** The variant of trainer to force (DEFAULT, FEMALE, or DOUBLE if available) */
+  trainerVariant?: TrainerVariant;
 };
 
 /** The type of the {@linkcode DefaultOverrides} class */

--- a/test/moves/whirlwind.test.ts
+++ b/test/moves/whirlwind.test.ts
@@ -10,6 +10,7 @@ import { PokemonType } from "#enums/pokemon-type";
 import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
 import { TrainerType } from "#enums/trainer-type";
+import { TrainerVariant } from "#enums/trainer-variant";
 import { GameManager } from "#test/test-utils/game-manager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -193,7 +194,7 @@ describe("Moves - Whirlwind", () => {
       .battleType(BattleType.TRAINER)
       .randomTrainer({
         trainerType: TrainerType.BREEDER,
-        alwaysDouble: true,
+        trainerVariant: TrainerVariant.DOUBLE,
       })
       .enemyMoveset([MoveId.SPLASH, MoveId.LUNAR_DANCE])
       .moveset([MoveId.WHIRLWIND, MoveId.SPLASH]);


### PR DESCRIPTION
## What are the changes the user will see?

hopefully none

## Why am I making these changes?

to make it possible to aslo force Female/Male trainers insdead of just being able to force double

## What are the changes from a developer perspective?

- changed `alwaysDouble` to `trainerVariant` in `RANDOM_TRAINER_OVERRIDE`.
- adjusted battle scene `newBattle`, to work with the change

- fixed a bug when forcing a double battle on wave 1 would lead to only one pokemon being sent out, making it impossible to beat the wave without reloading.

## Screenshots/Videos


## How to test the changes?

```ts
const overrides = {
  BATTLE_TYPE_OVERRIDE: BattleType.TRAINER,
  RANDOM_TRAINER_OVERRIDE: {
    trainerType: TrainerType.VETERAN,
    trainerVariant: TrainerVariant.FEMALE,
  },
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?