### PR TITLE
[Bug] Fix speedup/slowdown buttons not working properly

### DIFF
--- a/src/ui-inputs.ts
+++ b/src/ui-inputs.ts
@@ -13,7 +13,7 @@ import { SettingsGamepadUiHandler } from "#ui/settings-gamepad-ui-handler";
 import { SettingsKeyboardUiHandler } from "#ui/settings-keyboard-ui-handler";
 import { SettingsUiHandler } from "#ui/settings-ui-handler";
 import { StarterSelectUiHandler } from "#ui/starter-select-ui-handler";
-import type Phaser from "phaser";
+import Phaser from "phaser";
 
 type ActionKeys = Record<Button, () => void>;
 
@@ -224,25 +224,26 @@ export class UiInputs {
 
   buttonSpeedChange(up = true): void {
     const settingGameSpeed = settingIndex(SettingKeys.Game_Speed);
+    const settingOptions = Setting[settingGameSpeed].options;
+    let currentSetting = settingOptions.findIndex(item => item.value === globalScene.gameSpeed.toString());
+    // if current setting is -1, then the current game speed is not a valid option, so default to index 5 (3x)
+    if (currentSetting === -1) {
+      currentSetting = 5;
+    }
+    let direction: number;
     if (up && globalScene.gameSpeed < 5) {
-      globalScene.gameData.saveSetting(
-        SettingKeys.Game_Speed,
-        Setting[settingGameSpeed].options.findIndex(item => item.label === `${globalScene.gameSpeed}x`) + 1,
-      );
-      if (globalScene.ui?.getMode() === UiMode.SETTINGS) {
-        (globalScene.ui.getHandler() as SettingsUiHandler).show([]);
-      }
+      direction = 1;
     } else if (!up && globalScene.gameSpeed > 1) {
-      globalScene.gameData.saveSetting(
-        SettingKeys.Game_Speed,
-        Math.max(
-          Setting[settingGameSpeed].options.findIndex(item => item.label === `${globalScene.gameSpeed}x`) - 1,
-          0,
-        ),
-      );
-      if (globalScene.ui?.getMode() === UiMode.SETTINGS) {
-        (globalScene.ui.getHandler() as SettingsUiHandler).show([]);
-      }
+      direction = -1;
+    } else {
+      return;
+    }
+    globalScene.gameData.saveSetting(
+      SettingKeys.Game_Speed,
+      Phaser.Math.Clamp(currentSetting + direction, 0, settingOptions.length - 1),
+    );
+    if (globalScene.ui?.getMode() === UiMode.SETTINGS) {
+      (globalScene.ui.getHandler() as SettingsUiHandler).show([]);
     }
   }
 }


### PR DESCRIPTION
## What are the changes the user will see?
The speedup and speed down buttons will now properly speed up / slow down the game.
Notably, the speedup button no longer sets the speed to 1x

## Why am I making these changes?
Bugfix

## What are the changes from a developer perspective?
Refactored `buttonSpeedChange`:
- No longer computes an i18nkey to determine setting to change to.
- Reduces code duplication
- General cleanup

## Screenshots/Videos
<details><summary>After the bugfix</summary>

https://github.com/user-attachments/assets/fe2346fa-01af-4682-924b-29cd1afa51dc
</details> 

## How to test the changes?
Go into game, look at settings. Press page up / page down. See the value change.

## Checklist
- [x] **I'm using `hotfix-1.10.3` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?