### PR TITLE
[Bug] [Sprite] Fix third type icon missing texture

### DIFF
--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -36,7 +36,7 @@ export class EnemyBattleInfo extends BattleInfo {
   override constructTypeIcons(): void {
     this.type1Icon = globalScene.add.sprite(-15, -15.5, "pbinfo_enemy_type1").setName("icon_type_1").setOrigin(0);
     this.type2Icon = globalScene.add.sprite(-15, -2.5, "pbinfo_enemy_type2").setName("icon_type_2").setOrigin(0);
-    this.type3Icon = globalScene.add.sprite(0, 15.5, "pbinfo_enemy_type3").setName("icon_type_3").setOrigin(0);
+    this.type3Icon = globalScene.add.sprite(0, -15.5, "pbinfo_enemy_type").setName("icon_type_3").setOrigin(0);
     this.add([this.type1Icon, this.type2Icon, this.type3Icon]);
   }
 

--- a/src/ui/battle-info/player-battle-info.ts
+++ b/src/ui/battle-info/player-battle-info.ts
@@ -21,7 +21,7 @@ export class PlayerBattleInfo extends BattleInfo {
   override constructTypeIcons(): void {
     this.type1Icon = globalScene.add.sprite(-139, -17, "pbinfo_player_type1").setName("icon_type_1").setOrigin(0);
     this.type2Icon = globalScene.add.sprite(-139, -1, "pbinfo_player_type2").setName("icon_type_2").setOrigin(0);
-    this.type3Icon = globalScene.add.sprite(-154, -17, "pbinfo_player_type3").setName("icon_type_3").setOrigin(0);
+    this.type3Icon = globalScene.add.sprite(-154, -17, "pbinfo_player_type").setName("icon_type_3").setOrigin(0);
     this.add([this.type1Icon, this.type2Icon, this.type3Icon]);
   }
 


### PR DESCRIPTION
## What are the changes the user will see?
When a pokemon gains a third type (usually from trick or treat / forest's curse), the type icon will no longer be missing and in the wrong position.

## Why am I making these changes?
Fixes a bug: https://discord.com/channels/1125469663833370665/1409134651120947280/1409134651120947280

## What are the changes from a developer perspective?
Adjusted the texture name used for the type icon, and fixed its placement in `enemy-battle-info-ui`

## Screenshots/Videos
<details><summary>Before</summary>

https://github.com/user-attachments/assets/e43e2811-24d0-45b9-bba3-68d91802ee71
</details> 

<details><summary>After</summary>

https://github.com/user-attachments/assets/b25a4098-4442-4c27-aa24-e023d9767c0a
</details> 

## How to test the changes?
```ts
const overrides = {
  MOVESET_OVERRIDE: MoveId.TRICK_OR_TREAT,
  ENEMY_SPECIES_OVERRIDE: SpeciesId.SPEAROW,
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- [x] **I'm using `hotfix-1.10.3` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~