### PR TITLE
[Bug] [Sprite] Fix fusion shiny party icon

### DIFF
--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -287,9 +287,6 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
       2.5,
     );
     this.splicedIcon.setVisible(pokemon.isFusion(true));
-    if (!this.splicedIcon.visible) {
-      return;
-    }
     this.splicedIcon
       .on("pointerover", () =>
         globalScene.ui.showTooltip(
@@ -323,6 +320,10 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
       .setVisible(pokemon.isShiny())
       .setTint(getVariantTint(baseVariant));
 
+    this.shinyIcon
+      .on("pointerover", () => globalScene.ui.showTooltip("", i18next.t("common:shinyOnHover") + shinyDescriptor))
+      .on("pointerout", () => globalScene.ui.hideTooltip());
+
     if (!this.shinyIcon.visible) {
       return;
     }
@@ -335,10 +336,6 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
       }
       shinyDescriptor += ")";
     }
-
-    this.shinyIcon
-      .on("pointerover", () => globalScene.ui.showTooltip("", i18next.t("common:shinyOnHover") + shinyDescriptor))
-      .on("pointerout", () => globalScene.ui.hideTooltip());
   }
 
   initInfo(pokemon: Pokemon) {

--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -2041,12 +2041,13 @@ class PartySlot extends Phaser.GameObjects.Container {
 
     if (this.pokemon.isShiny()) {
       const doubleShiny = this.pokemon.isDoubleShiny(false);
+      const largeIconTint = doubleShiny ? this.pokemon.getBaseVariant() : this.pokemon.getVariant();
 
       const shinyStar = globalScene.add
         .image(0, 0, `shiny_star_small${doubleShiny ? "_1" : ""}`)
         .setOrigin(0)
         .setPositionRelative(this.slotName, shinyIconToNameOffset.x, shinyIconToNameOffset.y)
-        .setTint(getVariantTint(this.pokemon.getBaseVariant()));
+        .setTint(getVariantTint(largeIconTint));
       slotInfoContainer.add(shinyStar);
 
       if (doubleShiny) {

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -430,20 +430,21 @@ export class SummaryUiHandler extends UiHandler {
     this.friendshipShadow.setCrop(0, 0, 16, 16 - 16 * ((this.pokemon?.friendship || 0) / 255));
 
     const doubleShiny = this.pokemon.isDoubleShiny(false);
-    const baseVariant = this.pokemon.getBaseVariant(doubleShiny);
+    const bigIconVariant = doubleShiny ? this.pokemon.getBaseVariant(doubleShiny) : this.pokemon.getVariant();
 
     this.shinyIcon.setPositionRelative(
       this.nameText,
       this.nameText.displayWidth + (this.splicedIcon.visible ? this.splicedIcon.displayWidth + 1 : 0) + 1,
       3,
     );
-    this.shinyIcon.setTexture(`shiny_star${doubleShiny ? "_1" : ""}`);
-    this.shinyIcon.setVisible(this.pokemon.isShiny(false));
-    this.shinyIcon.setTint(getVariantTint(baseVariant));
+    this.shinyIcon
+      .setTexture(`shiny_star${doubleShiny ? "_1" : ""}`)
+      .setVisible(this.pokemon.isShiny(false))
+      .setTint(getVariantTint(bigIconVariant));
     if (this.shinyIcon.visible) {
       let shinyDescriptor = "";
-      if (doubleShiny || baseVariant) {
-        shinyDescriptor = " (" + getShinyDescriptor(baseVariant);
+      if (doubleShiny || bigIconVariant) {
+        shinyDescriptor = " (" + getShinyDescriptor(bigIconVariant);
         if (doubleShiny) {
           shinyDescriptor += "/" + getShinyDescriptor(this.pokemon.fusionVariant);
         }


### PR DESCRIPTION
## What are the changes the user will see?
The icon in party and summary view for shiny fusion pokemon now shows the right color.
Also, the hover tooltip for the shiny icon and spliced will now work after fusing a pokemon while they were already on the field.

## Why am I making these changes?
Fixes a bug: https://discord.com/channels/1125469663833370665/1409186470333251584/1409186470333251584

## What are the changes from a developer perspective?

In the case that the pokemon is not a double shiny, places where the variant tint was being used now call the `getVariant` instead of `getBaseVariant`, as this returns the maximum variant between the two fusions.
Also, moved the tooltip logic to happen before the relevant methods short circuit return.

## Screenshots/Videos
<details><summary>Before</summary>
<img width="644" height="433" alt="image" src="https://github.com/user-attachments/assets/eb7660ac-03d3-4ac2-bfc5-2e79e2058742" />
<img width="508" height="783" alt="image" src="https://github.com/user-attachments/assets/0c4f3f6e-00a1-49a4-9433-ce3855bdadfc" />
</details> 
<details><summary>After</summary>
<img width="590" height="423" alt="image" src="https://github.com/user-attachments/assets/cbb877fc-4f15-47d0-9947-2b88207a8ed7" />
<img width="510" height="782" alt="image" src="https://github.com/user-attachments/assets/7e3c6016-41a0-4d01-a445-a32574c4e9da" />
</details> 

## How to test the changes?
Fuse a non-shiny pokemon (base) with a tier2 or tier3 shiny pokemon.

## Checklist
- [x] **I'm using `hotfix-1.10.3` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~