### PR TITLE
[Bug] [Ability] Fix trace's RNG

### DIFF
--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -3014,41 +3014,44 @@ export class PostSummonFormChangeAbAttr extends PostSummonAbAttr {
   }
 }
 
-/** Attempts to copy a pokemon's ability */
+/**
+ * Attempts to copy a pokemon's ability
+ *
+ * @remarks
+ * Hardcodes idiosyncrasies specific to trace, so should not be used for other abilities
+ * that might copy abilities in the future
+ * @sealed
+ */
 export class PostSummonCopyAbilityAbAttr extends PostSummonAbAttr {
   private target: Pokemon;
   private targetAbilityName: string;
 
-  override canApply({ pokemon }: AbAttrBaseParams): boolean {
-    const targets = pokemon.getOpponents();
+  override canApply({ pokemon, simulated }: AbAttrBaseParams): boolean {
+    const targets = pokemon
+      .getOpponents()
+      .filter(t => target.getAbility().isCopiable || t.getAbility().id === AbilityId.WONDER_GUARD);
     if (!targets.length) {
       return false;
     }
 
     let target: Pokemon;
-    if (targets.length > 1) {
-      globalScene.executeWithSeedOffset(() => (target = randSeedItem(targets)), globalScene.currentBattle.waveIndex);
+    // simulated call always chooses first target so as to not advance RNG
+    if (targets.length > 1 && !simulated) {
+      target = targets[randSeedInt(targets.length)];
     } else {
       target = targets[0];
     }
 
-    if (
-      !target!.getAbility().isCopiable &&
-      // Wonder Guard is normally uncopiable so has the attribute, but Trace specifically can copy it
-      !(pokemon.hasAbility(AbilityId.TRACE) && target!.getAbility().id === AbilityId.WONDER_GUARD)
-    ) {
-      return false;
-    }
-
-    this.target = target!;
-    this.targetAbilityName = allAbilities[target!.getAbility().id].name;
+    this.target = target;
+    this.targetAbilityName = allAbilities[target.getAbility().id].name;
     return true;
   }
 
   override apply({ pokemon, simulated }: AbAttrBaseParams): void {
-    if (!simulated) {
-      pokemon.setTempAbility(this.target!.getAbility());
-      setAbilityRevealed(this.target!);
+    // Protect against this somehow being called before canApply by ensuring target is defined
+    if (!simulated && this.target) {
+      pokemon.setTempAbility(this.target.getAbility());
+      setAbilityRevealed(this.target);
       pokemon.updateInfo();
     }
   }

--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -3029,7 +3029,7 @@ export class PostSummonCopyAbilityAbAttr extends PostSummonAbAttr {
   override canApply({ pokemon, simulated }: AbAttrBaseParams): boolean {
     const targets = pokemon
       .getOpponents()
-      .filter(t => target.getAbility().isCopiable || t.getAbility().id === AbilityId.WONDER_GUARD);
+      .filter(t => t.getAbility().isCopiable || t.getAbility().id === AbilityId.WONDER_GUARD);
     if (!targets.length) {
       return false;
     }


### PR DESCRIPTION
## What are the changes the user will see?
Trace will now no longer always copy the same ability when used on the same wave.
Note that the original bug report seems to be slightly incorrect. Trace will not always copy the same slot. Rather, it will copy the same slot on the same wave. Meaning, if you switch out and in, the same pokemon was always selected.

## Why am I making these changes?
Fixes #6396 
## What are the changes from a developer perspective?
<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

## Screenshots/Videos
Kinda hard to show

## How to test the changes?
Swap in / out with trace a bunch of times on the same wave

## Checklist
- [x] **I'm using `hotfix-1.10.3` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?