### PR TITLE
[Bug] [Ability] Fix berserk multi proc

### DIFF
--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -402,8 +402,14 @@ export class MoveEffectPhase extends PokemonPhase {
    * @param hitResult - The {@linkcode HitResult} of the attempted move
    * @param wasCritical - `true` if the move was a critical hit
    */
-  protected applyOnGetHitAbEffects(user: Pokemon, target: Pokemon, hitResult: HitResult, wasCritical = false): void {
-    const params = { pokemon: target, opponent: user, move: this.move, hitResult };
+  protected applyOnGetHitAbEffects(
+    user: Pokemon,
+    target: Pokemon,
+    hitResult: HitResult,
+    damage: number,
+    wasCritical = false,
+  ): void {
+    const params = { pokemon: target, opponent: user, move: this.move, hitResult, damage };
     applyAbAttrs("PostDefendAbAttr", params);
 
     if (wasCritical) {
@@ -763,12 +769,12 @@ export class MoveEffectPhase extends PokemonPhase {
 
     this.triggerMoveEffects(MoveEffectTrigger.PRE_APPLY, user, target);
 
-    const [hitResult, wasCritical] = this.applyMove(user, target, effectiveness);
+    const [hitResult, wasCritical, dmg] = this.applyMove(user, target, effectiveness);
 
     // Apply effects to the user (always) and the target (if not blocked by substitute).
     this.triggerMoveEffects(MoveEffectTrigger.POST_APPLY, user, target, firstTarget, true);
     if (!this.move.hitsSubstitute(user, target)) {
-      this.applyOnTargetEffects(user, target, hitResult, firstTarget, wasCritical);
+      this.applyOnTargetEffects(user, target, hitResult, firstTarget, dmg, wasCritical);
     }
     if (this.lastHit) {
       globalScene.triggerPokemonFormChange(user, SpeciesFormChangePostMoveTrigger);
@@ -790,7 +796,11 @@ export class MoveEffectPhase extends PokemonPhase {
    * @param effectiveness - The effectiveness of the move against the target
    * @returns The {@linkcode HitResult} of the move against the target and a boolean indicating whether the target was crit
    */
-  protected applyMoveDamage(user: Pokemon, target: Pokemon, effectiveness: TypeDamageMultiplier): [HitResult, boolean] {
+  protected applyMoveDamage(
+    user: Pokemon,
+    target: Pokemon,
+    effectiveness: TypeDamageMultiplier,
+  ): [result: HitResult, critical: boolean, damage: number] {
     const isCritical = target.getCriticalHitResult(user, this.move);
 
     /*
@@ -821,7 +831,7 @@ export class MoveEffectPhase extends PokemonPhase {
     const isOneHitKo = result === HitResult.ONE_HIT_KO;
 
     if (!dmg) {
-      return [result, false];
+      return [result, false, 0];
     }
 
     target.lapseTags(BattlerTagLapseType.HIT);
@@ -850,7 +860,7 @@ export class MoveEffectPhase extends PokemonPhase {
     }
 
     if (damage <= 0) {
-      return [result, isCritical];
+      return [result, isCritical, dmg];
     }
 
     if (user.isPlayer()) {
@@ -879,7 +889,7 @@ export class MoveEffectPhase extends PokemonPhase {
       globalScene.applyModifiers(DamageMoneyRewardModifier, true, user, new NumberHolder(damage));
     }
 
-    return [result, isCritical];
+    return [result, isCritical, dmg];
   }
 
   /**
@@ -933,11 +943,15 @@ export class MoveEffectPhase extends PokemonPhase {
    * @param target - The {@linkcode Pokemon} struck by the move
    * @param effectiveness - The effectiveness of the move against the target
    */
-  protected applyMove(user: Pokemon, target: Pokemon, effectiveness: TypeDamageMultiplier): [HitResult, boolean] {
+  protected applyMove(
+    user: Pokemon,
+    target: Pokemon,
+    effectiveness: TypeDamageMultiplier,
+  ): [HitResult, critical: boolean, damage: number] {
     const moveCategory = user.getMoveCategory(target, this.move);
 
     if (moveCategory === MoveCategory.STATUS) {
-      return [HitResult.STATUS, false];
+      return [HitResult.STATUS, false, 0];
     }
 
     const result = this.applyMoveDamage(user, target, effectiveness);
@@ -967,6 +981,7 @@ export class MoveEffectPhase extends PokemonPhase {
     target: Pokemon,
     hitResult: HitResult,
     firstTarget: boolean,
+    damage: number,
     wasCritical = false,
   ): void {
     /** Does {@linkcode hitResult} indicate that damage was dealt to the target? */
@@ -979,8 +994,8 @@ export class MoveEffectPhase extends PokemonPhase {
 
     this.triggerMoveEffects(MoveEffectTrigger.POST_APPLY, user, target, firstTarget, false);
     this.applyHeldItemFlinchCheck(user, target, dealsDamage);
-    this.applyOnGetHitAbEffects(user, target, hitResult, wasCritical);
-    applyAbAttrs("PostAttackAbAttr", { pokemon: user, opponent: target, move: this.move, hitResult });
+    this.applyOnGetHitAbEffects(user, target, hitResult, damage, wasCritical);
+    applyAbAttrs("PostAttackAbAttr", { pokemon: user, opponent: target, move: this.move, hitResult, damage: damage });
 
     // We assume only enemy Pokemon are able to have the EnemyAttackStatusEffectChanceModifier from tokens
     if (!user.isPlayer() && this.move.is("AttackMove")) {

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -400,6 +400,7 @@ export class MoveEffectPhase extends PokemonPhase {
    * @param user - The {@linkcode Pokemon} using this phase's invoked move
    * @param target - {@linkcode Pokemon} the current target of this phase's invoked move
    * @param hitResult - The {@linkcode HitResult} of the attempted move
+   * @param damage - The amount of damage dealt to the target in the interaction
    * @param wasCritical - `true` if the move was a critical hit
    */
   protected applyOnGetHitAbEffects(
@@ -794,7 +795,7 @@ export class MoveEffectPhase extends PokemonPhase {
    * @param user - The {@linkcode Pokemon} using this phase's invoked move
    * @param target - The {@linkcode Pokemon} targeted by the move
    * @param effectiveness - The effectiveness of the move against the target
-   * @returns The {@linkcode HitResult} of the move against the target and a boolean indicating whether the target was crit
+   * @returns The {@linkcode HitResult} of the move against the target, a boolean indicating whether the target was crit, and the amount of damage dealt
    */
   protected applyMoveDamage(
     user: Pokemon,
@@ -942,6 +943,7 @@ export class MoveEffectPhase extends PokemonPhase {
    * @param user - The {@linkcode Pokemon} using this phase's invoked move
    * @param target - The {@linkcode Pokemon} struck by the move
    * @param effectiveness - The effectiveness of the move against the target
+   * @returns The {@linkcode HitResult} of the move against the target, a boolean indicating whether the target was crit, and the amount of damage dealt
    */
   protected applyMove(
     user: Pokemon,
@@ -974,6 +976,7 @@ export class MoveEffectPhase extends PokemonPhase {
    * @param target - The {@linkcode Pokemon} targeted by the move
    * @param hitResult - The {@linkcode HitResult} obtained from applying the move
    * @param firstTarget - `true` if the target is the first Pokemon hit by the attack
+   * @param damage - The amount of damage dealt to the target in the interaction
    * @param wasCritical - `true` if the move was a critical hit
    */
   protected applyOnTargetEffects(

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -860,7 +860,7 @@ export class MoveEffectPhase extends PokemonPhase {
     }
 
     if (damage <= 0) {
-      return [result, isCritical, dmg];
+      return [result, isCritical, damage];
     }
 
     if (user.isPlayer()) {
@@ -889,7 +889,7 @@ export class MoveEffectPhase extends PokemonPhase {
       globalScene.applyModifiers(DamageMoneyRewardModifier, true, user, new NumberHolder(damage));
     }
 
-    return [result, isCritical, dmg];
+    return [result, isCritical, damage];
   }
 
   /**


### PR DESCRIPTION
## What are the changes the user will see?
Abilities that have an activation gated by dropping below some HP threshold (anger shell, berserk, etc), will no longer sometimes trigger multiple times when hit by a multi hit move that drops them below half hp (including parental bond / multi-lens).

## Why am I making these changes?
Fixes #6364 

## What are the changes from a developer perspective?
Added a new parameter to `PostMoveInteractionAbAttrParams` that carries the amount of damage dealt in the interaction.
Then, adds tracking for this information to move effect phase.

Previously, the code was checking the last attack received, and then looking at its damage, which clearly did not always work.

## Screenshots/Videos
<details><summary>Details</summary>

https://github.com/user-attachments/assets/ff345c7a-dfbc-4a49-b604-54559d441925
</details> 

## How to test the changes?
```ts
const overrides = {
  ABILITY_OVERRIDE: AbilityId.PARENTAL_BOND,
  MOVESET_OVERRIDE: MoveId.EMBER,
  ENEMY_MOVESET_OVERRIDE: [MoveId.SPLASH],
  ENEMY_SPECIES_OVERRIDE: SpeciesId.GLOOM,
  ENEMY_LEVEL_OVERRIDE: 5,
  ENEMY_ABILITY_OVERRIDE: AbilityId.BERSERK,
} satisfies Partial<InstanceType<OverridesType>>;
```

Use this set of overrides, and choose charmander WITHOUT its passive or a boosted nature. This will ensure that the first hit from parental bond drops the target below half hp.

## Checklist
- [x] **I'm using `hotfix-1.10.3` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?
