### PR TITLE
[Test] Made test workflow run all shards when debug mode is set

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,7 @@ jobs:
     name: Run Tests
     needs: check-path-change-filter
     strategy:
+      fail-fast: ${{ !runner.debug }} # don't stop on failed shards when debugging
       matrix:
         shard: [1, 2, 3, 4, 5]
     uses: ./.github/workflows/test-shard-template.yml


### PR DESCRIPTION
## What are the changes the user will see?
No

## Why am I making these changes?
Good for diagnosing stuff
## What are the changes from a developer perspective?
Added 1 loc to the tests workflow that disables `fail-fast` on debug mode

## Screenshots/Videos
no
## How to test the changes?
fail some tests?
## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
