### PR TITLE
[Bug] Fix oversight where mons aren't guaranteed damaging moves if none are STAB

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3243,6 +3243,18 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         rand -= stabMovePool[index++][1];
       }
       this.moveset.push(new PokemonMove(stabMovePool[index][0]));
+    } else {
+      // If there are no damaging STAB moves, just force a random damaging move
+      const attackMovePool = baseWeights.filter(m => allMoves[m[0]].category !== MoveCategory.STATUS);
+      if (attackMovePool.length) {
+        const totalWeight = attackMovePool.reduce((v, m) => v + m[1], 0);
+        let rand = randSeedInt(totalWeight);
+        let index = 0;
+        while (rand > attackMovePool[index][1]) {
+          rand -= attackMovePool[index++][1];
+        }
+        this.moveset.push(new PokemonMove(attackMovePool[index][0], 0, 0));
+      }
     }
 
     while (baseWeights.length > this.moveset.length && this.moveset.length < 4) {


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-  [Bug]: If the PR is primarily a bug fix
-  [Move]: If a move has new or changed functionality
-  [Ability]: If an ability has new or changed functionality
-  [Item]: For new or modified items
-  [Mystery]: For new or modified Mystery Encounters
-  [Test]: If the PR is primarily adding or modifying tests
-  [UI/UX]: If the PR is changing UI/UX elements
-  [Audio]: If the PR is adding or changing music/sfx
-  [Sprite]: If the PR is adding or changing sprites
-  [Balance]: If the PR is related to game balance
-  [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-  [Dev]: If the PR is primarily changing something pertaining to development (lefthook hooks, linter rules, etc.)
-  [i18n]: If the PR is primarily adding/changing locale keys or key usage (may come with an associated locales PR)
-  [Docs]: If the PR is adding or modifying documentation (such as tsdocs/code comments)
-  [GitHub]: For changes to GitHub workflows/templates/etc
-  [Misc]: If no other category fits the PR
-->

<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small!)
-->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
- Some mons encountered before they learn damaging STAB moves are now correctly guaranteed to have a damaging move
  - This includes Trainer mons that are either too low level to learn TMs or don't learn a damaging STAB TM

## Why am I making these changes?
<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->
- #5801 deleted a block of code that guarantees a damaging move for wild mons. This was because all mons were guaranteed a damaging STAB move now.
- However, there was an oversight with the way this was done. Originally, if a Trainer/boss mon didn't have a STAB damaging move in its movepool yet, it would just continue moveset gen without guaranteeing a damaging move.
- Now, the code block is restored, which is run if the `stabMovePool` is empty.
- This means every mon is now guaranteed to generate with a damaging move (if one exists in its movepool)

## What are the changes from a developer perspective?
<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->
- Stated above

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?
