### PR TITLE
[Balance][ME]Tweak weird dream do a party heal in option 1, random tera, and no longer revive pokemon in hardcore

### DIFF
--- a/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
+++ b/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
@@ -11,7 +11,7 @@ import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { Nature } from "#enums/nature";
 import { PartyMemberStrength } from "#enums/party-member-strength";
 import { PlayerGender } from "#enums/player-gender";
-import { PokemonType } from "#enums/pokemon-type";
+import { MAX_POKEMON_TYPE, PokemonType } from "#enums/pokemon-type";
 import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
 import { TrainerType } from "#enums/trainer-type";
@@ -233,7 +233,7 @@ export const WeirdDreamEncounter: MysteryEncounter = MysteryEncounterBuilder.wit
           ],
           fillRemaining: false,
         });
-        leaveEncounterWithoutBattle(true);
+        leaveEncounterWithoutBattle(false);
       })
       .build(),
   )
@@ -434,6 +434,8 @@ function getTeamTransformations(): PokemonTransformation[] {
       newAbilityIndex,
       undefined,
     );
+
+    transformation.newPokemon.teraType = randSeedInt(MAX_POKEMON_TYPE);
   }
 
   return pokemonTransformations;

--- a/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
+++ b/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
@@ -2,6 +2,7 @@ import { globalScene } from "#app/global-scene";
 import { allSpecies, modifierTypes } from "#data/data-lists";
 import { getLevelTotalExp } from "#data/exp";
 import type { PokemonSpecies } from "#data/pokemon-species";
+import { AbilityId } from "#enums/ability-id";
 import { Challenges } from "#enums/challenges";
 import { ModifierTier } from "#enums/modifier-tier";
 import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
@@ -12,6 +13,7 @@ import { PartyMemberStrength } from "#enums/party-member-strength";
 import { PlayerGender } from "#enums/player-gender";
 import { PokemonType } from "#enums/pokemon-type";
 import { SpeciesId } from "#enums/species-id";
+import { StatusEffect } from "#enums/status-effect";
 import { TrainerType } from "#enums/trainer-type";
 import type { PlayerPokemon, Pokemon } from "#field/pokemon";
 import type { PokemonHeldItemModifier } from "#modifiers/modifier";
@@ -219,6 +221,7 @@ export const WeirdDreamEncounter: MysteryEncounter = MysteryEncounterBuilder.wit
         await showEncounterText(`${namespace}:option.1.dreamComplete`);
 
         await doNewTeamPostProcess(transformations);
+        globalScene.phaseManager.unshiftNew("PartyHealPhase", true);
         setEncounterRewards({
           guaranteedModifierTypeFuncs: [
             modifierTypes.MEMORY_MUSHROOM,
@@ -440,6 +443,8 @@ async function doNewTeamPostProcess(transformations: PokemonTransformation[]) {
   let atLeastOneNewStarter = false;
   for (const transformation of transformations) {
     const previousPokemon = transformation.previousPokemon;
+    const oldHpRatio = previousPokemon.getHpRatio(true);
+    const oldStatus = previousPokemon.status;
     const newPokemon = transformation.newPokemon;
     const speciesRootForm = newPokemon.species.getRootSpeciesId();
 
@@ -462,6 +467,19 @@ async function doNewTeamPostProcess(transformations: PokemonTransformation[]) {
     }
 
     newPokemon.calculateStats();
+    if (oldHpRatio > 0) {
+      newPokemon.hp = Math.ceil(oldHpRatio * newPokemon.getMaxHp());
+      // Assume that the `status` instance can always safely be transferred to the new pokemon
+      // This is the case (as of version 1.10.4)
+      // Safeguard against COMATOSE here
+      if (!newPokemon.hasAbility(AbilityId.COMATOSE, false, true)) {
+        newPokemon.status = oldStatus;
+      }
+    } else {
+      newPokemon.hp = 0;
+      newPokemon.doSetStatus(StatusEffect.FAINT);
+    }
+
     await newPokemon.updateInfo();
   }
 

--- a/src/enums/pokemon-type.ts
+++ b/src/enums/pokemon-type.ts
@@ -20,3 +20,6 @@ export enum PokemonType {
   FAIRY,
   STELLAR
 }
+
+/** The largest legal value for a {@linkcode PokemonType} (includes Stellar) */
+export const MAX_POKEMON_TYPE = PokemonType.STELLAR;


### PR DESCRIPTION
## What are the changes the user will see?
Weird dream will now do a party heal when selecting the first option, and will not 

## Why am I making these changes?
Requested by balance team.
Directing it to the hotfix-1.10.4 branch, because the fact that it could revive fainted Pokémon in hardcore is considered a balance bug.

## What are the changes from a developer perspective?
Track the status and hp ratio of the previous Pokémon before transforming it into a new one. After transformation, set its HP ratio to the new one, and carry over its status. If it was fainted, set it to faint.
Note that I add a catch for comatose, since I believe that bad things can happen if comatose somehow ends up with a status, and I didn't want to take that chance.

Also adds a new constant for `MAX_POKEMON_TYPE` and use it to set a random tera type for the transformed Pokémon.

Note: We may want to get rid of the shop items in the select-modifier phase that comes after the heal, this is not done here. (note we _do_ want the party heal to take place before the select modifier phase, so the player is aware of this when choosing the modifier).

## Screenshots/Videos

<details><summary>Non-Hardcore weird dream</summary>

https://github.com/user-attachments/assets/374f2200-95ee-430b-8f68-8814d6c360a5
</details>

## How to test the changes?
```ts
const overrides = {
  MYSTERY_ENCOUNTER_OVERRIDE: MysteryEncounterType.WEIRD_DREAM,
  MYSTERY_ENCOUNTER_RATE_OVERRIDE: 256,
  STARTING_WAVE_OVERRIDE: 21,
  STARTING_LEVEL_OVERRIDE: 13,
  STARTING_MODIFIER_OVERRIDE: [{
    name: "TERA_ORB"
  }]
} satisfies Partial<InstanceType<OverridesType>>;
```

Make sure to take multiple pokemon, and ensure the user takes damage on the first wave so you can see the heal phase work successfully.

## Checklist
- [x] **I'm using `hotfix-1.10.4` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~