### PR TITLE
[Balance] Move Future Sight/etc before berry use

### DIFF
--- a/src/phases/turn-start-phase.ts
+++ b/src/phases/turn-start-phase.ts
@@ -179,12 +179,12 @@ export class TurnStartPhase extends FieldPhase {
     // https://www.smogon.com/forums/threads/sword-shield-battle-mechanics-research.3655528/page-64#post-9244179
 
     phaseManager.pushNew("WeatherEffectPhase");
+    phaseManager.pushNew("PositionalTagPhase");
+
     phaseManager.pushNew("BerryPhase");
 
-    /** Add a new phase to check who should be taking status damage */
     phaseManager.pushNew("CheckStatusEffectPhase", moveOrder);
 
-    phaseManager.pushNew("PositionalTagPhase");
     phaseManager.pushNew("TurnEndPhase");
 
     /*


### PR DESCRIPTION
## What are the changes the user will see?
Future sight now procs after weather but before berries

## Why am I making these changes?
Balance wanted it

## What are the changes from a developer perspective?
Moved a line of code

## Screenshots/Videos
N/A?
## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)