### PR TITLE
[UI/UX] Auto focus first input field

### DIFF
--- a/src/ui/form-modal-ui-handler.ts
+++ b/src/ui/form-modal-ui-handler.ts
@@ -136,6 +136,11 @@ export abstract class FormModalUiHandler extends ModalUiHandler {
       this.submitAction = config.buttonActions.length ? config.buttonActions[0] : null;
       this.cancelAction = config.buttonActions[1] ?? null;
 
+      // Auto focus the first input field after a short delay, to prevent accidental inputs
+      setTimeout(() => {
+        this.inputs[0].setFocus();
+      }, 50);
+
       // #region: Override button pointerDown
       // Override the pointerDown event for the buttonBgs to call the `submitAction` and `cancelAction`
       // properties that we set above, allowing their behavior to change after this method terminates

--- a/src/ui/pokedex-scan-ui-handler.ts
+++ b/src/ui/pokedex-scan-ui-handler.ts
@@ -106,10 +106,6 @@ export class PokedexScanUiHandler extends FormModalUiHandler {
 
     this.reduceKeys();
 
-    setTimeout(() => {
-      input.setFocus(); // Focus after a short delay to avoid unwanted input
-    }, 50);
-
     input.on("keydown", (inputObject, evt: KeyboardEvent) => {
       if (
         ["escape", "space"].some(v => v === evt.key.toLowerCase() || v === evt.code.toLowerCase()) &&


### PR DESCRIPTION
## What are the changes the user will see?

The first input will be auto focused, so the user doens't have to click onto the input.

## Why am I making these changes?

Having to click on the input field, before being able to type is annoying and an unneeded extra step. Especially since the game can just be played without mouse.
Also the pokedex scan inputs already had this.

## What are the changes from a developer perspective?

Automatically sets the focus for the first input field, when calling `show()` on `formModalUiHandler`

## Screenshots/Videos

<details open><summary>video</summary>

https://github.com/user-attachments/assets/1933316c-725a-492d-b239-0033de293023

</details> 

## How to test the changes?

Open any input field. e.g. rename pokemon, rename run, change password, login

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  ~~- [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?