### PR TITLE
[Hotfix] Fix tyrogue evo

### DIFF
--- a/src/data/balance/pokemon-evolutions.ts
+++ b/src/data/balance/pokemon-evolutions.ts
@@ -77,6 +77,7 @@ export enum EvolutionItem {
   LEADERS_CREST
 }
 
+const tyrogueMoves = [MoveId.LOW_SWEEP, MoveId.MACH_PUNCH, MoveId.RAPID_SPIN];
 type TyrogueMove = MoveId.LOW_SWEEP | MoveId.MACH_PUNCH | MoveId.RAPID_SPIN;
 
 /**
@@ -192,7 +193,7 @@ export class SpeciesEvolutionCondition {
         case EvoCondKey.WEATHER:
           return cond.weather.includes(globalScene.arena.getWeatherType());
         case EvoCondKey.TYROGUE:
-          return pokemon.getMoveset(true).find(m => m.moveId as TyrogueMove)?.moveId === cond.move;
+          return pokemon.getMoveset(true).find(m => tyrogueMoves.includes(m.moveId))?.moveId === cond.move;
         case EvoCondKey.NATURE:
           return cond.nature.includes(pokemon.getNature());
         case EvoCondKey.RANDOM_FORM: {


### PR DESCRIPTION
## What are the changes the user will see?
Fixes #6408 

## Why am I making these changes?
Evolution condition was simplified too much in #5679 .

## What are the changes from a developer perspective?
Doing `as TyrogueMove` does not actually enforce typing at runtime, so we need to check that the moveId is one of the allowed ones.

## Screenshots/Videos

https://github.com/user-attachments/assets/8b51988a-f491-4767-ae62-ff43b99b0a4d


https://github.com/user-attachments/assets/8803af08-451f-44a3-aad1-3e19bb52482e



## How to test the changes?
Override from the bug report:
```ts
const overrides = {
  STARTER_SPECIES_OVERRIDE:SpeciesId.TYROGUE,
  STARTING_LEVEL_OVERRIDE: 19,
  ITEM_REWARD_OVERRIDE: [{name: "RARE_CANDY"}, {name: "MEMORY_MUSHROOM"}],
} satisfies Partial<InstanceType<OverridesType>>;
```
Note that apparently move overrides can mess with the evo conditions, use memory mushrooms instead.
