### PR TITLE
Remove unnecessary tsdoc comments from `service-worker.js`

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,9 +1,7 @@
-/// <reference lib = "WebWorker" />
 self.addEventListener('install', function () {
   console.log('Service worker installing...');
 });
 
 self.addEventListener('activate', (event) => {
-  // @ts-expect-error: See https://github.com/microsoft/TypeScript/issues/14877
   event.waitUntil(self.clients.claim());
 })


### PR DESCRIPTION
Follow up to #6415 