### PR TITLE
[Misc] Add " (Beta)" to site title and version display on beta

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,10 @@ import InputTextPlugin from "phaser3-rex-plugins/plugins/inputtext-plugin";
 import TransitionImagePackPlugin from "phaser3-rex-plugins/templates/transitionimagepack/transitionimagepack-plugin";
 import UIPlugin from "phaser3-rex-plugins/templates/ui/ui-plugin";
 
+if (import.meta.env.DEV) {
+  document.title += " (Beta)";
+}
+
 // Catch global errors and display them in an alert so users can report the issue.
 window.onerror = (_message, _source, _lineno, _colno, error) => {
   console.error(error);

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -141,7 +141,8 @@ export class TitleUiHandler extends OptionSelectUiHandler {
         }),
       );
 
-      this.appVersionText.setText("v" + version);
+      const betaText = import.meta.env.DEV ? " (Beta)" : "";
+      this.appVersionText.setText("v" + version + betaText);
 
       const ui = this.getUi();
 


### PR DESCRIPTION
## What are the changes the user will see?
The title of the webpage and the version string displayed on the title screen will have " (Beta)" appended to them when on the beta website (`beta.pokerogue.net`) or when running locally.

## Why am I making these changes?
To reduce user confusion.

## What are the changes from a developer perspective?
Checks added in `main.ts` and `title-ui-handler.ts` to append " (Beta)" as necessary.

## Screenshots/Videos
<details><summary>Screenshot</summary>
<p>

<img width="1274" height="800" alt="image" src="https://github.com/user-attachments/assets/56c36719-b156-437e-9c7d-b3d2fc0f3b9b" />

</p>
</details>

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?