### PR TITLE
Fix starter preferences resetting (1.10.4-rc2)

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1828,9 +1828,9 @@ export class StarterSelectUiHandler extends MessageUiHandler {
       // The persistent starter data to apply e.g. candy upgrades
       const persistentStarterData = globalScene.gameData.starterData[this.lastSpecies.speciesId];
       // The sanitized starter preferences
-      let starterAttributes = this.starterPreferences[this.lastSpecies.speciesId];
+      let starterAttributes = this.starterPreferences[this.lastSpecies.speciesId] ?? {};
       // The original starter preferences
-      const originalStarterAttributes = this.originalStarterPreferences[this.lastSpecies.speciesId];
+      const originalStarterAttributes = this.originalStarterPreferences[this.lastSpecies.speciesId] ?? {};
 
       // this gets the correct pokemon cursor depending on whether you're in the starter screen or the party icons
       if (!this.starterIconsCursorObj.visible) {
@@ -3408,8 +3408,9 @@ export class StarterSelectUiHandler extends MessageUiHandler {
       if (species) {
         const defaultDexAttr = this.getCurrentDexProps(species.speciesId);
         const defaultProps = globalScene.gameData.getSpeciesDexAttrProps(species, defaultDexAttr);
+        // Bang is correct due to the `?` before variant
         const variant = this.starterPreferences[species.speciesId]?.variant
-          ? (this.starterPreferences[species.speciesId].variant as Variant)
+          ? (this.starterPreferences[species.speciesId]!.variant as Variant)
           : defaultProps.variant;
         const tint = getVariantTint(variant);
         this.pokemonShinyIcon.setFrame(getVariantIcon(variant)).setTint(tint);

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -8,7 +8,7 @@ import { AES, enc } from "crypto-js";
  * @param values - The object to be deep copied.
  * @returns A new object that is a deep copy of the input.
  */
-export function deepCopy(values: object): object {
+export function deepCopy<T extends object>(values: T): T {
   // Convert the object to a JSON string and parse it back to an object to perform a deep copy
   return JSON.parse(JSON.stringify(values));
 }
@@ -58,6 +58,21 @@ export function decrypt(data: string, bypassLogin: boolean): string {
   return AES.decrypt(data, saveKey).toString(enc.Utf8);
 }
 
+/**
+ * Check if an object has no properties of its own (its shape is `{}`). An empty array is considered a bare object.
+ * @param obj - Object to check
+ * @returns - Whether the object is bare
+ */
+export function isBareObject(obj: any): boolean {
+  if (typeof obj !== "object") {
+    return false;
+  }
+  for (const _ in obj) {
+    return false;
+  }
+  return true;
+}
+
 // the latest data saved/loaded for the Starter Preferences. Required to reduce read/writes. Initialize as "{}", since this is the default value and no data needs to be stored if present.
 // if they ever add private static variables, move this into StarterPrefs
 const StarterPrefers_DEFAULT: string = "{}";
@@ -75,18 +90,6 @@ export function loadStarterPreferences(): StarterPreferences {
   );
 }
 
-/**
- * Check if an object has no properties of its own (its shape is `{}`)
- * @param obj - Object to check
- * @returns - Whether the object is bare
- */
-export function isBareObject(obj: object): boolean {
-  for (const _ in obj) {
-    return false;
-  }
-  return true;
-}
-
 export function saveStarterPreferences(prefs: StarterPreferences): void {
   // Fastest way to check if an object has any properties (does no allocation)
   if (isBareObject(prefs)) {
@@ -96,6 +99,7 @@ export function saveStarterPreferences(prefs: StarterPreferences): void {
   // no reason to store `{}` (for starters not customized)
   const pStr: string = JSON.stringify(prefs, (_, value) => (isBareObject(value) ? undefined : value));
   if (pStr !== StarterPrefers_private_latest) {
+    console.log("%cSaving starter preferences", "color: blue");
     // something changed, store the update
     localStorage.setItem(`starterPrefs_${loggedInUser?.username}`, pStr);
     // update the latest prefs

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -64,7 +64,7 @@ const StarterPrefers_DEFAULT: string = "{}";
 let StarterPrefers_private_latest: string = StarterPrefers_DEFAULT;
 
 export interface StarterPreferences {
-  [key: number]: StarterAttributes;
+  [key: number]: StarterAttributes | undefined;
 }
 // called on starter selection show once
 
@@ -74,10 +74,27 @@ export function loadStarterPreferences(): StarterPreferences {
       localStorage.getItem(`starterPrefs_${loggedInUser?.username}`) || StarterPrefers_DEFAULT),
   );
 }
-// called on starter selection clear, always
+
+/**
+ * Check if an object has no properties of its own (its shape is `{}`)
+ * @param obj - Object to check
+ * @returns - Whether the object bare
+ */
+export function isBareObject(obj: object): boolean {
+  for (const _ in obj) {
+    return false;
+  }
+  return true;
+}
 
 export function saveStarterPreferences(prefs: StarterPreferences): void {
-  const pStr: string = JSON.stringify(prefs);
+  // Fastest way to check if an object has any properties (does no allocation)
+  if (isBareObject(prefs)) {
+    console.warn("Refusing to save empty starter preferences");
+    return;
+  }
+  // no reason to store `{}` (for starters not customized)
+  const pStr: string = JSON.stringify(prefs, (_, value) => (isBareObject(value) ? undefined : value));
   if (pStr !== StarterPrefers_private_latest) {
     // something changed, store the update
     localStorage.setItem(`starterPrefs_${loggedInUser?.username}`, pStr);

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -78,7 +78,7 @@ export function loadStarterPreferences(): StarterPreferences {
 /**
  * Check if an object has no properties of its own (its shape is `{}`)
  * @param obj - Object to check
- * @returns - Whether the object bare
+ * @returns - Whether the object is bare
  */
 export function isBareObject(obj: object): boolean {
   for (const _ in obj) {

--- a/test/utils/data.test.ts
+++ b/test/utils/data.test.ts
@@ -1,0 +1,39 @@
+import { deepCopy, isBareObject } from "#utils/data";
+import { describe, expect, it } from "vitest";
+
+describe("Utils - Data", () => {
+  describe("deepCopy", () => {
+    it("should create a deep copy of an object", () => {
+      const original = { a: 1, b: { c: 2 } };
+      const copy = deepCopy(original);
+      // ensure the references are different
+      expect(copy === original, "copied object should not compare equal").not;
+      expect(copy).toEqual(original);
+      // update copy's `a` to a different value and ensure original is unaffected
+      copy.a = 42;
+      expect(original.a, "adjusting property of copy should not affect original").toBe(1);
+      // update copy's nested `b.c` to a different value and ensure original is unaffected
+      copy.b.c = 99;
+      expect(original.b.c, "adjusting nested property of copy should not affect original").toBe(2);
+    });
+  });
+
+  describe("isBareObject", () => {
+    it("should properly identify bare objects", () => {
+      expect(isBareObject({}), "{} should be considered bare");
+      expect(isBareObject(new Object()), "new Object() should be considered bare");
+      expect(isBareObject(Object.create(null)));
+      expect(isBareObject([]), "an empty array should be considered bare");
+    });
+
+    it("should properly reject non-objects", () => {
+      expect(isBareObject(new Date())).not;
+      expect(isBareObject(null)).not;
+      expect(isBareObject(42)).not;
+      expect(isBareObject("")).not;
+      expect(isBareObject(undefined)).not;
+      expect(isBareObject(() => {})).not;
+      expect(isBareObject(new (class A {})())).not;
+    });
+  });
+});


### PR DESCRIPTION
See #6410 for the other fields

We should have confidence that the _attempted_ fix in #6410 _did stop this bug_ (though introduced a different one), because after that patch went live, people that were previously impacted by the issue _were seeing nickname persist_ (whereas it wouldn't before).

The reason that nickname would persist while the other primitives weren't, is because our nickname is actually using the `String()` method (for whatever reason) to create a string _object_ instead, which is what made it immune.

## What are the changes from a developer perspective?

Made it so that starter preferences aren't saved when *first opening* SSUI, as this could happen _before_ the `initStarterPrefs` method was called, meaning that the starter preferences could be overwritten!
This is accomplished by making all of the calls to `setSpeciesDetials` in `setStarter` pass the `save = false` value (which is a new parameter to `setSpeciesDetails`.

I also *fixed* my previous attempt, which had a HUGE oversight where primitives were being treated as empty objects.

## Screenshots/Videos

https://github.com/user-attachments/assets/0eca5a9d-8952-4f9e-945b-f7e26a8bc450


## How to test the changes?
`pnpm test test/utils/data.test.ts`

## Checklist
- [x] **I'm using `hotfix-1.10.5` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~
