### PR TITLE
[Misc] Bump version to 1.10.5 to main

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pokemon-rogue-battle",
   "private": true,
-  "version": "1.10.4",
+  "version": "1.10.5",
   "type": "module",
   "scripts": {
     "start": "vite",


### PR DESCRIPTION
## What are the changes the user will see?
The version will display 1.10.5 on the homepage.

## Why am I making these changes?
It turns out not bumping the version when we tweak something isn't the best idea, because we don't know if users are on the right version.

## What are the changes from a developer perspective?
ran `pnpm update-version:patch`

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

