### PR TITLE
[Bug] Fix monotype challenge using unlocalized type names

### DIFF
--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -27,7 +27,7 @@ import type { DexEntry } from "#types/dex-data";
 import { type BooleanHolder, isBetween, type NumberHolder, randSeedItem } from "#utils/common";
 import { deepCopy } from "#utils/data";
 import { getPokemonSpecies, getPokemonSpeciesForm } from "#utils/pokemon-utils";
-import { toCamelCase, toSnakeCase } from "#utils/strings";
+import { toCamelCase } from "#utils/strings";
 import i18next from "i18next";
 
 /** A constant for the default max cost of the starting party before a run */
@@ -764,7 +764,7 @@ export class SingleTypeChallenge extends Challenge {
   }
 
   getValue(overrideValue: number = this.value): string {
-    return toSnakeCase(PokemonType[overrideValue - 1]);
+    return i18next.t(`pokemonInfo:type.${toCamelCase(PokemonType[overrideValue - 1]})`);
   }
 
   getDescription(overrideValue: number = this.value): string {

--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -764,7 +764,7 @@ export class SingleTypeChallenge extends Challenge {
   }
 
   getValue(overrideValue: number = this.value): string {
-    return i18next.t(`pokemonInfo:type.${toCamelCase(PokemonType[overrideValue - 1]})`);
+    return i18next.t(`pokemonInfo:type.${toCamelCase(PokemonType[overrideValue - 1])}`);
   }
 
   getDescription(overrideValue: number = this.value): string {


### PR DESCRIPTION
## What are the changes from a user perspective?
Monotype challenge desc no longer is jank

## Why am I making these changes?
Removes snake case jank
## What are the changes from a developer perspective?
Made the `getValue` call use the standard type i18n key

## Screenshots/Videos
N/A

## How to test the changes?
Do monotype challenge