### PR TITLE
[GitHub] Workflows will now time out after 10 minutes

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   create-release:
     if: github.repository == 'pagefaultgames/pokerogue' && (vars.BETA_DEPLOY_BRANCH == '' || ! startsWith(vars.BETA_DEPLOY_BRANCH, 'release'))
+    timeout-minutes: 10
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed for github cli commands
     runs-on: ubuntu-latest
@@ -36,11 +37,13 @@ jobs:
             exit 1
           fi
         shell: bash
+
       - uses: actions/create-github-app-token@v2
         id: app-token
         with:
           app-id: ${{ secrets.PAGEFAULT_APP_ID }}
           private-key: ${{ secrets.PAGEFAULT_APP_PRIVATE_KEY }}
+
       - name: Check out code
         uses: actions/checkout@v4
         with:
@@ -48,8 +51,10 @@ jobs:
           # Always base off of beta branch, regardless of the branch the workflow was triggered from.
           ref: beta
           token: ${{ steps.app-token.outputs.token }}
+
       - name: Create release branch
         run: git checkout -b release
+
       # In order to be able to open a PR into beta, we need the branch to have at least one change.
       - name: Overwrite RELEASE file
         run: |
@@ -58,11 +63,14 @@ jobs:
           echo "Release v${{ github.event.inputs.versionName }}" > RELEASE
           git add RELEASE
           git commit -m "Stage release v${{ github.event.inputs.versionName }}"
+
       - name: Push new branch
         run: git push origin release
+
       # The repository variable is used by the deploy-beta workflow to determine whether to deploy from beta or release.
       - name: Set repository variable
         run: GITHUB_TOKEN="${{ steps.app-token.outputs.token }}" gh variable set BETA_DEPLOY_BRANCH --body "release"
+
       - name: Create pull request to main
         run: |
           gh pr create --base main \
@@ -70,6 +78,7 @@ jobs:
                        --title "Release v${{ github.event.inputs.versionName }} to main" \
                        --body "This PR is for the release of v${{ github.event.inputs.versionName }}, and was created automatically by the GitHub Actions workflow invoked by ${{ github.actor }}" \
                        --draft
+
       - name: Create pull request to beta
         run: |
           gh pr create --base beta \

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   deploy:
     if: github.repository == 'pagefaultgames/pokerogue' && github.ref_name == (vars.BETA_DEPLOY_BRANCH || 'beta')
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   deploy:
     if: github.repository == 'pagefaultgames/pokerogue'
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -20,6 +20,7 @@ jobs:
   pages:
     name: Github Pages
     if: github.repository == 'pagefaultgames/pokerogue'
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     env:
       api-dir: ./

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   run-linters:
     name: Run linters
+    timeout-minutes: 10
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/post-release-deleted.yml
+++ b/.github/workflows/post-release-deleted.yml
@@ -6,6 +6,7 @@ jobs:
   # Set the BETA_DEPLOY_BRANCH variable to beta when a release branch is deleted
   update-release-var:
     if: github.repository == 'pagefaultgames/pokerogue' && github.event.ref_type == 'branch' && github.event.ref == 'release'
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - name: Set BETA_DEPLOY_BRANCH to beta

--- a/.github/workflows/test-shard-template.yml
+++ b/.github/workflows/test-shard-template.yml
@@ -21,6 +21,7 @@ jobs:
   test:
     # We can't use dynmically named jobs until https://github.com/orgs/community/discussions/13261 is implemented
     name: Shard
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     if: ${{ !inputs.skip }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   check-path-change-filter:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Prevent workflows (tests specifically) from running for excessively long periods of time.

## What are the changes from a developer perspective?
Workflows now have a time limit of 10 minutes (a couple of the simpler ones are set to 5).

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?