### PR TITLE
[Bug][Sprite] Ensure evo silhouette disappears in evo phase

### DIFF
--- a/src/phases/evolution-phase.ts
+++ b/src/phases/evolution-phase.ts
@@ -31,6 +31,7 @@ export class EvolutionPhase extends Phase {
   private evolutionBgm: AnySound;
   private evolutionHandler: EvolutionSceneHandler;
 
+  /** Container for all assets used by the scene. When the scene is cleared, the children within this are destroyed. */
   protected evolutionContainer: Phaser.GameObjects.Container;
   protected evolutionBaseBg: Phaser.GameObjects.Image;
   protected evolutionBg: Phaser.GameObjects.Video;
@@ -522,6 +523,7 @@ export class EvolutionPhase extends Phase {
             return;
           }
           if (i === lastCycle) {
+            this.pokemonTintSprite.setVisible(false).setActive(false);
             this.pokemonEvoTintSprite.setScale(1);
           }
         },


### PR DESCRIPTION
## What are the changes the user will see?
There will no longer be a tiny silhouette of the pokemon once the evolution phase finishes.

## Why am I making these changes?
Fixes https://discord.com/channels/1125469663833370665/1408694341844865115/1408694341844865115

## What are the changes from a developer perspective?
Set the `visibility` and `active` property of the mini evolution tint sprite to false once the evolution animation ends.

## Screenshots/Videos
<details><summary>After (then before, in same video)</summary>

https://github.com/user-attachments/assets/4abacbfa-59ff-4224-8072-9cba68cb0fcd
</details> 

## How to test the changes?
```ts
const overrides = {
  STARTER_SPECIES_OVERRIDE: SpeciesId.MEOWTH,
  STARTING_LEVEL_OVERRIDE: 100,
  ITEM_REWARD_OVERRIDE: [{ name: "RARE_CANDY"}]
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- [x] **I'm using `hotfix-1.10.6` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - ~~[ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~ Can't test UI elements that rely on phaser actually doing stuff
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~