### PR TITLE
[Bug] [UI]Fix ribbon and status effect overlap

### DIFF
--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -115,6 +115,9 @@ export class EnemyBattleInfo extends BattleInfo {
       globalScene.gameData.starterData[pokemon.species.getRootSpeciesId()].classicWinCount > 0 &&
       globalScene.gameData.starterData[pokemon.species.getRootSpeciesId(true)].classicWinCount > 0
     ) {
+      // move the ribbon to the left if there is no owned icon
+      const championRibbonX = this.ownedIcon.visible ? 8 : 0;
+      this.championRibbon.setPositionRelative(this.nameText, championRibbonX, 11.75);
       this.championRibbon.setVisible(true);
     }
 


### PR DESCRIPTION
## What are the changes the user will see?

The ribbon will no longer overlap with the status effect, when the pokémon hasn't been caught

## Why am I making these changes?

[Discord report](https://discord.com/channels/1125469663833370665/1238339524778790922/1411013791168336068)

## What are the changes from a developer perspective?

The ribbon icon x position will be adjusted if there is no owned icon.
THe status effect already did that, which lead to the overlap

## Screenshots/Videos

Before:

<details><summary>Without owned icon</summary>
<p>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b5aae5c7-babd-4016-bf79-800042484598" />

</p>
</details> 

After:
<details><summary>Without owned icon</summary>

<img width="1920" height="1080" alt="No owned icon" src="https://github.com/user-attachments/assets/e30b722b-568d-4e08-b4cf-68607809cb23" />

</details>

<details><summary>With owned icon</summary>

<img width="1920" height="1080" alt="with owned icon" src="https://github.com/user-attachments/assets/6c0a4caa-77aa-4304-86ff-b5fce296d598" />

</details> 

## How to test the changes?

Set the enemy pokémon to one, which has a ribbon, but hasn't been caught
```ts
const overrides = {
  ENEMY_STATUS_OVERRIDE: StatusEffect.SLEEP,
  ENEMY_SPECIES_OVERRIDE: SpeciesId.GALLADE
} satisfies Partial<InstanceType<Overr
```

## Checklist
- [x] **I'm using `hotfix-1.10.6` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  ~~- [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?
