### PR TITLE
[Bug] Pokemon not on the field can't be caught

### DIFF
--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -456,7 +456,7 @@ export class CommandPhase extends FieldPhase {
 
     const numBallTypes = 5;
     if (cursor < numBallTypes) {
-      const targetPokemon = globalScene.getEnemyPokemon();
+      const targetPokemon = globalScene.getEnemyPokemon(false);
       if (
         targetPokemon?.isBoss() &&
         targetPokemon?.bossSegmentIndex >= 1 &&


### PR DESCRIPTION
The root of this bug is an "oversight" from #5873 , where the line
`const targetPokemon = globalScene.getEnemyField().find(p => p.isActive(true));`
was replaced by
`const targetPokemon = globalScene.getEnemyPokemon();`

Due to the weirdness surrounding these functions, `isActive` can be `true` even if the mon is not on the field, which is why it was called with the parameter `onField` set to `true`. Similarly, `getEnemyPokemon` must be called with the parameter `false`, otherwise it also considers mons that have switched out.

This is relevant in the case of trying to catch a boss in the second party slot, after phazing out the boss in the first slot. This caused a bug reported in [this discord thread](https://discord.com/channels/1125469663833370665/1409970865415651511): even after the second mon has been weakened down, the game continues checking the first mon, which is not on the field anymore but still has all its health segments.


## Screenshots/Videos

After the fix:

https://github.com/user-attachments/assets/0538f2a6-cb58-40d2-a418-85c1c730a344


## How to test the changes?

Check discord thread for session data and instructions.
