### PR TITLE
[Bug] [UI] Fix enemy level position

### DIFF
--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -180,7 +180,6 @@ export class EnemyBattleInfo extends BattleInfo {
         this.ownedIcon,
         this.championRibbon,
         this.statusIndicator,
-        this.levelContainer,
         this.statValuesContainer,
       ].map(e => (e.x += 48 * (boss ? -1 : 1)));
       this.hpBar.x += 38 * (boss ? -1 : 1);


### PR DESCRIPTION
## What are the changes the user will see?

The enemy level will be aligned to the right again at higher levels vs a Boss

## Why am I making these changes?

Fixes #6419

## What are the changes from a developer perspective?

Removed `this.levelContainer` from having it's x adjusted in `updateBossSegments``.
This was added in #5696

## Screenshots/Videos


## How to test the changes?

I used these overrides:

```ts
const overrides = {
  STARTING_WAVE_OVERRIDE: 960,
  STARTING_LEVEL_OVERRIDE: 5000
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- [x] **I'm using `hotfix-1.10.6` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  ~~- [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?