### PR TITLE
Sound error handling improvement

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2318,7 +2318,7 @@ export class BattleScene extends SceneBase {
     });
   }
 
-  playSound(sound: string | AnySound, config?: object): AnySound {
+  playSound(sound: string | AnySound, config?: object): AnySound | null {
     const key = typeof sound === "string" ? sound : sound.key;
     config = config ?? {};
     try {
@@ -2354,16 +2354,19 @@ export class BattleScene extends SceneBase {
       this.sound.play(key, config);
       return this.sound.get(key) as AnySound;
     } catch {
-      console.log(`${key} not found`);
-      return sound as AnySound;
+      console.warn(`${key} not found`);
+      return null;
     }
   }
 
-  playSoundWithoutBgm(soundName: string, pauseDuration?: number): AnySound {
+  playSoundWithoutBgm(soundName: string, pauseDuration?: number): AnySound | null {
     this.bgmCache.add(soundName);
     const resumeBgm = this.pauseBgm();
     this.playSound(soundName);
-    const sound = this.sound.get(soundName) as AnySound;
+    const sound = this.sound.get(soundName);
+    if (!sound) {
+      return sound;
+    }
     if (this.bgmResumeTimer) {
       this.bgmResumeTimer.destroy();
     }
@@ -2373,7 +2376,7 @@ export class BattleScene extends SceneBase {
         this.bgmResumeTimer = null;
       });
     }
-    return sound;
+    return sound as AnySound;
   }
 
   /** The loop point of any given battle, mystery encounter, or title track, read as seconds and milliseconds. */

--- a/src/data/battle-anims.ts
+++ b/src/data/battle-anims.ts
@@ -291,9 +291,17 @@ class AnimTimedSoundEvent extends AnimTimedEvent {
       } catch (err) {
         console.error(err);
       }
-      return Math.ceil((globalScene.sound.get(`battle_anims/${this.resourceName}`).totalDuration * 1000) / 33.33);
+      const sound = globalScene.sound.get(`battle_anims/${this.resourceName}`);
+      if (!sound) {
+        return 0;
+      }
+      return Math.ceil((sound.totalDuration * 1000) / 33.33);
     }
-    return Math.ceil((battleAnim.user!.cry(soundConfig).totalDuration * 1000) / 33.33); // TODO: is the bang behind user correct?
+    const cry = battleAnim.user!.cry(soundConfig); // TODO: is the bang behind user correct?
+    if (!cry) {
+      return 0;
+    }
+    return Math.ceil((cry.totalDuration * 1000) / 33.33);
   }
 
   getEventType(): string {

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -593,14 +593,14 @@ export abstract class PokemonSpeciesForm {
     });
   }
 
-  cry(soundConfig?: Phaser.Types.Sound.SoundConfig, ignorePlay?: boolean): AnySound {
+  cry(soundConfig?: Phaser.Types.Sound.SoundConfig, ignorePlay?: boolean): AnySound | null {
     const cryKey = this.getCryKey(this.formIndex);
     let cry: AnySound | null = globalScene.sound.get(cryKey) as AnySound;
     if (cry?.pendingRemove) {
       cry = null;
     }
     cry = globalScene.playSound(cry ?? cryKey, soundConfig);
-    if (ignorePlay) {
+    if (cry && ignorePlay) {
       cry.stop();
     }
     return cry;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4565,6 +4565,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         try {
           SoundFade.fadeOut(scene, cry, fixedInt(Math.ceil(duration * 0.2)));
           fusionCry = this.getFusionSpeciesForm(undefined, true).cry({
+            // Typescript's type checker doesn't handle using and assigning to the same variable in one line correctly.
             seek: Math.max(fusionCry!.totalDuration * 0.4, 0),
             ...soundConfig,
           });

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4555,7 +4555,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }
     let duration = cry.totalDuration * 1000;
     if (this.fusionSpecies && this.getSpeciesForm(undefined, true) !== this.getFusionSpeciesForm(undefined, true)) {
-      let fusionCry = this.getFusionSpeciesForm(undefined, true).cry(soundConfig, true);
+      const fusionCry = this.getFusionSpeciesForm(undefined, true).cry(soundConfig, true);
       if (!fusionCry) {
         return cry;
       }
@@ -4564,15 +4564,14 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       scene.time.delayedCall(fixedInt(Math.ceil(duration * 0.4)), () => {
         try {
           SoundFade.fadeOut(scene, cry, fixedInt(Math.ceil(duration * 0.2)));
-          fusionCry = this.getFusionSpeciesForm(undefined, true).cry({
-            // Typescript's type checker doesn't handle using and assigning to the same variable in one line correctly.
-            seek: Math.max(fusionCry!.totalDuration * 0.4, 0),
+          const fusionCryInner = this.getFusionSpeciesForm(undefined, true).cry({
+            seek: Math.max(fusionCry.totalDuration * 0.4, 0),
             ...soundConfig,
           });
-          if (fusionCry) {
+          if (fusionCryInner) {
             SoundFade.fadeIn(
               scene,
-              fusionCry,
+              fusionCryInner,
               fixedInt(Math.ceil(duration * 0.2)),
               scene.masterVolume * scene.fieldVolume,
               0,
@@ -4721,6 +4720,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         if (i === transitionIndex && fusionCryKey) {
           SoundFade.fadeOut(globalScene, cry, fixedInt(Math.ceil((duration / rate) * 0.2)));
           fusionCry = globalScene.playSound(fusionCryKey, {
+            // TODO: This bang is correct as this callback can only be called once, but
+            // this whole block with conditionally reassigning fusionCry needs a second lock.
             seek: Math.max(fusionCry!.totalDuration * 0.4, 0),
             rate: rate,
           });

--- a/src/phases/egg-hatch-phase.ts
+++ b/src/phases/egg-hatch-phase.ts
@@ -64,7 +64,7 @@ export class EggHatchPhase extends Phase {
   private canSkip: boolean;
   private skipped: boolean;
   /** The sound effect being played when the egg is hatched */
-  private evolutionBgm: AnySound;
+  private evolutionBgm: AnySound | null;
   private eggLapsePhase: EggLapsePhase;
 
   constructor(hatchScene: EggLapsePhase, egg: Egg, eggsToHatchCount: number) {

--- a/src/phases/evolution-phase.ts
+++ b/src/phases/evolution-phase.ts
@@ -28,7 +28,7 @@ export class EvolutionPhase extends Phase {
 
   private evolution: SpeciesFormEvolution | null;
   private fusionSpeciesEvolved: boolean; // Whether the evolution is of the fused species
-  private evolutionBgm: AnySound;
+  private evolutionBgm: AnySound | null;
   private evolutionHandler: EvolutionSceneHandler;
 
   /** Container for all assets used by the scene. When the scene is cleared, the children within this are destroyed. */
@@ -298,7 +298,9 @@ export class EvolutionPhase extends Phase {
         this.evolutionBg.setVisible(false);
       },
     });
-    SoundFade.fadeOut(globalScene, this.evolutionBgm, 100);
+    if (this.evolutionBgm) {
+      SoundFade.fadeOut(globalScene, this.evolutionBgm, 100);
+    }
   }
 
   /**
@@ -378,7 +380,9 @@ export class EvolutionPhase extends Phase {
    * Fadeout evolution music, play the cry, show the evolution completed text, and end the phase
    */
   private onEvolutionComplete(evolvedPokemon: Pokemon) {
-    SoundFade.fadeOut(globalScene, this.evolutionBgm, 100);
+    if (this.evolutionBgm) {
+      SoundFade.fadeOut(globalScene, this.evolutionBgm, 100);
+    }
     globalScene.time.delayedCall(250, () => {
       this.pokemon.cry();
       globalScene.time.delayedCall(1250, () => {

--- a/src/phases/party-heal-phase.ts
+++ b/src/phases/party-heal-phase.ts
@@ -38,13 +38,15 @@ export class PartyHealPhase extends BattlePhase {
         pokemon.updateInfo(true);
       }
       const healSong = globalScene.playSoundWithoutBgm("heal");
-      globalScene.time.delayedCall(fixedInt(healSong.totalDuration * 1000), () => {
-        healSong.destroy();
-        if (this.resumeBgm && bgmPlaying) {
-          globalScene.playBgm();
-        }
-        globalScene.ui.fadeIn(500).then(() => this.end());
-      });
+      if (healSong) {
+        globalScene.time.delayedCall(fixedInt(healSong.totalDuration * 1000), () => {
+          healSong.destroy();
+          if (this.resumeBgm && bgmPlaying) {
+            globalScene.playBgm();
+          }
+          globalScene.ui.fadeIn(500).then(() => this.end());
+        });
+      }
     });
     globalScene.arena.playerTerasUsed = 0;
   }


### PR DESCRIPTION
## What are the changes the user will see?
The game should no longer occasionally crash when it's failed to load a sound file that it tries to play.

## Why am I making these changes?
It was crashing in rare circumstances. https://discord.com/channels/1125469663833370665/1409451631740846120

## What are the changes from a developer perspective?
Changes playSound to return null instead of returning the argument when it errors while playing the sound, as this caused multiple pieces of error handling code to fail. This caused multiple other functions to have to be changed to this new return signature, and adds several new checks throughout the codebase for failed sounds which should prevent similar errors in other places.

## Screenshots/Videos


## How to test the changes?
The easiest way to fake a sound failing to load is to delete the sound file. To test the specific bug which caused this delete the cry for a pokemon then faint that pokemon.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?
