### PR TITLE
[Dev] Simplify `isLocal` and add `start:prod`/`start:beta`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "1.10.6",
   "type": "module",
   "scripts": {
-    "start": "vite",
+    "start:prod": "vite --mode production",
+    "start:beta": "vite --mode beta",
     "start:dev": "vite --mode development",
     "build": "vite build",
     "build:beta": "vite build --mode beta",

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -276,25 +276,11 @@ export function executeIf<T>(condition: boolean, promiseFunc: () => Promise<T>):
 }
 
 export const sessionIdKey = "pokerogue_sessionId";
-// Check if the current hostname is 'localhost' or an IP address, and ensure a port is specified
-export const isLocal =
-  ((window.location.hostname === "localhost" || /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/.test(window.location.hostname)) &&
-    window.location.port !== "") ||
-  window.location.hostname === "";
 
-/**
- * @deprecated Refer to [pokerogue-api.ts](./plugins/api/pokerogue-api.ts) instead
- */
-export const localServerUrl =
-  import.meta.env.VITE_SERVER_URL ?? `http://${window.location.hostname}:${window.location.port + 1}`;
+/** `true` when run via `pnpm start:dev` (which runs `vite --mode development`) */
+export const isLocal = import.meta.env.MODE === "development";
 
-/**
- * Set the server URL based on whether it's local or not
- *
- * @deprecated Refer to [pokerogue-api.ts](./plugins/api/pokerogue-api.ts) instead
- */
-export const apiUrl = localServerUrl ?? "https://api.pokerogue.net";
-// used to disable api calls when isLocal is true and a server is not found
+/** Used to disable api calls when isLocal is true and a server is not found */
 export let isLocalServerConnected = true;
 
 /**
@@ -302,7 +288,7 @@ export let isLocalServerConnected = true;
  * with a GET request to verify if a server is running,
  * sets isLocalServerConnected based on results
  */
-export async function localPing() {
+export async function localPing(): Promise<void> {
   if (isLocal) {
     const titleStats = await pokerogueApi.getGameTitleStats();
     isLocalServerConnected = !!titleStats;

--- a/src/utils/utility-vars.ts
+++ b/src/utils/utility-vars.ts
@@ -1,1 +1,4 @@
-export const isBeta = import.meta.env.MODE === "beta"; // this checks to see if the env mode is development. Technically this gives the same value for beta AND for dev envs
+// TODO: move this (and other global constants) to `src/constants/*-constants.ts`
+
+/** `true` if running on `beta.pokerogue.net` or via `pnpm start:beta` (which runs `vite --mode beta`) */
+export const isBeta = import.meta.env.MODE === "beta";


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Simplify code (which will hopefully help the build process remove unnecessary code from production).

## What are the changes from a developer perspective?
- The constant `isLocal` now checks to see if `import.meta.env.MODE` is `"development"` (which it is when running via `pnpm start:dev`) instead of checking what URL is being used to access the client (e.g. `"localhost"` or an IP address).

- Removes `start` from `package.json` and replaces it with `start:prod` (which runs `vite --mode production`) and `start:beta` (which runs `vite --mode beta`).

|   Command    | `isBeta` | `isLocal` |
| ------------ | -------- | --------- |
| `start:prod` | `false`  |  `false`  |
| `start:beta` | `true`   |  `false`  |
| `start:dev`  | `false`  |  `true`   |

- Removes obsolete/unused `localServerUrl` and `apiUrl` constants.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?