### PR TITLE
[Bug] Fix monotype selector image

### DIFF
--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -764,7 +764,7 @@ export class SingleTypeChallenge extends Challenge {
   }
 
   getValue(overrideValue: number = this.value): string {
-    return i18next.t(`pokemonInfo:type.${toCamelCase(PokemonType[overrideValue - 1])}`);
+    return PokemonType[overrideValue - 1].toLowerCase();
   }
 
   getDescription(overrideValue: number = this.value): string {


### PR DESCRIPTION
## What are the changes the user will see?

The image when selecting a monotype challange will correctly show the type again

## Why am I making these changes?

#6438 Localized the value for monotype challenges, which lead to them not matching the frame names.

[Bug report](https://discord.com/channels/1125469663833370665/1125894949020381285/1412432524482711573)

## What are the changes from a developer perspective?

Replaced the localization with a `toLowerCase()`

There is no need to localize the monotype values, since they are only used for the image, which by itsself is already localized

## Screenshots/Videos

<details><summary>Before</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0e8f22f5-49ad-4a79-88f4-022c1fe55c92" />

</details> 

<details><summary>After</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/faafbf13-1d8d-4e22-810c-5176900fa768" />

</details> 

## How to test the changes?

Change the type in the challenge selct ui

## Checklist
- [x] **I'm using `hotfix-1.10.7` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  ~~- [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?