### PR TITLE
[UI/UX][Refactor] Remove redundant references to globalScene.uiTheme

### DIFF
--- a/src/data/mystery-encounters/encounters/training-session-encounter.ts
+++ b/src/data/mystery-encounters/encounters/training-session-encounter.ts
@@ -188,7 +188,7 @@ export const TrainingSessionEncounter: MysteryEncounter = MysteryEncounterBuilde
           // Return the options for nature selection
           return getEnumValues(Nature).map((nature: Nature) => {
             const option: OptionSelectItem = {
-              label: getNatureName(nature, true, true, true, globalScene.uiTheme),
+              label: getNatureName(nature, true, true, true),
               handler: () => {
                 // Pokemon and second option selected
                 encounter.setDialogueToken("nature", getNatureName(nature));

--- a/src/data/mystery-encounters/utils/encounter-dialogue-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-dialogue-utils.ts
@@ -1,6 +1,5 @@
 import { globalScene } from "#app/global-scene";
 import type { TextStyle } from "#enums/text-style";
-import { UiTheme } from "#enums/ui-theme";
 import { getTextWithColors } from "#ui/text";
 import { isNullOrUndefined } from "#utils/common";
 import i18next from "i18next";
@@ -16,14 +15,12 @@ export function getEncounterText(keyOrString?: string, primaryStyle?: TextStyle)
     return null;
   }
 
-  const uiTheme = globalScene.uiTheme ?? UiTheme.DEFAULT;
-
   let textString: string | null = getTextWithDialogueTokens(keyOrString);
 
   // Can only color the text if a Primary Style is defined
   // primaryStyle is applied to all text that does not have its own specified style
   if (primaryStyle && textString) {
-    textString = getTextWithColors(textString, primaryStyle, uiTheme, true);
+    textString = getTextWithColors(textString, primaryStyle, true);
   }
 
   return textString;

--- a/src/data/nature.ts
+++ b/src/data/nature.ts
@@ -1,7 +1,6 @@
 import { Nature } from "#enums/nature";
 import { EFFECTIVE_STATS, getShortenedStatKey, Stat } from "#enums/stat";
 import { TextStyle } from "#enums/text-style";
-import { UiTheme } from "#enums/ui-theme";
 import { getBBCodeFrag } from "#ui/text";
 import { toCamelCase } from "#utils/strings";
 import i18next from "i18next";
@@ -11,7 +10,6 @@ export function getNatureName(
   includeStatEffects = false,
   forStarterSelect = false,
   ignoreBBCode = false,
-  uiTheme: UiTheme = UiTheme.DEFAULT,
 ): string {
   let ret = toCamelCase(Nature[nature]);
   //Translating nature
@@ -31,7 +29,7 @@ export function getNatureName(
     }
     const textStyle = forStarterSelect ? TextStyle.SUMMARY_ALT : TextStyle.WINDOW;
     const getTextFrag = !ignoreBBCode
-      ? (text: string, style: TextStyle) => getBBCodeFrag(text, style, uiTheme)
+      ? (text: string, style: TextStyle) => getBBCodeFrag(text, style)
       : (text: string, _style: TextStyle) => text;
     if (increasedStat && decreasedStat) {
       ret = `${getTextFrag(`${ret}${!forStarterSelect ? "\n" : " "}(`, textStyle)}${getTextFrag(`+${i18next.t(getShortenedStatKey(increasedStat))}`, TextStyle.SUMMARY_PINK)}${getTextFrag("/", textStyle)}${getTextFrag(`-${i18next.t(getShortenedStatKey(decreasedStat))}`, TextStyle.SUMMARY_BLUE)}${getTextFrag(")", textStyle)}`;

--- a/src/phases/scan-ivs-phase.ts
+++ b/src/phases/scan-ivs-phase.ts
@@ -24,7 +24,6 @@ export class ScanIvsPhase extends PokemonPhase {
     let statsContainer: Phaser.GameObjects.Sprite[] = [];
     let statsContainerLabels: Phaser.GameObjects.Sprite[] = [];
     const enemyField = globalScene.getEnemyField();
-    const uiTheme = globalScene.uiTheme; // Assuming uiTheme is accessible
     for (let e = 0; e < enemyField.length; e++) {
       enemyIvs = enemyField[e].ivs;
       // we are using getRootSpeciesId() here because we want to check against the baby form, not the mid form if it exists
@@ -36,8 +35,8 @@ export class ScanIvsPhase extends PokemonPhase {
         if (enemyIvs[ivStat] > currentIvs[ivStat] && PERMANENT_STATS.indexOf(Number(ivStat)) >= 0) {
           const hexColour =
             enemyIvs[ivStat] === 31
-              ? getTextColor(TextStyle.PERFECT_IV, false, uiTheme)
-              : getTextColor(TextStyle.SUMMARY_GREEN, false, uiTheme);
+              ? getTextColor(TextStyle.PERFECT_IV, false)
+              : getTextColor(TextStyle.SUMMARY_GREEN, false);
           const hexTextColour = Phaser.Display.Color.HexStringToColor(hexColour).color;
           statsContainerLabels[s].setTint(hexTextColour);
         }

--- a/src/ui/abstract-option-select-ui-handler.ts
+++ b/src/ui/abstract-option-select-ui-handler.ts
@@ -81,7 +81,7 @@ export abstract class AbstractOptionSelectUiHandler extends UiHandler {
 
     this.optionSelectIcons = [];
 
-    this.scale = getTextStyleOptions(TextStyle.WINDOW, globalScene.uiTheme).scale;
+    this.scale = getTextStyleOptions(TextStyle.WINDOW).scale;
 
     this.setCursor(0);
   }
@@ -124,8 +124,8 @@ export abstract class AbstractOptionSelectUiHandler extends UiHandler {
       optionsForWidth
         .map(o =>
           o.item
-            ? `[shadow=${getTextColor(o.style ?? this.defaultTextStyle, true, globalScene.uiTheme)}][color=${getTextColor(o.style ?? TextStyle.WINDOW, false, globalScene.uiTheme)}]    ${o.label}[/color][/shadow]`
-            : `[shadow=${getTextColor(o.style ?? this.defaultTextStyle, true, globalScene.uiTheme)}][color=${getTextColor(o.style ?? TextStyle.WINDOW, false, globalScene.uiTheme)}]${o.label}[/color][/shadow]`,
+            ? `[shadow=${getTextColor(o.style ?? this.defaultTextStyle, true)}][color=${getTextColor(o.style ?? TextStyle.WINDOW, false)}]    ${o.label}[/color][/shadow]`
+            : `[shadow=${getTextColor(o.style ?? this.defaultTextStyle, true)}][color=${getTextColor(o.style ?? TextStyle.WINDOW, false)}]${o.label}[/color][/shadow]`,
         )
         .join("\n"),
       TextStyle.WINDOW,
@@ -149,8 +149,8 @@ export abstract class AbstractOptionSelectUiHandler extends UiHandler {
     this.textContent = optionsWithScroll
       .map(o =>
         o.item
-          ? `[shadow=${getTextColor(o.style ?? this.defaultTextStyle, true, globalScene.uiTheme)}][color=${getTextColor(o.style ?? TextStyle.WINDOW, false, globalScene.uiTheme)}]    ${o.label}[/color][/shadow]`
-          : `[shadow=${getTextColor(o.style ?? this.defaultTextStyle, true, globalScene.uiTheme)}][color=${getTextColor(o.style ?? TextStyle.WINDOW, false, globalScene.uiTheme)}]${o.label}[/color][/shadow]`,
+          ? `[shadow=${getTextColor(o.style ?? this.defaultTextStyle, true)}][color=${getTextColor(o.style ?? TextStyle.WINDOW, false)}]    ${o.label}[/color][/shadow]`
+          : `[shadow=${getTextColor(o.style ?? this.defaultTextStyle, true)}][color=${getTextColor(o.style ?? TextStyle.WINDOW, false)}]${o.label}[/color][/shadow]`,
       )
       .join("\n");
     this.optionSelectText.setText(this.textContent);

--- a/src/ui/admin-ui-handler.ts
+++ b/src/ui/admin-ui-handler.ts
@@ -7,6 +7,7 @@ import type { InputFieldConfig } from "#ui/form-modal-ui-handler";
 import { FormModalUiHandler } from "#ui/form-modal-ui-handler";
 import type { ModalConfig } from "#ui/modal-ui-handler";
 import { toTitleCase } from "#utils/strings";
+import { getTextColor } from "./text";
 
 type AdminUiHandlerService = "discord" | "google";
 type AdminUiHandlerServiceMode = "Link" | "Unlink";
@@ -129,11 +130,11 @@ export class AdminUiHandler extends FormModalUiHandler {
 
     this.errorMessage.setPosition(10, (hasTitle ? 31 : 5) + 20 * (fields.length - 1) + 16 + this.getButtonTopMargin()); // sets the position of the message dynamically
     if (isMessageError) {
-      this.errorMessage.setColor(this.getTextColor(TextStyle.SUMMARY_PINK));
-      this.errorMessage.setShadowColor(this.getTextColor(TextStyle.SUMMARY_PINK, true));
+      this.errorMessage.setColor(getTextColor(TextStyle.SUMMARY_PINK));
+      this.errorMessage.setShadowColor(getTextColor(TextStyle.SUMMARY_PINK, true));
     } else {
-      this.errorMessage.setColor(this.getTextColor(TextStyle.SUMMARY_GREEN));
-      this.errorMessage.setShadowColor(this.getTextColor(TextStyle.SUMMARY_GREEN, true));
+      this.errorMessage.setColor(getTextColor(TextStyle.SUMMARY_GREEN));
+      this.errorMessage.setShadowColor(getTextColor(TextStyle.SUMMARY_GREEN, true));
     }
 
     if (super.show(args)) {

--- a/src/ui/ball-ui-handler.ts
+++ b/src/ui/ball-ui-handler.ts
@@ -26,7 +26,7 @@ export class BallUiHandler extends UiHandler {
   setup() {
     const ui = this.getUi();
 
-    this.scale = getTextStyleOptions(TextStyle.WINDOW, globalScene.uiTheme).scale;
+    this.scale = getTextStyleOptions(TextStyle.WINDOW).scale;
 
     let optionsTextContent = "";
 

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -5,6 +5,7 @@ import { PokemonType } from "#enums/pokemon-type";
 import { Stat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
 import { TextStyle } from "#enums/text-style";
+import { UiTheme } from "#enums/ui-theme";
 import type { Pokemon } from "#field/pokemon";
 import { getVariantTint } from "#sprites/variant";
 import { addTextObject } from "#ui/text";
@@ -265,7 +266,7 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
     this.add(this.hpBar);
 
     this.levelNumbersContainer = globalScene.add
-      .container(9.5, globalScene.uiTheme ? 0 : -0.5)
+      .container(9.5, globalScene.uiTheme === UiTheme.LEGACY ? 0 : -0.5)
       .setName("container_level");
     this.levelContainer.add(this.levelNumbersContainer);
 

--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -1,6 +1,7 @@
 import { globalScene } from "#app/global-scene";
 import { Stat } from "#enums/stat";
 import { TextStyle } from "#enums/text-style";
+import { UiTheme } from "#enums/ui-theme";
 import type { EnemyPokemon } from "#field/pokemon";
 import { BattleFlyout } from "#ui/battle-flyout";
 import type { BattleInfoParamList } from "#ui/battle-info";
@@ -203,7 +204,7 @@ export class EnemyBattleInfo extends BattleInfo {
     }
 
     if (this.boss && this.bossSegments > 1) {
-      const uiTheme = globalScene.uiTheme;
+      const isLegacyUiTheme = globalScene.uiTheme === UiTheme.LEGACY;
       const maxHp = pokemon.getMaxHp();
       for (let s = 1; s < this.bossSegments; s++) {
         const dividerX = (Math.round((maxHp / this.bossSegments) * s) / maxHp) * this.hpBar.width;
@@ -211,14 +212,14 @@ export class EnemyBattleInfo extends BattleInfo {
           0,
           0,
           1,
-          this.hpBar.height - (uiTheme ? 0 : 1),
+          this.hpBar.height - (isLegacyUiTheme ? 0 : 1),
           pokemon.bossSegmentIndex >= s ? 0xffffff : 0x404040,
         );
         divider.setOrigin(0.5, 0).setName("hpBar_divider_" + s.toString());
         this.add(divider);
         this.moveBelow(divider as Phaser.GameObjects.GameObject, this.statsContainer);
 
-        divider.setPositionRelative(this.hpBar, dividerX, uiTheme ? 0 : 1);
+        divider.setPositionRelative(this.hpBar, dividerX, isLegacyUiTheme ? 0 : 1);
         this.hpBarSegmentDividers.push(divider);
       }
     }

--- a/src/ui/battle-message-ui-handler.ts
+++ b/src/ui/battle-message-ui-handler.ts
@@ -245,7 +245,6 @@ export class BattleMessageUiHandler extends MessageUiHandler {
   getIvDescriptor(value: number, typeIv: number, pokemonId: number): string {
     const starterSpecies = globalScene.getPokemonById(pokemonId)!.species.getRootSpeciesId(); // we are using getRootSpeciesId() here because we want to check against the baby form, not the mid form if it exists
     const starterIvs: number[] = globalScene.gameData.dexData[starterSpecies].ivs;
-    const uiTheme = globalScene.uiTheme; // Assuming uiTheme is accessible
 
     // Function to wrap text in color based on comparison
     const coloredText = (text: string, isBetter: boolean, ivValue) => {
@@ -259,8 +258,8 @@ export class BattleMessageUiHandler extends MessageUiHandler {
       } else {
         textStyle = TextStyle.WINDOW;
       }
-      const color = getTextColor(textStyle, false, uiTheme);
-      return `[color=${color}][shadow=${getTextColor(textStyle, true, uiTheme)}]${text}[/shadow][/color]`;
+      const color = getTextColor(textStyle, false);
+      return `[color=${color}][shadow=${getTextColor(textStyle, true)}]${text}[/shadow][/color]`;
     };
 
     if (value > 30) {

--- a/src/ui/egg-gacha-ui-handler.ts
+++ b/src/ui/egg-gacha-ui-handler.ts
@@ -170,7 +170,7 @@ export class EggGachaUiHandler extends MessageUiHandler {
 
   setup() {
     this.gachaCursor = 0;
-    this.scale = getTextStyleOptions(TextStyle.WINDOW, globalScene.uiTheme).scale;
+    this.scale = getTextStyleOptions(TextStyle.WINDOW).scale;
 
     const ui = this.getUi();
 

--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -13,7 +13,7 @@ import type { EnemyPokemon, Pokemon } from "#field/pokemon";
 import type { PokemonMove } from "#moves/pokemon-move";
 import type { CommandPhase } from "#phases/command-phase";
 import { MoveInfoOverlay } from "#ui/move-info-overlay";
-import { addTextObject } from "#ui/text";
+import { addTextObject, getTextColor } from "#ui/text";
 import { UiHandler } from "#ui/ui-handler";
 import { fixedInt, getLocalizedSpriteKey, padInt } from "#utils/common";
 import i18next from "i18next";
@@ -284,7 +284,7 @@ export class FightUiHandler extends UiHandler implements InfoToggle {
     const ppColorStyle = FightUiHandler.ppRatioToColor(pp / maxPP);
 
     // Changes the text color and shadow according to the determined TextStyle
-    this.ppText.setColor(this.getTextColor(ppColorStyle, false)).setShadowColor(this.getTextColor(ppColorStyle, true));
+    this.ppText.setColor(getTextColor(ppColorStyle, false)).setShadowColor(getTextColor(ppColorStyle, true));
     this.moveInfoOverlay.show(pokemonMove.getMove());
 
     pokemon.getOpponents().forEach(opponent => {

--- a/src/ui/filter-bar.ts
+++ b/src/ui/filter-bar.ts
@@ -97,9 +97,9 @@ export class FilterBar extends Phaser.GameObjects.Container {
   updateFilterLabels(): void {
     for (let i = 0; i < this.numFilters; i++) {
       if (this.dropDowns[i].hasDefaultValues()) {
-        this.labels[i].setColor(getTextColor(TextStyle.TOOLTIP_CONTENT, false, globalScene.uiTheme));
+        this.labels[i].setColor(getTextColor(TextStyle.TOOLTIP_CONTENT, false));
       } else {
-        this.labels[i].setColor(getTextColor(TextStyle.STATS_LABEL, false, globalScene.uiTheme));
+        this.labels[i].setColor(getTextColor(TextStyle.STATS_LABEL, false));
       }
     }
   }

--- a/src/ui/filter-text.ts
+++ b/src/ui/filter-text.ts
@@ -167,9 +167,9 @@ export class FilterText extends Phaser.GameObjects.Container {
   updateFilterLabels(): void {
     for (let i = 0; i < this.numFilters; i++) {
       if (this.selections[i].text === this.defaultText) {
-        this.labels[i].setColor(getTextColor(TextStyle.TOOLTIP_CONTENT, false, globalScene.uiTheme));
+        this.labels[i].setColor(getTextColor(TextStyle.TOOLTIP_CONTENT, false));
       } else {
-        this.labels[i].setColor(getTextColor(TextStyle.STATS_LABEL, false, globalScene.uiTheme));
+        this.labels[i].setColor(getTextColor(TextStyle.STATS_LABEL, false));
       }
     }
   }

--- a/src/ui/form-modal-ui-handler.ts
+++ b/src/ui/form-modal-ui-handler.ts
@@ -4,7 +4,7 @@ import { TextStyle } from "#enums/text-style";
 import type { UiMode } from "#enums/ui-mode";
 import type { ModalConfig } from "#ui/modal-ui-handler";
 import { ModalUiHandler } from "#ui/modal-ui-handler";
-import { addTextInputObject, addTextObject } from "#ui/text";
+import { addTextInputObject, addTextObject, getTextColor } from "#ui/text";
 import { addWindow, WindowVariant } from "#ui/ui-theme";
 import { fixedInt } from "#utils/common";
 import type InputText from "phaser3-rex-plugins/plugins/inputtext";
@@ -78,8 +78,8 @@ export abstract class FormModalUiHandler extends ModalUiHandler {
         wordWrap: { width: 850 },
       },
     );
-    this.errorMessage.setColor(this.getTextColor(TextStyle.SUMMARY_PINK));
-    this.errorMessage.setShadowColor(this.getTextColor(TextStyle.SUMMARY_PINK, true));
+    this.errorMessage.setColor(getTextColor(TextStyle.SUMMARY_PINK));
+    this.errorMessage.setShadowColor(getTextColor(TextStyle.SUMMARY_PINK, true));
     this.errorMessage.setVisible(false);
     this.modalContainer.add(this.errorMessage);
   }

--- a/src/ui/menu-ui-handler.ts
+++ b/src/ui/menu-ui-handler.ts
@@ -145,7 +145,7 @@ export class MenuUiHandler extends MessageUiHandler {
     );
     this.optionSelectText.setLineSpacing(12);
 
-    this.scale = getTextStyleOptions(TextStyle.WINDOW, globalScene.uiTheme).scale;
+    this.scale = getTextStyleOptions(TextStyle.WINDOW).scale;
     this.menuBg = addWindow(
       globalScene.scaledCanvas.width - (this.optionSelectText.displayWidth + 25),
       0,

--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -65,7 +65,7 @@ export class ModifierSelectUiHandler extends AwaitableUiHandler {
 
     const canvas = document.createElement("canvas");
     const context = canvas.getContext("2d");
-    const styleOptions = getTextStyleOptions(TextStyle.PARTY, globalScene.uiTheme).styleOptions;
+    const styleOptions = getTextStyleOptions(TextStyle.PARTY).styleOptions;
 
     if (context) {
       context.font = styleOptions.fontSize + "px " + styleOptions.fontFamily;
@@ -686,14 +686,14 @@ export class ModifierSelectUiHandler extends AwaitableUiHandler {
     const formattedMoney = formatMoney(globalScene.moneyFormat, this.rerollCost);
 
     this.rerollCostText.setText(i18next.t("modifierSelectUiHandler:rerollCost", { formattedMoney }));
-    this.rerollCostText.setColor(this.getTextColor(canReroll ? TextStyle.MONEY : TextStyle.PARTY_RED));
-    this.rerollCostText.setShadowColor(this.getTextColor(canReroll ? TextStyle.MONEY : TextStyle.PARTY_RED, true));
+    this.rerollCostText.setColor(getTextColor(canReroll ? TextStyle.MONEY : TextStyle.PARTY_RED));
+    this.rerollCostText.setShadowColor(getTextColor(canReroll ? TextStyle.MONEY : TextStyle.PARTY_RED, true));
   }
 
   updateLockRaritiesText(): void {
     const textStyle = globalScene.lockModifierTiers ? TextStyle.SUMMARY_BLUE : TextStyle.PARTY;
-    this.lockRarityButtonText.setColor(this.getTextColor(textStyle));
-    this.lockRarityButtonText.setShadowColor(this.getTextColor(textStyle, true));
+    this.lockRarityButtonText.setColor(getTextColor(textStyle));
+    this.lockRarityButtonText.setShadowColor(getTextColor(textStyle, true));
   }
 
   clear() {
@@ -1042,7 +1042,7 @@ class ModifierOption extends Phaser.GameObjects.Container {
     const formattedMoney = formatMoney(globalScene.moneyFormat, cost);
 
     this.itemCostText.setText(i18next.t("modifierSelectUiHandler:itemCost", { formattedMoney }));
-    this.itemCostText.setColor(getTextColor(textStyle, false, globalScene.uiTheme));
-    this.itemCostText.setShadowColor(getTextColor(textStyle, true, globalScene.uiTheme));
+    this.itemCostText.setColor(getTextColor(textStyle, false));
+    this.itemCostText.setShadowColor(getTextColor(textStyle, true));
   }
 }

--- a/src/ui/pokedex-page-ui-handler.ts
+++ b/src/ui/pokedex-page-ui-handler.ts
@@ -662,7 +662,7 @@ export class PokedexPageUiHandler extends MessageUiHandler {
       i18next.t("pokedexUiHandler:showEvolutions"),
     ];
 
-    this.scale = getTextStyleOptions(TextStyle.WINDOW, globalScene.uiTheme).scale;
+    this.scale = getTextStyleOptions(TextStyle.WINDOW).scale;
     this.menuBg = addWindow(
       globalScene.scaledCanvas.width - 83,
       0,
@@ -767,16 +767,8 @@ export class PokedexPageUiHandler extends MessageUiHandler {
           !isSeen ||
           (!isStarterCaught && (o === MenuOptions.TOGGLE_IVS || o === MenuOptions.NATURES)) ||
           (this.tmMoves.length < 1 && o === MenuOptions.TM_MOVES);
-        const color = getTextColor(
-          isDark ? TextStyle.SHADOW_TEXT : TextStyle.SETTINGS_VALUE,
-          false,
-          globalScene.uiTheme,
-        );
-        const shadow = getTextColor(
-          isDark ? TextStyle.SHADOW_TEXT : TextStyle.SETTINGS_VALUE,
-          true,
-          globalScene.uiTheme,
-        );
+        const color = getTextColor(isDark ? TextStyle.SHADOW_TEXT : TextStyle.SETTINGS_VALUE, false);
+        const shadow = getTextColor(isDark ? TextStyle.SHADOW_TEXT : TextStyle.SETTINGS_VALUE, true);
         return `[shadow=${shadow}][color=${color}]${label}[/color][/shadow]`;
       })
       .join("\n");
@@ -1789,7 +1781,7 @@ export class PokedexPageUiHandler extends MessageUiHandler {
                     options: natures
                       .map((n: Nature, _i: number) => {
                         const option: OptionSelectItem = {
-                          label: getNatureName(n, true, true, true, globalScene.uiTheme),
+                          label: getNatureName(n, true, true, true),
                           handler: () => {
                             return false;
                           },
@@ -2517,10 +2509,10 @@ export class PokedexPageUiHandler extends MessageUiHandler {
 
       this.shinyOverlay.setVisible(shiny ?? false); // TODO: is false the correct default?
       this.pokemonNumberText.setColor(
-        this.getTextColor(shiny ? TextStyle.SUMMARY_DEX_NUM_GOLD : TextStyle.SUMMARY_DEX_NUM, false),
+        getTextColor(shiny ? TextStyle.SUMMARY_DEX_NUM_GOLD : TextStyle.SUMMARY_DEX_NUM, false),
       );
       this.pokemonNumberText.setShadowColor(
-        this.getTextColor(shiny ? TextStyle.SUMMARY_DEX_NUM_GOLD : TextStyle.SUMMARY_DEX_NUM, true),
+        getTextColor(shiny ? TextStyle.SUMMARY_DEX_NUM_GOLD : TextStyle.SUMMARY_DEX_NUM, true),
       );
 
       const assetLoadCancelled = new BooleanHolder(false);
@@ -2728,8 +2720,8 @@ export class PokedexPageUiHandler extends MessageUiHandler {
       }
     } else {
       this.shinyOverlay.setVisible(false);
-      this.pokemonNumberText.setColor(this.getTextColor(TextStyle.SUMMARY));
-      this.pokemonNumberText.setShadowColor(this.getTextColor(TextStyle.SUMMARY, true));
+      this.pokemonNumberText.setColor(getTextColor(TextStyle.SUMMARY));
+      this.pokemonNumberText.setShadowColor(getTextColor(TextStyle.SUMMARY, true));
       this.pokemonGenderText.setText("");
       this.setTypeIcons(null, null);
     }

--- a/src/ui/pokedex-ui-handler.ts
+++ b/src/ui/pokedex-ui-handler.ts
@@ -28,6 +28,7 @@ import { PokemonType } from "#enums/pokemon-type";
 import type { SpeciesId } from "#enums/species-id";
 import { TextStyle } from "#enums/text-style";
 import { UiMode } from "#enums/ui-mode";
+import { UiTheme } from "#enums/ui-theme";
 import type { Variant } from "#sprites/variant";
 import { getVariantIcon, getVariantTint } from "#sprites/variant";
 import type { DexAttrProps, StarterAttributes } from "#system/game-data";
@@ -41,7 +42,7 @@ import { MessageUiHandler } from "#ui/message-ui-handler";
 import { PokedexMonContainer } from "#ui/pokedex-mon-container";
 import { PokemonIconAnimHandler, PokemonIconAnimMode } from "#ui/pokemon-icon-anim-handler";
 import { ScrollBar } from "#ui/scroll-bar";
-import { addTextObject } from "#ui/text";
+import { addTextObject, getTextColor } from "#ui/text";
 import { addWindow } from "#ui/ui-theme";
 import { BooleanHolder, fixedInt, getLocalizedSpriteKey, padInt, randIntRange, rgbHexToRgba } from "#utils/common";
 import type { StarterPreferences } from "#utils/data";
@@ -470,7 +471,7 @@ export class PokedexUiHandler extends MessageUiHandler {
     // Offset the generation filter dropdown to avoid covering the filtered pokemon
     this.filterBar.offsetHybridFilters();
 
-    if (!globalScene.uiTheme) {
+    if (globalScene.uiTheme === UiTheme.DEFAULT) {
       pokemonContainerWindow.setVisible(false);
     }
 
@@ -2314,8 +2315,8 @@ export class PokedexUiHandler extends MessageUiHandler {
         break;
     }
     if (baseStarterValue - starterValue > 0) {
-      starter.label.setColor(this.getTextColor(textStyle));
-      starter.label.setShadowColor(this.getTextColor(textStyle, true));
+      starter.label.setColor(getTextColor(textStyle));
+      starter.label.setShadowColor(getTextColor(textStyle, true));
     }
   }
 

--- a/src/ui/pokemon-info-container.ts
+++ b/src/ui/pokemon-info-container.ts
@@ -274,8 +274,8 @@ export class PokemonInfoContainer extends Phaser.GameObjects.Container {
 
         const newGender = BigInt(1 << pokemon.gender) * DexAttr.MALE;
         this.pokemonGenderNewText.setText("(+)");
-        this.pokemonGenderNewText.setColor(getTextColor(TextStyle.SUMMARY_BLUE, false, globalScene.uiTheme));
-        this.pokemonGenderNewText.setShadowColor(getTextColor(TextStyle.SUMMARY_BLUE, true, globalScene.uiTheme));
+        this.pokemonGenderNewText.setColor(getTextColor(TextStyle.SUMMARY_BLUE, false));
+        this.pokemonGenderNewText.setShadowColor(getTextColor(TextStyle.SUMMARY_BLUE, true));
         this.pokemonGenderNewText.setVisible((newGender & caughtAttr) === BigInt(0));
       } else {
         this.pokemonGenderNewText.setVisible(false);
@@ -290,11 +290,11 @@ export class PokemonInfoContainer extends Phaser.GameObjects.Container {
         const newForm = BigInt(1 << pokemon.formIndex) * DexAttr.DEFAULT_FORM;
 
         if ((newForm & caughtAttr) === BigInt(0)) {
-          this.pokemonFormLabelText.setColor(getTextColor(TextStyle.SUMMARY_BLUE, false, globalScene.uiTheme));
-          this.pokemonFormLabelText.setShadowColor(getTextColor(TextStyle.SUMMARY_BLUE, true, globalScene.uiTheme));
+          this.pokemonFormLabelText.setColor(getTextColor(TextStyle.SUMMARY_BLUE, false));
+          this.pokemonFormLabelText.setShadowColor(getTextColor(TextStyle.SUMMARY_BLUE, true));
         } else {
-          this.pokemonFormLabelText.setColor(getTextColor(TextStyle.WINDOW, false, globalScene.uiTheme));
-          this.pokemonFormLabelText.setShadowColor(getTextColor(TextStyle.WINDOW, true, globalScene.uiTheme));
+          this.pokemonFormLabelText.setColor(getTextColor(TextStyle.WINDOW, false));
+          this.pokemonFormLabelText.setShadowColor(getTextColor(TextStyle.WINDOW, true));
         }
 
         this.pokemonFormText.setText(
@@ -320,31 +320,31 @@ export class PokemonInfoContainer extends Phaser.GameObjects.Container {
 
       const abilityTextStyle = pokemon.abilityIndex === 2 ? TextStyle.MONEY : TextStyle.WINDOW;
       this.pokemonAbilityText.setText(pokemon.getAbility(true).name);
-      this.pokemonAbilityText.setColor(getTextColor(abilityTextStyle, false, globalScene.uiTheme));
-      this.pokemonAbilityText.setShadowColor(getTextColor(abilityTextStyle, true, globalScene.uiTheme));
+      this.pokemonAbilityText.setColor(getTextColor(abilityTextStyle, false));
+      this.pokemonAbilityText.setShadowColor(getTextColor(abilityTextStyle, true));
 
       // Check if the player owns ability for the root form
       const playerOwnsThisAbility = pokemon.checkIfPlayerHasAbilityOfStarter(starterEntry.abilityAttr);
 
       if (!playerOwnsThisAbility) {
-        this.pokemonAbilityLabelText.setColor(getTextColor(TextStyle.SUMMARY_BLUE, false, globalScene.uiTheme));
-        this.pokemonAbilityLabelText.setShadowColor(getTextColor(TextStyle.SUMMARY_BLUE, true, globalScene.uiTheme));
+        this.pokemonAbilityLabelText.setColor(getTextColor(TextStyle.SUMMARY_BLUE, false));
+        this.pokemonAbilityLabelText.setShadowColor(getTextColor(TextStyle.SUMMARY_BLUE, true));
       } else {
-        this.pokemonAbilityLabelText.setColor(getTextColor(TextStyle.WINDOW, false, globalScene.uiTheme));
-        this.pokemonAbilityLabelText.setShadowColor(getTextColor(TextStyle.WINDOW, true, globalScene.uiTheme));
+        this.pokemonAbilityLabelText.setColor(getTextColor(TextStyle.WINDOW, false));
+        this.pokemonAbilityLabelText.setShadowColor(getTextColor(TextStyle.WINDOW, true));
       }
 
-      this.pokemonNatureText.setText(getNatureName(pokemon.getNature(), true, false, false, globalScene.uiTheme));
+      this.pokemonNatureText.setText(getNatureName(pokemon.getNature(), true, false, false));
 
       const dexNatures = dexEntry.natureAttr;
       const newNature = 1 << (pokemon.nature + 1);
 
       if (!(dexNatures & newNature)) {
-        this.pokemonNatureLabelText.setColor(getTextColor(TextStyle.SUMMARY_BLUE, false, globalScene.uiTheme));
-        this.pokemonNatureLabelText.setShadowColor(getTextColor(TextStyle.SUMMARY_BLUE, true, globalScene.uiTheme));
+        this.pokemonNatureLabelText.setColor(getTextColor(TextStyle.SUMMARY_BLUE, false));
+        this.pokemonNatureLabelText.setShadowColor(getTextColor(TextStyle.SUMMARY_BLUE, true));
       } else {
-        this.pokemonNatureLabelText.setColor(getTextColor(TextStyle.WINDOW, false, globalScene.uiTheme));
-        this.pokemonNatureLabelText.setShadowColor(getTextColor(TextStyle.WINDOW, true, globalScene.uiTheme));
+        this.pokemonNatureLabelText.setColor(getTextColor(TextStyle.WINDOW, false));
+        this.pokemonNatureLabelText.setShadowColor(getTextColor(TextStyle.WINDOW, true));
       }
 
       const isFusion = pokemon.isFusion();
@@ -373,16 +373,16 @@ export class PokemonInfoContainer extends Phaser.GameObjects.Container {
         const newVariant = BigInt(1 << (pokemon.variant + 4));
 
         this.pokemonShinyNewIcon.setText("(+)");
-        this.pokemonShinyNewIcon.setColor(getTextColor(TextStyle.SUMMARY_BLUE, false, globalScene.uiTheme));
-        this.pokemonShinyNewIcon.setShadowColor(getTextColor(TextStyle.SUMMARY_BLUE, true, globalScene.uiTheme));
+        this.pokemonShinyNewIcon.setColor(getTextColor(TextStyle.SUMMARY_BLUE, false));
+        this.pokemonShinyNewIcon.setShadowColor(getTextColor(TextStyle.SUMMARY_BLUE, true));
         const newShinyOrVariant = (newShiny & caughtAttr) === BigInt(0) || (newVariant & caughtAttr) === BigInt(0);
         this.pokemonShinyNewIcon.setVisible(!!newShinyOrVariant);
       } else if ((caughtAttr & DexAttr.NON_SHINY) === BigInt(0) && (caughtAttr & DexAttr.SHINY) === DexAttr.SHINY) {
         //If the player has *only* caught any shiny variant of this species, not a non-shiny
         this.pokemonShinyNewIcon.setVisible(true);
         this.pokemonShinyNewIcon.setText("(+)");
-        this.pokemonShinyNewIcon.setColor(getTextColor(TextStyle.SUMMARY_BLUE, false, globalScene.uiTheme));
-        this.pokemonShinyNewIcon.setShadowColor(getTextColor(TextStyle.SUMMARY_BLUE, true, globalScene.uiTheme));
+        this.pokemonShinyNewIcon.setColor(getTextColor(TextStyle.SUMMARY_BLUE, false));
+        this.pokemonShinyNewIcon.setShadowColor(getTextColor(TextStyle.SUMMARY_BLUE, true));
       } else {
         this.pokemonShinyNewIcon.setVisible(false);
       }

--- a/src/ui/run-info-ui-handler.ts
+++ b/src/ui/run-info-ui-handler.ts
@@ -618,7 +618,7 @@ export class RunInfoUiHandler extends UiHandler {
     const runTime = getPlayTimeString(this.runInfo.playTime);
     runInfoText.appendText(`${i18next.t("runHistory:runLength")}: ${runTime}`, false);
     const runMoney = formatMoney(globalScene.moneyFormat, this.runInfo.money);
-    const moneyTextColor = getTextColor(TextStyle.MONEY_WINDOW, false, globalScene.uiTheme);
+    const moneyTextColor = getTextColor(TextStyle.MONEY_WINDOW, false);
     runInfoText.appendText(
       `[color=${moneyTextColor}]${i18next.t("battleScene:moneyOwned", { formattedMoney: runMoney })}[/color]`,
     );

--- a/src/ui/settings/abstract-binding-ui-handler.ts
+++ b/src/ui/settings/abstract-binding-ui-handler.ts
@@ -3,7 +3,7 @@ import { Button } from "#enums/buttons";
 import { TextStyle } from "#enums/text-style";
 import type { UiMode } from "#enums/ui-mode";
 import { NavigationManager } from "#ui/navigation-menu";
-import { addTextObject } from "#ui/text";
+import { addTextObject, getTextColor } from "#ui/text";
 import { UiHandler } from "#ui/ui-handler";
 import { addWindow } from "#ui/ui-theme";
 import i18next from "i18next";
@@ -222,16 +222,16 @@ export abstract class AbstractBindingUiHandler extends UiHandler {
   setCursor(cursor: number): boolean {
     this.cursor = cursor;
     if (cursor === 1) {
-      this.actionLabel.setColor(this.getTextColor(TextStyle.SETTINGS_SELECTED));
-      this.actionLabel.setShadowColor(this.getTextColor(TextStyle.SETTINGS_SELECTED, true));
-      this.cancelLabel.setColor(this.getTextColor(TextStyle.WINDOW));
-      this.cancelLabel.setShadowColor(this.getTextColor(TextStyle.WINDOW, true));
+      this.actionLabel.setColor(getTextColor(TextStyle.SETTINGS_SELECTED));
+      this.actionLabel.setShadowColor(getTextColor(TextStyle.SETTINGS_SELECTED, true));
+      this.cancelLabel.setColor(getTextColor(TextStyle.WINDOW));
+      this.cancelLabel.setShadowColor(getTextColor(TextStyle.WINDOW, true));
       return true;
     }
-    this.actionLabel.setColor(this.getTextColor(TextStyle.WINDOW));
-    this.actionLabel.setShadowColor(this.getTextColor(TextStyle.WINDOW, true));
-    this.cancelLabel.setColor(this.getTextColor(TextStyle.SETTINGS_SELECTED));
-    this.cancelLabel.setShadowColor(this.getTextColor(TextStyle.SETTINGS_SELECTED, true));
+    this.actionLabel.setColor(getTextColor(TextStyle.WINDOW));
+    this.actionLabel.setShadowColor(getTextColor(TextStyle.WINDOW, true));
+    this.cancelLabel.setColor(getTextColor(TextStyle.SETTINGS_SELECTED));
+    this.cancelLabel.setShadowColor(getTextColor(TextStyle.SETTINGS_SELECTED, true));
     return true;
   }
 

--- a/src/ui/settings/abstract-control-settings-ui-handler.ts
+++ b/src/ui/settings/abstract-control-settings-ui-handler.ts
@@ -7,7 +7,7 @@ import type { UiMode } from "#enums/ui-mode";
 import { getIconWithSettingName } from "#inputs/config-handler";
 import { NavigationManager, NavigationMenu } from "#ui/navigation-menu";
 import { ScrollBar } from "#ui/scroll-bar";
-import { addTextObject } from "#ui/text";
+import { addTextObject, getTextColor } from "#ui/text";
 import { UiHandler } from "#ui/ui-handler";
 import { addWindow } from "#ui/ui-theme";
 import { toCamelCase } from "#utils/strings";
@@ -653,16 +653,16 @@ export abstract class AbstractControlSettingsUiHandler extends UiHandler {
     if (!this.bindingSettings.includes(setting) && !setting.includes("BUTTON_")) {
       // Get the label of the last selected option and revert its color to the default.
       const lastValueLabel = this.optionValueLabels[settingIndex][lastCursor];
-      lastValueLabel.setColor(this.getTextColor(TextStyle.WINDOW));
-      lastValueLabel.setShadowColor(this.getTextColor(TextStyle.WINDOW, true));
+      lastValueLabel.setColor(getTextColor(TextStyle.WINDOW));
+      lastValueLabel.setShadowColor(getTextColor(TextStyle.WINDOW, true));
 
       // Update the cursor for the setting to the new position.
       this.optionCursors[settingIndex] = cursor;
 
       // Change the color of the new selected option to indicate it's selected.
       const newValueLabel = this.optionValueLabels[settingIndex][cursor];
-      newValueLabel.setColor(this.getTextColor(TextStyle.SETTINGS_SELECTED));
-      newValueLabel.setShadowColor(this.getTextColor(TextStyle.SETTINGS_SELECTED, true));
+      newValueLabel.setColor(getTextColor(TextStyle.SETTINGS_SELECTED));
+      newValueLabel.setShadowColor(getTextColor(TextStyle.SETTINGS_SELECTED, true));
     }
 
     // If the save flag is set, save the setting to local storage

--- a/src/ui/settings/abstract-settings-ui-handler.ts
+++ b/src/ui/settings/abstract-settings-ui-handler.ts
@@ -8,7 +8,7 @@ import type { InputsIcons } from "#ui/abstract-control-settings-ui-handler";
 import { MessageUiHandler } from "#ui/message-ui-handler";
 import { NavigationManager, NavigationMenu } from "#ui/navigation-menu";
 import { ScrollBar } from "#ui/scroll-bar";
-import { addTextObject } from "#ui/text";
+import { addTextObject, getTextColor } from "#ui/text";
 import { addWindow } from "#ui/ui-theme";
 import i18next from "i18next";
 
@@ -403,14 +403,14 @@ export class AbstractSettingsUiHandler extends MessageUiHandler {
     const lastCursor = this.optionCursors[settingIndex];
 
     const lastValueLabel = this.optionValueLabels[settingIndex][lastCursor];
-    lastValueLabel.setColor(this.getTextColor(TextStyle.SETTINGS_VALUE));
-    lastValueLabel.setShadowColor(this.getTextColor(TextStyle.SETTINGS_VALUE, true));
+    lastValueLabel.setColor(getTextColor(TextStyle.SETTINGS_VALUE));
+    lastValueLabel.setShadowColor(getTextColor(TextStyle.SETTINGS_VALUE, true));
 
     this.optionCursors[settingIndex] = cursor;
 
     const newValueLabel = this.optionValueLabels[settingIndex][cursor];
-    newValueLabel.setColor(this.getTextColor(TextStyle.SETTINGS_SELECTED));
-    newValueLabel.setShadowColor(this.getTextColor(TextStyle.SETTINGS_SELECTED, true));
+    newValueLabel.setColor(getTextColor(TextStyle.SETTINGS_SELECTED));
+    newValueLabel.setShadowColor(getTextColor(TextStyle.SETTINGS_SELECTED, true));
 
     if (save) {
       const saveSetting = () => {

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -40,6 +40,7 @@ import { PokemonType } from "#enums/pokemon-type";
 import { SpeciesId } from "#enums/species-id";
 import { TextStyle } from "#enums/text-style";
 import { UiMode } from "#enums/ui-mode";
+import { UiTheme } from "#enums/ui-theme";
 import type { CandyUpgradeNotificationChangedEvent } from "#events/battle-scene";
 import { BattleSceneEventType } from "#events/battle-scene";
 import type { Variant } from "#sprites/variant";
@@ -58,7 +59,7 @@ import { PokemonIconAnimHandler, PokemonIconAnimMode } from "#ui/pokemon-icon-an
 import { ScrollBar } from "#ui/scroll-bar";
 import { StarterContainer } from "#ui/starter-container";
 import { StatsContainer } from "#ui/stats-container";
-import { addBBCodeTextObject, addTextObject } from "#ui/text";
+import { addBBCodeTextObject, addTextObject, getTextColor } from "#ui/text";
 import { addWindow } from "#ui/ui-theme";
 import { applyChallenges, checkStarterValidForChallenge } from "#utils/challenge-utils";
 import {
@@ -599,7 +600,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
     // Offset the generation filter dropdown to avoid covering the filtered pokemon
     this.filterBar.offsetHybridFilters();
 
-    if (!globalScene.uiTheme) {
+    if (globalScene.uiTheme === UiTheme.DEFAULT) {
       starterContainerWindow.setVisible(false);
     }
 
@@ -2065,7 +2066,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
                     options: natures
                       .map((n: Nature, _i: number) => {
                         const option: OptionSelectItem = {
-                          label: getNatureName(n, true, true, true, globalScene.uiTheme),
+                          label: getNatureName(n, true, true, true),
                           handler: () => {
                             starterAttributes.nature = n;
                             originalStarterAttributes.nature = starterAttributes.nature;
@@ -3909,10 +3910,10 @@ export class StarterSelectUiHandler extends MessageUiHandler {
 
       this.shinyOverlay.setVisible(shiny ?? false); // TODO: is false the correct default?
       this.pokemonNumberText.setColor(
-        this.getTextColor(shiny ? TextStyle.SUMMARY_DEX_NUM_GOLD : TextStyle.SUMMARY_DEX_NUM, false),
+        getTextColor(shiny ? TextStyle.SUMMARY_DEX_NUM_GOLD : TextStyle.SUMMARY_DEX_NUM, false),
       );
       this.pokemonNumberText.setShadowColor(
-        this.getTextColor(shiny ? TextStyle.SUMMARY_DEX_NUM_GOLD : TextStyle.SUMMARY_DEX_NUM, true),
+        getTextColor(shiny ? TextStyle.SUMMARY_DEX_NUM_GOLD : TextStyle.SUMMARY_DEX_NUM, true),
       );
 
       if (forSeen ? this.speciesStarterDexEntry?.seenAttr : this.speciesStarterDexEntry?.caughtAttr) {
@@ -4021,8 +4022,8 @@ export class StarterSelectUiHandler extends MessageUiHandler {
         const isHidden = abilityIndex === (this.lastSpecies.ability2 ? 2 : 1);
         this.pokemonAbilityText
           .setText(ability.name)
-          .setColor(this.getTextColor(!isHidden ? TextStyle.SUMMARY_ALT : TextStyle.SUMMARY_GOLD))
-          .setShadowColor(this.getTextColor(!isHidden ? TextStyle.SUMMARY_ALT : TextStyle.SUMMARY_GOLD, true));
+          .setColor(getTextColor(!isHidden ? TextStyle.SUMMARY_ALT : TextStyle.SUMMARY_GOLD))
+          .setShadowColor(getTextColor(!isHidden ? TextStyle.SUMMARY_ALT : TextStyle.SUMMARY_GOLD, true));
 
         const passiveAttr = starterDataEntry.passiveAttr;
         const passiveAbility = allAbilities[this.lastSpecies.getPassiveAbility(formIndex)];
@@ -4051,14 +4052,14 @@ export class StarterSelectUiHandler extends MessageUiHandler {
 
           this.pokemonPassiveLabelText
             .setVisible(!isFreshStartChallenge)
-            .setColor(this.getTextColor(TextStyle.SUMMARY_ALT))
-            .setShadowColor(this.getTextColor(TextStyle.SUMMARY_ALT, true));
+            .setColor(getTextColor(TextStyle.SUMMARY_ALT))
+            .setShadowColor(getTextColor(TextStyle.SUMMARY_ALT, true));
           this.pokemonPassiveText
             .setVisible(!isFreshStartChallenge)
             .setText(passiveAbility.name)
-            .setColor(this.getTextColor(textStyle))
+            .setColor(getTextColor(textStyle))
             .setAlpha(textAlpha)
-            .setShadowColor(this.getTextColor(textStyle, true));
+            .setShadowColor(getTextColor(textStyle, true));
 
           if (this.activeTooltip === "PASSIVE") {
             globalScene.ui.editTooltip(`${passiveAbility.name}`, `${passiveAbility.description}`);
@@ -4090,9 +4091,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
           globalScene.ui.hideTooltip();
         }
 
-        this.pokemonNatureText.setText(
-          getNatureName(natureIndex as unknown as Nature, true, true, false, globalScene.uiTheme),
-        );
+        this.pokemonNatureText.setText(getNatureName(natureIndex as unknown as Nature, true, true, false));
 
         let levelMoves: LevelMoves;
         if (
@@ -4159,8 +4158,8 @@ export class StarterSelectUiHandler extends MessageUiHandler {
     } else {
       this.shinyOverlay.setVisible(false);
       this.pokemonNumberText
-        .setColor(this.getTextColor(TextStyle.SUMMARY))
-        .setShadowColor(this.getTextColor(TextStyle.SUMMARY, true));
+        .setColor(getTextColor(TextStyle.SUMMARY))
+        .setShadowColor(getTextColor(TextStyle.SUMMARY, true));
       this.pokemonGenderText.setText("");
       this.pokemonAbilityText.setText("");
       this.pokemonPassiveText.setText("");
@@ -4302,7 +4301,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
         textStyle = TextStyle.SUMMARY_GOLD;
         break;
     }
-    starter.label.setColor(this.getTextColor(textStyle)).setShadowColor(this.getTextColor(textStyle, true));
+    starter.label.setColor(getTextColor(textStyle)).setShadowColor(getTextColor(textStyle, true));
   }
 
   tryUpdateValue(add?: number, addingToParty?: boolean): boolean {
@@ -4322,8 +4321,8 @@ export class StarterSelectUiHandler extends MessageUiHandler {
     }
     this.valueLimitLabel
       .setText(`${newValueStr}/${valueLimit}`)
-      .setColor(this.getTextColor(!overLimit ? TextStyle.TOOLTIP_CONTENT : TextStyle.SUMMARY_PINK))
-      .setShadowColor(this.getTextColor(!overLimit ? TextStyle.TOOLTIP_CONTENT : TextStyle.SUMMARY_PINK, true));
+      .setColor(getTextColor(!overLimit ? TextStyle.TOOLTIP_CONTENT : TextStyle.SUMMARY_PINK))
+      .setShadowColor(getTextColor(!overLimit ? TextStyle.TOOLTIP_CONTENT : TextStyle.SUMMARY_PINK, true));
     if (overLimit) {
       globalScene.time.delayedCall(fixedInt(500), () => this.tryUpdateValue());
       return false;

--- a/src/ui/stats-container.ts
+++ b/src/ui/stats-container.ts
@@ -113,7 +113,7 @@ export class StatsContainer extends Phaser.GameObjects.Container {
           (ivs[ivChartStatIndexes[i]] / 31) * ivChartSize * ivChartStatCoordMultipliers[ivChartStatIndexes[i]][1],
         ]);
       const lastIvChartData = this.statsIvsCache || defaultIvChartData;
-      const perfectIVColor: string = getTextColor(TextStyle.SUMMARY_GOLD, false, globalScene.uiTheme);
+      const perfectIVColor: string = getTextColor(TextStyle.SUMMARY_GOLD, false);
       this.statsIvsCache = ivChartData.slice(0);
 
       this.ivStatValueTexts.map((t: BBCodeText, i: number) => {
@@ -127,7 +127,7 @@ export class StatsContainer extends Phaser.GameObjects.Container {
         }
         if (this.showDiff && originalIvs) {
           if (originalIvs[i] < ivs[i]) {
-            label += ` ([color=${getTextColor(TextStyle.SUMMARY_BLUE, false, globalScene.uiTheme)}][shadow=${getTextColor(TextStyle.SUMMARY_BLUE, true, globalScene.uiTheme)}]+${ivs[i] - originalIvs[i]}[/shadow][/color])`;
+            label += ` ([color=${getTextColor(TextStyle.SUMMARY_BLUE, false)}][shadow=${getTextColor(TextStyle.SUMMARY_BLUE, true)}]+${ivs[i] - originalIvs[i]}[/shadow][/color])`;
           } else {
             label += " (-)";
           }

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -25,7 +25,7 @@ import type { PokemonMove } from "#moves/pokemon-move";
 import type { Variant } from "#sprites/variant";
 import { getVariantTint } from "#sprites/variant";
 import { achvs } from "#system/achv";
-import { addBBCodeTextObject, addTextObject, getBBCodeFrag } from "#ui/text";
+import { addBBCodeTextObject, addTextObject, getBBCodeFrag, getTextColor } from "#ui/text";
 import { UiHandler } from "#ui/ui-handler";
 import {
   fixedInt,
@@ -361,9 +361,9 @@ export class SummaryUiHandler extends UiHandler {
     this.candyOverlay.setTint(argbFromRgba(rgbHexToRgba(colorScheme[1])));
 
     this.numberText.setText(padInt(this.pokemon.species.speciesId, 4));
-    this.numberText.setColor(this.getTextColor(!this.pokemon.isShiny() ? TextStyle.SUMMARY : TextStyle.SUMMARY_GOLD));
+    this.numberText.setColor(getTextColor(!this.pokemon.isShiny() ? TextStyle.SUMMARY : TextStyle.SUMMARY_GOLD));
     this.numberText.setShadowColor(
-      this.getTextColor(!this.pokemon.isShiny() ? TextStyle.SUMMARY : TextStyle.SUMMARY_GOLD, true),
+      getTextColor(!this.pokemon.isShiny() ? TextStyle.SUMMARY : TextStyle.SUMMARY_GOLD, true),
     );
     const spriteKey = this.pokemon.getSpriteKey(true);
     try {

--- a/src/ui/text.ts
+++ b/src/ui/text.ts
@@ -16,11 +16,7 @@ export function addTextObject(
   style: TextStyle,
   extraStyleOptions?: Phaser.Types.GameObjects.Text.TextStyle,
 ): Phaser.GameObjects.Text {
-  const { scale, styleOptions, shadowColor, shadowXpos, shadowYpos } = getTextStyleOptions(
-    style,
-    globalScene.uiTheme,
-    extraStyleOptions,
-  );
+  const { scale, styleOptions, shadowColor, shadowXpos, shadowYpos } = getTextStyleOptions(style, extraStyleOptions);
 
   const ret = globalScene.add
     .text(x, y, content, styleOptions)
@@ -38,11 +34,7 @@ export function setTextStyle(
   style: TextStyle,
   extraStyleOptions?: Phaser.Types.GameObjects.Text.TextStyle,
 ) {
-  const { scale, styleOptions, shadowColor, shadowXpos, shadowYpos } = getTextStyleOptions(
-    style,
-    globalScene.uiTheme,
-    extraStyleOptions,
-  );
+  const { scale, styleOptions, shadowColor, shadowXpos, shadowYpos } = getTextStyleOptions(style, extraStyleOptions);
   obj.setScale(scale).setShadow(shadowXpos, shadowYpos, shadowColor);
   if (!(styleOptions as Phaser.Types.GameObjects.Text.TextStyle).lineSpacing) {
     obj.setLineSpacing(scale * 30);
@@ -60,11 +52,7 @@ export function addBBCodeTextObject(
   style: TextStyle,
   extraStyleOptions?: Phaser.Types.GameObjects.Text.TextStyle,
 ): BBCodeText {
-  const { scale, styleOptions, shadowColor, shadowXpos, shadowYpos } = getTextStyleOptions(
-    style,
-    globalScene.uiTheme,
-    extraStyleOptions,
-  );
+  const { scale, styleOptions, shadowColor, shadowXpos, shadowYpos } = getTextStyleOptions(style, extraStyleOptions);
 
   const ret = new BBCodeText(globalScene, x, y, content, styleOptions as BBCodeText.TextStyle);
   globalScene.add.existing(ret);
@@ -84,7 +72,7 @@ export function addTextInputObject(
   style: TextStyle,
   extraStyleOptions?: InputText.IConfig,
 ): InputText {
-  const { scale, styleOptions } = getTextStyleOptions(style, globalScene.uiTheme, extraStyleOptions);
+  const { scale, styleOptions } = getTextStyleOptions(style, extraStyleOptions);
 
   const ret = globalScene.add.rexInputText(x, y, width, height, styleOptions as InputText.IConfig);
   ret.setScale(scale);
@@ -94,7 +82,6 @@ export function addTextInputObject(
 
 export function getTextStyleOptions(
   style: TextStyle,
-  uiTheme: UiTheme,
   extraStyleOptions?: Phaser.Types.GameObjects.Text.TextStyle,
 ): TextStyleOptions {
   const lang = i18next.resolvedLanguage;
@@ -106,7 +93,7 @@ export function getTextStyleOptions(
   let styleOptions: Phaser.Types.GameObjects.Text.TextStyle = {
     fontFamily: "emerald",
     fontSize: 96,
-    color: getTextColor(style, false, uiTheme),
+    color: getTextColor(style, false),
     padding: {
       bottom: 6,
     },
@@ -465,7 +452,7 @@ export function getTextStyleOptions(
       break;
   }
 
-  const shadowColor = getTextColor(style, true, uiTheme);
+  const shadowColor = getTextColor(style, true);
 
   if (extraStyleOptions) {
     if (extraStyleOptions.fontSize) {
@@ -480,8 +467,8 @@ export function getTextStyleOptions(
   return { scale, styleOptions, shadowColor, shadowXpos, shadowYpos };
 }
 
-export function getBBCodeFrag(content: string, textStyle: TextStyle, uiTheme: UiTheme = UiTheme.DEFAULT): string {
-  return `[color=${getTextColor(textStyle, false, uiTheme)}][shadow=${getTextColor(textStyle, true, uiTheme)}]${content}`;
+export function getBBCodeFrag(content: string, textStyle: TextStyle): string {
+  return `[color=${getTextColor(textStyle, false)}][shadow=${getTextColor(textStyle, true)}]${content}`;
 }
 
 /**
@@ -500,14 +487,9 @@ export function getBBCodeFrag(content: string, textStyle: TextStyle, uiTheme: Ui
  * @param forWindow set to `true` if the text is to be displayed in a window ({@linkcode BattleScene.addWindow})
  *  it will replace all instances of the default MONEY TextStyle by {@linkcode TextStyle.MONEY_WINDOW}
  */
-export function getTextWithColors(
-  content: string,
-  primaryStyle: TextStyle,
-  uiTheme: UiTheme,
-  forWindow?: boolean,
-): string {
+export function getTextWithColors(content: string, primaryStyle: TextStyle, forWindow?: boolean): string {
   // Apply primary styling before anything else
-  let text = getBBCodeFrag(content, primaryStyle, uiTheme) + "[/color][/shadow]";
+  let text = getBBCodeFrag(content, primaryStyle) + "[/color][/shadow]";
   const primaryStyleString = [...text.match(new RegExp(/\[color=[^[]*\]\[shadow=[^[]*\]/i))!][0];
 
   /* For money text displayed in game windows, we can't use the default {@linkcode TextStyle.MONEY}
@@ -520,10 +502,7 @@ export function getTextWithColors(
   // Set custom colors
   text = text.replace(/@\[([^{]*)\]{([^}]*)}/gi, (_substring, textStyle: string, textToColor: string) => {
     return (
-      "[/color][/shadow]" +
-      getBBCodeFrag(textToColor, TextStyle[textStyle], uiTheme) +
-      "[/color][/shadow]" +
-      primaryStyleString
+      "[/color][/shadow]" + getBBCodeFrag(textToColor, TextStyle[textStyle]) + "[/color][/shadow]" + primaryStyleString
     );
   });
 
@@ -532,8 +511,8 @@ export function getTextWithColors(
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: This is a giant switch which is the best option.
-export function getTextColor(textStyle: TextStyle, shadow?: boolean, uiTheme: UiTheme = UiTheme.DEFAULT): string {
-  const isLegacyTheme = uiTheme === UiTheme.LEGACY;
+export function getTextColor(textStyle: TextStyle, shadow?: boolean): string {
+  const isLegacyTheme = globalScene.uiTheme === UiTheme.LEGACY;
   switch (textStyle) {
     case TextStyle.MESSAGE:
       return !shadow ? "#f8f8f8" : "#6b5a73";

--- a/src/ui/ui-handler.ts
+++ b/src/ui/ui-handler.ts
@@ -1,8 +1,6 @@
 import { globalScene } from "#app/global-scene";
 import type { Button } from "#enums/buttons";
-import type { TextStyle } from "#enums/text-style";
 import type { UiMode } from "#enums/ui-mode";
-import { getTextColor } from "#ui/text";
 
 /**
  * A basic abstract class to act as a holder and processor for UI elements.
@@ -31,10 +29,6 @@ export abstract class UiHandler {
 
   getUi() {
     return globalScene.ui;
-  }
-
-  getTextColor(style: TextStyle, shadow = false): string {
-    return getTextColor(style, shadow, globalScene.uiTheme);
   }
 
   getCursor(): number {

--- a/src/ui/ui-theme.ts
+++ b/src/ui/ui-theme.ts
@@ -51,7 +51,7 @@ export function addWindow(
     windowVariant = WindowVariant.NORMAL;
   }
 
-  const borderSize = globalScene.uiTheme ? 6 : 8;
+  const borderSize = globalScene.uiTheme === UiTheme.LEGACY ? 6 : 8;
 
   const window = globalScene.add.nineslice(
     x,
@@ -153,7 +153,11 @@ export function addUiThemeOverrides(): void {
     frame?: string | number,
   ): Phaser.GameObjects.Image {
     let legacy = false;
-    if (typeof texture === "string" && globalScene.uiTheme && legacyCompatibleImages.includes(texture)) {
+    if (
+      typeof texture === "string" &&
+      globalScene.uiTheme === UiTheme.LEGACY &&
+      legacyCompatibleImages.includes(texture)
+    ) {
       legacy = true;
       texture += "_legacy";
     }
@@ -176,7 +180,11 @@ export function addUiThemeOverrides(): void {
     frame?: string | number,
   ): Phaser.GameObjects.Sprite {
     let legacy = false;
-    if (typeof texture === "string" && globalScene.uiTheme && legacyCompatibleImages.includes(texture)) {
+    if (
+      typeof texture === "string" &&
+      globalScene.uiTheme === UiTheme.LEGACY &&
+      legacyCompatibleImages.includes(texture)
+    ) {
       legacy = true;
       texture += "_legacy";
     }
@@ -205,7 +213,11 @@ export function addUiThemeOverrides(): void {
     bottomHeight?: number,
   ): Phaser.GameObjects.NineSlice {
     let legacy = false;
-    if (typeof texture === "string" && globalScene.uiTheme && legacyCompatibleImages.includes(texture)) {
+    if (
+      typeof texture === "string" &&
+      globalScene.uiTheme === UiTheme.LEGACY &&
+      legacyCompatibleImages.includes(texture)
+    ) {
       legacy = true;
       texture += "_legacy";
     }


### PR DESCRIPTION
This method of `UiHandler`:
```ts
  getTextColor(style: TextStyle, shadow = false): string {
    return getTextColor(style, shadow, globalScene.uiTheme);
  }
```
is just used to all the `getTextColor` utility function passing the ui theme, this is not necessary anymore since the utility functions can directly access `globalScene`.

There were a few more functions across the code which needed to pass `globalScene.uiTheme` as a parameter, which is not needed.

## Why am I making these changes?
Reduce cluttering in the code.

## What are the changes from a developer perspective?
The `getTextColor` utility function in `text.ts` does not need `globalScene.uiTheme` as a parameter anymore, this propagates to a few other functions that call it.

The `UiHandler.getTextColor` method has been removed.

Additionally, a few places where `globalScene.uiTheme` or `!globalScene.uiTheme` was used as a condition have been replaced with an explicit check to `globalScene.uiTheme === UiTheme.DEFAULT` or `globalScene.uiTheme === UiTheme.LEGACY` (this can be checked by looking up `globalScene.uiTheme` with the search function, there are now only a dozen or so references left.


## How to test the changes?

Open the game and check that UI is behaving as usual.


## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?
