### PR TITLE
[Bug] Future Sight no longer crashes after catching the user

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -863,6 +863,8 @@ export class BattleScene extends SceneBase {
    * @param pokemonId - The ID whose Pokemon will be retrieved.
    * @returns The {@linkcode Pokemon} associated with the given id.
    * Returns `null` if the ID is `undefined` or not present in either party.
+   * @todo Change the `null` to `undefined` and update callers' signatures -
+   * this is weird and causes a lot of random jank
    */
   getPokemonById(pokemonId: number | undefined): Pokemon | null {
     if (isNullOrUndefined(pokemonId)) {

--- a/src/data/battle-anims.ts
+++ b/src/data/battle-anims.ts
@@ -835,7 +835,7 @@ export abstract class BattleAnim {
   // biome-ignore lint/complexity/noBannedTypes: callback is used liberally
   play(onSubstitute?: boolean, callback?: Function) {
     const isOppAnim = this.isOppAnim();
-    const user = !isOppAnim ? this.user! : this.target!; // TODO: are those bangs correct?
+    const user = !isOppAnim ? this.user! : this.target!; // TODO: These bangs are LITERALLY not correct at all
     const target = !isOppAnim ? this.target! : this.user!;
 
     if (!target?.isOnField() && !this.playRegardlessOfIssues) {

--- a/src/data/positional-tags/positional-tag.ts
+++ b/src/data/positional-tags/positional-tag.ts
@@ -126,7 +126,9 @@ export class DelayedAttackTag extends PositionalTag implements DelayedAttackArgs
     // Silently disappear if either source or target are missing or happen to be the same pokemon
     // (i.e. targeting oneself)
     // We also need to check for fainted targets as they don't technically leave the field until _after_ the turn ends
-    return !!source && !!target && source !== target && !target.isFainted();
+    // TODO: Figure out a way to store the target's offensive stat if they faint to allow pending attacks to persist
+    // TODO: Remove the `?.scene` checks once battle anims are cleaned up - needed to avoid catch+release crash
+    return !!source?.scene && !!target?.scene && source !== target && !target.isFainted();
   }
 }
 

--- a/test/test-utils/phase-interceptor.ts
+++ b/test/test-utils/phase-interceptor.ts
@@ -1,6 +1,7 @@
 import type { BattleScene } from "#app/battle-scene";
 import { Phase } from "#app/phase";
 import { UiMode } from "#enums/ui-mode";
+import { AttemptCapturePhase } from "#phases/attempt-capture-phase";
 import { AttemptRunPhase } from "#phases/attempt-run-phase";
 import { BattleEndPhase } from "#phases/battle-end-phase";
 import { BerryPhase } from "#phases/berry-phase";
@@ -183,6 +184,7 @@ export class PhaseInterceptor {
     PostGameOverPhase,
     RevivalBlessingPhase,
     PokemonHealPhase,
+    AttemptCapturePhase,
   ];
 
   private endBySetMode = [


### PR DESCRIPTION
## What are the changes the user will see?
Delayed attacks used by wild pokemon will not crash if the source is caught before the attack is released

## Why am I making these changes?
Fixes a regression from the future sight PR.

## What are the changes from a developer perspective?
Added the ye olde `?.scene` checks to the FS condition function

Added a test to make sure it was fixed

Added TODOs mentioning how we really need to get this shit together

## Screenshots/Videos
N/A
## How to test the changes?
run the new test in `delayed-attack.test.ts`
## Checklist
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?