### PR TITLE
Add blacklist of moves that can't be forced STAB.

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3220,9 +3220,51 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       Math.ceil(Math.pow(m[1], weightMultiplier) * 100),
     ]);
 
+    const STAB_BLACKLIST = [
+      MoveId.SHELL_TRAP,
+      MoveId.FUTURE_SIGHT,
+      MoveId.UPPER_HAND,
+      MoveId.SKY_DROP,
+      MoveId.STEEL_ROLLER,
+      MoveId.BELCH,
+      MoveId.FAKE_OUT,
+      MoveId.LAST_RESORT,
+      MoveId.SYNCHRONOISE,
+      MoveId.DREAM_EATER,
+      MoveId.DOOM_DESIRE,
+      MoveId.FOCUS_PUNCH,
+      MoveId.NIGHT_SHADE,
+      MoveId.DRAGON_RAGE,
+      MoveId.SONIC_BOOM,
+      MoveId.BIDE,
+      MoveId.COMEUPPANCE,
+      MoveId.MIRROR_COAT,
+      MoveId.METAL_BURST,
+      MoveId.COUNTER,
+      MoveId.FLING,
+      MoveId.NATURAL_GIFT,
+      MoveId.SPIT_UP,
+      MoveId.FISSURE,
+      MoveId.SHEER_COLD,
+      MoveId.HORN_DRILL,
+      MoveId.GUILLOTINE,
+      MoveId.ENDEAVOR,
+      MoveId.NATURES_MADNESS,
+      MoveId.RUINATION,
+      MoveId.SUPER_FANG,
+      MoveId.SNORE,
+      MoveId.HOLD_BACK,
+      MoveId.BEAT_UP,
+      MoveId.PSYWAVE,
+      MoveId.FIRST_IMPRESSION,
+    ];
+
     // All Pokemon force a STAB move first
     const stabMovePool = baseWeights.filter(
-      m => allMoves[m[0]].category !== MoveCategory.STATUS && this.isOfType(allMoves[m[0]].type),
+      m =>
+        allMoves[m[0]].category !== MoveCategory.STATUS &&
+        this.isOfType(allMoves[m[0]].type) &&
+        !STAB_BLACKLIST.includes(m[0]),
     );
 
     if (stabMovePool.length) {
@@ -3235,7 +3277,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       this.moveset.push(new PokemonMove(stabMovePool[index][0]));
     } else {
       // If there are no damaging STAB moves, just force a random damaging move
-      const attackMovePool = baseWeights.filter(m => allMoves[m[0]].category !== MoveCategory.STATUS);
+      const attackMovePool = baseWeights.filter(
+        m => allMoves[m[0]].category !== MoveCategory.STATUS && !STAB_BLACKLIST.includes(m[0]),
+      );
       if (attackMovePool.length) {
         const totalWeight = attackMovePool.reduce((v, m) => v + m[1], 0);
         let rand = randSeedInt(totalWeight);
@@ -3273,7 +3317,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
               ret = Math.ceil(
                 (m[1] /
                   Math.max(Math.pow(4, this.moveset.filter(mo => (mo.getMove().power ?? 0) > 1).length) / 8, 0.5)) *
-                  (this.isOfType(allMoves[m[0]].type) ? 20 : 1),
+                  (this.isOfType(allMoves[m[0]].type) && !STAB_BLACKLIST.includes(m[0]) ? 20 : 1),
               );
             } else {
               ret = m[1];


### PR DESCRIPTION
## What are the changes the user will see?
A few dozen specific moves should no longer be generated as the only damaging move in a moveset.

## Why am I making these changes?
Balance asked.

## What are the changes from a developer perspective?
The blacklist is currently hardcoded inside the moveset generation code.

## Screenshots/Videos
N/A

## How to test the changes?
It's easiest to see this with a debugger, but just generating movesets for pokemon who get these moves can work.

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?
