### PR TITLE
[Misc/Docs] Fix Typedoc workflow to not break the "go to main" link

### DIFF
--- a/typedoc-plugins/typedoc-plugin-rename-svg.js
+++ b/typedoc-plugins/typedoc-plugin-rename-svg.js
@@ -19,15 +19,10 @@ export function load(app) {
   app.renderer.on(Renderer.EVENT_END_PAGE, page => {
     if (page.pageKind === PageKind.Index && page.contents) {
       page.contents = page.contents
-        // Replace links to the beta documentation site with the current ref name
+        // Replace the SVG to the beta documentation site with the current ref name
         .replace(
-          /href="(.*pagefaultgames.github.io\/pokerogue\/).*?"/, // formatting
-          `href="$1/${process.env.REF_NAME}"`,
-        )
-        // Replace the link to Beta's coverage SVG with the SVG file for the branch in question.
-        .replace(
-          /img src=".*?coverage.svg/, // formatting
-          `img src="coverage.svg"`,
+          /^<a href="(.*?)\/beta(.*?)"><img src=".*coverage.svg"/m, // formatting
+          `<a href="$1/${process.env.REF_NAME}$2"><"coverage.svg"`,
         );
     }
   });

--- a/typedoc-plugins/typedoc-plugin-rename-svg.js
+++ b/typedoc-plugins/typedoc-plugin-rename-svg.js
@@ -22,7 +22,7 @@ export function load(app) {
         // Replace the SVG to the beta documentation site with the current ref name
         .replace(
           /^<a href="(.*?)\/beta(.*?)"><img src=".*coverage.svg"/m, // formatting
-          `<a href="$1/${process.env.REF_NAME}$2"><"coverage.svg"`,
+          `<a href="$1/${process.env.REF_NAME}$2"><img src="coverage.svg"`,
         );
     }
   });


### PR DESCRIPTION
## What are the changes the user will see?
Docs site will not have broken link

## Why am I making these changes?
broken link bad

## What are the changes from a developer perspective?
Fixed the plugin that renames the SVG to only rename the `href` for the svg file.

## Screenshots/Videos
N/A
## How to test the changes?
`REF_NAME=beta pnpm typedoc --skipErrorChecking`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)