### PR TITLE
[Bug] Secondary fusions with gender evo condition can now evolve

### DIFF
--- a/src/data/balance/pokemon-evolutions.ts
+++ b/src/data/balance/pokemon-evolutions.ts
@@ -186,7 +186,7 @@ export class SpeciesEvolutionCondition {
             m.getStackCount() + pokemon.getPersistentTreasureCount() >= cond.value
           );
         case EvoCondKey.GENDER:
-          return  cond.gender === (forFusion ? pokemon.fusionGender : pokemon.gender);
+          return cond.gender === (forFusion ? pokemon.fusionGender : pokemon.gender);
         case EvoCondKey.SHEDINJA: // Shedinja cannot be evolved into directly
           return false;
         case EvoCondKey.BIOME:

--- a/src/data/balance/pokemon-evolutions.ts
+++ b/src/data/balance/pokemon-evolutions.ts
@@ -166,7 +166,7 @@ export class SpeciesEvolutionCondition {
     return this.desc;
   }
 
-  public conditionsFulfilled(pokemon: Pokemon): boolean {
+  public conditionsFulfilled(pokemon: Pokemon, forFusion = false): boolean {
     console.log(this.data);
     return this.data.every(cond => {
       switch (cond.key) {
@@ -186,7 +186,7 @@ export class SpeciesEvolutionCondition {
             m.getStackCount() + pokemon.getPersistentTreasureCount() >= cond.value
           );
         case EvoCondKey.GENDER:
-          return pokemon.gender === cond.gender;
+          return  cond.gender === (forFusion ? pokemon.fusionGender : pokemon.gender);
         case EvoCondKey.SHEDINJA: // Shedinja cannot be evolved into directly
           return false;
         case EvoCondKey.BIOME:
@@ -293,7 +293,7 @@ export class SpeciesFormEvolution {
       pokemon.level >= this.level &&
       // Check form key, using the fusion's form key if we're checking the fusion
       (this.preFormKey == null || (forFusion ? pokemon.getFusionFormKey() : pokemon.getFormKey()) === this.preFormKey) &&
-      (this.condition == null || this.condition.conditionsFulfilled(pokemon)) &&
+      (this.condition == null || this.condition.conditionsFulfilled(pokemon, forFusion)) &&
       ((item ?? EvolutionItem.NONE) === (this.item ?? EvolutionItem.NONE))
     );
   }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2635,7 +2635,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         e => new FusionSpeciesFormEvolution(this.species.speciesId, e),
       );
       for (const fe of fusionEvolutions) {
-        if (fe.validate(this)) {
+        if (fe.validate(this, true)) {
           return fe;
         }
       }


### PR DESCRIPTION
## What are the changes the user will see?
Fusions with a secondary pokemon that is gender locked will now evolve properly based on the gender of the fusion pokemon instead of the gender of the base pokemon.

## Why am I making these changes?
Fixes a bug reported: https://discord.com/channels/1125469663833370665/1414159874039873566/1414159874039873566
## What are the changes from a developer perspective?

Actually use the `forFusion` parameter when checking fusions evolutions.

## Screenshots/Videos
<details><summary>Magearne evolving with lechonk fusion</summary>

https://github.com/user-attachments/assets/9bab1d28-9628-4b36-819e-5d60d0b6e382
</details> 

## How to test the changes?
```ts
const overrides = {
  STARTER_SPECIES_OVERRIDE: SpeciesId.MAGEARNA,
  STARTER_FUSION_OVERRIDE: true,
  STARTER_FUSION_SPECIES_OVERRIDE: SpeciesId.LECHONK,
  ITEM_REWARD_OVERRIDE: [
    { name: "RARE_CANDY"},
  ],
  STARTING_LEVEL_OVERRIDE: 100
} satisfies Partial<InstanceType<OverridesType>>;
```

Since lechonk can evolve with either gender, no need to worry about which gender it is. Though if you want to check for a specific gender, edit around line 3205 in `src/field/pokemon.ts` to force a certain gender.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes? 
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~