### PR TITLE
[Bug] Fix memory leak in egg hatch

### DIFF
--- a/src/phases/egg-hatch-phase.ts
+++ b/src/phases/egg-hatch-phase.ts
@@ -230,6 +230,7 @@ export class EggHatchPhase extends Phase {
     } else {
       globalScene.time.delayedCall(250, () => globalScene.setModifiersVisible(true));
     }
+    this.pokemon?.destroy();
     super.end();
   }
 

--- a/src/phases/egg-summary-phase.ts
+++ b/src/phases/egg-summary-phase.ts
@@ -39,6 +39,10 @@ export class EggSummaryPhase extends Phase {
   }
 
   end() {
+    this.eggHatchData.forEach(data => {
+      data.pokemon?.destroy();
+    });
+    this.eggHatchData = [];
     globalScene.time.delayedCall(250, () => globalScene.setModifiersVisible(true));
     globalScene.ui.setModeForceTransition(UiMode.MESSAGE).then(() => {
       super.end();


### PR DESCRIPTION
## What are the changes the user will see?
Reduced memory usage

## Why am I making these changes?
Was looking at https://github.com/Despair-Games/poketernity/pull/882 and saw this would be easy.

## What are the changes from a developer perspective?
Call `destroy` on the pokemon created in egg hatch phase and egg summary phase when their UIs are closed.

## Screenshots/Videos

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist
- [x] **I'm using `hotfix-1.10.7` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually? Yeah nothing breaks
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes? How? If i hold onto it in a test, it's not destroyed...
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~