### PR TITLE
[bug] ssui refactor Fix pokerus and select borders

### DIFF
--- a/src/ui/handlers/starter-select-ui-handler.ts
+++ b/src/ui/handlers/starter-select-ui-handler.ts
@@ -2598,11 +2598,6 @@ export class StarterSelectUiHandler extends MessageUiHandler {
     this.scrollCursor = 0;
     this.filteredStarterIds = [];
 
-    // biome-ignore-start lint/nursery/useIterableCallbackReturn: benign
-    this.pokerusCursorObjs.forEach(cursor => cursor.setVisible(false));
-    this.starterCursorObjs.forEach(cursor => cursor.setVisible(false));
-    // biome-ignore-end lint/nursery/useIterableCallbackReturn: benign
-
     this.filterBar.updateFilterLabels();
 
     // filter
@@ -2830,6 +2825,11 @@ export class StarterSelectUiHandler extends MessageUiHandler {
 
     this.starterSelectScrollBar.setScrollCursor(this.scrollCursor);
 
+    // biome-ignore-start lint/nursery/useIterableCallbackReturn: benign
+    this.pokerusCursorObjs.forEach(cursor => cursor.setVisible(false));
+    this.starterCursorObjs.forEach(cursor => cursor.setVisible(false));
+    // biome-ignore-end lint/nursery/useIterableCallbackReturn: benign
+
     let pokerusCursorIndex = 0;
     this.starterContainers.forEach((container, i) => {
       const offset_i = i + onScreenFirstIndex;
@@ -2863,14 +2863,14 @@ export class StarterSelectUiHandler extends MessageUiHandler {
         }
 
         if (this.pokerusSpecies.includes(container.species)) {
-          this.pokerusCursorObjs[pokerusCursorIndex].setPosition(container.x - 1, container.y + 1).setVisible(false);
+          this.pokerusCursorObjs[pokerusCursorIndex].setPosition(container.x - 1, container.y + 1).setVisible(true);
           pokerusCursorIndex++;
         }
 
         if (this.starterSpecies.includes(container.species)) {
           this.starterCursorObjs[this.starterSpecies.indexOf(container.species)]
             .setPosition(container.x - 1, container.y + 1)
-            .setVisible(false);
+            .setVisible(true);
         }
 
         this.updateStarterValueLabel(container);


### PR DESCRIPTION
## What are the changes the user will see?

- pokerus borders will show
- selected borders will work properly

## Why am I making these changes?

fix bugs

## What are the changes from a developer perspective?

- changed `setVisible()` from false to true for the borders
- moved the reset to the `updateScroll` method

## Screenshots/Videos


## How to test the changes?

- select a pokemon and scroll it of the screen
- filter for pokerus

## Checklist
- [x] **I'm using `ssui-refactor` as my base branch**
- [x]  There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?