### PR TITLE
[bug] show correct tint

### DIFF
--- a/src/ui/handlers/starter-select-ui-handler.ts
+++ b/src/ui/handlers/starter-select-ui-handler.ts
@@ -3422,7 +3422,9 @@ export class StarterSelectUiHandler extends MessageUiHandler {
     const remainValue = valueLimit - newValue;
     for (let s = 0; s < this.starterContainers.length; s++) {
       /** Cost of pokemon species */
-      const speciesStarterValue = globalScene.gameData.getSpeciesStarterValue(this.allStarterSpecies[s].speciesId);
+      const speciesStarterValue = globalScene.gameData.getSpeciesStarterValue(
+        this.starterContainers[s].species.speciesId,
+      );
       /** {@linkcode Phaser.GameObjects.Sprite} object of Pokémon for setting the alpha value */
       const speciesSprite = this.starterContainers[s].icon;
 

--- a/src/ui/handlers/starter-select-ui-handler.ts
+++ b/src/ui/handlers/starter-select-ui-handler.ts
@@ -2823,6 +2823,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
     });
 
     this.updateScroll();
+    this.tryUpdateValue();
   };
 
   updateScroll = () => {


### PR DESCRIPTION
## What are the changes the user will see?

- correctly grey out too expensive starters
- correctly tints starters when applying filters

## Why am I making these changes?

bug fix

## What are the changes from a developer perspective?

access the starter value with the correct speciesId

update tint on filter

## Screenshots/Videos

## How to test the changes?

select a pokemon and check that all too expensive mons are greyed out

## Checklist
- [x] **I'm using `ssui-refactor` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?