### PR TITLE
[Test] Enforced usage of test matchers across existing test files

### DIFF
--- a/test/abilities/aroma-veil.test.ts
+++ b/test/abilities/aroma-veil.test.ts
@@ -57,7 +57,7 @@ describe("Moves - Aroma Veil", () => {
     await game.move.selectEnemyMove(MoveId.IMPRISON, BattlerIndex.PLAYER);
     await game.move.selectEnemyMove(MoveId.SPLASH);
     await game.toNextTurn();
-    expect(game.scene.arena.getTag(ArenaTagType.IMPRISON)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.IMPRISON);
     party.forEach(p => {
       expect(p.getTag(BattlerTagType.IMPRISON)).toBeDefined();
     });

--- a/test/abilities/corrosion.test.ts
+++ b/test/abilities/corrosion.test.ts
@@ -39,12 +39,12 @@ describe("Abilities - Corrosion", () => {
     await game.classicMode.startBattle([SpeciesId.SALANDIT]);
 
     const enemy = game.field.getEnemyPokemon();
-    expect(enemy.status?.effect).toBeUndefined();
+    expect(enemy).toHaveStatusEffect(StatusEffect.NONE);
 
     game.move.use(MoveId.POISON_GAS);
     await game.toEndOfTurn();
 
-    expect(enemy.status?.effect).toBe(StatusEffect.POISON);
+    expect(enemy).toHaveStatusEffect(StatusEffect.POISON);
   });
 
   it("should not affect Toxic Spikes", async () => {
@@ -55,7 +55,7 @@ describe("Abilities - Corrosion", () => {
     await game.toNextWave();
 
     const enemyPokemon = game.field.getEnemyPokemon();
-    expect(enemyPokemon.status).toBeUndefined();
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   it("should not affect an opponent's Synchronize ability", async () => {
@@ -64,13 +64,13 @@ describe("Abilities - Corrosion", () => {
 
     const playerPokemon = game.field.getPlayerPokemon();
     const enemyPokemon = game.field.getEnemyPokemon();
-    expect(enemyPokemon.status?.effect).toBeUndefined();
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.NONE);
 
     game.move.use(MoveId.TOXIC);
     await game.toEndOfTurn();
 
-    expect(enemyPokemon.status?.effect).toBe(StatusEffect.TOXIC);
-    expect(playerPokemon.status?.effect).toBeUndefined();
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.TOXIC);
+    expect(playerPokemon).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   it("should affect the user's held Toxic Orb", async () => {
@@ -78,11 +78,11 @@ describe("Abilities - Corrosion", () => {
     await game.classicMode.startBattle([SpeciesId.SALAZZLE]);
 
     const salazzle = game.field.getPlayerPokemon();
-    expect(salazzle.status?.effect).toBeUndefined();
+    expect(salazzle).toHaveStatusEffect(StatusEffect.NONE);
 
     game.move.use(MoveId.SPLASH);
     await game.toNextTurn();
 
-    expect(salazzle.status?.effect).toBe(StatusEffect.TOXIC);
+    expect(salazzle).toHaveStatusEffect(StatusEffect.TOXIC);
   });
 });

--- a/test/abilities/disguise.test.ts
+++ b/test/abilities/disguise.test.ts
@@ -99,7 +99,7 @@ describe("Abilities - Disguise", () => {
     await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(mimikyu.formIndex).toBe(disguisedForm);
-    expect(mimikyu.status?.effect).toBe(StatusEffect.POISON);
+    expect(mimikyu).toHaveStatusEffect(StatusEffect.POISON);
     expect(mimikyu.getStatStage(Stat.SPD)).toBe(-1);
     expect(mimikyu.hp).toBeLessThan(mimikyu.getMaxHp());
   });

--- a/test/abilities/early-bird.test.ts
+++ b/test/abilities/early-bird.test.ts
@@ -44,18 +44,18 @@ describe("Abilities - Early Bird", () => {
     game.move.select(MoveId.REST);
     await game.toNextTurn();
 
-    expect(player.status?.effect).toBe(StatusEffect.SLEEP);
+    expect(player).toHaveStatusEffect(StatusEffect.SLEEP);
 
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
 
-    expect(player.status?.effect).toBe(StatusEffect.SLEEP);
+    expect(player).toHaveStatusEffect(StatusEffect.SLEEP);
     expect(player.getLastXMoves(1)[0].result).toBe(MoveResult.FAIL);
 
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
 
-    expect(player.status?.effect).toBeUndefined();
+    expect(player).toHaveStatusEffect(StatusEffect.NONE);
     expect(player.getLastXMoves(1)[0].result).toBe(MoveResult.SUCCESS);
   });
 
@@ -68,13 +68,13 @@ describe("Abilities - Early Bird", () => {
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
 
-    expect(player.status?.effect).toBe(StatusEffect.SLEEP);
+    expect(player).toHaveStatusEffect(StatusEffect.SLEEP);
     expect(player.getLastXMoves(1)[0].result).toBe(MoveResult.FAIL);
 
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
 
-    expect(player.status?.effect).toBeUndefined();
+    expect(player).toHaveStatusEffect(StatusEffect.NONE);
     expect(player.getLastXMoves(1)[0].result).toBe(MoveResult.SUCCESS);
   });
 
@@ -87,7 +87,7 @@ describe("Abilities - Early Bird", () => {
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
 
-    expect(player.status?.effect).toBeUndefined();
+    expect(player).toHaveStatusEffect(StatusEffect.NONE);
     expect(player.getLastXMoves(1)[0].result).toBe(MoveResult.SUCCESS);
   });
 });

--- a/test/abilities/flower-veil.test.ts
+++ b/test/abilities/flower-veil.test.ts
@@ -51,14 +51,14 @@ describe("Abilities - Flower Veil", () => {
     await game.move.selectEnemyMove(MoveId.TACKLE);
     await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.toNextTurn();
-    expect(user.status?.effect).toBe(StatusEffect.SLEEP);
+    expect(user).toHaveStatusEffect(StatusEffect.SLEEP);
 
     // remove sleep status so we can get burn from the orb
     user.resetStatus();
     game.move.select(MoveId.SPLASH);
     await game.move.selectEnemyMove(MoveId.SPLASH);
     await game.toNextTurn();
-    expect(user.status?.effect).toBe(StatusEffect.BURN);
+    expect(user).toHaveStatusEffect(StatusEffect.BURN);
   });
 
   it("should prevent drowsiness from yawn for a grass user and its grass allies", async () => {
@@ -87,7 +87,7 @@ describe("Abilities - Flower Veil", () => {
     game.move.select(MoveId.SPLASH);
     await game.move.selectEnemyMove(MoveId.THUNDER_WAVE);
     await game.toNextTurn();
-    expect(game.field.getPlayerPokemon().status).toBeUndefined();
+    expect(game.field.getPlayerPokemon()).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   it("should not prevent status conditions for a non-grass user and its non-grass allies", async () => {
@@ -102,8 +102,8 @@ describe("Abilities - Flower Veil", () => {
     await game.move.selectEnemyMove(MoveId.THUNDER_WAVE, BattlerIndex.PLAYER);
     await game.move.selectEnemyMove(MoveId.THUNDER_WAVE, BattlerIndex.PLAYER_2);
     await game.phaseInterceptor.to("BerryPhase");
-    expect(user.status?.effect).toBe(StatusEffect.PARALYSIS);
-    expect(ally.status?.effect).toBe(StatusEffect.PARALYSIS);
+    expect(user).toHaveStatusEffect(StatusEffect.PARALYSIS);
+    expect(ally).toHaveStatusEffect(StatusEffect.PARALYSIS);
   });
 
   /*******************************************

--- a/test/abilities/good-as-gold.test.ts
+++ b/test/abilities/good-as-gold.test.ts
@@ -82,8 +82,8 @@ describe("Abilities - Good As Gold", () => {
     await game.phaseInterceptor.to("BerryPhase");
     expect(good_as_gold.getAbility().id).toBe(AbilityId.GOOD_AS_GOLD);
     expect(good_as_gold.getStatStage(Stat.ATK)).toBe(0);
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.STEALTH_ROCK, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.STEALTH_ROCK, ArenaTagSide.PLAYER);
+    expect(game).toHaveArenaTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER);
   });
 
   it("should not block field targeted effects in singles", async () => {
@@ -93,7 +93,7 @@ describe("Abilities - Good As Gold", () => {
     game.move.select(MoveId.SPLASH, 0);
     await game.phaseInterceptor.to("BerryPhase");
 
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.SPIKES, ArenaTagSide.PLAYER);
   });
 
   it("should block the ally's helping hand", async () => {

--- a/test/abilities/good-as-gold.test.ts
+++ b/test/abilities/good-as-gold.test.ts
@@ -120,12 +120,12 @@ describe("Abilities - Good As Gold", () => {
     game.move.use(MoveId.SPLASH, 0);
     game.move.use(MoveId.HEAL_BELL, 1);
     await game.toNextTurn();
-    expect(milotic.status?.effect).toBe(StatusEffect.BURN);
+    expect(milotic).toHaveStatusEffect(StatusEffect.BURN);
 
     game.doSwitchPokemon(2);
     game.move.use(MoveId.HEAL_BELL, 1);
     await game.toNextTurn();
-    expect(milotic.status?.effect).toBeUndefined();
+    expect(milotic).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   it("should not block field targeted effects like rain dance", async () => {

--- a/test/abilities/gulp-missile.test.ts
+++ b/test/abilities/gulp-missile.test.ts
@@ -179,7 +179,7 @@ describe("Abilities - Gulp Missile", () => {
     await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(enemy.damageAndUpdate).toHaveReturnedWith(getEffectDamage(enemy));
-    expect(enemy.status?.effect).toBe(StatusEffect.PARALYSIS);
+    expect(enemy).toHaveStatusEffect(StatusEffect.PARALYSIS);
     expect(cramorant.getTag(BattlerTagType.GULP_MISSILE_PIKACHU)).toBeUndefined();
     expect(cramorant.formIndex).toBe(NORMAL_FORM);
   });

--- a/test/abilities/infiltrator.test.ts
+++ b/test/abilities/infiltrator.test.ts
@@ -61,11 +61,17 @@ describe("Abilities - Infiltrator", () => {
     const player = game.field.getPlayerPokemon();
     const enemy = game.field.getEnemyPokemon();
 
-    const preScreenDmg = enemy.getAttackDamage({ source: player, move: allMoves[move] }).damage;
+    const preScreenDmg = enemy.getAttackDamage({
+      source: player,
+      move: allMoves[move],
+    }).damage;
 
     game.scene.arena.addTag(tagType, 1, MoveId.NONE, enemy.id, ArenaTagSide.ENEMY, true);
 
-    const postScreenDmg = enemy.getAttackDamage({ source: player, move: allMoves[move] }).damage;
+    const postScreenDmg = enemy.getAttackDamage({
+      source: player,
+      move: allMoves[move],
+    }).damage;
 
     expect(postScreenDmg).toBe(preScreenDmg);
     expect(player.waveData.abilitiesApplied).toContain(AbilityId.INFILTRATOR);
@@ -82,7 +88,7 @@ describe("Abilities - Infiltrator", () => {
     game.move.use(MoveId.SPORE);
     await game.toEndOfTurn();
 
-    expect(enemy.status?.effect).toBe(StatusEffect.SLEEP);
+    expect(enemy).toHaveStatusEffect(StatusEffect.SLEEP);
     expect(player.waveData.abilitiesApplied).toContain(AbilityId.INFILTRATOR);
   });
 

--- a/test/abilities/magic-bounce.test.ts
+++ b/test/abilities/magic-bounce.test.ts
@@ -127,7 +127,7 @@ describe("Abilities - Magic Bounce", () => {
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(game.scene.arena.getTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.PLAYER)!["layers"]).toBe(1);
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game).not.toHaveArenaTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY);
   });
 
   it("should bounce spikes even when the target is protected", async () => {

--- a/test/abilities/magic-bounce.test.ts
+++ b/test/abilities/magic-bounce.test.ts
@@ -260,7 +260,7 @@ describe("Abilities - Magic Bounce", () => {
     // Turn 1 - thunder wave immunity test
     game.move.select(MoveId.THUNDER_WAVE);
     await game.phaseInterceptor.to("BerryPhase");
-    expect(game.field.getPlayerPokemon().status).toBeUndefined();
+    expect(game.field.getPlayerPokemon()).toHaveStatusEffect(StatusEffect.NONE);
 
     // Turn 2 - soundproof immunity test
     game.move.select(MoveId.GROWL);
@@ -277,7 +277,7 @@ describe("Abilities - Magic Bounce", () => {
     vi.spyOn(attacker, "getAccuracyMultiplier").mockReturnValue(0.0);
     game.move.select(MoveId.SPORE);
     await game.phaseInterceptor.to("BerryPhase");
-    expect(game.field.getPlayerPokemon().status?.effect).toBe(StatusEffect.SLEEP);
+    expect(game.field.getPlayerPokemon()).toHaveStatusEffect(StatusEffect.SLEEP);
   });
 
   it("should take the accuracy of the magic bounce user into account", async () => {
@@ -288,7 +288,7 @@ describe("Abilities - Magic Bounce", () => {
     vi.spyOn(opponent, "getAccuracyMultiplier").mockReturnValue(0);
     game.move.select(MoveId.SPORE);
     await game.phaseInterceptor.to("BerryPhase");
-    expect(game.field.getPlayerPokemon().status).toBeUndefined();
+    expect(game.field.getPlayerPokemon()).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   it("should always apply the leftmost available target's magic bounce when bouncing moves like sticky webs in doubles", async () => {
@@ -332,8 +332,8 @@ describe("Abilities - Magic Bounce", () => {
     await game.move.selectEnemyMove(MoveId.FLY);
     await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.phaseInterceptor.to("BerryPhase");
-    expect(game.field.getEnemyPokemon().status?.effect).toBe(StatusEffect.TOXIC);
-    expect(game.field.getPlayerPokemon().status).toBeUndefined();
+    expect(game.field.getEnemyPokemon()).toHaveStatusEffect(StatusEffect.TOXIC);
+    expect(game.field.getPlayerPokemon()).toHaveStatusEffect(StatusEffect.NONE);
 
     game.override.ability(AbilityId.NO_GUARD);
     game.move.select(MoveId.CHARM);

--- a/test/abilities/magic-guard.test.ts
+++ b/test/abilities/magic-guard.test.ts
@@ -40,7 +40,11 @@ describe("AbilityId - Magic Guard", () => {
   it.each<{ name: string; move?: MoveId; enemyMove?: MoveId }>([
     { name: "Non-Volatile Status Conditions", enemyMove: MoveId.TOXIC },
     { name: "Volatile Status Conditions", enemyMove: MoveId.LEECH_SEED },
-    { name: "Crash Damage", move: MoveId.HIGH_JUMP_KICK, enemyMove: MoveId.PROTECT }, // Protect triggers crash damage
+    {
+      name: "Crash Damage",
+      move: MoveId.HIGH_JUMP_KICK,
+      enemyMove: MoveId.PROTECT,
+    }, // Protect triggers crash damage
     { name: "Variable Recoil Moves", move: MoveId.DOUBLE_EDGE },
     { name: "HP% Recoil Moves", move: MoveId.CHLOROBLAST },
   ])("should prevent damage from $name", async ({ move = MoveId.SPLASH, enemyMove = MoveId.SPLASH }) => {
@@ -55,13 +59,39 @@ describe("AbilityId - Magic Guard", () => {
     expect(magikarp.hp).toBe(magikarp.getMaxHp());
   });
 
-  it.each<{ abName: string; move?: MoveId; enemyMove?: MoveId; passive?: AbilityId; enemyAbility?: AbilityId }>([
-    { abName: "Bad Dreams", enemyMove: MoveId.SPORE, enemyAbility: AbilityId.BAD_DREAMS },
-    { abName: "Aftermath", move: MoveId.PSYCHIC_FANGS, enemyAbility: AbilityId.AFTERMATH },
-    { abName: "Innards Out", move: MoveId.PSYCHIC_FANGS, enemyAbility: AbilityId.INNARDS_OUT },
-    { abName: "Rough Skin", move: MoveId.PSYCHIC_FANGS, enemyAbility: AbilityId.ROUGH_SKIN },
+  it.each<{
+    abName: string;
+    move?: MoveId;
+    enemyMove?: MoveId;
+    passive?: AbilityId;
+    enemyAbility?: AbilityId;
+  }>([
+    {
+      abName: "Bad Dreams",
+      enemyMove: MoveId.SPORE,
+      enemyAbility: AbilityId.BAD_DREAMS,
+    },
+    {
+      abName: "Aftermath",
+      move: MoveId.PSYCHIC_FANGS,
+      enemyAbility: AbilityId.AFTERMATH,
+    },
+    {
+      abName: "Innards Out",
+      move: MoveId.PSYCHIC_FANGS,
+      enemyAbility: AbilityId.INNARDS_OUT,
+    },
+    {
+      abName: "Rough Skin",
+      move: MoveId.PSYCHIC_FANGS,
+      enemyAbility: AbilityId.ROUGH_SKIN,
+    },
     { abName: "Dry Skin", move: MoveId.SUNNY_DAY, passive: AbilityId.DRY_SKIN },
-    { abName: "Liquid Ooze", move: MoveId.DRAIN_PUNCH, enemyAbility: AbilityId.LIQUID_OOZE },
+    {
+      abName: "Liquid Ooze",
+      move: MoveId.DRAIN_PUNCH,
+      enemyAbility: AbilityId.LIQUID_OOZE,
+    },
   ])(
     "should prevent damage from $abName",
     async ({
@@ -140,7 +170,7 @@ describe("AbilityId - Magic Guard", () => {
 
     const magikarp = game.field.getPlayerPokemon();
     expect(magikarp.hp).toBe(magikarp.getMaxHp());
-    expect(magikarp.status?.effect).toBe(StatusEffect.BURN);
+    expect(magikarp).toHaveStatusEffect(StatusEffect.BURN);
     expect(getStatusEffectCatchRateMultiplier(magikarp.status!.effect)).toBe(1.5);
 
     // Heal blissey to full & use tackle again
@@ -163,6 +193,6 @@ describe("AbilityId - Magic Guard", () => {
     // Magic guard prevented damage but not poison
     const player = game.field.getPlayerPokemon();
     expect(player.hp).toBe(player.getMaxHp());
-    expect(player.status?.effect).toBe(StatusEffect.POISON);
+    expect(player).toHaveStatusEffect(StatusEffect.POISON);
   });
 });

--- a/test/abilities/neutralizing-gas.test.ts
+++ b/test/abilities/neutralizing-gas.test.ts
@@ -122,7 +122,7 @@ describe("Abilities - Neutralizing Gas", () => {
     await game.move.selectEnemyMove(MoveId.SPLASH);
     await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
     await game.phaseInterceptor.to("BerryPhase");
-    expect(game.scene.arena.getTag(ArenaTagType.NEUTRALIZING_GAS)).toBeUndefined(); // No neut gas users are left
+    expect(game).not.toHaveArenaTag(ArenaTagType.NEUTRALIZING_GAS); // No neut gas users are left
   });
 
   it("should deactivate when suppressed by gastro acid", async () => {
@@ -133,7 +133,7 @@ describe("Abilities - Neutralizing Gas", () => {
     game.move.select(MoveId.SPLASH);
     await game.phaseInterceptor.to("BerryPhase");
 
-    expect(game.scene.arena.getTag(ArenaTagType.NEUTRALIZING_GAS)).toBeUndefined();
+    expect(game).not.toHaveArenaTag(ArenaTagType.NEUTRALIZING_GAS);
   });
 
   it("should deactivate when the pokemon faints", async () => {
@@ -144,7 +144,7 @@ describe("Abilities - Neutralizing Gas", () => {
     expect(game.scene.arena.getTag(ArenaTagType.NEUTRALIZING_GAS)).toBeDefined();
     await game.doKillOpponents();
 
-    expect(game.scene.arena.getTag(ArenaTagType.NEUTRALIZING_GAS)).toBeUndefined();
+    expect(game).not.toHaveArenaTag(ArenaTagType.NEUTRALIZING_GAS);
   });
 
   it("should deactivate upon catching a wild pokemon", async () => {
@@ -156,7 +156,7 @@ describe("Abilities - Neutralizing Gas", () => {
     game.doThrowPokeball(PokeballType.MASTER_BALL);
     await game.phaseInterceptor.to("TurnEndPhase");
 
-    expect(game.scene.arena.getTag(ArenaTagType.NEUTRALIZING_GAS)).toBeUndefined();
+    expect(game).not.toHaveArenaTag(ArenaTagType.NEUTRALIZING_GAS);
   });
 
   it("should deactivate after fleeing from a wild pokemon", async () => {
@@ -171,7 +171,7 @@ describe("Abilities - Neutralizing Gas", () => {
     commandPhase.handleCommand(Command.RUN, 0);
     await game.phaseInterceptor.to("BerryPhase");
 
-    expect(game.scene.arena.getTag(ArenaTagType.NEUTRALIZING_GAS)).toBeUndefined();
+    expect(game).not.toHaveArenaTag(ArenaTagType.NEUTRALIZING_GAS);
   });
 
   it("should not activate abilities of pokemon no longer on the field", async () => {
@@ -188,7 +188,7 @@ describe("Abilities - Neutralizing Gas", () => {
     await game.killPokemon(enemy);
     await game.killPokemon(game.field.getPlayerPokemon());
 
-    expect(game.scene.arena.getTag(ArenaTagType.NEUTRALIZING_GAS)).toBeUndefined();
+    expect(game).not.toHaveArenaTag(ArenaTagType.NEUTRALIZING_GAS);
     expect(weatherChangeSpy).not.toHaveBeenCalled();
   });
 });

--- a/test/abilities/neutralizing-gas.test.ts
+++ b/test/abilities/neutralizing-gas.test.ts
@@ -114,7 +114,7 @@ describe("Abilities - Neutralizing Gas", () => {
     await game.move.selectEnemyMove(MoveId.SPLASH);
     await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
     await game.phaseInterceptor.to("BerryPhase");
-    expect(game.scene.arena.getTag(ArenaTagType.NEUTRALIZING_GAS)).toBeDefined(); // Now one neut gas user is left
+    expect(game).toHaveArenaTag(ArenaTagType.NEUTRALIZING_GAS); // Now one neut gas user is left
 
     game.move.select(MoveId.SPLASH, 0);
     game.move.select(MoveId.SPLASH, 1);
@@ -141,7 +141,7 @@ describe("Abilities - Neutralizing Gas", () => {
 
     await game.classicMode.startBattle([SpeciesId.FEEBAS]);
     game.move.select(MoveId.SPLASH);
-    expect(game.scene.arena.getTag(ArenaTagType.NEUTRALIZING_GAS)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.NEUTRALIZING_GAS);
     await game.doKillOpponents();
 
     expect(game).not.toHaveArenaTag(ArenaTagType.NEUTRALIZING_GAS);
@@ -150,7 +150,7 @@ describe("Abilities - Neutralizing Gas", () => {
   it("should deactivate upon catching a wild pokemon", async () => {
     game.override.battleStyle("single").enemyAbility(AbilityId.NEUTRALIZING_GAS).ability(AbilityId.BALL_FETCH);
     await game.classicMode.startBattle([SpeciesId.MAGIKARP]);
-    expect(game.scene.arena.getTag(ArenaTagType.NEUTRALIZING_GAS)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.NEUTRALIZING_GAS);
 
     game.scene.pokeballCounts[PokeballType.MASTER_BALL] = 1;
     game.doThrowPokeball(PokeballType.MASTER_BALL);
@@ -162,7 +162,7 @@ describe("Abilities - Neutralizing Gas", () => {
   it("should deactivate after fleeing from a wild pokemon", async () => {
     game.override.enemyAbility(AbilityId.NEUTRALIZING_GAS).ability(AbilityId.BALL_FETCH);
     await game.classicMode.startBattle([SpeciesId.MAGIKARP]);
-    expect(game.scene.arena.getTag(ArenaTagType.NEUTRALIZING_GAS)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.NEUTRALIZING_GAS);
 
     vi.spyOn(game.field.getPlayerPokemon(), "randBattleSeedInt").mockReturnValue(0);
     vi.spyOn(globalScene, "randBattleSeedInt").mockReturnValue(0);
@@ -182,7 +182,7 @@ describe("Abilities - Neutralizing Gas", () => {
     const weatherChangeAttr = enemy.getAbilityAttrs("PostSummonWeatherChangeAbAttr", false)[0];
     const weatherChangeSpy = vi.spyOn(weatherChangeAttr, "apply");
 
-    expect(game.scene.arena.getTag(ArenaTagType.NEUTRALIZING_GAS)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.NEUTRALIZING_GAS);
 
     game.move.select(MoveId.SPLASH);
     await game.killPokemon(enemy);

--- a/test/abilities/parental-bond.test.ts
+++ b/test/abilities/parental-bond.test.ts
@@ -330,11 +330,11 @@ describe("Abilities - Parental Bond", () => {
     await game.phaseInterceptor.to("DamageAnimPhase");
 
     expect(leadPokemon.turnData.hitCount).toBe(2);
-    expect(enemyPokemon.status?.effect).toBe(StatusEffect.SLEEP);
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.SLEEP);
 
     await game.phaseInterceptor.to("BerryPhase", false);
 
-    expect(enemyPokemon.status?.effect).toBeUndefined();
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   it("should not cause user to hit into King's Shield more than once", async () => {

--- a/test/abilities/sap-sipper.test.ts
+++ b/test/abilities/sap-sipper.test.ts
@@ -5,6 +5,7 @@ import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { Stat } from "#enums/stat";
+import { StatusEffect } from "#enums/status-effect";
 import { RandomMoveAttr } from "#moves/move";
 import { MoveEndPhase } from "#phases/move-end-phase";
 import { TurnEndPhase } from "#phases/turn-end-phase";
@@ -69,7 +70,7 @@ describe("Abilities - Sap Sipper", () => {
 
     await game.phaseInterceptor.to(TurnEndPhase);
 
-    expect(enemyPokemon.status).toBeUndefined();
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.NONE);
     expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(1);
   });
 

--- a/test/abilities/screen-cleaner.test.ts
+++ b/test/abilities/screen-cleaner.test.ts
@@ -41,7 +41,7 @@ describe("Abilities - Screen Cleaner", () => {
     game.doSwitchPokemon(1);
     await game.phaseInterceptor.to(PostSummonPhase);
 
-    expect(game.scene.arena.getTag(ArenaTagType.AURORA_VEIL)).toBeUndefined();
+    expect(game).not.toHaveArenaTag(ArenaTagType.AURORA_VEIL);
   });
 
   it("removes Light Screen", async () => {
@@ -58,7 +58,7 @@ describe("Abilities - Screen Cleaner", () => {
     game.doSwitchPokemon(1);
     await game.phaseInterceptor.to(PostSummonPhase);
 
-    expect(game.scene.arena.getTag(ArenaTagType.LIGHT_SCREEN)).toBeUndefined();
+    expect(game).not.toHaveArenaTag(ArenaTagType.LIGHT_SCREEN);
   });
 
   it("removes Reflect", async () => {
@@ -75,6 +75,6 @@ describe("Abilities - Screen Cleaner", () => {
     game.doSwitchPokemon(1);
     await game.phaseInterceptor.to(PostSummonPhase);
 
-    expect(game.scene.arena.getTag(ArenaTagType.REFLECT)).toBeUndefined();
+    expect(game).not.toHaveArenaTag(ArenaTagType.REFLECT);
   });
 });

--- a/test/abilities/screen-cleaner.test.ts
+++ b/test/abilities/screen-cleaner.test.ts
@@ -35,7 +35,7 @@ describe("Abilities - Screen Cleaner", () => {
     game.move.use(MoveId.HAIL);
     await game.phaseInterceptor.to(TurnEndPhase);
 
-    expect(game.scene.arena.getTag(ArenaTagType.AURORA_VEIL)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.AURORA_VEIL);
 
     await game.toNextTurn();
     game.doSwitchPokemon(1);
@@ -52,7 +52,7 @@ describe("Abilities - Screen Cleaner", () => {
     game.move.use(MoveId.SPLASH);
     await game.phaseInterceptor.to(TurnEndPhase);
 
-    expect(game.scene.arena.getTag(ArenaTagType.LIGHT_SCREEN)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.LIGHT_SCREEN);
 
     await game.toNextTurn();
     game.doSwitchPokemon(1);
@@ -69,7 +69,7 @@ describe("Abilities - Screen Cleaner", () => {
     game.move.use(MoveId.SPLASH);
     await game.phaseInterceptor.to(TurnEndPhase);
 
-    expect(game.scene.arena.getTag(ArenaTagType.REFLECT)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.REFLECT);
 
     await game.toNextTurn();
     game.doSwitchPokemon(1);

--- a/test/abilities/status-immunity-ab-attrs.test.ts
+++ b/test/abilities/status-immunity-ab-attrs.test.ts
@@ -11,14 +11,38 @@ import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe.each<{ name: string; ability: AbilityId; status: StatusEffect }>([
-  { name: "Vital Spirit", ability: AbilityId.VITAL_SPIRIT, status: StatusEffect.SLEEP },
+  {
+    name: "Vital Spirit",
+    ability: AbilityId.VITAL_SPIRIT,
+    status: StatusEffect.SLEEP,
+  },
   { name: "Insomnia", ability: AbilityId.INSOMNIA, status: StatusEffect.SLEEP },
-  { name: "Immunity", ability: AbilityId.IMMUNITY, status: StatusEffect.POISON },
-  { name: "Magma Armor", ability: AbilityId.MAGMA_ARMOR, status: StatusEffect.FREEZE },
+  {
+    name: "Immunity",
+    ability: AbilityId.IMMUNITY,
+    status: StatusEffect.POISON,
+  },
+  {
+    name: "Magma Armor",
+    ability: AbilityId.MAGMA_ARMOR,
+    status: StatusEffect.FREEZE,
+  },
   { name: "Limber", ability: AbilityId.LIMBER, status: StatusEffect.PARALYSIS },
-  { name: "Thermal Exchange", ability: AbilityId.THERMAL_EXCHANGE, status: StatusEffect.BURN },
-  { name: "Water Veil", ability: AbilityId.WATER_VEIL, status: StatusEffect.BURN },
-  { name: "Water Bubble", ability: AbilityId.WATER_BUBBLE, status: StatusEffect.BURN },
+  {
+    name: "Thermal Exchange",
+    ability: AbilityId.THERMAL_EXCHANGE,
+    status: StatusEffect.BURN,
+  },
+  {
+    name: "Water Veil",
+    ability: AbilityId.WATER_VEIL,
+    status: StatusEffect.BURN,
+  },
+  {
+    name: "Water Bubble",
+    ability: AbilityId.WATER_BUBBLE,
+    status: StatusEffect.BURN,
+  },
 ])("Abilities - $name", ({ ability, status }) => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
@@ -54,13 +78,13 @@ describe.each<{ name: string; ability: AbilityId; status: StatusEffect }>([
     await game.classicMode.startBattle([SpeciesId.FEEBAS]);
 
     const karp = game.field.getEnemyPokemon();
-    expect(karp.status?.effect).toBeUndefined();
+    expect(karp).toHaveStatusEffect(StatusEffect.NONE);
     expect(karp.canSetStatus(status)).toBe(false);
 
     game.move.use(MoveId.LUMINA_CRASH);
     await game.toEndOfTurn();
 
-    expect(karp.status?.effect).toBeUndefined();
+    expect(karp).toHaveStatusEffect(StatusEffect.NONE);
     expect(game.field.getPlayerPokemon().getLastXMoves()[0].result).toBe(MoveResult.SUCCESS);
   });
 
@@ -69,13 +93,13 @@ describe.each<{ name: string; ability: AbilityId; status: StatusEffect }>([
 
     const feebas = game.field.getPlayerPokemon();
     feebas.doSetStatus(status);
-    expect(feebas.status?.effect).toBe(status);
+    expect(feebas).toHaveStatusEffect(status);
 
     game.move.use(MoveId.SPLASH);
     await game.move.forceEnemyMove(MoveId.SKILL_SWAP);
     await game.toEndOfTurn();
 
-    expect(feebas.status?.effect).toBeUndefined();
+    expect(feebas).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   // TODO: This does not propagate failures currently
@@ -88,7 +112,7 @@ describe.each<{ name: string; ability: AbilityId; status: StatusEffect }>([
       await game.toEndOfTurn();
 
       const karp = game.field.getEnemyPokemon();
-      expect(karp.status?.effect).toBeUndefined();
+      expect(karp).toHaveStatusEffect(StatusEffect.NONE);
       expect(game.field.getPlayerPokemon().getLastXMoves()[0].result).toBe(MoveResult.FAIL);
     },
   );

--- a/test/abilities/synchronize.test.ts
+++ b/test/abilities/synchronize.test.ts
@@ -38,7 +38,7 @@ describe("Abilities - Synchronize", () => {
     game.move.select(MoveId.SPLASH);
     await game.phaseInterceptor.to("BerryPhase");
 
-    expect(game.field.getPlayerPokemon().status).toBeUndefined();
+    expect(game.field.getPlayerPokemon()).toHaveStatusEffect(StatusEffect.NONE);
     expect(game.phaseInterceptor.log).not.toContain("ShowAbilityPhase");
   });
 
@@ -48,8 +48,8 @@ describe("Abilities - Synchronize", () => {
     game.move.select(MoveId.THUNDER_WAVE);
     await game.phaseInterceptor.to("BerryPhase");
 
-    expect(game.field.getPlayerPokemon().status?.effect).toBe(StatusEffect.PARALYSIS);
-    expect(game.field.getEnemyPokemon().status?.effect).toBe(StatusEffect.PARALYSIS);
+    expect(game.field.getPlayerPokemon()).toHaveStatusEffect(StatusEffect.PARALYSIS);
+    expect(game.field.getEnemyPokemon()).toHaveStatusEffect(StatusEffect.PARALYSIS);
     expect(game.phaseInterceptor.log).toContain("ShowAbilityPhase");
   });
 
@@ -60,8 +60,8 @@ describe("Abilities - Synchronize", () => {
 
     await game.phaseInterceptor.to("BerryPhase");
 
-    expect(game.field.getPlayerPokemon().status?.effect).toBeUndefined();
-    expect(game.field.getEnemyPokemon().status?.effect).toBe(StatusEffect.SLEEP);
+    expect(game.field.getPlayerPokemon()).toHaveStatusEffect(StatusEffect.NONE);
+    expect(game.field.getEnemyPokemon()).toHaveStatusEffect(StatusEffect.SLEEP);
     expect(game.phaseInterceptor.log).not.toContain("ShowAbilityPhase");
   });
 
@@ -76,8 +76,8 @@ describe("Abilities - Synchronize", () => {
     game.doSwitchPokemon(1);
     await game.phaseInterceptor.to("BerryPhase");
 
-    expect(game.field.getPlayerPokemon().status?.effect).toBe(StatusEffect.POISON);
-    expect(game.field.getEnemyPokemon().status?.effect).toBeUndefined();
+    expect(game.field.getPlayerPokemon()).toHaveStatusEffect(StatusEffect.POISON);
+    expect(game.field.getEnemyPokemon()).toHaveStatusEffect(StatusEffect.NONE);
     expect(game.phaseInterceptor.log).not.toContain("ShowAbilityPhase");
   });
 
@@ -87,8 +87,8 @@ describe("Abilities - Synchronize", () => {
     game.move.select(MoveId.THUNDER_WAVE);
     await game.phaseInterceptor.to("BerryPhase");
 
-    expect(game.field.getPlayerPokemon().status?.effect).toBeUndefined();
-    expect(game.field.getEnemyPokemon().status?.effect).toBe(StatusEffect.PARALYSIS);
+    expect(game.field.getPlayerPokemon()).toHaveStatusEffect(StatusEffect.NONE);
+    expect(game.field.getEnemyPokemon()).toHaveStatusEffect(StatusEffect.PARALYSIS);
     expect(game.phaseInterceptor.log).toContain("ShowAbilityPhase");
   });
 });

--- a/test/arena/arena-gravity.test.ts
+++ b/test/arena/arena-gravity.test.ts
@@ -47,7 +47,7 @@ describe("Arena - Gravity", () => {
     game.move.select(MoveId.GRAVITY);
     await game.phaseInterceptor.to("TurnEndPhase");
 
-    expect(game.scene.arena.getTag(ArenaTagType.GRAVITY)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.GRAVITY);
 
     // Use non-OHKO move on second turn
     await game.toNextTurn();
@@ -68,7 +68,7 @@ describe("Arena - Gravity", () => {
     game.move.select(MoveId.GRAVITY);
     await game.phaseInterceptor.to("TurnEndPhase");
 
-    expect(game.scene.arena.getTag(ArenaTagType.GRAVITY)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.GRAVITY);
 
     // Use OHKO move on second turn
     await game.toNextTurn();
@@ -98,7 +98,7 @@ describe("Arena - Gravity", () => {
       game.move.select(MoveId.GRAVITY);
       await game.phaseInterceptor.to("TurnEndPhase");
 
-      expect(game.scene.arena.getTag(ArenaTagType.GRAVITY)).toBeDefined();
+      expect(game).toHaveArenaTag(ArenaTagType.GRAVITY);
 
       // Use ground move on 3rd turn
       await game.toNextTurn();
@@ -120,7 +120,7 @@ describe("Arena - Gravity", () => {
       game.move.select(MoveId.GRAVITY);
       await game.phaseInterceptor.to("TurnEndPhase");
 
-      expect(game.scene.arena.getTag(ArenaTagType.GRAVITY)).toBeDefined();
+      expect(game).toHaveArenaTag(ArenaTagType.GRAVITY);
 
       // Use electric move on 2nd turn
       await game.toNextTurn();

--- a/test/arena/psychic-terrain.test.ts
+++ b/test/arena/psychic-terrain.test.ts
@@ -42,7 +42,7 @@ describe("Arena - Psychic Terrain", () => {
     game.move.select(MoveId.DARK_VOID);
     await game.toEndOfTurn();
 
-    expect(game.field.getEnemyPokemon().status?.effect).toBe(StatusEffect.SLEEP);
+    expect(game.field.getEnemyPokemon()).toHaveStatusEffect(StatusEffect.SLEEP);
   });
 
   it("Rain Dance with Prankster is not blocked", async () => {

--- a/test/battle/inverse-battle.test.ts
+++ b/test/battle/inverse-battle.test.ts
@@ -147,7 +147,7 @@ describe("Inverse Battle", () => {
     await game.move.forceHit();
     await game.phaseInterceptor.to("MoveEndPhase");
 
-    expect(enemy.status?.effect).not.toBe(StatusEffect.BURN);
+    expect(enemy).not.toHaveStatusEffect(StatusEffect.BURN);
   });
 
   it("Electric type does not get paralyzed - Nuzzle against Pikachu", async () => {
@@ -161,7 +161,7 @@ describe("Inverse Battle", () => {
     await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
     await game.phaseInterceptor.to("MoveEndPhase");
 
-    expect(enemy.status?.effect).not.toBe(StatusEffect.PARALYSIS);
+    expect(enemy).not.toHaveStatusEffect(StatusEffect.PARALYSIS);
   });
 
   it("Ground type is not immune to Thunder Wave - Thunder Wave against Sandshrew", async () => {
@@ -176,7 +176,7 @@ describe("Inverse Battle", () => {
     await game.move.forceHit();
     await game.phaseInterceptor.to("MoveEndPhase");
 
-    expect(enemy.status?.effect).toBe(StatusEffect.PARALYSIS);
+    expect(enemy).toHaveStatusEffect(StatusEffect.PARALYSIS);
   });
 
   it("Anticipation should trigger on 2x effective moves", async () => {

--- a/test/data/status-effect.test.ts
+++ b/test/data/status-effect.test.ts
@@ -1,10 +1,10 @@
 import {
-  getStatusEffectActivationText,
-  getStatusEffectDescriptor,
-  getStatusEffectHealText,
-  getStatusEffectObtainText,
-  getStatusEffectOverlapText,
-  Status,
+    getStatusEffectActivationText,
+    getStatusEffectDescriptor,
+    getStatusEffectHealText,
+    getStatusEffectObtainText,
+    getStatusEffectOverlapText,
+    Status,
 } from "#data/status-effect";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
@@ -371,23 +371,23 @@ describe("Status Effects", () => {
       game.move.select(MoveId.SPLASH);
       await game.toNextTurn();
 
-      expect(player.status.effect).toBe(StatusEffect.SLEEP);
+      expect(player).toHaveStatusEffect(StatusEffect.SLEEP);
 
       game.move.select(MoveId.SPLASH);
       await game.toNextTurn();
 
-      expect(player.status.effect).toBe(StatusEffect.SLEEP);
+      expect(player).toHaveStatusEffect(StatusEffect.SLEEP);
 
       game.move.select(MoveId.SPLASH);
       await game.toNextTurn();
 
-      expect(player.status.effect).toBe(StatusEffect.SLEEP);
+      expect(player).toHaveStatusEffect(StatusEffect.SLEEP);
       expect(player.getLastXMoves(1)[0].result).toBe(MoveResult.FAIL);
 
       game.move.select(MoveId.SPLASH);
       await game.toNextTurn();
 
-      expect(player.status).toBeFalsy();
+      expect(player).toHaveStatusEffect(StatusEffect.NONE);
       expect(player.getLastXMoves(1)[0].result).toBe(MoveResult.SUCCESS);
     });
   });
@@ -426,7 +426,7 @@ describe("Status Effects", () => {
       player.hp = 0;
 
       expect(player.trySetStatus(StatusEffect.BURN)).toBe(false);
-      expect(player.status?.effect).not.toBe(StatusEffect.BURN);
+      expect(player).not.toHaveStatusEffect(StatusEffect.BURN);
     });
   });
 });

--- a/test/field/pokemon-funcs.test.ts
+++ b/test/field/pokemon-funcs.test.ts
@@ -38,13 +38,13 @@ describe("Spec - Pokemon Functions", () => {
 
       const player = game.field.getPlayerPokemon();
 
-      expect(player.status?.effect).toBeUndefined();
+      expect(player).toHaveStatusEffect(StatusEffect.NONE);
       player.doSetStatus(StatusEffect.BURN);
-      expect(player.status?.effect).toBe(StatusEffect.BURN);
+      expect(player).toHaveStatusEffect(StatusEffect.BURN);
 
       expect(player.canSetStatus(StatusEffect.SLEEP)).toBe(false);
       player.doSetStatus(StatusEffect.SLEEP, 5);
-      expect(player.status?.effect).toBe(StatusEffect.SLEEP);
+      expect(player).toHaveStatusEffect(StatusEffect.SLEEP);
       expect(player.status?.sleepTurnsRemaining).toBe(5);
     });
   });

--- a/test/final-boss.test.ts
+++ b/test/final-boss.test.ts
@@ -105,7 +105,7 @@ describe("Final Boss", () => {
 
     game.move.use(MoveId.WILL_O_WISP);
     await game.toNextTurn();
-    expect(eternatus.status?.effect).toBe(StatusEffect.BURN);
+    expect(eternatus).toHaveStatusEffect(StatusEffect.BURN);
 
     const tickDamage = phase1Hp - eternatus.hp;
     const lastShieldHp = Math.ceil(phase1Hp / eternatus.bossSegments);
@@ -123,7 +123,7 @@ describe("Final Boss", () => {
     // Eternatus phase 2: changed form, healed and restored its shields
     expect(eternatus.hp).toBeGreaterThan(phase1Hp);
     expect(eternatus.hp).toBe(eternatus.getMaxHp());
-    expect(eternatus.status?.effect).toBeUndefined();
+    expect(eternatus).toHaveStatusEffect(StatusEffect.NONE);
     expect(eternatus.formIndex).toBe(1);
     expect(eternatus.bossSegments).toBe(5);
     expect(eternatus.bossSegmentIndex).toBe(4);

--- a/test/items/toxic-orb.test.ts
+++ b/test/items/toxic-orb.test.ts
@@ -51,7 +51,7 @@ describe("Items - Toxic orb", () => {
     await game.phaseInterceptor.to("MessagePhase");
     expect(i18next.t).toHaveBeenCalledWith("statusEffect:toxic.obtainSource", expect.anything());
 
-    expect(player.status?.effect).toBe(StatusEffect.TOXIC);
+    expect(player).toHaveStatusEffect(StatusEffect.TOXIC);
     expect(player.status?.toxicTurnCount).toBe(0);
   });
 });

--- a/test/moves/aromatherapy.test.ts
+++ b/test/moves/aromatherapy.test.ts
@@ -46,9 +46,9 @@ describe("Moves - Aromatherapy", () => {
     expect(rightPlayer.resetStatus).toHaveBeenCalledOnce();
     expect(partyPokemon.resetStatus).toHaveBeenCalledOnce();
 
-    expect(leftPlayer.status?.effect).toBeUndefined();
-    expect(rightPlayer.status?.effect).toBeUndefined();
-    expect(partyPokemon.status?.effect).toBeUndefined();
+    expect(leftPlayer).toHaveStatusEffect(StatusEffect.NONE);
+    expect(rightPlayer).toHaveStatusEffect(StatusEffect.NONE);
+    expect(partyPokemon).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   it("should not cure status effect of the target/target's allies", async () => {
@@ -69,8 +69,8 @@ describe("Moves - Aromatherapy", () => {
     expect(leftOpp.status?.effect).toBeTruthy();
     expect(rightOpp.status?.effect).toBeTruthy();
 
-    expect(leftOpp.status?.effect).toBe(StatusEffect.BURN);
-    expect(rightOpp.status?.effect).toBe(StatusEffect.BURN);
+    expect(leftOpp).toHaveStatusEffect(StatusEffect.BURN);
+    expect(rightOpp).toHaveStatusEffect(StatusEffect.BURN);
   });
 
   it("should not cure status effect of allies ON FIELD with Sap Sipper, should still cure allies in party", async () => {
@@ -90,8 +90,8 @@ describe("Moves - Aromatherapy", () => {
     expect(rightPlayer.resetStatus).toHaveBeenCalledTimes(0);
     expect(partyPokemon.resetStatus).toHaveBeenCalledOnce();
 
-    expect(leftPlayer.status?.effect).toBeUndefined();
-    expect(rightPlayer.status?.effect).toBe(StatusEffect.BURN);
-    expect(partyPokemon.status?.effect).toBeUndefined();
+    expect(leftPlayer).toHaveStatusEffect(StatusEffect.NONE);
+    expect(rightPlayer).toHaveStatusEffect(StatusEffect.BURN);
+    expect(partyPokemon).toHaveStatusEffect(StatusEffect.NONE);
   });
 });

--- a/test/moves/baneful-bunker.test.ts
+++ b/test/moves/baneful-bunker.test.ts
@@ -35,8 +35,8 @@ describe("Moves - Baneful Bunker", () => {
   });
 
   function expectProtected() {
-    expect(game.scene.getEnemyPokemon()?.hp).toBe(game.scene.getEnemyPokemon()?.getMaxHp());
-    expect(game.scene.getPlayerPokemon()?.status?.effect).toBe(StatusEffect.POISON);
+    expect(game.field.getEnemyPokemon()).toHaveFullHp();
+    expect(game.scene.getPlayerPokemon()).toHaveStatusEffect(StatusEffect.POISON);
   }
 
   it("should protect the user and poison attackers that make contact", async () => {
@@ -71,6 +71,6 @@ describe("Moves - Baneful Bunker", () => {
     await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(toxapex.hp).toBe(toxapex.getMaxHp());
-    expect(charizard.status?.effect).toBeUndefined();
+    expect(charizard).toHaveStatusEffect(StatusEffect.NONE);
   });
 });

--- a/test/moves/beak-blast.test.ts
+++ b/test/moves/beak-blast.test.ts
@@ -49,7 +49,7 @@ describe("Moves - Beak Blast", () => {
     expect(leadPokemon.getTag(BattlerTagType.BEAK_BLAST_CHARGING)).toBeDefined();
 
     await game.phaseInterceptor.to(BerryPhase, false);
-    expect(enemyPokemon.status?.effect).toBe(StatusEffect.BURN);
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.BURN);
   });
 
   it("should still charge and burn opponents if the user is sleeping", async () => {
@@ -66,7 +66,7 @@ describe("Moves - Beak Blast", () => {
     expect(leadPokemon.getTag(BattlerTagType.BEAK_BLAST_CHARGING)).toBeDefined();
 
     await game.phaseInterceptor.to(BerryPhase, false);
-    expect(enemyPokemon.status?.effect).toBe(StatusEffect.BURN);
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.BURN);
   });
 
   it("should not burn attackers that don't make contact", async () => {
@@ -83,7 +83,7 @@ describe("Moves - Beak Blast", () => {
     expect(leadPokemon.getTag(BattlerTagType.BEAK_BLAST_CHARGING)).toBeDefined();
 
     await game.phaseInterceptor.to(BerryPhase, false);
-    expect(enemyPokemon.status?.effect).not.toBe(StatusEffect.BURN);
+    expect(enemyPokemon).not.toHaveStatusEffect(StatusEffect.BURN);
   });
 
   it("should only hit twice with Multi-Lens", async () => {
@@ -125,7 +125,7 @@ describe("Moves - Beak Blast", () => {
     user.hp = 1;
     game.move.select(MoveId.BEAK_BLAST);
     await game.phaseInterceptor.to("BerryPhase", false);
-    expect(enemyPokemon.status?.effect).toBe(StatusEffect.BURN);
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.BURN);
   });
 
   it("should not burn a long reach enemy that hits the user with a contact move", async () => {
@@ -134,6 +134,6 @@ describe("Moves - Beak Blast", () => {
     game.move.select(MoveId.BEAK_BLAST);
     await game.phaseInterceptor.to("BerryPhase", false);
     const enemyPokemon = game.field.getEnemyPokemon();
-    expect(enemyPokemon.status?.effect).not.toBe(StatusEffect.BURN);
+    expect(enemyPokemon).not.toHaveStatusEffect(StatusEffect.BURN);
   });
 });

--- a/test/moves/burning-jealousy.test.ts
+++ b/test/moves/burning-jealousy.test.ts
@@ -46,7 +46,7 @@ describe("Moves - Burning Jealousy", () => {
     await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.phaseInterceptor.to("BerryPhase");
 
-    expect(enemy.status?.effect).toBe(StatusEffect.BURN);
+    expect(enemy).toHaveStatusEffect(StatusEffect.BURN);
   });
 
   it("should still burn the opponent if their stat stages were both raised and lowered in the same turn", async () => {
@@ -60,7 +60,7 @@ describe("Moves - Burning Jealousy", () => {
     await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER_2, BattlerIndex.PLAYER, BattlerIndex.ENEMY_2]);
     await game.phaseInterceptor.to("BerryPhase");
 
-    expect(enemy.status?.effect).toBe(StatusEffect.BURN);
+    expect(enemy).toHaveStatusEffect(StatusEffect.BURN);
   });
 
   it("should ignore stat stages raised by IMPOSTER", async () => {
@@ -72,7 +72,7 @@ describe("Moves - Burning Jealousy", () => {
     game.move.select(MoveId.BURNING_JEALOUSY);
     await game.phaseInterceptor.to("BerryPhase");
 
-    expect(enemy.status?.effect).toBeUndefined();
+    expect(enemy).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   // TODO: Make this test if WP is implemented

--- a/test/moves/court-change.test.ts
+++ b/test/moves/court-change.test.ts
@@ -47,7 +47,7 @@ describe("Move - Court Change", () => {
     await game.toNextTurn();
 
     // enemy team will be in the swamp and slowed
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.ENEMY);
     expect(enemyPokemon.getEffectiveStat(Stat.SPD)).toBe(enemyPokemon.getStat(Stat.SPD) / 4);
 
     game.move.use(MoveId.COURT_CHANGE);
@@ -56,7 +56,7 @@ describe("Move - Court Change", () => {
 
     // own team should now be in the swamp and slowed
     expect(game).not.toHaveArenaTag(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.ENEMY);
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.PLAYER);
     expect(regieleki.getEffectiveStat(Stat.SPD)).toBe(regieleki.getStat(Stat.SPD) / 4);
   });
 
@@ -71,7 +71,7 @@ describe("Move - Court Change", () => {
     await game.toNextTurn();
 
     // Ninjask will not be poisoned because of Safeguard
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER);
     expect(ninjask).toHaveStatusEffect(StatusEffect.NONE);
 
     game.move.use(MoveId.COURT_CHANGE);
@@ -79,7 +79,7 @@ describe("Move - Court Change", () => {
 
     // Ninjask should now be poisoned due to lack of Safeguard
     expect(game).not.toHaveArenaTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER);
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY);
     expect(ninjask).toHaveStatusEffect(StatusEffect.POISON);
   });
 });

--- a/test/moves/court-change.test.ts
+++ b/test/moves/court-change.test.ts
@@ -72,7 +72,7 @@ describe("Move - Court Change", () => {
 
     // Ninjask will not be poisoned because of Safeguard
     expect(game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(ninjask.status?.effect).toBeUndefined();
+    expect(ninjask).toHaveStatusEffect(StatusEffect.NONE);
 
     game.move.use(MoveId.COURT_CHANGE);
     await game.toEndOfTurn();
@@ -80,6 +80,6 @@ describe("Move - Court Change", () => {
     // Ninjask should now be poisoned due to lack of Safeguard
     expect(game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)).toBeUndefined();
     expect(game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)).toBeDefined();
-    expect(ninjask.status?.effect).toBe(StatusEffect.POISON);
+    expect(ninjask).toHaveStatusEffect(StatusEffect.POISON);
   });
 });

--- a/test/moves/court-change.test.ts
+++ b/test/moves/court-change.test.ts
@@ -55,7 +55,7 @@ describe("Move - Court Change", () => {
     await game.toEndOfTurn();
 
     // own team should now be in the swamp and slowed
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game).not.toHaveArenaTag(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.ENEMY);
     expect(game.scene.arena.getTagOnSide(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.PLAYER)).toBeDefined();
     expect(regieleki.getEffectiveStat(Stat.SPD)).toBe(regieleki.getStat(Stat.SPD) / 4);
   });
@@ -78,7 +78,7 @@ describe("Move - Court Change", () => {
     await game.toEndOfTurn();
 
     // Ninjask should now be poisoned due to lack of Safeguard
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)).toBeUndefined();
+    expect(game).not.toHaveArenaTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER);
     expect(game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)).toBeDefined();
     expect(ninjask).toHaveStatusEffect(StatusEffect.POISON);
   });

--- a/test/moves/crafty-shield.test.ts
+++ b/test/moves/crafty-shield.test.ts
@@ -79,7 +79,7 @@ describe("Moves - Crafty Shield", () => {
     await game.move.forceEnemyMove(MoveId.TOXIC_SPIKES);
     await game.phaseInterceptor.to("TurnEndPhase");
 
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.PLAYER);
     expect(charizard.getTag(BattlerTagType.PERISH_SONG)).toBeDefined();
     expect(blastoise.getTag(BattlerTagType.PERISH_SONG)).toBeDefined();
   });

--- a/test/moves/destiny-bond.test.ts
+++ b/test/moves/destiny-bond.test.ts
@@ -145,7 +145,7 @@ describe("Moves - Destiny Bond", () => {
 
     expect(enemyPokemon.isFainted()).toBe(false);
     expect(playerPokemon.isFainted()).toBe(false);
-    expect(enemyPokemon.status?.effect).toBe(StatusEffect.SLEEP);
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.SLEEP);
 
     // Turn 2: Enemy should skip a turn due to sleep, then get KO'd
     game.move.select(moveToUse);

--- a/test/moves/dig.test.ts
+++ b/test/moves/dig.test.ts
@@ -101,7 +101,7 @@ describe("Moves - Dig", () => {
 
     await game.phaseInterceptor.to("TurnEndPhase");
     expect(playerPokemon.getTag(BattlerTagType.UNDERGROUND)).toBeUndefined();
-    expect(playerPokemon.status?.effect).toBe(StatusEffect.SLEEP);
+    expect(playerPokemon).toHaveStatusEffect(StatusEffect.SLEEP);
 
     const playerDig = playerPokemon.getMoveset().find(mv => mv && mv.moveId === MoveId.DIG);
     expect(playerDig?.ppUsed).toBe(0);

--- a/test/moves/dive.test.ts
+++ b/test/moves/dive.test.ts
@@ -85,7 +85,7 @@ describe("Moves - Dive", () => {
 
     await game.phaseInterceptor.to("TurnEndPhase");
     expect(playerPokemon.getTag(BattlerTagType.UNDERWATER)).toBeUndefined();
-    expect(playerPokemon.status?.effect).toBe(StatusEffect.SLEEP);
+    expect(playerPokemon).toHaveStatusEffect(StatusEffect.SLEEP);
 
     const playerDive = playerPokemon.getMoveset().find(mv => mv && mv.moveId === MoveId.DIVE);
     expect(playerDive?.ppUsed).toBe(0);

--- a/test/moves/fairy-lock.test.ts
+++ b/test/moves/fairy-lock.test.ts
@@ -43,8 +43,8 @@ describe("Moves - Fairy Lock", () => {
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.phaseInterceptor.to("BerryPhase");
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER);
+    expect(game).toHaveArenaTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY);
 
     await game.toNextTurn();
 
@@ -74,8 +74,8 @@ describe("Moves - Fairy Lock", () => {
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.phaseInterceptor.to("BerryPhase");
 
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER);
+    expect(game).toHaveArenaTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY);
 
     await game.toNextTurn();
 
@@ -102,8 +102,8 @@ describe("Moves - Fairy Lock", () => {
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.phaseInterceptor.to("BerryPhase");
 
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER);
+    expect(game).toHaveArenaTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY);
 
     await game.toNextTurn();
     game.move.select(MoveId.SPLASH);
@@ -129,8 +129,8 @@ describe("Moves - Fairy Lock", () => {
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.phaseInterceptor.to("BerryPhase");
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER);
+    expect(game).toHaveArenaTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY);
 
     await game.toNextTurn();
     game.move.select(MoveId.SPLASH);

--- a/test/moves/fly.test.ts
+++ b/test/moves/fly.test.ts
@@ -88,7 +88,7 @@ describe("Moves - Fly", () => {
 
     await game.phaseInterceptor.to("TurnEndPhase");
     expect(playerPokemon.getTag(BattlerTagType.FLYING)).toBeUndefined();
-    expect(playerPokemon.status?.effect).toBe(StatusEffect.SLEEP);
+    expect(playerPokemon).toHaveStatusEffect(StatusEffect.SLEEP);
 
     const playerFly = playerPokemon.getMoveset().find(mv => mv && mv.moveId === MoveId.FLY);
     expect(playerFly?.ppUsed).toBe(0);

--- a/test/moves/fusion-flare.test.ts
+++ b/test/moves/fusion-flare.test.ts
@@ -45,11 +45,11 @@ describe("Moves - Fusion Flare", () => {
 
     // Inflict freeze quietly and check if it was properly inflicted
     partyMember.doSetStatus(StatusEffect.FREEZE);
-    expect(partyMember.status!.effect).toBe(StatusEffect.FREEZE);
+    expect(partyMember).toHaveStatusEffect(StatusEffect.FREEZE);
 
     await game.toNextTurn();
 
     // Check if FUSION_FLARE thawed freeze
-    expect(partyMember.status?.effect).toBeUndefined();
+    expect(partyMember).toHaveStatusEffect(StatusEffect.NONE);
   });
 });

--- a/test/moves/gastro-acid.test.ts
+++ b/test/moves/gastro-acid.test.ts
@@ -4,6 +4,7 @@ import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { MoveResult } from "#enums/move-result";
 import { SpeciesId } from "#enums/species-id";
+import { StatusEffect } from "#enums/status-effect";
 import { GameManager } from "#test/test-utils/game-manager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -109,6 +110,6 @@ describe("Moves - Gastro Acid", () => {
     await game.toEndOfTurn();
 
     // Comatose should block stauts effect
-    expect(enemyPokemon.status?.effect).toBeUndefined();
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.NONE);
   });
 });

--- a/test/moves/heal-bell.test.ts
+++ b/test/moves/heal-bell.test.ts
@@ -46,9 +46,9 @@ describe("Moves - Heal Bell", () => {
     expect(rightPlayer.resetStatus).toHaveBeenCalledOnce();
     expect(partyPokemon.resetStatus).toHaveBeenCalledOnce();
 
-    expect(leftPlayer.status?.effect).toBeUndefined();
-    expect(rightPlayer.status?.effect).toBeUndefined();
-    expect(partyPokemon.status?.effect).toBeUndefined();
+    expect(leftPlayer).toHaveStatusEffect(StatusEffect.NONE);
+    expect(rightPlayer).toHaveStatusEffect(StatusEffect.NONE);
+    expect(partyPokemon).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   it("should not cure status effect of the target/target's allies", async () => {
@@ -69,8 +69,8 @@ describe("Moves - Heal Bell", () => {
     expect(leftOpp.status?.effect).toBeTruthy();
     expect(rightOpp.status?.effect).toBeTruthy();
 
-    expect(leftOpp.status?.effect).toBe(StatusEffect.BURN);
-    expect(rightOpp.status?.effect).toBe(StatusEffect.BURN);
+    expect(leftOpp).toHaveStatusEffect(StatusEffect.BURN);
+    expect(rightOpp).toHaveStatusEffect(StatusEffect.BURN);
   });
 
   it("should not cure status effect of allies ON FIELD with Soundproof, should still cure allies in party", async () => {
@@ -90,8 +90,8 @@ describe("Moves - Heal Bell", () => {
     expect(rightPlayer.resetStatus).toHaveBeenCalledTimes(0);
     expect(partyPokemon.resetStatus).toHaveBeenCalledOnce();
 
-    expect(leftPlayer.status?.effect).toBeUndefined();
-    expect(rightPlayer.status?.effect).toBe(StatusEffect.BURN);
-    expect(partyPokemon.status?.effect).toBeUndefined();
+    expect(leftPlayer).toHaveStatusEffect(StatusEffect.NONE);
+    expect(rightPlayer).toHaveStatusEffect(StatusEffect.BURN);
+    expect(partyPokemon).toHaveStatusEffect(StatusEffect.NONE);
   });
 });

--- a/test/moves/imprison.test.ts
+++ b/test/moves/imprison.test.ts
@@ -95,7 +95,7 @@ describe("Moves - Imprison", () => {
     await game.move.selectEnemyMove(MoveId.SPLASH);
     await game.toNextTurn();
     expect(playerPokemon.isActive(true)).toBeFalsy();
-    expect(game.scene.arena.getTag(ArenaTagType.IMPRISON)).toBeUndefined();
+    expect(game).not.toHaveArenaTag(ArenaTagType.IMPRISON);
     expect(enemyPokemon.getTag(BattlerTagType.IMPRISON)).toBeUndefined();
   });
 });

--- a/test/moves/imprison.test.ts
+++ b/test/moves/imprison.test.ts
@@ -89,7 +89,7 @@ describe("Moves - Imprison", () => {
     game.move.select(MoveId.IMPRISON);
     await game.move.selectEnemyMove(MoveId.GROWL);
     await game.toNextTurn();
-    expect(game.scene.arena.getTag(ArenaTagType.IMPRISON)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.IMPRISON);
     expect(enemyPokemon.getTag(BattlerTagType.IMPRISON)).toBeDefined();
     game.doSwitchPokemon(1);
     await game.move.selectEnemyMove(MoveId.SPLASH);

--- a/test/moves/lunar-blessing.test.ts
+++ b/test/moves/lunar-blessing.test.ts
@@ -71,7 +71,7 @@ describe("Moves - Lunar Blessing", () => {
     expect(leftPlayer.resetStatus).toHaveBeenCalledOnce();
     expect(rightPlayer.resetStatus).toHaveBeenCalledOnce();
 
-    expect(leftPlayer.status?.effect).toBeUndefined();
-    expect(rightPlayer.status?.effect).toBeUndefined();
+    expect(leftPlayer).toHaveStatusEffect(StatusEffect.NONE);
+    expect(rightPlayer).toHaveStatusEffect(StatusEffect.NONE);
   });
 });

--- a/test/moves/lunar-dance.test.ts
+++ b/test/moves/lunar-dance.test.ts
@@ -42,7 +42,7 @@ describe("Moves - Lunar Dance", () => {
     await game.toNextTurn();
 
     // Bulbasaur should still be burned and have used a PP for splash and not at max hp
-    expect(bulbasaur.status?.effect).toBe(StatusEffect.BURN);
+    expect(bulbasaur).toHaveStatusEffect(StatusEffect.BURN);
     expect(bulbasaur.moveset[1]?.ppUsed).toBe(1);
     expect(bulbasaur.hp).toBeLessThan(bulbasaur.getMaxHp());
 
@@ -58,7 +58,7 @@ describe("Moves - Lunar Dance", () => {
     await game.toNextTurn();
 
     // Bulbasaur should NOT have any status and have full PP for splash and be at max hp
-    expect(bulbasaur.status?.effect).toBeUndefined();
+    expect(bulbasaur).toHaveStatusEffect(StatusEffect.NONE);
     expect(bulbasaur.moveset[1]?.ppUsed).toBe(0);
     expect(bulbasaur.isFullHp()).toBe(true);
 
@@ -67,7 +67,7 @@ describe("Moves - Lunar Dance", () => {
     await game.toNextTurn();
 
     // Using Lunar dance again should fail because nothing in party and rattata should be alive
-    expect(rattata.status?.effect).toBe(StatusEffect.BURN);
+    expect(rattata).toHaveStatusEffect(StatusEffect.BURN);
     expect(rattata.hp).toBeLessThan(rattata.getMaxHp());
   });
 });

--- a/test/moves/magic-coat.test.ts
+++ b/test/moves/magic-coat.test.ts
@@ -165,7 +165,7 @@ describe("Moves - Magic Coat", () => {
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(game.scene.arena.getTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.PLAYER)!["layers"]).toBe(1);
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game).not.toHaveArenaTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY);
   });
 
   it("should not bounce back curse", async () => {

--- a/test/moves/magic-coat.test.ts
+++ b/test/moves/magic-coat.test.ts
@@ -252,7 +252,7 @@ describe("Moves - Magic Coat", () => {
     // Turn 1 - thunder wave immunity test
     game.move.select(MoveId.THUNDER_WAVE);
     await game.phaseInterceptor.to("BerryPhase");
-    expect(game.field.getPlayerPokemon().status).toBeUndefined();
+    expect(game.field.getPlayerPokemon()).toHaveStatusEffect(StatusEffect.NONE);
 
     // Turn 2 - soundproof immunity test
     game.move.select(MoveId.GROWL);
@@ -269,7 +269,7 @@ describe("Moves - Magic Coat", () => {
     vi.spyOn(attacker, "getAccuracyMultiplier").mockReturnValue(0.0);
     game.move.select(MoveId.SPORE);
     await game.phaseInterceptor.to("BerryPhase");
-    expect(game.field.getPlayerPokemon().status?.effect).toBe(StatusEffect.SLEEP);
+    expect(game.field.getPlayerPokemon()).toHaveStatusEffect(StatusEffect.SLEEP);
   });
 
   it("should take the accuracy of the magic bounce user into account", async () => {
@@ -280,6 +280,6 @@ describe("Moves - Magic Coat", () => {
     vi.spyOn(opponent, "getAccuracyMultiplier").mockReturnValue(0);
     game.move.select(MoveId.SPORE);
     await game.phaseInterceptor.to("BerryPhase");
-    expect(game.field.getPlayerPokemon().status).toBeUndefined();
+    expect(game.field.getPlayerPokemon()).toHaveStatusEffect(StatusEffect.NONE);
   });
 });

--- a/test/moves/pledge-moves.test.ts
+++ b/test/moves/pledge-moves.test.ts
@@ -100,7 +100,7 @@ describe("Moves - Pledge Moves", () => {
     // if they combined moves, so both should be damaged.
     expect(playerPokemon.hp).toBeLessThan(playerPokemon.getMaxHp());
     expect(enemyPokemon.hp).toBeLessThan(enemyPokemon.getMaxHp());
-    expect(game.scene.arena.getTag(ArenaTagType.FIRE_GRASS_PLEDGE)).toBeUndefined();
+    expect(game).not.toHaveArenaTag(ArenaTagType.FIRE_GRASS_PLEDGE);
   });
 
   it("Grass Pledge - should combine with Fire Pledge to form a 150-power Fire-type attack that creates a 'sea of fire'", async () => {

--- a/test/moves/pledge-moves.test.ts
+++ b/test/moves/pledge-moves.test.ts
@@ -129,7 +129,7 @@ describe("Moves - Pledge Moves", () => {
     const baseDmg = baseDmgMock.mock.results.at(-1)!.value;
     expect(enemyPokemon[0].getMaxHp() - enemyPokemon[0].hp).toBe(toDmgValue(baseDmg * 1.5));
     expect(enemyPokemon[1].hp).toBe(enemyPokemon[1].getMaxHp()); // PLAYER should not have attacked
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.FIRE_GRASS_PLEDGE, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.FIRE_GRASS_PLEDGE, ArenaTagSide.ENEMY);
 
     const enemyStartingHp = enemyPokemon.map(p => p.hp);
     await game.toNextTurn();
@@ -160,7 +160,7 @@ describe("Moves - Pledge Moves", () => {
     expect(playerPokemon[1].getMoveType).toHaveLastReturnedWith(PokemonType.WATER);
     expect(firePledge.calculateBattlePower).toHaveLastReturnedWith(150);
     expect(enemyPokemon[1].hp).toBe(enemyPokemon[1].getMaxHp()); // PLAYER should not have attacked
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER);
 
     await game.toNextTurn();
 
@@ -198,7 +198,7 @@ describe("Moves - Pledge Moves", () => {
     expect(waterPledge.calculateBattlePower).toHaveLastReturnedWith(150);
     expect(enemyPokemon[1].hp).toBe(enemyPokemon[1].getMaxHp());
 
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.ENEMY);
     enemyPokemon.forEach((p, i) => expect(p.getEffectiveStat(Stat.SPD)).toBe(Math.floor(enemyStartingSpd[i] / 4)));
   });
 
@@ -234,7 +234,7 @@ describe("Moves - Pledge Moves", () => {
 
     await game.phaseInterceptor.to("TurnEndPhase");
 
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER);
 
     game.move.select(MoveId.IRON_HEAD, 0, BattlerIndex.ENEMY);
     game.move.select(MoveId.SPLASH, 1);

--- a/test/moves/powder.test.ts
+++ b/test/moves/powder.test.ts
@@ -127,7 +127,7 @@ describe("Moves - Powder", () => {
     game.move.select(MoveId.POWDER);
 
     await game.phaseInterceptor.to(BerryPhase, false);
-    expect(enemyPokemon.status?.effect).not.toBe(StatusEffect.FREEZE);
+    expect(enemyPokemon).not.toHaveStatusEffect(StatusEffect.FREEZE);
     expect(enemyPokemon.getLastXMoves()[0].result).toBe(MoveResult.FAIL);
     expect(enemyPokemon.hp).toBe(Math.ceil((3 * enemyPokemon.getMaxHp()) / 4));
   });

--- a/test/moves/protect.test.ts
+++ b/test/moves/protect.test.ts
@@ -6,6 +6,7 @@ import { MoveResult } from "#enums/move-result";
 import { MoveUseMode } from "#enums/move-use-mode";
 import { SpeciesId } from "#enums/species-id";
 import { Stat } from "#enums/stat";
+import { StatusEffect } from "#enums/status-effect";
 import { GameManager } from "#test/test-utils/game-manager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -86,7 +87,12 @@ describe("Moves - Protect", () => {
 
     const charizard = game.field.getPlayerPokemon();
     charizard.summonData.moveHistory = [
-      { move: MoveId.ENDURE, result: MoveResult.SUCCESS, targets: [BattlerIndex.PLAYER], useMode: MoveUseMode.NORMAL },
+      {
+        move: MoveId.ENDURE,
+        result: MoveResult.SUCCESS,
+        targets: [BattlerIndex.PLAYER],
+        useMode: MoveUseMode.NORMAL,
+      },
       {
         move: MoveId.SPIKY_SHIELD,
         result: MoveResult.SUCCESS,
@@ -227,7 +233,7 @@ describe("Moves - Protect", () => {
     await game.toNextTurn();
 
     expect(aggron.hp).toBeLessThan(aggron.getMaxHp());
-    expect(aggron.status?.effect).toBeUndefined(); // check that protect actually worked
+    expect(aggron).toHaveStatusEffect(StatusEffect.NONE); // check that protect actually worked
   });
 
   // TODO: Add test

--- a/test/moves/psycho-shift.test.ts
+++ b/test/moves/psycho-shift.test.ts
@@ -40,11 +40,11 @@ describe("Moves - Psycho Shift", () => {
     const playerPokemon = game.field.getPlayerPokemon();
     const enemyPokemon = game.field.getEnemyPokemon();
     expect(playerPokemon.status).toBeDefined();
-    expect(enemyPokemon.status).toBeFalsy();
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.NONE);
 
     game.move.select(MoveId.PSYCHO_SHIFT);
     await game.phaseInterceptor.to("TurnEndPhase");
-    expect(playerPokemon.status).toBeNull();
+    expect(playerPokemon).toHaveStatusEffect(StatusEffect.NONE);
     expect(enemyPokemon.status).toBeDefined();
   });
 });

--- a/test/moves/purify.test.ts
+++ b/test/moves/purify.test.ts
@@ -48,7 +48,7 @@ describe("Moves - Purify", () => {
     await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
     await game.phaseInterceptor.to(MoveEndPhase);
 
-    expect(enemyPokemon.status).toBeNull();
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.NONE);
     expect(playerPokemon.isFullHp()).toBe(true);
   });
 

--- a/test/moves/quick-guard.test.ts
+++ b/test/moves/quick-guard.test.ts
@@ -3,6 +3,7 @@ import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { MoveResult } from "#enums/move-result";
 import { SpeciesId } from "#enums/species-id";
+import { StatusEffect } from "#enums/status-effect";
 import { GameManager } from "#test/test-utils/game-manager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -51,7 +52,11 @@ describe("Moves - Quick Guard", () => {
 
   it.each<{ name: string; move: MoveId; ability: AbilityId }>([
     { name: "Prankster", move: MoveId.SPORE, ability: AbilityId.PRANKSTER },
-    { name: "Gale Wings", move: MoveId.BRAVE_BIRD, ability: AbilityId.GALE_WINGS },
+    {
+      name: "Gale Wings",
+      move: MoveId.BRAVE_BIRD,
+      ability: AbilityId.GALE_WINGS,
+    },
   ])("should protect the user and allies from $name-boosted moves", async ({ move, ability }) => {
     game.override.enemyMoveset(move).enemyAbility(ability);
     await game.classicMode.startBattle([SpeciesId.CHARIZARD, SpeciesId.BLASTOISE]);
@@ -66,8 +71,8 @@ describe("Moves - Quick Guard", () => {
 
     expect(charizard.hp).toBe(charizard.getMaxHp());
     expect(blastoise.hp).toBe(blastoise.getMaxHp());
-    expect(charizard.status?.effect).toBeUndefined();
-    expect(blastoise.status?.effect).toBeUndefined();
+    expect(charizard).toHaveStatusEffect(StatusEffect.NONE);
+    expect(blastoise).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   it("should increment (but not respect) other protection moves' fail counters", async () => {

--- a/test/moves/rest.test.ts
+++ b/test/moves/rest.test.ts
@@ -40,13 +40,13 @@ describe("Move - Rest", () => {
 
     const snorlax = game.field.getPlayerPokemon();
     snorlax.hp = 1;
-    expect(snorlax.status?.effect).toBe(StatusEffect.POISON);
+    expect(snorlax).toHaveStatusEffect(StatusEffect.POISON);
 
     game.move.use(MoveId.REST);
     await game.toEndOfTurn();
 
     expect(snorlax.hp).toBe(snorlax.getMaxHp());
-    expect(snorlax.status?.effect).toBe(StatusEffect.SLEEP);
+    expect(snorlax).toHaveStatusEffect(StatusEffect.SLEEP);
   });
 
   it("should always last 3 turns", async () => {
@@ -60,7 +60,7 @@ describe("Move - Rest", () => {
     game.move.use(MoveId.REST);
     await game.toNextTurn();
 
-    expect(snorlax.status?.effect).toBe(StatusEffect.SLEEP);
+    expect(snorlax).toHaveStatusEffect(StatusEffect.SLEEP);
     expect(snorlax.status?.sleepTurnsRemaining).toBe(3);
 
     game.move.use(MoveId.SWORDS_DANCE);
@@ -73,7 +73,7 @@ describe("Move - Rest", () => {
 
     game.move.use(MoveId.SWORDS_DANCE);
     await game.toNextTurn();
-    expect(snorlax.status?.effect).toBeUndefined();
+    expect(snorlax).toHaveStatusEffect(StatusEffect.NONE);
     expect(snorlax.getStatStage(Stat.ATK)).toBe(2);
   });
 
@@ -90,9 +90,17 @@ describe("Move - Rest", () => {
     expect(snorlax.getTag(BattlerTagType.CONFUSED)).toBeDefined();
   });
 
-  it.each<{ name: string; status?: StatusEffect; ability?: AbilityId; dmg?: number }>([
+  it.each<{
+    name: string;
+    status?: StatusEffect;
+    ability?: AbilityId;
+    dmg?: number;
+  }>([
     { name: "is at full HP", dmg: 0 },
-    { name: "is grounded on Electric Terrain", ability: AbilityId.ELECTRIC_SURGE },
+    {
+      name: "is grounded on Electric Terrain",
+      ability: AbilityId.ELECTRIC_SURGE,
+    },
     { name: "is grounded on Misty Terrain", ability: AbilityId.MISTY_SURGE },
     { name: "has Comatose", ability: AbilityId.COMATOSE },
   ])("should fail if the user $name", async ({ status = StatusEffect.NONE, ability = AbilityId.NONE, dmg = 1 }) => {
@@ -121,7 +129,7 @@ describe("Move - Rest", () => {
     await game.toEndOfTurn();
 
     expect(snorlax.isFullHp()).toBe(false);
-    expect(snorlax.status?.effect).toBe(StatusEffect.SLEEP);
+    expect(snorlax).toHaveStatusEffect(StatusEffect.SLEEP);
     expect(snorlax.getLastXMoves(-1).map(tm => tm.result)).toEqual([MoveResult.FAIL, MoveResult.SUCCESS]);
   });
 
@@ -132,13 +140,13 @@ describe("Move - Rest", () => {
     const snorlax = game.field.getPlayerPokemon();
     snorlax.hp = 1;
 
-    expect(snorlax.status?.effect).toBe(StatusEffect.SLEEP);
+    expect(snorlax).toHaveStatusEffect(StatusEffect.SLEEP);
     snorlax.status!.sleepTurnsRemaining = 1;
 
     game.move.use(MoveId.REST);
     await game.toNextTurn();
 
-    expect(snorlax.status!.effect).toBe(StatusEffect.SLEEP);
+    expect(snorlax).toHaveStatusEffect(StatusEffect.SLEEP);
     expect(snorlax.isFullHp()).toBe(true);
     expect(snorlax.getLastXMoves()[0].result).toBe(MoveResult.SUCCESS);
     expect(snorlax.status!.sleepTurnsRemaining).toBeGreaterThan(1);

--- a/test/moves/revival-blessing.test.ts
+++ b/test/moves/revival-blessing.test.ts
@@ -3,6 +3,7 @@ import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { MoveResult } from "#enums/move-result";
 import { SpeciesId } from "#enums/species-id";
+import { StatusEffect } from "#enums/status-effect";
 import { GameManager } from "#test/test-utils/game-manager";
 import { toDmgValue } from "#utils/common";
 import Phaser from "phaser";
@@ -52,7 +53,7 @@ describe("Moves - Revival Blessing", () => {
     await game.phaseInterceptor.to("MoveEndPhase", false);
 
     const revivedPokemon = game.scene.getPlayerParty()[1];
-    expect(revivedPokemon.status?.effect).toBeFalsy();
+    expect(revivedPokemon).toHaveStatusEffect(StatusEffect.NONE);
     expect(revivedPokemon.hp).toBe(Math.floor(revivedPokemon.getMaxHp() / 2));
   });
 
@@ -71,7 +72,7 @@ describe("Moves - Revival Blessing", () => {
     await game.phaseInterceptor.to("MoveEndPhase", false);
 
     const revivedPokemon = game.scene.getEnemyParty()[1];
-    expect(revivedPokemon.status?.effect).toBeFalsy();
+    expect(revivedPokemon).toHaveStatusEffect(StatusEffect.NONE);
     expect(revivedPokemon.hp).toBe(Math.floor(revivedPokemon.getMaxHp() / 2));
   });
 

--- a/test/moves/safeguard.test.ts
+++ b/test/moves/safeguard.test.ts
@@ -43,7 +43,7 @@ describe("Moves - Safeguard", () => {
     await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.toNextTurn();
 
-    expect(enemy.status).toBeUndefined();
+    expect(enemy).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   it("protects from status moves", async () => {
@@ -54,7 +54,7 @@ describe("Moves - Safeguard", () => {
     await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.toNextTurn();
 
-    expect(enemyPokemon.status).toBeUndefined();
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   it("protects from confusion", async () => {
@@ -83,8 +83,8 @@ describe("Moves - Safeguard", () => {
 
     const enemyPokemon = game.scene.getEnemyField();
 
-    expect(enemyPokemon[0].status).toBeUndefined();
-    expect(enemyPokemon[1].status).toBeUndefined();
+    expect(enemyPokemon[0]).toHaveStatusEffect(StatusEffect.NONE);
+    expect(enemyPokemon[1]).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   it("protects from Yawn", async () => {
@@ -109,7 +109,7 @@ describe("Moves - Safeguard", () => {
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
 
-    expect(enemyPokemon.status?.effect).toBe(StatusEffect.SLEEP);
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.SLEEP);
   });
 
   it("doesn't protect from self-inflicted status from Rest or Flame Orb", async () => {
@@ -122,7 +122,7 @@ describe("Moves - Safeguard", () => {
     await game.move.forceEnemyMove(MoveId.SAFEGUARD);
     await game.toNextTurn();
 
-    expect(enemyPokemon.status?.effect).toBe(StatusEffect.BURN);
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.BURN);
 
     enemyPokemon.resetStatus();
 
@@ -130,7 +130,7 @@ describe("Moves - Safeguard", () => {
     await game.move.forceEnemyMove(MoveId.REST);
     await game.toNextTurn();
 
-    expect(enemyPokemon.status?.effect).toBe(StatusEffect.SLEEP);
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.SLEEP);
   });
 
   it("protects from ability-inflicted status", async () => {
@@ -152,6 +152,6 @@ describe("Moves - Safeguard", () => {
     await game.toNextTurn();
 
     const enemyPokemon = game.field.getEnemyPokemon();
-    expect(enemyPokemon.status).toBeUndefined();
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.NONE);
   });
 });

--- a/test/moves/secret-power.test.ts
+++ b/test/moves/secret-power.test.ts
@@ -49,7 +49,7 @@ describe("Moves - Secret Power", () => {
     game.move.select(MoveId.SECRET_POWER);
     await game.move.selectEnemyMove(MoveId.SPLASH);
     await game.phaseInterceptor.to("TurnEndPhase");
-    expect(enemyPokemon.status?.effect).toBe(StatusEffect.BURN);
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.BURN);
 
     // Misty Terrain --> SpAtk -1
     game.move.select(MoveId.SECRET_POWER);

--- a/test/moves/sleep-talk.test.ts
+++ b/test/moves/sleep-talk.test.ts
@@ -73,7 +73,7 @@ describe("Moves - Sleep Talk", () => {
     await game.classicMode.startBattle([SpeciesId.FEEBAS]);
 
     const feebas = game.field.getPlayerPokemon();
-    expect(feebas.status?.effect).toBe(StatusEffect.SLEEP);
+    expect(feebas).toHaveStatusEffect(StatusEffect.SLEEP);
     feebas.status!.sleepTurnsRemaining = 1;
 
     game.move.select(MoveId.SLEEP_TALK);

--- a/test/moves/sparkly-swirl.test.ts
+++ b/test/moves/sparkly-swirl.test.ts
@@ -50,9 +50,9 @@ describe("Moves - Sparkly Swirl", () => {
     expect(rightPlayer.resetStatus).toHaveBeenCalledOnce();
     expect(partyPokemon.resetStatus).toHaveBeenCalledOnce();
 
-    expect(leftPlayer.status?.effect).toBeUndefined();
-    expect(rightPlayer.status?.effect).toBeUndefined();
-    expect(partyPokemon.status?.effect).toBeUndefined();
+    expect(leftPlayer).toHaveStatusEffect(StatusEffect.NONE);
+    expect(rightPlayer).toHaveStatusEffect(StatusEffect.NONE);
+    expect(partyPokemon).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   it("should not cure status effect of the target/target's allies", async () => {
@@ -73,7 +73,7 @@ describe("Moves - Sparkly Swirl", () => {
     expect(leftOpp.status?.effect).toBeTruthy();
     expect(rightOpp.status?.effect).toBeTruthy();
 
-    expect(leftOpp.status?.effect).toBe(StatusEffect.BURN);
-    expect(rightOpp.status?.effect).toBe(StatusEffect.BURN);
+    expect(leftOpp).toHaveStatusEffect(StatusEffect.BURN);
+    expect(rightOpp).toHaveStatusEffect(StatusEffect.BURN);
   });
 });

--- a/test/moves/substitute.test.ts
+++ b/test/moves/substitute.test.ts
@@ -189,7 +189,7 @@ describe("Moves - Substitute", () => {
     await game.toNextTurn();
 
     expect(leadPokemon.getMoveEffectiveness).not.toHaveReturnedWith(0);
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.LIGHT_SCREEN, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.LIGHT_SCREEN, ArenaTagSide.PLAYER);
   });
 
   it("shouldn't block the opponent from setting hazards", async () => {
@@ -205,7 +205,7 @@ describe("Moves - Substitute", () => {
     await game.toNextTurn();
 
     expect(leadPokemon.getMoveEffectiveness).not.toHaveReturnedWith(0);
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.STEALTH_ROCK, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.STEALTH_ROCK, ArenaTagSide.PLAYER);
   });
 
   it("shouldn't block moves that target both sides of the field", async () => {
@@ -224,8 +224,8 @@ describe("Moves - Substitute", () => {
     await game.toNextTurn();
 
     pokemon.forEach(p => expect(p.getMoveEffectiveness).not.toHaveReturnedWith(0));
-    expect(game.scene.arena.getTag(ArenaTagType.TRICK_ROOM)).toBeDefined();
-    expect(game.scene.arena.getTag(ArenaTagType.GRAVITY)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.TRICK_ROOM);
+    expect(game).toHaveArenaTag(ArenaTagType.GRAVITY);
   });
 
   it("should protect the user from flinching", async () => {

--- a/test/moves/substitute.test.ts
+++ b/test/moves/substitute.test.ts
@@ -292,7 +292,7 @@ describe("Moves - Substitute", () => {
 
     await game.phaseInterceptor.to("BerryPhase", false);
 
-    expect(leadPokemon.status?.effect).not.toBe(StatusEffect.PARALYSIS);
+    expect(leadPokemon).not.toHaveStatusEffect(StatusEffect.PARALYSIS);
   });
 
   it("should prevent the user's items from being stolen", async () => {
@@ -471,7 +471,7 @@ describe("Moves - Substitute", () => {
 
     await game.phaseInterceptor.to("MoveEndPhase");
 
-    expect(enemyPokemon.status?.effect).not.toBe(StatusEffect.BURN);
+    expect(enemyPokemon).not.toHaveStatusEffect(StatusEffect.BURN);
   });
 
   it("should cause incoming attacks to not activate Counter", async () => {

--- a/test/moves/tailwind.test.ts
+++ b/test/moves/tailwind.test.ts
@@ -73,7 +73,7 @@ describe("Moves - Tailwind", () => {
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
 
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeUndefined();
+    expect(game).not.toHaveArenaTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER);
   });
 
   it("does not affect the opposing side", async () => {
@@ -89,8 +89,8 @@ describe("Moves - Tailwind", () => {
 
     expect(ally.getEffectiveStat(Stat.SPD)).equal(allySpd);
     expect(enemy.getEffectiveStat(Stat.SPD)).equal(enemySpd);
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeUndefined();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.TAILWIND, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game).not.toHaveArenaTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER);
+    expect(game).not.toHaveArenaTag(ArenaTagType.TAILWIND, ArenaTagSide.ENEMY);
 
     game.move.select(MoveId.TAILWIND);
 
@@ -99,6 +99,6 @@ describe("Moves - Tailwind", () => {
     expect(ally.getEffectiveStat(Stat.SPD)).toBe(allySpd * 2);
     expect(enemy.getEffectiveStat(Stat.SPD)).equal(enemySpd);
     expect(game.scene.arena.getTagOnSide(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.TAILWIND, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game).not.toHaveArenaTag(ArenaTagType.TAILWIND, ArenaTagSide.ENEMY);
   });
 });

--- a/test/moves/tailwind.test.ts
+++ b/test/moves/tailwind.test.ts
@@ -50,7 +50,7 @@ describe("Moves - Tailwind", () => {
 
     expect(magikarp.getEffectiveStat(Stat.SPD)).toBe(magikarpSpd * 2);
     expect(meowth.getEffectiveStat(Stat.SPD)).toBe(meowthSpd * 2);
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER);
   });
 
   it("lasts for 4 turns", async () => {
@@ -60,15 +60,15 @@ describe("Moves - Tailwind", () => {
 
     game.move.select(MoveId.TAILWIND);
     await game.toNextTurn();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER);
 
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER);
 
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER);
 
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
@@ -98,7 +98,7 @@ describe("Moves - Tailwind", () => {
 
     expect(ally.getEffectiveStat(Stat.SPD)).toBe(allySpd * 2);
     expect(enemy.getEffectiveStat(Stat.SPD)).equal(enemySpd);
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game).toHaveArenaTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER);
     expect(game).not.toHaveArenaTag(ArenaTagType.TAILWIND, ArenaTagSide.ENEMY);
   });
 });

--- a/test/moves/thunder-wave.test.ts
+++ b/test/moves/thunder-wave.test.ts
@@ -42,7 +42,7 @@ describe("Moves - Thunder Wave", () => {
     await game.move.forceHit();
     await game.phaseInterceptor.to("BerryPhase", false);
 
-    expect(enemyPokemon.status?.effect).toBe(StatusEffect.PARALYSIS);
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.PARALYSIS);
   });
 
   it("does not paralyze if the Pokemon is a Ground-type", async () => {
@@ -55,7 +55,7 @@ describe("Moves - Thunder Wave", () => {
     await game.move.forceHit();
     await game.phaseInterceptor.to("BerryPhase", false);
 
-    expect(enemyPokemon.status).toBeUndefined();
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   it("does not paralyze if the Pokemon already has a status effect", async () => {
@@ -68,7 +68,7 @@ describe("Moves - Thunder Wave", () => {
     await game.move.forceHit();
     await game.phaseInterceptor.to("BerryPhase", false);
 
-    expect(enemyPokemon.status?.effect).not.toBe(StatusEffect.PARALYSIS);
+    expect(enemyPokemon).not.toHaveStatusEffect(StatusEffect.PARALYSIS);
   });
 
   it("affects Ground types if the user has Normalize", async () => {
@@ -81,7 +81,7 @@ describe("Moves - Thunder Wave", () => {
     await game.move.forceHit();
     await game.phaseInterceptor.to("BerryPhase", false);
 
-    expect(enemyPokemon.status?.effect).toBe(StatusEffect.PARALYSIS);
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.PARALYSIS);
   });
 
   it("does not affect Ghost types if the user has Normalize", async () => {
@@ -94,6 +94,6 @@ describe("Moves - Thunder Wave", () => {
     await game.move.forceHit();
     await game.phaseInterceptor.to("BerryPhase", false);
 
-    expect(enemyPokemon.status).toBeUndefined();
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.NONE);
   });
 });

--- a/test/moves/tidy-up.test.ts
+++ b/test/moves/tidy-up.test.ts
@@ -45,7 +45,7 @@ describe("Moves - Tidy Up", () => {
     await game.phaseInterceptor.to(TurnEndPhase);
     game.move.select(MoveId.TIDY_UP);
     await game.phaseInterceptor.to(MoveEndPhase);
-    expect(game.scene.arena.getTag(ArenaTagType.SPIKES)).toBeUndefined();
+    expect(game).not.toHaveArenaTag(ArenaTagType.SPIKES);
   });
 
   it("stealth rocks are cleared", async () => {
@@ -56,7 +56,7 @@ describe("Moves - Tidy Up", () => {
     await game.phaseInterceptor.to(TurnEndPhase);
     game.move.select(MoveId.TIDY_UP);
     await game.phaseInterceptor.to(MoveEndPhase);
-    expect(game.scene.arena.getTag(ArenaTagType.STEALTH_ROCK)).toBeUndefined();
+    expect(game).not.toHaveArenaTag(ArenaTagType.STEALTH_ROCK);
   });
 
   it("toxic spikes are cleared", async () => {
@@ -67,7 +67,7 @@ describe("Moves - Tidy Up", () => {
     await game.phaseInterceptor.to(TurnEndPhase);
     game.move.select(MoveId.TIDY_UP);
     await game.phaseInterceptor.to(MoveEndPhase);
-    expect(game.scene.arena.getTag(ArenaTagType.TOXIC_SPIKES)).toBeUndefined();
+    expect(game).not.toHaveArenaTag(ArenaTagType.TOXIC_SPIKES);
   });
 
   it("sticky webs are cleared", async () => {
@@ -79,7 +79,7 @@ describe("Moves - Tidy Up", () => {
     await game.phaseInterceptor.to(TurnEndPhase);
     game.move.select(MoveId.TIDY_UP);
     await game.phaseInterceptor.to(MoveEndPhase);
-    expect(game.scene.arena.getTag(ArenaTagType.STICKY_WEB)).toBeUndefined();
+    expect(game).not.toHaveArenaTag(ArenaTagType.STICKY_WEB);
   });
 
   it("substitutes are cleared", async () => {

--- a/test/moves/toxic.test.ts
+++ b/test/moves/toxic.test.ts
@@ -37,7 +37,7 @@ describe("Moves - Toxic", () => {
     game.move.select(MoveId.TOXIC);
     await game.phaseInterceptor.to("BerryPhase", false);
 
-    expect(game.field.getEnemyPokemon().status?.effect).toBe(StatusEffect.TOXIC);
+    expect(game.field.getEnemyPokemon()).toHaveStatusEffect(StatusEffect.TOXIC);
   });
 
   it("may miss if user is not Poison-type", async () => {
@@ -47,7 +47,7 @@ describe("Moves - Toxic", () => {
     game.move.select(MoveId.TOXIC);
     await game.phaseInterceptor.to("BerryPhase", false);
 
-    expect(game.field.getEnemyPokemon().status).toBeUndefined();
+    expect(game.field.getEnemyPokemon()).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   it("should hit semi-invulnerable targets if user is Poison-type", async () => {
@@ -59,7 +59,7 @@ describe("Moves - Toxic", () => {
     await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.phaseInterceptor.to("BerryPhase", false);
 
-    expect(game.field.getEnemyPokemon().status?.effect).toBe(StatusEffect.TOXIC);
+    expect(game.field.getEnemyPokemon()).toHaveStatusEffect(StatusEffect.TOXIC);
   });
 
   it("should miss semi-invulnerable targets if user is not Poison-type", async () => {
@@ -71,7 +71,7 @@ describe("Moves - Toxic", () => {
     await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.phaseInterceptor.to("BerryPhase", false);
 
-    expect(game.field.getEnemyPokemon().status).toBeUndefined();
+    expect(game.field.getEnemyPokemon()).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   it("moves other than Toxic should not hit semi-invulnerable targets even if user is Poison-type", async () => {

--- a/test/moves/transform-imposter.test.ts
+++ b/test/moves/transform-imposter.test.ts
@@ -141,7 +141,7 @@ describe("Transforming Effects", () => {
       game.move.use(MoveId.TRANSFORM);
       await game.toEndOfTurn();
 
-      expect(ditto.status?.effect).toBeUndefined();
+      expect(ditto).toHaveStatusEffect(StatusEffect.NONE);
       expect(ditto.getNameToRender()).not.toBe(mew.getNameToRender());
       expect(ditto.level).not.toBe(mew.level);
       expect(ditto.friendship).not.toBe(mew.friendship);
@@ -257,7 +257,11 @@ describe("Transforming Effects", () => {
   });
 
   describe("Moves - Transform", () => {
-    it.each<{ cause: string; callback: (p: Pokemon) => void; player?: boolean }>([
+    it.each<{
+      cause: string;
+      callback: (p: Pokemon) => void;
+      player?: boolean;
+    }>([
       {
         cause: "user is fused",
         callback: p => vi.spyOn(p, "isFusion").mockReturnValue(true),
@@ -321,7 +325,10 @@ describe("Transforming Effects", () => {
         name: "opponents with substitutes",
         callback: p => p.addTag(BattlerTagType.SUBSTITUTE, 1, MoveId.SUBSTITUTE, p.id),
       },
-      { name: "fused opponents", callback: p => vi.spyOn(p, "isFusion").mockReturnValue(true) },
+      {
+        name: "fused opponents",
+        callback: p => vi.spyOn(p, "isFusion").mockReturnValue(true),
+      },
       {
         name: "opponents with illusions",
         callback: p => p.setIllusion(game.scene.getEnemyParty()[1]), // doesn't really matter what the illusion is, merely that it exists

--- a/test/moves/will-o-wisp.test.ts
+++ b/test/moves/will-o-wisp.test.ts
@@ -43,11 +43,11 @@ describe("Moves - Will-O-Wisp", () => {
     await game.move.forceHit();
     await game.toNextTurn();
 
-    expect(enemy.status?.effect).toBe(StatusEffect.BURN);
+    expect(enemy).toHaveStatusEffect(StatusEffect.BURN);
 
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
 
-    expect(enemy.status?.effect).toBe(StatusEffect.BURN);
+    expect(enemy).toHaveStatusEffect(StatusEffect.BURN);
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?
None

## Why am I making these changes?
Being consistent in the test utils we use is both crucial for developer DX (with more informative error messages and such) and is a good way to showcase our better test utils.

## What are the changes from a developer perspective?
Did a LOT of regexing.

The full list of regexes used will appear in the commit messages for each commit, each one being ~1 regex operation.

## How to test the changes?
run tests and check nothing breaks

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?