### PR TITLE
[Bug] [Ability] Fix stat boost message timing from quark drive / protosynthesis

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2159,7 +2159,7 @@ export class HighestStatBoostTag extends AbilityBattlerTag {
       null,
       false,
       null,
-      true,
+      false,
     );
   }
 


### PR DESCRIPTION
## What are the changes the user will see?
Stat boost message for quark drive / protosynthesis will now no longer occur after the effect.

## Why am I making these changes?
Annoying bug

## What are the changes from a developer perspective?
Pass `false` for defer in the method's invocation.

## Screenshots/Videos

## How to test the changes?
Activate quark drive in battle via something like electric terrain.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes? phase ordering with the other stuff going on? nty
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~