### PR TITLE
[Bug] remove `node:console` import

### DIFF
--- a/src/field/mystery-encounter-intro.ts
+++ b/src/field/mystery-encounter-intro.ts
@@ -6,7 +6,6 @@ import type { MysteryEncounter } from "#mystery-encounters/mystery-encounter";
 import { loadPokemonVariantAssets } from "#sprites/pokemon-sprite";
 import type { Variant } from "#sprites/variant";
 import { isNullOrUndefined } from "#utils/common";
-import console from "node:console";
 import type { GameObjects } from "phaser";
 
 type PlayAnimationConfig = Phaser.Types.Animations.PlayAnimationConfig;


### PR DESCRIPTION
## What are the changes the user will see?


## Why am I making these changes?

MEs threw an error and didn't work

## What are the changes from a developer perspective?

removed an import for `node:console` which was added in the biome pr

## Screenshots/Videos

## How to test the changes?

```ts
const overrides = {
  MYSTERY_ENCOUNTER_OVERRIDE: MysteryEncounterType.PART_TIMER,
  MYSTERY_ENCOUNTER_RATE_OVERRIDE: 256,
  STARTING_WAVE_OVERRIDE: 53
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)