### PR TITLE
[Docs] Cleanup docs in pokemon.ts

### DIFF
--- a/src/@types/damage-params.ts
+++ b/src/@types/damage-params.ts
@@ -3,14 +3,12 @@ import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#types/move-types";
 
 /**
- *
  * Collection of types for methods like {@linkcode Pokemon#getBaseDamage} and {@linkcode Pokemon#getAttackDamage}.
  * @module
- *
  */
 
-/** Base typeclass for damage parameter methods, used for DRY */
-export type damageParams = {
+/** Base type for damage parameter methods, used for DRY */
+export interface damageParams {
   /** The attacking {@linkcode Pokemon} */
   source: Pokemon;
   /** The move used in the attack */

--- a/src/@types/damage-params.ts
+++ b/src/@types/damage-params.ts
@@ -29,7 +29,7 @@ export interface damageParams {
   simulated?: boolean;
   /** If defined, used in place of calculated effectiveness values */
   effectiveness?: number;
-};
+}
 
 /**
  * Type for the parameters of {@linkcode Pokemon#getBaseDamage | getBaseDamage}

--- a/src/@types/damage-params.ts
+++ b/src/@types/damage-params.ts
@@ -1,0 +1,46 @@
+import type { MoveCategory } from "#enums/move-category";
+import type { Pokemon } from "#field/pokemon";
+import type { Move } from "#types/move-types";
+
+/**
+ *
+ * Collection of types for methods like {@linkcode Pokemon#getBaseDamage} and {@linkcode Pokemon#getAttackDamage}.
+ * @module
+ *
+ */
+
+/** Base typeclass for damage parameter methods, used for DRY */
+export type damageParams = {
+  /** The attacking {@linkcode Pokemon} */
+  source: Pokemon;
+  /** The move used in the attack */
+  move: Move;
+  /** The move's {@linkcode MoveCategory} after variable-category effects are applied */
+  moveCategory: MoveCategory;
+  /** If `true`, ignores this Pokemon's defensive ability effects */
+  ignoreAbility?: boolean;
+  /** If `true`, ignores the attacking Pokemon's ability effects */
+  ignoreSourceAbility?: boolean;
+  /** If `true`, ignores the ally Pokemon's ability effects */
+  ignoreAllyAbility?: boolean;
+  /** If `true`, ignores the ability effects of the attacking pokemon's ally */
+  ignoreSourceAllyAbility?: boolean;
+  /** If `true`, calculates damage for a critical hit */
+  isCritical?: boolean;
+  /** If `true`, suppresses changes to game state during the calculation */
+  simulated?: boolean;
+  /** If defined, used in place of calculated effectiveness values */
+  effectiveness?: number;
+};
+
+/**
+ * Type for the parameters of {@linkcode Pokemon#getBaseDamage | getBaseDamage}
+ * @interface
+ */
+export type getBaseDamageParams = Omit<damageParams, "effectiveness">;
+
+/**
+ * Type for the parameters of {@linkcode Pokemon#getAttackDamage | getAttackDamage}
+ * @interface
+ */
+export type getAttackDamageParams = Omit<damageParams, "moveCategory">;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2498,14 +2498,14 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Calculate the move's type effectiveness multiplier when based on this Pokémon's type(s)
-   * @param moveType - The type of the move being used
-   * @param source - The Pokemon using the move
-   * @param ignoreStrongWinds - Whether or not this ignores strong winds (anticipation, forewarn, stealth rocks)
-   * @param simulated - Whether to suppress changes to game state and prevent showing messages during this calculation
-   * @param move - The move whose type effectiveness is to be checked. Used for applying {@linkcode VariableMoveTypeChartAttr}
-   * @param useIllusion - Whether to consider an active illusion
-   * @returns A multiplier for the type effectiveness
+   * Calculates the move's type effectiveness multiplier based on the target's type/s.
+   * @param moveType {@linkcode PokemonType} the type of the move being used
+   * @param source {@linkcode Pokemon} the Pokemon using the move
+   * @param ignoreStrongWinds whether or not this ignores strong winds (anticipation, forewarn, stealth rocks)
+   * @param simulated tag to only apply the strong winds effect message when the move is used
+   * @param move (optional) the move whose type effectiveness is to be checked. Used for applying {@linkcode VariableMoveTypeChartAttr}
+   * @param useIllusion - Whether we want the attack type effectiveness on the illusion or not
+   * @returns a multiplier for the type effectiveness
    */
   getAttackTypeEffectiveness(
     moveType: PokemonType,
@@ -3486,7 +3486,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Adds experience to this PlayerPokemon, subject to wave based level caps.
    * @param exp - The amount of experience to add
-   * @param ignoreLevelCap - Whether to ignore level caps when adding experience (defaults to false)
+   * @param ignoreLevelCap - Whether to ignore level caps when adding experience; default `false`
    */
   addExp(exp: number, ignoreLevelCap = false) {
     const maxExpLevel = globalScene.getMaxExpLevel(ignoreLevelCap);
@@ -3503,8 +3503,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Compares if `this` and {@linkcode target} are on the same team.
-   * @param target - The {@linkcode Pokemon} to compare against.
+   * Check whether the specified Pokémon is an opponent
+   * @param target - The {@linkcode Pokemon} to compare against
    * @returns `true` if the two pokemon are allies, `false` otherwise
    */
   public isOpponent(target: Pokemon): boolean {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -227,10 +227,10 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * The ID of the biome this Pokémon was met in
    * @remarks
-   * Primarily used for displaying in the summary screen
+   * Primarily used for display in the summary screen.
    */
   public metBiome: BiomeId | -1;
-  // TODO: figure out why this used and document it (seems only to be read for getting the Pokémon's egg moves)
+  // TODO: figure out why this is used and document it (seems only to be read for getting the Pokémon's egg moves)
   public metSpecies: SpeciesId;
   /** The wave index at which this Pokémon was met/encountered */
   public metWave: number;
@@ -248,7 +248,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   public teraType: PokemonType;
   /** Whether this Pokémon is currently Terastallized */
   public isTerastallized: boolean;
-  /** The set of Types that have been boosted by this Pokémon's Stellar terastallization */
+  /** The set of Types that have been boosted by this Pokémon's Stellar Terastallization. */
   public stellarTypesBoosted: PokemonType[];
 
   // TODO: Create a fusionData class / interface and move all fusion-related fields there, exposed via getters
@@ -284,7 +284,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /** Used by Mystery Encounters to execute pokemon-specific logic (such as stat boosts) at start of battle */
   public mysteryEncounterBattleEffects?: (pokemon: Pokemon) => void;
 
-  /** The position of the pokemon on the field */
+  /** The position of this Pokémon on the field */
   public fieldPosition: FieldPosition;
 
   public maskEnabled: boolean;
@@ -841,11 +841,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * Gracefully handle errors loading a variant sprite. Log if it fails and attempt to fall back on
    * non-experimental sprites before giving up.
    *
-   * @param cacheKey - the cache key for the variant color sprite
-   * @param attemptedSpritePath - the sprite path that failed to load
-   * @param useExpSprite - was the attempted sprite experimental
-   * @param battleSpritePath - the filename of the sprite
-   * @param optionalParams - any additional params to log
+   * @param cacheKey - The cache key for the variant color sprite
+   * @param attemptedSpritePath - The sprite path that failed to load
+   * @param useExpSprite - Whether the attempted sprite was experimental
+   * @param battleSpritePath - The filename of the sprite
+   * @param optionalParams - Any additional params to log
    */
   async fallbackVariantColor(
     cacheKey: string,
@@ -1198,7 +1198,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @see {@linkcode Phaser.GameObjects.Sprite.play}
    * @param sprite - Sprite to animate
    * @param tintSprite - Sprite placed on top of the sprite to add a color tint
-   * @param animConfig - string to pass to the sprite's {@linkcode Phaser.GameObjects.Sprite.play | play} method
+   * @param animConfig - String to pass to the sprite's {@linkcode Phaser.GameObjects.Sprite.play | play} method
    * @returns true if the sprite was able to be animated
    */
   tryPlaySprite(sprite: Phaser.GameObjects.Sprite, tintSprite: Phaser.GameObjects.Sprite, key: string): boolean {
@@ -1267,7 +1267,6 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * Set the field position of this Pokémon
    * @param fieldPosition - The new field position
    * @param duration - How long the transition should take, in milliseconds; if `0` or `undefined`, the position is changed instantly
-   * @returns
    */
   public setFieldPosition(fieldPosition: FieldPosition, duration?: number): Promise<void> {
     return new Promise(resolve => {
@@ -1619,7 +1618,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return baseStats;
   }
 
-  // TOOD: Convert t his into a getter
+  // TODO: Convert this into a getter
   getNature(): Nature {
     return this.customPokemonData.nature !== -1 ? this.customPokemonData.nature : this.nature;
   }
@@ -1652,7 +1651,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return this.hp >= this.getMaxHp();
   }
 
-  // TODO: Conver this into a getter
+  // TODO: Convert this into a getter
   getMaxHp(): number {
     return this.getStat(Stat.HP);
   }
@@ -1664,7 +1663,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Return the ratio of this Pokémon's current HP to its maximum HP
-   * @param precise - Whether to return a precise ratio (e.g. `0.54321`), or one rounded
+   * @param precise - Whether to return the exact HP ratio (e.g. `0.54321`), or one rounded to the nearest %; default `false`
    * @returns The current HP ratio
    */
   getHpRatio(precise = false): number {
@@ -1716,7 +1715,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Get whether this Pokémon's _base_ species is shiny
-   * @param useIllusion - Whether to consider an active illusion
+   * @param useIllusion - Whether to consider an active illusion; default `false`
    * @returns Whether the pokemon is shiny
    */
   isBaseShiny(useIllusion = false) {
@@ -1725,8 +1724,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Get whether this Pokémon's _fusion_ species is shiny
-   * @param useIllusion - Whether to consider an active illusion
-   * @returns Whether the pokemon's fusion species is shiny. Always false if this is not a fusion
+   * @param useIllusion - Whether to consider an active illusion; default `true`
+   * @returns Whether this Pokémon's fusion species is shiny, or `false` if there is no fusion
    */
   isFusionShiny(useIllusion = false) {
     if (!this.isFusion(useIllusion)) {
@@ -1737,7 +1736,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Check whether this Pokemon is doubly shiny (both normal and fusion are shiny).
-   * @param useIllusion - Whether to consider an active illusion
+   * @param useIllusion - Whether to consider an active illusion; default `false`
    * @returns Whether this pokemon's base and fusion counterparts are both shiny.
    */
   isDoubleShiny(useIllusion = false): boolean {
@@ -1748,7 +1747,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * Return this Pokemon's shiny variant.
    * If a fusion, returns the maximum of the two variants.
    * Only meaningful if this pokemon is actually shiny.
-   * @param useIllusion - Whether to consider an active illusion
+   * @param useIllusion - Whether to consider an active illusion; default `false`
    * @returns The shiny variant of this Pokemon.
    */
   getVariant(useIllusion = false): Variant {
@@ -1763,7 +1762,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Return the base pokemon's variant. Equivalent to {@linkcode getVariant} if this pokemon is not a fusion.
-   * @param useIllusion - Whether to consider an active illusion
+   * @param useIllusion - Whether to consider an active illusion; default `false`
    * @returns The shiny variant of this Pokemon's base species.
    */
   getBaseVariant(useIllusion = false): Variant {
@@ -1772,7 +1771,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Return the fused Pokémon's shiny variant.
+   * Get the shiny variant of this Pokémon's _fusion_ species
    *
    * @remarks
    * Always returns `0` if the pokemon is not a fusion.
@@ -1797,7 +1796,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Return whether this {@linkcode Pokemon} is currently fused with anything.
-   * @param useIllusion - Whether to consider an active illusion
+   * @param useIllusion - Whether to consider an active illusion; default `false`
    * @returns Whether this Pokemon is currently fused with another species.
    */
   isFusion(useIllusion = false): boolean {
@@ -1806,7 +1805,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Return this {@linkcode Pokemon}'s name.
-   * @param useIllusion - Whether to consider an active illusion
+   * @param useIllusion - Whether to consider an active illusion; default `false`
    * @returns This Pokemon's name.
    * @see {@linkcode getNameToRender} - gets this Pokemon's display name.
    */
@@ -1912,8 +1911,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @param includeTeraType - Whether to use this Pokemon's tera type if Terastallized; default `false`
    * @param forDefend - Whether this Pokemon is currently receiving an attack; default `false`
    * @param ignoreOverride - Whether to ignore any overrides caused by {@linkcode MoveId.TRANSFORM | Transform}; default `false`
-   * @param useIllusion - Whether to consider an active illusion
-   * @returns An array of {@linkcode PokemonType}s corresponding to this Pokemon's typing (real or percieved).
+   * @param useIllusion - Whether to consider an active illusion; default `false`
+   * @returns An array of {@linkcode PokemonType}s corresponding to this Pokemon's typing (real or perceived).
    */
   public getTypes(
     includeTeraType = false,
@@ -2121,7 +2120,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Set the Pokémon's temporary ability, activating it if it normally activates on summon
+   * Set this Pokémon's temporary ability, activating it if it normally activates on summon
    *
    * Also clears primal weather if it is from the ability being changed
    * @param ability - The temporary ability to set
@@ -2185,12 +2184,12 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Check whether an ability of a pokemon can be currently applied.
+   * Check whether this Pokémon can apply its current ability
    *
    * @remarks
    * This should rarely be
    * directly called, as {@linkcode hasAbility} and {@linkcode hasAbilityWithAttr} already call this.
-   * @param passive - If true, check if passive can be applied instead of non-passive
+   * @param passive - Whether to check the passive (`true`) or non-passive (`false`) ability; default `false`
    * @returns Whether the ability can be applied
    */
   public canApplyAbility(passive = false): boolean {
@@ -2665,8 +2664,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Get the first evolution this Pokémon meets the conditions to evolve into
    * @remarks
-   * Fusion evolutions are also considered
-   * @returns The evolution this pokemon can currently evolve into, or null if it cannot evolve
+   * Fusion evolutions are also considered.
+   * @returns The evolution this pokemon can currently evolve into, or `null` if it cannot evolve
    */
   getEvolution(): SpeciesFormEvolution | null {
     if (pokemonEvolutions.hasOwnProperty(this.species.speciesId)) {
@@ -2860,7 +2859,6 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * Create a new {@linkcode PokemonMove} and set it to the specified move index in this Pokémon's moveset.
    * @param moveIndex - The index of the move to set
    * @param moveId - The ID of the move to set
-   * @returns
    */
   setMove(moveIndex: number, moveId: MoveId): void {
     if (moveId === MoveId.NONE) {
@@ -3034,7 +3032,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Generate a fusion species and add it to this Pokémon
-   * @param forStarter - Whether this fusion is being generated for a starter Pokemon
+   * @param forStarter - Whether this fusion is being generated for a starter Pokémon; default `false`
    */
   public generateFusionSpecies(forStarter?: boolean): void {
     const hiddenAbilityChance = new NumberHolder(BASE_HIDDEN_ABILITY_CHANCE);
@@ -3551,7 +3549,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Calculate the stat stage multiplier of the user against an opponent.
+   * Calculate the stat stage multiplier of the user against an opponent
    *
    * @remarks
    * This does not apply to evasion or accuracy
@@ -3559,10 +3557,10 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @param stat - The {@linkcode EffectiveStat} to calculate
    * @param opponent - The {@linkcode Pokemon} being targeted
    * @param move - The {@linkcode Move} being used
-   * @param ignoreOppAbility - determines whether the effects of the opponent's abilities (i.e. Unaware) should be ignored (`false` by default)
-   * @param isCritical - determines whether a critical hit has occurred or not (`false` by default)
-   * @param simulated - determines whether effects are applied without altering game state (`true` by default)
-   * @param ignoreHeldItems - determines whether this Pokemon's held items should be ignored during the stat calculation, default `false`
+   * @param ignoreOppAbility - determines whether the effects of the opponent's abilities (i.e. Unaware) should be ignored; default `false`
+   * @param isCritical - determines whether a critical hit has occurred or not; default `false`
+   * @param simulated - determines whether effects are applied without altering game state; default `true`
+   * @param ignoreHeldItems - determines whether this Pokemon's held items should be ignored during the stat calculation; default `false`
    * @returns the stat stage multiplier to be used for effective stat calculation
    */
   getStatStageMultiplier(
@@ -4148,7 +4146,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Submethod called by {@linkcode damageAndUpdate} to apply damage to this Pokemon and adjust its HP.
    * @param damage - The damage to deal
-   * @param _ignoreSegments - Whether to ignore boss segments (defaults to false)
+   * @param _ignoreSegments - Whether to ignore boss segments; default `false`
    * @param preventEndure - Whether to allow the damage to bypass an Endure/Sturdy effect
    * @param ignoreFaintPhase - Whether to ignore adding a FaintPhase if this damage causes a faint
    * @returns The actual damage dealt
@@ -4340,7 +4338,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * Also ensures the tag is able to be applied, similar to {@linkcode canAddTag}
    *
    * @param tagType - The type of tag to add
-   * @param turnCount - The number of turns the tag should last; defaults to `0`
+   * @param turnCount - The number of turns the tag should last; default `0`
    * @param sourceMove - The id of the move that causing the tag to be added, if caused by a move
    * @param sourceId - The {@linkcode Pokemon#id | id} of the pokemon causing the tag to be added, if caused by a Pokémon
    * @returns Whether the tag was successfully added
@@ -4512,7 +4510,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * Transfer stat changes and Tags from another Pokémon
    *
    * @remarks
-   * Used to implement Baton Pass and switching via the Baton item
+   * Used to implement Baton Pass and switching via the Baton item.
    *
    * @param source - The pokemon whose stats/Tags are to be passed on from, ie: the Pokemon using Baton Pass
    */
@@ -4546,7 +4544,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Get whether the given move is currently disabled for this Pokemon.
+   * Get whether the given move is currently disabled for this Pokémon
    *
    * @param moveId - The ID of the move to check
    * @returns `true` if the move is disabled for this Pokemon, otherwise `false`
@@ -4610,7 +4608,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Add a new entry to this Pokemon's move history
    * @remarks
-   * Does nothing if this Pokemon is not currently on the field
+   * Does nothing if this Pokemon is not currently on the field.
    * @param turnMove - The move to add to the history
    */
   public pushMoveHistory(turnMove: TurnMove): void {
@@ -4677,7 +4675,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * Change this Pokémon's form to the specified form, loading the required
    * assets and updating its stats and info display.
    * @param formChange - The form to change to
-   * @returns A promise that resolves once the form change has completed
+   * @returns A Promise that resolves once the form change has completed.
    */
   public async changeForm(formChange: SpeciesFormChange): Promise<void> {
     return new Promise(resolve => {
@@ -4705,7 +4703,6 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * Play this Pokémon's cry sound
    * @param soundConfig - Optional sound configuration to apply to the cry
    * @param sceneOverride - Optional scene to use instead of the global scene
-   * @returns
    */
   public cry(soundConfig?: Phaser.Types.Sound.SoundConfig, sceneOverride?: BattleScene): AnySound | null {
     const scene = sceneOverride ?? globalScene; // TODO: is `sceneOverride` needed?
@@ -5267,9 +5264,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Reset this Pokémon's status
-   * @param revive - Whether revive should be cured; default `true`.
-   * @param confusion - Whether resetStatus should include confusion or not; default `false`
-   * @param reloadAssets - Whether to reload the assets or not; default `false`.
+   * @param revive - Whether revive should be cured; default `true`
+   * @param confusion - Whether to also cure confusion; default `false`
+   * @param reloadAssets - Whether to reload the assets or not; default `false`
    * @param asPhase - Whether to reset the status in a phase or immediately; default `true`
    */
   resetStatus(revive = true, confusion = false, reloadAssets = false, asPhase = true): void {
@@ -5395,13 +5392,13 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Reset this Pokémon's terastallization state
+   * Reset this Pokémon's Terastallization state
    *
    * @remarks
    * Responsible for all of the cleanup required when a pokemon goes from being
    * terastallized to no longer terastallized:
    * - Resetting stellar type boosts
-   * - Upadting the Pokémon's terastallization-dependent form
+   * - Updating the Pokémon's terastallization-dependent form
    * - Adjusting the sprite pipeline to remove the Tera effect
    */
   resetTera(): void {
@@ -5847,7 +5844,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * or it directly calls {@linkcode randSeedInt randSeedInt}({@linkcode range}, {@linkcode min}) in `src/utils.ts` if there is no current battle
    *
    * @param range - How large of a range of random numbers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
-   * @param min - The minimum integer to pick, default `0`
+   * @param min - The minimum integer to pick; default `0`
    * @returns A random integer between {@linkcode min} and ({@linkcode min} + {@linkcode range} - 1)
    */
   randBattleSeedInt(range: number, min = 0): number {
@@ -5898,7 +5895,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    *
    * ### Custom Behavior
    * In addition to the base `destroy` behavior, this also destroys the Pokemon's
-   * {@linkcode battleInfo}, if it exists, and its substitute, if it exists.
+   * {@linkcode battleInfo} and substitute sprite (as applicable).
    */
   destroy(): void {
     this.battleInfo?.destroy();

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -141,6 +141,7 @@ import type { PokemonData } from "#system/pokemon-data";
 import { RibbonData } from "#system/ribbons/ribbon-data";
 import { awardRibbonsToSpeciesLine } from "#system/ribbons/ribbon-methods";
 import type { AbAttrMap, AbAttrString, TypeMultiplierAbAttrParams } from "#types/ability-types";
+import type { getAttackDamageParams, getBaseDamageParams } from "#types/damage-params";
 import type { DamageCalculationResult, DamageResult } from "#types/damage-result";
 import type { IllusionData } from "#types/illusion-data";
 import type { StarterDataEntry, StarterMoveset } from "#types/save-data";
@@ -175,36 +176,6 @@ import { argbFromRgba, QuantizerCelebi, rgbaFromArgb } from "@material/material-
 import i18next from "i18next";
 import Phaser from "phaser";
 import SoundFade from "phaser3-rex-plugins/plugins/soundfade";
-
-/** Base typeclass for damage parameter methods, used for DRY */
-type damageParams = {
-  /** The attacking {@linkcode Pokemon} */
-  source: Pokemon;
-  /** The move used in the attack */
-  move: Move;
-  /** The move's {@linkcode MoveCategory} after variable-category effects are applied */
-  moveCategory: MoveCategory;
-  /** If `true`, ignores this Pokemon's defensive ability effects */
-  ignoreAbility?: boolean;
-  /** If `true`, ignores the attacking Pokemon's ability effects */
-  ignoreSourceAbility?: boolean;
-  /** If `true`, ignores the ally Pokemon's ability effects */
-  ignoreAllyAbility?: boolean;
-  /** If `true`, ignores the ability effects of the attacking pokemon's ally */
-  ignoreSourceAllyAbility?: boolean;
-  /** If `true`, calculates damage for a critical hit */
-  isCritical?: boolean;
-  /** If `true`, suppresses changes to game state during the calculation */
-  simulated?: boolean;
-  /** If defined, used in place of calculated effectiveness values */
-  effectiveness?: number;
-};
-
-/** Type for the parameters of {@linkcode Pokemon#getBaseDamage | getBaseDamage} */
-type getBaseDamageParams = Omit<damageParams, "effectiveness">;
-
-/** Type for the parameters of {@linkcode Pokemon#getAttackDamage | getAttackDamage} */
-type getAttackDamageParams = Omit<damageParams, "moveCategory">;
 
 export abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
@@ -242,20 +213,46 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @todo Make private
    */
   public status: Status | null;
+  /**
+   * The Pokémon's current friendship value, ranging from 0 to 255.
+   * @see {@link https://bulbapedia.bulbagarden.net/wiki/Friendship}
+   */
   public friendship: number;
+  /**
+   * The level at which this Pokémon was met
+   * @remarks
+   * Primarily used for displaying in the summary screen
+   */
   public metLevel: number;
+  /**
+   * The ID of the biome this Pokémon was met in
+   * @remarks
+   * Primarily used for displaying in the summary screen
+   */
   public metBiome: BiomeId | -1;
+  // TODO: figure out why this used and document it (seems only to be read for getting the Pokémon's egg moves)
   public metSpecies: SpeciesId;
+  /** The wave index at which this Pokémon was met/encountered */
   public metWave: number;
   public luck: number;
   public pauseEvolutions: boolean;
   public pokerus: boolean;
+  /**
+   * Indicates whether this Pokémon has left or is about to leave the field
+   * @remarks
+   * When `true` on a Wild Pokemon, this indicates it is about to flee.
+   */
   public switchOutStatus = false;
   public evoCounter: number;
+  /** The type this Pokémon turns into when Terastallized  */
   public teraType: PokemonType;
+  /** Whether this Pokémon is currently Terastallized */
   public isTerastallized: boolean;
+  /** The set of Types that have been boosted by this Pokémon's Stellar terastallization */
   public stellarTypesBoosted: PokemonType[];
 
+  // TODO: Create a fusionData class / interface and move all fusion-related fields there, exposed via getters
+  /** If this Pokémon is a fusion, the species it is fused with; `null` if not a fusion */
   public fusionSpecies: PokemonSpecies | null;
   public fusionFormIndex: number;
   public fusionAbilityIndex: number;
@@ -287,11 +284,18 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /** Used by Mystery Encounters to execute pokemon-specific logic (such as stat boosts) at start of battle */
   public mysteryEncounterBattleEffects?: (pokemon: Pokemon) => void;
 
+  /** The position of the pokemon on the field */
   public fieldPosition: FieldPosition;
 
   public maskEnabled: boolean;
   public maskSprite: Phaser.GameObjects.Sprite | null;
 
+  /**
+   * The set of all TMs that have been used on this Pokémon
+   *
+   * @remarks
+   * Used to allow re-learning TM moves via, e.g., the Memory Mushroom
+   */
   public usedTMs: MoveId[];
 
   private shinySparkle: Phaser.GameObjects.Sprite;
@@ -516,7 +520,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   abstract initBattleInfo(): void;
 
-  isOnField(): boolean {
+  public isOnField(): boolean {
     if (!globalScene) {
       return false;
     }
@@ -568,7 +572,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return this.isAllowedInBattle() && (!onField || this.isOnField());
   }
 
-  getDexAttr(): bigint {
+  public getDexAttr(): bigint {
     let ret = 0n;
     if (this.gender !== Gender.GENDERLESS) {
       ret |= this.gender !== Gender.FEMALE ? DexAttr.MALE : DexAttr.FEMALE;
@@ -582,9 +586,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Sets the Pokemon's name. Only called when loading a Pokemon so this function needs to be called when
    * initializing hardcoded Pokemon or else it will not display the form index name properly.
-   * @returns n/a
    */
-  generateName(): void {
+  public generateName(): void {
     if (!this.fusionSpecies) {
       this.name = this.species.getName(this.formIndex);
       return;
@@ -838,11 +841,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * Gracefully handle errors loading a variant sprite. Log if it fails and attempt to fall back on
    * non-experimental sprites before giving up.
    *
-   * @param cacheKey the cache key for the variant color sprite
-   * @param attemptedSpritePath the sprite path that failed to load
-   * @param useExpSprite was the attempted sprite experimental
-   * @param battleSpritePath the filename of the sprite
-   * @param optionalParams any additional params to log
+   * @param cacheKey - the cache key for the variant color sprite
+   * @param attemptedSpritePath - the sprite path that failed to load
+   * @param useExpSprite - was the attempted sprite experimental
+   * @param battleSpritePath - the filename of the sprite
+   * @param optionalParams - any additional params to log
    */
   async fallbackVariantColor(
     cacheKey: string,
@@ -908,6 +911,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return this.fusionSpecies.forms[this.fusionFormIndex].formKey;
   }
 
+  //#region Atlas and sprite ID methods
   // TODO: Add more documentation for all these attributes.
   // They may be all similar, but what each one actually _does_ is quite unclear at first glance
 
@@ -1036,6 +1040,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       fusionVariant,
     );
   }
+  //#endregion Atlas and sprite ID methods
 
   /**
    * Return this Pokemon's {@linkcode PokemonSpeciesForm | SpeciesForm}.
@@ -1065,7 +1070,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * (such as by the effects of {@linkcode MoveId.TRANSFORM} or {@linkcode AbilityId.IMPOSTER}.
    * @returns Whether this Pokemon is currently transformed.
    */
-  isTransformed(): boolean {
+  public isTransformed(): boolean {
     return this.summonData.speciesForm !== null;
   }
 
@@ -1074,7 +1079,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @param target - The {@linkcode Pokemon} being transformed into
    * @returns Whether this Pokemon can transform into `target`.
    */
-  canTransformInto(target: Pokemon): boolean {
+  public canTransformInto(target: Pokemon): boolean {
     return !(
       // Neither pokemon can be already transformed
       (
@@ -1095,7 +1100,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @param useIllusion - Whether to consider the species of this Pokemon's illusion; default `false`
    * @returns The {@linkcode PokemonSpeciesForm} of this Pokemon's fusion counterpart.
    */
-  getFusionSpeciesForm(ignoreOverride = false, useIllusion = false): PokemonSpeciesForm {
+  public getFusionSpeciesForm(ignoreOverride = false, useIllusion = false): PokemonSpeciesForm {
     const fusionSpecies: PokemonSpecies =
       useIllusion && this.summonData.illusion ? this.summonData.illusion.fusionSpecies! : this.fusionSpecies!;
     const fusionFormIndex =
@@ -1140,7 +1145,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /** Resets the pokemon's field sprite properties, including position, alpha, and scale */
-  resetSprite(): void {
+  public resetSprite(): void {
     // Resetting properties should not be shown on the field
     this.setVisible(false);
 
@@ -1191,9 +1196,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Attempts to animate a given {@linkcode Phaser.GameObjects.Sprite}
    * @see {@linkcode Phaser.GameObjects.Sprite.play}
-   * @param sprite {@linkcode Phaser.GameObjects.Sprite} to animate
-   * @param tintSprite {@linkcode Phaser.GameObjects.Sprite} placed on top of the sprite to add a color tint
-   * @param animConfig {@linkcode String} to pass to {@linkcode Phaser.GameObjects.Sprite.play}
+   * @param sprite - Sprite to animate
+   * @param tintSprite - Sprite placed on top of the sprite to add a color tint
+   * @param animConfig - string to pass to the sprite's {@linkcode Phaser.GameObjects.Sprite.play | play} method
    * @returns true if the sprite was able to be animated
    */
   tryPlaySprite(sprite: Phaser.GameObjects.Sprite, tintSprite: Phaser.GameObjects.Sprite, key: string): boolean {
@@ -1258,7 +1263,13 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }
   }
 
-  setFieldPosition(fieldPosition: FieldPosition, duration?: number): Promise<void> {
+  /**
+   * Set the field position of this Pokémon
+   * @param fieldPosition - The new field position
+   * @param duration - How long the transition should take, in milliseconds; if `0` or `undefined`, the position is changed instantly
+   * @returns
+   */
+  public setFieldPosition(fieldPosition: FieldPosition, duration?: number): Promise<void> {
     return new Promise(resolve => {
       if (fieldPosition === this.fieldPosition) {
         resolve();
@@ -1608,10 +1619,12 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return baseStats;
   }
 
+  // TOOD: Convert t his into a getter
   getNature(): Nature {
     return this.customPokemonData.nature !== -1 ? this.customPokemonData.nature : this.nature;
   }
 
+  // TODO: Convert this into a setter OR just add a listener for calculateStats...
   setNature(nature: Nature): void {
     this.nature = nature;
     this.calculateStats();
@@ -1622,7 +1635,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     this.calculateStats();
   }
 
-  generateNature(naturePool?: Nature[]): void {
+  /**
+   * Randomly generate and set this Pokémon's nature
+   * @param naturePool - An optional array of Natures to choose from. If not provided, all natures will be considered.
+   */
+  private generateNature(naturePool?: Nature[]): void {
     if (naturePool === undefined) {
       naturePool = getEnumValues(Nature);
     }
@@ -1630,10 +1647,12 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     this.setNature(nature);
   }
 
+  // TODO: Convert this into a getter
   isFullHp(): boolean {
     return this.hp >= this.getMaxHp();
   }
 
+  // TODO: Conver this into a getter
   getMaxHp(): number {
     return this.getStat(Stat.HP);
   }
@@ -1643,6 +1662,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return this.getMaxHp() - this.hp;
   }
 
+  /**
+   * Return the ratio of this Pokémon's current HP to its maximum HP
+   * @param precise - Whether to return a precise ratio (e.g. `0.54321`), or one rounded
+   * @returns The current HP ratio
+   */
   getHpRatio(precise = false): number {
     return precise ? this.hp / this.getMaxHp() : Math.round((this.hp / this.getMaxHp()) * 100) / 100;
   }
@@ -1680,18 +1704,30 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Check whether this Pokemon is shiny.
-   * @param useIllusion - Whether to consider this pokemon's illusion if present; default `false`
+   * Check whether this Pokémon is shiny, including its fusion species
+   *
+   * @param useIllusion - Whether to consider an active illusion
    * @returns Whether this Pokemon is shiny
+   * @see {@linkcode isBaseShiny}
    */
   isShiny(useIllusion = false): boolean {
     return this.isBaseShiny(useIllusion) || this.isFusionShiny(useIllusion);
   }
 
+  /**
+   * Get whether this Pokémon's _base_ species is shiny
+   * @param useIllusion - Whether to consider an active illusion
+   * @returns Whether the pokemon is shiny
+   */
   isBaseShiny(useIllusion = false) {
     return useIllusion ? (this.summonData.illusion?.shiny ?? this.shiny) : this.shiny;
   }
 
+  /**
+   * Get whether this Pokémon's _fusion_ species is shiny
+   * @param useIllusion - Whether to consider an active illusion
+   * @returns Whether the pokemon's fusion species is shiny. Always false if this is not a fusion
+   */
   isFusionShiny(useIllusion = false) {
     if (!this.isFusion(useIllusion)) {
       return false;
@@ -1701,7 +1737,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Check whether this Pokemon is doubly shiny (both normal and fusion are shiny).
-   * @param useIllusion - Whether to consider this pokemon's illusion if present; default `false`
+   * @param useIllusion - Whether to consider an active illusion
    * @returns Whether this pokemon's base and fusion counterparts are both shiny.
    */
   isDoubleShiny(useIllusion = false): boolean {
@@ -1709,10 +1745,10 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Return this Pokemon's {@linkcode Variant | shiny variant}.
+   * Return this Pokemon's shiny variant.
    * If a fusion, returns the maximum of the two variants.
    * Only meaningful if this pokemon is actually shiny.
-   * @param useIllusion - Whether to consider this pokemon's illusion if present; default `false`
+   * @param useIllusion - Whether to consider an active illusion
    * @returns The shiny variant of this Pokemon.
    */
   getVariant(useIllusion = false): Variant {
@@ -1727,6 +1763,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Return the base pokemon's variant. Equivalent to {@linkcode getVariant} if this pokemon is not a fusion.
+   * @param useIllusion - Whether to consider an active illusion
    * @returns The shiny variant of this Pokemon's base species.
    */
   getBaseVariant(useIllusion = false): Variant {
@@ -1735,10 +1772,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Return the fused pokemon's variant.
+   * Return the fused Pokémon's shiny variant.
    *
    * @remarks
    * Always returns `0` if the pokemon is not a fusion.
+   * @param useIllusion - Whether to consider an active illusion
    * @returns The shiny variant of this pokemon's fusion species.
    */
   getFusionVariant(useIllusion = false): Variant {
@@ -1759,7 +1797,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Return whether this {@linkcode Pokemon} is currently fused with anything.
-   * @param useIllusion - Whether to consider this pokemon's illusion if present; default `false`
+   * @param useIllusion - Whether to consider an active illusion
    * @returns Whether this Pokemon is currently fused with another species.
    */
   isFusion(useIllusion = false): boolean {
@@ -1768,7 +1806,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Return this {@linkcode Pokemon}'s name.
-   * @param useIllusion - Whether to consider this pokemon's illusion if present; default `false`
+   * @param useIllusion - Whether to consider an active illusion
    * @returns This Pokemon's name.
    * @see {@linkcode getNameToRender} - gets this Pokemon's display name.
    */
@@ -1874,7 +1912,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @param includeTeraType - Whether to use this Pokemon's tera type if Terastallized; default `false`
    * @param forDefend - Whether this Pokemon is currently receiving an attack; default `false`
    * @param ignoreOverride - Whether to ignore any overrides caused by {@linkcode MoveId.TRANSFORM | Transform}; default `false`
-   * @param useIllusion - Whether to consider this Pokemon's illusion if present; default `false`
+   * @param useIllusion - Whether to consider an active illusion
    * @returns An array of {@linkcode PokemonType}s corresponding to this Pokemon's typing (real or percieved).
    */
   public getTypes(
@@ -2083,10 +2121,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Sets the {@linkcode Pokemon}'s ability and activates it if it normally activates on summon
+   * Set the Pokémon's temporary ability, activating it if it normally activates on summon
    *
    * Also clears primal weather if it is from the ability being changed
-   * @param ability New Ability
+   * @param ability - The temporary ability to set
+   * @param passive - Whether to set the passive ability instead of the non-passive one; default `false`
    */
   public setTempAbility(ability: Ability, passive = false): void {
     applyOnLoseAbAttrs({ pokemon: this, passive });
@@ -2146,11 +2185,13 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Checks whether an ability of a pokemon can be currently applied. This should rarely be
+   * Check whether an ability of a pokemon can be currently applied.
+   *
+   * @remarks
+   * This should rarely be
    * directly called, as {@linkcode hasAbility} and {@linkcode hasAbilityWithAttr} already call this.
-   * @see {@linkcode hasAbility} {@linkcode hasAbilityWithAttr} Intended ways to check abilities in most cases
-   * @param passive If true, check if passive can be applied instead of non-passive
-   * @returns `true` if the ability can be applied
+   * @param passive - If true, check if passive can be applied instead of non-passive
+   * @returns Whether the ability can be applied
    */
   public canApplyAbility(passive = false): boolean {
     if (passive && !this.hasPassive()) {
@@ -2365,14 +2406,14 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Calculates the effectiveness of a move against the Pokémon.
-   * This includes modifiers from move and ability attributes.
-   * @param source {@linkcode Pokemon} The attacking Pokémon.
-   * @param move {@linkcode Move} The move being used by the attacking Pokémon.
-   * @param ignoreAbility Whether to ignore abilities that might affect type effectiveness or immunity (defaults to `false`).
-   * @param simulated Whether to apply abilities via simulated calls (defaults to `true`)
-   * @param cancelled {@linkcode BooleanHolder} Stores whether the move was cancelled by a non-type-based immunity.
-   * @param useIllusion - Whether we want the attack move effectiveness on the illusion or not
+   * Calculate the effectiveness of the move against this Pokémon, including
+   * modifiers from move and ability attributes
+   * @param source - The attacking Pokémon.
+   * @param move - The move being used by the attacking Pokémon.
+   * @param ignoreAbility - Whether to ignore abilities that might affect type effectiveness or immunity (defaults to `false`).
+   * @param simulated - Whether to apply abilities via simulated calls (defaults to `true`)
+   * @param cancelled - Stores whether the move was cancelled by a non-type-based immunity.
+   * @param useIllusion - Whether to consider an active illusion
    * @returns The type damage multiplier, indicating the effectiveness of the move
    */
   getMoveEffectiveness(
@@ -2458,14 +2499,14 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Calculates the move's type effectiveness multiplier based on the target's type/s.
-   * @param moveType {@linkcode PokemonType} the type of the move being used
-   * @param source {@linkcode Pokemon} the Pokemon using the move
-   * @param ignoreStrongWinds whether or not this ignores strong winds (anticipation, forewarn, stealth rocks)
-   * @param simulated tag to only apply the strong winds effect message when the move is used
-   * @param move (optional) the move whose type effectiveness is to be checked. Used for applying {@linkcode VariableMoveTypeChartAttr}
-   * @param useIllusion - Whether we want the attack type effectiveness on the illusion or not
-   * @returns a multiplier for the type effectiveness
+   * Calculate the move's type effectiveness multiplier when based on this Pokémon's type(s)
+   * @param moveType - The type of the move being used
+   * @param source - The Pokemon using the move
+   * @param ignoreStrongWinds - Whether or not this ignores strong winds (anticipation, forewarn, stealth rocks)
+   * @param simulated - Whether to suppress changes to game state and prevent showing messages during this calculation
+   * @param move - The move whose type effectiveness is to be checked. Used for applying {@linkcode VariableMoveTypeChartAttr}
+   * @param useIllusion - Whether to consider an active illusion
+   * @returns A multiplier for the type effectiveness
    */
   getAttackTypeEffectiveness(
     moveType: PokemonType,
@@ -2540,10 +2581,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Computes the given Pokemon's matchup score against this Pokemon.
+   * Compute the given Pokémon's matchup score against this Pokémon
+   * @remarks
    * In most cases, this score ranges from near-zero to 16, but the maximum possible matchup score is 64.
-   * @param opponent {@linkcode Pokemon} The Pokemon to compare this Pokemon against
-   * @returns A score value based on how favorable this Pokemon is when fighting the given Pokemon
+   * @param opponent - The Pokemon to compare this Pokémon against
+   * @returns A score value based on how favorable this Pokémon is when fighting the given Pokémon
    */
   getMatchupScore(opponent: Pokemon): number {
     const enemyTypes = opponent.getTypes(true, false, false, true);
@@ -2620,6 +2662,12 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return (atkScore + defScore) * Math.min(hpDiffRatio, 1);
   }
 
+  /**
+   * Get the first evolution this Pokémon meets the conditions to evolve into
+   * @remarks
+   * Fusion evolutions are also considered
+   * @returns The evolution this pokemon can currently evolve into, or null if it cannot evolve
+   */
   getEvolution(): SpeciesFormEvolution | null {
     if (pokemonEvolutions.hasOwnProperty(this.species.speciesId)) {
       const evolutions = pokemonEvolutions[this.species.speciesId];
@@ -2645,11 +2693,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Gets all level up moves in a given range for a particular pokemon.
-   * @param startingLevel Don't include moves below this level
-   * @param includeEvolutionMoves Whether to include evolution moves
-   * @param simulateEvolutionChain Whether to include moves from prior evolutions
-   * @param includeRelearnerMoves Whether to include moves that would require a relearner. Note the move relearner inherently allows evolution moves
+   * Get all level up moves in a given range for a particular pokemon.
+   * @param startingLevel - Don't include moves below this level
+   * @param includeEvolutionMoves - Whether to include evolution moves
+   * @param simulateEvolutionChain - Whether to include moves from prior evolutions
+   * @param includeRelearnerMoves - Whether to include moves that would require a relearner. Note the move relearner inherently allows evolution moves
    * @returns A list of moves and the levels they can be learned at
    */
   getLevelMoves(
@@ -2781,12 +2829,14 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Helper function for getLevelMoves.
+   * Helper function for getLevelMoves
+   *
+   * @remarks
    * Finds all non-duplicate items from the input, and pushes them into the output.
    * Two items count as duplicate if they have the same Move, regardless of level.
    *
-   * @param levelMoves the input array to search for non-duplicates from
-   * @param ret the output array to be pushed into.
+   * @param levelMoves - The input array to search for non-duplicates from
+   * @param ret - The output array to be pushed into.
    */
   private getUniqueMoves(levelMoves: LevelMoves, ret: LevelMoves): void {
     const uniqueMoves: MoveId[] = [];
@@ -2800,13 +2850,18 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Get a list of all egg moves
-   *
    * @returns list of egg moves
    */
   getEggMoves(): MoveId[] | undefined {
     return speciesEggMoves[this.getSpeciesForm().getRootSpeciesId()];
   }
 
+  /**
+   * Create a new {@linkcode PokemonMove} and set it to the specified move index in this Pokémon's moveset.
+   * @param moveIndex - The index of the move to set
+   * @param moveId - The ID of the move to set
+   * @returns
+   */
   setMove(moveIndex: number, moveId: MoveId): void {
     if (moveId === MoveId.NONE) {
       return;
@@ -2819,14 +2874,16 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Function that tries to set a Pokemon shiny based on the trainer's trainer ID and secret ID.
+   * Attempt to set the Pokémon's shininess based on the trainer's trainer ID and secret ID.
    * Endless Pokemon in the end biome are unable to be set to shiny
+   *
+   * @remarks
    *
    * The exact mechanic is that it calculates E as the XOR of the player's trainer ID and secret ID.
    * F is calculated as the XOR of the first 16 bits of the Pokemon's ID with the last 16 bits.
    * The XOR of E and F are then compared to the {@linkcode shinyThreshold} (or {@linkcode thresholdOverride} if set) to see whether or not to generate a shiny.
    * The base shiny odds are {@linkcode BASE_SHINY_CHANCE} / 65536
-   * @param thresholdOverride number that is divided by 2^16 (65536) to get the shiny chance, overrides {@linkcode shinyThreshold} if set (bypassing shiny rate modifiers such as Shiny Charm)
+   * @param thresholdOverride - number that is divided by 2^16 (65536) to get the shiny chance, overrides {@linkcode shinyThreshold} if set (bypassing shiny rate modifiers such as Shiny Charm)
    * @returns true if the Pokemon has been set as a shiny, false otherwise
    */
   trySetShiny(thresholdOverride?: number): boolean {
@@ -2867,14 +2924,16 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Function that tries to set a Pokemon shiny based on seed.
+   * Tries to set a Pokémon's shininess based on seed
+   *
+   * @remarks
    * For manual use only, usually to roll a Pokemon's shiny chance a second time.
    * If it rolls shiny, or if it's already shiny, also sets a random variant and give the Pokemon the associated luck.
    *
    * The base shiny odds are {@linkcode BASE_SHINY_CHANCE} / `65536`
-   * @param thresholdOverride number that is divided by `2^16` (`65536`) to get the shiny chance, overrides {@linkcode shinyThreshold} if set (bypassing shiny rate modifiers such as Shiny Charm)
-   * @param applyModifiersToOverride If {@linkcode thresholdOverride} is set and this is true, will apply Shiny Charm and event modifiers to {@linkcode thresholdOverride}
-   * @returns `true` if the Pokemon has been set as a shiny, `false` otherwise
+   * @param thresholdOverride - number that is divided by `2^16` (`65536`) to get the shiny chance, overrides {@linkcode shinyThreshold} if set (bypassing shiny rate modifiers such as Shiny Charm)
+   * @param applyModifiersToOverride - If {@linkcode thresholdOverride} is set and this is true, will apply Shiny Charm and event modifiers to {@linkcode thresholdOverride}
+   * @returns Whether this Pokémon was set to shiny
    */
   public trySetShinySeed(thresholdOverride?: number, applyModifiersToOverride?: boolean): boolean {
     if (!this.shiny) {
@@ -2900,11 +2959,18 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Generates a shiny variant
-   * @returns `0-2`, with the following probabilities:
-   * - Has a 10% chance of returning `2` (epic variant)
-   * - Has a 30% chance of returning `1` (rare variant)
-   * - Has a 60% chance of returning `0` (basic shiny)
+   * Randomly generate a shiny variant
+   *
+   * @remarks
+   * Variants are returned with the following probabilities:
+   *
+   * | Variant | Description    | Probability |
+   * |---------|----------------|-------------|
+   * | 0       | Basic shiny    | 60%         |
+   * | 1       | Rare variant   | 30%         |
+   * | 2       | Epic variant   | 10%         |
+   *
+   * @returns The randomly chosen shiny variant
    */
   protected generateShinyVariant(): Variant {
     const formIndex: number = this.formIndex;
@@ -2940,12 +3006,14 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Function that tries to set a Pokemon to have its hidden ability based on seed, if it exists.
+   * Function that tries to set this Pokemon to have its hidden ability based on seed, if it exists.
+   *
+   * @remarks
    * For manual use only, usually to roll a Pokemon's hidden ability chance a second time.
    *
    * The base hidden ability odds are {@linkcode BASE_HIDDEN_ABILITY_CHANCE} / `65536`
-   * @param thresholdOverride number that is divided by `2^16` (`65536`) to get the HA chance, overrides {@linkcode haThreshold} if set (bypassing HA rate modifiers such as Ability Charm)
-   * @param applyModifiersToOverride If {@linkcode thresholdOverride} is set and this is true, will apply Ability Charm to {@linkcode thresholdOverride}
+   * @param thresholdOverride - number that is divided by `2^16` (`65536`) to get the HA chance, overrides {@linkcode haThreshold} if set (bypassing HA rate modifiers such as Ability Charm)
+   * @param applyModifiersToOverride - If {@linkcode thresholdOverride} is set and this is true, will apply Ability Charm to {@linkcode thresholdOverride}
    * @returns `true` if the Pokemon has been set to have its hidden ability, `false` otherwise
    */
   public tryRerollHiddenAbilitySeed(thresholdOverride?: number, applyModifiersToOverride?: boolean): boolean {
@@ -2964,6 +3032,10 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return this.abilityIndex === 2;
   }
 
+  /**
+   * Generate a fusion species and add it to this Pokémon
+   * @param forStarter - Whether this fusion is being generated for a starter Pokemon
+   */
   public generateFusionSpecies(forStarter?: boolean): void {
     const hiddenAbilityChance = new NumberHolder(BASE_HIDDEN_ABILITY_CHANCE);
     if (!this.hasTrainer()) {
@@ -3030,6 +3102,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     this.generateName();
   }
 
+  /** Remove the fusion species from this Pokémon */
   public clearFusionSpecies(): void {
     this.fusionSpecies = null;
     this.fusionFormIndex = 0;
@@ -3044,7 +3117,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     this.calculateStats();
   }
 
-  /** Generates a semi-random moveset for a Pokemon */
+  /** Generate a semi-random moveset for this Pokémon */
   public generateAndPopulateMoveset(): void {
     this.moveset = [];
     let movePool: [MoveId, number][] = [];
@@ -3350,6 +3423,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return move?.isUsable(this, ignorePp) ?? false;
   }
 
+  /** Show this Pokémon's info panel */
   showInfo(): void {
     if (!this.battleInfo.visible) {
       const otherBattleInfo = globalScene.fieldUI
@@ -3378,7 +3452,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }
   }
 
-  hideInfo(): Promise<void> {
+  /** Hide this Pokémon's info panel */
+  async hideInfo(): Promise<void> {
     return new Promise(resolve => {
       if (this.battleInfo?.visible) {
         globalScene.tweens.add({
@@ -3402,14 +3477,6 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     });
   }
 
-  /**
-   * sets if the pokemon is switching out (if it's a enemy wild implies it's going to flee)
-   * @param status - boolean
-   */
-  setSwitchOutStatus(status: boolean): void {
-    this.switchOutStatus = status;
-  }
-
   updateInfo(instant?: boolean): Promise<void> {
     return this.battleInfo.updateInfo(this, instant);
   }
@@ -3420,8 +3487,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Adds experience to this PlayerPokemon, subject to wave based level caps.
-   * @param exp The amount of experience to add
-   * @param ignoreLevelCap Whether to ignore level caps when adding experience (defaults to false)
+   * @param exp - The amount of experience to add
+   * @param ignoreLevelCap - Whether to ignore level caps when adding experience (defaults to false)
    */
   addExp(exp: number, ignoreLevelCap = false) {
     const maxExpLevel = globalScene.getMaxExpLevel(ignoreLevelCap);
@@ -3439,7 +3506,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Compares if `this` and {@linkcode target} are on the same team.
-   * @param target the {@linkcode Pokemon} to compare against.
+   * @param target - The {@linkcode Pokemon} to compare against.
    * @returns `true` if the two pokemon are allies, `false` otherwise
    */
   public isOpponent(target: Pokemon): boolean {
@@ -3484,17 +3551,18 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Calculates the stat stage multiplier of the user against an opponent.
+   * Calculate the stat stage multiplier of the user against an opponent.
    *
-   * Note that this does not apply to evasion or accuracy
+   * @remarks
+   * This does not apply to evasion or accuracy
    * @see {@linkcode getAccuracyMultiplier}
    * @param stat - The {@linkcode EffectiveStat} to calculate
    * @param opponent - The {@linkcode Pokemon} being targeted
    * @param move - The {@linkcode Move} being used
-   * @param ignoreOppAbility  determines whether the effects of the opponent's abilities (i.e. Unaware) should be ignored (`false` by default)
-   * @param isCritical determines whether a critical hit has occurred or not (`false` by default)
-   * @param simulated determines whether effects are applied without altering game state (`true` by default)
-   * @param ignoreHeldItems determines whether this Pokemon's held items should be ignored during the stat calculation, default `false`
+   * @param ignoreOppAbility - determines whether the effects of the opponent's abilities (i.e. Unaware) should be ignored (`false` by default)
+   * @param isCritical - determines whether a critical hit has occurred or not (`false` by default)
+   * @param simulated - determines whether effects are applied without altering game state (`true` by default)
+   * @param ignoreHeldItems - determines whether this Pokemon's held items should be ignored during the stat calculation, default `false`
    * @returns the stat stage multiplier to be used for effective stat calculation
    */
   getStatStageMultiplier(
@@ -3631,15 +3699,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Calculates the base damage of the given move against this Pokemon when attacked by the given source.
    * Used during damage calculation and for Shell Side Arm's forecasting effect.
-   * @param source - The attacking {@linkcode Pokemon}.
-   * @param move - The {@linkcode Move} used in the attack.
-   * @param moveCategory - The move's {@linkcode MoveCategory} after variable-category effects are applied.
-   * @param ignoreAbility - If `true`, ignores this Pokemon's defensive ability effects (defaults to `false`).
-   * @param ignoreSourceAbility - If `true`, ignore's the attacking Pokemon's ability effects (defaults to `false`).
-   * @param ignoreAllyAbility - If `true`, ignores the ally Pokemon's ability effects (defaults to `false`).
-   * @param ignoreSourceAllyAbility - If `true`, ignores the attacking Pokemon's ally's ability effects (defaults to `false`).
-   * @param isCritical - if `true`, calculates effective stats as if the hit were critical (defaults to `false`).
-   * @param simulated - if `true`, suppresses changes to game state during calculation (defaults to `true`).
+   * @param __namedParameters.source - Needed for proper typedoc rendering
    * @returns The move's base damage against this Pokemon when used by the source Pokemon.
    */
   getBaseDamage({
@@ -3757,15 +3817,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Calculates the damage of an attack made by another Pokemon against this Pokemon
-   * @param source {@linkcode Pokemon} the attacking Pokemon
-   * @param move The {@linkcode Move} used in the attack
-   * @param ignoreAbility If `true`, ignores this Pokemon's defensive ability effects
-   * @param ignoreSourceAbility If `true`, ignores the attacking Pokemon's ability effects
-   * @param ignoreAllyAbility If `true`, ignores the ally Pokemon's ability effects
-   * @param ignoreSourceAllyAbility If `true`, ignores the ability effects of the attacking pokemon's ally
-   * @param isCritical If `true`, calculates damage for a critical hit.
-   * @param simulated If `true`, suppresses changes to game state during the calculation.
-   * @param effectiveness If defined, used in place of calculated effectiveness values
+   * @param __namedParameters.source - Needed for proper typedoc rendering
    * @returns The {@linkcode DamageCalculationResult}
    */
   getAttackDamage({
@@ -4094,12 +4146,12 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Called by damageAndUpdate()
-   * @param damage integer
-   * @param ignoreSegments boolean, not currently used
-   * @param preventEndure used to update damage if endure or sturdy
-   * @param ignoreFaintPhase  flag on whether to add FaintPhase if pokemon after applying damage faints
-   * @returns integer representing damage dealt
+   * Submethod called by {@linkcode damageAndUpdate} to apply damage to this Pokemon and adjust its HP.
+   * @param damage - The damage to deal
+   * @param _ignoreSegments - Whether to ignore boss segments (defaults to false)
+   * @param preventEndure - Whether to allow the damage to bypass an Endure/Sturdy effect
+   * @param ignoreFaintPhase - Whether to ignore adding a FaintPhase if this damage causes a faint
+   * @returns The actual damage dealt
    */
   damage(damage: number, _ignoreSegments = false, preventEndure = false, ignoreFaintPhase = false): number {
     if (this.isFainted()) {
@@ -4145,14 +4197,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Given the damage, adds a new DamagePhase and update HP values, etc.
    *
-   * Checks for 'Indirect' HitResults to account for Endure/Reviver Seed applying correctly
-   * @param damage integer - passed to damage()
-   * @param result an enum if it's super effective, not very, etc.
-   * @param isCritical boolean if move is a critical hit
-   * @param ignoreSegments boolean, passed to damage() and not used currently
-   * @param preventEndure boolean, ignore endure properties of pokemon, passed to damage()
-   * @param ignoreFaintPhase boolean to ignore adding a FaintPhase, passsed to damage()
-   * @returns integer of damage done
+   * @remarks
+   * Checks for {@linkcode HitResult.INDIRECT | Indirect} hits to account for Endure/Reviver Seed applying correctly
+   * @param damage - The damage to inflict on this Pokémon
+   * @param __namedParameters.source - Needed for proper typedoc rendering
+   * @returns Amount of damage actually done
    */
   damageAndUpdate(
     damage: number,
@@ -4163,10 +4212,17 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       ignoreFaintPhase = false,
       source,
     }: {
+      /**
+       * An enum if it's super effective, not very effective, etc; default {@linkcode HitResult.EFFECTIVE}
+       */
       result?: DamageResult;
+      /** Whether the attack was a critical hit */
       isCritical?: boolean;
+      /** Whether to ignore boss segments */
       ignoreSegments?: boolean;
+      /** Whether to ignore adding a FaintPhase if this damage causes a faint; default `false` */
       ignoreFaintPhase?: boolean;
+      /** The Pokémon inflicting the damage, or undefined if not caused by a Pokémon */
       source?: Pokemon;
     } = {},
   ): number {
@@ -4200,17 +4256,25 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return damage;
   }
 
-  heal(amount: number): number {
+  /**
+   * Restore a specific amount of HP to this Pokémon
+   * @param amount - The amount of HP to restore
+   * @returns The true amount of HP restored; may be less than `amount` if `amount` would overheal
+   */
+  public heal(amount: number): number {
     const healAmount = Math.min(amount, this.getMaxHp() - this.hp);
     this.hp += healAmount;
     return healAmount;
   }
 
-  isBossImmune(): boolean {
+  public isBossImmune(): boolean {
     return this.isBoss();
   }
 
-  isMax(): boolean {
+  /**
+   * @returns Whether this Pokémon is in a Dynamax or Gigantamax form
+   */
+  public isMax(): boolean {
     const maxForms = [
       SpeciesFormKey.GIGANTAMAX,
       SpeciesFormKey.GIGANTAMAX_RAPID,
@@ -4222,7 +4286,10 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     );
   }
 
-  isMega(): boolean {
+  /**
+   * @returns Whether this Pokémon is in a Mega or Primal form
+   */
+  public isMega(): boolean {
     const megaForms = [
       SpeciesFormKey.MEGA,
       SpeciesFormKey.MEGA_X,
@@ -4235,7 +4302,14 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     );
   }
 
-  canAddTag(tagType: BattlerTagType): boolean {
+  /**
+   * Check whether a battler tag can be added to this Pokémon
+   *
+   * @param tagType - The tag to check
+   * @returns - Whether the tag can be added
+   * @see {@linkcode addTag}
+   */
+  public canAddTag(tagType: BattlerTagType): boolean {
     if (this.getTag(tagType)) {
       return false;
     }
@@ -4259,7 +4333,20 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return !cancelled.value;
   }
 
-  addTag(tagType: BattlerTagType, turnCount = 0, sourceMove?: MoveId, sourceId?: number): boolean {
+  /**
+   * Add a new {@linkcode BattlerTag} of the specified `tagType`
+   *
+   * @remarks
+   * Also ensures the tag is able to be applied, similar to {@linkcode canAddTag}
+   *
+   * @param tagType - The type of tag to add
+   * @param turnCount - The number of turns the tag should last; defaults to `0`
+   * @param sourceMove - The id of the move that causing the tag to be added, if caused by a move
+   * @param sourceId - The {@linkcode Pokemon#id | id} of the pokemon causing the tag to be added, if caused by a Pokémon
+   * @returns Whether the tag was successfully added
+   * @see {@linkcode canAddTag}
+   */
+  public addTag(tagType: BattlerTagType, turnCount = 0, sourceMove?: MoveId, sourceId?: number): boolean {
     const existingTag = this.getTag(tagType);
     if (existingTag) {
       existingTag.onOverlap(this);
@@ -4268,6 +4355,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     const newTag = getBattlerTag(tagType, turnCount, sourceMove!, sourceId!); // TODO: are the bangs correct?
 
+    // TODO: Just call canAddTag() here? Can possibly overload it to accept an actual tag instead of just a type
     const cancelled = new BooleanHolder(false);
     applyAbAttrs("BattlerTagImmunityAbAttr", { pokemon: this, tag: newTag, cancelled });
     if (cancelled.value) {
@@ -4290,31 +4378,46 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return false;
   }
 
-  getTag(tagType: BattlerTagType.GRUDGE): GrudgeTag | undefined;
-  getTag(tagType: BattlerTagType.SUBSTITUTE): SubstituteTag | undefined;
-  getTag(tagType: BattlerTagType): BattlerTag | undefined;
-  getTag<T extends BattlerTag>(tagType: Constructor<T>): T | undefined;
-  getTag(tagType: BattlerTagType | Constructor<BattlerTag>): BattlerTag | undefined {
+  // TODO: Utilize a type map for these so we can avoid overloads
+  public getTag(tagType: BattlerTagType.GRUDGE): GrudgeTag | undefined;
+  public getTag(tagType: BattlerTagType.SUBSTITUTE): SubstituteTag | undefined;
+  public getTag(tagType: BattlerTagType): BattlerTag | undefined;
+  public getTag<T extends BattlerTag>(tagType: Constructor<T>): T | undefined;
+  public getTag(tagType: BattlerTagType | Constructor<BattlerTag>): BattlerTag | undefined {
     return typeof tagType === "function"
       ? this.summonData.tags.find(t => t instanceof tagType)
       : this.summonData.tags.find(t => t.tagType === tagType);
   }
 
-  findTag(tagFilter: (tag: BattlerTag) => boolean) {
-    return this.summonData.tags.find(t => tagFilter(t));
+  /**
+   * Find the first `BattlerTag` matching the specified predicate
+   * @remarks
+   * Equivalent to `this.summonData.tags.find(tagFilter)`.
+   * @param tagFilter - The predicate to match against
+   * @returns The first matching tag, or `undefined` if none match
+   */
+  public findTag(tagFilter: (tag: BattlerTag) => boolean) {
+    return this.summonData.tags.find(tagFilter);
   }
 
-  findTags(tagFilter: (tag: BattlerTag) => boolean): BattlerTag[] {
-    return this.summonData.tags.filter(t => tagFilter(t));
+  /**
+   * Return the list of `BattlerTag`s that satisfy the given predicate
+   * @remarks
+   * Equivalent to `this.summonData.tags.filter(tagFilter)`.
+   * @param tagFilter - The predicate to match against
+   * @returns The filtered list of tags
+   */
+  public findTags(tagFilter: (tag: BattlerTag) => boolean): BattlerTag[] {
+    return this.summonData.tags.filter(tagFilter);
   }
 
   /**
    * Tick down the first {@linkcode BattlerTag} found matching the given {@linkcode BattlerTagType},
    * removing it if its duration goes below 0.
-   * @param tagType the {@linkcode BattlerTagType} to check against
-   * @returns `true` if the tag was present
+   * @param tagType - The `BattlerTagType` to lapse
+   * @returns Whether the tag was present
    */
-  lapseTag(tagType: BattlerTagType): boolean {
+  public lapseTag(tagType: BattlerTagType): boolean {
     const tags = this.summonData.tags;
     const tag = tags.find(t => t.tagType === tagType);
     if (!tag) {
@@ -4329,11 +4432,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Tick down all {@linkcode BattlerTags} matching the given {@linkcode BattlerTagLapseType},
-   * removing any whose durations fall below 0.
-   * @param tagType the {@linkcode BattlerTagLapseType} to tick down
+   * Tick down all {@linkcode BattlerTags} that lapse on the provided
+   * `lapseType`, removing any whose durations fall below 0.
+   * @param lapseType - The type of lapse to process
    */
-  lapseTags(lapseType: BattlerTagLapseType): void {
+  public lapseTags(lapseType: BattlerTagLapseType): void {
     const tags = this.summonData.tags;
     tags
       .filter(
@@ -4348,10 +4451,14 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Remove the first tag matching the given {@linkcode BattlerTagType}.
-   * @param tagType the {@linkcode BattlerTagType} to search for and remove
+   * Remove the first tag matching `tagType` and invoke its
+   * {@linkcode BattlerTag#onRemove | onRemove} method.
+   * @remarks
+   * Only removes the first matching tag, if multiple are present; to remove all
+   * matching tags, use {@linkcode findAndRemoveTags} instead.
+   * @param tagType - The tag type to search for and remove
    */
-  removeTag(tagType: BattlerTagType): void {
+  public removeTag(tagType: BattlerTagType): void {
     const tags = this.summonData.tags;
     const tag = tags.find(t => t.tagType === tagType);
     if (tag) {
@@ -4361,10 +4468,14 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Find and remove all {@linkcode BattlerTag}s matching the given function.
-   * @param tagFilter a function dictating which tags to remove
+   * Find and remove all {@linkcode BattlerTag}s matching the given function and
+   * invoke their {@linkcode BattlerTag#onRemove | onRemove} methods.
+   * @remarks
+   * Removes all matching tags; to remove only the first matching tag, use
+   * {@linkcode removeTag} instead.
+   * @param tagFilter - A function dictating which tags to remove
    */
-  findAndRemoveTags(tagFilter: (tag: BattlerTag) => boolean): void {
+  public findAndRemoveTags(tagFilter: (tag: BattlerTag) => boolean): void {
     const tags = this.summonData.tags;
     const tagsToRemove = tags.filter(t => tagFilter(t));
     for (const tag of tagsToRemove) {
@@ -4374,11 +4485,22 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }
   }
 
-  removeTagsBySourceId(sourceId: number): void {
+  /**
+   * Remove all tags that were applied by a Pokémon with the given `sourceId`,
+   * invoking their {@linkcode BattlerTag#onRemove | onRemove} methods.
+   * @param sourceId - Tags with this {@linkcode Pokemon#id | id} as their {@linkcode BattlerTag#sourceId | sourceId} will be removed
+   * @see {@linkcode findAndRemoveTags}
+   */
+  public removeTagsBySourceId(sourceId: number): void {
     this.findAndRemoveTags(t => t.isSourceLinked() && t.sourceId === sourceId);
   }
 
-  transferTagsBySourceId(sourceId: number, newSourceId: number): void {
+  /**
+   * Change the `sourceId` of all tags on this Pokémon with the given `sourceId` to `newSourceId`.
+   * @param sourceId - The {@linkcode Pokemon#id | id} of the pokemon whose tags are to be transferred
+   * @param newSourceId - The {@linkcode Pokemon#id | id} of the pokemon to which the tags are being transferred
+   */
+  public transferTagsBySourceId(sourceId: number, newSourceId: number): void {
     this.summonData.tags.forEach(t => {
       if (t.sourceId === sourceId) {
         t.sourceId = newSourceId;
@@ -4387,11 +4509,14 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Transferring stat changes and Tags
-   * @param source {@linkcode Pokemon} the pokemon whose stats/Tags are to be passed on from, ie: the Pokemon using Baton Pass
+   * Transfer stat changes and Tags from another Pokémon
+   *
+   * @remarks
+   * Used to implement Baton Pass and switching via the Baton item
+   *
+   * @param source - The pokemon whose stats/Tags are to be passed on from, ie: the Pokemon using Baton Pass
    */
-  transferSummon(source: Pokemon): void {
-    // Copy all stat stages
+  public transferSummon(source: Pokemon): void {
     for (const s of BATTLE_STATS) {
       const sourceStage = source.getStatStage(s);
       if (this.isPlayer() && sourceStage === 6) {
@@ -4421,9 +4546,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Gets whether the given move is currently disabled for this Pokemon.
+   * Get whether the given move is currently disabled for this Pokemon.
    *
-   * @param moveId - The {@linkcode MoveId} ID of the move to check
+   * @param moveId - The ID of the move to check
    * @returns `true` if the move is disabled for this Pokemon, otherwise `false`
    *
    * @see {@linkcode MoveRestrictionBattlerTag}
@@ -4433,9 +4558,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Gets whether the given move is currently disabled for the user based on the player's target selection
+   * Get whether the given move is currently disabled for the user based on the player's target selection
    *
-   * @param moveId - The {@linkcode MoveId} ID of the move to check
+   * @param moveId - The ID of the move to check
    * @param user - The move user
    * @param target - The target of the move
    *
@@ -4453,11 +4578,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Gets the {@link MoveRestrictionBattlerTag} that is restricting a move, if it exists.
+   * Get the {@link MoveRestrictionBattlerTag} that is restricting a move, if it exists.
    *
-   * @param moveId - {@linkcode MoveId} ID of the move to check
-   * @param user - {@linkcode Pokemon} the move user, optional and used when the target is a factor in the move's restricted status
-   * @param target - {@linkcode Pokemon} the target of the move, optional and used when the target is a factor in the move's restricted status
+   * @param moveId - The ID of the move to check
+   * @param user - The move user, optional and used when the target is a factor in the move's restricted status
+   * @param target - The target of the move; optional, and used when the target is a factor in the move's restricted status
    * @returns The first tag on this Pokemon that restricts the move, or `null` if the move is not restricted.
    */
   getRestrictingTag(moveId: MoveId, user?: Pokemon, target?: Pokemon): MoveRestrictionBattlerTag | null {
@@ -4482,6 +4607,12 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return this.summonData.moveHistory;
   }
 
+  /**
+   * Add a new entry to this Pokemon's move history
+   * @remarks
+   * Does nothing if this Pokemon is not currently on the field
+   * @param turnMove - The move to add to the history
+   */
   public pushMoveHistory(turnMove: TurnMove): void {
     if (!this.isOnField()) {
       return;
@@ -4499,7 +4630,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @returns An array of {@linkcode TurnMove}, as specified above.
    */
   // TODO: Update documentation in dancer PR to mention "getLastNonVirtualMove"
-  getLastXMoves(moveCount = 1): TurnMove[] {
+  public getLastXMoves(moveCount = 1): TurnMove[] {
     const moveHistory = this.getMoveHistory();
     if (moveCount > 0) {
       return moveHistory.slice(Math.max(moveHistory.length - moveCount, 0)).reverse();
@@ -4517,7 +4648,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @returns The last move this Pokemon has used satisfying the aforementioned conditions,
    * or `undefined` if no applicable moves have been used since switching in.
    */
-  getLastNonVirtualMove(ignoreStruggle = false, ignoreFollowUp = true): TurnMove | undefined {
+  public getLastNonVirtualMove(ignoreStruggle = false, ignoreFollowUp = true): TurnMove | undefined {
     return this.getLastXMoves(-1).find(
       m =>
         m.move !== MoveId.NONE
@@ -4530,7 +4661,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * Return this Pokemon's move queue, consisting of all the moves it is slated to perform.
    * @returns An array of {@linkcode TurnMove}, as described above
    */
-  getMoveQueue(): TurnMove[] {
+  public getMoveQueue(): TurnMove[] {
     return this.summonData.moveQueue;
   }
 
@@ -4538,11 +4669,17 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * Add a new entry to the end of this Pokemon's move queue.
    * @param queuedMove - A {@linkcode TurnMove} to push to this Pokemon's queue.
    */
-  pushMoveQueue(queuedMove: TurnMove): void {
+  public pushMoveQueue(queuedMove: TurnMove): void {
     this.summonData.moveQueue.push(queuedMove);
   }
 
-  changeForm(formChange: SpeciesFormChange): Promise<void> {
+  /**
+   * Change this Pokémon's form to the specified form, loading the required
+   * assets and updating its stats and info display.
+   * @param formChange - The form to change to
+   * @returns A promise that resolves once the form change has completed
+   */
+  public async changeForm(formChange: SpeciesFormChange): Promise<void> {
     return new Promise(resolve => {
       this.formIndex = Math.max(
         this.species.forms.findIndex(f => f.formKey === formChange.formKey),
@@ -4564,7 +4701,13 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     });
   }
 
-  cry(soundConfig?: Phaser.Types.Sound.SoundConfig, sceneOverride?: BattleScene): AnySound | null {
+  /**
+   * Play this Pokémon's cry sound
+   * @param soundConfig - Optional sound configuration to apply to the cry
+   * @param sceneOverride - Optional scene to use instead of the global scene
+   * @returns
+   */
+  public cry(soundConfig?: Phaser.Types.Sound.SoundConfig, sceneOverride?: BattleScene): AnySound | null {
     const scene = sceneOverride ?? globalScene; // TODO: is `sceneOverride` needed?
     const cry = this.getSpeciesForm(undefined, true).cry(soundConfig);
     if (!cry) {
@@ -4603,8 +4746,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return cry;
   }
 
-  // biome-ignore lint: there are a ton of issues..
-  faintCry(callback: Function): void {
+  /**
+   * Play this Pokémon's faint cry, pausing its animation until the cry is finished.
+   * @param callback - A function to be called once the cry has finished playing
+   */
+  public faintCry(callback: () => any): void {
     if (this.fusionSpecies && this.getSpeciesForm() !== this.getFusionSpeciesForm()) {
       this.fusionFaintCry(callback);
       return;
@@ -4676,8 +4822,12 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     });
   }
 
-  // biome-ignore lint/complexity/noBannedTypes: Consider refactoring to change type of Function
-  private fusionFaintCry(callback: Function): void {
+  /**
+   * Play this Pokémon's fusion faint cry, which is a mixture of the faint cries
+   * for both of its species
+   * @param callback - A function to be called once the cry has finished playing
+   */
+  private fusionFaintCry(callback: () => any): void {
     const key = this.species.getCryKey(this.formIndex);
     let i = 0;
     let rate = 0.85;
@@ -4787,7 +4937,12 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     });
   }
 
-  isOppositeGender(pokemon: Pokemon): boolean {
+  /**
+   * Check the specified pokemon is considered to be the opposite gender as this pokemon
+   * @param pokemon - The Pokémon to compare against
+   * @returns Whether the pokemon are considered to be opposite genders
+   */
+  public isOppositeGender(pokemon: Pokemon): boolean {
     return (
       this.gender !== Gender.GENDERLESS
       && pokemon.gender === (this.gender === Gender.MALE ? Gender.FEMALE : Gender.MALE)
@@ -4797,12 +4952,12 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Display an immunity message for a failed status application.
    * @param quiet - Whether to suppress message and return early
-   * @param reason - The reason for the status application failure -
+   * @param reason - The reason for the status application failure;
    * can be "overlap" (already has same status), "other" (generic fail message)
    * or a {@linkcode TerrainType} for terrain-based blockages.
    * Default `"other"`
    */
-  queueStatusImmuneMessage(
+  public queueStatusImmuneMessage(
     quiet: boolean,
     reason: "overlap" | "other" | Exclude<TerrainType, TerrainType.NONE> = "other",
   ): void {
@@ -5029,7 +5184,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    *
    * ⚠️ This method does **not** check for feasibility; that is the responsibility of the caller.
    */
-  doSetStatus(effect: Exclude<StatusEffect, StatusEffect.SLEEP>): void;
+  public doSetStatus(effect: Exclude<StatusEffect, StatusEffect.SLEEP>): void;
   /**
    * Set this Pokemon's {@linkcode status | non-volatile status condition} to the specified effect.
    * @param effect - {@linkcode StatusEffect.SLEEP}
@@ -5039,7 +5194,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    *
    * ⚠️ This method does **not** check for feasibility; that is the responsibility of the caller.
    */
-  doSetStatus(effect: StatusEffect.SLEEP, sleepTurnsRemaining?: number): void;
+  public doSetStatus(effect: StatusEffect.SLEEP, sleepTurnsRemaining?: number): void;
   /**
    * Set this Pokemon's {@linkcode status | non-volatile status condition} to the specified effect.
    * @param effect - The {@linkcode StatusEffect} to set
@@ -5050,7 +5205,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    *
    * ⚠️ This method does **not** check for feasibility; that is the responsibility of the caller.
    */
-  doSetStatus(effect: StatusEffect, sleepTurnsRemaining?: number): void;
+  public doSetStatus(effect: StatusEffect, sleepTurnsRemaining?: number): void;
   /**
    * Set this Pokemon's {@linkcode status | non-volatile status condition} to the specified effect.
    * @param effect - The {@linkcode StatusEffect} to set
@@ -5062,7 +5217,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * ⚠️ This method does **not** check for feasibility; that is the responsibility of the caller.
    * @todo Make this and all related fields private and change tests to use a field-based helper or similar
    */
-  doSetStatus(
+  public doSetStatus(
     effect: StatusEffect,
     sleepTurnsRemaining = effect !== StatusEffect.SLEEP ? 0 : this.randBattleSeedIntRange(2, 4),
   ): void {
@@ -5111,11 +5266,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Resets the status of a pokemon.
-   * @param revive Whether revive should be cured; defaults to true.
-   * @param confusion Whether resetStatus should include confusion or not; defaults to false.
-   * @param reloadAssets Whether to reload the assets or not; defaults to false.
-   * @param asPhase Whether to reset the status in a phase or immediately
+   * Reset this Pokémon's status
+   * @param revive - Whether revive should be cured; default `true`.
+   * @param confusion - Whether resetStatus should include confusion or not; default `false`
+   * @param reloadAssets - Whether to reload the assets or not; default `false`.
+   * @param asPhase - Whether to reset the status in a phase or immediately; default `true`
    */
   resetStatus(revive = true, confusion = false, reloadAssets = false, asPhase = true): void {
     const lastStatus = this.status?.effect;
@@ -5131,9 +5286,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Performs the action of clearing a Pokemon's status
-   *
+   * Perform the action of clearing a Pokemon's status
+   * @remarks
    * This is a helper to {@linkcode resetStatus}, which should be called directly instead of this method
+   * @param confusion - Whether to also clear this Pokémon's confusion
+   * @param reloadAssets - Whether to reload this pokemon's assets
    */
   public clearStatus(confusion: boolean, reloadAssets: boolean) {
     const lastStatus = this.status?.effect;
@@ -5152,11 +5309,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Checks if this Pokemon is protected by Safeguard
-   * @param attacker the {@linkcode Pokemon} inflicting status on this Pokemon
-   * @returns `true` if this Pokemon is protected by Safeguard; `false` otherwise.
+   * Check if this Pokémon is protected by Safeguard
+   * @param attacker - The Pokémon responsible for the interaction that needs to check against Safeguard
+   * @returns Whether this Pokémon is protected by Safeguard
    */
-  isSafeguarded(attacker: Pokemon): boolean {
+  public isSafeguarded(attacker: Pokemon): boolean {
     const defendingSide = this.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY;
     if (globalScene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, defendingSide)) {
       const bypassed = new BooleanHolder(false);
@@ -5169,11 +5326,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Performs miscellaneous setup for when the Pokemon is summoned, like generating the substitute sprite
+   * Perform miscellaneous setup for when the Pokemon is summoned, like generating the substitute sprite
    * @param resetSummonData - Whether to additionally reset the Pokemon's summon data (default: `false`)
    */
   public fieldSetup(resetSummonData?: boolean): void {
-    this.setSwitchOutStatus(false);
+    this.switchOutStatus = false;
     if (globalScene) {
       globalScene.triggerPokemonFormChange(this, SpeciesFormChangePostMoveTrigger, true);
     }
@@ -5201,7 +5358,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * Reset this Pokemon's {@linkcode PokemonSummonData | SummonData} and {@linkcode PokemonTempSummonData | TempSummonData}
    * in preparation for switching pokemon, as well as removing any relevant on-switch tags.
    */
-  resetSummonData(): void {
+  public resetSummonData(): void {
     const illusion: IllusionData | null = this.summonData.illusion;
     if (this.summonData.speciesForm) {
       this.summonData.speciesForm = null;
@@ -5214,17 +5371,21 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Reset a {@linkcode Pokemon}'s per-battle {@linkcode PokemonBattleData | battleData},
+   * Reset this Pokémon's per-battle {@linkcode PokemonBattleData | battleData}
    * as well as any transient {@linkcode PokemonWaveData | waveData} for the current wave.
+   *
+   * @remarks
    * Should be called once per arena transition (new biome/trainer battle/Mystery Encounter).
    */
-  resetBattleAndWaveData(): void {
+  public resetBattleAndWaveData(): void {
     this.battleData = new PokemonBattleData();
     this.resetWaveData();
   }
 
   /**
-   * Reset a {@linkcode Pokemon}'s {@linkcode PokemonWaveData | waveData}.
+   * Reset this Pokémon's {@linkcode PokemonWaveData | waveData}
+   *
+   * @remarks
    * Should be called upon starting a new wave in addition to whenever an arena transition occurs.
    * @see {@linkcode resetBattleAndWaveData}
    */
@@ -5233,6 +5394,16 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     this.tempSummonData.waveTurnCount = 1;
   }
 
+  /**
+   * Reset this Pokémon's terastallization state
+   *
+   * @remarks
+   * Responsible for all of the cleanup required when a pokemon goes from being
+   * terastallized to no longer terastallized:
+   * - Resetting stellar type boosts
+   * - Upadting the Pokémon's terastallization-dependent form
+   * - Adjusting the sprite pipeline to remove the Tera effect
+   */
   resetTera(): void {
     const wasTerastallized = this.isTerastallized;
     this.isTerastallized = false;
@@ -5243,6 +5414,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }
   }
 
+  /**
+   * Clear this Pokémon's transient turn data
+   */
   resetTurnData(): void {
     this.turnData = new PokemonTurnData();
   }
@@ -5252,6 +5426,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return (this.getSpeciesForm().getBaseExp() * this.level) / 5 + 1;
   }
 
+  //#region Sprite and Animation Methods
   setFrameRate(frameRate: number) {
     globalScene.anims.get(this.getBattleSpriteKey()).frameRate = frameRate;
     try {
@@ -5328,6 +5503,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }
   }
 
+  /** Play the shiny sparkle animation and effects, if applicable */
   sparkle(): void {
     if (this.shinySparkle) {
       doShinySparkleAnim(this.shinySparkle, this.variant);
@@ -5659,15 +5835,19 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     fusionCanvas.remove();
   }
 
+  //#endregion Sprite and Animation Methods
+
   /**
-   * Generates a random number using the current battle's seed, or the global seed if `globalScene.currentBattle` is falsy
+   * Generate a random number using the current battle's seed, or the global seed if `globalScene.currentBattle` is falsy
+   *
+   * @remarks
    * This calls either {@linkcode BattleScene.randBattleSeedInt}({@linkcode range}, {@linkcode min}) in `src/battle-scene.ts`
    * which calls {@linkcode Battle.randSeedInt}({@linkcode range}, {@linkcode min}) in `src/battle.ts`
    * which calls {@linkcode randSeedInt randSeedInt}({@linkcode range}, {@linkcode min}) in `src/utils.ts`,
    * or it directly calls {@linkcode randSeedInt randSeedInt}({@linkcode range}, {@linkcode min}) in `src/utils.ts` if there is no current battle
    *
-   * @param range How large of a range of random numbers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
-   * @param min The minimum integer to pick, default `0`
+   * @param range - How large of a range of random numbers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
+   * @param min - The minimum integer to pick, default `0`
    * @returns A random integer between {@linkcode min} and ({@linkcode min} + {@linkcode range} - 1)
    */
   randBattleSeedInt(range: number, min = 0): number {
@@ -5675,10 +5855,10 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Generates a random number using the current battle's seed, or the global seed if `globalScene.currentBattle` is falsy
-   * @param min The minimum integer to generate
-   * @param max The maximum integer to generate
-   * @returns a random integer between {@linkcode min} and {@linkcode max} inclusive
+   * Generate a random number using the current battle's seed, or the global seed if `globalScene.currentBattle` is falsy
+   * @param min - The minimum integer to generate
+   * @param max - The maximum integer to generate
+   * @returns A random integer between {@linkcode min} and {@linkcode max} (inclusive)
    */
   randBattleSeedIntRange(min: number, max: number): number {
     return globalScene.currentBattle ? globalScene.randBattleSeedInt(max - min + 1, min) : randSeedIntRange(min, max);
@@ -5686,9 +5866,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Causes a Pokemon to leave the field (such as in preparation for a switch out/escape).
-   * @param clearEffects Indicates if effects should be cleared (true) or passed
-   * to the next pokemon, such as during a baton pass (false)
-   * @param hideInfo Indicates if this should also play the animation to hide the Pokemon's
+   * @param clearEffects - Indicates if effects should be cleared (true) or passed
+   *    to the next pokemon, such as during a baton pass (false)
+   * @param hideInfo - Indicates if this should also play the animation to hide the Pokemon's
    * info container.
    */
   leaveField(clearEffects = true, hideInfo = true, destroy = false) {
@@ -5708,25 +5888,33 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }
     // Trigger abilities that activate upon leaving the field
     applyAbAttrs("PreLeaveFieldAbAttr", { pokemon: this });
-    this.setSwitchOutStatus(true);
+    this.switchOutStatus = true;
     globalScene.triggerPokemonFormChange(this, SpeciesFormChangeActiveTrigger, true);
     globalScene.field.remove(this, destroy);
   }
 
+  /**
+   * @inheritdoc {@linkcode Phaser.GameObjects.Container#destroy}
+   *
+   * ### Custom Behavior
+   * In addition to the base `destroy` behavior, this also destroys the Pokemon's
+   * {@linkcode battleInfo}, if it exists, and its substitute, if it exists.
+   */
   destroy(): void {
     this.battleInfo?.destroy();
     this.destroySubstitute();
     super.destroy();
   }
 
+  // TODO: Turn this into a getter
   getBattleInfo(): BattleInfo {
     return this.battleInfo;
   }
 
   /**
-   * Checks whether or not the Pokemon's root form has the same ability
-   * @param abilityIndex the given ability index we are checking
-   * @returns true if the abilities are the same
+   * Check whether or not this Pokémon's root form has the same ability
+   * @param abilityIndex - The ability index to check
+   * @returns Whether the Pokemon's root form has the same ability
    */
   hasSameAbilityInRootForm(abilityIndex: number): boolean {
     const currentAbilityIndex = this.abilityIndex;
@@ -5735,9 +5923,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Helper function to check if the player already owns the starter data of the Pokemon's
+   * Helper function to check if the player already owns the starter data of this Pokémon's
    * current ability
-   * @param ownedAbilityAttrs the owned abilityAttr of this Pokemon's root form
+   * @param ownedAbilityAttrs - The owned abilityAttr of this Pokemon's root form
    * @returns true if the player already has it, false otherwise
    */
   checkIfPlayerHasAbilityOfStarter(ownedAbilityAttrs: number): boolean {
@@ -5778,8 +5966,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Record a berry being eaten for ability and move triggers.
    * Only tracks things that proc _every_ time a berry is eaten.
-   * @param berryType The type of berry being eaten.
-   * @param updateHarvest Whether to track the berry for harvest; default `true`.
+   * @param berryType - The type of berry being eaten.
+   * @param updateHarvest - Whether to track the berry for harvest; default `true`.
    */
   public recordEatenBerry(berryType: BerryType, updateHarvest = true) {
     this.battleData.hasEatenBerry = true;
@@ -5790,6 +5978,14 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     this.turnData.berriesEaten.push(berryType);
   }
 
+  /**
+   * Get the number of persistent treasure items this Pokemon has
+   * @remarks
+   * Persistent treasure items are defined as held items that give money
+   * after battle, such as the Lucky Egg or the Amulet Coin.
+   * Used exclusively for Gimmighoul's evolution condition
+   * @returns The number of persistent treasure items this Pokémon has
+   */
   getPersistentTreasureCount(): number {
     return (
       this.getHeldItems().filter(m => m.is("DamageMoneyRewardModifier")).length
@@ -5920,10 +6116,10 @@ export class PlayerPokemon extends Pokemon {
   }
 
   /**
-   * Causes this mon to leave the field (via {@linkcode leaveField}) and then
-   * opens the party switcher UI to switch a new mon in
-   * @param switchType the {@linkcode SwitchType} for this switch-out. If this is
-   * `BATON_PASS` or `SHED_TAIL`, this Pokemon's effects are not cleared upon leaving
+   * Cause this Pokémon to leave the field (via {@linkcode leaveField}) and then
+   * open the party switcher UI to switch in a new Pokémon
+   * @param switchType - The type of this switch-out. If this is
+   * `BATON_PASS` or `SHED_TAIL`, this Pokémon's effects are not cleared upon leaving
    * the field.
    */
   switchOut(switchType: SwitchType = SwitchType.SWITCH): Promise<void> {
@@ -6257,8 +6453,8 @@ export class PlayerPokemon extends Pokemon {
   }
 
   /**
-   * Returns a Promise to fuse two PlayerPokemon together
-   * @param pokemon The PlayerPokemon to fuse to this one
+   * Fuse another PlayerPokemon into this one
+   * @param pokemon - The PlayerPokemon to fuse to this one
    */
   fuse(pokemon: PlayerPokemon): void {
     this.fusionSpecies = pokemon.species;
@@ -6749,7 +6945,7 @@ export class EnemyPokemon extends Pokemon {
 
   /**
    * Determines the Pokemon the given move would target if used by this Pokemon
-   * @param moveId {@linkcode MoveId} The move to be used
+   * @param moveId - The move to be used
    * @returns The indexes of the Pokemon the given move would target
    */
   getNextTargets(moveId: MoveId): BattlerIndex[] {
@@ -6862,7 +7058,11 @@ export class EnemyPokemon extends Pokemon {
     return 0;
   }
 
-  damage(damage: number, ignoreSegments = false, preventEndure = false, ignoreFaintPhase = false): number {
+  /**
+   * @inheritdoc
+   * @param ignoreSegments - Whether to ignore boss segments when applying damage
+   */
+  public damage(damage: number, ignoreSegments = false, preventEndure = false, ignoreFaintPhase = false): number {
     if (this.isFainted()) {
       return 0;
     }
@@ -6918,7 +7118,7 @@ export class EnemyPokemon extends Pokemon {
     return ret;
   }
 
-  canBypassBossSegments(segmentCount = 1): boolean {
+  private canBypassBossSegments(segmentCount = 1): boolean {
     if (
       globalScene.currentBattle.battleSpec === BattleSpec.FINAL_BOSS
       && !this.formIndex
@@ -6932,10 +7132,12 @@ export class EnemyPokemon extends Pokemon {
 
   /**
    * Go through a boss' health segments and give stats boosts for each newly cleared segment
+   *
+   * @remarks
    * The base boost is 1 to a random stat that's not already maxed out per broken shield
    * For Pokemon with 3 health segments or more, breaking the last shield gives +2 instead
    * For Pokemon with 5 health segments or more, breaking the last two shields give +2 each
-   * @param segmentIndex index of the segment to get down to (0 = no shield left, 1 = 1 shield left, etc.)
+   * @param segmentIndex - index of the segment to get down to (0 = no shield left, 1 = 1 shield left, etc.)
    */
   handleBossSegmentCleared(segmentIndex: number): void {
     while (this.bossSegmentIndex > 0 && segmentIndex - 1 < this.bossSegmentIndex) {
@@ -6990,22 +7192,22 @@ export class EnemyPokemon extends Pokemon {
     }
   }
 
-  getFieldIndex(): number {
+  public getFieldIndex(): number {
     return globalScene.getEnemyField().indexOf(this);
   }
 
-  getBattlerIndex(): BattlerIndex {
+  public getBattlerIndex(): BattlerIndex {
     return BattlerIndex.ENEMY + this.getFieldIndex();
   }
 
   /**
    * Add a new pokemon to the player's party (at `slotIndex` if set).
    * The new pokemon's visibility will be set to `false`.
-   * @param pokeballType the type of pokeball the pokemon was caught with
-   * @param slotIndex an optional index to place the pokemon in the party
-   * @returns the pokemon that was added or null if the pokemon could not be added
+   * @param pokeballType - The type of pokeball the pokemon was caught with
+   * @param slotIndex - An optional index to place the pokemon in the party
+   * @returns The pokemon that was added or null if the pokemon could not be added
    */
-  addToParty(pokeballType: PokeballType, slotIndex = -1) {
+  public addToParty(pokeballType: PokeballType, slotIndex = -1) {
     const party = globalScene.getPlayerParty();
     let ret: PlayerPokemon | null = null;
 
@@ -7048,11 +7250,11 @@ export class EnemyPokemon extends Pokemon {
    * Show or hide the type effectiveness multiplier window
    * Passing undefined will hide the window
    */
-  updateEffectiveness(effectiveness?: string) {
+  public updateEffectiveness(effectiveness?: string) {
     this.battleInfo.updateEffectiveness(effectiveness);
   }
 
-  toggleFlyout(visible: boolean): void {
+  public toggleFlyout(visible: boolean): void {
     this.battleInfo.toggleFlyout(visible);
   }
 }


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Cleanup docs for consistency

## What are the changes from a developer perspective?
- Fixed up documentation to use the hyphen required by tsdoc
- Added missing doc to many methods/parameters
- Added `public` and `private` visibility specifiers to many mehtods
- Moved some types into the `@types` folder.

## Screenshots/Videos

<details><summary>Showcase of docs appearing on destructured parameters</summary>
<img width="600" height="1017" alt="image" src="https://github.com/user-attachments/assets/1e687595-185b-456e-9525-e632d8759ce8" />
</details> 



## How to test the changes?
`pnpm typedoc`, then open up the docs for pokemon in `typedoc/classes/src_field_pokemon.Pokemon.html`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - ~~[ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~