### PR TITLE
[Balance] Change Happiny's evolution method

### DIFF
--- a/src/data/balance/pokemon-evolutions.ts
+++ b/src/data/balance/pokemon-evolutions.ts
@@ -53,6 +53,7 @@ export enum EvolutionItem {
   PRISM_SCALE,
   RAZOR_CLAW,
   RAZOR_FANG,
+  OVAL_STONE,
   REAPER_CLOTH,
   ELECTIRIZER,
   MAGMARIZER,
@@ -1496,10 +1497,13 @@ export const pokemonEvolutions: PokemonEvolutions = {
     new SpeciesFormEvolution(SpeciesId.DUDUNSPARCE, "", "two-segment", 32, null, {key: EvoCondKey.MOVE, move: MoveId.HYPER_DRILL}, SpeciesWildEvolutionDelay.LONG)
   ],
   [SpeciesId.GLIGAR]: [
-    new SpeciesEvolution(SpeciesId.GLISCOR, 1, EvolutionItem.RAZOR_FANG, {key: EvoCondKey.TIME, time: [TimeOfDay.DUSK, TimeOfDay.NIGHT]} /* Razor fang at night*/, SpeciesWildEvolutionDelay.VERY_LONG)
+    new SpeciesEvolution(SpeciesId.GLISCOR, 1, EvolutionItem.RAZOR_FANG, {key: EvoCondKey.TIME, time: [TimeOfDay.DUSK, TimeOfDay.NIGHT]}, SpeciesWildEvolutionDelay.VERY_LONG)
   ],
   [SpeciesId.SNEASEL]: [
-    new SpeciesEvolution(SpeciesId.WEAVILE, 1, EvolutionItem.RAZOR_CLAW, {key: EvoCondKey.TIME, time: [TimeOfDay.DUSK, TimeOfDay.NIGHT]} /* Razor claw at night*/, SpeciesWildEvolutionDelay.VERY_LONG)
+    new SpeciesEvolution(SpeciesId.WEAVILE, 1, EvolutionItem.RAZOR_CLAW, {key: EvoCondKey.TIME, time: [TimeOfDay.DUSK, TimeOfDay.NIGHT]}, SpeciesWildEvolutionDelay.VERY_LONG)
+  ],
+  [SpeciesId.HAPPINY]: [
+    new SpeciesEvolution(SpeciesId.CHANSEY, 1, EvolutionItem.OVAL_STONE, {key: EvoCondKey.TIME, time: [TimeOfDay.DAWN, TimeOfDay.DAY]}, SpeciesWildEvolutionDelay.SHORT)
   ],
   [SpeciesId.URSARING]: [
     new SpeciesEvolution(SpeciesId.URSALUNA, 1, EvolutionItem.PEAT_BLOCK, null, SpeciesWildEvolutionDelay.VERY_LONG) //Ursaring does not evolve into Bloodmoon Ursaluna
@@ -1786,9 +1790,6 @@ export const pokemonEvolutions: PokemonEvolutions = {
   ],
   [SpeciesId.CHINGLING]: [
     new SpeciesEvolution(SpeciesId.CHIMECHO, 1, null, [{key: EvoCondKey.FRIENDSHIP, value: 90}, {key: EvoCondKey.TIME, time: [TimeOfDay.DUSK, TimeOfDay.NIGHT]}], SpeciesWildEvolutionDelay.MEDIUM)
-  ],
-  [SpeciesId.HAPPINY]: [
-    new SpeciesEvolution(SpeciesId.CHANSEY, 1, null, {key: EvoCondKey.FRIENDSHIP, value: 160}, SpeciesWildEvolutionDelay.SHORT)
   ],
   [SpeciesId.MUNCHLAX]: [
     new SpeciesEvolution(SpeciesId.SNORLAX, 1, null, {key: EvoCondKey.FRIENDSHIP, value: 120}, SpeciesWildEvolutionDelay.LONG)


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-  [Bug]: If the PR is primarily a bug fix
-  [Move]: If a move has new or changed functionality
-  [Ability]: If an ability has new or changed functionality
-  [Item]: For new or modified items
-  [Mystery]: For new or modified Mystery Encounters
-  [Test]: If the PR is primarily adding or modifying tests
-  [UI/UX]: If the PR is changing UI/UX elements
-  [Audio]: If the PR is adding or changing music/sfx
-  [Sprite]: If the PR is adding or changing sprites
-  [Balance]: If the PR is related to game balance
-  [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-  [Dev]: If the PR is primarily changing something pertaining to development (lefthook hooks, linter rules, etc.)
-  [i18n]: If the PR is primarily adding/changing locale keys or key usage (may come with an associated locales PR)
-  [Docs]: If the PR is adding or modifying documentation (such as tsdocs/code comments)
-  [GitHub]: For changes to GitHub workflows/templates/etc
-  [Misc]: If no other category fits the PR
-->

<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small!)
-->

## What are the changes the user will see?
<!-- Summarize what are the changes from a user perspective on the application -->
Happiny now evolves into Chansey by using an Oval Stone during the Dawn or Day, instead of 160 friendship. Blissey's friendship requirement of 200 remains unchanged.

## Why am I making these changes?
<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->
Happiny evolving via friendship was incorrect, and weird to have two friendship evolutions in a row instead of the canon evolution method.

## What are the changes from a developer perspective?
<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->
Added the Oval Stone as a new evolution item, and changed Happiny's evolution method to now use it, along with the time-based evolution condition. The evolution data was moved up to be next to other similar item-based evolutions (Gligar and Sneasel).
Also removed unnecessary comments from Gligar's and Sneasel's evolutions, since they are self-explanatory now.

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a1d5b135-252f-4f9e-8a41-49e11fa92a15" />

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->
Pick Happiny as a starter, look for an Oval Stone reward during the dawn or day time.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  ~~- [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  ~~- [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?
