### PR TITLE
[Balance] Trainer boss Pokémon no longer gain a stat boost when a boss segment is broken

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -6909,7 +6909,7 @@ export class EnemyPokemon extends Pokemon {
         const segmentSize = this.getMaxHp() / this.bossSegments;
         clearedBossSegmentIndex = Math.ceil(this.hp / segmentSize);
       }
-      if (clearedBossSegmentIndex <= this.bossSegmentIndex) {
+      if (clearedBossSegmentIndex <= this.bossSegmentIndex && !this.hasTrainer()) {
         this.handleBossSegmentCleared(clearedBossSegmentIndex);
       }
       this.battleInfo.updateBossSegments(this);


### PR DESCRIPTION
## What are the changes the user will see?
Bosses that have a trainer will no longer receive a random stat boost when a boss segment breaks.

## Why am I making these changes?
Requested by balance

## What are the changes from a developer perspective?
Inside `EnemyPokemon`'s damage method, the call to `handleBossSegmentCleared` is additionally predicated on `!this.hasTrainer()`. Note that, despite the method's poor name, it is only responsible for providing the stat boost). The boss segments are still cleared inside the damage method.

## Screenshots/Videos


## How to test the changes?
Go into a fight against a trainer that has a boss pokemon. Maybe Ivy.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?