### PR TITLE
Remove `ARENA_TINT_OVERRIDE` + minor cleanup of arena tint code

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -300,7 +300,11 @@ export class BattleScene extends SceneBase {
   public seed: string;
   public waveSeed: string;
   public waveCycleOffset: number;
-  public offsetGym: boolean;
+  /**
+   * Whether to offset Gym Leader waves by 10 (30, 50, 70 instead of 20, 40, 60).
+   * Determined at the start of the run, and is unused for non-Classic game modes.
+   */
+  public offsetGym = false;
 
   public damageNumberHandler: DamageNumberHandler;
   private spriteSparkleHandler: PokemonSpriteSparkleHandler;

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -537,22 +537,20 @@ export class Arena {
     }
   }
 
-  getTimeOfDay(): TimeOfDay {
+  public getTimeOfDay(): TimeOfDay {
     switch (this.biomeType) {
       case BiomeId.ABYSS:
         return TimeOfDay.NIGHT;
     }
 
-    const waveCycle = ((globalScene.currentBattle?.waveIndex || 0) + globalScene.waveCycleOffset) % 40;
+    const waveCycle = ((globalScene.currentBattle?.waveIndex ?? 0) + globalScene.waveCycleOffset) % 40;
 
     if (waveCycle < 15) {
       return TimeOfDay.DAY;
     }
-
     if (waveCycle < 20) {
       return TimeOfDay.DUSK;
     }
-
     if (waveCycle < 35) {
       return TimeOfDay.NIGHT;
     }
@@ -560,6 +558,10 @@ export class Arena {
     return TimeOfDay.DAWN;
   }
 
+  /**
+   * @returns Whether the current biome takes place "outdoors"
+   * (for the purposes of time of day tints)
+   */
   isOutside(): boolean {
     switch (this.biomeType) {
       case BiomeId.SEABED:
@@ -578,23 +580,7 @@ export class Arena {
     }
   }
 
-  overrideTint(): [number, number, number] {
-    switch (Overrides.ARENA_TINT_OVERRIDE) {
-      case TimeOfDay.DUSK:
-        return [98, 48, 73].map(c => Math.round((c + 128) / 2)) as [number, number, number];
-      case TimeOfDay.NIGHT:
-        return [64, 64, 64];
-      case TimeOfDay.DAWN:
-      case TimeOfDay.DAY:
-      default:
-        return [128, 128, 128];
-    }
-  }
-
   getDayTint(): [number, number, number] {
-    if (Overrides.ARENA_TINT_OVERRIDE !== null) {
-      return this.overrideTint();
-    }
     switch (this.biomeType) {
       case BiomeId.ABYSS:
         return [64, 64, 64];
@@ -604,23 +590,14 @@ export class Arena {
   }
 
   getDuskTint(): [number, number, number] {
-    if (Overrides.ARENA_TINT_OVERRIDE) {
-      return this.overrideTint();
-    }
     if (!this.isOutside()) {
       return [0, 0, 0];
     }
 
-    switch (this.biomeType) {
-      default:
-        return [98, 48, 73].map(c => Math.round((c + 128) / 2)) as [number, number, number];
-    }
+    return [113, 88, 101];
   }
 
   getNightTint(): [number, number, number] {
-    if (Overrides.ARENA_TINT_OVERRIDE) {
-      return this.overrideTint();
-    }
     switch (this.biomeType) {
       case BiomeId.ABYSS:
       case BiomeId.SPACE:
@@ -632,10 +609,7 @@ export class Arena {
       return [64, 64, 64];
     }
 
-    switch (this.biomeType) {
-      default:
-        return [48, 48, 98];
-    }
+    return [48, 48, 98];
   }
 
   setIgnoreAbilities(ignoreAbilities: boolean, ignoringEffectSource: BattlerIndex | null = null): void {

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -75,7 +75,6 @@ class DefaultOverrides {
   readonly BATTLE_STYLE_OVERRIDE: BattleStyle | null = null;
   readonly STARTING_WAVE_OVERRIDE: number = 0;
   readonly STARTING_BIOME_OVERRIDE: BiomeId | null = null;
-  readonly ARENA_TINT_OVERRIDE: TimeOfDay | null = null;
   /** Multiplies XP gained by this value including 0. Set to null to ignore the override. */
   readonly XP_MULTIPLIER_OVERRIDE: number | null = null;
   /**


### PR DESCRIPTION
## What are the changes the user will see?
N/A
## Why am I making these changes?
To put it bluntly, having an override to change the _TINT_ that is displayed based on time of day is about as useless as it sounds.

Also `return [98, 48, 73].map(c => Math.round((c + 128) / 2)) as [number, number, number]` is just... no... please

## What are the changes from a developer perspective?
Removed useless override
Cleaned up functions to not have default-only switch cases and mapping constants
Added 0.5 docs

## Screenshots/Videos
N/A

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)