### PR TITLE
[Refactor] Remove `DEBUG_RNG`

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -152,8 +152,6 @@ import Phaser from "phaser";
 import SoundFade from "phaser3-rex-plugins/plugins/soundfade";
 import type UIPlugin from "phaser3-rex-plugins/templates/ui/ui-plugin";
 
-const DEBUG_RNG = false;
-
 export interface PokeballCounts {
   [pb: string]: number;
 }
@@ -360,20 +358,6 @@ export class BattleScene extends SceneBase {
   }
 
   async preload() {
-    if (DEBUG_RNG) {
-      const originalRealInRange = Phaser.Math.RND.realInRange;
-      Phaser.Math.RND.realInRange = function (min: number, max: number): number {
-        const ret = originalRealInRange.apply(this, [min, max]);
-        const args = ["RNG", ++this.rngCounter, ret / (max - min), `min: ${min} / max: ${max}`];
-        args.push(`seed: ${this.rngSeedOverride || this.waveSeed || this.seed}`);
-        if (this.rngOffset) {
-          args.push(`offset: ${this.rngOffset}`);
-        }
-        console.log(...args);
-        return ret;
-      };
-    }
-
     /**
      * These moves serve as fallback animations for other moves without loaded animations, and
      * must be loaded prior to game start.


### PR DESCRIPTION
## What are the changes the user will see?
N/A
## Why am I making these changes?
I really dislike debug constants.

Yes, seeing the game's RNG rolls could be useful... except it isn't since we already log those to console
## What are the changes from a developer perspective?
Removed debug constant
## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
