### PR TITLE
[Bug] [Docs] Fix `@module` tags

### DIFF
--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -1,7 +1,8 @@
 /**
- * @module
+ *
  * A big file storing colors used in logging.
  * Minified by Terser during production builds, so has no overhead.
+ * @module
  */
 
 // Colors used in prod

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -1,39 +1,4 @@
-/** biome-ignore-start lint/correctness/noUnusedImports: TSDoc imports */
-import type { BattlerTag } from "#app/data/battler-tags";
-/** biome-ignore-end lint/correctness/noUnusedImports: TSDoc imports */
-
-import { applyAbAttrs, applyOnGainAbAttrs, applyOnLoseAbAttrs } from "#abilities/apply-ab-attrs";
-import { globalScene } from "#app/global-scene";
-import { getPokemonNameWithAffix } from "#app/messages";
-import { CommonBattleAnim } from "#data/battle-anims";
-import { allMoves } from "#data/data-lists";
-import { AbilityId } from "#enums/ability-id";
-import { ArenaTagSide } from "#enums/arena-tag-side";
-import { ArenaTagType } from "#enums/arena-tag-type";
-import { BattlerTagType } from "#enums/battler-tag-type";
-import { HitResult } from "#enums/hit-result";
-import { CommonAnim } from "#enums/move-anims-common";
-import { MoveCategory } from "#enums/move-category";
-import { MoveId } from "#enums/move-id";
-import { MoveTarget } from "#enums/move-target";
-import { PokemonType } from "#enums/pokemon-type";
-import { Stat } from "#enums/stat";
-import { StatusEffect } from "#enums/status-effect";
-import type { Arena } from "#field/arena";
-import type { Pokemon } from "#field/pokemon";
-import type {
-  ArenaScreenTagType,
-  ArenaTagData,
-  EntryHazardTagType,
-  RoomArenaTagType,
-  SerializableArenaTagType,
-} from "#types/arena-tags";
-import type { Mutable } from "#types/type-helpers";
-import { BooleanHolder, type NumberHolder, toDmgValue } from "#utils/common";
-import i18next from "i18next";
-
 /**
- * @module
  * ArenaTags are are meant for effects that are tied to the arena (as opposed to a specific pokemon).
  * Examples include (but are not limited to)
  * - Cross-turn effects that persist even if the user/target switches out, such as Happy Hour
@@ -75,8 +40,42 @@ import i18next from "i18next";
  * }
  * ```
  * Notes
- * - If the class has any subclasses, then the second form of `loadTag` *must* be used.
+ * - If the class has any subclasses, then the second form of `loadTag` *must* be used.\
+ * @module
  */
+// biome-ignore-start lint/correctness/noUnusedImports: TSDoc imports
+import type { BattlerTag } from "#app/data/battler-tags";
+// biome-ignore-end lint/correctness/noUnusedImports: TSDoc imports
+
+import { applyAbAttrs, applyOnGainAbAttrs, applyOnLoseAbAttrs } from "#abilities/apply-ab-attrs";
+import { globalScene } from "#app/global-scene";
+import { getPokemonNameWithAffix } from "#app/messages";
+import { CommonBattleAnim } from "#data/battle-anims";
+import { allMoves } from "#data/data-lists";
+import { AbilityId } from "#enums/ability-id";
+import { ArenaTagSide } from "#enums/arena-tag-side";
+import { ArenaTagType } from "#enums/arena-tag-type";
+import { BattlerTagType } from "#enums/battler-tag-type";
+import { HitResult } from "#enums/hit-result";
+import { CommonAnim } from "#enums/move-anims-common";
+import { MoveCategory } from "#enums/move-category";
+import { MoveId } from "#enums/move-id";
+import { MoveTarget } from "#enums/move-target";
+import { PokemonType } from "#enums/pokemon-type";
+import { Stat } from "#enums/stat";
+import { StatusEffect } from "#enums/status-effect";
+import type { Arena } from "#field/arena";
+import type { Pokemon } from "#field/pokemon";
+import type {
+  ArenaScreenTagType,
+  ArenaTagData,
+  EntryHazardTagType,
+  RoomArenaTagType,
+  SerializableArenaTagType,
+} from "#types/arena-tags";
+import type { Mutable } from "#types/type-helpers";
+import { BooleanHolder, type NumberHolder, toDmgValue } from "#utils/common";
+import i18next from "i18next";
 
 /** Interface containing the serializable fields of ArenaTagData. */
 interface BaseArenaTag {

--- a/src/data/balance/moveset-generation.ts
+++ b/src/data/balance/moveset-generation.ts
@@ -3,9 +3,6 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { MoveId } from "#enums/move-id";
-
-
 /**
  * # Balance: Moveset Generation Configuration
  *
@@ -33,6 +30,7 @@ import { MoveId } from "#enums/move-id";
  *
  * @module
  */
+import { MoveId } from "#enums/move-id";
 
 
 //#region Constants

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -1,3 +1,41 @@
+/**
+ * BattlerTags are used to represent semi-persistent effects that can be attached to a Pokemon.
+ * Note that before serialization, a new tag object is created, and then `loadTag` is called on the
+ * tag with the object that was serialized.
+ *
+ * This means it is straightforward to avoid serializing fields.
+ * Fields that are not set in the constructor and not set in `loadTag` will thus not be serialized.
+ *
+ * Any battler tag that can persist across sessions must extend SerializableBattlerTag in its class definition signature.
+ * Only tags that persist across waves (meaning their effect can last >1 turn) should be considered
+ * serializable.
+ *
+ * Serializable battler tags have strict requirements for their fields.
+ * Properties that are not necessary to reconstruct the tag must not be serialized. This can be avoided
+ * by using a private property. If access to the property is needed outside of the class, then
+ * a getter (and potentially, a setter) should be used instead.
+ *
+ * If a property that is intended to be private must be serialized, then it should instead
+ * be declared as a public readonly propety. Then, in the `loadTag` method (or any method inside the class that needs to adjust the property)
+ * use `(this as Mutable<this>).propertyName = value;`
+ * These rules ensure that Typescript is aware of the shape of the serialized version of the class.
+ *
+ * If any new serializable fields *are* added, then the class *must* override the
+ * `loadTag` method to set the new fields. Its signature *must* match the example below:
+ * ```
+ * class ExampleTag extends SerializableBattlerTag {
+ *   // Example, if we add 2 new fields that should be serialized:
+ *   public a: string;
+ *   public b: number;
+ *   // Then we must also define a loadTag method with one of the following signatures
+ *   public override loadTag(source: BaseBattlerTag & Pick<ExampleTag, "tagType" | "a" | "b"): void;
+ *   public override loadTag<const T extends this>(source: BaseBattlerTag & Pick<T, "tagType" | "a" | "b">): void;
+ * }
+ * ```
+ * Notes
+ * - If the class has any subclasses, then the second form of `loadTag` *must* be used.
+ * @module
+ */
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
@@ -51,45 +89,6 @@ import type {
 import type { Mutable } from "#types/type-helpers";
 import { BooleanHolder, coerceArray, getFrameMs, NumberHolder, toDmgValue } from "#utils/common";
 import { toCamelCase } from "#utils/strings";
-
-/**
- * @module
- * BattlerTags are used to represent semi-persistent effects that can be attached to a Pokemon.
- * Note that before serialization, a new tag object is created, and then `loadTag` is called on the
- * tag with the object that was serialized.
- *
- * This means it is straightforward to avoid serializing fields.
- * Fields that are not set in the constructor and not set in `loadTag` will thus not be serialized.
- *
- * Any battler tag that can persist across sessions must extend SerializableBattlerTag in its class definition signature.
- * Only tags that persist across waves (meaning their effect can last >1 turn) should be considered
- * serializable.
- *
- * Serializable battler tags have strict requirements for their fields.
- * Properties that are not necessary to reconstruct the tag must not be serialized. This can be avoided
- * by using a private property. If access to the property is needed outside of the class, then
- * a getter (and potentially, a setter) should be used instead.
- *
- * If a property that is intended to be private must be serialized, then it should instead
- * be declared as a public readonly propety. Then, in the `loadTag` method (or any method inside the class that needs to adjust the property)
- * use `(this as Mutable<this>).propertyName = value;`
- * These rules ensure that Typescript is aware of the shape of the serialized version of the class.
- *
- * If any new serializable fields *are* added, then the class *must* override the
- * `loadTag` method to set the new fields. Its signature *must* match the example below:
- * ```
- * class ExampleTag extends SerializableBattlerTag {
- *   // Example, if we add 2 new fields that should be serialized:
- *   public a: string;
- *   public b: number;
- *   // Then we must also define a loadTag method with one of the following signatures
- *   public override loadTag(source: BaseBattlerTag & Pick<ExampleTag, "tagType" | "a" | "b"): void;
- *   public override loadTag<const T extends this>(source: BaseBattlerTag & Pick<T, "tagType" | "a" | "b">): void;
- * }
- * ```
- * Notes
- * - If the class has any subclasses, then the second form of `loadTag` *must* be used.
- */
 
 /** Interface containing the serializable fields of BattlerTag */
 interface BaseBattlerTag {

--- a/src/phase-manager.ts
+++ b/src/phase-manager.ts
@@ -1,3 +1,11 @@
+/**
+ * Manager for phases used by battle scene.
+ *
+ * @remarks
+ * **This file must not be imported or used directly.**
+ * The manager is exclusively used by the Battle Scene and is NOT intended for external use.
+ * @module
+ */
 import { PHASE_START_COLOR } from "#app/constants/colors";
 import { globalScene } from "#app/global-scene";
 import type { Phase } from "#app/phase";
@@ -102,15 +110,6 @@ import { VictoryPhase } from "#phases/victory-phase";
 import { WeatherEffectPhase } from "#phases/weather-effect-phase";
 import type { PhaseMap, PhaseString } from "#types/phase-types";
 import { type Constructor, coerceArray } from "#utils/common";
-
-/**
- * @module
- * Manager for phases used by battle scene.
- *
- * @remarks
- * **This file must not be imported or used directly.**
- * The manager is exclusively used by the Battle Scene and is NOT intended for external use.
- */
 
 /**
  * Object that holds all of the phase constructors.

--- a/test/test-utils/setup/test-end-log.ts
+++ b/test/test-utils/setup/test-end-log.ts
@@ -5,10 +5,10 @@ import chalk from "chalk";
 import type { RunnerTask, RunnerTaskResult, RunnerTestCase } from "vitest";
 
 /**
- * @module
  * Code to add markers to the beginning and end of tests.
  * Intended for use with {@linkcode CustomDefaultReporter}, and placed inside test hooks
  * (rather than as part of the reporter) to ensure Vitest waits for the log messages to be printed.
+ * @module
  */
 
 /** A long string of "="s to partition off each test from one another. */


### PR DESCRIPTION
## What are the changes the user will see?
None

## Why am I making these changes?
Typedoc is special...

## What are the changes from a developer perspective?
Fixed module tags. They need to be the first `/**` comment in a file, and must be before all statements in the file.