### PR TITLE
[Test] Added Map key matcher; enforced strong typing on matchers

### DIFF
--- a/test/@types/vitest.d.ts
+++ b/test/@types/vitest.d.ts
@@ -44,7 +44,7 @@ declare module "vitest" {
  * @typeParam T - The type parameter of the assertion
  * @typeParam R - The type to restrict T based off of
  * @privateRemarks
- * We cannot remove incompatible methods outright  as Typescript requires that
+ * We cannot remove incompatible methods outright as Typescript requires that
  * interfaces extend solely off of types with statically known members.
  */
 type RestrictMatcher<M extends object, T, R> = {

--- a/test/@types/vitest.d.ts
+++ b/test/@types/vitest.d.ts
@@ -63,7 +63,7 @@ interface GenericMatchers<T> {
    * @param expected - The expected contents of the array, in any order
    * @see {@linkcode expect.arrayContaining}
    */
-  toEqualArrayUnsorted: T extends (infer U)[] ? (expected: U[]) => void : never;
+  toEqualUnsorted: T extends (infer U)[] ? (expected: U[]) => void : never;
 
   /**
    * Check whether a {@linkcode Map} contains the given key, disregarding its value.

--- a/test/@types/vitest.d.ts
+++ b/test/@types/vitest.d.ts
@@ -84,7 +84,7 @@ interface GameManagerMatchers {
    * Check if the {@linkcode GameManager} has shown the given message at least once in the current test case.
    * @param expectedMessage - The expected message to be displayed
    * @remarks
-   * Strings consumed by this function should _always_ be produced by a call to `i18n.t`
+   * Strings consumed by this function should _always_ be produced by a call to `i18next.t`
    * to avoid hardcoding text into test files.
    */
   toHaveShownMessage(expectedMessage: string): void;

--- a/test/@types/vitest.d.ts
+++ b/test/@types/vitest.d.ts
@@ -71,7 +71,7 @@ interface GenericMatchers<T> {
    * @privateRemarks
    * While this functionality _could_ be simulated by writing
    * `expect(x.get(y)).toBeDefined()` or
-   * `expect(x).toContain[y, expect.anything()]`,
+   * `expect(x).toContain(y, expect.anything())`,
    * this is still preferred due to being more ergonomic and provides better error messsages.
    */
   toHaveKey: T extends Map<infer K, unknown> ? (expectedKey: K) => void : never;

--- a/test/@types/vitest.d.ts
+++ b/test/@types/vitest.d.ts
@@ -43,6 +43,9 @@ declare module "vitest" {
  * @typeParam M - The type of the matchers object to restrict
  * @typeParam T - The type parameter of the assertion
  * @typeParam R - The type to restrict T based off of
+ * @privateRemarks
+ * We cannot remove incompatible methods outright  as Typescript requires that
+ * interfaces extend solely off of types with statically known members.
  */
 type RestrictMatcher<M extends object, T, R> = {
   [k in keyof M]: T extends R ? M[k] : never;

--- a/test/@types/vitest.d.ts
+++ b/test/@types/vitest.d.ts
@@ -71,7 +71,7 @@ interface GenericMatchers<T> {
    * @privateRemarks
    * While this functionality _could_ be simulated by writing
    * `expect(x.get(y)).toBeDefined()` or
-   * `expect(x).toContain(y, expect.anything())`,
+   * `expect(x).toContain([y, expect.anything()])`,
    * this is still preferred due to being more ergonomic and provides better error messsages.
    */
   toHaveKey: T extends Map<infer K, unknown> ? (expectedKey: K) => void : never;

--- a/test/@types/vitest.d.ts
+++ b/test/@types/vitest.d.ts
@@ -1,7 +1,7 @@
 import "vitest";
 
-import type { Phase } from "#app/phase";
 import type Overrides from "#app/overrides";
+import type { Phase } from "#app/phase";
 import type { ArenaTag } from "#data/arena-tag";
 import type { TerrainType } from "#data/terrain";
 import type { AbilityId } from "#enums/ability-id";
@@ -14,6 +14,7 @@ import type { PositionalTagType } from "#enums/positional-tag-type";
 import type { BattleStat, EffectiveStat } from "#enums/stat";
 import type { WeatherType } from "#enums/weather-type";
 import type { toHaveArenaTagOptions } from "#test/test-utils/matchers/to-have-arena-tag";
+import type { toHaveBattlerTagOptions } from "#test/test-utils/matchers/to-have-battler-tag";
 import type { toHaveEffectiveStatOptions } from "#test/test-utils/matchers/to-have-effective-stat";
 import type { toHavePositionalTagOptions } from "#test/test-utils/matchers/to-have-positional-tag";
 import type { expectedStatusType } from "#test/test-utils/matchers/to-have-status-effect";
@@ -23,7 +24,6 @@ import type { TurnMove } from "#types/turn-move";
 import type { AtLeastOne } from "#types/type-helpers";
 import type { toDmgValue } from "#utils/common";
 import type { expect } from "vitest";
-import type { toHaveBattlerTagOptions } from "#test/test-utils/matchers/to-have-battler-tag";
 
 declare module "vitest" {
   interface Assertion<T> {
@@ -40,17 +40,33 @@ declare module "vitest" {
      */
     toEqualArrayUnsorted(expected: T[]): void;
 
+    /**
+     * Check whether a {@linkcode Map} contains the given key, disregarding its value.
+     * @param expectedKey - The key whose inclusion is being checked
+     * @privateRemarks
+     * While this functionality _could_ be simulated by writing
+     * `expect(x.get(y)).toBeDefined()` or
+     * `expect(x).toContain[y, expect.anything()]`,
+     * this is still preferred due to being more ergonomic and provides better error messsages.
+     */
+    toHaveKey<E>(expectedKey: E): void;
+
     // #endregion Generic Matchers
 
     // #region GameManager Matchers
 
     /**
-     * Check if the {@linkcode GameManager} has shown the given message at least once in the current battle.
-     * @param expectedMessage - The expected message
+     * Check if the {@linkcode GameManager} has shown the given message at least once in the current test case.
+     * @param expectedMessage - The expected message to be displayed
+     * @remarks
+     * Strings consumed by this function should _always_ be produced by a call to `i18n.t`
+     * to avoid hardcoding text into test files.
      */
     toHaveShownMessage(expectedMessage: string): void;
+
     /**
-     * @param expectedPhase - The expected {@linkcode PhaseString}
+     * Check if the currently-running {@linkcode Phase} is of the given type.
+     * @param expectedPhase - The expected {@linkcode PhaseString | name of the phase}
      */
     toBeAtPhase(expectedPhase: PhaseString): void;
     // #endregion GameManager Matchers

--- a/test/@types/vitest.d.ts
+++ b/test/@types/vitest.d.ts
@@ -13,6 +13,8 @@ import type { PokemonType } from "#enums/pokemon-type";
 import type { PositionalTagType } from "#enums/positional-tag-type";
 import type { BattleStat, EffectiveStat } from "#enums/stat";
 import type { WeatherType } from "#enums/weather-type";
+import type { Pokemon } from "#field/pokemon";
+import type { GameManager } from "#test/test-utils/game-manager";
 import type { toHaveArenaTagOptions } from "#test/test-utils/matchers/to-have-arena-tag";
 import type { toHaveBattlerTagOptions } from "#test/test-utils/matchers/to-have-battler-tag";
 import type { toHaveEffectiveStatOptions } from "#test/test-utils/matchers/to-have-effective-stat";
@@ -25,189 +27,196 @@ import type { AtLeastOne } from "#types/type-helpers";
 import type { toDmgValue } from "#utils/common";
 import type { expect } from "vitest";
 
+// #region Boilerplate
 declare module "vitest" {
-  interface Assertion<T> {
-    // #region Generic Matchers
-
-    /**
-     * Check whether an array contains EXACTLY the given items (in any order).
-     *
-     * Different from {@linkcode expect.arrayContaining} as the latter only checks for subset equality
-     * (as opposed to full equality).
-     *
-     * @param expected - The expected contents of the array, in any order
-     * @see {@linkcode expect.arrayContaining}
-     */
-    toEqualArrayUnsorted(expected: T[]): void;
-
-    /**
-     * Check whether a {@linkcode Map} contains the given key, disregarding its value.
-     * @param expectedKey - The key whose inclusion is being checked
-     * @privateRemarks
-     * While this functionality _could_ be simulated by writing
-     * `expect(x.get(y)).toBeDefined()` or
-     * `expect(x).toContain[y, expect.anything()]`,
-     * this is still preferred due to being more ergonomic and provides better error messsages.
-     */
-    toHaveKey<E>(expectedKey: E): void;
-
-    // #endregion Generic Matchers
-
-    // #region GameManager Matchers
-
-    /**
-     * Check if the {@linkcode GameManager} has shown the given message at least once in the current test case.
-     * @param expectedMessage - The expected message to be displayed
-     * @remarks
-     * Strings consumed by this function should _always_ be produced by a call to `i18n.t`
-     * to avoid hardcoding text into test files.
-     */
-    toHaveShownMessage(expectedMessage: string): void;
-
-    /**
-     * Check if the currently-running {@linkcode Phase} is of the given type.
-     * @param expectedPhase - The expected {@linkcode PhaseString | name of the phase}
-     */
-    toBeAtPhase(expectedPhase: PhaseString): void;
-    // #endregion GameManager Matchers
-
-    // #region Arena Matchers
-
-    /**
-     * Check whether the current {@linkcode WeatherType} is as expected.
-     * @param expectedWeatherType - The expected {@linkcode WeatherType}
-     */
-    toHaveWeather(expectedWeatherType: WeatherType): void;
-
-    /**
-     * Check whether the current {@linkcode TerrainType} is as expected.
-     * @param expectedTerrainType - The expected {@linkcode TerrainType}
-     */
-    toHaveTerrain(expectedTerrainType: TerrainType): void;
-
-    /**
-     * Check whether the current {@linkcode Arena} contains the given {@linkcode ArenaTag}.
-     * @param expectedTag - A partially-filled {@linkcode ArenaTag} containing the desired properties
-     */
-    toHaveArenaTag<A extends ArenaTagType>(expectedTag: toHaveArenaTagOptions<A>): void;
-    /**
-     * Check whether the current {@linkcode Arena} contains the given {@linkcode ArenaTag}.
-     * @param expectedType - The {@linkcode ArenaTagType} of the desired tag
-     * @param side - The {@linkcode ArenaTagSide | side(s) of the field} the tag should affect; default {@linkcode ArenaTagSide.BOTH}
-     */
-    toHaveArenaTag(expectedType: ArenaTagType, side?: ArenaTagSide): void;
-
-    /**
-     * Check whether the current {@linkcode Arena} contains the given {@linkcode PositionalTag}.
-     * @param expectedTag - A partially-filled `PositionalTag` containing the desired properties
-     */
-    toHavePositionalTag<P extends PositionalTagType>(expectedTag: toHavePositionalTagOptions<P>): void;
-    /**
-     * Check whether the current {@linkcode Arena} contains the given number of {@linkcode PositionalTag}s.
-     * @param expectedType - The {@linkcode PositionalTagType} of the desired tag
-     * @param count - The number of instances of {@linkcode expectedType} that should be active;
-     * defaults to `1` and must be within the range `[0, 4]`
-     */
-    toHavePositionalTag(expectedType: PositionalTagType, count?: number): void;
-
-    // #endregion Arena Matchers
-
-    // #region Pokemon Matchers
-
-    /**
-     * Check whether a {@linkcode Pokemon}'s current typing includes the given types.
-     * @param expectedTypes - The expected {@linkcode PokemonType}s to check against; must have length `>0`
-     * @param options - The {@linkcode toHaveTypesOptions | options} passed to the matcher
-     */
-    toHaveTypes(expectedTypes: PokemonType[], options?: toHaveTypesOptions): void;
-
-    /**
-     * Check whether a {@linkcode Pokemon} has used a move matching the given criteria.
-     * @param expectedMove - The {@linkcode MoveId} the Pokemon is expected to have used,
-     * or a partially filled {@linkcode TurnMove} containing the desired properties to check
-     * @param index - The index of the move history entry to check, in order from most recent to least recent; default `0`
-     * @see {@linkcode Pokemon.getLastXMoves}
-     */
-    toHaveUsedMove(expectedMove: MoveId | AtLeastOne<TurnMove>, index?: number): void;
-
-    /**
-     * Check whether a {@linkcode Pokemon}'s effective stat is as expected
-     * (checked after all stat value modifications).
-     * @param stat - The {@linkcode EffectiveStat} to check
-     * @param expectedValue - The expected value of {@linkcode stat}
-     * @param options - The {@linkcode toHaveEffectiveStatOptions | options} passed to the matcher
-     * @remarks
-     * If you want to check the stat **before** modifiers are applied, use {@linkcode Pokemon.getStat} instead.
-     */
-    toHaveEffectiveStat(stat: EffectiveStat, expectedValue: number, options?: toHaveEffectiveStatOptions): void;
-
-    /**
-     * Check whether a {@linkcode Pokemon} has a specific {@linkcode StatusEffect | non-volatile status effect}.
-     * @param expectedStatusEffect - The {@linkcode StatusEffect} the Pokemon is expected to have,
-     * or a partially filled {@linkcode Status} containing the desired properties
-     */
-    toHaveStatusEffect(expectedStatusEffect: expectedStatusType): void;
-
-    /**
-     * Check whether a {@linkcode Pokemon} has a specific {@linkcode Stat} stage.
-     * @param stat - The {@linkcode BattleStat} to check
-     * @param expectedStage - The expected stat stage value of {@linkcode stat}
-     */
-    toHaveStatStage(stat: BattleStat, expectedStage: number): void;
-
-    /**
-     * Check whether a {@linkcode Pokemon} has the given {@linkcode BattlerTag}.
-     * @param expectedTag - A partially-filled {@linkcode BattlerTag} containing the desired properties
-     */
-    toHaveBattlerTag<B extends BattlerTagType>(expectedTag: toHaveBattlerTagOptions<B>): void;
-    /**
-     * Check whether a {@linkcode Pokemon} has the given {@linkcode BattlerTag}.
-     * @param expectedType - The expected {@linkcode BattlerTagType}
-     */
-    toHaveBattlerTag(expectedType: BattlerTagType): void;
-
-    /**
-     * Check whether a {@linkcode Pokemon} has applied a specific {@linkcode AbilityId}.
-     * @param expectedAbilityId - The `AbilityId` to check for
-     */
-    toHaveAbilityApplied(expectedAbilityId: AbilityId): void;
-
-    /**
-     * Check whether a {@linkcode Pokemon} has a specific amount of {@linkcode Stat.HP | HP}.
-     * @param expectedHp - The expected amount of {@linkcode Stat.HP | HP} to have
-     */
-    toHaveHp(expectedHp: number): void;
-
-    /**
-     * Check whether a {@linkcode Pokemon} has taken a specific amount of damage.
-     * @param expectedDamageTaken - The expected amount of damage taken
-     * @param roundDown - Whether to round down `expectedDamageTaken` with {@linkcode toDmgValue}; default `true`
-     */
-    toHaveTakenDamage(expectedDamageTaken: number, roundDown?: boolean): void;
-
-    /**
-     * Check whether a {@linkcode Pokemon} is currently fainted (as determined by {@linkcode Pokemon.isFainted}).
-     * @remarks
-     * When checking whether an enemy wild Pokemon is fainted, one must store a reference to it in a variable _before_ the fainting effect occurs.
-     * Otherwise, the Pokemon will be removed from the field and garbage collected.
-     */
-    toHaveFainted(): void;
-
-    /**
-     * Check whether a {@linkcode Pokemon} is at full HP.
-     */
-    toHaveFullHp(): void;
-    /**
-     * Check whether a {@linkcode Pokemon} has consumed the given amount of PP for one of its moves.
-     * @param moveId - The {@linkcode MoveId} corresponding to the {@linkcode PokemonMove} that should have consumed PP
-     * @param ppUsed - The numerical amount of PP that should have been consumed,
-     * or `all` to indicate the move should be _out_ of PP
-     * @remarks
-     * If the Pokemon's moveset has been set via {@linkcode Overrides.MOVESET_OVERRIDE}/{@linkcode Overrides.ENEMY_MOVESET_OVERRIDE}
-     * or does not contain exactly one copy of `moveId`, this will fail the test.
-     */
-    toHaveUsedPP(moveId: MoveId, ppUsed: number | "all"): void;
-
-    // #endregion Pokemon Matchers
-  }
+  interface Assertion<T> extends GenericMatchers<T>, GameManagerMatchers<T>, ArenaMatchers<T>, PokemonMatchers<T> {}
 }
+
+// #endregion Boilerplate
+
+// #region Generic Matchers
+interface GenericMatchers<T> {
+  /**
+   * Check whether an array contains EXACTLY the given items (in any order).
+   *
+   * Different from {@linkcode expect.arrayContaining} as the latter only checks for subset equality
+   * (as opposed to full equality).
+   *
+   * @param expected - The expected contents of the array, in any order
+   * @see {@linkcode expect.arrayContaining}
+   */
+  toEqualArrayUnsorted(expected: T extends (infer U)[] ? U[] : never): void;
+
+  /**
+   * Check whether a {@linkcode Map} contains the given key, disregarding its value.
+   * @param expectedKey - The key whose inclusion is being checked
+   * @privateRemarks
+   * While this functionality _could_ be simulated by writing
+   * `expect(x.get(y)).toBeDefined()` or
+   * `expect(x).toContain[y, expect.anything()]`,
+   * this is still preferred due to being more ergonomic and provides better error messsages.
+   */
+  toHaveKey(expectedKey: T extends Map<infer K, unknown> ? K : never): void;
+}
+// #endregion Generic Matchers
+
+// #region GameManager Matchers
+interface GameManagerMatchers<_T> {
+  /**
+   * Check if the {@linkcode GameManager} has shown the given message at least once in the current test case.
+   * @param expectedMessage - The expected message to be displayed
+   * @remarks
+   * Strings consumed by this function should _always_ be produced by a call to `i18n.t`
+   * to avoid hardcoding text into test files.
+   */
+  toHaveShownMessage(expectedMessage: string): void;
+
+  /**
+   * Check if the currently-running {@linkcode Phase} is of the given type.
+   * @param expectedPhase - The expected {@linkcode PhaseString | name of the phase}
+   */
+  toBeAtPhase(expectedPhase: PhaseString): void;
+}
+
+// #endregion GameManager Matchers
+
+// #region Arena Matchers
+interface ArenaMatchers<_T> {
+  /**
+   * Check whether the current {@linkcode WeatherType} is as expected.
+   * @param expectedWeatherType - The expected {@linkcode WeatherType}
+   */
+  toHaveWeather(expectedWeatherType: WeatherType): void;
+
+  /**
+   * Check whether the current {@linkcode TerrainType} is as expected.
+   * @param expectedTerrainType - The expected {@linkcode TerrainType}
+   */
+  toHaveTerrain(expectedTerrainType: TerrainType): void;
+
+  /**
+   * Check whether the current {@linkcode Arena} contains the given {@linkcode ArenaTag}.
+   * @param expectedTag - A partially-filled {@linkcode ArenaTag} containing the desired properties
+   */
+  toHaveArenaTag<A extends ArenaTagType>(expectedTag: toHaveArenaTagOptions<A>): void;
+  /**
+   * Check whether the current {@linkcode Arena} contains the given {@linkcode ArenaTag}.
+   * @param expectedType - The {@linkcode ArenaTagType} of the desired tag
+   * @param side - The {@linkcode ArenaTagSide | side(s) of the field} the tag should affect; default {@linkcode ArenaTagSide.BOTH}
+   */
+  toHaveArenaTag(expectedType: ArenaTagType, side?: ArenaTagSide): void;
+
+  /**
+   * Check whether the current {@linkcode Arena} contains the given {@linkcode PositionalTag}.
+   * @param expectedTag - A partially-filled `PositionalTag` containing the desired properties
+   */
+  toHavePositionalTag<P extends PositionalTagType>(expectedTag: toHavePositionalTagOptions<P>): void;
+  /**
+   * Check whether the current {@linkcode Arena} contains the given number of {@linkcode PositionalTag}s.
+   * @param expectedType - The {@linkcode PositionalTagType} of the desired tag
+   * @param count - The number of instances of {@linkcode expectedType} that should be active;
+   * defaults to `1` and must be within the range `[0, 4]`
+   */
+  toHavePositionalTag(expectedType: PositionalTagType, count?: number): void;
+}
+// #endregion Arena Matchers
+
+// #region Pokemon Matchers
+interface PokemonMatchers<_T> {
+  /**
+   * Check whether a {@linkcode Pokemon}'s current typing includes the given types.
+   * @param expectedTypes - The expected {@linkcode PokemonType}s to check against; must have length `>0`
+   * @param options - The {@linkcode toHaveTypesOptions | options} passed to the matcher
+   */
+  toHaveTypes(expectedTypes: PokemonType[], options?: toHaveTypesOptions): void;
+
+  /**
+   * Check whether a {@linkcode Pokemon} has used a move matching the given criteria.
+   * @param expectedMove - The {@linkcode MoveId} the Pokemon is expected to have used,
+   * or a partially filled {@linkcode TurnMove} containing the desired properties to check
+   * @param index - The index of the move history entry to check, in order from most recent to least recent; default `0`
+   * @see {@linkcode Pokemon.getLastXMoves}
+   */
+  toHaveUsedMove(expectedMove: MoveId | AtLeastOne<TurnMove>, index?: number): void;
+
+  /**
+   * Check whether a {@linkcode Pokemon}'s effective stat is as expected
+   * (checked after all stat value modifications).
+   * @param stat - The {@linkcode EffectiveStat} to check
+   * @param expectedValue - The expected value of {@linkcode stat}
+   * @param options - The {@linkcode toHaveEffectiveStatOptions | options} passed to the matcher
+   * @remarks
+   * If you want to check the stat **before** modifiers are applied, use {@linkcode Pokemon.getStat} instead.
+   */
+  toHaveEffectiveStat(stat: EffectiveStat, expectedValue: number, options?: toHaveEffectiveStatOptions): void;
+
+  /**
+   * Check whether a {@linkcode Pokemon} has a specific {@linkcode StatusEffect | non-volatile status effect}.
+   * @param expectedStatusEffect - The {@linkcode StatusEffect} the Pokemon is expected to have,
+   * or a partially filled {@linkcode Status} containing the desired properties
+   */
+  toHaveStatusEffect(expectedStatusEffect: expectedStatusType): void;
+
+  /**
+   * Check whether a {@linkcode Pokemon} has a specific {@linkcode Stat} stage.
+   * @param stat - The {@linkcode BattleStat} to check
+   * @param expectedStage - The expected stat stage value of {@linkcode stat}
+   */
+  toHaveStatStage(stat: BattleStat, expectedStage: number): void;
+
+  /**
+   * Check whether a {@linkcode Pokemon} has the given {@linkcode BattlerTag}.
+   * @param expectedTag - A partially-filled {@linkcode BattlerTag} containing the desired properties
+   */
+  toHaveBattlerTag<B extends BattlerTagType>(expectedTag: toHaveBattlerTagOptions<B>): void;
+  /**
+   * Check whether a {@linkcode Pokemon} has the given {@linkcode BattlerTag}.
+   * @param expectedType - The expected {@linkcode BattlerTagType}
+   */
+  toHaveBattlerTag(expectedType: BattlerTagType): void;
+
+  /**
+   * Check whether a {@linkcode Pokemon} has applied a specific {@linkcode AbilityId}.
+   * @param expectedAbilityId - The `AbilityId` to check for
+   */
+  toHaveAbilityApplied(expectedAbilityId: AbilityId): void;
+
+  /**
+   * Check whether a {@linkcode Pokemon} has a specific amount of {@linkcode Stat.HP | HP}.
+   * @param expectedHp - The expected amount of {@linkcode Stat.HP | HP} to have
+   */
+  toHaveHp(expectedHp: number): void;
+
+  /**
+   * Check whether a {@linkcode Pokemon} has taken a specific amount of damage.
+   * @param expectedDamageTaken - The expected amount of damage taken
+   * @param roundDown - Whether to round down `expectedDamageTaken` with {@linkcode toDmgValue}; default `true`
+   */
+  toHaveTakenDamage(expectedDamageTaken: number, roundDown?: boolean): void;
+
+  /**
+   * Check whether a {@linkcode Pokemon} is currently fainted (as determined by {@linkcode Pokemon.isFainted}).
+   * @remarks
+   * When checking whether an enemy wild Pokemon is fainted, one must store a reference to it in a variable _before_ the fainting effect occurs.
+   * Otherwise, the Pokemon will be removed from the field and garbage collected.
+   */
+  toHaveFainted(): void;
+
+  /**
+   * Check whether a {@linkcode Pokemon} is at full HP.
+   */
+  toHaveFullHp(): void;
+
+  /**
+   * Check whether a {@linkcode Pokemon} has consumed the given amount of PP for one of its moves.
+   * @param moveId - The {@linkcode MoveId} corresponding to the {@linkcode PokemonMove} that should have consumed PP
+   * @param ppUsed - The numerical amount of PP that should have been consumed,
+   * or `all` to indicate the move should be _out_ of PP
+   * @remarks
+   * If the Pokemon's moveset has been set via {@linkcode Overrides.MOVESET_OVERRIDE}/{@linkcode Overrides.ENEMY_MOVESET_OVERRIDE}
+   * or does not contain exactly one copy of `moveId`, this will fail the test.
+   */
+  toHaveUsedPP(moveId: MoveId, ppUsed: number | "all"): void;
+}
+
+// #endregion Pokemon Matchers

--- a/test/setup/matchers.setup.ts
+++ b/test/setup/matchers.setup.ts
@@ -7,6 +7,7 @@ import { toHaveEffectiveStat } from "#test/test-utils/matchers/to-have-effective
 import { toHaveFainted } from "#test/test-utils/matchers/to-have-fainted";
 import { toHaveFullHp } from "#test/test-utils/matchers/to-have-full-hp";
 import { toHaveHp } from "#test/test-utils/matchers/to-have-hp";
+import { toHaveKey } from "#test/test-utils/matchers/to-have-key";
 import { toHavePositionalTag } from "#test/test-utils/matchers/to-have-positional-tag";
 import { toHaveShownMessage } from "#test/test-utils/matchers/to-have-shown-message";
 import { toHaveStatStage } from "#test/test-utils/matchers/to-have-stat-stage";
@@ -19,13 +20,15 @@ import { toHaveUsedPP } from "#test/test-utils/matchers/to-have-used-pp";
 import { toHaveWeather } from "#test/test-utils/matchers/to-have-weather";
 import { expect } from "vitest";
 
-/*
+/**
+ * @module
  * Setup file for custom matchers.
  * Make sure to define the call signatures in `#test/@types/vitest.d.ts` too!
  */
 
 expect.extend({
   toEqualArrayUnsorted,
+  toHaveKey,
   toHaveShownMessage,
   toBeAtPhase,
   toHaveWeather,

--- a/test/setup/matchers.setup.ts
+++ b/test/setup/matchers.setup.ts
@@ -1,3 +1,9 @@
+/**
+ * @module
+ * Setup file for custom matchers.
+ * Make sure to define the call signatures in `#test/@types/vitest.d.ts` too!
+ */
+
 import { toBeAtPhase } from "#test/test-utils/matchers/to-be-at-phase";
 import { toEqualUnsorted } from "#test/test-utils/matchers/to-equal-unsorted";
 import { toHaveAbilityApplied } from "#test/test-utils/matchers/to-have-ability-applied";
@@ -19,12 +25,6 @@ import { toHaveUsedMove } from "#test/test-utils/matchers/to-have-used-move";
 import { toHaveUsedPP } from "#test/test-utils/matchers/to-have-used-pp";
 import { toHaveWeather } from "#test/test-utils/matchers/to-have-weather";
 import { expect } from "vitest";
-
-/**
- * @module
- * Setup file for custom matchers.
- * Make sure to define the call signatures in `#test/@types/vitest.d.ts` too!
- */
 
 expect.extend({
   toEqualUnsorted,

--- a/test/setup/matchers.setup.ts
+++ b/test/setup/matchers.setup.ts
@@ -1,7 +1,7 @@
 /**
- * @module
  * Setup file for custom matchers.
  * Make sure to define the call signatures in `#test/@types/vitest.d.ts` too!
+ * @module
  */
 
 import { toBeAtPhase } from "#test/test-utils/matchers/to-be-at-phase";

--- a/test/setup/matchers.setup.ts
+++ b/test/setup/matchers.setup.ts
@@ -1,5 +1,5 @@
 import { toBeAtPhase } from "#test/test-utils/matchers/to-be-at-phase";
-import { toEqualArrayUnsorted } from "#test/test-utils/matchers/to-equal-array-unsorted";
+import { toEqualUnsorted } from "#test/test-utils/matchers/to-equal-unsorted";
 import { toHaveAbilityApplied } from "#test/test-utils/matchers/to-have-ability-applied";
 import { toHaveArenaTag } from "#test/test-utils/matchers/to-have-arena-tag";
 import { toHaveBattlerTag } from "#test/test-utils/matchers/to-have-battler-tag";
@@ -27,7 +27,7 @@ import { expect } from "vitest";
  */
 
 expect.extend({
-  toEqualArrayUnsorted,
+  toEqualUnsorted,
   toHaveKey,
   toHaveShownMessage,
   toBeAtPhase,

--- a/test/test-utils/helpers/modifiers-helper.ts
+++ b/test/test-utils/helpers/modifiers-helper.ts
@@ -40,10 +40,7 @@ export class ModifierHelper extends GameManagerHelper {
    * @returns `this`
    */
   testCheck(modifier: ModifierTypeKeys, expectToBePreset: boolean): this {
-    if (expectToBePreset) {
-      expect(itemPoolChecks.get(modifier)).toBeTruthy();
-    }
-    expect(itemPoolChecks.get(modifier)).toBeFalsy();
+    (expectToBePreset ? expect(itemPoolChecks) : expect(itemPoolChecks).not).toHaveKey(modifier);
     return this;
   }
 

--- a/test/test-utils/matchers/to-equal-unsorted.ts
+++ b/test/test-utils/matchers/to-equal-unsorted.ts
@@ -8,11 +8,7 @@ import type { MatcherState, SyncExpectationResult } from "@vitest/expect";
  * @param expected - The array to check equality with
  * @returns Whether the matcher passed
  */
-export function toEqualArrayUnsorted(
-  this: MatcherState,
-  received: unknown,
-  expected: unknown[],
-): SyncExpectationResult {
+export function toEqualUnsorted(this: MatcherState, received: unknown, expected: unknown[]): SyncExpectationResult {
   if (!Array.isArray(received)) {
     return {
       pass: this.isNot,

--- a/test/test-utils/matchers/to-have-key.ts
+++ b/test/test-utils/matchers/to-have-key.ts
@@ -18,7 +18,7 @@ export function toHaveKey(this: MatcherState, received: unknown, expectedKey: un
 
   if (received.size === 0) {
     return {
-      pass: false,
+      pass: this.isNot,
       message: () => "Expected to receive a non-empty Map, but received map was empty!",
       expected: expectedKey,
       actual: received,

--- a/test/test-utils/matchers/to-have-key.ts
+++ b/test/test-utils/matchers/to-have-key.ts
@@ -1,0 +1,47 @@
+import { getOnelineDiffStr } from "#test/test-utils/string-utils";
+import { receivedStr } from "#test/test-utils/test-utils";
+import type { MatcherState, SyncExpectationResult } from "@vitest/expect";
+
+/**
+ * Matcher that checks if a {@linkcode Map} contains the given key, regardless of its value.
+ * @param received - The received value. Should be a Map
+ * @param expectedKey - The key whose inclusion in the map is being checked
+ * @returns Whether the matcher passed
+ */
+export function toHaveKey(this: MatcherState, received: unknown, expectedKey: unknown): SyncExpectationResult {
+  if (!(received instanceof Map)) {
+    return {
+      pass: this.isNot,
+      message: () => `Expected to receive a Map, but got ${receivedStr(received)}!`,
+    };
+  }
+
+  if (received.size === 0) {
+    return {
+      pass: false,
+      message: () => "Expected to receive a non-empty Map, but received map was empty!",
+      expected: expectedKey,
+      actual: received,
+    };
+  }
+
+  const keys = [...received.values()];
+  const pass = this.equals(keys, expectedKey, [
+    ...this.customTesters,
+    this.utils.iterableEquality,
+    this.utils.subsetEquality,
+  ]);
+
+  const actualStr = getOnelineDiffStr.call(this, received);
+  const expectedStr = getOnelineDiffStr.call(this, expectedKey);
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? `Expected ${actualStr} to NOT have the key ${expectedStr}, but it did!`
+        : `Expected ${actualStr} to have the key ${expectedStr}, but it didn't!`,
+    expected: expectedKey,
+    actual: keys,
+  };
+}

--- a/test/test-utils/matchers/to-have-key.ts
+++ b/test/test-utils/matchers/to-have-key.ts
@@ -25,7 +25,7 @@ export function toHaveKey(this: MatcherState, received: unknown, expectedKey: un
     };
   }
 
-  const keys = [...received.values()];
+  const keys = [...received.keys()];
   const pass = this.equals(keys, expectedKey, [
     ...this.customTesters,
     this.utils.iterableEquality,

--- a/test/test-utils/matchers/to-have-terrain.ts
+++ b/test/test-utils/matchers/to-have-terrain.ts
@@ -8,8 +8,8 @@ import { isGameManagerInstance, receivedStr } from "#test/test-utils/test-utils"
 import type { MatcherState, SyncExpectationResult } from "@vitest/expect";
 
 /**
- * Matcher that checks if the {@linkcode TerrainType} is as expected
- * @param received - The object to check. Should be an instance of {@linkcode GameManager}.
+ * Matcher that checks if the current {@linkcode TerrainType} is as expected.
+ * @param received - The object to check. Should be the current {@linkcode GameManager}.
  * @param expectedTerrainType - The expected {@linkcode TerrainType}, or {@linkcode TerrainType.NONE} if no terrain should be active
  * @returns Whether the matcher passed
  */

--- a/test/test-utils/matchers/to-have-weather.ts
+++ b/test/test-utils/matchers/to-have-weather.ts
@@ -8,8 +8,8 @@ import { toTitleCase } from "#utils/strings";
 import type { MatcherState, SyncExpectationResult } from "@vitest/expect";
 
 /**
- * Matcher that checks if the {@linkcode WeatherType} is as expected
- * @param received - The object to check. Expects an instance of {@linkcode GameManager}.
+ * Matcher that checks if the current {@linkcode WeatherType} is as expected.
+ * @param received - The object to check. Should be the current {@linkcode GameManager}
  * @param expectedWeatherType - The expected {@linkcode WeatherType}
  * @returns Whether the matcher passed
  */


### PR DESCRIPTION
- **Added `toHaveKey` matcher + fixed imports**
- **Broke up the test matchers into multiple smaller interfaces**
- **Added restricted typing on matchers**

## What are the changes the user will see?
N/A
## Why am I making these changes?
Map matcher: Benjie wanted it

Type safety: I wanted it
## What are the changes from a developer perspective?
1. Added a matcher, `toHaveKey`, which takes a Map and asserts that its keys contain the given value.
2. Re-organized `vitest.d.ts` into sub-interfaces based on the category.
3. Added a utility type, `RestrictMatchers`, to restrict available matcher types based on the type of the assertion. This ensures that all matchers that _don't_ match the given argument will resolve to `never` (so you can't do `expect(1).toHaveFullHp()` or `expect("foo").toEqualArrayUnsorted([1, 2, 3])`).
4. Fixed the type declaration for `toEqualArrayUnsorted` to not be borked

## Screenshots/Videos
N/A
## How to test the changes?
Write some tests?
## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)