### PR TITLE
[Tests] Cleanup `getCookie` and add many unit tests

### DIFF
--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -17,19 +17,17 @@ export function removeCookie(cName: string): void {
 
 export function getCookie(cName: string): string {
   // check if there are multiple cookies with the same name and delete them
-  if (document.cookie.split(";").filter(c => c.includes(cName)).length > 1) {
+  if (document.cookie.split(";").filter(c => c.trim().includes(cName)).length > 1) {
     removeCookie(cName);
     return "";
   }
   const name = `${cName}=`;
-  const ca = document.cookie.split(";");
-  for (let c of ca) {
-    // ⚠️ DO NOT REPLACE THIS WITH C = C.TRIM() - IT BREAKS IN NON-CHROMIUM BROWSERS ⚠️
-    while (c.charAt(0) === " ") {
-      c = c.substring(1);
-    }
-    if (c.indexOf(name) === 0) {
-      return c.substring(name.length, c.length);
+  const cookieArray = document.cookie.split(";");
+  // Check all cookies in the document and see if any of them match, grabbing the first one whose value lines up
+  for (const cookie of cookieArray) {
+    const cookieTrimmed = cookie.trim();
+    if (cookieTrimmed.startsWith(name)) {
+      return cookieTrimmed.slice(name.length, cookieTrimmed.length);
     }
   }
   return "";

--- a/test/utils/cookies.test.ts
+++ b/test/utils/cookies.test.ts
@@ -1,0 +1,62 @@
+import { getCookie } from "#utils/cookies";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Unit Tests - cookies.ts", () => {
+  describe("getCookie", () => {
+    const cookieStart = document.cookie;
+    beforeEach(() => {
+      // clear cookie before each test
+      document.cookie = "";
+    });
+
+    afterEach(() => {
+      // restore original cookie after each test
+      document.cookie = cookieStart;
+    });
+    /**
+     * Spies on `document.cookie` and replaces its value with the provided string.
+     */
+    function setDocumentCookie(value: string) {
+      vi.spyOn(document, "cookie", "get").mockReturnValue(value);
+    }
+    it("returns the value of a single cookie", () => {
+      setDocumentCookie("foo=bar");
+      expect(getCookie("foo")).toBe("bar");
+    });
+
+    it("returns empty string if cookie is not found", () => {
+      setDocumentCookie("foo=bar");
+      expect(getCookie("baz")).toBe("");
+    });
+
+    it("returns the value when multiple cookies exist", () => {
+      setDocumentCookie("foo=bar; baz=qux");
+      expect(getCookie("baz")).toBe("qux");
+    });
+
+    it("trims leading spaces in cookies", () => {
+      setDocumentCookie("foo=bar;  baz=qux");
+      expect(getCookie("baz")).toBe("qux");
+    });
+
+    it("returns the value of the first matching cookie if only one exists", () => {
+      setDocumentCookie("foo=bar; test=val");
+      expect(getCookie("foo")).toBe("bar");
+    });
+
+    it("returns empty string if document.cookie is empty", () => {
+      setDocumentCookie("");
+      expect(getCookie("foo")).toBe("");
+    });
+
+    it("handles cookies that aren't separated with a space", () => {
+      setDocumentCookie("foo=bar;baz=qux;quux=corge;grault=garply");
+      expect(getCookie("baz")).toBe("qux");
+    });
+
+    it("handles cookies that may have leading tab characters", () => {
+      setDocumentCookie("foo=bar;\tbaz=qux");
+      expect(getCookie("baz")).toBe("qux");
+    });
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?
None, though cleans up the getCookie code to before the bug

## Why am I making these changes?
The original PR that adjusted `getCookie` to clean up its logic had a very hard to spot error where it was subslicing the wrong string. This mismatch occured because `cookieTrimmed` was being used to match name, but then the original `c` object was being subsliced. Which is wrong, and resulted in there being an off-by-one error whenever attempting to slice cookies.
This is why clearing cookies fixed it on beta. The bug couldn't be triggered if there were no cookies set prior to the login threshold. This is why I mistakenly believed it to be an idiosyncracy in Firefox (which I don't use, so I don't have my suite of adblockers on, and thus don't avoid the google analytics cookies that were set), which triggered the bug, while chrome didn't.

## What are the changes from a developer perspective?
Added a bunch of unit tests
Made the `getCookie` use the right code, and expanded out variable names to make it clear.
Folks, this is a tale of why we don't use acronyms for variable names. It obfuscates it and makes it easy to miss which variable corresponds to which thing.

Added a bunch of unit tests for this method.
## Screenshots/Videos
N/A

## How to test the changes?
`pnpm test test/utils/cookie.test.ts`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- ~~[ ] Have I provided screenshots/videos of the changes (if applicable)?~~
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~