### PR TITLE
[Challenge][Bug] Restrict starters with gender-based evolutions in challenges

### DIFF
--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -466,6 +466,20 @@ export class SingleGenerationChallenge extends Challenge {
     return false;
   }
 
+  applyStarterSelectModify(speciesId: SpeciesId, dexEntry: DexEntry, _starterDataEntry: StarterDataEntry): boolean {
+    // Ralts must be male and Snorunt must be female
+    if (this.value === 4) {
+      if (speciesId === SpeciesId.RALTS) {
+        dexEntry.caughtAttr &= ~DexAttr.FEMALE;
+      }
+      if (speciesId === SpeciesId.SNORUNT) {
+        dexEntry.caughtAttr &= ~DexAttr.MALE;
+      }
+    }
+
+    return true;
+  }
+
   applyPokemonInBattle(pokemon: Pokemon, valid: BooleanHolder): boolean {
     const baseGeneration = getPokemonSpecies(pokemon.species.speciesId).generation;
     const fusionGeneration = pokemon.isFusion() ? getPokemonSpecies(pokemon.fusionSpecies!.speciesId).generation : 0;
@@ -737,6 +751,27 @@ export class SingleTypeChallenge extends Challenge {
       return true;
     }
     return false;
+  }
+
+  applyStarterSelectModify(speciesId: SpeciesId, dexEntry: DexEntry, _starterDataEntry: StarterDataEntry): boolean {
+    const type = this.value - 1;
+
+    if (type === PokemonType.FIGHTING && speciesId === SpeciesId.RALTS) {
+      dexEntry.caughtAttr &= ~DexAttr.FEMALE;
+    }
+    if (type === PokemonType.GHOST && speciesId === SpeciesId.SNORUNT) {
+      dexEntry.caughtAttr &= ~DexAttr.MALE;
+    }
+    if (speciesId === SpeciesId.BURMY) {
+      if (type === PokemonType.FLYING) {
+        dexEntry.caughtAttr &= ~DexAttr.FEMALE;
+      }
+      if ([PokemonType.GRASS, PokemonType.GROUND, PokemonType.STEEL].includes(type)) {
+        dexEntry.caughtAttr &= ~DexAttr.MALE;
+      }
+    }
+
+    return true;
   }
 
   applyPokemonInBattle(pokemon: Pokemon, valid: BooleanHolder): boolean {


### PR DESCRIPTION
## What are the changes the user will see?
Female Ralts and Male Snorunt cannot be selected in mono gen 4 challenge. Same applies to various starters in mono type challenges.

## Why am I making these changes?
Prevents the player from accidentally selecting an illegal starter.

## What are the changes from a developer perspective?
Leveraging the technology introduced for fresh start which makes a temporary copy of unlock data, to filter out the wrong genders. This _could_ maybe be done automatically somehow, but the cases are so few that listing them out explicitly is more practical.

## Screenshots/Videos
<img width="801" height="463" alt="burmy2" src="https://github.com/user-attachments/assets/f8480c57-6a5b-45ef-aaa0-c4b42a29f17c" />

<img width="798" height="455" alt="ralts" src="https://github.com/user-attachments/assets/a876cb35-49c6-4e22-9fa3-de753acd01e7" />

## How to test the changes?
Try out the relevant challenges and check the starters, on a file where both genders are unlocked.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?