### PR TITLE
[UI/UX] Show correct max duration in flyout

### DIFF
--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -85,6 +85,10 @@ interface BaseArenaTag {
    */
   turnCount: number;
   /**
+   * The tag's max duration.
+   */
+  maxDuration: number;
+  /**
    * The {@linkcode MoveId} that created this tag, or `undefined` if not set by a move.
    */
   sourceMove?: MoveId;
@@ -110,12 +114,14 @@ export abstract class ArenaTag implements BaseArenaTag {
   /** The type of the arena tag */
   public abstract readonly tagType: ArenaTagType;
   public turnCount: number;
+  public maxDuration: number;
   public sourceMove?: MoveId;
   public sourceId: number | undefined;
   public side: ArenaTagSide;
 
   constructor(turnCount: number, sourceMove?: MoveId, sourceId?: number, side: ArenaTagSide = ArenaTagSide.BOTH) {
     this.turnCount = turnCount;
+    this.maxDuration = turnCount;
     this.sourceMove = sourceMove;
     this.sourceId = sourceId;
     this.side = side;
@@ -164,6 +170,7 @@ export abstract class ArenaTag implements BaseArenaTag {
    */
   loadTag<const T extends this>(source: BaseArenaTag & Pick<T, "tagType">): void {
     this.turnCount = source.turnCount;
+    this.maxDuration = source.maxDuration;
     this.sourceMove = source.sourceMove;
     this.sourceId = source.sourceId;
     this.side = source.side;

--- a/src/data/terrain.ts
+++ b/src/data/terrain.ts
@@ -22,10 +22,12 @@ export interface SerializedTerrain {
 export class Terrain {
   public terrainType: TerrainType;
   public turnsLeft: number;
+  public maxDuration: number;
 
-  constructor(terrainType: TerrainType, turnsLeft?: number) {
+  constructor(terrainType: TerrainType, turnsLeft?: number, maxDuration?: number) {
     this.terrainType = terrainType;
     this.turnsLeft = turnsLeft || 0;
+    this.maxDuration = maxDuration || turnsLeft || 0;
   }
 
   lapse(): boolean {

--- a/src/data/terrain.ts
+++ b/src/data/terrain.ts
@@ -24,10 +24,10 @@ export class Terrain {
   public turnsLeft: number;
   public maxDuration: number;
 
-  constructor(terrainType: TerrainType, turnsLeft?: number, maxDuration?: number) {
+  constructor(terrainType: TerrainType, turnsLeft = 0, maxDuration: number = turnsLeft) {
     this.terrainType = terrainType;
-    this.turnsLeft = turnsLeft || 0;
-    this.maxDuration = maxDuration || turnsLeft || 0;
+    this.turnsLeft = turnsLeft;
+    this.maxDuration = maxDuration;
   }
 
   lapse(): boolean {

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -21,10 +21,10 @@ export class Weather {
   public turnsLeft: number;
   public maxDuration: number;
 
-  constructor(weatherType: WeatherType, turnsLeft?: number, maxDuration?: number) {
+  constructor(weatherType: WeatherType, turnsLeft = 0, maxDuration: number = turnsLeft) {
     this.weatherType = weatherType;
-    this.turnsLeft = !this.isImmutable() ? turnsLeft || 0 : 0;
-    this.maxDuration = !this.isImmutable() ? maxDuration || turnsLeft || 0 : 0;
+    this.turnsLeft = this.isImmutable() ? 0 : turnsLeft;
+    this.maxDuration = this.isImmutable() ? 0 : maxDuration;
   }
 
   lapse(): boolean {

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -19,10 +19,12 @@ export interface SerializedWeather {
 export class Weather {
   public weatherType: WeatherType;
   public turnsLeft: number;
+  public maxDuration: number;
 
-  constructor(weatherType: WeatherType, turnsLeft?: number) {
+  constructor(weatherType: WeatherType, turnsLeft?: number, maxDuration?: number) {
     this.weatherType = weatherType;
     this.turnsLeft = !this.isImmutable() ? turnsLeft || 0 : 0;
+    this.maxDuration = !this.isImmutable() ? maxDuration || turnsLeft || 0 : 0;
   }
 
   lapse(): boolean {

--- a/src/events/arena.ts
+++ b/src/events/arena.ts
@@ -22,11 +22,11 @@ export class ArenaEvent extends Event {
   public duration: number;
   /** The maximum duration of the {@linkcode ArenaEventType} */
   public maxDuration: number;
-  constructor(eventType: ArenaEventType, duration: number, maxDuration?: number) {
+  constructor(eventType: ArenaEventType, duration: number, maxDuration: number = duration) {
     super(eventType);
 
     this.duration = duration;
-    this.maxDuration = maxDuration || duration;
+    this.maxDuration = maxDuration;
   }
 }
 /** Container class for {@linkcode ArenaEventType.WEATHER_CHANGED} events */

--- a/src/events/arena.ts
+++ b/src/events/arena.ts
@@ -71,10 +71,11 @@ export class TagAddedEvent extends ArenaEvent {
     arenaTagType: ArenaTagType,
     arenaTagSide: ArenaTagSide,
     duration: number,
+    maxDuration: number,
     arenaTagLayers?: number,
     arenaTagMaxLayers?: number,
   ) {
-    super(ArenaEventType.TAG_ADDED, duration);
+    super(ArenaEventType.TAG_ADDED, duration, maxDuration);
 
     this.arenaTagType = arenaTagType;
     this.arenaTagSide = arenaTagSide;
@@ -89,7 +90,7 @@ export class TagRemovedEvent extends ArenaEvent {
   /** The {@linkcode ArenaTagSide} the tag was being placed on */
   public arenaTagSide: ArenaTagSide;
   constructor(arenaTagType: ArenaTagType, arenaTagSide: ArenaTagSide, duration: number) {
-    super(ArenaEventType.TAG_REMOVED, duration);
+    super(ArenaEventType.TAG_REMOVED, duration, duration);
 
     this.arenaTagType = arenaTagType;
     this.arenaTagSide = arenaTagSide;

--- a/src/events/arena.ts
+++ b/src/events/arena.ts
@@ -20,10 +20,13 @@ export enum ArenaEventType {
 export class ArenaEvent extends Event {
   /** The total duration of the {@linkcode ArenaEventType} */
   public duration: number;
-  constructor(eventType: ArenaEventType, duration: number) {
+  /** The maximum duration of the {@linkcode ArenaEventType} */
+  public maxDuration: number;
+  constructor(eventType: ArenaEventType, duration: number, maxDuration: number) {
     super(eventType);
 
     this.duration = duration;
+    this.maxDuration = maxDuration || duration;
   }
 }
 /** Container class for {@linkcode ArenaEventType.WEATHER_CHANGED} events */
@@ -32,8 +35,8 @@ export class WeatherChangedEvent extends ArenaEvent {
   public oldWeatherType: WeatherType;
   /** The {@linkcode WeatherType} being set */
   public newWeatherType: WeatherType;
-  constructor(oldWeatherType: WeatherType, newWeatherType: WeatherType, duration: number) {
-    super(ArenaEventType.WEATHER_CHANGED, duration);
+  constructor(oldWeatherType: WeatherType, newWeatherType: WeatherType, duration: number, maxDuration: number) {
+    super(ArenaEventType.WEATHER_CHANGED, duration, maxDuration);
 
     this.oldWeatherType = oldWeatherType;
     this.newWeatherType = newWeatherType;
@@ -45,8 +48,8 @@ export class TerrainChangedEvent extends ArenaEvent {
   public oldTerrainType: TerrainType;
   /** The {@linkcode TerrainType} being set */
   public newTerrainType: TerrainType;
-  constructor(oldTerrainType: TerrainType, newTerrainType: TerrainType, duration: number) {
-    super(ArenaEventType.TERRAIN_CHANGED, duration);
+  constructor(oldTerrainType: TerrainType, newTerrainType: TerrainType, duration: number, maxDuration: number) {
+    super(ArenaEventType.TERRAIN_CHANGED, duration, maxDuration);
 
     this.oldTerrainType = oldTerrainType;
     this.newTerrainType = newTerrainType;

--- a/src/events/arena.ts
+++ b/src/events/arena.ts
@@ -22,7 +22,7 @@ export class ArenaEvent extends Event {
   public duration: number;
   /** The maximum duration of the {@linkcode ArenaEventType} */
   public maxDuration: number;
-  constructor(eventType: ArenaEventType, duration: number, maxDuration: number) {
+  constructor(eventType: ArenaEventType, duration: number, maxDuration?: number) {
     super(eventType);
 
     this.duration = duration;
@@ -35,7 +35,7 @@ export class WeatherChangedEvent extends ArenaEvent {
   public oldWeatherType: WeatherType;
   /** The {@linkcode WeatherType} being set */
   public newWeatherType: WeatherType;
-  constructor(oldWeatherType: WeatherType, newWeatherType: WeatherType, duration: number, maxDuration: number) {
+  constructor(oldWeatherType: WeatherType, newWeatherType: WeatherType, duration: number, maxDuration?: number) {
     super(ArenaEventType.WEATHER_CHANGED, duration, maxDuration);
 
     this.oldWeatherType = oldWeatherType;
@@ -48,7 +48,7 @@ export class TerrainChangedEvent extends ArenaEvent {
   public oldTerrainType: TerrainType;
   /** The {@linkcode TerrainType} being set */
   public newTerrainType: TerrainType;
-  constructor(oldTerrainType: TerrainType, newTerrainType: TerrainType, duration: number, maxDuration: number) {
+  constructor(oldTerrainType: TerrainType, newTerrainType: TerrainType, duration: number, maxDuration?: number) {
     super(ArenaEventType.TERRAIN_CHANGED, duration, maxDuration);
 
     this.oldTerrainType = oldTerrainType;
@@ -71,7 +71,7 @@ export class TagAddedEvent extends ArenaEvent {
     arenaTagType: ArenaTagType,
     arenaTagSide: ArenaTagSide,
     duration: number,
-    maxDuration: number,
+    maxDuration?: number,
     arenaTagLayers?: number,
     arenaTagMaxLayers?: number,
   ) {
@@ -90,7 +90,7 @@ export class TagRemovedEvent extends ArenaEvent {
   /** The {@linkcode ArenaTagSide} the tag was being placed on */
   public arenaTagSide: ArenaTagSide;
   constructor(arenaTagType: ArenaTagType, arenaTagSide: ArenaTagSide, duration: number) {
-    super(ArenaEventType.TAG_REMOVED, duration, duration);
+    super(ArenaEventType.TAG_REMOVED, duration);
 
     this.arenaTagType = arenaTagType;
     this.arenaTagSide = arenaTagSide;

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -344,9 +344,14 @@ export class Arena {
       globalScene.applyModifier(FieldEffectModifier, user.isPlayer(), user, weatherDuration);
     }
 
-    this.weather = weather ? new Weather(weather, weatherDuration.value) : null;
+    this.weather = weather ? new Weather(weather, weatherDuration.value, weatherDuration.value) : null;
     this.eventTarget.dispatchEvent(
-      new WeatherChangedEvent(oldWeatherType, this.weather?.weatherType!, this.weather?.turnsLeft!),
+      new WeatherChangedEvent(
+        oldWeatherType,
+        this.weather?.weatherType!,
+        this.weather?.turnsLeft!,
+        this.weather?.turnsLeft!,
+      ),
     ); // TODO: is this bang correct?
 
     if (this.weather) {
@@ -425,10 +430,15 @@ export class Arena {
       globalScene.applyModifier(FieldEffectModifier, user.isPlayer(), user, terrainDuration);
     }
 
-    this.terrain = terrain ? new Terrain(terrain, terrainDuration.value) : null;
+    this.terrain = terrain ? new Terrain(terrain, terrainDuration.value, terrainDuration.value) : null;
 
     this.eventTarget.dispatchEvent(
-      new TerrainChangedEvent(oldTerrainType, this.terrain?.terrainType!, this.terrain?.turnsLeft!),
+      new TerrainChangedEvent(
+        oldTerrainType,
+        this.terrain?.terrainType!,
+        this.terrain?.turnsLeft!,
+        this.terrain?.turnsLeft!,
+      ),
     ); // TODO: are those bangs correct?
 
     if (this.terrain) {

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -715,8 +715,8 @@ export class Arena {
       existingTag.onOverlap(this, globalScene.getPokemonById(sourceId));
 
       if (existingTag instanceof EntryHazardTag) {
-        const { tagType, side, turnCount, layers, maxLayers } = existingTag as EntryHazardTag;
-        this.eventTarget.dispatchEvent(new TagAddedEvent(tagType, side, turnCount, layers, maxLayers));
+        const { tagType, side, turnCount, maxDuration, layers, maxLayers } = existingTag as EntryHazardTag;
+        this.eventTarget.dispatchEvent(new TagAddedEvent(tagType, side, turnCount, maxDuration, layers, maxLayers));
       }
 
       return false;
@@ -731,7 +731,7 @@ export class Arena {
       const { layers = 0, maxLayers = 0 } = newTag instanceof EntryHazardTag ? newTag : {};
 
       this.eventTarget.dispatchEvent(
-        new TagAddedEvent(newTag.tagType, newTag.side, newTag.turnCount, layers, maxLayers),
+        new TagAddedEvent(newTag.tagType, newTag.side, newTag.turnCount, newTag.maxDuration, layers, maxLayers),
       );
     }
 

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -346,12 +346,7 @@ export class Arena {
 
     this.weather = weather ? new Weather(weather, weatherDuration.value, weatherDuration.value) : null;
     this.eventTarget.dispatchEvent(
-      new WeatherChangedEvent(
-        oldWeatherType,
-        this.weather?.weatherType!,
-        this.weather?.turnsLeft!,
-        this.weather?.turnsLeft!,
-      ),
+      new WeatherChangedEvent(oldWeatherType, this.weather?.weatherType!, this.weather?.turnsLeft!),
     ); // TODO: is this bang correct?
 
     if (this.weather) {
@@ -433,12 +428,7 @@ export class Arena {
     this.terrain = terrain ? new Terrain(terrain, terrainDuration.value, terrainDuration.value) : null;
 
     this.eventTarget.dispatchEvent(
-      new TerrainChangedEvent(
-        oldTerrainType,
-        this.terrain?.terrainType!,
-        this.terrain?.turnsLeft!,
-        this.terrain?.turnsLeft!,
-      ),
+      new TerrainChangedEvent(oldTerrainType, this.terrain?.terrainType!, this.terrain?.turnsLeft!),
     ); // TODO: are those bangs correct?
 
     if (this.terrain) {

--- a/src/system/arena-data.ts
+++ b/src/system/arena-data.ts
@@ -47,8 +47,12 @@ export class ArenaData {
     }
 
     this.biome = source.biome;
-    this.weather = source.weather ? new Weather(source.weather.weatherType, source.weather.turnsLeft) : null;
-    this.terrain = source.terrain ? new Terrain(source.terrain.terrainType, source.terrain.turnsLeft) : null;
+    this.weather = source.weather
+      ? new Weather(source.weather.weatherType, source.weather.turnsLeft, source.weather.maxDuration)
+      : null;
+    this.terrain = source.terrain
+      ? new Terrain(source.terrain.terrainType, source.terrain.turnsLeft, source.terrain.maxDuration)
+      : null;
     this.positionalTags = source.positionalTags ?? [];
   }
 }

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1021,6 +1021,7 @@ export class GameData {
             WeatherType.NONE,
             globalScene.arena.weather?.weatherType!,
             globalScene.arena.weather?.turnsLeft!,
+            globalScene.arena.weather?.maxDuration!,
           ),
         ); // TODO: is this bang correct?
 
@@ -1030,6 +1031,7 @@ export class GameData {
             TerrainType.NONE,
             globalScene.arena.terrain?.terrainType!,
             globalScene.arena.terrain?.turnsLeft!,
+            globalScene.arena.terrain?.maxDuration!,
           ),
         ); // TODO: is this bang correct?
 

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1041,12 +1041,14 @@ export class GameData {
         if (globalScene.arena.tags) {
           for (const tag of globalScene.arena.tags) {
             if (tag instanceof EntryHazardTag) {
-              const { tagType, side, turnCount, layers, maxLayers } = tag as EntryHazardTag;
+              const { tagType, side, turnCount, maxDuration, layers, maxLayers } = tag as EntryHazardTag;
               globalScene.arena.eventTarget.dispatchEvent(
-                new TagAddedEvent(tagType, side, turnCount, layers, maxLayers),
+                new TagAddedEvent(tagType, side, turnCount, maxDuration, layers, maxLayers),
               );
             } else {
-              globalScene.arena.eventTarget.dispatchEvent(new TagAddedEvent(tag.tagType, tag.side, tag.turnCount));
+              globalScene.arena.eventTarget.dispatchEvent(
+                new TagAddedEvent(tag.tagType, tag.side, tag.turnCount, tag.maxDuration),
+              );
             }
           }
         }

--- a/src/ui/containers/arena-flyout.ts
+++ b/src/ui/containers/arena-flyout.ts
@@ -317,7 +317,7 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
         this.fieldEffectInfo.push({
           name,
           effectType: arenaEffectType,
-          maxDuration: tagAddedEvent.duration,
+          maxDuration: tagAddedEvent.maxDuration,
           duration: tagAddedEvent.duration,
           tagType: tagAddedEvent.arenaTagType,
         });

--- a/src/ui/containers/arena-flyout.ts
+++ b/src/ui/containers/arena-flyout.ts
@@ -353,7 +353,7 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
           ),
           effectType:
             fieldEffectChangedEvent instanceof WeatherChangedEvent ? ArenaEffectType.WEATHER : ArenaEffectType.TERRAIN,
-          maxDuration: fieldEffectChangedEvent.duration,
+          maxDuration: fieldEffectChangedEvent.maxDuration,
           duration: fieldEffectChangedEvent.duration,
         };
 


### PR DESCRIPTION
## What are the changes the user will see?

After reloading the game the arena flyout will now correctly show the max duration of the effect, instead of just the remaining one.

> [!NOTE]
> For effects from already existing saves, the remaining duration will be shown. 
> The max duration is only saved for NEW effects

## Why am I making these changes?

fixes #6521

## What are the changes from a developer perspective?

- Weather, terrain and tags got an `maxDuration` property.
- The arena events also got this added and used when loading a session

## Screenshots/Videos

<details open><summary>Video</summary>

https://github.com/user-attachments/assets/8acc4426-2330-467b-a11f-92d13d061355

</details> 

## How to test the changes?

Use an ability/move that adds a weather/terrain/tag with a duration. then play the wave so the duration decreases and then reload and make sure the flyout still shows the max duration.
I mainly used these overrides to test:
```ts
const overrides = {
  ABILITY_OVERRIDE: AbilityId.DRIZZLE,
  MOVESET_OVERRIDE: MoveId.TAILWIND,
  PASSIVE_ABILITY_OVERRIDE: AbilityId.NEUTRALIZING_GAS,
  STARTING_HELD_ITEMS_OVERRIDE: [{name: "MYSTICAL_ROCK", count: 2}]
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  ~~- [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?