### PR TITLE
[Bug][Ability] Queenly Majesty flyout during move select

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2466,14 +2466,15 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
       if (!cancelledHolder.value) {
         const defendingSidePlayField = this.isPlayer() ? globalScene.getPlayerField() : globalScene.getEnemyField();
-        defendingSidePlayField.forEach(p =>
+        defendingSidePlayField.forEach((p: (typeof defendingSidePlayField)[0]) => {
           applyAbAttrs("FieldPriorityMoveImmunityAbAttr", {
             pokemon: p,
             opponent: source,
             move,
             cancelled: cancelledHolder,
-          }),
-        );
+            simulated,
+          });
+        });
       }
     }
 
@@ -2494,7 +2495,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       typeMultiplier.value = 0;
     }
 
-    return (!cancelledHolder.value ? typeMultiplier.value : 0) as TypeDamageMultiplier;
+    return (cancelledHolder.value ? 0 : typeMultiplier.value) as TypeDamageMultiplier;
   }
 
   /**


### PR DESCRIPTION
## What are the changes the user will see?
Queenly Majesty will no longer show its flyout when an affected move is selected.

## Why am I making these changes?
Fixes #6567 
## What are the changes from a developer perspective?
- Pass the `simulated` parameter to the `applyAbAttrs` that checks for `fieldPriorityImmunityAbAttr`
- Invert a condition later on to make biome happy

## Screenshots/Videos
<details><summary>Bugfix</summary>

https://github.com/user-attachments/assets/73a652f1-af56-4891-8076-6ca2aaa0ef2c
</details>

## How to test the changes?
I used these overrides

```ts
const overrides = {
  ENEMY_ABILITY_OVERRIDE: AbilityId.QUEENLY_MAJESTY,
  MOVESET_OVERRIDE: [MoveId.BULLET_PUNCH],
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes? Ehhh
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~