### PR TITLE
[Bug][Ability] Remove flyout for rivalry

### DIFF
--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -6949,7 +6949,7 @@ export function initAbilities() {
       .attr(TypeImmunityStatStageChangeAbAttr, PokemonType.ELECTRIC, Stat.SPD, 1)
       .ignorable(),
     new Ability(AbilityId.RIVALRY, 4)
-      .attr(MovePowerBoostAbAttr, (user, target, _move) => user?.gender !== Gender.GENDERLESS && target?.gender !== Gender.GENDERLESS && user?.gender === target?.gender, 1.25, true)
+      .attr(MovePowerBoostAbAttr, (user, target, _move) => user?.gender !== Gender.GENDERLESS && target?.gender !== Gender.GENDERLESS && user?.gender === target?.gender, 1.25)
       .attr(MovePowerBoostAbAttr, (user, target, _move) => user?.gender !== Gender.GENDERLESS && target?.gender !== Gender.GENDERLESS && user?.gender !== target?.gender, 0.75),
     new Ability(AbilityId.STEADFAST, 4)
       .attr(FlinchStatStageChangeAbAttr, [ Stat.SPD ], 1),


### PR DESCRIPTION
## What are the changes the user will see?
Rivalry will no longer show any flyouts when it boosts damage.

## Why am I making these changes?
This does not happen on cartridge. It's also annoying.

## What are the changes from a developer perspective?
Removed the `true` argument that was being passed to `MovePowerBoostAbAttr`.

## Screenshots/Videos


## How to test the changes?
This is what I used.
```ts
const overrides = {
  ENEMY_ABILITY_OVERRIDE: AbilityId.RIVALRY,
  ENEMY_GENDER_OVERRIDE: Gender.FEMALE,
  STARTER_SPECIES_OVERRIDE: SpeciesId.ILLUMISE,
  ENEMY_MOVESET_OVERRIDE: MoveId.FALSE_SWIPE
} satisfies Partial<InstanceType<OverridesType>>;
```
## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes? For lack of a flyout? No.
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~