### PR TITLE
[Bug][Balance] Make type boost items consider moves that have a variable type when rolling one for rewards

### DIFF
--- a/src/ai/ai-moveset-gen.ts
+++ b/src/ai/ai-moveset-gen.ts
@@ -31,6 +31,7 @@ import { Stat } from "#enums/stat";
 import type { EnemyPokemon, Pokemon } from "#field/pokemon";
 import { PokemonMove } from "#moves/pokemon-move";
 import { NumberHolder, randSeedInt } from "#utils/common";
+import { willTerastallize } from "#utils/pokemon-utils";
 import { isBeta } from "#utils/utility-vars";
 
 /**
@@ -677,12 +678,7 @@ export function generateMoveset(pokemon: Pokemon): void {
   }
 
   /** Determine whether this pokemon will instantly tera */
-  const willTera =
-    hasTrainer
-    && globalScene.currentBattle?.trainer?.config.trainerAI.instantTeras.includes(
-      // The cast to EnemyPokemon is safe; includes will just return false if the property doesn't exist
-      (pokemon as EnemyPokemon).initialTeamIndex,
-    );
+  const willTera = hasTrainer && willTerastallize(pokemon as EnemyPokemon);
 
   adjustDamageMoveWeights(movePool, pokemon, willTera);
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -107,3 +107,8 @@ export const FAKE_TITLE_LOGO_CHANCE = 10000;
  * Using rare candies will never increase friendship beyond this value.
  */
 export const RARE_CANDY_FRIENDSHIP_CAP = 200;
+
+/**
+ * The maximum number of times a player can Terastallize in a single arena run
+ */
+export const MAX_TERAS_PER_ARENA = 1;

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -95,7 +95,7 @@ import { areAllies } from "#utils/pokemon-utils";
 import { toCamelCase, toTitleCase } from "#utils/strings";
 import i18next from "i18next";
 import { MovePhaseTimingModifier } from "#enums/move-phase-timing-modifier";
-import { willTerastallize } from "#utils/pokemon-utils";
+import { canTerastallize, willTerastallize } from "#utils/pokemon-utils";
 
 /**
  * A function used to conditionally determine execution of a given {@linkcode MoveAttr}.
@@ -5538,20 +5538,15 @@ export class TeraBlastTypeAttr extends VariableMoveTypeAttr {
     const coreType = move.type;
     const teraType = user.getTeraType();
     /** Whether the user is allowed to tera. In the case of an enemy Pokémon, whether it *will* tera. */
-    const hasTeraAccess = user.isPlayer() ? globalScene.findModifier(m => m.is("TerastallizeAccessModifier")) != null : willTerastallize(user);
+    const hasTeraAccess = user.isPlayer() ? canTerastallize(user) : willTerastallize(user);
     if (
       // tera type matches the move's type; no change
-      teraType === coreType
+      !hasTeraAccess
+      || teraType === coreType
       || teraType === PokemonType.STELLAR
       || teraType === PokemonType.UNKNOWN
-      || user.isMega()
-      || user.isMax()
-      || user.hasSpecies(SpeciesId.NECROZMA, "ultra")
-      || (!hasTeraAccess)
     ) {
       return [coreType];
-    } else {
-
     }
     return [coreType, teraType];
   }

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -95,6 +95,7 @@ import { areAllies } from "#utils/pokemon-utils";
 import { toCamelCase, toTitleCase } from "#utils/strings";
 import i18next from "i18next";
 import { MovePhaseTimingModifier } from "#enums/move-phase-timing-modifier";
+import { willTerastallize } from "#utils/pokemon-utils";
 
 /**
  * A function used to conditionally determine execution of a given {@linkcode MoveAttr}.
@@ -5531,6 +5532,28 @@ export class TeraBlastTypeAttr extends VariableMoveTypeAttr {
     }
 
     return false;
+  }
+
+  override getTypesForItemSpawn(user: Pokemon, move: Move): PokemonType[] {
+    const coreType = move.type;
+    const teraType = user.getTeraType();
+    /** Whether the user is allowed to tera. In the case of an enemy Pokémon, whether it *will* tera. */
+    const hasTeraAccess = user.isPlayer() ? globalScene.findModifier(m => m.is("TerastallizeAccessModifier")) != null : willTerastallize(user);
+    if (
+      // tera type matches the move's type; no change
+      teraType === coreType
+      || teraType === PokemonType.STELLAR
+      || teraType === PokemonType.UNKNOWN
+      || user.isMega()
+      || user.isMax()
+      || user.hasSpecies(SpeciesId.NECROZMA, "ultra")
+      || (!hasTeraAccess)
+    ) {
+      return [coreType];
+    } else {
+
+    }
+    return [coreType, teraType];
   }
 }
 

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -95,7 +95,7 @@ import { areAllies } from "#utils/pokemon-utils";
 import { toCamelCase, toTitleCase } from "#utils/strings";
 import i18next from "i18next";
 import { MovePhaseTimingModifier } from "#enums/move-phase-timing-modifier";
-import { canTerastallize, willTerastallize } from "#utils/pokemon-utils";
+import { canSpeciesTera, willTerastallize } from "#utils/pokemon-utils";
 
 /**
  * A function used to conditionally determine execution of a given {@linkcode MoveAttr}.
@@ -5538,7 +5538,7 @@ export class TeraBlastTypeAttr extends VariableMoveTypeAttr {
     const coreType = move.type;
     const teraType = user.getTeraType();
     /** Whether the user is allowed to tera. In the case of an enemy Pokémon, whether it *will* tera. */
-    const hasTeraAccess = user.isPlayer() ? canTerastallize(user) : willTerastallize(user);
+    const hasTeraAccess = user.isPlayer() ? canSpeciesTera(user) : willTerastallize(user);
     if (
       // tera type matches the move's type; no change
       !hasTeraAccess

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1302,13 +1302,12 @@ class AttackTypeBoosterModifierTypeGenerator extends ModifierTypeGenerator {
           // Account for variable type changing moves
           // Get a variable type attribute of the move
           const variableTypeAttr = move.getAttrs("VariableMoveTypeAttr")[0];
-          if (variableTypeAttr != null) {
-            for (const type of variableTypeAttr.getTypesForItemSpawn(p, move)) {
-              const currentWeight = attackMoveTypeWeights.get(type) ?? 0;
-              if (currentWeight < 3) {
-                attackMoveTypeWeights.set(type, currentWeight + 1);
-                totalWeight++;
-              }
+          const types = variableTypeAttr != null ? variableTypeAttr.getTypesForItemSpawn(p, move) : [move.type];
+          for (const type of types) {
+            const currentWeight = attackMoveTypeWeights.get(type) ?? 0;
+            if (currentWeight < 3) {
+              attackMoveTypeWeights.set(type, currentWeight + 1);
+              totalWeight++;
             }
           }
         }

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1288,52 +1288,47 @@ class AttackTypeBoosterModifierTypeGenerator extends ModifierTypeGenerator {
         return new AttackTypeBoosterModifierType(pregenArgs[0] as PokemonType, TYPE_BOOST_ITEM_BOOST_PERCENT);
       }
 
-      const attackMoveTypes = party.flatMap(p =>
-        p
-          .getMoveset()
-          .map(m => m.getMove())
-          .filter(m => m.is("AttackMove"))
-          .map(m => m.type),
-      );
-      if (attackMoveTypes.length === 0) {
-        return null;
-      }
-
       const attackMoveTypeWeights = new Map<PokemonType, number>();
       let totalWeight = 0;
-      for (const t of attackMoveTypes) {
-        if (attackMoveTypeWeights.has(t)) {
-          if (attackMoveTypeWeights.get(t)! < 3) {
-            // attackMoveTypeWeights.has(t) was checked before
-            attackMoveTypeWeights.set(t, attackMoveTypeWeights.get(t)! + 1);
-          } else {
+      for (const p of party) {
+        if (!p.isAllowedInChallenge()) {
+          continue;
+        }
+        for (const pokemonMove of p.getMoveset()) {
+          const move = pokemonMove.getMove();
+          if (!move.is("AttackMove")) {
             continue;
           }
-        } else {
-          attackMoveTypeWeights.set(t, 1);
+          // Account for variable type changing moves
+          // Get a variable type attribute of the move
+          const variableTypeAttr = move.getAttrs("VariableMoveTypeAttr")[0];
+          if (variableTypeAttr != null) {
+            for (const type of variableTypeAttr.getTypesForItemSpawn(p, move)) {
+              const currentWeight = attackMoveTypeWeights.get(type) ?? 0;
+              if (currentWeight < 3) {
+                attackMoveTypeWeights.set(type, currentWeight + 1);
+                totalWeight++;
+              }
+            }
+          }
         }
-        totalWeight++;
       }
 
-      if (!totalWeight) {
+      if (attackMoveTypeWeights.size === 0) {
         return null;
       }
-
-      let type: PokemonType;
 
       const randInt = randSeedInt(totalWeight);
       let weight = 0;
 
-      for (const t of attackMoveTypeWeights.keys()) {
-        const typeWeight = attackMoveTypeWeights.get(t)!; // guranteed to be defined
+      for (const [type, typeWeight] of attackMoveTypeWeights.entries()) {
         if (randInt <= weight + typeWeight) {
-          type = t;
-          break;
+          return new AttackTypeBoosterModifierType(type, TYPE_BOOST_ITEM_BOOST_PERCENT);
         }
         weight += typeWeight;
       }
 
-      return new AttackTypeBoosterModifierType(type!, TYPE_BOOST_ITEM_BOOST_PERCENT);
+      return null;
     });
   }
 }

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1302,8 +1302,9 @@ class AttackTypeBoosterModifierTypeGenerator extends ModifierTypeGenerator {
           // Account for variable type changing moves
           // Get a variable type attribute of the move
           const variableTypeAttr = move.getAttrs("VariableMoveTypeAttr")[0];
-          const types = variableTypeAttr != null ? variableTypeAttr.getTypesForItemSpawn(p, move) : [move.type];
+          const types = variableTypeAttr?.getTypesForItemSpawn(p, move) ?? [move.type];
           for (const type of types) {
+            console.info("%cConsidering type " + PokemonType[type], "color: orange");
             const currentWeight = attackMoveTypeWeights.get(type) ?? 0;
             if (currentWeight < 3) {
               attackMoveTypeWeights.set(type, currentWeight + 1);
@@ -1318,10 +1319,12 @@ class AttackTypeBoosterModifierTypeGenerator extends ModifierTypeGenerator {
       }
 
       const randInt = randSeedInt(totalWeight);
+      console.log("%cTotal weight " + totalWeight + ", rolled " + randInt, "color: orange");
       let weight = 0;
 
       for (const [type, typeWeight] of attackMoveTypeWeights.entries()) {
-        if (randInt <= weight + typeWeight) {
+        console.log("%cWeighted type " + PokemonType[type] + " with weight " + typeWeight, "color: orange");
+        if (randInt < weight + typeWeight) {
           return new AttackTypeBoosterModifierType(type, TYPE_BOOST_ITEM_BOOST_PERCENT);
         }
         weight += typeWeight;

--- a/src/ui/handlers/command-ui-handler.ts
+++ b/src/ui/handlers/command-ui-handler.ts
@@ -1,3 +1,4 @@
+import { MAX_TERAS_PER_ARENA } from "#app/constants";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { getTypeRgb } from "#data/type";
@@ -198,9 +199,12 @@ export class CommandUiHandler extends UiHandler {
 
   canTera(): boolean {
     const activePokemon = globalScene.getField()[this.fieldIndex];
+    const currentTeras = globalScene.arena.playerTerasUsed;
     const canTera = activePokemon.isPlayer() && canTerastallize(activePokemon);
-    const plannedTera = globalScene.currentBattle.preTurnCommands[0]?.command === Command.TERA && this.fieldIndex > 0;
-    return canTera && !plannedTera;
+    const plannedTera = +(
+      globalScene.currentBattle.preTurnCommands[0]?.command === Command.TERA && this.fieldIndex > 0
+    );
+    return canTera && currentTeras + plannedTera < MAX_TERAS_PER_ARENA;
   }
 
   toggleTeraButton() {

--- a/src/ui/handlers/command-ui-handler.ts
+++ b/src/ui/handlers/command-ui-handler.ts
@@ -4,14 +4,13 @@ import { getTypeRgb } from "#data/type";
 import { Button } from "#enums/buttons";
 import { Command } from "#enums/command";
 import { PokemonType } from "#enums/pokemon-type";
-import { SpeciesId } from "#enums/species-id";
 import { TextStyle } from "#enums/text-style";
 import { UiMode } from "#enums/ui-mode";
-import { TerastallizeAccessModifier } from "#modifiers/modifier";
 import type { CommandPhase } from "#phases/command-phase";
 import { PartyUiHandler, PartyUiMode } from "#ui/party-ui-handler";
 import { addTextObject } from "#ui/text";
 import { UiHandler } from "#ui/ui-handler";
+import { canTerastallize } from "#utils/pokemon-utils";
 import i18next from "i18next";
 
 export class CommandUiHandler extends UiHandler {
@@ -198,14 +197,10 @@ export class CommandUiHandler extends UiHandler {
   }
 
   canTera(): boolean {
-    const hasTeraMod = globalScene.getModifiers(TerastallizeAccessModifier).length > 0;
     const activePokemon = globalScene.getField()[this.fieldIndex];
-    const isBlockedForm =
-      activePokemon.isMega() || activePokemon.isMax() || activePokemon.hasSpecies(SpeciesId.NECROZMA, "ultra");
-    const currentTeras = globalScene.arena.playerTerasUsed;
-    const plannedTera =
-      globalScene.currentBattle.preTurnCommands[0]?.command === Command.TERA && this.fieldIndex > 0 ? 1 : 0;
-    return hasTeraMod && !isBlockedForm && currentTeras + plannedTera < 1;
+    const canTera = activePokemon.isPlayer() && canTerastallize(activePokemon);
+    const plannedTera = globalScene.currentBattle.preTurnCommands[0]?.command === Command.TERA && this.fieldIndex > 0;
+    return canTera && !plannedTera;
   }
 
   toggleTeraButton() {

--- a/src/utils/pokemon-utils.ts
+++ b/src/utils/pokemon-utils.ts
@@ -181,7 +181,10 @@ export function canSpeciesTera(pokemon: Pokemon): boolean {
 }
 
 /**
- * Same as {@linkcode canSpeciesTera}, but also checks that the player has not already used their tera in the arena
+ * Same as {@linkcode canSpeciesTera}, but also checks that the player has not already used their tera in the arena.
+ *
+ * @remarks
+ * ⚠️ This does not account for tera commands that may be pending, so this should not be used during command selection!
  * @param pokemon - The Pokémon to check
  * @returns Whether the Pokémon can Terastallize
  */

--- a/src/utils/pokemon-utils.ts
+++ b/src/utils/pokemon-utils.ts
@@ -1,3 +1,4 @@
+import { MAX_TERAS_PER_ARENA } from "#app/constants";
 import { globalScene } from "#app/global-scene";
 import { POKERUS_STARTER_COUNT, speciesStarterCosts } from "#balance/starters";
 import { allSpecies } from "#data/data-lists";
@@ -155,7 +156,7 @@ export function areAllies(a: BattlerIndex, b: BattlerIndex): boolean {
  * Should really only be called with an enemy Pokémon, but will technically work with any Pokémon.
  *
  * @privateRemarks
- * Assumes that Pokémon with no trainer ever tera, so this must be changed if
+ * Assumes that Pokémon without a trainer will never tera, so this must be changed if
  * a wild Pokémon is allowed to tera, e.g. for a Mystery Encounter.
  */
 export function willTerastallize(pokemon: Pokemon): boolean {
@@ -169,13 +170,22 @@ export function willTerastallize(pokemon: Pokemon): boolean {
 }
 
 /**
- * Determine whether a player Pokémon can Terastallize
+ * Determine whether the Pokémon's species is tera capable, and that the player has acquired the tera orb.
+ * @param pokemon - The Pokémon to check
+ * @returns Whether
+ */
+export function canSpeciesTera(pokemon: Pokemon): boolean {
+  const hasTeraMod = globalScene.findModifier(modifier => modifier.is("TerastallizeAccessModifier")) != null;
+  const isBlockedForm = pokemon.isMega() || pokemon.isMax() || pokemon.hasSpecies(SpeciesId.NECROZMA, "ultra");
+  return hasTeraMod && !isBlockedForm;
+}
+
+/**
+ * Same as {@linkcode canSpeciesTera}, but also checks that the player has not already used their tera in the arena
  * @param pokemon - The Pokémon to check
  * @returns Whether the Pokémon can Terastallize
  */
 export function canTerastallize(pokemon: PlayerPokemon): boolean {
-  const hasTeraMod = globalScene.findModifier(modifier => modifier.is("TerastallizeAccessModifier")) != null;
-  const isBlockedForm = pokemon.isMega() || pokemon.isMax() || pokemon.hasSpecies(SpeciesId.NECROZMA, "ultra");
-  const currentTeras = globalScene.arena.playerTerasUsed === 0;
-  return hasTeraMod && !isBlockedForm && currentTeras;
+  const hasAvailableTeras = globalScene.arena.playerTerasUsed < MAX_TERAS_PER_ARENA;
+  return hasAvailableTeras && canSpeciesTera(pokemon);
 }


### PR DESCRIPTION
## What are the changes the user will see?
Moves with dynamic types whose type change is intrinsic to the move and its user will now resolve to that type for the purposes of determining which type boosting item to spawn
Notably, this impacts these moves:
- Revelation Dance
  - Same type as revelation dance would be when considering the user's real types (e.g. not a temporary one from Protean)
- Hidden Power
- Aura Wheel on Morpeko (will always allow both blackglasses and magnet)
- Techno Blast on Genesect - type of its current form instead of always normal. Normal on other mons
- Ivy Cudgel on Ogerpon
- Raging Bull on Paldean Tauros
- Judgement on Arceus
- Multi Attack on Silvally
- Tera Blast, allows both Tera Type and normal
  - Will only consider tera type on mons that are allowed to Terastallize
  - Player must have Tera Orb


As an additional QoL, Pokémon that are not allowed to be used in the challenge will no longer have their moves considered when rolling for type boosting items.

Also fixed an off-by-one bug related to the RNG used to pick a random attack type boost item.

## Why am I making these changes?
I asked players what bugs / annoyances they found.

Also, I asked balance about Tera Blast. And I asked some users.

<img width="649" height="76" alt="image" src="https://github.com/user-attachments/assets/80b8f81c-f0a2-48f0-8c55-2aacaa59c47c" />

<img width="819" height="78" alt="image" src="https://github.com/user-attachments/assets/f9ea4763-f7ec-4fce-859f-063e2e18765c" />

[source](https://discord.com/channels/1125469663833370665/1225619031156064317/1418955780756865124)




## What are the changes from a developer perspective?
Added a new method to `VariableMoveTypeAttr` called `getTypesForItemSpawn` that returns an array of `PokemonTypes` that the move with the attribute should allow when rolling for type boosting items.
By default, the method will return the move's type (same behavior as before). However, it can (and should) be overridden by subclasses where the move's type is mostly static (like revelation dance).
I special cased Aura Wheel on Morpeko, as well, for additional QoL.

## Screenshots/Videos
<details><summary>Arceus</summary>

https://github.com/user-attachments/assets/eed47b00-7d9e-44f2-bffe-595629c00370

https://github.com/user-attachments/assets/f14c99e7-adbb-45a9-80f3-8d98a746031d
</details> 

<details><summary>Silvally</summary>

https://github.com/user-attachments/assets/98814a86-a5e0-42fa-a0da-f0986c9dfe8c
</details> 

<details><summary>Tera Blast</summary>

https://github.com/user-attachments/assets/7a8303ed-0f3f-49e2-91e6-2bd792fbcf30
</details> 

## How to test the changes?

Use the overrides below, changing the first move override and the species ID.
I threw in status moves to ensure that it doesn't consider other moves in the moveslots.

E.g. for Arceus:
```ts
const overrides = {
  ITEM_REWARD_OVERRIDE: [
    { name: "ATTACK_TYPE_BOOSTER"},
    { name: "FORM_CHANGE_ITEM"},
  ],
  STARTER_SPECIES_OVERRIDE: SpeciesId.ARCEUS,
  MOVESET_OVERRIDE: [MoveId.JUDGMENT, MoveId.GROWL, MoveId.TAIL_WHIP, MoveId.DEFENSE_CURL],
  ENEMY_ABILITY_OVERRIDE: AbilityId.BALL_FETCH,
  ENEMY_MOVESET_OVERRIDE: [MoveId.SPLASH],
  ENEMY_LEVEL_OVERRIDE: 1,
} satisfies Partial<InstanceType<OverridesType>>;
```
See the "what changes will the user see" section for the rest.


For Tera Blast:
```ts
const overrides = {
  STARTING_MODIFIER_OVERRIDE: [
    { name: "TERA_ORB"}
  ],
  ITEM_REWARD_OVERRIDE: [
    { name: "ATTACK_TYPE_BOOSTER"},
  ],
  MOVESET_OVERRIDE: [MoveId.TERA_BLAST, MoveId.GROWL, MoveId.TAIL_WHIP, MoveId.DEFENSE_CURL],
  ENEMY_ABILITY_OVERRIDE: AbilityId.BALL_FETCH,
  ENEMY_SPECIES_OVERRIDE: SpeciesId.MAGIKARP,
  ENEMY_MOVESET_OVERRIDE: [MoveId.SPLASH],
  ENEMY_LEVEL_OVERRIDE: 1,
} satisfies Partial<InstanceType<OverridesType>>;
```

Might need to do a few waves for the tera blast test to see it allowing both items.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes? No, not until item rework
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~