### PR TITLE
[UI] Avoid prematurely updating HP bar when applying damage

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3942,11 +3942,6 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       damage = 0;
     }
     damage = this.damage(damage, ignoreSegments, isIndirectDamage, ignoreFaintPhase);
-    // Ensure the battle-info bar's HP is updated, though only if the battle info is visible
-    // TODO: When battle-info UI is refactored, make this only update the HP bar
-    if (this.battleInfo.visible) {
-      this.updateInfo();
-    }
     // Damage amount may have changed, but needed to be queued before calling damage function
     damagePhase.updateAmount(damage);
     /**


### PR DESCRIPTION
## What are the changes the user will see?
The HP bar will update synchronously with the damage animation instead of immediately

## Why am I making these changes?
Self explanatory probably

## What are the changes from a developer perspective?
`updateInfo()` is called in the `DamageAnimPhase` already, so the call in `damageAndUpdate` is removed.

## Screenshots/Videos
<details><summary>Before</summary>
<p>

https://github.com/user-attachments/assets/821200ed-81f5-40cd-8b83-9a675b12a308

</p>
</details> 

<details><summary>After</summary>
<p>

https://github.com/user-attachments/assets/ee37c04e-e573-49fd-9ce9-8e406dfa12aa

</p>
</details> 

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?