### PR TITLE
[Misc] Blacklist more dynamic phases

### DIFF
--- a/src/dynamic-queue-manager.ts
+++ b/src/dynamic-queue-manager.ts
@@ -23,6 +23,11 @@ const nonDynamicPokemonPhases: readonly PhaseString[] = [
   "VictoryPhase",
   "PokemonHealPhase",
   "WeatherEffectPhase",
+  "ShowAbilityPhase",
+  "HideAbilityPhase",
+  "ExpPhase",
+  "ShowPartyExpBarPhase",
+  "HidePartyExpBarPhase",
 ] as const;
 
 /**


### PR DESCRIPTION
## What are the changes the user will see?
Exp phases are no longer ordered by speed, no crash with `ShowAbilityPhase`s being queued after the turn (need to figure out why this is happening in the first place)

## Why am I making these changes?
Parity

## What are the changes from a developer perspective?
Add to array

## How to test the changes?
Run tests
## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?