### PR TITLE
[Bug] Fix `CheckSwitchPhase` not appearing on new wave

### DIFF
--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -583,18 +583,22 @@ export class EncounterPhase extends BattlePhase {
       const phaseManager = globalScene.phaseManager;
       if (!availablePartyMembers[0].isOnField()) {
         phaseManager.pushNew("SummonPhase", 0, true, false, checkSwitch);
+      } else if (checkSwitch) {
+        globalScene.phaseManager.pushNew("CheckSwitchPhase", 0, globalScene.currentBattle.double);
       }
 
       if (currentBattle.double) {
         if (availablePartyMembers.length > 1) {
           phaseManager.pushNew("ToggleDoublePositionPhase", true);
           if (!availablePartyMembers[1].isOnField()) {
-            phaseManager.pushNew("SummonPhase", 1, true, false, checkSwitch);
+            phaseManager.pushNew("SummonPhase", 1);
+          } else if (checkSwitch) {
+            globalScene.phaseManager.pushNew("CheckSwitchPhase", 1, globalScene.currentBattle.double);
           }
         }
       } else {
         if (availablePartyMembers.length > 1 && availablePartyMembers[1].isOnField()) {
-          globalScene.phaseManager.pushNew("ReturnPhase", 1);
+          phaseManager.pushNew("ReturnPhase", 1);
         }
         phaseManager.pushNew("ToggleDoublePositionPhase", false);
       }

--- a/src/phases/mystery-encounter-phases.ts
+++ b/src/phases/mystery-encounter-phases.ts
@@ -417,6 +417,8 @@ export class MysteryEncounterBattlePhase extends Phase {
 
     if (!availablePartyMembers[0].isOnField()) {
       globalScene.phaseManager.pushNew("SummonPhase", 0, true, false, checkSwitch);
+    } else if (checkSwitch) {
+      globalScene.phaseManager.pushNew("CheckSwitchPhase", 0, globalScene.currentBattle.double);
     }
 
     if (globalScene.currentBattle.double) {
@@ -424,6 +426,8 @@ export class MysteryEncounterBattlePhase extends Phase {
         globalScene.phaseManager.pushNew("ToggleDoublePositionPhase", true);
         if (!availablePartyMembers[1].isOnField()) {
           globalScene.phaseManager.pushNew("SummonPhase", 1, true, false, checkSwitch);
+        } else if (checkSwitch) {
+          globalScene.phaseManager.pushNew("CheckSwitchPhase", 0, globalScene.currentBattle.double);
         }
       }
     } else {
@@ -432,6 +436,16 @@ export class MysteryEncounterBattlePhase extends Phase {
         globalScene.phaseManager.pushNew("ReturnPhase", 1);
       }
       globalScene.phaseManager.pushNew("ToggleDoublePositionPhase", false);
+    }
+
+    if (encounterMode !== MysteryEncounterMode.TRAINER_BATTLE && !this.disableSwitch) {
+      const minPartySize = globalScene.currentBattle.double ? 2 : 1;
+      if (availablePartyMembers.length > minPartySize) {
+        globalScene.phaseManager.pushNew("CheckSwitchPhase", 0, globalScene.currentBattle.double);
+        if (globalScene.currentBattle.double) {
+          globalScene.phaseManager.pushNew("CheckSwitchPhase", 1, globalScene.currentBattle.double);
+        }
+      }
     }
 
     this.end();


### PR DESCRIPTION
## What are the changes the user will see?
Switch prompt will appear on new waves as well as after summon

## Why am I making these changes?
Fixing a bug I introduced with dynamic order

## What are the changes from a developer perspective?
Simple code change, I had originally just neglected to account for the case that the pokemon is already on the field

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?
Beat a wave on switch mode and ensure the prompt appears

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?
