### PR TITLE
[Bug] Fix `CheckSwitchPhase` on single -> double and reload

### DIFF
--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -579,21 +579,22 @@ export class EncounterPhase extends BattlePhase {
         currentBattle.battleType !== BattleType.TRAINER
         && (currentBattle.waveIndex > 1 || !globalScene.gameMode.isDaily)
         && availablePartyMembers.length > minPartySize;
+      const checkSwitchIndices: number[] = [];
 
       const phaseManager = globalScene.phaseManager;
       if (!availablePartyMembers[0].isOnField()) {
         phaseManager.pushNew("SummonPhase", 0, true, false, checkSwitch);
       } else if (checkSwitch) {
-        globalScene.phaseManager.pushNew("CheckSwitchPhase", 0, globalScene.currentBattle.double);
+        checkSwitchIndices.push(0);
       }
 
       if (currentBattle.double) {
         if (availablePartyMembers.length > 1) {
           phaseManager.pushNew("ToggleDoublePositionPhase", true);
           if (!availablePartyMembers[1].isOnField()) {
-            phaseManager.pushNew("SummonPhase", 1);
+            phaseManager.pushNew("SummonPhase", 1, true, false, checkSwitch);
           } else if (checkSwitch) {
-            globalScene.phaseManager.pushNew("CheckSwitchPhase", 1, globalScene.currentBattle.double);
+            checkSwitchIndices.push(1);
           }
         }
       } else {
@@ -602,6 +603,9 @@ export class EncounterPhase extends BattlePhase {
         }
         phaseManager.pushNew("ToggleDoublePositionPhase", false);
       }
+      checkSwitchIndices.forEach(i => {
+        phaseManager.pushNew("CheckSwitchPhase", i, globalScene.currentBattle.double);
+      });
     }
     handleTutorial(Tutorial.Access_Menu).then(() => super.end());
   }

--- a/src/phases/mystery-encounter-phases.ts
+++ b/src/phases/mystery-encounter-phases.ts
@@ -414,11 +414,12 @@ export class MysteryEncounterBattlePhase extends Phase {
       encounterMode !== MysteryEncounterMode.TRAINER_BATTLE
       && !this.disableSwitch
       && availablePartyMembers.length > minPartySize;
+    const checkSwitchIndices: number[] = [];
 
     if (!availablePartyMembers[0].isOnField()) {
       globalScene.phaseManager.pushNew("SummonPhase", 0, true, false, checkSwitch);
     } else if (checkSwitch) {
-      globalScene.phaseManager.pushNew("CheckSwitchPhase", 0, globalScene.currentBattle.double);
+      checkSwitchIndices.push(0);
     }
 
     if (globalScene.currentBattle.double) {
@@ -427,7 +428,7 @@ export class MysteryEncounterBattlePhase extends Phase {
         if (!availablePartyMembers[1].isOnField()) {
           globalScene.phaseManager.pushNew("SummonPhase", 1, true, false, checkSwitch);
         } else if (checkSwitch) {
-          globalScene.phaseManager.pushNew("CheckSwitchPhase", 0, globalScene.currentBattle.double);
+          checkSwitchIndices.push(1);
         }
       }
     } else {
@@ -438,16 +439,9 @@ export class MysteryEncounterBattlePhase extends Phase {
       globalScene.phaseManager.pushNew("ToggleDoublePositionPhase", false);
     }
 
-    if (encounterMode !== MysteryEncounterMode.TRAINER_BATTLE && !this.disableSwitch) {
-      const minPartySize = globalScene.currentBattle.double ? 2 : 1;
-      if (availablePartyMembers.length > minPartySize) {
-        globalScene.phaseManager.pushNew("CheckSwitchPhase", 0, globalScene.currentBattle.double);
-        if (globalScene.currentBattle.double) {
-          globalScene.phaseManager.pushNew("CheckSwitchPhase", 1, globalScene.currentBattle.double);
-        }
-      }
-    }
-
+    checkSwitchIndices.forEach(i => {
+      globalScene.phaseManager.pushNew("CheckSwitchPhase", i, globalScene.currentBattle.double);
+    });
     this.end();
   }
 

--- a/src/phases/summon-phase.ts
+++ b/src/phases/summon-phase.ts
@@ -279,6 +279,14 @@ export class SummonPhase extends PartyMemberPokemonPhase {
 
     pokemon.resetTurnData();
 
+    if (this.checkSwitch) {
+      globalScene.phaseManager.pushNew(
+        "CheckSwitchPhase",
+        this.getPokemon().getFieldIndex(),
+        globalScene.currentBattle.double,
+      );
+    }
+
     if (
       !this.loaded
       || [BattleType.TRAINER, BattleType.MYSTERY_ENCOUNTER].includes(globalScene.currentBattle.battleType)
@@ -290,13 +298,7 @@ export class SummonPhase extends PartyMemberPokemonPhase {
   }
 
   queuePostSummon(): void {
-    if (this.checkSwitch) {
-      globalScene.phaseManager.pushNew(
-        "CheckSwitchPhase",
-        this.getPokemon().getFieldIndex(),
-        globalScene.currentBattle.double,
-      );
-    } else {
+    if (!this.checkSwitch) {
       globalScene.phaseManager.pushNew("PostSummonPhase", this.getPokemon().getBattlerIndex(), this.phaseName);
     }
 


### PR DESCRIPTION
## What are the changes the user will see?
`CheckSwitchPhase` correctly appears on single -> double and reload.

## Why am I making these changes?
I made a couple pretty silly mistakes in #6591 because I did it late at night after coming home from school lol

## What are the changes from a developer perspective?
`CheckSwitchPhases` are pushed after both `SummonPhase`s. This uses an array of indices so it's not necessary to check the conditions multiple times.

I also moved the logic of adding the `CheckSwitchPhase` from `SummonPhase` to a bit earlier - there was some logic blocking the call to `queuePostSummon` that I didn't look at.

## How to test the changes?
```ts
const overrides = {
  STARTING_LEVEL_OVERRIDE: 100,
  BATTLE_STYLE_OVERRIDE: "even-doubles",
  ABILITY_OVERRIDE: AbilityId.INTIMIDATE,
  PASSIVE_ABILITY_OVERRIDE: AbilityId.INTREPID_SWORD
} satisfies Partial<InstanceType<OverridesType>>;
```
Kill some mons and make sure the switch prompts and ability activations are good

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?
