### PR TITLE
[Balance] Adjust evolution delay requirements

### DIFF
--- a/src/@types/species-gen-types.ts
+++ b/src/@types/species-gen-types.ts
@@ -1,0 +1,25 @@
+// biome-ignore lint/correctness/noUnusedImports: Used in TSDoc comment
+import type { EvoLevelThresholdSort } from "#enums/evo-level-threshold-kind";
+import type { SpeciesId } from "#enums/species-id";
+
+/**
+ * A tuple representing level thresholds for evolution based on encounter type.
+ * - `strong`: The evo level for, say, a Gym Leader or Evil Admin, etc.
+ * - `normal`: The evo level for a regular Trainer with average strength
+ * - `wild`: The evo level for wild encounters
+ *
+ * @see {@linkcode EvoLevelThresholdSort}
+ */
+export type EvoLevelThreshold = [strong: number, normal: number, wild: number];
+
+/**
+ * Pokemon Evolution tuple type consisting of:
+ * - `species`: The species of the Pokemon.
+ * - `level`: The level at which the Pokemon evolves.
+ */
+export type EvolutionLevel = [species: SpeciesId, level: number];
+
+/**
+ * {@inheritdoc EvolutionLevel}
+ */
+export type EvolutionLevelWithThreshold = [species: SpeciesId, level: number, evoLevelThreshold?: EvoLevelThreshold];

--- a/src/@types/species-gen-types.ts
+++ b/src/@types/species-gen-types.ts
@@ -1,5 +1,5 @@
 // biome-ignore lint/correctness/noUnusedImports: Used in TSDoc comment
-import type { EvoLevelThresholdSort } from "#enums/evo-level-threshold-kind";
+import type { EvoLevelThresholdKind } from "#enums/evo-level-threshold-kind";
 import type { SpeciesId } from "#enums/species-id";
 
 /**
@@ -8,7 +8,7 @@ import type { SpeciesId } from "#enums/species-id";
  * - `normal`: The evo level for a regular Trainer with average strength
  * - `wild`: The evo level for wild encounters
  *
- * @see {@linkcode EvoLevelThresholdSort}
+ * @see {@linkcode EvoLevelThresholdKind}
  */
 export type EvoLevelThreshold = [strong: number, normal: number, wild: number];
 

--- a/src/ai/ai-species-gen.ts
+++ b/src/ai/ai-species-gen.ts
@@ -7,6 +7,7 @@ import { EvoLevelThresholdKind } from "#enums/evo-level-threshold-kind";
 import { PartyMemberStrength } from "#enums/party-member-strength";
 import type { SpeciesId } from "#enums/species-id";
 import { randSeedInt, randSeedItem } from "#utils/common";
+import { getPokemonSpecies } from "#utils/pokemon-utils";
 
 /**
  * Controls the maximum level difference that a Pokémon spawned with
@@ -192,7 +193,15 @@ export function determineEnemySpecies(
   const randomLevel = randSeedInt(choice, Math.round(choice * multiplier));
   console.info("%c Random level is %d", "color: blue", randomLevel);
   if (randomLevel <= level) {
-    return determineEnemySpecies(allSpecies[evoSpecies - 1], level, true, forTrainer, strength, encounterKind, false);
+    return determineEnemySpecies(
+      getPokemonSpecies(evoSpecies),
+      level,
+      true,
+      forTrainer,
+      strength,
+      encounterKind,
+      false,
+    );
   }
   return species.speciesId;
 }

--- a/src/ai/ai-species-gen.ts
+++ b/src/ai/ai-species-gen.ts
@@ -1,0 +1,170 @@
+import { globalScene } from "#app/global-scene";
+import type { SpeciesFormEvolution } from "#balance/pokemon-evolutions";
+import { pokemonEvolutions, pokemonPrevolutions } from "#balance/pokemon-evolutions";
+import { allSpecies } from "#data/data-lists";
+import type { PokemonSpecies } from "#data/pokemon-species";
+import { EvoLevelThresholdSort } from "#enums/evo-level-threshold-kind";
+import { PartyMemberStrength } from "#enums/party-member-strength";
+import type { SpeciesId } from "#enums/species-id";
+import { randSeedInt, randSeedItem } from "#utils/common";
+
+/**
+ * Controls the maximum level difference that a Pokémon spawned with
+ * {@linkcode EvoLevelThresholdSort.NORMAL} is allowd to remain unevolved.
+ */
+const NORMAL_TRAINER_LEVEL_DIFF_PERCENT = 0.1;
+/**
+ * Controls the maximum level difference that a Pokémon spawned with
+ * {@linkcode EvoLevelThresholdSort.WILD} is allowd to remain unevolved.
+ */
+const WILD_LEVEL_DIFF_PERCENT = 0.2;
+/**
+ * Controls the maximum level difference that a Pokémon spawned with
+ * {@linkcode EvoLevelThresholdSort.} is allowd to remain unevolved.
+ */
+const STRONG_LEVEL_DIFF_PERCENT = 0;
+
+/**
+ * Get the evolution threshold for the given evolution, or `0` for ineligible
+ * @param ev - The evolution to consider
+ * @param level - The level of the Pokémon
+ * @param evolutionPool - The pool of evolutions to add to
+ * @returns The level threshold required for the evolution, or `0` if not eligible
+ */
+function calcEvoChance(ev: SpeciesFormEvolution, level: number, encounterKind: EvoLevelThresholdSort): number {
+  /** The level requirement based on the trainer type */
+  const levelThreshold = Math.max(ev.level, ev.evoLevelThreshold?.[encounterKind] ?? 0);
+  // Disallow evolution if the level is below its required threshold.
+  if (level < ev.level || level < levelThreshold) {
+    return 0;
+  }
+  return levelThreshold;
+}
+
+/**
+ * If the Pokémon is below the required level threshold for its species, return the
+ * first pre-evolution that meets the level requirement.
+ * @param species - The species to consider
+ * @param level - The level the Pokémon will be
+ * @param encounterKind - The kind of evolution threshold to use
+ * @returns The speciesId of the forced prevolution, or `null` if none is required.
+ *
+ * @remarks
+ * Forced prevolutions do *not* apply the randomness factor. That is, if the
+ * Pokémon evolves multiple times and its level is currently near (but above)
+ * the level requirement for its stage 2, it will always return the stage 2
+ * evolution. For example, if the provided species is Venusaur, but the spawn
+ * level is level 17 (bulbasaur evolves at 16), then it will *always* return
+ * Ivysaur with *no* chance for Bulbasaur.
+ *
+ * @privateRemarks
+ * The above limitation can be overcome, though requires more complex logic.
+ *
+ */
+function getRequiredPrevo(
+  species: PokemonSpecies,
+  level: number,
+  encounterKind: EvoLevelThresholdSort,
+): SpeciesId | null {
+  // Get the prevolution levels for this species.
+  const prevolutionLevels = species.getPrevolutionLevels(true);
+
+  // Return the base species if it's below the prevolution level threshold
+  // Go in reverse order to go from earlier in evolution line to later
+  // NOTE: This will *not* apply the randomness factor.
+  for (let pl = prevolutionLevels.length - 1; pl >= 0; pl--) {
+    const [prevoSpecies, levelReq, evoThreshold] = prevolutionLevels[pl];
+    const threshold = evoThreshold?.[encounterKind] ?? 0;
+    const req = levelReq === 1 ? threshold : Math.min(levelReq, threshold);
+    if (level < req) {
+      return prevoSpecies;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Determine the species of an enemy Pokémon, based on various factors.
+ *
+ * @param species - The species to consider
+ * @param level - The level the Pokémon will be
+ * @param allowEvolving - Whether to allow evolution; default `false`
+ * @param forTrainer - Whether the Pokémon is for a trainer; default `false`
+ * @param strength - The strength of the party member; default {@linkcode PartyMemberStrength.WEAKER | Weaker}
+ * @param encounterKind - The kind of evolution threshold to use; default {@linkcode EvoLevelThresholdSort.NORMAL | Normal} for trainers, {@linkcode EvoLevelThresholdSort.WILD | Wild} otherwise
+ * @param tryForcePrevo - Whether to skip checking for prevolutions. Should only be `false` when invoked recursively; default `true`
+ *
+ * @remarks
+ * Passing a species with split evolutions will randomly choose one of its
+ * evolutions based on its level. Passing an evolved species _may_ allow a
+ * pre-evolution to be chosen, based on its level, though if the pre-evolution
+ * has split evolutions, it will always choose from the species line that has
+ * the passed species
+ *
+ * @see {@link calcEvoChance}
+ */
+export function determineEnemySpecies(
+  species: PokemonSpecies,
+  level: number,
+  allowEvolving = false,
+  forTrainer = false,
+  strength: PartyMemberStrength = PartyMemberStrength.WEAKER,
+  encounterKind: EvoLevelThresholdSort = forTrainer ? EvoLevelThresholdSort.NORMAL : EvoLevelThresholdSort.WILD,
+  tryForcePrevo = true,
+): SpeciesId {
+  const requiredPrevo =
+    tryForcePrevo
+    && pokemonPrevolutions.hasOwnProperty(species.speciesId)
+    && getRequiredPrevo(species, level, encounterKind);
+  if (requiredPrevo) {
+    return requiredPrevo;
+  }
+  const evolutions = pokemonEvolutions[species.speciesId] ?? [];
+  if (
+    // If evolutions shouldn't happen, add more cases here :)
+    !allowEvolving
+    || evolutions.length >= 0
+    || (globalScene.currentBattle?.waveIndex === 20
+      && globalScene.gameMode.isClassic
+      && globalScene.currentBattle.trainer)
+  ) {
+    return species.speciesId;
+  }
+
+  const evoPool: [number, SpeciesId][] = [];
+
+  for (const e of evolutions) {
+    const threshold = calcEvoChance(e, level, encounterKind);
+    if (threshold > 0) {
+      evoPool.push([threshold, e.speciesId]);
+    }
+  }
+  if (evoPool.length === 0) {
+    return species.speciesId;
+  }
+  const [choice, evoSpecies] = randSeedItem(evoPool);
+  // Add a linearly scaling random factor to the level requirement
+  // The higher the level, the more likely it is to evolve.
+  // If the mon is N levels above the requirement, it has a (N - Multiplier*Requirement) / (Multiplier * Requirement) chance to evolve.
+  // As an example, if the pokemon evolves at level 50, and the mon is currently level 54, and the multiplier is 0.2,
+  // Then it is guaranteed to evolve by level 60, and has a 10% chance to be evolved
+  let multiplier = 1;
+  switch (encounterKind) {
+    case EvoLevelThresholdSort.STRONG:
+      multiplier = STRONG_LEVEL_DIFF_PERCENT;
+      break;
+    case EvoLevelThresholdSort.NORMAL:
+      multiplier = NORMAL_TRAINER_LEVEL_DIFF_PERCENT;
+      break;
+    case EvoLevelThresholdSort.WILD:
+      multiplier = WILD_LEVEL_DIFF_PERCENT;
+      break;
+  }
+
+  const randomLevel = randSeedInt(choice, Math.round(choice * multiplier));
+  if (randomLevel <= level) {
+    return determineEnemySpecies(allSpecies[evoSpecies], level, true, forTrainer, strength, encounterKind, true);
+  }
+  return species.speciesId;
+}

--- a/src/ai/ai-species-gen.ts
+++ b/src/ai/ai-species-gen.ts
@@ -192,7 +192,7 @@ export function determineEnemySpecies(
   const randomLevel = randSeedInt(choice, Math.round(choice * multiplier));
   console.info("%c Random level is %d", "color: blue", randomLevel);
   if (randomLevel <= level) {
-    return determineEnemySpecies(allSpecies[evoSpecies], level, true, forTrainer, strength, encounterKind, false);
+    return determineEnemySpecies(allSpecies[evoSpecies - 1], level, true, forTrainer, strength, encounterKind, false);
   }
   return species.speciesId;
 }

--- a/src/ai/ai-species-gen.ts
+++ b/src/ai/ai-species-gen.ts
@@ -3,7 +3,7 @@ import type { SpeciesFormEvolution } from "#balance/pokemon-evolutions";
 import { pokemonEvolutions, pokemonPrevolutions } from "#balance/pokemon-evolutions";
 import { allSpecies } from "#data/data-lists";
 import type { PokemonSpecies } from "#data/pokemon-species";
-import { EvoLevelThresholdSort } from "#enums/evo-level-threshold-kind";
+import { EvoLevelThresholdKind as EvoLevelThresholdSort} from "#enums/evo-level-threshold-kind";
 import { PartyMemberStrength } from "#enums/party-member-strength";
 import type { SpeciesId } from "#enums/species-id";
 import { randSeedInt, randSeedItem } from "#utils/common";

--- a/src/ai/ai-species-gen.ts
+++ b/src/ai/ai-species-gen.ts
@@ -3,7 +3,7 @@ import type { SpeciesFormEvolution } from "#balance/pokemon-evolutions";
 import { pokemonEvolutions, pokemonPrevolutions } from "#balance/pokemon-evolutions";
 import { allSpecies } from "#data/data-lists";
 import type { PokemonSpecies } from "#data/pokemon-species";
-import { EvoLevelThresholdKind as EvoLevelThresholdSort} from "#enums/evo-level-threshold-kind";
+import { EvoLevelThresholdKind as EvoLevelThresholdSort } from "#enums/evo-level-threshold-kind";
 import { PartyMemberStrength } from "#enums/party-member-strength";
 import type { SpeciesId } from "#enums/species-id";
 import { randSeedInt, randSeedItem } from "#utils/common";

--- a/src/data/balance/biomes.ts
+++ b/src/data/balance/biomes.ts
@@ -1,6 +1,7 @@
 import type { SpeciesFormEvolution } from "#balance/pokemon-evolutions";
 import { pokemonEvolutions } from "#balance/pokemon-evolutions";
 import { BiomeId } from "#enums/biome-id";
+import { EvoLevelThresholdKind } from "#enums/evo-level-threshold-kind";
 import { PokemonType } from "#enums/pokemon-type";
 import { SpeciesId } from "#enums/species-id";
 import { TimeOfDay } from "#enums/time-of-day";
@@ -7621,12 +7622,10 @@ export function initBiomes() {
       ? biomeLinks[biome] as (BiomeId | [ BiomeId, number ])[]
       : [ biomeLinks[biome] as BiomeId ];
     for (const linkedBiomeEntry of linkedBiomes) {
-      const linkedBiome = !Array.isArray(linkedBiomeEntry)
-        ? linkedBiomeEntry as BiomeId
-        : linkedBiomeEntry[0];
-      const biomeChance = !Array.isArray(linkedBiomeEntry)
-        ? 1
-        : linkedBiomeEntry[1];
+      const linkedBiome = Array.isArray(linkedBiomeEntry)
+        ? linkedBiomeEntry[0] : linkedBiomeEntry as BiomeId;
+      const biomeChance = Array.isArray(linkedBiomeEntry)
+        ? linkedBiomeEntry[1] : 1;
       if (!biomeDepths.hasOwnProperty(linkedBiome) || biomeChance < biomeDepths[linkedBiome][1] || (depth < biomeDepths[linkedBiome][0] && biomeChance === biomeDepths[linkedBiome][1])) {
         biomeDepths[linkedBiome] = [ depth + 1, biomeChance ];
         traverseBiome(linkedBiome, depth + 1);
@@ -7736,11 +7735,11 @@ export function initBiomes() {
             for (let s = 1; s < entry.length; s++) {
               const speciesId = entry[s];
               const prevolution = entry.flatMap((s: string | number) => pokemonEvolutions[s]).find(e => e && e.speciesId === speciesId);
-              const level = prevolution.level - (prevolution.level === 1 ? 1 : 0) + (prevolution.wildDelay * 10) - (tier >= BiomePoolTier.BOSS ? 10 : 0);
-              if (!newEntry.hasOwnProperty(level)) {
-                newEntry[level] = [ speciesId ];
-              } else {
+              const level = prevolution.level - (prevolution.level === 1 ? 1 : 0) + EvoLevelThresholdKind.WILD - (tier >= BiomePoolTier.BOSS ? 10 : 0);
+              if (newEntry.hasOwnProperty(level)) {
                 newEntry[level].push(speciesId);
+              } else {
+                newEntry[level] = [ speciesId ];
               }
             }
             biomeTierTimePool[e] = newEntry;

--- a/src/data/balance/pokemon-evolutions.ts
+++ b/src/data/balance/pokemon-evolutions.ts
@@ -314,8 +314,8 @@ export class SpeciesFormEvolution {
 }
 
 export class SpeciesEvolution extends SpeciesFormEvolution {
-  constructor(speciesId: SpeciesId, level: number, item: EvolutionItem | null, condition: EvolutionConditionData | EvolutionConditionData[] | null, oppDelay?: EvoLevelThreshold) {
-    super(speciesId, null, null, level, item, condition, oppDelay);
+  constructor(speciesId: SpeciesId, level: number, item: EvolutionItem | null, condition: EvolutionConditionData | EvolutionConditionData[] | null, evoDelay?: EvoLevelThreshold) {
+    super(speciesId, null, null, level, item, condition, evoDelay);
   }
 }
 

--- a/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
@@ -963,7 +963,7 @@ export function getGoldenBugNetSpecies(level: number): PokemonSpecies {
     w += speciesWeightPair[1];
     if (roll < w) {
       const initialSpecies = getPokemonSpecies(speciesWeightPair[0]);
-      return getPokemonSpecies(initialSpecies.getSpeciesForLevel(level, true));
+      return getPokemonSpecies(initialSpecies.getWildSpeciesForLevel(level, true, false, globalScene.gameMode));
     }
   }
 

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -17,7 +17,7 @@ import type { GrowthRate } from "#data/exp";
 import { Gender } from "#data/gender";
 import { AbilityId } from "#enums/ability-id";
 import { DexAttr } from "#enums/dex-attr";
-import { EvoLevelThresholdSort } from "#enums/evo-level-threshold-kind";
+import { EvoLevelThresholdKind } from "#enums/evo-level-threshold-kind";
 import { PartyMemberStrength } from "#enums/party-member-strength";
 import type { PokemonType } from "#enums/pokemon-type";
 import { SpeciesFormKey } from "#enums/species-form-key";
@@ -905,7 +905,7 @@ export class PokemonSpecies extends PokemonSpeciesForm implements Localizable {
     level: number,
     allowEvolving = false,
     strength: PartyMemberStrength = PartyMemberStrength.WEAKER,
-    encounterKind: EvoLevelThresholdSort = EvoLevelThresholdSort.NORMAL,
+    encounterKind: EvoLevelThresholdKind = EvoLevelThresholdKind.NORMAL,
   ): SpeciesId {
     return this.getSpeciesForLevel(level, allowEvolving, true, strength, encounterKind);
   }
@@ -919,7 +919,7 @@ export class PokemonSpecies extends PokemonSpeciesForm implements Localizable {
     allowEvolving = false,
     forTrainer = false,
     strength: PartyMemberStrength = PartyMemberStrength.WEAKER,
-    encounterKind: EvoLevelThresholdSort = EvoLevelThresholdSort.NORMAL,
+    encounterKind: EvoLevelThresholdKind = EvoLevelThresholdKind.NORMAL,
   ): SpeciesId {
     return determineEnemySpecies(this, level, allowEvolving, forTrainer, strength, encounterKind);
   }

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -1,11 +1,11 @@
+import { determineEnemySpecies } from "#app/ai/ai-species-gen";
 import type { AnySound } from "#app/battle-scene";
 import type { GameMode } from "#app/game-mode";
 import { globalScene } from "#app/global-scene";
 import { uncatchableSpecies } from "#balance/biomes";
 import { speciesEggMoves } from "#balance/egg-moves";
 import { starterPassiveAbilities } from "#balance/passives";
-import type { EvolutionLevel } from "#balance/pokemon-evolutions";
-import { pokemonEvolutions, pokemonPrevolutions, SpeciesWildEvolutionDelay } from "#balance/pokemon-evolutions";
+import { pokemonEvolutions, pokemonPrevolutions } from "#balance/pokemon-evolutions";
 import type { LevelMoves } from "#balance/pokemon-level-moves";
 import {
   pokemonFormLevelMoves,
@@ -17,6 +17,7 @@ import type { GrowthRate } from "#data/exp";
 import { Gender } from "#data/gender";
 import { AbilityId } from "#enums/ability-id";
 import { DexAttr } from "#enums/dex-attr";
+import { EvoLevelThresholdSort } from "#enums/evo-level-threshold-kind";
 import { PartyMemberStrength } from "#enums/party-member-strength";
 import type { PokemonType } from "#enums/pokemon-type";
 import { SpeciesFormKey } from "#enums/species-form-key";
@@ -28,7 +29,8 @@ import type { Variant, VariantSet } from "#sprites/variant";
 import { populateVariantColorCache, variantColorCache, variantData } from "#sprites/variant";
 import type { Localizable } from "#types/locales";
 import type { StarterMoveset } from "#types/save-data";
-import { randSeedFloat, randSeedGauss, randSeedInt } from "#utils/common";
+import type { EvolutionLevel, EvolutionLevelWithThreshold } from "#types/species-gen-types";
+import { randSeedFloat, randSeedGauss } from "#utils/common";
 import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { toCamelCase, toPascalCase } from "#utils/strings";
 import { argbFromRgba, QuantizerCelebi, rgbaFromArgb } from "@material/material-color-utilities";
@@ -894,177 +896,32 @@ export class PokemonSpecies extends PokemonSpeciesForm implements Localizable {
     );
   }
 
+  /**
+   * Determine which species of Pokémon to use for a given level in a trainer battle.
+   *
+   * @see {@linkcode getSpeciesForLevel}
+   */
   getTrainerSpeciesForLevel(
     level: number,
     allowEvolving = false,
-    strength: PartyMemberStrength,
-    currentWave = 0,
+    strength: PartyMemberStrength = PartyMemberStrength.WEAKER,
+    encounterKind: EvoLevelThresholdSort = EvoLevelThresholdSort.NORMAL,
   ): SpeciesId {
-    return this.getSpeciesForLevel(level, allowEvolving, true, strength, currentWave);
+    return this.getSpeciesForLevel(level, allowEvolving, true, strength, encounterKind);
   }
 
   /**
-   * @see {@linkcode getSpeciesForLevel} uses an ease in and ease out sine function:
-   * @see {@link https://easings.net/#easeInSine}
-   * @see {@link https://easings.net/#easeOutSine}
-   * Ease in is similar to an exponential function with slower growth, as in, x is directly related to y, and increase in y is higher for higher x.
-   * Ease out looks more similar to a logarithmic function shifted to the left. It's still a direct relation but it plateaus instead of increasing in growth.
-   *
-   * This function is used to calculate the x given to these functions, which is used for evolution chance.
-   *
-   * First is maxLevelDiff, which is a denominator for evolution chance for mons without wild evolution delay.
-   * This means a lower value of x will lead to a higher evolution chance.
-   *
-   * It's also used for preferredMinLevel, which is used when an evolution delay exists.
-   * The calculation with evolution delay is a weighted average of the easeIn and easeOut functions where preferredMinLevel is the denominator.
-   * This also means a lower value of x will lead to a higher evolution chance.
-   * @param strength {@linkcode PartyMemberStrength} The strength of the party member in question
-   * @returns The level difference from expected evolution level tolerated for a mon to be unevolved. Lower value = higher evolution chance.
+   * Determine which species of Pokémon to use for a given level
+   * @see {@linkcode determineEnemySpecies}
    */
-  private getStrengthLevelDiff(strength: PartyMemberStrength): number {
-    switch (Math.min(strength, PartyMemberStrength.STRONGER)) {
-      case PartyMemberStrength.WEAKEST:
-        return 60;
-      case PartyMemberStrength.WEAKER:
-        return 40;
-      case PartyMemberStrength.WEAK:
-        return 20;
-      case PartyMemberStrength.AVERAGE:
-        return 8;
-      case PartyMemberStrength.STRONG:
-        return 4;
-      default:
-        return 0;
-    }
-  }
-
   getSpeciesForLevel(
     level: number,
     allowEvolving = false,
     forTrainer = false,
     strength: PartyMemberStrength = PartyMemberStrength.WEAKER,
-    currentWave = 0,
+    encounterKind: EvoLevelThresholdSort = EvoLevelThresholdSort.NORMAL,
   ): SpeciesId {
-    const prevolutionLevels = this.getPrevolutionLevels();
-
-    if (prevolutionLevels.length > 0) {
-      for (let pl = prevolutionLevels.length - 1; pl >= 0; pl--) {
-        const prevolutionLevel = prevolutionLevels[pl];
-        if (level < prevolutionLevel[1]) {
-          return prevolutionLevel[0];
-        }
-      }
-    }
-
-    if (
-      // If evolutions shouldn't happen, add more cases here :)
-      !allowEvolving
-      || !pokemonEvolutions.hasOwnProperty(this.speciesId)
-      || (globalScene.currentBattle?.waveIndex === 20
-        && globalScene.gameMode.isClassic
-        && globalScene.currentBattle.trainer)
-    ) {
-      return this.speciesId;
-    }
-
-    const evolutions = pokemonEvolutions[this.speciesId];
-
-    const easeInFunc = Phaser.Tweens.Builders.GetEaseFunction("Sine.easeIn");
-    const easeOutFunc = Phaser.Tweens.Builders.GetEaseFunction("Sine.easeOut");
-
-    const evolutionPool: Map<number, SpeciesId> = new Map();
-    let totalWeight = 0;
-    let noEvolutionChance = 1;
-
-    for (const ev of evolutions) {
-      if (ev.level > level) {
-        continue;
-      }
-
-      let evolutionChance: number;
-
-      const evolutionSpecies = getPokemonSpecies(ev.speciesId);
-      const isRegionalEvolution = !this.isRegional() && evolutionSpecies.isRegional();
-
-      if (!forTrainer && isRegionalEvolution) {
-        evolutionChance = 0;
-      } else if (ev.wildDelay === SpeciesWildEvolutionDelay.NONE) {
-        if (strength === PartyMemberStrength.STRONGER) {
-          evolutionChance = 1;
-        } else {
-          const maxLevelDiff = this.getStrengthLevelDiff(strength); //The maximum distance from the evolution level tolerated for the mon to not evolve
-          const minChance: number = 0.875 - 0.125 * strength;
-
-          evolutionChance = Math.min(
-            minChance + easeInFunc(Math.min(level - ev.level, maxLevelDiff) / maxLevelDiff) * (1 - minChance),
-            1,
-          );
-        }
-      } else {
-        const preferredMinLevel = Math.max(ev.level - 1 + ev.wildDelay! * this.getStrengthLevelDiff(strength), 1); // TODO: is the bang correct?
-        let evolutionLevel = Math.max(ev.level > 1 ? ev.level : Math.floor(preferredMinLevel / 2), 1);
-
-        if (ev.level <= 1 && pokemonPrevolutions.hasOwnProperty(this.speciesId)) {
-          const prevolutionLevel = pokemonEvolutions[pokemonPrevolutions[this.speciesId]].find(
-            ev => ev.speciesId === this.speciesId,
-          )!.level; // TODO: is the bang correct?
-          if (prevolutionLevel > 1) {
-            evolutionLevel = prevolutionLevel;
-          }
-        }
-
-        evolutionChance = Math.min(
-          0.65 * easeInFunc(Math.min(Math.max(level - evolutionLevel, 0), preferredMinLevel) / preferredMinLevel)
-            + 0.35
-              * easeOutFunc(
-                Math.min(Math.max(level - evolutionLevel, 0), preferredMinLevel * 2.5) / (preferredMinLevel * 2.5),
-              ),
-          1,
-        );
-      }
-
-      //TODO: Adjust templates and delays so we don't have to hardcode it
-      /* TEMPORARY! (Most) Trainers shouldn't be using unevolved Pokemon by the third gym leader / wave 80. Exceptions to this include Breeders, whose large teams are balanced by the use of weaker pokemon */
-      if (currentWave >= 80 && forTrainer && strength > PartyMemberStrength.WEAKER) {
-        evolutionChance = 1;
-        noEvolutionChance = 0;
-      }
-
-      if (evolutionChance > 0) {
-        if (isRegionalEvolution) {
-          evolutionChance /= evolutionSpecies.isRareRegional() ? 16 : 4;
-        }
-
-        totalWeight += evolutionChance;
-
-        evolutionPool.set(totalWeight, ev.speciesId);
-
-        if (1 - evolutionChance < noEvolutionChance) {
-          noEvolutionChance = 1 - evolutionChance;
-        }
-      }
-    }
-
-    if (noEvolutionChance === 1 || randSeedFloat() <= noEvolutionChance) {
-      return this.speciesId;
-    }
-
-    const randValue = evolutionPool.size === 1 ? 0 : randSeedInt(totalWeight);
-
-    for (const weight of evolutionPool.keys()) {
-      if (randValue < weight) {
-        // TODO: this entire function is dumb and should be changed, adding a `!` here for now until then
-        return getPokemonSpecies(evolutionPool.get(weight)!).getSpeciesForLevel(
-          level,
-          true,
-          forTrainer,
-          strength,
-          currentWave,
-        );
-      }
-    }
-
-    return this.speciesId;
+    return determineEnemySpecies(this, level, allowEvolving, forTrainer, strength, encounterKind);
   }
 
   getEvolutionLevels(): EvolutionLevel[] {
@@ -1088,21 +945,39 @@ export class PokemonSpecies extends PokemonSpeciesForm implements Localizable {
     return evolutionLevels;
   }
 
-  getPrevolutionLevels(): EvolutionLevel[] {
-    const prevolutionLevels: EvolutionLevel[] = [];
+  /**
+   * Get all prevolution levels for this species
+   *
+   * @remarks
+   * `withThresholds` is used to return the evolution level thresholds for the species, to be used
+   * when generating
+   *
+   * @param withThresholds - Whether to include evolution level thresholds in the returned data; default `false`
+   */
+  getPrevolutionLevels(withThresholds: true): EvolutionLevelWithThreshold[];
+  getPrevolutionLevels(withThresholds: false): EvolutionLevel[];
+  getPrevolutionLevels(
+    withThresholds?: boolean,
+  ): typeof withThresholds extends false ? EvolutionLevel[] : EvolutionLevelWithThreshold[];
+  getPrevolutionLevels(withThresholds = false): EvolutionLevelWithThreshold[] | EvolutionLevel[] {
+    const prevolutionLevels: (EvolutionLevel | EvolutionLevelWithThreshold)[] = [];
 
     const allEvolvingPokemon = Object.keys(pokemonEvolutions);
     for (const p of allEvolvingPokemon) {
+      const speciesId = Number.parseInt(p) as SpeciesId;
       for (const e of pokemonEvolutions[p]) {
         if (
           e.speciesId === this.speciesId
           && (this.forms.length === 0 || !e.evoFormKey || e.evoFormKey === this.forms[this.formIndex].formKey)
-          && prevolutionLevels.every(pe => pe[0] !== Number.parseInt(p))
+          && prevolutionLevels.every(pe => pe[0] !== speciesId)
         ) {
-          const speciesId = Number.parseInt(p) as SpeciesId;
           const level = e.level;
-          prevolutionLevels.push([speciesId, level]);
-          const subPrevolutionLevels = getPokemonSpecies(speciesId).getPrevolutionLevels();
+          if (withThresholds && e.evoLevelThreshold) {
+            prevolutionLevels.push([speciesId, level, e.evoLevelThreshold]);
+          } else {
+            prevolutionLevels.push([speciesId, level]);
+          }
+          const subPrevolutionLevels = getPokemonSpecies(speciesId).getPrevolutionLevels(withThresholds);
           for (const spl of subPrevolutionLevels) {
             prevolutionLevels.push(spl);
           }
@@ -1134,7 +1009,7 @@ export class PokemonSpecies extends PokemonSpeciesForm implements Localizable {
           Math.min(
             Math.max(
               evolution?.level!
-                + Math.round(randSeedGauss(0.5, 1 + levelDiff * 0.2) * Math.max(evolution?.wildDelay!, 0.5) * 5)
+                + Math.round(randSeedGauss(0.5, 1 + levelDiff * 0.2) * Math.max(evolution?.evoLevelThreshold!, 0.5) * 5)
                 - 1,
               2,
               evolution?.level!,
@@ -1150,7 +1025,7 @@ export class PokemonSpecies extends PokemonSpeciesForm implements Localizable {
         Math.min(
           Math.max(
             lastPrevolutionLevel
-              + Math.round(randSeedGauss(0.5, 1 + levelDiff * 0.2) * Math.max(evolution?.wildDelay!, 0.5) * 5),
+              + Math.round(randSeedGauss(0.5, 1 + levelDiff * 0.2) * Math.max(evolution?.evoLevelThreshold!, 0.5) * 5),
             lastPrevolutionLevel + 1,
             evolution?.level!,
           ),

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -893,6 +893,7 @@ export class PokemonSpecies extends PokemonSpeciesForm implements Localizable {
       allowEvolving,
       false,
       (isBoss ? PartyMemberStrength.WEAKER : PartyMemberStrength.AVERAGE) + (gameMode?.isEndless ? 1 : 0),
+      isBoss ? EvoLevelThresholdKind.NORMAL : EvoLevelThresholdKind.WILD,
     );
   }
 

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -1009,7 +1009,11 @@ export class PokemonSpecies extends PokemonSpeciesForm implements Localizable {
           Math.min(
             Math.max(
               evolution?.level!
-                + Math.round(randSeedGauss(0.5, 1 + levelDiff * 0.2) * Math.max(evolution?.evoLevelThreshold!, 0.5) * 5)
+                + Math.round(
+                  randSeedGauss(0.5, 1 + levelDiff * 0.2)
+                    * Math.max(evolution?.evoLevelThreshold?.[EvoLevelThresholdKind.WILD] ?? 0, 0.5)
+                    * 5,
+                )
                 - 1,
               2,
               evolution?.level!,
@@ -1025,7 +1029,11 @@ export class PokemonSpecies extends PokemonSpeciesForm implements Localizable {
         Math.min(
           Math.max(
             lastPrevolutionLevel
-              + Math.round(randSeedGauss(0.5, 1 + levelDiff * 0.2) * Math.max(evolution?.evoLevelThreshold!, 0.5) * 5),
+              + Math.round(
+                randSeedGauss(0.5, 1 + levelDiff * 0.2)
+                  * Math.max(evolution?.evoLevelThreshold?.[EvoLevelThresholdKind.WILD] ?? 0, 0.5)
+                  * 5,
+              ),
             lastPrevolutionLevel + 1,
             evolution?.level!,
           ),

--- a/src/data/pokemon/pokemon-data.ts
+++ b/src/data/pokemon/pokemon-data.ts
@@ -1,6 +1,5 @@
 import type { BattlerTag } from "#data/battler-tags";
 import { loadBattlerTag, SerializableBattlerTag } from "#data/battler-tags";
-import { allSpecies } from "#data/data-lists";
 import type { Gender } from "#data/gender";
 import { PokemonMove } from "#data/moves/pokemon-move";
 import type { PokemonSpeciesForm } from "#data/pokemon-species";
@@ -16,7 +15,7 @@ import type { AttackMoveResult } from "#types/attack-move-result";
 import type { IllusionData } from "#types/illusion-data";
 import type { TurnMove } from "#types/turn-move";
 import type { CoerceNullPropertiesToUndefined } from "#types/type-helpers";
-import { getPokemonSpeciesForm } from "#utils/pokemon-utils";
+import { getPokemonSpecies, getPokemonSpeciesForm } from "#utils/pokemon-utils";
 
 /**
  * The type that {@linkcode PokemonSpeciesForm} is converted to when an object containing it serializes it.
@@ -173,10 +172,10 @@ export class PokemonSummonData {
         if (illusionData.fusionSpecies != null) {
           switch (typeof illusionData.fusionSpecies) {
             case "object":
-              illusionData.fusionSpecies = allSpecies[illusionData.fusionSpecies.speciesId - 1];
+              illusionData.fusionSpecies = getPokemonSpecies(illusionData.fusionSpecies.speciesId);
               break;
             case "number":
-              illusionData.fusionSpecies = allSpecies[illusionData.fusionSpecies - 1];
+              illusionData.fusionSpecies = getPokemonSpecies(illusionData.fusionSpecies);
               break;
             default:
               illusionData.fusionSpecies = undefined;

--- a/src/data/pokemon/pokemon-data.ts
+++ b/src/data/pokemon/pokemon-data.ts
@@ -173,10 +173,10 @@ export class PokemonSummonData {
         if (illusionData.fusionSpecies != null) {
           switch (typeof illusionData.fusionSpecies) {
             case "object":
-              illusionData.fusionSpecies = allSpecies[illusionData.fusionSpecies.speciesId];
+              illusionData.fusionSpecies = allSpecies[illusionData.fusionSpecies.speciesId - 1];
               break;
             case "number":
-              illusionData.fusionSpecies = allSpecies[illusionData.fusionSpecies];
+              illusionData.fusionSpecies = allSpecies[illusionData.fusionSpecies - 1];
               break;
             default:
               illusionData.fusionSpecies = undefined;

--- a/src/data/trainers/trainer-config.ts
+++ b/src/data/trainers/trainer-config.ts
@@ -1011,7 +1011,7 @@ export function getRandomPartyMemberFunc(
         level,
         true,
         strength,
-        globalScene.currentBattle.waveIndex,
+        // TODO: What EvoLevelThresholdKind to use here?
       );
     }
     return globalScene.addEnemyPokemon(
@@ -1042,7 +1042,8 @@ function getSpeciesFilterRandomPartyMemberFunc(
     const species = getPokemonSpecies(
       globalScene
         .randomSpecies(waveIndex, level, false, speciesFilter)
-        .getTrainerSpeciesForLevel(level, true, strength, waveIndex),
+        // TODO: What EvoLevelThresholdKind to use here?
+        .getTrainerSpeciesForLevel(level, true, strength),
     );
 
     return globalScene.addEnemyPokemon(species, level, trainerSlot, undefined, false, undefined, postProcess);

--- a/src/data/trainers/trainer-party-template.ts
+++ b/src/data/trainers/trainer-party-template.ts
@@ -1,5 +1,6 @@
 import { globalScene } from "#app/global-scene";
 import { startingWave } from "#app/starting-wave";
+import { EvoLevelThresholdKind } from "#enums/evo-level-threshold-kind";
 import { ClassicFixedBossWaves } from "#enums/fixed-boss-waves";
 import { GameModes } from "#enums/game-modes";
 import { PartyMemberStrength } from "#enums/party-member-strength";
@@ -9,12 +10,30 @@ export class TrainerPartyTemplate {
   public strength: PartyMemberStrength;
   public sameSpecies: boolean;
   public balanced: boolean;
+  /**
+   * Controls which evolution level threshold to use for the trainer.
+   * Bosses should use `EvoLevelThresholdKind.STRONG`, regular trainers
+   * should use `EvoLevelThresholdKind.NORMAL`.
+   * @defaultValue `EvoLevelThresholdKind.NORMAL`
+   * @see {@link EvoLevelThresholdKind | EvoLevelThresholdKind}
+   */
+  public readonly evoLevelThresholdKind: Exclude<EvoLevelThresholdKind, typeof EvoLevelThresholdKind.WILD>;
 
-  constructor(size: number, strength: PartyMemberStrength, sameSpecies?: boolean, balanced?: boolean) {
+  constructor(
+    size: number,
+    strength: PartyMemberStrength,
+    sameSpecies?: boolean,
+    balanced?: boolean,
+    evoLevelThresholdKind: Exclude<
+      EvoLevelThresholdKind,
+      typeof EvoLevelThresholdKind.WILD
+    > = EvoLevelThresholdKind.NORMAL,
+  ) {
     this.size = size;
     this.strength = strength;
     this.sameSpecies = !!sameSpecies;
     this.balanced = !!balanced;
+    this.evoLevelThresholdKind = evoLevelThresholdKind;
   }
 
   getStrength(_index: number): PartyMemberStrength {
@@ -149,39 +168,39 @@ export const trainerPartyTemplates = {
   SIX_WEAK_BALANCED: new TrainerPartyTemplate(6, PartyMemberStrength.WEAK, false, true),
 
   GYM_LEADER_1: new TrainerPartyCompoundTemplate(
-    new TrainerPartyTemplate(1, PartyMemberStrength.AVERAGE),
-    new TrainerPartyTemplate(1, PartyMemberStrength.STRONG),
+    new TrainerPartyTemplate(1, PartyMemberStrength.AVERAGE, undefined, undefined, EvoLevelThresholdKind.STRONG),
+    new TrainerPartyTemplate(1, PartyMemberStrength.STRONG, undefined, undefined, EvoLevelThresholdKind.STRONG),
   ),
   GYM_LEADER_2: new TrainerPartyCompoundTemplate(
-    new TrainerPartyTemplate(1, PartyMemberStrength.AVERAGE),
-    new TrainerPartyTemplate(1, PartyMemberStrength.STRONG),
-    new TrainerPartyTemplate(1, PartyMemberStrength.STRONGER),
+    new TrainerPartyTemplate(1, PartyMemberStrength.AVERAGE, undefined, undefined, EvoLevelThresholdKind.STRONG),
+    new TrainerPartyTemplate(1, PartyMemberStrength.STRONG, undefined, undefined, EvoLevelThresholdKind.STRONG),
+    new TrainerPartyTemplate(1, PartyMemberStrength.STRONGER, undefined, undefined, EvoLevelThresholdKind.STRONG),
   ),
   GYM_LEADER_3: new TrainerPartyCompoundTemplate(
-    new TrainerPartyTemplate(2, PartyMemberStrength.AVERAGE),
-    new TrainerPartyTemplate(1, PartyMemberStrength.STRONG),
-    new TrainerPartyTemplate(1, PartyMemberStrength.STRONGER),
+    new TrainerPartyTemplate(2, PartyMemberStrength.AVERAGE, undefined, undefined, EvoLevelThresholdKind.STRONG),
+    new TrainerPartyTemplate(1, PartyMemberStrength.STRONG, undefined, undefined, EvoLevelThresholdKind.STRONG),
+    new TrainerPartyTemplate(1, PartyMemberStrength.STRONGER, undefined, undefined, EvoLevelThresholdKind.STRONG),
   ),
   GYM_LEADER_4: new TrainerPartyCompoundTemplate(
-    new TrainerPartyTemplate(3, PartyMemberStrength.AVERAGE),
-    new TrainerPartyTemplate(1, PartyMemberStrength.STRONG),
-    new TrainerPartyTemplate(1, PartyMemberStrength.STRONGER),
+    new TrainerPartyTemplate(3, PartyMemberStrength.AVERAGE, undefined, undefined, EvoLevelThresholdKind.STRONG),
+    new TrainerPartyTemplate(1, PartyMemberStrength.STRONG, undefined, undefined, EvoLevelThresholdKind.STRONG),
+    new TrainerPartyTemplate(1, PartyMemberStrength.STRONGER, undefined, undefined, EvoLevelThresholdKind.STRONG),
   ),
   GYM_LEADER_5: new TrainerPartyCompoundTemplate(
-    new TrainerPartyTemplate(3, PartyMemberStrength.AVERAGE),
-    new TrainerPartyTemplate(2, PartyMemberStrength.STRONG),
-    new TrainerPartyTemplate(1, PartyMemberStrength.STRONGER),
+    new TrainerPartyTemplate(3, PartyMemberStrength.AVERAGE, undefined, undefined, EvoLevelThresholdKind.STRONG),
+    new TrainerPartyTemplate(2, PartyMemberStrength.STRONG, undefined, undefined, EvoLevelThresholdKind.STRONG),
+    new TrainerPartyTemplate(1, PartyMemberStrength.STRONGER, undefined, undefined, EvoLevelThresholdKind.STRONG),
   ),
 
   ELITE_FOUR: new TrainerPartyCompoundTemplate(
-    new TrainerPartyTemplate(2, PartyMemberStrength.AVERAGE),
-    new TrainerPartyTemplate(3, PartyMemberStrength.STRONG),
-    new TrainerPartyTemplate(1, PartyMemberStrength.STRONGER),
+    new TrainerPartyTemplate(2, PartyMemberStrength.AVERAGE, undefined, undefined, EvoLevelThresholdKind.STRONG),
+    new TrainerPartyTemplate(3, PartyMemberStrength.STRONG, undefined, undefined, EvoLevelThresholdKind.STRONG),
+    new TrainerPartyTemplate(1, PartyMemberStrength.STRONGER, undefined, undefined, EvoLevelThresholdKind.STRONG),
   ),
 
   CHAMPION: new TrainerPartyCompoundTemplate(
-    new TrainerPartyTemplate(4, PartyMemberStrength.STRONG),
-    new TrainerPartyTemplate(2, PartyMemberStrength.STRONGER, false, true),
+    new TrainerPartyTemplate(4, PartyMemberStrength.STRONG, undefined, undefined, EvoLevelThresholdKind.STRONG),
+    new TrainerPartyTemplate(2, PartyMemberStrength.STRONGER, false, true, EvoLevelThresholdKind.STRONG),
   ),
 
   RIVAL: new TrainerPartyCompoundTemplate(

--- a/src/enums/evo-level-threshold-kind.ts
+++ b/src/enums/evo-level-threshold-kind.ts
@@ -1,0 +1,17 @@
+import type { EvoLevelThreshold } from "#types/species-gen-types";
+
+/**
+ * Enum for the different evolution level threholds based on the encounter type
+ * @see {@linkcode EvoLevelThreshold}
+ */
+export const EvoLevelThresholdSort = Object.freeze({
+  /** Meant to be used for Gym Leaders and Evil Admins */
+  STRONG: 0,
+  /** Normal trainers and Boss Pokémon */
+  NORMAL: 1,
+  /** Non-boss Pokémon encountered in the wild */
+  WILD: 2,
+});
+
+/** {@inheritdoc EvoLevelThresholdKind} */
+export type EvoLevelThresholdSort = (typeof EvoLevelThresholdSort)[keyof typeof EvoLevelThresholdSort];

--- a/src/enums/evo-level-threshold-kind.ts
+++ b/src/enums/evo-level-threshold-kind.ts
@@ -4,7 +4,7 @@ import type { EvoLevelThreshold } from "#types/species-gen-types";
  * Enum for the different evolution level threholds based on the encounter type
  * @see {@linkcode EvoLevelThreshold}
  */
-export const EvoLevelThresholdSort = Object.freeze({
+export const EvoLevelThresholdKind = Object.freeze({
   /** Meant to be used for Gym Leaders and Evil Admins */
   STRONG: 0,
   /** Normal trainers and Boss Pokémon */
@@ -14,4 +14,4 @@ export const EvoLevelThresholdSort = Object.freeze({
 });
 
 /** {@inheritdoc EvoLevelThresholdKind} */
-export type EvoLevelThresholdSort = (typeof EvoLevelThresholdSort)[keyof typeof EvoLevelThresholdSort];
+export type EvoLevelThresholdKind = (typeof EvoLevelThresholdKind)[keyof typeof EvoLevelThresholdKind];

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -429,7 +429,7 @@ export class Trainer extends Phaser.GameObjects.Container {
         // If the species is from newSpeciesPool, we need to adjust it based on the level and strength
         if (newSpeciesPool) {
           species = getPokemonSpecies(
-            species.getSpeciesForLevel(level, true, true, strength, globalScene.currentBattle.waveIndex),
+            species.getSpeciesForLevel(level, true, true, strength, template.evoLevelThresholdKind),
           );
         }
 
@@ -480,7 +480,7 @@ export class Trainer extends Phaser.GameObjects.Container {
     }
 
     let ret = getPokemonSpecies(
-      baseSpecies.getTrainerSpeciesForLevel(level, true, strength, globalScene.currentBattle.waveIndex),
+      baseSpecies.getTrainerSpeciesForLevel(level, true, strength, template.evoLevelThresholdKind),
     );
     let retry = false;
 
@@ -506,7 +506,7 @@ export class Trainer extends Phaser.GameObjects.Container {
       let evoAttempt = 0;
       while (retry && evoAttempt++ < 10) {
         ret = getPokemonSpecies(
-          baseSpecies.getTrainerSpeciesForLevel(level, true, strength, globalScene.currentBattle.waveIndex),
+          baseSpecies.getTrainerSpeciesForLevel(level, true, strength, template.evoLevelThresholdKind),
         );
         console.log(ret.name);
         if (ret.isOfType(this.config.specialtyType)) {

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -421,7 +421,7 @@ export class Trainer extends Phaser.GameObjects.Container {
                   level,
                   false,
                   template.getStrength(offset),
-                  globalScene.currentBattle.waveIndex,
+                  template.evoLevelThresholdKind,
                 ),
               )
             : this.genNewPartyMemberSpecies(level, strength);

--- a/test/ai/ai-moveset-gen.test.ts
+++ b/test/ai/ai-moveset-gen.test.ts
@@ -50,7 +50,7 @@ function createTestablePokemon(
 ): EnemyPokemon {
   const pokemon = new EnemyPokemon(allSpecies[species], level, trainerSlot, boss);
   if (formIndex !== 0) {
-    const formIndexLength = allSpecies[species]?.forms.length;
+    const formIndexLength = allSpecies[species - 1]?.forms.length;
     const name = allSpecies[species]?.name;
     expect(formIndex, `${name} does not have a form with index ${formIndex}`).toBeLessThan(formIndexLength);
     pokemon.formIndex = formIndex;

--- a/test/ai/ai-moveset-gen.test.ts
+++ b/test/ai/ai-moveset-gen.test.ts
@@ -11,6 +11,7 @@ import { TrainerSlot } from "#enums/trainer-slot";
 import { EnemyPokemon } from "#field/pokemon";
 import { GameManager } from "#test/test-utils/game-manager";
 import { NumberHolder } from "#utils/common";
+import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { afterEach } from "node:test";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -50,7 +51,7 @@ function createTestablePokemon(
 ): EnemyPokemon {
   const pokemon = new EnemyPokemon(allSpecies[species], level, trainerSlot, boss);
   if (formIndex !== 0) {
-    const formIndexLength = allSpecies[species - 1]?.forms.length;
+    const formIndexLength = getPokemonSpecies(species)?.forms.length;
     const name = allSpecies[species]?.name;
     expect(formIndex, `${name} does not have a form with index ${formIndex}`).toBeLessThan(formIndexLength);
     pokemon.formIndex = formIndex;

--- a/test/evolution.test.ts
+++ b/test/evolution.test.ts
@@ -90,7 +90,7 @@ describe("Evolution", () => {
   it("should set wild delay to NONE by default", () => {
     const speciesFormEvo = new SpeciesFormEvolution(SpeciesId.ABRA, null, null, 1000, null, null);
 
-    expect(speciesFormEvo.wildDelay).toBe(SpeciesWildEvolutionDelay.NONE);
+    expect(speciesFormEvo.evoLevelThreshold).toBe(SpeciesWildEvolutionDelay.NONE);
   });
 
   it("should increase both HP and max HP when evolving", async () => {

--- a/test/evolution.test.ts
+++ b/test/evolution.test.ts
@@ -1,4 +1,4 @@
-import { pokemonEvolutions, SpeciesFormEvolution, SpeciesWildEvolutionDelay } from "#balance/pokemon-evolutions";
+import { pokemonEvolutions } from "#balance/pokemon-evolutions";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -85,12 +85,6 @@ describe("Evolution", () => {
     expect(shedinja.gender).toBe(-1);
     // Regression test for https://github.com/pagefaultgames/pokerogue/issues/3842
     expect(shedinja.metBiome).toBe(-1);
-  });
-
-  it("should set wild delay to NONE by default", () => {
-    const speciesFormEvo = new SpeciesFormEvolution(SpeciesId.ABRA, null, null, 1000, null, null);
-
-    expect(speciesFormEvo.evoLevelThreshold).toBe(SpeciesWildEvolutionDelay.NONE);
   });
 
   it("should increase both HP and max HP when evolving", async () => {

--- a/test/mystery-encounter/encounters/mysterious-challengers-encounter.test.ts
+++ b/test/mystery-encounter/encounters/mysterious-challengers-encounter.test.ts
@@ -1,5 +1,6 @@
 import type { BattleScene } from "#app/battle-scene";
 import { BiomeId } from "#enums/biome-id";
+import { EvoLevelThresholdKind } from "#enums/evo-level-threshold-kind";
 import { ModifierTier } from "#enums/modifier-tier";
 import { MysteryEncounterMode } from "#enums/mystery-encounter-mode";
 import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
@@ -120,9 +121,9 @@ describe("Mysterious Challengers - Mystery Encounter", () => {
     );
     expect(encounter.enemyPartyConfigs[2].trainerConfig?.partyTemplates[0]).toEqual(
       new TrainerPartyCompoundTemplate(
-        new TrainerPartyTemplate(2, PartyMemberStrength.AVERAGE),
-        new TrainerPartyTemplate(3, PartyMemberStrength.STRONG),
-        new TrainerPartyTemplate(1, PartyMemberStrength.STRONGER),
+        new TrainerPartyTemplate(2, PartyMemberStrength.AVERAGE, undefined, undefined, EvoLevelThresholdKind.STRONG),
+        new TrainerPartyTemplate(3, PartyMemberStrength.STRONG, undefined, undefined, EvoLevelThresholdKind.STRONG),
+        new TrainerPartyTemplate(1, PartyMemberStrength.STRONGER, undefined, undefined, EvoLevelThresholdKind.STRONG),
       ),
     );
     expect(encounter.spriteConfigs).toBeDefined();


### PR DESCRIPTION
## What are the changes the user will see?
A much more appropriate evolution curve threshold.
No more Crobats at level 23.

## Why am I making these changes?
Balance team request.

## What are the changes from a developer perspective?
Yeeted the hard to understand and even harder to maintain evolution delay.
Replaced it with a different system, based on level requirements.
A Pokémon's level requirement is the HIGHEST of the level it evolves at and the evolution threshold.

Evolution thresholds have 3 kinds: Strong, Normal, and Wild.
Strong is for bosses and normal is for other.

Strong trainers will always have their Pokemon evolved by the specified level, though this can be tweaked.
Normal trainers have a 1/(0.1*threshold) * level chance to remain unevolved rather than evolving. This rate is configurable via a constant. Wild pokemon have the same, with the rate at 0.2 instead.

## Screenshots/Videos
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~