### PR TITLE
[Dev] Added ability to pass in test type to `create-test` script from CLI

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -17,11 +17,6 @@ declare global {
 
     call<T extends AnyFn>(this: T, thisArg: ThisParameterType<T>, ...argArray: Parameters<T>): ReturnType<T>;
   }
-
-  // Type-safe aliases for `Object.keys` when working with string records
-  interface ObjectConstructor {
-    keys<O extends Record<string, unknown>>(o: O): keyof O[];
-  }
 }
 
 // Global augments for `typedoc` to prevent TS from erroring when editing the config JS file

--- a/global.d.ts
+++ b/global.d.ts
@@ -17,6 +17,11 @@ declare global {
 
     call<T extends AnyFn>(this: T, thisArg: ThisParameterType<T>, ...argArray: Parameters<T>): ReturnType<T>;
   }
+
+  // Type-safe aliases for `Object.keys` when working with string records
+  interface ObjectConstructor {
+    keys<O extends Record<string, unknown>>(o: O): keyof O[];
+  }
 }
 
 // Global augments for `typedoc` to prevent TS from erroring when editing the config JS file

--- a/scripts/create-test/create-test.js
+++ b/scripts/create-test/create-test.js
@@ -11,21 +11,26 @@
  */
 
 import fs from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
+import path, { join } from "node:path";
 import chalk from "chalk";
 import inquirer from "inquirer";
 
 //#region Constants
 
-const version = "2.0.1";
+const version = "2.0.2";
 // Get the directory name of the current module file
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __dirname = import.meta.dirname;
 const projectRoot = path.join(__dirname, "..", "..");
 
 const choices = /** @type {const} */ (["Move", "Ability", "Item", "Reward", "Mystery Encounter", "Utils", "UI"]);
-/** @typedef {choices[number]} choiceType */
+/** @typedef {typeof choices[number]} choiceType */
+/**
+ * Object mapping choice types to extra names they can be used with from CLI.
+ * @satisfies {Partial<Record<choiceType, readonly string[]>>}
+ */
+const cliAliases = {
+  "Mystery Encounter": ["ME"],
+};
 
 /** @satisfies {{[k in choiceType]: string}} */
 const choicesToDirs = /** @type {const} */ ({
@@ -56,8 +61,8 @@ function getTestFolderPath(...folders) {
  */
 async function promptTestType() {
   /** @type {choiceType | "EXIT"} */
-  const choice = await inquirer
-    .prompt([
+  const choice = (
+    await inquirer.prompt([
       {
         type: "list",
         name: "selectedOption",
@@ -65,7 +70,7 @@ async function promptTestType() {
         choices: [...choices, "EXIT"],
       },
     ])
-    .then(ta => ta.selectedOption);
+  ).selectedOption;
 
   if (choice === "EXIT") {
     console.log("Exiting...");
@@ -82,15 +87,15 @@ async function promptTestType() {
  */
 async function promptFileName(selectedType) {
   /** @type {string} */
-  const fileNameAnswer = await inquirer
-    .prompt([
+  const fileNameAnswer = (
+    await inquirer.prompt([
       {
         type: "input",
         name: "userInput",
         message: `Please provide the name of the ${selectedType}.`,
       },
     ])
-    .then(fa => fa.userInput);
+  ).userInput;
 
   if (fileNameAnswer.trim().length === 0) {
     console.error("Please provide a valid file name!");
@@ -115,14 +120,58 @@ function getBoilerplatePath(choiceType) {
 }
 
 /**
- * Runs the interactive test:create "CLI"
+ * Parse `process.argv` and get the test type if it exists.
+ * @returns {choiceType | undefined}
+ * The type of choice the CLI args corresponds to, or `undefined` if none were specified.
+ * Will set `process.exitCode` to a non-zero integer if args are invalid.
+ */
+function convertArgsToTestType() {
+  // If the first argument is a test name, use that as the test name
+  const args = process.argv.slice(2);
+  if (args[0] == null) {
+    return;
+  }
+
+  // Check for a direct match, falling back to alias checking.
+  const choiceName = choices.find(c => c.toLowerCase() === args[0].toLowerCase());
+  if (choiceName) {
+    return choiceName;
+  }
+
+  const alias = /** @type {(keyof cliAliases)[]} */ (Object.keys(cliAliases)).find(k =>
+    cliAliases[k].some(a => a.toLowerCase() === args[0].toLowerCase()),
+  );
+  if (alias) {
+    return alias;
+  }
+  console.error(
+    chalk.red.bold(`✗ Invalid type of test file specified: ${args[0]}!
+Valid types: ${chalk.blue(choices.join(", "))}`),
+  );
+  process.exitCode = 1;
+  return;
+}
+
+/**
+ * Run the interactive `test:create` CLI.
  * @returns {Promise<void>}
  */
 async function runInteractive() {
   console.group(chalk.grey(`🧪 Create Test - v${version}\n`));
 
+  const cliTestType = convertArgsToTestType();
+  if (process.exitCode) {
+    return;
+  }
+  // TODO: Add a help command
   try {
-    const choice = await promptTestType();
+    let choice;
+    if (cliTestType) {
+      console.log(chalk.blue(`Using ${cliTestType} as test type from CLI...`));
+      choice = cliTestType;
+    } else {
+      choice = await promptTestType();
+    }
     const fileNameAnswer = await promptFileName(choice);
 
     // Convert fileName from snake_case or camelCase to kebab-case
@@ -159,7 +208,7 @@ async function runInteractive() {
     // Write the template content to the file
     fs.writeFileSync(filePath, content, "utf8");
 
-    console.log(chalk.green.bold(`✔ File created at: test/${localDir}/${fileName}.test.ts\n`));
+    console.log(chalk.green.bold(`✔ File created at: ${join("test", localDir, fileName)}.test.ts\n`));
     console.groupEnd();
   } catch (err) {
     console.error(chalk.red("✗ Error: ", err));


### PR DESCRIPTION
## What are the changes the user will see?
N/A
## Why am I making these changes?
I like cli args and this makes creating many tests easier

## What are the changes from a developer perspective?
Added a few locs to the `create-test` CLI script that allow passing a single argument for the test type (skipping the interactive prompt entirely).

## Screenshots/Videos
N/A

## How to test the changes?
Run da script
## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?