### PR TITLE
[Bug][Mystery Encounter][Move] MEs with turn 0 moves no longer block sucker punch

### DIFF
--- a/src/phases/mystery-encounter-phases.ts
+++ b/src/phases/mystery-encounter-phases.ts
@@ -257,6 +257,10 @@ export class MysteryEncounterBattleStartCleanupPhase extends Phase {
       globalScene.phaseManager.unshiftNew("ToggleDoublePositionPhase", true);
     }
 
+    for (const pokemon of globalScene.getField(true)) {
+      pokemon.resetTurnData();
+    }
+
     this.end();
   }
 }


### PR DESCRIPTION
## What are the changes the user will see?
Moves like Thunderclap and Sucker Punch will no longer fail on the first turn MysteryEncounters where the opponent leads with a move.
This also fixes an issue where moves like Payback would consider the target to have already acted.

## Why am I making these changes?
Fixes 6588

## What are the changes from a developer perspective?
Add a call to `pokemon#resetTurnData` for each Pokémon on the field in `MysteryEncounterBattleStartCleanupPhase`.

## Screenshots/Videos
<details><summary>Details</summary>

https://github.com/user-attachments/assets/03804cab-0c4d-44fe-909f-1f474eb715fc
</details> 

## How to test the changes?
See #6588. Just download the save, swap oranguru, and use thunderclap with Xurkitree.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes? Ehh... for MEs? No thanks
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~