### PR TITLE
[Bug]]Beta] Boss segments not fully clearing

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -6835,6 +6835,7 @@ export class EnemyPokemon extends Pokemon {
         this.hp,
         segmentSize,
         this.getMinimumSegmentIndex(),
+        this.bossSegmentIndex,
       );
     }
 

--- a/src/utils/damage.ts
+++ b/src/utils/damage.ts
@@ -16,6 +16,7 @@ import { toDmgValue } from "#utils/common";
  * @param currentHp - The target's current HP
  * @param segmentHp - The HP in each segment (total HP / number of segments)
  * @param minSegmentIndex - The minimum segment index that can be cleared; default `0` (all segments). Used for the final boss
+ * @param currentSegmentIndex - The current segment index of the target; if not provided, it will be calculated from `currentHp` and `segmentHp`.
  * @returns A tuple consisting of the adjusted damage and index of the boss segment the target is in after damage is applied.
  */
 export function calculateBossSegmentDamage(
@@ -23,8 +24,9 @@ export function calculateBossSegmentDamage(
   currentHp: number,
   segmentHp: number,
   minSegmentIndex = 0,
+  currentSegmentIndex?: number,
 ): [adjustedDamage: number, clearedBossSegmentIndex: number] {
-  const segmentIndex = Math.ceil(currentHp / segmentHp) - 1;
+  const segmentIndex = currentSegmentIndex ?? Math.ceil(currentHp / segmentHp) - 1;
   if (segmentIndex <= 0) {
     return [damage, 1];
   }


### PR DESCRIPTION
## What are the changes the user will see?
Boss segments no longer stick around with 1HP

## Why am I making these changes?
Big Bad Bug

## What are the changes from a developer perspective?
Pass the boss' current HP segment to avoid issues related to rounding.

## Screenshots/Videos
<details><summary>Details</summary>

https://github.com/user-attachments/assets/d2ae3ebe-d48c-42a8-860b-20b308338fac
</details> 

## How to test the changes?

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~