### PR TITLE
[AI] Prevent ai from using moves guaranteed to fail due to the weather

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -6543,8 +6543,9 @@ export class EnemyPokemon extends Pokemon {
               move.category !== MoveCategory.STATUS
               && moveTargets.some(p => {
                 const doesNotFail =
-                  move.applyConditions(this, p, -1)
-                  || [MoveId.SUCKER_PUNCH, MoveId.UPPER_HAND, MoveId.THUNDERCLAP].includes(move.id);
+                  !globalScene.arena.isMoveWeatherCancelled(this, move)
+                  && (move.applyConditions(this, p, -1)
+                    || [MoveId.SUCKER_PUNCH, MoveId.UPPER_HAND, MoveId.THUNDERCLAP].includes(move.id));
                 return (
                   doesNotFail
                   && p.getAttackDamage({


### PR DESCRIPTION
## What are the changes the user will see?
AI now understands how primal weathers work and will no longer attempt to use moves guaranteed to fail in them.

## Why am I making these changes?
Requested by Balance. Fixes #6265

## What are the changes from a developer perspective?
Add a check to `!globalScene.arena.isMoveWeatherCancelled(this, move)` in `EnemyPokemon#getNextMove` when checking `doesNotFail`

## Screenshots/Videos


## How to test the changes?
Use primal groudon against an enemy that has a water move with high power, and a low power move like quick attack.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?