### PR TITLE
[Balance] Enemy trainer Pokemon will have friendship based on the wave

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -6390,6 +6390,7 @@ export class EnemyPokemon extends Pokemon {
           ivs.push(randSeedIntRange(Math.floor(waveIndex / 10), 31));
         }
         this.ivs = ivs;
+        this.friendship = Math.round(255 * (waveIndex / 200));
       }
     }
 

--- a/test/field/pokemon.test.ts
+++ b/test/field/pokemon.test.ts
@@ -203,14 +203,29 @@ describe("Spec - Pokemon", () => {
     "should set minimum IVs for enemy trainer pokemon based on wave (%i)",
     async wave => {
       game.override.startingWave(wave);
-      await game.classicMode.startBattle([SpeciesId.FEEBAS]);
-      const { waveIndex } = game.scene.currentBattle;
+      await game.classicMode.runToSummon([SpeciesId.FEEBAS]);
 
-      for (const pokemon of game.scene.getEnemyParty()) {
-        for (const index in pokemon.ivs) {
-          expect(pokemon.ivs[index]).toBeGreaterThanOrEqual(Math.floor(waveIndex / 10));
+      for (const pokemon of game.field.getEnemyParty()) {
+        for (const iv of pokemon.ivs) {
+          expect(iv).toBeGreaterThanOrEqual(Math.floor(wave / 10));
         }
       }
     },
   );
+
+  it.each([
+    { wave: 5, friendship: 6 },
+    { wave: 25, friendship: 32 },
+    { wave: 55, friendship: 70 },
+    { wave: 95, friendship: 121 },
+    { wave: 145, friendship: 185 },
+    { wave: 195, friendship: 249 },
+  ])("should set friendship for enemy trainer pokemon based on wave ($wave)", async ({ wave, friendship }) => {
+    game.override.startingWave(wave);
+    await game.classicMode.runToSummon([SpeciesId.FEEBAS]);
+
+    for (const pokemon of game.field.getEnemyParty()) {
+      expect(pokemon.friendship).toBe(friendship);
+    }
+  });
 });

--- a/test/test-utils/helpers/field-helper.ts
+++ b/test/test-utils/helpers/field-helper.ts
@@ -45,6 +45,26 @@ export class FieldHelper extends GameManagerHelper {
   }
 
   /**
+   * Passthrough for {@linkcode globalScene.getPlayerParty} that adds a check that the party contains at least 1 pokemon.
+   * @returns The enemy party
+   */
+  public getPlayerParty(): PlayerPokemon[] {
+    const party = this.game.scene.getPlayerParty();
+    expect(party.length).toBeGreaterThan(0);
+    return party;
+  }
+
+  /**
+   * Passthrough for {@linkcode globalScene.getEnemyParty} that adds a check that the party contains at least 1 pokemon.
+   * @returns The enemy party
+   */
+  public getEnemyParty(): EnemyPokemon[] {
+    const party = this.game.scene.getEnemyParty();
+    expect(party.length).toBeGreaterThan(0);
+    return party;
+  }
+
+  /**
    * Helper function to return all on-field {@linkcode Pokemon} in speed order (fastest first).
    * @param indices - Whether to only return {@linkcode BattlerIndex}es instead of full Pokemon objects
    * (such as for comparison with other speed order-related mechanisms); default `false`


### PR DESCRIPTION
## What are the changes the user will see?
Enemy trainer Pokémon will now have friendship based on the current wave.

## Why am I making these changes?
Request from balance team.

## What are the changes from a developer perspective?
Within the constructor for `EnemyPokemon`, the Pokémon's friendship value will be set based on the following formula if the fight is a trainer battle: `round(max friendship * (current wave / 200))` where the max friendship value a Pokémon can have is `255` and `current wave / 200` represents a % value based on how far in the game you are (e.g. on wave `100` the pokemon will have `50%` of the max friendship value: `round(255 * (100 / 200)) = 128`).

## How to test the changes?
`pnpm test:silent pokemon`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?