### PR TITLE
[Bug] [Ability] Tangling Hair / Gooey now work when its user faints

### DIFF
--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -7299,7 +7299,8 @@ export function initAbilities() {
     new Ability(AbilityId.PIXILATE, 6)
       .attr(MoveTypeChangeAbAttr, PokemonType.FAIRY, 1.2, (_user, _target, move) => move.type === PokemonType.NORMAL),
     new Ability(AbilityId.GOOEY, 6)
-      .attr(PostDefendStatStageChangeAbAttr, (_target, _user, move) => move.hasFlag(MoveFlags.MAKES_CONTACT), Stat.SPD, -1, false),
+      .attr(PostDefendStatStageChangeAbAttr, (_target, _user, move) => move.hasFlag(MoveFlags.MAKES_CONTACT), Stat.SPD, -1, false)
+      .bypassFaint(),
     new Ability(AbilityId.AERILATE, 6)
       .attr(MoveTypeChangeAbAttr, PokemonType.FLYING, 1.2, (_user, _target, move) => move.type === PokemonType.NORMAL),
     new Ability(AbilityId.PARENTAL_BOND, 6)
@@ -7464,7 +7465,8 @@ export function initAbilities() {
     new Ability(AbilityId.SOUL_HEART, 7)
       .attr(PostKnockOutStatStageChangeAbAttr, Stat.SPATK, 1),
     new Ability(AbilityId.TANGLING_HAIR, 7)
-      .attr(PostDefendStatStageChangeAbAttr, (target, user, move) => move.doesFlagEffectApply({flag: MoveFlags.MAKES_CONTACT, user, target}), Stat.SPD, -1, false),
+      .attr(PostDefendStatStageChangeAbAttr, (target, user, move) => move.doesFlagEffectApply({flag: MoveFlags.MAKES_CONTACT, user, target}), Stat.SPD, -1, false)
+      .bypassFaint(),
     new Ability(AbilityId.RECEIVER, 7)
       .attr(CopyFaintedAllyAbilityAbAttr)
       .uncopiable(),


### PR DESCRIPTION
## What are the changes the user will see?
Tangling hair and gooey now work when their user faints from the attack.

## Why am I making these changes?
Found bug while playtesting 6614. It's unrelated.

## What are the changes from a developer perspective?
Add `.bypassFaint()` to both abilities.

## Screenshots/Videos
Bro.

## How to test the changes?
Set override to spawn alolan dugtrio, have a level like 200 mon use fake out. Observe speed drop.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes? cba it's past midnight
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~