### PR TITLE
[Feature] Fixes #[6369] where Poison Puppeteer didn't work with Toxic Chain.

### DIFF
--- a/src/phases/obtain-status-effect-phase.ts
+++ b/src/phases/obtain-status-effect-phase.ts
@@ -6,6 +6,7 @@ import { SpeciesFormChangeStatusEffectTrigger } from "#data/form-change-triggers
 import { getStatusEffectObtainText } from "#data/status-effect";
 import type { BattlerIndex } from "#enums/battler-index";
 import { CommonAnim } from "#enums/move-anims-common";
+import { MoveId } from "#enums/move-id";
 import { StatusEffect } from "#enums/status-effect";
 import type { Pokemon } from "#field/pokemon";
 import { PokemonPhase } from "#phases/pokemon-phase";
@@ -60,6 +61,16 @@ export class ObtainStatusEffectPhase extends PokemonPhase {
           effect: this.statusEffect,
           sourcePokemon: this.sourcePokemon ?? undefined,
         });
+        // Trigger ConfusionOnStatusEffectAbAttr (e.g., Poison Puppeteer) when status is applied
+        //Before this, Poison Puppeteer didn't work with Toxic Chain.
+        if (this.sourcePokemon) {
+          applyAbAttrs("ConfusionOnStatusEffectAbAttr", {
+            pokemon: this.sourcePokemon,
+            opponent: pokemon,
+            move: { id: MoveId.NONE } as any, // Use NONE move since this is Ability/Passive trigger.
+            effect: this.statusEffect,
+          });
+        }
       }
       this.end();
     });


### PR DESCRIPTION
## What are the changes the user will see?
Now, whenever a Pokemon has both poison puppeteer and toxic chain, the toxic chain will activate, causing poison, and then poison puppeteer will cause confusion.


## Why am I making these changes?
Fixes #[6369] 
This PR tries to fix issue #6369 where poison puppeteer doesn't work with toxic chain.



## What are the changes from a developer perspective?
I added a conditional block within the current if statement of obtain-status-effect-phase.ts to check if the thing causing the poison was in fact a pokemon and not from another source. If it was, then applyAbAttrs("ConfusionOnStatusEffectAbAttr", ...) is called where within that, the pokemon is confirmed to have the ability/passive Poison Puppeteer, and if it does the opposing pokemon becomes confused.


## How to test the changes?
To test the change, unlock Pecharunt's passive and get it's Toxic Chain to poison a Pokemon and then it's Poison Puppeteer should activate and cause confusion.


## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?

Does this require any changes to the assets folder? If so:
  - [ ] Has a PR been created on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repo?
    - [ ] If so, please leave a link to it here: 