### PR TITLE
[Bug/Ability] Fix Forewarn not triggering + add randomized selection

### DIFF
--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -4272,14 +4272,14 @@ export class ForewarnAbAttr extends PostSummonAbAttr {
         if (movePower < maxPowerSeen) {
           continue;
         }
-  
-        // Another move at current max found; add to tiebreaker array 
+
+        // Another move at current max found; add to tiebreaker array
         if (movePower === maxPowerSeen) {
           movesAtMaxPower.push(move.name);
           continue;
         }
-  
-        // New max reached; clear prior results and update tracker 
+
+        // New max reached; clear prior results and update tracker
         maxPowerSeen = movePower;
         movesAtMaxPower.splice(0, movesAtMaxPower.length, move.name);
       }
@@ -4309,18 +4309,18 @@ export class ForewarnAbAttr extends PostSummonAbAttr {
 function getForewarnPower(move: Move): number {
   if (move.is("StatusMove")) {
     return 1;
-  } 
-  
+  }
+
   if (move.hasAttr("OneHitKOAttr")) {
     return 150;
-  } 
+  }
 
   // NB: Mainline doesn't count Comeuppance in its "counter move exceptions" list, which is dumb
   if (move.hasAttr("CounterDamageAttr")) {
     return 120;
   }
 
-  // All damaging moves with unlisted powers use 80 as a fallback 
+  // All damaging moves with unlisted powers use 80 as a fallback
   if (move.power === -1) {
     return 80;
   }


### PR DESCRIPTION
## What are the changes the user will see?
Forewarn:
1. Actually works again (since #6002 apparently inverted the `simulated` check conditional)
2. (Decided by balance) Now considers Comeuppance as a counter move for move power calcs. (Previously, it was lumped in with other "no listed power" moves as 80 base)
3. Will randomly pick a move if multiple tie (rather than always using the first one found)

## Why am I making these changes?
Blitzy asked me to take a look.
I took a look and found some ~~fun~~ bad stuff

## What are the changes from a developer perspective?
Fixed up `ForewarnAttr` with the help of a new helper function to compute move power

## Screenshots/Videos
N/A

## How to test the changes?
Send out Forewarn a lot, preferably against enemies with status-move-only movesets

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?