### PR TITLE
[Bug] Fix Heal Block inconsistencies + add restriction tests

### DIFF
--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -7,7 +7,7 @@ import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import type { EntryHazardTag, SuppressAbilitiesTag } from "#data/arena-tag";
-import type { BattlerTag } from "#data/battler-tags";
+import type { BattlerTag, BattlerTagTypeConstructorMap } from "#data/battler-tags";
 import { GroundedTag } from "#data/battler-tags";
 import { getBerryEffectFunc } from "#data/berry";
 import { allAbilities, allMoves } from "#data/data-lists";
@@ -4384,17 +4384,21 @@ export class PostWeatherChangeFormChangeAbAttr extends PostWeatherChangeAbAttr {
  * Add a battler tag to the pokemon when the weather changes.
  * @sealed
  */
-export class PostWeatherChangeAddBattlerTagAttr extends PostWeatherChangeAbAttr {
-  private tagType: BattlerTagType;
-  private turnCount: number;
-  private weatherTypes: WeatherType[];
+export class PostWeatherChangeAddBattlerTagAttr<T extends BattlerTagType> extends PostWeatherChangeAbAttr {
+  private readonly tagType: T;
+  private readonly weatherTypes: readonly [WeatherType, ...WeatherType[]];
+  private readonly args: readonly ConstructorParameters<BattlerTagTypeConstructorMap[T]>;
 
-  constructor(tagType: BattlerTagType, turnCount: number, ...weatherTypes: WeatherType[]) {
+  constructor(
+    tagType: T,
+    weatherTypes: readonly [WeatherType, ...WeatherType[]],
+    ...args: readonly ConstructorParameters<BattlerTagTypeConstructorMap[T]>
+  ) {
     super();
 
     this.tagType = tagType;
-    this.turnCount = turnCount;
     this.weatherTypes = weatherTypes;
+    this.args = args;
   }
 
   override canApply({ weather, pokemon }: PostWeatherChangeAbAttrParams): boolean {
@@ -4403,7 +4407,7 @@ export class PostWeatherChangeAddBattlerTagAttr extends PostWeatherChangeAbAttr 
 
   override apply({ simulated, pokemon }: PostWeatherChangeAbAttrParams): void {
     if (!simulated) {
-      pokemon.addTag(this.tagType, this.turnCount);
+      pokemon.addTag(this.tagType, ...this.args);
     }
   }
 }

--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -7,7 +7,7 @@ import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import type { EntryHazardTag, SuppressAbilitiesTag } from "#data/arena-tag";
-import type { BattlerTag, BattlerTagTypeConstructorMap } from "#data/battler-tags";
+import type { BattlerTag } from "#data/battler-tags";
 import { GroundedTag } from "#data/battler-tags";
 import { getBerryEffectFunc } from "#data/berry";
 import { allAbilities, allMoves } from "#data/data-lists";
@@ -4384,21 +4384,17 @@ export class PostWeatherChangeFormChangeAbAttr extends PostWeatherChangeAbAttr {
  * Add a battler tag to the pokemon when the weather changes.
  * @sealed
  */
-export class PostWeatherChangeAddBattlerTagAttr<T extends BattlerTagType> extends PostWeatherChangeAbAttr {
-  private readonly tagType: T;
-  private readonly weatherTypes: readonly [WeatherType, ...WeatherType[]];
-  private readonly args: readonly ConstructorParameters<BattlerTagTypeConstructorMap[T]>;
+export class PostWeatherChangeAddBattlerTagAttr extends PostWeatherChangeAbAttr {
+  private tagType: BattlerTagType;
+  private turnCount: number;
+  private weatherTypes: WeatherType[];
 
-  constructor(
-    tagType: T,
-    weatherTypes: readonly [WeatherType, ...WeatherType[]],
-    ...args: readonly ConstructorParameters<BattlerTagTypeConstructorMap[T]>
-  ) {
+  constructor(tagType: BattlerTagType, turnCount: number, ...weatherTypes: WeatherType[]) {
     super();
 
     this.tagType = tagType;
+    this.turnCount = turnCount;
     this.weatherTypes = weatherTypes;
-    this.args = args;
   }
 
   override canApply({ weather, pokemon }: PostWeatherChangeAbAttrParams): boolean {
@@ -4407,7 +4403,7 @@ export class PostWeatherChangeAddBattlerTagAttr<T extends BattlerTagType> extend
 
   override apply({ simulated, pokemon }: PostWeatherChangeAbAttrParams): void {
     if (!simulated) {
-      pokemon.addTag(this.tagType, ...this.args);
+      pokemon.addTag(this.tagType, this.turnCount);
     }
   }
 }

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2897,7 +2897,6 @@ export class HealBlockTag extends MoveRestrictionBattlerTag {
    * @param target - The target of the move
    * @returns `true` if the move cannot be used because the target is an ally
    */
-  // TODO: This should probably be a restriction on pollen puff rather than being done here
   override isMoveTargetRestricted(move: MoveId, user: Pokemon, target: Pokemon) {
     const moveCategory = new NumberHolder(allMoves[move].category);
     applyMoveAttrs("StatusCategoryOnAllyAttr", user, target, allMoves[move], moveCategory);

--- a/src/data/moves/invalid-moves.ts
+++ b/src/data/moves/invalid-moves.ts
@@ -1,3 +1,5 @@
+// biome-ignore lint/correctness/noUnusedImports: TSDoc
+import type { HealBlockTag } from "#data/battler-tags";
 import { MoveId } from "#enums/move-id";
 
 /** Set of moves that cannot be called by {@linkcode MoveId.METRONOME | Metronome}. */
@@ -241,7 +243,8 @@ export const invalidMirrorMoveMoves: ReadonlySet<MoveId> = new Set([
   MoveId.WIDE_GUARD,
 ]);
 
-/** Set of moves that can never have their type overridden by an ability like Pixilate or Normalize
+/**
+ *  Set of moves that can never have their type overridden by an ability like Pixilate or Normalize
  *
  * Excludes tera blast and tera starstorm, as these are only conditionally forbidden
  */
@@ -268,6 +271,50 @@ export const invalidSketchMoves: ReadonlySet<MoveId> = new Set([
   MoveId.TERA_STARSTORM,
   MoveId.BREAKNECK_BLITZ__PHYSICAL,
   MoveId.BREAKNECK_BLITZ__SPECIAL,
+]);
+
+/**
+ * Set of all Moves rendered unusable by {@linkcode HealBlockTag | Heal Block}.
+ *
+ * Pollen Puff is not included as that is only forbidden if used _against_ a Pokemon with Heal Block applied.
+ */
+export const healBlockedMoves: ReadonlySet<MoveId> = new Set([
+  MoveId.ABSORB,
+  MoveId.MEGA_DRAIN,
+  MoveId.RECOVER,
+  MoveId.SOFT_BOILED,
+  MoveId.DREAM_EATER,
+  MoveId.LEECH_LIFE,
+  MoveId.REST,
+  MoveId.GIGA_DRAIN,
+  MoveId.MILK_DRINK,
+  MoveId.MORNING_SUN,
+  MoveId.SYNTHESIS,
+  MoveId.MOONLIGHT,
+  MoveId.SWALLOW,
+  MoveId.WISH,
+  MoveId.SLACK_OFF,
+  MoveId.ROOST,
+  MoveId.HEALING_WISH,
+  MoveId.DRAIN_PUNCH,
+  MoveId.HEAL_ORDER,
+  MoveId.LUNAR_DANCE,
+  MoveId.HEAL_PULSE,
+  MoveId.HORN_LEECH,
+  MoveId.PARABOLIC_CHARGE,
+  MoveId.DRAINING_KISS,
+  MoveId.OBLIVION_WING,
+  MoveId.SHORE_UP,
+  MoveId.FLORAL_HEALING,
+  MoveId.STRENGTH_SAP,
+  MoveId.PURIFY,
+  MoveId.BOUNCY_BUBBLE,
+  MoveId.LIFE_DEW,
+  MoveId.JUNGLE_HEALING,
+  MoveId.LUNAR_BLESSING,
+  MoveId.REVIVAL_BLESSING,
+  MoveId.BITTER_BLADE,
+  MoveId.MATCHA_GOTCHA,
 ]);
 
 /** Set of all moves that cannot be locked into by {@linkcode MoveId.ENCORE}. */

--- a/src/data/pokemon/pokemon-data.ts
+++ b/src/data/pokemon/pokemon-data.ts
@@ -11,6 +11,8 @@ import type { Nature } from "#enums/nature";
 import type { PokemonType } from "#enums/pokemon-type";
 import type { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
+// biome-ignore lint/correctness/noUnusedImports: TSDoc
+import type { Pokemon } from "#field/pokemon";
 import type { AttackMoveResult } from "#types/attack-move-result";
 import type { IllusionData } from "#types/illusion-data";
 import type { TurnMove } from "#types/turn-move";

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4277,7 +4277,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    */
   // TODO: rename this method as it can be easily confused with a move being restricted
   public isMoveRestricted(moveId: MoveId): boolean {
-    return this.getRestrictingTag(moveId, this) !== null;
+    return this.getRestrictingTag(moveId) !== null;
   }
 
   /**
@@ -4292,7 +4292,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @see {@linkcode isMoveRestricted}
    */
   public isMoveSelectable(moveId: MoveId): [boolean, string] {
-    const restrictedTag = this.getRestrictingTag(moveId, this);
+    const restrictedTag = this.getRestrictingTag(moveId);
     if (restrictedTag) {
       return [false, restrictedTag.selectionDeniedText(this, moveId)];
     }
@@ -4300,19 +4300,17 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Get whether the given move is currently disabled for the user based on the player's target selection
-   *
-   * @param moveId - The ID of the move to check
-   * @param user - The move user
-   * @param target - The target of the move
-   *
-   * @returns `true` if the move is disabled for this Pokemon due to the player's target selection
-   *
+   * Return whether this Pokemon is restricted from using a move against the given target.
+   * @param moveId - The `MoveId` of the move being used
+   * @param target - The `Pokemon` being targeted by the move
+   * @returns Whether `moveId` is unable to target `target` due to a restricting effect
    * @see {@linkcode MoveRestrictionBattlerTag}
    */
-  isMoveTargetRestricted(moveId: MoveId, user: Pokemon, target: Pokemon): boolean {
+  // TODO: Expand `MoveRestriction`s to allow for target based stuff and
+  // refactor this entire line of functions
+  isMoveTargetRestricted(moveId: MoveId, target: Pokemon): boolean {
     for (const tag of this.findTags(t => t instanceof MoveRestrictionBattlerTag)) {
-      if ((tag as MoveRestrictionBattlerTag).isMoveTargetRestricted(moveId, user, target)) {
+      if ((tag as MoveRestrictionBattlerTag).isMoveTargetRestricted(moveId, this, target)) {
         return (tag as MoveRestrictionBattlerTag) !== null;
       }
     }
@@ -4320,19 +4318,19 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Get the {@link MoveRestrictionBattlerTag} that is restricting a move, if it exists.
+   * Get the {@link MoveRestrictionBattlerTag} that is restricting this Pokemon's move usage,
+   * if one exists.
    *
    * @param moveId - The ID of the move to check
-   * @param user - The move user, optional and used when the target is a factor in the move's restricted status
    * @param target - The target of the move; optional, and used when the target is a factor in the move's restricted status
    * @returns The first tag on this Pokemon that restricts the move, or `null` if the move is not restricted.
    */
-  getRestrictingTag(moveId: MoveId, user?: Pokemon, target?: Pokemon): MoveRestrictionBattlerTag | null {
+  getRestrictingTag(moveId: MoveId, target?: Pokemon): MoveRestrictionBattlerTag | null {
     for (const tag of this.findTags(t => t instanceof MoveRestrictionBattlerTag)) {
-      if ((tag as MoveRestrictionBattlerTag).isMoveRestricted(moveId, user)) {
+      if ((tag as MoveRestrictionBattlerTag).isMoveRestricted(moveId, this)) {
         return tag as MoveRestrictionBattlerTag;
       }
-      if (user && target && (tag as MoveRestrictionBattlerTag).isMoveTargetRestricted(moveId, user, target)) {
+      if (target && (tag as MoveRestrictionBattlerTag).isMoveTargetRestricted(moveId, this, target)) {
         return tag as MoveRestrictionBattlerTag;
       }
     }

--- a/src/phases/select-target-phase.ts
+++ b/src/phases/select-target-phase.ts
@@ -23,9 +23,9 @@ export class SelectTargetPhase extends PokemonPhase {
       const fieldSide = globalScene.getField();
       const user = fieldSide[this.fieldIndex];
       const moveObject = allMoves[move!];
-      if (moveObject && user.isMoveTargetRestricted(moveObject.id, user, fieldSide[targets[0]])) {
+      if (moveObject && user.isMoveTargetRestricted(moveObject.id, fieldSide[targets[0]])) {
         const errorMessage = user
-          .getRestrictingTag(move!, user, fieldSide[targets[0]])!
+          .getRestrictingTag(move!, fieldSide[targets[0]])!
           .selectionDeniedText(user, moveObject.id);
         globalScene.phaseManager.queueMessage(i18next.t(errorMessage, { moveName: moveObject.name }), 0, true);
         targets = [];

--- a/test/moves/heal-block.test.ts
+++ b/test/moves/heal-block.test.ts
@@ -1,16 +1,20 @@
+import { getPokemonNameWithAffix } from "#app/messages";
+import { allMoves } from "#data/data-lists";
 import { AbilityId } from "#enums/ability-id";
 import { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
 import { PositionalTagType } from "#enums/positional-tag-type";
 import { SpeciesId } from "#enums/species-id";
-import { WeatherType } from "#enums/weather-type";
+import { healBlockedMoves } from "#moves/invalid-moves";
+import i18next from "#plugins/i18n";
 import { GameManager } from "#test/test-utils/game-manager";
+import { toTitleCase } from "#utils/strings";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 // Bulbapedia Reference: https://bulbapedia.bulbagarden.net/wiki/Heal_Block_(move)
-describe("Moves - Heal Block", () => {
+describe("Move - Heal Block", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
 
@@ -27,7 +31,6 @@ describe("Moves - Heal Block", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     game.override
-      .moveset([MoveId.ABSORB, MoveId.WISH, MoveId.SPLASH, MoveId.AQUA_RING])
       .enemyMoveset(MoveId.HEAL_BLOCK)
       .ability(AbilityId.NO_GUARD)
       .enemyAbility(AbilityId.BALL_FETCH)
@@ -35,115 +38,105 @@ describe("Moves - Heal Block", () => {
       .criticalHits(false);
   });
 
-  it("shouldn't stop damage from HP-drain attacks, just HP restoration", async () => {
-    await game.classicMode.startBattle([SpeciesId.CHARIZARD]);
+  const blockTestCases = Array.from(healBlockedMoves).map(m => ({
+    move: m,
+    name: toTitleCase(MoveId[m]),
+  }));
 
-    const player = game.field.getPlayerPokemon();
-    const enemy = game.field.getEnemyPokemon();
+  it.each(blockTestCases)("should cause $name to become unselectable by the user", async ({ move }) => {
+    await game.classicMode.startBattle([SpeciesId.FEEBAS]);
 
-    player.damageAndUpdate(player.getMaxHp() - 1);
+    const feebas = game.field.getPlayerPokemon();
+    feebas.addTag(BattlerTagType.HEAL_BLOCK);
 
-    game.move.select(MoveId.ABSORB);
-    await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
-    await game.phaseInterceptor.to("TurnEndPhase");
-
-    expect(player.hp).toBe(1);
-    expect(enemy.hp).toBeLessThan(enemy.getMaxHp());
+    expect(feebas.isMoveSelectable(move)).toEqual([
+      false,
+      i18next.t("battle:moveDisabledHealBlock", {
+        pokemonNameWithAffix: getPokemonNameWithAffix(feebas),
+        moveName: allMoves[move].name,
+      }),
+    ]);
   });
 
   it("shouldn't stop Liquid Ooze from dealing damage", async () => {
     game.override.enemyAbility(AbilityId.LIQUID_OOZE);
-
-    await game.classicMode.startBattle([SpeciesId.CHARIZARD]);
+    await game.classicMode.startBattle([SpeciesId.FEEBAS]);
 
     const player = game.field.getPlayerPokemon();
     const enemy = game.field.getEnemyPokemon();
 
-    game.move.select(MoveId.ABSORB);
+    game.move.use(MoveId.ABSORB);
     await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
-    await game.phaseInterceptor.to("TurnEndPhase");
+    await game.toEndOfTurn();
 
-    expect(player.isFullHp()).toBe(false);
-    expect(enemy.isFullHp()).toBe(false);
+    expect(player).not.toHaveFullHp();
+    expect(enemy).not.toHaveFullHp();
   });
 
-  it("should prevent Wish from restoring HP", async () => {
-    await game.classicMode.startBattle([SpeciesId.CHARIZARD]);
+  it("should prevent pending Wishes from restoring HP", async () => {
+    await game.classicMode.startBattle([SpeciesId.FEEBAS]);
 
     const player = game.field.getPlayerPokemon();
-
     player.hp = 1;
 
     game.move.use(MoveId.WISH);
+    await game.move.forceEnemyMove(MoveId.SPLASH);
     await game.toNextTurn();
 
-    expect(game.scene.arena.positionalTagManager.tags.filter(t => t.tagType === PositionalTagType.WISH)) //
-      .toHaveLength(1);
+    expect(game).toHavePositionalTag(PositionalTagType.WISH, 1);
 
     game.move.use(MoveId.SPLASH);
-    await game.toNextTurn();
+    await game.move.forceEnemyMove(MoveId.HEAL_BLOCK);
+    await game.toEndOfTurn();
 
     // wish triggered, but did NOT heal the player
-    expect(game.scene.arena.positionalTagManager.tags.filter(t => t.tagType === PositionalTagType.WISH)) //
-      .toHaveLength(0);
-    expect(player.hp).toBe(1);
+    expect(game).not.toHavePositionalTag(PositionalTagType.WISH);
+    expect(player).toHaveHp(1);
   });
 
   it("should prevent Grassy Terrain from restoring HP", async () => {
     game.override.enemyAbility(AbilityId.GRASSY_SURGE);
-
-    await game.classicMode.startBattle([SpeciesId.CHARIZARD]);
+    await game.classicMode.startBattle([SpeciesId.FEEBAS]);
 
     const player = game.field.getPlayerPokemon();
+    player.hp = 1;
 
-    player.damageAndUpdate(player.getMaxHp() - 1);
+    game.move.use(MoveId.SPLASH);
+    await game.toEndOfTurn();
 
-    game.move.select(MoveId.SPLASH);
-    await game.phaseInterceptor.to("TurnEndPhase");
-
-    expect(player.hp).toBe(1);
+    expect(player).toHaveHp(1);
   });
 
-  it("should prevent healing from heal-over-time moves", async () => {
-    await game.classicMode.startBattle([SpeciesId.CHARIZARD]);
+  it.each([
+    { name: "Aqua Ring", move: MoveId.AQUA_RING, tagType: BattlerTagType.AQUA_RING },
+    { name: "Ingrain", move: MoveId.INGRAIN, tagType: BattlerTagType.INGRAIN },
+  ])("should not cause $name to fail, but should still prevent healing", async ({ move, tagType }) => {
+    await game.classicMode.startBattle([SpeciesId.FEEBAS]);
 
-    const player = game.field.getPlayerPokemon();
+    const feebas = game.field.getPlayerPokemon();
+    feebas.hp = 1;
 
-    player.damageAndUpdate(player.getMaxHp() - 1);
+    game.move.use(move);
+    await game.toEndOfTurn();
 
-    game.move.select(MoveId.AQUA_RING);
-    await game.phaseInterceptor.to("TurnEndPhase");
-
-    expect(player.getTag(BattlerTagType.AQUA_RING)).toBeDefined();
-    expect(player.hp).toBe(1);
-  });
-
-  it("should prevent abilities from restoring HP", async () => {
-    game.override.weather(WeatherType.RAIN).ability(AbilityId.RAIN_DISH);
-
-    await game.classicMode.startBattle([SpeciesId.CHARIZARD]);
-
-    const player = game.field.getPlayerPokemon();
-
-    player.damageAndUpdate(player.getMaxHp() - 1);
-
-    game.move.select(MoveId.SPLASH);
-    await game.phaseInterceptor.to("TurnEndPhase");
-
-    expect(player.hp).toBe(1);
+    expect(feebas).toHaveBattlerTag(tagType);
+    expect(feebas).toHaveHp(1);
   });
 
   it("should stop healing from items", async () => {
     game.override.startingHeldItems([{ name: "LEFTOVERS" }]);
-
-    await game.classicMode.startBattle([SpeciesId.CHARIZARD]);
+    await game.classicMode.startBattle([SpeciesId.FEEBAS]);
 
     const player = game.field.getPlayerPokemon();
-    player.damageAndUpdate(player.getMaxHp() - 1);
+    player.hp = 1;
 
-    game.move.select(MoveId.SPLASH);
-    await game.phaseInterceptor.to("TurnEndPhase");
+    game.move.use(MoveId.SPLASH);
+    await game.toEndOfTurn();
 
-    expect(player.hp).toBe(1);
+    expect(player).toHaveHp(1);
   });
+
+  // TODO: Write tests
+  it.todo("should not affect Pain Split");
+  it.todo("should not affect Regenerator");
 });


### PR DESCRIPTION
## What are the changes the user will see?
Heal block:
1. Restricts a list of moves (presumably) more in sync with mainline

## Why am I making these changes?
Was working on #5989 when I noticed heal block's messages were incorrect.
I also noted the entire move impl was incorrect lol

## What are the changes from a developer perspective?
Changed Heal Block's normal restriction method to a banlist instead of checking triage move status

Fixed approximately all the locales inconsistencies with heal block (locales PR WIP)

## Screenshots/Videos
TODO

## How to test the changes?
Use heal block and make sure nothing explodes

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? YES
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
