### PR TITLE
[Misc] Rename `Pokemon.isMoveRestricted` to `hasRestrictingTag`

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4264,19 +4264,16 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Get whether the given move is currently disabled for this Pokémon
+   * Get whether the given move is currently disabled for this Pokémon by a move restriction tag.
    *
    * @remarks
    * ⚠️ Only checks for restrictions due to a battler tag, not due to the move's own attributes.
-   * (for that behavior, see {@linkcode isMoveSelectable}).
-   *
    * @param moveId - The ID of the move to check
    * @returns `true` if the move is disabled for this Pokemon, otherwise `false`
-   *
    * @see {@linkcode MoveRestrictionBattlerTag}
    */
-  // TODO: rename this method as it can be easily confused with a move being restricted
-  public isMoveRestricted(moveId: MoveId): boolean {
+  // TODO: Move this behavior into a matcher and expunge it from the codebase - we only use it for tests
+  public hasRestrictingTag(moveId: MoveId): boolean {
     return this.getRestrictingTag(moveId, this) !== null;
   }
 

--- a/test/abilities/gorilla-tactics.test.ts
+++ b/test/abilities/gorilla-tactics.test.ts
@@ -48,8 +48,8 @@ describe("Abilities - Gorilla Tactics", () => {
 
     expect(darmanitan.getStat(Stat.ATK, false)).toBeCloseTo(initialAtkStat * 1.5);
     // Other moves should be restricted
-    expect(darmanitan.isMoveRestricted(MoveId.TACKLE)).toBe(true);
-    expect(darmanitan.isMoveRestricted(MoveId.SPLASH)).toBe(false);
+    expect(darmanitan.hasRestrictingTag(MoveId.TACKLE)).toBe(true);
+    expect(darmanitan.hasRestrictingTag(MoveId.SPLASH)).toBe(false);
   });
 
   it("should struggle if the only usable move is disabled", async () => {
@@ -92,8 +92,8 @@ describe("Abilities - Gorilla Tactics", () => {
     await game.phaseInterceptor.to("TurnEndPhase");
 
     // Gorilla Tactics should lock into Metronome, not tackle
-    expect(darmanitan.isMoveRestricted(MoveId.TACKLE)).toBe(true);
-    expect(darmanitan.isMoveRestricted(MoveId.METRONOME)).toBe(false);
+    expect(darmanitan.hasRestrictingTag(MoveId.TACKLE)).toBe(true);
+    expect(darmanitan.hasRestrictingTag(MoveId.METRONOME)).toBe(false);
     expect(darmanitan.getLastXMoves(-1)).toEqual([
       expect.objectContaining({ move: MoveId.TACKLE, result: MoveResult.SUCCESS, useMode: MoveUseMode.FOLLOW_UP }),
       expect.objectContaining({ move: MoveId.METRONOME, result: MoveResult.SUCCESS, useMode: MoveUseMode.NORMAL }),
@@ -109,8 +109,8 @@ describe("Abilities - Gorilla Tactics", () => {
     await game.move.forceEnemyMove(MoveId.PROTECT);
 
     await game.toEndOfTurn();
-    expect(darmanitan.isMoveRestricted(MoveId.SPLASH)).toBe(true);
-    expect(darmanitan.isMoveRestricted(MoveId.TACKLE)).toBe(false);
+    expect(darmanitan.hasRestrictingTag(MoveId.SPLASH)).toBe(true);
+    expect(darmanitan.hasRestrictingTag(MoveId.TACKLE)).toBe(false);
     const enemy = game.field.getEnemyPokemon();
     expect(enemy.hp).toBe(enemy.getMaxHp());
   });
@@ -125,7 +125,7 @@ describe("Abilities - Gorilla Tactics", () => {
     await game.move.forceMiss();
     await game.toEndOfTurn();
 
-    expect(darmanitan.isMoveRestricted(MoveId.SPLASH)).toBe(true);
-    expect(darmanitan.isMoveRestricted(MoveId.TACKLE)).toBe(false);
+    expect(darmanitan.hasRestrictingTag(MoveId.SPLASH)).toBe(true);
+    expect(darmanitan.hasRestrictingTag(MoveId.TACKLE)).toBe(false);
   });
 });

--- a/test/moves/disable.test.ts
+++ b/test/moves/disable.test.ts
@@ -49,8 +49,8 @@ describe("Moves - Disable", () => {
     await game.toNextTurn();
 
     expect(enemyMon.getLastXMoves(-1)).toHaveLength(2);
-    expect(enemyMon.isMoveRestricted(MoveId.SPLASH)).toBe(true);
-    expect(enemyMon.isMoveRestricted(MoveId.GROWL)).toBe(false);
+    expect(enemyMon.hasRestrictingTag(MoveId.SPLASH)).toBe(true);
+    expect(enemyMon.hasRestrictingTag(MoveId.GROWL)).toBe(false);
   });
 
   it("should fail if enemy has no move history", async () => {
@@ -67,7 +67,7 @@ describe("Moves - Disable", () => {
       move: MoveId.DISABLE,
       result: MoveResult.FAIL,
     });
-    expect(enemyMon.isMoveRestricted(MoveId.SPLASH)).toBe(false);
+    expect(enemyMon.hasRestrictingTag(MoveId.SPLASH)).toBe(false);
   });
 
   it("causes STRUGGLE if all usable moves are disabled", async () => {
@@ -100,7 +100,7 @@ describe("Moves - Disable", () => {
 
     expect(playerMon.getLastXMoves()[0].result).toBe(MoveResult.FAIL);
     expect(enemyMon.getLastXMoves()[0].move).toBe(MoveId.STRUGGLE);
-    expect(enemyMon.isMoveRestricted(MoveId.STRUGGLE)).toBe(false);
+    expect(enemyMon.hasRestrictingTag(MoveId.STRUGGLE)).toBe(false);
   });
 
   it("should interrupt target's move if used first", async () => {
@@ -142,11 +142,11 @@ describe("Moves - Disable", () => {
     await game.toNextTurn();
 
     const enemyMon = game.field.getEnemyPokemon();
-    expect(enemyMon.isMoveRestricted(moveId), `calling move ${MoveId[moveId]} was not disabled`).toBe(true);
+    expect(enemyMon.hasRestrictingTag(moveId), `calling move ${MoveId[moveId]} was not disabled`).toBe(true);
     expect(enemyMon.getLastXMoves(-1)).toHaveLength(2);
     const calledMove = enemyMon.getLastXMoves()[0].move;
     expect(
-      enemyMon.isMoveRestricted(calledMove),
+      enemyMon.hasRestrictingTag(calledMove),
       `called move ${MoveId[calledMove]} (from ${MoveId[moveId]}) was incorrectly disabled`,
     ).toBe(false);
   });
@@ -171,8 +171,8 @@ describe("Moves - Disable", () => {
     // Dancer-induced Swords Dance was ignored in favor of splash,
     // leaving the subsequent _normal_ swords dance free to work as normal
     const shuckle = game.field.getEnemyPokemon();
-    expect.soft(shuckle.isMoveRestricted(MoveId.SPLASH)).toBe(true);
-    expect.soft(shuckle.isMoveRestricted(MoveId.SWORDS_DANCE)).toBe(false);
+    expect.soft(shuckle.hasRestrictingTag(MoveId.SPLASH)).toBe(true);
+    expect.soft(shuckle.hasRestrictingTag(MoveId.SWORDS_DANCE)).toBe(false);
     expect(shuckle.getLastXMoves()[0]).toMatchObject({ move: MoveId.SWORDS_DANCE, result: MoveResult.SUCCESS });
     expect(shuckle.getStatStage(Stat.ATK)).toBe(4);
   });


### PR DESCRIPTION
## What are the changes the user will see?
N/A
## Why am I making these changes?
Simple + resolves TODO
## What are the changes from a developer perspective?
Renamed method and added TODO to remove from codebase (since it's only use ATM is for tests)

## Screenshots/Videos
N/A
## How to test the changes?
Typecheck
## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?