### PR TITLE
[Misc] Updated documentation & typing for `setPositionRelative` function

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -31,13 +31,25 @@ window.addEventListener("unhandledrejection", event => {
 });
 
 /**
- * Sets this object's position relative to another object with a given offset
+ * Set this object's position relative to another object with a given offset.
+ * @param guideObject - The object to base this object's position off of; must have defined
+ * x/y co-ordinates, an origin and width/height
+ * @param x - The X-position to set, relative to `guideObject`'s `x` value
+ * @param y - The Y-position to set, relative to `guideObject`'s `y` value
+ * @returns `this`
  */
-const setPositionRelative = function (guideObject: Phaser.GameObjects.GameObject, x: number, y: number) {
+function setPositionRelative<T extends Phaser.GameObjects.Components.Transform>(
+  this: T,
+  guideObject: Pick<Phaser.GameObjects.Components.ComputedSize, "width" | "height"> &
+    Pick<Phaser.GameObjects.Components.Transform, "x" | "y"> &
+    Pick<Phaser.GameObjects.Components.Origin, "originX" | "originY">,
+  x: number,
+  y: number,
+): T {
   const offsetX = guideObject.width * (-0.5 + (0.5 - guideObject.originX));
   const offsetY = guideObject.height * (-0.5 + (0.5 - guideObject.originY));
   return this.setPosition(guideObject.x + offsetX + x, guideObject.y + offsetY + y);
-};
+}
 
 Phaser.GameObjects.Container.prototype.setPositionRelative = setPositionRelative;
 Phaser.GameObjects.Sprite.prototype.setPositionRelative = setPositionRelative;

--- a/src/typings/phaser/index.d.ts
+++ b/src/typings/phaser/index.d.ts
@@ -1,57 +1,36 @@
 import "phaser";
 
+/**
+ * Interface representing an object that can be passed to {@linkcode setPositionRelative}.
+ * @interface
+ */
+type GuideObject = Pick<Phaser.GameObjects.Components.ComputedSize, "width" | "height"> &
+  Pick<Phaser.GameObjects.Components.Transform, "x" | "y"> &
+  Pick<Phaser.GameObjects.Components.Origin, "originX" | "originY">;
+
+type setPositionRelative =
+  /**
+   * Set this object's position relative to another object with a given offset.
+   * @param guideObject - The object to base this object's position off of; must have defined
+   * x/y co-ordinates, an origin and width/height
+   * @param x - The X-position to set, relative to `guideObject`'s `x` value
+   * @param y - The Y-position to set, relative to `guideObject`'s `y` value
+   * @returns `this`
+   */
+  <T extends Phaser.GameObjects.Components.Transform>(this: T, guideObject: GuideObject, x: number, y: number) => T;
+
+interface hasSetPositionRelative {
+  setPositionRelative: setPositionRelative;
+}
+
 declare module "phaser" {
   namespace GameObjects {
-    interface GameObject {
-      width: number;
-
-      height: number;
-
-      originX: number;
-
-      originY: number;
-
-      x: number;
-
-      y: number;
-    }
-
-    interface Container {
-      /**
-       * Sets this object's position relative to another object with a given offset
-       */
-      setPositionRelative(guideObject: any, x: number, y: number): this;
-    }
-    interface Sprite {
-      /**
-       * Sets this object's position relative to another object with a given offset
-       */
-      setPositionRelative(guideObject: any, x: number, y: number): this;
-    }
-    interface Image {
-      /**
-       * Sets this object's position relative to another object with a given offset
-       */
-      setPositionRelative(guideObject: any, x: number, y: number): this;
-    }
-    interface NineSlice {
-      /**
-       * Sets this object's position relative to another object with a given offset
-       */
-      setPositionRelative(guideObject: any, x: number, y: number): this;
-    }
-    interface Text {
-      /**
-       * Sets this object's position relative to another object with a given offset
-       */
-      setPositionRelative(guideObject: any, x: number, y: number): this;
-    }
-    interface Rectangle {
-      /**
-       * Sets this object's position relative to another object with a given offset
-       */
-      setPositionRelative(guideObject: any, x: number, y: number): this;
-    }
+    interface Container extends hasSetPositionRelative {}
+    interface Sprite extends hasSetPositionRelative {}
+    interface Image extends hasSetPositionRelative {}
+    interface NineSlice extends hasSetPositionRelative {}
+    interface Text extends hasSetPositionRelative {}
+    interface Rectangle extends hasSetPositionRelative {}
   }
 
   namespace Input {

--- a/src/ui/handlers/admin-ui-handler.ts
+++ b/src/ui/handlers/admin-ui-handler.ts
@@ -199,7 +199,9 @@ export class AdminUiHandler extends FormModalUiHandler {
       this.inputs[i].setText(adminResult[aR]);
       if (aR === "discordId" || aR === "googleId") {
         // this is here to add the icons for linking/unlinking of google/discord IDs
-        const nineSlice = this.inputContainers[i].list.find(iC => iC.type === "NineSlice");
+        const nineSlice = this.inputContainers[i].list.find(
+          (iC): iC is Phaser.GameObjects.NineSlice => iC.type === "NineSlice",
+        );
         const img = globalScene.add.image(
           this.inputContainers[i].x + nineSlice!.width + this.buttonGap,
           this.inputContainers[i].y + Math.floor(nineSlice!.height / 2),

--- a/src/ui/handlers/pokedex-scan-ui-handler.ts
+++ b/src/ui/handlers/pokedex-scan-ui-handler.ts
@@ -157,6 +157,8 @@ export class PokedexScanUiHandler extends FormModalUiHandler {
 
       const inputWidth = label.width < 420 ? 200 : 200 - (label.width - 420) / 5.75;
       this.inputs[0].resize(inputWidth * 5.75, 116);
+      // @ts-expect-error: TODO Resolve
+      // TODO: Figure out what the type of `this.inputContainers.list` is
       this.inputContainers[0].list[0].width = inputWidth;
       if (args[1] && typeof (args[1] as PlayerPokemon).getNameToRender === "function") {
         this.inputs[0].text = (args[1] as PlayerPokemon).getNameToRender();

--- a/src/ui/handlers/test-dialogue-ui-handler.ts
+++ b/src/ui/handlers/test-dialogue-ui-handler.ts
@@ -133,6 +133,8 @@ export class TestDialogueUiHandler extends FormModalUiHandler {
     if (super.show(args)) {
       const config = args[0] as ModalConfig;
       this.inputs[0].resize(1150, 116);
+      // @ts-expect-error: Resolve
+      // TODO: Figure out what the type of `this.inputContainers.list` is
       this.inputContainers[0].list[0].width = 200;
       if (args[1] && typeof (args[1] as PlayerPokemon).getNameToRender === "function") {
         this.inputs[0].text = (args[1] as PlayerPokemon).getNameToRender();


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
I had a stash that properly added TSDocs for the monkey patched version of `setPositionRelative` we have, and i never got around to making it into a pr until now

## What are the changes from a developer perspective?
Updated typing in `main.ts` and `src/typings/phaser/index.d.ts` to no longer pretend that all game objects have x/y coordinates and origins (since like half of them _don't_)

Added a few `ts-expect-error`s on a few lines that errored because of it
## Screenshots/Videos
N/A

## How to test the changes?
`pnpm typecheck`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)