### PR TITLE
[Refactor/Docs] Document + fix minor bugs in `MovePhase`

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -829,14 +829,15 @@ export abstract class Move implements Localizable {
   }
 
   /**
-   * Applies each {@linkcode MoveCondition} function of this move to the params, determines if the move can be used prior to calling each attribute's apply()
-   * @param user - {@linkcode Pokemon} to apply conditions to
-   * @param target - {@linkcode Pokemon} to apply conditions to
-   * @param move - {@linkcode Move} to apply conditions to
-   * @param sequence - The sequence number where the condition check occurs, or `-1` to check all; defaults to 4. Pass -1 to check all
-   * @returns boolean: false if any of the apply()'s return false, else true
+   * Apply this move's conditions prior to move effect application.
+   * @remarks
+   * Only applies conditions intrinsic to the particular move being used.
+   * @param user - The `Pokemon` using the move
+   * @param target - The `Pokemon targeted by the move
+   * @param sequence - The sequence number where the condition check occurs, or `-1` to check all; default 4
+   * @returns Whether all conditions passed
    */
-  applyConditions(user: Pokemon, target: Pokemon, sequence: -1 | 2 | 3 | 4  = 4): boolean {
+  public applyConditions(user: Pokemon, target: Pokemon, sequence: -1 | 2 | 3 | 4  = 4): boolean {
     let conditionsArray: MoveCondition[];
     switch (sequence) {
       case -1:
@@ -849,7 +850,6 @@ export abstract class Move implements Localizable {
         conditionsArray = this.conditionsSeq3;
         break;
       case 4:
-      default:
         conditionsArray = this.conditions;
     }
     return conditionsArray.every(cond => cond.apply(user, target, this));

--- a/src/data/moves/pokemon-move.ts
+++ b/src/data/moves/pokemon-move.ts
@@ -108,6 +108,10 @@ export class PokemonMove {
     return 1 - this.ppUsed / this.getMovePp();
   }
 
+  public isOutOfPp(): boolean {
+    return this.getMovePp() !== -1 && this.ppUsed >= this.getMovePp();
+  }
+
   getName(): string {
     return this.getMove().name;
   }
@@ -117,6 +121,7 @@ export class PokemonMove {
    * @param source The data for the move to copy; can be a {@linkcode PokemonMove} or JSON object representing one
    * @returns A valid {@linkcode PokemonMove} object
    */
+  // TODO: Don't serialize the `maxPpOverride` parameter - it is solely used for temporary moveset overrides from Transform
   static loadMove(source: PokemonMove | any): PokemonMove {
     return new PokemonMove(source.moveId, source.ppUsed, source.ppUp, source.maxPpOverride);
   }

--- a/src/enums/move-use-mode.ts
+++ b/src/enums/move-use-mode.ts
@@ -59,6 +59,7 @@ export const MoveUseMode = {
    * **cannot be reflected by other reflecting effects**.
    */
   REFLECTED: 5,
+
   /**
    * This "move" was created by a transparent effect that **does not count as using a move**,
    * such as {@linkcode DelayedAttackAttr | Future Sight/Doom Desire}.
@@ -79,7 +80,8 @@ export type MoveUseMode = ObjectValues<typeof MoveUseMode>;
 /**
  * Check if a given {@linkcode MoveUseMode} is virtual (i.e. called by another move or effect).
  * Virtual moves are ignored by most moveset-related effects due to not being executed directly.
- * @returns Whether {@linkcode useMode} is virtual.
+ * @param useMode - The `MoveUseMode` to check
+ * @returns Whether `useMode` is virtual.
  * @remarks
  * This function is equivalent to the following truth table:
  *
@@ -99,8 +101,8 @@ export function isVirtual(useMode: MoveUseMode): boolean {
 /**
  * Check if a given {@linkcode MoveUseMode} should ignore pre-move cancellation checks
  * from {@linkcode StatusEffect.PARALYSIS} and {@linkcode BattlerTagLapseType.MOVE}-type effects.
- * @param useMode - The {@linkcode MoveUseMode} to check.
- * @returns Whether {@linkcode useMode} should ignore status and otehr cancellation checks.
+ * @param useMode - The `MoveUseMode` to check
+ * @returns Whether `useMode` should ignore status and other cancellation checks.
  * @remarks
  * This function is equivalent to the following truth table:
  *
@@ -120,8 +122,8 @@ export function isIgnoreStatus(useMode: MoveUseMode): boolean {
 /**
  * Check if a given {@linkcode MoveUseMode} should ignore PP.
  * PP-ignoring moves will ignore normal PP consumption as well as associated failure checks.
- * @param useMode - The {@linkcode MoveUseMode} to check.
- * @returns Whether {@linkcode useMode} ignores PP.
+ * @param useMode - The `MoveUseMode` to check
+ * @returns Whether `useMode` ignores PP consumption.
  * @remarks
  * This function is equivalent to the following truth table:
  *
@@ -142,8 +144,8 @@ export function isIgnorePP(useMode: MoveUseMode): boolean {
  * Check if a given {@linkcode MoveUseMode} is reflected.
  * Reflected moves cannot be reflected, copied, or cancelled by status effects,
  * nor will they trigger {@linkcode PostDancingMoveAbAttr | Dancer}.
- * @param useMode - The {@linkcode MoveUseMode} to check.
- * @returns Whether {@linkcode useMode} is reflected.
+ * @param useMode - The `MoveUseMode` to check
+ * @returns Whether `useMode` is reflected.
  * @remarks
  * This function is equivalent to the following truth table:
  *

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -5006,18 +5006,21 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Queue the status cure message, reset the status, and update the info display
    * @param effect - The effect to cure. If this does not match the current status, nothing happens.
-   * @param msg - A custom message to display when curing the status effect (used for curing freeze due to move use)
+   * @param msg - If provided, will override the default message displayed when removing status.
+   *   Used for moves that thaw the user out
    */
-  public cureStatus(effect: StatusEffect, msg?: string): void {
+  // TODO: Distinguish this more from `resetStatus`
+  public cureStatus(effect: StatusEffect, msg = getStatusEffectHealText(effect, getPokemonNameWithAffix(this))): void {
     if (effect !== this.status?.effect) {
       return;
     }
     // Freeze healed by move uses its own msg
-    globalScene.phaseManager.queueMessage(msg ?? getStatusEffectHealText(effect, getPokemonNameWithAffix(this)));
+    globalScene.phaseManager.queueMessage(msg);
     // cannot use `asPhase=true` as it will cause status to be reset _after_ this phase ends
     this.resetStatus(undefined, undefined, undefined, false);
     this.updateInfo();
   }
+
   /**
    * Reset this Pokémon's status
    * @param revive - Whether revive should be cured; default `true`

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -1,8 +1,10 @@
 // biome-ignore-start lint/correctness/noUnusedImports: Used in a tsdoc comment
 import type { Move, PreUseInterruptAttr } from "#types/move-types";
+
 // biome-ignore-end lint/correctness/noUnusedImports: Used in a tsdoc comment
 
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
+import { MOVE_COLOR } from "#app/constants/colors";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import Overrides from "#app/overrides";
@@ -119,8 +121,7 @@ export class MovePhase extends PokemonPhase {
   }
 
   /**
-   * Check the first round of failure checks
-   *
+   * Perform the first round of failure checks.
    * @returns Whether the move failed
    *
    * @remarks
@@ -167,7 +168,8 @@ export class MovePhase extends PokemonPhase {
   }
 
   /**
-   * Follow up moves need to check a subset of the first failure checks
+   * Check a subset of the checks done in {@linkcode firstFailureCheck}
+   * for called moves.
    *
    * @remarks
    *
@@ -187,7 +189,7 @@ export class MovePhase extends PokemonPhase {
   }
 
   /**
-   * Handle the status interactions for sleep and freeze that happen after passing the first failure check
+   * Handle status interactions for sleep and freeze that happen after passing the first failure check.
    *
    * @remarks
    * - If the user is asleep but can use the move, the sleep animation and message is still shown
@@ -211,7 +213,8 @@ export class MovePhase extends PokemonPhase {
   }
 
   /**
-   * Second failure check that occurs after the "Pokemon used move" text is shown but BEFORE the move has been registered
+   * Perform the second round of move failure checks, occurring after move usage messages
+   *  text is shown but BEFORE the move has been registered
    * as being the last move used (for the purposes of something like Copycat)
    *
    * @remarks
@@ -383,48 +386,66 @@ export class MovePhase extends PokemonPhase {
   public start(): void {
     super.start();
 
-    if (!this.pokemon.isActive(true)) {
+    const user = this.pokemon;
+
+    // Fallback - end phase early if the user is removed from the field or faints
+    // before using a move.
+    // TODO: Cancel the user's queued `MovePhase`s when they leave the field -
+    // force switching a pokemon out and back in should not let them use a move
+    if (!user.isActive(true)) {
       this.end();
       return;
     }
 
-    const user = this.pokemon;
+    const useMode = this.useMode;
+    const ignoreStatus = isIgnoreStatus(useMode);
+    const isFollowUp = useMode === MoveUseMode.FOLLOW_UP;
 
-    // Removing Glaive Rush's two flags *always* happens first
+    console.log(
+      // biome-ignore lint/complexity/noUselessStringConcat: biome doesn't recognize leading pluses
+      `%cUser: ${user.name}`
+        + `\nMove: ${MoveId[this.move.moveId]}`
+        + `\nUse Mode: ${enumValueToKey(MoveUseMode, this.useMode)}`,
+      `color:${MOVE_COLOR}`,
+    );
+
+    // Removing Glaive Rush's two flags happens before **everything** else
     user.removeTag(BattlerTagType.ALWAYS_GET_HIT);
     user.removeTag(BattlerTagType.RECEIVE_DOUBLE_DAMAGE);
-    console.log(MoveId[this.move.moveId], enumValueToKey(MoveUseMode, this.useMode));
 
     // For the purposes of payback and kin, the pokemon is considered to have acted
     // if it attempted to move at all.
     user.turnData.acted = true;
-    const useMode = this.useMode;
-    const ignoreStatus = isIgnoreStatus(useMode);
-    const isFollowUp = useMode === MoveUseMode.FOLLOW_UP;
+
+    // TODO: Should these look at stuff
     if (!ignoreStatus) {
       this.firstFailureCheck();
       user.lapseTags(BattlerTagLapseType.PRE_MOVE);
-      // At this point, called moves should be decided.
+
+      // TODO: Rework move-calling-moves to change the currently queued move
+      // once the concept of a "move-in-flight" is established
       // For now, this comment works as a placeholder until called moves are reworked
       // For correct alignment with mainline, this SHOULD go here, and this phase SHOULD rewrite its own move
     } else if (isFollowUp) {
-      // Follow up moves need to make sure the called move passes a few of the conditions to continue
+      // Follow up moves check a subset of conditions
       this.followUpMoveFirstFailureCheck();
     }
+
     // If the first failure check did not pass, then the move is cancelled
-    // Note: This only checks `cancelled`, as `failed` should NEVER be set by anything in the first failure check
+    // Note: This only checks `cancelled`, as `failed` should NEVER be set by anything in the above block
     if (this.cancelled) {
       this.handlePreMoveFailures();
       this.end();
       return;
     }
 
-    // If the first failure check passes (and this is not a sub-move) then thaw the user if its move will thaw it.
+    // If this is not a sub-move, thaw the user if its move will thaw it.
     if (!isFollowUp) {
       this.doThawCheck();
     }
 
     // Reset hit-related turn data when starting follow-up moves (e.g. Metronomed moves, Dancer repeats)
+    // TODO: Apply this to the current "move in flight" object and remove the equivalent calls from MEP
     if (isVirtual(useMode)) {
       const turnData = user.turnData;
       turnData.hitsLeft = -1;
@@ -432,27 +453,32 @@ export class MovePhase extends PokemonPhase {
     }
 
     const pokemonMove = this.move;
+    const move = pokemonMove.getMove();
 
-    // Check move to see if arena.ignoreAbilities should be true.
+    // Toggle ability-ignoring effects for the duration of the move, if the user and move permit.
     if (
-      pokemonMove.getMove().doesFlagEffectApply({
+      move.doesFlagEffectApply({
         flag: MoveFlags.IGNORE_ABILITIES,
         user,
-        isFollowUp: isVirtual(useMode), // Sunsteel strike and co. don't work when called indirectly
+        isFollowUp: isVirtual(useMode), // Sunsteel strike and co. don't ignore abilities when called indirectly
       })
     ) {
       globalScene.arena.setIgnoreAbilities(true, user.getBattlerIndex());
     }
 
-    // At this point, move's type changing and multi-target effects *should* be applied
+    // TODO: Apply move type changes and multi-target effects here
     // Pokerogue's current implementation applies these effects during the move effect phase
     // as there is not (yet) a notion of a move-in-flight for determinations to occur
 
+    // Compute targets from redirection and counterattacks
     this.resolveRedirectTarget();
     this.resolveCounterAttackTarget();
 
-    // If this is the *release* turn of the charge move, PP is not deducted
-    const move = this.move.getMove();
+    // Update the battle's "last move" pointer unless we're currently mimicking a move or triggering Dancer.
+    // TODO: This should presumably be after the 2nd set of failure checks
+    if (!move.hasAttr("CopyMoveAttr") && !isReflected(useMode)) {
+      globalScene.currentBattle.lastMove = move.id;
+    }
 
     const isChargingMove = move.isChargingMove();
     /** Indicates this is the charging turn of the move */
@@ -460,25 +486,19 @@ export class MovePhase extends PokemonPhase {
     /** Indicates this is the release turn of the move */
     const releasing = isChargingMove && !charging;
 
-    // Update the battle's "last move" pointer unless we're currently mimicking a move or triggering Dancer.
-    if (!move.hasAttr("CopyMoveAttr") && !isReflected(useMode)) {
-      globalScene.currentBattle.lastMove = move.id;
-    }
-
     // Charging moves consume PP when they begin charging, *not* when they release
     if (!releasing) {
       this.usePP();
     }
 
     if (!isFollowUp) {
-      // Gorilla tactics lock in (and choice items if they are ever added)
-      // Stance Change form change
-      // Struggle's "There are no more moves it can use" message
+      // Stance Change
 
       globalScene.triggerPokemonFormChange(user, SpeciesFormChangePreMoveTrigger);
       // TODO: apply gorilla tactics here instead of in the move effect phase
     }
 
+    // Show move text
     this.showMoveText();
 
     if (this.secondFailureCheck()) {
@@ -714,7 +734,6 @@ export class MovePhase extends PokemonPhase {
   /**
    * Lapse the tag type and check if the move is cancelled from it. Meant to be used during the first failure check
    * @param tag - The tag type whose lapse method will be called with {@linkcode BattlerTagLapseType.PRE_MOVE}
-   * @param checkIgnoreStatus - Whether to check {@link isIgnoreStatus} for the current {@linkcode MoveUseMode} to skip this check
    * @returns Whether the move was cancelled due to a `BattlerTag` effect
    */
   private checkTagCancel(tag: BattlerTagType): boolean {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
       "#abilities/*": ["./src/data/abilities/*.ts"],
       "#api/*": ["./src/plugins/api/*.ts"],
       "#balance/*": ["./src/data/balance/*.ts"],
+      "#constants/*": ["./src/constants/*.ts"],
       "#enums/*": ["./src/enums/*.ts"],
       "#events/*": ["./src/events/*.ts"],
       "#field/*": ["./src/field/*.ts"],


### PR DESCRIPTION
## What are the changes the user will see?
Very minor and in no particular order:
1. `STATUS_ACTIVATION_OVERRIDE` now does not take precedence over self thaw moves
2. The Move use console log has been reverted to what it was prior to #6276
3. Other general cleanups

## Why am I making these changes?
I was checking out the MP for encore when i noticed some uglinesses that I apparently didn't catch during PR reviews

## What are the changes from a developer perspective?
Fixed a few instances of duplicated checks and nesting oopsies

Made 1-2 more helper functions for things like checking the current challenge

Documented all the functions consistently

Re-arranged all the fucntions in the MP to happen in order of execution (`start` first, then first failure check, ...)

## Screenshots/Videos
N/A
## How to test the changes?
Check that using moves still works? idk man

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)