### PR TITLE
[Bug] Reset hit-related turn data inside `MoveEndPhase` + remove `extraTurns`

### DIFF
--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -5091,7 +5091,6 @@ export class PostDancingMoveAbAttr extends PostMoveUsedAbAttr {
    */
   override apply({ source, pokemon, move, targets, simulated }: PostMoveUsedAbAttrParams): void {
     if (!simulated) {
-      pokemon.turnData.extraTurns++;
       // If the move is an AttackMove or a StatusMove the Dancer must replicate the move on the source of the Dance
       if (move.getMove().is("AttackMove") || move.getMove().is("StatusMove")) {
         const target = this.getTarget(pokemon, source, targets);

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -3469,7 +3469,7 @@ export class DelayedAttackAttr extends OverrideMoveEffectAttr {
 
 /**
  * Attribute to queue a {@linkcode WishTag} to activate in 2 turns.
- * The tag whill heal
+ * The tag will heal 50% of the user's maximum HP to whichever Pokemon is active when it triggers.
  */
 export class WishAttr extends MoveEffectAttr {
   public override apply(user: Pokemon, target: Pokemon, _move: Move): boolean {

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -1757,12 +1757,14 @@ export class TargetHalfHpDamageAttr extends FixedDamageAttr {
     super(0);
   }
 
-  apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
+  apply(user: Pokemon, target: Pokemon, move: Move, args: [NumberHolder, ...any[]]): boolean {
+    const [dmg] = args;
+
     // first, determine if the hit is coming from multi lens or not
     const lensCount = user.getHeldItems().find(i => i instanceof PokemonMultiHitModifier)?.getStackCount() ?? 0;
     if (lensCount <= 0) {
       // no multi lenses; we can just halve the target's hp and call it a day
-      (args[0] as NumberHolder).value = toDmgValue(target.hp / 2);
+      dmg.value = toDmgValue(target.hp / 2);
       return true;
     }
 
@@ -1773,11 +1775,11 @@ export class TargetHalfHpDamageAttr extends FixedDamageAttr {
         this.initialHp = target.hp;
       default:
         // multi lens added hit; use initialHp tracker to ensure correct damage
-        (args[0] as NumberHolder).value = toDmgValue(this.initialHp / 2);
+        dmg.value = toDmgValue(this.initialHp / 2);
         return true;
       case lensCount + 1:
         // parental bond added hit; calc damage as normal
-        (args[0] as NumberHolder).value = toDmgValue(target.hp / 2);
+        dmg.value = toDmgValue(target.hp / 2);
         return true;
     }
   }
@@ -7370,7 +7372,6 @@ export class RepeatMoveAttr extends MoveEffectAttr {
       userPokemonName: getPokemonNameWithAffix(user),
       targetPokemonName: getPokemonNameWithAffix(target)
     }));
-    target.turnData.extraTurns++;
     globalScene.phaseManager.unshiftNew("MovePhase", target, moveTargets, movesetMove, MoveUseMode.NORMAL, MovePhaseTimingModifier.FIRST);
     return true;
   }

--- a/src/data/pokemon/pokemon-data.ts
+++ b/src/data/pokemon/pokemon-data.ts
@@ -131,12 +131,16 @@ export class PokemonSummonData {
   public stats: number[] = [0, 0, 0, 0, 0, 0];
   public moveset: PokemonMove[] | null;
 
-  // If not initialized this value will not be populated from save data.
   public types: PokemonType[] = [];
   public addedType: PokemonType | null = null;
 
-  /** Data pertaining to this pokemon's illusion. */
+  /** Data pertaining to this pokemon's Illusion, if it has one. */
   public illusion: IllusionData | null = null;
+  /**
+   * Whether this Pokemon's illusion has been broken since switching out.
+   * @defaultValue `false`
+   */
+  // TODO: Since Illusion applies on switch in, and this entire class is reset
   public illusionBroken = false;
 
   /** Array containing all berries eaten in the last turn; used by {@linkcode AbilityId.CUD_CHEW} */
@@ -325,12 +329,15 @@ export class PokemonTurnData {
   public switchedInThisTurn = false;
   public failedRunAway = false;
   public joinedRound = false;
-  /** Tracker for a pending status effect
+  /**
+   * Tracker for a pending status effect.
    *
    * @remarks
    * Set whenever {@linkcode Pokemon#trySetStatus} succeeds in order to prevent subsequent status effects
-   * from being applied. Necessary because the status is not actually set until the {@linkcode ObtainStatusEffectPhase} runs,
+   * from being applied. \
+   * Necessary because the status is not actually set until the {@linkcode ObtainStatusEffectPhase} runs,
    * which may not happen before another status effect is attempted to be applied.
+   * @defaultValue `StatusEffect.NONE`
    */
   public pendingStatus: StatusEffect = StatusEffect.NONE;
   /**

--- a/src/data/pokemon/pokemon-data.ts
+++ b/src/data/pokemon/pokemon-data.ts
@@ -334,12 +334,6 @@ export class PokemonTurnData {
    */
   public pendingStatus: StatusEffect = StatusEffect.NONE;
   /**
-   * The amount of times this Pokemon has acted again and used a move in the current turn.
-   * Used to make sure multi-hits occur properly when the user is
-   * forced to act again in the same turn, and **must be incremented** by any effects that grant extra actions.
-   */
-  public extraTurns = 0;
-  /**
    * All berries eaten by this pokemon in this turn.
    * Saved into {@linkcode PokemonSummonData | SummonData} by {@linkcode AbilityId.CUD_CHEW} on turn end.
    * @see {@linkcode PokemonSummonData.berriesEatenLast}

--- a/src/data/positional-tags/positional-tag.ts
+++ b/src/data/positional-tags/positional-tag.ts
@@ -100,10 +100,8 @@ export class DelayedAttackTag extends PositionalTag implements DelayedAttackArgs
   public override trigger(): void {
     // Bangs are justified as the `shouldTrigger` method will queue the tag for removal
     // if the source or target no longer exist
-    const source = globalScene.getPokemonById(this.sourceId)!;
     const target = this.getTarget()!;
 
-    source.turnData.extraTurns++;
     globalScene.phaseManager.queueMessage(
       i18next.t("moveTriggers:tookMoveAttack", {
         pokemonName: getPokemonNameWithAffix(target),
@@ -113,7 +111,9 @@ export class DelayedAttackTag extends PositionalTag implements DelayedAttackArgs
 
     globalScene.phaseManager.unshiftNew(
       "MoveEffectPhase",
-      this.sourceId, // TODO: Find an alternate method of passing the source pokemon without a source ID
+      // TODO: Find an alternate method of passing the (currently off-field) source pokemon
+      // instead of relying on pokemon getter jank
+      this.sourceId,
       [this.targetIndex],
       allMoves[this.sourceMove],
       MoveUseMode.DELAYED_ATTACK,

--- a/src/data/positional-tags/positional-tag.ts
+++ b/src/data/positional-tags/positional-tag.ts
@@ -100,7 +100,13 @@ export class DelayedAttackTag extends PositionalTag implements DelayedAttackArgs
   public override trigger(): void {
     // Bangs are justified as the `shouldTrigger` method will queue the tag for removal
     // if the source or target no longer exist
+    const source = globalScene.getPokemonById(this.sourceId)!;
     const target = this.getTarget()!;
+
+    // Reset hits left counter.
+    // NB: This is required as the `MoveEndPhase` (when this is normally reset)
+    // does not get queued when queueing Future Sight directly
+    source.turnData.hitsLeft = -1;
 
     globalScene.phaseManager.queueMessage(
       i18next.t("moveTriggers:tookMoveAttack", {

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -133,6 +133,7 @@ export class MoveEffectPhase extends PokemonPhase {
     if (anySuccess) {
       this.moveHistoryEntry.result = MoveResult.SUCCESS;
     } else {
+      // If the move failed to impact all targets, disable all subsequent multi-hits
       user.turnData.hitCount = 1;
       user.turnData.hitsLeft = 1;
       this.moveHistoryEntry.result = allMiss ? MoveResult.MISS : MoveResult.FAIL;
@@ -257,14 +258,6 @@ export class MoveEffectPhase extends PokemonPhase {
 
     // Lapse `MOVE_EFFECT` effects (i.e. semi-invulnerability) when applicable
     user.lapseTags(BattlerTagLapseType.MOVE_EFFECT);
-
-    // If the user is acting again (such as due to Instruct or Dancer), reset hitsLeft/hitCount and
-    // recalculate hit count for multi-hit moves.
-    if (user.turnData.hitsLeft === 0 && user.turnData.hitCount > 0 && user.turnData.extraTurns > 0) {
-      user.turnData.hitsLeft = -1;
-      user.turnData.hitCount = 0;
-      user.turnData.extraTurns--;
-    }
 
     /**
      * If this phase is for the first hit of the invoked move,

--- a/src/phases/move-end-phase.ts
+++ b/src/phases/move-end-phase.ts
@@ -22,6 +22,13 @@ export class MoveEndPhase extends PokemonPhase {
     super.start();
 
     const pokemon = this.getPokemon();
+
+    // Reset hit-related temporary data.
+    // TODO: These properties should be stored inside a "move in flight" object,
+    // which this Phase would promptly destroy
+    pokemon.turnData.hitsLeft = -1;
+    pokemon.turnData.hitCount = 0;
+
     if (!this.wasFollowUp && pokemon?.isActive(true)) {
       pokemon.lapseTags(BattlerTagLapseType.AFTER_MOVE);
     }

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -424,13 +424,6 @@ export class MovePhase extends PokemonPhase {
       this.doThawCheck();
     }
 
-    // Reset hit-related turn data when starting follow-up moves (e.g. Metronomed moves, Dancer repeats)
-    if (isVirtual(useMode)) {
-      const turnData = user.turnData;
-      turnData.hitsLeft = -1;
-      turnData.hitCount = 0;
-    }
-
     const pokemonMove = this.move;
 
     // Check move to see if arena.ignoreAbilities should be true.


### PR DESCRIPTION
## What are the changes the user will see?
All instances of broken multi hits and damage amounts from a move being interrupted mid execution _should_ be fixed for good.

## Why am I making these changes?
Fixes #6610

## What are the changes from a developer perspective?
Rather than resetting hit data when a move is used, we instead reset it during the `MoveEndPhase`

## Screenshots/Videos
N/A
## How to test the changes?
do i need them _sigh_

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?

Does this require any changes to the assets folder? If so:
  - [ ] Has a PR been created on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repo?
    - [ ] If so, please leave a link to it here: