### PR TITLE
[UI/UX][Beta][Bug] Fix ribbons using wrong index when showMissingRibbons is off

### DIFF
--- a/src/system/ribbons/ribbon-data.ts
+++ b/src/system/ribbons/ribbon-data.ts
@@ -73,28 +73,39 @@ export class RibbonData {
   public static readonly MONO_GEN_9 = 0x4000000n as RibbonFlag;
   //#endregion Monogen ribbons
 
+  // biome-ignore format: manual
   /** Ribbon for winning classic */
-  public static readonly CLASSIC = 0x8000000n as RibbonFlag;
+  public static readonly CLASSIC        = 0x0008000000n as RibbonFlag;
+  // biome-ignore format: manual
   /** Ribbon for winning the nuzzlocke challenge */
-  public static readonly NUZLOCKE = 0x10000000n as RibbonFlag;
+  public static readonly NUZLOCKE       = 0x0010000000n as RibbonFlag;
+  // biome-ignore format: manual
   /** Ribbon for reaching max friendship */
-  public static readonly FRIENDSHIP = 0x20000000n as RibbonFlag;
+  public static readonly FRIENDSHIP     = 0x0020000000n as RibbonFlag;
+  // biome-ignore format: manual
   /** Ribbon for winning the flip stats challenge */
-  public static readonly FLIP_STATS = 0x40000000n as RibbonFlag;
+  public static readonly FLIP_STATS     = 0x0040000000n as RibbonFlag;
+  // biome-ignore format: manual
   /** Ribbon for winning the inverse challenge */
-  public static readonly INVERSE = 0x80000000n as RibbonFlag;
+  public static readonly INVERSE        = 0x0080000000n as RibbonFlag;
+  // biome-ignore format: manual
   /** Ribbon for winning the fresh start challenge */
-  public static readonly FRESH_START = 0x100000000n as RibbonFlag;
+  public static readonly FRESH_START    = 0x0100000000n as RibbonFlag;
+  // biome-ignore format: manual
   /** Ribbon for winning the hardcore challenge */
-  public static readonly HARDCORE = 0x200000000n as RibbonFlag;
+  public static readonly HARDCORE       = 0x0200000000n as RibbonFlag;
+  // biome-ignore format: manual
   /** Ribbon for winning the limited catch challenge */
-  public static readonly LIMITED_CATCH = 0x400000000n as RibbonFlag;
+  public static readonly LIMITED_CATCH  = 0x0400000000n as RibbonFlag;
+  // biome-ignore format: manual
   /** Ribbon for winning the limited support challenge set to no heal */
-  public static readonly NO_HEAL = 0x800000000n as RibbonFlag;
+  public static readonly NO_HEAL        = 0x0800000000n as RibbonFlag;
+  // biome-ignore format: manual
   /** Ribbon for winning the limited uspport challenge set to no shop */
-  public static readonly NO_SHOP = 0x1000000000n as RibbonFlag;
+  public static readonly NO_SHOP        = 0x1000000000n as RibbonFlag;
+  // biome-ignore format: manual
   /** Ribbon for winning the limited support challenge set to both*/
-  public static readonly NO_SUPPORT = 0x2000000000n as RibbonFlag;
+  public static readonly NO_SUPPORT     = 0x2000000000n as RibbonFlag;
 
   // NOTE: max possible ribbon flag is 0x20000000000000 (53 total ribbons)
   // Once this is exceeded, bitfield needs to be changed to a bigint or even a uint array

--- a/src/ui/containers/ribbon-tray-container.ts
+++ b/src/ui/containers/ribbon-tray-container.ts
@@ -111,21 +111,18 @@ export class RibbonTray extends Phaser.GameObjects.Container {
   }
 
   open(species: PokemonSpecies): boolean {
-    this.ribbons = getAvailableRibbons(species);
+    const ribbons: RibbonFlag[] = (this.ribbons = []);
 
     this.ribbonData = globalScene.gameData.dexData[species.speciesId].ribbons;
 
-    this.trayNumIcons = this.ribbons.length;
-    this.trayRows =
-      Math.floor(this.trayNumIcons / this.maxColumns) + (this.trayNumIcons % this.maxColumns === 0 ? 0 : 1);
-    this.trayColumns = Math.min(this.trayNumIcons, this.maxColumns);
-
-    this.trayBg.setSize(15 + this.trayColumns * 17, 8 + this.trayRows * 18);
-
     this.trayIcons = [];
     let index = 0;
-    for (const ribbon of this.ribbons) {
+    for (const ribbon of getAvailableRibbons(species)) {
       const hasRibbon = this.ribbonData.has(ribbon);
+      if (!hasRibbon && !globalScene.dexForDevs && !globalScene.showMissingRibbons) {
+        continue;
+      }
+      ribbons.push(ribbon);
 
       const icon = ribbonFlagToAssetKey(ribbon);
 
@@ -144,6 +141,12 @@ export class RibbonTray extends Phaser.GameObjects.Container {
         index++;
       }
     }
+
+    this.trayNumIcons = ribbons.length;
+    this.trayRows =
+      Math.floor(this.trayNumIcons / this.maxColumns) + (this.trayNumIcons % this.maxColumns === 0 ? 0 : 1);
+    this.trayColumns = Math.min(this.trayNumIcons, this.maxColumns);
+    this.trayBg.setSize(15 + this.trayColumns * 17, 8 + this.trayRows * 18);
 
     this.setVisible(true).setTrayCursor(0);
 

--- a/src/utils/ribbon-utils.ts
+++ b/src/utils/ribbon-utils.ts
@@ -84,11 +84,35 @@ export function getAvailableRibbons(species: PokemonSpecies): RibbonFlag[] {
   return ribbons.concat(extraRibbons);
 }
 
+/**
+ * Get the locale key for the given ribbon flag
+ * @param flag - The ribbon flag to get the key for
+ */
 export function getRibbonKey(flag: RibbonFlag): string {
-  for (const [key, value] of Object.entries(RibbonData)) {
-    if (typeof value === "bigint" && value === flag) {
-      return key;
-    }
+  switch (flag) {
+    case RibbonData.CLASSIC:
+      return "CLASSIC";
+    case RibbonData.NUZLOCKE:
+      return "NUZLOCKE";
+    case RibbonData.FRIENDSHIP:
+      return "FRIENDSHIP";
+    case RibbonData.FLIP_STATS:
+      return "FLIP_STATS";
+    case RibbonData.INVERSE:
+      return "INVERSE";
+    case RibbonData.FRESH_START:
+      return "FRESH_START";
+    case RibbonData.HARDCORE:
+      return "HARDCORE";
+    case RibbonData.LIMITED_CATCH:
+      return "LIMITED_CATCH";
+    case RibbonData.NO_HEAL:
+      return "NO_HEAL";
+    case RibbonData.NO_SHOP:
+      return "NO_SHOP";
+    case RibbonData.NO_SUPPORT:
+      return "NO_SUPPORT";
+    default:
+      return "";
   }
-  return "";
 }


### PR DESCRIPTION
## What are the changes the user will see?
Ribbons will now show the correct description when panning over them while showMissingRibbons is disabled.

## Why am I making these changes?
Fix bug pointed out by Blitzy.

## What are the changes from a developer perspective?
- Made `getRibbonKey` use a switch statement rather than relying on object properties.
- Made it so that the ribbon page is not set to every single ribbon and instead populates the array as ribbon icons are added.
- Added a unit test for ribbon data that I used while ensuring that ribbons were being detected properly, though this is a tame and not a comprehensive test.

## Screenshots/Videos
<img width="1639" height="913" alt="image" src="https://github.com/user-attachments/assets/43d34b43-d061-4899-9048-089797638901" />

<img width="1632" height="930" alt="image" src="https://github.com/user-attachments/assets/9cae5cbd-4701-4732-85da-23e3dfc070fb" />


## How to test the changes?
I use these overrides to force a win.
```ts
const overrides = {
  STARTING_WAVE_OVERRIDE: 201,
} satisfies Partial<InstanceType<OverridesType>>;
```
Select a challenge mode like fresh start, enter game, instant win. Then, go to pokedex for the mon you chose and see what its ribbons look like.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?