### PR TITLE
[Dev] Add polyfill for ES2025 iterator

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "dependencies": {
     "@material/material-color-utilities": "^0.3.0",
     "compare-versions": "^6.1.1",
+    "core-js": "^3.46.0",
     "crypto-js": "^4.2.0",
     "i18next": "^25.5.3",
     "i18next-browser-languagedetector": "^8.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       compare-versions:
         specifier: ^6.1.1
         version: 6.1.1
+      core-js:
+        specifier: ^3.46.0
+        version: 3.46.0
       crypto-js:
         specifier: ^4.2.0
         version: 4.2.0
@@ -960,6 +963,9 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  core-js@3.46.0:
+    resolution: {integrity: sha512-vDMm9B0xnqqZ8uSBpZ8sNtRtOdmfShrvT6h2TuQGLs0Is+cR0DYbj/KWP6ALVNbWPpqA/qPLoOuppJN07humpA==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -2799,6 +2805,8 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie@0.7.2: {}
+
+  core-js@3.46.0: {}
 
   core-util-is@1.0.3: {}
 

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,5 +1,5 @@
 /*
-Manual rolling of polyfills desired by the project.
+Manual rolling or other polyfills desired by the project.
 
 IMPORTANT: When adding / removing polyfills, ensure that typescript becomes
 aware of their existence, either by creating `src/typings/polyfills.d.ts`
@@ -19,3 +19,8 @@ if (typeof Promise.withResolvers === "undefined") {
     return { promise, resolve, reject };
   };
 }
+
+import "core-js/stable/set";
+import "core-js/stable/iterator";
+import "core-js/stable/map/group-by";
+import "core-js/stable/object/group-by";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,12 @@
       "DOM.AsyncIterable",
       "DOM.Iterable",
       "ScriptHost",
-      "WebWorker.ImportScripts"
+      "WebWorker.ImportScripts",
+      "ES2024.Object",
+      // NOTE: Be *very* mindful of these when updating typescript versions,
+      // as their definitions may change in breaking ways
+      "ESNext.Iterator",
+      "ESNext.Collection"
     ],
     "skipLibCheck": true, // Safe and almost always beneficial
     "moduleResolution": "bundler",


### PR DESCRIPTION
## What are the changes the user will see?
None

## Why am I making these changes?
I really want ES2025's iterator methods, which are so good and lightweight.

## What are the changes from a developer perspective?
- Add a new dependency on `core-js`.
- Add `core-js/stable/set` polyfills for the polyfills for set methods desired by @bertie690
- Add `core-js/stable/iterator` polyfill for the iterator methods that I really want
- Add `core-js/stable/map/group-by` polyfill so that we can get typings for the set methods by just adding `ESNext.collection` to tsconfig's lib, which has [Map.groupBy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/groupBy). I didn't see the harm in adding a polyfill for it, and the method looks crazy powerful anyway, so it'll probably be useful to some extent.
- Because we added Map.groupBy, I figured we should *also* add [Object.groupBy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/groupBy), since it would be weird to have one without the other. Again, this is a very powerful method.

## Screenshots/Videos
N/A

## How to test the changes?
N/A, as all I did was add polyfills.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?