### PR TITLE
[i18n] [Beta] Fix arena tag message typos

### DIFF
--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -899,7 +899,7 @@ class SpikesTag extends DamagingTrapTag {
   }
 
   protected override get onRemoveMessageKey(): string {
-    return "arenaTag:spikesOnAdd" + this.i18nSideKey;
+    return "arenaTag:spikesOnRemove" + this.i18nSideKey;
   }
 
   protected override get triggerMessageKey(): string {
@@ -1418,7 +1418,7 @@ class GrassWaterPledgeTag extends SerializableArenaTag {
   }
 
   protected override get onRemoveMessageKey(): string {
-    return "arenaTag:grassWaterPledgeOnAdd" + this.i18nSideKey;
+    return "arenaTag:grassWaterPledgeOnRemove" + this.i18nSideKey;
   }
 
   // TODO: Move speed drops into this class's `apply` method instead of an explicit check for it


### PR DESCRIPTION
## What are the changes the user will see?

Arena tag messages will not show the locales key anymore

## Why am I making these changes?

partialy Fixes #6642

## What are the changes from a developer perspective?

- Fixed 2 typos where the `add` key was used for the `remove` message.

## Screenshots/Videos

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  ~~- [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?~~
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  ~~- [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~