### PR TITLE
[Misc] Removed instance of `find(() => true)` from `BattleInfo` code

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3150,7 +3150,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       const otherBattleInfo = globalScene.fieldUI
         .getAll()
         .slice(0, 4)
-        .some(ui => ui instanceof BattleInfo && (ui as BattleInfo) instanceof PlayerBattleInfo === this.isPlayer());
+        .find(ui => ui instanceof BattleInfo && (ui as BattleInfo) instanceof PlayerBattleInfo === this.isPlayer());
       if (!otherBattleInfo || !this.getFieldIndex()) {
         globalScene.fieldUI.sendToBack(this.battleInfo);
         globalScene.sendTextToBack(); // Push the top right text objects behind everything else


### PR DESCRIPTION
## What are the changes the user will see?
N/A
## Why am I making these changes?
```ts
const otherBattleInfo = globalScene.fieldUI
  .getAll()
  .slice(0, 4)
  .filter(ui => ui instanceof BattleInfo && (ui as BattleInfo) instanceof PlayerBattleInfo === this.isPlayer())
  .find(() => true);
```

is bad

## What are the changes from a developer perspective?
Changed to use `find` directly

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)