### PR TITLE
[UI/UX][Beta] Show all ribbon descriptions

### DIFF
--- a/src/ui/containers/ribbon-tray-container.ts
+++ b/src/ui/containers/ribbon-tray-container.ts
@@ -6,7 +6,6 @@ import { ribbonFlagToAssetKey } from "#system/ribbons/ribbon-methods";
 import type { MessageUiHandler } from "#ui/message-ui-handler";
 import { addWindow } from "#ui/ui-theme";
 import { getAvailableRibbons, getRibbonKey } from "#utils/ribbon-utils";
-import { toCamelCase } from "#utils/strings";
 import i18next from "i18next";
 
 export class RibbonTray extends Phaser.GameObjects.Container {
@@ -98,7 +97,7 @@ export class RibbonTray extends Phaser.GameObjects.Container {
 
     this.trayCursorObj.setPosition(5 + (cursor % this.maxColumns) * 18, 4 + Math.floor(cursor / this.maxColumns) * 17);
 
-    const ribbonDescription = i18next.t(`ribbons:${toCamelCase(getRibbonKey(this.ribbons[cursor]))}`);
+    const ribbonDescription = i18next.t(`ribbons:${getRibbonKey(this.ribbons[cursor])}`);
 
     this.handler.showText(ribbonDescription);
 

--- a/src/utils/ribbon-utils.ts
+++ b/src/utils/ribbon-utils.ts
@@ -91,27 +91,81 @@ export function getAvailableRibbons(species: PokemonSpecies): RibbonFlag[] {
 export function getRibbonKey(flag: RibbonFlag): string {
   switch (flag) {
     case RibbonData.CLASSIC:
-      return "CLASSIC";
+      return "classic";
     case RibbonData.NUZLOCKE:
-      return "NUZLOCKE";
+      return "nuzlocke";
     case RibbonData.FRIENDSHIP:
-      return "FRIENDSHIP";
+      return "friendship";
     case RibbonData.FLIP_STATS:
-      return "FLIP_STATS";
+      return "flipStats";
     case RibbonData.INVERSE:
-      return "INVERSE";
+      return "inverse";
     case RibbonData.FRESH_START:
-      return "FRESH_START";
+      return "freshStart";
     case RibbonData.HARDCORE:
-      return "HARDCORE";
+      return "hardcore";
     case RibbonData.LIMITED_CATCH:
-      return "LIMITED_CATCH";
+      return "limitedCatch";
     case RibbonData.NO_HEAL:
-      return "NO_HEAL";
+      return "noHeal";
     case RibbonData.NO_SHOP:
-      return "NO_SHOP";
+      return "noShop";
     case RibbonData.NO_SUPPORT:
-      return "NO_SUPPORT";
+      return "noSupport";
+    case RibbonData.MONO_NORMAL:
+      return "monoNormal";
+    case RibbonData.MONO_FIGHTING:
+      return "monoFighting";
+    case RibbonData.MONO_FLYING:
+      return "monoFlying";
+    case RibbonData.MONO_POISON:
+      return "monoPoison";
+    case RibbonData.MONO_GROUND:
+      return "monoGround";
+    case RibbonData.MONO_ROCK:
+      return "monoRock";
+    case RibbonData.MONO_BUG:
+      return "monoBug";
+    case RibbonData.MONO_GHOST:
+      return "monoGhost";
+    case RibbonData.MONO_STEEL:
+      return "monoSteel";
+    case RibbonData.MONO_FIRE:
+      return "monoFire";
+    case RibbonData.MONO_WATER:
+      return "monoWater";
+    case RibbonData.MONO_GRASS:
+      return "monoGrass";
+    case RibbonData.MONO_ELECTRIC:
+      return "monoElectric";
+    case RibbonData.MONO_PSYCHIC:
+      return "monoPsychic";
+    case RibbonData.MONO_ICE:
+      return "monoIce";
+    case RibbonData.MONO_DRAGON:
+      return "monoDragon";
+    case RibbonData.MONO_DARK:
+      return "monoDark";
+    case RibbonData.MONO_FAIRY:
+      return "monoFairy";
+    case RibbonData.MONO_GEN_1:
+      return "monoGen1";
+    case RibbonData.MONO_GEN_2:
+      return "monoGen2";
+    case RibbonData.MONO_GEN_3:
+      return "monoGen3";
+    case RibbonData.MONO_GEN_4:
+      return "monoGen4";
+    case RibbonData.MONO_GEN_5:
+      return "monoGen5";
+    case RibbonData.MONO_GEN_6:
+      return "monoGen6";
+    case RibbonData.MONO_GEN_7:
+      return "monoGen7";
+    case RibbonData.MONO_GEN_8:
+      return "monoGen8";
+    case RibbonData.MONO_GEN_9:
+      return "monoGen9";
     default:
       return "";
   }


### PR DESCRIPTION
## What are the changes the user will see?

The user should see descriptions for all Ribbons

## Why am I making these changes?

Damo reported it

## What are the changes from a developer perspective?

- Added the remaining ribbons to `getRibbonKey`
- Also changed the existing ones to actually be the locale key instead of later using `toCamelCase()` on it

## Screenshots/Videos

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4112a9fa-8f6a-41bb-a577-affdb9a091c8" />

## How to test the changes?

```ts
const overrides = {
  STARTING_WAVE_OVERRIDE: 201
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?