### PR TITLE
[Beta] [Bug] Show correct username in title ui

### DIFF
--- a/src/ui/handlers/title-ui-handler.ts
+++ b/src/ui/handlers/title-ui-handler.ts
@@ -47,6 +47,10 @@ export class TitleUiHandler extends OptionSelectUiHandler {
     return i18next.t("menu:loggedInAs", { username: displayName });
   }
 
+  updateUsername() {
+    this.usernameLabel.setText(this.getUsername());
+  }
+
   constructor(mode: UiMode = UiMode.TITLE) {
     super(mode);
   }
@@ -166,6 +170,8 @@ export class TitleUiHandler extends OptionSelectUiHandler {
 
     const scaledHeight = globalScene.scaledCanvas.height;
     const windowHeight = this.getWindowHeight();
+
+    this.updateUsername();
 
     // Moving username and player count to top of the menu
     // and sorting it, to display the shorter one on top

--- a/src/ui/settings/abstract-settings-ui-handler.ts
+++ b/src/ui/settings/abstract-settings-ui-handler.ts
@@ -10,6 +10,7 @@ import { MessageUiHandler } from "#ui/message-ui-handler";
 import { NavigationManager, NavigationMenu } from "#ui/navigation-menu";
 import { ScrollBar } from "#ui/scroll-bar";
 import { addTextObject, getTextColor } from "#ui/text";
+import type { TitleUiHandler } from "#ui/title-ui-handler";
 import { addWindow } from "#ui/ui-theme";
 import i18next from "i18next";
 
@@ -497,6 +498,7 @@ export class AbstractSettingsUiHandler extends MessageUiHandler {
     this.setScrollCursor(0);
     this.eraseCursor();
     this.getUi().bgmBar.toggleBgmBar(globalScene.showBgmBar);
+    (this.getUi().handlers[UiMode.TITLE] as TitleUiHandler)?.updateUsername();
     if (this.reloadRequired) {
       this.reloadRequired = false;
       globalScene.reset(true, false, true);


### PR DESCRIPTION
## What are the changes the user will see?

- The correct username will show instead of `guest`
- when changing the gender or `hideUsername` setting, the name will update without hvaing to reload

## Why am I making these changes?

Bug fix

## What are the changes from a developer perspective?

added a `updateUsername` method to `titleUiHandler`
This method is called when exiting the settings and in `titleUiHandler#show`

## Screenshots/Videos

<details><summary>Correct name</summary>

<img width="1920" height="1080" alt="correct-name" src="https://github.com/user-attachments/assets/04002407-3f81-4999-97b4-0dd3976c5920" />

</details> 

<details><summary>Switch name</summary>

https://github.com/user-attachments/assets/ee3187d8-6e49-492f-a306-3f5cfc252274

</details> 

## How to test the changes?

Change gender/hideUsername setting and if you have a local rogueserver, turn off `VITE_BYPASS_LOGIN` in `.env.development` to check that it shows the name instead of `guest`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
- [x] Have I provided screenshots/videos of the changes (if applicable)?