### PR TITLE
[Bug] Fix awarded ribbon in limited support

### DIFF
--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -1109,7 +1109,16 @@ export class LowerStarterPointsChallenge extends Challenge {
  */
 export class LimitedSupportChallenge extends Challenge {
   public override get ribbonAwarded(): RibbonFlag {
-    return this.value ? ((RibbonData.NO_HEAL << (BigInt(this.value) - 1n)) as RibbonFlag) : 0n;
+    switch (this.value) {
+      case 1:
+        return RibbonData.NO_HEAL as RibbonFlag;
+      case 2:
+        return RibbonData.NO_SHOP as RibbonFlag;
+      case 3:
+        return (RibbonData.NO_HEAL | RibbonData.NO_SHOP | RibbonData.NO_SUPPORT) as RibbonFlag;
+      default:
+        return 0n as RibbonFlag;
+    }
   }
   constructor() {
     super(Challenges.LIMITED_SUPPORT, 3);


### PR DESCRIPTION
## What are the changes the user will see?
Completing the No Support challenge now awards both the No Heal and No Shop ribbons.

## What are the changes from a developer perspective?
Inserted a switch on the challenge value to determine which ribbon(s) to give.

## Screenshots/Videos
<img width="733" height="417" alt="image" src="https://github.com/user-attachments/assets/985c632d-2f5f-441c-91fd-05d69269babc" />

## How to test the changes?
const overrides = {
  STARTING_WAVE_OVERRIDE: 199,
  STARTING_BIOME_OVERRIDE: BiomeId.END,
  STARTING_LEVEL_OVERRIDE: 9999,
} satisfies Partial<InstanceType<OverridesType>>;

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?