### PR TITLE
[Bug][UI/UX] Display no heal and no shop ribbon if no support is unlocked

### DIFF
--- a/src/ui/containers/ribbon-tray-container.ts
+++ b/src/ui/containers/ribbon-tray-container.ts
@@ -119,6 +119,7 @@ export class RibbonTray extends Phaser.GameObjects.Container {
     const classicWinCount = globalScene.gameData.starterData[species.speciesId]?.classicWinCount ?? 0;
 
     for (const ribbon of availableOrderedRibbons) {
+      // TODO: eventually, write a save migrator to fix the ribbon save data and get rid of these two conditions
       // Display classic ribbons for starters with at least one classic win
       const overrideClassicRibbon = ribbon === RibbonData.CLASSIC && classicWinCount > 0;
       // Display no heal and no shop ribbons for mons that have the no support ribbon


### PR DESCRIPTION
PR #6713 fixed a bug which was not awarding no heal and no shop ribbons to mons that win the game in no support mode. However, players who collected the no support ribbon in 1.10 still would not have the other two unlocked.

This is a soft fix which lets no shop and no heal be displayed in any case as long as no support is unlocked, in the same vein as #6709 for classic wins.

Also a minor change to the check to classic win count for readability.


## Screenshots/Videos

This Bulbasaur only has a no support ribbon, but all three show up.

<img width="736" height="421" alt="image" src="https://github.com/user-attachments/assets/d03a1393-ce72-47b7-8312-be7c16ab71b3" />

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?