### PR TITLE
[Bug] Allow fainted Pokemon to be released post-battle in hardcore

### DIFF
--- a/src/ui/handlers/party-ui-handler.ts
+++ b/src/ui/handlers/party-ui-handler.ts
@@ -1586,9 +1586,8 @@ export class PartyUiHandler extends MessageUiHandler {
         this.updateOptionsWithModifierTransferMode(pokemon);
         break;
       case PartyUiMode.SWITCH:
-        this.options.push(PartyOption.RELEASE);
-        break;
       case PartyUiMode.RELEASE:
+      case PartyUiMode.CHECK:
         this.options.push(PartyOption.RELEASE);
         break;
     }


### PR DESCRIPTION
## What are the changes the user will see?
Fainted Pokémon will be releasable post-battle when the Hardcore challenge is enabled.

## Why am I making these changes?
When the option to release Pokémon was moved to post-battle, the Hardcore challenge was forgotten to be accounted for.

## What are the changes from a developer perspective?
Added `PartyUiMode.CHECK` to the `switch` statement in `PartyUiHandler#updateOptionsHardcore`.

## How to test the changes?
Try to release a Pokémon post-battle with the hardcore challenge enabled.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?