### PR TITLE
[Bug] Shinies won't be forced to match event boss shiny if set

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -6388,12 +6388,14 @@ export class EnemyPokemon extends Pokemon {
       }
 
       const eventBossVariant = getDailyEventSeedBossVariant(globalScene.seed);
-      if (eventBossVariant != null && globalScene.gameMode.isWaveFinal(globalScene.currentBattle.waveIndex)) {
+      const eventBossVariantEnabled =
+        eventBossVariant != null && globalScene.gameMode.isWaveFinal(globalScene.currentBattle.waveIndex);
+      if (eventBossVariantEnabled) {
         this.shiny = true;
       }
 
       if (this.shiny) {
-        this.variant = eventBossVariant ?? this.generateShinyVariant();
+        this.variant = eventBossVariantEnabled ? eventBossVariant : this.generateShinyVariant();
         if (Overrides.ENEMY_VARIANT_OVERRIDE !== null) {
           this.variant = Overrides.ENEMY_VARIANT_OVERRIDE;
         }


### PR DESCRIPTION
## What are the changes the user will see?
Shinies will not be forced to all match the variant tier of an event boss shiny set by custom daily seed.

## Why am I making these changes?
Bug fix.

## What are the changes from a developer perspective?
Added an additional check for whether to use the event boss variant tier.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?