### PR TITLE
[Hotfix] Fixed Candy Jar in Daily run event items disappearing after refresh

### DIFF
--- a/src/phases/title-phase.ts
+++ b/src/phases/title-phase.ts
@@ -268,7 +268,13 @@ export class TitlePhase extends Phase {
           globalScene.addModifier(m, true, false, false, true);
         }
         for (const m of timedEventManager.getEventDailyStartingItems()) {
-          globalScene.addModifier(modifierTypes[m]().newModifier(), true, false, false, true);
+          globalScene.addModifier(
+            modifierTypes[m]().withIdFromFunc(modifierTypes[m]).newModifier(),
+            true,
+            false,
+            false,
+            true,
+          );
         }
         globalScene.updateModifiers(true, true);
 


### PR DESCRIPTION
## What are the changes the user will see?
Candy Jar doesnt disappear anymore.

## Why am I making these changes?
It should persist

## What are the changes from a developer perspective?
The adding of new modifiers was missing a function call to add its id, this is necessary for all modifiers (modifier rework save us).

The only reason the Ability and Shiny Charm event items didnt break, is because they already had a correct assignment before this, so it was just a +1 and didnt actually miss its id.

## Screenshots/Videos

## How to test the changes?
Start a new daily run and after loading refresh the page and press continue. After the changes the Candy Jar is actually still there.

## Checklist
- [x] **I'm using `hotfix-1.11.3` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?

Does this require any changes to the assets folder? If so:
  - [ ] Has a PR been created on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repo?
    - [ ] If so, please leave a link to it here: 