### PR TITLE
[Hotfix] Prevent crash with two NG Pokemon fainting at the same time

### DIFF
--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -1532,6 +1532,11 @@ export class SuppressAbilitiesTag extends SerializableArenaTag {
       const setter = globalScene
         .getField(true)
         .filter(p => p.hasAbilityWithAttr("PreLeaveFieldRemoveSuppressAbilitiesSourceAbAttr", false))[0];
+      // Setter may not exist if both NG Pokemon faint simultaneously
+      if (setter == null) {
+        return;
+      }
+
       applyOnGainAbAttrs({
         pokemon: setter,
         passive: setter.getAbility().hasAttr("PreLeaveFieldRemoveSuppressAbilitiesSourceAbAttr"),


### PR DESCRIPTION
## What are the changes the user will see?
Game will not crash when two Neutralizing Gas users faint in the same turn

## Why am I making these changes?
DC: https://discord.com/channels/1125469663833370665/1434896848467923027

## What are the changes from a developer perspective?
If only one NG Pokemon is remaining, the game finds it to activate its passive. This was missing a check for this pokemon to be undefined, which would happen in the case that both NG pokemon were in a fainted state (`sourceCount` is decremented one at a time but both pokemon fainted at once, so for that small time it is desynced). 

This is fixed by just adding a null guard

## Screenshots/Videos


## How to test the changes?
Test with Precipice Blades on the session data provided in the DC post linked above

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?
