### PR TITLE
[i18n] Fix freeze healByMove message

### DIFF
--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -205,7 +205,7 @@ export class MovePhase extends PokemonPhase {
       user.cureStatus(
         StatusEffect.FREEZE,
         i18next.t("statusEffect:freeze.healByMove", {
-          pokemonName: getPokemonNameWithAffix(user),
+          pokemonNameWithAffix: getPokemonNameWithAffix(user),
           moveName: this.move.getMove().name,
         }),
       );


### PR DESCRIPTION
## What are the changes the user will see?

When a pokemon cures it's freeze with a move, ot will show the correct pokemon name instead of the i18n variable

## Why am I making these changes?

[Discord report](https://discord.com/channels/1125469663833370665/1125894949020381285/1435540969754722304)

## What are the changes from a developer perspective?

replaced `pokemonName` with `pokemonNameWithAffix` to match the locale

## Screenshots/Videos

<details><summary>Image</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/cc1b7a5d-5640-4970-b452-153a519c26d5" />

</details> 

## How to test the changes?

```ts
const overrides = {
  ENEMY_STATUS_OVERRIDE: StatusEffect.FREEZE,
  ENEMY_MOVESET_OVERRIDE: MoveId.FLARE_BLITZ
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- [x] **I'm using `hotfix-1.11.3` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
- [x] Have I provided screenshots/videos of the changes (if applicable)?
