### PR TITLE
[i18n] Fix mist message

### DIFF
--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -319,7 +319,11 @@ export class MistTag extends SerializableArenaTag {
     cancelled.value = true;
 
     if (!simulated) {
-      globalScene.phaseManager.queueMessage(i18next.t("arenaTag:mistApply"));
+      globalScene.phaseManager.queueMessage(
+        i18next.t("arenaTag:mistApply", {
+          pokemonNameWithAffix: getPokemonNameWithAffix(this.getSourcePokemon()),
+        }),
+      );
     }
 
     return true;


### PR DESCRIPTION
## What are the changes the user will see?

Mist will show the correct pokemon name instead of `{{pokemonNameWithAffix}}`

## Why am I making these changes?

[Discord report](https://discord.com/channels/1125469663833370665/1435859389457104926/1435859389457104926)

## What are the changes from a developer 

`mistApply` wasn't passing any i18n variable so added that

## Screenshots/Videos

<details><summary>Image</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5f820301-d48b-49f6-a900-32fceeda8d3b" />

</details> 

## How to test the changes?

```ts
const overrides = {
  MOVESET_OVERRIDE: MoveId.GROWL,
  ENEMY_MOVESET_OVERRIDE: [MoveId.MIST, MoveId.MIST,MoveId.MIST,MoveId.MIST]
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- [x] **I'm using `hotfix-1.11.3` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
- [x] Have I provided screenshots/videos of the changes (if applicable)? 