### PR TITLE
Converted various held item data types to interfaces

### DIFF
--- a/src/@types/held-item-data-types.ts
+++ b/src/@types/held-item-data-types.ts
@@ -5,7 +5,7 @@ import type { AllHeldItems } from "#items/all-held-items";
 import type { CosmeticHeldItem } from "#items/held-item";
 import type { InferKeys } from "#types/helpers/type-helpers";
 
-export type HeldItemData = {
+export interface HeldItemData {
   /**
    * Number of items in the stack, can also be used to track cooldown
    */
@@ -21,37 +21,36 @@ export type HeldItemData = {
    * @defaultValue `false`
    */
   active?: boolean;
-};
+}
 
 export type HeldItemDataMap = Map<HeldItemId, HeldItemData>;
 
-export type HeldItemSpecs = HeldItemData & {
+export interface HeldItemSpecs extends HeldItemData {
   id: HeldItemId;
-};
+}
 
+// TODO: Move these getters with the rest of the item getters in a nice big file
 export function isHeldItemSpecs(entry: any): entry is HeldItemSpecs {
   return typeof entry.id === "number" && "stack" in entry;
 }
 
-export type HeldItemWeights = {
-  [key in HeldItemId]?: number;
-};
+export type HeldItemWeights = Partial<Record<HeldItemId, number>>;
 
 export type HeldItemWeightFunc = (party: Pokemon[]) => number;
 
-export type HeldItemCategoryEntry = HeldItemData & {
+interface HeldItemCategoryEntry extends HeldItemData {
   id: HeldItemCategoryId;
   customWeights?: HeldItemWeights;
-};
+}
 
 export function isHeldItemCategoryEntry(entry: any): entry is HeldItemCategoryEntry {
   return entry?.id && isHeldItemCategoryEntry(entry.id) && "customWeights" in entry;
 }
 
-type HeldItemPoolEntry = {
+interface HeldItemPoolEntry {
   entry: HeldItemId | HeldItemCategoryId | HeldItemCategoryEntry | HeldItemSpecs | HeldItemPool;
   weight: number | HeldItemWeightFunc;
-};
+}
 
 export type HeldItemPool = HeldItemPoolEntry[];
 
@@ -59,21 +58,19 @@ export function isHeldItemPool(value: any): value is HeldItemPool {
   return Array.isArray(value) && value.every(entry => "entry" in entry && "weight" in entry);
 }
 
-export type HeldItemTieredPool = {
-  [key in RarityTier]?: HeldItemPool;
-};
+export type HeldItemTieredPool = Partial<Record<RarityTier, HeldItemPool>>;
 
-type HeldItemConfigurationEntry = {
+interface HeldItemConfigurationEntry {
   entry: HeldItemId | HeldItemCategoryId | HeldItemCategoryEntry | HeldItemSpecs | HeldItemPool;
   count?: number | (() => number);
-};
+}
 
 export type HeldItemConfiguration = HeldItemConfigurationEntry[];
 
-export type PokemonItemMap = {
+export interface PokemonItemMap {
   item: HeldItemSpecs;
   pokemonId: number;
-};
+}
 
 export type HeldItemSaveData = HeldItemSpecs[];
 


### PR DESCRIPTION
## What are the changes the user will see?
N/A
## Why am I making these changes?
Interfaces are faster than types for TS to parse, most notably when used to extend and create new types (like in the modifier rework branch).
TS is better able to cache results with interface extension than type intersection, plus the extra consistency is good.

## What are the changes from a developer perspective?
Changed a bunch of interfaces to types


## Screenshots/Videos
N/A

## How to test the changes?
N/A

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
