### PR TITLE
[i18n] Fix message for unimplemented moves

### DIFF
--- a/src/data/moves/pokemon-move.ts
+++ b/src/data/moves/pokemon-move.ts
@@ -55,7 +55,7 @@ export class PokemonMove {
 
     // TODO: Add Sky Drop's 1 turn stall
     if (this.moveId === MoveId.NONE || move.name.endsWith(" (N)")) {
-      return [false, i18next.t("battle:moveNotImplemented", moveName.replace(" (N)", ""))];
+      return [false, i18next.t("battle:moveNotImplemented", { moveName: moveName.replace(" (N)", "") })];
     }
 
     if (!ignorePp && move.pp !== -1 && this.ppUsed >= this.getMovePp()) {


### PR DESCRIPTION
## What are the changes the user will see?

Show correct message when trying to use unimplemented moves

## Why am I making these changes?

Damo reported

## What are the changes from a developer perspective?

the move name was directly passed instead of being an object with a `moveName` key

## Screenshots/Videos

<details><summary>Image</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b9b03dff-c672-411c-9ac0-2a53e7a13526" />

</details> 

## How to test the changes?

Try using any unimplemented move

```ts
const overrides = {
  MOVESET_OVERRIDE: MoveId.BIDE
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
- [x] Have I provided screenshots/videos of the changes (if applicable)?