### PR TITLE
[Bug][Balance] Actual correct minimum waves for Legends in Daily Mode

### DIFF
--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -184,7 +184,7 @@ export class Arena {
       ret = getPokemonSpecies(species!);
 
       if (ret.subLegendary || ret.legendary || ret.mythical) {
-        const waveDifficulty = globalScene.gameMode.getWaveForDifficulty(waveIndex);
+        const waveDifficulty = globalScene.gameMode.getWaveForDifficulty(waveIndex, true);
         if (ret.baseTotal >= 660) {
           regen = waveDifficulty < 80; // Wave 50+ in daily (however, max Daily wave is 50 currently so not possible)
         } else {


### PR DESCRIPTION
## What are the changes the user will see?
Daily Mode loses waves 22-24 as viable legend spawns. It was already advertised as wave 25+, so noone will actually notice.

## Why am I making these changes?
It was intended to be W25+ (see comments lol)

Also, if for any reason in the future biome rework the 660 BST legends are in the non-boss encounter list. Then suddenly they can be encountered in Daily Mode W42-49. Which is not something Balance wants.

## What are the changes from a developer perspective?
-

## Screenshots/Videos
-

## How to test the changes?
Set a breakpoint on the changed code and look at the `waveForDifficulty` variable. It should always be wave+30, no additional offsets.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
