### PR TITLE
[UI/UX] Fix confirm message overlap on run history import

### DIFF
--- a/src/ui/handlers/menu-ui-handler.ts
+++ b/src/ui/handlers/menu-ui-handler.ts
@@ -278,6 +278,7 @@ export class MenuUiHandler extends MessageUiHandler {
     manageDataOptions.push({
       label: i18next.t("menuUiHandler:importRunHistory"),
       handler: () => {
+        ui.revertMode();
         globalScene.gameData.importData(GameDataType.RUN_HISTORY);
         return true;
       },


### PR DESCRIPTION
## What are the changes the user will see?

When trying to import a run history, the confirm message will no longer overlap

## Why am I making these changes?

Better UX

## What are the changes from a developer perspective?

Added `ui.revertMode()` when selecting the import run history option. Now it behaves the same as the import data option.

## Screenshots/Videos

<details><summary>Before</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/66ab0b8c-c1e3-4a7e-932a-3b97c0fc57f7" />

</details> 

<details><summary>After</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d2842f85-5e21-42e6-8b07-531ce3ed3f3a" />

</details> 

## How to test the changes?

Try importing a run history

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?