### PR TITLE
fix: Captivate checks correct targets and is affected by Oblivious

### DIFF
--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -6925,7 +6925,7 @@ export function initAbilities() {
     new AbBuilder(AbilityId.OBLIVIOUS, 3)
       .attr(BattlerTagImmunityAbAttr, [ BattlerTagType.INFATUATED, BattlerTagType.TAUNT ])
       .attr(PostSummonRemoveBattlerTagAbAttr, BattlerTagType.INFATUATED, BattlerTagType.TAUNT)
-      .attr(MoveImmunityAbAttr, (pokemon, attacker, move) => move.id === MoveId.CAPTIVATE)
+      .attr(MoveImmunityAbAttr, (_pokemon, _attacker, move) => move.id === MoveId.CAPTIVATE)
       .attr(IntimidateImmunityAbAttr)
       .ignorable()
       .build(),

--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -6925,6 +6925,7 @@ export function initAbilities() {
     new AbBuilder(AbilityId.OBLIVIOUS, 3)
       .attr(BattlerTagImmunityAbAttr, [ BattlerTagType.INFATUATED, BattlerTagType.TAUNT ])
       .attr(PostSummonRemoveBattlerTagAbAttr, BattlerTagType.INFATUATED, BattlerTagType.TAUNT)
+      .attr(MoveImmunityAbAttr, (pokemon, attacker, move) => move.id === MoveId.CAPTIVATE)
       .attr(IntimidateImmunityAbAttr)
       .ignorable()
       .build(),

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -9970,7 +9970,7 @@ export function initMoves() {
       .attr(HighCritAttr)
       .makesContact(false),
     new StatusMove(MoveId.CAPTIVATE, PokemonType.NORMAL, 100, 20, -1, 0, 4)
-      .attr(StatStageChangeAttr, [ Stat.SPATK ], -2, false, { condition: (user, target, move) => target.isOppositeGender(user) })
+      .attr(StatStageChangeAttr, [ Stat.SPATK ], -2, false, { condition: (user, target) => target.isOppositeGender(user) })
       .target(MoveTarget.ALL_NEAR_ENEMIES)
       .reflectable(),
     new StatusMove(MoveId.STEALTH_ROCK, PokemonType.ROCK, -1, 20, -1, 0, 4)

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -10601,7 +10601,9 @@ export function initMoves() {
       .attr(HighCritAttr)
       .makesContact(false),
     new StatusMove(MoveId.CAPTIVATE, PokemonType.NORMAL, 100, 20, -1, 0, 4)
-      .attr(StatStageChangeAttr, [Stat.SPATK], -2, false, { condition: (user, target) => target.isOppositeGender(user) })
+      .attr(StatStageChangeAttr, [Stat.SPATK], -2, false, {
+        condition: (user, target) => target.isOppositeGender(user),
+      })
       .target(MoveTarget.ALL_NEAR_ENEMIES)
       .reflectable(),
     new StatusMove(MoveId.STEALTH_ROCK, PokemonType.ROCK, -1, 20, -1, 0, 4)

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -9970,8 +9970,7 @@ export function initMoves() {
       .attr(HighCritAttr)
       .makesContact(false),
     new StatusMove(MoveId.CAPTIVATE, PokemonType.NORMAL, 100, 20, -1, 0, 4)
-      .attr(StatStageChangeAttr, [ Stat.SPATK ], -2)
-      .condition((user, target, move) => target.isOppositeGender(user))
+      .attr(StatStageChangeAttr, [ Stat.SPATK ], -2, false, { condition: (user, target, move) => target.isOppositeGender(user) })
       .target(MoveTarget.ALL_NEAR_ENEMIES)
       .reflectable(),
     new StatusMove(MoveId.STEALTH_ROCK, PokemonType.ROCK, -1, 20, -1, 0, 4)

--- a/test/moves/captivate.test.ts
+++ b/test/moves/captivate.test.ts
@@ -13,89 +13,89 @@ describe("Moves - Captivate", () => {
   let game: GameManager;
 
   beforeAll(() => {
-	phaserGame = new Phaser.Game({
-	  type: Phaser.HEADLESS,
-	});
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
   });
 
   afterEach(() => {
-	game.phaseInterceptor.restoreOg();
+    game.phaseInterceptor.restoreOg();
   });
 
   beforeEach(() => {
-	game = new GameManager(phaserGame);
-	game.override
-	  .battleStyle("double")
-	  .enemyGender(Gender.MALE)
-	  .enemySpecies(SpeciesId.NIDORAN_M)
-	  .moveset([MoveId.CAPTIVATE, MoveId.SPLASH])
-	  .enemyMoveset(MoveId.SPLASH)
-	  .criticalHits(false);
+    game = new GameManager(phaserGame);
+    game.override
+      .battleStyle("double")
+      .enemyGender(Gender.MALE)
+      .enemySpecies(SpeciesId.NIDORAN_M)
+      .moveset([MoveId.CAPTIVATE, MoveId.SPLASH])
+      .enemyMoveset(MoveId.SPLASH)
+      .criticalHits(false);
   });
 
   it("Lowers special attack by two stages when all targets are valid", async () => {
-	// arrange
-	game.override.playerGender(Gender.FEMALE);
-	await game.classicMode.startBattle([SpeciesId.NIDORAN_F, SpeciesId.NIDORAN_F]);
-	const [enemyNidoran1, enemyNidoran2] = game.scene.getEnemyField();
+    // arrange
+    game.override.playerGender(Gender.FEMALE);
+    await game.classicMode.startBattle([SpeciesId.NIDORAN_F, SpeciesId.NIDORAN_F]);
+    const [enemyNidoran1, enemyNidoran2] = game.scene.getEnemyField();
 
-	// act
-	game.move.select(MoveId.CAPTIVATE, BattlerIndex.PLAYER);
-	game.move.select(MoveId.SPLASH, BattlerIndex.PLAYER_2);
-	await game.toEndOfTurn();
+    // act
+    game.move.select(MoveId.CAPTIVATE, BattlerIndex.PLAYER);
+    game.move.select(MoveId.SPLASH, BattlerIndex.PLAYER_2);
+    await game.toEndOfTurn();
 
-	// assert
-	expect(enemyNidoran1.getStatStage(Stat.SPATK)).toEqual(-2);
-	expect(enemyNidoran2.getStatStage(Stat.SPATK)).toEqual(-2);
+    // assert
+    expect(enemyNidoran1.getStatStage(Stat.SPATK)).toEqual(-2);
+    expect(enemyNidoran2.getStatStage(Stat.SPATK)).toEqual(-2);
   });
 
   it("Lowers special attack of only valid targets", async () => {
-	// arrange
-	game.override.playerGender(Gender.FEMALE);
-	await game.classicMode.startBattle([SpeciesId.NIDORAN_F, SpeciesId.NIDORAN_F]);
-	const [invalidTarget, validTarget] = game.scene.getEnemyField();
-	invalidTarget.gender = Gender.FEMALE;
+    // arrange
+    game.override.playerGender(Gender.FEMALE);
+    await game.classicMode.startBattle([SpeciesId.NIDORAN_F, SpeciesId.NIDORAN_F]);
+    const [invalidTarget, validTarget] = game.scene.getEnemyField();
+    invalidTarget.gender = Gender.FEMALE;
 
-	// act
-	game.move.select(MoveId.CAPTIVATE, BattlerIndex.PLAYER);
-	game.move.select(MoveId.SPLASH, BattlerIndex.PLAYER_2);
-	await game.toEndOfTurn();
+    // act
+    game.move.select(MoveId.CAPTIVATE, BattlerIndex.PLAYER);
+    game.move.select(MoveId.SPLASH, BattlerIndex.PLAYER_2);
+    await game.toEndOfTurn();
 
-	// assert
-	expect(invalidTarget.getStatStage(Stat.SPATK)).toEqual(0);
-	expect(validTarget.getStatStage(Stat.SPATK)).toEqual(-2);
+    // assert
+    expect(invalidTarget.getStatStage(Stat.SPATK)).toEqual(0);
+    expect(validTarget.getStatStage(Stat.SPATK)).toEqual(-2);
   });
 
   it("Does not lower special attack when no targets are valid", async () => {
-	// arrange
-	game.override.playerGender(Gender.MALE);
-	await game.classicMode.startBattle([SpeciesId.NIDORAN_M, SpeciesId.NIDORAN_M]);
-	const [enemyNidoran1, enemyNidoran2] = game.scene.getEnemyField();
+    // arrange
+    game.override.playerGender(Gender.MALE);
+    await game.classicMode.startBattle([SpeciesId.NIDORAN_M, SpeciesId.NIDORAN_M]);
+    const [enemyNidoran1, enemyNidoran2] = game.scene.getEnemyField();
 
-	// act
-	game.move.select(MoveId.CAPTIVATE, BattlerIndex.PLAYER);
-	game.move.select(MoveId.SPLASH, BattlerIndex.PLAYER_2);
-	await game.toEndOfTurn();
+    // act
+    game.move.select(MoveId.CAPTIVATE, BattlerIndex.PLAYER);
+    game.move.select(MoveId.SPLASH, BattlerIndex.PLAYER_2);
+    await game.toEndOfTurn();
 
-	// assert
-	expect(enemyNidoran1.getStatStage(Stat.SPATK)).toEqual(0);
-	expect(enemyNidoran2.getStatStage(Stat.SPATK)).toEqual(0);
+    // assert
+    expect(enemyNidoran1.getStatStage(Stat.SPATK)).toEqual(0);
+    expect(enemyNidoran2.getStatStage(Stat.SPATK)).toEqual(0);
   });
 
   it("Does not lower special attack when all targets have the Oblivious ability", async () => {
-	// arrange
-	game.override.enemyAbility(AbilityId.OBLIVIOUS);
-	game.override.playerGender(Gender.FEMALE);
-	await game.classicMode.startBattle([SpeciesId.NIDORAN_F, SpeciesId.NIDORAN_F]);
-	const [enemyNidoran1, enemyNidoran2] = game.scene.getEnemyField();
+    // arrange
+    game.override.enemyAbility(AbilityId.OBLIVIOUS);
+    game.override.playerGender(Gender.FEMALE);
+    await game.classicMode.startBattle([SpeciesId.NIDORAN_F, SpeciesId.NIDORAN_F]);
+    const [enemyNidoran1, enemyNidoran2] = game.scene.getEnemyField();
 
-	// act
-	game.move.select(MoveId.CAPTIVATE, BattlerIndex.PLAYER);
-	game.move.select(MoveId.SPLASH, BattlerIndex.PLAYER_2);
-	await game.toEndOfTurn();
+    // act
+    game.move.select(MoveId.CAPTIVATE, BattlerIndex.PLAYER);
+    game.move.select(MoveId.SPLASH, BattlerIndex.PLAYER_2);
+    await game.toEndOfTurn();
 
-	// assert
-	expect(enemyNidoran1.getStatStage(Stat.SPATK)).toEqual(0);
-	expect(enemyNidoran2.getStatStage(Stat.SPATK)).toEqual(0);
+    // assert
+    expect(enemyNidoran1.getStatStage(Stat.SPATK)).toEqual(0);
+    expect(enemyNidoran2.getStatStage(Stat.SPATK)).toEqual(0);
   });
 });

--- a/test/moves/captivate.test.ts
+++ b/test/moves/captivate.test.ts
@@ -1,9 +1,9 @@
+import { Gender } from "#data/gender";
 import { AbilityId } from "#enums/ability-id";
 import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { Stat } from "#enums/stat";
-import { StatusEffect } from "#enums/status-effect";
 import { GameManager } from "#test/test-utils/game-manager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -26,31 +26,76 @@ describe("Moves - Captivate", () => {
 	game = new GameManager(phaserGame);
 	game.override
 	  .battleStyle("double")
+	  .enemyGender(Gender.MALE)
 	  .enemySpecies(SpeciesId.NIDORAN_M)
-	  .startingLevel(1)
-	  .moveset(MoveId.SPLASH)
-	  .enemyMoveset(MoveId.CAPTIVATE)
+	  .moveset([MoveId.CAPTIVATE, MoveId.SPLASH])
+	  .enemyMoveset(MoveId.SPLASH)
 	  .criticalHits(false);
   });
 
   it("Lowers special attack by two stages when all targets are valid", async () => {
 	// arrange
+	game.override.playerGender(Gender.FEMALE);
 	await game.classicMode.startBattle([SpeciesId.NIDORAN_F, SpeciesId.NIDORAN_F]);
-	const [playerNidoran1, playerNidoran2] = game.scene.getPlayerField();
+	const [enemyNidoran1, enemyNidoran2] = game.scene.getEnemyField();
 
 	// act
-	game.move.forceEnemyMove(MoveId.CAPTIVATE, BattlerIndex.ENEMY_2);
-	await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
+	game.move.select(MoveId.CAPTIVATE, BattlerIndex.PLAYER);
+	game.move.select(MoveId.SPLASH, BattlerIndex.PLAYER_2);
 	await game.toEndOfTurn();
 
 	// assert
-	expect(playerNidoran1.getStatStage(Stat.SPATK)).toEqual(2);
-	expect(playerNidoran2.getStatStage(Stat.SPATK)).toEqual(2);
+	expect(enemyNidoran1.getStatStage(Stat.SPATK)).toEqual(-2);
+	expect(enemyNidoran2.getStatStage(Stat.SPATK)).toEqual(-2);
   });
 
-  // Wrong gender
+  it("Lowers special attack of only valid targets", async () => {
+	// arrange
+	game.override.playerGender(Gender.FEMALE);
+	await game.classicMode.startBattle([SpeciesId.NIDORAN_F, SpeciesId.NIDORAN_F]);
+	const [invalidTarget, validTarget] = game.scene.getEnemyField();
+	invalidTarget.gender = Gender.FEMALE;
 
-  // 1 wrong gender
+	// act
+	game.move.select(MoveId.CAPTIVATE, BattlerIndex.PLAYER);
+	game.move.select(MoveId.SPLASH, BattlerIndex.PLAYER_2);
+	await game.toEndOfTurn();
 
-  // Oblivious
+	// assert
+	expect(invalidTarget.getStatStage(Stat.SPATK)).toEqual(0);
+	expect(validTarget.getStatStage(Stat.SPATK)).toEqual(-2);
+  });
+
+  it("Does not lower special attack when no targets are valid", async () => {
+	// arrange
+	game.override.playerGender(Gender.MALE);
+	await game.classicMode.startBattle([SpeciesId.NIDORAN_M, SpeciesId.NIDORAN_M]);
+	const [enemyNidoran1, enemyNidoran2] = game.scene.getEnemyField();
+
+	// act
+	game.move.select(MoveId.CAPTIVATE, BattlerIndex.PLAYER);
+	game.move.select(MoveId.SPLASH, BattlerIndex.PLAYER_2);
+	await game.toEndOfTurn();
+
+	// assert
+	expect(enemyNidoran1.getStatStage(Stat.SPATK)).toEqual(0);
+	expect(enemyNidoran2.getStatStage(Stat.SPATK)).toEqual(0);
+  });
+
+  it("Does not lower special attack when all targets have the Oblivious ability", async () => {
+	// arrange
+	game.override.enemyAbility(AbilityId.OBLIVIOUS);
+	game.override.playerGender(Gender.FEMALE);
+	await game.classicMode.startBattle([SpeciesId.NIDORAN_F, SpeciesId.NIDORAN_F]);
+	const [enemyNidoran1, enemyNidoran2] = game.scene.getEnemyField();
+
+	// act
+	game.move.select(MoveId.CAPTIVATE, BattlerIndex.PLAYER);
+	game.move.select(MoveId.SPLASH, BattlerIndex.PLAYER_2);
+	await game.toEndOfTurn();
+
+	// assert
+	expect(enemyNidoran1.getStatStage(Stat.SPATK)).toEqual(0);
+	expect(enemyNidoran2.getStatStage(Stat.SPATK)).toEqual(0);
+  });
 });

--- a/test/moves/captivate.test.ts
+++ b/test/moves/captivate.test.ts
@@ -1,0 +1,56 @@
+import { AbilityId } from "#enums/ability-id";
+import { BattlerIndex } from "#enums/battler-index";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { StatusEffect } from "#enums/status-effect";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Moves - Captivate", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+	phaserGame = new Phaser.Game({
+	  type: Phaser.HEADLESS,
+	});
+  });
+
+  afterEach(() => {
+	game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+	game = new GameManager(phaserGame);
+	game.override
+	  .battleStyle("double")
+	  .enemySpecies(SpeciesId.NIDORAN_M)
+	  .startingLevel(1)
+	  .moveset(MoveId.SPLASH)
+	  .enemyMoveset(MoveId.CAPTIVATE)
+	  .criticalHits(false);
+  });
+
+  it("Lowers special attack by two stages when all targets are valid", async () => {
+	// arrange
+	await game.classicMode.startBattle([SpeciesId.NIDORAN_F, SpeciesId.NIDORAN_F]);
+	const [playerNidoran1, playerNidoran2] = game.scene.getPlayerField();
+
+	// act
+	game.move.forceEnemyMove(MoveId.CAPTIVATE, BattlerIndex.ENEMY_2);
+	await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
+	await game.toEndOfTurn();
+
+	// assert
+	expect(playerNidoran1.getStatStage(Stat.SPATK)).toEqual(2);
+	expect(playerNidoran2.getStatStage(Stat.SPATK)).toEqual(2);
+  });
+
+  // Wrong gender
+
+  // 1 wrong gender
+
+  // Oblivious
+});

--- a/test/test-utils/helpers/overrides-helper.ts
+++ b/test/test-utils/helpers/overrides-helper.ts
@@ -6,6 +6,7 @@ import type { NewArenaEvent } from "#events/battle-scene";
 import { OVERRIDES_COLOR } from "#app/constants/colors";
 import type { BattleStyle, RandomTrainerOverride } from "#app/overrides";
 import Overrides from "#app/overrides";
+import { type Gender, getGenderSymbol } from "#data/gender";
 import { AbilityId } from "#enums/ability-id";
 import type { BattleType } from "#enums/battle-type";
 import { BiomeId } from "#enums/biome-id";
@@ -24,7 +25,6 @@ import { coerceArray } from "#utils/array";
 import { shiftCharCodes } from "#utils/common";
 import chalk from "chalk";
 import { vi } from "vitest";
-import { Gender, getGenderSymbol } from "#data/gender";
 
 /**
  * Helper to handle overrides in tests

--- a/test/test-utils/helpers/overrides-helper.ts
+++ b/test/test-utils/helpers/overrides-helper.ts
@@ -24,6 +24,7 @@ import { coerceArray } from "#utils/array";
 import { shiftCharCodes } from "#utils/common";
 import chalk from "chalk";
 import { vi } from "vitest";
+import { Gender, getGenderSymbol } from "#data/gender";
 
 /**
  * Helper to handle overrides in tests
@@ -233,13 +234,25 @@ export class OverridesHelper extends GameManagerHelper {
   }
 
   /**
-   * Override the player pokemon's initial {@linkcode StatusEffect | status-effect},
+   * Override the player pokemon's initial {@linkcode StatusEffect | status-effect}
    * @param statusEffect - The {@linkcode StatusEffect | status-effect} to set
    * @returns `this`
    */
   public statusEffect(statusEffect: StatusEffect): this {
     vi.spyOn(Overrides, "STATUS_OVERRIDE", "get").mockReturnValue(statusEffect);
     this.log(`Player Pokemon status-effect set to ${StatusEffect[statusEffect]} (=${statusEffect})!`);
+    return this;
+  }
+
+  /**
+   * Override the player's pokemon's initial gender
+   * @param gender - The gender to set
+   * @returns `this`
+   */
+  public playerGender(gender: Gender): this {
+    vi.spyOn(Overrides, "GENDER_OVERRIDE", "get").mockReturnValue(gender);
+    const genderStr = getGenderSymbol(gender);
+    this.log(`Player Pokemon gender set to ${genderStr}!`);
     return this;
   }
 
@@ -510,6 +523,18 @@ export class OverridesHelper extends GameManagerHelper {
   public enemyStatusEffect(statusEffect: StatusEffect): this {
     vi.spyOn(Overrides, "ENEMY_STATUS_OVERRIDE", "get").mockReturnValue(statusEffect);
     this.log(`Enemy Pokemon status-effect set to ${StatusEffect[statusEffect]} (=${statusEffect})!`);
+    return this;
+  }
+
+  /**
+   * Override the enemy's pokemon's initial gender
+   * @param gender - The gender to set
+   * @returns `this`
+   */
+  public enemyGender(gender: Gender): this {
+    vi.spyOn(Overrides, "ENEMY_GENDER_OVERRIDE", "get").mockReturnValue(gender);
+    const genderStr = getGenderSymbol(gender);
+    this.log(`Enemy Pokemon gender set to ${genderStr}!`);
     return this;
   }
 

--- a/test/test-utils/helpers/overrides-helper.ts
+++ b/test/test-utils/helpers/overrides-helper.ts
@@ -6,7 +6,7 @@ import type { NewArenaEvent } from "#events/battle-scene";
 import { OVERRIDES_COLOR } from "#app/constants/colors";
 import type { BattleStyle, RandomTrainerOverride } from "#app/overrides";
 import Overrides from "#app/overrides";
-import { type Gender, getGenderSymbol } from "#data/gender";
+import { Gender } from "#data/gender";
 import { AbilityId } from "#enums/ability-id";
 import type { BattleType } from "#enums/battle-type";
 import { BiomeId } from "#enums/biome-id";
@@ -25,6 +25,7 @@ import { coerceArray } from "#utils/array";
 import { shiftCharCodes } from "#utils/common";
 import chalk from "chalk";
 import { vi } from "vitest";
+import { getEnumStr } from "../string-utils";
 
 /**
  * Helper to handle overrides in tests
@@ -245,14 +246,23 @@ export class OverridesHelper extends GameManagerHelper {
   }
 
   /**
-   * Override the player's pokemon's initial gender
-   * @param gender - The gender to set
+   * Override the initial gender of newly generated player pokemon.
+   * @param gender - The gender to set, or `null` to disable the override
    * @returns `this`
+   * @remarks
+   * This will ignore and supercede species gender distributions,
+   * potentially resulting in invalid combinations of gender/species.
    */
-  public playerGender(gender: Gender): this {
+  public playerGender(gender: Gender | null): this {
     vi.spyOn(Overrides, "GENDER_OVERRIDE", "get").mockReturnValue(gender);
-    const genderStr = getGenderSymbol(gender);
-    this.log(`Player Pokemon gender set to ${genderStr}!`);
+
+    if (gender === null) {
+      this.log("Player Pokemon initial gender override disabled!");
+    } else {
+      const genderStr = getEnumStr(Gender, gender);
+      this.log(`Player Pokemon initial gender set to ${genderStr}!`);
+    }
+
     return this;
   }
 
@@ -527,14 +537,23 @@ export class OverridesHelper extends GameManagerHelper {
   }
 
   /**
-   * Override the enemy's pokemon's initial gender
-   * @param gender - The gender to set
+   * Override the initial gender of newly generated enemy pokemon.
+   * @param gender - The {@linkcode Gender} to set, or `null` to disable the override
    * @returns `this`
+   * @remarks
+   * This will ignore and supercede species gender distributions,
+   * potentially resulting in invalid combinations of gender/species.
    */
-  public enemyGender(gender: Gender): this {
+  public enemyGender(gender: Gender | null): this {
     vi.spyOn(Overrides, "ENEMY_GENDER_OVERRIDE", "get").mockReturnValue(gender);
-    const genderStr = getGenderSymbol(gender);
-    this.log(`Enemy Pokemon gender set to ${genderStr}!`);
+
+    if (gender === null) {
+      this.log("Enemy Pokemon initial gender override disabled!");
+    } else {
+      const genderStr = getEnumStr(Gender, gender, { casing: "Title" });
+      this.log(`Enemy Pokemon initial gender set to ${genderStr}!`);
+    }
+
     return this;
   }
 


### PR DESCRIPTION
## What are the changes the user will see?
- In double battles, Captivate will now fail or succeed depending on the gender compatibility of each target instead of the left target.
- Oblivious now correctly provides immunity to Captivate.

## Why am I making these changes?
Fixes #4976 and an undocumented issue that Oblivious (ability) does not provide immunity to Captivate

## What are the changes from a developer perspective?
- Captivate now uses the condition on `StatStageChangeAttr`
- Oblivious (ability) now has `MoveImmunityAbAttr` for Captivate specifically
- Added tests that cover Captivate behavior

## Screenshots/Videos
See before on #4976 
After:
https://github.com/user-attachments/assets/562f466e-a9ae-4e7d-ae78-eed07411e614


## How to test the changes?
- Override to force double battles and set captivate on all player Pokemon, also optionally override to force Oblivious on all enemy Pokemon
- Automated tests added in this change

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?