### PR TITLE
[Dev] Add lefthook command to update packages on checkout/merge

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -25,4 +25,6 @@ post-merge:
 post-checkout:
   commands:
     update-packages:
-      run: pnpm i
+      # cf https://git-scm.com/docs/githooks#_post_checkout:
+      # The 3rd argument is 1 for branch checkouts and 0 for file checkouts.
+      run: if test {3} -eq "1"; then pnpm i; fi


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Devs won't need to run `pnpm i` manually anymore whenever packages are updated.

## What are the changes from a developer perspective?
`pnpm i` will be run whenever a branch is checked out or `git pull` is used.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?