### PR TITLE
[Bug] Fix evil team admin randomization

### DIFF
--- a/src/utils/random.ts
+++ b/src/utils/random.ts
@@ -12,7 +12,7 @@
 
 import { globalScene } from "#app/global-scene";
 import type { Mutable } from "#types/type-helpers";
-import { randSeedItem } from "#utils/common";
+import { randSeedItem, randSeedShuffle } from "#utils/common";
 
 /**
  * Select a random element using an offset such that the chosen element is
@@ -38,8 +38,7 @@ import { randSeedItem } from "#utils/common";
  * ```
  */
 export function randSeedUniqueItem<T>(choices: readonly T[], seedOffset: number, scene = globalScene): T {
-  if (seedOffset === 0 || choices.length <= seedOffset) {
-    // cast to mutable is safe because randSeedItem does not actually modify the array
+  if (choices.length <= seedOffset) {
     return randSeedItem(choices as Mutable<typeof choices>);
   }
 
@@ -47,14 +46,7 @@ export function randSeedUniqueItem<T>(choices: readonly T[], seedOffset: number,
   let choice: T;
 
   scene.executeWithSeedOffset(() => {
-    const curChoices = choices.slice();
-    for (let i = 0; i < seedOffset; i++) {
-      const previousChoice = randSeedItem(curChoices);
-      curChoices.splice(curChoices.indexOf(previousChoice), 1);
-    }
-    choice = randSeedItem(curChoices);
-  }, seedOffset);
-
-  // Bang is safe since there are at least `seedOffset` choices, so the method above is guaranteed to set `choice`
+    choice = randSeedShuffle(choices.slice())[seedOffset];
+  }, 0);
   return choice!;
 }

--- a/src/utils/random.ts
+++ b/src/utils/random.ts
@@ -21,9 +21,10 @@ import { randSeedItem, randSeedShuffle } from "#utils/common";
  * @remarks
  * If the seed offset is greater than the number of choices, this will just choose a random element
  *
- * @param arr - The array of items to choose from
+ * @param choices - The array of items to choose from
+ * @param seedOffset - The offset into the array
  * @param scene - (default {@linkcode globalScene}); The scene to use for random seeding
- * @returns A random item from the array that is guaranteed to be different from the
+ * @returns A random item from the array that is guaranteed to be different from the previous result
  * @typeParam T - The type of items in the array
  *
  * @example

--- a/test/utils/random.test.ts
+++ b/test/utils/random.test.ts
@@ -30,7 +30,7 @@ describe("Utils - Random", () => {
       game = new GameManager(phaserGame);
     });
 
-    it("should prevent when provided with different offsets", async () => {
+    it("should prevent duplicates when provided with different offsets", async () => {
       const choices = ["a", "b", "c", "d"];
       const choice1 = randSeedUniqueItem(choices, 0);
       const choice2 = randSeedUniqueItem(choices, 1);

--- a/test/utils/random.test.ts
+++ b/test/utils/random.test.ts
@@ -4,6 +4,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 import { GameManager } from "#test/test-utils/game-manager";
 import { randSeedUniqueItem } from "#utils/random";
 import Phaser from "phaser";

--- a/test/utils/random.test.ts
+++ b/test/utils/random.test.ts
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: 2024-2025 Pagefault Games
+ * SPDX-FileContributor: SirzBenjie
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { GameManager } from "#test/test-utils/game-manager";
+import { randSeedUniqueItem } from "#utils/random";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Utils - Random", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  describe("randSeedUniqueItem", () => {
+    // TODO: Remove `initialization of game` once `randSeedUniqueItem` stops using `executeWithSeedOffset`
+    beforeAll(() => {
+      phaserGame = new Phaser.Game({
+        type: Phaser.HEADLESS,
+      });
+    });
+
+    afterEach(() => {
+      game.phaseInterceptor.restoreOg();
+    });
+
+    beforeEach(() => {
+      game = new GameManager(phaserGame);
+    });
+
+    it("should prevent when provided with different offsets", async () => {
+      const choices = ["a", "b", "c", "d"];
+      const choice1 = randSeedUniqueItem(choices, 0);
+      const choice2 = randSeedUniqueItem(choices, 1);
+      const choice3 = randSeedUniqueItem(choices, 2);
+      expect(choice2).not.toEqual(choice1);
+      expect(choice2).not.toEqual(choice3);
+      expect(choice1).not.toEqual(choice3);
+    });
+
+    it("should gracefully handle an offset larger than the choices", () => {
+      const choices = ["a", "b", "c"];
+      // 1) the function must not throw
+      // 2) The output must be one of the choices
+      const choice = randSeedUniqueItem(choices, 5);
+      expect(choices).toContain(choice);
+    });
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?
Evil Team admins will now actually be random

## Why am I making these changes?
Fixes #6689

## What are the changes from a developer perspective?
I had a really stupid oversight, where I was using `executeWithSeedOffset` to fix the rng used to take the same element multiple times. Except I was incrementing the offset, so of course the seed wouldn't be chosen.
I rewrote `randSeedUniqueItem` to instead shuffle the array using the run's seed with an offset of 0, and then index into it based on seedOffset.
I also added tests to make sure that this method actually works.

## Screenshots/Videos
I don't have time to go through the waves atm. But the automated test works, so this is good.

## How to test the changes?
See #6689

For automated test:
`pnpm test test/utils/random.test.ts -t randSeedUniqueItem`

## Checklist
- [x] ~~**I'm using `beta` as my base branch**~~ hotfix-1.11.4
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  ~~- [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~~