### PR TITLE
[Bug] Mystery Encounters that teach moves now check if move is already known

### DIFF
--- a/src/data/mystery-encounters/encounters/dancing-lessons-encounter.ts
+++ b/src/data/mystery-encounters/encounters/dancing-lessons-encounter.ts
@@ -258,7 +258,15 @@ export const DancingLessonsEncounter: MysteryEncounter = MysteryEncounterBuilder
           danceAnim.play();
         };
 
-        return selectPokemonForOption(onPokemonSelected);
+        // Pokemon that already know Revelation Dance cannot be selected
+        const selectableFilter = (pokemon: Pokemon) => {
+          if (pokemon.moveset.some(m => m.moveId === MoveId.REVELATION_DANCE)) {
+            return getEncounterText(`${namespace}:option.2.alreadyKnowsMove`) ?? null;
+          }
+          return null;
+        };
+
+        return selectPokemonForOption(onPokemonSelected, undefined, selectableFilter);
       })
       .withOptionPhase(async () => {
         // Learn its Dance

--- a/test/mystery-encounter/encounters/dancing-lessons-encounter.test.ts
+++ b/test/mystery-encounter/encounters/dancing-lessons-encounter.test.ts
@@ -6,6 +6,7 @@ import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesId } from "#enums/species-id";
 import { UiMode } from "#enums/ui-mode";
+import { PokemonMove } from "#moves/pokemon-move";
 import { DancingLessonsEncounter } from "#mystery-encounters/dancing-lessons-encounter";
 import * as EncounterPhaseUtils from "#mystery-encounters/encounter-phase-utils";
 import * as MysteryEncounters from "#mystery-encounters/mystery-encounters";
@@ -168,6 +169,24 @@ describe("Dancing Lessons - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 2, { pokemonNo: 1 });
 
       expect(leaveEncounterWithoutBattleSpy).toBeCalled();
+    });
+
+    it("should not allow selecting a Pokémon that already knows Revelation Dance", async () => {
+      const selectPokemonSpy = vi.spyOn(EncounterPhaseUtils, "selectPokemonForOption");
+
+      await game.runToMysteryEncounter(MysteryEncounterType.DANCING_LESSONS, defaultParty);
+      scene.getPlayerParty()[0].moveset = [];
+      await runMysteryEncounterToEnd(game, 2, { pokemonNo: 1 });
+
+      const filter = selectPokemonSpy.mock.calls[0][2];
+      expect(filter).toBeDefined();
+
+      const pokemon = scene.getPlayerParty()[0];
+      pokemon.moveset = [new PokemonMove(MoveId.REVELATION_DANCE)];
+      expect(filter!(pokemon)).toBeTypeOf("string");
+
+      pokemon.moveset = [];
+      expect(filter!(pokemon)).toBeNull();
     });
   });
 


### PR DESCRIPTION
## What are the changes the user will see?
When selecting a Pokémon to learn a move in the "Dancing Lessons" or "Bug-Type Superfan" Mystery Encounters, Pokémon that already know the move will now be marked as unselectable with an error message, preventing wasted selections.

## Why am I making these changes?
Fixes #5286
Previously, players could select a Pokémon that already knew the move being taught. The LearnMovePhase would silently skip teaching the move, leaving players confused about why nothing happened. This change provides immediate feedback during Pokémon selection.

## What are the changes from a developer perspective?
Added selectableFilter functions to both Mystery Encounters that teach moves. For Dancing Lessons, the filter checks if the Pokémon already knows Revelation Dance before allowing selection. For Bug-Type Superfan, the selected move ID is stored in encounter.misc.selectedMoveId when the player picks a move, and the filter then checks if the Pokémon already knows that move. Both filters return a localized error message if the Pokémon is ineligible, or null if selectable. Unit tests were added for both encounters to verify the filters correctly reject Pokémon that already know the move.

## Screenshots/Videos
See issue #5286 for the original bug behavior.
Fix demonstration:
Dancing Lessons - Pokémon that already knows Revelation Dance is now unselectable:
https://github.com/user-attachments/assets/a19a2b43-c952-44ba-b29a-d83da26dbf5c
Bug-Type Superfan - Pokémon that already knows the selected move is now unselectable:
https://github.com/user-attachments/assets/e0c1d041-9a47-4026-a51d-04a9652df5d0

## How to test the changes?
Dancing Lessons:
`const overrides = {  STARTING_WAVE_OVERRIDE: 11,  MOVESET_OVERRIDE: MoveId.REVELATION_DANCE,  MYSTERY_ENCOUNTER_RATE_OVERRIDE: 255,  MYSTERY_ENCOUNTER_OVERRIDE: MysteryEncounterType.DANCING_LESSONS,} satisfies Partial<InstanceType<OverridesType>>;`
Select Option 2 "Learn Its Dance" - your Pokémon should be unselectable since it already knows Revelation Dance.

Bug-Type Superfan:
`const overrides = {  STARTING_WAVE_OVERRIDE: 11,  MOVESET_OVERRIDE: [MoveId.SILK_TRAP, MoveId.LEECH_LIFE, MoveId.BUG_BUZZ, MoveId.MEGAHORN],  MYSTERY_ENCOUNTER_RATE_OVERRIDE: 255,  MYSTERY_ENCOUNTER_OVERRIDE: MysteryEncounterType.BUG_TYPE_SUPERFAN,  STARTING_BIOME_OVERRIDE: BiomeId.CAVE,  STARTING_LEVEL_OVERRIDE: 100,} satisfies Partial<InstanceType<OverridesType>>;`
Win the battle, then select a move from the tutor that your Pokémon already knows (e.g. Silk Trap) - your Pokémon should be unselectable.

Run automated tests with: pnpm test:silent dancing-lessons bug-type-superfan

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [X] Are all unit tests still passing? (`pnpm test:silent`)
  - [X] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [X] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [X] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [X] If so, please leave a link to it here: https://github.com/pagefaultgames/pokerogue-locales/pull/265
- [ ] Has the translation team been contacted for proofreading/translation?

Does this require any changes to the assets folder? If so:
  - [ ] Has a PR been created on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repo?
    - [ ] If so, please leave a link to it here: 