### PR TITLE
[Docs] Dynamic copyright year in footer

### DIFF
--- a/typedoc.config.js
+++ b/typedoc.config.js
@@ -57,7 +57,7 @@ const config = {
   coverageSvgWidth: 120, // Increased from 104 baseline due to adding 2 extra letters
   favicon: "./favicon.ico",
   theme: "typedoc-github-theme",
-  customFooterHtml: "<p>Copyright <strong>Pagefault Games</strong> 2025</p>",
+  customFooterHtml: `<p>Copyright <strong>Pagefault Games</strong> ${new Date().getFullYear() === 2025 ? "2025" : "2025 - " + new Date().getFullYear()}</p>`,
   customFooterHtmlDisableWrapper: true,
   navigationLinks: {
     GitHub: "https://github.com/pagefaultgames/pokerogue",


### PR DESCRIPTION
## What are the changes the user will see?

The copyright year in the fotter will be updated automatically

## Why am I making these changes?

New year soon

## What are the changes from a developer perspective?

Updated typedoc config to check the current year and update accordingly

## Screenshots/Videos

<details><summary>2026</summary>
<p>

<img width="347" height="58" alt="image" src="https://github.com/user-attachments/assets/8fd40bce-caf2-41d0-8690-af1a4f48c787" />

</p>
</details> 

## How to test the changes?

Change your local time to another year

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?