### PR TITLE
[Bug] [Move] Charging moves no longer fail on last PP

### DIFF
--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -906,7 +906,7 @@ export class MovePhase extends PokemonPhase {
       this.pokemon.getBattlerIndex(),
       this.targets[0],
       this.move,
-      this.useMode,
+      this.useMode === MoveUseMode.NORMAL ? MoveUseMode.IGNORE_PP : this.useMode,
     );
   }
 


### PR DESCRIPTION
## What are the changes the user will see?

When using a charging move on the last PP it will no longer fail.

## Why am I making these changes?

#6831

## What are the changes from a developer perspective?

Charging moves no use `MoveUseMode.IGNORE_PP`

## Screenshots/Videos

<details><summary>Dive example</summary>

https://github.com/user-attachments/assets/82584552-a68b-432b-a663-08fe61b34e0f

</details> 

## How to test the changes?

Use a charging move (e.g. Dive) with 1PP left

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?