### PR TITLE
[UI] [Bug] Correctly update level after Weird Dream ME

### DIFF
--- a/src/ui/battle-info/player-battle-info.ts
+++ b/src/ui/battle-info/player-battle-info.ts
@@ -207,9 +207,7 @@ export class PlayerBattleInfo extends BattleInfo {
     this.lastLevelCapped = isLevelCapped;
 
     if (this.lastExp !== pokemon.exp || this.lastLevel !== pokemon.level) {
-      if (this.lastLevel > pokemon.level) {
-        this.lastLevel = pokemon.level;
-      }
+      this.lastLevel = Math.min(this.lastLevel, pokemon.level);
       const durationMultiplier = Math.max(
         Phaser.Tweens.Builders.GetEaseFunction("Cubic.easeIn")(1 - Math.min(pokemon.level - this.lastLevel, 10) / 10),
         0.1,


### PR DESCRIPTION
## What are the changes the user will see?

After selecting the `leave` option for the Weird Dream ME, the level will be correctly updated on level up.

## Why am I making these changes?

Fixes #5287

## What are the changes from a developer perspective?

Added a check to see if the current level is lower then the saved last level and if so update the last level

## Screenshots/Videos

<details><summary>Video</summary>

https://github.com/user-attachments/assets/4e2b4043-6cde-43ac-bd48-b7339cc2eb00

</details> 

## How to test the changes?

Level up a Pokémon after selecting the `leave` option.

```ts
const overrides = {
  STARTING_WAVE_OVERRIDE: 11,
  STARTING_LEVEL_OVERRIDE: 40,
  MYSTERY_ENCOUNTER_RATE_OVERRIDE: 100,
  MYSTERY_ENCOUNTER_OVERRIDE: MysteryEncounterType.WEIRD_DREAM,
  ITEM_REWARD_OVERRIDE: [{ name: "RARE_CANDY" }],
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?