### PR TITLE
[Dev] Simplify `update-submodules` commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "postinstall": "lefthook install; git config --local fetch.recurseSubmodules true; git config --local blame.ignoreRevsFile .git-blame-ignore-revs",
     "update-version:patch": "pnpm version patch --force --no-git-tag-version",
     "update-version:minor": "pnpm version minor --force --no-git-tag-version",
-    "update-locales": "git submodule update --progress --init --recursive --depth 1 locales",
-    "update-locales:remote": "git submodule update --progress --init --recursive --force --remote --depth 1 locales",
-    "update-assets": "git submodule update --progress --init --recursive --depth 1 assets",
-    "update-assets:remote": "git submodule update --progress --init --recursive --force --remote --depth 1 assets",
-    "update-submodules": "pnpm update-locales && pnpm update-assets",
-    "update-submodules:remote": "pnpm update-locales:remote && pnpm update-assets:remote"
+    "update-locales": "pnpm update-submodules locales",
+    "update-locales:remote": "pnpm update-submodules:remote locales",
+    "update-assets": "pnpm update-submodules assets",
+    "update-assets:remote": "pnpm update-submodules:remote assets",
+    "update-submodules": "git submodule update --progress --init --recursive --force --depth 1",
+    "update-submodules:remote": "pnpm update-submodules --remote"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.8",


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Minor simplification.

## What are the changes from a developer perspective?
The `update-submodules` command is now the only command with `git submodule update ...`, and the other commands pass extra params as appropriate.
This means the command only needs to be updated in one spot in the future.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?