### PR TITLE
[UI/UX] move `unsplice` option from switch to shop

### DIFF
--- a/src/ui/handlers/party-ui-handler.ts
+++ b/src/ui/handlers/party-ui-handler.ts
@@ -1515,9 +1515,6 @@ export class PartyUiHandler extends MessageUiHandler {
           );
         }
         this.addCommonOptions(pokemon);
-        if (this.partyUiMode === PartyUiMode.SWITCH && pokemon.isFusion()) {
-          this.options.push(PartyOption.UNSPLICE);
-        }
         break;
       case PartyUiMode.REVIVAL_BLESSING:
         this.options.push(PartyOption.REVIVE);
@@ -1551,6 +1548,9 @@ export class PartyUiHandler extends MessageUiHandler {
       case PartyUiMode.CHECK:
         this.addCommonOptions(pokemon);
         if (globalScene.phaseManager.getCurrentPhase().is("SelectModifierPhase")) {
+          if (pokemon.isFusion()) {
+            this.options.push(PartyOption.UNSPLICE);
+          }
           this.options.push(PartyOption.RELEASE);
           const formChangeItemModifiers = this.getFormChangeItemsModifiers(pokemon);
           for (let i = 0; i < formChangeItemModifiers.length; i++) {


### PR DESCRIPTION
## What are the changes the user will see?

- The user will no longer be able to unsplice during battle
- The user will be able to unsplice during shop

## Why am I making these changes?

[Discord report](https://discord.com/channels/1125469663833370665/1125894949020381285/1452751736690180377) and makes more sense

## What are the changes from a developer perspective?

Moved the unsplice option from `switch` to `check` (during shop phase)

## Screenshots/Videos

<details><summary>Video</summary>

https://github.com/user-attachments/assets/83c30433-46f0-47c8-bba0-644e637cd531

</details> 

## How to test the changes?

Try unsplicing during battle and shop.
```ts
const overrides = {
  ITEM_REWARD_OVERRIDE: [{name: "DNA_SPLICERS"}]
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- [x] **I'm using `hotfix-1.11.5` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?