### PR TITLE
[Ability] Multiple abilities can now be replaced

### DIFF
--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -8074,7 +8074,6 @@ export function initAbilities() {
       .attr(CommanderAbAttr)
       .attr(DoubleBattleChanceAbAttr)
       .uncopiable()
-      .unreplaceable()
       .edgeCase() // Encore, Frenzy, and other non-`TURN_END` tags don't lapse correctly on the commanding Pokemon.
       .build(),
     new AbBuilder(AbilityId.ELECTROMORPHOSIS, 9)
@@ -8217,19 +8216,16 @@ export function initAbilities() {
     new AbBuilder(AbilityId.TERA_SHELL, 9)
       .attr(FullHpResistTypeAbAttr)
       .uncopiable()
-      .unreplaceable()
       .ignorable()
       .build(),
     new AbBuilder(AbilityId.TERAFORM_ZERO, 9)
       .attr(ClearWeatherAbAttr)
       .attr(ClearTerrainAbAttr)
       .uncopiable()
-      .unreplaceable()
       .condition(getOncePerBattleCondition(AbilityId.TERAFORM_ZERO))
       .build(),
     new AbBuilder(AbilityId.POISON_PUPPETEER, 9)
       .uncopiable()
-      .unreplaceable() // TODO is this true?
       .attr(ConfusionOnStatusEffectAbAttr, StatusEffect.POISON, StatusEffect.TOXIC).build()
   );
 }


### PR DESCRIPTION
## What are the changes the user will see?
Pokémon that have Commander, Tera Shell, Teraform Zero and Poison Puppeteer can now get those abilities replaced by Entrainment, Worry Seed or Simple Beam.

## Why am I making these changes?

Matches mainline. Commander was updated in SV 2.0.1 so it could now be replaced and suppressed but only the "suppressed" part is possible in Pokerogue. The other three are abilities added in DLC and I assume those weren't tested before, Poison Puppeteer did have a TODO.

Included video evidence for Entrainment working on both of these in the videos section. (thank you Monkee)

## What are the changes from a developer perspective?

Minimal changes in ability.ts

## Screenshots/Videos

https://discord.com/channels/1125469663833370665/1225619031156064317/1454064689674977394
https://discord.com/channels/1125469663833370665/1225619031156064317/1454062577695850507

Thank you Monkee for testing.

## How to test the changes?

`const overrides = {ENEMY_SPECIES_OVERRIDE: SpeciesId.TATSUGIRI, ENEMY_ABILITY_OVERRIDE: AbilityId.COMMANDER, ABILITY_OVERRIDE: AbilityId.SPEED_BOOST, MOVESET_OVERRIDE: [MoveId.SIMPLE_BEAM, MoveId.ENTRAINMENT]} satisfies Partial<InstanceType<OverridesType>>;`

Speed Boost as a way to see the ability be correctly replaced while using Entrainment

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?

Does this require any changes to the assets folder? If so:
  - [ ] Has a PR been created on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repo?
    - [ ] If so, please leave a link to it here: 