### PR TITLE
[i18n] Don't use `getPokemonNameWithAffix` for caught Pokemon

### DIFF
--- a/src/phases/attempt-capture-phase.ts
+++ b/src/phases/attempt-capture-phase.ts
@@ -1,7 +1,6 @@
 import { PLAYER_PARTY_MAX_SIZE } from "#app/constants";
 import { timedEventManager } from "#app/global-event-manager";
 import { globalScene } from "#app/global-scene";
-import { getPokemonNameWithAffix } from "#app/messages";
 import { isBeta, isDev } from "#constants/app-constants";
 import { SubstituteTag } from "#data/battler-tags";
 import { Gender } from "#data/gender";
@@ -278,7 +277,7 @@ export class AttemptCapturePhase extends PokemonPhase {
 
     globalScene.ui.showText(
       i18next.t(addStatus.value ? "battle:pokemonCaught" : "battle:pokemonCaughtButChallenge", {
-        pokemonName: getPokemonNameWithAffix(pokemon),
+        pokemonName: pokemon.name,
       }),
       null,
       () => {


### PR DESCRIPTION
## What are the changes the user will see?
After catching a Pokémon, the message will be "[Pokémon] was caught!" instead of "Wild [Pokémon] was caught!".

## Why am I making these changes?
To match mainline.

## What are the changes from a developer perspective?
Replaced `getPokemonNameWithAffix(pokemon)` with `pokemon.name` being passed to the translation function.

## Screenshots/Videos
<details><summary>Details</summary>
<p>

<img width="1230" height="691" alt="image" src="https://github.com/user-attachments/assets/3e360a53-da25-4c68-82b2-7f88dd928e71" />

</p>
</details> 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Have I provided screenshots/videos of the changes (if applicable)?