### PR TITLE
[UI/UX] Fix legacy event timer color

### DIFF
--- a/src/timed-event-manager.ts
+++ b/src/timed-event-manager.ts
@@ -763,7 +763,7 @@ export class TimedEventDisplay extends Phaser.GameObjects.Container {
           this.banner.x,
           this.banner.y + 2,
           this.timeToGo(this.event.endDate),
-          TextStyle.WINDOW,
+          TextStyle.MESSAGE,
         );
         this.eventTimerText.setName("text-event-timer");
         this.eventTimerText.setScale(0.15);


### PR DESCRIPTION
## What are the changes the user will see?

The color of the event timer won't look out of place in kegacy Ui theme

## Why am I making these changes?

Since the title screen background doesn't change based on UITheme it looks weird when changing the color of the text

## What are the changes from a developer perspective?

changed the textstyle from `window` to `message`.
For the default theme this uses the exact same colors while also useing them now for legacy

## Screenshots/Videos

<details><summary>Before</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/46e26240-e72c-49aa-bf56-7a068f5f0bab" />

</details> 

<details><summary>After</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/cb9eef2a-9570-4ebe-a79d-257312f7865a" />

</details> 

## How to test the changes?

Look at the timer in legacy ui

## Checklist
- [x] **I'm using `hotfix-1.11.6` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?