### PR TITLE
[BUG] Fix Rapin Spin removing the wrong side

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -6687,8 +6687,16 @@ export class RemoveArenaTagsAttr extends MoveEffectAttr {
     if (!super.apply(user, target, move, args)) {
       return false;
     }
+    const rapidSpinUserSide = user.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY;
 
-    const side = (move.id === MoveId.RAPID_SPIN) ? ArenaTagSide.PLAYER : this.removeAllTags ? ArenaTagSide.BOTH : target.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY;
+    const side =
+      move.id === MoveId.RAPID_SPIN
+        ? rapidSpinUserSide
+        : this.removeAllTags
+          ? ArenaTagSide.BOTH
+          : target.isPlayer()
+            ? ArenaTagSide.PLAYER
+            : ArenaTagSide.ENEMY;
 
     globalScene.arena.removeTagsOnSide(this.tagTypes, side);
 


### PR DESCRIPTION
## What are the changes the user will see?
Rapid Spin will now correctly remove the users side instead of the targets side

## Why am I making these changes?
Bug was reported a bit ago on discord, decided to take a crack at it.

You can find video of the bug [here](https://cdn.discordapp.com/attachments/1437638359647518741/1437638442564583434/PokeRogue_1.mp4?ex=695340a2&is=6951ef22&hm=812d7b7a5fcbeebb2dd93f8f02c6e30d137d57189a371d7a728f847b33dfdade&)

 
## What are the changes from a developer perspective?


Modifies `RemoveArenaTagsAttr` to do a check if the move being used matches `MoveId.RAPID_SPIN`, and if so forcibly set `side` to `ArenaTagSide.PLAYER`

## Screenshots/Videos
N/A

## How to test the changes?
 - Trigger hazards on your side with toxic debris toxipex, and then use rapid spin and swap to verify they were removed from your side.
 - Setup hazard on the enemy and use rapid spin, and then force a swap to verify enemy hazards were not removed.
 - 
## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?

Does this require any changes to the assets folder? If so:
  - [ ] Has a PR been created on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repo?
    - [ ] If so, please leave a link to it here: 