### PR TITLE
[GitHub] Cancel stale workflows when a commit is pushed

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -9,6 +9,10 @@ on:
     types: completed
     workflows: ["Post Release Deleted"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     if: github.repository == 'pagefaultgames/pokerogue' && github.ref_name == (vars.BETA_DEPLOY_BRANCH || 'beta')

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     if: github.repository == 'pagefaultgames/pokerogue'

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -16,6 +16,10 @@ on:
   merge_group:
     types: [checks_requested]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pages:
     name: Github Pages

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,6 +17,10 @@ on:
     types: [checks_requested]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-linters:
     name: Run all linters

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,10 @@ on:
     types: [checks_requested]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-path-change-filter:
     timeout-minutes: 5


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
There's no need to finish running workflows for a commit if a later one is pushed.

## What are the changes from a developer perspective?
Less time wasted waiting on runners (GitHub has a limit of 20 active workflows at a time), less CPU/etc resources wasted on workflows that don't matter.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?