### PR TITLE
[Bug] [Balance] Trainers will now correctly not spawn 2 waves before gym leader battles 

### DIFF
--- a/src/game-mode.ts
+++ b/src/game-mode.ts
@@ -193,7 +193,7 @@ export class GameMode implements GameModeConfig {
       if (trainerChance) {
         const waveBase = Math.floor(waveIndex / 10) * 10;
         // Stop generic trainers from spawning in within 2 waves of a fixed trainer battle
-        for (let w = Math.max(waveIndex - 2, waveBase + 2); w <= Math.min(waveIndex + 2, waveBase + 9); w++) {
+        for (let w = Math.max(waveIndex - 2, waveBase + 2); w <= Math.min(waveIndex + 2, waveBase + 10); w++) {
           if (w === waveIndex) {
             continue;
           }


### PR DESCRIPTION
## What are the changes the user will see?

Trainers won't spawn 2 waves prior to gym leaders, as was intended

## Why am I making these changes?

Might be our easiest bug fix for one of the longest standing bugs. 

## What are the changes from a developer perspective?

In `src/game-modes.ts`'s, modified `isWaveTrainer` to properly exit the trainerChance conditional when within 2 waves of a scripted trainer by changing the waveBase to be offset by `10` instead of `9`.

```diff
-        for (let w = Math.max(waveIndex - 2, waveBase + 2); w <= Math.min(waveIndex + 2, waveBase + 9); w++) {
+        for (let w = Math.max(waveIndex - 2, waveBase + 2); w <= Math.min(waveIndex + 2, waveBase + 10); w++) {
```

## Screenshots/Videos

Vid too big, here's a streamable link https://streamable.com/6bj1a9

## How to test the changes?

[W28W29TraienrW30Gym.txt](https://github.com/user-attachments/files/24439734/W28W29TraienrW30Gym.txt)

This savefile should start at wave 28, has a trainer in wave 29 if the changes aren't applied, doesn't have it with the changes applied.

## Checklist
- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:
- [ ] Has a locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo?
  - [ ] If so, please leave a link to it here: 
- [ ] Has the translation team been contacted for proofreading/translation?

Does this require any changes to the assets folder? If so:
  - [ ] Has a PR been created on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repo?
    - [ ] If so, please leave a link to it here: 