### PR TITLE
i18n: Swedish addition

### DIFF
--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -200,6 +200,7 @@ await i18next
         "hi",
         "tl",
         "nb-NO",
+        "sv",
       ],
       backend: {
         loadPath(lng: string, [ns]: string[]) {

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -80,13 +80,13 @@ const fonts: LoadingFontFaceProperty[] = [
     face: new FontFace("emerald", "url(./fonts/pokemon-bw.ttf)", {
       unicodeRange: rangesByLanguage.japanese,
     }),
-    only: ["en", "es", "fr", "it", "de", "pt", "ko", "ja", "ca", "da", "tr", "ro", "ru", "id", "hi", "tl"],
+    only: ["en", "es", "fr", "it", "de", "pt", "ko", "ja", "ca", "da", "tr", "ro", "ru", "id", "hi", "tl", "sv"],
   },
   {
     face: new FontFace("pkmnems", "url(./fonts/pokemon-bw.ttf)", {
       unicodeRange: rangesByLanguage.japanese,
     }),
-    only: ["en", "es", "fr", "it", "de", "pt", "ko", "ja", "ca", "da", "tr", "ro", "ru", "id", "hi", "tl"],
+    only: ["en", "es", "fr", "it", "de", "pt", "ko", "ja", "ca", "da", "tr", "ro", "ru", "id", "hi", "tl", "sv"],
   },
   // devanagari
   {

--- a/src/system/settings/settings-language.ts
+++ b/src/system/settings/settings-language.ts
@@ -102,6 +102,10 @@ export const languageOptions = [
     handler: () => changeLocaleHandler("nb-NO"),
   },
   {
+    label: "Svenska",
+    handler: () => changeLocaleHandler("sv"),
+  },
+  {
     label: "Română (Needs Help)",
     handler: () => changeLocaleHandler("ro"),
   },

--- a/src/ui/handlers/game-stats-ui-handler.ts
+++ b/src/ui/handlers/game-stats-ui-handler.ts
@@ -250,7 +250,7 @@ export class GameStatsUiHandler extends UiHandler {
     const resolvedLang = i18next.resolvedLanguage ?? "en";
     // NOTE TO TRANSLATION TEAM: Add more languages that want to display
     // in a single-column inside of the `[]` (e.g. `["ru", "fr"]`)
-    return ["fr", "es-ES", "es-419", "it", "ja", "pt-BR", "ru", "id", "tr"].includes(resolvedLang);
+    return ["fr", "es-ES", "es-419", "it", "ja", "pt-BR", "ru", "id", "tr", "sv"].includes(resolvedLang);
   }
   /** The number of columns used by this menu in the resolved language */
   private get columnCount(): 1 | 2 {

--- a/src/ui/handlers/pokedex-page-ui-handler.ts
+++ b/src/ui/handlers/pokedex-page-ui-handler.ts
@@ -159,6 +159,10 @@ const languageSettings: { [key: string]: LanguageSetting } = {
     starterInfoTextSize: "56px",
     instructionTextSize: "38px",
   },
+  sv: {
+    starterInfoTextSize: "56px",
+    instructionTextSize: "38px",
+  },
 };
 
 const valueReductionMax = 2;

--- a/src/ui/handlers/starter-select-ui-handler.ts
+++ b/src/ui/handlers/starter-select-ui-handler.ts
@@ -186,6 +186,10 @@ const languageSettings: { [key: string]: LanguageSetting } = {
     starterInfoTextSize: "56px",
     instructionTextSize: "38px",
   },
+  sv: {
+    starterInfoTextSize: "56px",
+    instructionTextSize: "38px",
+  },
 };
 
 const valueReductionMax = 2;

--- a/src/ui/settings/settings-display-ui-handler.ts
+++ b/src/ui/settings/settings-display-ui-handler.ts
@@ -129,6 +129,12 @@ export class SettingsDisplayUiHandler extends AbstractSettingsUiHandler {
             label: "Norsk bokmål (Needs Help)",
           };
           break;
+        case "sv":
+          this.settings[languageIndex].options[0] = {
+            value: "Svenska",
+            label: "Svenska",
+          };
+          break;
         case "ro":
           this.settings[languageIndex].options[0] = {
             value: "Română",

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -417,6 +417,7 @@ export function hasAllLocalizedSprites(lang?: string): boolean {
     case "hi":
     case "tl":
     case "nb-NO":
+    case "sv":
       return true;
     default:
       return false;


### PR DESCRIPTION
## Why am I making these changes?
To initiate Swedish, initiated by Chapybara, Swedish native better known for the Japanese transaltion of the game

## What are the changes from a developer perspective?
One new language to consider

## Screenshots/Videos
--

## How to test the changes?
Play the game in the said language

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Does this require any changes to the assets folder? If so:
  - [x] Has a PR been created on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repo?
    - [x] If so, please leave a link to it here: https://github.com/pagefaultgames/pokerogue-assets/pull/48