### PR TITLE
feat(ui): expose login error messages

### DIFF
--- a/src/ui/handlers/change-password-form-ui-handler.ts
+++ b/src/ui/handlers/change-password-form-ui-handler.ts
@@ -6,14 +6,14 @@ import type { InputFieldConfig } from "#ui/form-modal-ui-handler";
 import { FormModalUiHandler } from "#ui/form-modal-ui-handler";
 import i18next from "i18next";
 
-export class ChangePasswordFormUiHandler extends FormModalUiHandler {
-  private readonly ERR_PASSWORD: string = "invalid password";
-  private readonly ERR_ACCOUNT_EXIST: string = "account doesn't exist";
-  private readonly ERR_PASSWORD_MISMATCH: string = "password doesn't match";
-  private readonly ERR_GENERATE_SALT: string = "failed to generate salt";
-  private readonly ERR_REMOVE_SESSIONS: string = "failed to remove sessions";
-  private readonly ERR_ADD_RECORD: string = "failed to add account record";
+const ERR_PASSWORD: string = "invalid password";
+const ERR_ACCOUNT_EXIST: string = "account doesn't exist";
+const ERR_PASSWORD_MISMATCH: string = "password doesn't match";
+const ERR_GENERATE_SALT: string = "failed to generate salt";
+const ERR_REMOVE_SESSIONS: string = "failed to remove sessions";
+const ERR_ADD_RECORD: string = "failed to add account record";
 
+export class ChangePasswordFormUiHandler extends FormModalUiHandler {
   setup(): void {
     super.setup();
   }
@@ -40,16 +40,18 @@ export class ChangePasswordFormUiHandler extends FormModalUiHandler {
       error = error.slice(0, colonIndex);
     }
     switch (error) {
-      case this.ERR_PASSWORD:
+      case ERR_PASSWORD:
         return i18next.t("menu:invalidRegisterPassword");
-      case this.ERR_ACCOUNT_EXIST:
+      case ERR_ACCOUNT_EXIST:
         return i18next.t("menu:accountNonExistent");
-      case this.ERR_PASSWORD_MISMATCH:
+      case ERR_PASSWORD_MISMATCH:
         return i18next.t("menu:passwordNotMatchingConfirmPassword");
-      case this.ERR_GENERATE_SALT:
-      case this.ERR_REMOVE_SESSIONS:
-      case this.ERR_ADD_RECORD:
-        return i18next.t("menu:serverError");
+      case ERR_GENERATE_SALT:
+        return i18next.t("menu:serverErrorGenerateSalt");
+      case ERR_REMOVE_SESSIONS:
+        return i18next.t("menu:serverErrorRemoveSessions");
+      case ERR_ADD_RECORD:
+        return i18next.t("menu:serverErrorUpdateAccount");
     }
 
     return super.getReadableErrorMessage(error);
@@ -87,7 +89,7 @@ export class ChangePasswordFormUiHandler extends FormModalUiHandler {
             return onFail(this.getReadableErrorMessage("invalid password"));
           }
           if (passwordInput.text !== confirmPasswordInput.text) {
-            return onFail(this.ERR_PASSWORD_MISMATCH);
+            return onFail(ERR_PASSWORD_MISMATCH);
           }
 
           pokerogueApi.account.changePassword({ password: passwordInput.text }).then(error => {

--- a/src/ui/handlers/change-password-form-ui-handler.ts
+++ b/src/ui/handlers/change-password-form-ui-handler.ts
@@ -10,6 +10,9 @@ export class ChangePasswordFormUiHandler extends FormModalUiHandler {
   private readonly ERR_PASSWORD: string = "invalid password";
   private readonly ERR_ACCOUNT_EXIST: string = "account doesn't exist";
   private readonly ERR_PASSWORD_MISMATCH: string = "password doesn't match";
+  private readonly ERR_GENERATE_SALT: string = "failed to generate salt";
+  private readonly ERR_REMOVE_SESSIONS: string = "failed to remove sessions";
+  private readonly ERR_ADD_RECORD: string = "failed to add account record";
 
   setup(): void {
     super.setup();
@@ -43,6 +46,10 @@ export class ChangePasswordFormUiHandler extends FormModalUiHandler {
         return i18next.t("menu:accountNonExistent");
       case this.ERR_PASSWORD_MISMATCH:
         return i18next.t("menu:passwordNotMatchingConfirmPassword");
+      case this.ERR_GENERATE_SALT:
+      case this.ERR_REMOVE_SESSIONS:
+      case this.ERR_ADD_RECORD:
+        return i18next.t("menu:serverError");
     }
 
     return super.getReadableErrorMessage(error);

--- a/src/ui/handlers/change-password-form-ui-handler.ts
+++ b/src/ui/handlers/change-password-form-ui-handler.ts
@@ -8,12 +8,12 @@ import i18next from "i18next";
 
 // TODO: Consider replacing server error strings with numeric error codes for better maintainability
 // TODO: Centralize server error constants
-const ERR_PASSWORD = "invalid password";
-const ERR_ACCOUNT_EXIST = "account doesn't exist";
+const ERR_INVALID_PASSWORD = "invalid password";
+const ERR_NO_ACCOUNT = "account doesn't exist";
 const ERR_PASSWORD_MISMATCH = "password doesn't match";
-const ERR_GENERATE_SALT = "failed to generate salt";
+const ERR_FAILED_TO_GENERATE_PASSWORD = "failed to generate salt";
 const ERR_REMOVE_SESSIONS = "failed to remove sessions";
-const ERR_ADD_RECORD = "failed to add account record";
+const ERR_ACCOUNT_UPDATE_FAILURE = "failed to add account record";
 
 export class ChangePasswordFormUiHandler extends FormModalUiHandler {
   setup(): void {
@@ -42,17 +42,17 @@ export class ChangePasswordFormUiHandler extends FormModalUiHandler {
       error = error.slice(0, colonIndex);
     }
     switch (error) {
-      case ERR_PASSWORD:
+      case ERR_INVALID_PASSWORD:
         return i18next.t("menu:invalidRegisterPassword");
-      case ERR_ACCOUNT_EXIST:
+      case ERR_NO_ACCOUNT:
         return i18next.t("menu:accountNonExistent");
       case ERR_PASSWORD_MISMATCH:
         return i18next.t("menu:passwordNotMatchingConfirmPassword");
-      case ERR_GENERATE_SALT:
+      case ERR_FAILED_TO_GENERATE_PASSWORD:
         return `${i18next.t("menu:serverErrorGenerateSalt")}\n${i18next.t("menu:pleaseTryAgainLater")}`;
       case ERR_REMOVE_SESSIONS:
         return `${i18next.t("menu:serverErrorRemoveSessions")}\n${i18next.t("menu:pleaseTryAgainLater")}`;
-      case ERR_ADD_RECORD:
+      case ERR_ACCOUNT_UPDATE_FAILURE:
         return `${i18next.t("menu:serverErrorUpdateAccount")}\n${i18next.t("menu:pleaseTryAgainLater")}`;
     }
 

--- a/src/ui/handlers/change-password-form-ui-handler.ts
+++ b/src/ui/handlers/change-password-form-ui-handler.ts
@@ -6,12 +6,14 @@ import type { InputFieldConfig } from "#ui/form-modal-ui-handler";
 import { FormModalUiHandler } from "#ui/form-modal-ui-handler";
 import i18next from "i18next";
 
-const ERR_PASSWORD: string = "invalid password";
-const ERR_ACCOUNT_EXIST: string = "account doesn't exist";
-const ERR_PASSWORD_MISMATCH: string = "password doesn't match";
-const ERR_GENERATE_SALT: string = "failed to generate salt";
-const ERR_REMOVE_SESSIONS: string = "failed to remove sessions";
-const ERR_ADD_RECORD: string = "failed to add account record";
+// TODO: Consider replacing server error strings with numeric error codes for better maintainability
+// TODO: Centralize server error constants
+const ERR_PASSWORD = "invalid password";
+const ERR_ACCOUNT_EXIST = "account doesn't exist";
+const ERR_PASSWORD_MISMATCH = "password doesn't match";
+const ERR_GENERATE_SALT = "failed to generate salt";
+const ERR_REMOVE_SESSIONS = "failed to remove sessions";
+const ERR_ADD_RECORD = "failed to add account record";
 
 export class ChangePasswordFormUiHandler extends FormModalUiHandler {
   setup(): void {

--- a/src/ui/handlers/change-password-form-ui-handler.ts
+++ b/src/ui/handlers/change-password-form-ui-handler.ts
@@ -47,11 +47,11 @@ export class ChangePasswordFormUiHandler extends FormModalUiHandler {
       case ERR_PASSWORD_MISMATCH:
         return i18next.t("menu:passwordNotMatchingConfirmPassword");
       case ERR_GENERATE_SALT:
-        return i18next.t("menu:serverErrorGenerateSalt");
+        return `${i18next.t("menu:serverErrorGenerateSalt")}\n${i18next.t("menu:pleaseTryAgainLater")}`;
       case ERR_REMOVE_SESSIONS:
-        return i18next.t("menu:serverErrorRemoveSessions");
+        return `${i18next.t("menu:serverErrorRemoveSessions")}\n${i18next.t("menu:pleaseTryAgainLater")}`;
       case ERR_ADD_RECORD:
-        return i18next.t("menu:serverErrorUpdateAccount");
+        return `${i18next.t("menu:serverErrorUpdateAccount")}\n${i18next.t("menu:pleaseTryAgainLater")}`;
     }
 
     return super.getReadableErrorMessage(error);

--- a/src/ui/handlers/login-form-ui-handler.ts
+++ b/src/ui/handlers/login-form-ui-handler.ts
@@ -8,12 +8,12 @@ import i18next from "i18next";
 
 // TODO: Consider replacing server error strings with numeric error codes for better maintainability
 // TODO: Centralize server error constants
-const ERR_USERNAME = "invalid username";
-const ERR_PASSWORD = "invalid password";
-const ERR_ACCOUNT_EXIST = "account doesn't exist";
-const ERR_PASSWORD_MATCH = "password doesn't match";
-const ERR_GENERATE_TOKEN = "failed to generate token";
-const ERR_ADD_SESSION = "failed to add account session";
+const ERR_INVALID_USERNAME = "invalid username";
+const ERR_INVALID_PASSWORD = "invalid password";
+const ERR_NO_ACCOUNT = "account doesn't exist";
+const ERR_PASSWORD_MISMATCH = "password doesn't match";
+const ERR_FAILED_TO_GENERATE_TOKEN = "failed to generate token";
+const ERR_FAILED_TO_ADD_SESSION = "failed to add account session";
 
 export class LoginFormUiHandler extends OAuthProvidersUiHandler {
   public override getModalTitle(): string {
@@ -46,17 +46,17 @@ export class LoginFormUiHandler extends OAuthProvidersUiHandler {
     }
 
     switch (error) {
-      case ERR_USERNAME:
+      case ERR_INVALID_USERNAME:
         return i18next.t("menu:invalidLoginUsername");
-      case ERR_PASSWORD:
+      case ERR_INVALID_PASSWORD:
         return i18next.t("menu:invalidLoginPassword");
-      case ERR_ACCOUNT_EXIST:
+      case ERR_NO_ACCOUNT:
         return i18next.t("menu:accountNonExistent");
-      case ERR_PASSWORD_MATCH:
+      case ERR_PASSWORD_MISMATCH:
         return i18next.t("menu:unmatchingPassword");
-      case ERR_GENERATE_TOKEN:
+      case ERR_FAILED_TO_GENERATE_TOKEN:
         return `${i18next.t("menu:serverErrorGenerateToken")}\n${i18next.t("menu:pleaseTryAgainLater")}`;
-      case ERR_ADD_SESSION:
+      case ERR_FAILED_TO_ADD_SESSION:
         return `${i18next.t("menu:serverErrorAddSession")}\n${i18next.t("menu:pleaseTryAgainLater")}`;
     }
 

--- a/src/ui/handlers/login-form-ui-handler.ts
+++ b/src/ui/handlers/login-form-ui-handler.ts
@@ -6,12 +6,14 @@ import type { InputFieldConfig } from "#ui/form-modal-ui-handler";
 import { OAuthProvidersUiHandler } from "#ui/oauth-providers-ui-handler";
 import i18next from "i18next";
 
-const ERR_USERNAME: string = "invalid username";
-const ERR_PASSWORD: string = "invalid password";
-const ERR_ACCOUNT_EXIST: string = "account doesn't exist";
-const ERR_PASSWORD_MATCH: string = "password doesn't match";
-const ERR_GENERATE_TOKEN: string = "failed to generate token";
-const ERR_ADD_SESSION: string = "failed to add account session";
+// TODO: Consider replacing server error strings with numeric error codes for better maintainability
+// TODO: Centralize server error constants
+const ERR_USERNAME = "invalid username";
+const ERR_PASSWORD = "invalid password";
+const ERR_ACCOUNT_EXIST = "account doesn't exist";
+const ERR_PASSWORD_MATCH = "password doesn't match";
+const ERR_GENERATE_TOKEN = "failed to generate token";
+const ERR_ADD_SESSION = "failed to add account session";
 
 export class LoginFormUiHandler extends OAuthProvidersUiHandler {
   public override getModalTitle(): string {

--- a/src/ui/handlers/login-form-ui-handler.ts
+++ b/src/ui/handlers/login-form-ui-handler.ts
@@ -53,9 +53,9 @@ export class LoginFormUiHandler extends OAuthProvidersUiHandler {
       case ERR_PASSWORD_MATCH:
         return i18next.t("menu:unmatchingPassword");
       case ERR_GENERATE_TOKEN:
-        return i18next.t("menu:serverErrorGenerateToken");
+        return `${i18next.t("menu:serverErrorGenerateToken")}\n${i18next.t("menu:pleaseTryAgainLater")}`;
       case ERR_ADD_SESSION:
-        return i18next.t("menu:serverErrorAddSession");
+        return `${i18next.t("menu:serverErrorAddSession")}\n${i18next.t("menu:pleaseTryAgainLater")}`;
     }
 
     return super.getReadableErrorMessage(error);

--- a/src/ui/handlers/login-form-ui-handler.ts
+++ b/src/ui/handlers/login-form-ui-handler.ts
@@ -10,6 +10,8 @@ const ERR_USERNAME: string = "invalid username";
 const ERR_PASSWORD: string = "invalid password";
 const ERR_ACCOUNT_EXIST: string = "account doesn't exist";
 const ERR_PASSWORD_MATCH: string = "password doesn't match";
+const ERR_GENERATE_TOKEN: string = "failed to generate token";
+const ERR_ADD_SESSION: string = "failed to add account session";
 
 export class LoginFormUiHandler extends OAuthProvidersUiHandler {
   public override getModalTitle(): string {
@@ -36,6 +38,11 @@ export class LoginFormUiHandler extends OAuthProvidersUiHandler {
       return "";
     }
 
+    const colonIndex = error.indexOf(":");
+    if (colonIndex > 0) {
+      error = error.slice(0, colonIndex);
+    }
+
     switch (error) {
       case ERR_USERNAME:
         return i18next.t("menu:invalidLoginUsername");
@@ -45,6 +52,9 @@ export class LoginFormUiHandler extends OAuthProvidersUiHandler {
         return i18next.t("menu:accountNonExistent");
       case ERR_PASSWORD_MATCH:
         return i18next.t("menu:unmatchingPassword");
+      case ERR_GENERATE_TOKEN:
+      case ERR_ADD_SESSION:
+        return i18next.t("menu:serverError");
     }
 
     return super.getReadableErrorMessage(error);

--- a/src/ui/handlers/login-form-ui-handler.ts
+++ b/src/ui/handlers/login-form-ui-handler.ts
@@ -53,8 +53,9 @@ export class LoginFormUiHandler extends OAuthProvidersUiHandler {
       case ERR_PASSWORD_MATCH:
         return i18next.t("menu:unmatchingPassword");
       case ERR_GENERATE_TOKEN:
+        return i18next.t("menu:serverErrorGenerateToken");
       case ERR_ADD_SESSION:
-        return i18next.t("menu:serverError");
+        return i18next.t("menu:serverErrorAddSession");
     }
 
     return super.getReadableErrorMessage(error);

--- a/src/ui/handlers/registration-form-ui-handler.ts
+++ b/src/ui/handlers/registration-form-ui-handler.ts
@@ -43,6 +43,9 @@ export class RegistrationFormUiHandler extends LoginRegisterInfoContainerUiHandl
         return i18next.t("menu:invalidRegisterPassword");
       case "failed to add account record":
         return i18next.t("menu:usernameAlreadyUsed");
+      case "failed to generate uuid":
+      case "failed to generate salt":
+        return i18next.t("menu:serverError");
     }
 
     return super.getReadableErrorMessage(error);

--- a/src/ui/handlers/registration-form-ui-handler.ts
+++ b/src/ui/handlers/registration-form-ui-handler.ts
@@ -44,8 +44,9 @@ export class RegistrationFormUiHandler extends LoginRegisterInfoContainerUiHandl
       case "failed to add account record":
         return i18next.t("menu:usernameAlreadyUsed");
       case "failed to generate uuid":
+        return i18next.t("menu:serverErrorGenerateUuid");
       case "failed to generate salt":
-        return i18next.t("menu:serverError");
+        return i18next.t("menu:serverErrorGenerateSalt");
     }
 
     return super.getReadableErrorMessage(error);

--- a/src/ui/handlers/registration-form-ui-handler.ts
+++ b/src/ui/handlers/registration-form-ui-handler.ts
@@ -36,6 +36,7 @@ export class RegistrationFormUiHandler extends LoginRegisterInfoContainerUiHandl
     if (colonIndex > 0) {
       error = error.slice(0, colonIndex);
     }
+    // TODO: Consider replacing server error strings with numeric error codes for better maintainability
     switch (error) {
       case "invalid username":
         return i18next.t("menu:invalidRegisterUsername");

--- a/src/ui/handlers/registration-form-ui-handler.ts
+++ b/src/ui/handlers/registration-form-ui-handler.ts
@@ -45,9 +45,9 @@ export class RegistrationFormUiHandler extends LoginRegisterInfoContainerUiHandl
       case "failed to add account record":
         return i18next.t("menu:usernameAlreadyUsed");
       case "failed to generate uuid":
-        return i18next.t("menu:serverErrorGenerateUuid");
+        return `${i18next.t("menu:serverErrorGenerateUuid")}\n${i18next.t("menu:pleaseTryAgainLater")}`;
       case "failed to generate salt":
-        return i18next.t("menu:serverErrorGenerateSalt");
+        return `${i18next.t("menu:serverErrorGenerateSalt")}\n${i18next.t("menu:pleaseTryAgainLater")}`;
     }
 
     return super.getReadableErrorMessage(error);

--- a/src/ui/handlers/registration-form-ui-handler.ts
+++ b/src/ui/handlers/registration-form-ui-handler.ts
@@ -5,10 +5,18 @@ import { UiMode } from "#enums/ui-mode";
 import type { LoginPhase } from "#phases/login-phase";
 import type { ModalConfig } from "#types/ui-types";
 import type { InputFieldConfig } from "#ui/form-modal-ui-handler";
+import { LoginRegisterInfoContainerUiHandler } from "#ui/login-register-info-container-ui-handler";
 import { addTextObject } from "#ui/text";
 import { fixedInt } from "#utils/common";
 import i18next from "i18next";
-import { LoginRegisterInfoContainerUiHandler } from "./login-register-info-container-ui-handler";
+
+// TODO: Consider replacing server error strings with numeric error codes for better maintainability
+// TODO: Centralize server error constants
+const ERR_INVALID_USERNAME = "invalid username";
+const ERR_INVALID_PASSWORD = "invalid password";
+const ERR_USERNAME_IN_USE = "failed to add account record";
+const ERR_FAILED_TO_GENERATE_UUID = "failed to generate uuid";
+const ERR_FAILED_TO_GENERATE_PASSWORD = "failed to generate salt";
 
 export class RegistrationFormUiHandler extends LoginRegisterInfoContainerUiHandler {
   public override getModalTitle(): string {
@@ -36,17 +44,17 @@ export class RegistrationFormUiHandler extends LoginRegisterInfoContainerUiHandl
     if (colonIndex > 0) {
       error = error.slice(0, colonIndex);
     }
-    // TODO: Consider replacing server error strings with numeric error codes for better maintainability
+
     switch (error) {
-      case "invalid username":
+      case ERR_INVALID_USERNAME:
         return i18next.t("menu:invalidRegisterUsername");
-      case "invalid password":
+      case ERR_INVALID_PASSWORD:
         return i18next.t("menu:invalidRegisterPassword");
-      case "failed to add account record":
+      case ERR_USERNAME_IN_USE:
         return i18next.t("menu:usernameAlreadyUsed");
-      case "failed to generate uuid":
+      case ERR_FAILED_TO_GENERATE_UUID:
         return `${i18next.t("menu:serverErrorGenerateUuid")}\n${i18next.t("menu:pleaseTryAgainLater")}`;
-      case "failed to generate salt":
+      case ERR_FAILED_TO_GENERATE_PASSWORD:
         return `${i18next.t("menu:serverErrorGenerateSalt")}\n${i18next.t("menu:pleaseTryAgainLater")}`;
     }
 


### PR DESCRIPTION
## What are the changes the user will see?

When server-side errors occur during login, registration, or password change operations, users will now see user-friendly error messages instead of technical error strings or "Unknown error".

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

- Fixes #6769

## What are the changes from a developer perspective?

### Error Mapping Table

| Backend Error                   | Frontend Mapping                 | Affected Screen              | Backend Source                                                                                                                                                                                                     |
| ------------------------------- | -------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `failed to generate token`      | `menu:serverErrorGenerateToken`  | Login                        | [login.go:L60](https://github.com/pagefaultgames/rogueserver/blob/master/api/account/login.go#L60), [L81](https://github.com/pagefaultgames/rogueserver/blob/master/api/account/login.go#L81)                      |
| `failed to add account session` | `menu:serverErrorAddSession`     | Login                        | [login.go:L85](https://github.com/pagefaultgames/rogueserver/blob/master/api/account/login.go#L85)                                                                                                                 |
| `failed to generate uuid`       | `menu:serverErrorGenerateUuid`   | Registration                 | [register.go:L39](https://github.com/pagefaultgames/rogueserver/blob/master/api/account/register.go#L39)                                                                                                           |
| `failed to generate salt`       | `menu:serverErrorGenerateSalt`   | Registration/Change Password | [register.go:L45](https://github.com/pagefaultgames/rogueserver/blob/master/api/account/register.go#L45), [changepw.go:L37](https://github.com/pagefaultgames/rogueserver/blob/master/api/account/changepw.go#L37) |
| `failed to remove sessions`     | `menu:serverErrorRemoveSessions` | Change Password              | [changepw.go:L42](https://github.com/pagefaultgames/rogueserver/blob/master/api/account/changepw.go#L42)                                                                                                           |
| `failed to add account record`  | `menu:serverErrorUpdateAccount`  | Change Password              | [changepw.go:L47](https://github.com/pagefaultgames/rogueserver/blob/master/api/account/changepw.go#L47) 

### Backend Coverage

All server-side errors from `rogueserver` are now properly handled:

- ✅ `api/account/login.go` - 6 errors (2 new mappings)
- ✅ `api/account/register.go` - 5 errors (2 new mappings)
- ✅ `api/account/changepw.go` - 4 errors (3 new mappings)

**No server errors are left unmapped.**

## Screenshots/Videos

See pagefaultgames/pokerogue-locales#272

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] I have provided a clear explanation of the changes
- [x] The PR title matches the format described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request)
- [x] I have tested the changes manually
- [x] I have provided screenshots/videos of the changes (if applicable)

Are there any localization additions or changes? If so:

- [x] A locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo
  - [x] Link to locales PR: pagefaultgames/pokerogue-locales#272
- [x] The translation team been contacted for proofreading/translation on Discord