### PR TITLE
github: add `perf` as a valid PR title prefix

### DIFF
--- a/.github/scripts/pr-title.mts
+++ b/.github/scripts/pr-title.mts
@@ -20,6 +20,7 @@ const PREFIXES = [
   "github", // Updating the CI pipeline or otherwise modifying something in the `./github/**` directory
   "i18n", // Adding/modifying translation keys, etc
   "misc", // A change that doesn't fit any other prefix
+  "perf", // A refactor aimed at improving performance
   "refactor", // A change that doesn't impact functionality or fix any bugs (except incidentally)
   "test", // Primarily adding/updating tests or modifying the test framework
 ] as const;
@@ -53,6 +54,7 @@ const PREFIX_SCOPE_MAP = {
   github: [],
   i18n: [],
   misc: [],
+  perf: [],
   refactor: ALL_SCOPES,
   test: ALL_SCOPES,
 } as const satisfies Record<Prefixes, readonly AllScopes[]>;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,7 @@ fix(move): Future Sight no longer crashes
 - "github" - Updating the CI pipeline or otherwise modifying something in the `./github/**` directory
 - "i18n" - Adding/modifying translation keys, etc
 - "misc" - A change that doesn't fit any other prefix
+- "perf" - A refactor aimed at improving performance
 - "refactor" - A change that doesn't impact functionality or fix any bugs (except incidentally)
 - "test" - Primarily adding/updating tests or modifying the test framework
 


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Requested.

## What are the changes from a developer perspective?
`perf:` is now a valid prefix to use for PR titles.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] I have provided a clear explanation of the changes
- [x] The PR title matches the format described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request)