### PR TITLE
github: GitHub Pages workflow only runs on changes to src files

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -37,6 +37,10 @@ jobs:
             all:
               - "src/**/*.ts"
               - "test/test-utils/*.ts"
+              - "typedoc.config.js"
+              - "tsdoc.json"
+              - "tsconfig.json"
+              - "typedoc-plugins/**/*"
 
   pages:
     name: Github Pages


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
The GH Pages workflow doesn't need to run if no files that are checked by Typedoc were changed.

## What are the changes from a developer perspective?
Added a path filter to the GH Pages workflow that causes it to be skipped if no relevant files were changed.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] I have provided a clear explanation of the changes
- [x] The PR title matches the format described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request)
- [x] I have tested the changes manually