### PR TITLE
github: add link to info on formatting PR titles in workflow output

### DIFF
--- a/.github/scripts/pr-title.mts
+++ b/.github/scripts/pr-title.mts
@@ -80,6 +80,7 @@ async function run(): Promise<void> {
     });
 
     const { title } = pullRequest;
+    core.info("Info on PR title formatting: https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request");
     core.info(`Pull Request title: "${title}"`);
 
     // if (title.length > 72) {


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
In case someone doesn't realize the link is in the PR template, but looks at a failing PR title lint workflow to see what's going on.

## What are the changes from a developer perspective?
Link to PR title formatting section of `CONTRIBUTING.md` is output to the workflow logs.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] I have provided a clear explanation of the changes
- [x] The PR title matches the format described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request)
- [x] I have tested the changes manually