### PR TITLE
fix(move): Magnitude power values and thresholds set to correct values

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -4746,12 +4746,13 @@ export class TurnDamagedDoublePowerAttr extends VariablePowerAttr {
   }
 }
 
-const magnitudeMessageFunc = (_user: Pokemon, _target: Pokemon, _move: Move) => {
-  let message: string;
+const magnitudeThresholds = [5, 15, 35, 65, 85, 95];
+
+const magnitudeMessageFunc = (): string => {
+  let message!: string;
+
   globalScene.executeWithSeedOffset(
     () => {
-      const magnitudeThresholds = [5, 15, 35, 65, 75, 95];
-
       const rand = randSeedInt(100);
 
       let m = 0;
@@ -4766,32 +4767,32 @@ const magnitudeMessageFunc = (_user: Pokemon, _target: Pokemon, _move: Move) => 
     globalScene.currentBattle.turn << 6,
     globalScene.waveSeed,
   );
-  return message!;
+
+  return message;
 };
 
 export class MagnitudePowerAttr extends VariablePowerAttr {
-  apply(_user: Pokemon, _target: Pokemon, _move: Move, args: any[]): boolean {
-    const power = args[0] as NumberHolder;
+  apply(_user: Pokemon, _target: Pokemon, _move: Move, args: [NumberHolder, ...any[]]): boolean {
+    const power = args[0];
 
-    const magnitudeThresholds = [5, 15, 35, 65, 75, 95];
-    const magnitudePowers = [10, 30, 50, 70, 90, 100, 110, 150];
-
-    let rand: number;
+    const magnitudePowers = [10, 30, 50, 70, 90, 110, 150];
 
     globalScene.executeWithSeedOffset(
-      () => (rand = randSeedInt(100)),
+      () => {
+        const rand = randSeedInt(100);
+
+        let m = 0;
+        for (; m < magnitudeThresholds.length; m++) {
+          if (rand < magnitudeThresholds[m]) {
+            break;
+          }
+        }
+
+        power.value = magnitudePowers[m];
+      },
       globalScene.currentBattle.turn << 6,
       globalScene.waveSeed,
     );
-
-    let m = 0;
-    for (; m < magnitudeThresholds.length; m++) {
-      if (rand! < magnitudeThresholds[m]) {
-        break;
-      }
-    }
-
-    power.value = magnitudePowers[m];
 
     return true;
   }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1,6 +1,7 @@
 import type { Ability, PreAttackModifyDamageAbAttrParams } from "#abilities/ability";
 import { applyAbAttrs, applyOnGainAbAttrs, applyOnLoseAbAttrs } from "#abilities/apply-ab-attrs";
 import { generateMoveset } from "#app/ai/ai-moveset-gen";
+import type { Battle } from "#app/battle";
 import type { AnySound, BattleScene } from "#app/battle-scene";
 import { EVOLVE_MOVE, PLAYER_PARTY_MAX_SIZE, RARE_CANDY_FRIENDSHIP_CAP, RELEARN_MOVE } from "#app/constants";
 import { timedEventManager } from "#app/global-event-manager";
@@ -5612,7 +5613,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     [this.getSprite(), this.getTintSprite()]
       .filter(s => !!s)
-      .map(s => {
+      .forEach(s => {
         s.pipelineData[`spriteColors${ignoreOverride && this.summonData.speciesForm ? "Base" : ""}`] = spriteColors;
         s.pipelineData[`fusionSpriteColors${ignoreOverride && this.summonData.speciesForm ? "Base" : ""}`] =
           fusionSpriteColors;
@@ -5626,37 +5627,34 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Generate a random number using the current battle's seed, or the global seed if `globalScene.currentBattle` is falsy
-   *
-   * @remarks
-   * This calls either {@linkcode BattleScene.randBattleSeedInt}({@linkcode range}, {@linkcode min}) in `src/battle-scene.ts`
-   * which calls {@linkcode Battle.randSeedInt}({@linkcode range}, {@linkcode min}) in `src/battle.ts`
-   * which calls {@linkcode randSeedInt randSeedInt}({@linkcode range}, {@linkcode min}) in `src/utils.ts`,
-   * or it directly calls {@linkcode randSeedInt randSeedInt}({@linkcode range}, {@linkcode min}) in `src/utils.ts` if there is no current battle
-   *
-   * @param range - How large of a range of random numbers to choose from. If {@linkcode range} <= 1, returns {@linkcode min}
-   * @param min - The minimum integer to pick; default `0`
-   * @returns A random integer between {@linkcode min} and ({@linkcode min} + {@linkcode range} - 1)
+   * @param range - How large of a range of random numbers to choose from.
+   * @param min - (Default `0`) The minimum integer to pick
+   * @returns A random integer between `min` and `min + range - 1`
+   * @remarks If `range <= 1`, this returns `min`
+   * @privateRemarks
+   * This calls either {@linkcode BattleScene.randBattleSeedInt}
+   * which calls {@linkcode Battle.randSeedInt}
+   * which calls {@linkcode randSeedInt}, \
+   * or it directly calls {@linkcode randSeedInt} if there is no current battle.
    */
   randBattleSeedInt(range: number, min = 0): number {
     return globalScene.currentBattle ? globalScene.randBattleSeedInt(range, min) : randSeedInt(range, min);
   }
 
   /**
-   * Generate a random number using the current battle's seed, or the global seed if `globalScene.currentBattle` is falsy
+   * Generate a random number within the specified range
    * @param min - The minimum integer to generate
    * @param max - The maximum integer to generate
-   * @returns A random integer between {@linkcode min} and {@linkcode max} (inclusive)
+   * @returns A random integer between `min` and `max` (inclusive)
    */
   randBattleSeedIntRange(min: number, max: number): number {
-    return globalScene.currentBattle ? globalScene.randBattleSeedInt(max - min + 1, min) : randSeedIntRange(min, max);
+    return this.randBattleSeedInt(max - min + 1, min);
   }
 
   /**
    * Causes a Pokemon to leave the field (such as in preparation for a switch out/escape).
-   * @param clearEffects - Indicates if effects should be cleared (true) or passed
-   *    to the next pokemon, such as during a baton pass (false)
-   * @param hideInfo - Indicates if this should also play the animation to hide the Pokemon's
-   * info container.
+   * @param clearEffects - Whether effects should be cleared, or passed to the next pokemon (e.g. due to Baton Pass)
+   * @param hideInfo - Indicates if this should also play the animation to hide the Pokemon's info container
    */
   leaveField(clearEffects = true, hideInfo = true, destroy = false) {
     this.resetSprite();

--- a/test/moves/magnitude.test.ts
+++ b/test/moves/magnitude.test.ts
@@ -1,0 +1,48 @@
+import { allMoves } from "#data/data-lists";
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import { NumberHolder } from "#utils/common";
+import Phaser from "phaser";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move - Magnitude", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleStyle("single")
+      .criticalHits(false)
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset(MoveId.SPLASH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should have the correct rng thresholds and power values", async () => {
+    await game.classicMode.runToSummon([SpeciesId.FEEBAS]);
+
+    const magnitudeAttr = allMoves[MoveId.MAGNITUDE].getAttrs("MagnitudePowerAttr")[0];
+    const movePower = new NumberHolder(0);
+    const results = { [0]: 0, [10]: 0, [30]: 0, [50]: 0, [70]: 0, [90]: 0, [110]: 0, [150]: 0 };
+
+    await game.rng.equalSample(100, () => {
+      movePower.value = 0;
+      magnitudeAttr.apply(null!, null!, null!, [movePower]);
+      results[movePower.value]++;
+    });
+
+    expect(results).toMatchObject({ [0]: 0, [10]: 5, [30]: 10, [50]: 20, [70]: 30, [90]: 20, [110]: 10, [150]: 5 });
+  });
+});

--- a/test/test-utils/game-manager.ts
+++ b/test/test-utils/game-manager.ts
@@ -36,6 +36,7 @@ import { MoveHelper } from "#test/test-utils/helpers/move-helper";
 import { OverridesHelper } from "#test/test-utils/helpers/overrides-helper";
 import { PromptHandler } from "#test/test-utils/helpers/prompt-handler";
 import { ReloadHelper } from "#test/test-utils/helpers/reload-helper";
+import { RngHelper } from "#test/test-utils/helpers/rng-helper";
 import { SettingsHelper } from "#test/test-utils/helpers/settings-helper";
 import type { InputsHandler } from "#test/test-utils/inputs-handler";
 import { MockFetch } from "#test/test-utils/mocks/mock-fetch";
@@ -72,6 +73,7 @@ export class GameManager {
   public readonly reload: ReloadHelper;
   public readonly modifiers: ModifierHelper;
   public readonly field: FieldHelper;
+  public readonly rng: RngHelper;
 
   /**
    * Creates an instance of GameManager.
@@ -109,6 +111,7 @@ export class GameManager {
     this.reload = new ReloadHelper(this);
     this.modifiers = new ModifierHelper(this);
     this.field = new FieldHelper(this);
+    this.rng = new RngHelper(this);
 
     this.initDefaultOverrides();
 

--- a/test/test-utils/helpers/rng-helper.ts
+++ b/test/test-utils/helpers/rng-helper.ts
@@ -1,0 +1,47 @@
+import { GameManagerHelper } from "#test/test-utils/helpers/game-manager-helper";
+import { vi } from "vitest";
+
+export class RngHelper extends GameManagerHelper {
+  /**
+   * Performs the RNG experiment dictated by `fn` while sampling uniformly n times from
+   * the full range of possible RNG values, where n is the number of trials to perform.
+   *
+   * Specifically, this function divides the interval of possible RNG values into n equal slices,
+   * then samples exactly once from the midpoint of each interval,
+   * and rounds down as necessary for integer-based RNG functions.
+   *
+   * @param numTrials - The number of trials to perform
+   * @param fn - The function to be called during each trial
+   * @example
+   * ```
+   * let zeroCounter = 0;
+   *
+   * await game.rng.equalSample(1000, () => {
+   *   if (randSeedInt(1000) === 0) {
+   *     zeroCounter++;
+   *   }
+   * });
+   *
+   * expect(zeroCounter).toBe(1);
+   * ```
+   */
+  public async equalSample(numTrials: number, fn: () => Promise<void> | void): Promise<void> {
+    let sampleProgress = 0; // This will simulate range of RNG calls by slowly increasing from 0 to 1
+
+    // Mock both the global RNG and the battle-specific RNG
+    vi.spyOn(Phaser.Math.RND, "realInRange").mockImplementation((min: number, max: number) => {
+      return min + (max - min) * sampleProgress;
+    });
+    vi.spyOn(this.game.scene, "randBattleSeedInt").mockImplementation((range: number, min = 0) => {
+      return Math.floor(min + range * sampleProgress);
+    });
+
+    for (let i = 0; i < numTrials; i++) {
+      sampleProgress = (2 * i + 1) / (2 * numTrials); // The midpoint of the i^th interval
+      await fn();
+    }
+
+    vi.spyOn(Phaser.Math.RND, "realInRange").mockRestore();
+    vi.spyOn(this.game.scene, "randBattleSeedInt").mockRestore();
+  }
+}


### PR DESCRIPTION
## What are the changes the user will see?
Magnitude will now have the correct move base power values and will output them with the correct frequency.

## Why am I making these changes?
The move is bugged.

## What are the changes from a developer perspective?
- Removed the extra incorrect entry from the move power array and fixed the incorrect value in the RNG thresholds array.
- Ported the RNG helper from pkty for the test.
- Cleaned up a bunch of docs on the RNG functions in the `Pokemon` class.

## How to test the changes?
`pnpm test:silent magnitude`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] I have provided a clear explanation of the changes
- [x] The PR title matches the format described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request)
- [x] The full test suite still passes (`pnpm test:silent`)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes