### PR TITLE
docs: update `CONTRIBUTING.md`, PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,13 @@
 <!--
 Thank you for contributing to PokéRogue!
-Open-source contributions like yours are what keep this project going.
+Open-source contributions like yours help keep this project going.
 
 Note that these comment blocks are purely informative and can be removed once you're done reading them.
 -->
 
 <!--
 Make sure your title matches the https://www.conventionalcommits.org/en/v1.0.0/ format.
-Attempt to make the title no longer than 72 characters (GitHub cuts off commit titles longer than this length).
+Try to keep the title under 72 characters, as GitHub cuts off commit titles longer than this length.
 
 See https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request
 for more information on the allowed scopes and prefixes.
@@ -26,7 +26,7 @@ fix(move): Future Sight no longer crashes
 Summarize the changes from a user perspective on the application.
 Try to keep this section (relatively) brief as it is used to generate changelogs.
 
-PRs with no user-facing changes should instead write "N/A" to be ommitted from auto-generated changelogs.
+PRs with no user-facing changes should leave this blank or write "N/A" to be omitted from auto-generated changelogs.
 -->
 
 ## Why am I making these changes?
@@ -37,9 +37,9 @@ How can this can enhance user experience or otherwise improve the codebase?
 
 Try to keep this explanation as objective as possible — avoid referring to personal feelings or making derogatory comments about existing code.
 
-If this PR fixes an existing GitHub issue,
-you can add "Fixes #[issue number]" (e.g.: "Fixes #1234") to link the issue
-so that it will automatically be closed when the PR is merged.
+If this PR resolves an existing GitHub issue,
+you can add "Fixes #[issue number]" (e.g.: "Fixes #1234") to link the issue.
+(See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue for more information.)
 -->
 
 ## What are the changes from a developer perspective?
@@ -79,13 +79,13 @@ Do the reviewers need to do something special in order to test your changes?
 ## Checklist
 <!--
 Please ensure the following requirements are all met before creating your PR.
-If this is not the case, consider [marking the PR as a draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.
+If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.
 
 If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
 you can strike it out with the `~` character to mark them as not applicable.
 -->
 
-- The PR is correctly formatted:
+- The PR content is correctly formatted:
   - [ ] **I'm using `beta` as my base branch**
   - [ ] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
   - [ ] I have provided a clear explanation of the changes within the PR description
@@ -94,11 +94,10 @@ you can strike it out with the `~` character to mark them as not applicable.
   - [ ] There is no overlap with another open PR
 - The PR has been confirmed to work correctly:
   - [ ] I have tested the changes manually
-  - [ ] The full automated test suite still passes
+  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
   - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
 - [ ] I have provided screenshots/videos of the changes (if applicable)
   - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)
-- [ ] **I have notified the Dev Team about this PR's existence** (such as by posting inside the current PR callout thread on Discord)
 
 Are there any localization additions or changes? If so:
 - [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,6 @@ Notable topics include:
 
 Again, if you have unanswered questions please feel free to ask!
 
-
 ## 🧪 Testing Your Changes
 
 You've just made a change - how can you check if it works? You have two areas to hit:
@@ -132,19 +131,19 @@ You can get help testing your specific changes, and you might have found a new o
 
 ### 2 - Automatic Testing
 
-PokéRogue uses [Vitest](https://vitest.dev/) for automated testing. \
+PokéRogue uses [Vitest](https://vitest.dev/) for automated testing.
 Checking out existing tests in the [test](./test/) folder is a great way to understand how the existing system works, as well as familiarizing yourself with the project as a whole.
 
 #### Writing tests
 Most non-trivial changes (_especially bug fixes_) should be accompanied by one or more new automated test cases.
 
-To create a new test file, run `pnpm test:create` and follow the on-screen prompts. \
+To create a new test file, run `pnpm test:create` and follow the on-screen prompts.
 If the move/ability/etc. you're modifying already has tests, you can add new cases to the test file or edit existing ones.
 
-- Ensure that new test cases:
-  - Are deterministic. In other words, the test should never pass or fail when it shouldn't due to randomness. Among other things, this involves ensuring that abilities and moves are never randomly selected.
-  - Do not test multiple separate things in the same test case. If you have made two distinct changes, they should be tested in two separate cases.
-  - Cover as many edge cases as possible. A good strategy is to think of edge cases beforehand and create tests for them using `it.todo`. Once the edge case has been handled, you can remove the `todo` marker.
+Ensure that new test cases:
+- Are deterministic. In other words, the test should never pass or fail when it shouldn't due to randomness. Among other things, this involves ensuring that abilities and moves are never randomly selected.
+- Do not test multiple separate things in the same test case. If you have made two distinct changes, they should be tested in two separate cases.
+- Cover as many edge cases as possible. A good strategy is to think of edge cases beforehand and create tests for them using `it.todo`. Once the edge case has been handled, you can remove the `todo` marker.
 
 <!-- TODO: Decide on and suggest a specific placement heiarchy for test cases involving interactions between different moves/abilities/etc. -->
 
@@ -184,7 +183,7 @@ fix(move): Future Sight no longer crashes
 > [!IMPORTANT]
 > If a save migrator, version increase or other breaking change is part of the PR, a `!` must be added before the `:`.
 
-Try to keep the PR title to 72 characters or less (GitHub cuts off commit titles longer than this).
+Try to keep the title under 72 characters, as GitHub cuts off commit titles longer than this length.
 
 #### Examples
 `refactor(data)!: improve serialization of Pokemon save data`


### PR DESCRIPTION
## What are the changes the user will see?
N/A
## Why am I making these changes?
I thought the section could use a bit of updating, not to mention some info was all over the place.


## What are the changes from a developer perspective?
- Moved some explanatory comments into their relevant sections
- Made the checklist part more explicitly grouped
- Added sub-headers to `CONTRIBUTING.md` while I had the opportunity (and added links to Vitest's docs)

## Screenshots/Videos
N/A
## How to test the changes?
N/A

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] I have provided a clear explanation of the changes
- [x] The PR title matches the format described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request)
- [x] I have tested the changes manually
