### PR TITLE
dev: add missing type import to `game-manager.ts`

### DIFF
--- a/test/test-utils/game-manager.ts
+++ b/test/test-utils/game-manager.ts
@@ -46,6 +46,7 @@ import type { PhaseClass, PhaseString } from "#types/phase-types";
 import type { BallUiHandler } from "#ui/ball-ui-handler";
 import type { BattleMessageUiHandler } from "#ui/battle-message-ui-handler";
 import type { CommandUiHandler } from "#ui/command-ui-handler";
+import type { AwaitableUiHandler } from "#ui/handlers/awaitable-ui-handler";
 import type { ModifierSelectUiHandler } from "#ui/modifier-select-ui-handler";
 import type { PartyUiHandler } from "#ui/party-ui-handler";
 import type { StarterSelectUiHandler } from "#ui/starter-select-ui-handler";


### PR DESCRIPTION
## What are the changes the user will see?
N/A
## Why am I making these changes?
we missed a type import used in a linkcode
## What are the changes from a developer perspective?
added type import for `AwaitableUiHandler`
## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] I have provided a clear explanation of the changes
- [x] The PR title matches the format described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request)