### PR TITLE
fix: GMax Pikachu and Eevee will revert to the correct form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ coverage
 
 # Script outputs
 ./*.csv
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,3 @@ coverage
 
 # Script outputs
 ./*.csv
-package-lock.json

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -30,7 +30,11 @@ import { initCommonAnims, initMoveAnim, loadCommonAnimAssets, loadMoveAnimAssets
 import { allMoves, allSpecies, biomeDepths, modifierTypes } from "#data/data-lists";
 import { battleSpecDialogue } from "#data/dialogue";
 import type { SpeciesFormChangeTrigger } from "#data/form-change-triggers";
-import { SpeciesFormChangeManualTrigger, SpeciesFormChangeTimeOfDayTrigger } from "#data/form-change-triggers";
+import {
+  SpeciesFormChangeItemTrigger,
+  SpeciesFormChangeManualTrigger,
+  SpeciesFormChangeTimeOfDayTrigger,
+} from "#data/form-change-triggers";
 import { Gender } from "#data/gender";
 import type { SpeciesFormChange } from "#data/pokemon-forms";
 import { pokemonFormChanges } from "#data/pokemon-forms";
@@ -3209,10 +3213,45 @@ export class BattleScene extends SceneBase {
           : formChangeItemModifiers.includes(FormChangeItem.N_SOLARIZER)
             ? matchingFormChangeOpts[1]
             : null;
+      } else if (formChangeTriggerType === SpeciesFormChangeItemTrigger && matchingFormChangeOpts.length > 1) {
+        const isPlayer = pokemon.isPlayer();
+        matchingFormChange =
+          matchingFormChangeOpts.find(fc => {
+            const itemTrigger = fc.findTrigger(SpeciesFormChangeItemTrigger) as SpeciesFormChangeItemTrigger | null;
+            if (!itemTrigger || itemTrigger.active) {
+              return false;
+            }
+            const modifier = this.findModifier(
+              m =>
+                m instanceof PokemonFormChangeItemModifier
+                && m.pokemonId === pokemon.id
+                && m.formChangeItem === itemTrigger.item,
+              isPlayer,
+            ) as PokemonFormChangeItemModifier | undefined;
+
+            return modifier?.preFormKey != null && modifier.preFormKey === fc.formKey;
+          }) ?? matchingFormChangeOpts[0];
       } else {
         matchingFormChange = matchingFormChangeOpts[0];
       }
       if (matchingFormChange) {
+        if (formChangeTriggerType === SpeciesFormChangeItemTrigger) {
+          const itemTrigger = matchingFormChange.findTrigger(
+            SpeciesFormChangeItemTrigger,
+          ) as SpeciesFormChangeItemTrigger | null;
+          if (itemTrigger?.active) {
+            const modifier = this.findModifier(
+              m =>
+                m instanceof PokemonFormChangeItemModifier
+                && m.pokemonId === pokemon.id
+                && m.formChangeItem === itemTrigger.item,
+              pokemon.isPlayer(),
+            ) as PokemonFormChangeItemModifier | undefined;
+            if (modifier) {
+              modifier.preFormKey = matchingFormChange.preFormKey;
+            }
+          }
+        }
         let phase: Phase;
         if (pokemon.isPlayer() && !matchingFormChange.quiet) {
           phase = this.phaseManager.create("FormChangePhase", pokemon, matchingFormChange, modal);

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -2779,6 +2779,7 @@ export class PokemonFormChangeItemModifier extends PokemonHeldItemModifier {
   public declare type: FormChangeItemModifierType;
   public formChangeItem: FormChangeItem;
   public active: boolean;
+  public preFormKey: string | null;
   public isTransferable = false;
 
   constructor(
@@ -2786,11 +2787,18 @@ export class PokemonFormChangeItemModifier extends PokemonHeldItemModifier {
     pokemonId: number,
     formChangeItem: FormChangeItem,
     active: boolean,
+    preFormKeyOrStackCount?: string | number | null,
     stackCount?: number,
   ) {
-    super(type, pokemonId, stackCount);
+    // Backward compatibility: saved data used to pass stackCount as the 5th arg.
+    const usesLegacyStackCount = typeof preFormKeyOrStackCount === "number" && stackCount === undefined;
+    const resolvedStackCount = usesLegacyStackCount ? preFormKeyOrStackCount : stackCount;
+    const resolvedPreFormKey = usesLegacyStackCount ? null : ((preFormKeyOrStackCount as string | null) ?? null);
+
+    super(type, pokemonId, resolvedStackCount);
     this.formChangeItem = formChangeItem;
     this.active = active;
+    this.preFormKey = resolvedPreFormKey;
   }
 
   matchType(modifier: Modifier): boolean {
@@ -2803,12 +2811,13 @@ export class PokemonFormChangeItemModifier extends PokemonHeldItemModifier {
       this.pokemonId,
       this.formChangeItem,
       this.active,
+      this.preFormKey,
       this.stackCount,
     );
   }
 
   getArgs(): any[] {
-    return super.getArgs().concat(this.formChangeItem, this.active);
+    return super.getArgs().concat(this.formChangeItem, this.active, this.preFormKey ?? null);
   }
 
   /**


### PR DESCRIPTION
## What are the changes the user will see?
Deactivating Max Mushrooms on a Gmax Partner Eevee and Pikachu reverts them to their Intial selected (Partner) forms. 

## Why am I making these changes?
Fixes #4865 

## What are the changes from a developer perspective?
Battlescene.ts and modifier.ts

## Screenshots/Videos
<details>

<img width="770" height="778" alt="image" src="https://github.com/user-attachments/assets/4e376405-32fa-4f4c-81dd-0dc515990e2e" />

</details>

## How to test the changes?


## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] I have provided a clear explanation of the changes
- [x] The PR title matches the format described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request)
- [x] I have tested the changes manually
- [x] The full test suite still passes (`pnpm test:silent`)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI change works for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [ ] A locales PR been created on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repo
  - [ ] Link to locales PR: 
- [ ] The translation team been contacted for proofreading/translation on Discord

Does this require any changes to the assets folder? If so:
- [ ] A PR been created on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repo
  - [ ] Link to assets PR: 