### PR TITLE
fix(ui): the Delete key works again in the key rebinding menu

### DIFF
--- a/src/ui/settings/settings-keyboard-ui-handler.ts
+++ b/src/ui/settings/settings-keyboard-ui-handler.ts
@@ -16,7 +16,7 @@ import { AbstractControlSettingsUiHandler } from "#ui/abstract-control-settings-
 import { NavigationManager } from "#ui/navigation-menu";
 import { addTextObject } from "#ui/text";
 import { truncateString } from "#utils/common";
-import { toPascalSnakeCase } from "#utils/strings";
+import { toUpperSnakeCase } from "#utils/strings";
 import i18next from "i18next";
 
 /** Class representing the settings UI handler for keyboards */
@@ -98,7 +98,7 @@ export class SettingsKeyboardUiHandler extends AbstractControlSettingsUiHandler 
     }
     const cursor = this.cursor + this.scrollCursor; // Calculate the absolute cursor position.
     const selection = this.settingLabels[cursor].text;
-    const key = toPascalSnakeCase(selection);
+    const key = toUpperSnakeCase(selection);
     const settingName = SettingKeyboard[key];
     const activeConfig = this.getActiveConfig();
     const success = activeConfig != null && deleteBind(activeConfig, settingName);


### PR DESCRIPTION
## What are the changes the user will see?
The "Delete" key will be able to clear keybindings again.
Note: this bug only existed on the beta branch, no changelog entry is needed.

## Why am I making these changes?
Fixed an oversight from #6992 

## What are the changes from a developer perspective?
Replaced a `toPascalSnakeCase()` with `toUpperSnakeCase()` in `settings-keyboard-ui-handler.ts`

## How to test the changes?
Go to the key rebinding menu and hit the "Delete" key on a rebindable key.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](../CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually