### PR TITLE
fix(battle): Use min `Def` to prevent infinite dmg

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1582,7 +1582,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       ret *= highestStatBoost.multiplier;
     }
 
-    return Math.floor(ret);
+    return Math.max(Math.floor(ret), 1);
   }
 
   calculateStats(): void {


### PR DESCRIPTION
## What are the changes the user will see?

It's no longer to deal infinite damage due to the enemy having `0` def. Instead it will always have 1

## Why am I making these changes?

[Discord](https://discord.com/channels/1125469663833370665/1250836282926436413/1467593208069619956)

## What are the changes from a developer perspective?

Added a `Math.max`  to `#getEffectiveStat` so it never falls below `1`

> Note that prior to [Generation III](https://m.bulbapedia.bulbagarden.net/wiki/Generation_III), no stat can fall below 1 or rise above 999; any further modifiers will be treated as if the stat was capped regardless of whether the stat is at −6 or +6 or not.

via [Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Stat_modifier)

## Screenshots/Videos

<details><summary>Before</summary>
<img width="220" height="40" alt="image" src="https://github.com/user-attachments/assets/d3c19a24-63c3-40ad-bb8b-398ec7698820" />
</details> 
<details><summary>After</summary>
<img width="203" height="32" alt="image" src="https://github.com/user-attachments/assets/793fe502-5c81-41c4-a378-9774c6755c1e" />
</details> 

## How to test the changes?

```ts
const overrides = {
  ENEMY_HELD_ITEMS_OVERRIDE: [{ name: "SOUL_DEW", count: 10 }],
  ENEMY_NATURE_OVERRIDE: Nature.LONELY,
  MOVESET_OVERRIDE: [MoveId.TACKLE, MoveId.SCREECH]
} satisfies Partial<InstanceType<OverridesType>>;
```

Use `screech` 3 times then `tackle`

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)