### PR TITLE
dev: enable strict `import.meta.env` typechecking

### DIFF
--- a/src/vite.env.d.ts
+++ b/src/vite.env.d.ts
@@ -12,6 +12,6 @@ interface ImportMetaEnv {
   readonly NODE_ENV?: string;
 }
 
-declare interface ImportMeta {
-  readonly env: ImportMetaEnv;
+interface ViteTypeOptions {
+  strictImportMetaEnv: unknown;
 }


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
I noticed that "vite/client" had an interface with a property named `strictImportMetaEnv`, which (if specified via declaration merging) will change the type of `import.meta.env` to disallow missing properties.

## What are the changes from a developer perspective?
Enabled the requisite flag inside the `.d.ts` file.
Now, something like `import.meta.env.FOO` will not produce a type of `any` and instead just error outright.

## How to test the changes?
N/A
## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
