### PR TITLE
test: disable stacktrace spam in Vitest VSCode extension v1.40.0+

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -2,11 +2,10 @@ import type { SetupServerApi } from "msw/node";
 
 declare global {
   /**
-   * Only used in testing.
-   * Can technically be undefined/null but for ease of use we are going to assume it is always defined.
-   * Used to load i18n files exclusively.
+   * An MSW HTTP server, used to load i18n locale files during normal tests and serve mock
+   * HTTP requests during API tests.
    *
-   * To set up your own server in a test see `game-data.test.ts`
+   * ⚠️ Should not be used in production code, as it is only populated during test runs!
    */
   var server: SetupServerApi;
 }

--- a/test/setup/vitest.setup.ts
+++ b/test/setup/vitest.setup.ts
@@ -29,10 +29,13 @@ vi.mock(import("#app/overrides"), async importOriginal => {
  * Do NOT try to put any of this code into external functions, it won't work as it's elevated during runtime.
  */
 vi.mock(import("i18next"), async importOriginal => {
-  console.log("Mocking i18next");
+  // NB: We have to use raw ANSI escapes here since chalk isn't initialized yet.
+  // (For those wondering, this corresponds to the same rgb(223, 184, 216) color used in the chalk calls below, just in RGB)
+  console.log("\x1b[38;2;223;184;216mMocking i18next...\x1b[0m");
   const { setupServer } = await import("msw/node");
   const { http, HttpResponse } = await import("msw");
 
+  // TODO: This sounds like a good use for Vitest's `globalSetupFiles`...?
   global.server = setupServer(
     http.get("/locales/en/*", async req => {
       const filename = req.params[0];
@@ -45,7 +48,7 @@ vi.mock(import("i18next"), async importOriginal => {
         }
         return HttpResponse.json(json);
       } catch (err) {
-        console.error(`Failed to load locale ${filename}\n`, err);
+        console.error(`Failed to load locale ${filename}!\n`, err);
         return HttpResponse.json({});
       }
     }),
@@ -54,7 +57,7 @@ vi.mock(import("i18next"), async importOriginal => {
     }),
   );
   global.server.listen({ onUnhandledRequest: "error" });
-  console.log("i18n MSW server listening!");
+  console.log("\x1b[38;2;223;184;216mi18n MSW server listening\x1b[0m");
 
   return await importOriginal();
 });


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Vitest's VS Code extension was updated in vitest-dev/vscode#720 to respect the current reporter's output settings, resulting in actual colored output (yay) alongside a copious amount of stack traces every other line (not yay).

## What are the changes from a developer perspective?
Added a constant to `CustomDefaultReporter` to toggle stack traces.
For whatever reason, these never seemed to show up on terminal anyhow, so this really only affects IDEs for the most part.

## Screenshots/Videos
N/A

## How to test the changes?
Run `tackle.test.ts`
## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?