### PR TITLE
feat(ability): implement Battle Bond's stat boost effect

### DIFF
--- a/src/data/abilities/ab-attrs.ts
+++ b/src/data/abilities/ab-attrs.ts
@@ -2083,22 +2083,27 @@ export class PostVictoryAbAttr extends AbAttr {
   apply(_params: Closed<AbAttrBaseParams>): void {}
 }
 
+type StatOrStatArray = BattleStat | NonEmptyTuple<BattleStat>;
+type PostVictoryStatStageChangeStats = StatOrStatArray | ((p: Pokemon) => StatOrStatArray);
+
 export class PostVictoryStatStageChangeAbAttr extends PostVictoryAbAttr {
-  private readonly stat: BattleStat | ((p: Pokemon) => BattleStat);
+  private readonly stats: PostVictoryStatStageChangeStats;
   private readonly stages: number;
 
-  constructor(stat: BattleStat | ((p: Pokemon) => BattleStat), stages: number) {
+  constructor(stats: PostVictoryStatStageChangeStats, stages: number) {
     super();
 
-    this.stat = stat;
+    this.stats = stats;
     this.stages = stages;
   }
 
   override apply({ pokemon, simulated }: AbAttrBaseParams): void {
-    const stat = typeof this.stat === "function" ? this.stat(pokemon) : this.stat;
-    if (!simulated) {
-      globalScene.phaseManager.unshiftNew("StatStageChangePhase", pokemon.getBattlerIndex(), true, [stat], this.stages);
+    if (simulated) {
+      return;
     }
+
+    const stats = coerceArray(typeof this.stats === "function" ? this.stats(pokemon) : this.stats);
+    globalScene.phaseManager.unshiftNew("StatStageChangePhase", pokemon.getBattlerIndex(), true, stats, this.stages);
   }
 }
 

--- a/src/data/abilities/apply-ab-attrs.ts
+++ b/src/data/abilities/apply-ab-attrs.ts
@@ -52,6 +52,7 @@ function applySingleAbAttrs<T extends AbAttrString>(
 
     if (!simulated) {
       pokemon.waveData.abilitiesApplied.add(ability.id);
+      pokemon.summonData.abilitiesApplied.add(ability.id);
     }
   }
 }

--- a/src/data/abilities/init-abilities.ts
+++ b/src/data/abilities/init-abilities.ts
@@ -1374,9 +1374,27 @@ export function initAbilities() {
       .ignorable()
       .build(),
     new AbBuilder(AbilityId.BATTLE_BOND, 7) //
-      .attr(PostVictoryFormChangeAbAttr, () => 2)
-      .attr(PostBattleInitFormChangeAbAttr, () => 1)
-      .attr(PostFaintFormChangeAbAttr, () => 1)
+      .conditionalAttr(
+        p => p.species.speciesId === SpeciesId.GRENINJA,
+        PostVictoryFormChangeAbAttr,
+        () => 2,
+      )
+      .conditionalAttr(
+        p => p.species.speciesId === SpeciesId.GRENINJA,
+        PostBattleInitFormChangeAbAttr,
+        () => 1,
+      )
+      .conditionalAttr(
+        p => p.species.speciesId === SpeciesId.GRENINJA,
+        PostFaintFormChangeAbAttr,
+        () => 1,
+      )
+      .conditionalAttr(
+        p => p.species.speciesId !== SpeciesId.GRENINJA && !p.summonData.abilitiesApplied.has(AbilityId.BATTLE_BOND),
+        PostVictoryStatStageChangeAbAttr,
+        [Stat.ATK, Stat.SPATK, Stat.SPD],
+        1,
+      )
       .attr(NoFusionAbilityAbAttr)
       .uncopiable()
       .unreplaceable()

--- a/src/data/pokemon/pokemon-data.ts
+++ b/src/data/pokemon/pokemon-data.ts
@@ -11,7 +11,6 @@ import type { Nature } from "#enums/nature";
 import type { PokemonType } from "#enums/pokemon-type";
 import type { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
-// biome-ignore lint/correctness/noUnusedImports: TSDoc
 import type { Pokemon } from "#field/pokemon";
 import type { AttackMoveResult } from "#types/attack-move-result";
 import type { IllusionData } from "#types/illusion-data";
@@ -80,6 +79,7 @@ interface SerializedPokemonSummonData {
   moveQueue: TurnMove[];
   tags: BattlerTag[];
   abilitySuppressed: boolean;
+  abilitiesApplied: AbilityId[];
   speciesForm?: SerializedSpeciesForm | undefined;
   fusionSpeciesForm?: SerializedSpeciesForm | undefined;
   ability?: AbilityId | undefined;
@@ -106,13 +106,15 @@ export class PokemonSummonData {
   public statStages: number[] = [0, 0, 0, 0, 0, 0, 0];
   /**
    * A queue of moves yet to be executed, used by charging, recharging and frenzy moves.
-   * So long as this array is nonempty, this Pokemon's corresponding `CommandPhase` will be skipped over entirely
-   * in favor of using the queued move.
-   * TODO: Clean up a lot of the code surrounding the move queue.
+   * @remarks
+   * So long as this array is non-empty, this Pokemon's corresponding `CommandPhase`
+   * will be skipped over entirely in favor of using the queued move.
    */
+  // TODO: Clean up a lot of the code surrounding the move queue.
   public moveQueue: TurnMove[] = [];
   public tags: BattlerTag[] = [];
   public abilitySuppressed = false;
+  public abilitiesApplied: Set<AbilityId> = new Set();
 
   // Overrides for transform and company.
   // TODO: Move these into a separate class & add rage fist hit count
@@ -189,6 +191,14 @@ export class PokemonSummonData {
           .filter((t): t is SerializableBattlerTag => t instanceof SerializableBattlerTag);
         continue;
       }
+
+      if (key === "abilitiesApplied") {
+        for (const a of value) {
+          this.abilitiesApplied.add(a);
+        }
+        continue;
+      }
+
       this[key] = value;
     }
   }
@@ -226,6 +236,7 @@ export class PokemonSummonData {
               ...(this.illusion as Omit<typeof illusion, "fusionSpecies">),
               fusionSpecies: illusionSpeciesForm?.speciesId,
             },
+      abilitiesApplied: [...this.abilitiesApplied.values()],
     };
     // Replace `null` with `undefined`, as `undefined` never gets serialized
     for (const [key, value] of Object.entries(t)) {

--- a/test/abilities/battle-bond.test.ts
+++ b/test/abilities/battle-bond.test.ts
@@ -4,16 +4,14 @@ import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { MultiHitType } from "#enums/multi-hit-type";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
 import { GameManager } from "#test/test-utils/game-manager";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-describe("Abilities - BATTLE BOND", () => {
+describe("Abilities - Battle Bond", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-
-  const baseForm = 1;
-  const ashForm = 2;
 
   beforeAll(() => {
     phaserGame = new Phaser.Game({
@@ -21,71 +19,127 @@ describe("Abilities - BATTLE BOND", () => {
     });
   });
 
-  beforeEach(() => {
-    game = new GameManager(phaserGame);
-    game.override
-      .battleStyle("single")
-      .startingWave(4) // Leads to arena reset on Wave 5 trainer battle
-      .ability(AbilityId.BATTLE_BOND)
-      .starterForms({ [SpeciesId.GRENINJA]: ashForm })
-      .moveset([MoveId.SPLASH, MoveId.WATER_SHURIKEN])
-      .enemySpecies(SpeciesId.BULBASAUR)
-      .enemyMoveset(MoveId.SPLASH)
-      .startingLevel(100) // Avoid levelling up
-      .enemyLevel(1000); // Avoid opponent dying before `doKillOpponents()`
-  });
+  describe("Greninja", () => {
+    const baseForm = 1;
+    const ashForm = 2;
 
-  it("check if fainted pokemon switches to base form on arena reset", async () => {
-    await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.GRENINJA);
-
-    const greninja = game.scene.getPlayerParty()[1];
-    expect(greninja.formIndex).toBe(ashForm);
-
-    greninja.hp = 0;
-    greninja.status = new Status(StatusEffect.FAINT);
-    expect(greninja.isFainted()).toBe(true);
-
-    game.move.select(MoveId.SPLASH);
-    await game.doKillOpponents();
-    await game.phaseInterceptor.to("TurnEndPhase");
-    game.doSelectModifier();
-    await game.phaseInterceptor.to("QuietFormChangePhase");
-
-    expect(greninja.formIndex).toBe(baseForm);
-  });
-
-  it("should not keep buffing Water Shuriken after Greninja switches to base form", async () => {
-    await game.classicMode.startBattle(SpeciesId.GRENINJA);
-
-    const waterShuriken = allMoves[MoveId.WATER_SHURIKEN];
-    vi.spyOn(waterShuriken, "calculateBattlePower");
-
-    let actualMultiHitType: MultiHitType | null = null;
-    const multiHitAttr = waterShuriken.getAttrs("MultiHitAttr")[0];
-    vi.spyOn(multiHitAttr, "getHitCount").mockImplementation(() => {
-      actualMultiHitType = multiHitAttr.getMultiHitType();
-      return 3;
+    beforeEach(() => {
+      game = new GameManager(phaserGame);
+      game.override
+        .battleStyle("single")
+        .startingWave(4) // Leads to arena reset on Wave 5 trainer battle
+        .ability(AbilityId.BATTLE_BOND)
+        .starterForms({ [SpeciesId.GRENINJA]: ashForm })
+        .enemySpecies(SpeciesId.BULBASAUR)
+        .enemyMoveset(MoveId.SPLASH)
+        .startingLevel(100) // Avoid levelling up
+        .enemyLevel(1000); // Avoid opponent dying before `doKillOpponents()`
     });
 
-    // Wave 4: Use Water Shuriken in Ash form
-    let expectedBattlePower = 20;
-    let expectedMultiHitType = MultiHitType.THREE;
+    it("check if fainted pokemon switches to base form on arena reset", async () => {
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.GRENINJA);
 
-    game.move.select(MoveId.WATER_SHURIKEN);
-    await game.phaseInterceptor.to("BerryPhase", false);
-    expect(waterShuriken.calculateBattlePower).toHaveLastReturnedWith(expectedBattlePower);
-    expect(actualMultiHitType).toBe(expectedMultiHitType);
+      const greninja = game.scene.getPlayerParty()[1];
+      expect(greninja.formIndex).toBe(ashForm);
 
-    await game.doKillOpponents();
-    await game.toNextWave();
+      greninja.hp = 0;
+      greninja.status = new Status(StatusEffect.FAINT);
+      expect(greninja.isFainted()).toBe(true);
 
-    // Wave 5: Use Water Shuriken in base form
-    expectedBattlePower = 15;
-    expectedMultiHitType = MultiHitType.TWO_TO_FIVE;
+      game.move.use(MoveId.SPLASH);
+      await game.doKillOpponents();
+      await game.phaseInterceptor.to("TurnEndPhase");
+      game.doSelectModifier();
+      await game.phaseInterceptor.to("QuietFormChangePhase");
 
-    game.move.select(MoveId.WATER_SHURIKEN);
-    await game.phaseInterceptor.to("BerryPhase", false);
-    expect(waterShuriken.calculateBattlePower).toHaveLastReturnedWith(expectedBattlePower);
-    expect(actualMultiHitType).toBe(expectedMultiHitType);
+      expect(greninja.formIndex).toBe(baseForm);
+    });
+
+    it("should not keep buffing Water Shuriken after Greninja switches to base form", async () => {
+      await game.classicMode.startBattle(SpeciesId.GRENINJA);
+
+      const waterShuriken = allMoves[MoveId.WATER_SHURIKEN];
+      vi.spyOn(waterShuriken, "calculateBattlePower");
+
+      let actualMultiHitType: MultiHitType | null = null;
+      const multiHitAttr = waterShuriken.getAttrs("MultiHitAttr")[0];
+      vi.spyOn(multiHitAttr, "getHitCount").mockImplementation(() => {
+        actualMultiHitType = multiHitAttr.getMultiHitType();
+        return 3;
+      });
+
+      // Wave 4: Use Water Shuriken in Ash form
+      let expectedBattlePower = 20;
+      let expectedMultiHitType = MultiHitType.THREE;
+
+      game.move.use(MoveId.WATER_SHURIKEN);
+      await game.phaseInterceptor.to("BerryPhase", false);
+      expect(waterShuriken.calculateBattlePower).toHaveLastReturnedWith(expectedBattlePower);
+      expect(actualMultiHitType).toBe(expectedMultiHitType);
+
+      await game.doKillOpponents();
+      await game.toNextWave();
+
+      // Wave 5: Use Water Shuriken in base form
+      expectedBattlePower = 15;
+      expectedMultiHitType = MultiHitType.TWO_TO_FIVE;
+
+      game.move.use(MoveId.WATER_SHURIKEN);
+      await game.phaseInterceptor.to("BerryPhase", false);
+      expect(waterShuriken.calculateBattlePower).toHaveLastReturnedWith(expectedBattlePower);
+      expect(actualMultiHitType).toBe(expectedMultiHitType);
+    });
+  });
+
+  describe("Non-Greninja", () => {
+    beforeEach(() => {
+      game = new GameManager(phaserGame);
+      game.override
+        .ability(AbilityId.BATTLE_BOND)
+        .battleStyle("single")
+        .criticalHits(false)
+        .startingLevel(100)
+        .enemyLevel(1)
+        .enemySpecies(SpeciesId.MAGIKARP)
+        .enemyAbility(AbilityId.BALL_FETCH)
+        .enemyMoveset(MoveId.SPLASH);
+    });
+
+    it("should increase Attack, Special Attack, and Speed stages by 1 on KO once per switch-in", async () => {
+      await game.classicMode.startBattle(SpeciesId.MILOTIC, SpeciesId.FEEBAS);
+
+      game.move.use(MoveId.THUNDERBOLT);
+      await game.toEndOfTurn();
+
+      const player = game.field.getPlayerPokemon();
+      expect(player).toHaveStatStage(Stat.ATK, 1);
+      expect(player).toHaveStatStage(Stat.SPATK, 1);
+      expect(player).toHaveStatStage(Stat.SPD, 1);
+
+      await game.toNextWave();
+      game.move.use(MoveId.THUNDERBOLT);
+      await game.toEndOfTurn();
+
+      expect(player).toHaveStatStage(Stat.ATK, 1);
+      expect(player).toHaveStatStage(Stat.SPATK, 1);
+      expect(player).toHaveStatStage(Stat.SPD, 1);
+
+      await game.toNextWave();
+      game.doSwitchPokemon(1);
+      await game.toNextTurn();
+      game.doSwitchPokemon(1);
+      await game.toNextTurn();
+
+      expect(player).toHaveStatStage(Stat.ATK, 0);
+      expect(player).toHaveStatStage(Stat.SPATK, 0);
+      expect(player).toHaveStatStage(Stat.SPD, 0);
+
+      game.move.use(MoveId.THUNDERBOLT);
+      await game.toEndOfTurn();
+
+      expect(player).toHaveStatStage(Stat.ATK, 1);
+      expect(player).toHaveStatStage(Stat.SPATK, 1);
+      expect(player).toHaveStatStage(Stat.SPD, 1);
+    });
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?
Battle Bond's alternate effect that increases Attack, Special Attack and Speed by 1 stage is implemented and will occur if a Pokémon other than Greninja has Battle Bond. The effect will apply once per switch-in, unlike mainline.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Requested by balance team.

## What are the changes from a developer perspective?
`PostVictoryStatStageChangeAbAttr` was updated to take either a single stat or an array of stats.
Battle Bond's `AbAttr`s were set to be conditional, with the form change attrs affecting only Greninja and the stat stage change attr affecting all non-Greninja Pokémon.
`PokemonSummonData#abilitiesApplied` was re-added to implement the once per switch in effect for the stat stage change.

## How to test the changes?
`pnpm test:silent battle-bond`

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary

Are there any localization additions or changes? If so:
- [x] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: https://github.com/pagefaultgames/pokerogue-locales/pull/279
- [x] I have contacted the Translation Team on Discord for proofreading/translation