### PR TITLE
github: use `pull_request_target` and `workflow_run` for label workflow

### DIFF
--- a/.github/workflows/detect-labels.yml
+++ b/.github/workflows/detect-labels.yml
@@ -1,0 +1,30 @@
+name: Detect Labels
+
+on:
+    pull_request_target:
+        types: [labeled]
+        branches:
+            - main
+            - beta
+            - release
+            - "hotfix*"
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: false
+
+jobs:
+    upload-label-data:
+        if: github.event.label.name == 'Awaiting Locales' || github.event.label.name == 'Update Locales' || github.event.label.name == 'Update Assets'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Save PR number
+              run: |
+                  mkdir -p ./pr
+                  echo ${{ github.event.number }} > ./pr/NR
+                  echo ${{ github.event.label.name }} > ./pr/LABEL
+                  echo ${{ github.event.pull_request.head.ref }} > ./pr/REF
+            - uses: actions/upload-artifact@v4
+              with:
+                  name: pr-data
+                  path: pr/

--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -1,63 +1,95 @@
 name: Update Submodule
 
 on:
-  pull_request:
-    branches:
-      - main
-      - beta
-      - release
-      - "hotfix*"
-    types: [labeled]
+  workflow_run:
+    workflows: ["Detect Labels"]
+    types: [completed]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
-
-permissions:
-  contents: write
-  pull-requests: write
+env:
+  GH_TOKEN: ${{ github.token }}
 
 jobs:
-  update-submodule-assets:
-    if: github.event.label.name == 'Update Assets'
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  read-label-data:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Download artifact"
+        uses: actions/github-script@v8
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr-data"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+            const fs = require('fs');
+            const path = require('path');
+            const temp = '${{ runner.temp }}/artifacts';
+            if (!fs.existsSync(temp)){
+              fs.mkdirSync(temp);
+            }
+            fs.writeFileSync(path.join(temp, 'pr-data.zip'), Buffer.from(download.data));
+
+      - name: "Unzip artifact"
+        run: unzip "${{ runner.temp }}/artifacts/pr-data.zip" -d "${{ runner.temp }}/artifacts"
+
+      - name: "Read label data"
+        id: read-label-data
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const temp = '${{ runner.temp }}/artifacts';
+            const prNumber = Number(fs.readFileSync(path.join(temp, 'NR')));
+            const label = fs.readFileSync(path.join(temp, 'LABEL')).toString().trim();
+            const ref = fs.readFileSync(path.join(temp, 'REF')).toString().trim();
+            core.setOutput('label', label);
+            core.setOutput('prNumber', prNumber);
+            core.setOutput('ref', ref);
+
+    outputs:
+      label: ${{ steps.read-label-data.outputs.label }}
+      prNumber: ${{ steps.read-label-data.outputs.prNumber }}
+      ref: ${{ steps.read-label-data.outputs.ref }}
+
+  block-pr:
+    needs: read-label-data
+    if: needs.read-label-data.outputs.label == 'Awaiting Locales'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ needs.read-label-data.outputs.ref }}
           sparse-checkout: |
-            assets
-            .gitmodules
+            .nvmrc
           sparse-checkout-cone-mode: false
 
-      - name: Update assets submodule
+      - name: "Block PR"
         run: |
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git submodule update --progress --init --recursive --force --depth 1 --remote assets
+          gh pr review ${{ needs.read-label-data.outputs.prNumber }} --request-changes --body "This pull request is blocked until the associated locales PR is merged.
+          To unblock and update the locales submodule, add the \`Update Locales\` label."
 
-      - name: Commit and push changes
-        run: |
-          git add assets
-          git commit -m "Update assets submodule" || echo "No changes to commit"
-          git push
-
-      - name: Remove label
-        run: gh pr edit ${{ github.event.pull_request.number }} --remove-label "Update Assets"
-
-  update-submodule-locales:
-    if: github.event.label.name == 'Update Locales'
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  update-locales:
+    needs: read-label-data
+    if: needs.read-label-data.outputs.label == 'Update Locales'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ needs.read-label-data.outputs.ref }}
           sparse-checkout: |
             locales
             .gitmodules
@@ -73,35 +105,48 @@ jobs:
         run: |
           git add locales
           git commit -m "Update locales submodule" || echo "No changes to commit"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          git push || true
 
       - name: Remove label
         run: |
-          gh pr edit ${{ github.event.pull_request.number }} --remove-label "Update Locales"
-          gh pr edit ${{ github.event.pull_request.number }} --remove-label "Awaiting Locales"
-          
-          REVIEW_ID=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews \
-            --jq '.[] | select(.user.login == "github-actions[bot]" and .state == "CHANGES_REQUESTED") | .id' | head -n 1)
+          gh pr edit ${{ needs.read-label-data.outputs.prNumber }} --remove-label "Update Locales"
+          gh pr edit ${{ needs.read-label-data.outputs.prNumber }} --remove-label "Awaiting Locales"
+
+      - name: Unblock PR
+        run: |
+          REVIEW_ID=$(gh api repos/${{ github.repository }}/pulls/${{ needs.read-label-data.outputs.prNumber }}/reviews \
+              --jq '.[] | select(.user.login == "github-actions[bot]" and .state == "CHANGES_REQUESTED") | .id' | head -n 1)
           if [ -n "$REVIEW_ID" ]; then
-            gh api --method PUT repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/$REVIEW_ID/dismissals \
+              gh api --method PUT repos/${{ github.repository }}/pulls/${{ needs.read-label-data.outputs.prNumber }}/reviews/$REVIEW_ID/dismissals \
               -f message="Locales updated, unblocking PR."
           fi
 
-  block-pull-request:
-    if: github.event.label.name == 'Awaiting Locales'
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  update-assets:
+    needs: read-label-data
+    if: needs.read-label-data.outputs.label == 'Update Assets'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ needs.read-label-data.outputs.ref }}
           sparse-checkout: |
-            .nvmrc
+            assets
+            .gitmodules
           sparse-checkout-cone-mode: false
 
-      - name: Block pull request
+      - name: Update assets submodule
         run: |
-          gh pr review ${{ github.event.pull_request.number }} --request-changes --body "This pull request is blocked until the associated locales PR is merged.
-          To unblock and update the locales submodule, add the \`Update Locales\` label."
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git submodule update --progress --init --recursive --force --depth 1 --remote assets
+
+      - name: Commit and push changes
+        run: |
+          git add assets
+          git commit -m "Update assets submodule" || echo "No changes to commit"
+          git push || true
+
+      - name: Remove label
+        run: |
+          gh pr edit ${{ needs.read-label-data.outputs.prNumber }} --remove-label "Update Assets"


### PR DESCRIPTION
## What are the changes the user will see?

N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

#7014 added a workflow that worked on a fork but not the main repo due to permisions

## What are the changes from a developer perspective?

instead of using `pull_request` trigger it now uses the `pull_request_target` and `workflow_run` triggers

## How to test the changes?

Who knows

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)