### PR TITLE
balance: catching and friendship won't increase candy past 9999

### DIFF
--- a/src/constants/game-constants.ts
+++ b/src/constants/game-constants.ts
@@ -1,0 +1,2 @@
+/** The maximum candy a starter is allowed to have. */
+export const MAX_STARTER_CANDY_COUNT = 9999;

--- a/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
+++ b/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
@@ -589,7 +589,7 @@ async function postProcessTransformedPokemon(
 
   // For pokemon that the player owns (including ones just caught), gain a candy
   if (!forBattle && !!globalScene.gameData.dexData[speciesRootForm].caughtAttr) {
-    globalScene.gameData.addStarterCandy(getPokemonSpecies(speciesRootForm), 1);
+    globalScene.gameData.addStarterCandy(speciesRootForm, 1);
   }
 
   // Set the moveset of the new pokemon to be the same as previous, but with 1 egg move and 1 (attempted) STAB move of the new species

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1787,21 +1787,25 @@ export class GameData {
   }
 
   /**
-   * Adds a candy to the player's game data for a given {@linkcode PokemonSpecies}.
-   * @param species
-   * @param count
+   * Adds candy to the player's game data for a given {@linkcode PokemonSpecies}.
+   * @remarks
+   * Will not increase the candy count past `9999`.
    */
-  addStarterCandy(species: PokemonSpecies, count: number): void {
-    globalScene.candyBar.showStarterSpeciesCandy(species.speciesId, count);
-    this.starterData[species.speciesId].candyCount += count;
+  public addStarterCandy(species: PokemonSpecies, count: number): void {
+    const { speciesId } = species;
+    const { candyCount } = this.starterData[speciesId];
+
+    if (candyCount >= 9999) {
+      return;
+    }
+
+    globalScene.candyBar.showStarterSpeciesCandy(speciesId, count);
+    this.starterData[speciesId].candyCount = Math.min(candyCount + count, 9999);
   }
 
   /**
-   *
-   * @param species
-   * @param eggMoveIndex
-   * @param showMessage Default true. If true, will display message for unlocked egg move
-   * @param prependSpeciesToMessage Default false. If true, will change message from "X Egg Move Unlocked!" to "Bulbasaur X Egg Move Unlocked!"
+   * @param showMessage - (Default `true`) Whether to display a message for the unlocked egg move
+   * @param prependSpeciesToMessage - (Default `false`) Whether to change the message from "X Egg Move Unlocked!" to "Bulbasaur X Egg Move Unlocked!"
    */
   setEggMoveUnlocked(
     species: PokemonSpecies,


### PR DESCRIPTION
## What are the changes the user will see?
Starter candy can't be increased past 9999 via catching or friendship gain.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Request by balance team.

## What are the changes from a developer perspective?
`GameData#addStarterCandy` now has checks to prevent increasing candy count past 9999.

## How to test the changes?
Set a starter to have 9999 candy and then catch one or increase its friendship in a run.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually