### PR TITLE
fix: stop off-field Pokemon from incorrectly form changing

### DIFF
--- a/src/phases/quiet-form-change-phase.ts
+++ b/src/phases/quiet-form-change-phase.ts
@@ -17,6 +17,7 @@ import { playTween } from "#utils/anim-utils";
 // TODO: Rename as the term "quiet" can be confusing
 export class QuietFormChangePhase extends BattlePhase {
   public readonly phaseName = "QuietFormChangePhase";
+
   public readonly pokemon: Pokemon;
   protected readonly formChange: SpeciesFormChange;
   /** The Pokemon's prior name before changing forms. */
@@ -24,6 +25,7 @@ export class QuietFormChangePhase extends BattlePhase {
 
   constructor(pokemon: Pokemon, formChange: SpeciesFormChange) {
     super();
+
     this.pokemon = pokemon;
     this.formChange = formChange;
   }
@@ -52,13 +54,15 @@ export class QuietFormChangePhase extends BattlePhase {
     }
   }
 
+  /**
+   * Helper function to show text upon changing forms and end the phase.
+   * @remarks
+   * Does not actually change the user's form.
+   */
   private showFormChangeTextAndEnd(): void {
-    globalScene.ui.showText(
-      getSpeciesFormChangeMessage(this.pokemon, this.formChange, this.preName),
-      null,
-      () => this.end(),
-      1500,
-    );
+    const { pokemon, formChange, preName } = this;
+    const { ui } = globalScene;
+    ui.showText(getSpeciesFormChangeMessage(pokemon, formChange, preName), null, () => this.end(), 1500);
   }
 
   /**
@@ -159,12 +163,8 @@ export class QuietFormChangePhase extends BattlePhase {
       duration: 1000,
     });
     pokemonTintSprite.setVisible(false);
-    globalScene.ui.showText(
-      getSpeciesFormChangeMessage(this.pokemon, this.formChange, this.preName),
-      null,
-      () => this.end(),
-      1500,
-    );
+
+    this.showFormChangeTextAndEnd();
   }
 
   private getPokemonSprite(): Phaser.GameObjects.Sprite {


### PR DESCRIPTION
## What are the changes the user will see?
Pokémon that are off the field won't incorrectly attempt to play a form change animation, preventing a crash.
Note: This bug was introduced in #6707 and is a beta-only bug.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Fixing a crash.

## What are the changes from a developer perspective?
Inverted a conditional in `QuietFormChangePhase`, added a missing `super.end()` and added a guard to prevent attempting to play animations for off-field Pokemon.

## How to test the changes?
Let Aegislash form change to Blade Forme and then knock it out. You should be able to proceed to the next wave without issue.
```ts
const overrides = {
  MOVESET_OVERRIDE: [MoveId.EARTH_POWER, MoveId.PROTECT],
  ENEMY_MOVESET_OVERRIDE: MoveId.TACKLE,
  ENEMY_SPECIES_OVERRIDE: SpeciesId.AEGISLASH,
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually