### PR TITLE
github: add indenting to changelog script output

### DIFF
--- a/scripts/changelog-reader/format.mjs
+++ b/scripts/changelog-reader/format.mjs
@@ -70,7 +70,15 @@ function formatPullRequest(pr) {
     return null;
   }
 
-  return `- #${pr.number}\n  - ${sanitizedBody}\n`;
+  const lines = sanitizedBody.split("\n");
+  const indentedBody = lines
+    .map((line, index) => {
+      const prefix = index === 0 && !line.trimStart().startsWith("- ") ? "  - " : "\t";
+      return line.trim() === "" ? "" : prefix + line;
+    })
+    .join("\n");
+
+  return `- #${pr.number}\n${indentedBody}\n`;
 }
 
 /**


### PR DESCRIPTION
## What are the changes the user will see?

N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

bad output previously

## What are the changes from a developer perspective?

added a section that indents each line

## Screenshots/Videos

<details><summary>Before</summary>

<img width="461" height="131" alt="image" src="https://github.com/user-attachments/assets/656a4735-35c7-4e44-a82b-34580ae2931a" />

</details>
<details><summary>After</summary>

<img width="533" height="130" alt="image" src="https://github.com/user-attachments/assets/621ebf53-0c2e-4679-a75e-7e3448179dc8" />

</details>

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `hotfix-1.11.7` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
- [x] I have provided screenshots/videos of the changes (if applicable)