### PR TITLE
fix: daily starters won't be male only anymore

### DIFF
--- a/src/data/daily-seed/daily-seed-utils.ts
+++ b/src/data/daily-seed/daily-seed-utils.ts
@@ -1,5 +1,6 @@
 import { globalScene } from "#app/global-scene";
 import { isBeta, isDev } from "#constants/app-constants";
+import { Gender } from "#data/gender";
 import type { PokemonSpecies } from "#data/pokemon-species";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
@@ -211,6 +212,7 @@ export function getDailyRunStarter(species: PokemonSpecies, config?: DailySeedSt
     passive: false,
     nature: pokemon.getNature(),
     pokerus: pokemon.pokerus,
+    female: pokemon.gender === Gender.FEMALE,
   };
   pokemon.destroy();
   return starter;


### PR DESCRIPTION
## What are the changes the user will see?

Daily starters won't be male only anymore

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

damo noticed

## What are the changes from a developer perspective?

actually use the rolled gender for daily starters

## Screenshots/Videos
<!--
If you are changing anything visual (UI/UX, locales changes, etc.), please include screenshot(s) and/or video(s) showing the changes within collapsible blocks, like below:

<details><summary>Before</summary>

[before screenshot here]

</details>
<details><summary>After</summary>

[after screenshot here]

</details>
-->

## How to test the changes?



## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `hotfix-1.11.7` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)
