### PR TITLE
refactor: clean up `updatePlayerMoney` in `encounter-phase-utils.ts`

### DIFF
--- a/src/data/mystery-encounters/encounters/the-pokemon-salesman-encounter.ts
+++ b/src/data/mystery-encounters/encounters/the-pokemon-salesman-encounter.ts
@@ -98,12 +98,13 @@ export const ThePokemonSalesmanEncounter: MysteryEncounter = MysteryEncounterBui
     );
 
     let pokemon: PlayerPokemon;
-    /**
+    /*
      * Mon is determined as follows:
-     * If you roll the 1% for Shiny Magikarp, you get Magikarp with a random variant
-     * If an event with more than 1 valid event encounter species is active, you have 20% chance to get one of those
-     * If the rolled species has no HA, and there are valid event encounters, you will get one of those
-     * If the rolled species has no HA and there are no valid event encounters, you will get Shiny Magikarp
+     * - If you roll the 1% for Shiny Magikarp, you get Magikarp with a random variant
+     * - If an event with more than 1 valid event encounter species is active, you have 20% chance to get one of those
+     * - If the rolled species has no HA, and there are valid event encounters, you will get one of those
+     * - If the rolled species has no HA and there are no valid event encounters, you will get Shiny Magikarp
+     *
      * Mons rolled from the event encounter pool get 3 extra shiny rolls
      */
     if (

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -463,36 +463,28 @@ export async function loadCustomMovesForEncounter(moves: MoveId | MoveId[]): Pro
 }
 
 /**
- * Will update player money, and animate change (sound optional)
- * @param changeValue
- * @param playSound
- * @param showMessage
+ * @param moneyAmount - The amount of money being added; negative values remove money
+ * @param playSound - (Default `true`) Whether to play a sound afterward
+ * @param showMessage - (Default `true`) Whether to show a message afterward
  */
-export function updatePlayerMoney(changeValue: number, playSound = true, showMessage = true): void {
-  globalScene.money = Math.min(Math.max(globalScene.money + changeValue, 0), Number.MAX_SAFE_INTEGER);
+export function updatePlayerMoney(moneyAmount: number, playSound = true, showMessage = true): void {
+  globalScene.money = Phaser.Math.Clamp(globalScene.money + moneyAmount, 0, Number.MAX_SAFE_INTEGER);
   globalScene.updateMoneyText();
-  globalScene.animateMoneyChanged(false);
+  const isIncrease = moneyAmount >= 0;
+  globalScene.animateMoneyChanged(isIncrease);
+
   if (playSound) {
     globalScene.playSound("se/buy");
   }
+
   if (showMessage) {
-    if (changeValue < 0) {
-      globalScene.phaseManager.queueMessage(
-        i18next.t("mysteryEncounterMessages:paidMoney", {
-          amount: -changeValue,
-        }),
-        null,
-        true,
-      );
-    } else {
-      globalScene.phaseManager.queueMessage(
-        i18next.t("mysteryEncounterMessages:receiveMoney", {
-          amount: changeValue,
-        }),
-        null,
-        true,
-      );
-    }
+    const i18nKey = isIncrease ? "receive" : "paid";
+    const amount = isIncrease ? moneyAmount : -moneyAmount;
+    globalScene.phaseManager.queueMessage(
+      i18next.t(`mysteryEncounterMessages:${i18nKey}Money`, { amount }),
+      null,
+      true,
+    );
   }
 }
 


### PR DESCRIPTION
## What are the changes the user will see?
The correct color tint will be used when animating the player's money count changing from choosing an ME option when the player gains money.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Saw some code that could be made better.

## What are the changes from a developer perspective?
Simplified `updatePlayerMoney` and added missing docs.
The correct tint color will now be applied if the player's money increases.

## How to test the changes?
Start an ME and choose an option that changes your money, such as from "The Pokémon Salesman" (decrease) or "An Offer You Can't Refuse" (increase).

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually