### PR TITLE
github: add "beta" scope for "fix" prefix

### DIFF
--- a/.github/scripts/pr-title.mts
+++ b/.github/scripts/pr-title.mts
@@ -61,6 +61,9 @@ const PREFIX_SCOPE_MAP = {
   test: ALL_SCOPES,
 } as const satisfies Record<Prefixes, readonly AllScopes[]>;
 
+// @ts-expect-error: Add special scope for fixing bugs that only existed on the beta branch
+PREFIX_SCOPE_MAP.fix = [...ALL_SCOPES, "beta"];
+
 async function run(): Promise<void> {
   try {
     const authToken = core.getInput("github_token", { required: true });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,3 +226,6 @@ Try to keep the title under 72 characters, as GitHub cuts off commit titles long
 > All scopes are valid when using the "docs", "feat", "fix", "refactor" and "test" prefixes. \
 > All scopes except "audio", "battle", "graphics", and "ui" are valid when using the "balance" prefix. \
 > No other prefixes have valid scopes.
+>
+> There is a special "beta" scope for the "fix" prefix,
+> for fixing bugs that only existed on the `beta` branch that never made it onto `main`.


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Adding a useful scope.

## What are the changes from a developer perspective?
PR titles can now be "`fix(beta): ...`" for fixing bugs that only existed on the `beta` branch.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually