### PR TITLE
fix(encounter): "The Pokemon Salesman" ME won't pick invalid Pokemon

### DIFF
--- a/src/data/mystery-encounters/encounters/the-pokemon-salesman-encounter.ts
+++ b/src/data/mystery-encounters/encounters/the-pokemon-salesman-encounter.ts
@@ -94,7 +94,12 @@ export const ThePokemonSalesmanEncounter: MysteryEncounter = MysteryEncounterBui
       false,
       false,
       false,
-      s => !NON_LEGEND_PARADOX_POKEMON.includes(s.speciesId) && !NON_LEGEND_ULTRA_BEASTS.includes(s.speciesId),
+      s =>
+        !NON_LEGEND_PARADOX_POKEMON.includes(s.speciesId)
+        && !NON_LEGEND_ULTRA_BEASTS.includes(s.speciesId)
+        && Object.keys(speciesStarterCosts) // The event expects the chosen pokemon to be a valid starter,
+          .map(sId => Number.parseInt(sId)) // and will break if a non-starter is chosen
+          .includes(s.speciesId),
     );
 
     let pokemon: PlayerPokemon;


### PR DESCRIPTION
## What are the changes the user will see?
"The Pokémon Salesman" ME will no longer offer invalid Pokémon, which would cause their cost to break and thus the player's money to also break.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Fixing a bug.

## What are the changes from a developer perspective?
Non-starters will be filtered out of the event Pokémon pool before being processed by "The Pokémon Salesman" ME, which expects all Pokémon offered to be starters and calculates their cost accordingly.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually