### PR TITLE
misc: reduce `target` to "ES2022" and polyfill "ES2023.Array"

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -24,3 +24,12 @@ import "core-js/stable/set";
 import "core-js/stable/iterator";
 import "core-js/stable/map/group-by";
 import "core-js/stable/object/group-by";
+
+// https://github.com/microsoft/TypeScript/blob/main/src/lib/es2023.array.d.ts
+
+import "core-js/stable/array/find-last";
+import "core-js/stable/array/find-last-index";
+import "core-js/stable/array/to-reversed";
+import "core-js/stable/array/to-sorted";
+import "core-js/stable/array/to-spliced";
+import "core-js/stable/array/with";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,18 +5,21 @@
  */
 {
   "compilerOptions": {
-    "target": "ES2023",
+    "target": "ES2022",
     "module": "ES2022",
     // Modifying this option requires all values to be set manually because the defaults get overridden
     // Values other than "ES2024.Promise" taken from https://github.com/microsoft/TypeScript/blob/main/src/lib/es2023.full.d.ts
     "lib": [
-      "ES2023",
-      "ES2024.Promise",
+      // ES2022 stdlibs
+      "ES2022",
       "DOM",
       "DOM.AsyncIterable",
       "DOM.Iterable",
       "ScriptHost",
       "WebWorker.ImportScripts",
+      // future libs
+      "ES2023.Array",
+      "ES2024.Promise",
       "ES2024.Object",
       // NOTE: Be *very* mindful of these when updating typescript versions,
       // as their definitions may change in breaking ways


### PR DESCRIPTION
## What are the changes the user will see?
Older browsers should be able to run the game again.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Old Chromebooks can't update to modern versions of Chrome (thanks Google) and thus can't use modern ES features.

## What are the changes from a developer perspective?
Reduced `target` in `tsconfig.json` from "ES2023" to "ES2022" and modified `lib` from `["ES2023", ...]` to `["ES2022", "ES2023.Array", ...]`, and added polyfills for all ES2023 `Array` features to `polyfills.ts`.

## How to test the changes?
Use an older browser that doesn't have ES2023 features (such as Chrome <= 103)?

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR