### PR TITLE
refactor: unify `HeldItemManager` and `TrainerItemManager`

### DIFF
--- a/src/@types/held-item-data-types.ts
+++ b/src/@types/held-item-data-types.ts
@@ -1,4 +1,4 @@
-import type { HeldItemCategoryId, HeldItemId } from "#enums/held-item-id";
+import { type HeldItemCategoryId, HeldItemId } from "#enums/held-item-id";
 import type { RarityTier } from "#enums/reward-tier";
 import type { Pokemon } from "#field/pokemon";
 import type { AllHeldItems } from "#items/all-held-items";
@@ -14,7 +14,7 @@ export interface HeldItemData {
    * Whether this item is currently disabled.
    * @defaultValue `false`
    */
-  disabled?: boolean;
+  disabled: boolean;
   /**
    * Whether a form change is active.
    * TODO: This is only temporary to make things work, form change rework should get rid of it.
@@ -30,12 +30,20 @@ export interface HeldItemSpecs extends HeldItemData {
 }
 
 // TODO: Move these getters with the rest of the item getters in a nice big file
-export function isHeldItemSpecs(entry: any): entry is HeldItemSpecs {
-  return typeof entry.id === "number" && "stack" in entry;
+export function isHeldItemSpecs(entry: unknown): entry is HeldItemSpecs {
+  if (typeof entry !== "object" || entry === null) {
+    return false;
+  }
+  return (
+    typeof (entry as HeldItemSpecs).id === "number"
+    && typeof (entry as HeldItemSpecs).stack === "number"
+    && (entry as HeldItemSpecs).id in HeldItemId
+  );
 }
 
 export type HeldItemWeights = Partial<Record<HeldItemId, number>>;
 
+// TODO: Inline this into the sole place it is used
 export type HeldItemWeightFunc = (party: Pokemon[]) => number;
 
 interface HeldItemCategoryEntry extends HeldItemData {
@@ -43,6 +51,8 @@ interface HeldItemCategoryEntry extends HeldItemData {
   customWeights?: HeldItemWeights;
 }
 
+// TODO: These predicate functions should use `unknown` instead of `any`, and should be reviewed to
+// avoid misclassifying types
 export function isHeldItemCategoryEntry(entry: any): entry is HeldItemCategoryEntry {
   return entry?.id && isHeldItemCategoryEntry(entry.id) && "customWeights" in entry;
 }

--- a/src/@types/trainer-item-data-types.ts
+++ b/src/@types/trainer-item-data-types.ts
@@ -1,23 +1,29 @@
-// TODO: move to `src/@types/`
 import type { RarityTier } from "#enums/reward-tier";
-import type { TrainerItemId } from "#enums/trainer-item-id";
+import { TrainerItemId } from "#enums/trainer-item-id";
 
 export interface TrainerItemData {
+  /** The stack count of the item, or its duration for duration-based trainer items. */
   stack: number;
   disabled?: boolean;
   cooldown?: number;
 }
 
-export type TrainerItemDataMap = {
-  [key in TrainerItemId]?: TrainerItemData;
-};
+export type TrainerItemDataMap = Map<TrainerItemId, TrainerItemData>;
 
 export interface TrainerItemSpecs extends TrainerItemData {
   id: TrainerItemId;
 }
 
-export function isTrainerItemSpecs(entry: any): entry is TrainerItemSpecs {
-  return typeof entry.id === "number" && "stack" in entry;
+// TODO: This should emphatically not be in "#types"
+export function isTrainerItemSpecs(entry: unknown): entry is TrainerItemSpecs {
+  if (typeof entry !== "object" || entry === null) {
+    return false;
+  }
+  return (
+    typeof (entry as TrainerItemSpecs).id === "number"
+    && typeof (entry as TrainerItemSpecs).stack === "number"
+    && (entry as TrainerItemSpecs).id in TrainerItemId
+  );
 }
 
 interface TrainerItemPoolEntry {

--- a/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
+++ b/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
@@ -302,7 +302,7 @@ export const ClowningAroundEncounter: MysteryEncounter = MysteryEncounterBuilder
 
         // Shuffles Berries (if they have any)
         const oldBerries = mostHeldItemsPokemon.heldItemManager
-          .getHeldItems()
+          .getItems()
           .filter(m => isItemInCategory(m, HeldItemCategoryId.BERRY));
 
         let numBerries = 0;

--- a/src/data/mystery-encounters/encounters/dark-deal-encounter.ts
+++ b/src/data/mystery-encounters/encounters/dark-deal-encounter.ts
@@ -149,7 +149,7 @@ export const DarkDealEncounter: MysteryEncounter = MysteryEncounterBuilder.withE
         const removedPokemon = getRandomPlayerPokemon(true, false, true);
 
         // Get all the pokemon's held items
-        const itemConfig = removedPokemon.heldItemManager.generateHeldItemConfiguration();
+        const itemConfig = removedPokemon.heldItemManager.generateItemConfiguration();
         globalScene.removePokemonFromPlayerParty(removedPokemon);
 
         const encounter = globalScene.currentBattle.mysteryEncounter!;

--- a/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
+++ b/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
@@ -211,7 +211,7 @@ export const GlobalTradeSystemEncounter: MysteryEncounter = MysteryEncounterBuil
         const tradedPokemon: PlayerPokemon = encounter.misc.tradedPokemon;
         const receivedPokemonData: EnemyPokemon = encounter.misc.receivedPokemon;
         const heldItemConfig = tradedPokemon.heldItemManager
-          .generateHeldItemConfiguration()
+          .generateItemConfiguration()
           .filter(ic => !isItemInCategory(ic.entry as HeldItemId, HeldItemCategoryId.SPECIES_STAT_BOOSTER));
 
         // Generate a trainer name
@@ -312,7 +312,7 @@ export const GlobalTradeSystemEncounter: MysteryEncounter = MysteryEncounterBuil
         const tradedPokemon: PlayerPokemon = encounter.misc.tradedPokemon;
         const receivedPokemonData: EnemyPokemon = encounter.misc.receivedPokemon;
         const heldItemConfig = tradedPokemon.heldItemManager
-          .generateHeldItemConfiguration()
+          .generateItemConfiguration()
           .filter(ic => !isItemInCategory(ic.entry as HeldItemId, HeldItemCategoryId.SPECIES_STAT_BOOSTER));
 
         // Generate a trainer name

--- a/src/data/mystery-encounters/encounters/training-session-encounter.ts
+++ b/src/data/mystery-encounters/encounters/training-session-encounter.ts
@@ -358,7 +358,7 @@ function getEnemyConfig(playerPokemon: PlayerPokemon, segments: number): EnemyPa
 
   // Passes modifiers by reference
   // TODO: fix various things, like make enemy items untransferable, make sure form change items can come back
-  const config = playerPokemon.heldItemManager.generateHeldItemConfiguration();
+  const config = playerPokemon.heldItemManager.generateItemConfiguration();
 
   const data = new PokemonData(playerPokemon);
   return {

--- a/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
+++ b/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
@@ -387,7 +387,7 @@ function getTeamTransformations(): PokemonTransformation[] {
   for (let i = 0; i < numPokemon; i++) {
     const removed = removedPokemon[i];
     const index = pokemonTransformations.findIndex(p => p.previousPokemon.id === removed.id);
-    pokemonTransformations[index].heldItems = removed.heldItemManager.generateHeldItemConfiguration();
+    pokemonTransformations[index].heldItems = removed.heldItemManager.generateItemConfiguration();
 
     const bst = removed.getSpeciesForm().getBaseStatTotal();
     let newBstRange: [number, number];

--- a/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
@@ -687,7 +687,7 @@ export async function catchPokemon(
                       pokemon.variant,
                       pokemon.ivs,
                       pokemon.nature,
-                      pokemon.heldItemManager.generateHeldItemConfiguration(),
+                      pokemon.heldItemManager.generateItemConfiguration(),
                       pokemon,
                     );
                     globalScene.ui.setMode(

--- a/src/data/pokemon-forms/form-change-triggers.ts
+++ b/src/data/pokemon-forms/form-change-triggers.ts
@@ -88,7 +88,7 @@ export class SpeciesFormChangeItemTrigger extends SpeciesFormChangeTrigger {
   }
 
   canChange(pokemon: Pokemon): boolean {
-    const matchItem = pokemon.heldItemManager.heldItems[this.item];
+    const matchItem = pokemon.heldItemManager.getItemSpecs(this.item);
     if (!matchItem) {
       return false;
     }

--- a/src/enums/held-item-id.ts
+++ b/src/enums/held-item-id.ts
@@ -1,5 +1,6 @@
 import type { ObjectValues } from "#types/type-helpers";
 import { FormChangeItemId } from "./form-change-item-id";
+import type { TrainerItemId } from "./trainer-item-id";
 
 // TODO: make category the lower 2 bytes
 // TODO: Create subsets of HeldItemId for different types of items
@@ -153,3 +154,5 @@ export function isItemInCategory(itemId: HeldItemId, category: HeldItemCategoryI
 export function isItemInRequested(itemId: HeldItemId, requestedItems: (HeldItemCategoryId | HeldItemId)[]): boolean {
   return requestedItems.some(entry => itemId === entry || (itemId & ITEM_CATEGORY_MASK) === entry);
 }
+
+declare const EnsureHeldItemsAndTrainerItemsDontOverlap: (HeldItemId & TrainerItemId) | 1;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1157,7 +1157,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   // TODO: Review uses of this function - callers should try to use the held item manager's utils where possible
   getHeldItems(): HeldItemId[] {
-    return this.heldItemManager.getHeldItems();
+    return this.heldItemManager.getItems();
   }
 
   updateScale(): void {
@@ -5977,7 +5977,7 @@ export class PlayerPokemon extends Pokemon {
           this.variant,
           this.ivs,
           this.nature,
-          this.heldItemManager.generateHeldItemConfiguration(),
+          this.heldItemManager.generateItemConfiguration(),
           this,
         );
         this.fusionSpecies = originalFusionSpecies;
@@ -6000,7 +6000,7 @@ export class PlayerPokemon extends Pokemon {
           this.variant,
           this.ivs,
           this.nature,
-          this.heldItemManager.generateHeldItemConfiguration(),
+          this.heldItemManager.generateItemConfiguration(),
           this,
         );
       }
@@ -6154,7 +6154,7 @@ export class PlayerPokemon extends Pokemon {
         this.variant,
         this.ivs,
         this.nature,
-        this.heldItemManager.generateHeldItemConfiguration(),
+        this.heldItemManager.generateItemConfiguration(),
         this,
       );
       ret.loadAssets().then(() => resolve(ret));
@@ -6970,7 +6970,7 @@ export class EnemyPokemon extends Pokemon {
         this.variant,
         this.ivs,
         this.nature,
-        this.heldItemManager.generateHeldItemConfiguration(),
+        this.heldItemManager.generateItemConfiguration(),
         this,
       );
 

--- a/src/items/all-trainer-items.ts
+++ b/src/items/all-trainer-items.ts
@@ -126,7 +126,7 @@ export function applyTrainerItems<T extends TrainerItemEffect>(
   params: TrainerItemEffectParamMap[T],
 ) {
   if (manager) {
-    for (const item of Object.keys(manager.trainerItems)) {
+    for (const item of manager.items.keys()) {
       if (allTrainerItems[item].effects.includes(effect)) {
         allTrainerItems[item].apply(manager, params);
       }

--- a/src/items/held-item-manager.ts
+++ b/src/items/held-item-manager.ts
@@ -7,199 +7,93 @@ import {
   isItemInCategory,
   isItemInRequested,
 } from "#enums/held-item-id";
-import {
-  type HeldItemConfiguration,
-  type HeldItemDataMap,
-  type HeldItemSaveData,
-  type HeldItemSpecs,
-  isHeldItemSpecs,
-} from "#types/held-item-data-types";
+import { ItemManager } from "#items/item-manager";
+import { type HeldItemData, type HeldItemSpecs, isHeldItemSpecs } from "#types/held-item-data-types";
 
 /**
  * The `HeldItemManager` is a manager for a {@linkcode Pokemon}'s held items. \
  * It stores data about the items its associated `Pokemon` is holding,
  * with methods to query, retrieve and alter them as needed.
  */
-export class HeldItemManager {
-  // TODO: There should be a way of making these private...
-  public heldItems: HeldItemDataMap = new Map();
-
-  getItemSpecs(id: HeldItemId): HeldItemSpecs | undefined {
-    const item = this.heldItems.get(id);
-    if (!item) {
-      return;
-    }
-    return {
-      ...item,
-      id,
-    };
+export class HeldItemManager extends ItemManager<HeldItemId, HeldItemData, HeldItemSpecs> {
+  // #region Abstract method implementations
+  protected override getMaxStackCount(id: HeldItemId): number {
+    return allHeldItems[id].getMaxStackCount();
   }
 
-  // TODO: This is never called with a restricted ID array ever
-  // TODO: Would an array of `HeldItemSpecs` make more sense as a return value?
-  // We're literally just bundling these into objects with counts of 1 apiece
-  generateHeldItemConfiguration(restrictedIds?: HeldItemId[]): HeldItemConfiguration {
-    const config: HeldItemConfiguration = [];
-    for (const [id, item] of this.heldItems) {
-      // TODO: `in` breaks with arrays
-      if (!restrictedIds || restrictedIds.includes(id)) {
-        const specs: HeldItemSpecs = { ...item, id };
-        config.push({ entry: specs, count: 1 });
-      }
-    }
-    return config;
+  protected override isSpecs(entry: unknown): entry is HeldItemSpecs {
+    return isHeldItemSpecs(entry);
   }
 
-  // TODO: Rename to "getAllItemSpecs" or similar
-  generateSaveData(): HeldItemSaveData {
-    const saveData: HeldItemSaveData = [];
-    for (const [id, item] of this.heldItems) {
-      const specs: HeldItemSpecs = { ...item, id };
-      saveData.push(specs);
-    }
-    return saveData;
-  }
+  // #region HeldItem-specific methods
 
   // TODO: Condense these all into a single generic function that takes an arbitrary predicate,
   // and then export several pre-made predicates ready for use
   // TODO: These functions should return iterators rather than less efficient arrays
-  getHeldItems(): HeldItemId[] {
-    return Array.from(this.heldItems.keys());
+  // once `getItems` is changed to do the same
+  public getTransferableHeldItems(): HeldItemId[] {
+    return this.getItems().filter(k => allHeldItems[k].isTransferable);
   }
 
-  getTransferableHeldItems(): HeldItemId[] {
-    return this.getHeldItems().filter(k => allHeldItems[k].isTransferable);
+  public getStealableHeldItems(): HeldItemId[] {
+    return this.getItems().filter(k => allHeldItems[k].isStealable);
   }
 
-  getStealableHeldItems(): HeldItemId[] {
-    return this.getHeldItems().filter(k => allHeldItems[k].isStealable);
+  public getSuppressableHeldItems(): HeldItemId[] {
+    return this.getItems().filter(k => allHeldItems[k].isSuppressable);
   }
 
-  getSuppressableHeldItems(): HeldItemId[] {
-    return this.getHeldItems().filter(k => allHeldItems[k].isSuppressable);
-  }
-
-  hasItem(itemType: HeldItemId | HeldItemCategoryId): boolean {
+  public override hasItem(itemType: HeldItemId | HeldItemCategoryId): boolean {
     if (isCategoryId(itemType)) {
-      return this.getHeldItems().some(id => isItemInCategory(id, itemType));
+      return this.getItems().some(id => isItemInCategory(id, itemType));
     }
-    return this.heldItems.has(itemType);
+    return super.hasItem(itemType);
   }
 
-  hasTransferableItem(itemType: HeldItemId | HeldItemCategoryId): boolean {
+  public hasTransferableItem(itemType: HeldItemId | HeldItemCategoryId): boolean {
     if (isCategoryId(itemType)) {
-      return this.getHeldItems().some(
-        id => isItemInCategory(id, itemType as HeldItemCategoryId) && allHeldItems[id].isTransferable,
-      );
+      return this.getItems().some(id => isItemInCategory(id, itemType) && allHeldItems[id].isTransferable);
     }
-    return this.heldItems.has(itemType) && allHeldItems[itemType].isTransferable;
-  }
-
-  // TODO: Consider renaming?
-  getStack(itemType: HeldItemId): number {
-    const item = this.heldItems.get(itemType);
-    return item?.stack ?? 0;
+    return this.items.has(itemType) && allHeldItems[itemType].isTransferable;
   }
 
   // Use for tests if necessary to go over stack limit
-  // TODO: Do we need this? This is solely used for grip claw
-  setStack(itemType: HeldItemId, stack: number): void {
-    const item = this.heldItems.get(itemType);
+  // TODO: Remove - this is solely used for grip claw, and any tests that require exceeding the stack limit can simply access the underlying map
+  // (not that exceeding the stack limit should be a thing we test for anyways; a more appropriate approach would be stubbing out relevant functions)
+  public setStack(itemType: HeldItemId, stack: number): void {
+    const item = this.items.get(itemType);
     if (item) {
       item.stack = stack;
     }
   }
 
-  isMaxStack(itemType: HeldItemId): boolean {
-    const item = this.heldItems.get(itemType);
-    return !!item && item.stack >= allHeldItems[itemType].getMaxStackCount();
-  }
-
-  add(itemType: HeldItemSpecs): boolean;
-  add(itemType: HeldItemId | HeldItemSpecs, addStack?: number): boolean;
-  add(itemType: HeldItemId | HeldItemSpecs, addStack = 1): boolean {
-    if (isHeldItemSpecs(itemType)) {
-      return this.addItemWithSpecs(itemType);
-    }
-
-    const maxStack = allHeldItems[itemType].getMaxStackCount();
-    const item = this.heldItems.get(itemType);
-
-    if (!item) {
-      this.heldItems.set(itemType, { stack: Math.min(addStack, maxStack) });
-      return true;
-    }
-
-    // TODO: We may want an error message of some kind instead
-    if (item.stack < maxStack) {
-      item.stack = Math.min(item.stack + addStack, maxStack);
-      return true;
-    }
-
-    return false;
-  }
-
-  addItemWithSpecs(itemSpecs: HeldItemSpecs): boolean {
-    const id = itemSpecs.id;
-    const maxStack = allHeldItems[id].getMaxStackCount();
-    const existing = this.heldItems.get(id);
-
-    const tempStack = existing?.stack ?? 0;
-
-    this.heldItems.set(id, {
-      ...itemSpecs,
-      stack: Math.min(itemSpecs.stack + tempStack, maxStack),
-    });
-
-    return true;
-  }
-
-  // TODO: Merge `removeStack` and `all` into 1 parameter to avoid passing useless values for the former
-  remove(itemType: HeldItemId, removeStack = 1, all = false) {
-    const item = this.heldItems.get(itemType);
-
-    if (!item) {
-      return;
-    }
-    item.stack -= removeStack;
-
-    if (all || item.stack <= 0) {
-      this.heldItems.delete(itemType);
-    }
-  }
-
-  filterRequestedItems(requestedItems: (HeldItemCategoryId | HeldItemId)[], transferableOnly = true, exclude = false) {
-    const currentItems = transferableOnly ? this.getTransferableHeldItems() : this.getHeldItems();
+  public filterRequestedItems(
+    requestedItems: (HeldItemCategoryId | HeldItemId)[],
+    transferableOnly = true,
+    exclude = false,
+  ) {
+    const currentItems = transferableOnly ? this.getTransferableHeldItems() : this.getItems();
 
     return currentItems.filter(it => !exclude && isItemInRequested(it, requestedItems));
   }
 
-  getHeldItemCount(): number {
-    return this.heldItems.values().reduce((acc, { stack }) => acc + stack, 0);
+  public hasActiveFormChangeItem(id: FormChangeItemId): boolean {
+    return !!this.items.get(id)?.active;
   }
 
-  hasActiveFormChangeItem(id: FormChangeItemId): boolean {
-    return !!this.heldItems.get(id)?.active;
-  }
-
-  getFormChangeItems(): FormChangeItemId[] {
+  public getFormChangeItems(): FormChangeItemId[] {
     return this.filterRequestedItems(
       [HeldItemCategoryId.FORM_CHANGE, HeldItemCategoryId.RARE_FORM_CHANGE],
       false,
     ) as FormChangeItemId[];
   }
 
-  toggleActive(id: FormChangeItemId): void {
-    const item = this.heldItems.get(id);
+  public toggleActive(id: FormChangeItemId): void {
+    const item = this.items.get(id);
     if (item) {
       item.active = !item.active;
     }
   }
 
-  /**
-   * Remove all item data from the manager.
-   */
-  clearItems(): void {
-    this.heldItems.clear();
-  }
+  // #endregion
 }

--- a/src/items/held-item-pool.ts
+++ b/src/items/held-item-pool.ts
@@ -86,7 +86,7 @@ export function assignEnemyHeldItemsForWave(
   poolType: HeldItemPoolType.WILD | HeldItemPoolType.TRAINER,
   upgradeChance = 0,
 ): void {
-  const existingItemCount = enemy.heldItemManager.getHeldItemCount();
+  const existingItemCount = enemy.heldItemManager.getItemCount();
   count -= existingItemCount;
   if (count <= 0) {
     return;

--- a/src/items/item-manager.ts
+++ b/src/items/item-manager.ts
@@ -1,0 +1,148 @@
+/**
+ * Abstract base class for item managers. \
+ * Stores a `Map` of item IDs to their associated data, with shared methods
+ * for querying, retrieving, and altering them.
+ *
+ * @typeParam Id - The numeric ID of the items being stored
+ * @typeParam Data - The data type associated with the given ID; must include
+ * @typeParam Specs - The serializable item specification type (Data + `id`).
+ */
+// NB: To anyone looking at this, please upvote https://github.com/microsoft/TypeScript/issues/7061
+// so we can make `Specs` a proper type alias instead of a free type parameter and remove numerous `as Specs` calls
+export abstract class ItemManager<
+  Id extends number,
+  // TODO: Restrict `Data` to have `stack` as the only allowed non-optional property (which would hopefully shut up the type errors);
+  // this will be untenable until after a beta merge since `exactOptionalPropertyTypes` is disabled atm
+  Data extends { stack: number },
+  Specs extends Data & { id: Id } = Data & { id: Id },
+> {
+  protected readonly items: Map<Id, Data> = new Map();
+
+  /** Look up the item definition's max stack count for the given ID. */
+  protected abstract getMaxStackCount(id: Id): number;
+
+  /** Type guard to check whether an input is a full `Specs` object. */
+  protected abstract isSpecs(entry: Id | Specs): entry is Specs;
+
+  public getItemSpecs(id: Id): Specs | undefined {
+    const item = this.items.get(id);
+    if (!item) {
+      return;
+    }
+    return {
+      ...item,
+      id,
+    } as Specs;
+  }
+
+  /**
+   * Build an item configuration array from all currently held items.
+   * @param restrictedIds - If provided, only include items whose ID is in this array.
+   */
+  // TODO: This is never called with a restricted ID array ever
+  // TODO: Would an array of `Specs` make more sense as a return value?
+  // We're literally just bundling these into objects with counts of 1 apiece
+  public generateItemConfiguration(restrictedIds?: Id[]): { entry: Specs; count: 1 }[] {
+    const config: { entry: Specs; count: 1 }[] = [];
+    for (const [id, item] of this.items) {
+      if (!restrictedIds || restrictedIds.includes(id)) {
+        const specs = { ...item, id } as Specs;
+        config.push({ entry: specs, count: 1 });
+      }
+    }
+    return config;
+  }
+
+  // TODO: Rename to `getAllItemSpecs` or something more illustrative of its functionality
+  public generateSaveData(): Specs[] {
+    const saveData: Specs[] = [];
+    for (const [id, item] of this.items) {
+      const specs = { ...item, id } as Specs;
+      saveData.push(specs);
+    }
+    return saveData;
+  }
+
+  // TODO: Return an iterator for efficiency; we already provide an arity function
+  // and polyfill all ES2025 iterator methods
+  public getItems(): Id[] {
+    return Array.from(this.items.keys());
+  }
+
+  public getItemCount(): number {
+    return this.items.size;
+  }
+
+  public hasItem(itemType: Id): boolean {
+    return this.items.has(itemType);
+  }
+
+  // TODO: Consider renaming to `getStackCount`
+  public getStack(itemType: Id): number {
+    const item = this.items.get(itemType);
+    return item?.stack ?? 0;
+  }
+
+  public isMaxStack(itemType: Id): boolean {
+    const item = this.items.get(itemType);
+    return !!item && item.stack >= this.getMaxStackCount(itemType);
+  }
+
+  public add(itemType: Specs): boolean;
+  public add(itemType: Id | Specs, qty?: number): boolean;
+  public add(itemType: Id | Specs, qty = 1): boolean {
+    if (this.isSpecs(itemType)) {
+      return this.addItemWithSpecs(itemType);
+    }
+    const maxStack = this.getMaxStackCount(itemType);
+
+    const item = this.items.get(itemType);
+    if (!item) {
+      this.items.set(itemType, { stack: Math.min(qty, maxStack) } as Data);
+      return true;
+    }
+
+    // TODO: We may want an error message of some kind instead
+    if (item.stack < maxStack) {
+      item.stack = Math.min(item.stack + qty, maxStack);
+      return true;
+    }
+
+    return false;
+  }
+
+  private addItemWithSpecs(itemSpecs: Specs): boolean {
+    const { id } = itemSpecs;
+    const maxStack = this.getMaxStackCount(id);
+    const existing = this.items.get(id);
+
+    const tempStack = existing?.stack ?? 0;
+
+    this.items.set(id, {
+      ...itemSpecs,
+      stack: Math.min(itemSpecs.stack + tempStack, maxStack),
+    } as unknown as Data);
+
+    return true;
+  }
+
+  // TODO: Merge `removeStack` and `all` into 1 parameter to avoid passing useless values for the former
+  public remove(itemType: Id, removeStack = 1, all = false): void {
+    const item = this.items.get(itemType);
+    if (!item) {
+      return;
+    }
+
+    item.stack -= removeStack;
+    if (all || item.stack <= 0) {
+      this.items.delete(itemType);
+    }
+  }
+
+  /**
+   * Remove all item data from the manager.
+   */
+  public clearItems(): void {
+    this.items.clear();
+  }
+}

--- a/src/items/trainer-item-manager.ts
+++ b/src/items/trainer-item-manager.ts
@@ -1,158 +1,39 @@
 import { allTrainerItems } from "#data/data-lists";
 import type { TrainerItemId } from "#enums/trainer-item-id";
-import {
-  isTrainerItemSpecs,
-  type TrainerItemConfiguration,
-  type TrainerItemDataMap,
-  type TrainerItemSaveData,
-  type TrainerItemSpecs,
-} from "#types/trainer-item-data-types";
-import { getTypedEntries, getTypedKeys } from "#utils/common";
+import { ItemManager } from "#items/item-manager";
+import { isTrainerItemSpecs, type TrainerItemData, type TrainerItemSpecs } from "#types/trainer-item-data-types";
 
-// TODO: Merge similar methods with those from `HeldItemManager` and move them into a shared subclass
-export class TrainerItemManager {
-  public trainerItems: TrainerItemDataMap;
-
-  constructor() {
-    this.trainerItems = {};
+// TODO: Remove unused methods
+export class TrainerItemManager extends ItemManager<TrainerItemId, TrainerItemData, TrainerItemSpecs> {
+  // #region Abstract method implementations
+  protected override getMaxStackCount(id: TrainerItemId): number {
+    return allTrainerItems[id].getMaxStackCount();
   }
 
-  getItemSpecs(id: TrainerItemId): TrainerItemSpecs | undefined {
-    const item = this.trainerItems[id];
-    if (item) {
-      const itemSpecs: TrainerItemSpecs = {
-        ...item,
-        id,
-      };
-      return itemSpecs;
-    }
-    return;
+  protected override isSpecs(entry: TrainerItemId | TrainerItemSpecs): entry is TrainerItemSpecs {
+    return isTrainerItemSpecs(entry);
   }
 
-  generateTrainerItemConfiguration(restrictedIds?: TrainerItemId[]): TrainerItemConfiguration {
-    const config: TrainerItemConfiguration = [];
-    for (const [id, item] of getTypedEntries(this.trainerItems)) {
-      if (item && (!restrictedIds || id in restrictedIds)) {
-        const specs: TrainerItemSpecs = { ...item, id };
-        config.push({ entry: specs, count: 1 });
-      }
-    }
-    return config;
-  }
+  // #endregion Abstract method implementations
 
-  generateSaveData(): TrainerItemSaveData {
-    const saveData: TrainerItemSaveData = [];
-    for (const [id, item] of getTypedEntries(this.trainerItems)) {
-      if (item) {
-        const specs: TrainerItemSpecs = { ...item, id };
-        saveData.push(specs);
-      }
-    }
-    return saveData;
-  }
+  // #region TrainerItem-specific methods
 
-  getTrainerItems(): TrainerItemId[] {
-    return getTypedKeys(this.trainerItems);
-  }
-
-  hasItem(itemType: TrainerItemId): boolean {
-    return itemType in this.trainerItems;
-  }
-
-  getStack(itemType: TrainerItemId): number {
-    const item = this.trainerItems[itemType];
-    return item?.stack ?? 0;
-  }
-
-  isMaxStack(itemType: TrainerItemId): boolean {
-    const item = this.trainerItems[itemType];
-    return item ? item.stack >= allTrainerItems[itemType].getMaxStackCount() : false;
-  }
-
-  overrideItems(newItems: TrainerItemDataMap) {
-    this.trainerItems = newItems;
-    // The following is to allow randomly generated item configs to have stack 0
-    for (const [item, properties] of Object.entries(this.trainerItems)) {
-      if (!properties || properties.stack <= 0) {
-        delete this.trainerItems[item];
-      }
-    }
-  }
-
-  add(itemType: TrainerItemId | TrainerItemSpecs, addStack?: number): boolean {
-    if (isTrainerItemSpecs(itemType)) {
-      return this.addItemWithSpecs(itemType);
-    }
-
-    if (!addStack) {
-      addStack = allTrainerItems[itemType].isLapsing ? allTrainerItems[itemType].getMaxStackCount() : 1;
-    }
-    const maxStack = allTrainerItems[itemType].getMaxStackCount();
-    const item = this.trainerItems[itemType];
-
-    if (item) {
-      // TODO: We may want an error message of some kind instead
-      if (item.stack < maxStack) {
-        item.stack = Math.min(item.stack + addStack, maxStack);
-        return true;
-      }
-    } else {
-      this.trainerItems[itemType] = { stack: Math.min(addStack, maxStack) };
-      return true;
-    }
-    return false;
-  }
-
-  addItemWithSpecs(itemSpecs: TrainerItemSpecs): boolean {
-    const id = itemSpecs.id;
-    const maxStack = allTrainerItems[id].getMaxStackCount();
-    const item = this.trainerItems[id];
-
-    const tempStack = item?.stack ?? 0;
-
-    this.trainerItems[id] = itemSpecs;
-    this.trainerItems[id].stack = Math.min(itemSpecs.stack + tempStack, maxStack);
-
-    return true;
-  }
-
-  remove(itemType: TrainerItemId, removeStack = 1, all = false) {
-    const item = this.trainerItems[itemType];
-
-    if (item) {
-      item.stack -= removeStack;
-
-      if (all || item.stack <= 0) {
-        delete this.trainerItems[itemType];
-      }
-    }
-  }
-
-  filterRequestedItems(requestedItems: TrainerItemId[], exclude = false) {
-    const currentItems = this.getTrainerItems();
+  public filterRequestedItems(requestedItems: TrainerItemId[], exclude = false) {
+    const currentItems = this.getItems();
     return currentItems.filter(it => !exclude && requestedItems.some(entry => it === entry));
   }
 
-  getTrainerItemCount(): number {
-    let total = 0;
-    for (const properties of Object.values(this.trainerItems)) {
-      total += properties?.stack ?? 0;
-    }
-    return total;
-  }
-
-  lapseItems(): void {
-    for (const [item, properties] of Object.entries(this.trainerItems)) {
-      if (allTrainerItems[item].isLapsing && properties) {
-        properties.stack -= 1;
-      }
-      if (!properties || properties.stack <= 0) {
-        delete this.trainerItems[item];
+  /**
+   * Decrease the durations of all duration-based trainer items on turn end.
+   */
+  // TODO: We should avoid reusing the nebulous "lapse" terminology and name this something like "decreaseDurations"/etc.
+  public lapseItems(): void {
+    for (const item of this.items.keys()) {
+      if (allTrainerItems[item].isLapsing) {
+        this.remove(item, 1);
       }
     }
   }
 
-  clearItems() {
-    this.trainerItems = {};
-  }
+  // #endregion
 }

--- a/src/phases/attempt-capture-phase.ts
+++ b/src/phases/attempt-capture-phase.ts
@@ -281,7 +281,7 @@ export class AttemptCapturePhase extends PokemonPhase {
       }),
       null,
       () => {
-        const heldItemConfig = pokemon.heldItemManager.generateHeldItemConfiguration();
+        const heldItemConfig = pokemon.heldItemManager.generateItemConfiguration();
         const end = () => {
           globalScene.phaseManager.unshiftNew("VictoryPhase", this.battlerIndex);
           globalScene.pokemonInfoContainer.hide();

--- a/src/ui/handlers/run-info-ui-handler.ts
+++ b/src/ui/handlers/run-info-ui-handler.ts
@@ -887,7 +887,7 @@ export class RunInfoUiHandler extends UiHandler {
         this.runInfo.gameMode === GameModes.SPLICED_ENDLESS || this.runInfo.gameMode === GameModes.ENDLESS ? 0.25 : 0.5;
       const heldItemsContainer = globalScene.add.container(-82, 2);
       let row = 0;
-      for (const [index, item] of pokemon.heldItemManager.getHeldItems().sort(heldItemSortFunc).entries()) {
+      for (const [index, item] of pokemon.heldItemManager.getItems().sort(heldItemSortFunc).entries()) {
         if (index > 36) {
           const overflowIcon = addTextObject(182, 4, "+", TextStyle.WINDOW);
           heldItemsContainer.add(overflowIcon);

--- a/src/ui/item-bar-ui.ts
+++ b/src/ui/item-bar-ui.ts
@@ -28,7 +28,7 @@ export class ItemBar extends Phaser.GameObjects.Container {
   updateItems(trainerItems: TrainerItemManager, pokemonA?: Pokemon, pokemonB?: Pokemon) {
     this.removeAll(true);
 
-    const sortedTrainerItems = trainerItems.getTrainerItems().sort(trainerItemSortFunc);
+    const sortedTrainerItems = trainerItems.getItems().sort(trainerItemSortFunc);
 
     const heldItemsA = pokemonA ? pokemonA.getHeldItems().sort(heldItemSortFunc) : [];
     const heldItemsB = pokemonB ? pokemonB.getHeldItems().sort(heldItemSortFunc) : [];

--- a/src/utils/items.ts
+++ b/src/utils/items.ts
@@ -6,7 +6,7 @@ import type { HeldItemEffectParamMap } from "#types/held-item-parameter";
 
 export function applyHeldItems<T extends HeldItemEffect>(effect: T, params: HeldItemEffectParamMap[T]) {
   const { pokemon } = params;
-  for (const item of pokemon.heldItemManager.getHeldItems()) {
+  for (const item of pokemon.heldItemManager.getItems()) {
     const heldItem = allHeldItems[item];
     if ("effects" in heldItem && heldItem.effects.includes(effect) && heldItem.shouldApply(effect, params)) {
       heldItem.apply(effect, params);

--- a/test/items/grip-claw.test.ts
+++ b/test/items/grip-claw.test.ts
@@ -46,9 +46,9 @@ describe("Items - Grip Claw", () => {
     const enemyPokemon = game.scene.getEnemyField();
     playerPokemon.heldItemManager.setStack(HeldItemId.GRIP_CLAW, 10);
 
-    const playerHeldItemCount = playerPokemon.heldItemManager.getHeldItemCount();
-    const enemy1HeldItemCount = enemyPokemon[0].heldItemManager.getHeldItemCount();
-    const enemy2HeldItemCount = enemyPokemon[1].heldItemManager.getHeldItemCount();
+    const playerHeldItemCount = playerPokemon.heldItemManager.getItemCount();
+    const enemy1HeldItemCount = enemyPokemon[0].heldItemManager.getItemCount();
+    const enemy2HeldItemCount = enemyPokemon[1].heldItemManager.getItemCount();
     expect(enemy2HeldItemCount).toBeGreaterThan(0);
 
     game.move.select(MoveId.TACKLE, 0, BattlerIndex.ENEMY_2);
@@ -56,9 +56,9 @@ describe("Items - Grip Claw", () => {
 
     await game.phaseInterceptor.to("BerryPhase", false);
 
-    const playerHeldItemCountAfter = playerPokemon.heldItemManager.getHeldItemCount();
-    const enemy1HeldItemCountsAfter = enemyPokemon[0].heldItemManager.getHeldItemCount();
-    const enemy2HeldItemCountsAfter = enemyPokemon[1].heldItemManager.getHeldItemCount();
+    const playerHeldItemCountAfter = playerPokemon.heldItemManager.getItemCount();
+    const enemy1HeldItemCountsAfter = enemyPokemon[0].heldItemManager.getItemCount();
+    const enemy2HeldItemCountsAfter = enemyPokemon[1].heldItemManager.getItemCount();
 
     expect(playerHeldItemCountAfter).toBe(playerHeldItemCount + 1);
     expect(enemy1HeldItemCountsAfter).toBe(enemy1HeldItemCount);
@@ -71,9 +71,9 @@ describe("Items - Grip Claw", () => {
     const playerPokemon = game.field.getPlayerPokemon();
     const enemyPokemon = game.scene.getEnemyField();
 
-    const playerHeldItemCount = playerPokemon.heldItemManager.getHeldItemCount();
-    const enemy1HeldItemCount = enemyPokemon[0].heldItemManager.getHeldItemCount();
-    const enemy2HeldItemCount = enemyPokemon[1].heldItemManager.getHeldItemCount();
+    const playerHeldItemCount = playerPokemon.heldItemManager.getItemCount();
+    const enemy1HeldItemCount = enemyPokemon[0].heldItemManager.getItemCount();
+    const enemy2HeldItemCount = enemyPokemon[1].heldItemManager.getItemCount();
     expect(enemy2HeldItemCount).toBeGreaterThan(0);
 
     game.move.select(MoveId.ATTRACT, 0, BattlerIndex.ENEMY_2);
@@ -81,9 +81,9 @@ describe("Items - Grip Claw", () => {
 
     await game.phaseInterceptor.to("BerryPhase", false);
 
-    const playerHeldItemCountAfter = playerPokemon.heldItemManager.getHeldItemCount();
-    const enemy1HeldItemCountsAfter = enemyPokemon[0].heldItemManager.getHeldItemCount();
-    const enemy2HeldItemCountsAfter = enemyPokemon[1].heldItemManager.getHeldItemCount();
+    const playerHeldItemCountAfter = playerPokemon.heldItemManager.getItemCount();
+    const enemy1HeldItemCountsAfter = enemyPokemon[0].heldItemManager.getItemCount();
+    const enemy2HeldItemCountsAfter = enemyPokemon[1].heldItemManager.getItemCount();
 
     expect(playerHeldItemCountAfter).toBe(playerHeldItemCount);
     expect(enemy1HeldItemCountsAfter).toBe(enemy1HeldItemCount);
@@ -100,13 +100,13 @@ describe("Items - Grip Claw", () => {
     const [leftPokemon, rightPokemon] = game.scene.getPlayerField();
     leftPokemon.heldItemManager.setStack(HeldItemId.GRIP_CLAW, 10);
 
-    const heldItemCountBefore = rightPokemon.heldItemManager.getHeldItemCount();
+    const heldItemCountBefore = rightPokemon.heldItemManager.getItemCount();
 
     game.move.select(MoveId.POLLEN_PUFF, 0, BattlerIndex.PLAYER_2);
     game.move.select(MoveId.ENDURE, 1);
 
     await game.toNextTurn();
 
-    expect(rightPokemon.heldItemManager.getHeldItemCount()).toBe(heldItemCountBefore);
+    expect(rightPokemon.heldItemManager.getItemCount()).toBe(heldItemCountBefore);
   });
 });

--- a/test/mystery-encounter/encounters/absolute-avarice-encounter.test.ts
+++ b/test/mystery-encounter/encounters/absolute-avarice-encounter.test.ts
@@ -181,7 +181,7 @@ describe("Absolute Avarice - Mystery Encounter", () => {
 
       await runMysteryEncounterToEnd(game, 2);
 
-      expect(scene.getPlayerParty()[0].heldItemManager.getHeldItemCount()).toBe(3);
+      expect(scene.getPlayerParty()[0].heldItemManager.getItemCount()).toBe(3);
     });
 
     it("Should return 2 (2/5ths floored) berries if 7 were stolen", { retry: 5 }, async () => {
@@ -198,7 +198,7 @@ describe("Absolute Avarice - Mystery Encounter", () => {
 
       await runMysteryEncounterToEnd(game, 2);
 
-      expect(scene.getPlayerParty()[0].heldItemManager.getHeldItemCount()).toBe(2);
+      expect(scene.getPlayerParty()[0].heldItemManager.getItemCount()).toBe(2);
     });
 
     it("should leave encounter without battle", async () => {

--- a/test/test-utils/matchers/to-have-held-item.ts
+++ b/test/test-utils/matchers/to-have-held-item.ts
@@ -39,7 +39,7 @@ export function toHaveHeldItem(
 
   // fast track for lacking item at all
   if (!received.heldItemManager.hasItem(id)) {
-    const actualStr = stringifyEnumArray(HeldItemId, received.heldItemManager.getHeldItems(), { base: 16 });
+    const actualStr = stringifyEnumArray(HeldItemId, received.heldItemManager.getItems(), { base: 16 });
     const expectedStr = itemIdToString(id);
 
     return {

--- a/test/test-utils/utils/item-test-utils.ts
+++ b/test/test-utils/utils/item-test-utils.ts
@@ -7,7 +7,7 @@ import { expect } from "vitest";
 
 export function getAllItemSpecs(pokemon: Pokemon): HeldItemSpecs[] {
   const { heldItemManager } = pokemon;
-  return heldItemManager.getHeldItems().map(iid => heldItemManager.getItemSpecs(iid)!);
+  return heldItemManager.getItems().map(iid => heldItemManager.getItemSpecs(iid)!);
 }
 
 /**


### PR DESCRIPTION
As requested by company on discord, the managers have been emrged into a single big `ItemManager` encapsulating both parts' logic.

Most of the code changes are renaming callsites to use the new method names, though I fid manage to make the items map `protected` by fixing  a callsite.