### PR TITLE
fix: prevent crash from corrupt save data

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1266,6 +1266,10 @@ export class BattleScene extends SceneBase {
     double?: boolean,
     mysteryEncounterType?: MysteryEncounterType,
   ): Battle {
+    // failsafe for corrupt saves (such as due to enum shifting)
+    if (trainerData?.variant === TrainerVariant.DOUBLE && !trainerConfigs[trainerData.trainerType].hasDouble) {
+      trainerData = undefined;
+    }
     const _startingWave = Overrides.STARTING_WAVE_OVERRIDE || startingWave;
     const newWaveIndex = waveIndex || (this.currentBattle?.waveIndex || _startingWave - 1) + 1;
     let newDouble: boolean | undefined;


### PR DESCRIPTION
## What are the changes the user will see?
Prevent a crash caused by trying to load incorrect enemy trainer data.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Due to enum values being shifted, saves from before the update that were on a trainer battle would try to load the wrong trainer, potentially causing a crash if a trainer that doesn't have doubles configuration set tried to load as a double battle.

## What are the changes from a developer perspective?
If the session save data is set to be a doubles trainer battle but that trainer type isn't configured to allow double battles, erase the trainer data and force regeneration of a new trainer.

## How to test the changes?
Load the following save data: [sessionData1_Bubbles5.prsv.txt](https://github.com/user-attachments/files/25429191/sessionData1_Bubbles5.prsv.txt)

## Checklist
- The PR content is correctly formatted:
  - ~[ ] **I'm using `beta` as my base branch**~
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually