### PR TITLE
fix: prevent softlock from corrupt save data

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1268,7 +1268,8 @@ export class BattleScene extends SceneBase {
   ): Battle {
     // failsafe for corrupt saves (such as due to enum shifting)
     if (trainerData?.variant === TrainerVariant.DOUBLE && !trainerConfigs[trainerData.trainerType].hasDouble) {
-      trainerData = undefined;
+      trainerData.variant = TrainerVariant.DEFAULT;
+      double = false;
     }
     const _startingWave = Overrides.STARTING_WAVE_OVERRIDE || startingWave;
     const newWaveIndex = waveIndex || (this.currentBattle?.waveIndex || _startingWave - 1) + 1;

--- a/src/enums/trainer-type.ts
+++ b/src/enums/trainer-type.ts
@@ -1,6 +1,7 @@
 export enum TrainerType {
   UNKNOWN,
 
+  // #region Generic Trainers
   ACE_TRAINER,
   AROMA_LADY,
   ARTIST,
@@ -64,42 +65,57 @@ export enum TrainerType {
   WORKER,
   YOUNG_COUPLE,
   YOUNGSTER,
+  // #endregion
+
+  // #region Evil Teams
   ROCKET_GRUNT,
   ARCHER,
   ARIANA,
   PROTON,
   PETREL,
+
   MAGMA_GRUNT,
   TABITHA,
   COURTNEY,
+
   AQUA_GRUNT,
   MATT,
   SHELLY,
+
   GALACTIC_GRUNT,
   JUPITER,
   MARS,
   SATURN,
+
   PLASMA_GRUNT,
   ZINZOLIN,
   COLRESS,
+
   FLARE_GRUNT,
   BRYONY,
   XEROSIC,
   ALIANA,
   CELOSIA,
   MABLE,
+
   AETHER_GRUNT,
   FABA,
+
   SKULL_GRUNT,
   PLUMERIA,
+
   MACRO_GRUNT,
   OLEANA,
+
   STAR_GRUNT,
   GIACOMO,
   MELA,
   ATTICUS,
   ORTEGA,
   ERI,
+  // #endregion
+
+  // #region Evil Team Bosses
   ROCKET_BOSS_GIOVANNI_1,
   ROCKET_BOSS_GIOVANNI_2,
   MAXIE,
@@ -120,6 +136,9 @@ export enum TrainerType {
   ROSE_2,
   PENNY,
   PENNY_2,
+  // #endregion
+
+  // #region ME trainers
   BUCK,
   CHERYL,
   MARLEY,
@@ -134,7 +153,9 @@ export enum TrainerType {
   EXPERT_POKEMON_BREEDER,
   FUTURE_SELF_M,
   FUTURE_SELF_F,
+  // #endregion
 
+  // #region Gym Leaders
   BROCK = 200,
   MISTY,
   LT_SURGE,
@@ -209,6 +230,9 @@ export enum TrainerType {
   RYME,
   TULIP,
   GRUSHA,
+  // #endregion
+
+  // #region Elite Four
   LORELEI = 300,
   BRUNO,
   AGATHA,
@@ -251,6 +275,9 @@ export enum TrainerType {
   AMARYS,
   LACEY,
   DRAYTON,
+  // #endregion
+
+  // #region Champions
   BLUE = 350,
   RED,
   LANCE_CHAMPION,
@@ -267,10 +294,14 @@ export enum TrainerType {
   GEETA,
   NEMONA,
   KIERAN,
+  // #endregion
+
+  // #region Rivals
   RIVAL = 375,
   RIVAL_2,
   RIVAL_3,
   RIVAL_4,
   RIVAL_5,
   RIVAL_6,
+  // #endregion
 }


### PR DESCRIPTION
## What are the changes the user will see?
Prevents a softlock caused by trying to load incorrect enemy trainer data on fixed battle waves (e.g. evil team battles).
The wrong trainer may be loaded (e.g. where a Team Skull Grunt should appear, Aqua Admin Shelly may appear instead), but the enemy's team will still be correct.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Fixing a softlock.

## What are the changes from a developer perspective?
Modified the previously added failsafe to overwrite the `trainerData.variant` and `double` params of `BattleScene#newBattle` to `TrainerVariant.DEFAULT` and `false` respectively if the trainer type in the save data doesn't support doubles but is set to be a double battle, instead of clearing the `trainerData` field which caused the trainer to be regenerated. For some reason the trainer regeneration method doesn't work properly for fixed battles.

## How to test the changes?
Try to load the following session save: [sessionData_Bugged run.prsv.txt](https://github.com/user-attachments/files/25463477/sessionData_Bugged.run.prsv.txt)
You should be able to advance to the next wave normally.
The save from #7089 should also work.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually