### PR TITLE
github: stop workflows from failing on `hotfix-*` branches

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -36,7 +36,6 @@ jobs:
         with:
           sparse-checkout: |
             .nvmrc
-          sparse-checkout-cone-mode: false
 
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -39,7 +39,6 @@ jobs:
         with:
           sparse-checkout: |
             .nvmrc
-          sparse-checkout-cone-mode: false
 
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,6 @@ jobs:
         with:
           sparse-checkout: |
             .github/test-filters.yml
-          sparse-checkout-cone-mode: false
 
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: filter


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
The workflows were failing on non-[beta|main] branches.

## What are the changes from a developer perspective?
Removed `sparse-checkout-cone-mode: false` from the path filter workflows' checkout step.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually