### PR TITLE
fix(biomes): Fix off by one error on daily starting biome

### DIFF
--- a/src/data/daily-seed/daily-run.ts
+++ b/src/data/daily-seed/daily-run.ts
@@ -89,11 +89,8 @@ export function getDailyStartingBiome(): BiomeId {
   const biomes = getEnumValues(BiomeId);
   let totalWeight = 0;
   const biomeThresholds: number[] = [];
-  for (const biome of getEnumValues(BiomeId)) {
+  for (const biome of biomes) {
     const weight = dailyBiomeWeights[biome];
-    if (weight === 0) {
-      continue;
-    }
 
     // Keep track of the total weight & each biome's cumulative weight
     totalWeight += weight;


### PR DESCRIPTION
## What are the changes the user will see?
Daily Starting Biomes have their correct weights again. Town is once again impossible to roll and Lab becomes possible again.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Town should not be allowed as a starting biome and Lab should be allowed. Also the weights were all off by one.

## What are the changes from a developer perspective?
A previous commit removed the filter of Town and End from the `biomes` array, which I do admit, was ugly to have. However, the `biomeThresholds` array was still filtering them out, which means you had two arrays, off by one, using each others indexes to pull values out.

Instead of filtering Town and End again, I tested if the `weight === 0 and continue` was still necessary and it seems like it isn't. So instead of filtering the biomes array again I just removed that and it works correctly again.

Now it does add Town and End to the `biomeThresholds` array, but with a cumulative weight of +0, which always makes it either 0 (and `randint < 0` is always false) or the same value as the index before it, which makes it impossible to be picked.

## Screenshots/Videos

## How to test the changes?
Change the value of `const randInt = randSeedInt(totalWeight);` to 0 or 62 (total weight -1) and check that Town and End are unable to be picked (you should see Plains and Lab instead). Also can check that `biomes` and `biomeThresholds` arrays are now equal length and all weights match with their biomes.

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: _____
- [ ] I have contacted the Translation Team on Discord for proofreading/translation

Does this require any additions or changes to in-game assets? If so:
- [ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: _____
