### PR TITLE
fix(ui): display correct labels for alt button assignment

### DIFF
--- a/src/ui/settings/abstract-control-settings-ui-handler.ts
+++ b/src/ui/settings/abstract-control-settings-ui-handler.ts
@@ -206,18 +206,13 @@ export abstract class AbstractControlSettingsUiHandler extends UiHandler {
       settingFiltered.forEach((setting, s) => {
         // Convert the setting key from format 'Key_Name' to 'Key name' for display.
         // TODO: IDK if this can be followed by both an underscore and a space, so leaving it as a regex matching both for now
-        const i18nKey = toCamelCase(setting.replace(/Alt(_| )/, ""));
+        const i18nKey = toCamelCase(setting.replace(/ALT(_| )/, ""));
 
         // Create and add a text object for the setting name to the scene.
         const isLock = this.settingBlacklisted.includes(this.setting[setting]);
         const labelStyle = isLock ? TextStyle.SETTINGS_LOCKED : TextStyle.SETTINGS_LABEL;
-        const isAlt = setting.includes("Alt");
-        let labelText: string;
-        if (isAlt) {
-          labelText = `${i18next.t(`settings:${i18nKey}`)}${i18next.t("settings:alt")}`;
-        } else {
-          labelText = i18next.t(`settings:${i18nKey}`);
-        }
+        const isAlt = setting.includes("ALT");
+        const labelText = i18next.t(`settings:${i18nKey}`) + (isAlt ? i18next.t("settings:alt") : "");
         settingLabels[s] = addTextObject(8, 28 + s * 16, labelText, labelStyle);
         settingLabels[s].setOrigin(0, 0);
         optionsContainer.add(settingLabels[s]);


### PR DESCRIPTION
## What are the changes the user will see?
The labels for the alt button assignments in the key config menu will display correctly again.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Bug report.

## What are the changes from a developer perspective?
Changed 2 checks for "Alt" to "ALT" to match the updated casing of the enum values.

## Screenshots/Videos
<details><summary>Before</summary>

<img width="1222" height="682" alt="image" src="https://github.com/user-attachments/assets/be6090ea-9b81-4c9c-aa96-df0a46094e21" />

</details>
<details><summary>After</summary>

<img width="1228" height="678" alt="image" src="https://github.com/user-attachments/assets/beee9d96-e833-49d2-bf5d-ce8284d55e5a" />

</details>

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually