### PR TITLE
fix(battle): DoubleOnly trainers no longer set to single battle after reload

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1267,7 +1267,11 @@ export class BattleScene extends SceneBase {
     mysteryEncounterType?: MysteryEncounterType,
   ): Battle {
     // failsafe for corrupt saves (such as due to enum shifting)
-    if (trainerData?.variant === TrainerVariant.DOUBLE && !trainerConfigs[trainerData.trainerType].hasDouble) {
+    if (
+      trainerData?.variant === TrainerVariant.DOUBLE
+      && !trainerConfigs[trainerData.trainerType].hasDouble
+      && !trainerConfigs[trainerData.trainerType].doubleOnly
+    ) {
       trainerData.variant = TrainerVariant.DEFAULT;
       double = false;
     }


### PR DESCRIPTION
## What are the changes the user will see?
Twins and other DoubleOnly trainers were being set to single battle when loading from a session.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
They should not be single battles. Ever.

## What are the changes from a developer perspective?
Added a `.doubleOnly` check to the existing `.hasDouble` check.

## Screenshots/Videos
<details><summary>Twins</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2f4b97f9-5923-4f69-b33a-da44929c7ec8" />

</details>
<details><summary>Before</summary>
Before changes, after refreshing and loading from a session:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/04fba5dd-3582-49bd-8613-adcf5f463b32" />

</details>
<details><summary>After</summary>
After changes, after refreshing and loading from a session:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ad7488ba-99ae-4617-9cb4-7d2f323b0c9f" />

</details>

## How to test the changes?
This seed has Twins on Wave 5:
```ts
const overrides = {
  STARTING_WAVE_OVERRIDE: 5,
  STARTING_BIOME_OVERRIDE: BiomeId.PLAINS,
  DAILY_RUN_SEED_OVERRIDE: "adsfasdfddds",
} satisfies Partial<InstanceType<OverridesType>>;
```

New Game > Daily Run > fight (see that the Twins throw out 2 enemies and you're in a double battle)
Refresh browser > Continue > fight (before: single battle, after: still a double battle)

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: _____
- [ ] I have contacted the Translation Team on Discord for proofreading/translation

Does this require any additions or changes to in-game assets? If so:
- [ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: _____
