### PR TITLE
fix(ui): Thai font call fix

### DIFF
--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -94,6 +94,12 @@ const fonts: LoadingFontFaceProperty[] = [
       unicodeRange: unicodeRanges.thai,
     }),
   },
+  {
+    face: new FontFace("pkmnems", "url(./fonts/terrible-thaifix.ttf)", {
+      unicodeRange: unicodeRanges.thai,
+    }),
+    extraOptions: { sizeAdjust: "133%" },
+  },
 ];
 
 //#region Functions


### PR DESCRIPTION
## What are the changes the user will see?
Properly displayed diacritics in Thai subsitute font

## Why am I making these changes?
To fix the previously mentionned issue

## What are the changes from a developer perspective?
--

## Screenshots/Videos
Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/94301cd6-e250-4f1e-a7bc-c3b90d6410fb" />

After:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/20d7e316-903d-402e-a222-4e52d9e4b0c5" />

## How to test the changes?
Play in Thai and go everywhere the pkmnems font initially used

## Checklist
--

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [ ] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)