### PR TITLE
fix(ui): Danish and Korean UI adjustments

### DIFF
--- a/src/ui/handlers/egg-gacha-ui-handler.ts
+++ b/src/ui/handlers/egg-gacha-ui-handler.ts
@@ -81,7 +81,7 @@ export class EggGachaUiHandler extends MessageUiHandler {
     let pokemonIconX = -20;
     let pokemonIconY = 6;
 
-    if (["de", "es-ES", "es-419", "fr", "ko", "pt-BR", "ja", "ru", "uk", "tr"].includes(currentLanguage)) {
+    if (["de", "es-ES", "es-419", "fr", "ko", "pt-BR", "ja", "da", "ru", "uk", "tr"].includes(currentLanguage)) {
       gachaTextStyle = TextStyle.SMALLER_WINDOW_ALT;
       gachaX = 2;
       gachaY = 2;
@@ -119,14 +119,14 @@ export class EggGachaUiHandler extends MessageUiHandler {
         }
         break;
       case GachaType.MOVE:
-        if (["de", "es-ES", "fr", "pt-BR", "ru", "uk", "tr"].includes(currentLanguage)) {
+        if (["de", "es-ES", "fr", "pt-BR", "da", "ru", "uk", "tr"].includes(currentLanguage)) {
           gachaUpLabel.setAlign("center").setY(0);
         }
 
         gachaUpLabel.setText(i18next.t("egg:moveUpGacha")).setX(0).setOrigin(0.5, 0);
         break;
       case GachaType.SHINY:
-        if (["de", "fr", "ko", "ru", "uk", "tr"].includes(currentLanguage)) {
+        if (["de", "fr", "ko", "da", "ru", "uk", "tr"].includes(currentLanguage)) {
           gachaUpLabel.setAlign("center").setY(0);
         }
 

--- a/src/ui/text.ts
+++ b/src/ui/text.ts
@@ -197,6 +197,7 @@ export function getTextStyleOptions(
       let fontSizeLabel = "96px";
       switch (lang) {
         case "ja":
+        case "ko":
           styleOptions.padding = { top: 2 };
           fontSizeLabel = "92px";
           break;


### PR DESCRIPTION
## What are the changes the user will see?
Some texts Danish and Korean won't go out of bounds anymore

## Why am I making these changes?
See above

## What are the changes from a developer perspective?
--

## Screenshots/Videos
--

## How to test the changes?
Play in Danish

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [x] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)