### PR TITLE
dev: replace default export in `overrides.ts` with named export

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -14,7 +14,7 @@ import { initGlobalScene } from "#app/global-scene";
 import { starterColors } from "#app/global-vars/starter-colors";
 import { InputsController } from "#app/inputs-controller";
 import { LoadingScene } from "#app/loading-scene";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import type { Phase } from "#app/phase";
 import { PhaseManager } from "#app/phase-manager";
 import { FieldSpritePipeline } from "#app/pipelines/field-sprite";
@@ -865,6 +865,7 @@ export class BattleScene extends SceneBase {
     return party.find(p => p.id === pokemonId);
   }
 
+  // biome-ignore lint/complexity/useMaxParams: will be fixed later
   addPlayerPokemon(
     species: PokemonSpecies,
     level: number,
@@ -895,31 +896,32 @@ export class BattleScene extends SceneBase {
       postProcess(pokemon);
     }
 
-    if (Overrides.IVS_OVERRIDE === null) {
+    if (activeOverrides.IVS_OVERRIDE === null) {
       // do nothing
-    } else if (Array.isArray(Overrides.IVS_OVERRIDE)) {
-      if (Overrides.IVS_OVERRIDE.length !== 6) {
+    } else if (Array.isArray(activeOverrides.IVS_OVERRIDE)) {
+      if (activeOverrides.IVS_OVERRIDE.length !== 6) {
         throw new Error("The Player IVs override must be an array of length 6 or a number!");
       }
-      if (Overrides.IVS_OVERRIDE.some(value => !isBetween(value, 0, 31))) {
+      if (activeOverrides.IVS_OVERRIDE.some(value => !isBetween(value, 0, 31))) {
         throw new Error("All IVs in the player IV override must be between 0 and 31!");
       }
-      pokemon.ivs = Overrides.IVS_OVERRIDE;
+      pokemon.ivs = activeOverrides.IVS_OVERRIDE;
     } else {
-      if (!isBetween(Overrides.IVS_OVERRIDE, 0, 31)) {
+      if (!isBetween(activeOverrides.IVS_OVERRIDE, 0, 31)) {
         throw new Error("The Player IV override must be a value between 0 and 31!");
       }
-      pokemon.ivs = new Array(6).fill(Overrides.IVS_OVERRIDE);
+      pokemon.ivs = new Array(6).fill(activeOverrides.IVS_OVERRIDE);
     }
 
-    if (Overrides.NATURE_OVERRIDE !== null) {
-      pokemon.nature = Overrides.NATURE_OVERRIDE;
+    if (activeOverrides.NATURE_OVERRIDE !== null) {
+      pokemon.nature = activeOverrides.NATURE_OVERRIDE;
     }
 
     pokemon.init();
     return pokemon;
   }
 
+  // biome-ignore lint/complexity/useMaxParams: will be fixed later
   addEnemyPokemon(
     species: PokemonSpecies,
     level: number,
@@ -930,17 +932,17 @@ export class BattleScene extends SceneBase {
     postProcess?: (enemyPokemon: EnemyPokemon) => void,
     forRival = false,
   ): EnemyPokemon {
-    if (Overrides.ENEMY_LEVEL_OVERRIDE > 0) {
-      level = Overrides.ENEMY_LEVEL_OVERRIDE;
+    if (activeOverrides.ENEMY_LEVEL_OVERRIDE > 0) {
+      level = activeOverrides.ENEMY_LEVEL_OVERRIDE;
     }
-    if (Overrides.ENEMY_SPECIES_OVERRIDE) {
-      species = getPokemonSpecies(Overrides.ENEMY_SPECIES_OVERRIDE);
+    if (activeOverrides.ENEMY_SPECIES_OVERRIDE) {
+      species = getPokemonSpecies(activeOverrides.ENEMY_SPECIES_OVERRIDE);
       // The fact that a Pokemon is a boss or not can change based on its Species and level
       boss = this.getEncounterBossSegments(this.currentBattle.waveIndex, level, species) > 1;
     }
 
     const pokemon = new EnemyPokemon(species, level, trainerSlot, boss, shinyLock, dataSource, forRival);
-    if (Overrides.ENEMY_FUSION_OVERRIDE) {
+    if (activeOverrides.ENEMY_FUSION_OVERRIDE) {
       pokemon.generateFusionSpecies();
     }
 
@@ -961,25 +963,25 @@ export class BattleScene extends SceneBase {
       postProcess(pokemon);
     }
 
-    if (Overrides.ENEMY_IVS_OVERRIDE === null) {
+    if (activeOverrides.ENEMY_IVS_OVERRIDE === null) {
       // do nothing
-    } else if (Array.isArray(Overrides.ENEMY_IVS_OVERRIDE)) {
-      if (Overrides.ENEMY_IVS_OVERRIDE.length !== 6) {
+    } else if (Array.isArray(activeOverrides.ENEMY_IVS_OVERRIDE)) {
+      if (activeOverrides.ENEMY_IVS_OVERRIDE.length !== 6) {
         throw new Error("The Enemy IVs override must be an array of length 6 or a number!");
       }
-      if (Overrides.ENEMY_IVS_OVERRIDE.some(value => !isBetween(value, 0, 31))) {
+      if (activeOverrides.ENEMY_IVS_OVERRIDE.some(value => !isBetween(value, 0, 31))) {
         throw new Error("All IVs in the enemy IV override must be between 0 and 31!");
       }
-      pokemon.ivs = Overrides.ENEMY_IVS_OVERRIDE;
+      pokemon.ivs = activeOverrides.ENEMY_IVS_OVERRIDE;
     } else {
-      if (!isBetween(Overrides.ENEMY_IVS_OVERRIDE, 0, 31)) {
+      if (!isBetween(activeOverrides.ENEMY_IVS_OVERRIDE, 0, 31)) {
         throw new Error("The Enemy IV override must be a value between 0 and 31!");
       }
-      pokemon.ivs = new Array(6).fill(Overrides.ENEMY_IVS_OVERRIDE);
+      pokemon.ivs = new Array(6).fill(activeOverrides.ENEMY_IVS_OVERRIDE);
     }
 
-    if (Overrides.ENEMY_NATURE_OVERRIDE !== null) {
-      pokemon.nature = Overrides.ENEMY_NATURE_OVERRIDE;
+    if (activeOverrides.ENEMY_NATURE_OVERRIDE !== null) {
+      pokemon.nature = activeOverrides.ENEMY_NATURE_OVERRIDE;
     }
 
     pokemon.init();
@@ -1150,8 +1152,8 @@ export class BattleScene extends SceneBase {
 
     this.lockModifierTiers = false;
 
-    if (Overrides.POKEBALL_OVERRIDE.active) {
-      this.pokeballCounts = Overrides.POKEBALL_OVERRIDE.pokeballs;
+    if (activeOverrides.POKEBALL_OVERRIDE.active) {
+      this.pokeballCounts = activeOverrides.POKEBALL_OVERRIDE.pokeballs;
     } else {
       // TODO: Remove unused luxury balls and remove the `filter`
       this.pokeballCounts = Object.fromEntries(
@@ -1184,7 +1186,7 @@ export class BattleScene extends SceneBase {
 
     // Reset RNG after end of game or save & quit.
     // This needs to happen after clearing this.currentBattle or the seed will be affected by the last wave played
-    this.setSeed(Overrides.SEED_OVERRIDE || randomString(24));
+    this.setSeed(activeOverrides.SEED_OVERRIDE || randomString(24));
     console.log("Seed:", this.seed);
     this.resetSeed();
 
@@ -1201,7 +1203,7 @@ export class BattleScene extends SceneBase {
       t.setVisible(false);
     });
 
-    this.newArena(Overrides.STARTING_BIOME_OVERRIDE || BiomeId.TOWN);
+    this.newArena(activeOverrides.STARTING_BIOME_OVERRIDE || BiomeId.TOWN);
 
     this.field.setVisible(true);
 
@@ -1359,7 +1361,7 @@ export class BattleScene extends SceneBase {
         // Don't increment wave index when computing starting wave
         waveIndex:
           this.currentBattle == null
-            ? (Overrides.STARTING_WAVE_OVERRIDE ?? STARTING_WAVE)
+            ? (activeOverrides.STARTING_WAVE_OVERRIDE ?? STARTING_WAVE)
             : this.currentBattle.waveIndex + 1,
       };
     }
@@ -1455,16 +1457,16 @@ export class BattleScene extends SceneBase {
   private handleNonFixedBattle(resolved: NewBattleInitialProps): void {
     const { waveIndex } = resolved;
     resolved.battleType =
-      !this.gameMode.hasTrainers || Overrides.DISABLE_STANDARD_TRAINERS_OVERRIDE
+      !this.gameMode.hasTrainers || activeOverrides.DISABLE_STANDARD_TRAINERS_OVERRIDE
         ? BattleType.WILD
-        : (Overrides.BATTLE_TYPE_OVERRIDE
+        : (activeOverrides.BATTLE_TYPE_OVERRIDE
           ?? (this.gameMode.isWaveTrainer(waveIndex) ? BattleType.TRAINER : BattleType.WILD));
 
     // Check for mystery encounter
     // Can only occur in place of a standard (non-boss) wild battle, waves 10-180
     // NB: battle type checks are offloaded to `isWaveMysteryEncounter`
     // TODO: This means MEs can generate when the override is set to `BattleType.WILD`
-    if (!Overrides.BATTLE_TYPE_OVERRIDE && this.isWaveMysteryEncounter(resolved.battleType, waveIndex)) {
+    if (!activeOverrides.BATTLE_TYPE_OVERRIDE && this.isWaveMysteryEncounter(resolved.battleType, waveIndex)) {
       resolved.battleType = BattleType.MYSTERY_ENCOUNTER;
       // Reset to base spawn weight
       this.mysteryEncounterSaveData.encounterSpawnChance = BASE_MYSTERY_ENCOUNTER_SPAWN_WEIGHT;
@@ -1486,7 +1488,7 @@ export class BattleScene extends SceneBase {
    * @returns The generated trainer.
    */
   private generateNewBattleTrainer(waveIndex: number): Trainer {
-    const trainerType = Overrides.RANDOM_TRAINER_OVERRIDE?.trainerType ?? this.arena.randomTrainerType(waveIndex);
+    const trainerType = activeOverrides.RANDOM_TRAINER_OVERRIDE?.trainerType ?? this.arena.randomTrainerType(waveIndex);
     const config = trainerConfigs[trainerType];
 
     let doubleTrainer: boolean;
@@ -1503,7 +1505,9 @@ export class BattleScene extends SceneBase {
       doubleTrainer = randSeedInt(this.getDoubleBattleChance(waveIndex)) === 0;
     }
 
-    const overrideVariant = doubleTrainer ? TrainerVariant.DOUBLE : Overrides.RANDOM_TRAINER_OVERRIDE?.trainerVariant;
+    const overrideVariant = doubleTrainer
+      ? TrainerVariant.DOUBLE
+      : activeOverrides.RANDOM_TRAINER_OVERRIDE?.trainerVariant;
     const variant = overrideVariant ?? (randSeedInt(2) ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT);
 
     return new Trainer(trainerType, variant);
@@ -1549,7 +1553,7 @@ export class BattleScene extends SceneBase {
    * Returns `undefined` if the override is `null`.
    */
   private doCheckDoubleOverride(waveIndex: number): boolean | undefined {
-    switch (Overrides.BATTLE_STYLE_OVERRIDE) {
+    switch (activeOverrides.BATTLE_STYLE_OVERRIDE) {
       case "double":
         return true;
       case "single":
@@ -1559,7 +1563,7 @@ export class BattleScene extends SceneBase {
       case "odd-doubles":
         return waveIndex % 2 === 1;
       default:
-        Overrides.BATTLE_STYLE_OVERRIDE satisfies null;
+        activeOverrides.BATTLE_STYLE_OVERRIDE satisfies null;
         return;
     }
   }
@@ -1892,10 +1896,10 @@ export class BattleScene extends SceneBase {
   }
 
   getEncounterBossSegments(waveIndex: number, level: number, species?: PokemonSpecies, forceBoss = false): number {
-    if (Overrides.ENEMY_HEALTH_SEGMENTS_OVERRIDE > 1) {
-      return Overrides.ENEMY_HEALTH_SEGMENTS_OVERRIDE;
+    if (activeOverrides.ENEMY_HEALTH_SEGMENTS_OVERRIDE > 1) {
+      return activeOverrides.ENEMY_HEALTH_SEGMENTS_OVERRIDE;
     }
-    if (Overrides.ENEMY_HEALTH_SEGMENTS_OVERRIDE === 1) {
+    if (activeOverrides.ENEMY_HEALTH_SEGMENTS_OVERRIDE === 1) {
       // The rest of the code expects to be returned 0 and not 1 if the enemy is not a boss
       return 0;
     }
@@ -2238,7 +2242,7 @@ export class BattleScene extends SceneBase {
   }
 
   getMaxExpLevel(ignoreLevelCap = false): number {
-    const capOverride = Overrides.LEVEL_CAP_OVERRIDE ?? 0;
+    const capOverride = activeOverrides.LEVEL_CAP_OVERRIDE ?? 0;
     if (capOverride > 0) {
       return capOverride;
     }
@@ -3414,7 +3418,7 @@ export class BattleScene extends SceneBase {
 
   validateAchv<T extends Achv>(achv: T, args?: Parameters<T["validate"]>[0]): boolean {
     if (
-      (!Object.hasOwn(this.gameData.achvUnlocks, achv.id) || Overrides.ACHIEVEMENTS_REUNLOCK_OVERRIDE)
+      (!Object.hasOwn(this.gameData.achvUnlocks, achv.id) || activeOverrides.ACHIEVEMENTS_REUNLOCK_OVERRIDE)
       && achv.validate(args)
     ) {
       this.gameData.achvUnlocks[achv.id] = Date.now();
@@ -3649,8 +3653,8 @@ export class BattleScene extends SceneBase {
         if (partyMember.pokerus) {
           expMultiplier *= 1.5;
         }
-        if (Overrides.XP_MULTIPLIER_OVERRIDE !== null) {
-          expMultiplier = Overrides.XP_MULTIPLIER_OVERRIDE;
+        if (activeOverrides.XP_MULTIPLIER_OVERRIDE !== null) {
+          expMultiplier = activeOverrides.XP_MULTIPLIER_OVERRIDE;
         }
         const pokemonExp = new NumberHolder(expValue * expMultiplier);
         this.applyModifiers(PokemonExpBoosterModifier, true, partyMember, pokemonExp);
@@ -3724,7 +3728,7 @@ export class BattleScene extends SceneBase {
 
     // MEs can only spawn 3 or more waves after the previous ME, barring overrides
     const canSpawn =
-      Overrides.MYSTERY_ENCOUNTER_RATE_OVERRIDE !== null
+      activeOverrides.MYSTERY_ENCOUNTER_RATE_OVERRIDE !== null
       || encounteredEvents.length === 0
       || waveIndex > 3 + encounteredEvents.at(-1)!.waveIndex; // Bang on `at()` is justified due to the check for length === 0
     if (!canSpawn) {
@@ -3742,7 +3746,7 @@ export class BattleScene extends SceneBase {
       sessionEncounterRate
       + Math.min(currentRunDiffFromAvg * ANTI_VARIANCE_WEIGHT_MODIFIER, MYSTERY_ENCOUNTER_SPAWN_MAX_WEIGHT / 2);
 
-    const successRate = Overrides.MYSTERY_ENCOUNTER_RATE_OVERRIDE ?? favoredEncounterRate;
+    const successRate = activeOverrides.MYSTERY_ENCOUNTER_RATE_OVERRIDE ?? favoredEncounterRate;
 
     let roll = 0;
     // Always rolls the check on the same offset to ensure no RNG changes from reloading session
@@ -3780,10 +3784,10 @@ export class BattleScene extends SceneBase {
     // Loading override or session encounter
     let encounter: MysteryEncounter | null;
     if (
-      Overrides.MYSTERY_ENCOUNTER_OVERRIDE != null
-      && Object.hasOwn(allMysteryEncounters, Overrides.MYSTERY_ENCOUNTER_OVERRIDE)
+      activeOverrides.MYSTERY_ENCOUNTER_OVERRIDE != null
+      && Object.hasOwn(allMysteryEncounters, activeOverrides.MYSTERY_ENCOUNTER_OVERRIDE)
     ) {
-      encounter = allMysteryEncounters[Overrides.MYSTERY_ENCOUNTER_OVERRIDE];
+      encounter = allMysteryEncounters[activeOverrides.MYSTERY_ENCOUNTER_OVERRIDE];
       if (canBypass) {
         return encounter;
       }
@@ -3850,8 +3854,8 @@ export class BattleScene extends SceneBase {
             ? MysteryEncounterTier.ULTRA
             : MysteryEncounterTier.ROGUE;
 
-    if (Overrides.MYSTERY_ENCOUNTER_TIER_OVERRIDE != null) {
-      tier = Overrides.MYSTERY_ENCOUNTER_TIER_OVERRIDE;
+    if (activeOverrides.MYSTERY_ENCOUNTER_TIER_OVERRIDE != null) {
+      tier = activeOverrides.MYSTERY_ENCOUNTER_TIER_OVERRIDE;
     }
 
     let availableEncounters: MysteryEncounter[] = [];

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -52,7 +52,7 @@
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { CommonBattleAnim, MoveChargeAnim } from "#data/battle-anims";
 import { allAbilities, allMoves } from "#data/data-lists";
 import { SpeciesFormChangeAbilityTrigger } from "#data/form-change-triggers";
@@ -883,7 +883,7 @@ export class ConfusedTag extends SerializableBattlerTag {
     phaseManager.unshiftNew("CommonAnimPhase", pokemon.getBattlerIndex(), undefined, CommonAnim.CONFUSION);
 
     // 1/3 chance of hitting self with a 40 base power move
-    if (pokemon.randBattleSeedInt(3) === 0 || Overrides.CONFUSION_ACTIVATION_OVERRIDE === true) {
+    if (pokemon.randBattleSeedInt(3) === 0 || activeOverrides.CONFUSION_ACTIVATION_OVERRIDE === true) {
       const atk = pokemon.getEffectiveStat(Stat.ATK);
       const def = pokemon.getEffectiveStat(Stat.DEF);
       const damage = toDmgValue(

--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -1,6 +1,6 @@
 import type { BattleScene } from "#app/battle-scene";
 import { globalScene } from "#app/global-scene";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { pokemonPrevolutions } from "#balance/pokemon-evolutions";
 import {
   BOOSTED_RARE_EGGMOVE_RATES,
@@ -162,7 +162,7 @@ export class Egg {
 
       this._sourceType = eggOptions?.sourceType!; // TODO: is this bang correct?
       // Ensure _sourceType is defined before invoking rollEggTier(), as it is referenced
-      this._tier = eggOptions?.tier ?? Overrides.EGG_TIER_OVERRIDE ?? this.rollEggTier();
+      this._tier = eggOptions?.tier ?? activeOverrides.EGG_TIER_OVERRIDE ?? this.rollEggTier();
       // If egg was pulled, check if egg pity needs to override the egg tier
       if (eggOptions?.pulled) {
         // Needs this._tier and this._sourceType to work
@@ -176,8 +176,8 @@ export class Egg {
       this._timestamp = eggOptions?.timestamp ?? Date.now();
 
       // First roll shiny and variant so we can filter if species with an variant exist
-      this._isShiny = eggOptions?.isShiny ?? (Overrides.EGG_SHINY_OVERRIDE || this.rollShiny());
-      this._variantTier = eggOptions?.variantTier ?? Overrides.EGG_VARIANT_OVERRIDE ?? this.rollVariant();
+      this._isShiny = eggOptions?.isShiny ?? (activeOverrides.EGG_SHINY_OVERRIDE || this.rollShiny());
+      this._variantTier = eggOptions?.variantTier ?? activeOverrides.EGG_VARIANT_OVERRIDE ?? this.rollVariant();
       this._species = eggOptions?.species ?? this.rollSpecies()!; // TODO: Is this bang correct?
 
       this._overrideHiddenAbility = eggOptions?.overrideHiddenAbility ?? false;

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -1,7 +1,7 @@
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { timedEventManager } from "#app/global-event-manager";
 import { globalScene } from "#app/global-scene";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { NIGHT_TIME } from "#constants/game-constants";
 import type { ArenaTag, ArenaTagTypeMap } from "#data/arena-tag";
 import { EntryHazardTag, getArenaTag } from "#data/arena-tag";
@@ -237,7 +237,7 @@ export class Arena {
    * Sets weather to the override specified in `overrides.ts`
    */
   private overrideWeather(): void {
-    const weather = Overrides.WEATHER_OVERRIDE;
+    const weather = activeOverrides.WEATHER_OVERRIDE;
     this.weather = new Weather(weather, 0);
     globalScene.phaseManager.unshiftNew("CommonAnimPhase", undefined, undefined, CommonAnim.SUNNY + (weather - 1));
     globalScene.phaseManager.queueMessage(getWeatherStartMessage(weather)!); // TODO: is this bang correct?
@@ -250,7 +250,7 @@ export class Arena {
    * @returns true if new weather set, false if no weather provided or attempting to set the same weather as currently in use
    */
   public trySetWeather(weather: WeatherType, user?: Pokemon): boolean {
-    if (Overrides.WEATHER_OVERRIDE) {
+    if (activeOverrides.WEATHER_OVERRIDE) {
       this.overrideWeather();
       return true;
     }
@@ -437,9 +437,9 @@ export class Arena {
     return true;
   }
 
-  /** Override the terrain to the value set inside {@linkcode Overrides.STARTING_TERRAIN_OVERRIDE}. */
+  /** Override the terrain to the value set inside {@linkcode activeOverrides.STARTING_TERRAIN_OVERRIDE}. */
   private overrideTerrain(): void {
-    const terrain = Overrides.STARTING_TERRAIN_OVERRIDE;
+    const terrain = activeOverrides.STARTING_TERRAIN_OVERRIDE;
     // TODO: Add a flag for permanent terrains
     this.terrain = new Terrain(terrain, 0);
     this.eventTarget.dispatchEvent(
@@ -456,7 +456,7 @@ export class Arena {
 
   /** Sets a random terrain based on the biome */
   public setBiomeTerrain(): void {
-    if (Overrides.STARTING_TERRAIN_OVERRIDE) {
+    if (activeOverrides.STARTING_TERRAIN_OVERRIDE) {
       this.overrideTerrain();
       return;
     }
@@ -891,8 +891,8 @@ export class Arena {
         return TimeOfDay.NIGHT;
     }
 
-    if (Overrides.TIME_OF_DAY_OVERRIDE !== null) {
-      return Overrides.TIME_OF_DAY_OVERRIDE;
+    if (activeOverrides.TIME_OF_DAY_OVERRIDE !== null) {
+      return activeOverrides.TIME_OF_DAY_OVERRIDE;
     }
 
     const waveCycle = ((globalScene.currentBattle?.waveIndex ?? 0) + globalScene.waveCycleOffset) % 40;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -8,7 +8,7 @@ import { EVOLVE_MOVE, PLAYER_PARTY_MAX_SIZE, RARE_CANDY_FRIENDSHIP_CAP, RELEARN_
 import { timedEventManager } from "#app/global-event-manager";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { speciesEggMoves } from "#balance/moves/egg-moves";
 import type { FORCED_RIVAL_SIGNATURE_MOVES } from "#balance/moves/signature-moves";
 import type { SpeciesFormEvolution } from "#balance/pokemon-evolutions";
@@ -1875,7 +1875,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    */
   getMoveset(ignoreOverride = false): PokemonMove[] {
     // Override moveset based on arrays specified in overrides.ts
-    const overrideArray = coerceArray(this.isPlayer() ? Overrides.MOVESET_OVERRIDE : Overrides.ENEMY_MOVESET_OVERRIDE);
+    const overrideArray = coerceArray(
+      this.isPlayer() ? activeOverrides.MOVESET_OVERRIDE : activeOverrides.ENEMY_MOVESET_OVERRIDE,
+    );
     if (overrideArray.length === 0) {
       return !ignoreOverride && this.summonData.moveset ? this.summonData.moveset : this.moveset;
     }
@@ -2061,11 +2063,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     if (!ignoreOverride && this.summonData.ability) {
       return allAbilities[this.summonData.ability];
     }
-    if (Overrides.ABILITY_OVERRIDE && this.isPlayer()) {
-      return allAbilities[Overrides.ABILITY_OVERRIDE];
+    if (activeOverrides.ABILITY_OVERRIDE && this.isPlayer()) {
+      return allAbilities[activeOverrides.ABILITY_OVERRIDE];
     }
-    if (Overrides.ENEMY_ABILITY_OVERRIDE && this.isEnemy()) {
-      return allAbilities[Overrides.ENEMY_ABILITY_OVERRIDE];
+    if (activeOverrides.ENEMY_ABILITY_OVERRIDE && this.isEnemy()) {
+      return allAbilities[activeOverrides.ENEMY_ABILITY_OVERRIDE];
     }
     if (this.isFusion()) {
       if (this.fusionCustomPokemonData?.ability != null && this.fusionCustomPokemonData.ability !== -1) {
@@ -2097,11 +2099,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @returns The passive {@linkcode Ability} of the pokemon
    */
   public getPassiveAbility(): Ability {
-    if (Overrides.PASSIVE_ABILITY_OVERRIDE && this.isPlayer()) {
-      return allAbilities[Overrides.PASSIVE_ABILITY_OVERRIDE];
+    if (activeOverrides.PASSIVE_ABILITY_OVERRIDE && this.isPlayer()) {
+      return allAbilities[activeOverrides.PASSIVE_ABILITY_OVERRIDE];
     }
-    if (Overrides.ENEMY_PASSIVE_ABILITY_OVERRIDE && this.isEnemy()) {
-      return allAbilities[Overrides.ENEMY_PASSIVE_ABILITY_OVERRIDE];
+    if (activeOverrides.ENEMY_PASSIVE_ABILITY_OVERRIDE && this.isEnemy()) {
+      return allAbilities[activeOverrides.ENEMY_PASSIVE_ABILITY_OVERRIDE];
     }
     if (this.customPokemonData.passive != null && this.customPokemonData.passive !== -1) {
       return allAbilities[this.customPokemonData.passive];
@@ -2181,15 +2183,16 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     // returns override if valid for current case
     // TODO: This can be simplified greatly with minimal effort via ternaries
     if (
-      (Overrides.HAS_PASSIVE_ABILITY_OVERRIDE === false && this.isPlayer())
-      || (Overrides.ENEMY_HAS_PASSIVE_ABILITY_OVERRIDE === false && this.isEnemy())
+      (activeOverrides.HAS_PASSIVE_ABILITY_OVERRIDE === false && this.isPlayer())
+      || (activeOverrides.ENEMY_HAS_PASSIVE_ABILITY_OVERRIDE === false && this.isEnemy())
     ) {
       return false;
     }
     if (
-      ((Overrides.PASSIVE_ABILITY_OVERRIDE !== AbilityId.NONE || Overrides.HAS_PASSIVE_ABILITY_OVERRIDE)
+      ((activeOverrides.PASSIVE_ABILITY_OVERRIDE !== AbilityId.NONE || activeOverrides.HAS_PASSIVE_ABILITY_OVERRIDE)
         && this.isPlayer())
-      || ((Overrides.ENEMY_PASSIVE_ABILITY_OVERRIDE !== AbilityId.NONE || Overrides.ENEMY_HAS_PASSIVE_ABILITY_OVERRIDE)
+      || ((activeOverrides.ENEMY_PASSIVE_ABILITY_OVERRIDE !== AbilityId.NONE
+        || activeOverrides.ENEMY_HAS_PASSIVE_ABILITY_OVERRIDE)
         && this.isEnemy())
     ) {
       return true;
@@ -3146,10 +3149,10 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     let fusionOverride: PokemonSpecies | undefined;
 
-    if (forStarter && this.isPlayer() && Overrides.STARTER_FUSION_SPECIES_OVERRIDE) {
-      fusionOverride = getPokemonSpecies(Overrides.STARTER_FUSION_SPECIES_OVERRIDE);
-    } else if (this.isEnemy() && Overrides.ENEMY_FUSION_SPECIES_OVERRIDE) {
-      fusionOverride = getPokemonSpecies(Overrides.ENEMY_FUSION_SPECIES_OVERRIDE);
+    if (forStarter && this.isPlayer() && activeOverrides.STARTER_FUSION_SPECIES_OVERRIDE) {
+      fusionOverride = getPokemonSpecies(activeOverrides.STARTER_FUSION_SPECIES_OVERRIDE);
+    } else if (this.isEnemy() && activeOverrides.ENEMY_FUSION_SPECIES_OVERRIDE) {
+      fusionOverride = getPokemonSpecies(activeOverrides.ENEMY_FUSION_SPECIES_OVERRIDE);
     }
 
     this.fusionSpecies =
@@ -3977,7 +3980,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     let isCritical = alwaysCrit.value || alwaysCritTag || critChance === 1;
 
     // If we aren't already guaranteed to crit, do a random roll & check overrides
-    isCritical ||= Overrides.CRITICAL_HIT_OVERRIDE ?? globalScene.randBattleSeedInt(critChance) === 0;
+    isCritical ||= activeOverrides.CRITICAL_HIT_OVERRIDE ?? globalScene.randBattleSeedInt(critChance) === 0;
 
     // apply crit block effects from lucky chant & co., overriding previous effects
     const blockCrit = new BooleanHolder(false);
@@ -5925,25 +5928,25 @@ export class PlayerPokemon extends Pokemon {
   ) {
     super(106, 148, species, level, abilityIndex, formIndex, gender, shiny, variant, ivs, nature, dataSource);
 
-    if (Overrides.STATUS_OVERRIDE) {
-      this.status = new Status(Overrides.STATUS_OVERRIDE, 0, 4);
+    if (activeOverrides.STATUS_OVERRIDE) {
+      this.status = new Status(activeOverrides.STATUS_OVERRIDE, 0, 4);
     }
 
-    if (Overrides.SHINY_OVERRIDE) {
+    if (activeOverrides.SHINY_OVERRIDE) {
       this.shiny = true;
       this.initShinySparkle();
-    } else if (Overrides.SHINY_OVERRIDE === false) {
+    } else if (activeOverrides.SHINY_OVERRIDE === false) {
       this.shiny = false;
     }
 
-    if (Overrides.VARIANT_OVERRIDE !== null && this.shiny) {
-      this.variant = Overrides.VARIANT_OVERRIDE;
+    if (activeOverrides.VARIANT_OVERRIDE !== null && this.shiny) {
+      this.variant = activeOverrides.VARIANT_OVERRIDE;
     }
 
     if (!dataSource) {
       if (
         globalScene.gameMode.isDaily // Keldeo is excluded due to crashes involving its signature move and the associated form change
-        || (Overrides.STARTER_SPECIES_OVERRIDE && Overrides.STARTER_SPECIES_OVERRIDE !== SpeciesId.KELDEO)
+        || (activeOverrides.STARTER_SPECIES_OVERRIDE && activeOverrides.STARTER_SPECIES_OVERRIDE !== SpeciesId.KELDEO)
       ) {
         this.generateAndPopulateMoveset();
       } else {
@@ -6104,8 +6107,8 @@ export class PlayerPokemon extends Pokemon {
           sd.friendship = friendshipCap - 1;
         }
       }
-      if (Overrides.IMMEDIATE_ADD_CANDY_OVERRIDE > 0) {
-        gameData.addStarterCandy(id, Overrides.IMMEDIATE_ADD_CANDY_OVERRIDE);
+      if (activeOverrides.IMMEDIATE_ADD_CANDY_OVERRIDE > 0) {
+        gameData.addStarterCandy(id, activeOverrides.IMMEDIATE_ADD_CANDY_OVERRIDE);
       }
     });
   }
@@ -6490,39 +6493,39 @@ export class EnemyPokemon extends Pokemon {
       this.setBoss(boss, dataSource?.bossSegments);
     }
 
-    if (Overrides.ENEMY_STATUS_OVERRIDE) {
-      this.status = new Status(Overrides.ENEMY_STATUS_OVERRIDE, 0, 4);
+    if (activeOverrides.ENEMY_STATUS_OVERRIDE) {
+      this.status = new Status(activeOverrides.ENEMY_STATUS_OVERRIDE, 0, 4);
     }
 
-    if (Overrides.ENEMY_GENDER_OVERRIDE !== null) {
-      this.gender = Overrides.ENEMY_GENDER_OVERRIDE;
+    if (activeOverrides.ENEMY_GENDER_OVERRIDE !== null) {
+      this.gender = activeOverrides.ENEMY_GENDER_OVERRIDE;
     }
 
     const speciesId = this.species.speciesId;
 
     if (
-      speciesId in Overrides.ENEMY_FORM_OVERRIDES
-      && Overrides.ENEMY_FORM_OVERRIDES[speciesId] != null
-      && this.species.forms[Overrides.ENEMY_FORM_OVERRIDES[speciesId]]
+      speciesId in activeOverrides.ENEMY_FORM_OVERRIDES
+      && activeOverrides.ENEMY_FORM_OVERRIDES[speciesId] != null
+      && this.species.forms[activeOverrides.ENEMY_FORM_OVERRIDES[speciesId]]
     ) {
-      this.formIndex = Overrides.ENEMY_FORM_OVERRIDES[speciesId];
+      this.formIndex = activeOverrides.ENEMY_FORM_OVERRIDES[speciesId];
     }
 
     if (!dataSource) {
       this.generateAndPopulateMoveset(forRival);
-      if (shinyLock || Overrides.ENEMY_SHINY_OVERRIDE === false) {
+      if (shinyLock || activeOverrides.ENEMY_SHINY_OVERRIDE === false) {
         this.shiny = false;
       } else {
         this.trySetShiny();
       }
 
-      if (!this.shiny && Overrides.ENEMY_SHINY_OVERRIDE) {
+      if (!this.shiny && activeOverrides.ENEMY_SHINY_OVERRIDE) {
         this.shiny = true;
         this.initShinySparkle();
       }
 
       if (this.shiny) {
-        this.variant = Overrides.ENEMY_VARIANT_OVERRIDE ?? this.generateShinyVariant();
+        this.variant = activeOverrides.ENEMY_VARIANT_OVERRIDE ?? this.generateShinyVariant();
       }
 
       this.luck = (this.shiny ? this.variant + 1 : 0) + (this.fusionShiny ? this.fusionVariant + 1 : 0);

--- a/src/game-mode.ts
+++ b/src/game-mode.ts
@@ -1,7 +1,7 @@
 import { FixedBattleConfig } from "#app/battle";
 import { CHALLENGE_MODE_MYSTERY_ENCOUNTER_WAVES, CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants";
 import { globalScene } from "#app/global-scene";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { allChallenges, type Challenge, copyChallenge } from "#data/challenge";
 import {
   getDailyEventSeedBoss,
@@ -136,8 +136,8 @@ export class GameMode implements GameModeConfig {
    * - 5 for all other modes
    */
   getStartingLevel(): number {
-    if (Overrides.STARTING_LEVEL_OVERRIDE > 0) {
-      return Overrides.STARTING_LEVEL_OVERRIDE;
+    if (activeOverrides.STARTING_LEVEL_OVERRIDE > 0) {
+      return activeOverrides.STARTING_LEVEL_OVERRIDE;
     }
     switch (this.modeId) {
       case GameModes.DAILY:
@@ -154,8 +154,8 @@ export class GameMode implements GameModeConfig {
    * - override from a custom daily seed
    */
   getStartingMoney(): number {
-    if (Overrides.STARTING_MONEY_OVERRIDE > 0) {
-      return Overrides.STARTING_MONEY_OVERRIDE;
+    if (activeOverrides.STARTING_MONEY_OVERRIDE > 0) {
+      return activeOverrides.STARTING_MONEY_OVERRIDE;
     }
 
     switch (this.modeId) {
@@ -178,8 +178,8 @@ export class GameMode implements GameModeConfig {
    * - Town
    */
   getStartingBiome(): BiomeId {
-    if (Overrides.STARTING_BIOME_OVERRIDE != null) {
-      return Overrides.STARTING_BIOME_OVERRIDE;
+    if (activeOverrides.STARTING_BIOME_OVERRIDE != null) {
+      return activeOverrides.STARTING_BIOME_OVERRIDE;
     }
 
     switch (this.modeId) {

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -2,7 +2,7 @@ import { TYPE_BOOST_ITEM_BOOST_PERCENT } from "#app/constants";
 import { timedEventManager } from "#app/global-event-manager";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { EvolutionItem, pokemonEvolutions } from "#balance/pokemon-evolutions";
 import { tmSpecies } from "#balance/tm-species-map";
 import { tmPoolTiers } from "#balance/tms";
@@ -2607,15 +2607,15 @@ function getModifierTypeOptionWithRetry(
 
 /**
  * Replaces the {@linkcode ModifierType} of the entries within {@linkcode options} with any
- * {@linkcode ModifierOverride} entries listed in {@linkcode Overrides.ITEM_REWARD_OVERRIDE}
+ * {@linkcode ModifierOverride} entries listed in {@linkcode activeOverrides.ITEM_REWARD_OVERRIDE}
  * up to the smallest amount of entries between {@linkcode options} and the override array.
  * @param options Array of naturally rolled {@linkcode ModifierTypeOption}s
  * @param party Array of the player's current party
  */
 export function overridePlayerModifierTypeOptions(options: ModifierTypeOption[], party: PlayerPokemon[]) {
-  const minLength = Math.min(options.length, Overrides.ITEM_REWARD_OVERRIDE.length);
+  const minLength = Math.min(options.length, activeOverrides.ITEM_REWARD_OVERRIDE.length);
   for (let i = 0; i < minLength; i++) {
-    const override: ModifierOverride = Overrides.ITEM_REWARD_OVERRIDE[i];
+    const override: ModifierOverride = activeOverrides.ITEM_REWARD_OVERRIDE[i];
     const modifierFunc = modifierTypeInitObj[override.name];
     let modifierType: ModifierType | null = modifierFunc();
 

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -1,7 +1,7 @@
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { FusionSpeciesFormEvolution, pokemonEvolutions } from "#balance/pokemon-evolutions";
 import { FRIENDSHIP_GAIN_FROM_RARE_CANDY } from "#balance/starters";
 import { getBerryEffectFunc, getBerryPredicate } from "#data/berry";
@@ -3718,8 +3718,8 @@ export class EnemyFusionChanceModifier extends EnemyPersistentModifier {
  */
 export function overrideModifiers(isPlayer = true): void {
   const modifiersOverride: ModifierOverride[] = isPlayer
-    ? Overrides.STARTING_MODIFIER_OVERRIDE
-    : Overrides.ENEMY_MODIFIER_OVERRIDE;
+    ? activeOverrides.STARTING_MODIFIER_OVERRIDE
+    : activeOverrides.ENEMY_MODIFIER_OVERRIDE;
   if (!modifiersOverride || modifiersOverride.length === 0 || !globalScene) {
     return;
   }
@@ -3760,8 +3760,8 @@ export function overrideModifiers(isPlayer = true): void {
  */
 export function overrideHeldItems(pokemon: Pokemon, isPlayer = true): void {
   const heldItemsOverride: ModifierOverride[] = isPlayer
-    ? Overrides.STARTING_HELD_ITEMS_OVERRIDE
-    : Overrides.ENEMY_HELD_ITEMS_OVERRIDE;
+    ? activeOverrides.STARTING_HELD_ITEMS_OVERRIDE
+    : activeOverrides.ENEMY_HELD_ITEMS_OVERRIDE;
   if (!heldItemsOverride || heldItemsOverride.length === 0 || !globalScene) {
     return;
   }

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -97,7 +97,7 @@ class DefaultOverrides {
    * This override's ability to force doubles trainer battles is deprecated due to not altering the spawned trainer's variant,
    * and may be removed in a future PR.
    */
-  readonly BATTLE_STYLE_OVERRIDE: BattleStyle | null = null;
+  readonly BATTLE_STYLE_OVERRIDE: BattleStyleOverride | null = null;
   /**
    * If present and non-`null`, will override the starting wave # when starting a new run.
    * Should never be set to a negative value.
@@ -349,12 +349,9 @@ class DefaultOverrides {
 
 export const defaultOverrides = new DefaultOverrides();
 
-export default {
-  ...defaultOverrides,
-  ...overrides,
-} satisfies InstanceType<typeof DefaultOverrides>;
+export const activeOverrides = { ...defaultOverrides, ...overrides } satisfies InstanceType<OverridesType>;
 
-export type BattleStyle = "double" | "single" | "even-doubles" | "odd-doubles";
+export type BattleStyleOverride = "double" | "single" | "even-doubles" | "odd-doubles";
 
 export type RandomTrainerOverride = {
   /** The Type of trainer to force */
@@ -368,4 +365,4 @@ export type RandomTrainerOverride = {
 };
 
 /** The type of the {@linkcode DefaultOverrides} class */
-export type OverridesType = typeof DefaultOverrides;
+type OverridesType = typeof DefaultOverrides;

--- a/src/phases/attempt-run-phase.ts
+++ b/src/phases/attempt-run-phase.ts
@@ -1,6 +1,6 @@
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { ArenaTagSide } from "#enums/arena-tag-side";
 import { Stat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
@@ -74,8 +74,8 @@ export class AttemptRunPhase extends FieldPhase {
    */
   public calculateEscapeChance(escapeAttempts: number): number {
     //   Check for override, guaranteeing or forbidding random flee attempts as applicable.
-    if (Overrides.RUN_SUCCESS_OVERRIDE !== null) {
-      return Overrides.RUN_SUCCESS_OVERRIDE ? 100 : 0;
+    if (activeOverrides.RUN_SUCCESS_OVERRIDE !== null) {
+      return activeOverrides.RUN_SUCCESS_OVERRIDE ? 100 : 0;
     }
 
     const enemyField = globalScene.getEnemyField();

--- a/src/phases/egg-lapse-phase.ts
+++ b/src/phases/egg-lapse-phase.ts
@@ -1,5 +1,5 @@
 import { globalScene } from "#app/global-scene";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { Phase } from "#app/phase";
 import type { Egg } from "#data/egg";
 import { EGG_SEED } from "#data/egg";
@@ -21,7 +21,7 @@ export class EggLapsePhase extends Phase {
   start() {
     super.start();
     const eggsToHatch: Egg[] = globalScene.gameData.eggs.filter((egg: Egg) => {
-      return Overrides.EGG_IMMEDIATE_HATCH_OVERRIDE ? true : --egg.hatchWaves < 1;
+      return activeOverrides.EGG_IMMEDIATE_HATCH_OVERRIDE ? true : --egg.hatchWaves < 1;
     });
     const eggsToHatchCount: number = eggsToHatch.length;
     this.eggHatchData = [];

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -2,7 +2,7 @@ import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { PLAYER_PARTY_MAX_SIZE, WEIGHT_INCREMENT_ON_SPAWN_MISS } from "#app/constants";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { handleTutorial, Tutorial } from "#app/tutorial";
 import { initEncounterAnims, loadEncounterAnimAssets } from "#data/battle-anims";
 import { getCharVariantFromDialogue } from "#data/dialogue";
@@ -222,7 +222,7 @@ export class EncounterPhase extends BattlePhase {
         }),
       );
     } else {
-      const overridedBossSegments = Overrides.ENEMY_HEALTH_SEGMENTS_OVERRIDE > 1;
+      const overridedBossSegments = activeOverrides.ENEMY_HEALTH_SEGMENTS_OVERRIDE > 1;
       // for double battles, reduce the health segments for boss Pokemon unless there is an override
       if (!overridedBossSegments && battle.enemyParty.filter(p => p.isBoss()).length > 1) {
         for (const enemyPokemon of battle.enemyParty) {

--- a/src/phases/learn-move-phase.ts
+++ b/src/phases/learn-move-phase.ts
@@ -1,6 +1,6 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { initMoveAnim, loadMoveAnimAssets } from "#data/battle-anims";
 import { allMoves } from "#data/data-lists";
 import { SpeciesFormChangeMoveLearnedTrigger } from "#data/form-change-triggers";
@@ -206,7 +206,7 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
       if (this.cost === -1) {
         globalScene.phaseManager.tryRemovePhase("SelectModifierPhase");
       } else {
-        if (!Overrides.WAIVE_ROLL_FEE_OVERRIDE) {
+        if (!activeOverrides.WAIVE_ROLL_FEE_OVERRIDE) {
           globalScene.money -= this.cost;
           globalScene.updateMoneyText();
           globalScene.animateMoneyChanged(false);

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -2,7 +2,7 @@ import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { MOVE_COLOR } from "#app/constants/colors";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { PokemonPhase } from "#app/phases/pokemon-phase";
 import { CenterOfAttentionTag, type EncoreTag } from "#data/battler-tags";
 import { SpeciesFormChangePreMoveTrigger } from "#data/form-change-triggers";
@@ -370,7 +370,7 @@ export class MovePhase extends PokemonPhase {
       return false;
     }
 
-    if (Overrides.STATUS_ACTIVATION_OVERRIDE) {
+    if (activeOverrides.STATUS_ACTIVATION_OVERRIDE) {
       return false;
     }
 
@@ -384,11 +384,11 @@ export class MovePhase extends PokemonPhase {
       return false;
     }
     if (
-      Overrides.STATUS_ACTIVATION_OVERRIDE === false
+      activeOverrides.STATUS_ACTIVATION_OVERRIDE === false
       || this.move
         .getMove()
         .findAttr(attr => attr.selfTarget && attr.is("HealStatusEffectAttr") && attr.isOfEffect(StatusEffect.FREEZE))
-      || (!pokemon.randBattleSeedInt(5) && Overrides.STATUS_ACTIVATION_OVERRIDE !== true)
+      || (!pokemon.randBattleSeedInt(5) && activeOverrides.STATUS_ACTIVATION_OVERRIDE !== true)
     ) {
       pokemon.cureStatus(StatusEffect.FREEZE);
       return false;
@@ -519,7 +519,7 @@ export class MovePhase extends PokemonPhase {
       return false;
     }
 
-    const proc = Overrides.STATUS_ACTIVATION_OVERRIDE ?? user.randBattleSeedInt(4) === 0;
+    const proc = activeOverrides.STATUS_ACTIVATION_OVERRIDE ?? user.randBattleSeedInt(4) === 0;
     if (!proc) {
       return false;
     }

--- a/src/phases/select-modifier-phase.ts
+++ b/src/phases/select-modifier-phase.ts
@@ -1,5 +1,5 @@
 import { globalScene } from "#app/global-scene";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { ModifierPoolType } from "#enums/modifier-pool-type";
 import type { ModifierTier } from "#enums/modifier-tier";
 import { UiMode } from "#enums/ui-mode";
@@ -156,7 +156,7 @@ export class SelectModifierPhase extends BattlePhase {
     globalScene.applyModifier(HealShopCostModifier, true, healingItemCost);
     const cost = healingItemCost.value;
 
-    if (globalScene.money < cost && !Overrides.WAIVE_ROLL_FEE_OVERRIDE) {
+    if (globalScene.money < cost && !activeOverrides.WAIVE_ROLL_FEE_OVERRIDE) {
       globalScene.ui.playError();
       return false;
     }
@@ -197,7 +197,7 @@ export class SelectModifierPhase extends BattlePhase {
     );
     globalScene.ui.clearText();
     globalScene.ui.setMode(UiMode.MESSAGE).then(() => super.end());
-    if (!Overrides.WAIVE_ROLL_FEE_OVERRIDE) {
+    if (!activeOverrides.WAIVE_ROLL_FEE_OVERRIDE) {
       globalScene.money -= rerollCost;
       globalScene.updateMoneyText();
       globalScene.animateMoneyChanged(false);
@@ -276,7 +276,7 @@ export class SelectModifierPhase extends BattlePhase {
 
     if (cost !== -1 && !(modifier.type instanceof RememberMoveModifierType)) {
       if (result) {
-        if (!Overrides.WAIVE_ROLL_FEE_OVERRIDE) {
+        if (!activeOverrides.WAIVE_ROLL_FEE_OVERRIDE) {
           globalScene.money -= cost;
           globalScene.updateMoneyText();
           globalScene.animateMoneyChanged(false);
@@ -416,7 +416,7 @@ export class SelectModifierPhase extends BattlePhase {
 
   getRerollCost(lockRarities: boolean): number {
     let baseValue = 0;
-    if (Overrides.WAIVE_ROLL_FEE_OVERRIDE) {
+    if (activeOverrides.WAIVE_ROLL_FEE_OVERRIDE) {
       return baseValue;
     }
     if (lockRarities) {

--- a/src/phases/select-starter-phase.ts
+++ b/src/phases/select-starter-phase.ts
@@ -1,5 +1,5 @@
 import { globalScene } from "#app/global-scene";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { Phase } from "#app/phase";
 import { SpeciesFormChangeMoveLearnedTrigger } from "#data/form-change-triggers";
 import { Gender } from "#data/gender";
@@ -42,23 +42,23 @@ export class SelectStarterPhase extends Phase {
     const party = globalScene.getPlayerParty();
     const loadPokemonAssets: Promise<void>[] = [];
     starters.forEach((starter: Starter, i: number) => {
-      if (!i && Overrides.STARTER_SPECIES_OVERRIDE) {
-        starter.speciesId = Overrides.STARTER_SPECIES_OVERRIDE;
+      if (!i && activeOverrides.STARTER_SPECIES_OVERRIDE) {
+        starter.speciesId = activeOverrides.STARTER_SPECIES_OVERRIDE;
       }
       const species = getPokemonSpecies(starter.speciesId);
       let starterFormIndex = starter.formIndex;
       if (
-        starter.speciesId in Overrides.STARTER_FORM_OVERRIDES
-        && Overrides.STARTER_FORM_OVERRIDES[starter.speciesId] != null
-        && species.forms[Overrides.STARTER_FORM_OVERRIDES[starter.speciesId]!]
+        starter.speciesId in activeOverrides.STARTER_FORM_OVERRIDES
+        && activeOverrides.STARTER_FORM_OVERRIDES[starter.speciesId] != null
+        && species.forms[activeOverrides.STARTER_FORM_OVERRIDES[starter.speciesId]!]
       ) {
-        starterFormIndex = Overrides.STARTER_FORM_OVERRIDES[starter.speciesId]!;
+        starterFormIndex = activeOverrides.STARTER_FORM_OVERRIDES[starter.speciesId]!;
       }
 
       let starterGender =
         species.malePercent === null ? Gender.GENDERLESS : starter.female ? Gender.FEMALE : Gender.MALE;
-      if (Overrides.GENDER_OVERRIDE !== null) {
-        starterGender = Overrides.GENDER_OVERRIDE;
+      if (activeOverrides.GENDER_OVERRIDE !== null) {
+        starterGender = activeOverrides.GENDER_OVERRIDE;
       }
       const starterPokemon = globalScene.addPlayerPokemon(
         species,
@@ -94,7 +94,7 @@ export class SelectStarterPhase extends Phase {
         starterPokemon.teraType = starter.teraType;
       }
 
-      if (globalScene.gameMode.isSplicedOnly || Overrides.STARTER_FUSION_OVERRIDE) {
+      if (globalScene.gameMode.isSplicedOnly || activeOverrides.STARTER_FUSION_OVERRIDE) {
         starterPokemon.generateFusionSpecies(true);
       }
       starterPokemon.setVisible(false);

--- a/src/phases/title-phase.ts
+++ b/src/phases/title-phase.ts
@@ -3,7 +3,7 @@ import { loggedInUser } from "#app/account";
 import { GameMode, getGameMode } from "#app/game-mode";
 import { timedEventManager } from "#app/global-event-manager";
 import { globalScene } from "#app/global-scene";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { Phase } from "#app/phase";
 import { bypassLogin } from "#constants/app-constants";
 import { getDailyRunStarters, startDailyEventChallenges } from "#data/daily-seed/daily-run";
@@ -338,11 +338,11 @@ export class TitlePhase extends Phase {
       } else {
         // Grab first 10 chars of ISO date format (YYYY-MM-DD) and convert to base64
         let seed: string = btoa(new Date().toISOString().slice(0, 10));
-        if (Overrides.DAILY_RUN_SEED_OVERRIDE != null) {
+        if (activeOverrides.DAILY_RUN_SEED_OVERRIDE != null) {
           seed =
-            typeof Overrides.DAILY_RUN_SEED_OVERRIDE === "string"
-              ? Overrides.DAILY_RUN_SEED_OVERRIDE
-              : JSON.stringify(Overrides.DAILY_RUN_SEED_OVERRIDE);
+            typeof activeOverrides.DAILY_RUN_SEED_OVERRIDE === "string"
+              ? activeOverrides.DAILY_RUN_SEED_OVERRIDE
+              : JSON.stringify(activeOverrides.DAILY_RUN_SEED_OVERRIDE);
         }
         generateDaily(seed);
       }

--- a/src/pipelines/field-sprite.ts
+++ b/src/pipelines/field-sprite.ts
@@ -1,5 +1,5 @@
 import { globalScene } from "#app/global-scene";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { getTerrainColor } from "#data/terrain";
 import { TimeOfDay } from "#enums/time-of-day";
 import type { RGBArray } from "#types/sprite-types";
@@ -78,7 +78,7 @@ export class FieldSpritePipeline extends Phaser.Renderer.WebGL.Pipelines.MultiPi
  * @returns The overriden tint colors as an RGB array.
  */
 function overrideTint(): RGBArray {
-  switch (Overrides.TIME_OF_DAY_OVERRIDE) {
+  switch (activeOverrides.TIME_OF_DAY_OVERRIDE) {
     case TimeOfDay.DAY:
     case TimeOfDay.DAWN:
       return globalScene.arena.getDayTint();

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -3,7 +3,7 @@ import { clientSessionId, getSessionDataLocalStorageKey, loggedInUser, updateUse
 import { defaultStarterSpecies, saveKey } from "#app/constants";
 import { getGameMode } from "#app/game-mode";
 import { globalScene } from "#app/global-scene";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { isIos } from "#app/touch-controls";
 import { Tutorial } from "#app/tutorial";
 import { speciesEggMoves } from "#balance/moves/egg-moves";
@@ -212,7 +212,7 @@ export class GameData {
    * @returns `true` if the player has unlocked this `Unlockable` or an override has enabled it
    */
   public isUnlocked(unlockable: Unlockables): boolean {
-    if (Overrides.ITEM_UNLOCK_OVERRIDE.includes(unlockable)) {
+    if (activeOverrides.ITEM_UNLOCK_OVERRIDE.includes(unlockable)) {
       return true;
     }
     return this.unlocks[unlockable];
@@ -956,8 +956,8 @@ export class GameData {
     Object.keys(globalScene.pokeballCounts).forEach((key: string) => {
       globalScene.pokeballCounts[key] = fromSession.pokeballCounts[key] || 0;
     });
-    if (Overrides.POKEBALL_OVERRIDE.active) {
-      globalScene.pokeballCounts = Overrides.POKEBALL_OVERRIDE.pokeballs;
+    if (activeOverrides.POKEBALL_OVERRIDE.active) {
+      globalScene.pokeballCounts = activeOverrides.POKEBALL_OVERRIDE.pokeballs;
     }
 
     globalScene.money = Math.floor(fromSession.money || 0);
@@ -1852,8 +1852,8 @@ export class GameData {
    * Adds candy to the player's game data for a given {@linkcode PokemonSpecies}.
    * @remarks
    * Will not increase the candy count past {@linkcode MAX_STARTER_CANDY_COUNT}.
-   * @param speciesId - The species ID of the PokÃ©mon to increment candy for
-   * @param numCandiesToAdd - The number of candies to add to the PokÃ©mon
+   * @param speciesId - The species ID of the Pokémon to increment candy for
+   * @param numCandiesToAdd - The number of candies to add to the Pokémon
    * @returns Whether the candy count was incremented
    */
   public addStarterCandy(speciesId: SpeciesId, numCandiesToAdd: number): boolean {

--- a/src/tutorial.ts
+++ b/src/tutorial.ts
@@ -1,5 +1,5 @@
 import { globalScene } from "#app/global-scene";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { UiMode } from "#enums/ui-mode";
 import { AwaitableUiHandler } from "#ui/awaitable-ui-handler";
 import type { UiHandler } from "#ui/ui-handler";
@@ -127,11 +127,11 @@ const tutorialHandlers = {
  * @returns a promise with result `true` if the tutorial was run and finished, `false` otherwise
  */
 export async function handleTutorial(tutorial: Tutorial): Promise<boolean> {
-  if (!globalScene.enableTutorials && !Overrides.BYPASS_TUTORIAL_SKIP_OVERRIDE) {
+  if (!globalScene.enableTutorials && !activeOverrides.BYPASS_TUTORIAL_SKIP_OVERRIDE) {
     return false;
   }
 
-  if (globalScene.gameData.getTutorialFlags()[tutorial] && !Overrides.BYPASS_TUTORIAL_SKIP_OVERRIDE) {
+  if (globalScene.gameData.getTutorialFlags()[tutorial] && !activeOverrides.BYPASS_TUTORIAL_SKIP_OVERRIDE) {
     return false;
   }
 

--- a/src/ui/handlers/egg-gacha-ui-handler.ts
+++ b/src/ui/handlers/egg-gacha-ui-handler.ts
@@ -1,5 +1,5 @@
 import { globalScene } from "#app/global-scene";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { handleTutorial, Tutorial } from "#app/tutorial";
 import type { IEggOptions } from "#data/egg";
 import { Egg, getLegendaryGachaSpeciesForTimestamp } from "#data/egg";
@@ -493,8 +493,8 @@ export class EggGachaUiHandler extends MessageUiHandler {
    * @param pullCount - The number of eggs to pull
    */
   async pull(pullCount = 0): Promise<void> {
-    if (Overrides.EGG_GACHA_PULL_COUNT_OVERRIDE) {
-      pullCount = Overrides.EGG_GACHA_PULL_COUNT_OVERRIDE;
+    if (activeOverrides.EGG_GACHA_PULL_COUNT_OVERRIDE) {
+      pullCount = activeOverrides.EGG_GACHA_PULL_COUNT_OVERRIDE;
     }
 
     // Set the eggs
@@ -738,7 +738,7 @@ export class EggGachaUiHandler extends MessageUiHandler {
     const [voucherType, vouchersConsumed, pulls] = voucher;
 
     let errorKey: string | undefined;
-    const freePulls = Overrides.EGG_FREE_GACHA_PULLS_OVERRIDE;
+    const freePulls = activeOverrides.EGG_FREE_GACHA_PULLS_OVERRIDE;
 
     if (!freePulls && globalScene.gameData.eggs.length + pulls > 99) {
       errorKey = "egg:tooManyEggs";

--- a/src/ui/handlers/modifier-select-ui-handler.ts
+++ b/src/ui/handlers/modifier-select-ui-handler.ts
@@ -1,5 +1,5 @@
 import { globalScene } from "#app/global-scene";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { handleTutorial, Tutorial } from "#app/tutorial";
 import { allMoves } from "#data/data-lists";
 import { getPokeballAtlasKey } from "#data/pokeball";
@@ -1036,7 +1036,7 @@ class ModifierOption extends Phaser.GameObjects.Container {
   }
 
   updateCostText(): void {
-    const cost = Overrides.WAIVE_ROLL_FEE_OVERRIDE ? 0 : this.modifierTypeOption.cost;
+    const cost = activeOverrides.WAIVE_ROLL_FEE_OVERRIDE ? 0 : this.modifierTypeOption.cost;
     const textStyle = cost <= globalScene.money ? TextStyle.MONEY : TextStyle.PARTY_RED;
 
     const formattedMoney = formatMoney(globalScene.moneyFormat, cost);

--- a/src/ui/handlers/pokedex-page-ui-handler.ts
+++ b/src/ui/handlers/pokedex-page-ui-handler.ts
@@ -1,6 +1,6 @@
 import { globalScene } from "#app/global-scene";
 import { starterColors } from "#app/global-vars/starter-colors";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { speciesEggMoves } from "#balance/moves/egg-moves";
 import { starterPassiveAbilities } from "#balance/passives";
 import type { SpeciesFormEvolution } from "#balance/pokemon-evolutions";
@@ -1998,12 +1998,12 @@ export class PokedexPageUiHandler extends MessageUiHandler {
               options.push({
                 label: `×${passiveCost} ${i18next.t("pokedexUiHandler:unlockPassive")}`,
                 handler: () => {
-                  if (!Overrides.FREE_CANDY_UPGRADE_OVERRIDE && candyCount < passiveCost) {
+                  if (!activeOverrides.FREE_CANDY_UPGRADE_OVERRIDE && candyCount < passiveCost) {
                     return false;
                   }
 
                   starterData.passiveAttr |= PassiveAttr.UNLOCKED | PassiveAttr.ENABLED;
-                  if (!Overrides.FREE_CANDY_UPGRADE_OVERRIDE) {
+                  if (!activeOverrides.FREE_CANDY_UPGRADE_OVERRIDE) {
                     starterData.candyCount -= passiveCost;
                   }
                   this.pokemonCandyCountText.setText(`×${starterData.candyCount}`);
@@ -2032,12 +2032,12 @@ export class PokedexPageUiHandler extends MessageUiHandler {
               options.push({
                 label: `×${reductionCost} ${i18next.t("starterSelectUiHandler:reduceCost", { newCost: globalScene.gameData.getSpeciesStarterValue(this.starterId, starterData.valueReduction + 1) })}`,
                 handler: () => {
-                  if (!Overrides.FREE_CANDY_UPGRADE_OVERRIDE && candyCount < reductionCost) {
+                  if (!activeOverrides.FREE_CANDY_UPGRADE_OVERRIDE && candyCount < reductionCost) {
                     return false;
                   }
 
                   starterData.valueReduction++;
-                  if (!Overrides.FREE_CANDY_UPGRADE_OVERRIDE) {
+                  if (!activeOverrides.FREE_CANDY_UPGRADE_OVERRIDE) {
                     starterData.candyCount -= reductionCost;
                   }
                   this.pokemonCandyCountText.setText(`×${starterData.candyCount}`);
@@ -2064,11 +2064,11 @@ export class PokedexPageUiHandler extends MessageUiHandler {
             options.push({
               label: `×${sameSpeciesEggCost} ${i18next.t("pokedexUiHandler:sameSpeciesEgg")}`,
               handler: () => {
-                if (!Overrides.FREE_CANDY_UPGRADE_OVERRIDE && candyCount < sameSpeciesEggCost) {
+                if (!activeOverrides.FREE_CANDY_UPGRADE_OVERRIDE && candyCount < sameSpeciesEggCost) {
                   return false;
                 }
 
-                if (globalScene.gameData.eggs.length >= 99 && !Overrides.UNLIMITED_EGG_COUNT_OVERRIDE) {
+                if (globalScene.gameData.eggs.length >= 99 && !activeOverrides.UNLIMITED_EGG_COUNT_OVERRIDE) {
                   // Egg list full, show error message at the top of the screen and abort
                   this.showText(
                     i18next.t("egg:tooManyEggs"),
@@ -2081,7 +2081,7 @@ export class PokedexPageUiHandler extends MessageUiHandler {
                   );
                   return false;
                 }
-                if (!Overrides.FREE_CANDY_UPGRADE_OVERRIDE) {
+                if (!activeOverrides.FREE_CANDY_UPGRADE_OVERRIDE) {
                   starterData.candyCount -= sameSpeciesEggCost;
                 }
                 this.pokemonCandyCountText.setText(`×${starterData.candyCount}`);

--- a/src/ui/handlers/starter-select-ui-handler.ts
+++ b/src/ui/handlers/starter-select-ui-handler.ts
@@ -2,7 +2,7 @@ import type { Ability } from "#abilities/ability";
 import { PLAYER_PARTY_MAX_SIZE } from "#app/constants";
 import { globalScene } from "#app/global-scene";
 import { starterColors } from "#app/global-vars/starter-colors";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { handleTutorial, Tutorial } from "#app/tutorial";
 import { speciesEggMoves } from "#balance/moves/egg-moves";
 import { pokemonPrevolutions } from "#balance/pokemon-evolutions";
@@ -2256,10 +2256,10 @@ export class StarterSelectUiHandler extends MessageUiHandler {
               options.push({
                 label: `×${passiveCost} ${i18next.t("starterSelectUiHandler:unlockPassive")}`,
                 handler: () => {
-                  if (Overrides.FREE_CANDY_UPGRADE_OVERRIDE || candyCount >= passiveCost) {
+                  if (activeOverrides.FREE_CANDY_UPGRADE_OVERRIDE || candyCount >= passiveCost) {
                     persistentStarterData.passiveAttr |= PassiveAttr.UNLOCKED | PassiveAttr.ENABLED;
                     starterData.passiveAttr = persistentStarterData.passiveAttr;
-                    if (!Overrides.FREE_CANDY_UPGRADE_OVERRIDE) {
+                    if (!activeOverrides.FREE_CANDY_UPGRADE_OVERRIDE) {
                       persistentStarterData.candyCount -= passiveCost;
                       starterData.candyCount = persistentStarterData.candyCount;
                     }
@@ -2297,10 +2297,10 @@ export class StarterSelectUiHandler extends MessageUiHandler {
               options.push({
                 label: `×${reductionCost} ${i18next.t("starterSelectUiHandler:reduceCost", { newCost: globalScene.gameData.getSpeciesStarterValue(this.lastSpecies.speciesId, starterData.valueReduction + 1) })}`,
                 handler: () => {
-                  if (Overrides.FREE_CANDY_UPGRADE_OVERRIDE || candyCount >= reductionCost) {
+                  if (activeOverrides.FREE_CANDY_UPGRADE_OVERRIDE || candyCount >= reductionCost) {
                     persistentStarterData.valueReduction++;
                     starterData.valueReduction = persistentStarterData.valueReduction;
-                    if (!Overrides.FREE_CANDY_UPGRADE_OVERRIDE) {
+                    if (!activeOverrides.FREE_CANDY_UPGRADE_OVERRIDE) {
                       persistentStarterData.candyCount -= reductionCost;
                       starterData.candyCount = persistentStarterData.candyCount;
                     }
@@ -2336,8 +2336,8 @@ export class StarterSelectUiHandler extends MessageUiHandler {
             options.push({
               label: `×${sameSpeciesEggCost} ${i18next.t("starterSelectUiHandler:sameSpeciesEgg")}`,
               handler: () => {
-                if (Overrides.FREE_CANDY_UPGRADE_OVERRIDE || candyCount >= sameSpeciesEggCost) {
-                  if (globalScene.gameData.eggs.length >= 99 && !Overrides.UNLIMITED_EGG_COUNT_OVERRIDE) {
+                if (activeOverrides.FREE_CANDY_UPGRADE_OVERRIDE || candyCount >= sameSpeciesEggCost) {
+                  if (globalScene.gameData.eggs.length >= 99 && !activeOverrides.UNLIMITED_EGG_COUNT_OVERRIDE) {
                     // Egg list full, show error message at the top of the screen and abort
                     this.showText(
                       i18next.t("egg:tooManyEggs"),
@@ -2350,7 +2350,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
                     );
                     return false;
                   }
-                  if (!Overrides.FREE_CANDY_UPGRADE_OVERRIDE) {
+                  if (!activeOverrides.FREE_CANDY_UPGRADE_OVERRIDE) {
                     persistentStarterData.candyCount -= sameSpeciesEggCost;
                     starterData.candyCount = persistentStarterData.candyCount;
                   }

--- a/test/framework/game-manager.ts
+++ b/test/framework/game-manager.ts
@@ -2,7 +2,7 @@ import { updateUserInfo } from "#app/account";
 import { BattleScene } from "#app/battle-scene";
 import { getGameMode } from "#app/game-mode";
 import { globalScene } from "#app/global-scene";
-import overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { modifierTypes } from "#data/data-lists";
 import { BattlerIndex } from "#enums/battler-index";
 import { Button } from "#enums/buttons";
@@ -220,7 +220,7 @@ export class GameManager {
     // This will consider all battle entry dialog as seens and skip them
     vi.spyOn(this.scene.ui, "shouldSkipDialogue").mockReturnValue(true);
 
-    if (overrides.ENEMY_HELD_ITEMS_OVERRIDE.length === 0) {
+    if (activeOverrides.ENEMY_HELD_ITEMS_OVERRIDE.length === 0) {
       this.removeEnemyHeldItems();
     }
 

--- a/test/helpers/challenge-mode-helper.ts
+++ b/test/helpers/challenge-mode-helper.ts
@@ -1,4 +1,4 @@
-import overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import type { Challenge } from "#data/challenge";
 import { copyChallenge } from "#data/challenge";
 import { BattleStyle } from "#enums/battle-style";
@@ -54,7 +54,7 @@ export class ChallengeModeHelper extends GameManagerHelper {
     });
 
     await this.game.phaseInterceptor.to("EncounterPhase");
-    if (overrides.ENEMY_HELD_ITEMS_OVERRIDE.length === 0 && this.game.override.removeEnemyStartingItems) {
+    if (activeOverrides.ENEMY_HELD_ITEMS_OVERRIDE.length === 0 && this.game.override.removeEnemyStartingItems) {
       this.game.removeEnemyHeldItems();
     }
   }

--- a/test/helpers/classic-mode-helper.ts
+++ b/test/helpers/classic-mode-helper.ts
@@ -1,5 +1,5 @@
 import { getGameMode } from "#app/game-mode";
-import overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { BattleStyle } from "#enums/battle-style";
 import { Button } from "#enums/buttons";
 import { GameModes } from "#enums/game-modes";
@@ -45,7 +45,7 @@ export class ClassicModeHelper extends GameManagerHelper {
     });
 
     await this.game.phaseInterceptor.to("EncounterPhase");
-    if (overrides.ENEMY_HELD_ITEMS_OVERRIDE.length === 0 && this.game.override.removeEnemyStartingItems) {
+    if (activeOverrides.ENEMY_HELD_ITEMS_OVERRIDE.length === 0 && this.game.override.removeEnemyStartingItems) {
       this.game.removeEnemyHeldItems();
     }
   }

--- a/test/helpers/daily-mode-helper.ts
+++ b/test/helpers/daily-mode-helper.ts
@@ -1,4 +1,4 @@
-import overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { BattleStyle } from "#enums/battle-style";
 import { Button } from "#enums/buttons";
 import { UiMode } from "#enums/ui-mode";
@@ -34,7 +34,7 @@ export class DailyModeHelper extends GameManagerHelper {
 
     await this.game.phaseInterceptor.to("EncounterPhase");
 
-    if (overrides.ENEMY_HELD_ITEMS_OVERRIDE.length === 0 && this.game.override.removeEnemyStartingItems) {
+    if (activeOverrides.ENEMY_HELD_ITEMS_OVERRIDE.length === 0 && this.game.override.removeEnemyStartingItems) {
       this.game.removeEnemyHeldItems();
     }
   }

--- a/test/helpers/move-helper.ts
+++ b/test/helpers/move-helper.ts
@@ -1,4 +1,4 @@
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { allMoves } from "#data/data-lists";
 import { BattlerIndex } from "#enums/battler-index";
 import { Command } from "#enums/command";
@@ -177,8 +177,8 @@ export class MoveHelper extends GameManagerHelper {
     targetIndex?: BattlerIndex,
     useTera = false,
   ): void {
-    if ([Overrides.MOVESET_OVERRIDE].flat().length > 0) {
-      vi.spyOn(Overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([]);
+    if ([activeOverrides.MOVESET_OVERRIDE].flat().length > 0) {
+      vi.spyOn(activeOverrides, "MOVESET_OVERRIDE", "get").mockReturnValue([]);
       console.warn("Warning: `MoveHelper.use` overwriting player pokemon moveset and disabling moveset override!");
     }
 
@@ -196,25 +196,25 @@ export class MoveHelper extends GameManagerHelper {
   }
 
   /**
-   * Forces the Paralysis or Freeze status to activate on the next move by temporarily mocking {@linkcode Overrides.STATUS_ACTIVATION_OVERRIDE},
+   * Forces the Paralysis or Freeze status to activate on the next move by temporarily mocking {@linkcode activeOverrides.STATUS_ACTIVATION_OVERRIDE},
    * advancing to the next `MovePhase`, and then resetting the override to `null`
    * @param activated - `true` to force the status to activate, `false` to force the status to not activate (will cause Freeze to heal)
    */
   public async forceStatusActivation(activated: boolean): Promise<void> {
-    vi.spyOn(Overrides, "STATUS_ACTIVATION_OVERRIDE", "get").mockReturnValue(activated);
+    vi.spyOn(activeOverrides, "STATUS_ACTIVATION_OVERRIDE", "get").mockReturnValue(activated);
     await this.game.phaseInterceptor.to("MovePhase");
-    vi.spyOn(Overrides, "STATUS_ACTIVATION_OVERRIDE", "get").mockReturnValue(null);
+    vi.spyOn(activeOverrides, "STATUS_ACTIVATION_OVERRIDE", "get").mockReturnValue(null);
   }
 
   /**
-   * Forces the Confusion status to activate on the next move by temporarily mocking {@linkcode Overrides.CONFUSION_ACTIVATION_OVERRIDE},
+   * Forces the Confusion status to activate on the next move by temporarily mocking {@linkcode activeOverrides.CONFUSION_ACTIVATION_OVERRIDE},
    * advancing to the next `MovePhase`, and then resetting the override to `null`
    * @param activated - `true` to force the Pokemon to hit themself, `false` to forcibly disable it
    */
   public async forceConfusionActivation(activated: boolean): Promise<void> {
-    vi.spyOn(Overrides, "CONFUSION_ACTIVATION_OVERRIDE", "get").mockReturnValue(activated);
+    vi.spyOn(activeOverrides, "CONFUSION_ACTIVATION_OVERRIDE", "get").mockReturnValue(activated);
     await this.game.phaseInterceptor.to("MovePhase");
-    vi.spyOn(Overrides, "CONFUSION_ACTIVATION_OVERRIDE", "get").mockReturnValue(null);
+    vi.spyOn(activeOverrides, "CONFUSION_ACTIVATION_OVERRIDE", "get").mockReturnValue(null);
   }
 
   /**
@@ -228,12 +228,12 @@ export class MoveHelper extends GameManagerHelper {
    */
   public changeMoveset(pokemon: Pokemon, moveset: MoveId | MoveId[]): void {
     if (pokemon.isPlayer()) {
-      if (coerceArray(Overrides.MOVESET_OVERRIDE).length > 0) {
-        vi.spyOn(Overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([]);
+      if (coerceArray(activeOverrides.MOVESET_OVERRIDE).length > 0) {
+        vi.spyOn(activeOverrides, "MOVESET_OVERRIDE", "get").mockReturnValue([]);
         console.warn("Player moveset override disabled due to use of `game.move.changeMoveset`!");
       }
-    } else if (coerceArray(Overrides.ENEMY_MOVESET_OVERRIDE).length > 0) {
-      vi.spyOn(Overrides, "ENEMY_MOVESET_OVERRIDE", "get").mockReturnValue([]);
+    } else if (coerceArray(activeOverrides.ENEMY_MOVESET_OVERRIDE).length > 0) {
+      vi.spyOn(activeOverrides, "ENEMY_MOVESET_OVERRIDE", "get").mockReturnValue([]);
       console.warn("Enemy moveset override disabled due to use of `game.move.changeMoveset`!");
     }
     moveset = coerceArray(moveset);
@@ -311,8 +311,8 @@ export class MoveHelper extends GameManagerHelper {
     const phase = this.game.scene.phaseManager.getCurrentPhase() as EnemyCommandPhase;
     const enemy = this.game.scene.getEnemyField()[phase.getFieldIndex()];
 
-    if ([Overrides.ENEMY_MOVESET_OVERRIDE].flat().length > 0) {
-      vi.spyOn(Overrides, "ENEMY_MOVESET_OVERRIDE", "get").mockReturnValue([]);
+    if ([activeOverrides.ENEMY_MOVESET_OVERRIDE].flat().length > 0) {
+      vi.spyOn(activeOverrides, "ENEMY_MOVESET_OVERRIDE", "get").mockReturnValue([]);
       console.warn(
         "Warning: `forceEnemyMove` overwrites the Pokemon's moveset and disables the enemy moveset override!",
       );

--- a/test/helpers/overrides-helper.ts
+++ b/test/helpers/overrides-helper.ts
@@ -1,7 +1,6 @@
 import { OVERRIDES_COLOR } from "#app/constants/colors";
 import { TerrainType } from "#app/data/terrain";
-import type { BattleStyle, RandomTrainerOverride } from "#app/overrides";
-import Overrides from "#app/overrides";
+import { activeOverrides, type BattleStyleOverride, type RandomTrainerOverride } from "#app/overrides";
 import { AbilityId } from "#enums/ability-id";
 import { BattleType } from "#enums/battle-type";
 import { BiomeId } from "#enums/biome-id";
@@ -76,7 +75,7 @@ export class OverridesHelper extends GameManagerHelper {
     if (wave != null && wave <= 0) {
       throw new Error("Attempted to set invalid wave index: " + wave.toString());
     }
-    vi.spyOn(Overrides, "STARTING_WAVE_OVERRIDE", "get").mockReturnValue(wave);
+    vi.spyOn(activeOverrides, "STARTING_WAVE_OVERRIDE", "get").mockReturnValue(wave);
     this.log(`Starting wave set to ${wave}!`);
     return this;
   }
@@ -87,7 +86,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public startingLevel(level: number): this {
-    vi.spyOn(Overrides, "STARTING_LEVEL_OVERRIDE", "get").mockReturnValue(level);
+    vi.spyOn(activeOverrides, "STARTING_LEVEL_OVERRIDE", "get").mockReturnValue(level);
     this.log(`Player Pokemon starting level set to ${level}!`);
     return this;
   }
@@ -98,7 +97,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public xpMultiplier(value: number): this {
-    vi.spyOn(Overrides, "XP_MULTIPLIER_OVERRIDE", "get").mockReturnValue(value);
+    vi.spyOn(activeOverrides, "XP_MULTIPLIER_OVERRIDE", "get").mockReturnValue(value);
     this.log(`XP Multiplier set to ${value}!`);
     return this;
   }
@@ -110,7 +109,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public levelCap(cap: number): this {
-    vi.spyOn(Overrides, "LEVEL_CAP_OVERRIDE", "get").mockReturnValue(cap);
+    vi.spyOn(activeOverrides, "LEVEL_CAP_OVERRIDE", "get").mockReturnValue(cap);
     let capStr: string;
     if (cap > 0) {
       capStr = `Level cap set to ${cap}!`;
@@ -129,7 +128,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public startingHeldItems(items: ModifierOverride[]): this {
-    vi.spyOn(Overrides, "STARTING_HELD_ITEMS_OVERRIDE", "get").mockReturnValue(items);
+    vi.spyOn(activeOverrides, "STARTING_HELD_ITEMS_OVERRIDE", "get").mockReturnValue(items);
     this.log("Player Pokemon starting held items set to:", items);
     return this;
   }
@@ -144,7 +143,7 @@ export class OverridesHelper extends GameManagerHelper {
    * {@linkcode ClassicModeHelper.startBattle | startBattle}
    */
   public starterSpecies(species: SpeciesId | null): this {
-    vi.spyOn(Overrides, "STARTER_SPECIES_OVERRIDE", "get").mockReturnValue(species);
+    vi.spyOn(activeOverrides, "STARTER_SPECIES_OVERRIDE", "get").mockReturnValue(species);
     if (species === null) {
       this.log("Player Pokemon starter species override disabled!");
     } else {
@@ -158,7 +157,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public enableStarterFusion(): this {
-    vi.spyOn(Overrides, "STARTER_FUSION_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(activeOverrides, "STARTER_FUSION_OVERRIDE", "get").mockReturnValue(true);
     this.log("Player Pokemon is a random fusion!");
     return this;
   }
@@ -168,12 +167,12 @@ export class OverridesHelper extends GameManagerHelper {
    * @param species - The fusion {@linkcode SpeciesId} to set, or `null` to disable the override
    * @returns `this`
    * @remarks
-   * Does nothing if {@linkcode Overrides.STARTER_FUSION_OVERRIDE} is not enabled
+   * Does nothing if {@linkcode activeOverrides.STARTER_FUSION_OVERRIDE} is not enabled
    * @see {@linkcode enableStarterFusions}
    */
   // TODO: Should we just bundle these 2 together?
   public starterFusionSpecies(species: SpeciesId | null): this {
-    vi.spyOn(Overrides, "STARTER_FUSION_SPECIES_OVERRIDE", "get").mockReturnValue(species);
+    vi.spyOn(activeOverrides, "STARTER_FUSION_SPECIES_OVERRIDE", "get").mockReturnValue(species);
     if (species === null) {
       this.log("Player Pokemon starter fusion species override disabled!");
     } else {
@@ -188,7 +187,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public starterForms(forms: Partial<Record<SpeciesId, number>>): this {
-    vi.spyOn(Overrides, "STARTER_FORM_OVERRIDES", "get").mockReturnValue(forms);
+    vi.spyOn(activeOverrides, "STARTER_FORM_OVERRIDES", "get").mockReturnValue(forms);
     const formsStr = Object.entries(forms)
       .filter(e => !!e)
       .map(([speciesId, formIndex]) => `${SpeciesId[speciesId]}=${formIndex}`)
@@ -203,7 +202,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public startingModifier(modifiers: ModifierOverride[]): this {
-    vi.spyOn(Overrides, "STARTING_MODIFIER_OVERRIDE", "get").mockReturnValue(modifiers);
+    vi.spyOn(activeOverrides, "STARTING_MODIFIER_OVERRIDE", "get").mockReturnValue(modifiers);
     this.log(`Player starting modifiers set to: ${modifiers}`);
     return this;
   }
@@ -214,7 +213,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public ability(ability: AbilityId): this {
-    vi.spyOn(Overrides, "ABILITY_OVERRIDE", "get").mockReturnValue(ability);
+    vi.spyOn(activeOverrides, "ABILITY_OVERRIDE", "get").mockReturnValue(ability);
     if (ability === AbilityId.NONE) {
       this.log("Player Pokemon ability override disabled!");
     } else {
@@ -233,7 +232,7 @@ export class OverridesHelper extends GameManagerHelper {
    */
   // TODO: Review uses and make sure callers aren't mistakedly passing `AbilityId.NONE`
   public passiveAbility(passive: AbilityId): this {
-    vi.spyOn(Overrides, "PASSIVE_ABILITY_OVERRIDE", "get").mockReturnValue(passive);
+    vi.spyOn(activeOverrides, "PASSIVE_ABILITY_OVERRIDE", "get").mockReturnValue(passive);
     if (passive === AbilityId.NONE) {
       this.log("Player Pokemon passive ability override disabled!");
     } else {
@@ -252,7 +251,7 @@ export class OverridesHelper extends GameManagerHelper {
    * If a granular per-Pokemon override is required, consider using {@linkcode FieldHelper.mockAbility}
    */
   public hasPassiveAbility(hasPassive: boolean | null): this {
-    vi.spyOn(Overrides, "HAS_PASSIVE_ABILITY_OVERRIDE", "get").mockReturnValue(hasPassive);
+    vi.spyOn(activeOverrides, "HAS_PASSIVE_ABILITY_OVERRIDE", "get").mockReturnValue(hasPassive);
     if (hasPassive === null) {
       this.log("Player Pokemon passive ability override disabled!");
     } else {
@@ -271,7 +270,7 @@ export class OverridesHelper extends GameManagerHelper {
    */
   public moveset(moveset: MoveId | MoveId[]): this {
     moveset = coerceArray(moveset);
-    vi.spyOn(Overrides, "MOVESET_OVERRIDE", "get").mockReturnValue(moveset);
+    vi.spyOn(activeOverrides, "MOVESET_OVERRIDE", "get").mockReturnValue(moveset);
     this.log(`Player Pokemon moveset set to ${stringifyEnumArray(MoveId, moveset)}!`);
     return this;
   }
@@ -284,7 +283,7 @@ export class OverridesHelper extends GameManagerHelper {
    * If this is set to `StatusEffect.SLEEP`, the duration will be set to a guaranteed 4 turns.
    */
   public statusEffect(effect: StatusEffect): this {
-    vi.spyOn(Overrides, "STATUS_OVERRIDE", "get").mockReturnValue(effect);
+    vi.spyOn(activeOverrides, "STATUS_OVERRIDE", "get").mockReturnValue(effect);
     if (effect === StatusEffect.NONE) {
       this.log("Player Pokemon status effect override disabled!");
     } else {
@@ -301,9 +300,9 @@ export class OverridesHelper extends GameManagerHelper {
    * @remarks
    * This will disable player/enemy IV normalization when called.
    */
-  public playerIVs(ivs: (typeof Overrides)["IVS_OVERRIDE"]): this {
+  public playerIVs(ivs: (typeof activeOverrides)["IVS_OVERRIDE"]): this {
     this.normalizeIVs = false;
-    vi.spyOn(Overrides, "IVS_OVERRIDE", "get").mockReturnValue(ivs);
+    vi.spyOn(activeOverrides, "IVS_OVERRIDE", "get").mockReturnValue(ivs);
     if (ivs === null) {
       this.log("Player Pokemon IVs override disabled!");
     } else {
@@ -319,7 +318,7 @@ export class OverridesHelper extends GameManagerHelper {
    */
   public nature(nature: Nature | null): this {
     this.normalizeNatures = false;
-    vi.spyOn(Overrides, "NATURE_OVERRIDE", "get").mockReturnValue(nature);
+    vi.spyOn(activeOverrides, "NATURE_OVERRIDE", "get").mockReturnValue(nature);
     if (nature === null) {
       this.log("Player Pokemon Nature override disabled!");
     } else {
@@ -336,9 +335,9 @@ export class OverridesHelper extends GameManagerHelper {
    * @remarks
    * This will disable player/enemy IV normalization when called.
    */
-  public enemyIVs(ivs: (typeof Overrides)["IVS_OVERRIDE"]): this {
+  public enemyIVs(ivs: (typeof activeOverrides)["IVS_OVERRIDE"]): this {
     this.normalizeIVs = false;
-    vi.spyOn(Overrides, "ENEMY_IVS_OVERRIDE", "get").mockReturnValue(ivs);
+    vi.spyOn(activeOverrides, "ENEMY_IVS_OVERRIDE", "get").mockReturnValue(ivs);
     if (ivs === null) {
       this.log("Enemy Pokemon IVs override disabled!");
     } else {
@@ -354,7 +353,7 @@ export class OverridesHelper extends GameManagerHelper {
    */
   public enemyNature(nature: Nature | null): this {
     this.normalizeNatures = false;
-    vi.spyOn(Overrides, "ENEMY_NATURE_OVERRIDE", "get").mockReturnValue(nature);
+    vi.spyOn(activeOverrides, "ENEMY_NATURE_OVERRIDE", "get").mockReturnValue(nature);
     if (nature === null) {
       this.log("Enemy Nature override disabled!");
     } else {
@@ -370,7 +369,7 @@ export class OverridesHelper extends GameManagerHelper {
    * Use {@linkcode battleType} instead
    */
   public disableTrainerWaves(): this {
-    vi.spyOn(Overrides, "DISABLE_STANDARD_TRAINERS_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(activeOverrides, "DISABLE_STANDARD_TRAINERS_OVERRIDE", "get").mockReturnValue(true);
     this.log("Standard trainer waves are disabled!");
     return this;
   }
@@ -384,7 +383,7 @@ export class OverridesHelper extends GameManagerHelper {
    * Does **not** force the wave to be a trainer battle.
    */
   public randomTrainer(trainer: RandomTrainerOverride | null): this {
-    vi.spyOn(Overrides, "RANDOM_TRAINER_OVERRIDE", "get").mockReturnValue(trainer);
+    vi.spyOn(activeOverrides, "RANDOM_TRAINER_OVERRIDE", "get").mockReturnValue(trainer);
     if (trainer === null) {
       this.log("Random trainer override disabled!");
     } else {
@@ -406,7 +405,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public criticalHits(alwaysCrit: boolean | null): this {
-    vi.spyOn(Overrides, "CRITICAL_HIT_OVERRIDE", "get").mockReturnValue(alwaysCrit);
+    vi.spyOn(activeOverrides, "CRITICAL_HIT_OVERRIDE", "get").mockReturnValue(alwaysCrit);
     const freq = alwaysCrit === true ? "always" : alwaysCrit === false ? "never" : "randomly";
     this.log(`Critical hit rolls set to ${freq} succeed!`);
     return this;
@@ -422,7 +421,7 @@ export class OverridesHelper extends GameManagerHelper {
    * This behavior is dubious in quality and should hopefully be made sane.
    */
   public weather(type: WeatherType): this {
-    vi.spyOn(Overrides, "WEATHER_OVERRIDE", "get").mockReturnValue(type);
+    vi.spyOn(activeOverrides, "WEATHER_OVERRIDE", "get").mockReturnValue(type);
     this.log(`Weather set to ${getEnumStr(WeatherType, type)}!`);
     return this;
   }
@@ -436,7 +435,7 @@ export class OverridesHelper extends GameManagerHelper {
    * a new biome, and will last until removed or replaced by another effect.
    */
   public startingTerrain(terrainType: TerrainType): this {
-    vi.spyOn(Overrides, "STARTING_TERRAIN_OVERRIDE", "get").mockReturnValue(terrainType);
+    vi.spyOn(activeOverrides, "STARTING_TERRAIN_OVERRIDE", "get").mockReturnValue(terrainType);
     this.log(`Starting terrain for next biome set to ${getEnumStr(TerrainType, terrainType)}!`);
     return this;
   }
@@ -457,11 +456,11 @@ export class OverridesHelper extends GameManagerHelper {
 
   /**
    * Override the battle style (e.g., single or double).
-   * @param battleStyle - The {@linkcode BattleStyle} to set, or `null` to disable the override
+   * @param battleStyle - The {@linkcode BattleStyleOverride} to set, or `null` to disable the override
    * @returns `this`
    */
-  public battleStyle(battleStyle: BattleStyle | null): this {
-    vi.spyOn(Overrides, "BATTLE_STYLE_OVERRIDE", "get").mockReturnValue(battleStyle);
+  public battleStyle(battleStyle: BattleStyleOverride | null): this {
+    vi.spyOn(activeOverrides, "BATTLE_STYLE_OVERRIDE", "get").mockReturnValue(battleStyle);
     this.log(battleStyle === null ? "Battle type override disabled!" : `Battle type set to ${battleStyle}!`);
     return this;
   }
@@ -474,7 +473,7 @@ export class OverridesHelper extends GameManagerHelper {
    * Typically used to either guarantee or forbid trainer battles.
    */
   public battleType(battleType: Exclude<BattleType, BattleType.CLEAR>): this {
-    vi.spyOn(Overrides, "BATTLE_TYPE_OVERRIDE", "get").mockReturnValue(battleType);
+    vi.spyOn(activeOverrides, "BATTLE_TYPE_OVERRIDE", "get").mockReturnValue(battleType);
     this.log(
       battleType === null
         ? "Battle type override disabled!"
@@ -489,7 +488,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public enemySpecies(species: SpeciesId | null): this {
-    vi.spyOn(Overrides, "ENEMY_SPECIES_OVERRIDE", "get").mockReturnValue(species);
+    vi.spyOn(activeOverrides, "ENEMY_SPECIES_OVERRIDE", "get").mockReturnValue(species);
     if (species === null) {
       this.log("Enemy Pokemon starter species override disabled!");
     } else {
@@ -504,7 +503,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public enableEnemyFusion(): this {
-    vi.spyOn(Overrides, "ENEMY_FUSION_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(activeOverrides, "ENEMY_FUSION_OVERRIDE", "get").mockReturnValue(true);
     this.log("Enemy Pokemon is a random fusion!");
     return this;
   }
@@ -514,12 +513,12 @@ export class OverridesHelper extends GameManagerHelper {
    * @param species - The fusion {@linkcode SpeciesId} to set, or `null` to disable the override
    * @returns `this`
    * @remarks
-   * Does nothing if {@linkcode Overrides.ENEMY_FUSION_OVERRIDE} is not enabled
+   * Does nothing if {@linkcode activeOverrides.ENEMY_FUSION_OVERRIDE} is not enabled
    * @see {@linkcode enableEnemyFusion}
    */
   // TODO: Should we just bundle these 2 together?
   public enemyFusionSpecies(species: SpeciesId | null): this {
-    vi.spyOn(Overrides, "ENEMY_FUSION_SPECIES_OVERRIDE", "get").mockReturnValue(species);
+    vi.spyOn(activeOverrides, "ENEMY_FUSION_SPECIES_OVERRIDE", "get").mockReturnValue(species);
     if (species === null) {
       this.log("Enemy Pokemon fusion species override disabled!");
     } else {
@@ -534,7 +533,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public enemyAbility(ability: AbilityId): this {
-    vi.spyOn(Overrides, "ENEMY_ABILITY_OVERRIDE", "get").mockReturnValue(ability);
+    vi.spyOn(activeOverrides, "ENEMY_ABILITY_OVERRIDE", "get").mockReturnValue(ability);
     if (ability === AbilityId.NONE) {
       this.log("Enemy Pokemon ability override disabled!");
     } else {
@@ -553,7 +552,7 @@ export class OverridesHelper extends GameManagerHelper {
    */
   // TODO: Review uses and make sure callers aren't mistakedly passing `AbilityId.NONE`
   public enemyPassiveAbility(passive: AbilityId): this {
-    vi.spyOn(Overrides, "ENEMY_PASSIVE_ABILITY_OVERRIDE", "get").mockReturnValue(passive);
+    vi.spyOn(activeOverrides, "ENEMY_PASSIVE_ABILITY_OVERRIDE", "get").mockReturnValue(passive);
     if (passive === AbilityId.NONE) {
       this.log("Enemy Pokemon passive ability override disabled!");
     } else {
@@ -572,7 +571,7 @@ export class OverridesHelper extends GameManagerHelper {
    * If a granular per-Pokemon override is required, consider using {@linkcode FieldHelper.mockAbility}
    */
   public enemyHasPassiveAbility(hasPassive: boolean | null): this {
-    vi.spyOn(Overrides, "ENEMY_HAS_PASSIVE_ABILITY_OVERRIDE", "get").mockReturnValue(hasPassive);
+    vi.spyOn(activeOverrides, "ENEMY_HAS_PASSIVE_ABILITY_OVERRIDE", "get").mockReturnValue(hasPassive);
     if (hasPassive === null) {
       this.log("Enemy Pokemon passive ability override disabled!");
     } else {
@@ -592,7 +591,7 @@ export class OverridesHelper extends GameManagerHelper {
    */
   // TODO: Make the default value for the override actually sensible and forbid 1-length arrays
   public enemyMoveset(moveset: MoveId | MoveId[]): this {
-    vi.spyOn(Overrides, "ENEMY_MOVESET_OVERRIDE", "get").mockReturnValue(moveset);
+    vi.spyOn(activeOverrides, "ENEMY_MOVESET_OVERRIDE", "get").mockReturnValue(moveset);
     moveset = coerceArray(moveset);
     this.log(`Enemy Pokemon moveset set to ${stringifyEnumArray(MoveId, moveset)}!`);
     return this;
@@ -604,7 +603,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public enemyLevel(level: number): this {
-    vi.spyOn(Overrides, "ENEMY_LEVEL_OVERRIDE", "get").mockReturnValue(level);
+    vi.spyOn(activeOverrides, "ENEMY_LEVEL_OVERRIDE", "get").mockReturnValue(level);
     this.log(`Enemy Pokemon level set to ${level}!`);
     return this;
   }
@@ -617,7 +616,7 @@ export class OverridesHelper extends GameManagerHelper {
    * If this is set to `StatusEffect.SLEEP`, the duration will be set to a guaranteed 4 turns.
    */
   public enemyStatusEffect(effect: StatusEffect): this {
-    vi.spyOn(Overrides, "ENEMY_STATUS_OVERRIDE", "get").mockReturnValue(effect);
+    vi.spyOn(activeOverrides, "ENEMY_STATUS_OVERRIDE", "get").mockReturnValue(effect);
     if (effect === StatusEffect.NONE) {
       this.log("Enemy Pokemon status effect override disabled!");
     } else {
@@ -632,7 +631,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public enemyHeldItems(items: ModifierOverride[]): this {
-    vi.spyOn(Overrides, "ENEMY_HELD_ITEMS_OVERRIDE", "get").mockReturnValue(items);
+    vi.spyOn(activeOverrides, "ENEMY_HELD_ITEMS_OVERRIDE", "get").mockReturnValue(items);
     this.log("Enemy Pokemon held items set to:", items);
     return this;
   }
@@ -643,7 +642,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public enableUnlockable(unlockable: Unlockables[]): this {
-    vi.spyOn(Overrides, "ITEM_UNLOCK_OVERRIDE", "get").mockReturnValue(unlockable);
+    vi.spyOn(activeOverrides, "ITEM_UNLOCK_OVERRIDE", "get").mockReturnValue(unlockable);
     this.log("Temporarily unlocked the following content: ", unlockable);
     return this;
   }
@@ -654,7 +653,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public itemRewards(items: ModifierOverride[]): this {
-    vi.spyOn(Overrides, "ITEM_REWARD_OVERRIDE", "get").mockReturnValue(items);
+    vi.spyOn(activeOverrides, "ITEM_REWARD_OVERRIDE", "get").mockReturnValue(items);
     this.log("Item rewards set to:", items);
     return this;
   }
@@ -675,7 +674,7 @@ export class OverridesHelper extends GameManagerHelper {
    */
   public shiny(shininess: true, variant?: Variant): this;
   public shiny(shininess: boolean | null, variant?: Variant): this {
-    vi.spyOn(Overrides, "SHINY_OVERRIDE", "get").mockReturnValue(shininess);
+    vi.spyOn(activeOverrides, "SHINY_OVERRIDE", "get").mockReturnValue(shininess);
     if (shininess === null) {
       this.log("Player Pokemon shininess override disabled!");
     } else {
@@ -683,7 +682,7 @@ export class OverridesHelper extends GameManagerHelper {
     }
 
     if (variant != null) {
-      vi.spyOn(Overrides, "VARIANT_OVERRIDE", "get").mockReturnValue(variant);
+      vi.spyOn(activeOverrides, "VARIANT_OVERRIDE", "get").mockReturnValue(variant);
       this.log(`Player Pokemon shiny variant set to ${variant}!`);
     }
 
@@ -706,7 +705,7 @@ export class OverridesHelper extends GameManagerHelper {
    */
   public enemyShiny(shininess: true, variant?: Variant): this;
   public enemyShiny(shininess: boolean | null, variant?: Variant): this {
-    vi.spyOn(Overrides, "ENEMY_SHINY_OVERRIDE", "get").mockReturnValue(shininess);
+    vi.spyOn(activeOverrides, "ENEMY_SHINY_OVERRIDE", "get").mockReturnValue(shininess);
     if (shininess === null) {
       this.log("Enemy Pokemon shininess override disabled!");
     } else {
@@ -714,7 +713,7 @@ export class OverridesHelper extends GameManagerHelper {
     }
 
     if (variant != null) {
-      vi.spyOn(Overrides, "ENEMY_VARIANT_OVERRIDE", "get").mockReturnValue(variant);
+      vi.spyOn(activeOverrides, "ENEMY_VARIANT_OVERRIDE", "get").mockReturnValue(variant);
       this.log(`Enemy Pokemon shiny variant set to ${variant}!`);
     }
 
@@ -730,7 +729,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public enemyHealthSegments(healthSegments: number): this {
-    vi.spyOn(Overrides, "ENEMY_HEALTH_SEGMENTS_OVERRIDE", "get").mockReturnValue(healthSegments);
+    vi.spyOn(activeOverrides, "ENEMY_HEALTH_SEGMENTS_OVERRIDE", "get").mockReturnValue(healthSegments);
     this.log(`Enemy Pokemon health segment count set to ${healthSegments}!`);
     return this;
   }
@@ -741,7 +740,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public statusActivation(activate: boolean | null): this {
-    vi.spyOn(Overrides, "STATUS_ACTIVATION_OVERRIDE", "get").mockReturnValue(activate);
+    vi.spyOn(activeOverrides, "STATUS_ACTIVATION_OVERRIDE", "get").mockReturnValue(activate);
     if (activate === null) {
       this.log("Status activation override disabled!");
     } else {
@@ -756,7 +755,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public confusionActivation(activate: boolean | null): this {
-    vi.spyOn(Overrides, "CONFUSION_ACTIVATION_OVERRIDE", "get").mockReturnValue(activate);
+    vi.spyOn(activeOverrides, "CONFUSION_ACTIVATION_OVERRIDE", "get").mockReturnValue(activate);
     if (activate === null) {
       this.log("Confusion activation override disabled!");
     } else {
@@ -773,7 +772,7 @@ export class OverridesHelper extends GameManagerHelper {
   public mysteryEncounterChance(percentage: number): this {
     const maxRate = 256; // 100%
     const rate = maxRate * (percentage / 100);
-    vi.spyOn(Overrides, "MYSTERY_ENCOUNTER_RATE_OVERRIDE", "get").mockReturnValue(rate);
+    vi.spyOn(activeOverrides, "MYSTERY_ENCOUNTER_RATE_OVERRIDE", "get").mockReturnValue(rate);
     this.log(`Mystery encounter chance set to ${percentage}% (=${rate})!`);
     return this;
   }
@@ -784,7 +783,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public mysteryEncounterTier(tier: MysteryEncounterTier): this {
-    vi.spyOn(Overrides, "MYSTERY_ENCOUNTER_TIER_OVERRIDE", "get").mockReturnValue(tier);
+    vi.spyOn(activeOverrides, "MYSTERY_ENCOUNTER_TIER_OVERRIDE", "get").mockReturnValue(tier);
     this.log(`Mystery encounter tier set to ${tier}!`);
     return this;
   }
@@ -795,7 +794,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public mysteryEncounter(encounterType: MysteryEncounterType): this {
-    vi.spyOn(Overrides, "MYSTERY_ENCOUNTER_OVERRIDE", "get").mockReturnValue(encounterType);
+    vi.spyOn(activeOverrides, "MYSTERY_ENCOUNTER_OVERRIDE", "get").mockReturnValue(encounterType);
     this.log(`Mystery encounter override set to ${encounterType}!`);
     return this;
   }

--- a/test/matchers/to-have-used-pp.ts
+++ b/test/matchers/to-have-used-pp.ts
@@ -1,5 +1,5 @@
 import { getPokemonNameWithAffix } from "#app/messages";
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";
 import { getEnumStr } from "#test/utils/string-utils";
@@ -30,7 +30,7 @@ export function toHaveUsedPP(
     };
   }
 
-  const override = received.isPlayer() ? Overrides.MOVESET_OVERRIDE : Overrides.ENEMY_MOVESET_OVERRIDE;
+  const override = received.isPlayer() ? activeOverrides.MOVESET_OVERRIDE : activeOverrides.ENEMY_MOVESET_OVERRIDE;
   if (coerceArray(override).length > 0) {
     return {
       pass: this.isNot,

--- a/test/setup/vitest.setup.ts
+++ b/test/setup/vitest.setup.ts
@@ -15,7 +15,7 @@ vi.mock(import("#app/overrides"), async importOriginal => {
   const { defaultOverrides } = await importOriginal();
 
   return {
-    default: defaultOverrides,
+    activeOverrides: defaultOverrides,
     // Export `defaultOverrides` as a *copy*.
     // This ensures we can easily reset `overrides` back to its default values after modifying it.
     defaultOverrides: { ...defaultOverrides },

--- a/test/tests/abilities/honey-gather.test.ts
+++ b/test/tests/abilities/honey-gather.test.ts
@@ -1,4 +1,4 @@
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { AbilityId } from "#enums/ability-id";
 import { Command } from "#enums/command";
 import { MoveId } from "#enums/move-id";
@@ -61,7 +61,7 @@ describe("Abilities - Honey Gather", () => {
     const enemy = game.field.getEnemyPokemon();
     vi.spyOn(enemy, "scene", "get").mockReturnValue(game.scene);
     // Expects next wave so run must succeed
-    vi.spyOn(Overrides, "RUN_SUCCESS_OVERRIDE", "get").mockReturnValue(true);
+    vi.spyOn(activeOverrides, "RUN_SUCCESS_OVERRIDE", "get").mockReturnValue(true);
 
     const commandPhase = game.scene.phaseManager.getCurrentPhase() as CommandPhase;
     commandPhase.handleCommand(Command.RUN, 0);

--- a/test/tests/abilities/speed-boost.test.ts
+++ b/test/tests/abilities/speed-boost.test.ts
@@ -1,4 +1,4 @@
-import Overrides from "#app/overrides";
+import { activeOverrides } from "#app/overrides";
 import { AbilityId } from "#enums/ability-id";
 import { Command } from "#enums/command";
 import { MoveId } from "#enums/move-id";
@@ -96,7 +96,7 @@ describe("Abilities - Speed Boost", () => {
     game.override.battleStyle("double");
     await game.classicMode.startBattle(SpeciesId.SHUCKLE);
 
-    vi.spyOn(Overrides, "RUN_SUCCESS_OVERRIDE", "get").mockReturnValue(false);
+    vi.spyOn(activeOverrides, "RUN_SUCCESS_OVERRIDE", "get").mockReturnValue(false);
 
     const commandPhase = game.scene.phaseManager.getCurrentPhase() as CommandPhase;
     commandPhase.handleCommand(Command.RUN, 0);


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Default exports bad.

## What are the changes from a developer perspective?
Removed the default export from `overrides.ts` and replaced it with the named export `activeOverrides`.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR