### PR TITLE
fix(ability): Retry from start of battle now checks if OnSummon abilities should trigger

### DIFF
--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -87,9 +87,9 @@ export class GameOverPhase extends BattlePhase {
 
                 const availablePartyMembers = globalScene.getPokemonAllowedInBattle().length;
 
-                globalScene.phaseManager.pushNew("SummonPhase", 0);
+                globalScene.phaseManager.pushNew("SummonPhase", 0, true, true);
                 if (globalScene.currentBattle.double && availablePartyMembers > 1) {
-                  globalScene.phaseManager.pushNew("SummonPhase", 1);
+                  globalScene.phaseManager.pushNew("SummonPhase", 1, true, true);
                 }
                 if (
                   globalScene.currentBattle.waveIndex > 1


### PR DESCRIPTION
## What are the changes the user will see?
On summon abilities like Intimidate were always triggering after you chose `retry from start of battle`, even if you were in a continued battle against wild pokemon. Now it properly checks if it actually should.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
The retry option should re-load your wave in the exact state it entered. If it re-triggers all your OnSummon abilities then retrying offers a tactical advantage.

## What are the changes from a developer perspective?
Added 2 true parameters to the `SummonPhase` `pushNew()` for `player` and `loaded` in the game-over-phase.

## Screenshots/Videos
<details><summary>Wave 2 retry</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c7a3370e-6dd6-4595-b8dd-daa8bc7a1384" />

</details>

<details><summary>Before, it would trigger Intimidate</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4b0c32b8-a28f-4042-b981-81f34b6138cd" />

</details>

<details><summary>After, no Intimidate anymore</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b3abaf73-6409-4a51-8d07-4df527279bd0" />

</details>

## How to test the changes?
```ts
const overrides = {
  STARTER_SPECIES_OVERRIDE: SpeciesId.GROWLITHE,
  STARTING_LEVEL_OVERRIDE: 999,
  BATTLE_STYLE_OVERRIDE: "single",
  MOVESET_OVERRIDE: [MoveId.EXPLOSION, MoveId.FLAMETHROWER],
} satisfies Partial<InstanceType<OverridesType>>;
```
EnableRetries ON
Start classic with 1 pokemon.
Wave 1: flamethrower
Shop: no item
Wave 2: *notice there is no Intimidate trigger* Explosion
Yes to retry

*before*
Wave 2 (again): *notice there is now an Intimidate trigger*

*after*
Wave 2 (again): *No Intimidate trigger anymore.*

Note:
If you do the retry on Wave 1, you do still get the Intimidate trigger, because Growlithe was actually summoned there. So that did not change.

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: _____
- [ ] I have contacted the Translation Team on Discord for proofreading/translation

Does this require any additions or changes to in-game assets? If so:
- [ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: _____
