### PR TITLE
dev: `pnpm test:create` no longer uses outdated paths

### DIFF
--- a/scripts/create-test/dirs.js
+++ b/scripts/create-test/dirs.js
@@ -41,7 +41,7 @@ export function getBoilerplatePath(testType) {
  * @returns {string} the path to the requested folder
  */
 function getTestFolderPath(...folders) {
-  return join(projectRoot, "test", ...folders);
+  return join(projectRoot, "test/tests", ...folders);
 }
 
 /**


### PR DESCRIPTION
## What are the changes the user will see?
N/A
<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
`pnpm test:create` was creating test files in the wrong directory since all the test files got moved to `test/tests`.
## What are the changes from a developer perspective?
Changed a single line of code to use the right dir
## How to test the changes?
`pnpm test:create`
## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)