### PR TITLE
fix: properly utilize cached fetching for all URLs

### DIFF
--- a/src/@types/phaser.d.ts
+++ b/src/@types/phaser.d.ts
@@ -19,9 +19,4 @@ declare module "phaser" {
       }
     }
   }
-
-  interface Game {
-    /** A manifest used to cache various files requested from the server. */
-    manifest?: Record<string, string> | undefined;
-  }
 }

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -148,6 +148,7 @@ import {
 } from "#utils/common";
 import { deepMergeSpriteData } from "#utils/data";
 import { getEnumValues } from "#utils/enums";
+import { cachedFetch } from "#utils/fetch-utils";
 import { getModifierPoolForType, getModifierType } from "#utils/modifier-utils";
 import { getPokemonSpecies } from "#utils/pokemon-utils";
 import i18next from "i18next";
@@ -668,7 +669,7 @@ export class BattleScene extends SceneBase {
     if (expSpriteKeys.size > 0) {
       return;
     }
-    const res = await this.cachedFetch("./exp-sprites.json");
+    const res = await cachedFetch("./exp-sprites.json");
     const keys = await res.json();
     if (!Array.isArray(keys)) {
       throw new Error("EXP Sprites were not array when fetched!");
@@ -686,24 +687,15 @@ export class BattleScene extends SceneBase {
    */
   async initVariantData(): Promise<void> {
     clearVariantData();
-    const otherVariantData = await this.cachedFetch("./images/pokemon/variant/_masterlist.json").then(r => r.json());
+    const otherVariantData = await cachedFetch("./images/pokemon/variant/_masterlist.json").then(r => r.json());
     for (const k of Object.keys(otherVariantData)) {
       variantData[k] = otherVariantData[k];
     }
     if (!this.experimentalSprites) {
       return;
     }
-    const expVariantData = await this.cachedFetch("./images/pokemon/variant/_exp_masterlist.json").then(r => r.json());
+    const expVariantData = await cachedFetch("./images/pokemon/variant/_exp_masterlist.json").then(r => r.json());
     deepMergeSpriteData(variantData, expVariantData);
-  }
-
-  cachedFetch(url: string, init?: RequestInit): Promise<Response> {
-    const { manifest } = this.game;
-    const timestamp = manifest?.[`/${url.replace("./", "")}`];
-    if (timestamp) {
-      url += `?t=${timestamp}`;
-    }
-    return fetch(url, init);
   }
 
   async initStarterColors(): Promise<void> {
@@ -711,7 +703,7 @@ export class BattleScene extends SceneBase {
       // already initialized
       return;
     }
-    const sc = await this.cachedFetch("./starter-colors.json").then(res => res.json());
+    const sc = await cachedFetch("./starter-colors.json").then(res => res.json());
     for (const key of Object.keys(sc)) {
       starterColors[key] = sc[key];
     }

--- a/src/data/battle-anims.ts
+++ b/src/data/battle-anims.ts
@@ -11,6 +11,7 @@ import type { nil } from "#types/common";
 import { coerceArray } from "#utils/array";
 import { getFrameMs } from "#utils/common";
 import { getEnumKeys, getEnumValues } from "#utils/enums";
+import { cachedFetch } from "#utils/fetch-utils";
 import { toKebabCase } from "#utils/strings";
 import Phaser from "phaser";
 
@@ -421,8 +422,7 @@ export async function initCommonAnims(): Promise<void> {
   for (const commonAnimName of getEnumKeys(CommonAnim)) {
     const commonAnimId = CommonAnim[commonAnimName];
     commonAnimFetches.push(
-      globalScene
-        .cachedFetch(`./battle-anims/common-${toKebabCase(commonAnimName)}.json`)
+      cachedFetch(`./battle-anims/common-${toKebabCase(commonAnimName)}.json`)
         .then(response => response.json())
         .then(cas => commonAnims.set(commonAnimId, new AnimConfig(cas))),
     );
@@ -458,8 +458,7 @@ export function initMoveAnim(move: MoveId): Promise<void> {
           : MoveId.TAIL_WHIP;
 
       const fetchAnimAndResolve = (move: MoveId) => {
-        globalScene
-          .cachedFetch(`./battle-anims/${toKebabCase(MoveId[move])}.json`)
+        cachedFetch(`./battle-anims/${toKebabCase(MoveId[move])}.json`)
           .then(response => {
             const contentType = response.headers.get("content-type");
             if (!response.ok || contentType?.indexOf("application/json") === -1) {
@@ -532,8 +531,7 @@ export async function initEncounterAnims(encounterAnim: EncounterAnim | Encounte
       continue;
     }
     encounterAnimFetches.push(
-      globalScene
-        .cachedFetch(`./battle-anims/encounter-${toKebabCase(encounterAnimNames[anim])}.json`)
+      cachedFetch(`./battle-anims/encounter-${toKebabCase(encounterAnimNames[anim])}.json`)
         .then(response => response.json())
         .then(cas => encounterAnims.set(anim, new AnimConfig(cas))),
     );
@@ -556,8 +554,7 @@ export function initMoveChargeAnim(chargeAnim: ChargeAnim): Promise<void> {
       }
     } else {
       chargeAnims.set(chargeAnim, null);
-      globalScene
-        .cachedFetch(`./battle-anims/${toKebabCase(ChargeAnim[chargeAnim])}.json`)
+      cachedFetch(`./battle-anims/${toKebabCase(ChargeAnim[chargeAnim])}.json`)
         .then(response => response.json())
         .then(ca => {
           if (Array.isArray(ca)) {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -183,6 +183,7 @@ import {
 } from "#utils/common";
 import { calculateBossSegmentDamage } from "#utils/damage";
 import { getEnumValues } from "#utils/enums";
+import { cachedFetch } from "#utils/fetch-utils";
 import { getFusedSpeciesName, getPokemonSpecies, getPokemonSpeciesForm } from "#utils/pokemon-utils";
 import { inSpeedOrder } from "#utils/speed-order-generator";
 import { argbFromRgba, QuantizerCelebi, rgbaFromArgb } from "@material/material-color-utilities";
@@ -904,8 +905,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    */
   async populateVariantColorCache(cacheKey: string, useExpSprite: boolean, battleSpritePath: string) {
     const spritePath = `./images/pokemon/variant/${useExpSprite ? "exp/" : ""}${battleSpritePath}.json`;
-    return globalScene
-      .cachedFetch(spritePath)
+    return cachedFetch(spritePath)
       .then(res => {
         // Prevent the JSON from processing if it failed to load
         if (!res.ok) {

--- a/src/global-manifest.ts
+++ b/src/global-manifest.ts
@@ -1,0 +1,6 @@
+/** A manifest used to cache various files requested from the server. */
+export let globalManifest: Record<string, string> | undefined;
+
+export function initializeManifest(manifest?: Record<string, string>): void {
+  globalManifest = manifest;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import "#app/polyfills"; // All polyfills MUST be loaded first for side effects
 import "#plugins/i18n"; // Initializes i18n on import
 
+import { initializeManifest } from "#app/global-manifest";
 import { InvertPostFX } from "#app/pipelines/invert";
 import { isBeta, isDev } from "#constants/app-constants";
 import { version } from "#package.json";
@@ -85,7 +86,7 @@ async function startGame(gameManifest?: Record<string, string>): Promise<void> {
     version,
   });
   game.sound.pauseOnBlur = false;
-  game.manifest = gameManifest;
+  initializeManifest(gameManifest);
 }
 
 let manifest: Record<string, string> | undefined;

--- a/src/plugins/cache-busted-loader-plugin.ts
+++ b/src/plugins/cache-busted-loader-plugin.ts
@@ -1,10 +1,11 @@
-import { globalScene } from "#app/global-scene";
+import { globalManifest } from "#app/global-manifest";
 import { coerceArray } from "#utils/array";
+import { getCachedUrl } from "#utils/fetch-utils";
 
 export class CacheBustedLoaderPlugin extends Phaser.Loader.LoaderPlugin {
   addFile(files: Phaser.Loader.File | Phaser.Loader.File[]): void {
     files = coerceArray(files);
-    const { manifest } = globalScene.game;
+    const manifest = globalManifest;
 
     if (!manifest) {
       super.addFile(files);
@@ -16,10 +17,7 @@ export class CacheBustedLoaderPlugin extends Phaser.Loader.LoaderPlugin {
         continue;
       }
 
-      const timestamp = manifest[`/${item.url.replace(/\/\//g, "/")}`];
-      if (timestamp) {
-        item.url += `?t=${timestamp}`;
-      }
+      item.url = getCachedUrl(item.url.replace(/\/\//g, "/"));
     }
 
     super.addFile(files);

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -1,4 +1,4 @@
-import pkg from "#package.json";
+import { getCachedUrl } from "#utils/fetch-utils";
 import { toKebabCase } from "#utils/strings";
 import i18next from "i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
@@ -23,7 +23,7 @@ const unicodeRanges = {
   CJKIdeograph: "U+4E00-9FFF",
   devanagari: "U+0900-097F",
   thai: "U+0E00-0E7F",
-  specialCharacters: "U+266A,U+2605,U+2665,U+2663", //♪.★,♥,♣
+  specialCharacters: "U+266A,U+2605,U+2665,U+2663", //♪,★,♥,♣
 };
 
 const rangesByLanguage = {
@@ -36,14 +36,14 @@ const rangesByLanguage = {
 const fonts: LoadingFontFaceProperty[] = [
   // unicode (special characters)
   {
-    face: new FontFace("pkmnems", "url(./fonts/pokemon-emerald-pro.ttf)", {
+    face: new FontFace("pkmnems", `url(${getCachedUrl("./fonts/pokemon-emerald-pro.ttf")})`, {
       unicodeRange: unicodeRanges.specialCharacters,
     }),
     extraOptions: { sizeAdjust: "133%" },
   },
   // unicode (chinese)
   {
-    face: new FontFace("pkmnems", "url(./fonts/pokemon-emerald-pro.ttf)", {
+    face: new FontFace("pkmnems", `url(${getCachedUrl("./fonts/pokemon-emerald-pro.ttf")})`, {
       unicodeRange: rangesByLanguage.chinese,
     }),
     extraOptions: { sizeAdjust: "133%" },
@@ -72,25 +72,25 @@ const fonts: LoadingFontFaceProperty[] = [
   },
   // japanese
   {
-    face: new FontFace("emerald", "url(./fonts/pokemon-bw.ttf)", {
+    face: new FontFace("emerald", `url(${getCachedUrl("./fonts/pokemon-bw.ttf")})`, {
       unicodeRange: rangesByLanguage.japanese,
     }),
     only: ["ja"],
   },
   // devanagari
   {
-    face: new FontFace("emerald", "url(./fonts/8-bit-devanagari.ttf)", {
+    face: new FontFace("emerald", `url(${getCachedUrl("./fonts/8-bit-devanagari.ttf")})`, {
       unicodeRange: unicodeRanges.devanagari,
     }),
   },
   {
-    face: new FontFace("pkmnems", "url(./fonts/8-bit-devanagari.ttf)", {
+    face: new FontFace("pkmnems", `url(${getCachedUrl("./fonts/8-bit-devanagari.ttf")})`, {
       unicodeRange: unicodeRanges.devanagari,
     }),
   },
   // thai
   {
-    face: new FontFace("emerald", "url(./fonts/fsrebellion.otf)", {
+    face: new FontFace("emerald", `url(${getCachedUrl("./fonts/fsrebellion.otf")})`, {
       unicodeRange: unicodeRanges.thai,
     }),
   },
@@ -199,8 +199,8 @@ await i18next
           } else {
             fileName = toKebabCase(ns);
           }
-          // ex: "./locales/en/move-anims"
-          return `./locales/${lng}/${fileName}.json?v=${pkg.version}`;
+          // ex: "./locales/en/move-anims?t=1234567890"
+          return getCachedUrl(`./locales/${lng}/${fileName}.json`);
         },
       },
       defaultNS: "menu",

--- a/src/scene-base.ts
+++ b/src/scene-base.ts
@@ -1,4 +1,5 @@
 import { coerceArray } from "#utils/array";
+import { getCachedUrl } from "#utils/fetch-utils";
 
 export const legacyCompatibleImages: string[] = [];
 
@@ -26,38 +27,23 @@ export class SceneBase extends Phaser.Scene {
     });
   }
 
-  public getCachedUrl(url: string): string {
-    const manifest = this.game.manifest;
-    if (!manifest) {
-      return url;
-    }
-
-    // TODO: This is inconsistent with how the battle scene cached fetch
-    // uses the manifest
-    const timestamp = manifest[`/${url}`];
-    if (timestamp) {
-      url += `?t=${timestamp}`;
-    }
-    return url;
-  }
-
   public loadImage(key: string, folder: string, filename = `${key}.png`): this {
-    this.load.image(key, this.getCachedUrl(`images/${folder}/${filename}`));
+    this.load.image(key, getCachedUrl(`images/${folder}/${filename}`));
     if (folder.startsWith("ui")) {
       folder = folder.replace("ui", "ui/legacy");
-      this.load.image(`${key}_legacy`, this.getCachedUrl(`images/${folder}/${filename}`));
+      this.load.image(`${key}_legacy`, getCachedUrl(`images/${folder}/${filename}`));
     }
     return this;
   }
 
   public loadSpritesheet(key: string, folder: string, size: number, filename = `${key}.png`): this {
-    this.load.spritesheet(key, this.getCachedUrl(`images/${folder}/${filename}`), {
+    this.load.spritesheet(key, getCachedUrl(`images/${folder}/${filename}`), {
       frameWidth: size,
       frameHeight: size,
     });
     if (folder.startsWith("ui")) {
       folder = folder.replace("ui", "ui/legacy");
-      this.load.spritesheet(`${key}_legacy`, this.getCachedUrl(`images/${folder}/${filename}`), {
+      this.load.spritesheet(`${key}_legacy`, getCachedUrl(`images/${folder}/${filename}`), {
         frameWidth: size,
         frameHeight: size,
       });
@@ -71,15 +57,15 @@ export class SceneBase extends Phaser.Scene {
     }
     this.load.atlas(
       key,
-      this.getCachedUrl(`images/${folder}${filenameRoot}.png`),
-      this.getCachedUrl(`images/${folder}${filenameRoot}.json`),
+      getCachedUrl(`images/${folder}${filenameRoot}.png`),
+      getCachedUrl(`images/${folder}${filenameRoot}.json`),
     );
     if (folder.startsWith("ui")) {
       folder = folder.replace("ui", "ui/legacy");
       this.load.atlas(
         `${key}_legacy`,
-        this.getCachedUrl(`images/${folder}${filenameRoot}.png`),
-        this.getCachedUrl(`images/${folder}${filenameRoot}.json`),
+        getCachedUrl(`images/${folder}${filenameRoot}.png`),
+        getCachedUrl(`images/${folder}${filenameRoot}.json`),
       );
     }
     return this;
@@ -91,13 +77,13 @@ export class SceneBase extends Phaser.Scene {
     filenames = coerceArray(filenames);
     for (const f of filenames as string[]) {
       // TODO: Use actual path joining logic
-      this.load.audio(folder + key, this.getCachedUrl(`audio/${folder}${f}`));
+      this.load.audio(folder + key, getCachedUrl(`audio/${folder}${f}`));
     }
     return this;
   }
 
   public loadBgm(key: string, filename = `${key}.mp3`): this {
-    this.load.audio(key, this.getCachedUrl(`audio/bgm/${filename}`));
+    this.load.audio(key, getCachedUrl(`audio/bgm/${filename}`));
     return this;
   }
 }

--- a/src/sprites/pokemon-sprite.ts
+++ b/src/sprites/pokemon-sprite.ts
@@ -5,6 +5,7 @@ import type { Pokemon } from "#field/pokemon";
 import { hasExpSprite } from "#sprites/sprite-utils";
 import type { Variant, VariantSet } from "#sprites/variant";
 import { variantColorCache, variantData } from "#sprites/variant";
+import { cachedFetch } from "#utils/fetch-utils";
 
 // Regex patterns
 
@@ -73,7 +74,5 @@ export async function loadPokemonVariantAssets(
   if (!variantConfig || variantSet[variant] !== 1) {
     return;
   }
-  variantColorCache[spriteKey] = await scene
-    .cachedFetch(`./images/pokemon/variant/${fileRoot}.json`)
-    .then(res => res.json());
+  variantColorCache[spriteKey] = await cachedFetch(`./images/pokemon/variant/${fileRoot}.json`).then(res => res.json());
 }

--- a/src/sprites/variant.ts
+++ b/src/sprites/variant.ts
@@ -2,6 +2,7 @@ import { globalScene } from "#app/global-scene";
 import { VariantTier } from "#enums/variant-tier";
 import type { Pokemon } from "#field/pokemon";
 import { hasExpSprite } from "#sprites/sprite-utils";
+import { cachedFetch } from "#utils/fetch-utils";
 
 export type Variant = 0 | 1 | 2;
 
@@ -124,8 +125,7 @@ export async function populateVariantColorCache(
   battleSpritePath: string,
 ): Promise<void> {
   const spritePath = `./images/pokemon/variant/${useExpSprite ? "exp/" : ""}${battleSpritePath}.json`;
-  return globalScene
-    .cachedFetch(spritePath)
+  return cachedFetch(spritePath)
     .then(res => {
       // Prevent the JSON from processing if it failed to load
       if (!res.ok) {

--- a/src/utils/fetch-utils.ts
+++ b/src/utils/fetch-utils.ts
@@ -1,0 +1,18 @@
+import { globalManifest } from "#app/global-manifest";
+
+export function getCachedUrl(url: string): string {
+  const manifest = globalManifest;
+  if (!manifest) {
+    return url;
+  }
+
+  const timestamp = manifest[`/${url.replace("./", "")}`];
+  if (timestamp) {
+    url += `?t=${timestamp}`;
+  }
+  return url;
+}
+
+export function cachedFetch(url: string, init?: RequestInit): Promise<Response> {
+  return fetch(getCachedUrl(url), init);
+}

--- a/test/framework/game-wrapper.ts
+++ b/test/framework/game-wrapper.ts
@@ -11,7 +11,6 @@ import { MockLoader } from "#test/mocks/mock-loader";
 import { MockTextureManager } from "#test/mocks/mock-texture-manager";
 import { MockContainer } from "#test/mocks/mocks-container/mock-container";
 import { PokedexMonContainer } from "#ui/pokedex-mon-container";
-import fs from "node:fs";
 import Phaser from "phaser";
 import { vi } from "vitest";
 
@@ -203,48 +202,9 @@ export class GameWrapper {
     this.scene.scene = this.scene as any; // TODO: This seems wacky
     this.scene.input.keyboard = new KeyboardPlugin(this.scene as any);
     this.scene.input.gamepad = new GamepadPlugin(this.scene as any);
-    this.scene.cachedFetch = async (url, _init): Promise<Response> => {
-      // Replace all battle anim fetches solely with the tackle anim to save time.
-      // TODO: This effectively bars us from testing battle animation related code ever
-      const newUrl = url.includes("./battle-anims/") ? prependPath("./battle-anims/tackle.json") : prependPath(url);
-      try {
-        const raw = fs.readFileSync(newUrl, { encoding: "utf8", flag: "r" });
-        return createFetchResponse(JSON.parse(raw));
-      } catch {
-        return createFetchBadResponse({});
-      }
-    };
     this.scene.make = new MockGameObjectCreator(mockTextureManager) as any;
     this.scene.time = new MockClock(this.scene);
     this.scene["remove"] = vi.fn(); // TODO: this should be stubbed differently
     timedEventManager.disable();
   }
-}
-
-function prependPath(originalPath) {
-  const prefix = "assets";
-  if (originalPath.startsWith("./")) {
-    return originalPath.replace("./", `${prefix}/`);
-  }
-  return originalPath;
-}
-// Simulate fetch response
-function createFetchResponse(data: unknown): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers(),
-    json: () => Promise.resolve(data),
-    text: () => Promise.resolve(JSON.stringify(data)),
-  } as any;
-}
-// Simulate fetch response
-function createFetchBadResponse(data: unknown): Response {
-  return {
-    ok: false,
-    status: 404,
-    headers: new Headers(),
-    json: () => Promise.resolve(data),
-    text: () => Promise.resolve(JSON.stringify(data)),
-  } as any;
 }

--- a/test/setup/vitest.setup.ts
+++ b/test/setup/vitest.setup.ts
@@ -5,6 +5,7 @@ import { PromptHandler } from "#test/helpers/prompt-handler";
 import { MockConsole } from "#test/mocks/mock-console/mock-console";
 import { logTestEnd, logTestStart } from "#test/setup/test-end-log";
 import { initTests } from "#test/setup/test-file-initialization";
+import fs from "node:fs";
 import chalk from "chalk";
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
 
@@ -60,6 +61,52 @@ vi.mock(import("i18next"), async importOriginal => {
   console.log("\x1b[38;2;223;184;216mi18n MSW server listening\x1b[0m");
 
   return await importOriginal();
+});
+
+vi.mock(import("#utils/fetch-utils"), async importOriginal => {
+  const { getCachedUrl } = await importOriginal();
+
+  function prependPath(originalPath: string) {
+    const prefix = "assets";
+    if (originalPath.startsWith("./")) {
+      return originalPath.replace("./", `${prefix}/`);
+    }
+    return originalPath;
+  }
+  // Simulate fetch response
+  function createFetchResponse(data: unknown): Response {
+    return {
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      json: () => Promise.resolve(data),
+      text: () => Promise.resolve(JSON.stringify(data)),
+    } as Response;
+  }
+  // Simulate fetch response
+  function createFetchBadResponse(data: unknown): Response {
+    return {
+      ok: false,
+      status: 404,
+      headers: new Headers(),
+      json: () => Promise.resolve(data),
+      text: () => Promise.resolve(JSON.stringify(data)),
+    } as Response;
+  }
+
+  async function cachedFetch(url: string, _init?: RequestInit): Promise<Response> {
+    // Replace all battle anim fetches solely with the tackle anim to save time.
+    // TODO: This effectively bars us from testing battle animation related code ever
+    const newUrl = url.includes("./battle-anims/") ? prependPath("./battle-anims/tackle.json") : prependPath(url);
+    try {
+      const raw = fs.readFileSync(newUrl, { encoding: "utf8", flag: "r" });
+      return createFetchResponse(JSON.parse(raw));
+    } catch {
+      return createFetchBadResponse({});
+    }
+  }
+
+  return { cachedFetch, getCachedUrl } satisfies typeof import("#utils/fetch-utils");
 });
 
 //#endregion Mocking

--- a/test/tests/test-framework/misc.test.ts
+++ b/test/tests/test-framework/misc.test.ts
@@ -1,10 +1,11 @@
 import { GameManager } from "#test/framework/game-manager";
+import { cachedFetch } from "#utils/fetch-utils";
 import Phaser from "phaser";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("Test misc", () => {
   let phaserGame: Phaser.Game;
-  let game: GameManager;
+  let _game: GameManager;
 
   beforeAll(() => {
     phaserGame = new Phaser.Game({
@@ -13,7 +14,7 @@ describe("Test misc", () => {
   });
 
   beforeEach(() => {
-    game = new GameManager(phaserGame);
+    _game = new GameManager(phaserGame);
   });
 
   it("test fetch mock async", async () => {
@@ -41,7 +42,7 @@ describe("Test misc", () => {
   });
 
   it("test apifetch mock sync", async () => {
-    const data = await game.scene.cachedFetch("./battle-anims/splishy-splash.json");
+    const data = await cachedFetch("./battle-anims/splishy-splash.json");
     expect(data).toBeDefined();
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?
Less issues with improperly cached files, hopefully.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Users were being served files (e.g. locales) that were outdated, causing issues.

## What are the changes from a developer perspective?
- Removed `manifest` from `BattleScene#game` and into a `globalManifest` object in `src/global-manifest.ts`.
- Moved `SceneBase#getCachedUrl` and `BattleScene#cachedFetch` into utility functions in `src/utils/fetch-utils.ts`.
- Fonts now use `getCachedUrl`.

## How to test the changes?
I think this can only be tested on main? No other source uses `manifest.json`.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
    - It works locally but that doesn't mean much.