### PR TITLE
dev: add `desktop.ini` files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,13 +34,6 @@ desktop.ini
 *.sw?
 /vs
 
-assets/images/trainer/convert/*
-assets/images/battle_anims/input/*.png
-assets/images/pokemon/input/*.png
-assets/images/pokemon/input/output/*
-assets/images/pokemon/icons/input/*.png
-assets/images/pokemon/icons/input/output/*
-assets/images/character/*/
 src/data/battle-anim-raw-data*.ts
 src/data/battle-anim-data.ts
 


### PR DESCRIPTION
## What are the changes the user will see?
N/A
<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Damo noticed that a `desktop.ini` file was getting tracked by Git.
This is a Windows-specific file created to track explorer.exe info, and is re-created each time the folder is opened.
## What are the changes from a developer perspective?
Added `desktop.ini` (in all subdirectories) to the `gitignore`.

Removed the gitignore entries for assets into a submodule-specific gitignore file.
## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR

Does this require any additions or changes to in-game assets? If so:
- [x] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: https://github.com/pagefaultgames/pokerogue-assets/pull/66
