### PR TITLE
i18n: Translatable "Score" label

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2009,10 +2009,7 @@ export class BattleScene extends SceneBase {
   }
 
   updateScoreText(): void {
-    // TODO: Localize this
-    this.scoreText //
-      .setText(`Score: ${this.score.toString()}`)
-      .setVisible(this.gameMode.isDaily);
+    this.scoreText.setText(i18next.t("battleScene:score", { score: this.score })).setVisible(this.gameMode.isDaily);
   }
 
   /**

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2009,7 +2009,9 @@ export class BattleScene extends SceneBase {
   }
 
   updateScoreText(): void {
-    this.scoreText.setText(i18next.t("battleScene:score", { score: this.score })).setVisible(this.gameMode.isDaily);
+    this.scoreText // formatting
+      .setText(i18next.t("battleScene:score", { score: this.score }))
+      .setVisible(this.gameMode.isDaily);
   }
 
   /**

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2009,8 +2009,9 @@ export class BattleScene extends SceneBase {
   }
 
   updateScoreText(): void {
+    const { score } = this;
     this.scoreText // formatting
-      .setText(i18next.t("battleScene:score", { score: this.score }))
+      .setText(i18next.t("battleScene:score", { score }))
       .setVisible(this.gameMode.isDaily);
   }
 


### PR DESCRIPTION
## What are the changes the user will see?
Translated "Score:" label in battle UI

## Why am I making these changes?
To have it translatable

## What are the changes from a developer perspective?
--

## Screenshots/Videos
<details><summary>Before (French)</summary>
<img width="284" height="186" alt="image" src="https://github.com/user-attachments/assets/871e72d4-6131-4266-8861-e42f8d512028" />
</details>
<details><summary>After (French)</summary>
<img width="298" height="187" alt="image" src="https://github.com/user-attachments/assets/78b499fe-6b74-41a1-8119-ce0108585b4c" />
</details>

## How to test the changes?
--

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [x] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [x] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: https://github.com/pagefaultgames/pokerogue-locales/pull/287
- [x] I have contacted the Translation Team on Discord for proofreading/translation
