### PR TITLE
fix(battle): add another double battle desync failsafe

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1266,7 +1266,7 @@ export class BattleScene extends SceneBase {
     double?: boolean,
     mysteryEncounterType?: MysteryEncounterType,
   ): Battle {
-    // failsafe for corrupt saves (such as due to enum shifting)
+    // failsafes for corrupt saves (such as due to enum shifting)
     if (
       trainerData?.variant === TrainerVariant.DOUBLE
       && !trainerConfigs[trainerData.trainerType].hasDouble
@@ -1274,7 +1274,15 @@ export class BattleScene extends SceneBase {
     ) {
       trainerData.variant = TrainerVariant.DEFAULT;
       double = false;
+    } else if (
+      trainerData
+      && trainerData.variant !== TrainerVariant.DOUBLE
+      && trainerConfigs[trainerData.trainerType].doubleOnly
+    ) {
+      trainerData.variant = TrainerVariant.DOUBLE;
+      double = true;
     }
+
     const _startingWave = Overrides.STARTING_WAVE_OVERRIDE || startingWave;
     const newWaveIndex = waveIndex || (this.currentBattle?.waveIndex || _startingWave - 1) + 1;
     let newDouble: boolean | undefined;


### PR DESCRIPTION
## What are the changes the user will see?
Another scenario where the trainer type was desynched with the battle type is now accounted for, preventing a crash.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Bug report.

## What are the changes from a developer perspective?
Added another check to the failsafe accounting for corrupt save data.

## How to test the changes?
Ensure it's possible to progress to the next wave in the following session data: [sessionData_Ajdin1103.prsv.txt](https://github.com/user-attachments/files/25783986/sessionData_Ajdin1103.prsv.txt)

## Checklist
- The PR content is correctly formatted:
  - ~[ ] **I'm using `beta` as my base branch**~
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually