### PR TITLE
fix(beta): don't ignore session data for fixed battle waves

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1283,8 +1283,8 @@ export class BattleScene extends SceneBase {
 
   /**
    * Create and initialize a new battle.
-   * @param fromSession - The {@linkcode SessionSaveData} being used to seed the battle.
-   * Should be omitted if not loading an existing save file.
+   * @param fromSession - The {@linkcode SessionSaveData} being used to seed the battle. \
+   *   Should be omitted if not loading an existing save file.
    * @returns The newly created `Battle` instance.
    */
   public newBattle(fromSession?: SessionSaveData): Battle {
@@ -1296,10 +1296,10 @@ export class BattleScene extends SceneBase {
     this.resetSeed(waveIndex);
 
     // Set attributes of the `resolved` object based on the type of battle being created.
-    if (this.gameMode.isFixedBattle(waveIndex)) {
-      this.handleFixedBattle(resolved);
-    } else if (fromSession) {
+    if (fromSession) {
       this.handleSavedBattle(resolved, props);
+    } else if (this.gameMode.isFixedBattle(waveIndex)) {
+      this.handleFixedBattle(resolved);
     } else {
       this.handleNonFixedBattle(resolved);
     }


### PR DESCRIPTION
## What are the changes the user will see?
Session data will be properly used when loading from a save on fixed battle waves (e.g. evil team fights, rival fights, etc).

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Discord bug report of a softlock due to a double battle loading as a single battle.

## What are the changes from a developer perspective?
Swapped the order of the `if/else if` statements in `BattleScene#newBattle` so that save data is loaded first if it exists.

### Additional Notes
Technically the bug would be masked if `getRandomTrainerFunc` in `src/battle.ts` was using seeded RNG like it should be.

## How to test the changes?
Load this session save a few times pre- and post-fix and observe that it will sometimes roll a single battle without the fix but never after the fix: [sessionData3_BlackTeePoison.prsv.txt](https://github.com/user-attachments/files/25844480/sessionData3_BlackTeePoison.prsv.txt)

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually