### PR TITLE
fix(beta): fix issues from `new-battle` PR

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -3650,9 +3650,9 @@ export class BattleScene extends SceneBase {
 
     // MEs can only spawn 3 or more waves after the previous ME, barring overrides
     const canSpawn =
-      Overrides.MYSTERY_ENCOUNTER_RATE_OVERRIDE !== null // Bang on `at()` is justified due to the check for length === 0
+      Overrides.MYSTERY_ENCOUNTER_RATE_OVERRIDE !== null
       || encounteredEvents.length === 0
-      || waveIndex > 3 + encounteredEvents.at(-1)!.waveIndex;
+      || waveIndex > 3 + encounteredEvents.at(-1)!.waveIndex; // Bang on `at()` is justified due to the check for length === 0
     if (!canSpawn) {
       return false;
     }


### PR DESCRIPTION
## What are the changes the user will see?
- MEs will spawn again
- Double -> trainer battle transitions will correctly recall the second Pokemon in the player's party
  - I doubt this will 100% fix things for good (given reports of similar phenomena have been reported in other contexts), but it at least fixes a major cause of said issues.
<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Fixes #7155
Fixes #7154

## What are the changes from a developer perspective?
Fixed an inverted conditional and an incorrect `playerField` check
## Screenshots/Videos
N/A
## How to test the changes?
play le game
## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [x] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)
