### PR TITLE
fix: correct cursor position calculation in challenges UI

### DIFF
--- a/src/ui/handlers/challenges-select-ui-handler.ts
+++ b/src/ui/handlers/challenges-select-ui-handler.ts
@@ -469,7 +469,7 @@ export class GameChallengesUiHandler extends UiHandler {
     ret ||= !this.cursorObj.visible;
     this.cursorObj //
       .setVisible(true)
-      .setPositionRelative(this.optionsBg, 4, 4 + (this.cursor + this.scrollCursor) * 16);
+      .setPositionRelative(this.optionsBg, 4, 4 + this.cursor * 16);
 
     return ret;
   }


### PR DESCRIPTION
Fixes #7141

## Problem
When there are more challenges than fit on the screen, scrolling to later entries causes the cursor to get displaced off-screen and become desynchronized with the actual selection until scrolling is reset.

## Solution
Removed `scrollCursor` from cursor Y position calculation in `challenges-select-ui-handler.ts`. The cursor should only use the relative cursor position within the visible area, not the absolute scrolled position.

## Testing
- Tested locally with challenges UI
- Cursor now stays correctly positioned when scrolling through challenges
- All existing tests pass

## Changes
- `src/ui/handlers/challenges-select-ui-handler.ts`: Removed `+ this.scrollCursor` from cursor Y calculation