### PR TITLE
fix(ui): Pokédex species pages will display correct biomes

### DIFF
--- a/src/data/balance/pokemon-evolutions.ts
+++ b/src/data/balance/pokemon-evolutions.ts
@@ -148,6 +148,11 @@ export class SpeciesEvolutionCondition {
           return i18next.t("pokemonEvolutions:caught", {species: getPokemonSpecies(cond.speciesCaught).name});
         case EvoCondKey.HELD_ITEM:
           return i18next.t(`pokemonEvolutions:heldItem.${toCamelCase(cond.itemKey)}`);
+        case EvoCondKey.RANDOM_FORM:
+          return null;
+        default:
+          cond satisfies never;
+          return null;
       }
     }).filter(s => s != null); // Filter out stringless conditions
     return this.desc;
@@ -166,7 +171,7 @@ export class SpeciesEvolutionCondition {
         case EvoCondKey.MOVE_TYPE:
           return pokemon.moveset.some(m => m.getMove().type === cond.pkmnType);
         case EvoCondKey.PARTY_TYPE:
-          return globalScene.getPlayerParty().some(p => p.getTypes(false, false, true).includes(cond.pkmnType))
+          return globalScene.getPlayerParty().some(p => p.getTypes(false, false, true).includes(cond.pkmnType));
         case EvoCondKey.EVO_TREASURE_TRACKER:
           return pokemon.getHeldItems().some(m =>
             m.is("EvoTrackerModifier") &&
@@ -195,7 +200,10 @@ export class SpeciesEvolutionCondition {
         case EvoCondKey.SPECIES_CAUGHT:
           return !!globalScene.gameData.dexData[cond.speciesCaught].caughtAttr;
         case EvoCondKey.HELD_ITEM:
-          return pokemon.getHeldItems().some(m => m.is("SpeciesStatBoosterModifier") && (m.type as SpeciesStatBoosterModifierType).key === cond.itemKey)
+          return pokemon.getHeldItems().some(m => m.is("SpeciesStatBoosterModifier") && (m.type as SpeciesStatBoosterModifierType).key === cond.itemKey);
+        default:
+          cond satisfies never;
+          return false;
       }
     });
   }
@@ -1885,23 +1893,48 @@ export function initPokemonPrevolutions(): void {
 // TODO: This may cause funny business for double starters such as Pichu/Pikachu
 export const pokemonStarters: PokemonPrevolutions = {};
 
-/**
- * The default species and all their evolutions
- */
-export const defaultStarterSpeciesAndEvolutions: SpeciesId[] = defaultStarterSpecies.flatMap(id => {
-  const stage2ids = pokemonEvolutions[id]?.map(e => e.speciesId) ?? [];
-  const stage3ids = stage2ids.flatMap(s2id => pokemonEvolutions[s2id]?.map(e => e.speciesId) ?? []);
-  return [id, ...stage2ids, ...stage3ids];
-});
+/** The default starters and their evolution lines */
+export const defaultStarterSpeciesAndEvolutions: SpeciesId[] = defaultStarterSpecies.flatMap(sId => [sId, ...getEvolutions(sId).values()]);
 
 export function initPokemonStarters(): void {
   const starterKeys = Object.keys(pokemonPrevolutions);
   starterKeys.forEach(pk => {
     const prevolution = pokemonPrevolutions[pk];
-    if (speciesStarterCosts.hasOwnProperty(prevolution)) {
+    if (Object.hasOwn(speciesStarterCosts, prevolution)) {
       pokemonStarters[pk] = prevolution;
     } else {
       pokemonStarters[pk] = pokemonPrevolutions[prevolution];
     }
   });
+}
+
+/**
+ * @param speciesId - The ID of the species to get the evolutions of
+ * @returns A set containing all the {@linkcode SpeciesId}s the input species can evolve into
+ */
+export function getEvolutions(speciesId: SpeciesId): Set<SpeciesId> {
+  const evolutionIds: Set<SpeciesId> = new Set();
+  const recurseEvolutions = (sId: SpeciesId): void => {
+    const evolutions = pokemonEvolutions[sId] ?? [];
+    for (const evoSpecies of evolutions) {
+      evolutionIds.add(evoSpecies.speciesId);
+      recurseEvolutions(evoSpecies.speciesId);
+    }
+  };
+  recurseEvolutions(speciesId);
+  return evolutionIds;
+}
+
+/**
+ * @param speciesId - The ID of the species to get the pre-evolutions of
+ * @returns An array containing all the {@linkcode SpeciesId}s that can evolve into the input species
+ */
+export function getPreEvolutions(speciesId: SpeciesId): SpeciesId[] {
+  const preEvoSpecies: SpeciesId[] = [];
+  let preEvoSpeciesId = pokemonPrevolutions[speciesId];
+  while (preEvoSpeciesId) {
+    preEvoSpecies.push(preEvoSpeciesId);
+    preEvoSpeciesId = pokemonPrevolutions[preEvoSpeciesId];
+  }
+  return preEvoSpecies;
 }

--- a/src/ui/handlers/pokedex-page-ui-handler.ts
+++ b/src/ui/handlers/pokedex-page-ui-handler.ts
@@ -4,7 +4,13 @@ import Overrides from "#app/overrides";
 import { speciesEggMoves } from "#balance/moves/egg-moves";
 import { starterPassiveAbilities } from "#balance/passives";
 import type { SpeciesFormEvolution } from "#balance/pokemon-evolutions";
-import { pokemonEvolutions, pokemonPrevolutions, pokemonStarters } from "#balance/pokemon-evolutions";
+import {
+  getEvolutions,
+  getPreEvolutions,
+  pokemonEvolutions,
+  pokemonPrevolutions,
+  pokemonStarters,
+} from "#balance/pokemon-evolutions";
 import { pokemonFormLevelMoves, pokemonSpeciesLevelMoves } from "#balance/pokemon-level-moves";
 import {
   getPassiveCandyCount,
@@ -284,7 +290,6 @@ export class PokedexPageUiHandler extends MessageUiHandler {
   private hasPassive: boolean;
   private hasAbilities: [ability1: number, ability2: number, hiddenAbility: number];
   private biomes: readonly BiomeTierTimeOfDay[] = [];
-  private preBiomes: readonly BiomeTierTimeOfDay[] = [];
   private baseStats: number[];
   private baseTotal: number;
   private evolutions: SpeciesFormEvolution[] = [];
@@ -901,15 +906,17 @@ export class PokedexPageUiHandler extends MessageUiHandler {
 
     this.hasAbilities = [hasAbility1, hasAbility2, hasHiddenAbility];
 
-    // TODO: this is jank, relying on extremely jank data structures that have been removed; refactor
-    const speciesBiomes = catchableSpecies[species.speciesId] ?? [];
-    const starterBiomes = catchableSpecies[this.starterId] ?? [];
-    this.preBiomes = this.filterBiomeFormIndexes(
-      starterBiomes.filter(
-        b => !speciesBiomes.some(bm => b.biome === bm.biome && b.tier === bm.tier) && !(b.biome === BiomeId.TOWN),
-      ),
-      this.starterId,
-    );
+    const evoLine: Set<SpeciesId> = new Set([
+      species.speciesId,
+      ...getPreEvolutions(species.speciesId),
+      ...getEvolutions(species.speciesId).values(),
+    ]);
+    const speciesBiomes: Set<BiomeTierTimeOfDay> = new Set();
+    for (const sId of evoLine) {
+      for (const bttod of catchableSpecies[sId]) {
+        speciesBiomes.add(bttod);
+      }
+    }
     this.biomes = this.filterBiomeFormIndexes(speciesBiomes, species.speciesId);
 
     const allFormChanges = Object.hasOwn(pokemonFormChanges, species.speciesId)
@@ -940,10 +947,8 @@ export class PokedexPageUiHandler extends MessageUiHandler {
   }
 
   // Function to ensure that forms appear in the appropriate biome and tod
-  private filterBiomeFormIndexes(
-    biomes: readonly BiomeTierTimeOfDay[],
-    speciesId: number,
-  ): readonly BiomeTierTimeOfDay[] {
+  private filterBiomeFormIndexes(bttodSet: Set<BiomeTierTimeOfDay>, speciesId: number): readonly BiomeTierTimeOfDay[] {
+    const biomes: readonly BiomeTierTimeOfDay[] = [...bttodSet.values()];
     if (speciesId === SpeciesId.BURMY || speciesId === SpeciesId.WORMADAM) {
       return biomes.filter(b => {
         const formIndex = (() => {
@@ -1551,9 +1556,7 @@ export class PokedexPageUiHandler extends MessageUiHandler {
             this.blockInput = true;
 
             ui.setMode(UiMode.POKEDEX_PAGE, "refresh").then(() => {
-              const noBiomes = !this.biomes || this.biomes.length === 0;
-              const noPreEvoBiomes = !this.preBiomes || this.preBiomes.length === 0;
-              if (noBiomes && noPreEvoBiomes) {
+              if (!this.biomes || this.biomes.length === 0) {
                 ui.showText(i18next.t("pokedexUiHandler:noBiomes"));
                 ui.playError();
                 this.blockInput = false;
@@ -1577,23 +1580,9 @@ export class PokedexPageUiHandler extends MessageUiHandler {
                 for (const bttod of this.biomes) {
                   options.push({
                     label: getBiomeLabel(bttod),
-                    handler: () => false,
-                  });
-                }
-
-                if (this.preBiomes.length > 0) {
-                  options.push({
-                    label: i18next.t("pokedexUiHandler:preBiomes"),
                     skip: true,
                     handler: () => false,
                   });
-
-                  for (const bttod of this.preBiomes) {
-                    options.push({
-                      label: getBiomeLabel(bttod),
-                      handler: () => false,
-                    });
-                  }
                 }
 
                 options.push({

--- a/src/ui/handlers/pokedex-ui-handler.ts
+++ b/src/ui/handlers/pokedex-ui-handler.ts
@@ -1,7 +1,7 @@
 import { globalScene } from "#app/global-scene";
 import { starterColors } from "#app/global-vars/starter-colors";
 import { speciesEggMoves } from "#balance/moves/egg-moves";
-import { pokemonEvolutions, pokemonPrevolutions, pokemonStarters } from "#balance/pokemon-evolutions";
+import { getEvolutions, getPreEvolutions, pokemonStarters } from "#balance/pokemon-evolutions";
 import { pokemonFormLevelMoves, pokemonSpeciesLevelMoves } from "#balance/pokemon-level-moves";
 import {
   getPassiveCandyCount,
@@ -1562,22 +1562,11 @@ export class PokedexUiHandler extends MessageUiHandler {
 
       // The entire evolutionary line is processed from the point of the current species,
       // due to pokemon being automatically [de-]evolved when encountered
-      const evoLine: Set<SpeciesId> = new Set([species.speciesId]);
-
-      let preEvoSpeciesId = pokemonPrevolutions[species.speciesId];
-      while (preEvoSpeciesId) {
-        evoLine.add(preEvoSpeciesId);
-        preEvoSpeciesId = pokemonPrevolutions[preEvoSpeciesId];
-      }
-
-      const getEvolutions = (sId: SpeciesId) => {
-        const evolutions = pokemonEvolutions[sId] ?? [];
-        for (const evoSpecies of evolutions) {
-          evoLine.add(evoSpecies.speciesId);
-          getEvolutions(evoSpecies.speciesId);
-        }
-      };
-      getEvolutions(species.speciesId);
+      const evoLine: Set<SpeciesId> = new Set([
+        species.speciesId,
+        ...getPreEvolutions(species.speciesId),
+        ...getEvolutions(species.speciesId).values(),
+      ]);
 
       const biomes: Set<string> = new Set(catchableSpecies[starterId].map(b => enumValueToKey(BiomeId, b.biome)));
       for (const sId of evoLine) {


### PR DESCRIPTION
## What are the changes the user will see?
The Pokédex will show the correct biomes for Pokémon when viewing their species pages.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

Note: Technically it's less broken on main, but there were still some inconsistencies before the biome structure rework that are also fixed by this.

## Why am I making these changes?
The Pokédex is bugged and doesn't properly consider evolution lines when displaying which biomes a Pokémon can appear in.

## What are the changes from a developer perspective?
- Added utility functions `getEvolutions` and `getPreEvolutions` that return the relevant `SpeciesId`s for the input species' evolution line, and implemented them in the Pokédex UI handlers.
- Removed `PokedexPageUiHandler#preBiomes` due to it being redundant.
- `PokedexPageUiHandler#biomes` now considers the entire evolution line at once, due to Pokémon automatically being [de-]evolved when encountered regardless of the specific `SpeciesId` set in the biome's definition.

## Screenshots/Videos
Before (note the Lycanroc forms being shown to be in biomes they can't show up in due to time of day restrictions):
<details><summary>Rockruff</summary>

<img width="1230" height="689" alt="image" src="https://github.com/user-attachments/assets/64cb58ca-87ba-4647-8efe-ba5be3c12e26" />

</details>
<details><summary>Lycanroc (Midday)</summary>

<img width="1231" height="697" alt="image" src="https://github.com/user-attachments/assets/070bf876-f760-4a42-b3f2-ab14147bd2cc" />

</details>
<details><summary>Lycanroc (Dusk)</summary>

<img width="1229" height="684" alt="image" src="https://github.com/user-attachments/assets/4b98152d-3629-4382-ba7f-13dbfaa99b55" />

</details>
<details><summary>Lycanroc (Midnight)</summary>

<img width="1233" height="689" alt="image" src="https://github.com/user-attachments/assets/44845f01-678f-4441-8459-ea3f2ed9a523" />

</details>

After:
<details><summary>Rockruff</summary>

<img width="1233" height="686" alt="image" src="https://github.com/user-attachments/assets/a9a68676-de86-4939-8564-4b99b57e49d0" />

</details>
<details><summary>Lycanroc (Midday)</summary>

<img width="1231" height="686" alt="image" src="https://github.com/user-attachments/assets/dc477521-5180-4aae-8dbc-52b1d972e296" />

</details>
<details><summary>Lycanroc (Dusk)</summary>

<img width="1230" height="688" alt="image" src="https://github.com/user-attachments/assets/c57acad6-36c9-43aa-8b27-2f457241b24b" />


</details>
<details><summary>Lycanroc (Midnight)</summary>

<img width="1228" height="686" alt="image" src="https://github.com/user-attachments/assets/2d9ffdcd-41f6-4304-a2e5-2d2ec4ed8029" />

</details>

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
- [x] I have provided screenshots/videos of the changes (if applicable)