### PR TITLE
refactor: ME intros consistently use `species`

### DIFF
--- a/src/data/mystery-encounters/encounters/an-offer-you-cant-refuse-encounter.ts
+++ b/src/data/mystery-encounters/encounters/an-offer-you-cant-refuse-encounter.ts
@@ -49,8 +49,9 @@ export const AnOfferYouCantRefuseEncounter: MysteryEncounter = MysteryEncounterB
   .withScenePartySizeRequirement(2, 6, true) // Must have at least 2 pokemon in party
   .withIntroSpriteConfigs([
     {
-      spriteKey: SpeciesId.LIEPARD.toString(),
-      fileRoot: "pokemon",
+      species: SpeciesId.LIEPARD,
+      spriteKey: "",
+      fileRoot: "",
       hasShadow: true,
       repeat: true,
       x: 0,

--- a/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
+++ b/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
@@ -86,8 +86,9 @@ export const ClowningAroundEncounter: MysteryEncounter = MysteryEncounterBuilder
   .withAutoHideIntroVisuals(false)
   .withIntroSpriteConfigs([
     {
-      spriteKey: SpeciesId.MR_MIME.toString(),
-      fileRoot: "pokemon",
+      species: SpeciesId.MR_MIME,
+      spriteKey: "",
+      fileRoot: "",
       hasShadow: true,
       repeat: true,
       x: -25,
@@ -96,8 +97,9 @@ export const ClowningAroundEncounter: MysteryEncounter = MysteryEncounterBuilder
       yShadow: -3,
     },
     {
-      spriteKey: SpeciesId.BLACEPHALON.toString(),
-      fileRoot: "pokemon/exp",
+      species: SpeciesId.BLACEPHALON,
+      spriteKey: "",
+      fileRoot: "",
       hasShadow: true,
       repeat: true,
       x: 25,

--- a/src/data/mystery-encounters/encounters/shady-vitamin-dealer-encounter.ts
+++ b/src/data/mystery-encounters/encounters/shady-vitamin-dealer-encounter.ts
@@ -48,8 +48,9 @@ export const ShadyVitaminDealerEncounter: MysteryEncounter = MysteryEncounterBui
   .withPrimaryPokemonHealthRatioRequirement([0.51, 1]) // At least 1 Pokemon must have above half HP
   .withIntroSpriteConfigs([
     {
-      spriteKey: SpeciesId.KROKOROK.toString(),
-      fileRoot: "pokemon",
+      species: SpeciesId.KROKOROK,
+      spriteKey: "",
+      fileRoot: "",
       hasShadow: true,
       repeat: false,
       scale: 1.1,

--- a/src/data/mystery-encounters/encounters/slumbering-snorlax-encounter.ts
+++ b/src/data/mystery-encounters/encounters/slumbering-snorlax-encounter.ts
@@ -51,8 +51,9 @@ export const SlumberingSnorlaxEncounter: MysteryEncounter = MysteryEncounterBuil
   .withFleeAllowed(false)
   .withIntroSpriteConfigs([
     {
-      spriteKey: SpeciesId.SNORLAX.toString(),
-      fileRoot: "pokemon",
+      species: SpeciesId.SNORLAX,
+      spriteKey: "",
+      fileRoot: "",
       hasShadow: true,
       tint: 0.25,
       scale: 1.25,

--- a/src/data/mystery-encounters/encounters/the-expert-pokemon-breeder-encounter.ts
+++ b/src/data/mystery-encounters/encounters/the-expert-pokemon-breeder-encounter.ts
@@ -162,8 +162,9 @@ export const TheExpertPokemonBreederEncounter: MysteryEncounter = MysteryEncount
           : SpeciesId.CLEFABLE;
     encounter.spriteConfigs = [
       {
-        spriteKey: cleffaSpecies.toString(),
-        fileRoot: "pokemon",
+        species: cleffaSpecies,
+        spriteKey: "",
+        fileRoot: "",
         hasShadow: true,
         repeat: true,
         x: 14,

--- a/src/data/mystery-encounters/encounters/the-strong-stuff-encounter.ts
+++ b/src/data/mystery-encounters/encounters/the-strong-stuff-encounter.ts
@@ -64,8 +64,9 @@ export const TheStrongStuffEncounter: MysteryEncounter = MysteryEncounterBuilder
       disableAnimation: true,
     },
     {
-      spriteKey: SpeciesId.SHUCKLE.toString(),
-      fileRoot: "pokemon",
+      species: SpeciesId.SHUCKLE,
+      spriteKey: "",
+      fileRoot: "",
       hasShadow: true,
       repeat: true,
       scale: 1.25,
@@ -73,7 +74,7 @@ export const TheStrongStuffEncounter: MysteryEncounter = MysteryEncounterBuilder
       y: 10,
       yShadow: 7,
     },
-  ]) // Set in onInit()
+  ])
   .withIntroDialogue([
     {
       text: `${namespace}:intro`,


### PR DESCRIPTION
## What are the changes the user will see?

N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

Make ME intros a little more consistent

## What are the changes from a developer perspective?

Replaced `spriteKey` with `species` where possible

## Screenshots/Videos
Clowning Around will now have a different sprite (for now) between "Consistent" and "Animated"
Animated
<img width="489" height="294" alt="image" src="https://github.com/user-attachments/assets/8783b470-acff-45dd-ae32-c3f939fc2359" />
Consistent
<img width="489" height="294" alt="image" src="https://github.com/user-attachments/assets/e2c57176-4d36-45af-8c10-460d46159e13" />

## How to test the changes?

force one of the following MEs. Nothing should have changed.
- an offer you can't refues
- clowing around
- shady vitamin dealer
- slumbering snorlax
- the expert pokemon breeder
- the strong stuff

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)