### PR TITLE
fix(ui): update Legacy UI ability bars

### DIFF
--- a/src/ui/containers/ability-bar.ts
+++ b/src/ui/containers/ability-bar.ts
@@ -43,13 +43,11 @@ export class AbilityBar extends Phaser.GameObjects.Container {
         this.abilityBars.push(bar);
       }
 
-      this.legacyUiPokemonText = addTextObject(textPadding + 2, 3, "", TextStyle.MESSAGE, {
-        fontSize: "72px",
-      }).setOrigin(0);
+      this.legacyUiPokemonText = addTextObject(textPadding + 2, 3, "", TextStyle.MESSAGE, { fontSize: "72px" }) //
+        .setOrigin(0);
 
-      this.legacyUiAbilityText = addTextObject(textPadding + 2, 16, "", TextStyle.MESSAGE, {
-        fontSize: "72px",
-      }).setOrigin(0);
+      this.legacyUiAbilityText = addTextObject(textPadding + 2, 16, "", TextStyle.MESSAGE, { fontSize: "72px" }) //
+        .setOrigin(0);
 
       this.legacyUiAbilityText.setColor("#484848");
       this.legacyUiAbilityText.setShadowColor("#d0d0c8");
@@ -72,11 +70,12 @@ export class AbilityBar extends Phaser.GameObjects.Container {
         .setOrigin(0)
         .setWordWrapWidth(600, true);
 
-      this.add(this.abilityBarText).bringToTop(this.abilityBarText);
+      this.add(this.abilityBarText) //
+        .bringToTop(this.abilityBarText);
     }
 
-    this.setVisible(false);
-    this.setX(-defaultBarWidth); // start hidden (right edge of bar at x=0)
+    this.setVisible(false) //
+      .setX(-defaultBarWidth); // start hidden (right edge of bar at x=0)
 
     return this;
   }

--- a/src/ui/containers/ability-bar.ts
+++ b/src/ui/containers/ability-bar.ts
@@ -1,46 +1,82 @@
 import { globalScene } from "#app/global-scene";
 import { TextStyle } from "#enums/text-style";
+import { UiTheme } from "#enums/ui-theme";
 import { addTextObject } from "#ui/text";
 import i18next from "i18next";
 
-const barWidth = 118;
+const defaultBarWidth = 118;
+const defaultBarHeight = 31;
 const screenLeft = 0;
 const baseY = -116;
+const textPadding = 15;
+const legacyUiPlayerTextPadding = 17;
+const legacyUiEnemyTextPadding = 5;
 
 export class AbilityBar extends Phaser.GameObjects.Container {
-  private readonly abilityBars: Phaser.GameObjects.Image[];
+  private readonly abilityBars: (Phaser.GameObjects.Image | Phaser.GameObjects.NineSlice)[];
   private abilityBarText: Phaser.GameObjects.Text;
+  private legacyUiPokemonText: Phaser.GameObjects.Text;
+  private legacyUiAbilityText: Phaser.GameObjects.Text;
+  private readonly isLegacyUi: boolean;
   private player: boolean;
   private screenRight: number; // hold screenRight in case size changes between show and hide
   private shown: boolean;
+  private currentBarWidth: number;
 
   constructor() {
-    super(globalScene, barWidth, baseY);
+    super(globalScene, defaultBarWidth, baseY);
     this.abilityBars = [];
     this.player = true;
     this.shown = false;
+    this.isLegacyUi = globalScene.uiTheme === UiTheme.LEGACY;
+    this.currentBarWidth = defaultBarWidth;
   }
 
   setup(): this {
-    for (const key of ["ability_bar_right", "ability_bar_left"]) {
-      const bar = globalScene.add //
-        .image(0, 0, key)
+    if (this.isLegacyUi) {
+      for (const key of ["ability_bar_right", "ability_bar_left"]) {
+        const bar = globalScene.add
+          .nineslice(0, 0, key, undefined, defaultBarWidth, defaultBarHeight, 4, 4, 4, 4)
+          .setOrigin(0)
+          .setVisible(false);
+        this.add(bar);
+        this.abilityBars.push(bar);
+      }
+
+      this.legacyUiPokemonText = addTextObject(textPadding + 2, 3, "", TextStyle.MESSAGE, {
+        fontSize: "72px",
+      }).setOrigin(0);
+
+      this.legacyUiAbilityText = addTextObject(textPadding + 2, 16, "", TextStyle.MESSAGE, {
+        fontSize: "72px",
+      }).setOrigin(0);
+
+      this.legacyUiAbilityText.setColor("#484848");
+      this.legacyUiAbilityText.setShadowColor("#d0d0c8");
+
+      this.add(this.legacyUiPokemonText).bringToTop(this.legacyUiPokemonText);
+      this.add(this.legacyUiAbilityText).bringToTop(this.legacyUiAbilityText);
+    } else {
+      for (const key of ["ability_bar_right", "ability_bar_left"]) {
+        const bar = globalScene.add //
+          .image(0, 0, key)
+          .setOrigin(0)
+          .setVisible(false);
+        this.add(bar);
+        this.abilityBars.push(bar);
+      }
+
+      this.abilityBarText = addTextObject(textPadding, 3, "", TextStyle.MESSAGE, {
+        fontSize: "72px",
+      })
         .setOrigin(0)
-        .setVisible(false);
-      this.add(bar);
-      this.abilityBars.push(bar);
+        .setWordWrapWidth(600, true);
+
+      this.add(this.abilityBarText).bringToTop(this.abilityBarText);
     }
 
-    this.abilityBarText = addTextObject(15, 3, "", TextStyle.MESSAGE, {
-      fontSize: "72px",
-    })
-      .setOrigin(0)
-      .setWordWrapWidth(600, true);
-
-    this.add(this.abilityBarText) //
-      .bringToTop(this.abilityBarText)
-      .setVisible(false)
-      .setX(-barWidth); // start hidden (right edge of bar at x=0)
+    this.setVisible(false);
+    this.setX(-defaultBarWidth); // start hidden (right edge of bar at x=0)
 
     return this;
   }
@@ -51,10 +87,27 @@ export class AbilityBar extends Phaser.GameObjects.Container {
     return this;
   }
 
+  private updateBarWidth(): void {
+    if (!this.isLegacyUi) {
+      return;
+    }
+    this.currentBarWidth =
+      Math.max(this.legacyUiPokemonText.displayWidth, this.legacyUiAbilityText.displayWidth) + textPadding * 2;
+    this.abilityBars[+this.player].setSize(this.currentBarWidth, defaultBarHeight);
+  }
+
   public async startTween(config: any, text?: string): Promise<void> {
     this.setVisible(true);
     if (text) {
-      this.abilityBarText.setText(text);
+      if (this.isLegacyUi) {
+        const lines = text.split("\n");
+        this.legacyUiPokemonText.setText(lines[0]?.trimStart());
+        this.legacyUiAbilityText.setText(lines[1]?.trimStart());
+        this.updateBarWidth();
+        config.x = this.player ? screenLeft : this.screenRight - this.currentBarWidth;
+      } else {
+        this.abilityBarText.setText(text);
+      }
     }
     return new Promise(resolve => {
       globalScene.tweens.add({
@@ -74,10 +127,17 @@ export class AbilityBar extends Phaser.GameObjects.Container {
     this.screenRight = globalScene.scaledCanvas.width;
     if (player !== this.player) {
       // Move the bar if it has changed from the player to enemy side (or vice versa)
-      this.setX(player ? -barWidth : this.screenRight);
+      this.setX(player ? -this.currentBarWidth : this.screenRight);
       this.player = player;
     }
     globalScene.fieldUI.bringToTop(this);
+
+    if (this.isLegacyUi) {
+      // Handle the empty space being on opposite sides for left and right ability bar images
+      const textX = this.player ? legacyUiPlayerTextPadding : legacyUiEnemyTextPadding;
+      this.legacyUiPokemonText.setX(textX);
+      this.legacyUiAbilityText.setX(textX);
+    }
 
     let y = baseY;
     if (this.player) {
@@ -91,7 +151,7 @@ export class AbilityBar extends Phaser.GameObjects.Container {
     return this.startTween(
       {
         targets: this,
-        x: this.player ? screenLeft : this.screenRight - barWidth,
+        x: this.player ? screenLeft : this.screenRight - this.currentBarWidth,
         duration: 500,
         ease: "Sine.easeOut",
         hold: 1000,
@@ -103,7 +163,7 @@ export class AbilityBar extends Phaser.GameObjects.Container {
   public async hide(): Promise<void> {
     return this.startTween({
       targets: this,
-      x: this.player ? -barWidth : this.screenRight,
+      x: this.player ? -this.currentBarWidth : this.screenRight,
       duration: 200,
       ease: "Sine.easeIn",
       onComplete: () => {


### PR DESCRIPTION
## What are the changes the user will see?

Ability Bars in Legacy UI are more readable and dynamically resize.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

In the Legacy UI, the ability bars had light text on a light background for the ability name, making them difficult to read. The ability bars were also a fixed width, so if the pokemon/ability name was too long (eg. Passive Orichalcum Pulse), the text would continue beyond the end of the ability bar.

## What are the changes from a developer perspective?

Updated `Ability Bar.setup()` to include separate flow for the Legacy UI, creating two different `Text` objects for the Pokemon name and the ability name. Also replaced the type of `abilityBars` to be `NineSlice` objects, allowing the ability bars to be stretched horizontally while retaining fixed corners. 

Changed the color/shadow color of the ability text to be dark so it is legible against the light background.

The `ability_bar_left` and `ability_bar_right` images have empty padding on opposite sides, so updated the `showAbility()` function to set the correct x-value for the `Text` objects in relation to the ability bars.'

Created `updateBarWidth()` function to dynamically increase or decrease the ability bar widths depending on the maximum length of the text.

## Screenshots/Videos

<details><summary>Before</summary>

<img width="1281" height="710" alt="old player passive ability bar" src="https://github.com/user-attachments/assets/3bbe6073-89df-44f8-be57-0de541bc4f6c" />

<img width="1280" height="709" alt="old enemy ability bar" src="https://github.com/user-attachments/assets/196619c4-d723-437f-9bfa-ec01699fab0c" />


<img width="1281" height="709" alt="old enemy passive ability bar" src="https://github.com/user-attachments/assets/ced8babd-2c8e-43fb-b019-0222da25b7bb" />

</details>

<details><summary>After</summary>

<img width="1280" height="709" alt="new player passive ability bar" src="https://github.com/user-attachments/assets/82cd51c5-fda9-4bf5-a9e8-49ef1af5d9e2" />

<img width="1281" height="710" alt="new enemy ability bar" src="https://github.com/user-attachments/assets/3e625c83-1bf9-4d0f-ac68-011f195e5bcd" />

<img width="1280" height="708" alt="new enemy passive ability bar" src="https://github.com/user-attachments/assets/51ac5055-b260-4395-8c59-fe4ea4952eea" />



</details>

## How to test the changes?

Easiest is to do challenge run with all passives active to see how different abilities appear.

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [~] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [x] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [~] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: _____
- [~] I have contacted the Translation Team on Discord for proofreading/translation

Does this require any additions or changes to in-game assets? If so:
- [~] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: _____
