### PR TITLE
dev: test creation script now fails if the file already exists

### DIFF
--- a/scripts/create-test/create-test.js
+++ b/scripts/create-test/create-test.js
@@ -24,7 +24,7 @@ import { HELP_FLAGS, showHelpText } from "./help-message.js";
  */
 
 //#region Constants
-const version = "2.1.0";
+const version = "2.1.1";
 const __dirname = import.meta.dirname;
 const projectRoot = join(__dirname, "..", "..");
 //#endregion
@@ -57,7 +57,7 @@ async function runInteractive() {
   try {
     doCreateFile(testType, fileNameAnswer);
   } catch (err) {
-    console.error(chalk.red("✗ Error: ", err));
+    console.error(chalk.red("✗", err));
   }
   console.groupEnd();
 }
@@ -67,6 +67,7 @@ async function runInteractive() {
  * @param {testType} testType - The type of test to create
  * @param {string} fileNameAnswer - The name of the file to create
  * @returns {void}
+ * @throws {Error} If the file to create already exists
  */
 function doCreateFile(testType, fileNameAnswer) {
   // Convert file name to kebab-case, formatting the description in Title Case
@@ -76,6 +77,9 @@ function doCreateFile(testType, fileNameAnswer) {
 
   const content = fs.readFileSync(getBoilerplatePath(testType), "utf8").replace("{{description}}", description);
   const filePath = getTestFileFullPath(testType, fileName);
+  if (fs.existsSync(filePath)) {
+    throw new Error(`File "${filePath}" already exists!`);
+  }
   writeFileSafe(filePath, content, "utf8");
 
   console.log(chalk.green.bold(`✔ File created at: ${filePath.replace(`${projectRoot}/`, "")}\n`));


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
The script run by `pnpm test:create` could overwrite existing test files, which isn't desirable.

## What are the changes from a developer perspective?
Added a check to make sure the file doesn't already exist, and if it does the script exists with an error message informing the user.


## Screenshots/Videos
<details><summary>Example</summary>

<img width="886" height="192" alt="image" src="https://github.com/user-attachments/assets/c6ee3f54-c676-4661-aa26-6166b1fed808" />

</details> 

## How to test the changes?
Run `pnpm test:create` and then try to create a test file for something that already exists (such as Tackle).

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually