### PR TITLE
fix(ui): Cursor box for save slot select is no longer off by a pixel

### DIFF
--- a/src/ui/handlers/save-slot-select-ui-handler.ts
+++ b/src/ui/handlers/save-slot-select-ui-handler.ts
@@ -373,7 +373,7 @@ export class SaveSlotSelectUiHandler extends MessageUiHandler {
     if (!this.cursorObj) {
       this.cursorObj = globalScene.add.container(0, 0);
       const cursorBox = globalScene.add.nineslice(
-        0,
+        1,
         15,
         "select_cursor_highlight_thick",
         undefined,


### PR DESCRIPTION
## What are the changes the user will see?
Save slot cursor box image will no longer be off by one pixel

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Pointed out by someone

## What are the changes from a developer perspective?
Set x offset for cursorBox nineslice to 1 instead of 0

## Screenshots/Videos

<details><summary>Before</summary>

<img width="1516" height="353" alt="image" src="https://github.com/user-attachments/assets/fd120a16-8ff1-432a-a23c-3ea21bce235f" />

</details>
<details><summary>After</summary>

<img width="1520" height="354" alt="image" src="https://github.com/user-attachments/assets/31e1b500-befb-49c7-ac8f-29b951839df3" />

</details>


## How to test the changes?
Open save slot selection
## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [x] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)