### PR TITLE
fix(move): Life Dew now ignores Substitute

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -11993,6 +11993,7 @@ export function initMoves() {
       .attr(HealAttr, 0.25, true, false)
       .target(MoveTarget.USER_AND_ALLIES)
       .ignoresProtect()
+      .ignoresSubstitute()
       .triageMove(),
     new SelfStatusMove(MoveId.OBSTRUCT, PokemonType.DARK, 100, 10, -1, 4, 8)
       .attr(ProtectAttr, BattlerTagType.OBSTRUCT)

--- a/test/tests/moves/life-dew.test.ts
+++ b/test/tests/moves/life-dew.test.ts
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: 2024-2026 Pagefault Games
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/framework/game-manager";
+import Phaser from "phaser";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move - Life Dew", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleStyle("single")
+      .criticalHits(false)
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset(MoveId.SPLASH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  // TODO: add test to check that all moves have the correct move flags, then delete this test file
+  // cf: https://github.com/Despair-Games/poketernity/pull/268
+  it("should ignore substitute", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const player = game.field.getPlayerPokemon();
+
+    game.move.use(MoveId.SUBSTITUTE);
+    await game.toNextTurn();
+    player.hp = player.getMaxHp() - 1;
+
+    game.move.use(MoveId.LIFE_DEW);
+    await game.toNextTurn();
+
+    expect(player).toHaveFullHp();
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?
Life Dew will correctly ignore Substitute.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Fixes #7182 

## What are the changes from a developer perspective?
Added `.ignoresSubstitute()` to the definition of Life Dew.
Also added a temporary test that can be removed once a test for move attributes is added.

## How to test the changes?
`pnpm test:silent life-dew`

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary