### PR TITLE
fix(ui): fix rendering/text issues in legacy ui

### DIFF
--- a/src/ui/containers/egg-counter-container.ts
+++ b/src/ui/containers/egg-counter-container.ts
@@ -43,9 +43,8 @@ export class EggCounterContainer extends Phaser.GameObjects.Container {
 
     const eggSprite = globalScene.add.sprite(19, 18, "egg", "egg_0").setScale(0.32);
 
-    this.eggCountText = addTextObject(28, 13, `${this.eggCount}`, TextStyle.MESSAGE, { fontSize: "66px" }).setName(
-      "text-egg-count",
-    );
+    this.eggCountText = addTextObject(28, 13, `${this.eggCount}`, TextStyle.WINDOW, { fontSize: "66px" }) //
+      .setName("text-egg-count");
 
     this.add([eggSprite, this.eggCountText]);
   }

--- a/src/ui/handlers/pokedex-page-ui-handler.ts
+++ b/src/ui/handlers/pokedex-page-ui-handler.ts
@@ -45,6 +45,7 @@ import { SpeciesId } from "#enums/species-id";
 import { TextStyle } from "#enums/text-style";
 import { TimeOfDay } from "#enums/time-of-day";
 import { UiMode } from "#enums/ui-mode";
+import { UiTheme } from "#enums/ui-theme";
 import type { Variant } from "#sprites/variant";
 import { getVariantIcon, getVariantTint } from "#sprites/variant";
 import { SettingKeyboard } from "#system/settings-keyboard";
@@ -371,11 +372,6 @@ export class PokedexPageUiHandler extends MessageUiHandler {
       .setOrigin(0);
     this.starterSelectContainer.add(starterSelectBg);
 
-    this.pokemonSprite = globalScene.add //
-      .sprite(53, 63, "pkmn__sub")
-      .setPipeline(globalScene.spritePipeline, { tone: [0.0, 0.0, 0.0, 0.0], ignoreTimeTint: true });
-    this.starterSelectContainer.add(this.pokemonSprite);
-
     this.starterDexNoLabel = globalScene.add //
       .image(6, 14, getLocalizedSpriteKey("summary_dexnb_label"))
       .setOrigin(0, 1);
@@ -386,6 +382,11 @@ export class PokedexPageUiHandler extends MessageUiHandler {
       .setOrigin(0, 1)
       .setVisible(false);
     this.starterSelectContainer.add(this.shinyOverlay);
+
+    this.pokemonSprite = globalScene.add //
+      .sprite(53, 63, "pkmn__sub")
+      .setPipeline(globalScene.spritePipeline, { tone: [0.0, 0.0, 0.0, 0.0], ignoreTimeTint: true });
+    this.starterSelectContainer.add(this.pokemonSprite);
 
     this.pokemonNumberText = addTextObject(17, 1, "0000", TextStyle.SUMMARY_DEX_NUM) //
       .setOrigin(0);
@@ -399,7 +400,7 @@ export class PokedexPageUiHandler extends MessageUiHandler {
       8,
       106,
       i18next.t("pokedexUiHandler:growthRate"),
-      TextStyle.SUMMARY_ALT,
+      TextStyle.WINDOW_ALT,
       { fontSize: "36px" },
     )
       .setOrigin(0)
@@ -462,7 +463,9 @@ export class PokedexPageUiHandler extends MessageUiHandler {
     this.starterSelectContainer.add(this.pokemonLuckText);
 
     // Candy icon and count
-    this.pokemonCandyContainer = globalScene.add.container(4.5, 18);
+    const isLegacyUi = globalScene.uiTheme === UiTheme.LEGACY;
+    this.pokemonCandyContainer = globalScene.add //
+      .container(isLegacyUi ? 7 : 4.5, 18);
 
     this.pokemonCandyIcon = globalScene.add //
       .sprite(0, 0, "candy")
@@ -500,7 +503,7 @@ export class PokedexPageUiHandler extends MessageUiHandler {
     this.starterSelectContainer.add(this.pokemonCategoryText);
 
     this.pokemonCaughtHatchedContainer = globalScene.add //
-      .container(2, 25)
+      .container(isLegacyUi ? 4.5 : 2, 25)
       .setScale(0.5);
     this.starterSelectContainer.add(this.pokemonCaughtHatchedContainer);
 
@@ -510,7 +513,7 @@ export class PokedexPageUiHandler extends MessageUiHandler {
       .setScale(0.75);
     this.pokemonCaughtHatchedContainer.add(pokemonCaughtIcon);
 
-    this.pokemonCaughtCountText = addTextObject(24, 4, "0", TextStyle.SUMMARY_ALT) //
+    this.pokemonCaughtCountText = addTextObject(24, 4, "0", TextStyle.WINDOW_ALT) //
       .setOrigin(0);
     this.pokemonCaughtHatchedContainer.add(this.pokemonCaughtCountText);
 
@@ -532,7 +535,7 @@ export class PokedexPageUiHandler extends MessageUiHandler {
       this.pokemonShinyIcons.push(pokemonShinyIcon);
     }
 
-    this.pokemonHatchedCountText = addTextObject(24, 19, "0", TextStyle.SUMMARY_ALT) //
+    this.pokemonHatchedCountText = addTextObject(24, 19, "0", TextStyle.WINDOW_ALT) //
       .setOrigin(0);
     this.pokemonCaughtHatchedContainer.add(this.pokemonHatchedCountText);
 

--- a/src/ui/handlers/starter-select-ui-handler.ts
+++ b/src/ui/handlers/starter-select-ui-handler.ts
@@ -644,7 +644,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
       8,
       106,
       i18next.t("starterSelectUiHandler:growthRate"),
-      TextStyle.SUMMARY_ALT,
+      TextStyle.WINDOW_ALT,
       { fontSize: "36px" },
     )
       .setOrigin(0)
@@ -845,12 +845,19 @@ export class StarterSelectUiHandler extends MessageUiHandler {
     ).setOrigin(0);
 
     // Candy icon and count
+    const isLegacyUi = globalScene.uiTheme === UiTheme.LEGACY;
     this.pokemonCandyContainer = globalScene.add
-      .container(4.5, 18)
+      .container(isLegacyUi ? 7 : 4.5, 18)
       .setInteractive(new Phaser.Geom.Rectangle(0, 0, 30, 20), Phaser.Geom.Rectangle.Contains);
-    this.pokemonCandyIcon = globalScene.add.sprite(0, 0, "candy").setScale(0.5).setOrigin(0);
-    this.pokemonCandyOverlayIcon = globalScene.add.sprite(0, 0, "candy_overlay").setScale(0.5).setOrigin(0);
-    this.pokemonCandyDarknessOverlay = globalScene.add
+    this.pokemonCandyIcon = globalScene.add //
+      .sprite(0, 0, "candy")
+      .setScale(0.5)
+      .setOrigin(0);
+    this.pokemonCandyOverlayIcon = globalScene.add //
+      .sprite(0, 0, "candy_overlay")
+      .setScale(0.5)
+      .setOrigin(0);
+    this.pokemonCandyDarknessOverlay = globalScene.add //
       .sprite(0, 0, "candy")
       .setScale(0.5)
       .setOrigin(0)
@@ -869,15 +876,30 @@ export class StarterSelectUiHandler extends MessageUiHandler {
       fontSize: "42px",
     }).setOrigin(0);
 
-    this.pokemonCaughtHatchedContainer = globalScene.add.container(2, 25).setScale(0.5);
+    this.pokemonCaughtHatchedContainer = globalScene.add //
+      .container(isLegacyUi ? 4.5 : 2, 25)
+      .setScale(0.5);
 
-    const pokemonCaughtIcon = globalScene.add.sprite(1, 0, "items", "pb").setOrigin(0).setScale(0.75);
+    const pokemonCaughtIcon = globalScene.add //
+      .sprite(1, 0, "items", "pb")
+      .setOrigin(0)
+      .setScale(0.75);
 
-    this.pokemonCaughtCountText = addTextObject(24, 4, "0", TextStyle.SUMMARY_ALT).setOrigin(0);
-    this.pokemonHatchedIcon = globalScene.add.sprite(1, 14, "egg_icons").setOrigin(0.15, 0.2).setScale(0.8);
-    this.pokemonShinyIcon = globalScene.add.sprite(14, 76, "shiny_icons").setOrigin(0.15, 0.2).setScale(1);
-    this.pokemonHatchedCountText = addTextObject(24, 19, "0", TextStyle.SUMMARY_ALT).setOrigin(0);
-    this.pokemonMovesContainer = globalScene.add.container(102, 16).setScale(0.375);
+    this.pokemonCaughtCountText = addTextObject(24, 4, "0", TextStyle.WINDOW_ALT) //
+      .setOrigin(0);
+    this.pokemonHatchedIcon = globalScene.add //
+      .sprite(1, 14, "egg_icons")
+      .setOrigin(0.15, 0.2)
+      .setScale(0.8);
+    this.pokemonShinyIcon = globalScene.add //
+      .sprite(isLegacyUi ? 8 : 14, 76, "shiny_icons")
+      .setOrigin(0.15, 0.2)
+      .setScale(1);
+    this.pokemonHatchedCountText = addTextObject(24, 19, "0", TextStyle.WINDOW_ALT) //
+      .setOrigin(0);
+    this.pokemonMovesContainer = globalScene.add //
+      .container(102, 16)
+      .setScale(0.375);
     this.pokemonCaughtHatchedContainer.add([
       pokemonCaughtIcon,
       this.pokemonCaughtCountText,
@@ -909,11 +931,16 @@ export class StarterSelectUiHandler extends MessageUiHandler {
       56,
       "(+0)",
       TextStyle.MOVE_LABEL,
-    ).setOrigin(0.5, 0);
+    )
+      .setOrigin(0.5, 0)
+      .setColor(getTextColor(TextStyle.WINDOW_ALT))
+      .setShadowColor(getTextColor(TextStyle.WINDOW_ALT, true));
 
     this.pokemonMovesContainer.add(this.pokemonAdditionalMoveCountLabel);
 
-    this.pokemonEggMovesContainer = globalScene.add.container(102, 85).setScale(0.375);
+    this.pokemonEggMovesContainer = globalScene.add //
+      .container(102, 85)
+      .setScale(0.375);
 
     this.eggMovesLabel = addTextObject(
       -46,

--- a/src/ui/handlers/summary-ui-handler.ts
+++ b/src/ui/handlers/summary-ui-handler.ts
@@ -848,19 +848,16 @@ export class SummaryUiHandler extends UiHandler {
             ? i18next.t("trainerNames:playerF")
             : i18next.t("trainerNames:playerM");
 
-        const profileContainerProfilTitle = globalScene.add.image(
-          7,
-          4,
-          getLocalizedSpriteKey("summary_profile_profile_title"), // Pixel text 'PROFIL'
-        );
-        profileContainerProfilTitle.setOrigin(0, 0.5);
-        profileContainer.add(profileContainerProfilTitle);
+        const profileContainerProfileTitle = globalScene.add //
+          .image(7, 4, getLocalizedSpriteKey("summary_profile_profile_title")) // Pixel text 'PROFILE'
+          .setOrigin(0, 0.5);
+        profileContainer.add(profileContainerProfileTitle);
 
         // TODO: should add field for original trainer name to Pokemon object, to support gift/traded Pokemon from MEs
         const trainerText = addBBCodeTextObject(
           7,
           12,
-          `${i18next.t("pokemonSummary:ot")}/${getBBCodeFrag(
+          `${getBBCodeFrag(`${i18next.t("pokemonSummary:ot")}/`, TextStyle.SUMMARY_ALT)}${getBBCodeFrag(
             globalScene.hideUsername
               ? usernameReplacement
               : loggedInUser?.username || i18next.t("pokemonSummary:unknown"),
@@ -904,8 +901,12 @@ export class SummaryUiHandler extends UiHandler {
         }
 
         if (this.pokemon?.getLuck()) {
-          const luckLabelText = addTextObject(141, 28, i18next.t("common:luckIndicator"), TextStyle.SUMMARY_ALT);
-          luckLabelText.setOrigin(0, 0);
+          const luckLabelText = addTextObject(
+            141,
+            28,
+            i18next.t("common:luckIndicator"),
+            TextStyle.WINDOW_ALT,
+          ).setOrigin(0, 0);
           profileContainer.add(luckLabelText);
 
           const luckText = addTextObject(
@@ -1225,12 +1226,12 @@ export class SummaryUiHandler extends UiHandler {
             newMoveTypeIcon.setOrigin(0, 1);
             this.extraMoveRowContainer.add(newMoveTypeIcon);
           }
-          const ppOverlay = globalScene.add.image(172, -5, getLocalizedSpriteKey("summary_moves_overlay_pp")); // Pixel text 'PP'
+          const ppOverlay = globalScene.add.image(177, -5, getLocalizedSpriteKey("summary_moves_overlay_pp")); // Pixel text 'PP'
           ppOverlay.setOrigin(1, 0.5);
           this.extraMoveRowContainer.add(ppOverlay);
 
           const pp = padInt(this.newMove?.pp!, 2, "  "); // TODO: is this bang correct?
-          const ppText = addTextObject(173, 1, `${pp}/${pp}`, TextStyle.WINDOW);
+          const ppText = addTextObject(178, 1, `${pp}/${pp}`, TextStyle.WINDOW);
           ppText.setOrigin(0, 1);
           this.extraMoveRowContainer.add(ppText);
         }


### PR DESCRIPTION
## What are the changes the user will see?
<!--
Summarize the changes from a user perspective on the application.
Try to keep this section (relatively) brief as it is used to generate changelogs.
If you need to provide additional details, you can do so below the cutoff.

PRs with no user-facing changes should leave this blank or write "N/A" to be omitted from auto-generated changelogs.
-->

Various text / rendering fixes for Legacy UI.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

In the Legacy UI, there are many instances of text being illegible or ui elements that are misaligned.

## What are the changes from a developer perspective?
<!--
Describe the changes this PR introduces to the codebase.
You can make use of a comparison between the state of the code before and after your changes.
Ex: What files have been changed? What classes/functions/variables/etc. have been added or changed?

Include enough detail to convey the scope of the changes being made and the rationale behind their implementation.
Feel free to include small code snippets if you think they will help illustrate your points.
-->
Egg Counter Container
* Adjusted `eggCountText` to use `TextStyle.WINDOW` instead of `TextStyle.MESSAGE`. The text styles are indentical for the default UI, while on legacy UI 'WINDOW' uses dark text so it is legible against the light background.

Pokédex Page UI
* Rendered `pokemonSprite` after `starterDexNoLabel` and `shinyOverlay` so the shiny bars would not cover the Pokémon sprite.
* Changed `TextStyle.SUMMARY_ALT` to `WINDOW_ALT` on  `growthRateLabelText`, `pokemonCaughtCountText` and `pokemonHatchedCountText`. The text styles are identical for the default UI, while on legacy UI `WINDOW_ALT` uses dark text.
* Adjusted container placement for the `pokemonCandyContainer` and the `pokemonCaughtHatchedContainer` if legacy UI is active to properly be inside the Pokémon window.

Starter Select UI
* Changed `TextStyle.SUMMARY_ALT` to `TextStyle.WINDOW_ALT` on `pokemonGrowthRateLabelText`, `pokemonCaughtCountText`, and `pokemonHatchedCountText`.
* Used `TextStyle.WINDOW_ALT` color and shadow on`pokemonAdditionalMoveCountLabel` so it keeps the same font as the egg moves but is legible against the background. (this also effects default UI).
* * Adjusted container placement for the `pokemonCandyContainer` and the `pokemonCaughtHatchedContainer` if legacy UI is active to properly be inside the Pokémon window.

Summary UI
* Updated `trainerText` to use `getBBCodeFrag()` for `pokemonSummary:ot` text to properly apply text style.
* Changed `TextStyle.SUMMARY_ALT` to `WINDOW_ALT` on  `luckLabelText`.
* Adjusted `ppOverlay` and `ppText` for a new move to match placement on the existing moves.

## Screenshots/Videos

<details><summary>Pokédex: Before and After</summary>

<img width="516" height="611" alt="image" src="https://github.com/user-attachments/assets/e0d862e2-1c0e-46ef-8e3b-ea7c5057eeff" />

<img width="517" height="609" alt="image" src="https://github.com/user-attachments/assets/694feae1-502b-4cbe-9800-194ca36447fa" />

</details>

<details><summary>Starter Select: Before and After</summary>

<img width="529" height="861" alt="image" src="https://github.com/user-attachments/assets/9f51880f-05b2-4020-a076-9d56079d51f7" />

<img width="525" height="860" alt="image" src="https://github.com/user-attachments/assets/3e9c9440-85e3-4662-8bb1-203b0bed1f12" />

</details>

<details><summary>Pokémon Summary: Before and After</summary>

<img width="1537" height="863" alt="image" src="https://github.com/user-attachments/assets/68f43e3e-ba29-498f-af43-b1104f4aaaf0" />

<img width="1534" height="864" alt="image" src="https://github.com/user-attachments/assets/f836060c-5b86-498b-a5bf-5243baf0f5a7" />

</details>

<details><summary>Egg Hatch Counter: Before and After</summary>

<img width="1535" height="858" alt="image" src="https://github.com/user-attachments/assets/83e06c22-fb53-4d65-9c00-ab6023273aee" />

<img width="1536" height="848" alt="image" src="https://github.com/user-attachments/assets/5c9ac20c-bde4-49ca-aaa5-5abbc22e8841" />

</details>

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->
View the different screens changed.

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [~] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [x] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [~] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: _____
- [~] I have contacted the Translation Team on Discord for proofreading/translation

Does this require any additions or changes to in-game assets? If so:
- [~] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: _____
