### PR TITLE
fix(ui): give legacy ui ability bars minimum size

### DIFF
--- a/src/ui/containers/ability-bar.ts
+++ b/src/ui/containers/ability-bar.ts
@@ -5,12 +5,13 @@ import { addTextObject } from "#ui/text";
 import i18next from "i18next";
 
 const defaultBarWidth = 118;
+const defaultLegacyBarWidth = 90;
 const defaultBarHeight = 31;
 const screenLeft = 0;
 const baseY = -116;
 const textPadding = 15;
-const legacyUiPlayerTextPadding = 17;
-const legacyUiEnemyTextPadding = 5;
+const legacyUiPlayerTextPadding = 16;
+const legacyUiEnemyTextPadding = 6;
 
 export class AbilityBar extends Phaser.GameObjects.Container {
   private readonly abilityBars: (Phaser.GameObjects.Image | Phaser.GameObjects.NineSlice)[];
@@ -29,31 +30,37 @@ export class AbilityBar extends Phaser.GameObjects.Container {
     this.player = true;
     this.shown = false;
     this.isLegacyUi = globalScene.uiTheme === UiTheme.LEGACY;
-    this.currentBarWidth = defaultBarWidth;
+    this.currentBarWidth = this.isLegacyUi ? defaultLegacyBarWidth : defaultBarWidth;
   }
 
   setup(): this {
     if (this.isLegacyUi) {
       for (const key of ["ability_bar_right", "ability_bar_left"]) {
         const bar = globalScene.add
-          .nineslice(0, 0, key, undefined, defaultBarWidth, defaultBarHeight, 4, 4, 4, 4)
+          .nineslice(0, 0, key, undefined, defaultBarWidth, defaultBarHeight, 16, 16)
           .setOrigin(0)
           .setVisible(false);
         this.add(bar);
         this.abilityBars.push(bar);
       }
 
-      this.legacyUiPokemonText = addTextObject(textPadding + 2, 3, "", TextStyle.MESSAGE, { fontSize: "72px" }) //
+      this.legacyUiPokemonText = addTextObject(legacyUiPlayerTextPadding, 3, "", TextStyle.MESSAGE, {
+        fontSize: "72px",
+      }) //
         .setOrigin(0);
 
-      this.legacyUiAbilityText = addTextObject(textPadding + 2, 16, "", TextStyle.MESSAGE, { fontSize: "72px" }) //
+      this.legacyUiAbilityText = addTextObject(legacyUiPlayerTextPadding, 16, "", TextStyle.MESSAGE, {
+        fontSize: "72px",
+      }) //
         .setOrigin(0);
 
       this.legacyUiAbilityText.setColor("#484848");
       this.legacyUiAbilityText.setShadowColor("#d0d0c8");
 
-      this.add(this.legacyUiPokemonText).bringToTop(this.legacyUiPokemonText);
-      this.add(this.legacyUiAbilityText).bringToTop(this.legacyUiAbilityText);
+      this.add(this.legacyUiPokemonText) //
+        .bringToTop(this.legacyUiPokemonText);
+      this.add(this.legacyUiAbilityText) //
+        .bringToTop(this.legacyUiAbilityText);
     } else {
       for (const key of ["ability_bar_right", "ability_bar_left"]) {
         const bar = globalScene.add //
@@ -75,7 +82,7 @@ export class AbilityBar extends Phaser.GameObjects.Container {
     }
 
     this.setVisible(false) //
-      .setX(-defaultBarWidth); // start hidden (right edge of bar at x=0)
+      .setX(-this.currentBarWidth); // start hidden (right edge of bar at x=0)
 
     return this;
   }
@@ -90,8 +97,11 @@ export class AbilityBar extends Phaser.GameObjects.Container {
     if (!this.isLegacyUi) {
       return;
     }
-    this.currentBarWidth =
-      Math.max(this.legacyUiPokemonText.displayWidth, this.legacyUiAbilityText.displayWidth) + textPadding * 2;
+    const textMaxWidth = Math.max(this.legacyUiPokemonText.displayWidth, this.legacyUiAbilityText.displayWidth);
+    this.currentBarWidth = Math.max(
+      defaultLegacyBarWidth,
+      textMaxWidth + legacyUiEnemyTextPadding + legacyUiPlayerTextPadding,
+    );
     this.abilityBars[+this.player].setSize(this.currentBarWidth, defaultBarHeight);
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to PokéRogue!
Open-source contributions like yours help keep this project going.

Note that these comment blocks are purely informative and can be removed once you're done reading them.
-->

<!--
Make sure your title matches the https://www.conventionalcommits.org/en/v1.0.0/ format.
Try to keep the title under 72 characters, as GitHub cuts off commit titles longer than this length.

See https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request
for more information on the allowed scopes and prefixes.

Example:
fix(move): Future Sight no longer crashes
^   ^      ^
|   |      |__ Subject
|   |_________ Scope (optional)
|_____________ Prefix
-->

## What are the changes the user will see?
<!--
Summarize the changes from a user perspective on the application.
Try to keep this section (relatively) brief as it is used to generate changelogs.
If you need to provide additional details, you can do so below the cutoff.

PRs with no user-facing changes should leave this blank or write "N/A" to be omitted from auto-generated changelogs.
-->
Ability Bars in Legacy UI now have a minimum size and consistent text placement.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
<!--
Explain why you decided to introduce these changes.
Does it come from another issue, PR or other prior discussion? Link to them if possible.
How can this can enhance user experience or otherwise improve the codebase?

Try to keep this explanation as objective as possible — avoid referring to personal feelings or making derogatory comments about existing code.

If this PR resolves an existing GitHub issue,
you can add "Fixes #[issue number]" (e.g.: "Fixes #1234") to link the issue.
(See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue for more information.)
-->
Ability bar sizes were too variable, and inconsistency in bar expansion caused text to appear in different place along the bar.  Now added a min size and only the option to grow if the text extends beyond the bar.

## What are the changes from a developer perspective?
<!--
Describe the changes this PR introduces to the codebase.
You can make use of a comparison between the state of the code before and after your changes.
Ex: What files have been changed? What classes/functions/variables/etc. have been added or changed?

Include enough detail to convey the scope of the changes being made and the rationale behind their implementation.
Feel free to include small code snippets if you think they will help illustrate your points.
-->

AbilityBar.ts
* Set `defaultLegacyBarWidth` to 90px
* Updated `legacyUiPlayerTextPadding` and `legacyUiEnemyTextPadding` respectively to handle the 10 empty pixels of space on the left side of `ability_bar_left.png` that are instead on the right side of `ability_bar_right.png`.
* Updated the `NineSlice` objects for the legacy ability bars to be a 3-Phase Slice since we don't need to grow vertically. Also set the right and left widths to be 16px to handle the difference in empty space.
* Changed `updateBarWidth()` to find the maximum width of the text. `currentBarWidth` is then set to the max of `defaultLegacyBarWidth` or the text width + minimum padding needed for both player and enemy ability bars.
* Minor changes for formatting consistency

## Screenshots/Videos

<details><summary>Short Player Abiilty: Before and After</summary>
Before
<img width="1475" height="848" alt="image" src="https://github.com/user-attachments/assets/9d1b2e91-a8d5-4832-9b06-3007ef6eee51" />

After
<img width="1472" height="838" alt="image" src="https://github.com/user-attachments/assets/8e23564e-89b9-42b3-8dac-40e0aa5276f7" />


</details>
<details><summary>Long Player Abiilty: Before and After</summary>
Before
<img width="1473" height="845" alt="image" src="https://github.com/user-attachments/assets/e74d845e-effc-48b4-ad76-9376d731214e" />

After
<img width="1472" height="843" alt="image" src="https://github.com/user-attachments/assets/ae7a3abc-bc70-4061-b8aa-44e1123eeb6b" />


</details>
<details><summary>Short Enemy Abiilty: Before and After</summary>
Before
<img width="1472" height="841" alt="image" src="https://github.com/user-attachments/assets/602ae7ef-6cfc-4b9e-a712-81fa4aa4a93f" />

After
<img width="1473" height="841" alt="image" src="https://github.com/user-attachments/assets/19af2db8-5586-446d-9eb6-507400c7b9ab" />


</details>
<details><summary>Long Enemy Abiilty: Before and After</summary>
Before
<img width="1472" height="844" alt="image" src="https://github.com/user-attachments/assets/9922c8f2-c510-4bdd-b30e-173fa937b72d" />

After
<img width="1468" height="837" alt="image" src="https://github.com/user-attachments/assets/5c858028-7968-4798-8384-6f56d14de9b0" />

</details>

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [~] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [x] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [~] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: _____
- [~] I have contacted the Translation Team on Discord for proofreading/translation

Does this require any additions or changes to in-game assets? If so:
- [~] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: _____
