### PR TITLE
fix: splash text `itsBeenTotalRuns` will display properly

### DIFF
--- a/src/ui/handlers/title-ui-handler.ts
+++ b/src/ui/handlers/title-ui-handler.ts
@@ -190,6 +190,7 @@ export class TitleUiHandler extends OptionSelectUiHandler {
     this.splashMessageText.setText(
       i18next.t(this.splashMessage, {
         count: TitleUiHandler.BATTLES_WON_FALLBACK,
+        cycleCountNoOrdinal: 5643853 + globalScene.gameData.gameStats.classicSessionsPlayed, // for `splashMessages:itsBeenTotalRuns`
       }),
     );
 


### PR DESCRIPTION
## What are the changes the user will see?
The splash text "It's been [#] runs..." will display properly.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Fixing a bug.

## What are the changes from a developer perspective?
Passed a missing `cycleCountNoOrdinal` property to the `i18next.t` call in the title screen UI handler.

## Screenshots/Videos
<details><summary>Before</summary>

<img width="1229" height="686" alt="image" src="https://github.com/user-attachments/assets/6e2702f3-3d58-4bb3-bcc4-140752f9f013" />

</details>
<details><summary>After</summary>

<img width="1228" height="689" alt="image" src="https://github.com/user-attachments/assets/b7f141dd-685d-4b23-9a86-e2c3421d5ce8" />

</details>

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually