### PR TITLE
dev: `.mts` files in `.github/` are now parsed by tsconfig

### DIFF
--- a/.github/scripts/pr-title.mts
+++ b/.github/scripts/pr-title.mts
@@ -67,8 +67,12 @@ async function run(): Promise<void> {
     const authToken = core.getInput("github_token", { required: true });
 
     const { eventName } = github.context;
-    if (eventName !== "pull_request" || !github.context.payload.pull_request) {
+    if (eventName !== "pull_request") {
       core.setFailed(`Invalid event: ${eventName}`);
+      return;
+    }
+    if (!github.context.payload.pull_request) {
+      core.setFailed("Error parsing pull request data!");
       return;
     }
 

--- a/.github/scripts/pr-title.mts
+++ b/.github/scripts/pr-title.mts
@@ -43,15 +43,16 @@ const ALL_SCOPES = [
   "ui", // UI/UX
 ] as const;
 
-type AllScopes = (typeof ALL_SCOPES)[number];
+type AllScopes = (typeof ALL_SCOPES)[number] | "beta";
 
-const PREFIX_SCOPE_MAP = {
+const PREFIX_SCOPE_MAP: Readonly<Record<Prefixes, readonly AllScopes[]>> = {
   balance: ["ability", "ai", "biomes", "challenge", "encounter", "event", "item", "move"],
   chore: [],
   dev: [],
   docs: ALL_SCOPES,
   feat: ALL_SCOPES,
-  fix: ALL_SCOPES,
+  // Add special scope for fixing bugs that only existed on the beta branch
+  fix: [...ALL_SCOPES, "beta"],
   github: [],
   i18n: [],
   misc: [],
@@ -59,17 +60,14 @@ const PREFIX_SCOPE_MAP = {
   refactor: ALL_SCOPES,
   revert: [],
   test: ALL_SCOPES,
-} as const satisfies Record<Prefixes, readonly AllScopes[]>;
-
-// @ts-expect-error: Add special scope for fixing bugs that only existed on the beta branch
-PREFIX_SCOPE_MAP.fix = [...ALL_SCOPES, "beta"];
+} as const;
 
 async function run(): Promise<void> {
   try {
     const authToken = core.getInput("github_token", { required: true });
 
     const { eventName } = github.context;
-    if (eventName !== "pull_request") {
+    if (eventName !== "pull_request" || !github.context.payload.pull_request) {
       core.setFailed(`Invalid event: ${eventName}`);
       return;
     }
@@ -79,9 +77,9 @@ async function run(): Promise<void> {
     // When the user updates the title and re-runs the workflow, it would be outdated.
     // Therefore fetch the pull request via the REST API to ensure we use the current title.
     const { data: pullRequest } = await client.rest.pulls.get({
-      owner: github.context.payload.pull_request!.base.user.login,
-      repo: github.context.payload.pull_request!.base.repo.name,
-      pull_number: github.context.payload.pull_request!.number,
+      owner: github.context.payload.pull_request.base.user.login,
+      repo: github.context.payload.pull_request.base.repo.name,
+      pull_number: github.context.payload.pull_request.number,
     });
 
     const { title } = pullRequest;
@@ -104,32 +102,32 @@ Terminology: fix(move): Future Sight no longer crashes
              |_____________ Prefix
 `;
 
-    core.info(info.trim());
+    core.info(info);
 
     // Example usage of regex: https://regex101.com/r/FeN8jG/8
     const regex = /^([a-z0-9]+)!?(\([a-z]+\))?: .+/;
-    if (!regex.test(title)) {
+    const regexResult = regex.exec(title);
+    if (!regexResult) {
       core.setFailed(`Pull Request title "${title}" failed to match - "Prefix(Scope): Subject"`);
       return;
     }
 
-    const regexResult = regex.exec(title);
     const prefix = regexResult[1];
-    const scope = regexResult[2]?.replace(/[()]/g, "");
+    const scope = regexResult[2]?.replace(/[()]/g, "") as AllScopes | undefined;
 
-    if (!PREFIXES.some(p => p === prefix)) {
+    if (!(PREFIXES as readonly string[]).includes(prefix)) {
       core.setFailed(`Pull Request title "${title}" did not match any of the prefixes: [${PREFIXES}]`);
       return;
     }
 
     // biome-ignore lint/style/useExplicitLengthCheck: doubles as a nullish check for `scope`
-    if (scope?.length && !PREFIX_SCOPE_MAP[prefix].includes(scope)) {
+    if (scope?.length && !PREFIX_SCOPE_MAP[prefix as Prefixes].includes(scope)) {
       core.setFailed(`Pull Request title "${title}" has an invalid prefix (${prefix}) + scope (${scope}) combination!`);
       return;
     }
   } catch (error) {
-    core.setFailed(error.message);
+    core.setFailed((error as Error).message);
   }
 }
 
-run();
+await run();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -97,6 +97,6 @@
     }
   },
   // Exclude checking for script JS files as those are covered by the folder's `jsconfig.json`
-  "include": ["**/*.ts", "**/*.d.ts", "**/*.mts"],
+  "include": ["**/*.ts", "**/*.d.ts", "**/*.mts", ".github/**/*.mts"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## What are the changes the user will see?
N/A
<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
https://github.com/microsoft/TypeScript/issues/49555 meant that `.github` was not linted under our TSConfig.
The only reason no errors appeared was that VSCode's defaults were less stringent than what we actually used.

## What are the changes from a developer perspective?
Added necessary type assertions to make `pr-title.mts` not error, and added the directory to the tsconfig's include list.

## Screenshots/Videos
N/A
## How to test the changes?
`pnpm exec tsgo`
## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary