### PR TITLE
fix: Infiltrator bypasses Mist, Mist activation message fixed

### DIFF
--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -170,7 +170,7 @@ export abstract class ArenaTag implements BaseArenaTag {
   // TODO: Move all classes with `apply` triggers into a unique sub-class to prevent
   // applying effects of tags that lack effect application
   // biome-ignore lint/correctness/noUnusedFunctionParameters: pseudo-abstract method
-  public apply(...args: never): void {}
+  public apply(...args: unknown[]): void {}
 
   /**
    * Trigger effects when this tag is added to the Arena.

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -314,7 +314,12 @@ export class MistTag extends SerializableArenaTag {
    * @param defender - The {@linkcode Pokemon} receiving the stat drop
    * @param cancelled - A {@linkcode BooleanHolder} containing whether to nullify the interaction
    */
-  override apply(simulated: boolean, defender: Pokemon, cancelled: BooleanHolder, source: Pokemon | undefined): boolean {
+  override apply(
+    simulated: boolean,
+    defender: Pokemon,
+    cancelled: BooleanHolder,
+    source: Pokemon | undefined,
+  ): boolean {
     // `StatStageChangePhase` currently doesn't have a reference to the source of stat drops,
     // so this code currently has no effect on gameplay.
     if (source) {
@@ -333,7 +338,7 @@ export class MistTag extends SerializableArenaTag {
         }),
       );
     }
-    
+
     return true;
   }
 }

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -296,8 +296,8 @@ export abstract class SerializableArenaTag extends ArenaTag {
  */
 export class MistTag extends SerializableArenaTag {
   readonly tagType = ArenaTagType.MIST;
-  constructor(turnCount: number, sourceId: number | undefined, side: ArenaTagSide) {
-    super(turnCount, MoveId.MIST, sourceId, side);
+  constructor(turnCount: number, side: ArenaTagSide) {
+    super(turnCount, MoveId.MIST, undefined, side);
   }
 
   protected override get onAddMessageKey(): string {
@@ -1728,7 +1728,7 @@ export function getArenaTag(
 ): ArenaTag | null {
   switch (tagType) {
     case ArenaTagType.MIST:
-      return new MistTag(turnCount, sourceId, side);
+      return new MistTag(turnCount, side);
     case ArenaTagType.QUICK_GUARD:
       return new QuickGuardTag(sourceId, side);
     case ArenaTagType.WIDE_GUARD:

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -313,6 +313,7 @@ export class MistTag extends SerializableArenaTag {
    * @param simulated - Whether to suppress messages and other animations from being playerd
    * @param defender - The {@linkcode Pokemon} receiving the stat drop
    * @param cancelled - A {@linkcode BooleanHolder} containing whether to nullify the interaction
+   * @param source - The Pokemon causing the stat drop, if applicable
    */
   override apply(
     simulated: boolean,

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -321,7 +321,7 @@ export class MistTag extends SerializableArenaTag {
       const bypassed = new BooleanHolder(false);
       applyAbAttrs("InfiltratorAbAttr", { pokemon: source, simulated, bypassed });
       if (bypassed.value) {
-        return;
+        return false;
       }
     }
 

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -170,7 +170,7 @@ export abstract class ArenaTag implements BaseArenaTag {
   // TODO: Move all classes with `apply` triggers into a unique sub-class to prevent
   // applying effects of tags that lack effect application
   // biome-ignore lint/correctness/noUnusedFunctionParameters: pseudo-abstract method
-  public apply(...args: unknown[]): void {}
+  public apply(...args: never): void {}
 
   /**
    * Trigger effects when this tag is added to the Arena.
@@ -309,36 +309,30 @@ export class MistTag extends SerializableArenaTag {
   }
 
   /**
-   * Cancels the lowering of stats
-   * @param simulated `true` if the effect should be applied quietly
-   * @param attacker the {@linkcode Pokemon} using a move into this effect.
-   * @param cancelled a {@linkcode BooleanHolder} whose value is set to `true`
-   * to flag the stat reduction as cancelled
-   * @returns `true` if a stat reduction was cancelled; `false` otherwise
+   * Attempt to block the lowering of stats.
+   * @param simulated - Whether to suppress messages and other animations from being playerd
+   * @param defender - The {@linkcode Pokemon} receiving the stat drop
+   * @param cancelled - A {@linkcode BooleanHolder} containing whether to nullify the interaction
    */
-  override apply(simulated: boolean, attacker: Pokemon | null, cancelled: BooleanHolder): boolean {
+  override apply(simulated: boolean, defender: Pokemon, cancelled: BooleanHolder, _source: undefined): void {
     // `StatStageChangePhase` currently doesn't have a reference to the source of stat drops,
     // so this code currently has no effect on gameplay.
-    if (attacker) {
-      const bypassed = new BooleanHolder(false);
-      // TODO: Allow this to be simulated
-      applyAbAttrs("InfiltratorAbAttr", { pokemon: attacker, simulated: false, bypassed });
-      if (bypassed.value) {
-        return false;
-      }
-    }
+    // if (source) {
+    //   const bypassed = new BooleanHolder(false);
+    //   applyAbAttrs("InfiltratorAbAttr", { pokemon: source, simulated, bypassed });
+    //   if (bypassed.value) {
+    //     return;
+    //   }
+    // }
 
     cancelled.value = true;
-
     if (!simulated) {
       globalScene.phaseManager.queueMessage(
         i18next.t("arenaTag:mistApply", {
-          pokemonNameWithAffix: getPokemonNameWithAffix(this.getSourcePokemon()),
+          pokemonNameWithAffix: getPokemonNameWithAffix(defender),
         }),
       );
     }
-
-    return true;
   }
 }
 

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -333,6 +333,8 @@ export class MistTag extends SerializableArenaTag {
         }),
       );
     }
+    
+    return true;
   }
 }
 

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -314,7 +314,7 @@ export class MistTag extends SerializableArenaTag {
    * @param defender - The {@linkcode Pokemon} receiving the stat drop
    * @param cancelled - A {@linkcode BooleanHolder} containing whether to nullify the interaction
    */
-  override apply(simulated: boolean, defender: Pokemon, cancelled: BooleanHolder, _source: undefined): void {
+  override apply(simulated: boolean, defender: Pokemon, cancelled: BooleanHolder, source: Pokemon | undefined): boolean {
     // `StatStageChangePhase` currently doesn't have a reference to the source of stat drops,
     // so this code currently has no effect on gameplay.
     // if (source) {

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -320,8 +320,6 @@ export class MistTag extends SerializableArenaTag {
     cancelled: BooleanHolder,
     source: Pokemon | undefined,
   ): boolean {
-    // `StatStageChangePhase` currently doesn't have a reference to the source of stat drops,
-    // so this code currently has no effect on gameplay.
     if (source) {
       const bypassed = new BooleanHolder(false);
       applyAbAttrs("InfiltratorAbAttr", { pokemon: source, simulated, bypassed });

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -317,13 +317,13 @@ export class MistTag extends SerializableArenaTag {
   override apply(simulated: boolean, defender: Pokemon, cancelled: BooleanHolder, source: Pokemon | undefined): boolean {
     // `StatStageChangePhase` currently doesn't have a reference to the source of stat drops,
     // so this code currently has no effect on gameplay.
-    // if (source) {
-    //   const bypassed = new BooleanHolder(false);
-    //   applyAbAttrs("InfiltratorAbAttr", { pokemon: source, simulated, bypassed });
-    //   if (bypassed.value) {
-    //     return;
-    //   }
-    // }
+    if (source) {
+      const bypassed = new BooleanHolder(false);
+      applyAbAttrs("InfiltratorAbAttr", { pokemon: source, simulated, bypassed });
+      if (bypassed.value) {
+        return;
+      }
+    }
 
     cancelled.value = true;
     if (!simulated) {

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -652,7 +652,7 @@ export class Arena {
         continue;
       }
 
-      tag.apply(...args);
+      (tag.apply as (...params: Parameters<T["apply"]>) => void)(...args);
     }
   }
 

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -652,7 +652,7 @@ export class Arena {
         continue;
       }
 
-      (tag.apply as (...params: Parameters<T["apply"]>) => void)(...args);
+      tag.apply(...args);
     }
   }
 

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -3,7 +3,6 @@ import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { handleTutorial, Tutorial } from "#app/tutorial";
 import type { ArenaTag } from "#data/arena-tag";
-import { MistTag } from "#data/arena-tag";
 import { OctolockTag } from "#data/battler-tags";
 import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
@@ -130,13 +129,14 @@ export class StatStageChangePhase extends PokemonPhase {
       const cancelled = new BooleanHolder(false);
 
       if (!this.selfTarget && stages.value < 0) {
-        // TODO: add a reference to the source of the stat change to fix Infiltrator interaction
         globalScene.arena.applyTagsForSide(
-          MistTag,
+          ArenaTagType.MIST,
           pokemon.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY,
           false,
-          null,
+          pokemon,
           cancelled,
+          // TODO: add a reference to the source of the stat change to fix Infiltrator interaction
+          undefined,
         );
       }
 

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -135,8 +135,7 @@ export class StatStageChangePhase extends PokemonPhase {
           false,
           pokemon,
           cancelled,
-          // TODO: add a reference to the source of the stat change to fix Infiltrator interaction
-          undefined,
+          opponentPokemon,
         );
       }
 

--- a/src/utils/value-holder.ts
+++ b/src/utils/value-holder.ts
@@ -68,6 +68,6 @@ export class NumberHolder<T = number> extends ValueHolder<T, number> {}
 /**
  * An alias for a boolean-only {@linkcode ValueHolder}.
  * @deprecated
- * New code should prefer using `ValueHolder` instead - this is kept for compatibility
+ * New code should prefer using `ValueHolder` instead - this is kept for compatibility reasons
  */
 export class BooleanHolder<T = boolean> extends ValueHolder<T, boolean> {}

--- a/test/framework/game-manager.ts
+++ b/test/framework/game-manager.ts
@@ -369,7 +369,7 @@ export class GameManager {
 
   /**
    * Transition to the {@linkcode TurnEndPhase | end of the current turn}.
-   * @param endTurn - Whether to run the `TurnEndPhase` or not; default `true`
+   * @param endTurn - (Default `true`) Whether to run the `TurnEndPhase` before resolving.
    * @returns A Promise that resolves once the current turn has ended.
    */
   async toEndOfTurn(endTurn = true): Promise<void> {

--- a/test/tests/moves/mist.test.ts
+++ b/test/tests/moves/mist.test.ts
@@ -1,8 +1,13 @@
+import { getPokemonNameWithAffix } from "#app/messages";
 import { AbilityId } from "#enums/ability-id";
+import { ArenaTagSide } from "#enums/arena-tag-side";
+import { ArenaTagType } from "#enums/arena-tag-type";
+import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { Stat } from "#enums/stat";
 import { GameManager } from "#test/framework/game-manager";
+import i18next from "i18next";
 import Phaser from "phaser";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -19,27 +24,66 @@ describe("Moves - Mist", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     game.override
-      .moveset([MoveId.MIST, MoveId.SPLASH])
       .ability(AbilityId.BALL_FETCH)
-      .battleStyle("double")
+      .battleStyle("single")
       .criticalHits(false)
-      .enemySpecies(SpeciesId.SNORLAX)
+      .enemySpecies(SpeciesId.MAGIKARP)
       .enemyAbility(AbilityId.BALL_FETCH)
-      .enemyMoveset(MoveId.GROWL);
+      .enemyMoveset(MoveId.SPLASH);
   });
 
-  it("should prevent the user's side from having stats lowered", async () => {
-    await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
+  it("should prevent the user and its allies from having their stats lowered by other Pokemon", async () => {
+    game.override.battleStyle("double");
+    await game.classicMode.startBattle(SpeciesId.FEEBAS, SpeciesId.MILOTIC);
 
-    const playerPokemon = game.scene.getPlayerField();
+    const [feebas, milotic] = game.scene.getPlayerField();
 
-    game.move.select(MoveId.MIST, 0);
-    game.move.select(MoveId.SPLASH, 1);
+    game.move.use(MoveId.MIST, BattlerIndex.PLAYER);
+    game.move.use(MoveId.TICKLE, BattlerIndex.PLAYER_2, BattlerIndex.PLAYER);
+    await game.move.forceEnemyMove(MoveId.GROWL);
+    await game.move.forceEnemyMove(MoveId.SPLASH);
+    game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
+    await game.toEndOfTurn(false);
 
-    await game.phaseInterceptor.to("BerryPhase");
-
-    playerPokemon.forEach(p => expect(p.getStatStage(Stat.ATK)).toBe(0));
+    // all stat drops should have been blocked, including those from allies
+    expect(game).toHaveArenaTag({ tagType: ArenaTagType.MIST, side: ArenaTagSide.PLAYER, turnCount: 5 });
+    expect(feebas).toHaveStatStage(Stat.ATK, 0);
+    expect(milotic).toHaveStatStage(Stat.ATK, 0);
+    // TODO: Move failures don't get propagated here...
+    // const karp = game.field.getEnemyPokemon();
+    // expect(karp).toHaveUsedMove({move: MoveId.GROWL, result: MoveResult.FAIL});
   });
 
+  it("should show a message upon successfully blocking a stat drop", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const feebas = game.field.getPlayerPokemon();
+
+    game.move.use(MoveId.MIST);
+    await game.move.forceEnemyMove(MoveId.LEER);
+    game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+    await game.toEndOfTurn();
+
+    expect(game).toHaveShownMessage(
+      i18next.t("arenaTag:mistApply", {
+        pokemonNameWithAffix: getPokemonNameWithAffix(feebas),
+      }),
+    );
+  });
+
+  it("should not apply to self-targeting moves", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    game.scene.arena.addTag(ArenaTagType.MIST, 5, undefined, 0, ArenaTagSide.PLAYER);
+
+    game.move.use(MoveId.SHELL_SMASH);
+    await game.toEndOfTurn();
+
+    const feebas = game.field.getPlayerPokemon();
+    expect(feebas).toHaveStatStage(Stat.ATK, 2);
+    expect(feebas).toHaveStatStage(Stat.DEF, -1);
+  });
+
+  // TODO: Implement once stat stage change phase is refactored
   it.todo("should be ignored by opponents with Infiltrator");
 });

--- a/test/tests/moves/mist.test.ts
+++ b/test/tests/moves/mist.test.ts
@@ -91,6 +91,9 @@ describe("Moves - Mist", () => {
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     game.move.use(MoveId.GROWL);
     await game.move.forceEnemyMove(MoveId.MIST);
+    await game.phaseInterceptor.to("MoveEndPhase");
+    expect(game).toHaveArenaTag(ArenaTagType.MIST, ArenaTagSide.ENEMY);
+    expect(game.field.getEnemyPokemon()).toHaveStatStage(Stat.ATK, 0);
     await game.toEndOfTurn();
 
     expect(game.field.getEnemyPokemon()).toHaveStatStage(Stat.ATK, -1);

--- a/test/tests/moves/mist.test.ts
+++ b/test/tests/moves/mist.test.ts
@@ -84,6 +84,15 @@ describe("Moves - Mist", () => {
     expect(feebas).toHaveStatStage(Stat.DEF, -1);
   });
 
-  // TODO: Implement once stat stage change phase is refactored
-  it.todo("should be ignored by opponents with Infiltrator");
+  it("should be ignored by opponents with Infiltrator", async () => {
+    game.override.ability(AbilityId.INFILTRATOR);
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+    game.move.use(MoveId.GROWL);
+    await game.move.forceEnemyMove(MoveId.MIST);
+    await game.toEndOfTurn();
+
+    expect(game.field.getEnemyPokemon()).toHaveStatStage(Stat.ATK, -1);
+  });
 });


### PR DESCRIPTION
## What are the changes the user will see?
- Mist will display the correct message when blocking a stat stage decrease.
- Infiltrator will correctly ignore the effects of Mist.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Fixes discord bug report: https://discord.com/channels/1125469663833370665/1477230513268850768

## What are the changes from a developer perspective?
Added parameters to tag apply function to track the pokemon being protected by Mist.

Added tests

## Screenshots/Videos

## How to test the changes?
`pnpm test mist.test.ts`

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
