### PR TITLE
misc: Remove no longer used Consent Pref menu option

### DIFF
--- a/src/ui/handlers/menu-ui-handler.ts
+++ b/src/ui/handlers/menu-ui-handler.ts
@@ -324,21 +324,6 @@ export class MenuUiHandler extends MessageUiHandler {
         },
         keepOpen: true,
       },
-      {
-        label: i18next.t("menuUiHandler:consentPreferences"),
-        handler: () => {
-          const consentLink = document.querySelector(".termly-display-preferences") as HTMLInputElement;
-          const clickEvent = new MouseEvent("click", {
-            view: window,
-            bubbles: true,
-            cancelable: true,
-          });
-          consentLink.dispatchEvent(clickEvent);
-          consentLink.focus();
-          return true;
-        },
-        keepOpen: true,
-      },
     );
     if (isBeta || isDev) {
       manageDataOptions.push({


### PR DESCRIPTION
## What are the changes the user will see?
Remove unused "Consent Preferences" menu item inside Manage Data
<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Cleanup. This menu item does nothing. The consent prefs were originally removed in #3989

## What are the changes from a developer perspective?
None

## Screenshots/Videos
N/A

## How to test the changes?
Observe the menu item no longer shows

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] ~I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary~
- [ ] ~I have provided screenshots/videos of the changes (if applicable)~
  - [ ] ~I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)~

Are there any localization additions or changes? If so:
- [ ] ~I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - ~If so, include a link to the PR here: _____~
- [ ] ~I have contacted the Translation Team on Discord for proofreading/translation~

Does this require any additions or changes to in-game assets? If so:
- [ ] ~I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository~
  - ~If so, include a link to the PR here: _____~
