### PR TITLE
dev: adjust ls-lint to allow `.local` dirs

### DIFF
--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -11,7 +11,7 @@ _cfg: &cfg
    .js: kebab-case
    .*.ts: kebab-case
    .*.js: kebab-case
-   .dir: kebab-case
+   .dir: kebab-case | regex:.+\.local
    .py: snake_case # python files should always use snake_case
 
 ls:


### PR DESCRIPTION
## What are the changes the user will see?

N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

no need to prevent commiting when there is a `*.local` dir that is ignored by git

## What are the changes from a developer perspective?

adjusted ls lint to allow dirs ending in `.local` IF they are not in `src/`

## Screenshots/Videos
<!--
If you are changing anything visual (UI/UX, locales changes, etc.), please include screenshot(s) and/or video(s) showing the changes within collapsible blocks, like below:

<details><summary>Before</summary>

[before screenshot here]

</details>
<details><summary>After</summary>

[after screenshot here]

</details>
-->

## How to test the changes?

make a dir ending in `.local` outside of `src/`

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary