### PR TITLE
fix(ability): Dazzling won't stop enemies from targeting their ally

### DIFF
--- a/src/data/abilities/ab-attrs.ts
+++ b/src/data/abilities/ab-attrs.ts
@@ -558,12 +558,13 @@ export interface FieldPriorityMoveImmunityAbAttrParams extends AugmentMoveIntera
 }
 
 export class FieldPriorityMoveImmunityAbAttr extends PreDefendAbAttr {
-  override canApply({ move, opponent: attacker, cancelled }: FieldPriorityMoveImmunityAbAttrParams): boolean {
+  override canApply({ move, opponent: attacker, cancelled, pokemon }: FieldPriorityMoveImmunityAbAttrParams): boolean {
     return (
       !cancelled.value
-      && !(move.moveTarget === MoveTarget.USER || move.moveTarget === MoveTarget.NEAR_ALLY)
       && move.getPriority(attacker) > 0
+      && !move.isAllyTarget()
       && !move.isMultiTarget()
+      && attacker.isOpponent(pokemon)
     );
   }
 

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -35,6 +35,7 @@ import { applyChallenges } from "#utils/challenge-utils";
 import { BooleanHolder, NumberHolder } from "#utils/common";
 import { enumValueToKey } from "#utils/enums";
 import { inSpeedOrder } from "#utils/speed-order-generator";
+import { ValueHolder } from "#utils/value-holder";
 import i18next from "i18next";
 
 export class MovePhase extends PokemonPhase {
@@ -852,30 +853,22 @@ export class MovePhase extends PokemonPhase {
    * The rest of the failure conditions are marked as sequence 4 and *should* happen in the move effect phase (though happen here for now)
    */
   protected thirdFailureCheck(): boolean {
-    /**
-     * Move conditions assume the move has a single target
-     * TODO: is this sustainable?
-     */
     const move = this.move.getMove();
     const targets = this.getActiveTargetPokemon();
     const arena = globalScene.arena;
     const user = this.pokemon;
 
+    // Note: Move conditions currently assume the move has a single target
+    // TODO: should this be changed?
     const failsConditions = !move.applyConditions(user, targets[0], 3);
     const failedDueToTerrain = arena.isMoveTerrainCancelled(user, this.targets, move);
     let failed = failsConditions || failedDueToTerrain;
 
-    // Apply queenly majesty / dazzling
-    if (!failed) {
+    if (!failed && user.isOpponent(targets[0])) {
       const defendingSidePlayField = user.isPlayer() ? globalScene.getEnemyField() : globalScene.getPlayerField();
-      const cancelled = new BooleanHolder(false);
+      const cancelled = new ValueHolder(false);
       defendingSidePlayField.forEach((pokemon: Pokemon) => {
-        applyAbAttrs("FieldPriorityMoveImmunityAbAttr", {
-          pokemon,
-          opponent: user,
-          move,
-          cancelled,
-        });
+        applyAbAttrs("FieldPriorityMoveImmunityAbAttr", { pokemon, opponent: user, move, cancelled });
       });
       failed = cancelled.value;
     }

--- a/test/tests/abilities/priority-prevention.test.ts
+++ b/test/tests/abilities/priority-prevention.test.ts
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: 2024-2026 Pagefault Games
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { AbilityId } from "#enums/ability-id";
+import { BattlerIndex } from "#enums/battler-index";
+import { MoveId } from "#enums/move-id";
+import { MoveResult } from "#enums/move-result";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/framework/game-manager";
+import Phaser from "phaser";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe.each([
+  { abilityId: AbilityId.DAZZLING, abilityName: "Dazzling" },
+  { abilityId: AbilityId.QUEENLY_MAJESTY, abilityName: "Queenly Majesty" },
+])("Ability - $abilityName", ({ abilityId }) => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleStyle("single")
+      .criticalHits(false)
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(abilityId)
+      .enemyMoveset(MoveId.SPLASH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should block enemy single-target increased priority moves", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    game.move.use(MoveId.QUICK_ATTACK);
+    await game.toEndOfTurn();
+
+    expect(game.field.getPlayerPokemon()).toHaveUsedMove({ move: MoveId.QUICK_ATTACK, result: MoveResult.FAIL });
+  });
+
+  describe("Doubles Interactions", () => {
+    beforeEach(() => {
+      game.override.battleStyle("double");
+    });
+
+    it("should block enemy single-target increased priority moves from affecting allies", async () => {
+      game.override.enemyAbility(AbilityId.BALL_FETCH);
+      await game.classicMode.startBattle(SpeciesId.FEEBAS, SpeciesId.MILOTIC);
+
+      game.field.mockAbility(game.field.getEnemyPokemon(), abilityId);
+
+      game.move.use(MoveId.SPLASH);
+      game.move.use(MoveId.QUICK_ATTACK, 1, BattlerIndex.ENEMY_2);
+      await game.toEndOfTurn();
+
+      expect(game.scene.getPlayerField()[1]).toHaveUsedMove({ move: MoveId.QUICK_ATTACK, result: MoveResult.FAIL });
+      expect(game.scene.getEnemyField()[1].hasAbility(AbilityId.BALL_FETCH)).toBeTruthy();
+    });
+
+    it("should not block allied single-target increased priority moves", async () => {
+      await game.classicMode.startBattle(SpeciesId.FEEBAS, SpeciesId.MILOTIC);
+
+      game.move.use(MoveId.SPLASH);
+      game.move.use(MoveId.SPLASH, 1);
+      await game.move.forceEnemyMove(MoveId.QUICK_ATTACK, BattlerIndex.ENEMY_2);
+      await game.toEndOfTurn();
+
+      expect(game.field.getEnemyPokemon()).toHaveUsedMove({ move: MoveId.QUICK_ATTACK, result: MoveResult.SUCCESS });
+    });
+
+    it("should not block enemy single-target increased priority moves if the enemy targeted the other enemy", async () => {
+      await game.classicMode.startBattle(SpeciesId.FEEBAS, SpeciesId.MILOTIC);
+
+      game.move.use(MoveId.SPLASH);
+      game.move.use(MoveId.QUICK_ATTACK, 1, BattlerIndex.PLAYER);
+      await game.toEndOfTurn();
+
+      expect(game.scene.getPlayerField()[1]).toHaveUsedMove({ move: MoveId.QUICK_ATTACK, result: MoveResult.SUCCESS });
+    });
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?
If an opposing Pokémon has Dazzling or Queenly Majesty, the user will no longer be prevented from targeting their ally.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Bug report.

## What are the changes from a developer perspective?
Added a check for the user being allied to the target in the move failure check that determines whether to apply Dazzling/Queenly Majesty.

## How to test the changes?
`pnpm test:silent priority-prevention`

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary