### PR TITLE
fix(encounter): HA chance for MEs will be calculated correctly

### DIFF
--- a/src/data/balance/rates.ts
+++ b/src/data/balance/rates.ts
@@ -5,12 +5,14 @@
  */
 
 // #region Encounterable properties
+
 /** `64/65536 -> 1/1024` */
 export const BASE_SHINY_CHANCE = 64;
 
-/** `256/65536 -> 1/256` */
-export const BASE_HIDDEN_ABILITY_CHANCE = 256;
+/** `1 / 256` */
+export const BASE_HIDDEN_ABILITY_RATE = 256;
 
+// #endregion
 // #region Egg properties
 
 // Threshold x at which a gacha egg is determined to be a certain tier
@@ -47,7 +49,9 @@ export const GACHA_EGG_HA_RATE = 192;
 export const RARE_EGGMOVE_RATES: readonly number[] = [48, 24, 12, 6];
 export const BOOSTED_RARE_EGGMOVE_RATES: readonly number[] = [16, 12, 6, 3];
 
+// #endregion
 // #region Variant properties
+
 // The chance x/10 of a shiny being a variant, then of being specifically an epic variant
 export const SHINY_VARIANT_CHANCE = 4;
 export const SHINY_EPIC_CHANCE = 1;

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -2,7 +2,7 @@ import type { Battle } from "#app/battle";
 import { timedEventManager } from "#app/global-event-manager";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import { BASE_HIDDEN_ABILITY_CHANCE, BASE_SHINY_CHANCE } from "#balance/rates";
+import { BASE_HIDDEN_ABILITY_RATE, BASE_SHINY_CHANCE } from "#balance/rates";
 import { initMoveAnim, loadMoveAnimAssets } from "#data/battle-anims";
 import { modifierTypes } from "#data/data-lists";
 import type { IEggOptions } from "#data/egg";
@@ -998,7 +998,7 @@ export function getRandomEncounterPokemon(params: RandomEncounterParams): EnemyP
     shinyRerolls = 0,
     eventHiddenRerolls = 0,
     eventShinyRerolls = 0,
-    hiddenAbilityChance = BASE_HIDDEN_ABILITY_CHANCE,
+    hiddenAbilityChance = BASE_HIDDEN_ABILITY_RATE,
     shinyChance = BASE_SHINY_CHANCE,
     maxShinyChance = 0,
     speciesFilter = () => true,
@@ -1052,8 +1052,8 @@ export function getRandomEncounterPokemon(params: RandomEncounterParams): EnemyP
     shinyRerolls--;
   }
 
-  while (hiddenRerolls > 0) {
-    ret.tryRerollHiddenAbilitySeed(hiddenAbilityChance, true);
+  while (hiddenRerolls > 0 && ret.abilityIndex !== 2) {
+    ret.tryRerollHiddenAbilitySeed(hiddenAbilityChance);
     hiddenRerolls--;
   }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -636,7 +636,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /** Generate `abilityIndex` based on species and hidden ability if not pre-defined. */
   private generateAbilityIndex(): number {
-    const hiddenAbilityChance = new NumberHolder(BASE_HIDDEN_ABILITY_RATE);
+    const hiddenAbilityChance = new ValueHolder(BASE_HIDDEN_ABILITY_RATE);
     // Ability Charms should only affect wild Pokemon
     // TODO: move this `if` check into the ability charm code
     if (!this.hasTrainer()) {
@@ -3148,7 +3148,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @param forStarter - Whether this fusion is being generated for a starter Pokémon; default `false`
    */
   public generateFusionSpecies(forStarter?: boolean): void {
-    const hiddenAbilityChance = new NumberHolder(BASE_HIDDEN_ABILITY_RATE);
+    const hiddenAbilityChance = new ValueHolder(BASE_HIDDEN_ABILITY_RATE);
     if (!this.hasTrainer()) {
       globalScene.applyModifiers(HiddenAbilityRateBoosterModifier, true, hiddenAbilityChance);
     }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -18,7 +18,7 @@ import {
   pokemonPrevolutions,
   validateShedinjaEvo,
 } from "#balance/pokemon-evolutions";
-import { BASE_HIDDEN_ABILITY_CHANCE, BASE_SHINY_CHANCE, SHINY_EPIC_CHANCE, SHINY_VARIANT_CHANCE } from "#balance/rates";
+import { BASE_HIDDEN_ABILITY_RATE, BASE_SHINY_CHANCE, SHINY_EPIC_CHANCE, SHINY_VARIANT_CHANCE } from "#balance/rates";
 import {
   getStarterValueFriendshipCap,
   speciesStarterCosts,
@@ -187,6 +187,7 @@ import { getEnumValues } from "#utils/enums";
 import { cachedFetch } from "#utils/fetch-utils";
 import { getFusedSpeciesName, getPokemonSpecies, getPokemonSpeciesForm } from "#utils/pokemon-utils";
 import { inSpeedOrder } from "#utils/speed-order-generator";
+import { ValueHolder } from "#utils/value-holder";
 import { argbFromRgba, QuantizerCelebi, rgbaFromArgb } from "@material/material-color-utilities";
 import i18next from "i18next";
 import Phaser from "phaser";
@@ -635,7 +636,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /** Generate `abilityIndex` based on species and hidden ability if not pre-defined. */
   private generateAbilityIndex(): number {
-    const hiddenAbilityChance = new NumberHolder(BASE_HIDDEN_ABILITY_CHANCE);
+    const hiddenAbilityChance = new NumberHolder(BASE_HIDDEN_ABILITY_RATE);
     // Ability Charms should only affect wild Pokemon
     // TODO: move this `if` check into the ability charm code
     if (!this.hasTrainer()) {
@@ -3126,30 +3127,20 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Function that tries to set this Pokemon to have its hidden ability based on seed, if it exists.
-   *
-   * @remarks
-   * For manual use only, usually to roll a Pokemon's hidden ability chance a second time.
-   *
-   * The base hidden ability odds are {@linkcode BASE_HIDDEN_ABILITY_CHANCE} / `65536`
-   * @param thresholdOverride - number that is divided by `2^16` (`65536`) to get the HA chance, overrides {@linkcode haThreshold} if set (bypassing HA rate modifiers such as Ability Charm)
-   * @param applyModifiersToOverride - If {@linkcode thresholdOverride} is set and this is true, will apply Ability Charm to {@linkcode thresholdOverride}
-   * @returns `true` if the Pokemon has been set to have its hidden ability, `false` otherwise
+   * Used by Mystery Encounters to override a Pokemon's ability to be its hidden ability
+   * @param haThreshold - The denominator for the HA chance (`1 / haThreshold`)
    */
-  public tryRerollHiddenAbilitySeed(thresholdOverride?: number, applyModifiersToOverride?: boolean): boolean {
+  public tryRerollHiddenAbilitySeed(haThreshold: number): void {
     if (!this.species.abilityHidden) {
-      return false;
-    }
-    const haThreshold = new NumberHolder(thresholdOverride ?? BASE_HIDDEN_ABILITY_CHANCE);
-    if (applyModifiersToOverride && !this.hasTrainer()) {
-      globalScene.applyModifiers(HiddenAbilityRateBoosterModifier, true, haThreshold);
+      return;
     }
 
-    if (randSeedInt(65536) < haThreshold.value) {
+    const hiddenAbilityChance = new ValueHolder(haThreshold);
+    globalScene.applyModifiers(HiddenAbilityRateBoosterModifier, true, hiddenAbilityChance);
+
+    if (!randSeedInt(hiddenAbilityChance.value)) {
       this.abilityIndex = 2;
     }
-
-    return this.abilityIndex === 2;
   }
 
   /**
@@ -3157,7 +3148,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @param forStarter - Whether this fusion is being generated for a starter Pokémon; default `false`
    */
   public generateFusionSpecies(forStarter?: boolean): void {
-    const hiddenAbilityChance = new NumberHolder(BASE_HIDDEN_ABILITY_CHANCE);
+    const hiddenAbilityChance = new NumberHolder(BASE_HIDDEN_ABILITY_RATE);
     if (!this.hasTrainer()) {
       globalScene.applyModifiers(HiddenAbilityRateBoosterModifier, true, hiddenAbilityChance);
     }


### PR DESCRIPTION
## What are the changes the user will see?
Ability Charms will now increase the chance of ME Pokémon having their HA instead of decreasing it, as intended.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Fixes #7219 

## What are the changes from a developer perspective?
Reworked `Pokemon#tryRerollHiddenAbilitySeed` to work the same as `Pokemon#generateAbilityIndex` wrt calculating HA chance.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR