### PR TITLE
fix(ui): resolve candy bar count desync

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -6085,6 +6085,9 @@ export class PlayerPokemon extends Pokemon {
           sd.friendship = friendshipCap - 1;
         }
       }
+      if (Overrides.IMMEDIATE_ADD_CANDY_OVERRIDE > 0) {
+        gameData.addStarterCandy(id, Overrides.IMMEDIATE_ADD_CANDY_OVERRIDE);
+      }
     });
   }
 

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -114,6 +114,8 @@ class DefaultOverrides {
   readonly TIME_OF_DAY_OVERRIDE: Exclude<TimeOfDay, TimeOfDay.ALL> | null = null;
   /** Multiplies XP gained by this value including 0. Set to null to ignore the override. */
   readonly XP_MULTIPLIER_OVERRIDE: number | null = null;
+  /** If greater than `0`, adds candies on every instance of friendship gain. */
+  readonly IMMEDIATE_ADD_CANDY_OVERRIDE: number = 0;
   /**
    * Sets the level cap to this number during experience gain calculations.
    *

--- a/src/phases/egg-hatch-phase.ts
+++ b/src/phases/egg-hatch-phase.ts
@@ -76,6 +76,9 @@ export class EggHatchPhase extends Phase {
   start() {
     super.start();
 
+    // Hide previous candy bar if it exists
+    globalScene.candyBar.hide();
+
     globalScene.ui.setModeForceTransition(UiMode.EGG_HATCH_SCENE).then(() => {
       if (!this.egg) {
         return this.end();
@@ -380,25 +383,46 @@ export class EggHatchPhase extends Phase {
 
         globalScene.playSoundWithoutBgm("evolution_fanfare");
 
+        const hatchText = i18next.t("egg:hatchFromTheEgg", {
+          pokemonName: this.pokemon.species.getExpandedSpeciesName(),
+        });
+
+        // For new starter catches, `setPokemonCaught` queues its own "added as a starter" message,
+        // so defer it until after the hatch text is dismissed to avoid interrupting it mid-display
+        const rootSpeciesId = this.pokemon.species.getRootSpeciesId();
+        const isNewStarterCatch = !globalScene.gameData.dexData[rootSpeciesId].caughtAttr;
+
+        const finishHatch = () => {
+          globalScene.gameData.setEggMoveUnlocked(this.pokemon.species, this.eggMoveIndex).then(value => {
+            this.eggHatchData.setEggMoveUnlocked(value);
+            globalScene.ui.showText("", 0);
+            this.end();
+          });
+        };
+
         globalScene.ui.showText(
-          i18next.t("egg:hatchFromTheEgg", {
-            pokemonName: this.pokemon.species.getExpandedSpeciesName(),
-          }),
+          hatchText,
           null,
           () => {
-            globalScene.gameData.updateSpeciesDexIvs(this.pokemon.species.speciesId, this.pokemon.ivs);
-            globalScene.gameData.setPokemonCaught(this.pokemon, true, true).then(() => {
-              globalScene.gameData.setEggMoveUnlocked(this.pokemon.species, this.eggMoveIndex).then(value => {
-                this.eggHatchData.setEggMoveUnlocked(value);
-                globalScene.ui.showText("", 0);
-                this.end();
-              });
-            });
+            if (isNewStarterCatch) {
+              globalScene.gameData.updateSpeciesDexIvs(this.pokemon.species.speciesId, this.pokemon.ivs);
+              globalScene.gameData.setPokemonCaught(this.pokemon, true, true).then(finishHatch);
+            } else {
+              finishHatch();
+            }
           },
           null,
           true,
           3000,
         );
+
+        if (!isNewStarterCatch) {
+          const printDuration = (hatchText.length + 1) * 20;
+          globalScene.time.delayedCall(printDuration, () => {
+            globalScene.gameData.updateSpeciesDexIvs(this.pokemon.species.speciesId, this.pokemon.ivs);
+            globalScene.gameData.setPokemonCaught(this.pokemon, true, true);
+          });
+        }
       });
     });
     globalScene.tweens.add({

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1779,17 +1779,19 @@ export class GameData {
    * Adds candy to the player's game data for a given {@linkcode PokemonSpecies}.
    * @remarks
    * Will not increase the candy count past {@linkcode MAX_STARTER_CANDY_COUNT}.
+   * @param speciesId - The species ID of the Pokémon to increment candy for
+   * @param numCandiesToAdd - The number of candies to add to the Pokémon
    * @returns Whether the candy count was incremented
    */
-  public addStarterCandy(speciesId: SpeciesId, count: number): boolean {
+  public addStarterCandy(speciesId: SpeciesId, numCandiesToAdd: number): boolean {
     const { candyCount } = this.starterData[speciesId];
 
     if (candyCount >= MAX_STARTER_CANDY_COUNT) {
       return false;
     }
 
-    globalScene.candyBar.showStarterSpeciesCandy(speciesId, count);
-    this.starterData[speciesId].candyCount = Math.min(candyCount + count, MAX_STARTER_CANDY_COUNT);
+    this.starterData[speciesId].candyCount = Math.min(candyCount + numCandiesToAdd, MAX_STARTER_CANDY_COUNT);
+    globalScene.candyBar.showStarterSpeciesCandy(speciesId, numCandiesToAdd);
 
     return true;
   }

--- a/src/ui/containers/candy-bar.ts
+++ b/src/ui/containers/candy-bar.ts
@@ -14,6 +14,9 @@ export class CandyBar extends Phaser.GameObjects.Container {
 
   private tween: Phaser.Tweens.Tween | null;
   private autoHideTimer: NodeJS.Timeout | null;
+  private isHiding: boolean;
+  private pendingCandyAdditions: { speciesId: SpeciesId; numCandiesAdded: number }[];
+  private cumulativeCandiesAdded: number;
 
   public shown: boolean;
 
@@ -42,65 +45,95 @@ export class CandyBar extends Phaser.GameObjects.Container {
     this.add([this.bg, this.candyIcon, this.candyOverlayIcon, this.countText]) //
       .setVisible(false);
     this.shown = false;
-
+    this.isHiding = false;
+    this.pendingCandyAdditions = [];
+    this.cumulativeCandiesAdded = 0;
     return this;
   }
 
-  showStarterSpeciesCandy(starterSpeciesId: SpeciesId, count: number): Promise<void> {
-    return new Promise<void>(resolve => {
-      if (this.shown) {
-        if (this.speciesId === starterSpeciesId) {
-          return resolve();
-        }
-        return this.hide()
-          .then(() => this.showStarterSpeciesCandy(starterSpeciesId, count))
-          .then(() => resolve());
+  /**
+   * Slide in the candy bar to display the candy count for the given starter species.
+   * @remarks
+   * - If the bar is already showing for the same species, the count is updated in place.
+   * - If the bar is showing for a different species, the request is queued.
+   * @param starterSpeciesId - The {@linkcode SpeciesId} of the starter to display
+   * @param numCandiesAdded - The number of candies just to the starter1
+   */
+  showStarterSpeciesCandy(starterSpeciesId: SpeciesId, numCandiesAdded: number): void {
+    if (this.shown) {
+      if (!this.isHiding && this.speciesId === starterSpeciesId) {
+        this.cumulativeCandiesAdded += numCandiesAdded;
+        this.countText.setText(
+          `${globalScene.gameData.starterData[starterSpeciesId].candyCount} (+${this.cumulativeCandiesAdded.toString()})`,
+        );
+        this.bg.width = this.countText.displayWidth + 28;
+        this.resetAutoHideTimer();
+        return;
       }
 
-      const colorScheme = starterColors[starterSpeciesId];
-
-      this.candyIcon.setTint(argbFromRgba(rgbHexToRgba(colorScheme[0])));
-      this.candyOverlayIcon.setTint(argbFromRgba(rgbHexToRgba(colorScheme[1])));
-
-      this.countText.setText(
-        `${globalScene.gameData.starterData[starterSpeciesId].candyCount + count} (+${count.toString()})`,
-      );
-
-      this.bg.width = this.countText.displayWidth + 28;
-
-      globalScene.fieldUI.bringToTop(this);
-
-      if (this.tween) {
-        this.tween.stop();
-      }
-
-      globalScene.playSound("se/shing");
-
-      this.tween = globalScene.tweens.add({
-        targets: this,
-        x: globalScene.scaledCanvas.width - (this.bg.width - 5),
-        duration: 500,
-        ease: "Sine.easeOut",
-        onComplete: () => {
-          this.tween = null;
-          this.resetAutoHideTimer();
-          resolve();
-        },
-      });
-
-      this.setVisible(true);
-      this.shown = true;
-    });
-  }
-
-  hide(): Promise<void> {
-    return new Promise<void>(resolve => {
-      if (!this.shown) {
-        return resolve();
+      const speciesAlreadyPending = this.pendingCandyAdditions.find(p => p.speciesId === starterSpeciesId);
+      if (speciesAlreadyPending) {
+        speciesAlreadyPending.numCandiesAdded += numCandiesAdded;
+      } else {
+        this.pendingCandyAdditions.push({ speciesId: starterSpeciesId, numCandiesAdded });
       }
 
       if (this.autoHideTimer) {
+        this.resetAutoHideTimer();
+      }
+      return;
+    }
+
+    const colorScheme = starterColors[starterSpeciesId];
+
+    this.candyIcon.setTint(argbFromRgba(rgbHexToRgba(colorScheme[0])));
+    this.candyOverlayIcon.setTint(argbFromRgba(rgbHexToRgba(colorScheme[1])));
+
+    this.cumulativeCandiesAdded = numCandiesAdded;
+    this.countText.setText(
+      `${globalScene.gameData.starterData[starterSpeciesId].candyCount} (+${this.cumulativeCandiesAdded.toString()})`,
+    );
+
+    this.bg.width = this.countText.displayWidth + 28;
+
+    globalScene.fieldUI.bringToTop(this);
+
+    if (this.tween) {
+      this.tween.stop();
+    }
+
+    globalScene.playSound("se/shing");
+
+    this.tween = globalScene.tweens.add({
+      targets: this,
+      x: globalScene.scaledCanvas.width - (this.bg.width - 5),
+      duration: 500,
+      ease: "Sine.easeOut",
+      onComplete: () => {
+        this.tween = null;
+        this.resetAutoHideTimer();
+      },
+    });
+
+    this.setVisible(true);
+    this.shown = true;
+    this.speciesId = starterSpeciesId;
+  }
+
+  /**
+   * Slide the candy bar off-screen. Resolves once the hide tween has finished and queues the next candy bar if pending.
+   */
+  hide(): Promise<void> {
+    return new Promise<void>(resolve => {
+      if (!this.shown || this.isHiding) {
+        return resolve();
+      }
+
+      this.isHiding = true;
+
+      if (this.autoHideTimer) {
         clearInterval(this.autoHideTimer);
+        this.autoHideTimer = null;
       }
 
       if (this.tween) {
@@ -115,20 +148,31 @@ export class CandyBar extends Phaser.GameObjects.Container {
         onComplete: () => {
           this.tween = null;
           this.shown = false;
+          this.isHiding = false;
           this.setVisible(false);
           resolve();
+          const nextCandyAddition = this.pendingCandyAdditions.shift();
+          if (nextCandyAddition) {
+            this.showStarterSpeciesCandy(nextCandyAddition.speciesId, nextCandyAddition.numCandiesAdded);
+          }
         },
       });
     });
   }
 
+  /**
+   * (Re)schedule the auto-hide that fires after the bar has been visible.
+   * @remarks
+   * The wait is compressed to 500ms while {@linkcode pendingCandyAdditions} is not empty.
+   */
   resetAutoHideTimer(): void {
     if (this.autoHideTimer) {
       clearInterval(this.autoHideTimer);
     }
+    const delay = this.pendingCandyAdditions.length > 0 ? 500 : 2500;
     this.autoHideTimer = setTimeout(() => {
       this.hide();
       this.autoHideTimer = null;
-    }, 2500);
+    }, delay);
   }
 }


### PR DESCRIPTION
## What are the changes the user will see?

The candy count popup during egg hatching and battles will now be synced to the correct value.



## Why am I making these changes?

Fixes #3334

During batch hatching, the candy bar popup could display an incorrect total because `showStarterSpeciesCandy` was called with the candy count to add before `starterData[].candyCount` was incremented in `addStarterCandy`, but `candyCount` could increment before the bar was shown causing the candy gain to be double counted. Additionally, rapid candy additions for different species would race each other. The old code would `hide()` then re-show via chained promises, causing the bar to read stale counts or double-count candies.

## What are the changes from a developer perspective?

 **`game-data.ts`**
* In `addStarterCandy`, the candy count is now updated _before_ calling `showStarterSpeciesCandy`, so the bar reads the already-correct value. Renamed `count` param to `numCandiesToAdd` for clarity.

 **`candy-bar.ts`** 
* `showStarterSpeciesCandy` promise was never used, so refactored from a promise-chaining show/hide model to a queue-based system
  - `showStarterSpeciesCandy` is now `void` instead of `Promise`. If the bar is already visible for the same species, the count updates in place with a cumulative `(+N)`. If visible for a different species, the request is queued in `pendingCandyAdditions`.
  - `hide()` dequeues and displays the next pending entry on tween completion, with a shortened 500ms auto-hide delay when the queue is non-empty.
  - Added `isHiding` guard to prevent concurrent hide tweens from racing.
  
**`egg-hatch-phase.ts`**
* Hides any existing candy bar at phase start.
* For already-caught starters, `setPokemonCaught` is now fired via a delayed call during the hatch text print rather than on its callback
  - This makes it so the current pokemon candy bar flyout shows on its ownegg hatch screen, instead of appearing on the next screen
  - Prevented the "added as a starter" message from interrupting the hatch text.

**`overrides.ts` / `pokemon.ts`**
* Added `IMMEDIATE_ADD_CANDY_OVERRIDE` dev override for testing candy bar behavior on friendship gains.

## Screenshots/Videos

### Candy gain from battle

<details><summary>Before</summary>

https://github.com/user-attachments/assets/579d3393-7061-483e-9c91-5aa33286865c

</details>
<details><summary>After</summary>

https://github.com/user-attachments/assets/3515bc4f-8531-49f1-af5e-4c5a71dfc692

</details>

### Candy gain from egg hatch

<details><summary>Before</summary>

https://github.com/user-attachments/assets/d81fc86d-54dc-4b31-95d9-5cfd980397cf

</details>
<details><summary>After</summary>

https://github.com/user-attachments/assets/23f2d1c2-499a-405e-9906-cc9bf39a9d18

</details>

## How to test the changes?

- Hatch 10+ eggs in bulk containing duplicates of the same species. Verify the candy bar count matches the starter select screen after hatching.
- Hatch eggs for a species not yet caught. Confirm the "added as a starter" message displays correctly after the hatch text.
- Set `IMMEDIATE_ADD_CANDY_OVERRIDE` to a value > 0 in `src/overrides.ts` and trigger friendship gains to observe the candy bar queuing behavior.

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [~] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [x] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

~Are there any localization additions or changes?~

~Does this require any additions or changes to in-game assets?~