### PR TITLE
fix(beta): Moves with post-target effects no longer softlock with no valid targets

### DIFF
--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -8,7 +8,7 @@ import { DamageProtectedTag, ProtectedTag, SemiInvulnerableTag, SubstituteTag, T
 import { SpeciesFormChangePostMoveTrigger } from "#data/form-change-triggers";
 import type { TypeDamageMultiplier } from "#data/type";
 import { ArenaTagSide } from "#enums/arena-tag-side";
-import { BattlerIndex } from "#enums/battler-index";
+import type { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { HitCheckResult } from "#enums/hit-check-result";
@@ -177,14 +177,15 @@ export class MoveEffectPhase extends PokemonPhase {
       this.moveHistoryEntry.result === MoveResult.SUCCESS
       || move.getAttrs("MoveEffectAttr").some(attr => attr.trigger === MoveEffectTrigger.POST_TARGET)
     ) {
-      const targetsForAnimation = this.getTargets();
+      const moveTargets = this.getTargets();
+      const targetsForAnimation = moveTargets.length > 0 ? moveTargets : [user];
       let animationsLeft = targetsForAnimation.length;
 
       for (const target of targetsForAnimation) {
         new MoveAnim(
           move.id as MoveId,
           user,
-          target?.getBattlerIndex() ?? BattlerIndex.ATTACKER,
+          target.getBattlerIndex(),
           // Some moves used in mystery encounters should be played even on an empty field
           globalScene.currentBattle?.mysteryEncounter?.hasBattleAnimationsWithoutTargets ?? false,
         ).play(move.hitsSubstitute(user, target), () => {

--- a/test/tests/moves/post-apply-effect.test.ts
+++ b/test/tests/moves/post-apply-effect.test.ts
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: 2024-2026 Pagefault Games
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/framework/game-manager";
+import Phaser from "phaser";
+import { beforeAll, beforeEach, describe, it } from "vitest";
+
+describe("Move - Post Apply Effect", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleStyle("single")
+      .criticalHits(false)
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset(MoveId.EXPLOSION)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should not softlock when failing", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    game.move.use(MoveId.PROTECT);
+    await game.move.forceEnemyMove(MoveId.EXPLOSION);
+    await game.toEndOfTurn();
+    // If we get here, there was no softlock
+  });
+});

--- a/test/tests/moves/post-apply-effect.test.ts
+++ b/test/tests/moves/post-apply-effect.test.ts
@@ -40,6 +40,8 @@ describe("Move - Post Apply Effect", () => {
     game.move.use(MoveId.PROTECT);
     await game.move.forceEnemyMove(MoveId.EXPLOSION);
     await game.toEndOfTurn();
+
     // If we get here, there was no softlock
+    expect(game.field.getPlayerPokemon()).toHaveFullHp();
   });
 });

--- a/test/tests/moves/post-apply-effect.test.ts
+++ b/test/tests/moves/post-apply-effect.test.ts
@@ -9,7 +9,7 @@ import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/framework/game-manager";
 import Phaser from "phaser";
-import { beforeAll, beforeEach, describe, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Move - Post Apply Effect", () => {
   let phaserGame: Phaser.Game;


### PR DESCRIPTION
<!--
Thank you for contributing to PokéRogue!
Open-source contributions like yours help keep this project going.

Note that these comment blocks are purely informative and can be removed once you're done reading them.
-->

<!--
Make sure your title matches the https://www.conventionalcommits.org/en/v1.0.0/ format.
Try to keep the title under 72 characters, as GitHub cuts off commit titles longer than this length.

See https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request
for more information on the allowed scopes and prefixes.

Example:
fix(move): Future Sight no longer crashes
^   ^      ^
|   |      |__ Subject
|   |_________ Scope (optional)
|_____________ Prefix
-->

## What are the changes the user will see?
Moves like explosion, burn up, etc. (ones with a POST_TARGET effect) will no longer freeze the game when used with no valid targets i.e. into protect

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
https://discord.com/channels/1125469663833370665/1125894949020381285/1491239539736576040

## What are the changes from a developer perspective?
#7189 changed the move animation code to loop through targets instead of always using the first target, but didn't consider the case where no valid targets exist. There is an early return after the animation loop intended to avoid calling `postAnimCallback` multiple times, but this means that if the loop never iterated, the return will be hit without ever running the callback. That breaks the chain and `end()` -> `shiftPhase` is never called, so the game freezes.

It's fixed by simply using `user` as the animation target if none exists. I can't say for certain that this is correct in all cases, but it's equivalent to the previous logic of `target?.getBattlerIndex() ?? BattlerIndex.ATTACKER` (the code still looked like this before my edits, but all the optional chaining was useless as `target` can't be undefined in the for loop).

## How to test the changes?
```ts
const overrides = {
  ENEMY_MOVESET_OVERRIDE: MoveId.EXPLOSION,
  ENEMY_SPECIES_OVERRIDE: SpeciesId.PAWMOT,
  MOVESET_OVERRIDE: MoveId.PROTECT
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)
