### PR TITLE
feat(ui): Display new cost when upgrading starter

### DIFF
--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1996,21 +1996,30 @@ export class GameData {
     return ret;
   }
 
-  getSpeciesStarterValue(speciesId: SpeciesId): number {
+  /**
+   * Obtain the value of a particular starter by SpeciesID
+   * @param speciesId - The {@linkcode SpeciesId} of the starter
+   * @param valueReduction - The applied value reduction; defaults to the value stored in `this.starterData[speciesId].valueReduction`
+   * @returns The value/cost of the starter
+   * @privateRemarks
+   * `valueReduction` only needs to be provided when testing a value reduction other than the one currently unlocked
+   */
+  getSpeciesStarterValue(speciesId: SpeciesId, valueReduction?: number): number {
     // TODO: is this bang correct?
     const baseValue = speciesStarterCosts[speciesId]!;
+    const reduction = valueReduction ?? this.starterData[speciesId].valueReduction;
     let value = baseValue;
 
-    const decrementValue = (value: number) => {
-      if (value > 1) {
-        value--;
+    const decrementValue = (v: number) => {
+      if (v > 1) {
+        v--;
       } else {
-        value /= 2;
+        v /= 2;
       }
-      return value;
+      return v;
     };
 
-    for (let v = 0; v < this.starterData[speciesId].valueReduction; v++) {
+    for (let v = 0; v < reduction; v++) {
       value = decrementValue(value);
     }
 

--- a/src/ui/handlers/pokedex-page-ui-handler.ts
+++ b/src/ui/handlers/pokedex-page-ui-handler.ts
@@ -2030,7 +2030,7 @@ export class PokedexPageUiHandler extends MessageUiHandler {
             if (valueReduction < valueReductionMax) {
               const reductionCost = getValueReductionCandyCounts(speciesStarterCosts[this.starterId])[valueReduction];
               options.push({
-                label: `×${reductionCost} ${i18next.t("pokedexUiHandler:reduceCost")}`,
+                label: `×${reductionCost} ${i18next.t("starterSelectUiHandler:reduceCost", { newCost: globalScene.gameData.getSpeciesStarterValue(this.starterId, starterData.valueReduction + 1) })}`,
                 handler: () => {
                   if (!Overrides.FREE_CANDY_UPGRADE_OVERRIDE && candyCount < reductionCost) {
                     return false;

--- a/src/ui/handlers/starter-select-ui-handler.ts
+++ b/src/ui/handlers/starter-select-ui-handler.ts
@@ -2296,7 +2296,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
                 valueReduction
               ];
               options.push({
-                label: `×${reductionCost} ${i18next.t("starterSelectUiHandler:reduceCost")}`,
+                label: `×${reductionCost} ${i18next.t("starterSelectUiHandler:reduceCost", { newCost: globalScene.gameData.getSpeciesStarterValue(this.lastSpecies.speciesId, starterData.valueReduction + 1) })}`,
                 handler: () => {
                   if (Overrides.FREE_CANDY_UPGRADE_OVERRIDE || candyCount >= reductionCost) {
                     persistentStarterData.valueReduction++;


### PR DESCRIPTION
## What are the changes the user will see?
In ssui or the pokedex, the user will see "Reduce cost to x" instead of "Reduce cost"
<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
It's otherwise unintuitive that prices are halved instead of -1 when reduced below 1.

Requested here with positive feedback: https://discord.com/channels/1125469663833370665/1479541179916750981

## What are the changes from a developer perspective?
Added an optional parameter to the cost calculation function to manually specify the value reduction in cases like this where it does not match the actual unlocked reduction. Outside of that, just changing locales keys and using said function to pass the proper value

## Screenshots/Videos

<details><summary>After</summary>

<img width="3462" height="1944" alt="image" src="https://github.com/user-attachments/assets/9ac2038d-94cd-44d5-a39b-25a8a0c8d905" />


</details>

## How to test the changes?
Go into ssui or dex

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [x] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [x] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: https://github.com/pagefaultgames/pokerogue-locales/pull/304
  - [ ] I have contacted the Translation Team on Discord for proofreading/translation
