### PR TITLE
misc: clean up some ME functions to use `async`/`await`

### DIFF
--- a/src/data/mystery-encounters/encounters/bug-type-superfan-encounter.ts
+++ b/src/data/mystery-encounters/encounters/bug-type-superfan-encounter.ts
@@ -667,67 +667,61 @@ function getTrainerConfigForWave(waveIndex: number) {
   return config;
 }
 
-function doBugTypeMoveTutor(): Promise<void> {
-  // biome-ignore lint/suspicious/noAsyncPromiseExecutor: TODO explain
-  return new Promise<void>(async resolve => {
-    const moveOptions = globalScene.currentBattle.mysteryEncounter!.misc.moveTutorOptions;
-    await showEncounterDialogue(`${namespace}:battleWon`, `${namespace}:speaker`);
+async function doBugTypeMoveTutor(): Promise<void> {
+  const moveOptions = globalScene.currentBattle.mysteryEncounter!.misc.moveTutorOptions;
+  await showEncounterDialogue(`${namespace}:battleWon`, `${namespace}:speaker`);
 
-    const moveInfoOverlay = new MoveInfoOverlay({
-      delayVisibility: false,
-      onSide: true,
-      right: true,
-      x: 1,
-      y: -MoveInfoOverlay.getHeight(true) - 1,
-      width: globalScene.scaledCanvas.width - 2,
-    });
-    globalScene.ui.add(moveInfoOverlay);
-
-    const optionSelectItems = moveOptions.map((move: PokemonMove) => {
-      const option: OptionSelectItem = {
-        label: move.getName(),
-        handler: () => {
-          moveInfoOverlay.active = false;
-          moveInfoOverlay.setVisible(false);
-          return true;
-        },
-        onHover: () => {
-          moveInfoOverlay.active = true;
-          moveInfoOverlay.show(allMoves[move.moveId]);
-        },
-      };
-      return option;
-    });
-
-    const onHoverOverCancel = () => {
-      moveInfoOverlay.active = false;
-      moveInfoOverlay.setVisible(false);
-    };
-
-    const result = await selectOptionThenPokemon(
-      optionSelectItems,
-      `${namespace}:teachMovePrompt`,
-      undefined,
-      onHoverOverCancel,
-    );
-    // let forceExit = !!result;
-    if (!result) {
-      moveInfoOverlay.active = false;
-      moveInfoOverlay.setVisible(false);
-    }
-
-    // TODO: add menu to confirm player doesn't want to teach a move?
-
-    // Option select complete, handle if they are learning a move
-    if (result && result.selectedOptionIndex < moveOptions.length) {
-      globalScene.phaseManager.unshiftNew(
-        "LearnMovePhase",
-        result.selectedPokemonIndex,
-        moveOptions[result.selectedOptionIndex].moveId,
-      );
-    }
-
-    // Complete battle and go to rewards
-    resolve();
+  const moveInfoOverlay = new MoveInfoOverlay({
+    delayVisibility: false,
+    onSide: true,
+    right: true,
+    x: 1,
+    y: -MoveInfoOverlay.getHeight(true) - 1,
+    width: globalScene.scaledCanvas.width - 2,
   });
+  globalScene.ui.add(moveInfoOverlay);
+
+  const optionSelectItems = moveOptions.map((move: PokemonMove) => {
+    const option: OptionSelectItem = {
+      label: move.getName(),
+      handler: () => {
+        moveInfoOverlay.active = false;
+        moveInfoOverlay.setVisible(false);
+        return true;
+      },
+      onHover: () => {
+        moveInfoOverlay.active = true;
+        moveInfoOverlay.show(allMoves[move.moveId]);
+      },
+    };
+    return option;
+  });
+
+  const onHoverOverCancel = () => {
+    moveInfoOverlay.active = false;
+    moveInfoOverlay.setVisible(false);
+  };
+
+  const result = await selectOptionThenPokemon(
+    optionSelectItems,
+    `${namespace}:teachMovePrompt`,
+    undefined,
+    onHoverOverCancel,
+  );
+  // let forceExit = !!result;
+  if (!result) {
+    moveInfoOverlay.active = false;
+    moveInfoOverlay.setVisible(false);
+  }
+
+  // TODO: add menu to confirm player doesn't want to teach a move?
+
+  // Option select complete, handle if they are learning a move
+  if (result && result.selectedOptionIndex < moveOptions.length) {
+    globalScene.phaseManager.unshiftNew(
+      "LearnMovePhase",
+      result.selectedPokemonIndex,
+      moveOptions[result.selectedOptionIndex].moveId,
+    );
+  }
 }

--- a/src/data/mystery-encounters/encounters/bug-type-superfan-encounter.ts
+++ b/src/data/mystery-encounters/encounters/bug-type-superfan-encounter.ts
@@ -668,67 +668,61 @@ function getTrainerConfigForWave(waveIndex: number) {
   return config;
 }
 
-function doBugTypeMoveTutor(): Promise<void> {
-  // biome-ignore lint/suspicious/noAsyncPromiseExecutor: TODO explain
-  return new Promise<void>(async resolve => {
-    const moveOptions = globalScene.currentBattle.mysteryEncounter!.misc.moveTutorOptions;
-    await showEncounterDialogue(`${namespace}:battleWon`, `${namespace}:speaker`);
+async function doBugTypeMoveTutor(): Promise<void> {
+  const moveOptions = globalScene.currentBattle.mysteryEncounter!.misc.moveTutorOptions;
+  await showEncounterDialogue(`${namespace}:battleWon`, `${namespace}:speaker`);
 
-    const moveInfoOverlay = new MoveInfoOverlay({
-      delayVisibility: false,
-      onSide: true,
-      right: true,
-      x: 1,
-      y: -MoveInfoOverlay.getHeight(true) - 1,
-      width: globalScene.scaledCanvas.width - 2,
-    });
-    globalScene.ui.add(moveInfoOverlay);
-
-    const optionSelectItems = moveOptions.map((move: PokemonMove) => {
-      const option: OptionSelectItem = {
-        label: move.getName(),
-        handler: () => {
-          moveInfoOverlay.active = false;
-          moveInfoOverlay.setVisible(false);
-          return true;
-        },
-        onHover: () => {
-          moveInfoOverlay.active = true;
-          moveInfoOverlay.show(allMoves[move.moveId]);
-        },
-      };
-      return option;
-    });
-
-    const onHoverOverCancel = () => {
-      moveInfoOverlay.active = false;
-      moveInfoOverlay.setVisible(false);
-    };
-
-    const result = await selectOptionThenPokemon(
-      optionSelectItems,
-      `${namespace}:teachMovePrompt`,
-      undefined,
-      onHoverOverCancel,
-    );
-    // let forceExit = !!result;
-    if (!result) {
-      moveInfoOverlay.active = false;
-      moveInfoOverlay.setVisible(false);
-    }
-
-    // TODO: add menu to confirm player doesn't want to teach a move?
-
-    // Option select complete, handle if they are learning a move
-    if (result && result.selectedOptionIndex < moveOptions.length) {
-      globalScene.phaseManager.unshiftNew(
-        "LearnMovePhase",
-        result.selectedPokemonIndex,
-        moveOptions[result.selectedOptionIndex].moveId,
-      );
-    }
-
-    // Complete battle and go to rewards
-    resolve();
+  const moveInfoOverlay = new MoveInfoOverlay({
+    delayVisibility: false,
+    onSide: true,
+    right: true,
+    x: 1,
+    y: -MoveInfoOverlay.getHeight(true) - 1,
+    width: globalScene.scaledCanvas.width - 2,
   });
+  globalScene.ui.add(moveInfoOverlay);
+
+  const optionSelectItems = moveOptions.map((move: PokemonMove) => {
+    const option: OptionSelectItem = {
+      label: move.getName(),
+      handler: () => {
+        moveInfoOverlay.active = false;
+        moveInfoOverlay.setVisible(false);
+        return true;
+      },
+      onHover: () => {
+        moveInfoOverlay.active = true;
+        moveInfoOverlay.show(allMoves[move.moveId]);
+      },
+    };
+    return option;
+  });
+
+  const onHoverOverCancel = () => {
+    moveInfoOverlay.active = false;
+    moveInfoOverlay.setVisible(false);
+  };
+
+  const result = await selectOptionThenPokemon(
+    optionSelectItems,
+    `${namespace}:teachMovePrompt`,
+    undefined,
+    onHoverOverCancel,
+  );
+  // let forceExit = !!result;
+  if (!result) {
+    moveInfoOverlay.active = false;
+    moveInfoOverlay.setVisible(false);
+  }
+
+  // TODO: add menu to confirm player doesn't want to teach a move?
+
+  // Option select complete, handle if they are learning a move
+  if (result && result.selectedOptionIndex < moveOptions.length) {
+    globalScene.phaseManager.unshiftNew(
+      "LearnMovePhase",
+      result.selectedPokemonIndex,
+      moveOptions[result.selectedOptionIndex].moveId,
+    );
+  }
 }

--- a/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
+++ b/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
@@ -435,19 +435,19 @@ export const ClowningAroundEncounter: MysteryEncounter = MysteryEncounterBuilder
   ])
   .build();
 
-async function handleSwapAbility() {
-  // biome-ignore lint/suspicious/noAsyncPromiseExecutor: TODO: Consider refactoring to avoid async promise executor
-  return new Promise<boolean>(async resolve => {
-    await showEncounterDialogue(`${namespace}:option.1.applyAbilityDialogue`, `${namespace}:speaker`);
-    await showEncounterText(`${namespace}:option.1.applyAbilityMessage`);
+async function handleSwapAbility(): Promise<boolean> {
+  const { promise, resolve } = Promise.withResolvers<boolean>();
 
-    globalScene.ui.setMode(UiMode.MESSAGE).then(() => {
-      displayYesNoOptions(resolve);
-    });
-  });
+  await showEncounterDialogue(`${namespace}:option.1.applyAbilityDialogue`, `${namespace}:speaker`);
+  await showEncounterText(`${namespace}:option.1.applyAbilityMessage`);
+
+  await globalScene.ui.setMode(UiMode.MESSAGE);
+  displayYesNoOptions(resolve);
+
+  return promise;
 }
 
-function displayYesNoOptions(resolve) {
+function displayYesNoOptions(resolve: { (value: boolean | PromiseLike<boolean>): void; (arg0: boolean): void }): void {
   showEncounterText(`${namespace}:option.1.abilityPrompt`, null, 500, false);
   const fullOptions = [
     {
@@ -474,8 +474,12 @@ function displayYesNoOptions(resolve) {
   globalScene.ui.setModeWithoutClear(UiMode.OPTION_SELECT, config, null, true);
 }
 
-function onYesAbilitySwap(resolve) {
-  const onPokemonSelected = (pokemon: PlayerPokemon) => {
+function onYesAbilitySwap(resolve: {
+  (value: boolean | PromiseLike<boolean>): void;
+  (arg0: boolean): void;
+  (arg0: boolean): any;
+}): void {
+  const onPokemonSelected = (pokemon: PlayerPokemon): void => {
     // Do ability swap
     const encounter = globalScene.currentBattle.mysteryEncounter!;
 
@@ -484,7 +488,7 @@ function onYesAbilitySwap(resolve) {
     globalScene.ui.setMode(UiMode.MESSAGE).then(() => resolve(true));
   };
 
-  const onPokemonNotSelected = () => {
+  const onPokemonNotSelected = (): void => {
     globalScene.ui.setMode(UiMode.MESSAGE).then(() => {
       displayYesNoOptions(resolve);
     });

--- a/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
+++ b/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
@@ -431,19 +431,19 @@ export const ClowningAroundEncounter: MysteryEncounter = MysteryEncounterBuilder
   ])
   .build();
 
-async function handleSwapAbility() {
-  // biome-ignore lint/suspicious/noAsyncPromiseExecutor: TODO: Consider refactoring to avoid async promise executor
-  return new Promise<boolean>(async resolve => {
-    await showEncounterDialogue(`${namespace}:option.1.applyAbilityDialogue`, `${namespace}:speaker`);
-    await showEncounterText(`${namespace}:option.1.applyAbilityMessage`);
+async function handleSwapAbility(): Promise<boolean> {
+  const { promise, resolve } = Promise.withResolvers<boolean>();
 
-    globalScene.ui.setMode(UiMode.MESSAGE).then(() => {
-      displayYesNoOptions(resolve);
-    });
-  });
+  await showEncounterDialogue(`${namespace}:option.1.applyAbilityDialogue`, `${namespace}:speaker`);
+  await showEncounterText(`${namespace}:option.1.applyAbilityMessage`);
+
+  await globalScene.ui.setMode(UiMode.MESSAGE);
+  displayYesNoOptions(resolve);
+
+  return promise;
 }
 
-function displayYesNoOptions(resolve) {
+function displayYesNoOptions(resolve: { (value: boolean | PromiseLike<boolean>): void; (arg0: boolean): void }): void {
   showEncounterText(`${namespace}:option.1.abilityPrompt`, null, 500, false);
   const fullOptions = [
     {
@@ -470,8 +470,12 @@ function displayYesNoOptions(resolve) {
   globalScene.ui.setModeWithoutClear(UiMode.OPTION_SELECT, config, null, true);
 }
 
-function onYesAbilitySwap(resolve) {
-  const onPokemonSelected = (pokemon: PlayerPokemon) => {
+function onYesAbilitySwap(resolve: {
+  (value: boolean | PromiseLike<boolean>): void;
+  (arg0: boolean): void;
+  (arg0: boolean): any;
+}): void {
+  const onPokemonSelected = (pokemon: PlayerPokemon): void => {
     // Do ability swap
     const encounter = globalScene.currentBattle.mysteryEncounter!;
 
@@ -480,7 +484,7 @@ function onYesAbilitySwap(resolve) {
     globalScene.ui.setMode(UiMode.MESSAGE).then(() => resolve(true));
   };
 
-  const onPokemonNotSelected = () => {
+  const onPokemonNotSelected = (): void => {
     globalScene.ui.setMode(UiMode.MESSAGE).then(() => {
       displayYesNoOptions(resolve);
     });

--- a/src/data/mystery-encounters/encounters/fiery-fallout-encounter.ts
+++ b/src/data/mystery-encounters/encounters/fiery-fallout-encounter.ts
@@ -91,11 +91,11 @@ export const FieryFalloutEncounter: MysteryEncounter = MysteryEncounterBuilder.w
           isBoss: false,
           gender: Gender.MALE,
           tags: [BattlerTagType.MYSTERY_ENCOUNTER_POST_SUMMON],
-          mysteryEncounterBattleEffects: (pokemon: Pokemon) => {
+          mysteryEncounterBattleEffects: (pkmn: Pokemon) => {
             globalScene.phaseManager.unshiftNew("StatStageChangePhase", {
-              battlerIndex: pokemon.getBattlerIndex(),
+              battlerIndex: pkmn.getBattlerIndex(),
               changes: groupStatChange([Stat.SPDEF, Stat.SPD], 1),
-              sourcePokemon: pokemon,
+              sourcePokemon: pkmn,
             });
           },
         },
@@ -104,11 +104,11 @@ export const FieryFalloutEncounter: MysteryEncounter = MysteryEncounterBuilder.w
           isBoss: false,
           gender: Gender.FEMALE,
           tags: [BattlerTagType.MYSTERY_ENCOUNTER_POST_SUMMON],
-          mysteryEncounterBattleEffects: (pokemon: Pokemon) => {
+          mysteryEncounterBattleEffects: (pkmn: Pokemon) => {
             globalScene.phaseManager.unshiftNew("StatStageChangePhase", {
-              battlerIndex: pokemon.getBattlerIndex(),
+              battlerIndex: pkmn.getBattlerIndex(),
               changes: groupStatChange([Stat.SPDEF, Stat.SPD], 1),
-              sourcePokemon: pokemon,
+              sourcePokemon: pkmn,
             });
           },
         },

--- a/src/data/mystery-encounters/encounters/fiery-fallout-encounter.ts
+++ b/src/data/mystery-encounters/encounters/fiery-fallout-encounter.ts
@@ -90,10 +90,10 @@ export const FieryFalloutEncounter: MysteryEncounter = MysteryEncounterBuilder.w
           isBoss: false,
           gender: Gender.MALE,
           tags: [BattlerTagType.MYSTERY_ENCOUNTER_POST_SUMMON],
-          mysteryEncounterBattleEffects: (pokemon: Pokemon) => {
+          mysteryEncounterBattleEffects: (pkmn: Pokemon) => {
             globalScene.phaseManager.unshiftNew(
               "StatStageChangePhase",
-              pokemon.getBattlerIndex(),
+              pkmn.getBattlerIndex(),
               true,
               [Stat.SPDEF, Stat.SPD],
               1,
@@ -105,10 +105,10 @@ export const FieryFalloutEncounter: MysteryEncounter = MysteryEncounterBuilder.w
           isBoss: false,
           gender: Gender.FEMALE,
           tags: [BattlerTagType.MYSTERY_ENCOUNTER_POST_SUMMON],
-          mysteryEncounterBattleEffects: (pokemon: Pokemon) => {
+          mysteryEncounterBattleEffects: (pkmn: Pokemon) => {
             globalScene.phaseManager.unshiftNew(
               "StatStageChangePhase",
-              pokemon.getBattlerIndex(),
+              pkmn.getBattlerIndex(),
               true,
               [Stat.SPDEF, Stat.SPD],
               1,

--- a/src/data/mystery-encounters/encounters/fun-and-games-encounter.ts
+++ b/src/data/mystery-encounters/encounters/fun-and-games-encounter.ts
@@ -167,101 +167,93 @@ export const FunAndGamesEncounter: MysteryEncounter = MysteryEncounterBuilder.wi
   )
   .build();
 
-async function summonPlayerPokemon() {
-  // biome-ignore lint/suspicious/noAsyncPromiseExecutor: TODO: Consider refactoring to avoid async promise executor
-  return new Promise<void>(async resolve => {
-    const encounter = globalScene.currentBattle.mysteryEncounter!;
+async function summonPlayerPokemon(): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
 
-    const playerPokemon = encounter.misc.playerPokemon;
-    // Swaps the chosen Pokemon and the first player's lead Pokemon in the party
-    const party = globalScene.getPlayerParty();
-    const chosenIndex = party.indexOf(playerPokemon);
-    if (chosenIndex !== 0) {
-      const leadPokemon = party[0];
-      party[0] = playerPokemon;
-      party[chosenIndex] = leadPokemon;
+  const encounter = globalScene.currentBattle.mysteryEncounter!;
+
+  const playerPokemon = encounter.misc.playerPokemon;
+  // Swaps the chosen Pokemon and the first player's lead Pokemon in the party
+  const party = globalScene.getPlayerParty();
+  const chosenIndex = party.indexOf(playerPokemon);
+  if (chosenIndex !== 0) {
+    const leadPokemon = party[0];
+    party[0] = playerPokemon;
+    party[chosenIndex] = leadPokemon;
+  }
+
+  // Do trainer summon animation
+  let playerAnimationPromise: Promise<void> | undefined;
+  globalScene.ui.showText(i18next.t("battle:playerGo", { pokemonName: getPokemonNameWithAffix(playerPokemon) }));
+  globalScene.pbTray.hide();
+  globalScene.trainer.setTexture(`trainer_${settings.isPlayerFemale ? "f" : "m"}_back_pb`);
+  globalScene.time.delayedCall(562, () => {
+    globalScene.trainer.setFrame("2");
+    globalScene.time.delayedCall(64, () => {
+      globalScene.trainer.setFrame("3");
+    });
+  });
+  globalScene.tweens.add({
+    targets: globalScene.trainer,
+    x: -36,
+    duration: 1000,
+    onComplete: () => globalScene.trainer.setVisible(false),
+  });
+  globalScene.time.delayedCall(750, () => {
+    playerAnimationPromise = summonPlayerPokemonAnimation(playerPokemon);
+  });
+
+  // Also loads Wobbuffet data (cannot be shiny)
+  const enemySpecies = speciesDataRegistry.getSpecies(SpeciesId.WOBBUFFET);
+  globalScene.currentBattle.enemyParty = [];
+  const wobbuffet = globalScene.addEnemyPokemon(
+    enemySpecies,
+    encounter.misc.playerPokemon.level,
+    TrainerSlot.NONE,
+    false,
+    true,
+  );
+  wobbuffet.ivs.fill(0);
+  wobbuffet.setNature(Nature.MILD);
+  wobbuffet.setAlpha(0);
+  wobbuffet.setVisible(false);
+  wobbuffet.calculateStats();
+  globalScene.currentBattle.enemyParty[0] = wobbuffet;
+  globalScene.gameData.setPokemonSeen(wobbuffet, true);
+  await wobbuffet.loadAssets();
+  const id = setInterval(checkPlayerAnimationPromise, 500);
+  async function checkPlayerAnimationPromise(): Promise<void> {
+    if (playerAnimationPromise !== undefined) {
+      clearInterval(id);
+      await playerAnimationPromise;
+      resolve();
     }
+  }
 
-    // Do trainer summon animation
-    let playerAnimationPromise: Promise<void> | undefined;
-    globalScene.ui.showText(
-      i18next.t("battle:playerGo", {
-        pokemonName: getPokemonNameWithAffix(playerPokemon),
-      }),
-    );
-    globalScene.pbTray.hide();
-    globalScene.trainer.setTexture(`trainer_${settings.isPlayerFemale ? "f" : "m"}_back_pb`);
-    globalScene.time.delayedCall(562, () => {
-      globalScene.trainer.setFrame("2");
-      globalScene.time.delayedCall(64, () => {
-        globalScene.trainer.setFrame("3");
-      });
-    });
-    globalScene.tweens.add({
-      targets: globalScene.trainer,
-      x: -36,
-      duration: 1000,
-      onComplete: () => globalScene.trainer.setVisible(false),
-    });
-    globalScene.time.delayedCall(750, () => {
-      playerAnimationPromise = summonPlayerPokemonAnimation(playerPokemon);
-    });
+  return promise;
+}
 
-    // Also loads Wobbuffet data (cannot be shiny)
-    const enemySpecies = speciesDataRegistry.getSpecies(SpeciesId.WOBBUFFET);
+async function handleLoseMinigame(): Promise<void> {
+  // Check Wobbuffet is still alive
+  const wobbuffet = globalScene.getEnemyPokemon();
+  if (!wobbuffet || wobbuffet.isFainted(true) || wobbuffet.hp === 0) {
+    // Player loses
+    // End the battle
+    if (wobbuffet) {
+      wobbuffet.hideInfo();
+      wobbuffet.leaveField();
+    }
+    transitionMysteryEncounterIntroVisuals(true, true);
     globalScene.currentBattle.enemyParty = [];
-    const wobbuffet = globalScene.addEnemyPokemon(
-      enemySpecies,
-      encounter.misc.playerPokemon.level,
-      TrainerSlot.NONE,
-      false,
-      true,
-    );
-    wobbuffet.ivs.fill(0);
-    wobbuffet.setNature(Nature.MILD);
-    wobbuffet.setAlpha(0);
-    wobbuffet.setVisible(false);
-    wobbuffet.calculateStats();
-    globalScene.currentBattle.enemyParty[0] = wobbuffet;
-    globalScene.gameData.setPokemonSeen(wobbuffet, true);
-    await wobbuffet.loadAssets();
-    const id = setInterval(checkPlayerAnimationPromise, 500);
-    async function checkPlayerAnimationPromise() {
-      if (playerAnimationPromise) {
-        clearInterval(id);
-        await playerAnimationPromise;
-        resolve();
-      }
-    }
-  });
+    globalScene.currentBattle.mysteryEncounter!.doContinueEncounter = undefined;
+    leaveEncounterWithoutBattle(true);
+    await showEncounterText(`${namespace}:ko`);
+    const reviveCost = globalScene.getWaveMoneyAmount(1.5);
+    updatePlayerMoney(-reviveCost, true, false);
+  }
 }
 
-function handleLoseMinigame() {
-  // biome-ignore lint/suspicious/noAsyncPromiseExecutor: TODO: Consider refactoring to avoid async promise executor
-  return new Promise<void>(async resolve => {
-    // Check Wobbuffet is still alive
-    const wobbuffet = globalScene.getEnemyPokemon();
-    if (!wobbuffet || wobbuffet.isFainted(true) || wobbuffet.hp === 0) {
-      // Player loses
-      // End the battle
-      if (wobbuffet) {
-        wobbuffet.hideInfo();
-        wobbuffet.leaveField();
-      }
-      transitionMysteryEncounterIntroVisuals(true, true);
-      globalScene.currentBattle.enemyParty = [];
-      globalScene.currentBattle.mysteryEncounter!.doContinueEncounter = undefined;
-      leaveEncounterWithoutBattle(true);
-      await showEncounterText(`${namespace}:ko`);
-      const reviveCost = globalScene.getWaveMoneyAmount(1.5);
-      updatePlayerMoney(-reviveCost, true, false);
-    }
-
-    resolve();
-  });
-}
-
-function handleNextTurn() {
+function handleNextTurn(): boolean {
   const encounter = globalScene.currentBattle.mysteryEncounter!;
 
   const wobbuffet = globalScene.getEnemyPokemon();

--- a/src/data/mystery-encounters/encounters/fun-and-games-encounter.ts
+++ b/src/data/mystery-encounters/encounters/fun-and-games-encounter.ts
@@ -167,103 +167,93 @@ export const FunAndGamesEncounter: MysteryEncounter = MysteryEncounterBuilder.wi
   )
   .build();
 
-async function summonPlayerPokemon() {
-  // biome-ignore lint/suspicious/noAsyncPromiseExecutor: TODO: Consider refactoring to avoid async promise executor
-  return new Promise<void>(async resolve => {
-    const encounter = globalScene.currentBattle.mysteryEncounter!;
+async function summonPlayerPokemon(): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
 
-    const playerPokemon = encounter.misc.playerPokemon;
-    // Swaps the chosen Pokemon and the first player's lead Pokemon in the party
-    const party = globalScene.getPlayerParty();
-    const chosenIndex = party.indexOf(playerPokemon);
-    if (chosenIndex !== 0) {
-      const leadPokemon = party[0];
-      party[0] = playerPokemon;
-      party[chosenIndex] = leadPokemon;
+  const encounter = globalScene.currentBattle.mysteryEncounter!;
+
+  const playerPokemon = encounter.misc.playerPokemon;
+  // Swaps the chosen Pokemon and the first player's lead Pokemon in the party
+  const party = globalScene.getPlayerParty();
+  const chosenIndex = party.indexOf(playerPokemon);
+  if (chosenIndex !== 0) {
+    const leadPokemon = party[0];
+    party[0] = playerPokemon;
+    party[chosenIndex] = leadPokemon;
+  }
+
+  // Do trainer summon animation
+  let playerAnimationPromise: Promise<void> | undefined;
+  globalScene.ui.showText(i18next.t("battle:playerGo", { pokemonName: getPokemonNameWithAffix(playerPokemon) }));
+  globalScene.pbTray.hide();
+  globalScene.trainer.setTexture(`trainer_${globalScene.gameData.gender === PlayerGender.FEMALE ? "f" : "m"}_back_pb`);
+  globalScene.time.delayedCall(562, () => {
+    globalScene.trainer.setFrame("2");
+    globalScene.time.delayedCall(64, () => {
+      globalScene.trainer.setFrame("3");
+    });
+  });
+  globalScene.tweens.add({
+    targets: globalScene.trainer,
+    x: -36,
+    duration: 1000,
+    onComplete: () => globalScene.trainer.setVisible(false),
+  });
+  globalScene.time.delayedCall(750, () => {
+    playerAnimationPromise = summonPlayerPokemonAnimation(playerPokemon);
+  });
+
+  // Also loads Wobbuffet data (cannot be shiny)
+  const enemySpecies = getPokemonSpecies(SpeciesId.WOBBUFFET);
+  globalScene.currentBattle.enemyParty = [];
+  const wobbuffet = globalScene.addEnemyPokemon(
+    enemySpecies,
+    encounter.misc.playerPokemon.level,
+    TrainerSlot.NONE,
+    false,
+    true,
+  );
+  wobbuffet.ivs.fill(0);
+  wobbuffet.setNature(Nature.MILD);
+  wobbuffet.setAlpha(0);
+  wobbuffet.setVisible(false);
+  wobbuffet.calculateStats();
+  globalScene.currentBattle.enemyParty[0] = wobbuffet;
+  globalScene.gameData.setPokemonSeen(wobbuffet, true);
+  await wobbuffet.loadAssets();
+  const id = setInterval(checkPlayerAnimationPromise, 500);
+  async function checkPlayerAnimationPromise(): Promise<void> {
+    if (playerAnimationPromise !== undefined) {
+      clearInterval(id);
+      await playerAnimationPromise;
+      resolve();
     }
+  }
 
-    // Do trainer summon animation
-    let playerAnimationPromise: Promise<void> | undefined;
-    globalScene.ui.showText(
-      i18next.t("battle:playerGo", {
-        pokemonName: getPokemonNameWithAffix(playerPokemon),
-      }),
-    );
-    globalScene.pbTray.hide();
-    globalScene.trainer.setTexture(
-      `trainer_${globalScene.gameData.gender === PlayerGender.FEMALE ? "f" : "m"}_back_pb`,
-    );
-    globalScene.time.delayedCall(562, () => {
-      globalScene.trainer.setFrame("2");
-      globalScene.time.delayedCall(64, () => {
-        globalScene.trainer.setFrame("3");
-      });
-    });
-    globalScene.tweens.add({
-      targets: globalScene.trainer,
-      x: -36,
-      duration: 1000,
-      onComplete: () => globalScene.trainer.setVisible(false),
-    });
-    globalScene.time.delayedCall(750, () => {
-      playerAnimationPromise = summonPlayerPokemonAnimation(playerPokemon);
-    });
+  return promise;
+}
 
-    // Also loads Wobbuffet data (cannot be shiny)
-    const enemySpecies = getPokemonSpecies(SpeciesId.WOBBUFFET);
+async function handleLoseMinigame(): Promise<void> {
+  // Check Wobbuffet is still alive
+  const wobbuffet = globalScene.getEnemyPokemon();
+  if (!wobbuffet || wobbuffet.isFainted(true) || wobbuffet.hp === 0) {
+    // Player loses
+    // End the battle
+    if (wobbuffet) {
+      wobbuffet.hideInfo();
+      wobbuffet.leaveField();
+    }
+    transitionMysteryEncounterIntroVisuals(true, true);
     globalScene.currentBattle.enemyParty = [];
-    const wobbuffet = globalScene.addEnemyPokemon(
-      enemySpecies,
-      encounter.misc.playerPokemon.level,
-      TrainerSlot.NONE,
-      false,
-      true,
-    );
-    wobbuffet.ivs.fill(0);
-    wobbuffet.setNature(Nature.MILD);
-    wobbuffet.setAlpha(0);
-    wobbuffet.setVisible(false);
-    wobbuffet.calculateStats();
-    globalScene.currentBattle.enemyParty[0] = wobbuffet;
-    globalScene.gameData.setPokemonSeen(wobbuffet, true);
-    await wobbuffet.loadAssets();
-    const id = setInterval(checkPlayerAnimationPromise, 500);
-    async function checkPlayerAnimationPromise() {
-      if (playerAnimationPromise) {
-        clearInterval(id);
-        await playerAnimationPromise;
-        resolve();
-      }
-    }
-  });
+    globalScene.currentBattle.mysteryEncounter!.doContinueEncounter = undefined;
+    leaveEncounterWithoutBattle(true);
+    await showEncounterText(`${namespace}:ko`);
+    const reviveCost = globalScene.getWaveMoneyAmount(1.5);
+    updatePlayerMoney(-reviveCost, true, false);
+  }
 }
 
-function handleLoseMinigame() {
-  // biome-ignore lint/suspicious/noAsyncPromiseExecutor: TODO: Consider refactoring to avoid async promise executor
-  return new Promise<void>(async resolve => {
-    // Check Wobbuffet is still alive
-    const wobbuffet = globalScene.getEnemyPokemon();
-    if (!wobbuffet || wobbuffet.isFainted(true) || wobbuffet.hp === 0) {
-      // Player loses
-      // End the battle
-      if (wobbuffet) {
-        wobbuffet.hideInfo();
-        wobbuffet.leaveField();
-      }
-      transitionMysteryEncounterIntroVisuals(true, true);
-      globalScene.currentBattle.enemyParty = [];
-      globalScene.currentBattle.mysteryEncounter!.doContinueEncounter = undefined;
-      leaveEncounterWithoutBattle(true);
-      await showEncounterText(`${namespace}:ko`);
-      const reviveCost = globalScene.getWaveMoneyAmount(1.5);
-      updatePlayerMoney(-reviveCost, true, false);
-    }
-
-    resolve();
-  });
-}
-
-function handleNextTurn() {
+function handleNextTurn(): boolean {
   const encounter = globalScene.currentBattle.mysteryEncounter!;
 
   const wobbuffet = globalScene.getEnemyPokemon();

--- a/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
+++ b/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
@@ -608,11 +608,6 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
     const tradeContainer = globalScene.fieldUI.getByName("Trade Background") as Phaser.GameObjects.Container;
     const tradeBaseBg = tradeContainer.getByName("Trade Background Image") as Phaser.GameObjects.Image;
 
-    let tradedPokemonSprite: Phaser.GameObjects.Sprite;
-    let tradedPokemonTintSprite: Phaser.GameObjects.Sprite;
-    let receivedPokemonSprite: Phaser.GameObjects.Sprite;
-    let receivedPokemonTintSprite: Phaser.GameObjects.Sprite;
-
     const getPokemonSprite = () => {
       const ret = globalScene.addPokemonSprite(
         tradedPokemon,
@@ -627,10 +622,17 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
       return ret;
     };
 
-    tradeContainer.add((tradedPokemonSprite = getPokemonSprite()));
-    tradeContainer.add((tradedPokemonTintSprite = getPokemonSprite()));
-    tradeContainer.add((receivedPokemonSprite = getPokemonSprite()));
-    tradeContainer.add((receivedPokemonTintSprite = getPokemonSprite()));
+    const tradedPokemonSprite: Phaser.GameObjects.Sprite = getPokemonSprite();
+    const tradedPokemonTintSprite: Phaser.GameObjects.Sprite = getPokemonSprite();
+    const receivedPokemonSprite: Phaser.GameObjects.Sprite = getPokemonSprite();
+    const receivedPokemonTintSprite: Phaser.GameObjects.Sprite = getPokemonSprite();
+
+    tradeContainer.add([
+      tradedPokemonSprite,
+      tradedPokemonTintSprite,
+      receivedPokemonSprite,
+      receivedPokemonTintSprite,
+    ]);
 
     tradedPokemonSprite.setAlpha(0);
     tradedPokemonTintSprite.setAlpha(0);

--- a/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
+++ b/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
@@ -610,11 +610,6 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
     const tradeContainer = globalScene.fieldUI.getByName("Trade Background") as Phaser.GameObjects.Container;
     const tradeBaseBg = tradeContainer.getByName("Trade Background Image") as Phaser.GameObjects.Image;
 
-    let tradedPokemonSprite: Phaser.GameObjects.Sprite;
-    let tradedPokemonTintSprite: Phaser.GameObjects.Sprite;
-    let receivedPokemonSprite: Phaser.GameObjects.Sprite;
-    let receivedPokemonTintSprite: Phaser.GameObjects.Sprite;
-
     const getPokemonSprite = () => {
       const ret = globalScene.addPokemonSprite(
         tradedPokemon,
@@ -629,10 +624,17 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
       return ret;
     };
 
-    tradeContainer.add((tradedPokemonSprite = getPokemonSprite()));
-    tradeContainer.add((tradedPokemonTintSprite = getPokemonSprite()));
-    tradeContainer.add((receivedPokemonSprite = getPokemonSprite()));
-    tradeContainer.add((receivedPokemonTintSprite = getPokemonSprite()));
+    const tradedPokemonSprite: Phaser.GameObjects.Sprite = getPokemonSprite();
+    const tradedPokemonTintSprite: Phaser.GameObjects.Sprite = getPokemonSprite();
+    const receivedPokemonSprite: Phaser.GameObjects.Sprite = getPokemonSprite();
+    const receivedPokemonTintSprite: Phaser.GameObjects.Sprite = getPokemonSprite();
+
+    tradeContainer.add([
+      tradedPokemonSprite,
+      tradedPokemonTintSprite,
+      receivedPokemonSprite,
+      receivedPokemonTintSprite,
+    ]);
 
     tradedPokemonSprite.setAlpha(0);
     tradedPokemonTintSprite.setAlpha(0);
@@ -641,7 +643,7 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
     receivedPokemonTintSprite.setVisible(false);
     receivedPokemonTintSprite.setTintFill(getPokeballTintColor(receivedPokemon.pokeball));
 
-    [tradedPokemonSprite, tradedPokemonTintSprite].map(sprite => {
+    [tradedPokemonSprite, tradedPokemonTintSprite].forEach(sprite => {
       const spriteKey = tradedPokemon.getSpriteKey(true);
       try {
         sprite.play(spriteKey);
@@ -659,7 +661,7 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
       sprite.setPipelineData("spriteKey", tradedPokemon.getSpriteKey());
       sprite.setPipelineData("shiny", tradedPokemon.shiny);
       sprite.setPipelineData("variant", tradedPokemon.variant);
-      ["spriteColors", "fusionSpriteColors"].map(k => {
+      ["spriteColors", "fusionSpriteColors"].forEach(k => {
         if (tradedPokemon.summonData.speciesForm) {
           k += "Base";
         }
@@ -667,7 +669,7 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
       });
     });
 
-    [receivedPokemonSprite, receivedPokemonTintSprite].map(sprite => {
+    [receivedPokemonSprite, receivedPokemonTintSprite].forEach(sprite => {
       const spriteKey = receivedPokemon.getSpriteKey(true);
       try {
         sprite.play(spriteKey);
@@ -685,7 +687,7 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
       sprite.setPipelineData("spriteKey", receivedPokemon.getSpriteKey());
       sprite.setPipelineData("shiny", receivedPokemon.shiny);
       sprite.setPipelineData("variant", receivedPokemon.variant);
-      ["spriteColors", "fusionSpriteColors"].map(k => {
+      ["spriteColors", "fusionSpriteColors"].forEach(k => {
         if (receivedPokemon.summonData.speciesForm) {
           k += "Base";
         }

--- a/src/data/mystery-encounters/encounters/part-timer-encounter.ts
+++ b/src/data/mystery-encounters/encounters/part-timer-encounter.ts
@@ -251,7 +251,7 @@ export const PartTimerEncounter: MysteryEncounter = MysteryEncounterBuilder.with
       })
       .withPreOptionPhase(async () => {
         const encounter = globalScene.currentBattle.mysteryEncounter!;
-        const selectedPokemon = encounter.selectedOption?.primaryPokemon!;
+        const selectedPokemon = encounter.selectedOption!.primaryPokemon!;
         encounter.setDialogueToken("selectedPokemon", selectedPokemon.getNameToRender());
 
         // Reduce all PP to 2 (if they started at greater than 2)

--- a/src/data/mystery-encounters/encounters/part-timer-encounter.ts
+++ b/src/data/mystery-encounters/encounters/part-timer-encounter.ts
@@ -250,7 +250,7 @@ export const PartTimerEncounter: MysteryEncounter = MysteryEncounterBuilder.with
       })
       .withPreOptionPhase(async () => {
         const encounter = globalScene.currentBattle.mysteryEncounter!;
-        const selectedPokemon = encounter.selectedOption?.primaryPokemon!;
+        const selectedPokemon = encounter.selectedOption!.primaryPokemon!;
         encounter.setDialogueToken("selectedPokemon", selectedPokemon.getNameToRender());
 
         // Reduce all PP to 2 (if they started at greater than 2)

--- a/src/data/mystery-encounters/encounters/the-winstrate-challenge-encounter.ts
+++ b/src/data/mystery-encounters/encounters/the-winstrate-challenge-encounter.ts
@@ -181,74 +181,78 @@ async function spawnNextTrainerOrEndEncounter() {
   }
 }
 
-function endTrainerBattleAndShowDialogue(): Promise<void> {
-  // biome-ignore lint/suspicious/noAsyncPromiseExecutor: TODO: Consider refactoring to avoid async promise executor
-  return new Promise(async resolve => {
-    if (globalScene.currentBattle.mysteryEncounter!.enemyPartyConfigs.length === 0) {
-      // Battle is over
-      const trainer = globalScene.currentBattle.trainer;
-      if (trainer) {
-        globalScene.tweens.add({
-          targets: trainer,
-          x: "+=16",
-          y: "-=16",
-          alpha: 0,
-          ease: "Sine.easeInOut",
-          duration: 750,
-          onComplete: () => {
-            globalScene.field.remove(trainer, true);
-          },
-        });
-      }
+async function endTrainerBattleAndShowDialogue(): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
 
-      await spawnNextTrainerOrEndEncounter();
-      resolve(); // Wait for all dialogue/post battle stuff to complete before resolving
-    } else {
-      globalScene.arena.resetArenaEffects();
-      const playerField = globalScene.getPlayerField();
-      for (const pokemon of playerField) {
-        pokemon.lapseTag(BattlerTagType.COMMANDED);
-      }
-      playerField.forEach((_, p) => globalScene.phaseManager.unshiftNew("ReturnPhase", p));
-
-      for (const pokemon of globalScene.getPlayerParty()) {
-        // Only trigger form change when Eiscue is in Noice form
-        // Hardcoded Eiscue for now in case it is fused with another pokemon
-        if (
-          pokemon.species.speciesId === SpeciesId.EISCUE
-          && pokemon.hasAbility(AbilityId.ICE_FACE)
-          && pokemon.formIndex === 1
-        ) {
-          globalScene.triggerPokemonFormChange(pokemon, SpeciesFormChangeAbilityTrigger);
-        }
-
-        // Each trainer battle is supposed to be a new fight, so reset all per-battle activation effects
-        pokemon.resetBattleAndWaveData();
-        applyAbAttrs("PostBattleInitAbAttr", { pokemon });
-      }
-
-      globalScene.phaseManager.unshiftNew("ShowTrainerPhase");
-      // Hide the trainer and init next battle
-      const trainer = globalScene.currentBattle.trainer;
-      // Unassign previous trainer from battle so it isn't destroyed before animation completes
-      globalScene.currentBattle.trainer = null;
-      await spawnNextTrainerOrEndEncounter();
-      if (trainer) {
-        globalScene.tweens.add({
-          targets: trainer,
-          x: "+=16",
-          y: "-=16",
-          alpha: 0,
-          ease: "Sine.easeInOut",
-          duration: 750,
-          onComplete: () => {
-            globalScene.field.remove(trainer, true);
-            resolve();
-          },
-        });
-      }
+  if (globalScene.currentBattle.mysteryEncounter!.enemyPartyConfigs.length === 0) {
+    // Battle is over
+    const trainer = globalScene.currentBattle.trainer;
+    if (trainer) {
+      globalScene.tweens.add({
+        targets: trainer,
+        x: "+=16",
+        y: "-=16",
+        alpha: 0,
+        ease: "Sine.easeInOut",
+        duration: 750,
+        onComplete: () => {
+          globalScene.field.remove(trainer, true);
+        },
+      });
     }
-  });
+
+    await spawnNextTrainerOrEndEncounter();
+    resolve();
+    return promise;
+  }
+
+  globalScene.arena.resetArenaEffects();
+  const playerField = globalScene.getPlayerField();
+  for (const pokemon of playerField) {
+    pokemon.lapseTag(BattlerTagType.COMMANDED);
+  }
+  playerField.forEach((_, p) => globalScene.phaseManager.unshiftNew("ReturnPhase", p));
+
+  for (const pokemon of globalScene.getPlayerParty()) {
+    // Only trigger form change when Eiscue is in Noice form
+    // Hardcoded Eiscue for now in case it is fused with another pokemon
+    if (
+      pokemon.species.speciesId === SpeciesId.EISCUE
+      && pokemon.hasAbility(AbilityId.ICE_FACE)
+      && pokemon.formIndex === 1
+    ) {
+      globalScene.triggerPokemonFormChange(pokemon, SpeciesFormChangeAbilityTrigger);
+    }
+
+    // Each trainer battle is supposed to be a new fight, so reset all per-battle activation effects
+    pokemon.resetBattleAndWaveData();
+    applyAbAttrs("PostBattleInitAbAttr", { pokemon });
+  }
+
+  globalScene.phaseManager.unshiftNew("ShowTrainerPhase");
+  // Hide the trainer and init next battle
+  const trainer = globalScene.currentBattle.trainer;
+  // Unassign previous trainer from battle so it isn't destroyed before animation completes
+  globalScene.currentBattle.trainer = null;
+  await spawnNextTrainerOrEndEncounter();
+  if (trainer) {
+    globalScene.tweens.add({
+      targets: trainer,
+      x: "+=16",
+      y: "-=16",
+      alpha: 0,
+      ease: "Sine.easeInOut",
+      duration: 750,
+      onComplete: () => {
+        globalScene.field.remove(trainer, true);
+        resolve();
+      },
+    });
+  } else {
+    resolve();
+  }
+
+  return promise;
 }
 
 function getVictorTrainerConfig(): EnemyPartyConfig {

--- a/src/data/mystery-encounters/encounters/the-winstrate-challenge-encounter.ts
+++ b/src/data/mystery-encounters/encounters/the-winstrate-challenge-encounter.ts
@@ -180,74 +180,78 @@ async function spawnNextTrainerOrEndEncounter() {
   }
 }
 
-function endTrainerBattleAndShowDialogue(): Promise<void> {
-  // biome-ignore lint/suspicious/noAsyncPromiseExecutor: TODO: Consider refactoring to avoid async promise executor
-  return new Promise(async resolve => {
-    if (globalScene.currentBattle.mysteryEncounter!.enemyPartyConfigs.length === 0) {
-      // Battle is over
-      const trainer = globalScene.currentBattle.trainer;
-      if (trainer) {
-        globalScene.tweens.add({
-          targets: trainer,
-          x: "+=16",
-          y: "-=16",
-          alpha: 0,
-          ease: "Sine.easeInOut",
-          duration: 750,
-          onComplete: () => {
-            globalScene.field.remove(trainer, true);
-          },
-        });
-      }
+async function endTrainerBattleAndShowDialogue(): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
 
-      await spawnNextTrainerOrEndEncounter();
-      resolve(); // Wait for all dialogue/post battle stuff to complete before resolving
-    } else {
-      globalScene.arena.resetArenaEffects();
-      const playerField = globalScene.getPlayerField();
-      for (const pokemon of playerField) {
-        pokemon.lapseTag(BattlerTagType.COMMANDED);
-      }
-      playerField.forEach((_, p) => globalScene.phaseManager.unshiftNew("ReturnPhase", p));
-
-      for (const pokemon of globalScene.getPlayerParty()) {
-        // Only trigger form change when Eiscue is in Noice form
-        // Hardcoded Eiscue for now in case it is fused with another pokemon
-        if (
-          pokemon.species.speciesId === SpeciesId.EISCUE
-          && pokemon.hasAbility(AbilityId.ICE_FACE)
-          && pokemon.formIndex === 1
-        ) {
-          globalScene.triggerPokemonFormChange(pokemon, SpeciesFormChangeAbilityTrigger);
-        }
-
-        // Each trainer battle is supposed to be a new fight, so reset all per-battle activation effects
-        pokemon.resetBattleAndWaveData();
-        applyAbAttrs("PostBattleInitAbAttr", { pokemon });
-      }
-
-      globalScene.phaseManager.unshiftNew("ShowTrainerPhase");
-      // Hide the trainer and init next battle
-      const trainer = globalScene.currentBattle.trainer;
-      // Unassign previous trainer from battle so it isn't destroyed before animation completes
-      globalScene.currentBattle.trainer = null;
-      await spawnNextTrainerOrEndEncounter();
-      if (trainer) {
-        globalScene.tweens.add({
-          targets: trainer,
-          x: "+=16",
-          y: "-=16",
-          alpha: 0,
-          ease: "Sine.easeInOut",
-          duration: 750,
-          onComplete: () => {
-            globalScene.field.remove(trainer, true);
-            resolve();
-          },
-        });
-      }
+  if (globalScene.currentBattle.mysteryEncounter!.enemyPartyConfigs.length === 0) {
+    // Battle is over
+    const trainer = globalScene.currentBattle.trainer;
+    if (trainer) {
+      globalScene.tweens.add({
+        targets: trainer,
+        x: "+=16",
+        y: "-=16",
+        alpha: 0,
+        ease: "Sine.easeInOut",
+        duration: 750,
+        onComplete: () => {
+          globalScene.field.remove(trainer, true);
+        },
+      });
     }
-  });
+
+    await spawnNextTrainerOrEndEncounter();
+    resolve();
+    return promise;
+  }
+
+  globalScene.arena.resetArenaEffects();
+  const playerField = globalScene.getPlayerField();
+  for (const pokemon of playerField) {
+    pokemon.lapseTag(BattlerTagType.COMMANDED);
+  }
+  playerField.forEach((_, p) => globalScene.phaseManager.unshiftNew("ReturnPhase", p));
+
+  for (const pokemon of globalScene.getPlayerParty()) {
+    // Only trigger form change when Eiscue is in Noice form
+    // Hardcoded Eiscue for now in case it is fused with another pokemon
+    if (
+      pokemon.species.speciesId === SpeciesId.EISCUE
+      && pokemon.hasAbility(AbilityId.ICE_FACE)
+      && pokemon.formIndex === 1
+    ) {
+      globalScene.triggerPokemonFormChange(pokemon, SpeciesFormChangeAbilityTrigger);
+    }
+
+    // Each trainer battle is supposed to be a new fight, so reset all per-battle activation effects
+    pokemon.resetBattleAndWaveData();
+    applyAbAttrs("PostBattleInitAbAttr", { pokemon });
+  }
+
+  globalScene.phaseManager.unshiftNew("ShowTrainerPhase");
+  // Hide the trainer and init next battle
+  const trainer = globalScene.currentBattle.trainer;
+  // Unassign previous trainer from battle so it isn't destroyed before animation completes
+  globalScene.currentBattle.trainer = null;
+  await spawnNextTrainerOrEndEncounter();
+  if (trainer) {
+    globalScene.tweens.add({
+      targets: trainer,
+      x: "+=16",
+      y: "-=16",
+      alpha: 0,
+      ease: "Sine.easeInOut",
+      duration: 750,
+      onComplete: () => {
+        globalScene.field.remove(trainer, true);
+        resolve();
+      },
+    });
+  } else {
+    resolve();
+  }
+
+  return promise;
 }
 
 function getVictorTrainerConfig(): EnemyPartyConfig {

--- a/src/data/mystery-encounters/encounters/uncommon-breed-encounter.ts
+++ b/src/data/mystery-encounters/encounters/uncommon-breed-encounter.ts
@@ -103,12 +103,12 @@ export const UncommonBreedEncounter: MysteryEncounter = MysteryEncounterBuilder.
           dataSource: new PokemonData(pokemon),
           isBoss: false,
           tags: [BattlerTagType.MYSTERY_ENCOUNTER_POST_SUMMON],
-          mysteryEncounterBattleEffects: (pokemon: Pokemon) => {
+          mysteryEncounterBattleEffects: (pkmn: Pokemon) => {
             queueEncounterMessage(`${namespace}:option.1.statBoost`);
             globalScene.phaseManager.unshiftNew("StatStageChangePhase", {
-              battlerIndex: pokemon.getBattlerIndex(),
+              battlerIndex: pkmn.getBattlerIndex(),
               changes: groupStatChange(statChangesForBattle, 1),
-              sourcePokemon: pokemon,
+              sourcePokemon: pkmn,
             });
           },
         },

--- a/src/data/mystery-encounters/encounters/uncommon-breed-encounter.ts
+++ b/src/data/mystery-encounters/encounters/uncommon-breed-encounter.ts
@@ -101,11 +101,11 @@ export const UncommonBreedEncounter: MysteryEncounter = MysteryEncounterBuilder.
           dataSource: new PokemonData(pokemon),
           isBoss: false,
           tags: [BattlerTagType.MYSTERY_ENCOUNTER_POST_SUMMON],
-          mysteryEncounterBattleEffects: (pokemon: Pokemon) => {
+          mysteryEncounterBattleEffects: (pkmn: Pokemon) => {
             queueEncounterMessage(`${namespace}:option.1.statBoost`);
             globalScene.phaseManager.unshiftNew(
               "StatStageChangePhase",
-              pokemon.getBattlerIndex(),
+              pkmn.getBattlerIndex(),
               true,
               statChangesForBattle,
               1,


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Cleaning up some code, resolving lint issues.

## What are the changes from a developer perspective?
Changed a few function to be `async` functions using `await` instead of using `return new Promise`.

## How to test the changes?
Use overrides to activate the modified MEs.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [ ] I have tested the changes manually