### PR TITLE
fix(biomes): biome weather will now activate correctly

### DIFF
--- a/src/phases/new-biome-encounter-phase.ts
+++ b/src/phases/new-biome-encounter-phase.ts
@@ -1,9 +1,10 @@
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
-import { NextEncounterPhase } from "#phases/next-encounter-phase";
+import { EncounterPhase } from "#phases/encounter-phase";
 
-export class NewBiomeEncounterPhase extends NextEncounterPhase {
+export class NewBiomeEncounterPhase extends EncounterPhase {
   public readonly phaseName = "NewBiomeEncounterPhase";
+
   doEncounter(): void {
     globalScene.playBgm(undefined, true);
 

--- a/src/phases/next-encounter-phase.ts
+++ b/src/phases/next-encounter-phase.ts
@@ -6,10 +6,7 @@ import { EncounterPhase } from "#phases/encounter-phase";
  * Handles generating, loading and preparing for it.
  */
 export class NextEncounterPhase extends EncounterPhase {
-  public readonly phaseName: "NextEncounterPhase" | "NewBiomeEncounterPhase" = "NextEncounterPhase";
-  start() {
-    super.start();
-  }
+  public readonly phaseName = "NextEncounterPhase";
 
   doEncounter(): void {
     globalScene.playBgm(undefined, true);


### PR DESCRIPTION
## What are the changes the user will see?
Biome weather will activate correctly when moving between biomes.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Bug report.

## What are the changes from a developer perspective?
Fixed the class inheritance so `NewBiomeEncounterPhase` inherits from `EncounterPhase` instead of `NextEncounterPhase`.

## How to test the changes?
```ts
const overrides = {
  STARTING_BIOME_OVERRIDE: BiomeId.SEA,
  STARTING_LEVEL_OVERRIDE: 200,
  STARTING_WAVE_OVERRIDE: 10,
  STARTING_MODIFIER_OVERRIDE: [{ name: "MAP" }],
  ENEMY_MOVESET_OVERRIDE: MoveId.SPLASH,
  MOVESET_OVERRIDE: MoveId.SUNNY_DAY,
} satisfies Partial<InstanceType<OverridesType>>;
```
Set the weather to sunny, move to wave 11, choose to travel to "Seabed", the weather should be changed to rain when the wave starts.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually