### PR TITLE
misc: add a 3 second delay to advance the endless end message

### DIFF
--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -26,14 +26,15 @@ import { TrainerData } from "#system/trainer-data";
 import { trainerConfigs } from "#trainers/trainer-config";
 import type { SessionSaveData } from "#types/save-data";
 import { checkSpeciesValidForChallenge, isNuzlockeChallenge } from "#utils/challenge-utils";
-import { isLocalServerConnected } from "#utils/common";
+import { fixedInt, isLocalServerConnected } from "#utils/common";
 import { getPokemonSpecies } from "#utils/pokemon-utils";
 import i18next from "i18next";
 
 export class GameOverPhase extends BattlePhase {
   public readonly phaseName = "GameOverPhase";
+
   private isVictory: boolean;
-  private firstRibbons: PokemonSpecies[] = [];
+  private readonly firstRibbons: PokemonSpecies[] = [];
 
   constructor(isVictory = false) {
     super();
@@ -71,6 +72,8 @@ export class GameOverPhase extends BattlePhase {
         i18next.t("miscDialogue:endingName"),
         0,
         () => this.handleGameOver(),
+        0,
+        fixedInt(3000),
       );
     } else if (this.isVictory || !globalScene.enableRetries) {
       this.handleGameOver();


### PR DESCRIPTION
## What are the changes the user will see?
The message that appears after you reach the end of endless mode won't be skippable for 3 seconds after appearing, preventing newer players from skipping past it accidentally and then being confused when the game ends unexpectedly.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Reducing player confusion.

## What are the changes from a developer perspective?
Added a 3 second prompt delay to the end of endless message in `GameOverPhase`.

## How to test the changes?
```ts
const overrides = {
  ENEMY_LEVEL_OVERRIDE: 1,
  STARTING_LEVEL_OVERRIDE: 10000,
  STARTING_WAVE_OVERRIDE: 5850,
  STARTING_BIOME_OVERRIDE: BiomeId.END,
} satisfies Partial<InstanceType<OverridesType>>;
```
Defeat wave 5850 in endless to trigger the message, and spam the action key.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually