### PR TITLE
misc: prevent Rapidash from creating unfortunate fusion names

### DIFF
--- a/src/utils/pokemon-utils.ts
+++ b/src/utils/pokemon-utils.ts
@@ -123,6 +123,14 @@ export function getFusedSpeciesName(speciesAName: string, speciesBName: string):
 
   fragB = `${fragB.slice(0, 1).toLowerCase()}${fragB.slice(1)}`;
 
+  // Prevents some unfortunate fusion names from Rapidash + X
+  if (fragA === "Rapi") {
+    fragA = "Rapid";
+    if (fragB === "ng") {
+      fragB = speciesBName.slice(speciesBName.length - 3);
+    }
+  }
+
   return `${speciesAPrefix || speciesBPrefix}${fragA}${fragB}${speciesBSuffix || speciesASuffix}`;
 }
 


### PR DESCRIPTION
## What are the changes the user will see?
Fusion names created by having Rapidash as the base will be better.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Stopgap fix for some fusion name generation issues.

## What are the changes from a developer perspective?
Manual overrides were added if the first Pokémon in a fusion is Rapidash.

## Screenshots/Videos
<details><summary>Rapidash + Metang</summary>

<img width="544" height="161" alt="image" src="https://github.com/user-attachments/assets/6f03a239-74d6-4bbe-8457-4463e91287bf" />

</details>
<details><summary>Rapidash + Uxie</summary>

<img width="524" height="116" alt="image" src="https://github.com/user-attachments/assets/ca9a62cc-b1a0-4423-aa61-28cf566fe65c" />

</details>

## How to test the changes?
```ts
const overrides = {
  ITEM_REWARD_OVERRIDE: [
    { name: "DNA_SPLICERS" },
    { name: "RARER_CANDY" },
    { name: "EVOLUTION_ITEM" },
    { name: "RARE_CANDY" },
  ],
  STARTING_LEVEL_OVERRIDE: 200,
  STARTING_MODIFIER_OVERRIDE: [{ name: "GOLDEN_POKEBALL" }],
} satisfies Partial<InstanceType<OverridesType>>;
```
Fuse Rapidash with various Pokémon.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually