### PR TITLE
refactor: remove `BattleSpec` enum

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -29,7 +29,7 @@ import { FRIENDSHIP_GAIN_FROM_BATTLE } from "#balance/starters";
 import { initCommonAnims, initMoveAnim, loadCommonAnimAssets, loadMoveAnimAssets } from "#data/battle-anims";
 import { getDailyMysteryEncounter } from "#data/daily-seed/daily-run";
 import { allMoves, allSpecies, biomeDepths, modifierTypes } from "#data/data-lists";
-import { battleSpecDialogue } from "#data/dialogue";
+import { classicFinalBossDialogue } from "#data/dialogue";
 import type { SpeciesFormChangeTrigger } from "#data/form-change-triggers";
 import { SpeciesFormChangeManualTrigger, SpeciesFormChangeTimeOfDayTrigger } from "#data/form-change-triggers";
 import { Gender } from "#data/gender";
@@ -37,7 +37,6 @@ import type { SpeciesFormChange } from "#data/pokemon-forms";
 import { pokemonFormChanges } from "#data/pokemon-forms";
 import type { PokemonSpecies, PokemonSpeciesFilter } from "#data/pokemon-species";
 import { getTypeRgb } from "#data/type";
-import { BattleSpec } from "#enums/battle-spec";
 import { BattleStyle } from "#enums/battle-style";
 import { BattleType } from "#enums/battle-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
@@ -1569,7 +1568,7 @@ export class BattleScene extends SceneBase {
     const resetArenaState =
       isNewBiome
       || [BattleType.TRAINER, BattleType.MYSTERY_ENCOUNTER].includes(this.currentBattle.battleType)
-      || this.currentBattle.battleSpec === BattleSpec.FINAL_BOSS;
+      || this.currentBattle.isClassicFinalBoss;
 
     for (const enemyPokemon of this.getEnemyParty()) {
       enemyPokemon.destroy();
@@ -3035,7 +3034,7 @@ export class BattleScene extends SceneBase {
 
   generateEnemyModifiers(heldModifiersConfigs?: HeldModifierConfig[][]): Promise<void> {
     return new Promise(resolve => {
-      if (this.currentBattle.battleSpec === BattleSpec.FINAL_BOSS) {
+      if (this.currentBattle.isClassicFinalBoss) {
         return resolve();
       }
       const difficultyWaveIndex = this.gameMode.getWaveForDifficulty(this.currentBattle.waveIndex);
@@ -3488,38 +3487,33 @@ export class BattleScene extends SceneBase {
    * @param pokemon The (enemy) pokemon
    */
   initFinalBossPhaseTwo(pokemon: Pokemon): void {
-    if (pokemon.isEnemy() && pokemon.isBoss() && !pokemon.formIndex && pokemon.bossSegmentIndex < 1) {
-      this.fadeOutBgm(fixedInt(2000), false);
-      this.ui.showDialogue(
-        battleSpecDialogue[BattleSpec.FINAL_BOSS].firstStageWin,
-        pokemon.species.name,
-        undefined,
-        () => {
-          const finalBossMBH = getModifierType(modifierTypes.MINI_BLACK_HOLE).newModifier(
-            pokemon,
-          ) as TurnHeldItemTransferModifier;
-          finalBossMBH.setTransferrableFalse();
-          this.addEnemyModifier(finalBossMBH, false, true);
-          pokemon.generateAndPopulateMoveset(false, 1);
-          this.setFieldScale(0.75);
-          this.triggerPokemonFormChange(pokemon, SpeciesFormChangeManualTrigger, false);
-          this.currentBattle.double = true;
-          const availablePartyMembers = this.getPlayerParty().filter(p => p.isAllowedInBattle());
-          if (availablePartyMembers.length > 1) {
-            this.phaseManager.pushNew("ToggleDoublePositionPhase", true);
-            if (!availablePartyMembers[1].isOnField()) {
-              this.phaseManager.pushNew("SummonPhase", 1);
-              this.phaseManager.pushNew("PostSummonPhase", 1);
-            }
-          }
-
-          this.phaseManager.shiftPhase();
-        },
-      );
+    if (!pokemon.isEnemy() || !pokemon.isBoss() || pokemon.formIndex > 0 || pokemon.bossSegmentIndex >= 1) {
+      this.phaseManager.shiftPhase();
       return;
     }
 
-    this.phaseManager.shiftPhase();
+    this.fadeOutBgm(fixedInt(2000), false);
+    this.ui.showDialogue(classicFinalBossDialogue.firstStageWin, pokemon.species.name, undefined, () => {
+      const finalBossMBH = getModifierType(modifierTypes.MINI_BLACK_HOLE).newModifier(
+        pokemon,
+      ) as TurnHeldItemTransferModifier;
+      finalBossMBH.setTransferrableFalse();
+      this.addEnemyModifier(finalBossMBH, false, true);
+      pokemon.generateAndPopulateMoveset(false, 1);
+      this.setFieldScale(0.75);
+      this.triggerPokemonFormChange(pokemon, SpeciesFormChangeManualTrigger, false);
+      this.currentBattle.double = true;
+      const availablePartyMembers = this.getPlayerParty().filter(p => p.isAllowedInBattle());
+      if (availablePartyMembers.length > 1) {
+        this.phaseManager.pushNew("ToggleDoublePositionPhase", true);
+        if (!availablePartyMembers[1].isOnField()) {
+          this.phaseManager.pushNew("SummonPhase", 1);
+          this.phaseManager.pushNew("PostSummonPhase", 1);
+        }
+      }
+
+      this.phaseManager.shiftPhase();
+    });
   }
 
   /**

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1,7 +1,6 @@
 import type { GameMode } from "#app/game-mode";
 import { globalScene } from "#app/global-scene";
 import { ArenaTagType } from "#enums/arena-tag-type";
-import { BattleSpec } from "#enums/battle-spec";
 import { BattleType } from "#enums/battle-type";
 import { BattlerIndex } from "#enums/battler-index";
 import { BiomeId } from "#enums/biome-id";
@@ -59,7 +58,6 @@ export class Battle {
   protected gameMode: GameMode;
   public waveIndex: number;
   public battleType: BattleType;
-  public battleSpec: BattleSpec;
   public trainer: Trainer | null;
   public enemyLevels: number[] | undefined;
   public enemyParty: EnemyPokemon[] = [];
@@ -117,7 +115,6 @@ export class Battle {
     this.mysteryEncounterType = mysteryEncounterType;
     this.double = double;
 
-    this.initBattleSpec();
     this.enemyLevels =
       battleType === BattleType.TRAINER
         ? trainer?.getPartyLevels(this.waveIndex)
@@ -125,12 +122,8 @@ export class Battle {
           new Array(double ? 2 : 1).fill(null).map(() => this.getLevelForWave());
   }
 
-  private initBattleSpec(): void {
-    let spec = BattleSpec.DEFAULT;
-    if (this.gameMode.isWaveFinal(this.waveIndex) && this.gameMode.isClassic) {
-      spec = BattleSpec.FINAL_BOSS;
-    }
-    this.battleSpec = spec;
+  public get isClassicFinalBoss(): boolean {
+    return this.gameMode.isClassic && this.gameMode.isWaveFinal(this.waveIndex);
   }
 
   public getLevelForWave(): number {
@@ -140,7 +133,7 @@ export class Battle {
 
     if (this.gameMode.isBoss(this.waveIndex)) {
       const ret = Math.floor(baseLevel * bossMultiplier);
-      if (this.battleSpec === BattleSpec.FINAL_BOSS || !(this.waveIndex % 250)) {
+      if (this.isClassicFinalBoss || !(this.waveIndex % 250)) {
         return Math.ceil(ret / 25) * 25;
       }
       let levelOffset = 0;
@@ -271,7 +264,7 @@ export class Battle {
     }
     const wildOpponents = globalScene.getEnemyParty();
     for (const pokemon of wildOpponents) {
-      if (this.battleSpec === BattleSpec.FINAL_BOSS) {
+      if (this.isClassicFinalBoss) {
         if (pokemon.species.getFormSpriteKey(pokemon.formIndex) === SpeciesFormKey.ETERNAMAX) {
           return "battle_final";
         }

--- a/src/data/dialogue.ts
+++ b/src/data/dialogue.ts
@@ -1,4 +1,3 @@
-import { BattleSpec } from "#enums/battle-spec";
 import { TrainerType } from "#enums/trainer-type";
 import { trainerConfigs } from "#trainers/trainer-config";
 import { capitalizeFirstLetter } from "#utils/strings";
@@ -1921,12 +1920,10 @@ export const trainerTypeDialogue: TrainerTypeDialogue = {
   ],
 };
 
-export const battleSpecDialogue = {
-  [BattleSpec.FINAL_BOSS]: {
-    encounter: "battleSpecDialogue:encounter",
-    firstStageWin: "battleSpecDialogue:firstStageWin",
-    secondStageWin: "battleSpecDialogue:secondStageWin",
-  },
+export const classicFinalBossDialogue = {
+  encounter: "battleSpecDialogue:encounter",
+  firstStageWin: "battleSpecDialogue:firstStageWin",
+  secondStageWin: "battleSpecDialogue:secondStageWin",
 };
 
 export const miscDialogue = {

--- a/src/enums/battle-spec.ts
+++ b/src/enums/battle-spec.ts
@@ -1,4 +1,0 @@
-export enum BattleSpec {
-  DEFAULT,
-  FINAL_BOSS,
-}

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -78,7 +78,6 @@ import { AbilityId } from "#enums/ability-id";
 import { AiType } from "#enums/ai-type";
 import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
-import { BattleSpec } from "#enums/battle-spec";
 import { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
@@ -2226,18 +2225,14 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     if (
       this.isEnemy()
       && !gameMode.hasChallenge(Challenges.PASSIVES)
-      && (currentBattle?.battleSpec === BattleSpec.FINAL_BOSS
+      && (currentBattle?.isClassicFinalBoss
         || gameMode.isEndlessMinorBoss(waveIndex)
         || gameMode.isEndlessMajorBoss(waveIndex))
     ) {
       return false;
     }
 
-    if (
-      globalScene.gameMode.isDaily
-      && this.customPokemonData.passive != null
-      && this.customPokemonData.passive !== -1
-    ) {
+    if (gameMode.isDaily && this.customPokemonData.passive != null && this.customPokemonData.passive !== -1) {
       return true;
     }
 
@@ -7037,11 +7032,8 @@ export class EnemyPokemon extends Pokemon {
       );
     }
 
-    switch (globalScene.currentBattle.battleSpec) {
-      case BattleSpec.FINAL_BOSS:
-        if (!this.formIndex && this.bossSegmentIndex < 1) {
-          damage = Math.min(damage, this.hp - 1);
-        }
+    if (globalScene.currentBattle.isClassicFinalBoss && this.formIndex === 0 && this.bossSegmentIndex < 1) {
+      damage = Math.min(damage, this.hp - 1);
     }
 
     const ret = super.damage(damage, ignoreSegments, preventEndure, ignoreFaintPhase);
@@ -7060,7 +7052,7 @@ export class EnemyPokemon extends Pokemon {
   }
 
   private getMinimumSegmentIndex(): number {
-    if (globalScene.currentBattle.battleSpec === BattleSpec.FINAL_BOSS && !this.formIndex) {
+    if (globalScene.currentBattle.isClassicFinalBoss && !this.formIndex) {
       return 1;
     }
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,5 +1,4 @@
 import { globalScene } from "#app/global-scene";
-import { BattleSpec } from "#enums/battle-spec";
 import type { Pokemon } from "#field/pokemon";
 import i18next from "i18next";
 
@@ -22,7 +21,7 @@ export function getPokemonNameWithAffix(pokemon: Pokemon | undefined, useIllusio
   }
 
   // Even though the final boss is a "wild"/"trainerless" Pokemon, it uses "Foe" instead of "Wild"
-  const useFoePrefix = globalScene.currentBattle.battleSpec === BattleSpec.FINAL_BOSS || pokemon.hasTrainer();
+  const useFoePrefix = globalScene.currentBattle.isClassicFinalBoss || pokemon.hasTrainer();
   const i18nkey = useFoePrefix ? "battle:foePokemonWithAffix" : "battle:wildPokemonWithAffix";
   return i18next.t(i18nkey, { pokemonName });
 }

--- a/src/phases/damage-anim-phase.ts
+++ b/src/phases/damage-anim-phase.ts
@@ -1,5 +1,4 @@
 import { globalScene } from "#app/global-scene";
-import { BattleSpec } from "#enums/battle-spec";
 import type { BattlerIndex } from "#enums/battler-index";
 import { HitResult } from "#enums/hit-result";
 import { PokemonPhase } from "#phases/pokemon-phase";
@@ -8,9 +7,10 @@ import { fixedInt } from "#utils/common";
 
 export class DamageAnimPhase extends PokemonPhase {
   public readonly phaseName = "DamageAnimPhase";
+
   private amount: number;
-  private damageResult: DamageResult;
-  private critical: boolean;
+  private readonly damageResult: DamageResult;
+  private readonly critical: boolean;
 
   constructor(
     battlerIndex: BattlerIndex,
@@ -42,11 +42,12 @@ export class DamageAnimPhase extends PokemonPhase {
     this.applyDamage();
   }
 
-  updateAmount(amount: number): void {
+  // TODO: this is silly, just make `amount` `public`
+  public updateAmount(amount: number): void {
     this.amount = amount;
   }
 
-  applyDamage() {
+  private applyDamage() {
     switch (this.damageResult) {
       case HitResult.EFFECTIVE:
       case HitResult.CONFUSION:
@@ -89,8 +90,8 @@ export class DamageAnimPhase extends PokemonPhase {
     }
   }
 
-  override end() {
-    if (globalScene.currentBattle.battleSpec === BattleSpec.FINAL_BOSS) {
+  public override end() {
+    if (globalScene.currentBattle.isClassicFinalBoss) {
       globalScene.initFinalBossPhaseTwo(this.getPokemon());
     } else {
       super.end();

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -7,7 +7,6 @@ import { handleTutorial, Tutorial } from "#app/tutorial";
 import { initEncounterAnims, loadEncounterAnimAssets } from "#data/battle-anims";
 import { getCharVariantFromDialogue } from "#data/dialogue";
 import { getNatureName } from "#data/nature";
-import { BattleSpec } from "#enums/battle-spec";
 import { BattleType } from "#enums/battle-type";
 import { BattlerIndex } from "#enums/battler-index";
 import { BiomeId } from "#enums/biome-id";
@@ -39,7 +38,8 @@ import i18next from "i18next";
 export class EncounterPhase extends BattlePhase {
   // Union type is necessary as this is subclassed, and typescript will otherwise complain
   public readonly phaseName: "EncounterPhase" | "NextEncounterPhase" | "NewBiomeEncounterPhase" = "EncounterPhase";
-  private loaded: boolean;
+
+  private readonly loaded: boolean;
 
   constructor(loaded = false) {
     super();
@@ -123,7 +123,7 @@ export class EncounterPhase extends BattlePhase {
             TrainerSlot.NONE,
             !!globalScene.getEncounterBossSegments(battle.waveIndex, level, enemySpecies),
           );
-          if (globalScene.currentBattle.battleSpec === BattleSpec.FINAL_BOSS) {
+          if (globalScene.currentBattle.isClassicFinalBoss) {
             battle.enemyParty[e].ivs.fill(31);
           }
           globalScene
@@ -151,14 +151,7 @@ export class EncounterPhase extends BattlePhase {
       }
 
       if (enemyPokemon.species.speciesId === SpeciesId.ETERNATUS) {
-        if (
-          globalScene.gameMode.isClassic
-          && (battle.battleSpec === BattleSpec.FINAL_BOSS || globalScene.gameMode.isWaveFinal(battle.waveIndex))
-        ) {
-          if (battle.battleSpec !== BattleSpec.FINAL_BOSS) {
-            enemyPokemon.formIndex = 1;
-            enemyPokemon.updateScale();
-          }
+        if (battle.isClassicFinalBoss) {
           enemyPokemon.setBoss();
         } else if (!(battle.waveIndex % 1000)) {
           enemyPokemon.formIndex = 1;
@@ -327,7 +320,7 @@ export class EncounterPhase extends BattlePhase {
     }
   }
 
-  doEncounter() {
+  protected doEncounter(): void {
     globalScene.playBgm(undefined, true);
     globalScene.updateModifiers(false);
     globalScene.setFieldScale(1);
@@ -352,7 +345,9 @@ export class EncounterPhase extends BattlePhase {
       x: (_target, _key, value, fieldIndex: number) => (fieldIndex < 2 + enemyField.length ? value + 300 : value - 300),
       duration: 2000,
       onComplete: () => {
-        if (!this.tryOverrideForBattleSpec()) {
+        if (globalScene.currentBattle.isClassicFinalBoss) {
+          this.displayFinalBossDialogue();
+        } else {
           this.doEncounterCommon();
         }
       },
@@ -375,7 +370,7 @@ export class EncounterPhase extends BattlePhase {
   getEncounterMessage(): string {
     const enemyField = globalScene.getEnemyField();
 
-    if (globalScene.currentBattle.battleSpec === BattleSpec.FINAL_BOSS) {
+    if (globalScene.currentBattle.isClassicFinalBoss) {
       return i18next.t("battle:bossAppeared", {
         bossName: getPokemonNameWithAffix(enemyField[0]),
       });
@@ -605,53 +600,49 @@ export class EncounterPhase extends BattlePhase {
     globalScene.phaseManager.pushNew("InitEncounterPhase");
   }
 
-  tryOverrideForBattleSpec(): boolean {
-    switch (globalScene.currentBattle.battleSpec) {
-      case BattleSpec.FINAL_BOSS: {
-        const enemy = globalScene.getEnemyPokemon();
-        globalScene.ui.showText(
-          this.getEncounterMessage(),
-          null,
-          () => {
-            const localizationKey = "battleSpecDialogue:encounter";
-            if (globalScene.ui.shouldSkipDialogue(localizationKey)) {
-              // Logging mirrors logging found in dialogue-ui-handler
-              console.log(`Dialogue ${localizationKey} skipped`);
-              this.doEncounterCommon(false);
-            } else {
-              const count = 5643853 + globalScene.gameData.gameStats.classicSessionsPlayed;
-              // The line below checks if an English ordinal is necessary or not based on whether an entry for encounterLocalizationKey exists in the language or not.
-              const ordinalUsed =
-                !i18next.exists(localizationKey, { fallbackLng: [] }) || i18next.resolvedLanguage === "en"
-                  ? i18next.t("battleSpecDialogue:key", {
-                      count,
-                      ordinal: true,
-                    })
-                  : "";
-              const cycleCount = count.toLocaleString() + ordinalUsed;
-              const cycleCountNoOrdinal = count.toLocaleString();
-              const genderIndex = globalScene.gameData.gender ?? PlayerGender.UNSET;
-              const genderStr = PlayerGender[genderIndex].toLowerCase();
-              const encounterDialogue = i18next.t(localizationKey, {
-                context: genderStr,
-                cycleCount,
-                cycleCountNoOrdinal,
-              });
-              if (!globalScene.gameData.getSeenDialogues()[localizationKey]) {
-                globalScene.gameData.saveSeenDialogue(localizationKey);
-              }
-              globalScene.ui.showDialogue(encounterDialogue, enemy?.species.name, null, () => {
-                this.doEncounterCommon(false);
-              });
-            }
-          },
-          1500,
-          true,
-        );
-        return true;
-      }
-    }
-    return false;
+  protected displayFinalBossDialogue(): void {
+    const { gameData, ui } = globalScene;
+    const enemy = globalScene.getEnemyPokemon();
+
+    ui.showText(
+      this.getEncounterMessage(),
+      null,
+      () => {
+        const localizationKey = "battleSpecDialogue:encounter";
+        if (ui.shouldSkipDialogue(localizationKey)) {
+          // Logging mirrors logging found in dialogue-ui-handler
+          console.log(`Dialogue ${localizationKey} skipped`);
+          this.doEncounterCommon(false);
+        } else {
+          const count = 5643853 + gameData.gameStats.classicSessionsPlayed;
+          // The line below checks if an English ordinal is necessary or not based on whether an entry for encounterLocalizationKey exists in the language or not.
+          const ordinalUsed =
+            !i18next.exists(localizationKey, { fallbackLng: [] }) || i18next.resolvedLanguage === "en"
+              ? i18next.t("battleSpecDialogue:key", {
+                  count,
+                  ordinal: true,
+                })
+              : "";
+          const cycleCount = count.toLocaleString() + ordinalUsed;
+          const cycleCountNoOrdinal = count.toLocaleString();
+          const genderIndex = gameData.gender ?? PlayerGender.UNSET;
+          const genderStr = PlayerGender[genderIndex].toLowerCase();
+          const encounterDialogue = i18next.t(localizationKey, {
+            context: genderStr,
+            cycleCount,
+            cycleCountNoOrdinal,
+          });
+          if (!gameData.getSeenDialogues()[localizationKey]) {
+            gameData.saveSeenDialogue(localizationKey);
+          }
+          ui.showDialogue(encounterDialogue, enemy?.species.name, null, () => {
+            this.doEncounterCommon(false);
+          });
+        }
+      },
+      1500,
+      true,
+    );
   }
 
   /**

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -3,10 +3,9 @@ import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { FRIENDSHIP_LOSS_FROM_FAINT } from "#balance/starters";
 import { allMoves } from "#data/data-lists";
-import { battleSpecDialogue } from "#data/dialogue";
+import { classicFinalBossDialogue } from "#data/dialogue";
 import { SpeciesFormChangeActiveTrigger } from "#data/form-change-triggers";
 import { ArenaTagSide } from "#enums/arena-tag-side";
-import { BattleSpec } from "#enums/battle-spec";
 import { BattleType } from "#enums/battle-type";
 import type { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
@@ -26,13 +25,13 @@ export class FaintPhase extends PokemonPhase {
   /**
    * Whether or not instant revive should be prevented
    */
-  private preventInstantRevive: boolean;
+  private readonly preventInstantRevive: boolean;
 
   /**
    * The source Pokemon that dealt fatal damage; only present for faints triggered by a move.
    */
   // TODO: This should be handled by a move in flight object/similar
-  private source?: Pokemon | undefined;
+  private readonly source?: Pokemon | undefined;
 
   constructor(battlerIndex: BattlerIndex, preventInstantRevive = false, source?: Pokemon) {
     super(battlerIndex);
@@ -41,7 +40,7 @@ export class FaintPhase extends PokemonPhase {
     this.source = source;
   }
 
-  start() {
+  public override start(): void {
     super.start();
 
     const faintPokemon = this.getPokemon();
@@ -63,7 +62,8 @@ export class FaintPhase extends PokemonPhase {
       if (instantReviveModifier) {
         faintPokemon.loseHeldItem(instantReviveModifier);
         globalScene.updateModifiers(this.player);
-        return this.end();
+        this.end();
+        return;
       }
     }
 
@@ -79,12 +79,14 @@ export class FaintPhase extends PokemonPhase {
       }
     }
 
-    if (!this.tryOverrideForBattleSpec()) {
+    if (globalScene.currentBattle.isClassicFinalBoss && !this.player) {
+      this.handleFinalBossFaint();
+    } else {
       this.doFaint();
     }
   }
 
-  doFaint(): void {
+  private doFaint(): void {
     const pokemon = this.getPokemon();
 
     // Track total times pokemon have been KO'd for Last Respects/Supreme Overlord
@@ -220,28 +222,18 @@ export class FaintPhase extends PokemonPhase {
     });
   }
 
-  tryOverrideForBattleSpec(): boolean {
-    switch (globalScene.currentBattle.battleSpec) {
-      case BattleSpec.FINAL_BOSS:
-        if (!this.player) {
-          const enemy = this.getPokemon();
-          if (enemy.formIndex) {
-            globalScene.ui.showDialogue(
-              battleSpecDialogue[BattleSpec.FINAL_BOSS].secondStageWin,
-              enemy.species.name,
-              null,
-              () => this.doFaint(),
-            );
-          } else {
-            // Final boss' HP threshold has been bypassed; cancel faint and force check for 2nd phase
-            enemy.hp++;
-            globalScene.phaseManager.unshiftNew("DamageAnimPhase", enemy.getBattlerIndex(), 0, HitResult.INDIRECT);
-            this.end();
-          }
-          return true;
-        }
+  private handleFinalBossFaint(): void {
+    const { phaseManager, ui } = globalScene;
+    const enemy = this.getPokemon();
+
+    if (enemy.formIndex > 0) {
+      ui.showDialogue(classicFinalBossDialogue.secondStageWin, enemy.species.name, null, () => this.doFaint());
+      return;
     }
 
-    return false;
+    // Final boss' HP threshold has been bypassed; cancel faint and force check for 2nd phase
+    enemy.hp++;
+    phaseManager.unshiftNew("DamageAnimPhase", enemy.getBattlerIndex(), 0, HitResult.INDIRECT);
+    this.end();
   }
 }

--- a/src/phases/mystery-encounter-phases.ts
+++ b/src/phases/mystery-encounter-phases.ts
@@ -2,7 +2,6 @@ import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
 import { getCharVariantFromDialogue } from "#data/dialogue";
 import { ArenaTagSide } from "#enums/arena-tag-side";
-import { BattleSpec } from "#enums/battle-spec";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MysteryEncounterMode } from "#enums/mystery-encounter-mode";
@@ -297,7 +296,7 @@ export class MysteryEncounterBattlePhase extends Phase {
     const enemyField = globalScene.getEnemyField();
     const encounterMode = globalScene.currentBattle.mysteryEncounter!.encounterMode;
 
-    if (globalScene.currentBattle.battleSpec === BattleSpec.FINAL_BOSS) {
+    if (globalScene.currentBattle.isClassicFinalBoss) {
       return i18next.t("battle:bossAppeared", { bossName: enemyField[0].name });
     }
 

--- a/src/phases/new-biome-encounter-phase.ts
+++ b/src/phases/new-biome-encounter-phase.ts
@@ -5,7 +5,7 @@ import { EncounterPhase } from "#phases/encounter-phase";
 export class NewBiomeEncounterPhase extends EncounterPhase {
   public readonly phaseName = "NewBiomeEncounterPhase";
 
-  doEncounter(): void {
+  protected override doEncounter(): void {
     globalScene.playBgm(undefined, true);
 
     // Reset all battle and wave data, perform form changes, etc.
@@ -31,7 +31,9 @@ export class NewBiomeEncounterPhase extends EncounterPhase {
       x: "+=300",
       duration: 2000,
       onComplete: () => {
-        if (!this.tryOverrideForBattleSpec()) {
+        if (globalScene.currentBattle.isClassicFinalBoss) {
+          this.displayFinalBossDialogue();
+        } else {
           this.doEncounterCommon();
         }
       },

--- a/src/phases/next-encounter-phase.ts
+++ b/src/phases/next-encounter-phase.ts
@@ -8,7 +8,7 @@ import { EncounterPhase } from "#phases/encounter-phase";
 export class NextEncounterPhase extends EncounterPhase {
   public readonly phaseName = "NextEncounterPhase";
 
-  doEncounter(): void {
+  protected override doEncounter(): void {
     globalScene.playBgm(undefined, true);
 
     // Reset all player transient wave data/intel before starting a new wild encounter.
@@ -68,7 +68,9 @@ export class NextEncounterPhase extends EncounterPhase {
           globalScene.lastMysteryEncounter!.introVisuals = undefined;
         }
 
-        if (!this.tryOverrideForBattleSpec()) {
+        if (globalScene.currentBattle.isClassicFinalBoss) {
+          this.displayFinalBossDialogue();
+        } else {
           this.doEncounterCommon();
         }
       },

--- a/src/phases/post-turn-status-effect-phase.ts
+++ b/src/phases/post-turn-status-effect-phase.ts
@@ -3,7 +3,6 @@ import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { CommonBattleAnim } from "#data/battle-anims";
 import { getStatusEffectActivationText } from "#data/status-effect";
-import { BattleSpec } from "#enums/battle-spec";
 import type { BattlerIndex } from "#enums/battler-index";
 import { CommonAnim } from "#enums/move-anims-common";
 import { StatusEffect } from "#enums/status-effect";
@@ -63,7 +62,7 @@ export class PostTurnStatusEffectPhase extends PokemonPhase {
   }
 
   override end() {
-    if (globalScene.currentBattle.battleSpec === BattleSpec.FINAL_BOSS) {
+    if (globalScene.currentBattle.isClassicFinalBoss) {
       globalScene.initFinalBossPhaseTwo(this.getPokemon());
     } else {
       super.end();

--- a/src/phases/quiet-form-change-phase.ts
+++ b/src/phases/quiet-form-change-phase.ts
@@ -4,7 +4,6 @@ import { getPokemonNameWithAffix } from "#app/messages";
 import { getSpeciesFormChangeMessage } from "#data/form-change-triggers";
 import type { SpeciesFormChange } from "#data/pokemon-forms";
 import { getTypeRgb } from "#data/type";
-import { BattleSpec } from "#enums/battle-spec";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import type { Pokemon } from "#field/pokemon";
 import { BattlePhase } from "#phases/battle-phase";
@@ -21,6 +20,7 @@ export class QuietFormChangePhase extends BattlePhase {
   public readonly pokemon: Pokemon;
   protected readonly formChange: SpeciesFormChange;
   /** The Pokemon's prior name before changing forms. */
+  // TODO: remove? it's unused
   private preName: string;
 
   constructor(pokemon: Pokemon, formChange: SpeciesFormChange) {
@@ -203,7 +203,7 @@ export class QuietFormChangePhase extends BattlePhase {
     this.pokemon.removeTag(BattlerTagType.AUTOTOMIZED);
 
     // TODO: This eternatus boss fight code should almost certainly go in its own superclass phase
-    if (globalScene.currentBattle.battleSpec === BattleSpec.FINAL_BOSS && this.pokemon.isEnemy()) {
+    if (globalScene.currentBattle.isClassicFinalBoss && this.pokemon.isEnemy()) {
       globalScene.playBgm();
       globalScene.phaseManager.unshiftNew(
         "PokemonHealPhase",


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
It's unnecessary, and removing it allows for simplifying some code.

## What are the changes from a developer perspective?
`BattleSpec` enum and `Battle#initBattleSpec` deleted.

Added `Battle#isClassicFinalBoss` getter.

Various checks for `battleSpec === BattleSpec.FINAL_BOSS` replaced with checks for `.isClassicFinalBoss`

`EncounterPhase#tryOverrideForBattleSpec` renamed to `#displayFinalBossDialogue`

`FaintPhase#tryOverrideForBattleSpec` renamed to `#handleFinalBossFaint`

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually