### PR TITLE
feat(challenge): Randomized Mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start:prod": "vite --mode production",
     "start:beta": "vite --mode beta",
-    "start:dev": "__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=pkr.scooom.com vite --mode development",
+    "start:dev": "vite --mode development",
     "start:podman": "vite --mode development --host 0.0.0.0 --port $PORT",
     "build": "vite build",
     "build:beta": "vite build --mode beta",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start:prod": "vite --mode production",
     "start:beta": "vite --mode beta",
-    "start:dev": "vite --mode development",
+    "start:dev": "__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=pkr.scooom.com vite --mode development",
     "start:podman": "vite --mode development --host 0.0.0.0 --port $PORT",
     "build": "vite build",
     "build:beta": "vite build --mode beta",

--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -5,6 +5,7 @@ import { globalScene } from "#app/global-scene";
 import { defaultStarterSpeciesAndEvolutions } from "#balance/pokemon-evolutions";
 import { type StarterSpeciesId, speciesStarterCosts } from "#balance/starters";
 import type { PokemonSpecies } from "#data/pokemon-species";
+import { getRandomizerEntry } from "#data/randomizer-data";
 import { AbilityAttr } from "#enums/ability-attr";
 import { BattleType } from "#enums/battle-type";
 import { Challenges } from "#enums/challenges";
@@ -388,6 +389,15 @@ export abstract class Challenge {
    * @returns Whether this function did anything
    */
   applyPokemonAddToParty(pokemon: EnemyPokemon, isValid: BooleanHolder): boolean {
+    return false;
+  }
+
+  /**
+   * An apply function for POKEMON_RANDOMIZE. Derived classes should alter this.
+   * @param pokemon - The Pokémon to randomize
+   * @returns Whether this function did anything
+   */
+  applyPokemonRandomize(pokemon: Pokemon): boolean {
     return false;
   }
 
@@ -1232,6 +1242,36 @@ export class PassivesChallenge extends Challenge {
   }
 }
 
+export class RandomizeChallenge extends Challenge {
+  constructor() {
+    super(Challenges.RANDOMIZE, 1);
+  }
+
+  override applyStarterModify(pokemon: Pokemon): boolean {
+    return this.applyPokemonRandomize(pokemon);
+  }
+
+  override applyPokemonRandomize(pokemon: Pokemon): boolean {
+    if (pokemon.isBoss()) {
+      return false;
+    }
+    const entry = getRandomizerEntry(pokemon.species.speciesId);
+    if (!entry) {
+      return false;
+    }
+    pokemon.customPokemonData.ability = entry.ability;
+    pokemon.customPokemonData.types = entry.types.slice();
+    return true;
+  }
+
+  static override loadChallenge(source: RandomizeChallenge | any): RandomizeChallenge {
+    const newChallenge = new RandomizeChallenge();
+    newChallenge.value = source.value;
+    newChallenge.severity = source.severity;
+    return newChallenge;
+  }
+}
+
 /**
  * @param source - A challenge to copy, or an object of a challenge's properties. Missing values are treated as defaults.
  * @returns The challenge in question.
@@ -1260,6 +1300,8 @@ export function copyChallenge(source: Challenge | any): Challenge {
       return HardcoreChallenge.loadChallenge(source);
     case Challenges.PASSIVES:
       return PassivesChallenge.loadChallenge(source);
+    case Challenges.RANDOMIZE:
+      return RandomizeChallenge.loadChallenge(source);
   }
   throw new Error("Unknown challenge copied");
 }
@@ -1277,5 +1319,6 @@ export function initChallenges() {
     new PassivesChallenge(),
     new InverseBattleChallenge(),
     new FlipStatChallenge(),
+    new RandomizeChallenge(),
   );
 }

--- a/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
+++ b/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
@@ -80,7 +80,7 @@ export const ClowningAroundEncounter: MysteryEncounter = MysteryEncounterBuilder
   MysteryEncounterType.CLOWNING_AROUND,
 )
   .withEncounterTier(MysteryEncounterTier.ULTRA)
-  .withDisallowedChallenges(Challenges.SINGLE_TYPE)
+  .withDisallowedChallenges(Challenges.SINGLE_TYPE, Challenges.RANDOMIZE)
   .withSceneWaveRangeRequirement(80, CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES[1])
   .withAnimations(EncounterAnim.SMOKESCREEN)
   .withAutoHideIntroVisuals(false)

--- a/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
+++ b/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
@@ -126,7 +126,7 @@ export const WeirdDreamEncounter: MysteryEncounter = MysteryEncounterBuilder.wit
   MysteryEncounterType.WEIRD_DREAM,
 )
   .withEncounterTier(MysteryEncounterTier.ROGUE)
-  .withDisallowedChallenges(Challenges.SINGLE_TYPE, Challenges.SINGLE_GENERATION)
+  .withDisallowedChallenges(Challenges.SINGLE_TYPE, Challenges.SINGLE_GENERATION, Challenges.RANDOMIZE)
   .withSceneWaveRangeRequirement(30, 140)
   .withScenePartySizeRequirement(3, 6)
   .withMaxAllowedEncounters(1)

--- a/src/data/randomizer-data.ts
+++ b/src/data/randomizer-data.ts
@@ -1,0 +1,73 @@
+import { globalScene } from "#app/global-scene";
+import { allAbilities } from "#data/data-lists";
+import { AbilityId } from "#enums/ability-id";
+import { PokemonType } from "#enums/pokemon-type";
+import { SpeciesId } from "#enums/species-id";
+import { randSeedInt } from "#utils/common";
+import { getPokemonSpecies } from "#utils/pokemon-utils";
+
+const RANDOMIZER_SEED_OFFSET = 0x52414e44;
+
+export interface RandomizerEntry {
+  ability: AbilityId;
+  types: PokemonType[];
+}
+
+let randomizerMap: Map<number, RandomizerEntry> | null = null;
+
+const VALID_TYPES: PokemonType[] = (Object.values(PokemonType) as PokemonType[]).filter(
+  t => typeof t === "number" && t !== PokemonType.UNKNOWN && t !== PokemonType.STELLAR,
+);
+
+function buildValidAbilityPool(): AbilityId[] {
+  return allAbilities.filter(a => a.id !== AbilityId.NONE && !a.unimplemented).map(a => a.id);
+}
+
+function randomType(exclude?: PokemonType): PokemonType {
+  const pool = exclude !== undefined ? VALID_TYPES.filter(t => t !== exclude) : VALID_TYPES;
+  return pool[randSeedInt(pool.length)];
+}
+
+export function generateRandomizerMap(): void {
+  const abilityPool = buildValidAbilityPool();
+
+  globalScene.executeWithSeedOffset(() => {
+    const map = new Map<number, RandomizerEntry>();
+
+    for (const value of Object.values(SpeciesId)) {
+      if (typeof value !== "number") {
+        continue;
+      }
+      const speciesId = value as SpeciesId;
+      const species = getPokemonSpecies(speciesId);
+      if (!species) {
+        continue;
+      }
+
+      const ability = abilityPool[randSeedInt(abilityPool.length)];
+      const type1 = randomType();
+      const isDual = species.type2 !== null && species.type2 !== PokemonType.UNKNOWN;
+
+      let types: PokemonType[];
+      if (isDual) {
+        types = [type1, randomType(type1)];
+      } else if (randSeedInt(3) === 0) {
+        types = [type1, randomType(type1)];
+      } else {
+        types = [type1];
+      }
+
+      map.set(speciesId, { ability, types });
+    }
+
+    randomizerMap = map;
+  }, RANDOMIZER_SEED_OFFSET);
+}
+
+export function getRandomizerEntry(speciesId: number): RandomizerEntry | undefined {
+  return randomizerMap?.get(speciesId);
+}
+
+export function clearRandomizerMap(): void {
+  randomizerMap = null;
+}

--- a/src/data/randomizer-data.ts
+++ b/src/data/randomizer-data.ts
@@ -24,7 +24,7 @@ function buildValidAbilityPool(): AbilityId[] {
 }
 
 function randomType(exclude?: PokemonType): PokemonType {
-  const pool = exclude !== undefined ? VALID_TYPES.filter(t => t !== exclude) : VALID_TYPES;
+  const pool = exclude === undefined ? VALID_TYPES : VALID_TYPES.filter(t => t !== exclude);
   return pool[randSeedInt(pool.length)];
 }
 

--- a/src/enums/challenge-type.ts
+++ b/src/enums/challenge-type.ts
@@ -111,4 +111,9 @@ export enum ChallengeType {
    * @see {@linkcode Challenge.applyPermanentFaint}
    */
   PREVENT_REVIVE,
+  /**
+   * Applies randomized ability and types to a pokemon
+   * @see {@linkcode Challenge.applyPokemonRandomize}
+   */
+  POKEMON_RANDOMIZE,
 }

--- a/src/enums/challenges.ts
+++ b/src/enums/challenges.ts
@@ -10,4 +10,5 @@ export enum Challenges {
   LIMITED_SUPPORT,
   HARDCORE,
   PASSIVES,
+  RANDOMIZE,
 }

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -4,6 +4,7 @@ import { signatureSpecies } from "#balance/signature-species";
 import { EntryHazardTag } from "#data/arena-tag";
 import type { PokemonSpecies } from "#data/pokemon-species";
 import { ArenaTagSide } from "#enums/arena-tag-side";
+import { ChallengeType } from "#enums/challenge-type";
 import { PartyMemberStrength } from "#enums/party-member-strength";
 import { SpeciesId } from "#enums/species-id";
 import { TeraAIMode } from "#enums/tera-ai-mode";
@@ -16,6 +17,7 @@ import type { PersistentModifier } from "#modifiers/modifier";
 import type { TrainerConfig } from "#trainers/trainer-config";
 import { trainerConfigs } from "#trainers/trainer-config";
 import { TrainerPartyCompoundTemplate, type TrainerPartyTemplate } from "#trainers/trainer-party-template";
+import { applyChallenges } from "#utils/challenge-utils";
 import { randSeedInt, randSeedItem } from "#utils/common";
 import { getRandomLocaleEntry } from "#utils/i18n";
 import { getPokemonSpecies } from "#utils/pokemon-utils";
@@ -432,6 +434,7 @@ export class Trainer extends Phaser.GameObjects.Container {
           level,
           !this.isDouble() || !(index % 2) ? TrainerSlot.TRAINER : TrainerSlot.TRAINER_PARTNER,
         );
+        applyChallenges(ChallengeType.POKEMON_RANDOMIZE, ret);
       },
       this.config.hasStaticParty
         ? this.config.getDerivedType() + ((index + 1) << 8)

--- a/src/phases/attempt-capture-phase.ts
+++ b/src/phases/attempt-capture-phase.ts
@@ -313,6 +313,7 @@ export class AttemptCapturePhase extends PokemonPhase {
             end();
             return;
           }
+          applyChallenges(ChallengeType.POKEMON_RANDOMIZE, pokemon);
           if (globalScene.getPlayerParty().length === PLAYER_PARTY_MAX_SIZE) {
             const promptRelease = () => {
               globalScene.ui.showText(

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -11,6 +11,7 @@ import { BattleSpec } from "#enums/battle-spec";
 import { BattleType } from "#enums/battle-type";
 import { BattlerIndex } from "#enums/battler-index";
 import { BiomeId } from "#enums/biome-id";
+import { ChallengeType } from "#enums/challenge-type";
 import { FieldPosition } from "#enums/field-position";
 import { ModifierPoolType } from "#enums/modifier-pool-type";
 import { MysteryEncounterMode } from "#enums/mystery-encounter-mode";
@@ -33,6 +34,7 @@ import { doTrainerExclamation } from "#mystery-encounters/encounter-phase-utils"
 import { getGoldenBugNetSpecies } from "#mystery-encounters/encounter-pokemon-utils";
 import { BattlePhase } from "#phases/battle-phase";
 import { achvs } from "#system/achv";
+import { applyChallenges } from "#utils/challenge-utils";
 import { randSeedInt, randSeedItem } from "#utils/common";
 import i18next from "i18next";
 
@@ -123,6 +125,7 @@ export class EncounterPhase extends BattlePhase {
             TrainerSlot.NONE,
             !!globalScene.getEncounterBossSegments(battle.waveIndex, level, enemySpecies),
           );
+          applyChallenges(ChallengeType.POKEMON_RANDOMIZE, battle.enemyParty[e]);
           if (globalScene.currentBattle.battleSpec === BattleSpec.FINAL_BOSS) {
             battle.enemyParty[e].ivs.fill(31);
           }

--- a/src/phases/select-starter-phase.ts
+++ b/src/phases/select-starter-phase.ts
@@ -3,7 +3,9 @@ import Overrides from "#app/overrides";
 import { Phase } from "#app/phase";
 import { SpeciesFormChangeMoveLearnedTrigger } from "#data/form-change-triggers";
 import { Gender } from "#data/gender";
+import { generateRandomizerMap } from "#data/randomizer-data";
 import { ChallengeType } from "#enums/challenge-type";
+import { Challenges } from "#enums/challenges";
 import { UiMode } from "#enums/ui-mode";
 import { overrideHeldItems, overrideModifiers } from "#modifiers/modifier";
 import type { Starter } from "#types/save-data";
@@ -41,6 +43,9 @@ export class SelectStarterPhase extends Phase {
   initBattle(starters: Starter[]) {
     const party = globalScene.getPlayerParty();
     const loadPokemonAssets: Promise<void>[] = [];
+    if (globalScene.gameMode.challenges.some(c => c.id === Challenges.RANDOMIZE && c.value > 0)) {
+      generateRandomizerMap();
+    }
     starters.forEach((starter: Starter, i: number) => {
       if (!i && Overrides.STARTER_SPECIES_OVERRIDE) {
         starter.speciesId = Overrides.STARTER_SPECIES_OVERRIDE;

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -17,10 +17,12 @@ import type { Egg } from "#data/egg";
 import { pokemonFormChanges } from "#data/pokemon-forms";
 import type { PokemonSpecies } from "#data/pokemon-species";
 import { loadPositionalTag } from "#data/positional-tags/load-positional-tag";
+import { generateRandomizerMap } from "#data/randomizer-data";
 import { TerrainType } from "#data/terrain";
 import { AbilityAttr } from "#enums/ability-attr";
 import { BattleType } from "#enums/battle-type";
 import { ChallengeType } from "#enums/challenge-type";
+import { Challenges } from "#enums/challenges";
 import { Device } from "#enums/devices";
 import { DexAttr } from "#enums/dex-attr";
 import { GameDataType } from "#enums/game-data-type";
@@ -935,6 +937,10 @@ export class GameData {
     globalScene.resetSeed();
 
     console.log("Seed:", globalScene.seed);
+
+    if (globalScene.gameMode.challenges.some(c => c.id === Challenges.RANDOMIZE && c.value > 0)) {
+      generateRandomizerMap();
+    }
 
     globalScene.gameMode.trySetCustomDailyConfig(JSON.stringify(fromSession.dailyConfig));
 

--- a/src/utils/challenge-utils.ts
+++ b/src/utils/challenge-utils.ts
@@ -270,6 +270,14 @@ export function applyChallenges(
  */
 export function applyChallenges(challengeType: ChallengeType.PREVENT_REVIVE, status: BooleanHolder): boolean;
 
+/**
+ * Apply all challenges that randomize a pokemon's ability and types
+ * @param challengeType - {@linkcode ChallengeType.POKEMON_RANDOMIZE}
+ * @param pokemon - The pokemon to randomize
+ * @returns `true` if any challenge was successfully applied, `false` otherwise
+ */
+export function applyChallenges(challengeType: ChallengeType.POKEMON_RANDOMIZE, pokemon: Pokemon): boolean;
+
 export function applyChallenges(challengeType: ChallengeType, ...args: any[]): boolean {
   let ret = false;
   globalScene.gameMode.challenges.forEach(c => {
@@ -343,6 +351,9 @@ export function applyChallenges(challengeType: ChallengeType, ...args: any[]): b
           break;
         case ChallengeType.PREVENT_REVIVE:
           ret ||= c.applyPreventRevive(args[0]);
+          break;
+        case ChallengeType.POKEMON_RANDOMIZE:
+          ret ||= c.applyPokemonRandomize(args[0]);
           break;
       }
     }


### PR DESCRIPTION
## What are the changes the user will see?
New Randomizer Challenge Mode

What it does:
 - Randomized the typings of all pokemon based on a seed offset
  - Mono type pokemon have a 1/3rd chance to gain a random secondary typing
 - Randomize all abilities, but do not randomize passives
  - Boss pokemon do not randomize their abilities in order to keep synergy with their passives (?)
 
<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
To quote [7023](https://github.com/pagefaultgames/pokerogue/pull/7023):
> Randomizer challenges are popular and desired.



## What are the changes from a developer perspective?
 - New challenge type `RandomizeChallenge`
 - Updates `Clowning Around` and `Weird Dream` to disable them in `Challenges.RANDOMIZE`
 - `src/data/randomizer-data.ts` generates a Map containing the replacements using `executeWithSeedOffset`
 - run `applyChallenges` in various relevant sections


TODO:
 - Disable dex data updates (?)
 - Biome Map Randomization
 - Disable achievement voucher unlocks (?)

## Screenshots/Videos

<details>

<img width="915" height="347" alt="image" src="https://github.com/user-attachments/assets/879e0dcf-952d-4669-b6bf-18c260dd6865" />
<img width="1014" height="302" alt="image" src="https://github.com/user-attachments/assets/d750723d-8498-4983-8b57-23033519c1e3" />


</details>

## How to test the changes?
Make a new run using the new challenge. 

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [ ] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: _____
- [ ] I have contacted the Translation Team on Discord for proofreading/translation

Does this require any additions or changes to in-game assets? If so:
- [ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: _____
