### PR TITLE
refactor: rework `HeldItem` into an attribute based system

### DIFF
--- a/scripts/create-test/boilerplates/item.boilerplate.ts
+++ b/scripts/create-test/boilerplates/item.boilerplate.ts
@@ -32,7 +32,8 @@ describe("{{description}}", () => {
       .startingLevel(100)
       .enemyLevel(100);
 
-    vi.spyOn(allHeldItems[HeldItemId.WIDE_LENS], "shouldApply");
+    // replace with actual item ID in question
+    vi.spyOn(allHeldItems[HeldItemId.WIDE_LENS], "apply");
   });
 
   it("should do XYZ when applied", async () => {
@@ -58,6 +59,7 @@ describe("{{description}}", () => {
 
     feebas.heldItemManager.add(HeldItemId.WIDE_LENS);
 
+    // replace with actual logic for triggering the item
     game.move.use(MoveId.TACKLE);
     await game.phaseInterceptor.to("MoveEffectPhase");
 

--- a/src/@types/common.ts
+++ b/src/@types/common.ts
@@ -7,11 +7,13 @@ export type { Constructor } from "type-fest";
 export type nil = null | undefined;
 
 /**
- * This removes the `| undefined` from `Map#get`'s return type.
+ * A Map that is known to have keys for every key that it can possibly have, and is thus guaranteed
+ * to always return a proper value instead of `undefined`.
  * @remarks
  * Used for maps where we know the entire structure at compile time
  * (but may sometimes only technically be populated at runtime).
  */
+// TODO: Move this to another file
 export interface DataMap<K, V> extends Map<K, V> {
   get(key: K): V;
 }

--- a/src/@types/held-item-data-types.ts
+++ b/src/@types/held-item-data-types.ts
@@ -1,9 +1,13 @@
+import type { HeldItemEffect } from "#enums/held-item-effect";
 import { type HeldItemCategoryId, HeldItemId } from "#enums/held-item-id";
 import type { RarityTier } from "#enums/reward-tier";
 import type { Pokemon } from "#field/pokemon";
 import type { AllHeldItems } from "#items/all-held-items";
-import type { CosmeticHeldItem } from "#items/held-item";
+import type { CosmeticHeldItem, HeldItem } from "#items/held-item";
 import type { InferKeys } from "#types/type-helpers";
+
+// TODO: This file is less of a _data_ types file and more of an _everything_ types file;
+// we should rename it to clarify that intent
 
 export interface HeldItemData {
   /**
@@ -98,10 +102,15 @@ type CosmeticHeldItemId = InferKeys<AllHeldItems, CosmeticHeldItem>;
 /** Union type of all `HeldItemId`s whose corresponding items can be applied. */
 export type ApplicableHeldItemId = Exclude<keyof AllHeldItems, CosmeticHeldItemId>;
 
+/** Utility type to retrieve the effects of a given {@linkcode HeldItem} based on its ID. */
+export type ExtractItemEffect<T extends ApplicableHeldItemId> =
+  AllHeldItems[T] extends HeldItem<infer Effects extends HeldItemEffect> ? Effects : never;
+
 /**
  * Dummy, TypeScript-only type to ensure that {@linkcode HeldItemId} and {@linkcode HeldItemCategoryId}
  * have 0 overlap between allowed IDs.
  *
  * ⚠️ Does not actually exist at runtime, so it must not be used!
  */
+// TODO: Fix this and other "dummy" types to actually work - the intersection with never makes this actively useless
 declare const EnsureHeldItemIDsAreDisjointFromCategories: (HeldItemId & HeldItemCategoryEntry) & never;

--- a/src/@types/held-item-data-types.ts
+++ b/src/@types/held-item-data-types.ts
@@ -1,9 +1,9 @@
-import type { HeldItemEffect } from "#enums/held-item-effect";
 import { type HeldItemCategoryId, HeldItemId } from "#enums/held-item-id";
 import type { RarityTier } from "#enums/reward-tier";
 import type { Pokemon } from "#field/pokemon";
 import type { AllHeldItems } from "#items/all-held-items";
 import type { CosmeticHeldItem, HeldItem } from "#items/held-item";
+import type { HeldItemAttr } from "#items/held-item-attr";
 import type { InferKeys } from "#types/type-helpers";
 
 // TODO: This file is less of a _data_ types file and more of an _everything_ types file;
@@ -45,6 +45,7 @@ export function isHeldItemSpecs(entry: unknown): entry is HeldItemSpecs {
   );
 }
 
+// TODO: Make this generic on a subset of `HeldItemId`
 export type HeldItemWeights = Partial<Record<HeldItemId, number>>;
 
 // TODO: Inline this into the sole place it is used
@@ -104,7 +105,7 @@ export type ApplicableHeldItemId = Exclude<keyof AllHeldItems, CosmeticHeldItemI
 
 /** Utility type to retrieve the effects of a given {@linkcode HeldItem} based on its ID. */
 export type ExtractItemEffect<T extends ApplicableHeldItemId> =
-  AllHeldItems[T] extends HeldItem<infer Effects extends HeldItemEffect> ? Effects : never;
+  AllHeldItems[T] extends HeldItem<infer Attr extends HeldItemAttr> ? Attr["effect"] : never;
 
 /**
  * Dummy, TypeScript-only type to ensure that {@linkcode HeldItemId} and {@linkcode HeldItemCategoryId}

--- a/src/@types/held-item-parameter.ts
+++ b/src/@types/held-item-parameter.ts
@@ -5,6 +5,8 @@ import type { Stat } from "#enums/stat";
 import type { Pokemon } from "#field/pokemon";
 import type { BooleanHolder, NumberHolder } from "#utils/common";
 
+// TODO: Make all these readonly
+
 /** Base interface for all held item parameter types. */
 export interface DefaultHeldItemParams {
   /** The pokemon with the item */

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2785,6 +2785,7 @@ export class BattleScene extends SceneBase {
     if (!ignoreUpdate) {
       this.updateItems(pokemon.isPlayer());
     }
+    // TODO: Held items don't have sound names...?
     const soundName = allHeldItems[heldItemId].soundName;
     if (playSound && !this.sound.get(soundName)) {
       this.playSound(soundName);

--- a/src/data/abilities/ab-attrs.ts
+++ b/src/data/abilities/ab-attrs.ts
@@ -41,7 +41,7 @@ import { SwitchType } from "#enums/switch-type";
 import { WeatherType } from "#enums/weather-type";
 import { BerryUsedEvent } from "#events/battle-scene";
 import type { EnemyPokemon, Pokemon } from "#field/pokemon";
-import { type BerryHeldItem, berryTypeToHeldItem } from "#items/berry";
+import { type BerryHeldItemAttr, berryTypeToHeldItem } from "#items/berry";
 import { getMoveTargets } from "#moves/move-utils";
 import { PokemonMove } from "#moves/pokemon-move";
 import type { MoveReflectPhase } from "#phases/move-reflect-phase";
@@ -4114,7 +4114,7 @@ export class PostTurnRestoreBerryAbAttr extends PostTurnAbAttr {
             isItemInCategory(bm, HeldItemCategoryId.BERRY)
             && pokemon.heldItemManager.getStack(bm) < allHeldItems[bm].maxStackCount,
         )
-        .map(bm => (allHeldItems[bm] as BerryHeldItem).berryType),
+        .map(bm => (allHeldItems[bm] as BerryHeldItemAttr).berryType),
     );
 
     this.berriesUnderCap = pokemon.battleData.berriesEaten.filter(bt => !cappedBerries.has(bt));

--- a/src/data/abilities/ab-attrs.ts
+++ b/src/data/abilities/ab-attrs.ts
@@ -21,6 +21,7 @@ import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import type { BerryType } from "#enums/berry-type";
 import { Command } from "#enums/command";
+import { HeldItemEffect } from "#enums/held-item-effect";
 import { HeldItemCategoryId, HeldItemId, isItemInCategory } from "#enums/held-item-id";
 import { HitResult } from "#enums/hit-result";
 import { CommonAnim } from "#enums/move-anims-common";
@@ -41,6 +42,7 @@ import { SwitchType } from "#enums/switch-type";
 import { WeatherType } from "#enums/weather-type";
 import { BerryUsedEvent } from "#events/battle-scene";
 import type { EnemyPokemon, Pokemon } from "#field/pokemon";
+import type { BerryItemId } from "#items/all-held-items";
 import { type BerryHeldItemAttr, berryTypeToHeldItem } from "#items/berry";
 import { getMoveTargets } from "#moves/move-utils";
 import { PokemonMove } from "#moves/pokemon-move";
@@ -4107,14 +4109,15 @@ export class PostTurnRestoreBerryAbAttr extends PostTurnAbAttr {
   override canApply({ pokemon }: AbAttrBaseParams): boolean {
     // Ensure we have at least 1 recoverable berry (at least 1 berry in berriesEaten is not capped)
     const cappedBerries = new Set(
-      pokemon
-        .getHeldItems()
-        .filter(
-          bm =>
-            isItemInCategory(bm, HeldItemCategoryId.BERRY)
-            && pokemon.heldItemManager.getStack(bm) < allHeldItems[bm].maxStackCount,
-        )
-        .map(bm => (allHeldItems[bm] as BerryHeldItemAttr).berryType),
+      (
+        pokemon
+          .getHeldItems()
+          .filter(
+            bm =>
+              isItemInCategory(bm, HeldItemCategoryId.BERRY)
+              && pokemon.heldItemManager.getStack(bm) < allHeldItems[bm].maxStackCount,
+          ) as BerryItemId[]
+      ).map(bm => (allHeldItems[bm].getAttrs(HeldItemEffect.BERRY)[0] as BerryHeldItemAttr).berryType),
     );
 
     this.berriesUnderCap = pokemon.battleData.berriesEaten.filter(bt => !cappedBerries.has(bt));

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -70,6 +70,7 @@ import { TrainerItemEffect } from "#enums/trainer-item-effect";
 import { WeatherType } from "#enums/weather-type";
 import { MoveUsedEvent } from "#events/battle-scene";
 import type { EnemyPokemon, Pokemon } from "#field/pokemon";
+import type { BerryItemId } from "#items/all-held-items";
 import { type BerryHeldItemAttr, berryTypeToHeldItem } from "#items/berry";
 import { applyMoveAttrs } from "#moves/apply-attrs";
 import {
@@ -3326,7 +3327,7 @@ export class RemoveHeldItemAttr extends MoveEffectAttr {
  * Attribute that causes targets of the move to eat a berry. Used for Teatime, Stuff Cheeks
  */
 export class EatBerryAttr extends MoveEffectAttr {
-  protected chosenBerry: HeldItemId;
+  protected chosenBerry: BerryItemId;
 
   /**
    * Causes the target to eat a berry.
@@ -3368,8 +3369,8 @@ export class EatBerryAttr extends MoveEffectAttr {
     globalScene.updateItems(target.isPlayer());
   }
 
-  protected getTargetHeldBerries(target: Pokemon): HeldItemId[] {
-    return target.getHeldItems().filter(m => isItemInCategory(m, HeldItemCategoryId.BERRY));
+  protected getTargetHeldBerries(target: Pokemon): BerryItemId[] {
+    return target.getHeldItems().filter(m => isItemInCategory(m, HeldItemCategoryId.BERRY)) as BerryItemId[];
   }
 
   /**
@@ -3382,10 +3383,13 @@ export class EatBerryAttr extends MoveEffectAttr {
    */
   protected eatBerry(consumer: Pokemon, berryOwner: Pokemon = consumer, updateHarvest = consumer === berryOwner) {
     // consumer eats berry, owner triggers unburden and similar effects
-    getBerryEffectFunc((allHeldItems[this.chosenBerry] as BerryHeldItemAttr).berryType)(consumer);
+    // TODO: This really should be accomplished by applying the berry with a parameter to customize its consumption
+    const berryType = (allHeldItems[this.chosenBerry].getAttrs(HeldItemEffect.BERRY) as BerryHeldItemAttr[])[0]
+      .berryType;
+    getBerryEffectFunc(berryType)(consumer);
     applyAbAttrs("PostItemLostAbAttr", { pokemon: berryOwner });
     applyAbAttrs("HealFromBerryUseAbAttr", { pokemon: consumer });
-    consumer.recordEatenBerry((allHeldItems[this.chosenBerry] as BerryHeldItemAttr).berryType, updateHarvest);
+    consumer.recordEatenBerry(berryType, updateHarvest);
   }
 }
 

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -3383,9 +3383,9 @@ export class EatBerryAttr extends MoveEffectAttr {
    */
   protected eatBerry(consumer: Pokemon, berryOwner: Pokemon = consumer, updateHarvest = consumer === berryOwner) {
     // consumer eats berry, owner triggers unburden and similar effects
-    // TODO: This really should be accomplished by applying the berry with a parameter to customize its consumption
-    const berryType = (allHeldItems[this.chosenBerry].getAttrs(HeldItemEffect.BERRY) as BerryHeldItemAttr[])[0]
-      .berryType;
+    // TODO: This would ideally be accomplished by applying the berry with a parameter to customize its consumption procedure
+    // (rather than breaking encapsulation and doing it manually)
+    const { berryType } = allHeldItems[this.chosenBerry].getAttrs(HeldItemEffect.BERRY)[0] as BerryHeldItemAttr;
     getBerryEffectFunc(berryType)(consumer);
     applyAbAttrs("PostItemLostAbAttr", { pokemon: berryOwner });
     applyAbAttrs("HealFromBerryUseAbAttr", { pokemon: consumer });

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -70,7 +70,7 @@ import { TrainerItemEffect } from "#enums/trainer-item-effect";
 import { WeatherType } from "#enums/weather-type";
 import { MoveUsedEvent } from "#events/battle-scene";
 import type { EnemyPokemon, Pokemon } from "#field/pokemon";
-import { type BerryHeldItem, berryTypeToHeldItem } from "#items/berry";
+import { type BerryHeldItemAttr, berryTypeToHeldItem } from "#items/berry";
 import { applyMoveAttrs } from "#moves/apply-attrs";
 import {
   invalidAssistMoves,
@@ -3382,10 +3382,10 @@ export class EatBerryAttr extends MoveEffectAttr {
    */
   protected eatBerry(consumer: Pokemon, berryOwner: Pokemon = consumer, updateHarvest = consumer === berryOwner) {
     // consumer eats berry, owner triggers unburden and similar effects
-    getBerryEffectFunc((allHeldItems[this.chosenBerry] as BerryHeldItem).berryType)(consumer);
+    getBerryEffectFunc((allHeldItems[this.chosenBerry] as BerryHeldItemAttr).berryType)(consumer);
     applyAbAttrs("PostItemLostAbAttr", { pokemon: berryOwner });
     applyAbAttrs("HealFromBerryUseAbAttr", { pokemon: consumer });
-    consumer.recordEatenBerry((allHeldItems[this.chosenBerry] as BerryHeldItem).berryType, updateHarvest);
+    consumer.recordEatenBerry((allHeldItems[this.chosenBerry] as BerryHeldItemAttr).berryType, updateHarvest);
   }
 }
 

--- a/src/enums/held-item-effect.ts
+++ b/src/enums/held-item-effect.ts
@@ -35,3 +35,10 @@ export const HeldItemEffect = {
 } as const;
 
 export type HeldItemEffect = ObjectValues<typeof HeldItemEffect>;
+
+/**
+ * Type matching held item effects to their names.
+ */
+export type HeldItemEffectNames = {
+  [k in keyof typeof HeldItemEffect as (typeof HeldItemEffect)[k]]: k;
+};

--- a/src/enums/held-item-id.ts
+++ b/src/enums/held-item-id.ts
@@ -147,6 +147,7 @@ export function isCategoryId(id: number): id is HeldItemCategoryId {
   return Object.values<number>(HeldItemCategoryId).includes(id);
 }
 
+// TODO: Can we make this a type predicate?
 export function isItemInCategory(itemId: HeldItemId, category: HeldItemCategoryId): boolean {
   return getHeldItemCategory(itemId) === category;
 }

--- a/src/items/all-held-items.ts
+++ b/src/items/all-held-items.ts
@@ -6,38 +6,40 @@
 import { allHeldItems } from "#data/data-lists";
 import { BerryType } from "#enums/berry-type";
 import { FormChangeItemId } from "#enums/form-change-item-id";
-import { HeldItemId } from "#enums/held-item-id";
+import type { HeldItemEffect } from "#enums/held-item-effect";
+import { HeldItemId, HeldItemNames } from "#enums/held-item-id";
 import { PokemonType } from "#enums/pokemon-type";
 import { SpeciesId } from "#enums/species-id";
 import { PERMANENT_STATS, Stat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
-import { AccuracyBoosterHeldItem } from "#items/accuracy-booster";
-import { AttackTypeBoosterHeldItem, attackTypeToHeldItem } from "#items/attack-type-booster";
-import { OldGateauHeldItem, ShuckleJuiceHeldItem } from "#items/base-stat-add";
-import { BaseStatMultiplyHeldItem, permanentStatToHeldItem } from "#items/base-stat-multiply";
-import { BatonHeldItem } from "#items/baton";
-import { BerryHeldItem, berryTypeToHeldItem } from "#items/berry";
-import { BypassSpeedChanceHeldItem } from "#items/bypass-speed-chance";
-import { CritBoostHeldItem, SpeciesCritBoostHeldItem } from "#items/crit-booster";
-import { DamageMoneyRewardHeldItem } from "#items/damage-money-reward";
+import { AccuracyBoosterHeldItemAttr } from "#items/accuracy-booster";
+import { AttackTypeBoostHeldItemAttr, attackTypeToHeldItem } from "#items/attack-type-booster";
+import { OldGateauHeldItemAttr, ShuckleJuiceHeldItemAttr } from "#items/base-stat-add";
+import { BaseStatMultiplyHeldItemAttr, permanentStatToHeldItem } from "#items/base-stat-multiply";
+import { BatonHeldItemAttr } from "#items/baton";
+import { BerryHeldItemAttr, berryTypeToHeldItem } from "#items/berry";
+import { BypassSpeedChanceHeldItemAttr } from "#items/bypass-speed-chance";
+import { CritBoostHeldItemAttr, SpeciesCritBoostHeldItemAttr } from "#items/crit-booster";
+import { DamageMoneyRewardHeldItemAttr } from "#items/damage-money-reward";
 import { GimmighoulEvoTrackerHeldItem } from "#items/evo-tracker";
-import { ExpBoosterHeldItem } from "#items/exp-booster";
-import { FieldEffectHeldItem } from "#items/field-effect";
-import { FlinchChanceHeldItem } from "#items/flinch-chance";
+import { ExpBoosterHeldItemAttr } from "#items/exp-booster";
+import { FieldEffectHeldItemAttr } from "#items/field-effect";
+import { FlinchChanceHeldItemAttr } from "#items/flinch-chance";
 import { FormChangeHeldItem } from "#items/form-change-item";
-import { FriendshipBoosterHeldItem } from "#items/friendship-booster";
+import { FriendshipBoosterHeldItemAttr } from "#items/friendship-booster";
 import type { CosmeticHeldItem, HeldItem } from "#items/held-item";
-import { HitHealHeldItem } from "#items/hit-heal";
-import { InstantReviveHeldItem } from "#items/instant-revive";
-import { ContactItemStealChanceHeldItem, TurnEndItemStealHeldItem } from "#items/item-steal";
-import { MachoBraceHeldItem } from "#items/macho-brace";
-import { MultiHitHeldItem } from "#items/multi-hit";
-import { NatureWeightBoosterHeldItem } from "#items/nature-weight-booster";
-import { ResetNegativeStatStageHeldItem } from "#items/reset-negative-stat-stage";
-import { EvolutionStatBoostHeldItem, SpeciesStatBoostHeldItem } from "#items/stat-boost";
-import { SurviveChanceHeldItem } from "#items/survive-chance";
-import { TurnEndHealHeldItem } from "#items/turn-end-heal";
-import { TurnEndStatusHeldItem } from "#items/turn-end-status";
+import { HeldItemBuilder } from "#items/held-item-builder";
+import { HitHealHeldItemAttr } from "#items/hit-heal";
+import { InstantReviveHeldItemAttr } from "#items/instant-revive";
+import { ContactItemStealChanceHeldItemAttr, TurnEndItemStealHeldItemAttr } from "#items/item-steal";
+import { MachoBraceHeldItemAttr } from "#items/macho-brace";
+import { MultiHitCountHeldItemAttr } from "#items/multi-hit";
+import { NatureWeightBoosterHeldItemAttr } from "#items/nature-weight-booster";
+import { ResetNegativeStatStageHeldItemAttr } from "#items/reset-negative-stat-stage";
+import { EvolutionStatBoostHeldItemAttr, SpeciesStatBoostHeldItemAttr } from "#items/stat-boost";
+import { SurviveChanceHeldItemAttr } from "#items/survive-chance";
+import { TurnEndHealHeldItemAttr } from "#items/turn-end-heal";
+import { TurnEndStatusHeldItemAttr } from "#items/turn-end-status";
 import { getEnumValues } from "#utils/enums";
 
 // #region Types
@@ -94,10 +96,12 @@ const berryItems = getEnumValues(BerryType).reduce(
     const maxStackCount = twoStackBerryTypes.includes(berry) ? 2 : 3;
     const berryId = berryTypeToHeldItem[berry];
     berryId satisfies BerryItemId;
-    ret[berryId] = new BerryHeldItem(berry, maxStackCount);
+    ret[berryId] = new HeldItemBuilder(berryId, maxStackCount) //
+      .attr(BerryHeldItemAttr, berry)
+      .build();
     return ret;
   },
-  {} as Record<BerryItemId, BerryHeldItem>,
+  {} as Record<BerryItemId, HeldItem<typeof HeldItemEffect.BERRY>>,
 );
 //#endregion Berries
 
@@ -106,12 +110,17 @@ const typeBoostHeldItems = (
   getEnumValues(PokemonType).slice(1, -1) as Exclude<PokemonType, PokemonType.UNKNOWN | PokemonType.STELLAR>[]
 ).reduce(
   (ret, type) => {
-    const id = attackTypeToHeldItem[type];
-    id satisfies TypeBoostItemId;
-    ret[id] = new AttackTypeBoosterHeldItem(id, 99, type, 0.2).unstealable().untransferable().unsuppressable();
+    const id = attackTypeToHeldItem[type] satisfies TypeBoostItemId;
+    ret[id] = new HeldItemBuilder(id, 99)
+      .attr(AttackTypeBoostHeldItemAttr, type, 0.2)
+      .unstealable()
+      .untransferable()
+      .unsuppressable()
+      .name(`modifierType:AttackTypeBoosterItem.${HeldItemNames[type].toLowerCase()}`)
+      .build();
     return ret;
   },
-  {} as Record<TypeBoostItemId, AttackTypeBoosterHeldItem>,
+  {} as Record<TypeBoostItemId, HeldItem<typeof HeldItemEffect.ATTACK_TYPE_BOOST>>,
 );
 //#endregion Type Boosters
 
@@ -120,10 +129,15 @@ const vitaminItems = PERMANENT_STATS.reduce(
   (ret, stat) => {
     const id = permanentStatToHeldItem[stat];
     id satisfies BaseStatItemId;
-    ret[stat] = new BaseStatMultiplyHeldItem(id, 30, stat).unstealable().untransferable().unsuppressable();
+    ret[stat] = new HeldItemBuilder(id, 30) //
+      .attr(BaseStatMultiplyHeldItemAttr, stat)
+      .unstealable()
+      .untransferable()
+      .unsuppressable()
+      .build();
     return ret;
   },
-  {} as Record<BaseStatItemId, BaseStatMultiplyHeldItem>,
+  {} as Record<BaseStatItemId, HeldItem<typeof HeldItemEffect.BASE_STAT_MULTIPLY>>,
 );
 
 //#endregion Vitamins
@@ -132,7 +146,7 @@ const vitaminItems = PERMANENT_STATS.reduce(
 // TODO: Do we want these in a separate object?
 const formChangeItems = Object.values(FormChangeItemId).reduce(
   (ret, id) => {
-    ret[id] = new FormChangeHeldItem(id, 1).unstealable().untransferable().unsuppressable();
+    ret[id] = new FormChangeHeldItem(id, 1);
     return ret;
   },
   {} as Record<FormChangeItemId, FormChangeHeldItem>,
@@ -140,88 +154,157 @@ const formChangeItems = Object.values(FormChangeItemId).reduce(
 //#endregion Form change items
 
 //#region Initialization
-const heldItems = Object.freeze({
+const heldItems = {
   ...berryItems,
   ...typeBoostHeldItems,
   ...vitaminItems,
   ...formChangeItems,
-  [HeldItemId.REVIVER_SEED]: new InstantReviveHeldItem(HeldItemId.REVIVER_SEED, 1),
-  [HeldItemId.WHITE_HERB]: new ResetNegativeStatStageHeldItem(HeldItemId.WHITE_HERB, 2),
+  [HeldItemId.REVIVER_SEED]: new HeldItemBuilder(HeldItemId.REVIVER_SEED, 1) //
+    .attr(InstantReviveHeldItemAttr)
+    .build(),
+  [HeldItemId.WHITE_HERB]: new HeldItemBuilder(HeldItemId.WHITE_HERB, 2) //
+    .attr(ResetNegativeStatStageHeldItemAttr)
+    .build(),
 
   // Items that boost specific stats
-  [HeldItemId.EVIOLITE]: new EvolutionStatBoostHeldItem(HeldItemId.EVIOLITE, 1, [Stat.DEF, Stat.SPDEF], 1.5),
-  [HeldItemId.LIGHT_BALL]: new SpeciesStatBoostHeldItem(HeldItemId.LIGHT_BALL, 1, [Stat.ATK, Stat.SPATK], 2, [
-    SpeciesId.PIKACHU,
-  ]),
-  [HeldItemId.THICK_CLUB]: new SpeciesStatBoostHeldItem(HeldItemId.LIGHT_BALL, 1, [Stat.ATK], 2, [
-    SpeciesId.CUBONE,
-    SpeciesId.MAROWAK,
-    SpeciesId.ALOLA_MAROWAK,
-  ]),
-  [HeldItemId.METAL_POWDER]: new SpeciesStatBoostHeldItem(HeldItemId.LIGHT_BALL, 1, [Stat.DEF], 2, [SpeciesId.DITTO]),
-  [HeldItemId.QUICK_POWDER]: new SpeciesStatBoostHeldItem(HeldItemId.LIGHT_BALL, 1, [Stat.SPD], 2, [SpeciesId.DITTO]),
-  [HeldItemId.DEEP_SEA_SCALE]: new SpeciesStatBoostHeldItem(HeldItemId.LIGHT_BALL, 1, [Stat.SPDEF], 2, [
-    SpeciesId.CLAMPERL,
-  ]),
-  [HeldItemId.DEEP_SEA_TOOTH]: new SpeciesStatBoostHeldItem(HeldItemId.LIGHT_BALL, 1, [Stat.SPATK], 2, [
-    SpeciesId.CLAMPERL,
-  ]),
+  [HeldItemId.EVIOLITE]: new HeldItemBuilder(HeldItemId.EVIOLITE, 1) //
+    .attr(EvolutionStatBoostHeldItemAttr, [Stat.DEF, Stat.SPDEF], 1.5)
+    .build(),
+  [HeldItemId.LIGHT_BALL]: new HeldItemBuilder(HeldItemId.LIGHT_BALL, 1) //
+    .attr(SpeciesStatBoostHeldItemAttr, [Stat.ATK, Stat.SPATK], 2, [SpeciesId.PIKACHU])
+    .build(),
+  [HeldItemId.THICK_CLUB]: new HeldItemBuilder(HeldItemId.THICK_CLUB, 1) //
+    .attr(SpeciesStatBoostHeldItemAttr, [Stat.ATK], 2, [SpeciesId.CUBONE, SpeciesId.MAROWAK, SpeciesId.ALOLA_MAROWAK])
+    .build(),
+  [HeldItemId.METAL_POWDER]: new HeldItemBuilder(HeldItemId.METAL_POWDER, 1) //
+    .attr(SpeciesStatBoostHeldItemAttr, [Stat.DEF], 2, [SpeciesId.DITTO])
+    .build(),
+  [HeldItemId.QUICK_POWDER]: new HeldItemBuilder(HeldItemId.QUICK_POWDER, 1) //
+    .attr(SpeciesStatBoostHeldItemAttr, [Stat.SPD], 2, [SpeciesId.DITTO])
+    .build(),
+  [HeldItemId.DEEP_SEA_SCALE]: new HeldItemBuilder(HeldItemId.DEEP_SEA_SCALE, 1) //
+    .attr(SpeciesStatBoostHeldItemAttr, [Stat.SPDEF], 2, [SpeciesId.CLAMPERL])
+    .build(),
+  [HeldItemId.DEEP_SEA_TOOTH]: new HeldItemBuilder(HeldItemId.DEEP_SEA_TOOTH, 1) //
+    .attr(SpeciesStatBoostHeldItemAttr, [Stat.SPATK], 2, [SpeciesId.CLAMPERL])
+    .build(),
 
   // crit rate boosters
-  [HeldItemId.SCOPE_LENS]: new CritBoostHeldItem(HeldItemId.SCOPE_LENS, 1, 1),
-  [HeldItemId.LEEK]: new SpeciesCritBoostHeldItem(HeldItemId.LEEK, 1, 2, [
-    SpeciesId.FARFETCHD,
-    SpeciesId.GALAR_FARFETCHD,
-    SpeciesId.SIRFETCHD,
-  ]),
+  [HeldItemId.SCOPE_LENS]: new HeldItemBuilder(HeldItemId.SCOPE_LENS, 1) //
+    .attr(CritBoostHeldItemAttr, 1)
+    .build(),
+  [HeldItemId.LEEK]: new HeldItemBuilder(HeldItemId.LEEK, 1) //
+    .attr(SpeciesCritBoostHeldItemAttr, 2, [SpeciesId.FARFETCHD, SpeciesId.GALAR_FARFETCHD, SpeciesId.SIRFETCHD])
+    .build(),
 
-  [HeldItemId.LUCKY_EGG]: new ExpBoosterHeldItem(HeldItemId.LUCKY_EGG, 99, 40),
-  [HeldItemId.GOLDEN_EGG]: new ExpBoosterHeldItem(HeldItemId.GOLDEN_EGG, 99, 100),
-  [HeldItemId.SOOTHE_BELL]: new FriendshipBoosterHeldItem(HeldItemId.SOOTHE_BELL, 3),
+  [HeldItemId.LUCKY_EGG]: new HeldItemBuilder(HeldItemId.LUCKY_EGG, 99) //
+    .attr(ExpBoosterHeldItemAttr, 40)
+    .description("modifierType:ModifierType.PokemonExpBoosterModifierType.description", { boostPercent: 40 })
+    .build(),
+  [HeldItemId.GOLDEN_EGG]: new HeldItemBuilder(HeldItemId.GOLDEN_EGG, 99) //
+    .attr(ExpBoosterHeldItemAttr, 100)
+    .description("modifierType:ModifierType.PokemonExpBoosterModifierType.description", { boostPercent: 100 })
+    .build(),
+  [HeldItemId.SOOTHE_BELL]: new HeldItemBuilder(HeldItemId.SOOTHE_BELL, 3)
+    .attr(FriendshipBoosterHeldItemAttr)
+    .description("modifierType:ModifierType.PokemonFriendshipBoosterModifierType.description")
+    .build(),
 
-  [HeldItemId.LEFTOVERS]: new TurnEndHealHeldItem(HeldItemId.LEFTOVERS, 4),
-  [HeldItemId.SHELL_BELL]: new HitHealHeldItem(HeldItemId.SHELL_BELL, 4),
+  [HeldItemId.LEFTOVERS]: new HeldItemBuilder(HeldItemId.LEFTOVERS, 4) //
+    .attr(TurnEndHealHeldItemAttr)
+    .build(),
+  [HeldItemId.SHELL_BELL]: new HeldItemBuilder(HeldItemId.SHELL_BELL, 4) //
+    .attr(HitHealHeldItemAttr)
+    .name("modifierType:ModifierType.SHELL_BELL.name")
+    .description("modifierType:ModifierType.SHELL_BELL.description")
+    .iconName("shell_bell")
+    .build(),
 
-  [HeldItemId.FOCUS_BAND]: new SurviveChanceHeldItem(HeldItemId.FOCUS_BAND, 5),
-  [HeldItemId.QUICK_CLAW]: new BypassSpeedChanceHeldItem(HeldItemId.QUICK_CLAW, 3),
-  [HeldItemId.KINGS_ROCK]: new FlinchChanceHeldItem(HeldItemId.KINGS_ROCK, 3, 10),
-  [HeldItemId.MYSTICAL_ROCK]: new FieldEffectHeldItem(HeldItemId.MYSTICAL_ROCK, 2),
-  [HeldItemId.SOUL_DEW]: new NatureWeightBoosterHeldItem(HeldItemId.SOUL_DEW, 10),
-  [HeldItemId.WIDE_LENS]: new AccuracyBoosterHeldItem(HeldItemId.WIDE_LENS, 3, 5),
-  [HeldItemId.MULTI_LENS]: new MultiHitHeldItem(HeldItemId.MULTI_LENS, 2),
-  [HeldItemId.GOLDEN_PUNCH]: new DamageMoneyRewardHeldItem(HeldItemId.GOLDEN_PUNCH, 5),
-  [HeldItemId.BATON]: new BatonHeldItem(HeldItemId.BATON, 1),
-  [HeldItemId.GRIP_CLAW]: new ContactItemStealChanceHeldItem(HeldItemId.GRIP_CLAW, 5, 10),
-  [HeldItemId.MINI_BLACK_HOLE]: new TurnEndItemStealHeldItem(HeldItemId.MINI_BLACK_HOLE, 1)
-    .unstealable()
-    .untransferable(),
-
-  [HeldItemId.FLAME_ORB]: new TurnEndStatusHeldItem(HeldItemId.FLAME_ORB, 1, StatusEffect.BURN),
-  [HeldItemId.TOXIC_ORB]: new TurnEndStatusHeldItem(HeldItemId.TOXIC_ORB, 1, StatusEffect.TOXIC),
-
-  [HeldItemId.SHUCKLE_JUICE_GOOD]: new ShuckleJuiceHeldItem(HeldItemId.SHUCKLE_JUICE_GOOD, 1, 10)
+  [HeldItemId.FOCUS_BAND]: new HeldItemBuilder(HeldItemId.FOCUS_BAND, 5).attr(SurviveChanceHeldItemAttr).build(),
+  [HeldItemId.QUICK_CLAW]: new HeldItemBuilder(HeldItemId.QUICK_CLAW, 3) //
+    .attr(BypassSpeedChanceHeldItemAttr)
+    .build(),
+  [HeldItemId.KINGS_ROCK]: new HeldItemBuilder(HeldItemId.KINGS_ROCK, 3) //
+    .attr(FlinchChanceHeldItemAttr, 10)
+    .build(),
+  [HeldItemId.MYSTICAL_ROCK]: new HeldItemBuilder(HeldItemId.MYSTICAL_ROCK, 2) //
+    .attr(FieldEffectHeldItemAttr)
+    .build(),
+  [HeldItemId.SOUL_DEW]: new HeldItemBuilder(HeldItemId.SOUL_DEW, 10) //
+    .attr(NatureWeightBoosterHeldItemAttr)
+    .build(),
+  [HeldItemId.WIDE_LENS]: new HeldItemBuilder(HeldItemId.WIDE_LENS, 3) //
+    .attr(AccuracyBoosterHeldItemAttr, 5)
+    .build(),
+  [HeldItemId.MULTI_LENS]: new HeldItemBuilder(HeldItemId.MULTI_LENS, 2) //
+    .attr(MultiHitCountHeldItemAttr)
+    .description("modifierType:ModifierType.PokemonMultiHitModifierType.description")
+    .build(),
+  [HeldItemId.GOLDEN_PUNCH]: new HeldItemBuilder(HeldItemId.GOLDEN_PUNCH, 5) //
+    .attr(DamageMoneyRewardHeldItemAttr)
+    .build(),
+  [HeldItemId.BATON]: new HeldItemBuilder(HeldItemId.BATON, 1) //
+    .attr(BatonHeldItemAttr)
+    .build(),
+  [HeldItemId.GRIP_CLAW]: new HeldItemBuilder(HeldItemId.GRIP_CLAW, 5) //
+    .attr(ContactItemStealChanceHeldItemAttr, 10)
+    .description("modifierType:ModifierType.ContactHeldItemTransferChanceModifierType.description", {
+      chancePercent: 10,
+    })
+    .build(),
+  [HeldItemId.MINI_BLACK_HOLE]: new HeldItemBuilder(HeldItemId.MINI_BLACK_HOLE, 1) //
+    .attr(TurnEndItemStealHeldItemAttr)
+    .description("modifierType:ModifierType.TurnHeldItemTransferModifierType.description")
     .unstealable()
     .untransferable()
-    .unsuppressable(),
-  [HeldItemId.SHUCKLE_JUICE_BAD]: new ShuckleJuiceHeldItem(HeldItemId.SHUCKLE_JUICE_BAD, 1, -15)
+    .build(),
+
+  [HeldItemId.FLAME_ORB]: new HeldItemBuilder(HeldItemId.FLAME_ORB, 1)
+    .attr(TurnEndStatusHeldItemAttr, StatusEffect.BURN)
+    .build(),
+  [HeldItemId.TOXIC_ORB]: new HeldItemBuilder(HeldItemId.TOXIC_ORB, 1)
+    .attr(TurnEndStatusHeldItemAttr, StatusEffect.TOXIC)
+    .build(),
+
+  [HeldItemId.SHUCKLE_JUICE_GOOD]: new HeldItemBuilder(HeldItemId.SHUCKLE_JUICE_GOOD, 1)
+    .attr(ShuckleJuiceHeldItemAttr, 10)
     .unstealable()
     .untransferable()
-    .unsuppressable(),
-  [HeldItemId.OLD_GATEAU]: new OldGateauHeldItem(HeldItemId.OLD_GATEAU, 1)
+    .unsuppressable()
+    .name("modifierType:ModifierType.MYSTERY_ENCOUNTER_SHUCKLE_JUICE_GOOD.name")
+    .description("modifierType:ModifierType.MYSTERY_ENCOUNTER_SHUCKLE_JUICE_GOOD.description")
+    .iconName("berry_juice_good")
+    .build(),
+  [HeldItemId.SHUCKLE_JUICE_BAD]: new HeldItemBuilder(HeldItemId.SHUCKLE_JUICE_BAD, 1)
+    .attr(ShuckleJuiceHeldItemAttr, -15)
     .unstealable()
     .untransferable()
-    .unsuppressable(),
-  [HeldItemId.MACHO_BRACE]: new MachoBraceHeldItem(HeldItemId.MACHO_BRACE, 50)
+    .unsuppressable()
+    .name("modifierType:ModifierType.MYSTERY_ENCOUNTER_SHUCKLE_JUICE_BAD.name")
+    .description("modifierType:ModifierType.MYSTERY_ENCOUNTER_SHUCKLE_JUICE_BAD.description")
+    .iconName("berry_juice_bad")
+    .build(),
+  [HeldItemId.OLD_GATEAU]: new HeldItemBuilder(HeldItemId.OLD_GATEAU, 1)
+    .attr(OldGateauHeldItemAttr)
     .unstealable()
     .untransferable()
-    .unsuppressable(),
+    .unsuppressable()
+    .build(),
+  [HeldItemId.MACHO_BRACE]: new HeldItemBuilder(HeldItemId.MACHO_BRACE, 50)
+    .attr(MachoBraceHeldItemAttr)
+    .unstealable()
+    .untransferable()
+    .unsuppressable()
+    .build(),
   [HeldItemId.GIMMIGHOUL_EVO_TRACKER]: new GimmighoulEvoTrackerHeldItem(
     HeldItemId.GIMMIGHOUL_EVO_TRACKER,
     999,
     SpeciesId.GIMMIGHOUL,
     10,
   ),
-} as const satisfies Readonly<Record<HeldItemId, CosmeticHeldItem | HeldItem<any>>>); // `any` typeparam used to avoid errors about individual items not accepting `HeldItemEffect`
+  // `any` type parameter used to get around `HeldItem` being invariant in `Effects`,
+  // thereby rendering all instances without an actual supertype
+} as const satisfies Readonly<Record<HeldItemId, CosmeticHeldItem | HeldItem>>;
 
 /**
  * Resolved type of {@linkcode allHeldItems}.

--- a/src/items/all-held-items.ts
+++ b/src/items/all-held-items.ts
@@ -9,12 +9,12 @@ import { FormChangeItemId } from "#enums/form-change-item-id";
 import { HeldItemId, HeldItemNames } from "#enums/held-item-id";
 import { PokemonType } from "#enums/pokemon-type";
 import { SpeciesId } from "#enums/species-id";
-import { PERMANENT_STATS, Stat } from "#enums/stat";
+import { getStatKey, PERMANENT_STATS, Stat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
 import { AccuracyBoosterHeldItemAttr } from "#items/accuracy-booster";
 import { AttackTypeBoostHeldItemAttr, attackTypeToHeldItem } from "#items/attack-type-booster";
 import { OldGateauHeldItemAttr, ShuckleJuiceHeldItemAttr } from "#items/base-stat-add";
-import { BaseStatMultiplyHeldItemAttr, permanentStatToHeldItem } from "#items/base-stat-multiply";
+import { BaseStatMultiplyHeldItemAttr, permanentStatToHeldItem, statBoostItems } from "#items/base-stat-multiply";
 import { BatonHeldItemAttr } from "#items/baton";
 import { BerryHeldItemAttr, berryTypeToHeldItem } from "#items/berry";
 import { BypassSpeedChanceHeldItemAttr } from "#items/bypass-speed-chance";
@@ -40,6 +40,7 @@ import { SurviveChanceHeldItemAttr } from "#items/survive-chance";
 import { TurnEndHealHeldItemAttr } from "#items/turn-end-heal";
 import { TurnEndStatusHeldItemAttr } from "#items/turn-end-status";
 import { getEnumValues } from "#utils/enums";
+import i18next from "i18next";
 
 // #region Types
 // TODO: Move these to wherever the "XYZ enum to held item id" utils are eventually placed
@@ -97,6 +98,9 @@ const berryItems = getEnumValues(BerryType).reduce(
     berryId satisfies BerryItemId;
     ret[berryId] = new HeldItemBuilder(berryId, maxStackCount) //
       .attr(BerryHeldItemAttr, berry)
+      .name(`berry:${BerryType[berry].toLowerCase()}.name`)
+      .description(`berry:${BerryType[berry].toLowerCase()}.effect`)
+      .iconName(`${BerryType[berry].toLowerCase()}_berry`)
       .build();
     return ret;
   },
@@ -108,14 +112,19 @@ const berryItems = getEnumValues(BerryType).reduce(
 const typeBoostHeldItems = (
   getEnumValues(PokemonType).slice(1, -1) as Exclude<PokemonType, PokemonType.UNKNOWN | PokemonType.STELLAR>[]
 ).reduce(
-  (ret, type) => {
-    const id = attackTypeToHeldItem[type] satisfies TypeBoostItemId;
-    ret[id] = new HeldItemBuilder(id, 99)
-      .attr(AttackTypeBoostHeldItemAttr, type, 0.2)
+  (ret, pokemonType) => {
+    const id = attackTypeToHeldItem[pokemonType] satisfies TypeBoostItemId;
+    ret[id] = new HeldItemBuilder(id, 99) //
+      .attr(AttackTypeBoostHeldItemAttr, pokemonType, 0.2)
       .unstealable()
       .untransferable()
       .unsuppressable()
-      .name(`modifierType:AttackTypeBoosterItem.${HeldItemNames[type].toLowerCase()}`)
+      .name(`modifierType:AttackTypeBoosterItem.${HeldItemNames[id].toLowerCase()}`)
+      // TODO: Rework the locales entry to use i18next's native nesting support
+      // by replacing `{{moveType}}` with "$t(pokemonInfo:Type.{{moveType}})"
+      .description("modifierType:ModifierType.AttackTypeBoosterModifierType.description", {
+        moveType: i18next.t(`pokemonInfo:Type.${PokemonType[pokemonType]}`),
+      })
       .build();
     return ret;
   },
@@ -133,6 +142,12 @@ const vitaminItems = PERMANENT_STATS.reduce(
       .unstealable()
       .untransferable()
       .unsuppressable()
+      .name(`modifierType:BaseStatBoosterItem.${statBoostItems[stat]}`)
+      // TODO: Rework the locales entry to use i18next's native nesting support
+      // by replacing `{{stat}}` with "$t({{statKey}})"
+      .description("modifierType:ModifierType.BaseStatBoosterModifierType.description", {
+        stat: i18next.t(getStatKey(stat)),
+      })
       .build();
     return ret;
   },
@@ -204,7 +219,7 @@ const heldItems = {
     .attr(ExpBoosterHeldItemAttr, 100)
     .description("modifierType:ModifierType.PokemonExpBoosterModifierType.description", { boostPercent: 100 })
     .build(),
-  [HeldItemId.SOOTHE_BELL]: new HeldItemBuilder(HeldItemId.SOOTHE_BELL, 3)
+  [HeldItemId.SOOTHE_BELL]: new HeldItemBuilder(HeldItemId.SOOTHE_BELL, 3) //
     .attr(FriendshipBoosterHeldItemAttr)
     .description("modifierType:ModifierType.PokemonFriendshipBoosterModifierType.description")
     .build(),
@@ -219,7 +234,7 @@ const heldItems = {
     .iconName("shell_bell")
     .build(),
 
-  [HeldItemId.FOCUS_BAND]: new HeldItemBuilder(HeldItemId.FOCUS_BAND, 5).attr(SurviveChanceHeldItemAttr).build(),
+  [HeldItemId.FOCUS_BAND]: new HeldItemBuilder(HeldItemId.FOCUS_BAND, 5).attr(SurviveChanceHeldItemAttr).build(), //
   [HeldItemId.QUICK_CLAW]: new HeldItemBuilder(HeldItemId.QUICK_CLAW, 3) //
     .attr(BypassSpeedChanceHeldItemAttr)
     .build(),
@@ -258,14 +273,14 @@ const heldItems = {
     .untransferable()
     .build(),
 
-  [HeldItemId.FLAME_ORB]: new HeldItemBuilder(HeldItemId.FLAME_ORB, 1)
+  [HeldItemId.FLAME_ORB]: new HeldItemBuilder(HeldItemId.FLAME_ORB, 1) //
     .attr(TurnEndStatusHeldItemAttr, StatusEffect.BURN)
     .build(),
-  [HeldItemId.TOXIC_ORB]: new HeldItemBuilder(HeldItemId.TOXIC_ORB, 1)
+  [HeldItemId.TOXIC_ORB]: new HeldItemBuilder(HeldItemId.TOXIC_ORB, 1) //
     .attr(TurnEndStatusHeldItemAttr, StatusEffect.TOXIC)
     .build(),
 
-  [HeldItemId.SHUCKLE_JUICE_GOOD]: new HeldItemBuilder(HeldItemId.SHUCKLE_JUICE_GOOD, 1)
+  [HeldItemId.SHUCKLE_JUICE_GOOD]: new HeldItemBuilder(HeldItemId.SHUCKLE_JUICE_GOOD, 1) //
     .attr(ShuckleJuiceHeldItemAttr, 10)
     .unstealable()
     .untransferable()
@@ -274,7 +289,7 @@ const heldItems = {
     .description("modifierType:ModifierType.MYSTERY_ENCOUNTER_SHUCKLE_JUICE_GOOD.description")
     .iconName("berry_juice_good")
     .build(),
-  [HeldItemId.SHUCKLE_JUICE_BAD]: new HeldItemBuilder(HeldItemId.SHUCKLE_JUICE_BAD, 1)
+  [HeldItemId.SHUCKLE_JUICE_BAD]: new HeldItemBuilder(HeldItemId.SHUCKLE_JUICE_BAD, 1) //
     .attr(ShuckleJuiceHeldItemAttr, -15)
     .unstealable()
     .untransferable()
@@ -283,14 +298,17 @@ const heldItems = {
     .description("modifierType:ModifierType.MYSTERY_ENCOUNTER_SHUCKLE_JUICE_BAD.description")
     .iconName("berry_juice_bad")
     .build(),
-  [HeldItemId.OLD_GATEAU]: new HeldItemBuilder(HeldItemId.OLD_GATEAU, 1)
+  [HeldItemId.OLD_GATEAU]: new HeldItemBuilder(HeldItemId.OLD_GATEAU, 1) //
     .attr(OldGateauHeldItemAttr)
     .unstealable()
     .untransferable()
     .unsuppressable()
+    .description("modifierType:ModifierType.PokemonBaseStatFlatModifierType.description")
     .build(),
-  [HeldItemId.MACHO_BRACE]: new HeldItemBuilder(HeldItemId.MACHO_BRACE, 50)
+  [HeldItemId.MACHO_BRACE]: new HeldItemBuilder(HeldItemId.MACHO_BRACE, 50) //
     .attr(MachoBraceHeldItemAttr)
+    .name("modifierType:ModifierType.MYSTERY_ENCOUNTER_MACHO_BRACE.name")
+    .description("modifierType:ModifierType.MYSTERY_ENCOUNTER_MACHO_BRACE.description")
     .unstealable()
     .untransferable()
     .unsuppressable()
@@ -301,9 +319,7 @@ const heldItems = {
     SpeciesId.GIMMIGHOUL,
     10,
   ),
-  // `any` type parameter used to get around `HeldItem` being invariant in `Effects`,
-  // thereby rendering all instances without an actual supertype
-} as const satisfies Readonly<Record<HeldItemId, CosmeticHeldItem | HeldItem<any>>>;
+} as const satisfies Readonly<Record<HeldItemId, CosmeticHeldItem | HeldItem>>;
 
 /**
  * Resolved type of {@linkcode allHeldItems}.

--- a/src/items/all-held-items.ts
+++ b/src/items/all-held-items.ts
@@ -40,7 +40,6 @@ import { SurviveChanceHeldItemAttr } from "#items/survive-chance";
 import { TurnEndHealHeldItemAttr } from "#items/turn-end-heal";
 import { TurnEndStatusHeldItemAttr } from "#items/turn-end-status";
 import { getEnumValues } from "#utils/enums";
-import i18next from "i18next";
 
 // #region Types
 // TODO: Move these to wherever the "XYZ enum to held item id" utils are eventually placed
@@ -120,10 +119,8 @@ const typeBoostHeldItems = (
       .untransferable()
       .unsuppressable()
       .name(`modifierType:AttackTypeBoosterItem.${HeldItemNames[id].toLowerCase()}`)
-      // TODO: Rework the locales entry to use i18next's native nesting support
-      // by replacing `{{moveType}}` with "$t(pokemonInfo:Type.{{moveType}})"
       .description("modifierType:ModifierType.AttackTypeBoosterModifierType.description", {
-        moveType: i18next.t(`pokemonInfo:Type.${PokemonType[pokemonType]}`),
+        moveType: `$t(pokemonInfo:Type.${PokemonType[pokemonType]})`,
       })
       .build();
     return ret;
@@ -143,11 +140,10 @@ const vitaminItems = PERMANENT_STATS.reduce(
       .untransferable()
       .unsuppressable()
       .name(`modifierType:BaseStatBoosterItem.${statBoostItems[stat]}`)
-      // TODO: Rework the locales entry to use i18next's native nesting support
-      // by replacing `{{stat}}` with "$t({{statKey}})"
       .description("modifierType:ModifierType.BaseStatBoosterModifierType.description", {
-        stat: i18next.t(getStatKey(stat)),
+        stat: `$t(${getStatKey(stat)})`,
       })
+      .iconName(statBoostItems[stat])
       .build();
     return ret;
   },

--- a/src/items/all-held-items.ts
+++ b/src/items/all-held-items.ts
@@ -303,7 +303,7 @@ const heldItems = {
   ),
   // `any` type parameter used to get around `HeldItem` being invariant in `Effects`,
   // thereby rendering all instances without an actual supertype
-} as const satisfies Readonly<Record<HeldItemId, CosmeticHeldItem | HeldItem>>;
+} as const satisfies Readonly<Record<HeldItemId, CosmeticHeldItem | HeldItem<any>>>;
 
 /**
  * Resolved type of {@linkcode allHeldItems}.

--- a/src/items/all-held-items.ts
+++ b/src/items/all-held-items.ts
@@ -74,7 +74,7 @@ type TypeBoostItemId =
   | typeof HeldItemId.BLACK_GLASSES
   | typeof HeldItemId.FAIRY_FEATHER;
 
-type BerryItemId =
+export type BerryItemId =
   | typeof HeldItemId.SITRUS_BERRY
   | typeof HeldItemId.LUM_BERRY
   | typeof HeldItemId.ENIGMA_BERRY

--- a/src/items/all-held-items.ts
+++ b/src/items/all-held-items.ts
@@ -6,7 +6,6 @@
 import { allHeldItems } from "#data/data-lists";
 import { BerryType } from "#enums/berry-type";
 import { FormChangeItemId } from "#enums/form-change-item-id";
-import type { HeldItemEffect } from "#enums/held-item-effect";
 import { HeldItemId, HeldItemNames } from "#enums/held-item-id";
 import { PokemonType } from "#enums/pokemon-type";
 import { SpeciesId } from "#enums/species-id";
@@ -101,7 +100,7 @@ const berryItems = getEnumValues(BerryType).reduce(
       .build();
     return ret;
   },
-  {} as Record<BerryItemId, HeldItem<typeof HeldItemEffect.BERRY>>,
+  {} as Record<BerryItemId, HeldItem<BerryHeldItemAttr>>,
 );
 //#endregion Berries
 
@@ -120,7 +119,7 @@ const typeBoostHeldItems = (
       .build();
     return ret;
   },
-  {} as Record<TypeBoostItemId, HeldItem<typeof HeldItemEffect.ATTACK_TYPE_BOOST>>,
+  {} as Record<TypeBoostItemId, HeldItem<AttackTypeBoostHeldItemAttr>>,
 );
 //#endregion Type Boosters
 
@@ -137,7 +136,7 @@ const vitaminItems = PERMANENT_STATS.reduce(
       .build();
     return ret;
   },
-  {} as Record<BaseStatItemId, HeldItem<typeof HeldItemEffect.BASE_STAT_MULTIPLY>>,
+  {} as Record<BaseStatItemId, HeldItem<BaseStatMultiplyHeldItemAttr>>,
 );
 
 //#endregion Vitamins

--- a/src/items/held-item-attr.ts
+++ b/src/items/held-item-attr.ts
@@ -8,8 +8,8 @@ import type { HeldItem } from "#items/held-item";
 import type { HeldItemEffectParamMap } from "#types/held-item-parameter";
 
 /**
- * Maps each {@linkcode HeldItemEffect} to its attribute instances for a given set of effects.
- * Effects not in the `Effects` union map to `undefined`.
+ * Type matching each {@linkcode HeldItemEffect} to the subset of `Attrs` that can apply said effect. \
+ * Any effects absent from all `Attrs` will map to `undefined`.
  */
 export type HeldItemRecord<Attrs extends HeldItemAttr> = {
   [effect in HeldItemEffect]: effect extends Attrs["effect"] ? readonly Extract<Attrs, HeldItemAttr<effect>>[] : never;

--- a/src/items/held-item-attr.ts
+++ b/src/items/held-item-attr.ts
@@ -11,8 +11,8 @@ import type { HeldItemEffectParamMap } from "#types/held-item-parameter";
  * Maps each {@linkcode HeldItemEffect} to its attribute instances for a given set of effects.
  * Effects not in the `Effects` union map to `undefined`.
  */
-export type HeldItemRecord<Effects extends HeldItemEffect> = {
-  [effect in HeldItemEffect]: effect extends Effects ? readonly HeldItemAttr<effect>[] : never;
+export type HeldItemRecord<Attrs extends HeldItemAttr> = {
+  [effect in HeldItemEffect]: effect extends Attrs["effect"] ? readonly Extract<Attrs, HeldItemAttr<effect>>[] : never;
 };
 
 /**

--- a/src/items/held-item-attr.ts
+++ b/src/items/held-item-attr.ts
@@ -1,27 +1,54 @@
+import { applyAbAttrs } from "#abilities/apply-ab-attrs";
+import { globalScene } from "#app/global-scene";
+import { allHeldItems } from "#data/data-lists";
 import type { HeldItemEffect } from "#enums/held-item-effect";
-import { HeldItemId } from "#enums/held-item-id";
+import type { HeldItemId } from "#enums/held-item-id";
+import type { Pokemon } from "#field/pokemon";
+import type { HeldItem } from "#items/held-item";
 import type { HeldItemEffectParamMap } from "#types/held-item-parameter";
-import type { NonEmptyTuple } from "type-fest";
 
 /**
  * Maps each {@linkcode HeldItemEffect} to its attribute instances for a given set of effects.
  * Effects not in the `Effects` union map to `undefined`.
  */
 export type HeldItemRecord<Effects extends HeldItemEffect> = {
-  [effect in HeldItemEffect]: effect extends Effects ? NonEmptyTuple<HeldItemAttr<effect>> : undefined;
+  [effect in HeldItemEffect]: effect extends Effects ? readonly HeldItemAttr<effect>[] : never;
 };
 
 /**
  * Abstract base class for held item attributes.
+ *
+ * A single {@linkcode HeldItem} instance can have any number of attributes per effect,
+ * in a similar manner to {@linkcode AbAttr}s and {@linkcode MoveAttr}s
  */
 export abstract class HeldItemAttr<E extends HeldItemEffect = HeldItemEffect> {
   /**
-   * The HeldItemID associated with this attribute.
-   * Set by the builder class during initialization.
+   * The {@linkcode HeldItemId} associated with this attribute.
+   *
+   * Set by {@linkcode HeldItemBuilder} during attribute initialization,
+   * and exists solely to allow attributes to identify the item they belong to for message generation and similar purposes.
+   * @sealed
+   * @privateRemarks
+   * This cannot be typed as `ApplicableHeldItemId` due to causing a circular type dependency.
    */
   protected readonly type!: HeldItemId;
 
-  /** The {@linkcode HeldItemEffect} this attribute handles. */
+  /**
+   * @returns A reference to the {@linkcode HeldItem} instance to which this attribute is attached.
+   * @sealed
+   */
+  protected get item(): HeldItem {
+    // Type assertion is necessary to avoid circular type dependency issues, but this is guaranteed to be correct
+    // since the builder sets the attribute's `type` to the correct value at runtime.
+    return allHeldItems[this.type] as HeldItem;
+  }
+
+  /**
+   * The {@linkcode HeldItemEffect} this attribute handles.
+   * Should not be a union.
+   * @remarks
+   * Used by {@linkcode HeldItemBuilder} to sort items by effect.
+   */
   public abstract readonly effect: E;
 
   /**
@@ -35,9 +62,39 @@ export abstract class HeldItemAttr<E extends HeldItemEffect = HeldItemEffect> {
   }
 
   /**
-   * Apply this attribute's effect.
+   * Apply this attribute's effect. \
    * Called if and only if {@linkcode shouldApply} returns `true`.
    * @param params - The parameters for this effect
    */
   public abstract apply(params: HeldItemEffectParamMap[E]): void;
+}
+
+/**
+ * Abstract base class for consumable held item attributes,
+ * i.e. ones that consume their source items after triggering.
+ *
+ * Each item may have a maximum of one consumable attribute per effect, enforced by the builder during creation.
+ *
+ * @remarks
+ * Combining with other attributes that depend on stack count may have unexpected results.
+ */
+export abstract class ConsumableHeldItemAttr<E extends HeldItemEffect = HeldItemEffect> extends HeldItemAttr<E> {
+  /**
+   * Consume the item associated with this attribute and apply relevant effects.
+   * Should be called by the attribute's `apply` method once finished.
+   * @param pokemon - The {@linkcode Pokemon} consuming the item
+   * @param remove - (Default `true`) Whether to remove the item during consumption
+   * @param unburden - (Default `true`) Whether to trigger item loss abilities (i.e. Unburden) when consuming the item
+   * @sealed
+   */
+  protected consume(pokemon: Pokemon, remove = true, unburden = true): void {
+    if (remove) {
+      pokemon.heldItemManager.remove(this.type, 1);
+      // TODO: Turn this into updateItemBar or something
+      globalScene.updateItems(pokemon.isPlayer());
+    }
+    if (unburden) {
+      applyAbAttrs("PostItemLostAbAttr", { pokemon });
+    }
+  }
 }

--- a/src/items/held-item-attr.ts
+++ b/src/items/held-item-attr.ts
@@ -6,10 +6,14 @@ import type { HeldItemId } from "#enums/held-item-id";
 import type { Pokemon } from "#field/pokemon";
 import type { HeldItem } from "#items/held-item";
 import type { HeldItemEffectParamMap } from "#types/held-item-parameter";
+import type { IsEqual, IsUnion } from "type-fest";
 
 /**
  * Type matching each {@linkcode HeldItemEffect} to the subset of `Attrs` that can apply said effect. \
  * Any effects absent from all `Attrs` will map to an empty array.
+ * @package
+ * @remarks
+ * We cannot outright remove mismatched attributes from the object (or set them to `undefined`/`never`) due to breaking the covariance of `HeldItem`.
  */
 export type HeldItemRecord<Attrs extends HeldItemAttr> = {
   readonly [E in HeldItemEffect]: [Extract<Attrs, HeldItemAttr<E>>] extends [never]
@@ -22,8 +26,10 @@ export type HeldItemRecord<Attrs extends HeldItemAttr> = {
  *
  * A single {@linkcode HeldItem} instance can have any number of attributes per effect,
  * in a similar manner to {@linkcode AbAttr}s and {@linkcode MoveAttr}s.
+ * @typeParam E - The {@linkcode HeldItemEffect} this attribute applies to.
+ * Should not be a union.
  */
-export abstract class HeldItemAttr<out E extends HeldItemEffect = HeldItemEffect> {
+export abstract class HeldItemAttr<E extends HeldItemEffect = HeldItemEffect> {
   /**
    * The {@linkcode HeldItemId} associated with this attribute.
    *
@@ -46,12 +52,13 @@ export abstract class HeldItemAttr<out E extends HeldItemEffect = HeldItemEffect
   }
 
   /**
-   * The {@linkcode HeldItemEffect} this attribute handles.
-   * Should not be a union.
+   * The {@linkcode HeldItemEffect} this attribute handles. \
+   * Used by {@linkcode HeldItemBuilder} to sort items by effect, and is otherwise unused.
    * @remarks
-   * Used by {@linkcode HeldItemBuilder} to sort items by effect.
+   * This will resolve to `never` if `E` is a union, which is desirable since attributes should not be able to apply to multiple effects.
    */
-  public abstract readonly effect: E;
+  // add explicit bypass for base class (since `HeldItemEffect` is itself a union)
+  public abstract readonly effect: IsEqual<E, HeldItemEffect> extends true ? E : IsUnion<E> extends true ? never : E;
 
   /**
    * Check whether this attribute's effect should be allowed to trigger.
@@ -81,8 +88,6 @@ export abstract class HeldItemAttr<out E extends HeldItemEffect = HeldItemEffect
  * Combining with other attributes that depend on stack count may have unexpected results.
  */
 export abstract class ConsumableHeldItemAttr<E extends HeldItemEffect = HeldItemEffect> extends HeldItemAttr<E> {
-  private declare readonly _: never;
-
   /**
    * Consume the item associated with this attribute and apply relevant effects.
    * Should be called by the attribute's `apply` method once finished.

--- a/src/items/held-item-attr.ts
+++ b/src/items/held-item-attr.ts
@@ -1,3 +1,4 @@
+import type { AbAttr } from "#abilities/ab-attrs";
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
 import { allHeldItems } from "#data/data-lists";
@@ -5,7 +6,9 @@ import type { HeldItemEffect } from "#enums/held-item-effect";
 import type { HeldItemId } from "#enums/held-item-id";
 import type { Pokemon } from "#field/pokemon";
 import type { HeldItem } from "#items/held-item";
+import type { HeldItemBuilder } from "#items/held-item-builder";
 import type { HeldItemEffectParamMap } from "#types/held-item-parameter";
+import type { MoveAttr } from "#types/move-types";
 import type { IsEqual, IsUnion } from "type-fest";
 
 /**

--- a/src/items/held-item-attr.ts
+++ b/src/items/held-item-attr.ts
@@ -9,19 +9,21 @@ import type { HeldItemEffectParamMap } from "#types/held-item-parameter";
 
 /**
  * Type matching each {@linkcode HeldItemEffect} to the subset of `Attrs` that can apply said effect. \
- * Any effects absent from all `Attrs` will map to `undefined`.
+ * Any effects absent from all `Attrs` will map to an empty array.
  */
 export type HeldItemRecord<Attrs extends HeldItemAttr> = {
-  [effect in HeldItemEffect]: effect extends Attrs["effect"] ? readonly Extract<Attrs, HeldItemAttr<effect>>[] : never;
+  readonly [E in HeldItemEffect]: [Extract<Attrs, HeldItemAttr<E>>] extends [never]
+    ? readonly []
+    : readonly Extract<Attrs, HeldItemAttr<E>>[];
 };
 
 /**
  * Abstract base class for held item attributes.
  *
  * A single {@linkcode HeldItem} instance can have any number of attributes per effect,
- * in a similar manner to {@linkcode AbAttr}s and {@linkcode MoveAttr}s
+ * in a similar manner to {@linkcode AbAttr}s and {@linkcode MoveAttr}s.
  */
-export abstract class HeldItemAttr<E extends HeldItemEffect = HeldItemEffect> {
+export abstract class HeldItemAttr<out E extends HeldItemEffect = HeldItemEffect> {
   /**
    * The {@linkcode HeldItemId} associated with this attribute.
    *

--- a/src/items/held-item-attr.ts
+++ b/src/items/held-item-attr.ts
@@ -79,6 +79,8 @@ export abstract class HeldItemAttr<E extends HeldItemEffect = HeldItemEffect> {
  * Combining with other attributes that depend on stack count may have unexpected results.
  */
 export abstract class ConsumableHeldItemAttr<E extends HeldItemEffect = HeldItemEffect> extends HeldItemAttr<E> {
+  private declare readonly _: never;
+
   /**
    * Consume the item associated with this attribute and apply relevant effects.
    * Should be called by the attribute's `apply` method once finished.

--- a/src/items/held-item-attr.ts
+++ b/src/items/held-item-attr.ts
@@ -1,0 +1,43 @@
+import type { HeldItemEffect } from "#enums/held-item-effect";
+import { HeldItemId } from "#enums/held-item-id";
+import type { HeldItemEffectParamMap } from "#types/held-item-parameter";
+import type { NonEmptyTuple } from "type-fest";
+
+/**
+ * Maps each {@linkcode HeldItemEffect} to its attribute instances for a given set of effects.
+ * Effects not in the `Effects` union map to `undefined`.
+ */
+export type HeldItemRecord<Effects extends HeldItemEffect> = {
+  [effect in HeldItemEffect]: effect extends Effects ? NonEmptyTuple<HeldItemAttr<effect>> : undefined;
+};
+
+/**
+ * Abstract base class for held item attributes.
+ */
+export abstract class HeldItemAttr<E extends HeldItemEffect = HeldItemEffect> {
+  /**
+   * The HeldItemID associated with this attribute.
+   * Set by the builder class during initialization.
+   */
+  protected readonly type!: HeldItemId;
+
+  /** The {@linkcode HeldItemEffect} this attribute handles. */
+  public abstract readonly effect: E;
+
+  /**
+   * Check whether this attribute's effect should be allowed to trigger.
+   * @param params - The parameters for this effect
+   * @returns Whether this attribute's effect should be applied; defaults to `true` if not overridden
+   */
+  // biome-ignore lint/correctness/noUnusedFunctionParameters: pseudo-abstract method
+  public shouldApply(...params: Parameters<this["apply"]>): boolean {
+    return true;
+  }
+
+  /**
+   * Apply this attribute's effect.
+   * Called if and only if {@linkcode shouldApply} returns `true`.
+   * @param params - The parameters for this effect
+   */
+  public abstract apply(params: HeldItemEffectParamMap[E]): void;
+}

--- a/src/items/held-item-builder.ts
+++ b/src/items/held-item-builder.ts
@@ -145,11 +145,11 @@ export class HeldItemBuilder<Attrs extends HeldItemAttr = never, ConsumableEffec
    * Build a non-consumable {@linkcode HeldItem} with the stored attributes and flags.
    * @returns A fully-typed `HeldItem` with all registered attributes.
    */
-  public build(): HeldItem<Attrs["effect"]> {
+  public build(): HeldItem<Attrs> {
     // @ts-expect-error - TypeScript doesn't support friend classes, so this is the closest we can get to
     // ensuring `HeldItem` is only constructed by its corresponding builder.
     // NB: The type specifier here is required due to TS resolving this as `any`
-    const item: HeldItem<Attrs["effect"]> = new HeldItem({
+    const item: HeldItem<Attrs> = new HeldItem({
       type: this.id,
       effects: this.buildRecord(),
       maxStackCount: this.maxStackCount,
@@ -161,12 +161,12 @@ export class HeldItemBuilder<Attrs extends HeldItemAttr = never, ConsumableEffec
     return item;
   }
 
-  private buildRecord(): HeldItemRecord<Attrs["effect"]> {
+  private buildRecord(): HeldItemRecord<Attrs> {
     // TODO: Remove type assertion after `Object.keys` PR
-    return Object.fromEntries(this.attrMap.entries()) as unknown as HeldItemRecord<Attrs["effect"]>;
+    return Object.fromEntries(this.attrMap.entries()) as unknown as HeldItemRecord<Attrs>;
   }
 
-  private applyFlags(item: HeldItem<Attrs["effect"]>): void {
+  private applyFlags(item: HeldItem<Attrs>): void {
     if (!this.isTransferable) {
       item.isTransferable = false;
     }

--- a/src/items/held-item-builder.ts
+++ b/src/items/held-item-builder.ts
@@ -1,0 +1,180 @@
+import type { HeldItemEffect } from "#enums/held-item-effect";
+import type { HeldItemId } from "#enums/held-item-id";
+import { ConsumableHeldItem, HeldItem } from "#items/held-item";
+import type { HeldItemAttr, HeldItemRecord } from "#items/held-item-attr";
+import type { Mutable } from "#types/type-helpers";
+import type i18next from "i18next";
+import type { Constructor } from "type-fest";
+
+/**
+ * Builder class for {@linkcode HeldItem} instances.
+ *
+ * Accumulates {@linkcode HeldItemAttr} instances via {@linkcode HeldItemBuilder.attr | attr},
+ * before transforming them into a concrete `HeldItem` subclass with {@linkcode HeldItemBuilder.build | build}.
+ *
+ * @typeParam A - A union of all the {@linkcode HeldItemAttr}s registered so far.
+ *
+ * @example
+ * ```ts
+ * new HeldItemBuilder(HeldItemId.KINGS_ROCK, 3) //
+ *   .attr(FlinchChanceAttr, 0.1)
+ *   .build()
+ * ```
+ * @sealed
+ */
+export class HeldItemBuilder<A extends HeldItemAttr = never> {
+  public readonly id: HeldItemId;
+  /** @defaultValue `1` */
+  public readonly maxStackCount: number;
+
+  private isTransferable = true;
+  private isStealable = true;
+  private isSuppressable = true;
+
+  private nameParams?: Parameters<typeof i18next.t>;
+  private descriptionParams?: Parameters<typeof i18next.t>;
+  private iconName?: string;
+
+  /** Internal sparse map matching effects to their corresponding attributes. */
+  private readonly attrMap: Map<HeldItemEffect, HeldItemAttr[]> = new Map();
+
+  constructor(id: HeldItemId, maxStackCount = 1) {
+    this.id = id;
+    this.maxStackCount = maxStackCount;
+  }
+
+  // #region Attributes
+
+  /**
+   * Instantiate an {@linkcode HeldItemAttr} and register it on this builder.
+   * @param attrType - The constructor of a {@linkcode HeldItemAttr} subclass
+   * @param args - Arguments forwarded to the constructor.
+   * @returns `this` with `Attr` added to the effect union.
+   */
+  public attr<Attr extends HeldItemAttr>(
+    attrType: Constructor<Attr>,
+    ...args: ConstructorParameters<Constructor<Attr>>
+  ): HeldItemBuilder<A | Attr> {
+    this.addAttr(new attrType(...args));
+    return this as unknown as HeldItemBuilder<A | Attr>;
+  }
+
+  /** Internal helper method to add an attribute to the builder. */
+  private addAttr(attr: HeldItemAttr): void {
+    (attr as Mutable<HeldItemAttr>)["type"] = this.id;
+    const { effect } = attr;
+    const existing = this.attrMap.get(effect);
+    if (existing) {
+      existing.push(attr);
+    } else {
+      this.attrMap.set(effect, [attr]);
+    }
+  }
+
+  // #endregion Attributes
+
+  // #region Flags
+
+  /**
+   * Prevent this item from being transferred to another {@linkcode Pokemon}.
+   * @returns `this`
+   */
+  public untransferable(): this {
+    this.isTransferable = false;
+    return this;
+  }
+
+  /**
+   * Prevent this item from being stolen by another {@linkcode Pokemon}.
+   * @returns `this`
+   */
+  public unstealable(): this {
+    this.isStealable = false;
+    return this;
+  }
+
+  /**
+   * Prevent this item's effects from being suppressed by moves or abilities.
+   * @returns `this`
+   */
+  public unsuppressable(): this {
+    this.isSuppressable = false;
+    return this;
+  }
+
+  // #endregion Flags
+
+  // #region Localization
+
+  public name(...params: Parameters<typeof i18next.t>): this {
+    this.nameParams = params;
+    return this;
+  }
+
+  public description(...params: Parameters<typeof i18next.t>): this {
+    this.descriptionParams = params;
+    return this;
+  }
+
+  public icon(iconName: string): this {
+    this.iconName = iconName;
+    return this;
+  }
+
+  // #endregion Builder code
+
+  /**
+   * Build a non-consumable {@linkcode HeldItem} with the stored attributes and flags.
+   * @returns A fully-typed `HeldItem` with all registered attributes.
+   */
+  public build(): HeldItem<A["effect"]> {
+    // @ts-expect-error - TypeScript doesn't support friend classes, so this is the closest we can get to
+    // ensuring `HeldItem` is only constructed by its corresponding builder.
+    // NB: The type specifier here is required due to TS resolving this as `any`
+    const item: HeldItem<A["effect"]> = new HeldItem({
+      type: this.id,
+      effects: this.buildRecord(),
+      maxStackCount: this.maxStackCount,
+      nameParams: this.nameParams,
+      descriptionParams: this.descriptionParams,
+      iconName: this.iconName,
+    });
+    this.applyFlags(item);
+    return item;
+  }
+
+  /**
+   * Build a {@linkcode ConsumableHeldItem} that supports the {@linkcode ConsumableHeldItem.consume | consume} lifecycle.
+   * @returns A fully-typed `ConsumableHeldItem` with all registered attributes.
+   */
+  public buildConsumable(): ConsumableHeldItem<A["effect"]> {
+    // @ts-expect-error - see comment in `build` for rationale
+    const item: ConsumableHeldItem<A["effect"]> = new ConsumableHeldItem({
+      type: this.id,
+      effects: this.buildRecord(),
+      maxStackCount: this.maxStackCount,
+      nameParams: this.nameParams,
+      descriptionParams: this.descriptionParams,
+      iconName: this.iconName,
+    });
+    this.applyFlags(item);
+    return item;
+  }
+
+  private buildRecord(): HeldItemRecord<A["effect"]> {
+    return Object.fromEntries(this.attrMap.entries()) as unknown as HeldItemRecord<A["effect"]>;
+  }
+
+  private applyFlags(item: HeldItem<A["effect"]>): void {
+    if (!this.isTransferable) {
+      item.isTransferable = false;
+    }
+    if (!this.isStealable) {
+      item.isStealable = false;
+    }
+    if (!this.isSuppressable) {
+      item.isSuppressable = false;
+    }
+  }
+  // #endregion Builder code
+}

--- a/src/items/held-item-builder.ts
+++ b/src/items/held-item-builder.ts
@@ -142,10 +142,15 @@ export class HeldItemBuilder<Attrs extends HeldItemAttr = never, ConsumableEffec
   // #endregion Builder code
 
   /**
-   * Build a non-consumable {@linkcode HeldItem} with the stored attributes and flags.
+   * Build a new {@linkcode HeldItem} with the stored attributes and flags.
    * @returns A fully-typed `HeldItem` with all registered attributes.
+   * @remarks
+   * This will resolve to `never` if no attributes have been registered.
    */
-  public build(): HeldItem<Attrs> {
+  // TODO: Do we want to allow 0-item builds (and make them cosmetic?)
+  public build(): [Attrs] extends [never] ? ErrorType<"Cannot create a HeldItem with no attributes!"> : HeldItem<Attrs>;
+  // NB: The implementation signature needs to return a union here to satisfy TypeScript, but we never actually return one ourselves
+  public build(): ErrorType<"Cannot create a HeldItem with no attributes!"> | HeldItem<Attrs> {
     // @ts-expect-error - TypeScript doesn't support friend classes, so this is the closest we can get to
     // ensuring `HeldItem` is only constructed by its corresponding builder.
     // NB: The type specifier here is required due to TS resolving this as `any`

--- a/src/items/held-item-builder.ts
+++ b/src/items/held-item-builder.ts
@@ -160,7 +160,9 @@ export class HeldItemBuilder<Attrs extends HeldItemAttr = never, ConsumableEffec
     return this;
   }
 
-  // #endregion Builder code
+  // #endregion Localization
+
+  // #region Builder code
 
   /**
    * Build a new {@linkcode HeldItem} with the stored attributes and flags.

--- a/src/items/held-item-builder.ts
+++ b/src/items/held-item-builder.ts
@@ -1,4 +1,4 @@
-import type { HeldItemEffect, HeldItemEffectNames } from "#enums/held-item-effect";
+import { HeldItemEffect, type HeldItemEffectNames } from "#enums/held-item-effect";
 import type { HeldItemId } from "#enums/held-item-id";
 import { HeldItem } from "#items/held-item";
 import type { ConsumableHeldItemAttr, HeldItemAttr, HeldItemRecord } from "#items/held-item-attr";
@@ -9,7 +9,7 @@ import type { Constructor } from "type-fest";
 
 /**
  * Internal helper type to add a new attribute to a {@linkcode HeldItemBuilder}, erroring if
- * multiple {@linkcode ConsumableHeldItemAttr}s
+ * multiple {@linkcode ConsumableHeldItemAttr}s are added for the same effect.
  */
 type AddAttrToBuilder<Attrs extends HeldItemAttr, Effects extends HeldItemEffect, NewAttr extends HeldItemAttr> =
   NewAttr extends ConsumableHeldItemAttr<infer E extends HeldItemEffect>
@@ -49,8 +49,10 @@ export class HeldItemBuilder<Attrs extends HeldItemAttr = never, ConsumableEffec
   private descriptionParams?: Parameters<typeof i18next.t>;
   private icon?: string;
 
-  /** Internal sparse map matching effects to their corresponding attributes. */
-  private readonly attrMap: Map<HeldItemEffect, HeldItemAttr[]> = new Map();
+  /** A `Map` matching effects to their corresponding attributes. */
+  private readonly attrMap: Map<HeldItemEffect, HeldItemAttr[]> = new Map(
+    Object.values(HeldItemEffect).map(effect => [effect, []]),
+  );
 
   constructor(id: HeldItemId, maxStackCount = 1) {
     this.id = id;
@@ -81,12 +83,9 @@ export class HeldItemBuilder<Attrs extends HeldItemAttr = never, ConsumableEffec
   private addAttr(attr: HeldItemAttr): void {
     (attr as Mutable<HeldItemAttr>)["type"] = this.id;
     const { effect } = attr;
-    const existing = this.attrMap.get(effect);
-    if (existing) {
-      existing.push(attr);
-    } else {
-      this.attrMap.set(effect, [attr]);
-    }
+    // bang is safe since the constructor initializes the map with all effects set to empty arrays
+    const existing = this.attrMap.get(effect)!;
+    existing.push(attr);
   }
 
   // #endregion Attributes
@@ -167,7 +166,7 @@ export class HeldItemBuilder<Attrs extends HeldItemAttr = never, ConsumableEffec
   }
 
   private buildRecord(): HeldItemRecord<Attrs> {
-    // TODO: Remove type assertion after `Object.keys` PR
+    // TODO: Consider removing type assertion after `Object.keys` PR
     return Object.fromEntries(this.attrMap.entries()) as unknown as HeldItemRecord<Attrs>;
   }
 

--- a/src/items/held-item-builder.ts
+++ b/src/items/held-item-builder.ts
@@ -1,8 +1,8 @@
 import { HeldItemEffect, type HeldItemEffectNames } from "#enums/held-item-effect";
 import type { HeldItemId } from "#enums/held-item-id";
-import type { Pokemon } from "#field/pokemon";
 import { HeldItem } from "#items/held-item";
 import type { ConsumableHeldItemAttr, HeldItemAttr, HeldItemRecord } from "#items/held-item-attr";
+import type { DataMap } from "#types/common";
 import type { ErrorType } from "#types/error-type";
 import type { Mutable } from "#types/type-helpers";
 import type i18next from "i18next";
@@ -49,11 +49,16 @@ export class HeldItemBuilder<Attrs extends HeldItemAttr = never, ConsumableEffec
   private nameParams?: Parameters<typeof i18next.t>;
   private descriptionParams?: Parameters<typeof i18next.t>;
   private icon?: string;
-
-  /** A `Map` matching effects to their corresponding attributes. */
-  private readonly attrMap: Map<HeldItemEffect, HeldItemAttr[]> = new Map(
-    Object.values(HeldItemEffect).map(effect => [effect, []]),
-  );
+  /**
+   * A `DataMap` matching effects to their corresponding (potentially empty) attribute lists.
+   * @remarks
+   * While it is not strictly necessary to populate unused effects with empty arrays, doing so ensures our runtime behaviour
+   * matches the type of `HeldItemRecord<Attrs>` (in which empty arrays are needed to preserve covariance).
+   */
+  private readonly attrMap = new Map(Object.values(HeldItemEffect).map(e => [e, []])) as DataMap<
+    HeldItemEffect,
+    HeldItemAttr[]
+  >;
 
   constructor(id: HeldItemId, maxStackCount = 1) {
     this.id = id;
@@ -191,7 +196,7 @@ export class HeldItemBuilder<Attrs extends HeldItemAttr = never, ConsumableEffec
   }
 
   private buildRecord(): HeldItemRecord<Attrs> {
-    // TODO: Consider removing type assertion after `Object.keys` PR
+    // TODO: Consider removing type assertion after `Object.keys` PR is merged (if possible, albeit likely not)
     return Object.fromEntries(this.attrMap.entries()) as unknown as HeldItemRecord<Attrs>;
   }
 

--- a/src/items/held-item-builder.ts
+++ b/src/items/held-item-builder.ts
@@ -1,5 +1,6 @@
 import { HeldItemEffect, type HeldItemEffectNames } from "#enums/held-item-effect";
 import type { HeldItemId } from "#enums/held-item-id";
+import type { Pokemon } from "#field/pokemon";
 import { HeldItem } from "#items/held-item";
 import type { ConsumableHeldItemAttr, HeldItemAttr, HeldItemRecord } from "#items/held-item-attr";
 import type { ErrorType } from "#types/error-type";

--- a/src/items/held-item-builder.ts
+++ b/src/items/held-item-builder.ts
@@ -123,16 +123,37 @@ export class HeldItemBuilder<Attrs extends HeldItemAttr = never, ConsumableEffec
 
   // #region Localization
 
+  /**
+   * Set this item's name localization parameters.
+   * @param params - The parameters to pass to `i18next.t` when localizing this item's name
+   * @returns `this`
+   * @remarks
+   * If this method is not called, the item will use the default localization key provided by `HeldItemBase`.
+   */
   public name(...params: Parameters<typeof i18next.t>): this {
     this.nameParams = params;
     return this;
   }
 
+  /**
+   * Set this item's description localization parameters.
+   * @param params - The parameters to pass to `i18next.t` when localizing this item's description
+   * @returns `this`
+   * @remarks
+   * If this method is not called, the item will use the default localization key provided by `HeldItemBase`.
+   */
   public description(...params: Parameters<typeof i18next.t>): this {
     this.descriptionParams = params;
     return this;
   }
 
+  /**
+   * Set this item's icon name.
+   * @param iconName - The name of the icon to use for this item
+   * @returns `this`
+   * @remarks
+   * If this method is not called, the item will use the default icon provided by `HeldItemBase`.
+   */
   public iconName(iconName: string): this {
     this.icon = iconName;
     return this;
@@ -152,7 +173,8 @@ export class HeldItemBuilder<Attrs extends HeldItemAttr = never, ConsumableEffec
   public build(): ErrorType<"Cannot create a HeldItem with no attributes!"> | HeldItem<Attrs> {
     // @ts-expect-error - TypeScript doesn't support friend classes, so this is the closest we can get to
     // ensuring `HeldItem` is only constructed by its corresponding builder.
-    // NB: The type specifier here is required due to TS resolving this as `any`
+    // NB: The type annotation here is required due to TS resolving generic private-constructor classes as `any`
+    // when instantiated by outsiders.
     const item: HeldItem<Attrs> = new HeldItem({
       type: this.id,
       effects: this.buildRecord(),

--- a/src/items/held-item-builder.ts
+++ b/src/items/held-item-builder.ts
@@ -16,7 +16,7 @@ type AddAttrToBuilder<Attrs extends HeldItemAttr, Effects extends HeldItemEffect
     ? E extends Effects
       ? ErrorType<`A held item cannot have more than one consumable attribute for a given effect, but 2 were found for HeldItemEffect.${HeldItemEffectNames[E]}!`>
       : HeldItemBuilder<Attrs | NewAttr, Effects | E>
-    : HeldItemBuilder<Attrs | NewAttr, Effects | NewAttr["effect"]>;
+    : HeldItemBuilder<Attrs | NewAttr, Effects>;
 
 /**
  * Builder class for {@linkcode HeldItem} instances.

--- a/src/items/held-item-builder.ts
+++ b/src/items/held-item-builder.ts
@@ -1,10 +1,22 @@
-import type { HeldItemEffect } from "#enums/held-item-effect";
+import type { HeldItemEffect, HeldItemEffectNames } from "#enums/held-item-effect";
 import type { HeldItemId } from "#enums/held-item-id";
-import { ConsumableHeldItem, HeldItem } from "#items/held-item";
-import type { HeldItemAttr, HeldItemRecord } from "#items/held-item-attr";
+import { HeldItem } from "#items/held-item";
+import type { ConsumableHeldItemAttr, HeldItemAttr, HeldItemRecord } from "#items/held-item-attr";
+import type { ErrorType } from "#types/error-type";
 import type { Mutable } from "#types/type-helpers";
 import type i18next from "i18next";
 import type { Constructor } from "type-fest";
+
+/**
+ * Internal helper type to add a new attribute to a {@linkcode HeldItemBuilder}, erroring if
+ * multiple {@linkcode ConsumableHeldItemAttr}s
+ */
+type AddAttrToBuilder<Attrs extends HeldItemAttr, Effects extends HeldItemEffect, NewAttr extends HeldItemAttr> =
+  NewAttr extends ConsumableHeldItemAttr<infer E extends HeldItemEffect>
+    ? E extends Effects
+      ? ErrorType<`A held item cannot have more than one consumable attribute for a given effect, but 2 were found for HeldItemEffect.${HeldItemEffectNames[E]}!`>
+      : HeldItemBuilder<Attrs | NewAttr, Effects | E>
+    : HeldItemBuilder<Attrs | NewAttr, Effects | NewAttr["effect"]>;
 
 /**
  * Builder class for {@linkcode HeldItem} instances.
@@ -12,7 +24,9 @@ import type { Constructor } from "type-fest";
  * Accumulates {@linkcode HeldItemAttr} instances via {@linkcode HeldItemBuilder.attr | attr},
  * before transforming them into a concrete `HeldItem` subclass with {@linkcode HeldItemBuilder.build | build}.
  *
- * @typeParam A - A union of all the {@linkcode HeldItemAttr}s registered so far.
+ * @typeParam Attrs - A union of all the {@linkcode HeldItemAttr}s registered so far.
+ * @typeParam ConsumableEffects - A union of {@linkcode HeldItemEffect}s corresponding to all {@linkcode ConsumableHeldItemAttr}s registered so far;
+ * used to prevent registration of multiple consumable attributes for the same effect.
  *
  * @example
  * ```ts
@@ -22,7 +36,7 @@ import type { Constructor } from "type-fest";
  * ```
  * @sealed
  */
-export class HeldItemBuilder<A extends HeldItemAttr = never> {
+export class HeldItemBuilder<Attrs extends HeldItemAttr = never, ConsumableEffects extends HeldItemEffect = never> {
   public readonly id: HeldItemId;
   /** @defaultValue `1` */
   public readonly maxStackCount: number;
@@ -33,7 +47,7 @@ export class HeldItemBuilder<A extends HeldItemAttr = never> {
 
   private nameParams?: Parameters<typeof i18next.t>;
   private descriptionParams?: Parameters<typeof i18next.t>;
-  private iconName?: string;
+  private icon?: string;
 
   /** Internal sparse map matching effects to their corresponding attributes. */
   private readonly attrMap: Map<HeldItemEffect, HeldItemAttr[]> = new Map();
@@ -47,16 +61,20 @@ export class HeldItemBuilder<A extends HeldItemAttr = never> {
 
   /**
    * Instantiate an {@linkcode HeldItemAttr} and register it on this builder.
-   * @param attrType - The constructor of a {@linkcode HeldItemAttr} subclass
-   * @param args - Arguments forwarded to the constructor.
+   * @param attrType - The constructor of a {@linkcode HeldItemAttr} subclass to instantiate and register
+   * @param args - The arguments used to instantiate `attrType`
    * @returns `this` with `Attr` added to the effect union.
+   * @remarks
+   * If the attribute to be added is a {@linkcode ConsumableHeldItemAttr},
+   * the builder will enforce that it is the _only_ consumable attribute for its respective effects.
    */
-  public attr<Attr extends HeldItemAttr>(
-    attrType: Constructor<Attr>,
-    ...args: ConstructorParameters<Constructor<Attr>>
-  ): HeldItemBuilder<A | Attr> {
+  public attr<C extends Constructor<HeldItemAttr>>(
+    attrType: C,
+    ...args: ConstructorParameters<C>
+  ): AddAttrToBuilder<Attrs, ConsumableEffects, InstanceType<C>>;
+  public attr<C extends Constructor<HeldItemAttr>>(attrType: C, ...args: ConstructorParameters<C>): this {
     this.addAttr(new attrType(...args));
-    return this as unknown as HeldItemBuilder<A | Attr>;
+    return this;
   }
 
   /** Internal helper method to add an attribute to the builder. */
@@ -116,8 +134,8 @@ export class HeldItemBuilder<A extends HeldItemAttr = never> {
     return this;
   }
 
-  public icon(iconName: string): this {
-    this.iconName = iconName;
+  public iconName(iconName: string): this {
+    this.icon = iconName;
     return this;
   }
 
@@ -127,45 +145,28 @@ export class HeldItemBuilder<A extends HeldItemAttr = never> {
    * Build a non-consumable {@linkcode HeldItem} with the stored attributes and flags.
    * @returns A fully-typed `HeldItem` with all registered attributes.
    */
-  public build(): HeldItem<A["effect"]> {
+  public build(): HeldItem<Attrs["effect"]> {
     // @ts-expect-error - TypeScript doesn't support friend classes, so this is the closest we can get to
     // ensuring `HeldItem` is only constructed by its corresponding builder.
     // NB: The type specifier here is required due to TS resolving this as `any`
-    const item: HeldItem<A["effect"]> = new HeldItem({
+    const item: HeldItem<Attrs["effect"]> = new HeldItem({
       type: this.id,
       effects: this.buildRecord(),
       maxStackCount: this.maxStackCount,
       nameParams: this.nameParams,
       descriptionParams: this.descriptionParams,
-      iconName: this.iconName,
+      iconName: this.icon,
     });
     this.applyFlags(item);
     return item;
   }
 
-  /**
-   * Build a {@linkcode ConsumableHeldItem} that supports the {@linkcode ConsumableHeldItem.consume | consume} lifecycle.
-   * @returns A fully-typed `ConsumableHeldItem` with all registered attributes.
-   */
-  public buildConsumable(): ConsumableHeldItem<A["effect"]> {
-    // @ts-expect-error - see comment in `build` for rationale
-    const item: ConsumableHeldItem<A["effect"]> = new ConsumableHeldItem({
-      type: this.id,
-      effects: this.buildRecord(),
-      maxStackCount: this.maxStackCount,
-      nameParams: this.nameParams,
-      descriptionParams: this.descriptionParams,
-      iconName: this.iconName,
-    });
-    this.applyFlags(item);
-    return item;
+  private buildRecord(): HeldItemRecord<Attrs["effect"]> {
+    // TODO: Remove type assertion after `Object.keys` PR
+    return Object.fromEntries(this.attrMap.entries()) as unknown as HeldItemRecord<Attrs["effect"]>;
   }
 
-  private buildRecord(): HeldItemRecord<A["effect"]> {
-    return Object.fromEntries(this.attrMap.entries()) as unknown as HeldItemRecord<A["effect"]>;
-  }
-
-  private applyFlags(item: HeldItem<A["effect"]>): void {
+  private applyFlags(item: HeldItem<Attrs["effect"]>): void {
     if (!this.isTransferable) {
       item.isTransferable = false;
     }

--- a/src/items/held-item-manager.ts
+++ b/src/items/held-item-manager.ts
@@ -7,6 +7,7 @@ import {
   isItemInCategory,
   isItemInRequested,
 } from "#enums/held-item-id";
+import type { CosmeticHeldItem, HeldItem } from "#items/held-item";
 import { ItemManager } from "#items/item-manager";
 import { type HeldItemData, type HeldItemSpecs, isHeldItemSpecs } from "#types/held-item-data-types";
 
@@ -18,7 +19,7 @@ import { type HeldItemData, type HeldItemSpecs, isHeldItemSpecs } from "#types/h
 export class HeldItemManager extends ItemManager<HeldItemId, HeldItemData> {
   // #region Abstract method implementations
   protected override getMaxStackCount(id: HeldItemId): number {
-    return allHeldItems[id].getMaxStackCount();
+    return (allHeldItems[id] satisfies HeldItem | CosmeticHeldItem).getMaxStackCount();
   }
 
   protected override isSpecs(entry: unknown): entry is HeldItemSpecs {

--- a/src/items/held-item-pool.ts
+++ b/src/items/held-item-pool.ts
@@ -6,6 +6,7 @@ import { HeldItemPoolType } from "#enums/reward-pool-type";
 import { RarityTier } from "#enums/reward-tier";
 import { PERMANENT_STATS } from "#enums/stat";
 import type { EnemyPokemon, PlayerPokemon, Pokemon } from "#field/pokemon";
+import type { BerryItemId } from "#items/all-held-items";
 import { attackTypeToHeldItem } from "#items/attack-type-booster";
 import { permanentStatToHeldItem } from "#items/base-stat-multiply";
 import { berryTypeToHeldItem } from "#items/berry";
@@ -161,7 +162,7 @@ export function getNewVitaminHeldItem(customWeights: HeldItemWeights = {}, targe
   return pickedIndex != null ? items[pickedIndex] : 0;
 }
 
-export function getNewBerryHeldItem(customWeights: HeldItemWeights = {}, target?: Pokemon): HeldItemId {
+export function getNewBerryHeldItem(customWeights: HeldItemWeights = {}, target?: Pokemon): BerryItemId {
   const berryTypes = getEnumValues(BerryType);
   const items = berryTypes.map(b => berryTypeToHeldItem[b]);
 

--- a/src/items/held-item.ts
+++ b/src/items/held-item.ts
@@ -113,9 +113,7 @@ export abstract class HeldItemBase {
   }
 }
 
-type HeldItemWithAttr<Attrs extends HeldItemAttr, E extends HeldItemEffect> = [Attrs] extends [HeldItemEffect]
-  ? HeldItem<HeldItemAttr<E>>
-  : HeldItem<Attrs | HeldItemAttr<E>>;
+type HeldItemWithAttr<Attrs extends HeldItemAttr, E extends HeldItemEffect> = HeldItem<Attrs | HeldItemAttr<E>>;
 
 /**
  * Class for all non-cosmetic held items
@@ -127,9 +125,10 @@ type HeldItemWithAttr<Attrs extends HeldItemAttr, E extends HeldItemEffect> = [A
  * While exposing the exact kinds of attributes this class supports technically breaks encapsulation,
  * this is required for existing code to work without excessive type assertions.
  */
-// NB: `any` type parameter is needed to ensure `HeldItem<XYZ>` extends `HeldItem` despite being invariant in `Effects`
-export class HeldItem<Attrs extends HeldItemAttr = any> extends HeldItemBase {
-  /** An object matching each supported {@linkcode HeldItemEffect} to the attributes that implement said effect. */
+export class HeldItem<out Attrs extends HeldItemAttr = HeldItemAttr> extends HeldItemBase {
+  /**
+   * An object matching each supported {@linkcode HeldItemEffect} to the attributes that implement said effect.
+   */
   private readonly effects: HeldItemRecord<Attrs>;
 
   // #region Localization
@@ -189,7 +188,7 @@ export class HeldItem<Attrs extends HeldItemAttr = any> extends HeldItemBase {
    * @sealed
    */
   public hasEffect<E extends HeldItemEffect>(effect: E): this is HeldItemWithAttr<Attrs, E> {
-    return this.effects[effect] != null;
+    return this.effects[effect].length > 0;
   }
 
   /**
@@ -221,7 +220,7 @@ export class HeldItem<Attrs extends HeldItemAttr = any> extends HeldItemBase {
    * @sealed
    */
   public getAttrs<E extends Attrs["effect"]>(effect: E): readonly Extract<Attrs, HeldItemAttr<E>>[] {
-    return this.effects[effect] as unknown as readonly Extract<Attrs, HeldItemAttr<E>>[];
+    return this.effects[effect];
   }
 }
 

--- a/src/items/held-item.ts
+++ b/src/items/held-item.ts
@@ -113,8 +113,6 @@ export abstract class HeldItemBase {
   }
 }
 
-type HeldItemWithAttr<Attrs extends HeldItemAttr, E extends HeldItemEffect> = HeldItem<Attrs | HeldItemAttr<E>>;
-
 /**
  * Class for all non-cosmetic held items
  * (i.e. ones that can have their effects applied during or outside of battle).
@@ -125,7 +123,7 @@ type HeldItemWithAttr<Attrs extends HeldItemAttr, E extends HeldItemEffect> = He
  * While exposing the exact kinds of attributes this class supports technically breaks encapsulation,
  * this is required for existing code to work without excessive type assertions.
  */
-export class HeldItem<out Attrs extends HeldItemAttr = HeldItemAttr> extends HeldItemBase {
+export class HeldItem<Attrs extends HeldItemAttr = HeldItemAttr> extends HeldItemBase {
   /**
    * An object matching each supported {@linkcode HeldItemEffect} to the attributes that implement said effect.
    */
@@ -184,10 +182,10 @@ export class HeldItem<out Attrs extends HeldItemAttr = HeldItemAttr> extends Hel
    * Check whether this item handles the given effect at runtime.
    * Narrows the item's effect set to include `E`.
    * @param effect - The {@linkcode HeldItemEffect} to check
-   * @returns Whether this item has at least 1 attribute for `effect`
+   * @returns Whether this item has at least 1 attribute for `effect`.
    * @sealed
    */
-  public hasEffect<E extends HeldItemEffect>(effect: E): this is HeldItemWithAttr<Attrs, E> {
+  public hasEffect<E extends HeldItemEffect>(effect: E): this is HeldItem<Attrs | HeldItemAttr<E>> {
     return this.effects[effect].length > 0;
   }
 

--- a/src/items/held-item.ts
+++ b/src/items/held-item.ts
@@ -113,16 +113,24 @@ export abstract class HeldItemBase {
   }
 }
 
+type HeldItemWithAttr<Attrs extends HeldItemAttr, E extends HeldItemEffect> = [Attrs] extends [HeldItemEffect]
+  ? HeldItem<HeldItemAttr<E>>
+  : HeldItem<Attrs | HeldItemAttr<E>>;
+
 /**
  * Class for all non-cosmetic held items
  * (i.e. ones that can have their effects applied during or outside of battle).
  *
+ * @typeParam Attrs - A union of {@linkcode HeldItemAttr}s that this class supports.
  * @see {@linkcode HeldItemBuilder}
+ * @privateRemarks
+ * While exposing the exact kinds of attributes this class supports technically breaks encapsulation,
+ * this is required for existing code to work without excessive type assertions.
  */
-// NB: `any` type parameter is needed to ensure `HeldItem<1>` extends `HeldItem` despite being invariant in `Effects`
-export class HeldItem<Effects extends HeldItemEffect = any> extends HeldItemBase {
+// NB: `any` type parameter is needed to ensure `HeldItem<XYZ>` extends `HeldItem` despite being invariant in `Effects`
+export class HeldItem<Attrs extends HeldItemAttr = any> extends HeldItemBase {
   /** An object matching each supported {@linkcode HeldItemEffect} to the attributes that implement said effect. */
-  private readonly effects: HeldItemRecord<Effects>;
+  private readonly effects: HeldItemRecord<Attrs>;
 
   // #region Localization
   /**
@@ -159,7 +167,7 @@ export class HeldItem<Effects extends HeldItemEffect = any> extends HeldItemBase
     iconName,
   }: {
     type: HeldItemId;
-    effects: HeldItemRecord<Effects>;
+    effects: HeldItemRecord<Attrs>;
     maxStackCount?: number;
     nameParams?: Parameters<typeof i18next.t> | undefined;
     descriptionParams?: Parameters<typeof i18next.t> | undefined;
@@ -180,7 +188,7 @@ export class HeldItem<Effects extends HeldItemEffect = any> extends HeldItemBase
    * @returns Whether this item has at least 1 attribute for `effect`
    * @sealed
    */
-  public hasEffect<E extends HeldItemEffect>(effect: E): this is HeldItem<Effects | E> {
+  public hasEffect<E extends HeldItemEffect>(effect: E): this is HeldItemWithAttr<Attrs, E> {
     return this.effects[effect] != null;
   }
 
@@ -195,8 +203,8 @@ export class HeldItem<Effects extends HeldItemEffect = any> extends HeldItemBase
    * (including other consumable attributes) is undefined behavior.
    * @sealed
    */
-  public apply<E extends Effects>(effect: E, params: HeldItemEffectParamMap[E]): void {
-    for (const attr of this.getAttrs(effect)) {
+  public apply<E extends Attrs["effect"]>(effect: E, params: HeldItemEffectParamMap[E]): void {
+    for (const attr of this.getAttrs(effect) as readonly HeldItemAttr<E>[]) {
       if (attr.shouldApply(params)) {
         attr.apply(params);
       }
@@ -206,14 +214,14 @@ export class HeldItem<Effects extends HeldItemEffect = any> extends HeldItemBase
   /**
    * Retrieve all attributes of this item pertaining to the given effect.
    * @param effect - The {@linkcode HeldItemEffect | effect} to retrieve
-   * @returns An array containing all attributes this item has for `effect`;
-   * will be empty if none exist
+   * @returns An array containing all attributes this item has for `effect`.
+   * Is guaranteed to be non-empty for properly constructed `HeldItem`s.
    * @remarks
    * The order of the attributes within the returned array is not guaranteed and should not be relied upon.
    * @sealed
    */
-  public getAttrs<E extends Effects>(effect: E): readonly HeldItemAttr<E>[] {
-    return (this.effects[effect] ?? []) as readonly HeldItemAttr<E>[];
+  public getAttrs<E extends Attrs["effect"]>(effect: E): readonly Extract<Attrs, HeldItemAttr<E>>[] {
+    return this.effects[effect] as unknown as readonly Extract<Attrs, HeldItemAttr<E>>[];
   }
 }
 

--- a/src/items/held-item.ts
+++ b/src/items/held-item.ts
@@ -1,4 +1,3 @@
-import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
 import type { HeldItemEffect } from "#enums/held-item-effect";
 import { type HeldItemId, HeldItemNames } from "#enums/held-item-id";
@@ -7,7 +6,6 @@ import type { HeldItemAttr, HeldItemRecord } from "#items/held-item-attr";
 import type { HeldItemBuilder } from "#items/held-item-builder";
 import type { HeldItemEffectParamMap } from "#types/held-item-parameter";
 import i18next from "i18next";
-import type { NonEmptyTuple } from "type-fest";
 
 /**
  * Base class for all held items, both functional and cosmetic.
@@ -121,9 +119,10 @@ export abstract class HeldItemBase {
  *
  * @see {@linkcode HeldItemBuilder}
  */
-export class HeldItem<Effects extends HeldItemEffect = HeldItemEffect> extends HeldItemBase {
+// NB: `any` type parameter is needed to ensure `HeldItem<1>` extends `HeldItem` despite being invariant in `Effects`
+export class HeldItem<Effects extends HeldItemEffect = any> extends HeldItemBase {
   /** An object matching each supported {@linkcode HeldItemEffect} to the attributes that implement said effect. */
-  public readonly effects: HeldItemRecord<Effects>;
+  private readonly effects: HeldItemRecord<Effects>;
 
   // #region Localization
   /**
@@ -175,25 +174,14 @@ export class HeldItem<Effects extends HeldItemEffect = HeldItemEffect> extends H
   }
 
   /**
-   * Retrieve all {@linkcode HeldItemAttr}s this item has for a given effect.
-   * @param effect - The effect to check
-   * @returns An array containing all attributes of the given type that exist on this item;
-   * will be empty if none exist
-   * @remarks
-   * The order of the attributes within the returned array is unspecified and should not be relied upon.
-   */
-  private getAttrs<E extends Effects>(effect: E): readonly HeldItemAttr<E>[] {
-    return (this.effects[effect] ?? []) as HeldItemAttr<E>[];
-  }
-
-  /**
    * Check whether this item handles the given effect at runtime.
    * Narrows the item's effect set to include `E`.
    * @param effect - The {@linkcode HeldItemEffect} to check
    * @returns Whether this item has at least 1 attribute for `effect`
+   * @sealed
    */
   public hasEffect<E extends HeldItemEffect>(effect: E): this is HeldItem<Effects | E> {
-    return (this.effects as Record<HeldItemEffect, NonEmptyTuple<HeldItemAttr> | undefined>)[effect] != null;
+    return this.effects[effect] != null;
   }
 
   /**
@@ -201,6 +189,9 @@ export class HeldItem<Effects extends HeldItemEffect = HeldItemEffect> extends H
    * {@linkcode HeldItemAttr.shouldApply | shouldApply} conditions.
    * @param effect - The {@linkcode HeldItemEffect | effect} to apply
    * @param params - The parameters to pass to the item attributes' `apply` methods
+   * @remarks
+   * The order of application of multiple attributes for the same effect is not guaranteed and should not be relied upon.
+   * For the context of {@linkcode ConsumableHeldItemAttr}s,
    * @sealed
    */
   public apply<E extends Effects>(effect: E, params: HeldItemEffectParamMap[E]): void {
@@ -210,38 +201,37 @@ export class HeldItem<Effects extends HeldItemEffect = HeldItemEffect> extends H
       }
     }
   }
-}
 
-// TODO: Make this a mixin to avoid diamond problem issues
-/** Class for all {@linkcode HeldItem}s that can be consumed during battle. */
-export class ConsumableHeldItem<Effects extends HeldItemEffect = HeldItemEffect> extends HeldItem<Effects> {
   /**
-   * Consume this item and apply relevant effects.
-   * Should be extended by any subclasses with their own on-consume effects.
-   * @param pokemon - The Pokémon consuming the item
-   * @param remove - Whether to remove the item during consumption; default `true`
-   * @param unburden - Whether to trigger item loss abilities (i.e. Unburden)  when consuming the item; default `true`
+   * Retrieve all attributes of this item pertaining to the given effect.
+   * @param effect - The {@linkcode HeldItemEffect | effect} to retrieve
+   * @returns An array containing all attributes this item has for `effect`;
+   * will be empty if none exist
+   * @remarks
+   * The order of the attributes within the returned array is not guaranteed and should not be relied upon.
    * @sealed
    */
-  public consume(pokemon: Pokemon, remove = true, unburden = true): void {
-    if (remove) {
-      pokemon.heldItemManager.remove(this.type, 1);
-      // TODO: Turn this into updateItemBar or something
-      globalScene.updateItems(pokemon.isPlayer());
-    }
-    if (unburden) {
-      applyAbAttrs("PostItemLostAbAttr", { pokemon });
-    }
+  public getAttrs<E extends Effects>(effect: E): readonly HeldItemAttr<E>[] {
+    return (this.effects[effect] ?? []) as readonly HeldItemAttr<E>[];
   }
 }
 
-/** Abstract class for all items that are purely cosmetic.
+/**
+ * Abstract class for all items that are purely cosmetic.
  * Currently coincides with the {@linkcode HeldItemBase} class.
- * Might become concrete later on if we want cosmetic items without a subclass. */
+ * Might become concrete later on if we want cosmetic items without a subclass.
+ *
+ * @remarks
+ * All cosmetic held items are innately non-stealable, non-transferable, and un-suppressable.
+ */
 export abstract class CosmeticHeldItem extends HeldItemBase {
   /**
    * This field does not exist at runtime and must not be used.
    * Its sole purpose is to ensure that typescript is able to properly differentiate cosmetic items from normal ones.
    */
   private declare _: never;
+
+  public override readonly isStealable = false;
+  public override readonly isSuppressable = false;
+  public override readonly isTransferable = false;
 }

--- a/src/items/held-item.ts
+++ b/src/items/held-item.ts
@@ -2,7 +2,7 @@ import { globalScene } from "#app/global-scene";
 import type { HeldItemEffect } from "#enums/held-item-effect";
 import { type HeldItemId, HeldItemNames } from "#enums/held-item-id";
 import type { Pokemon } from "#field/pokemon";
-import type { HeldItemAttr, HeldItemRecord } from "#items/held-item-attr";
+import type { ConsumableHeldItemAttr, HeldItemAttr, HeldItemRecord } from "#items/held-item-attr";
 import type { HeldItemBuilder } from "#items/held-item-builder";
 import type { HeldItemEffectParamMap } from "#types/held-item-parameter";
 import i18next from "i18next";
@@ -190,8 +190,9 @@ export class HeldItem<Effects extends HeldItemEffect = any> extends HeldItemBase
    * @param effect - The {@linkcode HeldItemEffect | effect} to apply
    * @param params - The parameters to pass to the item attributes' `apply` methods
    * @remarks
-   * The order of application of multiple attributes for the same effect is not guaranteed and should not be relied upon.
-   * For the context of {@linkcode ConsumableHeldItemAttr}s,
+   * The execution order of multiple attributes is not guaranteed and should not be relied upon. \
+   * Notably, this means that combining {@linkcode ConsumableHeldItemAttr}s with other attributes that depend on the item's current stack count
+   * (including other consumable attributes) is undefined behavior.
    * @sealed
    */
   public apply<E extends Effects>(effect: E, params: HeldItemEffectParamMap[E]): void {

--- a/src/items/held-item.ts
+++ b/src/items/held-item.ts
@@ -32,6 +32,8 @@ export abstract class HeldItemBase {
    */
   public isSuppressable = true;
 
+  // TODO: Remove these defaults for non-cosmetic held items (and maybe cosmetic ones as well)
+  // in favor of explicitly specifying them for each item
   public get name(): string {
     return i18next.t(`modifierType:ModifierType.${HeldItemNames[this.type]}.name`);
   }

--- a/src/items/held-item.ts
+++ b/src/items/held-item.ts
@@ -3,8 +3,9 @@ import { globalScene } from "#app/global-scene";
 import type { HeldItemEffect } from "#enums/held-item-effect";
 import { type HeldItemId, HeldItemNames } from "#enums/held-item-id";
 import type { Pokemon } from "#field/pokemon";
+import type { HeldItemAttr, HeldItemRecord } from "#items/held-item-attr";
+import type { HeldItemBuilder } from "#items/held-item-builder";
 import type { HeldItemEffectParamMap } from "#types/held-item-parameter";
-import type { Mutable } from "#types/type-helpers";
 import i18next from "i18next";
 import type { NonEmptyTuple } from "type-fest";
 
@@ -12,10 +13,11 @@ import type { NonEmptyTuple } from "type-fest";
  * Base class for all held items, both functional and cosmetic.
  */
 export abstract class HeldItemBase {
-  // TODO: Renme parameter to `id` or similar
+  // TODO: Rename parameter to `id` or similar
   public readonly type: HeldItemId;
   public readonly maxStackCount: number;
   // TODO: Consider converting these to a bitmask for efficiency
+
   /**
    * Whether this item can be transferred to another {@linkcode Pokemon}.
    * @defaultValue `true`
@@ -32,21 +34,21 @@ export abstract class HeldItemBase {
    */
   public isSuppressable = true;
 
-  constructor(type: HeldItemId, maxStackCount = 1) {
-    this.type = type;
-    this.maxStackCount = maxStackCount;
-  }
-
-  get name(): string {
+  public get name(): string {
     return i18next.t(`modifierType:ModifierType.${HeldItemNames[this.type]}.name`);
   }
 
-  get description(): string {
+  public get description(): string {
     return i18next.t(`modifierType:ModifierType.${HeldItemNames[this.type]}.description`);
   }
 
-  get iconName(): string {
+  public get iconName(): string {
     return `${HeldItemNames[this.type]?.toLowerCase()}`;
+  }
+
+  constructor(type: HeldItemId, maxStackCount = 1) {
+    this.type = type;
+    this.maxStackCount = maxStackCount;
   }
 
   // TODO: https://github.com/pagefaultgames/pokerogue/pull/5656#discussion_r2114950716
@@ -111,64 +113,108 @@ export abstract class HeldItemBase {
   getScoreMultiplier(): number {
     return 1;
   }
-
-  untransferable(): this {
-    (this as Mutable<this>).isTransferable = false;
-    return this;
-  }
-
-  unstealable(): this {
-    this.isStealable = false;
-    return this;
-  }
-
-  unsuppressable(): this {
-    this.isSuppressable = false;
-    return this;
-  }
 }
 
 /**
- * Abstract class for all non-cosmetic held items
+ * Class for all non-cosmetic held items
  * (i.e. ones that can have their effects applied during or outside of battle).
+ *
+ * @see {@linkcode HeldItemBuilder}
  */
-// TODO: Try and make items that have multiple effects more ergonomic rather than requiring dynamic dispatch
-export abstract class HeldItem<
-  T extends NonEmptyTuple<HeldItemEffect> = NonEmptyTuple<HeldItemEffect>,
-> extends HeldItemBase {
-  /**
-   * A readonly tuple containing all {@linkcode HeldItemEffect | effects} that this class can apply.
-   * @privateRemarks
-   * Please sort entries in ascending numerical order (for consistency)
-   */
-  public abstract readonly effects: Readonly<T>;
+export class HeldItem<Effects extends HeldItemEffect = HeldItemEffect> extends HeldItemBase {
+  /** An object matching each supported {@linkcode HeldItemEffect} to the attributes that implement said effect. */
+  public readonly effects: HeldItemRecord<Effects>;
 
+  // #region Localization
   /**
-   * Check whether a given effect of this item should apply.
-   * @typeParam E - The type of one of this class' {@linkcode HeldItem.effects | effects}
-   * @param effect - The {@linkcode HeldItemEffect | effect} being applied
-   * @param args - Arguments required for the effect application
-   * @returns Whether the effect should apply.
-   * Defaults to `true` if not overridden.
+   * Optional parameters used to localize this item's name.
+   * If omitted, will use the default implementation provided from {@linkcode HeldItemBase}.
    */
-  // biome-ignore lint/correctness/noUnusedFunctionParameters: pseudo-abstract method
-  public shouldApply<E extends T[number]>(effect: E, args: HeldItemEffectParamMap[E]): boolean {
-    return true;
+  private readonly nameParams?: Parameters<typeof i18next.t> | undefined;
+  /**
+   * Optional parameters used to localize this item's description.
+   * If omitted, will use the default implementation provided from {@linkcode HeldItemBase}.
+   */
+  private readonly descriptionParams?: Parameters<typeof i18next.t> | undefined;
+  public readonly customIconName?: string | undefined;
+
+  public override get name(): string {
+    return this.nameParams ? i18next.t(...this.nameParams) : super.name;
+  }
+
+  public override get description(): string {
+    return this.descriptionParams ? i18next.t(...this.descriptionParams) : super.description;
+  }
+
+  public override get iconName(): string {
+    return this.customIconName ?? super.iconName;
+  }
+  // #endregion Localization
+
+  protected constructor({
+    type,
+    effects,
+    maxStackCount = 1,
+    nameParams,
+    descriptionParams,
+    iconName,
+  }: {
+    type: HeldItemId;
+    effects: HeldItemRecord<Effects>;
+    maxStackCount?: number;
+    nameParams?: Parameters<typeof i18next.t> | undefined;
+    descriptionParams?: Parameters<typeof i18next.t> | undefined;
+    iconName?: string | undefined;
+  }) {
+    super(type, maxStackCount);
+
+    this.effects = effects;
+    this.nameParams = nameParams;
+    this.descriptionParams = descriptionParams;
+    this.customIconName = iconName;
   }
 
   /**
-   * Apply the given item's effects.
-   * Called if and only if {@linkcode HeldItem.shouldApply | shouldApply} returns `true`.
-   * @typeParam E - The type of one of this class' {@linkcode HeldItem.effects | effects}
-   * @param effect - The effect being applied
-   * @param args - Arguments required for the effect application
+   * Retrieve all {@linkcode HeldItemAttr}s this item has for a given effect.
+   * @param effect - The effect to check
+   * @returns An array containing all attributes of the given type that exist on this item;
+   * will be empty if none exist
+   * @remarks
+   * The order of the attributes within the returned array is unspecified and should not be relied upon.
    */
-  public abstract apply<E extends T[number]>(effect: E, param: HeldItemEffectParamMap[E]): void;
+  private getAttrs<E extends Effects>(effect: E): readonly HeldItemAttr<E>[] {
+    return (this.effects[effect] ?? []) as HeldItemAttr<E>[];
+  }
+
+  /**
+   * Check whether this item handles the given effect at runtime.
+   * Narrows the item's effect set to include `E`.
+   * @param effect - The {@linkcode HeldItemEffect} to check
+   * @returns Whether this item has at least 1 attribute for `effect`
+   */
+  public hasEffect<E extends HeldItemEffect>(effect: E): this is HeldItem<Effects | E> {
+    return (this.effects as Record<HeldItemEffect, NonEmptyTuple<HeldItemAttr> | undefined>)[effect] != null;
+  }
+
+  /**
+   * Apply all of this item's attributes that pertain to the given effect, subject to their individual
+   * {@linkcode HeldItemAttr.shouldApply | shouldApply} conditions.
+   * @param effect - The {@linkcode HeldItemEffect | effect} to apply
+   * @param params - The parameters to pass to the item attributes' `apply` methods
+   * @sealed
+   */
+  public apply<E extends Effects>(effect: E, params: HeldItemEffectParamMap[E]): void {
+    for (const attr of this.getAttrs(effect)) {
+      if (attr.shouldApply(params)) {
+        attr.apply(params);
+      }
+    }
+  }
 }
 
 // TODO: Make this a mixin to avoid diamond problem issues
-/** Abstract class for all `HeldItem`s that can be consumed during battle. */
-export abstract class ConsumableHeldItem<T extends NonEmptyTuple<HeldItemEffect>> extends HeldItem<T> {
+/** Class for all {@linkcode HeldItem}s that can be consumed during battle. */
+export class ConsumableHeldItem<Effects extends HeldItemEffect = HeldItemEffect> extends HeldItem<Effects> {
   /**
    * Consume this item and apply relevant effects.
    * Should be extended by any subclasses with their own on-consume effects.

--- a/src/items/held-items/accuracy-booster.ts
+++ b/src/items/held-items/accuracy-booster.ts
@@ -1,25 +1,21 @@
 import { HeldItemEffect } from "#enums/held-item-effect";
-import type { HeldItemId } from "#enums/held-item-id";
-import { HeldItem } from "#items/held-item";
+import { HeldItemAttr } from "#items/held-item-attr";
 import type { AccuracyBoostParams } from "#types/held-item-parameter";
 
 /**
- * Class used for items that boost move accuracy by a flat amount.
+ * Attribute used for items that boost move accuracy by a flat amount.
  * @sealed
  */
-export class AccuracyBoosterHeldItem extends HeldItem<[typeof HeldItemEffect.ACCURACY_BOOSTER]> {
-  public readonly effects = [HeldItemEffect.ACCURACY_BOOSTER] as const;
+export class AccuracyBoosterHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.ACCURACY_BOOSTER> {
+  public override readonly effect = HeldItemEffect.ACCURACY_BOOSTER;
   private readonly accuracyAmount: number;
 
-  constructor(type: HeldItemId, maxStackCount: number, accuracy: number) {
-    super(type, maxStackCount);
-    this.accuracyAmount = accuracy;
+  constructor(accuracyAmount: number) {
+    super();
+    this.accuracyAmount = accuracyAmount;
   }
 
-  public override apply(
-    _effect: typeof HeldItemEffect.ACCURACY_BOOSTER,
-    { pokemon, moveAccuracy }: AccuracyBoostParams,
-  ): void {
+  public override apply({ pokemon, moveAccuracy }: AccuracyBoostParams): void {
     const stackCount = pokemon.heldItemManager.getStack(this.type);
     moveAccuracy.value += this.accuracyAmount * stackCount;
   }

--- a/src/items/held-items/attack-type-booster.ts
+++ b/src/items/held-items/attack-type-booster.ts
@@ -1,7 +1,7 @@
 import { HeldItemEffect } from "#enums/held-item-effect";
 import { HeldItemId, HeldItemNames } from "#enums/held-item-id";
 import { PokemonType } from "#enums/pokemon-type";
-import { HeldItem } from "#items/held-item";
+import { HeldItemAttr } from "#items/held-item-attr";
 import type { AttackTypeBoostParams } from "#types/held-item-parameter";
 import i18next from "i18next";
 
@@ -24,20 +24,20 @@ export const attackTypeToHeldItem = {
   [PokemonType.DRAGON]: HeldItemId.DRAGON_FANG,
   [PokemonType.DARK]: HeldItemId.BLACK_GLASSES,
   [PokemonType.FAIRY]: HeldItemId.FAIRY_FEATHER,
-} as const;
+} as const satisfies Record<Exclude<PokemonType, PokemonType.UNKNOWN | PokemonType.STELLAR>, HeldItemId>;
 
-export class AttackTypeBoosterHeldItem extends HeldItem<[typeof HeldItemEffect.ATTACK_TYPE_BOOST]> {
-  public readonly effects = [HeldItemEffect.ATTACK_TYPE_BOOST] as const;
-  public moveType: PokemonType;
-  public powerBoost: number;
+export class AttackTypeBoostHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.ATTACK_TYPE_BOOST> {
+  public override readonly effect = HeldItemEffect.ATTACK_TYPE_BOOST;
+  public readonly moveType: PokemonType;
+  public readonly powerBoost: number;
 
-  // This constructor may need a revision
-  constructor(type: HeldItemId, maxStackCount: number, moveType: PokemonType, powerBoost: number) {
-    super(type, maxStackCount);
+  constructor(moveType: PokemonType, powerBoost: number) {
+    super();
     this.moveType = moveType;
     this.powerBoost = powerBoost;
   }
 
+  // TODO: Move to builder
   get name(): string {
     return i18next.t(`modifierType:AttackTypeBoosterItem.${HeldItemNames[this.type]?.toLowerCase()}`);
   }
@@ -48,18 +48,12 @@ export class AttackTypeBoosterHeldItem extends HeldItem<[typeof HeldItemEffect.A
     });
   }
 
-  public override shouldApply(
-    _effect: typeof HeldItemEffect.ATTACK_TYPE_BOOST,
-    { moveType, movePower }: AttackTypeBoostParams,
-  ): boolean {
+  public override shouldApply({ moveType, movePower }: AttackTypeBoostParams): boolean {
     // TODO: Investigate why there's a check against movePower being less than 1
     return moveType === this.moveType && movePower.value >= 1;
   }
 
-  public override apply(
-    _effect: typeof HeldItemEffect.ATTACK_TYPE_BOOST,
-    { pokemon, movePower }: AttackTypeBoostParams,
-  ): void {
+  public override apply({ pokemon, movePower }: AttackTypeBoostParams): void {
     // TODO: Don't round this
     const stackCount = pokemon.heldItemManager.getStack(this.type);
     movePower.value = Math.floor(movePower.value * (1 + stackCount * this.powerBoost));

--- a/src/items/held-items/attack-type-booster.ts
+++ b/src/items/held-items/attack-type-booster.ts
@@ -1,9 +1,8 @@
 import { HeldItemEffect } from "#enums/held-item-effect";
-import { HeldItemId, HeldItemNames } from "#enums/held-item-id";
+import { HeldItemId } from "#enums/held-item-id";
 import { PokemonType } from "#enums/pokemon-type";
 import { HeldItemAttr } from "#items/held-item-attr";
 import type { AttackTypeBoostParams } from "#types/held-item-parameter";
-import i18next from "i18next";
 
 export const attackTypeToHeldItem = {
   [PokemonType.NORMAL]: HeldItemId.SILK_SCARF,
@@ -35,17 +34,6 @@ export class AttackTypeBoostHeldItemAttr extends HeldItemAttr<typeof HeldItemEff
     super();
     this.moveType = moveType;
     this.powerBoost = powerBoost;
-  }
-
-  // TODO: Move to builder
-  get name(): string {
-    return i18next.t(`modifierType:AttackTypeBoosterItem.${HeldItemNames[this.type]?.toLowerCase()}`);
-  }
-
-  get description(): string {
-    return i18next.t("modifierType:ModifierType.AttackTypeBoosterModifierType.description", {
-      moveType: i18next.t(`pokemonInfo:Type.${PokemonType[this.moveType]}`),
-    });
   }
 
   public override shouldApply({ moveType, movePower }: AttackTypeBoostParams): boolean {

--- a/src/items/held-items/base-stat-add.ts
+++ b/src/items/held-items/base-stat-add.ts
@@ -3,7 +3,6 @@ import { Stat } from "#enums/stat";
 import type { Pokemon } from "#field/pokemon";
 import { HeldItemAttr } from "#items/held-item-attr";
 import type { BaseStatParams } from "#types/held-item-parameter";
-import i18next from "i18next";
 
 // TODO: Consider combining these 2 into a single base class for extensibility
 
@@ -16,10 +15,6 @@ const OLD_GATEAU_STAT_MODIFIER = 20;
  */
 export class OldGateauHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.BASE_STAT_ADD> {
   public override readonly effect = HeldItemEffect.BASE_STAT_ADD;
-
-  get description(): string {
-    return i18next.t("modifierType:ModifierType.PokemonBaseStatFlatModifierType.description");
-  }
 
   public override apply({ pokemon, baseStats }: BaseStatParams): void {
     const stats = this.getStats(pokemon);

--- a/src/items/held-items/base-stat-add.ts
+++ b/src/items/held-items/base-stat-add.ts
@@ -1,31 +1,32 @@
 import { HeldItemEffect } from "#enums/held-item-effect";
-import type { HeldItemId } from "#enums/held-item-id";
 import { Stat } from "#enums/stat";
 import type { Pokemon } from "#field/pokemon";
-import { HeldItem } from "#items/held-item";
+import { HeldItemAttr } from "#items/held-item-attr";
 import type { BaseStatParams } from "#types/held-item-parameter";
 import i18next from "i18next";
+
+// TODO: Consider combining these 2 into a single base class for extensibility
+
+const OLD_GATEAU_STAT_MODIFIER = 20;
 
 /**
  * Class to add +20 base stats to the lowest of HP/Spd, lowest of Atk/SpAtk, and lowest of Def/SpDef.
  * Used for Old Gateau.
  * @sealed
  */
-export class OldGateauHeldItem extends HeldItem<[typeof HeldItemEffect.BASE_STAT_ADD]> {
-  public readonly effects = [HeldItemEffect.BASE_STAT_ADD] as const;
-  public isTransferable = false;
+export class OldGateauHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.BASE_STAT_ADD> {
+  public override readonly effect = HeldItemEffect.BASE_STAT_ADD;
 
   get description(): string {
     return i18next.t("modifierType:ModifierType.PokemonBaseStatFlatModifierType.description");
   }
 
-  public override apply(_effect: typeof HeldItemEffect.BASE_STAT_ADD, { pokemon, baseStats }: BaseStatParams): void {
+  public override apply({ pokemon, baseStats }: BaseStatParams): void {
     const stats = this.getStats(pokemon);
-    const statModifier = 20;
+    // TODO: This is inefficient and clunky
     baseStats.forEach((v, i) => {
       if (stats.includes(i)) {
-        const newVal = Math.floor(v + statModifier);
-        baseStats[i] = Phaser.Math.Clamp(newVal, 1, 999999);
+        baseStats[i] = Phaser.Math.Clamp(v + OLD_GATEAU_STAT_MODIFIER, 1, 999999);
       }
     });
   }
@@ -45,36 +46,19 @@ export class OldGateauHeldItem extends HeldItem<[typeof HeldItemEffect.BASE_STAT
 }
 
 /**
- * Currently used by Shuckle Juice item
+ * Attribute for the Shuckle Juice mystery encounter items. \
+ * Adds {@linkcode statModifier} to all base stats (HP gains half the modifier).
  */
-export class ShuckleJuiceHeldItem extends HeldItem<[typeof HeldItemEffect.BASE_STAT_ADD]> {
-  public readonly effects = [HeldItemEffect.BASE_STAT_ADD] as const;
-  public isTransferable = false;
-  public statModifier: number;
+export class ShuckleJuiceHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.BASE_STAT_ADD> {
+  public override readonly effect = HeldItemEffect.BASE_STAT_ADD;
+  public readonly statModifier: number;
 
-  constructor(type: HeldItemId, maxStackCount: number, statModifier: number) {
-    super(type, maxStackCount);
+  constructor(statModifier: number) {
+    super();
     this.statModifier = statModifier;
   }
 
-  override get name(): string {
-    return this.statModifier > 0
-      ? i18next.t("modifierType:ModifierType.MYSTERY_ENCOUNTER_SHUCKLE_JUICE_GOOD.name")
-      : i18next.t("modifierType:ModifierType.MYSTERY_ENCOUNTER_SHUCKLE_JUICE_BAD.name");
-  }
-
-  // TODO: where is this description shown?
-  override get description(): string {
-    return this.statModifier > 0
-      ? i18next.t("modifierType:ModifierType.MYSTERY_ENCOUNTER_SHUCKLE_JUICE_GOOD.description")
-      : i18next.t("modifierType:ModifierType.MYSTERY_ENCOUNTER_SHUCKLE_JUICE_BAD.description");
-  }
-
-  override get iconName(): string {
-    return this.statModifier > 0 ? "berry_juice_good" : "berry_juice_bad";
-  }
-
-  public override apply(_effect: typeof HeldItemEffect.BASE_STAT_ADD, { baseStats }: BaseStatParams): void {
+  public override apply({ baseStats }: BaseStatParams): void {
     baseStats.forEach((value, index) => {
       // HP is affected by half as much as other stats
       const mod = index === 0 ? this.statModifier / 2 : this.statModifier;

--- a/src/items/held-items/base-stat-multiply.ts
+++ b/src/items/held-items/base-stat-multiply.ts
@@ -1,9 +1,8 @@
 import { HeldItemEffect } from "#enums/held-item-effect";
 import { HeldItemId } from "#enums/held-item-id";
-import { getStatKey, type PermanentStat, Stat } from "#enums/stat";
+import { type PermanentStat, Stat } from "#enums/stat";
 import { HeldItemAttr } from "#items/held-item-attr";
 import type { BaseStatParams } from "#types/held-item-parameter";
-import i18next from "i18next";
 
 export const permanentStatToHeldItem = {
   [Stat.HP]: HeldItemId.HP_UP,
@@ -35,21 +34,6 @@ export class BaseStatMultiplyHeldItemAttr extends HeldItemAttr<typeof HeldItemEf
   constructor(stat: PermanentStat) {
     super();
     this.stat = stat;
-  }
-
-  // TODO: Move to builder
-  get name(): string {
-    return i18next.t(`modifierType:BaseStatBoosterItem.${statBoostItems[this.stat]}`);
-  }
-
-  get description(): string {
-    return i18next.t("modifierType:ModifierType.BaseStatBoosterModifierType.description", {
-      stat: i18next.t(getStatKey(this.stat)),
-    });
-  }
-
-  get iconName(): string {
-    return statBoostItems[this.stat];
   }
 
   public override apply({ pokemon, baseStats }: BaseStatParams): void {

--- a/src/items/held-items/base-stat-multiply.ts
+++ b/src/items/held-items/base-stat-multiply.ts
@@ -1,7 +1,7 @@
 import { HeldItemEffect } from "#enums/held-item-effect";
 import { HeldItemId } from "#enums/held-item-id";
 import { getStatKey, type PermanentStat, Stat } from "#enums/stat";
-import { HeldItem } from "#items/held-item";
+import { HeldItemAttr } from "#items/held-item-attr";
 import type { BaseStatParams } from "#types/held-item-parameter";
 import i18next from "i18next";
 
@@ -27,16 +27,17 @@ export const statBoostItems: Record<PermanentStat, string> = {
  * Class used for items that multiply a given base stat.
  * Used for the various Vitamin items.
  */
-export class BaseStatMultiplyHeldItem extends HeldItem<[typeof HeldItemEffect.BASE_STAT_MULTIPLY]> {
-  public readonly effects = [HeldItemEffect.BASE_STAT_MULTIPLY] as const;
-  /** The {@linkcode PermanentStat} to boost */
+export class BaseStatMultiplyHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.BASE_STAT_MULTIPLY> {
+  public override readonly effect = HeldItemEffect.BASE_STAT_MULTIPLY;
+  /** The {@linkcode PermanentStat} to boost. */
   private readonly stat: PermanentStat;
 
-  constructor(type: HeldItemId, maxStackCount: number, stat: PermanentStat) {
-    super(type, maxStackCount);
+  constructor(stat: PermanentStat) {
+    super();
     this.stat = stat;
   }
 
+  // TODO: Move to builder
   get name(): string {
     return i18next.t(`modifierType:BaseStatBoosterItem.${statBoostItems[this.stat]}`);
   }
@@ -51,10 +52,7 @@ export class BaseStatMultiplyHeldItem extends HeldItem<[typeof HeldItemEffect.BA
     return statBoostItems[this.stat];
   }
 
-  public override apply(
-    _effect: typeof HeldItemEffect.BASE_STAT_MULTIPLY,
-    { pokemon, baseStats }: BaseStatParams,
-  ): void {
+  public override apply({ pokemon, baseStats }: BaseStatParams): void {
     const stackCount = pokemon.heldItemManager.getStack(this.type);
     const { stat } = this;
     baseStats[stat] = Math.floor(baseStats[stat] * (1 + stackCount * 0.1));

--- a/src/items/held-items/baton.ts
+++ b/src/items/held-items/baton.ts
@@ -1,10 +1,10 @@
 import { HeldItemEffect } from "#enums/held-item-effect";
-import { HeldItem } from "#items/held-item";
+import { HeldItemAttr } from "#items/held-item-attr";
 import type { BatonParams } from "#types/held-item-parameter";
 
-export class BatonHeldItem extends HeldItem<[typeof HeldItemEffect.BATON]> {
-  public readonly effects = [HeldItemEffect.BATON] as const;
+export class BatonHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.BATON> {
+  public override readonly effect = HeldItemEffect.BATON;
 
   // TODO: This seems suspicious...
-  apply(_effect: typeof HeldItemEffect.BATON, _params: BatonParams): void {}
+  public override apply(_params: BatonParams): void {}
 }

--- a/src/items/held-items/berry.ts
+++ b/src/items/held-items/berry.ts
@@ -5,12 +5,13 @@ import { HeldItemEffect } from "#enums/held-item-effect";
 import { HeldItemId } from "#enums/held-item-id";
 import { TrainerItemEffect } from "#enums/trainer-item-effect";
 import { BerryUsedEvent } from "#events/battle-scene";
+import type { BerryItemId } from "#items/all-held-items";
 import { ConsumableHeldItemAttr } from "#items/held-item-attr";
 import type { BerryParams } from "#types/held-item-parameter";
 import { BooleanHolder } from "#utils/common";
 
 type BerryTypeToHeldItemMap = {
-  [key in BerryType]: HeldItemId;
+  [key in BerryType]: BerryItemId;
 };
 
 // TODO: Rework this to use a bitwise XOR

--- a/src/items/held-items/berry.ts
+++ b/src/items/held-items/berry.ts
@@ -5,7 +5,7 @@ import { HeldItemEffect } from "#enums/held-item-effect";
 import { HeldItemId } from "#enums/held-item-id";
 import { TrainerItemEffect } from "#enums/trainer-item-effect";
 import { BerryUsedEvent } from "#events/battle-scene";
-import { ConsumableHeldItem } from "#items/held-item";
+import { ConsumableHeldItemAttr } from "#items/held-item-attr";
 import type { BerryParams } from "#types/held-item-parameter";
 import { BooleanHolder } from "#utils/common";
 
@@ -28,18 +28,17 @@ export const berryTypeToHeldItem = {
   [BerryType.LEPPA]: HeldItemId.LEPPA_BERRY,
 } satisfies BerryTypeToHeldItemMap;
 
-// TODO: Maybe split up into subclasses?
-export class BerryHeldItem extends ConsumableHeldItem<[typeof HeldItemEffect.BERRY]> {
-  public readonly effects = [HeldItemEffect.BERRY] as const;
-  public berryType: BerryType;
+// TODO: Split up the berry effect into multiple ones if/when berry phase is reworked
+export class BerryHeldItemAttr extends ConsumableHeldItemAttr<typeof HeldItemEffect.BERRY> {
+  public override readonly effect = HeldItemEffect.BERRY;
+  public readonly berryType: BerryType;
 
-  constructor(berryType: BerryType, maxStackCount = 1) {
-    const type = berryTypeToHeldItem[berryType];
-    super(type, maxStackCount);
-
+  constructor(berryType: BerryType) {
+    super();
     this.berryType = berryType;
   }
 
+  // TODO: Move to builder
   get name(): string {
     return getBerryName(this.berryType);
   }
@@ -52,11 +51,11 @@ export class BerryHeldItem extends ConsumableHeldItem<[typeof HeldItemEffect.BER
     return `${BerryType[this.berryType].toLowerCase()}_berry`;
   }
 
-  override shouldApply(_effect: typeof HeldItemEffect.BERRY, { pokemon }: BerryParams): boolean {
+  public override shouldApply({ pokemon }: BerryParams): boolean {
     return getBerryPredicate(this.berryType)(pokemon);
   }
 
-  apply(_effect: typeof HeldItemEffect.BERRY, { pokemon }: BerryParams): void {
+  public override apply({ pokemon }: BerryParams): void {
     const preserve = new BooleanHolder(false);
     globalScene.applyPlayerItems(TrainerItemEffect.PRESERVE_BERRY, { pokemon, doPreserve: preserve });
     const consumed = !preserve.value;
@@ -67,7 +66,7 @@ export class BerryHeldItem extends ConsumableHeldItem<[typeof HeldItemEffect.BER
     // Update berry eaten trackers for Belch, Harvest, Cud Chew, etc.
     // Don't recover if we proc berry pouch (no item duplication)
     pokemon.recordEatenBerry(this.berryType, consumed);
-    // TODO: remove event emission after battle move flyout PR is merged
+    // TODO: remove event emission after battle move flyout PR is merged (which moves it into `getBerryEffectFunc`)
 
     globalScene.eventTarget.dispatchEvent(new BerryUsedEvent(pokemon, this.berryType));
   }

--- a/src/items/held-items/berry.ts
+++ b/src/items/held-items/berry.ts
@@ -1,5 +1,5 @@
 import { globalScene } from "#app/global-scene";
-import { getBerryEffectDescription, getBerryEffectFunc, getBerryName, getBerryPredicate } from "#data/berry";
+import { getBerryEffectFunc, getBerryPredicate } from "#data/berry";
 import { BerryType } from "#enums/berry-type";
 import { HeldItemEffect } from "#enums/held-item-effect";
 import { HeldItemId } from "#enums/held-item-id";
@@ -37,19 +37,6 @@ export class BerryHeldItemAttr extends ConsumableHeldItemAttr<typeof HeldItemEff
   constructor(berryType: BerryType) {
     super();
     this.berryType = berryType;
-  }
-
-  // TODO: Move to builder
-  get name(): string {
-    return getBerryName(this.berryType);
-  }
-
-  get description(): string {
-    return getBerryEffectDescription(this.berryType);
-  }
-
-  get iconName(): string {
-    return `${BerryType[this.berryType].toLowerCase()}_berry`;
   }
 
   public override shouldApply({ pokemon }: BerryParams): boolean {

--- a/src/items/held-items/bypass-speed-chance.ts
+++ b/src/items/held-items/bypass-speed-chance.ts
@@ -3,35 +3,33 @@ import { getPokemonNameWithAffix } from "#app/messages";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { Command } from "#enums/command";
 import { HeldItemEffect } from "#enums/held-item-effect";
-import { HeldItem } from "#items/held-item";
+import { HeldItemAttr } from "#items/held-item-attr";
 import type { BypassSpeedChanceParams } from "#types/held-item-parameter";
 import i18next from "i18next";
 
 /**
- * Class used for items that allow a Pokémon to randomly move first in their priority bracket.
+ * Attribute used for items that allow a Pokémon to randomly move first in their priority bracket.
  * @see {@link https://bulbapedia.bulbagarden.net/wiki/Quick_Claw}
  * @sealed
  */
-export class BypassSpeedChanceHeldItem extends HeldItem<[typeof HeldItemEffect.BYPASS_SPEED_CHANCE]> {
-  public readonly effects = [HeldItemEffect.BYPASS_SPEED_CHANCE] as const;
+export class BypassSpeedChanceHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.BYPASS_SPEED_CHANCE> {
+  public override readonly effect = HeldItemEffect.BYPASS_SPEED_CHANCE;
 
-  override shouldApply(
-    _effect: typeof HeldItemEffect.BYPASS_SPEED_CHANCE,
-    { pokemon }: BypassSpeedChanceParams,
-  ): boolean {
+  public override shouldApply({ pokemon }: BypassSpeedChanceParams): boolean {
     const stackCount = pokemon.heldItemManager.getStack(this.type);
     return pokemon.randBattleSeedInt(10) < stackCount;
   }
 
-  apply(_effect: typeof HeldItemEffect.BYPASS_SPEED_CHANCE, { pokemon }: BypassSpeedChanceParams): void {
+  public override apply({ pokemon }: BypassSpeedChanceParams): void {
     pokemon.addTag(BattlerTagType.BYPASS_SPEED);
 
     const isCommandFight = globalScene.currentBattle.turnCommands[pokemon.getBattlerIndex()]?.command === Command.FIGHT;
     if (isCommandFight) {
+      // TODO: Remove the `itemName` parameter
       globalScene.phaseManager.queueMessage(
         i18next.t("modifier:bypassSpeedChanceApply", {
           pokemonName: getPokemonNameWithAffix(pokemon),
-          itemName: this.name,
+          itemName: this.item.name,
         }),
       );
     }

--- a/src/items/held-items/crit-booster.ts
+++ b/src/items/held-items/crit-booster.ts
@@ -1,54 +1,45 @@
 import { HeldItemEffect } from "#enums/held-item-effect";
-import type { HeldItemId } from "#enums/held-item-id";
 import type { SpeciesId } from "#enums/species-id";
-import { HeldItem } from "#items/held-item";
+import { HeldItemAttr } from "#items/held-item-attr";
 import type { CritBoostParams } from "#types/held-item-parameter";
 
 /**
- * Modifier used for held items that apply critical-hit stage boost(s).
- * using a multiplier.
- * @see {@linkcode apply}
+ * Attribute used for held items that increase the critical hit ratio of the Pokemon's moves.
  */
-export class CritBoostHeldItem extends HeldItem<[typeof HeldItemEffect.CRIT_BOOST]> {
-  public readonly effects = [HeldItemEffect.CRIT_BOOST] as const;
+export class CritBoostHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.CRIT_BOOST> {
+  public override readonly effect = HeldItemEffect.CRIT_BOOST;
 
-  /** The amount of stages by which the held item increases the current critical-hit stage value */
-  protected stageIncrement: number;
+  /** The amount of stages to increase the critical-hit stage by */
+  protected stages: number;
 
-  constructor(type: HeldItemId, maxStackCount: number, stageIncrement: number) {
-    super(type, maxStackCount);
+  constructor(stageIncrement: number) {
+    super();
 
-    this.stageIncrement = stageIncrement;
+    this.stages = stageIncrement;
   }
 
-  /**
-   * Increases the current critical-hit stage value by {@linkcode stageIncrement}.
-   * @param _pokemon {@linkcode Pokemon} N/A
-   * @param critStage {@linkcode NumberHolder} that holds the resulting critical-hit level
-   * @returns always `true`
-   */
-  apply(_effect: typeof HeldItemEffect.CRIT_BOOST, { critStage }: CritBoostParams): void {
-    critStage.value += this.stageIncrement;
+  public override apply({ critStage }: CritBoostParams): void {
+    critStage.value += this.stages;
   }
 }
 
 /**
- * Class used for held items that apply critical-hit stage boost(s) if the holder is of a specific {@linkcode SpeciesId}.
+ * Attribute used for held items that only apply critical-hit boosts to specific species.
  */
-export class SpeciesCritBoostHeldItem extends CritBoostHeldItem {
+export class SpeciesCritBoostHeldItemAttr extends CritBoostHeldItemAttr {
   /** The species that the held item's critical-hit stage boost applies to */
   private readonly species: readonly SpeciesId[];
 
-  constructor(type: HeldItemId, maxStackCount: number, stageIncrement: number, species: readonly SpeciesId[]) {
-    super(type, maxStackCount, stageIncrement);
+  constructor(stageIncrement: number, species: readonly SpeciesId[]) {
+    super(stageIncrement);
 
     this.species = species;
   }
 
-  public override shouldApply(effect: typeof HeldItemEffect.CRIT_BOOST, params: CritBoostParams): boolean {
-    const pokemon = params.pokemon;
+  public override shouldApply(params: CritBoostParams): boolean {
+    const { pokemon } = params;
     return (
-      super.shouldApply(effect, params)
+      super.shouldApply(params)
       && (this.species.includes(pokemon.getSpeciesForm(true).speciesId)
         || (pokemon.isFusion() && this.species.includes(pokemon.getFusionSpeciesForm(true).speciesId)))
     );

--- a/src/items/held-items/crit-booster.ts
+++ b/src/items/held-items/crit-booster.ts
@@ -2,6 +2,7 @@ import { HeldItemEffect } from "#enums/held-item-effect";
 import type { SpeciesId } from "#enums/species-id";
 import { HeldItemAttr } from "#items/held-item-attr";
 import type { CritBoostParams } from "#types/held-item-parameter";
+import type { NonEmptyTuple } from "type-fest";
 
 /**
  * Attribute used for held items that increase the critical hit ratio of the Pokemon's moves.
@@ -27,10 +28,10 @@ export class CritBoostHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.CR
  * Attribute used for held items that only apply critical-hit boosts to specific species.
  */
 export class SpeciesCritBoostHeldItemAttr extends CritBoostHeldItemAttr {
-  /** The species that the held item's critical-hit stage boost applies to */
-  private readonly species: readonly SpeciesId[];
+  /** The species that the held item's critical-hit stage boost should apply to */
+  private readonly species: NonEmptyTuple<SpeciesId>;
 
-  constructor(stageIncrement: number, species: readonly SpeciesId[]) {
+  constructor(stageIncrement: number, species: NonEmptyTuple<SpeciesId>) {
     super(stageIncrement);
 
     this.species = species;
@@ -39,9 +40,8 @@ export class SpeciesCritBoostHeldItemAttr extends CritBoostHeldItemAttr {
   public override shouldApply(params: CritBoostParams): boolean {
     const { pokemon } = params;
     return (
-      super.shouldApply(params)
-      && (this.species.includes(pokemon.getSpeciesForm(true).speciesId)
-        || (pokemon.isFusion() && this.species.includes(pokemon.getFusionSpeciesForm(true).speciesId)))
+      this.species.includes(pokemon.getSpeciesForm(true).speciesId)
+      || (pokemon.isFusion() && this.species.includes(pokemon.getFusionSpeciesForm(true).speciesId))
     );
   }
 }

--- a/src/items/held-items/damage-money-reward.ts
+++ b/src/items/held-items/damage-money-reward.ts
@@ -1,19 +1,19 @@
 import { globalScene } from "#app/global-scene";
 import { HeldItemEffect } from "#enums/held-item-effect";
 import { TrainerItemEffect } from "#enums/trainer-item-effect";
-import { HeldItem } from "#items/held-item";
+import { HeldItemAttr } from "#items/held-item-attr";
 import type { DamageMoneyRewardParams } from "#types/held-item-parameter";
 import { NumberHolder } from "#utils/common";
 
 /**
- * Class used for held items that grant money based on damage dealt in battle.
+ * Attribute used for held items that grant money based on damage dealt in battle.
  * Used for Golden Punch.
  * @sealed
  */
-export class DamageMoneyRewardHeldItem extends HeldItem<[typeof HeldItemEffect.DAMAGE_MONEY_REWARD]> {
-  public readonly effects = [HeldItemEffect.DAMAGE_MONEY_REWARD] as const;
+export class DamageMoneyRewardHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.DAMAGE_MONEY_REWARD> {
+  public override readonly effect = HeldItemEffect.DAMAGE_MONEY_REWARD;
 
-  apply(_effect: typeof HeldItemEffect.DAMAGE_MONEY_REWARD, { pokemon, damage }: DamageMoneyRewardParams): void {
+  public override apply({ pokemon, damage }: DamageMoneyRewardParams): void {
     const stackCount = pokemon.heldItemManager.getStack(this.type);
     const moneyAmount = new NumberHolder(Math.floor(damage * (0.5 * stackCount)));
     globalScene.applyPlayerItems(TrainerItemEffect.MONEY_MULTIPLIER, { numberHolder: moneyAmount });

--- a/src/items/held-items/evo-tracker.ts
+++ b/src/items/held-items/evo-tracker.ts
@@ -13,7 +13,6 @@ import i18next from "i18next";
 abstract class EvoTrackerHeldItem extends CosmeticHeldItem {
   protected species: SpeciesId;
   protected required: number;
-  public isTransferable = false;
 
   constructor(type: HeldItemId, maxStackCount: number, species: SpeciesId, required: number) {
     super(type, maxStackCount);

--- a/src/items/held-items/exp-booster.ts
+++ b/src/items/held-items/exp-booster.ts
@@ -1,32 +1,25 @@
 import { HeldItemEffect } from "#enums/held-item-effect";
-import type { HeldItemId } from "#enums/held-item-id";
-import { HeldItem } from "#items/held-item";
+import { HeldItemAttr } from "#items/held-item-attr";
 import type { ExpBoostParams } from "#types/held-item-parameter";
-import i18next from "i18next";
 
 /**
- * Class used for items that boost the amount of experience gained from battles.
+ * Attribute used for items that boost the amount of experience gained from battles.
  * Used for Lucky and Golden Eggs.
+ * @sealed
  */
-export class ExpBoosterHeldItem extends HeldItem<[typeof HeldItemEffect.EXP_BOOSTER]> {
-  public readonly effects = [HeldItemEffect.EXP_BOOSTER] as const;
+export class ExpBoosterHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.EXP_BOOSTER> {
+  public override readonly effect = HeldItemEffect.EXP_BOOSTER;
   /** The percentage boost to experience gained. */
   // TODO: This should arguably be stored as a decimal instead of % for consistency with other similar effects
   private readonly boostPercent: number;
 
-  constructor(type: HeldItemId, maxStackCount: number, boostPercent: number) {
-    super(type, maxStackCount);
+  constructor(boostPercent: number) {
+    super();
     this.boostPercent = boostPercent;
   }
 
-  get description(): string {
-    return i18next.t("modifierType:ModifierType.PokemonExpBoosterModifierType.description", {
-      boostPercent: this.boostPercent,
-    });
-  }
-
-  apply(_effect: typeof HeldItemEffect.EXP_BOOSTER, { pokemon, expAmount }: ExpBoostParams): void {
+  public override apply({ pokemon, expAmount }: ExpBoostParams): void {
     const stackCount = pokemon.heldItemManager.getStack(this.type);
-    expAmount.value = Math.floor(expAmount.value * (1 + stackCount * this.boostPercent * 0.01));
+    expAmount.value = Math.floor(expAmount.value * (1 + (stackCount * this.boostPercent) / 100));
   }
 }

--- a/src/items/held-items/field-effect.ts
+++ b/src/items/held-items/field-effect.ts
@@ -1,21 +1,21 @@
 import { HeldItemEffect } from "#enums/held-item-effect";
-import { HeldItem } from "#items/held-item";
+import { HeldItemAttr } from "#items/held-item-attr";
 import type { FieldEffectParams } from "#types/held-item-parameter";
 
 /**
- * Class for held items that extend the duration of weather and terrain effects.
+ * Attribute for held items that extend the duration of weather and terrain effects.
  * Used for Mystical Rock.
  * @sealed
  */
 // TODO: Rename this to be more descriptive
-export class FieldEffectHeldItem extends HeldItem<[typeof HeldItemEffect.FIELD_EFFECT]> {
-  public readonly effects = [HeldItemEffect.FIELD_EFFECT] as const;
+export class FieldEffectHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.FIELD_EFFECT> {
+  public override readonly effect = HeldItemEffect.FIELD_EFFECT;
 
   /**
    * Provides two more turns per stack to any weather or terrain effect caused
    * by the holder.
    */
-  apply(_effect: typeof HeldItemEffect.FIELD_EFFECT, { pokemon, fieldDuration }: FieldEffectParams): void {
+  public override apply({ pokemon, fieldDuration }: FieldEffectParams): void {
     fieldDuration.value += 2 * pokemon.heldItemManager.getStack(this.type);
   }
 }

--- a/src/items/held-items/flinch-chance.ts
+++ b/src/items/held-items/flinch-chance.ts
@@ -1,6 +1,5 @@
 import { HeldItemEffect } from "#enums/held-item-effect";
-import type { HeldItemId } from "#enums/held-item-id";
-import { HeldItem } from "#items/held-item";
+import { HeldItemAttr } from "#items/held-item-attr";
 import type { FlinchChanceParams } from "#types/held-item-parameter";
 
 /**
@@ -8,30 +7,21 @@ import type { FlinchChanceParams } from "#types/held-item-parameter";
  * @see {@link https://bulbapedia.bulbagarden.net/wiki/King%27s_Rock}
  * @sealed
  */
-export class FlinchChanceHeldItem extends HeldItem<[typeof HeldItemEffect.FLINCH_CHANCE]> {
-  public readonly effects = [HeldItemEffect.FLINCH_CHANCE] as const;
+export class FlinchChanceHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.FLINCH_CHANCE> {
+  public override readonly effect = HeldItemEffect.FLINCH_CHANCE;
   private readonly chance: number;
 
-  constructor(type: HeldItemId, maxStackCount: number, chance: number) {
-    super(type, maxStackCount);
-
+  constructor(chance: number) {
+    super();
     this.chance = chance;
   }
 
-  /**
-   * Checks if {@linkcode FlinchChanceModifier} should be applied
-   * @param _effect - Unused
-   * @param flinched {@linkcode BooleanHolder} that is `true` if the pokemon flinched
-   */
-  override shouldApply(
-    _effect: typeof HeldItemEffect.FLINCH_CHANCE,
-    { pokemon, flinched }: FlinchChanceParams,
-  ): boolean {
+  public override shouldApply({ pokemon, flinched }: FlinchChanceParams): boolean {
     const stackCount = pokemon.heldItemManager.getStack(this.type);
     return !flinched.value && pokemon.randBattleSeedInt(100) < stackCount * this.chance;
   }
 
-  apply(_effect: typeof HeldItemEffect.FLINCH_CHANCE, { flinched }: FlinchChanceParams): void {
+  public override apply({ flinched }: FlinchChanceParams): void {
     flinched.value = true;
   }
 }

--- a/src/items/held-items/friendship-booster.ts
+++ b/src/items/held-items/friendship-booster.ts
@@ -1,20 +1,15 @@
 import { HeldItemEffect } from "#enums/held-item-effect";
-import { HeldItem } from "#items/held-item";
+import { HeldItemAttr } from "#items/held-item-attr";
 import type { FriendshipBoostParams } from "#types/held-item-parameter";
-import i18next from "i18next";
 
 /**
  * Class used for items that boost the amount of friendship gained from battles.
  * @see {@link https://bulbapedia.bulbagarden.net/wiki/Soothe_Bell}
  */
-export class FriendshipBoosterHeldItem extends HeldItem<[typeof HeldItemEffect.FRIENDSHIP_BOOSTER]> {
-  public readonly effects = [HeldItemEffect.FRIENDSHIP_BOOSTER] as const;
+export class FriendshipBoosterHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.FRIENDSHIP_BOOSTER> {
+  public override readonly effect = HeldItemEffect.FRIENDSHIP_BOOSTER;
 
-  get description(): string {
-    return i18next.t("modifierType:ModifierType.PokemonFriendshipBoosterModifierType.description");
-  }
-
-  apply(_effect: typeof HeldItemEffect.FRIENDSHIP_BOOSTER, { pokemon, friendship }: FriendshipBoostParams): void {
+  public override apply({ pokemon, friendship }: FriendshipBoostParams): void {
     const stackCount = pokemon.heldItemManager.getStack(this.type);
     friendship.value = Math.floor(friendship.value * (1 + 0.5 * stackCount));
   }

--- a/src/items/held-items/hit-heal.ts
+++ b/src/items/held-items/hit-heal.ts
@@ -1,37 +1,25 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { HeldItemEffect } from "#enums/held-item-effect";
-import { HeldItem } from "#items/held-item";
+import { HeldItemAttr } from "#items/held-item-attr";
 import { PokemonHealPhase } from "#phases/pokemon-heal-phase";
 import type { HitHealParams } from "#types/held-item-parameter";
 import { toDmgValue } from "#utils/common";
 import i18next from "i18next";
 
 /**
- * Class used for items that heal the holder by a fraction of the damage dealt in battle.
+ * Attribute used for items that heal the holder by a fraction of the damage dealt in battle.
  * @see {@link https://bulbapedia.bulbagarden.net/wiki/Shell_Bell}
  * @sealed
  */
-export class HitHealHeldItem extends HeldItem<[typeof HeldItemEffect.HIT_HEAL]> {
-  public readonly effects = [HeldItemEffect.HIT_HEAL] as const;
+export class HitHealHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.HIT_HEAL> {
+  public override readonly effect = HeldItemEffect.HIT_HEAL;
 
-  get name(): string {
-    return i18next.t("modifierType:ModifierType.SHELL_BELL.name");
-  }
-
-  get description(): string {
-    return i18next.t("modifierType:ModifierType.SHELL_BELL.description");
-  }
-
-  get iconName(): string {
-    return "shell_bell";
-  }
-
-  public override shouldApply(_effect: typeof HeldItemEffect.HIT_HEAL, { pokemon }: HitHealParams): boolean {
+  public override shouldApply({ pokemon }: HitHealParams): boolean {
     return pokemon.turnData.totalDamageDealt > 0 && !pokemon.isFullHp();
   }
 
-  apply(_effect: typeof HeldItemEffect.HIT_HEAL, { pokemon }: HitHealParams): void {
+  public override apply({ pokemon }: HitHealParams): void {
     const stackCount = pokemon.heldItemManager.getStack(this.type);
 
     // TODO: This will need to be adjusted after the pokemon heal phase refactor
@@ -41,7 +29,7 @@ export class HitHealHeldItem extends HeldItem<[typeof HeldItemEffect.HIT_HEAL]> 
         toDmgValue(pokemon.turnData.totalDamageDealt / 8) * stackCount,
         i18next.t("modifier:hitHealApply", {
           pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
-          typeName: this.name,
+          typeName: this.item.name,
         }),
         true,
       ),

--- a/src/items/held-items/instant-revive.ts
+++ b/src/items/held-items/instant-revive.ts
@@ -2,20 +2,21 @@ import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { HeldItemEffect } from "#enums/held-item-effect";
-import { ConsumableHeldItem } from "#items/held-item";
+import { ConsumableHeldItemAttr } from "#items/held-item-attr";
 import { PokemonHealPhase } from "#phases/pokemon-heal-phase";
 import type { InstantReviveParams } from "#types/held-item-parameter";
 import { toDmgValue } from "#utils/common";
 import i18next from "i18next";
 
 /**
- * Class used for items that revive a Pokemon when it faints to direct damage.
+ * Attributes used for items that revive a Pokemon when it faints to direct damage.
  * Used for Reviver Seed.
  * @sealed
  */
-export class InstantReviveHeldItem extends ConsumableHeldItem<[typeof HeldItemEffect.INSTANT_REVIVE]> {
-  public readonly effects = [HeldItemEffect.INSTANT_REVIVE] as const;
+export class InstantReviveHeldItemAttr extends ConsumableHeldItemAttr<typeof HeldItemEffect.INSTANT_REVIVE> {
+  public override readonly effect = HeldItemEffect.INSTANT_REVIVE;
 
+  // TODO: Move to builder
   get name(): string {
     return i18next.t("modifierType:ModifierType.REVIVER_SEED.name");
   }
@@ -28,7 +29,7 @@ export class InstantReviveHeldItem extends ConsumableHeldItem<[typeof HeldItemEf
     return "reviver_seed";
   }
 
-  apply(_effect: typeof HeldItemEffect.INSTANT_REVIVE, { pokemon }: InstantReviveParams): void {
+  public override apply({ pokemon }: InstantReviveParams): void {
     // TODO: Since this should be the only place `revive=true` is passed to `PokemonHealPhase`, we can remove it
     // later on
     globalScene.phaseManager.unshiftPhase(

--- a/src/items/held-items/instant-revive.ts
+++ b/src/items/held-items/instant-revive.ts
@@ -16,19 +16,6 @@ import i18next from "i18next";
 export class InstantReviveHeldItemAttr extends ConsumableHeldItemAttr<typeof HeldItemEffect.INSTANT_REVIVE> {
   public override readonly effect = HeldItemEffect.INSTANT_REVIVE;
 
-  // TODO: Move to builder
-  get name(): string {
-    return i18next.t("modifierType:ModifierType.REVIVER_SEED.name");
-  }
-
-  get description(): string {
-    return i18next.t("modifierType:ModifierType.REVIVER_SEED.description");
-  }
-
-  get iconName(): string {
-    return "reviver_seed";
-  }
-
   public override apply({ pokemon }: InstantReviveParams): void {
     // TODO: Since this should be the only place `revive=true` is passed to `PokemonHealPhase`, we can remove it
     // later on
@@ -38,7 +25,7 @@ export class InstantReviveHeldItemAttr extends ConsumableHeldItemAttr<typeof Hel
         toDmgValue(pokemon.getMaxHp() / 2),
         i18next.t("modifier:pokemonInstantReviveApply", {
           pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
-          typeName: this.name,
+          typeName: this.item.name,
         }),
         false,
         false,

--- a/src/items/held-items/item-steal.ts
+++ b/src/items/held-items/item-steal.ts
@@ -4,21 +4,20 @@ import { allHeldItems } from "#data/data-lists";
 import { HeldItemEffect } from "#enums/held-item-effect";
 import type { HeldItemId } from "#enums/held-item-id";
 import { Pokemon } from "#field/pokemon";
-import { HeldItem } from "#items/held-item";
+import { HeldItemAttr } from "#items/held-item-attr";
 import type { ItemStealParams } from "#types/held-item-parameter";
 import { coerceArray, randSeedFloat } from "#utils/common";
 import i18next from "i18next";
-import type { NonEmptyTuple } from "type-fest";
 
 /**
  * Abstract class for held items that steal other Pokemon's items.
- * @see {@linkcode TurnEndItemStealHeldItem}
- * @see {@linkcode ContactItemStealChanceHeldItem}
+ * @see {@linkcode TurnEndItemStealHeldItemAttr}
+ * @see {@linkcode ContactItemStealChanceHeldItemAttr}
  */
-export abstract class ItemTransferHeldItem<T extends NonEmptyTuple<HeldItemEffect>> extends HeldItem<T> {
+abstract class ItemTransferHeldItemAttr<T extends HeldItemEffect> extends HeldItemAttr<T> {
   /** @sealed */
   // TODO: This works but can perhaps be done more elegantly
-  public override apply(_effect: this["effects"][number], params: ItemStealParams): void {
+  public override apply(params: ItemStealParams): void {
     const opponents = this.getTargets(params);
 
     if (opponents.length === 0) {
@@ -64,68 +63,53 @@ export abstract class ItemTransferHeldItem<T extends NonEmptyTuple<HeldItemEffec
 }
 
 /**
- * Held item that steal items from the enemy at the end of
- * each turn.
+ * Attribute for held items that steal items from the enemy at the end of each turn.
+ * @sealed
  */
-export class TurnEndItemStealHeldItem extends ItemTransferHeldItem<[typeof HeldItemEffect.TURN_END_ITEM_STEAL]> {
-  public readonly effects = [HeldItemEffect.TURN_END_ITEM_STEAL] as const;
-  isTransferable = true;
-
-  get description(): string {
-    return i18next.t("modifierType:ModifierType.TurnHeldItemTransferModifierType.description");
-  }
+export class TurnEndItemStealHeldItemAttr extends ItemTransferHeldItemAttr<typeof HeldItemEffect.TURN_END_ITEM_STEAL> {
+  public override readonly effect = HeldItemEffect.TURN_END_ITEM_STEAL;
 
   /**
    * Determines the targets to transfer items from when this applies.
    * @param pokemon the {@linkcode Pokemon} holding this item
-   * @param _args N/A
    * @returns the opponents of the source {@linkcode Pokemon}
    */
-  getTargets(params: ItemStealParams): Pokemon[] {
+  protected override getTargets(params: ItemStealParams): Pokemon[] {
     // TODO: this will always be defined, might be placeholder?
     return params.pokemon instanceof Pokemon ? params.pokemon.getOpponents() : [];
   }
 
-  getTransferredItemCount(_params: ItemStealParams): number {
+  protected override getTransferredItemCount(): number {
     return 1;
   }
 
-  getTransferMessage(params: ItemStealParams, itemId: HeldItemId): string {
+  protected override getTransferMessage({ target, pokemon }: ItemStealParams, itemId: HeldItemId): string {
     return i18next.t("modifier:turnHeldItemTransferApply", {
-      pokemonNameWithAffix: getPokemonNameWithAffix(params.target),
+      pokemonNameWithAffix: getPokemonNameWithAffix(target),
       itemName: allHeldItems[itemId].name,
-      pokemonName: params.pokemon.getNameToRender(),
-      typeName: this.name,
+      pokemonName: pokemon.getNameToRender(),
+      typeName: this.item.name,
     });
-  }
-
-  setTransferrableFalse(): void {
-    this.isTransferable = false;
   }
 }
 
 /**
- * Held item that adds a chance to steal items from the target of a
+ * Attribute for held items that add a chance to steal items from the target of a
  * successful attack.
+ * @sealed
  */
-export class ContactItemStealChanceHeldItem extends ItemTransferHeldItem<
-  [typeof HeldItemEffect.CONTACT_ITEM_STEAL_CHANCE]
+export class ContactItemStealChanceHeldItemAttr extends ItemTransferHeldItemAttr<
+  typeof HeldItemEffect.CONTACT_ITEM_STEAL_CHANCE
 > {
-  public readonly effects = [HeldItemEffect.CONTACT_ITEM_STEAL_CHANCE] as const;
+  public override readonly effect = HeldItemEffect.CONTACT_ITEM_STEAL_CHANCE;
   public readonly chancePercent: number;
   public readonly chance: number;
 
-  constructor(type: HeldItemId, maxStackCount: number, chancePercent: number) {
-    super(type, maxStackCount);
+  constructor(chancePercent: number) {
+    super();
 
     this.chancePercent = chancePercent;
     this.chance = chancePercent / 100;
-  }
-
-  get description(): string {
-    return i18next.t("modifierType:ModifierType.ContactHeldItemTransferChanceModifierType.description", {
-      chancePercent: this.chancePercent,
-    });
   }
 
   /**
@@ -134,21 +118,21 @@ export class ContactItemStealChanceHeldItem extends ItemTransferHeldItem<
    * @param targetPokemon - The {@linkcode Pokemon} the holder is targeting with an attack
    * @returns The target {@linkcode Pokemon} as array for further use in `apply` implementations
    */
-  getTargets({ target }: ItemStealParams): Pokemon[] {
+  protected override getTargets({ target }: ItemStealParams): Pokemon[] {
     return target ? coerceArray(target) : [];
   }
 
-  getTransferredItemCount({ pokemon }: ItemStealParams): number {
+  protected override getTransferredItemCount({ pokemon }: ItemStealParams): number {
     const stackCount = pokemon.heldItemManager.getStack(this.type);
     return randSeedFloat() <= this.chance * stackCount ? 1 : 0;
   }
 
-  getTransferMessage({ pokemon, target }: ItemStealParams, itemId: HeldItemId): string {
+  protected override getTransferMessage({ pokemon, target }: ItemStealParams, itemId: HeldItemId): string {
     return i18next.t("modifier:contactHeldItemTransferApply", {
       pokemonNameWithAffix: getPokemonNameWithAffix(target),
       itemName: allHeldItems[itemId].name,
       pokemonName: pokemon.getNameToRender(),
-      typeName: this.name,
+      typeName: this.item.name,
     });
   }
 }

--- a/src/items/held-items/macho-brace.ts
+++ b/src/items/held-items/macho-brace.ts
@@ -1,17 +1,16 @@
 import { HeldItemEffect } from "#enums/held-item-effect";
 import { Stat } from "#enums/stat";
-import { HeldItem } from "#items/held-item";
+import { HeldItemAttr } from "#items/held-item-attr";
 import type { StatBoostParams } from "#types/held-item-parameter";
 import i18next from "i18next";
 
 /**
  * Currently used by Macho Brace item
  */
-export class MachoBraceHeldItem extends HeldItem<[typeof HeldItemEffect.MACHO_BRACE]> {
-  // TODO: Rename to be more general instead of tying the effect to its sole use
-  public readonly effects = [HeldItemEffect.MACHO_BRACE] as const;
-  public readonly isTransferable = false;
+export class MachoBraceHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.MACHO_BRACE> {
+  public override readonly effect = HeldItemEffect.MACHO_BRACE;
 
+  // TODO: Move to builder
   get name(): string {
     return i18next.t("modifierType:ModifierType.MYSTERY_ENCOUNTER_MACHO_BRACE.name") + " (new)";
   }
@@ -20,15 +19,16 @@ export class MachoBraceHeldItem extends HeldItem<[typeof HeldItemEffect.MACHO_BR
     return i18next.t("modifierType:ModifierType.MYSTERY_ENCOUNTER_MACHO_BRACE.description");
   }
 
-  apply(_effect: typeof HeldItemEffect.MACHO_BRACE, { pokemon, statHolder, stat }: StatBoostParams): void {
-    const stackCount = pokemon.heldItemManager.getStack(this.type);
+  public override apply({ pokemon, statHolder, stat }: StatBoostParams): void {
+    const { heldItemManager: manager } = pokemon;
+    const stackCount = manager.getStack(this.type);
 
     // Modifies the passed in stat number holder by +2 per stack for HP, +1 per stack for other stats
     // If the Macho Brace is at max stacks (50), adds additional 10% to total HP and 5% to other stats
     const isHp = stat === Stat.HP;
 
     statHolder.value += isHp ? 2 * stackCount : stackCount;
-    if (stackCount === this.maxStackCount) {
+    if (manager.isMaxStack(this.type)) {
       statHolder.value = Math.floor(statHolder.value * (isHp ? 1.1 : 1.05));
     }
   }

--- a/src/items/held-items/macho-brace.ts
+++ b/src/items/held-items/macho-brace.ts
@@ -2,22 +2,12 @@ import { HeldItemEffect } from "#enums/held-item-effect";
 import { Stat } from "#enums/stat";
 import { HeldItemAttr } from "#items/held-item-attr";
 import type { StatBoostParams } from "#types/held-item-parameter";
-import i18next from "i18next";
 
 /**
  * Currently used by Macho Brace item
  */
 export class MachoBraceHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.MACHO_BRACE> {
   public override readonly effect = HeldItemEffect.MACHO_BRACE;
-
-  // TODO: Move to builder
-  get name(): string {
-    return i18next.t("modifierType:ModifierType.MYSTERY_ENCOUNTER_MACHO_BRACE.name") + " (new)";
-  }
-
-  get description(): string {
-    return i18next.t("modifierType:ModifierType.MYSTERY_ENCOUNTER_MACHO_BRACE.description");
-  }
 
   public override apply({ pokemon, statHolder, stat }: StatBoostParams): void {
     const { heldItemManager: manager } = pokemon;

--- a/src/items/held-items/multi-hit.ts
+++ b/src/items/held-items/multi-hit.ts
@@ -1,92 +1,47 @@
 import { allMoves } from "#data/data-lists";
 import { HeldItemEffect } from "#enums/held-item-effect";
-import type { Pokemon } from "#field/pokemon";
-import { HeldItem } from "#items/held-item";
+import { HeldItemAttr } from "#items/held-item-attr";
 import type { MultiHitCountParams, MultiHitDamageParams } from "#types/held-item-parameter";
-import type { NumberHolder } from "#utils/common";
-import i18next from "i18next";
 
 /**
- * Class used for held items that add additional hits to a move and reduce its damage proportionally.
+ * Attribute used for held items that add additional hits to a move.
  * Used by Multi Lens.
  * @sealed
  */
-export class MultiHitHeldItem extends HeldItem<
-  [typeof HeldItemEffect.MULTI_HIT_COUNT, typeof HeldItemEffect.MULTI_HIT_DAMAGE]
-> {
-  public readonly effects = [HeldItemEffect.MULTI_HIT_COUNT, HeldItemEffect.MULTI_HIT_DAMAGE] as const;
+export class MultiHitCountHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.MULTI_HIT_COUNT> {
+  public override readonly effect = HeldItemEffect.MULTI_HIT_COUNT;
 
-  public override get description(): string {
-    return i18next.t("modifierType:ModifierType.PokemonMultiHitModifierType.description");
+  public override shouldApply({ moveId, pokemon }: MultiHitCountParams): boolean {
+    return allMoves[moveId].canBeMultiStrikeEnhanced(pokemon);
   }
 
-  private shouldApplyDamageModifier({ pokemon }: MultiHitDamageParams): boolean {
+  /**
+   * For each stack, reduces the damage of the hit by 25%
+   * @param params - The parameters associated with the effect
+   */
+  public override apply({ pokemon, count }: MultiHitCountParams): void {
     const stackCount = pokemon.heldItemManager.getStack(this.type);
-    return (
-      pokemon.turnData.hitsLeft === pokemon.turnData.hitCount
-      || pokemon.turnData.hitCount - pokemon.turnData.hitsLeft !== stackCount + 1
-    );
+    count.value += stackCount;
   }
+}
 
-  override shouldApply(
-    effect: typeof HeldItemEffect.MULTI_HIT_COUNT | typeof HeldItemEffect.MULTI_HIT_DAMAGE,
-    params: MultiHitCountParams & MultiHitDamageParams,
-  ): boolean {
-    const { moveId, pokemon } = params;
+export class MultiHitDamageModifyHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.MULTI_HIT_DAMAGE> {
+  public override readonly effect = HeldItemEffect.MULTI_HIT_DAMAGE;
+
+  public override shouldApply({ moveId, pokemon }: MultiHitDamageParams): boolean {
     const move = allMoves[moveId];
-
     if (!move.canBeMultiStrikeEnhanced(pokemon)) {
       return false;
     }
 
-    if (effect === HeldItemEffect.MULTI_HIT_DAMAGE) {
-      return this.shouldApplyDamageModifier(params);
-    }
-
-    return true;
-  }
-
-  /**
-   * For each stack, adds one additional hit
-   * @param effect - {@linkcode HeldItemEffect.MULTI_HIT_COUNT}
-   * @param params - The parameters associated with the effect
-   */
-  public override apply(effect: typeof HeldItemEffect.MULTI_HIT_COUNT, params: MultiHitCountParams): void;
-  /**
-   * For each stack, reduces the damage of the hit by 25%
-   * @param effect - {@linkcode HeldItemEffect.MULTI_HIT_DAMAGE}
-   * @param params - The parameters associated with the effect
-   */
-  public override apply(effect: typeof HeldItemEffect.MULTI_HIT_DAMAGE, params: MultiHitDamageParams): void;
-  // TODO: This implementation signature does not restrict us from using the wrong parameter type (and hence, crashing)
-  public override apply(
-    effect: typeof HeldItemEffect.MULTI_HIT_COUNT | typeof HeldItemEffect.MULTI_HIT_DAMAGE,
-    params: MultiHitCountParams & MultiHitDamageParams,
-  ): void {
-    const { pokemon } = params;
-
-    switch (effect) {
-      case HeldItemEffect.MULTI_HIT_COUNT:
-        this.applyHitCountBoost(pokemon, params.count);
-        return;
-      case HeldItemEffect.MULTI_HIT_DAMAGE:
-        this.applyDamageModifier(pokemon, params.damageMultiplier);
-        return;
-    }
-  }
-
-  /** Adds strikes to a move equal to the number of stacked Multi-Lenses */
-  private applyHitCountBoost(pokemon: Pokemon, count: NumberHolder): void {
     const stackCount = pokemon.heldItemManager.getStack(this.type);
-    count.value += stackCount;
+    const hitsDone = pokemon.turnData.hitCount - pokemon.turnData.hitsLeft;
+
+    // Do not modify the damage of the final hit added by Parental Bond (which occurs after Multi Lens)
+    return hitsDone < stackCount + 1;
   }
 
-  /**
-   * If applied to the first hit of a move, sets the damage multiplier
-   * equal to (1 - the number of stacked Multi-Lenses).
-   * Additional strikes beyond that are given a 0.25x damage multiplier
-   */
-  private applyDamageModifier(pokemon: Pokemon, damageMultiplier: NumberHolder): void {
+  public override apply({ pokemon, damageMultiplier }: MultiHitDamageParams): void {
     const stackCount = pokemon.heldItemManager.getStack(this.type);
     if (pokemon.turnData.hitsLeft === pokemon.turnData.hitCount) {
       // Reduce first hit by 25% for each stack count
@@ -94,6 +49,9 @@ export class MultiHitHeldItem extends HeldItem<
     } else if (pokemon.turnData.hitCount - pokemon.turnData.hitsLeft !== stackCount + 1) {
       // Deal 25% damage for each remaining Multi Lens hit
       damageMultiplier.value *= 0.25;
+    } else {
+      // should be impossible due to `shouldApply` block
+      // TODO: Throw an error during testing
     }
   }
 }

--- a/src/items/held-items/nature-weight-booster.ts
+++ b/src/items/held-items/nature-weight-booster.ts
@@ -1,22 +1,16 @@
 import { HeldItemEffect } from "#enums/held-item-effect";
-import { HeldItem } from "#items/held-item";
+import { HeldItemAttr } from "#items/held-item-attr";
 import type { NatureWeightBoostParams } from "#types/held-item-parameter";
 
 // TODO: Consider renaming this ("nature stat mult" or similar would perhaps be clearer)
-export class NatureWeightBoosterHeldItem extends HeldItem<[typeof HeldItemEffect.NATURE_WEIGHT_BOOSTER]> {
-  public readonly effects = [HeldItemEffect.NATURE_WEIGHT_BOOSTER] as const;
+export class NatureWeightBoosterHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.NATURE_WEIGHT_BOOSTER> {
+  public override readonly effect = HeldItemEffect.NATURE_WEIGHT_BOOSTER;
 
-  public override shouldApply(
-    _effect: typeof HeldItemEffect.NATURE_WEIGHT_BOOSTER,
-    { multiplier }: NatureWeightBoostParams,
-  ): boolean {
+  public override shouldApply({ multiplier }: NatureWeightBoostParams): boolean {
     return multiplier.value !== 1;
   }
 
-  public override apply(
-    _effect: typeof HeldItemEffect.NATURE_WEIGHT_BOOSTER,
-    { pokemon, multiplier }: NatureWeightBoostParams,
-  ): boolean {
+  public override apply({ pokemon, multiplier }: NatureWeightBoostParams): boolean {
     const stackCount = pokemon.heldItemManager.getStack(this.type);
     multiplier.value += 0.1 * stackCount * Math.sign(multiplier.value);
     return true;

--- a/src/items/held-items/reset-negative-stat-stage.ts
+++ b/src/items/held-items/reset-negative-stat-stage.ts
@@ -1,38 +1,31 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { HeldItemEffect } from "#enums/held-item-effect";
-import { ConsumableHeldItem } from "#items/held-item";
+import { ConsumableHeldItemAttr } from "#items/held-item-attr";
 import type { ResetNegativeStatStageParams } from "#types/held-item-parameter";
 import i18next from "i18next";
 
 /**
- * Class used for held items that restore adverse stat stages in battle.
+ * Attribute used for held items that revert adverse stat stages in battle.
  * @see {@link https://bulbapedia.bulbagarden.net/wiki/White_Herb}
  * @sealed
  */
-export class ResetNegativeStatStageHeldItem extends ConsumableHeldItem<
-  [typeof HeldItemEffect.RESET_NEGATIVE_STAT_STAGE]
+export class ResetNegativeStatStageHeldItemAttr extends ConsumableHeldItemAttr<
+  typeof HeldItemEffect.RESET_NEGATIVE_STAT_STAGE
 > {
-  public readonly effects = [HeldItemEffect.RESET_NEGATIVE_STAT_STAGE] as const;
+  public override readonly effect = HeldItemEffect.RESET_NEGATIVE_STAT_STAGE;
 
-  public override shouldApply(
-    _effect: typeof HeldItemEffect.RESET_NEGATIVE_STAT_STAGE,
-    params: ResetNegativeStatStageParams,
-  ): boolean {
-    const { pokemon } = params;
+  public override shouldApply({ pokemon }: ResetNegativeStatStageParams): boolean {
     return pokemon.getStatStages().some(stage => stage < 0);
   }
 
-  public override apply(
-    _effect: typeof HeldItemEffect.RESET_NEGATIVE_STAT_STAGE,
-    { pokemon }: ResetNegativeStatStageParams,
-  ): void {
+  public override apply({ pokemon }: ResetNegativeStatStageParams): void {
     pokemon.summonData.statStages = pokemon.summonData.statStages.map(stage => Math.max(stage, 0));
 
     globalScene.phaseManager.queueMessage(
       i18next.t("modifier:resetNegativeStatStageApply", {
         pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
-        typeName: this.name,
+        typeName: this.item.name,
       }),
     );
 

--- a/src/items/held-items/stat-boost.ts
+++ b/src/items/held-items/stat-boost.ts
@@ -1,103 +1,81 @@
 import { pokemonEvolutions } from "#balance/pokemon-evolutions";
 import { HeldItemEffect } from "#enums/held-item-effect";
-import { HeldItemId } from "#enums/held-item-id";
+import type { HeldItemId } from "#enums/held-item-id";
 import type { SpeciesId } from "#enums/species-id";
 import type { Stat } from "#enums/stat";
-import { HeldItem } from "#items/held-item";
+import { HeldItemAttr } from "#items/held-item-attr";
 import type { StatBoostParams } from "#types/held-item-parameter";
+import type { NonEmptyTuple } from "type-fest";
 
 /**
  * Class used for held items that boost specific stats by a multiplicative amount.
  */
-abstract class StatBoostHeldItem extends HeldItem<[typeof HeldItemEffect.STAT_BOOST]> {
-  public readonly effects = [HeldItemEffect.STAT_BOOST] as const;
-  /** The stats that the held item boosts */
+// TODO: Rename class and effect to `StatMultiply`
+abstract class StatBoostHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.STAT_BOOST> {
+  public override readonly effect = HeldItemEffect.STAT_BOOST;
+  /** The stats to multiply */
   protected readonly stats: readonly Stat[];
-  /** The multiplier used to increase the relevant stat(s) */
-  // TODO: Consider making this an object mapping stats to multipliers if flaxibility is desired
+  /**
+   * The multiplier to apply to `stats`; must be strictly positive
+   */
   protected readonly multiplier: number;
 
-  constructor(type: HeldItemId, maxStackCount: number, stats: readonly Stat[], multiplier: number) {
-    super(type, maxStackCount);
+  constructor(stats: NonEmptyTuple<Stat>, multiplier: number) {
+    super();
 
     this.stats = stats;
     this.multiplier = multiplier;
   }
 
-  /**
-   * Checks if the incoming stat is listed in {@linkcode stats}
-   * @param _pokemon the {@linkcode Pokemon} that holds the item
-   * @param _stat the {@linkcode Stat} to be boosted
-   * @param statValue {@linkcode NumberHolder} that holds the resulting value of the stat
-   * @returns `true` if the stat could be boosted, false otherwise
-   */
-  public override shouldApply(_effect: typeof HeldItemEffect.STAT_BOOST, { stat }: StatBoostParams): boolean {
+  public override shouldApply({ stat }: StatBoostParams): boolean {
     return this.stats.includes(stat);
   }
 
-  /**
-   * Boosts the incoming stat by a {@linkcode multiplier} if the stat is listed
-   * in {@linkcode stats}.
-   * @returns `true` if the stat boost applies successfully, false otherwise
-   * @see shouldApply
-   */
-  apply(_effect: typeof HeldItemEffect.STAT_BOOST, { statHolder }: StatBoostParams): void {
+  public override apply({ statHolder }: StatBoostParams): void {
     statHolder.value *= this.multiplier;
   }
 
+  // TODO: This looks like a holdover that can be removed
   getMaxHeldItemCount(): number {
     return 1;
   }
 }
 
+// TODO: Since the core logic for both classes is somewhat similar, could we try to combine them?
 /**
- * Modifier used for held items, specifically Eviolite, that apply
- * {@linkcode Stat} boost(s) using a multiplier if the holder can evolve.
- * @see {@linkcode apply}
+ * Attribute used for held items that only boost stats of pre-evolved pokemon.
  */
-export class EvolutionStatBoostHeldItem extends StatBoostHeldItem {
-  /**
-   * Checks if the stat boosts can apply and if the holder is not currently
-   * Gigantamax'd.
-   * @param pokemon {@linkcode Pokemon} that holds the held item
-   * @param stat {@linkcode Stat} The {@linkcode Stat} to be boosted
-   * @param statValue {@linkcode NumberHolder} that holds the resulting value of the stat
-   * @returns `true` if the stat boosts can be applied, false otherwise
-   */
-  //  override shouldApply(pokemon: Pokemon, stat: Stat, statValue: NumberHolder): boolean {
-  //    return super.shouldApply(pokemon, stat, statValue) && !pokemon.isMax();
-  //  }
-
-  override shouldApply(_: typeof HeldItemEffect.STAT_BOOST, { pokemon }: StatBoostParams): boolean {
-    const isUnevolved = pokemon.getSpeciesForm(true).speciesId in pokemonEvolutions;
-    // check for fusion that has eviolite
-    return (
-      (pokemon.isFusion() && pokemon.getFusionSpeciesForm(true).speciesId in pokemonEvolutions !== isUnevolved)
-      || (isUnevolved && !pokemon.isMax())
-    );
-  }
-  /**
-   * Boosts the incoming stat value by a {@linkcode EvolutionStatBoosterModifier.multiplier} if the holder
-   * can evolve. Note that, if the holder is a fusion, they will receive
-   * only half of the boost if either of the fused members are fully
-   * evolved. However, if they are both unevolved, the full boost
-   * will apply.
-   * @returns `true` if the stat boost applies successfully, false otherwise
-   */
-  override apply(effect: typeof HeldItemEffect.STAT_BOOST, params: StatBoostParams): void {
-    const pokemon = params.pokemon;
-    const isUnevolved = pokemon.getSpeciesForm(true).speciesId in pokemonEvolutions;
-
-    if (pokemon.isFusion() && pokemon.getFusionSpeciesForm(true).speciesId in pokemonEvolutions !== isUnevolved) {
-      // Half boost applied if pokemon is fused and either part of fusion is fully evolved
-      params.statHolder.value *= 1 + (this.multiplier - 1) / 2;
-      return;
+export class EvolutionStatBoostHeldItemAttr extends StatBoostHeldItemAttr {
+  public override shouldApply(params: StatBoostParams): boolean {
+    if (!super.shouldApply(params)) {
+      return false;
+    }
+    const { pokemon } = params;
+    const isUnevolved = Object.hasOwn(pokemonEvolutions, pokemon.getSpeciesForm(true).speciesId);
+    if (isUnevolved) {
+      // Dynamax/G-Max pokemon can never benefit from eviolite, even if their root species is unevolved
+      return !pokemon.isMax();
     }
 
-    super.apply(effect, params);
+    // check for fusion that has eviolite
+    return pokemon.isFusion() && Object.hasOwn(pokemonEvolutions, pokemon.getFusionSpeciesForm(true).speciesId);
+  }
+
+  public override apply({ pokemon, statHolder }: StatBoostParams): void {
+    const isUnevolved = Object.hasOwn(pokemonEvolutions, pokemon.getSpeciesForm(true).speciesId);
+    const isFusionUnevolved = Object.hasOwn(pokemonEvolutions, pokemon.getFusionSpeciesForm(true).speciesId);
+
+    let boost = this.multiplier - 1;
+    if (pokemon.isFusion() && isFusionUnevolved !== isUnevolved) {
+      // Halve the boost if 1/2 of a fused pokemon is unevolved.
+      boost /= 2;
+    }
+
+    statHolder.value *= 1 + boost;
   }
 }
 
+// TODO: Stop littering these types all over the codebase and move them to 1 file
 export type SpeciesStatBoosterItemId =
   | typeof HeldItemId.LIGHT_BALL
   | typeof HeldItemId.THICK_CLUB
@@ -106,48 +84,24 @@ export type SpeciesStatBoosterItemId =
   | typeof HeldItemId.DEEP_SEA_SCALE
   | typeof HeldItemId.DEEP_SEA_TOOTH;
 
-export const SPECIES_STAT_BOOSTER_ITEMS: readonly SpeciesStatBoosterItemId[] = [
-  HeldItemId.LIGHT_BALL,
-  HeldItemId.THICK_CLUB,
-  HeldItemId.METAL_POWDER,
-  HeldItemId.QUICK_POWDER,
-  HeldItemId.DEEP_SEA_SCALE,
-  HeldItemId.DEEP_SEA_TOOTH,
-];
-
-/**
- * Modifier used for held items that Applies {@linkcode Stat} boost(s) using a
- * multiplier if the holder is of a specific {@linkcode SpeciesId}.
-|*/
-export class SpeciesStatBoostHeldItem extends StatBoostHeldItem {
+export class SpeciesStatBoostHeldItemAttr extends StatBoostHeldItemAttr {
   /** The species that the held item's stat boost(s) apply to */
-  public species: readonly SpeciesId[];
+  public readonly species: readonly SpeciesId[];
 
-  constructor(
-    type: SpeciesStatBoosterItemId,
-    maxStackCount: number,
-    stats: readonly Stat[],
-    multiplier: number,
-    species: readonly SpeciesId[],
-  ) {
-    super(type, maxStackCount, stats, multiplier);
+  constructor(stats: NonEmptyTuple<Stat>, multiplier: number, species: NonEmptyTuple<SpeciesId>) {
+    super(stats, multiplier);
     this.species = species;
   }
 
-  override shouldApply(_: typeof HeldItemEffect.STAT_BOOST, { pokemon }: StatBoostParams): boolean {
+  public override shouldApply(params: StatBoostParams): boolean {
+    if (!super.shouldApply(params)) {
+      return false;
+    }
+
+    const { pokemon } = params;
     return (
       this.species.includes(pokemon.getSpeciesForm(true).speciesId)
       || (pokemon.isFusion() && this.species.includes(pokemon.getFusionSpeciesForm(true).speciesId))
     );
-  }
-
-  /**
-   * Checks if either parameter is included in the corresponding lists
-   * @param speciesId {@linkcode SpeciesId} being checked
-   * @param stat {@linkcode Stat} being checked
-   * @returns `true` if both parameters are in {@linkcode species} and {@linkcode stats} respectively, false otherwise
-   */
-  contains(speciesId: SpeciesId, stat: Stat): boolean {
-    return this.species.includes(speciesId) && this.stats.includes(stat);
   }
 }

--- a/src/items/held-items/survive-chance.ts
+++ b/src/items/held-items/survive-chance.ts
@@ -1,7 +1,7 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { HeldItemEffect } from "#enums/held-item-effect";
-import { HeldItem } from "#items/held-item";
+import { HeldItemAttr } from "#items/held-item-attr";
 import type { SurviveChanceParams } from "#types/held-item-parameter";
 import i18next from "i18next";
 
@@ -11,26 +11,20 @@ import i18next from "i18next";
  * @sealed
  */
 // TODO: Rename to "endure chance" for clarity
-export class SurviveChanceHeldItem extends HeldItem<[typeof HeldItemEffect.SURVIVE_CHANCE]> {
-  public readonly effects = [HeldItemEffect.SURVIVE_CHANCE] as const;
+export class SurviveChanceHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.SURVIVE_CHANCE> {
+  public override readonly effect = HeldItemEffect.SURVIVE_CHANCE;
 
-  public override shouldApply(
-    _effect: typeof HeldItemEffect.SURVIVE_CHANCE,
-    { pokemon, surviveDamage }: SurviveChanceParams,
-  ): boolean {
+  public override shouldApply({ pokemon, surviveDamage }: SurviveChanceParams): boolean {
     return !surviveDamage.value && pokemon.randBattleSeedInt(10) < pokemon.heldItemManager.getStack(this.type);
   }
 
-  public override apply(
-    _effect: typeof HeldItemEffect.SURVIVE_CHANCE,
-    { pokemon, surviveDamage }: SurviveChanceParams,
-  ): void {
+  public override apply({ pokemon, surviveDamage }: SurviveChanceParams): void {
     surviveDamage.value = true;
 
     globalScene.phaseManager.queueMessage(
       i18next.t("modifier:surviveDamageApply", {
         pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
-        typeName: this.name,
+        typeName: this.item.name,
       }),
     );
   }

--- a/src/items/held-items/turn-end-heal.ts
+++ b/src/items/held-items/turn-end-heal.ts
@@ -1,7 +1,7 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { HeldItemEffect } from "#enums/held-item-effect";
-import { HeldItem } from "#items/held-item";
+import { HeldItemAttr } from "#items/held-item-attr";
 import { PokemonHealPhase } from "#phases/pokemon-heal-phase";
 import type { TurnEndHealParams } from "#types/held-item-parameter";
 import { toDmgValue } from "#utils/common";
@@ -12,14 +12,14 @@ import i18next from "i18next";
  * @see {@link https://bulbapedia.bulbagarden.net/wiki/Leftovers}
  * @sealed
  */
-export class TurnEndHealHeldItem extends HeldItem<[typeof HeldItemEffect.TURN_END_HEAL]> {
-  public readonly effects = [HeldItemEffect.TURN_END_HEAL] as const;
+export class TurnEndHealHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.TURN_END_HEAL> {
+  public override readonly effect = HeldItemEffect.TURN_END_HEAL;
 
-  override shouldApply(_effect: typeof HeldItemEffect.TURN_END_HEAL, { pokemon }: TurnEndHealParams): boolean {
+  public override shouldApply({ pokemon }: TurnEndHealParams): boolean {
     return !pokemon.isFullHp();
   }
 
-  apply(_effect: typeof HeldItemEffect.TURN_END_HEAL, { pokemon }: TurnEndHealParams): void {
+  public override apply({ pokemon }: TurnEndHealParams): void {
     const stackCount = pokemon.heldItemManager.getStack(this.type);
     globalScene.phaseManager.unshiftPhase(
       new PokemonHealPhase(
@@ -27,7 +27,8 @@ export class TurnEndHealHeldItem extends HeldItem<[typeof HeldItemEffect.TURN_EN
         toDmgValue(pokemon.getMaxHp() / 16) * stackCount,
         i18next.t("modifier:turnHealApply", {
           pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
-          typeName: this.name,
+          // TODO: consider removing the parameter
+          typeName: this.item.name,
         }),
         true,
       ),

--- a/src/items/held-items/turn-end-status.ts
+++ b/src/items/held-items/turn-end-status.ts
@@ -1,7 +1,6 @@
 import { HeldItemEffect } from "#enums/held-item-effect";
-import type { HeldItemId } from "#enums/held-item-id";
 import type { StatusEffect } from "#enums/status-effect";
-import { HeldItem } from "#items/held-item";
+import { HeldItemAttr } from "#items/held-item-attr";
 import type { TurnEndStatusParams } from "#types/held-item-parameter";
 
 /**
@@ -10,25 +9,22 @@ import type { TurnEndStatusParams } from "#types/held-item-parameter";
  * @see {@link https://bulbapedia.bulbagarden.net/wiki/Toxic_Orb}
  * @sealed
  */
-export class TurnEndStatusHeldItem extends HeldItem<[typeof HeldItemEffect.TURN_END_STATUS]> {
-  public readonly effects = [HeldItemEffect.TURN_END_STATUS] as const;
+export class TurnEndStatusHeldItemAttr extends HeldItemAttr<typeof HeldItemEffect.TURN_END_STATUS> {
+  public readonly effect = HeldItemEffect.TURN_END_STATUS;
   /** The status effect to be applied. */
-  public readonly effect: StatusEffect;
+  public readonly statusEffect: StatusEffect;
 
-  constructor(type: HeldItemId, maxStackCount: number, effect: StatusEffect) {
-    super(type, maxStackCount);
+  constructor(statusEffect: StatusEffect) {
+    super();
 
-    this.effect = effect;
+    this.statusEffect = statusEffect;
   }
 
-  public override shouldApply(
-    _effect: typeof HeldItemEffect.TURN_END_STATUS,
-    { pokemon }: TurnEndStatusParams,
-  ): boolean {
-    return pokemon.canSetStatus(this.effect, true, false, pokemon, false);
+  public override shouldApply({ pokemon }: TurnEndStatusParams): boolean {
+    return pokemon.canSetStatus(this.statusEffect, true, false, pokemon, false);
   }
 
-  apply(_effect: typeof HeldItemEffect.TURN_END_STATUS, { pokemon }: TurnEndStatusParams): void {
-    pokemon.trySetStatus(this.effect, pokemon, undefined, this.name);
+  public override apply({ pokemon }: TurnEndStatusParams): void {
+    pokemon.trySetStatus(this.statusEffect, pokemon, undefined, this.item.name);
   }
 }

--- a/src/items/init-reward-pools.ts
+++ b/src/items/init-reward-pools.ts
@@ -180,7 +180,11 @@ function initGreatRewardPool(): void {
               && !p
                 .getHeldItems()
                 .filter(i => i === HeldItemId.TOXIC_ORB || i === HeldItemId.FLAME_ORB)
-                .some(i => (allHeldItems[i] satisfies TurnEndStatusHeldItemAttr).effect === p.status?.effect),
+                .some(i =>
+                  allHeldItems[i]
+                    .getAttrs(HeldItemEffect.TURN_END_STATUS)
+                    .some(a => (a as TurnEndStatusHeldItemAttr).statusEffect === p.status?.effect),
+                ),
           ).length,
           3,
         );

--- a/src/items/init-reward-pools.ts
+++ b/src/items/init-reward-pools.ts
@@ -4,6 +4,7 @@ import { pokemonEvolutions } from "#balance/pokemon-evolutions";
 import { allHeldItems, allTrainerItems } from "#data/data-lists";
 import { MAX_PER_TYPE_POKEBALLS } from "#data/pokeball";
 import { AbilityId } from "#enums/ability-id";
+import { HeldItemEffect } from "#enums/held-item-effect";
 import { HeldItemId } from "#enums/held-item-id";
 import { MoveId } from "#enums/move-id";
 import { PokeballType } from "#enums/pokeball";
@@ -108,9 +109,14 @@ function initGreatRewardPool(): void {
               p.hp > 0
               && p.status != null
               && !p
+                // TODO: This breaks encapsulation and is a chore to maintain
                 .getHeldItems()
                 .filter(i => i === HeldItemId.TOXIC_ORB || i === HeldItemId.FLAME_ORB)
-                .some(i => (allHeldItems[i] satisfies TurnEndStatusHeldItemAttr).effect === p.status?.effect),
+                .some(i =>
+                  allHeldItems[i]
+                    .getAttrs(HeldItemEffect.TURN_END_STATUS)
+                    .some(a => (a as TurnEndStatusHeldItemAttr).statusEffect === p.status?.effect),
+                ),
           ).length,
           3,
         );

--- a/src/items/init-reward-pools.ts
+++ b/src/items/init-reward-pools.ts
@@ -15,7 +15,7 @@ import { TrainerItemId } from "#enums/trainer-item-id";
 import { Unlockables } from "#enums/unlockables";
 import type { Pokemon } from "#field/pokemon";
 import { rewardPool } from "#items/reward-pools";
-import type { TurnEndStatusHeldItem } from "#items/turn-end-status";
+import type { TurnEndStatusHeldItemAttr } from "#items/turn-end-status";
 import type { WeightedRewardWeightFunc } from "#types/rewards";
 
 /**
@@ -110,7 +110,7 @@ function initGreatRewardPool(): void {
               && !p
                 .getHeldItems()
                 .filter(i => i === HeldItemId.TOXIC_ORB || i === HeldItemId.FLAME_ORB)
-                .some(i => (allHeldItems[i] satisfies TurnEndStatusHeldItem).effect === p.status?.effect),
+                .some(i => (allHeldItems[i] satisfies TurnEndStatusHeldItemAttr).effect === p.status?.effect),
           ).length,
           3,
         );
@@ -174,7 +174,7 @@ function initGreatRewardPool(): void {
               && !p
                 .getHeldItems()
                 .filter(i => i === HeldItemId.TOXIC_ORB || i === HeldItemId.FLAME_ORB)
-                .some(i => (allHeldItems[i] satisfies TurnEndStatusHeldItem).effect === p.status?.effect),
+                .some(i => (allHeldItems[i] satisfies TurnEndStatusHeldItemAttr).effect === p.status?.effect),
           ).length,
           3,
         );

--- a/src/items/rewards/species-stat-booster.ts
+++ b/src/items/rewards/species-stat-booster.ts
@@ -1,9 +1,10 @@
 import { globalScene } from "#app/global-scene";
 import { allHeldItems } from "#data/data-lists";
+import { HeldItemEffect } from "#enums/held-item-effect";
 import { HeldItemId } from "#enums/held-item-id";
 import { SpeciesId } from "#enums/species-id";
 import { RewardGenerator } from "#items/reward";
-import type { SpeciesStatBoosterItemId, SpeciesStatBoostHeldItem } from "#items/stat-boost";
+import type { SpeciesStatBoosterItemId, SpeciesStatBoostHeldItemAttr } from "#items/stat-boost";
 import { randSeedInt } from "#utils/common";
 import { HeldItemReward } from "./held-item-reward";
 
@@ -39,8 +40,11 @@ export class SpeciesStatBoosterRewardGenerator extends RewardGenerator {
       // TODO: Use commented boolean when Fling is implemented
       const hasFling = false; /* p.getMoveset(true).some(m => m.moveId === MoveId.FLING) */
 
-      for (const i in tierItems) {
-        const checkedSpecies = (allHeldItems[tierItems[i]] as SpeciesStatBoostHeldItem).species;
+      for (let i = 0; i < tierItems.length; i++) {
+        // TODO: Handle this more gracefully with some semblance of encapsulation
+        const checkedSpecies = (
+          allHeldItems[tierItems[i]].getAttrs(HeldItemEffect.STAT_BOOST)[0] as SpeciesStatBoostHeldItemAttr
+        ).species;
 
         // If party member already has the item being weighted currently, skip to the next item
         const hasItem = p.heldItemManager.hasItem(tierItems[i]);

--- a/src/phases/berry-phase.ts
+++ b/src/phases/berry-phase.ts
@@ -6,6 +6,7 @@ import { HeldItemEffect } from "#enums/held-item-effect";
 import { HeldItemCategoryId, isItemInCategory } from "#enums/held-item-id";
 import { CommonAnim } from "#enums/move-anims-common";
 import type { Pokemon } from "#field/pokemon";
+import type { BerryItemId } from "#items/all-held-items";
 import type { BerryHeldItemAttr } from "#items/berry";
 import { FieldPhase } from "#phases/field-phase";
 import { BooleanHolder } from "#utils/common";
@@ -34,10 +35,13 @@ export class BerryPhase extends FieldPhase {
    * @param pokemon - The {@linkcode Pokemon} to check
    */
   eatBerries(pokemon: Pokemon): void {
+    // TODO: This breaks encapsulation...
     const hasUsableBerry = pokemon.getHeldItems().some(m => {
       return (
         isItemInCategory(m, HeldItemCategoryId.BERRY)
-        && (allHeldItems[m] as BerryHeldItemAttr).shouldApply(HeldItemEffect.BERRY, { pokemon })
+        && (allHeldItems[m as BerryItemId].getAttrs(HeldItemEffect.BERRY) satisfies readonly BerryHeldItemAttr[]).some(
+          attr => attr.shouldApply({ pokemon }),
+        )
       );
     });
 

--- a/src/phases/berry-phase.ts
+++ b/src/phases/berry-phase.ts
@@ -6,7 +6,7 @@ import { HeldItemEffect } from "#enums/held-item-effect";
 import { HeldItemCategoryId, isItemInCategory } from "#enums/held-item-id";
 import { CommonAnim } from "#enums/move-anims-common";
 import type { Pokemon } from "#field/pokemon";
-import type { BerryHeldItem } from "#items/berry";
+import type { BerryHeldItemAttr } from "#items/berry";
 import { FieldPhase } from "#phases/field-phase";
 import { BooleanHolder } from "#utils/common";
 import { applyHeldItems } from "#utils/items";
@@ -37,7 +37,7 @@ export class BerryPhase extends FieldPhase {
     const hasUsableBerry = pokemon.getHeldItems().some(m => {
       return (
         isItemInCategory(m, HeldItemCategoryId.BERRY)
-        && (allHeldItems[m] as BerryHeldItem).shouldApply(HeldItemEffect.BERRY, { pokemon })
+        && (allHeldItems[m] as BerryHeldItemAttr).shouldApply(HeldItemEffect.BERRY, { pokemon })
       );
     });
 

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -219,7 +219,11 @@ await i18next
       ns: nsEn,
       debug: import.meta.env.VITE_I18N_DEBUG === "1",
       interpolation: {
+        // Phaser is unable to parse the HTML escape codes produced by i18next, resulting in things like
+        // &amp; being displayed verbatim on screen (which is bad)
         escapeValue: false,
+        // Interpolate variables passed to i18next.t() to allow for easier key nesting
+        skipOnVariables: false,
       },
       postProcess: ["korean-postposition"],
     },

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -219,8 +219,9 @@ await i18next
       ns: nsEn,
       debug: import.meta.env.VITE_I18N_DEBUG === "1",
       interpolation: {
-        // Phaser is unable to parse the HTML escape codes produced by i18next, resulting in things like
-        // &amp; being displayed verbatim on screen (which is bad)
+        // Phaser is unable to parse the HTML escape codes produced by i18next, so turning this on results in codes like
+        // &amp; being displayed verbatim on screen.
+        // We use i18next solely for localizing values inside code anyways, so the risk of XSS from user input is virtually nonexistent.
         escapeValue: false,
         // Interpolate variables passed to i18next.t() to allow for easier key nesting
         skipOnVariables: false,

--- a/src/utils/items.ts
+++ b/src/utils/items.ts
@@ -7,10 +7,10 @@ import type { HeldItemEffectParamMap } from "#types/held-item-parameter";
 
 export function applyHeldItems<T extends HeldItemEffect>(effect: T, params: HeldItemEffectParamMap[T]) {
   const { pokemon } = params;
-  for (const item of pokemon.heldItemManager.getItems()) {
-    const heldItem = allHeldItems[item] as HeldItem | CosmeticHeldItem;
-    if ("effects" in heldItem && heldItem.effects.includes(effect) && heldItem.shouldApply(effect, params)) {
-      heldItem.apply(effect, params);
+  for (const itemId of pokemon.heldItemManager.getItems()) {
+    const heldItem = allHeldItems[itemId] as HeldItem | CosmeticHeldItem;
+    if ("effects" in heldItem && heldItem.hasEffect(effect)) {
+      (heldItem satisfies HeldItem).apply(effect, params);
     }
   }
 }

--- a/test/@types/vitest.d.ts
+++ b/test/@types/vitest.d.ts
@@ -21,7 +21,6 @@ import type { StatusEffect } from "#enums/status-effect";
 import type { WeatherType } from "#enums/weather-type";
 import type { Arena } from "#field/arena";
 import type { Pokemon } from "#field/pokemon";
-import type { AllHeldItems } from "#items/all-held-items";
 import type { PokemonMove } from "#moves/pokemon-move";
 import type { OneOther } from "#test/@types/test-helpers";
 import type { GameManager } from "#test/framework/game-manager";
@@ -34,7 +33,6 @@ import type { ToHaveHpOptions } from "#test/matchers/to-have-hp";
 import type { PartiallyFilledPositionalTag } from "#test/matchers/to-have-positional-tag";
 import type { PartiallyFilledStatus } from "#test/matchers/to-have-status-effect";
 import type { ToHaveTypesOptions } from "#test/matchers/to-have-types";
-import type { ApplicableHeldItemId } from "#types/held-item-data-types";
 import type { PhaseString } from "#types/phase-types";
 import type { TurnMove } from "#types/turn-move";
 import type { toDmgValue } from "#utils/common";
@@ -308,10 +306,11 @@ interface PokemonMatchers {
    * Check whether a {@linkcode Pokemon} has applied the given {@linkcode HeldItem}.
    * Used during unit tests to ensure effects were applied correctly.
    * @param id - The {@linkcode HeldItemId} of the item being applied
-   * @param effect - One of `item`'s applicable {@linkcode HeldItemEffect} to check application of
+   * @param effect - One of `item`'s applicable {@linkcode HeldItemEffect} whose application will be checked
    * @param options - A partially-filled parameters object used to query the arguments `item` was called with
    */
-  toHaveAppliedItem<T extends ApplicableHeldItemId, E extends AllHeldItems[T]["effects"][number]>(
+  // TODO: Should `options` truly be optional?
+  toHaveAppliedItem<T extends ApplicableHeldItemIdEffect, E extends ExtractItemEffect<T>>(
     id: T,
     effect: E,
     options?: ToHaveAppliedItemOptions<E>,

--- a/test/matchers/to-have-applied-item.ts
+++ b/test/matchers/to-have-applied-item.ts
@@ -47,7 +47,7 @@ export function toHaveAppliedItem<T extends ApplicableHeldItemId, E extends Extr
     };
   }
 
-  const item = allHeldItems[id];
+  const item: HeldItem = allHeldItems[id];
   const itemName = HeldItemNames[id];
 
   // This is technically checked by the type system, but better safe than sorry

--- a/test/matchers/to-have-applied-item.ts
+++ b/test/matchers/to-have-applied-item.ts
@@ -2,32 +2,38 @@ import { getPokemonNameWithAffix } from "#app/messages";
 import { allHeldItems } from "#data/data-lists";
 import { HeldItemEffect } from "#enums/held-item-effect";
 import { HeldItemNames } from "#enums/held-item-id";
-import type { AllHeldItems } from "#items/all-held-items";
-import { type CosmeticHeldItem, HeldItem } from "#items/held-item";
+import { HeldItem } from "#items/held-item";
 import { getOnelineDiffStr } from "#test/utils/string-utils";
 import { isPokemonInstance, receivedStr } from "#test/utils/test-utils";
-import type { ApplicableHeldItemId } from "#types/held-item-data-types";
+import type { ApplicableHeldItemId, ExtractItemEffect } from "#types/held-item-data-types";
 import type { HeldItemEffectParamMap } from "#types/held-item-parameter";
 import type { AtLeastOne } from "#types/type-helpers";
 import { enumValueToKey } from "#utils/enums";
 import type { MatcherState, SyncExpectationResult } from "@vitest/expect";
 import { type MockInstance, vi } from "vitest";
 
+/**
+ * Internal union type containing all {@linkcode HeldItemEffect}s whose parameters
+ * solely contain `Pokemon`.
+ */
+type EffectsUsingDefaultParams = {
+  [E in HeldItemEffect]: keyof HeldItemEffectParamMap[E] extends "pokemon" ? E : never;
+}[HeldItemEffect];
+
 /** Options type for {@linkcode toHaveAppliedItem}. */
-export type ToHaveAppliedItemOptions<E extends HeldItemEffect> =
-  Omit<HeldItemEffectParamMap[E], "pokemon"> extends Record<string, never>
-    ? never
-    : AtLeastOne<Omit<HeldItemEffectParamMap[E], "pokemon">>;
+export type ToHaveAppliedItemOptions<E extends HeldItemEffect> = E extends EffectsUsingDefaultParams
+  ? never
+  : AtLeastOne<Omit<HeldItemEffectParamMap[E], "pokemon">>;
 
 /**
- * Matcher that checks if a {@linkcode Pokemon} has applied the given {@linkcode HeldItem}.
  * Used during unit tests to ensure effects were applied correctly.
+ * @param received - The object to check. Should be a {@linkcode Pokemon}
  * @param id - The {@linkcode HeldItemId} of the item being applied
  * @param effect - One of `item`'s applicable {@linkcode HeldItemEffect}s whose application will be checked
  * @param options - A partially-filled parameters object used to query the arguments `item` was called with
  * @returns Whether the matcher passed
  */
-export function toHaveAppliedItem<T extends ApplicableHeldItemId, E extends AllHeldItems[T]["effects"][number]>(
+export function toHaveAppliedItem<T extends ApplicableHeldItemId, E extends ExtractItemEffect<T>>(
   this: MatcherState,
   received: unknown,
   id: T,
@@ -41,8 +47,10 @@ export function toHaveAppliedItem<T extends ApplicableHeldItemId, E extends AllH
     };
   }
 
-  const item = allHeldItems[id] as CosmeticHeldItem | HeldItem;
+  const item = allHeldItems[id];
   const itemName = HeldItemNames[id];
+
+  // This is technically checked by the type system, but better safe than sorry
   if (!(item instanceof HeldItem)) {
     return {
       pass: this.isNot,
@@ -50,20 +58,22 @@ export function toHaveAppliedItem<T extends ApplicableHeldItemId, E extends AllH
     };
   }
 
-  if (!item.effects.includes(effect)) {
+  if (!item.hasEffect(effect)) {
     return {
       pass: this.isNot,
       message: () =>
         `Held item ${itemName}'s effects does not include HeldItemEffect.${enumValueToKey(HeldItemEffect, effect)}!`,
       expected: enumValueToKey(HeldItemEffect, effect),
-      actual: item.effects.map(e => enumValueToKey(HeldItemEffect, e)),
+      actual: (Object.keys(item["effects"]) as `${HeldItemEffect}`[]).map(e =>
+        enumValueToKey(HeldItemEffect, Number(e) as HeldItemEffect),
+      ),
     };
   }
 
-  if (!vi.isMockFunction(item.shouldApply)) {
+  if (!vi.isMockFunction(item.apply)) {
     return {
       pass: this.isNot,
-      message: () => `Held item ${itemName}'s \`shouldApply\` function is not a spy!`,
+      message: () => `Held item ${itemName}'s \`apply\` function is not a spy!`,
     };
   }
 
@@ -72,7 +82,7 @@ export function toHaveAppliedItem<T extends ApplicableHeldItemId, E extends AllH
     pokemon: received,
   } as unknown as Partial<HeldItemEffectParamMap[E]>;
 
-  const calls = (item.shouldApply as unknown as MockInstance<typeof item.shouldApply>).mock.calls;
+  const calls = (item.apply as unknown as MockInstance<typeof item.apply>).mock.calls;
   const pass = this.equals(
     calls,
     [effect, params],

--- a/test/tests/items/reviver-seed.test.ts
+++ b/test/tests/items/reviver-seed.test.ts
@@ -5,11 +5,11 @@ import { BattlerTagType } from "#enums/battler-tag-type";
 import { HeldItemId } from "#enums/held-item-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import type { InstantReviveHeldItem } from "#items/instant-revive";
 import { GameManager } from "#test/framework/game-manager";
 import Phaser from "phaser";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+// TODO: Rework and fix tests
 describe("Items - Reviver Seed", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
@@ -51,7 +51,7 @@ describe("Items - Reviver Seed", () => {
     const player = game.field.getPlayerPokemon();
     player.damageAndUpdate(player.hp - 1);
 
-    const reviverSeed = allHeldItems[HeldItemId.REVIVER_SEED] as InstantReviveHeldItem;
+    const reviverSeed = allHeldItems[HeldItemId.REVIVER_SEED];
     vi.spyOn(reviverSeed, "apply");
 
     game.move.select(MoveId.TACKLE);
@@ -67,7 +67,7 @@ describe("Items - Reviver Seed", () => {
     player.damageAndUpdate(player.hp - 1);
     player.addTag(BattlerTagType.CONFUSED, 3);
 
-    const reviverSeed = allHeldItems[HeldItemId.REVIVER_SEED] as InstantReviveHeldItem;
+    const reviverSeed = allHeldItems[HeldItemId.REVIVER_SEED];
     vi.spyOn(reviverSeed, "apply");
 
     vi.spyOn(player, "randBattleSeedInt").mockReturnValue(0); // Force confusion self-hit
@@ -119,7 +119,7 @@ describe("Items - Reviver Seed", () => {
     const player = game.field.getPlayerPokemon();
     player.damageAndUpdate(player.hp - 1);
 
-    const reviverSeed = allHeldItems[HeldItemId.REVIVER_SEED] as InstantReviveHeldItem;
+    const reviverSeed = allHeldItems[HeldItemId.REVIVER_SEED];
     vi.spyOn(reviverSeed, "apply");
 
     game.move.select(move);

--- a/test/tests/types/held-item-types.test-d.ts
+++ b/test/tests/types/held-item-types.test-d.ts
@@ -4,6 +4,7 @@ import type { HeldItem } from "#items/held-item";
 import { ConsumableHeldItemAttr, HeldItemAttr } from "#items/held-item-attr";
 import { HeldItemBuilder } from "#items/held-item-builder";
 import type { ErrorType } from "#types/error-type";
+import type { ExtractItemEffect } from "#types/held-item-data-types";
 import { describe, expectTypeOf, it } from "vitest";
 
 // Dummy classes
@@ -53,7 +54,10 @@ describe("HeldItemBuilder", () => {
 
   it("should convert the builder into a properly typed held item instance", () => {
     expectTypeOf(builder().build()).toEqualTypeOf<HeldItem<never>>();
-    expectTypeOf(builder().attr(NonConsumableAttr).build()).toEqualTypeOf<HeldItem<NonConsumableAttr["effect"]>>();
+    expectTypeOf(builder().attr(NonConsumableAttr).build()).toEqualTypeOf<HeldItem<NonConsumableAttr>>();
+    expectTypeOf(builder().attr(NonConsumableAttr).attr(ConsumableAttr).build()).toEqualTypeOf<
+      HeldItem<NonConsumableAttr | ConsumableAttr>
+    >();
   });
 
   describe("Errors", () => {
@@ -71,5 +75,11 @@ describe("HeldItemBuilder", () => {
         ExtractError<typeof result>
       >().toEqualTypeOf<"A held item cannot have more than one consumable attribute for a given effect, but 2 were found for HeldItemEffect.EXP_BOOSTER!">();
     });
+  });
+});
+
+describe("ExtractItemEffect", () => {
+  it("should map item IDs to effects", () => {
+    expectTypeOf<ExtractItemEffect<typeof HeldItemId.SITRUS_BERRY>>().toEqualTypeOf<typeof HeldItemEffect.BERRY>();
   });
 });

--- a/test/tests/types/held-item-types.test-d.ts
+++ b/test/tests/types/held-item-types.test-d.ts
@@ -53,7 +53,6 @@ describe("HeldItemBuilder", () => {
   });
 
   it("should convert the builder into a properly typed held item instance", () => {
-    expectTypeOf(builder().build()).toEqualTypeOf<HeldItem<never>>();
     expectTypeOf(builder().attr(NonConsumableAttr).build()).toEqualTypeOf<HeldItem<NonConsumableAttr>>();
     expectTypeOf(builder().attr(NonConsumableAttr).attr(ConsumableAttr).build()).toEqualTypeOf<
       HeldItem<NonConsumableAttr | ConsumableAttr>
@@ -61,6 +60,10 @@ describe("HeldItemBuilder", () => {
   });
 
   describe("Errors", () => {
+    it("should produce an ErrorType when creating an item without attributes", () => {
+      expectTypeOf(builder().build()).toEqualTypeOf<ErrorType<"Cannot create a HeldItem with no attributes!">>();
+    });
+
     it("should produce an ErrorType when adding a second consumable attr for the same effect", () => {
       const result = builder().attr(ConsumableAttr).attr(ConsumableAttr);
       expectTypeOf(result).toExtend<ErrorType<string>>();

--- a/test/tests/types/held-item-types.test-d.ts
+++ b/test/tests/types/held-item-types.test-d.ts
@@ -1,0 +1,75 @@
+import { HeldItemEffect } from "#enums/held-item-effect";
+import { HeldItemId } from "#enums/held-item-id";
+import type { HeldItem } from "#items/held-item";
+import { ConsumableHeldItemAttr, HeldItemAttr } from "#items/held-item-attr";
+import { HeldItemBuilder } from "#items/held-item-builder";
+import type { ErrorType } from "#types/error-type";
+import { describe, expectTypeOf, it } from "vitest";
+
+// Dummy classes
+
+class NonConsumableAttr extends HeldItemAttr<typeof HeldItemEffect.FIELD_EFFECT> {
+  private declare readonly _: never;
+  public override readonly effect = HeldItemEffect.FIELD_EFFECT;
+  public override apply(): void {}
+}
+class ConsumableAttr extends ConsumableHeldItemAttr<typeof HeldItemEffect.EXP_BOOSTER> {
+  public override readonly effect = HeldItemEffect.EXP_BOOSTER;
+  public override apply(): void {}
+}
+class ConsumableAttr2 extends ConsumableHeldItemAttr<typeof HeldItemEffect.MACHO_BRACE> {
+  public override readonly effect = HeldItemEffect.MACHO_BRACE;
+  public override apply(): void {}
+}
+
+const builder = () => new HeldItemBuilder(HeldItemId.ABOMASITE);
+
+describe("HeldItemBuilder", () => {
+  it("should start with never for both type parameters", () => {
+    expectTypeOf(builder()).toEqualTypeOf<HeldItemBuilder<never, never>>();
+  });
+
+  it("should preserve type information when adding non-consumable attributes", () => {
+    const result = builder().attr(NonConsumableAttr);
+    expectTypeOf(result).toEqualTypeOf<HeldItemBuilder<NonConsumableAttr, never>>();
+  });
+
+  it("should add a consumable attr to both Attrs and ConsumableEffects", () => {
+    const result = builder().attr(ConsumableAttr);
+    expectTypeOf(result).toEqualTypeOf<HeldItemBuilder<ConsumableAttr, ConsumableAttr["effect"]>>();
+  });
+
+  it("should accumulate types from multiple attributes", () => {
+    const result = builder().attr(NonConsumableAttr).attr(ConsumableAttr);
+    expectTypeOf(result).toEqualTypeOf<HeldItemBuilder<NonConsumableAttr | ConsumableAttr, ConsumableAttr["effect"]>>();
+  });
+
+  it("should allow two consumable attrs for different effects", () => {
+    const result = builder().attr(ConsumableAttr).attr(ConsumableAttr2);
+    expectTypeOf(result).toEqualTypeOf<
+      HeldItemBuilder<ConsumableAttr | ConsumableAttr2, ConsumableAttr["effect"] | ConsumableAttr2["effect"]>
+    >();
+  });
+
+  it("should convert the builder into a properly typed held item instance", () => {
+    expectTypeOf(builder().build()).toEqualTypeOf<HeldItem<never>>();
+    expectTypeOf(builder().attr(NonConsumableAttr).build()).toEqualTypeOf<HeldItem<NonConsumableAttr["effect"]>>();
+  });
+
+  describe("Errors", () => {
+    it("should produce an ErrorType when adding a second consumable attr for the same effect", () => {
+      const result = builder().attr(ConsumableAttr).attr(ConsumableAttr);
+      expectTypeOf(result).toExtend<ErrorType<string>>();
+      expectTypeOf(result).not.toExtend<HeldItemBuilder>();
+    });
+
+    it("should include the effect name in the error message", () => {
+      const result = builder().attr(ConsumableAttr).attr(ConsumableAttr);
+      type ExtractError<T> = T extends ErrorType<infer Message> ? Message : never;
+
+      expectTypeOf<
+        ExtractError<typeof result>
+      >().toEqualTypeOf<"A held item cannot have more than one consumable attribute for a given effect, but 2 were found for HeldItemEffect.EXP_BOOSTER!">();
+    });
+  });
+});

--- a/test/tests/types/held-item-types.test-d.ts
+++ b/test/tests/types/held-item-types.test-d.ts
@@ -5,6 +5,7 @@ import { ConsumableHeldItemAttr, HeldItemAttr } from "#items/held-item-attr";
 import { HeldItemBuilder } from "#items/held-item-builder";
 import type { ErrorType } from "#types/error-type";
 import type { ExtractItemEffect } from "#types/held-item-data-types";
+import type { IsUnion } from "type-fest";
 import { describe, expectTypeOf, it } from "vitest";
 
 // Dummy classes
@@ -78,6 +79,30 @@ describe("HeldItemBuilder", () => {
         ExtractError<typeof result>
       >().toEqualTypeOf<"A held item cannot have more than one consumable attribute for a given effect, but 2 were found for HeldItemEffect.EXP_BOOSTER!">();
     });
+  });
+});
+
+describe("HeldItem", () => {
+  it("should be covariant on Attrs", () => {
+    expectTypeOf<HeldItem<NonConsumableAttr>>().toExtend<HeldItem<NonConsumableAttr | ConsumableAttr>>();
+  });
+});
+
+declare const badAttr: HeldItemAttr<typeof HeldItemEffect.ACCURACY_BOOSTER | typeof HeldItemEffect.ATTACK_TYPE_BOOST>;
+
+describe("HeldItemAttr", () => {
+  it("should be covariant on E", () => {
+    expectTypeOf<HeldItemAttr<1>>().toExtend<HeldItemAttr<1 | 2>>();
+  });
+
+  it("should invalidate `effect` if the type parameter is a union of HeldItemEffects", () => {
+    type BadAttrTypeParam = typeof badAttr extends HeldItemAttr<infer Param> ? Param : never;
+    expectTypeOf<IsUnion<BadAttrTypeParam>>().toEqualTypeOf(true);
+    expectTypeOf<(typeof badAttr)["effect"]>().toBeNever();
+  });
+
+  it("should still type the base class's effect property as HeldItemEffect", () => {
+    expectTypeOf<HeldItemAttr["effect"]>().toEqualTypeOf<HeldItemEffect>();
   });
 });
 

--- a/test/utils/item-test-utils.ts
+++ b/test/utils/item-test-utils.ts
@@ -2,9 +2,8 @@ import { getPokemonNameWithAffix } from "#app/messages";
 import { allHeldItems } from "#data/data-lists";
 import type { HeldItemEffect } from "#enums/held-item-effect";
 import { type HeldItemId, HeldItemNames } from "#enums/held-item-id";
-import type { AllHeldItems } from "#items/all-held-items";
 import type { HeldItem } from "#items/held-item";
-import type { ApplicableHeldItemId } from "#types/held-item-data-types";
+import type { ApplicableHeldItemId, ExtractItemEffect } from "#types/held-item-data-types";
 import type { HeldItemEffectParamMap } from "#types/held-item-parameter";
 import { expect } from "vitest";
 
@@ -13,27 +12,24 @@ import { expect } from "vitest";
  * Used during unit tests to ensure proper baseline functionality.
  *
  * @param itemId - The {@linkcode HeldItemId | ID} of the `HeldItem` class instance to apply
- * @param effect - The corrsponding {@linkcode HeldItemEffect} to apply
+ * @param effect - One of `item`'s {@linkcode HeldItemEffect}s to apply
  * @param params - Parameters to pass to the class' `apply` method
- * @returns Whether the application succeeded.
  * @throws
  * Fails test immediately if the `pokemon` contained inside `params` lacks a copy of the item in question.
+ * This ensures that items whose functionality depend on stack count or other properties are applied consistently
+ * with how they would be during normal gameplay.
  */
-export function applySingleHeldItem<T extends ApplicableHeldItemId, E extends AllHeldItems[T]["effects"][number]>(
+export function applySingleHeldItem<T extends ApplicableHeldItemId, E extends ExtractItemEffect<T>>(
   itemId: T,
   effect: E,
   params: HeldItemEffectParamMap[E],
-): boolean {
+): void {
   const { pokemon } = params;
-  const itemObj = allHeldItems[itemId] as HeldItem<AllHeldItems[T]["effects"]>;
+  const itemObj = allHeldItems[itemId] as unknown as HeldItem<E>;
   expect(
     pokemon.heldItemManager.hasItem(itemObj.type),
     `Pokemon ${getPokemonNameWithAffix(pokemon)} lacks item of type ${HeldItemNames[itemObj.type]}`,
   ).toBe(true);
 
-  if (!itemObj.shouldApply(effect, params)) {
-    return false;
-  }
-  itemObj.apply(effect, params);
-  return true;
+  itemObj["apply"](effect, params);
 }

--- a/test/utils/item-test-utils.ts
+++ b/test/utils/item-test-utils.ts
@@ -3,6 +3,7 @@ import { allHeldItems } from "#data/data-lists";
 import type { HeldItemEffect } from "#enums/held-item-effect";
 import { type HeldItemId, HeldItemNames } from "#enums/held-item-id";
 import type { HeldItem } from "#items/held-item";
+import type { HeldItemAttr } from "#items/held-item-attr";
 import type { ApplicableHeldItemId, ExtractItemEffect } from "#types/held-item-data-types";
 import type { HeldItemEffectParamMap } from "#types/held-item-parameter";
 import { expect } from "vitest";
@@ -25,7 +26,7 @@ export function applySingleHeldItem<T extends ApplicableHeldItemId, E extends Ex
   params: HeldItemEffectParamMap[E],
 ): void {
   const { pokemon } = params;
-  const itemObj = allHeldItems[itemId] as unknown as HeldItem<E>;
+  const itemObj = allHeldItems[itemId] as HeldItem<HeldItemAttr<E>>;
   expect(
     pokemon.heldItemManager.hasItem(itemObj.type),
     `Pokemon ${getPokemonNameWithAffix(pokemon)} lacks item of type ${HeldItemNames[itemObj.type]}`,


### PR DESCRIPTION
## The issue
@DayKev brought up a very good point during discussion of #7254 - the current system of `HeldItem`s directly applying effects (while very minimal infrastructure-wise) is extremely hard to maintain and work with.
Items like Multi Lens effectively have to hack together multiple effect handling with verbose code that was unable to be 100% safely typed (TypeScript's type system is unable to associate the value of `effect` with the shape of the passed `params` object).
Moreover, the process of creating a new item that uses 2 pre-existing attributes together is far more convoluted than it really ought to be, requiring one to either duplicate the code for both attributes, create extra `HeldItem` instances used solely for their `apply` functions, or other similar shenanigans.

## The Rework
`HeldItem` has been reworked to be a generic attribute holder similar to `Ability` and `Move`, except with strong types provided by the `HeldItemBuilder` builder class (inspired very loosely by `@commander-js/extra-typing`'s generic builder chain, albeit a bit simpler).

All existing item classes have been reworked into `HeldITemAttr`s.

Assorted cleanups