### PR TITLE
docs: minor typo fixes

### DIFF
--- a/src/@types/arena-tags.ts
+++ b/src/@types/arena-tags.ts
@@ -50,11 +50,12 @@ export type ArenaTagDataMap = {
 export type ArenaTagData = ObjectValues<ArenaTagDataMap>;
 
 /**
- * Dummy, typescript-only declaration to ensure that
- * {@linkcode ArenaTagTypeMap} has a map for all ArenaTagTypes.
+ * Dummy, TypeScript-only declaration to ensure that
+ * {@linkcode ArenaTagTypeMap} has an entry for all `ArenaTagType`s.
  *
- * If an arena tag is missing from the map, typescript will throw an error on this statement.
+ * If a tag type is missing from the map, TypeScript will throw an error on this statement.
  *
  * ⚠️ Does not actually exist at runtime, so it must not be used!
+ * @internal
  */
 declare const EnsureAllArenaTagTypesAreMapped: ArenaTagTypeMap[ArenaTagType] & never;

--- a/src/@types/battler-tags.ts
+++ b/src/@types/battler-tags.ts
@@ -138,7 +138,7 @@ export type BattlerTagData = ObjectValues<BattlerTagDataMap>;
  * Dummy, typescript-only declaration to ensure that
  * {@linkcode BattlerTagTypeMap} has an entry for all `BattlerTagType`s.
  *
- * If a battler tag is missing from the map, Typescript will throw an error on this statement.
+ * If a tag type is missing from the map, TypeScript will throw an error on this statement.
  *
  * ⚠️ Does not actually exist at runtime, so it must not be used!
  */

--- a/src/@types/battler-tags.ts
+++ b/src/@types/battler-tags.ts
@@ -141,5 +141,6 @@ export type BattlerTagData = ObjectValues<BattlerTagDataMap>;
  * If a tag type is missing from the map, TypeScript will throw an error on this statement.
  *
  * ⚠️ Does not actually exist at runtime, so it must not be used!
+ * @internal
  */
 declare const EnsureAllBattlerTagTypesAreMapped: BattlerTagTypeMap[BattlerTagType] & never;

--- a/test/matchers/to-have-types.ts
+++ b/test/matchers/to-have-types.ts
@@ -12,11 +12,11 @@ export interface ToHaveTypesOptions {
   /**
    * Value dictating the strength of the enforced typing match.
    *
-   * Possible values (in ascending order of strength) are:
+   * Possible values (in descending order of strictness) are:
    * - `"ordered"`: Enforce that the {@linkcode Pokemon}'s types are identical **and in the same order**
    * - `"unordered"`: Enforce that the {@linkcode Pokemon}'s types are identical **without checking order**
    * - `"superset"`: Enforce that the {@linkcode Pokemon}'s types are **a superset of** the expected types
-   * (all must be present, but extras can be there)
+   *   (all must be present, but extras can be there)
    * @defaultValue `"unordered"`
    */
   mode?: "ordered" | "unordered" | "superset";
@@ -30,12 +30,12 @@ export interface ToHaveTypesOptions {
  * Matcher that checks if a Pokemon's typing is as expected.
  * @param received - The object to check. Should be a {@linkcode Pokemon}
  * @param expectedTypes - An array of one or more {@linkcode PokemonType}s to compare against.
- * @param mode - The mode to perform the matching in.
- * Possible values (in ascending order of strength) are:
+ * @param mode - The mode in which to perform the matching.
+ * Possible values (in descending order of strictness) are:
  * - `"ordered"`: Enforce that the {@linkcode Pokemon}'s types are identical **and in the same order**
  * - `"unordered"`: Enforce that the {@linkcode Pokemon}'s types are identical **without checking order**
  * - `"superset"`: Enforce that the {@linkcode Pokemon}'s types are **a superset of** the expected types
- * (all must be present, but extras can be there)
+ *   (all must be present, but extras can be there)
  *
  * Default `unordered`
  * @param args - Extra arguments passed to {@linkcode Pokemon.getTypes}
@@ -44,7 +44,7 @@ export interface ToHaveTypesOptions {
 export function toHaveTypes(
   this: Readonly<MatcherState>,
   received: unknown,
-  expectedTypes: [PokemonType, ...PokemonType[]],
+  expectedTypes: readonly PokemonType[],
   { mode = "unordered", args = [] }: ToHaveTypesOptions = {},
 ): SyncExpectationResult {
   if (!isPokemonInstance(received)) {


### PR DESCRIPTION

## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
I noticed some typos and inconsistencies in doc comments.

## What are the changes from a developer perspective?
Made the comments for the dummy constants for `arena-tag.ts` and `battler-tag.ts` consistent with each other and more precise

fixed the description of the `mode` option for the `toHaveTypes` matcher being reversed (ascending vs descending specificity)

## Screenshots/Videos
N/A
## How to test the changes?
N/A
## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
