### PR TITLE
fix(ai): Sunny Day will generate properly on NPC movesets

### DIFF
--- a/src/ai/ai-moveset-gen.ts
+++ b/src/ai/ai-moveset-gen.ts
@@ -755,17 +755,21 @@ function shouldRemoveRainDance(pokemon: Pokemon): boolean {
   if (getExistingDamageMoveTypes(pokemon, false).has(PokemonType.WATER)) {
     return false;
   }
-  for (const rainAbility of [AbilityId.RAIN_DISH, AbilityId.FORECAST, AbilityId.SWIFT_SWIM, AbilityId.DRY_SKIN]) {
+
+  const rainAbilities = [AbilityId.RAIN_DISH, AbilityId.FORECAST, AbilityId.SWIFT_SWIM, AbilityId.DRY_SKIN] as const;
+  for (const rainAbility of rainAbilities) {
     if (pokemon.hasAbility(rainAbility, false, true)) {
       return false;
     }
   }
+
   for (const pokemonMove of pokemon.moveset) {
     const move = pokemonMove.getMove();
-    if (move.findAttr(attr => attr.is("WeatherInstantChargeAttr") && attr.weatherTypes.includes(WeatherType.RAIN))) {
+    if (isWeatherInstantCharge(move, WeatherType.RAIN)) {
       return false;
     }
   }
+
   return true;
 }
 
@@ -777,20 +781,23 @@ function shouldRemoveRainDance(pokemon: Pokemon): boolean {
  */
 function shouldRemoveSunnyDay(pokemon: Pokemon): boolean {
   if (getExistingDamageMoveTypes(pokemon, false).has(PokemonType.FIRE)) {
-    return true;
+    return false;
   }
-  // Solar power depends on having a move that is specially boosted
-  for (const sunAbility of [
+
+  const sunAbilities = [
     AbilityId.CHLOROPHYLL,
     AbilityId.FLOWER_GIFT,
     AbilityId.PROTOSYNTHESIS,
     AbilityId.HARVEST,
     AbilityId.FORECAST,
-  ]) {
+  ] as const;
+  for (const sunAbility of sunAbilities) {
     if (pokemon.hasAbility(sunAbility, false, true)) {
       return false;
     }
   }
+
+  // Solar power depends on having a move that is specially boosted
   const hasSolarPower = pokemon.hasAbility(AbilityId.SOLAR_POWER, false, true);
   for (const pokemonMove of pokemon.moveset) {
     const move = pokemonMove.getMove();
@@ -803,6 +810,7 @@ function shouldRemoveSunnyDay(pokemon: Pokemon): boolean {
       return false;
     }
   }
+
   return true;
 }
 


### PR DESCRIPTION
## What are the changes the user will see?
NPC Pokémon can have Sunny Day when their moveset supports it (has a damaging fire move) instead of the opposite.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Bug noticed.

## What are the changes from a developer perspective?
`shouldRemoveSunnyDay()` returns `false` instead of `true` when the Pokémon has a damaging fire move in its moveset, the same as `shouldRemoveRainDance()` is for damaging water moves.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR