### PR TITLE
misc: remove unused `rextextedit` plugin

### DIFF
--- a/src/loading-scene.ts
+++ b/src/loading-scene.ts
@@ -372,13 +372,6 @@ export class LoadingScene extends SceneBase {
       .loadBgm("evolution", "bw/evolution.mp3")
       .loadBgm("evolution_fanfare", "bw/evolution_fanfare.mp3");
 
-    // TODO: Shouldn't this be inside the middle of the code?
-    this.load.plugin(
-      "rextexteditplugin",
-      "https://raw.githubusercontent.com/rexrainbow/phaser3-rex-notes/master/dist/rextexteditplugin.min.js",
-      true,
-    );
-
     this.loadLoadingScreen();
 
     initializeGame();


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

(Maybe marginally improved performance and/or memory usage..?)

## Why am I making these changes?
This is not only unused, but also a security issue due to pulling directly from a GitHub repo without even being pinned to a SHA1 commit hash.

## What are the changes from a developer perspective?
Removed the line of code loading a random js file from GitHub as a Phaser plugin.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually