### PR TITLE
feat: add more data to `window.gameInfo`

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -59,6 +59,7 @@ import type { PokemonAnimType } from "#enums/pokemon-anim-type";
 import { PokemonType } from "#enums/pokemon-type";
 import { ShopCursorTarget } from "#enums/shop-cursor-target";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
 import { TextStyle } from "#enums/text-style";
 import { TimeOfDay } from "#enums/time-of-day";
@@ -156,7 +157,8 @@ import { deepMergeSpriteData } from "#utils/data";
 import { getEnumValues } from "#utils/enums";
 import { cachedFetch } from "#utils/fetch-utils";
 import { getModifierPoolForType, getModifierType } from "#utils/modifier-utils";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
+import { decodeNickname, getPokemonSpecies } from "#utils/pokemon-utils";
+import { capitalizeFirstLetterOnly } from "#utils/strings";
 import i18next from "i18next";
 import Phaser from "phaser";
 import SoundFade from "phaser3-rex-plugins/plugins/soundfade";
@@ -3436,8 +3438,16 @@ export class BattleScene extends SceneBase {
     return false;
   }
 
-  updateGameInfo(): void {
+  public updateGameInfo(): void {
+    const variantMap = {
+      [0]: "Normal",
+      [1]: "Rare",
+      [2]: "Epic",
+    };
     const gameInfo = {
+      //! Make sure to update this in accordance with semver when the output is changed
+      // cf https://semver.org/
+      gameInfoVersion: "2.0.0",
       playTime: this.sessionPlayTime ?? 0,
       gameMode: this.currentBattle ? this.gameMode.getName() : "Title",
       biome: this.currentBattle ? getBiomeName(this.arena.biomeId) : "",
@@ -3445,17 +3455,66 @@ export class BattleScene extends SceneBase {
       party:
         this.party?.map(p => ({
           name: p.name,
+          nickname: p.nickname ? decodeNickname(p.nickname, p.name) : "",
+          gender: capitalizeFirstLetterOnly(Gender[p.gender]),
           form: p.getFormKey(),
-          // Ignore alterations from Transform/etc.
-          types: p.getTypes(false, false, false).map(type => PokemonType[type]),
-          teraType: PokemonType[p.getTeraType()],
+          // Does not include temporary changes, such as those from Transform, Forest's Curse, etc
+          // Ignores Tera type
+          types: p.getTypes(false, false, true, false).map(pType => capitalizeFirstLetterOnly(PokemonType[pType])),
+          // Includes temporary changes, such as those from Transform, Forest's Curse, etc
+          // Ignores Tera type
+          tempTypes:
+            p.summonData.types.length > 0 || p.summonData.addedType
+              ? p.getTypes(false, false, false, false).map(pType => capitalizeFirstLetterOnly(PokemonType[pType]))
+              : [],
+          teraType: capitalizeFirstLetterOnly(PokemonType[p.getTeraType()]),
           isTerastallized: p.isTerastallized,
           level: p.level,
           currentHP: p.hp,
           maxHP: p.getMaxHp(),
-          status: p.status?.effect ? StatusEffect[p.status.effect] : "",
-        })) ?? [], // TODO: review if this can be nullish
-      modeChain: this.ui?.getModeChain() ?? [],
+          status: p.status?.effect ? capitalizeFirstLetterOnly(StatusEffect[p.status.effect]) : "",
+          // the pokemon's actual moveset
+          moveset: p.getMoveset(true).map(move => move.getName()),
+          // the pokemon's temporary moveset, e.g. from Transform
+          // biome-ignore lint/style/useExplicitLengthCheck: doubles as a null check
+          tempMoveset: p.summonData.moveset?.length ? p.getMoveset().map(move => move.getName()) : [],
+          // the pokemon's actual ability
+          ability: p.getAbility(true).name,
+          // the pokemon's temporary ability, e.g. from Transform or Skill Swap
+          tempAbility: p.summonData.ability ? p.getAbility().name : "",
+          passiveAbility: p.getPassiveAbility().name,
+          isPassiveEnabled: p.hasPassive(),
+          nature: capitalizeFirstLetterOnly(Nature[p.getNature()]),
+          baseStats: {
+            atk: p.getStat(Stat.ATK),
+            def: p.getStat(Stat.DEF),
+            spAtk: p.getStat(Stat.SPATK),
+            spDef: p.getStat(Stat.SPDEF),
+            speed: p.getStat(Stat.SPD),
+          },
+          // e.g. from Transform
+          tempStats: p.summonData.stats.some(v => v > 0)
+            ? {
+                atk: p.getStat(Stat.ATK, false),
+                def: p.getStat(Stat.DEF, false),
+                spAtk: p.getStat(Stat.SPATK, false),
+                spDef: p.getStat(Stat.SPDEF, false),
+                speed: p.getStat(Stat.SPD, false),
+              }
+            : {},
+          statStages: {
+            atk: p.getStatStage(Stat.ATK),
+            def: p.getStatStage(Stat.DEF),
+            spAtk: p.getStatStage(Stat.SPATK),
+            spDef: p.getStatStage(Stat.SPDEF),
+            speed: p.getStatStage(Stat.SPD),
+            acc: p.getStatStage(Stat.ACC),
+            eva: p.getStatStage(Stat.EVA),
+          },
+          shiny: p.isShiny(),
+          variant: p.isShiny() ? variantMap[p.getVariant()] : "N/A",
+          isFusion: p.isFusion(),
+        })) ?? [],
     };
     // TODO: Don't store it here
     (window as any).gameInfo = gameInfo;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -181,7 +181,7 @@ import {
 import { calculateBossSegmentDamage } from "#utils/damage";
 import { getEnumValues } from "#utils/enums";
 import { cachedFetch } from "#utils/fetch-utils";
-import { getFusedSpeciesName, getPokemonSpecies, getPokemonSpeciesForm } from "#utils/pokemon-utils";
+import { decodeNickname, getFusedSpeciesName, getPokemonSpecies, getPokemonSpeciesForm } from "#utils/pokemon-utils";
 import { inSpeedOrder } from "#utils/speed-order-generator";
 import { ValueHolder } from "#utils/value-holder";
 import { QuantizerCelebi } from "@material/material-color-utilities";
@@ -471,25 +471,16 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     useIllusion?: boolean;
     prependFormName?: boolean;
   } = {}) {
-    const decodeNickname = (nickname: string): string => {
-      try {
-        return decodeURIComponent(escape(atob(nickname))); // TODO: this seems jank, and `escape` is deprecated
-      } catch (err) {
-        console.error(`Failed to decode nickname for ${this.name}`, err);
-        return this.name;
-      }
-    };
-
     const { illusion } = this.summonData;
     if (useIllusion && illusion) {
       if (illusion.nickname) {
-        return decodeNickname(illusion.nickname);
+        return decodeNickname(illusion.nickname, this.name);
       }
       return illusion.name;
     }
 
     if (this.nickname) {
-      return decodeNickname(this.nickname);
+      return decodeNickname(this.nickname, this.name);
     }
 
     if (prependFormName) {

--- a/src/utils/pokemon-utils.ts
+++ b/src/utils/pokemon-utils.ts
@@ -207,3 +207,12 @@ export function canTerastallize(pokemon: PlayerPokemon): boolean {
   const hasAvailableTeras = globalScene.arena.playerTerasUsed < MAX_TERAS_PER_ARENA;
   return hasAvailableTeras && canSpeciesTera(pokemon);
 }
+
+export function decodeNickname(nickname: string, pokemonName: string): string {
+  try {
+    return decodeURIComponent(escape(atob(nickname))); // TODO: this seems jank, and `escape` is deprecated
+  } catch (err) {
+    console.error(`Failed to decode nickname for ${pokemonName}!\n`, err);
+    return pokemonName;
+  }
+}

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -71,6 +71,19 @@ export function capitalizeFirstLetter(str: string) {
 }
 
 /**
+ * Capitalize the first letter of a string, and make the rest lowercase.
+ * @param str - The string to transform
+ * @returns The original string with all letters lowercase except the first which is capitalized
+ * @example
+ * ```ts
+ * console.log(capitalizeFirstLetterOnly("WATER")); // prints "Water"
+ * ```
+ */
+export function capitalizeFirstLetterOnly(str: string): string {
+  return capitalizeFirstLetter(str.toLowerCase());
+}
+
+/**
  * Helper method to convert a string into `Title Case` (such as one used for console logs).
  * @param str - The string being converted
  * @returns The result of converting `str` into title case.


### PR DESCRIPTION
## What are the changes the user will see?
More information is exposed through `window.gameInfo` for plugin devs. Specifics in the [PR description](https://github.com/pagefaultgames/pokerogue/pull/7290).

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Making it easier for plugin devs.

## What are the changes from a developer perspective?
Added a bunch of stuff to the output of `BattleScene#updateGameInfo` for Pokémon:
- nickname
- gender
- base moveset
- temporary moveset (e.g. from Transform)
- base ability
- temporary ability (e.g. from Transform or Skill Swap)
- passive ability
- whether the passive is enabled
- nature
- base stats
- temporary in-battle stats (e.g. from Transform)
- current stat stages
- whether the Pokémon is shiny
- if the Pokémon is shiny, which shiny variant it is
- temporary in-battle types (e.g. from Transform or Forest's Curse)
- whether the Pokémon is a fusion (note that some of the fields may be inaccurate for fusions)

Fixed the `types` field so it shows the Pokémon's actual/base types as intended, ignoring temporary types such as from Transform or Forest's Curse.

Removed the unnecessary (and basically useless) `modeChain` field.

Added a `gameInfoVersion` field, to be updated whenever the output of `gameInfo` is modified.

Added a helper function to `src/utils/strings.ts` to capitalize only the first letter of a string.

Pulled `decodeNickname` out of `Pokemon#getNameToRender` into an exported utility function in `src/utils/pokemon-utils.ts`.

## Screenshots/Videos
<details><summary>Output Example 1</summary>

<img width="661" height="1065" alt="image" src="https://github.com/user-attachments/assets/a41fd3f8-58d4-4009-ad8a-921a164f311a" />

</details>
<details><summary>Output Example 2</summary>

<img width="658" height="624" alt="image" src="https://github.com/user-attachments/assets/1c4e8cf7-c92f-4e60-ab82-4b0cf59f4de7" />

</details>

## How to test the changes?
Load a battle, open the browser devtools, and enter `window.gameInfo`.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually