### PR TITLE
refactor: `fixedInt(...)` no longer pretends `FixedInt`s are `number`s

### DIFF
--- a/src/@types/phaser.d.ts
+++ b/src/@types/phaser.d.ts
@@ -1,4 +1,58 @@
+import type { AnyFn } from "#types/type-helpers";
+import type { FixedInt } from "#utils/common";
 import "phaser";
+
+/**
+ * A Timer Event represents a delayed function call. \
+ * It's managed by a Scene's {@linkcode Phaser.Time.Clock | Clock} and will call its function after a set amount of time has passed. \
+ * The Timer Event can optionally repeat - i.e. call its function multiple times before finishing, or loop indefinitely.
+ *
+ * Because it's managed by a Clock, a Timer Event is based on game time, \
+ * will be affected by its Clock's time scale, and will pause if its Clock pauses.
+ */
+interface TimerEventFixedInt extends Phaser.Time.TimerEvent {
+  readonly delay: number | FixedInt;
+}
+
+interface TimerEventConfigFixedInt extends Phaser.Types.Time.TimerEventConfig {
+  delay?: number | FixedInt;
+}
+
+interface NumberTweenBuilderConfigFixedInt extends Phaser.Types.Tweens.NumberTweenBuilderConfig {
+  delay?: number | FixedInt;
+  duration?: number | FixedInt;
+  hold?: number | FixedInt;
+  repeatDelay?: number | FixedInt;
+  completeDelay?: string | number | AnyFn | object | any[] | FixedInt;
+  loopDelay?: string | number | AnyFn | object | any[] | FixedInt;
+}
+
+export interface TweenBuilderConfigFixedInt extends Phaser.Types.Tweens.TweenBuilderConfig {
+  delay?: number | AnyFn | FixedInt;
+  duration?: number | FixedInt;
+  hold?: number | FixedInt;
+  repeatDelay?: number | FixedInt;
+  completeDelay?: string | number | AnyFn | object | any[] | FixedInt;
+  loopDelay?: string | number | AnyFn | object | any[] | FixedInt;
+}
+
+export interface TweenChainBuilderConfigFixedInt extends Phaser.Types.Tweens.TweenChainBuilderConfig {
+  delay?: number | AnyFn | FixedInt;
+  completeDelay?: string | number | AnyFn | object | any[] | FixedInt;
+  loopDelay?: string | number | AnyFn | object | any[] | FixedInt;
+  tweens?: (Phaser.Types.Tweens.TweenBuilderConfig | TweenBuilderConfigFixedInt)[];
+}
+
+/**
+ * A Tween is able to manipulate the properties of one or more objects to any given value,
+ * based on a duration and type of ease. \
+ * They are rarely instantiated directly and instead should be created via the TweenManager.
+ *
+ * Please note that a Tween will not manipulate any property that begins with an underscore.
+ */
+interface TweenFixedInt extends Phaser.Tweens.Tween {
+  duration: number | FixedInt;
+}
 
 declare module "phaser" {
   namespace Math {
@@ -17,6 +71,31 @@ declare module "phaser" {
          */
         refreshPads(): void;
       }
+    }
+  }
+
+  namespace Time {
+    interface Clock {
+      addEvent(config: TimerEventFixedInt | TimerEventConfigFixedInt): Phaser.Time.TimerEvent;
+      delayedCall(delay: number | FixedInt, callback: AnyFn, args?: any[], callbackScope?: any): Phaser.Time.TimerEvent;
+    }
+  }
+
+  namespace Tweens {
+    interface TweenManager {
+      add(
+        config:
+          | TweenBuilderConfigFixedInt
+          | TweenChainBuilderConfigFixedInt
+          | TweenFixedInt
+          | Phaser.Types.Tweens.TweenBuilderConfig
+          | Phaser.Types.Tweens.TweenChainBuilderConfig
+          | Phaser.Tweens.Tween
+          | Phaser.Tweens.TweenChain,
+      ): Phaser.Tweens.Tween;
+      addCounter(config: NumberTweenBuilderConfigFixedInt): Phaser.Tweens.Tween;
+      addMultiple(configs: TweenBuilderConfigFixedInt[] | object[]): Phaser.Tweens.Tween[];
+      chain(tweens: TweenChainBuilderConfigFixedInt | object): Phaser.Tweens.TweenChain;
     }
   }
 }

--- a/src/ui/containers/time-of-day-widget.ts
+++ b/src/ui/containers/time-of-day-widget.ts
@@ -2,6 +2,7 @@ import { globalScene } from "#app/global-scene";
 import { EaseType } from "#enums/ease-type";
 import { TimeOfDay } from "#enums/time-of-day";
 import { BattleSceneEventType } from "#events/battle-scene";
+import type { TweenBuilderConfigFixedInt } from "#types/phaser.d";
 import { fixedInt } from "#utils/common";
 
 /** A small self contained UI element that displays the time of day as an icon */
@@ -71,7 +72,7 @@ export class TimeOfDayWidget extends Phaser.GameObjects.Container {
    * Creates a tween animation based on the 'Back' ease algorithm
    * @returns an array of all tweens in the animation
    */
-  private getBackTween(): Phaser.Types.Tweens.TweenBuilderConfig[] {
+  private getBackTween(): TweenBuilderConfigFixedInt[] {
     const rotate = {
       targets: [this.timeOfDayIconMgs[0], this.timeOfDayIconMgs[1]],
       angle: "+=90",
@@ -94,7 +95,7 @@ export class TimeOfDayWidget extends Phaser.GameObjects.Container {
    * Creates a tween animation based on the 'Bounce' ease algorithm
    * @returns an array of all tweens in the animation
    */
-  private getBounceTween(): Phaser.Types.Tweens.TweenBuilderConfig[] {
+  private getBounceTween(): TweenBuilderConfigFixedInt[] {
     const bounce = {
       targets: [this.timeOfDayIconMgs[0], this.timeOfDayIconMgs[1]],
       angle: "+=90",

--- a/src/ui/handlers/battle-message-ui-handler.ts
+++ b/src/ui/handlers/battle-message-ui-handler.ts
@@ -6,6 +6,7 @@ import { UiMode } from "#enums/ui-mode";
 import { MessageUiHandler } from "#ui/message-ui-handler";
 import { addBBCodeTextObject, addTextObject, getTextColor } from "#ui/text";
 import { addWindow } from "#ui/ui-theme";
+import type { FixedInt } from "#utils/common";
 import i18next from "i18next";
 import type BBCodeText from "phaser3-rex-plugins/plugins/bbcodetext";
 
@@ -170,11 +171,11 @@ export class BattleMessageUiHandler extends MessageUiHandler {
 
   showText(
     text: string,
-    delay?: number | null,
+    delay?: number | FixedInt | null,
     callback?: (() => void) | null,
-    callbackDelay?: number | null,
+    callbackDelay?: number | FixedInt | null,
     prompt?: boolean | null,
-    promptDelay?: number | null,
+    promptDelay?: number | FixedInt | null,
   ) {
     this.hideNameText();
     super.showText(text, delay, callback, callbackDelay, prompt, promptDelay);
@@ -183,11 +184,11 @@ export class BattleMessageUiHandler extends MessageUiHandler {
   showDialogue(
     text: string,
     name?: string,
-    delay?: number | null,
+    delay?: number | FixedInt | null,
     callback?: () => void,
-    callbackDelay?: number,
+    callbackDelay?: number | FixedInt,
     prompt?: boolean,
-    promptDelay?: number,
+    promptDelay?: number | FixedInt,
   ) {
     if (name) {
       this.showNameText(name);

--- a/src/ui/handlers/egg-gacha-ui-handler.ts
+++ b/src/ui/handlers/egg-gacha-ui-handler.ts
@@ -9,10 +9,11 @@ import { GachaType } from "#enums/gacha-types";
 import { TextStyle } from "#enums/text-style";
 import { UiMode } from "#enums/ui-mode";
 import { getVoucherTypeIcon, VoucherType } from "#system/voucher";
+import type { TweenBuilderConfigFixedInt } from "#types/phaser.d";
 import { MessageUiHandler } from "#ui/message-ui-handler";
 import { addTextObject, getEggTierTextTint, getTextStyleOptions } from "#ui/text";
 import { addWindow } from "#ui/ui-theme";
-import { fixedInt, randSeedShuffle } from "#utils/common";
+import { type FixedInt, fixedInt, randSeedShuffle } from "#utils/common";
 import { getEnumValues } from "#utils/enums";
 import { getPokemonSpecies } from "#utils/pokemon-utils";
 import i18next from "i18next";
@@ -356,7 +357,7 @@ export class EggGachaUiHandler extends MessageUiHandler {
     return fixedInt(delay);
   }
 
-  private firstDropAnims(): Phaser.Types.Tweens.TweenBuilderConfig[] {
+  private firstDropAnims(): TweenBuilderConfigFixedInt[] {
     globalScene.playSound("se/gacha_dial");
     return [
       // Tween 1 animates the gacha knob turning left
@@ -411,7 +412,7 @@ export class EggGachaUiHandler extends MessageUiHandler {
       resolve = res;
     });
 
-    const tweens: Phaser.Types.Tweens.TweenBuilderConfig[] = count ? [] : this.firstDropAnims();
+    const tweens: TweenBuilderConfigFixedInt[] = count ? [] : this.firstDropAnims();
 
     tweens.push(
       // Tween 1 is responsible for animating the egg dropping from the gacha
@@ -659,11 +660,11 @@ export class EggGachaUiHandler extends MessageUiHandler {
 
   showText(
     text: string,
-    delay?: number,
+    delay?: number | FixedInt,
     callback?: () => void,
-    callbackDelay?: number,
+    callbackDelay?: number | FixedInt,
     prompt?: boolean,
-    promptDelay?: number,
+    promptDelay?: number | FixedInt,
   ): void {
     if (!text) {
       text = this.defaultText;

--- a/src/ui/handlers/message-ui-handler.ts
+++ b/src/ui/handlers/message-ui-handler.ts
@@ -1,7 +1,7 @@
 import { globalScene } from "#app/global-scene";
 import type { UiMode } from "#enums/ui-mode";
 import { AwaitableUiHandler } from "#ui/awaitable-ui-handler";
-import { getFrameMs } from "#utils/common";
+import { type FixedInt, getFrameMs } from "#utils/common";
 
 export abstract class MessageUiHandler extends AwaitableUiHandler {
   protected textTimer: Phaser.Time.TimerEvent | null;
@@ -36,11 +36,11 @@ export abstract class MessageUiHandler extends AwaitableUiHandler {
 
   showText(
     text: string,
-    delay?: number | null,
+    delay?: number | FixedInt | null,
     callback?: (() => void) | null,
-    callbackDelay?: number | null,
+    callbackDelay?: number | FixedInt | null,
     prompt?: boolean | null,
-    promptDelay?: number | null,
+    promptDelay?: number | FixedInt | null,
   ) {
     this.showTextInternal(text, delay, callback, callbackDelay, prompt, promptDelay);
   }
@@ -48,22 +48,22 @@ export abstract class MessageUiHandler extends AwaitableUiHandler {
   showDialogue(
     text: string,
     _name?: string,
-    delay?: number | null,
+    delay?: number | FixedInt | null,
     callback?: (() => void) | null,
-    callbackDelay?: number | null,
+    callbackDelay?: number | FixedInt | null,
     prompt?: boolean | null,
-    promptDelay?: number | null,
+    promptDelay?: number | FixedInt | null,
   ) {
     this.showTextInternal(text, delay, callback, callbackDelay, prompt, promptDelay);
   }
 
   private showTextInternal(
     text: string,
-    delay?: number | null,
+    delay?: number | FixedInt | null,
     callback?: (() => void) | null,
-    callbackDelay?: number | null,
+    callbackDelay?: number | FixedInt | null,
     prompt?: boolean | null,
-    promptDelay?: number | null,
+    promptDelay?: number | FixedInt | null,
   ) {
     if (delay === null || delay === undefined) {
       delay = 20;
@@ -219,7 +219,7 @@ export abstract class MessageUiHandler extends AwaitableUiHandler {
     }
   }
 
-  showPrompt(callback?: (() => void) | null, callbackDelay?: number | null) {
+  showPrompt(callback?: (() => void) | null, callbackDelay?: number | FixedInt | null) {
     const wrappedTextLines = this.message.runWordWrap(this.message.text).split(/\n/g);
     const textLinesCount = wrappedTextLines.length;
     const lastTextLine = wrappedTextLines.at(-1) ?? "";

--- a/src/ui/handlers/pokedex-ui-handler.ts
+++ b/src/ui/handlers/pokedex-ui-handler.ts
@@ -33,6 +33,7 @@ import { getVariantIcon, getVariantTint } from "#sprites/variant";
 import type { GameData } from "#system/game-data";
 import { SettingKeyboard } from "#system/settings-keyboard";
 import type { DexEntry } from "#types/dex-data";
+import type { TweenChainBuilderConfigFixedInt } from "#types/phaser.d";
 import type { DexAttrProps, StarterAttributes } from "#types/save-data";
 import type { OptionSelectConfig } from "#ui/abstract-option-select-ui-handler";
 import { DropDown, DropDownLabel, DropDownOption, DropDownState, DropDownType, SortCriteria } from "#ui/dropdown";
@@ -969,7 +970,7 @@ export class PokedexUiHandler extends MessageUiHandler {
 
     icon.y = 2;
 
-    const tweenChain: Phaser.Types.Tweens.TweenChainBuilderConfig = {
+    const tweenChain: TweenChainBuilderConfigFixedInt = {
       targets: icon,
       loop: -1,
       paused: startPaused,

--- a/src/ui/handlers/starter-select-ui-handler.ts
+++ b/src/ui/handlers/starter-select-ui-handler.ts
@@ -48,6 +48,7 @@ import { achvs } from "#system/achv";
 import { RibbonData } from "#system/ribbons/ribbon-data";
 import { SettingKeyboard } from "#system/settings-keyboard";
 import type { DexEntry } from "#types/dex-data";
+import type { TweenChainBuilderConfigFixedInt } from "#types/phaser.d";
 import type { LevelMoves } from "#types/pokemon-level-moves";
 import type { Starter, StarterAttributes, StarterDataEntry, StarterMoveset } from "#types/save-data";
 import type { OptionSelectItem } from "#ui/abstract-option-select-ui-handler";
@@ -1499,7 +1500,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
 
     icon.y = 2;
 
-    const tweenChain: Phaser.Types.Tweens.TweenChainBuilderConfig = {
+    const tweenChain: TweenChainBuilderConfigFixedInt = {
       targets: icon,
       paused: startPaused,
       loop: -1,

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -58,7 +58,7 @@ import { TitleUiHandler } from "#ui/title-ui-handler";
 import type { UiHandler } from "#ui/ui-handler";
 import { addWindow } from "#ui/ui-theme";
 import { UnavailableModalUiHandler } from "#ui/unavailable-modal-ui-handler";
-import { executeIf } from "#utils/common";
+import { executeIf, type FixedInt } from "#utils/common";
 import i18next from "i18next";
 import { AdminUiHandler } from "./handlers/admin-ui-handler";
 import { RenameRunFormUiHandler } from "./handlers/rename-run-ui-handler";
@@ -279,11 +279,11 @@ export class UI extends Phaser.GameObjects.Container {
 
   showText(
     text: string,
-    delay?: number | null,
+    delay?: number | FixedInt | null,
     callback?: (() => void) | null,
-    callbackDelay?: number | null,
+    callbackDelay?: number | FixedInt | null,
     prompt?: boolean | null,
-    promptDelay?: number | null,
+    promptDelay?: number | FixedInt | null,
   ): void {
     const pokename: string[] = [];
     const repname = ["#POKEMON1", "#POKEMON2"];
@@ -317,10 +317,10 @@ export class UI extends Phaser.GameObjects.Container {
   showDialogue(
     keyOrText: string,
     name: string | undefined,
-    delay: number | null = 0,
+    delay: number | FixedInt | null = 0,
     callback: () => void,
-    callbackDelay?: number,
-    promptDelay?: number,
+    callbackDelay?: number | FixedInt,
+    promptDelay?: number | FixedInt,
   ): void {
     // Get localized dialogue (if available)
     let hasi18n = false;

--- a/src/utils/anim-utils.ts
+++ b/src/utils/anim-utils.ts
@@ -1,19 +1,16 @@
 import { globalScene } from "#app/global-scene";
 import type { SceneBase } from "#app/scene-base";
+import type { TweenBuilderConfigFixedInt } from "#types/phaser.d";
 import type { Except } from "type-fest";
 
 /**
  * Argument type for {@linkcode playTween},
- * containing all attributes of {@linkcode Phaser.Types.Tweens.TweenBuilderConfig | TweenBuilderConfig}
- * save for ones related to the `onComplete` callback.
+ * containing all attributes of {@linkcode TweenBuilderConfigFixedInt}
+ * except for ones related to the `onComplete` callback.
  * @internal
  */
 interface PlayTweenConfig
-  extends Except<
-    Phaser.Types.Tweens.TweenBuilderConfig,
-    "onComplete" | "onCompleteParams",
-    { requireExactProps: true }
-  > {}
+  extends Except<TweenBuilderConfigFixedInt, "onComplete" | "onCompleteParams", { requireExactProps: true }> {}
 
 /**
  * Play a Tween animation and wait for its animation to complete.

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -302,20 +302,24 @@ export async function localPing(): Promise<void> {
   }
 }
 
+/**
+ * Class used to wrap numbers that should be treated as fixed values and not mutated by changes to game speed.
+ * @remarks
+ * Many `Phaser` functions are overridden in `src/system/game-speed.ts` to mutate the numbers for duration/etc \
+ * that are passed in to them by dividing by the game speed, unless a `FixedInt` object is passed in.
+ *
+ * There is no reason to use this outside of those functions.
+ */
 export class FixedInt {
   public readonly value: number;
 
   constructor(value: number) {
     this.value = value;
   }
-
-  [Symbol.toPrimitive](_hint: string): number {
-    return this.value;
-  }
 }
 
-export function fixedInt(value: number): number {
-  return new FixedInt(value) as unknown as number;
+export function fixedInt(value: number): FixedInt {
+  return new FixedInt(value);
 }
 
 /**


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Fake typing was causing bugs.

## What are the changes from a developer perspective?
Soon :tm:

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [ ] There is no overlap with another open PR
  - Waiting on #7263 and #7136 so as not to duplicate effort.
- The PR has been confirmed to work correctly:
  - [ ] I have tested the changes manually