### PR TITLE
docs: Standardize and fix up `#region` comments

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -36,7 +36,7 @@ type FromEntries<E extends Iterable<readonly [StringableKey, unknown]>> =
       ? Record<Unstringify<K>, V>
       : never;
 
-// #endregion Object-related code
+// #endregion Object-related types
 
 // #region Declaration merges
 

--- a/global.d.ts
+++ b/global.d.ts
@@ -3,6 +3,7 @@ import type { PreventHoverExpansion } from "#types/type-helpers";
 import type { SetupServer } from "msw/node";
 
 // #region Object-related types
+
 /**
  * A key that can be stringified.
  * @privateRemarks

--- a/scripts/create-test/create-test.js
+++ b/scripts/create-test/create-test.js
@@ -23,13 +23,15 @@ import { HELP_FLAGS, showHelpText } from "./help-message.js";
  * @import {testType} from "./constants.js"
  */
 
-//#region Constants
+// #region Constants
+
 const version = "2.1.1";
 const __dirname = import.meta.dirname;
 const projectRoot = join(__dirname, "..", "..");
-//#endregion
 
-//#region Main
+// #endregion Constants
+
+// #region Main
 
 /**
  * Run the interactive `test:create` CLI.
@@ -85,6 +87,6 @@ function doCreateFile(testType, fileNameAnswer) {
   console.log(chalk.green.bold(`✔ File created at: ${filePath.replace(`${projectRoot}/`, "")}\n`));
 }
 
-//#endregion
+// #endregion Main
 
 await runInteractive();

--- a/scripts/daily-seed/constants.js
+++ b/scripts/daily-seed/constants.js
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+// #region Constants
+
 /**
  * A mapping of biome pool tier names to their corresponding IDs.
  * @enum {number}

--- a/scripts/helpers/casing.js
+++ b/scripts/helpers/casing.js
@@ -6,6 +6,7 @@
  */
 
 // #region Split string code
+
 // Regexps involved with splitting words in various case formats.
 // Sourced from https://www.npmjs.com/package/change-case (with slight tweaking here and there)
 
@@ -63,7 +64,8 @@ function trimFromStartAndEnd(str, charToTrim) {
   }
   return str.slice(start, end);
 }
-// #endregion Split String code
+
+// #endregion Split string code
 
 /**
  * Capitalize the first letter of a string.

--- a/src/@types/api.ts
+++ b/src/@types/api.ts
@@ -37,8 +37,7 @@ export interface AccountChangePwRequest {
 export interface AccountChangePwResponse {
   success: boolean;
 }
-
-// #endregion
+// #endregion Account API
 // #region Admin API
 
 export interface SearchAccountRequest {
@@ -71,8 +70,7 @@ export interface PokerogueAdminApiParams extends Record<AdminUiHandlerService, S
   discord: DiscordRequest;
   google: GoogleRequest;
 }
-
-// #endregion
+// #endregion Admin API
 
 export interface UpdateAllSavedataRequest {
   system: SystemSaveData;
@@ -122,8 +120,7 @@ export interface ClearSessionSavedataResponse {
   /** Is `true` if the request was successfully processed */
   success?: boolean;
 }
-
-// #endregion
+// #endregion Session Save API
 // #region System Save API
 
 export interface GetSystemSavedataRequest {
@@ -144,5 +141,4 @@ export interface VerifySystemSavedataResponse {
   valid: boolean;
   systemData: SystemSaveData;
 }
-
-// #endregion
+// #endregion System Save API

--- a/src/@types/api.ts
+++ b/src/@types/api.ts
@@ -37,7 +37,9 @@ export interface AccountChangePwRequest {
 export interface AccountChangePwResponse {
   success: boolean;
 }
+
 // #endregion Account API
+
 // #region Admin API
 
 export interface SearchAccountRequest {
@@ -70,6 +72,7 @@ export interface PokerogueAdminApiParams extends Record<AdminUiHandlerService, S
   discord: DiscordRequest;
   google: GoogleRequest;
 }
+
 // #endregion Admin API
 
 export interface UpdateAllSavedataRequest {
@@ -120,7 +123,9 @@ export interface ClearSessionSavedataResponse {
   /** Is `true` if the request was successfully processed */
   success?: boolean;
 }
+
 // #endregion Session Save API
+
 // #region System Save API
 
 export interface GetSystemSavedataRequest {
@@ -141,4 +146,5 @@ export interface VerifySystemSavedataResponse {
   valid: boolean;
   systemData: SystemSaveData;
 }
+
 // #endregion System Save API

--- a/src/@types/configs/inputs.ts
+++ b/src/@types/configs/inputs.ts
@@ -153,6 +153,7 @@ export interface SelectedDevice {
 }
 
 // #region Button mappings
+
 /** Button keycode mappings for Dualshock controller */
 export type DualshockButtons = {
   RC_S: 0;
@@ -345,6 +346,7 @@ export type KeyboardMapping = {
   KEY_BACKSPACE: typeof Phaser.Input.Keyboard.KeyCodes.BACKSPACE;
   KEY_ALT: typeof Phaser.Input.Keyboard.KeyCodes.ALT;
 };
-//#endregion Button mappings
+
+// #endregion Button mappings
 
 export type MappingSettingName = SettingGamepad | SettingKeyboard;

--- a/src/@types/configs/inputs.ts
+++ b/src/@types/configs/inputs.ts
@@ -152,7 +152,7 @@ export interface SelectedDevice {
   [Device.KEYBOARD]: string;
 }
 
-//#region Button mappings
+// #region Button mappings
 /** Button keycode mappings for Dualshock controller */
 export type DualshockButtons = {
   RC_S: 0;

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -269,7 +269,9 @@ export class Animation {
   public sin(index: number, amplitude: number): number {
     return amplitude * Math.sin(index * (Math.PI / 128));
   }
+
   // #endregion Public Methods
+
   // #region Private Methods
 
   private doDefaultPbOpenParticles(x: number, y: number, radius: number): void {
@@ -587,5 +589,6 @@ export class Animation {
 
     updateParticle();
   }
+
   // #endregion Private Methods
 }

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -269,8 +269,7 @@ export class Animation {
   public sin(index: number, amplitude: number): number {
     return amplitude * Math.sin(index * (Math.PI / 128));
   }
-
-  // #endregion
+  // #endregion Public Methods
   // #region Private Methods
 
   private doDefaultPbOpenParticles(x: number, y: number, radius: number): void {
@@ -588,6 +587,5 @@ export class Animation {
 
     updateParticle();
   }
-
-  // #endregion
+  // #endregion Private Methods
 }

--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -11,7 +11,7 @@ import type { Constructor } from "#types/common";
 import { toCamelCase } from "#utils/strings";
 import i18next from "i18next";
 
-//#region Bit sets
+// #region Bit sets
 /** Bit set for an ability's `bypass faint` flag */
 const AB_FLAG_BYPASS_FAINT = 1 << 0;
 /** Bit set for an ability's `ignorable` flag */

--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -11,7 +11,8 @@ import type { Constructor } from "#types/common";
 import { toCamelCase } from "#utils/strings";
 import i18next from "i18next";
 
-// #region Bit sets
+// #region Bitflags
+
 /** Bit set for an ability's `bypass faint` flag */
 const AB_FLAG_BYPASS_FAINT = 1 << 0;
 /** Bit set for an ability's `ignorable` flag */
@@ -29,7 +30,7 @@ const AB_FLAG_PARTIAL = 1 << 6;
 /** Bit set for an unswappable ability */
 const AB_FLAG_UNSWAPPABLE = AB_FLAG_UNCOPIABLE | AB_FLAG_UNREPLACEABLE;
 
-//#endregion Bit sets
+// #endregion Bitflags
 
 /**
  * An Ability is a class representing the various Abilities Pokemon may have. \

--- a/src/data/balance/moves/moveset-generation.ts
+++ b/src/data/balance/moves/moveset-generation.ts
@@ -37,7 +37,7 @@ import type { FORCED_SIGNATURE_MOVES } from "#balance/moves/signature-moves";
 import { MoveId } from "#enums/move-id";
 import type { IntRange } from "type-fest";
 
-//#region Constants
+// #region Constants
 /**
  * The minimum level for a Pokémon to generate with a move it can only learn
  * from a common tier TM

--- a/src/data/balance/moves/moveset-generation.ts
+++ b/src/data/balance/moves/moveset-generation.ts
@@ -38,6 +38,7 @@ import { MoveId } from "#enums/move-id";
 import type { IntRange } from "type-fest";
 
 // #region Constants
+
 /**
  * The minimum level for a Pokémon to generate with a move it can only learn
  * from a common tier TM
@@ -223,7 +224,7 @@ export const STAB_BLACKLIST: ReadonlySet<MoveId> = new Set([
   MoveId.HIDDEN_POWER,
 ]);
 
-//#endregion Constants
+// #endregion Constants
 
 /**
  * Get the maximum number of TMs a Pokémon is allowed to learn based on

--- a/src/data/balance/rates.ts
+++ b/src/data/balance/rates.ts
@@ -11,8 +11,7 @@ export const BASE_SHINY_CHANCE = 64;
 
 /** `1 / 256` */
 export const BASE_HIDDEN_ABILITY_RATE = 256;
-
-// #endregion
+// #endregion Encounterable properties
 // #region Egg properties
 
 // Threshold x at which a gacha egg is determined to be a certain tier
@@ -48,8 +47,7 @@ export const GACHA_EGG_HA_RATE = 192;
 // [COMMON, RARE, EPIC/MANAPHY, LEGEND]
 export const RARE_EGGMOVE_RATES: readonly number[] = [48, 24, 12, 6];
 export const BOOSTED_RARE_EGGMOVE_RATES: readonly number[] = [16, 12, 6, 3];
-
-// #endregion
+// #endregion Egg properties
 // #region Variant properties
 
 // The chance x/10 of a shiny being a variant, then of being specifically an epic variant
@@ -58,3 +56,4 @@ export const SHINY_EPIC_CHANCE = 1;
 
 // The catch rate bonus for shiny mons, introduced in Z-A. Can be boosted in events.
 export const SHINY_CATCH_RATE_MULTIPLIER = 2;
+// #endregion Variant properties

--- a/src/data/balance/rates.ts
+++ b/src/data/balance/rates.ts
@@ -11,7 +11,9 @@ export const BASE_SHINY_CHANCE = 64;
 
 /** `1 / 256` */
 export const BASE_HIDDEN_ABILITY_RATE = 256;
+
 // #endregion Encounterable properties
+
 // #region Egg properties
 
 // Threshold x at which a gacha egg is determined to be a certain tier
@@ -47,7 +49,9 @@ export const GACHA_EGG_HA_RATE = 192;
 // [COMMON, RARE, EPIC/MANAPHY, LEGEND]
 export const RARE_EGGMOVE_RATES: readonly number[] = [48, 24, 12, 6];
 export const BOOSTED_RARE_EGGMOVE_RATES: readonly number[] = [16, 12, 6, 3];
+
 // #endregion Egg properties
+
 // #region Variant properties
 
 // The chance x/10 of a shiny being a variant, then of being specifically an epic variant
@@ -56,4 +60,5 @@ export const SHINY_EPIC_CHANCE = 1;
 
 // The catch rate bonus for shiny mons, introduced in Z-A. Can be boosted in events.
 export const SHINY_CATCH_RATE_MULTIPLIER = 2;
+
 // #endregion Variant properties

--- a/src/data/balance/starters.ts
+++ b/src/data/balance/starters.ts
@@ -17,7 +17,7 @@ export const FRIENDSHIP_LOSS_FROM_FAINT = 5;
 export const TRAINER_MIN_FRIENDSHIP = 50;
 /** The wave at which enemy trainers reach the maximum friendship value of 255. */
 export const TRAINER_MAX_FRIENDSHIP_WAVE = 145;
-// #endregion
+// #endregion Friendship constants
 
 /** The numeric point cost of a starter. */
 export type StarterCost = IntClosedRange<1, 10>;

--- a/src/data/balance/starters.ts
+++ b/src/data/balance/starters.ts
@@ -5,6 +5,7 @@ import type { IntClosedRange } from "type-fest";
 export const POKERUS_STARTER_COUNT = 5;
 
 // #region Friendship constants
+
 /** The multiplier applied to candy friendship gain in classic mode. */
 export const CLASSIC_CANDY_FRIENDSHIP_MULTIPLIER = 3;
 /** The base amount of friendship gained from a single battle. */
@@ -17,6 +18,7 @@ export const FRIENDSHIP_LOSS_FROM_FAINT = 5;
 export const TRAINER_MIN_FRIENDSHIP = 50;
 /** The wave at which enemy trainers reach the maximum friendship value of 255. */
 export const TRAINER_MAX_FRIENDSHIP_WAVE = 145;
+
 // #endregion Friendship constants
 
 /** The numeric point cost of a starter. */

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -132,6 +132,7 @@ export class BattlerTag implements BaseBattlerTag {
   public sourceId?: number;
 
   // #region non-serializable fields
+
   // Fields that should never be serialized, as they must not change after instantiation
   readonly #isBatonPassable: boolean;
   public get isBatonPassable(): boolean {
@@ -147,7 +148,8 @@ export class BattlerTag implements BaseBattlerTag {
   public get lapseTypes(): readonly BattlerTagLapseType[] {
     return this.#lapseTypes;
   }
-  //#endregion non-serializable fields
+
+  // #endregion non-serializable fields
 
   constructor(
     tagType: BattlerTagType,
@@ -3127,6 +3129,7 @@ export class SubstituteTag extends SerializableBattlerTag {
   public hp: number;
 
   // #region non-serializable properties
+
   /** A reference to the sprite representing the Substitute doll */
   #sprite: Phaser.GameObjects.Sprite;
   /** A reference to the sprite representing the Substitute doll */
@@ -3145,7 +3148,8 @@ export class SubstituteTag extends SerializableBattlerTag {
   public set sourceInFocus(value: boolean) {
     this.#sourceInFocus = value;
   }
-  //#endregion non-serializable properties
+
+  // #endregion non-serializable properties
 
   constructor(sourceMove: MoveId, sourceId: number) {
     super(

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -131,7 +131,7 @@ export class BattlerTag implements BaseBattlerTag {
   public sourceMove?: MoveId;
   public sourceId?: number;
 
-  //#region non-serializable fields
+  // #region non-serializable fields
   // Fields that should never be serialized, as they must not change after instantiation
   readonly #isBatonPassable: boolean;
   public get isBatonPassable(): boolean {
@@ -3126,7 +3126,7 @@ export class SubstituteTag extends SerializableBattlerTag {
   /** The substitute's remaining HP. If HP is depleted, the Substitute fades. */
   public hp: number;
 
-  //#region non-serializable properties
+  // #region non-serializable properties
   /** A reference to the sprite representing the Substitute doll */
   #sprite: Phaser.GameObjects.Sprite;
   /** A reference to the sprite representing the Substitute doll */

--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -83,10 +83,7 @@ export interface IEggOptions {
 }
 
 export class Egg {
-  ////
-
   // #region Private properties
-  ////
 
   private _id: number;
   private _tier: EggTier;
@@ -103,14 +100,10 @@ export class Egg {
 
   private eggDescriptor?: string | undefined;
 
-  ////
   // #endregion Private properties
-  ////
-
-  ////
 
   // #region Public facing properties
-  ////
+
   get id(): number {
     return this._id;
   }
@@ -161,9 +154,7 @@ export class Egg {
     return this._overrideHiddenAbility;
   }
 
-  ////
   // #endregion Public facing properties
-  ////
 
   constructor(eggOptions?: IEggOptions) {
     const generateEggProperties = (eggOptions?: IEggOptions) => {
@@ -222,10 +213,7 @@ export class Egg {
     this.eggDescriptor = eggOptions?.eggDescriptor;
   }
 
-  ////
-
   // #region Public methods
-  ////
 
   public isManaphyEgg(): boolean {
     return (
@@ -355,14 +343,9 @@ export class Egg {
     }
   }
 
-  ////
   // #endregion Public methods
-  ////
-
-  ////
 
   // #region Private methods
-  ////
 
   /**
    * Rolls which egg move slot the egg will have.
@@ -606,9 +589,7 @@ export class Egg {
     return speciesEggTiers[this.species] ?? EggTier.COMMON;
   }
 
-  ////
   // #endregion Private methods
-  ////
 }
 
 export function getValidLegendaryGachaSpecies(): SpeciesId[] {

--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -84,6 +84,7 @@ export interface IEggOptions {
 
 export class Egg {
   ////
+
   // #region Private properties
   ////
 
@@ -103,10 +104,11 @@ export class Egg {
   private eggDescriptor?: string | undefined;
 
   ////
-  // #endregion
+  // #endregion Private properties
   ////
 
   ////
+
   // #region Public facing properties
   ////
   get id(): number {
@@ -160,7 +162,7 @@ export class Egg {
   }
 
   ////
-  // #endregion
+  // #endregion Public facing properties
   ////
 
   constructor(eggOptions?: IEggOptions) {
@@ -221,6 +223,7 @@ export class Egg {
   }
 
   ////
+
   // #region Public methods
   ////
 
@@ -353,10 +356,11 @@ export class Egg {
   }
 
   ////
-  // #endregion
+  // #endregion Public methods
   ////
 
   ////
+
   // #region Private methods
   ////
 
@@ -603,7 +607,7 @@ export class Egg {
   }
 
   ////
-  // #endregion
+  // #endregion Private methods
   ////
 }
 

--- a/src/data/mystery-encounters/mystery-encounter.ts
+++ b/src/data/mystery-encounters/mystery-encounter.ts
@@ -95,6 +95,7 @@ export class MysteryEncounter implements IMysteryEncounter {
   encounterType: MysteryEncounterType;
   options: [MysteryEncounterOption, MysteryEncounterOption, ...MysteryEncounterOption[]];
   spriteConfigs: MysteryEncounterSpriteConfig[];
+
   // #endregion Required params
 
   // #region Optional params
@@ -167,6 +168,7 @@ export class MysteryEncounter implements IMysteryEncounter {
    * If true, will prevent updating {@linkcode GameStats} for encountering and/or defeating Pokemon
    */
   preventGameStatsUpdates: boolean;
+
   // #endregion Optional params
 
   // #region Event callback functions
@@ -206,9 +208,11 @@ export class MysteryEncounter implements IMysteryEncounter {
   excludePrimaryFromSupportRequirements: boolean;
   primaryPokemon: PlayerPokemon | undefined;
   secondaryPokemon: PlayerPokemon[] | undefined;
+
   // #endregion Event callback functions
 
   // #region Post-construct / Auto-populated params
+
   localizationKey: string;
   /**
    * Dialogue object containing all the dialogue, messages, tooltips, etc. for an encounter
@@ -226,6 +230,7 @@ export class MysteryEncounter implements IMysteryEncounter {
    * You probably shouldn't do anything directly with this unless you have a very specific need
    */
   introVisuals: MysteryEncounterIntroVisuals | undefined;
+
   // #endregion Post-construct / Auto-populated params
 
   // #region Flags
@@ -278,6 +283,7 @@ export class MysteryEncounter implements IMysteryEncounter {
    * You should only need to interact via getter/update methods
    */
   private seedOffset?: any;
+
   // #endregion Flags
 
   constructor(encounter: IMysteryEncounter | null) {

--- a/src/data/mystery-encounters/mystery-encounter.ts
+++ b/src/data/mystery-encounters/mystery-encounter.ts
@@ -95,6 +95,7 @@ export class MysteryEncounter implements IMysteryEncounter {
   encounterType: MysteryEncounterType;
   options: [MysteryEncounterOption, MysteryEncounterOption, ...MysteryEncounterOption[]];
   spriteConfigs: MysteryEncounterSpriteConfig[];
+  // #endregion Required params
 
   // #region Optional params
 
@@ -166,6 +167,7 @@ export class MysteryEncounter implements IMysteryEncounter {
    * If true, will prevent updating {@linkcode GameStats} for encountering and/or defeating Pokemon
    */
   preventGameStatsUpdates: boolean;
+  // #endregion Optional params
 
   // #region Event callback functions
 
@@ -204,6 +206,7 @@ export class MysteryEncounter implements IMysteryEncounter {
   excludePrimaryFromSupportRequirements: boolean;
   primaryPokemon: PlayerPokemon | undefined;
   secondaryPokemon: PlayerPokemon[] | undefined;
+  // #endregion Event callback functions
 
   // #region Post-construct / Auto-populated params
   localizationKey: string;
@@ -223,6 +226,7 @@ export class MysteryEncounter implements IMysteryEncounter {
    * You probably shouldn't do anything directly with this unless you have a very specific need
    */
   introVisuals: MysteryEncounterIntroVisuals | undefined;
+  // #endregion Post-construct / Auto-populated params
 
   // #region Flags
 
@@ -274,6 +278,7 @@ export class MysteryEncounter implements IMysteryEncounter {
    * You should only need to interact via getter/update methods
    */
   private seedOffset?: any;
+  // #endregion Flags
 
   constructor(encounter: IMysteryEncounter | null) {
     if (encounter != null) {

--- a/src/data/pokemon/pokemon-data.ts
+++ b/src/data/pokemon/pokemon-data.ts
@@ -318,6 +318,7 @@ export class PokemonWaveData {
  */
 export class PokemonTurnData {
   // #region Move usage-related properties
+
   // All of these properties can likely go inside a "move-in-flight" object later
 
   /** How many times the current move should hit the target(s) */

--- a/src/data/splash-messages.ts
+++ b/src/data/splash-messages.ts
@@ -1,6 +1,6 @@
 import { USE_SEASONAL_SPLASH_MESSAGES } from "#app/constants";
 
-//#region Interfaces/Types
+// #region Interfaces/Types
 
 type Month = "01" | "02" | "03" | "04" | "05" | "06" | "07" | "08" | "09" | "10" | "11" | "12";
 type Day =
@@ -41,7 +41,9 @@ interface Season {
   messages: string[];
 }
 
-//#region Constants
+// #endregion Interfaces/Types
+
+// #region Constants
 
 /** The weight multiplier for the battles-won splash message */
 const BATTLES_WON_WEIGHT_MULTIPLIER = 15;
@@ -50,7 +52,9 @@ const POKEMON_NAMES_WEIGHT_MULTIPLIER = 10;
 /** The weight multiplier for the seasonal splash messages */
 const SEASONAL_WEIGHT_MULTIPLIER = 15;
 
-//#region Common Messages
+// #endregion Constants
+
+// #region Common Messages
 
 const commonSplashMessages = [
   ...new Array(BATTLES_WON_WEIGHT_MULTIPLIER).fill("battlesWon"),
@@ -230,7 +234,9 @@ const commonSplashMessages = [
   "letsGetHumid",
 ];
 
-//#region Seasonal Messages
+// #endregion Common Messages
+
+// #region Seasonal Messages
 
 const seasonalSplashMessages: Season[] = [
   {
@@ -342,8 +348,7 @@ const seasonalSplashMessages: Season[] = [
     ],
   },
 ];
-
-//#endregion
+// #endregion Seasonal Messages
 
 export function getSplashMessages(): string[] {
   const splashMessages: string[] = [...commonSplashMessages];

--- a/src/data/splash-messages.ts
+++ b/src/data/splash-messages.ts
@@ -348,6 +348,7 @@ const seasonalSplashMessages: Season[] = [
     ],
   },
 ];
+
 // #endregion Seasonal Messages
 
 export function getSplashMessages(): string[] {

--- a/src/data/trainers/rival-party-config.ts
+++ b/src/data/trainers/rival-party-config.ts
@@ -3,7 +3,7 @@ import { SpeciesId } from "#enums/species-id";
 import type { EnemyPokemon } from "#field/pokemon";
 import { randSeedItem } from "#utils/common";
 
-//#region constants
+// #region constants
 
 // Levels for slots 1 and 2 do not need post-processing logic
 
@@ -31,7 +31,7 @@ const SLOT_6_FIGHT_6_LEVEL = 200;
 
 //#endregion constants
 
-//#region Slot 1
+// #region Slot 1
 
 /**
  * Set the abiltiy index to 0 and the tera type to the primary type
@@ -146,7 +146,7 @@ const SLOT_1_FINAL = [
 ];
 //#endregion slot 1
 
-//#region Slot 2
+// #region Slot 2
 /**
  * Post-process rival birds to override their sets
  *
@@ -247,7 +247,7 @@ const SLOT_2_FINAL = [
 ];
 //#endregion Slot 2
 
-//#region Slot 3
+// #region Slot 3
 /** Rival's slot 3 species pool for fight 2 */
 const SLOT_3_FIGHT_2 = [
   SpeciesId.NIDORINA,
@@ -375,7 +375,7 @@ const SLOT_3_FINAL = [
 ];
 //#endregion Slot 3
 
-//#region Slot 4
+// #region Slot 4
 
 /**
  * Post-process logic for rival slot 4, fight 4
@@ -530,7 +530,7 @@ const SLOT_4_FINAL = [
 ];
 //#endregion Slot 4
 
-//#region Slot 5
+// #region Slot 5
 /** Rival's slot 5 species pool for fight 4 and beyond */
 const SLOT_5_FINAL = [
   SpeciesId.DRAGONITE,
@@ -553,7 +553,7 @@ const SLOT_5_FINAL = [
 ];
 //#endregion Slot 5
 
-//#region Slot 6
+// #region Slot 6
 /**
  * Post-process logic for rival slot 6, fight 5
  *

--- a/src/data/trainers/rival-party-config.ts
+++ b/src/data/trainers/rival-party-config.ts
@@ -29,7 +29,7 @@ const SLOT_5_FIGHT_6_LEVEL = 189;
 const SLOT_6_FIGHT_5_LEVEL = 129;
 const SLOT_6_FIGHT_6_LEVEL = 200;
 
-//#endregion constants
+// #endregion constants
 
 // #region Slot 1
 
@@ -144,9 +144,11 @@ const SLOT_1_FINAL = [
   SpeciesId.SKELEDIRGE,
   SpeciesId.QUAQUAVAL,
 ];
-//#endregion slot 1
+
+// #endregion Slot 1
 
 // #region Slot 2
+
 /**
  * Post-process rival birds to override their sets
  *
@@ -245,9 +247,11 @@ const SLOT_2_FINAL = [
   SpeciesId.CORVIKNIGHT,
   SpeciesId.KILOWATTREL,
 ];
-//#endregion Slot 2
+
+// #endregion Slot 2
 
 // #region Slot 3
+
 /** Rival's slot 3 species pool for fight 2 */
 const SLOT_3_FIGHT_2 = [
   SpeciesId.NIDORINA,
@@ -373,7 +377,8 @@ const SLOT_3_FINAL = [
   SpeciesId.TINKATON,
   SpeciesId.GLIMMORA,
 ];
-//#endregion Slot 3
+
+// #endregion Slot 3
 
 // #region Slot 4
 
@@ -528,9 +533,11 @@ const SLOT_4_FINAL = [
   SpeciesId.HISUI_ARCANINE,
   SpeciesId.PALDEA_TAUROS,
 ];
-//#endregion Slot 4
+
+// #endregion Slot 4
 
 // #region Slot 5
+
 /** Rival's slot 5 species pool for fight 4 and beyond */
 const SLOT_5_FINAL = [
   SpeciesId.DRAGONITE,
@@ -551,9 +558,11 @@ const SLOT_5_FINAL = [
   SpeciesId.HYDRAPPLE,
   SpeciesId.HISUI_GOODRA,
 ];
-//#endregion Slot 5
+
+// #endregion Slot 5
 
 // #region Slot 6
+
 /**
  * Post-process logic for rival slot 6, fight 5
  *
@@ -592,7 +601,8 @@ function postProcessSlot6Fight6(pokemon: EnemyPokemon): void {
 
 /** Rival's slot 6 species pool for fight 5 and beyond */
 const SLOT_6_FINAL = [SpeciesId.RAYQUAZA];
-//#endregion Slot 6
+
+// #endregion Slot 6
 
 export interface RivalSlotConfig {
   /**

--- a/src/enums/move-use-mode.ts
+++ b/src/enums/move-use-mode.ts
@@ -74,7 +74,8 @@ export const MoveUseMode = {
 
 export type MoveUseMode = ObjectValues<typeof MoveUseMode>;
 
-// # HELPER FUNCTIONS
+// #region Helper Functions
+
 // Please update the markdown tables if any new `MoveUseMode`s get added.
 
 /**
@@ -162,3 +163,5 @@ export function isIgnorePP(useMode: MoveUseMode): boolean {
 export function isReflected(useMode: MoveUseMode): boolean {
   return useMode === MoveUseMode.REFLECTED;
 }
+
+// #endregion Helper Functions

--- a/src/enums/trainer-type.ts
+++ b/src/enums/trainer-type.ts
@@ -65,8 +65,7 @@ export enum TrainerType {
   WORKER,
   YOUNG_COUPLE,
   YOUNGSTER,
-  // #endregion
-
+  // #endregion Generic Trainers
   // #region Evil Teams
   ROCKET_GRUNT,
   ARCHER,
@@ -113,8 +112,7 @@ export enum TrainerType {
   ATTICUS,
   ORTEGA,
   ERI,
-  // #endregion
-
+  // #endregion Evil Teams
   // #region Evil Team Bosses
   ROCKET_BOSS_GIOVANNI_1,
   ROCKET_BOSS_GIOVANNI_2,
@@ -136,8 +134,7 @@ export enum TrainerType {
   ROSE_2,
   PENNY,
   PENNY_2,
-  // #endregion
-
+  // #endregion Evil Team Bosses
   // #region ME trainers
   BUCK,
   CHERYL,
@@ -153,8 +150,7 @@ export enum TrainerType {
   EXPERT_POKEMON_BREEDER,
   PLAYER_M_ALTERNATE,
   PLAYER_F_ALTERNATE,
-  // #endregion
-
+  // #endregion ME trainers
   // #region Gym Leaders
   BROCK = 200,
   MISTY,
@@ -230,8 +226,7 @@ export enum TrainerType {
   RYME,
   TULIP,
   GRUSHA,
-  // #endregion
-
+  // #endregion Gym Leaders
   // #region Elite Four
   LORELEI = 300,
   BRUNO,
@@ -275,8 +270,7 @@ export enum TrainerType {
   AMARYS,
   LACEY,
   DRAYTON,
-  // #endregion
-
+  // #endregion Elite Four
   // #region Champions
   BLUE = 350,
   RED,
@@ -294,8 +288,7 @@ export enum TrainerType {
   GEETA,
   NEMONA,
   KIERAN,
-  // #endregion
-
+  // #endregion Champions
   // #region Rivals
   RIVAL = 375,
   RIVAL_2,
@@ -303,5 +296,5 @@ export enum TrainerType {
   RIVAL_4,
   RIVAL_5,
   RIVAL_6,
-  // #endregion
+  // #endregion Rivals
 }

--- a/src/enums/trainer-type.ts
+++ b/src/enums/trainer-type.ts
@@ -2,6 +2,7 @@ export enum TrainerType {
   UNKNOWN,
 
   // #region Generic Trainers
+
   ACE_TRAINER,
   AROMA_LADY,
   ARTIST,
@@ -65,8 +66,11 @@ export enum TrainerType {
   WORKER,
   YOUNG_COUPLE,
   YOUNGSTER,
+
   // #endregion Generic Trainers
+
   // #region Evil Teams
+
   ROCKET_GRUNT,
   ARCHER,
   ARIANA,
@@ -112,8 +116,11 @@ export enum TrainerType {
   ATTICUS,
   ORTEGA,
   ERI,
+
   // #endregion Evil Teams
+
   // #region Evil Team Bosses
+
   ROCKET_BOSS_GIOVANNI_1,
   ROCKET_BOSS_GIOVANNI_2,
   MAXIE,
@@ -134,8 +141,11 @@ export enum TrainerType {
   ROSE_2,
   PENNY,
   PENNY_2,
+
   // #endregion Evil Team Bosses
+
   // #region ME trainers
+
   BUCK,
   CHERYL,
   MARLEY,
@@ -150,8 +160,11 @@ export enum TrainerType {
   EXPERT_POKEMON_BREEDER,
   PLAYER_M_ALTERNATE,
   PLAYER_F_ALTERNATE,
+
   // #endregion ME trainers
+
   // #region Gym Leaders
+
   BROCK = 200,
   MISTY,
   LT_SURGE,
@@ -226,8 +239,11 @@ export enum TrainerType {
   RYME,
   TULIP,
   GRUSHA,
+
   // #endregion Gym Leaders
+
   // #region Elite Four
+
   LORELEI = 300,
   BRUNO,
   AGATHA,
@@ -270,8 +286,11 @@ export enum TrainerType {
   AMARYS,
   LACEY,
   DRAYTON,
+
   // #endregion Elite Four
+
   // #region Champions
+
   BLUE = 350,
   RED,
   LANCE_CHAMPION,
@@ -288,13 +307,17 @@ export enum TrainerType {
   GEETA,
   NEMONA,
   KIERAN,
+
   // #endregion Champions
+
   // #region Rivals
+
   RIVAL = 375,
   RIVAL_2,
   RIVAL_3,
   RIVAL_4,
   RIVAL_5,
   RIVAL_6,
+
   // #endregion Rivals
 }

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -1,6 +1,6 @@
 import "phaser";
 
-//#region Methods/Interfaces
+// #region Methods/Interfaces
 
 /**
  * Interface representing an object that can be passed to {@linkcode setPositionRelative}.
@@ -36,9 +36,9 @@ Phaser.GameObjects.NineSlice.prototype.setPositionRelative = setPositionRelative
 Phaser.GameObjects.Text.prototype.setPositionRelative = setPositionRelative;
 Phaser.GameObjects.Rectangle.prototype.setPositionRelative = setPositionRelative;
 
-//#endregion
+// #endregion Methods/Interfaces
 
-//#region Declaration Merging
+// #region Declaration Merging
 
 interface HasSetPositionRelative {
   /**
@@ -63,4 +63,4 @@ declare module "phaser" {
   }
 }
 
-//#endregion
+// #endregion Declaration Merging

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -121,8 +121,7 @@ export class Arena {
 
     return 131 / 180;
   }
-
-  // #endregion
+  // #endregion Getters
   // #region Misc Public Methods
 
   public init() {
@@ -162,8 +161,7 @@ export class Arena {
     this.resetPlayerFaintCount();
     this.removeAllTags();
   }
-
-  // #endregion
+  // #endregion Misc Public Methods
   // #region Misc Private Methods
 
   /**
@@ -221,8 +219,7 @@ export class Arena {
     }
     return BiomePoolTier.ULTRA_RARE;
   }
-
-  // #endregion
+  // #endregion Misc Private Methods
   // #region Weather
 
   /** @returns Whether or not the weather can be changed to the specified weather */
@@ -372,8 +369,7 @@ export class Arena {
     const randomWeather = weightedPick(weatherMap);
     this.trySetWeather(randomWeather);
   }
-
-  // #endregion
+  // #endregion Weather
   // #region Terrain
 
   /** @returns Whether or not the terrain can be set to the specified terrain */
@@ -470,8 +466,7 @@ export class Arena {
   public isMoveTerrainCancelled(user: Pokemon, targets: BattlerIndex[], move: Move): boolean {
     return !!this.terrain && this.terrain.isMoveTerrainCancelled(user, targets, move);
   }
-
-  // #endregion
+  // #endregion Terrain
   // #region Trainers
 
   public randomTrainerType(waveIndex: number, isBoss = false): TrainerType {
@@ -491,8 +486,7 @@ export class Arena {
     const tierPool = this.trainerPool[tier];
     return tierPool.length > 0 ? randSeedItem(tierPool) : TrainerType.BREEDER;
   }
-
-  // #endregion
+  // #endregion Trainers
   // #region Pokemon
 
   public updatePoolsForTimeOfDay(): void {
@@ -605,8 +599,7 @@ export class Arena {
       ? adjustedWave < 80 // Wave 50+ in daily (however, max Daily wave is 50 currently so not possible)
       : adjustedWave < 55; // Wave 25+ in daily
   }
-
-  // #endregion
+  // #endregion Pokemon
   // #region Arena Tags
 
   /**
@@ -873,8 +866,7 @@ export class Arena {
       this.tags.splice(0, 1);
     }
   }
-
-  // #endregion
+  // #endregion Arena Tags
   // #region Time of Day
 
   public getTimeOfDay(): TimeOfDay {
@@ -955,8 +947,7 @@ export class Arena {
 
     return [48, 48, 98];
   }
-
-  // #endregion
+  // #endregion Time of Day
 
   // TODO: replace this
   getAttackTypeMultiplier(attackType: PokemonType, grounded: boolean): number {
@@ -1013,5 +1004,4 @@ export function getBiomeHasProps(biomeId: BiomeId): boolean {
 
   return false;
 }
-
-// #endregion
+// #endregion Helper Functions

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -121,7 +121,9 @@ export class Arena {
 
     return 131 / 180;
   }
+
   // #endregion Getters
+
   // #region Misc Public Methods
 
   public init() {
@@ -161,7 +163,9 @@ export class Arena {
     this.resetPlayerFaintCount();
     this.removeAllTags();
   }
+
   // #endregion Misc Public Methods
+
   // #region Misc Private Methods
 
   /**
@@ -219,7 +223,9 @@ export class Arena {
     }
     return BiomePoolTier.ULTRA_RARE;
   }
+
   // #endregion Misc Private Methods
+
   // #region Weather
 
   /** @returns Whether or not the weather can be changed to the specified weather */
@@ -369,7 +375,9 @@ export class Arena {
     const randomWeather = weightedPick(weatherMap);
     this.trySetWeather(randomWeather);
   }
+
   // #endregion Weather
+
   // #region Terrain
 
   /** @returns Whether or not the terrain can be set to the specified terrain */
@@ -466,7 +474,9 @@ export class Arena {
   public isMoveTerrainCancelled(user: Pokemon, targets: BattlerIndex[], move: Move): boolean {
     return !!this.terrain && this.terrain.isMoveTerrainCancelled(user, targets, move);
   }
+
   // #endregion Terrain
+
   // #region Trainers
 
   public randomTrainerType(waveIndex: number, isBoss = false): TrainerType {
@@ -486,7 +496,9 @@ export class Arena {
     const tierPool = this.trainerPool[tier];
     return tierPool.length > 0 ? randSeedItem(tierPool) : TrainerType.BREEDER;
   }
+
   // #endregion Trainers
+
   // #region Pokemon
 
   public updatePoolsForTimeOfDay(): void {
@@ -599,7 +611,9 @@ export class Arena {
       ? adjustedWave < 80 // Wave 50+ in daily (however, max Daily wave is 50 currently so not possible)
       : adjustedWave < 55; // Wave 25+ in daily
   }
+
   // #endregion Pokemon
+
   // #region Arena Tags
 
   /**
@@ -866,7 +880,9 @@ export class Arena {
       this.tags.splice(0, 1);
     }
   }
+
   // #endregion Arena Tags
+
   // #region Time of Day
 
   public getTimeOfDay(): TimeOfDay {
@@ -947,6 +963,7 @@ export class Arena {
 
     return [48, 48, 98];
   }
+
   // #endregion Time of Day
 
   // TODO: replace this
@@ -1004,4 +1021,5 @@ export function getBiomeHasProps(biomeId: BiomeId): boolean {
 
   return false;
 }
+
 // #endregion Helper Functions

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -934,6 +934,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   // #region Atlas and sprite ID methods
+
   // TODO: Add more documentation for all these attributes.
   // They may be all similar, but what each one actually _does_ is quite unclear at first glance
 
@@ -1062,7 +1063,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       fusionVariant,
     );
   }
-  //#endregion Atlas and sprite ID methods
+
+  // #endregion Atlas and sprite ID methods
 
   /**
    * Return this Pokemon's {@linkcode PokemonSpeciesForm | SpeciesForm}.
@@ -5320,6 +5322,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   // #region Sprite and Animation Methods
+
   setFrameRate(frameRate: number) {
     globalScene.anims.get(this.getBattleSpriteKey()).frameRate = frameRate;
     try {
@@ -5728,7 +5731,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     fusionCanvas.remove();
   }
 
-  //#endregion Sprite and Animation Methods
+  // #endregion Sprite and Animation Methods
 
   /**
    * Generate a random number using the current battle's seed, or the global seed if `globalScene.currentBattle` is falsy

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -933,7 +933,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return this.fusionSpecies.forms[this.fusionFormIndex].formKey;
   }
 
-  //#region Atlas and sprite ID methods
+  // #region Atlas and sprite ID methods
   // TODO: Add more documentation for all these attributes.
   // They may be all similar, but what each one actually _does_ is quite unclear at first glance
 
@@ -5319,7 +5319,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return (this.getSpeciesForm().getBaseExp() * this.level) / 5 + 1;
   }
 
-  //#region Sprite and Animation Methods
+  // #region Sprite and Animation Methods
   setFrameRate(frameRate: number) {
     globalScene.anims.get(this.getBattleSpriteKey()).frameRate = frameRate;
     try {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -14,7 +14,9 @@ interface LoadingFontFaceProperty {
   extraOptions?: { [key: string]: any };
   only?: string[];
 }
+
 // #endregion Interfaces/Types
+
 // #region Constants
 
 const unicodeRanges = {
@@ -100,7 +102,9 @@ const fonts: LoadingFontFaceProperty[] = [
     extraOptions: { sizeAdjust: "133%" },
   },
 ];
+
 // #endregion Constants
+
 // #region Functions
 
 async function initFonts(language: string | undefined) {
@@ -134,10 +138,12 @@ function i18nMoneyFormatter(amount: any): string {
   return `@[MONEY]{${i18next.t("common:money", { amount })}}`;
 }
 
+// #endregion Functions
+
 // assigned during post-processing in #app/plugins/vite/namespaces-i18n-plugin.ts
 const nsEn: string[] = [];
-// #endregion Functions
-// #region Exports
+
+// #region Init
 
 /*
  * i18next is a localization library for maintaining and using translation resources.
@@ -227,7 +233,9 @@ await i18next
       await initFonts(localStorage.getItem("prLang") ?? undefined);
     },
   );
-// #endregion Exports
+
+// #endregion Init
+
 // #region Event Proxy
 
 if (timedEventManager.hasEventTextReplacement()) {
@@ -243,4 +251,5 @@ if (timedEventManager.hasEventTextReplacement()) {
     },
   });
 }
+
 // #endregion Event Proxy

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -7,17 +7,15 @@ import LanguageDetector from "i18next-browser-languagedetector";
 import HttpBackend from "i18next-http-backend";
 import { KoreanPostpositionProcessor } from "i18next-korean-postposition-processor";
 
-//#region Interfaces/Types
+// #region Interfaces/Types
 
 interface LoadingFontFaceProperty {
   face: FontFace;
   extraOptions?: { [key: string]: any };
   only?: string[];
 }
-
-//#endregion
-
-//#region Constants
+// #endregion Interfaces/Types
+// #region Constants
 
 const unicodeRanges = {
   fullwidth: "U+FF00-FFEF",
@@ -102,10 +100,8 @@ const fonts: LoadingFontFaceProperty[] = [
     extraOptions: { sizeAdjust: "133%" },
   },
 ];
-
-//#endregion
-
-//#region Functions
+// #endregion Constants
+// #region Functions
 
 async function initFonts(language: string | undefined) {
   const results = await Promise.allSettled(
@@ -140,10 +136,8 @@ function i18nMoneyFormatter(amount: any): string {
 
 // assigned during post-processing in #app/plugins/vite/namespaces-i18n-plugin.ts
 const nsEn: string[] = [];
-
-//#endregion
-
-//#region Exports
+// #endregion Functions
+// #region Exports
 
 /*
  * i18next is a localization library for maintaining and using translation resources.
@@ -233,10 +227,8 @@ await i18next
       await initFonts(localStorage.getItem("prLang") ?? undefined);
     },
   );
-
-//#endregion
-
-//#region Event Proxy
+// #endregion Exports
+// #region Event Proxy
 
 if (timedEventManager.hasEventTextReplacement()) {
   console.warn("Event text replacements are active.");
@@ -251,5 +243,4 @@ if (timedEventManager.hasEventTextReplacement()) {
     },
   });
 }
-
-//#endregion
+// #endregion Event Proxy

--- a/src/phase-manager.ts
+++ b/src/phase-manager.ts
@@ -610,5 +610,6 @@ export class PhaseManager {
       turnEndPhase.upcomingInterlude = true;
     }
   }
+
   // #endregion Phase Functions
 }

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -965,7 +965,7 @@ export class MoveEffectPhase extends PokemonPhase {
     }
   }
 
-  // # endregion Helpers
+  // #endregion Helpers
 }
 
 /**

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -110,7 +110,7 @@ export class MovePhase extends PokemonPhase {
     };
   }
 
-  //#region Phase Start
+  // #region Phase Start
   public start(): void {
     super.start();
 
@@ -239,7 +239,7 @@ export class MovePhase extends PokemonPhase {
 
   //#endregion Phase Start
 
-  //#region First Failure Check
+  // #region First Failure Check
 
   /**
    * Perform the first round of move failure checks, occurring before move usage text is displayed
@@ -529,7 +529,7 @@ export class MovePhase extends PokemonPhase {
 
   //#endregion First Failure Check
 
-  //#region Second Failure Check
+  // #region Second Failure Check
 
   /**
    * Attempt to thaw the user if it successfully uses a self-thawing move.
@@ -752,7 +752,7 @@ export class MovePhase extends PokemonPhase {
 
   //#endregion Second Failure Check
 
-  //#region Move Execution
+  // #region Move Execution
 
   /**
    * Check for cancellation edge cases - no targets remaining, or `MoveId.NONE` is in the queue
@@ -932,7 +932,7 @@ export class MovePhase extends PokemonPhase {
 
   //#endregion Move Execution
 
-  //#region Helpers
+  // #region Helpers
 
   /**
    * Handles the case where the move was cancelled or failed:

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -111,6 +111,7 @@ export class MovePhase extends PokemonPhase {
   }
 
   // #region Phase Start
+
   public start(): void {
     super.start();
 
@@ -237,7 +238,7 @@ export class MovePhase extends PokemonPhase {
     this.end();
   }
 
-  //#endregion Phase Start
+  // #endregion Phase Start
 
   // #region First Failure Check
 
@@ -527,7 +528,7 @@ export class MovePhase extends PokemonPhase {
     return true;
   }
 
-  //#endregion First Failure Check
+  // #endregion First Failure Check
 
   // #region Second Failure Check
 
@@ -750,7 +751,7 @@ export class MovePhase extends PokemonPhase {
     return false;
   }
 
-  //#endregion Second Failure Check
+  // #endregion Second Failure Check
 
   // #region Move Execution
 
@@ -930,7 +931,7 @@ export class MovePhase extends PokemonPhase {
     super.end();
   }
 
-  //#endregion Move Execution
+  // #endregion Move Execution
 
   // #region Helpers
 
@@ -1068,5 +1069,5 @@ export class MovePhase extends PokemonPhase {
     }
   }
 
-  //#endregion Helpers
+  // #endregion Helpers
 }

--- a/src/system/ribbons/ribbon-data.ts
+++ b/src/system/ribbons/ribbon-data.ts
@@ -12,8 +12,8 @@ export class RibbonData {
   /** Internal bitfield storing the unlock state for each ribbon */
   private payload: bigint;
 
-  //#region Ribbons
-  //#region Monotype challenge ribbons
+  // #region Ribbons
+  // #region Monotype challenge ribbons
   /** Ribbon for winning the normal monotype challenge */
   public static readonly MONO_NORMAL = 0x1n as RibbonFlag;
   /** Ribbon for winning the fighting monotype challenge */
@@ -52,7 +52,7 @@ export class RibbonData {
   public static readonly MONO_FAIRY = 0x20000n as RibbonFlag;
   //#endregion Monotype ribbons
 
-  //#region Monogen ribbons
+  // #region Monogen ribbons
   /** Ribbon for winning the the mono gen 1 challenge */
   public static readonly MONO_GEN_1 = 0x40000n as RibbonFlag;
   /** Ribbon for winning the the mono gen 2 challenge */

--- a/src/system/ribbons/ribbon-data.ts
+++ b/src/system/ribbons/ribbon-data.ts
@@ -12,6 +12,8 @@ export class RibbonData {
   /** Internal bitfield storing the unlock state for each ribbon */
   private payload: bigint;
 
+  // #region Ribbons
+
   // #region Monotype ribbons
 
   /** Ribbon for winning the normal monotype challenge */
@@ -120,6 +122,8 @@ export class RibbonData {
   // Note that this has no impact on serialization as it is stored in hex.
 
   // #endregion Misc Ribbons
+
+  // #endregion Ribbons
 
   /** Create a new instance of RibbonData. Generally, {@linkcode fromJSON} is used instead. */
   constructor(value: number | bigint) {

--- a/src/system/ribbons/ribbon-data.ts
+++ b/src/system/ribbons/ribbon-data.ts
@@ -12,8 +12,8 @@ export class RibbonData {
   /** Internal bitfield storing the unlock state for each ribbon */
   private payload: bigint;
 
-  // #region Ribbons
-  // #region Monotype challenge ribbons
+  // #region Monotype ribbons
+
   /** Ribbon for winning the normal monotype challenge */
   public static readonly MONO_NORMAL = 0x1n as RibbonFlag;
   /** Ribbon for winning the fighting monotype challenge */
@@ -50,9 +50,11 @@ export class RibbonData {
   public static readonly MONO_DARK = 0x10000n as RibbonFlag;
   /** Ribbon for winning the fairy monotype challenge */
   public static readonly MONO_FAIRY = 0x20000n as RibbonFlag;
-  //#endregion Monotype ribbons
+
+  // #endregion Monotype ribbons
 
   // #region Monogen ribbons
+
   /** Ribbon for winning the the mono gen 1 challenge */
   public static readonly MONO_GEN_1 = 0x40000n as RibbonFlag;
   /** Ribbon for winning the the mono gen 2 challenge */
@@ -71,7 +73,10 @@ export class RibbonData {
   public static readonly MONO_GEN_8 = 0x2000000n as RibbonFlag;
   /** Ribbon for winning the mono gen 9 challenge */
   public static readonly MONO_GEN_9 = 0x4000000n as RibbonFlag;
-  //#endregion Monogen ribbons
+
+  // #endregion Monogen ribbons
+
+  // #region Misc Ribbons
 
   // biome-ignore format: manual
   /** Ribbon for winning classic */
@@ -109,11 +114,12 @@ export class RibbonData {
   /** Ribbon for winning the passive ability challenge */
   public static readonly PASSIVE_CHALLENGE = 0x4000000000n as RibbonFlag;
 
+  // TODO: is this comment still accurate? ribbons appear to be using `bigint`s already
   // NOTE: max possible ribbon flag is 0x20000000000000 (53 total ribbons)
   // Once this is exceeded, bitfield needs to be changed to a bigint or even a uint array
   // Note that this has no impact on serialization as it is stored in hex.
 
-  //#endregion Ribbons
+  // #endregion Misc Ribbons
 
   /** Create a new instance of RibbonData. Generally, {@linkcode fromJSON} is used instead. */
   constructor(value: number | bigint) {

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -524,8 +524,6 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
     );
   }
 
-  // #region Hp Bar Display handling
-
   /**
    * Called every time the hp frame is updated by the tween
    * @param pokemon - The pokemon object attached to this battle info
@@ -568,7 +566,6 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
     });
     this.lastMaxHp = pokemon.getMaxHp();
   }
-  // #endregion Hp Bar Display handling
 
   async updateInfo(pokemon: Pokemon, instant?: boolean): Promise<void> {
     let resolve: (r: void | PromiseLike<void>) => void = () => {};
@@ -625,8 +622,6 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
     resolve();
     await promise;
   }
-
-  // #endregion Update methods and helpers
 
   updateNameText(pokemon: Pokemon): void {
     let displayName = pokemon.getNameToRender({ prependFormName: false }).replace(/[♂♀]/g, "");
@@ -689,6 +684,8 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
       }
     }
   }
+
+  // #endregion Update methods and helpers
 
   getBaseY(): number {
     return this.baseY;

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -285,7 +285,7 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
     return this.statValuesContainer;
   }
 
-  //#region Initialization methods
+  // #region Initialization methods
 
   initSplicedIcon(pokemon: Pokemon, baseWidth: number) {
     this.splicedIcon.setPositionRelative(
@@ -403,7 +403,8 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
     this.lastStats = stats.join("");
     this.updateStats(stats);
   }
-  //#endregion
+
+  // #endregion Initialization methods
 
   /**
    * Return the texture name of the battle info box
@@ -433,7 +434,7 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
     this.baseY = this.y;
   }
 
-  //#region Update methods and helpers
+  // #region Update methods and helpers
 
   /**
    * Update the status icon to match the pokemon's current status
@@ -523,7 +524,8 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
     );
   }
 
-  //#region Hp Bar Display handling
+  // #region Hp Bar Display handling
+
   /**
    * Called every time the hp frame is updated by the tween
    * @param pokemon - The pokemon object attached to this battle info
@@ -566,8 +568,7 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
     });
     this.lastMaxHp = pokemon.getMaxHp();
   }
-
-  //#endregion
+  // #endregion Hp Bar Display handling
 
   async updateInfo(pokemon: Pokemon, instant?: boolean): Promise<void> {
     let resolve: (r: void | PromiseLike<void>) => void = () => {};
@@ -624,7 +625,8 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
     resolve();
     await promise;
   }
-  //#endregion
+
+  // #endregion Update methods and helpers
 
   updateNameText(pokemon: Pokemon): void {
     let displayName = pokemon.getNameToRender({ prependFormName: false }).replace(/[♂♀]/g, "");

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -524,6 +524,8 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
     );
   }
 
+  // #region HP Bar Display handling
+
   /**
    * Called every time the hp frame is updated by the tween
    * @param pokemon - The pokemon object attached to this battle info
@@ -566,6 +568,8 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
     });
     this.lastMaxHp = pokemon.getMaxHp();
   }
+
+  // #endregion HP Bar Display handling
 
   async updateInfo(pokemon: Pokemon, instant?: boolean): Promise<void> {
     let resolve: (r: void | PromiseLike<void>) => void = () => {};

--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -25,7 +25,7 @@ export class EnemyBattleInfo extends BattleInfo {
   protected effectivenessWindow: Phaser.GameObjects.NineSlice;
   protected effectivenessText: Phaser.GameObjects.Text;
   protected currentEffectiveness?: string | undefined;
-  // #endregion
+  // #endregion Type effectiveness hint objects
 
   override get statOrder(): Stat[] {
     return [Stat.HP, Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.ACC, Stat.EVA, Stat.SPD];

--- a/src/ui/battle-info/enemy-battle-info.ts
+++ b/src/ui/battle-info/enemy-battle-info.ts
@@ -21,10 +21,12 @@ export class EnemyBattleInfo extends BattleInfo {
   protected hpBarSegmentDividers: GameObjects.Rectangle[] = [];
 
   // #region Type effectiveness hint objects
+
   protected effectivenessContainer: Phaser.GameObjects.Container;
   protected effectivenessWindow: Phaser.GameObjects.NineSlice;
   protected effectivenessText: Phaser.GameObjects.Text;
   protected currentEffectiveness?: string | undefined;
+
   // #endregion Type effectiveness hint objects
 
   override get statOrder(): Stat[] {

--- a/src/ui/handlers/achvs-ui-handler.ts
+++ b/src/ui/handlers/achvs-ui-handler.ts
@@ -230,6 +230,7 @@ export class AchvsUiHandler extends MessageUiHandler {
   }
 
   // #region Input Processing
+
   /**
    * Submethod of {@linkcode processInput} that handles the action button input
    * @returns Whether the success sound should be played
@@ -354,6 +355,7 @@ export class AchvsUiHandler extends MessageUiHandler {
 
     return success;
   }
+
   // #endregion Input Processing
 
   setCursor(cursor: number, pageChange?: boolean): boolean {

--- a/src/ui/handlers/form-modal-ui-handler.ts
+++ b/src/ui/handlers/form-modal-ui-handler.ts
@@ -128,9 +128,8 @@ export abstract class FormModalUiHandler extends ModalUiHandler {
         this.inputs[0]?.setFocus();
       }, 50);
 
-      // #region: Override button pointerDown
       // Override the pointerDown event for the buttonBgs to call the `submitAction` and `cancelAction`
-      // properties that we set above, allowing their behavior to change after this method terminates
+      // properties that we set above, allowing their behavior to change after this method terminates.
       // Some subclasses use this to add behavior to the submit and cancel action
 
       this.buttonBgs[0] // formatting
@@ -148,7 +147,6 @@ export abstract class FormModalUiHandler extends ModalUiHandler {
             this.cancelAction();
           }
         });
-      //#endregion: Override pointerDown events
 
       this.modalContainer.setAlpha(0).y += 24;
 

--- a/src/ui/handlers/modifier-select-ui-handler.ts
+++ b/src/ui/handlers/modifier-select-ui-handler.ts
@@ -275,7 +275,8 @@ export class ModifierSelectUiHandler extends AwaitableUiHandler {
     const { promise: tweenPromise, resolve: tweenResolve } = Promise.withResolvers<void>();
     let i = 0;
 
-    // #region: animation
+    // #region animation
+
     /** Holds promises that resolve once each reward's *upgrade animation* has finished playing */
     const rewardAnimPromises: Promise<void>[] = [];
     /** Holds promises that resolves once *all* animations for a reward have finished playing */
@@ -390,7 +391,7 @@ export class ModifierSelectUiHandler extends AwaitableUiHandler {
       });
     });
 
-    // #endregion: animation
+    // #endregion animation
 
     return true;
   }

--- a/src/utils/color-utils.ts
+++ b/src/utils/color-utils.ts
@@ -50,8 +50,7 @@ export function argbFromRgba({ r, g, b, a }: Rgba): number {
 }
 
 // SPDX-SnippetEnd
-
-// #endregion
+// #endregion @material functions
 
 export function rgbToHsv(r: number, g: number, b: number) {
   const v = Math.max(r, g, b);

--- a/src/utils/color-utils.ts
+++ b/src/utils/color-utils.ts
@@ -50,6 +50,7 @@ export function argbFromRgba({ r, g, b, a }: Rgba): number {
 }
 
 // SPDX-SnippetEnd
+
 // #endregion @material functions
 
 export function rgbToHsv(r: number, g: number, b: number) {

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -190,7 +190,8 @@ export function toPascalSnakeCase(str: string) {
     .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join("_");
 }
-// #endregion Split String code
+
+// #endregion Split string code
 
 /**
  * Chunk a string into an array, creating a new element every `length` characters.

--- a/test/@types/matcher-helpers.ts
+++ b/test/@types/matcher-helpers.ts
@@ -45,7 +45,9 @@ type MatcherInterface<K extends string> = Record<K, AnyFn<never, void>>;
  * This is required as there's no clean way to ensure that 2 interfaces are assignable inside a `.d.ts` file without using `extends`.
  * @example
  * ```
- * // #region MyCustomMatchers
+ *
+
+// #region MyCustomMatchers
  * declare class MyCustomMatchers implements MatchersBase<keyof MyCustomMatchersCommon> {
  *   common: MyCustomMatchersCommon,
  *   positive: MyCustomMatchersPositive,

--- a/test/@types/matcher-helpers.ts
+++ b/test/@types/matcher-helpers.ts
@@ -45,9 +45,8 @@ type MatcherInterface<K extends string> = Record<K, AnyFn<never, void>>;
  * This is required as there's no clean way to ensure that 2 interfaces are assignable inside a `.d.ts` file without using `extends`.
  * @example
  * ```
+ * // #region MyCustomMatchers
  *
-
-// #region MyCustomMatchers
  * declare class MyCustomMatchers implements MatchersBase<keyof MyCustomMatchersCommon> {
  *   common: MyCustomMatchersCommon,
  *   positive: MyCustomMatchersPositive,

--- a/test/@types/vitest.d.ts
+++ b/test/@types/vitest.d.ts
@@ -49,6 +49,7 @@ type IntLiteral<T extends number> = If<IsNumericLiteral<T>, NonNegativeInteger<T
  * @internal
  */
 type NonNumericLiteral<T extends number> = If<IsNumericLiteral<T>, never, T>;
+
 // #endregion Helper Types
 
 /**
@@ -78,6 +79,7 @@ declare module "vitest" {
     not: NegativeAssertion<T>;
 
     // #region Banned Chai Assertions
+
     // enforce consistent style by banning chai assertions at a type level (except `not` which is also in jest).
     // NB: We cannot place these in a nice interface since TS will complain about `Assertion` extending 2 interfaces with clashing types.
     // We also cannot make these anything other than `never` as TS will error about incompatible types (which prevents any custom error messages)
@@ -189,6 +191,7 @@ declare module "vitest" {
 }
 
 // #region Generic Matchers
+
 interface GenericMatchers<T> {
   /**
    * Check whether an array contains EXACTLY the given items (in any order).
@@ -214,9 +217,11 @@ interface GenericMatchers<T> {
    */
   toHaveKey: T extends ReadonlyMap<infer K, infer V> ? (expectedKey: K, expectedValue?: V) => void : never;
 }
+
 // #endregion Generic Matchers
 
 // #region GameManager Matchers
+
 interface GameManagerMatchers {
   /**
    * Check whether the {@linkcode GameManager} has shown the given message at least once in the current test case.
@@ -238,9 +243,11 @@ interface GameManagerMatchers {
    */
   toBeAtPhase(expectedPhase: PhaseString): void;
 }
+
 // #endregion GameManager Matchers
 
 // #region Arena Matchers
+
 declare class ArenaMatchers implements MatchersBase<keyof ArenaMatchersCommon> {
   common: ArenaMatchersCommon;
   negative: ArenaMatchersNegative;
@@ -301,6 +308,7 @@ interface ArenaMatchersNegative {
 // #endregion Arena Matchers
 
 // #region Pokemon Matchers
+
 interface PokemonMatchers {
   /**
    * Check whether a {@linkcode Pokemon}'s current typing includes the given types.

--- a/test/mocks/mock-console/mock-console.ts
+++ b/test/mocks/mock-console/mock-console.ts
@@ -38,7 +38,7 @@ export class MockConsole implements Omit<Console, "Console"> {
    */
   private readonly console = console;
 
-  //#region Static Properties
+  // #region Static Properties
 
   /**
    * Queue a warning to be printed after all tests in the same file are finished.
@@ -58,9 +58,9 @@ export class MockConsole implements Omit<Console, "Console"> {
     MockConsole.queuedWarnings.splice(0);
   }
 
-  //#endregion Static Properties
+  // #endregion Static Properties
 
-  //#region Utilities
+  // #region Utilities
 
   /**
    * Check whether a given set of data is in the blacklist to be barred from logging.
@@ -93,9 +93,10 @@ export class MockConsole implements Omit<Console, "Console"> {
     return (data as unknown[]).map(a => color(typeof a === "function" || typeof a === "object" ? this.getStr(a) : a));
   }
 
-  //#endregion Utilities
+  // #endregion Utilities
 
-  //#region Custom wrappers
+  // #region Custom wrappers
+
   public info(...data: unknown[]) {
     return this.log(...data);
   }
@@ -160,9 +161,10 @@ export class MockConsole implements Omit<Console, "Console"> {
     this.console.error(...this.format(chalk.redBright, data));
   }
 
-  //#endregion Custom Wrappers
+  // #endregion Custom Wrappers
 
-  //#region Copy-pasted Console code
+  // #region Copy-pasted Console code
+
   // TODO: Progressively add proper coloration and support for all these methods
   public dir(...args: Parameters<(typeof console)["dir"]>): ReturnType<(typeof console)["dir"]> {
     return this.console.dir(...args);
@@ -214,5 +216,6 @@ export class MockConsole implements Omit<Console, "Console"> {
   public timeStamp(...args: Parameters<(typeof console)["timeStamp"]>): ReturnType<(typeof console)["timeStamp"]> {
     return this.console.timeStamp(...args);
   }
-  //#endregion Copy-pasted Console code
+
+  // #endregion Copy-pasted Console code
 }

--- a/test/setup/vitest.setup.ts
+++ b/test/setup/vitest.setup.ts
@@ -8,7 +8,7 @@ import { initTests } from "#test/setup/test-file-initialization";
 import fs from "node:fs";
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
 
-//#region Mocking
+// #region Mocking
 
 // Mock the override import to always return default values, ignoring any custom overrides.
 vi.mock(import("#app/overrides"), async importOriginal => {
@@ -104,9 +104,9 @@ vi.mock(import("#utils/fetch-utils"), async importOriginal => {
   return { cachedFetch, getCachedUrl } satisfies typeof import("#utils/fetch-utils");
 });
 
-//#endregion Mocking
+// #endregion Mocking
 
-//#region Hooks
+// #region Hooks
 
 beforeAll(() => {
   initTests();
@@ -127,4 +127,4 @@ afterEach(context => {
   PromptHandler.runInterval = undefined;
 });
 
-//#endregion Hooks
+// #endregion Hooks

--- a/test/tests/ai/ai-moveset-gen.test.ts
+++ b/test/tests/ai/ai-moveset-gen.test.ts
@@ -159,7 +159,6 @@ describe("Unit Tests - ai-moveset-gen.ts", () => {
 
   // Unit tests for methods that require a game context
   describe("", () => {
-    //#region boilerplate
     let phaserGame: Phaser.Game;
     /**A pokemon object that will be cleaned up after every test */
     let pokemon: EnemyPokemon | null = null;
@@ -178,8 +177,6 @@ describe("Unit Tests - ai-moveset-gen.ts", () => {
     afterEach(() => {
       pokemon?.destroy();
     });
-
-    //#endregion boilerplate
 
     function createCharmander(_ = pokemon): asserts _ is EnemyPokemon {
       pokemon?.destroy();
@@ -243,7 +240,6 @@ describe("Unit Tests - ai-moveset-gen.ts", () => {
 });
 
 describe("Regression Tests - ai-moveset-gen.ts", () => {
-  //#region boilerplate
   let phaserGame: Phaser.Game;
   let game: GameManager;
   /**A pokemon object that will be cleaned up after every test */
@@ -263,8 +259,6 @@ describe("Regression Tests - ai-moveset-gen.ts", () => {
   afterEach(() => {
     pokemon?.destroy();
   });
-
-  //#endregion boilerplate
 
   describe("getTmPoolForSpecies", () => {
     const { getTmPoolForSpecies } = __INTERNAL_TEST_EXPORTS;

--- a/test/tests/ui/pokedex.test.ts
+++ b/test/tests/ui/pokedex.test.ts
@@ -186,7 +186,8 @@ describe("UI - Pokedex", () => {
     }
   }
 
-  // #endregion
+  // #endregion Helper Functions
+
   // #region Filter Tests
 
   it("should filter to show only the pokemon with an ability when filtering by ability", async () => {
@@ -444,7 +445,8 @@ describe("UI - Pokedex", () => {
     expect(filteredPokemon, "not shiny").not.toContain(SpeciesId.EKANS);
   });
 
-  // #endregion
+  // #endregion Filter Tests
+
   // #region UI Input Tests
 
   // TODO: fix cursor wrapping
@@ -470,7 +472,8 @@ describe("UI - Pokedex", () => {
     expect(selectedPokemon).toEqual(pokedexHandler["lastSpeciesId"].speciesId);
   });
 
-  // #endregion
+  // #endregion UI Input Tests
+
   // #region Pokedex Pages Tests
 
   it("should show caught battle form as caught", async () => {
@@ -498,5 +501,5 @@ describe("UI - Pokedex", () => {
     expect(pageHandler["isSeen"]()).toEqual(true);
   });
 
-  // #endregion
+  // #endregion Pokedex Pages Tests
 });

--- a/test/tests/utils/strings.test.ts
+++ b/test/tests/utils/strings.test.ts
@@ -50,7 +50,6 @@ describe("Utils - Strings", () => {
   });
 
   describe("Test Enum Utils", () => {
-    //#region boilerplate
     enum TestEnumNum {
       TEST_N1 = 1,
       TEST_N2 = 2,
@@ -70,8 +69,6 @@ describe("Utils - Strings", () => {
       ABCD: 0xabcd,
       FFFD: 0xfffd,
     } as const;
-
-    //#endregion boilerplate
 
     describe("stringifyEnumArray", () => {
       const cases = [

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -71,7 +71,7 @@ export default defineConfig(async config => {
   return opts;
 });
 
-//#region Helpers
+// #region Helpers
 
 /**
  * Class for sorting test files in the desired order.
@@ -104,4 +104,4 @@ function getTestOrder(testName: string): number {
   return 3;
 }
 
-//#endregion
+// #endregion Helpers


### PR DESCRIPTION
## What are the changes the user will see?
N/A
<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
The codebase used a variety of different methods for creating `// #region` foldable command blocks - with leading space, without leading space, including or omitting the region name at the end, or even omitting the closing `// #endregion` entirely.

## What are the changes from a developer perspective?
- All `//#region` and `// #region` comments were standardized to `// #region`.
- All `//#endregion` and `// #endregion` comments standardized to `// #endregion`.
- All `// #endregion` comments now have the same name as their matching `// #region` comment.
- There is now a newline before and after all `// #region` and `// #endregion` comments, instead of a mix of some newlines and no newlines.
- Added matching `// #endregion` comments to `// #region` comments that were missing them.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
