### PR TITLE
refactor: Rework trainer items to an attribute-like system

### DIFF
--- a/src/@types/held-item-data-types.ts
+++ b/src/@types/held-item-data-types.ts
@@ -104,14 +104,5 @@ type CosmeticHeldItemId = InferKeys<AllHeldItems, CosmeticHeldItem>;
 export type ApplicableHeldItemId = Exclude<keyof AllHeldItems, CosmeticHeldItemId>;
 
 /** Utility type to retrieve the effects of a given {@linkcode HeldItem} based on its ID. */
-export type ExtractItemEffect<T extends ApplicableHeldItemId> =
+export type ExtractHeldItemEffect<T extends ApplicableHeldItemId> =
   AllHeldItems[T] extends HeldItem<infer Attr extends HeldItemAttr> ? Attr["effect"] : never;
-
-/**
- * Dummy, TypeScript-only type to ensure that {@linkcode HeldItemId} and {@linkcode HeldItemCategoryId}
- * have 0 overlap between allowed IDs.
- *
- * ⚠️ Does not actually exist at runtime, so it must not be used!
- */
-// TODO: Fix this and other "dummy" types to actually work - the intersection with never makes this actively useless
-declare const EnsureHeldItemIDsAreDisjointFromCategories: (HeldItemId & HeldItemCategoryEntry) & never;

--- a/src/@types/trainer-item-data-types.ts
+++ b/src/@types/trainer-item-data-types.ts
@@ -1,5 +1,9 @@
 import type { RarityTier } from "#enums/reward-tier";
 import { TrainerItemId } from "#enums/trainer-item-id";
+import type { AllTrainerItems } from "#items/all-trainer-items";
+import type { MarkerTrainerItem, TrainerItem } from "#items/trainer-item";
+import type { TrainerItemAttr } from "#items/trainer-item-attr";
+import type { InferKeys } from "#types/type-helpers";
 
 export interface TrainerItemData {
   /** The stack count of the item, or its duration for duration-based trainer items. */
@@ -50,4 +54,12 @@ export type TrainerItemConfiguration = TrainerItemConfigurationEntry[];
 
 export type TrainerItemSaveData = TrainerItemSpecs[];
 
-// todo add applicabletraineritemid
+/** Union type of all `TrainerItemId`s whose corresponding items cannot be applied. */
+type MarkerTrainerItemId = InferKeys<AllTrainerItems, MarkerTrainerItem>;
+
+/** Union type of all `TrainerItemId`s whose corresponding items can be applied. */
+export type ApplicableTrainerItemId = Exclude<keyof AllTrainerItems, MarkerTrainerItemId>;
+
+/** Utility type to retrieve the effects of a given {@linkcode TrainerItem} based on its ID. */
+export type ExtractTrainerItemEffect<T extends ApplicableTrainerItemId> =
+  AllTrainerItems[T] extends TrainerItem<infer Attr extends TrainerItemAttr> ? Attr["effect"] : never;

--- a/src/@types/trainer-item-data-types.ts
+++ b/src/@types/trainer-item-data-types.ts
@@ -49,3 +49,5 @@ interface TrainerItemConfigurationEntry {
 export type TrainerItemConfiguration = TrainerItemConfigurationEntry[];
 
 export type TrainerItemSaveData = TrainerItemSpecs[];
+
+// todo add applicabletraineritemid

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -80,9 +80,10 @@ import { EnemyPokemon, PlayerPokemon } from "#field/pokemon";
 import { PokemonSpriteSparkleHandler } from "#field/pokemon-sprite-sparkle-handler";
 import { Trainer } from "#field/trainer";
 import { applyTrainerItems } from "#items/all-trainer-items";
-import type { EnemyAttackStatusEffectChanceTrainerItem } from "#items/enemy-tokens";
+import type { EnemyAttackStatusEffectChanceTrainerItemAttr } from "#items/enemy-tokens";
 import { assignEnemyHeldItemsForWave, assignItemsFromConfiguration } from "#items/held-item-pool";
 import type { MatchExact, Reward } from "#items/reward";
+import type { TrainerItem } from "#items/trainer-item";
 import { TrainerItemManager } from "#items/trainer-item-manager";
 import { getNewTrainerItemFromPool } from "#items/trainer-item-pool";
 import { MysteryEncounter } from "#mystery-encounters/mystery-encounter";
@@ -3037,6 +3038,7 @@ export class BattleScene extends SceneBase {
     });
   }
 
+  // TODO: This is extraordinarily scuffed
   applyShuffledStatusTokens(pokemon: Pokemon) {
     let tokens = [
       TrainerItemId.ENEMY_ATTACK_BURN_CHANCE,
@@ -3056,14 +3058,13 @@ export class BattleScene extends SceneBase {
         };
         tokens = shuffleTokens(tokens);
       },
-      this.currentBattle.turn << 4,
+      this.currentBattle.turn << 4, // TODO: I HATE RANDOM SEED OFFSETS LIKE THIS
       this.waveSeed,
     );
 
-    for (const t in tokens) {
-      (allTrainerItems[t] as EnemyAttackStatusEffectChanceTrainerItem).apply(this.enemyTrainerItems, {
-        pokemon,
-      });
+    for (const t of tokens) {
+      const item = allTrainerItems[t] satisfies TrainerItem<EnemyAttackStatusEffectChanceTrainerItemAttr>;
+      item.apply(TrainerItemEffect.ENEMY_ATTACK_STATUS_CHANCE, { pokemon }, this.enemyTrainerItems);
     }
   }
 

--- a/src/data/data-lists.ts
+++ b/src/data/data-lists.ts
@@ -2,9 +2,8 @@ import type { Ability } from "#abilities/ability";
 import type { PokemonSpecies } from "#data/pokemon-species";
 import type { BiomeId } from "#enums/biome-id";
 import type { HeldItemId } from "#enums/held-item-id";
-import type { TrainerItemId } from "#enums/trainer-item-id";
 import type { AllHeldItems } from "#items/all-held-items";
-import type { TrainerItem } from "#items/trainer-item";
+import type { AllTrainerItems } from "#items/all-trainer-items";
 import type { Move } from "#moves/move";
 import type { Biome, BiomeDepths, CatchableSpecies } from "#types/biomes";
 import type { DataMap } from "#types/common";
@@ -13,7 +12,7 @@ export const allAbilities: readonly Ability[] = [];
 export const allMoves: readonly Move[] = [];
 export const allSpecies: readonly PokemonSpecies[] = [];
 
-export const allTrainerItems: Record<TrainerItemId, TrainerItem> = {} as Record<TrainerItemId, TrainerItem>;
+export const allTrainerItems: AllTrainerItems = {} as AllTrainerItems;
 
 export const catchableSpecies: CatchableSpecies = {} as CatchableSpecies;
 export const biomeDepths: BiomeDepths = {};

--- a/src/data/status-effect.ts
+++ b/src/data/status-effect.ts
@@ -98,6 +98,7 @@ export function getStatusEffectDescriptor(statusEffect: StatusEffect): string {
     return "";
   }
   const i18nKey = `${getStatusEffectMessageKey(statusEffect)}.description` as ParseKeys;
+  // TODO: Use i18next key nesting instead of whatever the fuck this is
   return i18next.t(i18nKey);
 }
 

--- a/src/data/status-effect.ts
+++ b/src/data/status-effect.ts
@@ -98,7 +98,7 @@ export function getStatusEffectDescriptor(statusEffect: StatusEffect): string {
     return "";
   }
   const i18nKey = `${getStatusEffectMessageKey(statusEffect)}.description` as ParseKeys;
-  // TODO: Use i18next key nesting instead of whatever the fuck this is
+  // TODO: Use i18next key nesting instead
   return i18next.t(i18nKey);
 }
 

--- a/src/enums/trainer-item-id.ts
+++ b/src/enums/trainer-item-id.ts
@@ -1,6 +1,4 @@
 export const TrainerItemId = {
-  NONE: 0x0000,
-
   MAP: 0x1001,
   IV_SCANNER: 0x1002,
   LOCK_CAPSULE: 0x1003,

--- a/src/items/all-held-items.ts
+++ b/src/items/all-held-items.ts
@@ -329,4 +329,4 @@ export function initHeldItems(): void {
   Object.freeze(allHeldItems);
 }
 
-//#endregion Initialization
+// #endregion Initialization

--- a/src/items/all-trainer-items.ts
+++ b/src/items/all-trainer-items.ts
@@ -1,4 +1,5 @@
 import { allTrainerItems } from "#data/data-lists";
+import { getStatusEffectDescriptor } from "#data/status-effect";
 import type { Stat, TempBattleStat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
 import type { TrainerItemEffect } from "#enums/trainer-item-effect";
@@ -140,37 +141,65 @@ const trainerItems = {
 
   [TrainerItemId.LURE]: new TrainerItemBuilder(TrainerItemId.LURE, 10) //
     .attr(DoubleBattleChanceBoosterTrainerItemAttr)
+    .lapsing()
+    .description("modifierType:ModifierType.DoubleBattleChanceBoosterModifierType.description", {
+      battleCount: 10,
+    })
     .build(),
   [TrainerItemId.SUPER_LURE]: new TrainerItemBuilder(TrainerItemId.SUPER_LURE, 15) //
     .attr(DoubleBattleChanceBoosterTrainerItemAttr)
+    .lapsing()
     .build(),
   [TrainerItemId.MAX_LURE]: new TrainerItemBuilder(TrainerItemId.MAX_LURE, 30) //
     .attr(DoubleBattleChanceBoosterTrainerItemAttr)
+    .lapsing()
     .build(),
 
-  [TrainerItemId.ENEMY_DAMAGE_BOOSTER]: new TrainerItemBuilder(TrainerItemId.ENEMY_DAMAGE_BOOSTER) //
-    .attr(EnemyDamageBoosterTrainerItemAttr)
+  [TrainerItemId.ENEMY_DAMAGE_BOOSTER]: new TrainerItemBuilder(TrainerItemId.ENEMY_DAMAGE_BOOSTER, 999) //
+    .attr(EnemyDamageBoosterTrainerItemAttr, 0.05)
+    .iconName("wl_item_drop")
     .build(),
-  [TrainerItemId.ENEMY_DAMAGE_REDUCTION]: new TrainerItemBuilder(TrainerItemId.ENEMY_DAMAGE_REDUCTION) //
-    .attr(EnemyDamageReducerTrainerItemAttr)
+  [TrainerItemId.ENEMY_DAMAGE_REDUCTION]: new TrainerItemBuilder(TrainerItemId.ENEMY_DAMAGE_REDUCTION, 999) //
+    .attr(EnemyDamageReducerTrainerItemAttr, 0.025)
+    .iconName("wl_guard_spec")
     .build(),
   [TrainerItemId.ENEMY_HEAL]: new TrainerItemBuilder(TrainerItemId.ENEMY_HEAL, 10) //
-    .attr(EnemyTurnHealTrainerItemAttr)
+    .attr(EnemyTurnHealTrainerItemAttr, 2)
+    .iconName("wl_potion")
     .build(),
   [TrainerItemId.ENEMY_ATTACK_POISON_CHANCE]: new TrainerItemBuilder(TrainerItemId.ENEMY_ATTACK_POISON_CHANCE, 10) //
-    .attr(EnemyAttackStatusEffectChanceTrainerItemAttr, StatusEffect.POISON)
+    .attr(EnemyAttackStatusEffectChanceTrainerItemAttr, StatusEffect.POISON, 0.05)
+    .description("modifierType:ModifierType.EnemyAttackStatusEffectChanceModifierType.description", {
+      chancePercent: 5,
+      // TODO: This needs to use key nesting
+      statusEffect: getStatusEffectDescriptor(StatusEffect.POISON),
+    })
+    .iconName("wl_antidote")
     .build(),
   [TrainerItemId.ENEMY_ATTACK_PARALYZE_CHANCE]: new TrainerItemBuilder(TrainerItemId.ENEMY_ATTACK_PARALYZE_CHANCE, 10) //
-    .attr(EnemyAttackStatusEffectChanceTrainerItemAttr, StatusEffect.PARALYSIS)
+    .attr(EnemyAttackStatusEffectChanceTrainerItemAttr, StatusEffect.PARALYSIS, 0.025)
+    .iconName("wl_paralyze_heal")
+    .description("modifierType:ModifierType.EnemyAttackStatusEffectChanceModifierType.description", {
+      chancePercent: 2.5,
+      // TODO: This needs to use key nesting
+      statusEffect: getStatusEffectDescriptor(StatusEffect.PARALYSIS),
+    })
     .build(),
   [TrainerItemId.ENEMY_ATTACK_BURN_CHANCE]: new TrainerItemBuilder(TrainerItemId.ENEMY_ATTACK_BURN_CHANCE, 10) //
-    .attr(EnemyAttackStatusEffectChanceTrainerItemAttr, StatusEffect.BURN)
+    .attr(EnemyAttackStatusEffectChanceTrainerItemAttr, StatusEffect.BURN, 0.05)
+    .iconName("wl_burn_heal")
+    .description("modifierType:ModifierType.EnemyAttackStatusEffectChanceModifierType.description", {
+      chancePercent: 5,
+      // TODO: This needs to use key nesting
+      statusEffect: getStatusEffectDescriptor(StatusEffect.BURN),
+    })
     .build(),
   [TrainerItemId.ENEMY_STATUS_EFFECT_HEAL_CHANCE]: new TrainerItemBuilder(
     TrainerItemId.ENEMY_STATUS_EFFECT_HEAL_CHANCE,
     10,
   )
-    .attr(EnemyStatusEffectHealChanceTrainerItemAttr)
+    .attr(EnemyStatusEffectHealChanceTrainerItemAttr, 0.025)
+    .iconName("wl_full_heal")
     .build(),
   [TrainerItemId.ENEMY_ENDURE_CHANCE]: new TrainerItemBuilder(TrainerItemId.ENEMY_ENDURE_CHANCE, 10) //
     .attr(EnemyEndureChanceTrainerItemAttr)

--- a/src/items/all-trainer-items.ts
+++ b/src/items/all-trainer-items.ts
@@ -1,11 +1,179 @@
 import { allTrainerItems } from "#data/data-lists";
+import type { Stat, TempBattleStat } from "#enums/stat";
+import { StatusEffect } from "#enums/status-effect";
 import type { TrainerItemEffect } from "#enums/trainer-item-effect";
-import type { TrainerItemId } from "#enums/trainer-item-id";
-import type { MarkerTrainerItem, TrainerItem } from "#items/trainer-item";
+import { TrainerItemId } from "#enums/trainer-item-id";
+import { MarkerTrainerItem, type TrainerItem } from "#items/trainer-item";
+import { TrainerItemBuilder } from "#items/trainer-item-builder";
+import { CriticalCatchChanceBoosterTrainerItemAttr } from "#items/trainer-items/critical-catch-chance-booster";
+import {
+  EnemyAttackStatusEffectChanceTrainerItemAttr,
+  EnemyDamageBoosterTrainerItemAttr,
+  EnemyDamageReducerTrainerItemAttr,
+  EnemyEndureChanceTrainerItemAttr,
+  EnemyFusionChanceTrainerItemAttr,
+  EnemyStatusEffectHealChanceTrainerItemAttr,
+  EnemyTurnHealTrainerItemAttr,
+} from "#items/trainer-items/enemy-tokens";
+import { ExpBoosterTrainerItemAttr } from "#items/trainer-items/exp-booster";
+import { ExtraRewardTrainerItemAttr } from "#items/trainer-items/extra-reward";
+import { HealShopCostTrainerItemAttr } from "#items/trainer-items/heal-shop-cost";
+import { HealingBoosterTrainerItemAttr } from "#items/trainer-items/healing-booster";
+import { HiddenAbilityChanceBoosterTrainerItemAttr } from "#items/trainer-items/hidden-ability-chance-booster";
+import { LevelIncrementBoosterTrainerItemAttr } from "#items/trainer-items/level-increment-booster";
+import { DoubleBattleChanceBoosterTrainerItemAttr } from "#items/trainer-items/lure";
+import { MoneyMultiplierTrainerItemAttr } from "#items/trainer-items/money-multiplier";
+import { PreserveBerryTrainerItemAttr } from "#items/trainer-items/preserve-berry";
+import { ShinyRateBoosterTrainerItemAttr } from "#items/trainer-items/shiny-rate-booster";
+import {
+  AccuracyBoosterTrainerItemAttr,
+  CritBoosterTrainerItemAttr,
+  StatStageBoosterTrainerItemAttr,
+  tempStatToTrainerItem,
+} from "#items/trainer-items/x-items";
 import type { TrainerItemEffectParamMap } from "#types/trainer-item-parameter";
+import type { Mutable } from "#types/type-helpers";
 import type { TrainerItemManager } from "./trainer-item-manager";
 
-const trainerItems = {} as const satisfies Readonly<Record<TrainerItemId, TrainerItem | MarkerTrainerItem>>;
+// #region Marker items
+const markerItems = {
+  [TrainerItemId.MAP]: new MarkerTrainerItem(TrainerItemId.MAP, 1),
+  [TrainerItemId.IV_SCANNER]: new MarkerTrainerItem(TrainerItemId.IV_SCANNER, 1),
+  [TrainerItemId.LOCK_CAPSULE]: new MarkerTrainerItem(TrainerItemId.LOCK_CAPSULE, 1),
+  [TrainerItemId.MEGA_BRACELET]: new MarkerTrainerItem(TrainerItemId.MEGA_BRACELET, 1),
+  [TrainerItemId.DYNAMAX_BAND]: new MarkerTrainerItem(TrainerItemId.DYNAMAX_BAND, 1),
+  [TrainerItemId.TERA_ORB]: new MarkerTrainerItem(TrainerItemId.TERA_ORB, 1),
+
+  [TrainerItemId.OVAL_CHARM]: new MarkerTrainerItem(TrainerItemId.OVAL_CHARM, 5),
+  [TrainerItemId.EXP_SHARE]: new MarkerTrainerItem(TrainerItemId.EXP_SHARE, 5),
+  [TrainerItemId.EXP_BALANCE]: new MarkerTrainerItem(TrainerItemId.EXP_BALANCE, 4),
+
+  [TrainerItemId.GOLDEN_BUG_NET]: new MarkerTrainerItem(TrainerItemId.GOLDEN_BUG_NET, 1),
+} as const satisfies Partial<Readonly<Record<TrainerItemId, MarkerTrainerItem>>>;
+
+type XItemsType = {
+  [k in keyof typeof tempStatToTrainerItem as (typeof tempStatToTrainerItem)[k]]: TrainerItem<
+    k extends Stat.ACC ? AccuracyBoosterTrainerItemAttr : StatStageBoosterTrainerItemAttr
+  >;
+};
+
+const xItems = Object.entries(tempStatToTrainerItem)
+  .values()
+  .reduce(
+    (acc, [statKey, trainerItemType]) => {
+      const stat = Number(statKey) satisfies TempBattleStat;
+      if (trainerItemType === TrainerItemId.X_ACCURACY) {
+        acc[trainerItemType] = new TrainerItemBuilder(TrainerItemId.X_ACCURACY, 5) //
+          .attr(AccuracyBoosterTrainerItemAttr)
+          .lapsing()
+          .build();
+      } else {
+        acc[trainerItemType] = new TrainerItemBuilder(trainerItemType, 5) //
+          .attr(StatStageBoosterTrainerItemAttr, stat as Exclude<TempBattleStat, Stat.ACC>, 0.3)
+          .lapsing()
+          .build();
+      }
+      return acc;
+    },
+    {} as Mutable<XItemsType>,
+  );
+
+const trainerItems = {
+  ...markerItems,
+  ...xItems,
+
+  [TrainerItemId.CANDY_JAR]: new TrainerItemBuilder(TrainerItemId.CANDY_JAR, 99) //
+    .attr(LevelIncrementBoosterTrainerItemAttr)
+    .build(),
+  [TrainerItemId.BERRY_POUCH]: new TrainerItemBuilder(TrainerItemId.BERRY_POUCH, 3) //
+    .attr(PreserveBerryTrainerItemAttr)
+    .build(),
+
+  [TrainerItemId.HEALING_CHARM]: new TrainerItemBuilder(TrainerItemId.HEALING_CHARM, 5) //
+    .attr(HealingBoosterTrainerItemAttr, 0.1)
+    .build(),
+
+  [TrainerItemId.EXP_CHARM]: new TrainerItemBuilder(TrainerItemId.EXP_CHARM, 99) //
+    .attr(ExpBoosterTrainerItemAttr, 25)
+    .build(),
+  [TrainerItemId.SUPER_EXP_CHARM]: new TrainerItemBuilder(TrainerItemId.SUPER_EXP_CHARM, 30) //
+    .attr(ExpBoosterTrainerItemAttr, 60)
+    .build(),
+  [TrainerItemId.GOLDEN_EXP_CHARM]: new TrainerItemBuilder(TrainerItemId.GOLDEN_EXP_CHARM, 10) //
+    .attr(ExpBoosterTrainerItemAttr, 100)
+    .build(),
+
+  [TrainerItemId.AMULET_COIN]: new TrainerItemBuilder(TrainerItemId.AMULET_COIN, 5) //
+    .attr(MoneyMultiplierTrainerItemAttr)
+    .build(),
+
+  [TrainerItemId.GOLDEN_POKEBALL]: new TrainerItemBuilder(TrainerItemId.GOLDEN_POKEBALL, 3) //
+    .attr(ExtraRewardTrainerItemAttr)
+    .build(),
+
+  [TrainerItemId.ABILITY_CHARM]: new TrainerItemBuilder(TrainerItemId.ABILITY_CHARM, 4) //
+    .attr(HiddenAbilityChanceBoosterTrainerItemAttr)
+    .build(),
+  [TrainerItemId.SHINY_CHARM]: new TrainerItemBuilder(TrainerItemId.SHINY_CHARM, 4) //
+    .attr(ShinyRateBoosterTrainerItemAttr)
+    .build(),
+  [TrainerItemId.CATCHING_CHARM]: new TrainerItemBuilder(TrainerItemId.CATCHING_CHARM, 3) //
+    .attr(CriticalCatchChanceBoosterTrainerItemAttr)
+    .build(),
+
+  [TrainerItemId.BLACK_SLUDGE]: new TrainerItemBuilder(TrainerItemId.BLACK_SLUDGE, 1) //
+    .attr(HealShopCostTrainerItemAttr, 2.5)
+    .build(),
+
+  [TrainerItemId.LURE]: new TrainerItemBuilder(TrainerItemId.LURE, 10) //
+    .attr(DoubleBattleChanceBoosterTrainerItemAttr)
+    .build(),
+  [TrainerItemId.SUPER_LURE]: new TrainerItemBuilder(TrainerItemId.SUPER_LURE, 15) //
+    .attr(DoubleBattleChanceBoosterTrainerItemAttr)
+    .build(),
+  [TrainerItemId.MAX_LURE]: new TrainerItemBuilder(TrainerItemId.MAX_LURE, 30) //
+    .attr(DoubleBattleChanceBoosterTrainerItemAttr)
+    .build(),
+
+  [TrainerItemId.DIRE_HIT]: new TrainerItemBuilder(TrainerItemId.DIRE_HIT, 5) //
+    .attr(CritBoosterTrainerItemAttr)
+    .lapsing()
+    .build(),
+
+  // #region Tokens
+  [TrainerItemId.ENEMY_DAMAGE_BOOSTER]: new TrainerItemBuilder(TrainerItemId.ENEMY_DAMAGE_BOOSTER) //
+    .attr(EnemyDamageBoosterTrainerItemAttr)
+    .build(),
+  [TrainerItemId.ENEMY_DAMAGE_REDUCTION]: new TrainerItemBuilder(TrainerItemId.ENEMY_DAMAGE_REDUCTION) //
+    .attr(EnemyDamageReducerTrainerItemAttr)
+    .build(),
+  [TrainerItemId.ENEMY_HEAL]: new TrainerItemBuilder(TrainerItemId.ENEMY_HEAL, 10) //
+    .attr(EnemyTurnHealTrainerItemAttr)
+    .build(),
+  [TrainerItemId.ENEMY_ATTACK_POISON_CHANCE]: new TrainerItemBuilder(TrainerItemId.ENEMY_ATTACK_POISON_CHANCE, 10) //
+    .attr(EnemyAttackStatusEffectChanceTrainerItemAttr, StatusEffect.POISON)
+    .build(),
+  [TrainerItemId.ENEMY_ATTACK_PARALYZE_CHANCE]: new TrainerItemBuilder(TrainerItemId.ENEMY_ATTACK_PARALYZE_CHANCE, 10) //
+    .attr(EnemyAttackStatusEffectChanceTrainerItemAttr, StatusEffect.PARALYSIS)
+    .build(),
+  [TrainerItemId.ENEMY_ATTACK_BURN_CHANCE]: new TrainerItemBuilder(TrainerItemId.ENEMY_ATTACK_BURN_CHANCE, 10) //
+    .attr(EnemyAttackStatusEffectChanceTrainerItemAttr, StatusEffect.BURN)
+    .build(),
+  [TrainerItemId.ENEMY_STATUS_EFFECT_HEAL_CHANCE]: new TrainerItemBuilder(
+    TrainerItemId.ENEMY_STATUS_EFFECT_HEAL_CHANCE,
+    10,
+  ) //
+    .attr(EnemyStatusEffectHealChanceTrainerItemAttr)
+    .build(),
+  [TrainerItemId.ENEMY_ENDURE_CHANCE]: new TrainerItemBuilder(TrainerItemId.ENEMY_ENDURE_CHANCE, 10) //
+    .attr(EnemyEndureChanceTrainerItemAttr)
+    .build(),
+  [TrainerItemId.ENEMY_FUSED_CHANCE]: new TrainerItemBuilder(TrainerItemId.ENEMY_FUSED_CHANCE, 10) //
+    .attr(EnemyFusionChanceTrainerItemAttr)
+    .build(),
+
+  // #endregion Tokens
+};
 
 export function initTrainerItems() {
   Object.assign(allTrainerItems, trainerItems);

--- a/src/items/all-trainer-items.ts
+++ b/src/items/all-trainer-items.ts
@@ -3,21 +3,8 @@ import { Stat, type TempBattleStat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
 import type { TrainerItemEffect } from "#enums/trainer-item-effect";
 import { TrainerItemId } from "#enums/trainer-item-id";
-import {
-  CriticalCatchChanceBoosterTrainerItem,
-  ExpBoosterTrainerItem,
-  ExtraRewardTrainerItem,
-  HealingBoosterTrainerItem,
-  HealShopCostTrainerItem,
-  HiddenAbilityChanceBoosterTrainerItem,
-  LevelIncrementBoosterTrainerItem,
-  MoneyMultiplierTrainerItem,
-  PreserveBerryTrainerItem,
-  ShinyRateBoosterTrainerItem,
-  TrainerItem,
-} from "#items/trainer-item";
-import type { TrainerItemEffectParamMap } from "#types/trainer-item-parameter";
-import type { TrainerItemManager } from "./trainer-item-manager";
+import { TrainerItem } from "#items/trainer-item";
+import { CriticalCatchChanceBoosterTrainerItem } from "#items/trainer-items/critical-catch-chance-booster";
 import {
   EnemyAttackStatusEffectChanceTrainerItem,
   EnemyDamageBoosterTrainerItem,
@@ -26,14 +13,25 @@ import {
   EnemyFusionChanceTrainerItem,
   EnemyStatusEffectHealChanceTrainerItem,
   EnemyTurnHealTrainerItem,
-} from "./trainer-items/enemy-tokens";
-import { DoubleBattleChanceBoosterTrainerItem } from "./trainer-items/lure";
+} from "#items/trainer-items/enemy-tokens";
+import { ExpBoosterTrainerItem } from "#items/trainer-items/exp-booster";
+import { ExtraRewardTrainerItem } from "#items/trainer-items/extra-reward";
+import { HealShopCostTrainerItem } from "#items/trainer-items/heal-shop-cost";
+import { HealingBoosterTrainerItem } from "#items/trainer-items/healing-booster";
+import { HiddenAbilityChanceBoosterTrainerItem } from "#items/trainer-items/hidden-ability-chance-booster";
+import { LevelIncrementBoosterTrainerItem } from "#items/trainer-items/level-increment-booster";
+import { DoubleBattleChanceBoosterTrainerItem } from "#items/trainer-items/lure";
+import { MoneyMultiplierTrainerItem } from "#items/trainer-items/money-multiplier";
+import { PreserveBerryTrainerItem } from "#items/trainer-items/preserve-berry";
+import { ShinyRateBoosterTrainerItem } from "#items/trainer-items/shiny-rate-booster";
 import {
   TempAccuracyBoosterTrainerItem,
   TempCritBoosterTrainerItem,
   TempStatStageBoosterTrainerItem,
   tempStatToTrainerItem,
-} from "./trainer-items/x-items";
+} from "#items/trainer-items/x-items";
+import type { TrainerItemEffectParamMap } from "#types/trainer-item-parameter";
+import type { TrainerItemManager } from "./trainer-item-manager";
 
 export function initTrainerItems() {
   allTrainerItems[TrainerItemId.MAP] = new TrainerItem(TrainerItemId.MAP, 1);

--- a/src/items/all-trainer-items.ts
+++ b/src/items/all-trainer-items.ts
@@ -1,121 +1,15 @@
 import { allTrainerItems } from "#data/data-lists";
-import { Stat, type TempBattleStat } from "#enums/stat";
-import { StatusEffect } from "#enums/status-effect";
 import type { TrainerItemEffect } from "#enums/trainer-item-effect";
-import { TrainerItemId } from "#enums/trainer-item-id";
-import { TrainerItem } from "#items/trainer-item";
-import { CriticalCatchChanceBoosterTrainerItem } from "#items/trainer-items/critical-catch-chance-booster";
-import {
-  EnemyAttackStatusEffectChanceTrainerItem,
-  EnemyDamageBoosterTrainerItem,
-  EnemyDamageReducerTrainerItem,
-  EnemyEndureChanceTrainerItem,
-  EnemyFusionChanceTrainerItem,
-  EnemyStatusEffectHealChanceTrainerItem,
-  EnemyTurnHealTrainerItem,
-} from "#items/trainer-items/enemy-tokens";
-import { ExpBoosterTrainerItem } from "#items/trainer-items/exp-booster";
-import { ExtraRewardTrainerItem } from "#items/trainer-items/extra-reward";
-import { HealShopCostTrainerItem } from "#items/trainer-items/heal-shop-cost";
-import { HealingBoosterTrainerItem } from "#items/trainer-items/healing-booster";
-import { HiddenAbilityChanceBoosterTrainerItem } from "#items/trainer-items/hidden-ability-chance-booster";
-import { LevelIncrementBoosterTrainerItem } from "#items/trainer-items/level-increment-booster";
-import { DoubleBattleChanceBoosterTrainerItem } from "#items/trainer-items/lure";
-import { MoneyMultiplierTrainerItem } from "#items/trainer-items/money-multiplier";
-import { PreserveBerryTrainerItem } from "#items/trainer-items/preserve-berry";
-import { ShinyRateBoosterTrainerItem } from "#items/trainer-items/shiny-rate-booster";
-import {
-  TempAccuracyBoosterTrainerItem,
-  TempCritBoosterTrainerItem,
-  TempStatStageBoosterTrainerItem,
-  tempStatToTrainerItem,
-} from "#items/trainer-items/x-items";
+import type { TrainerItemId } from "#enums/trainer-item-id";
+import type { MarkerTrainerItem, TrainerItem } from "#items/trainer-item";
 import type { TrainerItemEffectParamMap } from "#types/trainer-item-parameter";
 import type { TrainerItemManager } from "./trainer-item-manager";
 
+const trainerItems = {} as const satisfies Readonly<Record<TrainerItemId, TrainerItem | MarkerTrainerItem>>;
+
 export function initTrainerItems() {
-  allTrainerItems[TrainerItemId.MAP] = new TrainerItem(TrainerItemId.MAP, 1);
-  allTrainerItems[TrainerItemId.IV_SCANNER] = new TrainerItem(TrainerItemId.IV_SCANNER, 1);
-  allTrainerItems[TrainerItemId.LOCK_CAPSULE] = new TrainerItem(TrainerItemId.LOCK_CAPSULE, 1);
-  allTrainerItems[TrainerItemId.MEGA_BRACELET] = new TrainerItem(TrainerItemId.MEGA_BRACELET, 1);
-  allTrainerItems[TrainerItemId.DYNAMAX_BAND] = new TrainerItem(TrainerItemId.DYNAMAX_BAND, 1);
-  allTrainerItems[TrainerItemId.TERA_ORB] = new TrainerItem(TrainerItemId.TERA_ORB, 1);
-
-  allTrainerItems[TrainerItemId.OVAL_CHARM] = new TrainerItem(TrainerItemId.OVAL_CHARM, 5);
-  allTrainerItems[TrainerItemId.EXP_SHARE] = new TrainerItem(TrainerItemId.EXP_SHARE, 5);
-  allTrainerItems[TrainerItemId.EXP_BALANCE] = new TrainerItem(TrainerItemId.EXP_BALANCE, 4);
-
-  allTrainerItems[TrainerItemId.CANDY_JAR] = new LevelIncrementBoosterTrainerItem(TrainerItemId.CANDY_JAR, 99);
-  allTrainerItems[TrainerItemId.BERRY_POUCH] = new PreserveBerryTrainerItem(TrainerItemId.BERRY_POUCH, 3);
-
-  allTrainerItems[TrainerItemId.HEALING_CHARM] = new HealingBoosterTrainerItem(TrainerItemId.HEALING_CHARM, 0.1, 5);
-  allTrainerItems[TrainerItemId.EXP_CHARM] = new ExpBoosterTrainerItem(TrainerItemId.EXP_CHARM, 25, 99);
-  allTrainerItems[TrainerItemId.SUPER_EXP_CHARM] = new ExpBoosterTrainerItem(TrainerItemId.SUPER_EXP_CHARM, 60, 30);
-  allTrainerItems[TrainerItemId.GOLDEN_EXP_CHARM] = new ExpBoosterTrainerItem(TrainerItemId.GOLDEN_EXP_CHARM, 100, 10);
-  allTrainerItems[TrainerItemId.AMULET_COIN] = new MoneyMultiplierTrainerItem(TrainerItemId.AMULET_COIN, 5);
-
-  allTrainerItems[TrainerItemId.ABILITY_CHARM] = new HiddenAbilityChanceBoosterTrainerItem(
-    TrainerItemId.ABILITY_CHARM,
-    4,
-  );
-  allTrainerItems[TrainerItemId.GOLDEN_POKEBALL] = new ExtraRewardTrainerItem(TrainerItemId.GOLDEN_POKEBALL, 3);
-  allTrainerItems[TrainerItemId.SHINY_CHARM] = new ShinyRateBoosterTrainerItem(TrainerItemId.SHINY_CHARM, 4);
-  allTrainerItems[TrainerItemId.CATCHING_CHARM] = new CriticalCatchChanceBoosterTrainerItem(
-    TrainerItemId.CATCHING_CHARM,
-    3,
-  );
-
-  allTrainerItems[TrainerItemId.BLACK_SLUDGE] = new HealShopCostTrainerItem(TrainerItemId.BLACK_SLUDGE, 2.5, 1);
-  allTrainerItems[TrainerItemId.GOLDEN_BUG_NET] = new TrainerItem(TrainerItemId.GOLDEN_BUG_NET, 1);
-
-  allTrainerItems[TrainerItemId.LURE] = new DoubleBattleChanceBoosterTrainerItem(TrainerItemId.LURE, 10);
-  allTrainerItems[TrainerItemId.SUPER_LURE] = new DoubleBattleChanceBoosterTrainerItem(TrainerItemId.SUPER_LURE, 15);
-  allTrainerItems[TrainerItemId.MAX_LURE] = new DoubleBattleChanceBoosterTrainerItem(TrainerItemId.MAX_LURE, 30);
-
-  for (const [statKey, trainerItemType] of Object.entries(tempStatToTrainerItem)) {
-    const stat = Number(statKey) as TempBattleStat;
-    if (stat === Stat.ACC) {
-      allTrainerItems[trainerItemType] = new TempAccuracyBoosterTrainerItem(trainerItemType, 5);
-    } else {
-      allTrainerItems[trainerItemType] = new TempStatStageBoosterTrainerItem(trainerItemType, stat, 5);
-    }
-  }
-  allTrainerItems[TrainerItemId.DIRE_HIT] = new TempCritBoosterTrainerItem(TrainerItemId.DIRE_HIT, 5);
-
-  allTrainerItems[TrainerItemId.ENEMY_DAMAGE_BOOSTER] = new EnemyDamageBoosterTrainerItem(
-    TrainerItemId.ENEMY_DAMAGE_BOOSTER,
-  );
-  allTrainerItems[TrainerItemId.ENEMY_DAMAGE_REDUCTION] = new EnemyDamageReducerTrainerItem(
-    TrainerItemId.ENEMY_DAMAGE_REDUCTION,
-  );
-  allTrainerItems[TrainerItemId.ENEMY_HEAL] = new EnemyTurnHealTrainerItem(TrainerItemId.ENEMY_HEAL, 10);
-  allTrainerItems[TrainerItemId.ENEMY_ATTACK_POISON_CHANCE] = new EnemyAttackStatusEffectChanceTrainerItem(
-    TrainerItemId.ENEMY_ATTACK_POISON_CHANCE,
-    StatusEffect.POISON,
-    10,
-  );
-  allTrainerItems[TrainerItemId.ENEMY_ATTACK_PARALYZE_CHANCE] = new EnemyAttackStatusEffectChanceTrainerItem(
-    TrainerItemId.ENEMY_ATTACK_PARALYZE_CHANCE,
-    StatusEffect.PARALYSIS,
-    10,
-  );
-  allTrainerItems[TrainerItemId.ENEMY_ATTACK_BURN_CHANCE] = new EnemyAttackStatusEffectChanceTrainerItem(
-    TrainerItemId.ENEMY_ATTACK_BURN_CHANCE,
-    StatusEffect.BURN,
-    10,
-  );
-  allTrainerItems[TrainerItemId.ENEMY_STATUS_EFFECT_HEAL_CHANCE] = new EnemyStatusEffectHealChanceTrainerItem(
-    TrainerItemId.ENEMY_STATUS_EFFECT_HEAL_CHANCE,
-    10,
-  );
-  allTrainerItems[TrainerItemId.ENEMY_ENDURE_CHANCE] = new EnemyEndureChanceTrainerItem(
-    TrainerItemId.ENEMY_ENDURE_CHANCE,
-    10,
-  );
-  allTrainerItems[TrainerItemId.ENEMY_FUSED_CHANCE] = new EnemyFusionChanceTrainerItem(
-    TrainerItemId.ENEMY_FUSED_CHANCE,
-    10,
-  );
+  Object.assign(allTrainerItems, trainerItems);
+  Object.freeze(allTrainerItems);
 }
 
 export function applyTrainerItems<T extends TrainerItemEffect>(
@@ -124,9 +18,10 @@ export function applyTrainerItems<T extends TrainerItemEffect>(
   params: TrainerItemEffectParamMap[T],
 ) {
   if (manager) {
-    for (const item of manager.items.keys()) {
-      if (allTrainerItems[item].effects.includes(effect)) {
-        allTrainerItems[item].apply(manager, params);
+    for (const itemId of manager.getItems()) {
+      const item = allTrainerItems[itemId];
+      if (item.hasEffect(effect)) {
+        item.apply(effect, params, manager);
       }
     }
   }

--- a/src/items/all-trainer-items.ts
+++ b/src/items/all-trainer-items.ts
@@ -36,6 +36,7 @@ import type { Mutable } from "#types/type-helpers";
 import type { TrainerItemManager } from "./trainer-item-manager";
 
 // #region Marker items
+
 const markerItems = {
   [TrainerItemId.MAP]: new MarkerTrainerItem(TrainerItemId.MAP, 1),
   [TrainerItemId.IV_SCANNER]: new MarkerTrainerItem(TrainerItemId.IV_SCANNER, 1),
@@ -50,6 +51,10 @@ const markerItems = {
 
   [TrainerItemId.GOLDEN_BUG_NET]: new MarkerTrainerItem(TrainerItemId.GOLDEN_BUG_NET, 1),
 } as const satisfies Partial<Readonly<Record<TrainerItemId, MarkerTrainerItem>>>;
+
+// #endregion Marker items
+
+// #region X items
 
 type XItemsType = {
   [k in keyof typeof tempStatToTrainerItem as (typeof tempStatToTrainerItem)[k]]: TrainerItem<
@@ -78,9 +83,18 @@ const xItems = Object.entries(tempStatToTrainerItem)
     {} as Mutable<XItemsType>,
   );
 
+// #endregion X items
+
+// #region Initialization
+
 const trainerItems = {
   ...markerItems,
+
   ...xItems,
+  [TrainerItemId.DIRE_HIT]: new TrainerItemBuilder(TrainerItemId.DIRE_HIT, 5) //
+    .attr(CritBoosterTrainerItemAttr)
+    .lapsing()
+    .build(),
 
   [TrainerItemId.CANDY_JAR]: new TrainerItemBuilder(TrainerItemId.CANDY_JAR, 99) //
     .attr(LevelIncrementBoosterTrainerItemAttr)
@@ -106,7 +120,6 @@ const trainerItems = {
   [TrainerItemId.AMULET_COIN]: new TrainerItemBuilder(TrainerItemId.AMULET_COIN, 5) //
     .attr(MoneyMultiplierTrainerItemAttr)
     .build(),
-
   [TrainerItemId.GOLDEN_POKEBALL]: new TrainerItemBuilder(TrainerItemId.GOLDEN_POKEBALL, 3) //
     .attr(ExtraRewardTrainerItemAttr)
     .build(),
@@ -135,12 +148,6 @@ const trainerItems = {
     .attr(DoubleBattleChanceBoosterTrainerItemAttr)
     .build(),
 
-  [TrainerItemId.DIRE_HIT]: new TrainerItemBuilder(TrainerItemId.DIRE_HIT, 5) //
-    .attr(CritBoosterTrainerItemAttr)
-    .lapsing()
-    .build(),
-
-  // #region Tokens
   [TrainerItemId.ENEMY_DAMAGE_BOOSTER]: new TrainerItemBuilder(TrainerItemId.ENEMY_DAMAGE_BOOSTER) //
     .attr(EnemyDamageBoosterTrainerItemAttr)
     .build(),
@@ -162,7 +169,7 @@ const trainerItems = {
   [TrainerItemId.ENEMY_STATUS_EFFECT_HEAL_CHANCE]: new TrainerItemBuilder(
     TrainerItemId.ENEMY_STATUS_EFFECT_HEAL_CHANCE,
     10,
-  ) //
+  )
     .attr(EnemyStatusEffectHealChanceTrainerItemAttr)
     .build(),
   [TrainerItemId.ENEMY_ENDURE_CHANCE]: new TrainerItemBuilder(TrainerItemId.ENEMY_ENDURE_CHANCE, 10) //
@@ -171,26 +178,31 @@ const trainerItems = {
   [TrainerItemId.ENEMY_FUSED_CHANCE]: new TrainerItemBuilder(TrainerItemId.ENEMY_FUSED_CHANCE, 10) //
     .attr(EnemyFusionChanceTrainerItemAttr)
     .build(),
+} as const satisfies Readonly<Record<TrainerItemId, MarkerTrainerItem | TrainerItem>>;
 
-  // #endregion Tokens
-};
+/**
+ * Resolved type of {@linkcode allTrainerItems}.
+ * @privateRemarks
+ * Declared in a separate file to avoid circular imports.
+ */
+export type AllTrainerItems = typeof trainerItems;
 
 export function initTrainerItems() {
   Object.assign(allTrainerItems, trainerItems);
   Object.freeze(allTrainerItems);
 }
 
-export function applyTrainerItems<T extends TrainerItemEffect>(
-  effect: T,
+// #endregion Initialization
+
+export function applyTrainerItems<E extends TrainerItemEffect>(
+  effect: E,
   manager: TrainerItemManager,
-  params: TrainerItemEffectParamMap[T],
+  params: TrainerItemEffectParamMap[E],
 ) {
-  if (manager) {
-    for (const itemId of manager.getItems()) {
-      const item = allTrainerItems[itemId];
-      if (item.hasEffect(effect)) {
-        item.apply(effect, params, manager);
-      }
+  for (const itemId of manager.getItems()) {
+    const trainerItem = allTrainerItems[itemId] as TrainerItem | MarkerTrainerItem;
+    if ("effects" in trainerItem && trainerItem.hasEffect(effect)) {
+      trainerItem.apply(effect, params, manager);
     }
   }
 }

--- a/src/items/held-item-attr.ts
+++ b/src/items/held-item-attr.ts
@@ -9,7 +9,7 @@ import type { HeldItem } from "#items/held-item";
 import type { HeldItemBuilder } from "#items/held-item-builder";
 import type { HeldItemEffectParamMap } from "#types/held-item-parameter";
 import type { MoveAttr } from "#types/move-types";
-import type { IsEqual, IsUnion } from "type-fest";
+import type { IsEqual, IsUnion, NonEmptyTuple } from "type-fest";
 
 /**
  * Type matching each {@linkcode HeldItemEffect} to the subset of `Attrs` that can apply said effect. \
@@ -21,7 +21,7 @@ import type { IsEqual, IsUnion } from "type-fest";
 export type HeldItemRecord<Attrs extends HeldItemAttr> = {
   readonly [E in HeldItemEffect]: [Extract<Attrs, HeldItemAttr<E>>] extends [never]
     ? readonly []
-    : readonly Extract<Attrs, HeldItemAttr<E>>[];
+    : NonEmptyTuple<Extract<Attrs, HeldItemAttr<E>>>;
 };
 
 /**

--- a/src/items/held-item-builder.ts
+++ b/src/items/held-item-builder.ts
@@ -23,7 +23,7 @@ type AddAttrToBuilder<Attrs extends HeldItemAttr, Effects extends HeldItemEffect
  * Builder class for {@linkcode HeldItem} instances.
  *
  * Accumulates {@linkcode HeldItemAttr} instances via {@linkcode HeldItemBuilder.attr | attr},
- * before transforming them into a concrete `HeldItem` subclass with {@linkcode HeldItemBuilder.build | build}.
+ * before transforming them into a concrete `HeldItem` instance with {@linkcode HeldItemBuilder.build | build}.
  *
  * @typeParam Attrs - A union of all the {@linkcode HeldItemAttr}s registered so far.
  * @typeParam ConsumableEffects - A union of {@linkcode HeldItemEffect}s corresponding to all {@linkcode ConsumableHeldItemAttr}s registered so far;

--- a/src/items/held-item-builder.ts
+++ b/src/items/held-item-builder.ts
@@ -49,6 +49,7 @@ export class HeldItemBuilder<Attrs extends HeldItemAttr = never, ConsumableEffec
   private nameParams?: Parameters<typeof i18next.t>;
   private descriptionParams?: Parameters<typeof i18next.t>;
   private icon?: string;
+
   /**
    * A `DataMap` matching effects to their corresponding (potentially empty) attribute lists.
    * @remarks
@@ -177,7 +178,7 @@ export class HeldItemBuilder<Attrs extends HeldItemAttr = never, ConsumableEffec
    */
   // TODO: Do we want to allow 0-item builds (and make them cosmetic?)
   public build(): [Attrs] extends [never] ? ErrorType<"Cannot create a HeldItem with no attributes!"> : HeldItem<Attrs>;
-  // NB: The implementation signature needs to return a union here to satisfy TypeScript, but we never actually return one ourselves
+  // NB: The implementation signature needs to return a union containing ErrorType to satisfy TypeScript, but we never actually return one ourselves
   public build(): ErrorType<"Cannot create a HeldItem with no attributes!"> | HeldItem<Attrs> {
     // @ts-expect-error - TypeScript doesn't support friend classes, so this is the closest we can get to
     // ensuring `HeldItem` is only constructed by its corresponding builder.

--- a/src/items/held-item.ts
+++ b/src/items/held-item.ts
@@ -132,6 +132,7 @@ export class HeldItem<Attrs extends HeldItemAttr = HeldItemAttr> extends HeldIte
   private readonly effects: HeldItemRecord<Attrs>;
 
   // #region Localization
+
   /**
    * Optional parameters used to localize this item's name.
    * If omitted, will use the default implementation provided from {@linkcode HeldItemBase}.
@@ -155,6 +156,7 @@ export class HeldItem<Attrs extends HeldItemAttr = HeldItemAttr> extends HeldIte
   public override get iconName(): string {
     return this.customIconName ?? super.iconName;
   }
+
   // #endregion Localization
 
   protected constructor({

--- a/src/items/rewards/trainer-item-reward.ts
+++ b/src/items/rewards/trainer-item-reward.ts
@@ -31,6 +31,7 @@ export class TrainerItemReward extends Reward {
   }
 }
 
+// TODO: This probably shouldn't need to be its own class...
 export class LapsingTrainerItemReward extends TrainerItemReward {
   apply(): boolean {
     return globalScene.trainerItems.add(this.itemId, allTrainerItems[this.itemId].getMaxStackCount());

--- a/src/items/trainer-item-attr.ts
+++ b/src/items/trainer-item-attr.ts
@@ -23,6 +23,11 @@ export type TrainerItemRecord<Attrs extends TrainerItemAttr> = {
 
 /** 
  * Abstract base class for trainer item attributes.
+ *
+ * A single {@linkcode TrainerItem} instance can have any number of attributes per effect,
+ * in a similar manner to {@linkcode AbAttr}s and {@linkcode MoveAttr}s.
+ * @typeParam E - The {@linkcode TrainerItemEffect} this attribute applies to.
+ * Should not be a union.
  */
 export abstract class TrainerItemAttr<out E extends TrainerItemEffect = TrainerItemEffect> {
   /**

--- a/src/items/trainer-item-attr.ts
+++ b/src/items/trainer-item-attr.ts
@@ -51,10 +51,11 @@ export abstract class TrainerItemAttr<out E extends TrainerItemEffect = TrainerI
   /**
    * Check whether this attribute's effect should be allowed to trigger.
    * @param params - The parameters for this effect
+   * @param manager - A reference to the {@linkcode TrainerItemManager} for the given side of the field; can be discarded if not needed
    * @returns Whether this attribute's effect should be applied; defaults to `true` if not overridden
    */
   // biome-ignore lint/correctness/noUnusedFunctionParameters: pseudo-abstract method
-  public shouldApply(...params: Parameters<this["apply"]>): boolean {
+  public shouldApply(...[params, manager]: Parameters<this["apply"]>): boolean {
     return true;
   }
 
@@ -62,7 +63,7 @@ export abstract class TrainerItemAttr<out E extends TrainerItemEffect = TrainerI
    * Apply this attribute's effect. \
    * Called if and only if {@linkcode shouldApply} returns `true`.
    * @param params - The parameters for this effect
-   * @param manager - A reference to the {@linkcode TrainerItemManager} for the parent item; can be discarded if not needed
+   * @param manager - A reference to the {@linkcode TrainerItemManager} for the given side of the field; can be discarded if not needed
    */
   public abstract apply(params: TrainerItemEffectParamMap[E], manager: TrainerItemManager): void;
 }

--- a/src/items/trainer-item-attr.ts
+++ b/src/items/trainer-item-attr.ts
@@ -1,0 +1,66 @@
+import { allTrainerItems } from "#data/data-lists";
+import type { TrainerItemEffect } from "#enums/trainer-item-effect";
+import type { TrainerItemId } from "#enums/trainer-item-id";
+import type { TrainerItem } from "#items/trainer-item";
+import type { TrainerItemManager } from "#items/trainer-item-manager";
+import type { TrainerItemEffectParamMap } from "#types/trainer-item-parameter";
+
+/**
+ * Type matching each {@linkcode TrainerItemEffect} to the subset of `Attrs` that can apply said effect. \
+ * Any effects absent from all `Attrs` will map to an empty array.
+ */
+export type TrainerItemRecord<Attrs extends TrainerItemAttr> = {
+  readonly [E in TrainerItemEffect]: [Extract<Attrs, TrainerItemAttr<E>>] extends [never]
+    ? readonly []
+    : readonly Extract<Attrs, TrainerItemAttr<E>>[];
+};
+
+export type WithManager<T extends object> = T & { readonly manager: TrainerItemManager };
+
+export abstract class TrainerItemAttr<out E extends TrainerItemEffect = TrainerItemEffect> {
+  /**
+   * The {@linkcode TrainerItemEffect} this attribute handles.
+   * Should not be a union.
+   * @remarks
+   * Used by {@linkcode TrainerItemBuilder} to sort items by effect.
+   */
+
+  public abstract readonly effect: E;
+
+  /**
+   * The {@linkcode TrainerItemId} associated with this attribute.
+   *
+   * Set by {@linkcode TrainerItemBuilder} during attribute initialization,
+   * and exists solely to allow attributes to identify the item they belong to for message generation and similar purposes.
+   * @sealed
+   */
+  protected readonly type!: TrainerItemId;
+
+  /**
+   * @returns A reference to the {@linkcode TrainerItem} instance to which this attribute is attached.
+   * @sealed
+   */
+  protected get item(): TrainerItem {
+    // Type assertion is necessary to avoid circular type dependency issues, but this is guaranteed to be correct
+    // since the builder sets the attribute's `type` to the correct value at runtime.
+    return allTrainerItems[this.type] as TrainerItem;
+  }
+
+  /**
+   * Check whether this attribute's effect should be allowed to trigger.
+   * @param params - The parameters for this effect
+   * @returns Whether this attribute's effect should be applied; defaults to `true` if not overridden
+   */
+  // biome-ignore lint/correctness/noUnusedFunctionParameters: pseudo-abstract method
+  public shouldApply(...params: Parameters<this["apply"]>): boolean {
+    return true;
+  }
+
+  /**
+   * Apply this attribute's effect. \
+   * Called if and only if {@linkcode shouldApply} returns `true`.
+   * @param params - The parameters for this effect
+   * @param manager - A reference to the {@linkcode TrainerItemManager} for the parent item; can be discarded if not needed
+   */
+  public abstract apply(params: TrainerItemEffectParamMap[E], manager: TrainerItemManager): void;
+}

--- a/src/items/trainer-item-attr.ts
+++ b/src/items/trainer-item-attr.ts
@@ -4,29 +4,22 @@ import type { TrainerItemId } from "#enums/trainer-item-id";
 import type { TrainerItem } from "#items/trainer-item";
 import type { TrainerItemManager } from "#items/trainer-item-manager";
 import type { TrainerItemEffectParamMap } from "#types/trainer-item-parameter";
+import type { IsEqual, IsUnion, NonEmptyTuple } from "type-fest";
 
 /**
  * Type matching each {@linkcode TrainerItemEffect} to the subset of `Attrs` that can apply said effect. \
  * Any effects absent from all `Attrs` will map to an empty array.
+ * @package
+ * @remarks
+ * We cannot outright remove mismatched attributes from the object (or set them to `undefined`/`never`) due to breaking the covariance of `TrainerItem`.
  */
 export type TrainerItemRecord<Attrs extends TrainerItemAttr> = {
   readonly [E in TrainerItemEffect]: [Extract<Attrs, TrainerItemAttr<E>>] extends [never]
     ? readonly []
-    : readonly Extract<Attrs, TrainerItemAttr<E>>[];
+    : NonEmptyTuple<Extract<Attrs, TrainerItemAttr<E>>>;
 };
 
-export type WithManager<T extends object> = T & { readonly manager: TrainerItemManager };
-
 export abstract class TrainerItemAttr<out E extends TrainerItemEffect = TrainerItemEffect> {
-  /**
-   * The {@linkcode TrainerItemEffect} this attribute handles.
-   * Should not be a union.
-   * @remarks
-   * Used by {@linkcode TrainerItemBuilder} to sort items by effect.
-   */
-
-  public abstract readonly effect: E;
-
   /**
    * The {@linkcode TrainerItemId} associated with this attribute.
    *
@@ -45,6 +38,15 @@ export abstract class TrainerItemAttr<out E extends TrainerItemEffect = TrainerI
     // since the builder sets the attribute's `type` to the correct value at runtime.
     return allTrainerItems[this.type] as TrainerItem;
   }
+
+  /**
+   * The {@linkcode TrainerItemEffect} this attribute handles. \
+   * Used by {@linkcode TrainerItemBuilder} to sort items by effect, and is otherwise unused.
+   * @remarks
+   * This will resolve to `never` if `E` is a union, which is desirable since attributes should not be able to apply to multiple effects.
+   */
+  // add explicit bypass for base class (since `TrainerItemEffect` is itself a union)
+  public abstract readonly effect: IsEqual<E, TrainerItemEffect> extends true ? E : IsUnion<E> extends true ? never : E;
 
   /**
    * Check whether this attribute's effect should be allowed to trigger.

--- a/src/items/trainer-item-attr.ts
+++ b/src/items/trainer-item-attr.ts
@@ -1,10 +1,12 @@
-import { allTrainerItems } from "#data/data-lists";
+import type { AbAttr } from "#abilities/ab-attrs";import { allTrainerItems } from "#data/data-lists";
 import type { TrainerItemEffect } from "#enums/trainer-item-effect";
 import type { TrainerItemId } from "#enums/trainer-item-id";
 import type { TrainerItem } from "#items/trainer-item";
 import type { TrainerItemManager } from "#items/trainer-item-manager";
+import type { MoveAttr } from "#types/move-types";
 import type { TrainerItemEffectParamMap } from "#types/trainer-item-parameter";
 import type { IsEqual, IsUnion, NonEmptyTuple } from "type-fest";
+
 
 /**
  * Type matching each {@linkcode TrainerItemEffect} to the subset of `Attrs` that can apply said effect. \
@@ -19,6 +21,9 @@ export type TrainerItemRecord<Attrs extends TrainerItemAttr> = {
     : NonEmptyTuple<Extract<Attrs, TrainerItemAttr<E>>>;
 };
 
+/** 
+ * Abstract base class for trainer item attributes.
+ */
 export abstract class TrainerItemAttr<out E extends TrainerItemEffect = TrainerItemEffect> {
   /**
    * The {@linkcode TrainerItemId} associated with this attribute.

--- a/src/items/trainer-item-builder.ts
+++ b/src/items/trainer-item-builder.ts
@@ -2,6 +2,7 @@ import { TrainerItemEffect } from "#enums/trainer-item-effect";
 import type { TrainerItemId } from "#enums/trainer-item-id";
 import { TrainerItem } from "#items/trainer-item";
 import type { TrainerItemAttr, TrainerItemRecord } from "#items/trainer-item-attr";
+import type { DataMap } from "#types/common";
 import type { ErrorType } from "#types/error-type";
 import type { Mutable } from "#types/type-helpers";
 import type i18next from "i18next";
@@ -25,20 +26,28 @@ import type { Constructor } from "type-fest";
  */
 export class TrainerItemBuilder<Attrs extends TrainerItemAttr = never> {
   public readonly id: TrainerItemId;
-  /** @defaultValue `1` */
   public readonly maxStackCount: number;
 
-  /** Whether the item should lapse over time, decreasing its stack count each wave until fully depleted. */
+  /**
+   * Whether the item should lapse over time, decreasing its stack count each wave until fully depleted.
+   * @defaultValue `false`
+   */
   private isLapsing?: boolean;
 
   private nameParams?: Parameters<typeof i18next.t>;
   private descriptionParams?: Parameters<typeof i18next.t>;
   private icon?: string;
 
-  /** A `Map` matching effects to their corresponding attributes. */
-  private readonly attrMap: Map<TrainerItemEffect, TrainerItemAttr[]> = new Map(
-    Object.values(TrainerItemEffect).map(effect => [effect, []]),
-  );
+  /**
+   * A `DataMap` matching effects to their corresponding (potentially empty) attribute lists.
+   * @remarks
+   * While it is not strictly necessary to populate unused effects with empty arrays, doing so ensures our runtime behaviour
+   * matches the type of `TrainerItemRecord<Attrs>` (in which empty arrays are needed to preserve covariance).
+   */
+  private readonly attrMap = new Map(Object.values(TrainerItemEffect).map(effect => [effect, []])) as DataMap<
+    TrainerItemEffect,
+    TrainerItemAttr[]
+  >;
 
   constructor(id: TrainerItemId, maxStackCount = 1) {
     this.id = id;
@@ -74,6 +83,7 @@ export class TrainerItemBuilder<Attrs extends TrainerItemAttr = never> {
   // #endregion Attributes
 
   // #region Flags
+
   /**
    * Make this item lapse over time, losing stacks once per wave until removed.
    * @returns `this`
@@ -87,16 +97,37 @@ export class TrainerItemBuilder<Attrs extends TrainerItemAttr = never> {
 
   // #region Localization
 
+  /**
+   * Set this item's name localization parameters.
+   * @param params - The parameters to pass to `i18next.t` when localizing this item's name
+   * @returns `this`
+   * @remarks
+   * If this method is not called, the item will use the default localization key provided by `TrainerItemBase`.
+   */
   public name(...params: Parameters<typeof i18next.t>): this {
     this.nameParams = params;
     return this;
   }
 
+  /**
+   * Set this item's description localization parameters.
+   * @param params - The parameters to pass to `i18next.t` when localizing this item's description
+   * @returns `this`
+   * @remarks
+   * If this method is not called, the item will use the default localization key provided by `TrainerItemBase`.
+   */
   public description(...params: Parameters<typeof i18next.t>): this {
     this.descriptionParams = params;
     return this;
   }
 
+  /**
+   * Set this item's icon name.
+   * @param iconName - The name of the icon to use for this item
+   * @returns `this`
+   * @remarks
+   * If this method is not called, the item will use the default icon provided by `TrainerItemBase`.
+   */
   public iconName(iconName: string): this {
     this.icon = iconName;
     return this;
@@ -104,19 +135,16 @@ export class TrainerItemBuilder<Attrs extends TrainerItemAttr = never> {
 
   // #endregion Builder code
 
-  // TODO: Add `lapsing` flag and corresponding builder method
-
   /**
    * Build a new {@linkcode TrainerItem} with the stored attributes and flags.
    * @returns A fully-typed `TrainerItem` with all registered attributes.
    * @remarks
    * This will resolve to `never` if no attributes have been registered.
    */
-  // TODO: Do we want to allow 0-item builds (and make them cosmetic?)
   public build(): [Attrs] extends [never]
     ? ErrorType<"Cannot create a TrainerItem with no attributes!">
     : TrainerItem<Attrs>;
-  // NB: The implementation signature needs to return a union here to satisfy TypeScript, but we never actually return one ourselves
+  // NB: The implementation signature needs to return a union containing ErrorType to satisfy TypeScript, but we never actually return one ourselves
   public build(): ErrorType<"Cannot create a TrainerItem with no attributes!"> | TrainerItem<Attrs> {
     // @ts-expect-error - TypeScript doesn't support friend classes, so this is the closest we can get to
     // ensuring `TrainerItem` is only constructed by its corresponding builder.

--- a/src/items/trainer-item-builder.ts
+++ b/src/items/trainer-item-builder.ts
@@ -11,7 +11,7 @@ import type { Constructor } from "type-fest";
  * Builder class for {@linkcode TrainerItem} instances.
  *
  * Accumulates {@linkcode TrainerItemAttr} instances via {@linkcode TrainerItemBuilder.attr | attr},
- * before transforming them into a concrete `TrainerItem` subclass with {@linkcode TrainerItemBuilder.build | build}.
+ * before transforming them into a concrete `TrainerItem` instance with {@linkcode TrainerItemBuilder.build | build}.
  *
  * @typeParam Attrs - A union of all the {@linkcode TrainerItemAttr}s registered so far.
  *
@@ -28,15 +28,12 @@ export class TrainerItemBuilder<Attrs extends TrainerItemAttr = never> {
   /** @defaultValue `1` */
   public readonly maxStackCount: number;
 
-  private isTransferable = true;
-  private isStealable = true;
-  private isSuppressable = true;
+  /** Whether the item should lapse over time, decreasing its stack count each wave until fully depleted. */
+  private isLapsing?: boolean;
 
   private nameParams?: Parameters<typeof i18next.t>;
   private descriptionParams?: Parameters<typeof i18next.t>;
   private icon?: string;
-  /** Whether the item is a `LapsingTrainerItem`. */
-  private lapsing?: boolean;
 
   /** A `Map` matching effects to their corresponding attributes. */
   private readonly attrMap: Map<TrainerItemEffect, TrainerItemAttr[]> = new Map(
@@ -77,31 +74,12 @@ export class TrainerItemBuilder<Attrs extends TrainerItemAttr = never> {
   // #endregion Attributes
 
   // #region Flags
-
   /**
-   * Prevent this item from being transferred to another {@linkcode Pokemon}.
+   * Make this item lapse over time, losing stacks once per wave until removed.
    * @returns `this`
    */
-  public untransferable(): this {
-    this.isTransferable = false;
-    return this;
-  }
-
-  /**
-   * Prevent this item from being stolen by another {@linkcode Pokemon}.
-   * @returns `this`
-   */
-  public unstealable(): this {
-    this.isStealable = false;
-    return this;
-  }
-
-  /**
-   * Prevent this item's effects from being suppressed by moves or abilities.
-   * @returns `this`
-   */
-  public unsuppressable(): this {
-    this.isSuppressable = false;
+  public lapsing(): this {
+    this.isLapsing = true;
     return this;
   }
 
@@ -150,6 +128,7 @@ export class TrainerItemBuilder<Attrs extends TrainerItemAttr = never> {
       nameParams: this.nameParams,
       descriptionParams: this.descriptionParams,
       iconName: this.icon,
+      lapsing: this.isLapsing,
     });
     return item;
   }

--- a/src/items/trainer-item-builder.ts
+++ b/src/items/trainer-item-builder.ts
@@ -26,7 +26,7 @@ import type { Constructor } from "type-fest";
  */
 export class TrainerItemBuilder<Attrs extends TrainerItemAttr = never> {
   public readonly id: TrainerItemId;
-  public readonly maxStackCount: number;
+  public readonly maxStackCount: number | (() => number);
 
   /**
    * Whether the item should lapse over time, decreasing its stack count each wave until fully depleted.
@@ -49,7 +49,12 @@ export class TrainerItemBuilder<Attrs extends TrainerItemAttr = never> {
     TrainerItemAttr[]
   >;
 
-  constructor(id: TrainerItemId, maxStackCount = 1) {
+  /**
+   * Create a new `TrainerItemBuilder`.
+   * @param id - The {@linkcode TrainerItemId} of the item to build
+   * @param maxStackCount - The maximum stack count of the item to build, or a function that returns it
+   */
+  constructor(id: TrainerItemId, maxStackCount: number | (() => number)) {
     this.id = id;
     this.maxStackCount = maxStackCount;
   }

--- a/src/items/trainer-item-builder.ts
+++ b/src/items/trainer-item-builder.ts
@@ -1,0 +1,162 @@
+import { TrainerItemEffect } from "#enums/trainer-item-effect";
+import type { TrainerItemId } from "#enums/trainer-item-id";
+import { TrainerItem } from "#items/trainer-item";
+import type { TrainerItemAttr, TrainerItemRecord } from "#items/trainer-item-attr";
+import type { ErrorType } from "#types/error-type";
+import type { Mutable } from "#types/type-helpers";
+import type i18next from "i18next";
+import type { Constructor } from "type-fest";
+
+/**
+ * Builder class for {@linkcode TrainerItem} instances.
+ *
+ * Accumulates {@linkcode TrainerItemAttr} instances via {@linkcode TrainerItemBuilder.attr | attr},
+ * before transforming them into a concrete `TrainerItem` subclass with {@linkcode TrainerItemBuilder.build | build}.
+ *
+ * @typeParam Attrs - A union of all the {@linkcode TrainerItemAttr}s registered so far.
+ *
+ * @example
+ * ```ts
+ * new TrainerItemBuilder(TrainerItemId.AMULET_COIN, 3) //
+ *   .attr(MoneyMultiplierTrainerItemAttr)
+ *   .build()
+ * ```
+ * @sealed
+ */
+export class TrainerItemBuilder<Attrs extends TrainerItemAttr = never> {
+  public readonly id: TrainerItemId;
+  /** @defaultValue `1` */
+  public readonly maxStackCount: number;
+
+  private isTransferable = true;
+  private isStealable = true;
+  private isSuppressable = true;
+
+  private nameParams?: Parameters<typeof i18next.t>;
+  private descriptionParams?: Parameters<typeof i18next.t>;
+  private icon?: string;
+  /** Whether the item is a `LapsingTrainerItem`. */
+  private lapsing?: boolean;
+
+  /** A `Map` matching effects to their corresponding attributes. */
+  private readonly attrMap: Map<TrainerItemEffect, TrainerItemAttr[]> = new Map(
+    Object.values(TrainerItemEffect).map(effect => [effect, []]),
+  );
+
+  constructor(id: TrainerItemId, maxStackCount = 1) {
+    this.id = id;
+    this.maxStackCount = maxStackCount;
+  }
+
+  // #region Attributes
+
+  /**
+   * Instantiate a {@linkcode TrainerItemAttr} and register it on this builder.
+   * @param attrType - The constructor of a {@linkcode TrainerItemAttr} subclass to instantiate and register
+   * @param args - The arguments used to instantiate `attrType`
+   * @returns `this` with `Attr` added to the effect union.
+   */
+  public attr<C extends Constructor<TrainerItemAttr>>(
+    attrType: C,
+    ...args: ConstructorParameters<C>
+  ): TrainerItemBuilder<Attrs | InstanceType<C>>;
+  public attr<C extends Constructor<TrainerItemAttr>>(attrType: C, ...args: ConstructorParameters<C>): this {
+    this.addAttr(new attrType(...args));
+    return this;
+  }
+
+  /** Internal helper method to add an attribute to the builder. */
+  private addAttr(attr: TrainerItemAttr): void {
+    (attr as Mutable<TrainerItemAttr>)["type"] = this.id;
+    const { effect } = attr;
+    // bang is safe since the constructor initializes the map with all effects set to empty arrays
+    const existing = this.attrMap.get(effect)!;
+    existing.push(attr);
+  }
+
+  // #endregion Attributes
+
+  // #region Flags
+
+  /**
+   * Prevent this item from being transferred to another {@linkcode Pokemon}.
+   * @returns `this`
+   */
+  public untransferable(): this {
+    this.isTransferable = false;
+    return this;
+  }
+
+  /**
+   * Prevent this item from being stolen by another {@linkcode Pokemon}.
+   * @returns `this`
+   */
+  public unstealable(): this {
+    this.isStealable = false;
+    return this;
+  }
+
+  /**
+   * Prevent this item's effects from being suppressed by moves or abilities.
+   * @returns `this`
+   */
+  public unsuppressable(): this {
+    this.isSuppressable = false;
+    return this;
+  }
+
+  // #endregion Flags
+
+  // #region Localization
+
+  public name(...params: Parameters<typeof i18next.t>): this {
+    this.nameParams = params;
+    return this;
+  }
+
+  public description(...params: Parameters<typeof i18next.t>): this {
+    this.descriptionParams = params;
+    return this;
+  }
+
+  public iconName(iconName: string): this {
+    this.icon = iconName;
+    return this;
+  }
+
+  // #endregion Builder code
+
+  // TODO: Add `lapsing` flag and corresponding builder method
+
+  /**
+   * Build a new {@linkcode TrainerItem} with the stored attributes and flags.
+   * @returns A fully-typed `TrainerItem` with all registered attributes.
+   * @remarks
+   * This will resolve to `never` if no attributes have been registered.
+   */
+  // TODO: Do we want to allow 0-item builds (and make them cosmetic?)
+  public build(): [Attrs] extends [never]
+    ? ErrorType<"Cannot create a TrainerItem with no attributes!">
+    : TrainerItem<Attrs>;
+  // NB: The implementation signature needs to return a union here to satisfy TypeScript, but we never actually return one ourselves
+  public build(): ErrorType<"Cannot create a TrainerItem with no attributes!"> | TrainerItem<Attrs> {
+    // @ts-expect-error - TypeScript doesn't support friend classes, so this is the closest we can get to
+    // ensuring `TrainerItem` is only constructed by its corresponding builder.
+    // NB: The type specifier here is required due to TS resolving this as `any`
+    const item: TrainerItem<Attrs> = new TrainerItem({
+      type: this.id,
+      effects: this.buildRecord(),
+      maxStackCount: this.maxStackCount,
+      nameParams: this.nameParams,
+      descriptionParams: this.descriptionParams,
+      iconName: this.icon,
+    });
+    return item;
+  }
+
+  private buildRecord(): TrainerItemRecord<Attrs> {
+    // TODO: Consider removing type assertion after `Object.keys` PR
+    return Object.fromEntries(this.attrMap.entries()) as unknown as TrainerItemRecord<Attrs>;
+  }
+  // #endregion Builder code
+}

--- a/src/items/trainer-item.ts
+++ b/src/items/trainer-item.ts
@@ -37,9 +37,9 @@ export abstract class TrainerItemBase {
   }
 
   createIcon(stackCount: number): Phaser.GameObjects.Container {
-    const container = globalScene.add.container();
-
-    container.add(globalScene.add.sprite(0, 12, "items").setFrame(this.iconName).setOrigin(0, 0.5));
+    // TODO: This could be restructured to merge these 2 code paths more, I just copied the code from `LapsingTrainerItem`
+    const item = globalScene.add.sprite(0, 12, "items").setFrame(this.iconName).setOrigin(0, 0.5);
+    const container = globalScene.add.container().add(item);
 
     const stackText = this.getIconStackText(stackCount);
     if (stackText) {
@@ -49,9 +49,25 @@ export abstract class TrainerItemBase {
     return container;
   }
 
-  public getIconStackText(stackCount: number): Phaser.GameObjects.BitmapText | null {
+  private getIconStackText(stackCount: number): Phaser.GameObjects.BitmapText | Phaser.GameObjects.Text | undefined {
+    if (this.isLapsing) {
+      // Generate the text with a linearly interpolated hue based on remaining duration
+      // Ranges from #f2dbd9 / #822017 (≈ 0% duration) to #d9f2db / #178220 (100% duration)
+      const hue = Math.floor(120 * (stackCount / this.getMaxStackCount()) + 5);
+      const typeHex = hslToHex(hue, 0.5, 0.9);
+      const strokeHex = hslToHex(hue, 0.7, 0.3);
+
+      return addTextObject(27, 0, stackCount.toString(), TextStyle.PARTY, {
+        fontSize: "66px",
+        color: typeHex,
+      })
+        .setShadow(0, 0)
+        .setStroke(strokeHex, 16)
+        .setOrigin(1, 0);
+    }
+
     if (this.getMaxStackCount() === 1 || stackCount < 1) {
-      return null;
+      return;
     }
 
     const text = globalScene.add
@@ -148,25 +164,4 @@ export abstract class TrainerItem<out Attrs extends TrainerItemAttr = TrainerIte
 // TODO: Rework to not be its own class (either make it a mixin or have `TrainerItemBase` handle things itself)
 export class LapsingTrainerItem extends TrainerItem {
   public readonly isLapsing = true;
-
-  public override createIcon(battleCount: number): Phaser.GameObjects.Container {
-    const item = globalScene.add.sprite(0, 12, "items").setFrame(this.iconName).setOrigin(0, 0.5);
-
-    // Linear interpolation on hue
-    const hue = Math.floor(120 * (battleCount / this.getMaxStackCount()) + 5);
-
-    // Generates the color hex code with a constant saturation and lightness but varying hue
-    const typeHex = hslToHex(hue, 0.5, 0.9);
-    const strokeHex = hslToHex(hue, 0.7, 0.3);
-
-    const battleCountText = addTextObject(27, 0, battleCount.toString(), TextStyle.PARTY, {
-      fontSize: "66px",
-      color: typeHex,
-    })
-      .setShadow(0, 0)
-      .setStroke(strokeHex, 16)
-      .setOrigin(1, 0);
-
-    return globalScene.add.container(0, 0, [item, battleCountText]);
-  }
 }

--- a/src/items/trainer-item.ts
+++ b/src/items/trainer-item.ts
@@ -7,7 +7,7 @@ import type { TrainerItemBuilder } from "#items/trainer-item-builder";
 import type { TrainerItemManager } from "#items/trainer-item-manager";
 import type { TrainerItemEffectParamMap } from "#types/trainer-item-parameter";
 import { addTextObject } from "#ui/text";
-import { hslToHex } from "#utils/common";
+import { hslToHex } from "#utils/color-utils";
 import i18next from "i18next";
 
 export abstract class TrainerItemBase {
@@ -17,7 +17,7 @@ export abstract class TrainerItemBase {
    * Whether this item will be removed after a set number of turns (using its stack count as a "timer" of sorts).
    * @defaultValue `false`
    */
-  public readonly isLapsing = false;
+  public readonly isLapsing: boolean;
 
   constructor(type: TrainerItemId, maxStackCount: number, isLapsing = false) {
     this.type = type;
@@ -112,6 +112,7 @@ export abstract class TrainerItem<out Attrs extends TrainerItemAttr = TrainerIte
   public readonly effects: TrainerItemRecord<Attrs>;
 
   // #region Localization
+
   /**
    * Optional parameters used to localize this item's name.
    * If omitted, will use the default implementation provided from {@linkcode TrainerItemBase}.
@@ -135,16 +136,17 @@ export abstract class TrainerItem<out Attrs extends TrainerItemAttr = TrainerIte
   public override get iconName(): string {
     return this.customIconName ?? super.iconName;
   }
+
   // #endregion Localization
 
   protected constructor({
     type,
     effects,
+    lapsing = false,
     maxStackCount = 1,
     nameParams,
     descriptionParams,
     iconName,
-    lapsing = false,
   }: {
     type: TrainerItemId;
     effects: TrainerItemRecord<Attrs>;

--- a/src/items/trainer-item.ts
+++ b/src/items/trainer-item.ts
@@ -12,16 +12,29 @@ import i18next from "i18next";
 
 export abstract class TrainerItemBase {
   public readonly type: TrainerItemId;
-  public readonly maxStackCount: number;
+
+  /**
+   * Private backing property for `maxStackCount`
+   */
+  // TODO: This is added for the SOLE purpose of supporting endure tokens' dynamic max stack count.
+  readonly #maxStackCount: number | (() => number);
+  public get maxStackCount(): number {
+    return typeof this.#maxStackCount === "function" ? this.#maxStackCount() : this.#maxStackCount;
+  }
+  // TODO: Remove as we now expose the base property
+  getMaxStackCount(): number {
+    return this.maxStackCount;
+  }
+
   /**
    * Whether this item will be removed after a set number of turns (using its stack count as a "timer" of sorts).
    * @defaultValue `false`
    */
   public readonly isLapsing: boolean;
 
-  constructor(type: TrainerItemId, maxStackCount: number, isLapsing = false) {
+  constructor(type: TrainerItemId, maxStackCount: number | (() => number), isLapsing = false) {
     this.type = type;
-    this.maxStackCount = maxStackCount;
+    this.#maxStackCount = maxStackCount;
     this.isLapsing = isLapsing;
   }
 
@@ -37,12 +50,7 @@ export abstract class TrainerItemBase {
     return `${TrainerItemNames[this.type]?.toLowerCase()}`;
   }
 
-  // TODO: Remove and expose the underlying property
-  getMaxStackCount(): number {
-    return this.maxStackCount;
-  }
-
-  createIcon(stackCount: number): Phaser.GameObjects.Container {
+  public createIcon(stackCount: number): Phaser.GameObjects.Container {
     const item = globalScene.add
       .sprite(0, 12, "items") //
       .setFrame(this.iconName)

--- a/src/items/trainer-item.ts
+++ b/src/items/trainer-item.ts
@@ -6,7 +6,6 @@ import type { TrainerItemAttr, TrainerItemRecord } from "#items/trainer-item-att
 import type { TrainerItemBuilder } from "#items/trainer-item-builder";
 import type { TrainerItemManager } from "#items/trainer-item-manager";
 import type { TrainerItemEffectParamMap } from "#types/trainer-item-parameter";
-import type { Mutable } from "#types/type-helpers";
 import { addTextObject } from "#ui/text";
 import { hslToHex } from "#utils/common";
 import i18next from "i18next";
@@ -14,12 +13,16 @@ import i18next from "i18next";
 export abstract class TrainerItemBase {
   public readonly type: TrainerItemId;
   public readonly maxStackCount: number;
-  /** Whether this item will be removed after a set number of turns (using its stack count as a "timer" of sorts). */
-  public readonly isLapsing: boolean = false;
+  /**
+   * Whether this item will be removed after a set number of turns (using its stack count as a "timer" of sorts).
+   * @defaultValue `false`
+   */
+  public readonly isLapsing = false;
 
-  constructor(type: TrainerItemId, maxStackCount = 1) {
+  constructor(type: TrainerItemId, maxStackCount: number, isLapsing = false) {
     this.type = type;
     this.maxStackCount = maxStackCount;
+    this.isLapsing = isLapsing;
   }
 
   public get name(): string {
@@ -151,13 +154,12 @@ export abstract class TrainerItem<out Attrs extends TrainerItemAttr = TrainerIte
     iconName?: string | undefined;
     lapsing?: boolean;
   }) {
-    super(type, maxStackCount);
+    super(type, maxStackCount, lapsing);
 
     this.effects = effects;
     this.nameParams = nameParams;
     this.descriptionParams = descriptionParams;
     this.customIconName = iconName;
-    (this as Mutable<this>).isLapsing = lapsing;
   }
 
   /**

--- a/src/items/trainer-item.ts
+++ b/src/items/trainer-item.ts
@@ -3,8 +3,10 @@ import { TextStyle } from "#enums/text-style";
 import type { TrainerItemEffect } from "#enums/trainer-item-effect";
 import { type TrainerItemId, TrainerItemNames } from "#enums/trainer-item-id";
 import type { TrainerItemAttr, TrainerItemRecord } from "#items/trainer-item-attr";
+import type { TrainerItemBuilder } from "#items/trainer-item-builder";
 import type { TrainerItemManager } from "#items/trainer-item-manager";
 import type { TrainerItemEffectParamMap } from "#types/trainer-item-parameter";
+import type { Mutable } from "#types/type-helpers";
 import { addTextObject } from "#ui/text";
 import { hslToHex } from "#utils/common";
 import i18next from "i18next";
@@ -32,13 +34,16 @@ export abstract class TrainerItemBase {
     return `${TrainerItemNames[this.type]?.toLowerCase()}`;
   }
 
+  // TODO: Remove and expose the underlying property
   getMaxStackCount(): number {
     return this.maxStackCount;
   }
 
   createIcon(stackCount: number): Phaser.GameObjects.Container {
-    // TODO: This could be restructured to merge these 2 code paths more, I just copied the code from `LapsingTrainerItem`
-    const item = globalScene.add.sprite(0, 12, "items").setFrame(this.iconName).setOrigin(0, 0.5);
+    const item = globalScene.add
+      .sprite(0, 12, "items") //
+      .setFrame(this.iconName)
+      .setOrigin(0, 0.5);
     const container = globalScene.add.container().add(item);
 
     const stackText = this.getIconStackText(stackCount);
@@ -81,6 +86,7 @@ export abstract class TrainerItemBase {
     return text;
   }
 
+  // TODO: This is unused
   getScoreMultiplier(): number {
     return 1;
   }
@@ -102,17 +108,56 @@ export abstract class TrainerItem<out Attrs extends TrainerItemAttr = TrainerIte
    */
   public readonly effects: TrainerItemRecord<Attrs>;
 
+  // #region Localization
+  /**
+   * Optional parameters used to localize this item's name.
+   * If omitted, will use the default implementation provided from {@linkcode TrainerItemBase}.
+   */
+  private readonly nameParams?: Parameters<typeof i18next.t> | undefined;
+  /**
+   * Optional parameters used to localize this item's description.
+   * If omitted, will use the default implementation provided from {@linkcode TrainerItemBase}.
+   */
+  private readonly descriptionParams?: Parameters<typeof i18next.t> | undefined;
+  public readonly customIconName?: string | undefined;
+
+  public override get name(): string {
+    return this.nameParams ? i18next.t(...this.nameParams) : super.name;
+  }
+
+  public override get description(): string {
+    return this.descriptionParams ? i18next.t(...this.descriptionParams) : super.description;
+  }
+
+  public override get iconName(): string {
+    return this.customIconName ?? super.iconName;
+  }
+  // #endregion Localization
+
   protected constructor({
     type,
     effects,
     maxStackCount = 1,
+    nameParams,
+    descriptionParams,
+    iconName,
+    lapsing = false,
   }: {
     type: TrainerItemId;
     effects: TrainerItemRecord<Attrs>;
     maxStackCount?: number;
+    nameParams?: Parameters<typeof i18next.t> | undefined;
+    descriptionParams?: Parameters<typeof i18next.t> | undefined;
+    iconName?: string | undefined;
+    lapsing?: boolean;
   }) {
     super(type, maxStackCount);
+
     this.effects = effects;
+    this.nameParams = nameParams;
+    this.descriptionParams = descriptionParams;
+    this.customIconName = iconName;
+    (this as Mutable<this>).isLapsing = lapsing;
   }
 
   /**
@@ -161,7 +206,6 @@ export abstract class TrainerItem<out Attrs extends TrainerItemAttr = TrainerIte
   }
 }
 
-// TODO: Rework to not be its own class (either make it a mixin or have `TrainerItemBase` handle things itself)
-export class LapsingTrainerItem extends TrainerItem {
-  public readonly isLapsing = true;
+export class MarkerTrainerItem extends TrainerItemBase {
+  private declare readonly _: never;
 }

--- a/src/items/trainer-item.ts
+++ b/src/items/trainer-item.ts
@@ -1,21 +1,19 @@
 import { globalScene } from "#app/global-scene";
 import { TextStyle } from "#enums/text-style";
-import { TrainerItemEffect } from "#enums/trainer-item-effect";
+import type { TrainerItemEffect } from "#enums/trainer-item-effect";
 import { type TrainerItemId, TrainerItemNames } from "#enums/trainer-item-id";
+import type { TrainerItemAttr, TrainerItemRecord } from "#items/trainer-item-attr";
 import type { TrainerItemManager } from "#items/trainer-item-manager";
-import type { NumberHolderParams, PreserveBerryParams } from "#types/trainer-item-parameter";
+import type { TrainerItemEffectParamMap } from "#types/trainer-item-parameter";
 import { addTextObject } from "#ui/text";
 import { hslToHex } from "#utils/common";
 import i18next from "i18next";
 
-// TODO: Give this the subclass treatment for `HeldItem` - splitting it into "marker" held items and ones that can be applied
-// (this would resolve some type errors)
-export class TrainerItem {
-  //  public pokemonId: number;
+export abstract class TrainerItemBase {
   public readonly type: TrainerItemId;
   public readonly maxStackCount: number;
+  /** Whether this item will be removed after a set number of turns (using its stack count as a "timer" of sorts). */
   public readonly isLapsing: boolean = false;
-  public readonly effects: readonly TrainerItemEffect[] = [];
 
   constructor(type: TrainerItemId, maxStackCount = 1) {
     this.type = type;
@@ -72,10 +70,86 @@ export class TrainerItem {
   }
 }
 
+/**
+ * Class for all non-marker trainer items
+ * (i.e. ones that can have their effects applied during or outside of battle).
+ *
+ * @typeParam Attrs - A union of {@linkcode TrainerItemAttr}s that this class supports.
+ * @see {@linkcode TrainerItemBuilder}
+ * @privateRemarks
+ * While exposing the exact kinds of attributes this class supports technically breaks encapsulation,
+ * this is required for existing code to work without excessive type assertions.
+ */
+export abstract class TrainerItem<out Attrs extends TrainerItemAttr = TrainerItemAttr> extends TrainerItemBase {
+  /**
+   * An object matching each supported {@linkcode TrainerItemEffect} to the attributes that implement said effect.
+   */
+  public readonly effects: TrainerItemRecord<Attrs>;
+
+  protected constructor({
+    type,
+    effects,
+    maxStackCount = 1,
+  }: {
+    type: TrainerItemId;
+    effects: TrainerItemRecord<Attrs>;
+    maxStackCount?: number;
+  }) {
+    super(type, maxStackCount);
+    this.effects = effects;
+  }
+
+  /**
+   * Check whether this item handles the given effect at runtime.
+   * Narrows the item's effect set to include `E`.
+   * @param effect - The {@linkcode TrainerItemEffect} to check
+   * @returns Whether this item has at least 1 attribute for `effect`
+   * @sealed
+   */
+  public hasEffect<E extends TrainerItemEffect>(effect: E): this is TrainerItem<Attrs | TrainerItemAttr<E>> {
+    return this.effects[effect].length > 0;
+  }
+
+  /**
+   * Apply all of this item's attributes that pertain to the given effect, subject to their individual
+   * {@linkcode TrainerItemAttr.shouldApply | shouldApply} conditions.
+   * @param effect - The {@linkcode TrainerItemEffect | effect} to apply
+   * @param params - The parameters to pass to the item attributes' `apply` methods
+   * @remarks
+   * The execution order of multiple attributes is not guaranteed and should not be relied upon.
+   * @sealed
+   */
+  public apply<E extends Attrs["effect"]>(
+    effect: E,
+    params: TrainerItemEffectParamMap[E],
+    manager: TrainerItemManager,
+  ): void {
+    for (const attr of this.getAttrs(effect) as readonly TrainerItemAttr<E>[]) {
+      if (attr.shouldApply(params, manager)) {
+        attr.apply(params, manager);
+      }
+    }
+  }
+
+  /**
+   * Retrieve all attributes of this item pertaining to the given effect.
+   * @param effect - The {@linkcode TrainerItemEffect | effect} to retrieve
+   * @returns An array containing all attributes this item has for `effect`.
+   * Is guaranteed to be non-empty for properly constructed `TrainerItem`s.
+   * @remarks
+   * The order of the attributes within the returned array is not guaranteed and should not be relied upon.
+   * @sealed
+   */
+  public getAttrs<E extends Attrs["effect"]>(effect: E): readonly Extract<Attrs, TrainerItemAttr<E>>[] {
+    return this.effects[effect];
+  }
+}
+
+// TODO: Rework to not be its own class (either make it a mixin or have `TrainerItemBase` handle things itself)
 export class LapsingTrainerItem extends TrainerItem {
   public readonly isLapsing = true;
 
-  public createIcon(battleCount: number): Phaser.GameObjects.Container {
+  public override createIcon(battleCount: number): Phaser.GameObjects.Container {
     const item = globalScene.add.sprite(0, 12, "items").setFrame(this.iconName).setOrigin(0, 0.5);
 
     // Linear interpolation on hue
@@ -94,134 +168,5 @@ export class LapsingTrainerItem extends TrainerItem {
       .setOrigin(1, 0);
 
     return globalScene.add.container(0, 0, [item, battleCountText]);
-  }
-}
-
-// Candy Jar
-export class LevelIncrementBoosterTrainerItem extends TrainerItem {
-  public effects: TrainerItemEffect[] = [TrainerItemEffect.LEVEL_INCREMENT_BOOSTER];
-
-  apply(manager: TrainerItemManager, params: NumberHolderParams) {
-    const count = params.numberHolder;
-    const stack = manager.getStack(this.type);
-    count.value += stack;
-  }
-}
-
-// Berry Pouch
-export class PreserveBerryTrainerItem extends TrainerItem {
-  public effects: TrainerItemEffect[] = [TrainerItemEffect.PRESERVE_BERRY];
-
-  public apply(manager: TrainerItemManager, params: PreserveBerryParams) {
-    const stack = manager.getStack(this.type);
-    params.doPreserve.value ||= params.pokemon.randBattleSeedInt(10) < stack * 3;
-  }
-}
-
-// Healing Charm
-export class HealingBoosterTrainerItem extends TrainerItem {
-  public effects: readonly TrainerItemEffect[] = [TrainerItemEffect.HEALING_BOOSTER];
-  private readonly multiplier: number;
-
-  constructor(type: TrainerItemId, multiplier: number, stackCount?: number) {
-    super(type, stackCount);
-
-    this.multiplier = multiplier;
-  }
-
-  public apply(manager: TrainerItemManager, params: NumberHolderParams) {
-    const healingMultiplier = params.numberHolder;
-    const stack = manager.getStack(this.type);
-    healingMultiplier.value *= 1 + (this.multiplier - 1) * stack;
-  }
-}
-
-// Exp Booster
-export class ExpBoosterTrainerItem extends TrainerItem {
-  public effects: TrainerItemEffect[] = [TrainerItemEffect.EXP_BOOSTER];
-  private readonly boostPercent: number;
-
-  constructor(type: TrainerItemId, boostPercent: number, stackCount?: number) {
-    super(type, stackCount);
-
-    this.boostPercent = boostPercent;
-  }
-
-  public get description(): string {
-    return i18next.t("modifierType:ModifierType.ExpBoosterModifierType.description", {
-      boostPercent: this.boostPercent,
-    });
-  }
-
-  public apply(manager: TrainerItemManager, params: NumberHolderParams): void {
-    const boost = params.numberHolder;
-    const stack = manager.getStack(this.type);
-    boost.value = Math.floor(boost.value * (1 + stack * this.boostPercent * 0.01));
-  }
-}
-
-export class MoneyMultiplierTrainerItem extends TrainerItem {
-  public effects: readonly TrainerItemEffect[] = [TrainerItemEffect.MONEY_MULTIPLIER];
-
-  apply(manager: TrainerItemManager, params: NumberHolderParams): void {
-    const moneyMultiplier = params.numberHolder;
-    const stack = manager.getStack(this.type);
-    moneyMultiplier.value += Math.floor(moneyMultiplier.value * 0.2 * stack);
-  }
-}
-
-export class HiddenAbilityChanceBoosterTrainerItem extends TrainerItem {
-  public effects: TrainerItemEffect[] = [TrainerItemEffect.HIDDEN_ABILITY_CHANCE_BOOSTER];
-
-  public apply(manager: TrainerItemManager, params: NumberHolderParams): void {
-    const boost = params.numberHolder;
-    const stack = manager.getStack(this.type);
-    boost.value *= Math.pow(2, -1 - stack);
-  }
-}
-
-export class ShinyRateBoosterTrainerItem extends TrainerItem {
-  public effects: TrainerItemEffect[] = [TrainerItemEffect.SHINY_RATE_BOOSTER];
-
-  public apply(manager: TrainerItemManager, params: NumberHolderParams): void {
-    const boost = params.numberHolder;
-    const stack = manager.getStack(this.type);
-    boost.value *= Math.pow(2, 1 + stack);
-  }
-}
-
-export class CriticalCatchChanceBoosterTrainerItem extends TrainerItem {
-  public effects: TrainerItemEffect[] = [TrainerItemEffect.CRITICAL_CATCH_CHANCE_BOOSTER];
-
-  public apply(manager: TrainerItemManager, params: NumberHolderParams): void {
-    const boost = params.numberHolder;
-    const stack = manager.getStack(this.type);
-    boost.value *= 1.5 + stack / 2;
-  }
-}
-
-export class ExtraRewardTrainerItem extends TrainerItem {
-  public effects: TrainerItemEffect[] = [TrainerItemEffect.EXTRA_REWARD];
-
-  public apply(manager: TrainerItemManager, params: NumberHolderParams): void {
-    const count = params.numberHolder;
-    const stack = manager.getStack(this.type);
-    count.value += stack;
-  }
-}
-
-export class HealShopCostTrainerItem extends TrainerItem {
-  public effects: TrainerItemEffect[] = [TrainerItemEffect.HEAL_SHOP_COST];
-  public readonly shopMultiplier: number;
-
-  constructor(type: TrainerItemId, shopMultiplier: number, stackCount?: number) {
-    super(type, stackCount);
-
-    this.shopMultiplier = shopMultiplier;
-  }
-
-  apply(_manager: TrainerItemManager, params: NumberHolderParams): void {
-    const moneyCost = params.numberHolder;
-    moneyCost.value = Math.floor(moneyCost.value * this.shopMultiplier);
   }
 }

--- a/src/items/trainer-items/critical-catch-chance-booster.ts
+++ b/src/items/trainer-items/critical-catch-chance-booster.ts
@@ -1,0 +1,16 @@
+import { TrainerItemEffect } from "#enums/trainer-item-effect";
+import { TrainerItemAttr } from "#items/trainer-item-attr";
+import type { TrainerItemManager } from "#items/trainer-item-manager";
+import type { NumberHolderParams } from "#types/trainer-item-parameter";
+
+export class CriticalCatchChanceBoosterTrainerItemAttr extends TrainerItemAttr<
+  typeof TrainerItemEffect.CRITICAL_CATCH_CHANCE_BOOSTER
+> {
+  public override readonly effect = TrainerItemEffect.CRITICAL_CATCH_CHANCE_BOOSTER;
+
+  public apply(params: NumberHolderParams, manager: TrainerItemManager): void {
+    const boost = params.numberHolder;
+    const stack = manager.getStack(this.type);
+    boost.value *= 1.5 + stack / 2;
+  }
+}

--- a/src/items/trainer-items/critical-catch-chance-booster.ts
+++ b/src/items/trainer-items/critical-catch-chance-booster.ts
@@ -8,8 +8,7 @@ export class CriticalCatchChanceBoosterTrainerItemAttr extends TrainerItemAttr<
 > {
   public override readonly effect = TrainerItemEffect.CRITICAL_CATCH_CHANCE_BOOSTER;
 
-  public apply(params: NumberHolderParams, manager: TrainerItemManager): void {
-    const boost = params.numberHolder;
+  public override apply({ numberHolder: boost }: NumberHolderParams, manager: TrainerItemManager): void {
     const stack = manager.getStack(this.type);
     boost.value *= 1.5 + stack / 2;
   }

--- a/src/items/trainer-items/enemy-tokens.ts
+++ b/src/items/trainer-items/enemy-tokens.ts
@@ -1,8 +1,8 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import { getStatusEffectDescriptor, getStatusEffectHealText } from "#data/status-effect";
+import { getStatusEffectHealText } from "#data/status-effect";
 import { BattlerTagType } from "#enums/battler-tag-type";
-import { StatusEffect } from "#enums/status-effect";
+import type { StatusEffect } from "#enums/status-effect";
 import { TrainerItemEffect } from "#enums/trainer-item-effect";
 import { TrainerItemAttr } from "#items/trainer-item-attr";
 import type { TrainerItemManager } from "#items/trainer-item-manager";
@@ -12,59 +12,84 @@ import i18next from "i18next";
 
 export class EnemyDamageBoosterTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.ENEMY_DAMAGE_BOOSTER> {
   public override readonly effect = TrainerItemEffect.ENEMY_DAMAGE_BOOSTER;
-  public damageBoost = 1.05;
+  /**
+   * The extent to which the attached item should increase outbound damage, expressed as a decimal.
+   * @remarks
+   * Multiple stacks of the same item will each **multiplicatively** increase damage dealt,
+   * resulting in an overall multiplier of `(1+damageBoost)^stacks`.
+   */
+  private readonly damageBoost: number;
 
-  get iconName(): string {
-    return "wl_item_drop";
+  /**
+   * @param damageBoost - The extent to which this item should increase outbound damage, expressed as a decimal.
+   *
+   */
+  constructor(damageBoost: number) {
+    super();
+    this.damageBoost = damageBoost;
   }
-
-  public override apply({ numberHolder: multiplier }: NumberHolderParams, manager: TrainerItemManager): void {
+  public override apply({ numberHolder: damageDealt }: NumberHolderParams, manager: TrainerItemManager): void {
     const stack = manager.getStack(this.type);
-    multiplier.value = toDmgValue(multiplier.value * Math.pow(this.damageBoost, stack));
-  }
-
-  getMaxStackCount(): number {
-    return 999;
+    const multiplier = Math.pow(1 + this.damageBoost, stack);
+    damageDealt.value = toDmgValue(damageDealt.value * multiplier);
   }
 }
 
 export class EnemyDamageReducerTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.ENEMY_DAMAGE_REDUCER> {
   public override readonly effect = TrainerItemEffect.ENEMY_DAMAGE_REDUCER;
-  public damageReduction = 0.975;
+  /**
+   * The extent to which each stack of this item should reduce incoming damage, expressed as a decimal.
+   * @remarks
+   * Multiple stacks of the same item will each **multiplicatively** decrease damage taken,
+   * resulting in an overall multiplier of `(1-damageReduction)^stacks`.
+   */
+  private readonly damageReduction: number;
 
-  get iconName(): string {
-    return "wl_guard_spec";
+  constructor(damageReduction: number) {
+    super();
+    this.damageReduction = damageReduction;
   }
 
-  public override apply({ numberHolder: multiplier }: NumberHolderParams, manager: TrainerItemManager): void {
-    const stack = manager.getStack(this.type);
+  public override apply({ numberHolder: damageTaken }: NumberHolderParams, manager: TrainerItemManager): void {
+    const stackCount = manager.getStack(this.type);
 
-    multiplier.value = toDmgValue(multiplier.value * Math.pow(this.damageReduction, stack));
-  }
-
-  getMaxStackCount(): number {
-    return globalScene.currentBattle.waveIndex < 2000 ? 99 : 999;
+    const multiplier = Math.pow(1 - this.damageReduction, stackCount);
+    damageTaken.value = toDmgValue(damageTaken.value * multiplier);
   }
 }
 
 export class EnemyTurnHealTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.ENEMY_HEAL> {
   public override readonly effect = TrainerItemEffect.ENEMY_HEAL;
-  public healPercent = 2;
+  /**
+   * The portion of the holder's maximum HP the attached item should heal each turn, expressed as a decimal. \
+   * Multiple stacks of the same item will each add to the amount healed,
+   * resulting in an overall heal percentage of `healPercent*stacks`.
+   * Note that this effect can never heal an enemy to full HP.
+   */
+  private readonly healPercent: number;
 
-  get iconName(): string {
-    return "wl_potion";
+  /**
+   * @param healPercent - The portion of the holder's maximum HP the attached item should heal each turn, expressed as a decimal.
+   * Multiple stacks of the same item will each add to the amount healed,
+   * resulting in an overall heal percentage of `healPercent*stacks`.
+   */
+  constructor(healPercent: number) {
+    super();
+    this.healPercent = healPercent;
   }
 
   public override apply({ pokemon: enemyPokemon }: PokemonParams, manager: TrainerItemManager): void {
-    const stack = manager.getStack(this.type);
-
     if (enemyPokemon.isFullHp()) {
       return;
     }
+
+    const stack = manager.getStack(this.type);
+
     globalScene.phaseManager.unshiftNew(
       "PokemonHealPhase",
       enemyPokemon.getBattlerIndex(),
-      Math.max(Math.floor((enemyPokemon.getMaxHp() * this.healPercent * stack) / 100), 1),
+      // TODO: Do we need to round this?
+      Math.max(Math.floor(enemyPokemon.getMaxHp() * this.healPercent * stack), 1),
       i18next.t("modifier:enemyTurnHealApply", {
         pokemonNameWithAffix: getPokemonNameWithAffix(enemyPokemon),
       }),
@@ -82,44 +107,21 @@ export class EnemyAttackStatusEffectChanceTrainerItemAttr extends TrainerItemAtt
 > {
   public override readonly effect = TrainerItemEffect.ENEMY_ATTACK_STATUS_CHANCE;
   public statusEffect: StatusEffect;
+  /** The chance of this token triggering per stack, expressed as a decimal. */
+  private readonly chance: number;
 
-  constructor(statusEffect: StatusEffect) {
+  constructor(statusEffect: StatusEffect, chance: number) {
     super();
 
     this.statusEffect = statusEffect;
-  }
-
-  get iconName(): string {
-    if (this.statusEffect === StatusEffect.POISON) {
-      return "wl_antidote";
-    }
-    if (this.statusEffect === StatusEffect.PARALYSIS) {
-      return "wl_paralyze_heal";
-    }
-    if (this.statusEffect === StatusEffect.BURN) {
-      return "wl_burn_heal";
-    }
-    return "";
-  }
-
-  get description(): string {
-    return i18next.t("modifierType:ModifierType.EnemyAttackStatusEffectChanceModifierType.description", {
-      chancePercent: this.getChance() * 100,
-      statusEffect: getStatusEffectDescriptor(this.statusEffect),
-    });
+    this.chance = chance;
   }
 
   public override apply({ pokemon: enemyPokemon }: PokemonParams, manager: TrainerItemManager): void {
     const stack = manager.getStack(this.type);
-    const chance = this.getChance();
-
-    if (randSeedFloat() <= chance * stack) {
+    if (randSeedFloat() <= this.chance * stack) {
       enemyPokemon.trySetStatus(this.statusEffect);
     }
-  }
-
-  getChance(): number {
-    return 0.025 * (this.statusEffect === StatusEffect.BURN || this.statusEffect === StatusEffect.POISON ? 2 : 1);
   }
 }
 
@@ -127,10 +129,12 @@ export class EnemyStatusEffectHealChanceTrainerItemAttr extends TrainerItemAttr<
   typeof TrainerItemEffect.ENEMY_STATUS_HEAL_CHANCE
 > {
   public override readonly effect = TrainerItemEffect.ENEMY_STATUS_HEAL_CHANCE;
-  public chance = 0.025;
+  private readonly chance: number;
 
-  get iconName(): string {
-    return "wl_full_heal";
+  constructor(chance: number) {
+    super();
+
+    this.chance = chance;
   }
 
   public override apply({ pokemon: enemyPokemon }: PokemonParams, manager: TrainerItemManager): void {

--- a/src/items/trainer-items/enemy-tokens.ts
+++ b/src/items/trainer-items/enemy-tokens.ts
@@ -4,22 +4,21 @@ import { getStatusEffectDescriptor, getStatusEffectHealText } from "#data/status
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { StatusEffect } from "#enums/status-effect";
 import { TrainerItemEffect } from "#enums/trainer-item-effect";
-import type { TrainerItemId } from "#enums/trainer-item-id";
-import { TrainerItem } from "#items/trainer-item";
+import { TrainerItemAttr } from "#items/trainer-item-attr";
 import type { TrainerItemManager } from "#items/trainer-item-manager";
 import type { BooleanHolderParams, NumberHolderParams, PokemonParams } from "#types/trainer-item-parameter";
 import { randSeedFloat, toDmgValue } from "#utils/common";
 import i18next from "i18next";
 
-export class EnemyDamageBoosterTrainerItem extends TrainerItem {
-  public effects: TrainerItemEffect[] = [TrainerItemEffect.ENEMY_DAMAGE_BOOSTER];
+export class EnemyDamageBoosterTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.ENEMY_DAMAGE_BOOSTER> {
+  public override readonly effect = TrainerItemEffect.ENEMY_DAMAGE_BOOSTER;
   public damageBoost = 1.05;
 
   get iconName(): string {
     return "wl_item_drop";
   }
 
-  apply(manager: TrainerItemManager, params: NumberHolderParams): boolean {
+  public override apply(params: NumberHolderParams, manager: TrainerItemManager): boolean {
     const stack = manager.getStack(this.type);
     const multiplier = params.numberHolder;
 
@@ -33,15 +32,15 @@ export class EnemyDamageBoosterTrainerItem extends TrainerItem {
   }
 }
 
-export class EnemyDamageReducerTrainerItem extends TrainerItem {
-  public effects: TrainerItemEffect[] = [TrainerItemEffect.ENEMY_DAMAGE_REDUCER];
+export class EnemyDamageReducerTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.ENEMY_DAMAGE_REDUCER> {
+  public override readonly effect = TrainerItemEffect.ENEMY_DAMAGE_REDUCER;
   public damageReduction = 0.975;
 
   get iconName(): string {
     return "wl_guard_spec";
   }
 
-  apply(manager: TrainerItemManager, params: NumberHolderParams): boolean {
+  public override apply(params: NumberHolderParams, manager: TrainerItemManager): boolean {
     const stack = manager.getStack(this.type);
     const multiplier = params.numberHolder;
 
@@ -55,15 +54,15 @@ export class EnemyDamageReducerTrainerItem extends TrainerItem {
   }
 }
 
-export class EnemyTurnHealTrainerItem extends TrainerItem {
-  public effects: TrainerItemEffect[] = [TrainerItemEffect.ENEMY_HEAL];
+export class EnemyTurnHealTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.ENEMY_HEAL> {
+  public override readonly effect = TrainerItemEffect.ENEMY_HEAL;
   public healPercent = 2;
 
   get iconName(): string {
     return "wl_potion";
   }
 
-  apply(manager: TrainerItemManager, params: PokemonParams): boolean {
+  public override apply(params: PokemonParams, manager: TrainerItemManager): boolean {
     const stack = manager.getStack(this.type);
     const enemyPokemon = params.pokemon;
 
@@ -71,7 +70,7 @@ export class EnemyTurnHealTrainerItem extends TrainerItem {
       globalScene.phaseManager.unshiftNew(
         "PokemonHealPhase",
         enemyPokemon.getBattlerIndex(),
-        Math.max(Math.floor(enemyPokemon.getMaxHp() / (100 / this.healPercent)) * stack, 1),
+        Math.max(Math.floor((enemyPokemon.getMaxHp() * this.healPercent * stack) / 100), 1),
         i18next.t("modifier:enemyTurnHealApply", {
           pokemonNameWithAffix: getPokemonNameWithAffix(enemyPokemon),
         }),
@@ -88,14 +87,16 @@ export class EnemyTurnHealTrainerItem extends TrainerItem {
   }
 }
 
-export class EnemyAttackStatusEffectChanceTrainerItem extends TrainerItem {
-  public effects: TrainerItemEffect[] = [TrainerItemEffect.ENEMY_ATTACK_STATUS_CHANCE];
-  public effect: StatusEffect;
+export class EnemyAttackStatusEffectChanceTrainerItemAttr extends TrainerItemAttr<
+  typeof TrainerItemEffect.ENEMY_ATTACK_STATUS_CHANCE
+> {
+  public override readonly effect = TrainerItemEffect.ENEMY_ATTACK_STATUS_CHANCE;
+  public statusEffect: StatusEffect;
 
-  constructor(type: TrainerItemId, effect: StatusEffect, stackCount?: number) {
-    super(type, stackCount);
+  constructor(statusEffect: StatusEffect) {
+    super();
 
-    this.effect = effect;
+    this.statusEffect = statusEffect;
   }
 
   get iconName(): string {
@@ -118,7 +119,7 @@ export class EnemyAttackStatusEffectChanceTrainerItem extends TrainerItem {
     });
   }
 
-  apply(manager: TrainerItemManager, params: PokemonParams): boolean {
+  public override apply(params: PokemonParams, manager: TrainerItemManager): boolean {
     const stack = manager.getStack(this.type);
     const enemyPokemon = params.pokemon;
     const chance = this.getChance();
@@ -135,15 +136,17 @@ export class EnemyAttackStatusEffectChanceTrainerItem extends TrainerItem {
   }
 }
 
-export class EnemyStatusEffectHealChanceTrainerItem extends TrainerItem {
-  public effects: TrainerItemEffect[] = [TrainerItemEffect.ENEMY_STATUS_HEAL_CHANCE];
+export class EnemyStatusEffectHealChanceTrainerItemAttr extends TrainerItemAttr<
+  typeof TrainerItemEffect.ENEMY_STATUS_HEAL_CHANCE
+> {
+  public override readonly effect = TrainerItemEffect.ENEMY_STATUS_HEAL_CHANCE;
   public chance = 0.025;
 
   get iconName(): string {
     return "wl_full_heal";
   }
 
-  apply(manager: TrainerItemManager, params: PokemonParams): boolean {
+  public override apply(params: PokemonParams, manager: TrainerItemManager): boolean {
     const stack = manager.getStack(this.type);
     const enemyPokemon = params.pokemon;
 
@@ -160,8 +163,8 @@ export class EnemyStatusEffectHealChanceTrainerItem extends TrainerItem {
   }
 }
 
-export class EnemyEndureChanceTrainerItem extends TrainerItem {
-  public effects: TrainerItemEffect[] = [TrainerItemEffect.ENEMY_ENDURE_CHANCE];
+export class EnemyEndureChanceTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.ENEMY_ENDURE_CHANCE> {
+  public override readonly effect = TrainerItemEffect.ENEMY_ENDURE_CHANCE;
   public chance = 2;
 
   get iconName(): string {
@@ -174,7 +177,7 @@ export class EnemyEndureChanceTrainerItem extends TrainerItem {
     });
   }
 
-  apply(manager: TrainerItemManager, params: PokemonParams): boolean {
+  public override apply(params: PokemonParams, manager: TrainerItemManager): boolean {
     const stack = manager.getStack(this.type);
     const target = params.pokemon;
 
@@ -190,15 +193,15 @@ export class EnemyEndureChanceTrainerItem extends TrainerItem {
   }
 }
 
-export class EnemyFusionChanceTrainerItem extends TrainerItem {
-  public effects: TrainerItemEffect[] = [TrainerItemEffect.ENEMY_FUSED_CHANCE];
+export class EnemyFusionChanceTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.ENEMY_FUSED_CHANCE> {
+  public override readonly effect = TrainerItemEffect.ENEMY_FUSED_CHANCE;
   public chance = 0.01;
 
   get iconName(): string {
     return "wl_custom_spliced";
   }
 
-  apply(manager: TrainerItemManager, params: BooleanHolderParams) {
+  public override apply(params: BooleanHolderParams, manager: TrainerItemManager) {
     const stack = manager.getStack(this.type);
     const isFusion = params.booleanHolder;
     if (randSeedFloat() > this.chance * stack) {

--- a/src/items/trainer-items/enemy-tokens.ts
+++ b/src/items/trainer-items/enemy-tokens.ts
@@ -18,13 +18,9 @@ export class EnemyDamageBoosterTrainerItemAttr extends TrainerItemAttr<typeof Tr
     return "wl_item_drop";
   }
 
-  public override apply(params: NumberHolderParams, manager: TrainerItemManager): boolean {
+  public override apply({ numberHolder: multiplier }: NumberHolderParams, manager: TrainerItemManager): void {
     const stack = manager.getStack(this.type);
-    const multiplier = params.numberHolder;
-
     multiplier.value = toDmgValue(multiplier.value * Math.pow(this.damageBoost, stack));
-
-    return true;
   }
 
   getMaxStackCount(): number {
@@ -40,13 +36,10 @@ export class EnemyDamageReducerTrainerItemAttr extends TrainerItemAttr<typeof Tr
     return "wl_guard_spec";
   }
 
-  public override apply(params: NumberHolderParams, manager: TrainerItemManager): boolean {
+  public override apply({ numberHolder: multiplier }: NumberHolderParams, manager: TrainerItemManager): void {
     const stack = manager.getStack(this.type);
-    const multiplier = params.numberHolder;
 
     multiplier.value = toDmgValue(multiplier.value * Math.pow(this.damageReduction, stack));
-
-    return true;
   }
 
   getMaxStackCount(): number {
@@ -62,28 +55,25 @@ export class EnemyTurnHealTrainerItemAttr extends TrainerItemAttr<typeof Trainer
     return "wl_potion";
   }
 
-  public override apply(params: PokemonParams, manager: TrainerItemManager): boolean {
+  public override apply({ pokemon: enemyPokemon }: PokemonParams, manager: TrainerItemManager): void {
     const stack = manager.getStack(this.type);
-    const enemyPokemon = params.pokemon;
 
-    if (!enemyPokemon.isFullHp()) {
-      globalScene.phaseManager.unshiftNew(
-        "PokemonHealPhase",
-        enemyPokemon.getBattlerIndex(),
-        Math.max(Math.floor((enemyPokemon.getMaxHp() * this.healPercent * stack) / 100), 1),
-        i18next.t("modifier:enemyTurnHealApply", {
-          pokemonNameWithAffix: getPokemonNameWithAffix(enemyPokemon),
-        }),
-        true,
-        false,
-        false,
-        false,
-        true,
-      );
-      return true;
+    if (enemyPokemon.isFullHp()) {
+      return;
     }
-
-    return false;
+    globalScene.phaseManager.unshiftNew(
+      "PokemonHealPhase",
+      enemyPokemon.getBattlerIndex(),
+      Math.max(Math.floor((enemyPokemon.getMaxHp() * this.healPercent * stack) / 100), 1),
+      i18next.t("modifier:enemyTurnHealApply", {
+        pokemonNameWithAffix: getPokemonNameWithAffix(enemyPokemon),
+      }),
+      true,
+      false,
+      false,
+      false,
+      true,
+    );
   }
 }
 
@@ -100,13 +90,13 @@ export class EnemyAttackStatusEffectChanceTrainerItemAttr extends TrainerItemAtt
   }
 
   get iconName(): string {
-    if (this.effect === StatusEffect.POISON) {
+    if (this.statusEffect === StatusEffect.POISON) {
       return "wl_antidote";
     }
-    if (this.effect === StatusEffect.PARALYSIS) {
+    if (this.statusEffect === StatusEffect.PARALYSIS) {
       return "wl_paralyze_heal";
     }
-    if (this.effect === StatusEffect.BURN) {
+    if (this.statusEffect === StatusEffect.BURN) {
       return "wl_burn_heal";
     }
     return "";
@@ -115,24 +105,21 @@ export class EnemyAttackStatusEffectChanceTrainerItemAttr extends TrainerItemAtt
   get description(): string {
     return i18next.t("modifierType:ModifierType.EnemyAttackStatusEffectChanceModifierType.description", {
       chancePercent: this.getChance() * 100,
-      statusEffect: getStatusEffectDescriptor(this.effect),
+      statusEffect: getStatusEffectDescriptor(this.statusEffect),
     });
   }
 
-  public override apply(params: PokemonParams, manager: TrainerItemManager): boolean {
+  public override apply({ pokemon: enemyPokemon }: PokemonParams, manager: TrainerItemManager): void {
     const stack = manager.getStack(this.type);
-    const enemyPokemon = params.pokemon;
     const chance = this.getChance();
 
     if (randSeedFloat() <= chance * stack) {
-      return enemyPokemon.trySetStatus(this.effect);
+      enemyPokemon.trySetStatus(this.statusEffect);
     }
-
-    return false;
   }
 
   getChance(): number {
-    return 0.025 * (this.effect === StatusEffect.BURN || this.effect === StatusEffect.POISON ? 2 : 1);
+    return 0.025 * (this.statusEffect === StatusEffect.BURN || this.statusEffect === StatusEffect.POISON ? 2 : 1);
   }
 }
 
@@ -146,12 +133,11 @@ export class EnemyStatusEffectHealChanceTrainerItemAttr extends TrainerItemAttr<
     return "wl_full_heal";
   }
 
-  public override apply(params: PokemonParams, manager: TrainerItemManager): boolean {
+  public override apply({ pokemon: enemyPokemon }: PokemonParams, manager: TrainerItemManager): void {
     const stack = manager.getStack(this.type);
-    const enemyPokemon = params.pokemon;
 
     if (!enemyPokemon.status || randSeedFloat() > this.chance * stack) {
-      return false;
+      return;
     }
 
     globalScene.phaseManager.queueMessage(
@@ -159,12 +145,12 @@ export class EnemyStatusEffectHealChanceTrainerItemAttr extends TrainerItemAttr<
     );
     enemyPokemon.resetStatus();
     enemyPokemon.updateInfo();
-    return true;
   }
 }
 
 export class EnemyEndureChanceTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.ENEMY_ENDURE_CHANCE> {
   public override readonly effect = TrainerItemEffect.ENEMY_ENDURE_CHANCE;
+  // TODO: MAKE THIS CONSISTENT PLEASEEEEEE
   public chance = 2;
 
   get iconName(): string {
@@ -177,19 +163,16 @@ export class EnemyEndureChanceTrainerItemAttr extends TrainerItemAttr<typeof Tra
     });
   }
 
-  public override apply(params: PokemonParams, manager: TrainerItemManager): boolean {
+  public override apply({ pokemon: target }: PokemonParams, manager: TrainerItemManager): void {
     const stack = manager.getStack(this.type);
-    const target = params.pokemon;
 
     if (target.waveData.endured || target.randBattleSeedInt(100) >= this.chance * stack) {
-      return false;
+      return;
     }
 
     target.addTag(BattlerTagType.ENDURE_TOKEN, 1);
 
     target.waveData.endured = true;
-
-    return true;
   }
 }
 
@@ -201,12 +184,10 @@ export class EnemyFusionChanceTrainerItemAttr extends TrainerItemAttr<typeof Tra
     return "wl_custom_spliced";
   }
 
-  public override apply(params: BooleanHolderParams, manager: TrainerItemManager) {
+  public override apply({ booleanHolder: isFusion }: BooleanHolderParams, manager: TrainerItemManager): void {
     const stack = manager.getStack(this.type);
-    const isFusion = params.booleanHolder;
-    if (randSeedFloat() > this.chance * stack) {
-      return false;
+    if (randSeedFloat() <= this.chance * stack) {
+      isFusion.value = true;
     }
-    isFusion.value = true;
   }
 }

--- a/src/items/trainer-items/exp-booster.ts
+++ b/src/items/trainer-items/exp-booster.ts
@@ -20,8 +20,7 @@ export class ExpBoosterTrainerItemAttr extends TrainerItemAttr<typeof TrainerIte
     });
   }
 
-  public apply(params: NumberHolderParams, manager: TrainerItemManager): void {
-    const boost = params.numberHolder;
+  public override apply({ numberHolder: boost }: NumberHolderParams, manager: TrainerItemManager): void {
     const stack = manager.getStack(this.type);
     boost.value = Math.floor(boost.value * (1 + stack * this.boostPercent * 0.01));
   }

--- a/src/items/trainer-items/exp-booster.ts
+++ b/src/items/trainer-items/exp-booster.ts
@@ -1,0 +1,28 @@
+import { TrainerItemEffect } from "#enums/trainer-item-effect";
+import { TrainerItemAttr } from "#items/trainer-item-attr";
+import type { TrainerItemManager } from "#items/trainer-item-manager";
+import type { NumberHolderParams } from "#types/trainer-item-parameter";
+import i18next from "i18next";
+
+export class ExpBoosterTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.EXP_BOOSTER> {
+  public override readonly effect = TrainerItemEffect.EXP_BOOSTER;
+  private readonly boostPercent: number;
+
+  constructor(boostPercent: number) {
+    super();
+
+    this.boostPercent = boostPercent;
+  }
+
+  public get description(): string {
+    return i18next.t("modifierType:ModifierType.ExpBoosterModifierType.description", {
+      boostPercent: this.boostPercent,
+    });
+  }
+
+  public apply(params: NumberHolderParams, manager: TrainerItemManager): void {
+    const boost = params.numberHolder;
+    const stack = manager.getStack(this.type);
+    boost.value = Math.floor(boost.value * (1 + stack * this.boostPercent * 0.01));
+  }
+}

--- a/src/items/trainer-items/extra-reward.ts
+++ b/src/items/trainer-items/extra-reward.ts
@@ -6,8 +6,7 @@ import type { NumberHolderParams } from "#types/trainer-item-parameter";
 export class ExtraRewardTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.EXTRA_REWARD> {
   public override readonly effect = TrainerItemEffect.EXTRA_REWARD;
 
-  public apply(params: NumberHolderParams, manager: TrainerItemManager): void {
-    const count = params.numberHolder;
+  public override apply({ numberHolder: count }: NumberHolderParams, manager: TrainerItemManager): void {
     const stack = manager.getStack(this.type);
     count.value += stack;
   }

--- a/src/items/trainer-items/extra-reward.ts
+++ b/src/items/trainer-items/extra-reward.ts
@@ -1,0 +1,14 @@
+import { TrainerItemEffect } from "#enums/trainer-item-effect";
+import { TrainerItemAttr } from "#items/trainer-item-attr";
+import type { TrainerItemManager } from "#items/trainer-item-manager";
+import type { NumberHolderParams } from "#types/trainer-item-parameter";
+
+export class ExtraRewardTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.EXTRA_REWARD> {
+  public override readonly effect = TrainerItemEffect.EXTRA_REWARD;
+
+  public apply(params: NumberHolderParams, manager: TrainerItemManager): void {
+    const count = params.numberHolder;
+    const stack = manager.getStack(this.type);
+    count.value += stack;
+  }
+}

--- a/src/items/trainer-items/heal-shop-cost.ts
+++ b/src/items/trainer-items/heal-shop-cost.ts
@@ -1,0 +1,18 @@
+import { TrainerItemEffect } from "#enums/trainer-item-effect";
+import { TrainerItemAttr } from "#items/trainer-item-attr";
+import type { NumberHolderParams } from "#types/trainer-item-parameter";
+
+export class HealShopCostTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.HEAL_SHOP_COST> {
+  public override readonly effect = TrainerItemEffect.HEAL_SHOP_COST;
+  public readonly shopMultiplier: number;
+
+  constructor(shopMultiplier: number) {
+    super();
+
+    this.shopMultiplier = shopMultiplier;
+  }
+
+  public override apply({ numberHolder: moneyCost }: NumberHolderParams): void {
+    moneyCost.value = Math.floor(moneyCost.value * this.shopMultiplier);
+  }
+}

--- a/src/items/trainer-items/healing-booster.ts
+++ b/src/items/trainer-items/healing-booster.ts
@@ -1,0 +1,21 @@
+import { TrainerItemEffect } from "#enums/trainer-item-effect";
+import { TrainerItemAttr } from "#items/trainer-item-attr";
+import type { TrainerItemManager } from "#items/trainer-item-manager";
+import type { NumberHolderParams } from "#types/trainer-item-parameter";
+
+export class HealingBoosterTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.HEALING_BOOSTER> {
+  public override readonly effect = TrainerItemEffect.HEALING_BOOSTER;
+  // TODO: decide on % or multiplier and stop mixing the two for everything ffs
+  private readonly multiplier: number;
+
+  constructor(multiplier: number) {
+    super();
+
+    this.multiplier = multiplier;
+  }
+
+  public apply({ numberHolder: healingMultiplier }: NumberHolderParams, manager: TrainerItemManager) {
+    const stack = manager.getStack(this.type);
+    healingMultiplier.value *= 1 + (this.multiplier - 1) * stack;
+  }
+}

--- a/src/items/trainer-items/healing-booster.ts
+++ b/src/items/trainer-items/healing-booster.ts
@@ -14,7 +14,7 @@ export class HealingBoosterTrainerItemAttr extends TrainerItemAttr<typeof Traine
     this.multiplier = multiplier;
   }
 
-  public apply({ numberHolder: healingMultiplier }: NumberHolderParams, manager: TrainerItemManager) {
+  public override apply({ numberHolder: healingMultiplier }: NumberHolderParams, manager: TrainerItemManager): void {
     const stack = manager.getStack(this.type);
     healingMultiplier.value *= 1 + (this.multiplier - 1) * stack;
   }

--- a/src/items/trainer-items/hidden-ability-chance-booster.ts
+++ b/src/items/trainer-items/hidden-ability-chance-booster.ts
@@ -8,8 +8,7 @@ export class HiddenAbilityChanceBoosterTrainerItemAttr extends TrainerItemAttr<
 > {
   public override readonly effect = TrainerItemEffect.HIDDEN_ABILITY_CHANCE_BOOSTER;
 
-  public apply(params: NumberHolderParams, manager: TrainerItemManager): void {
-    const boost = params.numberHolder;
+  public override apply({ numberHolder: boost }: NumberHolderParams, manager: TrainerItemManager): void {
     const stack = manager.getStack(this.type);
     boost.value *= Math.pow(2, -1 - stack);
   }

--- a/src/items/trainer-items/hidden-ability-chance-booster.ts
+++ b/src/items/trainer-items/hidden-ability-chance-booster.ts
@@ -1,0 +1,16 @@
+import { TrainerItemEffect } from "#enums/trainer-item-effect";
+import { TrainerItemAttr } from "#items/trainer-item-attr";
+import type { TrainerItemManager } from "#items/trainer-item-manager";
+import type { NumberHolderParams } from "#types/trainer-item-parameter";
+
+export class HiddenAbilityChanceBoosterTrainerItemAttr extends TrainerItemAttr<
+  typeof TrainerItemEffect.HIDDEN_ABILITY_CHANCE_BOOSTER
+> {
+  public override readonly effect = TrainerItemEffect.HIDDEN_ABILITY_CHANCE_BOOSTER;
+
+  public apply(params: NumberHolderParams, manager: TrainerItemManager): void {
+    const boost = params.numberHolder;
+    const stack = manager.getStack(this.type);
+    boost.value *= Math.pow(2, -1 - stack);
+  }
+}

--- a/src/items/trainer-items/level-increment-booster.ts
+++ b/src/items/trainer-items/level-increment-booster.ts
@@ -9,8 +9,7 @@ export class LevelIncrementBoosterTrainerItemAttr extends TrainerItemAttr<
 > {
   public override readonly effect = TrainerItemEffect.LEVEL_INCREMENT_BOOSTER;
 
-  public override apply(params: NumberHolderParams, manager: TrainerItemManager) {
-    const count = params.numberHolder;
+  public override apply({ numberHolder: count }: NumberHolderParams, manager: TrainerItemManager): void {
     const stack = manager.getStack(this.type);
     count.value += stack;
   }

--- a/src/items/trainer-items/level-increment-booster.ts
+++ b/src/items/trainer-items/level-increment-booster.ts
@@ -1,0 +1,17 @@
+import { TrainerItemEffect } from "#enums/trainer-item-effect";
+// Candy Jar
+import { TrainerItemAttr } from "#items/trainer-item-attr";
+import type { TrainerItemManager } from "#items/trainer-item-manager";
+import type { NumberHolderParams } from "#types/trainer-item-parameter";
+
+export class LevelIncrementBoosterTrainerItemAttr extends TrainerItemAttr<
+  typeof TrainerItemEffect.LEVEL_INCREMENT_BOOSTER
+> {
+  public override readonly effect = TrainerItemEffect.LEVEL_INCREMENT_BOOSTER;
+
+  public override apply(params: NumberHolderParams, manager: TrainerItemManager) {
+    const count = params.numberHolder;
+    const stack = manager.getStack(this.type);
+    count.value += stack;
+  }
+}

--- a/src/items/trainer-items/lure.ts
+++ b/src/items/trainer-items/lure.ts
@@ -1,22 +1,24 @@
 import { TrainerItemEffect } from "#enums/trainer-item-effect";
-import { LapsingTrainerItem } from "#items/trainer-item";
-import type { TrainerItemManager } from "#items/trainer-item-manager";
+import { TrainerItemAttr } from "#items/trainer-item-attr";
 import type { NumberHolderParams } from "#types/trainer-item-parameter";
 import i18next from "i18next";
 
-export class DoubleBattleChanceBoosterTrainerItem extends LapsingTrainerItem {
-  public effects: TrainerItemEffect[] = [TrainerItemEffect.DOUBLE_BATTLE_CHANCE_BOOSTER];
+export class DoubleBattleChanceBoosterTrainerItemAttr extends TrainerItemAttr<
+  typeof TrainerItemEffect.DOUBLE_BATTLE_CHANCE_BOOSTER
+> {
+  public override readonly effect = TrainerItemEffect.DOUBLE_BATTLE_CHANCE_BOOSTER;
 
+  // todo move to builder
   get description(): string {
     return i18next.t("modifierType:ModifierType.DoubleBattleChanceBoosterModifierType.description", {
       battleCount: this.getMaxStackCount(),
     });
   }
 
-  apply(_manager: TrainerItemManager, params: NumberHolderParams) {
-    const doubleBattleChance = params.numberHolder;
+  public override apply({ numberHolder: doubleBattleChanceThreshold }: NumberHolderParams) {
     // This is divided because the chance is generated as a number from 0 to doubleBattleChance.value using randSeedInt
     // A double battle will initiate if the generated number is 0
-    doubleBattleChance.value /= 4;
+    // TODO: This is emphatically a very dumb way to do this and should be reworked (alongside similar effects) later
+    doubleBattleChanceThreshold.value /= 4;
   }
 }

--- a/src/items/trainer-items/lure.ts
+++ b/src/items/trainer-items/lure.ts
@@ -15,7 +15,7 @@ export class DoubleBattleChanceBoosterTrainerItemAttr extends TrainerItemAttr<
     });
   }
 
-  public override apply({ numberHolder: doubleBattleChanceThreshold }: NumberHolderParams) {
+  public override apply({ numberHolder: doubleBattleChanceThreshold }: NumberHolderParams): void {
     // This is divided because the chance is generated as a number from 0 to doubleBattleChance.value using randSeedInt
     // A double battle will initiate if the generated number is 0
     // TODO: This is emphatically a very dumb way to do this and should be reworked (alongside similar effects) later

--- a/src/items/trainer-items/lure.ts
+++ b/src/items/trainer-items/lure.ts
@@ -1,19 +1,11 @@
 import { TrainerItemEffect } from "#enums/trainer-item-effect";
 import { TrainerItemAttr } from "#items/trainer-item-attr";
 import type { NumberHolderParams } from "#types/trainer-item-parameter";
-import i18next from "i18next";
 
 export class DoubleBattleChanceBoosterTrainerItemAttr extends TrainerItemAttr<
   typeof TrainerItemEffect.DOUBLE_BATTLE_CHANCE_BOOSTER
 > {
   public override readonly effect = TrainerItemEffect.DOUBLE_BATTLE_CHANCE_BOOSTER;
-
-  // todo move to builder
-  get description(): string {
-    return i18next.t("modifierType:ModifierType.DoubleBattleChanceBoosterModifierType.description", {
-      battleCount: this.getMaxStackCount(),
-    });
-  }
 
   public override apply({ numberHolder: doubleBattleChanceThreshold }: NumberHolderParams): void {
     // This is divided because the chance is generated as a number from 0 to doubleBattleChance.value using randSeedInt

--- a/src/items/trainer-items/money-multiplier.ts
+++ b/src/items/trainer-items/money-multiplier.ts
@@ -1,0 +1,14 @@
+import { TrainerItemEffect } from "#enums/trainer-item-effect";
+import { TrainerItemAttr } from "#items/trainer-item-attr";
+import type { TrainerItemManager } from "#items/trainer-item-manager";
+import type { NumberHolderParams } from "#types/trainer-item-parameter";
+
+export class MoneyMultiplierTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.MONEY_MULTIPLIER> {
+  public override readonly effect = TrainerItemEffect.MONEY_MULTIPLIER;
+
+  public override apply(params: NumberHolderParams, manager: TrainerItemManager): void {
+    const moneyMultiplier = params.numberHolder;
+    const stack = manager.getStack(this.type);
+    moneyMultiplier.value += Math.floor(moneyMultiplier.value * 0.2 * stack);
+  }
+}

--- a/src/items/trainer-items/money-multiplier.ts
+++ b/src/items/trainer-items/money-multiplier.ts
@@ -6,8 +6,7 @@ import type { NumberHolderParams } from "#types/trainer-item-parameter";
 export class MoneyMultiplierTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.MONEY_MULTIPLIER> {
   public override readonly effect = TrainerItemEffect.MONEY_MULTIPLIER;
 
-  public override apply(params: NumberHolderParams, manager: TrainerItemManager): void {
-    const moneyMultiplier = params.numberHolder;
+  public override apply({ numberHolder: moneyMultiplier }: NumberHolderParams, manager: TrainerItemManager): void {
     const stack = manager.getStack(this.type);
     moneyMultiplier.value += Math.floor(moneyMultiplier.value * 0.2 * stack);
   }

--- a/src/items/trainer-items/preserve-berry.ts
+++ b/src/items/trainer-items/preserve-berry.ts
@@ -1,0 +1,14 @@
+import { TrainerItemEffect } from "#enums/trainer-item-effect";
+import { TrainerItemAttr } from "#items/trainer-item-attr";
+import type { TrainerItemManager } from "#items/trainer-item-manager";
+import type { PreserveBerryParams } from "#types/trainer-item-parameter";
+
+// Berry Pouch
+export class PreserveBerryTrainerItem extends TrainerItemAttr<typeof TrainerItemEffect.PRESERVE_BERRY> {
+  public override readonly effect = TrainerItemEffect.PRESERVE_BERRY;
+
+  public override apply({ pokemon, doPreserve }: PreserveBerryParams, manager: TrainerItemManager) {
+    const stack = manager.getStack(this.type);
+    doPreserve.value ||= pokemon.randBattleSeedInt(10) < stack * 3;
+  }
+}

--- a/src/items/trainer-items/preserve-berry.ts
+++ b/src/items/trainer-items/preserve-berry.ts
@@ -4,7 +4,7 @@ import type { TrainerItemManager } from "#items/trainer-item-manager";
 import type { PreserveBerryParams } from "#types/trainer-item-parameter";
 
 // Berry Pouch
-export class PreserveBerryTrainerItem extends TrainerItemAttr<typeof TrainerItemEffect.PRESERVE_BERRY> {
+export class PreserveBerryTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.PRESERVE_BERRY> {
   public override readonly effect = TrainerItemEffect.PRESERVE_BERRY;
 
   public override apply({ pokemon, doPreserve }: PreserveBerryParams, manager: TrainerItemManager): void {

--- a/src/items/trainer-items/preserve-berry.ts
+++ b/src/items/trainer-items/preserve-berry.ts
@@ -7,7 +7,7 @@ import type { PreserveBerryParams } from "#types/trainer-item-parameter";
 export class PreserveBerryTrainerItem extends TrainerItemAttr<typeof TrainerItemEffect.PRESERVE_BERRY> {
   public override readonly effect = TrainerItemEffect.PRESERVE_BERRY;
 
-  public override apply({ pokemon, doPreserve }: PreserveBerryParams, manager: TrainerItemManager) {
+  public override apply({ pokemon, doPreserve }: PreserveBerryParams, manager: TrainerItemManager): void {
     const stack = manager.getStack(this.type);
     doPreserve.value ||= pokemon.randBattleSeedInt(10) < stack * 3;
   }

--- a/src/items/trainer-items/shiny-rate-booster.ts
+++ b/src/items/trainer-items/shiny-rate-booster.ts
@@ -1,0 +1,14 @@
+import { TrainerItemEffect } from "#enums/trainer-item-effect";
+import { TrainerItemAttr } from "#items/trainer-item-attr";
+import type { TrainerItemManager } from "#items/trainer-item-manager";
+import type { NumberHolderParams } from "#types/trainer-item-parameter";
+
+export class ShinyRateBoosterTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.SHINY_RATE_BOOSTER> {
+  public override readonly effect = TrainerItemEffect.SHINY_RATE_BOOSTER;
+
+  public apply(params: NumberHolderParams, manager: TrainerItemManager): void {
+    const boost = params.numberHolder;
+    const stack = manager.getStack(this.type);
+    boost.value *= Math.pow(2, 1 + stack);
+  }
+}

--- a/src/items/trainer-items/shiny-rate-booster.ts
+++ b/src/items/trainer-items/shiny-rate-booster.ts
@@ -6,8 +6,7 @@ import type { NumberHolderParams } from "#types/trainer-item-parameter";
 export class ShinyRateBoosterTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.SHINY_RATE_BOOSTER> {
   public override readonly effect = TrainerItemEffect.SHINY_RATE_BOOSTER;
 
-  public apply(params: NumberHolderParams, manager: TrainerItemManager): void {
-    const boost = params.numberHolder;
+  public override apply({ numberHolder: boost }: NumberHolderParams, manager: TrainerItemManager): void {
     const stack = manager.getStack(this.type);
     boost.value *= Math.pow(2, 1 + stack);
   }

--- a/src/items/trainer-items/x-items.ts
+++ b/src/items/trainer-items/x-items.ts
@@ -43,7 +43,7 @@ export class StatStageBoosterTrainerItemAttr extends TrainerItemAttr<typeof Trai
     });
   }
 
-  public override apply({ numberHolder: statLevel }: NumberHolderParams) {
+  public override apply({ numberHolder: statLevel }: NumberHolderParams): void {
     statLevel.value += this.boost;
   }
 }
@@ -63,7 +63,7 @@ export class AccuracyBoosterTrainerItemAttr extends TrainerItemAttr<typeof Train
     });
   }
 
-  public override apply({ numberHolder: statLevel }: NumberHolderParams) {
+  public override apply({ numberHolder: statLevel }: NumberHolderParams): void {
     const boost = 1;
     statLevel.value += boost;
   }
@@ -79,7 +79,7 @@ export class CritBoosterTrainerItemAttr extends TrainerItemAttr<typeof TrainerIt
     });
   }
 
-  public override apply({ numberHolder: critLevel }: NumberHolderParams) {
+  public override apply({ numberHolder: critLevel }: NumberHolderParams): void {
     critLevel.value++;
   }
 }

--- a/src/items/trainer-items/x-items.ts
+++ b/src/items/trainer-items/x-items.ts
@@ -1,8 +1,7 @@
 import { getStatKey, Stat, type TempBattleStat } from "#enums/stat";
 import { TrainerItemEffect } from "#enums/trainer-item-effect";
 import { TrainerItemId, TrainerItemNames } from "#enums/trainer-item-id";
-import { LapsingTrainerItem } from "#items/trainer-item";
-import type { TrainerItemManager } from "#items/trainer-item-manager";
+import { TrainerItemAttr } from "#items/trainer-item-attr";
 import type { NumberHolderParams } from "#types/trainer-item-parameter";
 import i18next from "i18next";
 
@@ -19,16 +18,19 @@ export const tempStatToTrainerItem: TempStatToTrainerItemMap = {
   [Stat.ACC]: TrainerItemId.X_ACCURACY,
 };
 
-export class TempStatStageBoosterTrainerItem extends LapsingTrainerItem {
-  public effects: TrainerItemEffect[] = [TrainerItemEffect.TEMP_STAT_STAGE_BOOSTER];
-  private stat: TempBattleStat;
+export class StatStageBoosterTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.TEMP_STAT_STAGE_BOOSTER> {
+  public override readonly effect = TrainerItemEffect.TEMP_STAT_STAGE_BOOSTER;
+  private readonly stat: TempBattleStat;
+  private readonly boost: number;
 
-  constructor(type: TrainerItemId, stat: TempBattleStat, stackCount?: number) {
-    super(type, stackCount);
+  constructor(stat: TempBattleStat, boost: number) {
+    super();
 
     this.stat = stat;
+    this.boost = boost;
   }
 
+  // TODO move to builder
   get name(): string {
     return i18next.t(`modifierType:TempStatStageBoosterItem.${TrainerItemNames[this.type]?.toLowerCase()}`);
   }
@@ -41,15 +43,13 @@ export class TempStatStageBoosterTrainerItem extends LapsingTrainerItem {
     });
   }
 
-  apply(_manager: TrainerItemManager, params: NumberHolderParams) {
-    const statLevel = params.numberHolder;
-    const boost = 0.3;
-    statLevel.value += boost;
+  public override apply({ numberHolder: statLevel }: NumberHolderParams) {
+    statLevel.value += this.boost;
   }
 }
 
-export class TempAccuracyBoosterTrainerItem extends LapsingTrainerItem {
-  public effects: TrainerItemEffect[] = [TrainerItemEffect.TEMP_ACCURACY_BOOSTER];
+export class AccuracyBoosterTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.TEMP_ACCURACY_BOOSTER> {
+  public override readonly effect = TrainerItemEffect.TEMP_ACCURACY_BOOSTER;
 
   get name(): string {
     return i18next.t(`modifierType:TempStatStageBoosterItem.${TrainerItemNames[this.type]?.toLowerCase()}`);
@@ -63,15 +63,14 @@ export class TempAccuracyBoosterTrainerItem extends LapsingTrainerItem {
     });
   }
 
-  apply(_manager: TrainerItemManager, params: NumberHolderParams) {
-    const statLevel = params.numberHolder;
+  public override apply({ numberHolder: statLevel }: NumberHolderParams) {
     const boost = 1;
     statLevel.value += boost;
   }
 }
 
-export class TempCritBoosterTrainerItem extends LapsingTrainerItem {
-  public effects: TrainerItemEffect[] = [TrainerItemEffect.TEMP_CRIT_BOOSTER];
+export class CritBoosterTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.TEMP_CRIT_BOOSTER> {
+  public override readonly effect = TrainerItemEffect.TEMP_CRIT_BOOSTER;
 
   get description(): string {
     return i18next.t("modifierType:ModifierType.TempStatStageBoosterModifierType.description", {
@@ -80,8 +79,7 @@ export class TempCritBoosterTrainerItem extends LapsingTrainerItem {
     });
   }
 
-  apply(_manager: TrainerItemManager, params: NumberHolderParams) {
-    const critLevel = params.numberHolder;
+  public override apply({ numberHolder: critLevel }: NumberHolderParams) {
     critLevel.value++;
   }
 }

--- a/src/items/trainer-items/x-items.ts
+++ b/src/items/trainer-items/x-items.ts
@@ -5,25 +5,21 @@ import { TrainerItemAttr } from "#items/trainer-item-attr";
 import type { NumberHolderParams } from "#types/trainer-item-parameter";
 import i18next from "i18next";
 
-type TempStatToTrainerItemMap = {
-  [key in TempBattleStat]: TrainerItemId;
-};
-
-export const tempStatToTrainerItem: TempStatToTrainerItemMap = {
+export const tempStatToTrainerItem = {
   [Stat.ATK]: TrainerItemId.X_ATTACK,
   [Stat.DEF]: TrainerItemId.X_DEFENSE,
   [Stat.SPATK]: TrainerItemId.X_SP_ATK,
   [Stat.SPDEF]: TrainerItemId.X_SP_DEF,
   [Stat.SPD]: TrainerItemId.X_SPEED,
   [Stat.ACC]: TrainerItemId.X_ACCURACY,
-};
+} as const satisfies Record<TempBattleStat, TrainerItemId>;
 
 export class StatStageBoosterTrainerItemAttr extends TrainerItemAttr<typeof TrainerItemEffect.TEMP_STAT_STAGE_BOOSTER> {
   public override readonly effect = TrainerItemEffect.TEMP_STAT_STAGE_BOOSTER;
-  private readonly stat: TempBattleStat;
+  private readonly stat: Exclude<TempBattleStat, Stat.ACC>;
   private readonly boost: number;
 
-  constructor(stat: TempBattleStat, boost: number) {
+  constructor(stat: Exclude<TempBattleStat, Stat.ACC>, boost: number) {
     super();
 
     this.stat = stat;

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -279,15 +279,6 @@ export function formatStat(stat: number, forHp = false): string {
   return formatLargeNumber(stat, forHp ? 100_000 : 1_000_000);
 }
 
-// TODO: Remove in place of enum utils
-export function getTypedKeys<T extends Record<number, any>, K extends number = Extract<keyof T, number>>(obj: T): K[] {
-  return Object.keys(obj).map(k => Number(k) as K);
-}
-
-export function getTypedEntries<T extends object>(obj: T): [keyof T, T[keyof T]][] {
-  return Object.entries(obj) as [keyof T, T[keyof T]][];
-}
-
 // TODO: Remove in favor of async functions
 export function executeIf<T>(condition: boolean, promiseFunc: () => Promise<T>): Promise<T | undefined> {
   return condition ? promiseFunc() : Promise.resolve(undefined);

--- a/test/matchers/to-have-applied-item.ts
+++ b/test/matchers/to-have-applied-item.ts
@@ -5,7 +5,7 @@ import { HeldItemNames } from "#enums/held-item-id";
 import { HeldItem } from "#items/held-item";
 import { getOnelineDiffStr } from "#test/utils/string-utils";
 import { isPokemonInstance, receivedStr } from "#test/utils/test-utils";
-import type { ApplicableHeldItemId, ExtractItemEffect } from "#types/held-item-data-types";
+import type { ApplicableHeldItemId, ExtractHeldItemEffect } from "#types/held-item-data-types";
 import type { HeldItemEffectParamMap } from "#types/held-item-parameter";
 import type { AtLeastOne } from "#types/type-helpers";
 import { enumValueToKey } from "#utils/enums";
@@ -33,7 +33,7 @@ export type ToHaveAppliedItemOptions<E extends HeldItemEffect> = E extends Effec
  * @param options - A partially-filled parameters object used to query the arguments `item` was called with
  * @returns Whether the matcher passed
  */
-export function toHaveAppliedItem<T extends ApplicableHeldItemId, E extends ExtractItemEffect<T>>(
+export function toHaveAppliedItem<T extends ApplicableHeldItemId, E extends ExtractHeldItemEffect<T>>(
   this: MatcherState,
   received: unknown,
   id: T,

--- a/test/tests/types/held-item-types.test-d.ts
+++ b/test/tests/types/held-item-types.test-d.ts
@@ -1,10 +1,10 @@
 import { HeldItemEffect } from "#enums/held-item-effect";
-import { HeldItemId } from "#enums/held-item-id";
+import { type HeldItemCategoryId, HeldItemId } from "#enums/held-item-id";
 import type { HeldItem } from "#items/held-item";
 import { ConsumableHeldItemAttr, HeldItemAttr } from "#items/held-item-attr";
 import { HeldItemBuilder } from "#items/held-item-builder";
 import type { ErrorType } from "#types/error-type";
-import type { ExtractItemEffect } from "#types/held-item-data-types";
+import type { ExtractHeldItemEffect } from "#types/held-item-data-types";
 import type { IsUnion } from "type-fest";
 import { describe, expectTypeOf, it } from "vitest";
 
@@ -25,6 +25,12 @@ class ConsumableAttr2 extends ConsumableHeldItemAttr<typeof HeldItemEffect.MACHO
 }
 
 const builder = () => new HeldItemBuilder(HeldItemId.ABOMASITE);
+
+describe("HeldItemId and HeldItemCategoryId", () => {
+  it("should be disjoint from one another", () => {
+    expectTypeOf<HeldItemId & HeldItemCategoryId>().toBeNever();
+  });
+});
 
 describe("HeldItemBuilder", () => {
   it("should start with never for both type parameters", () => {
@@ -108,6 +114,6 @@ describe("HeldItemAttr", () => {
 
 describe("ExtractItemEffect", () => {
   it("should map item IDs to effects", () => {
-    expectTypeOf<ExtractItemEffect<typeof HeldItemId.SITRUS_BERRY>>().toEqualTypeOf<typeof HeldItemEffect.BERRY>();
+    expectTypeOf<ExtractHeldItemEffect<typeof HeldItemId.SITRUS_BERRY>>().toEqualTypeOf<typeof HeldItemEffect.BERRY>();
   });
 });

--- a/test/utils/item-test-utils.ts
+++ b/test/utils/item-test-utils.ts
@@ -4,7 +4,7 @@ import type { HeldItemEffect } from "#enums/held-item-effect";
 import { type HeldItemId, HeldItemNames } from "#enums/held-item-id";
 import type { HeldItem } from "#items/held-item";
 import type { HeldItemAttr } from "#items/held-item-attr";
-import type { ApplicableHeldItemId, ExtractItemEffect } from "#types/held-item-data-types";
+import type { ApplicableHeldItemId, ExtractHeldItemEffect } from "#types/held-item-data-types";
 import type { HeldItemEffectParamMap } from "#types/held-item-parameter";
 import { expect } from "vitest";
 
@@ -20,7 +20,7 @@ import { expect } from "vitest";
  * This ensures that items whose functionality depend on stack count or other properties are applied consistently
  * with how they would be during normal gameplay.
  */
-export function applySingleHeldItem<T extends ApplicableHeldItemId, E extends ExtractItemEffect<T>>(
+export function applySingleHeldItem<T extends ApplicableHeldItemId, E extends ExtractHeldItemEffect<T>>(
   itemId: T,
   effect: E,
   params: HeldItemEffectParamMap[E],


### PR DESCRIPTION
This PR builds upon the work laid out in #7273 by expanding the attribute treatment towards the `TrainerItem` class.

This is a significantly larger rewrite than the former (due in part to the fact that trainer items were never made generic nor strongly typed to begin with).