### PR TITLE
refactor: convert `Pokemon#getTypes` and `#isOfType` to object params

### DIFF
--- a/src/ai/ai-moveset-gen.ts
+++ b/src/ai/ai-moveset-gen.ts
@@ -814,7 +814,7 @@ function shouldRemoveSunnyDay(pokemon: Pokemon): boolean {
  */
 // TODO: Extract out common functionality between this and sandstorm
 function removeSnowscapeHail(pokemon: Pokemon, willTera: boolean): boolean {
-  const types = new Set(pokemon.getTypes(willTera, true));
+  const types = new Set(pokemon.getTypes({ includeTeraType: willTera, returnOriginalTypesIfStellar: true }));
   if (types.has(PokemonType.ICE)) {
     return false;
   }
@@ -845,7 +845,7 @@ function removeSnowscapeHail(pokemon: Pokemon, willTera: boolean): boolean {
  * @returns Whether the Pokémon would benefit from Sandstorm
  */
 function shouldRemoveSandstorm(pokemon: Pokemon, willTera: boolean): boolean {
-  if (pokemon.getTypes(willTera, true).includes(PokemonType.ROCK)) {
+  if (pokemon.getTypes({ includeTeraType: willTera, returnOriginalTypesIfStellar: true }).includes(PokemonType.ROCK)) {
     return false;
   }
   if (

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -3460,12 +3460,14 @@ export class BattleScene extends SceneBase {
           form: p.getFormKey(),
           // Does not include temporary changes, such as those from Transform, Forest's Curse, etc
           // Ignores Tera type
-          types: p.getTypes(false, false, true, false).map(pType => capitalizeFirstLetterOnly(PokemonType[pType])),
+          types: p
+            .getTypes({ includeTeraType: false, bypassSummonData: true, ignoreThirdType: true })
+            .map(pType => capitalizeFirstLetterOnly(PokemonType[pType])),
           // Includes temporary changes, such as those from Transform, Forest's Curse, etc
           // Ignores Tera type
           tempTypes:
             p.summonData.types.length > 0 || p.summonData.addedType
-              ? p.getTypes(false, false, false, false).map(pType => capitalizeFirstLetterOnly(PokemonType[pType]))
+              ? p.getTypes({ includeTeraType: false }).map(pType => capitalizeFirstLetterOnly(PokemonType[pType]))
               : [],
           teraType: capitalizeFirstLetterOnly(PokemonType[p.getTeraType()]),
           isTerastallized: p.isTerastallized,

--- a/src/data/abilities/ab-attrs.ts
+++ b/src/data/abilities/ab-attrs.ts
@@ -5625,7 +5625,7 @@ export class TerrainEventTypeChangeAbAttr extends PostSummonAbAttr {
         typeChange.push(PokemonType.PSYCHIC);
         break;
       default:
-        pokemon.getTypes(false, false, true).forEach(t => {
+        pokemon.getTypes({ includeTeraType: false, bypassSummonData: true, ignoreThirdType: true }).forEach(t => {
           typeChange.push(t);
         });
         break;

--- a/src/data/abilities/ab-attrs.ts
+++ b/src/data/abilities/ab-attrs.ts
@@ -882,7 +882,7 @@ export class PostDefendTypeChangeAbAttr extends PostDefendAbAttr {
     }
 
     this.type = attacker.getMoveType(move);
-    if (pokemon.isOfType(this.type, true, true)) {
+    if (pokemon.isOfType(this.type, { returnOriginalTypesIfStellar: true })) {
       return false;
     }
 
@@ -4729,7 +4729,7 @@ export class ArenaTrapAbAttr extends CheckTrappedAbAttr {
   override canApply({ pokemon, opponent }: CheckTrappedAbAttrParams): boolean {
     return (
       this.arenaTrapCondition(pokemon, opponent)
-      && !opponent.isOfType(PokemonType.GHOST, true, true)
+      && !opponent.isOfType(PokemonType.GHOST, { returnOriginalTypesIfStellar: true })
       && !opponent.hasAbility(AbilityId.RUN_AWAY)
     );
   }

--- a/src/data/abilities/init-abilities.ts
+++ b/src/data/abilities/init-abilities.ts
@@ -413,7 +413,9 @@ export function initAbilities() {
       .ignorable()
       .build(),
     new AbBuilder(AbilityId.MAGNET_PULL, 3) //
-      .attr(ArenaTrapAbAttr, (_user, target) => target.isOfType(PokemonType.STEEL, true, true))
+      .attr(ArenaTrapAbAttr, (_user, target) =>
+        target.isOfType(PokemonType.STEEL, { returnOriginalTypesIfStellar: true }),
+      )
       .build(),
     new AbBuilder(AbilityId.SOUNDPROOF, 3) //
       .attr(
@@ -1128,12 +1130,19 @@ export function initAbilities() {
     new AbBuilder(AbilityId.FLOWER_VEIL, 6)
       .attr(
         ConditionalUserFieldStatusEffectImmunityAbAttr,
-        (target, source) => !!source && target.id !== source.id && target.isOfType(PokemonType.GRASS, true, true),
+        (target, source) =>
+          !!source
+          && target.id !== source.id
+          && target.isOfType(PokemonType.GRASS, { returnOriginalTypesIfStellar: true }),
       )
-      .attr(ConditionalUserFieldBattlerTagImmunityAbAttr, target => target.isOfType(PokemonType.GRASS, true, true), [
-        BattlerTagType.DROWSY,
-      ])
-      .attr(ConditionalUserFieldProtectStatAbAttr, target => target.isOfType(PokemonType.GRASS, true, true))
+      .attr(
+        ConditionalUserFieldBattlerTagImmunityAbAttr,
+        target => target.isOfType(PokemonType.GRASS, { returnOriginalTypesIfStellar: true }),
+        [BattlerTagType.DROWSY],
+      )
+      .attr(ConditionalUserFieldProtectStatAbAttr, target =>
+        target.isOfType(PokemonType.GRASS, { returnOriginalTypesIfStellar: true }),
+      )
       .ignorable()
       .ignorable()
       .build(),

--- a/src/data/balance/pokemon-evolutions.ts
+++ b/src/data/balance/pokemon-evolutions.ts
@@ -171,7 +171,7 @@ export class SpeciesEvolutionCondition {
         case EvoCondKey.MOVE_TYPE:
           return pokemon.moveset.some(m => m.getMove().type === cond.pkmnType);
         case EvoCondKey.PARTY_TYPE:
-          return globalScene.getPlayerParty().some(p => p.isOfType(cond.pkmnType, false, false, true))
+          return globalScene.getPlayerParty().some(p => p.isOfType(cond.pkmnType, { includeTeraType: false, bypassSummonData: true, ignoreThirdType: true }))
         case EvoCondKey.EVO_TREASURE_TRACKER:
           return pokemon.getHeldItems().some(m =>
             m.is("EvoTrackerModifier") &&

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2649,8 +2649,9 @@ export class RoostedTag extends BattlerTag {
 
   onRemove(pokemon: Pokemon): void {
     const currentTypes = pokemon.getTypes();
-    const baseTypes = pokemon.getTypes(false, false, true);
+    const baseTypes = pokemon.getTypes({ includeTeraType: false, bypassSummonData: true, ignoreThirdType: true });
 
+    // TODO: this is very wrong
     const forestsCurseApplied: boolean =
       currentTypes.includes(PokemonType.GRASS) && !baseTypes.includes(PokemonType.GRASS);
     const trickOrTreatApplied: boolean =
@@ -2674,7 +2675,7 @@ export class RoostedTag extends BattlerTag {
 
   onAdd(pokemon: Pokemon): void {
     const currentTypes = pokemon.getTypes();
-    const baseTypes = pokemon.getTypes(false, false, true);
+    const baseTypes = pokemon.getTypes({ includeTeraType: false, bypassSummonData: true, ignoreThirdType: true });
 
     const isOriginallyDualType = baseTypes.length === 2;
     const isCurrentlyDualType = currentTypes.length === 2;

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2469,7 +2469,10 @@ export class CritBoostTag extends SerializableBattlerTag {
     super.onAdd(pokemon);
 
     // Dragon cheer adds +2 crit stages if the pokemon is a Dragon type when the tag is added
-    if (this.tagType === BattlerTagType.DRAGON_CHEER && !pokemon.isOfType(PokemonType.DRAGON, true, true)) {
+    if (
+      this.tagType === BattlerTagType.DRAGON_CHEER
+      && !pokemon.isOfType(PokemonType.DRAGON, { returnOriginalTypesIfStellar: true })
+    ) {
       (this as Mutable<this>).critStages = 1;
     } else {
       (this as Mutable<this>).critStages = 2;

--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -806,7 +806,7 @@ export class SingleTypeChallenge extends Challenge {
   applyPokemonInBattle(pokemon: Pokemon, valid: BooleanHolder): boolean {
     if (
       pokemon.isPlayer()
-      && !pokemon.isOfType(this.value - 1, false, false, true)
+      && !pokemon.isOfType(this.value - 1, { includeTeraType: false, bypassSummonData: true, ignoreThirdType: true })
       && !SingleTypeChallenge.TYPE_OVERRIDES.some(
         o =>
           o.type === this.value - 1

--- a/src/data/moves/move-condition.ts
+++ b/src/data/moves/move-condition.ts
@@ -108,7 +108,10 @@ export const failTeleportCondition = new MoveCondition(user => {
   }
   // If smoke ball / shed tail items are ever added, checks for them should be placed here
   // If a conditional "run away" ability is ever added, then we should use the apply method instead of the `hasAbility`
-  if (user.isOfType(PokemonType.GHOST, true, true) || user.hasAbilityWithAttr("RunSuccessAbAttr")) {
+  if (
+    user.isOfType(PokemonType.GHOST, { returnOriginalTypesIfStellar: true })
+    || user.hasAbilityWithAttr("RunSuccessAbAttr")
+  ) {
     return true;
   }
 

--- a/src/data/moves/move-utils.ts
+++ b/src/data/moves/move-utils.ts
@@ -73,7 +73,7 @@ export function getMoveTargets(user: Pokemon, move: MoveId, replaceTarget?: Move
     case MoveTarget.CURSE:
       // Non ghost-type Curse targets exclusively the user; ghost-type Curse targets any enemy
       // TODO: check if the user is about to Terastallize to/from Ghost type
-      if (!user.isOfType(PokemonType.GHOST, true, true)) {
+      if (!user.isOfType(PokemonType.GHOST, { returnOriginalTypesIfStellar: true })) {
         set = [user];
         break;
       }

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -6132,7 +6132,7 @@ export class TeraStarstormTypeAttr extends VariableMoveTypeAttr {
 export class MatchUserTypeAttr extends VariableMoveTypeAttr {
   apply(user: Pokemon, _target: Pokemon, _move: Move, args: [ValueHolder<PokemonType>, ...any[]]): boolean {
     const moveType = args[0];
-    const userTypes = user.getTypes(true, true);
+    const userTypes = user.getTypes({ returnOriginalTypesIfStellar: true });
     if (userTypes.length === 0) {
       return false;
     }
@@ -6145,11 +6145,12 @@ export class MatchUserTypeAttr extends VariableMoveTypeAttr {
     // Instead of calling apply, just return the user's primary type
     // this avoids inconsistencies when the user's type is temporarily changed
     // from tera
-    return [user.getTypes(false, true, true, false)[0] ?? move.type];
+    return [user.getTypes({ includeTeraType: false, bypassSummonData: true, ignoreThirdType: true })[0] ?? move.type];
   }
 
   override getTypeForMovegen(user: Pokemon, move: Move, willTera: boolean): PokemonType {
-    const defaultType = user.getTypes(false, true, true, false)[0] ?? move.type;
+    const defaultType =
+      user.getTypes({ includeTeraType: false, bypassSummonData: true, ignoreThirdType: true })[0] ?? move.type;
     if (willTera) {
       const type = user.getTeraType();
       if (type !== PokemonType.STELLAR) {
@@ -6282,7 +6283,7 @@ export class HitsSameTypeAttr extends MoveTypeChartOverrideAttr {
     args: [multiplier: NumberHolder, types: readonly PokemonType[], moveType: PokemonType],
   ): boolean {
     const [multiplier, oppTypes] = args;
-    const userTypes = user.getTypes(true);
+    const userTypes = user.getTypes();
     // Synchronoise is never effective if the user is typeless
     if (userTypes.includes(PokemonType.UNKNOWN)) {
       multiplier.value = 0;
@@ -6718,7 +6719,7 @@ export class JawLockAttr extends AddBattlerTagAttr {
 
 export class CurseAttr extends MoveEffectAttr {
   apply(user: Pokemon, target: Pokemon, move: Move, _args: any[]): boolean {
-    if (user.getTypes(true).includes(PokemonType.GHOST)) {
+    if (user.getTypes().includes(PokemonType.GHOST)) {
       if (target.getTag(BattlerTagType.CURSED)) {
         globalScene.phaseManager.queueMessage(i18next.t("battle:attackFailed"));
         return false;
@@ -7527,7 +7528,7 @@ export class RemoveTypeAttr extends MoveEffectAttr {
       return false;
     }
 
-    const userTypes = user.getTypes(true);
+    const userTypes = user.getTypes();
     const modifiedTypes = userTypes.filter(type => type !== this.removedType);
     if (modifiedTypes.length === 0) {
       modifiedTypes.push(PokemonType.UNKNOWN);
@@ -7554,7 +7555,7 @@ export class CopyTypeAttr extends MoveEffectAttr {
       return false;
     }
 
-    const targetTypes = target.getTypes(true, true);
+    const targetTypes = target.getTypes({ returnOriginalTypesIfStellar: true });
     // Replace UNKNOWN with grass type
     // TODO: `getTypes` arguably shouldn't include `UNKNOWN` if a type was added anyways,
     // and this should DEFNINITELY get its own helper function for Roost and co.
@@ -9023,7 +9024,7 @@ export class ResistLastMoveTypeAttr extends MoveEffectAttr {
    */
   private getTypeResistances(user: Pokemon, moveType: PokemonType): PokemonType[] {
     const resistances: PokemonType[] = [];
-    const userTypes = user.getTypes(true, true);
+    const userTypes = user.getTypes({ returnOriginalTypesIfStellar: true });
 
     for (const type of getEnumValues(PokemonType)) {
       if (userTypes.includes(type)) {

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -7579,7 +7579,8 @@ export class CopyTypeAttr extends MoveEffectAttr {
   getCondition(): MoveConditionFunc {
     return (user, target) =>
       !user.isTerastallized
-      && (!target.isOfType(PokemonType.UNKNOWN, true, true) || target.summonData.addedType !== null);
+      && (!target.isOfType(PokemonType.UNKNOWN, { returnOriginalTypesIfStellar: true })
+        || target.summonData.addedType !== null);
   }
 }
 
@@ -11278,14 +11279,18 @@ export function initMoves() {
     new StatusMove(MoveId.FLOWER_SHIELD, PokemonType.FAIRY, -1, 10, -1, 0, 6)
       .attr(StatStageChangeAttr, [Stat.DEF], 1, false, {
         condition: (_user, target) =>
-          target.isOfType(PokemonType.GRASS, true, true) && !target.getTag(SemiInvulnerableTag),
+          target.isOfType(PokemonType.GRASS, { returnOriginalTypesIfStellar: true })
+          && !target.getTag(SemiInvulnerableTag),
       })
       .target(MoveTarget.ALL)
       // fails if no non-invulnerable pokemon on field are grass-type
       .condition(() =>
         globalScene
           .getField(true)
-          .some(p => p.isOfType(PokemonType.GRASS, true, true) && !p.getTag(SemiInvulnerableTag)),
+          .some(
+            p =>
+              p.isOfType(PokemonType.GRASS, { returnOriginalTypesIfStellar: true }) && !p.getTag(SemiInvulnerableTag),
+          ),
       ),
     new StatusMove(MoveId.GRASSY_TERRAIN, PokemonType.GRASS, -1, 10, -1, 0, 6)
       .attr(TerrainChangeAttr, TerrainType.GRASSY)
@@ -11613,7 +11618,7 @@ export function initMoves() {
       .attr(PositiveStatStagePowerAttr),
     new AttackMove(MoveId.BURN_UP, PokemonType.FIRE, MoveCategory.SPECIAL, 130, 100, 5, -1, 0, 7)
       // fail if the user is not currently Fire-type (including being Terastallized to Stellar)
-      .condition(user => user.isOfType(PokemonType.FIRE, true, true), 2)
+      .condition(user => user.isOfType(PokemonType.FIRE, { returnOriginalTypesIfStellar: true }), 2)
       .attr(HealStatusEffectAttr, true, StatusEffect.FREEZE)
       .attr(AddBattlerTagAttr, BattlerTagType.BURNED_UP, true, false)
       .attr(RemoveTypeAttr, PokemonType.FIRE, user => {
@@ -12338,7 +12343,7 @@ export function initMoves() {
       .attr(TeraBlastTypeAttr)
       .attr(TeraBlastPowerAttr)
       .attr(StatStageChangeAttr, [Stat.ATK, Stat.SPATK], -1, true, {
-        condition: user => user.isTerastallized && user.isOfType(PokemonType.STELLAR, true, false),
+        condition: user => user.isTerastallized && user.isOfType(PokemonType.STELLAR),
       }),
     new SelfStatusMove(MoveId.SILK_TRAP, PokemonType.BUG, -1, 10, -1, 4, 9)
       .attr(ProtectAttr, BattlerTagType.SILK_TRAP)
@@ -12496,7 +12501,7 @@ export function initMoves() {
       .triageMove(),
     new AttackMove(MoveId.DOUBLE_SHOCK, PokemonType.ELECTRIC, MoveCategory.PHYSICAL, 120, 100, 5, -1, 0, 9)
       // Pass `true` to `isOfType` to fail if the user is terastallized to a type other than ELECTRIC
-      .condition(user => user.isOfType(PokemonType.ELECTRIC, true, true), 2)
+      .condition(user => user.isOfType(PokemonType.ELECTRIC, { returnOriginalTypesIfStellar: true }), 2)
       .attr(AddBattlerTagAttr, BattlerTagType.DOUBLE_SHOCKED, true, false)
       .attr(RemoveTypeAttr, PokemonType.ELECTRIC, user => {
         globalScene.phaseManager.queueMessage(

--- a/src/data/mystery-encounters/encounters/bug-type-superfan-encounter.ts
+++ b/src/data/mystery-encounters/encounters/bug-type-superfan-encounter.ts
@@ -280,7 +280,7 @@ export const BugTypeSuperfanEncounter: MysteryEncounter = MysteryEncounterBuilde
         const encounter = globalScene.currentBattle.mysteryEncounter!;
 
         // Player gets different rewards depending on the number of bug types they have
-        const numBugTypes = globalScene.getPlayerParty().filter(p => p.isOfType(PokemonType.BUG, true)).length;
+        const numBugTypes = globalScene.getPlayerParty().filter(p => p.isOfType(PokemonType.BUG)).length;
         const numBugTypesText = i18next.t(`${namespace}:numBugTypes`, {
           count: numBugTypes,
         });

--- a/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
+++ b/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
@@ -373,7 +373,11 @@ export const ClowningAroundEncounter: MysteryEncounter = MysteryEncounterBuilder
         // Randomize the second type of all player's pokemon
         // If the pokemon does not normally have a second type, it will gain 1
         for (const pokemon of globalScene.getPlayerParty()) {
-          const originalTypes = pokemon.getTypes(false, false, true);
+          const originalTypes = pokemon.getTypes({
+            includeTeraType: false,
+            bypassSummonData: true,
+            ignoreThirdType: true,
+          });
 
           // If the Pokemon has non-status moves that don't match the Pokemon's type, prioritizes those as the new type
           // Makes the "randomness" of the shuffle slightly less punishing

--- a/src/data/mystery-encounters/encounters/fiery-fallout-encounter.ts
+++ b/src/data/mystery-encounters/encounters/fiery-fallout-encounter.ts
@@ -228,7 +228,7 @@ export const FieryFalloutEncounter: MysteryEncounter = MysteryEncounterBuilder.w
       const encounter = globalScene.currentBattle.mysteryEncounter!;
       const nonFireTypes = globalScene
         .getPlayerParty()
-        .filter(p => p.isAllowedInBattle() && !p.isOfType(PokemonType.FIRE, false, false));
+        .filter(p => p.isAllowedInBattle() && !p.isOfType(PokemonType.FIRE, { includeTeraType: false }));
 
       for (const pkm of nonFireTypes) {
         const percentage = DAMAGE_PERCENTAGE / 100;

--- a/src/data/mystery-encounters/mystery-encounter-requirements.ts
+++ b/src/data/mystery-encounters/mystery-encounter-requirements.ts
@@ -517,14 +517,18 @@ export class TypeRequirement extends EncounterPokemonRequirement {
 
   override queryParty(partyPokemon: PlayerPokemon[]): PlayerPokemon[] {
     if (!this.invertQuery) {
-      return partyPokemon.filter(pokemon => this.requiredType.some(type => pokemon.isOfType(type, false, false)));
+      return partyPokemon.filter(pokemon =>
+        this.requiredType.some(type => pokemon.isOfType(type, { includeTeraType: false })),
+      );
     }
     // for an inverted query, we only want to get the pokemon that don't have ANY of the listed types
-    return partyPokemon.filter(pokemon => this.requiredType.every(type => !pokemon.isOfType(type, false, false)));
+    return partyPokemon.filter(pokemon =>
+      this.requiredType.every(type => !pokemon.isOfType(type, { includeTeraType: false })),
+    );
   }
 
   override getDialogueToken(pokemon?: PlayerPokemon): [string, string] {
-    const includedType = this.requiredType.find(ty => pokemon?.isOfType(ty, false, false));
+    const includedType = this.requiredType.find(ty => pokemon?.isOfType(ty, { includeTeraType: false }));
     return ["type", includedType == null ? "" : PokemonType[includedType]];
   }
 }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2032,10 +2032,17 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   // TODO: Make `returnOriginalTypesIfStellar` default to `true`
   public isOfType(
     type: PokemonType,
-    includeTeraType = true,
-    returnOriginalTypesIfStellar = false,
-    bypassSummonData = false,
-    ignoreThirdType = false,
+    {
+      includeTeraType = true,
+      returnOriginalTypesIfStellar = false,
+      bypassSummonData = false,
+      ignoreThirdType = false,
+    }: {
+      includeTeraType?: boolean;
+      returnOriginalTypesIfStellar?: boolean;
+      bypassSummonData?: boolean;
+      ignoreThirdType?: boolean;
+    } = {},
   ): boolean {
     return this.getTypes({ includeTeraType, returnOriginalTypesIfStellar, bypassSummonData, ignoreThirdType }) //
       .includes(type);
@@ -2356,7 +2363,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   public isGrounded(): boolean {
     return (
       !!this.getTag(GroundedTag)
-      || (!this.isOfType(PokemonType.FLYING, true, true)
+      || (!this.isOfType(PokemonType.FLYING, { returnOriginalTypesIfStellar: true })
         && !this.hasAbility(AbilityId.LEVITATE)
         && !this.getTag(BattlerTagType.FLOATING)
         && !this.getTag(SemiInvulnerableTag))
@@ -2696,7 +2703,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
       // Add STAB multiplier for attack type effectiveness.
       // For now, simply don't apply STAB to moves that may change type
-      if (this.isOfType(moveType, true) && !move.getMove().hasAttr("VariableMoveTypeAttr")) {
+      if (this.isOfType(moveType) && !move.getMove().hasAttr("VariableMoveTypeAttr")) {
         thisScore *= 1.5;
       }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -438,7 +438,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       this.luck = (this.shiny ? this.variant + 1 : 0) + (this.fusionShiny ? this.fusionVariant + 1 : 0);
       this.fusionLuck = this.luck;
 
-      this.teraType = randSeedItem(this.getTypes(false, false, true));
+      this.teraType = randSeedItem(
+        this.getTypes({ includeTeraType: false, bypassSummonData: true, ignoreThirdType: true }),
+      );
       this.isTerastallized = false;
       this.stellarTypesBoosted = [];
     }
@@ -1932,18 +1934,26 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Evaluate and return this Pokemon's typing.
-   * @param includeTeraType - (Default `true`) Whether to use this Pokemon's tera type if Terastallized; default `true`
-   * @param returnOriginalTypesIfStellar - (Default `false`) Whether to treat this Pokemon as its original types if it is currently {@linkcode PokemonType.STELLAR | Tera Stellar}
-   * @param ignoreOverride - (Default `false`) Whether to ignore any overrides caused by {@linkcode MoveId.TRANSFORM | Transform} and similar effects; default `false`
-   * @param useIllusion - (Default `false`) Whether to consider an active illusion; default `false`
+   * @param includeTeraType - (Default `true`) Whether to use this Pokemon's Tera type if Terastallized
+   * @param returnOriginalTypesIfStellar - (Default `false`) Whether to treat this Pokemon as its original types if it is currently Tera Stellar
+   * @param bypassSummonData - (Default `false`) Whether to ignore any overrides caused by Transform and similar effects
+   * @param useIllusion - (Default `false`) Whether to consider an active illusion
+   * @param ignoreThirdType - (Default `false`) Whether to ignore the typing added by Forest's Curse or Trick-or-Treat
    * @returns A non-empty array of {@linkcode PokemonType}s corresponding to this Pokemon's typing (real or perceived).
    */
-  public getTypes(
+  public getTypes({
     includeTeraType = true,
     returnOriginalTypesIfStellar = false,
-    ignoreOverride = false,
+    bypassSummonData = false,
     useIllusion = false,
-  ): Mutable<NonEmptyTuple<PokemonType>> {
+    ignoreThirdType = false,
+  }: {
+    includeTeraType?: boolean;
+    returnOriginalTypesIfStellar?: boolean;
+    bypassSummonData?: boolean;
+    useIllusion?: boolean;
+    ignoreThirdType?: boolean;
+  } = {}): Mutable<NonEmptyTuple<PokemonType>> {
     const teraType = this.getTeraType();
     // Stellar tera does nothing defensively (uses original types)
     const shouldUseTeraStellar = !(returnOriginalTypesIfStellar && teraType === PokemonType.STELLAR);
@@ -1952,7 +1962,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       return [teraType];
     }
 
-    const types = new Set(this.getBaseTypes(ignoreOverride, useIllusion));
+    const types = new Set(this.getBaseTypes(bypassSummonData, useIllusion));
 
     // become UNKNOWN if no types are present, or remove it if other types are present.
     // TODO: Move this after the added type checks once Roost is refactored to check removed types correctly
@@ -1963,7 +1973,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }
 
     // check type added to Pokemon from moves like Forest's Curse or Trick Or Treat.
-    if (!ignoreOverride && this.summonData.addedType) {
+    if (!ignoreThirdType && this.summonData.addedType) {
       types.add(this.summonData.addedType);
     }
 
@@ -1973,13 +1983,13 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Helper to {@linkcode getTypes} that handles computing a Pokemon's normal typing.
    */
-  private getBaseTypes(ignoreOverride = false, useIllusion = false): PokemonType[] {
-    if (!ignoreOverride && this.summonData.types.length > 0 && (!this.summonData.illusion || !useIllusion)) {
+  private getBaseTypes(bypassSummonData = false, useIllusion = false): PokemonType[] {
+    if (!bypassSummonData && this.summonData.types.length > 0 && (!this.summonData.illusion || !useIllusion)) {
       return this.summonData.types;
     }
 
-    const speciesForm = this.getSpeciesForm(ignoreOverride, useIllusion);
-    const fusionSpeciesForm = this.getFusionSpeciesForm(ignoreOverride, useIllusion);
+    const speciesForm = this.getSpeciesForm(bypassSummonData, useIllusion);
+    const fusionSpeciesForm = this.getFusionSpeciesForm(bypassSummonData, useIllusion);
 
     // TODO: This `map` call is only needed due to the fact that these arrays use -1 as defaults
     const customTypes = this.customPokemonData.types.map(t => (t === PokemonType.UNKNOWN ? undefined : t));
@@ -2012,10 +2022,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Check if this Pokemon's typing includes the specified type.
    * @param type - The {@linkcode PokemonType} to check
-   * @param includeTeraType - Whether to use this Pokemon's tera type if Terastallized; default `true`
+   * @param includeTeraType - (Default `true`) Whether to use this Pokemon's tera type if Terastallized
    * @param returnOriginalTypesIfStellar - (Default `false`)
-   *   Whether to treat this Pokemon as its original types if it is currently {@linkcode PokemonType.STELLAR | Tera Stellar}
-   * @param ignoreOverride - (Default `false`) Whether to ignore any overrides caused by {@linkcode MoveId.TRANSFORM | Transform} and similar effects
+   *   Whether to treat this Pokemon as its original types if it is currently Tera Stellar
+   * @param bypassSummonData - (Default `false`) Whether to ignore any overrides caused by Transform and similar effects
+   * @param ignoreThirdType - (Default `false`) Whether to ignore the typing added by Forest's Curse or Trick-or-Treat
    * @returns Whether this Pokemon is of the specified type.
    */
   // TODO: Make `returnOriginalTypesIfStellar` default to `true`
@@ -2023,9 +2034,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     type: PokemonType,
     includeTeraType = true,
     returnOriginalTypesIfStellar = false,
-    ignoreOverride = false,
+    bypassSummonData = false,
+    ignoreThirdType = false,
   ): boolean {
-    return this.getTypes(includeTeraType, returnOriginalTypesIfStellar, ignoreOverride).includes(type);
+    return this.getTypes({ includeTeraType, returnOriginalTypesIfStellar, bypassSummonData, ignoreThirdType }) //
+      .includes(type);
   }
 
   /**
@@ -2463,7 +2476,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         : 1,
     );
 
-    if (this.getTypes(true, true).find(t => move.isTypeImmune(source, this, t))) {
+    if (this.getTypes({ returnOriginalTypesIfStellar: true }).find(t => move.isTypeImmune(source, this, t))) {
       typeMultiplier.value = 0;
     }
 
@@ -2544,7 +2557,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       return this.isTerastallized ? 2 : 1;
     }
 
-    const types = this.getTypes(true, true, false, useIllusion);
+    const types = this.getTypes({ returnOriginalTypesIfStellar: true, useIllusion });
     const { arena } = globalScene;
 
     // Handle flying v ground type immunity without removing flying type so effective types are still effective
@@ -2642,7 +2655,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @returns A score value based on how favorable this Pokémon is when fighting the given Pokémon
    */
   getMatchupScore(opponent: Pokemon): number {
-    const enemyTypes = opponent.getTypes(true, false, false, true);
+    const enemyTypes = opponent.getTypes({ useIllusion: true });
     /** Is this Pokemon faster than the opponent? */
     const outspeed =
       (this.isActive(true) ? this.getEffectiveStat(Stat.SPD, opponent) : this.getStat(Stat.SPD, false))
@@ -3612,7 +3625,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       return 1;
     }
 
-    const sourceTypes = source.getTypes(false, false);
+    const sourceTypes = source.getTypes({ includeTeraType: false });
     const sourceTeraType = source.getTeraType();
     const moveType = source.getMoveType(move);
     const matchesSourceType = sourceTypes.includes(source.getMoveType(move));
@@ -4895,7 +4908,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       }
     }
 
-    const types = this.getTypes(true, true);
+    const types = this.getTypes({ returnOriginalTypesIfStellar: true });
 
     /* Whether the target is immune to the specific status being applied. */
     let isImmune = false;

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -488,7 +488,7 @@ export class Trainer extends Phaser.GameObjects.Container {
     if (Object.hasOwn(pokemonPrevolutions, baseSpecies.speciesId) && ret.speciesId !== baseSpecies.speciesId) {
       retry = true;
     } else if (template.isBalanced(battle.enemyParty.length)) {
-      const partyMemberTypes = battle.enemyParty.flatMap(p => p.getTypes(true));
+      const partyMemberTypes = battle.enemyParty.flatMap(p => p.getTypes());
       if (
         partyMemberTypes.indexOf(ret.type1) > -1
         || (ret.type2 !== null && partyMemberTypes.indexOf(ret.type2) > -1)

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -378,7 +378,7 @@ export class MovePhase extends PokemonPhase {
     const move = this.move.getMove();
     if (
       move.findAttr(attr => attr.selfTarget && attr.is("HealStatusEffectAttr") && attr.isOfEffect(StatusEffect.FREEZE))
-      && (move.id !== MoveId.BURN_UP || pokemon.isOfType(PokemonType.FIRE, true, true))
+      && (move.id !== MoveId.BURN_UP || pokemon.isOfType(PokemonType.FIRE, { returnOriginalTypesIfStellar: true }))
     ) {
       this.thaw = true;
       return false;

--- a/src/phases/pokemon-transform-phase.ts
+++ b/src/phases/pokemon-transform-phase.ts
@@ -60,7 +60,7 @@ export class PokemonTransformPhase extends PokemonPhase {
     });
 
     // TODO: This should fallback to the target's original typing if none are left (from Burn Up, etc.)
-    user.summonData.types = target.getTypes(false);
+    user.summonData.types = target.getTypes({ includeTeraType: false });
 
     const promises = [user.updateInfo()];
 

--- a/src/phases/weather-effect-phase.ts
+++ b/src/phases/weather-effect-phase.ts
@@ -64,7 +64,8 @@ export class WeatherEffectPhase extends CommonAnimPhase {
         this.executeForAll((pokemon: Pokemon) => {
           const immune =
             !pokemon
-            || pokemon.getTypes(true, true).filter(t => this.weather?.isTypeDamageImmune(t)).length > 0
+            || pokemon.getTypes({ returnOriginalTypesIfStellar: true }).filter(t => this.weather?.isTypeDamageImmune(t))
+              .length > 0
             || pokemon.switchOutStatus;
           if (!immune) {
             inflictDamage(pokemon);

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -396,7 +396,7 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
 
     this.shinyIcon.setVisible(pokemon.isShiny());
 
-    this.setTypes(pokemon.getTypes(true, false, undefined, true));
+    this.setTypes(pokemon.getTypes({ useIllusion: true }));
 
     const stats = this.statOrder.map(() => 0);
 
@@ -594,7 +594,7 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
 
     this.updateStatusIcon(pokemon);
 
-    this.setTypes(pokemon.getTypes(true, false, undefined, true));
+    this.setTypes(pokemon.getTypes({ useIllusion: true }));
 
     if (this.lastHp !== pokemon.hp || this.lastMaxHp !== pokemon.getMaxHp()) {
       this.updatePokemonHp(pokemon, resolve, instant);

--- a/src/ui/handlers/summary-ui-handler.ts
+++ b/src/ui/handlers/summary-ui-handler.ts
@@ -886,7 +886,11 @@ export class SummaryUiHandler extends UiHandler {
           return typeIcon;
         };
 
-        const types = this.pokemon?.getTypes(false, false, true, false)!; // TODO: is this bang correct?
+        const types = this.pokemon?.getTypes({
+          includeTeraType: false,
+          bypassSummonData: true,
+          ignoreThirdType: true,
+        })!; // TODO: is this bang correct?
         profileContainer.add(getTypeIcon(0, types[0]));
         if (types.length > 1) {
           profileContainer.add(getTypeIcon(1, types[1]));

--- a/test/matchers/to-have-types.ts
+++ b/test/matchers/to-have-types.ts
@@ -24,10 +24,9 @@ export interface ToHaveTypesOptions {
    */
   mode?: "ordered" | "unordered" | "superset" | "oneOf";
   /**
-   * Optional arguments to pass to {@linkcode Pokemon.getTypes}.
+   * (Optional) Arguments to pass to {@linkcode Pokemon.getTypes}.
    */
-  // TODO: Change this to use object spread once `Pokemon.getTypes` has its parameters coaclesced into an object
-  args?: Parameters<Pokemon["getTypes"]>;
+  args?: Parameters<Pokemon["getTypes"]>[0];
 }
 
 /**
@@ -51,7 +50,7 @@ export function toHaveTypes(
   this: Readonly<MatcherState>,
   received: unknown,
   expectedTypes: PokemonType | readonly [PokemonType, ...PokemonType[]],
-  { mode = "unordered", args = [] }: ToHaveTypesOptions = {},
+  { mode = "unordered", args = {} }: ToHaveTypesOptions = {},
 ): SyncExpectationResult {
   if (!isPokemonInstance(received)) {
     return {
@@ -71,7 +70,7 @@ export function toHaveTypes(
   }
 
   // Avoid sorting the types if strict ordering is desired
-  const actualSorted = mode === "ordered" ? received.getTypes(...args) : received.getTypes(...args).toSorted();
+  const actualSorted = mode === "ordered" ? received.getTypes(args) : received.getTypes(args).toSorted();
   const expectedSorted = mode === "ordered" ? expectedTypes : expectedTypes.toSorted();
 
   const actualStr = stringifyEnumArray(PokemonType, actualSorted);

--- a/test/tests/abilities/color-change.test.ts
+++ b/test/tests/abilities/color-change.test.ts
@@ -48,7 +48,10 @@ describe("Ability - Color Change", () => {
       return;
     }
     expect(enemy).not.toHaveAbilityApplied(AbilityId.COLOR_CHANGE);
-    expect(enemy).toHaveTypes(enemy.getTypes(true, true, true), { mode: "ordered" });
+    expect(enemy).toHaveTypes(
+      enemy.getTypes({ returnOriginalTypesIfStellar: true, bypassSummonData: true, ignoreThirdType: true }),
+      { mode: "ordered" },
+    );
   }
 
   it("should change the pokemon's type to the move's type", async () => {


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Easier use of these functions.

## What are the changes from a developer perspective?
- Converted `Pokemon#getTypes` and `#isOfType` to use object params.
- Added `ignoreThirdType` param to both, which handles whether to ignore the type added from Forest's Curse or Trick-or-Treat, split from the `bypassSummonData` param.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR