### PR TITLE
fix(move): Pay Day no longer gives money after running or capturing a pokemon

### DIFF
--- a/src/phases/attempt-capture-phase.ts
+++ b/src/phases/attempt-capture-phase.ts
@@ -127,7 +127,8 @@ export class AttemptCapturePhase extends PokemonPhase {
             globalScene.time.delayedCall(17, () => this.pokeball.setTexture("pb", `${pokeballAtlasKey}`));
 
             const doShake = () => {
-              // After the overall catch rate check, the game does 3 shake checks before confirming the catch.
+              // After the overall catch rate check, the game does 3 shake
+              // checks before confirming the catch.
               let shakeCount = 0;
               const pbX = this.pokeball.x;
               const shakeCounter = globalScene.tweens.addCounter({
@@ -148,7 +149,8 @@ export class AttemptCapturePhase extends PokemonPhase {
                 },
                 onRepeat: () => {
                   if (shakeCount++ < (isCritical ? 1 : 3)) {
-                    // Shake check (skip check for critical or guaranteed captures, but still play the sound)
+                    // Shake check (skip check for critical or guaranteed
+                    // captures, but still play the sound)
                     if (
                       pokeballMultiplier === -1
                       || isCritical
@@ -161,7 +163,8 @@ export class AttemptCapturePhase extends PokemonPhase {
                       this.failCatch(shakeCount);
                     }
                   } else if (isCritical && pokemon.randBattleSeedInt(65536) >= shakeProbability) {
-                    // Above, perform the one shake check for critical captures after the ball shakes once
+                    // Above, perform the one shake check for critical captures
+                    // after the ball shakes once
                     shakeCounter.stop();
                     this.failCatch(shakeCount);
                   } else {
@@ -278,7 +281,7 @@ export class AttemptCapturePhase extends PokemonPhase {
       null,
       () => {
         const end = () => {
-          globalScene.phaseManager.unshiftNew("VictoryPhase", this.battlerIndex);
+          globalScene.phaseManager.unshiftNew("VictoryPhase", this.battlerIndex, false, false);
           globalScene.pokemonInfoContainer.hide();
           this.removePb();
           this.end();

--- a/src/phases/battle-end-phase.ts
+++ b/src/phases/battle-end-phase.ts
@@ -7,11 +7,13 @@ export class BattleEndPhase extends BattlePhase {
   public readonly phaseName = "BattleEndPhase";
   /** If true, will increment battles won */
   isVictory: boolean;
+  shouldPickUpScatteredMoney: boolean;
 
-  constructor(isVictory: boolean) {
+  constructor(isVictory: boolean, shouldPickUpScatteredMoney = isVictory) {
     super();
 
     this.isVictory = isVictory;
+    this.shouldPickUpScatteredMoney = shouldPickUpScatteredMoney;
   }
 
   start() {
@@ -51,7 +53,11 @@ export class BattleEndPhase extends BattlePhase {
     }
 
     if (globalScene.currentBattle.moneyScattered) {
-      globalScene.currentBattle.pickUpScatteredMoney();
+      if (this.shouldPickUpScatteredMoney) {
+        globalScene.currentBattle.pickUpScatteredMoney();
+      } else {
+        globalScene.currentBattle.moneyScattered = 0;
+      }
     }
 
     globalScene.clearEnemyHeldItemModifiers();

--- a/src/phases/victory-phase.ts
+++ b/src/phases/victory-phase.ts
@@ -9,13 +9,17 @@ import { PokemonPhase } from "#phases/pokemon-phase";
 
 export class VictoryPhase extends PokemonPhase {
   public readonly phaseName = "VictoryPhase";
-  /** If true, indicates that the phase is intended for EXP purposes only, and not to continue a battle to next phase */
+  /**
+   * If true, indicates that the phase is intended for EXP purposes only, and
+   * not to continue a battle to next phase
+   */
   isExpOnly: boolean;
+  shouldPickUpScatteredMoney: boolean;
 
-  constructor(battlerIndex: BattlerIndex | number, isExpOnly = false) {
+  constructor(battlerIndex: BattlerIndex | number, isExpOnly = false, shouldPickUpScatteredMoney = true) {
     super(battlerIndex);
-
     this.isExpOnly = isExpOnly;
+    this.shouldPickUpScatteredMoney = shouldPickUpScatteredMoney;
   }
 
   start() {
@@ -41,7 +45,7 @@ export class VictoryPhase extends PokemonPhase {
         .getEnemyParty()
         .find(p => (globalScene.currentBattle.battleType === BattleType.WILD ? p.isOnField() : !p?.isFainted(true)))
     ) {
-      globalScene.phaseManager.pushNew("BattleEndPhase", true);
+      globalScene.phaseManager.pushNew("BattleEndPhase", true, this.shouldPickUpScatteredMoney);
       if (globalScene.currentBattle.battleType === BattleType.TRAINER) {
         globalScene.phaseManager.pushNew("TrainerVictoryPhase");
       }
@@ -61,7 +65,8 @@ export class VictoryPhase extends PokemonPhase {
                 .map(r => globalScene.phaseManager.pushNew("ModifierRewardPhase", modifierTypes[r]));
               break;
             case ClassicFixedBossWaves.EVIL_BOSS_2:
-              // Should get Lock Capsule on 165 before shop phase so it can be used in the rewards shop
+              // Should get Lock Capsule on 165 before shop phase so it can be
+              // used in the rewards shop
               globalScene.phaseManager.pushNew("ModifierRewardPhase", modifierTypes.LOCK_CAPSULE);
               break;
           }

--- a/test/tests/moves/pay-day.test.ts
+++ b/test/tests/moves/pay-day.test.ts
@@ -2,6 +2,7 @@ import { AbilityId } from "#enums/ability-id";
 import { BattlerIndex } from "#enums/battler-index";
 import { Command } from "#enums/command";
 import { MoveId } from "#enums/move-id";
+import { PokeballType } from "#enums/pokeball";
 import { SpeciesId } from "#enums/species-id";
 import { UiMode } from "#enums/ui-mode";
 import type { CommandPhase } from "#phases/command-phase";
@@ -56,6 +57,25 @@ describe("Move - Pay Day", () => {
 
     game.promptHandler.addToNextPrompt("CommandPhase", UiMode.COMMAND, () => {
       (game.scene.phaseManager.getCurrentPhase() as CommandPhase).handleCommand(Command.RUN, 0);
+    });
+
+    await game.toNextTurn();
+
+    expect(game.scene.money).toBe(startingMoney);
+  }, 60000);
+
+  it("should not award scattered money after capturing the wild Pokémon", async () => {
+    game.override.enemyLevel(100);
+
+    await game.classicMode.startBattle(SpeciesId.MEOWTH);
+
+    const startingMoney = game.scene.money;
+
+    game.move.use(MoveId.PAY_DAY);
+    game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+
+    game.promptHandler.addToNextPrompt("CommandPhase", UiMode.COMMAND, () => {
+      (game.scene.phaseManager.getCurrentPhase() as CommandPhase).handleCommand(Command.BALL, PokeballType.MASTER_BALL);
     });
 
     await game.toNextTurn();

--- a/test/tests/moves/pay-day.test.ts
+++ b/test/tests/moves/pay-day.test.ts
@@ -1,0 +1,65 @@
+import { AbilityId } from "#enums/ability-id";
+import { BattlerIndex } from "#enums/battler-index";
+import { Command } from "#enums/command";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { UiMode } from "#enums/ui-mode";
+import type { CommandPhase } from "#phases/command-phase";
+import { GameManager } from "#test/framework/game-manager";
+import Phaser from "phaser";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move - Pay Day", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleStyle("single")
+      .criticalHits(false)
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset(MoveId.SPLASH)
+      .startingLevel(100)
+      .enemyLevel(1);
+  });
+
+  it("should award scattered money after winning the battle", async () => {
+    await game.classicMode.startBattle(SpeciesId.MEOWTH);
+
+    const startingMoney = game.scene.money;
+
+    game.move.use(MoveId.PAY_DAY);
+    game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+    await game.phaseInterceptor.to("BattleEndPhase");
+
+    expect(game.scene.money).toBeGreaterThan(startingMoney);
+  });
+
+  it("should not award scattered money after running from battle", async () => {
+    game.override.enemyLevel(100);
+
+    await game.classicMode.startBattle(SpeciesId.MEOWTH);
+
+    const startingMoney = game.scene.money;
+
+    game.move.use(MoveId.PAY_DAY);
+    game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+
+    game.promptHandler.addToNextPrompt("CommandPhase", UiMode.COMMAND, () => {
+      (game.scene.phaseManager.getCurrentPhase() as CommandPhase).handleCommand(Command.RUN, 0);
+    });
+
+    await game.toNextTurn();
+
+    expect(game.scene.money).toBe(startingMoney);
+  }, 60000);
+});


### PR DESCRIPTION
## What are the changes the user will see?
Pay Day will no longer give players money after running from a battle or capturing a pokemon to mirror the official games.


## Why am I making these changes?
It fixes #5116.

## What are the changes from a developer perspective?
```VictoryPhase``` and ```BattleEndPhase``` now have an optional constructor to determine ```shouldPickUpScatteredMoney```. By default, this is set to true or ```isVictory```, but this can be overridden in special cases such as captures.

## How to test the changes?
A new automated test has been made for Pay Day.

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
 - ~~[ ] I have provided screenshots/videos of the changes (if applicable)~~
  - ~~[ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)~~

~~Are there any localization additions or changes? If so:~~
~~- [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository~~
~~  - ~~If so, include a link to the PR here: _____~~
~~- [ ] I have contacted the Translation Team on Discord for proofreading/translation~~

~~Does this require any additions or changes to in-game assets? If so:~~
- ~~[ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository~~
- ~~If so, include a link to the PR here: _____~~
