### PR TITLE
fix(ai): prevent empty generated movesets

### DIFF
--- a/src/ai/ai-moveset-gen.ts
+++ b/src/ai/ai-moveset-gen.ts
@@ -34,7 +34,10 @@ import {
   ULTRA_TIER_TM_LEVEL_REQUIREMENT,
   ULTRA_TM_MOVESET_WEIGHT,
 } from "#balance/moves/moveset-generation";
-import { getSpeciesDeniedOffensiveStat } from "#balance/moves/off-stat-denylist";
+import {
+  EXCLUDED_MOVES_FOR_WORSE_OFFENSIVE_STAT,
+  getSpeciesDeniedOffensiveStat,
+} from "#balance/moves/off-stat-denylist";
 import { FORCED_RIVAL_SIGNATURE_MOVES, FORCED_SIGNATURE_MOVES } from "#balance/moves/signature-moves";
 import { SUPERCEDED_MOVES } from "#balance/moves/superceded-moves";
 import { tmPoolTiers } from "#balance/tm-pool-tiers";
@@ -360,11 +363,18 @@ function filterMovePool(
 
   for (const [moveId, weight] of pool) {
     const move = allMoves[moveId];
+    // forbid doubles only moves in singles
+    const noDoublesMovesInSingles = isSingles && FORBIDDEN_SINGLES_MOVES.has(moveId);
+    // forbid level based denylist moves
+    const applyLevelBasedDenyList = level >= LEVEL_BASED_DENYLIST_THRESHOLD && LEVEL_BASED_DENYLIST.has(moveId);
+    // forbid moves that use the worse offensive stat
+    const excludeWorseOffensiveStatMoves =
+      move.category !== MoveCategory.STATUS
+      && !EXCLUDED_MOVES_FOR_WORSE_OFFENSIVE_STAT.has(moveId)
+      && worseOffensiveStatDenylist != null
+      && doesMoveMatchOffensiveCategory(move, worseOffensiveStatDenylist);
     const isSoftBlocked =
-      (!ignoreSoftBlocklists
-        && ((isSingles && FORBIDDEN_SINGLES_MOVES.has(moveId)) // forbid doubles only moves in singles
-          || (level >= LEVEL_BASED_DENYLIST_THRESHOLD && LEVEL_BASED_DENYLIST.has(moveId)))) // forbid level based denylist moves
-      || (worseOffensiveStatDenylist != null && doesMoveMatchOffensiveCategory(move, worseOffensiveStatDenylist)); // forbid moves that use the worse offensive stat
+      !ignoreSoftBlocklists && (noDoublesMovesInSingles || applyLevelBasedDenyList || excludeWorseOffensiveStatMoves);
     if (
       weight <= 0
       || move.name.endsWith(" (N)") // Forbid unimplemented moves
@@ -1243,7 +1253,7 @@ export function generateMoveset(pokemon: Pokemon, forceRivalSignatures = false):
   const unfilteredMovePool = new Map(movePool);
   filterMovePool(movePool, isBoss, hasTrainer, pokemon);
   if (movePool.size === 0 && unfilteredMovePool.size > 0) {
-    movePool = new Map(unfilteredMovePool);
+    movePool = unfilteredMovePool;
     filterMovePool(movePool, isBoss, hasTrainer, pokemon, true);
   }
 

--- a/src/ai/ai-moveset-gen.ts
+++ b/src/ai/ai-moveset-gen.ts
@@ -34,10 +34,7 @@ import {
   ULTRA_TIER_TM_LEVEL_REQUIREMENT,
   ULTRA_TM_MOVESET_WEIGHT,
 } from "#balance/moves/moveset-generation";
-import {
-  EXCLUDED_MOVES_FOR_WORSE_OFFENSIVE_STAT,
-  getSpeciesDeniedOffensiveStat,
-} from "#balance/moves/off-stat-denylist";
+import { getSpeciesDeniedOffensiveStat } from "#balance/moves/off-stat-denylist";
 import { FORCED_RIVAL_SIGNATURE_MOVES, FORCED_SIGNATURE_MOVES } from "#balance/moves/signature-moves";
 import { SUPERCEDED_MOVES } from "#balance/moves/superceded-moves";
 import { tmPoolTiers } from "#balance/tm-pool-tiers";
@@ -342,8 +339,15 @@ function filterSupercededMoves(pool: Map<MoveId, number>, ...otherPools: Map<Mov
  * @param isBoss - Whether the Pokémon is a boss
  * @param hasTrainer - Whether the Pokémon has a trainer
  * @param pokemon - The Pokémon having its moveset generated
+ * @param ignoreSoftBlocklists - Whether to ignore movegen blocklists that are allowed as a fallback
  */
-function filterMovePool(pool: Map<MoveId, number>, isBoss: boolean, hasTrainer: boolean, pokemon: Pokemon): void {
+function filterMovePool(
+  pool: Map<MoveId, number>,
+  isBoss: boolean,
+  hasTrainer: boolean,
+  pokemon: Pokemon,
+  ignoreSoftBlocklists = false,
+): void {
   const isSingles = !globalScene.currentBattle?.double;
   const level = pokemon.level;
   const blockWeatherSettingMoves =
@@ -356,6 +360,11 @@ function filterMovePool(pool: Map<MoveId, number>, isBoss: boolean, hasTrainer: 
 
   for (const [moveId, weight] of pool) {
     const move = allMoves[moveId];
+    const isSoftBlocked =
+      (!ignoreSoftBlocklists
+        && ((isSingles && FORBIDDEN_SINGLES_MOVES.has(moveId)) // forbid doubles only moves in singles
+          || (level >= LEVEL_BASED_DENYLIST_THRESHOLD && LEVEL_BASED_DENYLIST.has(moveId)))) // forbid level based denylist moves
+      || (worseOffensiveStatDenylist != null && doesMoveMatchOffensiveCategory(move, worseOffensiveStatDenylist)); // forbid moves that use the worse offensive stat
     if (
       weight <= 0
       || move.name.endsWith(" (N)") // Forbid unimplemented moves
@@ -363,12 +372,7 @@ function filterMovePool(pool: Map<MoveId, number>, isBoss: boolean, hasTrainer: 
       || (isBoss && (move.hasAttr("SacrificialAttr") || move.hasAttr("HpSplitAttr"))) // Bosses never get self ko moves or Pain Split
       || (hasTrainer && move.hasAttr("OneHitKOAttr")) // trainers never get OHKO moves
       || ((isBoss || hasTrainer) // Following conditions do not apply to normal wild pokemon
-        && ((isSingles && FORBIDDEN_SINGLES_MOVES.has(moveId)) // forbid doubles only moves in singles
-          || (level >= LEVEL_BASED_DENYLIST_THRESHOLD && LEVEL_BASED_DENYLIST.has(moveId)) // forbid level based denylist moves
-          || (move.category !== MoveCategory.STATUS
-            && !EXCLUDED_MOVES_FOR_WORSE_OFFENSIVE_STAT.has(moveId)
-            && worseOffensiveStatDenylist != null
-            && doesMoveMatchOffensiveCategory(move, worseOffensiveStatDenylist))
+        && (isSoftBlocked
           || (move.hasAttr("WeatherChangeAttr") && blockWeatherSettingMoves) // Forbid weather setting moves if the pokemon has a weather summoning or suppressing ability
           || (move.hasAttr("TerrainChangeAttr") && blockTerrainSettingMoves) // Forbid terrain setting moves if the pokemon has a terrain summoning ability
           || (hasGorillaTactics && move.category === MoveCategory.STATUS))) // Forbid status moves if pokemon has Gorilla Tactics
@@ -1233,10 +1237,15 @@ export function generateMoveset(pokemon: Pokemon, forceRivalSignatures = false):
 
   // Now, combine pools into one master pool.
   // The pools are kept around so we know where the move was sourced from
-  const movePool = new Map<MoveId, number>([...tmPool.entries(), ...eggMovePool.entries(), ...learnPool.entries()]);
+  let movePool = new Map<MoveId, number>([...tmPool.entries(), ...eggMovePool.entries(), ...learnPool.entries()]);
 
   // Step 2: Filter out forbidden moves
+  const unfilteredMovePool = new Map(movePool);
   filterMovePool(movePool, isBoss, hasTrainer, pokemon);
+  if (movePool.size === 0 && unfilteredMovePool.size > 0) {
+    movePool = new Map(unfilteredMovePool);
+    filterMovePool(movePool, isBoss, hasTrainer, pokemon, true);
+  }
 
   // Step 3: Adjust weights for trainers
   if (hasTrainer) {

--- a/test/tests/ai/ai-moveset-gen.test.ts
+++ b/test/tests/ai/ai-moveset-gen.test.ts
@@ -295,7 +295,7 @@ describe("Regression Tests - ai-moveset-gen.ts", () => {
 
     it("should fall back to soft-blocked moves instead of generating an empty moveset", async () => {
       pokemon = createTestablePokemon(SpeciesId.BLIPBUG, { level: 10, boss: true });
-      vi.spyOn(pokemon, "getLevelMoves").mockReturnValue([[1, MoveId.HELPING_HAND]]);
+      vi.spyOn(pokemon, "getLevelMoves").mockReturnValue([[1, MoveId.HELPING_HAND, LearnableMoveSource.OTHER]]);
 
       generateMoveset(pokemon);
 

--- a/test/tests/ai/ai-moveset-gen.test.ts
+++ b/test/tests/ai/ai-moveset-gen.test.ts
@@ -292,5 +292,14 @@ describe("Regression Tests - ai-moveset-gen.ts", () => {
       generateMoveset(pokemon);
       expect(pokemon.moveset).toHaveLength(4);
     });
+
+    it("should fall back to soft-blocked moves instead of generating an empty moveset", async () => {
+      pokemon = createTestablePokemon(SpeciesId.BLIPBUG, { level: 10, boss: true });
+      vi.spyOn(pokemon, "getLevelMoves").mockReturnValue([[1, MoveId.HELPING_HAND]]);
+
+      generateMoveset(pokemon);
+
+      expect(pokemon.moveset.map(m => m.moveId)).toEqual([MoveId.HELPING_HAND]);
+    });
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?

Enemy Pokemon generated by the AI will no longer be able to end up with an empty moveset when every otherwise valid move is removed only by the soft deny lists.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

Fixes #7313.

The AI moveset generator could filter all available moves out for some enemy Pokemon, leaving them with no usable moves. This fallback keeps the existing hard safety filters, but retries without the soft blocklists if the normal filtering pass would otherwise produce an empty moveset.

## What are the changes from a developer perspective?

- `filterMovePool` now accepts an optional `ignoreSoftBlocklists` flag.
- `generateMoveset` keeps a snapshot of the combined learn/TM/egg move pool before the normal filtering pass.
- If the normal filtering pass empties a non-empty pool, the generator retries using the snapshot while ignoring only the soft blocklists (`FORBIDDEN_SINGLES_MOVES` and `LEVEL_BASED_DENYLIST`).
- Hard exclusions remain in place for unimplemented moves, invalid weights, boss self-KO/Pain Split cases, trainer OHKO moves, and unsupported weather/terrain constraints.
- Added a regression test covering the fallback path.

## Screenshots/Videos

N/A. This is not a visual change.

## How to test the changes?

Automated/local checks used:

- `pnpm exec biome check --write src/ai/ai-moveset-gen.ts test/tests/ai/ai-moveset-gen.test.ts --diagnostic-level=error`
- `pnpm typecheck`

I also attempted `pnpm test:silent test/tests/ai/ai-moveset-gen.test.ts`, but the isolated suite currently fails during existing test harness setup before this regression runs (`Iterator.drop` / `GameManager` initialization in test helpers).

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [ ] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [x] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [x] N/A, this PR does not add or change localization.
- [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: N/A
- [ ] I have contacted the Translation Team on Discord for proofreading/translation

Does this require any additions or changes to in-game assets? If so:
- [x] N/A, this PR does not add or change assets.
- [ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: N/A