### PR TITLE
fix(ui): Adjustments of Held items in Summary

### DIFF
--- a/src/ui/handlers/summary-ui-handler.ts
+++ b/src/ui/handlers/summary-ui-handler.ts
@@ -1032,9 +1032,9 @@ export class SummaryUiHandler extends UiHandler {
       case Page.STATS: {
         this.statsContainer = globalScene.add.container(0, -pageBg.height);
         pageContainer.add(this.statsContainer);
-        this.permStatsContainer = globalScene.add.container(27, 56);
+        this.permStatsContainer = globalScene.add.container(27, 64);
         this.statsContainer.add(this.permStatsContainer);
-        this.ivContainer = globalScene.add.container(27, 56);
+        this.ivContainer = globalScene.add.container(27, 64);
         this.statsContainer.add(this.ivContainer);
         this.statsContainer.setVisible(true);
 
@@ -1044,19 +1044,19 @@ export class SummaryUiHandler extends UiHandler {
 
         this.statsContainerStatsTitle = globalScene.add.image(
           16,
-          51,
+          59,
           getLocalizedSpriteKey("summary_stats_stats_title"), // Pixel text 'STATS'
         );
         this.statsContainerStatsTitle.setOrigin(0, 0.5);
         this.statsContainer.add(this.statsContainerStatsTitle);
 
-        this.statsContainerExpTitle = globalScene.add.image(7, 107, getLocalizedSpriteKey("summary_stats_exp_title")); // Pixel text 'EXP.'
+        this.statsContainerExpTitle = globalScene.add.image(7, 115, getLocalizedSpriteKey("summary_stats_exp_title")); // Pixel text 'EXP.'
         this.statsContainerExpTitle.setOrigin(0, 0.5);
         this.statsContainer.add(this.statsContainerExpTitle);
 
         this.statsContainerExpBarTitle = globalScene.add.image(
           126,
-          144,
+          152,
           getLocalizedSpriteKey("summary_stats_expbar_title"), // Pixel mini text 'EXP'
         );
         this.statsContainerExpBarTitle.setOrigin(0, 0);
@@ -1117,7 +1117,7 @@ export class SummaryUiHandler extends UiHandler {
         itemModifiers.forEach((item, i) => {
           const icon = item.getIcon(true);
 
-          icon.setPosition((i % 17) * 12 + 3, 14 * Math.floor(i / 17) + 15);
+          icon.setPosition((i % 17) * 12 + 3, 14 * Math.floor(i / 17) + 10);
           this.statsContainer.add(icon);
 
           icon.setInteractive(new Phaser.Geom.Rectangle(0, 0, 32, 32), Phaser.Geom.Rectangle.Contains);
@@ -1132,25 +1132,25 @@ export class SummaryUiHandler extends UiHandler {
         const relLvExp = getLevelRelExp(pkmLvl + 1, pkmSpeciesGrowthRate);
         const expRatio = pkmLvl < globalScene.getMaxExpLevel() ? pkmLvlExp / relLvExp : 0;
 
-        const expLabel = addTextObject(6, 112, i18next.t("pokemonSummary:expPoints"), TextStyle.SUMMARY);
+        const expLabel = addTextObject(6, 120, i18next.t("pokemonSummary:expPoints"), TextStyle.SUMMARY);
         expLabel.setOrigin(0, 0);
         this.statsContainer.add(expLabel);
 
-        const nextLvExpLabel = addTextObject(6, 128, i18next.t("pokemonSummary:nextLv"), TextStyle.SUMMARY);
+        const nextLvExpLabel = addTextObject(6, 136, i18next.t("pokemonSummary:nextLv"), TextStyle.SUMMARY);
         nextLvExpLabel.setOrigin(0, 0);
         this.statsContainer.add(nextLvExpLabel);
 
-        const expText = addTextObject(213, 112, pkmExp.toString(), TextStyle.WINDOW_ALT);
+        const expText = addTextObject(213, 120, pkmExp.toString(), TextStyle.WINDOW_ALT);
         expText.setOrigin(1, 0);
         this.statsContainer.add(expText);
 
         const nextLvExp =
           pkmLvl < globalScene.getMaxExpLevel() ? getLevelTotalExp(pkmLvl + 1, pkmSpeciesGrowthRate) - pkmExp : 0;
-        const nextLvExpText = addTextObject(213, 128, nextLvExp.toString(), TextStyle.WINDOW_ALT);
+        const nextLvExpText = addTextObject(213, 136, nextLvExp.toString(), TextStyle.WINDOW_ALT);
         nextLvExpText.setOrigin(1, 0);
         this.statsContainer.add(nextLvExpText);
 
-        const expOverlay = globalScene.add.image(140, 145, "summary_stats_overlay_exp");
+        const expOverlay = globalScene.add.image(140, 153, "summary_stats_overlay_exp");
         expOverlay.setOrigin(0, 0);
         this.statsContainer.add(expOverlay);
 
@@ -1168,7 +1168,7 @@ export class SummaryUiHandler extends UiHandler {
           0,
           globalScene.inputController?.gamepadSupport ? "summary_profile_prompt_a" : "summary_profile_prompt_z",
         );
-        this.abilityPrompt.setPosition(8, 47);
+        this.abilityPrompt.setPosition(8, 55);
         this.abilityPrompt.setVisible(true);
         this.abilityPrompt.setOrigin(0, 0);
         this.statsContainer.add(this.abilityPrompt);


### PR DESCRIPTION
## What are the changes the user will see?
The 3rd row of items in the summary will be properly displayed

## Why am I making these changes?
Ajustement of the held itms container in the Summary UI to properly accomodate a 3rd row of items

## What are the changes from a developer perspective?
--

## Screenshots/Videos

<details><summary>Before</summary>
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/06acf930-2b3b-4e78-82b9-6321be52d316" />
</details>
<details><summary>After</summary>
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f4a668e5-483d-443e-b10a-fc62f0a9d71a" />
</details>

## How to test the changes?
Play a run with a lot of items

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [x] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Does this require any additions or changes to in-game assets? If so:
- [x] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: https://github.com/pagefaultgames/pokerogue-assets/pull/88
