### PR TITLE
i18n: Move effectiveness multiplier translatable

### DIFF
--- a/src/ui/containers/pokemon-info-container.ts
+++ b/src/ui/containers/pokemon-info-container.ts
@@ -39,6 +39,11 @@ const languageSettings: { [key: string]: LanguageSetting } = {
     infoContainerLabelXPos: -27,
     infoContainerTextXPos: -25,
   },
+  pl: {
+    infoContainerTextSize: "54px",
+    infoContainerLabelXPos: -20,
+    infoContainerTextXPos: -17,
+  },
 };
 
 export class PokemonInfoContainer extends Phaser.GameObjects.Container {

--- a/src/ui/handlers/fight-ui-handler.ts
+++ b/src/ui/handlers/fight-ui-handler.ts
@@ -333,12 +333,12 @@ export class FightUiHandler extends UiHandler implements InfoToggle {
     );
     if (pokemonMove.getMove().category === MoveCategory.STATUS) {
       if (effectiveness === 0) {
-        return "0x";
+        return i18next.t("fightUiHandler:effectiveness000");
       }
-      return "1x";
+      return i18next.t("fightUiHandler:effectiveness100");
     }
 
-    return `${effectiveness}x`;
+    return i18next.t("fightUiHandler:effectivenessMultiplier", { effectiveness });
   }
 
   displayMoves() {

--- a/src/ui/handlers/starter-select-ui-handler.ts
+++ b/src/ui/handlers/starter-select-ui-handler.ts
@@ -202,9 +202,10 @@ const languageSettings: { [key: string]: LanguageSetting } = {
     instructionTextSize: "28px",
   },
   vi: {
-    starterInfoTextSize: "56px",
+    starterInfoTextSize: "50px",
     instructionTextSize: "28px",
-    starterInfoXPos: 35,
+    starterInfoYOffset: 0.5,
+    starterInfoXPos: 34,
   },
   tl: {
     starterInfoTextSize: "56px",

--- a/src/ui/handlers/starter-select-ui-handler.ts
+++ b/src/ui/handlers/starter-select-ui-handler.ts
@@ -174,7 +174,6 @@ const languageSettings: { [key: string]: LanguageSetting } = {
     starterInfoTextSize: "48px",
     instructionTextSize: "28px",
     starterInfoYOffset: 0.5,
-    starterInfoXPos: 40,
   },
   ro: {
     starterInfoTextSize: "56px",


### PR DESCRIPTION
## What are the changes the user will see?
N/a

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
To have it translatable

## What are the changes from a developer perspective?
None

## Screenshots/Videos
--

## How to test the changes?
Play the game and check the effectivness multiplier of a move on the opponent

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [x] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: https://github.com/pagefaultgames/pokerogue-locales/pull/317
- [x] I have contacted the Translation Team on Discord for proofreading/translation
