### PR TITLE
chore!: Hotfix 1.11.20 to main

### DIFF
--- a/.github/scripts/changelog-reader/main.mts
+++ b/.github/scripts/changelog-reader/main.mts
@@ -115,8 +115,8 @@ async function getPullRequests(commits: Set<string>): Promise<PullRequest[]> {
         repo: CONFIG.REPO_NAME,
         commit_sha: sha,
       });
-      const pr = prs.data.at(-1);
-      if (!pr || !pr.merged_at) {
+      const pr = prs.data.find(p => p.merged_at != null && p.base.ref === CONFIG.REPO_BRANCH);
+      if (!pr) {
         continue;
       }
       const section = getChangelogSection(pr.body || "");

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pokemon-rogue-battle",
   "private": true,
-  "version": "1.11.19",
+  "version": "1.11.20",
   "type": "module",
   "scripts": {
     "start:prod": "vite --mode production",

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -88,6 +88,7 @@ import { BiomeId } from "#enums/biome-id";
 import { ChallengeType } from "#enums/challenge-type";
 import { Challenges } from "#enums/challenges";
 import { DexAttr } from "#enums/dex-attr";
+import { ExpGainsSpeed } from "#enums/exp-gains-speed";
 import { FieldPosition } from "#enums/field-position";
 import { HitResult } from "#enums/hit-result";
 import { LearnMoveSituation } from "#enums/learn-move-situation";
@@ -6438,7 +6439,7 @@ export class PlayerPokemon extends Pokemon {
    * @param lastLevel - The level of this Pokemon before the EXP increase
    */
   public async showExpGain(lastLevel: number): Promise<void> {
-    await this.battleInfo.updatePokemonExpDisplay(this, lastLevel);
+    await this.battleInfo.updatePokemonExpDisplay(this, lastLevel, globalScene.expGainsSpeed === ExpGainsSpeed.SKIP);
     await this.updateInfo();
   }
 

--- a/src/phases/level-up-phase.ts
+++ b/src/phases/level-up-phase.ts
@@ -33,7 +33,6 @@ export class LevelUpPhase extends PlayerPartyMemberPokemonPhase {
     const prevStats = this.pokemon.stats.slice(0);
 
     this.pokemon.calculateStats();
-    this.pokemon.getBattleInfo().setLevelDisplay(this.pokemon.level);
     this.pokemon.updateInfo();
 
     switch (globalScene.expParty) {

--- a/src/phases/victory-phase.ts
+++ b/src/phases/victory-phase.ts
@@ -9,8 +9,9 @@ import { PokemonPhase } from "#phases/pokemon-phase";
 
 export class VictoryPhase extends PokemonPhase {
   public readonly phaseName = "VictoryPhase";
+
   /** If true, indicates that the phase is intended for EXP purposes only, and not to continue a battle to next phase */
-  isExpOnly: boolean;
+  private readonly isExpOnly: boolean;
 
   constructor(battlerIndex: BattlerIndex | number, isExpOnly = false) {
     super(battlerIndex);
@@ -18,7 +19,7 @@ export class VictoryPhase extends PokemonPhase {
     this.isExpOnly = isExpOnly;
   }
 
-  start() {
+  public override start(): void {
     super.start();
 
     const isMysteryEncounter = globalScene.currentBattle.isBattleMysteryEncounter();
@@ -33,13 +34,16 @@ export class VictoryPhase extends PokemonPhase {
 
     if (isMysteryEncounter) {
       handleMysteryEncounterVictory(false, this.isExpOnly);
-      return this.end();
+      this.end();
+      return;
     }
 
+    // TODO: clean this up a bit - this shouldn't use `.find`; invert conditional and use early return
     if (
       !globalScene
         .getEnemyParty()
         .find(p => (globalScene.currentBattle.battleType === BattleType.WILD ? p.isOnField() : !p?.isFainted()))
+      && !globalScene.phaseManager.hasPhaseOfType("TrainerVictoryPhase") // temporary hotfix
     ) {
       globalScene.phaseManager.pushNew("BattleEndPhase", true);
       if (globalScene.currentBattle.battleType === BattleType.TRAINER) {

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -57,7 +57,6 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
   protected lastHp: number;
   protected lastMaxHp: number;
   protected lastHpFrame: string | null;
-  protected lastLevelCapped: boolean;
   protected lastStats: string;
 
   protected box: Phaser.GameObjects.Sprite;

--- a/src/ui/battle-info/player-battle-info.ts
+++ b/src/ui/battle-info/player-battle-info.ts
@@ -141,8 +141,8 @@ export class PlayerBattleInfo extends BattleInfo {
    * @param lastLevel - The level the Pokemon was at before the update
    * @param lastLevelExp - The relative EXP the Pokemon had within its level before the update
    */
-  public async updatePokemonExpDisplay(pokemon: PlayerPokemon, lastLevel: number): Promise<void> {
-    if (globalScene.expGainsSpeed === ExpGainsSpeed.SKIP) {
+  public async updatePokemonExpDisplay(pokemon: PlayerPokemon, lastLevel: number, skip: boolean): Promise<void> {
+    if (skip) {
       this.setLevelDisplay(pokemon.level);
       const relLevelExp = getLevelRelExp(pokemon.level + 1, pokemon.species.growthRate);
       this.expMaskRect.x = EXP_BAR_WIDTH * (relLevelExp === 0 ? 0 : pokemon.levelExp / relLevelExp);
@@ -154,6 +154,11 @@ export class PlayerBattleInfo extends BattleInfo {
     }
 
     await this.doUpdateExpAnimation(pokemon, pokemon.level, false);
+  }
+
+  public override async updateInfo(pokemon: PlayerPokemon, instant?: boolean): Promise<void> {
+    await super.updateInfo(pokemon, instant);
+    this.updatePokemonExpDisplay(pokemon, pokemon.level, true);
   }
 
   /**
@@ -195,10 +200,7 @@ export class PlayerBattleInfo extends BattleInfo {
 
     const levelDurationMultiplier = this.getLevelDurationMultiplier(lastLevel, pokemon.level);
     let duration = this.visible
-      ? ((nextWidth - this.expMaskRect.x) / EXP_BAR_WIDTH)
-        * BattleInfo.EXP_GAINS_DURATION_BASE
-        * durationMultiplier
-        * levelDurationMultiplier
+      ? ratio * BattleInfo.EXP_GAINS_DURATION_BASE * durationMultiplier * levelDurationMultiplier
       : 0;
     if (speed && speed >= ExpGainsSpeed.DEFAULT) {
       duration = speed >= ExpGainsSpeed.SKIP ? ExpGainsSpeed.DEFAULT : duration / Math.pow(2, speed);
@@ -224,7 +226,7 @@ export class PlayerBattleInfo extends BattleInfo {
             this.setLevelDisplay(level);
             globalScene.time.delayedCall(500 * levelDurationMultiplier, () => {
               this.expMaskRect.x = 0;
-              this.updateInfo(pokemon).then(() => resolve());
+              resolve();
             });
             return;
           }

--- a/test/tests/battle/double-battle.test.ts
+++ b/test/tests/battle/double-battle.test.ts
@@ -1,10 +1,13 @@
 import { getGameMode } from "#app/game-mode";
 import { Status } from "#data/status-effect";
 import { AbilityId } from "#enums/ability-id";
+import { BattleType } from "#enums/battle-type";
 import { GameModes } from "#enums/game-modes";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
+import { TrainerType } from "#enums/trainer-type";
+import { TrainerVariant } from "#enums/trainer-variant";
 import { GameManager } from "#test/framework/game-manager";
 import Phaser from "phaser";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -23,16 +26,20 @@ describe("Double Battles", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
+    game.override //
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset(MoveId.SPLASH)
+      .ability(AbilityId.BALL_FETCH);
   });
 
   // double-battle player's pokemon both fainted in same round, then revive one, and next double battle summons two player's pokemon successfully.
   // (There were bugs that either only summon one when can summon two, player stuck in switchPhase etc)
   it("3v2 edge case: player summons 2 pokemon on the next battle after being fainted and revived", async () => {
-    game.override.battleStyle("double").enemyMoveset(MoveId.SPLASH).moveset(MoveId.SPLASH);
+    game.override.battleStyle("double");
     await game.classicMode.startBattle(SpeciesId.BULBASAUR, SpeciesId.CHARIZARD, SpeciesId.SQUIRTLE);
 
-    game.move.select(MoveId.SPLASH);
-    game.move.select(MoveId.SPLASH, 1);
+    game.move.use(MoveId.SPLASH);
+    game.move.use(MoveId.SPLASH, 1);
 
     for (const pokemon of game.scene.getPlayerField()) {
       pokemon.hp = 0;
@@ -61,12 +68,6 @@ describe("Double Battles", () => {
       return rngSweepProgress * (max - min) + min;
     });
 
-    game.override
-      .enemyMoveset(MoveId.SPLASH)
-      .moveset(MoveId.SPLASH)
-      .enemyAbility(AbilityId.BALL_FETCH)
-      .ability(AbilityId.BALL_FETCH);
-
     // Play through endless, waves 1 to 9, counting number of double battles from waves 2 to 9
     await game.classicMode.startBattle(SpeciesId.BULBASAUR);
     game.scene.gameMode = getGameMode(GameModes.ENDLESS);
@@ -74,7 +75,7 @@ describe("Double Battles", () => {
     for (let i = 0; i < DOUBLE_CHANCE; i++) {
       rngSweepProgress = (i + 0.5) / DOUBLE_CHANCE;
 
-      game.move.select(MoveId.SPLASH);
+      game.move.use(MoveId.SPLASH);
       await game.doKillOpponents();
       await game.toNextWave();
 
@@ -87,5 +88,22 @@ describe("Double Battles", () => {
 
     expect(doubleCount).toBe(1);
     expect(singleCount).toBe(DOUBLE_CHANCE - 1);
+  });
+
+  it("won't queue multiple `BattleEndPhase`s/etc if the last 2 enemy Pokemon are defeated simultaneously in a trainer battle", async () => {
+    game.override //
+      .battleType(BattleType.TRAINER)
+      .randomTrainer({ trainerType: TrainerType.YOUNGSTER, trainerVariant: TrainerVariant.DOUBLE })
+      .startingLevel(200);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    expect(game.field.getEnemyParty()).toHaveLength(2);
+    expect(game.scene.getEnemyField()).toHaveLength(2);
+
+    game.move.use(MoveId.SURF);
+    await game.toEndOfTurn(false);
+
+    expect(game.scene.phaseManager["phaseQueue"].findAll("BattleEndPhase")).toHaveLength(1);
   });
 });


### PR DESCRIPTION
**Changelog:** hotfix-1.11.20 ---> main
---------------------------
## Bug Fixes

- #7325
  - The game won't crash if the last 2 enemy Pokémon are defeated with a spread move in a doubles trainer battle.
## Miscellaneous

- #7328
  - The player's level won't stay red after a biome change when at the level cap, and the exp bar will update properly after a rare candy is used.
## Unknown

- #7327

---------------------------
**This changelog was auto generated at May 26, 2026 at 4:45 AM UTC.**