### PR TITLE
fix(ui): Update level display on cap phase

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -88,6 +88,7 @@ import { BiomeId } from "#enums/biome-id";
 import { ChallengeType } from "#enums/challenge-type";
 import { Challenges } from "#enums/challenges";
 import { DexAttr } from "#enums/dex-attr";
+import { ExpGainsSpeed } from "#enums/exp-gains-speed";
 import { FieldPosition } from "#enums/field-position";
 import { HitResult } from "#enums/hit-result";
 import { LearnMoveSituation } from "#enums/learn-move-situation";
@@ -6438,7 +6439,7 @@ export class PlayerPokemon extends Pokemon {
    * @param lastLevel - The level of this Pokemon before the EXP increase
    */
   public async showExpGain(lastLevel: number): Promise<void> {
-    await this.battleInfo.updatePokemonExpDisplay(this, lastLevel);
+    await this.battleInfo.updatePokemonExpDisplay(this, lastLevel, globalScene.expGainsSpeed === ExpGainsSpeed.SKIP);
     await this.updateInfo();
   }
 

--- a/src/phases/level-cap-phase.ts
+++ b/src/phases/level-cap-phase.ts
@@ -21,7 +21,11 @@ export class LevelCapPhase extends FieldPhase {
         null,
         true,
       );
-      this.executeForAll(pokemon => pokemon.updateInfo(true));
+      this.executeForAll(pokemon => {
+        pokemon.updateInfo(true);
+        // Update level display to remove red coloring after cap increase
+        pokemon.getBattleInfo().setLevelDisplay(pokemon.level);
+      });
     });
   }
 }

--- a/src/phases/level-cap-phase.ts
+++ b/src/phases/level-cap-phase.ts
@@ -21,11 +21,7 @@ export class LevelCapPhase extends FieldPhase {
         null,
         true,
       );
-      this.executeForAll(pokemon => {
-        pokemon.updateInfo(true);
-        // Update level display to remove red coloring after cap increase
-        pokemon.getBattleInfo().setLevelDisplay(pokemon.level);
-      });
+      this.executeForAll(pokemon => pokemon.updateInfo(true));
     });
   }
 }

--- a/src/phases/level-up-phase.ts
+++ b/src/phases/level-up-phase.ts
@@ -33,7 +33,6 @@ export class LevelUpPhase extends PlayerPartyMemberPokemonPhase {
     const prevStats = this.pokemon.stats.slice(0);
 
     this.pokemon.calculateStats();
-    this.pokemon.getBattleInfo().setLevelDisplay(this.pokemon.level);
     this.pokemon.updateInfo();
 
     switch (globalScene.expParty) {

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -57,7 +57,6 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
   protected lastHp: number;
   protected lastMaxHp: number;
   protected lastHpFrame: string | null;
-  protected lastLevelCapped: boolean;
   protected lastStats: string;
 
   protected box: Phaser.GameObjects.Sprite;

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -611,6 +611,8 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
       this.fusionShinyIcon.setTint(getVariantTint(pokemon.fusionVariant));
     }
 
+    this.setLevelDisplay(pokemon.level);
+
     resolve();
     await promise;
   }

--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -611,8 +611,6 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
       this.fusionShinyIcon.setTint(getVariantTint(pokemon.fusionVariant));
     }
 
-    this.setLevelDisplay(pokemon.level);
-
     resolve();
     await promise;
   }

--- a/src/ui/battle-info/player-battle-info.ts
+++ b/src/ui/battle-info/player-battle-info.ts
@@ -141,8 +141,8 @@ export class PlayerBattleInfo extends BattleInfo {
    * @param lastLevel - The level the Pokemon was at before the update
    * @param lastLevelExp - The relative EXP the Pokemon had within its level before the update
    */
-  public async updatePokemonExpDisplay(pokemon: PlayerPokemon, lastLevel: number): Promise<void> {
-    if (globalScene.expGainsSpeed === ExpGainsSpeed.SKIP) {
+  public async updatePokemonExpDisplay(pokemon: PlayerPokemon, lastLevel: number, skip: boolean): Promise<void> {
+    if (skip) {
       this.setLevelDisplay(pokemon.level);
       const relLevelExp = getLevelRelExp(pokemon.level + 1, pokemon.species.growthRate);
       this.expMaskRect.x = EXP_BAR_WIDTH * (relLevelExp === 0 ? 0 : pokemon.levelExp / relLevelExp);
@@ -154,6 +154,11 @@ export class PlayerBattleInfo extends BattleInfo {
     }
 
     await this.doUpdateExpAnimation(pokemon, pokemon.level, false);
+  }
+
+  public override async updateInfo(pokemon: PlayerPokemon, instant?: boolean): Promise<void> {
+    await super.updateInfo(pokemon, instant);
+    this.updatePokemonExpDisplay(pokemon, pokemon.level, true);
   }
 
   /**

--- a/src/ui/battle-info/player-battle-info.ts
+++ b/src/ui/battle-info/player-battle-info.ts
@@ -224,7 +224,7 @@ export class PlayerBattleInfo extends BattleInfo {
             this.setLevelDisplay(level);
             globalScene.time.delayedCall(500 * levelDurationMultiplier, () => {
               this.expMaskRect.x = 0;
-              this.updateInfo(pokemon).then(() => resolve());
+              resolve();
             });
             return;
           }

--- a/src/ui/battle-info/player-battle-info.ts
+++ b/src/ui/battle-info/player-battle-info.ts
@@ -195,10 +195,7 @@ export class PlayerBattleInfo extends BattleInfo {
 
     const levelDurationMultiplier = this.getLevelDurationMultiplier(lastLevel, pokemon.level);
     let duration = this.visible
-      ? ((nextWidth - this.expMaskRect.x) / EXP_BAR_WIDTH)
-        * BattleInfo.EXP_GAINS_DURATION_BASE
-        * durationMultiplier
-        * levelDurationMultiplier
+      ? ratio * BattleInfo.EXP_GAINS_DURATION_BASE * durationMultiplier * levelDurationMultiplier
       : 0;
     if (speed && speed >= ExpGainsSpeed.DEFAULT) {
       duration = speed >= ExpGainsSpeed.SKIP ? ExpGainsSpeed.DEFAULT : duration / Math.pow(2, speed);


### PR DESCRIPTION
## What are the changes the user will see?
The player's level won't stay red after a biome change when at the level cap, and the exp bar will update properly after a rare candy is used.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
bug

## What are the changes from a developer perspective?
Set level display in `updateInfo` to align with the expectation that visual elements are recalculated whenever this method is called. Removed the existing call to `updateInfo` in the level up flow (otherwise the level would snap to the highest instead of animating). This should be safe as the only thing (maybe) expected to update during the animation would be HP, but that never has

## Screenshots/Videos
<!--
If you are changing anything visual (UI/UX, locales changes, etc.), please include screenshot(s) and/or video(s) showing the changes within collapsible blocks, like below:

<details><summary>Before</summary>

[before screenshot here]

</details>
<details><summary>After</summary>

[after screenshot here]

</details>
-->

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [ ] **I'm using `beta` as my base branch**
  - [ ] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [ ] I have provided a clear explanation of the changes within the PR description
  - [ ] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [ ] The PR is self-contained and cannot be split into smaller PRs
- [ ] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [ ] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: _____
- [ ] I have contacted the Translation Team on Discord for proofreading/translation

Does this require any additions or changes to in-game assets? If so:
- [ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: _____
