### PR TITLE
fix(ui): Fix summary exp bar

### DIFF
--- a/src/ui/handlers/summary-ui-handler.ts
+++ b/src/ui/handlers/summary-ui-handler.ts
@@ -1158,7 +1158,7 @@ export class SummaryUiHandler extends UiHandler {
         expMaskRect.setScale(6);
         expMaskRect.fillStyle(0xffffff);
         expMaskRect.beginPath();
-        expMaskRect.fillRect(140 + pageContainer.x, 145 + pageContainer.y + 21, Math.floor(expRatio * 64), 3);
+        expMaskRect.fillRect(140 + pageContainer.x, 152 + pageContainer.y + 22, Math.floor(expRatio * 64), 3);
 
         const expMask = expMaskRect.createGeometryMask();
 


### PR DESCRIPTION
## What are the changes the user will see?

the Exp bar will show again in the summary ui

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

[Discord bug report](https://discord.com/channels/1125469663833370665/1509154187097800704)

#7305 moved the images which hid the bar behind them

## What are the changes from a developer perspective?
adjusted the y coordinate

## Screenshots/Videos

<details><summary>Before</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f86b6e05-a171-4d6b-af0b-a81c9fb3e79d" />

</details>
<details><summary>After</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9bcfe7eb-11ea-42e1-b643-69526cdc10e5" />

</details>

## How to test the changes?


## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [x] **I'm using `hotfix-1.11.21` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [x] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: _____
- [ ] I have contacted the Translation Team on Discord for proofreading/translation

Does this require any additions or changes to in-game assets? If so:
- [ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: _____
