### PR TITLE
chore!: Hotfix 1.11.21 to main

### DIFF
--- a/src/audio/background-music.ts
+++ b/src/audio/background-music.ts
@@ -47,22 +47,27 @@ export class BackgroundMusic {
   constructor(key: string, loop: boolean, loopPoint = 0) {
     this.key = key;
 
-    globalScene.loadBgm(key).then(() => {
-      if (this.destroyed) {
-        return;
-      }
-      this.sound = globalScene.sound.add(key, { loop });
-      if (loop) {
-        this.sound.on("looped", () => {
-          if (!this.destroyed) {
-            this.sound?.play({ seek: loopPoint });
-          }
-        });
-      } else {
-        this.sound.once("complete", () => this.triggerEnd());
-      }
-      this.runPendingCalls();
-    });
+    globalScene
+      .loadBgm(key)
+      .then(() => {
+        if (this.destroyed) {
+          return;
+        }
+        this.sound = globalScene.sound.add(key, { loop });
+        if (loop) {
+          this.sound.on("looped", () => {
+            if (!this.destroyed) {
+              this.sound?.play({ seek: loopPoint });
+            }
+          });
+        } else {
+          this.sound.once("complete", () => this.triggerEnd());
+          // Defensive, "complete" should be the right event but Phaser docs aren't very clear
+          this.sound.once("stop", () => this.triggerEnd());
+        }
+        this.runPendingCalls();
+      })
+      .catch(() => this.destroy());
   }
 
   public play(volume?: number): void {
@@ -99,7 +104,16 @@ export class BackgroundMusic {
   }
 
   public resume(): void {
-    this.withSound(sound => sound.resume());
+    this.withSound(sound => {
+      if (sound.isPlaying) {
+        return;
+      }
+      if (sound.isPaused) {
+        sound.resume();
+      } else {
+        sound.play();
+      }
+    });
   }
 
   public setVolume(value: number): void {

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -629,6 +629,11 @@ export class MoveEffectPhase extends PokemonPhase {
    * @returns A {@linkcode MoveDamageTuple} containing the results of damage application.
    */
   protected applyMoveDamage(user: Pokemon, target: Pokemon, effectiveness: TypeDamageMultiplier): MoveDamageTuple {
+    // TODO: make sure this doesn't break anything, possibly find better solution
+    if (this.move.hasAttr("HealOnAllyAttr") && target === user.getAlly()) {
+      return [HitCheckResult.HIT, 0, false];
+    }
+
     const isCritical = target.getCriticalHitResult(user, this.move);
 
     /*

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -870,7 +870,7 @@ export class MovePhase extends PokemonPhase {
     const failedDueToTerrain = arena.isMoveTerrainCancelled(user, this.targets, move);
     let failed = failsConditions || failedDueToTerrain;
 
-    if (!failed && user.isOpponent(targets[0])) {
+    if (!failed && targets[0] != null && user.isOpponent(targets[0])) {
       const defendingSidePlayField = user.isPlayer() ? globalScene.getEnemyField() : globalScene.getPlayerField();
       const cancelled = new ValueHolder(false);
       defendingSidePlayField.forEach((pokemon: Pokemon) => {

--- a/src/scene-base.ts
+++ b/src/scene-base.ts
@@ -88,10 +88,18 @@ export class SceneBase extends Phaser.Scene {
     }
 
     this.load.audio(key, getCachedUrl(`audio/bgm/${key}.mp3`));
-    await new Promise<void>(resolve => {
+    await new Promise<void>((resolve, reject) => {
+      const onError = (file: Phaser.Loader.File) => {
+        if (file.key === key) {
+          this.load.off(Phaser.Loader.Events.FILE_LOAD_ERROR, onError);
+          reject(new Error(`Failed to load BGM: ${key}`));
+        }
+      };
       this.load.once(`filecomplete-audio-${key}`, () => {
+        this.load.off(Phaser.Loader.Events.FILE_LOAD_ERROR, onError);
         resolve();
       });
+      this.load.on(Phaser.Loader.Events.FILE_LOAD_ERROR, onError);
       this.load.start();
     });
   }

--- a/src/ui/handlers/pokedex-ui-handler.ts
+++ b/src/ui/handlers/pokedex-ui-handler.ts
@@ -2234,7 +2234,11 @@ export class PokedexUiHandler extends MessageUiHandler {
       }
     } else {
       this.pokemonNumberText.setText(
-        species ? i18next.t("pokedexUiHandler:pokemonNumber") + padInt(getDexNumber(species.speciesId), 4) : "",
+        species
+          ? i18next.t("pokedexUiHandler:pokemonNumber", {
+              dexNo: padInt(getDexNumber(species.speciesId), 4),
+            })
+          : "",
       );
       this.pokemonNameText.setText(species ? "???" : "");
       this.pokemonFormText.setText("");

--- a/src/ui/handlers/summary-ui-handler.ts
+++ b/src/ui/handlers/summary-ui-handler.ts
@@ -1158,7 +1158,7 @@ export class SummaryUiHandler extends UiHandler {
         expMaskRect.setScale(6);
         expMaskRect.fillStyle(0xffffff);
         expMaskRect.beginPath();
-        expMaskRect.fillRect(140 + pageContainer.x, 145 + pageContainer.y + 21, Math.floor(expRatio * 64), 3);
+        expMaskRect.fillRect(140 + pageContainer.x, 152 + pageContainer.y + 22, Math.floor(expRatio * 64), 3);
 
         const expMask = expMaskRect.createGeometryMask();
 


### PR DESCRIPTION
**Changelog:** hotfix-1.11.21 ---> main
---------------------------
## Bug Fixes

- #7332
  - Applying hazards with no targets no longer crashes. The move still will not execute (this was the behavior pre-update), but the game doesn't crash.
- #7333
  - the Exp bar will show again in the summary ui
- #7338
  - For unknown pokemon it will show the dexNum correctly instead of the i18next key.
- #7329
  - Pollen Puff doesn't damage ally before healing
- #7339
  - Hopefully, no freezes on the party heal screen

---------------------------
**This changelog was auto generated at May 29, 2026 at 8:24 PM UTC.**