### PR TITLE
misc: rename `PokemonPhasePriorityQueue` to `DynamicPhasePriorityQueue`

### DIFF
--- a/src/dynamic-queue-manager.ts
+++ b/src/dynamic-queue-manager.ts
@@ -2,11 +2,11 @@ import type { Pokemon } from "#app/field/pokemon";
 import type { Phase } from "#app/phase";
 import type { MovePhase } from "#app/phases/move-phase";
 import { MovePhasePriorityQueue } from "#app/queues/move-phase-priority-queue";
-import { PokemonPhasePriorityQueue } from "#app/queues/pokemon-phase-priority-queue";
+import { DynamicPhasePriorityQueue } from "#app/queues/pokemon-phase-priority-queue";
 import { PostSummonPhasePriorityQueue } from "#app/queues/post-summon-phase-priority-queue";
 import type { PriorityQueue } from "#app/queues/priority-queue";
 import type { MovePhaseTimingModifier } from "#enums/move-phase-timing-modifier";
-import type { DynamicPhase, PhaseConditionFunc, PhaseString } from "#types/phase-types";
+import type { DynamicPhase, PhaseConditionFunc, PhaseMap, PhaseString } from "#types/phase-types";
 
 // TODO: might be easier to define which phases should be dynamic instead
 /** All phases which have defined a `getPokemon` method but should not be sorted dynamically */
@@ -38,7 +38,7 @@ const nonDynamicPokemonPhases: readonly PhaseString[] = [
  * This is mostly used in redirection, cancellation, etc. of {@linkcode MovePhase}s.
  */
 export class DynamicQueueManager {
-  /** A Map matching `Phase` names to their corresponding priority queuess */
+  /** A Map matching `Phase` names to their corresponding priority queues. */
   private readonly dynamicPhaseMap: Map<PhaseString, PriorityQueue<Phase>>;
 
   constructor() {
@@ -60,15 +60,15 @@ export class DynamicQueueManager {
    * @param phase - The {@linkcode Phase} to add
    * @returns `true` if the phase was added, or `false` if it is not dynamic
    */
-  public queueDynamicPhase(phase: Phase): boolean {
+  public queueDynamicPhase(phase: Phase): phase is DynamicPhase {
     if (!this.isDynamicPhase(phase)) {
       return false;
     }
 
     if (!this.dynamicPhaseMap.has(phase.phaseName)) {
-      this.dynamicPhaseMap.set(phase.phaseName, new PokemonPhasePriorityQueue());
+      this.dynamicPhaseMap.set(phase.phaseName, new DynamicPhasePriorityQueue());
     }
-    this.dynamicPhaseMap.get(phase.phaseName)?.push(phase);
+    this.dynamicPhaseMap.get(phase.phaseName)!.push(phase);
     return true;
   }
 
@@ -88,7 +88,7 @@ export class DynamicQueueManager {
    * @returns Whether a matching phase exists
    */
   public exists<T extends PhaseString>(name: T, condition: PhaseConditionFunc<T> = () => true): boolean {
-    return !!this.dynamicPhaseMap.get(name)?.has(condition as (phase: Phase) => boolean);
+    return !!(this.dynamicPhaseMap.get(name) as PriorityQueue<PhaseMap[T]> | undefined)?.has(condition);
   }
 
   /**
@@ -98,7 +98,7 @@ export class DynamicQueueManager {
    * @returns Whether a removal occurred
    */
   public removePhase<T extends PhaseString>(name: T, condition: PhaseConditionFunc<T> = () => true): boolean {
-    return !!this.dynamicPhaseMap.get(name)?.remove(condition as (phase: Phase) => boolean);
+    return !!(this.dynamicPhaseMap.get(name) as PriorityQueue<PhaseMap[T]> | undefined)?.remove(condition);
   }
 
   /**

--- a/src/queues/move-phase-priority-queue.ts
+++ b/src/queues/move-phase-priority-queue.ts
@@ -1,13 +1,13 @@
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import type { MovePhase } from "#app/phases/move-phase";
-import { PokemonPhasePriorityQueue } from "#app/queues/pokemon-phase-priority-queue";
+import { DynamicPhasePriorityQueue } from "#app/queues/pokemon-phase-priority-queue";
 import type { MovePhaseTimingModifier } from "#enums/move-phase-timing-modifier";
 import type { MovePriorityInBracket } from "#enums/move-priority-in-bracket";
 import type { PhaseConditionFunc } from "#types/phase-types";
 
 /** A priority queue responsible for the ordering of {@linkcode MovePhase}s */
-export class MovePhasePriorityQueue extends PokemonPhasePriorityQueue<MovePhase> {
+export class MovePhasePriorityQueue extends DynamicPhasePriorityQueue<MovePhase> {
   private lastTurnOrder: Pokemon[] = [];
 
   protected override reorder(): void {

--- a/src/queues/pokemon-phase-priority-queue.ts
+++ b/src/queues/pokemon-phase-priority-queue.ts
@@ -3,7 +3,7 @@ import { sortInSpeedOrder } from "#app/utils/speed-order";
 import type { DynamicPhase } from "#types/phase-types";
 
 /** A generic speed-based priority queue of {@linkcode DynamicPhase}s. */
-export class PokemonPhasePriorityQueue<T extends DynamicPhase> extends PriorityQueue<T> {
+export class DynamicPhasePriorityQueue<T extends DynamicPhase> extends PriorityQueue<T> {
   protected override reorder(): void {
     this.queue = sortInSpeedOrder(this.queue);
   }

--- a/src/queues/post-summon-phase-priority-queue.ts
+++ b/src/queues/post-summon-phase-priority-queue.ts
@@ -1,7 +1,7 @@
 import { globalScene } from "#app/global-scene";
 import { PostSummonActivateAbilityPhase } from "#app/phases/post-summon-activate-ability-phase";
 import type { PostSummonPhase } from "#app/phases/post-summon-phase";
-import { PokemonPhasePriorityQueue } from "#app/queues/pokemon-phase-priority-queue";
+import { DynamicPhasePriorityQueue } from "#app/queues/pokemon-phase-priority-queue";
 import { sortInSpeedOrder } from "#app/utils/speed-order";
 
 /**
@@ -9,7 +9,7 @@ import { sortInSpeedOrder } from "#app/utils/speed-order";
  *
  * Orders phases first by ability priority, then by the {@linkcode Pokemon}'s effective speed
  */
-export class PostSummonPhasePriorityQueue extends PokemonPhasePriorityQueue<PostSummonPhase> {
+export class PostSummonPhasePriorityQueue extends DynamicPhasePriorityQueue<PostSummonPhase> {
   protected override reorder(): void {
     this.queue = sortInSpeedOrder(this.queue);
     this.queue.sort((phaseA, phaseB) => phaseB.getPriority() - phaseA.getPriority());


### PR DESCRIPTION

## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
renaming a class to be more generic

## What are the changes from a developer perspective?
renamed a single class and updated its references

changed some type assertions in the dynamic queue manager to be more explicit about the types of the priority queues being used

## Screenshots/Videos
N/A
## How to test the changes?
N/A
## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
