### PR TITLE
fix: Show dex num for unknown pokemon

### DIFF
--- a/src/ui/handlers/pokedex-ui-handler.ts
+++ b/src/ui/handlers/pokedex-ui-handler.ts
@@ -2234,7 +2234,11 @@ export class PokedexUiHandler extends MessageUiHandler {
       }
     } else {
       this.pokemonNumberText.setText(
-        species ? i18next.t("pokedexUiHandler:pokemonNumber") + padInt(getDexNumber(species.speciesId), 4) : "",
+        species
+          ? i18next.t("pokedexUiHandler:pokemonNumber", {
+              dexNo: padInt(getDexNumber(species.speciesId), 4),
+            })
+          : "",
       );
       this.pokemonNameText.setText(species ? "???" : "");
       this.pokemonFormText.setText("");


### PR DESCRIPTION
## What are the changes the user will see?

For unknown pokemon it will show the dexNum correctly instead of the i18next key.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

fix bug

## What are the changes from a developer perspective?

pass the value to i18next instead of just appending it

## Screenshots/Videos

<details><summary>Before</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/859b4b2a-0cef-4485-85f1-f86c438d6d1d" />

</details>
<details><summary>After</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7c7bf642-a342-4175-875c-829b41dd1e7f" />

</details>

## How to test the changes?

look at an unkown pokemon in the pokedex

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `hotfix-1.11.21` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: _____
- [ ] I have contacted the Translation Team on Discord for proofreading/translation

Does this require any additions or changes to in-game assets? If so:
- [ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: _____
