### PR TITLE
fix(audio): Make BGM loading a bit more robust

### DIFF
--- a/src/audio/background-music.ts
+++ b/src/audio/background-music.ts
@@ -47,22 +47,26 @@ export class BackgroundMusic {
   constructor(key: string, loop: boolean, loopPoint = 0) {
     this.key = key;
 
-    globalScene.loadBgm(key).then(() => {
-      if (this.destroyed) {
-        return;
-      }
-      this.sound = globalScene.sound.add(key, { loop });
-      if (loop) {
-        this.sound.on("looped", () => {
-          if (!this.destroyed) {
-            this.sound?.play({ seek: loopPoint });
-          }
-        });
-      } else {
-        this.sound.once("complete", () => this.triggerEnd());
-      }
-      this.runPendingCalls();
-    });
+    globalScene
+      .loadBgm(key)
+      .then(() => {
+        if (this.destroyed) {
+          return;
+        }
+        this.sound = globalScene.sound.add(key, { loop });
+        if (loop) {
+          this.sound.on("looped", () => {
+            if (!this.destroyed) {
+              this.sound?.play({ seek: loopPoint });
+            }
+          });
+        } else {
+          this.sound.once("complete", () => this.triggerEnd());
+          this.sound.once("stop", () => this.triggerEnd());
+        }
+        this.runPendingCalls();
+      })
+      .catch(() => this.triggerEnd());
   }
 
   public play(volume?: number): void {
@@ -99,7 +103,16 @@ export class BackgroundMusic {
   }
 
   public resume(): void {
-    this.withSound(sound => sound.resume());
+    this.withSound(sound => {
+      if (sound.isPlaying) {
+        return;
+      }
+      if (sound.isPaused) {
+        sound.resume();
+      } else {
+        sound.play();
+      }
+    });
   }
 
   public setVolume(value: number): void {

--- a/src/audio/background-music.ts
+++ b/src/audio/background-music.ts
@@ -62,6 +62,7 @@ export class BackgroundMusic {
           });
         } else {
           this.sound.once("complete", () => this.triggerEnd());
+          // Defensive, "complete" should be the right event but Phaser docs aren't very clear
           this.sound.once("stop", () => this.triggerEnd());
         }
         this.runPendingCalls();

--- a/src/audio/background-music.ts
+++ b/src/audio/background-music.ts
@@ -67,7 +67,7 @@ export class BackgroundMusic {
         }
         this.runPendingCalls();
       })
-      .catch(() => this.triggerEnd());
+      .catch(() => this.destroy());
   }
 
   public play(volume?: number): void {

--- a/src/scene-base.ts
+++ b/src/scene-base.ts
@@ -88,10 +88,18 @@ export class SceneBase extends Phaser.Scene {
     }
 
     this.load.audio(key, getCachedUrl(`audio/bgm/${key}.mp3`));
-    await new Promise<void>(resolve => {
+    await new Promise<void>((resolve, reject) => {
+      const onError = (file: Phaser.Loader.File) => {
+        if (file.key === key) {
+          this.load.off(Phaser.Loader.Events.FILE_LOAD_ERROR, onError);
+          reject(new Error(`Failed to load BGM: ${key}`));
+        }
+      };
       this.load.once(`filecomplete-audio-${key}`, () => {
+        this.load.off(Phaser.Loader.Events.FILE_LOAD_ERROR, onError);
         resolve();
       });
+      this.load.on(Phaser.Loader.Events.FILE_LOAD_ERROR, onError);
       this.load.start();
     });
   }


### PR DESCRIPTION
<!--
Thank you for contributing to PokéRogue!
Open-source contributions like yours help keep this project going.

Note that these comment blocks are purely informative and can be removed once you're done reading them.
-->

<!--
Make sure your title matches the https://www.conventionalcommits.org/en/v1.0.0/ format.
Try to keep the title under 72 characters, as GitHub cuts off commit titles longer than this length.

See https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request
for more information on the allowed scopes and prefixes.

Example:
fix(move): Future Sight no longer crashes
^   ^      ^
|   |      |__ Subject
|   |_________ Scope (optional)
|_____________ Prefix
-->

## What are the changes the user will see?
Hopefully, no freezes on the party heal screen

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Some reports have come in that people are rarely freezing on the party heal screen, indicating that the `onEnd` callback of the party background music isn't firing. I haven't been able to reproduce this, but I made some changes that should make it less likely regardless. It's questionable whether it's good practice to hinge something like a phase transition on music to begin with, but I'm not sure what the alternative is. We could just add a timeout equal to the length of the heal, but that would be screwy with load times and cut the music off.

## What are the changes from a developer perspective?
Throw an error in the load promise if one happens, catch it in the BGM constructor and destroy it immediately, firing `onEnd` in the process. Also made a couple of general robustness fixes like attempting to play if `resume` is called on a non-started track (which maybe could happen i.e. if a track takes so long to load that it has been "paused" before actually playing)

## Screenshots/Videos
<!--
If you are changing anything visual (UI/UX, locales changes, etc.), please include screenshot(s) and/or video(s) showing the changes within collapsible blocks, like below:

<details><summary>Before</summary>

[before screenshot here]

</details>
<details><summary>After</summary>

[after screenshot here]

</details>
-->

## How to test the changes?
Run through a x10 wave and see if it works

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [ ] **I'm using `beta` as my base branch**
  - [ ] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [ ] I have provided a clear explanation of the changes within the PR description
  - [ ] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [ ] The PR is self-contained and cannot be split into smaller PRs
- [ ] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [ ] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)
