### PR TITLE
fix(move): Stomping Tantrum doesn't boost after recharging or Sky Drop

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -11760,8 +11760,9 @@ export function initMoves() {
         // Stomping tantrum triggers on most failures (including sleep/freeze)
         // Exceptions include after being targeted with Sky Drop and after recharging
         let lastNonDancerMove = user.getLastXMoves(2)[1] as TurnMove | undefined;
-        if (user.getLastXMoves(3)[2] && allMoves[user.getLastXMoves(3)[2].move].hasAttr("RechargeAttr")) {
-          lastNonDancerMove = user.getLastXMoves(3)[2] as TurnMove | undefined;
+        const thirdMostRecentMove = user.getLastXMoves(3)[2] as TurnMove | undefined;
+        if (thirdMostRecentMove && allMoves[thirdMostRecentMove.move].hasAttr("RechargeAttr")) {
+          lastNonDancerMove = thirdMostRecentMove;
         }
         const enemyIsException = isStompingTantrumExceptionFunc(user, target);
         let enemyTwoIsException = false;

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -11735,23 +11735,19 @@ export function initMoves() {
     new AttackMove(MoveId.STOMPING_TANTRUM, PokemonType.GROUND, MoveCategory.PHYSICAL, 75, 100, 10, -1, 0, 7)
       .attr(MovePowerMultiplierAttr, (user, target) => {
         // Stomping tantrum triggers on most failures (including sleep/freeze)
-        // Notable exceptions include after being targeted with Sky Drop and after recharging
+        // Exceptions include after being targeted with Sky Drop and after recharging
         let lastNonDancerMove = user.getLastXMoves(2)[1] as TurnMove | undefined;
-        const enemyLastMoveUsed = target.getLastXMoves(2)[1] as TurnMove | undefined;
-        // Checking if the last move was a recharge move
         if (user.getLastXMoves(3)[2] && allMoves[user.getLastXMoves(3)[2].move].hasAttr("RechargeAttr")) {
           lastNonDancerMove = user.getLastXMoves(3)[2] as TurnMove | undefined;
         }
-        // Checking for the Sky Drop exception
-        if (enemyLastMoveUsed) {
-          return lastNonDancerMove
-            && (lastNonDancerMove.result === MoveResult.MISS || lastNonDancerMove.result === MoveResult.FAIL)
-            && !(enemyLastMoveUsed.move === MoveId.SKY_DROP && enemyLastMoveUsed.result === MoveResult.OTHER)
-            ? 2
-            : 1;
-        }
+        const enemyLastMoveUsed = target.getLastXMoves(2)[1] as TurnMove | undefined;
+        const isLastEnemyMoveSkyDrop =
+          enemyLastMoveUsed
+          && enemyLastMoveUsed.move === MoveId.SKY_DROP
+          && enemyLastMoveUsed.result === MoveResult.OTHER;
         return lastNonDancerMove
           && (lastNonDancerMove.result === MoveResult.MISS || lastNonDancerMove.result === MoveResult.FAIL)
+          && !isLastEnemyMoveSkyDrop
           ? 2
           : 1;
       })

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -135,6 +135,7 @@ import { areAllies, canSpeciesTera, willTerastallize } from "#utils/pokemon-util
 import { inSpeedOrder } from "#utils/speed-order-generator";
 import { toCamelCase, toTitleCase } from "#utils/strings";
 import type { ValueHolder } from "#utils/value-holder";
+import { stat } from "fs";
 import i18next from "i18next";
 
 // TODO: Make these (and all condition functions actually)
@@ -4541,6 +4542,28 @@ export class MovePowerMultiplierAttr extends VariablePowerAttr {
     return true;
   }
 }
+
+/**
+ * Helper function to check for exceptions that shouldn't boost Stomping Tantrum's power.
+ * @param user The Pokemon using Stomping Tantrum.
+ * @param target The enemy Pokemon.
+ * @returns Whether a relevant exception case is present.
+ * @todo Implement a check for whether move failure was due to the target using a Protect-like move
+ */
+const isStompingTantrumExceptionFunc = (user: Pokemon, target: Pokemon): boolean => {
+  const enemyLastMoveUsed = target.getLastXMoves(2)[1] as TurnMove | undefined;
+  const isLastEnemyMoveSkyDrop =
+    enemyLastMoveUsed
+    && (enemyLastMoveUsed.targets[0] === user.getBattlerIndex()
+      || enemyLastMoveUsed.targets[1] === user.getBattlerIndex())
+    && enemyLastMoveUsed.move === MoveId.SKY_DROP
+    && enemyLastMoveUsed.result === MoveResult.OTHER;
+
+  if (isLastEnemyMoveSkyDrop) {
+    return true;
+  }
+  return false;
+};
 
 /**
  * Helper function to calculate the the base power of an ally's hit when using Beat Up.
@@ -11740,14 +11763,16 @@ export function initMoves() {
         if (user.getLastXMoves(3)[2] && allMoves[user.getLastXMoves(3)[2].move].hasAttr("RechargeAttr")) {
           lastNonDancerMove = user.getLastXMoves(3)[2] as TurnMove | undefined;
         }
-        const enemyLastMoveUsed = target.getLastXMoves(2)[1] as TurnMove | undefined;
-        const isLastEnemyMoveSkyDrop =
-          enemyLastMoveUsed
-          && enemyLastMoveUsed.move === MoveId.SKY_DROP
-          && enemyLastMoveUsed.result === MoveResult.OTHER;
+        const enemyIsException = isStompingTantrumExceptionFunc(user, target);
+        let enemyTwoIsException = false;
+        const enemyTwo = target.getAlly();
+        if (enemyTwo) {
+          enemyTwoIsException = isStompingTantrumExceptionFunc(user, enemyTwo);
+        }
         return lastNonDancerMove
           && (lastNonDancerMove.result === MoveResult.MISS || lastNonDancerMove.result === MoveResult.FAIL)
-          && !isLastEnemyMoveSkyDrop
+          && !enemyIsException
+          && !enemyTwoIsException
           ? 2
           : 1;
       })

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -135,7 +135,6 @@ import { areAllies, canSpeciesTera, willTerastallize } from "#utils/pokemon-util
 import { inSpeedOrder } from "#utils/speed-order-generator";
 import { toCamelCase, toTitleCase } from "#utils/strings";
 import type { ValueHolder } from "#utils/value-holder";
-import { stat } from "fs";
 import i18next from "i18next";
 
 // TODO: Make these (and all condition functions actually)

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -4545,8 +4545,8 @@ export class MovePowerMultiplierAttr extends VariablePowerAttr {
 
 /**
  * Helper function to check for exceptions that shouldn't boost Stomping Tantrum's power.
- * @param user The Pokemon using Stomping Tantrum.
- * @param target The enemy Pokemon.
+ * @param user - The Pokemon using Stomping Tantrum.
+ * @param target - The enemy Pokemon.
  * @returns Whether a relevant exception case is present.
  * @todo Implement a check for whether move failure was due to the target using a Protect-like move
  */

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -11733,9 +11733,23 @@ export function initMoves() {
       .bitingMove()
       .attr(RemoveScreensAttr, (_user, target) => (target.isPlayer() ? ArenaTagSide.PLAYER : ArenaTagSide.ENEMY)),
     new AttackMove(MoveId.STOMPING_TANTRUM, PokemonType.GROUND, MoveCategory.PHYSICAL, 75, 100, 10, -1, 0, 7)
-      .attr(MovePowerMultiplierAttr, user => {
+      .attr(MovePowerMultiplierAttr, (user, target) => {
         // Stomping tantrum triggers on most failures (including sleep/freeze)
-        const lastNonDancerMove = user.getLastXMoves(2)[1] as TurnMove | undefined;
+        // Notable exceptions include after being targeted with Sky Drop and after recharging
+        let lastNonDancerMove = user.getLastXMoves(2)[1] as TurnMove | undefined;
+        const enemyLastMoveUsed = target.getLastXMoves(2)[1] as TurnMove | undefined;
+        // Checking if the last move was a recharge move
+        if (user.getLastXMoves(3)[2] && allMoves[user.getLastXMoves(3)[2].move].hasAttr("RechargeAttr")) {
+          lastNonDancerMove = user.getLastXMoves(3)[2] as TurnMove | undefined;
+        }
+        // Checking for the Sky Drop exception
+        if (enemyLastMoveUsed) {
+          return lastNonDancerMove
+            && (lastNonDancerMove.result === MoveResult.MISS || lastNonDancerMove.result === MoveResult.FAIL)
+            && !(enemyLastMoveUsed.move === MoveId.SKY_DROP && enemyLastMoveUsed.result === MoveResult.OTHER)
+            ? 2
+            : 1;
+        }
         return lastNonDancerMove
           && (lastNonDancerMove.result === MoveResult.MISS || lastNonDancerMove.result === MoveResult.FAIL)
           ? 2

--- a/test/tests/moves/stomping-tantrum.test.ts
+++ b/test/tests/moves/stomping-tantrum.test.ts
@@ -76,6 +76,7 @@ describe("Move - Stomping Tantrum", () => {
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
 
     game.move.use(MoveId.GIGA_IMPACT);
+    await game.move.forceHit();
     await game.toEndOfTurn();
 
     // Recharge turn

--- a/test/tests/moves/stomping-tantrum.test.ts
+++ b/test/tests/moves/stomping-tantrum.test.ts
@@ -72,8 +72,6 @@ describe("Move - Stomping Tantrum", () => {
 
   it("should do normal damage after using a recharge move", async () => {
     const { stompingTantrum, powerSpy } = setUpTest();
-    // Guaranteeing Giga Impact hits
-    vi.spyOn(allMoves[MoveId.GIGA_IMPACT], "accuracy", "get").mockReturnValue(100);
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
 

--- a/test/tests/moves/stomping-tantrum.test.ts
+++ b/test/tests/moves/stomping-tantrum.test.ts
@@ -62,7 +62,7 @@ describe("Move - Stomping Tantrum", () => {
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
 
     game.move.use(MoveId.TACKLE);
-    await game.toEndOfTurn();
+    await game.toNextTurn();
 
     game.move.use(MoveId.STOMPING_TANTRUM);
     await game.toEndOfTurn();
@@ -77,11 +77,11 @@ describe("Move - Stomping Tantrum", () => {
 
     game.move.use(MoveId.GIGA_IMPACT);
     await game.move.forceHit();
-    await game.toEndOfTurn();
+    await game.toNextTurn();
 
     // Recharge turn
     game.move.use(MoveId.SPLASH);
-    await game.toEndOfTurn();
+    await game.toNextTurn();
 
     game.move.use(MoveId.STOMPING_TANTRUM);
     await game.toEndOfTurn();
@@ -97,7 +97,7 @@ describe("Move - Stomping Tantrum", () => {
     // Intentionally failing Sucker Punch
     game.move.use(MoveId.SUCKER_PUNCH);
     await game.move.forceEnemyMove(MoveId.SPLASH);
-    await game.toEndOfTurn();
+    await game.toNextTurn();
 
     game.move.use(MoveId.STOMPING_TANTRUM);
     await game.toEndOfTurn();
@@ -112,7 +112,7 @@ describe("Move - Stomping Tantrum", () => {
 
     game.move.use(MoveId.TACKLE);
     await game.move.forceEnemyMove(MoveId.SKY_DROP);
-    await game.toEndOfTurn();
+    await game.toNextTurn();
 
     game.move.use(MoveId.STOMPING_TANTRUM);
     await game.toEndOfTurn();
@@ -130,7 +130,7 @@ describe("Move - Stomping Tantrum", () => {
     game.move.use(MoveId.TACKLE, 1);
     await game.move.forceEnemyMove(MoveId.SKY_DROP, BattlerIndex.PLAYER);
     await game.move.forceEnemyMove(MoveId.SPLASH, BattlerIndex.PLAYER_2);
-    await game.toEndOfTurn();
+    await game.toNextTurn();
 
     // Targeting the enemy that didn't use Sky Drop with Stomping Tantrum
     game.move.use(MoveId.STOMPING_TANTRUM, 0, 3);
@@ -147,7 +147,7 @@ describe("Move - Stomping Tantrum", () => {
 
     game.move.use(MoveId.TACKLE);
     await game.move.forceEnemyMove(MoveId.PROTECT);
-    await game.toEndOfTurn();
+    await game.toNextTurn();
 
     game.move.use(MoveId.STOMPING_TANTRUM);
     await game.move.forceEnemyMove(MoveId.SPLASH);

--- a/test/tests/moves/stomping-tantrum.test.ts
+++ b/test/tests/moves/stomping-tantrum.test.ts
@@ -120,4 +120,40 @@ describe("Move - Stomping Tantrum", () => {
 
     expect(powerSpy).toHaveLastReturnedWith(stompingTantrum.power);
   });
+
+  it("should check both Pokemon for exceptions in a double battle", async () => {
+    const { stompingTantrum, powerSpy } = setUpTest();
+    game.override.battleStyle("double");
+    await game.classicMode.startBattle(SpeciesId.FEEBAS, SpeciesId.WEEDLE);
+
+    // First enemy uses Sky Drop, causing Feebas' move to fail
+    game.move.use(MoveId.TACKLE);
+    game.move.use(MoveId.TACKLE, 1);
+    await game.move.forceEnemyMove(MoveId.SKY_DROP, BattlerIndex.PLAYER);
+    await game.move.forceEnemyMove(MoveId.SPLASH, BattlerIndex.PLAYER_2);
+    await game.toEndOfTurn();
+
+    // Targeting the enemy that didn't use Sky Drop with Stomping Tantrum
+    game.move.use(MoveId.STOMPING_TANTRUM, 0, 3);
+    game.move.use(MoveId.TACKLE, 1);
+    await game.toEndOfTurn();
+
+    expect(powerSpy).toHaveLastReturnedWith(stompingTantrum.power);
+  });
+
+  // TODO: Activate this test when Stomping Tantrum correctly checks for move failure caused by Protect-like moves
+  it.todo("should do normal damage after a move fails because of Protect", async () => {
+    const { stompingTantrum, powerSpy } = setUpTest();
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    game.move.use(MoveId.TACKLE);
+    await game.move.forceEnemyMove(MoveId.PROTECT);
+    await game.toEndOfTurn();
+
+    game.move.use(MoveId.STOMPING_TANTRUM);
+    await game.move.forceEnemyMove(MoveId.SPLASH);
+    await game.toEndOfTurn();
+
+    expect(powerSpy).toHaveLastReturnedWith(stompingTantrum.power);
+  });
 });

--- a/test/tests/moves/stomping-tantrum.test.ts
+++ b/test/tests/moves/stomping-tantrum.test.ts
@@ -37,9 +37,15 @@ describe("Move - Stomping Tantrum", () => {
       .moveset([MoveId.STOMPING_TANTRUM, MoveId.GIGA_IMPACT, MoveId.SUCKER_PUNCH, MoveId.SPLASH]);
   });
 
-  it("should do normal damage if no prior move is called", async () => {
+  function setUpTest() {
     const stompingTantrum = allMoves[MoveId.STOMPING_TANTRUM];
     const powerSpy = vi.spyOn(stompingTantrum, "calculateBattlePower");
+
+    return { stompingTantrum, powerSpy };
+  }
+
+  it("should do normal damage if no prior move is called", async () => {
+    const { stompingTantrum, powerSpy } = setUpTest();
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
 
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
@@ -51,8 +57,7 @@ describe("Move - Stomping Tantrum", () => {
   });
 
   it("should do normal damage after successfully using a move", async () => {
-    const stompingTantrum = allMoves[MoveId.STOMPING_TANTRUM];
-    const powerSpy = vi.spyOn(stompingTantrum, "calculateBattlePower");
+    const { stompingTantrum, powerSpy } = setUpTest();
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
 
@@ -66,8 +71,7 @@ describe("Move - Stomping Tantrum", () => {
   });
 
   it("should do normal damage after using a recharge move", async () => {
-    const stompingTantrum = allMoves[MoveId.STOMPING_TANTRUM];
-    const powerSpy = vi.spyOn(stompingTantrum, "calculateBattlePower");
+    const { stompingTantrum, powerSpy } = setUpTest();
     // Guaranteeing Giga Impact hits
     vi.spyOn(allMoves[MoveId.GIGA_IMPACT], "accuracy", "get").mockReturnValue(100);
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
@@ -87,8 +91,7 @@ describe("Move - Stomping Tantrum", () => {
   });
 
   it("should do double damage after a move fails", async () => {
-    const stompingTantrum = allMoves[MoveId.STOMPING_TANTRUM];
-    const powerSpy = vi.spyOn(stompingTantrum, "calculateBattlePower");
+    const { stompingTantrum, powerSpy } = setUpTest();
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
 
@@ -104,8 +107,7 @@ describe("Move - Stomping Tantrum", () => {
   });
 
   it("should do normal damage after getting targeted by Sky Drop", async () => {
-    const stompingTantrum = allMoves[MoveId.STOMPING_TANTRUM];
-    const powerSpy = vi.spyOn(stompingTantrum, "calculateBattlePower");
+    const { stompingTantrum, powerSpy } = setUpTest();
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
 

--- a/test/tests/moves/stomping-tantrum.test.ts
+++ b/test/tests/moves/stomping-tantrum.test.ts
@@ -1,0 +1,121 @@
+/*
+ * SPDX-FileCopyrightText: 2024-2026 Pagefault Games
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { allMoves } from "#data/data-lists";
+import { AbilityId } from "#enums/ability-id";
+import { BattlerIndex } from "#enums/battler-index";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/framework/game-manager";
+import Phaser from "phaser";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Move - Stomping Tantrum", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleStyle("single")
+      .criticalHits(false)
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset(MoveId.SPLASH)
+      .startingLevel(100)
+      .enemyLevel(100)
+      .moveset([MoveId.STOMPING_TANTRUM, MoveId.GIGA_IMPACT, MoveId.SUCKER_PUNCH, MoveId.SPLASH]);
+  });
+
+  it("should do normal damage if no prior move is called", async () => {
+    const stompingTantrum = allMoves[MoveId.STOMPING_TANTRUM];
+    const powerSpy = vi.spyOn(stompingTantrum, "calculateBattlePower");
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+    game.move.use(MoveId.STOMPING_TANTRUM);
+
+    await game.toEndOfTurn();
+
+    expect(powerSpy).toHaveLastReturnedWith(stompingTantrum.power);
+  });
+
+  it("should do normal damage after successfully using a move", async () => {
+    const stompingTantrum = allMoves[MoveId.STOMPING_TANTRUM];
+    const powerSpy = vi.spyOn(stompingTantrum, "calculateBattlePower");
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+    game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+
+    game.move.use(MoveId.TACKLE);
+    await game.toEndOfTurn();
+
+    game.move.use(MoveId.STOMPING_TANTRUM);
+    await game.toEndOfTurn();
+
+    expect(powerSpy).toHaveLastReturnedWith(stompingTantrum.power);
+  });
+
+  it("should do normal damage after using a recharge move", async () => {
+    const stompingTantrum = allMoves[MoveId.STOMPING_TANTRUM];
+    const powerSpy = vi.spyOn(stompingTantrum, "calculateBattlePower");
+    // Guaranteeing Giga Impact hits
+    vi.spyOn(allMoves[MoveId.GIGA_IMPACT], "accuracy", "get").mockReturnValue(100);
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+    game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+
+    game.move.use(MoveId.GIGA_IMPACT);
+    await game.toEndOfTurn();
+
+    // Recharge turn
+    game.move.use(MoveId.SPLASH);
+    await game.toEndOfTurn();
+
+    game.move.use(MoveId.STOMPING_TANTRUM);
+    await game.toEndOfTurn();
+
+    expect(powerSpy).toHaveLastReturnedWith(stompingTantrum.power);
+  });
+
+  it("should do double damage after a move fails", async () => {
+    const stompingTantrum = allMoves[MoveId.STOMPING_TANTRUM];
+    const powerSpy = vi.spyOn(stompingTantrum, "calculateBattlePower");
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+    game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+
+    // Intentionally failing Sucker Punch
+    game.move.use(MoveId.SUCKER_PUNCH);
+    await game.move.forceEnemyMove(MoveId.SPLASH);
+    await game.toEndOfTurn();
+
+    game.move.use(MoveId.STOMPING_TANTRUM);
+    await game.toEndOfTurn();
+
+    expect(powerSpy).toHaveLastReturnedWith(stompingTantrum.power * 2);
+  });
+
+  it("should do normal damage after getting targeted by Sky Drop", async () => {
+    const stompingTantrum = allMoves[MoveId.STOMPING_TANTRUM];
+    const powerSpy = vi.spyOn(stompingTantrum, "calculateBattlePower");
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+    game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+
+    game.move.use(MoveId.TACKLE);
+    await game.move.forceEnemyMove(MoveId.SKY_DROP);
+    await game.toEndOfTurn();
+
+    game.move.use(MoveId.STOMPING_TANTRUM);
+    await game.toEndOfTurn();
+
+    expect(powerSpy).toHaveLastReturnedWith(stompingTantrum.power);
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?

Stomping Tantrum won't get a damage boost in certain exception cases (when the user spent the last turn recharging after a move like Giga Impact or was targeted by Sky Drop).

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

Fixes #1805.

## What are the changes from a developer perspective?

When Stomping Tantrum is made in ```move.ts```, it now checks if the user's second to last move has the ```RechargeAttr```, meaning the last turn would have been spent recharging and shouldn't boost Stomping Tantrum's damage. It also calls a new helper function for each enemy, ```isStompingTantrumExceptionFunc```, to check if either enemy's last moves are exception cases that should prevent damage boosts. Currently it only checks for Sky Drop, but it's made so that future exception cases can be added. New test cases for Stomping Tantrum were also made (including one marked as ```todo``` for failures caused by Protect-like moves, as that's another [unimplemented] case that shouldn't boost). 

## Screenshots/Videos

N/A

## How to test the changes?

There's a new testing file, ```stomping-tantrum-test.ts```.

## Checklist

- The PR content is correctly formatted:
  - [X] **I'm using `beta` as my base branch**
  - [X] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [X] I have provided a clear explanation of the changes within the PR description
  - [X] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [X] The PR is self-contained and cannot be split into smaller PRs
- [X] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [X] I have tested the changes manually
  - [X] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [X] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- ~[ ] I have provided screenshots/videos of the changes (if applicable)~
  - ~[ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)~

~Are there any localization additions or changes? If so:~
- ~[ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository~
  - ~If so, include a link to the PR here: _____~
- ~[ ] I have contacted the Translation Team on Discord for proofreading/translation~

~Does this require any additions or changes to in-game assets? If so:~
- ~[ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository~
  - ~If so, include a link to the PR here: _____~
