### PR TITLE
fix(audio): Prevent crash on egg hatch screen

### DIFF
--- a/src/audio/audio-manager.ts
+++ b/src/audio/audio-manager.ts
@@ -135,10 +135,13 @@ export class AudioManager {
    * Fades out the current bgm over `duration` ms.
    * @param duration - (Default `500`) The amount of time the fade out should take place over, in ms
    * @param fixed - (Default `false`) Whether the duration should ignore game speed
+   * @param destroy - (Default `true`) `true` to destroy after fading, `false` to pause instead
    */
-  public fadeOutBgm(duration = 500, fixed = false): void {
-    this.currentBgm?.fadeOut(duration, fixed);
-    this.currentBgm = null;
+  public fadeOutBgm(duration = 500, fixed = false, destroy = true): void {
+    this.currentBgm?.fadeOut(duration, fixed, destroy);
+    if (destroy) {
+      this.currentBgm = null;
+    }
   }
 
   /**

--- a/src/audio/audio-manager.ts
+++ b/src/audio/audio-manager.ts
@@ -135,7 +135,7 @@ export class AudioManager {
    * Fades out the current bgm over `duration` ms.
    * @param duration - (Default `500`) The amount of time the fade out should take place over, in ms
    * @param fixed - (Default `false`) Whether the duration should ignore game speed
-   * @param destroy - (Default `true`) `true` to destroy after fading, `false` to pause instead
+   * @param destroy - (Default `true`) Whether to destroy the bgm after fading out, or just pause it
    */
   public fadeOutBgm(duration = 500, fixed = false, destroy = true): void {
     this.currentBgm?.fadeOut(duration, fixed, destroy);

--- a/src/audio/background-music.ts
+++ b/src/audio/background-music.ts
@@ -16,8 +16,9 @@ import SoundFade from "phaser3-rex-plugins/plugins/soundfade";
  */
 export class BackgroundMusic {
   /**
-   * Maps the number of active BGM objects for a particular key
-   * this will almost always be 1, but with i.e. paused/resumed music it may be more.
+   * Maps the number of active BGM objects for a particular key.
+   *
+   * This will almost always be 1, but with i.e. paused/resumed music it may be more.
    */
   private static readonly refCounts = new Map<string, number>();
 
@@ -118,7 +119,7 @@ export class BackgroundMusic {
       if (sound.isPaused) {
         sound.resume();
       } else {
-        this.play();
+        sound.play();
       }
     });
   }
@@ -185,7 +186,7 @@ export class BackgroundMusic {
    * Fade the volume to zero over `duration` ms.
    * @param duration - Fade time in milliseconds
    * @param fixed - (Default `false`) Whether duration should ignore game speed
-   * @param destroy - (Default `true`) `true` to destroy after fading, `false` to pause instead
+   * @param destroy - (Default `true`) Whether to destroy the bgm after fading out, or just pause it
    */
   public fadeOut(duration: number, fixed = false, destroy = true): void {
     const realDuration = fixed ? fixedInt(duration) : duration;

--- a/src/audio/background-music.ts
+++ b/src/audio/background-music.ts
@@ -15,6 +15,12 @@ import SoundFade from "phaser3-rex-plugins/plugins/soundfade";
  * of if the music is able to start and stop cleanly.
  */
 export class BackgroundMusic {
+  /**
+   * Maps the number of active BGM objects for a particular key
+   * this will almost always be 1, but with i.e. paused/resumed music it may be more.
+   */
+  private static readonly refCounts = new Map<string, number>();
+
   /** The key for the audio file */
   public readonly key: string;
 
@@ -46,6 +52,7 @@ export class BackgroundMusic {
    */
   constructor(key: string, loop: boolean, loopPoint = 0) {
     this.key = key;
+    BackgroundMusic.refCounts.set(key, (BackgroundMusic.refCounts.get(key) ?? 0) + 1);
 
     globalScene
       .loadBgm(key)
@@ -111,7 +118,7 @@ export class BackgroundMusic {
       if (sound.isPaused) {
         sound.resume();
       } else {
-        sound.play();
+        this.play();
       }
     });
   }
@@ -159,18 +166,40 @@ export class BackgroundMusic {
     if (this.sound?.isPlaying) {
       this.sound.stop();
     }
-    globalScene.sound.removeByKey(this.key);
-    globalScene.cache.audio.remove(this.key);
+
+    if (this.sound != null) {
+      globalScene.sound.remove(this.sound);
+      this.sound = undefined;
+    }
+
+    const remaining = (BackgroundMusic.refCounts.get(this.key) ?? 1) - 1;
+    if (remaining <= 0) {
+      BackgroundMusic.refCounts.delete(this.key);
+      globalScene.cache.audio.remove(this.key);
+    } else {
+      BackgroundMusic.refCounts.set(this.key, remaining);
+    }
   }
 
-  public fadeOut(duration: number, fixed = false): void {
+  /**
+   * Fade the volume to zero over `duration` ms.
+   * @param duration - Fade time in milliseconds
+   * @param fixed - (Default `false`) Whether duration should ignore game speed
+   * @param destroy - (Default `true`) `true` to destroy after fading, `false` to pause instead
+   */
+  public fadeOut(duration: number, fixed = false, destroy = true): void {
     const realDuration = fixed ? fixedInt(duration) : duration;
     this.withSound(sound => {
-      SoundFade.fadeOut(globalScene, sound, realDuration, true);
+      SoundFade.fadeOut(globalScene, sound, realDuration, false);
     });
-    globalScene.time.delayedCall(realDuration, () => {
-      if (!this.destroyed) {
+    globalScene.time.delayedCall(realDuration + 100, () => {
+      if (this.destroyed) {
+        return;
+      }
+      if (destroy) {
         this.destroy();
+      } else if (this.sound) {
+        this.sound.pause();
       }
     });
   }

--- a/src/phases/party-heal-phase.ts
+++ b/src/phases/party-heal-phase.ts
@@ -18,7 +18,7 @@ export class PartyHealPhase extends BattlePhase {
   start() {
     super.start();
 
-    audioManager.fadeOutBgm(1000);
+    audioManager.fadeOutBgm(1000, false, !this.resumeBgm);
     globalScene.ui.fadeOut(1000).then(() => {
       const preventRevive = new BooleanHolder(false);
       applyChallenges(ChallengeType.PREVENT_REVIVE, preventRevive);


### PR DESCRIPTION
<!--
Thank you for contributing to PokéRogue!
Open-source contributions like yours help keep this project going.

Note that these comment blocks are purely informative and can be removed once you're done reading them.
-->

<!--
Make sure your title matches the https://www.conventionalcommits.org/en/v1.0.0/ format.
Try to keep the title under 72 characters, as GitHub cuts off commit titles longer than this length.

See https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request
for more information on the allowed scopes and prefixes.

Example:
fix(move): Future Sight no longer crashes
^   ^      ^
|   |      |__ Subject
|   |_________ Scope (optional)
|_____________ Prefix
-->

## What are the changes the user will see?
No crash on egg hatch screen

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
<!--
Explain why you decided to introduce these changes.
Does it come from another issue, PR or other prior discussion? Link to them if possible.
How can this can enhance user experience or otherwise improve the codebase?

Try to keep this explanation as objective as possible — avoid referring to personal feelings or making derogatory comments about existing code.

If this PR resolves an existing GitHub issue,
you can add "Fixes #[issue number]" (e.g.: "Fixes #1234") to link the issue.
(See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue for more information.)
-->

## What are the changes from a developer perspective?
The crash happened because when bgms were loaded/unloaded quickly, the audio cache could be purged while a sound playing that audio is still active. Fixed by tracking the number of instances using each track and only clearing from cache when none are left. Also allowed heal phase to not purge bgm in the case that it's going to resume it

## Screenshots/Videos
<!--
If you are changing anything visual (UI/UX, locales changes, etc.), please include screenshot(s) and/or video(s) showing the changes within collapsible blocks, like below:

<details><summary>Before</summary>

[before screenshot here]

</details>
<details><summary>After</summary>

[after screenshot here]

</details>
-->

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [ ] **I'm using `beta` as my base branch**
  - [ ] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [ ] I have provided a clear explanation of the changes within the PR description
  - [ ] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [ ] The PR is self-contained and cannot be split into smaller PRs
- [ ] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [ ] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: _____
- [ ] I have contacted the Translation Team on Discord for proofreading/translation

Does this require any additions or changes to in-game assets? If so:
- [ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: _____
