### PR TITLE
fix(audio): BGM no longer plays loudly after some fades even when muted

### DIFF
--- a/src/audio/audio-manager.ts
+++ b/src/audio/audio-manager.ts
@@ -67,6 +67,7 @@ export class AudioManager {
    * @param fadeDuration - (Default `500`) How long, in ms, the fade out of the previous bgm should take
    * @returns The {@linkcode BackgroundMusic} instance for the new bgm,
    * or `null` if no valid bgm could be played or the input bgm was the same as the currently playing bgm
+   * todo group the fade parameters next to each other
    */
   public playBgm(bgmName?: string, fadeOutPrevious = false, loop = true, fadeDuration = 500): BackgroundMusic | null {
     const resolvedName = timedEventManager.getEventBgmReplacement(

--- a/src/audio/audio-manager.ts
+++ b/src/audio/audio-manager.ts
@@ -64,10 +64,11 @@ export class AudioManager {
    * Can be overridden by a currently running event.
    * @param fadeOutPrevious - (Default `false`) Whether to fade out the previously playing bgm
    * @param loop - (Default `true`) Whether to loop the new bgm
+   * @param fadeDuration - (Default `500`) How long, in ms, the fade out of the previous bgm should take
    * @returns The {@linkcode BackgroundMusic} instance for the new bgm,
    * or `null` if no valid bgm could be played or the input bgm was the same as the currently playing bgm
    */
-  public playBgm(bgmName?: string, fadeOutPrevious = false, loop = true): BackgroundMusic | null {
+  public playBgm(bgmName?: string, fadeOutPrevious = false, loop = true, fadeDuration = 500): BackgroundMusic | null {
     const resolvedName = timedEventManager.getEventBgmReplacement(
       bgmName ?? globalScene.currentBattle?.getBgmOverride() ?? globalScene.arena?.bgm,
     );
@@ -93,7 +94,6 @@ export class AudioManager {
     const volume = this.getVolume(VolumeSetting.BGM);
 
     if (fadeOutPrevious && previous?.isPlaying) {
-      const fadeDuration = 500;
       previous.fadeOut(fadeDuration, true);
       newBgm.playAfterDelay(fixedInt(fadeDuration + 250), volume);
     } else {
@@ -139,18 +139,6 @@ export class AudioManager {
   public fadeOutBgm(duration = 500, fixed = false): void {
     this.currentBgm?.fadeOut(duration, fixed);
     this.currentBgm = null;
-  }
-
-  /**
-   * Fade out the current BGM track over `delay` ms, then start `newBgmKey` once it finishes.
-   * @param newBgmKey - (Optional) The key for the next track to start
-   * @param delay - (Default `2000`) The delay to use before starting the next track
-   */
-  public fadeAndSwitchBgm(newBgmKey?: string, delay = 2000): void {
-    this.fadeOutBgm(delay, true);
-    globalScene.time.delayedCall(fixedInt(delay), () => {
-      this.playBgm(newBgmKey);
-    });
   }
 
   /**

--- a/src/audio/audio-manager.ts
+++ b/src/audio/audio-manager.ts
@@ -67,8 +67,8 @@ export class AudioManager {
    * @param fadeDuration - (Default `500`) How long, in ms, the fade out of the previous bgm should take
    * @returns The {@linkcode BackgroundMusic} instance for the new bgm,
    * or `null` if no valid bgm could be played or the input bgm was the same as the currently playing bgm
-   * todo group the fade parameters next to each other
    */
+  // TODO: use object params
   public playBgm(bgmName?: string, fadeOutPrevious = false, loop = true, fadeDuration = 500): BackgroundMusic | null {
     const resolvedName = timedEventManager.getEventBgmReplacement(
       bgmName ?? globalScene.currentBattle?.getBgmOverride() ?? globalScene.arena?.bgm,

--- a/src/data/mystery-encounters/encounters/delibirdy-encounter.ts
+++ b/src/data/mystery-encounters/encounters/delibirdy-encounter.ts
@@ -141,7 +141,7 @@ export const DelibirdyEncounter: MysteryEncounter = MysteryEncounterBuilder.with
     return true;
   })
   .withOnVisualsStart(() => {
-    audioManager.fadeAndSwitchBgm("mystery_encounter_delibirdy");
+    audioManager.playBgm("mystery_encounter_delibirdy", true);
     return true;
   })
   .withOption(

--- a/src/data/mystery-encounters/encounters/fun-and-games-encounter.ts
+++ b/src/data/mystery-encounters/encounters/fun-and-games-encounter.ts
@@ -91,7 +91,7 @@ export const FunAndGamesEncounter: MysteryEncounter = MysteryEncounterBuilder.wi
     return true;
   })
   .withOnVisualsStart(() => {
-    audioManager.fadeAndSwitchBgm("mystery_encounter_fun_and_games");
+    audioManager.playBgm("mystery_encounter_fun_and_games", true);
     return true;
   })
   .withOption(

--- a/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
+++ b/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
@@ -146,7 +146,7 @@ export const GlobalTradeSystemEncounter: MysteryEncounter = MysteryEncounterBuil
     return true;
   })
   .withOnVisualsStart(() => {
-    audioManager.fadeAndSwitchBgm(globalScene.currentBattle.mysteryEncounter!.misc.bgmKey);
+    audioManager.playBgm(globalScene.currentBattle.mysteryEncounter!.misc.bgmKey, true);
     return true;
   })
   .withOption(

--- a/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
+++ b/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
@@ -166,7 +166,7 @@ export const WeirdDreamEncounter: MysteryEncounter = MysteryEncounterBuilder.wit
     return true;
   })
   .withOnVisualsStart(() => {
-    audioManager.fadeAndSwitchBgm("mystery_encounter_weird_dream");
+    audioManager.playBgm("mystery_encounter_weird_dream", true);
     return true;
   })
   .withOption(

--- a/src/phases/select-starter-phase.ts
+++ b/src/phases/select-starter-phase.ts
@@ -109,7 +109,7 @@ export class SelectStarterPhase extends Phase {
     overrideModifiers();
     overrideHeldItems(party[0]);
     Promise.all(loadPokemonAssets).then(() => {
-      audioManager.fadeAndSwitchBgm(undefined, 500);
+      audioManager.playBgm(undefined, true);
       if (globalScene.gameMode.isClassic) {
         globalScene.gameData.gameStats.classicSessionsPlayed++;
       } else {


### PR DESCRIPTION
## What are the changes the user will see?
Certain MEs will no longer loudly play the previous BGM track when muted during the fade out.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
<!--
Explain why you decided to introduce these changes.
Does it come from another issue, PR or other prior discussion? Link to them if possible.
How can this can enhance user experience or otherwise improve the codebase?

Try to keep this explanation as objective as possible — avoid referring to personal feelings or making derogatory comments about existing code.

If this PR resolves an existing GitHub issue,
you can add "Fixes #[issue number]" (e.g.: "Fixes #1234") to link the issue.
(See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue for more information.)
-->

## What are the changes from a developer perspective?
I removed `fadeAndSwitchBgm` as it's redundant considering that there's already a `fadeOutPrevious` parameter on `playBgm`. I'm not sure where the actual issue came from, I suspect it was some sort of race condition due to `fadeAndSwitchBgm` using `delayedCall` instead of `playAfterDelay`, etc. But I figured this change (which needed to happen anyway) would fix the issue, and it does.

Note that this is technically a behavior change because the default fade duration is only 500ms rather than 2000, and there is a short delay between the delayed track ending and the new one starting. The 2000ms fade resulted in a pretty long period of just silence, so I don't think that there was much reason behind it and if anything it's better now, but it would be easy to add that delay back if it were desired.

## Screenshots/Videos
<!--
If you are changing anything visual (UI/UX, locales changes, etc.), please include screenshot(s) and/or video(s) showing the changes within collapsible blocks, like below:

<details><summary>Before</summary>

[before screenshot here]

</details>
<details><summary>After</summary>

[after screenshot here]

</details>
-->

## How to test the changes?
```ts
const overrides = {
  STARTING_WAVE_OVERRIDE: 14,
  MYSTERY_ENCOUNTER_OVERRIDE: MysteryEncounterType.FUN_AND_GAMES,
  MYSTERY_ENCOUNTER_RATE_OVERRIDE: 256,
} satisfies Partial<InstanceType<OverridesType>>;
```
Use these overrides and spam through a few encounters (using "Leave" is fine). Before the changes you'll hear the BGM spike in loudly, after you won't

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [ ] **I'm using `beta` as my base branch**
  - [ ] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [ ] I have provided a clear explanation of the changes within the PR description
  - [ ] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [ ] The PR is self-contained and cannot be split into smaller PRs
- [ ] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [ ] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: _____
- [ ] I have contacted the Translation Team on Discord for proofreading/translation

Does this require any additions or changes to in-game assets? If so:
- [ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: _____
