### PR TITLE
i18n: Move effectiveness multiplier translatable

### DIFF
--- a/src/audio/audio-manager.ts
+++ b/src/audio/audio-manager.ts
@@ -135,10 +135,13 @@ export class AudioManager {
    * Fades out the current bgm over `duration` ms.
    * @param duration - (Default `500`) The amount of time the fade out should take place over, in ms
    * @param fixed - (Default `false`) Whether the duration should ignore game speed
+   * @param destroy - (Default `true`) Whether to destroy the bgm after fading out, or just pause it
    */
-  public fadeOutBgm(duration = 500, fixed = false): void {
-    this.currentBgm?.fadeOut(duration, fixed);
-    this.currentBgm = null;
+  public fadeOutBgm(duration = 500, fixed = false, destroy = true): void {
+    this.currentBgm?.fadeOut(duration, fixed, destroy);
+    if (destroy) {
+      this.currentBgm = null;
+    }
   }
 
   /**

--- a/src/audio/background-music.ts
+++ b/src/audio/background-music.ts
@@ -15,6 +15,13 @@ import SoundFade from "phaser3-rex-plugins/plugins/soundfade";
  * of if the music is able to start and stop cleanly.
  */
 export class BackgroundMusic {
+  /**
+   * Maps the number of active BGM objects for a particular key.
+   *
+   * This will almost always be 1, but with i.e. paused/resumed music it may be more.
+   */
+  private static readonly refCounts = new Map<string, number>();
+
   /** The key for the audio file */
   public readonly key: string;
 
@@ -46,6 +53,7 @@ export class BackgroundMusic {
    */
   constructor(key: string, loop: boolean, loopPoint = 0) {
     this.key = key;
+    BackgroundMusic.refCounts.set(key, (BackgroundMusic.refCounts.get(key) ?? 0) + 1);
 
     globalScene
       .loadBgm(key)
@@ -159,18 +167,40 @@ export class BackgroundMusic {
     if (this.sound?.isPlaying) {
       this.sound.stop();
     }
-    globalScene.sound.removeByKey(this.key);
-    globalScene.cache.audio.remove(this.key);
+
+    if (this.sound != null) {
+      globalScene.sound.remove(this.sound);
+      this.sound = undefined;
+    }
+
+    const remaining = (BackgroundMusic.refCounts.get(this.key) ?? 1) - 1;
+    if (remaining <= 0) {
+      BackgroundMusic.refCounts.delete(this.key);
+      globalScene.cache.audio.remove(this.key);
+    } else {
+      BackgroundMusic.refCounts.set(this.key, remaining);
+    }
   }
 
-  public fadeOut(duration: number, fixed = false): void {
+  /**
+   * Fade the volume to zero over `duration` ms.
+   * @param duration - Fade time in milliseconds
+   * @param fixed - (Default `false`) Whether duration should ignore game speed
+   * @param destroy - (Default `true`) Whether to destroy the bgm after fading out, or just pause it
+   */
+  public fadeOut(duration: number, fixed = false, destroy = true): void {
     const realDuration = fixed ? fixedInt(duration) : duration;
     this.withSound(sound => {
-      SoundFade.fadeOut(globalScene, sound, realDuration, true);
+      SoundFade.fadeOut(globalScene, sound, realDuration, false);
     });
-    globalScene.time.delayedCall(realDuration, () => {
-      if (!this.destroyed) {
+    globalScene.time.delayedCall(realDuration + 100, () => {
+      if (this.destroyed) {
+        return;
+      }
+      if (destroy) {
         this.destroy();
+      } else if (this.sound) {
+        this.sound.pause();
       }
     });
   }

--- a/src/phases/party-heal-phase.ts
+++ b/src/phases/party-heal-phase.ts
@@ -18,7 +18,7 @@ export class PartyHealPhase extends BattlePhase {
   start() {
     super.start();
 
-    audioManager.fadeOutBgm(1000);
+    audioManager.fadeOutBgm(1000, false, !this.resumeBgm);
     globalScene.ui.fadeOut(1000).then(() => {
       const preventRevive = new BooleanHolder(false);
       applyChallenges(ChallengeType.PREVENT_REVIVE, preventRevive);

--- a/src/ui/containers/pokemon-info-container.ts
+++ b/src/ui/containers/pokemon-info-container.ts
@@ -39,6 +39,11 @@ const languageSettings: { [key: string]: LanguageSetting } = {
     infoContainerLabelXPos: -27,
     infoContainerTextXPos: -25,
   },
+  pl: {
+    infoContainerTextSize: "54px",
+    infoContainerLabelXPos: -20,
+    infoContainerTextXPos: -17,
+  },
 };
 
 export class PokemonInfoContainer extends Phaser.GameObjects.Container {

--- a/src/ui/handlers/fight-ui-handler.ts
+++ b/src/ui/handlers/fight-ui-handler.ts
@@ -333,12 +333,12 @@ export class FightUiHandler extends UiHandler implements InfoToggle {
     );
     if (pokemonMove.getMove().category === MoveCategory.STATUS) {
       if (effectiveness === 0) {
-        return "0x";
+        return i18next.t("fightUiHandler:effectiveness000");
       }
-      return "1x";
+      return i18next.t("fightUiHandler:effectiveness100");
     }
 
-    return `${effectiveness}x`;
+    return i18next.t("fightUiHandler:effectivenessMultiplier", { effectiveness });
   }
 
   displayMoves() {

--- a/src/ui/handlers/starter-select-ui-handler.ts
+++ b/src/ui/handlers/starter-select-ui-handler.ts
@@ -202,9 +202,10 @@ const languageSettings: { [key: string]: LanguageSetting } = {
     instructionTextSize: "28px",
   },
   vi: {
-    starterInfoTextSize: "56px",
+    starterInfoTextSize: "50px",
     instructionTextSize: "28px",
-    starterInfoXPos: 35,
+    starterInfoYOffset: 0.5,
+    starterInfoXPos: 34,
   },
   tl: {
     starterInfoTextSize: "56px",

--- a/src/ui/handlers/starter-select-ui-handler.ts
+++ b/src/ui/handlers/starter-select-ui-handler.ts
@@ -174,7 +174,6 @@ const languageSettings: { [key: string]: LanguageSetting } = {
     starterInfoTextSize: "48px",
     instructionTextSize: "28px",
     starterInfoYOffset: 0.5,
-    starterInfoXPos: 40,
   },
   ro: {
     starterInfoTextSize: "56px",


### PR DESCRIPTION
> [!NOTE]
> Copy of #7321 

## What are the changes the user will see?
N/a

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
To have it translatable

## What are the changes from a developer perspective?
None

## Screenshots/Videos
--

## How to test the changes?
Play the game and check the effectivness multiplier of a move on the opponent

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [x] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: https://github.com/pagefaultgames/pokerogue-locales/pull/317
- [x] I have contacted the Translation Team on Discord for proofreading/translation
