### PR TITLE
feat(battle): added "Retry Biome" option on Daily Run

### DIFF
--- a/src/@types/save-data.ts
+++ b/src/@types/save-data.ts
@@ -70,6 +70,11 @@ export interface SessionSaveData {
    * Counts the amount of pokemon fainted in your party during the current arena encounter.
    */
   playerFaints: number;
+  /**
+   * Integral copy of a session save, that is ovewritten at the first wave of every biome.
+   * Only used in Daily Runs, if "Retry Battles" is enabled.
+   */
+  biomeCheckpoint?: Omit<SessionSaveData, "biomeCheckpoint">;
 }
 
 export interface Unlocks {

--- a/src/api/savedata-api.ts
+++ b/src/api/savedata-api.ts
@@ -18,14 +18,16 @@ export class PokerogueSavedataApi extends ApiBase {
   /**
    * Update all savedata
    * @param bodyData The {@linkcode UpdateAllSavedataRequest | request data} to send
+   * @param reset If `true`, appends `?reset=true` to bypass wave-index rollback protection
    * @returns An error message if something went wrong
    */
-  public async updateAll(bodyData: UpdateAllSavedataRequest): Promise<string> {
+  public async updateAll(bodyData: UpdateAllSavedataRequest, reset = false): Promise<string> {
     try {
       const rawBodyData = JSON.stringify(bodyData, (_k: any, v: any) =>
         typeof v === "bigint" ? (v <= MAX_INT_ATTR_VALUE ? Number(v) : v.toString()) : v,
       );
-      const response = await this.doPost("/savedata/updateall", rawBodyData);
+      const url = reset ? "/savedata/updateall?reset=true" : "/savedata/updateall";
+      const response = await this.doPost(url, rawBodyData);
       return await response.text();
     } catch (err) {
       console.warn("Could not update all savedata!", err);

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -292,10 +292,8 @@ export class EncounterPhase extends BattlePhase {
           // Set weather and terrain before session gets saved
           this.trySetWeatherIfNewBiome();
           this.trySetTerrainIfNewBiome();
-          // Save biome checkpoint in all X1 waves, if Enable Retries is active
-          if (globalScene.enableRetries && globalScene.gameMode.isDaily && battle.waveIndex % 10 === 1) {
-            globalScene.gameData.saveBiomeCheckpoint();
-          }
+          this.trySaveBiomeCheckpointIfNewBiome();
+
           // Game syncs to server on waves X1 and X6 (As of 1.2.0)
           globalScene.gameData
             .saveAll(true, battle.waveIndex % 5 === 1 || (globalScene.lastSavePlayTime ?? 0) >= 300)
@@ -671,5 +669,18 @@ export class EncounterPhase extends BattlePhase {
    */
   protected trySetTerrainIfNewBiome(): void {
     globalScene.arena.setBiomeTerrain();
+  }
+
+  /**
+   * Save a biome checkpoint if and only if this encounter is the start of a new biome.
+   * @remarks
+   * By using function overrides, this should happen if and only if this phase
+   * is exactly a `NewBiomeEncounterPhase` or an `EncounterPhase` (to account for
+   * Wave 1 of a Daily Run), but NOT `NextEncounterPhase`.
+   */
+  protected trySaveBiomeCheckpointIfNewBiome(): void {
+    if (globalScene.enableRetries && globalScene.gameMode.isDaily) {
+      globalScene.gameData.saveBiomeCheckpoint();
+    }
   }
 }

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -292,6 +292,10 @@ export class EncounterPhase extends BattlePhase {
           // Set weather and terrain before session gets saved
           this.trySetWeatherIfNewBiome();
           this.trySetTerrainIfNewBiome();
+          // Save biome checkpoint in all X1 waves, if Enable Retries is active
+          if (globalScene.enableRetries && globalScene.gameMode.isDaily && battle.waveIndex % 10 === 1) {
+            globalScene.gameData.saveBiomeCheckpoint();
+          }
           // Game syncs to server on waves X1 and X6 (As of 1.2.0)
           globalScene.gameData
             .saveAll(true, battle.waveIndex % 5 === 1 || (globalScene.lastSavePlayTime ?? 0) >= 300)

--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -77,21 +77,21 @@ export class GameOverPhase extends BattlePhase {
       );
     } else if (this.isVictory || !globalScene.enableRetries) {
       this.handleGameOver();
-    } else if (globalScene.gameMode.isDaily) {
+    } else if (globalScene.gameMode.isDaily && globalScene.gameData.biomeCheckpoint) {
       globalScene.ui.showText(i18next.t("battle:retryBattleDaily"), null, () => {
         globalScene.ui.setMode(UiMode.OPTION_SELECT, {
           options: [
             {
               label: i18next.t("battle:retryBattleOption"),
               handler: () => {
-                this.doRetryBattle();
+                this.doRetry();
                 return true;
               },
             },
             {
               label: i18next.t("battle:retryBiomeOption"),
               handler: () => {
-                this.doRetryBiome();
+                this.doRetry(true);
                 return true;
               },
             },
@@ -111,7 +111,7 @@ export class GameOverPhase extends BattlePhase {
         globalScene.ui.setMode(
           UiMode.CONFIRM,
           () => {
-            this.doRetryBattle();
+            this.doRetry();
           },
           () => this.handleGameOver(),
           false,
@@ -122,70 +122,46 @@ export class GameOverPhase extends BattlePhase {
       });
     }
   }
-
   /**
-   * Handles retry battle, available when the Enable Retries is active.
+   * Handles retry from the start of the biome and restart of battle.
+   * Available in Daily Run when Enable Retries is active.
    */
-  private doRetryBattle(): void {
+  private doRetry(biomeRetry = false): void {
     globalScene.ui.fadeOut(1250).then(() => {
       globalScene.reset();
       globalScene.phaseManager.clearPhaseQueue();
-      globalScene.gameData.loadSession(globalScene.sessionSlotId).then(() => {
-        globalScene.phaseManager.pushNew("EncounterPhase", true);
 
-        const availablePartyMembers = globalScene.getPokemonAllowedInBattle().length;
+      const loadOption = biomeRetry
+        ? globalScene.gameData.loadBiomeCheckpoint()
+        : globalScene.gameData.loadSession(globalScene.sessionSlotId);
 
-        globalScene.phaseManager.pushNew("SummonPhase", 0, true, true);
-        if (globalScene.currentBattle.double && availablePartyMembers > 1) {
-          globalScene.phaseManager.pushNew("SummonPhase", 1, true, true);
-        }
-        if (globalScene.currentBattle.waveIndex > 1 && globalScene.currentBattle.battleType !== BattleType.TRAINER) {
-          globalScene.phaseManager.pushNew("CheckSwitchPhase", 0, globalScene.currentBattle.double);
-          if (globalScene.currentBattle.double && availablePartyMembers > 1) {
-            globalScene.phaseManager.pushNew("CheckSwitchPhase", 1, globalScene.currentBattle.double);
-          }
-        }
-
-        globalScene.ui.fadeIn(1250);
-        this.end();
+      loadOption.then(() => {
+        this.setupRetryEncounter();
       });
     });
   }
 
   /**
-   * Handles retry from the start of the biome, available in Daily Run when Enable Retries is active.
+   * Sets up initial phases and UI transitions when restarting (battle or biome).
    */
-  private doRetryBiome(): void {
-    globalScene.ui.fadeOut(1250).then(() => {
-      globalScene.reset();
-      globalScene.phaseManager.clearPhaseQueue();
+  private setupRetryEncounter(): void {
+    globalScene.phaseManager.pushNew("EncounterPhase", true);
 
-      globalScene.gameData.loadBiomeCheckpoint().then(success => {
-        // Falls back to a normal retry battle
-        if (!success) {
-          console.warn("No biome checkpoint found, falling back to retry battle");
-          return this.doRetryBattle();
-        }
+    const availablePartyMembers = globalScene.getPokemonAllowedInBattle().length;
 
-        globalScene.phaseManager.pushNew("EncounterPhase", true);
+    globalScene.phaseManager.pushNew("SummonPhase", 0, true, true);
+    if (globalScene.currentBattle.double && availablePartyMembers > 1) {
+      globalScene.phaseManager.pushNew("SummonPhase", 1, true, true);
+    }
+    if (globalScene.currentBattle.waveIndex > 1 && globalScene.currentBattle.battleType !== BattleType.TRAINER) {
+      globalScene.phaseManager.pushNew("CheckSwitchPhase", 0, globalScene.currentBattle.double);
+      if (globalScene.currentBattle.double && availablePartyMembers > 1) {
+        globalScene.phaseManager.pushNew("CheckSwitchPhase", 1, globalScene.currentBattle.double);
+      }
+    }
 
-        const availablePartyMembers = globalScene.getPokemonAllowedInBattle().length;
-
-        globalScene.phaseManager.pushNew("SummonPhase", 0, true, true);
-        if (globalScene.currentBattle.double && availablePartyMembers > 1) {
-          globalScene.phaseManager.pushNew("SummonPhase", 1, true, true);
-        }
-        if (globalScene.currentBattle.waveIndex > 1 && globalScene.currentBattle.battleType !== BattleType.TRAINER) {
-          globalScene.phaseManager.pushNew("CheckSwitchPhase", 0, globalScene.currentBattle.double);
-          if (globalScene.currentBattle.double && availablePartyMembers > 1) {
-            globalScene.phaseManager.pushNew("CheckSwitchPhase", 1, globalScene.currentBattle.double);
-          }
-        }
-
-        globalScene.ui.fadeIn(1250);
-        this.end();
-      });
-    });
+    globalScene.ui.fadeIn(1250);
+    this.end();
   }
 
   /**

--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -77,37 +77,41 @@ export class GameOverPhase extends BattlePhase {
       );
     } else if (this.isVictory || !globalScene.enableRetries) {
       this.handleGameOver();
+    } else if (globalScene.gameMode.isDaily) {
+      globalScene.ui.showText(i18next.t("battle:retryBattleDaily"), null, () => {
+        globalScene.ui.setMode(UiMode.OPTION_SELECT, {
+          options: [
+            {
+              label: i18next.t("battle:retryBattleOption"),
+              handler: () => {
+                this.doRetryBattle();
+                return true;
+              },
+            },
+            {
+              label: i18next.t("battle:retryBiomeOption"),
+              handler: () => {
+                this.doRetryBiome();
+                return true;
+              },
+            },
+            {
+              label: i18next.t("battle:quitOption"),
+              handler: () => {
+                this.handleGameOver();
+                return true;
+              },
+            },
+          ],
+          delay: 1000,
+        });
+      });
     } else {
       globalScene.ui.showText(i18next.t("battle:retryBattle"), null, () => {
         globalScene.ui.setMode(
           UiMode.CONFIRM,
           () => {
-            globalScene.ui.fadeOut(1250).then(() => {
-              globalScene.reset();
-              globalScene.phaseManager.clearPhaseQueue();
-              globalScene.gameData.loadSession(globalScene.sessionSlotId).then(() => {
-                globalScene.phaseManager.pushNew("EncounterPhase", true);
-
-                const availablePartyMembers = globalScene.getPokemonAllowedInBattle().length;
-
-                globalScene.phaseManager.pushNew("SummonPhase", 0, true, true);
-                if (globalScene.currentBattle.double && availablePartyMembers > 1) {
-                  globalScene.phaseManager.pushNew("SummonPhase", 1, true, true);
-                }
-                if (
-                  globalScene.currentBattle.waveIndex > 1
-                  && globalScene.currentBattle.battleType !== BattleType.TRAINER
-                ) {
-                  globalScene.phaseManager.pushNew("CheckSwitchPhase", 0, globalScene.currentBattle.double);
-                  if (globalScene.currentBattle.double && availablePartyMembers > 1) {
-                    globalScene.phaseManager.pushNew("CheckSwitchPhase", 1, globalScene.currentBattle.double);
-                  }
-                }
-
-                globalScene.ui.fadeIn(1250);
-                this.end();
-              });
-            });
+            this.doRetryBattle();
           },
           () => this.handleGameOver(),
           false,
@@ -117,6 +121,71 @@ export class GameOverPhase extends BattlePhase {
         );
       });
     }
+  }
+
+  /**
+   * Handles retry battle, available when the Enable Retries is active.
+   */
+  private doRetryBattle(): void {
+    globalScene.ui.fadeOut(1250).then(() => {
+      globalScene.reset();
+      globalScene.phaseManager.clearPhaseQueue();
+      globalScene.gameData.loadSession(globalScene.sessionSlotId).then(() => {
+        globalScene.phaseManager.pushNew("EncounterPhase", true);
+
+        const availablePartyMembers = globalScene.getPokemonAllowedInBattle().length;
+
+        globalScene.phaseManager.pushNew("SummonPhase", 0, true, true);
+        if (globalScene.currentBattle.double && availablePartyMembers > 1) {
+          globalScene.phaseManager.pushNew("SummonPhase", 1, true, true);
+        }
+        if (globalScene.currentBattle.waveIndex > 1 && globalScene.currentBattle.battleType !== BattleType.TRAINER) {
+          globalScene.phaseManager.pushNew("CheckSwitchPhase", 0, globalScene.currentBattle.double);
+          if (globalScene.currentBattle.double && availablePartyMembers > 1) {
+            globalScene.phaseManager.pushNew("CheckSwitchPhase", 1, globalScene.currentBattle.double);
+          }
+        }
+
+        globalScene.ui.fadeIn(1250);
+        this.end();
+      });
+    });
+  }
+
+  /**
+   * Handles retry from the start of the biome, available in Daily Run when Enable Retries is active.
+   */
+  private doRetryBiome(): void {
+    globalScene.ui.fadeOut(1250).then(() => {
+      globalScene.reset();
+      globalScene.phaseManager.clearPhaseQueue();
+
+      globalScene.gameData.loadBiomeCheckpoint().then(success => {
+        // Falls back to a normal retry battle
+        if (!success) {
+          console.warn("No biome checkpoint found, falling back to retry battle");
+          return this.doRetryBattle();
+        }
+
+        globalScene.phaseManager.pushNew("EncounterPhase", true);
+
+        const availablePartyMembers = globalScene.getPokemonAllowedInBattle().length;
+
+        globalScene.phaseManager.pushNew("SummonPhase", 0, true, true);
+        if (globalScene.currentBattle.double && availablePartyMembers > 1) {
+          globalScene.phaseManager.pushNew("SummonPhase", 1, true, true);
+        }
+        if (globalScene.currentBattle.waveIndex > 1 && globalScene.currentBattle.battleType !== BattleType.TRAINER) {
+          globalScene.phaseManager.pushNew("CheckSwitchPhase", 0, globalScene.currentBattle.double);
+          if (globalScene.currentBattle.double && availablePartyMembers > 1) {
+            globalScene.phaseManager.pushNew("CheckSwitchPhase", 1, globalScene.currentBattle.double);
+          }
+        }
+
+        globalScene.ui.fadeIn(1250);
+        this.end();
+      });
+    });
   }
 
   /**

--- a/src/phases/next-encounter-phase.ts
+++ b/src/phases/next-encounter-phase.ts
@@ -82,4 +82,7 @@ export class NextEncounterPhase extends EncounterPhase {
 
   /** Do nothing (since this is simply the next wave in the same biome). */
   protected override trySetTerrainIfNewBiome(): void {}
+
+  /** Do nothing (since this is simply the next wave in the same biome). */
+  protected override trySaveBiomeCheckpointIfNewBiome(): void {}
 }

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1237,6 +1237,7 @@ export class GameData {
    * Save all data related to the current session to {@linkcode localStorage} and/or the backend server.
    * @param skipVerification - (Default `false`) Whether to skip verifying user info before saving
    * @param sync - (Default `false`) Whether to sync data to the server
+   * @param reset - (Default `false`) Whether to bypass the server's wave-index rollback protection
    * @param useCachedSession - (Default `false`) Whether to use cached session data from `localStorage` instead of generating new session data
    * @param useCachedSystem - (Default `false`) Whether to use cached system data from `localStorage` instead of generating new system data
    * @returns A Promise that resolves with whether the save operation succeeded.
@@ -1246,6 +1247,7 @@ export class GameData {
   async saveAll(
     skipVerification = false,
     sync = false,
+    reset = false,
     useCachedSession = false,
     useCachedSystem = false,
   ): Promise<boolean> {
@@ -1302,7 +1304,7 @@ export class GameData {
       return verified;
     }
 
-    const saveError = await pokerogueApi.savedata.updateAll(request);
+    const saveError = await pokerogueApi.savedata.updateAll(request, reset);
     if (sync) {
       globalScene.lastSavePlayTime = 0;
       globalScene.ui.savingIcon.hide();
@@ -2182,7 +2184,7 @@ export class GameData {
     // Preserve the checkpoint into the restored session so retries remain available
     restoredSession.biomeCheckpoint = sessionData.biomeCheckpoint;
     await this.initSessionFromData(restoredSession);
-    await this.saveAll(true, true);
+    await this.saveAll(true, true, true);
     return true;
   }
 }

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -148,7 +148,7 @@ export class GameData {
   public eggPity: number[];
   public unlockPity: number[];
 
-  public biomeCheckpoint?: Omit<SessionSaveData, "biomeCheckpoint">;
+  public biomeCheckpoint?: Omit<SessionSaveData, "biomeCheckpoint"> | undefined;
 
   /**
    * @param fromRaw - If true, will skip initialization of fields that are normally randomized on new game start. Used for the admin panel; default `false`
@@ -943,6 +943,8 @@ export class GameData {
 
     globalScene.sessionPlayTime = fromSession.playTime || 0;
     globalScene.lastSavePlayTime = 0;
+
+    this.biomeCheckpoint = fromSession.biomeCheckpoint;
 
     const loadPokemonAssets: Promise<void>[] = [];
 

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -148,6 +148,8 @@ export class GameData {
   public eggPity: number[];
   public unlockPity: number[];
 
+  public biomeCheckpoint?: Omit<SessionSaveData, "biomeCheckpoint">;
+
   /**
    * @param fromRaw - If true, will skip initialization of fields that are normally randomized on new game start. Used for the admin panel; default `false`
    */
@@ -824,6 +826,7 @@ export class GameData {
       mysteryEncounterType: globalScene.currentBattle.mysteryEncounter?.encounterType ?? -1,
       mysteryEncounterSaveData: globalScene.mysteryEncounterSaveData,
       playerFaints: globalScene.arena.playerFaints,
+      biomeCheckpoint: this.biomeCheckpoint,
     } as SessionSaveData;
   }
 
@@ -2146,5 +2149,38 @@ export class GameData {
         }
       }
     }
+  }
+
+  /**
+   * Saves the session state at the start of every current biome.
+   */
+  public saveBiomeCheckpoint(): void {
+    const sessionData = this.getSessionSaveData();
+    // Strip any existing checkpoint to avoid nesting
+    const { biomeCheckpoint: _, ...checkpointData } = sessionData;
+    // Deep clone the checkpoint to prevent live references (e.g. Pokemon stats arrays) from being mutated
+    const clonedCheckpoint = JSON.parse(JSON.stringify(checkpointData));
+    sessionData.biomeCheckpoint = clonedCheckpoint;
+    this.biomeCheckpoint = clonedCheckpoint;
+    const sessionDataStr = encrypt(JSON.stringify(sessionData), bypassLogin);
+    localStorage.setItem(getSessionDataLocalStorageKey(globalScene.sessionSlotId), sessionDataStr);
+  }
+
+  /**
+   * Restores the session to the state saved at the start of the current biome.
+   * @returns A promise resolving to `true` if the checkpoint was found and loaded, `false` otherwise.
+   */
+  public async loadBiomeCheckpoint(): Promise<boolean> {
+    const sessionData = await this.getSession(globalScene.sessionSlotId);
+    if (!sessionData?.biomeCheckpoint) {
+      return false;
+    }
+    const checkpointStr = JSON.stringify(sessionData.biomeCheckpoint);
+    const restoredSession = this.parseSessionData(checkpointStr);
+    // Preserve the checkpoint into the restored session so retries remain available
+    restoredSession.biomeCheckpoint = sessionData.biomeCheckpoint;
+    await this.initSessionFromData(restoredSession);
+    await this.saveAll(true, true);
+    return true;
   }
 }


### PR DESCRIPTION
## What are the changes the user will see?
<!--
Summarize the changes from a user perspective on the application.
Try to keep this section (relatively) brief as it is used to generate changelogs.
If you need to provide additional details, you can do so below the cutoff.

PRs with no user-facing changes should leave this blank or write "N/A" to be omitted from auto-generated changelogs.
-->

Upon being defeated in a Daily Run, if a player has the "Enable Retries" setting ON, instead of the standard 2 option menu for retrying the last battle/quitting, there is now a 3rd option for retrying the whole biome. Selecting that option, the player will go back to the first wave of the biome they were in when defeated (a checkpoint), losing all the items accumulated in the waves past that checkpoint.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
<!--
Explain why you decided to introduce these changes.
Does it come from another issue, PR or other prior discussion? Link to them if possible.
How can this can enhance user experience or otherwise improve the codebase?

Try to keep this explanation as objective as possible — avoid referring to personal feelings or making derogatory comments about existing code.

If this PR resolves an existing GitHub issue,
you can add "Fixes #[issue number]" (e.g.: "Fixes #1234") to link the issue.
(See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue for more information.)
-->

This feature addresses a concern raised by some fans of the Daily Run mode, as reported in issue #6541
Before, the only options available for a defeat would be : 
1. To retry the just lost battle;
 2. Quit, erasing the save. 

With this, a simple mistake could cost the whole run, and aside from exploits, there was no other way to go back in the run as much as a whole biome.

Now, with the addition of the 3 option for retrying the whole biome, the player now has a little bit more freedom to make mistakes, thus enjoying the game more, and improving playability!

Fixes #6541

## What are the changes from a developer perspective?
<!--
Describe the changes this PR introduces to the codebase.
You can make use of a comparison between the state of the code before and after your changes.
Ex: What files have been changed? What classes/functions/variables/etc. have been added or changed?

Include enough detail to convey the scope of the changes being made and the rationale behind their implementation.
Feel free to include small code snippets if you think they will help illustrate your points.
-->

`game-data.ts` and `save-data.ts`: the checkpoint data struct was created. This checkpoint is an integral copy of the Session Save the player is in. New functions were also created for saving and loading this checkpoint save, so that when the checkpoint is loaded, the SessionSave is re-written.
(update on `game-data.ts`): the saveAll method was modified, to comprise a new  optional 'reset' flag, that is set to true when used in the loadBiomeCheckpoint method.

`save-data-api.ts`: the updateAll method was updated to comprise the previous changes regarding the 'reset' flag. now, the method can send 2 distinct url when performing doPost:
- [NEW] "/savedata/updateall?reset=true" for the biomeCheckpoint variant;
- "/savedata/updateall".

`encounter-phase.ts`: the logic for saving this checkpoint was added. A simple if-clause was created to ensure that the save only occurs when "enableRetries" is On, the gamemode is Daily Run & the player is in the first wave of that biome.

`game-over-phase.ts`: the new menu was created, alongside new keys to present the options (more on that on the locales PR, link included below). A bit of refactoring was done to ensure that the previously menu still exists, but only on modes like Classic Run. New functions were also created to handle this new way to "end" a game,

 


## Screenshots/Videos

<details><summary>Before</summary>

[before screenshot here](https://github.com/user-attachments/assets/9bed3294-5f73-4764-88a0-13c1e74c4aca)


</details>
<details><summary>After</summary>

[after screenshot here](https://github.com/user-attachments/assets/fa5fb392-70a1-4dd1-a843-ef18ea7cfa3e)

</details>

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

For these changes to be tested, the reviewer should make sure that the "Enable Retries" feature is on, as well as that a Daily Run is being played. Overrides can be used to rig the starting phase, however this can be tested in the first 10 waves.
Force a defeat, and the new menu (with the new options) should appear!

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [X] **I'm using `beta` as my base branch**
  - [X] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [X] I have provided a clear explanation of the changes within the PR description
  - [X] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [X] The PR is self-contained and cannot be split into smaller PRs
- [X] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [X] I have tested the changes manually
  - [X] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [~] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [X] I have provided screenshots/videos of the changes (if applicable)
  - [X] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [X] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: [link](https://github.com/pagefaultgames/pokerogue-locales/pull/322)
- [X] I have contacted the Translation Team on Discord for proofreading/translation

Does this require any additions or changes to in-game assets? If so:
- [~] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: _____
