### PR TITLE
dev: added UI toggling override + show all biomes override

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1291,6 +1291,11 @@ export class BattleScene extends SceneBase {
    * @returns The newly created `Battle` instance.
    */
   public newBattle(fromSession?: SessionSaveData): Battle {
+    if (activeOverrides.STARTING_HIDE_UI_OVERRIDE) {
+      this.uiContainer.setVisible(false);
+      this.fieldUI.setVisible(false);
+    }
+
     const props = this.getNewBattleProps(fromSession);
     const { waveIndex, mysteryEncounterType } = props;
     const resolved: NewBattleInitialProps = { waveIndex, mysteryEncounterType };

--- a/src/field/arena-base.ts
+++ b/src/field/arena-base.ts
@@ -1,4 +1,5 @@
 import { globalScene } from "#app/global-scene";
+import { activeOverrides } from "#app/overrides";
 import type { BiomeId } from "#enums/biome-id";
 import { getBiomeHasProps, getBiomeKey } from "#field/arena";
 import { randSeedInt } from "#utils/common";
@@ -64,7 +65,9 @@ export class ArenaBase extends Phaser.GameObjects.Container {
     if (!this.player) {
       globalScene.executeWithSeedOffset(
         () => {
-          this.propValue = propValue === undefined ? (hasProps ? randSeedInt(8) : 0) : propValue;
+          this.propValue = propValue === undefined
+              ? (hasProps ? (activeOverrides.ALL_BIOME_PROPS_OVERRIDE ? 7 : randSeedInt(8)) : 0)
+              : propValue;
           this.props.forEach((prop, p) => {
             const propKey = `${biomeKey}_b${hasProps ? `_${p + 1}` : ""}`;
             prop.setTexture(propKey);

--- a/src/field/arena-base.ts
+++ b/src/field/arena-base.ts
@@ -65,9 +65,10 @@ export class ArenaBase extends Phaser.GameObjects.Container {
     if (!this.player) {
       globalScene.executeWithSeedOffset(
         () => {
-          this.propValue = propValue === undefined
-              ? (hasProps ? (activeOverrides.ALL_BIOME_PROPS_OVERRIDE ? 7 : randSeedInt(8)) : 0)
-              : propValue;
+          if (activeOverrides.ALL_BIOME_PROPS_OVERRIDE) {
+            propValue = 7;
+          }
+          this.propValue = propValue === undefined ? (hasProps ? randSeedInt(8) : 0) : propValue;
           this.props.forEach((prop, p) => {
             const propKey = `${biomeKey}_b${hasProps ? `_${p + 1}` : ""}`;
             prop.setTexture(propKey);

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -106,6 +106,15 @@ class DefaultOverrides {
   readonly STARTING_WAVE_OVERRIDE: number | null = null;
   readonly STARTING_BIOME_OVERRIDE: BiomeId | null = null;
   /**
+   * Hides the battle UI for cleaner screenshots (useful for seeing the biomes and pokemon clearly).
+   */
+  readonly STARTING_HIDE_UI_OVERRIDE: boolean = false;
+  /**
+   * Forces all available biome props to be visible when entering a biome.
+   * Sets the prop bitmask to show all 3 props instead of a random combination.
+   */
+  readonly ALL_BIOME_PROPS_OVERRIDE: boolean = false;
+  /**
    * Overrides the Time of Day for the given biome.
    * Set to `null` to disable.
    * @remarks


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
To help developers test the visual component of battles, adding the option to hide UI inside battles and the option to show all 3 biome props instead of a random combination, as overrides.

Fixes #6457.

## What are the changes from a developer perspective?
Added the overrides `STARTING_HIDE_UI_OVERRIDE` and `ALL_BIOME_PROPS_OVERRIDE` to `src/overrides.ts`.

The logic to hide the UI in battles is implemented in `src/battle-scene.ts`. It consists of an if-clause to set the `uiContainer` and `fieldUI` to not visible.

The logic to show all biome props is implemented in `src/field/battle-arena.ts`. The prop visibility is determined by the bitmask `propValue`, whose value was random. We added an if-clause to select a value that guarantees that all 3 props are visible. With three bits to true, 0b111, the value is 7.

## How to test the changes?
Set the overrides `STARTING_HIDE_UI_OVERRIDE` or `ALL_BIOME_PROPS_OVERRIDE` in `src/overrides.ts` to true and enter a battle.

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [x]  **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually