### PR TITLE
misc: `SpeciesDataRegistry#getForm[Key|Index]` early return if no forms

### DIFF
--- a/src/data/species-data-registry.ts
+++ b/src/data/species-data-registry.ts
@@ -408,7 +408,7 @@ export class SpeciesDataRegistry {
   // #region Helpers
 
   /**
-   * Helper to get the form key for a given species and formIndex or formKey.
+   * Helper to get the form key for a given species and formIndex or formKey. \
    * Also validates that the form exists and falls back to the base form if it doesn't.
    * @param speciesId - The {@linkcode SpeciesId} of the species to get the form key for
    * @param form - (Optional) The `formIndex` or `formKey` of the form to get the form key for.
@@ -416,8 +416,16 @@ export class SpeciesDataRegistry {
    * @returns The formKey
    */
   private getFormKey(speciesId: SpeciesId, form?: string | number): string {
-    const speciesData = this.getSpeciesData(speciesId);
-    const forms = speciesData.species.forms;
+    const forms = this.getSpeciesData(speciesId).species.forms;
+
+    if (forms.length === 0) {
+      return "";
+    }
+
+    if (form == null) {
+      console.debug(`No form requested for ${speciesId} (${this.getSpecies(speciesId).name}), returning base form.`);
+      return forms[0].formKey;
+    }
 
     if (typeof form === "string" && forms.some(f => f.formKey === form)) {
       return form;
@@ -427,7 +435,7 @@ export class SpeciesDataRegistry {
     }
 
     console.warn(`Invalid form index ${form} for species ${speciesId}, falling back to base form`);
-    return forms[0]?.formKey ?? "";
+    return forms[0].formKey;
   }
 
   /**
@@ -438,6 +446,10 @@ export class SpeciesDataRegistry {
    */
   private getFormIndex(speciesId: SpeciesId, form: string | number): number {
     const forms = this.getSpeciesData(speciesId).species.forms;
+
+    if (forms.length === 0) {
+      return 0;
+    }
 
     if (typeof form === "number" && form >= 0 && form < forms.length) {
       return form;


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
There were a bunch of unnecessary (and incorrect) warnings being printed to the console log.

## What are the changes from a developer perspective?
Added a check to see if the Pokémon has any forms, and if not to early return from `SpeciesDataRegistry#getFormKey` and `#getFormIndex`.

## How to test the changes?
Go to starter select and move the cursor around, there should be no warnings in the console on the PR branch and a bunch of warnings on beta.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually