### PR TITLE
fix(beta): `PokemonForm.getLevelMoves()` defaults to this forms formkey

### DIFF
--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -206,10 +206,10 @@ export abstract class PokemonSpeciesForm {
 
   /**
    * Get a list of all level moves for this species, including form specific moves.
-   * @param formKey - (Optional) The key for the form to be checked. Uses the base form if not specified.
+   * @param formKey - (Optional) The key for the form to be checked. Uses the base form if not specified
    * @returns A list of all level moves that can be learned by this species
    */
-  getLevelMoves(formKey?: string): LevelMoves {
+  public getLevelMoves(formKey?: string): LevelMoves {
     const levelMoves = speciesDataRegistry.getLevelMoves(this.speciesId, formKey);
     return levelMoves.sort((a, b) => a[0] - b[0]);
   }
@@ -1305,5 +1305,15 @@ export class PokemonForm extends PokemonSpeciesForm {
 
   getFormKey(): string {
     return this.formKey;
+  }
+
+  /**
+   * Get a list of all level moves for this species, including form specific moves.
+   * @param formKey - (Optional) The key for the form to be checked. Uses this form if not specified
+   * @returns A list of all level moves that can be learned by this species
+   */
+  public override getLevelMoves(formKey?: string): LevelMoves {
+    formKey = formKey ?? this.getFormKey();
+    return super.getLevelMoves(formKey);
   }
 }

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -1313,7 +1313,6 @@ export class PokemonForm extends PokemonSpeciesForm {
    * @returns A list of all level moves that can be learned by this species
    */
   public override getLevelMoves(formKey?: string): LevelMoves {
-    formKey = formKey ?? this.getFormKey();
-    return super.getLevelMoves(formKey);
+    return super.getLevelMoves(formKey ?? this.getFormKey());
   }
 }


### PR DESCRIPTION
## What are the changes the user will see?

Form will have correct level moves in some cases

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

noticed during a discussion in balance chat

[DIscord bug report](https://discord.com/channels/1125469663833370665/1125894949020381285/1515622152122929242)

## What are the changes from a developer perspective?

Calling `.getLevelMoves()` on a `PokemonForm` will now default to using the forms formkey instead of the base formkey

## Screenshots/Videos

Using a memory mushroom on `beauty-cosplay` pikachu

<details><summary>Before</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a3260d45-7356-4e48-9d9e-fbfa3fb94643" />

</details>
<details><summary>After</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/61eb1885-af5d-42d4-890a-c049bbd30fd1" />

</details>


## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)