### PR TITLE
github: update PR template wrt notifying devs of locales PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -104,7 +104,7 @@ you can strike it out with the `~` character to mark them as not applicable.
 Are there any localization additions or changes? If so:
 - [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
   - If so, include a link to the PR here: _____
-- [ ] I have contacted the Translation Team on Discord for proofreading/translation
+- [ ] I have contacted the Translation Team on Discord for proofreading/translation (contacting the devs in #pokerogue-dev is sufficient, we can then forward the PR to the TL team)
 
 Does this require any additions or changes to in-game assets? If so:
 - [ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Clarifying part of the PR template that was ambiguous.

## What are the changes from a developer perspective?
```diff
 Are there any localization additions or changes? If so:
 - [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
   - If so, include a link to the PR here: _____
-- [ ] I have contacted the Translation Team on Discord for proofreading/translation
+- [ ] I have contacted the Translation Team on Discord for proofreading/translation (contacting the devs in #pokerogue-dev is sufficient, we can then forward the PR to the TL team)
```

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR