### PR TITLE
feat: Arena flyout's weather status is now crossed out while weather is suppressed

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -795,7 +795,7 @@ export class BattleScene extends SceneBase {
   /**
    * Returns an array of Pokemon on both sides of the battle - player first, then enemy.
    * Does not actually check if the pokemon are on the field or not, and always has length 4 regardless of battle type.
-   * @param activeOnly - Whether to consider only active pokemon (as described by {@linkcode Pokemon.isActive()}); default `false`.
+   * @param activeOnly - Whether to consider only active pokemon (as described by {@linkcode Pokemon#isActive()}); default `false`.
    * If `true`, will also remove all `null` values from the array.
    * @returns An array of {@linkcode Pokemon}, as described above.
    *

--- a/src/data/abilities/ab-attrs.ts
+++ b/src/data/abilities/ab-attrs.ts
@@ -11,7 +11,7 @@ import { getPokeballName } from "#data/pokeball";
 import type { PokemonSpecies } from "#data/pokemon-species";
 import { getStatusEffectDescriptor, getStatusEffectHealText } from "#data/status-effect";
 import { TerrainType } from "#data/terrain";
-import type { Weather } from "#data/weather";
+import { isWeatherSuppressed, type Weather } from "#data/weather";
 import { AbilityId } from "#enums/ability-id";
 import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
@@ -3650,19 +3650,12 @@ export class BlockWeatherDamageAttr extends PreWeatherDamageAbAttr {
 }
 
 export class SuppressWeatherEffectAbAttr extends PreWeatherEffectAbAttr {
-  public readonly affectsImmutable: boolean;
-
-  constructor(affectsImmutable = false) {
+  constructor() {
     super(true);
-
-    this.affectsImmutable = affectsImmutable;
   }
 
   override canApply({ weather, cancelled }: PreWeatherEffectAbAttrParams): boolean {
-    if (!weather || cancelled.value) {
-      return false;
-    }
-    return this.affectsImmutable || weather.isImmutable();
+    return !cancelled.value && weather != null;
   }
 
   override apply({ cancelled }: PreWeatherEffectAbAttrParams): void {
@@ -6025,7 +6018,7 @@ function getPokemonWithWeatherBasedForms() {
 
 export function getWeatherCondition(...weatherTypes: WeatherType[]): AbAttrCondition {
   return () => {
-    if (globalScene.arena.weather?.isEffectSuppressed()) {
+    if (isWeatherSuppressed()) {
       return false;
     }
     return weatherTypes.includes(globalScene.arena.weatherType);

--- a/src/data/abilities/init-abilities.ts
+++ b/src/data/abilities/init-abilities.ts
@@ -277,7 +277,7 @@ export function initAbilities() {
       .ignorable()
       .build(),
     new AbBuilder(AbilityId.CLOUD_NINE, 3) //
-      .attr(SuppressWeatherEffectAbAttr, true)
+      .attr(SuppressWeatherEffectAbAttr)
       .attr(PostSummonUnnamedMessageAbAttr, i18next.t("abilityTriggers:weatherEffectDisappeared"))
       .attr(PostSummonWeatherSuppressedFormChangeAbAttr)
       .attr(PostFaintUnsuppressedWeatherFormChangeAbAttr)
@@ -588,7 +588,7 @@ export function initAbilities() {
       .ignorable()
       .build(),
     new AbBuilder(AbilityId.AIR_LOCK, 3) //
-      .attr(SuppressWeatherEffectAbAttr, true)
+      .attr(SuppressWeatherEffectAbAttr)
       .attr(PostSummonUnnamedMessageAbAttr, i18next.t("abilityTriggers:weatherEffectDisappeared"))
       .attr(PostSummonWeatherSuppressedFormChangeAbAttr)
       .attr(PostFaintUnsuppressedWeatherFormChangeAbAttr)

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -107,6 +107,7 @@ import { coerceArray } from "#utils/array";
 import { BooleanHolder, getFrameMs, toDmgValue } from "#utils/common";
 import { toCamelCase } from "#utils/strings";
 import i18next from "i18next";
+import { isWeatherSuppressed } from "./weather";
 
 /** Interface containing the serializable fields of `BattlerTag` */
 interface BaseBattlerTag {
@@ -1197,7 +1198,7 @@ export class PowderTag extends BattlerTag {
     const weather = globalScene.arena.weather;
     if (
       pokemon.getMoveType(move) !== PokemonType.FIRE
-      || (weather?.weatherType === WeatherType.HEAVY_RAIN && !weather.isEffectSuppressed()) // Since gen 7, Heavy rain takes priority over powder
+      || (weather?.weatherType === WeatherType.HEAVY_RAIN && !isWeatherSuppressed()) // Since gen 7, Heavy rain takes priority over powder
     ) {
       return true;
     }

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -3728,7 +3728,7 @@ export class WeatherInstantChargeAttr extends InstantChargeAttr {
       if (currentWeather?.weatherType == null) {
         return false;
       }
-      return !isWeatherSuppressed() && this.weatherTypes.includes(currentWeather.weatherType);
+      return this.weatherTypes.includes(currentWeather.weatherType) && !isWeatherSuppressed();
     });
 
     this.weatherTypes = weatherTypes;
@@ -5039,7 +5039,7 @@ export class MagnitudePowerAttr extends VariablePowerAttr {
 
 export class AntiSunlightPowerDecreaseAttr extends VariablePowerAttr {
   apply(_user: Pokemon, _target: Pokemon, _move: Move, args: any[]): boolean {
-    if (isWeatherSuppressed()) {
+    if (!isWeatherSuppressed()) {
       const power = args[0] as NumberHolder;
       const weatherType = globalScene.arena.weather?.weatherType || WeatherType.NONE;
       switch (weatherType) {

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -35,6 +35,7 @@ import { SpeciesFormChangeRevertWeatherFormTrigger } from "#data/form-change-tri
 import { getNonVolatileStatusEffects, getStatusEffectHealText, isNonVolatileStatusEffect } from "#data/status-effect";
 import { TerrainType } from "#data/terrain";
 import { getTypeDamageMultiplier } from "#data/type";
+import { isWeatherSuppressed } from "#data/weather";
 import { AbilityId } from "#enums/ability-id";
 import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
@@ -2727,7 +2728,7 @@ export abstract class WeatherHealAttr extends HealAttr {
 
   apply(user: Pokemon, _target: Pokemon, _move: Move, _args: any[]): boolean {
     let healRatio = 0.5;
-    if (!globalScene.arena.weather?.isEffectSuppressed()) {
+    if (!isWeatherSuppressed()) {
       const weatherType = globalScene.arena.weather?.weatherType || WeatherType.NONE;
       healRatio = this.getWeatherHealRatio(weatherType);
     }
@@ -3727,7 +3728,7 @@ export class WeatherInstantChargeAttr extends InstantChargeAttr {
       if (currentWeather?.weatherType == null) {
         return false;
       }
-      return !currentWeather.isEffectSuppressed() && this.weatherTypes.includes(currentWeather.weatherType);
+      return !isWeatherSuppressed() && this.weatherTypes.includes(currentWeather.weatherType);
     });
 
     this.weatherTypes = weatherTypes;
@@ -4354,7 +4355,7 @@ export class GrowthStatStageChangeAttr extends StatStageChangeAttr {
   }
 
   getLevels(_user: Pokemon): number {
-    if (!globalScene.arena.weather?.isEffectSuppressed()) {
+    if (!isWeatherSuppressed()) {
       const weatherType = globalScene.arena.weather?.weatherType;
       if (weatherType === WeatherType.SUNNY || weatherType === WeatherType.HARSH_SUN) {
         return this.stages + 1;
@@ -5038,7 +5039,7 @@ export class MagnitudePowerAttr extends VariablePowerAttr {
 
 export class AntiSunlightPowerDecreaseAttr extends VariablePowerAttr {
   apply(_user: Pokemon, _target: Pokemon, _move: Move, args: any[]): boolean {
-    if (!globalScene.arena.weather?.isEffectSuppressed()) {
+    if (isWeatherSuppressed()) {
       const power = args[0] as NumberHolder;
       const weatherType = globalScene.arena.weather?.weatherType || WeatherType.NONE;
       switch (weatherType) {
@@ -5556,7 +5557,7 @@ export class VariableAccuracyAttr extends MoveAttr {
  */
 export class ThunderAccuracyAttr extends VariableAccuracyAttr {
   apply(_user: Pokemon, _target: Pokemon, _move: Move, args: any[]): boolean {
-    if (!globalScene.arena.weather?.isEffectSuppressed()) {
+    if (!isWeatherSuppressed()) {
       const accuracy = args[0] as NumberHolder;
       const weatherType = globalScene.arena.weather?.weatherType || WeatherType.NONE;
       switch (weatherType) {
@@ -5582,7 +5583,7 @@ export class ThunderAccuracyAttr extends VariableAccuracyAttr {
  */
 export class StormAccuracyAttr extends VariableAccuracyAttr {
   apply(_user: Pokemon, _target: Pokemon, _move: Move, args: any[]): boolean {
-    if (!globalScene.arena.weather?.isEffectSuppressed()) {
+    if (!isWeatherSuppressed()) {
       const accuracy = args[0] as NumberHolder;
       const weatherType = globalScene.arena.weather?.weatherType || WeatherType.NONE;
       switch (weatherType) {
@@ -5636,7 +5637,7 @@ export class ToxicAccuracyAttr extends VariableAccuracyAttr {
 
 export class BlizzardAccuracyAttr extends VariableAccuracyAttr {
   apply(_user: Pokemon, _target: Pokemon, _move: Move, args: any[]): boolean {
-    if (!globalScene.arena.weather?.isEffectSuppressed()) {
+    if (!isWeatherSuppressed()) {
       const accuracy = args[0] as NumberHolder;
       const weatherType = globalScene.arena.weather?.weatherType || WeatherType.NONE;
       if (weatherType === WeatherType.HAIL || weatherType === WeatherType.SNOW) {
@@ -5994,7 +5995,7 @@ export class WeatherBallTypeAttr extends VariableMoveTypeAttr {
       return false;
     }
 
-    if (!globalScene.arena.weather?.isEffectSuppressed()) {
+    if (!isWeatherSuppressed()) {
       switch (globalScene.arena.weather?.weatherType) {
         case WeatherType.SUNNY:
         case WeatherType.HARSH_SUN:
@@ -10491,7 +10492,7 @@ export function initMoves() {
           WeatherType.HEAVY_RAIN,
           WeatherType.HARSH_SUN,
         ];
-        if (weatherTypes.includes(weather.weatherType) && !weather.isEffectSuppressed()) {
+        if (weatherTypes.includes(weather.weatherType) && !isWeatherSuppressed()) {
           return 2;
         }
         return 1;
@@ -11807,11 +11808,11 @@ export function initMoves() {
       .target(MoveTarget.ALL_NEAR_OTHERS),
     new StatusMove(MoveId.AURORA_VEIL, PokemonType.ICE, -1, 20, -1, 0, 7)
       .condition(() => {
-        const weather = globalScene.arena.weather;
-        if (weather == null || weather.isEffectSuppressed()) {
+        const weatherType = globalScene.arena.weather?.weatherType;
+        if (weatherType == null || isWeatherSuppressed()) {
           return false;
         }
-        return weather.weatherType === WeatherType.HAIL || weather.weatherType === WeatherType.SNOW;
+        return weatherType === WeatherType.HAIL || weatherType === WeatherType.SNOW;
       }, 3)
       .attr(AddArenaTagAttr, ArenaTagType.AURORA_VEIL, 5, true)
       .target(MoveTarget.USER_SIDE),

--- a/src/data/pokemon-forms/form-change-triggers.ts
+++ b/src/data/pokemon-forms/form-change-triggers.ts
@@ -1,6 +1,7 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import type { SpeciesFormChange } from "#data/pokemon-forms";
+import { isWeatherSuppressed } from "#data/weather";
 import { AbilityId } from "#enums/ability-id";
 import { Challenges } from "#enums/challenges";
 import { FormChangeItem } from "#enums/form-change-item";
@@ -259,12 +260,11 @@ export class SpeciesFormChangeWeatherTrigger extends SpeciesFormChangeTrigger {
    */
   canChange(pokemon: Pokemon): boolean {
     const currentWeather = globalScene.arena.weather?.weatherType ?? WeatherType.NONE;
-    const isWeatherSuppressed = globalScene.arena.weather?.isEffectSuppressed();
     const isAbilitySuppressed = pokemon.summonData.abilitySuppressed;
 
     return (
       !isAbilitySuppressed
-      && !isWeatherSuppressed
+      && !isWeatherSuppressed()
       && pokemon.hasAbility(this.ability)
       && this.weathers.includes(currentWeather)
     );
@@ -298,12 +298,11 @@ export class SpeciesFormChangeRevertWeatherFormTrigger extends SpeciesFormChange
   canChange(pokemon: Pokemon): boolean {
     if (pokemon.hasAbility(this.ability, false, true)) {
       const currentWeather = globalScene.arena.weather?.weatherType ?? WeatherType.NONE;
-      const isWeatherSuppressed = globalScene.arena.weather?.isEffectSuppressed();
       const isAbilitySuppressed = pokemon.summonData.abilitySuppressed;
       const summonDataAbility = pokemon.summonData.ability;
       const isAbilityChanged = summonDataAbility !== this.ability && summonDataAbility !== AbilityId.NONE;
 
-      if (this.weathers.includes(currentWeather) || isWeatherSuppressed || isAbilitySuppressed || isAbilityChanged) {
+      if (this.weathers.includes(currentWeather) || isWeatherSuppressed() || isAbilitySuppressed || isAbilityChanged) {
         return true;
       }
     }

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -1,4 +1,3 @@
-import type { SuppressWeatherEffectAbAttr } from "#abilities/ab-attrs";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { PokemonType } from "#enums/pokemon-type";
@@ -13,12 +12,11 @@ export interface SerializedWeather {
 }
 
 export class Weather {
-  // TODO: Exclude `WeatherType.NONE` from this (which indicates a lack of weather)
-  public weatherType: WeatherType;
+  public weatherType: Exclude<WeatherType, WeatherType.NONE>;
   public turnsLeft: number;
   public maxDuration: number;
 
-  constructor(weatherType: WeatherType, turnsLeft = 0, maxDuration: number = turnsLeft) {
+  constructor(weatherType: Exclude<WeatherType, WeatherType.NONE>, turnsLeft = 0, maxDuration: number = turnsLeft) {
     this.weatherType = weatherType;
     this.turnsLeft = this.isImmutable() ? 0 : turnsLeft;
     this.maxDuration = this.isImmutable() ? 0 : maxDuration;
@@ -109,31 +107,11 @@ export class Weather {
 
     return false;
   }
-
-  isEffectSuppressed(): boolean {
-    const field = globalScene.getField(true);
-
-    for (const pokemon of field) {
-      let suppressWeatherEffectAbAttr: SuppressWeatherEffectAbAttr | null = pokemon
-        .getAbility()
-        .getAttrs("SuppressWeatherEffectAbAttr")[0];
-      if (!suppressWeatherEffectAbAttr) {
-        suppressWeatherEffectAbAttr = pokemon.hasPassive()
-          ? pokemon.getPassiveAbility().getAttrs("SuppressWeatherEffectAbAttr")[0]
-          : null;
-      }
-      if (suppressWeatherEffectAbAttr && (!this.isImmutable() || suppressWeatherEffectAbAttr.affectsImmutable)) {
-        return true;
-      }
-    }
-
-    return false;
-  }
 }
 
 // TODO: These functions should not be able to accept `WeatherType.NONE`
 // and should have `null` removed from the signature
-export function getWeatherStartMessage(weatherType: WeatherType): string | null {
+export function getWeatherStartMessage(weatherType: Exclude<WeatherType, WeatherType.NONE>): string {
   switch (weatherType) {
     case WeatherType.SUNNY:
       return i18next.t("weather:sunnyStartMessage");
@@ -154,11 +132,9 @@ export function getWeatherStartMessage(weatherType: WeatherType): string | null 
     case WeatherType.STRONG_WINDS:
       return i18next.t("weather:strongWindsStartMessage");
   }
-
-  return null;
 }
 
-export function getWeatherLapseMessage(weatherType: WeatherType): string | null {
+export function getWeatherLapseMessage(weatherType: Exclude<WeatherType, WeatherType.NONE>): string {
   switch (weatherType) {
     case WeatherType.SUNNY:
       return i18next.t("weather:sunnyLapseMessage");
@@ -179,8 +155,6 @@ export function getWeatherLapseMessage(weatherType: WeatherType): string | null 
     case WeatherType.STRONG_WINDS:
       return i18next.t("weather:strongWindsLapseMessage");
   }
-
-  return null;
 }
 
 export function getWeatherDamageMessage(weatherType: WeatherType, pokemon: Pokemon): string | null {
@@ -198,7 +172,7 @@ export function getWeatherDamageMessage(weatherType: WeatherType, pokemon: Pokem
   return null;
 }
 
-export function getWeatherClearMessage(weatherType: WeatherType): string | null {
+export function getWeatherClearMessage(weatherType: Exclude<WeatherType, WeatherType.NONE>): string {
   switch (weatherType) {
     case WeatherType.SUNNY:
       return i18next.t("weather:sunnyClearMessage");
@@ -219,8 +193,6 @@ export function getWeatherClearMessage(weatherType: WeatherType): string | null 
     case WeatherType.STRONG_WINDS:
       return i18next.t("weather:strongWindsClearMessage");
   }
-
-  return null;
 }
 
 export function getLegendaryWeatherContinuesMessage(weatherType: WeatherType): string | null {
@@ -243,4 +215,22 @@ export function getWeatherBlockMessage(weatherType: WeatherType): string {
       return i18next.t("weather:heavyRainEffectMessage");
   }
   return i18next.t("weather:defaultEffectMessage");
+}
+
+/**
+ * Determine whether any effects that suppress weather are active;
+ * does not check if there is actually any weather currently active.
+ *
+ * @remarks
+ * Currently, the only source of weather suppression are the abilities Cloud Nine and Air Lock.
+ *
+ * @returns Whether there is any active effect suppressing weather.
+ */
+export function isWeatherSuppressed(): boolean {
+  for (const pokemon of globalScene.getField(true)) {
+    if (pokemon.hasAbilityWithAttr("SuppressWeatherEffectAbAttr")) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -17,6 +17,7 @@ import {
   getLegendaryWeatherContinuesMessage,
   getWeatherClearMessage,
   getWeatherStartMessage,
+  isWeatherSuppressed,
   Weather,
 } from "#data/weather";
 import { AbilityId } from "#enums/ability-id";
@@ -247,10 +248,15 @@ export class Arena {
 
   /**
    * Sets weather to the override specified in `overrides.ts`
+   *
+   * @remarks
+   * Before any call to this method, ensure that `activeOverrides.WEATHER_OVERRIDE` is not set to `WeatherType.NONE`
    */
   // TODO: make this apply at the start of a new biome like the terrain one - this would be a lot more useful for tests
   private overrideWeather(): void {
-    const weather = activeOverrides.WEATHER_OVERRIDE;
+    // the `as` cast is OK here, as the method is only called if `activeOverrides.WEATHER_OVERRIDE` is truthy, and
+    const weather = activeOverrides.WEATHER_OVERRIDE as Exclude<WeatherType, WeatherType.NONE>;
+
     this.weather = new Weather(weather, 0);
 
     this.eventTarget.dispatchEvent(new WeatherChangedEvent(weather, 0));
@@ -300,20 +306,21 @@ export class Arena {
     if (weather === WeatherType.NONE) {
       this.weather = null;
       this.eventTarget.dispatchEvent(new WeatherChangedEvent(WeatherType.NONE));
-      globalScene.phaseManager.queueMessage(getWeatherClearMessage(oldWeatherType)!); // TODO: is this bang correct?
+      // Cast is OK; `oldWEatherType` cannot be `WeatherType.NONE` here as `canSetWeather` would have returned false if it were
+      globalScene.phaseManager.queueMessage(
+        getWeatherClearMessage(oldWeatherType as Exclude<WeatherType, WeatherType.NONE>),
+      );
     } else {
       this.weather = new Weather(weather, weatherDuration.value, weatherDuration.value);
       this.eventTarget.dispatchEvent(new WeatherChangedEvent(weather, weatherDuration.value));
 
       globalScene.phaseManager.unshiftNew("CommonAnimPhase", undefined, undefined, CommonAnim.SUNNY + (weather - 1));
-      globalScene.phaseManager.queueMessage(getWeatherStartMessage(weather)!); // TODO: is this bang correct?
+      globalScene.phaseManager.queueMessage(getWeatherStartMessage(weather));
     }
 
     for (const pokemon of inSpeedOrder(ArenaTagSide.BOTH)) {
       // TODO: Specify the type of tags which are being removed here
-      pokemon.findAndRemoveTags(
-        tag => "weatherTypes" in tag && !(tag.weatherTypes as WeatherType[]).find(w => w === weather),
-      );
+      pokemon.findAndRemoveTags(tag => "weatherTypes" in tag && !(tag.weatherTypes as WeatherType[]).includes(weather));
       applyAbAttrs("PostWeatherChangeAbAttr", { pokemon, weather });
     }
 
@@ -321,7 +328,7 @@ export class Arena {
   }
 
   public isMoveWeatherCancelled(user: Pokemon, move: Move): boolean {
-    return !!this.weather && !this.weather.isEffectSuppressed() && this.weather.isMoveWeatherCancelled(user, move);
+    return !!this.weather && !isWeatherSuppressed() && this.weather.isMoveWeatherCancelled(user, move);
   }
 
   /**
@@ -363,7 +370,7 @@ export class Arena {
    * @returns The weather damage multiplier
    */
   public getWeatherDamageMultiplier(attackType: PokemonType): number {
-    if (this.weather && !this.weather.isEffectSuppressed()) {
+    if (this.weather && !isWeatherSuppressed()) {
       return this.weather.getAttackTypeMultiplier(attackType);
     }
     return 1;

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -254,7 +254,8 @@ export class Arena {
    */
   // TODO: make this apply at the start of a new biome like the terrain one - this would be a lot more useful for tests
   private overrideWeather(): void {
-    // the `as` cast is OK here, as the method is only called if `activeOverrides.WEATHER_OVERRIDE` is truthy, and
+    // the `as` cast is OK here, as the method is only called if `activeOverrides.WEATHER_OVERRIDE` is truthy
+    // and WeatherType.NONE is nonzero.
     const weather = activeOverrides.WEATHER_OVERRIDE as Exclude<WeatherType, WeatherType.NONE>;
 
     this.weather = new Weather(weather, 0);

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2289,10 +2289,13 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @returns Whether this Pokemon has an ability with the given {@linkcode AbAttr}.
    */
   public hasAbilityWithAttr(attrType: AbAttrString, canApply = true, ignoreOverride = false): boolean {
-    if ((!canApply || this.canApplyAbility()) && this.getAbility(ignoreOverride).hasAttr(attrType)) {
+    // n.b. Check if the ability has attribute *first*. This prevents recursion issues for some functions,
+    // like `isWeatherSuppressed`, that invoke this method, while the `canApplyAbility` check has some
+    // abilities that in turn call `isWeatherSuppressed` as part of their conditions.
+    if (this.getAbility(ignoreOverride).hasAttr(attrType) && (!canApply || this.canApplyAbility())) {
       return true;
     }
-    return this.hasPassive() && (!canApply || this.canApplyAbility(true)) && this.getPassiveAbility().hasAttr(attrType);
+    return this.hasPassive() && this.getPassiveAbility().hasAttr(attrType) && (!canApply || this.canApplyAbility(true));
   }
 
   /**

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -65,6 +65,7 @@ import { getRandomStatus, getStatusEffectHealText, getStatusEffectOverlapText, S
 import { getTerrainBlockMessage, TerrainType } from "#data/terrain";
 import type { TypeDamageMultiplier } from "#data/type";
 import { getTypeDamageMultiplier, getTypeRgb } from "#data/type";
+import { isWeatherSuppressed } from "#data/weather";
 import { AbilityId } from "#enums/ability-id";
 import { AiType } from "#enums/ai-type";
 import { ArenaTagSide } from "#enums/arena-tag-side";
@@ -2597,7 +2598,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     if (
       !ignoreStrongWinds
       && arena.weatherType === WeatherType.STRONG_WINDS
-      && !arena.weather?.isEffectSuppressed()
+      && !isWeatherSuppressed()
       && this.isOfType(PokemonType.FLYING)
       && getTypeDamageMultiplier(moveType, PokemonType.FLYING) === 2
     ) {

--- a/src/ui/containers/arena-flyout.ts
+++ b/src/ui/containers/arena-flyout.ts
@@ -1,7 +1,7 @@
 import { globalScene } from "#app/global-scene";
 import type { ArenaTag } from "#data/arena-tag";
 import { type Terrain, TerrainType } from "#data/terrain";
-import type { Weather } from "#data/weather";
+import { isWeatherSuppressed, type Weather } from "#data/weather";
 import { ArenaEventType } from "#enums/arena-event-type";
 import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
@@ -9,12 +9,13 @@ import { TextStyle } from "#enums/text-style";
 import { WeatherType } from "#enums/weather-type";
 import type { ArenaTagAddedEvent, ArenaTagRemovedEvent, TerrainChangedEvent, WeatherChangedEvent } from "#events/arena";
 import { BattleSceneEventType } from "#events/battle-scene";
-import { addTextObject } from "#ui/text";
+import { addBBCodeTextObject, addTextObject } from "#ui/text";
 import { TimeOfDayWidget } from "#ui/time-of-day-widget";
 import { addWindow, WindowVariant } from "#ui/ui-theme";
 import { fixedInt } from "#utils/common";
 import { toCamelCase } from "#utils/strings";
 import i18next from "i18next";
+import type BBCodeText from "phaser3-rex-plugins/plugins/gameobjects/tagtext/bbcodetext/BBCodeText";
 
 // #region Interfaces
 
@@ -28,6 +29,8 @@ interface WeatherInfo {
   duration: number;
   /** The current {@linkcode WeatherType}. */
   readonly weatherType: WeatherType;
+  /** Whether the weather is currently suppressed. */
+  suppressed?: boolean;
 }
 
 /** Base container for info about the currently active {@linkcode Terrain}. */
@@ -58,6 +61,8 @@ interface ArenaTagInfo {
   duration: number;
   /** The tag's {@linkcode ArenaTagType}. */
   readonly tagType: ArenaTagType;
+  /** Whether the tag is currently suppressed. */
+  suppressed?: boolean;
 }
 
 // #endregion Interfaces
@@ -106,7 +111,7 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
   /** The {@linkcode Phaser.GameObjects.Text} used to indicate the enemy's effects */
   private readonly flyoutTextEnemy: Phaser.GameObjects.Text;
   /** The {@linkcode Phaser.GameObjects.Text} used to indicate field effects */
-  private readonly flyoutTextField: Phaser.GameObjects.Text;
+  private readonly flyoutTextField: BBCodeText;
 
   /** Holds info about the current active {@linkcode Weather}, if any are active. */
   private weatherInfo?: WeatherInfo | undefined;
@@ -159,7 +164,9 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
     this.flyoutTextHeaderPlayer = addTextObject(6, 5, i18next.t("arenaFlyout:player"), TextStyle.SUMMARY_BLUE)
       .setFontSize(54)
       .setAlign("left")
-      .setOrigin(0, 0);
+      .setOrigin(1, 0);
+
+    this.flyoutContainer.add(this.flyoutTextHeaderPlayer);
 
     this.flyoutTextHeaderField = addTextObject(
       FLYOUT_WIDTH / 2,
@@ -187,11 +194,12 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
       .setAlign("left")
       .setOrigin(0, 0);
 
-    this.flyoutTextField = addTextObject(FLYOUT_WIDTH / 2, 13, "", TextStyle.BATTLE_INFO)
+    this.flyoutTextField = addBBCodeTextObject(FLYOUT_WIDTH / 2, 13, "", TextStyle.BATTLE_INFO)
       .setLineSpacing(-1)
       .setFontSize(48)
       .setAlign("center")
       .setOrigin(0.5, 0);
+    // .setStrikethrough(getTextColor(TextStyle.BATTLE_INFO), 5, 10);
 
     this.flyoutTextEnemy = addTextObject(FLYOUT_WIDTH - 6, 13, "", TextStyle.BATTLE_INFO)
       .setLineSpacing(-1)
@@ -229,12 +237,13 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
 
     eventTarget.addEventListener(ArenaEventType.WEATHER_CHANGED, this.#onWeatherChanged);
     eventTarget.addEventListener(ArenaEventType.TERRAIN_CHANGED, this.#onTerrainChanged);
+
     eventTarget.addEventListener(ArenaEventType.ARENA_TAG_ADDED, this.#onArenaTagAdded);
     eventTarget.addEventListener(ArenaEventType.ARENA_TAG_REMOVED, this.#onArenaTagRemoved);
   };
 
   /**
-   * Iterate through all currently present tags effects and decrement their durations, removing all tags expiring in this manner..
+   * Iterate through all currently present tags effects and decrement their durations, removing all tags expiring in this manner.
    */
   readonly #onTurnEnd = (): void => {
     this.arenaTags = this.arenaTags.filter(info => info.maxDuration === 0 || --info.duration >= 0);
@@ -340,6 +349,7 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
       maxDuration: event.maxDuration,
       duration: event.duration,
       weatherType: event.weatherType,
+      suppressed: isWeatherSuppressed(),
     };
 
     this.updateFieldText();
@@ -385,6 +395,7 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
     this.clearText();
 
     if (this.weatherInfo) {
+      this.weatherInfo.suppressed = isWeatherSuppressed();
       this.flyoutTextField.text += this.getTagText(this.weatherInfo);
     }
     if (this.terrainInfo) {
@@ -410,6 +421,10 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
     }
 
     text += "\n";
+    // Cast is OK here as the info types that don't have a `suppressed` property will simply have it as `undefined`
+    if ((info as WeatherInfo).suppressed) {
+      text = "[s]" + text + "[/s]";
+    }
     return text;
   }
 
@@ -418,7 +433,7 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
    * @param side - The {@linkcode ArenaTagSide} of the tag being updated
    * @returns The {@linkcode Phaser.GameObjects.Text} to be updated.
    */
-  private getArenaTagTargetObj(side: ArenaTagSide): Phaser.GameObjects.Text {
+  private getArenaTagTargetObj(side: ArenaTagSide): Phaser.GameObjects.Text | BBCodeText {
     switch (side) {
       case ArenaTagSide.PLAYER:
         return this.flyoutTextPlayer;

--- a/src/ui/containers/arena-flyout.ts
+++ b/src/ui/containers/arena-flyout.ts
@@ -9,7 +9,7 @@ import { TextStyle } from "#enums/text-style";
 import { WeatherType } from "#enums/weather-type";
 import type { ArenaTagAddedEvent, ArenaTagRemovedEvent, TerrainChangedEvent, WeatherChangedEvent } from "#events/arena";
 import { BattleSceneEventType } from "#events/battle-scene";
-import { addBBCodeTextObject, addTextObject } from "#ui/text";
+import { addBBCodeTextObject, addTextObject, getTextColor } from "#ui/text";
 import { TimeOfDayWidget } from "#ui/time-of-day-widget";
 import { addWindow, WindowVariant } from "#ui/ui-theme";
 import { fixedInt } from "#utils/common";
@@ -162,9 +162,7 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
     this.flyoutTextHeaderPlayer = addTextObject(6, 5, i18next.t("arenaFlyout:player"), TextStyle.SUMMARY_BLUE)
       .setFontSize(54)
       .setAlign("left")
-      .setOrigin(1, 0);
-
-    this.flyoutContainer.add(this.flyoutTextHeaderPlayer);
+      .setOrigin(0);
 
     this.flyoutTextHeaderField = addTextObject(
       FLYOUT_WIDTH / 2,
@@ -190,14 +188,14 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
       .setLineSpacing(-1)
       .setFontSize(48)
       .setAlign("left")
-      .setOrigin(0, 0);
+      .setOrigin(0);
 
     this.flyoutTextField = addBBCodeTextObject(FLYOUT_WIDTH / 2, 13, "", TextStyle.BATTLE_INFO)
       .setLineSpacing(-1)
       .setFontSize(48)
       .setAlign("center")
-      .setOrigin(0.5, 0);
-    // .setStrikethrough(getTextColor(TextStyle.BATTLE_INFO), 5, 10);
+      .setOrigin(0.5, 0)
+      .setStrikethrough(getTextColor(TextStyle.BATTLE_INFO), 4, -10);
 
     this.flyoutTextEnemy = addTextObject(FLYOUT_WIDTH - 6, 13, "", TextStyle.BATTLE_INFO)
       .setLineSpacing(-1)

--- a/src/ui/containers/arena-flyout.ts
+++ b/src/ui/containers/arena-flyout.ts
@@ -61,8 +61,6 @@ interface ArenaTagInfo {
   duration: number;
   /** The tag's {@linkcode ArenaTagType}. */
   readonly tagType: ArenaTagType;
-  /** Whether the tag is currently suppressed. */
-  suppressed?: boolean;
 }
 
 // #endregion Interfaces

--- a/src/ui/text.ts
+++ b/src/ui/text.ts
@@ -51,7 +51,7 @@ export function addBBCodeTextObject(
   y: number,
   content: string,
   style: TextStyle,
-  extraStyleOptions?: Phaser.Types.GameObjects.Text.TextStyle,
+  extraStyleOptions?: BBCodeText.TextStyle,
 ): BBCodeText {
   const { scale, styleOptions, shadowColor, shadowXpos, shadowYpos } = getTextStyleOptions(style, extraStyleOptions);
 
@@ -83,7 +83,7 @@ export function addTextInputObject(
 
 export function getTextStyleOptions(
   style: TextStyle,
-  extraStyleOptions?: Phaser.Types.GameObjects.Text.TextStyle,
+  extraStyleOptions?: Phaser.Types.GameObjects.Text.TextStyle | BBCodeText.TextStyle,
 ): TextStyleOptions {
   const lang = i18next.resolvedLanguage;
   let shadowXpos = 4;

--- a/test/mocks/mocks-container/mock-bbcode-text.ts
+++ b/test/mocks/mocks-container/mock-bbcode-text.ts
@@ -1,6 +1,28 @@
 import { MockText } from "#test/mocks/mocks-container/mock-text";
+import type BBCodeText from "phaser3-rex-plugins/plugins/gameobjects/tagtext/bbcodetext/BBCodeText";
 
 export class MockBBCodeText extends MockText {
-  setMaxLines(_lines: number) {}
-  setWrapMode(_mode: 0 | 1 | 2 | 3 | "none" | "word" | "char" | "character" | "mix") {}
+  setMaxLines(..._: Parameters<BBCodeText["setMaxLines"]>): this {
+    return this;
+  }
+
+  setWrapMode(_mode: 0 | 1 | 2 | 3 | "none" | "word" | "char" | "character" | "mix"): this {
+    return this;
+  }
+
+  setStrikethrough(..._args: Parameters<BBCodeText["setStrikethrough"]>): this {
+    return this;
+  }
+
+  setStrikethroughColor(..._args: Parameters<BBCodeText["setStrikethroughColor"]>): this {
+    return this;
+  }
+
+  setStrikethroughThinkness(..._args: Parameters<BBCodeText["setStrikethroughThinkness"]>): this {
+    return this;
+  }
+
+  setStrikethroughOffset(..._args: Parameters<BBCodeText["setStrikethroughOffset"]>): this {
+    return this;
+  }
 }


### PR DESCRIPTION
## What are the changes the user will see?
The arena flyout's weather status will now be crossed out while there is an active weather suppression effect: a mon with cloud nine or air lock on the field. Note that the strikethrough will only update at turn end or when the weather changes, not when a mon with air lock/cloud nine enters/leaves the field.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

Resolves #7363 

## What are the changes from a developer perspective?

In `arena-flyout.ts`
- Converted `flyoutTextField` into a `BBCodeText` object instead of a raw text, to allow for strikethrough.
- Augmented the `updateFieldText` method to set a new `suppressed` property on the weather info, based on the `isWeatherSuppressed`

In `weather.ts`
- Replaced the class method `isEffectSuppressed` with a standalone function, `isWeatherSuppressed`.
The only reason this was a class method was to check whether the weather itself was marked as immutable. The immutable flag was being checked based on whether the suppression effect was listed as applying to immutable weather. Both abilities —cloud nine and air lock— applied to immutable weather. Now, the method merely checks if there is an active pokemon that has an ability with the `SuppressWeatherEffectAbAttr` that can be applied.

- Addressed a TODO comment wanting to remove `WeatherType.NONE` from the set of types that the `Weather` class's weather could be.
- Addressed a TODO comment wanting to remove `null` as a possible return type from several of the `getWeatherXMessage` functions by changing their weather parameter to be `Exclude<WeatherType, WeatherType.NONE>`. Also updated a few callsites to respect this new type.

Misc:
- Removed the `affectsImmutable` flag from `SuppressWeatherEffectAbAttr`
- Replaced all invocations of `globalScene.arena.weather.isEffectSuppressed` with calls to `isWeatherSuppressed`.

## Screenshots/Videos
<!--
If you are changing anything visual (UI/UX, locales changes, etc.), please include screenshot(s) and/or video(s) showing the changes within collapsible blocks, like below:

<details><summary>Weather Effect</summary>

https://github.com/user-attachments/assets/e9be4363-00d1-42fd-a0c4-32362b91d1fb

</details>


## How to test the changes?

I used
```ts
const overrides = {
  ABILITY_OVERRIDE: AbilityId.DRIZZLE,
  ENEMY_ABILITY_OVERRIDE: AbilityId.CLOUD_NINE,
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [x] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)
