### PR TITLE
feat(battle): Increase daily boss level to `75`

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1,5 +1,6 @@
 import type { GameMode } from "#app/game-mode";
 import { globalScene } from "#app/global-scene";
+import { isDailyFinalBoss } from "#data/daily-seed/daily-seed-utils";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { BattleType } from "#enums/battle-type";
 import { BattlerIndex } from "#enums/battler-index";
@@ -35,6 +36,7 @@ import {
 import { getEnumValues } from "#utils/enums";
 import { randSeedUniqueItem } from "#utils/random";
 import i18next from "i18next";
+import { DAILY_BOSS_LEVEL } from "./constants";
 
 export interface TurnCommand {
   command: Command;
@@ -127,6 +129,9 @@ export class Battle {
   }
 
   public getLevelForWave(): number {
+    if (isDailyFinalBoss(this.waveIndex)) {
+      return DAILY_BOSS_LEVEL;
+    }
     const levelWaveIndex = this.gameMode.getWaveForDifficulty(this.waveIndex);
     const baseLevel = 1 + levelWaveIndex / 2 + Math.pow(levelWaveIndex / 25, 2);
     const bossMultiplier = 1.2;

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1,3 +1,4 @@
+import { DAILY_BOSS_LEVEL } from "#app/constants";
 import type { GameMode } from "#app/game-mode";
 import { globalScene } from "#app/global-scene";
 import { isDailyFinalBoss } from "#data/daily-seed/daily-seed-utils";
@@ -36,7 +37,6 @@ import {
 import { getEnumValues } from "#utils/enums";
 import { randSeedUniqueItem } from "#utils/random";
 import i18next from "i18next";
-import { DAILY_BOSS_LEVEL } from "./constants";
 
 export interface TurnCommand {
   command: Command;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -118,3 +118,6 @@ export const RELEARN_MOVE = -1;
 
 /** Moves that can only be learned with an evolve */
 export const EVOLVE_MOVE = 0;
+
+/** Level of the daily boss */
+export const DAILY_BOSS_LEVEL = 75;

--- a/src/data/daily-seed/daily-seed-utils.ts
+++ b/src/data/daily-seed/daily-seed-utils.ts
@@ -80,8 +80,13 @@ export function getSerializedDailyRunConfig(): SerializedDailyRunConfig | undefi
   } satisfies SerializedDailyRunConfig;
 }
 
-export function isDailyFinalBoss() {
-  return globalScene.gameMode.isDaily && globalScene.gameMode.isWaveFinal(globalScene.currentBattle.waveIndex);
+/**
+ * Checks if the current wave is the final boss of a daily run.
+ * @param wave - (Default: current battle's wave index) The wave to check
+ * @returns Whether the given wave is the final boss of a daily run.
+ */
+export function isDailyFinalBoss(wave = globalScene.currentBattle?.waveIndex): boolean {
+  return globalScene.gameMode.isDaily && globalScene.gameMode.isWaveFinal(wave);
 }
 
 /**


### PR DESCRIPTION
## What are the changes the user will see?

Daily bosses will be level 75 instead of 70

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

Damo wanted it for natdex

## What are the changes from a developer perspective?

added a constant for the level and a check if it's the daily boss in `getLevelForWave()`

## Screenshots/Videos

<details><summary>After</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3e702a32-b9ad-4c3c-9abd-be38e2805fd6" />

</details>


## How to test the changes?

```ts
const overrides = {
  STARTING_LEVEL_OVERRIDE: 999,
  STARTING_WAVE_OVERRIDE: 49,
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)