### PR TITLE
chore: update pnpm to `11.26.0` from `10.34.5`

### DIFF
--- a/.github/actions/install-pnpm/action.yml
+++ b/.github/actions/install-pnpm/action.yml
@@ -1,0 +1,13 @@
+name: "Setup pnpm and Node.js"
+description: "Sets up pnpm and Node.js environment for workflows. Does not install dependencies."
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install pnpm and Node.js
+      uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # 2.1.0
+      with:
+        version: 11
+        runtime: node@24.9
+        install: false
+        cache: true

--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -1,17 +1,15 @@
-name: "Setup pnpm and Node.js"
-description: "Setup pnpm and Node.js environment for workflows. Requires the repo to be cloned to at least have .nvmrc and package.json"
+name: "Setup pnpm and Node.js, and install dependencies"
+description: |
+  Sets up pnpm and Node.js environment for workflows and installs dependencies.
+  Requires the repo to be cloned to at least have `pnpm-lock.yaml` and `package.json`
+
 runs:
   using: "composite"
   steps:
-    - name: Install pnpm
-      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-    - name: Set up Node.js
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+    - name: Install pnpm, Node.js and dependencies
+      uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # 2.1.0
       with:
-        node-version-file: ".nvmrc"
-        cache: "pnpm"
-
-    - name: Install dependencies
-      run: pnpm i
-      shell: bash
+        runtime: node@24.9
+        install: true
+        require-lockfile: true
+        cache: true

--- a/.github/workflows/create-changelog.yml
+++ b/.github/workflows/create-changelog.yml
@@ -14,23 +14,13 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           sparse-checkout: |
-            .nvmrc
             pnpm-lock.yaml
             .github/scripts/changelog-reader
           sparse-checkout-cone-mode: false
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: 11
+      - uses: $/.github/actions/install-pnpm
 
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
-
-      - name: Install Node.js dependencies
+      - name: Install dependencies
         run: pnpm add chalk octokit
 
       - name: Generate Changelog

--- a/.github/workflows/create-changelog.yml
+++ b/.github/workflows/create-changelog.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 10
+          version: 11
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 10
+          version: 11
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -86,15 +86,14 @@ jobs:
             images/logo.png
           sparse-checkout-cone-mode: true
           
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - name: Install pnpm and Node.js
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # 2.1.0
         with:
-          version: 11
-
-      - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: "pokerogue_docs/.nvmrc"
+          runtime: node@24.9
+          install: true
+          require-lockfile: true
+          cache: true
+          working-directory: ${{ env.docs-dir }}
 
       - name: Checkout repository for Github Pages
         if: github.event_name == 'push'
@@ -102,10 +101,6 @@ jobs:
         with:
           path: pokerogue_gh
           ref: gh-pages
-
-      - name: Install Node.js dependencies
-        working-directory: ${{ env.docs-dir }}
-        run: pnpm i
 
       - name: Generate Typedoc docs
         working-directory: ${{ env.docs-dir }}
@@ -116,7 +111,7 @@ jobs:
 
       - name: Commit & Push docs
         # env vars are stored as strings instead of booleans (hence why an explicit check is required)
-        if: ${{ env.DRY_RUN == 'false'}}
+        if: ${{ env.DRY_RUN == 'false' }}
         run: |
           cd pokerogue_gh
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 10
+          version: 11
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -26,22 +26,12 @@ jobs:
           submodules: false
           sparse-checkout: |
             pnpm-lock.yaml
-            .nvmrc
             .github/scripts/apply-labels.mts
           sparse-checkout-cone-mode: false
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: 11
+      - uses: $/.github/actions/install-pnpm
 
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
-
-      - name: Install Node.js dependencies
+      - name: Install dependencies
         run: pnpm add @actions/core @actions/github
 
       - name: Apply Labels

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 10
+          version: 11
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -25,22 +25,12 @@ jobs:
           submodules: false
           sparse-checkout: |
             pnpm-lock.yaml
-            .nvmrc
             .github/scripts/pr-title.mts
           sparse-checkout-cone-mode: false
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: 11
+      - uses: $/.github/actions/install-pnpm
 
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
-
-      - name: Install Node.js dependencies
+      - name: Install dependencies
         run: pnpm add @actions/core @actions/github
 
       - name: Lint PR title

--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -23,23 +23,13 @@ jobs:
           submodules: false
           sparse-checkout: |
             pnpm-lock.yaml
-            .nvmrc
             .github/scripts/update-submodule/download-artifact.mts
             .github/scripts/update-submodule/read-label-data.mts
           sparse-checkout-cone-mode: false
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: 11
+      - uses: $/.github/actions/install-pnpm
 
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
-
-      - name: Install Node.js dependencies
+      - name: Install dependencies
         run: pnpm add @actions/core @actions/github
 
       - name: Download artifact

--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 10
+          version: 11
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ For those who prefer Docker containers, see [this instructions page](./docs/podm
 
 #### Prerequisites
 
-- node: >=24.9.0 - [manage with pnpm](https://pnpm.io/cli/env) | [manage with fnm](https://github.com/Schniz/fnm) | [manage with nvm](https://github.com/nvm-sh/nvm) | [manage with volta.sh](https://volta.sh/)
+- node: >=24.9.0 - [manage with pnpm](https://pnpm.io/cli/runtime) | [manage with fnm](https://github.com/Schniz/fnm) | [manage with nvm](https://github.com/nvm-sh/nvm) | [manage with volta.sh](https://volta.sh/)
 - pnpm: 10.x - [how to install](https://pnpm.io/installation) (not recommended to install via `npm` on Windows native) | [alternate method - volta.sh](https://volta.sh/)
 - The repository [forked](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) and [cloned](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) locally on your device
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache git
 WORKDIR /app
 
 # Enable and prepare pnpm
-RUN corepack enable && corepack prepare pnpm@10.34.5 --activate
+RUN corepack enable && corepack prepare pnpm@11.26.0 --activate
 
 COPY . .
 

--- a/package.json
+++ b/package.json
@@ -97,5 +97,5 @@
   "engines": {
     "node": ">=24.9.0"
   },
-  "packageManager": "pnpm@10.34.5"
+  "packageManager": "pnpm@11.26.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,7 @@ overrides:
   yaml@>=2.0.0 <2.8.3: '>=2.8.3'
 
 patchedDependencies:
-  '@material/material-color-utilities':
-    hash: a7c4bd77eeb4f5d318cbab031556e5f87c153cb12d8788ae0bdc42f2c63cb83a
-    path: patches/@material__material-color-utilities.patch
+  '@material/material-color-utilities': a7c4bd77eeb4f5d318cbab031556e5f87c153cb12d8788ae0bdc42f2c63cb83a
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,11 +1,11 @@
 minimumReleaseAge: 1440
 
-onlyBuiltDependencies:
-  - core-js
-  - esbuild
-  - lefthook
-  - msw
-  - vite-node
+allowBuilds:
+  core-js: true
+  esbuild: true
+  lefthook: true
+  msw: true
+  vite-node: true
 
 overrides:
   ajv@>=7.0.0-alpha.0 <8.18.0: '>=8.18.0'
@@ -29,3 +29,5 @@ patchedDependencies:
 shellEmulator: true
 
 dedupePeers: true
+
+confirmModulesPurge: false


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Keeping things up-to-date.

## What are the changes from a developer perspective?
- `pnpm` updated from v10 to v11 and settings migrated.
- Workflows updated to use `pnpm/setup` instead of `pnpm/action-setup` + `actions/setup-node`.
- Added `confirmModulesPurge: false` to `pnpm-workspace.yaml`.
- Updated `Dockerfile` to use pnpm11.

> [!IMPORTANT]
> Make sure to run `pnpm setup` after updating.
> "After installing v11, run `pnpm setup` to update your shell so the new `bin` subdirectory is on `PATH`."
> \- https://pnpm.io/blog/releases/11.0

> [!NOTE]
> pnpm will regenerate your `node_modules` directory after updating.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually