### PR TITLE
fix: `CustomPokemonData` migrator won't break any more

### DIFF
--- a/src/system/version-migration/versions/v1_12_0_0.ts
+++ b/src/system/version-migration/versions/v1_12_0_0.ts
@@ -216,12 +216,12 @@ const convertCustomPokemonDataTypes: SessionSaveMigrator = {
   version: "1.12.0.0",
   migrate: (data: SessionSaveData): void => {
     for (const p of data.party) {
-      if (p.customPokemonData.types.length > 0) {
+      if (p.customPokemonData?.types?.length > 0) {
         p.customPokemonData.types = p.customPokemonData.types.map(t =>
           (t as PokemonType) === PokemonType.UNKNOWN ? null : t,
         );
       }
-      if (p.fusionCustomPokemonData.types.length > 0) {
+      if (p.fusionCustomPokemonData?.types?.length > 0) {
         p.fusionCustomPokemonData.types = p.fusionCustomPokemonData.types.map(t =>
           (t as PokemonType) === PokemonType.UNKNOWN ? null : t,
         );


### PR DESCRIPTION
## What are the changes the user will see?
The save migrator for `CustomPokemonData#types` won't break any more.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Fixes a save loading bug.

## What are the changes from a developer perspective?
Added optional chaining in the `if` statements.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR