### PR TITLE
fix: the items migrator will no longer break

### DIFF
--- a/src/system/version-migration/versions/v1_12_0_0.ts
+++ b/src/system/version-migration/versions/v1_12_0_0.ts
@@ -236,7 +236,7 @@ const shiftFormChangeItems: SessionSaveMigrator = {
   migrate: (data: SessionSaveData) => {
     // Shifting these up by 50 will work for now, but a more permanent solution will be desired in the future
     const shiftAmount = 50;
-    for (const modifier of data.modifiers) {
+    for (const modifier of data.modifiers ?? []) {
       if (modifier.className === "PokemonFormChangeItemModifier") {
         if (typeof modifier.args[1] === "number" && modifier.args[1] >= 50) {
           modifier.args[1] += shiftAmount;


### PR DESCRIPTION
## What are the changes the user will see?
The migrator to change item IDs will no longer break.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Fixes a save data reading bug.

## What are the changes from a developer perspective?
Added `?? []` to the `for (x of y)` in the migrator.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR