### PR TITLE
fix: the BBGreninja session migrator will respect monogen challenges

### DIFF
--- a/src/system/version-migration/versions/v1_12_0_0.ts
+++ b/src/system/version-migration/versions/v1_12_0_0.ts
@@ -193,7 +193,7 @@ const migrateSpeciesSplitSession: SessionSaveMigrator = {
   migrate: (data: SessionSaveData): void => {
     // Grab the mono-gen challenge number, used to avoid replacing species
     // which could potentially brick existing monogen runs.
-    const monoGenChallenge = data.challenges?.find(c => c.id === 0)?.severity;
+    const monoGenChallenge = data.challenges?.find(c => c.id === 0)?.value;
 
     for (const pokemon of [...data.party, ...data.enemyParty]) {
       // NB: Due to fusions, the two migrators are not mutually exclusive


### PR DESCRIPTION
## What are the changes the user will see?
The migrator for sessions with Battle Bond Greninja will no longer convert the player's Greninja/etc to Battle Bond Greninja if the player is in a Mono Gen6 challenge (Battle Bond Greninja is now considered Gen7).

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Fixes a save data loading bug.

## What are the changes from a developer perspective?
Changed `.severity` to `.value` in the code checking for whether a Monogen challenge is active.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually