### PR TITLE
fix(battle): Second pokemon can act vs eternatus again

### DIFF
--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -76,7 +76,8 @@ export class CommandPhase extends FieldPhase {
     // Switch back to the center pokemon. This can happen rarely in double battles with mid turn switching
     // TODO: Prevent this from happening in the first place
     if (globalScene.getPlayerField().filter(p => p.isActive()).length === 1) {
-      this.fieldIndex = FieldPosition.CENTER;
+      const activeIndex = globalScene.getPlayerField().findIndex(p => p.isActive());
+      this.fieldIndex = activeIndex === -1 ? FieldPosition.CENTER : activeIndex;
       return;
     }
 


### PR DESCRIPTION
## What are the changes the user will see?

When you had exactly 2 pokemon and the first died indirectly (e.g. poison) the second mon previously couldn't do anything

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

fixes #7410 

## What are the changes from a developer perspective?

if there is only 1 pokemon active, get the correct fieldPosition instead of `center`.

Ideally the mon should not be in the right position to begin with, but for now it fixes the bug

## Screenshots/Videos
<details><summary>Before</summary>

https://github.com/user-attachments/assets/54474675-f0e7-48ed-a7c9-a33fd0698923

</details>
<details><summary>After</summary>

https://github.com/user-attachments/assets/11a42978-1c63-41c4-9301-c3153ea6d963

</details>


## How to test the changes?

```ts
const overrides = {
  STARTING_WAVE_OVERRIDE: 200,
  STATUS_OVERRIDE: StatusEffect.POISON,
  ENEMY_MOVESET_OVERRIDE: [MoveId.SPLASH, MoveId.SPLASH, MoveId.SPLASH, MoveId.SPLASH],
  STARTING_LEVEL_OVERRIDE: 10000,
  STARTING_BIOME_OVERRIDE: BiomeId.END
} satisfies Partial<InstanceType<OverridesType>>;
```

```ts
export async function customDevFunction() {
  const lead = globalScene.getPlayerPokemon()
  lead!.hp = 50
}
```

Press `Q` before attacking

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: _____
- [ ] I have contacted the Translation Team on Discord for proofreading/translation (contacting the devs in #pokerogue-dev is sufficient, we can then forward the PR to the TL team)

Does this require any additions or changes to in-game assets? If so:
- [ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: _____
