### PR TITLE
balance: Allow Zygarde 50% and 10% PC in Fresh Start again

### DIFF
--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -898,19 +898,8 @@ export class FreshStartChallenge extends Challenge {
     dexEntry.caughtAttr &= ~(DexAttr.VARIANT_2 | DexAttr.VARIANT_3);
 
     // Remove unlocked forms for specific species
-    if (speciesId === SpeciesId.ZYGARDE) {
-      // Sets ability from power construct to aura break
-      const formMask = (DexAttr.DEFAULT_FORM << 2n) - 1n;
-      dexEntry.caughtAttr &= formMask;
-    } else if (
-      [
-        SpeciesId.PIKACHU,
-        SpeciesId.EEVEE,
-        SpeciesId.PICHU,
-        SpeciesId.ROTOM,
-        SpeciesId.MELOETTA,
-        SpeciesId.FROAKIE,
-      ].includes(speciesId)
+    if (
+      [SpeciesId.PIKACHU, SpeciesId.EEVEE, SpeciesId.PICHU, SpeciesId.ROTOM, SpeciesId.MELOETTA].includes(speciesId)
     ) {
       const formMask = (DexAttr.DEFAULT_FORM << 1n) - 1n; // These mons are set to form 0 because they're meant to be unlocks or mid-run form changes
       dexEntry.caughtAttr &= formMask;
@@ -937,18 +926,11 @@ export class FreshStartChallenge extends Challenge {
     pokemon.luck = 0; // No luck
     pokemon.shiny = false; // Not shiny
     pokemon.variant = 0; // Not shiny
-    if (pokemon.species.speciesId === SpeciesId.ZYGARDE && pokemon.formIndex >= 2) {
-      pokemon.formIndex -= 2; // Sets 10%-PC to 10%-AB and 50%-PC to 50%-AB
-    } else if (
+    if (
       pokemon.formIndex > 0
-      && [
-        SpeciesId.PIKACHU,
-        SpeciesId.EEVEE,
-        SpeciesId.PICHU,
-        SpeciesId.ROTOM,
-        SpeciesId.MELOETTA,
-        SpeciesId.FROAKIE,
-      ].includes(pokemon.species.speciesId)
+      && [SpeciesId.PIKACHU, SpeciesId.EEVEE, SpeciesId.PICHU, SpeciesId.ROTOM, SpeciesId.MELOETTA].includes(
+        pokemon.species.speciesId,
+      )
     ) {
       pokemon.formIndex = 0; // These mons are set to form 0 because they're meant to be unlocks or mid-run form changes
     }


### PR DESCRIPTION
<!--
Thank you for contributing to PokéRogue!
Open-source contributions like yours help keep this project going.

Note that these comment blocks are purely informative and can be removed once you're done reading them.
-->

<!--
Make sure your title matches the https://www.conventionalcommits.org/en/v1.0.0/ format.
Try to keep the title under 72 characters, as GitHub cuts off commit titles longer than this length.

See https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request
for more information on the allowed scopes and prefixes.

Example:
fix(move): Future Sight no longer crashes
^   ^      ^
|   |      |__ Subject
|   |_________ Scope (optional)
|_____________ Prefix
-->

## What are the changes the user will see?
<!--
Summarize the changes from a user perspective on the application.
Try to keep this section (relatively) brief as it is used to generate changelogs.
If you need to provide additional details, you can do so below the cutoff.

PRs with no user-facing changes should leave this blank or write "N/A" to be omitted from auto-generated changelogs.
-->
Zygarde 50% and 10% with Power Construct will now be allowed in Fresh Start challenges again.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
<!--
Explain why you decided to introduce these changes.
Does it come from another issue, PR or other prior discussion? Link to them if possible.
How can this can enhance user experience or otherwise improve the codebase?

Try to keep this explanation as objective as possible — avoid referring to personal feelings or making derogatory comments about existing code.

If this PR resolves an existing GitHub issue,
you can add "Fixes #[issue number]" (e.g.: "Fixes #1234") to link the issue.
(See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue for more information.)
-->
Requested by the balance team.

## What are the changes from a developer perspective?
<!--
Describe the changes this PR introduces to the codebase.
You can make use of a comparison between the state of the code before and after your changes.
Ex: What files have been changed? What classes/functions/variables/etc. have been added or changed?

Include enough detail to convey the scope of the changes being made and the rationale behind their implementation.
Feel free to include small code snippets if you think they will help illustrate your points.
-->
Removed two `if` blocks specifically checking to block selecting Power Construct and change any Power Construct Zygardes to Aura Break.

Also removed the now-unnecessary check for Froakie forms, as Battle Bond has since been split off.

## Screenshots/Videos
<!--
If you are changing anything visual (UI/UX, locales changes, etc.), please include screenshot(s) and/or video(s) showing the changes within collapsible blocks, like below:

<details><summary>Before</summary>

[before screenshot here]

</details>
<details><summary>After</summary>

[after screenshot here]

</details>
-->

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8dd6a27c-5abe-4599-b661-95a00e2a3cf2" />

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->
Start a Fresh Start challenge on All Starters and select a Power Construct Zygarde. You should now be able to use it in the challenge.

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [-] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [-] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)
