### PR TITLE
fix!: block saving if dex data doesn't match starter data

### DIFF
--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -214,9 +214,56 @@ export class GameData {
     return this.unlocks[unlockable];
   }
 
+  /**
+   * @returns Whether the system data is valid
+   */
+  private validateSystemData(data: SystemSaveData): boolean {
+    // biome-ignore lint/suspicious/useGuardForIn: this should be safe
+    for (const index in data.starterData) {
+      const idx = Number.parseInt(index);
+      const entry = data.starterData[index];
+      if (entry == null) {
+        console.error("Missing starter entry for", index);
+        continue;
+      }
+      if (
+        entry.abilityAttr > 1
+        || entry.classicWinCount > 0
+        || entry.eggMoves > 0
+        || entry.moveset != null
+        || entry.passiveAttr > 0
+        || entry.valueReduction > 0
+      ) {
+        const dexEntry = data.dexData[index];
+        if (dexEntry == null) {
+          console.error("Missing dex entry for", index);
+          continue;
+        }
+        if (
+          dexEntry.caughtCount === 0
+          && dexEntry.hatchedCount === 0
+          && !defaultStarterSpecies.includes(idx)
+          && speciesDataRegistry.isStarter(idx)
+        ) {
+          console.error("Corrupt save data detected, save rejected!");
+          console.warn("Species:", SpeciesId[idx]);
+          console.warn(entry);
+          console.warn(dexEntry);
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
   public async saveSystem(): Promise<boolean> {
     globalScene.ui.savingIcon.show();
     const data = this.getSystemSaveData();
+
+    if (!this.validateSystemData(data)) {
+      globalScene.ui.savingIcon.hide();
+      return false;
+    }
 
     const maxIntAttrValue = 0x80000000;
     const systemData = JSON.stringify(data, (_k: any, v: any) =>
@@ -1255,6 +1302,13 @@ export class GameData {
     const systemData = useCachedSystem
       ? GameData.parseSystemData(decrypt(localStorage.getItem(`data_${loggedInUser?.username}`)!, bypassLogin))
       : this.getSystemSaveData(); // TODO: is this bang correct?
+
+    if (!this.validateSystemData(systemData)) {
+      if (sync) {
+        globalScene.ui.savingIcon.hide();
+      }
+      return false;
+    }
 
     const request = {
       system: systemData,

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -244,7 +244,6 @@ export class GameData {
 
       const hasStarterData =
         starterEntry.abilityAttr > 1
-        || starterEntry.classicWinCount > 0
         || starterEntry.eggMoves > 0
         || starterEntry.moveset != null
         || starterEntry.passiveAttr > 0

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -74,7 +74,7 @@ import { RUN_HISTORY_LIMIT } from "#ui/run-history-ui-handler";
 import { applyChallenges } from "#utils/challenge-utils";
 import { fixedInt, NumberHolder, randInt, randSeedItem } from "#utils/common";
 import { decrypt, encrypt } from "#utils/data";
-import { getEnumKeys } from "#utils/enums";
+import { getEnumKeys, getEnumValues } from "#utils/enums";
 import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { toCamelCase } from "#utils/strings";
 import { AES, enc } from "crypto-js";
@@ -218,41 +218,49 @@ export class GameData {
    * @returns Whether the system data is valid
    */
   private validateSystemData(data: SystemSaveData): boolean {
-    // biome-ignore lint/suspicious/useGuardForIn: this should be safe
-    for (const index in data.starterData) {
-      const idx = Number.parseInt(index);
-      const entry = data.starterData[index];
-      if (entry == null) {
-        console.error("Missing starter entry for", index);
+    if (data.starterData == null) {
+      console.error("Starter data missing!");
+      return false;
+    }
+
+    for (const speciesId of getEnumValues(SpeciesId)) {
+      if (!speciesDataRegistry.isStarter(speciesId) || defaultStarterSpecies.includes(speciesId)) {
         continue;
       }
-      if (
-        entry.abilityAttr > 1
-        || entry.classicWinCount > 0
-        || entry.eggMoves > 0
-        || entry.moveset != null
-        || entry.passiveAttr > 0
-        || entry.valueReduction > 0
-      ) {
-        const dexEntry = data.dexData[index];
-        if (dexEntry == null) {
-          console.error("Missing dex entry for", index);
-          continue;
-        }
-        if (
-          dexEntry.caughtCount === 0
-          && dexEntry.hatchedCount === 0
-          && !defaultStarterSpecies.includes(idx)
-          && speciesDataRegistry.isStarter(idx)
-        ) {
-          console.error("Corrupt save data detected, save rejected!");
-          console.warn("Species:", SpeciesId[idx]);
-          console.warn(entry);
-          console.warn(dexEntry);
-          return false;
-        }
+
+      const starterEntry = data.starterData[speciesId];
+      const dexEntry = data.dexData[speciesId];
+
+      const species = SpeciesId[speciesId];
+
+      if (starterEntry == null) {
+        console.error("Missing starter data for %s (%d)!", species, speciesId);
+        return false;
+      }
+      if (dexEntry == null) {
+        console.error("Missing dex data for %s (%d)!", species, speciesId);
+        return false;
+      }
+
+      const hasStarterData =
+        starterEntry.abilityAttr > 1
+        || starterEntry.classicWinCount > 0
+        || starterEntry.eggMoves > 0
+        || starterEntry.moveset != null
+        || starterEntry.passiveAttr > 0
+        || starterEntry.valueReduction > 0;
+
+      const noDexData = dexEntry.caughtCount === 0 && dexEntry.hatchedCount === 0 && dexEntry.caughtAttr === 0n;
+
+      if (hasStarterData && noDexData) {
+        console.error("Corrupt save data detected, save rejected!");
+        console.warn("Species: %s (%d)", species, speciesId);
+        console.warn(starterEntry);
+        console.warn(dexEntry);
+        return false;
       }
     }
+
     return true;
   }
 

--- a/src/system/version-migration/version-converter.ts
+++ b/src/system/version-migration/version-converter.ts
@@ -66,6 +66,7 @@ import * as v1_9_0 from "#system/v1_9_0";
 import * as v1_10_0 from "#system/v1_10_0";
 import * as v1_11_19 from "#system/v1_11_19";
 import * as v1_12_0_0 from "#system/v1_12_0_0";
+import * as v1_12_0_1 from "#system/v1_12_0_1";
 
 // To add a new set of migrators, add them to the appropriate array of migrators
 
@@ -75,6 +76,7 @@ const systemMigrators: SystemSaveMigrator[] = [
   ...v1_7_0.systemMigrators,
   ...v1_8_3.systemMigrators,
   ...v1_12_0_0.systemMigrators,
+  ...v1_12_0_1.systemMigrators,
 ];
 
 /** All session save migrators */

--- a/src/system/version-migration/versions/v1_12_0_1.ts
+++ b/src/system/version-migration/versions/v1_12_0_1.ts
@@ -1,0 +1,56 @@
+import { defaultStarterSpecies } from "#app/constants";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
+import { DexAttr } from "#enums/dex-attr";
+import { SpeciesId } from "#enums/species-id";
+import type { SystemSaveMigrator } from "#types/save-migrators";
+import { getEnumValues } from "#utils/enums";
+
+const fixDexData: SystemSaveMigrator = {
+  version: "1.12.0.1",
+  migrate: (data): void => {
+    const defaultStarterAttr =
+      DexAttr.NON_SHINY | DexAttr.MALE | DexAttr.FEMALE | DexAttr.DEFAULT_VARIANT | DexAttr.DEFAULT_FORM;
+
+    for (const speciesId of getEnumValues(SpeciesId)) {
+      if (!speciesDataRegistry.isStarter(speciesId) || defaultStarterSpecies.includes(speciesId)) {
+        continue;
+      }
+
+      const starterEntry = data.starterData[speciesId];
+      const dexEntry = data.dexData[speciesId];
+
+      const species = SpeciesId[speciesId];
+
+      if (starterEntry == null) {
+        console.warn("Missing starter data for %s (%d)!", species, speciesId);
+      }
+      if (dexEntry == null) {
+        console.warn("Missing dex data for %s (%d)!", species, speciesId);
+      }
+
+      const hasStarterData =
+        starterEntry.abilityAttr > 1
+        || starterEntry.classicWinCount > 0
+        || starterEntry.eggMoves > 0
+        || starterEntry.moveset != null
+        || starterEntry.passiveAttr > 0
+        || starterEntry.valueReduction > 0;
+
+      const noDexData = dexEntry.caughtCount === 0 && dexEntry.hatchedCount === 0 && dexEntry.caughtAttr === 0n;
+
+      if (hasStarterData && noDexData) {
+        console.warn("Missing dex data for %s (%d), creating backup data.");
+
+        data.dexData[speciesId] = {
+          ...data.dexData[speciesId],
+          caughtCount: 1,
+          caughtAttr: defaultStarterAttr,
+          natureAttr: 1,
+          ivs: [15, 15, 15, 15, 15, 15],
+        };
+      }
+    }
+  },
+};
+
+export const systemMigrators: readonly SystemSaveMigrator[] = [fixDexData] as const;

--- a/src/system/version-migration/versions/v1_12_0_1.ts
+++ b/src/system/version-migration/versions/v1_12_0_1.ts
@@ -30,7 +30,6 @@ const fixDexData: SystemSaveMigrator = {
 
       const hasStarterData =
         starterEntry.abilityAttr > 1
-        || starterEntry.classicWinCount > 0
         || starterEntry.eggMoves > 0
         || starterEntry.moveset != null
         || starterEntry.passiveAttr > 0


### PR DESCRIPTION
## What are the changes the user will see?
If the game detects that the player's dex data doesn't match their starter data, it will reject saving.
Players who already have missing data will have the missing starters unlocked with basic data.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
To prevent issues of save data loss.

## What are the changes from a developer perspective?
Added a method to `GameData` that validates the player's system save data. If they have a starter with no corresponding dex data, the save is rejected.
Added a save migrator that sets basic unlock data for starters with missing dex data.

## How to test the changes?
Import your data from main and do something that would cause a system save (e.g. buying an egg).

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually