### PR TITLE
test: fix parameter types/doc comments of matchers

### DIFF
--- a/test/@types/vitest.d.ts
+++ b/test/@types/vitest.d.ts
@@ -1,6 +1,6 @@
 import "vitest";
 
-import type Overrides from "#app/overrides";
+import type { activeOverrides } from "#app/overrides";
 import type { Phase } from "#app/phase";
 import type { ArenaTag } from "#data/arena-tag";
 import type { BattlerTag, BattlerTagTypeMap } from "#data/battler-tags";
@@ -25,13 +25,14 @@ import type { OneOther } from "#test/@types/test-helpers";
 import type { GameManager } from "#test/framework/game-manager";
 import type { PartiallyFilledArenaTag } from "#test/matchers/to-have-arena-tag";
 import type { PartiallyFilledBattlerTag } from "#test/matchers/to-have-battler-tag";
-import type { ToHaveEffectiveStatOptions } from "#test/matchers/to-have-effective-stat";
 import type { ToHaveHpOptions } from "#test/matchers/to-have-hp";
 import type { PartiallyFilledPositionalTag } from "#test/matchers/to-have-positional-tag";
 import type { PartiallyFilledStatus } from "#test/matchers/to-have-status-effect";
 import type { ToHaveTypesOptions } from "#test/matchers/to-have-types";
 import type { PhaseString } from "#types/phase-types";
+import type { GetEffectiveStatParams } from "#types/pokemon-common";
 import type { TurnMove } from "#types/turn-move";
+import type { AtLeastOne } from "#types/type-helpers";
 import type { toDmgValue } from "#utils/common";
 import type { If, IntClosedRange, Integer, IsNumericLiteral, IsStringLiteral, NonNegativeInteger } from "type-fest";
 import type { expect } from "vitest";
@@ -338,7 +339,7 @@ interface PokemonMatchers {
    * Check whether a {@linkcode Pokemon}'s effective stat equals a certain value.
    * @param stat - The {@linkcode EffectiveStat} to check
    * @param expectedValue - The expected value of `stat`; must be a non-negative integer
-   * @param options - The {@linkcode ToHaveEffectiveStatOptions | options} passed to the matcher
+   * @param options - The {@linkcode GetEffectiveStatParams | options} passed to the matcher
    * @remarks
    * This checks the value after all stat value modifications have occured.
    * If you want to query the raw stat value **before** modifiers are applied, use {@linkcode Pokemon.getStat} instead.
@@ -347,7 +348,7 @@ interface PokemonMatchers {
   toHaveEffectiveStat<S extends number>(
     stat: EffectiveStat,
     expectedValue: If<IsNumericLiteral<S>, NonNegativeInteger<S>, S>,
-    options?: ToHaveEffectiveStatOptions,
+    options?: AtLeastOne<GetEffectiveStatParams>,
   ): void;
 
   /**
@@ -436,7 +437,7 @@ interface PokemonMatchers {
    * @param ppUsed - The amount of PP that should have been consumed,
    * or `all` to indicate the move should be _out_ of PP
    * @throws {Error}
-   * Fails test if the Pokemon's moveset has been set via {@linkcode Overrides.MOVESET_OVERRIDE}/{@linkcode Overrides.ENEMY_MOVESET_OVERRIDE}
+   * Fails test if the Pokemon's moveset has been set via {@linkcode activeOverrides.MOVESET_OVERRIDE}/{@linkcode activeOverrides.ENEMY_MOVESET_OVERRIDE}
    * or does not contain exactly one copy of `moveId`.
    */
   toHaveUsedPP<P extends number | "all">(moveId: MoveId, ppUsed: If<IsNumericLiteral<P>, Integer<P>, P>): void;

--- a/test/matchers/to-have-effective-stat.ts
+++ b/test/matchers/to-have-effective-stat.ts
@@ -4,6 +4,7 @@ import type { Pokemon } from "#field/pokemon";
 import { getStatName } from "#test/utils/string-utils";
 import { isPokemonInstance, receivedStr } from "#test/utils/test-utils";
 import type { GetEffectiveStatParams } from "#types/pokemon-common";
+import type { AtLeastOne } from "#types/type-helpers";
 import type { MatcherState, SyncExpectationResult } from "@vitest/expect";
 
 /**
@@ -11,7 +12,7 @@ import type { MatcherState, SyncExpectationResult } from "@vitest/expect";
  * @param received - The object to check. Should be a {@linkcode Pokemon}
  * @param stat - The {@linkcode EffectiveStat} to check
  * @param expectedValue - The expected value of `stat`; must be a non-negative integer
- * @param options - The {@linkcode ToHaveEffectiveStatOptions}
+ * @param options - The {@linkcode GetEffectiveStatParams | options} passed to the matcher
  * @returns Whether the matcher passed
  */
 export function toHaveEffectiveStat(
@@ -19,7 +20,7 @@ export function toHaveEffectiveStat(
   received: unknown,
   stat: EffectiveStat,
   expectedValue: number,
-  options?: GetEffectiveStatParams,
+  options?: AtLeastOne<GetEffectiveStatParams>,
 ): SyncExpectationResult {
   if (!isPokemonInstance(received)) {
     return {


### PR DESCRIPTION
## What are the changes the user will see?
N/A
<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
test matcher types were not updated, resulting in type unsafety & broken doc comment links
## What are the changes from a developer perspective?
fixed the type imports
## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
