### PR TITLE
misc: add alert screen when rejecting saving due to invalid save

### DIFF
--- a/src/enums/ui-mode.ts
+++ b/src/enums/ui-mode.ts
@@ -47,4 +47,5 @@ export enum UiMode {
   ADMIN,
   MYSTERY_ENCOUNTER,
   CHANGE_PASSWORD_FORM,
+  ALERT_MODAL,
 }

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -285,7 +285,6 @@ export class GameData {
     const data = this.getSystemSaveData();
 
     if (!this.validateSystemData(data)) {
-      globalScene.ui.savingIcon.hide();
       return this.showInvalidSaveModal(false);
     }
     globalScene.ui.savingIcon.show();

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -263,14 +263,32 @@ export class GameData {
     return true;
   }
 
+  private async showInvalidSaveModal<const T>(returnValue: T): Promise<T> {
+    const { promise, resolve } = Promise.withResolvers<T>();
+    await globalScene.ui.setMode(UiMode.ALERT_MODAL, i18next.t("gameData:failedSaveValidation"));
+    // TODO: This is a temporary hacky solution to ensure the modal displays when saving
+    // on the starter select UI, which change the UI mode without awaiting this async call..
+    globalScene.time.delayedCall(fixedInt(1000), () => {
+      // on the pokedex page, which changes the UiMode after calling this so the
+      // user never sees the alert modal.
+      if (globalScene.ui.getMode() === UiMode.ALERT_MODAL) {
+        globalScene.time.delayedCall(fixedInt(4000), () => resolve(returnValue));
+      } else {
+        globalScene.ui.setMode(UiMode.ALERT_MODAL, i18next.t("gameData:failedSaveValidation"));
+        globalScene.time.delayedCall(fixedInt(4000), () => resolve(returnValue));
+      }
+    });
+    return promise;
+  }
+
   public async saveSystem(): Promise<boolean> {
-    globalScene.ui.savingIcon.show();
     const data = this.getSystemSaveData();
 
     if (!this.validateSystemData(data)) {
       globalScene.ui.savingIcon.hide();
-      return false;
+      return this.showInvalidSaveModal(false);
     }
+    globalScene.ui.savingIcon.show();
 
     const maxIntAttrValue = 0x80000000;
     const systemData = JSON.stringify(data, (_k: any, v: any) =>
@@ -1294,10 +1312,6 @@ export class GameData {
       }
     }
 
-    if (sync) {
-      globalScene.ui.savingIcon.show();
-    }
-
     const sessionData = useCachedSession
       ? this.parseSessionData(
           decrypt(localStorage.getItem(getSessionDataLocalStorageKey(globalScene.sessionSlotId))!, bypassLogin),
@@ -1311,10 +1325,12 @@ export class GameData {
       : this.getSystemSaveData(); // TODO: is this bang correct?
 
     if (!this.validateSystemData(systemData)) {
-      if (sync) {
-        globalScene.ui.savingIcon.hide();
-      }
-      return false;
+      return this.showInvalidSaveModal(false);
+    }
+
+    // Saving icon should go after validation to avoid confusing users.
+    if (sync) {
+      globalScene.ui.savingIcon.show();
     }
 
     const request = {

--- a/src/ui/handlers/alert-modal-ui-handler.ts
+++ b/src/ui/handlers/alert-modal-ui-handler.ts
@@ -53,7 +53,6 @@ export class AlertModalUiHandler extends ModalUiHandler {
    * @param args - The message that will be displayed in the alert box.
    */
   show(args: [message: string]): boolean {
-    console.error("AlertModalUiHandler.show called with args:", args);
     const config: ModalConfig = { buttonActions: [] };
 
     const msg = args[0];

--- a/src/ui/handlers/alert-modal-ui-handler.ts
+++ b/src/ui/handlers/alert-modal-ui-handler.ts
@@ -1,0 +1,66 @@
+import { TextStyle } from "#enums/text-style";
+import type { UiMode } from "#enums/ui-mode";
+import type { ModalConfig } from "#ui/modal-ui-handler";
+import { ModalUiHandler } from "#ui/modal-ui-handler";
+import { addTextObject } from "#ui/text";
+import i18next from "i18next";
+
+export class AlertModalUiHandler extends ModalUiHandler {
+  private label: Phaser.GameObjects.Text;
+
+  constructor(mode: UiMode | null = null) {
+    super(mode);
+  }
+
+  getModalTitle(): string {
+    return "";
+  }
+
+  getWidth(): number {
+    return 160;
+  }
+
+  getHeight(): number {
+    return 32;
+  }
+
+  getMargin(): [number, number, number, number] {
+    return [0, 0, 48, 0];
+  }
+
+  getButtonLabels(): string[] {
+    return [];
+  }
+
+  setup(): void {
+    super.setup();
+
+    this.label = addTextObject(
+      //
+      this.getWidth() / 2,
+      this.getHeight() / 2,
+      i18next.t("alert"),
+      TextStyle.WINDOW,
+      { fontSize: "48px", align: "center" },
+    ) //
+      .setOrigin(0.5, 0.5);
+
+    this.modalContainer.add(this.label);
+  }
+
+  /**
+   * Show the alert modal with the specified message.
+   * @param args - The message that will be displayed in the alert box.
+   */
+  show(args: [message: string]): boolean {
+    console.error("AlertModalUiHandler.show called with args:", args);
+    const config: ModalConfig = { buttonActions: [] };
+
+    const msg = args[0];
+    if (msg) {
+      this.label.setText(args[0]);
+    }
+
+    return super.show([config]);
+  }
+}

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -7,6 +7,7 @@ import { TextStyle } from "#enums/text-style";
 import { UiMode } from "#enums/ui-mode";
 import { AchvBar } from "#ui/achv-bar";
 import { AchvsUiHandler } from "#ui/achvs-ui-handler";
+import { AlertModalUiHandler } from "#ui/alert-modal-ui-handler";
 import { AutoCompleteUiHandler } from "#ui/autocomplete-ui-handler";
 import { AwaitableUiHandler } from "#ui/awaitable-ui-handler";
 import { BallUiHandler } from "#ui/ball-ui-handler";
@@ -108,6 +109,7 @@ const noTransitionModes = [
   UiMode.MYSTERY_ENCOUNTER,
   UiMode.RUN_INFO,
   UiMode.CHANGE_PASSWORD_FORM,
+  UiMode.ALERT_MODAL,
 ];
 
 // biome-ignore lint/style/useNamingConvention: a unique case (only 2 letters)
@@ -182,6 +184,7 @@ export class UI extends Phaser.GameObjects.Container {
       new AdminUiHandler(),
       new MysteryEncounterUiHandler(),
       new ChangePasswordFormUiHandler(),
+      new AlertModalUiHandler(),
     ];
   }
 


### PR DESCRIPTION
## What are the changes the user will see?
<!--
Summarize the changes from a user perspective on the application.
Try to keep this section (relatively) brief as it is used to generate changelogs.
If you need to provide additional details, you can do so below the cutoff.

PRs with no user-facing changes should leave this blank or write "N/A" to be omitted from auto-generated changelogs.
-->

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

Made it so when #7420 is triggered, users will see a message indicating the save validation failed, rather than silently going to title screen.
## Why am I making these changes?
<!--
Explain why you decided to introduce these changes.
Does it come from another issue, PR or other prior discussion? Link to them if possible.
How can this can enhance user experience or otherwise improve the codebase?

Try to keep this explanation as objective as possible — avoid referring to personal feelings or making derogatory comments about existing code.

If this PR resolves an existing GitHub issue,
you can add "Fixes #[issue number]" (e.g.: "Fixes #1234") to link the issue.
(See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue for more information.)
-->

## What are the changes from a developer perspective?
Added a new modal handler for alerts. Essentially, a copy/paste of `session-reload-modal-ui-handler.ts`, except allows a message to be provided as an argument to `show`.

## Screenshots/Videos

<details><summary>Demo</summary>

https://github.com/user-attachments/assets/b03d879f-7260-4ea4-bc09-d0579fac5a03
</details>
-->

## How to test the changes?
Easiest way to see the message is to force `validateSystemData` to return false (line 221 of game-data.ts).

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: Accidentally committed directly: https://github.com/pagefaultgames/pokerogue-locales/commit/65c08bd5a81670760da93f893f245c84e70051d4
- [x] I have contacted the Translation Team on Discord for proofreading/translation (contacting the devs in #pokerogue-dev is sufficient, we can then forward the PR to the TL team)

Does this require any additions or changes to in-game assets? If so:
- [ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: _____
