### PR TITLE
fix: the Tera rework save migrator will no longer crash

### DIFF
--- a/src/system/version-migration/versions/v1_7_0.ts
+++ b/src/system/version-migration/versions/v1_7_0.ts
@@ -38,8 +38,8 @@ const migrateUnselectableForms: SystemSaveMigrator = {
 
 export const systemMigrators: readonly SystemSaveMigrator[] = [migrateUnselectableForms] as const;
 
-function isArrayOfLengthThree(arr: unknown): arr is [unknown, unknown, unknown] {
-  return Array.isArray(arr) && arr.length === 3;
+function isArrayOfAtLeastTwo(arr: unknown): arr is unknown[] {
+  return Array.isArray(arr) && arr.length >= 2;
 }
 
 const migrateTera: SessionSaveMigrator = {
@@ -54,7 +54,7 @@ const migrateTera: SessionSaveMigrator = {
           // Assert the modifier has the expected args structure
           const modifierArgs = data.modifiers[i].args;
           // Skip malformed modifiers (it is not the migrator's responsibility to fix/remove)
-          if (!isArrayOfLengthThree(modifierArgs)) {
+          if (!isArrayOfAtLeastTwo(modifierArgs)) {
             continue;
           }
           data.party.forEach(p => {
@@ -87,7 +87,7 @@ const migrateTera: SessionSaveMigrator = {
         // Assert the modifier has the expected args structure
         const modifierArgs = data.enemyModifiers[i].args;
 
-        if (!isArrayOfLengthThree(modifierArgs)) {
+        if (!isArrayOfAtLeastTwo(modifierArgs)) {
           data.enemyModifiers.splice(i, 1);
           continue;
         }

--- a/src/system/version-migration/versions/v1_7_0.ts
+++ b/src/system/version-migration/versions/v1_7_0.ts
@@ -38,8 +38,8 @@ const migrateUnselectableForms: SystemSaveMigrator = {
 
 export const systemMigrators: readonly SystemSaveMigrator[] = [migrateUnselectableForms] as const;
 
-function isArrayOfLengthTwo(arr: unknown): arr is [unknown, unknown] {
-  return Array.isArray(arr) && arr.length === 2;
+function isArrayOfLengthThree(arr: unknown): arr is [unknown, unknown] {
+  return Array.isArray(arr) && arr.length === 3;
 }
 
 const migrateTera: SessionSaveMigrator = {
@@ -54,7 +54,7 @@ const migrateTera: SessionSaveMigrator = {
           // Assert the modifier has the expected args structure
           const modifierArgs = data.modifiers[i].args;
           // Skip malformed modifiers (it is not the migrator's responsibility to fix/remove)
-          if (!isArrayOfLengthTwo(modifierArgs)) {
+          if (!isArrayOfLengthThree(modifierArgs)) {
             continue;
           }
           data.party.forEach(p => {
@@ -87,7 +87,7 @@ const migrateTera: SessionSaveMigrator = {
         // Assert the modifier has the expected args structure
         const modifierArgs = data.enemyModifiers[i].args;
 
-        if (!isArrayOfLengthTwo(modifierArgs)) {
+        if (!isArrayOfLengthThree(modifierArgs)) {
           data.enemyModifiers.splice(i, 1);
           continue;
         }

--- a/src/system/version-migration/versions/v1_7_0.ts
+++ b/src/system/version-migration/versions/v1_7_0.ts
@@ -38,7 +38,7 @@ const migrateUnselectableForms: SystemSaveMigrator = {
 
 export const systemMigrators: readonly SystemSaveMigrator[] = [migrateUnselectableForms] as const;
 
-function isArrayOfLengthThree(arr: unknown): arr is [unknown, unknown] {
+function isArrayOfLengthThree(arr: unknown): arr is [unknown, unknown, unknown] {
   return Array.isArray(arr) && arr.length === 3;
 }
 


### PR DESCRIPTION
## What are the changes the user will see?
Session saves from before version 1.7.0 will no longer cause session loading to crash the game.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Fixing a bug that caused users to be completely unable to play the game without their session saves being cleared from the database.

## What are the changes from a developer perspective?
Fixed the migrator to check for array length of at least 2 for `args` instead of exactly 2 when determining if the modifier was valid or corrupt.

## How to test the changes?
Not sure how to export the broken save directly, but if you run `rogueserver` locally and import the save by executing a DB query you can test it.
You'll need to get the `uuid` of your user and replace `<your_uuid_here>` in the query.
Steps:
- Set up `rogueserver` and make the client connect to it by putting `VITE_BYPASS_LOGIN=0` in `.env.development.local` in the pokerogue repo root.
- Register an account on the local server.
- Connect to the server via `podman exec -it rogueserver_db_1 mariadb -u root -p` (password is "admin").
- Run `use pokeroguedb;`
- Run `SELECT HEX(uuid) FROM accounts;` and use that value in place of the `<your_uuid_here>` in the query below
- Execute the query from the collapsible block.
- Reload the client page and attempt to load the session.
- On beta, the game should become completely unresponsive.
- On the PR branch, it should be loadable, allowing you to play.
<details><summary>Session save import sql query</summary>

```sql
INSERT INTO `sessionSaveData` VALUES (0x<your_uuid_here>, 1, 0x28b52ffd64873c0d63009a78341a4770687100f1da302a71478a634ed6c2adcd2c8f318d175f2e8ba7acde5655d447a8a9e55353524d8ab527c107be039bad0636842488e4c4ffea32a2d5f51d4e20b31aa993317d1f7f018401a401665ce4486692888ba13e4c7df4162fc637dd2d54e543aecefe49526ddbaa92c8a658ddfc27671c3cc0bb55ad64443855d3aa4d53f07bc811c488f8bf9669f9871cc95c0a39d6e0b271e0b67a39cca630aed8f485bb0b77af056264191271965a85502c7a087ee264c252b142a03815f784a26a0b0de4aea3d3ff979908a72f1ff2de4ca8eea9e013997df2ff10cad9c7c731c4ff8f63fe20453993408e0efecb4ccb258fe3821d30cbe19ef6972bc899d471a4f05fcb9f836d579ed5ee2e742b1e84e12240ce248ea3edff831c73e7572c57d58d8573d70d77bea6be9ffcb4ccb6697ff9145f775350fe5a7e399beed727e32ed1c75518deb72d1e649ff870abf8e1c374c87941309b6e1340f9cb4c7c5b18984ed1de16d833f39799c8d95667e6ef71cc1d66852d4e557715cf6a7743f96b79b3fc3dcda1fc3b8eb9bf3cb54a83adee87b8721605ca9fe39889f0bb7766b0d5f17537cdf29799afa98fb8d5dd2c3f2d0739ef95b9287fd7316f7833f1e1eeb16dda3bef11e5ec73c3438e035f461fa58cc1707acfc7649aaaabfd32beb96dc430178ccbf6824812d219668b9cacae3c3f3bcf047abaf4bc4cd7e22fb589ae7f522b212129292971d934952d4597f1cd165a674348fc650ef855beae89d15f2963dd8219df4cb17a90e5e96b05f44fbe3cc8f2ab98aefa32bea99a38a8fec929add333205eea16c26f3a9449b96ef94ff22ee5ba31bd6389f1cd273e6cd758f951e543c931cc3b1fb6ab6c4a886d5358a8b6439477e176897451fca5ca873c07f375a65baaf84b184c8697f14d1d612ebaa95d6d7cb3f314c8dd2e7c7956ebcad452e3f032be8945ba333e4c7bdfaeec3b7789b019e4a9eaba67e769adb3afd02714e4bdf3d775853d00ffe4d586cb7f72d8ea825cadda3d0dd2fe492ee4c2147cd8ae3fb29f2a026fb85715f4f323723c641576a0cf020a736c9b76a115908e9d27203cd9f331eef34fc2ec4edf3d947def6d5579a619027347cfcb8229b9b6e90de6eb8c4b180fa6efcb8751fc15c29b1d5a0a8bbf5cdfd6ea27bf9cb85537a64b80582a21422fc55fc67eaac8b1186bd09c546f77e27e28705139da0ff597a7be2c609b3bf009ccf78a100209ca3b9d7abfdd0af4e783f8bbb17aee165afb004ffe93e6e77839dcdbf6e66ea101be88af1baaf7ad027fb4812ce0863b9086ca5f7b77a9e39d4eb8df6e05fae3a13ba91ed103a0c5824fdc25c2b16c3e93a351d65a49b508f19747bc5fd1e415612a2561b1c9af687c5386d7d9e62dacb1e5f9d95356310806fc32bea985e6d402343c82a751c639eb19605c688a5eb02e561bdfd492f13503ec0515958a2ee39be79b985551ccf3b3f3d645899a52eff9d8840f481d3c8428eaf2129266aa780566f454cab808d659024b1ba5f8cba3334e99b58e9e97e995caf8a61a7f1923fef2eaab1785452badf1cdda1252860d46bb628d1d114df9ba6192f14d61f1a7b5860e462fa58ccf3904de50d9f2fc6c69c306112570e0d9fa5a7516e39b4e74518f2cc6377595ed64f2b165cfc7b884e9185436e39badee432faeb0179a2bcc0d14d5d1b64d29638d157fa98506ab98da64a06981eaa40a6c6ae83d1ffb27b556fca53e3a6f5f886811a062a6e7655aeb86cbc65f969fe3c55fe6be96c24478b06d9081862a7fa7c513df914f9ecce142d2850ca6cf2dc7a598629cbdaaf818f36bc84519729994490ef9376433eb27ab4cf22d90fac1035b2da9c674f2501fd0d38a9e40ece118306026eb2624dda4437d4f3fb409ea74c2fd74bc2813b50fb072f8895fb11b0bb7bead0905cf20f6742e5cd0457c46aaaa1beefbe53e046f74e345fd4e1eea9b3d90f944f4934363d4cd9de0d489e80108406fbf5c0e75ea013d2d4952924ebaa3670df4cccd51edcc0315670ef7db3df19a80ecc6c2bddcaab3fbf5ad1c7e0aaadc09066e986d71105e421626a8f3f65b71ea4e28164cb41fdadaeb86d97d95361978044688efcb6f424fc482c7436fe6cb624f66298ccd2cfe32973b6f288aa8dd0f0a65ca4535113d80fdc25be8802f60be91635183d8bb39fad01c8a3b79b7dfd984ea849ea87320f0dc575c97e0151ce12ed19705dc307c72f0790c3574c7c2f743813b7dbe53c00f88bd9d5475535815ea0afc01a8a728dccf87e6a47467d00b0939ee4e9dcf9beed605bd109187fa7a5151b79feff4f57e68efbc0178017ddf0afc01f219fc934327cbaff8bbe32e111e8a7d8259a002c32054ce0ccdc00804000100f209020ac2481a4acb3c8ff82ca99dfb88b6761f4531bc4e1dc058c58ed4fa934603b006c031b4a7b225014a8e440e09eef94896cd14068c28c2a570b29855d13bc92414397591654ad84cb657ce145746d60843de4c039478903d4b3fe2ed92923b110ad2c34d4767b2a713323552ac8529a02fce1fe9e5a2f685a5f2e1a92e5a21c4b16c74f4aa8963d78eb7f9921c5f334823e90d9d98d950be62bab8e03ec10faef1b612edf0c2c5724a45743192e711301ccdbd64ca1999b2e402684f695ce090ae28748c091b72fe2192c6516447db0bf5b87a9571afa599d251836f265e5460dc9410c410e4cecd86c18af802960a7a508419713673e5226cd9834c81481d7fd168b543a3a341e1413e553eb95b1876abab3168e82318bf1641c0149d8fe9dbcee85c3317c41aa06b0aecb0cd9e64711135b1c6d3ed0dc70722ca3cd03c256333a830f231b1ebca8fbfedfe81ad2c2d654d03d784882994208fafbbd30405c8b66953f5e59354972a18a360fe1e039bc7bac85ecfa94d16837c094abdb8fd47d0a59fe71607228c218977aa42ca8811e59e8689c5b73d08ba141b39c2544e334a320d6a7a5d52a298a68014ca1b05464f7f4d3836d6e5e4b601258bcd093a74b0f7ade2485310b784673faa52804de87860186ad861b799bd88c74b12bad38038c5dc0d0627d29e76fa17375e6d49b745b4dc492bd092de311ed00befca5aedb0017d672b5244931658a3274fe00282861319a3f9a80e2973cd5b0b41d2ee73077b305a9749637b38cd36c5fe286544c599ecf19937268364368d3d79c8ce630f1643327370f27cde2dd9396393c7eba980e3e195afbbf24ee846dbb20307f4f1a8393decbb544725295f1fb30630c38de9a59016bde0f62f11f2404a1ef3ec5d95114475a504381df06944df94200925c9cc4ec7b62f8b2395998f20b9e9d1887418505ef2a74f9cff00c0dd963a112959f0baa2cfba6be100857e471f7ab4830fea5052bfbc8028b33fc623a53cfd6362f089a9c94db467e4896f5b74cff783e127f01f29779832d1d818022e441811ee158d61ae529766fc48b4b85e6fe397f379a94edbca5931037243f8488e08e2a88308de877850d77009776762f23d79bc78e0438f70fce38f23bd4e8cd38b53089ab441cd35d2d6dca12d1244086a49f1290854ca7bddbf2fa360351ffc84736d9c98793d5ccfd6299b02af4a4fe3dc0f4982a4fb5cf4f840471ef2d1552302d8cb0727d32a08d3b6a119ee21d47364c2af2868f54eba1b892d22f9b279373d1dc2f5e98b4cf366febc45d4a8fd21e2d2f99a0dca68cd9e3a3aa2fc8e2c11bc8f26c36396c9ab2e49650c5c869fba13fd914df50bd7654621c94479a40cf4656a7750fb25c30458e57e408f702039c103d46d826ca8748e302a33ddf75078e5a2e20e6b0925cb8c82a05873b6d422f39f2b3fff39c3399e80391484a3f815d40ad1fbbc2ba054dd668c691a7224c1f4a740f24cda39321dd5d7f11ebd9b699c6cdaefce170de0ea518e3dce517f18acb3d1b422b3ce04c06b69f662e40bd70ade95c36141f3cc2c5dceb8fde31ee7781982a2cbe43dd0798906991e8c448614b98939d9b2da65831fd1265e4a5bfda270480f890b4cfc4765e4981644c1788bf4518f3bfe510f1e00a216e08347d935738f7ca513066c2fb00794f475ec731f35a26bade210b42e2a14435d96f021ed24307626a2504804921d45066af5aac9410e7f96dc3ce62ad277f43399711f6a3dfed2e56cbf435cd85c6e1f47bbeda9da1e15e6a4ed1de906432fde3b360501643d4c6587257b4363aedc704519e494ffa52412de485ed39bfc3695bccd98ac744bd1c69e1a19067a72480986ebcb9b17b7e31399741acf71d2adadf1b3fa477bb61c0674e28e2f7cdcf24d2dc70a9acacc0c60bc91c32ccaca2e96444917b34e1706686e5fb6844cbde0a0831ef22306c84976095ce882582f693c54fc9947ab2ee591be2a80750b1f1a5732073332e89d9a97782148044d48b4f5e1066feee1d142c85a385327322b54f92a9d4bfb4d2922b2e81fbd7d8676660fef7baa1d, '2024-08-07 04:53:32');
```

</details> 


## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually