### PR TITLE
fix(ability): Mirror Armor won't crash if activated by Sticky Webs

### DIFF
--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -44,10 +44,15 @@ export class StatStageChangePhase extends PokemonPhase {
     this.options.changes = deepCopy(options.changes).filter(c => c.stages !== 0); // Allow changes with 0 stages to be passed as no-ops
   }
 
+  // @ts-expect-error: TODO: the return type of `PokemonPhase#getPokemon` is wrong
+  public override getPokemon(): Pokemon | undefined {
+    return super.getPokemon();
+  }
+
   public override start(): void {
     const pokemon = this.getPokemon();
 
-    if (!pokemon.isActive(true)) {
+    if (!pokemon?.isActive(true)) {
       this.end();
       return;
     }

--- a/test/tests/abilities/mirror-armor.test.ts
+++ b/test/tests/abilities/mirror-armor.test.ts
@@ -1,4 +1,6 @@
 import { AbilityId } from "#enums/ability-id";
+import { ArenaTagSide } from "#enums/arena-tag-side";
+import { ArenaTagType } from "#enums/arena-tag-type";
 import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -7,6 +9,7 @@ import { GameManager } from "#test/framework/game-manager";
 import Phaser from "phaser";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 
+// TODO: modernize this test file
 describe("Ability - Mirror Armor", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
@@ -289,5 +292,27 @@ describe("Ability - Mirror Armor", () => {
     expect(enemy2.getStatStage(Stat.SPD)).toBe(0);
     expect(player1.getStatStage(Stat.SPD)).toBe(0);
     expect(player2.getStatStage(Stat.SPD)).toBe(0);
+  });
+
+  it("doesn't crash if activated by Sticky Web when the Sticky Web user is off the field", async () => {
+    game.override //
+      .enemyAbility(AbilityId.MIRROR_ARMOR)
+      .enemyMoveset(MoveId.SPLASH);
+    await game.classicMode.startBattle(SpeciesId.FEEBAS, SpeciesId.MILOTIC);
+
+    game.move.use(MoveId.STICKY_WEB);
+    await game.toNextTurn();
+
+    game.doSwitchPokemon(1);
+    await game.toNextTurn();
+
+    game.field.getEnemyPokemon().hp = 1;
+
+    game.move.use(MoveId.AERIAL_ACE);
+    await game.toNextWave();
+
+    expect(game).toHaveArenaTag(ArenaTagType.STICKY_WEB, ArenaTagSide.ENEMY);
+    expect(game.field.getPlayerPokemon()).toHaveStatStage(Stat.SPD, 0);
+    expect(game.field.getEnemyPokemon()).toHaveStatStage(Stat.SPD, 0);
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?
Mirror Armor won't crash the game if activated by Sticky Web when the user of Sticky Web is no longer on the field.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Bug report.

## What are the changes from a developer perspective?
Added optional chaining in the `if` statement at the beginning of `StatStageChangePhase#start`.
Added a test for Mirror Armor vs Sticky Web from off-field user.

## How to test the changes?
`pnpm test:silent mirror-armor`

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary