### PR TITLE
fix(graphics): Fix certain female Mega icons not appearing

### DIFF
--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -481,17 +481,21 @@ export abstract class PokemonSpeciesForm {
     switch (this.speciesId) {
       case SpeciesId.DODUO:
       case SpeciesId.DODRIO:
-      case SpeciesId.MEGANIUM:
       case SpeciesId.TORCHIC:
       case SpeciesId.COMBUSKEN:
-      case SpeciesId.BLAZIKEN:
       case SpeciesId.HIPPOPOTAS:
       case SpeciesId.HIPPOWDON:
       case SpeciesId.UNFEZANT:
       case SpeciesId.FRILLISH:
       case SpeciesId.JELLICENT:
-      case SpeciesId.PYROAR:
         ret += female ? "-f" : "";
+        break;
+      case SpeciesId.MEGANIUM:
+      case SpeciesId.BLAZIKEN:
+      case SpeciesId.PYROAR:
+        if (this.getFormKey() !== SpeciesFormKey.MEGA) {
+          ret += female ? "-f" : "";
+        }
         break;
     }
 

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -483,6 +483,8 @@ export abstract class PokemonSpeciesForm {
       case SpeciesId.DODRIO:
       case SpeciesId.TORCHIC:
       case SpeciesId.COMBUSKEN:
+      case SpeciesId.GIBLE:
+      case SpeciesId.GABITE:
       case SpeciesId.HIPPOPOTAS:
       case SpeciesId.HIPPOWDON:
       case SpeciesId.UNFEZANT:

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -495,11 +495,13 @@ export abstract class PokemonSpeciesForm {
       case SpeciesId.MEGANIUM:
       case SpeciesId.BLAZIKEN:
       case SpeciesId.GARCHOMP:
-      case SpeciesId.PYROAR:
-        if (this.getFormKey() !== SpeciesFormKey.MEGA) {
+      case SpeciesId.PYROAR: {
+        const formKey = this.getFormKey();
+        if (formKey !== SpeciesFormKey.MEGA && formKey !== SpeciesFormKey.MEGA_Z) {
           ret += female ? "-f" : "";
         }
         break;
+      }
     }
 
     let formSpriteKey = this.getFormSpriteKey(formIndex);

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -492,6 +492,7 @@ export abstract class PokemonSpeciesForm {
         break;
       case SpeciesId.MEGANIUM:
       case SpeciesId.BLAZIKEN:
+      case SpeciesId.GARCHOMP:
       case SpeciesId.PYROAR:
         if (this.getFormKey() !== SpeciesFormKey.MEGA) {
           ret += female ? "-f" : "";


### PR DESCRIPTION
<!--
Thank you for contributing to PokéRogue!
Open-source contributions like yours help keep this project going.

Note that these comment blocks are purely informative and can be removed once you're done reading them.
-->

<!--
Make sure your title matches the https://www.conventionalcommits.org/en/v1.0.0/ format.
Try to keep the title under 72 characters, as GitHub cuts off commit titles longer than this length.

See https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request
for more information on the allowed scopes and prefixes.

Example:
fix(move): Future Sight no longer crashes
^   ^      ^
|   |      |__ Subject
|   |_________ Scope (optional)
|_____________ Prefix
-->

## What are the changes the user will see?
<!--
Summarize the changes from a user perspective on the application.
Try to keep this section (relatively) brief as it is used to generate changelogs.
If you need to provide additional details, you can do so below the cutoff.

PRs with no user-facing changes should leave this blank or write "N/A" to be omitted from auto-generated changelogs.
-->
Female Meganium, Blaziken, and Pyroar will now have their intended party icons when mega evolved. Female Gible, Gabite, and Garchomp now can use their unique party icons.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
<!--
Explain why you decided to introduce these changes.
Does it come from another issue, PR or other prior discussion? Link to them if possible.
How can this can enhance user experience or otherwise improve the codebase?

Try to keep this explanation as objective as possible — avoid referring to personal feelings or making derogatory comments about existing code.

If this PR resolves an existing GitHub issue,
you can add "Fixes #[issue number]" (e.g.: "Fixes #1234") to link the issue.
(See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue for more information.)
-->
Graphical bug that needed fixed.

## What are the changes from a developer perspective?
<!--
Describe the changes this PR introduces to the codebase.
You can make use of a comparison between the state of the code before and after your changes.
Ex: What files have been changed? What classes/functions/variables/etc. have been added or changed?

Include enough detail to convey the scope of the changes being made and the rationale behind their implementation.
Feel free to include small code snippets if you think they will help illustrate your points.
-->
Meganium, Blaziken, and Pyroar now no longer expect female icons for their mega evolutions, only expecting it on their base forms as intended. Gible, Gabite, and Garchomp were also added to this switch case, allowing them to properly use their female icons. 

## Screenshots/Videos
<!--
If you are changing anything visual (UI/UX, locales changes, etc.), please include screenshot(s) and/or video(s) showing the changes within collapsible blocks, like below:

<details><summary>Before</summary>

[before screenshot here]

</details>
<details><summary>After</summary>

[after screenshot here]

</details>
-->
Female Mega Meganium:

<img width="719" height="372" alt="image" src="https://github.com/user-attachments/assets/fe0347a4-513a-4f9e-a48d-295739403a91" />

Female Mega Pyroar:

<img width="719" height="367" alt="image" src="https://github.com/user-attachments/assets/a56bcaea-3c7b-4ac3-9a05-0dfc1ec7d7dd" />

## How to test the changes?
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->
```ts
const overrides = {
  GENDER_OVERRIDE: Gender.FEMALE,
  STARTER_SPECIES_OVERRIDE: SpeciesId.MEGANIUM,
  STARTER_FORM_OVERRIDES: { [SpeciesId.MEGANIUM]: 1 },
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [-] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [-] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Does this require any additions or changes to in-game assets? If so:
- [x] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: https://github.com/pagefaultgames/pokerogue-assets/pull/108
