### PR TITLE
fix(ability): Prevent Opportunist loop

### DIFF
--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -274,7 +274,10 @@ export class StatStageChangePhase extends PokemonPhase {
    * otherwise not significant beyond faster animation.
    */
   private triggerReactionAbilities(pokemon: Pokemon): void {
-    if (this.options.changes.some(c => c.stages > 0)) {
+    if (
+      this.options.sourceEffectType !== StatChangeSource.OPPORTUNIST
+      && this.options.changes.some(c => c.stages > 0)
+    ) {
       for (const opponent of pokemon.getOpponentsGenerator()) {
         applyAbAttrs("StatStageChangeCopyAbAttr", { pokemon: opponent, changes: this.options.changes });
       }

--- a/test/tests/abilities/opportunist.test.ts
+++ b/test/tests/abilities/opportunist.test.ts
@@ -1,0 +1,38 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/framework/game-manager";
+import Phaser from "phaser";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Abilities - Opportunist", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.OPPORTUNIST)
+      .battleStyle("single")
+      .criticalHits(false)
+      .startingLevel(200)
+      .enemyLevel(200)
+      .enemySpecies(SpeciesId.FEEBAS)
+      .enemyAbility(AbilityId.OPPORTUNIST)
+      .enemyMoveset(MoveId.SPLASH);
+  });
+
+  it("should not loop when opposing Pokemon both have the ability", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    game.move.use(MoveId.SWORDS_DANCE);
+    await game.toEndOfTurn();
+    expect(true).toEqual(true); // no loop if we got here
+  });
+});


### PR DESCRIPTION
<!--
Thank you for contributing to PokéRogue!
Open-source contributions like yours help keep this project going.

Note that these comment blocks are purely informative and can be removed once you're done reading them.
-->

<!--
Make sure your title matches the https://www.conventionalcommits.org/en/v1.0.0/ format.
Try to keep the title under 72 characters, as GitHub cuts off commit titles longer than this length.

See https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request
for more information on the allowed scopes and prefixes.

Example:
fix(move): Future Sight no longer crashes
^   ^      ^
|   |      |__ Subject
|   |_________ Scope (optional)
|_____________ Prefix
-->

## What are the changes the user will see?
Opportunist doesn't loop forever when opposing pokemon have the ability

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Fixes #7432 

## What are the changes from a developer perspective?
One line + test

## Screenshots/Videos
<!--
If you are changing anything visual (UI/UX, locales changes, etc.), please include screenshot(s) and/or video(s) showing the changes within collapsible blocks, like below:

<details><summary>Before</summary>

[before screenshot here]

</details>
<details><summary>After</summary>

[after screenshot here]

</details>
-->

## How to test the changes?
```ts
const overrides = {
  ABILITY_OVERRIDE: AbilityId.OPPORTUNIST,
  ENEMY_ABILITY_OVERRIDE: AbilityId.OPPORTUNIST,
  MOVESET_OVERRIDE: MoveId.SWORDS_DANCE
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [ ] **I'm using `beta` as my base branch**
  - [ ] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [ ] I have provided a clear explanation of the changes within the PR description
  - [ ] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [ ] The PR is self-contained and cannot be split into smaller PRs
- [ ] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [ ] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)