### PR TITLE
misc: add game version header to api requests

### DIFF
--- a/src/api/api-base.ts
+++ b/src/api/api-base.ts
@@ -1,4 +1,5 @@
 import { SESSION_ID_COOKIE_NAME } from "#app/constants";
+import { version } from "#package.json";
 import { getCookie } from "#utils/cookies";
 import type { SetRequired, UndefinedOnPartialDeep } from "type-fest";
 
@@ -84,6 +85,7 @@ export abstract class ApiBase {
       ...config.headers,
       Authorization: getCookie(SESSION_ID_COOKIE_NAME),
       "Content-Type": config.headers?.["Content-Type"] ?? "application/json",
+      "PKR-Client-Version": version,
     };
 
     // can't import `isLocal` due to circular import issues


### PR DESCRIPTION
## What are the changes the user will see?
<!--
Summarize the changes from a user perspective on the application.
Try to keep this section (relatively) brief as it is used to generate changelogs.
If you need to provide additional details, you can do so below the cutoff.

PRs with no user-facing changes should leave this blank or write "N/A" to be omitted from auto-generated changelogs.
-->

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->
None, unless they are inspecting web requests.
## Why am I making these changes?
I believe having a bit more information about client version for requests sent to the server may be useful for identifying outdated client. We can later use this to have the server respond differently based on the client's reported game version.

## What are the changes from a developer perspective?
Add `PKR-Client-Version` to headers in all requests sent by adding it to `ApiBase`'s `doFetch` method.

## Screenshots/Videos
<!--
If you are changing anything visual (UI/UX, locales changes, etc.), please include screenshot(s) and/or video(s) showing the changes within collapsible blocks, like below:

<details><summary>Before</summary>

[before screenshot here]

</details>
<details><summary>After</summary>

[after screenshot here]

</details>
-->

## How to test the changes?
Needs rogueserver to test as running locally won't send any api requests. But if you want to, just run rogueserver and inspect headers via network panel. Should see the new header.

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [ ] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - ~~[ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)~~