### PR TITLE
fix: change [Alola] Raichu starter to Pichu

### DIFF
--- a/src/data/balance/species/generation-01.ts
+++ b/src/data/balance/species/generation-01.ts
@@ -2796,7 +2796,7 @@ export function initGenerationOne(): SpeciesDataMapConfig {
         }),
       ],
     }),
-    starter: SpeciesId.PIKACHU, // TODO: Check if this can be changed to Pichu without problems
+    starter: SpeciesId.PICHU,
     evolutions: [],
     formChanges: [
       new SpeciesFormChange({

--- a/src/data/balance/species/generation-07.ts
+++ b/src/data/balance/species/generation-07.ts
@@ -10566,7 +10566,7 @@ export function initGenerationSeven(): SpeciesDataMapConfig {
       malePercent: 50,
       genderDiffs: false,
     }),
-    starter: SpeciesId.PIKACHU,
+    starter: SpeciesId.PICHU,
     evolutions: [],
     passives: AbilityId.TRANSISTOR,
     levelMoves: [


### PR DESCRIPTION
<!--
Thank you for contributing to PokéRogue!
Open-source contributions like yours help keep this project going.

Note that these comment blocks are purely informative and can be removed once you're done reading them.
-->

<!--
Make sure your title matches the https://www.conventionalcommits.org/en/v1.0.0/ format.
Try to keep the title under 72 characters, as GitHub cuts off commit titles longer than this length.

See https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request
for more information on the allowed scopes and prefixes.

Example:
fix(move): Future Sight no longer crashes
^   ^      ^
|   |      |__ Subject
|   |_________ Scope (optional)
|_____________ Prefix
-->

## What are the changes the user will see?

raichu will show pichu candy and not show its passive being buyable when pichu already has it

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

bug report

## What are the changes from a developer perspective?

just changed the 2 starters

## Screenshots/Videos
<details><summary>Before</summary>

<img width="2880" height="2160" alt="image" src="https://github.com/user-attachments/assets/ade75eaf-6dd5-43ec-948a-4987397e1a9b" />

</details>
<details><summary>After</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9221459d-1c57-4cbe-b4be-ed7f5348f191" />

</details>


## How to test the changes?

check pokedex

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [x] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

