### PR TITLE
fix(item): Learned but forgotten TMs should not appear in TM pool 

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -5867,7 +5867,7 @@ export class PlayerPokemon extends Pokemon {
    * Get all TMs compatible with this Pokémon. Includes TMs from its fused species.
    * @returns An array of all compatible TMs
    */
-  getCompatibleTms(excludeKnown = false, excludeLevelUp = false): MoveId[] {
+  getCompatibleTms(excludeKnown = false, excludeLevelUp = false, excludeUsedTMs = false): MoveId[] {
     const tms = new Set(this.species.getTms(this.getFormKey()));
     if (this.fusionSpecies) {
       this.fusionSpecies.getTms(this.getFusionFormKey() ?? undefined).forEach(tm => tms.add(tm));
@@ -5877,6 +5877,9 @@ export class PlayerPokemon extends Pokemon {
     }
     if (excludeLevelUp) {
       this.getLevelMoves(undefined, true, false, true).forEach(lm => tms.delete(lm[1]));
+    }
+    if (excludeUsedTMs) {
+      this.usedTMs?.forEach(moveId => tms.delete(moveId));
     }
 
     return Array.from(tms);

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1503,7 +1503,7 @@ class TmModifierTypeGenerator extends ModifierTypeGenerator {
       if (pregenArgs && pregenArgs.length === 1 && pregenArgs[0] in MoveId) {
         return new TmModifierType(pregenArgs[0] as MoveId);
       }
-      const partyMemberCompatibleTms = party.map(p => (p as PlayerPokemon).getCompatibleTms(true, true));
+      const partyMemberCompatibleTms = party.map(p => (p as PlayerPokemon).getCompatibleTms(true, true, true));
       const tierUniqueCompatibleTms = partyMemberCompatibleTms
         .flat()
         .filter(tm => tmPoolTiers[tm] === tier)

--- a/src/phases/learn-move-phase.ts
+++ b/src/phases/learn-move-phase.ts
@@ -205,7 +205,9 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
       if (!pokemon.usedTMs) {
         pokemon.usedTMs = [];
       }
-      pokemon.usedTMs.push(this.moveId);
+      if (!pokemon.usedTMs.includes(this.moveId)) {
+        pokemon.usedTMs.push(this.moveId);
+      }
       globalScene.phaseManager.tryRemovePhase("SelectModifierPhase");
     } else if (this.learnMoveType === LearnMoveType.MEMORY) {
       if (this.cost === -1) {

--- a/test/tests/pokemon/pokemon.test.ts
+++ b/test/tests/pokemon/pokemon.test.ts
@@ -76,6 +76,26 @@ describe("Spec - Pokemon", () => {
     expect(fanRotom.isTmCompatible(MoveId.AIR_SLASH)).toBe(true);
   });
 
+  it("should exclude previously-taught TMs from getCompatibleTms when excludeUsedTMs is set, without affecting other party members", async () => {
+    await game.classicMode.runToSummon(SpeciesId.BULBASAUR, SpeciesId.BULBASAUR);
+
+    const [bulbasaurA, bulbasaurB] = game.scene.getPlayerParty();
+
+    const compatibleTms = bulbasaurA.getCompatibleTms(true, true);
+    expect(compatibleTms.length).toBeGreaterThan(0);
+    const usedTm = compatibleTms[0];
+
+    bulbasaurA.usedTMs = [usedTm];
+
+    // The used TM should no longer show up as a compatible/spawnable TM for bulbasaurA
+    expect(bulbasaurA.getCompatibleTms(true, true, true)).not.toContain(usedTm);
+    // still should show up if excludeUsedTMs isn't set
+    expect(bulbasaurA.getCompatibleTms(true, true)).toContain(usedTm);
+
+    // Pokeon who hasn't been taught this TM should still have it available
+    expect(bulbasaurB.getCompatibleTms(true, true, true)).toContain(usedTm);
+  });
+
   describe("Get correct fusion type", () => {
     beforeEach(async () => {
       game.override.enemySpecies(SpeciesId.ZUBAT).enableStarterFusion();


### PR DESCRIPTION
## What are the changes the user will see?
Learned but forgotten TMs will not spawn unless other conditions are met

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

When rolling a TM, the user will no longer be given a TM reward of a learned but forgotten TM, unless another Pokemon in the party, who has not learned it, is also valid for the TM.


## Why am I making these changes?
Requested by @Blitz425 in #7451 
While the name of the issue calls this a feature, I am labeling this a fix as the comments indicate it is a bug. 

## What are the changes from a developer perspective?
 - `getCompatibleTms` has a 3rd optional (default `false`) param for excluding used TMs: `excludeUsedTMs`
 - Adds a dupe guard to usedTMs, since one didn't exist before. This could still happen if a Pokémon legally learns a TM that another Pokémon had already learned and then forgotten. 
 
## Screenshots/Videos
N/A

## How to test the changes?
Unsure how one can test this using overrides, however I had included a new test unit. 

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [x] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] ~I have provided screenshots/videos of the changes (if applicable)~
  - [ ] ~I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)~

Are there any localization additions or changes? If so:
- [ ] ~I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository~
  - ~If so, include a link to the PR here: _____~
- [ ] ~I have contacted the Translation Team on Discord for proofreading/translation (contacting the devs in #pokerogue-dev is sufficient, we can then forward the PR to the TL team)~

Does this require any additions or changes to in-game assets? If so:
- [ ] ~I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository~
  - ~If so, include a link to the PR here: _____~
