### PR TITLE
fix(ui)!: the egg compensation alert won't appear during a tutorial

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pokemon-rogue-battle",
   "private": true,
-  "version": "1.12.0.3",
+  "version": "1.12.0.4",
   "type": "module",
   "scripts": {
     "start:prod": "vite --mode production",

--- a/src/system/version-migration/versions/v1_12_0_3.ts
+++ b/src/system/version-migration/versions/v1_12_0_3.ts
@@ -11,6 +11,7 @@ import { EggData } from "#system/egg-data";
 import { VoucherType } from "#system/voucher";
 import type { DexData, DexEntry } from "#types/dex-data";
 import type { SystemSaveMigrator } from "#types/save-migrators";
+import type { AwaitableUiHandler } from "#ui/awaitable-ui-handler";
 import { fixedInt, randSeedItem } from "#utils/common";
 import i18next from "i18next";
 
@@ -90,11 +91,13 @@ function pullEggs(pullCount: number, ownedStarters: SpeciesId[]): EggData[] {
   }
 
   globalScene.time.delayedCall(fixedInt(2000), async () => {
-    await globalScene.ui.setOverlayMode(
-      UiMode.ALERT_MODAL,
-      i18next.t("migrators:eggCompensation", { eggCount: eggs.length }),
-      5000,
-    );
+    if (!globalScene.ui.getHandler<AwaitableUiHandler>().tutorialActive) {
+      await globalScene.ui.setOverlayMode(
+        UiMode.ALERT_MODAL,
+        i18next.t("migrators:eggCompensation", { eggCount: eggs.length }),
+        15000,
+      );
+    }
   });
 
   return eggs;


### PR DESCRIPTION
## What are the changes the user will see?
The alert notifying users of the egg compensation will not appear if a tutorial is active, to prevent a softlock that would occur if both were active at the same time.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Bug report.

## What are the changes from a developer perspective?
Added an `if` check to see if the tutorial is active, and to not trigger the alert if it is.

## How to test the changes?
Import a save that would trigger the egg compensation, then enable the following override and reload the game:
```ts
const overrides = {
  BYPASS_TUTORIAL_SKIP_OVERRIDE: true,
} satisfies Partial<InstanceType<OverridesType>>;
```
The alert should not appear after reloading when the tutorial is active.

## Checklist
- The PR content is correctly formatted:
  - ~[ ] **I'm using `beta` as my base branch**~
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually