### PR TITLE
fix(ui): set the egg compensation alert delay back to 5 seconds

### DIFF
--- a/src/system/version-migration/versions/v1_12_0_3.ts
+++ b/src/system/version-migration/versions/v1_12_0_3.ts
@@ -95,7 +95,7 @@ function pullEggs(pullCount: number, ownedStarters: SpeciesId[]): EggData[] {
       await globalScene.ui.setOverlayMode(
         UiMode.ALERT_MODAL,
         i18next.t("migrators:eggCompensation", { eggCount: eggs.length }),
-        15000,
+        5000,
       );
     }
   });


### PR DESCRIPTION
## What are the changes the user will see?
The egg compensation alert will allow user input after 5 seconds again, as intended.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Fixing a mistake from the emergency hotfix to prevent users being softlocked by the alert.

## What are the changes from a developer perspective?
Changed delay from 15s back to 5s.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR