### PR TITLE
fix: more item rework fixes 

### DIFF
--- a/src/@types/rewards.ts
+++ b/src/@types/rewards.ts
@@ -1,5 +1,6 @@
 import type { HeldItemId } from "#enums/held-item-id";
 import type { RewardId } from "#enums/reward-id";
+import type { RarityTier } from "#enums/reward-tier";
 import type { TrainerItemId } from "#enums/trainer-item-id";
 import type { Pokemon } from "#field/pokemon";
 import type { AllRewardsType } from "#items/all-rewards";
@@ -39,12 +40,12 @@ export type RewardPoolEntry = {
 };
 
 export type RewardPool = {
-  [tier: string]: RewardPoolEntry[];
+  [tier in RarityTier]: RewardPoolEntry[];
 };
 
-export interface RewardPoolWeights {
-  [tier: string]: number[];
-}
+export type RewardPoolWeights = {
+  [tier in RarityTier]: number[];
+};
 
 export type SilentReward =
   | TrainerItemId

--- a/src/@types/type-helpers.ts
+++ b/src/@types/type-helpers.ts
@@ -24,9 +24,11 @@ export type { Writable as Mutable } from "type-fest";
  *
  * @typeParam T - The type to match exactly
  */
-export type Exact<T> = {
-  [K in keyof T]: T[K];
-};
+export type Exact<T> = T extends object
+  ? {
+      [K in keyof T]: T[K];
+    }
+  : T;
 
 /**
  * Type hint that indicates that the type is intended to be closed to a specific shape.

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -94,7 +94,7 @@ import { hasExpSprite } from "#sprites/sprite-utils";
 import type { Variant } from "#sprites/variant";
 import { clearVariantData, variantData } from "#sprites/variant";
 import type { Achv } from "#system/achv";
-import { achvs, HeldItemAchv, MoneyAchv } from "#system/achv";
+import { achvs, MoneyAchv } from "#system/achv";
 import { GameData } from "#system/game-data";
 import { initGameSpeed } from "#system/game-speed";
 import type { PokemonData } from "#system/pokemon-data";
@@ -2417,23 +2417,6 @@ export class BattleScene extends SceneBase {
 
     reward.apply(params);
     return true;
-  }
-
-  // TODO: This is completely unused
-  addHeldItem(heldItemId: HeldItemId, pokemon: Pokemon, amount = 1, playSound?: boolean, ignoreUpdate?: boolean) {
-    pokemon.heldItemManager.add(heldItemId, amount);
-    if (!ignoreUpdate) {
-      this.updateItems(pokemon.isPlayer());
-    }
-    // TODO: Held items don't have sound names...?
-    const soundName = allHeldItems[heldItemId].soundName;
-    if (playSound) {
-      audioManager.playSound(soundName);
-    }
-
-    if (pokemon.isPlayer()) {
-      this.validateAchvs(HeldItemAchv, pokemon);
-    }
   }
 
   /**

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -82,7 +82,7 @@ import { Trainer } from "#field/trainer";
 import { applyTrainerItems } from "#items/all-trainer-items";
 import type { EnemyAttackStatusEffectChanceTrainerItemAttr } from "#items/enemy-tokens";
 import { assignEnemyHeldItemsForWave, assignItemsFromConfiguration } from "#items/held-item-pool";
-import type { MatchExact, Reward } from "#items/reward";
+import type { Reward } from "#items/reward";
 import type { TrainerItem } from "#items/trainer-item";
 import { TrainerItemManager } from "#items/trainer-item-manager";
 import { getNewTrainerItemFromPool } from "#items/trainer-item-pool";
@@ -119,6 +119,7 @@ import {
   type TrainerItemSaveData,
 } from "#types/trainer-item-data-types";
 import type { TrainerItemEffectParamMap } from "#types/trainer-item-parameter";
+import type { Exact } from "#types/type-helpers";
 import { AbilityBar } from "#ui/ability-bar";
 import { ArenaFlyout } from "#ui/arena-flyout";
 import { CandyBar } from "#ui/candy-bar";
@@ -153,6 +154,7 @@ import { decodeNickname, getPokemonSpecies } from "#utils/pokemon-utils";
 import { capitalizeFirstLetterOnly } from "#utils/strings";
 import i18next from "i18next";
 import Phaser from "phaser";
+
 export type PokeballCounts = Record<Exclude<PokeballType, PokeballType.LUXURY_BALL>, number>;
 
 export interface InfoToggle {
@@ -2401,11 +2403,8 @@ export class BattleScene extends SceneBase {
     applyTrainerItems(effect, this.trainerItems, params);
   }
 
-  applyReward<T extends Reward>(
-    reward: T,
-    params: MatchExact<Parameters<T["apply"]>[0]>,
-    playSound?: boolean,
-  ): boolean {
+  // TODO: Move this outside of here?
+  applyReward<T extends Reward>(reward: T, params: Exact<Parameters<T["apply"]>[0]>, playSound?: boolean): boolean {
     const { soundName } = reward;
 
     if (playSound) {

--- a/src/items/all-rewards.ts
+++ b/src/items/all-rewards.ts
@@ -27,7 +27,7 @@ import { TmRewardGenerator } from "./rewards/tm";
 import { LapsingTrainerItemReward, TempStatStageBoosterRewardGenerator } from "./rewards/trainer-item-reward";
 import { AddVoucherReward } from "./rewards/voucher";
 
-// TODO: Move to `reward-utils.ts` and remove export
+// TODO: Merge with `reward-utils.ts` and possibly remove export
 export const allRewards = {
   [RewardId.NONE]: new EmptyReward(),
 
@@ -177,8 +177,6 @@ export const allRewards = {
   [RewardId.TEMP_STAT_STAGE_BOOSTER]: new TempStatStageBoosterRewardGenerator(),
 
   [RewardId.DIRE_HIT]: new LapsingTrainerItemReward(TrainerItemId.DIRE_HIT),
-} as const satisfies {
-  [k in RewardId]: Reward | RewardGenerator;
-};
+} as const satisfies Readonly<Record<RewardId, Reward | RewardGenerator>>;
 
 export type AllRewardsType = typeof allRewards;

--- a/src/items/item-utility.ts
+++ b/src/items/item-utility.ts
@@ -1,32 +1,7 @@
 import { globalScene } from "#app/global-scene";
-import { allHeldItems, allTrainerItems } from "#data/data-lists";
 import { HeldItemCategoryId, type HeldItemId, isItemInCategory } from "#enums/held-item-id";
-import type { TrainerItemId } from "#enums/trainer-item-id";
 import type { Pokemon } from "#field/pokemon";
 import type { PokemonItemMap } from "#types/held-item-data-types";
-
-export const trainerItemSortFunc = (a: TrainerItemId, b: TrainerItemId): number => {
-  const itemNameMatch = allTrainerItems[a].name.localeCompare(allTrainerItems[b].name);
-  const itemIdMatch = a - b;
-
-  if (itemIdMatch === 0) {
-    return itemNameMatch;
-    //Finally sort by item name
-  }
-  return itemIdMatch;
-};
-
-//TODO: revisit this function
-export const heldItemSortFunc = (a: HeldItemId, b: HeldItemId): number => {
-  const itemNameMatch = allHeldItems[a].name.localeCompare(allHeldItems[b].name);
-  const itemIdMatch = a - b;
-
-  if (itemIdMatch === 0) {
-    return itemNameMatch;
-    //Finally sort by item name
-  }
-  return itemIdMatch;
-};
 
 // Iterate over the party until an item is successfully given
 export function assignItemToFirstFreePokemon(item: HeldItemId, party: Pokemon[]): void {

--- a/src/items/reward-pools.ts
+++ b/src/items/reward-pools.ts
@@ -5,5 +5,5 @@
 
 import type { RewardPool, RewardPoolWeights } from "#types/rewards";
 
-export const rewardPool: RewardPool = {};
-export const rewardPoolWeights: RewardPoolWeights = {};
+export const rewardPool: RewardPool = {} as RewardPool;
+export const rewardPoolWeights: RewardPoolWeights = {} as RewardPoolWeights;

--- a/src/items/reward-utils.ts
+++ b/src/items/reward-utils.ts
@@ -33,7 +33,6 @@ export function isRememberMoveReward(reward: Reward): reward is RememberMoveRewa
  * @param tierOverride - An optional {@linkcode RarityTier} to override the option's rarity
  * @param upgradeCount - The number of tier upgrades having occurred; default `0`
  * @returns The generated {@linkcode RewardOption}, or `null` if no reward could be generated
- * @todo Remove `null` from signature eventually
  */
 export function generateRewardOptionFromId<T extends RewardPoolId>(
   specs: RewardSpecs<T>,
@@ -59,6 +58,7 @@ export function generateRewardOptionFromId<T extends RewardPoolId>(
 
   const tempReward = allRewards[id] as Reward | RewardGenerator;
   let reward = tempReward instanceof RewardGenerator ? tempReward.generateReward(pregenArgs) : tempReward;
+  // TODO: handle reward generator incompatibilities more gracefully than this
   if (!reward) {
     reward = new EmptyReward();
   }

--- a/src/items/reward.ts
+++ b/src/items/reward.ts
@@ -51,25 +51,20 @@ import i18next from "i18next";
  * and RewardOption, which is displayed during the select reward phase at the end of each encounter.
 */
 
-/**
- * Type helper to exactly match objects and nothing else.
- * @todo merge with `Exact` later on
- */
-export type MatchExact<T> = T extends object ? Exact<T> : T;
-
 export abstract class Reward {
   // TODO: This is set inconsistently across classes and is only really used for category checks
   public id: RewardId;
   private readonly localeKey: string;
-  private readonly iconImage: string;
+  public readonly iconName: string;
   public group: string; // TODO: Make a union type of all groups
   public readonly soundName: string;
   public tier: RarityTier;
 
   // TODO: These bangs are emphatically NOT correct
-  constructor(localeKey: string | null, iconImage: string | null, group?: string, soundName = "se/restore") {
+  // TODO: Move `id` into the constructor instead of assigning it in subclasses
+  constructor(localeKey: string | null, iconName: string | null, group?: string, soundName = "se/restore") {
     this.localeKey = localeKey!;
-    this.iconImage = iconImage!;
+    this.iconName = iconName!;
     this.group = group!;
     this.soundName = soundName;
   }
@@ -82,29 +77,30 @@ export abstract class Reward {
     return i18next.t(`${this.localeKey}.description`);
   }
 
-  // TODO: why does this exist if the underlying property is still public
-  public get iconName(): string {
-    return this.iconImage;
-  }
-
   // TODO: Should this be abstract?
   /**
    * Check whether this reward should be applied.
+   * @param params - The parameters used by this reward
+   * @returns Whether the reward should be allowed to apply its effects.
    */
-  // TODO: This is erroring on stuff with `undefined`
-  shouldApply(_params: MatchExact<Parameters<this["apply"]>[0]>): boolean {
+  // biome-ignore lint/correctness/noUnusedFunctionParameters: psuedo-abstract hook method
+  shouldApply(params: Exact<Parameters<this["apply"]>[0]>): boolean {
     return true;
   }
 
-  /** Apply this Reward's effects. */
-  // TODO: Remove `boolean` return from all superclasses' type signatures
-  abstract apply(_params?: unknown): void;
+  /**
+   * Apply this Reward's effects.
+   * @param params - The parameters used by this reward
+   */
+  // TODO: Remove `boolean` return from all subclasses' type signatures
+  abstract apply(params?: unknown): void;
 }
 
 /**
  * A {@linkcode RewardGenerator} represents a dynamic generator for a given type of reward.
  * These can be customized by lieu of {@linkcode RewardGenerator.generateReward | RewardGenerator} to alter the generation result.
  */
+// TODO: Make generic over the type of reward generated
 export abstract class RewardGenerator {
   /**
    * Dynamically generate a new reward.
@@ -122,12 +118,12 @@ export abstract class PokemonReward extends Reward {
 
   constructor(
     localeKey: string,
-    iconImage: string,
+    iconName: string,
     selectFilter?: PokemonSelectFilter,
     group?: string,
     soundName?: string,
   ) {
-    super(localeKey, iconImage, group, soundName);
+    super(localeKey, iconName, group, soundName);
     this.selectFilter = selectFilter;
   }
 
@@ -139,13 +135,13 @@ export abstract class PokemonMoveReward extends PokemonReward {
 
   constructor(
     localeKey: string,
-    iconImage: string,
+    iconName: string,
     id: RewardId,
     selectFilter?: PokemonSelectFilter,
     moveSelectFilter?: PokemonMoveSelectFilter,
     group?: string,
   ) {
-    super(localeKey, iconImage, selectFilter, group);
+    super(localeKey, iconName, selectFilter, group);
     this.moveSelectFilter = moveSelectFilter;
     this.id = id;
   }

--- a/src/items/rewards/evolution-item.ts
+++ b/src/items/rewards/evolution-item.ts
@@ -1,5 +1,6 @@
 import { globalScene } from "#app/global-scene";
-import { EvolutionItem, FusionSpeciesFormEvolution, pokemonEvolutions } from "#balance/pokemon-evolutions";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
+import { EvolutionItem, FusionSpeciesFormEvolution } from "#balance/pokemon-evolutions";
 import { SpeciesFormKey } from "#enums/species-form-key";
 import { SpeciesId } from "#enums/species-id";
 import type { PlayerPokemon } from "#field/pokemon";
@@ -14,9 +15,10 @@ export class EvolutionItemReward extends PokemonReward {
   constructor(evolutionItem: EvolutionItem) {
     super("", EvolutionItem[evolutionItem].toLowerCase(), (pokemon: PlayerPokemon) => {
       if (
-        Object.hasOwn(pokemonEvolutions, pokemon.species.speciesId)
-        && pokemonEvolutions[pokemon.species.speciesId].filter(e => e.validate(pokemon, false, this.evolutionItem))
-          .length > 0
+        speciesDataRegistry.hasEvolutions(pokemon.species.speciesId)
+        && speciesDataRegistry
+          .getEvolutions(pokemon.species.speciesId)
+          .filter(e => e.validate(pokemon, false, this.evolutionItem)).length > 0
         && pokemon.getFormKey() !== SpeciesFormKey.GIGANTAMAX
       ) {
         return null;
@@ -24,9 +26,10 @@ export class EvolutionItemReward extends PokemonReward {
       if (
         pokemon.isFusion()
         && pokemon.fusionSpecies
-        && Object.hasOwn(pokemonEvolutions, pokemon.fusionSpecies.speciesId)
-        && pokemonEvolutions[pokemon.fusionSpecies.speciesId].filter(e => e.validate(pokemon, true, this.evolutionItem))
-          .length > 0
+        && speciesDataRegistry.hasEvolutions(pokemon.fusionSpecies.speciesId)
+        && speciesDataRegistry
+          .getEvolutions(pokemon.fusionSpecies.speciesId)
+          .filter(e => e.validate(pokemon, true, this.evolutionItem)).length > 0
         && pokemon.getFusionFormKey() !== SpeciesFormKey.GIGANTAMAX
       ) {
         return null;
@@ -52,16 +55,16 @@ export class EvolutionItemReward extends PokemonReward {
    * @returns `true` if the evolution was successful
    */
   apply({ pokemon }: PokemonRewardParams): boolean {
-    let matchingEvolution = Object.hasOwn(pokemonEvolutions, pokemon.species.speciesId)
-      ? pokemonEvolutions[pokemon.species.speciesId].find(
-          e => e.evoItem === this.evolutionItem && e.validate(pokemon, false, e.item!),
-        )
+    let matchingEvolution = speciesDataRegistry.hasEvolutions(pokemon.species.speciesId)
+      ? speciesDataRegistry
+          .getEvolutions(pokemon.species.speciesId)
+          .find(e => e.evoItem === this.evolutionItem && e.validate(pokemon, false, e.item!))
       : null;
 
     if (!matchingEvolution && pokemon.isFusion()) {
-      matchingEvolution = pokemonEvolutions[pokemon.fusionSpecies!.speciesId].find(
-        e => e.evoItem === this.evolutionItem && e.validate(pokemon, true, e.item!),
-      );
+      matchingEvolution = speciesDataRegistry
+        .getEvolutions(pokemon.fusionSpecies!.speciesId)
+        .find(e => e.evoItem === this.evolutionItem && e.validate(pokemon, true, e.item!));
       if (matchingEvolution) {
         matchingEvolution = new FusionSpeciesFormEvolution(pokemon.species.speciesId, matchingEvolution);
       }
@@ -90,11 +93,12 @@ export class EvolutionItemRewardGenerator extends RewardGenerator {
 
     const party = globalScene.getPlayerParty();
 
+    // TODO: refactor once species code isn't a horrible burning mess
     const evolutionItemPool = [
       party
         .filter(
           p =>
-            Object.hasOwn(pokemonEvolutions, p.species.speciesId)
+            speciesDataRegistry.hasEvolutions(p.species.speciesId)
             && (!p.pauseEvolutions
               || p.species.speciesId === SpeciesId.SLOWPOKE
               || p.species.speciesId === SpeciesId.EEVEE
@@ -102,7 +106,7 @@ export class EvolutionItemRewardGenerator extends RewardGenerator {
               || p.species.speciesId === SpeciesId.SNORUNT),
         )
         .flatMap(p => {
-          const evolutions = pokemonEvolutions[p.species.speciesId];
+          const evolutions = speciesDataRegistry.getEvolutions(p.species.speciesId);
           return evolutions.filter(e => e.isValidItemEvolution(p));
         }),
       party
@@ -110,7 +114,7 @@ export class EvolutionItemRewardGenerator extends RewardGenerator {
           p =>
             p.isFusion()
             && p.fusionSpecies
-            && Object.hasOwn(pokemonEvolutions, p.fusionSpecies.speciesId)
+            && speciesDataRegistry.hasEvolutions(p.fusionSpecies.speciesId)
             && (!p.pauseEvolutions
               || p.fusionSpecies.speciesId === SpeciesId.SLOWPOKE
               || p.fusionSpecies.speciesId === SpeciesId.EEVEE
@@ -118,7 +122,7 @@ export class EvolutionItemRewardGenerator extends RewardGenerator {
               || p.fusionSpecies.speciesId === SpeciesId.SNORUNT),
         )
         .flatMap(p => {
-          const evolutions = pokemonEvolutions[p.fusionSpecies!.speciesId];
+          const evolutions = speciesDataRegistry.getEvolutions(p.fusionSpecies!.speciesId);
           return evolutions.filter(e => e.isValidItemEvolution(p, true));
         }),
     ]

--- a/src/ui/handlers/run-info-ui-handler.ts
+++ b/src/ui/handlers/run-info-ui-handler.ts
@@ -15,7 +15,6 @@ import type { SpeciesId } from "#enums/species-id";
 import { TextStyle } from "#enums/text-style";
 import { TrainerVariant } from "#enums/trainer-variant";
 import { UiMode } from "#enums/ui-mode";
-import { heldItemSortFunc } from "#items/item-utility";
 import { getVariantTint } from "#sprites/variant";
 import type { PokemonData } from "#system/pokemon-data";
 import { SettingKeyboard } from "#system/settings-keyboard";
@@ -887,7 +886,10 @@ export class RunInfoUiHandler extends UiHandler {
         this.runInfo.gameMode === GameModes.SPLICED_ENDLESS || this.runInfo.gameMode === GameModes.ENDLESS ? 0.25 : 0.5;
       const heldItemsContainer = globalScene.add.container(-82, 2);
       let row = 0;
-      for (const [index, item] of pokemon.heldItemManager.getItems().sort(heldItemSortFunc).entries()) {
+      for (const [index, item] of pokemon.heldItemManager
+        .getItems()
+        .sort((a, b) => a - b)
+        .entries()) {
         if (index > 36) {
           const overflowIcon = addTextObject(182, 4, "+", TextStyle.WINDOW);
           heldItemsContainer.add(overflowIcon);

--- a/src/ui/handlers/summary-ui-handler.ts
+++ b/src/ui/handlers/summary-ui-handler.ts
@@ -20,7 +20,6 @@ import { StatusEffect } from "#enums/status-effect";
 import { TextStyle } from "#enums/text-style";
 import { UiMode } from "#enums/ui-mode";
 import type { PlayerPokemon } from "#field/pokemon";
-import { heldItemSortFunc } from "#items/item-utility";
 import type { Move } from "#moves/move";
 import type { PokemonMove } from "#moves/pokemon-move";
 import type { Variant } from "#sprites/variant";
@@ -1111,7 +1110,7 @@ export class SummaryUiHandler extends UiHandler {
         });
         this.ivContainer.setVisible(false);
 
-        const heldItems = this.pokemon?.getHeldItems().sort(heldItemSortFunc);
+        const heldItems = this.pokemon?.getHeldItems().sort((a, b) => a - b);
 
         heldItems?.forEach((itemKey, i) => {
           const heldItem = allHeldItems[itemKey];

--- a/src/ui/item-bar-ui.ts
+++ b/src/ui/item-bar-ui.ts
@@ -3,7 +3,6 @@ import { allHeldItems, allTrainerItems } from "#data/data-lists";
 import type { HeldItemId } from "#enums/held-item-id";
 import type { TrainerItemId } from "#enums/trainer-item-id";
 import type { Pokemon } from "#field/pokemon";
-import { heldItemSortFunc, trainerItemSortFunc } from "#items/item-utility";
 import type { TrainerItemManager } from "#items/trainer-item-manager";
 
 const iconOverflowIndex = 24;
@@ -28,10 +27,10 @@ export class ItemBar extends Phaser.GameObjects.Container {
   updateItems(trainerItems: TrainerItemManager, pokemonA?: Pokemon, pokemonB?: Pokemon) {
     this.removeAll(true);
 
-    const sortedTrainerItems = trainerItems.getItems().sort(trainerItemSortFunc);
+    const sortedTrainerItems = trainerItems.getItems().sort((a, b) => a - b);
 
-    const heldItemsA = pokemonA ? pokemonA.getHeldItems().sort(heldItemSortFunc) : [];
-    const heldItemsB = pokemonB ? pokemonB.getHeldItems().sort(heldItemSortFunc) : [];
+    const heldItemsA = pokemonA ? pokemonA.getHeldItems().sort((a, b) => a - b) : [];
+    const heldItemsB = pokemonB ? pokemonB.getHeldItems().sort((a, b) => a - b) : [];
 
     this.totalVisibleLength = sortedTrainerItems.length + heldItemsA.length + heldItemsB.length;
 


### PR DESCRIPTION
- **Held item refactor (#5656)**
- **Add `as const` to enum-objects in `held-item-id.ts`**
- **Fix `isItemInRequested`**
- **Add `as const` in `trainer-item-id.ts`**
- **Rename `HELD_ITEM_EFFECT` enum-object to `HeldItemEffect`**
- **Normalize naming**
- **Add a couple of `TODO`s**
- **Removed default value from maxStackCount**
- **Fixed some ME tests**
- **Auxiliary functions to fix type complaints in item managers**
- **HeldItemManager's .hasItem() now also works on categories**
- **Fixed fiery fallout encounter and relative test by making sure that isCategoryId works properly**
- **Fixed bug-type-superfan encounter; split up HoldingItemRequirement from HeldItemRequirement**
- **Partially fixed absolute avarice, fixed HeldItemRequirement to actually count the items**
- **More partial test fixes**
- **Partially fixed delibirdy test**
- **Renamed modifier-se-ect-ui-handler to reward-select-ui-handler**
- **Renamed various ModifierRewardPhase classes**
- **Rename SelectModifierPhase to SelectRewardPhase**
- **Some minor fixes**
- **Cleaned up more tests**
- **Apply Biome**
- **Create and apply `#items` import alias**
- **Fix some imports**
- **Remove relative imports**
- **Cleaned up more files**
- **formChangeItemName function**
- **Add some type specifications so biome is happy**
- **Added test override for pokeballs**
- **Moved getPartyBerries() utility function**
- **Reworked getPartyBerries function, fixed harvest test**
- **More minor fixes**
- **Minor lint**
- **Add parameter destructuring (#6092)**
- **Moved held item manager to item folder, some name changes**
- **Replace remaining Modifiers with Rewards (#6091)**
- **Merged `upstream/beta` into Modifier rework (#6206)**
- **Fixed `objectValues` issues**
- **[Modifier Refactor] Modernize reward pool (#6208)**
- **Removed unused leftover `getPregenArgs` methods**
- **Reward type safety (#6211)**
- **Minor nits and todos**
- **Removing some mentions of allRewards**
- **NoneReward called with correct arguments**
- **`NoneReward` constructed without any parameters; util function to generate reward options never returns `null`**
- **Fixed phases which award rewards without going through the reward selection screen**
- **Fixed inputs of `restorePokemonHp`**
- **Fixed various minor issues**
- **Updated `TextStyle` usage in trainer-item.ts**
- **Using `SilentReward` for fixed event rewards**
- **Remove leftover unused functions from merge; transfer/discard button**
- **Removed most uses of `allRewards` from across the code**
- **Added @ts-expect-error to data-lists.ts**
- **Fixed more conflicts from merge**
- **Fixed errors in data/challenge.ts, but will need more fixes to work with new rewards**
- **Added test utils for held item tests (#6233)**
- **[Modifier Rework] Incorporated Form Change items as part of HeldItemId (#6282)**
- **Fixed camel case in tera reward**
- **Splitting form change items (see #6325) to a separate file; renaming `FormChangeItem` to `FormChangeItemId`**
- **[Item] Held item implementation rework (#6345)**
- **description and iconName with getter fields in rewards**
- **Allow recursive held item pools**
- **[Modifier rework] Held item manager uses a map (#6456)**
- **Form change descriptions are getters**
- **Trainer configuration can specify held items**
- **Removed some log messages**
- **Fixed type weirdness in HeldItem & co.**
- **Reverted changes to `HeldItemBase`**
- **Revised typing in `allHeldItems` so it works**
- **Fixed various errors, moved some files for trainer items**
- **Updated names of held items which modify stats**
- **Moved various files**
- **Run biome**
- **Fixed various issues after merge**
- **Changed various imports**
- **Fixed wrong folder name**
- **Fixed up held item parameter typing**
- **Fixed assorted type errors**
- **Added item boilerplate + renamed stuff**
- **Fixed boilerplate**
- **Added strong typing on `allHeldItems`**
- **[Test] Fixed item test utils to use IDs rather than `HeldItem` instances**
- **Apply biome**
- **cleanup of item apply methods**
- **Cleanup stringifyEnumArray**
- **Remove modifier-type.ts**
- **Biome**
- **Fix various broken things**
- **Turned evo trackers into cosmetic items**
- **Removed leftover lines from merge**
- **Minor cleanups to held item manager code**
- **Converted various held item data types to interfaces (#6761)**
- **Slight cleanups to enemy item gen (#6770)**
- **Fix remaining linting errors + sync submodules**
- **Fix biome linting errors and other assorted issues**
- **Update typing on matcher + Fix trash to treasure test**
- **Fixed lingering `any` issues resulting from `HeldItemId.NONE` not being included in the output**
- **refactor: unify `HeldItemManager` and `TrainerItemManager` (#7080)**
- **fix submodules**
- **Re-add `initHeldItems()`**
- **Apply Biome, fix some test imports**
- **Move `src/data/items/` files to `src/items`**
- **Revert `lint/suspicious/noImportCycles` to "error"**
- **Put `item-test-utils.ts`/`reward-test-utils.ts` in `test/utils/`**
- **Fix some type errors**
- **Fix Biome errors, fix some type errors, fix some missing imports**
- **Fix some test stuff**
- **fix: Fix assorted errors (#7254)**
- **refactor: rework `HeldItem` into an attribute based system (#7273)**
- **Add todo comment to `src/enums/reward-tier.ts`**
- **docs: update doc comment for DataMap + remove TODO**
- **refactor: Rework trainer items to an attribute-like system (#7295)**
- **misc: remove unused helper types and clean up docs**
- **fix reviver seed tests**
- **Fix various type errors related to beta merge**
- **Remove `heldItemSortFunc`/`trainerItemSortFunc`**
- **Minor fixes for reward types**
- **fix type errors**
