### PR TITLE
fix: `BattleInfo#updateInfo` will early return if `active` is `false`

### DIFF
--- a/src/ui/battle-info/battle-info.ts
+++ b/src/ui/battle-info/battle-info.ts
@@ -566,7 +566,8 @@ export abstract class BattleInfo extends Phaser.GameObjects.Container {
   async updateInfo(pokemon: Pokemon, instant?: boolean): Promise<void> {
     let resolve: (r: void | PromiseLike<void>) => void = () => {};
     const promise = new Promise<void>(r => (resolve = r));
-    if (!globalScene) {
+
+    if (!globalScene || !this.active) {
       return resolve();
     }
 


### PR DESCRIPTION
## What are the changes the user will see?
Potentially fixes a crash that would occur upon biome transition in endless.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Attempts to fix #7433 

## What are the changes from a developer perspective?
Added a check to `BattleInfo#updateInfo` that causes it to early return if `this.active` is `false`.

## How to test the changes?
```ts
const overrides = {
  STARTING_WAVE_OVERRIDE: 46,
  STARTING_LEVEL_OVERRIDE: 200,
} satisfies Partial<InstanceType<OverridesType>>;
```
Start a new endless run with these overrides and transition to wave 51. Make sure "Pause on uncaught exceptions" is checked in the browser devtools (source tab). On beta, it should trigger, and on the PR branch it should not.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually