### PR TITLE
github: automatically apply labels to PRs

### DIFF
--- a/.github/scripts/apply-labels.mts
+++ b/.github/scripts/apply-labels.mts
@@ -1,0 +1,110 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Pagefault Games
+ * SPDX-FileContributor: NightKev <https://github.com/DayKev>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { getInput, info, setFailed } from "@actions/core";
+import { context, getOctokit } from "@actions/github";
+
+const PREFIX_LABEL_MAP = {
+  balance: "Game Balance",
+  dev: "Development",
+  docs: "Documentation",
+  feat: "Enhancement",
+  github: "GitHub",
+  i18n: "Localization",
+  misc: "Miscellaneous",
+  perf: "Performance",
+  refactor: "Refactor",
+  test: "Tests",
+} as const;
+
+const SCOPE_LABEL_MAP = {
+  ability: "Ability",
+  ai: "AI",
+  audio: "Audio",
+  battle: "Battle",
+  beta: "Beta",
+  biomes: "Biomes",
+  challenge: "Challenges",
+  encounter: "Mystery Encounter",
+  event: "Event",
+  graphics: "Sprite/Animation",
+  item: "Item",
+  move: "Move",
+  ui: "UI/UX",
+} as const;
+
+async function run(): Promise<void> {
+  try {
+    const authToken = getInput("github_token", { required: true });
+
+    const { eventName } = context;
+    if (eventName !== "pull_request") {
+      setFailed(`Invalid event: ${eventName}`);
+      return;
+    }
+    if (!context.payload.pull_request) {
+      setFailed("Error parsing pull request data!");
+      return;
+    }
+
+    const client = getOctokit(authToken);
+    const owner = context.payload.pull_request.base.user.login;
+    const repo = context.payload.pull_request.base.repo.name;
+    const pull_number = context.payload.pull_request.number;
+    const { data: pullRequest } = await client.rest.pulls.get({ owner, repo, pull_number });
+
+    const { title } = pullRequest;
+    info(`Pull Request title: "${title}"`);
+
+    const regex = /^([a-z0-9]+)(\([a-z]+\))?!?: .+/;
+    const regexResult = regex.exec(title);
+    if (!regexResult) {
+      setFailed(`Pull Request title "${title}" failed to match "Prefix(Scope): Subject" - unable to apply labels`);
+      return;
+    }
+
+    const prefix = regexResult[1];
+    const scope = regexResult[2]?.replace(/[()]/g, "") ?? "";
+
+    info(`Prefix: "${prefix}"`);
+    info(`Scope: "${scope}"`);
+
+    const labels: string[] = [];
+
+    if (prefix === "fix") {
+      let applyLabel = true;
+      for (const label of pullRequest.labels) {
+        if (["P0 Bug", "P1 Bug", "P2 Bug", "P3 Bug"].includes(label.name)) {
+          applyLabel = false;
+          info(`PR already has a bug label, skipping addition of "Triage" label`);
+          break;
+        }
+      }
+      if (applyLabel) {
+        labels.push("Triage");
+      }
+    } else if (prefix in PREFIX_LABEL_MAP) {
+      labels.push(PREFIX_LABEL_MAP[prefix as keyof typeof PREFIX_LABEL_MAP]);
+    }
+    if (scope in SCOPE_LABEL_MAP) {
+      labels.push(SCOPE_LABEL_MAP[scope as keyof typeof SCOPE_LABEL_MAP]);
+    }
+
+    if (labels.length === 0) {
+      info("No valid labels could be applied.");
+      return;
+    }
+
+    info(`Labels to be added: "${labels}"`);
+
+    await client.rest.issues.addLabels({ owner, repo, issue_number: pull_number, labels });
+  } catch (error) {
+    setFailed((error as Error).message);
+  }
+}
+
+await run();

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -1,0 +1,50 @@
+name: Label PRs
+on:
+  pull_request:
+    branches:
+      - main
+      - beta
+      - release
+      - "hotfix*"
+    types: [opened, edited, reopened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label-prs:
+    name: Label PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
+        with:
+          submodules: false
+          sparse-checkout: |
+            pnpm-lock.yaml
+            .nvmrc
+            .github/scripts/apply-labels.mts
+          sparse-checkout-cone-mode: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - name: Install Node.js dependencies
+        run: pnpm add @actions/core @actions/github
+
+      - name: Apply Labels
+        run: node .github/scripts/apply-labels.mts
+        env:
+          INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Automating a basic task.

## What are the changes from a developer perspective?
Added a workflow that will apply labels to PRs based on the title.

## How to test the changes?
The workflow won't have permission until it's merged, you'd have to clone the branch and test it on your own fork. I tested it here: https://github.com/DayKev/pokerogue/pull/29 (one of the runs: https://github.com/DayKev/pokerogue/actions/runs/28842049557/job/85537981149?pr=29)

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually