### PR TITLE
github: update workflow actions and pin to SHA

### DIFF
--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -7,7 +7,7 @@ runs:
       uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
     - name: Set up Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: ".nvmrc"
         cache: "pnpm"

--- a/.github/workflows/create-changelog.yml
+++ b/.github/workflows/create-changelog.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           sparse-checkout: |
             .nvmrc
@@ -20,12 +20,12 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 10
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"

--- a/.github/workflows/create-hotfix-pr.yml
+++ b/.github/workflows/create-hotfix-pr.yml
@@ -18,7 +18,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           submodules: false
           sparse-checkout: .nvmrc

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -38,14 +38,14 @@ jobs:
           fi
         shell: bash
 
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ secrets.PAGEFAULT_APP_ID }}
           private-key: ${{ secrets.PAGEFAULT_APP_PRIVATE_KEY }}
 
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           submodules: "recursive"
           # Always base off of beta branch, regardless of the branch the workflow was triggered from.

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           submodules: "recursive"
           ref: ${{ vars.BETA_DEPLOY_BRANCH || 'beta'}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/detect-labels.yml
+++ b/.github/workflows/detect-labels.yml
@@ -25,7 +25,7 @@ jobs:
                   echo ${{ github.event.label.name }} > ./pr/LABEL
                   echo ${{ github.event.pull_request.head.ref }} > ./pr/REF
                   echo ${{ github.event.pull_request.head.repo.full_name }} > ./pr/REPO
-            - uses: actions/upload-artifact@v4
+            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: pr-data
                   path: pr/

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       # ensure the correct commit is detected on push workflow
       - name: Checkout GitHub repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           sparse-checkout: |
             .nvmrc
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout repository for Typedoc
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           path: pokerogue_docs
 
@@ -75,7 +75,7 @@ jobs:
           rm -rf assets
 
       - name: Checkout asset submodule
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           repository: 'pagefaultgames/pokerogue-assets'
           ref: ${{ steps.asset-submodule-ref.asset_ref }}
@@ -87,18 +87,18 @@ jobs:
           sparse-checkout-cone-mode: true
           
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 10
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: "pokerogue_docs/.nvmrc"
 
       - name: Checkout repository for Github Pages
         if: github.event_name == 'push'
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           path: pokerogue_gh
           ref: gh-pages

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           submodules: false
           sparse-checkout: |
@@ -30,12 +30,12 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 10
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -36,7 +36,7 @@ jobs:
       local-scripts: ${{ steps.filter.outputs.local-scripts }}
     steps:
       - name: Checkout GitHub repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           sparse-checkout: |
             .github/lint-filters.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           submodules: "recursive"
 

--- a/.github/workflows/scrape-wiki.yml
+++ b/.github/workflows/scrape-wiki.yml
@@ -20,7 +20,7 @@ jobs:
       OUTPUT_BRANCH: species-data
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           fetch-depth: 1
           submodules: recursive

--- a/.github/workflows/test-shard-template.yml
+++ b/.github/workflows/test-shard-template.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           submodules: "recursive"
 
@@ -42,7 +42,7 @@ jobs:
       # NB: This CANNOT be made into a job output due to not being extractable from the matrix:
       # https://github.com/orgs/community/discussions/17245
       - name: Upload test result blobs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: shard-${{ inputs.shard }}-blob
           path: test-results

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,12 +35,12 @@ jobs:
       all: ${{ steps.filter.outputs.all }}
     steps:
       - name: Checkout GitHub repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           sparse-checkout: |
             .github/test-filters.yml
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
           filters: .github/test-filters.yml
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           sparse-checkout: |
             .github/actions/setup-deps/action.yml
@@ -87,7 +87,7 @@ jobs:
       - uses: ./.github/actions/setup-deps
 
       - name: Download blob artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: shard-?-blob
           path: test-results


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Keeping things up-to-date, also more secure.

## What are the changes from a developer perspective?
All actions used in GitHub workflows were updated to their latest version and pinned to a SHA.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually