### PR TITLE
github: use `.mts` files instead of `github-script` action

### DIFF
--- a/.github/scripts/pr-title.mts
+++ b/.github/scripts/pr-title.mts
@@ -6,9 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-// biome-ignore-all lint/performance/noNamespaceImport: This is the intended import method for these modules
-import * as core from "@actions/core";
-import * as github from "@actions/github";
+import { getInput, info, setFailed } from "@actions/core";
+import { context, getOctokit } from "@actions/github";
 
 const PREFIXES = [
   "balance", // Primarily a balance change
@@ -64,33 +63,33 @@ const PREFIX_SCOPE_MAP: Readonly<Record<Prefixes, readonly AllScopes[]>> = {
 
 async function run(): Promise<void> {
   try {
-    const authToken = core.getInput("github_token", { required: true });
+    const authToken = getInput("github_token", { required: true });
 
-    const { eventName } = github.context;
+    const { eventName } = context;
     if (eventName !== "pull_request") {
-      core.setFailed(`Invalid event: ${eventName}`);
+      setFailed(`Invalid event: ${eventName}`);
       return;
     }
-    if (!github.context.payload.pull_request) {
-      core.setFailed("Error parsing pull request data!");
+    if (!context.payload.pull_request) {
+      setFailed("Error parsing pull request data!");
       return;
     }
 
-    const client = github.getOctokit(authToken);
+    const client = getOctokit(authToken);
     // The pull request info on the context isn't up to date.
     // When the user updates the title and re-runs the workflow, it would be outdated.
     // Therefore fetch the pull request via the REST API to ensure we use the current title.
     const { data: pullRequest } = await client.rest.pulls.get({
-      owner: github.context.payload.pull_request.base.user.login,
-      repo: github.context.payload.pull_request.base.repo.name,
-      pull_number: github.context.payload.pull_request.number,
+      owner: context.payload.pull_request.base.user.login,
+      repo: context.payload.pull_request.base.repo.name,
+      pull_number: context.payload.pull_request.number,
     });
 
     const { title } = pullRequest;
-    core.info(
+    info(
       "Info on PR title formatting: https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request",
     );
-    core.info(`Pull Request title: "${title}"`);
+    info(`Pull Request title: "${title}"`);
 
     // if (title.length > 72) {
     //   core.setFailed(`Max title length of 72 exceeded! Current length: ${title.length}`);
@@ -98,7 +97,7 @@ async function run(): Promise<void> {
     // }
 
     // Note: `!` allowed before `:` for changes including a save migrator and/or version increase
-    const info = `
+    const terminology = `
 Terminology: fix(move): Future Sight no longer crashes
              ^   ^      ^
              |   |      |__ Subject
@@ -106,13 +105,13 @@ Terminology: fix(move): Future Sight no longer crashes
              |_____________ Prefix
 `;
 
-    core.info(info);
+    info(terminology);
 
     // Example usage of regex: https://regex101.com/r/FeN8jG/9
     const regex = /^([a-z0-9]+)(\([a-z]+\))?!?: .+/;
     const regexResult = regex.exec(title);
     if (!regexResult) {
-      core.setFailed(`Pull Request title "${title}" failed to match - "Prefix(Scope): Subject"`);
+      setFailed(`Pull Request title "${title}" failed to match "Prefix(Scope): Subject" format!`);
       return;
     }
 
@@ -120,17 +119,17 @@ Terminology: fix(move): Future Sight no longer crashes
     const scope = regexResult[2]?.replace(/[()]/g, "") as AllScopes | undefined;
 
     if (!(PREFIXES as readonly string[]).includes(prefix)) {
-      core.setFailed(`Pull Request title "${title}" did not match any of the prefixes: [${PREFIXES}]`);
+      setFailed(`Pull Request title "${title}" did not match any of the prefixes: [${PREFIXES}]`);
       return;
     }
 
     // biome-ignore lint/style/useExplicitLengthCheck: doubles as a nullish check for `scope`
     if (scope?.length && !PREFIX_SCOPE_MAP[prefix as Prefixes].includes(scope)) {
-      core.setFailed(`Pull Request title "${title}" has an invalid prefix (${prefix}) + scope (${scope}) combination!`);
+      setFailed(`Pull Request title "${title}" has an invalid prefix (${prefix}) + scope (${scope}) combination!`);
       return;
     }
   } catch (error) {
-    core.setFailed((error as Error).message);
+    setFailed((error as Error).message);
   }
 }
 

--- a/.github/scripts/update-submodule/download-artifact.mts
+++ b/.github/scripts/update-submodule/download-artifact.mts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import fs from "node:fs";
-import path from "node:path";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { getInput, setFailed } from "@actions/core";
 import { context, getOctokit } from "@actions/github";
 
@@ -33,10 +33,10 @@ async function run(): Promise<void> {
 
     const temp = `${getInput("runner_temp", { required: true })}/artifacts`;
 
-    if (!fs.existsSync(temp)) {
-      fs.mkdirSync(temp);
+    if (!existsSync(temp)) {
+      mkdirSync(temp);
     }
-    fs.writeFileSync(path.join(temp, "pr-data.zip"), Buffer.from(download.data as string));
+    writeFileSync(join(temp, "pr-data.zip"), Buffer.from(download.data as string));
   } catch (error) {
     setFailed((error as Error).message);
   }

--- a/.github/scripts/update-submodule/download-artifact.mts
+++ b/.github/scripts/update-submodule/download-artifact.mts
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Pagefault Games
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { getInput, setFailed } from "@actions/core";
+import { context, getOctokit } from "@actions/github";
+
+async function run(): Promise<void> {
+  try {
+    const authToken = getInput("github_token", { required: true });
+
+    const octokit = getOctokit(authToken);
+    const owner = context.repo.owner;
+    const repo = context.repo.repo;
+    const run_id = context.payload.workflow_run.id;
+
+    const allArtifacts = await octokit.rest.actions.listWorkflowRunArtifacts({ owner, repo, run_id });
+    const artifact = allArtifacts.data.artifacts.find(art => art.name === "pr-data");
+    if (!artifact) {
+      setFailed("Label data missing!");
+      return;
+    }
+    const download = await octokit.rest.actions.downloadArtifact({
+      owner,
+      repo,
+      artifact_id: artifact.id,
+      archive_format: "zip",
+    });
+
+    const temp = `${getInput("runner_temp", { required: true })}/artifacts`;
+
+    if (!fs.existsSync(temp)) {
+      fs.mkdirSync(temp);
+    }
+    fs.writeFileSync(path.join(temp, "pr-data.zip"), Buffer.from(download.data as string));
+  } catch (error) {
+    setFailed((error as Error).message);
+  }
+}
+
+await run();

--- a/.github/scripts/update-submodule/read-label-data.mts
+++ b/.github/scripts/update-submodule/read-label-data.mts
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Pagefault Games
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { getInput, setFailed, setOutput } from "@actions/core";
+
+function run(): void {
+  const temp = `${getInput("runner_temp", { required: true })}/artifacts`;
+
+  const prNumber = Number(fs.readFileSync(path.join(temp, "NR")));
+  const label = fs.readFileSync(path.join(temp, "LABEL")).toString().trim();
+  const ref = fs.readFileSync(path.join(temp, "REF")).toString().trim();
+  const repo = fs.readFileSync(path.join(temp, "REPO")).toString().trim();
+
+  setOutput("label", label);
+  setOutput("prNumber", prNumber);
+  setOutput("ref", ref);
+  setOutput("repo", repo);
+}
+
+try {
+  run();
+} catch (error) {
+  setFailed((error as Error).message);
+}

--- a/.github/scripts/update-submodule/read-label-data.mts
+++ b/.github/scripts/update-submodule/read-label-data.mts
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import fs from "node:fs";
-import path from "node:path";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { getInput, setFailed, setOutput } from "@actions/core";
 
 function run(): void {
   const temp = `${getInput("runner_temp", { required: true })}/artifacts`;
 
-  const prNumber = Number(fs.readFileSync(path.join(temp, "NR")));
-  const label = fs.readFileSync(path.join(temp, "LABEL")).toString().trim();
-  const ref = fs.readFileSync(path.join(temp, "REF")).toString().trim();
-  const repo = fs.readFileSync(path.join(temp, "REPO")).toString().trim();
+  const prNumber = Number(readFileSync(join(temp, "NR")));
+  const label = readFileSync(join(temp, "LABEL")).toString().trim();
+  const ref = readFileSync(join(temp, "REF")).toString().trim();
+  const repo = readFileSync(join(temp, "REPO")).toString().trim();
 
   setOutput("label", label);
   setOutput("prNumber", prNumber);

--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -1,4 +1,4 @@
-name: Update Submodule
+name: Update Submodules
 
 on:
   workflow_run:
@@ -17,52 +17,46 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - name: "Download artifact"
-        uses: actions/github-script@v8
+      - name: Check out Git repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
-          script: |
-            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.payload.workflow_run.id,
-            });
-            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "pr-data"
-            })[0];
-            let download = await github.rest.actions.downloadArtifact({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              artifact_id: matchArtifact.id,
-              archive_format: 'zip',
-            });
-            const fs = require('fs');
-            const path = require('path');
-            const temp = '${{ runner.temp }}/artifacts';
-            if (!fs.existsSync(temp)){
-              fs.mkdirSync(temp);
-            }
-            fs.writeFileSync(path.join(temp, 'pr-data.zip'), Buffer.from(download.data));
+          submodules: false
+          sparse-checkout: |
+            pnpm-lock.yaml
+            .nvmrc
+            .github/scripts/update-submodule/download-artifact.mts
+            .github/scripts/update-submodule/read-label-data.mts
+          sparse-checkout-cone-mode: false
 
-      - name: "Unzip artifact"
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - name: Install Node.js dependencies
+        run: pnpm add @actions/core @actions/github
+
+      - name: Download artifact
+        run: node .github/scripts/update-submodule/download-artifact.mts
+        env:
+          INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_RUNNER_TEMP: ${{ runner.temp }}
+
+      - name: Unzip artifact
         run: unzip "${{ runner.temp }}/artifacts/pr-data.zip" -d "${{ runner.temp }}/artifacts"
 
-      - name: "Read label data"
+      - name: Read label data
         id: read-label-data
-        uses: actions/github-script@v8
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            const temp = '${{ runner.temp }}/artifacts';
-            const prNumber = Number(fs.readFileSync(path.join(temp, 'NR')));
-            const label = fs.readFileSync(path.join(temp, 'LABEL')).toString().trim();
-            const ref = fs.readFileSync(path.join(temp, 'REF')).toString().trim();
-            const repo = fs.readFileSync(path.join(temp, 'REPO')).toString().trim();
-            core.setOutput('label', label);
-            core.setOutput('prNumber', prNumber);
-            core.setOutput('ref', ref);
-            core.setOutput('repo', repo);
+        run: node .github/scripts/update-submodule/read-label-data.mts
+        env:
+          INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_RUNNER_TEMP: ${{ runner.temp }}
 
     outputs:
       label: ${{ steps.read-label-data.outputs.label }}
@@ -76,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           sparse-checkout: |
             .nvmrc
@@ -93,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           sparse-checkout: |
             .nvmrc
@@ -109,14 +103,14 @@ jobs:
     if: needs.read-label-data.outputs.label == 'Update Locales'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ secrets.PAGEFAULT_APP_ID }}
           private-key: ${{ secrets.PAGEFAULT_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           repository: ${{ needs.read-label-data.outputs.repo }}
           ref: ${{ needs.read-label-data.outputs.ref }}
@@ -160,14 +154,14 @@ jobs:
     if: needs.read-label-data.outputs.label == 'Update Assets'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ secrets.PAGEFAULT_APP_ID }}
           private-key: ${{ secrets.PAGEFAULT_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
           repository: ${{ needs.read-label-data.outputs.repo }}
           ref: ${{ needs.read-label-data.outputs.ref }}


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
It's not possible to lint/typecheck scripts that are inlined as text in a yml file.

## What are the changes from a developer perspective?
Moved the scripts from being inlined in `update-submodule.yml` to separate `.mts` files in `.github/scripts/update-submodule/`.
Also changed the imports in `pr-title.mts` to be named imports instead of namespace imports.

## How to test the changes?
Made a test PR on my fork, the label was still read and the PR blocked as expected.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually