### PR TITLE
fix(graphics): animations won't crash if they fail to play

### DIFF
--- a/src/data/battle-anims.ts
+++ b/src/data/battle-anims.ts
@@ -292,6 +292,7 @@ class AnimTimedSoundEvent extends AnimTimedEvent {
   execute(battleAnim: BattleAnim): number {
     const soundConfig = { rate: this.pitch * 0.01, volume: this.volume * 0.01 };
     if (this.resourceName) {
+      // TODO: this `try` shouldn't be necessary, `playSound()` already encases itself in a `try`/`catch`
       try {
         audioManager.playSound(`battle_anims/${this.resourceName}`, soundConfig);
       } catch (err) {

--- a/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
+++ b/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
@@ -640,13 +640,9 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
     receivedPokemonTintSprite.setVisible(false);
     receivedPokemonTintSprite.setTintFill(getPokeballTintColor(receivedPokemon.pokeball));
 
-    [tradedPokemonSprite, tradedPokemonTintSprite].map(sprite => {
+    [tradedPokemonSprite, tradedPokemonTintSprite].forEach(sprite => {
       const spriteKey = tradedPokemon.getSpriteKey(true);
-      try {
-        sprite.play(spriteKey);
-      } catch (err: unknown) {
-        console.error(`Failed to play animation for ${spriteKey}`, err);
-      }
+      sprite.play(spriteKey);
 
       sprite.setPipeline(globalScene.spritePipeline, {
         tone: [0.0, 0.0, 0.0, 0.0],
@@ -658,7 +654,7 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
       sprite.setPipelineData("spriteKey", tradedPokemon.getSpriteKey());
       sprite.setPipelineData("shiny", tradedPokemon.shiny);
       sprite.setPipelineData("variant", tradedPokemon.variant);
-      ["spriteColors", "fusionSpriteColors"].map(k => {
+      ["spriteColors", "fusionSpriteColors"].forEach(k => {
         if (tradedPokemon.summonData.speciesForm) {
           k += "Base";
         }
@@ -666,13 +662,9 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
       });
     });
 
-    [receivedPokemonSprite, receivedPokemonTintSprite].map(sprite => {
+    [receivedPokemonSprite, receivedPokemonTintSprite].forEach(sprite => {
       const spriteKey = receivedPokemon.getSpriteKey(true);
-      try {
-        sprite.play(spriteKey);
-      } catch (err: unknown) {
-        console.error(`Failed to play animation for ${spriteKey}`, err);
-      }
+      sprite.play(spriteKey);
 
       sprite.setPipeline(globalScene.spritePipeline, {
         tone: [0.0, 0.0, 0.0, 0.0],
@@ -684,7 +676,7 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
       sprite.setPipelineData("spriteKey", receivedPokemon.getSpriteKey());
       sprite.setPipelineData("shiny", receivedPokemon.shiny);
       sprite.setPipelineData("variant", receivedPokemon.variant);
-      ["spriteColors", "fusionSpriteColors"].map(k => {
+      ["spriteColors", "fusionSpriteColors"].forEach(k => {
         if (receivedPokemon.summonData.speciesForm) {
           k += "Base";
         }

--- a/src/data/mystery-encounters/utils/encounter-transformation-sequence.ts
+++ b/src/data/mystery-encounters/utils/encounter-transformation-sequence.ts
@@ -68,13 +68,9 @@ export function doPokemonTransformationSequence(
     pokemonEvoTintSprite.setVisible(false);
     pokemonEvoTintSprite.setTintFill(0xffffff);
 
-    [pokemonSprite, pokemonTintSprite, pokemonEvoSprite, pokemonEvoTintSprite].map(sprite => {
+    [pokemonSprite, pokemonTintSprite, pokemonEvoSprite, pokemonEvoTintSprite].forEach(sprite => {
       const spriteKey = previousPokemon.getSpriteKey(true);
-      try {
-        sprite.play(spriteKey);
-      } catch (err: unknown) {
-        console.error(`Failed to play animation for ${spriteKey}`, err);
-      }
+      sprite.play(spriteKey);
 
       sprite.setPipeline(globalScene.spritePipeline, {
         tone: [0.0, 0.0, 0.0, 0.0],
@@ -86,7 +82,7 @@ export function doPokemonTransformationSequence(
       sprite.setPipelineData("spriteKey", previousPokemon.getSpriteKey());
       sprite.setPipelineData("shiny", previousPokemon.shiny);
       sprite.setPipelineData("variant", previousPokemon.variant);
-      ["spriteColors", "fusionSpriteColors"].map(k => {
+      ["spriteColors", "fusionSpriteColors"].forEach(k => {
         if (previousPokemon.summonData.speciesForm) {
           k += "Base";
         }
@@ -94,19 +90,15 @@ export function doPokemonTransformationSequence(
       });
     });
 
-    [pokemonEvoSprite, pokemonEvoTintSprite].map(sprite => {
+    [pokemonEvoSprite, pokemonEvoTintSprite].forEach(sprite => {
       const spriteKey = transformPokemon.getSpriteKey(true);
-      try {
-        sprite.play(spriteKey);
-      } catch (err: unknown) {
-        console.error(`Failed to play animation for ${spriteKey}`, err);
-      }
+      sprite.play(spriteKey);
 
       sprite.setPipelineData("ignoreTimeTint", true);
       sprite.setPipelineData("spriteKey", transformPokemon.getSpriteKey());
       sprite.setPipelineData("shiny", transformPokemon.shiny);
       sprite.setPipelineData("variant", transformPokemon.variant);
-      ["spriteColors", "fusionSpriteColors"].map(k => {
+      ["spriteColors", "fusionSpriteColors"].forEach(k => {
         if (transformPokemon.summonData.speciesForm) {
           k += "Base";
         }

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -1,6 +1,6 @@
 import "phaser";
 
-// #region Methods/Interfaces
+// #region Types
 
 /**
  * Interface representing an object that can be passed to {@linkcode setPositionRelative}.
@@ -9,6 +9,17 @@ interface GuideObject
   extends Pick<Phaser.GameObjects.Components.ComputedSize, "width" | "height">,
     Pick<Phaser.GameObjects.Components.Transform, "x" | "y">,
     Pick<Phaser.GameObjects.Components.Origin, "originX" | "originY"> {}
+
+// #endregion Types
+
+// #region Original Functions
+
+const originalPlay = Phaser.GameObjects.Sprite.prototype.play;
+const originalStop = Phaser.GameObjects.Sprite.prototype.stop;
+
+// #endregion Original Functions
+
+// #region Augmented Functions
 
 /**
  * Set this object's position relative to another object with a given offset.
@@ -29,6 +40,32 @@ function setPositionRelative<T extends Phaser.GameObjects.Components.Transform>(
   return this.setPosition(guideObject.x + offsetX + x, guideObject.y + offsetY + y);
 }
 
+function play<T extends Phaser.GameObjects.Sprite>(
+  this: T,
+  key: string | Phaser.Animations.Animation | Phaser.Types.Animations.PlayAnimationConfig,
+  ignoreIfPlaying?: boolean,
+): Phaser.GameObjects.Sprite {
+  try {
+    return originalPlay.call(this, key, ignoreIfPlaying);
+  } catch (err: unknown) {
+    console.error(`Failed to play animation for "${key}"!`, err);
+    return this;
+  }
+}
+
+function stop<T extends Phaser.GameObjects.Sprite>(this: T): Phaser.GameObjects.Sprite {
+  try {
+    return originalStop.call(this);
+  } catch (err: unknown) {
+    console.error("Failed to stop animation!", err);
+    return this;
+  }
+}
+
+// #endregion Augmented Functions
+
+// #region Extensions
+
 Phaser.GameObjects.Container.prototype.setPositionRelative = setPositionRelative;
 Phaser.GameObjects.Sprite.prototype.setPositionRelative = setPositionRelative;
 Phaser.GameObjects.Image.prototype.setPositionRelative = setPositionRelative;
@@ -36,7 +73,10 @@ Phaser.GameObjects.NineSlice.prototype.setPositionRelative = setPositionRelative
 Phaser.GameObjects.Text.prototype.setPositionRelative = setPositionRelative;
 Phaser.GameObjects.Rectangle.prototype.setPositionRelative = setPositionRelative;
 
-// #endregion Methods/Interfaces
+Phaser.GameObjects.Sprite.prototype.play = play;
+Phaser.GameObjects.Sprite.prototype.stop = stop;
+
+// #endregion Extensions
 
 // #region Declaration Merging
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1206,7 +1206,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   async updateSpritePipelineData(): Promise<void> {
     [this.getSprite(), this.getTintSprite()]
       .filter(s => !!s)
-      .map(s => {
+      .forEach(s => {
         s.pipelineData["teraColor"] = getTypeRgb(this.getTeraType());
         s.pipelineData["isTerastallized"] = this.isTerastallized;
       });
@@ -1225,27 +1225,17 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Attempts to animate a given {@linkcode Phaser.GameObjects.Sprite}
    * @see {@linkcode Phaser.GameObjects.Sprite.play}
-   * @param sprite - Sprite to animate
-   * @param tintSprite - Sprite placed on top of the sprite to add a color tint
-   * @param animConfig - String to pass to the sprite's {@linkcode Phaser.GameObjects.Sprite.play | play} method
-   * @returns true if the sprite was able to be animated
+   * @param sprite - The sprite to animate
+   * @param tintSprite - A sprite placed on top of the original sprite to add a color tint
+   * @param key - The animation key
    */
-  tryPlaySprite(sprite: Phaser.GameObjects.Sprite, tintSprite: Phaser.GameObjects.Sprite, key: string): boolean {
-    // Catch errors when trying to play an animation that doesn't exist
-    try {
-      sprite.play(key);
-      tintSprite.play(key);
-    } catch (error: unknown) {
-      console.error(`Couldn't play animation for '${key}'!\nIs the image for this Pokemon missing?\n`, error);
-
-      return false;
-    }
-
-    return true;
+  playSprite(sprite: Phaser.GameObjects.Sprite, tintSprite: Phaser.GameObjects.Sprite | null, key: string): void {
+    sprite.play(key);
+    tintSprite?.play(key);
   }
 
   playAnim(): void {
-    this.tryPlaySprite(this.getSprite(), this.getTintSprite()!, this.getBattleSpriteKey()); // TODO: is the bang correct?
+    this.playSprite(this.getSprite(), this.getTintSprite(), this.getBattleSpriteKey());
   }
 
   getFieldPositionOffset(): [number, number] {
@@ -5226,26 +5216,18 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   // #region Sprite and Animation Methods
 
-  protected setFrameRate(frameRate: number) {
+  protected setFrameRate(frameRate: number): void {
     // TODO: Augment Phaser's unsafe typing until they do it themselves
     const anim: Phaser.Animations.Animation | undefined = globalScene.anims.get(this.getBattleSpriteKey());
     if (!anim) {
-      throw new Error(
+      console.error(
         `Could not set frame rate for animation ${this.getBattleSpriteKey()}; animation not found!`
           + `\nPokemon: ${this.name}`,
       );
+      return;
     }
     anim.frameRate = frameRate;
-    try {
-      this.getSprite().play(this.getBattleSpriteKey());
-    } catch (err: unknown) {
-      console.error(`Failed to play animation for ${this.getBattleSpriteKey()}`, err);
-    }
-    try {
-      this.getTintSprite()?.play(this.getBattleSpriteKey());
-    } catch (err: unknown) {
-      console.error(`Failed to play animation for ${this.getBattleSpriteKey()}`, err);
-    }
+    this.playAnim();
   }
 
   tint(color: number, alpha?: number, duration?: number, ease?: string) {

--- a/src/phases/egg-hatch-phase.ts
+++ b/src/phases/egg-hatch-phase.ts
@@ -354,17 +354,16 @@ export class EggHatchPhase extends Phase {
       globalScene.validateAchv(achvs.HATCH_SHINY);
     }
     this.eggContainer.setVisible(false);
+
     const spriteKey = this.pokemon.getSpriteKey(true);
-    try {
-      this.pokemonSprite.play(spriteKey);
-    } catch (err: unknown) {
-      console.error(`Failed to play animation for ${spriteKey}`, err);
-    }
+    this.pokemonSprite.play(spriteKey);
+
     this.pokemonSprite.setPipelineData("ignoreTimeTint", true);
     this.pokemonSprite.setPipelineData("spriteKey", this.pokemon.getSpriteKey());
     this.pokemonSprite.setPipelineData("shiny", this.pokemon.shiny);
     this.pokemonSprite.setPipelineData("variant", this.pokemon.variant);
     this.pokemonSprite.setVisible(true);
+
     globalScene.time.delayedCall(fixedInt(250), () => {
       this.eggsToHatchCount--;
       this.eggHatchHandler.eventTarget.dispatchEvent(new EggCountChangedEvent(this.eggsToHatchCount));

--- a/src/phases/evolution-phase.ts
+++ b/src/phases/evolution-phase.ts
@@ -118,11 +118,7 @@ export class EvolutionPhase extends Phase {
    */
   protected configureSprite(pokemon: Pokemon, sprite: Phaser.GameObjects.Sprite, setPipeline = true): typeof sprite {
     const spriteKey = pokemon.getSpriteKey(true);
-    try {
-      sprite.play(spriteKey);
-    } catch (err: unknown) {
-      console.error(`Failed to play animation for ${spriteKey}`, err);
-    }
+    sprite.play(spriteKey);
 
     if (setPipeline) {
       sprite.setPipeline(globalScene.spritePipeline, {

--- a/src/phases/quiet-form-change-phase.ts
+++ b/src/phases/quiet-form-change-phase.ts
@@ -138,11 +138,7 @@ export class QuietFormChangePhase extends BattlePhase {
     const spriteKey = this.pokemon.getBattleSpriteKey();
     // TODO: Why do we play and then immediately stop the form tint sprite?
     // The thing isn't even visible anyways at this point in the code
-    try {
-      pokemonFormTintSprite.play(spriteKey).stop();
-    } catch (err: unknown) {
-      console.error(`Failed to play animation for ${spriteKey}`, err);
-    }
+    pokemonFormTintSprite.play(spriteKey).stop();
 
     pokemonFormTintSprite.setVisible(true);
     globalScene.tweens.add({
@@ -183,12 +179,7 @@ export class QuietFormChangePhase extends BattlePhase {
     );
     sprite.setOrigin(0.5, 1);
     const spriteKey = this.pokemon.getBattleSpriteKey();
-    // TODO: Move error handling elsewhere
-    try {
-      sprite.play(spriteKey).stop();
-    } catch (err: unknown) {
-      console.error(`Failed to play animation for ${spriteKey}`, err);
-    }
+    sprite.play(spriteKey).stop();
     sprite.setPipeline(globalScene.spritePipeline, {
       tone: [0.0, 0.0, 0.0, 0.0],
       hasShadow: false,

--- a/src/ui/handlers/summary-ui-handler.ts
+++ b/src/ui/handlers/summary-ui-handler.ts
@@ -384,12 +384,10 @@ export class SummaryUiHandler extends UiHandler {
     this.numberText.setShadowColor(
       getTextColor(this.pokemon.isShiny() ? TextStyle.SUMMARY_GOLD : TextStyle.SUMMARY, true),
     );
+
     const spriteKey = this.pokemon.getSpriteKey(true);
-    try {
-      this.pokemonSprite.play(spriteKey);
-    } catch (err: unknown) {
-      console.error(`Failed to play animation for ${spriteKey}`, err);
-    }
+    this.pokemonSprite.play(spriteKey);
+
     this.pokemonSprite
       .setPipelineData("teraColor", getTypeRgb(this.pokemon.getTeraType()))
       .setPipelineData("isTerastallized", this.pokemon.isTerastallized)


### PR DESCRIPTION
## What are the changes the user will see?
If there is an issue playing an animation, the game will skip playing the animation instead of crashing.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
- Fixes #7433

## What are the changes from a developer perspective?
- Augmented `Phaser.GameObjects.Sprite#play` and `#stop` with `try`/`catch` blocks that will print an error to the console instead of crashing if something goes wrong trying to play or stop the animation.
- Removed the scattered `try`/`catch` blocks from the rest of the codebase.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR