### PR TITLE
misc: limit candy flyout queue to 5

### DIFF
--- a/src/ui/containers/candy-bar.ts
+++ b/src/ui/containers/candy-bar.ts
@@ -61,6 +61,10 @@ export class CandyBar extends Phaser.GameObjects.Container {
    * @param numCandiesAdded - The number of candies just to the starter1
    */
   showStarterSpeciesCandy(starterSpeciesId: SpeciesId, numCandiesAdded: number): void {
+    if (this.pendingCandyAdditions.length >= 5) {
+      // prevent forever showing candies after opening a bunch of eggs at once
+      return;
+    }
     if (this.shown) {
       if (!this.isHiding && this.speciesId === starterSpeciesId) {
         this.cumulativeCandiesAdded += numCandiesAdded;


### PR DESCRIPTION
## What are the changes the user will see?

No more endless candy flyouts after opening eggs

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

annoying

## What are the changes from a developer perspective?

added an `if` to check if the queue is greater than 5 and if so don't add to the queue

## Screenshots/Videos
<!--
If you are changing anything visual (UI/UX, locales changes, etc.), please include screenshot(s) and/or video(s) showing the changes within collapsible blocks, like below:

<details><summary>Before</summary>

[before screenshot here]

</details>
<details><summary>After</summary>

[after screenshot here]

</details>
-->

## How to test the changes?

```ts
const overrides = {
  EGG_FREE_GACHA_PULLS_OVERRIDE: true,
  EGG_GACHA_PULL_COUNT_OVERRIDE: 100,
  EGG_IMMEDIATE_HATCH_OVERRIDE: true
} satisfies Partial<InstanceType<OverridesType>>;
```

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)
