### PR TITLE
github: update config for submodule update workflow

### DIFF
--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -112,6 +112,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
+          allow-unsafe-pr-checkout: true
           repository: ${{ needs.read-label-data.outputs.repo }}
           ref: ${{ needs.read-label-data.outputs.ref }}
           sparse-checkout: |
@@ -163,6 +164,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
+          allow-unsafe-pr-checkout: true
           repository: ${{ needs.read-label-data.outputs.repo }}
           ref: ${{ needs.read-label-data.outputs.ref }}
           sparse-checkout: |


### PR DESCRIPTION
## What are the changes the user will see?
N/A

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
The security defaults for the `actions/checkout` action were increased in an update and caused the submodule update jobs in the workflow to start failing.

> Error: Refusing to check out fork pull request code from a 'workflow_run' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. Fetching and executing a fork's code in that trusted context commonly leads to "pwn request" vulnerabilities. To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

## What are the changes from a developer perspective?
Adds `allow-unsafe-pr-checkout: true` for the repository checkout steps that are part of the jobs that update the `assets` and `locales` submodules in a PR.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR