### PR TITLE
fix: prevent crash from unloading animation while it's playing

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1705,6 +1705,7 @@ export class BattleScene extends SceneBase {
       }
     }
   }
+
   updateFieldScale(): Promise<void> {
     return new Promise(resolve => {
       const fieldScale =

--- a/src/phases/switch-biome-phase.ts
+++ b/src/phases/switch-biome-phase.ts
@@ -2,10 +2,11 @@ import { globalScene } from "#app/global-scene";
 import type { BiomeId } from "#enums/biome-id";
 import { getBiomeKey } from "#field/arena";
 import { BattlePhase } from "#phases/battle-phase";
+import { fixedInt } from "#utils/common";
 
 export class SwitchBiomePhase extends BattlePhase {
   public readonly phaseName = "SwitchBiomePhase";
-  private nextBiome: BiomeId;
+  private readonly nextBiome: BiomeId;
 
   constructor(nextBiome: BiomeId) {
     super();
@@ -13,11 +14,12 @@ export class SwitchBiomePhase extends BattlePhase {
     this.nextBiome = nextBiome;
   }
 
-  async start() {
+  public override async start(): Promise<void> {
     super.start();
 
     if (this.nextBiome === undefined) {
-      return this.end();
+      this.end();
+      return;
     }
 
     // Kick off biome asset loading in parallel with the 2000ms slide-out
@@ -69,8 +71,9 @@ export class SwitchBiomePhase extends BattlePhase {
             if (globalScene.lastEnemyTrainer) {
               globalScene.lastEnemyTrainer.destroy();
             }
-            // Clear previous biome textures now that the transition is complete
-            globalScene.clearBiomeAssets(previousBiome);
+            // Clear previous biome textures now that the transition is complete.
+            // Delay to hopefully prevent race conditions
+            globalScene.time.delayedCall(fixedInt(3000), () => globalScene.clearBiomeAssets(previousBiome));
             this.end();
           },
         });


### PR DESCRIPTION
## What are the changes the user will see?
~Fix~ Reduce probability of crash from biome transitions in endless.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Trying to fix a dumb crash that won't go away.

## What are the changes from a developer perspective?
Added a 3 second delay to biome assets being cleared on biome transition.

## How to test the changes?
Idk, pray to RNGesus? It's stupidly inconsistent.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR