### PR TITLE
fix(ui): fix controller settings being empty from early exit and not running setLayout

### DIFF
--- a/src/ui/settings/base-control-settings-ui-handler.ts
+++ b/src/ui/settings/base-control-settings-ui-handler.ts
@@ -327,7 +327,9 @@ export abstract class BaseControlSettingsUiHandler extends UiHandler {
     const activeConfig = this.getActiveConfig();
 
     // Set the UI layout for the active configuration. If unsuccessful, exit the function early.
-    if (activeConfig == null || !this.setLayout(activeConfig)) {
+    // Note: `setLayout` is always invoked here (even when `activeConfig` is null) because it is
+    // responsible for displaying the "no gamepad connected" fallback message in that case.
+    if (!this.setLayout(activeConfig)) {
       return;
     }
 
@@ -420,7 +422,7 @@ export abstract class BaseControlSettingsUiHandler extends UiHandler {
    * @param activeConfig - The active device configuration.
    * @returns `true` if the layout was successfully applied, otherwise `false`.
    */
-  protected setLayout(activeConfig: InterfaceConfig): boolean {
+  protected setLayout(activeConfig: InterfaceConfig | null): activeConfig is InterfaceConfig {
     // Check if there is no active configuration (e.g., no gamepad connected).
     if (!activeConfig) {
       // Retrieve the layout for when no gamepads are connected.

--- a/src/ui/settings/settings-gamepad-ui-handler.ts
+++ b/src/ui/settings/settings-gamepad-ui-handler.ts
@@ -66,7 +66,7 @@ export class SettingsGamepadUiHandler extends BaseControlSettingsUiHandler {
    * @param activeConfig - The active gamepad configuration.
    * @returns `true` if the layout was successfully applied, otherwise `false`.
    */
-  setLayout(activeConfig: InterfaceConfig): boolean {
+  setLayout(activeConfig: InterfaceConfig | null): activeConfig is InterfaceConfig {
     // Check if there is no active configuration (e.g., no gamepad connected).
     if (!activeConfig) {
       // Retrieve the layout for when no gamepads are connected.

--- a/src/ui/settings/settings-keyboard-ui-handler.ts
+++ b/src/ui/settings/settings-keyboard-ui-handler.ts
@@ -115,7 +115,7 @@ export class SettingsKeyboardUiHandler extends BaseControlSettingsUiHandler {
    * @param activeConfig - The active keyboard configuration.
    * @returns `true` if the layout was successfully applied, otherwise `false`.
    */
-  setLayout(activeConfig: InterfaceConfig): boolean {
+  setLayout(activeConfig: InterfaceConfig | null): activeConfig is InterfaceConfig {
     // Check if there is no active configuration (e.g., no gamepad connected).
     if (!activeConfig) {
       // Retrieve the layout for when no gamepads are connected.


### PR DESCRIPTION
## What are the changes the user will see?
The GamePad settings page will no longer be empty when no controller is detected 

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Due to a previous PR (#6638) the page never runs the code that shows the "Plug in controller or press a button" message, causing confusion among players.

## What are the changes from a developer perspective?

Since #6638 added `strictNullChecks` (among other stricter compiler options), it patched around a resulting type error by adding an `activeConfig == null` short-circuit to `updateBindings()`'s call to `setLayout()`. Because of `||` short-circuiting, that check caused `setLayout()` to never be called at all when no gamepad was connected — silently skipping the "please connect a gamepad" fallback UI it's responsible for displaying. This restores the pre-#6638 behavior of always calling `setLayout()`.

 `setLayout`'s signature was updated to accept `activeConfig: InterfaceConfig | null` and to return the type predicate `activeConfig is InterfaceConfig` instead of a plain `boolean`. This lets the compiler narrow `activeConfig` to non-null wherever `setLayout()` returns `true`, without needing a separate redundant null check afterward. The same signature change was applied to the two subclass overrides (`SettingsGamepadUiHandler` and `SettingsKeyboardUiHandler`) to keep them compatible.

## Screenshots/Videos
N/A

## How to test the changes?
Verify GamePad page shows message when no controller is plugged in

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] ~I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary~
- [ ] ~I have provided screenshots/videos of the changes (if applicable)~
  - [ ] ~I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)~

~Are there any localization additions or changes? If so:~
- [ ] ~I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository~
  - ~If so, include a link to the PR here: _____~
- [ ] ~I have contacted the Translation Team on Discord for proofreading/translation (contacting the devs in #pokerogue-dev is sufficient, we can then forward the PR to the TL team)~

~Does this require any additions or changes to in-game assets? If so:~
- [ ] ~I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository~
  - ~If so, include a link to the PR here: _____~
