### PR TITLE
chore!: Hotfix 1.12.0.7 to main

### DIFF
--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -112,6 +112,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
+          allow-unsafe-pr-checkout: true
           repository: ${{ needs.read-label-data.outputs.repo }}
           ref: ${{ needs.read-label-data.outputs.ref }}
           sparse-checkout: |
@@ -163,6 +164,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
         with:
+          allow-unsafe-pr-checkout: true
           repository: ${{ needs.read-label-data.outputs.repo }}
           ref: ${{ needs.read-label-data.outputs.ref }}
           sparse-checkout: |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pokemon-rogue-battle",
   "private": true,
-  "version": "1.12.0.6",
+  "version": "1.12.0.7",
   "type": "module",
   "scripts": {
     "start:prod": "vite --mode production",

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1710,6 +1710,7 @@ export class BattleScene extends SceneBase {
       }
     }
   }
+
   updateFieldScale(): Promise<void> {
     return new Promise(resolve => {
       const fieldScale =

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1700,6 +1700,11 @@ export class BattleScene extends SceneBase {
     }
 
     for (const key of keysToClear) {
+      if (this.anims.exists(key)) {
+        console.log(`Removing animation for key ${key}..`);
+        this.anims.remove(key);
+      }
+
       if (this.textures.exists(key)) {
         this.textures.remove(key);
       }

--- a/src/phases/move-charge-phase.ts
+++ b/src/phases/move-charge-phase.ts
@@ -2,6 +2,7 @@ import { globalScene } from "#app/global-scene";
 import { MoveChargeAnim } from "#data/battle-anims";
 import type { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagType } from "#enums/battler-tag-type";
+import { MovePhaseTimingModifier } from "#enums/move-phase-timing-modifier";
 import { MoveResult } from "#enums/move-result";
 import type { MoveUseMode } from "#enums/move-use-mode";
 import type { Pokemon } from "#field/pokemon";
@@ -76,7 +77,14 @@ export class MoveChargePhase extends PokemonPhase {
     // TODO: This checks status twice for a single-turn usage...
     if (instantCharge.value) {
       globalScene.phaseManager.tryRemovePhase("MoveEndPhase", phase => phase.getPokemon() === user);
-      globalScene.phaseManager.unshiftNew("MovePhase", user, [this.targetIndex], this.move, this.useMode);
+      globalScene.phaseManager.unshiftNew(
+        "MovePhase",
+        user,
+        [this.targetIndex],
+        this.move,
+        this.useMode,
+        MovePhaseTimingModifier.FIRST,
+      );
     } else {
       user.pushMoveQueue({ move: move.id, targets: [this.targetIndex], useMode: this.useMode });
     }

--- a/src/ui/settings/base-control-settings-ui-handler.ts
+++ b/src/ui/settings/base-control-settings-ui-handler.ts
@@ -327,7 +327,9 @@ export abstract class BaseControlSettingsUiHandler extends UiHandler {
     const activeConfig = this.getActiveConfig();
 
     // Set the UI layout for the active configuration. If unsuccessful, exit the function early.
-    if (activeConfig == null || !this.setLayout(activeConfig)) {
+    // Note: `setLayout` is always invoked here (even when `activeConfig` is null) because it is
+    // responsible for displaying the "no gamepad connected" fallback message in that case.
+    if (!this.setLayout(activeConfig)) {
       return;
     }
 
@@ -420,7 +422,7 @@ export abstract class BaseControlSettingsUiHandler extends UiHandler {
    * @param activeConfig - The active device configuration.
    * @returns `true` if the layout was successfully applied, otherwise `false`.
    */
-  protected setLayout(activeConfig: InterfaceConfig): boolean {
+  protected setLayout(activeConfig: InterfaceConfig | null): activeConfig is InterfaceConfig {
     // Check if there is no active configuration (e.g., no gamepad connected).
     if (!activeConfig) {
       // Retrieve the layout for when no gamepads are connected.

--- a/src/ui/settings/settings-gamepad-ui-handler.ts
+++ b/src/ui/settings/settings-gamepad-ui-handler.ts
@@ -66,7 +66,7 @@ export class SettingsGamepadUiHandler extends BaseControlSettingsUiHandler {
    * @param activeConfig - The active gamepad configuration.
    * @returns `true` if the layout was successfully applied, otherwise `false`.
    */
-  setLayout(activeConfig: InterfaceConfig): boolean {
+  setLayout(activeConfig: InterfaceConfig | null): activeConfig is InterfaceConfig {
     // Check if there is no active configuration (e.g., no gamepad connected).
     if (!activeConfig) {
       // Retrieve the layout for when no gamepads are connected.

--- a/src/ui/settings/settings-keyboard-ui-handler.ts
+++ b/src/ui/settings/settings-keyboard-ui-handler.ts
@@ -115,7 +115,7 @@ export class SettingsKeyboardUiHandler extends BaseControlSettingsUiHandler {
    * @param activeConfig - The active keyboard configuration.
    * @returns `true` if the layout was successfully applied, otherwise `false`.
    */
-  setLayout(activeConfig: InterfaceConfig): boolean {
+  setLayout(activeConfig: InterfaceConfig | null): activeConfig is InterfaceConfig {
     // Check if there is no active configuration (e.g., no gamepad connected).
     if (!activeConfig) {
       // Retrieve the layout for when no gamepads are connected.

--- a/test/tests/moves/solar-beam.test.ts
+++ b/test/tests/moves/solar-beam.test.ts
@@ -1,8 +1,11 @@
 import { allMoves } from "#data/data-lists";
 import { AbilityId } from "#enums/ability-id";
+import { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
+import { MovePhaseTimingModifier } from "#enums/move-phase-timing-modifier";
 import { MoveResult } from "#enums/move-result";
+import { MoveUseMode } from "#enums/move-use-mode";
 import { SpeciesId } from "#enums/species-id";
 import { WeatherType } from "#enums/weather-type";
 import { GameManager } from "#test/framework/game-manager";
@@ -64,10 +67,19 @@ describe("Moves - Solar Beam", () => {
 
     const playerPokemon = game.field.getPlayerPokemon();
     const enemyPokemon = game.field.getEnemyPokemon();
+    const unshiftNewSpy = vi.spyOn(game.scene.phaseManager, "unshiftNew");
 
     game.move.select(MoveId.SOLAR_BEAM);
 
     await game.phaseInterceptor.to("TurnEndPhase");
+    expect(unshiftNewSpy).toHaveBeenCalledWith(
+      "MovePhase",
+      playerPokemon,
+      [BattlerIndex.ENEMY],
+      expect.objectContaining({ moveId: MoveId.SOLAR_BEAM }),
+      MoveUseMode.IGNORE_PP,
+      MovePhaseTimingModifier.FIRST,
+    );
     expect(playerPokemon.getTag(BattlerTagType.CHARGING)).toBeUndefined();
     expect(enemyPokemon.hp).toBeLessThan(enemyPokemon.getMaxHp());
     expect(playerPokemon.getMoveHistory()).toHaveLength(2);


### PR DESCRIPTION
**Changelog:** beta ---> main
---------------------------
## Bug Fixes

- #7318
  - Instantly charged two-turn moves, such as Solar Beam in sun, now resolve their attack immediately without another Pokemon being able to interrupt the attack portion through a speed tie.
- #7514
  - When going to `End` or `power plant` it should not crash anymore
## Miscellaneous

- #7515
  - The GamePad settings page will no longer be empty when no controller is detected
## Unknown

- #7512
- #7509

---------------------------
**This changelog was auto generated at July 10, 2026 at 8:08 PM UTC.**