### PR TITLE
refactor: remove `getPokemonSpecies`

### DIFF
--- a/scripts/gen-moveset/gen-moveset.ts
+++ b/scripts/gen-moveset/gen-moveset.ts
@@ -11,6 +11,7 @@
 
 import { __INTERNAL_TEST_EXPORTS, generateMoveset } from "#app/ai/ai-moveset-gen";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import type { PokemonForm } from "#data/pokemon-species";
 import { BattleType } from "#enums/battle-type";
 import { SpeciesId } from "#enums/species-id";
@@ -19,7 +20,6 @@ import type { Pokemon } from "#field/pokemon";
 import { EnemyPokemon } from "#field/pokemon";
 import { GameManager } from "#test/framework/game-manager";
 import { randomString } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import net from "node:net";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { SamplerPayload } from "./types";
@@ -75,7 +75,7 @@ function createTestablePokemon(
   speciesId: SpeciesId,
   { level, trainerSlot = TrainerSlot.NONE, boss = false, formIndex = 0 }: MockPokemonParams,
 ): EnemyPokemon {
-  const species = getPokemonSpecies(speciesId);
+  const species = speciesDataRegistry.getSpecies(speciesId);
   const pokemon = new EnemyPokemon(species, level, trainerSlot, boss);
   if (formIndex !== 0 && species?.forms.length > formIndex) {
     pokemon.formIndex = formIndex;
@@ -152,7 +152,7 @@ describe("gen-moveset", () => {
         }
       });
     }
-    if (payload.formIndex && getPokemonSpecies(payload.speciesId).forms[payload.formIndex] == null) {
+    if (payload.formIndex && speciesDataRegistry.getSpecies(payload.speciesId).forms[payload.formIndex] == null) {
       payload.formIndex = undefined;
     }
     pokemon = createTestablePokemon(payload.speciesId, payload);

--- a/src/ai/ai-moveset-gen.ts
+++ b/src/ai/ai-moveset-gen.ts
@@ -8,6 +8,7 @@
 
 import { EVOLVE_MOVE, RELEARN_MOVE } from "#app/constants";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { speciesEggMoves } from "#balance/moves/egg-moves";
 import { FORBIDDEN_SINGLES_MOVES, FORBIDDEN_TM_MOVES, LEVEL_BASED_DENYLIST } from "#balance/moves/forbidden-moves";
 import {
@@ -61,7 +62,7 @@ import { PokemonMove } from "#moves/pokemon-move";
 import type { Move, StatStageChangeAttr } from "#types/move-types";
 import type { LevelMovesWithSource } from "#types/pokemon-species";
 import { NumberHolder, randSeedInt, randSeedItem } from "#utils/common";
-import { getPokemonSpecies, willTerastallize } from "#utils/pokemon-utils";
+import { willTerastallize } from "#utils/pokemon-utils";
 import { ValueHolder } from "#utils/value-holder";
 
 /**
@@ -161,7 +162,7 @@ function getTmPoolForSpecies(
   allowedTiers = getAllowedTmTiers(level),
 ): void {
   const [allowCommon, allowGreat, allowUltra] = allowedTiers;
-  const tms = getPokemonSpecies(speciesId).getTms(formKey);
+  const tms = speciesDataRegistry.getSpecies(speciesId).getTms(formKey);
 
   for (const tm of tms) {
     if (FORBIDDEN_TM_MOVES.has(tm) || levelPool.has(tm) || eggPool.has(tm) || tmPool.has(tm)) {

--- a/src/ai/ai-species-gen.ts
+++ b/src/ai/ai-species-gen.ts
@@ -6,7 +6,6 @@ import { EvoLevelThresholdKind } from "#enums/evo-level-threshold-kind";
 import { PartyMemberStrength } from "#enums/party-member-strength";
 import type { SpeciesId } from "#enums/species-id";
 import { randSeedIntRange, randSeedItem } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 
 /**
  * Controls the maximum level difference that a Pokémon spawned with
@@ -165,7 +164,7 @@ export function determineEnemySpecies(
   const randomLevel = randSeedIntRange(choice, Math.round(choice * multiplier));
   if (randomLevel <= level) {
     return determineEnemySpecies(
-      getPokemonSpecies(evoSpecies),
+      speciesDataRegistry.getSpecies(evoSpecies),
       level,
       true,
       forTrainer,

--- a/src/ai/rival-team-gen.ts
+++ b/src/ai/rival-team-gen.ts
@@ -1,4 +1,5 @@
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { isBeta, isDev } from "#constants/app-constants";
 import type { PokemonSpecies } from "#data/pokemon-species";
 import { getTypeDamageMultiplier } from "#data/type";
@@ -11,7 +12,6 @@ import type { EnemyPokemon } from "#field/pokemon";
 import { RIVAL_6_POOL, type RivalPoolConfig } from "#trainers/rival-party-config";
 import { randSeedItem } from "#utils/common";
 import { getEnumValues } from "#utils/enums";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 
 /**
  * The maximum number of shared weaknesses to tolerate when balancing weakness
@@ -152,7 +152,7 @@ function calcPartyTypings(
     if (refSpecies == null) {
       continue;
     }
-    const refPokeSpecies = getPokemonSpecies(refSpecies);
+    const refPokeSpecies = speciesDataRegistry.getSpecies(refSpecies);
     const type1 = refPokeSpecies.type1;
     const type2 = refPokeSpecies.type2;
     if (balanceTypes) {
@@ -188,7 +188,7 @@ function checkTypingConstraints(
   if (!balanceTypes && !balanceWeaknesses) {
     return true;
   }
-  const { type1, type2 } = getPokemonSpecies(species);
+  const { type1, type2 } = speciesDataRegistry.getSpecies(species);
 
   if (
     balanceTypes
@@ -199,7 +199,7 @@ function checkTypingConstraints(
   }
 
   if (balanceWeaknesses) {
-    const weaknesses = getWeakTypes(getPokemonSpecies(species));
+    const weaknesses = getWeakTypes(speciesDataRegistry.getSpecies(species));
     for (const weakType of weaknesses) {
       if ((existingWeaknesses.get(weakType) ?? 0) >= MAX_SHARED_WEAKNESSES) {
         return false;
@@ -322,7 +322,7 @@ export function getRandomRivalPartyMemberFunc(
     }
 
     return globalScene.addEnemyPokemon(
-      getPokemonSpecies(species),
+      speciesDataRegistry.getSpecies(species),
       level,
       TrainerSlot.TRAINER,
       undefined,

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -158,7 +158,7 @@ import { deepMergeSpriteData } from "#utils/data";
 import { getEnumValues } from "#utils/enums";
 import { cachedFetch } from "#utils/fetch-utils";
 import { getModifierPoolForType, getModifierType } from "#utils/modifier-utils";
-import { decodeNickname, getPokemonSpecies } from "#utils/pokemon-utils";
+import { decodeNickname } from "#utils/pokemon-utils";
 import { capitalizeFirstLetterOnly } from "#utils/strings";
 import i18next from "i18next";
 import Phaser from "phaser";
@@ -926,7 +926,7 @@ export class BattleScene extends SceneBase {
       level = activeOverrides.ENEMY_LEVEL_OVERRIDE;
     }
     if (activeOverrides.ENEMY_SPECIES_OVERRIDE) {
-      species = getPokemonSpecies(activeOverrides.ENEMY_SPECIES_OVERRIDE);
+      species = speciesDataRegistry.getSpecies(activeOverrides.ENEMY_SPECIES_OVERRIDE);
       // The fact that a Pokemon is a boss or not can change based on its Species and level
       boss = this.getEncounterBossSegments(this.currentBattle.waveIndex, level, species) > 1;
     }
@@ -2343,7 +2343,7 @@ export class BattleScene extends SceneBase {
               .map(s => {
                 if (!filterAllEvolutions) {
                   while (speciesDataRegistry.hasPrevolution(s.speciesId)) {
-                    s = getPokemonSpecies(speciesDataRegistry.getPrevolution(s.speciesId)!);
+                    s = speciesDataRegistry.getSpecies(speciesDataRegistry.getPrevolution(s.speciesId)!);
                   }
                 }
                 return s;

--- a/src/data/balance/pokemon-evolutions.ts
+++ b/src/data/balance/pokemon-evolutions.ts
@@ -1,5 +1,6 @@
 import type { determineEnemySpecies } from "#app/ai/ai-species-gen";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { allMoves, } from "#data/data-lists";
 import { type Gender, getGenderSymbol } from "#data/gender";
 import type { BiomeId } from "#enums/biome-id";
@@ -16,7 +17,6 @@ import type { EvoLevelThreshold } from "#types/species-gen-types";
 import { coerceArray } from "#utils/array";
 import { randSeedInt } from "#utils/common";
 import { getPokemonTypeLocaleKey } from "#utils/i18n";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { toCamelCase } from "#utils/strings";
 import i18next from "i18next";
 
@@ -143,7 +143,7 @@ export class SpeciesEvolutionCondition {
         case EvoCondKey.EVO_TREASURE_TRACKER:
           return i18next.t("pokemonEvolutions:treasure");
         case EvoCondKey.SPECIES_CAUGHT:
-          return i18next.t("pokemonEvolutions:caught", {species: getPokemonSpecies(cond.speciesCaught).name});
+          return i18next.t("pokemonEvolutions:caught", {species: speciesDataRegistry.getSpecies(cond.speciesCaught).name});
         case EvoCondKey.HELD_ITEM:
           return i18next.t(`pokemonEvolutions:heldItem.${toCamelCase(cond.itemKey)}`);
         case EvoCondKey.RANDOM_FORM:

--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -30,7 +30,7 @@ import type { DexAttrProps, StarterDataEntry } from "#types/save-data";
 import { type BooleanHolder, isBetween, type NumberHolder, randSeedItem } from "#utils/common";
 import { deepCopy } from "#utils/data";
 import { getPokemonTypeLocaleKey } from "#utils/i18n";
-import { getPokemonSpecies, getPokemonSpeciesForm } from "#utils/pokemon-utils";
+import { getPokemonSpeciesForm } from "#utils/pokemon-utils";
 import { toCamelCase } from "#utils/strings";
 import i18next from "i18next";
 
@@ -480,8 +480,10 @@ export class SingleGenerationChallenge extends Challenge {
   }
 
   applyPokemonInBattle(pokemon: Pokemon, valid: BooleanHolder): boolean {
-    const baseGeneration = getPokemonSpecies(pokemon.species.speciesId).generation;
-    const fusionGeneration = pokemon.isFusion() ? getPokemonSpecies(pokemon.fusionSpecies!.speciesId).generation : 0;
+    const baseGeneration = speciesDataRegistry.getSpecies(pokemon.species.speciesId).generation;
+    const fusionGeneration = pokemon.isFusion()
+      ? speciesDataRegistry.getSpecies(pokemon.fusionSpecies!.speciesId).generation
+      : 0;
     if (
       pokemon.isPlayer()
       && (baseGeneration !== this.value || (pokemon.isFusion() && fusionGeneration !== this.value))

--- a/src/data/daily-seed/daily-run.ts
+++ b/src/data/daily-seed/daily-run.ts
@@ -16,7 +16,6 @@ import type { Starter, StarterMoveset } from "#types/save-data";
 import type { TupleRange } from "#types/type-helpers";
 import { isBetween, randSeedGauss, randSeedInt, randSeedItem } from "#utils/common";
 import { getEnumValues } from "#utils/enums";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import {
   getDailyRunStarter,
   isDailyEventSeed,
@@ -54,8 +53,8 @@ export function getDailyRunStarters(): StarterTuple {
             // make sure there are no duplicate starters from the same line
             !starters.some(st => s === st.speciesId || speciesDataRegistry.getStarter(s) === st.speciesId),
         );
-        const randPkmSpecies = getPokemonSpecies(randSeedItem(costSpecies));
-        const starterSpecies = getPokemonSpecies(
+        const randPkmSpecies = speciesDataRegistry.getSpecies(randSeedItem(costSpecies));
+        const starterSpecies = speciesDataRegistry.getSpecies(
           randPkmSpecies.getTrainerSpeciesForLevel(
             startingLevel,
             true,
@@ -172,7 +171,7 @@ function getDailyEventSeedStarters(): StarterTuple | null {
       return null;
     }
 
-    const species = getPokemonSpecies(starterConfig.speciesId);
+    const species = speciesDataRegistry.getSpecies(starterConfig.speciesId);
 
     const starter = getDailyRunStarter(species, starterConfig);
 
@@ -221,7 +220,7 @@ export function getDailyForcedWaveSpecies(waveIndex: number): PokemonSpecies | n
     return null;
   }
 
-  return getPokemonSpecies(forcedWave.speciesId);
+  return speciesDataRegistry.getSpecies(forcedWave.speciesId);
 }
 
 /**

--- a/src/data/daily-seed/daily-seed-utils.ts
+++ b/src/data/daily-seed/daily-seed-utils.ts
@@ -1,4 +1,5 @@
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { isBeta, isDev } from "#constants/app-constants";
 import { Gender } from "#data/gender";
 import type { PokemonSpecies } from "#data/pokemon-species";
@@ -10,7 +11,7 @@ import type { CustomDailyRunConfig, DailySeedBoss, DailySeedStarter, SerializedD
 import type { Starter, StarterMoveset } from "#types/save-data";
 import { isBetween } from "#utils/common";
 import { getEnumValues } from "#utils/enums";
-import { getPokemonSpecies, getPokemonSpeciesForm } from "#utils/pokemon-utils";
+import { getPokemonSpeciesForm } from "#utils/pokemon-utils";
 import Ajv from "ajv";
 import customDailyRunSchema from "./schema.json";
 
@@ -112,7 +113,7 @@ export function validateDailyStarterConfig(config: DailySeedStarter): DailySeedS
   }
 
   // Fall back to default variant if none exists
-  const starterSpecies = getPokemonSpecies(config.speciesId);
+  const starterSpecies = speciesDataRegistry.getSpecies(config.speciesId);
   if (config.variant != null && !starterSpecies.hasVariants()) {
     console.warn("Variant for custom daily run seed starter does not exist, using base variant...", config.variant);
     config.variant = 0;
@@ -160,7 +161,7 @@ export function validateDailyBossConfig(config: DailySeedBoss): DailySeedBoss | 
   }
 
   // Fall back to default variant if none exists
-  const starterSpecies = getPokemonSpecies(config.speciesId);
+  const starterSpecies = speciesDataRegistry.getSpecies(config.speciesId);
   if (config.variant != null && !starterSpecies.hasVariants()) {
     console.warn("Variant for custom daily run seed boss does not exist, using base variant...", config.variant);
     config.variant = 0;

--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -32,7 +32,6 @@ import { SpeciesId } from "#enums/species-id";
 import { VariantTier } from "#enums/variant-tier";
 import type { PlayerPokemon } from "#field/pokemon";
 import { getIvsFromId, randInt, randomString, randSeedInt } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import i18next from "i18next";
 
 export const EGG_SEED = 1073741824;
@@ -190,7 +189,7 @@ export class Egg {
 
       // TODO: This is a race condition with the initialization of `variantData`.
       // It doesn't seem to impact nonlocal instances, but it should still be fixed.
-      if (this._species && !getPokemonSpecies(this._species).hasVariants()) {
+      if (this._species && !speciesDataRegistry.getSpecies(this._species).hasVariants()) {
         this._variantTier = VariantTier.STANDARD;
       }
       // Needs this._tier so it needs to be generated afer the tier override if bought from same species
@@ -241,10 +240,10 @@ export class Egg {
         this._species = this.rollSpecies()!; // TODO: is this bang correct?
       }
 
-      let pokemonSpecies = getPokemonSpecies(this._species);
+      let pokemonSpecies = speciesDataRegistry.getSpecies(this._species);
       // Special condition to have Phione eggs also have a chance of generating Manaphy
       if (this._species === SpeciesId.PHIONE && this._sourceType === EggSourceType.SAME_SPECIES_EGG) {
-        pokemonSpecies = getPokemonSpecies(
+        pokemonSpecies = speciesDataRegistry.getSpecies(
           randSeedInt(MANAPHY_EGG_MANAPHY_RATE) ? SpeciesId.PHIONE : SpeciesId.MANAPHY,
         );
       }
@@ -323,13 +322,13 @@ export class Egg {
         return (
           this.eggDescriptor
           ?? i18next.t("egg:sameSpeciesEgg", {
-            species: getPokemonSpecies(this._species).getName(),
+            species: speciesDataRegistry.getSpecies(this._species).getName(),
           })
         );
       case EggSourceType.GACHA_LEGENDARY:
         return (
           this.eggDescriptor
-          ?? `${i18next.t("egg:gachaTypeLegendary")} (${getPokemonSpecies(getLegendaryGachaSpeciesForTimestamp(this.timestamp)).getName()})`
+          ?? `${i18next.t("egg:gachaTypeLegendary")} (${speciesDataRegistry.getSpecies(getLegendaryGachaSpeciesForTimestamp(this.timestamp)).getName()})`
         );
       case EggSourceType.GACHA_SHINY:
         return this.eggDescriptor ?? i18next.t("egg:gachaTypeShiny");

--- a/src/data/mystery-encounters/encounters/absolute-avarice-encounter.ts
+++ b/src/data/mystery-encounters/encounters/absolute-avarice-encounter.ts
@@ -1,5 +1,6 @@
 import { audioManager } from "#app/global-audio-manager";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { modifierTypes } from "#data/data-lists";
 import { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagType } from "#enums/battler-tag-type";
@@ -38,7 +39,6 @@ import { MysteryEncounterOptionBuilder } from "#mystery-encounters/mystery-encou
 import { PersistentModifierRequirement } from "#mystery-encounters/mystery-encounter-requirements";
 import type { HeldModifierConfig } from "#types/held-modifier-config";
 import { randInt } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { groupStatChange } from "#utils/stat-change";
 import i18next from "i18next";
 
@@ -232,7 +232,7 @@ export const AbsoluteAvariceEncounter: MysteryEncounter = MysteryEncounterBuilde
       levelAdditiveModifier: 1,
       pokemonConfigs: [
         {
-          species: getPokemonSpecies(SpeciesId.GREEDENT),
+          species: speciesDataRegistry.getSpecies(SpeciesId.GREEDENT),
           isBoss: true,
           bossSegments: 3,
           shiny: false, // Shiny lock because of consistency issues between the different options
@@ -252,7 +252,7 @@ export const AbsoluteAvariceEncounter: MysteryEncounter = MysteryEncounterBuilde
     };
 
     encounter.enemyPartyConfigs = [config];
-    encounter.setDialogueToken("greedentName", getPokemonSpecies(SpeciesId.GREEDENT).getName());
+    encounter.setDialogueToken("greedentName", speciesDataRegistry.getSpecies(SpeciesId.GREEDENT).getName());
 
     return true;
   })
@@ -379,7 +379,13 @@ export const AbsoluteAvariceEncounter: MysteryEncounter = MysteryEncounterBuilde
         // Let it have the food
         // Greedent joins the team, level equal to 2 below highest party member (shiny locked)
         const level = getHighestLevelPlayerPokemon(false, true).level - 2;
-        const greedent = new EnemyPokemon(getPokemonSpecies(SpeciesId.GREEDENT), level, TrainerSlot.NONE, false, true);
+        const greedent = new EnemyPokemon(
+          speciesDataRegistry.getSpecies(SpeciesId.GREEDENT),
+          level,
+          TrainerSlot.NONE,
+          false,
+          true,
+        );
         greedent.moveset = [
           new PokemonMove(MoveId.THRASH),
           new PokemonMove(MoveId.BODY_PRESS),

--- a/src/data/mystery-encounters/encounters/an-offer-you-cant-refuse-encounter.ts
+++ b/src/data/mystery-encounters/encounters/an-offer-you-cant-refuse-encounter.ts
@@ -22,7 +22,6 @@ import {
   MoveRequirement,
 } from "#mystery-encounters/mystery-encounter-requirements";
 import { EXTORTION_ABILITIES, EXTORTION_MOVES } from "#mystery-encounters/requirement-groups";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import i18next from "i18next";
 
 /** the i18n namespace for this encounter */
@@ -112,7 +111,7 @@ export const AnOfferYouCantRefuseEncounter: MysteryEncounter = MysteryEncounterB
 
     const shinyCharm = generateModifierType(modifierTypes.SHINY_CHARM);
     encounter.setDialogueToken("itemName", shinyCharm?.name ?? i18next.t("modifierType:ModifierType.SHINY_CHARM.name"));
-    encounter.setDialogueToken("liepardName", getPokemonSpecies(SpeciesId.LIEPARD).getName());
+    encounter.setDialogueToken("liepardName", speciesDataRegistry.getSpecies(SpeciesId.LIEPARD).getName());
 
     return true;
   })
@@ -167,7 +166,11 @@ export const AnOfferYouCantRefuseEncounter: MysteryEncounter = MysteryEncounterB
         // Update money and remove pokemon from party
         updatePlayerMoney(encounter.misc.price);
 
-        setEncounterExp(encounter.options[1].primaryPokemon!.id, getPokemonSpecies(SpeciesId.LIEPARD).baseExp, true);
+        setEncounterExp(
+          encounter.options[1].primaryPokemon!.id,
+          speciesDataRegistry.getSpecies(SpeciesId.LIEPARD).baseExp,
+          true,
+        );
 
         leaveEncounterWithoutBattle(true);
       })

--- a/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
+++ b/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
@@ -1,5 +1,6 @@
 import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { EncounterBattleAnim } from "#data/battle-anims";
 import { allAbilities, modifierTypes } from "#data/data-lists";
 import { CustomPokemonData } from "#data/pokemon-data";
@@ -47,7 +48,7 @@ import { trainerConfigs } from "#trainers/trainer-config";
 import { TrainerPartyCompoundTemplate, TrainerPartyTemplate } from "#trainers/trainer-party-template";
 import type { OptionSelectConfig } from "#ui/base-option-select-ui-handler";
 import { randSeedInt, randSeedShuffle } from "#utils/common";
-import { getPokemonSpecies, getRandomRegularPokemonType } from "#utils/pokemon-utils";
+import { getRandomRegularPokemonType } from "#utils/pokemon-utils";
 import i18next from "i18next";
 
 /** the i18n namespace for the encounter */
@@ -157,13 +158,13 @@ export const ClowningAroundEncounter: MysteryEncounter = MysteryEncounterBuilder
       pokemonConfigs: [
         // Overrides first 2 pokemon to be Mr. Mime and Blacephalon
         {
-          species: getPokemonSpecies(SpeciesId.MR_MIME),
+          species: speciesDataRegistry.getSpecies(SpeciesId.MR_MIME),
           isBoss: true,
           moveSet: [MoveId.TEETER_DANCE, MoveId.ALLY_SWITCH, MoveId.DAZZLING_GLEAM, MoveId.PSYCHIC],
         },
         {
           // Blacephalon has the random ability from pool, and 2 entirely random types to fit with the theme of the encounter
-          species: getPokemonSpecies(SpeciesId.BLACEPHALON),
+          species: speciesDataRegistry.getSpecies(SpeciesId.BLACEPHALON),
           customPokemonData: new CustomPokemonData({
             ability,
             types: [firstType, secondType],
@@ -178,7 +179,7 @@ export const ClowningAroundEncounter: MysteryEncounter = MysteryEncounterBuilder
     // Load animations/sfx for start of fight moves
     loadCustomMovesForEncounter([MoveId.ROLE_PLAY, MoveId.TAUNT]);
 
-    encounter.setDialogueToken("blacephalonName", getPokemonSpecies(SpeciesId.BLACEPHALON).getName());
+    encounter.setDialogueToken("blacephalonName", speciesDataRegistry.getSpecies(SpeciesId.BLACEPHALON).getName());
 
     return true;
   })

--- a/src/data/mystery-encounters/encounters/dancing-lessons-encounter.ts
+++ b/src/data/mystery-encounters/encounters/dancing-lessons-encounter.ts
@@ -1,5 +1,6 @@
 import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { EncounterBattleAnim } from "#data/battle-anims";
 import { modifierTypes } from "#data/data-lists";
 import { BattlerIndex } from "#enums/battler-index";
@@ -38,7 +39,6 @@ import { MoveRequirement } from "#mystery-encounters/mystery-encounter-requireme
 import { DANCING_MOVES } from "#mystery-encounters/requirement-groups";
 import { PokemonData } from "#system/pokemon-data";
 import type { OptionSelectItem } from "#ui/base-option-select-ui-handler";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { groupStatChange } from "#utils/stat-change";
 import i18next from "i18next";
 
@@ -96,7 +96,7 @@ export const DancingLessonsEncounter: MysteryEncounter = MysteryEncounterBuilder
   .withOnInit(() => {
     const encounter = globalScene.currentBattle.mysteryEncounter!;
 
-    const species = getPokemonSpecies(SpeciesId.ORICORIO);
+    const species = speciesDataRegistry.getSpecies(SpeciesId.ORICORIO);
     const level = getEncounterPokemonLevelForWave(STANDARD_ENCOUNTER_BOOSTED_LEVEL_MODIFIER);
     const enemyPokemon = new EnemyPokemon(species, level, TrainerSlot.NONE, false);
     if (!enemyPokemon.moveset.some(m => m && m.getMove().id === MoveId.REVELATION_DANCE)) {
@@ -159,7 +159,7 @@ export const DancingLessonsEncounter: MysteryEncounter = MysteryEncounterBuilder
       oricorioData,
     };
 
-    encounter.setDialogueToken("oricorioName", getPokemonSpecies(SpeciesId.ORICORIO).getName());
+    encounter.setDialogueToken("oricorioName", speciesDataRegistry.getSpecies(SpeciesId.ORICORIO).getName());
 
     return true;
   })

--- a/src/data/mystery-encounters/encounters/dark-deal-encounter.ts
+++ b/src/data/mystery-encounters/encounters/dark-deal-encounter.ts
@@ -1,5 +1,6 @@
 import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { modifierTypes } from "#data/data-lists";
 import { Challenges } from "#enums/challenges";
 import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
@@ -16,7 +17,6 @@ import type { MysteryEncounter } from "#mystery-encounters/mystery-encounter";
 import { MysteryEncounterBuilder } from "#mystery-encounters/mystery-encounter";
 import { MysteryEncounterOptionBuilder } from "#mystery-encounters/mystery-encounter-option";
 import { randSeedInt } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 
 /** i18n namespace for encounter */
 const namespace = "mysteryEncounters/darkDeal";
@@ -181,7 +181,9 @@ export const DarkDealEncounter: MysteryEncounter = MysteryEncounterBuilder.withE
         // Starter egg tier, 35/50/10/5 %odds for tiers 6/7/8/9+
         const roll = randSeedInt(100);
         const starterTier: number | [number, number] = roll >= 65 ? 6 : roll >= 15 ? 7 : roll >= 5 ? 8 : [9, 10];
-        const bossSpecies = getPokemonSpecies(getRandomSpeciesByStarterCost(starterTier, excludedBosses, bossTypes));
+        const bossSpecies = speciesDataRegistry.getSpecies(
+          getRandomSpeciesByStarterCost(starterTier, excludedBosses, bossTypes),
+        );
         const pokemonConfig: EnemyPokemonConfig = {
           species: bossSpecies,
           isBoss: true,

--- a/src/data/mystery-encounters/encounters/delibirdy-encounter.ts
+++ b/src/data/mystery-encounters/encounters/delibirdy-encounter.ts
@@ -2,6 +2,7 @@ import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants";
 import { audioManager } from "#app/global-audio-manager";
 import { timedEventManager } from "#app/global-event-manager";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { modifierTypes } from "#data/data-lists";
 import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
 import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
@@ -35,7 +36,6 @@ import {
 } from "#mystery-encounters/mystery-encounter-requirements";
 import type { OptionSelectItem } from "#ui/base-option-select-ui-handler";
 import { randSeedItem } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import i18next from "i18next";
 
 /** the i18n namespace for this encounter */
@@ -137,7 +137,7 @@ export const DelibirdyEncounter: MysteryEncounter = MysteryEncounterBuilder.with
   ])
   .withOnInit(() => {
     const encounter = globalScene.currentBattle.mysteryEncounter!;
-    encounter.setDialogueToken("delibirdName", getPokemonSpecies(SpeciesId.DELIBIRD).getName());
+    encounter.setDialogueToken("delibirdName", speciesDataRegistry.getSpecies(SpeciesId.DELIBIRD).getName());
     return true;
   })
   .withOnVisualsStart(() => {

--- a/src/data/mystery-encounters/encounters/fiery-fallout-encounter.ts
+++ b/src/data/mystery-encounters/encounters/fiery-fallout-encounter.ts
@@ -1,5 +1,6 @@
 import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { EncounterBattleAnim } from "#data/battle-anims";
 import { allAbilities, modifierTypes } from "#data/data-lists";
 import { Gender } from "#data/gender";
@@ -46,7 +47,6 @@ import {
 } from "#mystery-encounters/mystery-encounter-requirements";
 import { FIRE_RESISTANT_ABILITIES } from "#mystery-encounters/requirement-groups";
 import { randSeedInt } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { groupStatChange } from "#utils/stat-change";
 
 /** the i18n namespace for the encounter */
@@ -83,7 +83,7 @@ export const FieryFalloutEncounter: MysteryEncounter = MysteryEncounterBuilder.w
     const encounter = globalScene.currentBattle.mysteryEncounter!;
 
     // Calculate boss mons
-    const volcaronaSpecies = getPokemonSpecies(SpeciesId.VOLCARONA);
+    const volcaronaSpecies = speciesDataRegistry.getSpecies(SpeciesId.VOLCARONA);
     const config: EnemyPartyConfig = {
       pokemonConfigs: [
         {
@@ -147,7 +147,7 @@ export const FieryFalloutEncounter: MysteryEncounter = MysteryEncounterBuilder.w
     const pokemon = globalScene.getEnemyPokemon();
     globalScene.arena.trySetWeather(WeatherType.SUNNY, pokemon);
 
-    encounter.setDialogueToken("volcaronaName", getPokemonSpecies(SpeciesId.VOLCARONA).getName());
+    encounter.setDialogueToken("volcaronaName", speciesDataRegistry.getSpecies(SpeciesId.VOLCARONA).getName());
 
     return true;
   })
@@ -288,7 +288,7 @@ export const FieryFalloutEncounter: MysteryEncounter = MysteryEncounterBuilder.w
 
         const primary = encounter.options[2].primaryPokemon!;
 
-        setEncounterExp([primary.id], getPokemonSpecies(SpeciesId.VOLCARONA).baseExp * 2);
+        setEncounterExp([primary.id], speciesDataRegistry.getSpecies(SpeciesId.VOLCARONA).baseExp * 2);
         leaveEncounterWithoutBattle();
       })
       .build(),

--- a/src/data/mystery-encounters/encounters/fun-and-games-encounter.ts
+++ b/src/data/mystery-encounters/encounters/fun-and-games-encounter.ts
@@ -1,6 +1,7 @@
 import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants";
 import { audioManager } from "#app/global-audio-manager";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { modifierTypes } from "#data/data-lists";
 import { SpeciesFormChangeActiveTrigger } from "#data/form-change-triggers";
@@ -27,7 +28,6 @@ import type { MysteryEncounter } from "#mystery-encounters/mystery-encounter";
 import { MysteryEncounterBuilder } from "#mystery-encounters/mystery-encounter";
 import { MysteryEncounterOptionBuilder } from "#mystery-encounters/mystery-encounter-option";
 import { MoneyRequirement } from "#mystery-encounters/mystery-encounter-requirements";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import i18next from "i18next";
 
 /** the i18n namespace for the encounter */
@@ -87,7 +87,7 @@ export const FunAndGamesEncounter: MysteryEncounter = MysteryEncounterBuilder.wi
   .withQuery(`${namespace}:query`)
   .withOnInit(() => {
     const encounter = globalScene.currentBattle.mysteryEncounter!;
-    encounter.setDialogueToken("wobbuffetName", getPokemonSpecies(SpeciesId.WOBBUFFET).getName());
+    encounter.setDialogueToken("wobbuffetName", speciesDataRegistry.getSpecies(SpeciesId.WOBBUFFET).getName());
     return true;
   })
   .withOnVisualsStart(() => {
@@ -210,7 +210,7 @@ async function summonPlayerPokemon() {
     });
 
     // Also loads Wobbuffet data (cannot be shiny)
-    const enemySpecies = getPokemonSpecies(SpeciesId.WOBBUFFET);
+    const enemySpecies = speciesDataRegistry.getSpecies(SpeciesId.WOBBUFFET);
     globalScene.currentBattle.enemyParty = [];
     const wobbuffet = globalScene.addEnemyPokemon(
       enemySpecies,

--- a/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
+++ b/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
@@ -41,7 +41,6 @@ import type { OptionSelectItem } from "#ui/base-option-select-ui-handler";
 import { randInt, randSeedInt, randSeedItem, randSeedShuffle } from "#utils/common";
 import { getEnumKeys } from "#utils/enums";
 import { getRandomLocaleEntry } from "#utils/i18n";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { toCamelCase } from "#utils/strings";
 import i18next from "i18next";
 
@@ -482,7 +481,7 @@ function getPokemonTradeOptions(): Map<number, EnemyPokemon[]> {
     if (pokemon.species.legendary || pokemon.species.subLegendary || pokemon.species.mythical) {
       const generation = pokemon.species.generation;
       const tradeOptions: EnemyPokemon[] = LEGENDARY_TRADE_POOLS[generation].map(s => {
-        const pokemonSpecies = getPokemonSpecies(s);
+        const pokemonSpecies = speciesDataRegistry.getSpecies(s);
         return new EnemyPokemon(pokemonSpecies, 5, TrainerSlot.NONE, false);
       });
       tradeOptionsMap.set(pokemon.id, tradeOptions);

--- a/src/data/mystery-encounters/encounters/lost-at-sea-encounter.ts
+++ b/src/data/mystery-encounters/encounters/lost-at-sea-encounter.ts
@@ -1,5 +1,6 @@
 import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { MoveId } from "#enums/move-id";
 import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
 import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
@@ -11,7 +12,6 @@ import { applyDamageToPokemon } from "#mystery-encounters/encounter-pokemon-util
 import type { MysteryEncounter } from "#mystery-encounters/mystery-encounter";
 import { MysteryEncounterBuilder } from "#mystery-encounters/mystery-encounter";
 import { MysteryEncounterOptionBuilder } from "#mystery-encounters/mystery-encounter-option";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 
 const OPTION_1_REQUIRED_MOVE = MoveId.SURF;
 const OPTION_2_REQUIRED_MOVE = MoveId.FLY;
@@ -129,7 +129,7 @@ export const LostAtSeaEncounter: MysteryEncounter = MysteryEncounterBuilder.with
  * Generic handler for using a guiding pokemon to guide you back.
  */
 function handlePokemonGuidingYouPhase() {
-  const laprasSpecies = getPokemonSpecies(SpeciesId.LAPRAS);
+  const laprasSpecies = speciesDataRegistry.getSpecies(SpeciesId.LAPRAS);
   const { mysteryEncounter } = globalScene.currentBattle;
 
   if (mysteryEncounter?.selectedOption?.primaryPokemon?.id) {

--- a/src/data/mystery-encounters/encounters/mysterious-chest-encounter.ts
+++ b/src/data/mystery-encounters/encounters/mysterious-chest-encounter.ts
@@ -1,5 +1,6 @@
 import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { ModifierTier } from "#enums/modifier-tier";
 import { MoveId } from "#enums/move-id";
 import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
@@ -19,7 +20,6 @@ import type { MysteryEncounter } from "#mystery-encounters/mystery-encounter";
 import { MysteryEncounterBuilder } from "#mystery-encounters/mystery-encounter";
 import { MysteryEncounterOptionBuilder } from "#mystery-encounters/mystery-encounter-option";
 import { randSeedInt } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 
 /** i18n namespace for encounter */
 const namespace = "mysteryEncounters/mysteriousChest";
@@ -82,7 +82,7 @@ export const MysteriousChestEncounter: MysteryEncounter = MysteryEncounterBuilde
       disableSwitch: true,
       pokemonConfigs: [
         {
-          species: getPokemonSpecies(SpeciesId.GIMMIGHOUL),
+          species: speciesDataRegistry.getSpecies(SpeciesId.GIMMIGHOUL),
           formIndex: 0,
           isBoss: true,
           moveSet: [MoveId.NASTY_PLOT, MoveId.SHADOW_BALL, MoveId.POWER_GEM, MoveId.THIEF],
@@ -92,7 +92,7 @@ export const MysteriousChestEncounter: MysteryEncounter = MysteryEncounterBuilde
 
     encounter.enemyPartyConfigs = [config];
 
-    encounter.setDialogueToken("gimmighoulName", getPokemonSpecies(SpeciesId.GIMMIGHOUL).getName());
+    encounter.setDialogueToken("gimmighoulName", speciesDataRegistry.getSpecies(SpeciesId.GIMMIGHOUL).getName());
     encounter.setDialogueToken("trapPercent", TRAP_PERCENT.toString());
     encounter.setDialogueToken("commonPercent", COMMON_REWARDS_PERCENT.toString());
     encounter.setDialogueToken("ultraPercent", ULTRA_REWARDS_PERCENT.toString());

--- a/src/data/mystery-encounters/encounters/safari-zone-encounter.ts
+++ b/src/data/mystery-encounters/encounters/safari-zone-encounter.ts
@@ -1,6 +1,7 @@
 import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants";
 import { audioManager } from "#app/global-audio-manager";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { NON_LEGEND_PARADOX_POKEMON } from "#balance/special-species-groups";
 import type { PokemonSpecies } from "#data/pokemon-species";
@@ -32,7 +33,6 @@ import type { MysteryEncounterOption } from "#mystery-encounters/mystery-encount
 import { MysteryEncounterOptionBuilder } from "#mystery-encounters/mystery-encounter-option";
 import { MoneyRequirement } from "#mystery-encounters/mystery-encounter-requirements";
 import { BooleanHolder, NumberHolder, randSeedInt } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 
 /** the i18n namespace for the encounter */
 const namespace = "mysteryEncounters/safariZone";
@@ -579,7 +579,7 @@ async function doEndTurn(cursorIndex: number) {
  * @returns A function to get a random species that has at most 5 starter cost and is not Mythical, Paradox, etc.
  */
 export function getSafariSpeciesSpawn(): PokemonSpecies {
-  return getPokemonSpecies(
+  return speciesDataRegistry.getSpecies(
     getRandomSpeciesByStarterCost([0, 5], NON_LEGEND_PARADOX_POKEMON, undefined, false, false, false),
   );
 }

--- a/src/data/mystery-encounters/encounters/slumbering-snorlax-encounter.ts
+++ b/src/data/mystery-encounters/encounters/slumbering-snorlax-encounter.ts
@@ -1,4 +1,5 @@
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { modifierTypes } from "#data/data-lists";
 import { CustomPokemonData } from "#data/pokemon-data";
 import { AiType } from "#enums/ai-type";
@@ -31,7 +32,6 @@ import { MysteryEncounterOptionBuilder } from "#mystery-encounters/mystery-encou
 import { MoveRequirement } from "#mystery-encounters/mystery-encounter-requirements";
 import { STEALING_MOVES } from "#mystery-encounters/requirement-groups";
 import { randSeedInt } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 
 /** i18n namespace for the encounter */
 const namespace = "mysteryEncounters/slumberingSnorlax";
@@ -71,7 +71,7 @@ export const SlumberingSnorlaxEncounter: MysteryEncounter = MysteryEncounterBuil
     console.log(encounter);
 
     // Calculate boss mon
-    const bossSpecies = getPokemonSpecies(SpeciesId.SNORLAX);
+    const bossSpecies = speciesDataRegistry.getSpecies(SpeciesId.SNORLAX);
     const pokemonConfig: EnemyPokemonConfig = {
       species: bossSpecies,
       isBoss: true,
@@ -110,7 +110,7 @@ export const SlumberingSnorlaxEncounter: MysteryEncounter = MysteryEncounterBuil
     // Load animations/sfx for Snorlax fight start moves
     loadCustomMovesForEncounter([MoveId.SNORE]);
 
-    encounter.setDialogueToken("snorlaxName", getPokemonSpecies(SpeciesId.SNORLAX).getName());
+    encounter.setDialogueToken("snorlaxName", speciesDataRegistry.getSpecies(SpeciesId.SNORLAX).getName());
 
     return true;
   })
@@ -183,7 +183,7 @@ export const SlumberingSnorlaxEncounter: MysteryEncounter = MysteryEncounterBuil
           fillRemaining: false,
         });
         // Snorlax exp to Pokemon that did the stealing
-        setEncounterExp(instance.primaryPokemon!.id, getPokemonSpecies(SpeciesId.SNORLAX).baseExp);
+        setEncounterExp(instance.primaryPokemon!.id, speciesDataRegistry.getSpecies(SpeciesId.SNORLAX).baseExp);
         leaveEncounterWithoutBattle();
       })
       .build(),

--- a/src/data/mystery-encounters/encounters/the-expert-pokemon-breeder-encounter.ts
+++ b/src/data/mystery-encounters/encounters/the-expert-pokemon-breeder-encounter.ts
@@ -31,7 +31,6 @@ import { MysteryEncounterBuilder } from "#mystery-encounters/mystery-encounter";
 import { MysteryEncounterOptionBuilder } from "#mystery-encounters/mystery-encounter-option";
 import { trainerConfigs } from "#trainers/trainer-config";
 import { randSeedShuffle } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import i18next from "i18next";
 
 /** the i18n namespace for the encounter */
@@ -478,20 +477,21 @@ function getPartyConfig(): EnemyPartyConfig {
   breederConfig.name = i18next.t(trainerNameKey);
 
   // First mon is *always* this special cleffa
-  const cleffaSpecies =
+  const cleffaSpeciesId =
     waveIndex < FIRST_STAGE_EVOLUTION_WAVE
       ? SpeciesId.CLEFFA
       : waveIndex < FINAL_STAGE_EVOLUTION_WAVE
         ? SpeciesId.CLEFAIRY
         : SpeciesId.CLEFABLE;
+  const cleffaSpecies = speciesDataRegistry.getSpecies(cleffaSpeciesId);
   const baseConfig: EnemyPartyConfig = {
     trainerType: TrainerType.EXPERT_POKEMON_BREEDER,
     pokemonConfigs: [
       {
         nickname: i18next.t(`${namespace}:cleffa1Nickname`, {
-          speciesName: getPokemonSpecies(cleffaSpecies).getName(),
+          speciesName: cleffaSpecies.getName(),
         }),
-        species: getPokemonSpecies(cleffaSpecies),
+        species: cleffaSpecies,
         isBoss: false,
         abilityIndex: 1, // Magic Guard
         shiny: false,
@@ -515,9 +515,9 @@ function getPartyConfig(): EnemyPartyConfig {
     baseConfig.pokemonConfigs!.push(
       {
         nickname: i18next.t(`${namespace}:cleffa2Nickname`, {
-          speciesName: getPokemonSpecies(cleffaSpecies).getName(),
+          speciesName: cleffaSpecies.getName(),
         }),
-        species: getPokemonSpecies(cleffaSpecies),
+        species: cleffaSpecies,
         isBoss: false,
         abilityIndex: 1, // Magic Guard
         shiny: true,
@@ -535,9 +535,9 @@ function getPartyConfig(): EnemyPartyConfig {
       },
       {
         nickname: i18next.t(`${namespace}:cleffa3Nickname`, {
-          speciesName: getPokemonSpecies(cleffaSpecies).getName(),
+          speciesName: cleffaSpecies.getName(),
         }),
-        species: getPokemonSpecies(cleffaSpecies),
+        species: cleffaSpecies,
         isBoss: false,
         abilityIndex: 2, // Friend Guard / Unaware
         shiny: true,
@@ -562,7 +562,7 @@ function getPartyConfig(): EnemyPartyConfig {
 
     baseConfig.pokemonConfigs!.push(
       {
-        species: getPokemonSpecies(pool1Species),
+        species: speciesDataRegistry.getSpecies(pool1Species),
         isBoss: false,
         modifierConfigs: [
           {
@@ -572,7 +572,7 @@ function getPartyConfig(): EnemyPartyConfig {
         ],
       },
       {
-        species: getPokemonSpecies(pool2Species),
+        species: speciesDataRegistry.getSpecies(pool2Species),
         isBoss: false,
         modifierConfigs: [
           {

--- a/src/data/mystery-encounters/encounters/the-pokemon-salesman-encounter.ts
+++ b/src/data/mystery-encounters/encounters/the-pokemon-salesman-encounter.ts
@@ -29,7 +29,6 @@ import { MysteryEncounterOptionBuilder } from "#mystery-encounters/mystery-encou
 import { MoneyRequirement } from "#mystery-encounters/mystery-encounter-requirements";
 import { PokemonData } from "#system/pokemon-data";
 import { randSeedInt, randSeedItem } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 
 /** the i18n namespace for this encounter */
 const namespace = "mysteryEncounters/thePokemonSalesman";
@@ -116,7 +115,7 @@ export const ThePokemonSalesmanEncounter: MysteryEncounter = MysteryEncounterBui
         && validEventEncounters.length === 0)
     ) {
       // If you roll 1%, give shiny Magikarp with random variant
-      species = getPokemonSpecies(SpeciesId.MAGIKARP);
+      species = speciesDataRegistry.getSpecies(SpeciesId.MAGIKARP);
       pokemon = new PlayerPokemon(species, 5, 2, undefined, undefined, true);
     } else if (
       validEventEncounters.length > 0
@@ -126,7 +125,7 @@ export const ThePokemonSalesmanEncounter: MysteryEncounter = MysteryEncounterBui
       do {
         // If you roll 50%, give event encounter with 3 extra shiny rolls and its HA, if it has one
         const enc = randSeedItem(validEventEncounters);
-        species = getPokemonSpecies(enc.species);
+        species = speciesDataRegistry.getSpecies(enc.species);
         pokemon = new PlayerPokemon(
           species,
           5,
@@ -144,10 +143,10 @@ export const ThePokemonSalesmanEncounter: MysteryEncounter = MysteryEncounterBui
       } while (tries < 6);
       if (!pokemon.shiny && pokemon.abilityIndex !== 2) {
         // If, after 6 tries, you STILL somehow don't have an HA or shiny mon, pick from only the event mons that have an HA.
-        if (validEventEncounters.some(s => !!getPokemonSpecies(s.species).abilityHidden)) {
-          validEventEncounters.filter(s => !!getPokemonSpecies(s.species).abilityHidden);
+        if (validEventEncounters.some(s => !!speciesDataRegistry.getSpecies(s.species).abilityHidden)) {
+          validEventEncounters.filter(s => !!speciesDataRegistry.getSpecies(s.species).abilityHidden);
           const enc = randSeedItem(validEventEncounters);
-          species = getPokemonSpecies(enc.species);
+          species = speciesDataRegistry.getSpecies(enc.species);
           pokemon = new PlayerPokemon(species, 5, 2, enc.formIndex);
           pokemon.trySetShinySeed();
           pokemon.trySetShinySeed();
@@ -155,7 +154,7 @@ export const ThePokemonSalesmanEncounter: MysteryEncounter = MysteryEncounterBui
           isEventEncounter = true;
         } else {
           // If there's, and this would never happen, no eligible event encounters with a hidden ability, just do Magikarp
-          species = getPokemonSpecies(SpeciesId.MAGIKARP);
+          species = speciesDataRegistry.getSpecies(SpeciesId.MAGIKARP);
           pokemon = new PlayerPokemon(species, 5, 2, undefined, undefined, true);
         }
       }
@@ -255,7 +254,7 @@ export const ThePokemonSalesmanEncounter: MysteryEncounter = MysteryEncounterBui
  * @returns A random species that has at most 5 starter cost and is not Mythical, Paradox, etc.
  */
 export function getSalesmanSpeciesOffer(): PokemonSpecies {
-  return getPokemonSpecies(
+  return speciesDataRegistry.getSpecies(
     getRandomSpeciesByStarterCost([0, 5], NON_LEGEND_PARADOX_POKEMON, undefined, false, false, false),
   );
 }

--- a/src/data/mystery-encounters/encounters/the-strong-stuff-encounter.ts
+++ b/src/data/mystery-encounters/encounters/the-strong-stuff-encounter.ts
@@ -1,5 +1,6 @@
 import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { modifierTypes } from "#data/data-lists";
 import { CustomPokemonData } from "#data/pokemon-data";
 import { BattlerIndex } from "#enums/battler-index";
@@ -28,7 +29,6 @@ import {
 import { modifyPlayerPokemonBST } from "#mystery-encounters/encounter-pokemon-utils";
 import type { MysteryEncounter } from "#mystery-encounters/mystery-encounter";
 import { MysteryEncounterBuilder } from "#mystery-encounters/mystery-encounter";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { groupStatChange } from "#utils/stat-change";
 
 /** the i18n namespace for the encounter */
@@ -90,7 +90,7 @@ export const TheStrongStuffEncounter: MysteryEncounter = MysteryEncounterBuilder
       disableSwitch: true,
       pokemonConfigs: [
         {
-          species: getPokemonSpecies(SpeciesId.SHUCKLE),
+          species: speciesDataRegistry.getSpecies(SpeciesId.SHUCKLE),
           isBoss: true,
           bossSegments: 5,
           shiny: false, // Shiny lock because shiny is rolled only if the battle option is picked
@@ -132,7 +132,7 @@ export const TheStrongStuffEncounter: MysteryEncounter = MysteryEncounterBuilder
 
     loadCustomMovesForEncounter([MoveId.GASTRO_ACID, MoveId.STEALTH_ROCK]);
 
-    encounter.setDialogueToken("shuckleName", getPokemonSpecies(SpeciesId.SHUCKLE).getName());
+    encounter.setDialogueToken("shuckleName", speciesDataRegistry.getSpecies(SpeciesId.SHUCKLE).getName());
 
     return true;
   })

--- a/src/data/mystery-encounters/encounters/the-winstrate-challenge-encounter.ts
+++ b/src/data/mystery-encounters/encounters/the-winstrate-challenge-encounter.ts
@@ -2,6 +2,7 @@ import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants";
 import { audioManager } from "#app/global-audio-manager";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { modifierTypes } from "#data/data-lists";
 import { SpeciesFormChangeAbilityTrigger } from "#data/form-change-triggers";
 import { AbilityId } from "#enums/ability-id";
@@ -30,7 +31,6 @@ import {
 } from "#mystery-encounters/encounter-phase-utils";
 import type { MysteryEncounter } from "#mystery-encounters/mystery-encounter";
 import { MysteryEncounterBuilder } from "#mystery-encounters/mystery-encounter";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import i18next from "i18next";
 
 /** the i18n namespace for the encounter */
@@ -256,7 +256,7 @@ function getVictorTrainerConfig(): EnemyPartyConfig {
     trainerType: TrainerType.VICTOR,
     pokemonConfigs: [
       {
-        species: getPokemonSpecies(SpeciesId.SWELLOW),
+        species: speciesDataRegistry.getSpecies(SpeciesId.SWELLOW),
         isBoss: false,
         abilityIndex: 0, // Guts
         nature: Nature.ADAMANT,
@@ -274,7 +274,7 @@ function getVictorTrainerConfig(): EnemyPartyConfig {
         ],
       },
       {
-        species: getPokemonSpecies(SpeciesId.OBSTAGOON),
+        species: speciesDataRegistry.getSpecies(SpeciesId.OBSTAGOON),
         isBoss: false,
         abilityIndex: 1, // Guts
         nature: Nature.ADAMANT,
@@ -300,7 +300,7 @@ function getVictoriaTrainerConfig(): EnemyPartyConfig {
     trainerType: TrainerType.VICTORIA,
     pokemonConfigs: [
       {
-        species: getPokemonSpecies(SpeciesId.ROSERADE),
+        species: speciesDataRegistry.getSpecies(SpeciesId.ROSERADE),
         isBoss: false,
         abilityIndex: 0, // Natural Cure
         nature: Nature.CALM,
@@ -318,7 +318,7 @@ function getVictoriaTrainerConfig(): EnemyPartyConfig {
         ],
       },
       {
-        species: getPokemonSpecies(SpeciesId.GARDEVOIR),
+        species: speciesDataRegistry.getSpecies(SpeciesId.GARDEVOIR),
         isBoss: false,
         formIndex: 1,
         nature: Nature.TIMID,
@@ -349,7 +349,7 @@ function getViviTrainerConfig(): EnemyPartyConfig {
     trainerType: TrainerType.VIVI,
     pokemonConfigs: [
       {
-        species: getPokemonSpecies(SpeciesId.SEAKING),
+        species: speciesDataRegistry.getSpecies(SpeciesId.SEAKING),
         isBoss: false,
         abilityIndex: 3, // Lightning Rod
         nature: Nature.ADAMANT,
@@ -368,7 +368,7 @@ function getViviTrainerConfig(): EnemyPartyConfig {
         ],
       },
       {
-        species: getPokemonSpecies(SpeciesId.BRELOOM),
+        species: speciesDataRegistry.getSpecies(SpeciesId.BRELOOM),
         isBoss: false,
         abilityIndex: 1, // Poison Heal
         nature: Nature.JOLLY,
@@ -386,7 +386,7 @@ function getViviTrainerConfig(): EnemyPartyConfig {
         ],
       },
       {
-        species: getPokemonSpecies(SpeciesId.CAMERUPT),
+        species: speciesDataRegistry.getSpecies(SpeciesId.CAMERUPT),
         isBoss: false,
         formIndex: 1,
         nature: Nature.CALM,
@@ -408,7 +408,7 @@ function getVickyTrainerConfig(): EnemyPartyConfig {
     trainerType: TrainerType.VICKY,
     pokemonConfigs: [
       {
-        species: getPokemonSpecies(SpeciesId.MEDICHAM),
+        species: speciesDataRegistry.getSpecies(SpeciesId.MEDICHAM),
         isBoss: false,
         formIndex: 1,
         nature: Nature.IMPISH,
@@ -429,7 +429,7 @@ function getVitoTrainerConfig(): EnemyPartyConfig {
     trainerType: TrainerType.VITO,
     pokemonConfigs: [
       {
-        species: getPokemonSpecies(SpeciesId.HISUI_ELECTRODE),
+        species: speciesDataRegistry.getSpecies(SpeciesId.HISUI_ELECTRODE),
         isBoss: false,
         abilityIndex: 0, // Soundproof
         nature: Nature.MODEST,
@@ -443,7 +443,7 @@ function getVitoTrainerConfig(): EnemyPartyConfig {
         ],
       },
       {
-        species: getPokemonSpecies(SpeciesId.SWALOT),
+        species: speciesDataRegistry.getSpecies(SpeciesId.SWALOT),
         isBoss: false,
         abilityIndex: 2, // Gluttony
         nature: Nature.QUIET,
@@ -496,7 +496,7 @@ function getVitoTrainerConfig(): EnemyPartyConfig {
         ],
       },
       {
-        species: getPokemonSpecies(SpeciesId.DODRIO),
+        species: speciesDataRegistry.getSpecies(SpeciesId.DODRIO),
         isBoss: false,
         abilityIndex: 2, // Tangled Feet
         nature: Nature.JOLLY,
@@ -510,7 +510,7 @@ function getVitoTrainerConfig(): EnemyPartyConfig {
         ],
       },
       {
-        species: getPokemonSpecies(SpeciesId.ALAKAZAM),
+        species: speciesDataRegistry.getSpecies(SpeciesId.ALAKAZAM),
         isBoss: false,
         formIndex: 1,
         nature: Nature.BOLD,
@@ -524,7 +524,7 @@ function getVitoTrainerConfig(): EnemyPartyConfig {
         ],
       },
       {
-        species: getPokemonSpecies(SpeciesId.DARMANITAN),
+        species: speciesDataRegistry.getSpecies(SpeciesId.DARMANITAN),
         isBoss: false,
         abilityIndex: 0, // Sheer Force
         nature: Nature.IMPISH,

--- a/src/data/mystery-encounters/encounters/trash-to-treasure-encounter.ts
+++ b/src/data/mystery-encounters/encounters/trash-to-treasure-encounter.ts
@@ -1,6 +1,7 @@
 import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants";
 import { audioManager } from "#app/global-audio-manager";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { modifierTypes } from "#data/data-lists";
 import { BattlerIndex } from "#enums/battler-index";
 import { ModifierTier } from "#enums/modifier-tier";
@@ -28,7 +29,6 @@ import { applyModifierTypeToPlayerPokemon } from "#mystery-encounters/encounter-
 import { type MysteryEncounter, MysteryEncounterBuilder } from "#mystery-encounters/mystery-encounter";
 import { MysteryEncounterOptionBuilder } from "#mystery-encounters/mystery-encounter-option";
 import { randSeedInt } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import i18next from "i18next";
 
 /** the i18n namespace for this encounter */
@@ -77,7 +77,7 @@ export const TrashToTreasureEncounter: MysteryEncounter = MysteryEncounterBuilde
     const encounter = globalScene.currentBattle.mysteryEncounter!;
 
     // Calculate boss mon (shiny locked)
-    const bossSpecies = getPokemonSpecies(SpeciesId.GARBODOR);
+    const bossSpecies = speciesDataRegistry.getSpecies(SpeciesId.GARBODOR);
     const pokemonConfig: EnemyPokemonConfig = {
       species: bossSpecies,
       isBoss: true,

--- a/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
+++ b/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
@@ -43,7 +43,7 @@ import { trainerConfigs } from "#trainers/trainer-config";
 import { TrainerPartyTemplate } from "#trainers/trainer-party-template";
 import type { HeldModifierConfig } from "#types/held-modifier-config";
 import { NumberHolder, randSeedInt, randSeedShuffle } from "#utils/common";
-import { getPokemonSpecies, getRandomRegularPokemonType } from "#utils/pokemon-utils";
+import { getRandomRegularPokemonType } from "#utils/pokemon-utils";
 import i18next from "i18next";
 
 /** i18n namespace for encounter */
@@ -569,7 +569,7 @@ async function postProcessTransformedPokemon(
       isNewStarter = true;
       await showEncounterText(
         i18next.t("battle:addedAsAStarter", {
-          pokemonName: getPokemonSpecies(speciesRootForm).getName(),
+          pokemonName: speciesDataRegistry.getSpecies(speciesRootForm).getName(),
         }),
       );
     }
@@ -786,7 +786,11 @@ async function addEggMoveToNewPokemonMoveset(
 
       // For pokemon that the player owns (including ones just caught), unlock the egg move
       if (!forBattle && randomEggMoveIndex != null && globalScene.gameData.dexData[speciesRootForm].caughtAttr) {
-        await globalScene.gameData.setEggMoveUnlocked(getPokemonSpecies(speciesRootForm), randomEggMoveIndex, true);
+        await globalScene.gameData.setEggMoveUnlocked(
+          speciesDataRegistry.getSpecies(speciesRootForm),
+          randomEggMoveIndex,
+          true,
+        );
       }
     }
   }

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -2,6 +2,7 @@ import type { Battle } from "#app/battle";
 import { audioManager } from "#app/global-audio-manager";
 import { timedEventManager } from "#app/global-event-manager";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { BASE_HIDDEN_ABILITY_RATE, BASE_SHINY_CHANCE } from "#balance/rates";
 import { initMoveAnim, loadMoveAnimAssets } from "#data/battle-anims";
@@ -52,7 +53,6 @@ import type { OptionSelectConfig, OptionSelectItem } from "#ui/base-option-selec
 import type { PartyOption, PokemonSelectFilter } from "#ui/party-ui-handler";
 import { coerceArray } from "#utils/array";
 import { BooleanHolder, randSeedInt, randSeedItem } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import i18next from "i18next";
 
 /**
@@ -1016,16 +1016,13 @@ export function getRandomEncounterPokemon(params: RandomEncounterParams): EnemyP
 
   if (eventChance && eventEncounters.length > 0 && (eventChance === 100 || randSeedInt(100) < eventChance)) {
     const eventEncounter = randSeedItem(eventEncounters);
-    const levelSpecies = getPokemonSpecies(eventEncounter.species).getWildSpeciesForLevel(
-      level,
-      !eventEncounter.blockEvolution,
-      isBoss,
-      globalScene.gameMode,
-    );
+    const levelSpecies = speciesDataRegistry
+      .getSpecies(eventEncounter.species)
+      .getWildSpeciesForLevel(level, !eventEncounter.blockEvolution, isBoss, globalScene.gameMode);
     if (params.isEventEncounter) {
       params.isEventEncounter.value = true;
     }
-    bossSpecies = getPokemonSpecies(levelSpecies);
+    bossSpecies = speciesDataRegistry.getSpecies(levelSpecies);
     formIndex = eventEncounter.formIndex;
   } else if (speciesFunction) {
     bossSpecies = speciesFunction();

--- a/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
@@ -37,7 +37,6 @@ import type { PartyOption } from "#ui/party-ui-handler";
 import { SummaryUiMode } from "#ui/summary-ui-handler";
 import { applyChallenges } from "#utils/challenge-utils";
 import { BooleanHolder, randSeedInt } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import i18next from "i18next";
 
 /** Will give +1 level every 10 waves */
@@ -45,31 +44,22 @@ export const STANDARD_ENCOUNTER_BOOSTED_LEVEL_MODIFIER = 1;
 
 /**
  * Gets the sprite key and file root for a given PokemonSpecies (accounts for gender, shiny, variants, forms, and experimental)
- * @param species
+ * @param speciesId
  * @param female
  * @param formIndex
  * @param shiny
  * @param variant
  */
 export function getSpriteKeysFromSpecies(
-  species: SpeciesId,
+  speciesId: SpeciesId,
   female?: boolean,
   formIndex?: number,
   shiny?: boolean,
   variant?: number,
 ): { spriteKey: string; fileRoot: string } {
-  const spriteKey = getPokemonSpecies(species).getSpriteKey(
-    female ?? false,
-    formIndex ?? 0,
-    shiny ?? false,
-    variant ?? 0,
-  );
-  const fileRoot = getPokemonSpecies(species).getSpriteAtlasPath(
-    female ?? false,
-    formIndex ?? 0,
-    shiny ?? false,
-    variant ?? 0,
-  );
+  const species = speciesDataRegistry.getSpecies(speciesId);
+  const spriteKey = species.getSpriteKey(female ?? false, formIndex ?? 0, shiny ?? false, variant ?? 0);
+  const fileRoot = species.getSpriteAtlasPath(female ?? false, formIndex ?? 0, shiny ?? false, variant ?? 0);
   return { spriteKey, fileRoot };
 }
 
@@ -261,20 +251,19 @@ export function getRandomSpeciesByStarterCost(
   let min = Array.isArray(starterTiers) ? starterTiers[0] : starterTiers;
   let max = Array.isArray(starterTiers) ? starterTiers[1] : starterTiers;
 
-  let filteredSpecies: [PokemonSpecies, number][] = speciesDataRegistry
-    .getAllStarters()
-    .map(s => [s, speciesDataRegistry.getStarterCost(s)])
-    .filter(s => {
-      const pokemonSpecies = getPokemonSpecies(s[0]);
-      return (
-        pokemonSpecies
-        && (!excludedSpecies || !excludedSpecies.includes(s[0]))
-        && (allowSubLegendary || !pokemonSpecies.subLegendary)
-        && (allowLegendary || !pokemonSpecies.legendary)
-        && (allowMythical || !pokemonSpecies.mythical)
-      );
-    })
-    .map(s => [getPokemonSpecies(s[0]), s[1]]);
+  let filteredSpecies: [species: PokemonSpecies, cost: number][] = [];
+
+  for (const species of speciesDataRegistry.getAllStarters(true)) {
+    if (
+      species
+      && !excludedSpecies?.includes(species.speciesId)
+      && (allowSubLegendary || !species.subLegendary)
+      && (allowLegendary || !species.legendary)
+      && (allowMythical || !species.mythical)
+    ) {
+      filteredSpecies.push([species, speciesDataRegistry.getStarterCost(species.speciesId)]);
+    }
+  }
 
   if (types && types.length > 0) {
     filteredSpecies = filteredSpecies.filter(
@@ -962,13 +951,15 @@ export function getGoldenBugNetSpecies(level: number): PokemonSpecies {
   for (const speciesWeightPair of GOLDEN_BUG_NET_SPECIES_POOL) {
     w += speciesWeightPair[1];
     if (roll < w) {
-      const initialSpecies = getPokemonSpecies(speciesWeightPair[0]);
-      return getPokemonSpecies(initialSpecies.getWildSpeciesForLevel(level, true, false, globalScene.gameMode));
+      const initialSpecies = speciesDataRegistry.getSpecies(speciesWeightPair[0]);
+      return speciesDataRegistry.getSpecies(
+        initialSpecies.getWildSpeciesForLevel(level, true, false, globalScene.gameMode),
+      );
     }
   }
 
   // Defaults to Scyther
-  return getPokemonSpecies(SpeciesId.SCYTHER);
+  return speciesDataRegistry.getSpecies(SpeciesId.SCYTHER);
 }
 
 /**

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -28,7 +28,7 @@ import type { StarterMoveset } from "#types/save-data";
 import type { EvolutionLevel, EvolutionLevelWithThreshold } from "#types/species-gen-types";
 import { argbFromRgba, rgbaFromArgb } from "#utils/color-utils";
 import { randSeedFloat } from "#utils/common";
-import { getPokemonSpecies, getPokemonSpeciesForm } from "#utils/pokemon-utils";
+import { getPokemonSpeciesForm } from "#utils/pokemon-utils";
 import { toCamelCase, toPascalCase } from "#utils/strings";
 import { QuantizerCelebi } from "@material/material-color-utilities";
 import i18next from "i18next";
@@ -373,12 +373,12 @@ export abstract class PokemonSpeciesForm {
 
     const replacement = timedEventManager.getEventPokemonSpriteReplacement(this.speciesId, formIndex);
     if (replacement) {
-      const replacementFormSpriteKey = getPokemonSpecies(replacement.speciesId).forms[
-        replacement.formIndex
-      ]?.getFormSpriteKey(replacement.formIndex);
+      const replacementFormSpriteKey = speciesDataRegistry
+        .getSpecies(replacement.speciesId)
+        .forms[replacement.formIndex]?.getFormSpriteKey(replacement.formIndex);
 
       const replacementShowGenderDiffs =
-        getPokemonSpecies(replacement.speciesId).genderDiffs
+        speciesDataRegistry.getSpecies(replacement.speciesId).genderDiffs
         && female
         && ![
           SpeciesFormKey.MEGA,
@@ -424,7 +424,7 @@ export abstract class PokemonSpeciesForm {
   getVariantDataIndex(formIndex?: number): string | number {
     let formkey: string | null = null;
     let variantDataIndex: number | string = this.speciesId;
-    const species = getPokemonSpecies(this.speciesId);
+    const species = speciesDataRegistry.getSpecies(this.speciesId);
     if (species.forms.length > 0 && formIndex !== undefined) {
       formkey = species.forms[formIndex]?.getFormSpriteKey(formIndex);
       if (formkey) {
@@ -556,11 +556,11 @@ export abstract class PokemonSpeciesForm {
       }
     }
     let ret: string = speciesId.toString();
-    const forms = getPokemonSpecies(speciesId).forms;
+    const forms = speciesDataRegistry.getSpecies(speciesId).forms;
     if (forms.length > 0) {
       if (formIndex !== undefined && formIndex >= forms.length) {
         console.warn(
-          `Attempted accessing form with index ${formIndex} of species ${getPokemonSpecies(speciesId).getName()} with only ${forms.length || 0} forms`,
+          `Attempted accessing form with index ${formIndex} of species ${speciesDataRegistry.getSpecies(speciesId).getName()} with only ${forms.length || 0} forms`,
         );
         formIndex = Math.min(formIndex, forms.length - 1);
       }
@@ -1100,7 +1100,7 @@ export class PokemonSpecies extends PokemonSpeciesForm implements Localizable {
         const sId = e.speciesId;
         const level = e.level;
         evolutionLevels.push([sId, level]);
-        const nextEvolutionLevels = getPokemonSpecies(sId).getEvolutionLevels();
+        const nextEvolutionLevels = speciesDataRegistry.getSpecies(sId).getEvolutionLevels();
         for (const npl of nextEvolutionLevels) {
           evolutionLevels.push(npl);
         }
@@ -1141,7 +1141,7 @@ export class PokemonSpecies extends PokemonSpeciesForm implements Localizable {
           } else {
             prevolutionLevels.push([speciesId, level]);
           }
-          const subPrevolutionLevels = getPokemonSpecies(speciesId).getPrevolutionLevels(withThresholds);
+          const subPrevolutionLevels = speciesDataRegistry.getSpecies(speciesId).getPrevolutionLevels(withThresholds);
           for (const spl of subPrevolutionLevels) {
             prevolutionLevels.push(spl);
           }

--- a/src/data/pokemon/pokemon-data.ts
+++ b/src/data/pokemon/pokemon-data.ts
@@ -1,3 +1,4 @@
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import type { BattlerTag } from "#data/battler-tags";
 import { loadBattlerTag, SerializableBattlerTag } from "#data/battler-tags";
 import type { Gender } from "#data/gender";
@@ -18,7 +19,7 @@ import type { IllusionData } from "#types/illusion-data";
 import type { SerializedSpeciesForm } from "#types/pokemon-common";
 import type { TurnMove } from "#types/turn-move";
 import type { CoerceNullPropertiesToUndefined } from "#types/type-helpers";
-import { getPokemonSpecies, getPokemonSpeciesForm } from "#utils/pokemon-utils";
+import { getPokemonSpeciesForm } from "#utils/pokemon-utils";
 
 /**
  * Permanent data that can customize a Pokemon in non-standard ways from its Species.
@@ -175,10 +176,10 @@ export class PokemonSummonData {
         if (illusionData.fusionSpecies != null) {
           switch (typeof illusionData.fusionSpecies) {
             case "object":
-              illusionData.fusionSpecies = getPokemonSpecies(illusionData.fusionSpecies.speciesId);
+              illusionData.fusionSpecies = speciesDataRegistry.getSpecies(illusionData.fusionSpecies.speciesId);
               break;
             case "number":
-              illusionData.fusionSpecies = getPokemonSpecies(illusionData.fusionSpecies);
+              illusionData.fusionSpecies = speciesDataRegistry.getSpecies(illusionData.fusionSpecies);
               break;
             default:
               illusionData.fusionSpecies = undefined;

--- a/src/data/trainers/trainer-config.ts
+++ b/src/data/trainers/trainer-config.ts
@@ -1,6 +1,7 @@
 import { getRandomRivalPartyMemberFunc } from "#app/ai/rival-team-gen";
 import { timedEventManager } from "#app/global-event-manager";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { signatureSpecies } from "#balance/signature-species";
 import { modifierTypes } from "#data/data-lists";
 import { doubleBattleDialogue } from "#data/double-battle-dialogue";
@@ -52,7 +53,6 @@ import type {
 import type { Mutable } from "#types/type-helpers";
 import { coerceArray } from "#utils/array";
 import { randSeedInt, randSeedIntRange, randSeedItem } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { toCamelCase, toTitleCase } from "#utils/strings";
 import i18next from "i18next";
 
@@ -999,11 +999,11 @@ export function getRandomPartyMemberFunc(
     } while (typeof species !== "number");
 
     if (!ignoreEvolution) {
-      species = getPokemonSpecies(species).getTrainerSpeciesForLevel(level, true, strength);
+      species = speciesDataRegistry.getSpecies(species).getTrainerSpeciesForLevel(level, true, strength);
     }
 
     return globalScene.addEnemyPokemon(
-      getPokemonSpecies(species),
+      speciesDataRegistry.getSpecies(species),
       level,
       trainerSlot,
       undefined,
@@ -1028,7 +1028,7 @@ function getSpeciesFilterRandomPartyMemberFunc(
 
   return (level: number, strength: PartyMemberStrength) => {
     const waveIndex = globalScene.currentBattle.waveIndex;
-    const species = getPokemonSpecies(
+    const species = speciesDataRegistry.getSpecies(
       globalScene
         .randomSpecies(waveIndex, level, false, speciesFilter)
         // TODO: What EvoLevelThresholdKind to use here?

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -1,6 +1,7 @@
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { timedEventManager } from "#app/global-event-manager";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { activeOverrides } from "#app/overrides";
 import { NIGHT_TIME } from "#constants/game-constants";
 import type { ArenaTag, ArenaTagTypeMap } from "#data/arena-tag";
@@ -51,7 +52,6 @@ import type { TypedEventTarget } from "#types/typed-event-target";
 import { coerceArray } from "#utils/array";
 import { NumberHolder, randSeedInt, randSeedItem } from "#utils/common";
 import { enumValueToKey, getEnumValues } from "#utils/enums";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { weightedPick } from "#utils/random";
 import { inSpeedOrder } from "#utils/speed-order-generator";
 import type { NonEmptyTuple } from "type-fest";
@@ -615,7 +615,7 @@ export class Arena {
     if (tierPool.length === 0) {
       species = globalScene.randomSpecies(waveIndex, level);
     } else {
-      species = getPokemonSpecies(randSeedItem(tierPool));
+      species = speciesDataRegistry.getSpecies(randSeedItem(tierPool));
     }
 
     const regen = this.checkLegendBST(species, globalScene.gameMode.getWaveForDifficulty(waveIndex, true));
@@ -629,7 +629,7 @@ export class Arena {
     const newSpeciesId = species.getWildSpeciesForLevel(level, true, isBoss ?? isBossSpecies, globalScene.gameMode);
     if (newSpeciesId !== species.speciesId) {
       console.log("Replaced", SpeciesId[species.speciesId], "with", SpeciesId[newSpeciesId]);
-      species = getPokemonSpecies(newSpeciesId);
+      species = speciesDataRegistry.getSpecies(newSpeciesId);
     }
 
     return species;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -179,7 +179,7 @@ import {
 import { calculateBossSegmentDamage } from "#utils/damage";
 import { getEnumValues } from "#utils/enums";
 import { cachedFetch } from "#utils/fetch-utils";
-import { decodeNickname, getFusedSpeciesName, getPokemonSpecies } from "#utils/pokemon-utils";
+import { decodeNickname, getFusedSpeciesName } from "#utils/pokemon-utils";
 import { weightedPick } from "#utils/random";
 import { inSpeedOrder } from "#utils/speed-order-generator";
 import { ValueHolder } from "#utils/value-holder";
@@ -379,7 +379,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         dataSource.fusionSpecies instanceof PokemonSpecies
           ? dataSource.fusionSpecies
           : dataSource.fusionSpecies
-            ? getPokemonSpecies(dataSource.fusionSpecies)
+            ? speciesDataRegistry.getSpecies(dataSource.fusionSpecies)
             : null;
       this.fusionFormIndex = dataSource.fusionFormIndex;
       this.fusionAbilityIndex = dataSource.fusionAbilityIndex;
@@ -1084,7 +1084,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }
 
     const species: PokemonSpecies =
-      useIllusion && this.summonData.illusion ? getPokemonSpecies(this.summonData.illusion.species) : this.species;
+      useIllusion && this.summonData.illusion
+        ? speciesDataRegistry.getSpecies(this.summonData.illusion.species)
+        : this.species;
     const formIndex = useIllusion && this.summonData.illusion ? this.summonData.illusion.formIndex : this.formIndex;
 
     if (species.forms && species.forms.length > 0) {
@@ -3039,9 +3041,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     let fusionOverride: PokemonSpecies | undefined;
 
     if (forStarter && this.isPlayer() && activeOverrides.STARTER_FUSION_SPECIES_OVERRIDE) {
-      fusionOverride = getPokemonSpecies(activeOverrides.STARTER_FUSION_SPECIES_OVERRIDE);
+      fusionOverride = speciesDataRegistry.getSpecies(activeOverrides.STARTER_FUSION_SPECIES_OVERRIDE);
     } else if (this.isEnemy() && activeOverrides.ENEMY_FUSION_SPECIES_OVERRIDE) {
-      fusionOverride = getPokemonSpecies(activeOverrides.ENEMY_FUSION_SPECIES_OVERRIDE);
+      fusionOverride = speciesDataRegistry.getSpecies(activeOverrides.ENEMY_FUSION_SPECIES_OVERRIDE);
     }
 
     this.fusionSpecies =
@@ -5705,7 +5707,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    */
   private hasSameAbilityInRootForm(abilityIndex: number): boolean {
     const currentAbilityIndex = this.abilityIndex;
-    const rootForm = getPokemonSpecies(this.species.getRootSpeciesId());
+    const rootForm = speciesDataRegistry.getSpecies(this.species.getRootSpeciesId());
     return rootForm.getAbility(abilityIndex) === rootForm.getAbility(currentAbilityIndex);
   }
 
@@ -5988,7 +5990,7 @@ export class PlayerPokemon extends Pokemon {
       return new Promise(resolve => resolve(this));
     }
     return new Promise(resolve => {
-      const evolutionSpecies = getPokemonSpecies(evolution.speciesId);
+      const evolutionSpecies = speciesDataRegistry.getSpecies(evolution.speciesId);
       const isFusion = evolution instanceof FusionSpeciesFormEvolution;
       let ret: PlayerPokemon;
       if (isFusion) {
@@ -6051,9 +6053,9 @@ export class PlayerPokemon extends Pokemon {
       this.handleSpecialEvolutions(evolution);
       const isFusion = evolution instanceof FusionSpeciesFormEvolution;
       if (isFusion) {
-        this.fusionSpecies = getPokemonSpecies(evolution.speciesId);
+        this.fusionSpecies = speciesDataRegistry.getSpecies(evolution.speciesId);
       } else {
-        this.species = getPokemonSpecies(evolution.speciesId);
+        this.species = speciesDataRegistry.getSpecies(evolution.speciesId);
       }
       if (evolution.preFormKey !== null) {
         const formIndex = Math.max(

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -18,7 +18,6 @@ import { trainerConfigs } from "#trainers/trainer-config";
 import { TrainerPartyCompoundTemplate, type TrainerPartyTemplate } from "#trainers/trainer-party-template";
 import { randSeedInt, randSeedItem } from "#utils/common";
 import { getRandomLocaleEntry } from "#utils/i18n";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { toCamelCase } from "#utils/strings";
 import i18next from "i18next";
 
@@ -408,9 +407,9 @@ export class Trainer extends Phaser.GameObjects.Container {
         // If useNewSpeciesPool is true, we need to generate a new species from the new species pool, otherwise we generate a random species
         let species = useNewSpeciesPool
           ? // TODO: should this use `randSeedItem`?
-            getPokemonSpecies(newSpeciesPool[Math.floor(randSeedInt(newSpeciesPool.length))])
+            speciesDataRegistry.getSpecies(newSpeciesPool[Math.floor(randSeedInt(newSpeciesPool.length))])
           : template.isSameSpecies(index) && index > offset
-            ? getPokemonSpecies(
+            ? speciesDataRegistry.getSpecies(
                 battle.enemyParty[offset].species.getTrainerSpeciesForLevel(
                   level,
                   false,
@@ -422,7 +421,7 @@ export class Trainer extends Phaser.GameObjects.Container {
 
         // If the species is from newSpeciesPool, we need to adjust it based on the level and strength
         if (newSpeciesPool) {
-          species = getPokemonSpecies(
+          species = speciesDataRegistry.getSpecies(
             species.getSpeciesForLevel(level, true, true, strength, template.evoLevelThresholdKind),
           );
         }
@@ -473,12 +472,12 @@ export class Trainer extends Phaser.GameObjects.Container {
       while (typeof rolledSpecies !== "number") {
         rolledSpecies = randSeedItem(tierPool);
       }
-      baseSpecies = getPokemonSpecies(rolledSpecies);
+      baseSpecies = speciesDataRegistry.getSpecies(rolledSpecies);
     } else {
       baseSpecies = globalScene.randomSpecies(battle.waveIndex, level, false, this.config.speciesFilter);
     }
 
-    let ret = getPokemonSpecies(
+    let ret = speciesDataRegistry.getSpecies(
       baseSpecies.getTrainerSpeciesForLevel(level, true, strength, template.evoLevelThresholdKind),
     );
     let retry = false;
@@ -504,7 +503,7 @@ export class Trainer extends Phaser.GameObjects.Container {
       console.log("Attempting reroll of species evolution to fit specialty type...");
       let evoAttempt = 0;
       while (retry && evoAttempt++ < 10) {
-        ret = getPokemonSpecies(
+        ret = speciesDataRegistry.getSpecies(
           baseSpecies.getTrainerSpeciesForLevel(level, true, strength, template.evoLevelThresholdKind),
         );
         console.log(ret.name);

--- a/src/game-mode.ts
+++ b/src/game-mode.ts
@@ -22,7 +22,6 @@ import { classicFixedBattles, type FixedBattleConfigs } from "#trainers/fixed-ba
 import type { CustomDailyRunConfig } from "#types/daily-run";
 import { applyChallenges } from "#utils/challenge-utils";
 import { BooleanHolder, randSeedInt, randSeedItem } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import i18next from "i18next";
 
 interface GameModeConfig {
@@ -271,7 +270,7 @@ export class GameMode implements GameModeConfig {
       const eventBoss = getDailyEventSeedBoss();
       if (eventBoss?.speciesId != null) {
         // Cannot set form index here, it will be overriden when adding it as enemy pokemon.
-        return getPokemonSpecies(eventBoss.speciesId);
+        return speciesDataRegistry.getSpecies(eventBoss.speciesId);
       }
 
       const allFinalBossSpecies = speciesDataRegistry.getAllSpecies().filter(s => {

--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -28,7 +28,6 @@ import { trainerConfigs } from "#trainers/trainer-config";
 import type { SessionSaveData } from "#types/save-data";
 import { checkSpeciesValidForChallenge, isNuzlockeChallenge } from "#utils/challenge-utils";
 import { fixedInt, isLocalServerConnected } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import i18next from "i18next";
 
 export class GameOverPhase extends BattlePhase {
@@ -318,11 +317,11 @@ export class GameOverPhase extends BattlePhase {
   }
 
   awardFirstClassicCompletion(pokemon: Pokemon, forStarter = false): void {
-    const speciesId = getPokemonSpecies(pokemon.species.speciesId);
+    const speciesId = speciesDataRegistry.getSpecies(pokemon.species.speciesId);
     const speciesRibbonCount = globalScene.gameData.incrementRibbonCount(speciesId, forStarter);
     // first time classic win, award voucher
     if (speciesRibbonCount === 1) {
-      this.firstRibbons.push(getPokemonSpecies(pokemon.species.getRootSpeciesId(forStarter)));
+      this.firstRibbons.push(speciesDataRegistry.getSpecies(pokemon.species.getRootSpeciesId(forStarter)));
     }
   }
 

--- a/src/phases/select-starter-phase.ts
+++ b/src/phases/select-starter-phase.ts
@@ -1,5 +1,6 @@
 import { audioManager } from "#app/global-audio-manager";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { activeOverrides } from "#app/overrides";
 import { Phase } from "#app/phase";
 import { SpeciesFormChangeMoveLearnedTrigger } from "#data/form-change-triggers";
@@ -10,7 +11,6 @@ import { overrideHeldItems, overrideModifiers } from "#modifiers/modifier";
 import type { Starter } from "#types/save-data";
 import { SaveSlotUiMode } from "#ui/handlers/save-slot-select-ui-handler";
 import { applyChallenges } from "#utils/challenge-utils";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 
 export class SelectStarterPhase extends Phase {
   public readonly phaseName = "SelectStarterPhase";
@@ -45,7 +45,7 @@ export class SelectStarterPhase extends Phase {
       if (!i && activeOverrides.STARTER_SPECIES_OVERRIDE) {
         starter.speciesId = activeOverrides.STARTER_SPECIES_OVERRIDE;
       }
-      const species = getPokemonSpecies(starter.speciesId);
+      const species = speciesDataRegistry.getSpecies(starter.speciesId);
       let starterFormIndex = starter.formIndex;
       if (
         starter.speciesId in activeOverrides.STARTER_FORM_OVERRIDES

--- a/src/phases/title-phase.ts
+++ b/src/phases/title-phase.ts
@@ -4,6 +4,7 @@ import { GameMode, getGameMode } from "#app/game-mode";
 import { audioManager } from "#app/global-audio-manager";
 import { timedEventManager } from "#app/global-event-manager";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { activeOverrides } from "#app/overrides";
 import { Phase } from "#app/phase";
 import { bypassLogin } from "#constants/app-constants";
@@ -22,7 +23,6 @@ import { vouchers } from "#system/voucher";
 import type { OptionSelectConfig, OptionSelectItem } from "#ui/base-option-select-ui-handler";
 import { SaveSlotUiMode } from "#ui/save-slot-select-ui-handler";
 import { isLocalServerConnected } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import i18next from "i18next";
 
 const NO_SAVE_SLOT = -1;
@@ -248,7 +248,7 @@ export class TitlePhase extends Phase {
         const party = globalScene.getPlayerParty();
         const loadPokemonAssets: Promise<void>[] = [];
         for (const [index, starter] of starters.entries()) {
-          const species = getPokemonSpecies(starter.speciesId);
+          const species = speciesDataRegistry.getSpecies(starter.speciesId);
           const starterFormIndex = starter.formIndex;
           const starterGender =
             species.malePercent === null ? Gender.GENDERLESS : starter.female ? Gender.FEMALE : Gender.MALE;

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -76,7 +76,6 @@ import { applyChallenges } from "#utils/challenge-utils";
 import { fixedInt, NumberHolder, randInt, randSeedItem } from "#utils/common";
 import { decrypt, encrypt } from "#utils/data";
 import { getEnumKeys } from "#utils/enums";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { toCamelCase } from "#utils/strings";
 import { AES, enc } from "crypto-js";
 import i18next from "i18next";
@@ -1872,7 +1871,7 @@ export class GameData {
       }
       return await this.setPokemonSpeciesCaught(
         pokemon,
-        getPokemonSpecies(prevolution),
+        speciesDataRegistry.getSpecies(prevolution),
         incrementCount,
         fromEgg,
         showMessage,

--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -1,4 +1,5 @@
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import type { Gender } from "#data/gender";
 import { CustomPokemonData, PokemonBattleData, PokemonSummonData } from "#data/pokemon-data";
 import { Status } from "#data/status-effect";
@@ -13,7 +14,7 @@ import { TrainerSlot } from "#enums/trainer-slot";
 import { EnemyPokemon, Pokemon } from "#field/pokemon";
 import { PokemonMove } from "#moves/pokemon-move";
 import type { Variant } from "#sprites/variant";
-import { getPokemonSpecies, getPokemonSpeciesForm } from "#utils/pokemon-utils";
+import { getPokemonSpeciesForm } from "#utils/pokemon-utils";
 
 export class PokemonData {
   public id: number;
@@ -83,7 +84,10 @@ export class PokemonData {
     this.player = sourcePokemon?.isPlayer() ?? source.player;
     this.species = sourcePokemon?.species.speciesId ?? source.species;
     this.nickname = source.nickname;
-    this.formIndex = Math.max(Math.min(source.formIndex, getPokemonSpecies(this.species).forms.length - 1), 0);
+    this.formIndex = Math.max(
+      Math.min(source.formIndex, speciesDataRegistry.getSpecies(this.species).forms.length - 1),
+      0,
+    );
     this.abilityIndex = source.abilityIndex;
     this.passive = source.passive;
     this.shiny = source.shiny;
@@ -108,7 +112,7 @@ export class PokemonData {
           source.status.freezeTurnsRemaining,
         )
       : null;
-    this.friendship = source.friendship ?? getPokemonSpecies(this.species).baseFriendship;
+    this.friendship = source.friendship ?? speciesDataRegistry.getSpecies(this.species).baseFriendship;
     this.metLevel = source.metLevel || 5;
     this.metBiome = source.metBiome ?? -1;
     this.metSpecies = source.metSpecies;
@@ -143,7 +147,7 @@ export class PokemonData {
   }
 
   toPokemon(battleType?: BattleType, partyMemberIndex = 0, double = false): Pokemon {
-    const species = getPokemonSpecies(this.species);
+    const species = speciesDataRegistry.getSpecies(this.species);
     const ret: Pokemon = this.player
       ? globalScene.addPlayerPokemon(
           species,

--- a/src/system/version-migration/versions/v1_7_0.ts
+++ b/src/system/version-migration/versions/v1_7_0.ts
@@ -1,10 +1,11 @@
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { DexAttr } from "#enums/dex-attr";
 import type { SpeciesId } from "#enums/species-id";
 import type { SystemSaveData } from "#types/save-data";
 import type { SessionSaveMigrator, SystemSaveMigrator } from "#types/save-migrators";
 import { validateIsArrayOfObjects } from "#utils/migrator-utils";
-import { getPokemonSpecies, getPokemonSpeciesForm } from "#utils/pokemon-utils";
+import { getPokemonSpeciesForm } from "#utils/pokemon-utils";
 
 /**
  * If a starter is caught, but the only forms registered as caught are not starterSelectable,
@@ -23,7 +24,7 @@ const migrateUnselectableForms: SystemSaveMigrator = {
           // An unknown bug at some point in time caused some accounts to have starter data for pokedex number 0 which crashes
           return;
         }
-        const species = getPokemonSpecies(speciesNumber);
+        const species = speciesDataRegistry.getSpecies(speciesNumber);
         if (caughtAttr && species.forms?.length > 1) {
           const selectableForms = species.forms.filter(
             (form, formIndex) => form.isStarterSelectable && caughtAttr & globalScene.gameData.getFormAttr(formIndex),

--- a/src/system/version-migration/versions/v1_8_3.ts
+++ b/src/system/version-migration/versions/v1_8_3.ts
@@ -1,8 +1,8 @@
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { DexAttr } from "#enums/dex-attr";
 import { SpeciesId } from "#enums/species-id";
 import type { SystemSaveData } from "#types/save-data";
 import type { SystemSaveMigrator } from "#types/save-migrators";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 
 /**
  * If pichu is caught, but the only forms registered as caught are not starterSelectable,
@@ -17,7 +17,7 @@ const migratePichuForms: SystemSaveMigrator = {
       // This is Pichu's Pokédex number
       const sd = 172;
       const caughtAttr = data.dexData[sd]?.caughtAttr;
-      const species = getPokemonSpecies(sd);
+      const species = speciesDataRegistry.getSpecies(sd);
       // An extra check because you never know
       if (species.speciesId === SpeciesId.PICHU && caughtAttr) {
         // Ensuring that only existing forms are unlocked

--- a/src/timed-event-manager.ts
+++ b/src/timed-event-manager.ts
@@ -9,7 +9,6 @@ import type { TrainerType } from "#enums/trainer-type";
 import type { ModifierTypeKeys } from "#modifiers/modifier-type";
 import type { EventEncounter, EventMysteryEncounterTier, EventWeatherPools, TimedEvent } from "#types/events";
 import { randSeedShuffle } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import i18next from "i18next";
 import { timedEvents } from "./data/balance/timed-events";
 import { globalScene } from "./global-scene";
@@ -90,7 +89,7 @@ export class TimedEventManager {
     speciesFilter: PokemonSpeciesFilter,
   ): EventEncounter[] {
     return this.getEventEncounters().filter(enc => {
-      const species = getPokemonSpecies(enc.species);
+      const species = speciesDataRegistry.getSpecies(enc.species);
       return (
         (allowSubLegendary || !species.subLegendary)
         && (allowLegendary || !species.legendary)

--- a/src/ui/handlers/egg-gacha-ui-handler.ts
+++ b/src/ui/handlers/egg-gacha-ui-handler.ts
@@ -1,5 +1,6 @@
 import { audioManager } from "#app/global-audio-manager";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { activeOverrides } from "#app/overrides";
 import { handleTutorial, Tutorial } from "#app/tutorial";
 import type { IEggOptions } from "#data/egg";
@@ -15,7 +16,6 @@ import { addTextObject, getEggTierTextTint, getTextStyleOptions } from "#ui/text
 import { addWindow } from "#ui/ui-theme";
 import { fixedInt, randSeedShuffle } from "#utils/common";
 import { getEnumValues } from "#utils/enums";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import i18next from "i18next";
 
 export class EggGachaUiHandler extends MessageUiHandler {
@@ -655,7 +655,7 @@ export class EggGachaUiHandler extends MessageUiHandler {
    */
   private updateLegendaryGacha(): void {
     const infoContainer = this.gachaInfoContainers[GachaType.LEGENDARY];
-    const species = getPokemonSpecies(getLegendaryGachaSpeciesForTimestamp(Date.now()));
+    const species = speciesDataRegistry.getSpecies(getLegendaryGachaSpeciesForTimestamp(Date.now()));
     const pokemonIcon = infoContainer.getAt(1) as Phaser.GameObjects.Sprite;
     pokemonIcon.setTexture(species.getIconAtlasKey(), species.getIconId(false));
   }

--- a/src/ui/handlers/pokedex-page-ui-handler.ts
+++ b/src/ui/handlers/pokedex-page-ui-handler.ts
@@ -61,7 +61,7 @@ import { addWindow } from "#ui/ui-theme";
 import { argbFromRgba, rgbHexToRgba } from "#utils/color-utils";
 import { BooleanHolder, getLocalizedSpriteKey, padInt } from "#utils/common";
 import { enumValueToKey, getEnumValues } from "#utils/enums";
-import { getDexNumber, getPokemonSpecies, getPokemonSpeciesForm } from "#utils/pokemon-utils";
+import { getDexNumber, getPokemonSpeciesForm } from "#utils/pokemon-utils";
 import { toCamelCase, toTitleCase } from "#utils/strings";
 import type { ValueHolder } from "#utils/value-holder";
 import i18next from "i18next";
@@ -2103,7 +2103,7 @@ export class PokedexPageUiHandler extends MessageUiHandler {
               if (this.filteredIndices) {
                 const index = this.filteredIndices.indexOf(this.species.speciesId);
                 const newIndex = index <= 0 ? this.filteredIndices.length - 1 : index - 1;
-                newSpecies = getPokemonSpecies(this.filteredIndices[newIndex]);
+                newSpecies = speciesDataRegistry.getSpecies(this.filteredIndices[newIndex]);
               } else {
                 const allSpecies = speciesDataRegistry.getAllSpecies();
                 const index = allSpecies.findIndex(species => species.speciesId === this.species.speciesId);
@@ -2143,7 +2143,7 @@ export class PokedexPageUiHandler extends MessageUiHandler {
               if (this.filteredIndices) {
                 const index = this.filteredIndices.indexOf(this.species.speciesId);
                 const newIndex = index >= this.filteredIndices.length - 1 ? 0 : index + 1;
-                newSpecies = getPokemonSpecies(this.filteredIndices[newIndex]);
+                newSpecies = speciesDataRegistry.getSpecies(this.filteredIndices[newIndex]);
               } else {
                 const allSpecies = speciesDataRegistry.getAllSpecies();
                 const index = allSpecies.findIndex(species => species.speciesId === this.species.speciesId);

--- a/src/ui/handlers/title-ui-handler.ts
+++ b/src/ui/handlers/title-ui-handler.ts
@@ -3,6 +3,7 @@ import { loggedInUser } from "#app/account";
 import { FAKE_TITLE_LOGO_CHANCE } from "#app/constants";
 import { timedEventManager } from "#app/global-event-manager";
 import { globalScene } from "#app/global-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { isBeta, isDev } from "#constants/app-constants";
 import { getSplashMessages } from "#data/splash-messages";
 import { PlayerGender } from "#enums/player-gender";
@@ -14,7 +15,6 @@ import { TimedEventDisplay } from "#ui/event-display";
 import { OptionSelectUiHandler } from "#ui/option-select-ui-handler";
 import { addTextObject } from "#ui/text";
 import { fixedInt, randInt, randItem } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import i18next from "i18next";
 
 export class TitleUiHandler extends OptionSelectUiHandler {
@@ -139,7 +139,7 @@ export class TitleUiHandler extends OptionSelectUiHandler {
   /** Used solely to display a random Pokémon name in a splash message. */
   randomPokemon(): void {
     const rand = randInt(1025, 1);
-    const pokemon = getPokemonSpecies(rand as SpeciesId);
+    const pokemon = speciesDataRegistry.getSpecies(rand as SpeciesId);
     const splashMessage = this.splashMessage;
     if (
       this.splashMessage === "splashMessages:underratedPokemon"

--- a/src/utils/challenge-utils.ts
+++ b/src/utils/challenge-utils.ts
@@ -12,7 +12,6 @@ import type { ModifierTypeOption } from "#modifiers/modifier-type";
 import type { DexEntry } from "#types/dex-data";
 import type { DexAttrProps, StarterDataEntry } from "#types/save-data";
 import { BooleanHolder, type NumberHolder } from "./common";
-import { getPokemonSpecies } from "./pokemon-utils";
 
 /**
  * @param challengeType - {@linkcode ChallengeType.STARTER_CHOICE}
@@ -371,7 +370,7 @@ export function checkStarterValidForChallenge(species: PokemonSpecies, props: De
     if (!checking) {
       return false;
     }
-    const checkingSpecies = getPokemonSpecies(checking);
+    const checkingSpecies = speciesDataRegistry.getSpecies(checking);
     if (checkSpeciesValidForChallenge(checkingSpecies, props, true)) {
       return true;
     }

--- a/src/utils/pokemon-utils.ts
+++ b/src/utils/pokemon-utils.ts
@@ -10,17 +10,6 @@ import type { EnemyPokemon, PlayerPokemon, Pokemon } from "#field/pokemon";
 import { randSeedIntRange, randSeedItem } from "#utils/common";
 
 /**
- * Gets the `PokemonSpecies` object associated with the given `SpeciesId`
- * @param speciesId - The {@linkcode SpeciesId} to fetch.
- * @returns The associated {@linkcode PokemonSpecies} object
- * @deprecated Use {@linkcode speciesDataRegistry.getSpecies}
- */
-// TODO: remove this function
-export function getPokemonSpecies(speciesId: SpeciesId): PokemonSpecies {
-  return speciesDataRegistry.getSpecies(speciesId);
-}
-
-/**
  * Converts the internal id of the Pokemon into its national dex number
  * @param speciesId - The {@linkcode SpeciesId} to get the dex number of
  * @returns The national dex number matching the `SpeciesId`
@@ -41,7 +30,7 @@ export function getPokerusStarters(): PokemonSpecies[] {
     () => {
       while (pokerusStarters.length < POKERUS_STARTER_COUNT) {
         const randomSpeciesId = randSeedItem(speciesDataRegistry.getAllStarters());
-        const species = getPokemonSpecies(randomSpeciesId);
+        const species = speciesDataRegistry.getSpecies(randomSpeciesId);
         if (!pokerusStarters.includes(species)) {
           pokerusStarters.push(species);
         }
@@ -128,7 +117,7 @@ export function getFusedSpeciesName(speciesAName: string, speciesBName: string):
 }
 
 export function getPokemonSpeciesForm(species: SpeciesId, formIndex: number): PokemonSpeciesForm {
-  const retSpecies: PokemonSpecies = getPokemonSpecies(species);
+  const retSpecies: PokemonSpecies = speciesDataRegistry.getSpecies(species);
 
   if (formIndex < retSpecies.forms.length) {
     return retSpecies.forms[formIndex];

--- a/src/utils/ribbon-utils.ts
+++ b/src/utils/ribbon-utils.ts
@@ -2,7 +2,6 @@ import { speciesDataRegistry } from "#app/global-species-data-registry";
 import type { PokemonSpecies } from "#data/pokemon-species";
 import { PokemonType } from "#enums/pokemon-type";
 import { RibbonData, type RibbonFlag } from "#system/ribbons/ribbon-data";
-import { getPokemonSpecies } from "./pokemon-utils";
 
 export function getRibbonForType(type: PokemonType): RibbonFlag {
   // Valid types: 0–17, excluding UNKNOWN (-1) and STELLAR (19)
@@ -58,7 +57,7 @@ export function getAvailableRibbons(species: PokemonSpecies): RibbonFlag[] {
     if (checking == null) {
       continue;
     }
-    const checkingSpecies = getPokemonSpecies(checking);
+    const checkingSpecies = speciesDataRegistry.getSpecies(checking);
 
     data |= getRibbonForGeneration(checkingSpecies.generation);
     data |= getRibbonForType(checkingSpecies.type1);

--- a/test/tests/ai/ai-moveset-gen.test.ts
+++ b/test/tests/ai/ai-moveset-gen.test.ts
@@ -13,7 +13,6 @@ import { TrainerSlot } from "#enums/trainer-slot";
 import { EnemyPokemon } from "#field/pokemon";
 import { GameManager } from "#test/framework/game-manager";
 import { NumberHolder } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 /**
@@ -52,7 +51,7 @@ function createTestablePokemon(
 ): EnemyPokemon {
   const pokemon = new EnemyPokemon(speciesDataRegistry.getSpecies(speciesId), level, trainerSlot, boss);
   if (formIndex !== 0) {
-    const formIndexLength = getPokemonSpecies(speciesId)?.forms.length;
+    const formIndexLength = speciesDataRegistry.getSpecies(speciesId)?.forms.length;
     const name = speciesDataRegistry.getSpecies(speciesId).name;
     expect(formIndex, `${name} does not have a form with index ${formIndex}`).toBeLessThan(formIndexLength);
     pokemon.formIndex = formIndex;

--- a/test/tests/moves/effectiveness.test.ts
+++ b/test/tests/moves/effectiveness.test.ts
@@ -1,3 +1,4 @@
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import * as Messages from "#app/messages";
 import { allMoves } from "#data/data-lists";
 import { AbilityId } from "#enums/ability-id";
@@ -6,7 +7,6 @@ import { PokemonType } from "#enums/pokemon-type";
 import { SpeciesId } from "#enums/species-id";
 import { TrainerSlot } from "#enums/trainer-slot";
 import { GameManager } from "#test/framework/game-manager";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import Phaser from "phaser";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -22,8 +22,8 @@ function testMoveEffectiveness(
   vi.spyOn(Messages, "getPokemonNameWithAffix").mockReturnValue("");
   game.override.enemyAbility(targetAbility);
 
-  const user = game.scene.addPlayerPokemon(getPokemonSpecies(SpeciesId.SNORLAX), 5);
-  const target = game.scene.addEnemyPokemon(getPokemonSpecies(targetSpecies), 5, TrainerSlot.NONE);
+  const user = game.scene.addPlayerPokemon(speciesDataRegistry.getSpecies(SpeciesId.SNORLAX), 5);
+  const target = game.scene.addEnemyPokemon(speciesDataRegistry.getSpecies(targetSpecies), 5, TrainerSlot.NONE);
 
   if (teraType !== undefined) {
     target.teraType = teraType;

--- a/test/tests/mystery-encounter/encounters/an-offer-you-cant-refuse-encounter.test.ts
+++ b/test/tests/mystery-encounter/encounters/an-offer-you-cant-refuse-encounter.test.ts
@@ -1,4 +1,5 @@
 import type { BattleScene } from "#app/battle-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { AbilityId } from "#enums/ability-id";
 import { BiomeId } from "#enums/biome-id";
 import { MoveId } from "#enums/move-id";
@@ -14,7 +15,6 @@ import { HUMAN_TRANSITABLE_BIOMES } from "#mystery-encounters/mystery-encounters
 import { GameManager } from "#test/framework/game-manager";
 import { runMysteryEncounterToEnd } from "#test/utils/encounter-test-utils";
 import { initSceneWithoutEncounterPhase } from "#test/utils/game-manager-utils";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import i18next from "i18next";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -194,7 +194,7 @@ describe("An Offer You Can't Refuse - Mystery Encounter", () => {
       await game.phaseInterceptor.to("SelectModifierPhase", false);
 
       expect(gyarados.exp).toBe(
-        expBefore + Math.floor((getPokemonSpecies(SpeciesId.LIEPARD).baseExp * defaultWave) / 5 + 1),
+        expBefore + Math.floor((speciesDataRegistry.getSpecies(SpeciesId.LIEPARD).baseExp * defaultWave) / 5 + 1),
       );
     });
 
@@ -209,7 +209,7 @@ describe("An Offer You Can't Refuse - Mystery Encounter", () => {
       await game.phaseInterceptor.to("SelectModifierPhase", false);
 
       expect(abra.exp).toBe(
-        expBefore + Math.floor((getPokemonSpecies(SpeciesId.LIEPARD).baseExp * defaultWave) / 5 + 1),
+        expBefore + Math.floor((speciesDataRegistry.getSpecies(SpeciesId.LIEPARD).baseExp * defaultWave) / 5 + 1),
       );
     });
 

--- a/test/tests/mystery-encounter/encounters/clowning-around-encounter.test.ts
+++ b/test/tests/mystery-encounter/encounters/clowning-around-encounter.test.ts
@@ -1,4 +1,5 @@
 import type { BattleScene } from "#app/battle-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import * as BattleAnims from "#data/battle-anims";
 import { modifierTypes } from "#data/data-lists";
 import { AbilityId } from "#enums/ability-id";
@@ -28,7 +29,6 @@ import { runMysteryEncounterToEnd, skipBattleRunMysteryEncounterRewardsPhase } f
 import { initSceneWithoutEncounterPhase } from "#test/utils/game-manager-utils";
 import type { OptionSelectUiHandler } from "#ui/option-select-ui-handler";
 import type { PartyUiHandler } from "#ui/party-ui-handler";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/clowningAround";
@@ -103,12 +103,12 @@ describe("Clowning Around - Mystery Encounter", () => {
     expect(config.doubleBattle).toBe(true);
     expect(config.trainerConfig?.trainerType).toBe(TrainerType.HARLEQUIN);
     expect(config.pokemonConfigs?.[0]).toEqual({
-      species: getPokemonSpecies(SpeciesId.MR_MIME),
+      species: speciesDataRegistry.getSpecies(SpeciesId.MR_MIME),
       isBoss: true,
       moveSet: [MoveId.TEETER_DANCE, MoveId.ALLY_SWITCH, MoveId.DAZZLING_GLEAM, MoveId.PSYCHIC],
     });
     expect(config.pokemonConfigs?.[1]).toEqual({
-      species: getPokemonSpecies(SpeciesId.BLACEPHALON),
+      species: speciesDataRegistry.getSpecies(SpeciesId.BLACEPHALON),
       customPokemonData: expect.anything(),
       isBoss: true,
       moveSet: [MoveId.TRICK, MoveId.HYPNOSIS, MoveId.SHADOW_BALL, MoveId.MIND_BLOWN],

--- a/test/tests/mystery-encounter/encounters/fiery-fallout-encounter.test.ts
+++ b/test/tests/mystery-encounter/encounters/fiery-fallout-encounter.test.ts
@@ -1,4 +1,5 @@
 import type { BattleScene } from "#app/battle-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import * as BattleAnims from "#data/battle-anims";
 import { Gender } from "#data/gender";
 import { Status } from "#data/status-effect";
@@ -25,7 +26,6 @@ import {
   skipBattleRunMysteryEncounterRewardsPhase,
 } from "#test/utils/encounter-test-utils";
 import { initSceneWithoutEncounterPhase } from "#test/utils/game-manager-utils";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import i18next from "i18next";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -109,14 +109,14 @@ describe("Fiery Fallout - Mystery Encounter", () => {
       {
         pokemonConfigs: [
           {
-            species: getPokemonSpecies(SpeciesId.VOLCARONA),
+            species: speciesDataRegistry.getSpecies(SpeciesId.VOLCARONA),
             isBoss: false,
             gender: Gender.MALE,
             tags: [BattlerTagType.MYSTERY_ENCOUNTER_POST_SUMMON],
             mysteryEncounterBattleEffects: expect.any(Function),
           },
           {
-            species: getPokemonSpecies(SpeciesId.VOLCARONA),
+            species: speciesDataRegistry.getSpecies(SpeciesId.VOLCARONA),
             isBoss: false,
             gender: Gender.FEMALE,
             tags: [BattlerTagType.MYSTERY_ENCOUNTER_POST_SUMMON],

--- a/test/tests/mystery-encounter/encounters/lost-at-sea-encounter.test.ts
+++ b/test/tests/mystery-encounter/encounters/lost-at-sea-encounter.test.ts
@@ -1,4 +1,5 @@
 import type { BattleScene } from "#app/battle-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { BiomeId } from "#enums/biome-id";
 import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
 import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
@@ -11,7 +12,6 @@ import { MysteryEncounterPhase } from "#phases/mystery-encounter-phases";
 import { GameManager } from "#test/framework/game-manager";
 import { runMysteryEncounterToEnd, runSelectMysteryEncounterOption } from "#test/utils/encounter-test-utils";
 import { initSceneWithoutEncounterPhase } from "#test/utils/game-manager-utils";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import i18next from "i18next";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -103,7 +103,7 @@ describe("Lost at Sea - Mystery Encounter", () => {
     });
 
     it("should award exp to surfable PKM (Blastoise)", async () => {
-      const laprasSpecies = getPokemonSpecies(SpeciesId.LAPRAS);
+      const laprasSpecies = speciesDataRegistry.getSpecies(SpeciesId.LAPRAS);
 
       await game.runToMysteryEncounter(MysteryEncounterType.LOST_AT_SEA, defaultParty);
       const party = game.scene.getPlayerParty();

--- a/test/tests/mystery-encounter/encounters/the-strong-stuff-encounter.test.ts
+++ b/test/tests/mystery-encounter/encounters/the-strong-stuff-encounter.test.ts
@@ -1,4 +1,5 @@
 import type { BattleScene } from "#app/battle-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import * as BattleAnims from "#data/battle-anims";
 import { CustomPokemonData } from "#data/pokemon-data";
 import { AbilityId } from "#enums/ability-id";
@@ -22,7 +23,6 @@ import { GameManager } from "#test/framework/game-manager";
 import { runMysteryEncounterToEnd, skipBattleRunMysteryEncounterRewardsPhase } from "#test/utils/encounter-test-utils";
 import { initSceneWithoutEncounterPhase } from "#test/utils/game-manager-utils";
 import { ModifierSelectUiHandler } from "#ui/modifier-select-ui-handler";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/theStrongStuff";
@@ -97,7 +97,7 @@ describe("The Strong Stuff - Mystery Encounter", () => {
         disableSwitch: true,
         pokemonConfigs: [
           {
-            species: getPokemonSpecies(SpeciesId.SHUCKLE),
+            species: speciesDataRegistry.getSpecies(SpeciesId.SHUCKLE),
             isBoss: true,
             bossSegments: 5,
             shiny: false,

--- a/test/tests/mystery-encounter/encounters/the-winstrate-challenge-encounter.test.ts
+++ b/test/tests/mystery-encounter/encounters/the-winstrate-challenge-encounter.test.ts
@@ -1,4 +1,5 @@
 import type { BattleScene } from "#app/battle-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { Status } from "#data/status-effect";
 import { BiomeId } from "#enums/biome-id";
 import { MoveId } from "#enums/move-id";
@@ -21,7 +22,6 @@ import { GameManager } from "#test/framework/game-manager";
 import { runMysteryEncounterToEnd } from "#test/utils/encounter-test-utils";
 import { initSceneWithoutEncounterPhase } from "#test/utils/game-manager-utils";
 import { ModifierSelectUiHandler } from "#ui/modifier-select-ui-handler";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/theWinstrateChallenge";
@@ -104,7 +104,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
         trainerType: TrainerType.VITO,
         pokemonConfigs: [
           {
-            species: getPokemonSpecies(SpeciesId.HISUI_ELECTRODE),
+            species: speciesDataRegistry.getSpecies(SpeciesId.HISUI_ELECTRODE),
             isBoss: false,
             abilityIndex: 0, // Soundproof
             nature: Nature.MODEST,
@@ -112,7 +112,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
             modifierConfigs: expect.any(Array),
           },
           {
-            species: getPokemonSpecies(SpeciesId.SWALOT),
+            species: speciesDataRegistry.getSpecies(SpeciesId.SWALOT),
             isBoss: false,
             abilityIndex: 2, // Gluttony
             nature: Nature.QUIET,
@@ -120,7 +120,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
             modifierConfigs: expect.any(Array),
           },
           {
-            species: getPokemonSpecies(SpeciesId.DODRIO),
+            species: speciesDataRegistry.getSpecies(SpeciesId.DODRIO),
             isBoss: false,
             abilityIndex: 2, // Tangled Feet
             nature: Nature.JOLLY,
@@ -128,7 +128,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
             modifierConfigs: expect.any(Array),
           },
           {
-            species: getPokemonSpecies(SpeciesId.ALAKAZAM),
+            species: speciesDataRegistry.getSpecies(SpeciesId.ALAKAZAM),
             isBoss: false,
             formIndex: 1,
             nature: Nature.BOLD,
@@ -136,7 +136,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
             modifierConfigs: expect.any(Array),
           },
           {
-            species: getPokemonSpecies(SpeciesId.DARMANITAN),
+            species: speciesDataRegistry.getSpecies(SpeciesId.DARMANITAN),
             isBoss: false,
             abilityIndex: 0, // Sheer Force
             nature: Nature.IMPISH,
@@ -149,7 +149,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
         trainerType: TrainerType.VICKY,
         pokemonConfigs: [
           {
-            species: getPokemonSpecies(SpeciesId.MEDICHAM),
+            species: speciesDataRegistry.getSpecies(SpeciesId.MEDICHAM),
             isBoss: false,
             formIndex: 1,
             nature: Nature.IMPISH,
@@ -162,7 +162,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
         trainerType: TrainerType.VIVI,
         pokemonConfigs: [
           {
-            species: getPokemonSpecies(SpeciesId.SEAKING),
+            species: speciesDataRegistry.getSpecies(SpeciesId.SEAKING),
             isBoss: false,
             abilityIndex: 3, // Lightning Rod
             nature: Nature.ADAMANT,
@@ -170,7 +170,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
             modifierConfigs: expect.any(Array),
           },
           {
-            species: getPokemonSpecies(SpeciesId.BRELOOM),
+            species: speciesDataRegistry.getSpecies(SpeciesId.BRELOOM),
             isBoss: false,
             abilityIndex: 1, // Poison Heal
             nature: Nature.JOLLY,
@@ -178,7 +178,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
             modifierConfigs: expect.any(Array),
           },
           {
-            species: getPokemonSpecies(SpeciesId.CAMERUPT),
+            species: speciesDataRegistry.getSpecies(SpeciesId.CAMERUPT),
             isBoss: false,
             formIndex: 1,
             nature: Nature.CALM,
@@ -191,7 +191,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
         trainerType: TrainerType.VICTORIA,
         pokemonConfigs: [
           {
-            species: getPokemonSpecies(SpeciesId.ROSERADE),
+            species: speciesDataRegistry.getSpecies(SpeciesId.ROSERADE),
             isBoss: false,
             abilityIndex: 0, // Natural Cure
             nature: Nature.CALM,
@@ -199,7 +199,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
             modifierConfigs: expect.any(Array),
           },
           {
-            species: getPokemonSpecies(SpeciesId.GARDEVOIR),
+            species: speciesDataRegistry.getSpecies(SpeciesId.GARDEVOIR),
             isBoss: false,
             formIndex: 1,
             nature: Nature.TIMID,
@@ -212,7 +212,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
         trainerType: TrainerType.VICTOR,
         pokemonConfigs: [
           {
-            species: getPokemonSpecies(SpeciesId.SWELLOW),
+            species: speciesDataRegistry.getSpecies(SpeciesId.SWELLOW),
             isBoss: false,
             abilityIndex: 0, // Guts
             nature: Nature.ADAMANT,
@@ -220,7 +220,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
             modifierConfigs: expect.any(Array),
           },
           {
-            species: getPokemonSpecies(SpeciesId.OBSTAGOON),
+            species: speciesDataRegistry.getSpecies(SpeciesId.OBSTAGOON),
             isBoss: false,
             abilityIndex: 1, // Guts
             nature: Nature.ADAMANT,

--- a/test/tests/mystery-encounter/encounters/trash-to-treasure-encounter.test.ts
+++ b/test/tests/mystery-encounter/encounters/trash-to-treasure-encounter.test.ts
@@ -1,4 +1,5 @@
 import type { BattleScene } from "#app/battle-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import * as BattleAnims from "#data/battle-anims";
 import { modifierTypes } from "#data/data-lists";
 import { BiomeId } from "#enums/biome-id";
@@ -26,7 +27,6 @@ import { runMysteryEncounterToEnd, skipBattleRunMysteryEncounterRewardsPhase } f
 import { initSceneWithoutEncounterPhase } from "#test/utils/game-manager-utils";
 import { ModifierSelectUiHandler } from "#ui/modifier-select-ui-handler";
 import * as Utils from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/trashToTreasure";
@@ -84,7 +84,7 @@ describe("Trash to Treasure - Mystery Encounter", () => {
     TrashToTreasureEncounter.populateDialogueTokensFromRequirements();
     const onInitResult = onInit!();
 
-    const bossSpecies = getPokemonSpecies(SpeciesId.GARBODOR);
+    const bossSpecies = speciesDataRegistry.getSpecies(SpeciesId.GARBODOR);
     const pokemonConfig: EnemyPokemonConfig = {
       species: bossSpecies,
       isBoss: true,

--- a/test/tests/mystery-encounter/encounters/uncommon-breed-encounter.test.ts
+++ b/test/tests/mystery-encounter/encounters/uncommon-breed-encounter.test.ts
@@ -1,4 +1,5 @@
 import type { BattleScene } from "#app/battle-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { speciesEggMoves } from "#balance/moves/egg-moves";
 import { modifierTypes } from "#data/data-lists";
 import { AbilityId } from "#enums/ability-id";
@@ -21,7 +22,6 @@ import { StatStageChangePhase } from "#phases/stat-stage-change-phase";
 import { GameManager } from "#test/framework/game-manager";
 import { runMysteryEncounterToEnd, runSelectMysteryEncounterOption } from "#test/utils/encounter-test-utils";
 import { initSceneWithoutEncounterPhase } from "#test/utils/game-manager-utils";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/uncommonBreed";
@@ -124,7 +124,7 @@ describe("Uncommon Breed - Mystery Encounter", () => {
       // Should have used its egg move pre-battle
       const movePhases = phaseSpy.mock.calls.filter(p => p[0] instanceof MovePhase).map(p => p[0]);
       expect(movePhases.length).toBe(1);
-      const eggMoves: MoveId[] = speciesEggMoves[getPokemonSpecies(speciesToSpawn).getRootSpeciesId()];
+      const eggMoves: MoveId[] = speciesEggMoves[speciesDataRegistry.getSpecies(speciesToSpawn).getRootSpeciesId()];
       const usedMove = (movePhases[0] as MovePhase).move.moveId;
       expect(eggMoves.includes(usedMove)).toBe(true);
     });
@@ -151,7 +151,7 @@ describe("Uncommon Breed - Mystery Encounter", () => {
       // Should have used its egg move pre-battle
       const movePhases = phaseSpy.mock.calls.filter(p => p[0] instanceof MovePhase).map(p => p[0]);
       expect(movePhases.length).toBe(1);
-      const eggMoves: MoveId[] = speciesEggMoves[getPokemonSpecies(speciesToSpawn).getRootSpeciesId()];
+      const eggMoves: MoveId[] = speciesEggMoves[speciesDataRegistry.getSpecies(speciesToSpawn).getRootSpeciesId()];
       const usedMove = (movePhases[0] as MovePhase).move.moveId;
       expect(eggMoves.includes(usedMove)).toBe(true);
     });

--- a/test/tests/mystery-encounter/mystery-encounter-utils.test.ts
+++ b/test/tests/mystery-encounter/mystery-encounter-utils.test.ts
@@ -20,7 +20,6 @@ import { MysteryEncounter } from "#mystery-encounters/mystery-encounter";
 import { MessagePhase } from "#phases/message-phase";
 import { GameManager } from "#test/framework/game-manager";
 import { initSceneWithoutEncounterPhase } from "#test/utils/game-manager-utils";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import Phaser from "phaser";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -214,7 +213,7 @@ describe("Mystery Encounter Utils", () => {
   describe("getRandomSpeciesByStarterCost", () => {
     it("gets species for a starter tier", () => {
       const result = getRandomSpeciesByStarterCost(5);
-      const pokeSpecies = getPokemonSpecies(result);
+      const pokeSpecies = speciesDataRegistry.getSpecies(result);
 
       expect(pokeSpecies.speciesId).toBe(result);
       expect(speciesDataRegistry.getStarterCost(result)).toBe(5);
@@ -222,7 +221,7 @@ describe("Mystery Encounter Utils", () => {
 
     it("gets species for a starter tier range", () => {
       const result = getRandomSpeciesByStarterCost([5, 8]);
-      const pokeSpecies = getPokemonSpecies(result);
+      const pokeSpecies = speciesDataRegistry.getSpecies(result);
 
       expect(pokeSpecies.speciesId).toBe(result);
       expect(speciesDataRegistry.getStarterCost(result)).toBeGreaterThanOrEqual(5);
@@ -242,7 +241,7 @@ describe("Mystery Encounter Utils", () => {
         SpeciesId.TERAPAGOS,
         SpeciesId.ZACIAN,
       ]);
-      const pokeSpecies = getPokemonSpecies(result);
+      const pokeSpecies = speciesDataRegistry.getSpecies(result);
       expect(pokeSpecies.speciesId).toBe(SpeciesId.ZAMAZENTA);
     });
 
@@ -250,7 +249,7 @@ describe("Mystery Encounter Utils", () => {
       // Only 9 tiers are: Kyogre, Groudon, Rayquaza, Arceus, Zygarde, Zacian, Zamazenta, Koraidon, Miraidon, Terapagos
       // TODO: This has to be changed
       const result = getRandomSpeciesByStarterCost(9, undefined, [PokemonType.WATER]);
-      const pokeSpecies = getPokemonSpecies(result);
+      const pokeSpecies = speciesDataRegistry.getSpecies(result);
       expect(pokeSpecies.speciesId).toBe(SpeciesId.KYOGRE);
     });
   });

--- a/test/tests/phases/select-modifier-phase.test.ts
+++ b/test/tests/phases/select-modifier-phase.test.ts
@@ -1,4 +1,5 @@
 import type { BattleScene } from "#app/battle-scene";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { modifierTypes } from "#data/data-lists";
 import { AbilityId } from "#enums/ability-id";
 import { Button } from "#enums/buttons";
@@ -14,7 +15,6 @@ import { GameManager } from "#test/framework/game-manager";
 import { initSceneWithoutEncounterPhase } from "#test/utils/game-manager-utils";
 import { ModifierSelectUiHandler } from "#ui/modifier-select-ui-handler";
 import { shiftCharCodes } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import Phaser from "phaser";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -187,7 +187,15 @@ describe("SelectModifierPhase", () => {
         ModifierTier.MASTER,
       ],
     };
-    const pokemon = new PlayerPokemon(getPokemonSpecies(SpeciesId.BULBASAUR), 10, undefined, 0, undefined, true, 2);
+    const pokemon = new PlayerPokemon(
+      speciesDataRegistry.getSpecies(SpeciesId.BULBASAUR),
+      10,
+      undefined,
+      0,
+      undefined,
+      true,
+      2,
+    );
 
     // Fill party with max shinies
     while (scene.getPlayerParty().length > 0) {

--- a/test/tests/pokemon/boss-pokemon.test.ts
+++ b/test/tests/pokemon/boss-pokemon.test.ts
@@ -1,3 +1,4 @@
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -5,7 +6,6 @@ import { EFFECTIVE_STATS, Stat } from "#enums/stat";
 import type { EnemyPokemon } from "#field/pokemon";
 import { GameManager } from "#test/framework/game-manager";
 import { toDmgValue } from "#utils/common";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Boss Pokemon / Shields", () => {
@@ -38,24 +38,24 @@ describe("Boss Pokemon / Shields", () => {
     let wave = 5;
 
     // On normal waves, no shields...
-    expect(game.scene.getEncounterBossSegments(wave, level, getPokemonSpecies(SpeciesId.RATTATA))).toBe(0);
+    expect(game.scene.getEncounterBossSegments(wave, level, speciesDataRegistry.getSpecies(SpeciesId.RATTATA))).toBe(0);
     // ... expect (sub)-legendary and mythical Pokemon who always get shields
-    expect(game.scene.getEncounterBossSegments(wave, level, getPokemonSpecies(SpeciesId.MEW))).toBe(2);
+    expect(game.scene.getEncounterBossSegments(wave, level, speciesDataRegistry.getSpecies(SpeciesId.MEW))).toBe(2);
     // Pokemon with 670+ BST get an extra shield
-    expect(game.scene.getEncounterBossSegments(wave, level, getPokemonSpecies(SpeciesId.MEWTWO))).toBe(3);
+    expect(game.scene.getEncounterBossSegments(wave, level, speciesDataRegistry.getSpecies(SpeciesId.MEWTWO))).toBe(3);
 
     // Every 10 waves will always be a boss Pokemon with shield(s)
     wave = 50;
-    expect(game.scene.getEncounterBossSegments(wave, level, getPokemonSpecies(SpeciesId.RATTATA))).toBe(2);
+    expect(game.scene.getEncounterBossSegments(wave, level, speciesDataRegistry.getSpecies(SpeciesId.RATTATA))).toBe(2);
     // Every extra 250 waves adds a shield
     wave += 250;
-    expect(game.scene.getEncounterBossSegments(wave, level, getPokemonSpecies(SpeciesId.RATTATA))).toBe(3);
+    expect(game.scene.getEncounterBossSegments(wave, level, speciesDataRegistry.getSpecies(SpeciesId.RATTATA))).toBe(3);
     wave += 750;
-    expect(game.scene.getEncounterBossSegments(wave, level, getPokemonSpecies(SpeciesId.RATTATA))).toBe(6);
+    expect(game.scene.getEncounterBossSegments(wave, level, speciesDataRegistry.getSpecies(SpeciesId.RATTATA))).toBe(6);
 
     // Pokemon above level 100 get an extra shield
     level = 100;
-    expect(game.scene.getEncounterBossSegments(wave, level, getPokemonSpecies(SpeciesId.RATTATA))).toBe(7);
+    expect(game.scene.getEncounterBossSegments(wave, level, speciesDataRegistry.getSpecies(SpeciesId.RATTATA))).toBe(7);
   });
 
   it("should reduce the number of shields if we are in a double battle", async () => {

--- a/test/tests/ui/pokedex.test.ts
+++ b/test/tests/ui/pokedex.test.ts
@@ -12,7 +12,6 @@ import type { StarterAttributes } from "#types/save-data";
 import { FilterTextRow } from "#ui/filter-text";
 import { PokedexPageUiHandler } from "#ui/pokedex-page-ui-handler";
 import { PokedexUiHandler } from "#ui/pokedex-ui-handler";
-import { getPokemonSpecies } from "#utils/pokemon-utils";
 import Phaser from "phaser";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -174,7 +173,7 @@ describe("UI - Pokedex", () => {
       setForms?: boolean;
     },
   ) {
-    const pokemon = getPokemonSpecies(species);
+    const pokemon = speciesDataRegistry.getSpecies(species);
     const checks: [PokemonSpecies | PokemonForm] = [pokemon];
     if (setForms) {
       checks.push(...pokemon.forms);
@@ -479,7 +478,7 @@ describe("UI - Pokedex", () => {
 
   it("should show caught battle form as caught", async () => {
     await game.importData("./test/utils/saves/data_pokedex_tests_v2.prsv");
-    const pageHandler = await runToPokedexPage(getPokemonSpecies(SpeciesId.VENUSAUR), { form: 1 });
+    const pageHandler = await runToPokedexPage(speciesDataRegistry.getSpecies(SpeciesId.VENUSAUR), { form: 1 });
 
     expect(pageHandler["species"].speciesId).toEqual(SpeciesId.VENUSAUR);
 
@@ -492,7 +491,7 @@ describe("UI - Pokedex", () => {
   // TODO: check tint of the sprite
   it("should show uncaught battle form as seen", async () => {
     await game.importData("./test/utils/saves/data_pokedex_tests_v2.prsv");
-    const pageHandler = await runToPokedexPage(getPokemonSpecies(SpeciesId.VENUSAUR), { form: 2 });
+    const pageHandler = await runToPokedexPage(speciesDataRegistry.getSpecies(SpeciesId.VENUSAUR), { form: 2 });
 
     expect(pageHandler["species"].speciesId).toEqual(SpeciesId.VENUSAUR);
 

--- a/test/utils/game-manager-utils.ts
+++ b/test/utils/game-manager-utils.ts
@@ -1,6 +1,7 @@
 import { Battle } from "#app/battle";
 import type { BattleScene } from "#app/battle-scene";
 import { getGameMode } from "#app/game-mode";
+import { speciesDataRegistry } from "#app/global-species-data-registry";
 import { getDailyRunStarters } from "#data/daily-seed/daily-run";
 import { Gender } from "#data/gender";
 import { BattleType } from "#enums/battle-type";
@@ -9,7 +10,7 @@ import type { MoveId } from "#enums/move-id";
 import type { SpeciesId } from "#enums/species-id";
 import { PlayerPokemon } from "#field/pokemon";
 import type { Starter, StarterMoveset } from "#types/save-data";
-import { getPokemonSpecies, getPokemonSpeciesForm } from "#utils/pokemon-utils";
+import { getPokemonSpeciesForm } from "#utils/pokemon-utils";
 
 /** Function to convert Blob to string */
 export function blobToString(blob: Blob): Promise<string> {
@@ -37,7 +38,7 @@ export function generateStarters(scene: BattleScene, speciesIds?: SpeciesId[]): 
   const starters = getTestRunStarters(speciesIds);
   const startingLevel = scene.gameMode.getStartingLevel();
   for (const starter of starters) {
-    const species = getPokemonSpecies(starter.speciesId);
+    const species = speciesDataRegistry.getSpecies(starter.speciesId);
     const starterFormIndex = starter.formIndex;
     const starterGender =
       species.malePercent === null ? Gender.GENDERLESS : starter.female ? Gender.FEMALE : Gender.MALE;
@@ -70,7 +71,7 @@ function getTestRunStarters(speciesIds?: SpeciesId[]): Starter[] {
 
   for (const speciesId of speciesIds) {
     const starterSpeciesForm = getPokemonSpeciesForm(speciesId, 0);
-    const starterSpecies = getPokemonSpecies(starterSpeciesForm.speciesId);
+    const starterSpecies = speciesDataRegistry.getSpecies(starterSpeciesForm.speciesId);
     const pokemon = new PlayerPokemon(starterSpecies, startingLevel, undefined, 0);
     const starter: Starter = {
       speciesId,
@@ -97,7 +98,7 @@ export function initSceneWithoutEncounterPhase(scene: BattleScene, speciesIds?: 
     const starterFormIndex = starter.formIndex;
     const starterGender = Gender.MALE;
     const starterPokemon = scene.addPlayerPokemon(
-      getPokemonSpecies(starter.speciesId),
+      speciesDataRegistry.getSpecies(starter.speciesId),
       scene.gameMode.getStartingLevel(),
       starter.abilityIndex,
       starterFormIndex,


### PR DESCRIPTION
## What are the changes the user will see?


<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

deprecated function

## What are the changes from a developer perspective?

- find and replace `getPokemonSpecies()` with `speciesDataRegistry.getSpecies()`
- reduced the number of calls in 1 file
- replaced a `.map().filter().map()` with a for loop

## Screenshots/Videos
<!--
If you are changing anything visual (UI/UX, locales changes, etc.), please include screenshot(s) and/or video(s) showing the changes within collapsible blocks, like below:

<details><summary>Before</summary>

[before screenshot here]

</details>
<details><summary>After</summary>

[after screenshot here]

</details>
-->

## How to test the changes?

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)