### PR TITLE
fix(ai): account for redirect abilities in double battle targeting

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -6713,17 +6713,22 @@ export class EnemyPokemon extends Pokemon {
                 /**
                  * Attack moves are given extra multipliers to their base benefit score based on
                  * the move's type effectiveness against the target and whether the move is a STAB move.
+                 * Account for redirect abilities (Storm Drain, Lightning Rod) in doubles:
+                 * score against the Pokemon that would actually receive the move.
                  */
-                const effectiveness = target.getMoveEffectiveness(
+                const effectiveTarget = globalScene.currentBattle.double
+                  ? this.getEffectiveTarget(move.id, target)
+                  : target;
+                const effectiveness = effectiveTarget.getMoveEffectiveness(
                   this,
                   move,
-                  !target.waveData.abilityRevealed,
+                  !effectiveTarget.waveData.abilityRevealed,
                   undefined,
                   undefined,
                   true,
                 );
 
-                if (target.isPlayer() !== this.isPlayer()) {
+                if (effectiveTarget.isPlayer() !== this.isPlayer()) {
                   targetScore *= effectiveness;
                   if (this.isOfType(move.type)) {
                     targetScore *= 1.5;
@@ -6889,6 +6894,35 @@ export class EnemyPokemon extends Pokemon {
     });
 
     return [sortedBenefitScores[targetIndex][0]];
+  }
+
+  /**
+   * Simulates redirect resolution for AI move scoring.
+   * Returns the Pokemon that would actually receive the move after
+   * redirect abilities (Storm Drain, Lightning Rod) are applied.
+   */
+  private getEffectiveTarget(moveId: MoveId, intendedTarget: Pokemon): Pokemon {
+    const move = allMoves[moveId];
+    if (move.moveTarget !== MoveTarget.NEAR_OTHER && move.moveTarget !== MoveTarget.OTHER) {
+      return intendedTarget;
+    }
+
+    const redirectTarget = new NumberHolder(intendedTarget.getBattlerIndex());
+    for (const pokemon of inSpeedOrder(ArenaTagSide.BOTH)) {
+      if (pokemon !== this) {
+        applyAbAttrs("RedirectMoveAbAttr", {
+          pokemon,
+          moveId,
+          targetIndex: redirectTarget,
+          sourcePokemon: this,
+        });
+      }
+    }
+
+    if (redirectTarget.value !== intendedTarget.getBattlerIndex()) {
+      return globalScene.getField()[redirectTarget.value];
+    }
+    return intendedTarget;
   }
 
   override isPlayer(): this is PlayerPokemon {

--- a/test/tests/ai/enemy-command.test.ts
+++ b/test/tests/ai/enemy-command.test.ts
@@ -162,4 +162,28 @@ describe("Enemy Commands - Move Selection", () => {
       }
     });
   });
+
+  it("should account for redirect abilities like Storm Drain in double battles", async () => {
+    game.override
+      .battleStyle("double")
+      .enemySpecies(SpeciesId.SWAMPERT)
+      .enemyMoveset([MoveId.SURF, MoveId.EARTHQUAKE])
+      .enemyLevel(100)
+      .startingLevel(100)
+      .ability(AbilityId.STORM_DRAIN)
+      .enemyAbility(AbilityId.BALL_FETCH);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.MAGIKARP);
+
+    const enemyPokemon = game.scene.getEnemyField()[0];
+    enemyPokemon.aiType = AiType.SMART;
+
+    const moveChoices: MoveChoiceSet = {};
+    const enemyMoveset = enemyPokemon.getMoveset();
+    enemyMoveset.forEach(mv => (moveChoices[mv!.moveId] = 0));
+    getEnemyMoveChoices(enemyPokemon, moveChoices);
+
+    // Storm Drain redirects Water moves, so the AI should not prefer Surf
+    expect(moveChoices[MoveId.SURF]).toBeLessThan(moveChoices[MoveId.EARTHQUAKE]);
+  });
 });


### PR DESCRIPTION
## What are the changes the user will see?

The enemy AI in double battles will now account for redirect abilities (Storm Drain, Lightning Rod) when selecting moves. Previously, the AI would score Water moves highly against a target that was weak to Water, even though an ally with Storm Drain would redirect the move, making it ineffective.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

Fixes #7352

The AI evaluated move effectiveness against the intended target without considering that redirect abilities like Storm Drain or Lightning Rod would intercept the move at execution time. This caused the AI to spam Water moves into a Gastrodon with Storm Drain, wasting turns.

## What are the changes from a developer perspective?

Added a getEffectiveTarget helper method to EnemyPokemon that simulates redirect resolution (matching the logic in MovePhase.resolveRedirectTarget). In the move scoring loop in getNextMove(), the AI now scores AttackMoves against the effective target after redirect, rather than the originally intended target.

This only applies to single-target moves in double battles (matching the actual redirect behavior). Multi-target moves cannot be redirected and are unaffected.

## Screenshots/Videos

N/A

## How to test the changes?

Automated: pnpm test:silent test/tests/ai/enemy-command.test.ts

The new test sets up a double battle where the player has Storm Drain and the enemy has Water moves. It verifies the AI prefers non-Water moves over Water moves.

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using \eta\ as my base branch**
  - [x] **The current branch is not named \eta\, \main\ or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (\pnpm test:silent\)
  - [x] I have created new automated tests or updated existing tests related to the PR's changes
- ~[ ] I have provided screenshots/videos of the changes (if applicable)~
  - ~[ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)~

~Are there any localization additions or changes?~
~Does this require any additions or changes to in-game assets?~