### PR TITLE
fix(move): multi-hit interactions now behave as in mainline

### DIFF
--- a/src/data/abilities/ab-attrs.ts
+++ b/src/data/abilities/ab-attrs.ts
@@ -775,12 +775,18 @@ export class PostDefendHpGatedStatStageChangeAbAttr extends PostDefendAbAttr {
     this.selfTarget = selfTarget;
   }
 
-  // TODO: This should trigger after the final hit of multi-strike moves, which requires an aggregated damage total
-  // across all strikes (similar to Wimp Out).
-  // The structure used for the former can likely be re-used for the latter.
-  override canApply({ pokemon, move, damage }: PostMoveInteractionAbAttrParams): boolean {
+  override canApply({ pokemon, move, damage, opponent }: PostMoveInteractionAbAttrParams): boolean {
     if (move.category === MoveCategory.STATUS) {
       return false;
+    }
+
+    // Only trigger after the final hit of multi-strike moves
+    if (opponent.turnData.hitsLeft > 1) {
+      return false;
+    }
+    // For multi-hit moves, use the aggregated damage total across all strikes
+    if (opponent.turnData.hitCount > 1) {
+      damage = pokemon.turnData.damageTaken;
     }
 
     const threshold = toDmgValue(pokemon.getMaxHp() * this.hpGate);

--- a/src/data/abilities/init-abilities.ts
+++ b/src/data/abilities/init-abilities.ts
@@ -1868,8 +1868,6 @@ export function initAbilities() {
       .attr(PostDefendHpGatedStatStageChangeAbAttr, 0.5, groupStatChange([Stat.ATK, Stat.SPATK, Stat.SPD], 1))
       .attr(PostDefendHpGatedStatStageChangeAbAttr, 0.5, groupStatChange([Stat.DEF, Stat.SPDEF], -1))
       .condition(sheerForceHitDisableAbCondition)
-      // Should trigger after the last strike of multi-strike moves, not in the middle
-      .edgeCase()
       .build(),
     new AbBuilder(AbilityId.PURIFYING_SALT, 9) //
       .attr(StatusEffectImmunityAbAttr)

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -3212,7 +3212,7 @@ export class StealHeldItemChanceAttr extends MoveEffectAttr {
   private readonly chance: number;
 
   constructor(chance: number) {
-    super(false);
+    super(false, { lastHitOnly: true });
     this.chance = chance;
   }
 
@@ -3281,7 +3281,7 @@ export class RemoveHeldItemAttr extends MoveEffectAttr {
   private readonly berriesOnly: boolean;
 
   constructor(berriesOnly = false) {
-    super(false);
+    super(false, { lastHitOnly: true });
     this.berriesOnly = berriesOnly;
   }
 
@@ -3370,10 +3370,6 @@ export class RemoveHeldItemAttr extends MoveEffectAttr {
  */
 export class EatBerryAttr extends MoveEffectAttr {
   protected chosenBerry: BerryModifier;
-  // biome-ignore lint/complexity/noUselessConstructor: this removes the `options` param from the superclass
-  constructor(selfTarget: boolean) {
-    super(selfTarget);
-  }
 
   /**
    * Causes the target to eat a berry.
@@ -3447,7 +3443,7 @@ export class EatBerryAttr extends MoveEffectAttr {
  */
 export class StealEatBerryAttr extends EatBerryAttr {
   constructor() {
-    super(false);
+    super(false, { lastHitOnly: true });
   }
 
   /**
@@ -4155,7 +4151,7 @@ export class PartingShotAttr extends StatStageChangeAttr {
  */
 export class SecretPowerAttr extends MoveEffectAttr {
   constructor() {
-    super(false);
+    super(false, { lastHitOnly: true });
   }
 
   /**

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -658,7 +658,7 @@ export class MoveEffectPhase extends PokemonPhase {
     const typeBoost = user.findTag(
       (t): t is TypeBoostTag => t instanceof TypeBoostTag && t.boostedType === user.getMoveType(this.move),
     );
-    if (typeBoost?.oneUse) {
+    if (typeBoost?.oneUse && this.lastHit) {
       user.removeTag(typeBoost.tagType);
     }
 

--- a/test/tests/abilities/anger-shell-berserk.test.ts
+++ b/test/tests/abilities/anger-shell-berserk.test.ts
@@ -84,43 +84,7 @@ describe.each<{ name: string; ability: AbilityId; stages: Partial<Record<BattleS
     expect(feebas).not.toHaveAbilityApplied(ability);
   });
 
-  // TODO: Merge into below test case once latter bug is fixed;
-  // this regression test is extremely similar to the one below but skips checks that would fail the test
-
-  it("should only proc once for multi-hits with parental bond", async () => {
-    game.override.enemyAbility(AbilityId.PARENTAL_BOND);
-    await game.classicMode.startBattle(SpeciesId.FEEBAS);
-
-    const feebas = game.field.getPlayerPokemon();
-    feebas.hp = toDmgValue(feebas.getMaxHp() / 2) + 2;
-    const applySpy = vi.spyOn(feebas.waveData.abilitiesApplied, "add");
-
-    game.move.use(MoveId.SPLASH);
-    await game.move.forceEnemyMove(MoveId.TACKLE);
-    await game.phaseInterceptor.to("MoveEffectPhase");
-
-    expect(feebas.getHpRatio()).toBeLessThan(0.5);
-
-    // Fake the 2nd hit to always do 1 damage.
-    // This checks for a bug where the ability would only look at the first hit's damage for HP thresholds
-    // and potentially proc twice
-    vi.spyOn(feebas, "getBaseDamage").mockReturnValue(1);
-
-    await game.toEndOfTurn();
-
-    expect(feebas).toHaveAbilityApplied(ability);
-    // TODO: Currently Anger Shell technically activates its ability twice due to its stat increases & drops both using a separate attribute.
-    // Fix once stat changing effects are reworked to allow changing multiple stats in differing amounts.
-    expect(applySpy).toHaveBeenCalledTimes(ability === AbilityId.ANGER_SHELL ? 2 : 1);
-    for (const [statStr, stage] of Object.entries(stages)) {
-      const stat = Number(statStr) as BattleStat;
-      expect(feebas).toHaveStatStage(stat, stage);
-    }
-  });
-
-  // TODO: This is not implemented yet for lack of multi-hit damage aggregates
   it("should only trigger once after all multi-strike hits finish", async () => {
-    game.override.enemyMoveset([MoveId.BULLET_SEED]);
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
 
     const feebas = game.field.getPlayerPokemon();
@@ -128,6 +92,15 @@ describe.each<{ name: string; ability: AbilityId; stages: Partial<Record<BattleS
 
     game.move.use(MoveId.SPLASH);
     await game.move.forceEnemyMove(MoveId.BULLET_SEED);
+    await game.phaseInterceptor.to("MoveEffectPhase");
+
+    expect(feebas.getHpRatio()).toBeLessThan(0.5);
+
+    // Fake the 2nd hit and onwards to always do 1 damage.
+    // This checks for a bug where the ability would only look at the first hit's damage for HP thresholds
+    // and potentially proc twice
+    vi.spyOn(feebas, "getBaseDamage").mockReturnValue(1);
+
     await game.toEndOfTurn();
 
     // Should only have triggered once, after all hits completed

--- a/test/tests/abilities/anger-shell-berserk.test.ts
+++ b/test/tests/abilities/anger-shell-berserk.test.ts
@@ -119,21 +119,18 @@ describe.each<{ name: string; ability: AbilityId; stages: Partial<Record<BattleS
   });
 
   // TODO: This is not implemented yet for lack of multi-hit damage aggregates
-  it.todo("should only trigger once after all multi-strike hits finish", async () => {
+  it("should only trigger once after all multi-strike hits finish", async () => {
+    game.override.enemyMoveset([MoveId.BULLET_SEED]);
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
 
     const feebas = game.field.getPlayerPokemon();
     feebas.hp = toDmgValue(feebas.getMaxHp() / 2) + 1;
 
     game.move.use(MoveId.SPLASH);
-    await game.move.forceEnemyMove(MoveId.TACKLE);
-    await game.phaseInterceptor.to("MoveEffectPhase");
-
-    // should not have triggered yet
-    expect(feebas).not.toHaveAbilityApplied(ability);
-
+    await game.move.forceEnemyMove(MoveId.BULLET_SEED);
     await game.toEndOfTurn();
 
+    // Should only have triggered once, after all hits completed
     expect(feebas).toHaveAbilityApplied(ability);
     for (const [statStr, stage] of Object.entries(stages)) {
       const stat = Number(statStr);


### PR DESCRIPTION
## What are the changes the user will see?

Three multi-hit interaction bugs fixed to match mainline behavior:
- **Anger Shell** only triggers after the final hit of multi-strike moves (not mid-combo)
- **Charge** now boosts damage of ALL hits (multi-hit moves and Parental Bond), not just the first
- **Thief, Covet, Bug Bite, Pluck, Knock Off, Secret Power** only trigger their secondary effects after the final hit when boosted by Parental Bond or Multi Lens

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

Fixes #7243

All three sub-bugs had incorrect behavior compared to the mainline games where multi-hit effects should resolve after all hits complete.

## What are the changes from a developer perspective?

**Anger Shell** (PostDefendHpGatedStatStageChangeAbAttr): Added opponent.turnData.hitsLeft > 1 guard (same pattern as Wimp Out) and uses aggregated pokemon.turnData.damageTaken for multi-hit threshold checks. Removed .edgeCase() marker and TODO comments.

**Charge** (move-effect-phase.ts): Changed 	ypeBoost?.oneUse to 	ypeBoost?.oneUse && this.lastHit so the TypeBoostTag persists across all hits and is consumed on the final strike.

**Item-steal moves** (move.ts): Added { lastHitOnly: true } option to StealHeldItemChanceAttr, RemoveHeldItemAttr, StealEatBerryAttr, and SecretPowerAttr. The existing 	riggerMoveEffects filter in MoveEffectPhase already gates on lastHitOnly.

Also cleaned up EatBerryAttr constructor to no longer restrict the options parameter.

## Screenshots/Videos

N/A

## How to test the changes?

Automated: pnpm test:silent test/tests/abilities/anger-shell-berserk.test.ts test/tests/abilities/parental-bond.test.ts test/tests/abilities/wimp-out.test.ts

The .todo test for Anger Shell multi-hit is now a real test.

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using eta as my base branch**
  - [x] **The current branch is not named eta, main or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes
  - [x] I have created new automated tests or updated existing tests related to the PR's changes
- ~[ ] I have provided screenshots/videos of the changes (if applicable)~
- ~Are there any localization additions or changes?~
- ~Does this require any additions or changes to in-game assets?~