### PR TITLE
fix: Allow Daily Run Starters to be shiny again

### DIFF
--- a/src/data/daily-seed/daily-seed-utils.ts
+++ b/src/data/daily-seed/daily-seed-utils.ts
@@ -210,7 +210,7 @@ export function validateDailyBossConfig(config: DailySeedBoss): DailySeedBoss | 
 export function getDailyRunStarter(species: PokemonSpecies, config?: DailySeedStarter): Starter {
   const startingLevel = globalScene.gameMode.getStartingLevel();
 
-  const isShiny = config?.variant != null;
+  const isShiny = config?.variant == null ? undefined : true;
   const pokemon = globalScene.addPlayerPokemon(
     species,
     startingLevel,


### PR DESCRIPTION
## What are the changes the user will see?
Daily Run Starters can be shiny again.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
With the refactor of custom seeds for daily run, it was accidentally introduced that anytime a starter was created and there was no variant specified in the event config (or no event at all), the shiny parameter would be set to false. This PR fixes it by setting it back to undefined when creating the starter.

This bug was found after someone questioned why we hadn't seen anyone post a shiny starter in a while.

## What are the changes from a developer perspective?
As long as `undefined` is passed to the `addPlayerPokemon` function, it will actually roll for shiny. Setting it to True/False will skip the shiny rng completely.

## Screenshots/Videos

## How to test the changes?
Add event override to test that setting variant 0-2 still works:
```ts
DAILY_RUN_SEED_OVERRIDE: {"seed":"baseshinyeevee","starters":[{"speciesId":133,"variant":0}]}
```
```ts
DAILY_RUN_SEED_OVERRIDE: {"seed":"epicshinyeevee","starters":[{"speciesId":133,"variant":2}]}
```

And to test random shiny, set a breakpoint on `src\data\daily-seed\daily-seed-utils.ts` `getDailyRunStarter()` line: 214 `const pokemon =`. And inspect that isShiny is passed along as `undefined`.

Also tested that event seed without variant override still results in `undefined` isShiny:
```ts
DAILY_RUN_SEED_OVERRIDE: {"seed":"epicshinyeevee","starters":[{"speciesId":133}]}
```

## Checklist

- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually
  - [x] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: _____
- [ ] I have contacted the Translation Team on Discord for proofreading/translation (contacting the devs in #pokerogue-dev is sufficient, we can then forward the PR to the TL team)

Does this require any additions or changes to in-game assets? If so:
- [ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: _____
