### PR TITLE
balance: Trainer Level Strength Adjustments

### DIFF
--- a/src/data/trainers/trainer-party-template.ts
+++ b/src/data/trainers/trainer-party-template.ts
@@ -243,7 +243,7 @@ export const trainerPartyTemplates = {
     new TrainerPartyTemplate(1, PartyMemberStrength.STRONG),
     new TrainerPartyTemplate(1, PartyMemberStrength.AVERAGE),
     new TrainerPartyTemplate(3, PartyMemberStrength.AVERAGE, false, true),
-    new TrainerPartyTemplate(1, PartyMemberStrength.STRONGER),
+    new TrainerPartyTemplate(1, PartyMemberStrength.STRONGEST),
   ),
 };
 

--- a/src/data/trainers/trainer-party-template.ts
+++ b/src/data/trainers/trainer-party-template.ts
@@ -202,7 +202,8 @@ export const trainerPartyTemplates = {
 
   CHAMPION: new TrainerPartyCompoundTemplate(
     new TrainerPartyTemplate(4, PartyMemberStrength.STRONG, undefined, undefined, EvoLevelThresholdKind.STRONG),
-    new TrainerPartyTemplate(2, PartyMemberStrength.STRONGER, false, true, EvoLevelThresholdKind.STRONG),
+    new TrainerPartyTemplate(1, PartyMemberStrength.STRONGER, false, true, EvoLevelThresholdKind.STRONG),
+    new TrainerPartyTemplate(1, PartyMemberStrength.STRONGEST, false, true, EvoLevelThresholdKind.STRONG),
   ),
 
   EVIL_LEADER: new TrainerPartyCompoundTemplate(

--- a/src/enums/party-member-strength.ts
+++ b/src/enums/party-member-strength.ts
@@ -5,4 +5,5 @@ export enum PartyMemberStrength {
   AVERAGE,
   STRONG,
   STRONGER,
+  STRONGEST,
 }

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -276,19 +276,25 @@ export class Trainer extends Phaser.GameObjects.Container {
       const strength = partyTemplate.getStrength(i);
 
       switch (strength) {
-        case PartyMemberStrength.WEAKER:
+        case PartyMemberStrength.WEAKEST:
           multiplier = 0.95;
           break;
+        case PartyMemberStrength.WEAKER:
+          multiplier = 1;
+          break;
         case PartyMemberStrength.WEAK:
-          multiplier = 1.0;
+          multiplier = 1.05;
           break;
         case PartyMemberStrength.AVERAGE:
-          multiplier = 1.1;
+          multiplier = 1.12;
           break;
         case PartyMemberStrength.STRONG:
-          multiplier = 1.2;
+          multiplier = 1.22;
           break;
         case PartyMemberStrength.STRONGER:
+          multiplier = 1.24;
+          break;
+        case PartyMemberStrength.STRONGEST:
           multiplier = 1.25;
           break;
       }
@@ -296,7 +302,7 @@ export class Trainer extends Phaser.GameObjects.Container {
       let levelOffset = 0;
 
       if (strength < PartyMemberStrength.STRONG) {
-        multiplier = Math.min(multiplier + 0.025 * Math.floor(difficultyWaveIndex / 25), 1.2);
+        multiplier = Math.min(multiplier + 0.025 * Math.floor(difficultyWaveIndex / 25), 1.225);
         levelOffset = -Math.floor((difficultyWaveIndex / 50) * (PartyMemberStrength.STRONG - strength));
       }
 

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -51,7 +51,7 @@ import type { IntClosedRange, TupleOf } from "type-fest";
  * }
  * ```
  */
-const overrides = {} satisfies Partial<InstanceType<OverridesType>>;
+const overrides = { STARTING_WAVE_OVERRIDE: 195 } satisfies Partial<InstanceType<OverridesType>>;
 
 /**
  * If you need to add Overrides values for local testing do that inside {@linkcode overrides}

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -51,7 +51,7 @@ import type { IntClosedRange, TupleOf } from "type-fest";
  * }
  * ```
  */
-const overrides = { STARTING_WAVE_OVERRIDE: 195 } satisfies Partial<InstanceType<OverridesType>>;
+const overrides = {} satisfies Partial<InstanceType<OverridesType>>;
 
 /**
  * If you need to add Overrides values for local testing do that inside {@linkcode overrides}


### PR DESCRIPTION
<!--
Thank you for contributing to PokéRogue!
Open-source contributions like yours help keep this project going.

Note that these comment blocks are purely informative and can be removed once you're done reading them.
-->

<!--
Make sure your title matches the https://www.conventionalcommits.org/en/v1.0.0/ format.
Try to keep the title under 72 characters, as GitHub cuts off commit titles longer than this length.

See https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#-submitting-a-pull-request
for more information on the allowed scopes and prefixes.

Example:
fix(move): Future Sight no longer crashes
^   ^      ^
|   |      |__ Subject
|   |_________ Scope (optional)
|_____________ Prefix
-->

## What are the changes the user will see?
<!--
Summarize the changes from a user perspective on the application.
Try to keep this section (relatively) brief as it is used to generate changelogs.
If you need to provide additional details, you can do so below the cutoff.

PRs with no user-facing changes should leave this blank or write "N/A" to be omitted from auto-generated changelogs.
-->

Adjusted trainer strengths, most trainer Pokémon will appear at an increased level, except Champion aces, which have been reduced.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?

Balance change

## What are the changes from a developer perspective?

Created new party member strength Strongest, played with the numbers of each multiplier
## Screenshots/Videos
<!--
If you are changing anything visual (UI/UX, locales changes, etc.), please include screenshot(s) and/or video(s) showing the changes within collapsible blocks, like below:


-->

Showing changes with wave 190 fight

<details><summary>Before</summary>

<img width="488" height="330" alt="image" src="https://github.com/user-attachments/assets/5e1f68ae-bcb3-4355-962c-3ea67da0bc18" />

</details>
<details><summary>After</summary>

<img width="281" height="195" alt="image" src="https://github.com/user-attachments/assets/cb9f6386-2650-42a6-b09f-d443086af6eb" />

</details>

## How to test the changes?

Wave overrides

## Checklist
<!--
Please ensure the following requirements are all met before creating your PR.
If this is not the case, consider marking the PR as a draft (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request) until all bullets have been resolved.

If an item or category isn't valid for the particular changes being made (for example, you didn't make any locales changes)
you can strike it out with the `~` character to mark them as not applicable.
-->

- The PR content is correctly formatted:
  - [X] **I'm using `beta` as my base branch**
  - [X] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [X] I have provided a clear explanation of the changes within the PR description
  - [X] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [X] The PR is self-contained and cannot be split into smaller PRs
- [X] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [X] I have tested the changes manually
  - [ ] The full automated test suite still passes (use `pnpm test:silent` to test locally)
  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes if necessary
- [ ] I have provided screenshots/videos of the changes (if applicable)
  - [ ] I have made sure that any UI changes work for both the default and legacy UI themes (if applicable)

Are there any localization additions or changes? If so:
- [ ] I have created an associated PR on the [locales](https://github.com/pagefaultgames/pokerogue-locales) repository
  - If so, include a link to the PR here: _____
- [ ] I have contacted the Translation Team on Discord for proofreading/translation (contacting the devs in #pokerogue-dev is sufficient, we can then forward the PR to the TL team)

Does this require any additions or changes to in-game assets? If so:
- [ ] I have created an associated PR on the [assets](https://github.com/pagefaultgames/pokerogue-assets) repository
  - If so, include a link to the PR here: _____
