### PR TITLE
fix(beta): change tab buttons will show in the challenges UI on mobile

### DIFF
--- a/index.css
+++ b/index.css
@@ -174,8 +174,8 @@ input:-internal-autofill-selected {
 /* Hide buttons on specific UIs */
 
 /* Show #apadPreviousTab and #apadNextTab only in settings, except in touch configuration panel */
-#touchControls:not([data-ui-mode^="SETTINGS"]) #apadPreviousTab,
-#touchControls:not([data-ui-mode^="SETTINGS"]) #apadNextTab,
+#touchControls:not([data-ui-mode^="SETTINGS"], [data-ui-mode="CHALLENGE_SELECT"]) #apadPreviousTab,
+#touchControls:not([data-ui-mode^="SETTINGS"], [data-ui-mode="CHALLENGE_SELECT"]) #apadNextTab,
 #touchControls:is(.config-mode) #apadPreviousTab,
 #touchControls:is(.config-mode) #apadNextTab {
   display: none;


### PR DESCRIPTION
## What are the changes the user will see?
The buttons to change the current tab will appear in the Challenge Select UI for mobile users.

<!-- ## Changelog cutoff (DO NOT REMOVE/EDIT) -->

## Why am I making these changes?
Bug report.

## What are the changes from a developer perspective?
Updated `index.css` to take into account the redesign of the Challenge Select UI.

## Screenshots/Videos
<details><summary>Image</summary>
Note the existence of the "F" and "R" buttons in the bottom right:

<img width="1186" height="425" alt="image" src="https://github.com/user-attachments/assets/e4452c80-05e1-4f46-b4bf-2356c28e3314" />

</details>

## How to test the changes?
If you don't have a mobile device, you can use the browser devtools to emulate one. In Chromium-based browsers, the icon looks like this:
<details><summary>Icon</summary>

<img width="25" height="26" alt="image" src="https://github.com/user-attachments/assets/f02e5c78-40c7-4893-a041-651b9bbdc1e7" />

</details>
<details><summary>Location to the left of the "Elements" tab</summary>

<img width="194" height="99" alt="image" src="https://github.com/user-attachments/assets/6ef00941-9559-421d-908e-20c5c4bbc9c7" />

</details>

You may need to reload the page after activating it for the game to notice.

## Checklist
- The PR content is correctly formatted:
  - [x] **I'm using `beta` as my base branch**
  - [x] **The current branch is not named `beta`, `main` or the name of another long-lived feature branch**
  - [x] I have provided a clear explanation of the changes within the PR description
  - [x] The PR title matches the Conventional Commits format (as described in [CONTRIBUTING.md](https://github.com/pagefaultgames/pokerogue/blob/beta/CONTRIBUTING.md#pr-title-format))
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] There is no overlap with another open PR
- The PR has been confirmed to work correctly:
  - [x] I have tested the changes manually